### PR TITLE
Fixed _custom_opac flag

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1484,7 +1484,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             opacity = np.array(opacity)
             if scalars.shape[0] == opacity.shape[0]:
                 # User could pass an array of opacities for every point/cell
-                pass
+                _custom_opac = True
             else:
                 opacity = opacity_transfer_function(opacity, n_colors)
 


### PR DESCRIPTION
If we specify opacity for every point, then pyvista fails with expection:
```
File ".../pyvista/plotting/plotting.py", line 1601, in add_mesh 
ctable[:,-1] = opacity 
ValueError: could not broadcast input array from shape (500) into shape (256)
```
Looks like it was just missed this line.