### PR TITLE
Patch brown color and legend geometry placement

### DIFF
--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -168,7 +168,7 @@ hexcolors = {
     'blanchedalmond':       '#FFEBCD',
     'blue':                 '#0000FF',
     'blueviolet':           '#8A2BE2',
-    'brown':                '#A52A2A',
+    'brown':                '#654321',
     'burlywood':            '#DEB887',
     'cadetblue':            '#5F9EA0',
     'chartreuse':           '#7FFF00',

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1282,6 +1282,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             if scalars is not None:
                 geom = pyvista.Box()
                 rgb_color = parse_color('black')
+            geom.points -= geom.center
             self._labels.append([geom, label, rgb_color])
 
         # lighting display style


### PR DESCRIPTION
For some reason the color brown was mapped incorrectly in `colors.py`... previously it was red-ish.

Also, some markers in the legend would not always be placed correctly becuase they need to be centered at (0,0) - this fixes that

```py
import pyvista as pv
from pyvista import examples

p = pv.Plotter()
p.add_mesh(examples.download_bunny(), label="mesh", color="brown", lighting=False)
p.add_legend()
p.show()
```

![download](https://user-images.githubusercontent.com/22067021/72457442-da3e9780-3783-11ea-9ef2-3efd710dddc2.png)

now we get

![download](https://user-images.githubusercontent.com/22067021/72457586-30abd600-3784-11ea-9c8c-475b85a00201.png)


-----
Previously misplaced legend markers:

<img width="1335" alt="Screen Shot 2020-01-15 at 10 44 34 AM" src="https://user-images.githubusercontent.com/22067021/72457525-0823dc00-3784-11ea-8153-12a3cf0578b6.png">

which are fixed to 

<img width="209" alt="Screen Shot 2020-01-15 at 10 44 54 AM" src="https://user-images.githubusercontent.com/22067021/72457543-13770780-3784-11ea-8b9d-71425e7e0957.png">

