### PR TITLE
Labelled Scalar bars

### DIFF
--- a/examples/02-plot/scalar-bars.py
+++ b/examples/02-plot/scalar-bars.py
@@ -74,3 +74,12 @@ sargs = dict(
 p = pv.Plotter()
 p.add_mesh(mesh, scalar_bar_args=sargs)
 p.show()
+
+
+###############################################################################
+# Labelling values outside of the scalar range
+p = pv.Plotter()
+p.add_mesh(mesh, clim=[1000, 2000],
+           below_color='blue', above_color='red',
+           scalar_bar_args=sargs)
+p.show()

--- a/examples/02-plot/scalar-bars.py
+++ b/examples/02-plot/scalar-bars.py
@@ -83,3 +83,18 @@ p.add_mesh(mesh, clim=[1000, 2000],
            below_color='blue', above_color='red',
            scalar_bar_args=sargs)
 p.show()
+
+
+###############################################################################
+# Annotate values of interest using a dictionary. The key of the dictionary
+# will be the annotation, and the value will be the float value to label.
+
+# Make a dictionary for the annotations
+annotations = {
+    "High" : 2300,
+    'Cutoff value': 800,
+}
+
+p = pv.Plotter()
+p.add_mesh(mesh, scalars='Elevation', annotations=annotations)
+p.show()

--- a/examples/02-plot/scalar-bars.py
+++ b/examples/02-plot/scalar-bars.py
@@ -87,12 +87,12 @@ p.show()
 
 ###############################################################################
 # Annotate values of interest using a dictionary. The key of the dictionary
-# will be the annotation, and the value will be the float value to label.
+# must be the value to annotate, and the value must be the string label.
 
 # Make a dictionary for the annotations
 annotations = {
-    "High" : 2300,
-    'Cutoff value': 800,
+    2300 : "High",
+    805.3 : "Cutoff value",
 }
 
 p = pv.Plotter()

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -214,7 +214,7 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters):
                 continue
             # get the scalar if availble
             arr = get_scalar(data, name)
-            if arr is None:
+            if arr is None or not np.issubdtype(arr.dtype, np.number):
                 continue
             tmi, tma = np.nanmin(arr), np.nanmax(arr)
             if tmi < mini:

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -27,6 +27,8 @@ def make_mapper(mapper_class):
         def scalar_range(self, clim):
             if hasattr(self, 'SetScalarRange'):
                 self.SetScalarRange(*clim)
+            if self.lookup_table is not None:
+                self.lookup_table.SetRange(*clim)
             self._scalar_range = clim
 
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -559,9 +559,9 @@ class BasePlotter(object):
             automatically set the scalar bar ``above_label`` to ``'Above'``
 
         annotations : dict, optional
-            Pass a dictionary of annotations. Keys are the string annotations
-            and values are float values in the scalar range to annotate on the
-            scalar bar.
+            Pass a dictionary of annotations. Keys are the float values in the
+            scalar range to annotate on the scalar bar and the values are the
+            the string annotations.
 
         Returns
         -------
@@ -865,8 +865,8 @@ class BasePlotter(object):
                 table.SetAnnotations(convert_array(values), convert_string_array(cats))
 
             if isinstance(annotations, dict):
-                for key, val in annotations.items():
-                    table.SetAnnotation(float(val), key)
+                for val, anno in annotations.items():
+                    table.SetAnnotation(float(val), anno)
 
             # Set scalar range
             if clim is None:
@@ -1121,9 +1121,9 @@ class BasePlotter(object):
             automatically set the scalar bar ``above_label`` to ``'Above'``
 
         annotations : dict, optional
-            Pass a dictionary of annotations. Keys are the string annotations
-            and values are float values in the scalar range to annotate on the
-            scalar bar.
+            Pass a dictionary of annotations. Keys are the float values in the
+            scalar range to annotate on the scalar bar and the values are the
+            the string annotations.
 
         Returns
         -------
@@ -1282,7 +1282,8 @@ class BasePlotter(object):
         # table.SetNanColor(nan_color) # NaN's are chopped out with current implementation
         if above_color:
             table.SetUseAboveRangeColor(True)
-            table.SetAboveRangeColor(*parse_color(above_color), 1)
+            c = parse_color(above_color)
+            table.SetAboveRangeColor(c[0], c[1], c[2], 1)
             scalar_bar_args.setdefault('above_label', 'Above')
         if below_color:
             table.SetUseBelowRangeColor(True)
@@ -1290,9 +1291,8 @@ class BasePlotter(object):
             scalar_bar_args.setdefault('below_label', 'Below')
 
         if isinstance(annotations, dict):
-            avals = np.array(annotations.values())
-            alabels = np.array(annotations.keys())
-            table.SetAnnotations(convert_array(avals), convert_string_array(alabels))
+            for val, anno in annotations.items():
+                table.SetAnnotation(float(val), anno)
 
         if cmap is None: # grab alias for cmaps: colormap
             cmap = kwargs.get('colormap', None)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -866,7 +866,7 @@ class BasePlotter(object):
 
             if isinstance(annotations, dict):
                 for val, anno in annotations.items():
-                    table.SetAnnotation(float(val), anno)
+                    table.SetAnnotation(float(val), str(anno))
 
             # Set scalar range
             if clim is None:
@@ -1275,7 +1275,7 @@ class BasePlotter(object):
 
         if isinstance(annotations, dict):
             for val, anno in annotations.items():
-                table.SetAnnotation(float(val), anno)
+                table.SetAnnotation(float(val), str(anno))
 
         if cmap is None: # grab alias for cmaps: colormap
             cmap = kwargs.get('colormap', None)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1001,7 +1001,8 @@ class BasePlotter(object):
                    loc=None, backface_culling=False, multi_colors=False,
                    blending='composite', mapper='fixed_point',
                    stitle=None, scalar_bar_args=None, show_scalar_bar=None,
-                   below_color=None, above_color=None,**kwargs):
+                   below_color=None, above_color=None, annotations=None,
+                   **kwargs):
         """
         Adds a volume, rendered using a fixed point ray cast mapper by default.
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -371,7 +371,7 @@ class BasePlotter(object):
                  specular_power=100.0, nan_color=None, nan_opacity=1.0,
                  loc=None, backface_culling=False, rgb=False, categories=False,
                  use_transparency=False, below_color=None, above_color=None,
-                 **kwargs):
+                 annotations=None, **kwargs):
         """
         Adds any PyVista/VTK mesh or dataset that PyVista can wrap to the
         scene. This method using a mesh representation to view the surfaces
@@ -557,6 +557,11 @@ class BasePlotter(object):
         above_color : string or 3 item list, optional
             Solid color for values below the scalar range (``clim``). This will
             automatically set the scalar bar ``above_label`` to ``'Above'``
+
+        annotations : dict, optional
+            Pass a dictionary of annotations. Keys are the string annotations
+            and values are float values in the scalar range to annotate on the
+            scalar bar.
 
         Returns
         -------
@@ -859,6 +864,10 @@ class BasePlotter(object):
             if _using_labels:
                 table.SetAnnotations(convert_array(values), convert_string_array(cats))
 
+            if isinstance(annotations, dict):
+                for key, val in annotations.items():
+                    table.SetAnnotation(float(val), key)
+
             # Set scalar range
             if clim is None:
                 clim = [np.nanmin(scalars), np.nanmax(scalars)]
@@ -1110,6 +1119,11 @@ class BasePlotter(object):
             Solid color for values below the scalar range (``clim``). This will
             automatically set the scalar bar ``above_label`` to ``'Above'``
 
+        annotations : dict, optional
+            Pass a dictionary of annotations. Keys are the string annotations
+            and values are float values in the scalar range to annotate on the
+            scalar bar.
+
         Returns
         -------
         actor: vtk.vtkVolume
@@ -1273,6 +1287,11 @@ class BasePlotter(object):
             table.SetUseBelowRangeColor(True)
             table.SetBelowRangeColor(*parse_color(below_color), 1)
             scalar_bar_args.setdefault('below_label', 'Below')
+
+        if isinstance(annotations, dict):
+            avals = np.array(annotations.values())
+            alabels = np.array(annotations.keys())
+            table.SetAnnotations(convert_array(avals), convert_string_array(alabels))
 
         if cmap is None: # grab alias for cmaps: colormap
             cmap = kwargs.get('colormap', None)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -880,11 +880,11 @@ class BasePlotter(object):
             table.SetNanColor(nan_color)
             if above_color:
                 table.SetUseAboveRangeColor(True)
-                table.SetAboveRangeColor(*parse_color(above_color), 1)
+                table.SetAboveRangeColor(*parse_color(above_color, opacity=1))
                 scalar_bar_args.setdefault('above_label', 'Above')
             if below_color:
                 table.SetUseBelowRangeColor(True)
-                table.SetBelowRangeColor(*parse_color(below_color), 1)
+                table.SetBelowRangeColor(*parse_color(below_color, opacity=1))
                 scalar_bar_args.setdefault('below_label', 'Below')
 
             if cmap is not None:

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1001,8 +1001,7 @@ class BasePlotter(object):
                    loc=None, backface_culling=False, multi_colors=False,
                    blending='composite', mapper='fixed_point',
                    stitle=None, scalar_bar_args=None, show_scalar_bar=None,
-                   below_color=None, above_color=None, annotations=None,
-                   **kwargs):
+                   annotations=None, **kwargs):
         """
         Adds a volume, rendered using a fixed point ray cast mapper by default.
 
@@ -1112,14 +1111,6 @@ class BasePlotter(object):
             the scalar array used to color the mesh.
             To create a bar with no title, use an empty string (i.e. '').
 
-        below_color : string or 3 item list, optional
-            Solid color for values below the scalar range (``clim``). This will
-            automatically set the scalar bar ``below_label`` to ``'Below'``
-
-        above_color : string or 3 item list, optional
-            Solid color for values below the scalar range (``clim``). This will
-            automatically set the scalar bar ``above_label`` to ``'Above'``
-
         annotations : dict, optional
             Pass a dictionary of annotations. Keys are the float values in the
             scalar range to annotate on the scalar bar and the values are the
@@ -1228,7 +1219,7 @@ class BasePlotter(object):
             scalars = np.asarray(scalars)
 
         if not np.issubdtype(scalars.dtype, np.number):
-            raise TypeError('Non-numeric scalars are currently not supported for plotting.')
+            raise TypeError('Non-numeric scalars are currently not supported for volume rendering.')
 
 
         if scalars.ndim != 1:
@@ -1280,15 +1271,7 @@ class BasePlotter(object):
         # Set colormap and build lookup table
         table = vtk.vtkLookupTable()
         # table.SetNanColor(nan_color) # NaN's are chopped out with current implementation
-        if above_color:
-            table.SetUseAboveRangeColor(True)
-            c = parse_color(above_color)
-            table.SetAboveRangeColor(c[0], c[1], c[2], 1)
-            scalar_bar_args.setdefault('above_label', 'Above')
-        if below_color:
-            table.SetUseBelowRangeColor(True)
-            table.SetBelowRangeColor(*parse_color(below_color), 1)
-            scalar_bar_args.setdefault('below_label', 'Below')
+        # above/below colors not supported with volume rendering
 
         if isinstance(annotations, dict):
             for val, anno in annotations.items():

--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -36,7 +36,7 @@ rcParams = {
         'width' : 0.6,
         'height' : 0.08,
         'position_x' : 0.35,
-        'position_y' : 0.02,
+        'position_y' : 0.05,
     },
     'colorbar_vertical' : {
         'width' : 0.08,

--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -106,7 +106,7 @@ def set_plot_theme(theme):
 
 
 
-def parse_color(color):
+def parse_color(color, opacity=None):
     """Parses color into a vtk friendly rgb list.
     Values returned will be between 0 and 1.
     """
@@ -126,6 +126,8 @@ def parse_color(color):
         color='w'
         color=[1, 1, 1]
         color='#FFFFFF'""".format(color))
+    if opacity is not None and isinstance(opacity, (float, int)):
+        color = [color[0], color[1], color[2], opacity]
     return color
 
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -749,6 +749,9 @@ def test_user_annotations_scalar_bar():
     p = pyvista.Plotter(off_screen=OFF_SCREEN)
     p.add_mesh(examples.load_uniform(), annotations={100.:'yum'})
     p.show()
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
+    p.add_volume(examples.load_uniform(), annotations={100.:'yum'})
+    p.show()
 
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -742,3 +742,23 @@ def test_above_below_scalar_range_annotations():
     p.add_mesh(examples.load_uniform(), clim=[100, 500], cmap='viridis',
            below_color='blue', above_color='red')
     p.show()
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+def test_annotated_scalar_bar():
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
+    p.add_mesh(examples.load_uniform(), annotations=dict(yum=100))
+    p.show()
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+def test_plot_string_array():
+    mesh = examples.load_uniform()
+    labels = np.empty(mesh.n_cells, dtype='<U10')
+    labels[:] = 'High'
+    labels[mesh['Spatial Cell Data'] < 300] = 'Medium'
+    labels[mesh['Spatial Cell Data'] < 100] = 'Low'
+    mesh['labels'] = labels
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
+    p.add_mesh(mesh, scalars='labels')
+    p.show()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -745,9 +745,9 @@ def test_above_below_scalar_range_annotations():
 
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
-def test_annotated_scalar_bar():
+def test_user_annotations_scalar_bar():
     p = pyvista.Plotter(off_screen=OFF_SCREEN)
-    p.add_mesh(examples.load_uniform(), annotations=dict(yum=100))
+    p.add_mesh(examples.load_uniform(), annotations={100.:'yum'})
     p.show()
 
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -734,3 +734,11 @@ def test_closing_and_mem_cleanup():
                 p.add_mesh(pyvista.Sphere(radius=k))
             p.show()
         pyvista.close_all()
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+def test_above_below_scalar_range_annotations():
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
+    p.add_mesh(examples.load_uniform(), clim=[100, 500], cmap='viridis',
+           below_color='blue', above_color='red')
+    p.show()


### PR DESCRIPTION
Resolve #298 
Relevant to #200 and https://github.com/pyvista/pyvista-support/issues/25

This PR updates functionality with the scalar bar to support annotations and categorical, labeled scalar bars.



## Annotatations

Now you can annotate specific values, NaN values, and values above/below the scalar range

Set up:
```py
import pyvista as pv
from pyvista import examples
pv.set_plot_theme('doc')
import numpy as np

mesh = examples.download_st_helens().warp_by_scalar().extract_surface()
```

### Below/Above Range

When setting the scalar bar range via the `clim` argument, you can pass `below_color` and `above_color` to color values below/above that range as desired:

```py
p = pv.Plotter()
p.add_mesh(mesh, clim=[1000, 2000],
           below_color='blue', above_color='red',)
p.show()
```

![sphx_glr_scalar-bars_004](https://user-images.githubusercontent.com/22067021/62406603-c6073500-b56b-11e9-9d1e-41a06af600bd.png)


### NaN values

Label the `nan_color` by passing `nan_annotation=True` in the `scalar_bar_args`

```py
inds = np.logical_and(mesh['Elevation'] < 1500, mesh['Elevation'] > 1300)
mesh['withnans'] = mesh['Elevation'].copy()
mesh['withnans'][inds] = np.nan

mesh.plot(scalars='withnans', nan_color='grey', 
          scalar_bar_args=dict(nan_annotation=True))
```

![download](https://user-images.githubusercontent.com/22067021/62406698-e5eb2880-b56c-11e9-9533-4d9874d9eb90.png)


### Specific values

Pass a set of annotations as a dictionary (key is label, value it float number to annotate) to label specific values on the scalar bar:

```py
# Make a dictionary for the annotations
annotations = {
    2300 : "High",
    805.3 : "Cutoff value",
}

p = pv.Plotter()
p.add_mesh(mesh, scalars='Elevation', annotations=annotations)
p.show()
```
![sphx_glr_scalar-bars_005](https://user-images.githubusercontent.com/22067021/62406612-e0d9a980-b56b-11e9-8d35-f8d568dd95a3.png)



## Categorical Arrays (string arrays)

Now automatically plot and label string categorical data arrays (see #298)

(We need a better example for this)

```py
# Creste string array
nmag = np.sum(mesh.compute_normals()['Normals'], axis=1)
labels = np.empty(len(nmag), dtype='<U10')
labels[:] = 'High'
labels[nmag < 1] = 'Medium'
labels[nmag < 0.7] = 'Low'

mesh['labels'] = labels
mesh.plot(scalars='labels')
```

![download](https://user-images.githubusercontent.com/22067021/62406629-2bf3bc80-b56c-11e9-9f43-7db7cb3f1124.png)