### PR TITLE
Revert #995

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -732,7 +732,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if not hasattr(self, 'ren_win') and hasattr(self, 'last_image'):
             return self.last_image
 
-        width, height = self.ren_win.GetSize()
+        width, height = self.window_size
         arr = vtk.vtkUnsignedCharArray()
         self.ren_win.GetRGBACharPixelData(0, 0, width - 1, height - 1, 0, arr)
         data = vtk_to_numpy(arr).reshape(height, width, -1)[::-1]


### PR DESCRIPTION
As @akaszynski pointed out in https://github.com/pyvista/pyvista/pull/995#issuecomment-724086473, `window_size` is an existing property, making the change irrelevant for `Plotter`. So I moved the original issue to https://github.com/pyvista/pyvistaqt/issues/70

Sorry for the noise.