### PR TITLE
Add basic slider styles

### DIFF
--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -71,6 +71,28 @@ rcParams = {
         'occlusion_ratio': 0.0,
         'enabled': False,
     },
+    'slider_style': {
+        'classic': {
+            'slider_length': 0.02,
+            'slider_width': 0.04,
+            'slider_color': (0.5, 0.5, 0.5),
+            'tube_width': 0.005,
+            'tube_color': (1, 1, 1),
+            'cap_opacity': 1,
+            'cap_length': 0.01,
+            'cap_width': 0.02,
+        },
+        'modern': {
+            'slider_length': 0.02,
+            'slider_width': 0.04,
+            'slider_color': (0.43137255, 0.44313725, 0.45882353),
+            'tube_width': 0.04,
+            'tube_color': (0.69803922, 0.70196078, 0.70980392),
+            'cap_opacity': 0,
+            'cap_length': 0.01,
+            'cap_width': 0.02,
+        },
+    },
 }
 
 

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -785,8 +785,8 @@ class WidgetHelper(object):
 
         if style is not None:
             if not isinstance(style, str):
-                raise TypeError("Expected type for ``style`` is NoneType or "
-                                "str but {} was given.".format(type(style)))
+                raise TypeError("Expected type for ``style`` is str but"
+                                " {} was given.".format(type(style)))
             style_params = rcParams['slider_style'].get(style, None)
             if style_params is None:
                 raise KeyError("The requested style does not exist: "

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -697,7 +697,7 @@ class WidgetHelper(object):
     def add_slider_widget(self, callback, rng, value=None, title=None,
                           pointa=(.4, .9), pointb=(.9, .9),
                           color=None, pass_widget=False,
-                          event_type='end'):
+                          event_type='end', style=None):
         """Add a slider bar widget.
 
         This is useless without a callback function. You can pass a callable
@@ -734,10 +734,13 @@ class WidgetHelper(object):
             If true, the widget will be passed as the last argument of the
             callback
 
-        event_type: str
+        event_type : str
             Either 'start', 'end' or 'always', this defines how often the
             slider interacts with the callback.
 
+        style : str, optional
+            The name of the slider style. The list of available styles are in
+            ``rcParams['slider_style']``. Defaults to None.
         """
         if hasattr(self, 'notebook') and self.notebook:
             raise AssertionError('Slider widget not available in notebook plotting')
@@ -779,6 +782,24 @@ class WidgetHelper(object):
         slider_rep.SetSliderLength(0.05)
         slider_rep.SetSliderWidth(0.05)
         slider_rep.SetEndCapLength(0.01)
+
+        if style is not None:
+            if not isinstance(style, str):
+                raise TypeError("Expected type for ``style`` is NoneType or "
+                                "str but {} was given.".format(type(style)))
+            style_params = rcParams['slider_style'].get(style, None)
+            if style_params is None:
+                raise KeyError("The requested style does not exist: "
+                               "{}. The styles available are {}.".format(style,
+                                   list(rcParams['slider_style'].keys())))
+            slider_rep.SetSliderLength(style_params['slider_length'])
+            slider_rep.SetSliderWidth(style_params['slider_width'])
+            slider_rep.GetSliderProperty().SetColor(style_params['slider_color'])
+            slider_rep.SetTubeWidth(style_params['tube_width'])
+            slider_rep.GetTubeProperty().SetColor(style_params['tube_color'])
+            slider_rep.GetCapProperty().SetOpacity(style_params['cap_opacity'])
+            slider_rep.SetEndCapLength(style_params['cap_length'])
+            slider_rep.SetEndCapWidth(style_params['cap_width'])
 
         def _the_callback(widget, event):
             value = widget.GetRepresentation().GetValue()

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -111,13 +111,17 @@ def test_widget_slider():
     p = pyvista.Plotter(off_screen=OFF_SCREEN)
     func = lambda value: value # Does nothing
     p.add_mesh(mesh)
-    p.add_slider_widget(callback=func, rng=[0,10])
+    p.add_slider_widget(callback=func, rng=[0,10], style="classic")
     p.close()
 
     p = pyvista.Plotter(off_screen=OFF_SCREEN)
     for event_type in ['start', 'end', 'always']:
         p.add_slider_widget(callback=func, rng=[0,10],
                             event_type=event_type)
+    with pytest.raises(TypeError, match='type for ``style``'):
+        p.add_slider_widget(callback=func, rng=[0,10], style=0)
+    with pytest.raises(KeyError, match='styles available'):
+        p.add_slider_widget(callback=func, rng=[0,10], style="foo")
     with pytest.raises(TypeError, match='type for `event_type`'):
         p.add_slider_widget(callback=func, rng=[0,10],
                             event_type=0)
@@ -129,7 +133,8 @@ def test_widget_slider():
     p = pyvista.Plotter(off_screen=OFF_SCREEN)
     func = lambda value, widget: value # Does nothing
     p.add_mesh(mesh)
-    p.add_slider_widget(callback=func, rng=[0,10], pass_widget=True)
+    p.add_slider_widget(callback=func, rng=[0,10], style="modern",
+                        pass_widget=True)
     p.close()
 
     p = pyvista.Plotter(off_screen=OFF_SCREEN)


### PR DESCRIPTION
This PR adds 2 basic slider styles: `classic` and `modern`

```py
import numpy as np
import pyvista as pv


def foo(value):
    pass


p = pv.BackgroundPlotter()
pos = np.array([.2, .8])
for style in (None, "classic", "modern"):
    p.add_slider_widget(foo, [0, 1], style=style,
                        pointa=pos, pointb=pos + [0.6, 0])
    pos += [0, -0.3]
```

![image](https://user-images.githubusercontent.com/18143289/79017390-77d21900-7b71-11ea-81ec-5ee8d2bbb02d.png)

