### PR TITLE
get pop to behave like pop

### DIFF
--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -295,7 +295,7 @@ class DataSetAttributes(VTKObjectWrapper):
             self.remove(key)
         except KeyError:
             if default in self.pop.__defaults__:
-                raise KeyError
+                raise
             return default
         return pyvista_ndarray(vtk_arr, dataset=self.dataset, association=self.association)
 

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -295,7 +295,7 @@ class DataSetAttributes(VTKObjectWrapper):
             self.remove(key)
         except KeyError:
             if default in self.pop.__defaults__:
-                raise
+                raise KeyError
             return default
         return pyvista_ndarray(vtk_arr, dataset=self.dataset, association=self.association)
 

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -10,6 +10,9 @@ import pyvista.utilities.helpers as helpers
 from pyvista.utilities.helpers import FieldAssociation
 from .pyvista_ndarray import pyvista_ndarray
 
+# Used to detect that a default value was not set
+# See https://stackoverflow.com/a/13287922/3369879
+sentinel = object()
 
 class DataSetAttributes(VTKObjectWrapper):
     """Python friendly wrapper of ``vtk.DataSetAttributes``.
@@ -251,7 +254,6 @@ class DataSetAttributes(VTKObjectWrapper):
             pass
         self.VTKObject.Modified()
 
-
     def remove(self, key):
         """Remove an array.
 
@@ -269,13 +271,17 @@ class DataSetAttributes(VTKObjectWrapper):
         self.VTKObject.RemoveArray(key)
         self.VTKObject.Modified()
 
-    def pop(self, key):
+    def pop(self, key, default=sentinel):
         """Remove an array and return it.
 
         Parameters
         ----------
         key : int, str
             The name or index of the array to remove and return.
+
+        default : anything
+            If default is not given and key is not in the dictionary,
+            a KeyError is raised.
 
         Returns
         -------
@@ -288,7 +294,12 @@ class DataSetAttributes(VTKObjectWrapper):
             copy = vtk_arr.NewInstance()
             copy.DeepCopy(vtk_arr)
             vtk_arr = copy
-        self.remove(key)
+            self.remove(key)
+        elif default is not sentinel:
+            return default
+        else:
+            raise KeyError(f'{key}')
+        
         return pyvista_ndarray(vtk_arr, dataset=self.dataset, association=self.association)
 
     def items(self):

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -10,9 +10,6 @@ import pyvista.utilities.helpers as helpers
 from pyvista.utilities.helpers import FieldAssociation
 from .pyvista_ndarray import pyvista_ndarray
 
-# Used to detect that a default value was not set
-# See https://stackoverflow.com/a/13287922/3369879
-sentinel = object()
 
 class DataSetAttributes(VTKObjectWrapper):
     """Python friendly wrapper of ``vtk.DataSetAttributes``.
@@ -271,7 +268,7 @@ class DataSetAttributes(VTKObjectWrapper):
         self.VTKObject.RemoveArray(key)
         self.VTKObject.Modified()
 
-    def pop(self, key, default=sentinel):
+    def pop(self, key, default=pyvista_ndarray(array=[])):
         """Remove an array and return it.
 
         Parameters
@@ -294,12 +291,12 @@ class DataSetAttributes(VTKObjectWrapper):
             copy = vtk_arr.NewInstance()
             copy.DeepCopy(vtk_arr)
             vtk_arr = copy
+        try:
             self.remove(key)
-        elif default is not sentinel:
+        except KeyError:
+            if default in self.pop.__defaults__:
+                raise
             return default
-        else:
-            raise KeyError(f'{key}')
-        
         return pyvista_ndarray(vtk_arr, dataset=self.dataset, association=self.association)
 
     def items(self):

--- a/tests/test_datasetattributes.py
+++ b/tests/test_datasetattributes.py
@@ -181,6 +181,14 @@ def test_pop_should_return_array(insert_arange_narray):
     assert np.array_equal(other_array, sample_array)
 
 
+def test_should_pop_array(insert_arange_narray):
+    dsa, sample_array = insert_arange_narray
+    key = 'invalid_key'
+    assert key not in dsa
+    default = 20
+    assert dsa.pop(key, default) is default
+
+
 @mark.parametrize('removed_key', [None, 'nonexistant_array_name', '', -1])
 def test_remove_should_fail_on_bad_argument(removed_key, hexbeam_point_attributes):
     with raises(KeyError):


### PR DESCRIPTION
This is a quick fix to a quirk I found recently where `pop` in `DataSetAttributes` wasn't behaving like the built-in dictionary pop.  See:

https://docs.python.org/3/library/stdtypes.html#dict.pop

We just need to add the `default` argument such that if the key isn't present in the `DataSetAttributes` instance, we return the default arg.
