### PR TITLE
Add note to widget docs about significance of the name kwarg in add_mesh

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,17 +116,6 @@ jobs:
       TWINE_PASSWORD: $(twine.password)
       TWINE_REPOSITORY_URL: "https://upload.pypi.org/legacy/"
 
-  - script: |
-      pip install twine
-      python setup.py sdist
-      twine upload --skip-existing dist/pyvista*
-    displayName: 'Upload to Testing PyPi'
-    condition: eq(variables['python.version'], '3.7')
-    env:
-      TWINE_USERNAME: $(twine.username)
-      TWINE_PASSWORD: $(twine.password)
-      TWINE_REPOSITORY_URL: "https://test.pypi.org/legacy/"
-
   # don't run job on no-ci builds
   condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))
 

--- a/docs/getting-started/simple.rst
+++ b/docs/getting-started/simple.rst
@@ -164,7 +164,9 @@ manually interact with the plotting window:
 Be sure to check out all the available plotters for your use case:
 
 * :class:`pyvista.Plotter`: The standard plotter that pauses the code until closed
-* :class:`pyvistaqt.BackgroundPlotter`: Creates a rendering window that is interactive and does not pause the code execution (documented under :ref:`qt_ref`)
+* :class:`pyvistaqt.BackgroundPlotter`: Creates a rendering window that is interactive and does not pause the code execution (for more information see the `pyvistaqt`_ package)
+
+.. _pyvistaqt: http://qtdocs.pyvista.org/
 
 
 

--- a/docs/plotting/plotting.rst
+++ b/docs/plotting/plotting.rst
@@ -60,8 +60,10 @@ Convenience Functions
 Base Plotter
 ~~~~~~~~~~~~
 
-The base plotter class that all PyVista plotters inherit. Please note that the
-:class:`pyvista.BackgroundPlotter` is documented under :ref:`qt_ref`.
+The base plotter class that all PyVista plotters inherit. Please note that the former
+``BackgroundPlotter`` class has been moved to the `pyvistaqt`_ package.
+
+.. _pyvistaqt: http://qtdocs.pyvista.org/
 
 
 .. rubric:: Attributes

--- a/docs/plotting/widgets.rst
+++ b/docs/plotting/widgets.rst
@@ -13,27 +13,6 @@ Here we'll take a look at the various widgets, some helper methods that leverage
 those widgets to do common tasks, and demonstrate how to leverage the widgets
 for user defined tasks and processing routines.
 
-The :class:`pyvista.BasePlotter` class inherits all of the widget methods in
-:class:`pyvista.WidgetHelper`, so all of the following methods
-are available from any PyVista plotter.
-
-.. rubric:: Attributes
-
-.. autoautosummary:: pyvista.WidgetHelper
-   :attributes:
-
-.. rubric:: Methods
-
-.. autoautosummary:: pyvista.WidgetHelper
-   :methods:
-
-
-.. autoclass:: pyvista.WidgetHelper
-   :show-inheritance:
-   :members:
-   :inherited-members:
-   :undoc-members:
-
 
 Box Widget
 ~~~~~~~~~~
@@ -400,3 +379,30 @@ A common task with splines is to slice a volumetric dataset using an irregular
 path. To do this, we have added a convenient helper method which leverages the
 :func:`pyvista.DataSetFilters.slice_along_line` filter named
 :func:`pyvista.WidgetHelper.add_mesh_slice_spline`.
+
+
+Widget API
+~~~~~~~~~~
+
+
+The :class:`pyvista.BasePlotter` class inherits all of the widget methods in
+:class:`pyvista.WidgetHelper`, so all of the following methods
+are available from any PyVista plotter.
+
+.. rubric:: Attributes
+
+.. autoautosummary:: pyvista.WidgetHelper
+   :attributes:
+
+.. rubric:: Methods
+
+.. autoautosummary:: pyvista.WidgetHelper
+   :methods:
+
+
+.. autoclass:: pyvista.WidgetHelper
+   :show-inheritance:
+   :members:
+   :inherited-members:
+   :undoc-members:
+

--- a/docs/plotting/widgets.rst
+++ b/docs/plotting/widgets.rst
@@ -9,12 +9,12 @@ widgets to control the positions of boxes, planes, and lines or slider bars
 which can all be highly customized through the use of custom callback
 functions.
 
-Here we'll take a look a the various widgets, some helper methods that leverage
+Here we'll take a look at the various widgets, some helper methods that leverage
 those widgets to do common tasks, and demonstrate how to leverage the widgets
 for user defined tasks and processing routines.
 
 The :class:`pyvista.BasePlotter` class inherits all of the widget methods in
-:class:`pyvista.WidgetHelper` so, all of the following methods
+:class:`pyvista.WidgetHelper`, so all of the following methods
 are available from any PyVista plotter.
 
 .. rubric:: Attributes
@@ -138,9 +138,9 @@ The line widget can be enabled and disabled by the
 :func:`pyvista.WidgetHelper.add_line_widget` and
 :func:`pyvista.WidgetHelper.clear_line_widgets` methods respectively.
 Unfortunately, PyVista does not have any helper methods to utilize this
-widget, so it is necessary to pas a custom callback method.
+widget, so it is necessary to pass a custom callback method.
 
-One particularly fun example is to use the line widget to create source for
+One particularly fun example is to use the line widget to create a source for
 the :func:`pyvista.DataSetFilters.streamlines` filter.
 
 .. code-block:: python
@@ -186,7 +186,7 @@ The slider widget can be enabled and disabled by the
 This is one of the most versatile widgets as it can control a value that can
 be used for just about anything.
 
-One helper method we've add is the
+One helper method we've added is the
 :func:`pyvista.WidgetHelper.add_mesh_threshold` method which leverages the
 slider widget to control a thresholding value.
 
@@ -233,7 +233,7 @@ Sphere Widget
 The slider widget can be enabled and disabled by the
 :func:`pyvista.WidgetHelper.add_sphere_widget` and
 :func:`pyvista.WidgetHelper.clear_sphere_widgets` methods respectively.
-This is a very versatile widgets as it can control vertex location that can
+This is a very versatile widget as it can control vertex location that can
 be used to control or update the location of just about anything.
 
 We don't have any convenient helper methods that utilize this widget out of
@@ -387,7 +387,7 @@ Spline Widget
 ~~~~~~~~~~~~~
 
 
-A spline widget can be added to the scenee by the
+A spline widget can be enabled and disabled by the
 :func:`pyvista.WidgetHelper.add_spline_widget` and
 :func:`pyvista.WidgetHelper.clear_spline_widgets` methods respectively.
 This widget allows users to interactively create a poly line (spline) through

--- a/docs/plotting/widgets.rst
+++ b/docs/plotting/widgets.rst
@@ -396,4 +396,4 @@ a scene and use that spline.
 A common task with splines is to slice a volumetric dataset using an irregular
 path. To do this, we have added a convenient helper method which leverages the
 :func:`pyvista.DataSetFilters.slice_along_line` filter named
-:func:`pyvosta.WidgetHelper.add_mesh_slice_spline`.
+:func:`pyvista.WidgetHelper.add_mesh_slice_spline`.

--- a/docs/plotting/widgets.rst
+++ b/docs/plotting/widgets.rst
@@ -105,7 +105,9 @@ Or you could slice a mesh using the plane widget:
 .. image:: ../images/gifs/plane-slice.gif
 
 Or you could leverage the plane widget for some custom task like glyphing a
-vector field along that plane.
+vector field along that plane. Note that we have to pass a ``name`` when
+calling ``add_mesh`` to ensure that there is only one set of glyphs plotted
+at a time.
 
 .. code-block:: python
 
@@ -141,7 +143,8 @@ Unfortunately, PyVista does not have any helper methods to utilize this
 widget, so it is necessary to pass a custom callback method.
 
 One particularly fun example is to use the line widget to create a source for
-the :func:`pyvista.DataSetFilters.streamlines` filter.
+the :func:`pyvista.DataSetFilters.streamlines` filter. Again note the use of
+the ``name`` argument in ``add_mesh``.
 
 .. code-block:: python
 
@@ -208,7 +211,7 @@ slider widget to control a thresholding value.
 
 Or you could leverage a custom callback function that takes a single value
 from the slider as its argument to do something like control the resolution
-of a mesh:
+of a mesh. Again note the use of the ``name`` argument in ``add_mesh``:
 
 .. code-block:: python
 

--- a/docs/plotting/widgets.rst
+++ b/docs/plotting/widgets.rst
@@ -230,7 +230,7 @@ of a mesh:
 Sphere Widget
 ~~~~~~~~~~~~~
 
-The slider widget can be enabled and disabled by the
+The sphere widget can be enabled and disabled by the
 :func:`pyvista.WidgetHelper.add_sphere_widget` and
 :func:`pyvista.WidgetHelper.clear_sphere_widgets` methods respectively.
 This is a very versatile widget as it can control vertex location that can
@@ -313,7 +313,7 @@ Use several sphere widgets at once
 Example C
 +++++++++
 
-This one is the coolest - use three sphere widgets to update perturbations on
+This one is the coolest - use four sphere widgets to update perturbations on
 a surface and interpolate between them with some boundary conditions
 
 .. code-block:: python

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -63,19 +63,21 @@ class BasePlotter(PickingHelper, WidgetHelper):
         Number of sub-render windows inside of the main window.
         Specify two across with ``shape=(2, 1)`` and a two by two grid
         with ``shape=(2, 2)``.  By default there is only one renderer.
-        Can also accept a shape as string descriptor. E.g.:
-            shape="3|1" means 3 plots on the left and 1 on the right,
-            shape="4/2" means 4 plots on top of 2 at bottom.
+        Can also accept a string descriptor as shape. E.g.:
+
+            * ``shape="3|1"`` means 3 plots on the left and 1 on the right,
+            * ``shape="4/2"`` means 4 plots on top and 2 at the bottom.
 
     border : bool, optional
         Draw a border around each render window.  Default False.
 
     border_color : string or 3 item list, optional, defaults to white
         Either a string, rgb list, or hex color string.  For example:
-            color='white'
-            color='w'
-            color=[1, 1, 1]
-            color='#FFFFFF'
+
+            * ``color='white'``
+            * ``color='w'``
+            * ``color=[1, 1, 1]``
+            * ``color='#FFFFFF'``
 
     border_width : float, optional
         Width of the border in pixels when enabled.
@@ -3663,19 +3665,21 @@ class Plotter(BasePlotter):
         Number of sub-render windows inside of the main window.
         Specify two across with ``shape=(2, 1)`` and a two by two grid
         with ``shape=(2, 2)``.  By default there is only one render window.
-        Can also accept a shape as string descriptor. E.g.:
-            shape="3|1" means 3 plots on the left and 1 on the right,
-            shape="4/2" means 4 plots on top of 2 at bottom.
+        Can also accept a string descriptor as shape. E.g.:
+
+            * ``shape="3|1"`` means 3 plots on the left and 1 on the right,
+            * ``shape="4/2"`` means 4 plots on top and 2 at the bottom.
 
     border : bool, optional
         Draw a border around each render window.  Default False.
 
     border_color : string or 3 item list, optional, defaults to white
         Either a string, rgb list, or hex color string.  For example:
-            color='white'
-            color='w'
-            color=[1, 1, 1]
-            color='#FFFFFF'
+
+            * ``color='white'``
+            * ``color='w'``
+            * ``color=[1, 1, 1]``
+            * ``color='#FFFFFF'``
 
     window_size : list, optional
         Window size in pixels.  Defaults to [1024, 768]


### PR DESCRIPTION
# Details

It's not obvious [in the excellent widget docs](https://docs.pyvista.org/plotting/widgets.html) that the `name` kwarg set in `Plotter.add_mesh` is crucial for callbacks to function seamlessly. E.g. in the sphere slider example:
```python
def create_mesh(value):
    res = int(value)
    sphere = pv.Sphere(phi_resolution=res, theta_resolution=res)
    p.add_mesh(sphere, name='sphere', show_edges=True)
    return
```
the fact that `name='sphere'` is passed is responsible for discarding meshes from previous calls to the callback.

The meat of this PR is to take explicit note of this keyword argument being passed. While I'm at it I also fixed a few typos and semantic mistakes on the same doc page. 

# Issues during build
I've also run into a few warnings and errors while I was building the docs locally. I can't tell whether some of these are actual issues (and not just misconfiguration on my side), so I'll post these here. I followed [the contributing guide](https://github.com/pyvista/pyvista/blob/master/CONTRIBUTING.md) so I executed the following commands from the `docs/` directory. I didn't run the pytest suite first, but I wouldn't expect that to be a problem in light of `make clean`.

### During `make doctest`
a. 15 different warnings of the kind:
```
WARNING: image file not readable: core/../images/auto-generated/structured_cube.png
```
b. Two indentation warnings:
```
/home/user/pyvista/pyvista/plotting/plotting.py:docstring of pyvista.BasePlotter:7: WARNING: Unexpected indentation.
/home/user/pyvista/pyvista/plotting/plotting.py:docstring of pyvista.Plotter:23: WARNING: Unexpected indentation.
```

### During `make html -b linkcheck`:
c. two warnings:
 ```
/home/user/pyvista/docs/examples/02-plot/depth-peeling.rst:15: WARNING: 'any' reference target not found: pyvista.rcParams
/home/user/pyvista/docs/plotting/plotting.rst:63: WARNING: undefined label: qt_ref (if the link has no caption the label must precede a section header)
```

Four link errors in three files:
```
writing output... [ 86%] getting-started/installation
(line  115) broken    https://github.com/pyvista/pyvista/blob/master/CONTRIBUTING.md#testing - Anchor 'testing' not found
```
d. This is weird, from what I can tell the anchor exists and works.

```
writing output... [ 89%] index
(line   52) broken    https://dev.azure.com/pyvista/PyVista/_build/latest?definitionId=3&branchName=master - 404 Client Error: Not Found for url: https://dev.azure.com/pyvista/PyVista/_build/latest?definitionId=3&branchName=master
```
e. This link is indeed broken for me; I suspect the existence of the link has to do with CI.

```
writing output... [ 91%] plotting/itk_plotting
(line   18) broken    https://github.com/InsightSoftwareConsortium/itkwidgets#installation - Anchor 'installation' not found
(line    6) broken    https://github.com/InsightSoftwareConsortium/itkwidgets#installation - Anchor 'installation' not found
```
f. Again this anchor seems to exist and work.

g. And with both runs of `sphinx` I got a deprecation warning:
```
/home/user/pyvista_test_env/lib/python3.7/site-packages/sphinx/deprecation.py:52: RemovedInSphinx40Warning: sphinx.builders.html.DirectoryHTMLBuilder is deprecated. Check CHANGES for Sphinx API modifications.
```


## TODO

- [x] add significance of the `name` kwarg
- [x] fix existing typos 
- [x] reorder so that examples come before documentation
- [x] fix indentation warnings in plotting.py (point b. above)
- [x] fix the Qt reference, point to pyvistaqt (point c. above)