### PR TITLE
Fix Hill Example Rotations

### DIFF
--- a/examples/01-filter/distance-between-surfaces.py
+++ b/examples/01-filter/distance-between-surfaces.py
@@ -20,9 +20,10 @@ import numpy as np
 
 # A helper to make a random surface
 def hill(seed):
-    mesh = pv.ParametricRandomHills(randomseed=seed,
+    mesh = pv.ParametricRandomHills(randomseed=seed, u_res=50, v_res=50,
                                     hillamplitude=0.5)
-    mesh.rotate_y(80) # give the surfaces some tilt
+    mesh.rotate_y(-10) # give the surfaces some tilt
+    
     return mesh
 
 h0 = hill(1).elevation()
@@ -34,8 +35,8 @@ h1 = h1.elevation()
 ###############################################################################
 
 p = pv.Plotter()
-p.add_mesh(h0)
-p.add_mesh(h1)
+p.add_mesh(h0, smooth_shading=True)
+p.add_mesh(h1, smooth_shading=True)
 p.show_grid()
 p.show()
 
@@ -45,7 +46,7 @@ p.show()
 #
 # Compute normals of lower surface
 h0n = h0.compute_normals(point_normals=True, cell_normals=False,
-                         auto_orient_normals=True, )
+                         auto_orient_normals=True)
 
 ###############################################################################
 # Travel along noramals to the other surface and compute the thickness on each
@@ -68,8 +69,8 @@ np.nanmean(h0n["distances"])
 
 ###############################################################################
 p = pv.Plotter()
-p.add_mesh(h0n, scalars="distances")
-p.add_mesh(h1, color=True, opacity=0.75)
+p.add_mesh(h0n, scalars="distances", smooth_shading=True)
+p.add_mesh(h1, color=True, opacity=0.75, smooth_shading=True)
 p.show()
 
 
@@ -90,6 +91,6 @@ np.mean(d)
 
 ###############################################################################
 p = pv.Plotter()
-p.add_mesh(h0, scalars="distances")
-p.add_mesh(h1, color=True, opacity=0.75)
+p.add_mesh(h0, scalars="distances", smooth_shading=True)
+p.add_mesh(h1, color=True, opacity=0.75, smooth_shading=True)
 p.show()

--- a/pyvista/examples/examples.py
+++ b/pyvista/examples/examples.py
@@ -246,13 +246,11 @@ def load_spline():
 
 def load_random_hills():
     """Create random hills toy example.
-    
-    Uses the parametric random hill function to create hills oriented like
-    topography and add's an elevation array.
 
+    Uses the parametric random hill function to create hills oriented
+    like topography and adds an elevation array.
     """
     mesh = pyvista.ParametricRandomHills()
-    mesh.rotate_y(90)
     return mesh.elevation()
 
 


### PR DESCRIPTION
### Hill Example Rotations

This PR addresses @banesullivan's issue #967 regarding the rotation of the `ParametricRandomHills`.  I've also reduced the resolution of the ray tracing and added smooth shading into the plotting to reduce the documentation build time as well as improve the look of the `distance-between-surfaces.py` example.

### Current Docs
![image](https://user-images.githubusercontent.com/11981631/97520801-aa066500-1961-11eb-8975-05e2c52f4be2.png)


### fix/hills_examples
![image](https://user-images.githubusercontent.com/11981631/97520778-9e1aa300-1961-11eb-9814-f45edf7cccee.png)

Build time for `distance-between-surfaces.py` drops from 21 to 4.4 seconds locally.

Resolves #967 