### PR TITLE
improve rendering depth image

### DIFF
--- a/examples/02-plot/README.txt
+++ b/examples/02-plot/README.txt
@@ -14,3 +14,4 @@ plotting routines to perform tasks like:
 * Creating side-by-side comparisons
 * Making a dataset transparent or using a scalar value to map opacity
 * Adding textures/images draped over a mesh (texture mapping)
+* Rendering a depth image   

--- a/examples/02-plot/image_depth.py
+++ b/examples/02-plot/image_depth.py
@@ -1,6 +1,6 @@
 """
 Render a depth image
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 Plot a depth image as viewed from a camera overlooking the "hills" example mesh.
 """
@@ -22,6 +22,9 @@ p.show(auto_close=False)
 zval = p.get_image_depth()
 zval_filled_by_42s = p.get_image_depth(fill_value=42)
 
+# Close the plotter after obtaining depth image
+p.close()
+
 # Visualize depth images
 plt.figure()
 plt.imshow(zval)
@@ -30,7 +33,6 @@ plt.title('Depth image')
 plt.xlabel('X Pixel')
 plt.ylabel('Y Pixel')
 plt.show()
-
 
 plt.figure()
 plt.imshow(zval_filled_by_42s)

--- a/examples/02-plot/image_depth.py
+++ b/examples/02-plot/image_depth.py
@@ -1,0 +1,41 @@
+"""
+Render a depth image
+~~~~~~~~~~~~~~~~~
+
+Plot a depth image as viewed from a camera overlooking the "hills" example mesh.
+"""
+import numpy as np
+import pyvista as pv
+import matplotlib.pyplot as plt
+from pyvista import examples
+
+# Load an interesting example of geometry
+mesh = examples.load_random_hills()
+
+# Establish geometry within a pv.Plotter()
+pv.close_all()
+p = pv.Plotter()
+p.add_mesh(mesh, color=True)
+p.show(auto_close=False)
+
+# Record depth image without and with a custom fill value
+zval = p.get_image_depth()
+zval_filled_by_42s = p.get_image_depth(fill_value=42)
+
+# Visualize depth images
+plt.figure()
+plt.imshow(zval)
+plt.colorbar(label='Distance to Camera')
+plt.title('Depth image') 
+plt.xlabel('X Pixel')
+plt.ylabel('Y Pixel')
+plt.show()
+
+
+plt.figure()
+plt.imshow(zval_filled_by_42s)
+plt.title('Depth image (custom fill_value)')
+plt.colorbar(label='Distance to Camera')
+plt.xlabel('X Pixel')
+plt.ylabel('Y Pixel')
+plt.show()

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2570,12 +2570,57 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     @property
     def image_depth(self):
-        """ Returns an image array of current render window """
+        raise AttributeError("Use Plotter.get_image_depth() please.")
+
+
+    def get_image_depth(self, 
+                        fill_value = np.nan,
+                        reset_camera_clipping_range = True):
+        """ Returns a depth image representing current render window 
+
+        Parameters
+        ----------
+        fill_value : 
+            Fill value for points in image that don't include objects in scene
+        reset_camera_clipping_range : bool
+            Reset the camera clipping range to include data in view?
+
+        Returns
+        -------
+        image_depth : numpy.ndarray
+            Image of depth values from camera orthogonal to image plane
+    
+        Notes
+        -----
+        Values in image_depth are negative to adhere to a 
+        right-handed coordinate system.
+        
+        """
+
+        # Ensure points in view are within clipping range of renderer?
+        if reset_camera_clipping_range:
+            self.renderer.ResetCameraClippingRange()
+
+        # Get the z-buffer image
         ifilter = vtk.vtkWindowToImageFilter()
         ifilter.SetInput(self.ren_win)
         ifilter.ReadFrontBufferOff()
         ifilter.SetInputBufferTypeToZBuffer()
-        return self._run_image_filter(ifilter)
+        zbuff = self._run_image_filter(ifilter)[:, :, 0]
+
+        # Convert z-buffer values to depth from camera
+        near, far = self.camera.GetClippingRange()
+        if self.camera.GetParallelProjection():
+            z_val = (zbuff - near) / (far - near)
+        else:
+            zval = 2 * near * far / ((zbuff - 0.5) * 2 * (far - near) - near - far)
+
+        # Consider image values outside clipping range as nans
+        zval[zval <= -far] = fill_value 
+
+        return zval
+
+
 
     @property
     def image(self):


### PR DESCRIPTION
Resolve #368 

In this pull request:

- pyvista.Plotter().image_depth raises an error now, it is replaced by get_image_depth()
- Added an example of using pyvista.Plotter().get_image_depth()  
- Updated the example readme
