### PR TITLE
Add support for poly data box in clip_box filter

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -47,8 +47,18 @@ def test_clip_box():
     result = dataset.clip_box(bounds=(900, 900, 200), invert=False)
     dataset = examples.load_uniform()
     result = dataset.clip_box(bounds=0.5)
+    assert result.n_cells
     with pytest.raises(AssertionError):
         dataset.clip_box(bounds=(5, 6,))
+    # Test with a poly data box
+    mesh = examples.load_airplane()
+    box = pyvista.Cube(center=(0.9e3, 0.2e3, mesh.center[2]),
+                       x_length=500, y_length=500, z_length=500)
+    box.rotate_z(33)
+    result = mesh.clip_box(box, invert=False)
+    assert result.n_cells
+    result = mesh.clip_box(box, invert=True)
+    assert result.n_cells
 
 
 @pytest.mark.skipif(PYTHON_2, reason="Python 2 doesn't support binding methods")


### PR DESCRIPTION
Resolve #372 - pinging @craigmillernz

This adds support for using a poly data box to clip a mesh. Why? the `clip_surface` filter isn't very efficient and the box clipping filter is very efficient. Most of the time, users just want a rotated volume/region of interest and this will provide a really good way to extract those!

```py
from pyvista import examples
import pyvista as pv

# The mesh to clip
mesh = examples.load_airplane()

# Use `pv.Box()` or `pv.Cube()` to create a region of interest
roi = pv.Cube(center=(0.9e3, 0.2e3, mesh.center[2]), 
              x_length=500, y_length=500, z_length=500)
roi.rotate_z(33)

# Runt the box lipping algorithm
extracted = mesh.clip_box(box, invert=False)

p = pv.Plotter(shape=(1,2))
p.add_mesh(box, opacity=0.75, color="red")
p.add_mesh(mesh)
p.subplot(0,1)
p.add_mesh(extracted)
p.link_views()
p.view_isometric()
p.show()
```

![download](https://user-images.githubusercontent.com/22067021/67919294-6c5fd800-fb65-11e9-93db-4a0e5b7dc565.png)
