### PR TITLE
MAINT: Remove ref on close

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -43,11 +43,12 @@ _ALL_PLOTTERS = {}
 
 def close_all():
     """Close all open/active plotters and clean up memory."""
-    for key, p in _ALL_PLOTTERS.items():
+    # need list() because the values() can be modified along the way
+    for p in list(_ALL_PLOTTERS.values()):
         if not p._closed:
             p.close()
         p.deep_clean()
-    _ALL_PLOTTERS.clear()
+    _ALL_PLOTTERS.clear()  # XXX in theory this should no longer be necessary
     return True
 
 
@@ -2680,6 +2681,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     def close(self):
         """Close the render window."""
+        if self._closed:
+            return
         # must close out widgets first
         super().close()
         # Renderer has an axes widget, so close it
@@ -2722,6 +2725,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         # this helps managing closed plotters
         self._closed = True
+        if self._id_name in _ALL_PLOTTERS:
+            del _ALL_PLOTTERS[self._id_name]
+
 
     def deep_clean(self):
         """Clean the plotter of the memory."""

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -117,8 +117,6 @@ def get_gpu_info():
     plotter.show(auto_close=False)
     gpu_info = plotter.ren_win.ReportCapabilities()
     plotter.close()
-    # Remove from list of Plotters
-    pyvista.plotting._ALL_PLOTTERS.pop(plotter._id_name)
     return gpu_info
 
 


### PR DESCRIPTION
It seems strange to me that `Plotter.__init__` adds a ref to this global `_ALL_PLOTTERS` but calling `Plotter.close` does not remove the reference. It really seems like it should. Otherwise you get memory accumulation even when closing your plotters, unless you call `pyvista.close_all()` (not a good solution because it closes all plotters, not just the one you might be trying to close) or modify `pyvista._ALL_PLOTTERS` (not a good solution -- private var).

This PR suggests that instead, let `plotter.close` take care of both keeping track of whether or not it's closed (by short-circuiting the `.close` operation if it has been done already) and keeping itself in `_ALL_PLOTTERS`.