### PR TITLE
Add .case reader to other _READERS directly.

### DIFF
--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -61,8 +61,8 @@ class MultiBlock(vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
     # Bind pyvista.plotting.plot to the object
     plot = pyvista.plot
-    _READERS = dict.fromkeys(['.vtm', '.vtmb'], vtk.vtkXMLMultiBlockDataReader)
-    _READERS['.case'] = vtk.vtkGenericEnSightReader
+    _READERS = {'.vtm': vtk.vtkXMLMultiBlockDataReader, '.vtmb': vtk.vtkXMLMultiBlockDataReader,
+                '.case': vtk.vtkGenericEnSightReader}
     _WRITERS = dict.fromkeys(['.vtm', '.vtmb'], vtk.vtkXMLMultiBlockDataWriter)
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
### Overview
Small change.

In #725 I mentioned that the .case reader should be added to the dictionary definition instead of another statement. This just makes that change. https://github.com/pyvista/pyvista/pull/725#discussion_r445833196