### PR TITLE
Fail CI step if any command fails in bash scripts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 variables:
   ALLOW_PLOTTING: true
+  SHELLOPTS: 'errexit:pipefail'
 
 trigger:
   branches:


### PR DESCRIPTION
In https://github.com/pyvista/pyvista/pull/660 I discovered that by default scripts in azure steps do not fail if any of the commands inside the script fails. While that's in principle just the bash default, I consider this harmful for CI: You really want to know if anything fails, and if there is a command that is know to fail and it is ok, you should use a proper `if` clause or prepend ` | :` to allow it specifically. As this applies to CI in general, not just adding conda tests, I am opening this separate PR.