### PR TITLE
Depth peeling off after VTK 8.2

### DIFF
--- a/examples/02-plot/depth-peeling.py
+++ b/examples/02-plot/depth-peeling.py
@@ -97,4 +97,4 @@ p.show()
 
 ###############################################################################
 # Re-enable depth peeling
-pv.rcParams["depth_peeling"]["enabled"] = True
+pv.rcParams["depth_peeling"]["enabled"] = pv.DEFAULT_THEME["depth_peeling"]["enabled"]

--- a/examples/02-plot/depth-peeling.py
+++ b/examples/02-plot/depth-peeling.py
@@ -3,7 +3,8 @@ Depth Peeling
 ~~~~~~~~~~~~~
 
 Depth peeling is a technique to correctly render translucent geometry.
-This is enabled by default in :any:`pyvista.rcParams`.
+This is enabled by default in :any:`pyvista.rcParams` if your VTK version is
+less than 8.2.
 
 For this example, we will showcase the difference that depth peeling provides
 as the justification for why we have enabled this by default.

--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -1,6 +1,7 @@
 """Module managing different plotting theme parameters."""
 
 import os
+import scooby
 import vtk
 
 from .colors import string_to_rgb, PARAVIEW_BACKGROUND
@@ -67,7 +68,7 @@ rcParams = {
     'depth_peeling': {
         'number_of_peels': 4,
         'occlusion_ratio': 0.0,
-        'enabled': True,
+        'enabled': False if scooby.meets_version(vtk.VTK_VERSION, '8.2.0') else True,
     },
 }
 


### PR DESCRIPTION
There's no real advantage to having depth peeling on by default if VTK is 8.2 or later (in my experience) and the depth peeling can be costly, so this turns it on by default only if VTK is less than 8.2