### PR TITLE
Use scoobys .Report() convention

### DIFF
--- a/pyvista/utilities/__init__.py
+++ b/pyvista/utilities/__init__.py
@@ -1,4 +1,5 @@
-from .errors import Observer, send_errors_to_logging, set_error_output_file
+from .errors import (Observer, Report, send_errors_to_logging,
+                     set_error_output_file)
 from .features import *
 from .fileio import *
 from .geometric_objects import *

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import scooby
 
 import vtk
 
@@ -91,3 +92,35 @@ def send_errors_to_logging():
     error_win.SetInstance(error_output)
     obs = Observer()
     return obs.observe(error_output)
+
+
+class Report(scooby.Report):
+    def __init__(self, additional=None, ncol=3, text_width=80, sort=False):
+        """Generate a :class:`scooby.Report` instance.
+
+        Parameters
+        ----------
+        additional : list(ModuleType), list(str)
+            List of packages or package names to add to output information.
+
+        ncol : int, optional
+            Number of package-columns in html table; only has effect if
+            ``mode='HTML'`` or ``mode='html'``. Defaults to 3.
+
+        text_width : int, optional
+            The text width for non-HTML display modes
+
+        sort : bool, optional
+            Alphabetically sort the packages
+
+        """
+
+        # Mandatory packages.
+        core = ['pyvista', 'vtk', 'numpy', 'imageio', 'appdirs', 'scooby']
+
+        # Optional packages.
+        optional = ['matplotlib', 'PyQt5', 'IPython', 'ipywidgets', 'colorcet',
+                    'cmocean']
+
+        super().__init__(additional=additional, core=core, optional=optional,
+                         ncol=ncol, text_width=text_width, sort=sort)

--- a/pyvista/utilities/utilities.py
+++ b/pyvista/utilities/utilities.py
@@ -459,24 +459,8 @@ def generate_plane(normal, origin):
 
 
 def generate_report(additional=None, ncol=3, text_width=54, sort=False):
-    """Generate an environment report using :module:`scooby`
-
-    Parameters
-    ----------
-    additional : list(ModuleType), list(str)
-        List of packages or package names to add to output information.
-
-    ncol : int, optional
-        Number of package-columns in html table; only has effect if
-        ``mode='HTML'`` or ``mode='html'``. Defaults to 3.
-
-    text_width : int, optional
-        The text width for non-HTML display modes
-
-    sort : bool, optional
-        Alphabetically sort the packages
-
-    """
+    """DEPRECATED: Please use :class:`pyvista.Report` instead."""
+    logging.warning('DEPRECATED: Please use `pyvista.Report` instead.')
     core = ['pyvista', 'vtk', 'numpy', 'imageio', 'appdirs', 'scooby']
     optional = ['matplotlib', 'PyQt5', 'IPython', 'ipywidgets', 'colorcet',
                 'cmocean']


### PR DESCRIPTION
Scooby is setting a new convention for having projects that use it make their own class called `Report` which is a child of `scooby.Report`.

This makes reporting consistent across libraries and makes it easier for user to remember how to generate a report for different packages.