### PR TITLE
MRG: Set window title for BackgroundPlotter

### DIFF
--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -360,6 +360,7 @@ class BackgroundPlotter(QtInteractor):
 
         self.app = app
         self.app_window = MainWindow()
+        self.app_window.setWindowTitle(kwargs.get('title', rcParams['title']))
 
         self.frame = QFrame()
         self.frame.setFrameStyle(QFrame.NoFrame)


### PR DESCRIPTION
Fix issue similar to #287 but for the `BackgroundPlotter`.