### PR TITLE
Add Clip by Scalar

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -52,6 +52,24 @@ def test_clip_filter():
             assert isinstance(clp, pyvista.UnstructuredGrid)
 
 
+def test_clip_by_scalars_filter():
+    """This tests the clip filter on all datatypes available filters"""
+    for i, dataset_in in enumerate(DATASETS):
+        dataset = dataset_in.copy()  # don't modify in-place
+        if dataset.active_scalars_info.name is None:
+            dataset['scalars'] = np.arange(dataset.n_points)
+        clip_value = dataset.n_points/2
+        clp = dataset.clip_scalar(value=clip_value)
+
+        assert clp is not None
+        if isinstance(dataset, pyvista.PolyData):
+            assert isinstance(clp, pyvista.PolyData)
+        else:
+            assert isinstance(clp, pyvista.UnstructuredGrid)
+
+        assert dataset.active_scalars.min() <= clip_value
+
+
 @skip_py2_nobind
 def test_clip_filter_composite():
     # Now test composite data structures


### PR DESCRIPTION
### Add Clip by Scalar

This PR adds clip by scalar as requested and written by @Aquan1412.

```python
import pyvista as pv
from pyvista import examples
dataset = examples.load_hexbeam()
clipped = dataset.clip_scalar(scalars="sample_point_scalars", value=100, invert=True)
clipped.plot()
```

![image](https://user-images.githubusercontent.com/11981631/91780236-312e9b00-ebb4-11ea-927c-4748f7b0b3cd.png)

Resolves #874 
