### PR TITLE
Include or not adjacent cells when using extract_points method

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2142,13 +2142,18 @@ class DataSetFilters:
 
         return subgrid
 
-    def extract_points(dataset, ind):
+    def extract_points(dataset, ind, adjacent_cells=True):
         """Return a subset of the grid (with cells) that contains any of the given point indices.
 
         Parameters
         ----------
         ind : np.ndarray, list, or sequence
             Numpy array of point indices to be extracted.
+        adjacent_cells : bool, optional
+            If True, extract the cells that contain at least one of the 
+            extracted points. If False, extract the cells that contain 
+            exclusively points from the extracted points list. The default is 
+            True.
 
         Return
         ------
@@ -2160,9 +2165,16 @@ class DataSetFilters:
         selectionNode = vtk.vtkSelectionNode()
         selectionNode.SetFieldType(vtk.vtkSelectionNode.POINT)
         selectionNode.SetContentType(vtk.vtkSelectionNode.INDICES)
+        if not adjacent_cells:
+            # Build array of point indices to be removed.
+            ind_rem = np.ones(dataset.n_points, dtype='bool')
+            ind_rem[ind] = False
+            ind = np.arange(dataset.n_points)[ind_rem]
+            # Invert selection
+            selectionNode.GetProperties().Set(vtk.vtkSelectionNode.INVERSE(), 1)
         selectionNode.SetSelectionList(numpy_to_idarr(ind))
         selectionNode.GetProperties().Set(vtk.vtkSelectionNode.CONTAINING_CELLS(), 1)
-
+        
         selection = vtk.vtkSelection()
         selection.AddNode(selectionNode)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -758,6 +758,33 @@ def extract_points_invalid(sphere):
     with pytest.raises(TypeError):
         sphere.extract_points(object)
 
+def test_extract_points():
+    # mesh points (4x4 regular grid)
+    vertices = np.array([[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0],
+                     [0, 1, 0], [1, 1, 0], [2, 1, 0], [3, 1, 0],
+                     [0, 2, 0], [1, 2, 0], [2, 2, 0], [3, 2, 0],
+                     [0, 3, 0], [1, 3, 0], [2, 3, 0], [3, 3, 0]])
+    # corresponding mesh faces
+    faces = np.hstack([[4, 0, 1, 5, 4],  # square
+                       [4, 1, 2, 6, 5],  # square
+                       [4, 2, 3, 7, 6],  # square
+                       [4, 4, 5, 9, 8],  # square
+                       [4, 5, 6, 10, 9],  # square
+                       [4, 6, 7, 11, 10],  # square
+                       [4, 8, 9, 13, 12],  # square
+                       [4, 9, 10, 14, 13],  # square
+                       [4, 10, 11, 15, 14]])  # square
+    # create pyvista object
+    surf = pyvista.PolyData(vertices, faces)
+    # extract sub-surface with adjacent cells
+    sub_surf_adj = surf.extract_points(np.array([0, 1, 4, 5]))
+     # extract sub-surface without adjacent cells
+    sub_surf = surf.extract_points(np.array([0, 1, 4, 5]), adjacent_cells=False)
+    # check sub-surface size
+    assert sub_surf.n_points == 4
+    assert sub_surf.n_cells == 1
+    assert sub_surf_adj.n_points == 9
+    assert sub_surf_adj.n_cells == 4
 
 @skip_py2_nobind
 def test_slice_along_line_composite():


### PR DESCRIPTION
### Overview

An input parameter ("adjacent_cells") is added to the "extract_points" method. For backward compatibility it is set to "True" by default. In this case, the output includes the cells that contain at least one of the extracted points. When it set to False, the output includes the cells that contain exclusively points from the extracted points list.
Please note that when using quadratic mesh, the list of nodes shall include the corner nodes AND the middle nodes for the adjacent_cells = False case.

A test function is provided to check the behavior of the "extract_points" method on a simple mesh.

resolves #953 

