### PR TITLE
BUG: Close file

### DIFF
--- a/pyvista/utilities/cell_type_helpers/cell_selector.py
+++ b/pyvista/utilities/cell_type_helpers/cell_selector.py
@@ -26,8 +26,8 @@ def generate_all_cell_types():
   """
   # Using readlines()
   current_dir = os.path.dirname(__file__)
-  cell_type_f = open(current_dir + '/vtk_cell_types.txt', 'r')
-  lines = cell_type_f.readlines()
+  with open(current_dir + '/vtk_cell_types.txt', 'r') as cell_type_f:
+    lines = cell_type_f.readlines()
 
   # Strips the newline character
   for line in lines:


### PR DESCRIPTION
Takes care of warnings of the form:
```
mne/viz/tests/test_3d.py::test_plot_sparse_source_estimates[pyvista]
  /home/larsoner/python/pyvista/pyvista/utilities/cell_type_helpers/cell_selector.py:106: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/larsoner/python/pyvista/pyvista/utilities/cell_type_helpers/vtk_cell_types.txt' mode='r' encoding='UTF-8'>
    generate_all_cell_types()
```
