### PR TITLE
Use new style classes an argumentless super() calls.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -277,7 +277,7 @@ class AutoAutoSummary(Autosummary):
         except:
             print('Something went wrong when autodocumenting {}'.format(clazz))
         finally:
-            return super(AutoAutoSummary, self).run()
+            return super().run()
 
 def setup(app):
     AutoAutoSummary.app = app

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -23,7 +23,7 @@ log.setLevel('CRITICAL')
 DEFAULT_VECTOR_KEY = '_vectors'
 
 
-class DataObject(object):
+class DataObject:
     """Methods common to all wrapped data objects."""
 
     def __init__(self, *args, **kwargs):
@@ -301,7 +301,7 @@ class Common(DataSetFilters, DataObject):
 
     def __init__(self, *args, **kwargs):
         """Initialize the common object."""
-        super(Common, self).__init__()
+        super().__init__()
         self.references = []
         self._point_bool_array_names = []
         self._cell_bool_array_names = []

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -68,7 +68,7 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
     def __init__(self, *args, **kwargs):
         """Initialize multi block."""
-        super(MultiBlock, self).__init__()
+        super().__init__()
         deep = kwargs.pop('deep', False)
         self.refs = []
 

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -57,7 +57,7 @@ def _get_output(algorithm, iport=0, iconnection=0, oport=0, active_scalars=None,
     return data
 
 
-class DataSetFilters(object):
+class DataSetFilters:
     """A set of common filters that can be applied to any vtkDataSet."""
 
     def __new__(cls, *args, **kwargs):
@@ -2217,7 +2217,7 @@ class DataSetFilters(object):
         return _get_output(alg)
 
 
-class CompositeFilters(object):
+class CompositeFilters:
     """An internal class to manage filtes/algorithms for composite datasets."""
 
     def __new__(cls, *args, **kwargs):

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -38,7 +38,7 @@ class Grid(Common):
 
     def __init__(self, *args, **kwargs):
         """Initialize the grid."""
-        super(Grid, self).__init__()
+        super().__init__()
 
     @property
     def dimensions(self):
@@ -99,7 +99,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
 
     def __init__(self, *args, **kwargs):
         """Initialize the rectilinear grid."""
-        super(RectilinearGrid, self).__init__()
+        super().__init__()
 
         if len(args) == 1:
             if isinstance(args[0], vtk.vtkRectilinearGrid):
@@ -298,7 +298,7 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
 
     def __init__(self, *args, **kwargs):
         """Initialize the uniform grid."""
-        super(UniformGrid, self).__init__()
+        super().__init__()
 
         if len(args) == 1:
             if isinstance(args[0], vtk.vtkImageData):

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -153,7 +153,7 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
 
     def __init__(self, *args, **kwargs):
         """Initialize the polydata."""
-        super(PolyData, self).__init__()
+        super().__init__()
 
         deep = kwargs.pop('deep', False)
 
@@ -508,7 +508,7 @@ class PointGrid(PointSet):
 
     def __init__(self, *args, **kwargs):
         """Initialize the point grid."""
-        super(PointGrid, self).__init__()
+        super().__init__()
 
     def plot_curvature(self, curv_type='mean', **kwargs):
         """Plot the curvature of the external surface of the grid.
@@ -583,7 +583,7 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
 
     def __init__(self, *args, **kwargs):
         """Initialize the unstructured grid."""
-        super(UnstructuredGrid, self).__init__()
+        super().__init__()
         deep = kwargs.pop('deep', False)
 
         if len(args) == 1:
@@ -845,7 +845,7 @@ class StructuredGrid(vtkStructuredGrid, PointGrid):
 
     def __init__(self, *args, **kwargs):
         """Initialize the structured grid."""
-        super(StructuredGrid, self).__init__()
+        super().__init__()
 
         if len(args) == 1:
             if isinstance(args[0], vtk.vtkStructuredGrid):

--- a/pyvista/plotting/background_renderer.py
+++ b/pyvista/plotting/background_renderer.py
@@ -15,7 +15,7 @@ class BackgroundRenderer(Renderer):
         # the image path is invalid
         image_data = pyvista.read(image_path)
 
-        super(BackgroundRenderer, self).__init__(parent, border=False)
+        super().__init__(parent, border=False)
         self.SetLayer(0)
         self.InteractiveOff()
         self.SetBackground(self.parent.renderer.GetBackground())

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -8,7 +8,7 @@ import pyvista
 from pyvista.utilities import try_callback
 
 
-class PickingHelper(object):
+class PickingHelper:
     """An internal class to hold picking related features."""
 
     picked_cells = None

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2535,7 +2535,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def close(self):
         """Close the render window."""
         # must close out widgets first
-        super(BasePlotter, self).close()
+        super().close()
         # Renderer has an axes widget, so close it
         for renderer in self.renderers:
             renderer.close()
@@ -3648,11 +3648,11 @@ class Plotter(BasePlotter):
                  point_smoothing=False, polygon_smoothing=False,
                  splitting_position=None, title=None):
         """Initialize a vtk plotting object."""
-        super(Plotter, self).__init__(shape=shape, border=border,
-                                      border_color=border_color,
-                                      border_width=border_width,
-                                      splitting_position=splitting_position,
-                                      title=title)
+        super().__init__(shape=shape, border=border,
+                         border_color=border_color,
+                         border_width=border_width,
+                         splitting_position=splitting_position,
+                         title=title)
         log.debug('Initializing')
 
         def on_timer(iren, event_id):

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -42,7 +42,7 @@ def scale_point(camera, point, invert=False):
     return (scaled[0], scaled[1], scaled[2])
 
 
-class CameraPosition(object):
+class CameraPosition:
     """Container to hold camera location attributes."""
 
     def __init__(self, position, focal_point, viewup):
@@ -104,7 +104,7 @@ class Renderer(vtkRenderer):
     def __init__(self, parent, border=True, border_color=(1, 1, 1),
                  border_width=2.0):
         """Initialize the renderer."""
-        super(Renderer, self).__init__()
+        super().__init__()
         self._actors = {}
         self.parent = parent
         self.camera_set = False

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -9,7 +9,7 @@ from pyvista.utilities import NORMALS, generate_plane, get_array, try_callback
 from .theme import rcParams, parse_color
 
 
-class WidgetHelper(object):
+class WidgetHelper:
     """An internal class to manage widgets.
 
     It also manages and other helper methods involving widgets.

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -632,7 +632,7 @@ def threaded(fn):
     return wrapper
 
 
-class conditional_decorator(object):
+class conditional_decorator:
     """Conditional decorator for methods."""
 
     def __init__(self, dec, condition):

--- a/pyvista/utilities/sphinx_gallery.py
+++ b/pyvista/utilities/sphinx_gallery.py
@@ -17,7 +17,7 @@ def _get_sg_image_scraper():
     return Scraper()
 
 
-class Scraper(object):
+class Scraper:
     """
     Save ``pyvista.Plotter`` objects.
 


### PR DESCRIPTION
### Overview

With minimum Python 3.5 support, explicit object inheritance and super() calls with arguments are no longer necessary.

