### PR TITLE
[patch] Fix VTK 8.2 compatibility

### DIFF
--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -4,7 +4,11 @@ import numpy as np
 from pyvista.utilities.helpers import convert_array, FieldAssociation
 from vtk.numpy_interface.dataset_adapter import VTKObjectWrapper, VTKArray
 from vtk.vtkCommonCore import vtkWeakReference
-from vtk.vtkCommonKitPython import vtkDataArray, vtkAbstractArray
+
+try:
+    from vtk.vtkCommonKitPython import vtkDataArray, vtkAbstractArray
+except (ModuleNotFoundError, ImportError):
+    from vtk.vtkCommonCore import vtkDataArray, vtkAbstractArray
 
 
 class pyvista_ndarray(VTKArray):


### PR DESCRIPTION
Urgently fix compatibility with VTK v8.2 introduced in #654 

Some parts of the numpy interface changed between 8.1 and 8.2 and these import changes handle it

