### PR TITLE
Remove Alpha Channel on Image Regression

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1347,11 +1347,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
             if not is_pyvista_dataset(mesh):
                 raise TypeError(f'Object type ({type(mesh)}) not supported for plotting in PyVista.')
 
-        try:  # attempt a shallow copy to avoid side effects
-            mesh = mesh.copy(deep=False)
-        except:
-            log.error('Unable to copy type `%s`', str(type(mesh)))
-
         ##### Parse arguments to be used for all meshes #####
 
         if scalar_bar_args is None:

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1345,8 +1345,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if not is_pyvista_dataset(mesh):
             mesh = wrap(mesh)
             if not is_pyvista_dataset(mesh):
-                raise TypeError(f'Object type ({type(mesh)}) not supported for plotting in PyVista.')
-
+                raise TypeError(f'Object type ({type(mesh)}) not supported for plotting in PyVista.'
+)
         ##### Parse arguments to be used for all meshes #####
 
         if scalar_bar_args is None:

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1344,6 +1344,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
         # Convert the VTK data object to a pyvista wrapped object if necessary
         if not is_pyvista_dataset(mesh):
             mesh = wrap(mesh)
+            try:  # attempt a shallow copy
+                mesh = mesh.copy(deep=False)
+            except:
+                log.error('Unable to copy type `%s`', str(type(mesh)))
             if not is_pyvista_dataset(mesh):
                 raise TypeError(f'Object type ({type(mesh)}) not supported for plotting in PyVista.')
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1344,12 +1344,13 @@ class BasePlotter(PickingHelper, WidgetHelper):
         # Convert the VTK data object to a pyvista wrapped object if necessary
         if not is_pyvista_dataset(mesh):
             mesh = wrap(mesh)
-            try:  # attempt a shallow copy
-                mesh = mesh.copy(deep=False)
-            except:
-                log.error('Unable to copy type `%s`', str(type(mesh)))
             if not is_pyvista_dataset(mesh):
                 raise TypeError(f'Object type ({type(mesh)}) not supported for plotting in PyVista.')
+
+        try:  # attempt a shallow copy to avoid side effects
+            mesh = mesh.copy(deep=False)
+        except:
+            log.error('Unable to copy type `%s`', str(type(mesh)))
 
         ##### Parse arguments to be used for all meshes #####
 

--- a/pyvista/utilities/regression.py
+++ b/pyvista/utilities/regression.py
@@ -5,7 +5,7 @@ import numpy as np
 
 
 def remove_alpha(img):
-    """Remove the alpha channel"""
+    """Remove the alpha channel from ``vtk.vtkImageData``."""
     ec = vtk.vtkImageExtractComponents()
     ec.SetComponents(0, 1, 2)
     ec.SetInputData(img)

--- a/pyvista/utilities/regression.py
+++ b/pyvista/utilities/regression.py
@@ -4,6 +4,14 @@ from vtk.util.numpy_support import numpy_to_vtk, vtk_to_numpy
 import numpy as np
 
 
+def remove_alpha(img):
+    """Remove the alpha channel"""
+    ec = vtk.vtkImageExtractComponents()
+    ec.SetComponents(0, 1, 2)
+    ec.SetInputData(img)
+    return ec.GetOutput()
+
+
 def wrap_image_array(arr):
     """Wrap a numpy array as a pyvista.UniformGrid.
 
@@ -120,8 +128,11 @@ def compare_images(im1, im2, threshold=1, use_vtk=True):
             raise TypeError(f'Unsupported data type {type(img)}.  Should be '
                             'Either a np.ndarray, vtkRenderWindow, or vtkImageData')
 
-    im1 = to_img(im1)
-    im2 = to_img(im2)
+    im1 = remove_alpha(to_img(im1))
+    im2 = remove_alpha(to_img(im2))
+
+    if im1.GetDimensions() != im2.GetDimensions():
+        raise RuntimeError('Input images %s and %s are not of equal size.')
 
     if use_vtk:
         img_diff = vtk.vtkImageDifference()
@@ -134,7 +145,5 @@ def compare_images(im1, im2, threshold=1, use_vtk=True):
         return img_diff.GetError()
 
     # otherwise, simply compute the mean pixel difference
-    if im1.shape != im2.shape:
-        raise RuntimeError('Image shapes do not match')
     diff = np.abs(im1.point_arrays[0] - im2.point_arrays[0])
     return np.sum(diff) / im1.point_arrays[0].shape[0]


### PR DESCRIPTION
In some cases, images being compared in ``pyvista`` contain alpha channels.  This PR corrects ``compare_images`` by always removing alpha channels as they are incompatible with `vtkImageDifference`.
