### PR TITLE
Add checking if the number_of_cells corresponds to the offset and cel…

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -630,18 +630,25 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
             self.SetCells(cell_type, numpy_to_idarr(offset), vtkcells)
 
     def _check_for_consistency(self):
-        '''
-        Checks if the number of offsets and celltypes
-        correspond to the number of cells.
-        Called after initialization of the self from arrays.
-        '''
-        if not self.number_of_cells == self.offset.shape[0] or\
-            not self.number_of_cells == self.celltypes.shape[0]:
-            raise ValueError('Number of cells (%s) must be equal to the number of offset values (%s) and to the number of celltypes values (%s)' %
-                             (str(self.number_of_cells),
-                              str(self.offset.shape[0]),
-                              str(self.celltypes.shape[0])),
-                            )
+        """Check if size of offsets and celltypes match the number of cells.
+
+        Checks if the number of offsets and celltypes correspond to
+        the number of cells.  Called after initialization of the self
+        from arrays.
+        """
+        if self.n_cells != self.celltypes.size:
+            raise ValueError(f'Number of cell types ({self.celltypes.size}) '
+                             f'must match the number of cells {self.n_cells})')
+
+        if VTK9:
+            if self.n_cells != self.offset.size - 1:
+                raise ValueError(f'Size of the offset ({self.offset.size}) '
+                                 'must be one greater than the number of cells '
+                                 f'({self.n_cells})')
+        else:
+            if self.n_cells != self.offset.size:
+                raise ValueError(f'Size of the offset ({self.offset.size}) '
+                                 f'must match the number of cells ({self.n_cells})')
 
     @property
     def cells(self):

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -526,6 +526,7 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
 
             if all([arg0_is_arr, arg1_is_arr, arg2_is_arr]):
                 self._from_arrays(None, args[0], args[1], args[2], deep)
+                self._check_for_consistency()
             else:
                 raise TypeError('All input types must be np.ndarray')
 
@@ -537,6 +538,7 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
 
             if all([arg0_is_arr, arg1_is_arr, arg2_is_arr, arg3_is_arr]):
                 self._from_arrays(args[0], args[1], args[2], args[3], deep)
+                self._check_for_consistency()
             else:
                 raise TypeError('All input types must be np.ndarray')
 
@@ -626,6 +628,20 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
             self.SetCells(cell_type, vtkcells)
         else:
             self.SetCells(cell_type, numpy_to_idarr(offset), vtkcells)
+
+    def _check_for_consistency(self):
+        '''
+        Checks if the number of offsets and celltypes
+        correspond to the number of cells.
+        Called after initialization of the self from arrays.
+        '''
+        if not self.number_of_cells == self.offset.shape[0] or\
+            not self.number_of_cells == self.celltypes.shape[0]:
+            raise ValueError('Number of cells (%s) must be equal to the number of offset values (%s) and to the number of celltypes values (%s)' %
+                             (str(self.number_of_cells),
+                              str(self.offset.shape[0]),
+                              str(self.celltypes.shape[0])),
+                            )
 
     @property
     def cells(self):


### PR DESCRIPTION
### Overview

When creating UnstructuredGrid from my own set of points I found out that `pyvista` created an invalid mesh
from wrong input arrays without any info to a user. It happens even if it's obvious that the mesh is invalid just looking on the shapes of input arrays. It took me a while to figure out that the problem was in the way I prepared those arrays.

I believe this PR would improve user experience when constructing UnstructuredGrid in complicated situations.

### Details

An actual case this PR could help with in the future:
https://github.com/pyvista/pyvista-support/issues/256

