### PR TITLE
Add new filter sample_over_line and refactor plot_over_line

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1628,7 +1628,6 @@ class DataSetFilters(object):
         return sampled_line
 
 
-
     def plot_over_line(dataset, pointa, pointb, resolution=None, scalars=None,
                        title=None, ylabel=None, figsize=None, figure=True,
                        show=True):

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1621,8 +1621,6 @@ class DataSetFilters(object):
         """
         if resolution is None:
             resolution = int(dataset.n_cells)
-        if not isinstance(resolution, int) or resolution < 0:
-            raise RuntimeError('`resolution` must be a positive integer, not {}'.format(type(resolution)))
         # Make a line and sample the dataset
         line = pyvista.Line(pointa, pointb, resolution=resolution)
         

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -338,6 +338,8 @@ def Line(pointa=(-0.5, 0., 0.), pointb=(0.5, 0., 0.), resolution=1):
         number of pieces to divide line into
 
     """
+    if resolution <= 0:
+        raise ValueError('Resolution must be positive')
     if np.array(pointa).size != 3:
         raise TypeError('Point A must be a length three tuple of floats.')
     if np.array(pointb).size != 3:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -504,6 +504,7 @@ def test_sample_over_line():
     # is sampled result a polydata object
     assert isinstance(sampled_from_sphere, pyvista.PolyData)
 
+
 def test_plot_over_line():
     """this requires matplotlib"""
     mesh = examples.load_uniform()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -484,6 +484,26 @@ def test_streamlines():
     assert src.n_points == 25
 
 
+def test_sample_over_line():
+    """Test that we get a sampled line."""
+    name = 'values'
+
+    line = pyvista.Line([0, 0, 0], [0, 0, 10], 9)
+    line[name] = np.linspace(0, 10, 10)
+
+    sampled_line = line.sample_over_line([0, 0, 0.5], [0, 0, 1.5], 2)
+
+    expected_result = np.array([0.5, 1, 1.5])
+    assert np.allclose(sampled_line[name], expected_result)
+    assert name in line.array_names # is name in sampled result
+
+    # test no resolution
+    sphere = pyvista.Sphere(center=(4.5,4.5,4.5), radius=4.5)
+    sampled_from_sphere = sphere.sample_over_line([3, 1, 1], [-3, -1, -1])
+    assert sampled_from_sphere.n_points == sphere.n_cells + 1
+    # is sampled result a polydata object
+    assert isinstance(sampled_from_sphere, pyvista.PolyData)
+
 def test_plot_over_line():
     """this requires matplotlib"""
     mesh = examples.load_uniform()

--- a/tests/test_geometric_objects.py
+++ b/tests/test_geometric_objects.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import pyvista
 
@@ -33,12 +34,21 @@ def test_plane():
 
 
 def test_line():
-    line = pyvista.Line((0,0,0), (10, 1., 3))
+    pointa = (0, 0, 0)
+    pointb = (10, 1., 3)
+
+    line = pyvista.Line(pointa, pointb)
     assert line.n_points == 2
     assert line.n_cells == 1
-    line = pyvista.Line((0,0,0), (10, 1., 3), 10)
+    line = pyvista.Line(pointa, pointb, 10)
     assert line.n_points == 11
     assert line.n_cells == 1
+
+    with pytest.raises(ValueError):
+        pyvista.Line(pointa, pointb, -1)
+
+    with pytest.raises(TypeError):
+        pyvista.Line(pointa, pointb, 0.1) # from vtk
 
 
 def test_cube():


### PR DESCRIPTION
This PR enables a new filter sample_over_line, which is a simple refactoring of plot_over_line, but enables the user to retrieve the data instead of just plotting it.  plot_over_line calls sample_over_line, and now only does plotting.