### PR TITLE
Gradient background colors

### DIFF
--- a/examples/02-plot/themes.py
+++ b/examples/02-plot/themes.py
@@ -63,3 +63,13 @@ plot_example()
 pv.set_plot_theme("document")
 
 plot_example()
+
+###############################################################################
+# Note that you can also use color gradients for the background of the plotting
+# window!
+plotter = pv.Plotter()
+plotter.add_mesh(mesh)
+plotter.show_grid()
+# Here we set the gradient
+plotter.set_background("cyan", top="orange")
+plotter.show()

--- a/examples/02-plot/themes.py
+++ b/examples/02-plot/themes.py
@@ -71,5 +71,5 @@ plotter = pv.Plotter()
 plotter.add_mesh(mesh)
 plotter.show_grid()
 # Here we set the gradient
-plotter.set_background("cyan", top="orange")
+plotter.set_background("royalblue", top="aliceblue")
 plotter.show()

--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -1,11 +1,11 @@
 from .colors import (color_char_to_word, get_cmap_safe, hex_to_rgb, hexcolors,
-                     string_to_rgb)
+                     string_to_rgb, PARAVIEW_BACKGROUND)
 from .export_vtkjs import export_plotter_vtkjs, get_vtkjs_url
 from .helpers import plot, plot_arrows, plot_compare_four
 from .plotting import BasePlotter, Plotter, close_all
 from .qt_plotting import BackgroundPlotter, QtInteractor
 from .renderer import Renderer
-from .theme import (DEFAULT_THEME, FONT_KEYS, MAX_N_COLOR_BARS, PV_BACKGROUND,
+from .theme import (DEFAULT_THEME, FONT_KEYS, MAX_N_COLOR_BARS,
                     parse_color, parse_font_family, rcParams, set_plot_theme)
 from .tools import (create_axes_orientation_box, opacity_transfer_function,
                     system_supports_plotting)

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -319,6 +319,9 @@ color_char_to_word = {
         'w': 'white'}
 
 
+PARAVIEW_BACKGROUND = [82/255., 87/255., 110/255.]
+
+
 def hex_to_rgb(h):
     """ Returns 0 to 1 rgb from a hex list or tuple """
     h = h.lstrip('#')
@@ -354,6 +357,10 @@ def string_to_rgb(string):
     # if a color name
     elif string.lower() in hexcolors:
         colorhex = hexcolors[string.lower()]
+
+    elif string.lower() in 'paraview' or string.lower() in 'pv':
+        # Use the default ParaView background color
+        return PARAVIEW_BACKGROUND
 
     # try to convert to hex
     else:

--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -1,11 +1,11 @@
 
 import vtk
 
-from .colors import string_to_rgb
+from .colors import string_to_rgb, PARAVIEW_BACKGROUND
 
 
 MAX_N_COLOR_BARS = 10
-PV_BACKGROUND = [82/255., 87/255., 110/255.]
+PV_BACKGROUND = PARAVIEW_BACKGROUND
 FONT_KEYS = {'arial': vtk.VTK_ARIAL,
              'courier': vtk.VTK_COURIER,
              'times': vtk.VTK_TIMES}
@@ -68,7 +68,7 @@ DEFAULT_THEME = dict(rcParams)
 def set_plot_theme(theme):
     """Set the plotting parameters to a predefined theme"""
     if theme.lower() in ['paraview', 'pv']:
-        rcParams['background'] = PV_BACKGROUND
+        rcParams['background'] = PARAVIEW_BACKGROUND
         rcParams['cmap'] = 'coolwarm'
         rcParams['font']['family'] = 'arial'
         rcParams['font']['label_size'] = 16

--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -5,7 +5,6 @@ from .colors import string_to_rgb, PARAVIEW_BACKGROUND
 
 
 MAX_N_COLOR_BARS = 10
-PV_BACKGROUND = PARAVIEW_BACKGROUND
 FONT_KEYS = {'arial': vtk.VTK_ARIAL,
              'courier': vtk.VTK_COURIER,
              'times': vtk.VTK_TIMES}

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -275,6 +275,7 @@ def test_add_point_labels():
         plotter.add_point_labels(points, range(n - 1))
 
     plotter.set_background('k')
+    plotter.set_background([0, 0, 0], top=[1,1,1]) # Gradient
     plotter.add_point_labels(points, range(n), show_points=True, point_color='r')
     plotter.add_point_labels(points - 1, range(n), show_points=False, point_color='r')
     plotter.show()


### PR DESCRIPTION
because why not?

```py
import pyvista as pv
from pyvista import examples

mesh = examples.load_airplane()

plotter = pv.Plotter()
plotter.add_mesh(mesh, color="white")
plotter.set_background("royalblue", top="aliceblue")
plotter.show()
```
![download](https://user-images.githubusercontent.com/22067021/67128518-1ed48a00-f1b9-11e9-9839-ae21aef48511.png)
