### PR TITLE
Refactor test_common transforms section, introduce Hypothesis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ flycheck*
 
 
 docs/external_examples.rst
+
+# hypothesis
+.hypothesis

--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - pytest-cov
   - pytest-qt
   - codecov
+  - hypothesis
   - pip
   - pip:
       - pytest-memprof

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - pytest-cov
   - pytest-qt
   - codecov
-  - hypothesis
+  - hypothesis>=5.8.0
   - pip
   - pip:
       - pytest-memprof

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -16,3 +16,4 @@ scooby>=0.5.1
 meshio>=4.0.3, <5.0
 itkwidgets>=0.25.2
 tqdm
+hypothesis>=5.8.0

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -139,8 +139,8 @@ class TestTransform:
         grid_a.transform(trans)
         grid_b.transform(trans.GetMatrix())
         grid_c.transform(pyvista.trans_from_matrix(trans.GetMatrix()))
-        assert np.allclose(grid_a.points, grid_b.points)
-        assert np.allclose(grid_a.points, grid_c.points)
+        assert np.allclose(grid_a.points, grid_b.points, equal_nan=True)
+        assert np.allclose(grid_a.points, grid_c.points, equal_nan=True)
 
     def test_should_fail_if_given_none(self, grid):
         with pytest.raises(TypeError):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -127,7 +127,7 @@ def test_copy(grid):
 class TestTransform:
     @settings(max_examples=10)
     @given(rotate_amounts=n_numbers(3), translate_amounts=n_numbers(3))
-    def test_should_match_vtk(self, rotate_amounts, translate_amounts, grid):
+    def test_should_match_vtk_translation(self, rotate_amounts, translate_amounts, grid):
         trans = vtk.vtkTransform()
         trans.RotateWXYZ(0, *rotate_amounts)
         trans.Translate(translate_amounts)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -126,7 +126,6 @@ def test_copy(grid):
 
 
 class TestTransform:
-    @settings(max_examples=10)
     @given(rotate_amounts=n_numbers(3), translate_amounts=n_numbers(3))
     def test_should_match_vtk_translation(self, rotate_amounts, translate_amounts, grid):
         trans = vtk.vtkTransform()
@@ -156,7 +155,6 @@ class TestTransform:
 
 
 class TestTranslate:
-    @settings(max_examples=20)
     @given(axis_amounts=n_numbers(3))
     def test_should_translate_grid(self, axis_amounts, grid):
         grid_copy = grid.copy()
@@ -167,7 +165,6 @@ class TestTranslate:
 
 
 class TestRotate:
-    @settings(max_examples=50)
     @given(angle=one_of(floats(), integers()))
     @pytest.mark.parametrize('axis', ('x', 'y', 'z'))
     def test_should_match_vtk_rotation(self, angle, axis, grid):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,4 +1,5 @@
 from hypothesis import given, settings
+from hypothesis.extra.numpy import arrays, array_shapes
 from hypothesis.strategies import composite, integers, floats, one_of
 import numpy as np
 import pytest
@@ -146,8 +147,12 @@ class TestTransform:
         with pytest.raises(TypeError):
             grid.transform(None)
 
+    @given(array=arrays(dtype=np.float32, shape=array_shapes(max_dims=5, max_side=5)))
+    def test_should_fail_if_given_wrong_numpy_shape(self, array):
+        if array.shape == (4, 4):
+            return
         with pytest.raises(Exception):
-            grid.transform(np.array([1]))
+            grid.transform(array)
 
 
 class TestTranslate:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -150,14 +150,15 @@ class TestTransform:
             grid.transform(np.array([1]))
 
 
-@settings(max_examples=20)
-@given(axis_amounts=n_numbers(3))
-def test_translate_should_translate_grid(axis_amounts, grid):
-    grid_copy = grid.copy()
-    grid_copy.translate(axis_amounts)
+class TestTranslate:
+    @settings(max_examples=20)
+    @given(axis_amounts=n_numbers(3))
+    def test_should_translate_grid(axis_amounts, grid):
+        grid_copy = grid.copy()
+        grid_copy.translate(axis_amounts)
 
-    grid_points = grid.points.copy() + np.array(axis_amounts)
-    assert np.allclose(grid_copy.points, grid_points)
+        grid_points = grid.points.copy() + np.array(axis_amounts)
+        assert np.allclose(grid_copy.points, grid_points)
 
 
 @settings(max_examples=50)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -150,13 +150,13 @@ def test_transform_errors(grid):
         grid.transform(np.array([1]))
 
 
-@given(one_of(floats(allow_infinity=False, allow_nan=False), integers()))
-def test_translate(grid):
+@settings(max_examples=8)
+@given(axis_amounts=n_numbers(3))
+def test_translate(axis_amounts, grid):
     grid_copy = grid.copy()
-    xyz = [1, 1, 1]
-    grid_copy.translate(xyz)
+    grid_copy.translate(axis_amounts)
 
-    grid_points = grid.points.copy() + np.array(xyz)
+    grid_points = grid.points.copy() + np.array(axis_amounts)
     assert np.allclose(grid_copy.points, grid_points)
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -127,7 +127,7 @@ def test_copy(grid):
 
 class TestTransform:
     @given(rotate_amounts=n_numbers(3), translate_amounts=n_numbers(3))
-    def test_should_match_vtk_translation(self, rotate_amounts, translate_amounts, grid):
+    def test_should_match_vtk_transformation(self, rotate_amounts, translate_amounts, grid):
         trans = vtk.vtkTransform()
         trans.RotateWXYZ(0, *rotate_amounts)
         trans.Translate(translate_amounts)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,5 +1,5 @@
 from hypothesis import given, settings
-from hypothesis.strategies import integers, floats, one_of
+from hypothesis.strategies import composite, integers, floats, one_of
 import numpy as np
 import pytest
 import vtk
@@ -12,6 +12,15 @@ from pyvista import examples
 @pytest.fixture()
 def grid():
     return pyvista.UnstructuredGrid(examples.hexbeamfile)
+
+
+@composite
+def n_numbers(draw, n):
+    numbers = []
+    for _ in range(n):
+        number = draw(one_of(floats(allow_infinity=False, allow_nan=False), integers()))
+        numbers.append(number)
+    return numbers
 
 
 def test_point_arrays(grid):
@@ -141,6 +150,7 @@ def test_transform_errors(grid):
         grid.transform(np.array([1]))
 
 
+@given(one_of(floats(allow_infinity=False, allow_nan=False), integers()))
 def test_translate(grid):
     grid_copy = grid.copy()
     xyz = [1, 1, 1]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -153,7 +153,7 @@ def test_translate(grid):
 @settings(max_examples=5)
 @given(angle=one_of(floats(allow_infinity=False, allow_nan=False), integers()))
 @pytest.mark.parametrize('axis', ('x', 'y', 'z'))
-def test_rotate(angle, axis, grid):
+def test_rotate_should_match_vtk_rotation(angle, axis, grid):
     trans = vtk.vtkTransform()
     getattr(trans, 'Rotate{}'.format(axis.upper()))(angle)
     trans.Update()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -124,30 +124,30 @@ def test_copy(grid):
     assert np.all(grid_copy_shallow.points[0] == grid.points[0])
 
 
-@settings(max_examples=10)
-@given(rotate_amounts=n_numbers(3), translate_amounts=n_numbers(3))
-def test_transform_should_match_vtk(rotate_amounts, translate_amounts, grid):
-    trans = vtk.vtkTransform()
-    trans.RotateWXYZ(0, *rotate_amounts)
-    trans.Translate(translate_amounts)
-    trans.Update()
+class TestTransform:
+    @settings(max_examples=10)
+    @given(rotate_amounts=n_numbers(3), translate_amounts=n_numbers(3))
+    def test_should_match_vtk(self, rotate_amounts, translate_amounts, grid):
+        trans = vtk.vtkTransform()
+        trans.RotateWXYZ(0, *rotate_amounts)
+        trans.Translate(translate_amounts)
+        trans.Update()
 
-    grid_a = grid.copy()
-    grid_b = grid.copy()
-    grid_c = grid.copy()
-    grid_a.transform(trans)
-    grid_b.transform(trans.GetMatrix())
-    grid_c.transform(pyvista.trans_from_matrix(trans.GetMatrix()))
-    assert np.allclose(grid_a.points, grid_b.points)
-    assert np.allclose(grid_a.points, grid_c.points)
+        grid_a = grid.copy()
+        grid_b = grid.copy()
+        grid_c = grid.copy()
+        grid_a.transform(trans)
+        grid_b.transform(trans.GetMatrix())
+        grid_c.transform(pyvista.trans_from_matrix(trans.GetMatrix()))
+        assert np.allclose(grid_a.points, grid_b.points)
+        assert np.allclose(grid_a.points, grid_c.points)
 
+    def test_transform_errors(self, grid):
+        with pytest.raises(TypeError):
+            grid.transform(None)
 
-def test_transform_errors(grid):
-    with pytest.raises(TypeError):
-        grid.transform(None)
-
-    with pytest.raises(Exception):
-        grid.transform(np.array([1]))
+        with pytest.raises(Exception):
+            grid.transform(np.array([1]))
 
 
 @settings(max_examples=20)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -158,7 +158,7 @@ class TestTransform:
 class TestTranslate:
     @settings(max_examples=20)
     @given(axis_amounts=n_numbers(3))
-    def test_should_translate_grid(axis_amounts, grid):
+    def test_should_translate_grid(self, axis_amounts, grid):
         grid_copy = grid.copy()
         grid_copy.translate(axis_amounts)
 
@@ -170,7 +170,7 @@ class TestRotate:
     @settings(max_examples=50)
     @given(angle=one_of(floats(), integers()))
     @pytest.mark.parametrize('axis', ('x', 'y', 'z'))
-    def test_should_match_vtk_rotation(angle, axis, grid):
+    def test_should_match_vtk_rotation(self, angle, axis, grid):
         trans = vtk.vtkTransform()
         getattr(trans, 'Rotate{}'.format(axis.upper()))(angle)
         trans.Update()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,4 +1,4 @@
-from hypothesis import given
+from hypothesis import assume, given
 from hypothesis.extra.numpy import arrays, array_shapes
 from hypothesis.strategies import composite, integers, floats, one_of
 import numpy as np
@@ -148,8 +148,7 @@ class TestTransform:
 
     @given(array=arrays(dtype=np.float32, shape=array_shapes(max_dims=5, max_side=5)))
     def test_should_fail_if_given_wrong_numpy_shape(self, array):
-        if array.shape == (4, 4):
-            return
+        assume(array.shape != (4, 4))
         with pytest.raises(Exception):
             grid.transform(array)
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -152,7 +152,7 @@ def test_transform_errors(grid):
 
 @settings(max_examples=8)
 @given(axis_amounts=n_numbers(3))
-def test_translate(axis_amounts, grid):
+def test_translate_should_translate_grid(axis_amounts, grid):
     grid_copy = grid.copy()
     grid_copy.translate(axis_amounts)
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,3 +1,5 @@
+from hypothesis import given, settings
+from hypothesis.strategies import integers, floats, one_of
 import numpy as np
 import pytest
 import vtk
@@ -148,10 +150,12 @@ def test_translate(grid):
     assert np.allclose(grid_copy.points, grid_points)
 
 
-def test_rotate_x(grid):
-    angle = 30
+@settings(max_examples=20)
+@given(angle=one_of(floats(allow_infinity=False, allow_nan=False), integers()))
+@pytest.mark.parametrize('axis', ('x', 'y', 'z'))
+def test_rotate(angle, axis, grid):
     trans = vtk.vtkTransform()
-    trans.RotateX(angle)
+    getattr(trans, 'Rotate{}'.format(axis.upper()))(angle)
     trans.Update()
 
     trans_filter = vtk.vtkTransformFilter()
@@ -161,41 +165,7 @@ def test_rotate_x(grid):
     grid_a = pyvista.UnstructuredGrid(trans_filter.GetOutput())
 
     grid_b = grid.copy()
-    grid_b.rotate_x(angle)
-    assert np.allclose(grid_a.points, grid_b.points)
-
-
-def test_rotate_y(grid):
-    angle = 30
-    trans = vtk.vtkTransform()
-    trans.RotateY(angle)
-    trans.Update()
-
-    trans_filter = vtk.vtkTransformFilter()
-    trans_filter.SetTransform(trans)
-    trans_filter.SetInputData(grid)
-    trans_filter.Update()
-    grid_a = pyvista.UnstructuredGrid(trans_filter.GetOutput())
-
-    grid_b = grid.copy()
-    grid_b.rotate_y(angle)
-    assert np.allclose(grid_a.points, grid_b.points)
-
-
-def test_rotate_z(grid):
-    angle = 30
-    trans = vtk.vtkTransform()
-    trans.RotateZ(angle)
-    trans.Update()
-
-    trans_filter = vtk.vtkTransformFilter()
-    trans_filter.SetTransform(trans)
-    trans_filter.SetInputData(grid)
-    trans_filter.Update()
-    grid_a = pyvista.UnstructuredGrid(trans_filter.GetOutput())
-
-    grid_b = grid.copy()
-    grid_b.rotate_z(angle)
+    getattr(grid_b, 'rotate_{}'.format(axis))(angle)
     assert np.allclose(grid_a.points, grid_b.points)
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -161,23 +161,24 @@ class TestTranslate:
         assert np.allclose(grid_copy.points, grid_points)
 
 
-@settings(max_examples=50)
-@given(angle=one_of(floats(), integers()))
-@pytest.mark.parametrize('axis', ('x', 'y', 'z'))
-def test_rotate_should_match_vtk_rotation(angle, axis, grid):
-    trans = vtk.vtkTransform()
-    getattr(trans, 'Rotate{}'.format(axis.upper()))(angle)
-    trans.Update()
+class TestRotate:
+    @settings(max_examples=50)
+    @given(angle=one_of(floats(), integers()))
+    @pytest.mark.parametrize('axis', ('x', 'y', 'z'))
+    def test_should_match_vtk_rotation(angle, axis, grid):
+        trans = vtk.vtkTransform()
+        getattr(trans, 'Rotate{}'.format(axis.upper()))(angle)
+        trans.Update()
 
-    trans_filter = vtk.vtkTransformFilter()
-    trans_filter.SetTransform(trans)
-    trans_filter.SetInputData(grid)
-    trans_filter.Update()
-    grid_a = pyvista.UnstructuredGrid(trans_filter.GetOutput())
+        trans_filter = vtk.vtkTransformFilter()
+        trans_filter.SetTransform(trans)
+        trans_filter.SetInputData(grid)
+        trans_filter.Update()
+        grid_a = pyvista.UnstructuredGrid(trans_filter.GetOutput())
 
-    grid_b = grid.copy()
-    getattr(grid_b, 'rotate_{}'.format(axis))(angle)
-    assert np.allclose(grid_a.points, grid_b.points)
+        grid_b = grid.copy()
+        getattr(grid_b, 'rotate_{}'.format(axis))(angle)
+        assert np.allclose(grid_a.points, grid_b.points)
 
 
 def test_make_points_double(grid):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -160,8 +160,8 @@ def test_translate_should_translate_grid(axis_amounts, grid):
     assert np.allclose(grid_copy.points, grid_points)
 
 
-@settings(max_examples=5)
-@given(angle=one_of(floats(allow_infinity=False, allow_nan=False), integers()))
+@settings(max_examples=50)
+@given(angle=one_of(floats(), integers()))
 @pytest.mark.parametrize('axis', ('x', 'y', 'z'))
 def test_rotate_should_match_vtk_rotation(angle, axis, grid):
     trans = vtk.vtkTransform()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -142,7 +142,7 @@ class TestTransform:
         assert np.allclose(grid_a.points, grid_b.points)
         assert np.allclose(grid_a.points, grid_c.points)
 
-    def test_transform_errors(self, grid):
+    def test_should_fail_if_given_none(self, grid):
         with pytest.raises(TypeError):
             grid.transform(None)
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,4 +1,4 @@
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis.extra.numpy import arrays, array_shapes
 from hypothesis.strategies import composite, integers, floats, one_of
 import numpy as np

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -125,32 +125,33 @@ def test_copy(grid):
     assert np.all(grid_copy_shallow.points[0] == grid.points[0])
 
 
-class TestTransform:
-    @given(rotate_amounts=n_numbers(3), translate_amounts=n_numbers(3))
-    def test_should_match_vtk_transformation(self, rotate_amounts, translate_amounts, grid):
-        trans = vtk.vtkTransform()
-        trans.RotateWXYZ(0, *rotate_amounts)
-        trans.Translate(translate_amounts)
-        trans.Update()
+@given(rotate_amounts=n_numbers(3), translate_amounts=n_numbers(3))
+def test_translate_should_match_vtk_transformation(rotate_amounts, translate_amounts, grid):
+    trans = vtk.vtkTransform()
+    trans.RotateWXYZ(0, *rotate_amounts)
+    trans.Translate(translate_amounts)
+    trans.Update()
 
-        grid_a = grid.copy()
-        grid_b = grid.copy()
-        grid_c = grid.copy()
-        grid_a.transform(trans)
-        grid_b.transform(trans.GetMatrix())
-        grid_c.transform(pyvista.trans_from_matrix(trans.GetMatrix()))
-        assert np.allclose(grid_a.points, grid_b.points, equal_nan=True)
-        assert np.allclose(grid_a.points, grid_c.points, equal_nan=True)
+    grid_a = grid.copy()
+    grid_b = grid.copy()
+    grid_c = grid.copy()
+    grid_a.transform(trans)
+    grid_b.transform(trans.GetMatrix())
+    grid_c.transform(pyvista.trans_from_matrix(trans.GetMatrix()))
+    assert np.allclose(grid_a.points, grid_b.points, equal_nan=True)
+    assert np.allclose(grid_a.points, grid_c.points, equal_nan=True)
 
-    def test_should_fail_if_given_none(self, grid):
-        with pytest.raises(TypeError):
-            grid.transform(None)
 
-    @given(array=arrays(dtype=np.float32, shape=array_shapes(max_dims=5, max_side=5)))
-    def test_should_fail_if_given_wrong_numpy_shape(self, array):
-        assume(array.shape != (4, 4))
-        with pytest.raises(Exception):
-            grid.transform(array)
+def test_translate_should_fail_given_none(grid):
+    with pytest.raises(TypeError):
+        grid.transform(None)
+
+
+@given(array=arrays(dtype=np.float32, shape=array_shapes(max_dims=5, max_side=5)))
+def test_transform_should_fail_given_wrong_numpy_shape(array):
+    assume(array.shape != (4, 4))
+    with pytest.raises(Exception):
+        grid.transform(array)
 
 
 @pytest.mark.parametrize('axis_amounts', [[1, 1, 1], [0, 0, 0], [-1, -1, -1]])
@@ -162,23 +163,22 @@ def test_translate_should_translate_grid(grid, axis_amounts):
     assert np.allclose(grid_copy.points, grid_points)
 
 
-class TestRotate:
-    @given(angle=one_of(floats(allow_infinity=False, allow_nan=False), integers()))
-    @pytest.mark.parametrize('axis', ('x', 'y', 'z'))
-    def test_should_match_vtk_rotation(self, angle, axis, grid):
-        trans = vtk.vtkTransform()
-        getattr(trans, 'Rotate{}'.format(axis.upper()))(angle)
-        trans.Update()
+@given(angle=one_of(floats(allow_infinity=False, allow_nan=False), integers()))
+@pytest.mark.parametrize('axis', ('x', 'y', 'z'))
+def test_rotate_should_match_vtk_rotation(angle, axis, grid):
+    trans = vtk.vtkTransform()
+    getattr(trans, 'Rotate{}'.format(axis.upper()))(angle)
+    trans.Update()
 
-        trans_filter = vtk.vtkTransformFilter()
-        trans_filter.SetTransform(trans)
-        trans_filter.SetInputData(grid)
-        trans_filter.Update()
-        grid_a = pyvista.UnstructuredGrid(trans_filter.GetOutput())
+    trans_filter = vtk.vtkTransformFilter()
+    trans_filter.SetTransform(trans)
+    trans_filter.SetInputData(grid)
+    trans_filter.Update()
+    grid_a = pyvista.UnstructuredGrid(trans_filter.GetOutput())
 
-        grid_b = grid.copy()
-        getattr(grid_b, 'rotate_{}'.format(axis))(angle)
-        assert np.allclose(grid_a.points, grid_b.points, equal_nan=True)
+    grid_b = grid.copy()
+    getattr(grid_b, 'rotate_{}'.format(axis))(angle)
+    assert np.allclose(grid_a.points, grid_b.points, equal_nan=True)
 
 
 def test_make_points_double(grid):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -150,7 +150,7 @@ def test_transform_errors(grid):
         grid.transform(np.array([1]))
 
 
-@settings(max_examples=8)
+@settings(max_examples=20)
 @given(axis_amounts=n_numbers(3))
 def test_translate_should_translate_grid(axis_amounts, grid):
     grid_copy = grid.copy()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -19,7 +19,7 @@ def grid():
 def n_numbers(draw, n):
     numbers = []
     for _ in range(n):
-        number = draw(one_of(floats(allow_infinity=False, allow_nan=False), integers()))
+        number = draw(one_of(floats(), integers()))
         numbers.append(number)
     return numbers
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -179,7 +179,7 @@ class TestRotate:
 
         grid_b = grid.copy()
         getattr(grid_b, 'rotate_{}'.format(axis))(angle)
-        assert np.allclose(grid_a.points, grid_b.points)
+        assert np.allclose(grid_a.points, grid_b.points, equal_nan=True)
 
 
 def test_make_points_double(grid):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -153,14 +153,13 @@ class TestTransform:
             grid.transform(array)
 
 
-class TestTranslate:
-    @given(axis_amounts=n_numbers(3))
-    def test_should_translate_grid(self, axis_amounts, grid):
-        grid_copy = grid.copy()
-        grid_copy.translate(axis_amounts)
+@pytest.mark.parametrize('axis_amounts', [[1, 1, 1], [0, 0, 0], [-1, -1, -1]])
+def test_translate_should_translate_grid(grid, axis_amounts):
+    grid_copy = grid.copy()
+    grid_copy.translate(axis_amounts)
 
-        grid_points = grid.points.copy() + np.array(axis_amounts)
-        assert np.allclose(grid_copy.points, grid_points)
+    grid_points = grid.points.copy() + np.array(axis_amounts)
+    assert np.allclose(grid_copy.points, grid_points)
 
 
 class TestRotate:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -124,12 +124,12 @@ def test_copy(grid):
     assert np.all(grid_copy_shallow.points[0] == grid.points[0])
 
 
-def test_transform(grid):
+@settings(max_examples=10)
+@given(rotate_amounts=n_numbers(3), translate_amounts=n_numbers(3))
+def test_transform_should_match_vtk(rotate_amounts, translate_amounts, grid):
     trans = vtk.vtkTransform()
-    trans.RotateX(30)
-    trans.RotateY(30)
-    trans.RotateZ(30)
-    trans.Translate(1, 1, 2)
+    trans.RotateWXYZ(0, *rotate_amounts)
+    trans.Translate(translate_amounts)
     trans.Update()
 
     grid_a = grid.copy()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -163,7 +163,7 @@ def test_translate_should_translate_grid(grid, axis_amounts):
 
 
 class TestRotate:
-    @given(angle=one_of(floats(), integers()))
+    @given(angle=one_of(floats(allow_infinity=False, allow_nan=False), integers()))
     @pytest.mark.parametrize('axis', ('x', 'y', 'z'))
     def test_should_match_vtk_rotation(self, angle, axis, grid):
         trans = vtk.vtkTransform()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -150,7 +150,7 @@ def test_translate(grid):
     assert np.allclose(grid_copy.points, grid_points)
 
 
-@settings(max_examples=20)
+@settings(max_examples=5)
 @given(angle=one_of(floats(allow_infinity=False, allow_nan=False), integers()))
 @pytest.mark.parametrize('axis', ('x', 'y', 'z'))
 def test_rotate(angle, axis, grid):


### PR DESCRIPTION
### Overview

This breaks up transforms related tests in test_common.py, specifically Common.transform(), rotate(), translate(). They are now separate tests, grouped and renamed to what is expected to happen. This also introduces [Hypothesis](https://hypothesis.readthedocs.io/en/latest/) to the testing requirements.

There are now failed tests which reveal possible "issues" that I'd like to discuss.

- If Common.transform is given values of nan or inf it will not have the same result as vtk

- Same for rotate

- Common.translate cannot handle addition of very large integers, likely overflow, specifically for example (+/-)9223372036854775809, which is just over size of long long.
