### PR TITLE
Switch interpolate_before_map to True

### DIFF
--- a/examples/02-plot/interpolate-before-map.py
+++ b/examples/02-plot/interpolate-before-map.py
@@ -110,10 +110,10 @@ dargs = dict(scalars='RTData', cmap='rainbow', show_edges=True, n_colors=8)
 
 p = pv.Plotter(shape=(1,2))
 p.add_mesh(wavelet, interpolate_before_map=False,
-           stitle='RTData - not mapped', **dargs)
+           stitle='RTData - not interpolated', **dargs)
 p.subplot(0,1)
 p.add_mesh(wavelet, interpolate_before_map=True,
-           stitle='RTData - mapped', **dargs)
+           stitle='RTData - interpolated', **dargs)
 p.link_views()
 p.camera_position = [(55., 16, 31),
                      (-5.0, 0.0, 0.0),

--- a/examples/02-plot/interpolate-before-map.py
+++ b/examples/02-plot/interpolate-before-map.py
@@ -39,10 +39,10 @@ dargs = dict(scalars='Elevation', cmap='rainbow', show_edges=True)
 
 p = pv.Plotter(shape=(1,2))
 p.add_mesh(cyl, interpolate_before_map=False,
-           stitle='Elevation - not mapped', **dargs)
+           stitle='Elevation - not interpolated', **dargs)
 p.subplot(0,1)
 p.add_mesh(cyl, interpolate_before_map=True,
-           stitle='Elevation - mapped', **dargs)
+           stitle='Elevation - interpolated', **dargs)
 p.link_views()
 p.camera_position = [(-1.67, -5.10, 2.06),
                      (0.0, 0.0, 0.0),
@@ -63,10 +63,10 @@ dargs = dict(scalars='Elevation', cmap='rainbow', show_edges=True,
 
 p = pv.Plotter(shape=(1,2))
 p.add_mesh(cyl, interpolate_before_map=False,
-           stitle='Elevation - not mapped', **dargs)
+           stitle='Elevation - not interpolated', **dargs)
 p.subplot(0,1)
 p.add_mesh(cyl, interpolate_before_map=True,
-           stitle='Elevation - mapped', **dargs)
+           stitle='Elevation - interpolated', **dargs)
 p.link_views()
 p.camera_position = [(-1.67, -5.10, 2.06),
                      (0.0, 0.0, 0.0),
@@ -89,10 +89,10 @@ dargs = dict(scalars='RTData', cmap='rainbow', show_edges=True)
 
 p = pv.Plotter(shape=(1,2))
 p.add_mesh(wavelet, interpolate_before_map=False,
-           stitle='RTData - not mapped', **dargs)
+           stitle='RTData - not interpolated', **dargs)
 p.subplot(0,1)
 p.add_mesh(wavelet, interpolate_before_map=True,
-           stitle='RTData - mapped', **dargs)
+           stitle='RTData - interpolated', **dargs)
 p.link_views()
 p.camera_position = [(55., 16, 31),
                      (-5.0, 0.0, 0.0),

--- a/examples/02-plot/interpolate-before-map.py
+++ b/examples/02-plot/interpolate-before-map.py
@@ -1,0 +1,133 @@
+"""
+Interpolate Before Mapping
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``add_mesh`` function has an ``interpolate_before_map`` argument - this
+affects the way scalar data is visualized with colors.
+The effect can of this can vary depending on the dataset's topology and the
+chosen colormap.
+
+This example serves to demo the difference and why we've chosen to enable this
+by default.
+
+For more details, please see `this blog post <https://blog.kitware.com/what-is-interpolatescalarsbeforemapping-in-vtk/>`_
+"""
+# sphinx_gallery_thumbnail_number = 4
+import pyvista as pv
+
+###############################################################################
+# Meshes are colored by the data on their nodes or cells - when coloring a mesh
+# by data on its nodes, the values must be interpolated across the faces of
+# cells. The process by which those scalars are interpolated is critical.
+# If the ``interpolate_before_map`` is left off, the color mapping occurs at
+# polygon points and  colors are interpolated, which is generally less accurate
+# whereas if the ``interpolate_before_map`` is on, then the scalars will be
+# interpolated across the topology of the dataset which is more accurate.
+#
+# To summarize, when ``interpolate_before_map`` is off, the colors are
+# interpolated after rendering and when ``interpolate_before_map`` is on, the
+# scalars are interpolated across the mesh and those values are mapped to
+# colors.
+#
+# So lets take a look at the difference:
+
+# Load a cylider which has cells with a wide spread
+cyl = pv.Cylinder(direction=(0,0,1), height=2).elevation()
+
+# Common display argument to make sure all else is constant
+dargs = dict(scalars='Elevation', cmap='rainbow', show_edges=True)
+
+p = pv.Plotter(shape=(1,2))
+p.add_mesh(cyl, interpolate_before_map=False,
+           stitle='Elevation - not mapped', **dargs)
+p.subplot(0,1)
+p.add_mesh(cyl, interpolate_before_map=True,
+           stitle='Elevation - mapped', **dargs)
+p.link_views()
+p.camera_position = [(-1.67, -5.10, 2.06),
+                     (0.0, 0.0, 0.0),
+                     (0.00, 0.37, 0.93)]
+p.show()
+
+###############################################################################
+# Shown in the figure above, when not interpolating the scalars before mapping,
+# the colors (RGB values, not scalars) are interpolated between the vertices by
+# the underlying graphics library (OpenGL), and the colors shown are not
+# accurate.
+#
+# The same interpolation effect occurs for wireframe visualization too:
+
+# Common display argument to make sure all else is constant
+dargs = dict(scalars='Elevation', cmap='rainbow', show_edges=True,
+             style='wireframe')
+
+p = pv.Plotter(shape=(1,2))
+p.add_mesh(cyl, interpolate_before_map=False,
+           stitle='Elevation - not mapped', **dargs)
+p.subplot(0,1)
+p.add_mesh(cyl, interpolate_before_map=True,
+           stitle='Elevation - mapped', **dargs)
+p.link_views()
+p.camera_position = [(-1.67, -5.10, 2.06),
+                     (0.0, 0.0, 0.0),
+                     (0.00, 0.37, 0.93)]
+p.show()
+
+###############################################################################
+# The cylider mesh above is a great example dataset for this as it has a wide
+# spread between the vertices (points are only at the top and bottom of the
+# cylinder) which means high surface are of the mesh has to be interpolated.
+#
+# However, most meshes don't have such a wide spread and the effects of
+# color interpolating are harder to notice. Let's take a look at a wavelet
+# example and try to figure out how the ``interpolate_before_map`` option
+# affects its rendering.
+wavelet = pv.Wavelet().clip('x')
+
+# Common display argument to make sure all else is constant
+dargs = dict(scalars='RTData', cmap='rainbow', show_edges=True)
+
+p = pv.Plotter(shape=(1,2))
+p.add_mesh(wavelet, interpolate_before_map=False,
+           stitle='RTData - not mapped', **dargs)
+p.subplot(0,1)
+p.add_mesh(wavelet, interpolate_before_map=True,
+           stitle='RTData - mapped', **dargs)
+p.link_views()
+p.camera_position = [(55., 16, 31),
+                     (-5.0, 0.0, 0.0),
+                     (-0.22, 0.97, -0.09)]
+p.show()
+
+###############################################################################
+# This time is pretty difficult to notice the differences - they are there,
+# subtle, but present. The differences become more apperant when we decrease
+# the number of colors in colormap.
+# Let's take a look at the differences when using eight discrete colors via
+# the ``n_colors`` argument:
+
+dargs = dict(scalars='RTData', cmap='rainbow', show_edges=True, n_colors=8)
+
+p = pv.Plotter(shape=(1,2))
+p.add_mesh(wavelet, interpolate_before_map=False,
+           stitle='RTData - not mapped', **dargs)
+p.subplot(0,1)
+p.add_mesh(wavelet, interpolate_before_map=True,
+           stitle='RTData - mapped', **dargs)
+p.link_views()
+p.camera_position = [(55., 16, 31),
+                     (-5.0, 0.0, 0.0),
+                     (-0.22, 0.97, -0.09)]
+p.show()
+
+###############################################################################
+# Left, ``interpolate_before_map`` OFF.  Right, ``interpolate_before_map`` ON.
+#
+# Now that is much more compelling! On the right, the contours of the scalar
+# field are visible, but on the left, the contours are obscured due to the color
+# interpolation by OpenGL. In both cases, the colors at the vertices are the
+# same, the difference is how color is assigned between the vertices.
+#
+# In our opinion, color interpolation is not a preffered default for scientific
+# visualization and is why we have chosen to set the ``interpolate_before_map``
+# flag to ``True``.

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -363,7 +363,7 @@ class BasePlotter(object):
                  clim=None, show_edges=None, edge_color=None,
                  point_size=5.0, line_width=None, opacity=1.0,
                  flip_scalars=False, lighting=None, n_colors=256,
-                 interpolate_before_map=False, cmap=None, label=None,
+                 interpolate_before_map=True, cmap=None, label=None,
                  reset_camera=None, scalar_bar_args=None, show_scalar_bar=None,
                  stitle=None, multi_colors=False, name=None, texture=None,
                  render_points_as_spheres=None, render_lines_as_tubes=False,
@@ -450,8 +450,9 @@ class BasePlotter(object):
             The scalar bar will also have this many colors.
 
         interpolate_before_map : bool, optional
-            Enabling makes for a smoother scalar display.  Default
-            False
+            Enabling makes for a smoother scalar display.  Default is True.
+            When False, OpenGL will interpolate the mapped colors which can
+            result is showing colors that are not present in the color map.
 
         cmap : str, optional
            Name of the Matplotlib colormap to us when mapping the ``scalars``.

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -526,3 +526,22 @@ def SuperToroid(**kwargs):
 def Ellipsoid(**kwargs):
     """DEPRECATED: use :func:`pyvista.ParametricEllipsoid`"""
     raise RuntimeError('use `pyvista.ParametricEllipsoid` instead')
+
+
+def Wavelet(extent=(-10,10,-10,10,-10,10), center=(0,0,0), maximum=255,
+            x_freq=60, y_freq=30, z_freq=40, x_mag=10, y_mag=18, z_mag=5,
+            std=0.5, subsample_rate=1):
+    wavelet_source = vtk.vtkRTAnalyticSource()
+    wavelet_source.SetWholeExtent(*extent)
+    wavelet_source.SetCenter(center)
+    wavelet_source.SetMaximum(maximum)
+    wavelet_source.SetXFreq(x_freq)
+    wavelet_source.SetYFreq(y_freq)
+    wavelet_source.SetZFreq(z_freq)
+    wavelet_source.SetXMag(x_mag)
+    wavelet_source.SetYMag(y_mag)
+    wavelet_source.SetZMag(z_mag)
+    wavelet_source.SetStandardDeviation(std)
+    wavelet_source.SetSubsampleRate(subsample_rate)
+    wavelet_source.Update()
+    return pyvista.wrap(wavelet_source.GetOutput())


### PR DESCRIPTION
I propose we change the default for `interpolate_before_map` to True as it is more accurate for scientific visualization.

@akaszynski - is there a reason why this is currently set to False by default?

For more information, please see the detailed example added in the gallery as a part of this PR - In brief, the difference can be stark and not an accurate representation of the data. When `interpolate_before_map` is False, OpenGL interpolates the colors between nodes which means colors that aren't in the colormap could appear on the mesh.

Here are two screenshots showing the differences:

![sphx_glr_interpolate-before-map_001](https://user-images.githubusercontent.com/22067021/63152493-329d1d80-bfc9-11e9-8d40-18ccd73df2a4.png)

![sphx_glr_interpolate-before-map_004](https://user-images.githubusercontent.com/22067021/63152610-7c860380-bfc9-11e9-9dbc-59c2796ef36b.png)

