### PR TITLE
Fix Plot Opacity Array

### DIFF
--- a/examples/02-plot/opacity.py
+++ b/examples/02-plot/opacity.py
@@ -132,17 +132,23 @@ contours.array_names
 ###############################################################################
 # Make sure to flag ``use_transparency=True`` since we want areas of high
 # variance to have high transparency.
+#
+# Also, since the opacity array must be between 0 and 1, we normalize
+# the temperature variance array by the maximum value.  That way high
+# variance will be completely transparent.
 
-p = pv.Plotter(shape=(1,2))
+contours['Temperature_var'] /= contours['Temperature_var'].max()
 
-p.subplot(0,0)
+p = pv.Plotter(shape=(1, 2))
+
+p.subplot(0, 0)
 p.add_text('Opacity by Array')
 p.add_mesh(contours.copy(), scalars='Temperature',
            opacity='Temperature_var',
            use_transparency=True,
            cmap='bwr')
 
-p.subplot(0,1)
+p.subplot(0, 1)
 p.add_text('No Opacity')
 p.add_mesh(contours, scalars='Temperature',
            cmap='bwr')

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1542,7 +1542,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 # Get array from mesh
                 opacity = get_array(mesh, opacity,
                                     preference=preference, err=True)
-                opacity = normalize(opacity)
+                if np.any(opacity > 1):
+                    warnings.warn("Opacity scalars contain values over 1")
+                if np.any(opacity < 0):
+                    warnings.warn("Opacity scalars contain values less than 0")
                 _custom_opac = True
             except:
                 # Or get opacity transfer function
@@ -1679,11 +1682,13 @@ class BasePlotter(PickingHelper, WidgetHelper):
                     ctable = np.ascontiguousarray(ctable[::-1])
                 table.SetTable(VN.numpy_to_vtk(ctable))
                 if _custom_opac:
+                    # need to round the colors here since we're
+                    # directly displaying the colors
                     hue = normalize(scalars, minimum=clim[0], maximum=clim[1])
-                    scalars = cmap(hue)[:, :3]
-                    # combine colors and alpha into a Nx4 matrix
-                    scalars = np.concatenate((scalars, opacity[:, None]), axis=1)
-                    scalars = (scalars * 255).astype(np.uint8)
+                    scalars = np.round(hue*n_colors)/n_colors
+                    scalars = cmap(scalars)*255
+                    scalars[:, -1] *= opacity
+                    scalars = scalars.astype(np.uint8)
                     prepare_mapper(scalars)
 
             else:  # no cmap specified

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -896,13 +896,14 @@ def test_plot_eye_dome_lighting():
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_opacity_by_array():
     mesh = examples.load_uniform()
+    opac = mesh['Spatial Point Data'] / mesh['Spatial Point Data'].max()
     # Test with opacity array
-    mesh['opac'] = mesh['Spatial Point Data'] / 100.
+    mesh['opac'] = opac
     p = pyvista.Plotter(off_screen=OFF_SCREEN)
     p.add_mesh(mesh, scalars='Spatial Point Data', opacity='opac',)
     p.show()
     # Test with uncertainty array (transparency)
-    mesh['unc'] = mesh['Spatial Point Data']
+    mesh['unc'] = opac
     p = pyvista.Plotter(off_screen=OFF_SCREEN)
     p.add_mesh(mesh, scalars='Spatial Point Data', opacity='unc',
                use_transparency=True)


### PR DESCRIPTION
### Fix Plot Opacity by Array

Opacity plotting when ``n_colors`` is specified is broken as reported by https://github.com/pyvista/pyvista-support/issues/251.  This fixes the ``n_colors`` argument.

The first issue as noted by that issue is that opacity is normalized internally, which I feel is non-idea as it's not possible to have part of the mesh with an opacity of 0.5 and the rest as 1, as normalizing the opacity scalars will cause half the mesh to be hidden and half to be fully visible.  Instead, this PR proposes that the opacity scalars not be normalized and a warning be issued when the scalars are outside the range ``[0, 1]``.

@banesullivan, since you're the one who implemented the opacity by scalars, I'd like your input before overwriting this.

Example Code:
```py
import numpy as np
import pyvista as pv

ellipsoid = pv.ParametricEllipsoid(10, 5, 5)
ellipsoid.point_arrays["color"] = np.linspace(0,10,len(ellipsoid.points))
ellipsoid.point_arrays["opacity"] = np.where(ellipsoid.points[:, 0] > 0, 0.5, 1)

ellipsoid.plot(scalars="color", n_colors=5, opacity="opacity")
```

Before Fix:
![image](https://user-images.githubusercontent.com/11981631/94350941-eb2cf180-0010-11eb-84a5-8b1f05e4d90a.png)

After Fix:
![image](https://user-images.githubusercontent.com/11981631/94350943-f1bb6900-0010-11eb-9ab2-99716a40d1a5.png)