### PR TITLE
Follow up #793: fix get_data_range

### DIFF
--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -637,7 +637,7 @@ class Common(DataSetFilters, DataObject):
                 # Raise a value error if fetching the range of an unknown array
                 raise ValueError('Array `{}` not present.'.format(name))
         # If array has no tuples return a NaN range
-        if arr.size == 0 or not np.issubdtype(arr.dtype, np.number):
+        if arr is None or arr.size == 0 or not np.issubdtype(arr.dtype, np.number):
             return (np.nan, np.nan)
         # Use the array range
         return np.nanmin(arr), np.nanmax(arr)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -761,3 +761,26 @@ def test_no_active():
 
     with pytest.raises(KeyError):
         pdata.point_arrays[None]
+
+
+def test_get_data_range(grid):
+    # Test with blank mesh
+    mesh = pyvista.Sphere()
+    mesh.clear_arrays()
+    rng = mesh.get_data_range()
+    assert all(np.isnan(rng))
+    with pytest.raises(ValueError):
+        rng = mesh.get_data_range('some data')
+
+    # Test with some data
+    rng = grid.get_data_range() # active scalars
+    assert len(rng) == 2
+    assert np.allclose(rng, (1, 302))
+
+    rng = grid.get_data_range('sample_point_scalars')
+    assert len(rng) == 2
+    assert np.allclose(rng, (1, 302))
+
+    rng = grid.get_data_range('sample_cell_scalars')
+    assert len(rng) == 2
+    assert np.allclose(rng, (1, 40))


### PR DESCRIPTION
A follow up to #793 to fix `get_data_range` for meshes without scalar data.

#793 broke the widget plotting helpers like: 

```py
mesh = pv.Sphere()
plotter.add_mesh_clip_plane(mesh)
```