### PR TITLE
Add Gitter badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,13 @@ PyVista
 .. |MIT| image:: https://img.shields.io/badge/License-MIT-yellow.svg
    :target: https://opensource.org/licenses/MIT
 
+.. |slack| image:: https://img.shields.io/badge/Slack-pyvista-green.svg?logo=slack
+   :target: http://slack.pyvista.org
+
+.. |gitter| image:: https://img.shields.io/gitter/room/pyvista/community?color=darkviolet
+   :target: https://gitter.im/pyvista/community
+
+
 
 +----------------------+------------------------+
 | Deployment           | |pypi| |conda|         |
@@ -41,6 +48,8 @@ PyVista
 | Citation             | |joss| |zenodo|        |
 +----------------------+------------------------+
 | License              | |MIT|                  |
++----------------------+------------------------+
+| Community            | |slack| |gitter|       |
 +----------------------+------------------------+
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,12 @@
 .. |MIT| image:: https://img.shields.io/badge/License-MIT-yellow.svg
    :target: https://opensource.org/licenses/MIT
 
+.. |slack| image:: https://img.shields.io/badge/Slack-PyVista-green.svg?logo=slack
+   :target: http://slack.pyvista.org
+
+.. |gitter| image:: https://img.shields.io/gitter/room/pyvista/community?color=darkviolet
+   :target: https://gitter.im/pyvista/community
+
 
 +----------------------+------------------------+
 | Deployment           | |pypi| |conda|         |
@@ -52,6 +58,8 @@
 | Citation             | |joss| |zenodo|        |
 +----------------------+------------------------+
 | License              | |MIT|                  |
++----------------------+------------------------+
+| Community            | |slack| |gitter|       |
 +----------------------+------------------------+
 
 


### PR DESCRIPTION
Add the Gitter badge because folks asked for a Gitter: [![image](https://img.shields.io/gitter/room/pyvista/community?color=darkviolet)](https://gitter.im/pyvista/community)

I still have a very strong preference for Slack and will be most active on Slack. Hopefully having a separate Gitter chat room doesn't fragment the community presence online.

