### PR TITLE
Fix volume rendering issues

### DIFF
--- a/examples/02-plot/volume.py
+++ b/examples/02-plot/volume.py
@@ -49,6 +49,18 @@ p.add_volume(vol, cmap="viridis", opacity=opacity)
 p.camera_position = cpos
 p.show()
 
+###############################################################################
+# We can also use a shading technique when volume rendering with the ``shade``
+# option
+p = pv.Plotter(shape=(1,2))
+p.add_volume(vol, cmap="viridis", opacity=opacity, shade=False)
+p.add_text("No shading")
+p.subplot(0,1)
+p.add_volume(vol, cmap="viridis", opacity=opacity, shade=True)
+p.add_text("Shading")
+p.link_views()
+p.camera_position = cpos
+p.show()
 
 ###############################################################################
 # Cool Volume Examples

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1412,11 +1412,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         opacity_unit_distance : float
             Set/Get the unit distance on which the scalar opacity transfer
-            function is defined. By default this is one hundredth the length of
-            the diagonal of the bounding box of the volome. Meaning that over
-            that distance, a given opacity (from the transfer function) is
-            accumulated. This is adjusted for the actual sampling distance
-            during rendering.
+            function is defined. Meaning that over that distance, a given
+            opacity (from the transfer function) is accumulated. This is
+            adjusted for the actual sampling distance during rendering. By
+            default, this is the length of the diagonal of the bounding box of
+            the volume divided by the dimensions.
 
         shade : bool
             Default off. If shading is turned on, the mapper may perform
@@ -1524,7 +1524,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             raise TypeError('Type ({}) not supported for volume rendering at this time. Use `pyvista.UniformGrid`.')
 
         if opacity_unit_distance is None:
-            opacity_unit_distance = volume.length / 100.0
+            opacity_unit_distance = volume.length / (np.mean(volume.dimensions) - 1)
 
         if scalars is None:
             # Make sure scalar components are not vectors/tuples

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1273,7 +1273,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                    blending='composite', mapper='smart',
                    stitle=None, scalar_bar_args=None, show_scalar_bar=None,
                    annotations=None, pickable=True, preference="point",
-                   opacity_unit_distance=None, **kwargs):
+                   opacity_unit_distance=None, shade=False, **kwargs):
         """
         Adds a volume, rendered using a fixed point ray cast mapper by default.
 
@@ -1396,6 +1396,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
             accumulated. This is adjusted for the actual sampling distance
             during rendering.
 
+        shade : bool
+            Default off. If shading is turned on, the mapper may perform
+            shading calculations - in some cases shading does not apply
+            (for example, in a maximum intensity projection) and therefore
+            shading will not be performed even if this flag is on.
+
         Returns
         -------
         actor: vtk.vtkVolume
@@ -1473,7 +1479,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
                                     ambient=ambient, categories=categories, loc=loc,
                                     culling=culling, clim=clim,
                                     mapper=mapper, pickable=pickable,
-                                    opacity_unit_distance=opacity_unit_distance)
+                                    opacity_unit_distance=opacity_unit_distance,
+                                    shade=shade)
 
                 actors.append(a)
             return actors
@@ -1641,6 +1648,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         prop.SetScalarOpacity(opacity_tf)
         prop.SetAmbient(ambient)
         prop.SetScalarOpacityUnitDistance(opacity_unit_distance)
+        prop.SetShade(shade)
         self.volume.SetProperty(prop)
 
         actor, prop = self.add_actor(self.volume, reset_camera=reset_camera,

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1389,6 +1389,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         mapper : str, optional
             Volume mapper to use given by name. Options include:
             ``'fixed_point'``, ``'gpu'``, ``'open_gl'``, and ``'smart'``.
+            If ``None`` the ``"volume_mapper"`` in the ``rcParams`` is used.
 
         scalar_bar_args : dict, optional
             Dictionary of keyword arguments to pass when adding the scalar bar

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1078,7 +1078,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
             title = stitle
         if scalars is not None:
             # if scalars is a string, then get the first array found with that name
-            set_active = True
 
             if not isinstance(scalars, np.ndarray):
                 scalars = np.asarray(scalars)
@@ -1114,10 +1113,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
             def prepare_mapper(scalars):
                 # Scalar interpolation approach
                 if scalars.shape[0] == mesh.n_points:
-                    self.mesh._add_point_array(scalars, title, set_active)
+                    self.mesh._add_point_array(scalars, title, True)
                     self.mapper.SetScalarModeToUsePointData()
                 elif scalars.shape[0] == mesh.n_cells:
-                    self.mesh._add_cell_array(scalars, title, set_active)
+                    self.mesh._add_cell_array(scalars, title, True)
                     self.mapper.SetScalarModeToUseCellData()
                 else:
                     raise_not_matching(scalars, mesh)
@@ -1488,15 +1487,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
         ##############
 
         title = 'Data' if stitle is None else stitle
-        set_active = False
         if isinstance(scalars, str):
             title = scalars
             scalars = get_array(volume, scalars,
                                 preference=preference, err=True)
             if stitle is None:
                 stitle = title
-        else:
-            set_active = True
 
         if not isinstance(scalars, np.ndarray):
             scalars = np.asarray(scalars)
@@ -1524,10 +1520,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         # Scalar interpolation approach
         if scalars.shape[0] == volume.n_points:
-            volume._add_point_array(scalars, title, set_active)
+            volume._add_point_array(scalars, title, True)
             self.mapper.SetScalarModeToUsePointData()
         elif scalars.shape[0] == volume.n_cells:
-            volume._add_cell_array(scalars, title, set_active)
+            volume._add_cell_array(scalars, title, True)
             self.mapper.SetScalarModeToUseCellData()
         else:
             raise_not_matching(scalars, volume)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1273,7 +1273,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
                    blending='composite', mapper=None,
                    stitle=None, scalar_bar_args=None, show_scalar_bar=None,
                    annotations=None, pickable=True, preference="point",
-                   opacity_unit_distance=None, shade=False, **kwargs):
+                   opacity_unit_distance=None, shade=False,
+                   diffuse=0.7, specular=0.2, specular_power=10.0, **kwargs):
         """
         Adds a volume, rendered using a fixed point ray cast mapper by default.
 
@@ -1402,6 +1403,15 @@ class BasePlotter(PickingHelper, WidgetHelper):
             (for example, in a maximum intensity projection) and therefore
             shading will not be performed even if this flag is on.
 
+        diffuse : float, optional
+            The diffuse lighting coefficient. Default 1.0
+
+        specular : float, optional
+            The specular lighting coefficient. Default 0.0
+
+        specular_power : float, optional
+            The specular power. Between 0.0 and 128.0
+
         Returns
         -------
         actor: vtk.vtkVolume
@@ -1483,7 +1493,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
                                     culling=culling, clim=clim,
                                     mapper=mapper, pickable=pickable,
                                     opacity_unit_distance=opacity_unit_distance,
-                                    shade=shade)
+                                    shade=shade, diffuse=diffuse, specular=specular,
+                                    specular_power=specular_power)
 
                 actors.append(a)
             return actors
@@ -1652,6 +1663,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
         prop.SetAmbient(ambient)
         prop.SetScalarOpacityUnitDistance(opacity_unit_distance)
         prop.SetShade(shade)
+        prop.SetDiffuse(diffuse)
+        prop.SetSpecular(specular)
+        prop.SetSpecularPower(specular_power)
         self.volume.SetProperty(prop)
 
         actor, prop = self.add_actor(self.volume, reset_camera=reset_camera,

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1270,7 +1270,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                    opacity='linear', n_colors=256, cmap=None, flip_scalars=False,
                    reset_camera=None, name=None, ambient=0.0, categories=False,
                    loc=None, culling=False, multi_colors=False,
-                   blending='composite', mapper='smart',
+                   blending='composite', mapper=None,
                    stitle=None, scalar_bar_args=None, show_scalar_bar=None,
                    annotations=None, pickable=True, preference="point",
                    opacity_unit_distance=None, shade=False, **kwargs):
@@ -1430,6 +1430,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         if culling is True:
             culling = 'backface'
+
+        if mapper is None:
+            mapper = rcParams["volume_mapper"]
 
         # Convert the VTK data object to a pyvista wrapped object if necessary
         if not is_pyvista_dataset(volume):

--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -61,11 +61,10 @@ rcParams = {
     },
     'multi_samples': 4,
     'multi_rendering_splitting_position': None,
-    "volume_mapper": "smart"
+    "volume_mapper": "fixed_point" if os.name == 'nt' else "smart",
 }
 
-if os.name == 'nt':
-    rcParams["volume_mapper"] = "fixed_point"
+
 
 DEFAULT_THEME = dict(rcParams)
 

--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -1,4 +1,5 @@
 
+import os
 import vtk
 
 from .colors import string_to_rgb, PARAVIEW_BACKGROUND
@@ -60,7 +61,11 @@ rcParams = {
     },
     'multi_samples': 4,
     'multi_rendering_splitting_position': None,
+    "volume_mapper": "smart"
 }
+
+if os.name == 'nt':
+    rcParams["volume_mapper"] = "fixed_point"
 
 DEFAULT_THEME = dict(rcParams)
 


### PR DESCRIPTION
Resolve #428, resolve #430, resolve #431, resolve #444

Woot! 🎉 

This fixes all the opacity issues we've been having when volume rendering. The problem had to do with how the opacity transfer function is applied over a distance - the default distance to apply it over was set to 1.0 which means if you have a mesh with an extent less than 1.0, the whole dataset could be transparent (#444) as the opacity function would be applied over an extent bigger than the mesh. Likewise, if you have a really big mesh, you wouldn't see any effect from the opacity transfer function (#430 and #431) for the inverse reason.

This also:
- fixes an issue around how the scalars were not properly set when volume rendering (#428)
- implements an option for shading when volume rendering
- adds diffuse and specular controls to volume rendering

@keltonhalbert, can you check this out with your data and make sure all is good?

@pyvista/developers, I'd like to merge this as soon as possible so a review would be greatly appreciated! Notable changes

- changes default mapper to `"smart"`. We've gone back and forth between what mapper to use in a few issues and implemented the `"fixed_point"` mapper at first as outlined in https://github.com/pyvista/pyvista/pull/231#issuecomment-496247649 and later justified in https://github.com/pyvista/pyvista/issues/301#issuecomment-509709765, but now I am having significant performance issues when using that mapper on my machine. The smart mapper performs the best for me so that's why I propose switching it. @supersubscript, do you have any objections to this? This may need to be checked for support on Windows and Linux (I'm Mac).
- Adds controls to two attributes of the volume property (minor impact) but are my default values good? for the opacity distance, I chose 1/100th of the length of the mesh which is what ParaView implements (I think).

------

## Fix to #428 

![download](https://user-images.githubusercontent.com/22067021/69401448-58198180-0cb2-11ea-81bd-0a49a9d990ac.png)


## Fix to #430 and #431 

![download](https://user-images.githubusercontent.com/22067021/69401496-71223280-0cb2-11ea-9445-16ac3d5ac9aa.png)

## Shading

![sphx_glr_volume_004](https://user-images.githubusercontent.com/22067021/69402859-5356cc80-0cb6-11ea-9f60-7c85da387af6.png)
