### PR TITLE
Fix issue where plotter appears in sphinx-gallery when making a report

### DIFF
--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -116,6 +116,8 @@ def get_gpu_info():
     plotter.show(auto_close=False)
     gpu_info = plotter.ren_win.ReportCapabilities()
     plotter.close()
+    # Remove from list of Plotters
+    pyvista.plotting._ALL_PLOTTERS.pop(plotter._id_name)
     return gpu_info
 
 


### PR DESCRIPTION
When putting a `Report` in an SG notebook, the GPU info routine would create a plotter that would be shown in the SG output. Not anymore