### PR TITLE
BUGFIX: save screenshot when no file extension given

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3069,10 +3069,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
             raise Exception('Empty image.  Have you run plot() first?')
 
         # write screenshot to file
+        supported_formats = [".png", ".jpeg", ".jpg", ".bmp", ".tif", ".tiff"]
         if isinstance(filename, str):
             if isinstance(pyvista.FIGURE_PATH, str) and not os.path.isabs(filename):
                 filename = os.path.join(pyvista.FIGURE_PATH, filename)
-            if not any([filename.endswith(ext) for ext in [".png", ".jpeg"]]):
+            if not any([filename.lower().endswith(ext) for ext in supported_formats]):
                 filename += ".png"
             if not return_img:
                 return imageio.imwrite(filename, image)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3072,6 +3072,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if isinstance(filename, str):
             if isinstance(pyvista.FIGURE_PATH, str) and not os.path.isabs(filename):
                 filename = os.path.join(pyvista.FIGURE_PATH, filename)
+            if not any([filename.endswith(ext) for ext in [".png", ".jpeg"]]):
+                filename += ".png"
             if not return_img:
                 return imageio.imwrite(filename, image)
             imageio.imwrite(filename, image)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -58,6 +58,11 @@ def test_plot(tmpdir):
     assert isinstance(cpos, list)
     assert isinstance(img, np.ndarray)
     assert os.path.isfile(filename)
+    os.remove(filename)
+    filename = os.path.join(pyvista.USER_DATA_PATH, 'foo')
+    cpos = pyvista.plot(sphere, off_screen=OFF_SCREEN, screenshot=filename)
+    filename = filename + ".png" # Ensure it added a PNG extension by default
+    assert os.path.isfile(filename)
     # remove file
     os.remove(filename)
 


### PR DESCRIPTION
When saving a screenshot with the BackgroundPlotters save dialog, it was very easy to forget to add a file extension - this resolves that issue and makes saving screenshots default to PNG.

@akaszynski, are there any formats besides PNG and JPEG that are used?