### PR TITLE
Fixed disk geometry to rotate and translate properly

### DIFF
--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -499,7 +499,7 @@ def Polygon(center=(0.,0.,0.), radius=1, normal=(0,0,1), n_sides=6):
     return pyvista.wrap(src.GetOutput())
 
 
-def Disc(center=(0.,0.,0.), inner=0.25, outer=0.5, normal=(0,0,1), r_res=1,
+def Disc(center=(0., 0., 0.), inner=0.25, outer=0.5, normal=(0, 0, 1), r_res=1,
          c_res=6):
     """Create a polygonal disk with a hole in the center.
 
@@ -537,7 +537,7 @@ def Disc(center=(0.,0.,0.), inner=0.25, outer=0.5, normal=(0,0,1), r_res=1,
     normal = np.array(normal)
     center = np.array(center)
     surf = pyvista.PolyData(src.GetOutput())
-    surf.rotate_y(-90)
+    surf.rotate_y(90)
     translate(surf, center, normal)
     return surf
 

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -534,26 +534,12 @@ def Disc(center=(0.,0.,0.), inner=0.25, outer=0.5, normal=(0,0,1), r_res=1,
     src.SetRadialResolution(r_res)
     src.SetCircumferentialResolution(c_res)
     src.Update()
-
-    default_normal = np.array([0, 0, 1])
     normal = np.array(normal)
     center = np.array(center)
-
-    axis = np.cross(default_normal, normal)
-    angle = np.rad2deg(np.arccos(
-        np.clip(np.dot(normal, default_normal), -1, 1)))
-
-    transform = vtk.vtkTransform()
-    transform.Translate(-center)
-    transform.RotateWXYZ(angle, axis)
-    transform.Translate(center)
-
-    transform_filter = vtk.vtkTransformFilter()
-    transform_filter.SetInputConnection(src.GetOutputPort())
-    transform_filter.SetTransform(transform)
-    transform_filter.Update()
-
-    return pyvista.wrap(transform_filter.GetOutput())
+    surf = pyvista.PolyData(src.GetOutput())
+    surf.rotate_y(-90)
+    translate(surf, center, normal)
+    return surf
 
 
 def Text3D(string, depth=0.5):


### PR DESCRIPTION
### Overview
A simple change to the Disk object creation (in geometric_objects.py) following the notation used for a sphere. The issue is explained in #315

### Details
The disk object is created and sent directly to `translate()` with the `center` and `normal` inputs. The rotation_y argument seems to be necessary to align the object along the x axis, as needed by the translate function.

