### PR TITLE
Allow Python 3.9 and Explain Building

### DIFF
--- a/docs/building_vtk.rst
+++ b/docs/building_vtk.rst
@@ -1,3 +1,37 @@
 Building VTK
 ============
-Describe how to build VTK from source.
+Kitware provides Python wheels for VTK at `PyPi VTK <https://pypi.org/project/vtk/>`_, but there are situations where you
+may need to build VTK from source (e.g. new release of Python, EGL
+rendering, additional features, etc).  As ``pyvista`` does not provide
+``vtk``, you will have to build it manually.
+
+
+Building VTK Python Wheels on Linux and Mac OS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Building VTK from source on Linux is fairly easy.  Using the default
+build settings, build a Python wheel of VTK using ``ninja`` using the following script.  This script assumes Python 3.9, but you can use any modern Python version.
+
+.. code::
+
+    git clone https://github.com/Kitware/VTK
+    cd VTK
+
+    mkdir build
+    cd build
+    PYBIN=/usr/bin/python3.9
+    cmake -GNinja -DVTK_BUILD_TESTING=OFF -DVTK_WHEEL_BUILD=ON -DVTK_PYTHON_VERSION=3 -DVTK_WRAP_PYTHON=ON -DPython3_EXECUTABLE=$PYBIN ../
+
+    ninja
+    $PYBIN setup.py bdist_wheel
+    pip install dist/vtk-*.whl  # optionally install it
+
+You may need to install ``python3.9-dev`` and ``ninja`` if you have
+not already installed it.
+
+
+Building VTK on Windows
+~~~~~~~~~~~~~~~~~~~~~~~
+Please reference the directions at `Building VTK with Windows
+<https://vtk.org/Wiki/VTK/Configure_and_Build#On_Windows_5>`_.  This
+is generally a non-trivial process and is not for the faint-hearted.

--- a/docs/building_vtk.rst
+++ b/docs/building_vtk.rst
@@ -1,0 +1,3 @@
+Building VTK
+============
+Describe how to build VTK from source.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -199,6 +199,8 @@ for 3D visualization in our `external examples list <./external_examples.html>`_
    examples/index
    external_examples
    optional_features
+   building_vtk
+
 
 Translating the documentation
 *****************************

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -199,7 +199,6 @@ for 3D visualization in our `external examples list <./external_examples.html>`_
    examples/index
    external_examples
    optional_features
-   building_vtk
 
 
 Translating the documentation
@@ -245,7 +244,15 @@ Highlights of the API include:
    plotting/index
    utilities/index
 
+Extras
+******
 
+.. toctree::
+   :maxdepth: 2
+   :caption: Extras
+   :hidden:
+
+   building_vtk
 
 
 Project Index

--- a/pyvista/utilities/__init__.py
+++ b/pyvista/utilities/__init__.py
@@ -8,4 +8,3 @@ from .geometric_objects import *
 from .helpers import *
 from .parametric_objects import *
 from .sphinx_gallery import Scraper, _get_sg_image_scraper
-from .xvfb import start_xvfb

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ if sys.version_info.minor == 9:
         import vtk
     except ImportError:
         raise RuntimeError('There are no wheels available for VTK on Python 3.9 yet.  '
-                           'Please use Python 3.6 through 3.8')
+                           'Please use Python 3.6 through 3.8, or build and install '
+                           'VTK from source with a wheel.')
 
 
 # pre-compiled vtk available for python3

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,12 @@ with io_open(version_file, mode='r') as fd:
 
 # Python 3.9 isn't supported at the moment
 if sys.version_info.minor == 9:
-    raise RuntimeError('There are no wheels available for VTK on Python 3.9 yet.  '
-                       'Please use Python 3.6 through 3.8')
+    # but, the user might have installed vtk from a non-pypi wheel.
+    try:
+        import vtk
+    except ImportError:
+        raise RuntimeError('There are no wheels available for VTK on Python 3.9 yet.  '
+                           'Please use Python 3.6 through 3.8')
 
 
 # pre-compiled vtk available for python3

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ if sys.version_info.minor == 9:
     except ImportError:
         raise RuntimeError('There are no wheels available for VTK on Python 3.9 yet.  '
                            'Please use Python 3.6 through 3.8, or build and install '
-                           'VTK from source with a wheel.')
+                           'VTK from source with a wheel.  Please see:\n'
+                           'https://docs.pyvista.org/building_vtk.html')
 
 
 # pre-compiled vtk available for python3


### PR DESCRIPTION
### Allow Python 3.9

Thanks to instructions from @banesullivan, I've build a wheel for VTK for Python 3.9.  I couldn't install it because we're a bit heavy-handed about supporting ``pyvista`` on Python 3.9.  This PR fixes it by providing a helpful error and additional docs for building a wheel for VTK.

