### PR TITLE
Add Callback support in BackgroundPlotter

### DIFF
--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -558,6 +558,12 @@ class BackgroundPlotter(QtInteractor):
     def __del__(self):  # pragma: no cover
         self.close()
 
+    def add_callback(self, callback, func, timeout=1000):
+        timer = QTimer(parent=self.app_window)
+        timer.timeout.connect(getattr(callback, func))
+        self.app_window.signal_close.connect(timer.stop)
+        timer.start(timeout)
+
 
 class MainWindow(QMainWindow):
     signal_close = pyqtSignal()

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -564,6 +564,18 @@ class BackgroundPlotter(QtInteractor):
         self.close()
 
     def add_callback(self, func, interval=1000, count=None):
+        """Add a function that can update the scene in the background
+
+        Parameters
+        ----------
+        func : callable
+            Function to be called with no arguments.
+        interval : int
+            Time interval between calls to `func` in milliseconds.
+        count : int, optional
+            Number of times `func` will be called. If None,
+            `func` will be called until the main window is closed.
+        """
         timer = QTimer(parent=self.app_window)
         timer.timeout.connect(func)
         timer.start(interval)

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -601,7 +601,6 @@ class Counter(QObject):
 
     @pyqtSlot()
     def decrease(self):
-        print(self.count)
         self.count -= 1
         if self.count <= 0:
             self.signal_finished.emit()

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -55,6 +55,10 @@ class QMainWindow(object):
     pass
 
 
+class QObject(object):
+    pass
+
+
 try:
     from PyQt5.QtCore import pyqtSignal, pyqtSlot, QObject, QTimer
     from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor

--- a/tests/test_qt_plotting.py
+++ b/tests/test_qt_plotting.py
@@ -152,3 +152,16 @@ def test_background_plotting_orbit(qtbot):
     # perfrom the orbit:
     plotter.orbit_on_path(bkg=False, step=0.0)
     plotter.close()
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+@pytest.mark.skipif(not has_pyqt5, reason="requires pyqt5")
+def test_background_plotting_add_callback(qtbot):
+    plotter = pyvista.BackgroundPlotter(show=False, title='Testing Window')
+    sphere = pyvista.Sphere()
+    plotter.add_mesh(sphere)
+
+    def mycallback():
+        sphere.points *= 0.5
+    plotter.add_callback(mycallback, interval=1000, count=3)
+    plotter.close()


### PR DESCRIPTION
This PR suggests a way to address #280 and implements the ideas shared in the discussion.

This is the code snippet I used to test the changes locally:

```py
import pyvista as pv

sphere = pv.Sphere()
plotter = pv.BackgroundPlotter()
plotter.add_mesh(sphere)


#  create custom callback class including the sphere
class CallBack:
    def __init__(self, sphere):
        self.sphere = sphere

    def __call__(self):
        # can now operate on the sphere and have it updated in the background
        self.sphere.points *= 0.5


# create the callback instance and ship it with the sphere
callback = CallBack(sphere) 
plotter.add_callback(callback, interval=1000, count=2)
```