### PR TITLE
Add OBJ scene exporter

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3457,7 +3457,24 @@ class BasePlotter(PickingHelper, WidgetHelper):
             raise RuntimeError('Export must be called before showing/closing the scene.')
         if isinstance(pyvista.FIGURE_PATH, str) and not os.path.isabs(filename):
             filename = os.path.join(pyvista.FIGURE_PATH, filename)
+        else:
+            filename = os.path.abspath(os.path.expanduser(filename))
         return export_plotter_vtkjs(self, filename, compress_arrays=compress_arrays)
+
+
+
+    def export_obj(self, filename):
+        """Export scene to OBJ format"""
+        if not hasattr(self, "ren_win"):
+            raise RuntimeError("This plotter must still have a render window open.")
+        if isinstance(pyvista.FIGURE_PATH, str) and not os.path.isabs(filename):
+            filename = os.path.join(pyvista.FIGURE_PATH, filename)
+        else:
+            filename = os.path.abspath(os.path.expanduser(filename))
+        exporter = vtk.vtkOBJExporter()
+        exporter.SetFilePrefix(filename)
+        exporter.SetRenderWindow(self.ren_win)
+        return exporter.Write()
 
 
     def __del__(self):


### PR DESCRIPTION
This makes exporting the geometry in a scene to an OBJ file easy. Note that you can also place *simple* OBJ files in PowerPoint presentations these days:

```py
import pyvista as pv
from pyvista import examples

mesh = examples.load_random_hills()

p = pv.Plotter()
p.add_mesh(mesh)
p.export_obj("~/Desktop/foo")
p.show()
```

![2019-10-09 00 00 10](https://user-images.githubusercontent.com/22067021/66455409-eb129b00-ea27-11e9-97c6-126ba06fd1e6.gif)
