### PR TITLE
Add viewport parameter for add_text

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2495,7 +2495,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.mapper = None
 
     def add_text(self, text, position='upper_left', font_size=18, color=None,
-                 font=None, shadow=False, name=None, loc=None):
+                 font=None, shadow=False, name=None, loc=None, viewport=False):
         """
         Adds text to plot object in the top left corner by default
 
@@ -2505,11 +2505,13 @@ class BasePlotter(PickingHelper, WidgetHelper):
             The text to add the the rendering
 
         position : str, tuple(float)
-            String name of the position or length 2 tuple of the pixelwise
-            position to place the bottom left corner of the text box.
-            If string name is used, returns a `vtkCornerAnnotation` object
-            normally used for fixed labels (like title or xlabel).
-            If tuple is used, returns a more general `vtkOpenGLTextActor`.
+            Position to place the bottom left corner of the text box.
+            If tuple is used, the position of the text uses the pixel
+            coordinate system (default) and if viewport is True, it uses
+            the normalized viewport coordinate system instead. In this case,
+            it returns a more general `vtkOpenGLTextActor`.
+            If string name is used, it returns a `vtkCornerAnnotation`
+            object normally used for fixed labels (like title or xlabel).
             Default is to find the top left corner of the renderering window
             and place text box up there. Available position: ``'lower_left'``,
             ``'lower_right'``, ``'upper_left'``, ``'upper_right'``,
@@ -2585,6 +2587,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
             self.textActor = vtk.vtkTextActor()
             self.textActor.SetInput(text)
             self.textActor.SetPosition(position)
+            if viewport:
+                self.textActor.GetActualPositionCoordinate().SetCoordinateSystemToNormalizedViewport()
+                self.textActor.GetActualPosition2Coordinate().SetCoordinateSystemToNormalizedViewport()
             self.textActor.GetTextProperty().SetFontSize(int(font_size * 2))
 
         self.textActor.GetTextProperty().SetColor(parse_color(color))

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2507,8 +2507,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         position : str, tuple(float)
             Position to place the bottom left corner of the text box.
             If tuple is used, the position of the text uses the pixel
-            coordinate system (default) and if viewport is True, it uses
-            the normalized viewport coordinate system instead. In this case,
+            coordinate system (default). In this case,
             it returns a more general `vtkOpenGLTextActor`.
             If string name is used, it returns a `vtkCornerAnnotation`
             object normally used for fixed labels (like title or xlabel).
@@ -2532,6 +2531,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         loc : int, tuple, or list
             Index of the renderer to add the actor to.  For example,
             ``loc=2`` or ``loc=(1, 1)``.
+
+        viewport: bool
+            If True and position is a tuple of float, uses
+            the normalized viewport coordinate system (values between 0.0
+            and 1.0 and support for HiDPI).
 
         Returns
         -------

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -520,7 +520,8 @@ def test_multi_renderers():
     plotter.add_mesh(pyvista.Arrow(), color='y', loc=loc, show_edges=True)
 
     plotter.subplot(1, 1)
-    plotter.add_text('Render Window 3', loc=loc, font_size=30)
+    plotter.add_text('Render Window 3', position=(0., 0.),
+                     loc=loc, font_size=30, viewport=True)
     plotter.add_mesh(pyvista.Cone(), color='g', loc=loc, show_edges=True,
                      backface_culling=True)
     plotter.add_bounding_box(render_lines_as_tubes=True, line_width=5)


### PR DESCRIPTION
Add a `viewport` parameter for the `add_text()` function of the `BasePlotter` to enable support for normalized viewport coordinates (values between 0 and 1 and support for HiDPI) if `position` is a `tuple` of `float`s.