### PR TITLE
Refactor Texture, add ability to load from file.

### DIFF
--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -77,7 +77,10 @@ class DataObject:
         reader = self._READERS[file_ext]()
         reader.SetFileName(str(file_path))
         reader.Update()
-        self.shallow_copy(reader.GetOutput())
+        return reader.GetOutputDataObject(0)
+
+    def _from_file(self, filename):
+        self.shallow_copy(self._load_file(filename))
 
     def save(self, filename, binary=True):
         """Save this vtk object to file.

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -185,7 +185,7 @@ class DataObject:
         This includes header details and information about all arrays.
 
         """
-        raise NotImplemented('Called only by the inherited class')
+        raise NotImplementedError('Called only by the inherited class')
 
     def copy_meta_from(self, ido):  # pragma: no cover
         """Copy pyvista meta data onto this object from another object."""

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -80,7 +80,7 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
                 for block in args[0]:
                     self.append(block)
             elif isinstance(args[0], (str, pathlib.Path)):
-                self._load_file(args[0])
+                self._from_file(args[0])
             elif isinstance(args[0], dict):
                 idx = 0
                 for key, block in args[0].items():

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -92,7 +92,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
             if isinstance(args[0], vtk.vtkRectilinearGrid):
                 self.deep_copy(args[0])
             elif isinstance(args[0], (str, pathlib.Path)):
-                self._load_file(args[0])
+                self._from_file(args[0])
             elif isinstance(args[0], np.ndarray):
                 self._from_arrays(args[0], None, None)
             else:
@@ -288,7 +288,7 @@ class UniformGrid(vtkImageData, Grid, UniformGridFilters):
             if isinstance(args[0], vtk.vtkImageData):
                 self.deep_copy(args[0])
             elif isinstance(args[0], (str, pathlib.Path)):
-                self._load_file(args[0])
+                self._from_file(args[0])
             else:
                 arg0_is_valid = len(args[0]) == 3
                 self._from_specs(args[0])

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -342,7 +342,7 @@ class Texture(vtk.vtkTexture, DataObject):
 
     def flip(self, axis):
         """Flip this texture inplace along the specified axis. 0 for X and 1 for Y."""
-        if axis < 0 or axis > 1:
+        if 0 <= axis <= 1:
             raise ValueError(f"Axis {axis} out of bounds")
         array = self.to_array()
         array = np.flip(array, axis=1 - axis)

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -341,6 +341,21 @@ class Texture(vtk.vtkTexture, DataObject):
         grid.set_active_scalars('Image')
         return self._from_image_data(grid)
 
+    @property
+    def repeat(self):
+        """Repeat the texture."""
+        return self.GetRepeat()
+
+    @repeat.setter
+    def repeat(self, flag):
+        self.SetRepeat(flag)
+
+    @property
+    def n_components(self):
+        """Components in the image (e.g. 3 [or 4] for RGB[A])."""
+        image = self.to_image()
+        return image.active_scalars.shape[1]
+
     def flip(self, axis):
         """Flip this texture inplace along the specified axis. 0 for X and 1 for Y."""
         if not 0 <= axis <= 1:
@@ -352,12 +367,6 @@ class Texture(vtk.vtkTexture, DataObject):
     def to_image(self):
         """Return the texture as an image."""
         return self.GetInput()
-
-    @property
-    def n_components(self):
-        """Components in the image (e.g. 3 [or 4] for RGB[A])."""
-        image = self.to_image()
-        return image.active_scalars.shape[1]
 
     def to_array(self):
         """Return the texture as a np.ndarray."""
@@ -373,15 +382,6 @@ class Texture(vtk.vtkTexture, DataObject):
     def plot(self, *args, **kwargs):
         """Plot the texture as image data by itself."""
         return self.to_image().plot(*args, **kwargs)
-
-    @property
-    def repeat(self):
-        """Repeat the texture."""
-        return self.GetRepeat()
-
-    @repeat.setter
-    def repeat(self, flag):
-        self.SetRepeat(flag)
 
     def copy(self):
         """Make a copy of this texture."""

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -294,6 +294,7 @@ class Texture(vtk.vtkTexture, DataObject):
 
     def __init__(self, *args, **kwargs):
         """Initialize the texture."""
+        super().__init__(*args, **kwargs)
         assert_empty_kwargs(**kwargs)
 
         if len(args) == 1:

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -3,7 +3,7 @@
 The data objects does not have any sort of spatial reference.
 
 """
-
+import imageio
 import numpy as np
 import vtk
 
@@ -310,8 +310,13 @@ class Texture(vtk.vtkTexture, DataObject):
                 raise TypeError(f'Table unable to be made from ({type(args[0])})')
 
     def _from_file(self, filename):
-        image = self._load_file(filename)
-        self._from_image_data(image)
+        try:
+            image = self._load_file(filename)
+            if image.GetNumberOfPoints() < 2:
+                raise ValueError("Problem reading the image with VTK.")
+            self._from_image_data(image)
+        except (KeyError, RuntimeError):
+            self._from_array(imageio.imread(filename))
 
     def _from_texture(self, texture):
         image = texture.GetInput()

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -359,7 +359,7 @@ class Texture(vtk.vtkTexture, DataObject):
         return image.active_scalars.shape[1]
 
     def to_array(self):
-        """Return the texture as an array."""
+        """Return the texture as a np.ndarray."""
         image = self.to_image()
 
         if image.active_scalars.ndim > 1:

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -283,8 +283,14 @@ class Table(vtk.vtkTable, DataObject):
         return np.nanmin(arr), np.nanmax(arr)
 
 
-class Texture(vtk.vtkTexture):
+class Texture(vtk.vtkTexture, DataObject):
     """A helper class for vtkTextures."""
+
+    _READERS = {'.bmp': vtk.vtkBMPReader, '.dem': vtk.vtkDEMReader, '.dcm': vtk.vtkDICOMImageReader,
+                '.img': vtk.vtkDICOMImageReader, '.jpeg': vtk.vtkJPEGReader, '.jpg': vtk.vtkJPEGReader,
+                '.mhd': vtk.vtkMetaImageReader, '.nrrd': vtk.vtkNrrdReader, '.nhdr': vtk.vtkNrrdReader,
+                '.png': vtk.vtkPNGReader, '.pnm': vtk.vtkPNMReader, '.slc': vtk.vtkSLCReader,
+                '.tiff': vtk.vtkTIFFReader, '.tif': vtk.vtkTIFFReader}
 
     def __init__(self, *args, **kwargs):
         """Initialize the texture."""
@@ -298,9 +304,13 @@ class Texture(vtk.vtkTexture):
             elif isinstance(args[0], vtk.vtkImageData):
                 self._from_image_data(args[0])
             elif isinstance(args[0], str):
-                self._from_texture(pyvista.read_texture(args[0]))
+                self._from_file(filename=args[0])
             else:
                 raise TypeError(f'Table unable to be made from ({type(args[0])})')
+
+    def _from_file(self, filename):
+        image = self._load_file(filename)
+        self._from_image_data(image)
 
     def _from_texture(self, texture):
         image = texture.GetInput()

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -323,6 +323,7 @@ class Texture(vtk.vtkTexture, DataObject):
         return self.Update()
 
     def _from_array(self, image):
+        """Create a texture from a np.ndarray."""
         if image.ndim not in (2, 3):
             # we support 2 [single component image] or 3 [e.g. rgb or rgba] dims
             raise ValueError('Input image must be nn by nm by RGB[A]')

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -384,5 +384,5 @@ class Texture(vtk.vtkTexture, DataObject):
         self.SetRepeat(flag)
 
     def copy(self):
-        """Make a copy of this textrue."""
+        """Make a copy of this texture."""
         return Texture(self.to_image().copy())

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -344,9 +344,8 @@ class Texture(vtk.vtkTexture, DataObject):
         """Flip this texture inplace along the specified axis. 0 for X and 1 for Y."""
         if axis < 0 or axis > 1:
             raise ValueError(f"Axis {axis} out of bounds")
-        ax = [1, 0]
         array = self.to_array()
-        array = np.flip(array, axis=ax[axis])
+        array = np.flip(array, axis=1 - axis)
         return self._from_array(array)
 
     def to_image(self):

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -324,12 +324,12 @@ class Texture(vtk.vtkTexture, DataObject):
 
     def _from_array(self, image):
         """Create a texture from a np.ndarray."""
-        if image.ndim not in (2, 3):
+        if not 2 <= image.ndim <= 3:
             # we support 2 [single component image] or 3 [e.g. rgb or rgba] dims
             raise ValueError('Input image must be nn by nm by RGB[A]')
 
         if image.ndim == 3:
-            if image.shape[2] not in (3, 4):
+            if not 3 <= image.shape[2] <= 4:
                 raise ValueError('Third dimension of the array must be of size 3 (RGB) or 4 (RGBA)')
             n_components = image.shape[2]
         elif image.ndim == 2:
@@ -342,7 +342,7 @@ class Texture(vtk.vtkTexture, DataObject):
 
     def flip(self, axis):
         """Flip this texture inplace along the specified axis. 0 for X and 1 for Y."""
-        if 0 <= axis <= 1:
+        if not 0 <= axis <= 1:
             raise ValueError(f"Axis {axis} out of bounds")
         array = self.to_array()
         array = np.flip(array, axis=1 - axis)

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -323,23 +323,20 @@ class Texture(vtk.vtkTexture, DataObject):
         return self.Update()
 
     def _from_array(self, image):
-        if image.ndim not in [2,3]:
+        if image.ndim not in (2, 3):
             # we support 2 [single component image] or 3 [e.g. rgb or rgba] dims
             raise ValueError('Input image must be nn by nm by RGB[A]')
 
         if image.ndim == 3:
-            if image.shape[2] != 3 and image.shape[2] != 4:
+            if image.shape[2] not in (3, 4):
                 raise ValueError('Third dimension of the array must be of size 3 (RGB) or 4 (RGBA)')
-
             n_components = image.shape[2]
-
         elif image.ndim == 2:
             n_components = 1
 
         grid = pyvista.UniformGrid((image.shape[1], image.shape[0], 1))
         grid.point_arrays['Image'] = np.flip(image.swapaxes(0, 1), axis=1).reshape((-1, n_components), order='F')
         grid.set_active_scalars('Image')
-
         return self._from_image_data(grid)
 
     def flip(self, axis):

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -315,7 +315,7 @@ class Texture(vtk.vtkTexture, DataObject):
             if image.GetNumberOfPoints() < 2:
                 raise ValueError("Problem reading the image with VTK.")
             self._from_image_data(image)
-        except (KeyError, RuntimeError):
+        except (KeyError, ValueError):
             self._from_array(imageio.imread(filename))
 
     def _from_texture(self, texture):

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -157,7 +157,7 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
                 else:
                     self.shallow_copy(args[0])
             elif isinstance(args[0], (str, pathlib.Path)):
-                self._load_file(args[0])
+                self._from_file(args[0])
             elif isinstance(args[0], (np.ndarray, list)):
                 if isinstance(args[0], list):
                     points = np.asarray(args[0])
@@ -501,7 +501,7 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
                     self.shallow_copy(args[0])
 
             elif isinstance(args[0], (str, pathlib.Path)):
-                self._load_file(args[0])
+                self._from_file(args[0])
 
             elif isinstance(args[0], vtk.vtkStructuredGrid):
                 vtkappend = vtk.vtkAppendFilter()
@@ -773,7 +773,7 @@ class StructuredGrid(vtkStructuredGrid, PointGrid):
             if isinstance(args[0], vtk.vtkStructuredGrid):
                 self.deep_copy(args[0])
             elif isinstance(args[0], str):
-                self._load_file(args[0])
+                self._from_file(args[0])
 
         elif len(args) == 3:
             arg0_is_arr = isinstance(args[0], np.ndarray)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -18,9 +18,8 @@ from vtk.util import numpy_support as VN
 from vtk.util.numpy_support import numpy_to_vtk, vtk_to_numpy
 
 import pyvista
-from pyvista.utilities import (assert_empty_kwargs,
-                               convert_array, convert_string_array, get_array,
-                               is_pyvista_dataset, numpy_to_texture, abstract_class,
+from pyvista.utilities import (assert_empty_kwargs, convert_array, convert_string_array,
+                               get_array, is_pyvista_dataset, abstract_class,
                                raise_not_matching, try_callback, wrap)
 from .background_renderer import BackgroundRenderer
 from .colors import get_cmap_safe

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -238,7 +238,7 @@ def read(filename, attrs=None, file_format=None):
         # Attempt to use the legacy reader...
         return read_legacy(filename)
     elif ext in ['.jpeg', '.jpg']:
-        return read_texture(filename).to_image()
+        return pyvista.Texture(filename).to_image()
     else:
         # Attempt find a reader in the readers mapping
         try:
@@ -268,12 +268,12 @@ def read_texture(filename, attrs=None):
         image = standard_reader_routine(reader, filename, attrs=attrs)
         if image.n_points < 2:
             raise RuntimeError("Problem reading the image with VTK.")
-        return pyvista.image_to_texture(image)
+        return pyvista.Texture(image)
     except (KeyError, RuntimeError):
         # Otherwise, use the imageio reader
         pass
     import imageio
-    return pyvista.numpy_to_texture(imageio.imread(filename))
+    return pyvista.Texture(imageio.imread(filename))
 
 
 def read_exodus(filename,

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -267,9 +267,9 @@ def read_texture(filename, attrs=None):
         reader = get_reader(filename)
         image = standard_reader_routine(reader, filename, attrs=attrs)
         if image.n_points < 2:
-            raise RuntimeError("Problem reading the image with VTK.")
+            raise ValueError("Problem reading the image with VTK.")
         return pyvista.Texture(image)
-    except (KeyError, RuntimeError):
+    except (KeyError, ValueError):
         # Otherwise, use the imageio reader
         pass
     import imageio

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -490,8 +490,6 @@ def image_to_texture(image):
 
 def numpy_to_texture(image):
     """Convert a NumPy image array to a vtk.vtkTexture."""
-    if not isinstance(image, np.ndarray):
-        raise TypeError(f'Unknown input type ({type(image)})')
     return pyvista.Texture(image)
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -7,7 +7,7 @@ from hypothesis.strategies import composite, integers, floats, one_of
 from vtk.util.numpy_support import vtk_to_numpy
 
 import pyvista
-from pyvista import examples
+from pyvista import examples, Texture
 
 
 @pytest.fixture()
@@ -386,7 +386,7 @@ def test_texture():
     # now grab the texture coordinates
     foo = mesh.t_coords
     assert np.allclose(foo, t_coords)
-    texture = pyvista.read_texture(examples.mapfile)
+    texture = Texture(examples.mapfile)
     mesh.textures['map'] = texture
     assert mesh.textures['map'] is not None
     mesh.clear_textures()
@@ -398,7 +398,7 @@ def test_texture_airplane():
     mesh.texture_map_to_plane(inplace=True, name="tex_a", use_bounds=False)
     mesh.texture_map_to_plane(inplace=True, name="tex_b", use_bounds=True)
     assert not np.allclose(mesh["tex_a"], mesh["tex_b"])
-    texture = pyvista.read_texture(examples.mapfile)
+    texture = Texture(examples.mapfile)
     mesh.textures["tex_a"] = texture.copy()
     mesh.textures["tex_b"] = texture.copy()
     mesh._activate_texture("tex_a")


### PR DESCRIPTION
### Overview

Various docstring and readability changes in Texture.

Added the ability for Texture to read load from file. This involves a change to DataObject._load_file to return the vtkObject it read. I've added DataObject._from_file() which seems to match the other methods used to create objects. 

It's not necessary to import and use read_texture(), image_to_texture() or numpy_to_texture(), so they could be removed but they're referenced in the docs.