### PR TITLE
Change default colormap to viridis and add Colorcet and cmocean support

### DIFF
--- a/examples/02-plot/plot-cmap.py
+++ b/examples/02-plot/plot-cmap.py
@@ -6,16 +6,20 @@ Use a custom built colormap when plotting scalar values.
 """
 
 from pyvista import examples
+import pyvista as pv
 import matplotlib.pyplot as plt
 
 ################################################################################
-# Any colormap built for ``matplotlib`` is fully compatible with PyVista.
-# Colormaps are typically specifiedby passing the string name of the
-# ``matplotlib`` colormap to the plotting routine via the ``cmap`` argument.
+# Any colormap built for ``matplotlib`` or ``colorcet`` is fully compatible
+# with PyVista. Colormaps are typically specified by passing the string name of
+# the ``matplotlib`` or ``colorcet`` colormap to the plotting routine via the
+# ``cmap`` argument.
 #
-# See `this page`_ for a complete list of available colormaps.
+# See `Matplotlib's complete list of available colormaps`_ and
+# `Colorcet's complete list`_.
 #
-# .. _this page: https://matplotlib.org/tutorials/colors/colormaps.html
+# .. _Matplotlib's complete list of available colormaps: https://matplotlib.org/tutorials/colors/colormaps.html
+# .. _Colorcet's complete list: http://colorcet.pyviz.org/user_guide/index.html
 #
 # To get started using a custom colormap, download some data with scalars to
 # plot.
@@ -31,3 +35,31 @@ cmap = plt.cm.get_cmap('viridis', 5)
 ################################################################################
 # Simply pass the colormap to the plotting routine!
 mesh.plot(cmap=cmap, cpos='xy')
+
+
+################################################################################
+# Matplotlib vs. Colorcet
+# +++++++++++++++++++++++
+#
+# Let's compare Colorcet's perceptually uniform "fire" colormap to Matplotlib's
+# "hot" colormap much like the example on the `first page of Colorcet's docs`_.
+#
+# .. _first page of Colorcet's docs: http://colorcet.pyviz.org/index.html
+#
+# The "hot" version washes out detail at the high end, as if the image is
+# overexposed, while "fire" makes detail visible throughout the data range.
+
+p = pv.Plotter(shape=(2,2), border=False)
+p.subplot(0,0)
+p.add_mesh(mesh, cmap='fire', lighting=True, stitle='Colorcet Fire')
+
+p.subplot(0,1)
+p.add_mesh(mesh, cmap='fire', lighting=False, stitle='Colorcet Fire (No Lighting)')
+
+p.subplot(1,0)
+p.add_mesh(mesh, cmap='hot', lighting=True, stitle='Matplotlib Hot')
+
+p.subplot(1,1)
+p.add_mesh(mesh, cmap='hot', lighting=False, stitle='Matplotlib Hot (No Lighting)')
+
+p.show()

--- a/pyvista/colors.py
+++ b/pyvista/colors.py
@@ -362,3 +362,30 @@ def string_to_rgb(string):
             raise ValueError('Invalid color string or hex string.')
 
     return hex_to_rgb(colorhex)
+
+
+def safe_get_cmap(cmap):
+    """Fetches a colormap by name from matplotlib, colorcet, or cmocean"""
+    try:
+        from matplotlib.cm import get_cmap
+    except ImportError:
+        raise Exception('cmap requires matplotlib')
+    if isinstance(cmap, str):
+        # Try colorcet first
+        try:
+            import colorcet
+            cmap = colorcet.cm[cmap]
+        except (ImportError, KeyError):
+            pass
+        else:
+            return cmap
+        # Try cmocean second
+        try:
+            import cmocean
+            cmap = getattr(cmocean.cm, cmap)
+        except (ImportError, AttributeError):
+            pass
+        else:
+            return cmap
+        cmap = get_cmap(cmap)
+    return cmap

--- a/pyvista/colors.py
+++ b/pyvista/colors.py
@@ -387,5 +387,6 @@ def safe_get_cmap(cmap):
             pass
         else:
             return cmap
+        # Else use Matplotlib
         cmap = get_cmap(cmap)
     return cmap

--- a/pyvista/colors.py
+++ b/pyvista/colors.py
@@ -364,7 +364,7 @@ def string_to_rgb(string):
     return hex_to_rgb(colorhex)
 
 
-def safe_get_cmap(cmap):
+def get_cmap_safe(cmap):
     """Fetches a colormap by name from matplotlib, colorcet, or cmocean"""
     try:
         from matplotlib.cm import get_cmap

--- a/pyvista/plotting.py
+++ b/pyvista/plotting.py
@@ -750,9 +750,8 @@ class BasePlotter(object):
             values as RGB+A colors! ``rgba`` is also accepted alias for this.
 
         categories : bool, optional
-            If fetching a colormap from matplotlib, this is the number of
-            categories to use in that colormap. If set to ``True``, then
-            the number of unique values in the scalar array will be used.
+            If set to ``True``, then the number of unique values in the scalar
+            array will be used as the ``n_colors`` argument.
 
         Returns
         -------
@@ -1021,12 +1020,18 @@ class BasePlotter(object):
                 except ImportError:
                     raise Exception('cmap requires matplotlib')
                 if isinstance(cmap, str):
+                    try:
+                        import colorcet
+                        cmap = colorcet.cm[cmap]
+                    except (ImportError, KeyError):
+                        colorcet = None
+                        pass
                     if categories:
                         if categories is True:
-                            categories = len(np.unique(scalars))
-                        cmap = get_cmap(cmap, categories)
-                    else:
-                        cmap = get_cmap(cmap)
+                            n_colors = len(np.unique(scalars))
+                        elif isinstance(categories, int):
+                            n_colors = categories
+                    cmap = get_cmap(cmap)
                     # ELSE: assume cmap is callable
                 ctable = cmap(np.linspace(0, 1, n_colors))*255
                 ctable = ctable.astype(np.uint8)

--- a/pyvista/plotting.py
+++ b/pyvista/plotting.py
@@ -1022,7 +1022,7 @@ class BasePlotter(object):
                 if isinstance(cmap, str):
                     try:
                         import colorcet
-                        cmap = colorcet.cm[cmap]
+                        cmap = colorcet.cm.get(cmap)
                     except (ImportError, KeyError):
                         colorcet = None
                         pass

--- a/pyvista/plotting.py
+++ b/pyvista/plotting.py
@@ -18,6 +18,7 @@ import pyvista
 from pyvista.export import export_plotter_vtkjs
 from pyvista.utilities import (get_scalar, is_pyvista_obj, numpy_to_texture, wrap,
                             _raise_not_matching, convert_array)
+from pyvista.colors import safe_get_cmap
 
 _ALL_PLOTTERS = {}
 
@@ -1015,24 +1016,12 @@ class BasePlotter(object):
                     cmap = None
                     logging.warning('Please install matplotlib for color maps.')
             if cmap is not None:
-                try:
-                    from matplotlib.cm import get_cmap
-                except ImportError:
-                    raise Exception('cmap requires matplotlib')
-                if isinstance(cmap, str):
-                    try:
-                        import colorcet
-                        cmap = colorcet.cm.get(cmap)
-                    except (ImportError, KeyError):
-                        colorcet = None
-                        pass
-                    if categories:
-                        if categories is True:
-                            n_colors = len(np.unique(scalars))
-                        elif isinstance(categories, int):
-                            n_colors = categories
-                    cmap = get_cmap(cmap)
-                    # ELSE: assume cmap is callable
+                cmap = safe_get_cmap(cmap)
+                if categories:
+                    if categories is True:
+                        n_colors = len(np.unique(scalars))
+                    elif isinstance(categories, int):
+                        n_colors = categories
                 ctable = cmap(np.linspace(0, 1, n_colors))*255
                 ctable = ctable.astype(np.uint8)
                 # Set opactities

--- a/pyvista/plotting.py
+++ b/pyvista/plotting.py
@@ -18,7 +18,7 @@ import pyvista
 from pyvista.export import export_plotter_vtkjs
 from pyvista.utilities import (get_scalar, is_pyvista_obj, numpy_to_texture, wrap,
                             _raise_not_matching, convert_array)
-from pyvista.colors import safe_get_cmap
+from pyvista.colors import get_cmap_safe
 
 _ALL_PLOTTERS = {}
 
@@ -1016,7 +1016,7 @@ class BasePlotter(object):
                     cmap = None
                     logging.warning('Please install matplotlib for color maps.')
             if cmap is not None:
-                cmap = safe_get_cmap(cmap)
+                cmap = get_cmap_safe(cmap)
                 if categories:
                     if categories is True:
                         n_colors = len(np.unique(scalars))

--- a/pyvista/plotting.py
+++ b/pyvista/plotting.py
@@ -54,7 +54,7 @@ rcParams = {
         'color' : [1, 1, 1],
         'fmt' : None,
     },
-    'cmap' : 'jet',
+    'cmap' : 'viridis',
     'color' : 'white',
     'nan_color' : 'darkgray',
     'edge_color' : 'black',

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ nbval
 ipywidgets
 imageio>=2.5.0
 imageio-ffmpeg
+colorcet

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ ipywidgets
 imageio>=2.5.0
 imageio-ffmpeg
 colorcet
+cmocean

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,6 @@ setup(
     install_requires=install_requires,
     extras_require={
         'ipy_tools': ['ipython', 'ipywidgets'],
-        'colormaps': ['matplotlib', 'colorcet']
+        'colormaps': ['matplotlib', 'colorcet', 'cmocean']
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -68,5 +68,6 @@ setup(
     install_requires=install_requires,
     extras_require={
         'ipy_tools': ['ipython', 'ipywidgets'],
+        'colormaps': ['matplotlib', 'colorcet']
     },
 )


### PR DESCRIPTION
I propose we change the default colormap to use Matplotlib's *viridis* when MPL is installed (if MPL is not installed, defaults back to jet/rainbow).

I'm curious if we could change the default colormap when MPL is unavailable to something like ParaView's "cool to warm" instead of jet - thoughts, @akaszynski?

Why should we use *viridis*? Besides it being MPL's default colormap, it's also perceptually uniform and ideal for scientific visualization.

Here are some nice articles/blogs/code on choosing colormaps for scientific visualization:

1. https://blogs.egu.eu/divisions/gd/2017/08/23/the-rainbow-colour-map/
2. https://www.kennethmoreland.com/color-advice/
3. http://www.cet.edu.au/research-projects/geophysics-integrated-data-analysis/projects/colour-maps-with-uniform-perceptual-contrast
4. https://github.com/ahartikainen/Perceptual-cmaps/blob/master/Divergent_monotonic_cmap.ipynb

On this topic of perceptually linear colormaps, maybe we should try to add support for [pyviz/colorcet](https://github.com/pyviz/colorcet) to get some more colormaps?

Relevant to #122