### PR TITLE
[BUGFIX] getitem list of str with MultiBlock

### DIFF
--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -287,7 +287,11 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
         elif isinstance(index, (list, tuple, np.ndarray)):
             multi = MultiBlock()
             for i in index:
-                multi[-1, self.get_block_name(i)] = self[i]
+                if isinstance(i, str):
+                    name = i
+                else:
+                    name = self.get_block_name(i)
+                multi[-1, name] = self[i]
             return multi
         elif isinstance(index, str):
             index = self.get_index_by_name(index)

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -347,6 +347,15 @@ def test_multi_block_list_index():
     for i, j in enumerate(indices):
         assert id(sub[i]) == id(multi[j])
         assert sub.get_block_name(i) == multi.get_block_name(j)
+    # check list of key names
+    multi = pyvista.MultiBlock()
+    multi["foo"] = pyvista.Sphere()
+    multi["goo"] = pyvista.Box()
+    multi["soo"] = pyvista.Cone()
+    indices = ["goo", "foo"]
+    sub = multi[indices]
+    assert len(sub) == len(indices)
+    assert isinstance(sub["foo"], pyvista.PolyData)
 
 def test_multi_block_volume():
     multi = pyvista.MultiBlock()


### PR DESCRIPTION
There was a bug if passing a list of string names to fetch subsets of a `MultiBlock` dataset. These changes fix that and add a test.