### PR TITLE
Add update hook on ModifiedEvents for Qt widgets

### DIFF
--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -151,7 +151,7 @@ class FileDialog(QFileDialog):
 
 class DoubleSlider(QSlider):
     """Double precision slider.
-    
+
     Reference:
     https://gist.github.com/dennis-tra/994a65d6165a328d4eabaadbaedac2cc
 
@@ -357,7 +357,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
                  border=None, border_color='k', border_width=2.0,
                  multi_samples=None, line_smoothing=False,
                  point_smoothing=False, polygon_smoothing=False,
-                 splitting_position=None):
+                 splitting_position=None, auto_update=True):
         """Initialize Qt interactor."""
         if not has_pyqt:
             raise AssertionError('Requires PyQt5')
@@ -414,6 +414,11 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
 
             self.iren.AddObserver("KeyPressEvent", self.key_press_event)
 
+        if auto_update:
+            update_event = lambda *args: self.update()
+            for renderer in self.renderers:
+                renderer.AddObserver(vtk.vtkCommand.ModifiedEvent, update_event)
+                renderer.camera.AddObserver(vtk.vtkCommand.ModifiedEvent, update_event)
 
 
 
@@ -533,7 +538,7 @@ class BackgroundPlotter(QtInteractor):
     ICON_TIME_STEP = 5.0
 
     def __init__(self, show=True, app=None, shape=(1, 1), window_size=None,
-                 off_screen=None, **kwargs):
+                 off_screen=None, auto_update=True, **kwargs):
         """Initialize the qt plotter."""
         if not has_pyqt:
             raise AssertionError('Requires PyQt5')
@@ -573,7 +578,8 @@ class BackgroundPlotter(QtInteractor):
 
 
         QtInteractor.__init__(self, parent=self.frame, shape=shape,
-                              off_screen=off_screen, **kwargs)
+                              off_screen=off_screen, auto_update=auto_update,
+                              **kwargs)
         self.app_window.signal_close.connect(self.quit)
         self.add_toolbars(self.app_window)
 
@@ -675,7 +681,7 @@ class BackgroundPlotter(QtInteractor):
         QtInteractor.quit(self)
 
     def close(self):
-        """Close the plotter.""" 
+        """Close the plotter."""
         self.app_window.close()
 
     def add_actor(self, actor, reset_camera=None, name=None, loc=None, culling=False, pickable=True):

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -252,6 +252,8 @@ class Renderer(vtkRenderer):
 
         self.ResetCameraClippingRange()
 
+        self.Modified()
+
         return actor, actor.GetProperty()
 
 
@@ -681,6 +683,7 @@ class Renderer(vtkRenderer):
                     pass
 
         self.RemoveAllViewProps()
+        self.Modified()
 
     @camera_position.setter
     def camera_position(self, camera_location):
@@ -831,6 +834,7 @@ class Renderer(vtkRenderer):
             self.reset_camera()
         else:
             self.parent._render()
+        self.Modified()
         return True
 
 


### PR DESCRIPTION
This is a simple fix to https://github.com/pyvista/pyvista-support/issues/86 to make sure the `update` method is called on any modified events when embedding a plotter as a qt widget.

I set this up so it can easily be turned off (on by default) using the `auto_update` argument when instantiating the `QtInteractor` class

Resolves https://github.com/pyvista/pyvista-support/issues/86