### PR TITLE
Add all depends to Report

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,6 @@ dependencies:
   - pytest-cov
   - pytest-qt
   - codecov
-  - appdirs
   - pip
   - pip:
       - pytest-memprof

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -221,11 +221,12 @@ class Report(scooby.Report):
 
         """
         # Mandatory packages.
-        core = ['pyvista', 'vtk', 'numpy', 'imageio', 'appdirs', 'scooby']
+        core = ['pyvista', 'vtk', 'numpy', 'imageio', 'appdirs', 'scooby',
+                'meshio']
 
         # Optional packages.
         optional = ['matplotlib', 'PyQt5', 'IPython', 'colorcet',
-                    'cmocean', 'panel', 'scipy']
+                    'cmocean', 'panel', 'scipy', 'itkwidgets', 'tqdm']
 
         # Information about the GPU - bare except in case there is a rendering
         # bug that the user is trying to report.


### PR DESCRIPTION
There was a duplicate listing in the conda env file, not all optional dependencies were being reported by `pyvista.Report()`, and core depend `meshio` wasn't reported at all
