### PR TITLE
Fix hook for normals computation

### DIFF
--- a/pyvista/plotting.py
+++ b/pyvista/plotting.py
@@ -771,7 +771,17 @@ class BasePlotter(object):
         if not is_pyvista_obj(mesh):
             mesh = wrap(mesh)
 
-        if smooth_shading and isinstance(mesh, pyvista.PolyData):
+        # Compute surface normals if using smooth shading
+        if smooth_shading:
+            # extract surface if mesh is exterior
+            if isinstance(mesh, (pyvista.UnstructuredGrid, pyvista.StructuredGrid)):
+                grid = mesh
+                mesh = grid.extract_surface()
+                ind = mesh.point_arrays['vtkOriginalPointIds']
+                # remap scalars
+                if scalars is not None:
+                    scalars = scalars[ind]
+
             mesh.compute_normals(cell_normals=False, inplace=True)
 
         if show_edges is None:

--- a/pyvista/plotting.py
+++ b/pyvista/plotting.py
@@ -771,7 +771,7 @@ class BasePlotter(object):
         if not is_pyvista_obj(mesh):
             mesh = wrap(mesh)
 
-        if smooth_shading:
+        if smooth_shading and isinstance(mesh, pyvista.PolyData):
             mesh.compute_normals(cell_normals=False, inplace=True)
 
         if show_edges is None:


### PR DESCRIPTION
If the user enables `smooth_shading=True` when the input mesh is not a `PolyData`, for example `UnstructuredGrid`, we obtain the following:
```sh
AttributeError: 'UnstructuredGrid' object has no attribute 'compute_normals'
```
This PR fixes the hook triggering the computation of the normals for `PolyData` in this case.