### PR TITLE
xfail on flaky mac tests

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,6 +1,8 @@
+import platform
+import sys
+
 import numpy as np
 import pytest
-import sys
 
 import pyvista
 from pyvista import examples
@@ -25,6 +27,8 @@ normals = ['x', 'y', '-z', (1,1,1), (3.3, 5.4, 0.8)]
 COMPOSITE = pyvista.MultiBlock(DATASETS, deep=True)
 
 
+# allow certain flaky MacOS tests to fail
+mac_xfail = pytest.mark.xfail(platform.system() == 'Darwin')
 
 
 def test_clip_filter():
@@ -513,8 +517,9 @@ def test_resample():
     assert isinstance(result, type(mesh))
 
 
+@mac_xfail
 def test_streamlines():
-    mesh = examples.download_carotid()
+    mesh = examples.download_carotid()  # flaky on mac os
     stream, src = mesh.streamlines(return_source=True, max_time=100.0,
                                    initial_step_length=2., terminal_speed=0.1,
                                    n_points=25, source_radius=2.0,
@@ -593,6 +598,7 @@ def test_slice_along_line_composite():
     assert output.n_blocks == COMPOSITE.n_blocks
 
 
+@mac_xfail
 def test_interpolate():
     surface = examples.download_saddle_surface()
     points = examples.download_sparse_points()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -28,7 +28,8 @@ COMPOSITE = pyvista.MultiBlock(DATASETS, deep=True)
 
 
 # allow certain flaky MacOS tests to fail
-mac_xfail = pytest.mark.xfail(platform.system() == 'Darwin')
+mac_xfail = pytest.mark.xfail(platform.system() == 'Darwin',
+                              reason='Mac OS is flaky on download examples')
 
 
 def test_clip_filter():
@@ -519,7 +520,7 @@ def test_resample():
 
 @mac_xfail
 def test_streamlines():
-    mesh = examples.download_carotid()  # flaky on mac os
+    mesh = examples.download_carotid()
     stream, src = mesh.streamlines(return_source=True, max_time=100.0,
                                    initial_step_length=2., terminal_speed=0.1,
                                    n_points=25, source_radius=2.0,


### PR DESCRIPTION
### Allow xfail on flaky macOS tests
Both `test_streamlines` and `test_interpolate` sometimes fail on Mac OS on the download examples steps.  It's hit or miss, but when your PR is solid and you have to restart the Mac OS test(s) it gets a little old.

As we're hitting these tests on Windows and Linux, I'm not worried about these tests not passing every time.
