### PR TITLE
clip closed surface for PolyData

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -3048,7 +3048,7 @@ class PolyDataFilters(DataSetFilters):
         """
         # verify it is manifold
         if poly_data.n_open_edges > 0:
-            raise Exception("This surface appears to be non-manifold.")
+            raise ValueError("This surface appears to be non-manifold.")
         if isinstance(normal, str):
             normal = NORMALS[normal.lower()]
         # find center of data if origin not specified

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -111,6 +111,15 @@ def test_clip_surface():
     assert 'implicit_distance' in clipped.array_names
 
 
+def test_clip_closed_surface():
+    closed_surface = pyvista.Sphere()
+    clipped = closed_surface.clip_closed_surface()
+    assert closed_surface.n_open_edges == 0
+    open_surface = closed_surface.clip()
+    with pytest.raises(ValueError):
+        _ = open_surface.clip_closed_surface()
+
+
 def test_implicit_distance():
     surface = pyvista.Cone(direction=(0,0,-1),
                            height=3.0, radius=1, resolution=50, )


### PR DESCRIPTION
See #794 

This only supports single plane clipping though the underlying VTK filter supports plane collections.

```py
import pyvista as pv
mesh = pv.Sphere()
cclipped = mesh.clip_closed_surface(normal='-x')
oclipped = mesh.clip(normal='-x', invert=False)

p = pv.Plotter(shape=(1,2))
p.add_mesh(cclipped, show_edges=True)
p.subplot(0,1)
p.add_mesh(oclipped, show_edges=True)
p.link_views()
p.view_isometric()
p.show()
```

![download](https://user-images.githubusercontent.com/22067021/84574758-b43f1280-ad76-11ea-8f25-118b0f266218.png)
