### PR TITLE
Improve naming consistency

### DIFF
--- a/docs/plotting/plotting.rst
+++ b/docs/plotting/plotting.rst
@@ -212,7 +212,7 @@ values change through time:
 
     globe = examples.load_globe()
     globe.point_arrays['scalars'] = np.random.rand(globe.n_points)
-    globe.set_active_scalar('scalars')
+    globe.set_active_scalars('scalars')
 
 
     plotter = pv.BackgroundPlotter()

--- a/docs/utilities/utilities.rst
+++ b/docs/utilities/utilities.rst
@@ -53,9 +53,11 @@ Array Access
 
 .. autofunction:: pyvista.convert_array
 
-.. autofunction:: pyvista.point_scalar
+.. autofunction:: pyvista.point_array
 
-.. autofunction:: pyvista.cell_scalar
+.. autofunction:: pyvista.cell_array
+
+.. autofunction:: pyvista.field_array
 
 .. autofunction:: pyvista.get_vtk_type
 

--- a/examples/01-filter/compute-volume.py
+++ b/examples/01-filter/compute-volume.py
@@ -20,7 +20,7 @@ from pyvista import examples
 
 # Load a simple example mesh
 dataset = examples.load_uniform()
-dataset.set_active_scalar("Spatial Cell Data")
+dataset.set_active_scalars("Spatial Cell Data")
 
 ###############################################################################
 # We can then calculate the volume of every cell in the array using the
@@ -105,7 +105,7 @@ largest.plot(show_grid=True, cpos=[-2, 5, 3])
 
 # Load a simple example mesh
 dataset = examples.load_uniform()
-dataset.set_active_scalar("Spatial Cell Data")
+dataset.set_active_scalars("Spatial Cell Data")
 threshed = dataset.threshold_percent([0.15, 0.50], invert=True)
 
 bodies = threshed.split_bodies()

--- a/examples/01-filter/streamlines.py
+++ b/examples/01-filter/streamlines.py
@@ -52,7 +52,7 @@ p.show()
 # Here is another example of blood flow:
 
 mesh = examples.download_blood_vessels().cell_data_to_point_data()
-mesh.set_active_scalar("velocity")
+mesh.set_active_scalars("velocity")
 streamlines, src = mesh.streamlines(
     return_source=True, source_radius=10, source_center=(92.46, 74.37, 135.5)
 )

--- a/examples/01-filter/using-filters.py
+++ b/examples/01-filter/using-filters.py
@@ -27,7 +27,7 @@ from pyvista import examples
 # object:
 
 dataset = examples.load_uniform()
-dataset.set_active_scalar("Spatial Point Data")
+dataset.set_active_scalars("Spatial Point Data")
 
 # Apply a threshold over a data range
 threshed = dataset.threshold([100, 500])

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -367,7 +367,10 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def active_scalar_info(self):
-        """DEPRECATED: Return the active scalar's field and name: [field, name]"""
+        """Return the active scalar's field and name.
+
+        DEPRECATED: use `.active_scalars_info` instead
+        """
         warnings.warn("DEPRECATED: use `.active_scalars_info` instead")
         return self.active_scalars_info
 
@@ -420,13 +423,13 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def active_scalars_name(self):
-        """Returns the active scalar's name"""
+        """Return the active scalar's name."""
         return self.active_scalars_info[1]
 
 
     @active_scalars_name.setter
     def active_scalars_name(self, name):
-        """Set the name of the active scalar"""
+        """Set the name of the active scalar."""
         return self.set_active_scalars(name)
 
     @property
@@ -622,7 +625,8 @@ class Common(DataSetFilters, DataObject):
 
 
     def set_active_scalar(self, name, preference='cell'):
-        """Finds the scalars by name and appropriately sets it as active.
+        """Find the scalars by name and appropriately sets it as active.
+
         To deactivate any active scalars, pass ``None`` as the ``name``.
         """
         warnings.warn("DEPRECATED: please use `.set_active_scalars` instead.")
@@ -665,8 +669,11 @@ class Common(DataSetFilters, DataObject):
 
 
     def rename_scalar(self, old_name, new_name, preference='cell'):
-        """DEPRECATED: Changes array name by searching for the array then
-        renaming it"""
+        """Change an array name by searching for the array then renaming it.
+
+        DEPRECATED: please use `.rename_array` instead.
+
+        """
         warnings.warn("DEPRECATED: please use `.rename_array` instead.")
         return self.rename_array(old_name, new_name, preference=preference)
 

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -352,6 +352,12 @@ class Common(DataSetFilters, DataObject):
 
         return self._active_scalars_info
 
+    @property
+    def active_scalar_info(self):
+        """DEPRECATED: Return the active scalar's field and name: [field, name]"""
+        warnings.warn("DEPRECATED: use `.active_scalars_info` instead")
+        return self.active_scalars_info
+
 
     @property
     def active_vectors_info(self):
@@ -409,6 +415,19 @@ class Common(DataSetFilters, DataObject):
     def active_scalars_name(self, name):
         """Set the name of the active scalar"""
         return self.set_active_scalars(name)
+
+    @property
+    def active_scalar_name(self):
+        """Returns the active scalar's name"""
+        warnings.warn("DEPRECATED: use `.active_scalars_name` instead.")
+        return self.active_scalars_name
+
+
+    @active_scalar_name.setter
+    def active_scalar_name(self, name):
+        """Set the name of the active scalar"""
+        warnings.warn("DEPRECATED: use `.active_scalars_name` instead.")
+        self.active_scalars_name = name
 
 
     @property

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -73,7 +73,7 @@ class DataObject(object):
 
 
     def get_data_range(self, arr=None, preference='field'):
-        """Get the non-NaN min and max of a named scalar array.
+        """Get the non-NaN min and max of a named array.
 
         Parameters
         ----------
@@ -82,7 +82,7 @@ class DataObject(object):
             is used
 
         preference : str, optional
-            When scalars is specified, this is the perfered scalar type to
+            When scalars is specified, this is the perfered array type to
             search for in the dataset.  Must be either ``'point'``, ``'cell'``,
             or ``'field'``.
 
@@ -141,7 +141,7 @@ class DataObject(object):
     def _repr_html_(self):
         """Return a pretty representation for Jupyter notebooks.
 
-        This includes header details and information about all scalar arrays.
+        This includes header details and information about all arrays.
 
         """
         raise NotImplemented
@@ -194,7 +194,7 @@ class DataObject(object):
             raise RuntimeError('Must specify an array to fetch.')
         vtkarr = self.GetFieldData().GetAbstractArray(name)
         if vtkarr is None:
-            raise AssertionError('({}) is not a valid field scalar array'.format(name))
+            raise AssertionError('({}) is not a valid field array.'.format(name))
 
         # numpy does not support bit array data types
         if isinstance(vtkarr, vtk.vtkBitArray):
@@ -209,7 +209,7 @@ class DataObject(object):
 
 
     def _add_field_array(self, scalars, name, deep=True):
-        """Add field scalars to the mesh.
+        """Add a field array to the mesh.
 
         Parameters
         ----------
@@ -247,7 +247,7 @@ class DataObject(object):
 
 
     def _add_field_scalar(self, scalars, name, set_active=False, deep=True):
-        """Add a scalar field.
+        """Add a field array.
 
         DEPRECATED: Please use `_add_field_array` instead.
 
@@ -257,7 +257,7 @@ class DataObject(object):
 
 
     def add_field_array(self, scalars, name, deep=True):
-        """Add a scalar field."""
+        """Add a field array."""
         self._add_field_array(scalars, name, deep=deep)
 
 
@@ -326,7 +326,7 @@ class Common(DataSetFilters, DataObject):
             self._last_active_scalars_name = None
         field, name = self._active_scalars_info
 
-        # rare error where scalar name isn't a valid scalar
+        # rare error where scalars name isn't a valid scalar
         if name not in self.point_arrays:
             if name not in self.cell_arrays:
                 if name in self.field_arrays:
@@ -383,7 +383,7 @@ class Common(DataSetFilters, DataObject):
                 self._active_vectors_info = [POINT_DATA_FIELD, None] # field and name
         _, name = self._active_vectors_info
 
-        # rare error where scalar name isn't a valid scalar
+        # rare error where name isn't a valid array
         if name not in self.point_arrays:
             if name not in self.cell_arrays:
                 if name in self.field_arrays:
@@ -601,7 +601,7 @@ class Common(DataSetFilters, DataObject):
 
 
     def set_active_scalars(self, name, preference='cell'):
-        """Find the scalar by name and appropriately sets it as active.
+        """Find the scalars by name and appropriately sets it as active.
 
         To deactivate any active scalars, pass ``None`` as the ``name``.
 
@@ -622,7 +622,7 @@ class Common(DataSetFilters, DataObject):
 
 
     def set_active_scalar(self, name, preference='cell'):
-        """Finds the scalar by name and appropriately sets it as active.
+        """Finds the scalars by name and appropriately sets it as active.
         To deactivate any active scalars, pass ``None`` as the ``name``.
         """
         warnings.warn("DEPRECATED: please use `.set_active_scalars` instead.")
@@ -673,7 +673,7 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def active_scalars(self):
-        """Return the active scalar as an array."""
+        """Return the active scalars as an array."""
         field, name = self.active_scalars_info
         if name is None:
             return None
@@ -684,7 +684,7 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def active_scalar(self):
-        """DEPRECATED: Returns the active scalar as an array."""
+        """DEPRECATED: Returns the active scalars as an array."""
         warnings.warn("DEPRECATED: please use `.active_scalars` instead.")
         return self.active_scalars
 
@@ -704,7 +704,7 @@ class Common(DataSetFilters, DataObject):
 
         """
         if name is None:
-            # use active scalar array
+            # use active scalars array
             field, name = self.active_scalars_info
             if field != POINT_DATA_FIELD:
                 raise RuntimeError('Must specify an array to fetch.')
@@ -781,22 +781,22 @@ class Common(DataSetFilters, DataObject):
 
 
     def get_data_range(self, arr=None, preference='cell'):
-        """Get the non-NaN min and max of a named scalar array.
+        """Get the non-NaN min and max of a named array.
 
         Parameters
         ----------
         arr : str, np.ndarray, optional
-            The name of the array to get the range. If None, the active scalar
+            The name of the array to get the range. If None, the active scalars
             is used
 
         preference : str, optional
-            When scalars is specified, this is the perfered scalar type to
+            When scalars is specified, this is the perfered array type to
             search for in the dataset.  Must be either ``'point'``, ``'cell'``,
             or ``'field'``.
 
         """
         if arr is None:
-            # use active scalar array
+            # use active scalars array
             _, arr = self.active_scalars_info
         if isinstance(arr, str):
             arr = get_array(self, arr, preference=preference)
@@ -909,7 +909,7 @@ class Common(DataSetFilters, DataObject):
 
         """
         if name is None:
-            # use active scalar array
+            # use active scalars array
             field, name = self.active_scalars_info
             if field != CELL_DATA_FIELD:
                 raise RuntimeError('Must specify an array to fetch.')
@@ -1210,7 +1210,7 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def n_arrays(self):
-        """Return the number of scalar arrays present in the dataset."""
+        """Return the number of arrays present in the dataset."""
         n = self.GetPointData().GetNumberOfArrays()
         n += self.GetCellData().GetNumberOfArrays()
         n += self.GetFieldData().GetNumberOfArrays()
@@ -1230,9 +1230,9 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def array_names(self):
-        """Return a list of scalar names for the dataset.
+        """Return a list of array names for the dataset.
 
-        This makes sure to put the active scalar's name first in the list.
+        This makes sure to put the active scalars' name first in the list.
 
         """
         names = []
@@ -1252,7 +1252,7 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def scalar_names(self):
-        """Return the scalar names.
+        """Return the array names.
 
         DEPRECATED: Please use `array_names` instead.
 
@@ -1279,7 +1279,7 @@ class Common(DataSetFilters, DataObject):
     def _repr_html_(self):
         """Return a pretty representation for Jupyter notebooks.
 
-        It includes header details and information about all scalar arrays.
+        It includes header details and information about all arrays.
 
         """
         fmt = ""
@@ -1289,7 +1289,7 @@ class Common(DataSetFilters, DataObject):
             fmt += "<tr><td>"
         # Get the header info
         fmt += self.head(display=False, html=True)
-        # Fill out scalar arrays
+        # Fill out arrays
         if self.n_arrays > 0:
             fmt += "</td><td>"
             fmt += "\n"
@@ -1452,7 +1452,7 @@ class CellScalarsDict(_ScalarsDict):
     """Update internal cell data when an array is added or removed from the dictionary."""
 
     def __init__(self, data):
-        """Initialize the cell scalar dict."""
+        """Initialize the cell array dict."""
         _ScalarsDict.__init__(self, data)
         self.remover = lambda key: self.data._remove_array(CELL_DATA_FIELD, key)
         self.modifier = lambda *args: self.data.GetCellData().Modified()
@@ -1467,7 +1467,7 @@ class PointScalarsDict(_ScalarsDict):
     """Update internal point data when an array is added or removed from the dictionary."""
 
     def __init__(self, data):
-        """Initialize the point scalar dict."""
+        """Initialize the point array dict."""
         _ScalarsDict.__init__(self, data)
         self.remover = lambda key: self.data._remove_array(POINT_DATA_FIELD, key)
         self.modifier = lambda *args: self.data.GetPointData().Modified()
@@ -1482,7 +1482,7 @@ class FieldScalarsDict(_ScalarsDict):
     """Update internal field data when an array is added or removed from the dictionary."""
 
     def __init__(self, data):
-        """Initialize the field scalars dict."""
+        """Initialize the field array dict."""
         _ScalarsDict.__init__(self, data)
         self.remover = lambda key: self.data._remove_array(FIELD_DATA_FIELD, key)
         self.modifier = lambda *args: self.data.GetFieldData().Modified()

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -685,7 +685,7 @@ class Common(DataSetFilters, DataObject):
     @property
     def active_scalar(self):
         """DEPRECATED: Returns the active scalar as an array."""
-        warnings.warn("DEPRECATED: please use `.rename_array` instead.")
+        warnings.warn("DEPRECATED: please use `.active_scalars` instead.")
         field, name = self.active_scalars_info
         if name is None:
             return None

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -686,13 +686,7 @@ class Common(DataSetFilters, DataObject):
     def active_scalar(self):
         """DEPRECATED: Returns the active scalar as an array."""
         warnings.warn("DEPRECATED: please use `.active_scalars` instead.")
-        field, name = self.active_scalars_info
-        if name is None:
-            return None
-        if field == POINT_DATA_FIELD:
-            return self._point_array(name)
-        elif field == CELL_DATA_FIELD:
-            return self._cell_array(name)
+        return self.active_scalars
 
 
     def _point_array(self, name=None):

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -245,13 +245,13 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
 
     def get_data_range(self, name):
-        """Get the min/max of a scalar given its name across all blocks."""
+        """Get the min/max of an array given its name across all blocks."""
         mini, maxi = np.inf, -np.inf
         for i in range(self.n_blocks):
             data = self[i]
             if data is None:
                 continue
-            # get the scalar if available
+            # get the scalars if available
             arr = get_array(data, name)
             if arr is None or not np.issubdtype(arr.dtype, np.number):
                 continue

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -422,10 +422,10 @@ class DataSetFilters(object):
                   preference='cell'):
         """Apply a ``vtkThreshold`` filter to the input dataset.
 
-        This filter will apply a ``vtkThreshold`` filter to the input dataset and
-        return the resulting object. This extracts cells where scalar value in each
-        cell satisfies threshold criterion.  If scalars is None, the inputs
-        active_scalars is used.
+        This filter will apply a ``vtkThreshold`` filter to the input dataset
+        and return the resulting object. This extracts cells where the scalar
+        value in each cell satisfies threshold criterion.  If scalars is None,
+        the inputs active scalars is used.
 
         Parameters
         ----------
@@ -449,7 +449,7 @@ class DataSetFilters(object):
             rather than the set of discrete scalar values from the vertices.
 
         preference : str, optional
-            When scalars is specified, this is the preferred scalar type to
+            When scalars is specified, this is the preferred array type to
             search for in the dataset.  Must be either ``'point'`` or ``'cell'``
 
         """
@@ -503,7 +503,7 @@ class DataSetFilters(object):
 
     def threshold_percent(dataset, percent=0.50, scalars=None, invert=False,
                           continuous=False, preference='cell'):
-        """Threshold the dataset by a percentage of its range on the active scalar array or as specified.
+        """Threshold the dataset by a percentage of its range on the active scalars array or as specified.
 
         Parameters
         ----------
@@ -526,7 +526,7 @@ class DataSetFilters(object):
             rather than the set of discrete scalar values from the vertices.
 
         preference : str, optional
-            When scalars is specified, this is the preferred scalar type to
+            When scalars is specified, this is the preferred array type to
             search for in the dataset.  Must be either ``'point'`` or ``'cell'``
 
         """
@@ -647,17 +647,17 @@ class DataSetFilters(object):
             dataset given, the valid range of that array will be used.
 
         preference : str, optional
-            When a scalar name is specified for ``scalar_range``, this is the
-            preferred scalar type to search for in the dataset.
+            When an array name is specified for ``scalar_range``, this is the
+            preferred array type to search for in the dataset.
             Must be either 'point' or 'cell'.
 
         set_active : bool, optional
             A boolean flag on whether or not to set the new `Elevation` scalar
-            as the active scalar array on the output dataset.
+            as the active scalars array on the output dataset.
 
         Warning
         -------
-        This will create a scalar array named `Elevation` on the point data of
+        This will create a scalars array named `Elevation` on the point data of
         the input dataset and overasdf write an array named `Elevation` if present.
 
         """
@@ -686,7 +686,7 @@ class DataSetFilters(object):
         alg.SetLowPoint(low_point)
         alg.SetHighPoint(high_point)
         alg.Update()
-        # Decide on updating active scalar array
+        # Decide on updating active scalars array
         name = 'Elevation' # Note that this is added to the PointData
         if not set_active:
             name = None
@@ -720,11 +720,11 @@ class DataSetFilters(object):
 
         rng : tuple(float), optional
             If an integer number of isosurfaces is specified, this is the range
-            over which to generate contours. Default is the scalar arrays's full
+            over which to generate contours. Default is the scalars arrays' full
             data range.
 
         preference : str, optional
-            When scalars is specified, this is the preferred scalar type to
+            When scalars is specified, this is the preferred array type to
             search for in the dataset.  Must be either ``'point'`` or ``'cell'``
 
         method : str, optional
@@ -1043,7 +1043,7 @@ class DataSetFilters(object):
 
     def warp_by_scalar(dataset, scalars=None, factor=1.0, normal=None,
                        inplace=False, **kwargs):
-        """Warp the dataset's points by a point data scalar array's values.
+        """Warp the dataset's points by a point data scalars array's values.
 
         This modifies point coordinates by moving points along point normals by
         the scalar amount times the scale factor.
@@ -1290,7 +1290,7 @@ class DataSetFilters(object):
 
     def sample(dataset, target, tolerance=None, pass_cell_arrays=True,
                pass_point_arrays=True):
-        """Resample scalar data from a passed mesh onto this mesh.
+        """Resample array data from a passed mesh onto this mesh.
 
         This uses :class:`vtk.vtkResampleWithDataSet`.
 
@@ -1797,11 +1797,11 @@ class DataSetFilters(object):
         Parameters
         ----------
         pass_pointid : bool, optional
-            Adds a point scalar "vtkOriginalPointIds" that idenfities which
+            Adds a point array "vtkOriginalPointIds" that idenfities which
             original points these surface points correspond to
 
         pass_cellid : bool, optional
-            Adds a cell scalar "vtkOriginalPointIds" that idenfities which
+            Adds a cell array "vtkOriginalPointIds" that idenfities which
             original cells these surface cells correspond to
 
         inplace : bool, optional
@@ -1925,7 +1925,7 @@ class DataSetFilters(object):
 
         main_has_priority : bool, optional
             When this parameter is true and merge_points is true,
-            the scalar arrays of the merging grids will be overwritten
+            the arrays of the merging grids will be overwritten
             by the original main mesh.
 
         Return
@@ -1936,7 +1936,7 @@ class DataSetFilters(object):
         Notes
         -----
         When two or more grids are joined, the type and name of each
-        scalar array must match or the arrays will be ignored and not
+        array must match or the arrays will be ignored and not
         included in the final merged mesh.
 
         """
@@ -2084,11 +2084,11 @@ class DataSetFilters(object):
 
         """
         alg = vtk.vtkGradientFilter()
-        # Check if scalar array given
+        # Check if scalars array given
         if scalars is None:
             field, scalars = dataset.active_scalars_info
         if not isinstance(scalars, str):
-            raise TypeError('Scalar array must be given as a string name')
+            raise TypeError('scalars array must be given as a string name')
         _, field = dataset.get_array(scalars, preference=preference, info=True)
         # args: (idx, port, connection, field, name)
         alg.SetInputArrayToProcess(0, 0, 0, field, scalars)
@@ -2634,7 +2634,7 @@ class PolyDataFilters(DataSetFilters):
             Minimum tube radius (minimum because the tube radius may vary).
 
         scalars : str, optional
-            Scalar array by which the radius varies
+            scalars array by which the radius varies
 
         capping : bool
             Turn on/off whether to cap the ends with polygons. Default True.
@@ -2646,7 +2646,7 @@ class PolyDataFilters(DataSetFilters):
             Maximum tube radius in terms of a multiple of the minimum radius.
 
         preference : str
-            The field preference when searching for the scalar array by name
+            The field preference when searching for the scalars array by name
 
         inplace : bool, optional
             Updates mesh in-place while returning nothing.
@@ -2669,10 +2669,10 @@ class PolyDataFilters(DataSetFilters):
             tube.SetRadius(radius)
         tube.SetNumberOfSides(n_sides)
         tube.SetRadiusFactor(radius_factor)
-        # Check if scalar array given
+        # Check if scalars array given
         if scalars is not None:
             if not isinstance(scalars, str):
-                raise TypeError('Scalar array must be given as a string name')
+                raise TypeError('scalars array must be given as a string name')
             _, field = poly_data.get_array(scalars, preference=preference, info=True)
             # args: (idx, port, connection, field, name)
             tube.SetInputArrayToProcess(0, 0, 0, field, scalars)
@@ -3518,7 +3518,7 @@ class UniformGridFilters(DataSetFilters):
             Name of scalars to process. Defaults to currently active scalars.
 
         preference : str, optional
-            When scalars is specified, this is the preferred scalar type to
+            When scalars is specified, this is the preferred array type to
             search for in the dataset.  Must be either ``'point'`` or ``'cell'``
 
         """

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -27,7 +27,7 @@ except ImportError:
 class Table(vtk.vtkTable, DataObject):
     """Wrapper for the ``vtkTable`` class.
 
-    Create by passing a 2D NumPy array of shape (``n_rows`` by ``n_columns``) 
+    Create by passing a 2D NumPy array of shape (``n_rows`` by ``n_columns``)
     or from a dictionary containing NumPy arrays.
 
     Example
@@ -313,7 +313,7 @@ class Table(vtk.vtkTable, DataObject):
     def _repr_html_(self):
         """Return a pretty representation for Jupyter notebooks.
 
-        It includes header details and information about all scalar arrays.
+        It includes header details and information about all arrays.
 
         """
         fmt = ""
@@ -323,7 +323,7 @@ class Table(vtk.vtkTable, DataObject):
             fmt += "<tr><td>"
         # Get the header info
         fmt += self.head(display=False, html=True)
-        # Fill out scalar arrays
+        # Fill out scalars arrays
         if self.n_arrays > 0:
             fmt += "</td><td>"
             fmt += "\n"
@@ -382,7 +382,7 @@ class Table(vtk.vtkTable, DataObject):
 
 
     def get_data_range(self, arr=None, preference='row'):
-        """Get the non-NaN min and max of a named scalar array.
+        """Get the non-NaN min and max of a named array.
 
         Parameters
         ----------
@@ -391,7 +391,7 @@ class Table(vtk.vtkTable, DataObject):
             is used
 
         preference : str, optional
-            When scalars is specified, this is the perfered scalar type to
+            When scalars is specified, this is the perfered array type to
             search for in the dataset.  Must be either ``'row'`` or
             ``'field'``.
 

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -440,7 +440,7 @@ class Texture(vtk.vtkTexture):
             raise AssertionError('Input image must be nn by nm by RGB')
         grid = pyvista.UniformGrid((image.shape[1], image.shape[0], 1))
         grid.point_arrays['Image'] = np.flip(image.swapaxes(0,1), axis=1).reshape((-1, 3), order='F')
-        grid.set_active_scalar('Image')
+        grid.set_active_scalars('Image')
         return self._from_image_data(grid)
 
 
@@ -462,7 +462,7 @@ class Texture(vtk.vtkTexture):
     def to_array(self):
         image = self.to_image()
         shape = (image.dimensions[0], image.dimensions[1], 3)
-        return np.flip(image.active_scalar.reshape(shape, order='F'), axis=1).swapaxes(1,0)
+        return np.flip(image.active_scalars.reshape(shape, order='F'), axis=1).swapaxes(1,0)
 
 
     def plot(self, *args, **kwargs):

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -305,7 +305,7 @@ def download_spider():
 
 def download_carotid():
     mesh = _download_and_read('carotid.vtk')
-    mesh.set_active_scalar('scalars')
+    mesh.set_active_scalars('scalars')
     mesh.set_active_vectors('vectors')
     return mesh
 
@@ -371,10 +371,10 @@ def download_tetra_dc_mesh():
     local_path, _ = _download_file('dc-inversion.zip')
     filename = os.path.join(local_path, 'mesh-forward.vtu')
     fwd = pyvista.read(filename)
-    fwd.set_active_scalar('Resistivity(log10)-fwd')
+    fwd.set_active_scalars('Resistivity(log10)-fwd')
     filename = os.path.join(local_path, 'mesh-inverse.vtu')
     inv = pyvista.read(filename)
-    inv.set_active_scalar('Resistivity(log10)')
+    inv.set_active_scalars('Resistivity(log10)')
     return pyvista.MultiBlock({'forward':fwd, 'inverse':inv})
 
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -168,7 +168,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                     self.renderers.append(renderer)
 
 
-        # This keeps track of scalar names already plotted and their ranges
+        # This keeps track of scalars names already plotted and their ranges
         self._scalar_bar_ranges = {}
         self._scalar_bar_mappers = {}
         self._scalar_bar_actors = {}
@@ -697,9 +697,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Opacity of the mesh. If a siblge float value is given, it will be
             the global opacity of the mesh and uniformly applied everywhere -
             should be between 0 and 1. A string can also be specified to map
-            the scalar range to a predefined opacity transfer function
+            the scalars range to a predefined opacity transfer function
             (options include: 'linear', 'linear_r', 'geom', 'geom_r').
-            A string could also be used to map a scalar array from the mesh to
+            A string could also be used to map a scalars array from the mesh to
             the opacity (must have same number of elements as the
             ``scalars`` argument). Or you can pass a custum made transfer
             function that is an array either ``n_colors`` in length or shorter.
@@ -716,7 +716,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             The scalar bar will also have this many colors.
 
         interpolate_before_map : bool, optional
-            Enabling makes for a smoother scalar display.  Default is True.
+            Enabling makes for a smoother scalars display.  Default is True.
             When False, OpenGL will interpolate the mapped colors which can
             result is showing colors that are not present in the color map.
 
@@ -750,7 +750,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         stitle : string, optional
             Scalar bar title. By default the scalar bar is given a title of the
-            the scalar array used to color the mesh.
+            the scalars array used to color the mesh.
             To create a bar with no title, use an empty string (i.e. '').
 
         multi_colors : bool, optional
@@ -823,16 +823,18 @@ class BasePlotter(PickingHelper, WidgetHelper):
             transparency.
 
         below_color : string or 3 item list, optional
-            Solid color for values below the scalar range (``clim``). This will
-            automatically set the scalar bar ``below_label`` to ``'Below'``
+            Solid color for values below the scalars range (``clim``). This
+            will automatically set the scalar bar ``below_label`` to
+            ``'Below'``
 
         above_color : string or 3 item list, optional
-            Solid color for values below the scalar range (``clim``). This will
-            automatically set the scalar bar ``above_label`` to ``'Above'``
+            Solid color for values below the scalars range (``clim``). This
+            will automatically set the scalar bar ``above_label`` to
+            ``'Above'``
 
         annotations : dict, optional
             Pass a dictionary of annotations. Keys are the float values in the
-            scalar range to annotate on the scalar bar and the values are the
+            scalars range to annotate on the scalar bar and the values are the
             the string annotations.
 
         pickable : bool
@@ -903,7 +905,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             # first check the scalars
             if clim is None and scalars is not None:
                 # Get the data range across the array for all blocks
-                # if scalar specified
+                # if scalars specified
                 if isinstance(scalars, str):
                     clim = mesh.get_data_range(scalars)
                 else:
@@ -912,7 +914,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                     #       arrays where first index corresponds to
                     #       the block? This could get complicated real
                     #       quick.
-                    raise RuntimeError('Scalar array must be given as a string name for multiblock datasets.')
+                    raise RuntimeError('scalars array must be given as a string name for multiblock datasets.')
 
             the_arguments = locals()
             the_arguments.pop('self')
@@ -1006,7 +1008,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 texture = True
             # If no texture, plot any active scalar
             else:
-                # Make sure scalar components are not vectors/tuples
+                # Make sure scalars components are not vectors/tuples
                 scalars = mesh.active_scalars_name
                 # Don't allow plotting of string arrays by default
                 if scalars is not None:# and np.issubdtype(mesh.active_scalars.dtype, np.number):
@@ -1086,7 +1088,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         elif use_transparency and isinstance(opacity, np.ndarray):
             opacity = 255 - opacity
 
-        # Scalar formatting ===================================================
+        # Scalars formatting ==================================================
         if cmap is None: # Set default map if matplotlib is available
             if has_matplotlib:
                 cmap = rcParams['cmap']
@@ -1133,7 +1135,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 scalars = scalars.astype(np.float)
 
             def prepare_mapper(scalars):
-                # Scalar interpolation approach
+                # Scalars interpolation approach
                 if scalars.shape[0] == mesh.n_points:
                     self.mesh._add_point_array(scalars, title, set_active)
                     self.mapper.SetScalarModeToUsePointData()
@@ -1163,7 +1165,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 for val, anno in annotations.items():
                     table.SetAnnotation(float(val), str(anno))
 
-            # Set scalar range
+            # Set scalars range
             if clim is None:
                 clim = [np.nanmin(scalars), np.nanmax(scalars)]
             elif isinstance(clim, float) or isinstance(clim, int):
@@ -1319,7 +1321,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         opacity : string or numpy.ndarray, optional
             Opacity mapping for the scalars array.
-            A string can also be specified to map the scalar range to a
+            A string can also be specified to map the scalars range to a
             predefined opacity transfer function (options include: 'linear',
             'linear_r', 'geom', 'geom_r'). Or you can pass a custum made
             transfer function that is an array either ``n_colors`` in length or
@@ -1400,12 +1402,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         stitle : string, optional
             Scalar bar title. By default the scalar bar is given a title of the
-            the scalar array used to color the mesh.
+            the scalars array used to color the mesh.
             To create a bar with no title, use an empty string (i.e. '').
 
         annotations : dict, optional
             Pass a dictionary of annotations. Keys are the float values in the
-            scalar range to annotate on the scalar bar and the values are the
+            scalars range to annotate on the scalar bar and the values are the
             the string annotations.
 
         Return
@@ -1494,7 +1496,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
 
         if scalars is None:
-            # Make sure scalar components are not vectors/tuples
+            # Make sure scalars components are not vectors/tuples
             scalars = volume.active_scalars
             # Don't allow plotting of string arrays by default
             if scalars is not None and np.issubdtype(scalars.dtype, np.number):
@@ -1542,7 +1544,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             raise RuntimeError('Mapper ({}) unknown. Available volume mappers include: {}'.format(mapper, ', '.join(mappers.keys())))
         self.mapper = make_mapper(mappers[mapper])
 
-        # Scalar interpolation approach
+        # Scalars interpolation approach
         if scalars.shape[0] == volume.n_points:
             volume._add_point_array(scalars, title, set_active)
             self.mapper.SetScalarModeToUsePointData()
@@ -1552,7 +1554,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         else:
             raise_not_matching(scalars, volume)
 
-        # Set scalar range
+        # Set scalars range
         if clim is None:
             clim = [np.nanmin(scalars), np.nanmax(scalars)]
         elif isinstance(clim, float) or isinstance(clim, int):
@@ -1796,7 +1798,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def add_actor(self, uinput, reset_camera=False, name=None, loc=None,
                   culling=False, pickable=True):
         """Add an actor to render window.
-        
+
         Creates an actor if input is a mapper.
 
         Parameters
@@ -2337,10 +2339,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Annotate the NaN color
 
         below_label : str, optional
-            String annotation for values below the scalar range
+            String annotation for values below the scalars range
 
         above_label : str, optional
-            String annotation for values above the scalar range
+            String annotation for values above the scalars range
 
         background_color: array, optional
             The color used for the background in RGB format.
@@ -2599,7 +2601,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             return
 
         if isinstance(scalars, str):
-            # Grab scalar array if name given
+            # Grab scalars array if name given
             scalars = get_array(mesh, scalars)
 
         if scalars is None:
@@ -2622,7 +2624,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         data.Modified()
         try:
             # Why are the points updated here? Not all datasets have points
-            # and only the scalar array is modified by this function...
+            # and only the scalars array is modified by this function...
             mesh.GetPoints().Modified()
         except:
             pass
@@ -3216,7 +3218,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
 
     def add_point_scalar_labels(self, points, labels, fmt=None, preamble='', **kwargs):
-        """Label the points from a dataset with their scalar values.
+        """Label the points from a dataset with the values of their scalars.
 
         Wrapper for :func:`pyvista.BasePlotter.add_point_labels`.
 
@@ -3235,7 +3237,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if not is_pyvista_dataset(points):
             raise TypeError('input points must be a pyvista dataset, not: {}'.format(type(points)))
         if not isinstance(labels, str):
-            raise TypeError('labels must be a string name of the scalar array to use')
+            raise TypeError('labels must be a string name of the scalars array to use')
         if fmt is None:
             fmt = rcParams['font']['fmt']
         if fmt is None:

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -950,9 +950,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
             # If no texture, plot any active scalar
             else:
                 # Make sure scalar components are not vectors/tuples
-                scalars = mesh.active_scalar_name
+                scalars = mesh.active_scalars_name
                 # Don't allow plotting of string arrays by default
-                if scalars is not None:# and np.issubdtype(mesh.active_scalar.dtype, np.number):
+                if scalars is not None:# and np.issubdtype(mesh.active_scalars.dtype, np.number):
                     if stitle is None:
                         stitle = scalars
                 else:
@@ -1439,11 +1439,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         if scalars is None:
             # Make sure scalar components are not vectors/tuples
-            scalars = volume.active_scalar
+            scalars = volume.active_scalars
             # Don't allow plotting of string arrays by default
             if scalars is not None and np.issubdtype(scalars.dtype, np.number):
                 if stitle is None:
-                    stitle = volume.active_scalar_info[1]
+                    stitle = volume.active_scalars_info[1]
             else:
                 raise RuntimeError('No scalars to use for volume rendering.')
         elif isinstance(scalars, str):
@@ -2810,7 +2810,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         ifilter.Update()
         image = pyvista.wrap(ifilter.GetOutput())
         img_size = image.dimensions
-        img_array = pyvista.utilities.point_scalar(image, 'ImageScalars')
+        img_array = pyvista.utilities.point_array(image, 'ImageScalars')
 
         # Reshape and write
         tgt_size = (img_size[1], img_size[0], -1)

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -710,7 +710,7 @@ class WidgetHelper(object):
             raise TypeError('MultiBlock datasets are not supported for threshold widget.')
         name = kwargs.get('name', str(hex(id(mesh))))
         if scalars is None:
-            field, scalars = mesh.active_scalar_info
+            field, scalars = mesh.active_scalars_info
         arr, field = get_array(mesh, scalars, preference=preference, info=True)
         if arr is None:
             raise AssertionError('No arrays present to threshold.')
@@ -780,7 +780,7 @@ class WidgetHelper(object):
         if mesh.n_arrays < 1:
             raise AssertionError('Input dataset for the contour filter must have scalar data.')
         if scalars is None:
-            field, scalars = mesh.active_scalar_info
+            field, scalars = mesh.active_scalars_info
         else:
             _, field = get_array(mesh, scalars, preference=preference, info=True)
         # NOTE: only point data is allowed? well cells works but seems buggy?

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -808,7 +808,7 @@ class WidgetHelper(object):
         name = kwargs.get('name', str(hex(id(mesh))))
         # set the array to contour on
         if mesh.n_arrays < 1:
-            raise AssertionError('Input dataset for the contour filter must have scalar data.')
+            raise AssertionError('Input dataset for the contour filter must have data arrays.')
         if scalars is None:
             field, scalars = mesh.active_scalars_info
         else:
@@ -1023,7 +1023,7 @@ class WidgetHelper(object):
                           selected_color="pink", indices=None,
                           pass_widget=False, test_callback=True):
         """Add one or many sphere widgets to a scene.
-        
+
         Use a sphere widget to control a vertex location.
 
         Parameters

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -147,7 +147,7 @@ def field_scalar(mesh, name):
     return field_array(mesh, name)
 
 def cell_array(mesh, name):
-    """Return cell scalars of a vtk object."""
+    """Return cell array of a vtk object."""
     vtkarr = mesh.GetCellData().GetAbstractArray(name)
     return convert_array(vtkarr)
 

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -157,7 +157,7 @@ def cell_scalar(mesh, name):
     return cell_array(mesh, name)
 
 def row_array(data_object, name):
-    """Return cell scalars of a vtk object."""
+    """Return row array of a vtk object."""
     vtkarr = data_object.GetRowData().GetAbstractArray(name)
     return convert_array(vtkarr)
 

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -191,12 +191,12 @@ def get_array(mesh, name, preference='cell', info=False, err=False):
         The name of the array to get the range.
 
     preference : str, optional
-        When scalars is specified, this is the perfered scalar type to
+        When scalars is specified, this is the perfered array type to
         search for in the dataset.  Must be either ``'point'``, ``'cell'``, or
         ``'field'``
 
     info : bool
-        Return info about the scalar rather than the array itself.
+        Return info about the array rather than the array itself.
 
     err : bool
         Boolean to control whether to throw an error if array is not present.
@@ -205,7 +205,7 @@ def get_array(mesh, name, preference='cell', info=False, err=False):
     if isinstance(mesh, vtk.vtkTable):
         arr = row_array(mesh, name)
         if arr is None and err:
-            raise KeyError('Data scalar ({}) not present in this dataset.'.format(name))
+            raise KeyError('Data array ({}) not present in this dataset.'.format(name))
         field = ROW_DATA_FIELD
         if info:
             return arr, field
@@ -245,7 +245,7 @@ def get_array(mesh, name, preference='cell', info=False, err=False):
         arr = farr
         field = FIELD_DATA_FIELD
     elif err:
-        raise KeyError('Data scalar ({}) not present in this dataset.'.format(name))
+        raise KeyError('Data array ({}) not present in this dataset.'.format(name))
     if info:
         return arr, field
     return arr

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -5,6 +5,7 @@ Supporting functions for polydata and grid objects
 import collections
 import ctypes
 import logging
+import warnings
 
 import numpy as np
 import scooby
@@ -123,20 +124,35 @@ def is_pyvista_dataset(obj):
     return isinstance(obj, (pyvista.Common, pyvista.MultiBlock))
 
 
-def point_scalar(mesh, name):
+def point_array(mesh, name):
     """ Returns point scalars of a vtk object """
     vtkarr = mesh.GetPointData().GetAbstractArray(name)
     return convert_array(vtkarr)
 
-def field_scalar(mesh, name):
+def point_scalar(mesh, name):
+    """DEPRECATED: Returns point scalars of a vtk object """
+    warnings.warn("DEPRECATED: please use `point_array` instead.")
+    return point_array(mesh, name)
+
+def field_array(mesh, name):
     """ Returns field scalars of a vtk object """
     vtkarr = mesh.GetFieldData().GetAbstractArray(name)
     return convert_array(vtkarr)
 
-def cell_scalar(mesh, name):
+def field_scalar(mesh, name):
+    """DEPRECATED Returns field scalars of a vtk object """
+    warnings.warn("DEPRECATED: please use `field_array` instead.")
+    return field_array(mesh, name)
+
+def cell_array(mesh, name):
     """ Returns cell scalars of a vtk object """
     vtkarr = mesh.GetCellData().GetAbstractArray(name)
     return convert_array(vtkarr)
+
+def cell_scalar(mesh, name):
+    """DEPRECATED: Returns cell scalars of a vtk object """
+    warnings.warn("DEPRECATED: please use `cell_array` instead.")
+    return cell_array(mesh, name)
 
 def row_array(data_object, name):
     """ Returns cell scalars of a vtk object """
@@ -192,9 +208,9 @@ def get_array(mesh, name, preference='cell', info=False, err=False):
             return arr, field
         return arr
 
-    parr = point_scalar(mesh, name)
-    carr = cell_scalar(mesh, name)
-    farr = field_scalar(mesh, name)
+    parr = point_array(mesh, name)
+    carr = cell_array(mesh, name)
+    farr = field_array(mesh, name)
     preference = parse_field_choice(preference)
     if np.sum([parr is not None, carr is not None, farr is not None]) > 1:
         if preference == CELL_DATA_FIELD:
@@ -410,7 +426,7 @@ def wrap(vtkdataset):
         elif vtkdataset.ndim == 3:
             mesh = pyvista.UniformGrid(vtkdataset.shape)
             mesh['values'] = vtkdataset.ravel(order='F')
-            mesh.active_scalar_name = 'values'
+            mesh.active_scalars_name = 'values'
             return mesh
         else:
             print(vtkdataset.shape, vtkdataset)

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -127,22 +127,28 @@ def is_pyvista_dataset(obj):
 
 
 def point_array(mesh, name):
-    """Return point scalars of a vtk object."""
+    """Return point array of a vtk object."""
     vtkarr = mesh.GetPointData().GetAbstractArray(name)
     return convert_array(vtkarr)
 
 def point_scalar(mesh, name):
-    """DEPRECATED: Returns point scalars of a vtk object """
+    """Return point array of a vtk object.
+
+    DEPRECATED: please use `point_array` instead.
+    """
     warnings.warn("DEPRECATED: please use `point_array` instead.")
     return point_array(mesh, name)
 
 def field_array(mesh, name):
-    """Return field scalars of a vtk object."""
+    """Return field array of a vtk object."""
     vtkarr = mesh.GetFieldData().GetAbstractArray(name)
     return convert_array(vtkarr)
 
 def field_scalar(mesh, name):
-    """DEPRECATED Returns field scalars of a vtk object """
+    """Return field array of a vtk object.
+
+    DEPRECATED: please use `field_array` instead.
+    """
     warnings.warn("DEPRECATED: please use `field_array` instead.")
     return field_array(mesh, name)
 
@@ -152,7 +158,10 @@ def cell_array(mesh, name):
     return convert_array(vtkarr)
 
 def cell_scalar(mesh, name):
-    """DEPRECATED: Returns cell scalars of a vtk object """
+    """Return cell array of a vtk object.
+
+    DEPRECATED: please use `cell_array` instead.
+    """
     warnings.warn("DEPRECATED: please use `cell_array` instead.")
     return cell_array(mesh, name)
 
@@ -508,7 +517,7 @@ def raise_not_matching(scalars, mesh):
         raise Exception('Number of scalars ({})'.format(scalars.size) +
                         'must match number of rows ' +
                         '({}).'.format(mesh.n_rows) )
-    raise Exception('Number of scalars ({})'.format(scalars.size) +
+    raise Exception('Number of scalars ({}) '.format(scalars.size) +
                     'must match either the number of points ' +
                     '({}) '.format(mesh.n_points) +
                     'or the number of cells ' +

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -433,11 +433,6 @@ def test_set_active_vectors_name():
     grid.active_vectors_name = None
 
 
-def test_set_active_scalars_name():
-    grid = GRID.copy()
-    grid.active_scalars_name = None
-
-
 def test_set_t_coords():
     grid = GRID.copy()
     with pytest.raises(TypeError):
@@ -480,7 +475,8 @@ def test_set_active_scalars():
 def test_set_active_scalars_name():
     grid = GRID.copy()
     point_keys = list(grid.point_arrays.keys())
-    grid.set_active_scalars_name = point_keys[0]
+    grid.active_scalars_name = point_keys[0]
+    grid.active_scalars_name = None
 
 
 def test_rename_array_point():

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -470,47 +470,47 @@ def test_set_active_scalars():
     grid_copy = grid.copy()
     arr = np.arange(grid_copy.n_cells)
     grid_copy.cell_arrays['tmp'] = arr
-    grid_copy.set_active_scalar('tmp')
-    assert np.allclose(grid_copy.active_scalar, arr)
+    grid_copy.set_active_scalars('tmp')
+    assert np.allclose(grid_copy.active_scalars, arr)
     # Make sure we can set no active scalars
-    grid_copy.set_active_scalar(None)
+    grid_copy.set_active_scalars(None)
     assert grid_copy.GetPointData().GetScalars() is None
     assert grid_copy.GetCellData().GetScalars() is None
 
-def test_set_active_scalar_name():
+def test_set_active_scalars_name():
     grid = GRID.copy()
     point_keys = list(grid.point_arrays.keys())
-    grid.set_active_scalar_name = point_keys[0]
+    grid.set_active_scalars_name = point_keys[0]
 
 
-def test_rename_scalar_point():
+def test_rename_array_point():
     grid = GRID.copy()
     point_keys = list(grid.point_arrays.keys())
     old_name = point_keys[0]
     new_name = 'point changed'
-    grid.set_active_scalar(old_name, preference='point')
-    grid.rename_scalar(old_name, new_name, preference='point')
+    grid.set_active_scalars(old_name, preference='point')
+    grid.rename_array(old_name, new_name, preference='point')
     assert new_name in grid.point_arrays
     assert old_name not in grid.point_arrays
 
 
-def test_rename_scalar_cell():
+def test_rename_array_cell():
     grid = GRID.copy()
     cell_keys = list(grid.cell_arrays.keys())
     old_name = cell_keys[0]
     new_name = 'cell changed'
-    grid.rename_scalar(old_name, new_name)
+    grid.rename_array(old_name, new_name)
     assert new_name in grid.cell_arrays
     assert old_name not in grid.cell_arrays
 
 
-def test_rename_scalar_field():
+def test_rename_array_field():
     grid = GRID.copy()
     grid.field_arrays['fieldfoo'] = np.array([8, 6, 7])
     field_keys = list(grid.field_arrays.keys())
     old_name = field_keys[0]
     new_name = 'cell changed'
-    grid.rename_scalar(old_name, new_name)
+    grid.rename_array(old_name, new_name)
     assert new_name in grid.field_arrays
     assert old_name not in grid.field_arrays
 
@@ -518,7 +518,7 @@ def test_rename_scalar_field():
 def test_change_name_fail():
     grid = GRID.copy()
     with pytest.raises(RuntimeError):
-        grid.rename_scalar('not a key', '')
+        grid.rename_array('not a key', '')
 
 
 def test_get_cell_array_fail():

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -263,7 +263,7 @@ def test_elevation():
     # Test default params
     elev = dataset.elevation()
     assert 'Elevation' in elev.array_names
-    assert 'Elevation' == elev.active_scalar_name
+    assert 'Elevation' == elev.active_scalars_name
     assert elev.get_data_range() == (dataset.bounds[4], dataset.bounds[5])
     # test vector args
     c = list(dataset.center)
@@ -271,21 +271,21 @@ def test_elevation():
     t[2] = dataset.bounds[-1]
     elev = dataset.elevation(low_point=c, high_point=t)
     assert 'Elevation' in elev.array_names
-    assert 'Elevation' == elev.active_scalar_name
+    assert 'Elevation' == elev.active_scalars_name
     assert elev.get_data_range() == (dataset.center[2], dataset.bounds[5])
     # Test not setting active
     elev = dataset.elevation(set_active=False)
     assert 'Elevation' in elev.array_names
-    assert 'Elevation' != elev.active_scalar_name
+    assert 'Elevation' != elev.active_scalars_name
     # Set use a range by scalar name
     elev = dataset.elevation(scalar_range='Spatial Point Data')
     assert 'Elevation' in elev.array_names
-    assert 'Elevation' == elev.active_scalar_name
+    assert 'Elevation' == elev.active_scalars_name
     assert dataset.get_data_range('Spatial Point Data') == (elev.get_data_range('Elevation'))
     # Set use a user defined range
     elev = dataset.elevation(scalar_range=[1.0, 100.0])
     assert 'Elevation' in elev.array_names
-    assert 'Elevation' == elev.active_scalar_name
+    assert 'Elevation' == elev.active_scalars_name
     assert elev.get_data_range('Elevation') == (1.0, 100.0)
     # test errors
     with pytest.raises(RuntimeError):
@@ -375,7 +375,7 @@ def test_glyph():
 def test_split_and_connectivity():
     # Load a simple example mesh
     dataset = examples.load_uniform()
-    dataset.set_active_scalar('Spatial Cell Data')
+    dataset.set_active_scalars('Spatial Cell Data')
     threshed = dataset.threshold_percent([0.15, 0.50], invert=True)
 
     bodies = threshed.split_bodies()

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -414,16 +414,16 @@ def test_grid_extract_selection_points():
 
 def test_gaussian_smooth():
     uniform = examples.load_uniform()
-    active = uniform.active_scalar_name
-    values = uniform.active_scalar
+    active = uniform.active_scalars_name
+    values = uniform.active_scalars
 
     uniform = uniform.gaussian_smooth(scalars=active)
-    assert uniform.active_scalar_name == active
-    assert uniform.active_scalar.shape == values.shape
-    assert not np.all(uniform.active_scalar == values)
-    values = uniform.active_scalar
+    assert uniform.active_scalars_name == active
+    assert uniform.active_scalars.shape == values.shape
+    assert not np.all(uniform.active_scalars == values)
+    values = uniform.active_scalars
 
     uniform = uniform.gaussian_smooth(radius_factor=5, std_dev=1.3)
-    assert uniform.active_scalar_name == active
-    assert uniform.active_scalar.shape == values.shape
-    assert not np.all(uniform.active_scalar == values)
+    assert uniform.active_scalars_name == active
+    assert uniform.active_scalars.shape == values.shape
+    assert not np.all(uniform.active_scalars == values)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -623,7 +623,7 @@ def test_link_views():
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_orthographic_slicer():
     data = examples.load_uniform()
-    data.set_active_scalar('Spatial Cell Data')
+    data.set_active_scalars('Spatial Cell Data')
 
     slices = data.slice_orthogonal()
 
@@ -698,10 +698,10 @@ def test_volume_rendering():
                                    b=examples.load_uniform(),
                                    c=examples.load_uniform(),
                                    d=examples.load_uniform(),))
-    data['a'].rename_scalar('Spatial Point Data', 'a')
-    data['b'].rename_scalar('Spatial Point Data', 'b')
-    data['c'].rename_scalar('Spatial Point Data', 'c')
-    data['d'].rename_scalar('Spatial Point Data', 'd')
+    data['a'].rename_array('Spatial Point Data', 'a')
+    data['b'].rename_array('Spatial Point Data', 'b')
+    data['c'].rename_array('Spatial Point Data', 'c')
+    data['d'].rename_array('Spatial Point Data', 'd')
     data.plot(off_screen=OFF_SCREEN, volume=True, multi_colors=True, )
 
 
@@ -846,10 +846,10 @@ def test_bad_keyword_arguments():
     with pytest.raises(TypeError):
         pyvista.plot(mesh, foo=5, off_screen=OFF_SCREEN)
     with pytest.raises(TypeError):
-        pyvista.plot(mesh, scalar=mesh.active_scalar_name, off_screen=OFF_SCREEN)
+        pyvista.plot(mesh, scalar=mesh.active_scalars_name, off_screen=OFF_SCREEN)
     with pytest.raises(TypeError):
         plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
-        plotter.add_mesh(mesh, scalar=mesh.active_scalar_name)
+        plotter.add_mesh(mesh, scalar=mesh.active_scalars_name)
         plotter.show()
     with pytest.raises(TypeError):
         plotter = pyvista.Plotter(off_screen=OFF_SCREEN)


### PR DESCRIPTION
Resolve #429 to improve naming consistency for `*_scalars` and `*_array`. This should be good to go and has deprecation warnings for the old methods to keep backward compatibility.

@pyvista/developers, anyone have time to double-check all of this? This needs to land before the `0.23.0` release.