### PR TITLE
Fix BackgroundPlotter window size setup

### DIFF
--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -575,6 +575,7 @@ class BackgroundPlotter(QtInteractor):
     def window_size(self, window_size):
         """ set the render window size """
         BasePlotter.window_size.fset(self, window_size)
+        self.app_window.setBaseSize(*window_size)
         self.app_window.resize(*window_size)
 
     def __del__(self):  # pragma: no cover

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -575,7 +575,7 @@ class BackgroundPlotter(QtInteractor):
     def window_size(self, window_size):
         """ set the render window size """
         BasePlotter.window_size.fset(self, window_size)
-        self.app_window.setBaseSize(*window_size)
+        self.app_window.resize(*window_size)
 
     def __del__(self):  # pragma: no cover
         self.app_window.close()


### PR DESCRIPTION
This PR fixes an issue with the window's size of the `BackgroundPlotter` for example a 1000x1000 window:
```py
import pyvista as pv
p = pv.BackgroundPlotter()
p.add_mesh(pv.Cone())
p.window_size=(1000, 1000)
```
Before | After
---------|-------
![image](https://user-images.githubusercontent.com/18143289/61487684-d08bd100-a9a6-11e9-9ece-2badcb24b50e.png) | ![image](https://user-images.githubusercontent.com/18143289/61487536-71c65780-a9a6-11e9-99b7-67935f6c573d.png)

