### PR TITLE
Fix axes widget warning

### DIFF
--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -449,7 +449,7 @@ class Renderer(vtkRenderer):
 
     def hide_axes(self):
         """Hide the axes orientation widget."""
-        if hasattr(self, 'axes_widget'):
+        if hasattr(self, 'axes_widget') and self.axes_widget.GetEnabled():
             self.axes_widget.EnabledOff()
 
 


### PR DESCRIPTION
The new close method of the `Renderer` from #565 is throwing a warning when offscreen plotting. This fixes that

```
ERROR:root:The interactor must be set prior to enabling/disabling widget
```