### PR TITLE
custom copy methods

### DIFF
--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -39,10 +39,12 @@ class DataObject(object):
 
 
     def shallow_copy(self, to_copy):
+        """Shallow copy the given mesh to this mesh"""
         return self.ShallowCopy(to_copy)
 
 
     def deep_copy(self, to_copy):
+        """Overwrite this mesh with the given mesh as a deep copy"""
         return self.DeepCopy(to_copy)
 
 

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -38,6 +38,14 @@ class DataObject(object):
         return object.__new__(cls, *args, **kwargs)
 
 
+    def shallow_copy(self, to_copy):
+        return self.ShallowCopy(to_copy)
+
+
+    def deep_copy(self, to_copy):
+        return self.DeepCopy(to_copy)
+
+
     def save(self, filename, binary=True):
          """
          Writes this mesh to a file.
@@ -151,9 +159,9 @@ class DataObject(object):
         thistype = type(self)
         newobject = thistype()
         if deep:
-            newobject.DeepCopy(self)
+            newobject.deep_copy(self)
         else:
-            newobject.ShallowCopy(self)
+            newobject.shallow_copy(self)
         newobject.copy_meta_from(self)
         return newobject
 
@@ -418,7 +426,11 @@ class Common(DataSetFilters, DataObject):
         if not isinstance(points, np.ndarray):
             raise TypeError('Points must be a numpy array')
         vtk_points = pyvista.vtk_points(points, False)
-        self.SetPoints(vtk_points)
+        pdata = self.GetPoints()
+        if not pdata:
+            self.SetPoints(vtk_points)
+        else:
+            pdata.SetData(vtk_points.GetData())
         self.GetPoints().Modified()
         self.Modified()
 
@@ -1251,7 +1263,7 @@ class Common(DataSetFilters, DataObject):
             The overwriting mesh.
 
         """
-        self.DeepCopy(mesh)
+        self.deep_copy(mesh)
         if is_pyvista_dataset(mesh):
             self.copy_meta_from(mesh)
 

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -40,9 +40,9 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
         if len(args) == 1:
             if isinstance(args[0], vtk.vtkMultiBlockDataSet):
                 if deep:
-                    self.DeepCopy(args[0])
+                    self.deep_copy(args[0])
                 else:
-                    self.ShallowCopy(args[0])
+                    self.shallow_copy(args[0])
             elif isinstance(args[0], (list, tuple)):
                 for block in args[0]:
                     self.append(block)
@@ -93,7 +93,7 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
         # Load file
         reader.SetFileName(filename)
         reader.Update()
-        self.ShallowCopy(reader.GetOutput())
+        self.shallow_copy(reader.GetOutput())
 
 
     def save(self, filename, binary=True):
@@ -478,8 +478,8 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
         thistype = type(self)
         newobject = thistype()
         if deep:
-            newobject.DeepCopy(self)
+            newobject.deep_copy(self)
         else:
-            newobject.ShallowCopy(self)
+            newobject.shallow_copy(self)
         newobject.copy_meta_from(self)
         return newobject

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1854,7 +1854,7 @@ class DataSetFilters(object):
         merged = _get_output(append_filter)
         if inplace:
             if type(dataset) == type(merged):
-                dataset.DeepCopy(merged)
+                dataset.deep_copy(merged)
             else:
                 raise TypeError("Mesh tpye {} not able to be overridden by output.".format(type(dataset)))
         else:

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -89,7 +89,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
 
         if len(args) == 1:
             if isinstance(args[0], vtk.vtkRectilinearGrid):
-                self.DeepCopy(args[0])
+                self.deep_copy(args[0])
             elif isinstance(args[0], str):
                 self._load_file(args[0])
 
@@ -206,7 +206,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
         reader.SetFileName(filename)
         reader.Update()
         grid = reader.GetOutput()
-        self.ShallowCopy(grid)
+        self.shallow_copy(grid)
 
     def save(self, filename, binary=True):
         """
@@ -348,7 +348,7 @@ class UniformGrid(vtkImageData, Grid):
 
         if len(args) == 1:
             if isinstance(args[0], vtk.vtkImageData):
-                self.DeepCopy(args[0])
+                self.deep_copy(args[0])
             elif isinstance(args[0], str):
                 self._load_file(args[0])
             else:
@@ -478,7 +478,7 @@ class UniformGrid(vtkImageData, Grid):
         reader.SetFileName(filename)
         reader.Update()
         grid = reader.GetOutput()
-        self.ShallowCopy(grid)
+        self.shallow_copy(grid)
 
     def save(self, filename, binary=True):
         """

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -42,9 +42,9 @@ class Table(vtk.vtkTable, DataObject):
             if isinstance(args[0], vtk.vtkTable):
                 deep = kwargs.get('deep', True)
                 if deep:
-                    self.DeepCopy(args[0])
+                    self.deep_copy(args[0])
                 else:
-                    self.ShallowCopy(args[0])
+                    self.shallow_copy(args[0])
             elif isinstance(args[0], np.ndarray):
                 self._from_arrays(args[0])
             elif isinstance(args[0], dict):
@@ -412,9 +412,9 @@ class Texture(vtk.vtkTexture):
             if isinstance(args[0], vtk.vtkTexture):
                 deep = kwargs.get('deep', True)
                 if deep:
-                    self.DeepCopy(args[0])
+                    self.deep_copy(args[0])
                 else:
-                    self.ShallowCopy(args[0])
+                    self.shallow_copy(args[0])
             elif isinstance(args[0], np.ndarray):
                 self._from_array(args[0])
             elif isinstance(args[0], vtk.vtkImageData):

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -54,6 +54,13 @@ class PointSet(Common):
         return np.array(alg.GetCenter())
 
 
+    def shallow_copy(self, to_copy):
+        # Set default points if needed
+        if not to_copy.GetPoints():
+            to_copy.SetPoints(vtk.vtkPoints())
+        return super().shallow_copy(to_copy)
+
+
 
 class PolyData(vtkPolyData, PointSet, PolyDataFilters):
     """
@@ -102,9 +109,9 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
         elif len(args) == 1:
             if isinstance(args[0], vtk.vtkPolyData):
                 if deep:
-                    self.DeepCopy(args[0])
+                    self.deep_copy(args[0])
                 else:
-                    self.ShallowCopy(args[0])
+                    self.shallow_copy(args[0])
             elif isinstance(args[0], str):
                 self._load_file(args[0])
             elif isinstance(args[0], np.ndarray):
@@ -186,7 +193,7 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
         # Load file
         reader.SetFileName(filename)
         reader.Update()
-        self.ShallowCopy(reader.GetOutput())
+        self.shallow_copy(reader.GetOutput())
 
         # sanity check
         if not np.any(self.points):
@@ -544,9 +551,9 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
         if len(args) == 1:
             if isinstance(args[0], vtk.vtkUnstructuredGrid):
                 if deep:
-                    self.DeepCopy(args[0])
+                    self.deep_copy(args[0])
                 else:
-                    self.ShallowCopy(args[0])
+                    self.shallow_copy(args[0])
 
             elif isinstance(args[0], str):
                 self._load_file(args[0])
@@ -555,7 +562,7 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
                 vtkappend = vtk.vtkAppendFilter()
                 vtkappend.AddInputData(args[0])
                 vtkappend.Update()
-                self.ShallowCopy(vtkappend.GetOutput())
+                self.shallow_copy(vtkappend.GetOutput())
 
             else:
                 itype = type(args[0])
@@ -697,7 +704,7 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
         reader.SetFileName(filename)
         reader.Update()
         grid = reader.GetOutput()
-        self.ShallowCopy(grid)
+        self.shallow_copy(grid)
 
     def save(self, filename, binary=True):
         """
@@ -860,7 +867,7 @@ class StructuredGrid(vtkStructuredGrid, PointGrid):
 
         if len(args) == 1:
             if isinstance(args[0], vtk.vtkStructuredGrid):
-                self.DeepCopy(args[0])
+                self.deep_copy(args[0])
             elif isinstance(args[0], str):
                 self._load_file(args[0])
 
@@ -952,7 +959,7 @@ class StructuredGrid(vtkStructuredGrid, PointGrid):
         reader.SetFileName(filename)
         reader.Update()
         grid = reader.GetOutput()
-        self.ShallowCopy(grid)
+        self.shallow_copy(grid)
 
     def save(self, filename, binary=True):
         """

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -132,7 +132,7 @@ class WidgetHelper(object):
 
             alg.SetBoxClip(*bounds)
             alg.Update()
-            self.box_clipped_mesh.ShallowCopy(alg.GetOutput(port))
+            self.box_clipped_mesh.shallow_copy(alg.GetOutput(port))
 
         self.enable_box_widget(callback=callback, bounds=mesh.bounds,
                 factor=1.25, rotation_enabled=rotation_enabled,
@@ -275,7 +275,7 @@ class WidgetHelper(object):
             function = generate_plane(normal, origin)
             alg.SetClipFunction(function) # the implicit function
             alg.Update() # Perfrom the Cut
-            self.plane_clipped_mesh.ShallowCopy(alg.GetOutput())
+            self.plane_clipped_mesh.shallow_copy(alg.GetOutput())
 
         self.enable_plane_widget(callback=callback, bounds=mesh.bounds,
                                  factor=1.25, normal=normal, color=widget_color)
@@ -327,7 +327,7 @@ class WidgetHelper(object):
             plane = generate_plane(normal, origin)
             alg.SetCutFunction(plane) # the the cutter to use the plane we made
             alg.Update() # Perfrom the Cut
-            self.plane_sliced_mesh.ShallowCopy(alg.GetOutput())
+            self.plane_sliced_mesh.shallow_copy(alg.GetOutput())
 
         self.enable_plane_widget(callback=callback, bounds=mesh.bounds,
                                  factor=1.25, normal=normal, color=widget_color)
@@ -549,7 +549,7 @@ class WidgetHelper(object):
             else:
                 alg.ThresholdByUpper(value)
             alg.Update()
-            self.threshold_mesh.ShallowCopy(alg.GetOutput())
+            self.threshold_mesh.shallow_copy(alg.GetOutput())
 
 
         self.enable_slider_widget(callback=callback, rng=rng, title=title,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -636,8 +636,10 @@ def test_hanlde_array_with_null_name():
 
 
 def test_shallow_copy_back_propagation():
-    """Test that th original data object's points get modieifed after wrapping.
-    Reference:
+    """Test that the original data object's points get modieifed after a
+    shallow copy.
+
+    Reference: https://github.com/pyvista/pyvista/issues/375#issuecomment-531691483
     """
     # Case 1
     points = vtk.vtkPoints()
@@ -650,7 +652,6 @@ def test_shallow_copy_back_propagation():
     wrapped.points[:] = 2.8
     orig_points = vtk_to_numpy(original.GetPoints().GetData())
     assert np.allclose(orig_points, wrapped.points)
-
     # Case 2
     original = vtk.vtkPolyData()
     wrapped = pyvista.PolyData(original, deep=False)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3,6 +3,7 @@ import sys
 import numpy as np
 import pytest
 import vtk
+from vtk.util.numpy_support import vtk_to_numpy
 
 import pyvista
 from pyvista import examples
@@ -631,3 +632,28 @@ def test_hanlde_array_with_null_name():
     fdata = poly.field_arrays
     assert fdata is not None
     assert len(fdata) == 1
+
+
+
+def test_shallow_copy_back_propagation():
+    """Test that th original data object's points get modieifed after wrapping.
+    Reference:
+    """
+    # Case 1
+    points = vtk.vtkPoints()
+    points.InsertNextPoint(0.0, 0.0, 0.0)
+    points.InsertNextPoint(1.0, 0.0, 0.0)
+    points.InsertNextPoint(2.0, 0.0, 0.0)
+    original = vtk.vtkPolyData()
+    original.SetPoints(points)
+    wrapped = pyvista.PolyData(original, deep=False)
+    wrapped.points[:] = 2.8
+    orig_points = vtk_to_numpy(original.GetPoints().GetData())
+    assert np.allclose(orig_points, wrapped.points)
+
+    # Case 2
+    original = vtk.vtkPolyData()
+    wrapped = pyvista.PolyData(original, deep=False)
+    wrapped.points = np.random.rand(5, 3)
+    orig_points = vtk_to_numpy(original.GetPoints().GetData())
+    assert np.allclose(orig_points, wrapped.points)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -636,7 +636,7 @@ def test_hanlde_array_with_null_name():
 
 
 def test_shallow_copy_back_propagation():
-    """Test that the original data object's points get modieifed after a
+    """Test that the original data object's points get modified after a
     shallow copy.
 
     Reference: https://github.com/pyvista/pyvista/issues/375#issuecomment-531691483


### PR DESCRIPTION
Resolve #375 by implementing custom shallow/deep copy methods that can be overridden in subclasses. For example, the `pyvista.PointSet` class overrides the `shallow_copy` method to ensure that when copying points-based datasets, the dataset being copied has a points data array which will properly link the wrapped and original datasets in memory. This also enables us to add more features when copying down the road for class-specific cases