### PR TITLE
MAINT: Underscore numpy types

### DIFF
--- a/examples/00-load/create-spline.py
+++ b/examples/00-load/create-spline.py
@@ -36,9 +36,9 @@ def lines_from_points(points):
     """Given an array of points, make a line set"""
     poly = pv.PolyData()
     poly.points = points
-    cells = np.full((len(points)-1, 3), 2, dtype=np.int)
-    cells[:, 1] = np.arange(0, len(points)-1, dtype=np.int)
-    cells[:, 2] = np.arange(1, len(points), dtype=np.int)
+    cells = np.full((len(points)-1, 3), 2, dtype=np.int_)
+    cells[:, 1] = np.arange(0, len(points)-1, dtype=np.int_)
+    cells[:, 2] = np.arange(1, len(points), dtype=np.int_)
     poly.lines = cells
     return poly
 
@@ -59,7 +59,7 @@ tube.plot(smooth_shading=True)
 def polyline_from_points(points):
     poly = pv.PolyData()
     poly.points = points
-    the_cell = np.arange(0, len(points), dtype=np.int)
+    the_cell = np.arange(0, len(points), dtype=np.int_)
     the_cell = np.insert(the_cell, 0, len(points))
     poly.lines = the_cell
     return poly

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -158,7 +158,7 @@ class DataSetAttributes(VTKObjectWrapper):
                 return vtk_arr
         narray = pyvista_ndarray(vtk_arr, dataset=self.dataset, association=self.association)
         if vtk_arr.GetName() in self.dataset.association_bitarray_names[self.association]:
-            narray = narray.view(np.bool)
+            narray = narray.view(np.bool_)
         return narray
 
     def append(self, narray, name, deep_copy=False, active_vectors=True, active_scalars=True):
@@ -205,7 +205,7 @@ class DataSetAttributes(VTKObjectWrapper):
             raise ValueError('narray length of ({}) != required length ({})'.format(
                 narray.shape[0], array_len))
 
-        if narray.dtype == np.bool:
+        if narray.dtype == np.bool_:
             self.dataset.association_bitarray_names[self.association].add(name)
             narray = narray.view(np.uint8)
 

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -3344,12 +3344,12 @@ class PolyDataFilters(DataSetFilters):
         if isinstance(remove, collections.Iterable):
             remove = np.asarray(remove)
 
-        if remove.dtype == np.bool:
+        if remove.dtype == np.bool_:
             if remove.size != poly_data.n_points:
                 raise ValueError('Mask different size than n_points')
             remove_mask = remove
         else:
-            remove_mask = np.zeros(poly_data.n_points, np.bool)
+            remove_mask = np.zeros(poly_data.n_points, np.bool_)
             remove_mask[remove] = True
 
         if not poly_data.is_all_triangles():

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -82,7 +82,7 @@ class PointSet(Common):
         >>> letter_a.remove_cells(range(1000))
         """
         if isinstance(ind, np.ndarray):
-            if ind.dtype == np.bool and ind.size != self.n_cells:
+            if ind.dtype == np.bool_ and ind.size != self.n_cells:
                 raise ValueError('Boolean array size must match the '
                                  'number of cells (%d)' % self.n_cells)
         ghost_cells = np.zeros(self.n_cells, np.uint8)
@@ -837,7 +837,7 @@ class StructuredGrid(vtkStructuredGrid, PointGrid):
         >>> grid.hide_cells(range(79*30, 79*50))
         """
         if isinstance(ind, np.ndarray):
-            if ind.dtype == np.bool and ind.size != self.n_cells:
+            if ind.dtype == np.bool_ and ind.size != self.n_cells:
                 raise ValueError('Boolean array size must match the '
                                  'number of cells (%d)' % self.n_cells)
         ghost_cells = np.zeros(self.n_cells, np.uint8)

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -326,10 +326,10 @@ class PickingHelper:
         kwargs.setdefault('pickable', False)
 
         def make_line_cells(n_points):
-            # cells = np.full((n_points-1, 3), 2, dtype=np.int)
-            # cells[:, 1] = np.arange(0, n_points-1, dtype=np.int)
-            # cells[:, 2] = np.arange(1, n_points, dtype=np.int)
-            cells = np.arange(0, n_points, dtype=np.int)
+            # cells = np.full((n_points-1, 3), 2, dtype=np.int_)
+            # cells[:, 1] = np.arange(0, n_points-1, dtype=np.int_)
+            # cells[:, 2] = np.arange(1, n_points, dtype=np.int_)
+            cells = np.arange(0, n_points, dtype=np.int_)
             cells = np.insert(cells, 0, n_points)
             return cells
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1466,7 +1466,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 else:
                     scalars = scalars.ravel()
 
-            if scalars.dtype == np.bool:
+            if scalars.dtype == np.bool_:
                 scalars = scalars.astype(np.float)
 
             def prepare_mapper(scalars):
@@ -1885,7 +1885,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if scalars.ndim != 1:
             scalars = scalars.ravel()
 
-        if scalars.dtype == np.bool or scalars.dtype == np.uint8:
+        if scalars.dtype == np.bool_ or scalars.dtype == np.uint8:
             scalars = scalars.astype(np.float)
 
         # Define mapper, volume, and add the correct properties

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1467,7 +1467,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                     scalars = scalars.ravel()
 
             if scalars.dtype == np.bool_:
-                scalars = scalars.astype(np.float)
+                scalars = scalars.astype(np.float_)
 
             def prepare_mapper(scalars):
                 # Scalars interpolation approach
@@ -1886,7 +1886,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             scalars = scalars.ravel()
 
         if scalars.dtype == np.bool_ or scalars.dtype == np.uint8:
-            scalars = scalars.astype(np.float)
+            scalars = scalars.astype(np.float_)
 
         # Define mapper, volume, and add the correct properties
         mappers = {
@@ -1917,7 +1917,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         ###############
 
-        scalars = scalars.astype(np.float)
+        scalars = scalars.astype(np.float_)
         with np.errstate(invalid='ignore'):
             idxs0 = scalars < clim[0]
             idxs1 = scalars > clim[1]

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -268,8 +268,8 @@ def opacity_transfer_function(mapping, n_colors, interpolate=True,
             if np.max(mapping) > 1.0 or np.min(mapping) < 0.0:
                 mapping = normalize(mapping)
             # Interpolate transfer function to match lookup table
-            xo = np.linspace(0, n_colors, len(mapping), dtype=np.int)
-            xx = np.linspace(0, n_colors, n_colors, dtype=np.int)
+            xo = np.linspace(0, n_colors, len(mapping), dtype=np.int_)
+            xx = np.linspace(0, n_colors, n_colors, dtype=np.int_)
             try:
                 if not interpolate:
                     raise AssertionError('No interpolation.')

--- a/pyvista/utilities/cells.py
+++ b/pyvista/utilities/cells.py
@@ -13,7 +13,7 @@ def numpy_to_idarr(ind, deep=False, return_ind=False):
     except:
         raise TypeError('Indices must be either a mask, array, list, or iterable')
 
-    if ind.dtype == np.bool:
+    if ind.dtype == np.bool_:
         ind = ind.nonzero()[0].astype(pyvista.ID_TYPE)
     elif ind.dtype != pyvista.ID_TYPE:
         ind = ind.astype(pyvista.ID_TYPE)

--- a/pyvista/utilities/features.py
+++ b/pyvista/utilities/features.py
@@ -40,7 +40,7 @@ def voxelize(mesh, density=None, check_surface=True):
     selection = ugrid.select_enclosed_points(mesh.extract_surface(),
                                              tolerance=0.0,
                                              check_surface=check_surface)
-    mask = selection.point_arrays['SelectedPoints'].view(np.bool)
+    mask = selection.point_arrays['SelectedPoints'].view(np.bool_)
 
     # extract cells from point indices
     return ugrid.extract_points(mask)

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -322,7 +322,7 @@ def line_segments_from_points(points):
     # Assuming ordered points, create array defining line order
     n_points = len(points)
     n_lines = n_points // 2
-    lines = np.c_[(2 * np.ones(n_lines, np.int),
+    lines = np.c_[(2 * np.ones(n_lines, np.int_),
                    np.arange(0, n_points-1, step=2),
                    np.arange(1, n_points+1, step=2))]
     poly = pyvista.PolyData()
@@ -353,9 +353,9 @@ def lines_from_points(points, close=False):
     """
     poly = pyvista.PolyData()
     poly.points = points
-    cells = np.full((len(points)-1, 3), 2, dtype=np.int)
-    cells[:, 1] = np.arange(0, len(points)-1, dtype=np.int)
-    cells[:, 2] = np.arange(1, len(points), dtype=np.int)
+    cells = np.full((len(points)-1, 3), 2, dtype=np.int_)
+    cells[:, 1] = np.arange(0, len(points)-1, dtype=np.int_)
+    cells[:, 2] = np.arange(1, len(points), dtype=np.int_)
     if close:
         cells = np.append(cells, [[2, len(points)-1, 0],], axis=0)
     poly.lines = cells

--- a/tests/test_cells.py
+++ b/tests/test_cells.py
@@ -23,6 +23,6 @@ def test_init_cell_array(cells, n_cells, deep):
 
 
 def test_numpy_to_idarr_bool():
-    mask = np.ones(10, np.bool)
+    mask = np.ones(10, np.bool_)
     idarr = pyvista.utilities.cells.numpy_to_idarr(mask)
     assert np.allclose(mask.nonzero()[0], vtk_to_numpy(idarr))

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -247,30 +247,30 @@ def test_invalid_points(grid):
 
 
 def test_points_np_bool(grid):
-    bool_arr = np.zeros(grid.n_points, np.bool)
+    bool_arr = np.zeros(grid.n_points, np.bool_)
     grid.point_arrays['bool_arr'] = bool_arr
     bool_arr[:] = True
     assert grid.point_arrays['bool_arr'].all()
     assert grid.point_arrays['bool_arr'].all()
-    assert grid.point_arrays['bool_arr'].dtype == np.bool
+    assert grid.point_arrays['bool_arr'].dtype == np.bool_
 
 
 def test_cells_np_bool(grid):
-    bool_arr = np.zeros(grid.n_cells, np.bool)
+    bool_arr = np.zeros(grid.n_cells, np.bool_)
     grid.cell_arrays['bool_arr'] = bool_arr
     bool_arr[:] = True
     assert grid.cell_arrays['bool_arr'].all()
     assert grid.cell_arrays['bool_arr'].all()
-    assert grid.cell_arrays['bool_arr'].dtype == np.bool
+    assert grid.cell_arrays['bool_arr'].dtype == np.bool_
 
 
 def test_field_np_bool(grid):
-    bool_arr = np.zeros(grid.n_cells // 3, np.bool)
+    bool_arr = np.zeros(grid.n_cells // 3, np.bool_)
     grid.field_arrays['bool_arr'] = bool_arr
     bool_arr[:] = True
     assert grid.field_arrays['bool_arr'].all()
     assert grid.field_arrays['bool_arr'].all()
-    assert grid.field_arrays['bool_arr'].dtype == np.bool
+    assert grid.field_arrays['bool_arr'].dtype == np.bool_
 
 
 def test_cells_uint8(grid):
@@ -298,7 +298,7 @@ def test_field_uint8(grid):
 def test_bitarray_points(grid):
     n = grid.n_points
     vtk_array = vtk.vtkBitArray()
-    np_array = np.empty(n, np.bool)
+    np_array = np.empty(n, np.bool_)
     vtk_array.SetNumberOfTuples(n)
     vtk_array.SetName('bint_arr')
     for i in range(n):
@@ -313,7 +313,7 @@ def test_bitarray_points(grid):
 def test_bitarray_cells(grid):
     n = grid.n_cells
     vtk_array = vtk.vtkBitArray()
-    np_array = np.empty(n, np.bool)
+    np_array = np.empty(n, np.bool_)
     vtk_array.SetNumberOfTuples(n)
     vtk_array.SetName('bint_arr')
     for i in range(n):
@@ -328,7 +328,7 @@ def test_bitarray_cells(grid):
 def test_bitarray_field(grid):
     n = grid.n_cells // 3
     vtk_array = vtk.vtkBitArray()
-    np_array = np.empty(n, np.bool)
+    np_array = np.empty(n, np.bool_)
     vtk_array.SetNumberOfTuples(n)
     vtk_array.SetName('bint_arr')
     for i in range(n):

--- a/tests/test_datasetattributes.py
+++ b/tests/test_datasetattributes.py
@@ -32,7 +32,7 @@ def insert_arange_narray(hexbeam_point_attributes):
 @fixture()
 def insert_bool_array(hexbeam_point_attributes):
     n_points = hexbeam_point_attributes.dataset.GetNumberOfPoints()
-    sample_array = np.ones(n_points, np.bool)
+    sample_array = np.ones(n_points, np.bool_)
     hexbeam_point_attributes.append(sample_array, 'sample_array')
     return hexbeam_point_attributes, sample_array
 
@@ -83,7 +83,7 @@ def test_get_array_should_fail_if_does_not_exist(array_key, hexbeam_point_attrib
 def test_get_array_should_return_bool_array(insert_bool_array):
     dsa, _ = insert_bool_array
     output_array = dsa.get_array('sample_array')
-    assert output_array.dtype == np.bool
+    assert output_array.dtype == np.bool_
 
 
 def test_get_array_bool_array_should_be_identical(insert_bool_array):

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -14,8 +14,8 @@ test_path = os.path.dirname(os.path.abspath(__file__))
 VTK9 = vtk.vtkVersion().GetVTKMajorVersion() >= 9
 
 # must be manually set until pytest adds parametrize with fixture feature
-HEXBEAM_CELLS_BOOL = np.ones(40, np.bool)  # matches hexbeam.n_cells == 40
-STRUCTGRID_CELLS_BOOL = np.ones(729, np.bool)  # struct_grid.n_cells == 729
+HEXBEAM_CELLS_BOOL = np.ones(40, np.bool_)  # matches hexbeam.n_cells == 40
+STRUCTGRID_CELLS_BOOL = np.ones(729, np.bool_)  # struct_grid.n_cells == 729
 
 
 def test_volume(hexbeam):
@@ -162,7 +162,7 @@ def test_extract_cells(hexbeam):
     assert part_beam.n_points < hexbeam.n_points
     assert np.allclose(part_beam.cell_arrays['vtkOriginalCellIds'], ind)
 
-    mask = np.zeros(hexbeam.n_cells, np.bool)
+    mask = np.zeros(hexbeam.n_cells, np.bool_)
     mask[ind] = True
     part_beam = hexbeam.extract_cells(mask)
     assert part_beam.n_cells == len(ind)
@@ -520,7 +520,7 @@ def test_remove_cells_not_inplace(ind, hexbeam):
 def test_remove_cells_invalid(hexbeam):
     grid_copy = hexbeam.copy()
     with pytest.raises(ValueError):
-        grid_copy.remove_cells(np.ones(10, np.bool))
+        grid_copy.remove_cells(np.ones(10, np.bool_))
 
 
 @pytest.mark.parametrize('ind', [range(10), np.arange(10),

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -152,12 +152,12 @@ def test_table_row_arrays():
 def test_table_row_np_bool():
     n = 50
     table = pyvista.Table()
-    bool_arr = np.zeros(n, np.bool)
+    bool_arr = np.zeros(n, np.bool_)
     table.row_arrays['bool_arr'] = bool_arr
     bool_arr[:] = True
     assert table.row_arrays['bool_arr'].all()
     assert table._row_array('bool_arr').all()
-    assert table._row_array('bool_arr').dtype == np.bool
+    assert table._row_array('bool_arr').dtype == np.bool_
 
 
 def test_table_row_uint8():

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -458,7 +458,7 @@ def test_plot_normals(sphere, flip):
 
 def test_remove_points_any():
     sphere = SPHERE.copy()
-    remove_mask = np.zeros(sphere.n_points, np.bool)
+    remove_mask = np.zeros(sphere.n_points, np.bool_)
     remove_mask[:3] = True
     sphere_mod, ind = sphere.remove_points(remove_mask, inplace=False, mode='any')
     assert (sphere_mod.n_points + remove_mask.sum()) == sphere.n_points
@@ -482,7 +482,7 @@ def test_remove_points_fail(sphere, plane):
 
     # invalid bool mask size
     with pytest.raises(ValueError):
-        sphere.remove_points(np.ones(10, np.bool))
+        sphere.remove_points(np.ones(10, np.bool_))
 
 
 def test_vertice_cells_on_read(tmpdir):

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -583,16 +583,16 @@ def test_lines():
     # Create line segments
     poly = pyvista.PolyData()
     poly.points = points
-    cells = np.full((len(points)-1, 3), 2, dtype=np.int)
-    cells[:, 1] = np.arange(0, len(points)-1, dtype=np.int)
-    cells[:, 2] = np.arange(1, len(points), dtype=np.int)
+    cells = np.full((len(points)-1, 3), 2, dtype=np.int_)
+    cells[:, 1] = np.arange(0, len(points)-1, dtype=np.int_)
+    cells[:, 2] = np.arange(1, len(points), dtype=np.int_)
     poly.lines = cells
     assert poly.n_points == len(points)
     assert poly.n_cells == len(points) - 1
     # Create a poly line
     poly = pyvista.PolyData()
     poly.points = points
-    the_cell = np.arange(0, len(points), dtype=np.int)
+    the_cell = np.arange(0, len(points), dtype=np.int_)
     the_cell = np.insert(the_cell, 0, len(points))
     poly.lines = the_cell
     assert poly.n_points == len(points)


### PR DESCRIPTION
### Overview

Numpy has `np.bool`, `np.int` and `np.float` and `np.complex` as aliases for the native python types `bool`, `int`, `float` and `complex`, respectively. The numpy-native types are available as `np.bool_`, `np.int_`, `np.float_` and `np.complex_`. This PR replaces the former with the latter.

### Details

The two scenarios in which these types appear in pyvista are like

  1. `array.astype(np.bool)` and
  2. `array.dtype == np.bool`

In both cases it doesn't actually make a difference whether one uses native types or numpy types:
```python
>>> np.bool_ == np.dtype(bool) is np.dtype(np.bool_) == bool
True
# even though
>>> np.bool_ == bool
False
```
So these are not bugs, but the semantics are a bit cleaner with the proper (underscored) numpy types.