### PR TITLE
patched edge case for empty mesh

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2170,9 +2170,10 @@ class DataSetFilters:
         subgrid = _get_output(extract_sel)
 
         # extracts only in float32
-        if dataset.points.dtype is not np.dtype('float32'):
-            ind = subgrid.point_arrays['vtkOriginalPointIds']
-            subgrid.points = dataset.points[ind]
+        if subgrid.n_points:
+            if dataset.points.dtype is not np.dtype('float32'):
+                ind = subgrid.point_arrays['vtkOriginalPointIds']
+                subgrid.points = dataset.points[ind]
 
         return subgrid
 


### PR DESCRIPTION
This PR patches an edge case where empty meshes from ``extract_cells`` raise a key error rather than simply returning an empty mesh.
