### PR TITLE
custom orientation widget

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -321,6 +321,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.renderer.set_viewup(*args, **kwargs)
         self.render()
 
+    @wraps(Renderer.add_orientation_widget)
+    def add_orientation_widget(self, *args, **kwargs):
+        """Wrap ``Renderer.add_orientation_widget``."""
+        return self.renderer.add_orientation_widget(*args, **kwargs)
+
     @wraps(Renderer.add_axes)
     def add_axes(self, *args, **kwargs):
         """Wrap ``Renderer.add_axes``."""

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -427,8 +427,11 @@ class Renderer(vtkRenderer):
         return self.marker_actor
 
 
-    def add_orientation_widget(self, actor, interactive=None, color=None, opacity=1.0):
+    def add_orientation_widget(self, actor, interactive=None, color=None,
+                               opacity=1.0):
         """Use the given actor in an orienntation marker widget.
+
+        Color and opacity are only valid arguments if a mesh is passed.
 
         Parameters
         ----------
@@ -442,17 +445,17 @@ class Renderer(vtkRenderer):
             Opacity of the marker.
 
         """
-        if not isinstance(actor, vtk.vtkActor):
+        if isinstance(actor, pyvista.Common):
             mapper = vtk.vtkDataSetMapper()
             mesh = actor.copy()
             mesh.clear_arrays()
             mapper.SetInputData(mesh)
             actor = vtk.vtkActor()
             actor.SetMapper(mapper)
-        prop = actor.GetProperty()
-        if color is not None:
-            prop.SetColor(parse_color(color))
-        prop.SetOpacity(opacity)
+            prop = actor.GetProperty()
+            if color is not None:
+                prop.SetColor(parse_color(color))
+            prop.SetOpacity(opacity)
         if hasattr(self, 'axes_widget'):
             # Delete the old one
             self.axes_widget.EnabledOff()
@@ -474,7 +477,7 @@ class Renderer(vtkRenderer):
     def add_axes(self, interactive=None, line_width=2,
                  color=None, x_color=None, y_color=None, z_color=None,
                  xlabel='X', ylabel='Y', zlabel='Z', labels_off=False,
-                 box=None, box_args=None, opacity=1.0):
+                 box=None, box_args=None):
         """Add an interactive axes widget in the bottom left corner.
 
         Parameters
@@ -495,9 +498,9 @@ class Renderer(vtkRenderer):
         if interactive is None:
             interactive = rcParams['interactive']
         if hasattr(self, 'axes_widget'):
-            self.axes_widget.SetInteractive(interactive)
-            update_axes_label_color(color)
-            return
+            self.axes_widget.EnabledOff()
+            self.Modified()
+            del self.axes_widget
         if box is None:
             box = rcParams['axes']['box']
         if box:
@@ -514,7 +517,7 @@ class Renderer(vtkRenderer):
                 x_color=x_color, y_color=y_color, z_color=z_color,
                 xlabel=xlabel, ylabel=ylabel, zlabel=zlabel, labels_off=labels_off)
         self.add_orientation_widget(self.axes_actor, interactive=interactive,
-                                    color=None, opacity=opacity)
+                                    color=None)
         return self.axes_actor
 
 

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -429,7 +429,7 @@ class Renderer(vtkRenderer):
 
     def add_orientation_widget(self, actor, interactive=None, color=None,
                                opacity=1.0):
-        """Use the given actor in an orienntation marker widget.
+        """Use the given actor in an orientation marker widget.
 
         Color and opacity are only valid arguments if a mesh is passed.
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -391,6 +391,10 @@ def test_axes():
     plotter.add_axes()
     plotter.add_mesh(pyvista.Sphere())
     plotter.show()
+    plotter = pyvista.Plotter(off_screen=True)
+    plotter.add_orientation_widget(pyvista.Cube())
+    plotter.add_mesh(pyvista.Cube())
+    plotter.show()
 
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")


### PR DESCRIPTION
### Overview

Abstracted how we add orientation markers to easily pass a custom mesh/actor as the marker for the widget

```py
import pyvista as pv
from pyvista import examples

mesh = examples.download_st_helens().warp_by_scalar()

p = pv.Plotter(notebook=False)
p.add_mesh(mesh)
p.add_orientation_widget(mesh, color="grey")
p.show()
```

![2020-04-27 21 30 53](https://user-images.githubusercontent.com/22067021/80436964-65284580-88ce-11ea-86bc-dc67e1db784a.gif)

## Details

- current implementation forces the actor to be a solid color (can add opacity)
- changed the `add_axes` method to enable it to replace custom actors if called after adding a custom actor
- this means there can only ever be one axes widget - we could enable more down the road but placement will get tricky and I don't have the time to implement a placement scheme.