### PR TITLE
Revert "Force Close Window on VTK9"

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1,7 +1,5 @@
 """Pyvista plotting module."""
 
-import platform
-import ctypes
 import pathlib
 import collections.abc
 from functools import partial
@@ -43,14 +41,10 @@ try:
 except ImportError:
     has_matplotlib = False
 
-VTK9 = vtk.vtkVersion().GetVTKMajorVersion() >= 9
-
 _ALL_PLOTTERS = {}
 
 SUPPORTED_FORMATS = [".png", ".jpeg", ".jpg", ".bmp", ".tif", ".tiff"]
 
-if VTK9 and platform.system() == 'Linux':
-    X11 = ctypes.CDLL("libX11.so")
 
 def close_all():
     """Close all open/active plotters and clean up memory."""
@@ -2740,8 +2734,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         """Clear the render window."""
         if hasattr(self, 'ren_win'):
             self.ren_win.Finalize()
-            if VTK9 and platform.system() == 'Linux':
-                self._kill_display()
             del self.ren_win
 
     def close(self, render=False):
@@ -2777,7 +2769,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         # reset scalar bar stuff
         self.clear()
 
-        # grab the display id before clearing the window
         self._clear_ren_win()
 
         self._style_class = None
@@ -2803,25 +2794,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         # this helps managing closed plotters
         self._closed = True
-
-    def _kill_display(self):
-        """Forcibly close the display on Linux.
-
-        See:
-        https://gitlab.kitware.com/vtk/vtk/-/issues/17917#note_783584
-
-        And more details into why...
-        https://stackoverflow.com/questions/64811503
-
-        """ 
-        if platform.system() != 'Linux':
-            raise OSError('This method only works on Linux')
-
-        disp_id = self.ren_win.GetGenericDisplayId()
-        if disp_id:
-            cdisp_id = ctypes.c_size_t(int(disp_id[1:].split('_')[0], 16))
-            # thread this as it take time and we don't need to wait
-            Thread(target=X11.XCloseDisplay, args=(cdisp_id, )).start()
 
     def deep_clean(self):
         """Clean the plotter of the memory."""


### PR DESCRIPTION
Reverts pyvista/pyvista#1007 due to some exciting segmentation faults.

In response to comments from @larsoner:
https://github.com/pyvista/pyvista/pull/1007#issuecomment-729933336

Would be awesome if we could get a patch for this that works without murdering the x server.