### PR TITLE
ENH: Expose tip_resolution in pyvista.Arrow

### DIFF
--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -178,7 +178,8 @@ def CylinderStructured(radius=0.5, height=1.0,
 
 
 def Arrow(start=(0.,0.,0.), direction=(1.,0.,0.), tip_length=0.25,
-          tip_radius=0.1, shaft_radius=0.05, shaft_resolution=20):
+          tip_radius=0.1, tip_resolution=20, shaft_radius=0.05,
+          shaft_resolution=20):
     """Create a vtk Arrow.
 
     Parameters
@@ -195,11 +196,14 @@ def Arrow(start=(0.,0.,0.), direction=(1.,0.,0.), tip_length=0.25,
     tip_radius : float, optional
         Radius of the tip.
 
+    tip_resolution : int, optional
+        Number of faces around the tip.
+
     shaft_radius : float, optional
         Radius of the shaft.
 
     shaft_resolution : int, optional
-        Number of faces around the shaft
+        Number of faces around the shaft.
 
     Return
     ------
@@ -211,6 +215,7 @@ def Arrow(start=(0.,0.,0.), direction=(1.,0.,0.), tip_length=0.25,
     arrow = vtk.vtkArrowSource()
     arrow.SetTipLength(tip_length)
     arrow.SetTipRadius(tip_radius)
+    arrow.SetTipResolution(tip_resolution)
     arrow.SetShaftRadius(shaft_radius)
     arrow.SetShaftResolution(shaft_resolution)
     arrow.Update()


### PR DESCRIPTION
### Overview

The API of `pyvista.Arrow` was missing `tip_resolution`. Exposing this parameter is straightforward.

Resolves #623 

### Details
 
The change exposes the tip resolution setting of `vtkArrowSource` objects. Short example code demonstrating its use:

```py
import pyvista as pv

plotter = pv.Plotter(shape=(1, 3))
for isub,resparams in enumerate([{}, {'shaft_resolution': 50}, {'tip_resolution': 50}]):
    plotter.subplot(0, isub)
    arrow = pv.Arrow(**resparams)
    plotter.add_mesh(arrow, show_edges=True)

plotter.show()
```

![mcve_screenshot_after](https://user-images.githubusercontent.com/17914410/74977623-58e5bf00-542b-11ea-89a8-2c38ec1cc6f4.png)

The first subplot is the default call to `Arrow()` which should be the same as the original default, the middle one changes the already existing `shaft_resolution` setting, and the third subplot demonstrates the new feature.

I chose a default resolution of `20` for the parameter, because that seemed like the current behaviour of `pv.Arrow`. I also snuck in a minor change in the docstring to make most of the parameter descriptions end in a fullstop.

I got four errors locally in pytest (3 in test_meshio and 1 in test_file_format) and an error during doctests, but none of them seem related to my change.