### PR TITLE
Better repr for camera position list

### DIFF
--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -59,7 +59,8 @@ class CameraPosition(object):
 
     def __repr__(self):
         """List representation method."""
-        return self.to_list().__repr__()
+        layout = "[{}\n {}\n {}]"
+        return layout.format(*self.to_list())
 
     def __getitem__(self, index):
         """Fetch a component by index location like a list."""

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -59,7 +59,7 @@ class CameraPosition(object):
 
     def __repr__(self):
         """List representation method."""
-        layout = "[{}\n {}\n {}]"
+        layout = "[{},\n {},\n {}]"
         return layout.format(*self.to_list())
 
     def __getitem__(self, index):


### PR DESCRIPTION
The repr for the camera position (from #491) was a bit poorly formatted and would sometimes result in really long lists if copy/pasting.

For example, in one scene I am working with right now, this is what is currently returned if I copy/paste:

```
[(315661.9406719345, 4234675.528454831, 15167.291249498076), (337498.00521202036, 4260818.504034578, -1261.5688408692681), (0.2708862567924439, 0.3397398234107863, 0.9006650255615491)]
```

which if I try to put back into my code, results in a really long line

now, the elements are broken up by lines so copy/pasting is a little better:

```
[(315661.9406719345, 4234675.528454831, 15167.291249498076),
 (337498.00521202036, 4260818.504034578, -1261.5688408692681),
 (0.2708862567924439, 0.3397398234107863, 0.9006650255615491)]
```