### PR TITLE
subplot with (semi)arbitrary geometry

### DIFF
--- a/examples/02-plot/multi-window.py
+++ b/examples/02-plot/multi-window.py
@@ -43,7 +43,6 @@ plotter.show()
 
 
 ###############################################################################
-
 plotter = pv.Plotter(shape=(1, 2))
 
 # Note that the (0, 0) location is active by default
@@ -58,3 +57,38 @@ plotter.add_mesh(examples.load_uniform(), show_edges=True)
 
 # Display the window
 plotter.show()
+
+
+###############################################################################
+# Split the rendering window in half and subdivide it in a nr. of vertical or
+# horizontal subplots. 
+
+# This defines the position of the vertical/horizontal splitting, in this
+# case 40% of the vertical/horizontal dimension of the window
+pv.rcParams['multi_rendering_splitting_position'] = 0.40
+
+# shape="3|1" means 3 plots on the left and 1 on the right,
+# shape="4/2" means four plots on top of 2 at bottom.  
+plotter = pv.Plotter(shape='3|1', window_size=(1000,1200))
+
+plotter.subplot(0)
+plotter.add_text("Airplane Example")
+plotter.add_mesh(examples.load_airplane(), show_edges=False)
+
+# load and plot the uniform data example on the right-hand side
+plotter.subplot(1)
+plotter.add_text("Uniform Data Example")
+plotter.add_mesh(examples.load_uniform(), show_edges=True)
+
+plotter.subplot(2)
+plotter.add_text("A Sphere")
+plotter.add_mesh(pv.Sphere(), show_edges=True)
+
+plotter.subplot(3)
+plotter.add_text("A Cone")
+plotter.add_mesh(pv.Cone(), show_edges=True)
+
+# Display the window
+plotter.show()
+
+

--- a/examples/02-plot/multi-window.py
+++ b/examples/02-plot/multi-window.py
@@ -68,7 +68,7 @@ plotter.show()
 pv.rcParams['multi_rendering_splitting_position'] = 0.40
 
 # shape="3|1" means 3 plots on the left and 1 on the right,
-# shape="4/2" means four plots on top of 2 at bottom.  
+# shape="4/2" means 4 plots on top of 2 at bottom.  
 plotter = pv.Plotter(shape='3|1', window_size=(1000,1200))
 
 plotter.subplot(0)

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -28,13 +28,11 @@ import logging
 
 import numpy as np
 import vtk
-from vtk.util.numpy_support import (numpy_to_vtk, numpy_to_vtkIdTypeArray,
-                                    vtk_to_numpy)
+from vtk.util.numpy_support import (numpy_to_vtkIdTypeArray, vtk_to_numpy)
 
 import pyvista
 from pyvista.utilities import (CELL_DATA_FIELD, POINT_DATA_FIELD, NORMALS,
-                               generate_plane, get_array, is_inside_bounds,
-                               wrap)
+                               generate_plane, get_array, wrap)
 
 
 def _get_output(algorithm, iport=0, iconnection=0, oport=0, active_scalar=None,
@@ -3068,9 +3066,9 @@ class PolyDataFilters(DataSetFilters):
         """
         points = vtk.vtkPoints()
         cell_ids = vtk.vtkIdList()
-        code = poly_data.obbTree.IntersectWithLine(np.array(origin),
-                                              np.array(end_point),
-                                              points, cell_ids)
+        poly_data.obbTree.IntersectWithLine(np.array(origin),
+                                            np.array(end_point),
+                                            points, cell_ids)
 
         intersection_points = vtk_to_numpy(points.GetData())
         if first_point and intersection_points.shape[0] >= 1:
@@ -3205,8 +3203,7 @@ class PolyDataFilters(DataSetFilters):
                 try:
                     newmesh.cell_arrays[key] = poly_data.cell_arrays[key][fmask]
                 except:
-                    log.warning('Unable to pass cell key %s onto reduced mesh' %
-                                key)
+                    logging.warning('Unable to pass cell key %s onto reduced mesh' % key)
 
         # Return vtk surface and reverse indexing array
         if inplace:

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -1,15 +1,12 @@
 """This module provides wrappers for vtkDataObjects: data onjects without any
 sort of spatial reference.
 """
-import collections
-
 import numpy as np
 import vtk
 
 import pyvista
 from pyvista.utilities import (ROW_DATA_FIELD, convert_array, get_array,
-                               parse_field_choice, raise_not_matching,
-                               row_array)
+                               parse_field_choice, row_array, vtk_bit_array_to_char)
 
 from .common import DataObject, _ScalarsDict
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1,7 +1,6 @@
 """
 Sub-classes for vtk.vtkPolyData
 """
-import collections
 import logging
 import os
 
@@ -17,10 +16,9 @@ from vtk.util.numpy_support import (numpy_to_vtk, numpy_to_vtkIdTypeArray,
                                     vtk_to_numpy)
 
 import pyvista
-from pyvista.utilities import generate_plane, get_array
 
 from .common import Common
-from .filters import _get_output, PolyDataFilters, UnstructuredGridFilters
+from .filters import PolyDataFilters, UnstructuredGridFilters
 
 log = logging.getLogger(__name__)
 log.setLevel('CRITICAL')

--- a/pyvista/examples/examples.py
+++ b/pyvista/examples/examples.py
@@ -211,10 +211,10 @@ def plot_wave(fps=30, frequency=1, wavetime=3, interactive=False,
         plotter.update_scalars(Z.ravel(), render=False)
 
         # Render and get time to render
-        rstart = time.time()
+        #rstart = time.time()
         plotter.update()
         # plotter.render()
-        rstop = time.time()
+        #rstop = time.time()
 
         # time delay
         tpast = time.time() - tlast

--- a/pyvista/plotting/export_vtkjs.py
+++ b/pyvista/plotting/export_vtkjs.py
@@ -401,7 +401,7 @@ def write_data_set(file_path, dataset, output_dir, color_array_info, new_name=No
     if writer:
         writer(dataset_dir, data_dir, dataset, color_array_info, root, compress)
     else:
-        print(dataObject.GetClassName(), 'is not supported')
+        print(dataset.GetClassName(), 'is not supported')
 
     with open(os.path.join(dataset_dir, "index.json"), 'w') as f:
         f.write(json.dumps(root, indent=2))
@@ -538,7 +538,7 @@ def export_plotter_vtkjs(plotter, filename, compress_arrays=False):
                     opacity = renProp.GetProperty().GetOpacity() if hasattr(
                         renProp, 'GetProperty') else 1.0
                     edgeVisibility = renProp.GetProperty().GetEdgeVisibility(
-                    ) if hasattr(renProp, 'GetProperty') else false
+                    ) if hasattr(renProp, 'GetProperty') else False
 
                     p3dPosition = renProp.GetPosition() if renProp.IsA(
                         'vtkProp3D') else [0, 0, 0]

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -3,9 +3,10 @@ import numpy as np
 
 import pyvista
 
-from .theme import *
-from .tools import *
-from .plotting import *
+from .theme import rcParams
+from pyvista.utilities import is_pyvista_dataset
+from .plotting import Plotter
+import scooby
 
 
 def plot(var_item, off_screen=None, full_screen=False, screenshot=None,

--- a/pyvista/plotting/ipy_tools.py
+++ b/pyvista/plotting/ipy_tools.py
@@ -4,7 +4,7 @@ Jupyter notebook.
 """
 IPY_AVAILABLE = False
 try:
-    from ipywidgets import interact, interactive
+    from ipywidgets import interact
     import ipywidgets as widgets
     IPY_AVAILABLE = True
 except ImportError:
@@ -172,7 +172,7 @@ class InteractiveTool(object):
                     loc=self.loc)
         # add the axis labels
         if show_bounds:
-            self.plotter.show_bounds(reset_camera=False, loc=loc)
+            self.plotter.show_bounds(reset_camera=False, loc=self.loc)
         if reset_camera:
             cpos = self.plotter.get_default_cam_pos()
             self.plotter.camera_position = cpos

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -28,6 +28,12 @@ from .theme import rcParams, parse_color, parse_font_family
 from .theme import FONT_KEYS, MAX_N_COLOR_BARS, PV_BACKGROUND
 from .widgets import WidgetHelper
 
+try:
+    import matplotlib
+    has_matplotlib = True
+except ImportError:
+    has_matplotlib = False
+
 _ALL_PLOTTERS = {}
 
 def close_all():
@@ -729,14 +735,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
             if multi_colors:
                 # Compute unique colors for each index of the block
-                try:
-                    import matplotlib as mpl
+                if has_matplotlib:
                     from itertools import cycle
-                    cycler = mpl.rcParams['axes.prop_cycle']
+                    cycler = matplotlib.rcParams['axes.prop_cycle']
                     colors = cycle(cycler)
-                except ImportError:
+                else:
                     multi_colors = False
                     logging.warning('Please install matplotlib for color cycles')
+
             # Now iteratively plot each element of the multiblock dataset
             actors = []
             for idx in range(mesh.GetNumberOfBlocks()):
@@ -887,11 +893,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if cmap is None: # grab alias for cmaps: colormap
             cmap = kwargs.get('colormap', None)
         if cmap is None: # Set default map if matplotlib is avaialble
-            try:
-                import matplotlib
+            if has_matplotlib:
                 cmap = rcParams['cmap']
-            except ImportError:
-                pass
         # Set the array title for when it is added back to the mesh
         if _custom_opac:
             title = '__custom_rgba'
@@ -985,12 +988,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 scalar_bar_args.setdefault('below_label', 'Below')
 
             if cmap is not None:
-                try:
-                    from matplotlib.cm import get_cmap
-                except ImportError:
+                if not has_matplotlib:
                     cmap = None
                     logging.warning('Please install matplotlib for color maps.')
-            if cmap is not None:
+
                 cmap = get_cmap_safe(cmap)
                 if categories:
                     if categories is True:
@@ -1379,18 +1380,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if cmap is None: # grab alias for cmaps: colormap
             cmap = kwargs.get('colormap', None)
             if cmap is None: # Set default map if matplotlib is avaialble
-                try:
-                    import matplotlib
+                if has_matplotlib:
                     cmap = rcParams['cmap']
-                except ImportError:
-                    pass
+
         if cmap is not None:
-            try:
-                from matplotlib.cm import get_cmap
-            except ImportError:
+            if not has_matplotlib:
                 cmap = None
                 raise RuntimeError('Please install matplotlib for volume rendering.')
-        if cmap is not None:
+
             cmap = get_cmap_safe(cmap)
             if categories:
                 if categories is True:

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -85,7 +85,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         return object.__new__(cls)
 
     def __init__(self, shape=(1, 1), border=None, border_color='k',
-                 border_width=2.0, title=None):
+                 border_width=2.0, title=None, splitting_position=None):
         """ Initialize base plotter """
         self.image_transparent_background = rcParams['transparent_background']
 
@@ -122,7 +122,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             else:
                 xsplit = 1-n/(n+m)
 
-            if rcParams['multi_rendering_splitting_position']:
+            if splitting_position:
                 xsplit = rcParams['multi_rendering_splitting_position']
 
             for i in rangen:
@@ -144,7 +144,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         else:
 
-            assert_str = '"shape" should be a list or tuple'
+            assert_str = '"shape" should be a list, tuple or string descriptor'
             assert isinstance(shape, collections.Iterable), assert_str
             assert shape[0] > 0, '"shape" must be positive'
             assert shape[1] > 0, '"shape" must be positive'
@@ -1625,7 +1625,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         # add actor to the correct render window
         self._active_renderer_index = self.loc_to_index(loc)
         renderer = self.renderers[self._active_renderer_index]
-        #print('marco', self._active_renderer_index, [renderer])
         return renderer.add_actor(uinput=uinput, reset_camera=reset_camera,
                     name=name, culling=culling, pickable=pickable)
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -54,6 +54,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
         Number of sub-render windows inside of the main window.
         Specify two across with ``shape=(2, 1)`` and a two by two grid
         with ``shape=(2, 2)``.  By default there is only one renderer.
+        Can also accept a shape as string descriptor. E.g.:
+            shape="3|1" means 3 plots on the left and 1 on the right,
+            shape="4/2" means 4 plots on top of 2 at bottom.
 
     border : bool, optional
         Draw a border around each render window.  Default False.
@@ -3472,8 +3475,10 @@ class Plotter(BasePlotter):
     shape : list or tuple, optional
         Number of sub-render windows inside of the main window.
         Specify two across with ``shape=(2, 1)`` and a two by two grid
-        with ``shape=(2, 2)``.  By default there is only one render
-        window.
+        with ``shape=(2, 2)``.  By default there is only one render window.
+        Can also accept a shape as string descriptor. E.g.:
+            shape="3|1" means 3 plots on the left and 1 on the right,
+            shape="4/2" means 4 plots on top of 2 at bottom.
 
     border : bool, optional
         Draw a border around each render window.  Default False.

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -94,7 +94,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         # add render windows
         self._active_renderer_index = 0
         self.renderers = []
-        
+
         if isinstance(shape, str):
 
             if '|' in shape:
@@ -112,29 +112,29 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 xsplit = m/(n+m)
             else:
                 xsplit = 1-n/(n+m)
-            
+
             if rcParams['multi_rendering_splitting_position']:
                 xsplit = rcParams['multi_rendering_splitting_position']
 
             for i in rangen:
                 arenderer = pyvista.Renderer(self, border, border_color, border_width)
-                if '|' in shape: 
+                if '|' in shape:
                     arenderer.SetViewport(0,  i/n, xsplit, (i+1)/n)
                 else:
                     arenderer.SetViewport(i/n, 0,  (i+1)/n, xsplit )
                 self.renderers.append(arenderer)
             for i in rangem:
                 arenderer = pyvista.Renderer(self, border, border_color, border_width)
-                if '|' in shape: 
+                if '|' in shape:
                     arenderer.SetViewport(xsplit, i/m, 1, (i+1)/m)
-                else: 
+                else:
                     arenderer.SetViewport(i/m, xsplit, (i+1)/m, 1)
                 self.renderers.append(arenderer)
-                
+
                 self.shape = (n+m,)
-       
+
         else:
-            
+
             assert_str = '"shape" should be a list or tuple'
             assert isinstance(shape, collections.Iterable), assert_str
             assert shape[0] > 0, '"shape" must be positive'

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -158,7 +158,7 @@ class DoubleSlider(QSlider):
         self.setValue(self.value())
 
 
-class RangeGroup(QHBoxLayout):
+class RangeGroup(QHBoxLayout): # this is redefined from above ... why?
 
     def __init__(self, parent, callback, minimum=0.0, maximum=20.0,
                  value=1.0):

--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -60,6 +60,7 @@ rcParams = {
         'box': False,
     },
     'multi_samples' : 4,
+    'multi_rendering_splitting_position': None,
 }
 
 DEFAULT_THEME = dict(rcParams)

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1,10 +1,9 @@
-import logging
 import vtk
 
 import pyvista
 from pyvista.utilities import NORMALS, generate_plane, get_array, try_callback
 
-from .theme import *
+from .theme import rcParams, parse_color
 
 
 class WidgetHelper(object):
@@ -114,7 +113,7 @@ class WidgetHelper(object):
         name = kwargs.get('name', str(hex(id(mesh))))
         kwargs.setdefault('clim', mesh.get_data_range(kwargs.get('scalars', None)))
 
-        _ = self.add_mesh(mesh.outline(), name=name+"outline", opacity=0.0)
+        self.add_mesh(mesh.outline(), name=name+"outline", opacity=0.0)
 
         port = 1 if invert else 0
 
@@ -256,7 +255,7 @@ class WidgetHelper(object):
         name = kwargs.get('name', str(hex(id(mesh))))
         kwargs.setdefault('clim', mesh.get_data_range(kwargs.get('scalars', None)))
 
-        _ = self.add_mesh(mesh.outline(), name=name+"outline", opacity=0.0)
+        self.add_mesh(mesh.outline(), name=name+"outline", opacity=0.0)
 
         if isinstance(mesh, vtk.vtkPolyData):
             alg = vtk.vtkClipPolyData()
@@ -313,7 +312,7 @@ class WidgetHelper(object):
         name = kwargs.get('name', str(hex(id(mesh))))
         kwargs.setdefault('clim', mesh.get_data_range(kwargs.get('scalars', None)))
 
-        _ = self.add_mesh(mesh.outline(), name=name+"outline", opacity=0.0)
+        self.add_mesh(mesh.outline(), name=name+"outline", opacity=0.0)
 
         alg = vtk.vtkCutter() # Construct the cutter object
         alg.SetInputDataObject(mesh) # Use the grid as the data we desire to cut
@@ -534,7 +533,7 @@ class WidgetHelper(object):
         if title is None:
             title = scalars
 
-        _ = self.add_mesh(mesh.outline(), name=name+"outline", opacity=0.0)
+        self.add_mesh(mesh.outline(), name=name+"outline", opacity=0.0)
 
         alg = vtk.vtkThreshold()
         alg.SetInputDataObject(mesh)

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -7,6 +7,8 @@ import vtk
 
 import pyvista
 
+import imageio
+
 READERS = {
     # Standard dataset readers:
     '.vtk': vtk.vtkDataSetReader,

--- a/pyvista/utilities/utilities.py
+++ b/pyvista/utilities/utilities.py
@@ -5,17 +5,13 @@ Supporting functions for polydata and grid objects
 import collections
 import ctypes
 import logging
-import os
 
-import imageio
 import numpy as np
 import scooby
 import vtk
 import vtk.util.numpy_support as nps
 
 import pyvista
-
-from .fileio import get_ext, get_reader, standard_reader_routine
 
 POINT_DATA_FIELD = 0
 CELL_DATA_FIELD = 1


### PR DESCRIPTION
this PR allows to split in half the window at automatic or specified position by a shape descriptor.

```python
# This defines the position of the vertical/horizontal splitting, in this
# case 40% of the vertical/horizontal dimension of the window
pv.rcParams['multi_rendering_splitting_position'] = 0.40

# shape="3|1" means 3 plots on the left and 1 on the right,
# shape="4/2" means 4 plots on top of 2 at bottom.  
plotter = pv.Plotter(shape='3|1', window_size=(1000,1200))

plotter.subplot(0)
plotter.add_text("Airplane Example")
plotter.add_mesh(examples.load_airplane(), show_edges=False)

# load and plot the uniform data example on the right-hand side
plotter.subplot(1)
plotter.add_text("Uniform Data Example")
plotter.add_mesh(examples.load_uniform(), show_edges=True)

plotter.subplot(2)
plotter.add_text("A Sphere")
plotter.add_mesh(pv.Sphere(), show_edges=True)

plotter.subplot(3)
plotter.add_text("A Cone")
plotter.add_mesh(pv.Cone(), show_edges=True)

# Display the window
plotter.show()
```
![mlt](https://user-images.githubusercontent.com/32848391/65270662-e9863f00-db1b-11e9-93cd-302dc3fb85f5.png)

- bug fixings
- example update

I just implemented this for vtkplotter and I thought that it might be useful to pyvista users too :)