### PR TITLE
Refactor Doc String Parm

### DIFF
--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1438,7 +1438,7 @@ class Renderer(vtkRenderer):
             self.remove_bounding_box()
 
         self.RemoveAllViewProps()
-        self._actors = None
+        self._actors = {}
         # remove reference to parent last
         self.parent = None
         return

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -100,6 +100,12 @@ class CameraPosition:
 class Renderer(vtkRenderer):
     """Renderer class."""
 
+    # map camera_position string to an attribute
+    CAMERA_STR_ATTR_MAP = {'xy': 'view_xy', 'xz': 'view_xz',
+                           'yz': 'view_yz', 'yx': 'view_yx',
+                           'zx': 'view_zx', 'zy': 'view_zy',
+                           'iso': 'view_isometric'}
+
     def __init__(self, parent, border=True, border_color=(1, 1, 1),
                  border_width=2.0):
         """Initialize the renderer."""
@@ -138,23 +144,12 @@ class Renderer(vtkRenderer):
             return
         elif isinstance(camera_location, str):
             camera_location = camera_location.lower()
-            if camera_location == 'xy':
-                self.view_xy()
-            elif camera_location == 'xz':
-                self.view_xz()
-            elif camera_location == 'yz':
-                self.view_yz()
-            elif camera_location == 'yx':
-                self.view_yx()
-            elif camera_location == 'zx':
-                self.view_zx()
-            elif camera_location == 'zy':
-                self.view_zy()
-            else:
+            if camera_location not in self.CAMERA_STR_ATTR_MAP:
                 err = pyvista.core.errors.InvalidCameraError
                 raise err('Invalid view direction.  '
-                          'Use one of the following:\n'
-                          "    'xy', 'xz', 'yz', 'yx', 'zx', 'zy'")
+                          'Use one of the following:\n    %s'
+                          % ', '.join(self.CAMERA_STR_ATTR_MAP))
+            getattr(self, self.CAMERA_STR_ATTR_MAP[camera_location])()
 
         elif isinstance(camera_location[0], (int, float)):
             if len(camera_location) != 3:

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -92,12 +92,6 @@ def test_init_from_arrays():
     assert grid.n_cells == 2
     assert np.allclose(cells, grid.cells)
 
-    if VTK9:
-        assert np.allclose(grid.cell_connectivity, np.arange(16))
-        assert np.allclose(grid.offset, np.array([0, 8]))
-    else:
-        assert np.allclose(grid.offset, offset)
-
 
 def test_destructor():
     ugrid = examples.load_hexbeam()

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -92,6 +92,12 @@ def test_init_from_arrays():
     assert grid.n_cells == 2
     assert np.allclose(cells, grid.cells)
 
+    if VTK9:
+        assert np.allclose(grid.cell_connectivity, np.arange(16))
+        assert np.allclose(grid.offset, np.array([0, 8]))
+    else:
+        assert np.allclose(grid.offset, offset)
+
 
 def test_destructor():
     ugrid = examples.load_hexbeam()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -88,15 +88,15 @@ def test_plot_show_grid():
 
 
 
-cpos_parm = [[(2.0, 5.0, 13.0),
+cpos_param = [[(2.0, 5.0, 13.0),
               (0.0, 0.0, 0.0),
               (-0.7, -0.5, 0.3)],
              [-1, 2, -5],  # trigger view vector
              [1.0, 2.0, 3.0],
 ]
-cpos_parm.extend(pyvista.plotting.Renderer.CAMERA_STR_ATTR_MAP)
+cpos_param.extend(pyvista.plotting.Renderer.CAMERA_STR_ATTR_MAP)
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
-@pytest.mark.parametrize('cpos', cpos_parm)
+@pytest.mark.parametrize('cpos', cpos_param)
 def test_set_camera_position(cpos, sphere):
     plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
     plotter.add_mesh(sphere)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -88,13 +88,15 @@ def test_plot_show_grid():
 
 
 
+cpos_parm = [[(2.0, 5.0, 13.0),
+              (0.0, 0.0, 0.0),
+              (-0.7, -0.5, 0.3)],
+             [-1, 2, -5],  # trigger view vector
+             [1.0, 2.0, 3.0],
+]
+cpos_parm.extend(pyvista.plotting.Renderer.CAMERA_STR_ATTR_MAP)
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
-@pytest.mark.parametrize('cpos', [[(2.0, 5.0, 13.0),
-                                   (0.0, 0.0, 0.0),
-                                   (-0.7, -0.5, 0.3)],
-                                  [-1, 2, -5],  # trigger view vector
-                                  [1.0, 2.0, 3.0],
-                                  'xy', 'xz', 'yz', 'yx', 'zx', 'zy'])
+@pytest.mark.parametrize('cpos', cpos_parm)
 def test_set_camera_position(cpos, sphere):
     plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
     plotter.add_mesh(sphere)


### PR DESCRIPTION
### Refactor Doc String Parm

I missed `'iso'` when testing out our `camera_position` string setter while running through our doc tests and figured I'd refactor the camera setter along the way to improve testing.

Rather than having a bunch of `if` and `elif` to test various strings, this PR introduces `CAMERA_STR_ATTR_MAP`, which maps an input string to a method (e.g. `'iso'` to `view_isometric`).  To allow us to test this, it needs to be a class global, but I can't assign a class global class methods as the class doesn't exist while it's being created.  To fix this, the implementation uses `getattr`.

If someone can think of a better way to do this, please chime in.  Otherwise, this way we kill two birds with one stone.  Any additional string options added to the class are automatically added to our testing.

Also, this PR adds a quick patch of `Renderer.deep_clean` as setting `_actors = None` has unintended consequences if anyone wants to add actors again to the `renderer` after cleaning (edge case).

I'm rapidly becoming of the opinion that if we're not testing something, it's probably broken, so the better unit testing we have, the less likely we're shipping a mildly/wildly broken release.