### PR TITLE
Add volume option to plot function

### DIFF
--- a/pyvista/plotting.py
+++ b/pyvista/plotting.py
@@ -143,7 +143,7 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
          interactive=True, cpos=None, window_size=None,
          show_bounds=False, show_axes=True, notebook=None, background=None,
          text='', return_img=False, eye_dome_lighting=False, use_panel=None,
-         **kwargs):
+         volume=False, **kwargs):
     """
     Convenience plotting function for a vtk or numpy object.
 
@@ -183,6 +183,9 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
     text : str, optional
         Adds text at the bottom of the plot.
 
+    volume : bool, optional
+        Use the ``add_volume`` method for volume rendering.
+
     **kwargs : optional keyword arguments
         See help(Plotter.add_mesh) for additional options.
 
@@ -221,18 +224,18 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
                 plotter.add_arrows(var_item[0], var_item[1])
             else:
                 for item in var_item:
-                    if isinstance(item, np.ndarray) and item.ndim == 3:
+                    if volume or (isinstance(item, np.ndarray) and item.ndim == 3):
                         plotter.add_volume(item, **kwargs)
                     else:
                         plotter.add_mesh(item, **kwargs)
         else:
             for item in var_item:
-                if isinstance(item, np.ndarray) and item.ndim == 3:
+                if volume or (isinstance(item, np.ndarray) and item.ndim == 3):
                     plotter.add_volume(item, **kwargs)
                 else:
                     plotter.add_mesh(item, **kwargs)
     else:
-        if isinstance(var_item, np.ndarray) and var_item.ndim == 3:
+        if volume or (isinstance(var_item, np.ndarray) and var_item.ndim == 3):
             plotter.add_volume(var_item, **kwargs)
         else:
             plotter.add_mesh(var_item, **kwargs)


### PR DESCRIPTION
Makes volume rendering available when calling the bound `.plot()` function on a mesh/volume dataset.

@supersubscript: can you overlook these changes to make sure I didn't mess anything up before merging into #231

```py
import pyvista as pv
from pyvista import examples

vol = examples.download_frog()

vol.plot(volume=True)
```

<img width="624" alt="Screen Shot 2019-05-31 at 12 57 25 PM" src="https://user-images.githubusercontent.com/22067021/58725102-f7188d00-83a3-11e9-8306-e8969e68b8ea.png">