### PR TITLE
Render Prior to Callback on Picking

### DIFF
--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -119,6 +119,9 @@ class PickingHelper:
                               line_width=line_width, pickable=False,
                               reset_camera=False, **kwargs)
 
+                # render here prior to running the callback
+                self.render()
+
             if callback is not None and is_valid_selection:
                 try_callback(callback, self.picked_cells)
 


### PR DESCRIPTION
### Overview

This PR forces a render prior to running the callback when picking cells.  This fixes undesired behavior as noted by #916 for long callbacks.
