### PR TITLE
Add box oreintation axes widget

### DIFF
--- a/docs/tools/plotting.rst
+++ b/docs/tools/plotting.rst
@@ -46,6 +46,9 @@ Convenience Functions
 .. autofunction:: pyvista.set_plot_theme
 
 
+.. autofunction:: pyvista.create_axes_orientation_box
+
+
 Base Plotter
 ~~~~~~~~~~~~
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -341,6 +341,14 @@ def test_axes():
 
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+def test_box_axes():
+    plotter = pyvista.Plotter(off_screen=True)
+    plotter.add_axes(box=True)
+    plotter.add_mesh(pyvista.Sphere())
+    plotter.plot()
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_screenshot():
     plotter = pyvista.Plotter(off_screen=True)
     plotter.add_mesh(pyvista.Sphere())


### PR DESCRIPTION
This adds a new box orientation widget.

Inspired by posts in https://discourse.vtk.org/t/colors-of-vtkannotatedcubeactor-faces-with-vtkorientationmarkerwidget/934/

Note we need to address #217 in order to properly color the box faces

```py
import pyvista as pv
from pyvista import examples
pv.set_plot_theme('doc')

mesh = examples.download_st_helens().warp_by_scalar()

p = pv.Plotter(notebook=0)
p.add_mesh(mesh)
p.add_axes(box=True)
p.show()
```

<img width="580" alt="Screen Shot 2019-05-16 at 1 49 50 PM" src="https://user-images.githubusercontent.com/22067021/57882751-b1739600-77e1-11e9-83db-4cf9f30603c8.png">