### PR TITLE
Add cell quality, gradient, and surface clip filters

### DIFF
--- a/examples/01-filter/clipping.py
+++ b/examples/01-filter/clipping.py
@@ -4,8 +4,10 @@ Clipping Meshes
 
 Clip/cut any dataset using using planes, boxes, or surface meshes.
 """
+# sphinx_gallery_thumbnail_number = 4
 import pyvista as pv
 from pyvista import examples
+import numpy as np
 
 ###############################################################################
 # Clip with Plane

--- a/examples/01-filter/clipping.py
+++ b/examples/01-filter/clipping.py
@@ -1,0 +1,79 @@
+"""
+Clipping Meshes
+~~~~~~~~~~~~~~~
+
+Clip/cut any dataset using using planes, boxes, or surface meshes.
+"""
+import pyvista as pv
+from pyvista import examples
+
+###############################################################################
+# Clip with Plane
+# +++++++++++++++
+#
+# Clip any dataset by a user defined plane using the
+# :func:`pyvista.DataSetFilters.clip` filter
+dataset = examples.download_bunny_coarse()
+clipped = dataset.clip('y', invert=False)
+
+p = pv.Plotter()
+p.add_mesh(dataset, style='wireframe' ,color='blue', label='Input')
+p.add_mesh(clipped, label='Clipped')
+p.add_legend()
+p.camera_position = [(0.24, 0.32, 0.7),
+                     (0.02, 0.03, -0.02),
+                     (-0.12, 0.93, -0.34)]
+p.show()
+
+
+###############################################################################
+# Clip with Box
+# +++++++++++++
+#
+# Clip any dataset by a solid box using the
+# :func:`pyvista.DataSetFilters.clip_box` filter
+dataset = examples.download_office()
+
+bounds = [2,4.5, 2,4.5, 1,3]
+clipped = dataset.clip_box(bounds)
+
+p = pv.Plotter()
+p.add_mesh(dataset, style='wireframe' ,color='blue', label='Input')
+p.add_mesh(clipped, label='Clipped')
+p.add_legend()
+p.show()
+
+
+###############################################################################
+# Clip with Surface
+# +++++++++++++++++
+#
+# Clip any PyVista dataset by a :class:`pyvista.PolyData` surface mesh using
+# the :func:`pyvista.DataSet.Filters.clip_surface` filter.
+surface = pv.Cone(direction=(0,0,-1), height=3.0, radius=1,
+                  resolution=50, capping=False)
+
+# Make a gridded dataset
+n = 51
+xx = yy = zz = 1 - np.linspace(0, n, n) * 2 / (n-1)
+dataset = pv.RectilinearGrid(xx, yy, zz)
+
+# Preview the problem
+p = pv.Plotter()
+p.add_mesh(surface, color='w', label='Surface')
+p.add_mesh(dataset, color='gold', show_edges=True,
+           opacity=0.75, label='To Clip')
+p.add_legend()
+p.show()
+
+###############################################################################
+# Clip the rectilinear grid dataset using the :class:`pyvista.PolyData`
+# surface mesh:
+clipped = dataset.clip_surface(surface, invert=False)
+
+# Visualize the results
+p = pv.Plotter()
+p.add_mesh(surface, color='w', opacity=0.75, label='Surface')
+p.add_mesh(clipped, color='gold', show_edges=True, label="clipped")
+p.add_legend()
+p.show()

--- a/examples/01-filter/clipping.py
+++ b/examples/01-filter/clipping.py
@@ -79,3 +79,19 @@ p.add_mesh(surface, color='w', opacity=0.75, label='Surface')
 p.add_mesh(clipped, color='gold', show_edges=True, label="clipped")
 p.add_legend()
 p.show()
+
+
+###############################################################################
+# Here is another example of clipping a mesh by a surface. This time, we'll
+# generate a :class:`pyvista.UniformGrid` around a topography surface and then
+# clip that grid using the surface to create a closed 3D model of the surface
+surface = examples.load_random_hills()
+
+# Create a grid around that surface
+grid = pv.create_grid(surface)
+
+# Clip the grid using the surface
+model = grid.clip_surface(surface)
+
+# Compute height nd display it
+model.elevation().plot()

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -184,7 +184,8 @@ class DataSetFilters(object):
         Parameters
         ----------
         surface : pyvista.PolyData
-            The PolyData surface mesh to use as a clipping function.
+            The PolyData surface mesh to use as a clipping function. If this
+            mesh is not PolyData, the external surface will be extracted.
 
         invert : bool
             Flag on whether to flip/invert the clip
@@ -200,7 +201,7 @@ class DataSetFilters(object):
             output clipped mesh.
         """
         if not isinstance(surface, vtk.vtkPolyData):
-            raise TypeError('`surface` mesh must be PolyData, not ({})'.format(type(surface)))
+            surface = DataSetFilters.extract_surface(surface)
         function = vtk.vtkImplicitPolyDataDistance()
         function.SetInput(surface)
         if compute_distance:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -465,3 +465,18 @@ def test_decimate_boundary():
     mesh = examples.load_uniform()
     boundary = mesh.decimate_boundary()
     assert boundary.n_points
+
+
+
+def test_compute_cell_quality():
+    mesh = pyvista.ParametricEllipsoid().decimate(0.8)
+    qual = mesh.compute_cell_quality()
+    assert 'CellQuality' in qual.scalar_names
+
+
+def test_compute_gradients():
+    mesh = examples.load_random_hills()
+    grad = mesh.compute_gradient()
+    assert 'gradient' in grad.scalar_names
+    assert np.shape(grad['gradient'])[0] == mesh.n_points
+    assert np.shape(grad['gradient'])[1] == 3

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -29,6 +29,7 @@ def test_clip_filter():
     output = COMPOSITE.clip(normal=normals[0], invert=False)
     assert output.n_blocks == COMPOSITE.n_blocks
 
+
 def test_clip_box():
     for i, dataset in enumerate(DATASETS):
         clp = dataset.clip_box(invert=True)
@@ -44,6 +45,16 @@ def test_clip_box():
     # Now test composite data structures
     output = COMPOSITE.clip_box(invert=False)
     assert output.n_blocks == COMPOSITE.n_blocks
+
+
+def test_clip_surface():
+    surface = pyvista.Cone(direction=(0,0,-1),
+                  height=3.0, radius=1, resolution=50, )
+    xx = yy = zz = 1 - np.linspace(0, 51, 51) * 2 / 50
+    dataset = pyvista.RectilinearGrid(xx, yy, zz)
+    clipped = dataset.clip_surface(surface, invert=False)
+    assert clipped.n_points < dataset.n_points
+
 
 def test_slice_filter():
     """This tests the slice filter on all datatypes avaialble filters"""


### PR DESCRIPTION
New filters:

- `.clip_surface()`
- `.compute_gradient()`
- `.compute_cell_quality()`


## Example of Clip with Surface filter

```py
import pyvista as pv
import numpy as np

surface = pv.Cone(direction=(0,0,-1), height=3.0, radius=1,
                  resolution=50, capping=False)

# Make a gridded dataset
n = 51
xx = yy = zz = 1 - np.linspace(0, n, n) * 2 / (n-1)
dataset = pv.RectilinearGrid(xx, yy, zz)

# Clip grid using poly data surface
clipped = dataset.clip_surface(surface, invert=False)

# Visualize the results
p = pv.Plotter()
p.add_mesh(surface, color='w', opacity=0.75, label='Surface')
p.add_mesh(clipped, color='gold', show_edges=True, label="clipped")
p.add_legend()
p.show()
```

![download](https://user-images.githubusercontent.com/22067021/62486690-2f11c700-b77d-11e9-9daf-38b878e2618b.png)