### PR TITLE
Faster Screenshot

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -41,6 +41,9 @@ except ImportError:
 
 _ALL_PLOTTERS = {}
 
+SUPPORTED_FORMATS = [".png", ".jpeg", ".jpg", ".bmp", ".tif", ".tiff"]
+
+
 def close_all():
     """Close all open/active plotters and clean up memory."""
     for key, p in _ALL_PLOTTERS.items():
@@ -3282,20 +3285,20 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if not image.size:
             raise ValueError('Empty image. Have you run plot() first?')
         # write screenshot to file
-        supported_formats = [".png", ".jpeg", ".jpg", ".bmp", ".tif", ".tiff"]
         if isinstance(filename, (str, pathlib.Path)):
+            from PIL import Image
             filename = pathlib.Path(filename)
             if isinstance(pyvista.FIGURE_PATH, str) and not filename.is_absolute():
                 filename = pathlib.Path(os.path.join(pyvista.FIGURE_PATH, filename))
             if not filename.suffix:
                 filename = filename.with_suffix('.png')
-            elif filename.suffix not in supported_formats:
+            elif filename.suffix not in SUPPORTED_FORMATS:
                 raise ValueError(f'Unsupported extension {filename.suffix}\n' +
-                                 f'Must be one of the following: {supported_formats}')
-            w = imageio.imwrite(os.path.abspath(os.path.expanduser(str(filename))),
-                                image)
+                                 f'Must be one of the following: {SUPPORTED_FORMATS}')
+            image_path = os.path.abspath(os.path.expanduser(str(filename)))
+            Image.fromarray(image).save(image_path)
             if not return_img:
-                return w
+                return image
         return image
 
     def save_graphic(self, filename, title='PyVista Export', raster=True, painter=True):

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ if sys.version_info.minor == 9:
 # pre-compiled vtk available for python3
 install_requires = ['numpy',
                     'imageio',
+                    'pillow',
                     'appdirs',
                     'scooby>=0.5.1',
                     'meshio>=4.0.3, <5.0',

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -11,6 +11,7 @@ import vtk
 import pyvista
 from pyvista import examples
 from pyvista.plotting import system_supports_plotting
+from pyvista.plotting.plotting import SUPPORTED_FORMATS
 
 NO_PLOTTING = not system_supports_plotting()
 
@@ -515,6 +516,14 @@ def test_screenshot(tmpdir):
         ref
     except:
         raise RuntimeError('Plotter did not close')
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+@pytest.mark.parametrize('ext', SUPPORTED_FORMATS)
+def test_save_screenshot(tmpdir, sphere, ext):
+    plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
+    plotter.add_mesh(sphere)
+    plotter.screenshot(str(tmpdir.mkdir("tmpdir").join('tmp' + ext)))
 
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -2,6 +2,7 @@ import pathlib
 import os
 import sys
 from weakref import proxy
+from pathlib import Path
 
 import imageio
 import numpy as np
@@ -521,9 +522,12 @@ def test_screenshot(tmpdir):
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 @pytest.mark.parametrize('ext', SUPPORTED_FORMATS)
 def test_save_screenshot(tmpdir, sphere, ext):
+    filename = str(tmpdir.mkdir("tmpdir").join('tmp' + ext))
     plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
     plotter.add_mesh(sphere)
-    plotter.screenshot(str(tmpdir.mkdir("tmpdir").join('tmp' + ext)))
+    plotter.screenshot(filename)
+    assert os.path.isfile(filename)
+    assert Path(filename).stat().st_size
 
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")


### PR DESCRIPTION
### Overview
Simple fix to speedup screenshots (at least on Linux).  Discovered this while working on potentially automating tests using screenshots.

### Details
Here's the screenshot speed on Linux and Windows

```py
import pyvista as pv

plotter = pv.Plotter(off_screen=True)
plotter.add_mesh(pv.Sphere(), smooth_shading=True)
timeit plotter.screenshot('/tmp/tmp.png')
```

#### `feat/faster_screenshot` (this branch)

```
# LINUX:   70.9 ms ± 212 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
# WINDOWS: 70 ms ± 145 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

#### `master`
```
# LINUX:   324 ms ± 564 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
# WINDOWS: 312 ms ± 462 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

### MISC
I've also made a minor change in the tests to make sure we test all file types.