### PR TITLE
New probe filter and massively improve interpolate filter

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1490,7 +1490,6 @@ class DataSetFilters:
 
     def interpolate(dataset, target, sharpness=2, radius=1.0,
                     strategy='null_value', null_value=0.0, n_points=None,
-                    pass_cell_arrays=False, pass_point_arrays=False,
                     progress_bar=False):
         """Interpolate values onto this mesh from a given dataset.
 

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1490,7 +1490,8 @@ class DataSetFilters:
 
     def interpolate(dataset, target, sharpness=2, radius=1.0,
                     strategy='null_value', null_value=0.0, n_points=None,
-                    progress_bar=False):
+                    pass_cell_arrays=True, pass_point_arrays=True,
+                    progress_bar=False, ):
         """Interpolate values onto this mesh from a given dataset.
 
         The input dataset is typically a point cloud.
@@ -1536,6 +1537,12 @@ class DataSetFilters:
             then all components of each null tuple are set to this value. By
             default the null value is set to zero.
 
+        pass_cell_arrays: bool, optional
+            Preserve input mesh's original cell data arrays
+
+        pass_point_arrays: bool, optional
+            Preserve input mesh's original point data arrays
+
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
@@ -1566,8 +1573,8 @@ class DataSetFilters:
             interpolator.SetNullPointsStrategyToClosestPoint()
         else:
             raise ValueError('strategy `{}` not supported.'.format(strategy))
-        interpolator.PassPointArraysOff()
-        interpolator.PassCellArraysOff()
+        interpolator.SetPassPointArrays(pass_point_arrays)
+        interpolator.SetPassCellArrays(pass_cell_arrays)
         _update_alg(interpolator, progress_bar, 'Interpolating')
         return _get_output(interpolator)
 

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1398,7 +1398,7 @@ class DataSetFilters:
         return out
 
     def probe(dataset, points, tolerance=None, pass_cell_arrays=True,
-               pass_point_arrays=True, categorical=False):
+              pass_point_arrays=True, categorical=False):
         """Sample data values at specified point locations.
 
         This uses :class:`vtk.vtkProbeFilter`.
@@ -1410,7 +1410,7 @@ class DataSetFilters:
             this object are probed onto the nodes of the ``points`` mesh
 
         points: pyvista.Common
-            The points to probe values on to. This should be a PyVsita mesh
+            The points to probe values on to. This should be a PyVista mesh
             or something :func:`pyvista.wrap` can handle.
 
         tolerance: float, optional
@@ -1427,6 +1427,18 @@ class DataSetFilters:
             Control whether the source point data is to be treated as
             categorical. If the data is categorical, then the resultant data
             will be determined by a nearest neighbor interpolation scheme.
+
+        Examples
+        --------
+        Probe the active scalars in ``grid`` at the points in ``mesh``
+
+        >>> import pyvista as pv
+        >>> from pyvista import examples
+        >>> mesh = pyvista.Sphere(center=(4.5, 4.5, 4.5), radius=4.5)
+        >>> grid = examples.load_uniform()
+        >>> result = grid.probe(mesh)
+        >>> 'Spatial Point Data' in result.point_arrays
+        True
 
         """
         if not pyvista.is_pyvista_dataset(points):

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1547,6 +1547,14 @@ class DataSetFilters:
             Display a progress bar to indicate progress.
 
         """
+        if not pyvista.is_pyvista_dataset(target):
+            raise TypeError('`target` must be a PyVista mesh type.')
+
+        # Must cast to UnstructuredGrid in some cases (e.g. vtkImageData/vtkRectilinearGrid)
+        # I believe the locator and the interpolator call `GetPoints` and not all mesh types have that method
+        if isinstance(target, (pyvista.UniformGrid, pyvista.RectilinearGrid)):
+            target = target.cast_to_unstructured_grid()
+
         gaussian_kernel = vtk.vtkGaussianKernel()
         gaussian_kernel.SetSharpness(sharpness)
         gaussian_kernel.SetRadius(radius)

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1490,7 +1490,8 @@ class DataSetFilters:
 
     def interpolate(dataset, target, sharpness=2, radius=1.0,
                     strategy='null_value', null_value=0.0, n_points=None,
-                    pass_cell_arrays=False, pass_point_arrays=False):
+                    pass_cell_arrays=False, pass_point_arrays=False,
+                    progress_bar=False):
         """Interpolate values onto this mesh from a given dataset.
 
         The input dataset is typically a point cloud.
@@ -1536,6 +1537,9 @@ class DataSetFilters:
             then all components of each null tuple are set to this value. By
             default the null value is set to zero.
 
+        progress_bar : bool, optional
+            Display a progress bar to indicate progress.
+
         """
         gaussian_kernel = vtk.vtkGaussianKernel()
         gaussian_kernel.SetSharpness(sharpness)
@@ -1565,7 +1569,7 @@ class DataSetFilters:
             raise ValueError('strategy `{}` not supported.'.format(strategy))
         interpolator.PassPointArraysOff()
         interpolator.PassCellArraysOff()
-        interpolator.Update()
+        _update_alg(interpolator, progress_bar, 'Interpolating')
         return _get_output(interpolator)
 
     def streamlines(dataset, vectors=None, source_center=None,

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -592,6 +592,25 @@ def test_resample():
     assert isinstance(result, type(mesh))
 
 
+@pytest.mark.parametrize('use_points', [True, False])
+@pytest.mark.parametrize('categorical', [True, False])
+def test_probe(categorical, use_points):
+    mesh = pyvista.Sphere(center=(4.5, 4.5, 4.5), radius=4.5)
+    data_to_probe = examples.load_uniform()
+    if use_points:
+        dataset = np.array(mesh.points)
+    else:
+        dataset = mesh
+    result = data_to_probe.probe(dataset, tolerance=1E-5, categorical=categorical)
+    name = 'Spatial Point Data'
+    assert name in result.array_names
+    assert isinstance(result, type(mesh))
+    result = mesh.sample(data_to_probe, tolerance=1.0)
+    name = 'Spatial Point Data'
+    assert name in result.array_names
+    assert isinstance(result, type(mesh))
+
+
 @pytest.mark.parametrize('integration_direction', ['forward', 'backward', 'both'])
 def test_streamlines_dir(uniform_vec, integration_direction):
     stream = uniform_vec.streamlines('vectors',


### PR DESCRIPTION
### Overview

This introduces a new `probe` filter based on `vtkProbeFilter` per https://github.com/pyvista/pyvista-support/issues/203 and has some massive improvements to the `interpolate` filter.

cc @jrwrigh 

### Details

- See https://github.com/pyvista/pyvista-support/issues/203 for details on the probe filter
- The `interpolate` filter was wildly inefficient for large datasets and required the use of an intermediate `UniformGrid` during the interpolation. This removes that intermediate step so that the gaussian interpolation happens directly on the calling mesh. This has drastic performance differences when interpolating large meshes and yields the exact same results for our example use cases. The arguments for the method have rightfully changed (DEPRECATION), but it's well worth the improvement
    - So much more is possible with this implementation that was previously not doable with the uniform grid sampling approach.
    - Note that we have to cast some inputs to an unstructured grid due to how the point locator and interpolator interface with the source data.
- See the super awesome use case for the interpolate filter at the bottom of https://github.com/pyvista/pyvista-support/issues/211#issuecomment-662801004