### PR TITLE
Fix `add_arrows`

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3322,7 +3322,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> cent = np.random.random((10, 3))
         >>> direction = np.random.random((10, 3))
         >>> plotter = pyvista.Plotter()
-        >>> _ = plotter.add_arrows(cent, direction)
+        >>> _ = plotter.add_arrows(cent, direction, mag=2)
         >>> plotter.show()  # doctest:+SKIP
 
         """
@@ -3337,9 +3337,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             direction = direction.reshape((-1, 3))
 
         if mag != 1:
-            direction[:, 0] *= mag
-            direction[:, 1] *= mag
-            direction[:, 2] *= mag
+            direction = direction*mag
 
         pdata = pyvista.vector_poly_data(cent, direction)
         # Create arrow object
@@ -3352,7 +3350,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         glyph3D.Update()
 
         arrows = wrap(glyph3D.GetOutput())
-
         return self.add_mesh(arrows, **kwargs)
 
     @staticmethod

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -564,7 +564,6 @@ def test_plot_arrows():
     pyvista.plot_arrows(cent, direction, before_close_callback=verify_cache_image)
 
 
-
 @skip_no_plotting
 def test_add_arrows():
     vector = np.array([1, 0, 0])

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -564,6 +564,16 @@ def test_plot_arrows():
     pyvista.plot_arrows(cent, direction, before_close_callback=verify_cache_image)
 
 
+
+@skip_no_plotting
+def test_add_arrows():
+    vector = np.array([1, 0, 0])
+    center = np.array([0, 0, 0])
+    plotter = pyvista.Plotter()
+    plotter.add_arrows(cent=center, direction=vector, mag=2.2, color="#009900")
+    plotter.show(before_close_callback=verify_cache_image)
+
+
 @skip_no_plotting
 def test_axes():
     plotter = pyvista.Plotter()


### PR DESCRIPTION
### Overview

Magnitude adjustment for arrows shouldn't be in-place in the `add_arrows` method for two reasons.  First, as noted in #1010, if we multiply an int array by a float `numpy` raises an error.  Second, it's a bad side effect to have the direction array modified in-place.

Resolves #1010
