### PR TITLE
🚧 Add Object Name Attribute

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -134,7 +134,7 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
 
     def __init__(self, *args, **kwargs):
         """Initialize the polydata."""
-        super(PolyData, self).__init__()
+        super(PolyData, self).__init__(*args, **kwargs)
 
         deep = kwargs.pop('deep', False)
 
@@ -234,6 +234,9 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
         # sanity check
         if not np.any(self.points):
             raise AssertionError('Empty or invalid file')
+
+        if not self.name:
+            self.name = os.path.basename(filename)
 
     @property
     def verts(self):
@@ -790,6 +793,8 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
         reader.Update()
         grid = reader.GetOutput()
         self.shallow_copy(grid)
+        if not self.name:
+            self.name = os.path.basename(filename)
 
     def save(self, filename, binary=True):
         """Write an unstructured grid to disk.

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -811,7 +811,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 for func in callbacks:
                     func()
         except Exception as e:
-            log.error('Exception encountered for keypress "%s": %s' % (key, e))
+            log.error('Exception encountered for keypress "%s": %s', key, e)
 
     def left_button_down(self, obj, event_type):
         """Register the event for a left button down click."""

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -181,21 +181,22 @@ def read(filename, attrs=None, file_format=None):
         return read_meshio(filename, file_format)
 
     # From the extension, decide which reader to use
+    name = os.path.basename(filename)
     if attrs is not None:
         reader = get_reader(filename)
         return standard_reader_routine(reader, filename, attrs=attrs)
     elif ext in '.vti': # ImageData
-        return pyvista.UniformGrid(filename)
+        return pyvista.UniformGrid(filename, name=name)
     elif ext in '.vtr': # RectilinearGrid
-        return pyvista.RectilinearGrid(filename)
+        return pyvista.RectilinearGrid(filename, name=name)
     elif ext in '.vtu': # UnstructuredGrid
-        return pyvista.UnstructuredGrid(filename)
+        return pyvista.UnstructuredGrid(filename, name=name)
     elif ext in ['.ply', '.obj', '.stl']: # PolyData
-        return pyvista.PolyData(filename)
+        return pyvista.PolyData(filename, name=name)
     elif ext in '.vts': # StructuredGrid
-        return pyvista.StructuredGrid(filename)
+        return pyvista.StructuredGrid(filename, name=name)
     elif ext in ['.vtm', '.vtmb']:
-        return pyvista.MultiBlock(filename)
+        return pyvista.MultiBlock(filename, name=name)
     elif ext in ['.e', '.exo']:
         return read_exodus(filename)
     elif ext in ['.vtk']:

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -13,6 +13,7 @@ vtkDiskSource
 vtkRegularPolygonSource
 
 """
+
 import numpy as np
 import vtk
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,5 +1,3 @@
-import sys
-
 import numpy as np
 import pytest
 import vtk
@@ -9,8 +7,6 @@ import pyvista
 from pyvista import examples
 
 GRID = pyvista.UnstructuredGrid(examples.hexbeamfile)
-
-py2 = sys.version_info.major == 2
 
 
 def test_point_arrays():
@@ -342,14 +338,22 @@ def test_html_repr():
     repr_html = grid._repr_html_()
     assert repr_html is not None
 
+
+def test_name():
+    assert GRID.name == 'hexbeam.vtk'
+    grid = GRID.copy()
+    grid.name = 'changed'
+    assert grid.name == 'changed'
+
+
 def test_print_repr():
     """
     This just tests to make sure no errors are thrown on the text friendly
     representation method for Common datasets.
     """
     grid = GRID.copy()
-    repr = grid.head()
-    assert repr is not None
+    repr_ = grid.head()
+    assert repr_ is not None
 
 
 def test_texture():


### PR DESCRIPTION
### Object Name Attribute
This was created in response to [#115 pyvista-support](https://github.com/pyvista/pyvista-support/issues/151).

The `name` attribute is now available on most `pyvista` data objects.  For example:
```python
from pyvista import examples
dragon = examples.download_dragon()
print(dragon)
```
```
PolyData (0x7ff9a9a21050)
  Name      :	dragon.ply
  N Cells   :	871414
  N Points  :	437645
  X Bounds  :	-1.083e-01, 9.657e-02
  Y Bounds  :	5.273e-02, 1.972e-01
  Z Bounds  :	-5.041e-02, 4.121e-02
  N Arrays  :	0
```
Objects created from files will have their names based on the filename they were created from, whereas the stack is inspected for a function name if the instance was created from another instance or function.  For example:
```python
print(pyvista.Sphere())
```
```
PolyData (0x7ff9a9a211a0)
  Name      :	Sphere
  N Cells   :	1680
  N Points  :	842
  X Bounds  :	-4.993e-01, 4.993e-01
  Y Bounds  :	-4.965e-01, 4.965e-01
  Z Bounds  :	-5.000e-01, 5.000e-01
  N Arrays  :	1
```
And:
```python
print(pyvista.Sphere().copy())
```
```
PolyData (0x7ff9a9a64e50)
  Name      :	copy
  N Cells   :	1680
  N Points  :	842
  X Bounds  :	-4.993e-01, 4.993e-01
  Y Bounds  :	-4.965e-01, 4.965e-01
  Z Bounds  :	-5.000e-01, 5.000e-01
  N Arrays  :	1
```