### PR TITLE
Glyphing subsets

### DIFF
--- a/examples/02-plot/plot-glyphs.py
+++ b/examples/02-plot/plot-glyphs.py
@@ -1,13 +1,13 @@
 """
 .. _glyph_example:
 
-Plotting Glyphs
-~~~~~~~~~~~~~~~
+Plotting Glyphs (Vectors)
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use vectors in a dataset to plot and orient glyphs/geometric objects.
 """
 
-# sphinx_gallery_thumbnail_number = 1
+# sphinx_gallery_thumbnail_number = 4
 import pyvista as pv
 from pyvista import examples
 import numpy as np
@@ -76,5 +76,5 @@ arrows = mesh.glyph(scale='Normals', orient='Normals', subset=0.05)
 
 p = pv.Plotter()
 p.add_mesh(arrows, color='black')
-p.add_mesh(mesh)
+p.add_mesh(mesh, scalars='Elevation', cmap='terrain')
 p.show()

--- a/examples/02-plot/plot-glyphs.py
+++ b/examples/02-plot/plot-glyphs.py
@@ -56,3 +56,25 @@ p = pv.Plotter()
 p.add_mesh(sphere.arrows, lighting=False, stitle='Vector Magnitude')
 p.add_mesh(sphere, color='grey', ambient=0.6, opacity=0.5, show_edges=False)
 p.show()
+
+
+################################################################################
+# Subset of Glyphs
+# ++++++++++++++++
+#
+# Sometimes you might not want glyphs for every node in the input dataset. In
+# this case, you can choose to build glyphs for a subset of the input dataset
+# by using a percentage of the points. Using this percentage, a uniform
+# distribuiton is used to select points from the input dataset and use them for
+# glyphing.
+
+# Example dataset with normals
+mesh = examples.load_random_hills()
+
+# create a subset of arrows using the glyph filter
+arrows = mesh.glyph(scale='Normals', orient='Normals', subset=0.05)
+
+p = pv.Plotter()
+p.add_mesh(arrows, color='black')
+p.add_mesh(mesh)
+p.show()

--- a/pyvista/examples/examples.py
+++ b/pyvista/examples/examples.py
@@ -244,3 +244,11 @@ def load_spline():
     y = r * np.cos(theta)
     points = np.column_stack((x, y, z))
     return pyvista.Spline(points, 1000)
+
+
+def load_random_hills():
+    """Uses the parametric random hill function to create hills oriented like
+    topography and add's an elevation array"""
+    mesh = pyvista.ParametricRandomHills()
+    mesh.rotate_y(90)
+    return mesh.elevation()

--- a/pyvista/filters.py
+++ b/pyvista/filters.py
@@ -758,7 +758,8 @@ class DataSetFilters(object):
         return output
 
 
-    def glyph(dataset, orient=True, scale=True, factor=1.0, geom=None):
+    def glyph(dataset, orient=True, scale=True, factor=1.0, geom=None,
+              subset=None):
         """
         Copies a geometric representation (called a glyph) to every
         point in the input dataset.  The glyph may be oriented along
@@ -778,7 +779,20 @@ class DataSetFilters(object):
 
         geom : vtk.vtkDataSet
             The geometry to use for the glyph
+
+        subset : float, optional
+            Take a percentage subset of the mesh's points. Float value is
+            percent subset between 0 and 1.
         """
+        if subset is not None:
+            if subset <= 0.0 or subset > 1.0:
+                raise RuntimeError('subset must be a percentage between 0 and 1.')
+            ids = np.random.random_integers(low=0, high=dataset.n_points-1,
+                                    size=int(dataset.n_points * subset))
+            small = pyvista.PolyData(dataset.points[ids])
+            for name in dataset.point_arrays.keys():
+                small.point_arrays[name] = dataset.point_arrays[name][ids]
+            dataset = small
         if geom is None:
             arrow = vtk.vtkArrowSource()
             arrow.Update()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -356,8 +356,7 @@ def test_arrows():
                          np.cos(sphere.points[:, 1]),
                          np.cos(sphere.points[:, 2]))).T
 
-    # add and scale
-    assert sphere.active_vectors is None
+    # add and scales
     sphere.vectors = vectors*0.3
     assert np.allclose(sphere.active_vectors, vectors*0.3)
     assert np.allclose(sphere.vectors, vectors*0.3)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -250,6 +250,7 @@ def test_glyph():
     sphere.point_arrays['arr'] = np.ones(sphere.n_points)
     result = sphere.glyph(scale='arr')
     result = sphere.glyph(scale='arr', orient='Normals', factor=0.1)
+    result = sphere.glyph(scale='arr', orient='Normals', factor=0.1, subset=0.5)
 
 
 def test_split_and_connectivity():


### PR DESCRIPTION
Some updates to the `glyph` filter and to the `arrows` property.

The `arrows` property now leverages the `glyph` filter - @akaszynski: you originally added this `arrows` property; could you make sure that it is now leveraging the `glyph` filter the way you intended?

This also adds an option to take a uniformly random subset of a dataset when glyphing incase you don't want glyphs for every node in the dataset. Quite often I glyph a dataset and have results that are difficult to interpret because there are way too many glyphs. For example:

```py
import pyvista as pv
from pyvista import examples

mesh = examples.load_random_hills()

arrows = mesh.glyph(scale='Elevation', orient='Normals', factor=0.25)

p = pv.Plotter()
p.add_mesh(arrows, color='black')
p.add_mesh(mesh, scalars='Elevation', cmap='terrain')
p.show()
```

![download](https://user-images.githubusercontent.com/22067021/59898007-61718b80-93ac-11e9-9915-8b1b3d8ba828.png)


The above plot is hard to decipher because there are too many glyphs. With these changes, we can take a uniform subset of the mesh's points.

*note this is a uniform sampling of the points array, not a uniform distribution in space - is this an issue for anyone?* @fourndo - you come to mind, do you have any suggestions on a better way to make a subset of the mesh for glyphing/drawing vectors?

```py
arrows = mesh.glyph(scale='Elevation', orient='Normals', factor=0.25, subset=0.05)

p = pv.Plotter()
p.add_mesh(arrows, color='black')
p.add_mesh(mesh, scalars='Elevation', cmap='terrain')
p.show()
```

![download](https://user-images.githubusercontent.com/22067021/59898010-646c7c00-93ac-11e9-809f-c79a67d202e3.png)
