### PR TITLE
Prevent q-key from binding to QtInteractor class

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -380,7 +380,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
         """Reset all of the key press events to their defaults."""
         self._key_press_event_callbacks = collections.defaultdict(list)
 
-        self.add_key_event('q', self._close_callback)
+        if not isinstance(self, pyvista.QtInteractor) or isinstance(self, pyvista.BackgroundPlotter):
+            self.add_key_event('q', self._close_callback)
         b_left_down_callback = lambda: self.iren.AddObserver('LeftButtonPressEvent', self.left_button_down)
         self.add_key_event('b', b_left_down_callback)
         self.add_key_event('v', lambda: self.isometric_view_interactive())


### PR DESCRIPTION
Adress issue raised in https://github.com/pyvista/pyvista-support/issues/86#issuecomment-566595944 by @akaszynski 

Now the `q`-key will not bind to embedded widgets in Qt apps but will still close the `BackgroundPlotter`