### PR TITLE
Backwards compatibility for py3.5 for ModuleNotFoundError

### DIFF
--- a/examples/01-filter/distance-between-surfaces.py
+++ b/examples/01-filter/distance-between-surfaces.py
@@ -9,7 +9,7 @@ lithological layers in a subsurface geological model and you want to know the
 average thickness of a unit between those boundaries.
 
 We can compute the thickness between the two surfaces using a few different
-methods. First, wee will demo a method where we compute the normals of the
+methods. First, we will demo a method where we compute the normals of the
 bottom surface, and then project a ray to the top surface to compute the
 distance along the surface normals. Second, we will use a KDTree to compute
 the distance from eevery point in the bottom mesh to it's closest point in

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -7,6 +7,15 @@ from vtk.vtkCommonCore import vtkWeakReference
 from vtk.util.numpy_support import vtk_to_numpy
 
 try:
+    ModuleNotFoundError
+except:
+    class ModuleNotFoundError():
+        """Empty placeholder for Python3.5 backwards compatibility."""
+
+        pass
+
+
+try:
     from vtk.vtkCommonKitPython import vtkDataArray, vtkAbstractArray
 except (ModuleNotFoundError, ImportError):
     from vtk.vtkCommonCore import vtkDataArray, vtkAbstractArray


### PR DESCRIPTION
`ModuleNotFoundError` is not valid in Python3.5, yet we have it:

```python
try:
    from vtk.vtkCommonKitPython import vtkDataArray, vtkAbstractArray
except (ModuleNotFoundError, ImportError):
    from vtk.vtkCommonCore import vtkDataArray, vtkAbstractArray
```

I've added a simple backwards compatibility class.  We don't see this on the main branch as we're not testing against vtk 9.0.