### PR TITLE
Fix issues with RectilinearGrid instantiation

### DIFF
--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -129,7 +129,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
 
 
     def _update_dimensions(self):
-        """Update the dimensions if coordinates have changed"""
+        """Update the dimensions if coordinates have changed."""
         return self.SetDimensions(len(self.x), len(self.y), len(self.z))
 
 

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -167,13 +167,22 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
 
 
     @property
+    def meshgrid(self):
+        """Return the a meshgrid of numpy arrays for this mesh.
+
+        This simply returns a ``numpy.meshgrid`` of the coordinates for this
+        mesh in ``ij`` indexing.
+
+        """
+        return np.meshgrid(self.x, self.y, self.z, indexing='ij')
+
+
+    @property
     def points(self):
-        """Return a pointer to the points as a numpy object."""
-        x = vtk_to_numpy(self.GetXCoordinates())
-        y = vtk_to_numpy(self.GetYCoordinates())
-        z = vtk_to_numpy(self.GetZCoordinates())
-        xx, yy, zz = np.meshgrid(x,y,z, indexing='ij')
+        """Return all of the points as an n by 3 numpy array."""
+        xx, yy, zz = self.meshgrid
         return np.c_[xx.ravel(order='F'), yy.ravel(order='F'), zz.ravel(order='F')]
+
 
     @points.setter
     def points(self, points):

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -296,6 +296,7 @@ def test_read_rectilinear_grid_from_file():
 def test_cast_rectilinear_grid():
     grid = pyvista.read(examples.rectfile)
     structured = grid.cast_to_structured_grid()
+    assert isinstance(structured, pyvista.StructuredGrid)
     assert structured.n_points == grid.n_points
     assert structured.n_cells == grid.n_cells
     assert np.allclose(structured.points, grid.points)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -242,6 +242,12 @@ def test_create_rectilinear_grid_from_specs():
     xrng = np.arange(-10, 10, 2)
     yrng = np.arange(-10, 10, 5)
     zrng = np.arange(-10, 10, 1)
+    grid = pyvista.RectilinearGrid(xrng)
+    assert grid.n_cells == 9
+    assert grid.n_points == 10
+    grid = pyvista.RectilinearGrid(xrng, yrng)
+    assert grid.n_cells == 9*3
+    assert grid.n_points == 10*4
     grid = pyvista.RectilinearGrid(xrng, yrng, zrng)
     assert grid.n_cells == 9*3*19
     assert grid.n_points == 10*4*20
@@ -254,6 +260,22 @@ def test_create_rectilinear_grid_from_specs():
     assert grid.n_cells == 5*5
     assert grid.n_points == 6*6
     assert grid.bounds == [1.,21., 1.,21., 0.,0.]
+
+
+def test_create_rectilinear_after_init():
+    x = np.array([0,1,2])
+    y = np.array([0,5,8])
+    z = np.array([3,2,1])
+    grid = pyvista.RectilinearGrid()
+    grid.x = x
+    assert grid.dimensions == [3, 1, 1]
+    grid.y = y
+    assert grid.dimensions == [3, 3, 1]
+    grid.z = z
+    assert grid.dimensions == [3, 3, 3]
+    assert np.allclose(grid.x, x)
+    assert np.allclose(grid.y, y)
+    assert np.allclose(grid.z, z)
 
 
 def test_create_rectilinear_grid_from_file():
@@ -269,6 +291,19 @@ def test_read_rectilinear_grid_from_file():
     assert grid.n_points == 18144
     assert grid.bounds == [-350.0,1350.0, -400.0,1350.0, -850.0,0.0]
     assert grid.n_arrays == 1
+
+
+def test_cast_rectilinear_grid():
+    grid = pyvista.read(examples.rectfile)
+    structured = grid.cast_to_structured_grid()
+    assert structured.n_points == grid.n_points
+    assert structured.n_cells == grid.n_cells
+    assert np.allclose(structured.points, grid.points)
+    for k, v in grid.point_arrays.items():
+        assert np.allclose(structured.point_arrays[k], v)
+    for k, v in grid.cell_arrays.items():
+        assert np.allclose(structured.cell_arrays[k], v)
+
 
 
 def test_create_uniform_grid_from_specs():


### PR DESCRIPTION
These changes fix an issue where you couldn't update the coordinates of a `RectilinearGrid` after instantiating it. 

The issue arose from how the dimensions have to be updated anytime the coordinates are changed. These changes make it so that the dimensions are automatically managed by PyVista and the user is unable to set them unless using the VTK method (`.SetDimensions()`). `RectilinearGrid`s are technically implicitly defined, so it makes sense to only let the user update the `x`, `y`, and `z` coordinates for the mesh grid.

These changes also give users more options if wanting to create a 1D or 2D `RectilinearGrid` upon instantiation by allowing 1 or 2 coordinate arrays to be passed instead of 3. The `__init__` method defaults to x first, then y, then z. If a user wants to have a 2D grid oriented on the `yz` plane, then they can set the coordinates after instantiating like so (this was previously not possible):

```py
import pyvista as pv
import numpy as np
foo = pv.RectilinearGrid()
foo.y = np.array([3,4,5])
foo.z = np.array([6,7,8])
foo.plot(show_edges=True, show_bounds=True, lighting=False)
```

![download](https://user-images.githubusercontent.com/22067021/72234855-376ff880-358c-11ea-8014-7a854762b94b.png)

-----

This also adds a convenient `cast_to_structured_grid()` method as `RectilinearGrid`s can easily be represented by a `StructuredGrid`.

Testing is implemented.