### PR TITLE
Make the menu bar optional

### DIFF
--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -642,6 +642,9 @@ class BackgroundPlotter(QtInteractor):
     allow_quit_keypress : bool, optional
         Allow user to exit by pressing ``"q"``.
 
+    menu_bar: bool, optional
+        Display the default main menu. Defaults to True.
+
     title : str, optional
         Title of plotting window.
 
@@ -675,10 +678,14 @@ class BackgroundPlotter(QtInteractor):
     ICON_TIME_STEP = 5.0
 
     def __init__(self, show=True, app=None, window_size=None,
-                 off_screen=None, allow_quit_keypress=True, **kwargs):
+                 off_screen=None, allow_quit_keypress=True,
+                 menu_bar=True, **kwargs):
         """Initialize the qt plotter."""
         if not has_pyqt:
             raise AssertionError('Requires PyQt5')
+        if not isinstance(menu_bar, bool):
+            raise TypeError("Expected type for ``menu_bar`` is bool"
+                            " but {} was given.".format(type(menu_bar)))
         self.active = True
         self.counters = []
         self.allow_quit_keypress = allow_quit_keypress
@@ -718,7 +725,8 @@ class BackgroundPlotter(QtInteractor):
                                                 **kwargs)
         self.app_window.signal_close.connect(self._close)
         self.add_toolbars(self.app_window)
-        self.add_menu_bar(self.app_window)
+        if menu_bar:
+            self.add_menu_bar(self.app_window)
 
         vlayout = QVBoxLayout()
         vlayout.addWidget(self.interactor)

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -540,9 +540,9 @@ class QtInteractor(QVTKRenderWindowInteractorAdapter, BasePlotter):
 
         return
 
-    def add_menu_bar(self, main_window):
+    def add_menu_bar(self):
         """Add the main menu bar."""
-        main_menu = _create_menu_bar(parent=main_window)
+        main_menu = _create_menu_bar(parent=self.app_window)
         self.app_window.signal_close.connect(main_menu.clear)
 
         file_menu = main_menu.addMenu('File')
@@ -550,7 +550,7 @@ class QtInteractor(QVTKRenderWindowInteractorAdapter, BasePlotter):
         file_menu.addAction('Export as VTKjs', self._qt_export_vtkjs)
         file_menu.addSeparator()
         # member variable for testing only
-        self._menu_close_action = file_menu.addAction('Exit', main_window.close)
+        self._menu_close_action = file_menu.addAction('Exit', self.app_window.close)
 
         view_menu = main_menu.addMenu('View')
         view_menu.addAction('Toggle Eye Dome Lighting', self._toggle_edl)

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -542,22 +542,22 @@ class QtInteractor(QVTKRenderWindowInteractorAdapter, BasePlotter):
 
     def add_menu_bar(self):
         """Add the main menu bar."""
-        main_menu = _create_menu_bar(parent=self.app_window)
-        self.app_window.signal_close.connect(main_menu.clear)
+        self.main_menu = _create_menu_bar(parent=self.app_window)
+        self.app_window.signal_close.connect(self.main_menu.clear)
 
-        file_menu = main_menu.addMenu('File')
+        file_menu = self.main_menu.addMenu('File')
         file_menu.addAction('Take Screenshot', self._qt_screenshot)
         file_menu.addAction('Export as VTKjs', self._qt_export_vtkjs)
         file_menu.addSeparator()
         # member variable for testing only
         self._menu_close_action = file_menu.addAction('Exit', self.app_window.close)
 
-        view_menu = main_menu.addMenu('View')
+        view_menu = self.main_menu.addMenu('View')
         view_menu.addAction('Toggle Eye Dome Lighting', self._toggle_edl)
         view_menu.addAction('Scale Axes', self.scale_axes_dialog)
         view_menu.addAction('Clear All', self.clear)
 
-        tool_menu = main_menu.addMenu('Tools')
+        tool_menu = self.main_menu.addMenu('Tools')
         tool_menu.addAction('Enable Cell Picking (through)', self.enable_cell_picking)
         tool_menu.addAction('Enable Cell Picking (visible)', lambda: self.enable_cell_picking(through=False))
 
@@ -642,13 +642,11 @@ class BackgroundPlotter(QtInteractor):
     allow_quit_keypress : bool, optional
         Allow user to exit by pressing ``"q"``.
 
-<<<<<<< HEAD
     menu_bar: bool, optional
         Display the default main menu. Defaults to True.
-=======
+
     toolbar : bool, optional
        Display the default camera toolbar. Defaults to True.
->>>>>>> master
 
     title : str, optional
         Title of plotting window.
@@ -737,7 +735,7 @@ class BackgroundPlotter(QtInteractor):
         self.main_menu = None
         self._menu_close_action = None
         if menu_bar:
-            self.main_menu = self.add_menu_bar(self.app_window)
+            self.add_menu_bar()
 
         if toolbar:
             self.add_toolbars(self.app_window)

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -542,7 +542,7 @@ class QtInteractor(QVTKRenderWindowInteractorAdapter, BasePlotter):
 
     def add_menu_bar(self, main_window):
         """Add the main menu bar."""
-        self.main_menu = _create_menu_bar(parent=self.app_window)
+        self.main_menu = _create_menu_bar(parent=main_window)
         self.app_window.signal_close.connect(self.main_menu.clear)
 
         file_menu = self.main_menu.addMenu('File')
@@ -550,7 +550,7 @@ class QtInteractor(QVTKRenderWindowInteractorAdapter, BasePlotter):
         file_menu.addAction('Export as VTKjs', self._qt_export_vtkjs)
         file_menu.addSeparator()
         # member variable for testing only
-        self._menu_close_action = file_menu.addAction('Exit', self.app_window.close)
+        self._menu_close_action = file_menu.addAction('Exit', main_window.close)
 
         view_menu = self.main_menu.addMenu('View')
         view_menu.addAction('Toggle Eye Dome Lighting', self._toggle_edl)

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -540,6 +540,47 @@ class QtInteractor(QVTKRenderWindowInteractorAdapter, BasePlotter):
 
         return
 
+    def add_menu_bar(self, main_window):
+        """Add the main menu bar."""
+        self.main_menu = _create_menu_bar(parent=self.app_window)
+        self.app_window.signal_close.connect(self.main_menu.clear)
+
+        file_menu = self.main_menu.addMenu('File')
+        file_menu.addAction('Take Screenshot', self._qt_screenshot)
+        file_menu.addAction('Export as VTKjs', self._qt_export_vtkjs)
+        file_menu.addSeparator()
+        # member variable for testing only
+        self._menu_close_action = file_menu.addAction('Exit', self.app_window.close)
+
+        view_menu = self.main_menu.addMenu('View')
+        view_menu.addAction('Toggle Eye Dome Lighting', self._toggle_edl)
+        view_menu.addAction('Scale Axes', self.scale_axes_dialog)
+        view_menu.addAction('Clear All', self.clear)
+
+        tool_menu = self.main_menu.addMenu('Tools')
+        tool_menu.addAction('Enable Cell Picking (through)', self.enable_cell_picking)
+        tool_menu.addAction('Enable Cell Picking (visible)', lambda: self.enable_cell_picking(through=False))
+
+        cam_menu = view_menu.addMenu('Camera')
+        cam_menu.addAction('Toggle Parallel Projection', self._toggle_parallel_projection)
+
+        view_menu.addSeparator()
+        # Orientation marker
+        orien_menu = view_menu.addMenu('Orientation Marker')
+        orien_menu.addAction('Show All', self.show_axes_all)
+        orien_menu.addAction('Hide All', self.hide_axes_all)
+        # Bounds axes
+        axes_menu = view_menu.addMenu('Bounds Axes')
+        axes_menu.addAction('Add Bounds Axes (front)', self.show_bounds)
+        axes_menu.addAction('Add Bounds Grid (back)', self.show_grid)
+        axes_menu.addAction('Add Bounding Box', self.add_bounding_box)
+        axes_menu.addSeparator()
+        axes_menu.addAction('Remove Bounding Box', self.remove_bounding_box)
+        axes_menu.addAction('Remove Bounds', self.remove_bounds_axes)
+
+        # A final separator to separate OS options
+        view_menu.addSeparator()
+
     def save_camera_position(self):
         """Save camera position to saved camera menu for recall."""
         self.saved_camera_positions.append(self.camera_position)
@@ -677,46 +718,7 @@ class BackgroundPlotter(QtInteractor):
                                                 **kwargs)
         self.app_window.signal_close.connect(self._close)
         self.add_toolbars(self.app_window)
-
-        # build main menu
-        self.main_menu = _create_menu_bar(parent=self.app_window)
-        self.app_window.signal_close.connect(self.main_menu.clear)
-
-        file_menu = self.main_menu.addMenu('File')
-        file_menu.addAction('Take Screenshot', self._qt_screenshot)
-        file_menu.addAction('Export as VTKjs', self._qt_export_vtkjs)
-        file_menu.addSeparator()
-        # member variable for testing only
-        self._menu_close_action = file_menu.addAction('Exit', self.app_window.close)
-
-        view_menu = self.main_menu.addMenu('View')
-        view_menu.addAction('Toggle Eye Dome Lighting', self._toggle_edl)
-        view_menu.addAction('Scale Axes', self.scale_axes_dialog)
-        view_menu.addAction('Clear All', self.clear)
-
-        tool_menu = self.main_menu.addMenu('Tools')
-        tool_menu.addAction('Enable Cell Picking (through)', self.enable_cell_picking)
-        tool_menu.addAction('Enable Cell Picking (visible)', lambda: self.enable_cell_picking(through=False))
-
-        cam_menu = view_menu.addMenu('Camera')
-        cam_menu.addAction('Toggle Parallel Projection', self._toggle_parallel_projection)
-
-        view_menu.addSeparator()
-        # Orientation marker
-        orien_menu = view_menu.addMenu('Orientation Marker')
-        orien_menu.addAction('Show All', self.show_axes_all)
-        orien_menu.addAction('Hide All', self.hide_axes_all)
-        # Bounds axes
-        axes_menu = view_menu.addMenu('Bounds Axes')
-        axes_menu.addAction('Add Bounds Axes (front)', self.show_bounds)
-        axes_menu.addAction('Add Bounds Grid (back)', self.show_grid)
-        axes_menu.addAction('Add Bounding Box', self.add_bounding_box)
-        axes_menu.addSeparator()
-        axes_menu.addAction('Remove Bounding Box', self.remove_bounding_box)
-        axes_menu.addAction('Remove Bounds', self.remove_bounds_axes)
-
-        # A final separator to separate OS options
-        view_menu.addSeparator()
+        self.add_menu_bar(self.app_window)
 
         vlayout = QVBoxLayout()
         vlayout.addWidget(self.interactor)

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -506,16 +506,16 @@ class QtInteractor(QVTKRenderWindowInteractorAdapter, BasePlotter):
                     print(str(e))
                     pass
 
-    def add_toolbars(self, main_window):
+    def add_toolbars(self):
         """Add the toolbars."""
         def _add_action(tool_bar, key, method):
-            action = QAction(key, main_window)
+            action = QAction(key, self.app_window)
             action.triggered.connect(method)
             tool_bar.addAction(action)
             return
 
         # Camera toolbar
-        self.default_camera_tool_bar = main_window.addToolBar('Camera Position')
+        self.default_camera_tool_bar = self.app_window.addToolBar('Camera Position')
         _view_vector = lambda *args: self.view_vector(*args)
         cvec_setters = {
             # Viewing vector then view up vector
@@ -533,7 +533,7 @@ class QtInteractor(QVTKRenderWindowInteractorAdapter, BasePlotter):
 
         # Saved camera locations toolbar
         self.saved_camera_positions = []
-        self.saved_cameras_tool_bar = main_window.addToolBar('Saved Camera Positions')
+        self.saved_cameras_tool_bar = self.app_window.addToolBar('Saved Camera Positions')
 
         _add_action(self.saved_cameras_tool_bar, SAVE_CAM_BUTTON_TEXT, self.save_camera_position)
         _add_action(self.saved_cameras_tool_bar, CLEAR_CAMS_BUTTON_TEXT, self.clear_camera_positions)
@@ -737,8 +737,11 @@ class BackgroundPlotter(QtInteractor):
         if menu_bar:
             self.add_menu_bar()
 
+        self.default_camera_tool_bar = None
+        self.saved_camera_positions = None
+        self.saved_cameras_tool_bar = None
         if toolbar:
-            self.add_toolbars(self.app_window)
+            self.add_toolbars()
 
         vlayout = QVBoxLayout()
         vlayout.addWidget(self.interactor)

--- a/tests/test_qt_plotting.py
+++ b/tests/test_qt_plotting.py
@@ -327,14 +327,16 @@ def test_background_plotting_toolbar(qtbot):
         pyvista.BackgroundPlotter(off_screen=False, toolbar="foo")
 
     plotter = pyvista.BackgroundPlotter(off_screen=False, toolbar=False)
-    assert not hasattr(plotter, "default_camera_tool_bar")
-    assert not hasattr(plotter, "saved_cameras_tool_bar")
+    assert plotter.default_camera_tool_bar is None
+    assert plotter.saved_camera_positions is None
+    assert plotter.saved_cameras_tool_bar is None
     plotter.close()
 
     plotter = pyvista.BackgroundPlotter(off_screen=False)
 
     assert _hasattr(plotter, "app_window", MainWindow)
     assert _hasattr(plotter, "default_camera_tool_bar", QToolBar)
+    assert _hasattr(plotter, "saved_camera_positions", list)
     assert _hasattr(plotter, "saved_cameras_tool_bar", QToolBar)
 
     window = plotter.app_window

--- a/tests/test_qt_plotting.py
+++ b/tests/test_qt_plotting.py
@@ -323,6 +323,18 @@ def test_background_plotting_orbit(qtbot):
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 @pytest.mark.skipif(not has_pyqt5, reason="requires pyqt5")
+def test_background_plotting_menu_bar(qtbot):
+    with pytest.raises(TypeError, match='menu_bar'):
+        pyvista.BackgroundPlotter(off_screen=False, menu_bar="foo")
+
+    plotter = pyvista.BackgroundPlotter(off_screen=False, menu_bar=False)
+    assert not hasattr(plotter, "main_menu")
+    assert not hasattr(plotter, "_menu_close_action")
+    plotter.close()
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+@pytest.mark.skipif(not has_pyqt5, reason="requires pyqt5")
 def test_background_plotting_add_callback(qtbot):
     class CallBack(object):
         def __init__(self, sphere):

--- a/tests/test_qt_plotting.py
+++ b/tests/test_qt_plotting.py
@@ -363,6 +363,23 @@ def test_background_plotting_menu_bar(qtbot):
     assert plotter._menu_close_action is None
     plotter.close()
 
+    plotter = pyvista.BackgroundPlotter(off_screen=False)  # menu_bar=True
+
+    assert _hasattr(plotter, "app_window", MainWindow)
+    assert _hasattr(plotter, "main_menu", QMenuBar)
+    assert _hasattr(plotter, "_menu_close_action", QAction)
+
+    window = plotter.app_window
+    main_menu = plotter.main_menu
+    assert not main_menu.isNativeMenuBar()
+
+    with qtbot.wait_exposed(window, timeout=500):
+        window.show()
+
+    assert main_menu.isVisible()
+    plotter.close()
+    assert not main_menu.isVisible()
+
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 @pytest.mark.skipif(not has_pyqt5, reason="requires pyqt5")
@@ -440,7 +457,6 @@ def test_background_plotting_close(qtbot, close_event, empty_scene):
 
     # check that BackgroundPlotter.__init__() is called
     assert _hasattr(plotter, "app_window", MainWindow)
-    assert _hasattr(plotter, "main_menu", QMenuBar)
     # check that QtInteractor.__init__() is called
     assert _hasattr(plotter, "iren", vtk.vtkRenderWindowInteractor)
     assert _hasattr(plotter, "render_timer", QTimer)
@@ -451,8 +467,6 @@ def test_background_plotting_close(qtbot, close_event, empty_scene):
     assert _hasattr(plotter, "interactor", QVTKRenderWindowInteractor)
 
     window = plotter.app_window  # MainWindow
-    main_menu = plotter.main_menu  # QMenuBar
-    assert not main_menu.isNativeMenuBar()
     interactor = plotter.interactor  # QVTKRenderWindowInteractor
     render_timer = plotter.render_timer  # QTimer
 
@@ -474,7 +488,6 @@ def test_background_plotting_close(qtbot, close_event, empty_scene):
     # check that the widgets are showed properly
     assert window.isVisible()
     assert interactor.isVisible()
-    assert main_menu.isVisible()
     assert render_timer.isActive()
     assert not plotter._closed
 
@@ -493,7 +506,6 @@ def test_background_plotting_close(qtbot, close_event, empty_scene):
     # check that the widgets are closed
     assert not window.isVisible()
     assert not interactor.isVisible()
-    assert not main_menu.isVisible()
     assert not render_timer.isActive()
 
     # check that BasePlotter.close() is called

--- a/tests/test_qt_plotting.py
+++ b/tests/test_qt_plotting.py
@@ -457,6 +457,7 @@ def test_background_plotting_close(qtbot, close_event, empty_scene):
 
     # check that BackgroundPlotter.__init__() is called
     assert _hasattr(plotter, "app_window", MainWindow)
+    assert _hasattr(plotter, "main_menu", QMenuBar)
     # check that QtInteractor.__init__() is called
     assert _hasattr(plotter, "iren", vtk.vtkRenderWindowInteractor)
     assert _hasattr(plotter, "render_timer", QTimer)
@@ -467,6 +468,8 @@ def test_background_plotting_close(qtbot, close_event, empty_scene):
     assert _hasattr(plotter, "interactor", QVTKRenderWindowInteractor)
 
     window = plotter.app_window  # MainWindow
+    main_menu = plotter.main_menu
+    assert not main_menu.isNativeMenuBar()
     interactor = plotter.interactor  # QVTKRenderWindowInteractor
     render_timer = plotter.render_timer  # QTimer
 
@@ -488,6 +491,7 @@ def test_background_plotting_close(qtbot, close_event, empty_scene):
     # check that the widgets are showed properly
     assert window.isVisible()
     assert interactor.isVisible()
+    assert main_menu.isVisible()
     assert render_timer.isActive()
     assert not plotter._closed
 
@@ -506,6 +510,7 @@ def test_background_plotting_close(qtbot, close_event, empty_scene):
     # check that the widgets are closed
     assert not window.isVisible()
     assert not interactor.isVisible()
+    assert not main_menu.isVisible()
     assert not render_timer.isActive()
 
     # check that BasePlotter.close() is called

--- a/tests/test_qt_plotting.py
+++ b/tests/test_qt_plotting.py
@@ -438,7 +438,7 @@ def test_background_plotting_close(qtbot, close_event, empty_scene):
 
     # check that BackgroundPlotter.__init__() is called
     assert _hasattr(plotter, "app_window", MainWindow)
-    # assert _hasattr(plotter, "main_menu", QMenuBar)
+    assert _hasattr(plotter, "main_menu", QMenuBar)
     # check that QtInteractor.__init__() is called
     assert _hasattr(plotter, "iren", vtk.vtkRenderWindowInteractor)
     assert _hasattr(plotter, "render_timer", QTimer)
@@ -450,8 +450,7 @@ def test_background_plotting_close(qtbot, close_event, empty_scene):
 
     window = plotter.app_window  # MainWindow
     main_menu = plotter.main_menu  # QMenuBar
-    if main_menu is not None:
-        assert not main_menu.isNativeMenuBar()
+    assert not main_menu.isNativeMenuBar()
     interactor = plotter.interactor  # QVTKRenderWindowInteractor
     render_timer = plotter.render_timer  # QTimer
 
@@ -473,8 +472,7 @@ def test_background_plotting_close(qtbot, close_event, empty_scene):
     # check that the widgets are showed properly
     assert window.isVisible()
     assert interactor.isVisible()
-    if main_menu is not None:
-        assert main_menu.isVisible()
+    assert main_menu.isVisible()
     assert render_timer.isActive()
     assert not plotter._closed
 
@@ -493,8 +491,7 @@ def test_background_plotting_close(qtbot, close_event, empty_scene):
     # check that the widgets are closed
     assert not window.isVisible()
     assert not interactor.isVisible()
-    if main_menu is not None:
-        assert not main_menu.isVisible()
+    assert not main_menu.isVisible()
     assert not render_timer.isActive()
 
     # check that BasePlotter.close() is called


### PR DESCRIPTION
This PR makes the `BackgroundPlotter` main menu bar optional. There is now a parameter `menu_bar` which can be set to `False` to disable it.