### PR TITLE
ENH: Capture click-and-drag events

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -901,7 +901,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def update_style(self):
         """Update the camera interactor style."""
         if self._style_class is None:
-            # We need an actualy custom style to
+            # We need an actually custom style to handle button up events
             self._style_class = _style_factory(self._style)(self)
         if hasattr(self, 'iren'):
             return self.iren.SetInteractorStyle(self._style_class)


### PR DESCRIPTION
Closes #116.

![Peek 2020-07-31 15-04](https://user-images.githubusercontent.com/2365790/89068403-22e42980-d33f-11ea-8686-8260e1effba8.gif)

<details>
<summary>Code</summary>

```
import pyvista as pv
from pyvista import examples
mesh = examples.download_cow()
decimated = mesh.decimate_boundary(target_reduction=0.75)
p = pv.Plotter(notebook=0, shape=(1, 2), border=False)
p.subplot(0, 0)
p.add_text("Original mesh", font_size=24)
p.add_mesh(mesh, show_edges=True, color=True)
p.subplot(0, 1)
p.add_text("Decimated version", font_size=24)
p.add_mesh(decimated, color=True, show_edges=True)
p.show()
```

</details>

EDIT: To produce the animation above, I just used screen-capture software with actual manual click-and-drag interactions.

1. In `_add_observer`, wrap all `call` within a `try_callback`. Should make the tracebacks a bit nicer. Remove related `try/except` elsewhere
2. To get the release event we [must](http://vtk.1045678.n5.nabble.com/Mouse-button-release-event-is-still-broken-in-VTK-6-0-0-td5724762.html) subclass the InteractorStyle. Hence I reworked `_style` and `update_style` and all functions that use these (e.g., `enable_trackball_style`).
3. Use an [extra layer](https://vtk.org/pipermail/vtkusers/2018-June/102030.html) approach to actually fix the issue by disabling and re-enabling interactivity with press/release. Not 100% sure the background stuff is correct but hopefully it is.