### PR TITLE
Fix typo in slice_along_axis docstring

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -361,7 +361,7 @@ class DataSetFilters:
             (``0``, ``1``, or ``2``).
 
         tolerance : float, optional
-            The toleranceerance to the edge of the dataset bounds to create the slices
+            The tolerance to the edge of the dataset bounds to create the slices
 
         generate_triangles: bool, optional
             If this is enabled (``False`` by default), the output will be


### PR DESCRIPTION
Fixes a small typo in the `slice_along_axis()` docstring. 

Sorry if this isn't pointing to the correct branch for a change like this -- feel free to close this PR and just amend the typo with the next PR getting merged.