### PR TITLE
[BUGFIX] correct how widget tools activate scalars

### DIFF
--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -143,6 +143,7 @@ class WidgetHelper(object):
         name = kwargs.get('name', mesh.memory_address)
         rng = mesh.get_data_range(kwargs.get('scalars', None))
         kwargs.setdefault('clim', kwargs.pop('rng', rng))
+        mesh.set_active_scalars(kwargs.get('scalars', None))
 
         self.add_mesh(mesh.outline(), name=name+"outline", opacity=0.0)
 
@@ -385,6 +386,7 @@ class WidgetHelper(object):
         name = kwargs.get('name', mesh.memory_address)
         rng = mesh.get_data_range(kwargs.get('scalars', None))
         kwargs.setdefault('clim', kwargs.pop('rng', rng))
+        mesh.set_active_scalars(kwargs.get('scalars', None))
 
         self.add_mesh(mesh.outline(), name=name+"outline", opacity=0.0)
 
@@ -456,6 +458,7 @@ class WidgetHelper(object):
         name = kwargs.get('name', mesh.memory_address)
         rng = mesh.get_data_range(kwargs.get('scalars', None))
         kwargs.setdefault('clim', kwargs.pop('rng', rng))
+        mesh.set_active_scalars(kwargs.get('scalars', None))
 
         self.add_mesh(mesh.outline(), name=name+"outline", opacity=0.0)
 
@@ -852,6 +855,7 @@ class WidgetHelper(object):
         kwargs.setdefault('clim', kwargs.pop('rng', rng))
         if title is None:
             title = scalars
+        mesh.set_active_scalars(scalars)
 
         self.add_mesh(mesh.outline(), name=name+"outline", opacity=0.0)
 
@@ -903,7 +907,7 @@ class WidgetHelper(object):
             The input dataset to add to the scene and contour
 
         scalars : str
-            The string name of the scalars on the mesh to threshold and display
+            The string name of the scalars on the mesh to contour and display
 
         kwargs : dict
             All additional keyword arguments are passed to ``add_mesh`` to
@@ -928,6 +932,7 @@ class WidgetHelper(object):
         kwargs.setdefault('clim', kwargs.pop('rng', rng))
         if title is None:
             title = scalars
+        mesh.set_active_scalars(scalars)
 
         alg = vtk.vtkContourFilter()
         alg.SetInputDataObject(mesh)
@@ -1090,6 +1095,7 @@ class WidgetHelper(object):
         name = kwargs.get('name', mesh.memory_address)
         rng = mesh.get_data_range(kwargs.get('scalars', None))
         kwargs.setdefault('clim', kwargs.pop('rng', rng))
+        mesh.set_active_scalars(kwargs.get('scalars', None))
 
         self.add_mesh(mesh.outline(), name=name+"outline", opacity=0.0)
 

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -143,7 +143,7 @@ class WidgetHelper(object):
         name = kwargs.get('name', mesh.memory_address)
         rng = mesh.get_data_range(kwargs.get('scalars', None))
         kwargs.setdefault('clim', kwargs.pop('rng', rng))
-        mesh.set_active_scalars(kwargs.get('scalars', None))
+        mesh.set_active_scalars(kwargs.get('scalars', mesh.active_scalars_name))
 
         self.add_mesh(mesh.outline(), name=name+"outline", opacity=0.0)
 
@@ -386,7 +386,7 @@ class WidgetHelper(object):
         name = kwargs.get('name', mesh.memory_address)
         rng = mesh.get_data_range(kwargs.get('scalars', None))
         kwargs.setdefault('clim', kwargs.pop('rng', rng))
-        mesh.set_active_scalars(kwargs.get('scalars', None))
+        mesh.set_active_scalars(kwargs.get('scalars', mesh.active_scalars_name))
 
         self.add_mesh(mesh.outline(), name=name+"outline", opacity=0.0)
 
@@ -458,7 +458,7 @@ class WidgetHelper(object):
         name = kwargs.get('name', mesh.memory_address)
         rng = mesh.get_data_range(kwargs.get('scalars', None))
         kwargs.setdefault('clim', kwargs.pop('rng', rng))
-        mesh.set_active_scalars(kwargs.get('scalars', None))
+        mesh.set_active_scalars(kwargs.get('scalars', mesh.active_scalars_name))
 
         self.add_mesh(mesh.outline(), name=name+"outline", opacity=0.0)
 
@@ -1095,7 +1095,7 @@ class WidgetHelper(object):
         name = kwargs.get('name', mesh.memory_address)
         rng = mesh.get_data_range(kwargs.get('scalars', None))
         kwargs.setdefault('clim', kwargs.pop('rng', rng))
-        mesh.set_active_scalars(kwargs.get('scalars', None))
+        mesh.set_active_scalars(kwargs.get('scalars', mesh.active_scalars_name))
 
         self.add_mesh(mesh.outline(), name=name+"outline", opacity=0.0)
 


### PR DESCRIPTION
Resolve #400 🎉 

If you try to use one of the widget tools like `add_mesh_slice` and plot any scalars other than the active scalars, then you will see incorrect results in the color mapping upon updating the widget.

Also, if a mesh does not have active scalars, then you will run into problems as the filter mesh will not either so the mapper will get all confused