### PR TITLE
Fix UnstructuredGrid init from arrays for VTK 8.90

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -697,7 +697,7 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
     def cell_connectivity(self):
         """Return a the vtk cell connectivity as a numpy array."""
         carr = self.GetCells()
-        if hasattr(carr, 'GetConnectivityArray'):  # available >= VTK9
+        if VTK9:
             return vtk_to_numpy(carr.GetConnectivityArray())
         raise AttributeError('Install vtk>=9.0.0 for `cell_connectivity`\n'
                              'Otherwise, use the legacy `cells` method')
@@ -788,7 +788,7 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
     def offset(self):
         """Get cell locations Array."""
         carr = self.GetCells()
-        if hasattr(carr, 'GetOffsetsArray'):  # available >= VTK9
+        if VTK9:
             # This will be the number of cells + 1.
             return vtk_to_numpy(carr.GetOffsetsArray())
         else:  # this is no longer used in >= VTK9

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -47,6 +47,47 @@ def test_init_from_unstructured(hexbeam):
     assert not np.any(grid.points == hexbeam.points)
 
 
+def test_init_from_numpy_arrays():
+    offset = np.array([0, 9])
+    cells = [
+        [8, 0, 1, 2, 3, 4, 5, 6, 7],
+        [8, 8, 9, 10, 11, 12, 13, 14, 15]
+    ]
+    cells = np.array(cells).ravel()
+    cell_type = np.array([vtk.VTK_HEXAHEDRON, vtk.VTK_HEXAHEDRON])
+    cell1 = np.array(
+        [
+            [0, 0, 0],
+            [1, 0, 0],
+            [1, 1, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            [1, 0, 1],
+            [1, 1, 1],
+            [0, 1, 1],
+        ]
+    )
+
+    cell2 = np.array(
+        [
+            [0, 0, 2],
+            [1, 0, 2],
+            [1, 1, 2],
+            [0, 1, 2],
+            [0, 0, 3],
+            [1, 0, 3],
+            [1, 1, 3],
+            [0, 1, 3],
+        ]
+    )
+
+    points = np.vstack((cell1, cell2))
+    grid = pyvista.UnstructuredGrid(offset, cells, cell_type, points)
+
+    assert grid.number_of_points == 16
+    assert grid.number_of_cells == 2
+
+
 def test_init_bad_input():
     with pytest.raises(TypeError):
         unstruct_grid = pyvista.UnstructuredGrid(np.array(1))


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Resolves #1036 for VTK 8.90, an unofficial version of VTK which comes bundled with ParaView 5.8.1

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details
Rather than using `hasattr` to effectively detect `VTK9` within `UnstructuredGrid.cell_connectivity` and `UnstructuredGrid.offset`, just use top level `VTK9` variable. Also adds a test for building initializing `UnstructuredGrid` from arrays.
