### PR TITLE
Deploy sdist

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,13 +107,25 @@ jobs:
 
   - script: |
       pip install twine
-      twine upload --skip-existing dist/pyvista*.whl
+      python setup.py sdist
+      twine upload --skip-existing dist/pyvista*.
     displayName: 'Upload to PyPi'
     condition: and(eq(variables['python.version'], '3.7'), contains(variables['Build.SourceBranch'], 'refs/tags/'))
     env:
       TWINE_USERNAME: $(twine.username)
       TWINE_PASSWORD: $(twine.password)
       TWINE_REPOSITORY_URL: "https://upload.pypi.org/legacy/"
+
+  - script: |
+      pip install twine
+      python setup.py sdist
+      twine upload --skip-existing dist/pyvista*.
+    displayName: 'Upload to Testing PyPi'
+    condition: eq(variables['python.version'], '3.7')
+    env:
+      TWINE_USERNAME: $(twine.username)
+      TWINE_PASSWORD: $(twine.password)
+      TWINE_REPOSITORY_URL: "https://test.pypi.org/legacy/"
 
   # don't run job on no-ci builds
   condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,7 +108,7 @@ jobs:
   - script: |
       pip install twine
       python setup.py sdist
-      twine upload --skip-existing dist/pyvista*.
+      twine upload --skip-existing dist/pyvista*
     displayName: 'Upload to PyPi'
     condition: and(eq(variables['python.version'], '3.7'), contains(variables['Build.SourceBranch'], 'refs/tags/'))
     env:
@@ -119,7 +119,7 @@ jobs:
   - script: |
       pip install twine
       python setup.py sdist
-      twine upload --skip-existing dist/pyvista*.
+      twine upload --skip-existing dist/pyvista*
     displayName: 'Upload to Testing PyPi'
     condition: eq(variables['python.version'], '3.7')
     env:


### PR DESCRIPTION
### Upload sdist to PyPi

Turns out a whl isn't a replacement for the source distribution.  This PR adds back in uploading the sdist.

Additionally, thought it would be great to always test uploading, and this PR adds in a step to the CI to always test out uploading to PyPi testing when not tagged.