### PR TITLE
Fix missing "pragma" from "pragma: no cover" in Common

### DIFF
--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -1142,7 +1142,7 @@ class Common(DataSetFilters, DataObject):
         return pyvista.filters._get_output(alg)
 
     @property
-    def quality(self):  # no cover
+    def quality(self):  # pragma: no cover
         """Return cell quality using PyANSYS.
 
         Computes the minimum scaled jacobian of each cell.


### PR DESCRIPTION
https://github.com/pyvista/pyvista/pull/709 introduced `no cover` coverage instructions, among other things, for methods of Common overridden by subclases. In one instance `pragma: no cover` turned into `no cover`, this is a quick fix for this.