### PR TITLE
BackgroundPlotter closing event

### DIFF
--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -47,7 +47,7 @@ class QFileDialog(object):
 
 
 try:
-    from PyQt5.QtCore import pyqtSignal, QThread
+    from PyQt5.QtCore import pyqtSignal, pyqtSlot, QThread
     from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
     from PyQt5 import QtGui
     from PyQt5 import QtCore
@@ -364,7 +364,7 @@ class BackgroundPlotter(QtInteractor):
         file_menu.addAction('Take Screenshot', self._qt_screenshot)
         file_menu.addAction('Export as VTKjs', self._qt_export_vtkjs)
         file_menu.addSeparator()
-        file_menu.addAction('Exit', self.quit)
+        file_menu.addAction('Exit', self.close)
 
         view_menu = main_menu.addMenu('View')
         view_menu.addAction('Toggle Eye Dome Lighting', self._toggle_edl)
@@ -538,9 +538,10 @@ class BackgroundPlotter(QtInteractor):
     def __del__(self):  # pragma: no cover
         self.close()
 
-    def quit(self):
+    def close(self):
         self.app_window.close()
         self.iren.TerminateApp()
+        self.app.quit()
 
 class MainWindow(QMainWindow):
     closed = pyqtSignal()
@@ -563,6 +564,7 @@ class RenderThread(QThread):
     def __del__(self):
         self.wait()
 
+    @pyqtSlot()
     def disable(self):
         self.active = False
 

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -450,7 +450,7 @@ class BackgroundPlotter(QtInteractor):
         ensures the render window stays updated without consuming too
         many resources.
         """
-        twait = rate**-1
+        twait = (rate**-1) * 1000.0
         self.render_thread = RenderThread(self.ren_win, twait)
         self.app_window.closed.connect(self.render_thread.disable)
         self.render_thread.start()
@@ -570,5 +570,5 @@ class RenderThread(QThread):
 
     def run(self):
         while self.active:
-            self.sleep(self.twait)
+            self.msleep(self.twait)
             self.ren_win.Render()

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -454,6 +454,7 @@ class BackgroundPlotter(QtInteractor):
         twait = (rate**-1) * 1000.0
         self.render_timer = QTimer(parent=self.app_window)
         self.render_timer.timeout.connect(self._render)
+        self.app_window.signal_close.connect(self.render_timer.stop)
         self.render_timer.start(twait)
 
     def closeEvent(self, event):

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -452,9 +452,8 @@ class BackgroundPlotter(QtInteractor):
         many resources.
         """
         twait = (rate**-1) * 1000.0
-        self.render_timer = QTimer()
+        self.render_timer = QTimer(parent=self.app_window)
         self.render_timer.timeout.connect(self._render)
-        self.app_window.signal_close.connect(self.render_timer.stop)
         self.render_timer.start(twait)
 
     def closeEvent(self, event):
@@ -528,6 +527,7 @@ class BackgroundPlotter(QtInteractor):
     def _render(self):
         super(BackgroundPlotter, self)._render()
         self.update_app_icon()
+        self.ren_win.Render() # force rendering
         return
 
     @property

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -46,6 +46,15 @@ class QFileDialog(object):
     pass
 
 
+def pyqtSlot(*args, **kwargs):
+    """dummy function for environments without pyqt5"""
+    return lambda *x: None
+
+
+class QMainWindow(object):
+    pass
+
+
 try:
     from PyQt5.QtCore import pyqtSignal, pyqtSlot, QTimer
     from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -356,8 +356,6 @@ class BackgroundPlotter(QtInteractor):
         self.frame.setFrameStyle(QFrame.NoFrame)
 
         QtInteractor.__init__(self, parent=self.frame, shape=shape, **kwargs)
-        #self.signal_close.connect(self.app_window.close)
-        self.app_window.closed.connect(self.quit)
 
         # build main menu
         main_menu = self.app_window.menuBar()
@@ -543,7 +541,6 @@ class BackgroundPlotter(QtInteractor):
     def quit(self):
         self.app_window.close()
         self.iren.TerminateApp()
-        #self.close()
 
 class MainWindow(QMainWindow):
     closed = pyqtSignal()

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -568,5 +568,5 @@ class RenderThread(QThread):
 
     def run(self):
         while self.active:
-            self.sleep(1)
+            self.sleep(self.twait)
             self.ren_win.Render()


### PR DESCRIPTION
This PR resolves #279.

My hypothesis is that the rendering thread is not cleared properly.

Since `BackgroundPlotter` is not a child of `QWidget`, `closeEvent()` is never called. That's why I noticed a different behaviour when we close the window with the top-right 'X' or if we do `File > Exit`. The actual window is stored in `app_window` so I created a new `MainWindow` class derived from `QMainWindow` and added the `closed` signal. That allowed me to migrate the rendering thread to `QThread`. After that, I connected the window closing signal with the rendering thread to ensure that it's closed correctly. I don't think closing the `BackgroundPlotter` itself is necessary since I assume it's done by `app_window` but I'm not entirely sure.

What do you think @akaszynski, @banesullivan, @coloss?

*EDIT: correct the issue number*