### PR TITLE
[BUGFIX] fix combine filter for nested MultiBlock

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1623,7 +1623,7 @@ class DataSetFilters(object):
             resolution = int(dataset.n_cells)
         # Make a line and sample the dataset
         line = pyvista.Line(pointa, pointb, resolution=resolution)
-        
+
         sampled_line = line.sample(dataset)
         return sampled_line
 
@@ -2156,6 +2156,8 @@ class CompositeFilters(object):
         """
         alg = vtk.vtkAppendFilter()
         for block in composite:
+            if isinstance(block, vtk.vtkMultiBlockDataSet):
+                block = CompositeFilters.combine(block, merge_points=merge_points)
             alg.AddInputData(block)
         alg.SetMergePoints(merge_points)
         alg.Update()

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -252,10 +252,12 @@ def test_combine_filter():
     multi.append(ex.load_ant())
     multi.append(ex.load_sphere())
     multi.append(ex.load_uniform())
-    multi.append(ex.load_airplane())
-    multi.append(ex.load_globe())
+    nested = pyvista.MultiBlock()
+    nested.append(ex.load_airplane())
+    nested.append(ex.load_globe())
+    multi.append(nested)
     # Now check everything
-    assert multi.n_blocks == 5
+    assert multi.n_blocks == 4
     # Now apply the geometry filter to combine a plethora of data blocks
     geom = multi.combine()
     assert isinstance(geom, pyvista.UnstructuredGrid)

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -237,10 +237,12 @@ def test_extract_geometry():
     multi.append(ex.load_ant())
     multi.append(ex.load_sphere())
     multi.append(ex.load_uniform())
-    multi.append(ex.load_airplane())
-    multi.append(ex.load_globe())
+    nested = pyvista.MultiBlock()
+    nested.append(ex.load_airplane())
+    nested.append(ex.load_globe())
+    multi.append(nested)
     # Now check everything
-    assert multi.n_blocks == 5
+    assert multi.n_blocks == 4
     # Now apply the geometry filter to combine a plethora of data blocks
     geom = multi.extract_geometry()
     assert isinstance(geom, pyvista.PolyData)
@@ -258,7 +260,7 @@ def test_combine_filter():
     multi.append(nested)
     # Now check everything
     assert multi.n_blocks == 4
-    # Now apply the geometry filter to combine a plethora of data blocks
+    # Now apply the append filter to combine a plethora of data blocks
     geom = multi.combine()
     assert isinstance(geom, pyvista.UnstructuredGrid)
 


### PR DESCRIPTION
Previously, running the `combine` filter on a nest MultiBlock dataset would result in a stream of errors. This resolves that.