### PR TITLE
ENH: Use dev0 for dev version

### DIFF
--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -1,6 +1,6 @@
 """Version info for pyvista."""
 # major, minor, patch
-version_info = 0, 26, 0
+version_info = 0, 27, 'dev0'
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
PyPi shows latest release to be 0.26.2, yet `master` shows version 0.26.0. This is strange behavior -- NumPy, SciPy, matplotlib, etc. do not work this way -- and prevents [proper testing of unreleased versions](https://github.com/mne-tools/mne-python/pull/8427#issuecomment-716659491).

This PR proposes changing the version in between releases to be `0.next.dev0`, which is currently `0.27.dev0`.