### PR TITLE
Fix screenshots for Sphinx Gallery

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,9 +25,6 @@ pyvista.FIGURE_PATH = os.path.join(os.path.abspath('./images/'), 'auto-generated
 if not os.path.exists(pyvista.FIGURE_PATH):
     os.makedirs(pyvista.FIGURE_PATH)
 
-# necessary when building the sphinx gallery
-pyvista.BUILDING_GALLERY = True
-
 # SG warnins
 import warnings
 warnings.filterwarnings(

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -1,7 +1,9 @@
 """PyVista package for 3D plotting and mesh analysis."""
 import warnings
 import os
+import sys
 import appdirs
+
 from pyvista._version import __version__
 from pyvista.plotting import *
 from pyvista.utilities import *
@@ -16,6 +18,7 @@ if VTK_ID_TYPE_SIZE == 4:
     ID_TYPE = np.int32
 elif VTK_ID_TYPE_SIZE == 8:
     ID_TYPE = np.int64
+
 
 # for additional error output for VTK segfaults
 try:
@@ -41,10 +44,11 @@ except KeyError:
     pass
 
 # flag for when building the sphinx_gallery
-BUILDING_GALLERY = False
+BUILDING_GALLERY = 'sphinx' in sys.modules
 if 'PYVISTA_BUILDING_GALLERY' in os.environ:
     if os.environ['PYVISTA_BUILDING_GALLERY'].lower() == 'true':
         BUILDING_GALLERY = True
+
 
 # Grab system flag for anti-aliasing
 try:

--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -1,6 +1,6 @@
 """Version info for pyvista."""
 # major, minor, patch
-version_info = 0, 25, 2
+version_info = 0, 25, 3
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
Many projects use `pyvista` for `sphinx_gallery` and this PR seeks to keep the past behavior without sacrificing performance by unnecessarily always saving screenshots.

On initialization, `pyvista` checks if `sphinx` has been imported.  If it has, screenshots are automatically saved upon the closing of a plot.

Follow up to #730 