### PR TITLE
Add method for casting UniformGrids to RectilinearGrids

### DIFF
--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -575,3 +575,21 @@ class UniformGrid(vtkImageData, Grid):
         alg.SetInputData(self)
         alg.Update()
         return _get_output(alg)
+
+
+    def cast_to_rectilinear_grid(self):
+        """Cast this unifrom grid to a :class:`pyvista.RectilinearGrid`"""
+        def gen_coords(i):
+            coords = np.cumsum(np.insert(np.full(self.dimensions[i] - 1,
+                                                 self.spacing[i]), 0, 0)
+                               ) + self.origin[i]
+            return coords
+        xcoords = gen_coords(0)
+        ycoords = gen_coords(1)
+        zcoords = gen_coords(2)
+        grid = pyvista.RectilinearGrid(xcoords, ycoords, zcoords)
+        grid.point_arrays.update(self.point_arrays)
+        grid.cell_arrays.update(self.cell_arrays)
+        grid.field_arrays.update(self.field_arrays)
+        grid.copy_meta_from(self)
+        return grid

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -326,6 +326,16 @@ def test_cast_uniform_to_structured():
     grid = examples.load_uniform()
     structured = grid.cast_to_structured_grid()
     assert structured.n_points == grid.n_points
+    assert structured.n_arrays == grid.n_arrays
+    assert structured.bounds == grid.bounds
+
+
+def test_cast_uniform_to_rectilinear():
+    grid = examples.load_uniform()
+    rectilinear = grid.cast_to_rectilinear_grid()
+    assert rectilinear.n_points == grid.n_points
+    assert rectilinear.n_arrays == grid.n_arrays
+    assert rectilinear.bounds == grid.bounds
 
 
 @pytest.mark.parametrize('binary', [True, False])


### PR DESCRIPTION
```py
import pyvista as pv
from pyvista import examples

m = examples.load_uniform()
r = m.cast_to_rectilinear_grid()
```