### PR TITLE
force rewrite faces when flipping normals

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -4129,6 +4129,7 @@ class PolyDataFilters(DataSetFilters):
 
         f = poly_data.faces.reshape((-1, 4))
         f[:, 1:] = f[:, 1:][:, ::-1]
+        poly_data.faces = f
 
     def delaunay_2d(poly_data, tol=1e-05, alpha=0.0, offset=1.0, bound=False,
                     inplace=False, edge_source=None, progress_bar=False):

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -692,9 +692,7 @@ def test_flip_normals(sphere):
     sphere_flipped = sphere.copy()
     sphere_flipped.flip_normals()
 
-
-    # TODO: Check why this fails on Mac OS and Windows on Azure
-    # sphere.compute_normals(inplace=True)
-    # sphere_flipped.compute_normals(inplace=True)
-    # assert np.allclose(sphere_flipped.point_arrays['Normals'],
-    #                    -sphere.point_arrays['Normals'])
+    sphere.compute_normals(inplace=True)
+    sphere_flipped.compute_normals(inplace=True)
+    assert np.allclose(sphere_flipped.point_arrays['Normals'],
+                       -sphere.point_arrays['Normals'])


### PR DESCRIPTION
### Overview

While testing `pyvista` on `vtk==9.0.1` on linux, it became apparent that `flip_normals` wasn't functioning as in ``vtk==8.1.2``.  The problem is that the face array isn't a view but a copy of the underlying array and attempting to update it in-place doesn't work.  Simple test to deomonstrate on ``vtk==9.0.1``:

```py
>>> import pyvista
>>> mesh = pyvista.Sphere()
>>> orig_value = mesh.faces[1]
>>> mesh.faces[1] += 1
>>> print(orig_value, mesh.faces[1])
2 2
```

In this example, attempting to update `mesh.faces` does nothing because the array `mesh.faces` is a copy of the underlying array from `mesh.GetPolys().GetData()`.

Interesting enough, we detected this problem some time ago but failed to correct it on Windows and Mac OS.  This PR corrects this flaw.


