### PR TITLE
allow textures with alpha-channel for opacity mapping

### DIFF
--- a/examples/02-plot/texture.py
+++ b/examples/02-plot/texture.py
@@ -95,6 +95,44 @@ tex = pv.numpy_to_texture(image)
 # Render it!
 curvsurf.plot(texture=tex)
 
+###############################################################################
+# Textures with transparency mapping
+# ++++++++++++++++++++++++
+#
+# Textures can also specify per-pixel opacity values. The image must 
+# contain a 4th channel specifiying the opacity value from 0 [transparent] to
+# 255 [fully visible]. To enable this feature just pass the opacity array as the
+# 4th channel of the image as a 3 dimensional matrix with shape [nrows, ncols, 4]
+# :func:`pyvista.numpy_to_texture`.
+
+from matplotlib.colors import ListedColormap
+
+# create an image using numpy,
+xx, yy = np.meshgrid(np.linspace(-200, 200, 20), np.linspace(-200, 200, 20))
+A, b = 500, 100
+zz = A * np.exp(-0.5 * ((xx / b) ** 2.0 + (yy / b) ** 2.0))
+
+# Creating a custom RGB image
+cmap = get_cmap("nipy_spectral")
+
+# alter the colormap to support a linear transparency
+# see https://stackoverflow.com/questions/37327308/add-alpha-to-an-existing-matplotlib-colormap
+alpha_cmap = cmap(np.arange(cmap.N))
+alpha_cmap[:,-1] = np.linspace(0, 1, cmap.N)
+# Create the new colormap
+alpha_cmap = ListedColormap(alpha_cmap)
+
+norm = lambda x: (x - np.nanmin(x)) / (np.nanmax(x) - np.nanmin(x))
+hue = norm(zz.ravel())
+colors = (alpha_cmap(hue) * 255.0).astype(np.uint8)
+image = colors.reshape((xx.shape[0], xx.shape[1], 4), order="F")
+
+# Convert 3D numpy array to texture
+tex = pv.numpy_to_texture(image)
+
+# Render it!
+curvsurf.plot(texture=tex)
+
 
 ###############################################################################
 # Repeating Textures

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -456,10 +456,14 @@ class Texture(vtk.vtkTexture):
 
 
     def _from_array(self, image):
-        if image.ndim != 3 or image.shape[2] != 3:
-            raise AssertionError('Input image must be nn by nm by RGB')
+        if image.ndim != 3:
+            raise AssertionError('Input image must be nn by nm by RGB[A]')
+
+        if image.shape[2] != 3 and image.shape[2] != 4:
+            raise AssertionError('Third dimension of the array must be of size 3 (RGB) or 4 (RGBA)')
+
         grid = pyvista.UniformGrid((image.shape[1], image.shape[0], 1))
-        grid.point_arrays['Image'] = np.flip(image.swapaxes(0,1), axis=1).reshape((-1, 3), order='F')
+        grid.point_arrays['Image'] = np.flip(image.swapaxes(0, 1), axis=1).reshape((-1, image.shape[2]), order='F')
         grid.set_active_scalars('Image')
         return self._from_image_data(grid)
 

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -73,7 +73,7 @@ class Table(vtk.vtkTable, DataObject):
     def _from_dict(self, array_dict):
         for array in array_dict.values():
             if not isinstance(array, (np.ndarray)) and array.ndim < 3:
-                raise RuntimeError('Dictionaty must contain only NumPy arrays with maximum of 2D.')
+                raise RuntimeError('Dictionary must contain only NumPy arrays with maximum of 2D.')
         for name, array in array_dict.items():
             self.row_arrays[name] = array
         return
@@ -432,6 +432,7 @@ class Texture(vtk.vtkTexture):
         """Initialize the texture."""
         assert_empty_kwargs(**kwargs)
 
+
         if len(args) == 1:
             if isinstance(args[0], vtk.vtkTexture):
                 self._from_texture(args[0])
@@ -456,16 +457,24 @@ class Texture(vtk.vtkTexture):
 
 
     def _from_array(self, image):
-        if image.ndim != 3:
+        if image.ndim not in [2,3]: # we support 2 [single scalars image] or 3 [e.g. rgb or rgba] dims
             raise AssertionError('Input image must be nn by nm by RGB[A]')
 
-        if image.shape[2] != 3 and image.shape[2] != 4:
-            raise AssertionError('Third dimension of the array must be of size 3 (RGB) or 4 (RGBA)')
+        if image.ndim == 3:
+            if image.shape[2] != 3 and image.shape[2] != 4:
+                raise AssertionError('Third dimension of the array must be of size 3 (RGB) or 4 (RGBA)')
+
+            n_components = image.shape[2]
+
+        elif image.ndim == 2:
+            n_components = 1
 
         grid = pyvista.UniformGrid((image.shape[1], image.shape[0], 1))
-        grid.point_arrays['Image'] = np.flip(image.swapaxes(0, 1), axis=1).reshape((-1, image.shape[2]), order='F')
+        grid.point_arrays['Image'] = np.flip(image.swapaxes(0, 1), axis=1).reshape((-1, n_components), order='F')
         grid.set_active_scalars('Image')
+
         return self._from_image_data(grid)
+
 
 
     def flip(self, axis):
@@ -486,7 +495,13 @@ class Texture(vtk.vtkTexture):
     def to_array(self):
         """Return the texture as an array."""
         image = self.to_image()
-        shape = (image.dimensions[0], image.dimensions[1], 3)
+        n_comps = image.active_scalars.shape[0] / image.dimensions[0] / image.dimensions[1]
+
+        if n_comps == 1:
+            shape = (image.dimensions[0], image.dimensions[1])
+        else:
+            shape = (image.dimensions[0], image.dimensions[1], n_comps)
+
         return np.flip(image.active_scalars.reshape(shape, order='F'), axis=1).swapaxes(1,0)
 
 


### PR DESCRIPTION
### Overview
modify the Texture class in in obejcts.py  to allow transparent-mapping of textures


### Details
input array for Texture was limited to RGB, but vtk also support RGBA imagery, this pull request add the possibility of using RGBA data for texture. Not sure other changes should be made in other portions of the code. Please review this request.
