### PR TITLE
BUGFIX: GPU issues with Report

### DIFF
--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -234,6 +234,8 @@ class Report(scooby.Report):
                 extra_meta = [(t[1], t[0]) for t in GPUInfo().get_info()]
             except:
                 extra_meta = ("GPU Details", "error")
+        else:
+            extra_meta = ("GPU Details", "None")
 
         scooby.Report.__init__(self, additional=additional, core=core,
                                optional=optional, ncol=ncol,

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -119,7 +119,9 @@ def test_voxelize():
 
 
 def test_report():
-    report = pyvista.Report()
+    report = pyvista.Report(gpu=True)
+    assert report is not None
+    report = pyvista.Report(gpu=False)
     assert report is not None
 
 


### PR DESCRIPTION
The `Report` had a bug when not wanting the GPU details included. This made debugging impossible if having OpenGL issues

