### PR TITLE
🚧 Add type hints to majority of public core methods.

### DIFF
--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -5,6 +5,7 @@ to VTK algorithms and PyVista filtering/plotting routines.
 """
 import collections
 import logging
+from typing import List
 
 import numpy as np
 import vtk
@@ -135,28 +136,28 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
         return bounds
 
     @property
-    def center(self):
+    def center(self) -> np.ndarray:
         """Return the center of the bounding box."""
         return np.array(self.bounds).reshape(3,2).mean(axis=1)
 
     @property
-    def length(self):
+    def length(self) -> float:
         """Return the length of the diagonal of the bounding box."""
         return pyvista.Box(self.bounds).length
 
     @property
-    def n_blocks(self):
+    def n_blocks(self) -> int:
         """Return the total number of blocks set."""
         return self.GetNumberOfBlocks()
 
     @n_blocks.setter
-    def n_blocks(self, n):
+    def n_blocks(self, n: int) :
         """Return the total number of blocks set."""
         self.SetNumberOfBlocks(n)
         self.Modified()
 
     @property
-    def volume(self):
+    def volume(self) -> float:
         """Return the total volume of all meshes in this dataset.
 
         Return
@@ -190,14 +191,14 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
                 maxi = tma
         return mini, maxi
 
-    def get_index_by_name(self, name):
+    def get_index_by_name(self, name) -> int:
         """Find the index number by block name."""
         for i in range(self.n_blocks):
             if self.get_block_name(i) == name:
                 return i
         raise KeyError('Block name ({}) not found'.format(name))
 
-    def __getitem__(self, index):
+    def __getitem__(self, index) -> 'pyvista.MultiBlock':
         """Get a block by its index or name.
 
         If the name is non-unique then returns the first occurrence.
@@ -241,7 +242,7 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
         self[index] = data
         self.refs.append(data)
 
-    def get(self, index):
+    def get(self, index: [int, str]) -> 'pyvista.MultiBlock':
         """Get a block by its index or name.
 
         If the name is non-unique then returns the first occurrence.
@@ -249,21 +250,21 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
         """
         return self[index]
 
-    def set_block_name(self, index, name):
+    def set_block_name(self, index: int, name: str):
         """Set a block's string name at the specified index."""
         if name is None:
             return
         self.GetMetaData(index).Set(vtk.vtkCompositeDataSet.NAME(), name)
         self.Modified()
 
-    def get_block_name(self, index):
+    def get_block_name(self, index: int):
         """Return the string name of the block at the given index."""
         meta = self.GetMetaData(index)
         if meta is not None:
             return meta.Get(vtk.vtkCompositeDataSet.NAME())
         return None
 
-    def keys(self):
+    def keys(self) -> List[str]:
         """Get all the block names in the dataset."""
         names = []
         for i in range(self.n_blocks):
@@ -334,7 +335,7 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
     __next__ = next
 
-    def pop(self, index):
+    def pop(self, index: int) -> 'pyvista.MultiBlock':
         """Pop off a block at the specified index."""
         data = self[index]
         del self[index]

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -1,6 +1,7 @@
 """Implements DataSetAttributes, which represents and manipulates datasets."""
 
 from collections.abc import Iterable
+from typing import Dict, List, Tuple
 
 import numpy as np
 import vtk
@@ -43,14 +44,14 @@ class DataSetAttributes(VTKObjectWrapper):
                'Contains keys:\n' \
                '\t{}'.format(self.association.name, '\n\t'.join(self.keys()))
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: [str, int]) -> [np.ndarray, vtk.vtkAbstractArray]:
         """Implement [] operator.
 
         Accepts an array name or an index.
         """
         return self.get_array(key)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: [str, int], value: np.ndarray):
         """Implement setting with the [] operator."""
         self.append(narray=value, name=key)
 
@@ -72,7 +73,7 @@ class DataSetAttributes(VTKObjectWrapper):
         return self.VTKObject.GetNumberOfArrays()
 
     @property
-    def active_scalars(self):
+    def active_scalars(self) -> np.ndarray:
         """Return the active scalar array as pyvista_ndarray."""
         self._raise_field_data_no_scalars_vectors()
         if self.GetScalars() is not None:
@@ -85,7 +86,7 @@ class DataSetAttributes(VTKObjectWrapper):
         self.SetActiveScalars(name)
 
     @property
-    def active_vectors(self):
+    def active_vectors(self) -> np.ndarray:
         """Return the active vectors as a pyvista_ndarray."""
         self._raise_field_data_no_scalars_vectors()
         if self.GetVectors() is not None:
@@ -98,7 +99,7 @@ class DataSetAttributes(VTKObjectWrapper):
         self.SetActiveVectors(name)
 
     @property
-    def valid_array_len(self):
+    def valid_array_len(self) -> int:
         """Return the length an ndarray should be when added to the dataset.
 
         If there are no restrictions, return ``None``
@@ -109,7 +110,7 @@ class DataSetAttributes(VTKObjectWrapper):
             return self.dataset.GetNumberOfCells()
 
     @property
-    def t_coords(self):
+    def t_coords(self) -> np.ndarray:
         """Return the active texture coordinates."""
         t_coords = self.GetTCoords()
         if t_coords is not None:
@@ -132,7 +133,7 @@ class DataSetAttributes(VTKObjectWrapper):
         self.SetTCoords(vtkarr)
         self.Modified()
 
-    def get_array(self, key):
+    def get_array(self, key: [str, int]) -> [np.ndarray, vtk.vtkAbstractArray]:
         """Get an array in this object.
 
         Parameters
@@ -237,7 +238,7 @@ class DataSetAttributes(VTKObjectWrapper):
         self.VTKObject.AddArray(vtk_arr)
         self.VTKObject.Modified()
 
-    def remove(self, key):
+    def remove(self, key: [str, int]):
         """Remove an array.
 
         Parameters
@@ -254,7 +255,7 @@ class DataSetAttributes(VTKObjectWrapper):
         self.VTKObject.RemoveArray(key)
         self.VTKObject.Modified()
 
-    def pop(self, key):
+    def pop(self, key: [str, int]) -> np.ndarray:
         """Remove an array and return it.
 
         Parameters
@@ -276,11 +277,11 @@ class DataSetAttributes(VTKObjectWrapper):
         self.remove(key)
         return pyvista_ndarray(vtk_arr, dataset=self.dataset, association=self.association)
 
-    def items(self):
+    def items(self) -> List[Tuple[str, np.ndarray]]:
         """Return a list of (array name, array value)."""
         return list(zip(self.keys(), self.values()))
 
-    def keys(self):
+    def keys(self) -> List[str]:
         """Return the names of the arrays as a list."""
         keys = []
         for i in range(self.GetNumberOfArrays()):
@@ -289,7 +290,7 @@ class DataSetAttributes(VTKObjectWrapper):
                 keys.append(name)
         return keys
 
-    def values(self):
+    def values(self) -> List[np.ndarray]:
         """Return the arrays as a list."""
         values = []
         for name in self.keys():
@@ -303,7 +304,7 @@ class DataSetAttributes(VTKObjectWrapper):
         for array_name in self.keys():
             self.remove(key=array_name)
 
-    def update(self, array_dict):
+    def update(self, array_dict: ['DataSetAttributes', Dict[str, np.ndarray]]):
         """Update arrays in this object.
 
         For each key, value given, add the pair, if it already exists,
@@ -317,7 +318,7 @@ class DataSetAttributes(VTKObjectWrapper):
         for name, array in array_dict.items():
             self[name] = array.copy()
 
-    def _raise_index_out_of_bounds(self, index):
+    def _raise_index_out_of_bounds(self, index: int):
         max_index = self.VTKObject.GetNumberOfArrays()
         if isinstance(index, int):
             if index < 0 or index >= self.VTKObject.GetNumberOfArrays():

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -162,7 +162,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
         self._update_dimensions()
 
     @property
-    def meshgrid(self):
+    def meshgrid(self) -> np.meshgrid:
         """Return the a meshgrid of numpy arrays for this mesh.
 
         This simply returns a ``numpy.meshgrid`` of the coordinates for this
@@ -172,13 +172,13 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
         return np.meshgrid(self.x, self.y, self.z, indexing='ij')
 
     @property
-    def points(self):
+    def points(self) -> np.ndarray:
         """Return all of the points as an n by 3 numpy array."""
         xx, yy, zz = self.meshgrid
         return np.c_[xx.ravel(order='F'), yy.ravel(order='F'), zz.ravel(order='F')]
 
     @points.setter
-    def points(self, points):
+    def points(self, points: np.ndarray):
         """Set points without copying."""
         if not isinstance(points, np.ndarray):
             raise TypeError('Points must be a numpy array')
@@ -192,36 +192,36 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
         self.Modified()
 
     @property
-    def x(self):
+    def x(self) -> np.ndarray:
         """Get the coordinates along the X-direction."""
         return vtk_to_numpy(self.GetXCoordinates())
 
     @x.setter
-    def x(self, coords):
+    def x(self, coords: np.ndarray):
         """Set the coordinates along the X-direction."""
         self.SetXCoordinates(numpy_to_vtk(coords))
         self._update_dimensions()
         self.Modified()
 
     @property
-    def y(self):
+    def y(self) -> np.ndarray:
         """Get the coordinates along the Y-direction."""
         return vtk_to_numpy(self.GetYCoordinates())
 
     @y.setter
-    def y(self, coords):
+    def y(self, coords: np.ndarray):
         """Set the coordinates along the Y-direction."""
         self.SetYCoordinates(numpy_to_vtk(coords))
         self._update_dimensions()
         self.Modified()
 
     @property
-    def z(self):
+    def z(self) -> np.ndarray:
         """Get the coordinates along the Z-direction."""
         return vtk_to_numpy(self.GetZCoordinates())
 
     @z.setter
-    def z(self, coords):
+    def z(self, coords: np.ndarray):
         """Set the coordinates along the Z-direction."""
         self.SetZCoordinates(numpy_to_vtk(coords))
         self._update_dimensions()
@@ -344,7 +344,7 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
         self.SetSpacing(xs, ys, zs)
 
     @property
-    def points(self):
+    def points(self) -> np.ndarray:
         """Return a pointer to the points as a numpy object."""
         # Get grid dimensions
         nx, ny, nz = self.dimensions
@@ -362,7 +362,7 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
         return np.c_[xx.ravel(order='F'), yy.ravel(order='F'), zz.ravel(order='F')]
 
     @points.setter
-    def points(self, points):
+    def points(self, points: np.ndarray):
         """Set points without copying."""
         if not isinstance(points, np.ndarray):
             raise TypeError('Points must be a numpy array')
@@ -382,17 +382,17 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
         self.Modified()
 
     @property
-    def x(self):
+    def x(self) -> np.ndarray:
         """Return all the X points."""
         return self.points[:, 0]
 
     @property
-    def y(self):
+    def y(self) -> np.ndarray:
         """Return all the Y points."""
         return self.points[:, 1]
 
     @property
-    def z(self):
+    def z(self) -> np.ndarray:
         """Return all the Z points."""
         return self.points[:, 2]
 

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -4,6 +4,8 @@ The data objects does not have any sort of spatial reference.
 
 """
 
+from typing import Dict, List, Tuple
+
 import numpy as np
 import vtk
 
@@ -74,22 +76,22 @@ class Table(vtk.vtkTable, DataObject):
             self.row_arrays[name] = data_frame[name].values
 
     @property
-    def n_rows(self):
+    def n_rows(self) -> int:
         """Return the number of rows."""
         return self.GetNumberOfRows()
 
     @n_rows.setter
-    def n_rows(self, n):
+    def n_rows(self, n: int):
         """Set the number of rows."""
         self.SetNumberOfRows(n)
 
     @property
-    def n_columns(self):
+    def n_columns(self) -> int:
         """Return the number of columns."""
         return self.GetNumberOfColumns()
 
     @property
-    def n_arrays(self):
+    def n_arrays(self) -> int:
         """Return the number of columns.
 
         Alias for: ``n_columns``.
@@ -114,27 +116,27 @@ class Table(vtk.vtkTable, DataObject):
         return self.row_arrays[name]
 
     @property
-    def row_arrays(self):
+    def row_arrays(self) -> DataSetAttributes:
         """Return the all row arrays."""
         return DataSetAttributes(vtkobject=self.GetRowData(), dataset=self, association=FieldAssociation.ROW)
 
-    def keys(self):
+    def keys(self) -> List[str]:
         """Return the table keys."""
         return self.row_arrays.keys()
 
-    def items(self):
+    def items(self) -> List[Tuple[str, np.ndarray]]:
         """Return the table items."""
         return self.row_arrays.items()
 
-    def values(self):
+    def values(self) -> List[np.ndarray]:
         """Return the table values."""
         return self.row_arrays.values()
 
-    def update(self, data):
+    def update(self, data: [DataSetAttributes, Dict[str, np.ndarray]]):
         """Set the table data."""
         self.row_arrays.update(data)
 
-    def pop(self, name):
+    def pop(self, name: str):
         """Pops off an array by the specified name."""
         return self.row_arrays.pop(name)
 
@@ -156,18 +158,18 @@ class Table(vtk.vtkTable, DataObject):
         """
         self.row_arrays[name] = scalars
 
-    def __getitem__(self, index):
+    def __getitem__(self, index) -> [np.ndarray, vtk.vtkAbstractArray]:
         """Search row data for an array."""
         return self._row_array(name=index)
 
     def _ipython_key_completions_(self):
         return self.keys()
 
-    def get(self, index):
+    def get(self, index) -> [np.ndarray, vtk.vtkAbstractArray]:
         """Get an array by its name."""
         return self[index]
 
-    def __setitem__(self, name, scalars):
+    def __setitem__(self, name: str, scalars: np.ndarray):
         """Add/set an array in the row_arrays."""
         self.row_arrays[name] = scalars
 
@@ -175,7 +177,7 @@ class Table(vtk.vtkTable, DataObject):
         """Remove a single array by name from each field (internal helper)."""
         self.row_arrays.remove(key)
 
-    def __delitem__(self, name):
+    def __delitem__(self, name: str):
         """Remove an array by the specified name."""
         del self.row_arrays[name]
 
@@ -242,7 +244,7 @@ class Table(vtk.vtkTable, DataObject):
         """Return the object string representation."""
         return self.head(display=False, html=False)
 
-    def to_pandas(self):
+    def to_pandas(self) -> 'pd.DataFrame':
         """Create a Pandas DataFrame from this Table."""
         if pd is None:
             raise ImportError('You must have Pandas installed.')
@@ -332,7 +334,7 @@ class Texture(vtk.vtkTexture):
 
         return self._from_image_data(grid)
 
-    def flip(self, axis):
+    def flip(self, axis: int):
         """Flip this texture inplace along the specified axis. 0 for X and 1 for Y."""
         if axis < 0 or axis > 1:
             raise RuntimeError("Axis {} out of bounds".format(axis))
@@ -346,7 +348,7 @@ class Texture(vtk.vtkTexture):
         return self.GetInput()
 
     @property
-    def n_components(self):
+    def n_components(self) -> int:
         """Components in the image (e.g. 3 [or 4] for RGB[A])."""
         image = self.to_image()
         return image.active_scalars.shape[1]

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import warnings
+from typing import List
 
 import numpy as np
 import vtk
@@ -31,7 +32,7 @@ class PointSet(Common):
     This holds methods common to PolyData and UnstructuredGrid.
     """
 
-    def center_of_mass(self, scalars_weight=False):
+    def center_of_mass(self, scalars_weight=False) -> np.ndarray:
         """Return the coordinates for the center of mass of the mesh.
 
         Parameters
@@ -58,7 +59,7 @@ class PointSet(Common):
             to_copy.SetPoints(vtk.vtkPoints())
         return Common.shallow_copy(self, to_copy)
 
-    def remove_cells(self, ind, inplace=True):
+    def remove_cells(self, ind: [List[int], List[bool]], inplace=True):
         """Remove cells.
 
         Parameters
@@ -201,12 +202,12 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
         return cells
 
     @property
-    def verts(self):
+    def verts(self) -> np.ndarray:
         """Get the vertice cells."""
         return vtk_to_numpy(self.GetVerts().GetData())
 
     @verts.setter
-    def verts(self, verts):
+    def verts(self, verts: np.ndarray):
         """Set the vertice cells."""
         if not isinstance(verts, np.ndarray):
             verts = np.asarray(verts)
@@ -230,12 +231,12 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
         self.SetVerts(vtkcells)
 
     @property
-    def lines(self):
+    def lines(self) -> np.ndarray:
         """Return a pointer to the lines as a numpy object."""
         return vtk_to_numpy(self.GetLines().GetData()).ravel()
 
     @lines.setter
-    def lines(self, lines):
+    def lines(self, lines: np.ndarray):
         """Set the lines of the polydata."""
         if lines.dtype != pyvista.ID_TYPE:
             lines = lines.astype(pyvista.ID_TYPE)
@@ -256,12 +257,12 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
         self.SetLines(vtkcells)
 
     @property
-    def faces(self):
+    def faces(self) -> np.ndarray:
         """Return a pointer to the points as a numpy object."""
         return vtk_to_numpy(self.GetPolys().GetData())
 
     @faces.setter
-    def faces(self, faces):
+    def faces(self, faces: np.ndarray):
         """Set faces without copying."""
         if faces.dtype != pyvista.ID_TYPE:
             faces = faces.astype(pyvista.ID_TYPE)
@@ -292,11 +293,11 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
     #     lines = vtk_to_numpy(self.GetLines().GetData()).reshape((-1, 3))
     #     return np.ascontiguousarray(lines[:, 1:])
 
-    def is_all_triangles(self):
+    def is_all_triangles(self) -> bool:
         """Return True if all the faces of the polydata are triangles."""
         return self.faces.size % 4 == 0 and (self.faces.reshape(-1, 4)[:, 0] == 3).all()
 
-    def _from_arrays(self, vertices, faces, deep=True, verts=False):
+    def _from_arrays(self, vertices: np.ndarray, faces, deep=True, verts=False):
         """Set polygons and points from numpy arrays.
 
         Parameters
@@ -357,7 +358,7 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
         return self.boolean_cut(cutting_mesh)
 
     @property
-    def n_faces(self):
+    def n_faces(self) -> int:
         """Return the number of cells.
 
         Alias for ``n_cells``.
@@ -366,11 +367,11 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
         return self.n_cells
 
     @property
-    def number_of_faces(self):
+    def number_of_faces(self) -> int:
         """Return the number of cells."""
         return self.n_cells
 
-    def save(self, filename, binary=True):
+    def save(self, filename: str, binary=True):
         """Write a surface mesh to disk.
 
         Written file may be an ASCII or binary ply, stl, or vtk mesh
@@ -403,7 +404,7 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
         super().save(filename, binary)
 
     @property
-    def area(self):
+    def area(self) -> float:
         """Return the mesh surface area.
 
         Return
@@ -417,7 +418,7 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
         return mprop.GetSurfaceArea()
 
     @property
-    def volume(self):
+    def volume(self) -> float:
         """Return the mesh volume.
 
         This will throw a VTK error/warning if not a closed surface
@@ -433,19 +434,19 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
         return mprop.GetVolume()
 
     @property
-    def point_normals(self):
+    def point_normals(self) -> np.ndarray:
         """Return the point normals."""
         mesh = self.compute_normals(cell_normals=False, inplace=False)
         return mesh.point_arrays['Normals']
 
     @property
-    def cell_normals(self):
+    def cell_normals(self) -> np.ndarray:
         """Return the cell normals."""
         mesh = self.compute_normals(point_normals=False, inplace=False)
         return mesh.cell_arrays['Normals']
 
     @property
-    def face_normals(self):
+    def face_normals(self) -> np.ndarray:
         """Return the cell normals."""
         return self.cell_normals
 
@@ -467,7 +468,7 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
         return self._obbTree
 
     @property
-    def n_open_edges(self):
+    def n_open_edges(self) -> int:
         """Return the number of open edges on this mesh."""
         alg = vtk.vtkFeatureEdges()
         alg.FeatureEdgesOff()
@@ -518,7 +519,7 @@ class PointGrid(PointSet):
         return trisurf.plot_curvature(curv_type, **kwargs)
 
     @property
-    def volume(self):
+    def volume(self) -> float:
         """Compute the volume of the point grid.
 
         This extracts the external surface and computes the interior volume
@@ -708,11 +709,11 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
             self.SetCells(cell_type, offset, vtkcells)
 
     @property
-    def cells(self):
+    def cells(self) -> np.ndarray:
         """Return a pointer to the cells as a numpy object."""
         return vtk_to_numpy(self.GetCells().GetData())
 
-    def linear_copy(self, deep=False):
+    def linear_copy(self, deep=False) -> 'UnstructuredGrid':
         """Return a copy of the unstructured grid containing only linear cells.
 
         Converts the following cell types to their linear equivalents.
@@ -775,12 +776,12 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
         return lgrid
 
     @property
-    def celltypes(self):
+    def celltypes(self) -> np.ndarray:
         """Get the cell types array."""
         return vtk_to_numpy(self.GetCellTypesArray())
 
     @property
-    def offset(self):
+    def offset(self) -> np.ndarray:
         """Get Cell Locations Array."""
         return vtk_to_numpy(self.GetCellLocationsArray())
 
@@ -894,17 +895,17 @@ class StructuredGrid(vtkStructuredGrid, PointGrid):
         self.Modified()
 
     @property
-    def x(self):
+    def x(self) -> np.ndarray:
         """Return the X coordinates of all points."""
         return self.points[:, 0].reshape(self.dimensions, order='F')
 
     @property
-    def y(self):
+    def y(self) -> np.ndarray:
         """Return the Y coordinates of all points."""
         return self.points[:, 1].reshape(self.dimensions, order='F')
 
     @property
-    def z(self):
+    def z(self) -> np.ndarray:
         """Return the Z coordinates of all points."""
         return self.points[:, 2].reshape(self.dimensions, order='F')
 
@@ -914,7 +915,7 @@ class StructuredGrid(vtkStructuredGrid, PointGrid):
         attrs.append(("Dimensions", self.dimensions, "{:d}, {:d}, {:d}"))
         return attrs
 
-    def hide_cells(self, ind):
+    def hide_cells(self, ind: [List[int], List[bool]]):
         """Hide cells without deleting them.
 
         Hides cells by setting the ghost_cells array to HIDDEN_CELL.


### PR DESCRIPTION
### Overview

Type hints(added in 3.5), make it easier for the user and IDEs to determine parameter and return types of functions, especially if there is no explicit documentation. 

It should also be possible to have the types automatically added to documentation. https://pypi.org/project/sphinx-autodoc-napoleon-typehints/

This adds type hints to most of the public methods in /core/. Please ensure that pyvista.Texture is the correct type for the texture related methods in common.py, I'm unsure if it's that or vtk.vtkTexture.
