### PR TITLE
Add more lighting controls for add_mesh

### DIFF
--- a/examples/02-plot/lighting.py
+++ b/examples/02-plot/lighting.py
@@ -1,0 +1,58 @@
+"""
+Lighting Controls
+~~~~~~~~~~~~~~~~~
+
+Control aspects of the rendered mesh's lighting such as Ambient, Diffuse,
+and Specular. These options only work if the ``lighting`` argument to
+``add_mesh`` is ``True`` (it's true by default).
+
+You can trun off all lighting by passing ``lighting=False`` to ``add_mesh``.
+"""
+# sphinx_gallery_thumbnail_number = 4
+import pyvista as pv
+from pyvista import examples
+
+mesh = examples.download_st_helens().warp_by_scalar()
+
+cpos = [(575848., 5128459., 22289.),
+        (562835.0, 5114981.5, 2294.5),
+        (-0.5, -0.5, 0.7)]
+
+###############################################################################
+# First, lets take a look at the mesh with default lighting conditions
+mesh.plot(cpos=cpos, show_scalar_bar=False)
+
+###############################################################################
+# What about with no lighting
+mesh.plot(lighting=False, cpos=cpos, show_scalar_bar=False)
+
+###############################################################################
+# Demonstration of the specular property
+p = pv.Plotter(shape=(1,2), window_size=[1500, 500])
+
+p.subplot(0,0)
+p.add_mesh(mesh, show_scalar_bar=False)
+p.add_text('No Specular')
+
+p.subplot(0,1)
+s = 1.0
+p.add_mesh(mesh, specular=s, show_scalar_bar=False)
+p.add_text('Specular of {}'.format(s))
+
+p.link_views()
+p.view_isometric()
+p.show(cpos=cpos)
+
+###############################################################################
+# Just specular
+mesh.plot(specular=0.5, cpos=cpos, show_scalar_bar=False)
+
+###############################################################################
+# Specular power
+mesh.plot(specular=0.5, specular_power=15,
+          cpos=cpos, show_scalar_bar=False)
+
+###############################################################################
+# Demonstration of all three in use
+mesh.plot(diffuse=0.5, specular=0.5, ambient=0.5,
+          cpos=cpos, show_scalar_bar=False)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -382,11 +382,10 @@ class BasePlotter(object):
                  reset_camera=None, scalar_bar_args=None, show_scalar_bar=None,
                  stitle=None, multi_colors=False, name=None, texture=None,
                  render_points_as_spheres=None, render_lines_as_tubes=False,
-                 smooth_shading=False, ambient=0.0, ambient_color='white',
-                 diffuse=1.0, diffuse_color='white',
-                 specular=0.0, specular_power=100.0, specular_color='white',
-                 nan_color=None, nan_opacity=1.0, loc=None, backface_culling=False,
-                 rgb=False, categories=False, use_transparency=False, **kwargs):
+                 smooth_shading=False, ambient=0.0, diffuse=1.0, specular=0.0,
+                 specular_power=100.0, nan_color=None, nan_opacity=1.0,
+                 loc=None, backface_culling=False, rgb=False, categories=False,
+                 use_transparency=False, **kwargs):
         """
         Adds any PyVista/VTK mesh or dataset that PyVista can wrap to the
         scene. This method using a mesh representation to view the surfaces
@@ -524,23 +523,14 @@ class BasePlotter(object):
             0 to 1 that reaches the actor when not directed at the
             light source emitted from the viewer.  Default 0.0
 
-        ambient_color : string or 3 item list, optional, defaults to white
-            Color used for ambient lighting
-
         diffuse : float, optional
             The diffuse lighting coefficient. Default 1.0
-
-        diffuse_color : string or 3 item list, optional, defaults to white
-            Color used for diffuse
 
         specular : float, optional
             The specular lighting coefficient. Default 0.0
 
         specular_power : float, optional
             The specular power. Bewteen 0.0 and 128.0
-
-        specular_color : string or 3 item list, optional, defaults to white
-            Color used for specular
 
         nan_color : string or 3 item list, optional, defaults to gray
             The color to use for all ``NaN`` values in the plotted scalar
@@ -933,12 +923,9 @@ class BasePlotter(object):
 
         prop.SetPointSize(point_size)
         prop.SetAmbient(ambient)
-        prop.SetAmbientColor(parse_color(ambient_color))
         prop.SetDiffuse(diffuse)
-        prop.SetDiffuseColor(parse_color(diffuse_color))
         prop.SetSpecular(specular)
         prop.SetSpecularPower(specular_power)
-        prop.SetSpecularColor(parse_color(specular_color))
 
         if smooth_shading:
             prop.SetInterpolationToPhong()


### PR DESCRIPTION
This adds controls for the specular and diffuse display properties in addition to ambient.

I tried setting the ambient, diffuse, and specular colors but I saw no affects so I'm not including those.

Example of Specular:

```py
import pyvista as pv
from pyvista import examples

mesh = examples.download_st_helens().warp_by_scalar()

p = pv.Plotter(notebook=False)
p.add_mesh(mesh, specular=1)
p.add_axes()
p.show()
```

![2019-07-31 23 30 53](https://user-images.githubusercontent.com/22067021/62268184-430ba080-b3ec-11e9-88bd-803b865d65ab.gif)

High ambient, low diffuse:

```py
p = pv.Plotter(notebook=False)
a = p.add_mesh(mesh, ambient=1, diffuse=0)
p.add_axes()
p.show()
```

![Screen Shot 2019-07-31 at 11 51 35 PM 1](https://user-images.githubusercontent.com/22067021/62268767-25d7d180-b3ee-11e9-9df8-815bf1d39c02.png)

