### PR TITLE
Use fixed version for style packages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
     inputs:
       versionSpec: '3.7'
   - script: |
-      pip install codespell pydocstyle
+      pip install -r requirements_style.txt
       make doctest
     displayName: 'Run doctest'
 

--- a/requirements_style.txt
+++ b/requirements_style.txt
@@ -1,0 +1,2 @@
+codespell==1.16.0
+pydocstyle==5.0.2


### PR DESCRIPTION
### Use fixed version for style packages

Our code style pipeline ran into an issue where the updated version of `codespell` detected a new spelling error (`wee --> we`).  While I was glad to have found out the (embarrassing) spelling error, if this pops up again, we're going to failures on branches that have nothing to do with the new branch.

As such, I'm proposing we fix the versions of both `codespell` and `pydocstyle` and set those versions in another requirement file rather in the pipelines.  That way we can have a separate PR for spelling and docstyle changes that might crop up due to upgrading those packages.

#### New style requirements file
`requirements_style.txt`
```
codespell==1.16.0
pydocstyle==5.0.2
```
