### PR TITLE
Enable Qt plotting tests on Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,5 @@ jobs:
       python -c "import pyvista; print(pyvista.Report())"
     displayName: 'Install PyVista'
   - script: |
-      del /Q tests\\test_qt_plotting.py
       python -m pytest --cov -v .
     displayName: 'Run Tests'


### PR DESCRIPTION
This PR enables testing of qt plotting on Azure. Let's make them all green.