### PR TITLE
Add .mailmap item to fix credentials of squashed commits

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -2,3 +2,5 @@ Bane Sullivan <banesullivan@gmail.com> banesullivan <banesulli@gmail.com>
 
 Alex Kaszynski <akascap@gmail.com> Alex Kaszynski <akaszynski@users.noreply.github.com>
 Alex Kaszynski <akascap@gmail.com> akaszynski <akascap@gmail.com>
+
+Andras Deak <deak.andris@gmail.com> Andras Deak <adeak@users.noreply.github.com>


### PR DESCRIPTION
Add my credentials to .mailmap to fix the git log for squashed commits.

My web settings are such that web actions hide my email address, but this seems to affect how squashed commits are created. The .mailmap restores my credentials in the git log for these cases.