### PR TITLE
HOTFIX: Allow examples path failure and override

### DIFF
--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -87,7 +87,7 @@ try:
 except Exception as e:
     warnings.warn('Unable to create `EXAMPLES_PATH` at "%s"\nError: %s\n\n'
                   % (EXAMPLES_PATH, str(e)) +
-                  'Override the default path by setting the enviornmental variable '
+                  'Override the default path by setting the environmental variable '
                   '`PYVISTA_USERDATA_PATH` to a writable path.')
     EXAMPLES_PATH = None
 

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -1,4 +1,6 @@
 """PyVista package for 3D plotting and mesh analysis."""
+import warnings
+import os
 import appdirs
 from pyvista._version import __version__
 from pyvista.plotting import *
@@ -68,9 +70,26 @@ USER_DATA_PATH = appdirs.user_data_dir('pyvista')
 if not os.path.exists(USER_DATA_PATH):
     os.makedirs(USER_DATA_PATH)
 
-EXAMPLES_PATH = os.path.join(USER_DATA_PATH, 'examples')
-if not os.path.exists(EXAMPLES_PATH):
-    os.makedirs(EXAMPLES_PATH)
+
+# allow user to override the examples path
+if 'PYVISTA_USERDATA_PATH' in os.environ:
+    USER_DATA_PATH = os.environ['PYVISTA_USERDATA_PATH']
+    if not os.path.isdir(USER_DATA_PATH):
+        raise FileNotFoundError('Invalid PYVISTA_USERDATA_PATH at %s' % USER_DATA_PATH)
+
+try:
+    EXAMPLES_PATH = os.path.join(USER_DATA_PATH, 'examples')
+    if not os.path.exists(EXAMPLES_PATH):
+        try:
+            os.makedirs(EXAMPLES_PATH)
+        except FileExistsError:  # Edge case due to IO race conditions
+            pass
+except Exception as e:
+    warnings.warn('Unable to create `EXAMPLES_PATH` at "%s"\nError: %s\n\n'
+                  % (EXAMPLES_PATH, str(e)) +
+                  'Override the default path by setting the enviornmental variable '
+                  '`PYVISTA_USERDATA_PATH` to a writable path.')
+    EXAMPLES_PATH = None
 
 # Send VTK messages to the logging module:
 send_errors_to_logging()

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -12,7 +12,7 @@ import pyvista
 # Helpers:
 
 def _check_examples_path():
-    """Check if the examples path exists"""
+    """Check if the examples path exists."""
     if pyvista.EXAMPLES_PATH is None:
         raise FileNotFoundError('EXAMPLES_PATH does not exist.  Try setting the '
                                 'environment variable `PYVISTA_USERDATA_PATH` '

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -11,22 +11,35 @@ import pyvista
 
 # Helpers:
 
+def _check_examples_path():
+    """Check if the examples path exists"""
+    if pyvista.EXAMPLES_PATH is None:
+        raise FileNotFoundError('EXAMPLES_PATH does not exist.  Try setting the '
+                                'environment variable `PYVISTA_USERDATA_PATH` '
+                                'to a writable path and restarting python')
+
+
 def delete_downloads():
     """Delete all downloaded examples to free space or update the files."""
+    _check_examples_path()
     shutil.rmtree(pyvista.EXAMPLES_PATH)
     os.makedirs(pyvista.EXAMPLES_PATH)
     return True
 
 
 def _decompress(filename):
+    _check_examples_path()
     zip_ref = zipfile.ZipFile(filename, 'r')
     zip_ref.extractall(pyvista.EXAMPLES_PATH)
     return zip_ref.close()
 
+
 def _get_vtk_file_url(filename):
     return 'https://github.com/pyvista/vtk-data/raw/master/Data/{}'.format(filename)
 
+
 def _retrieve_file(url, filename):
+    _check_examples_path()
     # First check if file has already been downloaded
     local_path = os.path.join(pyvista.EXAMPLES_PATH, os.path.basename(filename))
     local_path_no_zip = local_path.replace('.zip', '')


### PR DESCRIPTION
### Allow examples path failure and override

In some rare edge cases (e.g. on a network drive), creating a network path isn't possible or might encounter race conditions where the path doesn't exist when initially checked yet exists when `pyvista` tries to create the examples path.  This PR fixes that in two ways:

- Allow the user to override the user data path with `PYVISTA_USERDATA_PATH`
- If unable to create `EXAMPLES_PATH`, set to None and raise an error when attempting to download examples.

Having a module break on initialization is a deal breaker when `pyvista` is used as a dependency.