### PR TITLE
[BUGFIX] Properly close axes widgets

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2534,6 +2534,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
         """Close the render window."""
         # must close out widgets first
         super(BasePlotter, self).close()
+        # Renderer has an axes widget, so close it
+        for renderer in self.renderers:
+            renderer.close()
 
         # Grab screenshots of last render
         self.last_image = self.screenshot(None, return_img=True)

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1194,6 +1194,13 @@ class Renderer(vtkRenderer):
         return
 
 
+    def close(self):
+        """Close out widgets and sensitive elements."""
+        if hasattr(self, 'axes_widget'):
+            self.axes_widget.RemoveAllObservers()
+            del self.axes_widget
+
+
     def deep_clean(self):
         """Clean the renderer of the memory."""
         if hasattr(self, 'cube_axes_actor'):
@@ -1202,8 +1209,6 @@ class Renderer(vtkRenderer):
             del self.edl_pass
         if hasattr(self, '_box_object'):
             self.remove_bounding_box()
-        if hasattr(self, 'axes_widget'):
-            del self.axes_widget
 
         self.RemoveAllViewProps()
         self._actors = None

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1197,7 +1197,7 @@ class Renderer(vtkRenderer):
     def close(self):
         """Close out widgets and sensitive elements."""
         if hasattr(self, 'axes_widget'):
-            self.axes_widget.RemoveAllObservers()
+            self.hide_axes() # Necessary to avoid segfault
             del self.axes_widget
 
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -315,19 +315,30 @@ def test_add_points():
 def test_key_press_event():
     plotter = pyvista.Plotter(off_screen=False)
     plotter.key_press_event(None, None)
+    plotter.close()
 
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_left_button_down():
     plotter = pyvista.Plotter(off_screen=False)
     plotter.left_button_down(None, None)
-    # assert np.allclose(plotter.pickpoint, [0, 0, 0])
+    # assert np.allclose(plotter.pickpoint, [0, 0, 0])\
+    plotter.close()
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+def test_show_axes():
+    # if not closed correctly, a seg fault occurs when exitting
+    plotter = pyvista.Plotter(off_screen=False)
+    plotter.show_axes()
+    plotter.close()
 
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_update():
     plotter = pyvista.Plotter(off_screen=True)
     plotter.update()
+    plotter.close()
 
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")


### PR DESCRIPTION
Resolve #558 by adding a `close()` method to the `Renderer` class that will close out the axes widgets before the render window interactor is destroyed.

This also makes me think that we should refactor the `widgets` module to keep track of all the widgets on the `Renderer`s themselves rather than the `BasePlotter`.... for another time