### PR TITLE
🚧 [GemPy] widget enhancements

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -59,7 +59,6 @@ class PointSet(Common):
         return Common.shallow_copy(self, to_copy)
 
 
-
 class PolyData(vtkPolyData, PointSet, PolyDataFilters):
     """
     Extends the functionality of a vtk.vtkPolyData object
@@ -314,7 +313,6 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
         else:
             self.points = vertices
             self.faces = faces
-
 
     def __sub__(self, cutting_mesh):
         """ subtract two meshes """

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -162,7 +162,6 @@ class WidgetHelper(object):
 
         return actor
 
-
     def add_plane_widget(self, callback, normal='x', origin=None,
                          bounds=None, factor=1.25, color=None,
                          assign_to_axis=None, tubing=False,
@@ -179,7 +178,7 @@ class WidgetHelper(object):
             The method called everytime the plane is updated. Takes two
             arguments, the normal and origin of the plane in that order.
 
-        noraml : str or tuple(flaot)
+        normal : str or tuple(float)
             The starting normal vector of the plane
 
         origin : tuple(float)


### PR DESCRIPTION
I open a pull request so you @banesullivan can keep an eye on the small changes I did to fit my code.

So far the main changes are:

1) Added a plane widget for the orientations like what I had with gempy. It is a different widget than you implemented vtkPlaneWidget vs vtkImplicitPlaneWidget. I tried to give it a go with yours but I did not find an easy way. I guess that if we add this widget, we would need to make it more consistent with the rest of pyvista widgets.

2) On the sphere widget you were only passing the coordinates (and index if you create a list of widgets) to the user call back but I found easier to also pass the whole widget object -- in my case also for the index and radio of the points. I think in general is good to give the option to the user if they want to hack something more advanced