### PR TITLE
Delete obbTree to avoid memory leak

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -401,6 +401,11 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
         return alg.GetOutput().GetNumberOfCells()
 
 
+    def __del__(self):
+        if hasattr(self, '_obbTree'):
+            del self._obbTree
+
+
 @abstract_class
 class PointGrid(PointSet):
     """Class in common with structured and unstructured grids."""

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -402,6 +402,7 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
 
 
     def __del__(self):
+        """Delete the object."""
         if hasattr(self, '_obbTree'):
             del self._obbTree
 


### PR DESCRIPTION
### Overview

This should resolve #914. @Keou0007, would you please confirm?


### Details

```py
import pyvista as pv

start = [0, 0, 0]
stop = [-0.5, -0.5, 0.5]

for i in range(10000):
    mesh = pv.Sphere()
    point, cell = mesh.ray_trace(start, stop, first_point=True)
```

| master | this branch |
|---|---|
| ![master](https://user-images.githubusercontent.com/22067021/94981989-44ef5900-04f4-11eb-8acd-51f48313b77e.png) |  ![fix](https://user-images.githubusercontent.com/22067021/94981992-491b7680-04f4-11eb-8694-0d20bd562264.png) |


@pyvista/developers, should we more broadly implement `__del__` on the `Common` and clean up other objects?


