### PR TITLE
Make rendering optional when adding meshes and actors

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1127,7 +1127,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                  culling=None, rgb=False, categories=False,
                  use_transparency=False, below_color=None, above_color=None,
                  annotations=None, pickable=True, preference="point",
-                 log_scale=False, **kwargs):
+                 log_scale=False, render=True, **kwargs):
         """Add any PyVista/VTK mesh or dataset that PyVista can wrap to the scene.
 
         This method is using a mesh representation to view the surfaces
@@ -1766,7 +1766,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.add_actor(actor,
                        reset_camera=reset_camera,
                        name=name, culling=culling,
-                       pickable=pickable)
+                       pickable=pickable,
+                       render=render)
 
         self.renderer.Modified()
 

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -355,7 +355,7 @@ class Renderer(vtkRenderer):
 
         """
         # Remove actor by that name if present
-        rv = self.remove_actor(name, reset_camera=False)
+        rv = self.remove_actor(name, reset_camera=False, render=render)
 
         if isinstance(uinput, vtk.vtkMapper):
             actor = vtk.vtkActor()

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -326,7 +326,7 @@ class Renderer(vtkRenderer):
         return actor
 
     def add_actor(self, uinput, reset_camera=False, name=None, culling=False,
-                  pickable=True):
+                  pickable=True, render=True):
         """Add an actor to render window.
 
         Creates an actor if input is a mapper.
@@ -375,7 +375,7 @@ class Renderer(vtkRenderer):
             self.reset_camera()
         elif not self.camera_set and reset_camera is None and not rv:
             self.reset_camera()
-        else:
+        elif render:
             self.parent.render()
 
         self.update_bounds_axes()


### PR DESCRIPTION
There are 2 main reasons for this:

- Huge speed gain when hiding and displaying meshes.

- It looks much more professionnal when clicking a button to see all the changes at once.

This was executed in my app, but just to show the speed difference:

```
@timeit
def test_render(render=True):
    for i in range(20):
        actor = self.vtk_widget.add_mesh(s.mesh, None, scalars=scalars, clim=clim, cmap=cmap,
                                         label=None, reset_camera=reset_camera, scalar_bar_args=settings,
                                         show_scalar_bar=True, name="{0}".format(i), annotations=annotations,
                                         stitle=scale.title, pickable=s.pickable, render=render)
    if not render:
        self.vtk_widget.render()
```

```
test_render(False)
'test_render'  180.01 ms
test_render(True)
'test_render'  2520.14 ms
test_render(False)
'test_render'  185.01 ms
test_render(False)
'test_render'  178.01 ms
test_render(True)
'test_render'  2518.14 ms
```

That's a nice 14X increase in speed.