### PR TITLE
fix/threshold args

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -619,6 +619,10 @@ class DataSetFilters:
             field, scalars = dataset.active_scalars_info
         arr, field = get_array(dataset, scalars, preference=preference, info=True)
 
+        if all_scalars and scalars is not None:
+            raise ValueError('Setting `all_scalars=True` and designating `scalars` '
+                             'is incompatible.  Set one or the other but not both')
+
         if arr is None:
             raise ValueError('No arrays present to threshold.')
 

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -565,7 +565,7 @@ class DataSetFilters:
         return output
 
     def threshold(dataset, value=None, scalars=None, invert=False, continuous=False,
-                  preference='cell', all_scalars=True):
+                  preference='cell', all_scalars=False):
         """Apply a ``vtkThreshold`` filter to the input dataset.
 
         This filter will apply a ``vtkThreshold`` filter to the input dataset

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -242,7 +242,9 @@ def test_threshold():
     dataset = examples.load_uniform()
     with pytest.raises(ValueError):
         dataset.threshold([10, 100, 300])
-
+    with pytest.raises(ValueError):
+        DATASETS[0].threshold([10, 500], scalars='Spatial Point Data',
+                              all_scalars=True)
 
 def test_threshold_percent():
     percents = [25, 50, [18.0, 85.0], [19.0, 80.0], 0.70]


### PR DESCRIPTION
### Overview
Set the default threshold filter parameter `all_scalars` to `False` to resolve #1013.  This PR also adds a helpful error message when attempting to set incompatible parameters.

NOTE: Include this in the 0.27.3 release.
