### PR TITLE
Use smooth shading on gif example

### DIFF
--- a/examples/02-plot/gif.py
+++ b/examples/02-plot/gif.py
@@ -19,7 +19,7 @@ grid = pv.StructuredGrid(x, y, z)
 
 # Create a plotter object and set the scalars to the Z height
 plotter = pv.Plotter()
-plotter.add_mesh(grid, scalars=z.ravel())
+plotter.add_mesh(grid, scalars=z.ravel(), smooth_shading=True)
 
 print('Orient the view, then press "q" to close window and produce movie')
 
@@ -36,9 +36,15 @@ nframe = 15
 for phase in np.linspace(0, 2 * np.pi, nframe + 1)[:nframe]:
     z = np.sin(r + phase)
     pts[:, -1] = z.ravel()
-    plotter.update_coordinates(pts)
-    plotter.update_scalars(z.ravel())
-    plotter.write_frame()
+    plotter.update_coordinates(pts, render=False)
+    plotter.update_scalars(z.ravel(), render=False)
+
+    # must update normals when smooth shading is enabled
+    plotter.mesh.compute_normals(cell_normals=False, inplace=True)
+    plotter.write_frame()  # this will trigger the render
+
+    # otherwise, when not writing frames, render with:
+    # plotter.render()
 
 # Close movie and delete object
 plotter.close()


### PR DESCRIPTION
### Adds smooth shading to the gif example

Minor improvement to the gif example at [gif.py](https://docs.pyvista.org/examples/02-plot/gif.html#sphx-glr-examples-02-plot-gif-py).  While playing around with another project, I discovered that you have to update the normals on the fly when animating if you want to get an accurate rendering of your plot when using smooth shading.  Figured it's important to write this down somewhere and and example seems like a good spot for it.

Before:
![image](https://user-images.githubusercontent.com/11981631/85439537-6784e400-b58d-11ea-8532-b3db7306fa4f.png)


After:
![image](https://user-images.githubusercontent.com/11981631/85439477-5340e700-b58d-11ea-89a0-c228402fc938.png)
