### PR TITLE
Add missing no_itk skip to itk polydata point plotting test

### DIFF
--- a/tests/test_itk_plotting.py
+++ b/tests/test_itk_plotting.py
@@ -37,6 +37,7 @@ def test_itk_plotting_points():
     assert isinstance(viewer, itkwidgets.Viewer)
 
 
+@no_itk
 def test_itk_plotting_points_polydata():
     points = pyvista.wrap(np.random.random((100, 3)))
     viewer = pyvista.plot_itk(points)


### PR DESCRIPTION
One of the itk plotting tests is missing the `@no_itk` decorator. The test will fail on an install without `itk` (that's how I've found this), but it should be skipped instead.