### PR TITLE
Remove the temporary blue color on meshes when using add_mesh on large datasets

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1501,10 +1501,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if interpolate_before_map:
             self.mapper.InterpolateScalarsBeforeMappingOn()
 
-        actor, prop = self.add_actor(self.mapper,
-                                     reset_camera=reset_camera,
-                                     name=name, culling=culling,
-                                     pickable=pickable)
+        actor = vtk.vtkActor()
+        actor.SetMapper(self.mapper)
+        prop = vtk.vtkProperty()
 
         # Make sure scalars is a numpy array after this point
         original_scalar_name = None
@@ -1761,6 +1760,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         # Add scalar bar if available
         if stitle is not None and show_scalar_bar and (not rgb or _custom_opac):
             self.add_scalar_bar(stitle, **scalar_bar_args)
+
+        self.add_actor(actor,
+                       reset_camera=reset_camera,
+                       name=name, culling=culling,
+                       pickable=pickable)
 
         self.renderer.Modified()
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1502,8 +1502,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
             self.mapper.InterpolateScalarsBeforeMappingOn()
 
         actor = vtk.vtkActor()
-        actor.SetMapper(self.mapper)
         prop = vtk.vtkProperty()
+        actor.SetMapper(self.mapper)
+        actor.SetProperty(prop)
 
         # Make sure scalars is a numpy array after this point
         original_scalar_name = None


### PR DESCRIPTION
This resolves issue #927 by changing the order in which the actor is created. To do that, `add_actor` is receiving an actor instead of the mapper.
