### PR TITLE
WIP: Fix for VTK9

### DIFF
--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -433,7 +433,11 @@ class QtInteractor(QVTKRenderWindowInteractorAdapter, BasePlotter):
         if off_screen:
             self.ren_win.SetOffScreenRendering(1)
         else:
-            self.iren = self.ren_win.GetInteractor()
+            # On VTK 9 the existing interactor is a
+            # vtkGenericRenderWindowInteractor, which just hangs when you call
+            # Initialize, so create our own instead
+            self.iren = vtk.vtkRenderWindowInteractor()
+            self.ren_win.SetInteractor(self.iren)
             self.iren.RemoveObservers('MouseMoveEvent')  # slows window update?
 
             # Enter trackball camera mode


### PR DESCRIPTION
On VTK 9 this:

```py
import pyvista as pv
cyl = pv.Cylinder()
p = pv.BackgroundPlotter(shape=(3, 3))
p.subplot(0, 0)
p.add_mesh(cyl, color="tan", show_edges=True)
```
Just freezes on the line:
```py
            self.iren.Initialize()
```
It seems to be because the existing interactor is a vtkGenericRenderWindowInteractor. If I replace it with a vtkRenderWindowInteractor, things at least work somewhat -- the window opens, but the plot doesn't update when interacting with it. So there will probably need to be other fixes in addition to or instead of this one, but I at least wanted to get the ball rolling on these fixes.

----

Relevant to #562 