### PR TITLE
TST: Test for GC

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -7,6 +7,7 @@ import logging
 import os
 import time
 import warnings
+import weakref
 from functools import wraps
 from threading import Thread
 
@@ -4105,7 +4106,7 @@ def _style_factory(klass):
 
         def __init__(self, parent):
             super().__init__()
-            self._parent = parent
+            self._parent = weakref.ref(parent)
             self.AddObserver(
                 "LeftButtonPressEvent",
                 partial(try_callback, self._press))
@@ -4117,16 +4118,18 @@ def _style_factory(klass):
             # Figure out which renderer has the event and disable the
             # others
             super().OnLeftButtonDown()
-            if len(self._parent.renderers) > 1:
-                click_pos = self._parent.iren.GetEventPosition()
-                for renderer in self._parent.renderers:
+            parent = self.parent()
+            if len(parent.renderers) > 1:
+                click_pos = parent.iren.GetEventPosition()
+                for renderer in parent.renderers:
                     interact = renderer.IsInViewport(*click_pos)
                     renderer.SetInteractive(interact)
 
         def _release(self, obj, event):
             super().OnLeftButtonUp()
-            if len(self._parent.renderers) > 1:
-                for renderer in self._parent.renderers:
+            parent = self.parent()
+            if len(parent.renderers) > 1:
+                for renderer in parent.renderers:
                     renderer.SetInteractive(True)
 
     return CustomStyle

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2741,6 +2741,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 renderer.deep_clean()
         # Do not remove the renderers on the clean
         self.mesh = None
+        if getattr(self, 'mapper', None) is not None:
+            self.mapper.lookup_table = None
         self.mapper = None
         self.volume = None
         self.textactor = None

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2684,7 +2684,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         super().close()
         # Renderer has an axes widget, so close it
         for renderer in self.renderers:
-
             renderer.close()
         self._shadow_renderer.close()
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2693,6 +2693,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
             renderer.RemoveAllLights()
         self.lighting = None
 
+        # Clear the scalar bar
+        self.scalar_bar = None
+
         # Grab screenshots of last render
         if self._store_image:
             self.last_image = self.screenshot(None, return_img=True)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4118,7 +4118,7 @@ def _style_factory(klass):
             # Figure out which renderer has the event and disable the
             # others
             super().OnLeftButtonDown()
-            parent = self.parent()
+            parent = self._parent()
             if len(parent.renderers) > 1:
                 click_pos = parent.iren.GetEventPosition()
                 for renderer in parent.renderers:
@@ -4127,7 +4127,7 @@ def _style_factory(klass):
 
         def _release(self, obj, event):
             super().OnLeftButtonUp()
-            parent = self.parent()
+            parent = self._parent()
             if len(parent.renderers) > 1:
                 for renderer in parent.renderers:
                     renderer.SetInteractive(True)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2684,8 +2684,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
         super().close()
         # Renderer has an axes widget, so close it
         for renderer in self.renderers:
+
             renderer.close()
         self._shadow_renderer.close()
+
+        # Turn off the lights
+        for renderer in self.renderers:
+            renderer.RemoveAllLights()
+        self.lighting = None
 
         # Grab screenshots of last render
         if self._store_image:

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1426,6 +1426,7 @@ class Renderer(vtkRenderer):
         self.camera.RemoveAllObservers()
         if hasattr(self, 'axes_widget'):
             self.hide_axes()  # Necessary to avoid segfault
+            self.axes_actor = None
             del self.axes_widget
 
     def deep_clean(self):

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1059,6 +1059,9 @@ class Renderer(vtkRenderer):
 
     def remove_floors(self, clear_kwargs=True):
         """Remove all floor actors."""
+        if getattr(self, '_floor', None) is not None:
+            self._floor.ReleaseData()
+            self._floor = None
         for actor in self._floors:
             self.remove_actor(actor, reset_camera=False)
         self._floors.clear()
@@ -1438,6 +1441,7 @@ class Renderer(vtkRenderer):
         if hasattr(self, '_box_object'):
             self.remove_bounding_box()
 
+        self.remove_floors()
         self.RemoveAllViewProps()
         self._actors = {}
         # remove reference to parent last

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,3 +10,4 @@ cmocean
 itkwidgets>=0.25.2
 tqdm
 hypothesis>=5.8.0
+sphinx_gallery

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,17 @@ import pyvista
 from pyvista import examples
 
 
+@fixture(scope='session')
+def set_mpl():
+    """Avoid matplotlib windows popping up."""
+    try:
+        import matplotlib
+    except Exception:
+        pass
+    else:
+        matplotlib.use('agg', force=True)
+
+
 @fixture()
 def airplane():
     return examples.load_airplane()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -7,20 +7,14 @@ import pytest
 import pyvista
 from pyvista import examples
 
-try:
-    import matplotlib.pyplot as plt
-    HAS_MATPLOTLIB = True
-except:
-    HAS_MATPLOTLIB = False
-
 DATASETS = [
-    examples.load_uniform(), # UniformGrid
-    examples.load_rectilinear(), # RectilinearGrid
-    examples.load_hexbeam(), # UnstructuredGrid
-    examples.load_airplane(), # PolyData
-    examples.load_structured(), # StructuredGrid
+    examples.load_uniform(),  # UniformGrid
+    examples.load_rectilinear(),  # RectilinearGrid
+    examples.load_hexbeam(),  # UnstructuredGrid
+    examples.load_airplane(),  # PolyData
+    examples.load_structured(),  # StructuredGrid
 ]
-normals = ['x', 'y', '-z', (1,1,1), (3.3, 5.4, 0.8)]
+normals = ['x', 'y', '-z', (1, 1, 1), (3.3, 5.4, 0.8)]
 
 COMPOSITE = pyvista.MultiBlock(DATASETS, deep=True)
 
@@ -708,9 +702,9 @@ def test_sample_over_line():
     assert isinstance(sampled_from_sphere, pyvista.PolyData)
 
 
-@pytest.mark.skipif(not HAS_MATPLOTLIB, reason="Requires matplotlib")
 def test_plot_over_line():
     """this requires matplotlib"""
+    pytest.importorskip('matplotlib')
     mesh = examples.load_uniform()
     # Make two points to construct the line between
     a = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -446,6 +446,7 @@ def test_show_axes():
     # if not closed correctly, a seg fault occurs when exitting
     plotter = pyvista.Plotter(off_screen=False)
     plotter.show_axes()
+    plotter.close()
 
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -39,7 +39,10 @@ sphere_c = pyvista.Sphere(2.0)
 
 
 def _is_vtk(obj):
-    return obj.__class__.__name__.startswith('vtk')
+    try:
+        return obj.__class__.__name__.startswith('vtk')
+    except Exception:  # old Python sometimes no __class__.__name__
+        return False
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -338,6 +338,8 @@ def test_make_movie():
     # checking if plotter closes
     ref = proxy(plotter)
     plotter.close()
+    # release attached points data
+    movie_sphere.ReleaseData()
 
     # remove file
     os.remove(filename)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -330,18 +330,14 @@ def test_make_movie():
     for i in range(3):  # limiting number of frames to write for speed
         plotter.write_frame()
         random_points = np.random.random(movie_sphere.points.shape)
-        movie_sphere.points = random_points*0.01 + movie_sphere.points*0.99
-        movie_sphere.points -= movie_sphere.points.mean(0)
+        movie_sphere.points[:] = random_points*0.01 + movie_sphere.points*0.99
+        movie_sphere.points[:] -= movie_sphere.points.mean(0)
         scalars = np.random.random(movie_sphere.n_faces)
         plotter.update_scalars(scalars)
 
     # checking if plotter closes
     ref = proxy(plotter)
     plotter.close()
-
-    # release attached scalars
-    movie_sphere.ReleaseData()
-    del movie_sphere
 
     # remove file
     os.remove(filename)
@@ -1110,7 +1106,6 @@ def test_default_name_tracking():
     mesh.ReleaseData()
     del mesh
 
-
 @pytest.mark.parametrize("as_global", [True, False])
 def test_add_background_image(as_global):
     plotter = pyvista.Plotter()
@@ -1146,7 +1141,6 @@ def test_add_remove_floor():
     pl.update_bounds_axes()
     assert len(pl.renderer._floors) == 1
     pl.show()
-    pl.deep_clean()
 
     pl = pyvista.Plotter()
     pl.add_mesh(sphere)
@@ -1154,7 +1148,6 @@ def test_add_remove_floor():
     pl.remove_floors()
     assert not pl.renderer._floors
     pl.show()
-    pl.deep_clean()
 
 
 def test_reset_camera_clipping_range():

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -338,8 +338,10 @@ def test_make_movie():
     # checking if plotter closes
     ref = proxy(plotter)
     plotter.close()
-    # release attached points data
+
+    # release attached scalars
     movie_sphere.ReleaseData()
+    del movie_sphere
 
     # remove file
     os.remove(filename)
@@ -1094,6 +1096,10 @@ def test_default_name_tracking():
     n_made_it = len(p.renderer._actors)
     p.show()
     assert n_made_it == N**2
+
+    # release attached scalars
+    mesh.ReleaseData()
+    del mesh
 
 
 @pytest.mark.parametrize("as_global", [True, False])

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1131,6 +1131,7 @@ def test_add_remove_floor():
     pl.update_bounds_axes()
     assert len(pl.renderer._floors) == 1
     pl.show()
+    pl.deep_clean()
 
     pl = pyvista.Plotter()
     pl.add_mesh(sphere)
@@ -1138,6 +1139,7 @@ def test_add_remove_floor():
     pl.remove_floors()
     assert not pl.renderer._floors
     pl.show()
+    pl.deep_clean()
 
 
 def test_reset_camera_clipping_range():

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -435,6 +435,15 @@ def test_key_press_event():
 
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
+def test_enable_picking_gc():
+    plotter = pyvista.Plotter(off_screen=False)
+    sphere = pyvista.Sphere()
+    plotter.add_mesh(sphere)
+    plotter.enable_cell_picking()
+    plotter.close()
+
+
+@pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_left_button_down():
     plotter = pyvista.Plotter(off_screen=False)
     if VTK9:

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -45,9 +45,6 @@ def _is_vtk(obj):
 @pytest.fixture(autouse=True)
 def check_gc():
     """Ensure that all VTK objects are garbage-collected by Python."""
-    pyvista.close_all()
-    gc.collect()
-    # in theory this should be empty at the start, but just to be safe:
     before = set(id(o) for o in gc.get_objects() if _is_vtk(o))
     yield
     pyvista.close_all()

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,5 +1,6 @@
 import os
 import os.path as op
+import pytest
 import pyvista
 from pyvista.utilities import Scraper
 

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -4,6 +4,7 @@ import pyvista
 from pyvista.utilities import Scraper
 
 
+@pytest.importerskip('sphinx_gallery')
 def test_scraper(tmpdir):
     plotter = pyvista.Plotter(off_screen=False)
     scraper = Scraper()

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,23 @@
+import os
+import os.path as op
+import pyvista
+from pyvista.utilities import Scraper
+
+
+def test_scraper(tmpdir):
+    plotter = pyvista.Plotter(off_screen=False)
+    scraper = Scraper()
+    src_dir = str(tmpdir)
+    out_dir = op.join(str(tmpdir), '_build', 'html')
+    img_fname = op.join(src_dir, 'auto_examples', 'images',
+                        'sg_img.png')
+    gallery_conf = {"src_dir": src_dir, "builder_name": "html"}
+    target_file = op.join(src_dir, 'auto_examples', 'sg.py')
+    block = None
+    block_vars = dict(image_path_iterator=(img for img in [img_fname]),
+                      example_globals=dict(a=1), target_file=target_file)
+
+    os.makedirs(op.dirname(img_fname))
+    os.makedirs(out_dir)
+
+    scraper(block, block_vars, gallery_conf)

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -7,6 +7,7 @@ from pyvista.utilities import Scraper
 
 def test_scraper(tmpdir):
     pytest.importorskip('sphinx_gallery')
+    pyvista.close_all()
     plotter = pyvista.Plotter(off_screen=True)
     scraper = Scraper()
     src_dir = str(tmpdir)
@@ -23,3 +24,4 @@ def test_scraper(tmpdir):
     os.makedirs(out_dir)
     scraper(block, block_vars, gallery_conf)
     assert os.path.isfile(img_fname)
+    plotter.close()

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -5,8 +5,8 @@ import pyvista
 from pyvista.utilities import Scraper
 
 
-@pytest.importerskip('sphinx_gallery')
 def test_scraper(tmpdir):
+    pytest.importorskip('sphinx_gallery')
     plotter = pyvista.Plotter(off_screen=False)
     scraper = Scraper()
     src_dir = str(tmpdir)

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -7,7 +7,7 @@ from pyvista.utilities import Scraper
 
 def test_scraper(tmpdir):
     pytest.importorskip('sphinx_gallery')
-    plotter = pyvista.Plotter(off_screen=False)
+    plotter = pyvista.Plotter(off_screen=True)
     scraper = Scraper()
     src_dir = str(tmpdir)
     out_dir = op.join(str(tmpdir), '_build', 'html')
@@ -18,8 +18,8 @@ def test_scraper(tmpdir):
     block = None
     block_vars = dict(image_path_iterator=(img for img in [img_fname]),
                       example_globals=dict(a=1), target_file=target_file)
-
     os.makedirs(op.dirname(img_fname))
+    assert not os.path.isfile(img_fname)
     os.makedirs(out_dir)
-
     scraper(block, block_vars, gallery_conf)
+    assert os.path.isfile(img_fname)


### PR DESCRIPTION
Add a test that all objects can be garbage collected properly. Currently there are some failures for example with `vtkLightKit` suggesting that the `deep_clean` (or similar) functions need to be updated to remove VTK refs.

This is brought about by accumulating-memory issues @GuillaumeFavelier and I are hitting in our MNE doc builds with tens of PyVistaQt plots not releasing all memory. Some of the bugs are in PyVistaQt and some in MNE, but this should at least expose the ones in PyVista.

Note that this does not ensure that VTK can actually GC its own vtkSmartPointer objects, we'll probably need a separate case for that, too, somehow. But at least this will allow us to rule out Python GC keeping things alive and increasing memory usage.