### PR TITLE
Fix slider widget normalization to work with different sized viewports

### DIFF
--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -758,11 +758,11 @@ class WidgetHelper(object):
         if color is None:
             color = rcParams['font']['color']
 
-        def normalize(point, shape):
-            return (point[0] / shape[1], point[1] / shape[0])
+        def normalize(point, viewport):
+            return (point[0]*(viewport[2]-viewport[0]),point[1]*(viewport[3]-viewport[1]))
 
-        pointa = normalize(pointa, self.shape)
-        pointb = normalize(pointb, self.shape)
+        pointa = normalize(pointa, self.renderer.GetViewport())
+        pointb = normalize(pointb, self.renderer.GetViewport())
 
         slider_rep = vtk.vtkSliderRepresentation2D()
         slider_rep.SetPickable(False)


### PR DESCRIPTION
### Overview

Slider widget can now be added to arbitrary sized viewports (not limited to layouts created through the 2D shape grid).

Follow up of #549 to close #513 

### Details

- In combination with #696 the following is now possible (based on the example from #549):
```py
import pyvista as pv

shape = (3, 4)
row_w = [1,1.5,2]
col_w = [1,1.5,2,2.5]
groups = [
    ([0,1],[1,2]),
    ([1,2],0)
]
pointa = (0.2, 0.5)
pointb = (0.8, 0.5)

p = pv.Plotter(shape=shape,groups=groups,row_weights=row_w,col_weights=col_w)

for i in range(shape[0]):
    for j in range(shape[1]):
        group = p.loc_to_group((i,j))
        # Only draw on individual cells or on the first cell of the group (to prevent duplicates)
        if group is None or (p.groups[group,0]==i and p.groups[group,1]==j):
            p.subplot(i, j)
            p.add_mesh(pv.Sphere())
            p.add_slider_widget(
                callback=lambda value: value,
                rng=[0, 1],
                pointa=pointa,
                pointb=pointb,
            )

p.show()
```

![slider_fix](https://user-images.githubusercontent.com/15089458/80812143-a323b300-8bc7-11ea-8257-31a0d762c6c8.png)
