### PR TITLE
Add component feature for plotting vectors

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1309,8 +1309,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if line_width:
             prop.SetLineWidth(line_width)
 
+        print(rgb_color)
+
         # Add scalar bar if available
-        if title is not None and show_scalar_bar and (not rgb_color or _custom_opac):
+        if title is not None and show_scalar_bar and (not color or _custom_opac):
             self.add_scalar_bar(title, **scalar_bar_args)
 
         return actor

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1309,8 +1309,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if line_width:
             prop.SetLineWidth(line_width)
 
-        print(rgb_color)
-
         # Add scalar bar if available
         if title is not None and show_scalar_bar and (not color or _custom_opac):
             self.add_scalar_bar(title, **scalar_bar_args)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1293,8 +1293,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
             prop.SetLineWidth(line_width)
 
         # Add scalar bar if available
-        if stitle is not None and show_scalar_bar and (not rgb or _custom_opac):
-            self.add_scalar_bar(stitle, **scalar_bar_args)
+        if title is not None and show_scalar_bar and (not rgb or _custom_opac):
+            self.add_scalar_bar(title, **scalar_bar_args)
 
         return actor
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1293,7 +1293,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             prop.SetLineWidth(line_width)
 
         # Add scalar bar if available
-        if title is not None and show_scalar_bar and (not rgb or _custom_opac):
+        if title is not None and show_scalar_bar and (not rgb_color or _custom_opac):
             self.add_scalar_bar(title, **scalar_bar_args)
 
         return actor

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1310,8 +1310,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
             prop.SetLineWidth(line_width)
 
         # Add scalar bar if available
-        if title is not None and show_scalar_bar and (not color or _custom_opac):
-            self.add_scalar_bar(title, **scalar_bar_args)
+        if stitle is not None and show_scalar_bar and (not rgb or _custom_opac):
+            self.add_scalar_bar(stitle, **scalar_bar_args)
 
         return actor
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -946,7 +946,6 @@ def test_vector_plotting_doesnt_modify_input():
     assert np.array_equal(vector_values_points, copy_vector_values_points)
     assert np.array_equal(data['vector_values_points'], copy_vector_values_points)
 
-
     # test that adding a vector with component parameter to a Plotter instance
     # does not modify it.
     p = pyvista.Plotter(off_screen=OFF_SCREEN)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -904,17 +904,56 @@ def test_vector_array():
     data['vector_values_points'] = vector_values_points
     data['vector_values_cells'] = vector_values_cells
 
-    p = pyvista.Plotter(off_screen=OFF_SCREEN)
-
     # test no component argument
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
     p.add_mesh(data, scalars='vector_values_points')
+    p.show()
+
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
     p.add_mesh(data, scalars='vector_values_cells')
+    p.show()
 
     # test component argument
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
     p.add_mesh(data, scalars='vector_values_points', component=0)
-    p.add_mesh(data, scalars='vector_values_cells', component=2)
-
     p.show()
+
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
+    p.add_mesh(data, scalars='vector_values_cells', component=2)
+    p.show()
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+def test_vector_plotting_doesnt_modify_input():
+    data = examples.load_uniform()
+
+    vector_values_points = np.empty((data.n_points, 3))
+    vector_values_points[:, :] = [3., 4., 0.]  # Vector has this value at all points
+
+    copy_vector_values_points = vector_values_points.copy()
+
+    data['vector_values_points'] = vector_values_points
+
+    # test that adding a vector does not modify it.
+    assert np.array_equal(vector_values_points, copy_vector_values_points)
+    assert np.array_equal(data['vector_values_points'], copy_vector_values_points)
+
+    # test that adding a vector with no component parameter to a Plotter instance
+    # does not modify it.
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
+    p.add_mesh(data, scalars='vector_values_points')
+    p.show()
+    assert np.array_equal(vector_values_points, copy_vector_values_points)
+    assert np.array_equal(data['vector_values_points'], copy_vector_values_points)
+
+
+    # test that adding a vector with component parameter to a Plotter instance
+    # does not modify it.
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
+    p.add_mesh(data, scalars='vector_values_points', component=0)
+    p.show()
+    assert np.array_equal(vector_values_points, copy_vector_values_points)
+    assert np.array_equal(data['vector_values_points'], copy_vector_values_points)
 
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -889,3 +889,55 @@ def test_default_name_tracking():
     n_made_it = len(p.renderer._actors)
     p.show()
     assert n_made_it == N**2
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+def test_vector_array():
+    data = examples.load_uniform()
+
+    vector_values_points = np.empty((data.n_points, 3))
+    vector_values_points[:, :] = [3., 4., 0.]  # Vector has this value at all points
+
+    vector_values_cells = np.empty((data.n_cells, 3))
+    vector_values_cells[:, :] = [3., 4., 0.]  # Vector has this value at all cells
+
+    data['vector_values_points'] = vector_values_points
+    data['vector_values_cells'] = vector_values_cells
+
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
+
+    # test no component argument
+    p.add_mesh(data, scalars='vector_values_points')
+    p.add_mesh(data, scalars='vector_values_cells')
+
+    # test component argument
+    p.add_mesh(data, scalars='vector_values_points', component=0)
+    p.add_mesh(data, scalars='vector_values_cells', component=2)
+
+    p.show()
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+def test_vector_array_fail_with_incorrect_component():
+    data = examples.load_uniform()
+
+    vector_values_points = np.empty((data.n_points, 3))
+    vector_values_points[:, :] = [3., 4., 0.]  # Vector has this value at all points
+
+    data['vector_values_points'] = vector_values_points
+
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
+
+    with pytest.raises(TypeError):
+        p.add_mesh(data, scalars='vector_values_points', component=1.5)
+        p.show()
+
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
+    with pytest.raises(ValueError):
+        p.add_mesh(data, scalars='vector_values_points', component=3)
+        p.show()
+
+    p = pyvista.Plotter(off_screen=OFF_SCREEN)
+    with pytest.raises(ValueError):
+        p.add_mesh(data, scalars='vector_values_points', component=-1)
+        p.show()


### PR DESCRIPTION
Fixes title of scalar bar in `BasePlotter`. It looks like `title` was meant to be used, but `stitle` was used instead.

Confusingly, it looks like add_volume is intended to use `stitle`?

Example:
```py
import pyvista as pv
from pyvista import examples
mesh = examples.download_carotid().threshold(145, scalars="scalars")
p = pv.Plotter()
p.add_mesh(mesh, scalars="vectors")
p.show()
```

Old behavior:
![image](https://user-images.githubusercontent.com/39341281/72540456-d4fa4f00-384e-11ea-8519-5a3a41b26466.png)


New Behavior:
![image](https://user-images.githubusercontent.com/39341281/72540388-bc8a3480-384e-11ea-80df-88a168cbba23.png)



