### PR TITLE
✏️ fix format of python code

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -3353,6 +3353,7 @@ class PolyDataFilters(DataSetFilters):
         Examples
         --------
         Compute the point normals of the surface of a sphere
+
         >>> import pyvista as pv
         >>> sphere = pv.Sphere()
         >>> sphere.compute_normals(cell_normals=False, inplace=True)

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2929,6 +2929,7 @@ class PolyDataFilters(DataSetFilters):
         Examples
         --------
         Smooth the edges of an all triangular cube
+
         >>> import pyvista as pv
         >>> cube = pv.Cube().triangulate().subdivide(5).clean()
         >>> smooth_cube = cube.smooth(1000, feature_smoothing=False)


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Python code format is broken in pyvista.Spline document. We need 1 blank line before python code. Thank you for reading.

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- #866

