### PR TITLE
Wrap Trimesh

### DIFF
--- a/examples/00-load/wrap-trimesh.py
+++ b/examples/00-load/wrap-trimesh.py
@@ -1,0 +1,51 @@
+"""
+.. _ref_wrap_trimesh:
+
+Wrapping Other Objects
+~~~~~~~~~~~~~~~~~~~~~~
+You can wrap several other object types using pyvista including:
+
+- `numpy` arrays
+- `trimesh.Trimesh` meshes
+- VTK objects
+
+This allows for the "best of both worlds" programming special to
+Python due to its modularity.  If there's some limitation of pyvista
+(or trimesh), then you can adapt your scripts to use the best features
+of more than one module.
+
+"""
+import pyvista as pv
+
+###############################################################################
+# Wrap a point cloud composed of random points from numpy
+import numpy as np
+points = np.random.random((30, 3))
+cloud = pv.wrap(points)
+pv.plot(cloud, scalars=points[:, 2], render_points_as_spheres=True, point_size=50,
+        opacity=points[:, 0], cpos='xz')
+
+###############################################################################
+# Wrap an instance of Trimesh 
+import trimesh
+points = [[0, 0, 0], [0, 0, 1], [0, 1, 0]]
+faces = [[0, 1, 2]]
+tmesh = trimesh.Trimesh(points, faces=faces, process=False)
+mesh = pv.wrap(tmesh)
+print(mesh)
+
+###############################################################################
+# Wrap an instance of vtk.vtkPolyData
+
+import vtk
+points = vtk.vtkPoints()
+p = [1.0, 2.0, 3.0]
+vertices = vtk.vtkCellArray()
+pid = points.InsertNextPoint(p)
+vertices.InsertNextCell(1)
+vertices.InsertCellPoint(pid)
+point = vtk.vtkPolyData()
+point.SetPoints(points)
+point.SetVerts(vertices)
+mesh = pv.wrap(point)
+print(mesh)

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -493,12 +493,12 @@ def wrap(dataset):
     >>> p = [1.0, 2.0, 3.0]
     >>> vertices = vtk.vtkCellArray()
     >>> pid = points.InsertNextPoint(p)
-    >>> vertices.InsertNextCell(1)
-    >>> vertices.InsertCellPoint(pid)
+    >>> _ = vertices.InsertNextCell(1)
+    >>> _ = vertices.InsertCellPoint(pid)
     >>> point = vtk.vtkPolyData()
-    >>> point.SetPoints(points)
-    >>> point.SetVerts(vertices)
-    >>> mesh = pv.wrap(point)
+    >>> _ = point.SetPoints(points)
+    >>> _ = point.SetVerts(vertices)
+    >>> mesh = pyvista.wrap(point)
     >>> mesh  # doctest:+SKIP
     PolyData (0x7fc55ff27ad0)
       N Cells:  1

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -1,7 +1,6 @@
 """Supporting functions for polydata and grid objects."""
 
 import collections.abc
-import ctypes
 import enum
 import logging
 import signal
@@ -434,12 +433,80 @@ def is_meshio_mesh(mesh):
         return False
 
 
-def wrap(vtkdataset):
+def wrap(dataset):
     """Wrap any given VTK data object to its appropriate PyVista data object.
 
     Other formats that are supported include:
     * 2D :class:`numpy.ndarray` of XYZ vertices
     * 3D :class:`numpy.ndarray` representing a volume. Values will be scalars.
+    * 3d :class:`trimesh.Trimesh` mesh.
+
+    Parameters
+    ----------
+    dataset : :class:`numpy.ndarray`, :class:`trimesh.Trimesh`, or VTK object
+        Dataset to wrap.
+
+    Returns
+    -------
+    wrapped_dataset : pyvista class
+        The `pyvista` wrapped dataset.
+
+    Examples
+    --------
+    Wrap a numpy array representing a random point cloud
+
+    >>> import numpy as np
+    >>> import pyvista
+    >>> points = np.random.random((10, 3))
+    >>> cloud = pyvista.wrap(points)
+    >>> cloud  # doctest:+SKIP
+    PolyData (0x7fc52db83d70)
+      N Cells:  10
+      N Points: 10
+      X Bounds: 1.123e-01, 7.457e-01
+      Y Bounds: 1.009e-01, 9.877e-01
+      Z Bounds: 2.346e-03, 9.640e-01
+      N Arrays: 0
+
+    Wrap a Trimesh object
+
+    >>> import trimesh
+    >>> import pyvista
+    >>> points = [[0, 0, 0], [0, 0, 1], [0, 1, 0]]
+    >>> faces = [[0, 1, 2]]
+    >>> tmesh = trimesh.Trimesh(points, faces=faces, process=False)
+    >>> mesh = pyvista.wrap(tmesh)
+    >>> mesh  # doctest:+SKIP
+    PolyData (0x7fc55ff27ad0)
+      N Cells:  1
+      N Points: 3
+      X Bounds: 0.000e+00, 0.000e+00
+      Y Bounds: 0.000e+00, 1.000e+00
+      Z Bounds: 0.000e+00, 1.000e+00
+      N Arrays: 0
+
+    Wrap a VTK object
+
+    >>> import pyvista
+    >>> import vtk
+    >>> points = vtk.vtkPoints()
+    >>> p = [1.0, 2.0, 3.0]
+    >>> vertices = vtk.vtkCellArray()
+    >>> pid = points.InsertNextPoint(p)
+    >>> vertices.InsertNextCell(1)
+    >>> vertices.InsertCellPoint(pid)
+    >>> point = vtk.vtkPolyData()
+    >>> point.SetPoints(points)
+    >>> point.SetVerts(vertices)
+    >>> mesh = pv.wrap(point)
+    >>> mesh  # doctest:+SKIP
+    PolyData (0x7fc55ff27ad0)
+      N Cells:  1
+      N Points: 3
+      X Bounds: 0.000e+00, 0.000e+00
+      Y Bounds: 0.000e+00, 1.000e+00
+      Z Bounds: 0.000e+00, 1.000e+00
+      N Arrays: 0
 
     """
     wrappers = {
@@ -454,32 +521,39 @@ def wrap(vtkdataset):
         # 'vtkParametricSpline': pyvista.Spline,
     }
     # Otherwise, we assume a VTK data object was passed
-    if hasattr(vtkdataset, 'GetClassName'):
-        key = vtkdataset.GetClassName()
-    elif vtkdataset is None:
+    if hasattr(dataset, 'GetClassName'):
+        key = dataset.GetClassName()
+    elif dataset is None:
         return None
-    elif isinstance(vtkdataset, np.ndarray):
-        if vtkdataset.ndim == 1 and vtkdataset.shape[0] == 3:
-            return pyvista.PolyData(vtkdataset)
-        if vtkdataset.ndim > 1 and vtkdataset.ndim < 3 and vtkdataset.shape[1] == 3:
-            return pyvista.PolyData(vtkdataset)
-        elif vtkdataset.ndim == 3:
-            mesh = pyvista.UniformGrid(vtkdataset.shape)
-            mesh['values'] = vtkdataset.ravel(order='F')
+    elif isinstance(dataset, np.ndarray):
+        if dataset.ndim == 1 and dataset.shape[0] == 3:
+            return pyvista.PolyData(dataset)
+        if dataset.ndim > 1 and dataset.ndim < 3 and dataset.shape[1] == 3:
+            return pyvista.PolyData(dataset)
+        elif dataset.ndim == 3:
+            mesh = pyvista.UniformGrid(dataset.shape)
+            mesh['values'] = dataset.ravel(order='F')
             mesh.active_scalars_name = 'values'
             return mesh
         else:
-            print(vtkdataset.shape, vtkdataset)
+            print(dataset.shape, dataset)
             raise NotImplementedError('NumPy array could not be converted to PyVista.')
-    elif is_meshio_mesh(vtkdataset):
-        return from_meshio(vtkdataset)
+    elif is_meshio_mesh(dataset):
+        return from_meshio(dataset)
+    elif dataset.__class__.__name__ == 'Trimesh':
+        # trimesh doesn't pad faces
+        n_face = dataset.faces.shape[0]
+        faces = np.empty((n_face, 4), dataset.faces.dtype)
+        faces[:, 1:] = dataset.faces
+        faces[:, 0] = 3
+        return pyvista.PolyData(np.asarray(dataset.vertices), faces)
     else:
-        raise NotImplementedError(f'Type ({type(vtkdataset)}) not able to be wrapped into a PyVista mesh.')
+        raise NotImplementedError(f'Type ({type(dataset)}) not able to be wrapped into a PyVista mesh.')
     try:
-        wrapped = wrappers[key](vtkdataset)
+        wrapped = wrappers[key](dataset)
     except KeyError:
         logging.warning(f'VTK data type ({key}) is not currently supported by pyvista.')
-        return vtkdataset # if not supported just passes the VTK data object
+        return dataset  # if not supported just passes the VTK data object
     return wrapped
 
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -14,3 +14,4 @@ sphinx-notfound-page>=0.3.0
 sphinx-copybutton
 sphinx-gallery>=0.4.0
 lxml
+trimesh

--- a/requirements_style.txt
+++ b/requirements_style.txt
@@ -1,2 +1,2 @@
-codespell==1.16.0
-pydocstyle==5.0.2
+codespell==1.17.1
+pydocstyle==5.1.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,3 +11,4 @@ itkwidgets>=0.25.2
 tqdm
 hypothesis>=5.8.0
 sphinx_gallery
+trimesh

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,14 @@
+import pyvista
+import trimesh
+import numpy as np
+
+
+def test_wrap_trimesh():
+    points = [[0, 0, 0], [0, 0, 1], [0, 1, 0]]
+    faces = [[0, 1, 2]]
+    tmesh = trimesh.Trimesh(points, faces=faces, process=False)
+    mesh = pyvista.wrap(tmesh)
+    assert isinstance(mesh, pyvista.PolyData)
+
+    assert np.allclose(tmesh.vertices, mesh.points)
+    assert np.allclose(tmesh.faces, mesh.faces[1:])


### PR DESCRIPTION
## Wrap Trimesh

Given a few issues that have demonstrated the use of (or mentioned problems with) ``trimesh``, I thought it was time that we wrapped `trimesh.Trimesh` instances.  See issue #966.  For example:

```py
import trimesh
points = [[0, 0, 0], [0, 0, 1], [0, 1, 0]]
faces = [[0, 1, 2]]
tmesh = trimesh.Trimesh(points, faces=faces, process=False)
mesh = pv.wrap(tmesh)
```

I did some tests and the wrap is quite fast as it only generates a new faces array, which you can do fairly quickly.  For those users used to ``trimesh``, this means that we can now plot those mesh types with ``pyvista.plot(tmesh)``.


I've also taken the liberty to update ``codespell`` and ``pydocstyle`` since our versions are old and updating them didn't introduce any additional spelling or style changes.
