### PR TITLE
tolerance subsetting for glyph filter

### DIFF
--- a/examples/01-filter/glyphs.py
+++ b/examples/01-filter/glyphs.py
@@ -70,9 +70,8 @@ p.show()
 #
 # Sometimes you might not want glyphs for every node in the input dataset. In
 # this case, you can choose to build glyphs for a subset of the input dataset
-# by using a percentage of the points. Using this percentage, a uniform
-# distribuiton is used to select points from the input dataset and use them for
-# glyphing.
+# by using a merging tolerance. Here we specify a merging tolerance of five
+# percent which equats to five perfect of the bounding box's length.
 
 # Example dataset with normals
 mesh = examples.load_random_hills()

--- a/examples/01-filter/glyphs.py
+++ b/examples/01-filter/glyphs.py
@@ -53,13 +53,13 @@ vectors = np.vstack(
 sphere.vectors = vectors * 0.3
 
 # plot just the arrows
-sphere.arrows.plot()
+sphere.arrows.plot(scalars='GlyphScale')
 
 ###############################################################################
 
 # plot the arrows and the sphere
 p = pv.Plotter()
-p.add_mesh(sphere.arrows, lighting=False, stitle="Vector Magnitude")
+p.add_mesh(sphere.arrows, scalars='GlyphScale', lighting=False, stitle="Vector Magnitude")
 p.add_mesh(sphere, color="grey", ambient=0.6, opacity=0.5, show_edges=False)
 p.show()
 
@@ -78,7 +78,7 @@ p.show()
 mesh = examples.load_random_hills()
 
 # create a subset of arrows using the glyph filter
-arrows = mesh.glyph(scale="Normals", orient="Normals", subset=0.05)
+arrows = mesh.glyph(scale="Normals", orient="Normals", tolerance=0.05)
 
 p = pv.Plotter()
 p.add_mesh(arrows, color="black")

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -294,7 +294,7 @@ def test_glyph():
     sphere.point_arrays['arr'] = np.ones(sphere.n_points)
     result = sphere.glyph(scale='arr')
     result = sphere.glyph(scale='arr', orient='Normals', factor=0.1)
-    result = sphere.glyph(scale='arr', orient='Normals', factor=0.1, subset=0.5)
+    result = sphere.glyph(scale='arr', orient='Normals', factor=0.1, tolerance=0.1)
 
 
 def test_split_and_connectivity():


### PR DESCRIPTION
Implement tolerance based subsetting for glyph filter using `vtkCleanPolyData`

This fixes an issue from #269 using a suggestion from @marcomusy in #301

### Example

```py
import pyvista as pv
from pyvista import examples

# Example dataset with normals
mesh = examples.load_random_hills()

# create a subset of arrows using the glyph filter
arrows = mesh.glyph(scale="Normals", orient="Normals", tolerance=0.05)

p = pv.Plotter()
p.add_mesh(arrows, color="black")
p.add_mesh(mesh, scalars="Elevation", cmap="terrain")
p.show()
```

Note that the previous subsetting was not a uniform spatial distribution:

![sphx_glr_glyphs_004](https://user-images.githubusercontent.com/22067021/60910365-d3b3ee00-a23d-11e9-9937-d92a49871ea8.png)

Now it's uniform using a tolerance:

![sphx_glr_glyphs_004](https://user-images.githubusercontent.com/22067021/60910378-dca4bf80-a23d-11e9-8169-0d416e574845.png)