### PR TITLE
Allowing user to specify a colormap with a list of strings

### DIFF
--- a/examples/02-plot/cmap.py
+++ b/examples/02-plot/cmap.py
@@ -73,7 +73,8 @@ mesh.plot(scalars='values', cmap=boring_cmap)
 # approach divides up the colormap into 5 equal parts.
 mesh.plot(scalars=mesh['values'], cmap=['black', 'blue', 'yellow', 'grey', 'red'])
 
-# if you still wish to have control of the seperation of values, you
+###############################################################################
+# If you still wish to have control of the seperation of values, you
 # can do this by creating a scalar array and passing that to the
 # plotter along with the the colormap
 scalars = np.empty(mesh.n_points)

--- a/examples/02-plot/cmap.py
+++ b/examples/02-plot/cmap.py
@@ -69,6 +69,23 @@ boring_cmap = plt.cm.get_cmap("viridis", 5)
 mesh.plot(scalars='values', cmap=boring_cmap)
 
 ###############################################################################
+# You can also pass a list of color strings to the color map.  This
+# approach divides up the colormap into 5 equal parts.
+mesh.plot(scalars=mesh['values'], cmap=['black', 'blue', 'yellow', 'grey', 'red'])
+
+# if you still wish to have control of the seperation of values, you
+# can do this by creating a scalar array and passing that to the
+# plotter along with the the colormap
+scalars = np.empty(mesh.n_points)
+scalars[mesh['values'] >= 80] = 4  # red
+scalars[mesh['values'] < 80] = 3  # grey
+scalars[mesh['values'] < 55] = 2  # yellow
+scalars[mesh['values'] < 30] = 1  # blue
+scalars[mesh['values'] < 1] = 0  # black
+
+mesh.plot(scalars=scalars, cmap=['black', 'blue', 'yellow', 'grey', 'red'])
+
+###############################################################################
 # Matplotlib vs. Colorcet
 # +++++++++++++++++++++++
 #

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -397,4 +397,11 @@ def get_cmap_safe(cmap):
             return cmap
         # Else use Matplotlib
         cmap = get_cmap(cmap)
+    elif isinstance(cmap, list):
+        for item in cmap:
+            if not isinstance(item, str):
+                raise TypeError('When inputting a list as a cmap, each item should be a string.')
+        from matplotlib.colors import ListedColormap
+        cmap = ListedColormap(cmap)
+
     return cmap

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -664,12 +664,17 @@ class BasePlotter(PickingHelper, WidgetHelper):
             When False, OpenGL will interpolate the mapped colors which can
             result is showing colors that are not present in the color map.
 
-        cmap : str, optional
+        cmap : str, list, optional
            Name of the Matplotlib colormap to us when mapping the ``scalars``.
            See available Matplotlib colormaps.  Only applicable for when
            displaying ``scalars``. Requires Matplotlib to be installed.
            ``colormap`` is also an accepted alias for this. If ``colorcet`` or
            ``cmocean`` are installed, their colormaps can be specified by name.
+
+            You can also specify a list of colors to override an
+            existing colormap with a custom one.  For example, to
+            create a three color colormap you might specify
+            ``['green', 'red', 'blue']``
 
         label : str, optional
             String label to use when adding a legend to the scene with

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -788,8 +788,8 @@ def test_opacity_transfer_functions():
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_closing_and_mem_cleanup():
     n = 5
-    for i in range(n):
-        for j in range(n):
+    for _ in range(n):
+        for _ in range(n):
             p = pyvista.Plotter(off_screen=OFF_SCREEN)
             for k in range(n):
                 p.add_mesh(pyvista.Sphere(radius=k))
@@ -855,3 +855,21 @@ def test_bad_keyword_arguments():
         plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
         plotter.add_mesh(mesh, foo="bad")
         plotter.show()
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+def test_cmap_list():
+    mesh = sphere.copy()
+
+    n = mesh.n_points
+    scalars = np.empty(n)
+    scalars[:n//3] = 0
+    scalars[n//3:2*n//3] = 1
+    scalars[2*n//3:] = 2
+
+    with pytest.raises(TypeError):
+        mesh.plot(off_screen=OFF_SCREEN,
+                  scalars=scalars, cmap=['red', None, 'blue'])
+    
+    mesh.plot(off_screen=OFF_SCREEN,
+              scalars=scalars, cmap=['red', 'green', 'blue'])


### PR DESCRIPTION
You can now pass a color map with a list of strings:

```python
import numpy as np
import pyvista

sphere = pyvista.Sphere()

n = sphere.n_points

# specify scalars
scalars = np.empty(n)
scalars[:n//3] = 0
scalars[n//3:2*n//3] = 1
scalars[2*n//3:] = 2

sphere.plot(scalars=scalars, cmap=['red', 'green', 'blue'])
```

![tmp](https://user-images.githubusercontent.com/11981631/68693556-c609ce80-0577-11ea-90ce-de829ef4cd14.png)
