### PR TITLE
Add VTK9 Connectivity Support

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1912,6 +1912,9 @@ class DataSetFilters:
             surf_filter.PassThroughPointIdsOn()
         surf_filter.Update()
 
+        # need to add
+        # surf_filter.SetNonlinearSubdivisionLevel(subdivision)
+
         mesh = _get_output(surf_filter)
         return mesh
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -688,7 +688,7 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
         carr = self.GetCells()
         if hasattr(carr, 'GetOffsetsArray'):  # available >= VTK9
             # This will be the number of cells + 1.
-            return vtk_to_numpy(carr.GetOffsetsArray())[:-1]
+            return vtk_to_numpy(carr.GetOffsetsArray())
         else:  # this is no longer used in >= VTK9
             return vtk_to_numpy(self.GetCellLocationsArray())
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -606,8 +606,16 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
 
     @property
     def cells(self):
-        """Return a pointer to the cells as a numpy object."""
+        """Legacy method: Return a pointer to the cells as a numpy object."""
         return vtk_to_numpy(self.GetCells().GetData())
+
+    @property
+    def cell_connectivity(self):
+        """Return a the vtk cell connectivity as a numpy array."""
+        carr = self.GetCells()
+        if hasattr(carr, 'GetConnectivityArray'):  # available >= VTK9
+            return vtk_to_numpy(carr.GetConnectivityArray())
+        return None
 
     def linear_copy(self, deep=False):
         """Return a copy of the unstructured grid containing only linear cells.
@@ -678,8 +686,13 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
 
     @property
     def offset(self):
-        """Get Cell Locations Array."""
-        return vtk_to_numpy(self.GetCellLocationsArray())
+        """Get cell locations Array."""
+        carr = self.GetCells()
+        if hasattr(carr, 'GetOffsetsArray'):  # available >= VTK9
+            # This will be the number of cells + 1.
+            return vtk_to_numpy(carr.GetOffsetsArray())[:-1]
+        else:  # this is no longer used in >= VTK9
+            return vtk_to_numpy(self.GetCellLocationsArray())
 
 
 class StructuredGrid(vtkStructuredGrid, PointGrid):

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -623,7 +623,8 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
         carr = self.GetCells()
         if hasattr(carr, 'GetConnectivityArray'):  # available >= VTK9
             return vtk_to_numpy(carr.GetConnectivityArray())
-        return None
+        raise AttributeError('Install vtk>=9.0.0 for `cell_connectivity`\n'
+                             'Otherwise, use the legacy `cells` method')
 
     def linear_copy(self, deep=False):
         """Return a copy of the unstructured grid containing only linear cells.

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -26,8 +26,6 @@ log.setLevel('CRITICAL')
 VTK9 = vtk.vtkVersion().GetVTKMajorVersion() >= 9
 
 
-
-
 class PointSet(Common):
     """PyVista's equivalent of vtk.vtkPointSet.
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -661,16 +661,24 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
 
         # fixing bug with display of quad cells
         if np.any(quad_quad_mask):
-            quad_offset = lgrid.offset[quad_quad_mask]
-            base_point = lgrid.cells[quad_offset + 1]
-            lgrid.cells[quad_offset + 5] = base_point
-            lgrid.cells[quad_offset + 6] = base_point
-            lgrid.cells[quad_offset + 7] = base_point
-            lgrid.cells[quad_offset + 8] = base_point
+            if VTK9:
+                quad_offset = lgrid.offset[:-1][quad_quad_mask]
+                base_point = lgrid.cells[quad_offset]
+            else:
+                quad_offset = lgrid.offset[quad_quad_mask]
+                base_point = lgrid.cells[quad_offset + 1]
+                lgrid.cells[quad_offset + 5] = base_point
+                lgrid.cells[quad_offset + 6] = base_point
+                lgrid.cells[quad_offset + 7] = base_point
+                lgrid.cells[quad_offset + 8] = base_point
 
         if np.any(quad_tri_mask):
-            tri_offset = lgrid.offset[quad_tri_mask]
-            base_point = lgrid.cells[tri_offset + 1]
+            if VTK9:
+                tri_offset = lgrid.offset[:-1][quad_tri_mask]
+                base_point = lgrid.cells[tri_offset]
+            else:
+                tri_offset = lgrid.offset[quad_tri_mask]
+                base_point = lgrid.cells[tri_offset + 1]
             lgrid.cells[tri_offset + 4] = base_point
             lgrid.cells[tri_offset + 5] = base_point
             lgrid.cells[tri_offset + 6] = base_point

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -92,6 +92,11 @@ def test_init_from_arrays():
     assert grid.n_cells == 2
     assert np.allclose(cells, grid.cells)
 
+    if VTK9:
+        assert np.allclose(grid.cell_connectivity, np.arange(16))
+    else:
+        assert grid.cell_connectivity is None
+
 
 def test_destructor():
     ugrid = examples.load_hexbeam()

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -161,7 +161,7 @@ def test_linear_copy(hexbeam):
 
 
 def test_linear_copy_surf_elem():
-    cells = np.array([8, 0, 1, 2, 3, 4, 5, 6, 7])
+    cells = np.array([8, 0, 1, 2, 3, 4, 5, 6, 7, 6, 8, 9, 10, 11, 12, 13], np.int32)
     celltypes = np.array([vtk.VTK_QUADRATIC_QUAD, vtk.VTK_QUADRATIC_TRIANGLE],
                          np.uint8)
 
@@ -174,9 +174,28 @@ def test_linear_copy_surf_elem():
              [0.5, 0.9, 0.0],
              [0.1, 0.5, 0.0]]
 
-    points = np.hstack((cell0))
-    grid = pyvista.UnstructuredGrid(cells, celltypes, points, deep=False)
-    
+    cell1 = [[0.0, 0.0, 1.0],
+             [1.0, 0.0, 1.0],
+             [0.5, 0.5, 1.0],
+             [0.5, 0.0, 1.3],
+             [0.7, 0.7, 1.3],
+             [0.1, 0.1, 1.3]]
+
+    points = np.vstack((cell0, cell1))
+    if VTK9:
+        grid = pyvista.UnstructuredGrid(cells, celltypes, points, deep=False)
+    else:
+        offset = np.array([0, 9])
+        grid = pyvista.UnstructuredGrid(offset, cells, celltypes, points, deep=False)
+
+    lgrid = grid.linear_copy()
+
+    qfilter = vtk.vtkMeshQuality()
+    qfilter.SetInputData(lgrid)
+    qfilter.Update()
+    qual = pyvista.wrap(qfilter.GetOutput())['Quality']
+    assert np.allclose(qual, [1, 1.4], atol=0.01)
+
 
 def test_extract_cells(hexbeam):
     ind = [1, 2, 3]

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -95,7 +95,8 @@ def test_init_from_arrays():
     if VTK9:
         assert np.allclose(grid.cell_connectivity, np.arange(16))
     else:
-        assert grid.cell_connectivity is None
+        with pytest.raises(AttributeError):
+            grid.cell_connectivity
 
 
 def test_destructor():

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -160,6 +160,24 @@ def test_linear_copy(hexbeam):
     assert np.all(lgrid.celltypes < 20)
 
 
+def test_linear_copy_surf_elem():
+    cells = np.array([8, 0, 1, 2, 3, 4, 5, 6, 7])
+    celltypes = np.array([vtk.VTK_QUADRATIC_QUAD, vtk.VTK_QUADRATIC_TRIANGLE],
+                         np.uint8)
+
+    cell0 = [[0.0, 0.0, 0.0],
+             [1.0, 0.0, 0.0],
+             [1.0, 1.0, 0.0],
+             [0.0, 1.0, 0.0],
+             [0.5, 0.1, 0.0],
+             [1.1, 0.5, 0.0],
+             [0.5, 0.9, 0.0],
+             [0.1, 0.5, 0.0]]
+
+    points = np.hstack((cell0))
+    grid = pyvista.UnstructuredGrid(cells, celltypes, points, deep=False)
+    
+
 def test_extract_cells(hexbeam):
     ind = [1, 2, 3]
     part_beam = hexbeam.extract_cells(ind)


### PR DESCRIPTION
### Add VTK9 Connectivity Support
This PR adds support for VTK v9's new connectivity arrays with the `cell_connectivity` property available for the `UnstructuredGrid` class.  This class is used extensively by `pyansys` and other closed source software and the addition of this property is critical for supporting VTK 9. 

Summary of changes between the versions:

Topology:
---------
Cell 0: Triangle | point ids: {0, 1, 2}
Cell 1: Triangle | point ids: {5, 7, 2}
Cell 2: Quad     | point ids: {3, 4, 6, 7}
Cell 4: Line     | point ids: {5, 8}

VTKv9
=====
Offsets:      {0, 3, 6, 10, 12}
Connectivity: {0, 1, 2, 5, 7, 2, 3, 4, 6, 7, 5, 8}

```python
grid.offset
grid.cell_connectivity
```

Prior to VTKv9
==============
Offsets:      {0, 4, 8, 13, 16}
Connectivity: {3, 0, 1, 2, 3, 5, 7, 2, 4, 3, 4, 6, 7, 2, 5, 8}

```python
grid.offset
grid.cells
```