### PR TITLE
Fix Scalar Bar Colors

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1344,7 +1344,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         ##### Parse arguments to be used for all meshes #####
 
         if scalar_bar_args is None:
-            scalar_bar_args = {}
+            scalar_bar_args = {'n_colors': n_colors}
 
         if show_edges is None:
             show_edges = rcParams['show_edges']


### PR DESCRIPTION
### Overview

This minor bug has been bothing me for a while.  The maximum number of colors on the scalar bar does not match the number of colors in our mapper.  For example:

```py
import pyvista
import numpy as np
points = np.random.random((100000, 3))
pyvista.plot(points, scalars=points[:, 2], n_colors=256, stitle='Scalars')
```

### `master`
![PyVista_248](https://user-images.githubusercontent.com/11981631/97519073-36af2400-195e-11eb-998c-f0af97bff24f.png)

Zoomed into scalar bar:
![Selection_249](https://user-images.githubusercontent.com/11981631/97519210-7d048300-195e-11eb-8d23-537b1a0ad769.png)


### `fix/scalar_bar_n_colors`
![PyVista_247](https://user-images.githubusercontent.com/11981631/97519084-3adb4180-195e-11eb-8e14-9f6560ae064b.png)

Zoomed into scalar bar:
![Selection_250](https://user-images.githubusercontent.com/11981631/97519216-80980a00-195e-11eb-8c4a-b0a53fd2e737.png)


It's slight, but it's there.
