### PR TITLE
track all observers on iren.observers

### DIFF
--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -442,7 +442,8 @@ class QtInteractor(QVTKRenderWindowInteractorAdapter, BasePlotter):
 
             self.iren.Initialize()
 
-            self.iren.AddObserver("KeyPressEvent", self.key_press_event)
+            self._observers = {}    # Map of events to observers of self.iren
+            self._add_observer("KeyPressEvent", self.key_press_event)
 
         # Make the render timer but only activate if using auto update
         self.render_timer = QTimer(parent=parent)


### PR DESCRIPTION
This is a followup to https://github.com/pyvista/pyvista/pull/619#issuecomment-589274665:

> Instead of listing potential observers to close, it adds utility functions to add and remove observers and in the process tracks them, thus can be closed in a loop. Or should I just push to this branch and if anyone disagrees they can revert/adjust?