### PR TITLE
Remove Unnecessary Rendering on Exit/Close/Clear

### DIFF
--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -898,7 +898,7 @@ class Renderer(vtkRenderer):
         if self._actors:
             for actor in list(self._actors):
                 try:
-                    self.remove_actor(actor, reset_camera=False)
+                    self.remove_actor(actor, reset_camera=False, render=False)
                 except KeyError:
                     pass
 
@@ -951,7 +951,7 @@ class Renderer(vtkRenderer):
         self.Modified()
 
 
-    def remove_actor(self, actor, reset_camera=False):
+    def remove_actor(self, actor, reset_camera=False, render=True):
         """Remove an actor from the Renderer.
 
         Parameters
@@ -964,6 +964,10 @@ class Renderer(vtkRenderer):
 
         reset_camera : bool, optional
             Resets camera so all actors can be seen.
+
+        render : bool, optional
+            Render upon actor removal.  Set this to ``False`` to stop
+            the render window from rendering when an actor is removed.
 
         Return
         ------
@@ -1011,11 +1015,11 @@ class Renderer(vtkRenderer):
             self.reset_camera()
         elif not self.camera_set and reset_camera is None:
             self.reset_camera()
-        else:
+        elif render:
             self.parent.render()
+
         self.Modified()
         return True
-
 
     def set_scale(self, xscale=None, yscale=None, zscale=None, reset_camera=True):
         """Scale all the datasets in the scene.


### PR DESCRIPTION
### Remove Unnecessary Rendering on Exit/Close/Clear

This is a redo of #637, as it included changes from #619.

This issue has bothered me for a while.  Upon close, all the actors of each renderer are removed.  The problem is, upon removal, we trigger a `render` and the render window refreshed with a render.  This isn't an issue when there are only a handful of actors, but when there are hundreds, there is a significant delay when closing.  This gif was taken right after pressing "q":

![closing](https://user-images.githubusercontent.com/11981631/76280266-86d35c00-6291-11ea-9a7d-d84013b4f99b.gif)

This PR adds the `render=` keyword argument that is defaulted to True when an actor is removed so that the `Renderer` class retains its current behavior except when `clear` is called, whereby actors are removed without triggering a render.

