### PR TITLE
Add pathlib Support

### DIFF
--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -103,7 +103,7 @@ class DataObject:
                                       ' dict of (file extension: vtkWriter type)'
                                       .format(self.__class__.__name__))
 
-        filename = os.path.abspath(os.path.expanduser(filename))
+        filename = os.path.abspath(os.path.expanduser(str(filename)))
         file_ext = fileio.get_ext(filename)
         if file_ext not in self._WRITERS:
             raise ValueError('Invalid file extension for this data type. Must be one of: {}'.format(

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -65,7 +65,7 @@ class DataObject:
                                       ' dict of (file extension: vtkReader type)'
                                       .format(self.__class__.__name__))
 
-        filename = os.path.abspath(os.path.expanduser(filename))
+        filename = os.path.abspath(os.path.expanduser(str(filename)))
         if not os.path.isfile(filename):
             raise FileNotFoundError('File %s does not exist' % filename)
 

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -61,7 +61,7 @@ class DataObject:
 
         """
         if self._READERS is None:
-            raise NotImplementedError('{} readers are not specified, this should be a' \
+            raise NotImplementedError('{} readers are not specified, this should be a'
                                       ' dict of (file extension: vtkReader type)'
                                       .format(self.__class__.__name__))
 

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -3,6 +3,7 @@
 These classes hold many VTK datasets in one object that can be passed
 to VTK algorithms and PyVista filtering/plotting routines.
 """
+import pathlib
 import collections.abc
 import logging
 
@@ -78,16 +79,22 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
             elif isinstance(args[0], (list, tuple)):
                 for block in args[0]:
                     self.append(block)
-            elif isinstance(args[0], str):
+            elif isinstance(args[0], (str, pathlib.Path)):
                 self._load_file(args[0])
             elif isinstance(args[0], dict):
                 idx = 0
                 for key, block in args[0].items():
                     self[idx, key] = block
                     idx += 1
+            else:
+                raise TypeError('Type %s is not supported by pyvista.MultiBlock'
+                                % type(args[0]))
 
             # keep a reference of the args
             self.refs.append(args)
+        elif len(args) > 1:
+            raise ValueError('Invalid number of arguments:\n``pyvista.MultiBlock``'
+                             'supports 0 or 1 arguments.')
 
         # Upon creation make sure all nested structures are wrapped
         self.wrap_nested()

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -1,5 +1,5 @@
 """Sub-classes for vtk.vtkRectilinearGrid and vtk.vtkImageData."""
-
+import pathlib
 import logging
 
 import numpy as np
@@ -91,7 +91,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
         if len(args) == 1:
             if isinstance(args[0], vtk.vtkRectilinearGrid):
                 self.deep_copy(args[0])
-            elif isinstance(args[0], str):
+            elif isinstance(args[0], (str, pathlib.Path)):
                 self._load_file(args[0])
             elif isinstance(args[0], np.ndarray):
                 self._from_arrays(args[0], None, None)
@@ -287,7 +287,7 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
         if len(args) == 1:
             if isinstance(args[0], vtk.vtkImageData):
                 self.deep_copy(args[0])
-            elif isinstance(args[0], str):
+            elif isinstance(args[0], (str, pathlib.Path)):
                 self._load_file(args[0])
             else:
                 arg0_is_valid = len(args[0]) == 3

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -317,7 +317,7 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
          file size.
 
         """
-        filename = os.path.abspath(os.path.expanduser(filename))
+        filename = os.path.abspath(os.path.expanduser(str(filename)))
         ftype = get_ext(filename)
         # Recompute normals prior to save.  Corrects a bug were some
         # triangular meshes are not saved correctly

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1,4 +1,5 @@
 """Sub-classes and wrappers for vtk.vtkPointSet."""
+import pathlib
 import logging
 import os
 import warnings
@@ -155,7 +156,7 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
                     self.deep_copy(args[0])
                 else:
                     self.shallow_copy(args[0])
-            elif isinstance(args[0], str):
+            elif isinstance(args[0], (str, pathlib.Path)):
                 self._load_file(args[0])
             elif isinstance(args[0], (np.ndarray, list)):
                 if isinstance(args[0], list):
@@ -461,10 +462,12 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
     >>> from pyvista import examples
     >>> import vtk
 
-    >>> # Create an empty grid
+    Create an empty grid
+
     >>> grid = pyvista.UnstructuredGrid()
 
-    >>> # Copy a vtkUnstructuredGrid
+    Copy a vtkUnstructuredGrid
+
     >>> vtkgrid = vtk.vtkUnstructuredGrid()
     >>> grid = pyvista.UnstructuredGrid(vtkgrid)  # Initialize from a vtkUnstructuredGrid
 
@@ -474,7 +477,8 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
     >>> # from arrays (vtk<9)
     >>> #grid = pyvista.UnstructuredGrid(offset, cells, celltypes, points)
 
-    >>> # From a string filename
+    From a string filename
+
     >>> grid = pyvista.UnstructuredGrid(examples.hexbeamfile)
 
     """
@@ -496,7 +500,7 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
                 else:
                     self.shallow_copy(args[0])
 
-            elif isinstance(args[0], str):
+            elif isinstance(args[0], (str, pathlib.Path)):
                 self._load_file(args[0])
 
             elif isinstance(args[0], vtk.vtkStructuredGrid):

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1,5 +1,6 @@
 """Pyvista plotting module."""
 
+import pathlib
 import collections.abc
 import logging
 import os
@@ -3189,13 +3190,17 @@ class BasePlotter(PickingHelper, WidgetHelper):
             raise ValueError('Empty image. Have you run plot() first?')
         # write screenshot to file
         supported_formats = [".png", ".jpeg", ".jpg", ".bmp", ".tif", ".tiff"]
-        if isinstance(filename, str):
-            if isinstance(pyvista.FIGURE_PATH, str) and not os.path.isabs(filename):
+        if isinstance(filename, (str, pathlib.Path)):
+            filename = pathlib.Path(filename)
+            if isinstance(pyvista.FIGURE_PATH, str) and not filename.is_absolute():
                 filename = os.path.join(pyvista.FIGURE_PATH, filename)
-            if not any([filename.lower().endswith(ext) for ext in supported_formats]):
-                filename += ".png"
-            filename = os.path.abspath(os.path.expanduser(filename))
-            w = imageio.imwrite(filename, image)
+            if not filename.suffix:
+                filename = filename.with_suffix('.png')
+            elif filename.suffix not in supported_formats:
+                raise ValueError('Unsupported extension %s\n' % filename.suffix +
+                                 'Must be one of the following: %s' %
+                                 supported_formats)
+            w = imageio.imwrite(filename.expanduser().absolute(), image)
             if not return_img:
                 return w
         return image

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3200,7 +3200,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 raise ValueError('Unsupported extension %s\n' % filename.suffix +
                                  'Must be one of the following: %s' %
                                  supported_formats)
-            w = imageio.imwrite(os.path.abspath(os.path.expanduser(filename)), image)
+            w = imageio.imwrite(os.path.abspath(os.path.expanduser(str(filename))),
+                                image)
             if not return_img:
                 return w
         return image

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3200,7 +3200,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 raise ValueError('Unsupported extension %s\n' % filename.suffix +
                                  'Must be one of the following: %s' %
                                  supported_formats)
-            w = imageio.imwrite(filename.expanduser().absolute(), image)
+            w = imageio.imwrite(os.path.abspath(os.path.expanduser(filename)), image)
             if not return_img:
                 return w
         return image

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3193,7 +3193,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if isinstance(filename, (str, pathlib.Path)):
             filename = pathlib.Path(filename)
             if isinstance(pyvista.FIGURE_PATH, str) and not filename.is_absolute():
-                filename = os.path.join(pyvista.FIGURE_PATH, filename)
+                filename = pathlib.Path(os.path.join(pyvista.FIGURE_PATH, filename))
             if not filename.suffix:
                 filename = filename.with_suffix('.png')
             elif filename.suffix not in supported_formats:

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -1,5 +1,6 @@
 """Contains a dictionary that maps file extensions to VTK readers."""
 
+import pathlib
 import os
 
 import numpy as np
@@ -168,22 +169,40 @@ def read(filename, attrs=None, file_format=None):
     Parameters
     ----------
     filename : str
-        The string path to the file to read. If a list of files is given,
-        a :class:`pyvista.MultiBlock` dataset is returned with each file being
-        a separate block in the dataset.
+        The string path to the file to read. If a list of files is
+        given, a :class:`pyvista.MultiBlock` dataset is returned with
+        each file being a separate block in the dataset.
+
     attrs : dict, optional
-        A dictionary of attributes to call on the reader. Keys of dictionary are
-        the attribute/method names and values are the arguments passed to those
-        calls. If you do not have any attributes to call, pass ``None`` as the
-        value.
+        A dictionary of attributes to call on the reader. Keys of
+        dictionary are the attribute/method names and values are the
+        arguments passed to those calls. If you do not have any
+        attributes to call, pass ``None`` as the value.
+
     file_format : str, optional
         Format of file to read with meshio.
 
+    Examples
+    --------
+    Load an example mesh
+    >>> import pyvista
+    >>> from pyvista import examples
+    >>> mesh = pyvista.read(examples.antfile)
+
+    Load a vtk file
+
+    >>> mesh = pyvista.read('my_mesh.vtk')  # doctest:+SKIP
+
+    Load a meshio file
+
+    >>> mesh = pyvista.read("mesh.obj")
+
     """
+
     if isinstance(filename, (list, tuple)):
         multi = pyvista.MultiBlock()
         for each in filename:
-            if isinstance(each, str):
+            if isinstance(each, (str, pathlib.Path)):
                 name = os.path.basename(each)
             else:
                 name = None

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -195,10 +195,8 @@ def read(filename, attrs=None, file_format=None):
 
     Load a meshio file
 
-    >>> mesh = pyvista.read("mesh.obj")
-
+    >>> mesh = pyvista.read("mesh.obj")  # doctest:+SKIP
     """
-
     if isinstance(filename, (list, tuple)):
         multi = pyvista.MultiBlock()
         for each in filename:

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -201,12 +201,12 @@ def read(filename, attrs=None, file_format=None):
         multi = pyvista.MultiBlock()
         for each in filename:
             if isinstance(each, (str, pathlib.Path)):
-                name = os.path.basename(each)
+                name = os.path.basename(str(each))
             else:
                 name = None
             multi[-1, name] = read(each)
         return multi
-    filename = os.path.abspath(os.path.expanduser(filename))
+    filename = os.path.abspath(os.path.expanduser(str(filename)))
     if not os.path.isfile(filename):
         raise FileNotFoundError('File ({}) not found'.format(filename))
     ext = get_ext(filename)

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import numpy as np
 import pytest
 import vtk
@@ -194,8 +196,13 @@ def test_multi_block_repr(ant, sphere, uniform, airplane):
 
 @pytest.mark.parametrize('binary', [True, False])
 @pytest.mark.parametrize('extension', pyvista.core.composite.MultiBlock._WRITERS)
-def test_multi_block_io(extension, binary, tmpdir, ant, sphere, uniform, airplane, globe):
-    filename = str(tmpdir.mkdir("tmpdir").join('tmp.%s' % extension))
+@pytest.mark.parametrize('use_pathlib', [True, False])
+def test_multi_block_io(extension, binary, tmpdir, use_pathlib, ant,
+                        sphere, uniform, airplane, globe):
+    if use_pathlib:
+        filename = str(tmpdir.mkdir("tmpdir").join('tmp.%s' % extension))
+    else:
+        filename = pathlib.Path(tmpdir.mkdir("tmpdir").join('tmp.%s' % extension))
     multi = multi_from_datasets(ant, sphere, uniform, airplane, globe)
     # Now check everything
     assert multi.n_blocks == 5
@@ -205,6 +212,13 @@ def test_multi_block_io(extension, binary, tmpdir, ant, sphere, uniform, airplan
     assert foo.n_blocks == multi.n_blocks
     foo = pyvista.read(filename)
     assert foo.n_blocks == multi.n_blocks
+
+
+def test_invalid_arg():
+    with pytest.raises(TypeError):
+        pyvista.MultiBlock(np.empty(10))
+    with pytest.raises(ValueError):
+        pyvista.MultiBlock(np.empty(10), np.empty(10))
 
 
 def test_multi_io_erros(tmpdir):

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -199,10 +199,9 @@ def test_multi_block_repr(ant, sphere, uniform, airplane):
 @pytest.mark.parametrize('use_pathlib', [True, False])
 def test_multi_block_io(extension, binary, tmpdir, use_pathlib, ant,
                         sphere, uniform, airplane, globe):
+    filename = str(tmpdir.mkdir("tmpdir").join('tmp.%s' % extension))
     if use_pathlib:
-        filename = str(tmpdir.mkdir("tmpdir").join('tmp.%s' % extension))
-    else:
-        filename = pathlib.Path(tmpdir.mkdir("tmpdir").join('tmp.%s' % extension))
+        pathlib.Path(filename)
     multi = multi_from_datasets(ant, sphere, uniform, airplane, globe)
     # Now check everything
     assert multi.n_blocks == 5

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,3 +1,4 @@
+import pathlib
 import os
 import weakref
 
@@ -136,6 +137,22 @@ def test_save(extension, binary, tmpdir, hexbeam):
     assert grid.points.shape == hexbeam.points.shape
 
     grid = pyvista.read(filename)
+    assert grid.cells.shape == hexbeam.cells.shape
+    assert grid.points.shape == hexbeam.points.shape
+    assert isinstance(grid, pyvista.UnstructuredGrid)
+
+
+def test_pathlib_read_write(tmpdir, hexbeam):
+    path = pathlib.Path(tmpdir.mkdir("tmpdir").join('tmp.vtk'))
+    assert not path.is_file()
+    hexbeam.save(path)
+    assert path.is_file()
+
+    grid = pyvista.UnstructuredGrid(path)
+    assert grid.cells.shape == hexbeam.cells.shape
+    assert grid.points.shape == hexbeam.points.shape
+
+    grid = pyvista.read(path)
     assert grid.cells.shape == hexbeam.cells.shape
     assert grid.points.shape == hexbeam.points.shape
     assert isinstance(grid, pyvista.UnstructuredGrid)
@@ -361,6 +378,14 @@ def test_read_rectilinear_grid_from_file():
     assert grid.n_arrays == 1
 
 
+def test_read_rectilinear_grid_from_pathlib():
+    grid = pyvista.RectilinearGrid(pathlib.Path(examples.rectfile))
+    assert grid.n_cells == 16146
+    assert grid.n_points == 18144
+    assert grid.bounds == [-350.0, 1350.0, -400.0, 1350.0, -850.0, 0.0]
+    assert grid.n_arrays == 1
+
+
 def test_cast_rectilinear_grid():
     grid = pyvista.read(examples.rectfile)
     structured = grid.cast_to_structured_grid()
@@ -422,6 +447,15 @@ def test_read_uniform_grid_from_file():
     assert grid.n_cells == 729
     assert grid.n_points == 1000
     assert grid.bounds == [0.0,9.0, 0.0,9.0, 0.0,9.0]
+    assert grid.n_arrays == 2
+    assert grid.dimensions == [10, 10, 10]
+
+
+def test_read_uniform_grid_from_pathlib():
+    grid = pyvista.UniformGrid(pathlib.Path(examples.uniformfile))
+    assert grid.n_cells == 729
+    assert grid.n_points == 1000
+    assert grid.bounds == [0.0, 9.0, 0.0, 9.0, 0.0, 9.0]
     assert grid.n_arrays == 2
     assert grid.dimensions == [10, 10, 10]
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -143,7 +143,7 @@ def test_save(extension, binary, tmpdir, hexbeam):
 
 
 def test_pathlib_read_write(tmpdir, hexbeam):
-    path = pathlib.Path(tmpdir.mkdir("tmpdir").join('tmp.vtk'))
+    path = pathlib.Path(str(tmpdir.mkdir("tmpdir").join('tmp.vtk')))
     assert not path.is_file()
     hexbeam.save(path)
     assert path.is_file()

--- a/tests/test_meshio.py
+++ b/tests/test_meshio.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import numpy as np
 import pytest
 
@@ -27,6 +29,16 @@ def test_meshio(mesh_in, tmpdir):
         assert np.allclose(v, mesh.point_arrays[k.replace(" ", "_")])
     for k, v in mesh_in.cell_arrays.items():
         assert np.allclose(v, mesh.cell_arrays[k.replace(" ", "_")])
+
+
+def test_pathlib_read_write(tmpdir, sphere):
+    path = pathlib.Path(tmpdir.mkdir("tmpdir").join('tmp.vtk'))
+    pyvista.save_meshio(path, sphere)
+    assert path.is_file()
+
+    mesh = pyvista.read_meshio(path)
+    assert isinstance(mesh, pyvista.UnstructuredGrid)
+    assert mesh.points.shape == sphere.points.shape
 
 
 def test_file_format():

--- a/tests/test_meshio.py
+++ b/tests/test_meshio.py
@@ -32,7 +32,7 @@ def test_meshio(mesh_in, tmpdir):
 
 
 def test_pathlib_read_write(tmpdir, sphere):
-    path = pathlib.Path(tmpdir.mkdir("tmpdir").join('tmp.vtk'))
+    path = pathlib.Path(str(tmpdir.mkdir("tmpdir").join('tmp.vtk')))
     pyvista.save_meshio(path, sphere)
     assert path.is_file()
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -64,14 +64,13 @@ def test_plot(tmpdir):
     cpos = pyvista.plot(sphere, off_screen=OFF_SCREEN, screenshot=filename)
 
     # Ensure it added a PNG extension by default
-    filename = filename.with_suffix(".png")
-    assert os.path.isfile(filename)
+    assert filename.with_suffix(".png").is_file()
 
     # test invalid extension
     with pytest.raises(ValueError):
         filename = pathlib.Path(str(tmp_dir.join('tmp3.foo')))
         pyvista.plot(sphere, off_screen=OFF_SCREEN, screenshot=filename)
-    
+
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_plot_invalid_style():

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -60,7 +60,7 @@ def test_plot(tmpdir):
     assert isinstance(img, np.ndarray)
     assert os.path.isfile(filename)
 
-    filename = pathlib.Path(tmp_dir.join('tmp2.png'))
+    filename = pathlib.Path(str(tmp_dir.join('tmp2.png')))
     cpos = pyvista.plot(sphere, off_screen=OFF_SCREEN, screenshot=filename)
 
     # Ensure it added a PNG extension by default
@@ -69,7 +69,7 @@ def test_plot(tmpdir):
 
     # test invalid extension
     with pytest.raises(ValueError):
-        filename = pathlib.Path(tmp_dir.join('tmp3.foo'))
+        filename = pathlib.Path(str(tmp_dir.join('tmp3.foo')))
         pyvista.plot(sphere, off_screen=OFF_SCREEN, screenshot=filename)
     
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,3 +1,4 @@
+import pathlib
 import os
 import sys
 from weakref import proxy
@@ -38,7 +39,8 @@ sphere_c = pyvista.Sphere(2.0)
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_plot(tmpdir):
-    filename = os.path.join(pyvista.USER_DATA_PATH, 'tmp.png')
+    tmp_dir = tmpdir.mkdir("tmpdir2")
+    filename = str(tmp_dir.join('tmp.png'))
     scalars = np.arange(sphere.n_points)
     cpos, img = pyvista.plot(sphere,
                              off_screen=OFF_SCREEN,
@@ -57,14 +59,19 @@ def test_plot(tmpdir):
     assert isinstance(cpos, pyvista.CameraPosition)
     assert isinstance(img, np.ndarray)
     assert os.path.isfile(filename)
-    os.remove(filename)
-    filename = os.path.join(pyvista.USER_DATA_PATH, 'foo')
-    cpos = pyvista.plot(sphere, off_screen=OFF_SCREEN, screenshot=filename)
-    filename = filename + ".png" # Ensure it added a PNG extension by default
-    assert os.path.isfile(filename)
-    # remove file
-    os.remove(filename)
 
+    filename = pathlib.Path(tmp_dir.join('tmp2.png'))
+    cpos = pyvista.plot(sphere, off_screen=OFF_SCREEN, screenshot=filename)
+
+    # Ensure it added a PNG extension by default
+    filename = filename.with_suffix(".png")
+    assert os.path.isfile(filename)
+
+    # test invalid extension
+    with pytest.raises(ValueError):
+        filename = pathlib.Path(tmp_dir.join('tmp3.foo'))
+        pyvista.plot(sphere, off_screen=OFF_SCREEN, screenshot=filename)
+    
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_plot_invalid_style():

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -305,7 +305,7 @@ def test_save(extension, binary, tmpdir):
 
 
 def test_pathlib_read_write(tmpdir, sphere):
-    path = pathlib.Path(tmpdir.mkdir("tmpdir").join('tmp.vtk'))
+    path = pathlib.Path(str(tmpdir.mkdir("tmpdir").join('tmp.vtk')))
     sphere.save(path)
     assert path.is_file()
 

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -1,3 +1,4 @@
+import pathlib
 import os
 from math import pi
 
@@ -299,6 +300,21 @@ def test_save(extension, binary, tmpdir):
     sphere.save(filename, binary)
 
     mesh = pyvista.PolyData(filename)
+    assert mesh.faces.shape == sphere.faces.shape
+    assert mesh.points.shape == sphere.points.shape
+
+
+def test_pathlib_read_write(tmpdir, sphere):
+    path = pathlib.Path(tmpdir.mkdir("tmpdir").join('tmp.vtk'))
+    sphere.save(path)
+    assert path.is_file()
+
+    mesh = pyvista.PolyData(path)
+    assert mesh.faces.shape == sphere.faces.shape
+    assert mesh.points.shape == sphere.points.shape
+
+    mesh = pyvista.read(path)
+    assert isinstance(mesh, pyvista.PolyData)
     assert mesh.faces.shape == sphere.faces.shape
     assert mesh.points.shape == sphere.points.shape
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,4 +1,5 @@
 """ test pyvista.utilities """
+import pathlib
 import os
 
 import numpy as np
@@ -38,9 +39,12 @@ def test_createvectorpolydata():
     assert np.any(vdata.point_arrays['vectors'])
 
 
-def test_read(tmpdir):
+@pytest.mark.parametrize('use_pathlib', [True, False])
+def test_read(tmpdir, use_pathlib):
     fnames = (ex.antfile, ex.planefile, ex.hexbeamfile, ex.spherefile,
               ex.uniformfile, ex.rectfile)
+    if use_pathlib:
+        fnames = [pathlib.Path(fname) for fname in fnames]
     types = (pyvista.PolyData, pyvista.PolyData, pyvista.UnstructuredGrid,
              pyvista.PolyData, pyvista.UniformGrid, pyvista.RectilinearGrid)
     for i, filename in enumerate(fnames):


### PR DESCRIPTION
### Pathlib Support

This PR adds pathlib support and resolves #833, allowing:
```python
import pyvista as pv
from pathlib import Path
vtuFilePath = Path(r'./test.vtu')
pv.UnstructuredGrid(vtuFilePath)
```

This PR took longer than expected due to problems with Python3.5 and pathlib support for `~` and the many locations that we need to check for `pathlib` vs `str` in our code.