### PR TITLE
BUG: Fix ref cycle problem

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2686,6 +2686,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
         # Do not remove the renderers on the clean
         self.mesh = None
         self.mapper = None
+        self.volume = None
+        self.textactor = None
 
     def add_text(self, text, position='upper_left', font_size=18, color=None,
                  font=None, shadow=False, name=None, viewport=False):


### PR DESCRIPTION
This code:
```
import gc
import time
import pyvista as pv
from pyvistaqt import BackgroundPlotter
from pyvista import examples
vol = examples.download_knee_full()

for _ in range(10):
    plotter = BackgroundPlotter()
    plotter.add_volume(vol)
    plotter.show()
    plotter.close()
    plotter.deep_clean()
gc.collect()
time.sleep(2)
```
Run with:
```
mprof run mem.py; mprof plot
```
Produces this on `master`:
![Screenshot from 2020-09-18 07-49-28](https://user-images.githubusercontent.com/2365790/93596448-56c6ed00-f987-11ea-8453-5d1c0c8f89a1.png)

And this on this PR:

![Screenshot from 2020-09-18 07-49-51](https://user-images.githubusercontent.com/2365790/93596469-5d556480-f987-11ea-9e42-82eef3f48d9f.png)

Getting rid of `volume` was enough to fix it, but I figure getting rid of `textactor` is also a good idea.