### PR TITLE
Fix subplotting with ipyvtk_simple

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4129,10 +4129,6 @@ class Plotter(BasePlotter):
         cpos = self.camera_position
 
         if self.notebook and use_ipyvtk:
-            if self.shape != (1, 1):
-                raise NotImplementedError('`ipyvtk-simple` does not support multiple'
-                                          ' render windows (i.e. shape != (1, 1)')
-
             # Widgets do not work in spyder
             if any('SPYDER' in name for name in os.environ):
                 warnings.warn('``use_ipyvtk`` is incompatible with Spyder.\n'
@@ -4150,7 +4146,7 @@ class Plotter(BasePlotter):
                                          transparent_background=self.image_transparent_background)
 
         # If notebook is true and ipyvtk_simple display failed:
-        if self.notebook and (disp is None or self.shape != (1, 1)):
+        if self.notebook and (disp is None):
             import PIL.Image
             # sanity check
             try:

--- a/tests/plotting/test_ipyvtk.py
+++ b/tests/plotting/test_ipyvtk.py
@@ -9,9 +9,3 @@ def test_ipyvtk(sphere):
     pl.add_mesh(sphere)
     viewer = pl.show(use_ipyvtk=True, return_viewer=True)
     assert isinstance(viewer, ViewInteractiveWidget)
-
-
-def test_ipyvtk_sub_render_fail():
-    pl = pyvista.Plotter(notebook=True, shape=(2, 1))
-    with pytest.raises(NotImplementedError):
-        pl.show(use_ipyvtk=True)


### PR DESCRIPTION
### Overview

Subplotting with ipyvtk totally works! I'd like to get this out on 0.27.1 soon if we can... might as well wait a momennt to see if anything else comes to light

```py
import pyvista as pv
p = pv.Plotter(shape=(2,1))
p.add_mesh(pv.ParametricBohemianDome())
p.subplot(1,0)
p.add_mesh(pv.Cube())
p.show(use_ipyvtk=True)
```

![2020-11-08 21 27 35](https://user-images.githubusercontent.com/22067021/98500268-473a8680-2209-11eb-8294-14cc9bf32ac1.gif)


