### PR TITLE
Merge filter and __add__

### DIFF
--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -448,6 +448,10 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters):
         return MultiBlock.__repr__(self)
 
 
+    def __len__(self):
+        return self.n_blocks
+
+
     def copy_meta_from(self, ido):
         """Copies pyvista meta data onto this object from another object"""
         # Note that `pyvista.MultiBlock` datasets currently don't have any meta.

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2016,6 +2016,12 @@ class PolyDataFilters(DataSetFilters):
             return mesh
 
 
+    def __add__(poly_data, mesh):
+        if not isinstance(mesh, vtk.vtkPolyData):
+            return DataSetFilters.__add__(poly_data, mesh)
+        return PolyDataFilters.boolean_add(poly_data, mesh)
+
+
     def boolean_union(poly_data, mesh, inplace=False):
         """
         Combines two meshes and attempts to create a manifold mesh.

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1777,7 +1777,7 @@ class DataSetFilters(object):
             return mesh
 
 
-    def merge(dataset, grid=None, merge_points=False, inplace=False,
+    def merge(dataset, grid=None, merge_points=True, inplace=False,
               main_has_priority=True):
         """
         Join one or many other grids to this grid.  Grid is updated

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -465,3 +465,16 @@ def test_decimate_boundary():
     mesh = examples.load_uniform()
     boundary = mesh.decimate_boundary()
     assert boundary.n_points
+
+
+def test_merge_general():
+    mesh = examples.load_uniform()
+    thresh = mesh.threshold_percent([0.2, 0.5]) # unstructured grid
+    con = mesh.contour() # poly data
+    merged = thresh + con
+    assert isinstance(merged, pyvista.UnstructuredGrid)
+    merged = con + thresh
+    assert isinstance(merged, pyvista.UnstructuredGrid)
+    # Pure PolyData inputs should yield poly data output
+    merged = mesh.extract_surface() + con
+    assert isinstance(merged, pyvista.PolyData)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -159,7 +159,7 @@ def test_merge():
     grid.points[:, 0] += 1
     unmerged = grid.merge(beam, inplace=False, merge_points=False)
 
-    grid.merge(beam, inplace=True)
+    grid.merge(beam, inplace=True, merge_points=True)
     assert grid.n_points > beam.n_points
     assert grid.n_points < unmerged.n_points
 
@@ -170,7 +170,7 @@ def test_merge_not_main():
     unmerged = grid.merge(beam, inplace=False, merge_points=False,
                           main_has_priority=False)
 
-    grid.merge(beam, inplace=True)
+    grid.merge(beam, inplace=True, merge_points=True)
     assert grid.n_points > beam.n_points
     assert grid.n_points < unmerged.n_points
 
@@ -182,7 +182,7 @@ def test_merge_list():
     grid_b = beam.copy()
     grid_b.points[:, 1] += 1
 
-    grid_a.merge([beam, grid_b], inplace=True)
+    grid_a.merge([beam, grid_b], inplace=True, merge_points=True)
     assert grid_a.n_points > beam.n_points
 
 


### PR DESCRIPTION
Resolve #321 and resolve #356  by refactoring the `merge` filter and implementing `__add__` method for all PyVista mesh/grid types. Other operators types will not be implemented.

This also implements `__len__` for `MultiBlock` datasets.


### Example

```py
import pyvista as pv
from pyvista import examples

mesh = examples.download_st_helens().warp_by_scalar()

merged = mesh.clip('x') + mesh.clip('-x').contour()

merged.plot()
```
![download](https://user-images.githubusercontent.com/22067021/62408547-f9f05380-b587-11e9-88be-a2001219c381.png)