### PR TITLE
Add more exluded arrays from being active

### DIFF
--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -60,7 +60,7 @@ class Common(DataSetFilters, object):
                 else:
                     name = None
 
-        exclude = ['__custom_rgba', ]
+        exclude = ['__custom_rgba', 'Normals', 'vtkOriginalPointIds',]
 
         def search_for_array(data):
             arr = None


### PR DESCRIPTION
This adds more arrays from being selected as the active scalars by default given the new features from https://github.com/pyvista/pyvista/pull/297#issuecomment-510198041

- `'Normals'` (https://github.com/pyvista/pyvista/pull/297#issuecomment-510227643)
- `'vtkOriginalPointIds'` (#303)

What else should be on this list?