### PR TITLE
fix texture plotting with active scalars

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1525,6 +1525,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             texture = mesh._activate_texture(texture)
 
         if texture:
+
             if isinstance(texture, np.ndarray):
                 texture = numpy_to_texture(texture)
             if not isinstance(texture, (vtk.vtkTexture, vtk.vtkOpenGLTexture)):
@@ -1538,6 +1539,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
             if scalars is None:
                 show_scalar_bar = False
             self.mapper.SetScalarModeToUsePointFieldData()
+
+            # see https://github.com/pyvista/pyvista/issues/950
+            mesh.set_active_scalars(None)
 
         # Handle making opacity array =========================================
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import platform
 
 import numpy as np
 import pytest
@@ -22,6 +23,7 @@ skip_py2_nobind = pytest.mark.skipif(int(sys.version[0]) < 3,
                                      reason="Python 2 doesn't support binding methods")
 
 skip_windows = pytest.mark.skipif(os.name == 'nt', reason="Flaky Windows tests")
+skip_mac = pytest.mark.skipif(platform.system() == 'Darwin', reason="Flaky Mac tests")
 
 
 @pytest.fixture(scope='module')
@@ -51,6 +53,7 @@ def test_clip_filter():
 
 
 @skip_windows
+@skip_mac
 def test_clip_by_scalars_filter():
     """This tests the clip filter on all datatypes available filters"""
     for i, dataset_in in enumerate(DATASETS):


### PR DESCRIPTION
This PR resolves #950 and ~~brings the puppy back to his former glory~~ fixes texture plotting.

![image](https://user-images.githubusercontent.com/11981631/97523707-94486e00-1968-11eb-978e-c9770580c281.png)

It also skips the clip by scalars test as MacOS Python 3.8 fails intermittently with a segfault.