### PR TITLE
Fix QVTKRWIBase default value

### DIFF
--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -7,14 +7,20 @@ import time
 import numpy as np
 import scooby
 import vtk
-import vtk.qt
 
 import pyvista
 from .plotting import BasePlotter
 from .theme import rcParams
 
 # for display bugs due to older intel integrated GPUs
-vtk.qt.QVTKRWIBase = 'QGLWidget'
+vtk_major_version = vtk.vtkVersion.GetVTKMajorVersion()
+vtk_minor_version = vtk.vtkVersion.GetVTKMinorVersion()
+if vtk_major_version == 8 and vtk_minor_version < 2:
+    import vtk.qt
+    vtk.qt.QVTKRWIBase = 'QGLWidget'
+else:
+    import vtkmodules.qt
+    vtkmodules.qt.QVTKRWIBase = 'QGLWidget'
 
 log = logging.getLogger(__name__)
 log.setLevel('DEBUG')


### PR DESCRIPTION
Update the default class chosen by `QVTKRenderWindowInteractor` depending on the version of `vtk`.
The fix was suggested by @math-artist.

To reproduce, using the version `8.2` of `vtk`:

On my configuration, before:

```py
>>> import pyvista
>>> import vtk
>>> vtk.qt.QVTKRenderWindowInteractor.QVTKRenderWindowInteractor.__bases__
(<class 'PyQt5.QtWidgets.QWidget'>,)
```

With this patch:
```py
>>> import pyvista
>>> import vtk
>>> vtk.qt.QVTKRenderWindowInteractor.QVTKRenderWindowInteractor.__bases__
(<class 'PyQt5.QtOpenGL.QGLWidget'>,)
```

Closes #473 