### PR TITLE
PolyData project_points_to_plane

### DIFF
--- a/examples/01-filter/project-plane.py
+++ b/examples/01-filter/project-plane.py
@@ -1,0 +1,34 @@
+"""
+Project to a Plane
+~~~~~~~~~~~~~~~~~~
+
+:class:`pyvista.PolyData` surfaces and pointsets can easily be projected to a
+plane defined by a normal and origin
+"""
+
+# sphinx_gallery_thumbnail_number = 2
+import numpy as np
+import pyvista as pv
+from pyvista import examples
+
+
+def make_example_data():
+    surface = examples.download_saddle_surface()
+    points = examples.download_sparse_points()
+    poly = surface.interpolate(points, radius=12.0)
+    return poly
+
+poly = make_example_data()
+poly.plot()
+
+################################################################################
+# Project that surface to a plane underneath the surface
+origin = poly.center
+origin[-1] -= poly.length / 3.
+projected = poly.project_points_to_plane(origin=origin)
+
+# Display the results
+p = pv.Plotter()
+p.add_mesh(poly,)
+p.add_mesh(projected, )
+p.show()

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -29,8 +29,9 @@ import numpy as np
 import vtk
 
 import pyvista
-from pyvista.utilities import (CELL_DATA_FIELD, POINT_DATA_FIELD, get_scalar,
-                               is_inside_bounds, wrap)
+from pyvista.utilities import (CELL_DATA_FIELD, POINT_DATA_FIELD,
+                               generate_plane, get_scalar, is_inside_bounds,
+                               wrap)
 
 NORMALS = {
     'x': [1, 0, 0],
@@ -52,14 +53,6 @@ def _get_output(algorithm, iport=0, iconnection=0, oport=0, active_scalar=None,
         if active_scalar is not None:
             data.set_active_scalar(active_scalar, preference=active_scalar_field)
     return data
-
-
-def _generate_plane(normal, origin):
-    """ Returns a vtk.vtkPlane """
-    plane = vtk.vtkPlane()
-    plane.SetNormal(normal[0], normal[1], normal[2])
-    plane.SetOrigin(origin[0], origin[1], origin[2])
-    return plane
 
 
 
@@ -98,7 +91,7 @@ class DataSetFilters(object):
         if origin is None:
             origin = dataset.center
         # create the plane for clipping
-        plane = _generate_plane(normal, origin)
+        plane = generate_plane(normal, origin)
         # run the clip
         if isinstance(dataset, vtk.vtkPolyData):
             alg = vtk.vtkClipPolyData()
@@ -188,7 +181,7 @@ class DataSetFilters(object):
         if origin is None:
             origin = dataset.center
         # create the plane for clipping
-        plane = _generate_plane(normal, origin)
+        plane = generate_plane(normal, origin)
         # create slice
         alg = vtk.vtkCutter() # Construct the cutter object
         alg.SetInputDataObject(dataset) # Use the grid as the data we desire to cut

--- a/pyvista/utilities/utilities.py
+++ b/pyvista/utilities/utilities.py
@@ -445,3 +445,13 @@ def raise_not_matching(scalars, mesh):
                     '({}) '.format(mesh.n_points) +
                     'or the number of cells ' +
                     '({}). '.format(mesh.n_cells) )
+
+
+def generate_plane(normal, origin):
+    """ Returns a vtk.vtkPlane """
+    plane = vtk.vtkPlane()
+    # NORMAL MUST HAVE MAGNITUDE OF 1
+    normal = normal / np.linalg.norm(normal)
+    plane.SetNormal(normal)
+    plane.SetOrigin(origin)
+    return plane

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -457,3 +457,20 @@ def test_center_of_mass():
     cloud['weights'] = np.random.rand(cloud.n_points)
     center = cloud.center_of_mass(True)
     assert len(center) == 3
+
+
+def test_project_points_to_plane():
+    # Define a simple Gaussian surface
+    n = 20
+    x = np.linspace(-200,200, num=n) + np.random.uniform(-5, 5, size=n)
+    y = np.linspace(-200,200, num=n) + np.random.uniform(-5, 5, size=n)
+    xx, yy = np.meshgrid(x, y)
+    A, b = 100, 100
+    zz = A*np.exp(-0.5*((xx/b)**2. + (yy/b)**2.))
+    poly = pyvista.StructuredGrid(xx, yy, zz).extract_geometry()
+    poly['elev'] = zz.ravel(order='f')
+    # Test the filter
+    projected = poly.project_points_to_plane(origin=poly.center, normal=(0,0,1))
+    assert np.allclose(projected.points[:,-1], poly.center[-1])
+    projected = poly.project_points_to_plane(normal=(0,1,1))
+    assert projected.n_points


### PR DESCRIPTION
After #272 

Implement `project_points_to_plane` for https://github.com/pyvista/pyvista-support/issues/20


```py
import numpy as np
import pyvista as pv
from pyvista import examples
pv.rcParams['use_panel'] = False

def make_example_data():
    surface = examples.download_saddle_surface()
    points = examples.download_sparse_points()
    poly = surface.interpolate(points, radius=12.0)
    return poly

poly = make_example_data()

# Project that surface to a plane
og = poly.center
og[-1] -= poly.length / 3.
projected = poly.project_points_to_plane(origin=og, normal=[0,0,1])

# Plot it
p = pv.Plotter()
p.add_mesh(poly,)
p.add_mesh(projected, )
p.show()
```

![download](https://user-images.githubusercontent.com/22067021/60295715-a2542d80-98e1-11e9-9bcd-e04ec35c5bf7.png)
