### PR TITLE
✏️ fix format of python code

### DIFF
--- a/pyvista/utilities/cells.py
+++ b/pyvista/utilities/cells.py
@@ -43,6 +43,7 @@ class CellArray(vtkCellArray):
     Examples
     --------
     Create a cell array containing two triangles.
+
     >>> from pyvista.utilities.cells import CellArray
     >>> cellarr = CellArray([3, 0, 1, 2, 3, 3, 4, 5])
     """

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -185,6 +185,7 @@ def read(filename, attrs=None, file_format=None):
     Examples
     --------
     Load an example mesh
+
     >>> import pyvista
     >>> from pyvista import examples
     >>> mesh = pyvista.read(examples.antfile)

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -101,6 +101,7 @@ def ParametricBour(**kwargs):
     Examples
     --------
     Create a ParametricBour mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricBour()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -142,6 +143,7 @@ def ParametricBoy(zscale=None, **kwargs):
     Examples
     --------
     Create a ParametricBoy mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricBoy()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -175,6 +177,7 @@ def ParametricCatalanMinimal(**kwargs):
     Example
     -------
     Create a ParametricCatalanMinimal mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricCatalanMinimal()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -227,6 +230,7 @@ def ParametricConicSpiral(a=None, b=None, c=None, n=None, **kwargs):
     Examples
     --------
     Create a ParametricConicSpiral mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricConicSpiral()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -269,6 +273,7 @@ def ParametricCrossCap(**kwargs):
     Examples
     --------
     Create a ParametricCrossCap mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricCrossCap()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -311,6 +316,7 @@ def ParametricDini(a=None, b=None, **kwargs):
     Examples
     --------
     Create a ParametricDini mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricDini()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -361,6 +367,7 @@ def ParametricEllipsoid(xradius=None, yradius=None, zradius=None,
     Examples
     --------
     Create a ParametricEllipsoid mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricEllipsoid()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -410,6 +417,7 @@ def ParametricEnneper(**kwargs):
     Examples
     --------
     Create a ParametricEnneper mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricEnneper()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -446,6 +454,7 @@ def ParametricFigure8Klein(radius=None, **kwargs):
     Examples
     --------
     Create a ParametricFigure8Klein mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricFigure8Klein()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -475,6 +484,7 @@ def ParametricHenneberg(**kwargs):
     Examples
     --------
     Create a ParametricHenneberg mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricHenneberg()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -507,6 +517,7 @@ def ParametricKlein(**kwargs):
     Examples
     --------
     Create a ParametricKlein mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricKlein()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -546,6 +557,7 @@ def ParametricKuen(deltav0=None, **kwargs):
     Examples
     --------
     Create a ParametricKuen mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricKuen()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -580,6 +592,7 @@ def ParametricMobius(radius=None, **kwargs):
     Examples
     --------
     Create a ParametricMobius mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricMobius()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -620,6 +633,7 @@ def ParametricPluckerConoid(n=None, **kwargs):
     Examples
     --------
     Create a ParametricPluckerConoid mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricPluckerConoid()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -654,6 +668,7 @@ def ParametricPseudosphere(**kwargs):
     Examples
     --------
     Create a ParametricPseudosphere mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricPseudosphere()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -728,6 +743,7 @@ def ParametricRandomHills(numberofhills=None, hillxvariance=None,
     Examples
     --------
     Create a ParametricRandomHills mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricRandomHills()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -783,6 +799,7 @@ def ParametricRoman(radius=None, **kwargs):
     Examples
     --------
     Create a ParametricRoman mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricRoman()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -835,6 +852,7 @@ def ParametricSuperEllipsoid(xradius=None, yradius=None, zradius=None,
     Examples
     --------
     Create a ParametricSuperEllipsoid mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricSuperEllipsoid()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -912,6 +930,7 @@ def ParametricSuperToroid(ringradius=None, crosssectionradius=None,
     Examples
     --------
     Create a ParametricSuperToroid mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricSuperToroid()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP
@@ -968,6 +987,7 @@ def ParametricTorus(ringradius=None, crosssectionradius=None, **kwargs):
     Examples
     --------
     Create a ParametricTorus mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricTorus()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -71,6 +71,7 @@ def ParametricBohemianDome(a=None, **kwargs):
     Examples
     --------
     Create a ParametricBohemianDome mesh
+
     >>> import pyvista
     >>> mesh = pyvista.ParametricBohemianDome()
     >>> mesh.plot(color='w', smooth_shading=True)  # doctest:+SKIP

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -28,6 +28,7 @@ def Spline(points, n_points=None):
     Examples
     --------
     Construct a spline
+
     >>> import numpy as np
     >>> import pyvista as pv
     >>> theta = np.linspace(-4 * np.pi, 4 * np.pi, 100)


### PR DESCRIPTION
### Overview

Python code format is broken in pyvista.Spline document. We need 1 blank line before python code. Thank you for reading.

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details
Please see [here](https://docs.pyvista.org/utilities/geometric.html#pyvista.Spline).

![image](https://user-images.githubusercontent.com/7513610/90197379-76f41100-de09-11ea-8dea-a5a152204830.png)

