### PR TITLE
Read lists of files as MultiBlock datasets

### DIFF
--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -169,8 +169,11 @@ def read(filename, attrs=None, file_format=None):
     if isinstance(filename, (list, tuple)):
         multi = pyvista.MultiBlock()
         for each in filename:
-            name = os.path.basename(each)
-            multi[name] = read(each)
+            if isinstance(each, str):
+                name = os.path.basename(each)
+            else:
+                name = None
+            multi[-1, name] = read(each)
         return multi
     filename = os.path.abspath(os.path.expanduser(filename))
     if not os.path.isfile(filename):

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -153,6 +153,10 @@ def read(filename, attrs=None, file_format=None):
 
     Parameters
     ----------
+    filename : str
+        The string path to the file to read. If a list of files is given,
+        a :class:`pyvista.MultiBlock` dataset is returned with each file being
+        a seperate block in the dataset.
     attrs : dict, optional
         A dictionary of attributes to call on the reader. Keys of dictionary are
         the attribute/method names and values are the arguments passed to those
@@ -162,6 +166,12 @@ def read(filename, attrs=None, file_format=None):
         Format of file to read with meshio.
 
     """
+    if isinstance(filename, (list, tuple)):
+        multi = pyvista.MultiBlock()
+        for each in filename:
+            name = os.path.basename(each)
+            multi[name] = read(each)
+        return multi
     filename = os.path.abspath(os.path.expanduser(filename))
     if not os.path.isfile(filename):
         raise IOError('File ({}) not found'.format(filename))

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -59,6 +59,10 @@ def test_read(tmpdir):
     # read non existing file
     with pytest.raises(IOError):
         _ = pyvista.read('this_file_totally_does_not_exist.vtk')
+    # Now test reading lists of files as multi blocks
+    multi = pyvista.read(fnames)
+    assert isinstance(multi, pyvista.MultiBlock)
+    assert multi.n_blocks == len(fnames)
 
 
 def test_get_array():

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -63,6 +63,14 @@ def test_read(tmpdir):
     multi = pyvista.read(fnames)
     assert isinstance(multi, pyvista.MultiBlock)
     assert multi.n_blocks == len(fnames)
+    nested = [ex.planefile,
+              [ex.hexbeamfile, ex.uniformfile]]
+
+    multi = pyvista.read(nested)
+    assert isinstance(multi, pyvista.MultiBlock)
+    assert multi.n_blocks == 2
+    assert isinstance(multi[1], pyvista.MultiBlock)
+    assert multi[1].n_blocks == 2
 
 
 def test_get_array():


### PR DESCRIPTION
These changes enable recursive calling of `pv.read()` so that you can pass a nest list of filenames and get back a nested `pyvista.MultiBlock` dataset of all those meshes

For example:
```py
import glob
import pyvista as pv

files = glob.glob("archive/*.vtu")
dataset = pv.read(files)
```

or you could have nested file structures like:

```py
from pyvista import examples

files = [examples.planefile, 
         [examples.hexbeamfile, examples.uniformfile]]

dataset = pv.read(files)
```

![Screen Shot 2019-12-09 at 7 39 57 PM](https://user-images.githubusercontent.com/22067021/70490518-cb493300-1abb-11ea-9f2e-cdbe33694e5d.png)
