### PR TITLE
Read long description using UTF-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
               'pyvista.plotting', 'pyvista.utilities'],
     version=__version__,
     description='Easier Pythonic interface to VTK',
-    long_description=open(readme_file).read(),
+    long_description=open(readme_file).read(encoding="utf-8"),
     author='PyVista Developers',
     author_email='info@pyvista.org',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
               'pyvista.plotting', 'pyvista.utilities'],
     version=__version__,
     description='Easier Pythonic interface to VTK',
-    long_description=open(readme_file).read(encoding="utf-8"),
+    long_description=open(readme_file, encoding="utf-8").read(),
     author='PyVista Developers',
     author_email='info@pyvista.org',
     license='MIT',


### PR DESCRIPTION
Reading long description fails on CentOS 7.6 Python3.6