### PR TITLE
BUGFIX: copying composite datasets would not wrap internal structures

### DIFF
--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -516,4 +516,5 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
         else:
             newobject.shallow_copy(self)
         newobject.copy_meta_from(self)
+        newobject.wrap_nested()
         return newobject

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -279,11 +279,15 @@ def test_multi_block_copy():
     assert multi.n_blocks == 5 == newobj.n_blocks
     assert id(multi[0]) != id(newobj[0])
     assert id(multi[-1]) != id(newobj[-1])
+    for i in range(newobj.n_blocks):
+        assert pyvista.is_pyvista_dataset(newobj.GetBlock(i))
     # Now check shallow
     newobj = multi.copy(deep=False)
     assert multi.n_blocks == 5 == newobj.n_blocks
     assert id(multi[0]) == id(newobj[0])
     assert id(multi[-1]) == id(newobj[-1])
+    for i in range(newobj.n_blocks):
+        assert pyvista.is_pyvista_dataset(newobj.GetBlock(i))
     return
 
 


### PR DESCRIPTION
This fixes a bug when calling `.copy()` on `MultiBlock` datasets

```py
import pyvista as pv

centers = [(0, 0, 0), (1, 0, 0), (-1, 0, 0), 
           (0, 1, 0), (0, -1, 0)]
radii = [1, 0.5, 0.5, 0.5, 0.5]

spheres = pv.MultiBlock()
for i, c in enumerate(centers):
    spheres.append(pv.Sphere(center=c, radius=radii[i]))
    
    
spheres.copy().plot()
```
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-11-f0416828be34> in <module>
     11 
     12 
---> 13 spheres.copy().plot()

~/Software/pyvista/pyvista/pyvista/plotting/helpers.py in plot(var_item, off_screen, full_screen, screenshot, interactive, cpos, window_size, show_bounds, show_axes, notebook, background, text, return_img, eye_dome_lighting, use_panel, volume, parallel_projection, **kwargs)
    110             plotter.add_volume(var_item, **kwargs)
    111         else:
--> 112             plotter.add_mesh(var_item, **kwargs)
    113 
    114     if text:

~/Software/pyvista/pyvista/pyvista/plotting/plotting.py in add_mesh(self, mesh, color, style, scalars, clim, show_edges, edge_color, point_size, line_width, opacity, flip_scalars, lighting, n_colors, interpolate_before_map, cmap, label, reset_camera, scalar_bar_args, show_scalar_bar, stitle, multi_colors, name, texture, render_points_as_spheres, render_lines_as_tubes, smooth_shading, ambient, diffuse, specular, specular_power, nan_color, nan_opacity, loc, culling, rgb, categories, use_transparency, below_color, above_color, annotations, pickable, preference, **kwargs)
    920             # extract surface if mesh is exterior
    921             if not isinstance(mesh, pyvista.PolyData):
--> 922                 grid = mesh
    923                 mesh = grid.extract_surface()
    924                 ind = mesh.point_arrays['vtkOriginalPointIds']

AttributeError: 'vtkCommonDataModelPython.vtkPolyData' object has no attribute 'n_points'
```