### PR TITLE
🌐 Internationalization and localization of document.

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -4,9 +4,11 @@
 {% block extrahead %}
 {{ super() }}
 
+{%trans%}
 <meta name="description" content="3D plotting and mesh analysis through a streamlined interface for the Visualization Toolkit (VTK)">
 <meta name="author" content="PyVista Developers">
 <meta name="keywords" content="python, 3D, visualization, plotting, mesh, meshviewer, vtk, open-source">
+{%endtrans%}
 
 <!-- this contains PyVista's Google analytics code - please don't copy/paste our tracking ID -->
 <script>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -4,11 +4,9 @@
 {% block extrahead %}
 {{ super() }}
 
-{%trans%}
-<meta name="description" content="3D plotting and mesh analysis through a streamlined interface for the Visualization Toolkit (VTK)">
-<meta name="author" content="PyVista Developers">
-<meta name="keywords" content="python, 3D, visualization, plotting, mesh, meshviewer, vtk, open-source">
-{%endtrans%}
+<meta name="description" content={%trans%}"3D plotting and mesh analysis through a streamlined interface for the Visualization Toolkit (VTK)"{%endtrans%}>
+<meta name="author" content={%trans%}"PyVista Developers"{%endtrans%}>
+<meta name="keywords" content={%trans%}"python, 3D, visualization, plotting, mesh, meshviewer, vtk, open-source"{%endtrans%}>
 
 <!-- this contains PyVista's Google analytics code - please don't copy/paste our tracking ID -->
 <script>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -192,7 +192,7 @@ for 3D visualization in our `external examples list <./external_examples.html>`_
 Translating the documentation
 *****************************
 
-The recommended way for new contributors to translate pyvista reference is to
+The recommended way for new contributors to translate ``pyvista``'s documentation is to
 join the translation team on Transifex.
 
 There is `pyvista translation page`_ for pyvista (master) documentation.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -189,6 +189,26 @@ for 3D visualization in our `external examples list <./external_examples.html>`_
    external_examples
 
 
+Translating the documentation
+*****************************
+
+The recommended way for new contributors to translate pyvista reference is to
+join the translation team on Transifex.
+
+There is `pyvista translation page`_ for pyvista (master) documentation.
+
+1. Login to transifex_ service.
+2. Go to `pyvista translation page`_.
+3. Click ``Request language`` and fill form.
+4. Wait acceptance by transifex pyvista translation maintainers.
+5. (After acceptance) Translate on transifex.
+6. You can see the translated document in `Read The Docs`_.
+
+.. _`pyvista translation page`: https://www.transifex.com/getfem-doc/pyvista/
+.. _Transifex: https://www.transifex.com/
+.. _`Read The Docs`: https://pyvista-doc.readthedocs.io/en/latest
+
+
 API Reference
 *************
 


### PR DESCRIPTION
Hi all. I translate the pyvista document to my native language Japanese and release it in [read the docs](https://pyvista-doc.readthedocs.io/ja/latest/why.html). Easiest way to translate sphinx document is to make [CI repository](https://github.com/tkoyama010/pyvista-doc-translations) and translate document in Transifex. [sphinx](https://github.com/sphinx-doc/sphinx) project translate their document in this way by this [CI](https://github.com/sphinx-doc/sphinx-doc-translations.git) and I follow [this way](https://sphinx.readthedocs.io/).

I know that there is no resource to translate all language. But I want to give a framework to translate document to other translator.

### Overview

<!-- Please insert a high-level description of this pull request here. -->
:globe_with_meridians: Internationalization and localization of document.

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 
I did the same thing in mayavi project.
https://github.com/enthought/mayavi/pull/841

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

Here is the [contributing to sphinx document translation section](https://www.sphinx-doc.org/en/master/usage/advanced/intl.html#contributing-to-sphinx-reference-translation) of sphinx.

I use Read the Docs because they have a function to [project with multiple translations function](https://docs.readthedocs.io/en/stable/localization.html#project-with-multiple-translations).

Feel free to discuss :+1:
