### PR TITLE
🚧 copy_function_doc decorator

### DIFF
--- a/pyvista/utilities/__init__.py
+++ b/pyvista/utilities/__init__.py
@@ -1,6 +1,7 @@
 """Utilities routines."""
 
-from .docs import copy_function_doc
+from .docs import (copy_function_doc, deprecated_function_doc,
+                   aliased_function_doc)
 from .errors import (Observer, Report, assert_empty_kwargs,
                      send_errors_to_logging, set_error_output_file)
 from .features import *

--- a/pyvista/utilities/__init__.py
+++ b/pyvista/utilities/__init__.py
@@ -1,5 +1,6 @@
 """Utilities routines."""
 
+from .docs import copy_function_doc
 from .errors import (Observer, Report, assert_empty_kwargs,
                      send_errors_to_logging, set_error_output_file)
 from .features import *

--- a/pyvista/utilities/docs.py
+++ b/pyvista/utilities/docs.py
@@ -25,6 +25,7 @@ def copy_function_doc(source, alias=False, deprecated=False):
     def wrapper(func):
         if source.__doc__ is None or len(source.__doc__) == 0:
             raise ValueError('Cannot copy docstring: docstring was empty.')
+        # issue is here:
         doc = source.__doc__
         if func.__doc__ is not None:
             if not doc.rstrip(' ').endswith('\n'):

--- a/pyvista/utilities/docs.py
+++ b/pyvista/utilities/docs.py
@@ -33,6 +33,7 @@ def copy_function_doc(source):
 
 
 def deprecated_function_doc(source):
+    """Specify that the decorated function is a deprecated version of source."""
     def wrapper(func):
         doc = func.__doc__
         if func.__doc__ is not None:
@@ -47,6 +48,7 @@ def deprecated_function_doc(source):
 
 
 def aliased_function_doc(source):
+    """Specify that the decorated function is an alias version of source."""
     def wrapper(func):
         doc = func.__doc__
         if func.__doc__ is not None:

--- a/pyvista/utilities/docs.py
+++ b/pyvista/utilities/docs.py
@@ -1,7 +1,7 @@
 """Module containing helper function for the documentation."""
 
 
-def copy_function_doc(source, alias=False, deprecated=False):
+def copy_function_doc(source):
     """Copy the docstring from another function (decorator).
 
     The docstring of the source function is prepepended to the docstring of the
@@ -11,10 +11,6 @@ def copy_function_doc(source, alias=False, deprecated=False):
     ----------
     source : function
         Function to copy the docstring from.
-    alias : bool
-        Specify if the decorated function is an alias version of source.
-    deprecated : bool
-        Specify if the decorated function is deprecated.
 
     Return
     ------
@@ -31,13 +27,33 @@ def copy_function_doc(source, alias=False, deprecated=False):
             if not doc.rstrip(' ').endswith('\n'):
                 doc += '\n'
             doc += func.__doc__
-        elif alias or deprecated:
-            doc += '\n'
-        if alias:
-            doc += 'Alias for: ``' + source.__name__ + '``.\n'
-        elif deprecated:
-            doc += 'DEPRECATED: Please use ``' + source.__name__ \
-                + '`` instead.\n'
         func.__doc__ = doc
+        return func
+    return wrapper
+
+
+def deprecated_function_doc(source):
+    def wrapper(func):
+        doc = func.__doc__
+        if func.__doc__ is not None:
+            if not doc.rstrip(' ').endswith('\n'):
+                doc += '\n'
+        else:
+            func.__doc__ = ''
+        func.__doc__ += 'DEPRECATED: Please use ``' + source.__name__ + \
+            '`` instead.\n'
+        return func
+    return wrapper
+
+
+def aliased_function_doc(source):
+    def wrapper(func):
+        doc = func.__doc__
+        if func.__doc__ is not None:
+            if not doc.rstrip(' ').endswith('\n'):
+                doc += '\n'
+        else:
+            func.__doc__ = ''
+        func.__doc__ += 'Alias for: ``' + source.__name__ + '``.\n'
         return func
     return wrapper

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -2,6 +2,28 @@ import pytest
 from pyvista.utilities import copy_function_doc
 
 
+
+class Foo:
+    def goo(self, *args):
+        """This has some documentation.
+
+        Parameters
+        ----------
+        arg0 : int
+            This is an argument.
+
+        """
+        pass
+
+    @copy_function_doc(goo, alias=True)
+    def goo_alias(self, *args):
+        pass
+
+    @copy_function_doc(goo, deprecated=True)
+    def goo_depr(self, *args):
+        pass
+
+
 def test_copy_function_doc():
     """Test copying function documentation."""
 
@@ -57,6 +79,7 @@ def test_copy_function_doc():
         @copy_function_doc(blank)
         def blank2():
             pass
+
     assert bar.__doc__ == foo.__doc__
     assert bar2.__doc__ == foo.__doc__ + '\nSingle line.'
     assert bar3.__doc__ == foo2.__doc__ + 'Single line.'
@@ -64,3 +87,7 @@ def test_copy_function_doc():
     assert dep_fun.__doc__ == foo.__doc__ + '\nDEPRECATED: Please use' + \
         ' ``foo`` instead.\n'
     assert alias_fun.__doc__ == bar4.__doc__ + 'Alias for: ``foo2``.\n'
+    # Test a class
+    assert Foo.goo_alias.__doc__ == Foo.goo.__doc__ + '\nAlias for: ``goo``.\n'
+    assert Foo.goo_depr.__doc__ == Foo.goo.__doc__ + '\nDEPRECATED: Please use' + \
+        ' ``goo`` instead.\n'

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,6 +1,6 @@
 import pytest
-from pyvista.utilities import copy_function_doc
-
+from pyvista.utilities import (copy_function_doc, deprecated_function_doc,
+                               aliased_function_doc)
 
 
 class Foo:
@@ -15,11 +15,13 @@ class Foo:
         """
         pass
 
-    @copy_function_doc(goo, alias=True)
+    @copy_function_doc(goo)
+    @aliased_function_doc(goo)
     def goo_alias(self, *args):
         pass
 
-    @copy_function_doc(goo, deprecated=True)
+    @copy_function_doc(goo)
+    @deprecated_function_doc(goo)
     def goo_depr(self, *args):
         pass
 
@@ -63,11 +65,13 @@ def test_copy_function_doc():
         """
         pass
 
-    @copy_function_doc(foo, deprecated=True)
+    @copy_function_doc(foo)
+    @deprecated_function_doc(foo)
     def dep_fun():
         pass
 
-    @copy_function_doc(foo2, alias=True)
+    @copy_function_doc(foo2)
+    @aliased_function_doc(foo2)
     def alias_fun():
         """Multiple.
 
@@ -88,6 +92,6 @@ def test_copy_function_doc():
         ' ``foo`` instead.\n'
     assert alias_fun.__doc__ == bar4.__doc__ + 'Alias for: ``foo2``.\n'
     # Test a class
-    assert Foo.goo_alias.__doc__ == Foo.goo.__doc__ + '\nAlias for: ``goo``.\n'
-    assert Foo.goo_depr.__doc__ == Foo.goo.__doc__ + '\nDEPRECATED: Please use' + \
+    assert Foo.goo_alias.__doc__ == Foo.goo.__doc__ + 'Alias for: ``goo``.\n'
+    assert Foo.goo_depr.__doc__ == Foo.goo.__doc__ + 'DEPRECATED: Please use' + \
         ' ``goo`` instead.\n'


### PR DESCRIPTION
@GuillaumeFavelier, I didn't do my due diligence in reviewing #469 (which I reverted and put in this PR)

It doesn't work well for class methods. For example, the following class was just added to the tests and passes, but it looks like this:

```py
import pytest
from pyvista.utilities import copy_function_doc


class Foo:
    def goo(self, *args):
        """This has some documentation.

        Parameters
        ----------
        arg0 : int
            This is an argument.

        """
        pass

    @copy_function_doc(goo, alias=True)
    def goo_alias(self, *args):
        pass

    @copy_function_doc(goo, deprecated=True)
    def goo_depr(self, *args):
        pass
```

```py
>>> help(Foo.goo)
Help on function goo in module __main__:

goo(self, *args)
    This has some documentation.
    
    Parameters
    ----------
    arg0 : int
        This is an argument.
```

```py
>>> help(Foo.goo_alias)
Help on function goo_alias in module __main__:

goo_alias(self, *args)
    This has some documentation.
    
            Parameters
            ----------
            arg0 : int
                This is an argument.
    
            
    Alias for: ``goo``.
```

As shown, the aliased method's docs are improperly formatted - and thus Sphinx cannot properly auto-document that function.