### PR TITLE
Improve _make_vertice_cells performance

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -182,10 +182,9 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
 
     @staticmethod
     def _make_vertice_cells(npoints):
-        cells = np.hstack((np.ones((npoints, 1)),
-                           np.arange(npoints).reshape(-1, 1)))
-        cells = np.ascontiguousarray(cells, dtype=pyvista.ID_TYPE)
-        cells = np.reshape(cells, (2*npoints))
+        cells = np.empty((npoints, 2), dtype=pyvista.ID_TYPE)
+        cells[:, 0] = 1
+        cells[:, 1] = np.arange(npoints, dtype=pyvista.ID_TYPE)
         return cells
 
     def _load_file(self, filename):

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -126,12 +126,12 @@ def test_init_as_points():
 
     vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]])
     cells = np.array([1, 0, 1, 1, 1, 2], np.int16)
-    to_check = pyvista.PolyData._make_vertice_cells(len(vertices))
+    to_check = pyvista.PolyData._make_vertice_cells(len(vertices)).ravel()
     assert np.allclose(to_check, cells)
 
     # from list
     mesh.verts = [[1, 0], [1, 1], [1, 2]]
-    to_check = pyvista.PolyData._make_vertice_cells(len(vertices))
+    to_check = pyvista.PolyData._make_vertice_cells(len(vertices)).ravel()
     assert np.allclose(to_check, cells)
 
     mesh = pyvista.PolyData()


### PR DESCRIPTION
## Improve `_make_vertice_cells` Performance
As noted in https://github.com/pyvista/pyvista/issues/712, the performance of creating a polydata directly from points is quite slow.  This PR improves it.

closes #712 

Here's the timing improvement:
```python
import numpy as np
import pyvista as pv

pts = np.random.random((100000, 3))
timeit pv.PolyData(pts)
```

#### Master
```
56.9 ms ± 773 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

#### This PR
```
272 µs ± 6.22 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```