### PR TITLE
Force Close Window on VTK9

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2797,7 +2797,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
         disp_id = self.ren_win.GetGenericDisplayId()
         if disp_id:
             cdisp_id = ctypes.c_size_t(int(disp_id[1:].split('_')[0], 16))
-            X11.XCloseDisplay(cdisp_id)
+            # thread this as it take time and we don't need to wait
+            Thread(target=X11.XCloseDisplay, args=(cdisp_id, )).start()
 
     def deep_clean(self):
         """Clean the plotter of the memory."""

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2782,7 +2782,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self._closed = True
 
     def _kill_display(self):
-        """Forcibly closet the display on Linux
+        """Forcibly close the display on Linux.
 
         See:
         https://gitlab.kitware.com/vtk/vtk/-/issues/17917#note_783584


### PR DESCRIPTION
Many thanks to @adeak, we've figured out how to close the render windows on VTK9.

Rather than wait for the next wheel to come out (which might take another year), this PR proposes closing the render window using a ctypes interface to libX11 with:

```py
X11 = ctypes.CDLL("libX11.so")
``

Turns out you can handily close the display with ``XCloseDisplay`` provided that you have the DisplayID from the VTK render window.  Fortunately, VTK provides this in ``vtkRenderWindow.GetGenericDisplayId``.  @adeak was able to discover that you have to pass this as a ``ctypes.c_size_t``.  There's even an embrassing [SO question](https://stackoverflow.com/questions/64811503/python-memory-addresses-variation-across-python-3-5-3-9-on-linux/64814361#64814361) where I get schooled on python memory management.

This is only implemented for linux and VTK>=9.0, and docs/tests build just fine.  I'd really like this out for a 0.27.3 patch release.
