### PR TITLE
Use world coordinates with click tracking

### DIFF
--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -385,5 +385,5 @@ class PickingHelper(object):
             if hasattr(callback, '__call__'):
                 try_callback(callback, click_point)
 
-        self.track_click_position("right", _the_callback)
+        self.track_click_position(callback=_the_callback, side="right")
         return

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -297,7 +297,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             del self._mouse_observer
 
 
-    def track_click_position(self, side="right", callback=None,
+    def track_click_position(self, callback=None, side="right",
                              viewport=False):
         """Keep track of the click position.
 
@@ -305,13 +305,13 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         Parameters
         ----------
-        side : str
-            The side of the mouse for the button to track (left or right).
-            Default is left. Also accepts ``'r'`` or ``'l'``.
-
         callback : callable
             A callable method that will use the click position. Passes the
             click position as a length two tuple.
+
+        side : str
+            The side of the mouse for the button to track (left or right).
+            Default is left. Also accepts ``'r'`` or ``'l'``.
 
         viewport: bool
             If ``True``, uses the normalized viewport coordinate system

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -272,7 +272,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.mouse_position = self.iren.GetEventPosition()
 
     def store_click_position(self, *args):
-        """Store click position."""
+        """Store click position in viewport coordinates."""
         if not hasattr(self, "iren"):
             raise AttributeError("This plotting window is not interactive.")
         self.click_position = self.iren.GetEventPosition()
@@ -297,7 +297,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
             del self._mouse_observer
 
 
-    def track_click_position(self, side="right", callback=None, use_world=True):
+    def track_click_position(self, side="right", callback=None,
+                             viewport=False):
         """Keep track of the click position.
 
         By default, it only tracks right clicks.
@@ -312,9 +313,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
             A callable method that will use the click position. Passes the
             click position as a length two tuple.
 
-        use_world : bool
-            If ``True``, pass the picked world coordinates to the callback.
-            If ``False``, pass the picked viewport coordinates to the callback.
+        viewport: bool
+            If ``True``, uses the normalized viewport coordinate system
+            (values between 0.0 and 1.0 and support for HiDPI) when passing the
+            click position to the callback
 
         """
         if not hasattr(self, "iren"):
@@ -328,10 +330,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
         def _click_callback(obj, event):
             self.store_click_position()
             if hasattr(callback, '__call__'):
-                if use_world:
-                    try_callback(callback, self.pick_click_position())
-                else:
+                if viewport:
                     try_callback(callback, self.click_position)
+                else:
+                    try_callback(callback, self.pick_click_position())
 
         obs = self.iren.AddObserver(event, _click_callback)
         self._click_observer = obs

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -307,7 +307,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         ----------
         side : str
             The side of the mouse for the button to track (left or right).
-            Default is left. Also accepts ``'r'``.
+            Default is left. Also accepts ``'r'`` or ``'l'``.
 
         callback : callable
             A callable method that will use the click position. Passes the
@@ -322,10 +322,13 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if not hasattr(self, "iren"):
             return
 
-        if side in ["right", "r", "R"]:
+        side = str(side).lower()
+        if side in ["right", "r"]:
             event = vtk.vtkCommand.RightButtonPressEvent
-        else:
+        elif side in ["left", "l"]:
             event = vtk.vtkCommand.LeftButtonPressEvent
+        else:
+            raise TypeError("Side ({}) not supported. Try `left` or `right`".format(side))
 
         def _click_callback(obj, event):
             self.store_click_position()

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -297,7 +297,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             del self._mouse_observer
 
 
-    def track_click_position(self, side="right", callback=None):
+    def track_click_position(self, side="right", callback=None, use_world=True):
         """Keep track of the click position.
 
         By default, it only tracks right clicks.
@@ -312,6 +312,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
             A callable method that will use the click position. Passes the
             click position as a length two tuple.
 
+        use_world : bool
+            If ``True``, pass the picked world coordinates to the callback.
+            If ``False``, pass the picked viewport coordinates to the callback.
+
         """
         if not hasattr(self, "iren"):
             return
@@ -324,7 +328,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
         def _click_callback(obj, event):
             self.store_click_position()
             if hasattr(callback, '__call__'):
-                try_callback(callback, self.click_position)
+                if use_world:
+                    try_callback(callback, self.pick_click_position())
+                else:
+                    try_callback(callback, self.click_position)
 
         obs = self.iren.AddObserver(event, _click_callback)
         self._click_observer = obs
@@ -1796,7 +1803,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def add_actor(self, uinput, reset_camera=False, name=None, loc=None,
                   culling=False, pickable=True):
         """Add an actor to render window.
-        
+
         Creates an actor if input is a mapper.
 
         Parameters


### PR DESCRIPTION
Previously, when tracking the click position, it would use the viewport coordinates. Now it picks the world coordinates by default