### PR TITLE
Refactor various common.py methods.

### DIFF
--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -436,8 +436,7 @@ class Common(DataSetFilters, DataObject):
 
     def clear_textures(self):
         """Clear the textures from this mesh."""
-        if hasattr(self, '_textures'):
-            del self._textures
+        self._textures.clear()
 
     def _activate_texture(mesh, name):
         """Grab a texture and update the active texture coordinates.
@@ -758,10 +757,9 @@ class Common(DataSetFilters, DataObject):
         """Copy pyvista meta data onto this object from another object."""
         self._active_scalars_info = ido.active_scalars_info
         self._active_vectors_info = ido.active_vectors_info
-        if hasattr(ido, '_textures'):
-            self._textures = {}
-            for name, tex in ido._textures.items():
-                self._textures[name] = tex.copy()
+        self.clear_textures()
+        for name, tex in ido._textures.items():
+            self._textures[name] = tex.copy()
 
     @property
     def point_arrays(self):

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -271,6 +271,7 @@ class Common(DataSetFilters, DataObject):
         self._last_active_scalars_name = None
         self._active_scalars_info = ActiveArrayInfo(FieldAssociation.POINT, name=None)
         self._active_vectors_info = ActiveArrayInfo(FieldAssociation.POINT, name=None)
+        self._textures = {}
 
     @property
     def active_scalars_info(self):
@@ -431,8 +432,6 @@ class Common(DataSetFilters, DataObject):
         will not be passed.
 
         """
-        if not hasattr(self, '_textures'):
-            self._textures = {}
         return self._textures
 
     def clear_textures(self):

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -11,7 +11,7 @@ import vtk
 import pyvista
 from pyvista.utilities import (FieldAssociation, get_array, is_pyvista_dataset,
                                parse_field_choice, raise_not_matching, vtk_id_list_to_array,
-                               fileio, abstract_class)
+                               fileio, abstract_class, axis_rotation)
 from .datasetattributes import DataSetAttributes
 from .filters import DataSetFilters
 
@@ -1070,37 +1070,3 @@ class Common(DataSetFilters, DataObject):
             locator.FindClosestNPoints(n, point, id_list)
             return vtk_id_list_to_array(id_list)
         return locator.FindClosestPoint(point)
-
-
-def axis_rotation(points, angle, inplace=False, deg=True, axis='z'):
-    """Rotate points angle (in deg) about an axis."""
-    axis = axis.lower()
-
-    # Copy original array to if not inplace
-    if not inplace:
-        points = points.copy()
-
-    # Convert angle to radians
-    if deg:
-        angle *= np.pi / 180
-
-    if axis == 'x':
-        y = points[:, 1] * np.cos(angle) - points[:, 2] * np.sin(angle)
-        z = points[:, 1] * np.sin(angle) + points[:, 2] * np.cos(angle)
-        points[:, 1] = y
-        points[:, 2] = z
-    elif axis == 'y':
-        x = points[:, 0] * np.cos(angle) + points[:, 2] * np.sin(angle)
-        z = - points[:, 0] * np.sin(angle) + points[:, 2] * np.cos(angle)
-        points[:, 0] = x
-        points[:, 2] = z
-    elif axis == 'z':
-        x = points[:, 0] * np.cos(angle) - points[:, 1] * np.sin(angle)
-        y = points[:, 0] * np.sin(angle) + points[:, 1] * np.cos(angle)
-        points[:, 0] = x
-        points[:, 1] = y
-    else:
-        raise ValueError('invalid axis. Must be either "x", "y", or "z"')
-
-    if not inplace:
-        return points

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -10,8 +10,8 @@ import vtk
 
 import pyvista
 from pyvista.utilities import (FieldAssociation, get_array, is_pyvista_dataset,
-                               parse_field_choice, raise_not_matching, vtk_id_list_to_array,
-                               fileio, abstract_class, axis_rotation)
+                               raise_not_matching, vtk_id_list_to_array, fileio,
+                               abstract_class, axis_rotation)
 from .datasetattributes import DataSetAttributes
 from .filters import DataSetFilters
 

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -758,8 +758,7 @@ class Common(DataSetFilters, DataObject):
         self._active_scalars_info = ido.active_scalars_info
         self._active_vectors_info = ido.active_vectors_info
         self.clear_textures()
-        for name, tex in ido._textures.items():
-            self._textures[name] = tex.copy()
+        self._textures = {name: tex.copy() for name, tex in ido.textures.items()}
 
     @property
     def point_arrays(self):

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -391,10 +391,9 @@ class Common(DataSetFilters, DataObject):
             Active scalars represented as arrows.
 
         """
-        if self.active_vectors is None:
-            return
-        name = self.active_vectors_name
-        return self.glyph(scale=name, orient=name)
+        if self.active_vectors is not None:
+            name = self.active_vectors_name
+            return self.glyph(scale=name, orient=name)
 
     @property
     def vectors(self):

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -765,19 +765,6 @@ class Common(DataSetFilters, DataObject):
         """Return vtkPointData as DataSetAttributes."""
         return DataSetAttributes(self.GetPointData(), dataset=self, association=FieldAssociation.POINT)
 
-    def _remove_array(self, field, key):
-        """Remove a single array by name from each field (internal helper)."""
-        field = parse_field_choice(field)
-        if field == FieldAssociation.POINT:
-            self.GetPointData().RemoveArray(key)
-        elif field == FieldAssociation.CELL:
-            self.GetCellData().RemoveArray(key)
-        elif field == FieldAssociation.NONE:
-            self.GetFieldData().RemoveArray(key)
-        else:
-            raise NotImplementedError(f'Not able to remove arrays from the ({field}) data field')
-        return
-
     def clear_point_arrays(self):
         """Remove all point arrays."""
         self.point_arrays.clear()

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1219,8 +1219,8 @@ class DataSetFilters:
                 # strange behavior:
                 # must use this method rather than deleting from the point_arrays
                 # or else object is collected.
-                b._remove_array(FieldAssociation.CELL, 'RegionId')
-                b._remove_array(FieldAssociation.POINT, 'RegionId')
+                b.cell_arrays.remove('RegionId')
+                b.point_arrays.remove('RegionId')
             bodies.append(b)
 
         return bodies

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -729,3 +729,37 @@ def abstract_class(cls_):
         return object.__new__(cls)
     cls_.__new__ = __new__
     return cls_
+
+
+def axis_rotation(points, angle, inplace=False, deg=True, axis='z'):
+    """Rotate points angle (in deg) about an axis."""
+    axis = axis.lower()
+
+    # Copy original array to if not inplace
+    if not inplace:
+        points = points.copy()
+
+    # Convert angle to radians
+    if deg:
+        angle *= np.pi / 180
+
+    if axis == 'x':
+        y = points[:, 1] * np.cos(angle) - points[:, 2] * np.sin(angle)
+        z = points[:, 1] * np.sin(angle) + points[:, 2] * np.cos(angle)
+        points[:, 1] = y
+        points[:, 2] = z
+    elif axis == 'y':
+        x = points[:, 0] * np.cos(angle) + points[:, 2] * np.sin(angle)
+        z = - points[:, 0] * np.sin(angle) + points[:, 2] * np.cos(angle)
+        points[:, 0] = x
+        points[:, 2] = z
+    elif axis == 'z':
+        x = points[:, 0] * np.cos(angle) - points[:, 1] * np.sin(angle)
+        y = points[:, 0] * np.sin(angle) + points[:, 1] * np.cos(angle)
+        points[:, 0] = x
+        points[:, 1] = y
+    else:
+        raise ValueError('invalid axis. Must be either "x", "y", or "z"')
+
+    if not inplace:
+        return points


### PR DESCRIPTION
### Overview

Move axis_rotation to helpers.py

Remove Common._remove_array, marked as internal helper, no longer necessary and outdated.

Initialize _textures  in \_\_init\_\_ instead of creating when accessed.

Use pathlib in save(), _load_file and allow them to take a pathlib.Path.

Various small changes/renaming.
