### PR TITLE
Enforce retention of field_arrays for all filters

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -55,8 +55,8 @@ def _get_output(algorithm, iport=0, iconnection=0, oport=0, active_scalars=None,
     if not isinstance(data, pyvista.MultiBlock):
         data.copy_meta_from(ido)
         for array_name in ido.array_names:
-            if array_name not in data.array_names and len(ido[array_name]) == 1:
-                data.add_field_array(ido[array_name], array_name)
+            if not data.field_arrays and ido.field_arrays:
+                data.field_arrays.update(ido.field_arrays)
         if active_scalars is not None:
             data.set_active_scalars(active_scalars, preference=active_scalars_field)
     return data

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -54,9 +54,8 @@ def _get_output(algorithm, iport=0, iconnection=0, oport=0, active_scalars=None,
     data = wrap(algorithm.GetOutputDataObject(oport))
     if not isinstance(data, pyvista.MultiBlock):
         data.copy_meta_from(ido)
-        for array_name in ido.array_names:
-            if not data.field_arrays and ido.field_arrays:
-                data.field_arrays.update(ido.field_arrays)
+        if not data.field_arrays and ido.field_arrays:
+            data.field_arrays.update(ido.field_arrays)
         if active_scalars is not None:
             data.set_active_scalars(active_scalars, preference=active_scalars_field)
     return data

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -54,6 +54,9 @@ def _get_output(algorithm, iport=0, iconnection=0, oport=0, active_scalars=None,
     data = wrap(algorithm.GetOutputDataObject(oport))
     if not isinstance(data, pyvista.MultiBlock):
         data.copy_meta_from(ido)
+        for array_name in ido.array_names:
+            if array_name not in data.array_names and len(ido[array_name]) == 1:
+                data.add_field_array(ido[array_name], array_name)
         if active_scalars is not None:
             data.set_active_scalars(active_scalars, preference=active_scalars_field)
     return data

--- a/tests/test_datasetattributes.py
+++ b/tests/test_datasetattributes.py
@@ -260,3 +260,11 @@ def test_active_scalars_setter(hexbeam_point_attributes):
     dsa.active_scalars = 'sample_point_scalars'
     assert dsa.active_scalars is not None
     assert dsa.GetScalars().GetName() == 'sample_point_scalars'
+
+
+@given(arr=arrays(dtype='U', shape=10))
+def test_preserve_field_arrays_after_extract_cells(hexbeam, arr):
+    # https://github.com/pyvista/pyvista/pull/934
+    hexbeam.field_arrays["foo"] = arr
+    extracted = hexbeam.extract_cells([0, 1, 2, 3])
+    assert "foo" in extracted.field_arrays


### PR DESCRIPTION
This adds a condition that will detect when the data/output has empty field_arrays but its original input has field_arrays, and update the field_arrays when this happens.

Resolves #930 