### PR TITLE
Add find_closest_point method

### DIFF
--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -1407,6 +1407,32 @@ class Common(DataSetFilters, DataObject):
         return pyansys.CellQuality(dataset)
 
 
+    def find_closest_point(self, point):
+        """Find index of closest point in this mesh to the given point.
+
+        If wanting to query many points, use a KDTree with scipy or another
+        library as those implementations will be easier to work with.
+
+        See: https://github.com/pyvista/pyvista-support/issues/107
+
+        Parameters
+        ----------
+        point : iterable(float)
+            Length 3 coordinate of the point to query
+
+        Return
+        ------
+        int : the index of the point in this mesh that is closes to the given point.
+        """
+        if not isinstance(point, collections.Iterable) or len(point) != 3:
+            raise TypeError("Given point must be a length three iterable.")
+        locator = vtk.vtkPointLocator()
+        locator.SetDataSet(self)
+        locator.BuildLocator()
+        index = locator.FindClosestPoint(point)
+        return index
+
+
 
 class _ScalarsDict(dict):
     """Internal helper for scalars dictionaries."""

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -652,3 +652,14 @@ def test_shallow_copy_back_propagation():
     wrapped.points = np.random.rand(5, 3)
     orig_points = vtk_to_numpy(original.GetPoints().GetData())
     assert np.allclose(orig_points, wrapped.points)
+
+
+
+def test_find_closest_point():
+    sphere = pyvista.Sphere()
+    node = np.array([0, 0.2, 0.2])
+    index = sphere.find_closest_point(node)
+    assert isinstance(index, int)
+    # Make sure we can fetch that point
+    closest = sphere.points[index]
+    assert len(closest) == 3


### PR DESCRIPTION
Adds a method to all spatially referenced datasets to find the closest single point (see https://github.com/pyvista/pyvista-support/issues/107)