### PR TITLE
FIX: Set the _first_time variable to enable render on BackgroundPlotter

### DIFF
--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -688,6 +688,7 @@ class BackgroundPlotter(QtInteractor):
         self.render_timer.timeout.connect(self.render)
         self.app_window.signal_close.connect(self.render_timer.stop)
         self.render_timer.start(twait)
+        self._first_time = False
 
     def _close_callback(self):
         """Make sure a screenhsot is acquired before closing."""


### PR DESCRIPTION
This PR fixes the call to `BasePlotter.render()`. Because `_first_time` is not set in the `BackgroundPlotter`, `render()` was never called causing lags in widgets (waiting for `ModifiedEvent` to call `update()` instead)