### PR TITLE
Use imageio if libjpeg is broken

### DIFF
--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -215,7 +215,7 @@ def read(filename, attrs=None, file_format=None):
                 except ReadError:
                     pass
             except SyntaxError:
-                # https://github.com/pyvista/pyvista/pull/495 
+                # https://github.com/pyvista/pyvista/pull/495
                 pass
 
     raise IOError("This file was not able to be automatically read by pyvista.")
@@ -228,8 +228,10 @@ def read_texture(filename, attrs=None):
         # initialize the reader using the extension to find it
         reader = get_reader(filename)
         image = standard_reader_routine(reader, filename, attrs=attrs)
+        if image.n_points < 2:
+            raise AssertionError("Problem reading the image with VTK.")
         return pyvista.image_to_texture(image)
-    except KeyError:
+    except (KeyError, AssertionError):
         # Otherwise, use the imageio reader
         pass
     import imageio


### PR DESCRIPTION
Patch to handle issues from https://github.com/conda-forge/vtk-feedstock/issues/98 if using the conda build of VTK