### PR TITLE
Add Makefile targets for coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,15 @@ pydocstyle:
 doctest-modules:
 	@echo "Runnnig module doctesting"
 	pytest -v --doctest-modules pyvista
+
+coverage:
+	@echo "Running coverage"
+	@pytest -v --cov pyvista
+
+coverage-xml:
+	@echo "Reporting XML coverage"
+	@pytest -v --cov pyvista --cov-report xml
+
+coverage-html:
+	@echo "Reporting HTML coverage"
+	@pytest -v --cov pyvista --cov-report html


### PR DESCRIPTION
This small PR brings some convenience targets to the `Makefile` similarly to https://github.com/pyvista/pyvistaqt/pull/36.

I plan to work on fixing the codecov badge and improving the overall stats in a follow-up PR.