### PR TITLE
MAINT: Use the latest version of pydocstyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ matrix:
     - name: Documentation Testing 3.7
       python: 3.7
       script: |
-        pip install codespell pydocstyle==4.0.1;
+        pip install codespell pydocstyle;
         make doctest;
     - name: Documentation Build/Deploy 3.7
       python: 3.7

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -691,7 +691,11 @@ class Common(DataSetFilters, DataObject):
 
     @property
     def active_scalar(self):
-        """DEPRECATED: Returns the active scalars as an array."""
+        """Return the active scalars as an array.
+
+        DEPRECATED: Please use `.active_scalars` instead.
+
+        """
         warnings.warn("DEPRECATED: please use `.active_scalars` instead.")
         return self.active_scalars
 

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2962,7 +2962,11 @@ class PolyDataFilters(DataSetFilters):
 
 
     def clip_with_plane(poly_data, origin, normal, value=0, invert=False, inplace=False):
-        """DEPRECATED: Use ``.clip`` instead."""
+        """Clip a dataset by a plane by specifying the origin and normal.
+
+        DEPRECATED: Please use `.clip` instead.
+
+        """
         logging.warning('DEPRECATED: ``clip_with_plane`` is deprecated. Use ``.clip`` instead.')
         return DataSetFilters.clip(poly_data, normal=normal, origin=origin, value=value, invert=invert, inplace=inplace)
 


### PR DESCRIPTION
Now that a [patch is available](https://github.com/PyCQA/pydocstyle/issues/434#issuecomment-563413927) in the version `5.0.1` of `pydocstyle`, we can use the latest version.