### PR TITLE
Fix is_all_triangles

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -233,6 +233,10 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
 
     def is_all_triangles(self):
         """Return True if all the faces of the polydata are triangles."""
+        # Need to make sure there are only face cells and no lines/verts
+        if not len(self.faces) or len(self.lines) > 0 or len(self.verts) > 0:
+            return False
+        # All we have are faces, check if all faces are indeed triangles
         return self.faces.size % 4 == 0 and (self.faces.reshape(-1, 4)[:, 0] == 3).all()
 
     def _from_arrays(self, vertices, faces, deep=True, verts=False):

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -314,7 +314,7 @@ def test_triangulate_filter(plane):
     plane.triangulate(inplace=True)
     assert plane.is_all_triangles()
     # Make a point cloud and assert false
-    assert not pv.PolyData(plane.points).is_all_triangles()
+    assert not pyvista.PolyData(plane.points).is_all_triangles()
     # Extract lines and make sure false
     assert not plane.extract_all_edges().is_all_triangles()
 

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -313,6 +313,10 @@ def test_triangulate_filter(plane):
     assert not plane.is_all_triangles()
     plane.triangulate(inplace=True)
     assert plane.is_all_triangles()
+    # Make a point cloud and assert false
+    assert not pv.PolyData(plane.points).is_all_triangles()
+    # Extract lines and make sure false
+    assert not plane.extract_all_edges().is_all_triangles()
 
 
 @pytest.mark.parametrize('subfilter', ['butterfly', 'loop', 'linear'])


### PR DESCRIPTION
Fixes some edge cases where an empty `faces` array would evaluate to `True` in `is_all_triangles`. Also, if the mesh contained any lines or vertice cells, a false positive could occur so that was fixed too

Resolve #830 

cc @jrwrigh 

