### PR TITLE
use pypandoc for better jupyter notebooks from the gallery

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,6 +107,8 @@ todo_include_todos = False
 from sphinx_gallery.sorting import FileNameSortKey
 
 sphinx_gallery_conf = {
+    # convert rst to md for ipynb
+    'pypandoc': True,
     # path to your examples scripts
     "examples_dirs": ["../examples/"],
     # path where to save gallery generated examples

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -12,7 +12,8 @@ sphinxcontrib-websupport
 pytest-sphinx
 sphinx-notfound-page>=0.3.0
 sphinx-copybutton
-sphinx-gallery>=0.4.0
+sphinx-gallery>=0.8.1
 lxml
 trimesh
 vtk==8.1.2  # needed because 9.0.X has an issue with the plotter closing with iren
+pypandoc


### PR DESCRIPTION
## Use ``pypandoc``

The sphinx gallery within ``pyvista``'s doc build generates notebooks from the rst formatted python scripts within ``examples/``, but these notebooks must have the original rst formatted sections converted to markdown.  As it turns out, sphinx gallery only has limited support for converting rst to markdown, as noted [here](https://sphinx-gallery.github.io/stable/configuration.html#using-pypandoc-to-convert-rst-to-markdown).  It's recommended to use ``pypandoc`` for better conversions.

This PR adds `pypandoc` support within the documentation builds.  It's not a huge improvement, but it's signifiant and removes a bunch of ugly formatting issues.


### This Branch
![image](https://user-images.githubusercontent.com/11981631/99322693-bfb6ce00-282d-11eb-8a79-92096f518e36.png)

---

### Current docs 
![image](https://user-images.githubusercontent.com/11981631/99322730-d65d2500-282d-11eb-9f06-e7bcf2dd5714.png)
