### PR TITLE
Add dataset, association references to pyvista_ndarray.

### DIFF
--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -403,7 +403,7 @@ class Common(DataSetFilters, DataObject):
             return None
         vtk_data = pts.GetData()
         # arr = vtk_to_numpy(vtk_data)
-        return pyvista.pyvista_ndarray(vtk_data)
+        return pyvista.pyvista_ndarray(vtk_data, dataset=self)
 
 
     @points.setter

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -76,7 +76,7 @@ class DataSetAttributes(VTKObjectWrapper):
         """Return the active scalar array as pyvista_ndarray."""
         self._raise_field_data_no_scalars_vectors()
         if self.GetScalars() is not None:
-            return pyvista_ndarray(self.GetScalars())
+            return pyvista_ndarray(self.GetScalars(), dataset=self.dataset, association=self.association)
 
     @active_scalars.setter
     def active_scalars(self, name: str):
@@ -89,7 +89,7 @@ class DataSetAttributes(VTKObjectWrapper):
         """Return the active vectors as a pyvista_ndarray."""
         self._raise_field_data_no_scalars_vectors()
         if self.GetVectors() is not None:
-            return pyvista_ndarray(self.GetVectors())
+            return pyvista_ndarray(self.GetVectors(), dataset=self.dataset, association=self.association)
 
     @active_vectors.setter
     def active_vectors(self, name: str):
@@ -113,7 +113,7 @@ class DataSetAttributes(VTKObjectWrapper):
         """Return the active texture coordinates."""
         t_coords = self.GetTCoords()
         if t_coords is not None:
-            return pyvista_ndarray(t_coords)
+            return pyvista_ndarray(t_coords, dataset=self.dataset, association=self.association)
 
     @t_coords.setter
     def t_coords(self, t_coords: np.ndarray):
@@ -156,7 +156,7 @@ class DataSetAttributes(VTKObjectWrapper):
                 raise KeyError('{}'.format(key))
             if type(vtk_arr) == vtk.vtkAbstractArray:
                 return vtk_arr
-        narray = pyvista_ndarray(vtk_arr)
+        narray = pyvista_ndarray(vtk_arr, dataset=self.dataset, association=self.association)
         if vtk_arr.GetName() in self.dataset.association_bitarray_names[self.association]:
             narray = narray.view(np.bool)
         return narray
@@ -274,7 +274,7 @@ class DataSetAttributes(VTKObjectWrapper):
             copy.DeepCopy(vtk_arr)
             vtk_arr = copy
         self.remove(key)
-        return pyvista_ndarray(vtk_arr)
+        return pyvista_ndarray(vtk_arr, dataset=self.dataset, association=self.association)
 
     def items(self):
         """Return a list of (array name, array value)."""
@@ -294,7 +294,8 @@ class DataSetAttributes(VTKObjectWrapper):
         values = []
         for name in self.keys():
             array = self.VTKObject.GetAbstractArray(name)
-            values.append(pyvista_ndarray(array))
+            arr = pyvista_ndarray(array, dataset=self.dataset, association=self.association)
+            values.append(arr)
         return values
 
     def clear(self):

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -11,12 +11,7 @@ except ImportError:
 
 
 class pyvista_ndarray(np.ndarray):
-    """Link a numpy array with the vtk object the data is attached to.
-
-    When the array is changed it triggers "Modified()" which updates
-    all upstream objects, including any render windows holding the
-    object.
-    """
+    """Link a numpy array with the vtk object the data is attached to."""
 
     def __new__(cls, array, dataset=None, association=FieldAssociation.NONE):
         """Allocate the array."""
@@ -38,6 +33,7 @@ class pyvista_ndarray(np.ndarray):
 
     def __setitem__(self, key, value):
         """Set item at key index to value.
+
         When the array is changed it triggers "Modified()" which updates
         all upstream objects, including any render windows holding the
         object.

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -1,6 +1,8 @@
 """Contains pyvista_ndarray a numpy ndarray type used in pyvista."""
 from collections import Iterable
 import numpy as np
+
+from pyvista import Common
 from pyvista.utilities.helpers import FieldAssociation, convert_array
 from vtk.numpy_interface.dataset_adapter import VTKObjectWrapper, VTKArray
 
@@ -13,7 +15,7 @@ except ImportError:
 class pyvista_ndarray(np.ndarray):
     """Link a numpy array with the vtk object the data is attached to."""
 
-    def __new__(cls, array, dataset=None, association=FieldAssociation.NONE):
+    def __new__(cls, array: Iterable, dataset: Common=None, association=FieldAssociation.NONE):
         """Allocate the array."""
         if isinstance(array, Iterable):
             obj = np.asarray(array).view(cls)
@@ -31,8 +33,8 @@ class pyvista_ndarray(np.ndarray):
 
     __array_finalize__ = VTKArray.__array_finalize__
 
-    def __setitem__(self, key, value):
-        """Set item at key index to value.
+    def __setitem__(self, key: int, value):
+        """Implement [] set operator.
 
         When the array is changed it triggers "Modified()" which updates
         all upstream objects, including any render windows holding the

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -2,7 +2,6 @@
 from collections import Iterable
 import numpy as np
 
-from pyvista import Common
 from pyvista.utilities.helpers import FieldAssociation, convert_array
 from vtk.numpy_interface.dataset_adapter import VTKObjectWrapper, VTKArray
 
@@ -15,7 +14,7 @@ except ImportError:
 class pyvista_ndarray(np.ndarray):
     """Link a numpy array with the vtk object the data is attached to."""
 
-    def __new__(cls, array: Iterable, dataset: Common=None, association=FieldAssociation.NONE):
+    def __new__(cls, array: [Iterable, vtkAbstractArray], dataset=None, association=FieldAssociation.NONE):
         """Allocate the array."""
         if isinstance(array, Iterable):
             obj = np.asarray(array).view(cls)

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -1,15 +1,13 @@
 """Contains pyvista_ndarray a numpy ndarray type used in pyvista."""
 from collections import Iterable
-
 import numpy as np
+from pyvista.utilities.helpers import FieldAssociation, convert_array
 from vtk.numpy_interface.dataset_adapter import VTKObjectWrapper, VTKArray
 
-from pyvista.utilities.helpers import FieldAssociation, convert_array
-
 try:
-    from vtk.vtkCommonKitPython import vtkAbstractArray, vtkWeakReference, buffer_shared
+    from vtk.vtkCommonKitPython import buffer_shared, vtkAbstractArray, vtkWeakReference
 except ImportError:
-    from vtk.vtkCommonCore import vtkAbstractArray, vtkWeakReference, buffer_shared
+    from vtk.vtkCommonCore import buffer_shared, vtkAbstractArray, vtkWeakReference
 
 
 class pyvista_ndarray(np.ndarray):

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -1,12 +1,15 @@
 """Contains pyvista_ndarray a numpy ndarray type used in pyvista."""
+from collections import Iterable
 
 import numpy as np
-from pyvista.utilities.helpers import convert_array
+from vtk.numpy_interface.dataset_adapter import VTKObjectWrapper, VTKArray
+
+from pyvista.utilities.helpers import FieldAssociation, convert_array
 
 try:
-    from vtk.vtkCommonKitPython import vtkAbstractArray
+    from vtk.vtkCommonKitPython import vtkAbstractArray, vtkWeakReference, buffer_shared
 except ImportError:
-    from vtk.vtkCommonCore import vtkAbstractArray
+    from vtk.vtkCommonCore import vtkAbstractArray, vtkWeakReference, buffer_shared
 
 
 class pyvista_ndarray(np.ndarray):
@@ -17,22 +20,32 @@ class pyvista_ndarray(np.ndarray):
     object.
     """
 
-    def __new__(cls, input_array, proxy=None):
-        """Allocate memory for the pyvista ndarray."""
-        if isinstance(input_array, vtkAbstractArray):
-            if proxy is None:
-                cls._proxy = input_array
-                input_array = convert_array(input_array)
-            else:
-                cls._proxy = input_array
-        obj = np.asarray(input_array).view(cls)
+    def __new__(cls, array, dataset=None, association=FieldAssociation.NONE):
+        """Allocate the array."""
+        if isinstance(array, (Iterable, np.ndarray)):
+            obj = np.asarray(array).view(cls)
+        elif isinstance(array, vtkAbstractArray):
+            obj = convert_array(array).view(cls)
+            obj.VTKObject = array
+
+        obj.association = association
+        obj.dataset = vtkWeakReference()
+        if isinstance(dataset, VTKObjectWrapper):
+            obj.dataset.Set(dataset.VTKObject)
+        else:
+            obj.dataset.Set(dataset)
         return obj
 
-    def __setitem__(self, coords, value):
-        """Update the array and update the vtk object."""
-        super(pyvista_ndarray, self).__setitem__(coords, value)
-        self._proxy.Modified()
+    __array_finalize__ = VTKArray.__array_finalize__
 
-    def __getattr__(self, item):
-        """Forward unknown attribute requests to VTK array."""
-        return self._proxy.__getattribute__(item)
+    def __setitem__(self, key, value):
+        """Set item at key index to value.
+        When the array is changed it triggers "Modified()" which updates
+        all upstream objects, including any render windows holding the
+        object.
+        """
+        super().__setitem__(key, value)
+        if self.VTKObject is not None:
+            self.VTKObject.Modified()
+
+    __getattr__ = VTKArray.__getattr__

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -12,7 +12,7 @@ except ImportError:
 
 
 class pyvista_ndarray(np.ndarray):
-    """Link a numpy array with the vtk object the data is attached to."""
+    """An ndarray which references the owning dataset and the underlying vtkArray."""
 
     def __new__(cls, array: [Iterable, vtkAbstractArray], dataset=None, association=FieldAssociation.NONE):
         """Allocate the array."""

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -15,7 +15,7 @@ class pyvista_ndarray(np.ndarray):
 
     def __new__(cls, array, dataset=None, association=FieldAssociation.NONE):
         """Allocate the array."""
-        if isinstance(array, (Iterable, np.ndarray)):
+        if isinstance(array, Iterable):
             obj = np.asarray(array).view(cls)
         elif isinstance(array, vtkAbstractArray):
             obj = convert_array(array).view(cls)


### PR DESCRIPTION
### Overview

Brings back parts of #654 while keeping the base as ndarray. Accepts Iterable, ndarray, or vtk arrays.

I've changed references of cls.[member variable] to obj.[member variable]. The reason for this is because cls would be a static class member, not an instance member.



