### PR TITLE
🚧 Shallow copy mesh when adding to scene

### DIFF
--- a/examples/02-plot/depth-peeling.py
+++ b/examples/02-plot/depth-peeling.py
@@ -38,7 +38,7 @@ p.add_text("Depth Peeling")
 
 p.subplot(0,1)
 p.add_text("Standard")
-p.add_mesh(spheres.copy(), **dargs)
+p.add_mesh(spheres, **dargs)
 
 p.link_views()
 p.camera_position = [(11.695377287877744, 4.697473022306675, -4.313491106516902),
@@ -60,7 +60,7 @@ p.add_text("Depth Peeling")
 
 p.subplot(0,1)
 p.add_text("Standard")
-p.add_mesh(mesh.copy(), opacity=0.5, cmap=cmap)
+p.add_mesh(mesh, opacity=0.5, cmap=cmap)
 
 p.link_views()
 p.camera_position = [(418.29917315895693, 658.9752095516966, 53.784143976243364),

--- a/examples/02-plot/multi-window.py
+++ b/examples/02-plot/multi-window.py
@@ -90,3 +90,32 @@ plotter.add_mesh(pv.Cone(), show_edges=True)
 
 # Display the window
 plotter.show()
+
+
+###############################################################################
+# Note that you can easily plot the same mesh in multiple sublplots displaying
+# different scalar values on that mesh.
+
+# Load a mesh with three scalar arrays
+mesh = examples.download_blood_vessels().ctp()
+contours = mesh.contour(scalars="shearstress")
+
+
+plotter = pv.Plotter(shape=(1,3), window_size=[2048*3, 1536])
+
+plotter.add_mesh(contours, scalars="density")
+
+plotter.subplot(0,1)
+plotter.add_mesh(contours, scalars="velocity")
+
+plotter.subplot(0,2)
+plotter.add_mesh(contours, scalars="shearstress")
+
+plotter.link_views()
+plotter.camera_position = [
+    (104.95248078038908, -157.07391180168247, -16.534092166373355),
+    (87.72735313495542, 82.94721195427934, 110.3163662948969),
+    (-0.6644780195578007, -0.38590290740723265, 0.6399593015022035)
+  ]
+
+plotter.show()

--- a/examples/02-plot/opacity.py
+++ b/examples/02-plot/opacity.py
@@ -137,7 +137,7 @@ p = pv.Plotter(shape=(1,2))
 
 p.subplot(0,0)
 p.add_text('Opacity by Array')
-p.add_mesh(contours.copy(), scalars='Temperature',
+p.add_mesh(contours, scalars='Temperature',
            opacity='Temperature_var',
            use_transparency=True,
            cmap='bwr')

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1325,7 +1325,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
                     scalars = None
 
         # set main values
-        self.mesh = mesh
+        self.mesh = type(mesh)()
+        self.mesh.shallow_copy(mesh)
         self.mapper = make_mapper(vtk.vtkDataSetMapper)
         self.mapper.SetInputData(self.mesh)
         self.mapper.GetLookupTable().SetNumberOfTableValues(n_colors)


### PR DESCRIPTION
Resolve #542, pinging @MatthewFlamm

These changes make it so that meshes are shallow copied when added to the scene. This means that when we add a mesh to a scene, a new "container" mesh is created that points to the data values in the original mesh so that the same mesh can be added to other renderers with a different active scalar array. This is possible because the "container" mesh will manage the active scalars, but the actual data lives in the original mesh (the beauty of a shallow copy).

For example, maybe you have a mesh with a few different scalar arrays and you want to plot them all next to each other like:

![download](https://user-images.githubusercontent.com/22067021/73335488-c8053480-422c-11ea-9b30-cc09a973a57f.png)


Previously (as outlined in https://github.com/pyvista/pyvista/issues/542#issuecomment-574871438), the user would have to copy the mesh before adding the mesh to the scene after it had been added in a previous renderer as the active scalars attribute would be overwritten. Now, it works like a user might expect:

```py
import pyvista as pv
from pyvista import examples
import numpy as np

mesh = examples.download_blood_vessels().ctp()
contours = mesh.contour(scalars="shearstress")


plotter = pv.Plotter(shape=(1,3), window_size=[2048*3, 1536])

plotter.add_mesh(contours, scalars="density")

plotter.subplot(0,1)
plotter.add_mesh(contours, scalars="velocity")

plotter.subplot(0,2)
plotter.add_mesh(contours, scalars="shearstress")

plotter.link_views()
plotter.camera_position = [
    (104.95248078038908, -157.07391180168247, -16.534092166373355),
    (87.72735313495542, 82.94721195427934, 110.3163662948969),
    (-0.6644780195578007, -0.38590290740723265, 0.6399593015022035)
  ]

plotter.show()
```

-----

And to prove that no issues arise from these changes when wanting to dynamically update a mesh that has already been added to a renderer, check out this example:

*note that we add the same mesh to two renderers and display different scalars but are still able to update the coordinates of the mesh after it has been added (shallow copied).*

```py
import pyvista as pv
from pyvista import examples
import numpy as np

w = pv.Wavelet().cast_to_structured_grid()
w["x"] = w.points[:,0]

w.plot()
```

Original mesh:

![download](https://user-images.githubusercontent.com/22067021/73336069-16ff9980-422e-11ea-8f11-ebe593650b31.png)


```py
p = pv.Plotter(shape=(1,2))

# Add same mesh to scene twice with differrent active scalars
p.add_mesh(w, scalars="RTData")
p.subplot(0,1)
p.add_mesh(w, scalars="x")
# Update the mesh after it has been added to the scene
w.points[:,0] *= 2
p.show_grid()
p.show()
```

![download](https://user-images.githubusercontent.com/22067021/73335642-3813ba80-422d-11ea-91ef-c32f34829708.png)
