### PR TITLE
Fix scalar bar slot lookup edge case

### DIFF
--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1460,9 +1460,10 @@ def _remove_mapper_from_plotter(plotter, actor, reset_camera):
         except ValueError:
             pass
         if len(plotter._scalar_bar_mappers[name]) < 1:
-            slot = plotter._scalar_bar_slot_lookup.pop(name)
-            plotter._scalar_bar_mappers.pop(name)
-            plotter._scalar_bar_ranges.pop(name)
-            plotter.remove_actor(plotter._scalar_bar_actors.pop(name), reset_camera=reset_camera)
-            plotter._scalar_bar_slots.add(slot)
+            slot = plotter._scalar_bar_slot_lookup.pop(name, None)
+            if slot is not None:
+                plotter._scalar_bar_mappers.pop(name)
+                plotter._scalar_bar_ranges.pop(name)
+                plotter.remove_actor(plotter._scalar_bar_actors.pop(name), reset_camera=reset_camera)
+                plotter._scalar_bar_slots.add(slot)
     return


### PR DESCRIPTION
### Overview

This PR patches an edge case where its impossible to remove an actor when the scalar bar does not actually have an actors mapper from `_scalar_bar_mappers`.  Bug discovered in #897.

Code reposted for clarity:

```python
import numpy as np 
import pyvista as pv
# Volume rendering is not supported with Panel yet
pv.rcParams["use_panel"] = False
pv.rcParams["volume_mapper"] = 'gpu'

''' plot '''
values = np.linspace(0, 10, 1000).reshape((20, 5, 10))
grid = pv.UniformGrid()
grid.dimensions = np.array(values.shape) + 1
grid.origin = (100, 33, 55.6)  # The bottom left corner of the data set
grid.spacing = (1, 5, 2)  # These are the cell sizes along each axis
grid.cell_arrays["values"] = values.flatten(order="F")  # Flatten the array!
values_flat =  values.flatten(order="F")

scargs=dict(
    position_x=0.5,
    position_y=0.1
)

name='foo'
cmin=values.min()
cmax=values.max()
p = pv.Plotter(notebook=False)
p.add_mesh(grid,show_edges=True, name=name, clim=[cmin,cmax], scalar_bar_args=scargs)
p.add_mesh(grid.outline(),show_edges=True) 

def func(value): 
    ''' callback function '''
    thresh = grid.threshold(value, scalars='values')

    if thresh.n_points < 1:
        p.remove_actor(name)
    else:
        p.add_mesh(thresh,show_edges=True, name=name, clim=[cmin,cmax])
    return

p.add_slider_widget(callback=func,rng=(cmin,cmax))
p.show()
```

Error occurs at ``p.remove_actor(name)`` without this PR.
