### PR TITLE
Fix GPU info in scooby report

### DIFF
--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -224,7 +224,7 @@ class Report(scooby.Report):
         # bug that the user is trying to report.
         if gpu:
             try:
-                extra_meta = [(t[1], t[0]) for t in GPUInfo().get_info()]
+                extra_meta = GPUInfo().get_info()
             except:
                 extra_meta = ("GPU Details", "error")
         else:


### PR DESCRIPTION
Fixes the GPU info order in the scooby report's HTML table

<img width="731" alt="Screen Shot 2020-07-09 at 8 16 35 AM" src="https://user-images.githubusercontent.com/22067021/87038984-82c23700-c1bc-11ea-8334-60c60d78d084.png">
