### PR TITLE
MAINT: Fix documentation style

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1043,7 +1043,7 @@ class StructuredGrid(vtkStructuredGrid, PointGrid):
         return self.points[:, 2].reshape(self.dimensions, order='F')
 
     def _get_attrs(self):
-        """An internal helper for the representation methods"""
+        """Return the representation methods (internal helper)."""
         attrs = PointGrid._get_attrs(self)
         attrs.append(("Dimensions", self.dimensions, "{:d}, {:d}, {:d}"))
         return attrs


### PR DESCRIPTION
This fixes the last complain of `pydocstyle` found on https://github.com/pyvista/pyvista/pull/457#issuecomment-557868548