### PR TITLE
🚧 [BUG] clipping planes issues when linking views

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2090,13 +2090,31 @@ class BasePlotter(PickingHelper, WidgetHelper):
             views cameras.
 
         """
+        bounds = [np.inf,-np.inf, np.inf,-np.inf, np.inf,-np.inf]
+
+        def update_bounds(ax, nb, bounds):
+            """Update bounds while keeping track (internal helper)."""
+            if nb[2*ax] < bounds[2*ax]:
+                bounds[2*ax] = nb[2*ax]
+            if nb[2*ax+1] > bounds[2*ax+1]:
+                bounds[2*ax+1] = nb[2*ax+1]
+            return bounds
+
         if isinstance(views, int):
             for renderer in self.renderers:
                 renderer.camera = self.renderers[views].camera
+                bnds = renderer.bounds
+                for a in range(3):
+                    bounds = update_bounds(a, bnds, bounds)
+            self.renderers[views].ResetCameraClippingRange(bounds)
         elif isinstance(views, collections.Iterable):
             for view_index in views:
                 self.renderers[view_index].camera = \
                     self.renderers[views[0]].camera
+                bnds = self.renderers[view_index].bounds
+                for a in range(3):
+                    bounds = update_bounds(a, bnds, bounds)
+            self.renderers[views[0]].ResetCameraClippingRange(bounds)
         else:
             raise TypeError('Expected type is int, list or tuple:'
                             '{} is given'.format(type(views)))


### PR DESCRIPTION
When linking views in subplots that have varying spatial extents, the camera clipping planes get all wacky like the following depending on which renderer is being interacted with.

This is an attempt to fix this issue, though it doesn't work.


![2020-01-29 14 17 24](https://user-images.githubusercontent.com/22067021/73398138-23bdd500-42a2-11ea-9430-7bd44160b6d2.gif)
