### PR TITLE
Overhaul axes widgets

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -246,7 +246,7 @@ class BasePlotter(object):
     def add_axes(self, interactive=None, line_width=2,
                  color=None, x_color=None, y_color=None, z_color=None,
                  xlabel='X', ylabel='Y', zlabel='Z', labels_off=False,
-                 box=False, box_args=None):
+                 box=None, box_args=None):
         """ Add an interactive axes widget """
         if interactive is None:
             interactive = rcParams['interactive']
@@ -254,6 +254,8 @@ class BasePlotter(object):
             self.axes_widget.SetInteractive(interactive)
             update_axes_label_color(color)
             return
+        if box is None:
+            box = rcParams['axes']['box']
         if box:
             if box_args is None:
                 box_args = {}

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -252,7 +252,7 @@ class BasePlotter(object):
             interactive = rcParams['interactive']
         if hasattr(self, 'axes_widget'):
             self.axes_widget.SetInteractive(interactive)
-            _update_axes_label_color(color)
+            update_axes_label_color(color)
             return
         if box:
             if box_args is None:

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -14,6 +14,7 @@ from pyvista.utilities import wrap
 
 from .plotting import (MAX_N_COLOR_BARS, parse_color, parse_font_family,
                        rcParams)
+from .tools import create_axes_marker
 
 
 class Renderer(vtkRenderer):
@@ -132,7 +133,9 @@ class Renderer(vtkRenderer):
 
         return actor, actor.GetProperty()
 
-    def add_axes_at_origin(self):
+    def add_axes_at_origin(self, x_color=None, y_color=None, z_color=None,
+                    xlabel='X', ylabel='Y', zlabel='Z', line_width=2,
+                    labels_off=False):
         """
         Add axes actor at origin
 
@@ -141,8 +144,9 @@ class Renderer(vtkRenderer):
         marker_actor : vtk.vtkAxesActor
             vtkAxesActor actor
         """
-        self.marker_actor = vtk.vtkAxesActor()
-        # renderer = self.renderers[self.loc_to_index(loc)]
+        self.marker_actor = create_axes_marker(line_width=line_width,
+            x_color=x_color, y_color=y_color, z_color=z_color,
+            xlabel=xlabel, ylabel=ylabel, zlabel=zlabel, labels_off=labels_off)
         self.AddActor(self.marker_actor)
         self.parent._actors[str(hex(id(self.marker_actor)))] = self.marker_actor
         return self.marker_actor

--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -56,6 +56,7 @@ rcParams = {
         'x_color': 'tomato',
         'y_color': 'seagreen',
         'z_color': 'mediumblue',
+        'box': False,
     }
 }
 

--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -55,7 +55,7 @@ rcParams = {
     'axes': {
         'x_color': 'tomato',
         'y_color': 'seagreen',
-        'z_color': 'blue',
+        'z_color': 'mediumblue',
     }
 }
 
@@ -106,15 +106,17 @@ def set_plot_theme(theme):
 
 
 def parse_color(color):
-    """ Parses color into a vtk friendly rgb list """
+    """Parses color into a vtk friendly rgb list.
+    Values returned will be between 0 and 1.
+    """
     if color is None:
         color = rcParams['color']
     if isinstance(color, str):
-        return string_to_rgb(color)
+        color = string_to_rgb(color)
     elif len(color) == 3:
-        return color
+        pass
     elif len(color) == 4:
-        return color[:3]
+        color = color[:3]
     else:
         raise Exception("""
     Invalid color input: ({})
@@ -123,6 +125,7 @@ def parse_color(color):
         color='w'
         color=[1, 1, 1]
         color='#FFFFFF'""".format(color))
+    return color
 
 
 

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -32,7 +32,7 @@ def system_supports_plotting():
         return False
 
 
-def _update_axes_label_color(axes_actor, color=None):
+def update_axes_label_color(axes_actor, color=None):
     """Internal helper to set the axes label color"""
     if color is None:
         color = rcParams['font']['color']
@@ -77,7 +77,7 @@ def create_axes_marker(label_color=None, x_color=None, y_color=None,
     axes_actor.GetYAxisShaftProperty().SetLineWidth(line_width)
     axes_actor.GetZAxisShaftProperty().SetLineWidth(line_width)
 
-    _update_axes_label_color(axes_actor, label_color)
+    update_axes_label_color(axes_actor, label_color)
 
     return axes_actor
 
@@ -165,7 +165,7 @@ def create_axes_orientation_box(line_width=1, text_scale=0.366667,
     else:
         actor = axes_actor
 
-    _update_axes_label_color(actor, label_color)
+    update_axes_label_color(actor, label_color)
 
     return actor
 

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -6,7 +6,7 @@ import vtk
 
 import pyvista
 
-from .theme import parse_color
+from .theme import parse_color, rcParams
 
 def system_supports_plotting():
     """
@@ -32,14 +32,65 @@ def system_supports_plotting():
         return False
 
 
+def _update_axes_label_color(axes_actor, color=None):
+    """Internal helper to set the axes label color"""
+    if color is None:
+        color = rcParams['font']['color']
+    color = parse_color(color)
+    if isinstance(axes_actor, vtk.vtkAxesActor):
+        prop_x = axes_actor.GetXAxisCaptionActor2D().GetCaptionTextProperty()
+        prop_y = axes_actor.GetYAxisCaptionActor2D().GetCaptionTextProperty()
+        prop_z = axes_actor.GetZAxisCaptionActor2D().GetCaptionTextProperty()
+        for prop in [prop_x, prop_y, prop_z]:
+            prop.SetColor(color[0], color[1], color[2])
+            prop.SetShadow(False)
+    elif isinstance(axes_actor, vtk.vtkAnnotatedCubeActor):
+        axes_actor.GetTextEdgesProperty().SetColor(color)
+
+    return
+
+
+def create_axes_marker(label_color=None, x_color=None, y_color=None,
+                       z_color=None, xlabel='X', ylabel='Y', zlabel='Z',
+                       labels_off=False, line_width=2):
+    if x_color is None:
+        x_color = rcParams['axes']['x_color']
+    if y_color is None:
+        y_color = rcParams['axes']['y_color']
+    if z_color is None:
+        z_color = rcParams['axes']['z_color']
+    axes_actor = vtk.vtkAxesActor()
+    axes_actor.GetXAxisShaftProperty().SetColor(parse_color(x_color))
+    axes_actor.GetXAxisTipProperty().SetColor(parse_color(x_color))
+    axes_actor.GetYAxisShaftProperty().SetColor(parse_color(y_color))
+    axes_actor.GetYAxisTipProperty().SetColor(parse_color(y_color))
+    axes_actor.GetZAxisShaftProperty().SetColor(parse_color(z_color))
+    axes_actor.GetZAxisTipProperty().SetColor(parse_color(z_color))
+    # Set labels
+    axes_actor.SetXAxisLabelText(xlabel)
+    axes_actor.SetYAxisLabelText(ylabel)
+    axes_actor.SetZAxisLabelText(zlabel)
+    if labels_off:
+        axes_actor.AxisLabelsOff()
+    # Set Line width
+    axes_actor.GetXAxisShaftProperty().SetLineWidth(line_width)
+    axes_actor.GetYAxisShaftProperty().SetLineWidth(line_width)
+    axes_actor.GetZAxisShaftProperty().SetLineWidth(line_width)
+
+    _update_axes_label_color(axes_actor, label_color)
+
+    return axes_actor
+
+
 def create_axes_orientation_box(line_width=1, text_scale=0.366667,
                                 edge_color='black', x_color=None,
                                 y_color=None, z_color=None,
-                                x_label='X', y_label='Y', z_label='Z',
-                                x_face_color=(255, 0, 0),
-                                y_face_color=(0, 255, 0),
-                                z_face_color=(0, 0, 255),
-                                color_box=False):
+                                xlabel='X', ylabel='Y', zlabel='Z',
+                                x_face_color='red',
+                                y_face_color='green',
+                                z_face_color='mediumblue',
+                                color_box=False, label_color=None,
+                                labels_off=False, opacity=0.5,):
     """Create a Box axes orientation widget with labels.
     """
     if x_color is None:
@@ -48,16 +99,23 @@ def create_axes_orientation_box(line_width=1, text_scale=0.366667,
         y_color = rcParams['axes']['y_color']
     if z_color is None:
         z_color = rcParams['axes']['z_color']
+    if edge_color is None:
+        edge_color = rcParams['edge_color']
     axes_actor = vtk.vtkAnnotatedCubeActor()
     axes_actor.SetFaceTextScale(text_scale)
-    axes_actor.SetXPlusFaceText("+{}".format(x_label))
-    axes_actor.SetXMinusFaceText("-{}".format(x_label))
-    axes_actor.SetYPlusFaceText("+{}".format(y_label))
-    axes_actor.SetYMinusFaceText("-{}".format(y_label))
-    axes_actor.SetZPlusFaceText("+{}".format(z_label))
-    axes_actor.SetZMinusFaceText("-{}".format(z_label))
-    axes_actor.GetTextEdgesProperty().SetColor(parse_color(edge_color))
-    axes_actor.GetTextEdgesProperty().SetLineWidth(line_width)
+    if xlabel is not None:
+        axes_actor.SetXPlusFaceText("+{}".format(xlabel))
+        axes_actor.SetXMinusFaceText("-{}".format(xlabel))
+    if ylabel is not None:
+        axes_actor.SetYPlusFaceText("+{}".format(ylabel))
+        axes_actor.SetYMinusFaceText("-{}".format(ylabel))
+    if zlabel is not None:
+        axes_actor.SetZPlusFaceText("+{}".format(zlabel))
+        axes_actor.SetZMinusFaceText("-{}".format(zlabel))
+    axes_actor.SetFaceTextVisibility(not labels_off)
+    axes_actor.SetTextEdgesVisibility(False)
+    # axes_actor.GetTextEdgesProperty().SetColor(parse_color(edge_color))
+    # axes_actor.GetTextEdgesProperty().SetLineWidth(line_width)
     axes_actor.GetXPlusFaceProperty().SetColor(parse_color(x_color))
     axes_actor.GetXMinusFaceProperty().SetColor(parse_color(x_color))
     axes_actor.GetYPlusFaceProperty().SetColor(parse_color(y_color))
@@ -65,20 +123,29 @@ def create_axes_orientation_box(line_width=1, text_scale=0.366667,
     axes_actor.GetZPlusFaceProperty().SetColor(parse_color(z_color))
     axes_actor.GetZMinusFaceProperty().SetColor(parse_color(z_color))
 
+    axes_actor.GetCubeProperty().SetOpacity(opacity)
+    # axes_actor.GetCubeProperty().SetEdgeColor(parse_color(edge_color))
+    axes_actor.GetCubeProperty().SetEdgeVisibility(True)
+    axes_actor.GetCubeProperty().BackfaceCullingOn()
+    if opacity < 1.0:
+        # Hide the text edges
+        axes_actor.GetTextEdgesProperty().SetOpacity(0)
+
     if color_box:
         # Hide the cube so we can color each face
         axes_actor.GetCubeProperty().SetOpacity(0)
+        axes_actor.GetCubeProperty().SetEdgeVisibility(False)
 
         cube = pyvista.Cube()
         cube.clear_arrays() # remove normals
-        face_colors = np.array([x_face_color,
-                                x_face_color,
-                                y_face_color,
-                                y_face_color,
-                                z_face_color,
-                                z_face_color,
-                               ], dtype=np.uint8)
-
+        face_colors = np.array([parse_color(x_face_color),
+                                parse_color(x_face_color),
+                                parse_color(y_face_color),
+                                parse_color(y_face_color),
+                                parse_color(z_face_color),
+                                parse_color(z_face_color),
+                               ])
+        face_colors = (face_colors * 255).astype(np.uint8)
         cube.cell_arrays['face_colors'] = face_colors
 
         cube_mapper = vtk.vtkPolyDataMapper()
@@ -89,6 +156,7 @@ def create_axes_orientation_box(line_width=1, text_scale=0.366667,
         cube_actor = vtk.vtkActor()
         cube_actor.SetMapper(cube_mapper)
         cube_actor.GetProperty().BackfaceCullingOn()
+        cube_actor.GetProperty().SetOpacity(opacity)
 
         prop_assembly = vtk.vtkPropAssembly()
         prop_assembly.AddPart(axes_actor)
@@ -96,6 +164,8 @@ def create_axes_orientation_box(line_width=1, text_scale=0.366667,
         actor = prop_assembly
     else:
         actor = axes_actor
+
+    _update_axes_label_color(actor, label_color)
 
     return actor
 

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -88,7 +88,7 @@ def create_axes_orientation_box(line_width=1, text_scale=0.366667,
                                 xlabel='X', ylabel='Y', zlabel='Z',
                                 x_face_color='red',
                                 y_face_color='green',
-                                z_face_color='mediumblue',
+                                z_face_color='blue',
                                 color_box=False, label_color=None,
                                 labels_off=False, opacity=0.5,):
     """Create a Box axes orientation widget with labels.

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -355,7 +355,7 @@ def test_axes():
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_box_axes():
     plotter = pyvista.Plotter(off_screen=True)
-    plotter.add_axes(box=True, box_arguments={'color_box':True})
+    plotter.add_axes(box=True, box_args={'color_box':True})
     plotter.add_mesh(pyvista.Sphere())
     plotter.show()
 


### PR DESCRIPTION
Follow up to #334 

This improves the box axes widget a lot and creates a general way to construct axes actors which is now used by `add_axes_at_origin` too. This gives us a lot more control over what the axes markers look like and how they are labeled.

New default appearance when `box=True` is below. Note the opacity and backface culling for the annotations.

```py
import pyvista as pv
from pyvista import examples

mesh = examples.download_st_helens().warp_by_scalar()

p = pv.Plotter(notebook=False)
p.add_mesh(mesh)
p.add_axes(box=True)
p.show()
```

![2019-07-31 21 04 28](https://user-images.githubusercontent.com/22067021/62262678-d20dbe00-b3d6-11e9-8894-0de2f1f706f5.gif)



### Todo (later):

- [ ] how do we move/scale the axes actor added by `add_axes_at_origin`?