### PR TITLE
Add texture demo with scalar data

### DIFF
--- a/examples/02-plot/texture.py
+++ b/examples/02-plot/texture.py
@@ -45,6 +45,18 @@ curvsurf.texture_map_to_plane(inplace=True)
 
 curvsurf.plot(texture=tex)
 
+###############################################################################
+# Display scalar data along with a texture by ensuring the
+# ``interpolate_before_map`` setting is ``False`` and specifying both the
+# ``texture`` and ``scalars`` arguments.
+
+elevated = curvsurf.elevation()
+
+elevated.plot(scalars='Elevation',
+              cmap='terrain',
+              texture=tex,
+              interpolate_before_map=False)
+
 
 ###############################################################################
 # Note that this process can be completed with any image texture!
@@ -148,20 +160,3 @@ curvsurf.t_coords = puppy_coords
 # use the puppy image
 tex = examples.download_puppy_texture()
 curvsurf.plot(texture=tex, cpos="xy")
-
-
-###############################################################################
-# Textures and Scalar Data
-# ++++++++++++++++++++++++
-#
-# Display scalar data along with a texture by ensuring the
-# ``interpolate_before_map`` setting is ``False`` and specifying both the
-# ``texture`` and ``scalars`` arguments.
-
-globe = examples.load_globe().elevation()
-
-globe.plot(scalars="Elevation",
-           cmap="jet",
-           texture=True,
-           lighting=False,
-           interpolate_before_map=False)

--- a/examples/02-plot/texture.py
+++ b/examples/02-plot/texture.py
@@ -148,3 +148,20 @@ curvsurf.t_coords = puppy_coords
 # use the puppy image
 tex = examples.download_puppy_texture()
 curvsurf.plot(texture=tex, cpos="xy")
+
+
+###############################################################################
+# Textures and Scalar Data
+# ++++++++++++++++++++++++
+#
+# Display scalar data along with a texture by ensuring the
+# ``interpolate_before_map`` setting is ``False`` and specifying both the
+# ``texture`` and ``scalars`` arguments.
+
+globe = examples.load_globe().elevation()
+
+globe.plot(scalars="Elevation",
+           cmap="jet",
+           texture=True,
+           lighting=False,
+           interpolate_before_map=False)


### PR DESCRIPTION
Adds an example to show scalar data over a textured mesh. I forgot how to do this and figured I'd add an example to document this
