### PR TITLE
Array name autocompletion for IPython

### DIFF
--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -1118,6 +1118,9 @@ class Common(DataSetFilters, DataObject):
             raise KeyError('Index ({}) not understood. Index must be a string name or a tuple of string name and string preference.'.format(index))
         return self.get_array(name, preference=preference, info=False)
 
+    def _ipython_key_completions_(self):
+        return self.array_names
+
 
     def __setitem__(self, name, scalars):
         """Add/set an array in the point_arrays, or cell_arrays depending on the

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -319,6 +319,10 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
         return names
 
 
+    def _ipython_key_completions_(self):
+        return self.keys()
+
+
     def __setitem__(self, index, data):
         """Sets a block with a VTK data object. To set the name simultaneously,
         pass a string name as the 2nd index.

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -235,6 +235,10 @@ class Table(vtk.vtkTable, DataObject):
         return row_array(self, name)
 
 
+    def _ipython_key_completions_(self):
+        return self.keys()
+
+
     def get(self, index):
         """Get an array by its name"""
         return self[index]


### PR DESCRIPTION
I have become accustomed to Pandas' autocompletion when indexing a `DataFrame` by a column name (e.g. `df["a...`) and have longed for this in PyVista when fetching arrays. 

Now it's possible! 🎉 🎆 

![2019-10-28 22 25 21](https://user-images.githubusercontent.com/22067021/67737799-16a6f680-f9d2-11e9-9b0d-2a6ae8996971.gif)
