### PR TITLE
Fix slider coordinates in subplot

### DIFF
--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -752,6 +752,12 @@ class WidgetHelper(object):
         if color is None:
             color = rcParams['font']['color']
 
+        def normalize(point, shape):
+            return (point[0] / shape[1], point[1] / shape[0])
+
+        pointa = normalize(pointa, self.shape)
+        pointb = normalize(pointb, self.shape)
+
         slider_rep = vtk.vtkSliderRepresentation2D()
         slider_rep.SetPickable(False)
         slider_rep.SetMinimumValue(min)
@@ -763,9 +769,9 @@ class WidgetHelper(object):
         slider_rep.GetCapProperty().SetColor(parse_color(color))
         slider_rep.GetLabelProperty().SetColor(parse_color(color))
         slider_rep.GetTubeProperty().SetColor(parse_color(color))
-        slider_rep.GetPoint1Coordinate().SetCoordinateSystemToNormalizedViewport()
+        slider_rep.GetPoint1Coordinate().SetCoordinateSystemToNormalizedDisplay()
         slider_rep.GetPoint1Coordinate().SetValue(pointa[0], pointa[1])
-        slider_rep.GetPoint2Coordinate().SetCoordinateSystemToNormalizedViewport()
+        slider_rep.GetPoint2Coordinate().SetCoordinateSystemToNormalizedDisplay()
         slider_rep.GetPoint2Coordinate().SetValue(pointb[0], pointb[1])
         slider_rep.SetSliderLength(0.05)
         slider_rep.SetSliderWidth(0.05)


### PR DESCRIPTION
This PR is a follow-up of https://github.com/pyvista/pyvista/issues/513#issuecomment-575161649 and change the coordinate system of the slider to fix issues in subplots.

Now the following is possible:

```py
import pyvista as pv

shape = (2, 4)
pointa = (0.2, 0.5)
pointb = (0.8, 0.5)

p = pv.Plotter(shape=shape)

for i in range(shape[0]):
    for j in range(shape[1]):
        p.subplot(i, j)
        p.add_mesh(pv.Sphere())
        p.add_slider_widget(
            callback=lambda value: value,
            rng=[0, 1],
            pointa=pointa,
            pointb=pointb,
        )

p.show()
```

![image](https://user-images.githubusercontent.com/18143289/72744403-d3fa5200-3bad-11ea-8b5f-bee22386defb.png)

Closes #513 