### PR TITLE
load from meshio instances

### DIFF
--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -268,19 +268,12 @@ def read_exodus(filename,
     return pyvista.wrap(reader.GetOutput())
 
 
-def read_meshio(filename, file_format = None):
-    """Read any mesh file using meshio."""
-    import meshio
+def from_meshio(mesh):
+    """Convert a ``meshio`` mesh instance to a PyVista mesh."""
     from meshio.vtk._vtk import (
         meshio_to_vtk_type,
         vtk_type_to_numnodes,
     )
-
-    # Make sure relative paths will work
-    filename = os.path.abspath(os.path.expanduser(str(filename)))
-
-    # Read mesh file
-    mesh = meshio.read(filename, file_format)
 
     # Extract cells from meshio.Mesh object
     offset = []
@@ -322,6 +315,16 @@ def read_meshio(filename, file_format = None):
     grid.cell_arrays.update(cell_data)
 
     return grid
+
+
+def read_meshio(filename, file_format=None):
+    """Read any mesh file using meshio."""
+    import meshio
+    # Make sure relative paths will work
+    filename = os.path.abspath(os.path.expanduser(str(filename)))
+    # Read mesh file
+    mesh = meshio.read(filename, file_format)
+    return from_meshio(mesh)
 
 
 def save_meshio(filename, mesh, file_format = None, **kwargs):

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -11,6 +11,7 @@ import vtk
 import vtk.util.numpy_support as nps
 
 import pyvista
+from .fileio import from_meshio
 
 POINT_DATA_FIELD = 0
 CELL_DATA_FIELD = 1
@@ -405,6 +406,15 @@ def trans_from_matrix(matrix):
     return t
 
 
+def is_meshio_mesh(mesh):
+    """Test if passed object is instance of ``meshio.Mesh``."""
+    try:
+        import meshio
+        return isinstance(mesh, meshio.Mesh)
+    except ImportError:
+        return False
+
+
 def wrap(vtkdataset):
     """Wrap any given VTK data object to its appropriate PyVista data object.
 
@@ -442,6 +452,8 @@ def wrap(vtkdataset):
         else:
             print(vtkdataset.shape, vtkdataset)
             raise NotImplementedError('NumPy array could not be converted to PyVista.')
+    elif is_meshio_mesh(vtkdataset):
+        return from_meshio(vtkdataset)
     else:
         raise NotImplementedError('Type ({}) not able to be wrapped into a PyVista mesh.'.format(type(vtkdataset)))
     try:


### PR DESCRIPTION
These changes make it possible to load from `meshio` instances and pass `meshio` objects to the `pyvista.wrap()`, `pyvista.plot()`, and `pyvista.from_meshio` methods.

What does this mean? More interoperability with `meshio` based software like [`pygalmesh`](https://github.com/nschloe/pygalmesh) or [`pygmsh`](https://github.com/nschloe/pygmsh) without having to save a static copy of the mesh to a file.


```py
import pygmsh
import pyvista as pv

geom = pygmsh.opencascade.Geometry(
  characteristic_length_min=0.1,
  characteristic_length_max=0.1,
  )

rectangle = geom.add_rectangle([-1.0, -1.0, 0.0], 2.0, 2.0)
disk1 = geom.add_disk([-1.2, 0.0, 0.0], 0.5)
disk2 = geom.add_disk([+1.2, 0.0, 0.0], 0.5)
union = geom.boolean_union([rectangle, disk1, disk2])

disk3 = geom.add_disk([0.0, -0.9, 0.0], 0.5)
disk4 = geom.add_disk([0.0, +0.9, 0.0], 0.5)
flat = geom.boolean_difference([union], [disk3, disk4])

geom.extrude(flat, [0, 0, 0.3])

mesh = pygmsh.generate_mesh(geom)

pv.plot(mesh, show_edges=True, point_size=10, render_points_as_spheres=True)
```

![download](https://user-images.githubusercontent.com/22067021/73241860-91fa7e80-4160-11ea-9d57-c82af2bc4b6b.png)


