### PR TITLE
Update CONTRIBUTING Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,9 @@ Please also take a look at our [Code of Conduct](https://github.com/pyvista/pyvi
 To submit new code to pyvista, first fork the (pyvista GitHub
 Repo)[https://github.com/pyvista/pyvista] and then clone the forked
 repository to your computer.  Then, create a new branch based on the
-branch naming convention in the next section in your local repository.
+[Branch Naming Conventions Section](#branch-naming-conventions) in
+your local repository.
+
 Next, add your new feature and commit it locally.  Be sure to commit
 often as it is often helpful to revert to past commits, especially if
 your change is complex.  Also, be sure to test often.  See the
@@ -136,6 +138,8 @@ your change is complex.  Also, be sure to test often.  See the
 When you are ready to submit your code, create a pull request by
 following the steps in the 
 [Creating a New Pull Request section](#creating-a-new-pull-request).
+
+
 
 
 #### Branch Naming Conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,14 @@ There are two important copyright guidelines:
 Please also take a look at our [Code of Conduct](https://github.com/pyvista/pyvista/blob/master/CODE_OF_CONDUCT.md)
 
 
-### Branch Naming Conventions
+### Contributing to pyvista through GitHub
+
+To submit new code to pyvista, first fork the (pyvista GitHub Repo)[https://github.com/pyvista/pyvista] and then clone the forked repository to your computer.  Then, create a new branch based on the branch naming convention in the next section in your local repository.  Next, add your new feature and commit it locally.  Be sure to commit often as it is often helpful to revert to past commits, especially if your change is complex.  Also, be sure to test often.  See the testing section below for automating testing.
+
+When you are ready to submit your code, create a pull request by following the steps in the Creating a New Pull Request section.
+
+
+#### Branch Naming Conventions
 
 To streamline development, we have the following requirements for naming
 branches. These requirements help the core developers know what kind of changes
@@ -137,7 +144,7 @@ any given branch is introducing before looking at the code.
 - `release/`: releases (see below)
 
 
-### Testing
+#### Testing
 
 After making changes, please test changes locally before creating a pull
 request. The following tests will be executed after any commit or pull request,
@@ -176,9 +183,8 @@ If you are running windows and `make` is unavailable, then run:
 ```
 pydocstyle pyvista
 
-codespell pyvista/ examples/ tests/ -S "*.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*"$(CODESPELL_SKIP) -I "ignore_words.txt"
+codespell pyvista/ examples/ tests/ -S "*.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*" -I "ignore_words.txt"
 ```
-
 
 And finally, test the documentation examples:
 
@@ -191,8 +197,27 @@ make html -b linkcheck
 
 The finished documentation can be found in the `docs/_build/html` directory.
 
+#### Creating a New Pull Request
 
-### Branching Model and Releases
+Once you have tested your branch locally, push your branch to (pyvista
+GitHub)[https://github.com/pyvista/pyvista] and create a pull request
+while merging to master.  This will automatically run continious
+integration (CI) testing and verify your changes will work across
+several platforms.
+
+To ensure someone else reviews your code, at least one other member of
+the pyvista contributiors group must review and verify your code meets
+our community's standards.  Once approved, if you have write
+permission you may merge the branch.  If you don't have write
+permission, the reviewer or someone else with write permission will
+merge the branch and close out the PR.
+
+Since it may be necessary to merge your branch with the current
+release branch (see below), please do not close out your branch if it
+is a `fix/` branch.
+
+
+### Branching Model
 
 This project follows a modified
 [gitflow](https://datasift.github.io/gitflow/IntroducingGitFlow.html)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,17 @@ following the steps in the
 [Creating a New Pull Request section](#creating-a-new-pull-request).
 
 
+#### Coding Style
 
+We adhere to [PEP 8](https://www.python.org/dev/peps/pep-0008/)
+wherever possible, except that line widths are permitted to go beyond
+79 characters to a max of 90 to 100 characters.
+
+Outside of PEP 8, when coding please consider [PEP 20 -- The Zen of Python](https://www.python.org/dev/peps/pep-0020/).  When in doubt:
+
+```python
+import this
+```
 
 #### Branch Naming Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,7 +224,7 @@ The finished documentation can be found in the `docs/_build/html` directory.
 
 Once you have tested your branch locally, create a pull request on
 (pyvista GitHub)[https://github.com/pyvista/pyvista] while merging to
-master.  This will automatically run continious integration (CI)
+master.  This will automatically run continuous integration (CI)
 testing and verify your changes will work across several platforms.
 
 To ensure someone else reviews your code, at least one other member of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,11 +222,10 @@ The finished documentation can be found in the `docs/_build/html` directory.
 
 #### Creating a New Pull Request
 
-Once you have tested your branch locally, push your branch to (pyvista
-GitHub)[https://github.com/pyvista/pyvista] and create a pull request
-while merging to master.  This will automatically run continious
-integration (CI) testing and verify your changes will work across
-several platforms.
+Once you have tested your branch locally, create a pull request on
+(pyvista GitHub)[https://github.com/pyvista/pyvista] while merging to
+master.  This will automatically run continious integration (CI)
+testing and verify your changes will work across several platforms.
 
 To ensure someone else reviews your code, at least one other member of
 the pyvista contributors group must review and verify your code meets
@@ -242,11 +241,10 @@ is a `fix/` branch.
 
 ### Branching Model
 
-This project follows a modified
-[gitflow](https://datasift.github.io/gitflow/IntroducingGitFlow.html)
-branching model.  The purpose of this is to enable rapid development
-of features without sacrificing stability.  These are the main
-features:
+This project has a branching model that enables rapid development of
+features without sacrificing stability.  The main features of our
+branching model are:
+
 
 - The `master` branch is the main development branch.  All features,
   patches, and other branches should be merged here.  While all PRs
@@ -270,7 +268,8 @@ features:
   the version (`0.25.0` in this case), and if necessary merged with
   master if any changes were pushed to it.  Feature development then
   continues on `master` and any hotfixes will now be merged with this
-  release.  Older release branches may be deleted when needed.
+  release.  Older release branches should not be deleted so they can
+  be patched as needed.
 
 
 #### Minor Release Steps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,6 @@ features to make this software a useful tool for all users.
 This page is dedicated to outline where you should start with your question,
 concern, feature request, or desire to contribute.
 
-
 ## Cloning the Source Repository
 
 You can clone the source repository from `https://github.com/pyvista/pyvista`
@@ -21,7 +20,6 @@ cd pyvista
 python -m pip install -e .
 ```
 
-
 ## Questions
 
 For general questions about the project, its applications, or about software
@@ -31,13 +29,11 @@ You are also welcome to join us on [Slack](http://slack.pyvista.org)
 or send one of the developers an email.
 The project support team can be reached at [info@pyvista.org](mailto:info@pyvista.org)
 
-
 For more technical questions, you are welcome to create an issue on the
 [issues page](https://github.com/pyvista/pyvista/issues) which we will address promptly.
 Through posting on the issues page, your question can be addressed by community
 members with the needed expertise and the information gained will remain
 available on the issues page for other users.
-
 
 ## Reporting Bugs
 
@@ -65,8 +61,8 @@ If you have an idea for how to improve PyVista, please first create an issue as
 a feature request which we can use as a discussion thread to work through how to
 implement the contribution.
 
-Once you are ready to start coding and develop for PyVista, please take a look
-at the remainder of the pages in this *Development Guide*.
+Once you are ready to start coding and develop for PyVista, please see the
+[Development Practices](#development-practices) section for more detials.
 
 ## Licensing
 
@@ -76,8 +72,15 @@ to ensure that the existing license is compatible and included in the
 contributed files or you can obtain permission from the original author to
 relicense the code.
 
+-----
 
-## Guidelines
+## Development Practices
+
+This section provides a guide to how we conduct development in the PyVista
+repository. Please follow the practices outlined here when contributing
+directly to this repository.
+
+### Guidelines
 
 Through direct access to the Visualization Toolkit (VTK) via direct array
 access and intuitive Python properties, we hope to make the entire VTK library
@@ -118,12 +121,27 @@ There are two important copyright guidelines:
 
 Please also take a look at our [Code of Conduct](https://github.com/pyvista/pyvista/blob/master/CODE_OF_CONDUCT.md)
 
-## Testing
+
+### Branch Naming Conventions
+
+To streamline development, we have the following requirements for naming
+branches. These requirements help the core developers know what kind of changes
+any given branch is introducing before looking at the code.
+
+- `fix/`: any bug fixes, patches, or experimental changes that are minor
+- `feat/`: any changes that introduce a new feature or significant addition
+- `junk/`: for any experimental changes that can be deleted if gone stale
+- `maint/`: for general maintence of the repository or CI routines
+- `doc/`: for any changes only pertaining to documentation
+- `no-ci/`: for low impact activity that should NOT trigger the CI routines
+
+### Testing
 
 After making changes, please test changes locally before creating a pull
 request. The following tests will be executed after any commit or pull request,
 so we ask that you perform the following sequence locally to track down any new
 issues from your changes.
+
 To run our comprehensive suite of unit tests, install all the dependencies
 listed in ``requirements_test.txt``, ``requirements_docs.txt``:
 
@@ -133,8 +151,7 @@ pip install -r requirements_test.txt
 pip install -r requirements_docs.txt
 ```
 
-Then, if you have everything installed, you can run the various test suites:
-
+Then, if you have everything installed, you can run the various test suites.
 
 Run the primary test suite and generate coverage report:
 
@@ -161,10 +178,10 @@ make html -b linkcheck
 The finished documentation can be found in the `docs/_build/html` directory.
 
 
-## Release Checklist
+### Making a Release
 
-The following is a checklist to complete before taging a release.
-This helps us ensure everything goes smoothely before our army of robots send
+The following is a list of steps to complete before taging a release.
+This helps us ensure everything goes smoothly before our army of robots send
 PyVista out to PyPI and Conda-Forge for deployment. Please checkout the
 latest state of the `master` branch locally and:
 
@@ -172,7 +189,7 @@ latest state of the `master` branch locally and:
 all are passing.
 
 2. Ensure all builds and tests on Azure are passing for the latest commits on
-the `master` branch
+the `master` branch.
 
 3. Locally test and build the documentation with link checking to make sure
 no links are outdated. Be sure to run `make clean` to ensure no results are
@@ -189,10 +206,14 @@ examples gallery for any obvious issues. If issues are present, abort the
 release.
 
 
+5. At this point, there are two routes to take: a) making a patch release or b) making a major/minor.
+    - a) If making a patch release, checkout the current minor version's `release/` branch and proceed.
+    - b) If making a major/minor release, create a new branch from the `master` branch with name `release/MAJOR.MINOR` (e.g. `release/0.25`).
+
 5. Update the version numbers in `pyvista/_version.py`, commit those
 changes, and then tag with the same version. Push the changes *and* the tags:
     ```bash
-    git push origin master
+    git push origin release/MAJOR.MINOR
     git push origin --tags
     ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,18 @@ Run all code examples in the docstrings:
 python -m pytest -v --doctest-modules pyvista
 ```
 
+Run documentation testing by running
+```bash
+make
+```
+
+If you are running windows and `make` is unavailable, then run:
+```
+pydocstyle pyvista
+
+codespell pyvista/ examples/ tests/ -S "*.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*"$(CODESPELL_SKIP) -I "ignore_words.txt"
+```
+
 
 And finally, test the documentation examples:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,14 +262,14 @@ branching model are:
   for past versions of `pyvista` without having to worry about
   untested features.
 - When a minor release candidate is ready, a new `release` branch will
-  be created from `master` with the next incremented
-  minor version (e.g. `release/0.25.0`), which will be thoroughly
-  tested.  When deemed stable, the release branch will be tagged with
-  the version (`0.25.0` in this case), and if necessary merged with
-  master if any changes were pushed to it.  Feature development then
-  continues on `master` and any hotfixes will now be merged with this
-  release.  Older release branches should not be deleted so they can
-  be patched as needed.
+  be created from `master` with the next incremented minor version
+  (e.g. `release/0.25`), which will be thoroughly tested.  When deemed
+  stable, the release branch will be tagged with the version (`0.25.0`
+  in this case), and if necessary merged with master if any changes
+  were pushed to it.  Feature development then continues on `master`
+  and any hotfixes will now be merged with this release.  Older
+  release branches should not be deleted so they can be patched as
+  needed.
 
 
 #### Minor Release Steps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,9 +124,18 @@ Please also take a look at our [Code of Conduct](https://github.com/pyvista/pyvi
 
 ### Contributing to pyvista through GitHub
 
-To submit new code to pyvista, first fork the (pyvista GitHub Repo)[https://github.com/pyvista/pyvista] and then clone the forked repository to your computer.  Then, create a new branch based on the branch naming convention in the next section in your local repository.  Next, add your new feature and commit it locally.  Be sure to commit often as it is often helpful to revert to past commits, especially if your change is complex.  Also, be sure to test often.  See the testing section below for automating testing.
+To submit new code to pyvista, first fork the (pyvista GitHub
+Repo)[https://github.com/pyvista/pyvista] and then clone the forked
+repository to your computer.  Then, create a new branch based on the
+branch naming convention in the next section in your local repository.
+Next, add your new feature and commit it locally.  Be sure to commit
+often as it is often helpful to revert to past commits, especially if
+your change is complex.  Also, be sure to test often.  See the
+[Testing Section](#testing) below for automating testing.
 
-When you are ready to submit your code, create a pull request by following the steps in the Creating a New Pull Request section.
+When you are ready to submit your code, create a pull request by
+following the steps in the 
+[Creating a New Pull Request section](#creating-a-new-pull-request).
 
 
 #### Branch Naming Conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,14 +229,14 @@ integration (CI) testing and verify your changes will work across
 several platforms.
 
 To ensure someone else reviews your code, at least one other member of
-the pyvista contributiors group must review and verify your code meets
+the pyvista contributors group must review and verify your code meets
 our community's standards.  Once approved, if you have write
 permission you may merge the branch.  If you don't have write
 permission, the reviewer or someone else with write permission will
-merge the branch and close out the PR.
+merge the branch and delete the PR branch.
 
 Since it may be necessary to merge your branch with the current
-release branch (see below), please do not close out your branch if it
+release branch (see below), please do not delete your branch if it
 is a `fix/` branch.
 
 
@@ -263,9 +263,9 @@ features:
   triggers CI to push to PyPi, and allow us to rapidly push hotfixes
   for past versions of `pyvista` without having to worry about
   untested features.
-- When a minor release canidate is ready, a new `release` branch will
-  be created from `master` will be created with the next incremented
-  minor version (e.g. `release/0.25.0`), which will be throughly
+- When a minor release candidate is ready, a new `release` branch will
+  be created from `master` with the next incremented
+  minor version (e.g. `release/0.25.0`), which will be thoroughly
   tested.  When deemed stable, the release branch will be tagged with
   the version (`0.25.0` in this case), and if necessary merged with
   master if any changes were pushed to it.  Feature development then
@@ -282,7 +282,7 @@ created the following will occur:
 1.  Create a new branch from the `master` branch with name
     `release/MAJOR.MINOR` (e.g. `release/0.25`).
 
-2. Locally verify run all tests as outlined in the [Testing Section](#testing) 
+2. Locally run all tests as outlined in the [Testing Section](#testing) 
 and ensure all are passing.
 
 3. Locally test and build the documentation with link checking to make sure

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
       pip install codespell pydocstyle
       make doctest
     displayName: 'Run doctest'
-  condition: not(contains(variables['Build.SourceBranchName'], 'no-ci'))
+  condition: not(contains(variables['Build.SourceBranch'], 'no-ci'))
 
 
 # DESCRIPTION: Core API and doc string testing for Linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
       pip install codespell pydocstyle
       make doctest
     displayName: 'Run doctest'
-  condition: not(contains(variables['Build.SourceBranchName'], 'no-ci')
+  condition: not(contains(variables['Build.SourceBranchName'], 'no-ci'))
 
 # DESCRIPTION: Core API and doc string testing for Linux
 - job: Linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
       pip install codespell pydocstyle
       make doctest
     displayName: 'Run doctest'
-  condition: not(contains(variables['Build.SourceBranch'], 'no-ci'))
+  condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))
 
 
 # DESCRIPTION: Core API and doc string testing for Linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,7 @@ jobs:
     displayName: 'Run doctest'
   condition: not(contains(variables['Build.SourceBranchName'], 'no-ci'))
 
+
 # DESCRIPTION: Core API and doc string testing for Linux
 - job: Linux
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -353,5 +353,3 @@ jobs:
     env:
       GH_TOKEN: $(gh.token)
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
-
-  condition: not(contains(variables['Build.SourceBranchName'], 'no-ci')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,6 @@ jobs:
       pip install codespell pydocstyle
       make doctest
     displayName: 'Run doctest'
-  condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))
 
 
 # DESCRIPTION: Core API and doc string testing for Linux
@@ -118,6 +117,10 @@ jobs:
       TWINE_PASSWORD: $(twine.password)
       TWINE_REPOSITORY_URL: "https://upload.pypi.org/legacy/"
 
+  # don't run job on no-ci builds
+  condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))
+
+
 # DESCRIPTION: Core API testing for Windows
 - job: Windows
   pool:
@@ -164,6 +167,10 @@ jobs:
       python -m pytest --cov -v .
     displayName: 'Run Tests'
 
+  # don't run job on no-ci builds
+  condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))
+
+
 # DESCRIPTION: Core API testing for MacOS
 - job: macOS
   variables:
@@ -207,6 +214,9 @@ jobs:
         python -m pip install pytest-azurepipelines
         python -m pytest -v --cov pyvista --cov-report html --durations=0
       displayName: 'Run Tests'
+
+  # don't run job on no-ci builds
+  condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))
 
 
 # Builds the documentation
@@ -353,3 +363,6 @@ jobs:
     env:
       GH_TOKEN: $(gh.token)
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+
+  # don't run job on no-ci builds
+  condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
       pip install codespell pydocstyle
       make doctest
     displayName: 'Run doctest'
-
+  condition: not(contains(variables['Build.SourceBranchName'], 'no-ci')
 
 # DESCRIPTION: Core API and doc string testing for Linux
 - job: Linux
@@ -352,3 +352,5 @@ jobs:
     env:
       GH_TOKEN: $(gh.token)
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+
+  condition: not(contains(variables['Build.SourceBranchName'], 'no-ci')


### PR DESCRIPTION
### Overview

Some updates to the `CONTRIBUTING.md` guide.

### Details

- [x] new branch naming convention
- [x] update the steps for making a release
- [x] Add formatting guidelines (should we enforce 79 character lines)
- [x] add steps for running pycodestyle and codespell locally
- [x] discuss the motivation behind new release strategy and how to make patch releases vs minor releases
- [x] add rules about how old branches are deleted after merging (we only want to delete `fix/` branches after a minor release in case we need to send those changes as a patch to a previous release)
- [x] add rules about how reviews are required to merge a PR.

@akaszynski still needs to refine the steps to make a release based on the new process discussed in #669 

@pyvista/developers, can you all take a look at this when you get a chance and suggest changes/guidelines that we should add?
