### PR TITLE
Deep copy textures in copy_meta_from

### DIFF
--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -1005,8 +1005,9 @@ class Common(DataSetFilters, DataObject):
         self._active_scalars_info = ido.active_scalars_info
         self._active_vectors_info = ido.active_vectors_info
         if hasattr(ido, '_textures'):
-            self._textures = ido._textures
-
+            self._textures = {}
+            for name, tex in ido._textures.items():
+                self._textures[name] = tex.copy()
 
     @property
     def point_arrays(self):

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -499,3 +499,7 @@ class Texture(vtk.vtkTexture):
     @repeat.setter
     def repeat(self, flag):
         self.SetRepeat(flag)
+
+    def copy(self):
+        """Make a copy of this textrue."""
+        return Texture(self.to_image().copy())


### PR DESCRIPTION
When copying a dataset with textures, ensure the textures are also copied and not pointing to the original mesh's textures