### PR TITLE
Filter: slice along line

### DIFF
--- a/examples/01-filter/slicing.py
+++ b/examples/01-filter/slicing.py
@@ -8,6 +8,7 @@ Extract thin planar slices from a volume
 import pyvista as pv
 from pyvista import examples
 import matplotlib.pyplot as plt
+import numpy as np
 
 ################################################################################
 # PyVista meshes have several slicing filters bound directly to all datasets.

--- a/examples/01-filter/slicing.py
+++ b/examples/01-filter/slicing.py
@@ -61,3 +61,44 @@ p.show()
 slices = mesh.slice_along_axis(n=7, axis='y')
 
 slices.plot(cmap=cmap)
+
+
+################################################################################
+# Slice Along Poly Line
+# +++++++++++++++++++++
+#
+# We can also slice a dataset along a :func:`pyvista.Spline` or ``PolyLine``
+# contained in :class:`pyvista.PolyData` using the
+# :func:`DataSetFilters.slice_along_poly_line` filter.
+#
+# First, define a spline/polyline through a datset of interest. Please note
+# that this type of slicing is computationally expensive and might take a while
+# if there are a lot of points in the spline - try to keep the resolution of
+# the spline low.
+
+model = examples.load_channels()
+
+def path(y):
+    """Equation: x = a(y-h)^2 + k"""
+    a = 110.0 / 160.0**2
+    x = a*y**2 + 0.0
+    return x, y
+
+x, y = path(np.arange(model.bounds[2], model.bounds[3], 15.0))
+zo = np.linspace(9.0, 11.0, num=len(y))
+points = np.c_[x,y,zo]
+spline = pv.Spline(points, 15)
+print(spline)
+
+
+################################################################################
+# Then run the filter
+slc = model.slice_along_poly_line(spline)
+print(slc)
+
+################################################################################
+
+p = pv.Plotter()
+p.add_mesh(slc)
+p.add_mesh(model.outline())
+p.show(cpos=[1,-1,1])

--- a/examples/01-filter/slicing.py
+++ b/examples/01-filter/slicing.py
@@ -70,7 +70,7 @@ slices.plot(cmap=cmap)
 #
 # We can also slice a dataset along a :func:`pyvista.Spline` or ``PolyLine``
 # contained in :class:`pyvista.PolyData` using the
-# :func:`DataSetFilters.slice_along_poly_line` filter.
+# :func:`DataSetFilters.slice_along_line` filter.
 #
 # First, define a spline/polyline through a datset of interest. Please note
 # that this type of slicing is computationally expensive and might take a while
@@ -94,7 +94,7 @@ print(spline)
 
 ################################################################################
 # Then run the filter
-slc = model.slice_along_poly_line(spline)
+slc = model.slice_along_line(spline)
 print(slc)
 
 ################################################################################

--- a/examples/01-filter/slicing.py
+++ b/examples/01-filter/slicing.py
@@ -65,17 +65,16 @@ slices.plot(cmap=cmap)
 
 
 ################################################################################
-# Slice Along Poly Line
-# +++++++++++++++++++++
+# Slice Along Line
+# ++++++++++++++++
 #
-# We can also slice a dataset along a :func:`pyvista.Spline` or ``PolyLine``
-# contained in :class:`pyvista.PolyData` using the
-# :func:`DataSetFilters.slice_along_line` filter.
+# We can also slice a dataset along a :func:`pyvista.Spline` or
+# :func:`pyvista.Line` using the :func:`DataSetFilters.slice_along_line` filter.
 #
-# First, define a spline/polyline through a datset of interest. Please note
+# First, define a line source through a datset of interest. Please note
 # that this type of slicing is computationally expensive and might take a while
-# if there are a lot of points in the spline - try to keep the resolution of
-# the spline low.
+# if there are a lot of points in the line - try to keep the resolution of
+# the line low.
 
 model = examples.load_channels()
 

--- a/pyvista/filters.py
+++ b/pyvista/filters.py
@@ -287,9 +287,10 @@ class DataSetFilters(object):
         return output
 
 
-    def slice_along_poly_line(dataset, spline, generate_triangles=False,
+    def slice_along_line(dataset, spline, generate_triangles=False,
               contour=False):
-        """Slices a dataset using a polyline/spline as the path
+        """Slices a dataset using a polyline/spline as the path. This also works
+        for lines generated with :func:`pyvista.Line`
 
         Parameters
         ----------
@@ -302,11 +303,10 @@ class DataSetFilters(object):
 
         contour : bool, optional
             If True, apply a ``contour`` filter after slicing
-
         """
         # check that we have a PolyLine cell in the input spline
         if spline.GetNumberOfCells() != 1:
-            raise AssertionError('Input poly line must have only one PolyLine cell')
+            raise AssertionError('Input spline must have only one cell.')
         polyline = spline.GetCell(0)
         if not isinstance(polyline, vtk.vtkPolyLine):
             raise TypeError('Input spline must have a PolyLine cell, not ({})'.format(type(polyline)))

--- a/pyvista/filters.py
+++ b/pyvista/filters.py
@@ -287,14 +287,14 @@ class DataSetFilters(object):
         return output
 
 
-    def slice_along_line(dataset, spline, generate_triangles=False,
+    def slice_along_line(dataset, line, generate_triangles=False,
               contour=False):
         """Slices a dataset using a polyline/spline as the path. This also works
         for lines generated with :func:`pyvista.Line`
 
         Parameters
         ----------
-        spline : pyvista.PolyData
+        line : pyvista.PolyData
             A PolyData object containing one single PolyLine cell.
 
         generate_triangles: bool, optional
@@ -304,12 +304,12 @@ class DataSetFilters(object):
         contour : bool, optional
             If True, apply a ``contour`` filter after slicing
         """
-        # check that we have a PolyLine cell in the input spline
-        if spline.GetNumberOfCells() != 1:
-            raise AssertionError('Input spline must have only one cell.')
-        polyline = spline.GetCell(0)
+        # check that we have a PolyLine cell in the input line
+        if line.GetNumberOfCells() != 1:
+            raise AssertionError('Input line must have only one cell.')
+        polyline = line.GetCell(0)
         if not isinstance(polyline, vtk.vtkPolyLine):
-            raise TypeError('Input spline must have a PolyLine cell, not ({})'.format(type(polyline)))
+            raise TypeError('Input line must have a PolyLine cell, not ({})'.format(type(polyline)))
         # Generate PolyPlane
         polyplane = vtk.vtkPolyPlane()
         polyplane.SetPolyLine(polyline)

--- a/pyvista/filters.py
+++ b/pyvista/filters.py
@@ -287,6 +287,45 @@ class DataSetFilters(object):
         return output
 
 
+    def slice_along_poly_line(dataset, spline, generate_triangles=False,
+              contour=False):
+        """Slices a dataset using a polyline/spline as the path
+
+        Parameters
+        ----------
+        spline : pyvista.PolyData
+            A PolyData object containing one single PolyLine cell.
+
+        generate_triangles: bool, optional
+            If this is enabled (``False`` by default), the output will be
+            triangles otherwise, the output will be the intersection polygons.
+
+        contour : bool, optional
+            If True, apply a ``contour`` filter after slicing
+
+        """
+        # check that we have a PolyLine cell in the input spline
+        if spline.GetNumberOfCells() != 1:
+            raise AssertionError('Input poly line must have only one PolyLine cell')
+        polyline = spline.GetCell(0)
+        if not isinstance(polyline, vtk.vtkPolyLine):
+            raise TypeError('Input spline must have a PolyLine cell, not ({})'.format(type(polyline)))
+        # Generate PolyPlane
+        polyplane = vtk.vtkPolyPlane()
+        polyplane.SetPolyLine(polyline)
+        # Create slice
+        alg = vtk.vtkCutter() # Construct the cutter object
+        alg.SetInputDataObject(dataset) # Use the grid as the data we desire to cut
+        alg.SetCutFunction(polyplane) # the the cutter to use the poly planes
+        if not generate_triangles:
+            alg.GenerateTrianglesOff()
+        alg.Update() # Perfrom the Cut
+        output = _get_output(alg)
+        if contour:
+            return output.contour()
+        return output
+
+
     def threshold(dataset, value=None, scalars=None, invert=False, continuous=False,
                   preference='cell'):
         """

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -332,3 +332,31 @@ def test_plot_over_line():
     a = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
     b = [mesh.bounds[1], mesh.bounds[3], mesh.bounds[5]]
     mesh.plot_over_line(a, b, resolution=1000, show=False)
+
+
+def test_slice_along_line():
+    model = examples.load_uniform()
+    def path(y):
+        """Equation: x = a(y-h)^2 + k"""
+        a = 0.5**2
+        x = a*y**2 + 0.0
+        return x, y
+    x, y = path(np.arange(model.bounds[2], model.bounds[3], 15.0))
+    zo = np.linspace(9.0, 11.0, num=len(y))
+    points = np.c_[x,y,zo]
+    spline = pyvista.Spline(points, 3)
+    slc = model.slice_along_line(spline)
+    assert slc.n_points > 0
+    # Now check a simple line
+    a = [model.bounds[0], model.bounds[2], model.bounds[4]]
+    b = [model.bounds[1], model.bounds[3], model.bounds[5]]
+    line = pyvista.Line(a, b, resolution=10)
+    slc = model.slice_along_line(line)
+    assert slc.n_points > 0
+    # Now check a bad input
+    a = [model.bounds[0], model.bounds[2], model.bounds[4]]
+    b = [model.bounds[1], model.bounds[2], model.bounds[5]]
+    line2 = pyvista.Line(a, b, resolution=10)
+    line = line2.cast_to_unstructured_grid().merge(line.cast_to_unstructured_grid())
+    with pytest.raises(AssertionError):
+        slc = model.slice_along_line(line)


### PR DESCRIPTION
Add new `slice_along_line` filter now that `Spline` is supported - this filter mimics ParaView's "Slice Along Poly Line" filter but supports just about any line source

```py
import pyvista as pv
from pyvista import examples
import numpy as np

model = examples.load_channels()

def path(y):
    """Equation: x = a(y-h)^2 + k"""
    a = 110.0 / 160.0**2
    x = a*y**2 + 0.0
    return x, y

x, y = path(np.arange(model.bounds[2], model.bounds[3], 15.0))
zo = np.linspace(9.0, 11.0, num=len(y))
points = np.c_[x,y,zo]
spline = pv.Spline(points, 7)

slc = model.slice_along_line(spline)

p = pv.Plotter()
p.add_mesh(slc)
p.add_mesh(model.outline())
p.show(cpos=[1,-1,1])
```

![download](https://user-images.githubusercontent.com/22067021/59795781-45c99080-9299-11e9-91de-f432a802edf6.png)