### PR TITLE
Add offscreen support in BackgroundPlotter

### DIFF
--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -332,7 +332,8 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
 
     def quit(self):
         """Quit application"""
-        self.iren.TerminateApp()
+        if hasattr(self, 'iren'):
+            self.iren.TerminateApp()
         QVTKRenderWindowInteractor.close(self)
 
 

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -332,7 +332,8 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
             pass
 
     def quit(self):
-        self.iren.TerminateApp()
+        if hasattr(self, 'iren'):
+            self.iren.TerminateApp()
         self.close()
         self.signal_close.emit()
 

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -7,6 +7,7 @@ import scooby
 import vtk
 import vtk.qt
 
+import pyvista
 from .plotting import BasePlotter
 from .theme import rcParams
 
@@ -283,7 +284,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
     allow_quit_keypress = True
     signal_close = pyqtSignal()
 
-    def __init__(self, parent=None, title=None, shape=(1, 1), **kwargs):
+    def __init__(self, parent=None, title=None, shape=(1, 1), off_screen=None, **kwargs):
         """ Initialize Qt interactor """
         if not has_pyqt:
             raise AssertionError('Requires PyQt5')
@@ -295,23 +296,29 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         self.ren_win = self.GetRenderWindow()
         for renderer in self.renderers:
             self.ren_win.AddRenderer(renderer)
-        self.iren = self.ren_win.GetInteractor()
 
         self.background_color = rcParams['background']
-
         if self.title:
             self.setWindowTitle(title)
 
-        self.iren.RemoveObservers('MouseMoveEvent')  # slows window update?
-        self.iren.Initialize()
+        if off_screen is None:
+            off_screen = pyvista.OFF_SCREEN
+
+        if off_screen:
+            self.ren_win.SetOffScreenRendering(1)
+        else:
+            self.iren = self.ren_win.GetInteractor()
+            self.iren.RemoveObservers('MouseMoveEvent')  # slows window update?
+            self.iren.Initialize()
+
+            # QVTKRenderWindowInteractor doesn't have a "q" quit event
+            self.iren.AddObserver("KeyPressEvent", self.key_quit)
 
         # Enter trackball camera mode
         istyle = vtk.vtkInteractorStyleTrackballCamera()
         self.SetInteractorStyle(istyle)
         self.add_axes()
 
-        # QVTKRenderWindowInteractor doesn't have a "q" quit event
-        self.iren.AddObserver("KeyPressEvent", self.key_quit)
 
     def key_quit(self, obj=None, event=None):  # pragma: no cover
         try:
@@ -332,7 +339,8 @@ class BackgroundPlotter(QtInteractor):
 
     ICON_TIME_STEP = 5.0
 
-    def __init__(self, show=True, app=None, shape=(1, 1), window_size=None, **kwargs):
+    def __init__(self, show=True, app=None, shape=(1, 1), window_size=None,
+                 off_screen=None, **kwargs):
         if not has_pyqt:
             raise AssertionError('Requires PyQt5')
         self.active = True
@@ -370,7 +378,8 @@ class BackgroundPlotter(QtInteractor):
         self.frame = QFrame()
         self.frame.setFrameStyle(QFrame.NoFrame)
 
-        QtInteractor.__init__(self, parent=self.frame, shape=shape, **kwargs)
+        QtInteractor.__init__(self, parent=self.frame, shape=shape,
+                              off_screen=off_screen, **kwargs)
         self.signal_close.connect(self.app_window.close)
 
         # build main menu
@@ -427,7 +436,10 @@ class BackgroundPlotter(QtInteractor):
         self.frame.setLayout(vlayout)
         self.app_window.setCentralWidget(self.frame)
 
-        if show:  # pragma: no cover
+        if off_screen is None:
+            off_screen = pyvista.OFF_SCREEN
+
+        if show and not off_screen:  # pragma: no cover
             self.app_window.show()
             self.show()
 

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -309,15 +309,17 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         else:
             self.iren = self.ren_win.GetInteractor()
             self.iren.RemoveObservers('MouseMoveEvent')  # slows window update?
+
+            # Enter trackball camera mode
+            istyle = vtk.vtkInteractorStyleTrackballCamera()
+            self.SetInteractorStyle(istyle)
+            self.add_axes()
+
             self.iren.Initialize()
 
             # QVTKRenderWindowInteractor doesn't have a "q" quit event
             self.iren.AddObserver("KeyPressEvent", self.key_quit)
 
-        # Enter trackball camera mode
-        istyle = vtk.vtkInteractorStyleTrackballCamera()
-        self.SetInteractorStyle(istyle)
-        self.add_axes()
 
 
     def key_quit(self, obj=None, event=None):  # pragma: no cover


### PR DESCRIPTION
This PR adds basic support for offscreen rendering in the `BackgroundPlotter` class.

The following is an example of what's possible now:
```py
import pyvista as pv

pv.OFF_SCREEN = True

p = pv.BackgroundPlotter(size=(500, 500))
p.add_mesh(pv.Cone())
p.screenshot('shot1.png')

p.camera_position = [(5, 2, 2), (0, 0, 0), (0, 1, 0)]
p.background_color = (0.0, 0.0, 0.0)
p.screenshot('shot2.png')

p.close()
```

**shot1.png** | **shot2.png**
-----------------|------------------
![shot1](https://user-images.githubusercontent.com/18143289/61214285-cdbf8080-a707-11e9-9560-1de9e0b80ada.png) | ![shot2](https://user-images.githubusercontent.com/18143289/61214286-cdbf8080-a707-11e9-9fc3-9695f8171a9c.png)


**Known issues**:
* The axes are disabled by default when rendered offscreen.