### PR TITLE
Add basic text slider

### DIFF
--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -637,6 +637,7 @@ class WidgetHelper(object):
             raise ValueError("Expected value for `event_type` is 'start',"
                              " 'end' or 'always': {} was given.".format(event_type))
         title_callback(slider_widget, None)
+        return slider_widget
 
 
     def add_slider_widget(self, callback, rng, value=None, title=None,

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -604,15 +604,50 @@ class WidgetHelper(object):
     def add_text_slider_widget(self, callback, data, value=None,
                               pointa=(.4, .9), pointb=(.9, .9),
                               color=None, event_type='end'):
-        """Add a text slider bar widget."""
+        """Add a text slider bar widget.
+
+        This is useless without a callback function. You can pass a callable
+        function that takes a single argument, the value of this slider widget,
+        and performs a task with that value.
+
+        Parameters
+        ----------
+        callback : callable
+            The method called every time the slider is updated. This should take
+            a single parameter: the float value of the slider
+
+        data: list
+            The list of possible values displayed on the slider bar
+
+        value : float, optional
+            The starting value of the slider
+
+        pointa : tuple(float)
+            The relative coordinates of the left point of the slider on the
+            display port
+
+        pointb : tuple(float)
+            The relative coordinates of the right point of the slider on the
+            display port
+
+        color : string or 3 item list, optional, defaults to white
+            Either a string, rgb list, or hex color string.
+
+        event_type: str
+            Either 'start', 'end' or 'always', this defines how often the
+            slider interacts with the callback.
+
+        """
         n_states = len(data)
         delta = (n_states - 1) / float(n_states)
 
         def _the_callback(value):
             if isinstance(value, float):
                 idx = int(value / delta)
-                if hasattr(callback, '__call__'):
-                    try_callback(callback, data[idx])
+            else:
+                idx = 0
+            if hasattr(callback, '__call__'):
+                try_callback(callback, data[idx])
             return
 
         slider_widget = self.add_slider_widget(callback=_the_callback, rng=[0, n_states - 1],

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -601,6 +601,44 @@ class WidgetHelper(object):
         return
 
 
+    def add_text_slider_widget(self, callback, data, value=None,
+                              pointa=(.4, .9), pointb=(.9, .9),
+                              color=None, event_type='end'):
+        """Add a text slider bar widget."""
+        n_states = len(data)
+        delta = (n_states - 1) / float(n_states)
+
+        def _the_callback(value):
+            if isinstance(value, float):
+                idx = int(value / delta)
+                if hasattr(callback, '__call__'):
+                    try_callback(callback, data[idx])
+            return
+
+        slider_widget = self.add_slider_widget(callback=_the_callback, rng=[0, n_states - 1],
+                                               value=value,
+                                               pointa=pointa, pointb=pointb,
+                                               color=color, event_type=event_type)
+        slider_rep = slider_widget.GetRepresentation()
+        slider_rep.ShowSliderLabelOff()
+
+        def title_callback(widget, event):
+            value = widget.GetRepresentation().GetValue()
+            idx = int(value / delta)
+            slider_rep.SetTitleText(data[idx])
+
+        if event_type == 'start':
+            slider_widget.AddObserver(vtk.vtkCommand.StartInteractionEvent, title_callback)
+        elif event_type == 'end':
+            slider_widget.AddObserver(vtk.vtkCommand.EndInteractionEvent, title_callback)
+        elif event_type == 'always':
+            slider_widget.AddObserver(vtk.vtkCommand.InteractionEvent, title_callback)
+        else:
+            raise ValueError("Expected value for `event_type` is 'start',"
+                             " 'end' or 'always': {} was given.".format(event_type))
+        title_callback(slider_widget, None)
+
+
     def add_slider_widget(self, callback, rng, value=None, title=None,
                           pointa=(.4, .9), pointb=(.9, .9),
                           color=None, pass_widget=False,

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -637,6 +637,11 @@ class WidgetHelper(object):
             Either 'start', 'end' or 'always', this defines how often the
             slider interacts with the callback.
 
+        Returns
+        -------
+        slider_widget: vtk.vtkSliderWidget
+            The VTK slider widget configured to display text.
+
         """
         if not isinstance(data, list):
             raise TypeError("The `data` parameter must be a list "

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -638,16 +638,24 @@ class WidgetHelper(object):
             slider interacts with the callback.
 
         """
+        if not isinstance(data, list):
+            raise TypeError("The `data` parameter must be iterable "
+                            "but {} was given : ", type(data))
         n_states = len(data)
+        if n_states == 0:
+            raise ValueError("The input list of values is empty")
         delta = (n_states - 1) / float(n_states)
+        # avoid division by zero in case there is only one element
+        delta = 1 if delta == 0 else delta
 
         def _the_callback(value):
             if isinstance(value, float):
                 idx = int(value / delta)
-            else:
-                idx = 0
-            if hasattr(callback, '__call__'):
-                try_callback(callback, data[idx])
+                # handle limit index
+                if idx == n_states:
+                    idx = n_states - 1
+                if hasattr(callback, '__call__'):
+                    try_callback(callback, data[idx])
             return
 
         slider_widget = self.add_slider_widget(callback=_the_callback, rng=[0, n_states - 1],
@@ -660,6 +668,9 @@ class WidgetHelper(object):
         def title_callback(widget, event):
             value = widget.GetRepresentation().GetValue()
             idx = int(value / delta)
+            # handle limit index
+            if idx == n_states:
+                idx = n_states - 1
             slider_rep.SetTitleText(data[idx])
 
         if event_type == 'start':

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -639,7 +639,7 @@ class WidgetHelper(object):
 
         """
         if not isinstance(data, list):
-            raise TypeError("The `data` parameter must be iterable "
+            raise TypeError("The `data` parameter must be a list "
                             "but {} was given : ", type(data))
         n_states = len(data)
         if n_states == 0:

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -104,6 +104,20 @@ def test_widget_line():
 
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+def test_widget_text_slider():
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
+    func = lambda value: value # Does nothing
+    p.add_mesh(mesh)
+    with pytest.raises(TypeError, match='must be iterable'):
+        p.add_text_slider_widget(callback=func, data='foo')
+    with pytest.raises(ValueError, match='list of values is empty'):
+        p.add_text_slider_widget(callback=func, data=[])
+    p.add_text_slider_widget(callback=func, data=['foo', 'bar'])
+    p.clear_slider_widgets()
+    p.close()
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_widget_slider():
     p = pyvista.Plotter(off_screen=OFF_SCREEN)
     func = lambda value: value # Does nothing

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -108,7 +108,7 @@ def test_widget_text_slider():
     p = pyvista.Plotter(off_screen=OFF_SCREEN)
     func = lambda value: value # Does nothing
     p.add_mesh(mesh)
-    with pytest.raises(TypeError, match='must be iterable'):
+    with pytest.raises(TypeError, match='must be a list'):
         p.add_text_slider_widget(callback=func, data='foo')
     with pytest.raises(ValueError, match='list of values is empty'):
         p.add_text_slider_widget(callback=func, data=[])


### PR DESCRIPTION
This PR adds a text slider widget. This is a specialized version of `add_slider_widget()` for convenience.

```py
import pyvista as pv

data = ['red', 'green', 'blue', 'purple', 'orange']
cone = pv.Cone()


def set_color(color):
    color = pv.parse_color(color)
    cone.point_arrays['color'] = [color] * cone.n_points


p = pv.Plotter()
p.add_text_slider_widget(set_color, data=data, event_type='always')
p.add_mesh(cone, scalars='color', rgba=True)
p.show()
```

![output](https://user-images.githubusercontent.com/18143289/71544876-9165a100-2984-11ea-82f9-4067920258d3.gif)

This is still a work in progress. I have to:

- [x] Rework the documentation
- [x] Update the tests
- [x] Return the slider