### PR TITLE
Refactor BasePlotter's wrapping of Renderer

### DIFF
--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -3,12 +3,14 @@
 from .colors import (color_char_to_word, get_cmap_safe, hex_to_rgb, hexcolors,
                      string_to_rgb, PARAVIEW_BACKGROUND)
 from .export_vtkjs import export_plotter_vtkjs, get_vtkjs_url
-from .helpers import plot, plot_arrows, plot_compare_four
-from .plotting import BasePlotter, Plotter, close_all
-from .qt_plotting import BackgroundPlotter, QtInteractor
-from .renderer import CameraPosition, Renderer, scale_point
+
 from .theme import (DEFAULT_THEME, FONT_KEYS, MAX_N_COLOR_BARS,
                     parse_color, parse_font_family, rcParams, set_plot_theme)
 from .tools import (create_axes_marker, create_axes_orientation_box,
                     opacity_transfer_function, system_supports_plotting)
 from .widgets import WidgetHelper
+
+from .renderer import CameraPosition, Renderer, scale_point
+from .plotting import BasePlotter, Plotter, close_all
+from .qt_plotting import BackgroundPlotter, QtInteractor
+from .helpers import plot, plot_arrows, plot_compare_four

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4,31 +4,31 @@ import collections
 import logging
 import os
 import time
+import warnings
+from functools import wraps
 from threading import Thread
 
 import imageio
 import numpy as np
-import scooby
 import vtk
 from vtk.util import numpy_support as VN
 from vtk.util.numpy_support import numpy_to_vtk, vtk_to_numpy
-import warnings
 
 import pyvista
-from pyvista.utilities import (assert_empty_kwargs, convert_array,
-                               convert_string_array, get_array,
+import scooby
+from pyvista.utilities import (assert_empty_kwargs, check_depth_peeling,
+                               convert_array, convert_string_array, get_array,
                                is_pyvista_dataset, numpy_to_texture,
-                               raise_not_matching, try_callback, wrap,
-                               check_depth_peeling)
+                               raise_not_matching, try_callback, wrap)
 
 from .colors import get_cmap_safe
 from .export_vtkjs import export_plotter_vtkjs
 from .mapper import make_mapper
 from .picking import PickingHelper
-from .tools import update_axes_label_color, create_axes_orientation_box, create_axes_marker
+from .renderer import Renderer
+from .theme import (FONT_KEYS, MAX_N_COLOR_BARS, parse_color,
+                    parse_font_family, rcParams)
 from .tools import normalize, opacity_transfer_function
-from .theme import rcParams, parse_color, parse_font_family
-from .theme import FONT_KEYS, MAX_N_COLOR_BARS
 from .widgets import WidgetHelper
 
 try:
@@ -135,14 +135,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 xsplit = splitting_position
 
             for i in rangen:
-                arenderer = pyvista.Renderer(self, border, border_color, border_width)
+                arenderer = Renderer(self, border, border_color, border_width)
                 if '|' in shape:
                     arenderer.SetViewport(0, i/n, xsplit, (i+1)/n)
                 else:
                     arenderer.SetViewport(i/n, 0, (i+1)/n, xsplit)
                 self.renderers.append(arenderer)
             for i in rangem:
-                arenderer = pyvista.Renderer(self, border, border_color, border_width)
+                arenderer = Renderer(self, border, border_color, border_width)
                 if '|' in shape:
                     arenderer.SetViewport(xsplit, i/m, 1, (i+1)/m)
                 else:
@@ -160,7 +160,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             self.shape = shape
             for i in reversed(range(shape[0])):
                 for j in range(shape[1]):
-                    renderer = pyvista.Renderer(self, border, border_color, border_width)
+                    renderer = Renderer(self, border, border_color, border_width)
                     x0 = i/shape[0]
                     y0 = j/shape[1]
                     x1 = (i+1)/shape[0]
@@ -196,6 +196,261 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         # Key bindings
         self.reset_key_events()
+
+
+    #### Manage the active Renderer ####
+
+    def loc_to_index(self, loc):
+        """Return index of the render window given a location index.
+
+        Parameters
+        ----------
+        loc : int, tuple, or list
+            Index of the renderer to add the actor to.  For example,
+            ``loc=2`` or ``loc=(1, 1)``.
+
+        Return
+        ------
+        idx : int
+            Index of the render window.
+
+        """
+        if loc is None:
+            return self._active_renderer_index
+        elif isinstance(loc, int):
+            return loc
+        elif isinstance(loc, collections.Iterable):
+            if not len(loc) == 2:
+                raise AssertionError('"loc" must contain two items')
+            index_row = loc[0]
+            index_column = loc[1]
+            if index_row < 0 or index_row >= self.shape[0]:
+                raise IndexError('Row index is out of range ({})'.format(self.shape[0]))
+            if index_column < 0 or index_column >= self.shape[1]:
+                raise IndexError('Column index is out of range ({})'.format(self.shape[1]))
+            sz = int(self.shape[0] * self.shape[1])
+            idxs = np.array([i for i in range(sz)], dtype=int).reshape(self.shape)
+            return idxs[index_row, index_column]
+
+
+    def index_to_loc(self, index):
+        """Convert a 1D index location to the 2D location on the plotting grid."""
+        if len(self.shape) == 1:
+            return index
+        sz = int(self.shape[0] * self.shape[1])
+        idxs = np.array([i for i in range(sz)], dtype=int).reshape(self.shape)
+        args = np.argwhere(idxs == index)
+        if len(args) < 1:
+            raise RuntimeError('Index ({}) is out of range.')
+        return args[0]
+
+    @property
+    def renderer(self):
+        """Return the active renderer."""
+        return self.renderers[self._active_renderer_index]
+
+
+    def subplot(self, index_row, index_column=None):
+        """Set the active subplot.
+
+        Parameters
+        ----------
+        index_row : int
+            Index of the subplot to activate along the rows.
+
+        index_column : int
+            Index of the subplot to activate along the columns.
+
+        """
+        if len(self.shape) == 1:
+            self._active_renderer_index = index_row
+            return
+
+        if index_row < 0 or index_row >= self.shape[0]:
+            raise IndexError('Row index is out of range ({})'.format(self.shape[0]))
+        if index_column < 0 or index_column >= self.shape[1]:
+            raise IndexError('Column index is out of range ({})'.format(self.shape[1]))
+        self._active_renderer_index = self.loc_to_index((index_row, index_column))
+
+
+    #### Wrap Renderer methods ####
+
+    @wraps(Renderer.enable_anti_aliasing)
+    def enable_anti_aliasing(self, *args, **kwargs):
+        """Wraps ``Renderer.enable_anti_aliasing``."""
+        self.renderer.enable_anti_aliasing(*args, **kwargs)
+
+    @wraps(Renderer.disable_anti_aliasing)
+    def disable_anti_aliasing(self, *args, **kwargs):
+        """Wraps ``Renderer.disable_anti_aliasing``."""
+        self.renderer.disable_anti_aliasing(*args, **kwargs)
+
+    @wraps(Renderer.set_focus)
+    def set_focus(self, *args, **kwargs):
+        """Wraps ``Renderer.set_focus``."""
+        self.renderer.set_focus(*args, **kwargs)
+        self._render()
+
+    @wraps(Renderer.set_position)
+    def set_position(self, *args, **kwargs):
+        """Wraps ``Renderer.set_position``."""
+        self.renderer.set_position(*args, **kwargs)
+        self._render()
+
+    @wraps(Renderer.set_viewup)
+    def set_viewup(self, *args, **kwargs):
+        """Wraps ``Renderer.set_viewup``."""
+        self.renderer.set_viewup(*args, **kwargs)
+        self._render()
+
+    @wraps(Renderer.add_axes)
+    def add_axes(self, *args, **kwargs):
+        """Wraps ``Renderer.add_axes``."""
+        return self.renderer.add_axes(*args, **kwargs)
+
+    @wraps(Renderer.hide_axes)
+    def hide_axes(self, *args, **kwargs):
+        """Wraps ``Renderer.hide_axes``."""
+        return self.renderer.hide_axes(*args, **kwargs)
+
+    @wraps(Renderer.show_axes)
+    def show_axes(self, *args, **kwargs):
+        """Wraps ``Renderer.show_axes``."""
+        return self.renderer.show_axes(*args, **kwargs)
+
+    @wraps(Renderer.update_bounds_axes)
+    def update_bounds_axes(self, *args, **kwargs):
+        """Wraps ``Renderer.update_bounds_axes``."""
+        return self.renderer.update_bounds_axes(*args, **kwargs)
+
+    @wraps(Renderer.add_actor)
+    def add_actor(self, *args, **kwargs):
+        """Wraps ``Renderer.add_actor``."""
+        return self.renderer.add_actor(*args, **kwargs)
+
+    @wraps(Renderer.enable_parallel_projection)
+    def enable_parallel_projection(self, *args, **kwargs):
+        """Wraps ``Renderer.enable_parallel_projection``."""
+        return self.renderer.enable_parallel_projection(*args, **kwargs)
+
+    @wraps(Renderer.disable_parallel_projection)
+    def disable_parallel_projection(self, *args, **kwargs):
+        """Wraps ``Renderer.disable_parallel_projection``."""
+        return self.renderer.disable_parallel_projection(*args, **kwargs)
+
+    @wraps(Renderer.add_axes_at_origin)
+    def add_axes_at_origin(self, *args, **kwargs):
+        """Wraps ``Renderer.add_axes_at_origin``."""
+        return self.renderer.add_axes_at_origin(*args, **kwargs)
+
+    @wraps(Renderer.show_bounds)
+    def show_bounds(self, *args, **kwargs):
+        """Wraps ``Renderer.show_bounds``."""
+        return self.renderer.show_bounds(*args, **kwargs)
+
+    @wraps(Renderer.add_bounds_axes)
+    def add_bounds_axes(self, *args, **kwargs):
+        """Wraps ``add_bounds_axes``."""
+        return self.renderer.add_bounds_axes(*args, **kwargs)
+
+    @wraps(Renderer.add_bounding_box)
+    def add_bounding_box(self, *args, **kwargs):
+        """Wraps ``Renderer.add_bounding_box``."""
+        return self.renderer.add_bounding_box(*args, **kwargs)
+
+    @wraps(Renderer.remove_bounding_box)
+    def remove_bounding_box(self, *args, **kwargs):
+        """Wraps ``Renderer.remove_bounding_box``."""
+        return self.renderer.remove_bounding_box(*args, **kwargs)
+
+    @wraps(Renderer.remove_bounds_axes)
+    def remove_bounds_axes(self, *args, **kwargs):
+        """Wraps ``Renderer.remove_bounds_axes``."""
+        return self.renderer.remove_bounds_axes(*args, **kwargs)
+
+    @wraps(Renderer.show_grid)
+    def show_grid(self, *args, **kwargs):
+        """Wraps ``Renderer.show_grid``."""
+        return self.renderer.show_bounds(*args, **kwargs)
+
+    @wraps(Renderer.set_scale)
+    def set_scale(self, *args, **kwargs):
+        """Wraps ``Renderer.set_scale``."""
+        return self.renderer.set_scale(*args, **kwargs)
+
+    @wraps(Renderer.enable_eye_dome_lighting)
+    def enable_eye_dome_lighting(self, *args, **kwargs):
+        """Wraps ``Renderer.enable_eye_dome_lighting``."""
+        return self.renderer.enable_eye_dome_lighting(*args, **kwargs)
+
+    @wraps(Renderer.disable_eye_dome_lighting)
+    def disable_eye_dome_lighting(self, *args, **kwargs):
+        """Wraps ``Renderer.disable_eye_dome_lighting``."""
+        return self.renderer.disable_eye_dome_lighting(*args, **kwargs)
+
+    @wraps(Renderer.reset_camera)
+    def reset_camera(self, *args, **kwargs):
+        """Wraps ``Renderer.reset_camera``."""
+        self.renderer.reset_camera(*args, **kwargs)
+        self._render()
+
+    @wraps(Renderer.isometric_view)
+    def isometric_view(self, *args, **kwargs):
+        """Wraps ``Renderer.isometric_view``."""
+        return self.renderer.isometric_view(*args, **kwargs)
+
+    @wraps(Renderer.view_isometric)
+    def view_isometric(self, *args, **kwarg):
+        """Wraps ``Renderer.view_isometric``."""
+        return self.renderer.view_isometric(*args, **kwarg)
+
+    @wraps(Renderer.view_vector)
+    def view_vector(self, *args, **kwarg):
+        """Wraps ``Renderer.view_vector``."""
+        return self.renderer.view_vector(*args, **kwarg)
+
+    @wraps(Renderer.view_xy)
+    def view_xy(self, *args, **kwarg):
+        """Wraps ``Renderer.view_xy``."""
+        return self.renderer.view_xy(*args, **kwarg)
+
+    @wraps(Renderer.view_yx)
+    def view_yx(self, *args, **kwarg):
+        """Wraps ``Renderer.view_yx``."""
+        return self.renderer.view_yx(*args, **kwarg)
+
+    @wraps(Renderer.view_xz)
+    def view_xz(self, *args, **kwarg):
+        """Wraps ``Renderer.view_xz``."""
+        return self.renderer.view_xz(*args, **kwarg)
+
+    @wraps(Renderer.view_xz)
+    def view_zx(self, *args, **kwarg):
+        """Wraps ``Renderer.view_xz``."""
+        return self.renderer.view_zx(*args, **kwarg)
+
+    @wraps(Renderer.view_xz)
+    def view_yz(self, *args, **kwarg):
+        """Wraps ``Renderer.view_xz``."""
+        return self.renderer.view_yz(*args, **kwarg)
+
+    @wraps(Renderer.view_zy)
+    def view_zy(self, *args, **kwarg):
+        """Wraps ``Renderer.view_zy``."""
+        return self.renderer.view_zy(*args, **kwarg)
+
+    @wraps(Renderer.disable)
+    def disable(self, *args, **kwarg):
+        """Wraps ``Renderer.disable``."""
+        return self.renderer.disable(*args, **kwarg)
+
+    @wraps(Renderer.enable)
+    def enable(self, *args, **kwarg):
+        """Wraps ``Renderer.enable``."""
+        return self.renderer.enable(*args, **kwarg)
+
+
+    ################
 
 
     def add_key_event(self, key, callback):
@@ -261,13 +516,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
             self.ren_win.AlphaBitPlanesOff()
             self.renderer.disable_depth_peeling()
 
-    def enable_anti_aliasing(self):
-        """Enable anti-aliasing FXAA."""
-        self.renderer.enable_anti_aliasing()
-
-    def disable_anti_aliasing(self):
-        """Disable anti-aliasing FXAA."""
-        self.renderer.disable_anti_aliasing()
 
     def store_mouse_position(self, *args):
         """Store mouse position."""
@@ -519,21 +767,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self._style = vtk.vtkInteractorStyleRubberBandPick()
         return self.update_style()
 
-    def set_focus(self, point):
-        """Set focus to a point."""
-        self.renderer.set_focus(point)
-        self._render()
 
-    def set_position(self, point, reset=False):
-        """Set camera position to a point."""
-        self.renderer.set_position(point, reset=reset)
-        self._render()
-
-    def set_viewup(self, vector):
-        """Set camera viewup vector."""
-        self.renderer.set_viewup(vector)
-        self._render()
-
+    # TODO: this should be on the renderer....
     def _render(self):
         """Redraw the render window if it exists."""
         if hasattr(self, 'ren_win'):
@@ -542,38 +777,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
             elif not self._first_time:
                 self.render()
 
-    def add_axes(self, interactive=None, line_width=2,
-                 color=None, x_color=None, y_color=None, z_color=None,
-                 xlabel='X', ylabel='Y', zlabel='Z', labels_off=False,
-                 box=None, box_args=None, loc=None):
-        """Add an interactive axes widget in the bottom left corner.
-
-        Adds to the currently active renderer.
-
-        Parameters
-        ----------
-        interacitve : bool
-            Enable this orientation widget to be moved by the user.
-
-        line_width : int
-            The width of the marker lines
-
-        box : bool
-            Show a box orientation marker. Use ``box_args`` to adjust.
-            See :any:`pyvista.create_axes_orientation_box` for details.
-        """
-        self._active_renderer_index = self.loc_to_index(loc)
-        renderer = self.renderers[self._active_renderer_index]
-        return renderer.add_axes(interactive=interactive, line_width=line_width,
-                     color=color, x_color=x_color, y_color=y_color, z_color=z_color,
-                     xlabel=xlabel, ylabel=ylabel, zlabel=zlabel, labels_off=labels_off,
-                     box=box, box_args=box_args)
-
-    def hide_axes(self, loc=None):
-        """Hide the axes orientation widget."""
-        self._active_renderer_index = self.loc_to_index(loc)
-        renderer = self.renderers[self._active_renderer_index]
-        return renderer.hide_axes()
 
     def hide_axes_all(self):
         """Hide the axes orientation widget in all renderers."""
@@ -581,11 +784,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
             renderer.hide_axes()
         return
 
-    def show_axes(self, loc=None):
-        """Show the axes orientation widget."""
-        self._active_renderer_index = self.loc_to_index(loc)
-        renderer = self.renderers[self._active_renderer_index]
-        return renderer.show_axes()
 
     def show_axes_all(self):
         """Show the axes orientation widget in all renderers."""
@@ -1770,11 +1968,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.renderer.camera_set = is_set
 
     @property
-    def renderer(self):
-        """Return the active renderer."""
-        return self.renderers[self._active_renderer_index]
-
-    @property
     def bounds(self):
         """Return the bounds of the active renderer."""
         return self.renderer.bounds
@@ -1788,10 +1981,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def center(self):
         """Return the center of the active renderer."""
         return self.renderer.center
-
-    def update_bounds_axes(self):
-        """Update the bounds of the active renderer."""
-        return self.renderer.update_bounds_axes()
 
     @property
     def _scalar_bar_slots(self):
@@ -1847,89 +2036,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
             renderer.remove_actor(actor, reset_camera)
         return True
 
-    def add_actor(self, uinput, reset_camera=False, name=None, loc=None,
-                  culling=False, pickable=True):
-        """Add an actor to render window.
-
-        Creates an actor if input is a mapper.
-
-        Parameters
-        ----------
-        uinput : vtk.vtkMapper or vtk.vtkActor
-            vtk mapper or vtk actor to be added.
-
-        reset_camera : bool, optional
-            Resets the camera when true.
-
-        loc : int, tuple, or list
-            Index of the renderer to add the actor to.  For example,
-            ``loc=2`` or ``loc=(1, 1)``.  If None, selects the last
-            active Renderer.
-
-        culling : str, optional
-            Does not render faces that are culled. Options are ``'front'`` or
-            ``'back'``. This can be helpful for dense surface meshes,
-            especially when edges are visible, but can cause flat
-            meshes to be partially displayed.  Default False.
-
-        Returns
-        -------
-        actor : vtk.vtkActor
-            The actor.
-
-        actor_properties : vtk.Properties
-            Actor properties.
-
-        """
-        # add actor to the correct render window
-        self._active_renderer_index = self.loc_to_index(loc)
-        renderer = self.renderers[self._active_renderer_index]
-        return renderer.add_actor(uinput=uinput, reset_camera=reset_camera,
-                                  name=name, culling=culling, pickable=pickable)
-
-    def loc_to_index(self, loc):
-        """Return index of the render window given a location index.
-
-        Parameters
-        ----------
-        loc : int, tuple, or list
-            Index of the renderer to add the actor to.  For example,
-            ``loc=2`` or ``loc=(1, 1)``.
-
-        Return
-        ------
-        idx : int
-            Index of the render window.
-
-        """
-        if loc is None:
-            return self._active_renderer_index
-        elif isinstance(loc, int):
-            return loc
-        elif isinstance(loc, collections.Iterable):
-            if not len(loc) == 2:
-                raise AssertionError('"loc" must contain two items')
-            index_row = loc[0]
-            index_column = loc[1]
-            if index_row < 0 or index_row >= self.shape[0]:
-                raise IndexError('Row index is out of range ({})'.format(self.shape[0]))
-            if index_column < 0 or index_column >= self.shape[1]:
-                raise IndexError('Column index is out of range ({})'.format(self.shape[1]))
-            sz = int(self.shape[0] * self.shape[1])
-            idxs = np.array([i for i in range(sz)], dtype=int).reshape(self.shape)
-            return idxs[index_row, index_column]
-
-    def index_to_loc(self, index):
-        """Convert a 1D index location to the 2D location on the plotting grid."""
-        if len(self.shape) == 1:
-            return index
-        sz = int(self.shape[0] * self.shape[1])
-        idxs = np.array([i for i in range(sz)], dtype=int).reshape(self.shape)
-        args = np.argwhere(idxs == index)
-        if len(args) < 1:
-            raise RuntimeError('Index ({}) is out of range.')
-        return args[0]
-
 
     @property
     def camera(self):
@@ -1941,289 +2047,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         """Set the active camera for the rendering scene."""
         self.renderer.camera = camera
 
-
-    def enable_parallel_projection(self):
-        """Enable parallel projection.
-
-        The camera will have a parallel projection. Parallel projection is
-        often useful when viewing images or 2D datasets.
-
-        """
-        return self.renderer.enable_parallel_projection()
-
-
-    def disable_parallel_projection(self):
-        """Reset the camera to use perspective projection."""
-        return self.renderer.disable_parallel_projection()
-
-    def add_axes_at_origin(self, x_color=None, y_color=None, z_color=None,
-                           xlabel='X', ylabel='Y', zlabel='Z', line_width=2,
-                           labels_off=False, loc=None):
-        """Add axes actor at the origin of a render window.
-
-        Parameters
-        ----------
-        loc : int, tuple, or list
-            Index of the renderer to add the actor to.  For example,
-            ``loc=2`` or ``loc=(1, 1)``.  When None, defaults to the
-            active render window.
-
-        Return
-        ------
-        marker_actor : vtk.vtkAxesActor
-            vtkAxesActor actor
-
-        """
-        kwargs = locals()
-        _ = kwargs.pop('self')
-        _ = kwargs.pop('loc')
-        self._active_renderer_index = self.loc_to_index(loc)
-        return self.renderers[self._active_renderer_index].add_axes_at_origin(**kwargs)
-
-    def show_bounds(self, mesh=None, bounds=None, show_xaxis=True,
-                    show_yaxis=True, show_zaxis=True, show_xlabels=True,
-                    show_ylabels=True, show_zlabels=True, italic=False,
-                    bold=True, shadow=False, font_size=None,
-                    font_family=None, color=None,
-                    xlabel='X Axis', ylabel='Y Axis', zlabel='Z Axis',
-                    use_2d=False, grid=None, location='closest', ticks=None,
-                    all_edges=False, corner_factor=0.5, fmt=None,
-                    minor_ticks=False, loc=None, padding=0.0):
-        """Add bounds axes.
-
-        Shows the bounds of the most recent input mesh unless mesh is specified.
-
-        Parameters
-        ----------
-        mesh : vtkPolydata or unstructured grid, optional
-            Input mesh to draw bounds axes around
-
-        bounds : list or tuple, optional
-            Bounds to override mesh bounds.
-            [xmin, xmax, ymin, ymax, zmin, zmax]
-
-        show_xaxis : bool, optional
-            Makes x axis visible.  Default True.
-
-        show_yaxis : bool, optional
-            Makes y axis visible.  Default True.
-
-        show_zaxis : bool, optional
-            Makes z axis visible.  Default True.
-
-        show_xlabels : bool, optional
-            Shows x labels.  Default True.
-
-        show_ylabels : bool, optional
-            Shows y labels.  Default True.
-
-        show_zlabels : bool, optional
-            Shows z labels.  Default True.
-
-        italic : bool, optional
-            Italicises axis labels and numbers.  Default False.
-
-        bold : bool, optional
-            Bolds axis labels and numbers.  Default True.
-
-        shadow : bool, optional
-            Adds a black shadow to the text.  Default False.
-
-        font_size : float, optional
-            Sets the size of the label font.  Defaults to 16.
-
-        font_family : string, optional
-            Font family.  Must be either courier, times, or arial.
-
-        color : string or 3 item list, optional
-            Color of all labels and axis titles.  Default white.
-            Either a string, rgb list, or hex color string.  For example:
-
-                color='white'
-                color='w'
-                color=[1, 1, 1]
-                color='#FFFFFF'
-
-        xlabel : string, optional
-            Title of the x axis.  Default "X Axis"
-
-        ylabel : string, optional
-            Title of the y axis.  Default "Y Axis"
-
-        zlabel : string, optional
-            Title of the z axis.  Default "Z Axis"
-
-        use_2d : bool, optional
-            A bug with vtk 6.3 in Windows seems to cause this function
-            to crash this can be enabled for smoother plotting for
-            other environments.
-
-        grid : bool or str, optional
-            Add grid lines to the backface (``True``, ``'back'``, or
-            ``'backface'``) or to the frontface (``'front'``,
-            ``'frontface'``) of the axes actor.
-
-        location : str, optional
-            Set how the axes are drawn: either static (``'all'``),
-            closest triad (``front``), furthest triad (``'back'``),
-            static closest to the origin (``'origin'``), or outer
-            edges (``'outer'``) in relation to the camera
-            position. Options include: ``'all', 'front', 'back',
-            'origin', 'outer'``
-
-        ticks : str, optional
-            Set how the ticks are drawn on the axes grid. Options include:
-            ``'inside', 'outside', 'both'``
-
-        all_edges : bool, optional
-            Adds an unlabeled and unticked box at the boundaries of
-            plot. Useful for when wanting to plot outer grids while
-            still retaining all edges of the boundary.
-
-        corner_factor : float, optional
-            If ``all_edges````, this is the factor along each axis to
-            draw the default box. Dafuault is 0.5 to show the full box.
-
-        loc : int, tuple, or list
-            Index of the renderer to add the actor to.  For example,
-            ``loc=2`` or ``loc=(1, 1)``.  If None, selects the last
-            active Renderer.
-
-        padding : float, optional
-            An optional percent padding along each axial direction to cushion
-            the datasets in the scene from the axes annotations. Defaults to
-            have no padding
-
-        Return
-        ------
-        cube_axes_actor : vtk.vtkCubeAxesActor
-            Bounds actor
-
-        Examples
-        --------
-        >>> import pyvista
-        >>> from pyvista import examples
-        >>> mesh = pyvista.Sphere()
-        >>> plotter = pyvista.Plotter()
-        >>> _ = plotter.add_mesh(mesh)
-        >>> _ = plotter.show_bounds(grid='front', location='outer', all_edges=True)
-        >>> plotter.show() # doctest:+SKIP
-
-        """
-        kwargs = locals()
-        _ = kwargs.pop('self')
-        _ = kwargs.pop('loc')
-        self._active_renderer_index = self.loc_to_index(loc)
-        renderer = self.renderers[self._active_renderer_index]
-        renderer.show_bounds(**kwargs)
-
-    def add_bounds_axes(self, *args, **kwargs):
-        """Add bounds axes.
-
-        DEPRECATED: Please use ``show_bounds`` or ``show_grid``.
-
-        """
-        logging.warning('`add_bounds_axes` is deprecated. Use `show_bounds` or `show_grid`.')
-        return self.show_bounds(*args, **kwargs)
-
-    def add_bounding_box(self, color=None, corner_factor=0.5, line_width=None,
-                         opacity=1.0, render_lines_as_tubes=False,
-                         lighting=None, reset_camera=None, outline=True,
-                         culling='front', loc=None):
-        """Add an unlabeled and unticked box at the boundaries of the plot.
-
-        Useful for when wanting to plot outer grids while still retaining
-        all edges of the boundary.
-
-        Parameters
-        ----------
-        corner_factor : float, optional
-            If ``all_edges``, this is the factor along each axis to
-            draw the default box. Dafuault is 0.5 to show the full
-            box.
-
-        corner_factor : float, optional
-            This is the factor along each axis to draw the default
-            box. Dafuault is 0.5 to show the full box.
-
-        line_width : float, optional
-            Thickness of lines.
-
-        opacity : float, optional
-            Opacity of mesh.  Should be between 0 and 1.  Default 1.0
-
-        outline : bool
-            Default is ``True``. when False, a box with faces is shown with
-            the specified culling
-
-        culling : str, optional
-            Does not render faces that are culled. Options are ``'front'`` or
-            ``'back'``. Default is ``'front'`` for bounding box.
-
-        loc : int, tuple, or list
-            Index of the renderer to add the actor to.  For example,
-            ``loc=2`` or ``loc=(1, 1)``.  If None, selects the last
-            active Renderer.
-
-        """
-        kwargs = locals()
-        _ = kwargs.pop('self')
-        _ = kwargs.pop('loc')
-        self._active_renderer_index = self.loc_to_index(loc)
-        renderer = self.renderers[self._active_renderer_index]
-        return renderer.add_bounding_box(**kwargs)
-
-    def remove_bounding_box(self, loc=None):
-        """Remove bounding box from the active renderer.
-
-        Parameters
-        ----------
-        loc : int, tuple, or list
-            Index of the renderer to add the actor to.  For example,
-            ``loc=2`` or ``loc=(1, 1)``.  If None, selects the last
-            active Renderer.
-
-        """
-        self._active_renderer_index = self.loc_to_index(loc)
-        renderer = self.renderers[self._active_renderer_index]
-        renderer.remove_bounding_box()
-
-    def remove_bounds_axes(self, loc=None):
-        """Remove bounds axes from the active renderer.
-
-        Parameters
-        ----------
-        loc : int, tuple, or list
-            Index of the renderer to add the actor to.  For example,
-            ``loc=2`` or ``loc=(1, 1)``.  If None, selects the last
-            active Renderer.
-
-        """
-        self._active_renderer_index = self.loc_to_index(loc)
-        renderer = self.renderers[self._active_renderer_index]
-        renderer.remove_bounds_axes()
-
-    def subplot(self, index_row, index_column=None):
-        """Set the active subplot.
-
-        Parameters
-        ----------
-        index_row : int
-            Index of the subplot to activate along the rows.
-
-        index_column : int
-            Index of the subplot to activate along the columns.
-
-        """
-        if len(self.shape) == 1:
-            self._active_renderer_index = index_row
-            return
-
-        if index_row < 0 or index_row >= self.shape[0]:
-            raise IndexError('Row index is out of range ({})'.format(self.shape[0]))
-        if index_column < 0 or index_column >= self.shape[1]:
-            raise IndexError('Column index is out of range ({})'.format(self.shape[1]))
-        self._active_renderer_index = self.loc_to_index((index_row, index_column))
 
     def link_views(self, views=0):
         """Link the views' cameras.
@@ -2272,43 +2095,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         else:
             raise TypeError('Expected type is None, int, list or tuple:'
                             '{} is given'.format(type(views)))
-
-    def show_grid(self, **kwargs):
-        """Show gridlines and axes labels.
-
-        A wrapped implementation of ``show_bounds`` to change default
-        behaviour to use gridlines and showing the axes labels on the outer
-        edges. This is intended to be silimar to ``matplotlib``'s ``grid``
-        function.
-
-        """
-        kwargs.setdefault('grid', 'back')
-        kwargs.setdefault('location', 'outer')
-        kwargs.setdefault('ticks', 'both')
-        return self.show_bounds(**kwargs)
-
-    def set_scale(self, xscale=None, yscale=None, zscale=None, reset_camera=True):
-        """Scale all the datasets in the scene of the active renderer.
-
-        Scaling in performed independently on the X, Y and Z axis.
-        A scale of zero is illegal and will be replaced with one.
-
-        Parameters
-        ----------
-        xscale : float, optional
-            Scaling of the x axis.  Must be greater than zero.
-
-        yscale : float, optional
-            Scaling of the y axis.  Must be greater than zero.
-
-        zscale : float, optional
-            Scaling of the z axis.  Must be greater than zero.
-
-        reset_camera : bool, optional
-            Resets camera so all actors can be seen.
-
-        """
-        self.renderer.set_scale(xscale, yscale, zscale, reset_camera)
 
     @property
     def scale(self):
@@ -3016,13 +2802,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
             ifilter.SetInputBufferTypeToRGB()
         return self._run_image_filter(ifilter)
 
-    def enable_eye_dome_lighting(self):
-        """Enable eye dome lighting (EDL) for the active renderer."""
-        return self.renderer.enable_eye_dome_lighting()
-
-    def disable_eye_dome_lighting(self):
-        """Disable eye dome lighting (EDL) for the active renderer."""
-        return self.renderer.disable_eye_dome_lighting()
 
     def add_lines(self, lines, color=(1, 1, 1), width=5, label=None, name=None):
         """Add lines to the plotting object.
@@ -3574,76 +3353,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
     @property
     def camera_position(self):
         """Return camera position of the active render window."""
-        return self.renderers[self._active_renderer_index].camera_position
+        return self.renderer.camera_position
 
     @camera_position.setter
     def camera_position(self, camera_location):
         """Set camera position of the active render window."""
-        self.renderers[self._active_renderer_index].camera_position = camera_location
+        self.renderer.camera_position = camera_location
 
-    def reset_camera(self):
-        """Reset the camera of the active render window.
-
-        The camera slides along the vector defined from camera position to focal point
-        until all of the actors can be seen.
-
-        """
-        self.renderers[self._active_renderer_index].reset_camera()
-        self._render()
-
-    def isometric_view(self):
-        """Reset the camera to a default isometric view.
-
-        DEPRECATED: Please use ``view_isometric``.
-
-        """
-        return self.view_isometric()
-
-    def view_isometric(self, negative=False):
-        """Reset the camera to a default isometric view.
-
-        The view will show all the actors in the scene.
-
-        """
-        return self.renderer.view_isometric(negative=negative)
-
-    def view_vector(self, vector, viewup=None):
-        """Set the view vector."""
-        return self.renderer.view_vector(vector, viewup=viewup)
-
-    def view_xy(self, negative=False):
-        """View the XY plane."""
-        return self.renderer.view_xy(negative=negative)
-
-    def view_yx(self, negative=False):
-        """View the YX plane."""
-        return self.renderer.view_yx(negative=negative)
-
-    def view_xz(self, negative=False):
-        """View the XZ plane."""
-        return self.renderer.view_xz(negative=negative)
-
-    def view_zx(self, negative=False):
-        """View the ZX plane."""
-        return self.renderer.view_zx(negative=negative)
-
-    def view_yz(self, negative=False):
-        """View the YZ plane."""
-        return self.renderer.view_yz(negative=negative)
-
-    def view_zy(self, negative=False):
-        """View the ZY plane."""
-        return self.renderer.view_zy(negative=negative)
-
-    def disable(self):
-        """Disable this renderer's camera from being interactive."""
-        return self.renderer.disable()
-
-    def enable(self):
-        """Enable this renderer's camera to be interactive."""
-        return self.renderer.enable()
-
-    def set_background(self, color, loc='all', top=None):
+    def set_background(self, color, top=None, all_renderers=True):
         """Set the background color.
 
         Parameters
@@ -3655,40 +3372,22 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 color=[1, 1, 1]
                 color='#FFFFFF'
 
-        loc : int, tuple, list, or str, optional
-            Index of the renderer to add the actor to.  For example,
-            ``loc=2`` or ``loc=(1, 1)``.  If ``loc='all'`` then all
-            render windows will have their background set.
-
         top : string or 3 item list, optional, defaults to None
             If given, this will enable a gradient background where the
             ``color`` argument is at the bottom and the color given in ``top``
             will be the color at the top of the renderer.
 
+        all_renderers : bool
+            If True, applies to all renderers in subplots. If False, then
+            only applies to the active renderer.
+
         """
-        if color is None:
-            color = rcParams['background']
 
-        use_gradient = False
-        if top is not None:
-            use_gradient = True
-
-        if loc == 'all':
+        if all_renderers:
             for renderer in self.renderers:
-                renderer.SetBackground(parse_color(color))
-                if use_gradient:
-                    renderer.GradientBackgroundOn()
-                    renderer.SetBackground2(parse_color(top))
-                else:
-                    renderer.GradientBackgroundOff()
+                renderer.set_background(color, top=top)
         else:
-            renderer = self.renderers[self.loc_to_index(loc)]
-            renderer.SetBackground(parse_color(color))
-            if use_gradient:
-                renderer.GradientBackgroundOn()
-                renderer.SetBackground2(parse_color(top))
-            else:
-                renderer.GradientBackgroundOff()
+            self.renderer.set_background(color, top=top)
 
     @property
     def background_color(self):

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -880,7 +880,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         return self.update_style()
 
 
-    # TODO: this should be on the renderer....
     def _render(self):
         """Redraw the render window if it exists."""
         if hasattr(self, 'ren_win'):

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -431,7 +431,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     @wraps(Renderer.view_yz)
     def view_yz(self, *args, **kwarg):
-        """Wraps ``Renderer.view_xz``."""
+        """Wraps ``Renderer.view_yz``."""
         return self.renderer.view_yz(*args, **kwarg)
 
     @wraps(Renderer.view_zy)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -424,12 +424,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
         """Wraps ``Renderer.view_xz``."""
         return self.renderer.view_xz(*args, **kwarg)
 
-    @wraps(Renderer.view_xz)
+    @wraps(Renderer.view_zx)
     def view_zx(self, *args, **kwarg):
-        """Wraps ``Renderer.view_xz``."""
+        """Wraps ``Renderer.view_zx``."""
         return self.renderer.view_zx(*args, **kwarg)
 
-    @wraps(Renderer.view_xz)
+    @wraps(Renderer.view_yz)
     def view_yz(self, *args, **kwarg):
         """Wraps ``Renderer.view_xz``."""
         return self.renderer.view_yz(*args, **kwarg)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -845,7 +845,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                  render_points_as_spheres=None, render_lines_as_tubes=False,
                  smooth_shading=False, ambient=0.0, diffuse=1.0, specular=0.0,
                  specular_power=100.0, nan_color=None, nan_opacity=1.0,
-                 loc=None, culling=None, rgb=False, categories=False,
+                 culling=None, rgb=False, categories=False,
                  use_transparency=False, below_color=None, above_color=None,
                  annotations=None, pickable=True, preference="point",
                  log_scale=False, **kwargs):
@@ -1008,11 +1008,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         nan_opacity : float, optional
             Opacity of ``NaN`` values.  Should be between 0 and 1.
             Default 1.0
-
-        loc : int, tuple, or list
-            Index of the renderer to add the actor to.  For example,
-            ``loc=2`` or ``loc=(1, 1)``.  If None, selects the last
-            active Renderer.
 
         culling : str, optional
             Does not render faces that are culled. Options are ``'front'`` or
@@ -1210,7 +1205,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         actor, prop = self.add_actor(self.mapper,
                                      reset_camera=reset_camera,
-                                     name=name, loc=loc, culling=culling)
+                                     name=name, culling=culling)
 
         # Try to plot something if no preference given
         if scalars is None and color is None and texture is None:
@@ -1238,7 +1233,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         actor, prop = self.add_actor(self.mapper,
                                      reset_camera=reset_camera,
-                                     name=name, loc=loc, culling=culling,
+                                     name=name, culling=culling,
                                      pickable=pickable)
 
         # Make sure scalars is a numpy array after this point
@@ -1506,7 +1501,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def add_volume(self, volume, scalars=None, clim=None, resolution=None,
                    opacity='linear', n_colors=256, cmap=None, flip_scalars=False,
                    reset_camera=None, name=None, ambient=0.0, categories=False,
-                   loc=None, culling=False, multi_colors=False,
+                   culling=False, multi_colors=False,
                    blending='composite', mapper=None,
                    stitle=None, scalar_bar_args=None, show_scalar_bar=None,
                    annotations=None, pickable=True, preference="point",
@@ -1576,11 +1571,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
             When lighting is enabled, this is the amount of light from
             0 to 1 that reaches the actor when not directed at the
             light source emitted from the viewer.  Default 0.0.
-
-        loc : int, tuple, or list
-            Index of the renderer to add the actor to.  For example,
-            ``loc=2`` or ``loc=(1, 1)``.  If None, selects the last
-            active Renderer.
 
         culling : str, optional
             Does not render faces that are culled. Options are ``'front'`` or
@@ -1726,7 +1716,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 a = self.add_volume(block, resolution=block_resolution, opacity=opacity,
                                     n_colors=n_colors, cmap=color, flip_scalars=flip_scalars,
                                     reset_camera=reset_camera, name=next_name,
-                                    ambient=ambient, categories=categories, loc=loc,
+                                    ambient=ambient, categories=categories,
                                     culling=culling, clim=clim,
                                     mapper=mapper, pickable=pickable,
                                     opacity_unit_distance=opacity_unit_distance,
@@ -1906,7 +1896,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.volume.SetProperty(prop)
 
         actor, prop = self.add_actor(self.volume, reset_camera=reset_camera,
-                                     name=name, loc=loc, culling=culling,
+                                     name=name, culling=culling,
                                      pickable=pickable)
 
 
@@ -2548,7 +2538,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.mapper = None
 
     def add_text(self, text, position='upper_left', font_size=18, color=None,
-                 font=None, shadow=False, name=None, loc=None, viewport=False):
+                 font=None, shadow=False, name=None, viewport=False):
         """Add text to plot object in the top left corner by default.
 
         Parameters
@@ -2579,10 +2569,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
             The name for the added actor so that it can be easily updated.
             If an actor of this name already exists in the rendering window, it
             will be replaced by the new actor.
-
-        loc : int, tuple, or list
-            Index of the renderer to add the actor to.  For example,
-            ``loc=2`` or ``loc=(1, 1)``.
 
         viewport: bool
             If True and position is a tuple of float, uses
@@ -2652,7 +2638,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.textActor.GetTextProperty().SetFontFamily(FONT_KEYS[font])
         self.textActor.GetTextProperty().SetShadow(shadow)
 
-        self.add_actor(self.textActor, reset_camera=False, name=name, loc=loc, pickable=False)
+        self.add_actor(self.textActor, reset_camera=False, name=name, pickable=False)
         return self.textActor
 
     def open_movie(self, filename, framerate=24):

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -277,181 +277,181 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     @wraps(Renderer.enable_anti_aliasing)
     def enable_anti_aliasing(self, *args, **kwargs):
-        """Wraps ``Renderer.enable_anti_aliasing``."""
+        """Wrap ``Renderer.enable_anti_aliasing``."""
         self.renderer.enable_anti_aliasing(*args, **kwargs)
 
     @wraps(Renderer.disable_anti_aliasing)
     def disable_anti_aliasing(self, *args, **kwargs):
-        """Wraps ``Renderer.disable_anti_aliasing``."""
+        """Wrap ``Renderer.disable_anti_aliasing``."""
         self.renderer.disable_anti_aliasing(*args, **kwargs)
 
     @wraps(Renderer.set_focus)
     def set_focus(self, *args, **kwargs):
-        """Wraps ``Renderer.set_focus``."""
+        """Wrap ``Renderer.set_focus``."""
         self.renderer.set_focus(*args, **kwargs)
         self._render()
 
     @wraps(Renderer.set_position)
     def set_position(self, *args, **kwargs):
-        """Wraps ``Renderer.set_position``."""
+        """Wrap ``Renderer.set_position``."""
         self.renderer.set_position(*args, **kwargs)
         self._render()
 
     @wraps(Renderer.set_viewup)
     def set_viewup(self, *args, **kwargs):
-        """Wraps ``Renderer.set_viewup``."""
+        """Wrap ``Renderer.set_viewup``."""
         self.renderer.set_viewup(*args, **kwargs)
         self._render()
 
     @wraps(Renderer.add_axes)
     def add_axes(self, *args, **kwargs):
-        """Wraps ``Renderer.add_axes``."""
+        """Wrap ``Renderer.add_axes``."""
         return self.renderer.add_axes(*args, **kwargs)
 
     @wraps(Renderer.hide_axes)
     def hide_axes(self, *args, **kwargs):
-        """Wraps ``Renderer.hide_axes``."""
+        """Wrap ``Renderer.hide_axes``."""
         return self.renderer.hide_axes(*args, **kwargs)
 
     @wraps(Renderer.show_axes)
     def show_axes(self, *args, **kwargs):
-        """Wraps ``Renderer.show_axes``."""
+        """Wrap ``Renderer.show_axes``."""
         return self.renderer.show_axes(*args, **kwargs)
 
     @wraps(Renderer.update_bounds_axes)
     def update_bounds_axes(self, *args, **kwargs):
-        """Wraps ``Renderer.update_bounds_axes``."""
+        """Wrap ``Renderer.update_bounds_axes``."""
         return self.renderer.update_bounds_axes(*args, **kwargs)
 
     @wraps(Renderer.add_actor)
     def add_actor(self, *args, **kwargs):
-        """Wraps ``Renderer.add_actor``."""
+        """Wrap ``Renderer.add_actor``."""
         return self.renderer.add_actor(*args, **kwargs)
 
     @wraps(Renderer.enable_parallel_projection)
     def enable_parallel_projection(self, *args, **kwargs):
-        """Wraps ``Renderer.enable_parallel_projection``."""
+        """Wrap ``Renderer.enable_parallel_projection``."""
         return self.renderer.enable_parallel_projection(*args, **kwargs)
 
     @wraps(Renderer.disable_parallel_projection)
     def disable_parallel_projection(self, *args, **kwargs):
-        """Wraps ``Renderer.disable_parallel_projection``."""
+        """Wrap ``Renderer.disable_parallel_projection``."""
         return self.renderer.disable_parallel_projection(*args, **kwargs)
 
     @wraps(Renderer.add_axes_at_origin)
     def add_axes_at_origin(self, *args, **kwargs):
-        """Wraps ``Renderer.add_axes_at_origin``."""
+        """Wrap ``Renderer.add_axes_at_origin``."""
         return self.renderer.add_axes_at_origin(*args, **kwargs)
 
     @wraps(Renderer.show_bounds)
     def show_bounds(self, *args, **kwargs):
-        """Wraps ``Renderer.show_bounds``."""
+        """Wrap ``Renderer.show_bounds``."""
         return self.renderer.show_bounds(*args, **kwargs)
 
     @wraps(Renderer.add_bounds_axes)
     def add_bounds_axes(self, *args, **kwargs):
-        """Wraps ``add_bounds_axes``."""
+        """Wrap ``add_bounds_axes``."""
         return self.renderer.add_bounds_axes(*args, **kwargs)
 
     @wraps(Renderer.add_bounding_box)
     def add_bounding_box(self, *args, **kwargs):
-        """Wraps ``Renderer.add_bounding_box``."""
+        """Wrap ``Renderer.add_bounding_box``."""
         return self.renderer.add_bounding_box(*args, **kwargs)
 
     @wraps(Renderer.remove_bounding_box)
     def remove_bounding_box(self, *args, **kwargs):
-        """Wraps ``Renderer.remove_bounding_box``."""
+        """Wrap ``Renderer.remove_bounding_box``."""
         return self.renderer.remove_bounding_box(*args, **kwargs)
 
     @wraps(Renderer.remove_bounds_axes)
     def remove_bounds_axes(self, *args, **kwargs):
-        """Wraps ``Renderer.remove_bounds_axes``."""
+        """Wrap ``Renderer.remove_bounds_axes``."""
         return self.renderer.remove_bounds_axes(*args, **kwargs)
 
     @wraps(Renderer.show_grid)
     def show_grid(self, *args, **kwargs):
-        """Wraps ``Renderer.show_grid``."""
+        """Wrap ``Renderer.show_grid``."""
         return self.renderer.show_bounds(*args, **kwargs)
 
     @wraps(Renderer.set_scale)
     def set_scale(self, *args, **kwargs):
-        """Wraps ``Renderer.set_scale``."""
+        """Wrap ``Renderer.set_scale``."""
         return self.renderer.set_scale(*args, **kwargs)
 
     @wraps(Renderer.enable_eye_dome_lighting)
     def enable_eye_dome_lighting(self, *args, **kwargs):
-        """Wraps ``Renderer.enable_eye_dome_lighting``."""
+        """Wrap ``Renderer.enable_eye_dome_lighting``."""
         return self.renderer.enable_eye_dome_lighting(*args, **kwargs)
 
     @wraps(Renderer.disable_eye_dome_lighting)
     def disable_eye_dome_lighting(self, *args, **kwargs):
-        """Wraps ``Renderer.disable_eye_dome_lighting``."""
+        """Wrap ``Renderer.disable_eye_dome_lighting``."""
         return self.renderer.disable_eye_dome_lighting(*args, **kwargs)
 
     @wraps(Renderer.reset_camera)
     def reset_camera(self, *args, **kwargs):
-        """Wraps ``Renderer.reset_camera``."""
+        """Wrap ``Renderer.reset_camera``."""
         self.renderer.reset_camera(*args, **kwargs)
         self._render()
 
     @wraps(Renderer.isometric_view)
     def isometric_view(self, *args, **kwargs):
-        """Wraps ``Renderer.isometric_view``."""
+        """Wrap ``Renderer.isometric_view``."""
         return self.renderer.isometric_view(*args, **kwargs)
 
     @wraps(Renderer.view_isometric)
     def view_isometric(self, *args, **kwarg):
-        """Wraps ``Renderer.view_isometric``."""
+        """Wrap ``Renderer.view_isometric``."""
         return self.renderer.view_isometric(*args, **kwarg)
 
     @wraps(Renderer.view_vector)
     def view_vector(self, *args, **kwarg):
-        """Wraps ``Renderer.view_vector``."""
+        """Wrap ``Renderer.view_vector``."""
         return self.renderer.view_vector(*args, **kwarg)
 
     @wraps(Renderer.view_xy)
     def view_xy(self, *args, **kwarg):
-        """Wraps ``Renderer.view_xy``."""
+        """Wrap ``Renderer.view_xy``."""
         return self.renderer.view_xy(*args, **kwarg)
 
     @wraps(Renderer.view_yx)
     def view_yx(self, *args, **kwarg):
-        """Wraps ``Renderer.view_yx``."""
+        """Wrap ``Renderer.view_yx``."""
         return self.renderer.view_yx(*args, **kwarg)
 
     @wraps(Renderer.view_xz)
     def view_xz(self, *args, **kwarg):
-        """Wraps ``Renderer.view_xz``."""
+        """Wrap ``Renderer.view_xz``."""
         return self.renderer.view_xz(*args, **kwarg)
 
     @wraps(Renderer.view_zx)
     def view_zx(self, *args, **kwarg):
-        """Wraps ``Renderer.view_zx``."""
+        """Wrap ``Renderer.view_zx``."""
         return self.renderer.view_zx(*args, **kwarg)
 
     @wraps(Renderer.view_yz)
     def view_yz(self, *args, **kwarg):
-        """Wraps ``Renderer.view_yz``."""
+        """Wrap ``Renderer.view_yz``."""
         return self.renderer.view_yz(*args, **kwarg)
 
     @wraps(Renderer.view_zy)
     def view_zy(self, *args, **kwarg):
-        """Wraps ``Renderer.view_zy``."""
+        """Wrap ``Renderer.view_zy``."""
         return self.renderer.view_zy(*args, **kwarg)
 
     @wraps(Renderer.disable)
     def disable(self, *args, **kwarg):
-        """Wraps ``Renderer.disable``."""
+        """Wrap ``Renderer.disable``."""
         return self.renderer.disable(*args, **kwarg)
 
     @wraps(Renderer.enable)
     def enable(self, *args, **kwarg):
-        """Wraps ``Renderer.enable``."""
+        """Wrap ``Renderer.enable``."""
         return self.renderer.enable(*args, **kwarg)
 
     @wraps(Renderer.enable_depth_peeling)
     def enable_depth_peeling(self, *args, **kwargs):
-        """Wraps ``Renderer.enable_depth_peeling``."""
+        """Wrap ``Renderer.enable_depth_peeling``."""
         if hasattr(self, 'ren_win'):
             result = self.renderer.enable_depth_peeling(*args, **kwargs)
             if result:
@@ -461,7 +461,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     @wraps(Renderer.disable_depth_peeling)
     def disable_depth_peeling(self):
-        """Wraps ``Renderer.disable_depth_peeling``."""
+        """Wrap ``Renderer.disable_depth_peeling``."""
         if hasattr(self, 'ren_win'):
             self.ren_win.AlphaBitPlanesOff()
             return self.renderer.disable_depth_peeling()
@@ -469,7 +469,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     @wraps(Renderer.get_default_cam_pos)
     def get_default_cam_pos(self, *args, **kwargs):
-        """Wraps ``Renderer.get_default_cam_pos``."""
+        """Wrap ``Renderer.get_default_cam_pos``."""
         return self.renderer.get_default_cam_pos(*args, **kwargs)
 
 
@@ -3362,7 +3362,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
             only applies to the active renderer.
 
         """
-
         if all_renderers:
             for renderer in self.renderers:
                 renderer.set_background(color, top=top)

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -687,12 +687,11 @@ class BackgroundPlotter(QtInteractor):
         """Close the plotter."""
         self.app_window.close()
 
-    def add_actor(self, actor, reset_camera=None, name=None, loc=None, culling=False, pickable=True):
+    def add_actor(self, actor, reset_camera=None, name=None, culling=False, pickable=True):
         """Add an actor."""
         actor, prop = super(BackgroundPlotter, self).add_actor(actor,
                                                                reset_camera=reset_camera,
                                                                name=name,
-                                                               loc=loc,
                                                                culling=culling,
                                                                pickable=pickable)
         self.update_app_icon()

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -134,6 +134,40 @@ class Renderer(vtkRenderer):
             scale_point(self.camera, self.camera.GetFocalPoint(), invert=True),
             self.camera.GetViewUp())
 
+    @camera_position.setter
+    def camera_position(self, camera_location):
+        """Set camera position of all active render windows."""
+        if camera_location is None:
+            return
+
+        if isinstance(camera_location, str):
+            camera_location = camera_location.lower()
+            if camera_location == 'xy':
+                self.view_xy()
+            elif camera_location == 'xz':
+                self.view_xz()
+            elif camera_location == 'yz':
+                self.view_yz()
+            elif camera_location == 'yx':
+                self.view_yx()
+            elif camera_location == 'zx':
+                self.view_zx()
+            elif camera_location == 'zy':
+                self.view_zy()
+            return
+
+        if isinstance(camera_location[0], (int, float)):
+            return self.view_vector(camera_location)
+
+        # everything is set explicitly
+        self.camera.SetPosition(scale_point(self.camera, camera_location[0], invert=False))
+        self.camera.SetFocalPoint(scale_point(self.camera, camera_location[1], invert=False))
+        self.camera.SetViewUp(camera_location[2])
+
+        # reset clipping range
+        self.ResetCameraClippingRange()
+        self.camera_set = True
+
     @property
     def camera(self):
         """Return the active camera for the rendering scene."""
@@ -835,40 +869,6 @@ class Renderer(vtkRenderer):
 
         self.RemoveAllViewProps()
         self.Modified()
-
-    @camera_position.setter
-    def camera_position(self, camera_location):
-        """Set camera position of all active render windows."""
-        if camera_location is None:
-            return
-
-        if isinstance(camera_location, str):
-            camera_location = camera_location.lower()
-            if camera_location == 'xy':
-                self.view_xy()
-            elif camera_location == 'xz':
-                self.view_xz()
-            elif camera_location == 'yz':
-                self.view_yz()
-            elif camera_location == 'yx':
-                self.view_yx()
-            elif camera_location == 'zx':
-                self.view_zx()
-            elif camera_location == 'zy':
-                self.view_zy()
-            return
-
-        if isinstance(camera_location[0], (int, float)):
-            return self.view_vector(camera_location)
-
-        # everything is set explicitly
-        self.camera.SetPosition(scale_point(self.camera, camera_location[0], invert=False))
-        self.camera.SetFocalPoint(scale_point(self.camera, camera_location[1], invert=False))
-        self.camera.SetViewUp(camera_location[2])
-
-        # reset clipping range
-        self.ResetCameraClippingRange()
-        self.camera_set = True
 
 
     def set_focus(self, point):

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -173,8 +173,8 @@ class Renderer(vtkRenderer):
         self.AddViewProp(actor)
 
 
-    def add_actor(self, uinput, reset_camera=False, name=None, loc=None,
-                  culling=False, pickable=True):
+    def add_actor(self, uinput, reset_camera=False, name=None, culling=False,
+                  pickable=True):
         """Add an actor to render window.
 
         Creates an actor if input is a mapper.
@@ -186,10 +186,6 @@ class Renderer(vtkRenderer):
 
         reset_camera : bool, optional
             Resets the camera when true.
-
-        loc : int, tuple, or list
-            Index of the renderer to add the actor to.  For example,
-            ``loc=2`` or ``loc=(1, 1)``.
 
         culling : str, optional
             Does not render faces that are culled. Options are ``'front'`` or
@@ -349,7 +345,7 @@ class Renderer(vtkRenderer):
                     font_family=None, color=None,
                     xlabel='X Axis', ylabel='Y Axis', zlabel='Z Axis',
                     use_2d=False, grid=None, location='closest', ticks=None,
-                    all_edges=False, corner_factor=0.5, loc=None, fmt=None,
+                    all_edges=False, corner_factor=0.5, fmt=None,
                     minor_ticks=False, padding=0.0):
         """Add bounds axes.
 
@@ -445,11 +441,6 @@ class Renderer(vtkRenderer):
         corner_factor : float, optional
             If ``all_edges````, this is the factor along each axis to
             draw the default box. Dafuault is 0.5 to show the full box.
-
-        loc : int, tuple, or list
-            Index of the renderer to add the actor to.  For example,
-            ``loc=2`` or ``loc=(1, 1)``.  If None, selects the last
-            active Renderer.
 
         padding : float, optional
             An optional percent padding along each axial direction to cushion
@@ -664,7 +655,7 @@ class Renderer(vtkRenderer):
     def add_bounding_box(self, color="grey", corner_factor=0.5, line_width=None,
                          opacity=1.0, render_lines_as_tubes=False,
                          lighting=None, reset_camera=None, outline=True,
-                         culling='front', loc=None):
+                         culling='front'):
         """Add an unlabeled and unticked box at the boundaries of plot.
 
         Useful for when wanting to plot outer grids while still retaining all
@@ -694,11 +685,6 @@ class Renderer(vtkRenderer):
         culling : str, optional
             Does not render faces that are culled. Options are ``'front'`` or
             ``'back'``. Default is ``'front'`` for bounding box.
-
-        loc : int, tuple, or list
-            Index of the renderer to add the actor to.  For example,
-            ``loc=2`` or ``loc=(1, 1)``.  If None, selects the last
-            active Renderer.
 
         """
         if lighting is None:

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -9,7 +9,7 @@ import vtk
 from vtk import vtkRenderer
 
 import pyvista
-from pyvista.utilities import wrap
+from pyvista.utilities import wrap, check_depth_peeling
 
 from .theme import parse_color, parse_font_family, rcParams, MAX_N_COLOR_BARS
 from .tools import update_axes_label_color, create_axes_orientation_box, create_axes_marker
@@ -125,9 +125,15 @@ class Renderer(vtkRenderer):
 
     def enable_depth_peeling(self, number_of_peels=5, occlusion_ratio=0.1):
         """Enable depth peeling."""
-        self.SetUseDepthPeeling(True)
-        self.SetMaximumNumberOfPeels(number_of_peels)
-        self.SetOcclusionRatio(occlusion_ratio)
+        if number_of_peels is None:
+            number_of_peels = rcParams["depth_peeling"]["number_of_peels"]
+        depth_peeling_supported = check_depth_peeling(number_of_peels,
+                                                      occlusion_ratio)
+        if depth_peeling_supported:
+            self.SetUseDepthPeeling(True)
+            self.SetMaximumNumberOfPeels(number_of_peels)
+            self.SetOcclusionRatio(occlusion_ratio)
+        return depth_peeling_supported
 
     def disable_depth_peeling(self):
         """Disable depth peeling."""

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -638,6 +638,21 @@ class Renderer(vtkRenderer):
         logging.warning('`add_bounds_axes` is deprecated. Use `show_bounds` or `show_grid`.')
         return self.show_bounds(*args, **kwargs)
 
+
+    def show_grid(self, **kwargs):
+        """Show gridlines and axes labels.
+
+        A wrapped implementation of ``show_bounds`` to change default
+        behaviour to use gridlines and showing the axes labels on the outer
+        edges. This is intended to be silimar to ``matplotlib``'s ``grid``
+        function.
+
+        """
+        kwargs.setdefault('grid', 'back')
+        kwargs.setdefault('location', 'outer')
+        kwargs.setdefault('ticks', 'both')
+        return self.show_bounds(**kwargs)
+
     def remove_bounding_box(self):
         """Remove bounding box."""
         if hasattr(self, '_box_object'):
@@ -1125,6 +1140,40 @@ class Renderer(vtkRenderer):
         y0 = int(self.GetPickY1())
         y1 = int(self.GetPickY2())
         return x0, y0, x1, y1
+
+
+    def set_background(self, color, top=None):
+        """Set the background color.
+
+        Parameters
+        ----------
+        color : string or 3 item list, optional, defaults to white
+            Either a string, rgb list, or hex color string.  For example:
+                color='white'
+                color='w'
+                color=[1, 1, 1]
+                color='#FFFFFF'
+
+        top : string or 3 item list, optional, defaults to None
+            If given, this will enable a gradient background where the
+            ``color`` argument is at the bottom and the color given in ``top``
+            will be the color at the top of the renderer.
+
+        """
+        if color is None:
+            color = rcParams['background']
+
+        use_gradient = False
+        if top is not None:
+            use_gradient = True
+
+        self.SetBackground(parse_color(color))
+        if use_gradient:
+            self.GradientBackgroundOn()
+            self.SetBackground2(parse_color(top))
+        else:
+            self.GradientBackgroundOff()
+        return
 
 
     def deep_clean(self):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -522,24 +522,24 @@ def test_camera():
 def test_multi_renderers():
     plotter = pyvista.Plotter(shape=(2, 2), off_screen=OFF_SCREEN)
 
-    loc = (0, 0)
-    plotter.add_text('Render Window 0', loc=loc, font_size=30)
+    plotter.subplot(0, 0)
+    plotter.add_text('Render Window 0', font_size=30)
     sphere = pyvista.Sphere()
-    plotter.add_mesh(sphere, loc=loc, scalars=sphere.points[:, 2])
+    plotter.add_mesh(sphere, scalars=sphere.points[:, 2])
     plotter.add_scalar_bar('Z', vertical=True)
 
-    loc = (0, 1)
-    plotter.add_text('Render Window 1', loc=loc, font_size=30)
-    plotter.add_mesh(pyvista.Cube(), loc=loc, show_edges=True)
+    plotter.subplot(0, 1)
+    plotter.add_text('Render Window 1', font_size=30)
+    plotter.add_mesh(pyvista.Cube(), show_edges=True)
 
-    loc = (1, 0)
-    plotter.add_text('Render Window 2', loc=loc, font_size=30)
-    plotter.add_mesh(pyvista.Arrow(), color='y', loc=loc, show_edges=True)
+    plotter.subplot(1, 0)
+    plotter.add_text('Render Window 2', font_size=30)
+    plotter.add_mesh(pyvista.Arrow(), color='y', show_edges=True)
 
     plotter.subplot(1, 1)
     plotter.add_text('Render Window 3', position=(0., 0.),
-                     loc=loc, font_size=30, viewport=True)
-    plotter.add_mesh(pyvista.Cone(), color='g', loc=loc, show_edges=True,
+                     font_size=30, viewport=True)
+    plotter.add_mesh(pyvista.Cone(), color='g', show_edges=True,
                      culling=True)
     plotter.add_bounding_box(render_lines_as_tubes=True, line_width=5)
     plotter.show_bounds(all_edges=True)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -162,10 +162,13 @@ def test_plotter_scale():
     plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
     plotter.add_mesh(sphere)
     plotter.set_scale(10, 10, 10)
+    assert plotter.scale == [10, 10, 10]
     plotter.set_scale(5.0)
     plotter.set_scale(yscale=6.0)
     plotter.set_scale(zscale=9.0)
     assert plotter.scale == [5.0, 6.0, 9.0]
+    plotter.scale = [1.0, 4.0, 2.0]
+    assert plotter.scale == [1.0, 4.0, 2.0]
     plotter.show()
 
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -273,10 +273,29 @@ def test_add_point_labels():
     with pytest.raises(Exception):
         plotter.add_point_labels(points, range(n - 1))
 
-    plotter.set_background('k')
-    plotter.set_background([0, 0, 0], top=[1,1,1]) # Gradient
     plotter.add_point_labels(points, range(n), show_points=True, point_color='r')
     plotter.add_point_labels(points - 1, range(n), show_points=False, point_color='r')
+    plotter.show()
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+def test_set_background():
+    plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
+    plotter.set_background('k')
+    plotter.set_background([0, 0, 0], top=[1,1,1]) # Gradient
+    plotter.show()
+
+    plotter = pyvista.Plotter(off_screen=OFF_SCREEN, shape=(1,2))
+    plotter.set_background('orange')
+    for renderer in plotter.renderers:
+        assert renderer.GetBackground() == pyvista.parse_color('orange')
+    plotter.show()
+
+    plotter = pyvista.Plotter(off_screen=OFF_SCREEN, shape=(1,2))
+    plotter.subplot(0,1)
+    plotter.set_background('orange', all_renderers=False)
+    assert plotter.renderers[0].GetBackground() != pyvista.parse_color('orange')
+    assert plotter.renderers[1].GetBackground() == pyvista.parse_color('orange')
     plotter.show()
 
 


### PR DESCRIPTION
Close #470 and follow up https://github.com/pyvista/pyvista/pull/536#issuecomment-575248748

This uses `functools.wraps` to properly wrap the methods on `BasePlotter` that call to the active `Renderer`, minimizing duplicated docstrings and argument listing. Note that properties still aren't handled via wrapping but are all explicitly defined in `BasePlotter`.

I also went ahead and deprecated the `loc` argument that was in a few places across the `BasePlotter` API as it was mostly unused. This deprecation was done in favor of having the user activate a given plotter by the `subplot` method then calling the method of choice. See https://github.com/pyvista/pyvista/pull/536#issuecomment-575254512. I think that using one active renderer managed by `subplot()` is more in line with our mission to follow Matplotlib conventions and simpler (having `loc` argument just makes things messy and hard to manage). Also, this is in line with the Zen of Python:

> There should be one-- and preferably only one --obvious way to do it.

I also reorganized the `Plotter` and `Renderer` class by keeping all of the wrapped methods from `Renderer` and properties in their respective sections of the class definition.

