### PR TITLE
Clarify clip filter docstring

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -98,7 +98,7 @@ class DataSetFilters:
         invert : bool
             Flag on whether to flip/invert the clip.
 
-        value : float:
+        value : float, optional
             Set the clipping value along the normal direction.
             The default value is 0.0.
 

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -93,14 +93,13 @@ class DataSetFilters:
 
         origin : tuple(float)
             The center ``(x,y,z)`` coordinate of the plane on which the clip
-            occurs
+            occurs. The default is the center of the dataset.
 
         invert : bool
-            Flag on whether to flip/invert the clip
+            Flag on whether to flip/invert the clip.
 
         value : float:
-            Set the clipping value of the implicit function (if clipping with
-            implicit function) or scalar value (if clipping with scalars).
+            Set the clipping value along the normal direction.
             The default value is 0.0.
 
         inplace : bool, optional

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -95,7 +95,7 @@ class DataSetFilters:
             The center ``(x,y,z)`` coordinate of the plane on which the clip
             occurs. The default is the center of the dataset.
 
-        invert : bool
+        invert : bool, optional
             Flag on whether to flip/invert the clip.
 
         value : float, optional

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -91,7 +91,7 @@ class DataSetFilters:
             specified as a string conventional direction such as ``'x'`` for
             ``(1,0,0)`` or ``'-x'`` for ``(-1,0,0)``, etc.
 
-        origin : tuple(float)
+        origin : tuple(float), optional
             The center ``(x,y,z)`` coordinate of the plane on which the clip
             occurs. The default is the center of the dataset.
 


### PR DESCRIPTION
### Overview

The clip filter docstring currently states that "If no parameters are given the clip will occur in the center of that dataset."  However it isn't really clear why this is true from the defaults of the other parameters.  What if I specify just the value?  Adding this to the description of origin clarifies this.

The description of value seems to be held over from somewhere else, which is also fixed.

Additionally, I made an edit for consistency (within clip anyway) to end with a period, but I see both styles in other docstrings in this module.

### Details

I didn't make any changes, but there is inconsistent usage of `optional`. Specifying the default value in the parameter description is also inconsistent throughout the filters.  I wasn't sure what is preferred for further cleaning up the clip filter docstring. 

