### PR TITLE
Log scale color mapping and arial default font

### DIFF
--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -21,7 +21,7 @@ rcParams = {
     },
     'window_size': [1024, 768],
     'font': {
-        'family': 'courier',
+        'family': 'arial',
         'size': 12,
         'title_size': None,
         'label_size': None,


### PR DESCRIPTION
This enables access to a log scale when mapping the scalars during plotting and also changes the default font to Arial because courier looked harsh to me

Using the dataset from https://github.com/pyvista/pyvista-support/issues/83

No log scale:

![download](https://user-images.githubusercontent.com/22067021/70760315-7a794a80-1d06-11ea-8849-d9f4c6265e86.png)


With a log scale:

![download](https://user-images.githubusercontent.com/22067021/70760323-81a05880-1d06-11ea-8d7d-d20545f48932.png)
