### PR TITLE
Remove old name disclaimer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,6 @@
 PyVista
 #######
 
-**🚨🚨 PyVista was formerly vtki 🚨🚨 We recently changed the name of this
-software and we apologize for any confusion this may be causing**
-
 .. image:: https://github.com/pyvista/pyvista/raw/master/docs/_static/pyvista_logo.png
     :alt: pyvista
 
@@ -45,9 +42,10 @@ software and we apologize for any confusion this may be causing**
 +----------------------+------------------------+
 
 
-PyVista is a helper module for the Visualization Toolkit (VTK) that takes a
-different approach on interfacing with VTK through NumPy and direct array
-access. This package provides a Pythonic, well-documented interface exposing
+PyVista (formerly ``vtki``) is a helper module for the Visualization Toolkit
+(VTK) that takes a different approach on interfacing with VTK through NumPy and
+direct array access. 
+This package provides a Pythonic, well-documented interface exposing
 VTK's powerful visualization backend to facilitate rapid prototyping, analysis,
 and visual integration of spatially referenced datasets.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,5 @@
 .. title:: PyVista
 
-.. warning:: 🚨🚨 PyVista was formerly vtki 🚨🚨
-
-   We recently changed the name of this software and we apologize for any confusion this may be causing
-
-
 .. raw:: html
 
     <div class="banner">
@@ -61,9 +56,10 @@
 About
 *****
 
-PyVista is a helper module for the Visualization Toolkit (VTK) that takes a
-different approach on interfacing with VTK through NumPy and direct array
-access. This package provides a Pythonic, well-documented interface exposing
+PyVista (formerly ``vtki``) is a helper module for the Visualization Toolkit
+(VTK) that takes a different approach on interfacing with VTK through NumPy and
+direct array access.
+This package provides a Pythonic, well-documented interface exposing
 VTK's powerful visualization backend to facilitate rapid prototyping, analysis,
 and visual integration of spatially referenced datasets.
 


### PR DESCRIPTION
I think it's time we remove the big disclaimer about PyVista's name change in favor of a more subtle "...(formerly ``vtki``)" in the about section of the README.