### PR TITLE
Add GPU details to Report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install:
   - which python
   - python -c "import vtk; print(vtk.VTK_VERSION)"
   - pip list
+  - python -c "import pyvista; print(pyvista.Report())"
 
 before_script:
   - echo $TRAVIS_COMMIT

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,6 +41,7 @@ jobs:
   - script: |
       python setup.py sdist
       python setup.py install
+      python -c "import pyvista; print(pyvista.Report())"
     displayName: 'Install PyVista'
   - script: |
       del /Q tests\\test_qt_plotting.py

--- a/pyvista/utilities/__init__.py
+++ b/pyvista/utilities/__init__.py
@@ -1,7 +1,8 @@
 """Utilities routines."""
 
-from .errors import (Observer, Report, assert_empty_kwargs,
-                     send_errors_to_logging, set_error_output_file)
+from .errors import (GPUInfo, Observer, Report, assert_empty_kwargs,
+                     get_gpu_info, send_errors_to_logging,
+                     set_error_output_file)
 from .features import *
 from .fileio import *
 from .geometric_objects import *

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -218,7 +218,7 @@ class Report(scooby.Report):
         # bug that the user is trying to report.
         if gpu:
             try:
-                extra_meta = GPUInfo().get_info()
+                extra_meta = [(t[1], t[0]) for t in GPUInfo().get_info()]
             except:
                 extra_meta = ("GPU Details", "error")
 

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -8,6 +8,8 @@ import sys
 
 import vtk
 
+import pyvista
+
 
 def set_error_output_file(filename):
     """Set a file to write out the VTK errors."""
@@ -106,6 +108,76 @@ def send_errors_to_logging():
     return obs.observe(error_output)
 
 
+def get_gpu_info():
+    """Get all information about the GPU."""
+    # an OpenGL context MUST be opened before trying to do this.
+    plotter = pyvista.Plotter(notebook=False, off_screen=True)
+    plotter.add_mesh(pyvista.Sphere())
+    plotter.show(auto_close=False)
+    gpu_info = plotter.ren_win.ReportCapabilities()
+    plotter.close()
+    return gpu_info
+
+
+class GPUInfo():
+    """A class to hold GPU details."""
+    def __init__(self):
+        """Instantiate a container for the GPU information."""
+        self._gpu_info = get_gpu_info()
+
+
+    @property
+    def renderer(self):
+        """GPU renderer name."""
+        regex = re.compile("OpenGL renderer string:(.+)\n")
+        try:
+            renderer = regex.findall(self._gpu_info)[0]
+        except IndexError:
+            raise RuntimeError("Unable to parse GPU information for the renderer.")
+        return renderer.strip()
+
+
+    @property
+    def version(self):
+        """GPU renderer version."""
+        regex = re.compile("OpenGL version string:(.+)\n")
+        try:
+            version = regex.findall(self._gpu_info)[0]
+        except IndexError:
+            raise RuntimeError("Unable to parse GPU information for the version.")
+        return version.strip()
+
+
+    @property
+    def vendor(self):
+        """GPU renderer vendor."""
+        regex = re.compile("OpenGL vendor string:(.+)\n")
+        try:
+            vendor = regex.findall(self._gpu_info)[0]
+        except IndexError:
+            raise RuntimeError("Unable to parse GPU information for the vendor.")
+        return vendor.strip()
+
+
+    def get_info(self):
+        """All GPU information as tuple pairs."""
+        return (("GPU Vendor", self.vendor),
+                ("GPU Renderer", self.renderer),
+                ("GPU Version", self.version),
+               )
+
+
+    def _repr_html_(self):
+        """HTML table representation."""
+        fmt = "<table>"
+        row = "<tr><th>{}</th><td>{}</td></tr>\n"
+        for meta in self.get_info():
+            fmt += row.format(*meta)
+        fmt += "</table>"
+        return fmt
+
+
+
 class Report(scooby.Report):
     """A class for custom scooby.Report."""
 
@@ -135,9 +207,17 @@ class Report(scooby.Report):
         optional = ['matplotlib', 'PyQt5', 'IPython', 'colorcet',
                     'cmocean', 'panel']
 
+        # Information about the GPU - bare except incase there is a rendering
+        # bug that the user is trying to report.
+        try:
+            extra_meta = GPUInfo().get_info()
+        except:
+            extra_meta = ("GPU Details", "error")
+
         scooby.Report.__init__(self, additional=additional, core=core,
                                optional=optional, ncol=ncol,
-                               text_width=text_width, sort=sort)
+                               text_width=text_width, sort=sort,
+                               extra_meta=extra_meta)
 
 
 def assert_empty_kwargs(**kwargs):

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -178,6 +178,15 @@ class GPUInfo():
         return fmt
 
 
+    def __repr__(self):
+        """Representation method."""
+        content = "\n"
+        for k, v in self.get_info():
+            content += "{:>18}".format(k)+' : {}\n'.format(v)
+        content += "\n"
+        return content
+
+
 
 class Report(scooby.Report):
     """A class for custom scooby.Report."""

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -121,6 +121,7 @@ def get_gpu_info():
 
 class GPUInfo():
     """A class to hold GPU details."""
+
     def __init__(self):
         """Instantiate a container for the GPU information."""
         self._gpu_info = get_gpu_info()
@@ -181,7 +182,8 @@ class GPUInfo():
 class Report(scooby.Report):
     """A class for custom scooby.Report."""
 
-    def __init__(self, additional=None, ncol=3, text_width=80, sort=False):
+    def __init__(self, additional=None, ncol=3, text_width=80, sort=False,
+                 gpu=True):
         """Generate a :class:`scooby.Report` instance.
 
         Parameters
@@ -199,6 +201,11 @@ class Report(scooby.Report):
         sort : bool, optional
             Alphabetically sort the packages
 
+        gpu : bool
+            Gather information about the GPU. Defaults to ``True`` but if
+            experiencing renderinng issues, pass ``False`` to safely generate
+            a report.
+
         """
         # Mandatory packages.
         core = ['pyvista', 'vtk', 'numpy', 'imageio', 'appdirs', 'scooby']
@@ -209,10 +216,11 @@ class Report(scooby.Report):
 
         # Information about the GPU - bare except incase there is a rendering
         # bug that the user is trying to report.
-        try:
-            extra_meta = GPUInfo().get_info()
-        except:
-            extra_meta = ("GPU Details", "error")
+        if gpu:
+            try:
+                extra_meta = GPUInfo().get_info()
+            except:
+                extra_meta = ("GPU Details", "error")
 
         scooby.Report.__init__(self, additional=additional, core=core,
                                optional=optional, ncol=ncol,

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ imageio>=2.5.0
 imageio-ffmpeg
 colorcet
 cmocean
-scooby>=0.2.2
+scooby>=0.5.0
 meshio>=3.3.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with io_open(version_file, mode='r') as fd:
 install_requires = ['numpy',
                     'imageio',
                     'appdirs',
-                    'scooby>=0.2.2',
+                    'scooby>=0.5.0',
                     'meshio>=3.3.0',
                     ]
 


### PR DESCRIPTION
Waiting on a new release for `scooby`. Requires https://github.com/banesullivan/scooby/pull/39

These changes give us a way to gather information about a user's GPU:

```py
import pyvista as pv

pv.Report()
```
<img width="744" alt="Screen Shot 2019-12-19 at 6 33 47 PM" src="https://user-images.githubusercontent.com/22067021/71218080-34842f80-228e-11ea-9001-901d514ed162.png">

```py
print(pv.Report())
```
```
--------------------------------------------------------------------------------
  Date: Thu Dec 19 18:35:43 2019 EST

            Darwin : OS
                12 : CPU(s)
            x86_64 : Machine
             64bit : Architecture
        GPU Vendor : ATI Technologies Inc.
      GPU Renderer : AMD Radeon Pro Vega 20 OpenGL Engine
       GPU Version : 4.1 ATI-3.2.24
           32.0 GB : RAM
           Jupyter : Environment

  Python 3.7.3 | packaged by conda-forge | (default, Dec  6 2019, 08:36:57)
  [Clang 9.0.0 (tags/RELEASE_900/final)]

            0.23.0 : pyvista
             8.1.2 : vtk
            1.17.3 : numpy
             2.6.1 : imageio
             1.4.3 : appdirs
             0.4.3 : scooby
             3.1.2 : matplotlib
            5.12.3 : PyQt5
             7.6.1 : IPython
             1.0.0 : colorcet
               2.0 : cmocean
--------------------------------------------------------------------------------
```

```py
pv.GPUInfo()
```
<img width="360" alt="Screen Shot 2019-12-19 at 6 33 57 PM" src="https://user-images.githubusercontent.com/22067021/71218087-3c43d400-228e-11ea-98a9-da09347030d6.png">


```py
print(pv.get_gpu_info())
```
<details>

```
OpenGL vendor string:  ATI Technologies Inc.
OpenGL renderer string:  AMD Radeon Pro Vega 20 OpenGL Engine
OpenGL version string:  4.1 ATI-3.2.24
OpenGL extensions:  
  GL_ARB_blend_func_extended
  GL_ARB_draw_buffers_blend
  GL_ARB_draw_indirect
  GL_ARB_ES2_compatibility
  GL_ARB_explicit_attrib_location
  GL_ARB_gpu_shader_fp64
  GL_ARB_gpu_shader5
  GL_ARB_instanced_arrays
  GL_ARB_internalformat_query
  GL_ARB_occlusion_query2
  GL_ARB_sample_shading
  GL_ARB_sampler_objects
  GL_ARB_separate_shader_objects
  GL_ARB_shader_bit_encoding
  GL_ARB_shader_subroutine
  GL_ARB_shading_language_include
  GL_ARB_tessellation_shader
  GL_ARB_texture_buffer_object_rgb32
  GL_ARB_texture_cube_map_array
  GL_ARB_texture_gather
  GL_ARB_texture_query_lod
  GL_ARB_texture_rgb10_a2ui
  GL_ARB_texture_storage
  GL_ARB_texture_swizzle
  GL_ARB_timer_query
  GL_ARB_transform_feedback2
  GL_ARB_transform_feedback3
  GL_ARB_vertex_attrib_64bit
  GL_ARB_vertex_type_2_10_10_10_rev
  GL_ARB_viewport_array
  GL_EXT_debug_label
  GL_EXT_debug_marker
  GL_EXT_depth_bounds_test
  GL_EXT_texture_compression_s3tc
  GL_EXT_texture_filter_anisotropic
  GL_EXT_texture_mirror_clamp
  GL_EXT_texture_sRGB_decode
  GL_APPLE_client_storage
  GL_APPLE_container_object_shareable
  GL_APPLE_flush_render
  GL_APPLE_object_purgeable
  GL_APPLE_rgb_422
  GL_APPLE_row_bytes
  GL_APPLE_texture_range
  GL_ATI_texture_mirror_once
  GL_NV_texture_barrier
PixelFormat Descriptor:
  colorSize:  32
  alphaSize:  8
  stencilSize:  0
  depthSize:  32
  accumSize:  0
  double buffer:  Yes
  stereo:  No
  stencil:  0
  hardware acceleration:  Yes
  profile version:  0x3200
```

</details>