### PR TITLE
FIX: Logging error

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -799,7 +799,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 for func in callbacks:
                     func()
         except Exception as e:
-            log.error('Exception encountered for keypress "%s" % %s' (key, str(e)))
+            log.error('Exception encountered for keypress "%s": %s' % (key, e))
 
     def left_button_down(self, obj, event_type):
         """Register the event for a left button down click."""


### PR DESCRIPTION
On `master` I get:
```
/home/larsoner/python/pyvista/pyvista/plotting/plotting.py:802: SyntaxWarning: 'str' object is not callable; perhaps you missed a comma?
  log.error('Exception encountered for keypress "%s" % %s' (key, str(e)))
```
This should fix the missing `%`.