### PR TITLE
Use parent method to close BackgroundPlotter

### DIFF
--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -566,7 +566,10 @@ class QtInteractor(QVTKRenderWindowInteractorAdapter, BasePlotter):
 
     def close(self):
         """Quit application."""
-        self.render_timer.stop()
+        if self._closed:
+            return
+        if hasattr(self, "render_timer"):
+            self.render_timer.stop()
         BasePlotter.close(self)
         QVTKRenderWindowInteractorAdapter.close(self)
 
@@ -757,12 +760,11 @@ class BackgroundPlotter(QtInteractor):
         close the plotter through `signal_close`.
 
         """
-        self.app_window.close()
+        if not self._closed:
+            self.app_window.close()
 
     def _close(self):
-        if hasattr(self, "render_timer"):
-            self.render_timer.stop()
-        BasePlotter.close(self)
+        super().close()
 
     def update_app_icon(self):
         """Update the app icon if the user is not trying to resize the window."""


### PR DESCRIPTION
This is a followup to https://github.com/pyvista/pyvista/pull/619#discussion_r381302407:

> I'd call super().close() here. BackgroundPlotter inherits QtInteractor, whose close method already calls BasePlotter.close(self) and stops the timer (without the check though).

I investigated the following (by @GuillaumeFavelier):

> The thing is QtInteractor.close() calls QVTKRenderWindowInteractorAdapter.close() which is already done by app_window.close() (because of Qt parent relationship)

QVTKRenderWindowInteractorAdapter's parent is is `.frame` (`QFrame`), not `.app_window`. I manually checked that QVTKRenderWindowInteractorAdapter's close method is called once only and added some checks for `_closed` to be extra sure that closing happens once only.