### PR TITLE
Opacity by scalar array or custom transfer function

### DIFF
--- a/examples/02-plot/opacity.py
+++ b/examples/02-plot/opacity.py
@@ -2,18 +2,45 @@
 Plot with Opacity
 ~~~~~~~~~~~~~~~~~
 
-Plot a mesh's scalar array with an opacity trasfer funciton
+Plot a mesh's scalar array with an opacity trasfer funciton or opacity mapping
+based on a scalar array.
 """
 
 import pyvista as pv
 from pyvista import examples
 
+# Load St Helens DEM and warp the topography
+image = examples.download_st_helens()
+mesh = image.warp_by_scalar()
+
+
 ###############################################################################
-# It's possible to apply an opacity mapping to any scalar array plotted. You can
-# specify either a single static value to make the mesh opaque on all cells, or
-# use a transfer function where the scalar array plotted is mapped to the opacity.
+# Global Value
+# ++++++++++++
 #
-# Opacity transfer function options are:
+# You can also apply a global opacity value to the mesh by passing a single
+# float between 0 and 1 which would enable you to see objects behind the mesh:
+
+p = pv.Plotter()
+p.add_mesh(image.contour(), line_width=5,)
+p.add_mesh(mesh, opacity=0.4, color=True)
+p.show()
+
+###############################################################################
+# Note that you can specify ``use_transparency=True`` to convert opacities to
+# transperencies in any of the following examples.
+
+
+###############################################################################
+# Transfer Functions
+# ++++++++++++++++++
+#
+# It's possible to apply an opacity mapping to any scalar array plotted. You
+# can specify either a single static value to make the mesh transparent on all
+# cells, or use a transfer function where the scalar array plotted is mapped
+# to the opacity. We have several predefined transfer functions.
+#
+# Opacity transfer functions are:
 #
 # - ``'linear'``: linearly vary (increase) opacity across the plotted scalar range from low to high
 # - ``'linear_r'``: linearly vary (increase) opacity across the plotted scalar range from high to low
@@ -22,11 +49,26 @@ from pyvista import examples
 # - ``'sigmoid'``: vary (increase) opacity on a sigmoidal s-curve across the plotted scalar range from low to high
 # - ``'sigmoid_r'``: vary (increase) opacity on a sigmoidal s-curve across the plotted scalar range from high to low
 
-# Load St Helens DEM and warp the topography
-mesh = examples.download_st_helens().warp_by_scalar()
-
+# Show the linear opacity transfer function
 mesh.plot(opacity="linear")
 
+###############################################################################
+
+# Show the sigmoid opacity transfer function
+mesh.plot(opacity="sigmoid")
+
+###############################################################################
+# It's also possible to use your own transfer function that will be linearly
+# mapped to the scalar array plotted. For example, we can create an opacity
+# mapping as:
+opacity = [0, 0.2, 0.9, 0.2, 0.1]
+
+###############################################################################
+# That opacity mapping will have an opacity of 0.0 at the minimum scalar range,
+# a value or 0.9 at the middle of the scalar range, and a value of 0.1 at the
+# maximum of the scalar range:
+
+mesh.plot(opacity=opacity)
 
 ###############################################################################
 # Opacity mapping is often useful when plotting DICOM images. For example,
@@ -52,4 +94,39 @@ p.subplot(1, 1)
 p.add_mesh(knee, cmap="bone", opacity="geom_r", stitle="Log Scale Opacity")
 p.view_xy()
 
+p.show()
+
+###############################################################################
+# Opacity by Array
+# ++++++++++++++++
+#
+# You can also use a scalar array associated with the mesh to give each cell
+# its own opacity/transperency value derived from a scalar field. For exmple,
+# an uncertainty array from a modelling result could be used to hide regions of
+# a mesh that are uncertain and highlight regions that are well resolved.
+#
+# The following is a demonstartion of plotting a mesh with colored values and
+# using a second array to control the transperancy of the mesh
+
+model = examples.download_model_with_variance()
+contours = model.contour(10, scalars='Temperature')
+print(contours.scalar_names)
+
+###############################################################################
+# Make sure to flag ``use_transparency=True`` since we want areas of high
+# variance to have high transperency.
+
+p = pv.Plotter(shape=(1,2))
+
+p.subplot(0,0)
+p.add_text('Opacity by Array')
+p.add_mesh(contours.copy(), scalars='Temperature',
+           opacity='Temperature_var',
+           use_transparency=True,
+           cmap='bwr')
+
+p.subplot(0,1)
+p.add_text('No Opacity')
+p.add_mesh(contours, scalars='Temperature',
+           cmap='bwr')
 p.show()

--- a/examples/02-plot/opacity.py
+++ b/examples/02-plot/opacity.py
@@ -61,7 +61,7 @@ mesh.plot(opacity="sigmoid")
 # It's also possible to use your own transfer function that will be linearly
 # mapped to the scalar array plotted. For example, we can create an opacity
 # mapping as:
-opacity = [0, 0.2, 0.9, 0.2, 0.1]
+opacity = [0, 0.2, 0.9, 0.6, 0.3]
 
 ###############################################################################
 # When given a minimalized opacity mapping like that above, PyVista interplates
@@ -71,7 +71,7 @@ opacity = [0, 0.2, 0.9, 0.2, 0.1]
 # Curious what that opacity transfer function looks like? You can fetch it:
 
 # Have PyVista interpolate the transfer function
-tf = pv.opacity_transfer_function(opacity, 256)
+tf = pv.opacity_transfer_function(opacity, 256).astype(float) / 255.
 
 import matplotlib.pyplot as plt
 plt.plot(tf)
@@ -82,7 +82,7 @@ plt.show()
 
 ###############################################################################
 # That opacity mapping will have an opacity of 0.0 at the minimum scalar range,
-# a value or 0.9 at the middle of the scalar range, and a value of 0.1 at the
+# a value or 0.9 at the middle of the scalar range, and a value of 0.3 at the
 # maximum of the scalar range:
 
 mesh.plot(opacity=opacity)

--- a/examples/02-plot/opacity.py
+++ b/examples/02-plot/opacity.py
@@ -5,7 +5,7 @@ Plot with Opacity
 Plot a mesh's scalar array with an opacity trasfer funciton or opacity mapping
 based on a scalar array.
 """
-
+# sphinx_gallery_thumbnail_number = 2
 import pyvista as pv
 from pyvista import examples
 
@@ -23,7 +23,7 @@ mesh = image.warp_by_scalar()
 
 p = pv.Plotter()
 p.add_mesh(image.contour(), line_width=5,)
-p.add_mesh(mesh, opacity=0.4, color=True)
+p.add_mesh(mesh, opacity=0.85, color=True)
 p.show()
 
 ###############################################################################
@@ -62,6 +62,23 @@ mesh.plot(opacity="sigmoid")
 # mapped to the scalar array plotted. For example, we can create an opacity
 # mapping as:
 opacity = [0, 0.2, 0.9, 0.2, 0.1]
+
+###############################################################################
+# When given a minimalized opacity mapping like that above, PyVista interplates
+# it across a range of how many colors are shown when mapping the scalars.
+# If ``scipy`` is avaialble, then a quadratic interpolation is used -
+# otherwise, a simple linear interpolation is used.
+# Curious what that opacity transfer function looks like? You can fetch it:
+
+# Have PyVista interpolate the transfer function
+tf = pv.opacity_transfer_function(opacity, 256)
+
+import matplotlib.pyplot as plt
+plt.plot(tf)
+plt.title('My Interpolated Opacity Transfer Function')
+plt.ylabel('Opacity')
+plt.xlabel('Index along scalar mapping')
+plt.show()
 
 ###############################################################################
 # That opacity mapping will have an opacity of 0.0 at the minimum scalar range,

--- a/examples/02-plot/volume.py
+++ b/examples/02-plot/volume.py
@@ -6,7 +6,7 @@ Volume render uniform mesh types like :class:`pyvista.UniformGrid` or 3D
 NumPy arrays
 """
 
-# sphinx_gallery_thumbnail_number = 2
+# sphinx_gallery_thumbnail_number = 3
 import pyvista as pv
 from pyvista import examples
 
@@ -37,6 +37,15 @@ vol.plot(volume=True, cmap="bone", cpos=cpos)
 
 p = pv.Plotter()
 p.add_volume(vol, cmap="bone", opacity="sigmoid")
+p.camera_position = cpos
+p.show()
+
+###############################################################################
+# You can also use a custom opactiy mapping
+opacity = [0, 0, 0, 0.1, 0.3, 0.6, 1]
+
+p = pv.Plotter()
+p.add_volume(vol, cmap="viridis", opacity=opacity)
 p.camera_position = cpos
 p.show()
 

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -47,6 +47,8 @@ class Common(DataSetFilters, object):
         """Return the active scalar's field and name: [field, name]"""
         if not hasattr(self, '_active_scalar_info'):
             self._active_scalar_info = [POINT_DATA_FIELD, None] # field and name
+        if not hasattr(self, '_last_active_scalar_name'):
+            self._last_active_scalar_name = None
         field, name = self._active_scalar_info
 
         # rare error where scalar name isn't a valid scalar
@@ -58,18 +60,33 @@ class Common(DataSetFilters, object):
                 else:
                     name = None
 
+        exclude = ['__custom_rgba', ]
+
+        def search_for_array(data):
+            arr = None
+            for i in range(data.GetNumberOfArrays()):
+                name = data.GetArrayName(i)
+                if name not in exclude:
+                    arr = name
+                    break
+            return arr
+
+        if name in exclude:
+            name = self._last_active_scalar_name
+
         if name is None:
             if self.n_arrays < 1:
                 return field, name
             # find some array in the set field
-            parr = self.GetPointData().GetArrayName(0)
-            carr = self.GetCellData().GetArrayName(0)
+            parr = search_for_array(self.GetPointData())
+            carr = search_for_array(self.GetCellData())
             if parr is not None:
                 self._active_scalar_info = [POINT_DATA_FIELD, parr]
                 self.GetPointData().SetActiveScalars(parr)
             elif carr is not None:
                 self._active_scalar_info = [CELL_DATA_FIELD, carr]
                 self.GetCellData().SetActiveScalars(carr)
+
         return self._active_scalar_info
 
     @property
@@ -262,6 +279,7 @@ class Common(DataSetFilters, object):
     def set_active_scalar(self, name, preference='cell'):
         """Finds the scalar by name and appropriately sets it as active"""
         _, field = get_scalar(self, name, preference=preference, info=True)
+        self._last_active_scalar_name = self._active_scalar_info[1]
         if field == POINT_DATA_FIELD:
             self.GetPointData().SetActiveScalars(name)
         elif field == CELL_DATA_FIELD:

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -279,7 +279,7 @@ class Common(DataSetFilters, object):
     def set_active_scalar(self, name, preference='cell'):
         """Finds the scalar by name and appropriately sets it as active"""
         _, field = get_scalar(self, name, preference=preference, info=True)
-        self._last_active_scalar_name = self._active_scalar_info[1]
+        self._last_active_scalar_name = self.active_scalar_info[1]
         if field == POINT_DATA_FIELD:
             self.GetPointData().SetActiveScalars(name)
         elif field == CELL_DATA_FIELD:

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -376,3 +376,7 @@ def download_tetra_dc_mesh():
     inv = pyvista.read(filename)
     inv.set_active_scalar('Resistivity(log10)')
     return pyvista.MultiBlock({'forward':fwd, 'inverse':inv})
+
+
+def download_model_with_variance():
+    return _download_and_read("model_with_variance.vtu")

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -642,11 +642,11 @@ class BasePlotter(object):
             # If no texture, plot any active scalar
             else:
                 # Make sure scalar components are not vectors/tuples
-                scalars = mesh.active_scalar
+                scalars = mesh.active_scalar_name
                 # Don't allow plotting of string arrays by default
-                if scalars is not None and np.issubdtype(scalars.dtype, np.number):
+                if scalars is not None and np.issubdtype(mesh.active_scalar.dtype, np.number):
                     if stitle is None:
-                        stitle = mesh.active_scalar_info[1]
+                        stitle = scalars
                 else:
                     scalars = None
 
@@ -663,13 +663,14 @@ class BasePlotter(object):
                                      name=name, loc=loc, culling=backface_culling)
 
         # Make sure scalars is a numpy array after this point
+        original_scalar_name = None
         if isinstance(scalars, str):
             self.mapper.SetArrayName(scalars)
-            title = scalars
+            original_scalar_name = scalars
             scalars = get_scalar(mesh, scalars,
                     preference=kwargs.get('preference', 'cell'), err=True)
             if stitle is None:
-                stitle = title
+                stitle = original_scalar_name
 
 
         if texture == True or isinstance(texture, (str, int)):

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -680,12 +680,14 @@ class BasePlotter(object):
             self.mapper.SetScalarModeToUsePointFieldData()
 
         # Handle making opacity array =========================================
+        normalize = lambda x: (x - np.nanmin(x)) / (np.nanmax(x) - np.nanmin(x))
         _custom_opac = False
         if isinstance(opacity, str):
             try:
                 # Get array from mesh
                 opacity = get_scalar(mesh, opacity,
                         preference=kwargs.get('preference', 'cell'), err=True)
+                opacity = normalize(opacity)
                 _custom_opac = True
             except:
                 # Or get opacity trasfer function
@@ -694,7 +696,6 @@ class BasePlotter(object):
             raise NotImplemented
 
         # Scalar formatting ===================================================
-        normalize = lambda x: (x - np.nanmin(x)) / (np.nanmax(x) - np.nanmin(x))
         if cmap is None: # grab alias for cmaps: colormap
             cmap = kwargs.get('colormap', None)
         if cmap is None: # Set default map if matplotlib is avaialble
@@ -746,8 +747,6 @@ class BasePlotter(object):
 
             if np.any(rng) and not rgb:
                 self.mapper.scalar_range = rng[0], rng[1]
-            elif rgb or _custom_opac:
-                self.mapper.SetColorModeToDirectScalars()
 
             table = self.mapper.GetLookupTable()
             table.SetNanColor(nan_color)
@@ -793,6 +792,8 @@ class BasePlotter(object):
                 self.mapper.SetScalarModeToUseCellData()
             else:
                 raise_not_matching(scalars, mesh)
+            if rgb or _custom_opac:
+                self.mapper.SetColorModeToDirectScalars()
 
         else:
             self.mapper.SetScalarModeToUseFieldData()

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1163,7 +1163,6 @@ class BasePlotter(object):
         elif isinstance(opacity, (np.ndarray, list, tuple)):
             opacity = np.array(opacity)
             opacity_values = opacity_transfer_function(opacity, n_colors)
-            self.opacity_values = opacity_values
 
         opacity_tf = vtk.vtkPiecewiseFunction()
         for ii in range(n_colors):

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -695,13 +695,11 @@ class BasePlotter(object):
             except:
                 # Or get opacity trasfer function
                 opacity = opacity_transfer_function(opacity, n_colors)
-            if flip_opacity:
-                opacity = opacity[::-1]
         elif isinstance(opacity, np.ndarray):
             raise NotImplemented
-        elif isinstance(opacity, (float)):
-            if flip_opacity:
-                opacity = 1 - opacity
+
+        if flip_opacity:
+            opacity = 1 - opacity
 
         # Scalar formatting ===================================================
         if cmap is None: # grab alias for cmaps: colormap

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -360,7 +360,7 @@ class BasePlotter(object):
                  render_lines_as_tubes=False, edge_color=None,
                  ambient=0.0, show_scalar_bar=None, nan_color=None,
                  nan_opacity=1.0, loc=None, backface_culling=False,
-                 rgb=False, categories=False, flip_opacity=False, **kwargs):
+                 rgb=False, categories=False, use_transparency=False, **kwargs):
         """
         Adds a unstructured, structured, or surface mesh to the
         plotting object.
@@ -490,8 +490,9 @@ class BasePlotter(object):
             If set to ``True``, then the number of unique values in the scalar
             array will be used as the ``n_colors`` argument.
 
-        flip_opacity : bool, optional
-            Invert the opacity mapping.
+        use_transparency : bool, optional
+            Invert the opacity mapping and make the values correspond to
+            transperency.
 
         Returns
         -------
@@ -730,8 +731,10 @@ class BasePlotter(object):
             else:
                 raise RuntimeError('Opacity transfer function cannot have more values than `n_colors`.')
 
-        if flip_opacity:
+        if use_transparency and np.max(opacity) <=1.0:
             opacity = 1 - opacity
+        elif use_transparency and isinstance(opacity, np.ndarray):
+            opacity = 255 - opacity
 
         # Scalar formatting ===================================================
         if cmap is None: # grab alias for cmaps: colormap

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -356,7 +356,7 @@ class BasePlotter(object):
                  render_lines_as_tubes=False, edge_color=None,
                  ambient=0.0, show_scalar_bar=None, nan_color=None,
                  nan_opacity=1.0, loc=None, backface_culling=False,
-                 rgb=False, categories=False, **kwargs):
+                 rgb=False, categories=False, flip_opacity=False, **kwargs):
         """
         Adds a unstructured, structured, or surface mesh to the
         plotting object.
@@ -481,6 +481,9 @@ class BasePlotter(object):
         categories : bool, optional
             If set to ``True``, then the number of unique values in the scalar
             array will be used as the ``n_colors`` argument.
+
+        flip_opacity : bool, optional
+            Invert the opacity mapping.
 
         Returns
         -------
@@ -692,8 +695,13 @@ class BasePlotter(object):
             except:
                 # Or get opacity trasfer function
                 opacity = opacity_transfer_function(opacity, n_colors)
+            if flip_opacity:
+                opacity = opacity[::-1]
         elif isinstance(opacity, np.ndarray):
             raise NotImplemented
+        elif isinstance(opacity, (float)):
+            if flip_opacity:
+                opacity = 1 - opacity
 
         # Scalar formatting ===================================================
         if cmap is None: # grab alias for cmaps: colormap

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -101,7 +101,7 @@ def normalize(x, minimum=None, maximum=None):
     return (x - minimum) / (maximum - minimum)
 
 
-def opacity_transfer_function(mapping, n_colors):
+def opacity_transfer_function(mapping, n_colors, interpolate=True):
     """Get the opacity transfer function results: range from 0 to 255.
     """
     sigmoid = lambda x: np.array(1 / (1 + np.exp(-x)) * 255, dtype=np.uint8)
@@ -144,6 +144,8 @@ def opacity_transfer_function(mapping, n_colors):
             xo = np.linspace(0, n_colors, len(mapping), dtype=np.int)
             xx = np.linspace(0, n_colors, n_colors, dtype=np.int)
             try:
+                if not interpolate:
+                    raise AssertionError('No interpolation.')
                 # Use a quadratic interp if scipy is available
                 from scipy.interpolate import interp1d
                 # quadratic has best/smoothest results
@@ -152,7 +154,7 @@ def opacity_transfer_function(mapping, n_colors):
                 vals[vals<0] = 0.0
                 vals[vals>1.0] = 1.0
                 mapping = (vals * 255.).astype(np.uint8)
-            except ImportError:
+            except (ImportError, AssertionError):
                 # Otherwise use simple linear interp
                 mapping = (np.interp(xx, xo, mapping) * 255).astype(np.uint8)
         else:

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -7,3 +7,4 @@ pytest-sphinx
 sphinx-notfound-page>=0.3.0
 sphinx-copybutton
 sphinx-gallery>=0.4.0
+scipy

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -640,3 +640,30 @@ def test_plot_eye_dome_lighting():
     p.add_mesh(mesh)
     p.enable_eye_dome_lighting()
     p.show()
+
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+def test_opacity_by_array():
+    mesh = examples.load_uniform()
+    # Test with opacity arry
+    mesh['opac'] = mesh['Spatial Point Data'] / 100.
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
+    p.add_mesh(mesh, scalars='Spatial Point Data', opacity='opac',)
+    p.show()
+    # Test with uncertainty array (transperancy)
+    mesh['unc'] = mesh['Spatial Point Data']
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
+    p.add_mesh(mesh, scalars='Spatial Point Data', opacity='unc',
+               flip_opacity=True)
+    p.show()
+    # Test using mismatched arrays
+    with pytest.raises(RuntimeError):
+        p = pyvista.Plotter(off_screen=OFF_SCREEN)
+        p.add_mesh(mesh, scalars='Spatial Cell Data', opacity='unc',)
+        p.show()
+    # Test with user defined transfer function
+    opacities = [0,0.2,0.9,0.2,0.1]
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
+    p.add_mesh(mesh, scalars='Spatial Point Data', opacity=opacities,)
+    p.show()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -655,7 +655,7 @@ def test_opacity_by_array():
     mesh['unc'] = mesh['Spatial Point Data']
     p = pyvista.Plotter(off_screen=OFF_SCREEN)
     p.add_mesh(mesh, scalars='Spatial Point Data', opacity='unc',
-               flip_opacity=True)
+               use_transparency=True)
     p.show()
     # Test using mismatched arrays
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
These changes enable a user to specify all kinds of options for the opacity:

- a scalar array on the mesh be used for opacity mapping to enable us to see two arrays at once 
- predefined transfer functions by string name
- custom built transfer functions
- single value for global opacity

### Why?

Maybe you have an uncertainty array - these changes make it so that you could make regions with high values of uncertainty be transparent. Or maybe you have a mesh with a modeled scalar array on another array of your modeling variance. This would allow you to control the opacity of the mesh by the variance.

### Example

Here I have a mesh with a modelled scalar array from Kriging and an associated kriging variance array which I'd like to use to make my mesh transparent:

```py
temp_grid = pv.read('temp_grid.vtk')
temp_grid
```
<table><tr><th>Header</th><th>Data Arrays</th></tr><tr><td><table><tr><th>UnstructuredGrid</th><th>Information</th></tr><tr><td>N Cells</td><td>2841790</td></tr><tr><td>N Points</td><td>551724</td></tr><tr><td>X Bounds</td><td>3.299e+05, 3.442e+05</td></tr><tr><td>Y Bounds</td><td>4.253e+06, 4.271e+06</td></tr><tr><td>Z Bounds</td><td>-2.700e+03, 2.300e+03</td></tr><tr><td>N Arrays</td><td>2</td></tr></table></td><td><table><tr><th>Name</th><th>Field</th><th>Type</th><th>N Comp</th><th>Min</th><th>Max</th></tr><tr><td><b>Temperature</b></td><td>Points</td><td>float64</td><td>1</td><td>6.729e+00</td><td>2.738e+02</td></tr><tr><td>Temperature_var</td><td>Points</td><td>float64</td><td>1</td><td>2.214e+02</td><td>1.107e+04</td></tr></table></td></tr> </table>

```py
# Make some contours
cntrs = temp_grid.contour(10, scalars='Temperature')

p = pv.Plotter(notebook=0)
p.add_mesh(cntrs, scalars='Temperature', 
           opacity='Temperature_var', 
           flip_opacity=True, cmap='bwr')
p.show()
```

<img width="624" alt="Screen Shot 2019-07-07 at 4 09 40 PM" src="https://user-images.githubusercontent.com/22067021/60774490-acd8a900-a0d1-11e9-9967-cd78ac8f6bd0.png">


Which looks a bit more informative than just the scalar array alone:

<img width="580" alt="Screen Shot 2019-07-07 at 4 05 30 PM" src="https://user-images.githubusercontent.com/22067021/60774442-2e7c0700-a0d1-11e9-9521-d8421fc07445.png">



### Todo:

- [x] fix issue where the scalar bar is not appearing
- [x] fix the issue where the added `__custom_rgba` array is set as active and would be plotted wrong on the second iteration.
- [x] Add tests
- [x] Add the ability to use user-specified mappings/transfer functions per #301  
- [x] throw error if scalars and opacity arrays are on different fields (cell/point)
- [x] refactor and implement for `add_volume` as well (`add_volume` doesn't currently support RGBA plotting - this will come later)
- [x] add examples!