### PR TITLE
Check vectors are vectors

### DIFF
--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -246,9 +246,8 @@ class DataSetAttributes(VTKObjectWrapper):
                 self.active_scalars = name
             if active_vectors or self.active_vectors is None:
                 # verify this is actually vector data
-                if len(shape) == 2:
-                    if shape[1] == 3:
-                        self.active_vectors = name
+                if len(shape) == 2 and shape[1] == 3:
+                    self.active_vectors = name
         except TypeError:
             pass
         self.VTKObject.Modified()

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -245,7 +245,10 @@ class DataSetAttributes(VTKObjectWrapper):
             if active_scalars or self.active_scalars is None:
                 self.active_scalars = name
             if active_vectors or self.active_vectors is None:
-                self.active_vectors = name
+                # verify this is actually vector data
+                if len(shape) == 2:
+                    if shape[1] == 3:
+                        self.active_vectors = name
         except TypeError:
             pass
         self.VTKObject.Modified()

--- a/tests/test_datasetattributes.py
+++ b/tests/test_datasetattributes.py
@@ -74,6 +74,13 @@ def test_set_vectors(hexbeam):
     assert np.allclose(hexbeam.active_vectors, vectors)
 
 
+def test_set_active_vectors_invalid(hexbeam):
+    # verify non-vector data does not become active vectors
+    not_vectors = np.random.random((hexbeam.points.shape))
+    hexbeam.point_arrays['not_vectors'] = not_vectors
+    assert np.allclose(hexbeam.point_arrays.active_vectors, not_vectors)
+
+
 @mark.parametrize('array_key', ['invalid_array_name', -1])
 def test_get_array_should_fail_if_does_not_exist(array_key, hexbeam_point_attributes):
     with raises(KeyError):


### PR DESCRIPTION
#### New and Exciting VTK 9 Bugs
Seems that we've been spoiled a bit in VTK 8 as we've been able to set invalid active vectors without getting a warning.  Now we do:


Reproduce this using `vtk>=9.0.0` with:
```python
import pyvista
from pyvista import examples

import numpy as np
grid = examples.load_hexbeam()
grid.point_arrays['values'] = np.zeros(grid.n_points)
```

```
2020-05-28 00:58:00.464 (  82.406s) [        D7CF4740]vtkDataSetAttributes.cx:1305  WARN| vtkPointData (0x5561190ba540): Can not set attribute Vectors. Incorrect number of components.
```

However this works:
```python
grid.point_arrays['values'] = np.zeros((grid.n_points, 3))
```

We just need to implement a simple check to make sure that non-vector data isn't set as vector data.