### PR TITLE
Add checkbox button

### DIFF
--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1252,8 +1252,11 @@ class WidgetHelper(object):
         return
 
 
-    def add_button_widget(self, callback, position=(10., 10.), size=48,
-                          color_on='blue', color_off='grey'):
+    def add_radio_button_widget(self, callback, position=(10., 10.),
+                                value=False, size=50, border_size=5,
+                                color_on='blue', color_off='grey',
+                                background_color='white'):
+        """Add a button widget."""
         if not hasattr(self, "button_widgets"):
             self.button_widgets = []
 
@@ -1261,21 +1264,20 @@ class WidgetHelper(object):
             color1 = np.array(parse_color(color1)) * 255
             color2 = np.array(parse_color(color2)) * 255
             color3 = np.array(parse_color(color3)) * 255
-            border_size = size // 5
 
             n_points = dims[0] * dims[1]
             button = pyvista.UniformGrid(dims)
             arr = np.array([color1] * n_points).reshape(dims[0], dims[1], 3)  # fill with color1
-            arr[1:dims[0]-1, 1:dims[1]-1] = color2 # apply color2
+            arr[1:dims[0]-1, 1:dims[1]-1] = color2  # apply color2
             arr[
                 border_size:dims[0]-border_size,
                 border_size:dims[1]-border_size
-            ] = color3 # apply color3
+            ] = color3  # apply color3
             button.point_arrays['texture'] = arr.reshape(n_points, 3).astype(np.uint8)
             return button
 
-        button_off = create_button(color_on, 'white', color_on)
-        button_on = create_button(color_on, 'white', color_off)
+        button_on = create_button(color_on, background_color, color_on)
+        button_off = create_button(color_on, background_color, color_off)
 
         bounds = [
             position[0], position[0] + size,
@@ -1285,6 +1287,7 @@ class WidgetHelper(object):
 
         button_rep = vtk.vtkTexturedButtonRepresentation2D()
         button_rep.SetNumberOfStates(2)
+        button_rep.SetState(value)
         button_rep.SetButtonTexture(0, button_off)
         button_rep.SetButtonTexture(1, button_on)
         button_rep.SetPlaceFactor(1)

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1252,11 +1252,11 @@ class WidgetHelper(object):
         return
 
 
-    def add_radio_button_widget(self, callback, value=False,
-                                position=(10., 10.), size=50, border_size=5,
-                                color_on='blue', color_off='grey',
-                                background_color='white'):
-        """Add a button widget to the scene.
+    def add_checkbox_button_widget(self, callback, value=False,
+                                   position=(10., 10.), size=50, border_size=5,
+                                   color_on='blue', color_off='grey',
+                                   background_color='white'):
+        """Add a checkbox button widget to the scene.
 
         This is useless without a callback function. You can pass a callable
         function that takes a single argument, the state of this button widget
@@ -1281,10 +1281,10 @@ class WidgetHelper(object):
             The size of the borders of the button in pixels
 
         color_on : string or 3 item list, optional
-            The color used when the button is on. Default is 'blue'
+            The color used when the button is checked. Default is 'blue'
 
         color_off : string or 3 item list, optional
-            The color used when the button is off. Default is 'grey'
+            The color used when the button is not checked. Default is 'grey'
 
         background_color : string or 3 item list, optional
             The background color of the button. Default is 'white'
@@ -1292,7 +1292,7 @@ class WidgetHelper(object):
         Returns
         -------
         button_widget: vtk.vtkButtonWidget
-            The VTK button widget configured as a radio button.
+            The VTK button widget configured as a checkbox button.
 
         """
         if not hasattr(self, "button_widgets"):

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1252,11 +1252,49 @@ class WidgetHelper(object):
         return
 
 
-    def add_radio_button_widget(self, callback, position=(10., 10.),
-                                value=False, size=50, border_size=5,
+    def add_radio_button_widget(self, callback, value=False,
+                                position=(10., 10.), size=50, border_size=5,
                                 color_on='blue', color_off='grey',
                                 background_color='white'):
-        """Add a button widget."""
+        """Add a button widget to the scene.
+
+        This is useless without a callback function. You can pass a callable
+        function that takes a single argument, the state of this button widget
+        and performs a task with that value.
+
+        Parameters
+        ----------
+        callback : callable
+            The method called every time the button is clicked. This should take
+            a single parameter: the bool value of the button
+
+        value : bool
+            The default state of the button
+
+        position: tuple(float)
+            The absolute coordinates of the bottom left point of the button
+
+        size : int
+            The size of the button in number of pixels
+
+        border_size : int
+            The size of the borders of the button in pixels
+
+        color_on : string or 3 item list, optional
+            The color used when the button is on. Default is 'blue'
+
+        color_off : string or 3 item list, optional
+            The color used when the button is off. Default is 'grey'
+
+        background_color : string or 3 item list, optional
+            The background color of the button. Default is 'white'
+
+        Returns
+        -------
+        button_widget: vtk.vtkButtonWidget
+            The VTK button widget configured as a radio button.
+
+        """
         if not hasattr(self, "button_widgets"):
             self.button_widgets = []
 
@@ -1302,7 +1340,7 @@ class WidgetHelper(object):
         def _the_callback(widget, event):
             state = widget.GetRepresentation().GetState()
             if hasattr(callback, '__call__'):
-                try_callback(callback, state)
+                try_callback(callback, bool(state))
 
         button_widget.AddObserver(vtk.vtkCommand.StateChangedEvent, _the_callback)
         self.button_widgets.append(button_widget)

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -197,3 +197,13 @@ def test_widget_sphere():
     p.add_sphere_widget(callback=func, center=nodes)
     p.clear_sphere_widgets()
     p.close()
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+def test_widget_checkbox_button():
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
+    func = lambda value: value # Does nothing
+    p.add_mesh(mesh)
+    p.add_checkbox_button_widget(callback=func)
+    p.clear_button_widgets()
+    p.close()

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -205,5 +205,4 @@ def test_widget_checkbox_button():
     func = lambda value: value # Does nothing
     p.add_mesh(mesh)
     p.add_checkbox_button_widget(callback=func)
-    p.clear_button_widgets()
     p.close()


### PR DESCRIPTION
This PR adds basic support for checkbox button. The `Animate` label below is **not part of the button** but is given by [`add_text()`](https://docs.pyvista.org/plotting/plotting.html?highlight=add_text#pyvista.BasePlotter.add_text) instead.

To illustrate (inspired by [Orbiting](https://docs.pyvista.org/examples/02-plot/orbit.html?)):

![output](https://user-images.githubusercontent.com/18143289/72157902-418dcd80-33b9-11ea-9f69-2e8bf17d6a4e.gif)

Source code: https://gist.github.com/GuillaumeFavelier/1bfa7ad2160d86b0814ed890dd7f27bc

*I think this demo could be improved with [floors](https://github.com/pyvista/pyvista/pull/423) or [background image](https://github.com/pyvista/pyvista-support/issues/91).*