### PR TITLE
Add Smooth example and Parametric Geometry

### DIFF
--- a/docs/tools/geometric.rst
+++ b/docs/tools/geometric.rst
@@ -16,4 +16,35 @@ functions create, check out the example: :ref:`ref_geometric_example`.
 .. autofunction:: pyvista.Polygon
 .. autofunction:: pyvista.Disc
 .. autofunction:: pyvista.Text3D
-.. autofunction:: pyvista.SuperToroid
+.. autofunction:: pyvista.Spline
+
+
+Parametric Objects
+~~~~~~~~~~~~~~~~~~
+The following functions can be used to create parametric surfaces.  To
+see what these functions create, check out the example: :ref:`ref_parametric_example`.
+
+.. autofunction:: pyvista.Ellipsoid
+.. autofunction:: pyvista.ParametricBohemianDome
+.. autofunction:: pyvista.ParametricBour
+.. autofunction:: pyvista.ParametricBoy
+.. autofunction:: pyvista.ParametricDini
+.. autofunction:: pyvista.ParametricEllipsoid
+.. autofunction:: pyvista.ParametricEnneper
+.. autofunction:: pyvista.ParametricFigure8Klein
+.. autofunction:: pyvista.ParametricHenneberg
+.. autofunction:: pyvista.ParametricKlein
+.. autofunction:: pyvista.ParametricKuen
+.. autofunction:: pyvista.ParametricMobius
+.. autofunction:: pyvista.ParametricPluckerConoid
+.. autofunction:: pyvista.ParametricPseudosphere
+.. autofunction:: pyvista.ParametricRandomHills
+.. autofunction:: pyvista.ParametricRoman
+.. autofunction:: pyvista.ParametricSuperEllipsoid
+.. autofunction:: pyvista.ParametricSuperToroid
+.. autofunction:: pyvista.ParametricTorus
+
+These functions support building parametric surfaces:
+
+.. autofunction:: pyvista.parametric_keywords
+.. autofunction:: pyvista.surface_from_para

--- a/examples/00-load/create-parametric-geometric-objects.py
+++ b/examples/00-load/create-parametric-geometric-objects.py
@@ -1,0 +1,160 @@
+"""
+.. _ref_parametric_example:
+
+Geometric Parametric Objects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Creating parametric objects
+"""
+import pyvista as pv
+from math import pi
+
+###############################################################################
+# This example demonstrates how to plot parametric objects using pyvista
+# Create a supertoroid
+
+supertoroid = pv.ParametricSuperToroid(n1=0.5)
+supertoroid.plot(color='tan', smooth_shading=True)
+
+################################################################################
+# Create a parametric ellipsoid
+
+# Ellipsoid with a long x axis
+ellipsoid = pv.ParametricEllipsoid(10, 5, 5)
+ellipsoid.plot(color='tan')
+
+
+
+################################################################################
+# Create a partial parametric ellipsoid
+
+# cool plotting direction
+cpos = [(21.9930, 21.1810, -30.3780),
+        (-1.1640, -1.3098, -0.1061),
+        (0.8498, -0.2515, 0.4631)]
+
+
+# half ellipsoid
+part_ellipsoid = pv.ParametricEllipsoid(10, 5, 5, max_v=pi/2)
+part_ellipsoid.plot(color='tan', smooth_shading=True, cpos=cpos)
+
+
+################################################################################
+# Create a pseudosphere
+
+pseudosphere = pv.ParametricPseudosphere()
+pseudosphere.plot(color='tan', smooth_shading=True)
+
+###############################################################################
+# Create a bohemiandome
+
+bohemiandome = pv.ParametricBohemianDome()
+bohemiandome.plot(color='tan')
+
+###############################################################################
+# Create a bour
+
+bour = pv.ParametricBour()
+bour.plot(color='tan')
+
+###############################################################################
+# Create a boy
+
+boy = pv.ParametricBoy()
+boy.plot(color='tan')
+
+###############################################################################
+# Create a catalanminimal
+
+catalanminimal = pv.ParametricCatalanMinimal()
+catalanminimal.plot(color='tan')
+
+###############################################################################
+# Create a conicspiral
+
+conicspiral = pv.ParametricConicSpiral()
+conicspiral.plot(color='tan')
+
+###############################################################################
+# Create a crosscap
+
+crosscap = pv.ParametricCrossCap()
+crosscap.plot(color='tan')
+
+###############################################################################
+# Create a dini
+
+dini = pv.ParametricDini()
+dini.plot(color='tan')
+
+###############################################################################
+# Create a enneper
+
+enneper = pv.ParametricEnneper()
+enneper.plot(color='tan')
+
+###############################################################################
+# Create a figure8klein
+
+figure8klein = pv.ParametricFigure8Klein()
+figure8klein.plot(color='tan')
+
+###############################################################################
+# Create a henneberg
+
+henneberg = pv.ParametricHenneberg()
+henneberg.plot(color='tan')
+
+###############################################################################
+# Create a klein
+
+klein = pv.ParametricKlein()
+klein.plot(color='tan')
+
+###############################################################################
+# Create a kuen
+
+kuen = pv.ParametricKuen()
+kuen.plot(color='tan')
+
+###############################################################################
+# Create a mobius
+
+mobius = pv.ParametricMobius()
+mobius.plot(color='tan')
+
+###############################################################################
+# Create a pluckerconoid
+
+pluckerconoid = pv.ParametricPluckerConoid()
+pluckerconoid.plot(color='tan')
+
+###############################################################################
+# Create a pseudosphere
+
+pseudosphere = pv.ParametricPseudosphere()
+pseudosphere.plot(color='tan')
+
+###############################################################################
+# Create a randomhills
+
+randomhills = pv.ParametricRandomHills()
+randomhills.plot(color='tan')
+
+###############################################################################
+# Create a roman
+
+roman = pv.ParametricRoman()
+roman.plot(color='tan')
+
+###############################################################################
+# Create a superellipsoid
+
+superellipsoid = pv.ParametricSuperEllipsoid(n1=0.1, n2=2)
+superellipsoid.plot(color='tan')
+
+###############################################################################
+# Create a torus
+
+torus = pv.ParametricTorus()
+torus.plot(color='tan')

--- a/examples/02-plot/plot-shading.py
+++ b/examples/02-plot/plot-shading.py
@@ -1,0 +1,20 @@
+"""
+Types of Shading
+~~~~~~~~~~~~~~~~
+
+Use a custom built colormap when plotting scalar values.
+"""
+
+import pyvista
+pyvista.set_plot_theme('document')
+################################################################################
+# pyvista supports two types of shading, flat and smooth shading that uses VTK's
+# phong shading algorthim.
+#
+# This is a plot with the default flat shading:
+sphere = pyvista.Sphere()
+sphere.plot(color='w')
+
+################################################################################
+# Here's the same sphere with smooth shading:
+sphere.plot(color='w', smooth_shading=True)

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -16,6 +16,7 @@ from pyvista.grid import Grid
 from pyvista.grid import RectilinearGrid
 from pyvista.grid import UniformGrid
 from pyvista.geometric_objects import *
+from pyvista.parametric_geometry import *
 from pyvista.container import MultiBlock
 from pyvista.qt_plotting import QtInteractor
 from pyvista.qt_plotting import BackgroundPlotter

--- a/pyvista/geometric_objects.py
+++ b/pyvista/geometric_objects.py
@@ -11,11 +11,8 @@ vtkCubeSource
 vtkConeSource
 vtkDiskSource
 vtkRegularPolygonSource
-vtkParametricSuperToroid
 
 """
-from math import pi
-
 import numpy as np
 import vtk
 
@@ -434,256 +431,138 @@ def Text3D(string, depth=0.5):
     return pyvista.wrap(tri_filter.GetOutput())
 
 
-def SuperToroid(ring_radius=1.0, cross_section_radius=0.5,
-                x_radius=1.0, y_radius=1.0, z_radius=1.0, n_1=1.0,
-                n_2=1.0, **kwargs):
-    """Construct a supertoroid and return a mesh.
+# def SuperToroid(ring_radius=1.0, cross_section_radius=0.5,
+#                 x_radius=1.0, y_radius=1.0, z_radius=1.0, n_1=1.0,
+#                 n_2=1.0, **kwargs):
+#     """Construct a supertoroid and return a mesh.
 
-    Essentially a supertoroid is a torus with the sine and cosine
-    terms raised to a power. A supertoroid is a versatile primitive
-    that is controlled by four parameters r0, r1, n1 and n2. r0, r1
-    determine the type of torus whilst the value of n1 determines the
-    shape of the torus ring and n2 determines the shape of the cross
-    section of the ring. It is the different values of these powers
-    which give rise to a family of 3D shapes that are all basically
-    toroidal in shape.
+#     Essentially a supertoroid is a torus with the sine and cosine
+#     terms raised to a power. A supertoroid is a versatile primitive
+#     that is controlled by four parameters r0, r1, n1 and n2. r0, r1
+#     determine the type of torus whilst the value of n1 determines the
+#     shape of the torus ring and n2 determines the shape of the cross
+#     section of the ring. It is the different values of these powers
+#     which give rise to a family of 3D shapes that are all basically
+#     toroidal in shape.
 
-    By default torus whole points in the +x direction
+#     By default torus whole points in the +x direction
 
-    Parameters
-    ----------
-    ring_radius : float
-        The radius from the center to the middle of the ring of the
-        supertoroid.
+#     Parameters
+#     ----------
+#     ring_radius : float
+#         The radius from the center to the middle of the ring of the
+#         supertoroid.
 
-    cross_section_radius = 0.5
-        The radius of the cross section of ring of the supertoroid.
+#     cross_section_radius = 0.5
+#         The radius of the cross section of ring of the supertoroid.
 
-    x_radius : float, optional
-        Radius in the x direction.
+#     x_radius : float, optional
+#         Radius in the x direction.
 
-    y_radius : float, optional
-        Radius in the y direction.
+#     y_radius : float, optional
+#         Radius in the y direction.
 
-    z_radius : float, optional
-        Radius in the z direction.
+#     z_radius : float, optional
+#         Radius in the z direction.
 
-    n_1 : float
-        Controls shape of torus ring.
+#     n_1 : float
+#         Controls shape of torus ring.
 
-    n_2 = 1
-        Controls shape of cross section of the ring.
+#     n_2 = 1
+#         Controls shape of cross section of the ring.
 
-    **kwargs : keyword arguments
-        Additional settings to control mesh creation. See
+#     **kwargs : keyword arguments
+#         Additional settings to control mesh creation. See
 
-        - ``help(pyvista.parametric_keywords)``
-        - ``help(pyvista.surface_from_para)``
-        - ``help(pyvista.translate)``
+#         - ``help(pyvista.parametric_keywords)``
+#         - ``help(pyvista.surface_from_para)``
+#         - ``help(pyvista.translate)``
 
-    Notes
-    -----
-    Care needs to be taken specifying the bounds correctly. You may
-    need to carefully adjust MinimumU, MinimumV, MaximumU, MaximumV.
+#     Notes
+#     -----
+#     Care needs to be taken specifying the bounds correctly. You may
+#     need to carefully adjust MinimumU, MinimumV, MaximumU, MaximumV.
 
-    Examples
-    --------
-    Create default supertorid
-    >>> import pyvista
-    >>> mesh = pyvista.SuperToroid()
-    >>> mesh.plot(color='w')  # doctest:+SKIP
+#     Examples
+#     --------
+#     Create default supertorid
+#     >>> import pyvista
+#     >>> mesh = pyvista.SuperToroid()
+#     >>> mesh.plot(color='w')  # doctest:+SKIP
 
-    Alternative supertorid pointed in the y direction
-    >>> mesh = pyvista.SuperToroid(n_1=1, n_2=2, direction=[0, 1, 0])
-    """
-    # create parametric supertorus
-    parametric_function = vtk.vtkParametricSuperToroid()
-    parametric_function.SetRingRadius(ring_radius)
-    parametric_function.SetCrossSectionRadius(cross_section_radius)
-    parametric_function.SetXRadius(x_radius)
-    parametric_function.SetYRadius(y_radius)
-    parametric_function.SetZRadius(z_radius)
-    parametric_function.SetN1(n_1)
-    parametric_function.SetN2(n_2)
+#     Alternative supertorid pointed in the y direction
+#     >>> mesh = pyvista.SuperToroid(n_1=1, n_2=2, direction=[0, 1, 0])
+#     """
+#     # create parametric supertorus
+#     parametric_function = vtk.vtkParametricSuperToroid()
+#     parametric_function.SetRingRadius(ring_radius)
+#     parametric_function.SetCrossSectionRadius(cross_section_radius)
+#     parametric_function.SetXRadius(x_radius)
+#     parametric_function.SetYRadius(y_radius)
+#     parametric_function.SetZRadius(z_radius)
+#     parametric_function.SetN1(n_1)
+#     parametric_function.SetN2(n_2)
 
-    surf = surface_from_para(parametric_function, **kwargs)
-    # default direction is +z, change to +x
-    surf.rotate_y(-90)
+#     surf = surface_from_para(parametric_function, **kwargs)
+#     # default direction is +z, change to +x
+#     surf.rotate_y(-90)
 
-    center = kwargs.pop('center', [0., 0., 0.])
-    direction = kwargs.pop('direction', [1., 0., 0.])
-    translate(surf, center, direction)
+#     center = kwargs.pop('center', [0., 0., 0.])
+#     direction = kwargs.pop('direction', [1., 0., 0.])
+#     translate(surf, center, direction)
 
-    return surf
-
-
-def Ellipsoid(x_radius=1.0, y_radius=1.0, z_radius=1.0, **kwargs):
-    """Construct an ellipsoid mesh.
-
-    If all the radii are the same, we have a sphere. An oblate
-    spheroid occurs if ``radius_x`` = ``radius_y`` >
-    ``radius_z``. Here the Z-axis forms the symmetry axis. To a first
-    approximation, this is the shape of the earth. A prolate spheroid
-    occurs if ``radius_x`` = ``radius_y`` < ``radius_z``.
-
-    Parameters
-    ----------
-    x_radius : float, optional
-        Radius in the x direction.
-
-    y_radius : float, optional
-        Radius in the y direction.
-
-    z_radius : float, optional
-        Radius in the z direction.
-
-    **kwargs : keyword arguments
-        Additional settings to control mesh creation. See
-
-        - ``help(pyvista.parametric_keywords)``
-        - ``help(pyvista.surface_from_para)``
-        - ``help(pyvista.translate)``
-
-    Examples
-    --------
-    Create an Ellipsoid
-    >>> import pyvista
-    >>> mesh = pyvista.Ellipsoid(10, 1, 2)
-    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
-    """
-    # create parametric supertorus
-    parametric_function = vtk.vtkParametricEllipsoid()
-    parametric_function.SetXRadius(x_radius)
-    parametric_function.SetYRadius(y_radius)
-    parametric_function.SetZRadius(z_radius)
-
-    surf = surface_from_para(parametric_function, **kwargs)
-
-    # default direction is +z
-    surf.rotate_y(-90)
-
-    center = kwargs.pop('center', [0., 0., 0.])
-    direction = kwargs.pop('direction', [0., 0., 1.])
-    translate(surf, center, direction)
-
-    return surf
+#     return surf
 
 
-def parametric_keywords(parametric_function, min_u=0, max_u=2*pi,
-                        min_v=0.0, max_v=2*pi, join_u=False, join_v=False,
-                        twist_u=False, twist_v=False, clockwise=True):
-    """Applys keyword arguments to a parametric function.
+# def Ellipsoid(x_radius=1.0, y_radius=1.0, z_radius=1.0, **kwargs):
+#     """Construct an ellipsoid mesh.
 
-    Parameters
-    ----------
-    min_u : float, optional
-        The minimum u-value.
+#     If all the radii are the same, we have a sphere. An oblate
+#     spheroid occurs if ``radius_x`` = ``radius_y`` >
+#     ``radius_z``. Here the Z-axis forms the symmetry axis. To a first
+#     approximation, this is the shape of the earth. A prolate spheroid
+#     occurs if ``radius_x`` = ``radius_y`` < ``radius_z``.
 
-    max_u : float, optional
-        The maximum u-value.
+#     Parameters
+#     ----------
+#     x_radius : float, optional
+#         Radius in the x direction.
 
-    min_v : float, optional
-        The minimum v-value.
+#     y_radius : float, optional
+#         Radius in the y direction.
 
-    max_v : float, optional
-        The maximum v-value.
+#     z_radius : float, optional
+#         Radius in the z direction.
 
-    join_u : bool, optional
-        Joins the first triangle strip to the last one with a twist in
-        the u direction.
+#     **kwargs : keyword arguments
+#         Additional settings to control mesh creation. See
 
-    join_v : bool, optional
-        joins the first triangle strip to the last one with a twist in
-        the v direction.
+#         - ``help(pyvista.parametric_keywords)``
+#         - ``help(pyvista.surface_from_para)``
+#         - ``help(pyvista.translate)``
 
-    twist_u : bool, optional
-        Joins the first triangle strip to the last one with a twist in
-        the u direction.
+#     Examples
+#     --------
+#     Create an Ellipsoid
+#     >>> import pyvista
+#     >>> mesh = pyvista.Ellipsoid(10, 1, 2)
+#     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+#     """
+#     # create parametric supertorus
+#     parametric_function = vtk.vtkParametricEllipsoid()
+#     parametric_function.SetXRadius(x_radius)
+#     parametric_function.SetYRadius(y_radius)
+#     parametric_function.SetZRadius(z_radius)
 
-    twist_v : bool, optional
-        Joins the first triangle strip to the last one with a twist in
-        the v direction.
+#     surf = surface_from_para(parametric_function, **kwargs)
 
-    clockwise : bool, optional
-        Determines the ordering of the vertices forming the triangle
-        strips.
-    """
-    parametric_function.SetMinimumU(min_u)
-    parametric_function.SetMaximumU(max_u)
-    parametric_function.SetMinimumV(min_v)
-    parametric_function.SetMaximumV(max_v)
-    parametric_function.SetJoinU(join_u)
-    parametric_function.SetJoinV(join_v)
-    parametric_function.SetTwistU(twist_u)
-    parametric_function.SetTwistV(twist_v)
-    parametric_function.SetClockwiseOrdering(clockwise)
+#     # default direction is +z
+#     surf.rotate_y(-90)
 
+#     center = kwargs.pop('center', [0., 0., 0.])
+#     direction = kwargs.pop('direction', [0., 0., 1.])
+#     translate(surf, center, direction)
 
-def Spline(points, n_points=None):
-    """Create a spline from points
-
-    Parameters
-    ----------
-    points : np.ndarray
-        Array of points to build a spline out of.  Array must be 3D
-        and directionally ordered.
-
-    n_points : int, optional
-        Number of points to interpolate along the points array.
-
-    Returns
-    -------
-    spline : pyvista.PolyData
-        Line mesh of spline.
-
-    Examples
-    --------
-    Construct a spline
-    >>> import numpy as np
-    >>> import pyvista as pv
-    >>> theta = np.linspace(-4 * np.pi, 4 * np.pi, 100)
-    >>> z = np.linspace(-2, 2, 100)
-    >>> r = z**2 + 1
-    >>> x = r * np.sin(theta)
-    >>> y = r * np.cos(theta)
-    >>> points = np.column_stack((x, y, z))
-    >>> spline = pv.Spline(points, 1000)
-    """
-    spline_function = vtk.vtkParametricSpline()
-    spline_function.SetPoints(pyvista.vtk_points(points, False))
-
-    # get interpolation density
-    u_res = n_points
-    if u_res is None:
-        u_res = points.shape[0]
-
-    u_res -= 1
-    return surface_from_para(spline_function, u_res)
+#     return surf
 
 
-def surface_from_para(parametric_function, u_res=100, v_res=100,
-                      w_res=100, **kwargs):
-    """Construct a mesh from a parametric function.
-
-    Parameters
-    ----------
-    parametric_function : vtk.vtkParametricFunction
-        Parametric function to generate mesh from.
-
-    u_res : int, optional
-        Resolution in the u direction.
-
-    v_res : int, optional
-        Resolution in the v direction.
-
-    w_res : int, optional
-        Resolution in the w direction.
-    """
-    # convert to a mesh
-    para_source = vtk.vtkParametricFunctionSource()
-    para_source.SetParametricFunction(parametric_function)
-    para_source.SetUResolution(u_res)
-    para_source.SetVResolution(v_res)
-    para_source.SetWResolution(w_res)
-    para_source.Update()
-    return pyvista.wrap(para_source.GetOutput())

--- a/pyvista/parametric_geometry.py
+++ b/pyvista/parametric_geometry.py
@@ -1,0 +1,1037 @@
+from math import pi
+
+import vtk
+import pyvista
+from pyvista import translate
+
+
+def Spline(points, n_points=None):
+    """Create a spline from points.
+
+    Parameters
+    ----------
+    points : np.ndarray
+        Array of points to build a spline out of.  Array must be 3D
+        and directionally ordered.
+
+    n_points : int, optional
+        Number of points to interpolate along the points array.
+
+    Returns
+    -------
+    spline : pyvista.PolyData
+        Line mesh of spline.
+
+    Examples
+    --------
+    Construct a spline
+    >>> import numpy as np
+    >>> import pyvista as pv
+    >>> theta = np.linspace(-4 * np.pi, 4 * np.pi, 100)
+    >>> z = np.linspace(-2, 2, 100)
+    >>> r = z**2 + 1
+    >>> x = r * np.sin(theta)
+    >>> y = r * np.cos(theta)
+    >>> points = np.column_stack((x, y, z))
+    >>> spline = pv.Spline(points, 1000)
+    """
+    spline_function = vtk.vtkParametricSpline()
+    spline_function.SetPoints(pyvista.vtk_points(points, False))
+
+    # get interpolation density
+    u_res = n_points
+    if u_res is None:
+        u_res = points.shape[0]
+
+    u_res -= 1
+    return surface_from_para(spline_function, u_res)
+
+
+def ParametricBohemianDome(a=None, **kwargs):
+    """Generate a Bohemian dome.
+
+    Parameters
+    ----------
+    a : double, optional
+        Construct a Bohemian dome surface with the following parameters:
+     
+    vtkGetMacro(A, double);
+
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricBohemianDome surface
+
+    Examples
+    --------
+    Create a ParametricBohemianDome mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricBohemianDome()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricBohemianDome()
+    if a is not None:
+        parametric_function.SetA(a)
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricBour(**kwargs):
+    """Generate Bour's minimal surface.
+
+    Parameters
+    ----------
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricBour surface
+
+    Examples
+    --------
+    Create a ParametricBour mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricBour()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricBour()
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricBoy(zscale=None, **kwargs):
+    """Generate Boy's surface.
+ 
+    ParametricBoy generates Boy's surface.
+    This is a Model of the projective plane without singularities.
+    It was found by Werner Boy on assignment from David Hilbert.
+ 
+    For further information about this surface, please consult the
+    technical description "Parametric surfaces" in http:www.vtk.orgpublications
+    in the "VTK Technical Documents" section in the VTk.org web pages.
+
+    Parameters
+    ----------
+    zscale : double, optional
+        The scale factor for the z-coordinate.
+      Default is 18, giving a nice shape.
+
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricBoy surface
+
+    Examples
+    --------
+    Create a ParametricBoy mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricBoy()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricBoy()
+    if zscale is not None:
+        parametric_function.SetZScale(zscale)
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricCatalanMinimal(**kwargs):
+    """Generate Catalan's minimal surface.
+ 
+    ParametricCatalanMinimal generates Catalan's minimal surface
+    parametrically. This minimal surface contains the cycloid as a
+    geodesic.
+
+    Parameters
+    ----------
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricCatalanMinimal surface
+
+    Examples
+    --------
+    Create a ParametricCatalanMinimal mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricCatalanMinimal()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricCatalanMinimal()
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricConicSpiral(a=None, b=None, c=None, n=None, **kwargs):
+    """Generate conic spiral surfaces that resemble sea-shells.
+
+    ParametricConicSpiral generates conic spiral surfaces. These can
+    resemble sea shells, or may look like a torus "eating" its own
+    tail.
+
+    Parameters
+    ----------
+    a : double, optional
+        The scale factor.
+        Default is 0.2
+
+    b : double, optional
+        The A function coefficient.
+        See the definition in Parametric surfaces referred to above.
+        Default is 1.
+
+    c : double, optional
+        The B function coefficient.
+        See the definition in Parametric surfaces referred to above.
+        Default is 0.1.
+
+    n : double, optional
+        The C function coefficient.
+        See the definition in Parametric surfaces referred to above.
+        Default is 2.
+
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricConicSpiral surface
+
+    Examples
+    --------
+    Create a ParametricConicSpiral mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricConicSpiral()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricConicSpiral()
+    if a is not None:
+        parametric_function.SetA(a)
+
+    if b is not None:
+        parametric_function.SetB(b)
+
+    if c is not None:
+        parametric_function.SetC(c)
+
+    if n is not None:
+        parametric_function.SetN(n)
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricCrossCap(**kwargs):
+    """Generate a cross-cap.
+
+    ParametricCrossCap generates a cross-cap which is a non-orientable
+    self-intersecting single-sided surface.  This is one possible
+    image of a projective plane in three-space.
+
+    Parameters
+    ----------
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricCrossCap surface
+
+    Examples
+    --------
+    Create a ParametricCrossCap mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricCrossCap()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricCrossCap()
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricDini(a=None, b=None, **kwargs):
+    """Generate Dini's surface.
+
+    ParametricDini generates Dini's surface.  Dini's surface is a
+    surface that possesses constant negative Gaussian curvature
+
+    Parameters
+    ----------
+    a : double, optional
+        The scale factor.
+        See the definition in Parametric surfaces referred to above.
+        Default is 1.
+
+    b : double, optional
+        The scale factor.
+        See the definition in Parametric surfaces referred to above.
+        Default is 0.2
+
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricDini surface
+
+    Examples
+    --------
+    Create a ParametricDini mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricDini()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricDini()
+    if a is not None:
+        parametric_function.SetA(a)
+
+    if b is not None:
+        parametric_function.SetB(b)
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricEllipsoid(xradius=None, yradius=None, zradius=None,
+                        **kwargs):
+    """Generate an ellipsoid.
+
+    ParametricEllipsoid generates an ellipsoid.  If all the radii are
+    the same, we have a sphere.  An oblate spheroid occurs if RadiusX
+    = RadiusY > RadiusZ.  Here the Z-axis forms the symmetry axis. To
+    a first approximation, this is the shape of the earth.  A prolate
+    spheroid occurs if RadiusX = RadiusY < RadiusZ.
+
+    Parameters
+    ----------
+    xradius : double, optional
+        The scaling factor for the x-axis. Default is 1.
+
+    yradius : double, optional
+        The scaling factor for the y-axis. Default is 1.
+
+    zradius : double, optional
+        The scaling factor for the z-axis. Default is 1.
+
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricEllipsoid surface
+
+    Examples
+    --------
+    Create a ParametricEllipsoid mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricEllipsoid()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricEllipsoid()
+    parametric_keywords(parametric_function, **kwargs)
+
+    if xradius is not None:
+        parametric_function.SetXRadius(xradius)
+
+    if yradius is not None:
+        parametric_function.SetYRadius(yradius)
+
+    if zradius is not None:
+        parametric_function.SetZRadius(zradius)
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricEnneper(**kwargs):
+    """Generate Enneper's surface.
+
+    ParametricEnneper generates Enneper's surface.
+    Enneper's surface is a a self-intersecting minimal surface
+    possessing constant negative Gaussian curvature
+
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricEnneper surface
+
+    Examples
+    --------
+    Create a ParametricEnneper mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricEnneper()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricEnneper()
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricFigure8Klein(radius=None, **kwargs):
+    """Generate a figure-8 Klein bottle.
+
+    ParametricFigure8Klein generates a figure-8 Klein bottle.  A Klein
+    bottle is a closed surface with no interior and only one surface.
+    It is unrealisable in 3 dimensions without intersecting surfaces.
+
+    Parameters
+    ----------
+    radius : double, optional
+        The radius of the bottle. Default is 1.
+
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricFigure8Klein surface
+
+    Examples
+    --------
+    Create a ParametricFigure8Klein mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricFigure8Klein()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricFigure8Klein()
+    if radius is not None:
+        parametric_function.SetRadius(radius)
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricHenneberg(**kwargs):
+    """Generate Henneberg's minimal surface.
+
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricHenneberg surface
+
+    Examples
+    --------
+    Create a ParametricHenneberg mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricHenneberg()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricHenneberg()
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricKlein(**kwargs):
+    """Generates a "classical" representation of a Klein bottle.
+
+    ParametricKlein generates a "classical" representation of a Klein
+    bottle.  A Klein bottle is a closed surface with no interior and only one
+    surface.  It is unrealisable in 3 dimensions without intersecting
+    surfaces.
+
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricKlein surface
+
+    Examples
+    --------
+    Create a ParametricKlein mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricKlein()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricKlein()
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricKuen(deltav0=None, **kwargs):
+    """Generate Kuens' surface.
+
+    ParametricKuen generates Kuens' surface. This surface has a constant
+    negative gaussian curvature.
+
+    Parameters
+    ----------
+    deltav0 : double, optional
+        The value to use when V == 0.
+        Default is 0.05, giving the best appearance with the default settings.
+        Setting it to a value less than 0.05 extrapolates the surface
+        towards a pole in the -z direction.
+        Setting it to 0 retains the pole whose z-value is -inf.
+
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricKuen surface
+
+    Examples
+    --------
+    Create a ParametricKuen mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricKuen()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricKuen()
+    if deltav0 is not None:
+        parametric_function.SetDeltaV0(deltav0)
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricMobius(radius=None, **kwargs):
+    """Generate a Mobius strip.
+
+    Parameters
+    ----------
+    radius : double, optional
+        The radius of the Mobius strip. Default is 1.
+
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricMobius surface
+
+    Examples
+    --------
+    Create a ParametricMobius mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricMobius()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricMobius()
+    if radius is not None:
+        parametric_function.SetRadius(radius)
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricPluckerConoid(n=None, **kwargs):
+    """Generate Plucker's conoid surface.
+
+    ParametricPluckerConoid generates Plucker's conoid surface parametrically.
+    Plucker's conoid is a ruled surface, named after Julius Plucker. It is
+    possible to set the number of folds in this class via the parameter 'N'.
+
+    Parameters
+    ----------
+    n : int, optional
+        This is the number of folds in the conoid.
+     
+    vtkGetMacro(N, int);
+
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricPluckerConoid surface
+
+    Examples
+    --------
+    Create a ParametricPluckerConoid mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricPluckerConoid()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricPluckerConoid()
+    if n is not None:
+        parametric_function.SetN(n)
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricPseudosphere(**kwargs):
+    """Generate a pseudosphere.
+ 
+    ParametricPseudosphere generates a parametric pseudosphere. The
+    pseudosphere is generated as a surface of revolution of the
+    tractrix about it's asymptote, and is a surface of constant
+    negative Gaussian curvature.
+
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricPseudosphere surface
+
+    Examples
+    --------
+    Create a ParametricPseudosphere mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricPseudosphere()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricPseudosphere()
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricRandomHills(numberofhills=None, hillxvariance=None,
+                          hillyvariance=None, hillamplitude=None,
+                          randomseed=None, xvariancescalefactor=None,
+                          yvariancescalefactor=None,
+                          amplitudescalefactor=None, **kwargs):
+    """Generate a surface covered with randomly placed hills.
+
+    ParametricRandomHills generates a surface covered with randomly
+    placed hills. Hills will vary in shape and height since the
+    presence of nearby hills will contribute to the shape and height
+    of a given hill.  An option is provided for placing hills on a
+    regular grid on the surface.  In this case the hills will all have
+    the same shape and height.
+
+    Parameters
+    ----------
+    numberofhills : int, optional
+        The number of hills.
+        Default is 30.
+
+    hillxvariance : double, optional
+        The hill variance in the x-direction.
+        Default is 2.5.
+
+    hillyvariance : double, optional
+        The hill variance in the y-direction.
+        Default is 2.5.
+
+    hillamplitude : double, optional
+        The hill amplitude (height).
+        Default is 2.
+
+    randomseed : int, optional
+        The Seed for the random number generator,
+        a value of 1 will initialize the random number generator,
+        a negative value will initialize it with the system time.
+        Default is 1.
+
+    xvariancescalefactor : double, optional
+        The scaling factor for the variance in the x-direction.
+        Default is 13.
+
+    yvariancescalefactor : double, optional
+        The scaling factor for the variance in the y-direction.
+        Default is 13.
+
+    amplitudescalefactor : double, optional
+        The scaling factor for the amplitude.
+        Default is 13.
+
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricRandomHills surface
+
+    Examples
+    --------
+    Create a ParametricRandomHills mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricRandomHills()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricRandomHills()
+    if numberofhills is not None:
+        parametric_function.SetNumberOfHills(numberofhills)
+
+    if hillxvariance is not None:
+        parametric_function.SetHillXVariance(hillxvariance)
+
+    if hillyvariance is not None:
+        parametric_function.SetHillYVariance(hillyvariance)
+
+    if hillamplitude is not None:
+        parametric_function.SetHillAmplitude(hillamplitude)
+
+    if randomseed is not None:
+        parametric_function.SetRandomSeed(randomseed)
+
+    if xvariancescalefactor is not None:
+        parametric_function.SetXVarianceScaleFactor(xvariancescalefactor)
+
+    if yvariancescalefactor is not None:
+        parametric_function.SetYVarianceScaleFactor(yvariancescalefactor)
+
+    if amplitudescalefactor is not None:
+        parametric_function.SetAmplitudeScaleFactor(amplitudescalefactor)
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricRoman(radius=None, **kwargs):
+    """Generate Steiner's Roman Surface.
+
+    Parameters
+    ----------
+    radius : double, optional
+        The radius. Default is 1.
+
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricRoman surface
+
+    Examples
+    --------
+    Create a ParametricRoman mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricRoman()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricRoman()
+    if radius is not None:
+        parametric_function.SetRadius(radius)
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricSuperEllipsoid(xradius=None, yradius=None, zradius=None,
+                             n1=None, n2=None, **kwargs):
+    """Generate a superellipsoid.
+
+    ParametricSuperEllipsoid generates a superellipsoid.  A superellipsoid
+    is a versatile primitive that is controlled by two parameters n1 and
+    n2. As special cases it can represent a sphere, square box, and closed
+    cylindrical can.
+
+    Parameters
+    ----------
+    xradius : double, optional
+        The scaling factor for the x-axis. Default is 1.
+
+    yradius : double, optional
+        The scaling factor for the y-axis. Default is 1.
+
+    zradius : double, optional
+        The scaling factor for the z-axis. Default is 1.
+
+    n1 : double, optional
+        The "squareness" parameter in the z axis.  Default is 1.
+
+    n2 : double, optional
+        The "squareness" parameter in the x-y plane. Default is 1.
+
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricSuperEllipsoid surface
+
+    Examples
+    --------
+    Create a ParametricSuperEllipsoid mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricSuperEllipsoid()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricSuperEllipsoid()
+    if xradius is not None:
+        parametric_function.SetXRadius(xradius)
+
+    if yradius is not None:
+        parametric_function.SetYRadius(yradius)
+
+    if zradius is not None:
+        parametric_function.SetZRadius(zradius)
+
+    if n1 is not None:
+        parametric_function.SetN1(n1)
+
+    if n2 is not None:
+        parametric_function.SetN2(n2)
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricSuperToroid(ringradius=None, crosssectionradius=None,
+                          xradius=None, yradius=None, zradius=None,
+                          n1=None, n2=None, **kwargs):
+    """Generate a supertoroid.
+
+    ParametricSuperToroid generates a supertoroid.  Essentially a
+    supertoroid is a torus with the sine and cosine terms raised to a power.
+    A supertoroid is a versatile primitive that is controlled by four
+    parameters r0, r1, n1 and n2. r0, r1 determine the type of torus whilst
+    the value of n1 determines the shape of the torus ring and n2 determines
+    the shape of the cross section of the ring. It is the different values of
+    these powers which give rise to a family of 3D shapes that are all
+    basically toroidal in shape.
+
+    Parameters
+    ----------
+    ringradius : double, optional
+        The radius from the center to the middle of the ring of the
+      supertoroid. Default is 1.
+
+    crosssectionradius : double, optional
+        The radius of the cross section of ring of the supertoroid.
+      Default = 0.5.
+
+    xradius : double, optional
+        The scaling factor for the x-axis. Default is 1.
+
+    yradius : double, optional
+        The scaling factor for the y-axis. Default is 1.
+
+    zradius : double, optional
+        The scaling factor for the z-axis. Default is 1.
+
+    n1 : double, optional
+        The shape of the torus ring.  Default is 1.
+
+    n2 : double, optional
+        The shape of the cross section of the ring. Default is 1.
+
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricSuperToroid surface
+
+    Examples
+    --------
+    Create a ParametricSuperToroid mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricSuperToroid()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricSuperToroid()
+    if ringradius is not None:
+        parametric_function.SetRingRadius(ringradius)
+
+    if crosssectionradius is not None:
+        parametric_function.SetCrossSectionRadius(crosssectionradius)
+
+    if xradius is not None:
+        parametric_function.SetXRadius(xradius)
+
+    if yradius is not None:
+        parametric_function.SetYRadius(yradius)
+
+    if zradius is not None:
+        parametric_function.SetZRadius(zradius)
+
+    if n1 is not None:
+        parametric_function.SetN1(n1)
+
+    if n2 is not None:
+        parametric_function.SetN2(n2)
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def ParametricTorus(ringradius=None, crosssectionradius=None, **kwargs):
+    """Generate a torus.
+
+    Parameters
+    ----------
+    ringradius : double, optional
+        The radius from the center to the middle of the ring of the
+        torus. Default is 1.0.
+
+    crosssectionradius : double, optional
+        The radius of the cross section of ring of the torus. Default is 0.5.
+
+    Returns
+    -------
+    surf : pyvista.PolyData
+        ParametricTorus surface
+
+    Examples
+    --------
+    Create a ParametricTorus mesh
+    >>> import pyvista
+    >>> mesh = pyvista.ParametricTorus()
+    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+    """
+    parametric_function = vtk.vtkParametricTorus()
+    if ringradius is not None:
+        parametric_function.SetRingRadius(ringradius)
+
+    if crosssectionradius is not None:
+        parametric_function.SetCrossSectionRadius(crosssectionradius)
+
+    surf = surface_from_para(parametric_function, **kwargs)
+
+    center = kwargs.pop('center', [0., 0., 0.])
+    direction = kwargs.pop('direction', [0., 0., 1.])
+    translate(surf, center, direction)
+
+    return surf
+
+
+def parametric_keywords(parametric_function, min_u=0, max_u=2*pi,
+                        min_v=0.0, max_v=2*pi, join_u=False, join_v=False,
+                        twist_u=False, twist_v=False, clockwise=True, **kwargs):
+    """Applys keyword arguments to a parametric function.
+
+    Parameters
+    ----------
+    min_u : float, optional
+        The minimum u-value.
+
+    max_u : float, optional
+        The maximum u-value.
+
+    min_v : float, optional
+        The minimum v-value.
+
+    max_v : float, optional
+        The maximum v-value.
+
+    join_u : bool, optional
+        Joins the first triangle strip to the last one with a twist in
+        the u direction.
+
+    join_v : bool, optional
+        joins the first triangle strip to the last one with a twist in
+        the v direction.
+
+    twist_u : bool, optional
+        Joins the first triangle strip to the last one with a twist in
+        the u direction.
+
+    twist_v : bool, optional
+        Joins the first triangle strip to the last one with a twist in
+        the v direction.
+
+    clockwise : bool, optional
+        Determines the ordering of the vertices forming the triangle
+        strips.
+    """
+    parametric_function.SetMinimumU(min_u)
+    parametric_function.SetMaximumU(max_u)
+    parametric_function.SetMinimumV(min_v)
+    parametric_function.SetMaximumV(max_v)
+    parametric_function.SetJoinU(join_u)
+    parametric_function.SetJoinV(join_v)
+    parametric_function.SetTwistU(twist_u)
+    parametric_function.SetTwistV(twist_v)
+    parametric_function.SetClockwiseOrdering(clockwise)
+
+
+def surface_from_para(parametric_function, u_res=100, v_res=100,
+                      w_res=100, **kwargs):
+    """Construct a mesh from a parametric function.
+
+    Parameters
+    ----------
+    parametric_function : vtk.vtkParametricFunction
+        Parametric function to generate mesh from.
+
+    u_res : int, optional
+        Resolution in the u direction.
+
+    v_res : int, optional
+        Resolution in the v direction.
+
+    w_res : int, optional
+        Resolution in the w direction.
+    """
+    # convert to a mesh
+    para_source = vtk.vtkParametricFunctionSource()
+    para_source.SetParametricFunction(parametric_function)
+    para_source.SetUResolution(u_res)
+    para_source.SetVResolution(v_res)
+    para_source.SetWResolution(w_res)
+    para_source.Update()
+    return pyvista.wrap(para_source.GetOutput())

--- a/pyvista/plotting.py
+++ b/pyvista/plotting.py
@@ -139,13 +139,12 @@ def opacity_transfer_function(key, n_colors):
         raise KeyError('opactiy transfer function ({}) unknown.'.format(key))
 
 
-def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
-         interactive=True, cpos=None, window_size=None,
-         show_bounds=False, show_axes=True, notebook=None, background=None,
-         text='', return_img=False, eye_dome_lighting=False, use_panel=None,
-         **kwargs):
-    """
-    Convenience plotting function for a vtk or numpy object.
+def plot(var_item, off_screen=None, full_screen=False,
+         screenshot=None, interactive=True, cpos=None,
+         window_size=None, show_bounds=False, show_axes=True,
+         notebook=None, background=None, text='', return_img=False,
+         eye_dome_lighting=False, use_panel=None, **kwargs):
+    """Convenience plotting function for a vtk or numpy object.
 
     Parameters
     ----------

--- a/tests/test_geometric_objects.py
+++ b/tests/test_geometric_objects.py
@@ -68,23 +68,13 @@ def test_disc():
     assert np.any(geom.points)
 
 
-def test_supertoroid():
-    geom = pyvista.SuperToroid()
-    assert np.any(geom.points)
+# def test_supertoroid():
+#     geom = pyvista.SuperToroid()
+#     assert np.any(geom.points)
 
 
-def test_ellipsoid():
-    geom = pyvista.Ellipsoid()
-    assert np.any(geom.points)
+# def test_ellipsoid():
+#     geom = pyvista.Ellipsoid()
+#     assert np.any(geom.points)
 
 
-def test_spline():
-    theta = np.linspace(-4 * np.pi, 4 * np.pi, 100)
-    z = np.linspace(-2, 2, 100)
-    r = z**2 + 1
-    x = r * np.sin(theta)
-    y = r * np.cos(theta)
-
-    points = np.column_stack((x, y, z))
-    spline = pyvista.Spline(points, 1000)
-    assert spline.n_points == 1000

--- a/tests/test_parametric_geometry.py
+++ b/tests/test_parametric_geometry.py
@@ -1,0 +1,120 @@
+import numpy as np
+
+import pyvista
+
+
+def test_spline():
+    theta = np.linspace(-4 * np.pi, 4 * np.pi, 100)
+    z = np.linspace(-2, 2, 100)
+    r = z**2 + 1
+    x = r * np.sin(theta)
+    y = r * np.cos(theta)
+
+    points = np.column_stack((x, y, z))
+    spline = pyvista.Spline(points, 1000)
+    assert spline.n_points == 1000
+
+
+def test_ParametricBohemianDome():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricBour():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricBoy():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricCatalanMinimal():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricConicSpiral():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricCrossCap():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricDini():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricEllipsoid():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricEnneper():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricFigure8Klein():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricHenneberg():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricKlein():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricKuen():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricMobius():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricPluckerConoid():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricPseudosphere():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricRandomHills():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricRoman():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricSuperEllipsoid():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricSuperToroid():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points
+
+
+def test_ParametricTorus():
+    geom = pyvista.ParametricBohemianDome()
+    assert geom.n_points


### PR DESCRIPTION
Went ahead and added a bunch of parametric geometry functions to match vtk's example here:
[ParametricObjectsDemo](https://lorensen.github.io/VTKExamples/site/Cxx/GeometricObjects/ParametricObjectsDemo/)

```python
import pv
supertoroid = pv.ParametricSuperToroid(n1=0.5)
supertoroid.plot(color='tan', smooth_shading=True)
```
![Visualization Toolkit - OpenGL_084](https://user-images.githubusercontent.com/11981631/59108699-d7e9a480-893b-11e9-9d0c-2514c2eb9c85.png)

#### Header File Parser
If anyone's interested, I wrote a parser to avoid having to manually translate the header files into Python functions.  Wasn't too bad and only had to clean up a little bit.  You'll need to clone their source.

```python
import os
import re
import vtk

lib_path = '/home/alex/projects/vtk_parse/VTK/Common/ComputationalGeometry/'

# vtk.vtkParametricBohemianDome

def sliceindex(x):
    i = 0
    for c in x:
        if c.isalpha():
            i = i + 1
            return i
        i = i + 1

def upperfirst(x):
    i = sliceindex(x)
    return x[:i].upper() + x[i:]

def get_para(raw_parameters):
    parameters = []
    for raw in raw_parameters:
        info = raw[1].replace('*', '').replace('\\', '').replace('/', '').strip()
        if 'vtkSetMacro' not in info:
            continue
        split = info.split('vtkSetMacro')
        desc = split[0].strip()        
        var_tup = split[1].split('vtkGetMacro')[0].split('\n')[0].replace(';', '')
        para_name = var_tup.split(',')[0].replace('(', '')
        para_type = var_tup.split(',')[1].replace(')', '').strip()
        desc = upperfirst(desc.replace('SetGet', '').strip())
        parameters.append([para_name, para_type, desc])
    return parameters


def translate_function(vtk_class_name, test=False):
    infile = os.path.join(lib_path, '%s.h' % vtk_class_name)

    with open(infile) as f:
        text = f.read()

    class_name = re.findall("@class.*$", text, re.MULTILINE)[0]
    fun_name = class_name.split('vtk')[1]
    desc = re.findall('(@brief)((\s|.)*?)(@)', text)
    fun_desc = desc[0][1].replace('*', '').replace('\\', '').replace('/', '').strip()
    fun_desc = fun_desc.replace('\n  ', '\n    ')
    fun_desc = fun_desc.replace('vtk' + fun_name, fun_name)

    raw_parameters = re.findall('(//@{)((\s|.)*?)(//@})', text)
    parameters = get_para(raw_parameters)

    para_str = """    Parameters
    ----------
"""
    for para_name, para_type, desc in parameters:
        para_str += '    %s : %s, optional\n' % (para_name.lower(), para_type)
        para_str += '        %s\n\n' % desc

    return_str = """    Returns
    -------
    surf : pyvista.PolyData
        %s surface

    Examples
    --------
    Create a %s mesh
    >>> import pyvista
    >>> mesh = pyvista.%s()
    >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
""" % (fun_name, fun_name, fun_name)

    variables = [para_name.lower() for para_name, _, _ in parameters]

    none_var = ['%s=None' % var for var in variables]
    none_var.append('**kwargs')
    fun_signature = "def %s(%s):" % (fun_name, ', '.join(none_var))


    fun_set_para_lines = []
    for para_name, _, _ in parameters:
        line = '    if %s is not None:\n        parametric_function.Set%s(%s)\n' % (para_name.lower(), para_name, para_name.lower())
        fun_set_para_lines.append(line)

    fun_set_para = '\n'.join(fun_set_para_lines)

    fun_body = """    parametric_function = vtk.vtk%s()
%s
    surf = surface_from_para(parametric_function, **kwargs)

    center = kwargs.pop('center', [0., 0., 0.])
    direction = kwargs.pop('direction', [0., 0., 1.])
    translate(surf, center, direction)

    return surf""" % (fun_name, fun_set_para)

    doc_str = '"""%s\n\n%s%s    """' % (fun_desc, para_str, return_str)
    # print(doc_str)

    fun = '%s\n    %s\n%s' % (fun_signature, doc_str, fun_body)


    if test:
        exec(fun)
        exec("surf = %s(); surf.plot(color='w')" % fun_name)

    test_fun = """def test_%s():
    geom = pyvista.ParametricBohemianDome()
    assert geom.n_points""" % fun_name

    # exec(test_fun)
    # exec('test_%s()' % fun_name)

    return fun, test_fun



class_names = ['vtkParametricBohemianDome',
               'vtkParametricBour',
               'vtkParametricBoy',
               'vtkParametricCatalanMinimal',
               'vtkParametricConicSpiral',
               'vtkParametricCrossCap',
               'vtkParametricDini',
               'vtkParametricEllipsoid',
               'vtkParametricEnneper',
               'vtkParametricFigure8Klein',
               # 'vtkParametricFunction',
               'vtkParametricHenneberg',
               'vtkParametricKlein',
               'vtkParametricKuen',
               'vtkParametricMobius',
               'vtkParametricPluckerConoid',
               'vtkParametricPseudosphere',
               'vtkParametricRandomHills',
               'vtkParametricRoman',
               # 'vtkParametricSpline',
               'vtkParametricSuperEllipsoid',
               'vtkParametricSuperToroid',
               'vtkParametricTorus']

funs = []
test_funs = []
for class_name in class_names:
    fun, test_fun = translate_function(class_name)
    funs.append(fun)
    test_funs.append(test_fun)


write_file = '/home/alex/projects/vtk_parse/parametric_geometry.py'
with open(write_file, 'w') as f:
    f.write('\n\n\n'.join(funs))


write_file = '/home/alex/projects/vtk_parse/test_parametric_geometry.py'
with open(write_file, 'w') as f:
    f.write('\n\n\n'.join(test_funs))
```