### PR TITLE
Only volume render point data

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1489,8 +1489,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 if not is_pyvista_dataset(volume):
                     raise TypeError('Object type ({}) not supported for plotting in PyVista.'.format(type(volume)))
         else:
-            # HACK: Make a copy so the original object is not altered
-            volume = volume.copy()
+            # HACK: Make a copy so the original object is not altered.
+            #       Also, place all data on the nodes as issues arise when
+            #       volume rendering on the cells.
+            volume = volume.cell_data_to_point_data()
 
 
         if isinstance(volume, pyvista.MultiBlock):


### PR DESCRIPTION
I've had a number of issues volume rendering grids with cell data. these changes migrate cell data to point data right before volume rendering. Since we were already copying the dataset (see #475), this fits in easily as an effect that will only benefit users until we overhaul the volume rendering code in accordance with #475 

NOTE: see https://github.com/pyvista/pyvista/pull/464#issuecomment-558466410 for further reasoning