### PR TITLE
Update axes colors to match ParaView

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -274,6 +274,10 @@ class BasePlotter(object):
             self.axes_actor.SetXAxisLabelText(x_label)
             self.axes_actor.SetYAxisLabelText(y_label)
             self.axes_actor.SetZAxisLabelText(z_label)
+            # Set Line width
+            self.axes_actor.GetXAxisShaftProperty().SetLineWidth(2)
+            self.axes_actor.GetYAxisShaftProperty().SetLineWidth(2)
+            self.axes_actor.GetZAxisShaftProperty().SetLineWidth(2)
         self.axes_widget = vtk.vtkOrientationMarkerWidget()
         self.axes_widget.SetOrientationMarker(self.axes_actor)
         if hasattr(self, 'iren'):

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -243,8 +243,8 @@ class BasePlotter(object):
             elif not self._first_time:
                 self.render()
 
-    def add_axes(self, interactive=None, color=None, x_color='tomato',
-                 y_color='gold', z_color='seagreen',
+    def add_axes(self, interactive=None, color=None, x_color=None,
+                 y_color=None, z_color=None,
                  x_label='X', y_label='Y', z_label='Z',
                  box=False, box_arguments=None):
         """ Add an interactive axes widget """
@@ -254,6 +254,12 @@ class BasePlotter(object):
             self.axes_widget.SetInteractive(interactive)
             self._update_axes_color(color)
             return
+        if x_color is None:
+            x_color = rcParams['axes']['x_color']
+        if y_color is None:
+            y_color = rcParams['axes']['y_color']
+        if z_color is None:
+            z_color = rcParams['axes']['z_color']
         # Chose widget type
         if box:
             if box_arguments is None:

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -243,7 +243,10 @@ class BasePlotter(object):
             elif not self._first_time:
                 self.render()
 
-    def add_axes(self, interactive=None, color=None, box=False, box_arguments=None):
+    def add_axes(self, interactive=None, color=None, x_color='tomato',
+                 y_color='gold', z_color='seagreen',
+                 x_label='X', y_label='Y', z_label='Z',
+                 box=False, box_arguments=None):
         """ Add an interactive axes widget """
         if interactive is None:
             interactive = rcParams['interactive']
@@ -255,10 +258,22 @@ class BasePlotter(object):
         if box:
             if box_arguments is None:
                 box_arguments = {}
-            prop_assembly = create_axes_orientation_box(**box_arguments)
+            prop_assembly = create_axes_orientation_box(x_color=x_color,
+                y_color=y_color, z_color=z_color, x_label=x_label,
+                y_label=y_label, z_label=z_label, **box_arguments)
             self.axes_actor = prop_assembly
         else:
             self.axes_actor = vtk.vtkAxesActor()
+            self.axes_actor.GetXAxisShaftProperty().SetColor(parse_color(x_color))
+            self.axes_actor.GetXAxisTipProperty().SetColor(parse_color(x_color))
+            self.axes_actor.GetYAxisShaftProperty().SetColor(parse_color(y_color))
+            self.axes_actor.GetYAxisTipProperty().SetColor(parse_color(y_color))
+            self.axes_actor.GetZAxisShaftProperty().SetColor(parse_color(z_color))
+            self.axes_actor.GetZAxisTipProperty().SetColor(parse_color(z_color))
+            # Set labels
+            self.axes_actor.SetXAxisLabelText(x_label)
+            self.axes_actor.SetYAxisLabelText(y_label)
+            self.axes_actor.SetZAxisLabelText(z_label)
         self.axes_widget = vtk.vtkOrientationMarkerWidget()
         self.axes_widget.SetOrientationMarker(self.axes_actor)
         if hasattr(self, 'iren'):

--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -52,6 +52,11 @@ rcParams = {
     'use_panel' : True,
     'transparent_background' : False,
     'title' : 'PyVista',
+    'axes': {
+        'x_color': 'tomato',
+        'y_color': 'seagreen',
+        'z_color': 'blue',
+    }
 }
 
 DEFAULT_THEME = dict(rcParams)
@@ -63,7 +68,13 @@ def set_plot_theme(theme):
         rcParams['cmap'] = 'coolwarm'
         rcParams['font']['family'] = 'arial'
         rcParams['font']['label_size'] = 16
+        rcParams['font']['color'] = 'white'
         rcParams['show_edges'] = False
+        rcParams['color'] = 'white'
+        rcParams['outline_color'] = 'white'
+        rcParams['axes']['x_color'] = 'tomato'
+        rcParams['axes']['y_color'] = 'gold'
+        rcParams['axes']['z_color'] = 'green'
     elif theme.lower() in ['document', 'doc', 'paper', 'report']:
         rcParams['background'] = 'white'
         rcParams['cmap'] = 'viridis'
@@ -74,6 +85,9 @@ def set_plot_theme(theme):
         rcParams['show_edges'] = False
         rcParams['color'] = 'tan'
         rcParams['outline_color'] = 'black'
+        rcParams['axes']['x_color'] = 'tomato'
+        rcParams['axes']['y_color'] = 'seagreen'
+        rcParams['axes']['z_color'] = 'blue'
     elif theme.lower() in ['night', 'dark']:
         rcParams['background'] = 'black'
         rcParams['cmap'] = 'viridis'
@@ -82,6 +96,9 @@ def set_plot_theme(theme):
         rcParams['color'] = 'tan'
         rcParams['outline_color'] = 'white'
         rcParams['edge_color'] = 'white'
+        rcParams['axes']['x_color'] = 'tomato'
+        rcParams['axes']['y_color'] = 'seagreen'
+        rcParams['axes']['z_color'] = 'blue'
     elif theme.lower() in ['default']:
         for k,v in DEFAULT_THEME.items():
             rcParams[k] = v

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -33,8 +33,9 @@ def system_supports_plotting():
 
 
 def create_axes_orientation_box(line_width=1, text_scale=0.366667,
-                                edge_color='black', x_color='lightblue',
-                                y_color='seagreen', z_color='tomato',
+                                edge_color='black', x_color='tomato',
+                                y_color='gold', z_color='seagreen',
+                                x_label='X', y_label='Y', z_label='Z',
                                 x_face_color=(255, 0, 0),
                                 y_face_color=(0, 255, 0),
                                 z_face_color=(0, 0, 255),
@@ -43,12 +44,12 @@ def create_axes_orientation_box(line_width=1, text_scale=0.366667,
     """
     axes_actor = vtk.vtkAnnotatedCubeActor()
     axes_actor.SetFaceTextScale(text_scale)
-    axes_actor.SetXPlusFaceText("X+")
-    axes_actor.SetXMinusFaceText("X-")
-    axes_actor.SetYPlusFaceText("Y+")
-    axes_actor.SetYMinusFaceText("Y-")
-    axes_actor.SetZPlusFaceText("Z+")
-    axes_actor.SetZMinusFaceText("Z-")
+    axes_actor.SetXPlusFaceText("+{}".format(x_label))
+    axes_actor.SetXMinusFaceText("-{}".format(x_label))
+    axes_actor.SetYPlusFaceText("+{}".format(y_label))
+    axes_actor.SetYMinusFaceText("-{}".format(y_label))
+    axes_actor.SetZPlusFaceText("+{}".format(z_label))
+    axes_actor.SetZMinusFaceText("-{}".format(z_label))
     axes_actor.GetTextEdgesProperty().SetColor(parse_color(edge_color))
     axes_actor.GetTextEdgesProperty().SetLineWidth(line_width)
     axes_actor.GetXPlusFaceProperty().SetColor(parse_color(x_color))

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -33,8 +33,8 @@ def system_supports_plotting():
 
 
 def create_axes_orientation_box(line_width=1, text_scale=0.366667,
-                                edge_color='black', x_color='tomato',
-                                y_color='gold', z_color='seagreen',
+                                edge_color='black', x_color=None,
+                                y_color=None, z_color=None,
                                 x_label='X', y_label='Y', z_label='Z',
                                 x_face_color=(255, 0, 0),
                                 y_face_color=(0, 255, 0),
@@ -42,6 +42,12 @@ def create_axes_orientation_box(line_width=1, text_scale=0.366667,
                                 color_box=False):
     """Create a Box axes orientation widget with labels.
     """
+    if x_color is None:
+        x_color = rcParams['axes']['x_color']
+    if y_color is None:
+        y_color = rcParams['axes']['y_color']
+    if z_color is None:
+        z_color = rcParams['axes']['z_color']
     axes_actor = vtk.vtkAnnotatedCubeActor()
     axes_actor.SetFaceTextScale(text_scale)
     axes_actor.SetXPlusFaceText("+{}".format(x_label))


### PR DESCRIPTION
This has been bugging me for a long time - now the axes widget's colors match ParaView's default. One caveat, yellow can be difficult to see in the document theme (I made it gold and bumped up the line width of the shaft to mitigate the issue)

<img width="133" alt="Screen Shot 2019-07-29 at 8 38 00 PM" src="https://user-images.githubusercontent.com/22067021/62096389-c6888e80-b240-11e9-97aa-43ed05d2ae1a.png">


<img width="115" alt="Screen Shot 2019-07-29 at 8 38 35 PM" src="https://user-images.githubusercontent.com/22067021/62096421-da33f500-b240-11e9-949d-bb54e3ea4b65.png">


<img width="140" alt="Screen Shot 2019-07-29 at 8 53 16 PM" src="https://user-images.githubusercontent.com/22067021/62097050-e7ea7a00-b242-11e9-9692-502e7f43420b.png">

