### PR TITLE
🚧 Fix window exit crash

### DIFF
--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -15,7 +15,7 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
          interactive=True, cpos=None, window_size=None,
          show_bounds=False, show_axes=True, notebook=None, background=None,
          text='', return_img=False, eye_dome_lighting=False, use_panel=None,
-         volume=False, parallel_projection=False, **kwargs):
+         volume=False, parallel_projection=False, auto_close=False, **kwargs):
     """Plot a vtk or numpy object.
 
     Parameters
@@ -78,7 +78,8 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
     eye_dome_lighting = kwargs.pop("edl", eye_dome_lighting)
     show_grid = kwargs.pop('show_grid', False)
     height = kwargs.get('height', 400)
-    auto_close = kwargs.get('auto_close', rcParams['auto_close'])
+    if  auto_close is None:
+        auto_close = rcParams['auto_close']
 
     if notebook:
         off_screen = notebook

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -353,9 +353,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def _close_callback(self):
         """Make sure a screenhsot is acquired before closing."""
         self.q_pressed = True
-        # Grab screenshot right before renderer closes
-        self.last_image = self.screenshot(True, return_img=True)
-        self.last_image_depth = self.get_image_depth()
+        self.close()
 
 
     def increment_point_size_and_line_width(self, increment):

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3956,7 +3956,7 @@ class Plotter(BasePlotter):
             self.iren.AddObserver(vtk.vtkCommand.TimerEvent, on_timer)
 
     def show(self, title=None, window_size=None, interactive=True,
-             auto_close=None, interactive_update=False, full_screen=False,
+             auto_close=False, interactive_update=False, full_screen=False,
              screenshot=False, return_img=False, use_panel=None, cpos=None,
              height=400):
         """Create a plotting window.


### PR DESCRIPTION
Considering the following simple code snippet:

```py
from pyvista import examples
import pyvista as pv
mesh = examples.download_st_helens()
p = pv.Plotter(notebook=False)
p.add_mesh(mesh)
p.show()
```

Running this on Windows on a IPython environment either on a `jupyter notebook` or `Spyder` terminal for example will open a window:

![image](https://user-images.githubusercontent.com/18143289/70846618-554a2080-1e5b-11ea-81fe-96ed156a5532.png)

But a few issues have been reported:

- [ ]  **1)** Closing the window with the X button crashes the kernel with `ERROR:root:Shader object was not initialized, cannot attach it.` (see https://github.com/pyvista/pyvista/issues/186#issuecomment-545598442 or https://github.com/pyvista/pyvista/issues/500#issue-537459287)
- [ ]  **2)** Closing the window with `q` closes correctly but if you run the cell again, the window will open and close instantly. You need to restart the kernel to have the correct behaviour: only the first run of the cell opens a window that actually stays opened. (see https://github.com/pyvista/pyvista/issues/186#issuecomment-550993270)

Closes #186 and #500 