### PR TITLE
Allow List as PolyData input

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -148,8 +148,13 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
                     self.shallow_copy(args[0])
             elif isinstance(args[0], str):
                 self._load_file(args[0])
-            elif isinstance(args[0], np.ndarray):
-                points = args[0]
+            elif isinstance(args[0], (np.ndarray, list)):
+                if isinstance(args[0], list):
+                    points = np.asarray(args[0])
+                    if not np.issubdtype(points.dtype, np.number):
+                        raise TypeError('Points must be a numeric type')
+                else:
+                    points = args[0]
                 if points.ndim != 2:
                     points = points.reshape((-1, 3))
                 cells = self._make_vertice_cells(points.shape[0])

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -141,6 +141,13 @@ def test_init_as_points():
     assert mesh.n_cells == vertices.shape[0]
     assert np.allclose(mesh.verts, cells)
 
+def test_init_as_points_from_list():
+    points = [[0, 0, 0],
+              [0, 1, 0],
+              [0, 0, 1]]
+    mesh = pyvista.PolyData(points)
+    assert np.allclose(mesh.points, points)
+
 
 def test_invalid_init():
     with pytest.raises(ValueError):


### PR DESCRIPTION
### Allow List as PolyData Point Input
Discovered that this is invalid:
```python
import pyvista
points = [[0, 0, 0],
          [0, 1, 0],
          [0, 0, 1]]
mesh = pyvista.PolyData(points)
```
```
TypeError: Invalid input type
```

This simple PR fixes that by allowing for a list of points to be input.  Includes test and data type checks.
