### PR TITLE
remove viz of last picked cell after clicking outside the mesh

### DIFF
--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -124,6 +124,8 @@ class PickingHelper:
 
                 # render here prior to running the callback
                 self_().render()
+            elif not is_valid_selection:
+                self.remove_actor('_cell_picking_selection')
 
             if callback is not None and is_valid_selection:
                 try_callback(callback, self_().picked_cells)


### PR DESCRIPTION
Resolve https://github.com/pyvista/pyvista-support/issues/268

This is needed. The pointer to the picked cells is empty and thus this could be misleading if the viz remains after a user selects nothing. They might close the plotter thinking their selection is there but it isn't.

This will ensure the `.picked_cells` pointer matches what is displayed


cc @rodrigomologni
