### PR TITLE
Improve documentation of remove_actor

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2060,8 +2060,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         Parameters
         ----------
-        actor : vtk.vtkActor
-            Actor that has previously added to the Renderer.
+        actor : str, vtk.vtkActor, list or tuple
+            If the type is ``str``, removes the previously added actor with
+            the given name. If the type is ``vtk.vtkActor``, removes the actor
+            if it's previously added to the Renderer. If ``list`` or ``tuple``,
+            removes iteratively each actor.
 
         reset_camera : bool, optional
             Resets camera so all actors can be seen.

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2055,27 +2055,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self._scalar_bar_widgets = {}
         self.mesh = None
 
+    @wraps(Renderer.remove_actor)
     def remove_actor(self, actor, reset_camera=False):
-        """Remove an actor from the Plotter.
-
-        Parameters
-        ----------
-        actor : str, vtk.vtkActor, list or tuple
-            If the type is ``str``, removes the previously added actor with
-            the given name. If the type is ``vtk.vtkActor``, removes the actor
-            if it's previously added to the Renderer. If ``list`` or ``tuple``,
-            removes iteratively each actor.
-
-        reset_camera : bool, optional
-            Resets camera so all actors can be seen.
-
-        Returns
-        -------
-        success : bool
-            True when actor removed.  False when actor has not been
-            removed.
-
-        """
+        """Wrap ``Renderer.remove_actor``."""
         for renderer in self.renderers:
             renderer.remove_actor(actor, reset_camera)
         return True

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -936,8 +936,11 @@ class Renderer(vtkRenderer):
 
         Parameters
         ----------
-        actor : vtk.vtkActor
-            Actor that has previously added to the Renderer.
+        actor : str, vtk.vtkActor, list or tuple
+            If the type is ``str``, removes the previously added actor with
+            the given name. If the type is ``vtk.vtkActor``, removes the actor
+            if it's previously added to the Renderer. If ``list`` or ``tuple``,
+            removes iteratively each actor.
 
         reset_camera : bool, optional
             Resets camera so all actors can be seen.


### PR DESCRIPTION
In the discussion about `remove_actor` in https://github.com/pyvista/pyvista-support/issues/121#issuecomment-582866412, I realized the docstring of this function does not mention the support of  `str` type or iterable types which are very convenient! The goal of this PR is to make it clearer.