### PR TITLE
Add warning when using Plotter.plot()

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3515,6 +3515,7 @@ class Plotter(BasePlotter):
 
     def plot(self, *args, **kwargs):
         """ Present for backwards compatibility. Use `show()` instead """
+        logging.warning("`.plot()` is deprecated. Please use `.show()` instead.")
         return self.show(*args, **kwargs)
 
     def render(self):


### PR DESCRIPTION
`Plotter.plot()` has been deprecated for a while in favor of `Plotter.show()`. This finally adds a warning to get people to stop using it.