### PR TITLE
Control points merging in the glyph filter

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -946,8 +946,8 @@ class DataSetFilters:
         return output
 
     def glyph(dataset, orient=True, scale=True, factor=1.0, geom=None,
-              tolerance=0.0, absolute=False, clamping=False, clean=True,
-              rng=None, progress_bar=False):
+              tolerance=0.0, absolute=False, clamping=False, rng=None,
+              progress_bar=False):
         """Copy a geometric representation (called a glyph) to every point in the input dataset.
 
         The glyph may be oriented along the input vectors, and it may be scaled according to scalar
@@ -971,15 +971,13 @@ class DataSetFilters:
             Specify tolerance in terms of fraction of bounding box length.
             Float value is between 0 and 1. Default is 0.0. If ``absolute``
             is ``True`` then the tolerance can be an absolute distance.
+            If None, points merging as a preprocessing step is disabled.
 
         absolute : bool, optional
             Control if ``tolerance`` is an absolute distance or a fraction.
 
         clamping: bool
             Turn on/off clamping of "scalar" values to range.
-
-        clean: bool
-            Clean the points before glyphing. Defaults to True.
 
         rng: tuple(float), optional
             Set the range of values to be considered by the filter when scalars
@@ -990,7 +988,7 @@ class DataSetFilters:
 
         """
         # Clean the points before glyphing
-        if clean:
+        if tolerance is not None:
             small = pyvista.PolyData(dataset.points)
             small.point_arrays.update(dataset.point_arrays)
             dataset = small.clean(point_merging=True, merge_tol=tolerance,

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -946,8 +946,8 @@ class DataSetFilters:
         return output
 
     def glyph(dataset, orient=True, scale=True, factor=1.0, geom=None,
-              tolerance=0.0, absolute=False, clamping=False, rng=None,
-              progress_bar=False):
+              tolerance=0.0, absolute=False, clamping=False, clean=True,
+              rng=None, progress_bar=False):
         """Copy a geometric representation (called a glyph) to every point in the input dataset.
 
         The glyph may be oriented along the input vectors, and it may be scaled according to scalar
@@ -962,7 +962,7 @@ class DataSetFilters:
             Use the active scalars to scale the glyphs
 
         factor : float
-            Scale factor applied to sclaing array
+            Scale factor applied to scaling array
 
         geom : vtk.vtkDataSet
             The geometry to use for the glyph
@@ -978,6 +978,9 @@ class DataSetFilters:
         clamping: bool
             Turn on/off clamping of "scalar" values to range.
 
+        clean: bool
+            Clean the points before glyphing. Defaults to True.
+
         rng: tuple(float), optional
             Set the range of values to be considered by the filter when scalars
             values are provided.
@@ -987,12 +990,13 @@ class DataSetFilters:
 
         """
         # Clean the points before glyphing
-        small = pyvista.PolyData(dataset.points)
-        small.point_arrays.update(dataset.point_arrays)
-        dataset = small.clean(point_merging=True, merge_tol=tolerance,
-                              lines_to_points=False, polys_to_lines=False,
-                              strips_to_polys=False, inplace=False,
-                              absolute=absolute, progress_bar=progress_bar)
+        if clean:
+            small = pyvista.PolyData(dataset.points)
+            small.point_arrays.update(dataset.point_arrays)
+            dataset = small.clean(point_merging=True, merge_tol=tolerance,
+                                  lines_to_points=False, polys_to_lines=False,
+                                  strips_to_polys=False, inplace=False,
+                                  absolute=absolute, progress_bar=progress_bar)
         # Make glyphing geometry
         if geom is None:
             arrow = vtk.vtkArrowSource()

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -946,7 +946,7 @@ class DataSetFilters:
         return output
 
     def glyph(dataset, orient=True, scale=True, factor=1.0, geom=None,
-              tolerance=0.0, absolute=False, clamping=False, rng=None,
+              tolerance=None, absolute=False, clamping=False, rng=None,
               progress_bar=False):
         """Copy a geometric representation (called a glyph) to every point in the input dataset.
 
@@ -969,7 +969,7 @@ class DataSetFilters:
 
         tolerance : float, optional
             Specify tolerance in terms of fraction of bounding box length.
-            Float value is between 0 and 1. Default is 0.0. If ``absolute``
+            Float value is between 0 and 1. Default is None. If ``absolute``
             is ``True`` then the tolerance can be an absolute distance.
             If None, points merging as a preprocessing step is disabled.
 


### PR DESCRIPTION
This PR adds a `clean` parameter to control the preprocessing in the glyph filter.

It is now possible to do:

```py
import numpy as np
import pyvista as pv

cells = np.array([[1, 0], [1, 1], [1, 2]])
cell_type = np.array([1, 1, 1])
points = np.array([[0., 0., 0.], [0., 0., 0.], [0., 0., 0.]])
vectors = np.array([[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]])
grid = pv.UnstructuredGrid(cells, cell_type, points)
grid.point_arrays['vec'] = vectors

p = pv.Plotter()
p.add_mesh(grid.glyph(orient='vec', clean=False))
p.show()
```

to obtain:

![image](https://user-images.githubusercontent.com/18143289/90381165-45837b80-e07d-11ea-9603-540e998f73da.png)

Closes #869 