### PR TITLE
Do not build on no-ci branch name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,8 +4,8 @@ variables:
 
 trigger:
   branches:
-    include:
-    - '*'
+    # include:
+    # - '*'
     exclude:
     - '*no-ci*'
   tags:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,8 @@ trigger:
   branches:
     include:
     - '*'
+    exclude:
+    - no-ci*
   tags:
     include:
     - '*'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ trigger:
     - '*'
     exclude:
     - no-ci*
-    - refs/head/feature-no-ci/*
+    - refs/head/no-ci/*
   tags:
     include:
     - '*'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,8 +7,7 @@ trigger:
     include:
     - '*'
     exclude:
-    - no-ci*
-    - refs/head/no-ci/*
+    - *no-ci*
   tags:
     include:
     - '*'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
     include:
     - '*'
     exclude:
-    - *no-ci*
+    - '*no-ci*'
   tags:
     include:
     - '*'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,21 +2,16 @@ variables:
   ALLOW_PLOTTING: true
   SHELLOPTS: 'errexit:pipefail'
 
+
 trigger:
   branches:
-    exclude:
+    include:
     - '*'
-
-
-# trigger:
-#   branches:
-#     # include:
-#     - '*'
-#     exclude:
-#     - '*no-ci*'
-#   tags:
-#     include:
-#     - '*'
+    exclude:
+    - '*no-ci*'
+  tags:
+    include:
+    - '*'
 
 jobs:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,13 +4,19 @@ variables:
 
 trigger:
   branches:
-    # include:
-    # - '*'
     exclude:
-    - '*no-ci*'
-  tags:
-    include:
     - '*'
+
+
+# trigger:
+#   branches:
+#     # include:
+#     - '*'
+#     exclude:
+#     - '*no-ci*'
+#   tags:
+#     include:
+#     - '*'
 
 jobs:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,7 @@ trigger:
     - '*'
     exclude:
     - no-ci*
+    - refs/head/feature-no-ci/*
   tags:
     include:
     - '*'


### PR DESCRIPTION
## CI Change

This simple PR changes the pipeline to exclude CI builds on any branch that starts with "no-ci"
. 

This will help us avoid super long build times on branches that do not need it (for example, updating CONTRIBUTING).