### PR TITLE
Add parallel projection and parallel scale properties to Renderer and BasePlotter

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -497,6 +497,26 @@ class BasePlotter(PickingHelper, WidgetHelper):
         """Wrap ``Renderer.disable_parallel_projection``."""
         return self.renderer.disable_parallel_projection(*args, **kwargs)
 
+    @property
+    def parallel_projection(self):
+        """Return parallel projection state of active render window."""
+        return self.renderer.parallel_projection
+
+    @parallel_projection.setter
+    def parallel_projection(self, state):
+        """Set parallel projection state of all active render windows."""
+        self.renderer.parallel_projection = state
+
+    @property
+    def parallel_scale(self):
+        """Return parallel scale of active render window."""
+        return self.renderer.parallel_scale
+
+    @parallel_scale.setter
+    def parallel_scale(self, value):
+        """Set parallel scale of all active render windows."""
+        self.renderer.parallel_scale = value
+
     @wraps(Renderer.add_axes_at_origin)
     def add_axes_at_origin(self, *args, **kwargs):
         """Wrap ``Renderer.add_axes_at_origin``."""

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1119,6 +1119,28 @@ class Renderer(vtkRenderer):
         self.camera.SetParallelProjection(False)
         self.Modified()
 
+    @property
+    def parallel_projection(self):
+        """Return parallel projection state of active render window."""
+        return bool(self.camera.GetParallelProjection())
+
+    @parallel_projection.setter
+    def parallel_projection(self, state):
+        """Set parallel projection state of all active render windows."""
+        self.camera.SetParallelProjection(state)
+        self.Modified()
+
+    @property
+    def parallel_scale(self):
+        """Return parallel scale of active render window."""
+        return self.camera.GetParallelScale()
+
+    @parallel_scale.setter
+    def parallel_scale(self, value):
+        """Set parallel scale of all active render windows."""
+        self.camera.SetParallelScale(value)
+        self.Modified()
+
     def remove_actor(self, actor, reset_camera=False, render=True):
         """Remove an actor from the Renderer.
 

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -264,7 +264,35 @@ def test_set_camera_position_invalid(cpos, sphere):
     with pytest.raises(pyvista.core.errors.InvalidCameraError):
         plotter.camera_position = cpos
 
+@skip_no_plotting
+def test_parallel_projection():
+    plotter = pyvista.Plotter()
+    assert isinstance(plotter.parallel_projection, bool)
 
+@skip_no_plotting
+@pytest.mark.parametrize("state", [True, False])
+def test_set_parallel_projection(state):
+    plotter = pyvista.Plotter()
+    plotter.parallel_projection = state
+    assert plotter.parallel_projection == state
+
+@skip_no_plotting
+def test_parallel_scale():
+    plotter = pyvista.Plotter()
+    assert isinstance(plotter.parallel_scale, float)
+
+@skip_no_plotting
+@pytest.mark.parametrize("value", [1, 1.5, 0.3, 10])
+def test_set_parallel_scale(value):
+    plotter = pyvista.Plotter()
+    plotter.parallel_scale = value
+    assert plotter.parallel_scale == value
+
+@skip_no_plotting
+def test_set_parallel_scale_invalid():
+    plotter = pyvista.Plotter()
+    with pytest.raises(TypeError):
+        plotter.parallel_scale = "invalid"
 
 @skip_no_plotting
 def test_plot_no_active_scalars():


### PR DESCRIPTION
### Overview

Currently, there are functions to enable/disable parallel projection, but there is no native interface to view the current state or to view/set the parallel scale. These can be accessed using VTK functions through the camera object, but that is not documented.

This adds parallel_projection and parallel_scale as properties that can be accessed and edited similarly to the camera_position property.

With this change, the existing enable/disable functions become redundant, but there is no harm in leaving them in place for backward compatibility.

will resolve https://github.com/pyvista/pyvista-support/issues/207