### PR TITLE
Fix UniformGrid points and extract_subset

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -3792,4 +3792,15 @@ class UniformGridFilters(DataSetFilters):
         alg.SetSampleRate(rate)
         alg.SetIncludeBoundary(boundary)
         alg.Update()
-        return _get_output(alg)
+        result = _get_output(alg)
+        # Adjust for the confusing issue with the extents
+        #   see https://gitlab.kitware.com/vtk/vtk/-/issues/17938
+        fixed = pyvista.UniformGrid()
+        fixed.origin = result.bounds[::2]
+        fixed.spacing = result.spacing
+        fixed.dimensions = result.dimensions
+        fixed.point_arrays.update(result.point_arrays)
+        fixed.cell_arrays.update(result.cell_arrays)
+        fixed.field_arrays.update(result.field_arrays)
+        fixed.copy_meta_from(result)
+        return fixed

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -352,7 +352,7 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
         # get the points and convert to spacings
         dx, dy, dz = self.spacing
         # Now make the cell arrays
-        ox, oy, oz = self.origin
+        ox, oy, oz = np.array(self.origin) + np.array(self.extent[::2])
         x = np.insert(np.cumsum(np.full(nx, dx)), 0, 0.0) + ox
         y = np.insert(np.cumsum(np.full(ny, dy)), 0, 0.0) + oy
         z = np.insert(np.cumsum(np.full(nz, dz)), 0, 0.0) + oz

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -791,3 +791,6 @@ def test_extract_subset():
     volume = examples.load_uniform()
     voi = volume.extract_subset([0,3,1,4,5,7])
     assert isinstance(voi, pyvista.UniformGrid)
+    # Test that we fix the confusin issue from extents in
+    #   https://gitlab.kitware.com/vtk/vtk/-/issues/17938
+    assert voi.origin == voi.bounds[::2]

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -791,6 +791,6 @@ def test_extract_subset():
     volume = examples.load_uniform()
     voi = volume.extract_subset([0,3,1,4,5,7])
     assert isinstance(voi, pyvista.UniformGrid)
-    # Test that we fix the confusin issue from extents in
+    # Test that we fix the confusing issue from extents in
     #   https://gitlab.kitware.com/vtk/vtk/-/issues/17938
     assert voi.origin == voi.bounds[::2]


### PR DESCRIPTION
### Overview

In answering https://github.com/pyvista/pyvista-support/issues/154#issuecomment-647074618, I discovered some weirdness with the `extract_subset` filter (`vtkExtractVOI`) where the origin might not be what a user expects. This PR provides an extra step to that filter to adjust the result to be more in line with what you'd expect.

Also, this made me realize that I implemented the `points` property of `UniformGrid`s incorrectly as it did account for the extent.


### Details

- changed output of `extract_subset` to be more logical/user-friendly
- fixed bug when fetching points of a `UniformGrid` mesh with a non-origin based extent

