### PR TITLE
FIX: Fix for VTK9 + PyQt5 5.13.2

### DIFF
--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -1,9 +1,7 @@
 """Qt interactive plotter."""
-from distutils.version import LooseVersion
 import logging
 import os
 import platform
-import sys
 import time
 import warnings
 from functools import wraps

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -21,9 +21,10 @@ from .theme import rcParams
 # for display bugs due to older intel integrated GPUs
 vtk_major_version = vtk.vtkVersion.GetVTKMajorVersion()
 vtk_minor_version = vtk.vtkVersion.GetVTKMinorVersion()
+vtk_base_widget = 'QGLWidget'
 if vtk_major_version == 8 and vtk_minor_version < 2:
     import vtk.qt
-    vtk.qt.QVTKRWIBase = 'QGLWidget'
+    vtk.qt.QVTKRWIBase = vtk_base_widget
 else:
     import vtkmodules.qt
     if sys.platform == 'linux' and vtk_major_version >= 9:
@@ -31,12 +32,12 @@ else:
         try:
             from PyQt5.QtCore import QT_VERSION_STR
         except ImportError:
-            vtkmodules.qt.QVTKRWIBase = 'QGLWidget'
+            pass
         else:
-            if LooseVersion(QT_VERSION_STR) < LooseVersion('5.14'):
-                vtkmodules.qt.QVTKRWIBase = 'QWidget'
-            else:
-                vtkmodules.qt.QVTKRWIBase = 'QGLWidget'
+            if LooseVersion(QT_VERSION_STR) < LooseVersion('5.14.2'):
+                vtk_base_widget = 'QWidget'
+    vtkmodules.qt.QVTKRWIBase = vtk_base_widget
+del vtk_base_widget
 
 log = logging.getLogger(__name__)
 log.setLevel('DEBUG')

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -21,22 +21,22 @@ from .theme import rcParams
 # for display bugs due to older intel integrated GPUs
 vtk_major_version = vtk.vtkVersion.GetVTKMajorVersion()
 vtk_minor_version = vtk.vtkVersion.GetVTKMinorVersion()
-use_base = 'QGLWidget'
 if vtk_major_version == 8 and vtk_minor_version < 2:
     import vtk.qt
-    vtk.qt.QVTKRWIBase = use_base
+    vtk.qt.QVTKRWIBase = 'QGLWidget'
 else:
-    # Qt 5.13.2 + VTK 9 ends up with GenericWindowInteractor on Linux
-    if sys.platform == 'linux':
+    import vtkmodules.qt
+    if sys.platform == 'linux' and vtk_major_version >= 9:
+        # Qt 5.13.2 + VTK 9 ends up with GenericWindowInteractor on Linux
         try:
             from PyQt5.QtCore import QT_VERSION_STR
         except ImportError:
-            pass
+            vtkmodules.qt.QVTKRWIBase = 'QGLWidget'
         else:
             if LooseVersion(QT_VERSION_STR) < LooseVersion('5.14'):
-                use_base = 'QWidget'
-    import vtkmodules.qt
-    vtkmodules.qt.QVTKRWIBase = use_base
+                vtkmodules.qt.QVTKRWIBase = 'QWidget'
+            else:
+                vtkmodules.qt.QVTKRWIBase = 'QGLWidget'
 
 log = logging.getLogger(__name__)
 log.setLevel('DEBUG')

--- a/pyvista/plotting/qt_plotting.py
+++ b/pyvista/plotting/qt_plotting.py
@@ -18,26 +18,11 @@ import scooby
 from .plotting import BasePlotter
 from .theme import rcParams
 
-# for display bugs due to older intel integrated GPUs
-vtk_major_version = vtk.vtkVersion.GetVTKMajorVersion()
-vtk_minor_version = vtk.vtkVersion.GetVTKMinorVersion()
-vtk_base_widget = 'QGLWidget'
-if vtk_major_version == 8 and vtk_minor_version < 2:
-    import vtk.qt
-    vtk.qt.QVTKRWIBase = vtk_base_widget
-else:
-    import vtkmodules.qt
-    if sys.platform == 'linux' and vtk_major_version >= 9:
-        # Qt 5.13.2 + VTK 9 ends up with GenericWindowInteractor on Linux
-        try:
-            from PyQt5.QtCore import QT_VERSION_STR
-        except ImportError:
-            pass
-        else:
-            if LooseVersion(QT_VERSION_STR) < LooseVersion('5.14.2'):
-                vtk_base_widget = 'QWidget'
-    vtkmodules.qt.QVTKRWIBase = vtk_base_widget
-del vtk_base_widget
+# for display bugs due to older intel integrated GPUs, setting
+# vtkmodules.qt.QVTKRWIBase = 'QGLWidget' could help. However, its use
+# is discouraged and does not work well on VTK9+, so let's not bother
+# changing it from the default 'QWidget'.
+# See https://github.com/pyvista/pyvista/pull/693
 
 log = logging.getLogger(__name__)
 log.setLevel('DEBUG')


### PR DESCRIPTION
On PyQt 5.13.2 I was getting a VTKGenericWindowInteractor instead of the Qt variant only when using PyVista (Mayavi was fine). After some investigation, it seems that setting the `QVTKRWIBase` was the culprit -- leaving it as the default `QWidget` makes things work again.

This PR makes it so that if you are on VTK9+, Linux, and PyQt < 5.14, it will use `QWidget` instead of `QGLWidget`. This makes things work with both PyQt5 5.13.2 and 5.14.2 for me.

cc @GuillaumeFavelier 