### PR TITLE
Resolve subplot indexing issues

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1500,8 +1500,15 @@ class BasePlotter(object):
         elif isinstance(loc, int):
             return loc
         elif isinstance(loc, collections.Iterable):
-            assert len(loc) == 2, '"loc" must contain two items'
-            return loc[0]*self.shape[0] + loc[1]
+            if not len(loc) == 2:
+                raise AssertionError('"loc" must contain two items')
+            index_row = loc[0]
+            index_column = loc[1]
+            if index_row < 0 or index_row >= self.shape[0]:
+                raise IndexError('Row index is out of range ({})'.format(self.shape[0]))
+            if index_column < 0 or index_column >= self.shape[1]:
+                raise IndexError('Column index is out of range ({})'.format(self.shape[1]))
+            return (index_row * (self.shape[0] - 1)) + index_column
 
     def index_to_loc(self, index):
         """Convert a 1D index location to the 2D location on the plotting grid
@@ -1752,20 +1759,24 @@ class BasePlotter(object):
         renderer = self.renderers[self._active_renderer_index]
         renderer.remove_bounds_axes()
 
-    def subplot(self, index_x, index_y):
+    def subplot(self, index_row, index_column):
         """
         Sets the active subplot.
 
         Parameters
         ----------
-        index_x : int
-            Index of the subplot to activate in the x direction.
+        index_row : int
+            Index of the subplot to activate along the rows.
 
-        index_y : int
-            Index of the subplot to activate in the y direction.
+        index_column : int
+            Index of the subplot to activate along the columns.
 
         """
-        self._active_renderer_index = self.loc_to_index((index_x, index_y))
+        if index_row < 0 or index_row >= self.shape[0]:
+            raise IndexError('Row index is out of range ({})'.format(self.shape[0]))
+        if index_column < 0 or index_column >= self.shape[1]:
+            raise IndexError('Column index is out of range ({})'.format(self.shape[1]))
+        self._active_renderer_index = self.loc_to_index((index_row, index_column))
 
     def link_views(self, views=0):
         """

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1508,7 +1508,9 @@ class BasePlotter(object):
                 raise IndexError('Row index is out of range ({})'.format(self.shape[0]))
             if index_column < 0 or index_column >= self.shape[1]:
                 raise IndexError('Column index is out of range ({})'.format(self.shape[1]))
-            return (index_row * (self.shape[0] - 1)) + index_column
+            sz = int(self.shape[0] * self.shape[1])
+            idxs = np.array([i for i in range(sz)], dtype=int).reshape(self.shape)
+            return idxs[index_row, index_column]
 
     def index_to_loc(self, index):
         """Convert a 1D index location to the 2D location on the plotting grid

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -535,6 +535,14 @@ def test_multi_renderers():
     plotter.add_mesh(pyvista.Cube())
     plotter.show()
 
+    with pytest.raises(IndexError):
+        # Test bad indices
+        plotter = pyvista.Plotter(shape=(1, 2), off_screen=OFF_SCREEN)
+        plotter.subplot(0,0)
+        plotter.add_mesh(pyvista.Sphere())
+        plotter.subplot(1,0)
+        plotter.add_mesh(pyvista.Cube())
+        plotter.show()
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_link_views():

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -515,6 +515,26 @@ def test_multi_renderers():
     plotter.update_bounds_axes()
     plotter.show()
 
+    # Test subplot indices (2 rows by 1 column)
+    plotter = pyvista.Plotter(shape=(2, 1), off_screen=OFF_SCREEN)
+    # First row
+    plotter.subplot(0,0)
+    plotter.add_mesh(pyvista.Sphere())
+    # Second row
+    plotter.subplot(1,0)
+    plotter.add_mesh(pyvista.Cube())
+    plotter.show()
+
+    # Test subplot indices (1 row by 2 columns)
+    plotter = pyvista.Plotter(shape=(1, 2), off_screen=OFF_SCREEN)
+    # First column
+    plotter.subplot(0,0)
+    plotter.add_mesh(pyvista.Sphere())
+    # Second column
+    plotter.subplot(0,1)
+    plotter.add_mesh(pyvista.Cube())
+    plotter.show()
+
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_link_views():


### PR DESCRIPTION
Resolve #325.

This ensures that the indices used when calling `plotter.subplot()` correspond to the plotter's shape.