### PR TITLE
Normalize by scale when computing 4x4 transform

### DIFF
--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -711,9 +711,11 @@ class Common(DataSetFilters, DataObject):
                             '\tvtk.vtkTransform\n'
                             '\t4x4 np.ndarray\n')
 
-        x = (self.points*t[0, :3]).sum(1) + t[0, -1]
-        y = (self.points*t[1, :3]).sum(1) + t[1, -1]
-        z = (self.points*t[2, :3]).sum(1) + t[2, -1]
+        # Multiply by the transformation matrix and normalize by the
+        # homogeneous scale factor
+        x = ((self.points*t[0, :3]).sum(1) + t[0, -1]) / t[3, 3]
+        y = ((self.points*t[1, :3]).sum(1) + t[1, -1]) / t[3, 3]
+        z = ((self.points*t[2, :3]).sum(1) + t[2, -1]) / t[3, 3]
 
         # overwrite points
         self.points[:, 0] = x

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -711,11 +711,16 @@ class Common(DataSetFilters, DataObject):
                             '\tvtk.vtkTransform\n'
                             '\t4x4 np.ndarray\n')
 
-        # Multiply by the transformation matrix and normalize by the
-        # homogeneous scale factor
-        x = ((self.points*t[0, :3]).sum(1) + t[0, -1]) / t[3, 3]
-        y = ((self.points*t[1, :3]).sum(1) + t[1, -1]) / t[3, 3]
-        z = ((self.points*t[2, :3]).sum(1) + t[2, -1]) / t[3, 3]
+        if t[3, 3] == 0:
+            raise ValueError(
+                "Transform element (3,3), the inverse scale term, is zero")
+
+        # Normalize the transformation to account for the scale
+        t /= t[3, 3]
+
+        x = (self.points*t[0, :3]).sum(1) + t[0, -1]
+        y = (self.points*t[1, :3]).sum(1) + t[1, -1]
+        z = (self.points*t[2, :3]).sum(1) + t[2, -1]
 
         # overwrite points
         self.points[:, 0] = x


### PR DESCRIPTION
### Overview

It is convention that a when using a 4x4 homogeneous transformation matrix, the last element represents an inverse scale. This is described briefly in the third item of section Using homogeneous coordinates on [Wikipedia](https://en.wikipedia.org/wiki/Scaling_(geometry)). This change has been tested locally and it mimics the behavior of other libraries. If the last coordinate is 0, it could induce a division by zero error. 

### Details

- Add scaling to the `transform` method. 
