### PR TITLE
Version bump 0.24.1

### DIFF
--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -1,6 +1,6 @@
 """Version info for pyvista."""
 # major, minor, patch
-version_info = 0, 24, 0
+version_info = 0, 24, 1
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
### Version Bump to 0.24.1

I figure since our @pyvista/developers group has gotten large and active, I'd put out a PR instead of just pinging everyone on slack that I'd like to push a release.  The main reasoning for this is due to #645, which turns out to be a deal breaker for using `pyvista` when `stderr` is unavailable for any reason.

This release will include the following commits to master:
- 8ea409ca master origin/master Change base class of pyvista_ndarray back to ndarray (#664)
- 127ec0a7 Fail CI step if any command fails in bash scripts (#666)
- faaf1b26 [doc] Improve installation instructions (#658)
- 582ad8b4 Speed up test_clip_surface (#661)
- bc8b9750 Additional geometry features (#449)
- 9b92ec54 Only volume render point data (#531)
- 75c000df Add PolyData verts setter/getter (#554)
- 2c93aced Add plotting floors (#423)
- 0499cc96 Fix import issues (#656)
- dcf24365 Add tqdm progress bar to filters (#608)
- 4d87fb35 Fix potential false negative in TestSetItem.test_setitem_should_change_value. (#655)
- fae1d500 Refactor pyvista_ndarray (#654)
- 7f78a8c1 Remove Cells or Faces (#653)
- bc41aaac Use Enum for FieldAssociation (#652)
- ea24bc54 fork/master Add basic API for background image (#594)
- bc80eeb4 FIX: Logging error (#648)
- dd163eb5 patched faulthandler when missing stdout (#645)
- ff02a2c6 Fix auto generation of spacing for 2d uniform grids (#643)
- aea0751a Use parent method to close BackgroundPlotter (#641)

Anyone who objects to this release, please let me know.  Otherwise, I need this release soon for the bugfix.