### PR TITLE
Fix implicit points setters

### DIFF
--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -175,7 +175,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
 
     @points.setter
     def points(self, points):
-        """The points must be set along each axial direction.
+        """Points must be set along each axial direction.
 
         Please set the point coordinates with the ``x``, ``y``, and ``z``
         setters.
@@ -361,7 +361,7 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
 
     @points.setter
     def points(self, points):
-        """The points cannot be set.
+        """Points cannot be set.
 
         This setter overrides the base class' setter to ensure a user does not
         attempt to set them. See https://github.com/pyvista/pyvista/issues/713.

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -185,8 +185,8 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
 
         """
         raise AttributeError("The points cannot be set. The points of "
-            "`UniformGrid`/`vtkImageData` are implicitly defined by the "
-            "`origin`, `spacing`, and `dimensions` of the grid."
+            "`RectilinearGrid` are defined in each axial direction. Please "
+            "use the `x`, `y`, and `z` setters individually."
             )
 
     @property

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -180,7 +180,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
         Please set the point coordinates with the ``x``, ``y``, and ``z``
         setters.
 
-        This setter overrides the base class' setter to ensure a user does not
+        This setter overrides the base class's setter to ensure a user does not
         attempt to set them.
 
         """
@@ -363,7 +363,7 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
     def points(self, points):
         """Points cannot be set.
 
-        This setter overrides the base class' setter to ensure a user does not
+        This setter overrides the base class's setter to ensure a user does not
         attempt to set them. See https://github.com/pyvista/pyvista/issues/713.
 
         """

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -442,14 +442,20 @@ def test_save_uniform(extension, binary, tmpdir):
 def test_grid_points():
     """Test the points methods on UniformGrid and RectilinearGrid"""
     # test creation of 2d grids
-    x_surf = y_surf = range(3)
-    z_surf = np.ones(3)
+    x = y = range(3)
+    z = [0,]
+    xx, yy, zz = np.meshgrid(x, y, z, indexing='ij')
+    points = np.c_[xx.ravel(order='F'), yy.ravel(order='F'), zz.ravel(order='F')]
     grid = pyvista.UniformGrid()
-    grid.points = np.array([x_surf, y_surf, z_surf]).transpose()
+    with pytest.raises(AttributeError):
+        grid.points = points
+    grid.origin = (0.0, 0.0, 0.0)
+    grid.dimensions = (3, 3, 1)
+    grid.spacing = (1, 1, 1)
     assert grid.n_points == 9
     assert grid.n_cells == 4
+    assert np.allclose(grid.points, points)
     del grid
-
     points = np.array([[0, 0, 0],
                        [1, 0, 0],
                        [1, 1, 0],
@@ -459,19 +465,26 @@ def test_grid_points():
                        [1, 1, 1],
                        [0, 1, 1]])
     grid = pyvista.UniformGrid()
-    grid.points = points
-    assert grid.dimensions == [2, 2, 2]
-    assert grid.spacing == [1, 1, 1]
-    assert grid.origin == [0., 0., 0.]
+    grid.dimensions = [2, 2, 2]
+    grid.spacing = [1, 1, 1]
+    grid.origin = [0., 0., 0.]
     assert np.allclose(np.unique(grid.points, axis=0), np.unique(points, axis=0))
     opts = np.c_[grid.x, grid.y, grid.z]
     assert np.allclose(np.unique(opts, axis=0), np.unique(points, axis=0))
+
     # Now test rectilinear grid
     del grid
     grid = pyvista.RectilinearGrid()
-    grid.points = points
-    assert grid.dimensions == [2, 2, 2]
-    assert np.allclose(np.unique(grid.points, axis=0), np.unique(points, axis=0))
+    with pytest.raises(AttributeError):
+        grid.points = points
+    x, y, z = np.array([0, 1, 3]), np.array([0, 2.5, 5]), np.array([0, 1])
+    xx, yy, zz = np.meshgrid(x, y, z, indexing='ij')
+    grid.x = x
+    grid.y = y
+    grid.z = z
+    assert grid.dimensions == [3, 3, 2]
+    assert np.allclose(grid.meshgrid, (xx, yy, zz))
+    assert np.allclose(grid.points, np.c_[xx.ravel(order='F'), yy.ravel(order='F'), zz.ravel(order='F')])
 
 
 def test_grid_extract_selection_points(struct_grid):

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -455,7 +455,7 @@ def test_grid_points():
     assert grid.n_points == 9
     assert grid.n_cells == 4
     assert np.allclose(grid.points, points)
-    del grid
+
     points = np.array([[0, 0, 0],
                        [1, 0, 0],
                        [1, 1, 0],
@@ -473,7 +473,6 @@ def test_grid_points():
     assert np.allclose(np.unique(opts, axis=0), np.unique(points, axis=0))
 
     # Now test rectilinear grid
-    del grid
     grid = pyvista.RectilinearGrid()
     with pytest.raises(AttributeError):
         grid.points = points


### PR DESCRIPTION
### Overview

Resolve #713 

The `UniformGrid` and `RectilinearGrid`'s `points` setter should not be allowed. These changes deprecate those setters to resolve the bug in #713 and address an issue where setting the points in place has no effect.

### Details

- The `UniformGrid` points are implicitly defined and thus we cannot directly set them or directly access/modify them. 
- The `RectilinearGrid` points are similarly not explicitly defined and must be set along each axial direction individually.

Now when a user tries to set the points for either of these types, they will see a detailed error message:

```py
>>> from pyvista import examples
>>> import numpy as np
>>> grid = examples.load_uniform()
>>> grid.points = np.random.rand(10, 3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/bane/Software/pyvista/pyvista/pyvista/core/grid.py", line 370, in points
    raise AttributeError("The points cannot be set. The points of "
AttributeError: The points cannot be set. The points of `UniformGrid`/`vtkImageData` are implicitly defined by the `origin`, `spacing`, and `dimensions` of the grid.
>>>
```


Unfortunately, there still remains a behavior where the user might update the points in place and no error is raised or no effect takes place:

```py
>>> import numpy as np
>>> from pyvista import examples

>>> a = examples.load_rectilinear()
>>> b = a.copy()
>>> a.points[:,0] *= 10000000
>>> np.allclose(a.points, b.points)
True
```

This is because the numpy array that was fetched from the `points` getter is modified in place and not passed back to the setter. This could still confuse users, but I think we have to leave it as is because a user may want to modify that array of points in their own workflow. To mitigate this, I updated the language in the docs for those classes' `points` getter to highlight that they return a COPY of the points.