### PR TITLE
MAINT: pydocstyle update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ matrix:
     - name: Documentation Testing 3.7
       python: 3.7
       script: |
-        pip install codespell pydocstyle;
+        pip install codespell pydocstyle==4.0.1;
         make doctest;
     - name: Documentation Build/Deploy 3.7
       python: 3.7


### PR DESCRIPTION
This PR triggers the CIs to check the result of `pydocstyle` since the new version 5.0.0 is released.