### PR TITLE
Build and install wheel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,18 +73,17 @@ jobs:
 
   - script: |
       pip install wheel
-      pip install -e .
-    displayName: Install pyvista
+      python setup.py bdist_wheel
+      pip install dist/pyvista*.whl
+    displayName: Build wheel and install pyvista
 
   - script: |
       .ci/setup_headless_display.sh
-      # python .ci/pyvista_test.py
     displayName: Install headless display
 
   - script: |
       sudo apt-get install python3-tk
       pip install -r requirements_test.txt
-      # python -c "import vtk; print(vtk.VTK_VERSION)"
       python -c "import pyvista; print(pyvista.Report())"
       which python
       pip list
@@ -92,11 +91,12 @@ jobs:
 
   - script: |
       pip install pytest-azurepipelines
+      cd tests
       pytest -v --cov pyvista --cov-report html
+      cd ..
     displayName: 'Test Core API'
 
   - script: |
-      pip install pytest pytest-azurepipelines
       pytest -v --doctest-modules pyvista
     displayName: 'Test Package Docstrings'
 
@@ -107,8 +107,7 @@ jobs:
 
   - script: |
       pip install twine
-      python setup.py sdist
-      twine upload --skip-existing dist/pyvista*.gz
+      twine upload --skip-existing dist/pyvista*.whl
     displayName: 'Upload to PyPi'
     condition: and(eq(variables['python.version'], '3.7'), contains(variables['Build.SourceBranch'], 'refs/tags/'))
     env:

--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -1,6 +1,6 @@
 """Version info for pyvista."""
 # major, minor, patch
-version_info = 0, 25, 1
+version_info = 0, 25, 2
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
### Wheels!
Now that I've been using `pyvista` more on windows I've noticed that it takes a bit longer to install as `pip` builds a wheel and installs that instead of the source dist.  In an effort to test what's actually being installed, our CI now builds, installs, and tests against the wheel rather than the cloned source.

This PR also uploads the wheel by default and I've bumped the version with a minor patch so the latest version contains a wheel rather than the tar ball.