### PR TITLE
plot_over_line filter

### DIFF
--- a/examples/02-plot/plot-over-line.py
+++ b/examples/02-plot/plot-over-line.py
@@ -50,8 +50,11 @@ line = pv.Line(a, b)
 p = pv.Plotter()
 p.add_mesh(mesh)
 p.add_mesh(line, color='white', line_width=10)
+p.add_point_labels([a, b], ['A', 'B'], font_size=48,
+                   point_color='red', text_color='red')
 p.show()
 
 ###############################################################################
 # Run the filter and produce a line plot
-mesh.plot_over_line(a, b, resolution=10000)
+mesh.plot_over_line(a, b, resolution=10000, title='Elevation Profile',
+                    ylabel='Height above sea level', figsize=(10, 5))

--- a/examples/02-plot/plot-over-line.py
+++ b/examples/02-plot/plot-over-line.py
@@ -1,0 +1,57 @@
+"""
+Plot Over Line
+~~~~~~~~~~~~~~
+
+Plot the values of a dataset over a line through that dataset
+"""
+
+# sphinx_gallery_thumbnail_number = 2
+import pyvista as pv
+from pyvista import examples
+
+###############################################################################
+# Volumetric Mesh
+# +++++++++++++++
+#
+# First a 3D mesh example to demonstrate a
+mesh = examples.download_kitchen()
+
+# Make two points to construct the line between
+a = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
+b = [mesh.bounds[1], mesh.bounds[3], mesh.bounds[5]]
+
+# Preview how this line intersects this mesh
+line = pv.Line(a, b)
+
+p = pv.Plotter()
+p.add_mesh(mesh, style='wireframe', color='w')
+p.add_mesh(line, color='b')
+p.show()
+
+###############################################################################
+# Run the filter and produce a line plot
+mesh.plot_over_line(a, b, resolution=100)
+
+
+###############################################################################
+# Flat Surface
+# ++++++++++++
+#
+# We could also plot the values of a mesh that lies on a flat surface
+mesh = examples.download_st_helens()
+
+# Make two points to construct the line between
+a = [mesh.center[0], mesh.bounds[2], mesh.bounds[5]]
+b = [mesh.center[0], mesh.bounds[3], mesh.bounds[5]]
+
+# Preview how this line intersects this mesh
+line = pv.Line(a, b)
+
+p = pv.Plotter()
+p.add_mesh(mesh)
+p.add_mesh(line, color='white', line_width=10)
+p.show()
+
+###############################################################################
+# Run the filter and produce a line plot
+mesh.plot_over_line(a, b, resolution=10000)

--- a/pyvista/filters.py
+++ b/pyvista/filters.py
@@ -1280,7 +1280,7 @@ class DataSetFilters(object):
         return dataset.extract_geometry().tri_filter().decimate(target_reduction)
 
 
-    def plot_over_line(dataset, pointa, pointb, resolution=100, scalars=None,
+    def plot_over_line(dataset, pointa, pointb, resolution=None, scalars=None,
                        title=None, ylabel=None, figsize=None, figure=True,
                        show=True):
         """Sample a dataset along a high resolution line and plot the variables
@@ -1296,7 +1296,8 @@ class DataSetFilters(object):
             Location in [x, y, z].
 
         resolution : int
-            number of pieces to divide line into
+            number of pieces to divide line into. Defaults to number of cells
+            in the input mesh. Must be a positive integer.
 
         scalars : str
             The string name of the variable in the input dataset to probe. The
@@ -1323,8 +1324,10 @@ class DataSetFilters(object):
         except ImportError:
             raise ImportError('matplotlib must be available to use this filter.')
 
-        # TODO: implement a way to dynamically chose a "high" resolution based
-        #       on the input dataset
+        if resolution is None:
+            resolution = dataset.n_cells
+        if not isinstance(resolution, int) or resolution < 0:
+            raise RuntimeError('`resolution` must be a positive integer.')
         # Make a line and probe the dataset
         line = pyvista.Line(pointa, pointb, resolution=resolution)
         sampled = line.sample(dataset)

--- a/pyvista/filters.py
+++ b/pyvista/filters.py
@@ -1278,3 +1278,52 @@ class DataSetFilters(object):
             of the input triangles.
         """
         return dataset.extract_geometry().tri_filter().decimate(target_reduction)
+
+
+    def plot_over_line(dataset, pointa, pointb, resolution=100, scalars=None):
+        """Sample a dataset along a high resolution line and plot the variables
+        of interest in 2D where the X-axis is distance from Point A and the
+        Y-axis is the varaible of interest.
+
+        Parameters
+        ----------
+        pointa : np.ndarray or list
+            Location in [x, y, z].
+
+        pointb : np.ndarray or list
+            Location in [x, y, z].
+
+        resolution : int
+            number of pieces to divide line into
+
+        scalars : str
+            The string name of the variable in the input dataset to probe. The
+            active scalar is used by default.
+        """
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError:
+            raise ImportError('matplotlib must be available to use this filter.')
+        # TODO: implement a way to dynamically chose a "high" resolution based
+        #       on the input dataset
+        # Make a line and probe the dataset
+        line = pyvista.Line(pointa, pointb, resolution=resolution)
+        sampled = line.sample(dataset)
+
+        # Get variable of interest
+        if scalars is None:
+            field, scalars = dataset.active_scalar_info
+        values = sampled.get_scalar(scalars)
+        distance = sampled['Distance']
+
+        # Plot it in 2D
+        if values.ndim > 1:
+            for i in range(values.shape[1]):
+                plt.plot(distance, values[:, i], label='Component {}'.format(i))
+            plt.legend()
+        else:
+            plt.plot(distance, values)
+        plt.xlabel('Distance')
+        plt.ylabel(scalars)
+        plt.title('Plot Variable Along Line')
+        plt.show()

--- a/pyvista/filters.py
+++ b/pyvista/filters.py
@@ -1280,10 +1280,11 @@ class DataSetFilters(object):
         return dataset.extract_geometry().tri_filter().decimate(target_reduction)
 
 
-    def plot_over_line(dataset, pointa, pointb, resolution=100, scalars=None):
+    def plot_over_line(dataset, pointa, pointb, resolution=100, scalars=None,
+                       title=None, ylabel=None, figsize=None, figure=True):
         """Sample a dataset along a high resolution line and plot the variables
         of interest in 2D where the X-axis is distance from Point A and the
-        Y-axis is the varaible of interest.
+        Y-axis is the varaible of interest. Note that this filter returns None.
 
         Parameters
         ----------
@@ -1299,11 +1300,25 @@ class DataSetFilters(object):
         scalars : str
             The string name of the variable in the input dataset to probe. The
             active scalar is used by default.
+
+        title : str
+            The string title of the `matplotlib` figure
+
+        ylabel : str
+            The string label of the Y-axis. Defaults to variable name
+
+        figsize : tuple(int)
+            the size of the new figure
+
+        figure : bool
+            flag on whether or not to create a new figure
         """
+        # Ensure matplotlib is available
         try:
             import matplotlib.pyplot as plt
         except ImportError:
             raise ImportError('matplotlib must be available to use this filter.')
+
         # TODO: implement a way to dynamically chose a "high" resolution based
         #       on the input dataset
         # Make a line and probe the dataset
@@ -1316,6 +1331,9 @@ class DataSetFilters(object):
         values = sampled.get_scalar(scalars)
         distance = sampled['Distance']
 
+        # Remainder of the is plotting
+        if figure:
+            plt.figure(figsize=figsize)
         # Plot it in 2D
         if values.ndim > 1:
             for i in range(values.shape[1]):
@@ -1324,6 +1342,12 @@ class DataSetFilters(object):
         else:
             plt.plot(distance, values)
         plt.xlabel('Distance')
-        plt.ylabel(scalars)
-        plt.title('Plot Variable Along Line')
+        if ylabel is None:
+            plt.ylabel(scalars)
+        else:
+            plt.ylabel(ylabel)
+        if title is None:
+            plt.title('{} Profile'.format(scalars))
+        else:
+            plt.title(title)
         plt.show()

--- a/pyvista/filters.py
+++ b/pyvista/filters.py
@@ -1281,7 +1281,8 @@ class DataSetFilters(object):
 
 
     def plot_over_line(dataset, pointa, pointb, resolution=100, scalars=None,
-                       title=None, ylabel=None, figsize=None, figure=True):
+                       title=None, ylabel=None, figsize=None, figure=True,
+                       show=True):
         """Sample a dataset along a high resolution line and plot the variables
         of interest in 2D where the X-axis is distance from Point A and the
         Y-axis is the varaible of interest. Note that this filter returns None.
@@ -1312,6 +1313,9 @@ class DataSetFilters(object):
 
         figure : bool
             flag on whether or not to create a new figure
+
+        show : bool
+            Shows the matplotlib figure
         """
         # Ensure matplotlib is available
         try:
@@ -1350,4 +1354,5 @@ class DataSetFilters(object):
             plt.title('{} Profile'.format(scalars))
         else:
             plt.title(title)
-        plt.show()
+        if show:
+         return plt.show()

--- a/pyvista/geometric_objects.py
+++ b/pyvista/geometric_objects.py
@@ -259,7 +259,12 @@ def Line(pointa=(-0.5, 0., 0.), pointb=(0.5, 0., 0.), resolution=1):
     src.SetPoint2(*pointb)
     src.SetResolution(resolution)
     src.Update()
-    return pyvista.wrap(src.GetOutput())
+    line = pyvista.wrap(src.GetOutput())
+    # Compute distance of every point along line
+    compute = lambda p0, p1: np.sqrt(np.sum((p1 - p0)**2, axis=1))
+    distance = compute(np.array(pointa), line.points)
+    line['Distance'] = distance
+    return line
 
 
 def Cube(center=(0., 0., 0.), x_length=1.0, y_length=1.0, z_length=1.0, bounds=None):

--- a/pyvista/plotting.py
+++ b/pyvista/plotting.py
@@ -2271,6 +2271,9 @@ class BasePlotter(object):
         if text_color is None:
             text_color = rcParams['font']['color']
 
+        if isinstance(points, (list, tuple)):
+            points = np.array(points)
+
         if isinstance(points, np.ndarray):
             vtkpoints = pyvista.PolyData(points) # Cast to poly data
         elif is_pyvista_obj(points):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -323,3 +323,12 @@ def test_streamlines():
                            source_center=(133.1, 116.3, 5.0) )
     assert stream.n_points > 0
     assert src.n_points == 25
+
+
+def test_plot_over_line():
+    """this requires matplotlib"""
+    mesh = examples.load_channels()
+    # Make two points to construct the line between
+    a = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
+    b = [mesh.bounds[1], mesh.bounds[3], mesh.bounds[5]]
+    mesh.plot_over_line(a, b, resolution=1000, show=False)


### PR DESCRIPTION
Here is a new `.plot_over_line` filter in response to https://github.com/pyvista/pyvista-support/issues/13 that is intended to be much like ParaView's "Plot over line" filter.

## Simple Example

```py
import pyvista as pv
from pyvista import examples

mesh = examples.download_kitchen()

# Make two points to construct the line between
a = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
b = [mesh.bounds[1], mesh.bounds[3], mesh.bounds[5]]

mesh.plot_over_line(a, b)
```

![download](https://user-images.githubusercontent.com/22067021/59292836-0ff22f80-8c3b-11e9-8e30-1e55f468a50e.png)


## Better Example

```py
import pyvista as pv
from pyvista import examples

mesh = examples.download_st_helens()

# Make two points to construct the line between
a = [mesh.center[0], mesh.bounds[2], mesh.bounds[5]]
b = [mesh.center[0], mesh.bounds[3], mesh.bounds[5]]

# Preview how this line intersects this mesh
line = pv.Line(a, b)

p = pv.Plotter()
p.add_mesh(mesh)
p.add_mesh(line, color='white', line_width=10)
p.add_point_labels([a, b], ['A', 'B'], font_size=48,
                   point_color='red', text_color='red')
p.show()
```

![sphx_glr_plot-over-line_003](https://user-images.githubusercontent.com/22067021/59296100-700dc380-8c85-11e9-9d7a-a1c70d1aa04d.png)


```py
mesh.plot_over_line(a, b, resolution=10000, title='Elevation Profile',
                    ylabel='Height above sea level', figsize=(10, 5))
```

![sphx_glr_plot-over-line_004](https://user-images.githubusercontent.com/22067021/59296094-6dab6980-8c85-11e9-99f4-1ce19b92b935.png)



## Todo

- [x] implement a way to dynamically chose a "high resolution"
- [x] test
- [x] add arguments for controlling the `matplotlib` figure
- [x] add example