### PR TITLE
Fix setting view direction

### DIFF
--- a/pyvista/core/errors.py
+++ b/pyvista/core/errors.py
@@ -1,9 +1,30 @@
 """Pyvista specific errors."""
 
+CAMERA_ERROR_MESSAGE = """Invalid camera description
+Camera description must be one of the following:
+
+Iterable containing position, focal_point, and view up.  For example:
+[(2.0, 5.0, 13.0), (0.0, 0.0, 0.0), (-0.7, -0.5, 0.3)]
+
+Iterable containing a view vector.  For example:
+[-1.0, 2.0, -5.0]
+
+A string containing the plane orthogonal to the view direction.  For example:
+'xy'
+"""
+
 
 class NotAllTrianglesError(ValueError):
     """Exception when a mesh does not contain all triangles."""
 
     def __init__(self, message='Mesh must consist of only triangles'):
         """Empty init."""
-        Exception.__init__(self, message)
+        ValueError.__init__(self, message)
+
+
+class InvalidCameraError(ValueError):
+    """Exception when passed an invalid camera."""
+
+    def __init__(self, message=CAMERA_ERROR_MESSAGE):
+        """Empty init."""
+        ValueError.__init__(self, message)

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -175,9 +175,9 @@ class Renderer(vtkRenderer):
                                                   invert=False))
             self.camera.SetViewUp(camera_location[2])
 
-            # reset clipping range
-            self.ResetCameraClippingRange()
-            self.camera_set = True
+        # reset clipping range
+        self.ResetCameraClippingRange()
+        self.camera_set = True
         self.Modified()
 
     @property

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -136,8 +136,7 @@ class Renderer(vtkRenderer):
         """Set camera position of all active render windows."""
         if camera_location is None:
             return
-
-        if isinstance(camera_location, str):
+        elif isinstance(camera_location, str):
             camera_location = camera_location.lower()
             if camera_location == 'xy':
                 self.view_xy()
@@ -151,19 +150,34 @@ class Renderer(vtkRenderer):
                 self.view_zx()
             elif camera_location == 'zy':
                 self.view_zy()
-            return
+            else:
+                err = pyvista.core.errors.InvalidCameraError
+                raise err('Invalid view direction.  '
+                          'Use one of the following:\n'
+                          "    'xy', 'xz', 'yz', 'yx', 'zx', 'zy'")
 
-        if isinstance(camera_location[0], (int, float)):
+        elif isinstance(camera_location[0], (int, float)):
+            if len(camera_location) != 3:
+                raise pyvista.core.errors.InvalidCameraError
             self.view_vector(camera_location)
+        else:
+            # check if a valid camera position
+            if not isinstance(camera_location, CameraPosition):
+                if not len(camera_location) == 3:
+                    raise pyvista.core.errors.InvalidCameraError
+                elif any([len(item) != 3 for item in camera_location]):
+                    raise pyvista.core.errors.InvalidCameraError
 
-        # everything is set explicitly
-        self.camera.SetPosition(scale_point(self.camera, camera_location[0], invert=False))
-        self.camera.SetFocalPoint(scale_point(self.camera, camera_location[1], invert=False))
-        self.camera.SetViewUp(camera_location[2])
+            # everything is set explicitly
+            self.camera.SetPosition(scale_point(self.camera, camera_location[0],
+                                                invert=False))
+            self.camera.SetFocalPoint(scale_point(self.camera, camera_location[1],
+                                                  invert=False))
+            self.camera.SetViewUp(camera_location[2])
 
-        # reset clipping range
-        self.ResetCameraClippingRange()
-        self.camera_set = True
+            # reset clipping range
+            self.ResetCameraClippingRange()
+            self.camera_set = True
         self.Modified()
 
     @property

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -112,7 +112,7 @@ def test_set_camera_position(cpos, sphere):
 def test_set_camera_position_invalid(cpos, sphere):
     plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
     plotter.add_mesh(sphere)
-    with pytest.raises(ValueError):
+    with pytest.raises(pyvista.core.errors.InvalidCameraError):
         plotter.camera_position = cpos
 
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -87,24 +87,34 @@ def test_plot_show_grid():
     plotter.close()
 
 
-@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
-def test_set_camera_position():
-    # with pytest.raises(Exception):
-    cpos = [(2.085387555594636, 5.259683527170288, 13.092943022481887),
-            (0.0, 0.0, 0.0),
-            (-0.7611973344707588, -0.5507178512374836, 0.3424740374436883)]
 
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+@pytest.mark.parametrize('cpos', [[(2.0, 5.0, 13.0),
+                                   (0.0, 0.0, 0.0),
+                                   (-0.7, -0.5, 0.3)],
+                                  [-1, 2, -5],  # trigger view vector
+                                  [1.0, 2.0, 3.0],
+                                  'xy', 'xz', 'yz', 'yx', 'zx', 'zy'])
+def test_set_camera_position(cpos, sphere):
     plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
     plotter.add_mesh(sphere)
-    plotter.camera_position = 'xy'
-    plotter.camera_position = 'xz'
-    plotter.camera_position = 'yz'
-    plotter.camera_position = 'yx'
-    plotter.camera_position = 'zx'
-    plotter.camera_position = 'zy'
     plotter.camera_position = cpos
-    cpos_out = plotter.show()
-    assert cpos_out == cpos
+    plotter.show()
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+@pytest.mark.parametrize('cpos', [[(2.0, 5.0),
+                                   (0.0, 0.0, 0.0),
+                                   (-0.7, -0.5, 0.3)],
+                                  [-1, 2],
+                                  [(1,2,3)],
+                                  'notvalid'])
+def test_set_camera_position_invalid(cpos, sphere):
+    plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
+    plotter.add_mesh(sphere)
+    with pytest.raises(ValueError):
+        plotter.camera_position = cpos
+
 
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")


### PR DESCRIPTION
### Fix setting view direction

#750 broke setting the view direction from camera position:
```python
import pyvista
plotter = pyvista.Plotter()
plotter.add_mesh(sphere)
plotter.camera_position = [-1, 2, 5]
```
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/alex/python/pyvista/pyvista/plotting/plotting.py", line 636, in camera_position
    self.renderer.camera_position = camera_location
  File "/home/alex/python/pyvista/pyvista/plotting/renderer.py", line 160, in camera_position
    self.camera.SetPosition(scale_point(self.camera, camera_location[0], invert=False))
  File "/home/alex/python/pyvista/pyvista/plotting/renderer.py", line 40, in scale_point
    scaled = mtx.MultiplyDoublePoint((point[0], point[1], point[2], 0.0))
TypeError: 'int' object is not subscriptable
```

This slipped by our CI as we're not building our documentation on each PR.  We've known that our unit testing does not have full coverage, and this is another reason why we need to focus on improving coverage, especially with all our refactors.

This PR also improves `camera_position` setter value checking and provides a more helpful error statement when given an invalid camera position.