### PR TITLE
[MRG] Add border control to background plotter

### DIFF
--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -304,6 +304,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
     allow_quit_keypress = True
 
     def __init__(self, parent=None, title=None, shape=(1, 1), off_screen=None,
+                 border=None, border_color='k', border_width=2.0,
                  multi_samples=None, line_smoothing=False,
                  point_smoothing=False, polygon_smoothing=False,
                  splitting_position=None, **kwargs):
@@ -312,6 +313,8 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
             raise AssertionError('Requires PyQt5')
         QVTKRenderWindowInteractor.__init__(self, parent)
         BasePlotter.__init__(self, shape=shape, title=title,
+                             border=border, border_color=border_color,
+                             border_width=border_width,
                              splitting_position=splitting_position)
         self.parent = parent
 


### PR DESCRIPTION
By default, the `border`, `border_color` and `border_width` parameters are not passed to the `BasePlotter` so it's not possible to customize the borders with the `BackgroundPlotter`.

In this code snippet we try to disable the borders for example: 

```py
import pyvista as pv

p = pv.BackgroundPlotter(shape=(1,2), border=False)
p.background_color = 'white'
p.subplot(0, 0)
p.add_mesh(pv.Cone())
p.subplot(0, 1)
p.add_mesh(pv.Sphere())
p.screenshot("test.png")
```

master | PR
--------|--------
![image](https://user-images.githubusercontent.com/18143289/67392556-0ab9cf80-f5a1-11e9-8958-f665ecb5b6c7.png) | ![image](https://user-images.githubusercontent.com/18143289/67392492-eb22a700-f5a0-11e9-9444-78a18d958239.png)
