### PR TITLE
Add vtkExtractVOI filter

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,14 @@ pyvista.FIGURE_PATH = os.path.join(os.path.abspath('./images/'), 'auto-generated
 if not os.path.exists(pyvista.FIGURE_PATH):
     os.makedirs(pyvista.FIGURE_PATH)
 
+# SG warnins
+import warnings
+warnings.filterwarnings(
+    "ignore",
+    category=UserWarning,
+    message='Matplotlib is currently using agg, which is a non-GUI backend, so cannot show the figure.',
+)
+
 # -- General configuration ------------------------------------------------
 numfig = False
 html_show_sourcelink = False

--- a/examples/02-plot/volume.py
+++ b/examples/02-plot/volume.py
@@ -3,7 +3,11 @@ Volume Rendering
 ~~~~~~~~~~~~~~~~
 
 Volume render uniform mesh types like :class:`pyvista.UniformGrid` or 3D
-NumPy arrays
+NumPy arrays.
+
+This also explores how to extract a volume of interest (VOI) from a
+:class:`pyvista.UniformGrid` using the
+:func:`pyvista.UniformGridFilters.extract_subset` filter.
 """
 
 # sphinx_gallery_thumbnail_number = 3
@@ -93,4 +97,42 @@ p.add_volume(frog, cmap="viridis", opacity="sigmoid_6")
 p.camera_position = [(929., 1067., -278.9),
                      (249.5, 234.5, 101.25),
                      (-0.2048, -0.2632, -0.9427)]
+p.show()
+
+
+###############################################################################
+# Extracting a VOI
+# ++++++++++++++++
+#
+# Use the :func:`pyvista.UniformGridFilters.extract_subset` filter to extract
+# a volume of interest/subset volume to volume render. This is ideal when
+# dealing with particularly large volumes and you want to volume render only
+# a specific region.
+
+# Load a particularly large volume
+large_vol = examples.download_damavand_volcano()
+large_vol
+
+###############################################################################
+large_vol.plot()
+
+
+###############################################################################
+# Woah, that's a big volume! We probably don't want to volume render the
+# whole thing. So let's extract a region of interest.
+voi = large_vol.extract_subset([175, 200, 105, 132, 98, 170])
+
+p = pv.Plotter()
+p.add_mesh(large_vol.outline(), color="k")
+p.add_mesh(voi)
+p.show()
+
+###############################################################################
+# Ah, much better. Let's now volume render that region of interest!
+
+p = pv.Plotter()
+p.add_volume(voi, opacity=[0, 0.75, 0, 0.75, 1.0], opacity_unit_distance=2000)
+p.camera_position = [(531554.5542909054, 3944331.800171338, 26563.04809259223),
+ (599088.1433822059, 3982089.287834022, -11965.14728669936),
+ (0.3738545892415734, 0.244312810377319, 0.8947312427698892)]
 p.show()

--- a/examples/02-plot/volume.py
+++ b/examples/02-plot/volume.py
@@ -115,9 +115,10 @@ large_vol
 
 ###############################################################################
 opacity = [0, 0.75, 0, 0.75, 1.0]
+clim = [0, 100]
 
 p = pv.Plotter()
-p.add_volume(large_vol, cmap="magma",
+p.add_volume(large_vol, cmap="magma", clim=clim,
              opacity=opacity, opacity_unit_distance=6000,)
 p.show()
 
@@ -136,7 +137,7 @@ p.show()
 # Ah, much better. Let's now volume render that region of interest!
 
 p = pv.Plotter()
-p.add_volume(voi, cmap="magma", opacity=opacity,
+p.add_volume(voi, cmap="magma", clim=clim, opacity=opacity,
              opacity_unit_distance=2000)
 p.camera_position = [(531554.5542909054, 3944331.800171338, 26563.04809259223),
  (599088.1433822059, 3982089.287834022, -11965.14728669936),

--- a/examples/02-plot/volume.py
+++ b/examples/02-plot/volume.py
@@ -126,6 +126,11 @@ p.show()
 ###############################################################################
 # Woah, that's a big volume! We probably don't want to volume render the
 # whole thing. So let's extract a region of interest under the volcano.
+#
+# The region we will extract will be between nodes 175 and 200 on the x-axis,
+# between nodes 105 and 132 on the y-axis, and between nodes 98 and 170 on
+# the z-axis.
+
 voi = large_vol.extract_subset([175, 200, 105, 132, 98, 170])
 
 p = pv.Plotter()

--- a/examples/02-plot/volume.py
+++ b/examples/02-plot/volume.py
@@ -114,24 +114,30 @@ large_vol = examples.download_damavand_volcano()
 large_vol
 
 ###############################################################################
-large_vol.plot()
+opacity = [0, 0.75, 0, 0.75, 1.0]
+
+p = pv.Plotter()
+p.add_volume(large_vol, cmap="magma",
+             opacity=opacity, opacity_unit_distance=6000,)
+p.show()
 
 
 ###############################################################################
 # Woah, that's a big volume! We probably don't want to volume render the
-# whole thing. So let's extract a region of interest.
+# whole thing. So let's extract a region of interest under the volcano.
 voi = large_vol.extract_subset([175, 200, 105, 132, 98, 170])
 
 p = pv.Plotter()
 p.add_mesh(large_vol.outline(), color="k")
-p.add_mesh(voi)
+p.add_mesh(voi, cmap="magma")
 p.show()
 
 ###############################################################################
 # Ah, much better. Let's now volume render that region of interest!
 
 p = pv.Plotter()
-p.add_volume(voi, opacity=[0, 0.75, 0, 0.75, 1.0], opacity_unit_distance=2000)
+p.add_volume(voi, cmap="magma", opacity=opacity,
+             opacity_unit_distance=2000)
 p.camera_position = [(531554.5542909054, 3944331.800171338, 26563.04809259223),
  (599088.1433822059, 3982089.287834022, -11965.14728669936),
  (0.3738545892415734, 0.244312810377319, 0.8947312427698892)]

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -3568,7 +3568,7 @@ class UniformGridFilters(DataSetFilters):
         return _get_output(alg)
 
 
-    def extract_subset(dataset, voi):
+    def extract_subset(dataset, voi, rate=(1, 1, 1), boundary=False):
         """Select piece (e.g., volume of interest).
 
         To use this filter set the VOI ivar which are i-j-k min/max indices
@@ -3576,14 +3576,33 @@ class UniformGridFilters(DataSetFilters):
         0-offset.) You can also specify a sampling rate to subsample the
         data.
 
+        Typical applications of this filter are to extract a slice from a
+        volume for image processing, subsampling large volumes to reduce data
+        size, or extracting regions of a volume with interesting data.
+
         Parameters
         ----------
         voi : tuple(int)
-            Length 6 tuple of integers specifying the volume of interest in
-            i-j-k min/max indices.
+            Length 6 iterable of ints: ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+            These bounds specify the volume of interest in i-j-k min/max
+            indices.
+
+        rate : tuple(int)
+            Length 3 iterable of ints: ``(xrate, yrate, zrate)``.
+            Default: ``(1, 1, 1)``
+
+        boundary : bool
+            Control whether to enforce that the "boundary" of the grid is
+            output in the subsampling process. (This only has effect
+            when the rate in any direction is not equal to 1). When
+            this is on, the subsampling will always include the boundary of
+            the grid even though the sample rate is not an even multiple of
+            the grid dimensions. (By default this is off.)
         """
         alg = vtk.vtkExtractVOI()
         alg.SetVOI(voi)
         alg.SetInputDataObject(dataset)
+        alg.SetSampleRate(rate)
+        alg.SetIncludeBoundary(boundary)
         alg.Update()
         return _get_output(alg)

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1623,7 +1623,7 @@ class DataSetFilters(object):
             resolution = int(dataset.n_cells)
         # Make a line and sample the dataset
         line = pyvista.Line(pointa, pointb, resolution=resolution)
-        
+
         sampled_line = line.sample(dataset)
         return sampled_line
 
@@ -3564,5 +3564,26 @@ class UniformGridFilters(DataSetFilters):
             alg.SetStandardDeviations(std_dev)
         else:
             alg.SetStandardDeviations(std_dev, std_dev, std_dev)
+        alg.Update()
+        return _get_output(alg)
+
+
+    def extract_subset(dataset, voi):
+        """Select piece (e.g., volume of interest).
+
+        To use this filter set the VOI ivar which are i-j-k min/max indices
+        that specify a rectangular region in the data. (Note that these are
+        0-offset.) You can also specify a sampling rate to subsample the
+        data.
+
+        Parameters
+        ----------
+        voi : tuple(int)
+            Length 6 tuple of integers specifying the volume of interest in
+            i-j-k min/max indices.
+        """
+        alg = vtk.vtkExtractVOI()
+        alg.SetVOI(voi)
+        alg.SetInputDataObject(dataset)
         alg.Update()
         return _get_output(alg)

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -582,3 +582,10 @@ def download_crater_imagery():
 def download_dolfin():
     """Download crater texture."""
     return _download_and_read('dolfin_fine.xml', file_format="dolfin-xml")
+
+
+def download_damavand_volcano():
+    """Download damavand volcano model."""
+    volume = _download_and_read("damavand-volcano.vtk")
+    volume.rename_array("None", "data")
+    return volume

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1898,8 +1898,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
         ###############
 
         scalars = scalars.astype(np.float)
-        idxs0 = scalars < clim[0]
-        idxs1 = scalars > clim[1]
+        with np.errstate(invalid='ignore'):
+            idxs0 = scalars < clim[0]
+            idxs1 = scalars > clim[1]
         scalars[idxs0] = clim[0]
         scalars[idxs1] = clim[1]
         scalars = ((scalars - np.nanmin(scalars)) / (np.nanmax(scalars) - np.nanmin(scalars))) * 255

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -614,3 +614,10 @@ def test_compute_gradients():
     assert 'gradient' in grad.array_names
     assert np.shape(grad['gradient'])[0] == mesh.n_points
     assert np.shape(grad['gradient'])[1] == 3
+
+
+
+def test_extract_subset():
+    volume = examples.load_uniform()
+    voi = volume.extract_subset(0,3,1,4,5,7)
+    assert isinstance(voi, pyvista.UniformGrid)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -619,5 +619,5 @@ def test_compute_gradients():
 
 def test_extract_subset():
     volume = examples.load_uniform()
-    voi = volume.extract_subset(0,3,1,4,5,7)
+    voi = volume.extract_subset([0,3,1,4,5,7])
     assert isinstance(voi, pyvista.UniformGrid)


### PR DESCRIPTION
Adds an `extract_subset` filter to extract volumes of interest from image data/uniform grids while preserving the data type