### PR TITLE
Fix colormapping issue for uint8 arrays

### DIFF
--- a/pyvista/plotting.py
+++ b/pyvista/plotting.py
@@ -976,7 +976,7 @@ class BasePlotter(object):
                 else:
                     scalars = scalars.ravel()
 
-            if scalars.dtype == np.bool:
+            if scalars.dtype == np.bool or scalars.dtype == np.uint8:
                 scalars = scalars.astype(np.float)
 
             # Scalar interpolation approach


### PR DESCRIPTION
This change makes it possible to properly colormap arrays of `dtype('uint8')` by casting those arrays to floats. One problem - this changes the data type of the array to float and there no longer exists a `uint8` version of the array. Is there a situation where a user might not want to cast the `uint8` array to `float`?

Currently, this happens:

```py
import pyvista as pv
from pyvista import examples

data = examples.download_bolt_nut()
bolt = data['bolt'].threshold(50)
nut = data['nut'].threshold(50)

p = pv.Plotter()
p.add_mesh(bolt)
p.add_mesh(nut)
p.show(use_panel=False)
```

![download](https://user-images.githubusercontent.com/22067021/59792316-19117b00-9291-11e9-9885-7a4b28005758.png)


After casting the array to floats with this change, it looks like:

![download](https://user-images.githubusercontent.com/22067021/59792333-20d11f80-9291-11e9-95d2-4f07808b0e18.png)