### PR TITLE
Add abstract class decorator.

### DIFF
--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -10,7 +10,8 @@ import vtk
 
 import pyvista
 from pyvista.utilities import (FieldAssociation, get_array, is_pyvista_dataset,
-                               parse_field_choice, raise_not_matching, vtk_id_list_to_array, fileio)
+                               parse_field_choice, raise_not_matching, vtk_id_list_to_array,
+                               fileio, abstract_class)
 from .datasetattributes import DataSetAttributes
 from .filters import DataSetFilters
 
@@ -23,6 +24,7 @@ DEFAULT_VECTOR_KEY = '_vectors'
 ActiveArrayInfo = collections.namedtuple('ActiveInfo', field_names=['association', 'name'])
 
 
+@abstract_class
 class DataObject:
     """Methods common to all wrapped data objects."""
 
@@ -35,12 +37,6 @@ class DataObject:
         # Remember which arrays come from numpy.bool arrays, because there is no direct
         # conversion from bool to vtkBitArray, such arrays are stored as vtkCharArray.
         self.association_bitarray_names = collections.defaultdict(set)
-
-    def __new__(cls, *args, **kwargs):
-        """Allocate memory for the data object."""
-        if cls is DataObject:
-            raise TypeError("pyvista.DataObject is an abstract class and may not be instantiated.")
-        return object.__new__(cls, *args, **kwargs)
 
     def shallow_copy(self, to_copy):
         """Shallow copy the given mesh to this mesh."""
@@ -264,17 +260,12 @@ class DataObject:
         return self.GetInformation().GetAddressAsString("")
 
 
+@abstract_class
 class Common(DataSetFilters, DataObject):
     """Methods in common to spatially referenced objects."""
 
     # Simply bind pyvista.plotting.plot to the object
     plot = pyvista.plot
-
-    def __new__(cls, *args, **kwargs):
-        """Allocate memory for the common object."""
-        if cls is Common:
-            raise TypeError("pyvista.Common is an abstract class and may not be instantiated.")
-        return object.__new__(cls, *args, **kwargs)
 
     def __init__(self, *args, **kwargs):
         """Initialize the common object."""

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -33,7 +33,7 @@ from vtk.util.numpy_support import numpy_to_vtkIdTypeArray, vtk_to_numpy
 import pyvista
 from pyvista.utilities import (FieldAssociation, NORMALS, assert_empty_kwargs,
                                generate_plane, get_array, vtk_id_list_to_array,
-                               wrap, ProgressMonitor)
+                               wrap, ProgressMonitor, abstract_class)
 from pyvista.core.errors import NotAllTrianglesError
 
 
@@ -58,13 +58,9 @@ def _get_output(algorithm, iport=0, iconnection=0, oport=0, active_scalars=None,
     return data
 
 
+@abstract_class
 class DataSetFilters:
     """A set of common filters that can be applied to any vtkDataSet."""
-
-    def __new__(cls, *args, **kwargs):  # pragma: no cover
-        """Allocate memory for the dataset filters."""
-        if cls is DataSetFilters:
-            raise TypeError("pyvista.DataSetFilters is an abstract class and may not be instantiated.")
 
     def _clip_with_function(dataset, function, invert=True, value=0.0):
         """Clip using an implicit function (internal helper)."""
@@ -2217,13 +2213,9 @@ class DataSetFilters:
         return _get_output(alg)
 
 
+@abstract_class
 class CompositeFilters:
     """An internal class to manage filtes/algorithms for composite datasets."""
-
-    def __new__(cls, *args, **kwargs):  # pragma: no cover
-        """Allocate memory for the composite filters."""
-        if cls is CompositeFilters:
-            raise TypeError("pyvista.CompositeFilters is an abstract class and may not be instantiated.")
 
     def extract_geometry(composite):
         """Combine the geomertry of all blocks into a single ``PolyData`` object.
@@ -2320,13 +2312,9 @@ class CompositeFilters:
         return box.outline_corners(factor=factor)
 
 
+@abstract_class
 class PolyDataFilters(DataSetFilters):
     """An internal class to manage filtes/algorithms for polydata datasets."""
-
-    def __new__(cls, *args, **kwargs):  # pragma: no cover
-        """Allocate memory for the polydata filters."""
-        if cls is PolyDataFilters:
-            raise TypeError("pyvista.PolyDataFilters is an abstract class and may not be instantiated.")
 
     def edge_mask(poly_data, angle):
         """Return a mask of the points of a surface mesh that has a surface angle greater than angle.
@@ -3436,7 +3424,7 @@ class PolyDataFilters(DataSetFilters):
             raise NotAllTrianglesError('Can only flip normals on an all triangle mesh')
 
         f = poly_data.faces.reshape((-1, 4))
-        f[:, 1:] = f[:, 1:][:, ::-1]        
+        f[:, 1:] = f[:, 1:][:, ::-1]
 
     def delaunay_2d(poly_data, tol=1e-05, alpha=0.0, offset=1.0, bound=False,
                     inplace=False, edge_source=None, progress_bar=False):
@@ -3670,13 +3658,9 @@ class PolyDataFilters(DataSetFilters):
         poly_data.overwrite(output)
 
 
+@abstract_class
 class UnstructuredGridFilters(DataSetFilters):
     """An internal class to manage filtes/algorithms for unstructured grid datasets."""
-
-    def __new__(cls, *args, **kwargs):  # pragma: no cover
-        """Allocate memory for the unstructured grid."""
-        if cls is UnstructuredGridFilters:
-            raise TypeError("pyvista.UnstructuredGridFilters is an abstract class and may not be instantiated.")
 
     def delaunay_2d(ugrid, tol=1e-05, alpha=0.0, offset=1.0, bound=False,
                     progress_bar=False):
@@ -3695,13 +3679,9 @@ class UnstructuredGridFilters(DataSetFilters):
                                                           progress_bar=progress_bar)
 
 
+@abstract_class
 class UniformGridFilters(DataSetFilters):
     """An internal class to manage filtes/algorithms for uniform grid datasets."""
-
-    def __new__(cls, *args, **kwargs):  # pragma: no cover
-        """Allocate memory for the uniform grid."""
-        if cls is UniformGridFilters:
-            raise TypeError("pyvista.UniformGridFilters is an abstract class and may not be instantiated.")
 
     def gaussian_smooth(dataset, radius_factor=1.5, std_dev=2.,
                         scalars=None, preference='points', progress_bar=False):

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -8,6 +8,7 @@ from vtk import vtkImageData, vtkRectilinearGrid
 from vtk.util.numpy_support import numpy_to_vtk, vtk_to_numpy
 
 import pyvista
+from pyvista.utilities import abstract_class
 from .common import Common
 from .filters import _get_output, UniformGridFilters
 
@@ -15,14 +16,9 @@ log = logging.getLogger(__name__)
 log.setLevel('CRITICAL')
 
 
+@abstract_class
 class Grid(Common):
     """A class full of common methods for non-pointset grids."""
-
-    def __new__(cls, *args, **kwargs):
-        """Allocate a grid."""
-        if cls is Grid:
-            raise TypeError("pyvista.Grid is an abstract class and may not be instantiated.")
-        return object.__new__(cls, *args, **kwargs)
 
     def __init__(self, *args, **kwargs):
         """Initialize the grid."""

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -15,6 +15,7 @@ from vtk.util.numpy_support import (numpy_to_vtk, numpy_to_vtkIdTypeArray,
                                     vtk_to_numpy)
 
 import pyvista
+from pyvista.utilities import abstract_class
 from .common import Common
 from .filters import PolyDataFilters, UnstructuredGridFilters
 from ..utilities.fileio import get_ext
@@ -478,14 +479,9 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
         return alg.GetOutput().GetNumberOfCells()
 
 
+@abstract_class
 class PointGrid(PointSet):
     """Class in common with structured and unstructured grids."""
-
-    def __new__(cls, *args, **kwargs):
-        """Allocate memory for the point grid."""
-        if cls is PointGrid:
-            raise TypeError("pyvista.PointGrid is an abstract class and may not be instantiated.")
-        return object.__new__(cls, *args, **kwargs)
 
     def __init__(self, *args, **kwargs):
         """Initialize the point grid."""

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -18,7 +18,7 @@ from vtk.util.numpy_support import numpy_to_vtk, vtk_to_numpy
 import pyvista
 from pyvista.utilities import (assert_empty_kwargs,
                                convert_array, convert_string_array, get_array,
-                               is_pyvista_dataset, numpy_to_texture,
+                               is_pyvista_dataset, numpy_to_texture, abstract_class,
                                raise_not_matching, try_callback, wrap)
 from .background_renderer import BackgroundRenderer
 from .colors import get_cmap_safe
@@ -53,6 +53,7 @@ log = logging.getLogger(__name__)
 log.setLevel('CRITICAL')
 
 
+@abstract_class
 class BasePlotter(PickingHelper, WidgetHelper):
     """To be used by the Plotter and pyvistaqt.QtInteractor classes.
 
@@ -86,12 +87,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     mouse_position = None
     click_position = None
-
-    def __new__(cls, *args, **kwargs):
-        """Create an instance of base plotter."""
-        if cls is BasePlotter:
-            raise TypeError("pyvista.BasePlotter is an abstract class and may not be instantiated.")
-        return object.__new__(cls)
 
     def __init__(self, shape=(1, 1), border=None, border_color='k',
                  border_width=2.0, title=None, splitting_position=None):

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -716,13 +716,15 @@ class ProgressMonitor():
             signal.signal(signal.SIGINT, self._old_handler)
 
 
-def abstract_class(cls):
+def abstract_class(cls_):
     """Decorator which overrides __new__ preventing a class from being,
       instantiated, similar to abc.ABCMeta but does not require an abstract method.
     """
 
     def __new__(cls, *args, **kwargs):
-        raise TypeError('{} is an abstract class and may not be instantiated.'
-                        .format(cls.__name__))
-    cls.__new__ = __new__
-    return cls
+        if cls is cls_:
+            raise TypeError('{} is an abstract class and may not be instantiated.'
+                            .format(cls.__name__))
+        return object.__new__(cls)
+    cls_.__new__ = __new__
+    return cls_

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -717,8 +717,10 @@ class ProgressMonitor():
 
 
 def abstract_class(cls_):
-    """Decorator which overrides __new__ preventing a class from being,
-      instantiated, similar to abc.ABCMeta but does not require an abstract method.
+    """Decorate a class, overriding __new__.
+
+    Preventing a class from being instantiated similar to abc.ABCMeta
+      but does not require an abstract method.
     """
 
     def __new__(cls, *args, **kwargs):

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -717,10 +717,12 @@ class ProgressMonitor():
 
 
 def abstract_class(cls):
-    """Decorator which prevents a class from being instantiated,
-     similar to abc.ABCMeta but does not require an abstract method.
+    """Decorator which overrides __new__ preventing a class from being,
+      instantiated, similar to abc.ABCMeta but does not require an abstract method.
     """
 
-    def new(cls, *args, **kwargs):
-        raise TypeError("pyvista.Common is an abstract class and may not be instantiated.")
-    return type(name=cls.__name__, bases=(), dict={'__new__': new})
+    def __new__(cls, *args, **kwargs):
+        raise TypeError('{} is an abstract class and may not be instantiated.'
+                        .format(cls.__name__))
+    cls.__new__ = __new__
+    return cls

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -714,3 +714,13 @@ class ProgressMonitor():
         self.algorithm.RemoveObservers(self.event_type)
         if threading.current_thread().__class__.__name__ == '_MainThread':
             signal.signal(signal.SIGINT, self._old_handler)
+
+
+def abstract_class(cls):
+    """Decorator which prevents a class from being instantiated,
+     similar to abc.ABCMeta but does not require an abstract method.
+    """
+
+    def new(cls, *args, **kwargs):
+        raise TypeError("pyvista.Common is an abstract class and may not be instantiated.")
+    return type(name=cls.__name__, bases=(), dict={'__new__': new})

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,4 +1,5 @@
 import os
+import weakref
 
 import numpy as np
 import pytest
@@ -90,6 +91,13 @@ def test_init_from_arrays():
 
     assert grid.n_cells == 2
     assert np.allclose(cells, grid.cells)
+
+
+def test_destructor():
+    ugrid = examples.load_hexbeam()
+    ref = weakref.ref(ugrid)
+    del ugrid
+    assert ref() is None
 
 
 def test_surface_indices(hexbeam):


### PR DESCRIPTION
### Overview

Adds a decorator which marks a class abstract, preventing instantiation, similarly to abc, but does not require any @abstractmethods. Basically just automatically replaces \_\_new__ with the same \_\_new__ that was copy pasted before.

