### PR TITLE
Clean up example downloads

### DIFF
--- a/pyvista/core/errors.py
+++ b/pyvista/core/errors.py
@@ -31,7 +31,8 @@ class InvalidCameraError(ValueError):
 
 
 class DeprecationError(RuntimeError):
-    """Used for depreciated methods and functions"""
+    """Used for depreciated methods and functions."""
 
     def __init__(self, message='This feature has been depreciated'):
+        """Empty init."""
         RuntimeError.__init__(self, message)

--- a/pyvista/core/errors.py
+++ b/pyvista/core/errors.py
@@ -28,3 +28,10 @@ class InvalidCameraError(ValueError):
     def __init__(self, message=CAMERA_ERROR_MESSAGE):
         """Empty init."""
         ValueError.__init__(self, message)
+
+
+class DeprecationError(RuntimeError):
+    """Used for depreciated methods and functions"""
+
+    def __init__(self, message='This feature has been depreciated'):
+        RuntimeError.__init__(self, message)

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -183,7 +183,7 @@ def download_blood_vessels():
     return mesh
 
 def download_iron_pot():
-    """Download iron pot dataset."""
+    """Download iron protein dataset."""
     return _download_and_read('ironProt.vtk')
 
 def download_tetrahedron():
@@ -479,7 +479,7 @@ def download_model_with_variance():
 
 
 def download_thermal_probes():
-    """Download model with variance dataset."""
+    """Download thermal probes dataset."""
     return _download_and_read("probes.vtp")
 
 
@@ -539,7 +539,7 @@ def download_urn():
 
 
 def download_pepper():
-    """Download scan of a burial urn.
+    """Download scan of a pepper (capsicum).
 
     https://www.laserdesign.com/sample-files/hot-red-pepper/
 
@@ -558,7 +558,6 @@ def download_drill():
     url = "http://3dgallery.gks.com/2015/ryobi/index1.php"
     filename, _ = _retrieve_file(url, 'pepper.obj')
     return pyvista.read(filename)
-
 
 
 def download_action_figure():
@@ -599,7 +598,7 @@ def download_crater_imagery():
 
 
 def download_dolfin():
-    """Download crater texture."""
+    """Download dolfin mesh."""
     return _download_and_read('dolfin_fine.xml', file_format="dolfin-xml")
 
 
@@ -651,18 +650,18 @@ def download_vtk_logo():
     return _download_and_read("vtk.png", texture=True)
 
 def download_backward_facing_step():
-    """Download an ensigh gold case of a fluid simulation."""
+    """Download an ensight gold case of a fluid simulation."""
     folder, _ = _download_file('EnSight.zip')
     filename = os.path.join(folder, "foam_case_0_0_0_0.case")
     return pyvista.read(filename)
 
 def download_gpr_data_array():
-    """Download a texture of the VTK logo."""
+    """Download GPR example data array."""
     saved_file, _ = _download_file("gpr-example/data.npy")
     return np.load(saved_file)
 
 def download_gpr_path():
-    """Download a texture of the VTK logo."""
+    """Download GPR example path."""
     saved_file, _ = _download_file("gpr-example/path.txt")
     path = np.loadtxt(saved_file, skiprows=1)
     return pyvista.PolyData(path)

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -183,6 +183,14 @@ def download_blood_vessels():
     return mesh
 
 def download_iron_pot():
+    """Download iron protein dataset.
+
+    DEPRECATED: Please use ``download_iron_protein``.
+
+    """
+    return self.view_isometric()
+
+def download_iron_protein():
     """Download iron protein dataset."""
     return _download_and_read('ironProt.vtk')
 

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -66,9 +66,11 @@ def _retrieve_file(url, filename):
         local_path = local_path[:-4]
     return local_path, resp
 
+
 def _download_file(filename):
     url = _get_vtk_file_url(filename)
     return _retrieve_file(url, filename)
+
 
 def _download_and_read(filename, texture=False, file_format=None):
     saved_file, _ = _download_file(filename)
@@ -83,54 +85,67 @@ def download_masonry_texture():
     """Download masonry texture."""
     return _download_and_read('masonry.bmp', texture=True)
 
+
 def download_usa_texture():
     """Download usa texture."""
     return _download_and_read('usa_image.jpg', texture=True)
+
 
 def download_puppy_texture():
     """Download puppy texture."""
     return _download_and_read('puppy.jpg', texture=True)
 
+
 def download_puppy():
     """Download puppy dataset."""
     return _download_and_read('puppy.jpg')
+
 
 def download_usa():
     """Download usa dataset."""
     return _download_and_read('usa.vtk')
 
+
 def download_st_helens():
     """Download Saint Helens dataset."""
     return _download_and_read('SainteHelens.dem')
+
 
 def download_bunny():
     """Download bunny dataset."""
     return _download_and_read('bunny.ply')
 
+
 def download_bunny_coarse():
     """Download coarse bunny dataset."""
     return _download_and_read('Bunny.vtp')
+
 
 def download_cow():
     """Download cow dataset."""
     return _download_and_read('cow.vtp')
 
+
 def download_cow_head():
     """Download cow head dataset."""
     return _download_and_read('cowHead.vtp')
+
 
 def download_faults():
     """Download faults dataset."""
     return _download_and_read('faults.vtk')
 
+
 def download_tensors():
     """Download tensors dataset."""
     return _download_and_read('tensors.vtk')
+
 
 def download_head():
     """Download head dataset."""
     _download_file('HeadMRVolume.raw')
     return _download_and_read('HeadMRVolume.mhd')
+
 
 def download_bolt_nut():
     """Download bolt nut dataset."""
@@ -139,41 +154,51 @@ def download_bolt_nut():
     blocks['nut'] = _download_and_read('nut.slc')
     return blocks
 
+
 def download_clown():
     """Download clown dataset."""
     return _download_and_read('clown.facet')
+
 
 def download_topo_global():
     """Download topo dataset."""
     return _download_and_read('EarthModels/ETOPO_10min_Ice.vtp')
 
+
 def download_topo_land():
     """Download topo land dataset."""
     return _download_and_read('EarthModels/ETOPO_10min_Ice_only-land.vtp')
+
 
 def download_coastlines():
     """Download coastlines dataset."""
     return _download_and_read('EarthModels/Coastlines_Los_Alamos.vtp')
 
+
 def download_knee():
     """Download knee dataset."""
     return _download_and_read('DICOM_KNEE.dcm')
+
 
 def download_knee_full():
     """Download full knee dataset."""
     return _download_and_read('vw_knee.slc')
 
+
 def download_lidar():
     """Download lidar dataset."""
     return _download_and_read('kafadar-lidar-interp.vtp')
+
 
 def download_exodus():
     """Sample ExodusII data file."""
     return _download_and_read('mesh_fs8.exo')
 
+
 def download_nefertiti():
     """Download mesh of Queen Nefertiti."""
     return _download_and_read('Nefertiti.obj.zip')
+
 
 def download_blood_vessels():
     """Download data representing the bifurcation of blood vessels."""
@@ -182,6 +207,7 @@ def download_blood_vessels():
     mesh = pyvista.read(filename)
     mesh.set_active_vectors('velocity')
     return mesh
+
 
 def download_iron_pot():  # pragma: no cover
     """Download iron protein dataset.

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -455,7 +455,6 @@ def download_kitchen(split=False):
         kitchen[key] = result
     return kitchen
 
-
 def download_tetra_dc_mesh():
     """Download two meshes defining an electrical inverse problem.
 
@@ -472,16 +471,13 @@ def download_tetra_dc_mesh():
     inv.set_active_scalars('Resistivity(log10)')
     return pyvista.MultiBlock({'forward':fwd, 'inverse':inv})
 
-
 def download_model_with_variance():
     """Download model with variance dataset."""
     return _download_and_read("model_with_variance.vtu")
 
-
 def download_thermal_probes():
     """Download thermal probes dataset."""
     return _download_and_read("probes.vtp")
-
 
 def download_carburator():
     """Download scan of a carburator.
@@ -493,7 +489,6 @@ def download_carburator():
     filename, _ = _retrieve_file(url, 'carburator.ply')
     return pyvista.read(filename)
 
-
 def download_woman():
     """Download scan of a woman.
 
@@ -503,7 +498,6 @@ def download_woman():
     url = "http://3dgallery.gks.com/2012/bodyscan/bodyscan3.php"
     filename, _ = _retrieve_file(url, 'woman.stl')
     return pyvista.read(filename)
-
 
 def download_lobster():
     """Download scan of a lobster.
@@ -515,7 +509,6 @@ def download_lobster():
     filename, _ = _retrieve_file(url, 'lobster.ply')
     return pyvista.read(filename)
 
-
 def download_face2():
     """Download scan of a man's face.
 
@@ -525,7 +518,6 @@ def download_face2():
     url = "http://3dgallery.gks.com/2012/face/"
     filename, _ = _retrieve_file(url, 'man_face.stl')
     return pyvista.read(filename)
-
 
 def download_urn():
     """Download scan of a burial urn.
@@ -537,7 +529,6 @@ def download_urn():
     filename, _ = _retrieve_file(url, 'urn.stl')
     return pyvista.read(filename)
 
-
 def download_pepper():
     """Download scan of a pepper (capsicum).
 
@@ -547,7 +538,6 @@ def download_pepper():
     url = "http://3dgallery.gks.com/2012/redpepper/redpepper2.php"
     filename, _ = _retrieve_file(url, 'pepper.ply')
     return pyvista.read(filename)
-
 
 def download_drill():
     """Download scan of a power drill.
@@ -559,7 +549,6 @@ def download_drill():
     filename, _ = _retrieve_file(url, 'pepper.obj')
     return pyvista.read(filename)
 
-
 def download_action_figure():
     """Download scan of an action figure.
 
@@ -569,7 +558,6 @@ def download_action_figure():
     url = "http://3dgallery.gks.com/2013/tigerfighter"
     filename, _ = _retrieve_file(url, 'tigerfighter.obj')
     return pyvista.read(filename)
-
 
 def download_turbine_blade():
     """Download scan of a turbine blade.
@@ -581,26 +569,21 @@ def download_turbine_blade():
     filename, _ = _retrieve_file(url, 'turbine_blade.stl')
     return pyvista.read(filename)
 
-
 def download_pine_roots():
     """Download pine roots dataset."""
     return _download_and_read('pine_root.tri')
-
 
 def download_crater_topo():
     """Download crater dataset."""
     return _download_and_read('Ruapehu_mag_dem_15m_NZTM.vtk')
 
-
 def download_crater_imagery():
     """Download crater texture."""
     return _download_and_read('BJ34_GeoTifv1-04_crater_clip.tif', texture=True)
 
-
 def download_dolfin():
     """Download dolfin mesh."""
     return _download_and_read('dolfin_fine.xml', file_format="dolfin-xml")
-
 
 def download_damavand_volcano():
     """Download damavand volcano model."""
@@ -608,21 +591,17 @@ def download_damavand_volcano():
     volume.rename_array("None", "data")
     return volume
 
-
 def download_delaunay_example():
     """Download a pointset for the Delaunay example."""
     return _download_and_read('250.vtk')
-
 
 def download_embryo():
     """Download a volume of an embryo."""
     return _download_and_read('embryo.slc')
 
-
 def download_antarctica_velocity():
     """Download the antarctica velocity simulation results."""
     return _download_and_read("antarctica_velocity.vtp")
-
 
 def download_room_surface_mesh():
     """Download the room surface mesh.
@@ -634,16 +613,13 @@ def download_room_surface_mesh():
     """
     return _download_and_read("room_surface_mesh.obj")
 
-
 def download_beach():
     """Download the beach NRRD image."""
     return _download_and_read("beach.nrrd")
 
-
 def download_rgba_texture():
     """Download a texture with an alpha channel."""
     return _download_and_read("alphachannel.png", texture=True)
-
 
 def download_vtk_logo():
     """Download a texture of the VTK logo."""

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -9,6 +9,7 @@ import numpy as np
 import vtk
 
 import pyvista
+from pyvista.core.errors import DeprecationError
 
 # Helpers:
 
@@ -188,19 +189,23 @@ def download_iron_pot():  # pragma: no cover
     DEPRECATED: Please use ``download_iron_protein``.
 
     """
-    return self.view_isometric()
+    return DeprecationError('DEPRECATED: Please use ``download_iron_protein``')
+
 
 def download_iron_protein():
     """Download iron protein dataset."""
     return _download_and_read('ironProt.vtk')
 
+
 def download_tetrahedron():
     """Download tetrahedron dataset."""
     return _download_and_read('Tetrahedron.vtu')
 
+
 def download_saddle_surface():
     """Download saddle surface dataset."""
     return _download_and_read('InterpolatingOnSTL_final.stl')
+
 
 def download_sparse_points():
     """Download sparse points dataset.
@@ -222,49 +227,61 @@ def download_sparse_points():
     table_points.Update()
     return pyvista.wrap(table_points.GetOutput())
 
+
 def download_foot_bones():
     """Download foot bones dataset."""
     return _download_and_read('fsu/footbones.ply')
+
 
 def download_guitar():
     """Download guitar dataset."""
     return _download_and_read('fsu/stratocaster.ply')
 
+
 def download_quadratic_pyramid():
     """Download quadratic pyramid dataset."""
     return _download_and_read('QuadraticPyramid.vtu')
+
 
 def download_bird():
     """Download bird dataset."""
     return _download_and_read('Pileated.jpg')
 
+
 def download_bird_texture():
     """Download bird texture."""
     return _download_and_read('Pileated.jpg', texture=True)
+
 
 def download_office():
     """Download office dataset."""
     return _download_and_read('office.binary.vtk')
 
+
 def download_horse_points():
     """Download horse points dataset."""
     return _download_and_read('horsePoints.vtp')
+
 
 def download_horse():
     """Download horse dataset."""
     return _download_and_read('horse.vtp')
 
+
 def download_cake_easy():
     """Download cake dataset."""
     return _download_and_read('cake_easy.jpg')
+
 
 def download_cake_easy_texture():
     """Download cake texture."""
     return _download_and_read('cake_easy.jpg', texture=True)
 
+
 def download_rectilinear_grid():
     """Download rectilinear grid dataset."""
     return _download_and_read('RectilinearGrid.vtr')
+
 
 def download_gourds(zoom=False):
     """Download gourds dataset."""
@@ -272,31 +289,38 @@ def download_gourds(zoom=False):
         return _download_and_read('Gourds.png')
     return _download_and_read('Gourds2.jpg')
 
+
 def download_gourds_texture(zoom=False):
     """Download gourds texture."""
     if zoom:
         return _download_and_read('Gourds.png', texture=True)
     return _download_and_read('Gourds2.jpg', texture=True)
 
+
 def download_unstructured_grid():
     """Download unstructured grid dataset."""
     return _download_and_read('uGridEx.vtk')
+
 
 def download_letter_k():
     """Download letter k dataset."""
     return _download_and_read('k.vtk')
 
+
 def download_letter_a():
     """Download letter a dataset."""
     return _download_and_read('a_grid.vtk')
+
 
 def download_poly_line():
     """Download polyline dataset."""
     return _download_and_read('polyline.vtk')
 
+
 def download_cad_model():
     """Download cad dataset."""
     return _download_and_read('42400-IDGH.stl')
+
 
 def download_frog():
     """Download frog dataset."""
@@ -304,95 +328,118 @@ def download_frog():
     _download_file('froggy/frog.zraw')
     return _download_and_read('froggy/frog.mhd')
 
+
 def download_prostate():
     """Download prostate dataset."""
     return _download_and_read('prostate.img')
 
+
 def download_filled_contours():
     """Download filled contours dataset."""
     return _download_and_read('filledContours.vtp')
+
 
 def download_doorman():
     """Download doorman dataset."""
     # TODO: download textures as well
     return _download_and_read('doorman/doorman.obj')
 
+
 def download_mug():
     """Download mug dataset."""
     return _download_and_read('mug.e')
+
 
 def download_oblique_cone():
     """Download oblique cone dataset."""
     return _download_and_read('ObliqueCone.vtp')
 
+
 def download_emoji():
     """Download emoji dataset."""
     return _download_and_read('emote.jpg')
+
 
 def download_emoji_texture():
     """Download emoji texture."""
     return _download_and_read('emote.jpg', texture=True)
 
+
 def download_teapot():
     """Download teapot dataset."""
     return _download_and_read('teapot.g')
+
 
 def download_brain():
     """Download brain dataset."""
     return _download_and_read('brain.vtk')
 
+
 def download_structured_grid():
     """Download structured grid dataset."""
     return _download_and_read('StructuredGrid.vts')
+
 
 def download_structured_grid_two():
     """Download structured grid two dataset."""
     return _download_and_read('SampleStructGrid.vtk')
 
+
 def download_trumpet():
     """Download trumpet dataset."""
     return _download_and_read('trumpet.obj')
+
 
 def download_face():
     """Download face dataset."""
     # TODO: there is a texture with this
     return _download_and_read('fran_cut.vtk')
 
+
 def download_sky_box_nz():
     """Download skybox-nz dataset."""
     return _download_and_read('skybox-nz.jpg')
+
 
 def download_sky_box_nz_texture():
     """Download skybox-nz texture."""
     return _download_and_read('skybox-nz.jpg', texture=True)
 
+
 def download_disc_quads():
     """Download disc quads dataset."""
     return _download_and_read('Disc_BiQuadraticQuads_0_0.vtu')
+
 
 def download_honolulu():
     """Download honolulu dataset."""
     return _download_and_read('honolulu.vtk')
 
+
 def download_motor():
     """Download motor dataset."""
     return _download_and_read('motor.g')
+
 
 def download_tri_quadratic_hexahedron():
     """Download tri quadratic hexahedron dataset."""
     return _download_and_read('TriQuadraticHexahedron.vtu')
 
+
 def download_human():
     """Download human dataset."""
     return _download_and_read('Human.vtp')
+
 
 def download_vtk():
     """Download vtk dataset."""
     return _download_and_read('vtk.vtp')
 
+
 def download_spider():
     """Download spider dataset."""
     return _download_and_read('spider.ply')
+
 
 def download_carotid():
     """Download carotid dataset."""
@@ -401,29 +448,36 @@ def download_carotid():
     mesh.set_active_vectors('vectors')
     return mesh
 
+
 def download_blow():
     """Download blow dataset."""
     return _download_and_read('blow.vtk')
+
 
 def download_shark():
     """Download shark dataset."""
     return _download_and_read('shark.ply')
 
+
 def download_dragon():
     """Download dragon dataset."""
     return _download_and_read('dragon.ply')
+
 
 def download_armadillo():
     """Download armadillo dataset."""
     return _download_and_read('Armadillo.ply')
 
+
 def download_gears():
     """Download gears dataset."""
     return _download_and_read('gears.stl')
 
+
 def download_torso():
     """Download torso dataset."""
     return _download_and_read('Torso.vtp')
+
 
 def download_kitchen(split=False):
     """Download structured grid of kitchen with velocity field.
@@ -463,6 +517,7 @@ def download_kitchen(split=False):
         kitchen[key] = result
     return kitchen
 
+
 def download_tetra_dc_mesh():
     """Download two meshes defining an electrical inverse problem.
 
@@ -479,13 +534,16 @@ def download_tetra_dc_mesh():
     inv.set_active_scalars('Resistivity(log10)')
     return pyvista.MultiBlock({'forward':fwd, 'inverse':inv})
 
+
 def download_model_with_variance():
     """Download model with variance dataset."""
     return _download_and_read("model_with_variance.vtu")
 
+
 def download_thermal_probes():
     """Download thermal probes dataset."""
     return _download_and_read("probes.vtp")
+
 
 def download_carburator():
     """Download scan of a carburator.
@@ -497,6 +555,7 @@ def download_carburator():
     filename, _ = _retrieve_file(url, 'carburator.ply')
     return pyvista.read(filename)
 
+
 def download_woman():
     """Download scan of a woman.
 
@@ -506,6 +565,7 @@ def download_woman():
     url = "http://3dgallery.gks.com/2012/bodyscan/bodyscan3.php"
     filename, _ = _retrieve_file(url, 'woman.stl')
     return pyvista.read(filename)
+
 
 def download_lobster():
     """Download scan of a lobster.
@@ -517,6 +577,7 @@ def download_lobster():
     filename, _ = _retrieve_file(url, 'lobster.ply')
     return pyvista.read(filename)
 
+
 def download_face2():
     """Download scan of a man's face.
 
@@ -526,6 +587,7 @@ def download_face2():
     url = "http://3dgallery.gks.com/2012/face/"
     filename, _ = _retrieve_file(url, 'man_face.stl')
     return pyvista.read(filename)
+
 
 def download_urn():
     """Download scan of a burial urn.
@@ -537,6 +599,7 @@ def download_urn():
     filename, _ = _retrieve_file(url, 'urn.stl')
     return pyvista.read(filename)
 
+
 def download_pepper():
     """Download scan of a pepper (capsicum).
 
@@ -546,6 +609,7 @@ def download_pepper():
     url = "http://3dgallery.gks.com/2012/redpepper/redpepper2.php"
     filename, _ = _retrieve_file(url, 'pepper.ply')
     return pyvista.read(filename)
+
 
 def download_drill():
     """Download scan of a power drill.
@@ -557,6 +621,7 @@ def download_drill():
     filename, _ = _retrieve_file(url, 'pepper.obj')
     return pyvista.read(filename)
 
+
 def download_action_figure():
     """Download scan of an action figure.
 
@@ -566,6 +631,7 @@ def download_action_figure():
     url = "http://3dgallery.gks.com/2013/tigerfighter"
     filename, _ = _retrieve_file(url, 'tigerfighter.obj')
     return pyvista.read(filename)
+
 
 def download_turbine_blade():
     """Download scan of a turbine blade.
@@ -577,21 +643,26 @@ def download_turbine_blade():
     filename, _ = _retrieve_file(url, 'turbine_blade.stl')
     return pyvista.read(filename)
 
+
 def download_pine_roots():
     """Download pine roots dataset."""
     return _download_and_read('pine_root.tri')
+
 
 def download_crater_topo():
     """Download crater dataset."""
     return _download_and_read('Ruapehu_mag_dem_15m_NZTM.vtk')
 
+
 def download_crater_imagery():
     """Download crater texture."""
     return _download_and_read('BJ34_GeoTifv1-04_crater_clip.tif', texture=True)
 
+
 def download_dolfin():
     """Download dolfin mesh."""
     return _download_and_read('dolfin_fine.xml', file_format="dolfin-xml")
+
 
 def download_damavand_volcano():
     """Download damavand volcano model."""
@@ -599,17 +670,21 @@ def download_damavand_volcano():
     volume.rename_array("None", "data")
     return volume
 
+
 def download_delaunay_example():
     """Download a pointset for the Delaunay example."""
     return _download_and_read('250.vtk')
+
 
 def download_embryo():
     """Download a volume of an embryo."""
     return _download_and_read('embryo.slc')
 
+
 def download_antarctica_velocity():
     """Download the antarctica velocity simulation results."""
     return _download_and_read("antarctica_velocity.vtp")
+
 
 def download_room_surface_mesh():
     """Download the room surface mesh.
@@ -621,17 +696,21 @@ def download_room_surface_mesh():
     """
     return _download_and_read("room_surface_mesh.obj")
 
+
 def download_beach():
     """Download the beach NRRD image."""
     return _download_and_read("beach.nrrd")
+
 
 def download_rgba_texture():
     """Download a texture with an alpha channel."""
     return _download_and_read("alphachannel.png", texture=True)
 
+
 def download_vtk_logo():
     """Download a texture of the VTK logo."""
     return _download_and_read("vtk.png", texture=True)
+
 
 def download_backward_facing_step():
     """Download an ensight gold case of a fluid simulation."""
@@ -639,14 +718,15 @@ def download_backward_facing_step():
     filename = os.path.join(folder, "foam_case_0_0_0_0.case")
     return pyvista.read(filename)
 
+
 def download_gpr_data_array():
     """Download GPR example data array."""
     saved_file, _ = _download_file("gpr-example/data.npy")
     return np.load(saved_file)
+
 
 def download_gpr_path():
     """Download GPR example path."""
     saved_file, _ = _download_file("gpr-example/path.txt")
     path = np.loadtxt(saved_file, skiprows=1)
     return pyvista.PolyData(path)
-

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -189,7 +189,7 @@ def download_iron_pot():  # pragma: no cover
     DEPRECATED: Please use ``download_iron_protein``.
 
     """
-    return DeprecationError('DEPRECATED: Please use ``download_iron_protein``')
+    raise DeprecationError('DEPRECATED: Please use ``download_iron_protein``')
 
 
 def download_iron_protein():

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -182,7 +182,7 @@ def download_blood_vessels():
     mesh.set_active_vectors('velocity')
     return mesh
 
-def download_iron_pot():
+def download_iron_pot():  # pragma: no cover
     """Download iron protein dataset.
 
     DEPRECATED: Please use ``download_iron_protein``.

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -164,8 +164,8 @@ if TEST_DOWNLOADS:
         assert data.n_cells
 
 
-    def test_download_iron_pot():
-        data = examples.download_iron_pot()
+    def test_download_iron_protein():
+        data = examples.download_iron_protein()
         assert data.n_cells
 
 


### PR DESCRIPTION
### Overview

I bumped into a few issues with the downloaded examples. Almost all of them are docstring bugs, but there's also a change in the name of one of the examples.

### Details

  1. Some functions had docstrings copied over from other examples; I've updated these to something more meaningful.
  2. I replaced the mix of single- and double-empty-lines between example functions to uniform single ones (this is a separate commit, should it be deemed harmful or unnecessary).
  3. I noticed that there was an example called `download_iron_pot` the docstring of which referred to an iron pot. Suspiciously the data file is called `ironProt.vtk`. Upon closer inspection the vtk file bears the comment "Iron protein". I've replaced the function with `download_iron_protein` and wrote a "DEPRECATED" note in the docstring of the old, misnamed function (there are no internal uses of this example except for a dummy test, which I've also changed accordingly).

---

This last one brings me to a further note: it would be nice if we could show a minimal reasonable use for each of the example datasets, unless these are meant for internal use only. A lot of the datasets "work" with just loading the data and calling `.plot()` on them, but some (such as the "iron pot" example) are trickier. I think the new "demo" section could have an overlap with this, but not entirely: there are just too many examples.

For instance for the iron protein this could be something like
```
import pyvista as pv
import pyvista.examples

dat = pv.examples.download_iron_protein()

plotter = pyvista.Plotter()
plotter.add_volume(dat)
plotter.add_bounding_box()
plotter.show()
```
resulting in
![tmp](https://user-images.githubusercontent.com/17914410/98944538-7bf05b80-24f1-11eb-9497-45b8a64c6018.png)
