### PR TITLE
Catch up to sphinx_gallery v0.5

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,7 +101,7 @@ sphinx_gallery_conf = {
     # Sort gallery example by file name instead of number of lines (default)
     "within_subsection_order": FileNameSortKey,
     # directory where function granular galleries are stored
-    "backreferences_dir": False,
+    "backreferences_dir": None,
     # Modules for which function level galleries are created.  In
     "doc_module": "pyvista",
     "image_scrapers": ('pyvista', 'matplotlib'),

--- a/examples/00-load/create-point-cloud.py
+++ b/examples/00-load/create-point-cloud.py
@@ -33,17 +33,17 @@ def generate_points(subset=0.02):
 points = generate_points()
 # Print firts 5 rows to prove its a numpy array (n_points by 3)
 # Columns are (X Y Z)
-print(points[0:5, :])
+points[0:5, :]
 
 ###############################################################################
 # Now that you have a NumPy array of points/vertices either from our sample
 # data or your own project, creating a PyVista mesh of those points is simply:
 point_cloud = pv.PolyData(points)
-print(point_cloud)
+point_cloud
 
 ###############################################################################
 # And we can even do a sanity check
-print(np.allclose(points, point_cloud.points))
+np.allclose(points, point_cloud.points)
 
 ###############################################################################
 # And now that we have a PyVista mesh, we can plot it. Note that we add an
@@ -94,7 +94,7 @@ def compute_vectors(mesh):
     return vectors
 
 vectors = compute_vectors(point_cloud)
-print(vectors[0:5, :])
+vectors[0:5, :]
 
 ###############################################################################
 

--- a/examples/00-load/create-spline.py
+++ b/examples/00-load/create-spline.py
@@ -25,7 +25,7 @@ def make_points():
     return np.column_stack((x, y, z))
 
 points = make_points()
-print(points[0:5, :])
+points[0:5, :]
 
 ###############################################################################
 # Now let's make a function that can create line cells on a
@@ -44,7 +44,7 @@ def lines_from_points(points):
 
 
 line = lines_from_points(points)
-print(line)
+line
 
 ###############################################################################
 line["scalars"] = np.arange(line.n_points)

--- a/examples/00-load/create-structured-surface.py
+++ b/examples/00-load/create-structured-surface.py
@@ -41,7 +41,7 @@ grid.plot_curvature(clim=[-1, 1])
 # Generating a structured grid is a one liner in this module, and the points
 # from the resulting surface can be accessed as a NumPy array:
 
-print(grid.points)
+grid.points
 
 
 ###############################################################################
@@ -80,7 +80,7 @@ def make_point_set():
 
 # Get the points as a 2D NumPy array (N by 3)
 points = make_point_set()
-print(points[0:5, :])
+points[0:5, :]
 
 ###############################################################################
 # Now pretend that the (n by 3) NumPy array above are coordinates that you

--- a/examples/00-load/create-tri-surface.py
+++ b/examples/00-load/create-tri-surface.py
@@ -22,7 +22,7 @@ zz = A * np.exp(-0.5 * ((xx / b) ** 2.0 + (yy / b) ** 2.0))
 
 # Get the points as a 2D NumPy array (N by 3)
 points = np.c_[xx.reshape(-1), yy.reshape(-1), zz.reshape(-1)]
-print(points[0:5, :])
+points[0:5, :]
 
 ###############################################################################
 # Now use those points to create a point cloud PyVista data object. This will

--- a/examples/00-load/read-file.py
+++ b/examples/00-load/read-file.py
@@ -25,7 +25,7 @@ import matplotlib.pyplot as plt
 
 # Get a sample file
 filename = examples.planefile
-print(filename)
+filename
 
 ###############################################################################
 # Note the above filename, it's a ``.ply`` file - one of the many supported
@@ -46,12 +46,12 @@ plotter.show(screenshot="myscreenshot.png")
 ###############################################################################
 # The points from the mesh are directly accessible as a NumPy array:
 
-print(mesh.points)
+mesh.points
 
 ###############################################################################
 # The faces from the mesh are also directly accessible as a NumPy array:
 
-print(mesh.faces.reshape(-1, 4)[:, 1:]) # triangular faces
+mesh.faces.reshape(-1, 4)[:, 1:] # triangular faces
 
 
 ###############################################################################

--- a/examples/00-load/read-parallel.py
+++ b/examples/00-load/read-parallel.py
@@ -25,10 +25,10 @@ examples.download_blood_vessels()
 #
 # Let's inspect where this downloaded our dataset:
 path = os.path.join(pv.EXAMPLES_PATH, "blood_vessels")
-print(os.listdir(path))
+os.listdir(path)
 
 ###############################################################################
-print(os.listdir(os.path.join(path, "T0000000500")))
+os.listdir(os.path.join(path, "T0000000500"))
 
 ###############################################################################
 # Note that a ``.pvtu`` file is available along side a directory. This
@@ -37,7 +37,7 @@ print(os.listdir(os.path.join(path, "T0000000500")))
 # together.
 filename = os.path.join(path, "T0000000500.pvtu")
 mesh = pv.read(filename)
-print(mesh)
+mesh
 
 ###############################################################################
 # Plot the pieced together mesh

--- a/examples/01-filter/geodesic.py
+++ b/examples/01-filter/geodesic.py
@@ -28,4 +28,4 @@ p.show()
 ###############################################################################
 # How long is that path?
 distance = sphere.geodesic_distance(0, sphere.n_points - 1)
-print(distance)
+distance

--- a/examples/01-filter/slicing.py
+++ b/examples/01-filter/slicing.py
@@ -90,13 +90,13 @@ x, y = path(np.arange(model.bounds[2], model.bounds[3], 15.0))
 zo = np.linspace(9.0, 11.0, num=len(y))
 points = np.c_[x, y, zo]
 spline = pv.Spline(points, 15)
-print(spline)
+spline
 
 
 ###############################################################################
 # Then run the filter
 slc = model.slice_along_line(spline)
-print(slc)
+slc
 
 ###############################################################################
 

--- a/examples/02-plot/labels.py
+++ b/examples/02-plot/labels.py
@@ -27,8 +27,7 @@ poly = pv.PolyData(np.random.rand(10, 3))
 # node:
 
 poly["My Labels"] = ["Label {}".format(i) for i in range(poly.n_points)]
-
-print(poly)
+poly
 
 ###############################################################################
 # Now plot the points with labels:

--- a/examples/02-plot/opacity.py
+++ b/examples/02-plot/opacity.py
@@ -127,7 +127,7 @@ p.show()
 
 model = examples.download_model_with_variance()
 contours = model.contour(10, scalars='Temperature')
-print(contours.array_names)
+contours.array_names
 
 ###############################################################################
 # Make sure to flag ``use_transparency=True`` since we want areas of high

--- a/examples/02-plot/topo-map.py
+++ b/examples/02-plot/topo-map.py
@@ -16,7 +16,7 @@ elevation = examples.download_crater_topo().warp_by_scalar()
 # Load the topographic map from a GeoTiff
 topo_map = examples.download_crater_imagery()
 
-print(elevation)
+elevation
 
 ###############################################################################
 # Let's inspect the imagery that we just loaded

--- a/examples/02-plot/volume.py
+++ b/examples/02-plot/volume.py
@@ -15,7 +15,7 @@ pv.rcParams["use_panel"] = False
 
 # Download a volumetric dataset
 vol = examples.download_knee_full()
-print(vol)
+vol
 
 ###############################################################################
 # Simple Volume Render


### PR DESCRIPTION
Fixes the "backreferences_dir" issue from https://github.com/sphinx-gallery/sphinx-gallery/issues/567 which is causing all of our docs builds to fail

This also changes the examples gallery to now leverage the `__repr__` and `_repr_html_` methods utilized in `v0.5.0` of `sphinx-gallery`:

Before             |  After
:-------------------------:|:-------------------------:
<img width="669" alt="Screen Shot 2019-11-19 at 8 30 22 AM" src="https://user-images.githubusercontent.com/22067021/69160710-41eba580-0aa7-11ea-96b3-05944a8e415b.png">  |  <img width="664" alt="Screen Shot 2019-11-19 at 8 35 20 AM" src="https://user-images.githubusercontent.com/22067021/69160908-88410480-0aa7-11ea-86cd-86c762d4100e.png">




