### PR TITLE
Add copy_function_doc decorator

### DIFF
--- a/pyvista/utilities/__init__.py
+++ b/pyvista/utilities/__init__.py
@@ -8,3 +8,4 @@ from .geometric_objects import *
 from .parametric_objects import *
 from .sphinx_gallery import Scraper, _get_sg_image_scraper
 from .helpers import *
+from .docs import *

--- a/pyvista/utilities/docs.py
+++ b/pyvista/utilities/docs.py
@@ -1,0 +1,38 @@
+"""Module containing helper function for the documentation."""
+
+
+def copy_function_doc(source, alias=False, deprecated=False):
+    """Copy the docstring from another function (decorator).
+
+    The docstring of the source function is prepepended to the docstring of the
+    function wrapped by this decorator.
+
+    Parameters
+    ----------
+    source : function
+        Function to copy the docstring from.
+
+    Return
+    ------
+    wrapper : function
+        The decorated function.
+
+    """
+    def wrapper(func):
+        if source.__doc__ is None or len(source.__doc__) == 0:
+            raise ValueError('Cannot copy docstring: docstring was empty.')
+        doc = source.__doc__
+        if func.__doc__ is not None:
+            if not doc.rstrip(' ').endswith('\n'):
+                doc += '\n'
+            doc += func.__doc__
+        elif alias or deprecated:
+            doc += '\n'
+        if alias:
+            doc += 'Alias for: ``' + source.__name__ + '``.\n'
+        elif deprecated:
+            doc += 'DEPRECATED: Please use ``' + source.__name__ \
+                + '`` instead.\n'
+        func.__doc__ = doc
+        return func
+    return wrapper

--- a/pyvista/utilities/docs.py
+++ b/pyvista/utilities/docs.py
@@ -11,6 +11,10 @@ def copy_function_doc(source, alias=False, deprecated=False):
     ----------
     source : function
         Function to copy the docstring from.
+    alias : bool
+        Specify if the decorated function is an alias version of source.
+    deprecated : bool
+        Specify if the decorated function is deprecated.
 
     Return
     ------

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,66 @@
+import pytest
+from pyvista.utilities import copy_function_doc
+
+
+def test_copy_function_doc():
+    """Test copying function documentation."""
+
+    def blank():
+        pass
+
+    def foo():
+        """Single line."""
+        pass
+
+    def foo2():
+        """Multiple.
+
+        Lines.
+        """
+        pass
+
+    @copy_function_doc(foo)
+    def bar():
+        pass
+
+    @copy_function_doc(foo)
+    def bar2():
+        """Single line."""
+        pass
+
+    @copy_function_doc(foo2)
+    def bar3():
+        """Single line."""
+        pass
+
+    @copy_function_doc(foo2)
+    def bar4():
+        """Multiple.
+
+        Lines.
+        """
+        pass
+
+    @copy_function_doc(foo, deprecated=True)
+    def dep_fun():
+        pass
+
+    @copy_function_doc(foo2, alias=True)
+    def alias_fun():
+        """Multiple.
+
+        Lines.
+        """
+        pass
+
+    with pytest.raises(ValueError):
+        @copy_function_doc(blank)
+        def blank2():
+            pass
+    assert bar.__doc__ == foo.__doc__
+    assert bar2.__doc__ == foo.__doc__ + '\nSingle line.'
+    assert bar3.__doc__ == foo2.__doc__ + 'Single line.'
+    assert bar4.__doc__ == foo2.__doc__ + foo2.__doc__
+    assert dep_fun.__doc__ == foo.__doc__ + '\nDEPRECATED: Please use' + \
+        ' ``foo`` instead.\n'
+    assert alias_fun.__doc__ == bar4.__doc__ + 'Alias for: ``foo2``.\n'


### PR DESCRIPTION
Following this https://github.com/pyvista/pyvista/pull/461#issuecomment-557789538, this PR adds a `copy_function_doc` decorator with its corresponding tests.