### PR TITLE
Add release suffix to version string

### DIFF
--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -1,6 +1,7 @@
 """Version info for pyvista."""
 # major, minor, patch
-version_info = 0, 25, 2
+version_info = 0, 26, 0
+suffix = 'b'
 
 # Nice string for the version
-__version__ = '.'.join(map(str, version_info))
+__version__ = '.'.join(map(str, version_info)) + suffix

--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -1,7 +1,6 @@
 """Version info for pyvista."""
 # major, minor, patch
 version_info = 0, 26, 'b0'
-suffix = 'b'
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -4,4 +4,4 @@ version_info = 0, 26, 'b0'
 suffix = 'b'
 
 # Nice string for the version
-__version__ = '.'.join(map(str, version_info)) + suffix
+__version__ = '.'.join(map(str, version_info))

--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -1,6 +1,6 @@
 """Version info for pyvista."""
 # major, minor, patch
-version_info = 0, 26, 0
+version_info = 0, 26, 'b0'
 suffix = 'b'
 
 # Nice string for the version


### PR DESCRIPTION
### Overview

Resolve #814


### Details

- Adds a suffix to the version string. On actual releases, this will need to be empty
- I'm pretty positive this follows https://www.python.org/dev/peps/pep-0440/
