### PR TITLE
Add Docker Documentation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 USER jovyan
 
-# setup the itkwidgets conda enviornment
+# setup the itkwidgets conda environment
 COPY environment.yml labextensions.txt /tmp/
 RUN conda env update --name base --file /tmp/environment.yml
 RUN conda run conda install -y nodejs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,27 @@
+FROM jupyter/base-notebook:python-3.8.6
+LABEL maintainer="pyvista Developers"
+
+USER root
+RUN apt-get update \
+ && apt-get install  -yq --no-install-recommends \
+    libgl1-mesa-glx \
+    libglu1-mesa \
+    xvfb \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+USER jovyan
+
+# setup the itkwidgets conda enviornment
+COPY environment.yml labextensions.txt /tmp/
+RUN conda env update --name base --file /tmp/environment.yml
+RUN conda run conda install -y nodejs
+RUN conda run jupyter labextension install $(cat /tmp/labextensions.txt)
+
+RUN pip install ipyvtk-simple==0.1.2
+
+# allow jupyterlab for ipyvtk
+ENV DISPLAY=:99.0
+ENV JUPYTER_ENABLE_LAB=yes
+ENV PYVISTA_USE_IPYVTK=true
+
+# modify the CMD and start a background server first
+CMD /bin/bash -c "Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &" && start-notebook.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,27 @@
+### Pyvista within a Docker Container
+You can use ``pyvista`` from within a docker container with jupyterlab.
+To create a local docker image install ``docker`` and be sure you've logged into docker by following the directions at [Configuring Docker for use with GitHub Packages](https://docs.github.com/en/free-pro-team@latest/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages#authenticating-with-a-personal-access-token)
+
+Next, pull, and run the image with:
+
+```bash
+docker pull docker.pkg.github.com/pyvista/pyvista/pyvista-jupyterlab:latest
+docker run -it --rm -p 8888:8888 pyvista-jupyterlab:v0.27.0
+```
+
+Finally, open the link that shows up and start playing around with
+pyvista in jupyterlab!  For example:
+
+```
+http://127.0.0.1:8888/?token=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+### Create your own Docker Container with `pyvista`
+
+Clone pyvista and cd into this directory to create your own customized docker image.
+
+```bash
+IMAGE=my-pyvista-jupyterlab:v0.1.0
+docker build -t $IMAGE .
+docker push $IMAGE
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,8 +5,8 @@ To create a local docker image install ``docker`` and be sure you've logged into
 Next, pull, and run the image with:
 
 ```bash
-docker pull docker.pkg.github.com/pyvista/pyvista/pyvista-jupyterlab:latest
-docker run -it --rm -p 8888:8888 pyvista-jupyterlab:v0.27.0
+docker pull docker.pkg.github.com/pyvista/pyvista/pyvista-jupyterlab:v0.27.0
+docker run -p 8888:8888 docker.pkg.github.com/pyvista/pyvista/pyvista-jupyterlab:v0.27.0
 ```
 
 Finally, open the link that shows up and start playing around with

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - itkwidgets=0.32.0
+  - ipywidgets=7.5.1

--- a/docker/labextensions.txt
+++ b/docker/labextensions.txt
@@ -1,0 +1,4 @@
+@jupyter-widgets/jupyterlab-manager@2.0
+itkwidgets@0.32.0
+ipycanvas@0.6.1
+ipyevents@1.8.1

--- a/docker_dev/Dockerfile
+++ b/docker_dev/Dockerfile
@@ -1,0 +1,39 @@
+FROM jupyter/base-notebook:lab-2.2.8
+LABEL maintainer="pyvista Developers"
+
+USER root
+RUN apt-get update \
+ && apt-get install  -yq --no-install-recommends \
+    libgl1-mesa-glx \
+    libglu1-mesa \
+    libsm6 \
+    libopengl0 \
+    libegl1 \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+USER jovyan
+
+# setup the itkwidgets conda enviornment
+COPY environment.yml labextensions.txt /tmp/
+RUN conda env update --name base --file /tmp/environment.yml
+RUN conda run conda install -y nodejs
+RUN conda run jupyter labextension install $(cat /tmp/labextensions.txt)
+
+RUN pip install ipyvtk-simple==0.1.2
+
+COPY pyvista-0.27.dev1-py3-none-any.whl /tmp/
+RUN pip install /tmp/pyvista-0.27.dev1-py3-none-any.whl
+
+USER root
+RUN sudo apt update && sudo apt-get install xvfb -y
+
+COPY examples examples
+RUN chown jovyan -R examples
+RUN rm -rf /tmp/* && rm -rf work
+USER jovyan
+
+ENV DISPLAY=:99.0
+ENV JUPYTER_ENABLE_LAB=yes
+ENV PYVISTA_USE_IPYVTK=true
+
+# modify the CMD and start a background server first
+CMD /bin/bash -c "Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &" && start-notebook.sh

--- a/docker_dev/Dockerfile
+++ b/docker_dev/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 USER jovyan
 
-# setup the itkwidgets conda enviornment
+# setup the itkwidgets conda environment
 COPY environment.yml labextensions.txt /tmp/
 RUN conda env update --name base --file /tmp/environment.yml
 RUN conda run conda install -y nodejs

--- a/docker_dev/Dockerfile
+++ b/docker_dev/Dockerfile
@@ -20,6 +20,9 @@ RUN conda run jupyter labextension install $(cat /tmp/labextensions.txt)
 
 RUN pip install ipyvtk-simple==0.1.2
 
+# COPY vtk-9.0.20201105-cp38-cp38-linux_x86_64.whl /tmp/
+# RUN pip install /tmp/vtk-9.0.20201105-cp38-cp38-linux_x86_64.whl
+
 COPY pyvista-0.27.dev1-py3-none-any.whl /tmp/
 RUN pip install /tmp/pyvista-0.27.dev1-py3-none-any.whl
 

--- a/docker_dev/README.md
+++ b/docker_dev/README.md
@@ -1,0 +1,12 @@
+## Developer Docker Build
+
+Build file and Dockerfile for creating the docker images hosted at
+
+```
+docker.pkg.github.com/pyvista/pyvista/pyvista-jupyterlab:v0.27.0
+```
+
+Since this image was pushed before ``0.27.0`` was out, the
+``Dockerfile`` used ``0.27.dev1``.  Additionally, there are some
+features left over from building with EGL GPU offscreen support, but I
+dropped it as it seems that EGL has issues with software rendering.

--- a/docker_dev/build.sh
+++ b/docker_dev/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Developer script to build and push pyvista's docker image to github
+
+set -e
+
+# requires examples be build in advance...
+rm -rf examples
+mkdir examples
+find ../docs/examples -name "*.ipynb" | xargs cp --parents -t examples
+mv docs/examples/* examples
+rm -rf docs
+
+VERSION=v0.27.0
+IMAGE=docker.pkg.github.com/pyvista/pyvista/pyvista-jupyterlab:$VERSION
+docker build -t $IMAGE .
+docker push $IMAGE

--- a/docker_dev/environment.yml
+++ b/docker_dev/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - itkwidgets=0.32.0
+  - ipywidgets=7.5.1

--- a/docker_dev/labextensions.txt
+++ b/docker_dev/labextensions.txt
@@ -1,0 +1,4 @@
+@jupyter-widgets/jupyterlab-manager@2.0
+itkwidgets@0.32.0
+ipycanvas@0.6.1
+ipyevents@1.8.1

--- a/docs/extras/building_vtk.rst
+++ b/docs/extras/building_vtk.rst
@@ -1,3 +1,5 @@
+.. _ref_building_vtk:
+
 Building VTK
 ============
 Kitware provides Python wheels for VTK at `PyPi VTK <https://pypi.org/project/vtk/>`_, but there are situations where you
@@ -12,7 +14,7 @@ Building VTK Python Wheels on Linux and Mac OS
 Building VTK from source on Linux is fairly easy.  Using the default
 build settings, build a Python wheel of VTK using ``ninja`` using the following script.  This script assumes Python 3.9, but you can use any modern Python version.
 
-.. code::
+.. code-block:: bash
 
     git clone https://github.com/Kitware/VTK
     cd VTK
@@ -28,6 +30,20 @@ build settings, build a Python wheel of VTK using ``ninja`` using the following 
 
 You may need to install ``python3.9-dev`` and ``ninja`` if you have
 not already installed it.
+
+
+Building with Off-Screen Plotting GPU Support
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+You can also build VTK for off-screen plotting using GPU support by modifying the above ``cmake`` command with:
+
+.. code-block:: bash
+
+  cmake -GNinja -DVTK_BUILD_TESTING=OFF -DVTK_WHEEL_BUILD=ON -DVTK_PYTHON_VERSION=3 -DVTK_WRAP_PYTHON=ON -DVTK_OPENGL_HAS_EGL=True -DVTK_USE_X=False -DPython3_EXECUTABLE=$PYBIN ../
+
+This disables any plotting using the X server, so be prepared to use
+this module only on a headless display where you either intend to save
+static images or stream the render window to another computer with a
+display (e.g using ``use_ipyvtk=True`` and jupyterlab)
 
 
 Building VTK on Windows

--- a/docs/extras/docker.rst
+++ b/docs/extras/docker.rst
@@ -1,0 +1,107 @@
+
+
+Pyvista within a Docker Container
+=================================
+You can use ``pyvista`` from within a docker container with
+jupyterlab.  To create a local docker image install ``docker`` and be
+sure you've logged into docker by following the directions at
+[Configuring Docker for use with GitHub Packages](https://docs.github.com/en/free-pro-team@latest/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages#authenticating-with-a-personal-access-token)
+
+Next pull and run the image with:
+
+.. code-block:: bash
+
+  docker run -p 8888:8888 docker.pkg.github.com/pyvista/pyvista/pyvista-jupyterlab:v0.27.0
+
+Finally, open the link that shows up from the terminal output and
+start playing around with pyvista in jupyterlab!  For example:
+
+.. code::
+
+    To access the notebook, open this file in a browser:
+        file:///home/jovyan/.local/share/jupyter/runtime/nbserver-6-open.html
+    Or copy and paste one of these URLs:
+        http://861c873f6352:8888/?token=b3ac1f6397188944fb21e1f58b673b5b4e6f1ede1a84787b
+     or http://127.0.0.1:8888/?token=b3ac1f6397188944fb21e1f58b673b5b4e6f1ede1a84787b
+
+
+Create your own Docker Container with `pyvista`
+-----------------------------------------------
+Clone pyvista and cd into this directory to create your own customized docker image.
+
+.. code-block:: bash
+
+  git clone https://github.com/pyvista/pyvista
+  cd pyvista/docker
+  IMAGE=my-pyvista-jupyterlab:v0.1.0
+  docker build -t $IMAGE .
+  docker push $IMAGE
+
+If you wish to have off-screen GPU support when rending on jupyterlab,
+see the the notes about building with EGL at :ref:`ref_building_vtk`.
+Install that customized vtk wheel onto your docker image by modifying
+the docker image at ``pyvista/docker/Dockerfile`` with:
+
+
+.. code-block::
+
+  COPY vtk-9.0.20201105-cp38-cp38-linux_x86_64.whl /tmp/
+  RUN pip install /tmp/vtk-9.0.20201105-cp38-cp38-linux_x86_64.whl
+
+Additionally, you must install GPU drivers on the docker image of the
+same version running on the host machine.  For example, if you are
+running on Azure Kubernetes Service and the GPU nodes on the
+kubernetes cluster is running ``450.51.06``, you must install the same
+version on your image.  Since you will be using the underlying kernel
+module, there's no reason to build it on the container (and trying
+will only result in an error).
+
+.. code::
+
+  COPY NVIDIA-Linux-x86_64-450.51.06.run nvidia_drivers.run
+  RUN sudo apt-get install kmod libglvnd-dev pkg-config -yq
+  RUN ./NVIDIA-Linux-x86_64-450.51.06.run -s --no-kernel-module
+
+To verify that you're rendering on a GPU, first check the output of
+``nvidia-smi``.  You should get something like:
+
+.. code::
+
+  $ nvidia-smi
+  Sun Nov  8 05:48:46 2020       
+  +-----------------------------------------------------------------------------+
+  | NVIDIA-SMI 450.51.06    Driver Version: 450.51.06    CUDA Version: 11.0     |
+  |-------------------------------+----------------------+----------------------+
+  | GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
+  | Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
+  |                               |                      |               MIG M. |
+  |===============================+======================+======================|
+  |   0  Tesla K80           Off  | 00000001:00:00.0 Off |                    0 |
+  | N/A   34C    P8    32W / 149W |   1297MiB / 11441MiB |      0%      Default |
+  |                               |                      |                  N/A |
+  +-------------------------------+----------------------+----------------------+
+
+Note the driver version (which is actually the kernel driver version),
+and verify it matches the version you installed on your docker image.
+
+Finally, check that your render window is using NVIDIA by running
+``ReportCapabilities``:
+
+.. code:: python
+
+  >>> import pyvista
+  >>> pl = pyvista.Plotter()
+  >>> print(pl.ren_win.ReportCapabilities())
+
+  OpenGL vendor string:  NVIDIA Corporation
+  OpenGL renderer string:  Tesla K80/PCIe/SSE2
+  OpenGL version string:  4.6.0 NVIDIA 450.51.06
+  OpenGL extensions:  
+    GL_AMD_multi_draw_indirect
+    GL_AMD_seamless_cubemap_per_texture
+    GL_ARB_arrays_of_arrays
+    GL_ARB_base_instance
+    GL_ARB_bindless_texture
+
+If you get ``display id not set``, then your environment is likely not
+setup correctly.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -253,7 +253,7 @@ Extras
    :hidden:
 
    building_vtk
-
+   docker
 
 Project Index
 *************

--- a/docs/plotting/ipyvtk_plotting.rst
+++ b/docs/plotting/ipyvtk_plotting.rst
@@ -1,4 +1,4 @@
-.. _qt_plotting:
+.. _ipyvtk_plotting:
 
 Interactive Notebook Plotting Using ``ipyvtk-simple``
 -----------------------------------------------------

--- a/docs/plotting/ipyvtk_plotting.rst
+++ b/docs/plotting/ipyvtk_plotting.rst
@@ -4,7 +4,7 @@ Interactive Notebook Plotting Using ``ipyvtk-simple``
 -----------------------------------------------------
 
 ``pyvista`` has the ability to display fully featured plots within a
-jupyterlab enviornment using ``ipyvtk-simple``.  This feature works by
+jupyterlab environment using ``ipyvtk-simple``.  This feature works by
 streaming the current render window to a canvas within jupyterlab and
 then passing any user actions from the canvas back to the VTK render
 window.
@@ -40,7 +40,7 @@ For convenience, you can enable ``use_ipyvtk`` by default with:
 
 Installation
 ------------
-If you're using an Anaconda enviornment, installation is the quite straightforward:
+If you're using an Anaconda environment, installation is the quite straightforward:
 
 .. code::
 
@@ -61,7 +61,7 @@ Where environment.yml is:
       - ipywidgets=7.5.1
       - pyvista=0.27.0
 
-On Linux, you can setup your jupyterlab enviornment with:
+On Linux, you can setup your jupyterlab environment with:
 
 .. code::
 
@@ -71,8 +71,8 @@ On Linux, you can setup your jupyterlab enviornment with:
 
 
 
-Performance Notes and Tweaks
-----------------------------
+Off-Screen GPU Acceleration
+---------------------------
 Local usage on ``jupyterlab`` uses your GPU for off-screen rendering,
 but on a headless instance (e.g. VM or kubernetes cluster), you're
 limited to software rendering on the CPU.  This will result in
@@ -85,7 +85,7 @@ are not built with this feature as it results in a > 400 MB wheel.
 For the adventurous/desperate, build VTK with EGL for a given Python wheel on
 Linux with the following:
 
-.. code::
+.. code-block:: bash
 
     PYBIN=/usr/bin/python3.8  # replace with your version...
     cmake -GNinja -DVTK_BUILD_TESTING=OFF -DVTK_WHEEL_BUILD=ON -DVTK_PYTHON_VERSION=3 -DVTK_WRAP_PYTHON=ON -DVTK_OPENGL_HAS_EGL=True -DVTK_USE_X=False -DPython3_EXECUTABLE=$PYBIN ../
@@ -94,11 +94,30 @@ Linux with the following:
     $PYBIN setup.py bdist_wheel
     $PYBIN -m pip install dist/vtk-*.whl  # optional
 
-Please note you'll need to have the ``-dev`` package installed for
-Python along with ``ninja``.
-
 Note that this wheel will make VTK unusable outside of an off-screen
-enviornment, so only plan on installing it on a headless system
+environment, so only plan on installing it on a headless system
 without a X server.
 
-For those of you who 
+
+Other Considerations
+--------------------
+If you do not have GPU acceleration, be sure to start up a virtual
+framebuffer using ``Xvfb``.  You can either start it using bash with:
+
+.. code-block:: bash
+
+    export DISPLAY=:99.0
+    export PYVISTA_OFF_SCREEN=true
+    export PYVISTA_USE_IPYVTK=true
+    which Xvfb
+    Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+    sleep 3
+    set +x
+    exec "$@"
+
+
+Or alternatively, start it using the built in ``pyvista.start_xvfb()``.  Please be sure to install ``xvfb`` and ``libgl1-mesa-glx`` with:
+
+.. code-block:: bash
+
+    sudo apt-get libgl1-mesa-dev xvfb

--- a/docs/plotting/ipyvtk_plotting.rst
+++ b/docs/plotting/ipyvtk_plotting.rst
@@ -120,4 +120,4 @@ Or alternatively, start it using the built in ``pyvista.start_xvfb()``.  Please 
 
 .. code-block:: bash
 
-    sudo apt-get libgl1-mesa-dev xvfb
+    sudo apt-get install libgl1-mesa-dev xvfb

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4133,6 +4133,12 @@ class Plotter(BasePlotter):
                 raise NotImplementedError('`ipyvtk-simple` does not support multiple'
                                           ' render windows (i.e. shape != (1, 1)')
 
+            # Widgets do not work in spyder
+            if any('SPYDER' in name for name in os.environ):
+                warnings.warn('``use_ipyvtk`` is incompatible with Spyder.\n'
+                              'Use notebook=False for interactive '
+                              'plotting within spyder')
+
             try:
                 from ipyvtk_simple.viewer import ViewInteractiveWidget
             except ImportError:

--- a/pyvista/utilities/xvfb.py
+++ b/pyvista/utilities/xvfb.py
@@ -1,4 +1,4 @@
-"""Start xvfb from Python"""
+"""Start xvfb from Python."""
 import time
 import os
 

--- a/pyvista/utilities/xvfb.py
+++ b/pyvista/utilities/xvfb.py
@@ -1,16 +1,14 @@
-"""
-
-"""
+"""Start xvfb from Python"""
 import time
 import os
 
 XVFB_INSTALL_NOTES = """Please install Xvfb with:
 
 Debian
-$ sudo apt install libgl1-mesa-glx libglu1-mesa libsm6 xvfb
+$ sudo apt install libgl1-mesa-glx xvfb
 
 CentOS / RHL
-$ sudo yum install libgl1-mesa-glx libglu1-mesa libsm6 xvfb
+$ sudo yum install libgl1-mesa-glx xvfb
 
 """
 


### PR DESCRIPTION
## Docker!!!

I was never really impressed with `pyvista`'s support of dockerized environments, but with `ipyvtk-simple`, native performance within a docker image is actually quite good, so I think it's high time we have a docker image for pyvista as well.  Given it's the weekend, I went ahead and released a docker image at https://github.com/pyvista/pyvista/packages/493403

Turns out support for docker images hosted by github is really great!  I've updated the docs, but if you want to play around with the image, setup your docker credentials with GitHub and then run:
```
docker run -p 8888:8888 docker.pkg.github.com/pyvista/pyvista/pyvista-jupyterlab:v0.27.0
```

### Additional Notes

This PR adds additional documentation for ``ipyvtk-simple`` usage and installation.  Installing it on jupyterlab isn't that simple, so it's a good idea for us to provide detailed documentation for it.

This PR also adds some documentation for starting ``Xvfb`` from `pyvista` using `start_xvfb`.  For testing on my own docker containers, it's always nice to start a virtual framebuffer right from Python.
