### PR TITLE
MAINT: Fix documentation style

### DIFF
--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -1,3 +1,5 @@
+"""PyVista package for 3D plotting and mesh analysis."""
+
 import warnings
 from pyvista._version import __version__
 from pyvista.plotting import *

--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -1,4 +1,4 @@
-""" version info for pyvista """
+"""Version info for pyvista."""
 # major, minor, patch
 version_info = 0, 22, 4
 

--- a/pyvista/core/__init__.py
+++ b/pyvista/core/__init__.py
@@ -1,3 +1,5 @@
+"""Core routines."""
+
 from .common import Common, DataObject
 from .composite import MultiBlock
 from .filters import (CompositeFilters, DataSetFilters, PolyDataFilters,

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -1,6 +1,5 @@
-"""
-Attributes common to PolyData and Grid Objects
-"""
+"""Attributes common to PolyData and Grid Objects."""
+
 import collections
 import logging
 import warnings
@@ -27,30 +26,32 @@ DEFAULT_VECTOR_KEY = '_vectors'
 
 
 class DataObject(object):
-    """ Methods common to all wrapped data objects """
+    """Methods common to all wrapped data objects."""
+
     def __init__(self, *args, **kwargs):
+        """Initialize the data object."""
         self._field_bool_array_names = []
 
 
     def __new__(cls, *args, **kwargs):
+        """Allocate memory for the data object."""
         if cls is DataObject:
             raise TypeError("pyvista.DataObject is an abstract class and may not be instantiated.")
         return object.__new__(cls, *args, **kwargs)
 
 
     def shallow_copy(self, to_copy):
-        """Shallow copy the given mesh to this mesh"""
+        """Shallow copy the given mesh to this mesh."""
         return self.ShallowCopy(to_copy)
 
 
     def deep_copy(self, to_copy):
-        """Overwrite this mesh with the given mesh as a deep copy"""
+        """Overwrite this mesh with the given mesh as a deep copy."""
         return self.DeepCopy(to_copy)
 
 
     def save(self, filename, binary=True):
-        """
-        Writes this mesh to a file.
+        """Write this mesh to a file.
 
         Parameters
         ----------
@@ -66,12 +67,13 @@ class DataObject(object):
         -----
         Binary files write much faster than ASCII and have a smaller
         file size.
+
         """
         raise NotImplementedError('{} mesh type does not have a save method.'.format(type(self)))
 
 
     def get_data_range(self, arr=None, preference='field'):
-        """Get the non-NaN min and max of a named scalar array
+        """Get the non-NaN min and max of a named scalar array.
 
         Parameters
         ----------
@@ -89,13 +91,16 @@ class DataObject(object):
 
 
     def _get_attrs(self):
-        """An internal helper for the representation methods"""
+        """Return the representation methods (internal helper)."""
         raise NotImplementedError
 
 
     def head(self, display=True, html=None):
-        """Return the header stats of this dataset. If in IPython, this will
-        be formatted to HTML. Otherwise returns a console friendly string"""
+        """Return the header stats of this dataset.
+
+        If in IPython, this will be formatted to HTML. Otherwise returns a console friendly string.
+
+        """
         # Generate the output
         if html:
             fmt = ""
@@ -134,29 +139,32 @@ class DataObject(object):
 
 
     def _repr_html_(self):
-        """A pretty representation for Jupyter notebooks that includes header
-        details and information about all scalar arrays"""
+        """Return a pretty representation for Jupyter notebooks.
+
+        This includes header details and information about all scalar arrays.
+
+        """
         raise NotImplemented
 
 
     def copy_meta_from(self, ido):
-        """Copies pyvista meta data onto this object from another object"""
+        """Copy pyvista meta data onto this object from another object."""
         pass
 
 
     def copy(self, deep=True):
-        """
-        Returns a copy of the object
+        """Return a copy of the object.
 
         Parameters
         ----------
         deep : bool, optional
             When True makes a full copy of the object.
 
-        Returns
-        -------
+        Return
+        ------
         newobject : same as input
            Deep or shallow copy of the input.
+
         """
         thistype = type(self)
         newobject = thistype()
@@ -169,16 +177,15 @@ class DataObject(object):
 
 
     def _field_array(self, name=None):
-        """
-        Returns field scalars of a vtk object
+        """Return field scalars of a vtk object.
 
         Parameters
         ----------
         name : str
             Name of field scalars to retrieve.
 
-        Returns
-        -------
+        Return
+        ------
         scalars : np.ndarray
             Numpy array of scalars
 
@@ -202,8 +209,7 @@ class DataObject(object):
 
 
     def _add_field_array(self, scalars, name, deep=True):
-        """
-        Adds field scalars to the mesh
+        """Add field scalars to the mesh.
 
         Parameters
         ----------
@@ -241,18 +247,23 @@ class DataObject(object):
 
 
     def _add_field_scalar(self, scalars, name, set_active=False, deep=True):
-        """DEPRECATED: Please use `_add_field_array`"""
+        """Add a scalar field.
+
+        DEPRECATED: Please use `_add_field_array` instead.
+
+        """
         warnings.warn('Deprecation Warning: `_add_field_scalar` is now `_add_field_array`', RuntimeWarning)
         return self._add_field_array(scalars, name, set_active=set_active, deep=deep)
 
 
     def add_field_array(self, scalars, name, deep=True):
+        """Add a scalar field."""
         self._add_field_array(scalars, name, deep=deep)
 
 
     @property
     def field_arrays(self):
-        """ Returns all field arrays """
+        """Return all field arrays."""
         fdata = self.GetFieldData()
         narr = fdata.GetNumberOfArrays()
 
@@ -277,7 +288,7 @@ class DataObject(object):
 
 
     def clear_field_arrays(self):
-        """ removes all field arrays """
+        """Remove all field arrays."""
         keys = self.field_arrays.keys()
         for key in keys:
             self._remove_array(FIELD_DATA_FIELD, key)
@@ -285,19 +296,21 @@ class DataObject(object):
 
 
 class Common(DataSetFilters, DataObject):
-    """ Methods in common to spatially referenced objects"""
+    """Methods in common to spatially referenced objects."""
 
     # Simply bind pyvista.plotting.plot to the object
     plot = pyvista.plot
 
 
     def __new__(cls, *args, **kwargs):
+        """Allocate memory for the common object."""
         if cls is Common:
             raise TypeError("pyvista.Common is an abstract class and may not be instantiated.")
         return object.__new__(cls, *args, **kwargs)
 
 
     def __init__(self, *args, **kwargs):
+        """Initialize the common object."""
         super(Common, self).__init__()
         self.references = []
         self._point_bool_array_names = []
@@ -306,7 +319,7 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def active_scalar_info(self):
-        """Return the active scalar's field and name: [field, name]"""
+        """Return the active scalar's field and name: [field, name]."""
         if not hasattr(self, '_active_scalar_info'):
             self._active_scalar_info = [POINT_DATA_FIELD, None] # field and name
         if not hasattr(self, '_last_active_scalar_name'):
@@ -355,7 +368,7 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def active_vectors_info(self):
-        """Return the active scalar's field and name: [field, name]"""
+        """Return the active scalar's field and name: [field, name]."""
         if not hasattr(self, '_active_vectors_info'):
             # Sometimes, precomputed normals aren't set as active
             if 'Normals' in self.array_names:
@@ -378,7 +391,7 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def active_vectors(self):
-        """The active vectors array"""
+        """Return the active vectors array."""
         field, name = self.active_vectors_info
         if name:
             if field is POINT_DATA_FIELD:
@@ -389,31 +402,31 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def active_vectors_name(self):
-        """The name of the active vectors array"""
+        """Return the name of the active vectors array."""
         return self.active_vectors_info[1]
 
 
     @active_vectors_name.setter
     def active_vectors_name(self, name):
-        """Set the name of the active vector"""
+        """Set the name of the active vector."""
         return self.set_active_vectors(name)
 
 
     @property
     def active_scalar_name(self):
-        """Returns the active scalar's name"""
+        """Return the active scalar's name."""
         return self.active_scalar_info[1]
 
 
     @active_scalar_name.setter
     def active_scalar_name(self, name):
-        """Set the name of the active scalar"""
+        """Set the name of the active scalar."""
         return self.set_active_scalar(name)
 
 
     @property
     def points(self):
-        """ returns a pointer to the points as a numpy object """
+        """Return a pointer to the points as a numpy object."""
         pts = self.GetPoints()
         if pts is None:
             return None
@@ -424,7 +437,7 @@ class Common(DataSetFilters, DataObject):
 
     @points.setter
     def points(self, points):
-        """ set points without copying """
+        """Set points without copying."""
         if not isinstance(points, np.ndarray):
             raise TypeError('Points must be a numpy array')
         vtk_points = pyvista.vtk_points(points, False)
@@ -439,16 +452,17 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def arrows(self):
-        """
-        Returns a glyph representation of the active vector data as
-        arrows.  Arrows will be located at the points of the mesh and
+        """Return a glyph representation of the active vector data as arrows.
+
+        Arrows will be located at the points of the mesh and
         their size will be dependent on the length of the vector.
         Their direction will be the "direction" of the vector
 
-        Returns
-        -------
+        Return
+        ------
         arrows : pyvista.PolyData
             Active scalars represented as arrows.
+
         """
         if self.active_vectors is None:
             return
@@ -458,13 +472,13 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def vectors(self):
-        """ Returns active vectors """
+        """Return active vectors."""
         return self.active_vectors
 
 
     @vectors.setter
     def vectors(self, array):
-        """ Sets the active vector  """
+        """Set the active vector."""
         if array.ndim != 2:
             raise AssertionError('vector array must be a 2-dimensional array')
         elif array.shape[1] != 3:
@@ -478,7 +492,7 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def t_coords(self):
-        """The active texture coordinates on the points"""
+        """Return the active texture coordinates on the points."""
         if self.GetPointData().GetTCoords() is not None:
             return vtk_to_numpy(self.GetPointData().GetTCoords())
         return None
@@ -486,7 +500,7 @@ class Common(DataSetFilters, DataObject):
 
     @t_coords.setter
     def t_coords(self, t_coords):
-        """Set the array to use as the texture coordinates"""
+        """Set the array to use as the texture coordinates."""
         if not isinstance(t_coords, np.ndarray):
             raise TypeError('Texture coordinates must be a numpy array')
         if t_coords.ndim != 2:
@@ -507,9 +521,11 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def textures(self):
-        """A dictionary to hold ``vtk.vtkTexture`` objects that can be
-        associated with this dataset. When casting back to a VTK dataset or
-        filtering this dataset, these textures will not be passed.
+        """Return a dictionary to hold compatible ``vtk.vtkTexture`` objects.
+        
+        When casting back to a VTK dataset or filtering this dataset, these textures
+        will not be passed.
+
         """
         if not hasattr(self, '_textures'):
             self._textures = {}
@@ -517,14 +533,15 @@ class Common(DataSetFilters, DataObject):
 
 
     def clear_textures(self):
-        """Clear the textures from this mesh"""
+        """Clear the textures from this mesh."""
         if hasattr(self, '_textures'):
             del self._textures
 
 
     def _activate_texture(mesh, name):
-        """Grab a texture and update the active texture coordinates. This makes
-        sure to not destroy old texture coordinates
+        """Grab a texture and update the active texture coordinates.
+
+        This makes sure to not destroy old texture coordinates.
 
         Parameters
         ----------
@@ -534,6 +551,7 @@ class Common(DataSetFilters, DataObject):
         Return
         ------
         vtk.vtkTexture : The active texture
+
         """
         if name is True or isinstance(name, int):
             keys = list(mesh.textures.keys())
@@ -564,8 +582,10 @@ class Common(DataSetFilters, DataObject):
 
 
     def set_active_scalar(self, name, preference='cell'):
-        """Finds the scalar by name and appropriately sets it as active.
+        """Find the scalar by name and appropriately sets it as active.
+
         To deactivate any active scalars, pass ``None`` as the ``name``.
+
         """
         if name is None:
             self.GetCellData().SetActiveScalars(None)
@@ -583,8 +603,10 @@ class Common(DataSetFilters, DataObject):
 
 
     def set_active_vectors(self, name, preference='point'):
-        """Finds the vectors by name and appropriately sets it as active
+        """Find the vectors by name and appropriately sets it as active.
+
         To deactivate any active scalars, pass ``None`` as the ``name``.
+
         """
         if name is None:
             self.GetCellData().SetActiveVectors(None)
@@ -601,7 +623,7 @@ class Common(DataSetFilters, DataObject):
 
 
     def rename_scalar(self, old_name, new_name, preference='cell'):
-        """Changes array name by searching for the array then renaming it"""
+        """Change array name by searching for the array then renaming it."""
         _, field = get_array(self, old_name, preference=preference, info=True)
         if field == POINT_DATA_FIELD:
             self.point_arrays[new_name] = self.point_arrays.pop(old_name)
@@ -617,7 +639,7 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def active_scalar(self):
-        """Returns the active scalar as an array"""
+        """Return the active scalar as an array."""
         field, name = self.active_scalar_info
         if name is None:
             return None
@@ -628,16 +650,15 @@ class Common(DataSetFilters, DataObject):
 
 
     def _point_array(self, name=None):
-        """
-        Returns point scalars of a vtk object
+        """Return point scalars of a vtk object.
 
         Parameters
         ----------
         name : str
             Name of point scalars to retrieve.
 
-        Returns
-        -------
+        Return
+        ------
         scalars : np.ndarray
             Numpy array of scalars
 
@@ -664,8 +685,7 @@ class Common(DataSetFilters, DataObject):
 
 
     def _add_point_array(self, scalars, name, set_active=False, deep=True):
-        """
-        Adds point scalars to the mesh
+        """Add point scalars to the mesh.
 
         Parameters
         ----------
@@ -711,13 +731,17 @@ class Common(DataSetFilters, DataObject):
 
 
     def _add_point_scalar(self, scalars, name, set_active=False, deep=True):
-        """DEPRECATED: Please use `_add_point_array`"""
+        """Add points array.
+
+        DEPRECATED: Please use `_add_point_array` instead.
+
+        """
         warnings.warn('Deprecation Warning: `_add_point_scalar` is now `_add_point_array`', RuntimeWarning)
         return self._add_point_array(scalars, name, set_active=set_active, deep=deep)
 
 
     def get_data_range(self, arr=None, preference='cell'):
-        """Get the non-NaN min and max of a named scalar array
+        """Get the non-NaN min and max of a named scalar array.
 
         Parameters
         ----------
@@ -744,14 +768,13 @@ class Common(DataSetFilters, DataObject):
 
 
     def points_to_double(self):
-        """ Makes points double precision """
+        """Make points double precision."""
         if self.points.dtype != np.double:
             self.points = self.points.astype(np.double)
 
 
     def rotate_x(self, angle):
-        """
-        Rotates mesh about the x-axis.
+        """Rotate mesh about the x-axis.
 
         Parameters
         ----------
@@ -763,8 +786,7 @@ class Common(DataSetFilters, DataObject):
 
 
     def rotate_y(self, angle):
-        """
-        Rotates mesh about the y-axis.
+        """Rotate mesh about the y-axis.
 
         Parameters
         ----------
@@ -776,8 +798,7 @@ class Common(DataSetFilters, DataObject):
 
 
     def rotate_z(self, angle):
-        """
-        Rotates mesh about the z-axis.
+        """Rotate mesh about the z-axis.
 
         Parameters
         ----------
@@ -789,8 +810,7 @@ class Common(DataSetFilters, DataObject):
 
 
     def translate(self, xyz):
-        """
-        Translates the mesh.
+        """Translate the mesh.
 
         Parameters
         ----------
@@ -802,8 +822,7 @@ class Common(DataSetFilters, DataObject):
 
 
     def transform(self, trans):
-        """
-        Compute a transformation in place using a 4x4 transform.
+        """Compute a transformation in place using a 4x4 transform.
 
         Parameters
         ----------
@@ -836,16 +855,15 @@ class Common(DataSetFilters, DataObject):
 
 
     def _cell_array(self, name=None):
-        """
-        Returns the cell scalars of a vtk object
+        """Return the cell scalars of a vtk object.
 
         Parameters
         ----------
         name : str
             Name of cell scalars to retrieve.
 
-        Returns
-        -------
+        Return
+        ------
         scalars : np.ndarray
             Numpy array of scalars
 
@@ -873,8 +891,7 @@ class Common(DataSetFilters, DataObject):
 
 
     def _add_cell_array(self, scalars, name, set_active=False, deep=True):
-        """
-        Adds cell scalars to the vtk object.
+        """Add cell scalars to the vtk object.
 
         Parameters
         ----------
@@ -917,13 +934,17 @@ class Common(DataSetFilters, DataObject):
 
 
     def _add_cell_scalar(self, scalars, name, set_active=False, deep=True):
-        """DEPRECATED: Please use `_add_cell_array`"""
+        """Add a cell array.
+
+        DEPRECATED: Please use `_add_cell_array` instead.
+
+        """
         warnings.warn('Deprecation Warning: `_add_cell_scalar` is now `_add_cell_array`', RuntimeWarning)
         return self._add_cell_array(scalars, name, set_active=set_active, deep=deep)
 
 
     def copy_meta_from(self, ido):
-        """Copies pyvista meta data onto this object from another object"""
+        """Copy pyvista meta data onto this object from another object."""
         self._active_scalar_info = ido.active_scalar_info
         self._active_vectors_info = ido.active_vectors_info
         if hasattr(ido, '_textures'):
@@ -932,7 +953,7 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def point_arrays(self):
-        """ Returns the all point arrays """
+        """Return the all point arrays."""
         pdata = self.GetPointData()
         narr = pdata.GetNumberOfArrays()
 
@@ -962,7 +983,7 @@ class Common(DataSetFilters, DataObject):
 
 
     def _remove_array(self, field, key):
-        """internal helper to remove a single array by name from each field"""
+        """Remove a single array by name from each field (internal helper)."""
         field = parse_field_choice(field)
         if field == POINT_DATA_FIELD:
             self.GetPointData().RemoveArray(key)
@@ -976,21 +997,21 @@ class Common(DataSetFilters, DataObject):
 
 
     def clear_point_arrays(self):
-        """ removes all point arrays """
+        """Remove all point arrays."""
         keys = self.point_arrays.keys()
         for key in keys:
             self._remove_array(POINT_DATA_FIELD, key)
 
 
     def clear_cell_arrays(self):
-        """ removes all cell arrays """
+        """Remove all cell arrays."""
         keys = self.cell_arrays.keys()
         for key in keys:
             self._remove_array(CELL_DATA_FIELD, key)
 
 
     def clear_arrays(self):
-        """ removes all arrays from point/cell/field data """
+        """Remove all arrays from point/cell/field data."""
         self.clear_point_arrays()
         self.clear_cell_arrays()
         self.clear_field_arrays()
@@ -998,7 +1019,7 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def cell_arrays(self):
-        """ Returns the all cell arrays """
+        """Return the all cell arrays."""
         cdata = self.GetCellData()
         narr = cdata.GetNumberOfArrays()
 
@@ -1028,59 +1049,60 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def n_points(self):
-        """The number of points in the entire dataset"""
+        """Return the number of points in the entire dataset."""
         return self.GetNumberOfPoints()
 
 
     @property
     def n_cells(self):
-        """The number of cells in the entire dataset"""
+        """Return the number of cells in the entire dataset."""
         return self.GetNumberOfCells()
 
 
     @property
     def number_of_points(self):  # pragma: no cover
-        """ returns the number of points """
+        """Return the number of points."""
         return self.GetNumberOfPoints()
 
 
     @property
     def number_of_cells(self):  # pragma: no cover
-        """ returns the number of cells """
+        """Return the number of cells."""
         return self.GetNumberOfCells()
 
 
     @property
     def bounds(self):
-        """
-        bounding box of this dataset in the form
-        (xmin,xmax, ymin,ymax, zmin,zmax)
+        """Return the bounding box of this dataset.
+
+        The form is: (xmin,xmax, ymin,ymax, zmin,zmax).
+
         """
         return list(self.GetBounds())
 
 
     @property
     def length(self):
-        """the length of the diagonal of the bounding box"""
+        """Return the length of the diagonal of the bounding box."""
         return self.GetLength()
 
 
     @property
     def center(self):
-        """ Center of the bounding box """
+        """Return the center of the bounding box."""
         return list(self.GetCenter())
 
 
     @property
     def extent(self):
-        """ The range of the bounding box """
+        """Return the range of the bounding box."""
         if hasattr(self, 'GetExtent'):
             return list(self.GetExtent())
 
 
     @extent.setter
     def extent(self, extent):
-        """ The range of the bounding box """
+        """Return the range of the bounding box."""
         if hasattr(self, 'SetExtent'):
             return self.SetExtent(extent)
         else:
@@ -1089,11 +1111,10 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def volume(self):
-        """
-        Mesh volume
+        """Return the mesh volume.
 
-        Returns
-        -------
+        Return
+        ------
         volume : float
             Total volume of the mesh.
 
@@ -1103,12 +1124,12 @@ class Common(DataSetFilters, DataObject):
 
 
     def get_array(self, name, preference='cell', info=False):
-        """ Searches both point, cell and field data for an array """
+        """Search both point, cell and field data for an array."""
         return get_array(self, name, preference=preference, info=info)
 
 
     def __getitem__(self, index):
-        """ Searches both point, cell, and field data for an array """
+        """Search both point, cell, and field data for an array."""
         if isinstance(index, collections.Iterable) and not isinstance(index, str):
             name, preference = index[0], index[1]
         elif isinstance(index, str):
@@ -1123,8 +1144,10 @@ class Common(DataSetFilters, DataObject):
 
 
     def __setitem__(self, name, scalars):
-        """Add/set an array in the point_arrays, or cell_arrays depending on the
-        array's length, or specified mode.
+        """Add/set an array in the point_arrays, or cell_arrays accordingly.
+
+        It depends on the array's length, or specified mode.
+
         """
         # First check points - think of case with vertex cells
         #   there would be the same number of cells as points but we'd want
@@ -1147,7 +1170,7 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def n_arrays(self):
-        """The number of scalar arrays present in the dataset"""
+        """Return the number of scalar arrays present in the dataset."""
         n = self.GetPointData().GetNumberOfArrays()
         n += self.GetCellData().GetNumberOfArrays()
         n += self.GetFieldData().GetNumberOfArrays()
@@ -1156,15 +1179,22 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def n_scalars(self):
-        """DEPRECATED: Please use `n_arrays`"""
+        """Return the number of scalars.
+
+        DEPRECATED: Please use `n_arrays` instead.
+
+        """
         warnings.warn('Deprecation Warning: `n_scalars` is now `n_arrays`', RuntimeWarning)
         return self.n_arrays
 
 
     @property
     def array_names(self):
-        """A list of scalar names for the dataset. This makes
-        sure to put the active scalar's name first in the list."""
+        """Return a list of scalar names for the dataset.
+
+        This makes sure to put the active scalar's name first in the list.
+
+        """
         names = []
         for i in range(self.GetPointData().GetNumberOfArrays()):
             names.append(self.GetPointData().GetArrayName(i))
@@ -1182,13 +1212,17 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def scalar_names(self):
-        """DEPRECATED: Please use `array_names`"""
+        """Return the scalar names.
+
+        DEPRECATED: Please use `array_names` instead.
+
+        """
         warnings.warn('Deprecation Warning: `scalar_names` is now `array_names`', RuntimeWarning)
         return self.array_names
 
 
     def _get_attrs(self):
-        """An internal helper for the representation methods"""
+        """Return the representation methods (internal helper)."""
         attrs = []
         attrs.append(("N Cells", self.GetNumberOfCells(), "{}"))
         attrs.append(("N Points", self.GetNumberOfPoints(), "{}"))
@@ -1203,8 +1237,11 @@ class Common(DataSetFilters, DataObject):
 
 
     def _repr_html_(self):
-        """A pretty representation for Jupyter notebooks that includes header
-        details and information about all scalar arrays"""
+        """Return a pretty representation for Jupyter notebooks.
+
+        It includes header details and information about all scalar arrays.
+
+        """
         fmt = ""
         if self.n_arrays > 0:
             fmt += "<table>"
@@ -1223,7 +1260,7 @@ class Common(DataSetFilters, DataObject):
             row = "<tr>" + "".join(["<td>{}</td>" for i in range(len(titles))]) + "</tr>\n"
 
             def format_array(name, arr, field):
-                """internal helper to format array information for printing"""
+                """Format array information for printing (internal helper)."""
                 dl, dh = self.get_data_range(arr)
                 dl = pyvista.FLOAT_FORMAT.format(dl)
                 dh = pyvista.FLOAT_FORMAT.format(dh)
@@ -1249,18 +1286,17 @@ class Common(DataSetFilters, DataObject):
 
 
     def __repr__(self):
-        """Object representation"""
+        """Return the object representation."""
         return self.head(display=False, html=False)
 
 
     def __str__(self):
-        """Object string representation"""
+        """Return the object string representation."""
         return self.head(display=False, html=False)
 
 
     def overwrite(self, mesh):
-        """
-        Overwrites this mesh inplace with the new mesh's geometries and data
+        """Overwrite this mesh inplace with the new mesh's geometries and data.
 
         Parameters
         ----------
@@ -1274,9 +1310,7 @@ class Common(DataSetFilters, DataObject):
 
 
     def cast_to_unstructured_grid(self):
-        """Get a new representation of this object as an
-        :class:`pyvista.UnstructuredGrid`
-        """
+        """Get a new representation of this object as an :class:`pyvista.UnstructuredGrid`."""
         alg = vtk.vtkAppendFilter()
         alg.AddInputData(self)
         alg.Update()
@@ -1285,17 +1319,18 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def quality(self):
-        """
-        Returns cell quality using PyANSYS. Computes the minimum scaled
-        jacobian of each cell.  Cells that have values below 0 are invalid for
+        """Return cell quality using PyANSYS.
+
+        Computes the minimum scaled jacobian of each cell.
+        Cells that have values below 0 are invalid for
         a finite element analysis.
 
         Note
         ----
         This casts the input to an unstructured grid
 
-        Returns
-        -------
+        Return
+        ------
         cellquality : np.ndarray
             Minimum scaled jacobian of each cell.  Ranges from -1 to 1.
 
@@ -1317,8 +1352,10 @@ class Common(DataSetFilters, DataObject):
 
 
 class _ScalarsDict(dict):
-    """Internal helper for scalars dictionaries"""
+    """Internal helper for scalars dictionaries."""
+
     def __init__(self, data):
+        """Initialize the scalars dict."""
         self.data = proxy(data)
         dict.__init__(self)
         self.callback_enabled = False
@@ -1327,7 +1364,7 @@ class _ScalarsDict(dict):
 
 
     def enable_callback(self):
-        """Enable callbacks to be set True"""
+        """Enable callbacks to be set True."""
         self.callback_enabled = True
 
 
@@ -1336,17 +1373,14 @@ class _ScalarsDict(dict):
 
 
     def pop(self, key):
-        """Get and remove an element by key name"""
+        """Get and remove an element by key name."""
         arr = dict.pop(self, key).copy()
         self.remover(key)
         return arr
 
 
     def update(self, data):
-        """
-        Update this dictionary with th key-value pairs from a given
-        dictionary
-        """
+        """Update this dictionary with th key-value pairs from a given dictionary."""
         if not isinstance(data, (dict, pyvista.Table)):
             raise TypeError('Data to update must be in a dictionary or PyVista Table.')
         for k, v in data.items():
@@ -1359,7 +1393,7 @@ class _ScalarsDict(dict):
 
 
     def __setitem__(self, key, val):
-        """ overridden to assure data is contiguous """
+        """Ensure that data is contiguous."""
         if isinstance(val, (list, tuple)):
             val = np.array(val)
         if self.callback_enabled:
@@ -1369,58 +1403,58 @@ class _ScalarsDict(dict):
 
 
     def __delitem__(self, key):
-        """Remove item by key name"""
+        """Remove item by key name."""
         self.remover(key)
         return dict.__delitem__(self, key)
 
 
 class CellScalarsDict(_ScalarsDict):
-    """
-    Updates internal cell data when an array is added or removed from
-    the dictionary.
-    """
+    """Update internal cell data when an array is added or removed from the dictionary."""
+
     def __init__(self, data):
+        """Initialize the cell scalar dict."""
         _ScalarsDict.__init__(self, data)
         self.remover = lambda key: self.data._remove_array(CELL_DATA_FIELD, key)
         self.modifier = lambda *args: self.data.GetCellData().Modified()
 
 
     def adder(self, scalars, name, set_active=False, deep=True):
+        """Add a cell array."""
         self.data._add_cell_array(scalars, name, set_active=False, deep=deep)
 
 
 class PointScalarsDict(_ScalarsDict):
-    """
-    Updates internal point data when an array is added or removed from
-    the dictionary.
-    """
+    """Update internal point data when an array is added or removed from the dictionary."""
+
     def __init__(self, data):
+        """Initialize the point scalar dict."""
         _ScalarsDict.__init__(self, data)
         self.remover = lambda key: self.data._remove_array(POINT_DATA_FIELD, key)
         self.modifier = lambda *args: self.data.GetPointData().Modified()
 
 
     def adder(self, scalars, name, set_active=False, deep=True):
+        """Add a point array."""
         self.data._add_point_array(scalars, name, set_active=False, deep=deep)
 
 
 class FieldScalarsDict(_ScalarsDict):
-    """
-    Updates internal field data when an array is added or removed from
-    the dictionary.
-    """
+    """Update internal field data when an array is added or removed from the dictionary."""
+
     def __init__(self, data):
+        """Initialize the field scalars dict."""
         _ScalarsDict.__init__(self, data)
         self.remover = lambda key: self.data._remove_array(FIELD_DATA_FIELD, key)
         self.modifier = lambda *args: self.data.GetFieldData().Modified()
 
 
     def adder(self, scalars, name, set_active=False, deep=True):
+        """Add a field array."""
         self.data._add_field_array(scalars, name, deep=deep)
 
 
 def axis_rotation(points, angle, inplace=False, deg=True, axis='z'):
-    """ Rotates points angle (in deg) about an axis """
+    """Rotate points angle (in deg) about an axis."""
     axis = axis.lower()
 
     # Copy original array to if not inplace
@@ -1454,8 +1488,7 @@ def axis_rotation(points, angle, inplace=False, deg=True, axis='z'):
 
 
 class pyvista_ndarray(np.ndarray):
-    """
-    Links a numpy array with the vtk object the data is attached to.
+    """Link a numpy array with the vtk object the data is attached to.
 
     When the array is changed it triggers "Modified()" which updates
     all upstream objects, including any render windows holding the
@@ -1464,15 +1497,17 @@ class pyvista_ndarray(np.ndarray):
     """
 
     def __new__(cls, input_array, proxy):
+        """Allocate memory for the pyvista ndarray."""
         obj = np.asarray(input_array).view(cls)
         cls.proxy = proxy
         return obj
 
     def __array_finalize__(self, obj):
+        """Customize array at creation."""
         if obj is None:
             return
 
     def __setitem__(self, coords, value):
-        """ Update the array and update the vtk object """
+        """Update the array and update the vtk object."""
         super(pyvista_ndarray, self).__setitem__(coords, value)
         self.proxy.Modified()

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -1,7 +1,7 @@
-"""
-Container to mimic ``vtkMultiBlockDataSet`` objects. These classes hold many
-VTK datasets in one object that can be passed to VTK algorithms and PyVista
-filtering/plotting routines.
+"""Container to mimic ``vtkMultiBlockDataSet`` objects.
+
+These classes hold many VTK datasets in one object that can be passed
+to VTK algorithms and PyVista filtering/plotting routines.
 """
 import collections
 import logging
@@ -22,8 +22,8 @@ log.setLevel('CRITICAL')
 
 
 class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
-    """
-    A composite class to hold many data sets which can be iterated over.
+    """A composite class to hold many data sets which can be iterated over.
+
     This wraps/extends the ``vtkMultiBlockDataSet`` class in VTK so that we can
     easily plot these data sets and use the composite in a Pythonic manner.
 
@@ -57,12 +57,14 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
     >>> for block in blocks:
     ...     surf = block.extract_surface() # Do something with each dataset
+
     """
 
     # Bind pyvista.plotting.plot to the object
     plot = pyvista.plot
 
     def __init__(self, *args, **kwargs):
+        """Initialize multi block."""
         super(MultiBlock, self).__init__()
         deep = kwargs.pop('deep', False)
         self.refs = []
@@ -92,8 +94,11 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
 
     def wrap_nested(self):
-        """A helper to ensure all nested data structures are wrapped as PyVista
-        datasets. This is perfrom inplace"""
+        """Ensure that all nested data structures are wrapped as PyVista datasets.
+
+        This is performed in place.
+
+        """
         for i in range(self.n_blocks):
             block = self.GetBlock(i)
             if not is_pyvista_dataset(block):
@@ -102,8 +107,10 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
 
     def _load_file(self, filename):
-        """Load a vtkMultiBlockDataSet from a file (extension ``.vtm`` or
-        ``.vtmb``)
+        """Load a vtkMultiBlockDataSet from a file.
+
+        The supported extensions are:  ``.vtm`` or ``.vtmb``.
+
         """
         filename = os.path.abspath(os.path.expanduser(filename))
         # test if file exists
@@ -127,8 +134,7 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
 
     def save(self, filename, binary=True):
-        """
-        Writes a ``MultiBlock`` dataset to disk.
+        """Write a ``MultiBlock`` dataset to disk.
 
         Written file may be an ASCII or binary vtm file.
 
@@ -146,6 +152,7 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
         -----
         Binary files write much faster than ASCII and have a smaller
         file size.
+
         """
         filename = os.path.abspath(os.path.expanduser(filename))
         ext = pyvista.get_ext(filename)
@@ -165,16 +172,18 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
     @property
     def bounds(self):
-        """Finds min/max for bounds across blocks
+        """Find min/max for bounds across blocks.
 
-        Returns:
-            tuple(float):
-                length 6 tuple of floats containing min/max along each axis
+        Return
+        ------
+        tuple(float):
+            length 6 tuple of floats containing min/max along each axis
+
         """
         bounds = [np.inf,-np.inf, np.inf,-np.inf, np.inf,-np.inf]
 
         def update_bounds(ax, nb, bounds):
-            """internal helper to update bounds while keeping track"""
+            """Update bounds while keeping track (internal helper)."""
             if nb[2*ax] < bounds[2*ax]:
                 bounds[2*ax] = nb[2*ax]
             if nb[2*ax+1] > bounds[2*ax+1]:
@@ -194,36 +203,35 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
     @property
     def center(self):
-        """ Center of the bounding box """
+        """Return the center of the bounding box."""
         return np.array(self.bounds).reshape(3,2).mean(axis=1)
 
 
     @property
     def length(self):
-        """the length of the diagonal of the bounding box"""
+        """Return the length of the diagonal of the bounding box."""
         return pyvista.Box(self.bounds).length
 
 
     @property
     def n_blocks(self):
-        """The total number of blocks set"""
+        """Return the total number of blocks set."""
         return self.GetNumberOfBlocks()
 
 
     @n_blocks.setter
     def n_blocks(self, n):
-        """The total number of blocks set"""
+        """Return the total number of blocks set."""
         self.SetNumberOfBlocks(n)
         self.Modified()
 
 
     @property
     def volume(self):
-        """
-        Total volume of all meshes in this dataast
+        """Return the total volume of all meshes in this dataset.
 
-        Returns
-        -------
+        Return
+        ------
         volume : float
             Total volume of the mesh.
 
@@ -237,7 +245,7 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
 
     def get_data_range(self, name):
-        """Gets the min/max of a scalar given its name across all blocks"""
+        """Get the min/max of a scalar given its name across all blocks."""
         mini, maxi = np.inf, -np.inf
         for i in range(self.n_blocks):
             data = self[i]
@@ -256,7 +264,7 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
 
     def get_index_by_name(self, name):
-        """Find the index number by block name"""
+        """Find the index number by block name."""
         for i in range(self.n_blocks):
             if self.get_block_name(i) == name:
                 return i
@@ -264,8 +272,11 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
 
     def __getitem__(self, index):
-        """Get a block by its index or name (if the name is non-unique then
-        returns the first occurence)"""
+        """Get a block by its index or name.
+
+        If the name is non-unique then returns the first occurence.
+
+        """
         if isinstance(index, str):
             index = self.get_index_by_name(index)
         if index < 0:
@@ -283,20 +294,23 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
 
     def append(self, data):
-        """Add a data set to the next block index"""
+        """Add a data set to the next block index."""
         index = self.n_blocks # note off by one so use as index
         self[index] = data
         self.refs.append(data)
 
 
     def get(self, index):
-        """Get a block by its index or name (if the name is non-unique then
-        returns the first occurence)"""
+        """Get a block by its index or name.
+
+        If the name is non-unique then returns the first occurence.
+
+        """
         return self[index]
 
 
     def set_block_name(self, index, name):
-        """Set a block's string name at the specified index"""
+        """Set a block's string name at the specified index."""
         if name is None:
             return
         self.GetMetaData(index).Set(vtk.vtkCompositeDataSet.NAME(), name)
@@ -304,7 +318,7 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
 
     def get_block_name(self, index):
-        """Returns the string name of the block at the given index"""
+        """Return the string name of the block at the given index."""
         meta = self.GetMetaData(index)
         if meta is not None:
             return meta.Get(vtk.vtkCompositeDataSet.NAME())
@@ -312,7 +326,7 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
 
     def keys(self):
-        """Get all the block names in the dataset"""
+        """Get all the block names in the dataset."""
         names = []
         for i in range(self.n_blocks):
             names.append(self.get_block_name(i))
@@ -324,8 +338,9 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
 
     def __setitem__(self, index, data):
-        """Sets a block with a VTK data object. To set the name simultaneously,
-        pass a string name as the 2nd index.
+        """Set a block with a VTK data object.
+
+        To set the name simultaneously, pass a string name as the 2nd index.
 
         Example
         -------
@@ -336,6 +351,7 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
         >>> multi['bar'] = pyvista.PolyData()
         >>> multi.n_blocks
         3
+
         """
         if isinstance(index, collections.Iterable) and not isinstance(index, str):
             i, name = index[0], index[1]
@@ -362,19 +378,19 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
 
     def __delitem__(self, index):
-        """Removes a block at the specified index"""
+        """Remove a block at the specified index."""
         if isinstance(index, str):
             index = self.get_index_by_name(index)
         self.RemoveBlock(index)
 
 
     def __iter__(self):
-        """The iterator across all blocks"""
+        """Return the iterator across all blocks."""
         self._iter_n = 0
         return self
 
     def next(self):
-        """Get the next block from the iterator"""
+        """Get the next block from the iterator."""
         if self._iter_n < self.n_blocks:
             result = self[self._iter_n]
             self._iter_n += 1
@@ -386,18 +402,20 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
 
     def pop(self, index):
-        """Pops off a block at the specified index"""
+        """Pop off a block at the specified index."""
         data = self[index]
         del self[index]
         return data
 
 
     def clean(self, empty=True):
-        """This will remove any null blocks in place
+        """Remove any null blocks in place.
+
         Parameters
         -----------
         empty : bool
-            Remove any meshes that are empty as well (have zero points)
+            Remove any meshes that are empty as well (have zero points).
+
         """
         null_blocks = []
         for i in range(self.n_blocks):
@@ -420,7 +438,7 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
 
     def _get_attrs(self):
-        """An internal helper for the representation methods"""
+        """Return the representation methods (internal helper)."""
         attrs = []
         attrs.append(("N Blocks", self.n_blocks, "{}"))
         bds = self.bounds
@@ -431,7 +449,7 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
 
     def _repr_html_(self):
-        """A pretty representation for Jupyter notebooks"""
+        """Define a pretty representation for Jupyter notebooks."""
         fmt = ""
         fmt += "<table>"
         fmt += "<tr><th>Information</th><th>Blocks</th></tr>"
@@ -467,6 +485,7 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
 
     def __repr__(self):
+        """Define an adequate representation."""
         # return a string that is Python console friendly
         fmt = "{} ({})\n".format(type(self).__name__, hex(id(self)))
         # now make a call on the object to get its attributes as a list of len 2 tuples
@@ -480,15 +499,17 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
 
     def __str__(self):
+        """Return the str representation of the multi block."""
         return MultiBlock.__repr__(self)
 
 
     def __len__(self):
+        """Return the number of blocks."""
         return self.n_blocks
 
 
     def copy_meta_from(self, ido):
-        """Copies pyvista meta data onto this object from another object"""
+        """Copy pyvista meta data onto this object from another object."""
         # Note that `pyvista.MultiBlock` datasets currently don't have any meta.
         # This method is here for consistency witht the rest of the API and
         # incase we add meta data to this pbject down the road.
@@ -496,18 +517,18 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
 
     def copy(self, deep=True):
-        """
-        Returns a copy of the object
+        """Return a copy of the object.
 
         Parameters
         ----------
         deep : bool, optional
             When True makes a full copy of the object.
 
-        Returns
-        -------
+        Return
+        ------
         newobject : same as input
            Deep or shallow copy of the input.
+
         """
         thistype = type(self)
         newobject = thistype()

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1,5 +1,5 @@
-"""
-These classes hold methods to apply general filters to any data type.
+"""These classes hold methods to apply general filters to any data type.
+
 By inherritting these classes into the wrapped VTK data structures, a user
 can easily apply common filters in an intuitive manner.
 
@@ -38,7 +38,7 @@ from pyvista.utilities import (CELL_DATA_FIELD, POINT_DATA_FIELD, NORMALS,
 
 def _get_output(algorithm, iport=0, iconnection=0, oport=0, active_scalar=None,
                 active_scalar_field='point'):
-    """A helper to get the algorithm's output and copy input's pyvista meta info"""
+    """Get the algorithm's output and copy input's pyvista meta info."""
     ido = algorithm.GetInputDataObject(iport, iconnection)
     data = wrap(algorithm.GetOutputDataObject(oport))
     if not isinstance(data, pyvista.MultiBlock):
@@ -50,16 +50,17 @@ def _get_output(algorithm, iport=0, iconnection=0, oport=0, active_scalar=None,
 
 
 class DataSetFilters(object):
-    """A set of common filters that can be applied to any vtkDataSet"""
+    """A set of common filters that can be applied to any vtkDataSet."""
 
     def __new__(cls, *args, **kwargs):
+        """Allocate memory for the dataset filters."""
         if cls is DataSetFilters:
             raise TypeError("pyvista.DataSetFilters is an abstract class and may not be instantiated.")
         return object.__new__(cls)
 
 
     def _clip_with_function(dataset, function, invert=True, value=0.0):
-        """Internal helper to clip using an implicit function"""
+        """Clip using an implicit function (internal helper)."""
         if isinstance(dataset, vtk.vtkPolyData):
             alg = vtk.vtkClipPolyData()
         # elif isinstance(dataset, vtk.vtkImageData):
@@ -76,9 +77,9 @@ class DataSetFilters(object):
 
 
     def clip(dataset, normal='x', origin=None, invert=True, value=0.0, inplace=False):
-        """
-        Clip a dataset by a plane by specifying the origin and normal. If no
-        parameters are given the clip will occur in the center of that dataset
+        """Clip a dataset by a plane by specifying the origin and normal.
+
+        If no parameters are given the clip will occur in the center of that dataset.
 
         Parameters
         ----------
@@ -101,6 +102,7 @@ class DataSetFilters(object):
 
         inplace : bool, optional
             Updates mesh in-place while returning nothing.
+
         """
         if isinstance(normal, str):
             normal = NORMALS[normal.lower()]
@@ -119,8 +121,9 @@ class DataSetFilters(object):
 
 
     def clip_box(dataset, bounds=None, invert=True, factor=0.35):
-        """Clips a dataset by a bounding box defined by the bounds. If no bounds
-        are given, a corner of the dataset bounds will be removed.
+        """Clip a dataset by a bounding box defined by the bounds.
+
+        If no bounds are given, a corner of the dataset bounds will be removed.
 
         Parameters
         ----------
@@ -144,7 +147,7 @@ class DataSetFilters(object):
         """
         if bounds is None:
             def _get_quarter(dmin, dmax):
-                """internal helper to get a section of the given range"""
+                """Get a section of the given range (internal helper)."""
                 return dmax - ((dmax - dmin) * factor)
             xmin, xmax, ymin, ymax, zmin, zmax = dataset.bounds
             xmin = _get_quarter(xmin, xmax)
@@ -184,6 +187,7 @@ class DataSetFilters(object):
     def clip_surface(dataset, surface, invert=True, value=0.0,
                      compute_distance=False):
         """Clip any mesh type using a :class:`pyvista.PolyData` surface mesh.
+
         This will return a :class:`pyvista.UnstructuredGrid` of the clipped
         mesh. Geometry of the input dataset will be preserved where possible -
         geometries near the clip intersection will be triangulated/tessellated.
@@ -206,6 +210,7 @@ class DataSetFilters(object):
             Compute the implicit distance from the mesh onto the input dataset.
             A new array called ``'implicit_distance'`` will be added to the
             output clipped mesh.
+
         """
         if not isinstance(surface, vtk.vtkPolyData):
             surface = DataSetFilters.extract_geometry(surface)
@@ -224,9 +229,9 @@ class DataSetFilters(object):
 
     def slice(dataset, normal='x', origin=None, generate_triangles=False,
               contour=False):
-        """Slice a dataset by a plane at the specified origin and normal vector
-        orientation. If no origin is specified, the center of the input dataset will
-        be used.
+        """Slice a dataset by a plane at the specified origin and normal vector orientation.
+
+        If no origin is specified, the center of the input dataset will be used.
 
         Parameters
         ----------
@@ -268,8 +273,9 @@ class DataSetFilters(object):
 
     def slice_orthogonal(dataset, x=None, y=None, z=None,
                          generate_triangles=False, contour=False):
-        """Creates three orthogonal slices through the dataset on the three
-        caresian planes. Yields a MutliBlock dataset of the three slices.
+        """Create three orthogonal slices through the dataset on the three cartesian planes.
+
+        Yields a MutliBlock dataset of the three slices.
 
         Parameters
         ----------
@@ -373,8 +379,9 @@ class DataSetFilters(object):
 
     def slice_along_line(dataset, line, generate_triangles=False,
                          contour=False):
-        """Slices a dataset using a polyline/spline as the path. This also works
-        for lines generated with :func:`pyvista.Line`
+        """Slice a dataset using a polyline/spline as the path.
+
+        This also works for lines generated with :func:`pyvista.Line`
 
         Parameters
         ----------
@@ -387,6 +394,7 @@ class DataSetFilters(object):
 
         contour : bool, optional
             If True, apply a ``contour`` filter after slicing
+
         """
         # check that we have a PolyLine cell in the input line
         if line.GetNumberOfCells() != 1:
@@ -412,11 +420,10 @@ class DataSetFilters(object):
 
     def threshold(dataset, value=None, scalars=None, invert=False, continuous=False,
                   preference='cell'):
-        """
-        This filter will apply a ``vtkThreshold`` filter to the input dataset and
-        return the resulting object. This extracts cells where scalar value in each
-        cell satisfies threshold criterion.  If scalars is None, the inputs
-        active_scalar is used.
+        """Apply a ``vtkThreshold`` filter to the input dataset.
+
+        This extracts cells where scalar value in each cell satisfies threshold criterion.
+        If scalars is None, the inputs active_scalar is used.
 
         Parameters
         ----------
@@ -494,8 +501,7 @@ class DataSetFilters(object):
 
     def threshold_percent(dataset, percent=0.50, scalars=None, invert=False,
                           continuous=False, preference='cell'):
-        """Thresholds the dataset by a percentage of its range on the active
-        scalar array or as specified
+        """Threshold the dataset by a percentage of its range on the active scalar array or as specified.
 
         Parameters
         ----------
@@ -539,7 +545,7 @@ class DataSetFilters(object):
             return percent
 
         def _get_val(percent, dmin, dmax):
-            """Gets the value from a percentage of a range"""
+            """Get the value from a percentage of a range."""
             percent = _check_percent(percent)
             return dmin + float(percent) * (dmax - dmin)
 
@@ -557,7 +563,7 @@ class DataSetFilters(object):
 
 
     def outline(dataset, generate_faces=False):
-        """Produces an outline of the full extent for the input dataset.
+        """Produce an outline of the full extent for the input dataset.
 
         Parameters
         ----------
@@ -572,7 +578,7 @@ class DataSetFilters(object):
         return wrap(alg.GetOutputDataObject(0))
 
     def outline_corners(dataset, factor=0.2):
-        """Produces an outline of the corners for the input dataset.
+        """Produce an outline of the corners for the input dataset.
 
         Parameters
         ----------
@@ -588,9 +594,11 @@ class DataSetFilters(object):
         return wrap(alg.GetOutputDataObject(0))
 
     def extract_geometry(dataset):
-        """Extract the outer surface of a volume or structured grid dataset as
-        PolyData. This will extract all 0D, 1D, and 2D cells producing the
+        """Extract the outer surface of a volume or structured grid dataset as PolyData.
+
+        This will extract all 0D, 1D, and 2D cells producing the
         boundary faces of the dataset.
+
         """
         alg = vtk.vtkGeometryFilter()
         alg.SetInputDataObject(dataset)
@@ -599,7 +607,9 @@ class DataSetFilters(object):
 
     def wireframe(dataset):
         """Extract all the internal/external edges of the dataset as PolyData.
+
         This produces a full wireframe representation of the input dataset.
+
         """
         alg = vtk.vtkExtractEdges()
         alg.SetInputDataObject(dataset)
@@ -608,9 +618,10 @@ class DataSetFilters(object):
 
     def elevation(dataset, low_point=None, high_point=None, scalar_range=None,
                   preference='point', set_active=True):
-        """Generate scalar values on a dataset.  The scalar values lie within a
-        user specified range, and are generated by computing a projection of
-        each dataset point onto a line.
+        """Generate scalar values on a dataset.
+
+        The scalar values lie within a user specified range, and are generated by
+        computing a projection of each dataset point onto a line.
         The line can be oriented arbitrarily.
         A typical example is to generate scalars based on elevation or height
         above a plane.
@@ -683,9 +694,10 @@ class DataSetFilters(object):
     def contour(dataset, isosurfaces=10, scalars=None, compute_normals=False,
                 compute_gradients=False, compute_scalars=True, rng=None,
                 preference='point', method='contour'):
-        """Contours an input dataset by an array. ``isosurfaces`` can be an integer
-        specifying the number of isosurfaces in the data range or an iterable set of
-        values for explicitly setting the isosurfaces.
+        """Contour an input dataset by an array.
+
+        ``isosurfaces`` can be an integer specifying the number of isosurfaces in
+        the data range or an iterable set of values for explicitly setting the isosurfaces.
 
         Parameters
         ----------
@@ -762,9 +774,10 @@ class DataSetFilters(object):
     def texture_map_to_plane(dataset, origin=None, point_u=None, point_v=None,
                              inplace=False, name='Texture Coordinates',
                              use_bounds=False):
-        """Texture map this dataset to a user defined plane. This is often used
-        to define a plane to texture map an image to this dataset. The plane
-        defines the spatial reference and extent of that image.
+        """Texture map this dataset to a user defined plane.
+
+        This is often used to define a plane to texture map an image to this dataset.
+        The plane defines the spatial reference and extent of that image.
 
         Parameters
         ----------
@@ -792,6 +805,7 @@ class DataSetFilters(object):
         use_bounds : bool
             Use the bounds to set the mapping plane by default (bottom plane
             of the bounding box).
+
         """
         if use_bounds:
             if isinstance(use_bounds, (int, bool)):
@@ -823,8 +837,7 @@ class DataSetFilters(object):
         return # No return type because it is inplace
 
     def compute_cell_sizes(dataset, length=True, area=True, volume=True):
-        """This filter computes sizes for 1D (length), 2D (area) and 3D (volume)
-        cells.
+        """Compute sizes for 1D (length), 2D (area) and 3D (volume) cells.
 
         Parameters
         ----------
@@ -849,12 +862,14 @@ class DataSetFilters(object):
 
     def cell_centers(dataset, vertex=True):
         """Generate points at the center of the cells in this dataset.
+
         These points can be used for placing glyphs / vectors.
 
         Parameters
         ----------
         vertex : bool
             Enable/disable the generation of vertex cells.
+
         """
         alg = vtk.vtkCellCenters()
         alg.SetInputDataObject(dataset)
@@ -866,10 +881,9 @@ class DataSetFilters(object):
 
     def glyph(dataset, orient=True, scale=True, factor=1.0, geom=None,
               tolerance=0.0, absolute=False, clamping=False, rng=None):
-        """
-        Copies a geometric representation (called a glyph) to every
-        point in the input dataset.  The glyph may be oriented along
-        the input vectors, and it may be scaled according to scalar
+        """Copy a geometric representation (called a glyph) to every point in the input dataset.
+
+        The glyph may be oriented along the input vectors, and it may be scaled according to scalar
         data or vector magnitude.
 
         Parameters
@@ -900,6 +914,7 @@ class DataSetFilters(object):
         rng: tuple(float), optional
             Set the range of values to be considered by the filter when scalars
             values are provided.
+
         """
         # Clean the points before glyphing
         small = pyvista.PolyData(dataset.points)
@@ -942,10 +957,12 @@ class DataSetFilters(object):
 
 
     def connectivity(dataset, largest=False):
-        """Find and label connected bodies/volumes. This adds an ID array to
-        the point and cell data to distinguish separate connected bodies.
-        This applies a ``vtkConnectivityFilter`` filter which extracts cells
-        that share common points and/or meet other connectivity criterion.
+        """Find and label connected bodies/volumes.
+
+        This adds an ID array to the point and cell data to distinguish separate
+        connected bodies. This applies a ``vtkConnectivityFilter`` filter which
+        extracts cells that share common points and/or meet other connectivity
+        criterion.
         (Cells that share vertices and meet other connectivity criterion such
         as scalar range are known as a region.)
 
@@ -953,6 +970,7 @@ class DataSetFilters(object):
         ----------
         largest : bool
             Extract the largest connected part of the mesh.
+
         """
         alg = vtk.vtkConnectivityFilter()
         alg.SetInputData(dataset)
@@ -992,14 +1010,16 @@ class DataSetFilters(object):
 
 
     def split_bodies(dataset, label=False):
-        """Find, label, and split connected bodies/volumes. This splits
-        different connected bodies into blocks in a MultiBlock dataset.
+        """Find, label, and split connected bodies/volumes.
+        
+        This splits different connected bodies into blocks in a MultiBlock dataset.
 
         Parameters
         ----------
         label : bool
             A flag on whether to keep the ID arrays given by the
             ``connectivity`` filter.
+
         """
         # Get the connectivity and label different bodies
         labeled = DataSetFilters.connectivity(dataset)
@@ -1021,8 +1041,8 @@ class DataSetFilters(object):
 
     def warp_by_scalar(dataset, scalars=None, factor=1.0, normal=None,
                        inplace=False, **kwargs):
-        """
-        Warp the dataset's points by a point data scalar array's values.
+        """Warp the dataset's points by a point data scalar array's values.
+
         This modifies point coordinates by moving points along point normals by
         the scalar amount times the scale factor.
 
@@ -1041,6 +1061,7 @@ class DataSetFilters(object):
 
         inplace : bool
             If True, the points of the give dataset will be updated.
+
         """
         factor = kwargs.pop('scale_factor', factor)
         assert_empty_kwargs(**kwargs)
@@ -1068,8 +1089,11 @@ class DataSetFilters(object):
 
 
     def cell_data_to_point_data(dataset, pass_cell_data=False):
-        """Transforms cell data (i.e., data specified per cell) into point data
-        (i.e., data specified at cell points).
+        """Transform cell data into point data.
+
+        Point data are specified per node and cell data specified within cells.
+        Optionally, the input point data can be passed through to the output.
+
         The method of transformation is based on averaging the data values of
         all cells using a particular point. Optionally, the input cell data can
         be passed through to the output as well.
@@ -1080,6 +1104,7 @@ class DataSetFilters(object):
         ----------
         pass_cell_data : bool
             If enabled, pass the input cell data through to the output
+
         """
         alg = vtk.vtkCellDataToPointData()
         alg.SetInputDataObject(dataset)
@@ -1092,13 +1117,21 @@ class DataSetFilters(object):
 
 
     def ctp(dataset, pass_cell_data=False):
-        """An alias/shortcut for ``cell_data_to_point_data``"""
+        """Transform cell data into point data.
+
+        Point data are specified per node and cell data specified within cells.
+        Optionally, the input point data can be passed through to the output.
+
+        An alias/shortcut for ``cell_data_to_point_data``.
+
+        """
         return DataSetFilters.cell_data_to_point_data(dataset, pass_cell_data=pass_cell_data)
 
 
     def point_data_to_cell_data(dataset, pass_point_data=False):
-        """Transforms point data (i.e., data specified per node) into cell data
-        (i.e., data specified within cells).
+        """Transform point data into cell data.
+
+        Point data are specified per node and cell data specified within cells.
         Optionally, the input point data can be passed through to the output.
 
         See also: :func:`pyvista.DataSetFilters.cell_data_to_point_data`
@@ -1107,6 +1140,7 @@ class DataSetFilters(object):
         ----------
         pass_point_data : bool
             If enabled, pass the input point data through to the output
+
         """
         alg = vtk.vtkPointDataToCellData()
         alg.SetInputDataObject(dataset)
@@ -1119,22 +1153,29 @@ class DataSetFilters(object):
 
 
     def ptc(dataset, pass_point_data=False):
-        """An alias/shortcut for ``point_data_to_cell_data``"""
+        """Transform point data into cell data.
+
+        Point data are specified per node and cell data specified within cells.
+        Optionally, the input point data can be passed through to the output.
+
+        An alias/shortcut for ``point_data_to_cell_data``.
+        
+        """
         return DataSetFilters.point_data_to_cell_data(dataset, pass_point_data=pass_point_data)
 
 
     def triangulate(dataset, inplace=False):
-        """
-        Returns an all triangle mesh.  More complex polygons will be broken
-        down into triangles.
+        """Return an all triangle mesh.
+        
+        More complex polygons will be broken down into triangles.
 
         Parameters
         ----------
         inplace : bool, optional
             Updates mesh in-place while returning ``None``.
 
-        Returns
-        -------
+        Return
+        ------
         mesh : pyvista.UnstructuredGrid
             Mesh containing only triangles. ``None`` when ``inplace=True``
 
@@ -1151,7 +1192,8 @@ class DataSetFilters(object):
 
 
     def delaunay_3d(dataset, alpha=0, tol=0.001, offset=2.5):
-        """Constructs a 3D Delaunay triangulation of the mesh.
+        """Construct a 3D Delaunay triangulation of the mesh.
+
         This helps smooth out a rugged mesh.
 
         Parameters
@@ -1170,6 +1212,7 @@ class DataSetFilters(object):
         offset : float, optional
             multiplier to control the size of the initial, bounding Delaunay
             triangulation.
+
         """
         alg = vtk.vtkDelaunay3D()
         alg.SetInputData(dataset)
@@ -1183,6 +1226,7 @@ class DataSetFilters(object):
     def select_enclosed_points(dataset, surface, tolerance=0.001,
                                inside_out=False, check_surface=True):
         """Mark points as to whether they are inside a closed surface.
+
         This evaluates all the input points to determine whether they are in an
         enclosed surface. The filter produces a (0,1) mask
         (in the form of a vtkDataArray) that indicates whether points are
@@ -1221,6 +1265,7 @@ class DataSetFilters(object):
             algorithm first checks to see if the surface is closed and
             manifold. If the surface is not closed and manifold, a runtime
             error is raised.
+
         """
         if not isinstance(surface, pyvista.PolyData):
             raise TypeError("`surface` must be `pyvista.PolyData`")
@@ -1243,8 +1288,9 @@ class DataSetFilters(object):
 
     def sample(dataset, target, tolerance=None, pass_cell_arrays=True,
                pass_point_arrays=True):
-        """Resample scalar data from a passed mesh onto this mesh using
-        :class:`vtk.vtkResampleWithDataSet`.
+        """Resample scalar data from a passed mesh onto this mesh.
+
+        This uses :class:`vtk.vtkResampleWithDataSet`.
 
         Parameters
         ----------
@@ -1264,6 +1310,7 @@ class DataSetFilters(object):
 
         pass_point_arrays: bool, optional
             Preserve source mesh's original point data arrays
+
         """
         alg = vtk.vtkResampleWithDataSet() # Construct the ResampleWithDataSet object
         alg.SetInputData(dataset)  # Set the Input data (actually the source i.e. where to sample from)
@@ -1280,8 +1327,9 @@ class DataSetFilters(object):
     def interpolate(dataset, points, sharpness=2, radius=1.0,
                     dimensions=(101, 101, 101), pass_cell_arrays=True,
                     pass_point_arrays=True, null_value=0.0):
-        """Interpolate values onto this mesh from the point data of a given
-        :class:`pyvista.PolyData` object (typically a point cloud).
+        """Interpolate values onto this mesh from the point data of a given dataset.
+
+        The input dataset is typically a point cloud.
 
         This uses a gaussian interpolation kernel. Use the ``sharpness`` and
         ``radius`` parameters to adjust this kernel.
@@ -1318,6 +1366,7 @@ class DataSetFilters(object):
             Specify the null point value. When a null point is encountered
             then all components of each null tuple are set to this value. By
             default the null value is set to zero.
+
         """
         box = pyvista.create_grid(dataset, dimensions=dimensions)
 
@@ -1345,9 +1394,10 @@ class DataSetFilters(object):
                     max_time=None, compute_vorticity=True, rotation_scale=1.0,
                     interpolator_type='point', start_position=(0.0, 0.0, 0.0),
                     return_source=False, pointa=None, pointb=None):
-        """Integrate a vector field to generate streamlines. The integration is
-        performed using a specified integrator, by default Runge-Kutta2.
-        This supports integration through any type of dataset.
+        """Integrate a vector field to generate streamlines.
+
+        The integration is performed using a specified integrator, by default
+        Runge-Kutta2. This supports integration through any type of dataset.
         Thus if the dataset contains 2D cells like polygons or triangles, the
         integration is constrained to lie on the surface defined by 2D cells.
 
@@ -1448,6 +1498,7 @@ class DataSetFilters(object):
         pointa, pointb : tuple(float)
             The coordinates of a start and end point for a line source. This
             will override the sphere point source.
+
         """
         integration_direction = str(integration_direction).strip().lower()
         if integration_direction not in ['both', 'back', 'backward', 'forward']:
@@ -1531,8 +1582,9 @@ class DataSetFilters(object):
 
 
     def decimate_boundary(dataset, target_reduction=0.5):
-        """Return a decimated version of a triangulation of the boundary of
-        this mesh's outer surface
+        """Return a decimated version of a triangulation of the boundary.
+
+        Only the outer surface of the input dataset will be considered.
 
         Parameters
         ----------
@@ -1541,6 +1593,7 @@ class DataSetFilters(object):
             TargetReduction is set to ``0.9``, this filter will try to reduce
             the data set to 10% of its original size and will remove 90%
             of the input triangles.
+
         """
         return dataset.extract_geometry().triangulate().decimate(target_reduction)
 
@@ -1548,9 +1601,11 @@ class DataSetFilters(object):
     def plot_over_line(dataset, pointa, pointb, resolution=None, scalars=None,
                        title=None, ylabel=None, figsize=None, figure=True,
                        show=True):
-        """Sample a dataset along a high resolution line and plot the variables
-        of interest in 2D where the X-axis is distance from Point A and the
-        Y-axis is the variable of interest. Note that this filter returns None.
+        """Sample a dataset along a high resolution line.
+
+        Also plot the variables of interest in 2D where the X-axis is distance from
+        Point A and the Y-axis is the variable of interest. Note that this filter
+        returns None.
 
         Parameters
         ----------
@@ -1582,6 +1637,7 @@ class DataSetFilters(object):
 
         show : bool
             Shows the matplotlib figure
+
         """
         # Ensure matplotlib is available
         try:
@@ -1627,16 +1683,15 @@ class DataSetFilters(object):
 
 
     def extract_cells(dataset, ind):
-        """
-        Returns a subset of the grid
+        """Return a subset of the grid.
 
         Parameters
         ----------
         ind : np.ndarray
             Numpy array of cell indices to be extracted.
 
-        Returns
-        -------
+        Return
+        ------
         subgrid : pyvista.UnstructuredGrid
             Subselected grid
 
@@ -1680,18 +1735,18 @@ class DataSetFilters(object):
 
 
     def extract_points(dataset, ind):
-        """Returns a subset of the grid (with cells) that contains the points
-        that contain any of the given point indices.
+        """Return a subset of the grid (with cells) that contains any of the given point indices.
 
         Parameters
         ----------
         ind : np.ndarray, list, or iterable
             Numpy array of point indices to be extracted.
 
-        Returns
-        -------
+        Return
+        ------
         subgrid : pyvista.UnstructuredGrid
             Subselected grid.
+
         """
         try:
             ind = np.array(ind)
@@ -1725,13 +1780,17 @@ class DataSetFilters(object):
 
 
     def extract_selection_points(dataset, ind):
+        """Return a subset of the grid (with cells) that contains any of the given point indices.
+
+        DEPRECATED: Please use ``extract_points`` instead.
+
+        """
         logging.warning("DEPRECATED: use ``extract_points`` instead.")
         return DataSetFilters.extract_points(dataset, ind)
 
 
     def extract_surface(dataset, pass_pointid=True, pass_cellid=True, inplace=False):
-        """
-        Extract surface mesh of the grid
+        """Extract surface mesh of the grid.
 
         Parameters
         ----------
@@ -1746,10 +1805,11 @@ class DataSetFilters(object):
         inplace : bool, optional
             Return new mesh or overwrite input.
 
-        Returns
-        -------
+        Return
+        ------
         extsurf : pyvista.PolyData
             Surface mesh of the grid
+
         """
         surf_filter = vtk.vtkDataSetSurfaceFilter()
         surf_filter.SetInputData(dataset)
@@ -1767,11 +1827,10 @@ class DataSetFilters(object):
 
 
     def surface_indices(dataset):
-        """
-        The surface indices of a grid.
+        """Return the surface indices of a grid.
 
-        Returns
-        -------
+        Return
+        ------
         surf_ind : np.ndarray
             Indices of the surface points.
 
@@ -1783,9 +1842,10 @@ class DataSetFilters(object):
     def extract_edges(dataset, feature_angle=30, boundary_edges=True,
                       non_manifold_edges=True, feature_edges=True,
                       manifold_edges=True, inplace=False):
-        """
-        Extracts edges from the surface of the mesh. If the given mesh is not
-        PolyData, the external surface of the given mesh is extracted and used.
+        """Extract edges from the surface of the mesh.
+        
+        If the given mesh is not PolyData, the external surface of the given
+        mesh is extracted and used.
         From vtk documentation, the edges are one of the following
 
             1) boundary (used by one polygon) or a line cell
@@ -1814,8 +1874,8 @@ class DataSetFilters(object):
         inplace : bool, optional
             Return new mesh or overwrite input.
 
-        Returns
-        -------
+        Return
+        ------
         edges : pyvista.vtkPolyData
             Extracted edges. None if inplace=True.
 
@@ -1841,9 +1901,9 @@ class DataSetFilters(object):
 
     def merge(dataset, grid=None, merge_points=True, inplace=False,
               main_has_priority=True):
-        """
-        Join one or many other grids to this grid.  Grid is updated
-        in-place by default.
+        """Join one or many other grids to this grid.
+
+        Grid is updated in-place by default.
 
         Can be used to merge points of adjcent cells when no grids
         are input.
@@ -1866,8 +1926,8 @@ class DataSetFilters(object):
             the scalar arrays of the merging grids will be overwritten
             by the original main mesh.
 
-        Returns
-        -------
+        Return
+        ------
         merged_grid : vtk.UnstructuredGrid
             Merged grid.  Returned when inplace is False.
 
@@ -1876,6 +1936,7 @@ class DataSetFilters(object):
         When two or more grids are joined, the type and name of each
         scalar array must match or the arrays will be ignored and not
         included in the final merged mesh.
+
         """
         append_filter = vtk.vtkAppendFilter()
         append_filter.SetMergePoints(merge_points)
@@ -1905,13 +1966,13 @@ class DataSetFilters(object):
 
 
     def __add__(dataset, grid):
-        """Combine this mesh with another into an
-        :class:`pyvista.UnstructuredGrid`"""
+        """Combine this mesh with another into an :class:`pyvista.UnstructuredGrid`."""
         return DataSetFilters.merge(dataset, grid)
 
 
     def compute_cell_quality(dataset, quality_measure='scaled_jacobian', null_value=-1.0):
-        """compute a function of (geometric) quality for each cell of a mesh.
+        """Compute a function of (geometric) quality for each cell of a mesh.
+
         The per-cell quality is added to the mesh's cell data, in an array
         named "CellQuality". Cell types not supported by this filter or
         undefined quality of supported cell types will have an entry of -1.
@@ -2009,8 +2070,7 @@ class DataSetFilters(object):
 
     def compute_gradient(dataset, scalars=None, gradient_name='gradient',
                          preference='point'):
-        """Computes per cell gradient of point scalar field or per point
-        gradient of cell scalar field.
+        """Compute per cell gradient of point/cell scalar field.
 
         Parameters
         ----------
@@ -2019,6 +2079,7 @@ class DataSetFilters(object):
 
         gradient_name : str, optional
             The name of the output array of the computed gradient.
+
         """
         alg = vtk.vtkGradientFilter()
         # Check if scalar array given
@@ -2036,19 +2097,22 @@ class DataSetFilters(object):
 
 
 class CompositeFilters(object):
-    """An internal class to manage filtes/algorithms for composite datasets.
-    """
+    """An internal class to manage filtes/algorithms for composite datasets."""
+
     def __new__(cls, *args, **kwargs):
+        """Allocate memory for the composite filters."""
         if cls is CompositeFilters:
             raise TypeError("pyvista.CompositeFilters is an abstract class and may not be instantiated.")
         return object.__new__(cls)
 
 
     def extract_geometry(composite):
-        """Combines the geomertry of all blocks into a single ``PolyData``
-        object. Place this filter at the end of a pipeline before a polydata
+        """Combine the geomertry of all blocks into a single ``PolyData`` object.
+
+        Place this filter at the end of a pipeline before a polydata
         consumer such as a polydata mapper to extract geometry from all blocks
         and append them to one polydata object.
+
         """
         gf = vtk.vtkCompositeDataGeometryFilter()
         gf.SetInputData(composite)
@@ -2057,7 +2121,7 @@ class CompositeFilters(object):
 
 
     def combine(composite, merge_points=False):
-        """Appends all blocks into a single unstructured grid.
+        """Append all blocks into a single unstructured grid.
 
         Parameters
         ----------
@@ -2113,8 +2177,7 @@ class CompositeFilters(object):
 
 
     def outline(composite, generate_faces=False, nested=False):
-        """Produces an outline of the full extent for the all blocks in this
-        composite dataset.
+        """Produce an outline of the full extent for the all blocks in this composite dataset.
 
         Parameters
         ----------
@@ -2123,6 +2186,7 @@ class CompositeFilters(object):
 
         nested : bool, optional
             If True, these creates individual outlines for each nested dataset
+
         """
         if nested:
             return DataSetFilters.outline(composite, generate_faces=generate_faces)
@@ -2131,8 +2195,7 @@ class CompositeFilters(object):
 
 
     def outline_corners(composite, factor=0.2, nested=False):
-        """Produces an outline of the corners for the all blocks in this
-        composite dataset.
+        """Produce an outline of the corners for the all blocks in this composite dataset.
 
         Parameters
         ----------
@@ -2142,6 +2205,7 @@ class CompositeFilters(object):
 
         ested : bool, optional
             If True, these creates individual outlines for each nested dataset
+
         """
         if nested:
             return DataSetFilters.outline_corners(composite, factor=factor)
@@ -2151,16 +2215,16 @@ class CompositeFilters(object):
 
 
 class PolyDataFilters(DataSetFilters):
+    """An internal class to manage filtes/algorithms for polydata datasets."""
 
     def __new__(cls, *args, **kwargs):
+        """Allocate memory for the polydata filters."""
         if cls is PolyDataFilters:
             raise TypeError("pyvista.PolyDataFilters is an abstract class and may not be instantiated.")
         return object.__new__(cls)
 
     def edge_mask(poly_data, angle):
-        """
-        Returns a mask of the points of a surface mesh that have a surface
-        angle greater than angle
+        """Return a mask of the points of a surface mesh that has a surface angle greater than angle.
 
         Parameters
         ----------
@@ -2187,8 +2251,7 @@ class PolyDataFilters(DataSetFilters):
 
 
     def boolean_cut(poly_data, cut, tolerance=1E-5, inplace=False):
-        """
-        Performs a Boolean cut using another mesh.
+        """Perform a Boolean cut using another mesh.
 
         Parameters
         ----------
@@ -2198,8 +2261,8 @@ class PolyDataFilters(DataSetFilters):
         inplace : bool, optional
             Updates mesh in-place while returning nothing.
 
-        Returns
-        -------
+        Return
+        ------
         mesh : pyvista.PolyData
             The cut mesh when inplace=False
 
@@ -2225,9 +2288,9 @@ class PolyDataFilters(DataSetFilters):
 
 
     def boolean_add(poly_data, mesh, inplace=False):
-        """
-        Add a mesh to the current mesh.  Does not attempt to "join"
-        the meshes.
+        """Add a mesh to the current mesh.
+
+        Does not attempt to "join" the meshes.
 
         Parameters
         ----------
@@ -2237,8 +2300,8 @@ class PolyDataFilters(DataSetFilters):
         inplace : bool, optional
             Updates mesh in-place while returning nothing.
 
-        Returns
-        -------
+        Return
+        ------
         joinedmesh : pyvista.PolyData
             Initial mesh and the new mesh when inplace=False.
 
@@ -2256,15 +2319,14 @@ class PolyDataFilters(DataSetFilters):
 
 
     def __add__(poly_data, mesh):
-        """Merge these two meshes"""
+        """Merge these two meshes."""
         if not isinstance(mesh, vtk.vtkPolyData):
             return DataSetFilters.__add__(poly_data, mesh)
         return PolyDataFilters.boolean_add(poly_data, mesh)
 
 
     def boolean_union(poly_data, mesh, inplace=False):
-        """
-        Combines two meshes and attempts to create a manifold mesh.
+        """Combine two meshes and attempts to create a manifold mesh.
 
         Parameters
         ----------
@@ -2274,8 +2336,8 @@ class PolyDataFilters(DataSetFilters):
         inplace : bool, optional
             Updates mesh in-place while returning nothing.
 
-        Returns
-        -------
+        Return
+        ------
         union : pyvista.PolyData
             The union mesh when inplace=False.
 
@@ -2295,9 +2357,7 @@ class PolyDataFilters(DataSetFilters):
 
 
     def boolean_difference(poly_data, mesh, inplace=False):
-        """
-        Combines two meshes and retains only the volume in common
-        between the meshes.
+        """Combine two meshes and retains only the volume in common between the meshes.
 
         Parameters
         ----------
@@ -2307,8 +2367,8 @@ class PolyDataFilters(DataSetFilters):
         inplace : bool, optional
             Updates mesh in-place while returning nothing.
 
-        Returns
-        -------
+        Return
+        ------
         union : pyvista.PolyData
             The union mesh when inplace=False.
 
@@ -2328,8 +2388,7 @@ class PolyDataFilters(DataSetFilters):
 
 
     def curvature(poly_data, curv_type='mean'):
-        """
-        Returns the pointwise curvature of a mesh
+        """Return the pointwise curvature of a mesh.
 
         Parameters
         ----------
@@ -2343,8 +2402,8 @@ class PolyDataFilters(DataSetFilters):
             Maximum
             Minimum
 
-        Returns
-        -------
+        Return
+        ------
         curvature : np.ndarray
             Curvature values
 
@@ -2373,8 +2432,7 @@ class PolyDataFilters(DataSetFilters):
 
 
     def plot_curvature(poly_data, curv_type='mean', **kwargs):
-        """
-        Plots curvature
+        """Plot the curvature.
 
         Parameters
         ----------
@@ -2389,27 +2447,28 @@ class PolyDataFilters(DataSetFilters):
         **kwargs : optional
             See :func:`pyvista.plot`
 
-        Returns
-        -------
+        Return
+        ------
         cpos : list
             List of camera position, focal point, and view up
+
         """
         return poly_data.plot(scalars=poly_data.curvature(curv_type),
                               stitle='%s\nCurvature' % curv_type, **kwargs)
 
 
     def triangulate(poly_data, inplace=False):
-        """
-        Returns an all triangle mesh.  More complex polygons will be broken
-        down into triangles.
+        """Return an all triangle mesh.
+
+        More complex polygons will be broken down into triangles.
 
         Parameters
         ----------
         inplace : bool, optional
             Updates mesh in-place while returning nothing.
 
-        Returns
-        -------
+        Return
+        ------
         mesh : pyvista.PolyData
             Mesh containing only triangles.  None when inplace=True
 
@@ -2428,7 +2487,11 @@ class PolyDataFilters(DataSetFilters):
 
 
     def tri_filter(poly_data, inplace=False):
-        """DEPRECATED: use ``.triangulate`` instead"""
+        """Return an all triangle mesh.
+
+        DEPRECATED: Please use ``triangulate`` instead.
+
+        """
         logging.warning("DEPRECATED: ``.tri_filter`` is deprecated. Use ``.triangulate`` instead.")
         return PolyDataFilters.triangulate(poly_data, inplace=inplace)
 
@@ -2437,6 +2500,7 @@ class PolyDataFilters(DataSetFilters):
                edge_angle=15, feature_angle=45,
                boundary_smoothing=True, feature_smoothing=False, inplace=False):
         """Adjust point coordinates using Laplacian smoothing.
+
         The effect is to "relax" the mesh, making the cells better shaped and
         the vertices more evenly distributed.
 
@@ -2469,8 +2533,8 @@ class PolyDataFilters(DataSetFilters):
         inplace : bool, optional
             Updates mesh in-place while returning nothing.
 
-        Returns
-        -------
+        Return
+        ------
         mesh : pyvista.PolyData
             Decimated mesh. None when inplace=True.
 
@@ -2495,9 +2559,10 @@ class PolyDataFilters(DataSetFilters):
 
     def decimate_pro(poly_data, reduction, feature_angle=45.0, split_angle=75.0, splitting=True,
                      pre_split_mesh=False, preserve_topology=False, inplace=False):
-        """Reduce the number of triangles in a triangular mesh, forming a good
-        approximation to the original geometry. Based on the algorithm originally
-        described in "Decimation of Triangle Meshes", Proc Siggraph 92.
+        """Reduce the number of triangles in a triangular mesh.
+
+        It forms a good approximation to the original geometry. Based on the algorithm
+        originally described in "Decimation of Triangle Meshes", Proc Siggraph 92.
 
         Parameters
         ----------
@@ -2532,13 +2597,12 @@ class PolyDataFilters(DataSetFilters):
         inplace : bool, optional
             Updates mesh in-place while returning nothing.
 
-        Returns
-        -------
+        Return
+        ------
         mesh : pyvista.PolyData
             Decimated mesh. None when inplace=True.
 
         """
-
         alg = vtk.vtkDecimatePro()
         alg.SetInputData(poly_data)
         alg.SetTargetReduction(reduction)
@@ -2558,8 +2622,9 @@ class PolyDataFilters(DataSetFilters):
 
     def tube(poly_data, radius=None, scalars=None, capping=True, n_sides=20,
              radius_factor=10, preference='point', inplace=False):
-        """Generate a tube around each input line. The radius of the tube can be
-        set to linearly vary with a scalar value.
+        """Generate a tube around each input line.
+
+        The radius of the tube can be set to linearly vary with a scalar value.
 
         Parameters
         ----------
@@ -2584,8 +2649,8 @@ class PolyDataFilters(DataSetFilters):
         inplace : bool, optional
             Updates mesh in-place while returning nothing.
 
-        Returns
-        -------
+        Return
+        ------
         mesh : pyvista.PolyData
             Tube-filtered mesh. None when inplace=True.
 
@@ -2621,9 +2686,7 @@ class PolyDataFilters(DataSetFilters):
 
 
     def subdivide(poly_data, nsub, subfilter='linear', inplace=False):
-        """
-        Increase the number of triangles in a single, connected triangular
-        mesh.
+        """Increase the number of triangles in a single, connected triangular mesh.
 
         Uses one of the following vtk subdivision filters to subdivide a mesh.
         vtkButterflySubdivisionFilter
@@ -2653,8 +2716,8 @@ class PolyDataFilters(DataSetFilters):
         inplace : bool, optional
             Updates mesh in-place while returning nothing.
 
-        Returns
-        -------
+        Return
+        ------
         mesh : Polydata object
             pyvista polydata object.  None when inplace=True
 
@@ -2668,6 +2731,7 @@ class PolyDataFilters(DataSetFilters):
         alternatively, update mesh in-place
 
         >>> mesh.subdivide(1, 'loop', inplace=True) # doctest:+SKIP
+
         """
         subfilter = subfilter.lower()
         if subfilter == 'linear':
@@ -2697,9 +2761,7 @@ class PolyDataFilters(DataSetFilters):
                  normals=False, tcoords=True, tensors=True, scalars_weight=0.1,
                  vectors_weight=0.1, normals_weight=0.1, tcoords_weight=0.1,
                  tensors_weight=0.1, inplace=False):
-        """
-        Reduces the number of triangles in a triangular mesh using
-        vtkQuadricDecimation.
+        """Reduce the number of triangles in a triangular mesh using vtkQuadricDecimation.
 
         Parameters
         ----------
@@ -2761,8 +2823,8 @@ class PolyDataFilters(DataSetFilters):
         inplace : bool, optional
             Updates mesh in-place while returning nothing.
 
-        Returns
-        -------
+        Return
+        ------
         outmesh : pyvista.PolyData
             Decimated mesh.  None when inplace=True.
 
@@ -2800,8 +2862,7 @@ class PolyDataFilters(DataSetFilters):
                         auto_orient_normals=False,
                         non_manifold_traversal=True,
                         feature_angle=30.0, inplace=False):
-        """
-        Compute point and/or cell normals for a mesh.
+        """Compute point and/or cell normals for a mesh.
 
         The filter can reorder polygons to insure consistent orientation across
         polygon neighbors. Sharp edges can be split and points duplicated
@@ -2856,8 +2917,8 @@ class PolyDataFilters(DataSetFilters):
         inplace : bool, optional
             Updates mesh in-place while returning nothing. Defaults to False.
 
-        Returns
-        -------
+        Return
+        ------
         mesh : pyvista.PolyData
             Updated mesh with cell and point normals if inplace=False
 
@@ -2947,9 +3008,10 @@ class PolyDataFilters(DataSetFilters):
     def clean(poly_data, point_merging=True, tolerance=None, lines_to_points=True,
               polys_to_lines=True, strips_to_polys=True, inplace=False,
               absolute=True, **kwargs):
-        """
-        Cleans mesh by merging duplicate points, remove unused
-        points, and/or remove degenerate cells.
+        """Clean the mesh.
+
+        This merges duplicate points, removes unused points, and/or removes
+        degenerate cells.
 
         Parameters
         ----------
@@ -2979,10 +3041,11 @@ class PolyDataFilters(DataSetFilters):
         absolute : bool, optional
             Control if ``tolerance`` is an absolute distance or a fraction.
 
-        Returns
-        -------
+        Return
+        ------
         mesh : pyvista.PolyData
             Cleaned mesh.  None when inplace=True
+
         """
         if tolerance is None:
             tolerance = kwargs.pop('merge_tol', None)
@@ -3014,9 +3077,7 @@ class PolyDataFilters(DataSetFilters):
 
 
     def geodesic(poly_data, start_vertex, end_vertex, inplace=False):
-        """
-        Calculates the geodesic path between two vertices using Dijkstra's
-        algorithm.
+        """Calculate the geodesic path between two vertices using Dijkstra's algorithm.
 
         Parameters
         ----------
@@ -3026,8 +3087,8 @@ class PolyDataFilters(DataSetFilters):
         end_vertex : int
             Vertex index indicating the end point of the geodesic segment.
 
-        Returns
-        -------
+        Return
+        ------
         output : pyvista.PolyData
             PolyData object consisting of the line segment between the two given
             vertices.
@@ -3054,9 +3115,7 @@ class PolyDataFilters(DataSetFilters):
 
 
     def geodesic_distance(poly_data, start_vertex, end_vertex):
-        """
-        Calculates the geodesic distance between two vertices using Dijkstra's
-        algorithm.
+        """Calculate the geodesic distance between two vertices using Dijkstra's algorithm.
 
         Parameters
         ----------
@@ -3066,8 +3125,8 @@ class PolyDataFilters(DataSetFilters):
         end_vertex : int
             Vertex index indicating the end point of the geodesic segment.
 
-        Returns
-        -------
+        Return
+        ------
         length : float
             Length of the geodesic segment.
 
@@ -3081,9 +3140,10 @@ class PolyDataFilters(DataSetFilters):
 
     def ray_trace(poly_data, origin, end_point, first_point=False, plot=False,
                   off_screen=False):
-        """
-        Performs a single ray trace calculation given a mesh and a line segment
-        defined by an origin and end_point.
+        """Perform a single ray trace calculation.
+
+        This requires a mesh and a line segment defined by an origin
+        and end_point.
 
         Parameters
         ----------
@@ -3102,8 +3162,8 @@ class PolyDataFilters(DataSetFilters):
         off_screen : bool, optional
             Plots off screen.  Used for unit testing.
 
-        Returns
-        -------
+        Return
+        ------
         intersection_points : np.ndarray
             Location of the intersection points.  Empty array if no
             intersections.
@@ -3148,7 +3208,7 @@ class PolyDataFilters(DataSetFilters):
 
 
     def plot_boundaries(poly_data, edge_color="red", **kwargs):
-        """ Plots boundaries of a mesh
+        """Plot boundaries of a mesh.
 
         Parameters
         ----------
@@ -3172,9 +3232,7 @@ class PolyDataFilters(DataSetFilters):
 
     def plot_normals(poly_data, show_mesh=True, mag=1.0, flip=False,
                      use_every=1, **kwargs):
-        """
-        Plot the point normals of a mesh.
-        """
+        """Plot the point normals of a mesh."""
         plotter = pyvista.Plotter(off_screen=kwargs.pop('off_screen', False),
                                   notebook=kwargs.pop('notebook', None))
         if show_mesh:
@@ -3189,9 +3247,9 @@ class PolyDataFilters(DataSetFilters):
 
 
     def remove_points(poly_data, remove, mode='any', keep_scalars=True, inplace=False):
-        """
-        Rebuild a mesh by removing points.  Only valid for
-        all-triangle meshes.
+        """Rebuild a mesh by removing points.
+        
+        Only valid for all-triangle meshes.
 
         Parameters
         ----------
@@ -3210,8 +3268,8 @@ class PolyDataFilters(DataSetFilters):
         inplace : bool, optional
             Updates mesh in-place while returning nothing.
 
-        Returns
-        -------
+        Return
+        ------
         mesh : pyvista.PolyData
             Mesh without the points flagged for removal.  Not returned
             when inplace=False.
@@ -3274,10 +3332,7 @@ class PolyDataFilters(DataSetFilters):
 
 
     def flip_normals(poly_data):
-        """
-        Flip normals of a triangular mesh by reversing the point ordering.
-
-        """
+        """Flip normals of a triangular mesh by reversing the point ordering."""
         if poly_data.faces.size % 4:
             raise Exception('Can only flip normals on an all triangular mesh')
 
@@ -3286,7 +3341,7 @@ class PolyDataFilters(DataSetFilters):
 
 
     def delaunay_2d(poly_data, tol=1e-05, alpha=0.0, offset=1.0, bound=False, inplace=False):
-        """Apply a delaunay 2D filter along the best fitting plane"""
+        """Apply a delaunay 2D filter along the best fitting plane."""
         alg = vtk.vtkDelaunay2D()
         alg.SetProjectionPlaneMode(vtk.VTK_BEST_FITTING_PLANE)
         alg.SetInputDataObject(poly_data)
@@ -3304,16 +3359,22 @@ class PolyDataFilters(DataSetFilters):
 
 
     def delauney_2d(poly_data):
-        """DEPRECATED. Please see :func:`pyvista.PolyData.delaunay_2d`"""
+        """Apply a delaunay 2D filter along the best fitting plane.
+
+        DEPRECATED. Please see :func:`pyvista.PolyData.delaunay_2d`.
+
+        """
         raise AttributeError('`delauney_2d` is deprecated because we made a '
                              'spelling mistake. Please use `delaunay_2d`.')
 
 
     def compute_arc_length(poly_data):
-        """Computes the arc length over the length of the probed line.
+        """Compute the arc length over the length of the probed line.
+
         It adds a new point-data array named "arc_length" with the computed arc
         length for each of the polylines in the input. For all other cell types,
         the arc length is set to 0.
+
         """
         alg = vtk.vtkAppendArcLength()
         alg.SetInputData(poly_data)
@@ -3322,7 +3383,7 @@ class PolyDataFilters(DataSetFilters):
 
 
     def project_points_to_plane(poly_data, origin=None, normal=(0,0,1), inplace=False):
-        """Project points of this mesh to a plane"""
+        """Project points of this mesh to a plane."""
         if not isinstance(normal, collections.Iterable) or len(normal) != 3:
             raise TypeError('Normal must be a length three vector')
         if origin is None:
@@ -3376,6 +3437,7 @@ class PolyDataFilters(DataSetFilters):
             If True, generate texture coordinates along the ribbon. This can
             also be specified to generate the texture coordinates in the
             following ways: ``'length'``, ``'normalized'``,
+
         """
         if scalars is not None:
             arr, field = get_array(poly_data, scalars, preference=preference, info=True)
@@ -3410,15 +3472,19 @@ class PolyDataFilters(DataSetFilters):
 
 
 class UnstructuredGridFilters(DataSetFilters):
+    """An internal class to manage filtes/algorithms for unstructured grid datasets."""
 
     def __new__(cls, *args, **kwargs):
+        """Allocate memory for the unstructured grid."""
         if cls is UnstructuredGridFilters:
             raise TypeError("pyvista.UnstructuredGridFilters is an abstract class and may not be instantiated.")
         return object.__new__(cls)
 
     def delaunay_2d(ugrid, tol=1e-05, alpha=0.0, offset=1.0, bound=False):
-        """Apply a delaunay 2D filter along the best fitting plane. This
-        extracts the grid's points and performs the triangulation on those alone.
+        """Apply a delaunay 2D filter along the best fitting plane.
+
+        This extracts the grid's points and performs the triangulation on those alone.
+
         """
         return pyvista.PolyData(ugrid.points).delaunay_2d(tol=tol, alpha=alpha,
                                                           offset=offset,
@@ -3426,15 +3492,17 @@ class UnstructuredGridFilters(DataSetFilters):
 
 
 class UniformGridFilters(DataSetFilters):
+    """An internal class to manage filtes/algorithms for uniform grid datasets."""
 
     def __new__(cls, *args, **kwargs):
+        """Allocate memory for the uniform grid."""
         if cls is UniformGridFilters:
             raise TypeError("pyvista.UniformGridFilters is an abstract class and may not be instantiated.")
         return object.__new__(cls)
 
     def gaussian_smooth(dataset, radius_factor=1.5, std_dev=2.,
                         scalars=None, preference='points'):
-        """Smooths the data with a Gaussian kernel
+        """Smooth the data with a Gaussian kernel.
 
         Parameters
         ----------
@@ -3450,6 +3518,7 @@ class UniformGridFilters(DataSetFilters):
         preference : str, optional
             When scalars is specified, this is the preferred scalar type to
             search for in the dataset.  Must be either ``'point'`` or ``'cell'``
+
         """
         alg = vtk.vtkImageGaussianSmooth()
         alg.SetInputDataObject(dataset)

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -1,6 +1,5 @@
-"""
-Sub-classes for vtk.vtkRectilinearGrid and vtk.vtkImageData
-"""
+"""Sub-classes for vtk.vtkRectilinearGrid and vtk.vtkImageData."""
+
 import logging
 import os
 
@@ -19,40 +18,44 @@ log.setLevel('CRITICAL')
 
 
 class Grid(Common):
-    """A class full of common methods for non-pointset grids """
+    """A class full of common methods for non-pointset grids."""
 
     def __new__(cls, *args, **kwargs):
+        """Allocate a grid."""
         if cls is Grid:
             raise TypeError("pyvista.Grid is an abstract class and may not be instantiated.")
         return object.__new__(cls, *args, **kwargs)
 
     def __init__(self, *args, **kwargs):
+        """Initialize the grid."""
         super(Grid, self).__init__()
 
     @property
     def dimensions(self):
-        """Returns a length 3 tuple of the grid's dimensions - these are
-        effectively the number of nodes along each of the three dataset axes
+        """Return a length 3 tuple of the grid's dimensions.
+
+        These are effectively the number of nodes along each of the three dataset axes.
+
         """
         return list(self.GetDimensions())
 
     @dimensions.setter
     def dimensions(self, dims):
-        """Sets the dataset dimensions. Pass a length three tuple of integers"""
+        """Set the dataset dimensions. Pass a length three tuple of integers."""
         nx, ny, nz = dims[0], dims[1], dims[2]
         self.SetDimensions(nx, ny, nz)
         self.Modified()
 
     def _get_attrs(self):
-        """An internal helper for the representation methods"""
+        """Return the representation methods (internal helper)."""
         attrs = Common._get_attrs(self)
         attrs.append(("Dimensions", self.dimensions, "{:d}, {:d}, {:d}"))
         return attrs
 
 
 class RectilinearGrid(vtkRectilinearGrid, Grid):
-    """
-    Extends the functionality of a vtk.vtkRectilinearGrid object
+    """Extend the functionality of a vtk.vtkRectilinearGrid object.
+
     Can be initialized in several ways:
 
     - Create empty grid
@@ -85,6 +88,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the rectilinear grid."""
         super(RectilinearGrid, self).__init__()
 
         if len(args) == 1:
@@ -109,19 +113,21 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
 
 
     def __repr__(self):
+        """Return the default representation."""
         return Common.__repr__(self)
 
 
     def __str__(self):
+        """Return the str representation."""
         return Common.__str__(self)
 
 
     def _from_arrays(self, x, y, z):
-        """
-        Create VTK rectilinear grid directly from numpy arrays. Each array
-        gives the uniques coordinates of the mesh along each axial direction.
-        To help ensure you are using this correctly, we take the unique values
-        of each argument.
+        """Create VTK rectilinear grid directly from numpy arrays.
+
+        Each array gives the uniques coordinates of the mesh along each axial
+        direction. To help ensure you are using this correctly, we take the unique
+        values of each argument.
 
         Parameters
         ----------
@@ -133,6 +139,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
 
         z : np.ndarray
             Coordinates of the nodes in z direction.
+
         """
         x = np.unique(x.ravel())
         y = np.unique(y.ravel())
@@ -146,7 +153,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
 
     @property
     def points(self):
-        """ returns a pointer to the points as a numpy object """
+        """Return a pointer to the points as a numpy object."""
         x = vtk_to_numpy(self.GetXCoordinates())
         y = vtk_to_numpy(self.GetYCoordinates())
         z = vtk_to_numpy(self.GetZCoordinates())
@@ -155,7 +162,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
 
     @points.setter
     def points(self, points):
-        """ set points without copying """
+        """Set points without copying."""
         if not isinstance(points, np.ndarray):
             raise TypeError('Points must be a numpy array')
         # get the unique coordinates along each axial direction
@@ -209,8 +216,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
         self.shallow_copy(grid)
 
     def save(self, filename, binary=True):
-        """
-        Writes a rectilinear grid to disk.
+        """Write a rectilinear grid to disk.
 
         Parameters
         ----------
@@ -250,35 +256,35 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
 
     @property
     def x(self):
-        """Get the coordinates along the X-direction"""
+        """Get the coordinates along the X-direction."""
         return vtk_to_numpy(self.GetXCoordinates())
 
     @x.setter
     def x(self, coords):
-        """Set the coordinates along the X-direction"""
+        """Set the coordinates along the X-direction."""
         self.SetXCoordinates(numpy_to_vtk(coords))
         self.Modified()
 
     @property
     def y(self):
-        """Get the coordinates along the Y-direction"""
+        """Get the coordinates along the Y-direction."""
         return vtk_to_numpy(self.GetYCoordinates())
 
     @y.setter
     def y(self, coords):
-        """Set the coordinates along the Y-direction"""
+        """Set the coordinates along the Y-direction."""
         self.SetYCoordinates(numpy_to_vtk(coords))
         self.Modified()
 
     @property
     def z(self):
-        """Get the coordinates along the Z-direction"""
+        """Get the coordinates along the Z-direction."""
         return vtk_to_numpy(self.GetZCoordinates())
 
 
     @z.setter
     def z(self, coords):
-        """Set the coordinates along the Z-direction"""
+        """Set the coordinates along the Z-direction."""
         self.SetZCoordinates(numpy_to_vtk(coords))
         self.Modified()
 
@@ -305,8 +311,8 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
 
 
 class UniformGrid(vtkImageData, Grid, UniformGridFilters):
-    """
-    Extends the functionality of a vtk.vtkImageData object
+    """Extend the functionality of a vtk.vtkImageData object.
+
     Can be initialized in several ways:
 
     - Create empty grid
@@ -344,6 +350,7 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the uniform grid."""
         super(UniformGrid, self).__init__()
 
         if len(args) == 1:
@@ -370,19 +377,21 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
                 self._from_specs(args[0], args[1])
 
     def __repr__(self):
+        """Return the default representation."""
         return Common.__repr__(self)
 
 
     def __str__(self):
+        """Return the default str representation."""
         return Common.__str__(self)
 
 
     def _from_specs(self, dims, spacing=(1.0,1.0,1.0), origin=(0.0, 0.0, 0.0)):
-        """
-        Create VTK image data directly from numpy arrays. A uniform grid is
-        defined by the node spacings for each axis (uniform along each
-        individual axis) and the number of nodes on each axis. These are
-        relative to a specified origin (default is ``(0.0, 0.0, 0.0)``).
+        """Create VTK image data directly from numpy arrays.
+
+        A uniform grid is defined by the node spacings for each axis
+        (uniform along each individual axis) and the number of nodes on each axis.
+        These are relative to a specified origin (default is ``(0.0, 0.0, 0.0)``).
 
         Parameters
         ----------
@@ -394,6 +403,7 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
 
         origin : tuple(float)
             Length 3 tuple of floats/ints specifying minimum value for each axis
+
         """
         xn, yn, zn = dims[0], dims[1], dims[2]
         xs, ys, zs = spacing[0], spacing[1], spacing[2]
@@ -405,7 +415,7 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
 
     @property
     def points(self):
-        """ returns a pointer to the points as a numpy object """
+        """Return a pointer to the points as a numpy object."""
         # Get grid dimensions
         nx, ny, nz = self.dimensions
         nx -= 1
@@ -423,7 +433,7 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
 
     @points.setter
     def points(self, points):
-        """ set points without copying """
+        """Set points without copying."""
         if not isinstance(points, np.ndarray):
             raise TypeError('Points must be a numpy array')
         # get the unique coordinates along each axial direction
@@ -481,8 +491,7 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
         self.shallow_copy(grid)
 
     def save(self, filename, binary=True):
-        """
-        Writes image data grid to disk.
+        """Write image data grid to disk.
 
         Parameters
         ----------
@@ -522,27 +531,27 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
 
     @property
     def x(self):
-        """ all the X points """
+        """Return all the X points."""
         return self.points[:, 0]
 
     @property
     def y(self):
-        """ all the Y points """
+        """Return all the Y points."""
         return self.points[:, 1]
 
     @property
     def z(self):
-        """ all the Z points """
+        """Return all the Z points."""
         return self.points[:, 2]
 
     @property
     def origin(self):
-        """Origin of the grid (bottom southwest corner)"""
+        """Return the origin of the grid (bottom southwest corner)."""
         return list(self.GetOrigin())
 
     @origin.setter
     def origin(self, origin):
-        """Set the origin. Pass a length three tuple of floats"""
+        """Set the origin. Pass a length three tuple of floats."""
         ox, oy, oz = origin[0], origin[1], origin[2]
         self.SetOrigin(ox, oy, oz)
         self.Modified()
@@ -554,15 +563,18 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
 
     @spacing.setter
     def spacing(self, spacing):
-        """Set the spacing in each axial direction. Pass a length three tuple of
-        floats"""
+        """Set the spacing in each axial direction.
+
+        Pass a length three tuple of floats.
+
+        """
         dx, dy, dz = spacing[0], spacing[1], spacing[2]
         self.SetSpacing(dx, dy, dz)
         self.Modified()
 
 
     def _get_attrs(self):
-        """An internal helper for the representation methods"""
+        """Return the representation methods (internal helper)."""
         attrs = Grid._get_attrs(self)
         fmt = "{}, {}, {}".format(*[pyvista.FLOAT_FORMAT]*3)
         attrs.append(("Spacing", self.spacing, fmt))
@@ -570,7 +582,7 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
 
 
     def cast_to_structured_grid(self):
-        """Cast this uniform grid to a :class:`pyvista.StructuredGrid`"""
+        """Cast this uniform grid to a :class:`pyvista.StructuredGrid`."""
         alg = vtk.vtkImageToStructuredGrid()
         alg.SetInputData(self)
         alg.Update()
@@ -578,7 +590,7 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
 
 
     def cast_to_rectilinear_grid(self):
-        """Cast this uniform grid to a :class:`pyvista.RectilinearGrid`"""
+        """Cast this uniform grid to a :class:`pyvista.RectilinearGrid`."""
         def gen_coords(i):
             coords = np.cumsum(np.insert(np.full(self.dimensions[i] - 1,
                                                  self.spacing[i]), 0, 0)

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -1,6 +1,9 @@
-"""This module provides wrappers for vtkDataObjects: data onjects without any
-sort of spatial reference.
+"""This module provides wrappers for vtkDataObjects.
+
+The data objects does not have any sort of spatial reference.
+
 """
+
 import numpy as np
 import vtk
 
@@ -22,9 +25,10 @@ except ImportError:
 
 
 class Table(vtk.vtkTable, DataObject):
-    """Wrapper for the ``vtkTable`` class. Create by passing a 2D NumPy array
-    of shape (``n_rows`` by ``n_columns``) or from a dictionary containing
-    NumPy arrays.
+    """Wrapper for the ``vtkTable`` class.
+
+    Create by passing a 2D NumPy array of shape (``n_rows`` by ``n_columns``) 
+    or from a dictionary containing NumPy arrays.
 
     Example
     -------
@@ -34,8 +38,9 @@ class Table(vtk.vtkTable, DataObject):
     >>> table = pv.Table(arrays)
 
     """
-    def __init__(self, *args, **kwargs):
 
+    def __init__(self, *args, **kwargs):
+        """Initialize the table."""
         if len(args) == 1:
             if isinstance(args[0], vtk.vtkTable):
                 deep = kwargs.get('deep', True)
@@ -82,35 +87,42 @@ class Table(vtk.vtkTable, DataObject):
 
     @property
     def n_rows(self):
+        """Return the number of rows."""
         return self.GetNumberOfRows()
 
 
     @n_rows.setter
     def n_rows(self, n):
+        """Set the number of rows."""
         self.SetNumberOfRows(n)
 
 
     @property
     def n_columns(self):
+        """Return the number of columns."""
         return self.GetNumberOfColumns()
 
 
     @property
     def n_arrays(self):
+        """Return the number of columns.
+
+        Alias for: ``n_columns``.
+
+        """
         return self.n_columns
 
 
     def _row_array(self, name=None):
-        """
-        Returns row scalars of a vtk object
+        """Return row scalars of a vtk object.
 
         Parameters
         ----------
         name : str
             Name of row scalars to retrieve.
 
-        Returns
-        -------
+        Return
+        ------
         scalars : np.ndarray
             Numpy array of scalars
 
@@ -138,7 +150,7 @@ class Table(vtk.vtkTable, DataObject):
 
     @property
     def row_arrays(self):
-        """ Returns the all row arrays """
+        """Return the all row arrays."""
         pdata = self.GetRowData()
         narr = pdata.GetNumberOfArrays()
 
@@ -164,29 +176,32 @@ class Table(vtk.vtkTable, DataObject):
 
 
     def keys(self):
+        """Return the table keys."""
         return list(self.row_arrays.keys())
 
 
     def items(self):
+        """Return the table items."""
         return self.row_arrays.items()
 
 
     def values(self):
+        """Return the table values."""
         return self.row_arrays.values()
 
 
     def update(self, data):
+        """Set the table data."""
         self.row_arrays.update(data)
 
 
     def pop(self, name):
-        """Pops off an array by the specified name"""
+        """Pops off an array by the specified name."""
         return self.row_arrays.pop(name)
 
 
     def _add_row_array(self, scalars, name, deep=True):
-        """
-        Adds scalars to the vtk object.
+        """Add scalars to the vtk object.
 
         Parameters
         ----------
@@ -226,7 +241,7 @@ class Table(vtk.vtkTable, DataObject):
 
 
     def __getitem__(self, index):
-        """ Searches row data for an array """
+        """Search row data for an array."""
         if isinstance(index, str):
             name = index
         elif isinstance(index, int):
@@ -241,12 +256,12 @@ class Table(vtk.vtkTable, DataObject):
 
 
     def get(self, index):
-        """Get an array by its name"""
+        """Get an array by its name."""
         return self[index]
 
 
     def __setitem__(self, name, scalars):
-        """Add/set an array in the row_arrays"""
+        """Add/set an array in the row_arrays."""
         if scalars is None:
             raise TypeError('Empty array unable to be added')
         if not isinstance(scalars, np.ndarray):
@@ -255,7 +270,7 @@ class Table(vtk.vtkTable, DataObject):
 
 
     def _remove_array(self, field, key):
-        """internal helper to remove a single array by name from each field"""
+        """Remove a single array by name from each field (internal helper)."""
         field = parse_field_choice(field)
         if field == ROW_DATA_FIELD:
             self.GetRowData().RemoveArray(key)
@@ -265,18 +280,18 @@ class Table(vtk.vtkTable, DataObject):
 
 
     def __delitem__(self, name):
-        """Removes an array by the specified name"""
+        """Remove an array by the specified name."""
         del self.row_arrays[name]
 
 
     def __iter__(self):
-        """The iterator across all arrays"""
+        """Return the iterator across all arrays."""
         self._iter_n = 0
         return self
 
 
     def next(self):
-        """Get the next block from the iterator"""
+        """Get the next block from the iterator."""
         if self._iter_n < self.n_arrays:
             result = self[self._iter_n]
             self._iter_n += 1
@@ -289,15 +304,18 @@ class Table(vtk.vtkTable, DataObject):
 
 
     def _get_attrs(self):
-        """An internal helper for the representation methods"""
+        """Return the representation methods."""
         attrs = []
         attrs.append(("N Rows", self.n_rows, "{}"))
         return attrs
 
 
     def _repr_html_(self):
-        """A pretty representation for Jupyter notebooks that includes header
-        details and information about all scalar arrays"""
+        """Return a pretty representation for Jupyter notebooks.
+
+        It includes header details and information about all scalar arrays.
+
+        """
         fmt = ""
         if self.n_arrays > 0:
             fmt += "<table>"
@@ -316,7 +334,7 @@ class Table(vtk.vtkTable, DataObject):
             row = "<tr>" + "".join(["<td>{}</td>" for i in range(len(titles))]) + "</tr>\n"
 
             def format_array(key):
-                """internal helper to format array information for printing"""
+                """Format array information for printing (internal helper)."""
                 arr = row_array(self, key)
                 dl, dh = self.get_data_range(key)
                 dl = pyvista.FLOAT_FORMAT.format(dl)
@@ -338,17 +356,17 @@ class Table(vtk.vtkTable, DataObject):
 
 
     def __repr__(self):
-        """Object representation"""
+        """Return the object representation."""
         return self.head(display=False, html=False)
 
 
     def __str__(self):
-        """Object string representation"""
+        """Return the object string representation."""
         return self.head(display=False, html=False)
 
 
     def to_pandas(self):
-        """Create a Pandas DataFrame from this Table"""
+        """Create a Pandas DataFrame from this Table."""
         if pd is None:
             raise ImportError('You must have Pandas installed.')
         data_frame = pd.DataFrame()
@@ -358,12 +376,13 @@ class Table(vtk.vtkTable, DataObject):
 
 
     def save(self, *args, **kwargs):
+        """Save the table."""
         raise NotImplementedError("Please use the `to_pandas` method and "
                                   "harness Pandas' wonderful file IO methods.")
 
 
     def get_data_range(self, arr=None, preference='row'):
-        """Get the non-NaN min and max of a named scalar array
+        """Get the non-NaN min and max of a named scalar array.
 
         Parameters
         ----------
@@ -391,25 +410,26 @@ class Table(vtk.vtkTable, DataObject):
 
 
 class RowScalarsDict(_ScalarsDict):
-    """
-    Updates internal row data when an array is added or removed from
-    the dictionary.
-    """
+    """Update internal row data when an array is added or removed from the dictionary."""
 
     def __init__(self, data):
+        """Initialize te row scalars dict."""
         _ScalarsDict.__init__(self, data)
         self.remover = lambda key: self.data._remove_array(ROW_DATA_FIELD, key)
         self.modifier = lambda *args: self.data.GetRowData().Modified()
 
 
     def adder(self, scalars, name, set_active=False, deep=True):
+        """Add a row array."""
         self.data._add_row_array(scalars, name, deep=deep)
 
 
 
 class Texture(vtk.vtkTexture):
-    """A helper class for vtkTextures"""
+    """A helper class for vtkTextures."""
+
     def __init__(self, *args, **kwargs):
+        """Initialize the texture."""
         assert_empty_kwargs(**kwargs)
 
         if len(args) == 1:
@@ -445,8 +465,7 @@ class Texture(vtk.vtkTexture):
 
 
     def flip(self, axis):
-        """Flip this texture inplace along the specified axis. 0 for X and
-        1 for Y."""
+        """Flip this texture inplace along the specified axis. 0 for X and 1 for Y."""
         if axis < 0 or axis > 1:
             raise RuntimeError("Axis {} out of bounds".format(axis))
         ax = [1, 0]
@@ -456,22 +475,25 @@ class Texture(vtk.vtkTexture):
 
 
     def to_image(self):
+        """Return the texture as an image."""
         return self.GetInput()
 
 
     def to_array(self):
+        """Return the texture as an array."""
         image = self.to_image()
         shape = (image.dimensions[0], image.dimensions[1], 3)
         return np.flip(image.active_scalar.reshape(shape, order='F'), axis=1).swapaxes(1,0)
 
 
     def plot(self, *args, **kwargs):
-        """Plot the texture as image data by itself"""
+        """Plot the texture as image data by itself."""
         return self.to_image().plot(*args, **kwargs)
 
 
     @property
     def repeat(self):
+        """Repeat the texture."""
         return self.GetRepeat()
 
     @repeat.setter

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1,6 +1,4 @@
-"""
-Sub-classes for vtk.vtkPolyData
-"""
+"""Sub-classes for vtk.vtkPolyData."""
 import logging
 import os
 
@@ -25,14 +23,13 @@ log.setLevel('CRITICAL')
 
 
 class PointSet(Common):
-    """PyVista's equivalent of vtk.vtkPointSet. This holds methods common to
-    PolyData and UnstructuredGrid.
+    """PyVista's equivalent of vtk.vtkPointSet.
+    
+    This holds methods common to PolyData and UnstructuredGrid.
     """
 
-
     def center_of_mass(self, scalars_weight=False):
-        """
-        Returns the coordinates for the center of mass of the mesh.
+        """Return the coordinates for the center of mass of the mesh.
 
         Parameters
         ----------
@@ -53,6 +50,7 @@ class PointSet(Common):
 
 
     def shallow_copy(self, to_copy):
+        """Do a shallow copy the pointset."""
         # Set default points if needed
         if not to_copy.GetPoints():
             to_copy.SetPoints(vtk.vtkPoints())
@@ -60,8 +58,7 @@ class PointSet(Common):
 
 
 class PolyData(vtkPolyData, PointSet, PolyDataFilters):
-    """
-    Extends the functionality of a vtk.vtkPolyData object
+    """Extend the functionality of a vtk.vtkPolyData object.
 
     Can be initialized in several ways:
 
@@ -94,9 +91,11 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
 
     >>>  # initialize from a filename
     >>> surf = pyvista.PolyData(examples.antfile)
+
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the polydata."""
         super(PolyData, self).__init__()
 
         deep = kwargs.pop('deep', False)
@@ -136,9 +135,11 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
             self.faces = self._make_vertice_cells(self.n_points)
 
     def __repr__(self):
+        """Return the standard representation."""
         return Common.__repr__(self)
 
     def __str__(self):
+        """Return the standard str representation."""
         return Common.__str__(self)
 
     @staticmethod
@@ -198,10 +199,12 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
 
     @property
     def lines(self):
+        """Return a pointer to the lines as a numpy object."""
         return vtk_to_numpy(self.GetLines().GetData())
 
     @lines.setter
     def lines(self, lines):
+        """Set the lines of the polydata."""
         if lines.dtype != pyvista.ID_TYPE:
             lines = lines.astype(pyvista.ID_TYPE)
 
@@ -222,12 +225,12 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
 
     @property
     def faces(self):
-        """ returns a pointer to the points as a numpy object """
+        """Return a pointer to the points as a numpy object."""
         return vtk_to_numpy(self.GetPolys().GetData())
 
     @faces.setter
     def faces(self, faces):
-        """ set faces without copying """
+        """Set faces without copying."""
         if faces.dtype != pyvista.ID_TYPE:
             faces = faces.astype(pyvista.ID_TYPE)
 
@@ -259,11 +262,11 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
 
 
     def is_all_triangles(self):
+        """Return True if all the faces of the polydata are triangles."""
         return self.faces.size % 4 == 0 and (self.faces.reshape(-1, 4)[:, 0] == 3).all()
 
     def _from_arrays(self, vertices, faces, deep=True, verts=False):
-        """
-        Set polygons and points from numpy arrays
+        """Set polygons and points from numpy arrays.
 
         Parameters
         ----------
@@ -319,23 +322,26 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
             self.faces = faces
 
     def __sub__(self, cutting_mesh):
-        """ subtract two meshes """
+        """Subtract two meshes."""
         return self.boolean_cut(cutting_mesh)
 
     @property
     def n_faces(self):
-        """alias for ``n_cells``"""
+        """Return the number of cells.
+
+        Alias for ``n_cells``.
+
+        """
         return self.n_cells
 
     @property
     def number_of_faces(self):
-        """ returns the number of cells """
+        """Return the number of cells."""
         return self.n_cells
 
 
     def save(self, filename, binary=True):
-        """
-        Writes a surface mesh to disk.
+        """Write a surface mesh to disk.
 
         Written file may be an ASCII or binary ply, stl, or vtk mesh file.
 
@@ -354,6 +360,7 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
         -----
         Binary files write much faster than ASCII and have a smaller
         file size.
+
         """
         filename = os.path.abspath(os.path.expanduser(filename))
         file_mode = True
@@ -386,11 +393,10 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
 
     @property
     def area(self):
-        """
-        Mesh surface area
+        """Return the mesh surface area.
 
-        Returns
-        -------
+        Return
+        ------
         area : float
             Total area of the mesh.
 
@@ -401,11 +407,12 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
 
     @property
     def volume(self):
-        """
-        Mesh volume - will throw a VTK error/warning if not a closed surface
+        """Return the mesh volume.
 
-        Returns
-        -------
+        This will throw a VTK error/warning if not a closed surface
+
+        Return
+        ------
         volume : float
             Total volume of the mesh.
 
@@ -417,27 +424,29 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
 
     @property
     def point_normals(self):
-        """ Point normals """
+        """Return the point normals."""
         mesh = self.compute_normals(cell_normals=False, inplace=False)
         return mesh.point_arrays['Normals']
 
 
     @property
     def cell_normals(self):
-        """ Cell normals  """
+        """Return the cell normals."""
         mesh = self.compute_normals(point_normals=False, inplace=False)
         return mesh.cell_arrays['Normals']
 
 
     @property
     def face_normals(self):
-        """ Cell normals  """
+        """Return the cell normals."""
         return self.cell_normals
 
 
     @property
     def obbTree(self):
-        """obbTree is an object to generate oriented bounding box (OBB)
+        """Return the obbTree of the polydata.
+
+        An obbTree is an object to generate oriented bounding box (OBB)
         trees. An oriented bounding box is a bounding box that does not
         necessarily line up along coordinate axes. The OBB tree is a
         hierarchical tree structure of such boxes, where deeper levels of OBB
@@ -453,7 +462,7 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
 
     @property
     def n_open_edges(self):
-        """ The number of open edges on this mesh """
+        """Return the number of open edges on this mesh."""
         alg = vtk.vtkFeatureEdges()
         alg.FeatureEdgesOff()
         alg.BoundaryEdgesOn()
@@ -464,19 +473,20 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
 
 
 class PointGrid(PointSet):
-    """ Class in common with structured and unstructured grids """
+    """Class in common with structured and unstructured grids."""
 
     def __new__(cls, *args, **kwargs):
+        """Allocate memory for the point grid."""
         if cls is PointGrid:
             raise TypeError("pyvista.PointGrid is an abstract class and may not be instantiated.")
         return object.__new__(cls, *args, **kwargs)
 
     def __init__(self, *args, **kwargs):
+        """Initialize the point grid."""
         super(PointGrid, self).__init__()
 
     def plot_curvature(self, curv_type='mean', **kwargs):
-        """
-        Plots the curvature of the external surface of the grid
+        """Plot the curvature of the external surface of the grid.
 
         Parameters
         ----------
@@ -491,8 +501,8 @@ class PointGrid(PointSet):
         **kwargs : optional
             Optional keyword arguments.  See help(pyvista.plot)
 
-        Returns
-        -------
+        Return
+        ------
         cpos : list
             Camera position, focal point, and view up.  Used for storing and
             setting camera view.
@@ -503,9 +513,9 @@ class PointGrid(PointSet):
 
     @property
     def volume(self):
-        """
-        Computes volume by extracting the external surface and
-        computing interior volume
+        """Compute the volume of the point grid.
+
+        This extracts the external surface and computes the interior volume
         """
         surf = self.extract_surface().triangulate()
         return surf.volume
@@ -545,6 +555,7 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the unstructured grid."""
         super(UnstructuredGrid, self).__init__()
         deep = kwargs.pop('deep', False)
 
@@ -581,16 +592,17 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
 
 
     def __repr__(self):
+        """Return the standard representation."""
         return Common.__repr__(self)
 
 
     def __str__(self):
+        """Return the standard str representation."""
         return Common.__str__(self)
 
 
     def _from_arrays(self, offset, cells, cell_type, points, deep=True):
-        """
-        Create VTK unstructured grid from numpy arrays
+        """Create VTK unstructured grid from numpy arrays.
 
         Parameters
         ----------
@@ -641,7 +653,6 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
         >>> grid = pyvista.UnstructuredGrid(offset, cells, cell_type, points)
 
         """
-
         if offset.dtype != pyvista.ID_TYPE:
             offset = offset.astype(pyvista.ID_TYPE)
 
@@ -675,8 +686,7 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
         self.SetCells(cell_type, offset, vtkcells)
 
     def _load_file(self, filename):
-        """
-        Load an unstructured grid from a file.
+        """Load an unstructured grid from a file.
 
         The file extension will select the type of reader to use.  A .vtk
         extension will use the legacy reader, while .vtu will select the VTK
@@ -686,6 +696,7 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
         ----------
         filename : str
             Filename of grid to be loaded.
+
         """
         filename = os.path.abspath(os.path.expanduser(filename))
         # check file exists
@@ -707,8 +718,7 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
         self.shallow_copy(grid)
 
     def save(self, filename, binary=True):
-        """
-        Writes an unstructured grid to disk.
+        """Write an unstructured grid to disk.
 
         Parameters
         ----------
@@ -720,12 +730,12 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
         binary : bool, optional
             Writes as a binary file by default.  Set to False to write ASCII.
 
-
         Notes
         -----
         Binary files write much faster than ASCII, but binary files written on
         one system may not be readable on other systems.  Binary can be used
         only ".vtk" files
+
         """
         filename = os.path.abspath(os.path.expanduser(filename))
         # Use legacy writer if vtk is in filename
@@ -750,14 +760,13 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
 
     @property
     def cells(self):
-        """ returns a pointer to the cells as a numpy object """
+        """Return a pointer to the cells as a numpy object."""
         return vtk_to_numpy(self.GetCells().GetData())
 
     def linear_copy(self, deep=False):
-        """
-        Returns a copy of the input unstructured grid containing only
-        linear cells.  Converts the following cell types to their
-        linear equivalents.
+        """Return a copy of the unstructured grid containing only linear cells.
+        
+        Converts the following cell types to their linear equivalents.
 
         - VTK_QUADRATIC_TETRA      --> VTK_TETRA
         - VTK_QUADRATIC_PYRAMID    --> VTK_PYRAMID
@@ -770,10 +779,11 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
             When True, makes a copy of the points array.  Default
             False.  Cells and cell types are always copied.
 
-        Returns
-        -------
+        Return
+        ------
         grid : pyvista.UnstructuredGrid
             UnstructuredGrid containing only linear cells.
+
         """
         lgrid = self.copy(deep)
 
@@ -817,19 +827,19 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
 
     @property
     def celltypes(self):
-        """Get the cell types array"""
+        """Get the cell types array."""
         return vtk_to_numpy(self.GetCellTypesArray())
 
     @property
     def offset(self):
-        """Get Cell Locations Array"""
+        """Get Cell Locations Array."""
         return vtk_to_numpy(self.GetCellLocationsArray())
 
 
 
 class StructuredGrid(vtkStructuredGrid, PointGrid):
-    """
-    Extends the functionality of a vtk.vtkStructuredGrid object
+    """Extend the functionality of a vtk.vtkStructuredGrid object.
+
     Can be initialized in several ways:
 
     - Create empty grid
@@ -859,10 +869,10 @@ class StructuredGrid(vtkStructuredGrid, PointGrid):
     >>> x, y, z = np.meshgrid(xrng, yrng, zrng)
     >>> grid = pyvista.StructuredGrid(x, y, z)
 
-
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the structured grid."""
         super(StructuredGrid, self).__init__()
 
         if len(args) == 1:
@@ -881,16 +891,17 @@ class StructuredGrid(vtkStructuredGrid, PointGrid):
 
 
     def __repr__(self):
+        """Return the standard representation."""
         return Common.__repr__(self)
 
 
     def __str__(self):
+        """Return the standard str representation."""
         return Common.__str__(self)
 
 
     def _from_arrays(self, x, y, z):
-        """
-        Create VTK structured grid directly from numpy arrays.
+        """Create VTK structured grid directly from numpy arrays.
 
         Parameters
         ----------
@@ -902,6 +913,7 @@ class StructuredGrid(vtkStructuredGrid, PointGrid):
 
         z : np.ndarray
             Position of the points in z direction.
+
         """
         if not(x.shape == y.shape == z.shape):
             raise Exception('Input point array shapes must match exactly')
@@ -922,8 +934,7 @@ class StructuredGrid(vtkStructuredGrid, PointGrid):
         self.SetPoints(pyvista.vtk_points(points))
 
     def _load_file(self, filename):
-        """
-        Load a structured grid from a file.
+        """Load a structured grid from a file.
 
         The file extension will select the type of reader to use.  A .vtk
         extension will use the legacy reader, while .vts will select the VTK
@@ -962,8 +973,7 @@ class StructuredGrid(vtkStructuredGrid, PointGrid):
         self.shallow_copy(grid)
 
     def save(self, filename, binary=True):
-        """
-        Writes a structured grid to disk.
+        """Write a structured grid to disk.
 
         Parameters
         ----------
@@ -1007,27 +1017,27 @@ class StructuredGrid(vtkStructuredGrid, PointGrid):
 
     @property
     def dimensions(self):
-        """Returns a length 3 tuple of the grid's dimensions"""
+        """Return a length 3 tuple of the grid's dimensions."""
         return list(self.GetDimensions())
 
     @dimensions.setter
     def dimensions(self, dims):
-        """Sets the dataset dimensions. Pass a length three tuple of integers"""
+        """Set the dataset dimensions. Pass a length three tuple of integers."""
         nx, ny, nz = dims[0], dims[1], dims[2]
         self.SetDimensions(nx, ny, nz)
         self.Modified()
 
     @property
     def x(self):
-        """The X coordinates of all points"""
+        """Return the X coordinates of all points."""
         return self.points[:, 0].reshape(self.dimensions, order='F')
 
     @property
     def y(self):
-        """The Y coordinates of all points"""
+        """Return the Y coordinates of all points."""
         return self.points[:, 1].reshape(self.dimensions, order='F')
 
     @property
     def z(self):
-        """The Z coordinates of all points"""
+        """Return the Z coordinates of all points."""
         return self.points[:, 2].reshape(self.dimensions, order='F')

--- a/pyvista/examples/__init__.py
+++ b/pyvista/examples/__init__.py
@@ -1,2 +1,4 @@
+"""Examples routines."""
+
 from pyvista.examples.downloads import *
 from pyvista.examples.examples import *

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -1,5 +1,5 @@
-"""Functions to download sampe datasets from the VTK data repository
-"""
+"""Functions to download sample datasets from the VTK data repository."""
+
 import os
 import shutil
 import sys
@@ -12,7 +12,7 @@ import pyvista
 # Helpers:
 
 def delete_downloads():
-    """Delete all downloaded examples to free space or update the files"""
+    """Delete all downloaded examples to free space or update the files."""
     shutil.rmtree(pyvista.EXAMPLES_PATH)
     os.makedirs(pyvista.EXAMPLES_PATH)
     return True
@@ -65,82 +65,103 @@ def _download_and_read(filename, texture=False):
 ###############################################################################
 
 def download_masonry_texture():
+    """Download masonry texture."""
     return _download_and_read('masonry.bmp', texture=True)
 
 def download_usa_texture():
+    """Download usa texture."""
     return _download_and_read('usa_image.jpg', texture=True)
 
 def download_puppy_texture():
+    """Download puppy texture."""
     return _download_and_read('puppy.jpg', texture=True)
 
 def download_puppy():
+    """Download puppy dataset."""
     return _download_and_read('puppy.jpg')
 
 def download_usa():
+    """Download usa dataset."""
     return _download_and_read('usa.vtk')
 
 def download_st_helens():
+    """Download Saint Helens dataset."""
     return _download_and_read('SainteHelens.dem')
 
 def download_bunny():
+    """Download bunny dataset."""
     return _download_and_read('bunny.ply')
 
 def download_bunny_coarse():
+    """Download coarse bunny dataset."""
     return _download_and_read('Bunny.vtp')
 
 def download_cow():
+    """Download cow dataset."""
     return _download_and_read('cow.vtp')
 
 def download_cow_head():
+    """Download cow head dataset."""
     return _download_and_read('cowHead.vtp')
 
 def download_faults():
+    """Download faults dataset."""
     return _download_and_read('faults.vtk')
 
 def download_tensors():
+    """Download tensors dataset."""
     return _download_and_read('tensors.vtk')
 
 def download_head():
+    """Download head dataset."""
     _download_file('HeadMRVolume.raw')
     return _download_and_read('HeadMRVolume.mhd')
 
 def download_bolt_nut():
+    """Download bolt nut dataset."""
     blocks = pyvista.MultiBlock()
     blocks['bolt'] = _download_and_read('bolt.slc')
     blocks['nut'] = _download_and_read('nut.slc')
     return blocks
 
 def download_clown():
+    """Download clown dataset."""
     return _download_and_read('clown.facet')
 
 def download_topo_global():
+    """Download topo dataset."""
     return _download_and_read('EarthModels/ETOPO_10min_Ice.vtp')
 
 def download_topo_land():
+    """Download topo land dataset."""
     return _download_and_read('EarthModels/ETOPO_10min_Ice_only-land.vtp')
 
 def download_coastlines():
+    """Download coastlines dataset."""
     return _download_and_read('EarthModels/Coastlines_Los_Alamos.vtp')
 
 def download_knee():
+    """Download knee dataset."""
     return _download_and_read('DICOM_KNEE.dcm')
 
 def download_knee_full():
+    """Download full knee dataset."""
     return _download_and_read('vw_knee.slc')
 
 def download_lidar():
+    """Download lidar dataset."""
     return _download_and_read('kafadar-lidar-interp.vtp')
 
 def download_exodus():
-    """Sample ExodusII data file"""
+    """Sample ExodusII data file."""
     return _download_and_read('mesh_fs8.exo')
 
 def download_nefertiti():
-    """Download mesh of Queen Nefertiti"""
+    """Download mesh of Queen Nefertiti."""
     return _download_and_read('Nefertiti.obj.zip')
 
 def download_blood_vessels():
-    """data representing the bifurcation of blood vessels."""
+    """Download data representing the bifurcation of blood vessels."""
     local_path, _ = _download_file('pvtu_blood_vessels/blood_vessels.zip')
     filename = os.path.join(local_path, 'T0000000500.pvtu')
     mesh = pyvista.read(filename)
@@ -148,16 +169,23 @@ def download_blood_vessels():
     return mesh
 
 def download_iron_pot():
+    """Download iron pot dataset."""
     return _download_and_read('ironProt.vtk')
 
 def download_tetrahedron():
+    """Download tetrahedron dataset."""
     return _download_and_read('Tetrahedron.vtu')
 
 def download_saddle_surface():
+    """Download saddle surface dataset."""
     return _download_and_read('InterpolatingOnSTL_final.stl')
 
 def download_sparse_points():
-    """Used with ``download_saddle_surface``"""
+    """Download sparse points dataset.
+    
+    Used with ``download_saddle_surface``.
+
+    """
     saved_file, _ = _download_file('sparsePoints.txt')
     points_reader = vtk.vtkDelimitedTextReader()
     points_reader.SetFileName(saved_file)
@@ -173,163 +201,213 @@ def download_sparse_points():
     return pyvista.wrap(table_points.GetOutput())
 
 def download_foot_bones():
+    """Download foot bones dataset."""
     return _download_and_read('fsu/footbones.ply')
 
 def download_guitar():
+    """Download guitar dataset."""
     return _download_and_read('fsu/stratocaster.ply')
 
 def download_quadratic_pyramid():
+    """Download quadratic pyramid dataset."""
     return _download_and_read('QuadraticPyramid.vtu')
 
 def download_bird():
+    """Download bird dataset."""
     return _download_and_read('Pileated.jpg')
 
 def download_bird_texture():
+    """Download bird texture."""
     return _download_and_read('Pileated.jpg', texture=True)
 
 def download_office():
+    """Download office dataset."""
     return _download_and_read('office.binary.vtk')
 
 def download_horse_points():
+    """Download horse points dataset."""
     return _download_and_read('horsePoints.vtp')
 
 def download_horse():
+    """Download horse dataset."""
     return _download_and_read('horse.vtp')
 
 def download_cake_easy():
+    """Download cake dataset."""
     return _download_and_read('cake_easy.jpg')
 
 def download_cake_easy_texture():
+    """Download cake texture."""
     return _download_and_read('cake_easy.jpg', texture=True)
 
 def download_rectilinear_grid():
+    """Download rectilinear grid dataset."""
     return _download_and_read('RectilinearGrid.vtr')
 
 def download_gourds(zoom=False):
+    """Download gourds dataset."""
     if zoom:
         return _download_and_read('Gourds.png')
     return _download_and_read('Gourds2.jpg')
 
 def download_gourds_texture(zoom=False):
+    """Download gourds texture."""
     if zoom:
         return _download_and_read('Gourds.png', texture=True)
     return _download_and_read('Gourds2.jpg', texture=True)
 
 def download_unstructured_grid():
+    """Download unstructured grid dataset."""
     return _download_and_read('uGridEx.vtk')
 
 def download_letter_k():
+    """Download letter k dataset."""
     return _download_and_read('k.vtk')
 
 def download_letter_a():
+    """Download letter a dataset."""
     return _download_and_read('a_grid.vtk')
 
 def download_poly_line():
+    """Download polyline dataset."""
     return _download_and_read('polyline.vtk')
 
 def download_cad_model():
+    """Download cad dataset."""
     return _download_and_read('42400-IDGH.stl')
 
 def download_frog():
+    """Download frog dataset."""
     # TODO: there are other files with this
     _download_file('froggy/frog.zraw')
     return _download_and_read('froggy/frog.mhd')
 
 def download_prostate():
+    """Download prostate dataset."""
     return _download_and_read('prostate.img')
 
 def download_filled_contours():
+    """Download filled contours dataset."""
     return _download_and_read('filledContours.vtp')
 
 def download_doorman():
+    """Download doorman dataset."""
     # TODO: download textures as well
     return _download_and_read('doorman/doorman.obj')
 
 def download_mug():
+    """Download mug dataset."""
     return _download_and_read('mug.e')
 
 def download_oblique_cone():
+    """Download oblique cone dataset."""
     return _download_and_read('ObliqueCone.vtp')
 
 def download_emoji():
+    """Download emoji dataset."""
     return _download_and_read('emote.jpg')
 
 def download_emoji_texture():
+    """Download emoji texture."""
     return _download_and_read('emote.jpg', texture=True)
 
 def download_teapot():
+    """Download teapot dataset."""
     return _download_and_read('teapot.g')
 
 def download_brain():
+    """Download brain dataset."""
     return _download_and_read('brain.vtk')
 
 def download_structured_grid():
+    """Download structured grid dataset."""
     return _download_and_read('StructuredGrid.vts')
 
 def download_structured_grid_two():
+    """Download structured grid two dataset."""
     return _download_and_read('SampleStructGrid.vtk')
 
 def download_trumpet():
+    """Download trumpet dataset."""
     return _download_and_read('trumpet.obj')
 
 def download_face():
+    """Download face dataset."""
     # TODO: there is a texture with this
     return _download_and_read('fran_cut.vtk')
 
 def download_sky_box_nz():
+    """Download skybox-nz dataset."""
     return _download_and_read('skybox-nz.jpg')
 
 def download_sky_box_nz_texture():
+    """Download skybox-nz texture."""
     return _download_and_read('skybox-nz.jpg', texture=True)
 
 def download_disc_quads():
+    """Download disc quads dataset."""
     return _download_and_read('Disc_BiQuadraticQuads_0_0.vtu')
 
 def download_honolulu():
+    """Download honolulu dataset."""
     return _download_and_read('honolulu.vtk')
 
 def download_motor():
+    """Download motor dataset."""
     return _download_and_read('motor.g')
 
 def download_tri_quadratic_hexahedron():
+    """Download tri quadratic hexahedron dataset."""
     return _download_and_read('TriQuadraticHexahedron.vtu')
 
 def download_human():
+    """Download human dataset."""
     return _download_and_read('Human.vtp')
 
 def download_vtk():
+    """Download vtk dataset."""
     return _download_and_read('vtk.vtp')
 
 def download_spider():
+    """Download spider dataset."""
     return _download_and_read('spider.ply')
 
 def download_carotid():
+    """Download carotid dataset."""
     mesh = _download_and_read('carotid.vtk')
     mesh.set_active_scalar('scalars')
     mesh.set_active_vectors('vectors')
     return mesh
 
 def download_blow():
+    """Download blow dataset."""
     return _download_and_read('blow.vtk')
 
 def download_shark():
+    """Download shark dataset."""
     return _download_and_read('shark.ply')
 
 def download_dragon():
+    """Download dragon dataset."""
     return _download_and_read('dragon.ply')
 
 def download_armadillo():
+    """Download armadillo dataset."""
     return _download_and_read('Armadillo.ply')
 
 def download_gears():
+    """Download gears dataset."""
     return _download_and_read('gears.stl')
 
 def download_torso():
+    """Download torso dataset."""
     return _download_and_read('Torso.vtp')
 
 def download_kitchen(split=False):
-    """Download structured grid of kitchen with velocity field. Use the
-    ``split`` argument to extract all of the furniture in the kitchen.
+    """Download structured grid of kitchen with velocity field.
+
+    Use the ``split`` argument to extract all of the furniture in the kitchen.
+
     """
     mesh = _download_and_read('kitchen.vtk')
     if not split:
@@ -365,8 +443,11 @@ def download_kitchen(split=False):
 
 
 def download_tetra_dc_mesh():
-    """Download two meshes defining an electrical inverse problem. This contains
-    a high resolution forward modeled mesh and a coarse inverse modeled mesh
+    """Download two meshes defining an electrical inverse problem.
+
+    This contains a high resolution forward modeled mesh and a coarse
+    inverse modeled mesh.
+
     """
     local_path, _ = _download_file('dc-inversion.zip')
     filename = os.path.join(local_path, 'mesh-forward.vtu')
@@ -379,12 +460,15 @@ def download_tetra_dc_mesh():
 
 
 def download_model_with_variance():
+    """Download model with variance dataset."""
     return _download_and_read("model_with_variance.vtu")
 
 
 def download_carburator():
-    """Scan of a carburator from
-        https://www.laserdesign.com/sample-files/carburetor/
+    """Download scan of a carburator.
+
+    https://www.laserdesign.com/sample-files/carburetor/
+
     """
     url = "http://3dgallery.gks.com/2012/carburator/carburator2.php"
     filename, _ = _retrieve_file(url, 'carburator.ply')
@@ -392,8 +476,10 @@ def download_carburator():
 
 
 def download_woman():
-    """Scan of a woman from
-        https://www.laserdesign.com/sample-files/full-body-scan-with-texture/
+    """Download scan of a woman.
+
+    https://www.laserdesign.com/sample-files/full-body-scan-with-texture/
+
     """
     url = "http://3dgallery.gks.com/2012/bodyscan/bodyscan3.php"
     filename, _ = _retrieve_file(url, 'woman.stl')
@@ -401,8 +487,10 @@ def download_woman():
 
 
 def download_lobster():
-    """Scan of a lobster from
-        https://www.laserdesign.com/lobster-scan-data
+    """Download scan of a lobster.
+
+    https://www.laserdesign.com/lobster-scan-data
+
     """
     url = "http://3dgallery.gks.com/2016/lobster/index2.php"
     filename, _ = _retrieve_file(url, 'lobster.ply')
@@ -410,8 +498,10 @@ def download_lobster():
 
 
 def download_face2():
-    """Scan of a man's face from
-        https://www.laserdesign.com/sample-files/mans-face/
+    """Download scan of a man's face.
+
+    https://www.laserdesign.com/sample-files/mans-face/
+
     """
     url = "http://3dgallery.gks.com/2012/face/"
     filename, _ = _retrieve_file(url, 'man_face.stl')
@@ -419,8 +509,10 @@ def download_face2():
 
 
 def download_urn():
-    """Scan of a burial urn from
-        https://www.laserdesign.com/sample-files/burial-urn/
+    """Download scan of a burial urn.
+
+    https://www.laserdesign.com/sample-files/burial-urn/
+
     """
     url = "http://3dgallery.gks.com/2012/urn/urn3.php"
     filename, _ = _retrieve_file(url, 'urn.stl')
@@ -428,8 +520,10 @@ def download_urn():
 
 
 def download_pepper():
-    """Scan of a burial urn from
-        https://www.laserdesign.com/sample-files/hot-red-pepper/
+    """Download scan of a burial urn.
+
+    https://www.laserdesign.com/sample-files/hot-red-pepper/
+
     """
     url = "http://3dgallery.gks.com/2012/redpepper/redpepper2.php"
     filename, _ = _retrieve_file(url, 'pepper.ply')
@@ -437,8 +531,10 @@ def download_pepper():
 
 
 def download_drill():
-    """Scan of a power drill from
-        https://www.laserdesign.com/drill-scan-data
+    """Download scan of a power drill.
+
+    https://www.laserdesign.com/drill-scan-data
+
     """
     url = "http://3dgallery.gks.com/2015/ryobi/index1.php"
     filename, _ = _retrieve_file(url, 'pepper.obj')
@@ -447,8 +543,10 @@ def download_drill():
 
 
 def download_action_figure():
-    """Scan of an action figure from
-        https://www.laserdesign.com/sample-files/action-figure/
+    """Download scan of an action figure.
+
+    https://www.laserdesign.com/sample-files/action-figure/
+
     """
     url = "http://3dgallery.gks.com/2013/tigerfighter"
     filename, _ = _retrieve_file(url, 'tigerfighter.obj')
@@ -456,8 +554,10 @@ def download_action_figure():
 
 
 def download_turbine_blade():
-    """Scan of a turbine blade from
-        https://www.laserdesign.com/sample-files/blade/
+    """Download scan of a turbine blade.
+
+    https://www.laserdesign.com/sample-files/blade/
+
     """
     url = "http://3dgallery.gks.com/2012/blade/blade.php"
     filename, _ = _retrieve_file(url, 'turbine_blade.stl')
@@ -465,12 +565,15 @@ def download_turbine_blade():
 
 
 def download_pine_roots():
+    """Download pine roots dataset."""
     return _download_and_read('pine_root.tri')
 
 
 def download_crater_topo():
+    """Download crater dataset."""
     return _download_and_read('Ruapehu_mag_dem_15m_NZTM.vtk')
 
 
 def download_crater_imagery():
+    """Download crater texture."""
     return _download_and_read('BJ34_GeoTifv1-04_crater_clip.tif', texture=True)

--- a/pyvista/examples/examples.py
+++ b/pyvista/examples/examples.py
@@ -1,3 +1,5 @@
+"""Module managing examples and toy datasets."""
+
 import os
 import time
 
@@ -22,36 +24,36 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 
 
 def load_ant():
-    """ Load ply ant mesh """
+    """Load ply ant mesh."""
     return pyvista.PolyData(antfile)
 
 
 def load_airplane():
-    """ Load ply airplane mesh """
+    """Load ply airplane mesh."""
     return pyvista.PolyData(planefile)
 
 
 def load_sphere():
-    """ Loads sphere ply mesh """
+    """Load sphere ply mesh."""
     return pyvista.PolyData(spherefile)
 
 
 def load_uniform():
-    """ Loads a sample uniform grid """
+    """Load a sample uniform grid."""
     return pyvista.UniformGrid(uniformfile)
 
 
 def load_rectilinear():
-    """ Loads a sample uniform grid """
+    """Load a sample uniform grid."""
     return pyvista.RectilinearGrid(rectfile)
 
 def load_hexbeam():
-    """ Loads a sample UnstructuredGrid """
+    """Load a sample UnstructuredGrid."""
     return pyvista.UnstructuredGrid(hexbeamfile)
 
 
 def load_structured():
-    """ Loads a simple StructuredGrid """
+    """Load a simple StructuredGrid."""
     x = np.arange(-10, 10, 0.25)
     y = np.arange(-10, 10, 0.25)
     x, y = np.meshgrid(x, y)
@@ -60,28 +62,27 @@ def load_structured():
     return pyvista.StructuredGrid(x, y, z)
 
 def load_globe():
-    """ Loads a globe source """
+    """Load a globe source."""
     globe = pyvista.PolyData(globefile)
     globe.textures['2k_earth_daymap'] = load_globe_texture()
     return globe
 
 def load_globe_texture():
-    """ Loads a vtk.vtkTexture that can be applied to the globe source """
+    """Load a vtk.vtkTexture that can be applied to the globe source."""
     return pyvista.read_texture(mapfile)
 
 
 def load_channels():
-    """ Loads a uniform grid of fluvial channels in the subsurface """
+    """Load a uniform grid of fluvial channels in the subsurface."""
     return pyvista.read(channelsfile)
 
 def plot_ants_plane(off_screen=None, notebook=None):
-    """
+    """Plot two ants and airplane.
+
     Demonstrate how to create a plot class to plot multiple meshes while
     adding scalars and text.
 
-    Plot two ants and airplane
     """
-
     # load and shrink airplane
     airplane = pyvista.PolyData(planefile)
     airplane.points /= 10
@@ -110,6 +111,7 @@ def plot_ants_plane(off_screen=None, notebook=None):
 
 
 def beam_example(off_screen=None, notebook=None):
+    """Create the beam example."""
     # Load module and example file
     hexfile = hexbeamfile
 
@@ -142,8 +144,7 @@ def beam_example(off_screen=None, notebook=None):
 
 def plot_wave(fps=30, frequency=1, wavetime=3, interactive=False,
               off_screen=None, notebook=None):
-    """
-    Plot a 3D moving wave in a render window.
+    """Plot a 3D moving wave in a render window.
 
     Parameters
     ----------
@@ -164,8 +165,8 @@ def plot_wave(fps=30, frequency=1, wavetime=3, interactive=False,
         Enables off screen rendering when True.  Used for automated testing.
         Disabled by default.
 
-    Returns
-    -------
+    Return
+    ------
     points : np.ndarray
         Position of points at last frame.
 
@@ -233,7 +234,7 @@ def plot_wave(fps=30, frequency=1, wavetime=3, interactive=False,
 
 
 def load_spline():
-    """Load an example spline mesh"""
+    """Load an example spline mesh."""
     theta = np.linspace(-4 * np.pi, 4 * np.pi, 100)
     z = np.linspace(-2, 2, 100)
     r = z**2 + 1
@@ -244,8 +245,12 @@ def load_spline():
 
 
 def load_random_hills():
-    """Uses the parametric random hill function to create hills oriented like
-    topography and add's an elevation array"""
+    """Create random hills toy example.
+    
+    Uses the parametric random hill function to create hills oriented like
+    topography and add's an elevation array.
+
+    """
     mesh = pyvista.ParametricRandomHills()
     mesh.rotate_y(90)
     return mesh.elevation()

--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -1,3 +1,5 @@
+"""Plotting routines."""
+
 from .colors import (color_char_to_word, get_cmap_safe, hex_to_rgb, hexcolors,
                      string_to_rgb, PARAVIEW_BACKGROUND)
 from .export_vtkjs import export_plotter_vtkjs, get_vtkjs_url

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -1,5 +1,4 @@
-"""
-Color module supporting plotting module
+"""Color module supporting plotting module.
 
 Used code from matplotlib.colors.  Thanks for your work!
 
@@ -323,15 +322,15 @@ PARAVIEW_BACKGROUND = [82/255., 87/255., 110/255.]
 
 
 def hex_to_rgb(h):
-    """ Returns 0 to 1 rgb from a hex list or tuple """
+    """Return 0 to 1 rgb from a hex list or tuple."""
     h = h.lstrip('#')
     return tuple(int(h[i:i+2], 16)/255. for i in (0, 2, 4))
 
 
 def string_to_rgb(string):
-    """
-    Converts a literal color string (i.e. white) to a color rgb.  Also accepts
-    hex strings or single characters from the following list.
+    """Convert a literal color string (i.e. white) to a color rgb.
+
+    Also accepts hex strings or single characters from the following list.
 
         b: blue
         g: green
@@ -343,7 +342,6 @@ def string_to_rgb(string):
         w: white
 
     """
-
     # if a single character
     if len(string) == 1:
 
@@ -373,7 +371,7 @@ def string_to_rgb(string):
 
 
 def get_cmap_safe(cmap):
-    """Fetches a colormap by name from matplotlib, colorcet, or cmocean"""
+    """Fetch a colormap by name from matplotlib, colorcet, or cmocean."""
     try:
         from matplotlib.cm import get_cmap
     except ImportError:

--- a/pyvista/plotting/export_vtkjs.py
+++ b/pyvista/plotting/export_vtkjs.py
@@ -1,4 +1,5 @@
-"""
+"""Export a rendering window to a VTKjs file.
+
 This module holds a set of tools for exporting a VTK rendering window
 to a VTKjs file that can be viewed in a web browser.
 
@@ -76,7 +77,7 @@ writer_mapping = {}
 
 
 def get_range_info(array, component):
-    """Get the data range of the array's component"""
+    """Get the data range of the array's component."""
     r = array.GetRange(component)
     comp_range = {}
     comp_range['min'] = r[0]
@@ -88,7 +89,7 @@ def get_range_info(array, component):
 
 
 def get_ref(dest_dir, md5):
-    """Get reference"""
+    """Get reference."""
     ref = {}
     ref['id'] = md5
     ref['encode'] = 'BigEndian' if sys.byteorder == 'big' else 'LittleEndian'
@@ -102,7 +103,7 @@ objIds = []
 
 
 def get_object_id(obj):
-    """Get object identifier"""
+    """Get object identifier."""
     try:
         idx = objIds.index(obj)
         return idx + 1
@@ -114,7 +115,7 @@ def get_object_id(obj):
 # -----------------------------------------------------------------------------
 
 def dump_data_array(dataset_dir, data_dir, array, root=None, compress=True):
-    """Dump vtkjs data arry"""
+    """Dump vtkjs data array."""
     if root is None:
         root = {}
     if not array:
@@ -162,7 +163,7 @@ def dump_data_array(dataset_dir, data_dir, array, root=None, compress=True):
 
 
 def dump_color_array(dataset_dir, data_dir, color_array_info, root=None, compress=True):
-    """Dump vtkjs color array"""
+    """Dump vtkjs color array."""
     if root is None:
         root = {}
     root['pointData'] = {
@@ -214,7 +215,7 @@ def dump_color_array(dataset_dir, data_dir, color_array_info, root=None, compres
 
 
 def dump_t_coords(dataset_dir, data_dir, dataset, root=None, compress=True):
-    """dump vtkjs texture coordinates"""
+    """Dump vtkjs texture coordinates."""
     if root is None:
         root = {}
     tcoords = dataset.GetPointData().GetTCoords()
@@ -227,7 +228,7 @@ def dump_t_coords(dataset_dir, data_dir, dataset, root=None, compress=True):
 
 
 def dump_normals(dataset_dir, data_dir, dataset, root=None, compress=True):
-    """dump vtkjs normal vectors"""
+    """Dump vtkjs normal vectors."""
     if root is None:
         root = {}
     normals = dataset.GetPointData().GetNormals()
@@ -240,7 +241,7 @@ def dump_normals(dataset_dir, data_dir, dataset, root=None, compress=True):
 
 
 def dump_all_arrays(dataset_dir, data_dir, dataset, root=None, compress=True):
-    """Dump all data arrays to vtkjs"""
+    """Dump all data arrays to vtkjs."""
     if root is None:
         root = {}
     root['pointData'] = {
@@ -305,7 +306,7 @@ def dump_all_arrays(dataset_dir, data_dir, dataset, root=None, compress=True):
 
 
 def dump_poly_data(dataset_dir, data_dir, dataset, color_array_info, root=None, compress=True):
-    """Dump poly data object to vtkjs"""
+    """Dump poly data object to vtkjs."""
     if root is None:
         root = {}
     root['vtkClass'] = 'vtkPolyData'
@@ -363,7 +364,7 @@ writer_mapping['vtkPolyData'] = dump_poly_data
 
 
 def dump_image_data(dataset_dir, data_dir, dataset, color_array_info, root=None, compress=True):
-    """Dump image data object to vtkjs"""
+    """Dump image data object to vtkjs."""
     if root is None:
         root = {}
     root['vtkClass'] = 'vtkImageData'
@@ -384,7 +385,7 @@ writer_mapping['vtkImageData'] = dump_image_data
 
 
 def write_data_set(file_path, dataset, output_dir, color_array_info, new_name=None, compress=True):
-    """write dataset to vtkjs"""
+    """Write dataset to vtkjs."""
     fileName = new_name if new_name else os.path.basename(file_path)
     dataset_dir = os.path.join(output_dir, fileName)
     data_dir = os.path.join(dataset_dir, 'data')
@@ -412,7 +413,7 @@ def write_data_set(file_path, dataset, output_dir, color_array_info, new_name=No
 ### ----------------------------------------------------------------------- ###
 
 def mkdir_p(path):
-    """Make directory at path"""
+    """Make directory at path."""
     try:
         os.makedirs(path)
     except OSError as exc:  # Python >2.5
@@ -423,8 +424,7 @@ def mkdir_p(path):
 
 
 def export_plotter_vtkjs(plotter, filename, compress_arrays=False):
-    """Export a plotter's rendering window to the VTKjs format.
-    """
+    """Export a plotter's rendering window to the VTKjs format."""
     sceneName = os.path.split(filename)[1]
     doCompressArrays = compress_arrays
 
@@ -638,16 +638,18 @@ def export_plotter_vtkjs(plotter, filename, compress_arrays=False):
 
 
 def convert_dropbox_url(url):
-    """Convert dropbox url to direct download link"""
+    """Convert dropbox url to direct download link."""
     return url.replace("https://www.dropbox.com", "https://dl.dropbox.com")
 
 def generate_viewer_url(dataURL):
-    """Generate viewer url with data link"""
+    """Generate viewer url with data link."""
     viewerURL = "http://viewer.pyvista.org/"
     return viewerURL + '%s%s' % ("?fileURL=", dataURL)
 
 def get_vtkjs_url(*args):
-    """After using ``export_vtkjs()`` to create a ``.vtkjs`` file from a
+    """Provide shareable link from the vtkjs script.
+
+    After using ``export_vtkjs()`` to create a ``.vtkjs`` file from a
     data scene which is uploaded to an online file hosting service like Dropbox,
     use this method to get a shareable link to that scene on the
     `PVGeo VTKjs viewer`_.

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -1,3 +1,5 @@
+"""This module contains some convenience helper functions."""
+
 import numpy as np
 
 
@@ -14,8 +16,7 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
          show_bounds=False, show_axes=True, notebook=None, background=None,
          text='', return_img=False, eye_dome_lighting=False, use_panel=None,
          volume=False, parallel_projection=False, **kwargs):
-    """
-    Convenience plotting function for a vtk or numpy object.
+    """Plot a vtk or numpy object.
 
     Parameters
     ----------
@@ -150,8 +151,7 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
 
 
 def plot_arrows(cent, direction, **kwargs):
-    """
-    Plots arrows as vectors
+    """Plot arrows as vectors.
 
     Parameters
     ----------
@@ -176,8 +176,10 @@ def plot_compare_four(data_a, data_b, data_c, data_d, disply_kwargs=None,
                       plotter_kwargs=None, show_kwargs=None, screenshot=None,
                       camera_position=None, outline=None, outline_color='k',
                       labels=('A', 'B', 'C', 'D'), link=True, notebook=None):
-    """Plot a 2 by 2 comparison of data objects. Plotting parameters and camera
-    positions will all be the same.
+    """Plot a 2 by 2 comparison of data objects.
+
+    Plotting parameters and camera positions will all be the same.
+
     """
     datasets = [[data_a, data_b], [data_c, data_d]]
     labels = [labels[0:2], labels[2:4]]

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -1,15 +1,15 @@
-"""An internal module for wrapping the use of mappers
-"""
+"""An internal module for wrapping the use of mappers."""
 
 
 def make_mapper(mapper_class):
-    """This makes a mapper wrapped woth a few convenient tools for managing
+    """Wrap a mapper.
+
+    This makes a mapper wrapped with a few convenient tools for managing
     mappers with scalar bars in a consistent way since not all mapper classes
     have scalar ranges and lookup tables.
     """
-
     class MapperHelper(mapper_class):
-        """A helper that dynamically inherits the mapper's class"""
+        """A helper that dynamically inherits the mapper's class."""
 
         def __init__(self, *args, **kwargs):
             self._scalar_range = None

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -1,3 +1,5 @@
+"""Module managing picking events."""
+
 import logging
 import numpy as np
 import vtk
@@ -6,8 +8,8 @@ import pyvista
 from pyvista.utilities import try_callback
 
 class PickingHelper(object):
-    """An internal class to hold picking related features
-    """
+    """An internal class to hold picking related features."""
+
     picked_cells = None
     picked_point = None
     picked_path = None
@@ -15,18 +17,18 @@ class PickingHelper(object):
     picked_horizon = None
 
     def get_pick_position(self):
-        """Get the pick position/area as x0, y0, x1, y1"""
+        """Get the pick position/area as x0, y0, x1, y1."""
         return self.renderer.get_pick_position()
 
 
     def enable_cell_picking(self, mesh=None, callback=None, through=True,
                             show=True, show_message=True, style='wireframe',
                             line_width=5, color='pink', font_size=18, **kwargs):
-        """
-        Enables picking of cells.  Press "r" to enable retangle based
-        selection.  Press "r" again to turn it off.  Selection will be
-        saved to ``self.picked_cells``. Also press "p" to pick a single cell
-        under the mouse location.
+        """Enable picking at cells.
+
+        Press "r" to enable retangle based selection.  Press "r" again to
+        turn it off. Selection will be saved to ``self.picked_cells``. Also
+        press "p" to pick a single cell under the mouse location.
 
         Uses last input mesh for input by default.
 
@@ -61,7 +63,8 @@ class PickingHelper(object):
 
         kwargs : optional
             All remaining keyword arguments are used to control how the
-            selection is intereactively displayed
+            selection is intereactively displayed.
+
         """
         if hasattr(self, 'notebook') and self.notebook:
             raise AssertionError('Cell picking not available in notebook plotting')
@@ -154,7 +157,9 @@ class PickingHelper(object):
     def enable_point_picking(self, callback=None, show_message=True,
                              font_size=18, color='pink', point_size=10,
                              use_mesh=False, show_point=True, **kwargs):
-        """Enable picking a point at the mouse location in the render view
+        """Enable picking at points.
+
+        Enable picking a point at the mouse location in the render view
         using the ``P`` key. This point is saved to the ``.picked_point``
         attrbute on the plotter. Pass a callback function that takes that
         point as an argument. The picked point can either be a point on the
@@ -162,6 +167,7 @@ class PickingHelper(object):
 
         If ``use_mesh`` is True, the callback function will be passed a pointer
         to the picked mesh and the point ID of the selected mesh.
+
         """
         if hasattr(self, 'notebook') and self.notebook:
             raise AssertionError('Point picking not available in notebook plotting')
@@ -197,7 +203,9 @@ class PickingHelper(object):
     def enable_path_picking(self, callback=None, show_message=True,
                             font_size=18, color='pink', point_size=10,
                             line_width=5, show_path=True, **kwargs):
-        """This is a convenience method for ``enable_point_picking`` to keep
+        """Enable picking at paths.
+
+        This is a convenience method for ``enable_point_picking`` to keep
         track of the picked points and create a line using those points.
 
         The line is saved to the ``.picked_path`` attribute of this plotter
@@ -248,7 +256,9 @@ class PickingHelper(object):
     def enable_geodesic_picking(self, callback=None, show_message=True,
                                 font_size=18, color='pink', point_size=10,
                                 line_width=5, **kwargs):
-        """This is a convenience method for ``enable_point_picking`` to keep
+        """Enable picking at geodesic paths.
+
+        This is a convenience method for ``enable_point_picking`` to keep
         track of the picked points and create a geodesic path using those
         points.
 
@@ -303,7 +313,9 @@ class PickingHelper(object):
                                font_size=18, color='pink', point_size=10,
                                line_width=5, show_path=True, opacity=0.75,
                                show_horizon=True, **kwargs):
-        """Helper for the ``enable_path_picking`` method to also show a ribbon
+        """Enable horizon picking.
+
+        Helper for the ``enable_path_picking`` method to also show a ribbon
         surface along the picked path. Ribbon is saved under
         ``.picked_horizon``.
         """
@@ -331,7 +343,7 @@ class PickingHelper(object):
 
 
     def pick_click_position(self):
-        """Get corresponding click location in the 3D plot"""
+        """Get corresponding click location in the 3D plot."""
         if self.click_position is None:
             self.store_click_position()
         picker = vtk.vtkWorldPointPicker()
@@ -340,7 +352,7 @@ class PickingHelper(object):
 
 
     def pick_mouse_position(self):
-        """Get corresponding mouse location in the 3D plot"""
+        """Get corresponding mouse location in the 3D plot."""
         if self.mouse_position is None:
             self.store_mouse_position()
         picker = vtk.vtkWorldPointPicker()
@@ -349,7 +361,7 @@ class PickingHelper(object):
 
 
     def fly_to_mouse_position(self, focus=False):
-        """ Focuses on last stored mouse position """
+        """Focus on last stored mouse position."""
         if self.mouse_position is None:
             self.store_mouse_position()
         click_point = self.pick_mouse_position()
@@ -360,9 +372,13 @@ class PickingHelper(object):
 
 
     def enable_fly_to_right_click(self, callback=None):
-        """A convenience method to track right click positions and fly to the
+        """Set the camera to track right click positions.
+
+        A convenience method to track right click positions and fly to the
         picked point in the scene. The callback will be passed the point in
-        3D space."""
+        3D space.
+
+        """
         def _the_callback(*args):
             click_point = self.pick_mouse_position()
             self.fly_to(click_point)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1,6 +1,5 @@
-"""
-pyvista plotting module
-"""
+"""Pyvista plotting module."""
+
 import collections
 import logging
 import os
@@ -40,7 +39,7 @@ except ImportError:
 _ALL_PLOTTERS = {}
 
 def close_all():
-    """Close all open/active plotters and clean up memory"""
+    """Close all open/active plotters and clean up memory."""
     for key, p in _ALL_PLOTTERS.items():
         p.close()
         p.deep_clean()
@@ -54,8 +53,7 @@ log.setLevel('CRITICAL')
 
 
 class BasePlotter(PickingHelper, WidgetHelper):
-    """
-    To be used by the Plotter and QtInteractor classes.
+    """To be used by the Plotter and QtInteractor classes.
 
     Parameters
     ----------
@@ -81,17 +79,19 @@ class BasePlotter(PickingHelper, WidgetHelper):
         Width of the border in pixels when enabled.
 
     """
+
     mouse_position = None
     click_position = None
 
     def __new__(cls, *args, **kwargs):
+        """Create an instance of base plotter."""
         if cls is BasePlotter:
             raise TypeError("pyvista.BasePlotter is an abstract class and may not be instantiated.")
         return object.__new__(cls)
 
     def __init__(self, shape=(1, 1), border=None, border_color='k',
                  border_width=2.0, title=None, splitting_position=None):
-        """ Initialize base plotter """
+        """Initialize base plotter."""
         self.image_transparent_background = rcParams['transparent_background']
 
         if title is None:
@@ -197,10 +197,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
 
     def add_key_event(self, key, callback):
-        """Add a function to callback when the given key is pressed. These are
-        non-unique - thus a key could map to many callback functions.
+        """Add a function to callback when the given key is pressed.
 
-        The callback function must not have any arguments.
+        These are non-unique - thus a key could map to many callback
+        functions. The callback function must not have any arguments.
 
         Parameters
         ----------
@@ -209,6 +209,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         callback : callable
             A callable that takes no arguments
+
         """
         if not hasattr(callback, '__call__'):
             raise TypeError('callback must be callable.')
@@ -216,11 +217,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
 
     def clear_events_for_key(self, key):
+        """Remove the callbacks associated to the key."""
         self._key_press_event_callbacks.pop(key)
 
 
     def enable_depth_peeling(self, number_of_peels=5, occlusion_ratio=0.1):
-        """Enables depth peeling if supported.
+        """Enable depth peeling if supported.
 
         Parameters
         ----------
@@ -233,10 +235,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Greater values may speed-up the rendering with small impact on the
             quality.
 
-        Returns
-        -------
+        Return
+        ------
         depth_peeling_supported: bool
             If True, depth peeling is supported.
+
         """
         depth_peeling_supported = check_depth_peeling(number_of_peels,
                                                       occlusion_ratio)
@@ -255,30 +258,32 @@ class BasePlotter(PickingHelper, WidgetHelper):
             self.renderer.disable_depth_peeling()
 
     def enable_anti_aliasing(self):
-        """Enables anti-aliasing FXAA"""
+        """Enable anti-aliasing FXAA."""
         self.renderer.enable_anti_aliasing()
 
     def disable_anti_aliasing(self):
-        """Disables anti-aliasing FXAA"""
+        """Disable anti-aliasing FXAA."""
         self.renderer.disable_anti_aliasing()
 
     def store_mouse_position(self, *args):
-        """Store mouse position"""
+        """Store mouse position."""
         if not hasattr(self, "iren"):
             raise AttributeError("This plotting window is not interactive.")
         self.mouse_position = self.iren.GetEventPosition()
 
     def store_click_position(self, *args):
-        """Store click position"""
+        """Store click position."""
         if not hasattr(self, "iren"):
             raise AttributeError("This plotting window is not interactive.")
         self.click_position = self.iren.GetEventPosition()
         self.mouse_position = self.click_position
 
     def track_mouse_position(self):
-        """ Keep track of the mouse position. This will potentially slow down
-        the interactor. No callbacks supported here - use
-        :func:`pyvista.BasePlotter.track_click_position` instead.
+        """Keep track of the mouse position.
+
+        This will potentially slow down the interactor. No callbacks supported
+        here - use :func:`pyvista.BasePlotter.track_click_position` instead.
+
         """
         if hasattr(self, "iren"):
             obs = self.iren.AddObserver(vtk.vtkCommand.MouseMoveEvent,
@@ -286,15 +291,16 @@ class BasePlotter(PickingHelper, WidgetHelper):
             self._mouse_observer = obs
 
     def untrack_mouse_position(self):
-        """Stop tracking the mouse position"""
+        """Stop tracking the mouse position."""
         if hasattr(self, "_mouse_observer"):
             self.iren.RemoveObserver(self._mouse_observer)
             del self._mouse_observer
 
 
     def track_click_position(self, side="right", callback=None):
-        """ Keep track of the click position - defaults to only track right
-        clicks
+        """Keep track of the click position.
+
+        By default, it only tracks right clicks.
 
         Parameters
         ----------
@@ -325,14 +331,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
 
     def untrack_click_position(self):
-        """Stop tracking the click position """
+        """Stop tracking the click position."""
         if hasattr(self, "_click_observer"):
             self.iren.RemoveObserver(self._click_observer)
             del self._click_observer
 
 
     def _close_callback(self):
-        """ Make sure a screenhsot is acquired before closing"""
+        """Make sure a screenhsot is acquired before closing."""
         self.q_pressed = True
         # Grab screenshot right before renderer closes
         self.last_image = self.screenshot(True, return_img=True)
@@ -340,8 +346,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
 
     def increment_point_size_and_line_width(self, increment):
-        """For every actor in the scene, increment both its point size and
+        """Increment point size and line width of all actors.
+
+        For every actor in the scene, increment both its point size and
         line width by the given value.
+
         """
         for renderer in self.renderers:
             for actor in renderer._actors.values():
@@ -371,7 +380,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
 
     def key_press_event(self, obj, event):
-        """ Listens for key press event """
+        """Listen for key press event."""
         key = self.iren.GetKeySym()
         log.debug('Key %s pressed' % key)
         self._last_key = key
@@ -383,7 +392,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
 
     def left_button_down(self, obj, event_type):
-        """Register the event for a left button down click"""
+        """Register the event for a left button down click."""
         # Get 2D click location on window
         click_pos = self.iren.GetEventPosition()
 
@@ -396,25 +405,32 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
 
     def update_style(self):
+        """Update the camera interactor style."""
         if not hasattr(self, '_style'):
             self._style = vtk.vtkInteractorStyleTrackballCamera()
         if hasattr(self, 'iren'):
             return self.iren.SetInteractorStyle(self._style)
 
     def enable_trackball_style(self):
-        """ sets the interactive style to trackball camera - the default syle
+        """Set the interactive style to trackball camera.
+
+        The trackball camera is the default interactor style.
+
         """
         self._style = vtk.vtkInteractorStyleTrackballCamera()
         return self.update_style()
 
     def enable_trackball_actor_style(self):
-        """ sets the interactive style to trackball actor. This makes it
-        possible to rotate actors around the scene."""
+        """Set the interactive style to trackball actor.
+
+        This allows to rotate actors around the scene.
+
+        """
         self._style = vtk.vtkInteractorStyleTrackballActor()
         return self.update_style()
 
     def enable_image_style(self):
-        """ sets the interactive style to image
+        """Set the interactive style to image.
 
         Controls:
          - Left Mouse button triggers window level events
@@ -424,14 +440,15 @@ class BasePlotter(PickingHelper, WidgetHelper):
          - Middle mouse button pans the camera
          - Right mouse button dollys the camera.
          - SHIFT Right Mouse triggers pick events
+
         """
         self._style = vtk.vtkInteractorStyleImage()
         return self.update_style()
 
     def enable_joystick_style(self):
-        """ sets the interactive style to joystick
+        """Set the interactive style to joystick.
 
-        allows the user to move (rotate, pan, etc.) the camera, the point of
+        It allows the user to move (rotate, pan, etc.) the camera, the point of
         view for the scene.  The position of the mouse relative to the center of
         the scene determines the speed at which the camera moves, and the speed
         of the mouse movement determines the acceleration of the camera, so the
@@ -441,34 +458,37 @@ class BasePlotter(PickingHelper, WidgetHelper):
         for zooming, the middle button for panning, and ctrl + left button for
         spinning.  (With fewer mouse buttons, ctrl + shift + left button is
         for zooming, and shift + left button is for panning.)
+
         """
         self._style = vtk.vtkInteractorStyleJoystickCamera()
         return self.update_style()
 
     def enable_zoom_style(self):
-        """ sets the interactive style to rubber band zoom
+        """Set the interactive style to rubber band zoom.
 
         This interactor style allows the user to draw a rectangle in the render
         window using the left mouse button.  When the mouse button is released,
         the current camera zooms by an amount determined from the shorter side
         of the drawn rectangle.
+
         """
         self._style = vtk.vtkInteractorStyleRubberBandZoom()
         return self.update_style()
 
     def enable_terrain_style(self):
-        """ sets the interactive style to terrain
+        """Set the interactive style to terrain.
 
         Used to manipulate a camera which is viewing a scene with a natural
         view up, e.g., terrain. The camera in such a scene is manipulated by
         specifying azimuth (angle around the view up vector) and elevation
         (the angle from the horizon).
+
         """
         self._style = vtk.vtkInteractorStyleTerrain()
         return self.update_style()
 
     def enable_rubber_band_style(self):
-        """ sets the interactive style to rubber band picking
+        """Set the interactive style to rubber band picking.
 
         This interactor style allows the user to draw a rectangle in the render
         window by hitting 'r' and then using the left mouse button.
@@ -477,12 +497,13 @@ class BasePlotter(PickingHelper, WidgetHelper):
         be a vtkAreaPicker it will operate on the entire selection rectangle.
         When the 'p' key is hit the above pick operation occurs on a 1x1
         rectangle. In other respects it behaves the same as its parent class.
+
         """
         self._style = vtk.vtkInteractorStyleRubberBandPick()
         return self.update_style()
 
     def set_focus(self, point):
-        """ sets focus to a point """
+        """Set focus to a point."""
         if isinstance(point, np.ndarray):
             if point.ndim != 1:
                 point = point.ravel()
@@ -490,7 +511,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self._render()
 
     def set_position(self, point, reset=False):
-        """ sets camera position to a point """
+        """Set camera position to a point."""
         if isinstance(point, np.ndarray):
             if point.ndim != 1:
                 point = point.ravel()
@@ -501,7 +522,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self._render()
 
     def set_viewup(self, vector):
-        """ sets camera viewup vector """
+        """Set camera viewup vector."""
         if isinstance(vector, np.ndarray):
             if vector.ndim != 1:
                 vector = vector.ravel()
@@ -509,7 +530,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self._render()
 
     def _render(self):
-        """ redraws render window if the render window exists """
+        """Redraw the render window if it exists."""
         if hasattr(self, 'ren_win'):
             if hasattr(self, 'render_trigger'):
                 self.render_trigger.emit()
@@ -520,7 +541,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                  color=None, x_color=None, y_color=None, z_color=None,
                  xlabel='X', ylabel='Y', zlabel='Z', labels_off=False,
                  box=None, box_args=None):
-        """ Add an interactive axes widget """
+        """Add an interactive axes widget."""
         if interactive is None:
             interactive = rcParams['interactive']
         if hasattr(self, 'axes_widget'):
@@ -551,26 +572,25 @@ class BasePlotter(PickingHelper, WidgetHelper):
         return
 
     def hide_axes(self):
-        """Hide the axes orientation widget"""
+        """Hide the axes orientation widget."""
         if hasattr(self, 'axes_widget'):
             self.axes_widget.EnabledOff()
 
     def show_axes(self):
-        """Show the axes orientation widget"""
+        """Show the axes orientation widget."""
         if hasattr(self, 'axes_widget'):
             self.axes_widget.EnabledOn()
         else:
             self.add_axes()
 
     def isometric_view_interactive(self):
-        """ sets the current interactive render window to isometric view """
+        """Set the current interactive render window to isometric view."""
         interactor = self.iren.GetInteractorStyle()
         renderer = interactor.GetCurrentRenderer()
         renderer.view_isometric()
 
     def update(self, stime=1, force_redraw=True):
-        """
-        Update window, redraw, process messages query
+        """Update window, redraw, process messages query.
 
         Parameters
         ----------
@@ -580,8 +600,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         force_redraw : bool, optional
             Call vtkRenderWindowInteractor.Render() immediately.
-        """
 
+        """
         if stime <= 0:
             stime = 1
 
@@ -618,9 +638,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
                  loc=None, culling=None, rgb=False, categories=False,
                  use_transparency=False, below_color=None, above_color=None,
                  annotations=None, pickable=True, preference="point", **kwargs):
-        """
-        Adds any PyVista/VTK mesh or dataset that PyVista can wrap to the
-        scene. This method using a mesh representation to view the surfaces
+        """Add any PyVista/VTK mesh or dataset that PyVista can wrap to the scene.
+
+        This method is using a mesh representation to view the surfaces
         and/or geometry of datasets. For volume rendering, see
         :func:`pyvista.BasePlotter.add_volume`.
 
@@ -818,10 +838,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         pickable : bool
             Set whether this mesh is pickable
 
-        Returns
-        -------
+        Return
+        ------
         actor: vtk.vtkActor
             VTK actor of the mesh.
+
         """
         # Convert the VTK data object to a pyvista wrapped object if neccessary
         if not is_pyvista_dataset(mesh):
@@ -1274,8 +1295,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                    blending='composite', mapper='fixed_point',
                    stitle=None, scalar_bar_args=None, show_scalar_bar=None,
                    annotations=None, pickable=True, preference="point", **kwargs):
-        """
-        Adds a volume, rendered using a fixed point ray cast mapper by default.
+        """Add a volume, rendered using a fixed point ray cast mapper by default.
 
         Requires a 3D :class:`numpy.ndarray` or :class:`pyvista.UniformGrid`.
 
@@ -1388,12 +1408,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
             scalar range to annotate on the scalar bar and the values are the
             the string annotations.
 
-        Returns
-        -------
+        Return
+        ------
         actor: vtk.vtkVolume
             VTK volume of the input data.
-        """
 
+        """
         # Handle default arguments
 
         if name is None:
@@ -1657,6 +1677,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         name : str, optional
             The title of the scalar bar to update
+
         """
         if isinstance(clim, float) or isinstance(clim, int):
             clim = [-clim, clim]
@@ -1683,61 +1704,64 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     @property
     def camera_set(self):
-        """ Returns if the camera of the active renderer has been set """
+        """Return if the camera of the active renderer has been set."""
         return self.renderer.camera_set
 
     def get_default_cam_pos(self, negative=False):
-        """ Return the default camera position of the active renderer """
+        """Return the default camera position of the active renderer."""
         return self.renderer.get_default_cam_pos(negative=negative)
 
     @camera_set.setter
     def camera_set(self, is_set):
-        """ Sets if the camera has been set on the active renderer"""
+        """Set if the camera has been set on the active renderer."""
         self.renderer.camera_set = is_set
 
     @property
     def renderer(self):
-        """ simply returns the active renderer """
+        """Return the active renderer."""
         return self.renderers[self._active_renderer_index]
 
     @property
     def bounds(self):
-        """ Returns the bounds of the active renderer """
+        """Return the bounds of the active renderer."""
         return self.renderer.bounds
 
     @property
     def length(self):
-        """Returns the length of the diagonal of the bounding box of the scene
-        """
+        """Return the length of the diagonal of the bounding box of the scene."""
         return pyvista.Box(self.bounds).length
 
     @property
     def center(self):
-        """ Returns the center of the active renderer """
+        """Return the center of the active renderer."""
         return self.renderer.center
 
     def update_bounds_axes(self):
-        """ Update the bounds of the active renderer """
+        """Update the bounds of the active renderer."""
         return self.renderer.update_bounds_axes()
 
     @property
     def _scalar_bar_slots(self):
+        """Return the scalar bar slots of the active renderer."""
         return self.renderer._scalar_bar_slots
 
     @property
     def _scalar_bar_slot_lookup(self):
+        """Return the scalar bar slot lookup of the active renderer."""
         return self.renderer._scalar_bar_slot_lookup
 
     @_scalar_bar_slots.setter
     def _scalar_bar_slots(self, value):
+        """Set the scalar bar slots of the active renderer."""
         self.renderer._scalar_bar_slots = value
 
     @_scalar_bar_slot_lookup.setter
     def _scalar_bar_slot_lookup(self, value):
+        """Set the scalar bar slot lookup of the active renderer."""
         self.renderer._scalar_bar_slot_lookup = value
 
     def clear(self):
-        """ Clears plot by removing all actors and properties """
+        """Clear plot by removing all actors and properties."""
         for renderer in self.renderers:
             renderer.RemoveAllViewProps()
         self._scalar_bar_slots = set(range(MAX_N_COLOR_BARS))
@@ -1748,8 +1772,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self._scalar_bar_widgets = {}
 
     def remove_actor(self, actor, reset_camera=False):
-        """
-        Removes an actor from the Plotter.
+        """Remove an actor from the Plotter.
 
         Parameters
         ----------
@@ -1764,6 +1787,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         success : bool
             True when actor removed.  False when actor has not been
             removed.
+
         """
         for renderer in self.renderers:
             renderer.remove_actor(actor, reset_camera)
@@ -1771,9 +1795,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     def add_actor(self, uinput, reset_camera=False, name=None, loc=None,
                   culling=False, pickable=True):
-        """
-        Adds an actor to render window.  Creates an actor if input is
-        a mapper.
+        """Add an actor to render window.
+        
+        Creates an actor if input is a mapper.
 
         Parameters
         ----------
@@ -1810,8 +1834,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                                   name=name, culling=culling, pickable=pickable)
 
     def loc_to_index(self, loc):
-        """
-        Return index of the render window given a location index.
+        """Return index of the render window given a location index.
 
         Parameters
         ----------
@@ -1819,8 +1842,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Index of the renderer to add the actor to.  For example,
             ``loc=2`` or ``loc=(1, 1)``.
 
-        Returns
-        -------
+        Return
+        ------
         idx : int
             Index of the render window.
 
@@ -1843,8 +1866,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             return idxs[index_row, index_column]
 
     def index_to_loc(self, index):
-        """Convert a 1D index location to the 2D location on the plotting grid
-        """
+        """Convert a 1D index location to the 2D location on the plotting grid."""
         if len(self.shape) == 1:
             return index
         sz = int(self.shape[0] * self.shape[1])
@@ -1857,19 +1879,21 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     @property
     def camera(self):
-        """ The active camera of the active renderer """
+        """Return the active camera of the active renderer."""
         return self.renderer.camera
 
     @camera.setter
     def camera(self, camera):
-        """Set the active camera for the rendering scene"""
+        """Set the active camera for the rendering scene."""
         self.renderer.camera = camera
 
 
     def enable_parallel_projection(self):
-        """Set use parallel projection. The camera will have a parallel
-        projection. Parallel projection is often useful when viewing images or
-        2D datasets.
+        """Enable parallel projection.
+
+        The camera will have a parallel projection. Parallel projection is
+        often useful when viewing images or 2D datasets.
+
         """
         return self.renderer.enable_parallel_projection()
 
@@ -1881,8 +1905,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def add_axes_at_origin(self, x_color=None, y_color=None, z_color=None,
                            xlabel='X', ylabel='Y', zlabel='Z', line_width=2,
                            labels_off=False, loc=None):
-        """
-        Add axes actor at the origin of a render window.
+        """Add axes actor at the origin of a render window.
 
         Parameters
         ----------
@@ -1891,10 +1914,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
             ``loc=2`` or ``loc=(1, 1)``.  When None, defaults to the
             active render window.
 
-        Returns
-        --------
+        Return
+        ------
         marker_actor : vtk.vtkAxesActor
             vtkAxesActor actor
+
         """
         kwargs = locals()
         _ = kwargs.pop('self')
@@ -1911,9 +1935,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
                     use_2d=False, grid=None, location='closest', ticks=None,
                     all_edges=False, corner_factor=0.5, fmt=None,
                     minor_ticks=False, loc=None, padding=0.0):
-        """
-        Adds bounds axes.  Shows the bounds of the most recent input
-        mesh unless mesh is specified.
+        """Add bounds axes.
+
+        Shows the bounds of the most recent input mesh unless mesh is specified.
 
         Parameters
         ----------
@@ -2016,8 +2040,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
             the datasets in the scene from the axes annotations. Defaults to
             have no padding
 
-        Returns
-        -------
+        Return
+        ------
         cube_axes_actor : vtk.vtkCubeAxesActor
             Bounds actor
 
@@ -2030,6 +2054,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> _ = plotter.add_mesh(mesh)
         >>> _ = plotter.show_bounds(grid='front', location='outer', all_edges=True)
         >>> plotter.show() # doctest:+SKIP
+
         """
         kwargs = locals()
         _ = kwargs.pop('self')
@@ -2039,7 +2064,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         renderer.show_bounds(**kwargs)
 
     def add_bounds_axes(self, *args, **kwargs):
-        """Deprecated"""
+        """Add bounds axes.
+
+        DEPRECATED: Please use ``show_bounds`` or ``show_grid``.
+
+        """
         logging.warning('`add_bounds_axes` is deprecated. Use `show_bounds` or `show_grid`.')
         return self.show_bounds(*args, **kwargs)
 
@@ -2047,10 +2076,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
                          opacity=1.0, render_lines_as_tubes=False,
                          lighting=None, reset_camera=None, outline=True,
                          culling='front', loc=None):
-        """
-        Adds an unlabeled and unticked box at the boundaries of
-        plot.  Useful for when wanting to plot outer grids while
-        still retaining all edges of the boundary.
+        """Add an unlabeled and unticked box at the boundaries of the plot.
+
+        Useful for when wanting to plot outer grids while still retaining
+        all edges of the boundary.
 
         Parameters
         ----------
@@ -2091,8 +2120,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         return renderer.add_bounding_box(**kwargs)
 
     def remove_bounding_box(self, loc=None):
-        """
-        Removes bounding box from the active renderer.
+        """Remove bounding box from the active renderer.
 
         Parameters
         ----------
@@ -2100,14 +2128,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Index of the renderer to add the actor to.  For example,
             ``loc=2`` or ``loc=(1, 1)``.  If None, selects the last
             active Renderer.
+
         """
         self._active_renderer_index = self.loc_to_index(loc)
         renderer = self.renderers[self._active_renderer_index]
         renderer.remove_bounding_box()
 
     def remove_bounds_axes(self, loc=None):
-        """
-        Removes bounds axes from the active renderer.
+        """Remove bounds axes from the active renderer.
 
         Parameters
         ----------
@@ -2115,14 +2143,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Index of the renderer to add the actor to.  For example,
             ``loc=2`` or ``loc=(1, 1)``.  If None, selects the last
             active Renderer.
+
         """
         self._active_renderer_index = self.loc_to_index(loc)
         renderer = self.renderers[self._active_renderer_index]
         renderer.remove_bounds_axes()
 
     def subplot(self, index_row, index_column=None):
-        """
-        Sets the active subplot.
+        """Set the active subplot.
 
         Parameters
         ----------
@@ -2144,8 +2172,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self._active_renderer_index = self.loc_to_index((index_row, index_column))
 
     def link_views(self, views=0):
-        """
-        Links the views' cameras.
+        """Link the views' cameras.
 
         Parameters
         ----------
@@ -2167,8 +2194,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                             '{} is given'.format(type(views)))
 
     def unlink_views(self, views=None):
-        """
-        Unlinks the views' cameras.
+        """Unlink the views' cameras.
 
         Parameters
         ----------
@@ -2194,11 +2220,13 @@ class BasePlotter(PickingHelper, WidgetHelper):
                             '{} is given'.format(type(views)))
 
     def show_grid(self, **kwargs):
-        """
+        """Show gridlines and axes labels.
+
         A wrapped implementation of ``show_bounds`` to change default
         behaviour to use gridlines and showing the axes labels on the outer
         edges. This is intended to be silimar to ``matplotlib``'s ``grid``
         function.
+
         """
         kwargs.setdefault('grid', 'back')
         kwargs.setdefault('location', 'outer')
@@ -2206,8 +2234,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         return self.show_bounds(**kwargs)
 
     def set_scale(self, xscale=None, yscale=None, zscale=None, reset_camera=True):
-        """
-        Scale all the datasets in the scene of the active renderer.
+        """Scale all the datasets in the scene of the active renderer.
 
         Scaling in performed independently on the X, Y and Z axis.
         A scale of zero is illegal and will be replaced with one.
@@ -2231,7 +2258,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     @property
     def scale(self):
-        """ The scaling of the active renderer. """
+        """Return the scaling of the active renderer."""
         return self.renderer.scale
 
 
@@ -2245,9 +2272,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                        outline=False, nan_annotation=False,
                        below_label=None, above_label=None,
                        background_color=None, n_colors=None):
-        """
-        Creates scalar bar using the ranges as set by the last input
-        mesh.
+        """Create scalar bar using the ranges as set by the last input mesh.
 
         Parameters
         ----------
@@ -2327,7 +2352,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         -----
         Setting title_font_size, or label_font_size disables automatic font
         sizing for both the title and label.
-
 
         """
         if font_family is None:
@@ -2548,8 +2572,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.add_actor(self.scalar_bar, reset_camera=False, pickable=False)
 
     def update_scalars(self, scalars, mesh=None, render=True):
-        """
-        Updates scalars of the an object in the plotter.
+        """Update scalars of an object in the plotter.
 
         Parameters
         ----------
@@ -2608,8 +2631,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             self.ren_win.Render()
 
     def update_coordinates(self, points, mesh=None, render=True):
-        """
-        Updates the points of the an object in the plotter.
+        """Update the points of an object in the plotter.
 
         Parameters
         ----------
@@ -2633,7 +2655,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             self._render()
 
     def close(self):
-        """ closes render window """
+        """Close the render window."""
         # must close out widgets first
         super(BasePlotter, self).close()
 
@@ -2673,6 +2695,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 pass
 
     def deep_clean(self):
+        """Clean the plotter of the memory."""
         for renderer in self.renderers:
             renderer.deep_clean()
         # Do not remove the renderers on the clean
@@ -2681,8 +2704,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     def add_text(self, text, position='upper_left', font_size=18, color=None,
                  font=None, shadow=False, name=None, loc=None, viewport=False):
-        """
-        Adds text to plot object in the top left corner by default
+        """Add text to plot object in the top left corner by default.
 
         Parameters
         ----------
@@ -2722,8 +2744,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
             the normalized viewport coordinate system (values between 0.0
             and 1.0 and support for HiDPI).
 
-        Returns
-        -------
+        Return
+        ------
         textActor : vtk.vtkTextActor
             Text actor added to plot
 
@@ -2789,8 +2811,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         return self.textActor
 
     def open_movie(self, filename, framerate=24):
-        """
-        Establishes a connection to the ffmpeg writer
+        """Establish a connection to the ffmpeg writer.
 
         Parameters
         ----------
@@ -2807,8 +2828,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.mwriter = imageio.get_writer(filename, fps=framerate)
 
     def open_gif(self, filename):
-        """
-        Open a gif file.
+        """Open a gif file.
 
         Parameters
         ----------
@@ -2824,20 +2844,20 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.mwriter = imageio.get_writer(filename, mode='I')
 
     def write_frame(self):
-        """ Writes a single frame to the movie file """
+        """Write a single frame to the movie file."""
         if not hasattr(self, 'mwriter'):
             raise AssertionError('This plotter has not opened a movie or GIF file.')
         self.mwriter.append_data(self.image)
 
     @property
     def window_size(self):
-        """ returns render window size """
+        """Return the render window size."""
         return list(self.ren_win.GetSize())
 
 
     @window_size.setter
     def window_size(self, window_size):
-        """ set the render window size """
+        """Set the render window size."""
         self.ren_win.SetSize(window_size[0], window_size[1])
 
     def _run_image_filter(self, ifilter):
@@ -2856,7 +2876,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def get_image_depth(self,
                         fill_value=np.nan,
                         reset_camera_clipping_range=True):
-        """ Returns a depth image representing current render window
+        """Return a depth image representing current render window.
 
         Parameters
         ----------
@@ -2867,8 +2887,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
         reset_camera_clipping_range : bool
             Reset the camera clipping range to include data in view?
 
-        Returns
-        -------
+        Return
+        ------
         image_depth : numpy.ndarray
             Image of depth values from camera orthogonal to image plane
 
@@ -2915,13 +2935,17 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     @property
     def image_depth(self):
-        """Helper attribute for ``get_image_depth``"""
+        """Return a depth image representing current render window.
+
+        Helper attribute for ``get_image_depth``.
+
+        """
         return self.get_image_depth()
 
 
     @property
     def image(self):
-        """ Returns an image array of current render window """
+        """Return an image array of current render window."""
         if not hasattr(self, 'ren_win') and hasattr(self, 'last_image'):
             return self.last_image
         ifilter = vtk.vtkWindowToImageFilter()
@@ -2934,16 +2958,15 @@ class BasePlotter(PickingHelper, WidgetHelper):
         return self._run_image_filter(ifilter)
 
     def enable_eye_dome_lighting(self):
-        """Enable eye dome lighting (EDL) for active renderer"""
+        """Enable eye dome lighting (EDL) for the active renderer."""
         return self.renderer.enable_eye_dome_lighting()
 
     def disable_eye_dome_lighting(self):
-        """Disable eye dome lighting (EDL) for active renderer"""
+        """Disable eye dome lighting (EDL) for the active renderer."""
         return self.renderer.disable_eye_dome_lighting()
 
     def add_lines(self, lines, color=(1, 1, 1), width=5, label=None, name=None):
-        """
-        Adds lines to the plotting object.
+        """Add lines to the plotting object.
 
         Parameters
         ----------
@@ -2968,8 +2991,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
             If an actor of this name already exists in the rendering window, it
             will be replaced by the new actor.
 
-        Returns
-        -------
+        Return
+        ------
         actor : vtk.vtkActor
             Lines actor.
 
@@ -3005,7 +3028,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         return self.scalar_bar
 
     def remove_scalar_bar(self):
-        """ Removes scalar bar """
+        """Remove the scalar bar."""
         if hasattr(self, 'scalar_bar'):
             self.remove_actor(self.scalar_bar, reset_camera=False)
 
@@ -3018,9 +3041,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                          fill_shape=True, margin=3, shape_opacity=1.0,
                          pickable=False, render_points_as_spheres=False,
                          tolerance=0.001):
-        """
-        Creates a point actor with one label from list labels assigned to
-        each point.
+        """Create a point actor with one label from list labels assigned to each point.
 
         Parameters
         ----------
@@ -3096,8 +3117,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
             space to display space during rendering introduces numerical
             round-off.
 
-        Returns
-        -------
+        Return
+        ------
         labelMapper : vtk.vtkvtkLabeledDataMapper
             VTK label mapper.  Can be used to change properties of the labels.
 
@@ -3195,8 +3216,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
 
     def add_point_scalar_labels(self, points, labels, fmt=None, preamble='', **kwargs):
-        """Wrapper for :func:`pyvista.BasePlotter.add_point_labels` that will label
-        points from a dataset with their scalar values.
+        """Label the points from a dataset with their scalar values.
+
+        Wrapper for :func:`pyvista.BasePlotter.add_point_labels`.
 
         Parameters
         ----------
@@ -3208,6 +3230,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         fmt : str
             String formatter used to format numerical data
+
         """
         if not is_pyvista_dataset(points):
             raise TypeError('input points must be a pyvista dataset, not: {}'.format(type(points)))
@@ -3224,12 +3247,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
 
     def add_points(self, points, **kwargs):
-        """ Add points to a mesh """
+        """Add points to a mesh."""
         kwargs['style'] = 'points'
         self.add_mesh(points, **kwargs)
 
     def add_arrows(self, cent, direction, mag=1, **kwargs):
-        """ Adds arrows to plotting object """
+        """Add arrows to plotting object."""
         direction = direction.copy()
         if cent.ndim != 2:
             cent = cent.reshape((-1, 3))
@@ -3258,7 +3281,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     @staticmethod
     def _save_image(image, filename, return_img=None):
-        """Internal helper for saving a NumPy image array"""
+        """Save a NumPy image array.
+
+        This is an internal helper.
+
+        """
         if not image.size:
             raise Exception('Empty image.  Have you run plot() first?')
         # write screenshot to file
@@ -3276,8 +3303,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
 
     def save_graphic(self, filename, title='PyVista Export', raster=True, painter=True):
-        """Save a screenshot of the rendering window as a graphic file:
-        '.svg', '.eps', '.ps', '.pdf', '.tex'
+        """Save a screenshot of the rendering window as a graphic file.
+
+        The supported formats are: '.svg', '.eps', '.ps', '.pdf', '.tex'
+
         """
         if not hasattr(self, 'ren_win'):
             raise AttributeError('This plotter is closed and unable to save a screenshot.')
@@ -3310,8 +3339,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     def screenshot(self, filename=None, transparent_background=None,
                    return_img=None, window_size=None):
-        """
-        Takes screenshot at current camera position
+        """Take screenshot at current camera position.
 
         Parameters
         ----------
@@ -3325,8 +3353,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
             If a string filename is given and this is true, a NumPy array of
             the image will be returned.
 
-        Returns
-        -------
+        Return
+        ------
         img :  numpy.ndarray
             Array containing pixel RGB and alpha.  Sized:
             [Window height x Window width x 3] for transparent_background=False
@@ -3339,6 +3367,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> plotter = pyvista.Plotter()
         >>> actor = plotter.add_mesh(sphere)
         >>> plotter.screenshot('screenshot.png') # doctest:+SKIP
+
         """
         if window_size is not None:
             self.window_size = window_size
@@ -3373,9 +3402,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     def add_legend(self, labels=None, bcolor=(0.5, 0.5, 0.5), border=False,
                    size=None, name=None):
-        """
-        Adds a legend to render window.  Entries must be a list
-        containing one string and color entry for each item.
+        """Add a legend to render window.
+
+        Entries must be a list containing one string and color entry for each
+        item.
 
         Parameters
         ----------
@@ -3411,8 +3441,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
             If an actor of this name already exists in the rendering window, it
             will be replaced by the new actor.
 
-        Returns
-        -------
+        Return
+        ------
         legend : vtk.vtkLegendBoxActor
             Actor for the legend.
 
@@ -3442,6 +3472,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> _ = plotter.add_mesh(othermesh, 'k')
         >>> _ = plotter.add_legend(legend_entries)
         >>> plotter.show() # doctest:+SKIP
+
         """
         self.legend = vtk.vtkLegendBoxActor()
 
@@ -3483,71 +3514,78 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     @property
     def camera_position(self):
-        """ Returns camera position of the active render window """
+        """Return camera position of the active render window."""
         return self.renderers[self._active_renderer_index].camera_position
 
     @camera_position.setter
     def camera_position(self, camera_location):
-        """ Set camera position of the active render window """
+        """Set camera position of the active render window."""
         self.renderers[self._active_renderer_index].camera_position = camera_location
 
     def reset_camera(self):
-        """
-        Reset camera so it slides along the vector defined from camera
-        position to focal point until all of the actors can be seen.
+        """Reset the camera of the active render window.
+
+        The camera slides along the vector defined from camera position to focal point
+        until all of the actors can be seen.
+
         """
         self.renderers[self._active_renderer_index].reset_camera()
         self._render()
 
     def isometric_view(self):
-        """DEPRECATED: Please use ``view_isometric``"""
+        """Reset the camera to a default isometric view.
+
+        DEPRECATED: Please use ``view_isometric``.
+
+        """
         return self.view_isometric()
 
     def view_isometric(self, negative=False):
-        """
-        Resets the camera to a default isometric view showing all the
-        actors in the scene.
+        """Reset the camera to a default isometric view.
+
+        The view will show all the actors in the scene.
+
         """
         return self.renderer.view_isometric(negative=negative)
 
     def view_vector(self, vector, viewup=None):
+        """Set the view vector."""
         return self.renderer.view_vector(vector, viewup=viewup)
 
     def view_xy(self, negative=False):
-        """View the XY plane"""
+        """View the XY plane."""
         return self.renderer.view_xy(negative=negative)
 
     def view_yx(self, negative=False):
-        """View the YX plane"""
+        """View the YX plane."""
         return self.renderer.view_yx(negative=negative)
 
     def view_xz(self, negative=False):
-        """View the XZ plane"""
+        """View the XZ plane."""
         return self.renderer.view_xz(negative=negative)
 
     def view_zx(self, negative=False):
-        """View the ZX plane"""
+        """View the ZX plane."""
         return self.renderer.view_zx(negative=negative)
 
     def view_yz(self, negative=False):
-        """View the YZ plane"""
+        """View the YZ plane."""
         return self.renderer.view_yz(negative=negative)
 
     def view_zy(self, negative=False):
-        """View the ZY plane"""
+        """View the ZY plane."""
         return self.renderer.view_zy(negative=negative)
 
     def disable(self):
-        """Disable this renderer's camera from being interactive"""
+        """Disable this renderer's camera from being interactive."""
         return self.renderer.disable()
 
     def enable(self):
-        """Enable this renderer's camera to be interactive"""
+        """Enable this renderer's camera to be interactive."""
         return self.renderer.enable()
 
     def set_background(self, color, loc='all', top=None):
-        """
-        Sets background color
+        """Set the background color.
 
         Parameters
         ----------
@@ -3595,23 +3633,23 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     @property
     def background_color(self):
-        """ Returns background color of the first render window """
+        """Return the background color of the first render window."""
         return self.renderers[0].GetBackground()
 
     @background_color.setter
     def background_color(self, color):
-        """ Sets the background color of all the render windows """
+        """Set the background color of all the render windows."""
         self.set_background(color)
 
     def remove_legend(self):
-        """ Removes legend actor """
+        """Remove the legend actor."""
         if hasattr(self, 'legend'):
             self.remove_actor(self.legend, reset_camera=False)
             self._render()
 
 
     def generate_orbital_path(self, factor=3., n_points=20, viewup=None, shift=0.0):
-        """Genrates an orbital path around the data scene
+        """Generate an orbital path around the data scene.
 
         Parameters
         ----------
@@ -3626,6 +3664,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         shift : float, optional
             shift the plane up/down from the center of the scene by this amount
+
         """
         if viewup is None:
             viewup = rcParams['camera']['viewup']
@@ -3640,9 +3679,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
 
     def fly_to(self, point):
-        """Given a position point, move the current camera's focal point to that
-        point. The movement is animated over the number of frames specified in
+        """Move the current camera's focal point to a position point.
+
+        The movement is animated over the number of frames specified in
         NumberOfFlyFrames. The LOD desired frame rate is used.
+
         """
         if not hasattr(self, 'iren'):
             raise AttributeError('This plotter does not have an interactive window')
@@ -3651,7 +3692,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     def orbit_on_path(self, path=None, focus=None, step=0.5, viewup=None,
                       bkg=True, write_frames=False):
-        """Orbit on the given path focusing on the focus point
+        """Orbit on the given path focusing on the focus point.
 
         Parameters
         ----------
@@ -3671,6 +3712,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         write_frames : bool
             Assume a file is open and write a frame on each camera view during
             the orbit.
+
         """
         if focus is None:
             focus = self.center
@@ -3686,7 +3728,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.camera.SetThickness(path.length)
 
         def orbit():
-            """Internal thread for running the orbit"""
+            """Define the internal thread for running the orbit."""
             for point in points:
                 self.set_position(point)
                 self.set_focus(focus)
@@ -3707,9 +3749,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
 
     def export_vtkjs(self, filename, compress_arrays=False):
-        """
-        Export the current rendering scene as a VTKjs scene for
-        rendering in a web browser
+        """Export the current rendering scene as a VTKjs scene.
+
+        It can be used for rendering in a web browser.
+
         """
         if not hasattr(self, 'ren_win'):
             raise RuntimeError('Export must be called before showing/closing the scene.')
@@ -3722,7 +3765,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
 
     def export_obj(self, filename):
-        """Export scene to OBJ format"""
+        """Export scene to OBJ format."""
         if not hasattr(self, "ren_win"):
             raise RuntimeError("This plotter must still have a render window open.")
         if isinstance(pyvista.FIGURE_PATH, str) and not os.path.isabs(filename):
@@ -3736,13 +3779,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
 
     def __del__(self):
+        """Delete the plotter."""
         self.close()
         self.deep_clean()
         del self.renderers
 
 
 class Plotter(BasePlotter):
-    """ Plotting object to display vtk meshes or numpy arrays.
+    """Plotting object to display vtk meshes or numpy arrays.
 
     Example
     -------
@@ -3800,6 +3844,7 @@ class Plotter(BasePlotter):
         If True, enable polygon smothing
 
     """
+
     last_update_time = 0.0
     q_pressed = False
     right_timer_id = -1
@@ -3809,9 +3854,7 @@ class Plotter(BasePlotter):
                  window_size=None, multi_samples=None, line_smoothing=False,
                  point_smoothing=False, polygon_smoothing=False,
                  splitting_position=None, title=None):
-        """
-        Initialize a vtk plotting object
-        """
+        """Initialize a vtk plotting object."""
         super(Plotter, self).__init__(shape=shape, border=border,
                                       border_color=border_color,
                                       border_width=border_width,
@@ -3820,7 +3863,7 @@ class Plotter(BasePlotter):
         log.debug('Initializing')
 
         def on_timer(iren, event_id):
-            """ Exit application if interactive renderer stops """
+            """Exit application if interactive renderer stops."""
             if event_id == 'TimerEvent':
                 self.iren.TerminateApp()
 
@@ -3883,8 +3926,7 @@ class Plotter(BasePlotter):
              auto_close=None, interactive_update=False, full_screen=False,
              screenshot=False, return_img=False, use_panel=None, cpos=None,
              height=400):
-        """
-        Creates plotting window
+        """Create a plotting window.
 
         Parameters
         ----------
@@ -3919,8 +3961,8 @@ class Plotter(BasePlotter):
         height : int, optional
             height for panel pane. Only used with panel.
 
-        Returns
-        -------
+        Return
+        ------
         cpos : list
             List of camera position, focal point, and view up
 
@@ -4025,10 +4067,15 @@ class Plotter(BasePlotter):
         return cpos
 
     def plot(self, *args, **kwargs):
-        """ Present for backwards compatibility. Use `show()` instead """
+        """Create a plotting window.
+
+        Present for backwards compatibility.
+        DEPRECATED: Please use `show()` instead.
+
+        """
         logging.warning("`.plot()` is deprecated. Please use `.show()` instead.")
         return self.show(*args, **kwargs)
 
     def render(self):
-        """ renders main window """
+        """Render the main window."""
         self.ren_win.Render()

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -1,3 +1,5 @@
+"""Qt interactive plotter."""
+
 import logging
 import os
 import time
@@ -25,42 +27,59 @@ CLEAR_CAMS_BUTTON_TEXT = 'Clear Cameras'
 # dummy reference for when PyQt5 is not installed (i.e. readthedocs)
 has_pyqt = False
 class QVTKRenderWindowInteractor(object):
+    """Dummy QVTKRenderWindowInteractor class."""
+
     pass
 
 class RangeGroup(object):
+    """Dummy RangeGroup class."""
+
     pass
 
 
 class QDialog(object):
+    """Dummy QFileDialog class."""
+
     pass
 
 
 class QSlider(object):
+    """Dummy QSlider class."""
+
     pass
 
 
 def pyqtSignal(*args, **kwargs):  # pragma: no cover
+    """Declare dummy pyqtSignal function."""
     pass
 
 
 class QHBoxLayout(object):
+    """Dummy QHBoxLayout class."""
+
     pass
 
 
 class QFileDialog(object):
+    """Dummy QFileDialog class."""
+
     pass
 
 
 def pyqtSlot(*args, **kwargs):
-    """dummy function for environments without pyqt5"""
+    """Declare dummy function for environments without pyqt5."""
     return lambda *x: None
 
 
 class QMainWindow(object):
+    """Dummy QMainWindow class."""
+
     pass
 
 
 class QObject(object):
+    """Dummy QObject class."""
+
     pass
 
 
@@ -79,14 +98,17 @@ except ImportError:  # pragma: no cover
 
 
 class FileDialog(QFileDialog):
-    """
-    Generic file query that emits a signal when a file is selected and
+    """Generic file query.
+
+    It emits a signal when a file is selected and
     the dialog was property closed.
     """
+
     dlg_accepted = pyqtSignal(str)
 
     def __init__(self, parent=None, filefilter=None, save_mode=True, show=True,
                  callback=None, directory=False):
+        """Initialize the file dialog."""
         super(FileDialog, self).__init__(parent)
 
         if filefilter is not None:
@@ -109,11 +131,11 @@ class FileDialog(QFileDialog):
             self.show()
 
     def emit_accepted(self):
-        """
-        Sends signal that the file dialog was closed properly.
+        """Send signal that the file dialog was closed properly.
 
         Sends:
         filename
+
         """
         if self.result():
             filename = self.selectedFiles()[0]
@@ -122,11 +144,15 @@ class FileDialog(QFileDialog):
 
 
 class DoubleSlider(QSlider):
-    """
-    Double precision slider from:
+    """Double precision slider.
+    
+    Reference:
     https://gist.github.com/dennis-tra/994a65d6165a328d4eabaadbaedac2cc
+
     """
+
     def __init__(self, *args, **kwargs):
+        """Initialize the double slider."""
         super().__init__(*args, **kwargs)
         self.decimals = 5
         self._max_int = 10 ** self.decimals
@@ -139,15 +165,19 @@ class DoubleSlider(QSlider):
 
     @property
     def _value_range(self):
+        """Return the value range of the slider."""
         return self._max_value - self._min_value
 
     def value(self):
+        """Return the value of the slider."""
         return float(super().value()) / self._max_int * self._value_range + self._min_value
 
     def setValue(self, value):
+        """Set the value of the slider."""
         super().setValue(int((value - self._min_value) / self._value_range * self._max_int))
 
     def setMinimum(self, value):
+        """Set the minimum value of the slider."""
         if value > self._max_value:  # pragma: no cover
             raise ValueError("Minimum limit cannot be higher than maximum")
 
@@ -155,6 +185,7 @@ class DoubleSlider(QSlider):
         self.setValue(self.value())
 
     def setMaximum(self, value):
+        """Set the maximum value of the slider."""
         if value < self._min_value:  # pragma: no cover
             raise ValueError("Minimum limit cannot be higher than maximum")
 
@@ -163,9 +194,11 @@ class DoubleSlider(QSlider):
 
 
 class RangeGroup(QHBoxLayout): # this is redefined from above ... why?
+    """Range group box widget."""
 
     def __init__(self, parent, callback, minimum=0.0, maximum=20.0,
                  value=1.0):
+        """Initialize the range widget."""
         super(RangeGroup, self).__init__(parent)
         self.slider = DoubleSlider(QtCore.Qt.Horizontal)
         self.slider.setTickInterval(0.1)
@@ -188,9 +221,11 @@ class RangeGroup(QHBoxLayout): # this is redefined from above ... why?
         self.spinbox.valueChanged.connect(callback)
 
     def update_spinbox(self, value):
+        """Set the value of the internal spinbox."""
         self.spinbox.setValue(self.slider.value())
 
     def update_value(self, value):
+        """Update the value of the internal slider."""
         # if self.spinbox.value() < self.minimum:
         #     self.spinbox.setValue(self.minimum)
         # elif self.spinbox.value() > self.maximum:
@@ -202,19 +237,23 @@ class RangeGroup(QHBoxLayout): # this is redefined from above ... why?
 
     @property
     def value(self):
+        """Return the value of the internal spinbox."""
         return self.spinbox.value()
 
     @value.setter
     def value(self, new_value):
+        """Set the value of the internal slider."""
         self.slider.setValue(new_value)
 
 
 class ScaleAxesDialog(QDialog):
-    """ Dialog to control axes scaling """
+    """Dialog to control axes scaling."""
+
     accepted = pyqtSignal(float)
     signal_close = pyqtSignal()
 
     def __init__(self, parent, plotter, show=True):
+        """Initialize the scaling dialog."""
         super(ScaleAxesDialog, self).__init__(parent)
         self.setGeometry(300, 300, 50, 50)
         self.setMinimumWidth(500)
@@ -239,14 +278,14 @@ class ScaleAxesDialog(QDialog):
             self.show()
 
     def update_scale(self, value):
-        """ updates the scale of all actors in the plotter """
+        """Update the scale of all actors in the plotter."""
         self.plotter.set_scale(self.x_slider_group.value,
                                self.y_slider_group.value,
                                self.z_slider_group.value)
 
 
 def resample_image(arr, max_size=400):
-    """Resamples a square image to an image of max_size"""
+    """Resample a square image to an image of max_size."""
     dim = np.max(arr.shape[0:2])
     if dim < max_size:
         max_size = dim
@@ -262,7 +301,7 @@ def resample_image(arr, max_size=400):
 
 
 def pad_image(arr, max_size=400):
-    """Pads an image to a square then resamples to max_size"""
+    """Pad an image to a square then resamples to max_size."""
     dim = np.max(arr.shape)
     img = np.zeros((dim, dim, 3), dtype=arr.dtype)
     xl = (dim - arr.shape[0]) // 2
@@ -272,9 +311,9 @@ def pad_image(arr, max_size=400):
 
 
 class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
-    """
-    Extends QVTKRenderWindowInteractor class by adding the methods
-    available to pyvista.Plotter.
+    """Extend QVTKRenderWindowInteractor class.
+
+    This adds the methods available to pyvista.Plotter.
 
     Parameters
     ----------
@@ -298,6 +337,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         If True, enable polygon smothing
 
     """
+
     signal_set_view_vector = pyqtSignal(tuple, tuple)
     signal_reset_camera = pyqtSignal()
     signal_render = pyqtSignal()
@@ -312,7 +352,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
                  multi_samples=None, line_smoothing=False,
                  point_smoothing=False, polygon_smoothing=False,
                  splitting_position=None):
-        """ Initialize Qt interactor """
+        """Initialize Qt interactor."""
         if not has_pyqt:
             raise AssertionError('Requires PyQt5')
         QVTKRenderWindowInteractor.__init__(self, parent)
@@ -372,7 +412,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
 
 
     def add_toolbars(self, main_window):
-
+        """Add the toolbars."""
         def _add_action(tool_bar, key, method):
             action = QAction(key, main_window)
             action.triggered.connect(method)
@@ -407,7 +447,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
 
 
     def save_camera_position(self):
-        """ Saves camera position to saved camera menu for recall """
+        """Save camera position to saved camera menu for recall."""
         self.saved_camera_positions.append(self.camera_position)
         ncam = len(self.saved_camera_positions)
         camera_position = self.camera_position[:]  # py2.7 copy compatibility
@@ -424,7 +464,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
 
 
     def clear_camera_positions(self):
-        """ clears all camera positions """
+        """Clear all camera positions."""
         if hasattr(self, "saved_cameras_tool_bar"):
             for action in self.saved_cameras_tool_bar.actions():
                 if action.text() not in [SAVE_CAM_BUTTON_TEXT, CLEAR_CAMS_BUTTON_TEXT]:
@@ -434,7 +474,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
 
 
     def _close_callback(self):
-        """ Make sure a screenhsot is acquired before closing"""
+        """Make sure a screenhsot is acquired before closing."""
         if self.allow_quit_keypress:
             BasePlotter._close_callback(self)
             self.quit()
@@ -442,45 +482,53 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
 
 
     def quit(self):
-        """Quit application"""
+        """Quit application."""
         BasePlotter.close(self)
         QVTKRenderWindowInteractor.close(self)
 
 
     def reset_camera(self):
+        """Reset the camera."""
         self.signal_reset_camera.emit()
 
 
     def view_vector(self, vector, viewup=None):
+        """Set the view vector."""
         args = [vector, viewup]
         self.signal_view_vector.emit(*args)
 
 
     def _render(self):
-        """ updates the render window """
+        """Update the render window."""
         self.signal_render.emit()
 
 
     def enable_trackball_style(self):
+        """Enable trackball interactor style."""
         self.signal_enable_trackball_style.emit()
 
     def remove_legend(self):
+        """Remove the legend."""
         self.signal_remove_legend.emit()
 
     def set_background(self, color):
+        """Set the background color."""
         self.signal_set_background.emit(color)
 
     def remove_actor(self, actor, reset_camera=None):
+        """Remove an actor."""
         self.signal_remove_actor.emit(actor)
 
 
 
 class BackgroundPlotter(QtInteractor):
+    """Qt interactive plotter."""
 
     ICON_TIME_STEP = 5.0
 
     def __init__(self, show=True, app=None, shape=(1, 1), window_size=None,
                  off_screen=None, **kwargs):
+        """Initialize the qt plotter."""
         if not has_pyqt:
             raise AssertionError('Requires PyQt5')
         self.active = True
@@ -589,18 +637,18 @@ class BackgroundPlotter(QtInteractor):
 
 
     def scale_axes_dialog(self, show=True):
-        """ Open scale axes dialog """
+        """Open scale axes dialog."""
         return ScaleAxesDialog(self.app_window, self, show=show)
 
 
     def _spawn_background_rendering(self, rate=5.0):
-        """
-        Spawns a thread that updates the render window.
+        """Spawn a thread that updates the render window.
 
         Sometimes directly modifiying object data doesn't trigger
         Modified() and upstream objects won't be updated.  This
         ensures the render window stays updated without consuming too
         many resources.
+
         """
         twait = (rate**-1) * 1000.0
         self.render_timer = QTimer(parent=self.app_window)
@@ -610,19 +658,22 @@ class BackgroundPlotter(QtInteractor):
 
 
     def _close_callback(self):
-        """ Make sure a screenhsot is acquired before closing"""
+        """Make sure a screenhsot is acquired before closing."""
         if self.allow_quit_keypress:
             BasePlotter._close_callback(self)
             self.app_window.close()
 
 
     def quit(self):
+        """Quit the plotter."""
         QtInteractor.quit(self)
 
     def close(self):
+        """Close the plotter.""" 
         self.app_window.close()
 
     def add_actor(self, actor, reset_camera=None, name=None, loc=None, culling=False, pickable=True):
+        """Add an actor."""
         actor, prop = super(BackgroundPlotter, self).add_actor(actor,
                                                                reset_camera=reset_camera,
                                                                name=name,
@@ -633,9 +684,7 @@ class BackgroundPlotter(QtInteractor):
         return actor, prop
 
     def update_app_icon(self):
-        """
-        Update the app icon if the user is not trying to resize the window.
-        """
+        """Update the app icon if the user is not trying to resize the window."""
         if os.name == 'nt' or not hasattr(self, '_last_window_size'):  # pragma: no cover
             # DO NOT EVEN ATTEMPT TO UPDATE ICON ON WINDOWS
             return
@@ -672,9 +721,7 @@ class BackgroundPlotter(QtInteractor):
                           callback=self.screenshot)
 
     def _qt_export_vtkjs(self, show=True):
-        """
-        Spawn an save file dialog to export a vtkjs file.
-        """
+        """Spawn an save file dialog to export a vtkjs file."""
         return FileDialog(self.app_window,
                           filefilter=['VTK JS File(*.vtkjs)'],
                           show=show,
@@ -700,23 +747,24 @@ class BackgroundPlotter(QtInteractor):
 
     @property
     def window_size(self):
-        """ returns render window size """
+        """Return render window size."""
         the_size = self.app_window.baseSize()
         return the_size.width(), the_size.height()
 
 
     @window_size.setter
     def window_size(self, window_size):
-        """ set the render window size """
+        """Set the render window size."""
         BasePlotter.window_size.fset(self, window_size)
         self.app_window.setBaseSize(*window_size)
         self.app_window.resize(*window_size)
 
     def __del__(self):  # pragma: no cover
+        """Delete the qt plotter."""
         self.app_window.close()
 
     def add_callback(self, func, interval=1000, count=None):
-        """Add a function that can update the scene in the background
+        """Add a function that can update the scene in the background.
 
         Parameters
         ----------
@@ -727,6 +775,7 @@ class BackgroundPlotter(QtInteractor):
         count : int, optional
             Number of times `func` will be called. If None,
             `func` will be called until the main window is closed.
+
         """
         timer = QTimer(parent=self.app_window)
         timer.timeout.connect(func)
@@ -740,20 +789,27 @@ class BackgroundPlotter(QtInteractor):
 
 
 class MainWindow(QMainWindow):
+    """Convenience MainWindow that manages the application."""
+
     signal_close = pyqtSignal()
 
     def __init__(self, parent=None):
+        """Initialize the main window."""
         super(MainWindow, self).__init__(parent)
 
     def closeEvent(self, event):
+        """Manage the close event."""
         self.signal_close.emit()
         event.accept()
 
 
 class Counter(QObject):
+    """Counter augmented with a Qt timer."""
+
     signal_finished = pyqtSignal()
 
     def __init__(self, count):
+        """Initialize the counter."""
         super(Counter, self).__init__()
         if isinstance(count, int) and count > 0:
             self.count = count
@@ -765,6 +821,7 @@ class Counter(QObject):
 
     @pyqtSlot()
     def decrease(self):
+        """Decrease the count."""
         self.count -= 1
         if self.count <= 0:
             self.signal_finished.emit()

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1,6 +1,5 @@
-"""
-Module containing pyvista implementation of vtkRenderer
-"""
+"""Module containing pyvista implementation of vtkRenderer."""
+
 import collections
 import logging
 from weakref import proxy
@@ -17,8 +16,11 @@ from .tools import create_axes_marker
 
 
 class Renderer(vtkRenderer):
+    """Renderer class."""
+
     def __init__(self, parent, border=True, border_color=(1, 1, 1),
                  border_width=2.0):
+        """Initialize the renderer."""
         super(Renderer, self).__init__()
         self._actors = {}
         self.parent = parent
@@ -36,25 +38,26 @@ class Renderer(vtkRenderer):
             self.add_border(border_color, border_width)
 
     def enable_depth_peeling(self, number_of_peels=5, occlusion_ratio=0.1):
-        """Enables depth peeling."""
+        """Enable depth peeling."""
         self.SetUseDepthPeeling(True)
         self.SetMaximumNumberOfPeels(number_of_peels)
         self.SetOcclusionRatio(occlusion_ratio)
 
     def disable_depth_peeling(self):
-        """Disables depth peeling."""
+        """Disable depth peeling."""
         self.SetUseDepthPeeling(False)
 
     def enable_anti_aliasing(self):
-        """Enables anti-aliasing FXAA"""
+        """Enable anti-aliasing FXAA."""
         self.SetUseFXAA(True)
 
     def disable_anti_aliasing(self):
-        """Disables anti-aliasing FXAA"""
+        """Disable anti-aliasing FXAA."""
         self.SetUseFXAA(False)
 
 
     def add_border(self, color=[1, 1, 1], width=2.0):
+        """Add borders around the frame."""
         points = np.array([[1., 1., 0.],
                            [0., 1., 0.],
                            [0., 0., 0.],
@@ -86,9 +89,9 @@ class Renderer(vtkRenderer):
 
     def add_actor(self, uinput, reset_camera=False, name=None, loc=None,
                   culling=False, pickable=True):
-        """
-        Adds an actor to render window.  Creates an actor if input is
-        a mapper.
+        """Add an actor to render window.
+
+        Creates an actor if input is a mapper.
 
         Parameters
         ----------
@@ -108,8 +111,8 @@ class Renderer(vtkRenderer):
             especially when edges are visible, but can cause flat
             meshes to be partially displayed.  Default False.
 
-        Returns
-        -------
+        Return
+        ------
         actor : vtk.vtkActor
             The actor.
 
@@ -170,13 +173,13 @@ class Renderer(vtkRenderer):
     def add_axes_at_origin(self, x_color=None, y_color=None, z_color=None,
                            xlabel='X', ylabel='Y', zlabel='Z', line_width=2,
                            labels_off=False):
-        """
-        Add axes actor at origin
+        """Add axes actor at origin.
 
-        Returns
-        --------
+        Return
+        ------
         marker_actor : vtk.vtkAxesActor
             vtkAxesActor actor
+
         """
         self.marker_actor = create_axes_marker(line_width=line_width,
             x_color=x_color, y_color=y_color, z_color=z_color,
@@ -194,9 +197,9 @@ class Renderer(vtkRenderer):
                     use_2d=False, grid=None, location='closest', ticks=None,
                     all_edges=False, corner_factor=0.5, loc=None, fmt=None,
                     minor_ticks=False, padding=0.0):
-        """
-        Adds bounds axes.  Shows the bounds of the most recent input
-        mesh unless mesh is specified.
+        """Add bounds axes.
+
+        Shows the bounds of the most recent input mesh unless mesh is specified.
 
         Parameters
         ----------
@@ -299,8 +302,8 @@ class Renderer(vtkRenderer):
             the datasets in the scene from the axes annotations. Defaults to
             have no padding
 
-        Returns
-        -------
+        Return
+        ------
         cube_axes_actor : vtk.vtkCubeAxesActor
             Bounds actor
 
@@ -313,6 +316,7 @@ class Renderer(vtkRenderer):
         >>> _ = plotter.add_mesh(mesh)
         >>> _ = plotter.show_bounds(grid='front', location='outer', all_edges=True)
         >>> plotter.show() # doctest:+SKIP
+
         """
         self.remove_bounds_axes()
 
@@ -472,12 +476,16 @@ class Renderer(vtkRenderer):
         return cube_axes_actor
 
     def add_bounds_axes(self, *args, **kwargs):
-        """Deprecated"""
+        """Add bounds axes.
+
+        DEPRECATED: Please use ``show_bounds`` or ``show_grid``.
+
+        """
         logging.warning('`add_bounds_axes` is deprecated. Use `show_bounds` or `show_grid`.')
         return self.show_bounds(*args, **kwargs)
 
     def remove_bounding_box(self):
-        """ Removes bounding box """
+        """Remove bounding box."""
         if hasattr(self, '_box_object'):
             actor = self.bounding_box_actor
             self.bounding_box_actor = None
@@ -488,10 +496,10 @@ class Renderer(vtkRenderer):
                          opacity=1.0, render_lines_as_tubes=False,
                          lighting=None, reset_camera=None, outline=True,
                          culling='front', loc=None):
-        """
-        Adds an unlabeled and unticked box at the boundaries of
-        plot.  Useful for when wanting to plot outer grids while
-        still retaining all edges of the boundary.
+        """Add an unlabeled and unticked box at the boundaries of plot.
+
+        Useful for when wanting to plot outer grids while still retaining all
+        edges of the boundary.
 
         Parameters
         ----------
@@ -566,20 +574,20 @@ class Renderer(vtkRenderer):
         return self.bounding_box_actor
 
     def remove_bounds_axes(self):
-        """ Removes bounds axes """
+        """Remove bounds axes."""
         if hasattr(self, 'cube_axes_actor'):
             self.remove_actor(self.cube_axes_actor)
 
     @property
     def camera_position(self):
-        """ Returns camera position of active render window """
+        """Return camera position of active render window."""
         return [self.camera.GetPosition(),
                 self.camera.GetFocalPoint(),
                 self.camera.GetViewUp()]
 
     @camera_position.setter
     def camera_position(self, camera_location):
-        """ Set camera position of all active render windows """
+        """Set camera position of all active render windows."""
         if camera_location is None:
             return
 
@@ -613,12 +621,12 @@ class Renderer(vtkRenderer):
 
     @property
     def camera(self):
-        """The active camera for the rendering scene"""
+        """Return the active camera for the rendering scene."""
         return self.GetActiveCamera()
 
     @camera.setter
     def camera(self, camera):
-        """Set the active camera for the rendering scene"""
+        """Set the active camera for the rendering scene."""
         self.SetActiveCamera(camera)
         self.camera_position = [
             camera.GetPosition(),
@@ -628,9 +636,11 @@ class Renderer(vtkRenderer):
 
 
     def enable_parallel_projection(self):
-        """Set use parallel projection. The camera will have a parallel
-        projection. Parallel projection is often useful when viewing images or
-        2D datasets.
+        """Enable parallel projection.
+
+        The camera will have a parallel projection. Parallel projection is
+        often useful when viewing images or 2D datasets.
+
         """
         self.camera.SetParallelProjection(True)
 
@@ -640,8 +650,7 @@ class Renderer(vtkRenderer):
         self.camera.SetParallelProjection(False)
 
     def remove_actor(self, actor, reset_camera=False):
-        """
-        Removes an actor from the Renderer.
+        """Remove an actor from the Renderer.
 
         Parameters
         ----------
@@ -651,11 +660,12 @@ class Renderer(vtkRenderer):
         reset_camera : bool, optional
             Resets camera so all actors can be seen.
 
-        Returns
-        -------
+        Return
+        ------
         success : bool
             True when actor removed.  False when actor has not been
             removed.
+
         """
         name = None
         if isinstance(actor, str):
@@ -701,10 +711,11 @@ class Renderer(vtkRenderer):
         return True
 
     def set_scale(self, xscale=None, yscale=None, zscale=None, reset_camera=True):
-        """
-        Scale all the datasets in the scene.
+        """Scale all the datasets in the scene.
+
         Scaling in performed independently on the X, Y and Z axis.
         A scale of zero is illegal and will be replaced with one.
+
         """
         if xscale is None:
             xscale = self.scale[0]
@@ -725,7 +736,7 @@ class Renderer(vtkRenderer):
 
     @property
     def bounds(self):
-        """ Bounds of all actors present in the rendering window """
+        """Return the bounds of all actors present in the rendering window."""
         the_bounds = np.array([np.inf, -np.inf, np.inf, -np.inf, np.inf, -np.inf])
 
         def _update_bounds(bounds):
@@ -753,7 +764,7 @@ class Renderer(vtkRenderer):
 
     @property
     def center(self):
-        """Center of the bounding box around all data present in the scene"""
+        """Return the center of the bounding box around all data present in the scene."""
         bounds = self.bounds
         x = (bounds[1] + bounds[0])/2
         y = (bounds[3] + bounds[2])/2
@@ -761,9 +772,10 @@ class Renderer(vtkRenderer):
         return [x, y, z]
 
     def get_default_cam_pos(self, negative=False):
-        """
-        Returns the default focal points and viewup. Uses ResetCamera to
-        make a useful view.
+        """Return the default focal points and viewup.
+
+        Uses ResetCamera to make a useful view.
+
         """
         focal_pt = self.center
         if any(np.isnan(focal_pt)):
@@ -776,7 +788,7 @@ class Renderer(vtkRenderer):
         return cpos
 
     def update_bounds_axes(self):
-        """Update the bounds axes of the render window """
+        """Update the bounds axes of the render window."""
         if (hasattr(self, '_box_object') and self._box_object is not None
                 and self.bounding_box_actor is not None):
             if not np.allclose(self._box_object.bounds, self.bounds):
@@ -791,28 +803,35 @@ class Renderer(vtkRenderer):
                 self.cube_axes_actor.SetUse2DMode(False)
 
     def reset_camera(self):
-        """
-        Reset camera so it slides along the vector defined from camera
-        position to focal point until all of the actors can be seen.
+        """Reset the camera of the active render window.
+
+        The camera slides along the vector defined from camera position to focal point
+        until all of the actors can be seen.
+
         """
         self.ResetCamera()
         self.parent._render()
 
     def isometric_view(self):
-        """DEPRECATED: Please use ``view_isometric``"""
+        """Reset the camera to a default isometric view.
+
+        DEPRECATED: Please use ``view_isometric``.
+
+        """
         return self.view_isometric()
 
     def view_isometric(self, negative=False):
-        """
-        Resets the camera to a default isometric view showing all the
-        actors in the scene.
+        """Reset the camera to a default isometric view.
+
+        The view will show all the actors in the scene.
+
         """
         self.camera_position = self.get_default_cam_pos(negative=negative)
         self.camera_set = False
         return self.reset_camera()
 
     def view_vector(self, vector, viewup=None):
-        """Point the camera in the direction of the given vector"""
+        """Point the camera in the direction of the given vector."""
         focal_pt = self.center
         if viewup is None:
             viewup = rcParams['camera']['viewup']
@@ -822,7 +841,7 @@ class Renderer(vtkRenderer):
         return self.reset_camera()
 
     def view_xy(self, negative=False):
-        """View the XY plane"""
+        """View the XY plane."""
         vec = np.array([0,0,1])
         viewup = np.array([0,1,0])
         if negative:
@@ -830,7 +849,7 @@ class Renderer(vtkRenderer):
         return self.view_vector(vec, viewup)
 
     def view_yx(self, negative=False):
-        """View the YX plane"""
+        """View the YX plane."""
         vec = np.array([0,0,-1])
         viewup = np.array([1,0,0])
         if negative:
@@ -838,7 +857,7 @@ class Renderer(vtkRenderer):
         return self.view_vector(vec, viewup)
 
     def view_xz(self, negative=False):
-        """View the XZ plane"""
+        """View the XZ plane."""
         vec = np.array([0,-1,0])
         viewup = np.array([0,0,1])
         if negative:
@@ -846,7 +865,7 @@ class Renderer(vtkRenderer):
         return self.view_vector(vec, viewup)
 
     def view_zx(self, negative=False):
-        """View the ZX plane"""
+        """View the ZX plane."""
         vec = np.array([0,1,0])
         viewup = np.array([1,0,0])
         if negative:
@@ -854,7 +873,7 @@ class Renderer(vtkRenderer):
         return self.view_vector(vec, viewup)
 
     def view_yz(self, negative=False):
-        """View the YZ plane"""
+        """View the YZ plane."""
         vec = np.array([1,0,0])
         viewup = np.array([0,0,1])
         if negative:
@@ -863,7 +882,7 @@ class Renderer(vtkRenderer):
 
 
     def view_zy(self, negative=False):
-        """View the ZY plane"""
+        """View the ZY plane."""
         vec = np.array([-1,0,0])
         viewup = np.array([0,1,0])
         if negative:
@@ -871,15 +890,15 @@ class Renderer(vtkRenderer):
         return self.view_vector(vec, viewup)
 
     def disable(self):
-        """Disable this renderer's camera from being interactive"""
+        """Disable this renderer's camera from being interactive."""
         return self.SetInteractive(0)
 
     def enable(self):
-        """Enable this renderer's camera to be interactive"""
+        """Enable this renderer's camera to be interactive."""
         return self.SetInteractive(1)
 
     def enable_eye_dome_lighting(self):
-        """Enable eye dome lighting (EDL)"""
+        """Enable eye dome lighting (EDL)."""
         if hasattr(self, 'edl_pass'):
             return self
         # create the basic VTK render steps
@@ -895,7 +914,7 @@ class Renderer(vtkRenderer):
         return self.glrenderer
 
     def disable_eye_dome_lighting(self):
-        """Disable eye dome lighting (EDL)"""
+        """Disable eye dome lighting (EDL)."""
         if not hasattr(self, 'edl_pass'):
             return
         self.SetPass(None)
@@ -904,7 +923,7 @@ class Renderer(vtkRenderer):
 
 
     def get_pick_position(self):
-        """Get the pick position/area as x0, y0, x1, y1"""
+        """Get the pick position/area as x0, y0, x1, y1."""
         x0 = int(self.GetPickX1())
         x1 = int(self.GetPickX2())
         y0 = int(self.GetPickY1())
@@ -913,6 +932,7 @@ class Renderer(vtkRenderer):
 
 
     def deep_clean(self):
+        """Clean the renderer of the memory."""
         if hasattr(self, 'cube_axes_actor'):
             del self.cube_axes_actor
         if hasattr(self, 'edl_pass'):
@@ -928,11 +948,12 @@ class Renderer(vtkRenderer):
 
 
     def __del__(self):
+        """Delete the renderer."""
         self.deep_clean()
 
 
 def _remove_mapper_from_plotter(plotter, actor, reset_camera):
-    """removes this actor's mapper from the given plotter's _scalar_bar_mappers"""
+    """Remove this actor's mapper from the given plotter's _scalar_bar_mappers."""
     try:
         mapper = actor.GetMapper()
     except AttributeError:

--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -1,3 +1,4 @@
+"""Module managing different plotting theme parameters."""
 
 import vtk
 
@@ -65,7 +66,7 @@ rcParams = {
 DEFAULT_THEME = dict(rcParams)
 
 def set_plot_theme(theme):
-    """Set the plotting parameters to a predefined theme"""
+    """Set the plotting parameters to a predefined theme."""
     if theme.lower() in ['paraview', 'pv']:
         rcParams['background'] = PARAVIEW_BACKGROUND
         rcParams['cmap'] = 'coolwarm'
@@ -109,8 +110,10 @@ def set_plot_theme(theme):
 
 
 def parse_color(color, opacity=None):
-    """Parses color into a vtk friendly rgb list.
+    """Parse color into a vtk friendly rgb list.
+
     Values returned will be between 0 and 1.
+
     """
     if color is None:
         color = rcParams['color']
@@ -135,7 +138,7 @@ def parse_color(color, opacity=None):
 
 
 def parse_font_family(font_family):
-    """ checks font name """
+    """Check font name."""
     # check font name
     font_family = font_family.lower()
     if font_family not in ['courier', 'times', 'arial']:

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -1,3 +1,5 @@
+"""Module containing useful plotting tools."""
+
 import os
 from subprocess import PIPE, Popen
 
@@ -9,11 +11,10 @@ import pyvista
 from .theme import parse_color, rcParams
 
 def system_supports_plotting():
-    """
-    Check if x server is running
+    """Check if x server is running.
 
-    Returns
-    -------
+    Return
+    ------
     system_supports_plotting : bool
         True when on Linux and running an xserver.  Returns None when
         on a non-linux platform.
@@ -33,7 +34,7 @@ def system_supports_plotting():
 
 
 def update_axes_label_color(axes_actor, color=None):
-    """Internal helper to set the axes label color"""
+    """Set the axes label color (internale helper)."""
     if color is None:
         color = rcParams['font']['color']
     color = parse_color(color)
@@ -53,6 +54,7 @@ def update_axes_label_color(axes_actor, color=None):
 def create_axes_marker(label_color=None, x_color=None, y_color=None,
                        z_color=None, xlabel='X', ylabel='Y', zlabel='Z',
                        labels_off=False, line_width=2):
+    """Return an axis actor to add in the scene."""
     if x_color is None:
         x_color = rcParams['axes']['x_color']
     if y_color is None:
@@ -91,8 +93,7 @@ def create_axes_orientation_box(line_width=1, text_scale=0.366667,
                                 z_face_color='blue',
                                 color_box=False, label_color=None,
                                 labels_off=False, opacity=0.5,):
-    """Create a Box axes orientation widget with labels.
-    """
+    """Create a Box axes orientation widget with labels."""
     if x_color is None:
         x_color = rcParams['axes']['x_color']
     if y_color is None:
@@ -171,6 +172,7 @@ def create_axes_orientation_box(line_width=1, text_scale=0.366667,
 
 
 def normalize(x, minimum=None, maximum=None):
+    """Normalize the given value between [minimum, maximum]."""
     if minimum is None:
         minimum = np.nanmin(x)
     if maximum is None:
@@ -179,8 +181,7 @@ def normalize(x, minimum=None, maximum=None):
 
 
 def opacity_transfer_function(mapping, n_colors, interpolate=True):
-    """Get the opacity transfer function results: range from 0 to 255.
-    """
+    """Get the opacity transfer function results: range from 0 to 255."""
     sigmoid = lambda x: np.array(1 / (1 + np.exp(-x)) * 255, dtype=np.uint8)
     transfer_func = {
         'linear': np.linspace(0, 255, n_colors, dtype=np.uint8),

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1,3 +1,5 @@
+"""Module dedicated to widgets."""
+
 import numpy as np
 import vtk
 
@@ -8,16 +10,20 @@ from .theme import rcParams, parse_color
 
 
 class WidgetHelper(object):
-    """An internal class to manage widgets and other helper methods involving
-    widgets"""
+    """An internal class to manage widgets.
+
+    It also manages and other helper methods involving widgets.
+
+    """
 
     def add_box_widget(self, callback, bounds=None, factor=1.25,
                        rotation_enabled=True, color=None, use_planes=False,
                        outline_translation=True, pass_widget=False):
-        """Add a box widget to the scene. This is useless without a callback
-        function. You can pass a callable function that takes a single
-        argument, the PolyData box output from this widget, and performs a
-        task with that box.
+        """Add a box widget to the scene.
+
+        This is useless without a callback function. You can pass a callable
+        function that takes a single argument, the PolyData box output from
+        this widget, and performs a task with that box.
 
         Parameters
         ----------
@@ -98,7 +104,7 @@ class WidgetHelper(object):
 
 
     def clear_box_widgets(self):
-        """ Disables all of the box widgets """
+        """Disable all of the box widgets."""
         if hasattr(self, 'box_widgets'):
             for widget in self.box_widgets:
                 widget.Off()
@@ -109,7 +115,9 @@ class WidgetHelper(object):
     def add_mesh_clip_box(self, mesh, invert=False, rotation_enabled=True,
                           widget_color=None, outline_translation=True,
                           **kwargs):
-        """Add a mesh to the scene with a box widget that is used to clip
+        """Clip a mesh using a box widget.
+
+        Add a mesh to the scene with a box widget that is used to clip
         the mesh interactively.
 
         The clipped mesh is saved to the ``.box_clipped_meshes`` attribute on
@@ -130,6 +138,7 @@ class WidgetHelper(object):
         kwargs : dict
             All additional keyword arguments are passed to ``add_mesh`` to
             control how the mesh is displayed.
+
         """
         name = kwargs.get('name', str(hex(id(mesh))))
         rng = mesh.get_data_range(kwargs.get('scalars', None))
@@ -175,10 +184,12 @@ class WidgetHelper(object):
                          outline_translation=False,
                          origin_translation=True, implicit=True,
                          pass_widget=False, test_callback=True):
-        """Add a plane widget to the scene. This is useless without a callback
-        function. You can pass a callable function that takes two
-        arguments, the normal and origin of the plane in that order output
-        from this widget, and performs a task with that plane.
+        """Add a plane widget to the scene.
+
+        This is useless without a callback function. You can pass a callable
+        function that takes two arguments, the normal and origin of the plane
+        in that order output from this widget, and performs a task with that
+        plane.
 
         Parameters
         ----------
@@ -335,7 +346,7 @@ class WidgetHelper(object):
 
 
     def clear_plane_widgets(self):
-        """ Disables all of the plane widgets """
+        """Disable all of the plane widgets."""
         if hasattr(self, 'plane_widgets'):
             for widget in self.plane_widgets:
                 widget.Off()
@@ -347,7 +358,9 @@ class WidgetHelper(object):
                             widget_color=None, value=0.0, assign_to_axis=None,
                             tubing=False, origin_translation=True,
                             outline_translation=False, implicit=True, **kwargs):
-        """Add a mesh to the scene with a plane widget that is used to clip
+        """Clip a mesh using a plane widget.
+
+        Add a mesh to the scene with a plane widget that is used to clip
         the mesh interactively.
 
         The clipped mesh is saved to the ``.plane_clipped_meshes`` attribute on
@@ -367,6 +380,7 @@ class WidgetHelper(object):
         kwargs : dict
             All additional keyword arguments are passed to ``add_mesh`` to
             control how the mesh is displayed.
+
         """
         name = kwargs.get('name', str(hex(id(mesh))))
         rng = mesh.get_data_range(kwargs.get('scalars', None))
@@ -414,7 +428,9 @@ class WidgetHelper(object):
                        widget_color=None, assign_to_axis=None,
                        tubing=False, origin_translation=True,
                        outline_translation=False, **kwargs):
-        """Add a mesh to the scene with a plane widget that is used to slice
+        """Slice a mesh using a plane widget.
+
+        Add a mesh to the scene with a plane widget that is used to slice
         the mesh interactively.
 
         The sliced mesh is saved to the ``.plane_sliced_meshes`` attribute on
@@ -435,6 +451,7 @@ class WidgetHelper(object):
         kwargs : dict
             All additional keyword arguments are passed to ``add_mesh`` to
             control how the mesh is displayed.
+
         """
         name = kwargs.get('name', str(hex(id(mesh))))
         rng = mesh.get_data_range(kwargs.get('scalars', None))
@@ -473,8 +490,11 @@ class WidgetHelper(object):
 
     def add_mesh_slice_orthogonal(self, mesh, generate_triangles=False,
                                   widget_color=None, tubing=False, **kwargs):
-        """Adds three interactive plane slicing widgets for orthogonal slicing
+        """Slice a mesh with three interactive planes.
+
+        Adds three interactive plane slicing widgets for orthogonal slicing
         along each cartesian axis.
+
         """
         actors = []
         for ax in ["x", "y", "z"]:
@@ -493,10 +513,11 @@ class WidgetHelper(object):
     def add_line_widget(self, callback, bounds=None, factor=1.25,
                         resolution=100, color=None, use_vertices=False,
                         pass_widget=False):
-        """Add a line widget to the scene. This is useless without a callback
-        function. You can pass a callable function that takes a single
-        argument, the PolyData line output from this widget, and performs a
-        task with that line.
+        """Add a line widget to the scene.
+
+        This is useless without a callback function. You can pass a callable
+        function that takes a single argument, the PolyData line output from this
+        widget, and performs a task with that line.
 
         Parameters
         ----------
@@ -525,6 +546,7 @@ class WidgetHelper(object):
         pass_widget : bool
             If true, the widget will be passed as the last argument of the
             callback
+
         """
         if hasattr(self, 'notebook') and self.notebook:
             raise AssertionError('Line widget not available in notebook plotting')
@@ -570,7 +592,7 @@ class WidgetHelper(object):
 
 
     def clear_line_widgets(self):
-        """ Disables all of the line widgets """
+        """Disable all of the line widgets."""
         if hasattr(self, 'line_widgets'):
             for widget in self.line_widgets:
                 widget.Off()
@@ -581,10 +603,11 @@ class WidgetHelper(object):
     def add_slider_widget(self, callback, rng, value=None, title=None,
                           pointa=(.4, .9), pointb=(.9, .9),
                           color=None, pass_widget=False):
-        """Add a slider bar widget. This is useless without a callback
-        function. You can pass a callable function that takes a single
-        argument, the value of this slider widget, and performs a
-        task with that value.
+        """Add a slider bar widget.
+
+        This is useless without a callback function. You can pass a callable
+        function that takes a single argument, the value of this slider widget,
+        and performs a task with that value.
 
         Parameters
         ----------
@@ -615,6 +638,7 @@ class WidgetHelper(object):
         pass_widget : bool
             If true, the widget will be passed as the last argument of the
             callback
+
         """
         if hasattr(self, 'notebook') and self.notebook:
             raise AssertionError('Slider widget not available in notebook plotting')
@@ -673,7 +697,7 @@ class WidgetHelper(object):
 
 
     def clear_slider_widgets(self):
-        """ Disables all of the slider widgets """
+        """Disable all of the slider widgets."""
         if hasattr(self, 'slider_widgets'):
             for widget in self.slider_widgets:
                 widget.Off()
@@ -685,7 +709,9 @@ class WidgetHelper(object):
                            widget_color=None, preference='cell',
                            title=None, pointa=(.4, .9), pointb=(.9, .9),
                            continuous=False, **kwargs):
-        """Add a mesh to the scene with a slider widget that is used to
+        """Apply a threshold on a mesh with a slider.
+
+        Add a mesh to the scene with a slider widget that is used to
         threshold the mesh interactively.
 
         The threshold mesh is saved to the ``.threshold_meshes`` attribute on
@@ -705,6 +731,7 @@ class WidgetHelper(object):
         kwargs : dict
             All additional keyword arguments are passed to ``add_mesh`` to
             control how the mesh is displayed.
+
         """
         if isinstance(mesh, pyvista.MultiBlock):
             raise TypeError('MultiBlock datasets are not supported for threshold widget.')
@@ -755,7 +782,9 @@ class WidgetHelper(object):
                           compute_gradients=False, compute_scalars=True,
                           preference='point', title=None, pointa=(.4, .9),
                           pointb=(.9, .9), widget_color=None, **kwargs):
-        """Add a mesh to the scene with a slider widget that is used to
+        """Create a contour of a mesh with a slider.
+
+        Add a mesh to the scene with a slider widget that is used to
         contour at an isovalue of the *point* data on the mesh interactively.
 
         The isovalue mesh is saved to the ``.isovalue_meshes`` attribute on
@@ -772,6 +801,7 @@ class WidgetHelper(object):
         kwargs : dict
             All additional keyword arguments are passed to ``add_mesh`` to
             control how the mesh is displayed.
+
         """
         if isinstance(mesh, pyvista.MultiBlock):
             raise TypeError('MultiBlock datasets are not supported for this widget.')
@@ -826,10 +856,11 @@ class WidgetHelper(object):
                           n_hanldes=5, resolution=25, color="yellow",
                           show_ribbon=False, ribbon_color="pink",
                           ribbon_opacity=0.5, pass_widget=False):
-        """Create and add a spline widget to the scene. Use the bounds
-        argument to place this widget. Several "handles" are used to control a
-        parametric function for building this spline. Click directly on the
-        line to translate the widget.
+        """Create and add a spline widget to the scene.
+
+        Use the bounds argument to place this widget. Several "handles" are
+        used to control a parametric function for building this spline. Click
+        directly on the line to translate the widget.
 
         Note
         ----
@@ -865,6 +896,7 @@ class WidgetHelper(object):
         pass_widget : bool
             If true, the widget will be passed as the last argument of the
             callback
+
         """
         if hasattr(self, 'notebook') and self.notebook:
             raise AssertionError('Spline widget not available in notebook plotting')
@@ -914,7 +946,7 @@ class WidgetHelper(object):
 
 
     def clear_spline_widgets(self):
-        """disables all of the spline widgets"""
+        """Disable all of the spline widgets."""
         if hasattr(self, 'spline_widgets'):
             for widget in self.spline_widgets:
                 widget.Off()
@@ -926,7 +958,9 @@ class WidgetHelper(object):
                               widget_color=None, show_ribbon=False,
                               ribbon_color="pink", ribbon_opacity=0.5,
                               **kwargs):
-        """Add a mesh to the scene with a spline widget that is used to slice
+        """Slice a mesh with a spline widget.
+
+        Add a mesh to the scene with a spline widget that is used to slice
         the mesh interactively.
 
         The sliced mesh is saved to the ``.spline_sliced_meshes`` attribute on
@@ -944,6 +978,7 @@ class WidgetHelper(object):
         kwargs : dict
             All additional keyword arguments are passed to ``add_mesh`` to
             control how the mesh is displayed.
+
         """
         name = kwargs.get('name', str(hex(id(mesh))))
         rng = mesh.get_data_range(kwargs.get('scalars', None))
@@ -987,8 +1022,9 @@ class WidgetHelper(object):
                           color=None, style="surface",
                           selected_color="pink", indices=None,
                           pass_widget=False, test_callback=True):
-        """Add one or many sphere widgets to a scene. Use a sphere widget
-        to control a vertex location.
+        """Add one or many sphere widgets to a scene.
+        
+        Use a sphere widget to control a vertex location.
 
         Parameters
         ----------
@@ -1101,7 +1137,7 @@ class WidgetHelper(object):
 
 
     def clear_sphere_widgets(self):
-        """ Disable all of the sphere widgets """
+        """Disable all of the sphere widgets."""
         if hasattr(self, 'sphere_widgets'):
             for widget in self.sphere_widgets:
                 widget.Off()
@@ -1110,7 +1146,7 @@ class WidgetHelper(object):
 
 
     def close(self):
-        """ closes widgets """
+        """Close the widgets."""
         self.clear_box_widgets()
         self.clear_plane_widgets()
         self.clear_line_widgets()

--- a/pyvista/utilities/__init__.py
+++ b/pyvista/utilities/__init__.py
@@ -1,3 +1,5 @@
+"""Utilities routines."""
+
 from .errors import (Observer, Report, assert_empty_kwargs,
                      send_errors_to_logging, set_error_output_file)
 from .features import *

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -1,3 +1,5 @@
+"""Module managing errors."""
+
 import logging
 import os
 import re
@@ -8,7 +10,7 @@ import vtk
 
 
 def set_error_output_file(filename):
-    """Sets a file to write out the VTK errors"""
+    """Set a file to write out the VTK errors."""
     filename = os.path.abspath(os.path.expanduser(filename))
     fileOutputWindow = vtk.vtkFileOutputWindow()
     fileOutputWindow.SetFileName(filename)
@@ -18,9 +20,10 @@ def set_error_output_file(filename):
 
 
 class Observer:
-    """A standerd class for observing VTK objects.
-    """
+    """A standerd class for observing VTK objects."""
+
     def __init__(self, event_type='ErrorEvent', log=True):
+        """Initialize observer."""
         self.__event_occurred = False
         self.__message = None
         self.__message_etc = None
@@ -31,6 +34,7 @@ class Observer:
 
     @staticmethod
     def parse_message(message):
+        """Parse the given message."""
         # Message format
         regex = re.compile(r'([A-Z]+):\sIn\s(.+),\sline\s.+\n\w+\s(.+):\s(.+)')
         try:
@@ -40,7 +44,7 @@ class Observer:
             return '', '', '', message
 
     def log_message(self, kind, alert):
-        """Parses different event types and passes them to logging"""
+        """Parse different event types and passes them to logging."""
         if kind == 'ERROR':
             logging.error(alert)
         else:
@@ -48,7 +52,11 @@ class Observer:
         return
 
     def __call__(self, obj, event, message):
-        """On an event occurrence, this function executes"""
+        """Declare standard call function for the observer.
+
+        On an event occurrence, this function executes.
+
+        """
         self.__event_occurred = True
         self.__message_etc = message
         kind, path, address, alert = self.parse_message(message)
@@ -58,25 +66,28 @@ class Observer:
 
     def has_event_occurred(self):
         """Ask self if an error has occurred since last querried.
+
         This resets the observer's status.
+
         """
         occ = self.__event_occurred
         self.__event_occurred = False
         return occ
 
     def get_message(self, etc=False):
-        """Get the last set error message
+        """Get the last set error message.
 
-        Return:
+        Return
+        ------
             str: the last set error message
+
         """
         if etc:
             return self.__message_etc
         return self.__message
 
     def observe(self, algorithm):
-        """Make this an observer of an algorithm
-        """
+        """Make this an observer of an algorithm."""
         if self.__observing:
             raise RuntimeError('This error observer is already observing an algorithm.')
         if hasattr(algorithm, 'GetExecutive') and algorithm.GetExecutive() is not None:
@@ -87,7 +98,7 @@ class Observer:
 
 
 def send_errors_to_logging():
-    """Send all VTK error/warning messages to Python's logging module"""
+    """Send all VTK error/warning messages to Python's logging module."""
     error_output = vtk.vtkStringOutputWindow()
     error_win = vtk.vtkOutputWindow()
     error_win.SetInstance(error_output)
@@ -96,6 +107,8 @@ def send_errors_to_logging():
 
 
 class Report(scooby.Report):
+    """A class for custom scooby.Report."""
+
     def __init__(self, additional=None, ncol=3, text_width=80, sort=False):
         """Generate a :class:`scooby.Report` instance.
 
@@ -115,7 +128,6 @@ class Report(scooby.Report):
             Alphabetically sort the packages
 
         """
-
         # Mandatory packages.
         core = ['pyvista', 'vtk', 'numpy', 'imageio', 'appdirs', 'scooby']
 
@@ -129,8 +141,10 @@ class Report(scooby.Report):
 
 
 def assert_empty_kwargs(**kwargs):
-    """An internal helper to assert that all keyword arguments have been used.
+    """Assert that all keyword arguments have been used (internal helper).
+
     If any keyword arguments are passed, a ``TypeError`` is raised.
+
     """
     n = len(kwargs)
     if n == 0:

--- a/pyvista/utilities/features.py
+++ b/pyvista/utilities/features.py
@@ -1,3 +1,5 @@
+"""Module containing geometry helper functions."""
+
 import ctypes
 import numpy as np
 
@@ -5,7 +7,7 @@ import pyvista
 
 
 def voxelize(mesh, density):
-    """voxelize mesh to UnstructuredGrid"""
+    """Voxelize mesh to UnstructuredGrid."""
     x_min, x_max, y_min, y_max, z_min, z_max = mesh.bounds
     x = np.arange(x_min, x_max, density)
     y = np.arange(y_min, y_max, density)
@@ -25,8 +27,11 @@ def voxelize(mesh, density):
 
 
 def create_grid(dataset, dimensions=(101, 101, 101)):
-    """Creates a uniform grid surrounding the given dataset with the specified
-    dimensions. This grid is commonly used for interpolating the input dataset.
+    """Create a uniform grid surrounding the given dataset.
+
+    The output grid will have the specified dimensions and is commonly used
+    for interpolating the input dataset.
+
     """
     bounds = np.array(dataset.bounds)
     if dimensions is None:
@@ -46,7 +51,7 @@ def create_grid(dataset, dimensions=(101, 101, 101)):
 
 
 def single_triangle():
-    """ A single PolyData triangle """
+    """Create a single PolyData triangle."""
     points = np.zeros((3, 3))
     points[1] = [1, 0, 0]
     points[2] = [0.5, 0.707, 0]
@@ -55,8 +60,7 @@ def single_triangle():
 
 
 def grid_from_sph_coords(theta, phi, r):
-    """
-    Create a structured grid from arrays of spherical coordinates.
+    """Create a structured grid from arrays of spherical coordinates.
 
     Parameters
     ----------
@@ -67,9 +71,10 @@ def grid_from_sph_coords(theta, phi, r):
     r: array-like
         Distance (radius) from the point of origin
 
-    Returns
-    -------
+    Return
+    ------
     pyvista.StructuredGrid
+
     """
     x, y, z = np.meshgrid(np.radians(theta), np.radians(phi), r)
     # Transform grid to cartesian coordinates
@@ -81,8 +86,7 @@ def grid_from_sph_coords(theta, phi, r):
 
 
 def transform_vectors_sph_to_cart(theta, phi, r, u, v, w):
-    """
-    Transform vectors from spherical (r, phi, theta) to cartesian coordinates (z, y, x).
+    """Transform vectors from spherical (r, phi, theta) to cartesian coordinates (z, y, x).
 
     Note the "reverse" order of arrays's axes, commonly used in geosciences.
 
@@ -101,10 +105,11 @@ def transform_vectors_sph_to_cart(theta, phi, r, u, v, w):
     w: array-like
         Z-component of the vector of shape (P, N, M)
 
-    Returns
-    -------
+    Return
+    ------
     u_t, v_t, w_t: array-like
         Arrays of transformed x-, y-, z-components, respectively.
+
     """
     xx, yy, _ = np.meshgrid(np.radians(theta), np.radians(phi), r, indexing="ij")
     th, ph = xx.squeeze(), yy.squeeze()

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -1,6 +1,5 @@
-"""
-Contains a dictionary that maps file extensions to VTK readers
-"""
+"""Contains a dictionary that maps file extensions to VTK readers."""
+
 import os
 
 import vtk
@@ -73,21 +72,21 @@ if (VTK_MAJOR >= 8 and VTK_MINOR >= 2):
 
 
 def get_ext(filename):
-    """Extract the extension of the filename"""
+    """Extract the extension of the filename."""
     ext = os.path.splitext(filename)[1].lower()
     return ext
 
 
 def get_reader(filename):
-    """Gets the corresponding reader based on file extension and instantiates it
-    """
+    """Get the corresponding reader based on file extension and instantiates it."""
     ext = get_ext(filename)
     return READERS[ext]() # Get and instantiate the reader
 
 
 def standard_reader_routine(reader, filename, attrs=None):
-    """Use a given reader from the ``READERS`` mapping in the common VTK reading
-    pipeline routine.
+    """Use a given reader in the common VTK reading pipeline routine.
+
+    The reader must come from the ``READERS`` mapping.
 
     Parameters
     ----------
@@ -102,6 +101,7 @@ def standard_reader_routine(reader, filename, attrs=None):
         the attribute/method names and values are the arguments passed to those
         calls. If you do not have any attributes to call, pass ``None`` as the
         value.
+
     """
     if attrs is None:
         attrs = {}
@@ -123,7 +123,7 @@ def standard_reader_routine(reader, filename, attrs=None):
 
 
 def read_legacy(filename):
-    """Use VTK's legacy reader to read a file"""
+    """Use VTK's legacy reader to read a file."""
     reader = vtk.vtkDataSetReader()
     reader.SetFileName(filename)
     # Ensure all data is fetched with poorly formatted legacy files
@@ -141,8 +141,10 @@ def read_legacy(filename):
 
 
 def read(filename, attrs=None):
-    """This will read any VTK file! It will figure out what reader to use
-    then wrap the VTK object for use in PyVista.
+    """Read any VTK file.
+
+    It will figure out what reader to use then wrap the VTK object for
+    use in PyVista.
 
     Parameters
     ----------
@@ -151,6 +153,7 @@ def read(filename, attrs=None):
         the attribute/method names and values are the arguments passed to those
         calls. If you do not have any attributes to call, pass ``None`` as the
         value.
+
     """
     filename = os.path.abspath(os.path.expanduser(filename))
     if not os.path.isfile(filename):
@@ -189,7 +192,7 @@ def read(filename, attrs=None):
 
 
 def read_texture(filename, attrs=None):
-    """Loads a ``vtkTexture`` from an image file."""
+    """Load a ``vtkTexture`` from an image file."""
     filename = os.path.abspath(os.path.expanduser(filename))
     try:
         # initialize the reader using the extension to find it
@@ -207,7 +210,7 @@ def read_exodus(filename,
                 apply_displacements=True,
                 displacement_magnitude=1.0,
                 enabled_sidesets=None):
-    """Read an ExodusII file (``'.e'`` or ``'.exo'``)"""
+    """Read an ExodusII file (``'.e'`` or ``'.exo'``)."""
     reader = vtk.vtkExodusIIReader()
     reader.SetFileName(filename)
     reader.UpdateInformation()

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -1,4 +1,4 @@
-"""Provides an easy way of generating several geometric objects
+"""Provides an easy way of generating several geometric objects.
 
 CONTAINS
 --------
@@ -31,9 +31,11 @@ NORMALS = {
 
 
 def translate(surf, center=[0., 0., 0.], direction=[1., 0., 0.]):
-    """
-    Translates and orientates a mesh centered at the origin and
-    facing in the x direction to a new center and direction
+    """Translate and orientate a mesh to a new center and direction.
+
+    By default, the input mesh is considered centered at the origin
+    and facing in the x direction.
+
     """
     normx = np.array(direction)/np.linalg.norm(direction)
     normz = np.cross(normx, [0, 1.0, 0.0000001])
@@ -53,11 +55,9 @@ def translate(surf, center=[0., 0., 0.], direction=[1., 0., 0.]):
 
 def Cylinder(center=(0.,0.,0.), direction=(1.,0.,0.), radius=0.5, height=1.0,
              resolution=100, capping=True, **kwargs):
+    """Create the surface of a cylinder.
 
-    """
-    Create the surface of a cylinder.
-
-    See also :func:`pyvista.CylinderStructured`
+    See also :func:`pyvista.CylinderStructured`.
 
     Parameters
     ----------
@@ -79,8 +79,8 @@ def Cylinder(center=(0.,0.,0.), direction=(1.,0.,0.), radius=0.5, height=1.0,
     capping : bool, optional
         Cap cylinder ends with polygons.  Default True
 
-    Returns
-    -------
+    Return
+    ------
     cylinder : pyvista.PolyData
         Cylinder surface.
 
@@ -110,6 +110,7 @@ def CylinderStructured(radius=0.5, height=1.0,
                        center=(0.,0.,0.), direction=(1.,0.,0.),
                        theta_resolution=32, z_resolution=10):
     """Create a cylinder mesh as a :class:`pyvista.StructuredGrid`.
+
     The end caps are left open. This can create a surface mesh if a single
     value for the ``radius`` is given or a 3D mesh if multiple radii are given
     as a list/array in the ``radius`` argument.
@@ -133,6 +134,7 @@ def CylinderStructured(radius=0.5, height=1.0,
 
     z_resolution : int
         Number of points along the height (Z-axis) of the cylinder
+
     """
     # Define grid in polar coordinates
     r = np.array([radius]).ravel()
@@ -181,8 +183,7 @@ def CylinderStructured(radius=0.5, height=1.0,
 
 def Arrow(start=(0.,0.,0.), direction=(1.,0.,0.), tip_length=0.25,
           tip_radius=0.1, shaft_radius=0.05, shaft_resolution=20):
-    """
-    Create a vtk Arrow
+    """Create a vtk Arrow.
 
     Parameters
     ----------
@@ -204,10 +205,11 @@ def Arrow(start=(0.,0.,0.), direction=(1.,0.,0.), tip_length=0.25,
     shaft_resolution : int, optional
         Number of faces around the shaft
 
-    Returns
-    -------
+    Return
+    ------
     arrow : pyvista.PolyData
         Arrow surface.
+
     """
     # Create arrow object
     arrow = vtk.vtkArrowSource()
@@ -223,8 +225,7 @@ def Arrow(start=(0.,0.,0.), direction=(1.,0.,0.), tip_length=0.25,
 
 def Sphere(radius=0.5, center=(0, 0, 0), direction=(0, 0, 1), theta_resolution=30,
            phi_resolution=30, start_theta=0, end_theta=360, start_phi=0, end_phi=180):
-    """
-    Create a vtk Sphere
+    """Create a vtk Sphere.
 
     Parameters
     ----------
@@ -257,10 +258,11 @@ def Sphere(radius=0.5, center=(0, 0, 0), direction=(0, 0, 1), theta_resolution=3
     end_phi : float, optional
         Ending latitude angle.
 
-    Returns
-    -------
+    Return
+    ------
     sphere : pyvista.PolyData
         Sphere mesh.
+
     """
     sphere = vtk.vtkSphereSource()
     sphere.SetRadius(radius)
@@ -279,8 +281,7 @@ def Sphere(radius=0.5, center=(0, 0, 0), direction=(0, 0, 1), theta_resolution=3
 
 def Plane(center=(0, 0, 0), direction=(0, 0, 1), i_size=1, j_size=1,
           i_resolution=10, j_resolution=10):
-    """
-    Create a plane
+    """Create a plane.
 
     Parameters
     ----------
@@ -302,8 +303,8 @@ def Plane(center=(0, 0, 0), direction=(0, 0, 1), i_size=1, j_size=1,
     j_resolution : int
         Number of points on the plane in the j direction.
 
-    Returns
-    -------
+    Return
+    ------
     plane : pyvista.PolyData
         Plane mesh
 
@@ -323,7 +324,7 @@ def Plane(center=(0, 0, 0), direction=(0, 0, 1), i_size=1, j_size=1,
 
 
 def Line(pointa=(-0.5, 0., 0.), pointb=(0.5, 0., 0.), resolution=1):
-    """Create a line
+    """Create a line.
 
     Parameters
     ----------
@@ -335,6 +336,7 @@ def Line(pointa=(-0.5, 0., 0.), pointb=(0.5, 0., 0.), resolution=1):
 
     resolution : int
         number of pieces to divide line into
+
     """
     if np.array(pointa).size != 3:
         raise TypeError('Point A must be a length three tuple of floats.')
@@ -354,7 +356,9 @@ def Line(pointa=(-0.5, 0., 0.), pointb=(0.5, 0., 0.), resolution=1):
 
 
 def Cube(center=(0., 0., 0.), x_length=1.0, y_length=1.0, z_length=1.0, bounds=None):
-    """Create a cube by either specifying the center and side lengths or just
+    """Create a cube.
+
+    It's possible to specify either the center and side lengths or just
     the bounds of the cube. If ``bounds`` are given, all other arguments are
     ignored.
 
@@ -375,6 +379,7 @@ def Cube(center=(0., 0., 0.), x_length=1.0, y_length=1.0, z_length=1.0, bounds=N
     bounds : np.ndarray or list
         Specify the bounding box of the cube. If given, all other arguments are
         ignored. ``(xMin,xMax, yMin,yMax, zMin,zMax)``
+
     """
     src = vtk.vtkCubeSource()
     if bounds is not None:
@@ -391,20 +396,21 @@ def Cube(center=(0., 0., 0.), x_length=1.0, y_length=1.0, z_length=1.0, bounds=N
 
 
 def Box(bounds=(-1.,1.,-1.,1.,-1.,1.)):
-    """Creates a box with solid faces for the given bounds.
+    """Create a box with solid faces for the given bounds.
 
     Parameters
     ----------
     bounds : np.ndarray or list
         Specify the bounding box of the cube. If given, all other arguments are
         ignored. ``(xMin,xMax, yMin,yMax, zMin,zMax)``
+
     """
     return Cube(bounds=bounds)
 
 
 def Cone(center=(0.,0.,0.), direction=(1.,0.,0.), height=1.0, radius=None,
          capping=True, angle=None, resolution=6):
-    """Create a cone
+    """Create a cone.
 
     Parameters
     ----------
@@ -428,6 +434,7 @@ def Cone(center=(0.,0.,0.), direction=(1.,0.,0.), height=1.0, radius=None,
 
     resolution : int
         number of facets used to represent the cone
+
     """
     src = vtk.vtkConeSource()
     src.SetCapping(capping)
@@ -449,10 +456,11 @@ def Cone(center=(0.,0.,0.), direction=(1.,0.,0.), height=1.0, radius=None,
 
 
 def Polygon(center=(0.,0.,0.), radius=1, normal=(0,0,1), n_sides=6):
-    """
-    Create a polygonal disk with a hole in the center. The disk has zero
-    height. The user can specify the inner and outer radius of the disk, and
-    the radial and circumferential resolution of the polygonal representation.
+    """Create a polygonal disk with a hole in the center.
+
+    The disk has zero height. The user can specify the inner and outer radius
+    of the disk, and the radial and circumferential resolution of the polygonal
+    representation.
 
     Parameters
     ----------
@@ -467,6 +475,7 @@ def Polygon(center=(0.,0.,0.), radius=1, normal=(0,0,1), n_sides=6):
 
     n_sides : int
         Number of sides of the polygon
+
     """
     src = vtk.vtkRegularPolygonSource()
     src.SetCenter(center)
@@ -479,10 +488,11 @@ def Polygon(center=(0.,0.,0.), radius=1, normal=(0,0,1), n_sides=6):
 
 def Disc(center=(0.,0.,0.), inner=0.25, outer=0.5, normal=(0,0,1), r_res=1,
          c_res=6):
-    """
-    Create a polygonal disk with a hole in the center. The disk has zero
-    height. The user can specify the inner and outer radius of the disk, and
-    the radial and circumferential resolution of the polygonal representation.
+    """Create a polygonal disk with a hole in the center.
+
+    The disk has zero height. The user can specify the inner and outer radius
+    of the disk, and the radial and circumferential resolution of the polygonal
+    representation.
 
     Parameters
     ----------
@@ -503,6 +513,7 @@ def Disc(center=(0.,0.,0.), inner=0.25, outer=0.5, normal=(0,0,1), r_res=1,
 
     r_res: int
         number of points in circumferential direction.
+
     """
     src = vtk.vtkDiskSource()
     src.SetInnerRadius(inner)
@@ -514,7 +525,7 @@ def Disc(center=(0.,0.,0.), inner=0.25, outer=0.5, normal=(0,0,1), r_res=1,
 
 
 def Text3D(string, depth=0.5):
-    """ Create 3D text from a string"""
+    """Create 3D text from a string."""
     vec_text = vtk.vtkVectorText()
     vec_text.SetText(string)
 
@@ -531,18 +542,27 @@ def Text3D(string, depth=0.5):
 
 
 def SuperToroid(*args, **kwargs):
-    """DEPRECATED: use :func:`pyvista.ParametricSuperToroid`"""
+    """Create a super toroid.
+
+    DEPRECATED: Please use `pyvista.ParametricSuperToroid` instead.
+
+    """
     raise RuntimeError('use `pyvista.ParametricSuperToroid` instead')
 
 
 def Ellipsoid(*args, **kwargs):
-    """DEPRECATED: use :func:`pyvista.ParametricEllipsoid`"""
+    """Create an ellipsoid.
+
+    DEPRECATED: Please use :func:`pyvista.ParametricEllipsoid` instead.
+
+    """
     raise RuntimeError('use `pyvista.ParametricEllipsoid` instead')
 
 
 def Wavelet(extent=(-10,10,-10,10,-10,10), center=(0,0,0), maximum=255,
             x_freq=60, y_freq=30, z_freq=40, x_mag=10, y_mag=18, z_mag=5,
             std=0.5, subsample_rate=1):
+    """Create a wavelet."""
     wavelet_source = vtk.vtkRTAnalyticSource()
     wavelet_source.SetWholeExtent(*extent)
     wavelet_source.SetCenter(center)

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -1,7 +1,5 @@
-"""
-Supporting functions for polydata and grid objects
+"""Supporting functions for polydata and grid objects."""
 
-"""
 import collections
 import ctypes
 import logging
@@ -20,12 +18,14 @@ ROW_DATA_FIELD = 6
 
 
 def get_vtk_type(typ):
-    """This looks up the VTK type for a give python data type. Corrects for
-    string type mapping issues.
+    """Look up the VTK type for a give python data type.
+
+    Corrects for string type mapping issues.
 
     Return
     ------
-    int : the integer type id specified in vtkType.h
+        int : the integer type id specified in vtkType.h
+
     """
     typ = nps.get_vtk_array_type(typ)
     # This handles a silly string type bug
@@ -35,17 +35,19 @@ def get_vtk_type(typ):
 
 
 def vtk_bit_array_to_char(vtkarr_bint):
-    """ Cast vtk bit array to a char array """
+    """Cast vtk bit array to a char array."""
     vtkarr = vtk.vtkCharArray()
     vtkarr.DeepCopy(vtkarr_bint)
     return vtkarr
 
 
 def convert_string_array(arr, name=None):
-    """A helper to convert a numpy array of strings to a vtkStringArray
-    or vice versa. Note that this is terribly inefficient - inefficient support
+    """Convert a numpy array of strings to a vtkStringArray or vice versa.
+
+    Note that this is terribly inefficient - inefficient support
     is better than no support :). If you have ideas on how to make this faster,
     please consider opening a pull request.
+
     """
     if isinstance(arr, np.ndarray):
         vtkarr = vtk.vtkStringArray()
@@ -66,7 +68,7 @@ def convert_string_array(arr, name=None):
 
 
 def convert_array(arr, name=None, deep=0, array_type=None):
-    """A helper to convert a NumPy array to a vtkDataArray or vice versa
+    """Convert a NumPy array to a vtkDataArray or vice versa.
 
     Parameters
     -----------
@@ -119,31 +121,32 @@ def convert_array(arr, name=None, deep=0, array_type=None):
 
 
 def is_pyvista_dataset(obj):
-    """ Return True if the Object is a PyVista wrapped dataset """
+    """Return True if the Object is a PyVista wrapped dataset."""
     return isinstance(obj, (pyvista.Common, pyvista.MultiBlock))
 
 
 def point_scalar(mesh, name):
-    """ Returns point scalars of a vtk object """
+    """Return point scalars of a vtk object."""
     vtkarr = mesh.GetPointData().GetAbstractArray(name)
     return convert_array(vtkarr)
 
 def field_scalar(mesh, name):
-    """ Returns field scalars of a vtk object """
+    """Return field scalars of a vtk object."""
     vtkarr = mesh.GetFieldData().GetAbstractArray(name)
     return convert_array(vtkarr)
 
 def cell_scalar(mesh, name):
-    """ Returns cell scalars of a vtk object """
+    """Return cell scalars of a vtk object."""
     vtkarr = mesh.GetCellData().GetAbstractArray(name)
     return convert_array(vtkarr)
 
 def row_array(data_object, name):
-    """ Returns cell scalars of a vtk object """
+    """Return cell scalars of a vtk object."""
     vtkarr = data_object.GetRowData().GetAbstractArray(name)
     return convert_array(vtkarr)
 
 def parse_field_choice(field):
+    """Return the id of the given field."""
     if isinstance(field, str):
         field = field.strip().lower()
         if field in ['cell', 'c', 'cells']:
@@ -164,7 +167,7 @@ def parse_field_choice(field):
 
 
 def get_array(mesh, name, preference='cell', info=False, err=False):
-    """ Searches point, cell and field data for an array
+    """Search point, cell and field data for an array.
 
     Parameters
     ----------
@@ -233,7 +236,7 @@ def get_array(mesh, name, preference='cell', info=False, err=False):
 
 
 def vtk_points(points, deep=True):
-    """ Convert numpy points to a vtkPoints object """
+    """Convert numpy points to a vtkPoints object."""
     if not points.flags['C_CONTIGUOUS']:
         points = np.ascontiguousarray(points)
     vtkpts = vtk.vtkPoints()
@@ -242,8 +245,8 @@ def vtk_points(points, deep=True):
 
 
 def line_segments_from_points(points):
-    """
-    Generates non-connected line segments from points.
+    """Generate non-connected line segments from points.
+
     Assumes points are ordered as line segments and an even number of points
     are
 
@@ -287,7 +290,7 @@ def line_segments_from_points(points):
 
 
 def lines_from_points(points):
-    """Given an array of points, make a connected line set
+    """Make a connected line set given an array of points.
 
     Parameters
     ----------
@@ -297,8 +300,8 @@ def lines_from_points(points):
 
         np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0]])
 
-    Returns
-    -------
+    Return
+    ------
     lines : pyvista.PolyData
         PolyData with lines and cells.
 
@@ -313,8 +316,7 @@ def lines_from_points(points):
 
 
 def vector_poly_data(orig, vec):
-    """ Creates a vtkPolyData object composed of vectors """
-
+    """Create a vtkPolyData object composed of vectors."""
     # shape, dimension checking
     if not isinstance(orig, np.ndarray):
         orig = np.asarray(orig)
@@ -370,7 +372,7 @@ def vector_poly_data(orig, vec):
 
 
 def trans_from_matrix(matrix):
-    """ Convert a vtk matrix to a numpy.ndarray """
+    """Convert a vtk matrix to a numpy.ndarray."""
     t = np.zeros((4, 4))
     for i in range(4):
         for j in range(4):
@@ -379,12 +381,12 @@ def trans_from_matrix(matrix):
 
 
 def wrap(vtkdataset):
-    """This is a convenience method to safely wrap any given VTK data object
-    to its appropriate PyVista data object. Other formats that are supported
-    include:
+    """Wrap any given VTK data object to its appropriate PyVista data object.
 
+    Other formats that are supported include:
     * 2D :class:`numpy.ndarray` of XYZ vertices
     * 3D :class:`numpy.ndarray` representing a volume. Values will be scalars.
+
     """
     wrappers = {
         'vtkUnstructuredGrid': pyvista.UnstructuredGrid,
@@ -426,21 +428,22 @@ def wrap(vtkdataset):
 
 
 def image_to_texture(image):
-    """Converts ``vtkImageData`` (:class:`pyvista.UniformGrid`) to a ``vtkTexture``
-    """
+    """Convert ``vtkImageData`` (:class:`pyvista.UniformGrid`) to a ``vtkTexture``."""
     return pyvista.Texture(image)
 
 
 def numpy_to_texture(image):
-    """Convert a NumPy image array to a vtk.vtkTexture"""
+    """Convert a NumPy image array to a vtk.vtkTexture."""
     if not isinstance(image, np.ndarray):
         raise TypeError('Unknown input type ({})'.format(type(image)))
     return pyvista.Texture(image)
 
 
 def is_inside_bounds(point, bounds):
-    """ Checks if a point is inside a set of bounds. This is implemented
-    through recursion so that this is N-dimensional.
+    """Check if a point is inside a set of bounds.
+
+    This is implemented through recursion so that this is N-dimensional.
+
     """
     if isinstance(point, (int, float)):
         point = [point]
@@ -462,8 +465,7 @@ def is_inside_bounds(point, bounds):
 
 
 def fit_plane_to_points(points, return_meta=False):
-    """
-    Fits a plane to a set of points
+    """Fit a plane to a set of points.
 
     Parameters
     ----------
@@ -472,6 +474,7 @@ def fit_plane_to_points(points, return_meta=False):
 
     return_meta : bool
         If true, also returns the center and normal used to generate the plane
+
     """
     data = np.array(points)
     center = data.mean(axis=0)
@@ -484,6 +487,7 @@ def fit_plane_to_points(points, return_meta=False):
 
 
 def raise_not_matching(scalars, mesh):
+    """Raise exception about inconsistencies."""
     if isinstance(mesh, vtk.vtkTable):
         raise Exception('Number of scalars ({})'.format(scalars.size) +
                         'must match number of rows ' +
@@ -496,7 +500,7 @@ def raise_not_matching(scalars, mesh):
 
 
 def generate_plane(normal, origin):
-    """ Returns a vtk.vtkPlane """
+    """Return a vtk.vtkPlane."""
     plane = vtk.vtkPlane()
     # NORMAL MUST HAVE MAGNITUDE OF 1
     normal = normal / np.linalg.norm(normal)
@@ -506,7 +510,11 @@ def generate_plane(normal, origin):
 
 
 def generate_report(additional=None, ncol=3, text_width=54, sort=False):
-    """DEPRECATED: Please use :class:`pyvista.Report` instead."""
+    """Generate a report.
+
+    DEPRECATED: Please use :class:`pyvista.Report` instead.
+
+    """
     logging.warning('DEPRECATED: Please use `pyvista.Report` instead.')
     core = ['pyvista', 'vtk', 'numpy', 'imageio', 'appdirs', 'scooby']
     optional = ['matplotlib', 'PyQt5', 'IPython', 'colorcet',
@@ -518,7 +526,7 @@ def generate_report(additional=None, ncol=3, text_width=54, sort=False):
 
 
 def try_callback(func, *args):
-
+    """Wrap a given callback in a try statement."""
     try:
         func(*args)
     except Exception as e:
@@ -527,9 +535,12 @@ def try_callback(func, *args):
 
 
 def check_depth_peeling(number_of_peels=100, occlusion_ratio=0.0):
-    """Attempts to use depth peeling to see if it is available for the current
+    """Check if depth peeling is available.
+
+    Attempts to use depth peeling to see if it is available for the current
     environment. Returns ``True`` if depth peeling is available and has been
     successfully leveraged, otherwise ``False``.
+
     """
     # Try Depth Peeling with a basic scene
     source = vtk.vtkSphereSource()

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -1,3 +1,5 @@
+"""Module managing parametric objects."""
+
 from math import pi
 
 import vtk
@@ -20,8 +22,8 @@ def Spline(points, n_points=None):
     n_points : int, optional
         Number of points to interpolate along the points array.
 
-    Returns
-    -------
+    Return
+    ------
     spline : pyvista.PolyData
         Line mesh of spline.
 
@@ -37,6 +39,7 @@ def Spline(points, n_points=None):
     >>> y = r * np.cos(theta)
     >>> points = np.column_stack((x, y, z))
     >>> spline = pv.Spline(points, 1000)
+
     """
     spline_function = vtk.vtkParametricSpline()
     spline_function.SetPoints(pyvista.vtk_points(points, False))
@@ -61,8 +64,8 @@ def ParametricBohemianDome(a=None, **kwargs):
 
     vtkGetMacro(A, double);
 
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricBohemianDome surface
 
@@ -72,6 +75,7 @@ def ParametricBohemianDome(a=None, **kwargs):
     >>> import pyvista
     >>> mesh = pyvista.ParametricBohemianDome()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricBohemianDome()
     if a is not None:
@@ -89,10 +93,8 @@ def ParametricBohemianDome(a=None, **kwargs):
 def ParametricBour(**kwargs):
     """Generate Bour's minimal surface.
 
-    Parameters
-    ----------
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricBour surface
 
@@ -102,6 +104,7 @@ def ParametricBour(**kwargs):
     >>> import pyvista
     >>> mesh = pyvista.ParametricBour()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricBour()
 
@@ -131,8 +134,8 @@ def ParametricBoy(zscale=None, **kwargs):
         The scale factor for the z-coordinate.
       Default is 18, giving a nice shape.
 
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricBoy surface
 
@@ -142,6 +145,7 @@ def ParametricBoy(zscale=None, **kwargs):
     >>> import pyvista
     >>> mesh = pyvista.ParametricBoy()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricBoy()
     if zscale is not None:
@@ -163,19 +167,18 @@ def ParametricCatalanMinimal(**kwargs):
     parametrically. This minimal surface contains the cycloid as a
     geodesic.
 
-    Parameters
-    ----------
     Returns
     -------
     surf : pyvista.PolyData
         ParametricCatalanMinimal surface
 
-    Examples
-    --------
+    Example
+    -------
     Create a ParametricCatalanMinimal mesh
     >>> import pyvista
     >>> mesh = pyvista.ParametricCatalanMinimal()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricCatalanMinimal()
 
@@ -216,8 +219,8 @@ def ParametricConicSpiral(a=None, b=None, c=None, n=None, **kwargs):
         See the definition in Parametric surfaces referred to above.
         Default is 2.
 
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricConicSpiral surface
 
@@ -227,6 +230,7 @@ def ParametricConicSpiral(a=None, b=None, c=None, n=None, **kwargs):
     >>> import pyvista
     >>> mesh = pyvista.ParametricConicSpiral()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricConicSpiral()
     if a is not None:
@@ -257,10 +261,8 @@ def ParametricCrossCap(**kwargs):
     self-intersecting single-sided surface.  This is one possible
     image of a projective plane in three-space.
 
-    Parameters
-    ----------
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricCrossCap surface
 
@@ -270,6 +272,7 @@ def ParametricCrossCap(**kwargs):
     >>> import pyvista
     >>> mesh = pyvista.ParametricCrossCap()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricCrossCap()
 
@@ -300,8 +303,8 @@ def ParametricDini(a=None, b=None, **kwargs):
         See the definition in Parametric surfaces referred to above.
         Default is 0.2
 
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricDini surface
 
@@ -311,6 +314,7 @@ def ParametricDini(a=None, b=None, **kwargs):
     >>> import pyvista
     >>> mesh = pyvista.ParametricDini()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricDini()
     if a is not None:
@@ -349,8 +353,8 @@ def ParametricEllipsoid(xradius=None, yradius=None, zradius=None,
     zradius : double, optional
         The scaling factor for the z-axis. Default is 1.
 
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricEllipsoid surface
 
@@ -360,6 +364,7 @@ def ParametricEllipsoid(xradius=None, yradius=None, zradius=None,
     >>> import pyvista
     >>> mesh = pyvista.ParametricEllipsoid()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricEllipsoid()
     parametric_keywords(parametric_function, min_u=kwargs.pop("min_u", 0),
@@ -397,8 +402,8 @@ def ParametricEnneper(**kwargs):
     Enneper's surface is a a self-intersecting minimal surface
     possessing constant negative Gaussian curvature
 
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricEnneper surface
 
@@ -408,6 +413,7 @@ def ParametricEnneper(**kwargs):
     >>> import pyvista
     >>> mesh = pyvista.ParametricEnneper()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricEnneper()
 
@@ -432,8 +438,8 @@ def ParametricFigure8Klein(radius=None, **kwargs):
     radius : double, optional
         The radius of the bottle. Default is 1.
 
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricFigure8Klein surface
 
@@ -443,6 +449,7 @@ def ParametricFigure8Klein(radius=None, **kwargs):
     >>> import pyvista
     >>> mesh = pyvista.ParametricFigure8Klein()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricFigure8Klein()
     if radius is not None:
@@ -460,8 +467,8 @@ def ParametricFigure8Klein(radius=None, **kwargs):
 def ParametricHenneberg(**kwargs):
     """Generate Henneberg's minimal surface.
 
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricHenneberg surface
 
@@ -471,6 +478,7 @@ def ParametricHenneberg(**kwargs):
     >>> import pyvista
     >>> mesh = pyvista.ParametricHenneberg()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricHenneberg()
 
@@ -484,15 +492,15 @@ def ParametricHenneberg(**kwargs):
 
 
 def ParametricKlein(**kwargs):
-    """Generates a "classical" representation of a Klein bottle.
+    """Generate a "classical" representation of a Klein bottle.
 
     ParametricKlein generates a "classical" representation of a Klein
     bottle.  A Klein bottle is a closed surface with no interior and only one
     surface.  It is unrealisable in 3 dimensions without intersecting
     surfaces.
 
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricKlein surface
 
@@ -502,6 +510,7 @@ def ParametricKlein(**kwargs):
     >>> import pyvista
     >>> mesh = pyvista.ParametricKlein()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricKlein()
 
@@ -529,8 +538,8 @@ def ParametricKuen(deltav0=None, **kwargs):
         towards a pole in the -z direction.
         Setting it to 0 retains the pole whose z-value is -inf.
 
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricKuen surface
 
@@ -540,6 +549,7 @@ def ParametricKuen(deltav0=None, **kwargs):
     >>> import pyvista
     >>> mesh = pyvista.ParametricKuen()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricKuen()
     if deltav0 is not None:
@@ -562,8 +572,8 @@ def ParametricMobius(radius=None, **kwargs):
     radius : double, optional
         The radius of the Mobius strip. Default is 1.
 
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricMobius surface
 
@@ -573,6 +583,7 @@ def ParametricMobius(radius=None, **kwargs):
     >>> import pyvista
     >>> mesh = pyvista.ParametricMobius()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricMobius()
     if radius is not None:
@@ -601,8 +612,8 @@ def ParametricPluckerConoid(n=None, **kwargs):
 
     vtkGetMacro(N, int);
 
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricPluckerConoid surface
 
@@ -612,6 +623,7 @@ def ParametricPluckerConoid(n=None, **kwargs):
     >>> import pyvista
     >>> mesh = pyvista.ParametricPluckerConoid()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricPluckerConoid()
     if n is not None:
@@ -634,8 +646,8 @@ def ParametricPseudosphere(**kwargs):
     tractrix about it's asymptote, and is a surface of constant
     negative Gaussian curvature.
 
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricPseudosphere surface
 
@@ -645,6 +657,7 @@ def ParametricPseudosphere(**kwargs):
     >>> import pyvista
     >>> mesh = pyvista.ParametricPseudosphere()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricPseudosphere()
 
@@ -707,8 +720,8 @@ def ParametricRandomHills(numberofhills=None, hillxvariance=None,
         The scaling factor for the amplitude.
         Default is 13.
 
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricRandomHills surface
 
@@ -718,6 +731,7 @@ def ParametricRandomHills(numberofhills=None, hillxvariance=None,
     >>> import pyvista
     >>> mesh = pyvista.ParametricRandomHills()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricRandomHills()
     if numberofhills is not None:
@@ -761,8 +775,8 @@ def ParametricRoman(radius=None, **kwargs):
     radius : double, optional
         The radius. Default is 1.
 
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricRoman surface
 
@@ -772,6 +786,7 @@ def ParametricRoman(radius=None, **kwargs):
     >>> import pyvista
     >>> mesh = pyvista.ParametricRoman()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricRoman()
     if radius is not None:
@@ -812,8 +827,8 @@ def ParametricSuperEllipsoid(xradius=None, yradius=None, zradius=None,
     n2 : double, optional
         The "squareness" parameter in the x-y plane. Default is 1.
 
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricSuperEllipsoid surface
 
@@ -823,6 +838,7 @@ def ParametricSuperEllipsoid(xradius=None, yradius=None, zradius=None,
     >>> import pyvista
     >>> mesh = pyvista.ParametricSuperEllipsoid()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricSuperEllipsoid()
     if xradius is not None:
@@ -888,8 +904,8 @@ def ParametricSuperToroid(ringradius=None, crosssectionradius=None,
     n2 : double, optional
         The shape of the cross section of the ring. Default is 1.
 
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricSuperToroid surface
 
@@ -899,6 +915,7 @@ def ParametricSuperToroid(ringradius=None, crosssectionradius=None,
     >>> import pyvista
     >>> mesh = pyvista.ParametricSuperToroid()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricSuperToroid()
     if ringradius is not None:
@@ -943,8 +960,8 @@ def ParametricTorus(ringradius=None, crosssectionradius=None, **kwargs):
     crosssectionradius : double, optional
         The radius of the cross section of ring of the torus. Default is 0.5.
 
-    Returns
-    -------
+    Return
+    ------
     surf : pyvista.PolyData
         ParametricTorus surface
 
@@ -954,6 +971,7 @@ def ParametricTorus(ringradius=None, crosssectionradius=None, **kwargs):
     >>> import pyvista
     >>> mesh = pyvista.ParametricTorus()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
+
     """
     parametric_function = vtk.vtkParametricTorus()
     if ringradius is not None:
@@ -974,7 +992,7 @@ def ParametricTorus(ringradius=None, crosssectionradius=None, **kwargs):
 def parametric_keywords(parametric_function, min_u=0, max_u=2*pi,
                         min_v=0.0, max_v=2*pi, join_u=False, join_v=False,
                         twist_u=False, twist_v=False, clockwise=True):
-    """Applies keyword arguments to a parametric function.
+    """Apply keyword arguments to a parametric function.
 
     Parameters
     ----------
@@ -1009,6 +1027,7 @@ def parametric_keywords(parametric_function, min_u=0, max_u=2*pi,
     clockwise : bool, optional
         Determines the ordering of the vertices forming the triangle
         strips.
+
     """
     parametric_function.SetMinimumU(min_u)
     parametric_function.SetMaximumU(max_u)
@@ -1038,6 +1057,7 @@ def surface_from_para(parametric_function, u_res=100, v_res=100,
 
     w_res : int, optional
         Resolution in the w direction.
+
     """
     # convert to a mesh
     para_source = vtk.vtkParametricFunctionSource()

--- a/pyvista/utilities/sphinx_gallery.py
+++ b/pyvista/utilities/sphinx_gallery.py
@@ -1,6 +1,4 @@
-"""
-Utilities for using pyvista with sphinx-gallery.
-"""
+"""Utilities for using pyvista with sphinx-gallery."""
 
 import shutil
 
@@ -8,9 +6,10 @@ import pyvista
 
 
 def _get_sg_image_scraper():
-    """Returns the callable scraper to be used by Sphinx-Gallery which allows
-    PyVista users to just use strings as they already can for 'matplotlib' and
-    'mayavi'. Details on this implementation can be found in
+    """Return the callable scraper to be used by Sphinx-Gallery.
+
+    It allows PyVista users to just use strings as they already can for
+    'matplotlib' and 'mayavi'. Details on this implementation can be found in
     `sphinx-gallery/sphinx-gallery/494`_
 
     .. _sphinx-gallery/sphinx-gallery/494: https://github.com/sphinx-gallery/sphinx-gallery/pull/494
@@ -29,9 +28,10 @@ class Scraper(object):
     """
 
     def __call__(self, block, block_vars, gallery_conf):
-        """
-        Called by sphinx-gallery to save the figures generated after running
-        example code.
+        """Save the figures generated after running example code.
+
+        Called by sphinx-gallery.
+
         """
         try:
             from sphinx_gallery.scrapers import figure_rst


### PR DESCRIPTION
This PR is a follow-up of this https://github.com/pyvista/pyvista/pull/457#issuecomment-556389769 and fixes the documentation style. It doesn't add any features.

I iterate locally using:

`pydocstyle pyvista`

___

**Current status**

- [x] plotting.py 
- [x] qt_plotting.py 
- [x] renderer.py
- [x] widgets.py
- [x] export_vtkjs.py
- [x] colors.py
- [x] picking.py
- [x] mapper.py
- [x] helpers.py
- [x] tools.py
- [x] theme.py
- [x] examples.py
- [x] downloads.py
- [x] parametric_objects.py
- [x] fileio.py
- [x] geometric_objects.py
- [x] errors.py
- [x] features.py
- [x] sphinx-gallery.py
- [x] composite.py
- [x] common.py
- [x] pointset.py
- [x] filters.py
- [x] objects.py
- [x] grid.py

**Fancy progress bar**

🔵🔵🔵🔵🔵🔵🔵🔵🔵🔵🔵🔵🔵🔵🔵🔵🔵🔵🔵🔵🔵🔵🔵🔵🔵 100% :tada: 