### PR TITLE
Add trunk based development link and MISC CI fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,8 +124,8 @@ Please also take a look at our [Code of Conduct](https://github.com/pyvista/pyvi
 
 ### Contributing to pyvista through GitHub
 
-To submit new code to pyvista, first fork the (pyvista GitHub
-Repo)[https://github.com/pyvista/pyvista] and then clone the forked
+To submit new code to pyvista, first fork the [pyvista GitHub
+Repo](https://github.com/pyvista/pyvista) and then clone the forked
 repository to your computer.  Then, create a new branch based on the
 [Branch Naming Conventions Section](#branch-naming-conventions) in
 your local repository.
@@ -223,7 +223,7 @@ The finished documentation can be found in the `docs/_build/html` directory.
 #### Creating a New Pull Request
 
 Once you have tested your branch locally, create a pull request on
-(pyvista GitHub)[https://github.com/pyvista/pyvista] while merging to
+[pyvista GitHub](https://github.com/pyvista/pyvista) while merging to
 master.  This will automatically run continuous integration (CI)
 testing and verify your changes will work across several platforms.
 
@@ -242,8 +242,8 @@ is a `fix/` branch.
 ### Branching Model
 
 This project has a branching model that enables rapid development of
-features without sacrificing stability, and closely follows the (Trunk
-Based Development)[https://trunkbaseddevelopment.com/] approach.
+features without sacrificing stability, and closely follows the [Trunk
+Based Development](https://trunkbaseddevelopment.com/) approach.
 
 The main features of our branching model are:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,8 +242,8 @@ is a `fix/` branch.
 ### Branching Model
 
 This project has a branching model that enables rapid development of
-features without sacrificing stability, and closely follows the [Trunk
-Based Development](https://trunkbaseddevelopment.com/) approach.
+features without sacrificing stability, and closely follows the 
+[Trunk Based Development](https://trunkbaseddevelopment.com/) approach.
 
 The main features of our branching model are:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,9 +242,10 @@ is a `fix/` branch.
 ### Branching Model
 
 This project has a branching model that enables rapid development of
-features without sacrificing stability.  The main features of our
-branching model are:
+features without sacrificing stability, and closely follows the (Trunk
+Based Development)[https://trunkbaseddevelopment.com/] approach.
 
+The main features of our branching model are:
 
 - The `master` branch is the main development branch.  All features,
   patches, and other branches should be merged here.  While all PRs

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Simple makefile to simplify repetitive build env management tasks under posix
 
-CODESPELL_DIRS ?= pyvista/ examples/ tests/ ./
+CODESPELL_DIRS ?= ./
 CODESPELL_SKIP ?= "*.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,./docs/_build/*,./docs/images/*,./dist/*"
 CODESPELL_IGNORE ?= "ignore_words.txt"
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Simple makefile to simplify repetitive build env management tasks under posix
 
-CODESPELL_DIRS ?= pyvista/ examples/ tests/
-CODESPELL_SKIP ?= "*.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*"
+CODESPELL_DIRS ?= pyvista/ examples/ tests/ ./
+CODESPELL_SKIP ?= "*.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,./docs/_build/*,./docs/images/*,./dist/*"
 CODESPELL_IGNORE ?= "ignore_words.txt"
 
 all: doctest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,7 +166,7 @@ jobs:
         conda activate pyvista-vtk$(VTK.VERSION)
         pytest -v --doctest-modules pyvista
       displayName: 'Test Package Docstrings against VTK'
-
+  condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))
 
 # DESCRIPTION: Core API testing for Windows
 - job: Windows


### PR DESCRIPTION
CI fixes:
- Mentions the [Trunk Based Development](https://trunkbaseddevelopment.com/) in our branching model.
- Removes Conda builds from CI
- Includes root directory for `codespell`, thereby checking our `README` and `CONTRIBUTING`
- Fixes a handful of invalid markdown html links in `CONTRIBUTING`