### PR TITLE
Fix automatic generation of spacing for 2d uniform grids

### DIFF
--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -463,8 +463,10 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
         y = np.unique(points[:,1])
         z = np.unique(points[:,2])
         nx, ny, nz = len(x), len(y), len(z)
+        # diff returns an empty array if the input is constant
+        dx, dy, dz = [np.diff(d) if len(np.diff(d)) > 0 else d for d in (x, y, z)]
         # TODO: this needs to be tested (unique might return a tuple)
-        dx, dy, dz = np.unique(np.diff(x)), np.unique(np.diff(y)), np.unique(np.diff(z))
+        dx, dy, dz = np.unique(dx), np.unique(dy), np.unique(dz)
         ox, oy, oz = np.min(x), np.min(y), np.min(z)
         # Build the vtk object
         self._from_specs((nx,ny,nz), (dx,dy,dz), (ox,oy,oz))

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -415,6 +415,15 @@ def test_save_uniform(extension, binary, tmpdir):
 
 def test_grid_points():
     """Test the points methods on UniformGrid and RectilinearGrid"""
+    # test creation of 2d grids
+    x_surf = y_surf = range(3)
+    z_surf = np.ones(3)
+    grid = pyvista.UniformGrid()
+    grid.points = np.array([x_surf, y_surf, z_surf]).transpose()
+    assert grid.n_points == 9
+    assert grid.n_cells == 4
+    del grid
+
     points = np.array([[0, 0, 0],
                        [1, 0, 0],
                        [1, 1, 0],


### PR DESCRIPTION
This PR fixes the issue encountered in https://github.com/pyvista/pyvista/issues/642 (especially https://github.com/pyvista/pyvista/issues/642#issuecomment-600646555) and adds a test for it.

It's now possible to create 2d uniform grids with for example:

```py
import numpy as np
import pyvista as pv

x_surf = y_surf = range(80)
z_surf = np.ones(80)

grid = pv.UniformGrid()
grid.points = np.array([x_surf, y_surf, z_surf]).transpose()
grid.plot(show_edges=True)
```