### PR TITLE
Update visible cell selection

### DIFF
--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -170,9 +170,9 @@ class PickingHelper(object):
                       "not work properly with non-NVIDIA GPUs. Please "\
                       "consider triangulating your mesh:\n"\
                       "\t`.extract_geometry().triangulate()`"
-            if (not isinstance(mesh, pyvista.PolyData) or
-                    mesh.faces.size % 4 or
-                    not np.all(mesh.faces.reshape(-1, 4)[:,0] == 3)):
+            if mesh is None:
+                mesh = self.mesh
+            if not isinstance(mesh, pyvista.PolyData) or not mesh.is_all_triangles():
                 logging.warning(message)
             area_picker.AddObserver(vtk.vtkCommand.EndPickEvent, visible_pick_call_back)
 

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -94,7 +94,7 @@ class PickingHelper(object):
         """
         if hasattr(self, 'notebook') and self.notebook:
             raise AssertionError('Cell picking not available in notebook plotting')
-        if mesh is None and through:
+        if mesh is None:
             if not hasattr(self, 'mesh'):
                 raise Exception('Input a mesh into the Plotter class first or '
                                 'or set it in this function')
@@ -105,8 +105,12 @@ class PickingHelper(object):
         def end_pick_helper(picker, event_id):
             if show:
                 # Use try in case selection is empty
+                if isinstance(self.picked_cells, pyvista.MultiBlock):
+                    picked = self.picked_cells.combine()
+                else:
+                    picked = self.picked_cells
                 try:
-                    self.add_mesh(self.picked_cells, name='_cell_picking_selection',
+                    self.add_mesh(picked, name='_cell_picking_selection',
                                   style=style, color=color,
                                   line_width=line_width, pickable=False,
                                   reset_camera=False, **kwargs)
@@ -170,8 +174,6 @@ class PickingHelper(object):
                       "not work properly with non-NVIDIA GPUs. Please "\
                       "consider triangulating your mesh:\n"\
                       "\t`.extract_geometry().triangulate()`"
-            if mesh is None:
-                mesh = self.mesh
             if not isinstance(mesh, pyvista.PolyData) or not mesh.is_all_triangles():
                 logging.warning(message)
             area_picker.AddObserver(vtk.vtkCommand.EndPickEvent, visible_pick_call_back)


### PR DESCRIPTION
this provides some updates to fix visible cell selection when multiple meshes are in a scene.

Relevant to #560 

### Example

```py
import pyvista as pv

centers = [(0, 0, 0), (1, 0, 0), (-1, 0, 0),
           (0, 1, 0), (0, -1, 0)]
radii = [1, 0.5, 0.5, 0.5, 0.5]

spheres = pv.MultiBlock()
for i, c in enumerate(centers):
    spheres.append(pv.Sphere(center=c, radius=radii[i]))

p = pv.Plotter(notebook=False)
p.add_mesh(spheres)
p.enable_cell_picking(through=False)
p.show()
```


Previous behavior:


![2020-01-29 01 52 07](https://user-images.githubusercontent.com/22067021/73341513-05bc8a00-423a-11ea-936c-92edc6a50d61.gif)


New behavior:

![2020-01-29 01 50 59](https://user-images.githubusercontent.com/22067021/73341517-0b19d480-423a-11ea-87a7-cc6fa16d0cb6.gif)
