### PR TITLE
Fix/update various type checks

### DIFF
--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -1,6 +1,6 @@
 """Attributes common to PolyData and Grid Objects."""
 
-import collections
+import collections.abc
 import logging
 import os
 import warnings
@@ -882,7 +882,7 @@ class Common(DataSetFilters, DataObject):
 
     def __getitem__(self, index):
         """Search both point, cell, and field data for an array."""
-        if isinstance(index, collections.Iterable) and not isinstance(index, str):
+        if isinstance(index, collections.abc.Iterable) and not isinstance(index, str):
             name, preference = index
         elif isinstance(index, str):
             name = index
@@ -1110,7 +1110,7 @@ class Common(DataSetFilters, DataObject):
         ------
         int : the index of the point in this mesh that is closes to the given point.
         """
-        if not isinstance(point, collections.Iterable) or len(point) != 3:
+        if not isinstance(point, collections.abc.Iterable) or len(point) != 3:
             raise TypeError("Given point must be a length three iterable.")
         if not isinstance(n, int):
             raise TypeError("`n` must be a positive integer.")

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -1110,8 +1110,8 @@ class Common(DataSetFilters, DataObject):
         ------
         int : the index of the point in this mesh that is closes to the given point.
         """
-        if not isinstance(point, collections.abc.Iterable) or len(point) != 3:
-            raise TypeError("Given point must be a length three iterable.")
+        if not isinstance(point, (np.ndarray, collections.abc.Sequence)) or len(point) != 3:
+            raise TypeError("Given point must be a length three sequence.")
         if not isinstance(n, int):
             raise TypeError("`n` must be a positive integer.")
         if n < 1:

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -3,7 +3,7 @@
 These classes hold many VTK datasets in one object that can be passed
 to VTK algorithms and PyVista filtering/plotting routines.
 """
-import collections
+import collections.abc
 import logging
 
 import numpy as np
@@ -289,7 +289,7 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
         3
 
         """
-        if isinstance(index, collections.Iterable) and not isinstance(index, str):
+        if isinstance(index, collections.abc.Iterable) and not isinstance(index, str):
             i, name = index[0], index[1]
         elif isinstance(index, str):
             try:

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -289,7 +289,7 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
         3
 
         """
-        if isinstance(index, collections.abc.Iterable) and not isinstance(index, str):
+        if isinstance(index, (np.ndarray, collections.abc.Sequence)) and not isinstance(index, str):
             i, name = index[0], index[1]
         elif isinstance(index, str):
             try:

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -174,7 +174,7 @@ class DataSetFilters:
                 bounds.append(normal)
                 bounds.append(cell.center)
         if not isinstance(bounds, (np.ndarray, collections.abc.Sequence)) or len(bounds) not in [3, 6, 12]:
-            raise AssertionError('Bounds must be a sequence of floats with length 3, 6 or 12.')
+            raise TypeError('Bounds must be a sequence of floats with length 3, 6 or 12.')
         if len(bounds) == 3:
             xmin, xmax, ymin, ymax, zmin, zmax = dataset.bounds
             bounds = (xmin,xmin+bounds[0], ymin,ymin+bounds[1], zmin,zmin+bounds[2])

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -22,7 +22,7 @@ Example
 >>> iso = dataset.contour()
 
 """
-import collections
+import collections.abc
 import logging
 from functools import wraps
 
@@ -175,7 +175,7 @@ class DataSetFilters:
         if len(bounds) == 3:
             xmin, xmax, ymin, ymax, zmin, zmax = dataset.bounds
             bounds = (xmin,xmin+bounds[0], ymin,ymin+bounds[1], zmin,zmin+bounds[2])
-        if not isinstance(bounds, collections.Iterable) or not (len(bounds) == 6 or len(bounds) == 12):
+        if not isinstance(bounds, collections.abc.Iterable) or not (len(bounds) == 6 or len(bounds) == 12):
             raise AssertionError('Bounds must be a length 6 iterable of floats.')
         alg = vtk.vtkBoxClipDataSet()
         alg.SetInputDataObject(dataset)
@@ -505,7 +505,7 @@ class DataSetFilters:
             raise AssertionError('No arrays present to threshold.')
 
         # If using an inverted range, merge the result of two filters:
-        if isinstance(value, collections.Iterable) and invert:
+        if isinstance(value, collections.abc.Iterable) and invert:
             valid_range = [np.nanmin(arr), np.nanmax(arr)]
             # Create two thresholds
             t1 = dataset.threshold([valid_range[0], value[0]], scalars=scalars,
@@ -530,7 +530,7 @@ class DataSetFilters:
         if value is None:
             value = dataset.get_data_range(scalars)
         # check if value is iterable (if so threshold by min max range like ParaView)
-        if isinstance(value, collections.Iterable):
+        if isinstance(value, collections.abc.Iterable):
             if len(value) != 2:
                 raise AssertionError('Value range must be length one for a float value or two for min/max; not ({}).'.format(value))
             alg.ThresholdBetween(value[0], value[1])
@@ -595,7 +595,7 @@ class DataSetFilters:
             return dmin + float(percent) * (dmax - dmin)
 
         # Compute the values
-        if isinstance(percent, collections.Iterable):
+        if isinstance(percent, collections.abc.Iterable):
             # Get two values
             value = [_get_val(percent[0], dmin, dmax), _get_val(percent[1], dmin, dmax)]
         else:
@@ -733,7 +733,7 @@ class DataSetFilters:
             scalar_range = (low_point[2], high_point[2])
         elif isinstance(scalar_range, str):
             scalar_range = dataset.get_data_range(arr=scalar_range, preference=preference)
-        elif isinstance(scalar_range, collections.Iterable):
+        elif isinstance(scalar_range, collections.abc.Iterable):
             if len(scalar_range) != 2:
                 raise ValueError('scalar_range must have a length of two defining the min and max')
         else:
@@ -825,7 +825,7 @@ class DataSetFilters:
             if rng is None:
                 rng = dataset.get_data_range(scalars)
             alg.GenerateValues(isosurfaces, rng)
-        elif isinstance(isosurfaces, collections.Iterable):
+        elif isinstance(isosurfaces, collections.abc.Iterable):
             alg.SetNumberOfContours(len(isosurfaces))
             for i, val in enumerate(isosurfaces):
                 alg.SetValue(i, val)
@@ -1870,7 +1870,7 @@ class DataSetFilters:
             Subselected grid.
 
         """
-        if not isinstance(ind, collections.Iterable):
+        if not isinstance(ind, collections.abc.Iterable):
             raise TypeError('`ind` must be either a mask, array, list, or iterable')
 
         ind = np.asarray(ind)
@@ -3380,7 +3380,7 @@ class PolyDataFilters(DataSetFilters):
             returned when inplace=False.
 
         """
-        if isinstance(remove, collections.Iterable):
+        if isinstance(remove, collections.abc.Iterable):
             remove = np.asarray(remove)
 
         if remove.dtype == np.bool:
@@ -3523,7 +3523,7 @@ class PolyDataFilters(DataSetFilters):
 
     def project_points_to_plane(poly_data, origin=None, normal=(0,0,1), inplace=False):
         """Project points of this mesh to a plane."""
-        if not isinstance(normal, collections.Iterable) or len(normal) != 3:
+        if not isinstance(normal, collections.abc.Iterable) or len(normal) != 3:
             raise TypeError('Normal must be a length three vector')
         if origin is None:
             origin = np.array(poly_data.center) - np.array(normal)*poly_data.length/2.
@@ -3732,11 +3732,11 @@ class UniformGridFilters(DataSetFilters):
         else:
             _, field = dataset.get_array(scalars, preference=preference, info=True)
         alg.SetInputArrayToProcess(0, 0, 0, field.value, scalars) # args: (idx, port, connection, field, name)
-        if isinstance(radius_factor, collections.Iterable):
+        if isinstance(radius_factor, collections.abc.Iterable):
             alg.SetRadiusFactors(radius_factor)
         else:
             alg.SetRadiusFactors(radius_factor, radius_factor, radius_factor)
-        if isinstance(std_dev, collections.Iterable):
+        if isinstance(std_dev, collections.abc.Iterable):
             alg.SetStandardDeviations(std_dev)
         else:
             alg.SetStandardDeviations(std_dev, std_dev, std_dev)

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -130,7 +130,7 @@ class DataSetFilters:
 
         If no bounds are given, a corner of the dataset bounds will be removed.
 
-        Parametersequence
+        Parameters
         ----------
         bounds : tuple(float)
             Length 6 sequence of floats: (xmin, xmax, ymin, ymax, zmin, zmax).

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -130,13 +130,13 @@ class DataSetFilters:
 
         If no bounds are given, a corner of the dataset bounds will be removed.
 
-        Parameters
+        Parametersequence
         ----------
         bounds : tuple(float)
-            Length 6 iterable of floats: (xmin, xmax, ymin, ymax, zmin, zmax).
-            Length 3 iterable of floats: distances from the min coordinate of
+            Length 6 sequence of floats: (xmin, xmax, ymin, ymax, zmin, zmax).
+            Length 3 sequence of floats: distances from the min coordinate of
             of the input mesh. Single float value: uniform distance from the
-            min coordinate. Length 12 iterable of length 3 iterable of floats:
+            min coordinate. Length 12 sequence of length 3 sequence of floats:
             a plane collection (normal, center, ...).
             :class:`pyvista.PolyData`: if a poly mesh is passed that represents
             a box with 6 faces that all form a standard box, then planes will
@@ -175,8 +175,8 @@ class DataSetFilters:
         if len(bounds) == 3:
             xmin, xmax, ymin, ymax, zmin, zmax = dataset.bounds
             bounds = (xmin,xmin+bounds[0], ymin,ymin+bounds[1], zmin,zmin+bounds[2])
-        if not isinstance(bounds, collections.abc.Iterable) or not (len(bounds) == 6 or len(bounds) == 12):
-            raise AssertionError('Bounds must be a length 6 iterable of floats.')
+        if not isinstance(bounds, (np.ndarray, collections.abc.Sequence)) or not (len(bounds) == 6 or len(bounds) == 12):
+            raise AssertionError('Bounds must be a length 6 sequence of floats.')
         alg = vtk.vtkBoxClipDataSet()
         alg.SetInputDataObject(dataset)
         alg.SetBoxClip(*bounds)
@@ -457,9 +457,9 @@ class DataSetFilters:
 
         Parameters
         ----------
-        value : float or iterable, optional
+        value : float or sequence, optional
             Single value or (min, max) to be used for the data threshold.  If
-            iterable, then length must be 2. If no value is specified, the
+            a sequence, then length must be 2. If no value is specified, the
             non-NaN data range will be used to remove any NaN values.
 
         scalars : str, optional
@@ -505,7 +505,7 @@ class DataSetFilters:
             raise AssertionError('No arrays present to threshold.')
 
         # If using an inverted range, merge the result of two filters:
-        if isinstance(value, collections.abc.Iterable) and invert:
+        if isinstance(value, (np.ndarray, collections.abc.Sequence)) and invert:
             valid_range = [np.nanmin(arr), np.nanmax(arr)]
             # Create two thresholds
             t1 = dataset.threshold([valid_range[0], value[0]], scalars=scalars,
@@ -529,8 +529,8 @@ class DataSetFilters:
         # use valid range if no value given
         if value is None:
             value = dataset.get_data_range(scalars)
-        # check if value is iterable (if so threshold by min max range like ParaView)
-        if isinstance(value, collections.abc.Iterable):
+        # check if value is a sequence (if so threshold by min max range like ParaView)
+        if isinstance(value, (np.ndarray, collections.abc.Sequence)):
             if len(value) != 2:
                 raise AssertionError('Value range must be length one for a float value or two for min/max; not ({}).'.format(value))
             alg.ThresholdBetween(value[0], value[1])
@@ -595,7 +595,7 @@ class DataSetFilters:
             return dmin + float(percent) * (dmax - dmin)
 
         # Compute the values
-        if isinstance(percent, collections.abc.Iterable):
+        if isinstance(percent, (np.ndarray, collections.abc.Sequence)):
             # Get two values
             value = [_get_val(percent[0], dmin, dmax), _get_val(percent[1], dmin, dmax)]
         else:
@@ -733,7 +733,7 @@ class DataSetFilters:
             scalar_range = (low_point[2], high_point[2])
         elif isinstance(scalar_range, str):
             scalar_range = dataset.get_data_range(arr=scalar_range, preference=preference)
-        elif isinstance(scalar_range, collections.abc.Iterable):
+        elif isinstance(scalar_range, (np.ndarray, collections.abc.Sequence)):
             if len(scalar_range) != 2:
                 raise ValueError('scalar_range must have a length of two defining the min and max')
         else:
@@ -758,13 +758,13 @@ class DataSetFilters:
         """Contour an input dataset by an array.
 
         ``isosurfaces`` can be an integer specifying the number of isosurfaces in
-        the data range or an iterable set of values for explicitly setting the isosurfaces.
+        the data range or a sequence of values for explicitly setting the isosurfaces.
 
         Parameters
         ----------
-        isosurfaces : int or iterable
-            Number of isosurfaces to compute across valid data range or an
-            iterable of float values to explicitly use as the isosurfaces.
+        isosurfaces : int or sequence
+            Number of isosurfaces to compute across valid data range or a
+            sequence of float values to explicitly use as the isosurfaces.
 
         scalars : str, optional
             Name of scalars to threshold on. Defaults to currently active scalars.
@@ -825,7 +825,7 @@ class DataSetFilters:
             if rng is None:
                 rng = dataset.get_data_range(scalars)
             alg.GenerateValues(isosurfaces, rng)
-        elif isinstance(isosurfaces, collections.abc.Iterable):
+        elif isinstance(isosurfaces, (np.ndarray, collections.abc.Sequence)):
             alg.SetNumberOfContours(len(isosurfaces))
             for i, val in enumerate(isosurfaces):
                 alg.SetValue(i, val)
@@ -1861,7 +1861,7 @@ class DataSetFilters:
 
         Parameters
         ----------
-        ind : np.ndarray, list, or iterable
+        ind : np.ndarray, list, or sequence
             Numpy array of point indices to be extracted.
 
         Return
@@ -1870,8 +1870,8 @@ class DataSetFilters:
             Subselected grid.
 
         """
-        if not isinstance(ind, collections.abc.Iterable):
-            raise TypeError('`ind` must be either a mask, array, list, or iterable')
+        if not isinstance(ind, (np.ndarray, collections.abc.Sequence)):
+            raise TypeError('`ind` must be either a mask, array, list, or other sequence')
 
         ind = np.asarray(ind)
         if ind.dtype == np.bool:
@@ -3380,7 +3380,7 @@ class PolyDataFilters(DataSetFilters):
             returned when inplace=False.
 
         """
-        if isinstance(remove, collections.abc.Iterable):
+        if isinstance(remove, (np.ndarray, collections.abc.Sequence)):
             remove = np.asarray(remove)
 
         if remove.dtype == np.bool:
@@ -3523,7 +3523,7 @@ class PolyDataFilters(DataSetFilters):
 
     def project_points_to_plane(poly_data, origin=None, normal=(0,0,1), inplace=False):
         """Project points of this mesh to a plane."""
-        if not isinstance(normal, collections.abc.Iterable) or len(normal) != 3:
+        if not isinstance(normal, (np.ndarray, collections.abc.Sequence)) or len(normal) != 3:
             raise TypeError('Normal must be a length three vector')
         if origin is None:
             origin = np.array(poly_data.center) - np.array(normal)*poly_data.length/2.

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -173,11 +173,11 @@ class DataSetFilters:
                 normal = cell["Normals"][0]
                 bounds.append(normal)
                 bounds.append(cell.center)
+        if not isinstance(bounds, (np.ndarray, collections.abc.Sequence)) or len(bounds) not in [3, 6, 12]:
+            raise AssertionError('Bounds must be a sequence of floats with length 3, 6 or 12.')
         if len(bounds) == 3:
             xmin, xmax, ymin, ymax, zmin, zmax = dataset.bounds
             bounds = (xmin,xmin+bounds[0], ymin,ymin+bounds[1], zmin,zmin+bounds[2])
-        if not isinstance(bounds, (np.ndarray, collections.abc.Sequence)) or not (len(bounds) == 6 or len(bounds) == 12):
-            raise AssertionError('Bounds must be a length 6 sequence of floats.')
         alg = vtk.vtkBoxClipDataSet()
         alg.SetInputDataObject(dataset)
         alg.SetBoxClip(*bounds)

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -3357,8 +3357,11 @@ class PolyDataFilters(DataSetFilters):
             returned when inplace=False.
 
         """
-        if isinstance(remove, (np.ndarray, collections.abc.Sequence)):
-            remove = np.asarray(remove)
+        remove = np.asarray(remove)
+    
+        # np.asarray will eat anything, so we have to weed out bogus inputs
+        if not issubclass(remove.dtype.type, (np.bool_, np.integer)):
+            raise TypeError('Remove must be either a mask or an integer array-like')
 
         if remove.dtype == np.bool:
             if remove.size != poly_data.n_points:

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -535,6 +535,8 @@ class DataSetFilters:
             if len(value) != 2:
                 raise AssertionError('Value range must be length one for a float value or two for min/max; not ({}).'.format(value))
             alg.ThresholdBetween(value[0], value[1])
+        elif isinstance(value, collections.abc.Iterable):
+            raise TypeError('Value must either be a single scalar or a sequence.')
         else:
             # just a single value
             if invert:
@@ -599,6 +601,8 @@ class DataSetFilters:
         if isinstance(percent, (np.ndarray, collections.abc.Sequence)):
             # Get two values
             value = [_get_val(percent[0], dmin, dmax), _get_val(percent[1], dmin, dmax)]
+        elif isinstance(percent, collections.abc.Iterable):
+            raise TypeError('Percent must either be a single scalar or a sequence.')
         else:
             # Compute one value to threshold
             value = _get_val(percent, dmin, dmax)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1,6 +1,6 @@
 """Pyvista plotting module."""
 
-import collections
+import collections.abc
 import logging
 import os
 import time
@@ -159,7 +159,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         else:
 
             assert_str = '"shape" should be a list, tuple or string descriptor'
-            assert isinstance(shape, collections.Iterable), assert_str
+            assert isinstance(shape, collections.abc.Iterable), assert_str
             assert shape[0] > 0, '"shape" must be positive'
             assert shape[1] > 0, '"shape" must be positive'
             self.shape = shape
@@ -227,7 +227,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             return self._active_renderer_index
         elif isinstance(loc, int):
             return loc
-        elif isinstance(loc, collections.Iterable):
+        elif isinstance(loc, collections.abc.Iterable):
             if not len(loc) == 2:
                 raise AssertionError('"loc" must contain two items')
             index_row = loc[0]
@@ -2095,7 +2095,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if isinstance(views, int):
             for renderer in self.renderers:
                 renderer.camera = self.renderers[views].camera
-        elif isinstance(views, collections.Iterable):
+        elif isinstance(views, collections.abc.Iterable):
             for view_index in views:
                 self.renderers[view_index].camera = \
                     self.renderers[views[0]].camera
@@ -2121,7 +2121,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         elif isinstance(views, int):
             self.renderers[views].camera = vtk.vtkCamera()
             self.renderers[views].reset_camera()
-        elif isinstance(views, collections.Iterable):
+        elif isinstance(views, collections.abc.Iterable):
             for view_index in views:
                 self.renderers[view_index].camera = vtk.vtkCamera()
                 self.renderers[view_index].reset_camera()
@@ -2461,7 +2461,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if mesh is None:
             mesh = self.mesh
 
-        if isinstance(mesh, (collections.Iterable, pyvista.MultiBlock)):
+        if isinstance(mesh, (collections.abc.Iterable, pyvista.MultiBlock)):
             # Recursive if need to update scalars on many meshes
             for m in mesh:
                 self.update_scalars(scalars, mesh=m, render=False)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -159,7 +159,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         else:
 
             assert_str = '"shape" should be a list, tuple or string descriptor'
-            assert isinstance(shape, collections.abc.Iterable), assert_str
+            assert isinstance(shape, (np.ndarray, collections.abc.Sequence)), assert_str
             assert shape[0] > 0, '"shape" must be positive'
             assert shape[1] > 0, '"shape" must be positive'
             self.shape = shape
@@ -227,7 +227,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             return self._active_renderer_index
         elif isinstance(loc, int):
             return loc
-        elif isinstance(loc, collections.abc.Iterable):
+        elif isinstance(loc, (np.ndarray, collections.abc.Sequence)):
             if not len(loc) == 2:
                 raise AssertionError('"loc" must contain two items')
             index_row = loc[0]
@@ -2095,7 +2095,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if isinstance(views, int):
             for renderer in self.renderers:
                 renderer.camera = self.renderers[views].camera
-        elif isinstance(views, collections.abc.Iterable):
+        elif isinstance(views, (np.ndarray, collections.abc.Sequence)):
             for view_index in views:
                 self.renderers[view_index].camera = \
                     self.renderers[views[0]].camera

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -182,9 +182,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
             # Check and convert groups to internal format (Nx4 matrix where every row contains the row and col index of the top left cell
             # together with the row and col index of the bottom right cell)
             if groups is not None:
-                assert isinstance(groups, collections.Sequence), '"groups" should be a list or tuple'
+                assert isinstance(groups, collections.abc.Sequence), '"groups" should be a list or tuple'
                 for group in groups:
-                    assert isinstance(group, collections.Sequence) and len(group)==2, 'each group entry should be a list or tuple of 2 elements'
+                    assert isinstance(group, collections.abc.Sequence) and len(group)==2, 'each group entry should be a list or tuple of 2 elements'
                     rows = group[0]
                     if isinstance(rows,slice):
                         rows = np.arange(self.shape[0],dtype=int)[rows]

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1,6 +1,6 @@
 """Module containing pyvista implementation of vtkRenderer."""
 
-import collections
+import collections.abc
 import logging
 from weakref import proxy
 
@@ -1156,7 +1156,7 @@ class Renderer(vtkRenderer):
             except KeyError:
                 # If actor of that name is not present then return success
                 return False
-        if isinstance(actor, collections.Iterable):
+        if isinstance(actor, collections.abc.Iterable):
             success = False
             for a in actor:
                 rv = self.remove_actor(a, reset_camera=reset_camera)

--- a/pyvista/utilities/cells.py
+++ b/pyvista/utilities/cells.py
@@ -1,5 +1,4 @@
 """pyvista wrapping of vtkCellArray."""
-import collections.abc
 import numpy as np
 from vtk.util.numpy_support import numpy_to_vtkIdTypeArray, vtk_to_numpy
 from vtk import vtkCellArray

--- a/pyvista/utilities/cells.py
+++ b/pyvista/utilities/cells.py
@@ -1,4 +1,5 @@
 """pyvista wrapping of vtkCellArray."""
+import collections.abc
 import numpy as np
 from vtk.util.numpy_support import numpy_to_vtkIdTypeArray, vtk_to_numpy
 from vtk import vtkCellArray
@@ -8,12 +9,13 @@ import pyvista
 
 def numpy_to_idarr(ind, deep=False, return_ind=False):
     """Safely convert a numpy array to a vtkIdTypeArray."""
-    try:
-        ind = np.asarray(ind)
-    except:
-        raise TypeError('Indices must be either a mask, array, list, or iterable')
+    ind = np.asarray(ind)
 
-    if ind.dtype == np.bool:
+    # np.asarray will eat anything, so we have to weed out bogus inputs
+    if not issubclass(ind.dtype.type, (np.bool_, np.integer, np.floating)):
+        raise TypeError('Indices must be either a mask or a numeric array-like')
+
+    if ind.dtype == np.bool_:
         ind = ind.nonzero()[0].astype(pyvista.ID_TYPE)
     elif ind.dtype != pyvista.ID_TYPE:
         ind = ind.astype(pyvista.ID_TYPE)

--- a/pyvista/utilities/cells.py
+++ b/pyvista/utilities/cells.py
@@ -11,8 +11,8 @@ def numpy_to_idarr(ind, deep=False, return_ind=False):
     ind = np.asarray(ind)
 
     # np.asarray will eat anything, so we have to weed out bogus inputs
-    if not issubclass(ind.dtype.type, (np.bool_, np.integer, np.floating)):
-        raise TypeError('Indices must be either a mask or a numeric array-like')
+    if not issubclass(ind.dtype.type, (np.bool_, np.integer)):
+        raise TypeError('Indices must be either a mask or an integer array-like')
 
     if ind.dtype == np.bool_:
         ind = ind.nonzero()[0].astype(pyvista.ID_TYPE)

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -1,6 +1,6 @@
 """Supporting functions for polydata and grid objects."""
 
-import collections
+import collections.abc
 import ctypes
 import enum
 import logging
@@ -505,7 +505,7 @@ def is_inside_bounds(point, bounds):
     """
     if isinstance(point, (int, float)):
         point = [point]
-    if isinstance(point, collections.Iterable) and not isinstance(point, collections.deque):
+    if isinstance(point, collections.abc.Iterable) and not isinstance(point, collections.deque):
         if len(bounds) < 2 * len(point) or len(bounds) % 2 != 0:
             raise AssertionError('Bounds mismatch point dimensionality')
         point = collections.deque(point)

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -505,7 +505,7 @@ def is_inside_bounds(point, bounds):
     """
     if isinstance(point, (int, float)):
         point = [point]
-    if isinstance(point, collections.abc.Iterable) and not isinstance(point, collections.deque):
+    if isinstance(point, (np.ndarray, collections.abc.Sequence)) and not isinstance(point, collections.deque):
         if len(bounds) < 2 * len(point) or len(bounds) % 2 != 0:
             raise AssertionError('Bounds mismatch point dimensionality')
         point = collections.deque(point)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -729,6 +729,10 @@ def test_find_closest_point():
     with pytest.raises(TypeError):
         sphere.find_closest_point([0, 0, 0], n=3.0)
 
+    with pytest.raises(TypeError):
+        # allow Sequence but not Iterable
+        sphere.find_closest_point({1, 2, 3})
+
     index = sphere.find_closest_point(node)
     assert isinstance(index, int)
     # Make sure we can fetch that point

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -144,6 +144,9 @@ def test_multi_block_set_get_ers():
     assert multi.get_block_name(10) is None
     with pytest.raises(KeyError):
         _ = multi.get_index_by_name('foo')
+    # allow Sequence but not Iterable in setitem
+    with pytest.raises(TypeError):
+        multi[{1, 'foo'}] = data
 
 
 def test_multi_block_clean(rectilinear, uniform, ant):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -72,6 +72,9 @@ def test_clip_box():
     assert result.n_cells
     with pytest.raises(TypeError):
         dataset.clip_box(bounds=(5, 6,))
+    # allow Sequence but not Iterable bounds
+    with pytest.raises(TypeError):
+        dataset.clip_box(bounds={5, 6, 7})
     # Test with a poly data box
     mesh = examples.load_airplane()
     box = pyvista.Cube(center=(0.9e3, 0.2e3, mesh.center[2]),
@@ -198,6 +201,9 @@ def test_threshold():
     thresh = dataset.threshold([100, 500], invert=True)
     assert thresh is not None
     assert isinstance(thresh, pyvista.UnstructuredGrid)
+    # allow Sequence but not Iterable
+    with pytest.raises(TypeError):
+        dataset.threshold({100, 500})
     # Now test DATASETS without arrays
     with pytest.raises(AssertionError):
         for i, dataset in enumerate(DATASETS[3:-1]):
@@ -223,6 +229,9 @@ def test_threshold_percent():
         result = dataset.threshold_percent(20000)
     with pytest.raises(RuntimeError):
         result = dataset.threshold_percent(0.0)
+    # allow Sequence but not Iterable
+    with pytest.raises(TypeError):
+        dataset.threshold_percent({18.0, 85.0})
 
 
 def test_outline():
@@ -305,6 +314,8 @@ def test_contour_errors(uniform):
         uniform.contour(scalars='Spatial Cell Data')
     with pytest.raises(RuntimeError):
         uniform.contour(isosurfaces=pyvista.PolyData())
+    with pytest.raises(RuntimeError):
+        uniform.contour(isosurfaces={100, 300, 500})
     uniform = examples.load_airplane()
     with pytest.raises(AssertionError):
         uniform.contour()
@@ -346,6 +357,8 @@ def test_elevation():
         elev = dataset.elevation(scalar_range=0.5)
     with pytest.raises(ValueError):
         elev = dataset.elevation(scalar_range=[1, 2, 3])
+    with pytest.raises(RuntimeError):
+        elev = dataset.elevation(scalar_range={1, 2})
 
 
 @skip_py2_nobind

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -70,7 +70,7 @@ def test_clip_box():
     dataset = examples.load_uniform()
     result = dataset.clip_box(bounds=0.5)
     assert result.n_cells
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         dataset.clip_box(bounds=(5, 6,))
     # Test with a poly data box
     mesh = examples.load_airplane()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -73,6 +73,21 @@ def test_plot_invalid_style():
 
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+def test_plotter_shape_invalid():
+    # wrong size
+    with pytest.raises(ValueError):
+        pyvista.Plotter(shape=(1,))
+    # not positive
+    with pytest.raises(ValueError):
+        pyvista.Plotter(shape=(1, 0))
+    with pytest.raises(ValueError):
+        pyvista.Plotter(shape=(0, 2))
+    # not a sequence
+    with pytest.raises(TypeError):
+        pyvista.Plotter(shape={1, 2})
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_plot_bounds_axes_with_no_data():
     plotter = pyvista.Plotter()
     plotter.show_bounds()
@@ -997,3 +1012,35 @@ def test_reset_camera_clipping_range():
     pl.reset_camera_clipping_range()
     assert pl.camera.GetClippingRange() ==  default_clipping_range
     assert pl.camera.GetClippingRange() != (10,100)
+
+
+def test_index_vs_loc():
+    # first: 2d grid
+    pl = pyvista.Plotter(shape=(2, 3))
+    # index_to_loc valid cases
+    vals = [0, 2, 4]
+    expecteds = [(0, 0), (0, 2), (1, 1)]
+    for val,expected in zip(vals, expecteds):
+        assert tuple(pl.index_to_loc(val)) == expected
+    # loc_to_index valid cases
+    vals = [(0, 0), (0, 2), (1, 1)]
+    expecteds = [0, 2, 4]
+    for val,expected in zip(vals, expecteds):
+        assert pl.loc_to_index(val) == expected
+        assert pl.loc_to_index(expected) == expected
+    # failing cases
+    with pytest.raises(TypeError):
+        pl.loc_to_index({1, 2})
+    with pytest.raises(TypeError):
+        pl.index_to_loc(1.5)
+    with pytest.raises(TypeError):
+        pl.index_to_loc((1, 2))
+
+    # then: "1d" grid
+    pl = pyvista.Plotter(shape='2|3')
+    # valid cases
+    for val in range(5):
+        assert pl.index_to_loc(val) == val
+        assert pl.index_to_loc(np.int_(val)) == val
+        assert pl.loc_to_index(val) == val
+        assert pl.loc_to_index(np.int_(val)) == val

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -484,6 +484,10 @@ def test_remove_points_fail(sphere, plane):
     with pytest.raises(ValueError):
         sphere.remove_points(np.ones(10, np.bool))
 
+    # invalid mask type
+    with pytest.raises(TypeError):
+        sphere.remove_points([0.0])
+
 
 def test_vertice_cells_on_read(tmpdir):
     point_cloud = pyvista.PolyData(np.random.rand(100, 3))
@@ -516,8 +520,12 @@ def test_project_points_to_plane():
     poly = pyvista.StructuredGrid(xx, yy, zz).extract_geometry()
     poly['elev'] = zz.ravel(order='f')
 
+    # Wrong normal length
     with pytest.raises(TypeError):
         poly.project_points_to_plane(normal=(0, 0, 1, 1))
+    # allow Sequence but not Iterable
+    with pytest.raises(TypeError):
+        poly.project_points_to_plane(normal={0, 1, 2})
 
     # Test the filter
     projected = poly.project_points_to_plane(origin=poly.center, normal=(0,0,1))


### PR DESCRIPTION
### Overview

I've noticed several instances of type checks against `collections.Iterable`. A lot of these should actually be stricter checks, and they should all be using `collections.abc` going forward.

### Details

The first commit replaces every instance of `collections.Iterable` with `collections.abc.Iterable`, as the former is deprecated.

The second commit replaces some instances of `collections.abc.Iterable` checks with `(np.ndarray, collections.abc.Sequence)` checks. The two cases that made this necessary were

  * subsequent `len` checks on the iterables,
  * subsequent subscription of the iterables, and
  * subsequent calls of `np.asarray` on the iterables.

For the above [an `Iterable` is insufficient](https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes). For instance `obj = iter([2, 3, 4])` would pass the `Iterable` check, but it would fail both at `len(obj)` and `obj[0]`, and produce an unexpected (object-dtype) array when passed to `np.asarray`. For `len` it would be enough to use `collections.abc.Collection`, but these don't necessarily support subscription (e.g. `set`s). In every case it seemed to me that the collections in question actually had inherent order to them: bounds with from/to, ranges as min/max, things like that. So semantically speaking I believe `collections.abc.Sequence` is the correct abstract base type to check.

The small blemish is that [`numpy.ndarray` doesn't register as a `Sequence`](https://github.com/numpy/numpy/issues/2776), so we also have to explicitly check for `ndarray`s as well (which are a very common use case for most inputs).

### TODO

- [x] also handle `numpy_to_idarr`
- [x] also handle similar instances of `np.asarray`, if any 
- [x] add tests for each fixed `Iterable` case
- [ ] ~maybe do the same for high-profile entry points with array-like inputs~