### PR TITLE
Add vtkIdList converter and leverage in geodesic filter

### DIFF
--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -42,6 +42,11 @@ def vtk_bit_array_to_char(vtkarr_bint):
     return vtkarr
 
 
+def vtk_id_list_to_array(vtk_id_list):
+    """Convert a vtkIdList to a NumPy array."""
+    return np.array([vtk_id_list.GetId(i) for i in range(vtk_id_list.GetNumberOfIds())])
+
+
 def convert_string_array(arr, name=None):
     """Convert a numpy array of strings to a vtkStringArray or vice versa.
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -663,3 +663,7 @@ def test_find_closest_point():
     # Make sure we can fetch that point
     closest = sphere.points[index]
     assert len(closest) == 3
+    # n points
+    node = np.array([0, 0.2, 0.2])
+    index = sphere.find_closest_point(node, 5)
+    assert len(index) == 5

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -136,6 +136,9 @@ def test_geodesic():
     sphere = SPHERE.copy()
     geodesic = sphere.geodesic(0, sphere.n_points - 1)
     assert isinstance(geodesic, pyvista.PolyData)
+    assert "vtkOriginalPointIds" in geodesic.array_names
+    ids = geodesic.point_arrays["vtkOriginalPointIds"]
+    assert np.allclose(geodesic.points, sphere.points[ids])
 
 
 def test_geodesic_distance():

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -3,6 +3,7 @@ import os
 
 import numpy as np
 import pytest
+import vtk
 
 import pyvista
 from pyvista import examples as ex
@@ -189,3 +190,14 @@ def test_assert_empty_kwargs():
     with pytest.raises(TypeError):
         kwargs = {"foo":6, "goo":"bad"}
         errors.assert_empty_kwargs(**kwargs)
+
+
+
+def test_convert_id_list():
+    ids = np.array([4, 5, 8])
+    id_list = vtk.vtkIdList()
+    id_list.SetNumberOfIds(len(ids))
+    for i, v in enumerate(ids):
+        id_list.SetId(i, v)
+    converted = helpers.vtk_id_list_to_array(id_list)
+    assert np.allclose(converted, ids)


### PR DESCRIPTION
These changes add a converter for the `vtkIdList` type (had to use a comprehension as we cannot fetch the data values from a buffer... this is slow, but all I could manage to get to work).

This allows us to fetch the original point ids in the geodesic filter to close https://github.com/pyvista/pyvista-support/issues/105


```py
import pyvista as pv
from pyvista import examples

mesh = examples.download_bunny()

geo = mesh.geodesic(0, 10,)

p = pv.Plotter()
p.add_mesh(mesh, color=True, show_edges=True)
p.add_mesh(geo, color="red", line_width=5)

p.camera_position = [(0.020113726841265497, 0.17861833794480292, 0.11038697869173446), 
                     (-0.05506443936066557, 0.12216832283054987, 0.02454963672656186), 
                     (-0.1928428741624666, 0.8888478424625952, -0.41564544847062723)]
p.show()
```

![download](https://user-images.githubusercontent.com/22067021/72565169-8a88ca80-386e-11ea-8739-54a4ef949b91.png)


And now you can use the `vtkOriginalPointIds` array for whatever
```py
extracted = mesh.extract_points(geo["vtkOriginalPointIds"])

p = pv.Plotter()
p.add_mesh(mesh, color=True, show_edges=True)
p.add_mesh(extracted, color="red", line_width=5)
p.camera_position = [(0.020113726841265497, 0.17861833794480292, 0.11038697869173446), 
                     (-0.05506443936066557, 0.12216832283054987, 0.02454963672656186), 
                     (-0.1928428741624666, 0.8888478424625952, -0.41564544847062723)]
p.show()
```

![download](https://user-images.githubusercontent.com/22067021/72565188-91174200-386e-11ea-926a-a9417c827676.png)
