### PR TITLE
No More Downloads for Unit Tests

### DIFF
--- a/examples/01-filter/streamlines.py
+++ b/examples/01-filter/streamlines.py
@@ -10,6 +10,7 @@ Integrate a vector field to generate streamlines.
 # by experimenting with the data.
 
 # sphinx_gallery_thumbnail_number = 3
+import numpy as np
 import pyvista as pv
 from pyvista import examples
 
@@ -88,3 +89,33 @@ p.add_mesh(kitchen, color=True)
 p.add_mesh(streamlines.tube(radius=0.01), scalars="velocity", lighting=False)
 p.camera_position = kpos
 p.show()
+
+
+###############################################################################
+# Custom 3D Vector Field
+# ++++++++++++++++++++++
+#
+
+nx = 20
+ny = 15
+nz = 5
+
+origin = (-(nx - 1)*0.1/2, -(ny - 1)*0.1/2, -(nz - 1)*0.1/2)
+mesh = pv.UniformGrid((nx, ny, nz), (.1, .1, .1), origin)
+x = mesh.points[:, 0]
+y = mesh.points[:, 1]
+z = mesh.points[:, 2]
+vectors = np.empty((mesh.n_points, 3))
+vectors[:, 0] = np.sin(np.pi * x) * np.cos(np.pi * y) * np.cos(np.pi * z)
+vectors[:, 1] = -np.cos(np.pi * x) * np.sin(np.pi * y) * np.cos(np.pi * z)
+vectors[:, 2] = (np.sqrt(3.0 / 3.0) * np.cos(np.pi * x) * np.cos(np.pi * y) *
+                 np.sin(np.pi * z))
+
+mesh['vectors'] = vectors
+###############################################################################
+stream, src = mesh.streamlines('vectors', return_source=True,
+                               terminal_speed=0.0, n_points=200,
+                               source_radius=0.1)
+###############################################################################
+cpos = [(1.2, 1.2, 1.2), (-0.0, -0.0, -0.0), (0.0, 0.0, 1.0)]
+stream.tube(radius=0.0015).plot(cpos=cpos)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,4 +1,3 @@
-import platform
 import sys
 
 import numpy as np
@@ -13,8 +12,6 @@ try:
 except:
     HAS_MATPLOTLIB = False
 
-PYTHON_2 = int(sys.version[0]) < 3
-
 DATASETS = [
     examples.load_uniform(), # UniformGrid
     examples.load_rectilinear(), # RectilinearGrid
@@ -26,10 +23,8 @@ normals = ['x', 'y', '-z', (1,1,1), (3.3, 5.4, 0.8)]
 
 COMPOSITE = pyvista.MultiBlock(DATASETS, deep=True)
 
-
-# allow certain flaky MacOS tests to fail
-mac_xfail = pytest.mark.xfail(platform.system() == 'Darwin',
-                              reason='Mac OS is flaky on download examples')
+skip_py2_nobind = pytest.mark.skipif(int(sys.version[0]) < 3,
+                                     reason="Python 2 doesn't support binding methods")
 
 
 def test_clip_filter():
@@ -43,7 +38,7 @@ def test_clip_filter():
             assert isinstance(clp, pyvista.UnstructuredGrid)
 
 
-@pytest.mark.skipif(PYTHON_2, reason="Python 2 doesn't support binding methods")
+@skip_py2_nobind
 def test_clip_filter_composite():
     # Now test composite data structures
     output = COMPOSITE.clip(normal=normals[0], invert=False)
@@ -74,7 +69,7 @@ def test_clip_box():
     assert result.n_cells
 
 
-@pytest.mark.skipif(PYTHON_2, reason="Python 2 doesn't support binding methods")
+@skip_py2_nobind
 def test_clip_box_composite():
     # Now test composite data structures
     output = COMPOSITE.clip_box(invert=False)
@@ -121,7 +116,7 @@ def test_slice_filter():
     assert result.n_points < 1
 
 
-@pytest.mark.skipif(PYTHON_2, reason="Python 2 doesn't support binding methods")
+@skip_py2_nobind
 def test_slice_filter_composite():
     # Now test composite data structures
     output = COMPOSITE.slice(normal=normals[0])
@@ -140,7 +135,7 @@ def test_slice_orthogonal_filter():
             assert isinstance(slc, pyvista.PolyData)
 
 
-@pytest.mark.skipif(PYTHON_2, reason="Python 2 doesn't support binding methods")
+@skip_py2_nobind
 def test_slice_orthogonal_filter_composite():
     # Now test composite data structures
     output = COMPOSITE.slice_orthogonal()
@@ -163,7 +158,7 @@ def test_slice_along_axis():
         dataset.slice_along_axis(axis='u')
 
 
-@pytest.mark.skipif(PYTHON_2, reason="Python 2 doesn't support binding methods")
+@skip_py2_nobind
 def test_slice_along_axis_composite():
     # Now test composite data structures
     output = COMPOSITE.slice_along_axis()
@@ -220,7 +215,7 @@ def test_outline():
         assert isinstance(outline, pyvista.PolyData)
 
 
-@pytest.mark.skipif(PYTHON_2, reason="Python 2 doesn't support binding methods")
+@skip_py2_nobind
 def test_outline_composite():
     # Now test composite data structures
     output = COMPOSITE.outline()
@@ -236,7 +231,7 @@ def test_outline_corners():
         assert isinstance(outline, pyvista.PolyData)
 
 
-@pytest.mark.skipif(PYTHON_2, reason="Python 2 doesn't support binding methods")
+@skip_py2_nobind
 def test_outline_corners_composite():
     # Now test composite data structures
     output = COMPOSITE.outline_corners()
@@ -262,7 +257,7 @@ def test_wireframe():
         assert isinstance(wire, pyvista.PolyData)
 
 
-@pytest.mark.skipif(PYTHON_2, reason="Python 2 doesn't support binding methods")
+@skip_py2_nobind
 def test_wireframe_composite():
     # Now test composite data structures
     output = COMPOSITE.extract_all_edges()
@@ -319,7 +314,7 @@ def test_elevation():
         elev = dataset.elevation(scalar_range=0.5)
 
 
-@pytest.mark.skipif(PYTHON_2, reason="Python 2 doesn't support binding methods")
+@skip_py2_nobind
 def test_elevation_composite():
     # Now test composite data structures
     output = COMPOSITE.elevation()
@@ -358,7 +353,7 @@ def test_compute_cell_sizes():
     assert np.allclose(grid.volume, volume)
 
 
-@pytest.mark.skipif(PYTHON_2, reason="Python 2 doesn't support binding methods")
+@skip_py2_nobind
 def test_compute_cell_sizes_composite():
     # Now test composite data structures
     output = COMPOSITE.compute_cell_sizes()
@@ -372,7 +367,7 @@ def test_cell_centers():
         assert isinstance(result, pyvista.PolyData)
 
 
-@pytest.mark.skipif(PYTHON_2, reason="Python 2 doesn't support binding methods")
+@skip_py2_nobind
 def test_cell_centers_composite():
     # Now test composite data structures
     output = COMPOSITE.cell_centers()
@@ -454,7 +449,7 @@ def test_cell_data_to_point_data():
     _ = data.ctp()
 
 
-@pytest.mark.skipif(PYTHON_2, reason="Python 2 doesn't support binding methods")
+@skip_py2_nobind
 def test_cell_data_to_point_data_composite():
     # Now test composite data structures
     output = COMPOSITE.cell_data_to_point_data()
@@ -470,7 +465,7 @@ def test_point_data_to_cell_data():
     _ = data.ptc()
 
 
-@pytest.mark.skipif(PYTHON_2, reason="Python 2 doesn't support binding methods")
+@skip_py2_nobind
 def test_point_data_to_cell_data_composite():
     # Now test composite data structures
     output = COMPOSITE.point_data_to_cell_data()
@@ -484,7 +479,7 @@ def test_triangulate():
     assert np.any(tri.cells)
 
 
-@pytest.mark.skipif(PYTHON_2, reason="Python 2 doesn't support binding methods")
+@skip_py2_nobind
 def test_triangulate_composite():
     # Now test composite data structures
     output = COMPOSITE.triangulate()
@@ -518,15 +513,15 @@ def test_resample():
     assert isinstance(result, type(mesh))
 
 
-@mac_xfail
 def test_streamlines():
-    mesh = examples.download_carotid()
-    stream, src = mesh.streamlines(return_source=True, max_time=100.0,
-                                   initial_step_length=2., terminal_speed=0.1,
-                                   n_points=25, source_radius=2.0,
-                                   source_center=(133.1, 116.3, 5.0))
-    assert stream.n_points > 0
-    assert src.n_points == 25
+    nx, ny, nz = 20, 15, 5
+    origin = (-(nx - 1)*0.1/2, -(ny - 1)*0.1/2, -(nz - 1)*0.1/2)
+    mesh = pyvista.UniformGrid((nx, ny, nz), (.1, .1, .1), origin)
+    mesh['vectors'] = mesh.points
+    stream, src = mesh.streamlines('vectors', return_source=True)
+    assert stream.n_points
+    assert stream.n_cells
+    assert src.n_points
 
 
 def test_sample_over_line():
@@ -589,7 +584,7 @@ def test_slice_along_line():
         slc = model.slice_along_line(line)
 
 
-@pytest.mark.skipif(PYTHON_2, reason="Python 2 doesn't support binding methods")
+@skip_py2_nobind
 def test_slice_along_line_composite():
     # Now test composite data structures
     a = [COMPOSITE.bounds[0], COMPOSITE.bounds[2], COMPOSITE.bounds[4]]
@@ -599,14 +594,14 @@ def test_slice_along_line_composite():
     assert output.n_blocks == COMPOSITE.n_blocks
 
 
-@mac_xfail
 def test_interpolate():
-    surface = examples.download_saddle_surface()
-    points = examples.download_sparse_points()
-    # Run the interpolation
-    interpolated = surface.interpolate(points, radius=12.0)
-    assert interpolated.n_points
-    assert interpolated.n_arrays
+    pdata = pyvista.PolyData()
+    pdata.points = np.random.random((10, 3))
+    pdata['scalars'] = np.random.random(10)
+    surf = pyvista.Sphere(theta_resolution=10, phi_resolution=10)
+    interp = surf.interpolate(pdata, radius=0.01)
+    assert interp.n_points
+    assert interp.n_arrays
 
 
 def test_select_enclosed_points():


### PR DESCRIPTION
### Eliminate Flaky Downloading on CI

This PR replaces all unit tests that require downloads with simpler and faster ones that do not require downloads.  This allows us to have good coverage on Mac OS and now downloads won't fail on unit tests.

Also adds a bonus streamlines example:
![sphx_glr_streamlines_004](https://user-images.githubusercontent.com/11981631/82717124-256d3780-9c9b-11ea-8ece-65afe56036fa.png)

Chipping away at our bloated unit testing...