### PR TITLE
Anti-aliasing

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3350,6 +3350,20 @@ class Plotter(BasePlotter):
     window_size : list, optional
         Window size in pixels.  Defaults to [1024, 768]
 
+    multi_samples : int
+        The number of multi-samples used to mitigate aliasing. 4 is a good
+        default but 8 will have better results with a potential impact on
+        perfromance.
+
+    line_smoothing : bool
+        If True, enable line smothing
+
+    point_smoothing : bool
+        If True, enable point smothing
+
+    polygon_smoothing : bool
+        If True, enable polygon smothing
+
     """
     last_update_time = 0.0
     q_pressed = False
@@ -3357,7 +3371,8 @@ class Plotter(BasePlotter):
 
     def __init__(self, off_screen=None, notebook=None, shape=(1, 1),
                  border=None, border_color='k', border_width=2.0,
-                 window_size=None):
+                 window_size=None, multi_samples=4, line_smoothing=False,
+                 point_smoothing=False, polygon_smoothing=False):
         """
         Initialize a vtk plotting object
         """
@@ -3387,7 +3402,15 @@ class Plotter(BasePlotter):
 
         # initialize render window
         self.ren_win = vtk.vtkRenderWindow()
+        self.ren_win.SetMultiSamples(multi_samples)
         self.ren_win.SetBorders(True)
+        if line_smoothing:
+            self.ren_win.LineSmoothingOn()
+        if point_smoothing:
+            self.ren_win.PointSmoothingOn()
+        if polygon_smoothing:
+            self.ren_win.PolygonSmoothingOn()
+
         for renderer in self.renderers:
             self.ren_win.AddRenderer(renderer)
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3371,7 +3371,7 @@ class Plotter(BasePlotter):
 
     def __init__(self, off_screen=None, notebook=None, shape=(1, 1),
                  border=None, border_color='k', border_width=2.0,
-                 window_size=None, multi_samples=4, line_smoothing=False,
+                 window_size=None, multi_samples=None, line_smoothing=False,
                  point_smoothing=False, polygon_smoothing=False):
         """
         Initialize a vtk plotting object
@@ -3398,7 +3398,10 @@ class Plotter(BasePlotter):
         self.off_screen = off_screen
 
         if window_size is None:
-            window_size = pyvista.rcParams['window_size']
+            window_size = rcParams['window_size']
+
+        if multi_samples is None:
+            multi_samples = rcParams['multi_samples']
 
         # initialize render window
         self.ren_win = vtk.vtkRenderWindow()

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -279,11 +279,27 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
     title : string, optional
         Title of plotting window.
 
+    multi_samples : int
+        The number of multi-samples used to mitigate aliasing. 4 is a good
+        default but 8 will have better results with a potential impact on
+        perfromance.
+
+    line_smoothing : bool
+        If True, enable line smothing
+
+    point_smoothing : bool
+        If True, enable point smothing
+
+    polygon_smoothing : bool
+        If True, enable polygon smothing
+
     """
     render_trigger = pyqtSignal()
     allow_quit_keypress = True
 
-    def __init__(self, parent=None, title=None, shape=(1, 1), off_screen=None, **kwargs):
+    def __init__(self, parent=None, title=None, shape=(1, 1), off_screen=None,
+                 multi_samples=4, line_smoothing=False,
+                 point_smoothing=False, polygon_smoothing=False, **kwargs):
         """ Initialize Qt interactor """
         if not has_pyqt:
             raise AssertionError('Requires PyQt5')
@@ -293,6 +309,14 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
 
         # Create and start the interactive renderer
         self.ren_win = self.GetRenderWindow()
+        self.ren_win.SetMultiSamples(multi_samples)
+        if line_smoothing:
+            self.ren_win.LineSmoothingOn()
+        if point_smoothing:
+            self.ren_win.PointSmoothingOn()
+        if polygon_smoothing:
+            self.ren_win.PolygonSmoothingOn()
+
         for renderer in self.renderers:
             self.ren_win.AddRenderer(renderer)
 
@@ -499,7 +523,7 @@ class BackgroundPlotter(QtInteractor):
         actor, prop = super(BackgroundPlotter, self).add_actor(actor,
                                                                reset_camera=reset_camera,
                                                                name=name,
-                                                               loc=loc, 
+                                                               loc=loc,
                                                                culling=culling,
                                                                pickable=pickable)
         self.update_app_icon()

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -298,7 +298,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
     allow_quit_keypress = True
 
     def __init__(self, parent=None, title=None, shape=(1, 1), off_screen=None,
-                 multi_samples=4, line_smoothing=False,
+                 multi_samples=None, line_smoothing=False,
                  point_smoothing=False, polygon_smoothing=False, **kwargs):
         """ Initialize Qt interactor """
         if not has_pyqt:
@@ -306,6 +306,9 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         QVTKRenderWindowInteractor.__init__(self, parent)
         BasePlotter.__init__(self, shape=shape, title=title)
         self.parent = parent
+
+        if multi_samples is None:
+            multi_samples = rcParams['multi_samples']
 
         # Create and start the interactive renderer
         self.ren_win = self.GetRenderWindow()

--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -57,7 +57,8 @@ rcParams = {
         'y_color': 'seagreen',
         'z_color': 'mediumblue',
         'box': False,
-    }
+    },
+    'multi_samples' : 4,
 }
 
 DEFAULT_THEME = dict(rcParams)


### PR DESCRIPTION
This adds a way to control the anti-aliasing features in the `vtkRenderWindow`. I added options for controlling the point, line, and polygon smoothing (not sure if these really do anything, but I know they have to be called before the first render) and I added a convenient way to set the number of multi-samples used to avoid aliasing.

I'm not exactly sure if this will have any performance implications or issues across operating systems.


## Examples

The aliasing was most notable on axes grid lines/text and on the edges of meshes.

***Make sure to zoom into or download these PNGs if you want to compare - your web browser is likely affecting how they look!!!***

### Axes Grid

Current behavior - 0 multi-samples:

![Screen Shot 2019-08-22 at 11 02 30 PM](https://user-images.githubusercontent.com/22067021/63568499-a5ab1480-c532-11e9-8c7e-6fadc3d9ea87.png)


New default - 4 multi-samples:

![Screen Shot 2019-08-22 at 11 02 42 PM](https://user-images.githubusercontent.com/22067021/63568513-afcd1300-c532-11e9-93cf-8a8b4a2cfaf3.png)

And 8 multi-samples because why not:

![Screen Shot 2019-08-22 at 11 02 52 PM](https://user-images.githubusercontent.com/22067021/63568545-ca06f100-c532-11e9-9179-fe9199a71f3b.png)


### Edges on a Mesh

Current behavior - 0 multi-samples:

![Screen Shot 2019-08-22 at 11 05 02 PM](https://user-images.githubusercontent.com/22067021/63568547-cd01e180-c532-11e9-8f47-8a306d709f31.png)


New default - 4 multi-samples:

![Screen Shot 2019-08-22 at 11 05 09 PM](https://user-images.githubusercontent.com/22067021/63568550-d0956880-c532-11e9-9b1c-01d599cd371c.png)


And 8 multi-samples because why not:

![Screen Shot 2019-08-22 at 11 05 16 PM](https://user-images.githubusercontent.com/22067021/63568556-d428ef80-c532-11e9-9e26-a79e57e0dadd.png)
