### PR TITLE
Bump minor release to 0.24.2

### DIFF
--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -1,6 +1,6 @@
 """Version info for pyvista."""
 # major, minor, patch
-version_info = 0, 24, 1
+version_info = 0, 24, 2
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
This PR bumps our `release/0.24` branch to 0.24.2.  This is needed due as the `faulthandler` is still causing problems.  See https://github.com/akaszynski/pyansys/issues/209

I've cherry picked 85a9c3e38c492c23f132f8f1f47868c7c79ad045 and pushed it to the branch.  Once this PR is merged, I'll create a tag for 0.24.2

As stated earlier [Trunk Based Development](https://trunkbaseddevelopment.com/) is really the way to go for these release branches and I'm already seeing the advantages as we don't need additional testing for this patch release. 