### PR TITLE
Depth Peeling 

### DIFF
--- a/examples/02-plot/depth-peeling.py
+++ b/examples/02-plot/depth-peeling.py
@@ -1,0 +1,61 @@
+"""
+Depth Peeling
+~~~~~~~~~~~~~
+
+Depth peeling is a technique to correctly render translucent geometry.
+
+"""
+# sphinx_gallery_thumbnail_number = 2
+import pyvista as pv
+from pyvista import examples
+
+
+###############################################################################
+centers = [(0, 0, 0), (1, 0, 0), (-1, 0, 0),
+           (0, 1, 0), (0, -1, 0)]
+radii = [1, 0.5, 0.5, 0.5, 0.5]
+
+spheres = pv.MultiBlock()
+for i, c in enumerate(centers):
+    spheres.append(pv.Sphere(center=c, radius=radii[i]))
+
+###############################################################################
+dargs = dict(opacity=0.5, color="red", smooth_shading=True)
+
+p = pv.Plotter(shape=(1,2), multi_samples=8)
+
+p.add_mesh(spheres, **dargs)
+p.enable_depth_peeling(10)
+p.add_text("Depth Peeling")
+
+p.subplot(0,1)
+p.add_text("Standard")
+p.add_mesh(pv.wrap(spheres.copy()), **dargs)
+
+p.link_views()
+p.camera_position = [(11.695377287877744, 4.697473022306675, -4.313491106516902),
+ (0.0, 0.0, 0.0),
+ (0.3201103754961452, 0.07054027895287238, 0.944750451995112)]
+p.show()
+
+
+###############################################################################
+
+mesh = examples.download_brain().contour(5)
+cmap = "viridis_r"
+
+p = pv.Plotter(shape=(1,2), multi_samples=4)
+
+p.add_mesh(mesh, opacity=0.5, cmap=cmap)
+p.enable_depth_peeling(10)
+p.add_text("Depth Peeling")
+
+p.subplot(0,1)
+p.add_text("Standard")
+p.add_mesh(mesh.copy(), opacity=0.5, cmap=cmap)
+
+p.link_views()
+p.camera_position = [(418.29917315895693, 658.9752095516966, 53.784143976243364),
+ (90.19444444775581, 111.46052622795105, 90.0),
+ (0.03282296324460818, 0.046369526043831856, 0.9983849558854109)]
+p.show()

--- a/examples/02-plot/depth-peeling.py
+++ b/examples/02-plot/depth-peeling.py
@@ -30,7 +30,7 @@ p.add_text("Depth Peeling")
 
 p.subplot(0,1)
 p.add_text("Standard")
-p.add_mesh(pv.wrap(spheres.copy()), **dargs)
+p.add_mesh(spheres.copy(), **dargs)
 
 p.link_views()
 p.camera_position = [(11.695377287877744, 4.697473022306675, -4.313491106516902),

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -82,7 +82,7 @@ if scooby.in_ipykernel():
     try:
         import panel
         panel.extension('vtk')
-    except (ImportError, RuntimeError):
+    except:
         rcParams['use_panel'] = False
 
 # Set preferred plot theme

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -244,7 +244,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
             self.multi_samples = self.ren_win.GetMultiSamples()
             self.ren_win.AlphaBitPlanesOn()
             self.ren_win.SetMultiSamples(0)
-            self.renderer.enable_depth_peeling()
+            self.renderer.enable_depth_peeling(number_of_peels,
+                                               occlusion_ratio)
 
         return depth_peeling_supported
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -18,7 +18,8 @@ import pyvista
 from pyvista.utilities import (assert_empty_kwargs, convert_array,
                                convert_string_array, get_array,
                                is_pyvista_dataset, numpy_to_texture,
-                               raise_not_matching, try_callback, wrap)
+                               raise_not_matching, try_callback, wrap,
+                               check_depth_peeling)
 
 from .colors import get_cmap_safe
 from .export_vtkjs import export_plotter_vtkjs
@@ -217,6 +218,42 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def clear_events_for_key(self, key):
         self._key_press_event_callbacks.pop(key)
 
+
+    def enable_depth_peeling(self, number_of_peels=5, occlusion_ratio=0.1):
+        """Enables depth peeling if supported.
+
+        Parameters
+        ----------
+        number_of_peels: int
+            The maximum number of peeling layers. A value of 0 means no limit.
+
+        occlusion_ratio : float
+            The threshold under which the algorithm stops to iterate over peel
+            layers. A value of 0.0 means that the rendering have to be exact.
+            Greater values may speed-up the rendering with small impact on the
+            quality.
+
+        Returns
+        -------
+        depth_peeling_supported: bool
+            If True, depth peeling is supported.
+        """
+        depth_peeling_supported = check_depth_peeling(number_of_peels,
+                                                      occlusion_ratio)
+        if hasattr(self, 'ren_win') and depth_peeling_supported:
+            self.multi_samples = self.ren_win.GetMultiSamples()
+            self.ren_win.AlphaBitPlanesOn()
+            self.ren_win.SetMultiSamples(0)
+            self.renderer.enable_depth_peeling()
+
+        return depth_peeling_supported
+
+    def disable_depth_peeling(self):
+        """Disables depth peeling."""
+        if hasattr(self, 'multi_samples') and hasattr(self, 'ren_win'):
+            self.ren_win.AlphaBitPlanesOff()
+            self.ren_win.SetMultiSamples(self.multi_samples)
+            self.renderer.disable_depth_peeling()
 
     def enable_anti_aliasing(self):
         """Enables anti-aliasing FXAA"""

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -35,7 +35,7 @@ class Renderer(vtkRenderer):
         if border:
             self.add_border(border_color, border_width)
 
-    def enable_depth_peeling(self, number_of_peels=100, occlusion_ratio=0.1):
+    def enable_depth_peeling(self, number_of_peels=5, occlusion_ratio=0.1):
         """Enables depth peeling."""
         self.SetUseDepthPeeling(True)
         self.SetMaximumNumberOfPeels(number_of_peels)

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -35,7 +35,15 @@ class Renderer(vtkRenderer):
         if border:
             self.add_border(border_color, border_width)
 
+    def enable_depth_peeling(self, number_of_peels=100, occlusion_ratio=0.1):
+        """Enables depth peeling."""
+        self.SetUseDepthPeeling(True)
+        self.SetMaximumNumberOfPeels(number_of_peels)
+        self.SetOcclusionRatio(occlusion_ratio)
 
+    def disable_depth_peeling(self):
+        """Disables depth peeling."""
+        self.SetUseDepthPeeling(False)
 
     def enable_anti_aliasing(self):
         """Enables anti-aliasing FXAA"""

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -524,3 +524,26 @@ def try_callback(func, *args):
     except Exception as e:
         logging.warning('Encountered issue in callback: {}'.format(e))
     return
+
+
+def check_depth_peeling(number_of_peels=100, occlusion_ratio=0.0):
+    # Try Depth Peeling with a basic scene
+    source = vtk.vtkSphereSource()
+    mapper = vtk.vtkPolyDataMapper()
+    mapper.SetInputConnection(source.GetOutputPort())
+    actor = vtk.vtkActor()
+    actor.SetMapper(mapper)
+    # requires opacity < 1
+    actor.GetProperty().SetOpacity(0.5)
+    renderer = vtk.vtkRenderer()
+    renderWindow = vtk.vtkRenderWindow()
+    renderWindow.AddRenderer(renderer)
+    renderWindow.SetOffScreenRendering(True)
+    renderWindow.SetAlphaBitPlanes(True)
+    renderWindow.SetMultiSamples(0)
+    renderer.AddActor(actor)
+    renderer.SetUseDepthPeeling(True)
+    renderer.SetMaximumNumberOfPeels(number_of_peels)
+    renderer.SetOcclusionRatio(occlusion_ratio)
+    renderWindow.Render()
+    return renderer.GetLastRenderingUsedDepthPeeling() == 1

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -527,6 +527,10 @@ def try_callback(func, *args):
 
 
 def check_depth_peeling(number_of_peels=100, occlusion_ratio=0.0):
+    """Attempts to use depth peeling to see if it is available for the current
+    environment. Returns ``True`` if depth peeling is available and has been
+    successfully leveraged, otherwise ``False``.
+    """
     # Try Depth Peeling with a basic scene
     source = vtk.vtkSphereSource()
     mapper = vtk.vtkPolyDataMapper()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -721,6 +721,16 @@ def test_plot_compar_four():
 
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+def test_plot_depth_peeling():
+    mesh = examples.load_airplane()
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
+    p.add_mesh(mesh)
+    p.enable_depth_peeling()
+    p.disable_depth_peeling()
+    p.show()
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 @pytest.mark.skipif(os.name == 'nt', reason="No testing on windows for EDL")
 def test_plot_eye_dome_lighting():
     mesh = examples.load_airplane()


### PR DESCRIPTION
This PR adds `enable_depth_peeling()` and `disable_depth_peeling()` functions to the `BasePlotter` API. There is also `check_depth_peeling()` in `pyvista.utilities`. This is strongly inspired by the material provided in [lorensen.github.io](https://lorensen.github.io/VTKExamples/site/) about [translucent geometry](https://lorensen.github.io/VTKExamples/site/Cxx/Visualization/CorrectlyRenderTranslucentGeometry/).

Closes #437 