### PR TITLE
Creating an explicit structured grid

### DIFF
--- a/examples/00-load/create-explicit-structured-grid.py
+++ b/examples/00-load/create-explicit-structured-grid.py
@@ -1,0 +1,82 @@
+"""
+.. _ref_create_explicit_structured_grid:
+
+Creating an Explicit Structured Grid
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create an explicit structured grid from NumPy arrays:
+
+"""
+import numpy as np
+import pyvista as pv
+
+"""
+Algorithm for corners ordering:
+
+>>> for w in {'x', 'y', 'z'} do {
+>>>     for k from 1 until nk do {
+>>>         for j from 1 until nj do {
+>>>             for i from 1 until ni do {
+>>>                 write (0,0,0) and (1,0,0) w-coordinate values
+>>>                 for block (i,j,k)
+>>>             }
+>>>             for i from 1 until ni do {
+>>>                 write (1,0,0) and (1,1,0) w-coordinate values
+>>>                 for block (i,j,k)
+>>>             }
+>>>         }
+>>>         for j from 1 until nj do {
+>>>             for i from 1 until ni do {
+>>>                 write (0,0,1) and (0,1,1) w-coordinate values
+>>>                 for block (i,j,k)
+>>>             }
+>>>             for i from 1 until ni do {
+>>>                 write (1,0,1) and (1,1,1) w-coordinate values
+>>>                 for block (i,j,k)
+>>>             }
+>>>         }
+>>>     }
+>>> }
+
+where (ni, nj, nk) is the number of grid blocks in the I, J and K directions
+respectively.
+
+"""
+corners = '''
+0 100 100 200 200 300 300 400
+0 100 100 200 200 300 300 400
+0 100 100 200 200 300 300 400
+0 100 100 200 200 300 300 400
+0 100 100 200 200 300 300 400
+0 100 100 200 200 300 300 400
+0 100 100 200 200 300 300 400
+0 100 100 200 200 300 300 400
+
+0 0 0 0 0 0 0 0
+200 200 200 200 200 200 200 200
+200 200 200 200 200 200 200 200
+400 400 400 400 400 400 400 400
+0 0 0 0 0 0 0 0
+200 200 200 200 200 200 200 200
+200 200 200 200 200 200 200 200
+400 400 400 400 400 400 400 400
+
+2000 2001 2001 2002 2002 2003 2003 2004
+2000 2001 2001 2002 2002 2003 2003 2004
+2000 2001 2001 2002 2002 2003 2003 2004
+2000 2001 2001 2002 2002 2003 2003 2004
+2010 2011 2011 2012 2012 2013 2013 2014
+2010 2011 2011 2012 2012 2013 2013 2014
+2010 2011 2011 2012 2012 2013 2013 2014
+2010 2011 2011 2012 2012 2013 2013 2014
+'''
+corners = corners.split()
+
+points = np.asarray(corners, np.int)
+points = points.reshape((3, -1))
+points = points.transpose()
+
+dims = (5, 3, 2)
+grid = pv.ExplicitStructuredGrid(dims, points)
+grid.hide_cells((0, 7))
+grid.plot(color='w', show_edges=True)

--- a/examples/00-load/create-explicit-structured-grid.py
+++ b/examples/00-load/create-explicit-structured-grid.py
@@ -13,32 +13,32 @@ import pyvista as pv
 """
 Algorithm for corners ordering:
 
->>> for w in {'x', 'y', 'z'} do {
+>>> for ? in {x, y, z} do {
 >>>     for k from 1 until nk do {
 >>>         for j from 1 until nj do {
 >>>             for i from 1 until ni do {
->>>                 write (0,0,0) and (1,0,0) w-coordinate values
+>>>                 write (0,0,0) and (1,0,0) ?-coordinate values
 >>>                 for block (i,j,k)
 >>>             }
 >>>             for i from 1 until ni do {
->>>                 write (1,0,0) and (1,1,0) w-coordinate values
+>>>                 write (1,0,0) and (1,1,0) ?-coordinate values
 >>>                 for block (i,j,k)
 >>>             }
 >>>         }
 >>>         for j from 1 until nj do {
 >>>             for i from 1 until ni do {
->>>                 write (0,0,1) and (0,1,1) w-coordinate values
+>>>                 write (0,0,1) and (0,1,1) ?-coordinate values
 >>>                 for block (i,j,k)
 >>>             }
 >>>             for i from 1 until ni do {
->>>                 write (1,0,1) and (1,1,1) w-coordinate values
+>>>                 write (1,0,1) and (1,1,1) ?-coordinate values
 >>>                 for block (i,j,k)
 >>>             }
 >>>         }
 >>>     }
 >>> }
 
-where (ni, nj, nk) is the number of grid blocks in the I, J and K directions
+where (ni, nj, nk) is the number of grid cells in the I, J and K directions
 respectively.
 
 """
@@ -72,11 +72,10 @@ corners = '''
 '''
 corners = corners.split()
 
-points = np.asarray(corners, np.int)
-points = points.reshape((3, -1))
-points = points.transpose()
+points = np.asarray(corners, dtype=np.int)
+points = points.reshape((-1, 3), order='F')
 
-dims = (5, 3, 2)
+dims = np.asarray((5, 3, 2))
 grid = pv.ExplicitStructuredGrid(dims, points)
 grid.hide_cells((0, 7))
 grid.plot(color='w', show_edges=True)

--- a/pyvista/core/__init__.py
+++ b/pyvista/core/__init__.py
@@ -7,5 +7,6 @@ from .filters import (CompositeFilters, DataSetFilters, PolyDataFilters,
                       UnstructuredGridFilters, UniformGridFilters)
 from .grid import Grid, RectilinearGrid, UniformGrid
 from .objects import Table, Texture
-from .pointset import PointGrid, PolyData, StructuredGrid, UnstructuredGrid
+from .pointset import (PointGrid, PolyData, StructuredGrid, UnstructuredGrid,
+                       ExplicitStructuredGrid)
 from .pyvista_ndarray import pyvista_ndarray

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -235,6 +235,11 @@ class DataObject:
         """Get address of the underlying C++ object in format 'Addr=%p'."""
         return self.GetInformation().GetAddressAsString("")
 
+    @property
+    def actual_memory_size(self):
+        """Returns the actual size of the data in kibibytes (1024 bytes)."""
+        return self.GetActualMemorySize()
+
 
 @abstract_class
 class Common(DataSetFilters, DataObject):

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -1035,3 +1035,7 @@ class Common(DataSetFilters, DataObject):
         locator.BuildLocator()
         closest_cells = np.array([locator.FindCell(node) for node in point])
         return int(closest_cells[0]) if len(closest_cells) == 1 else closest_cells
+
+    def copy_attributes(self, dataset):
+        """Copy the data attributes of the input dataset."""
+        self.CopyAttributes(dataset)

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -4706,3 +4706,29 @@ class ExplicitStructuredGridFilters(DataSetFilters):
         alg.SetOutputWholeExtent(*voi)
         alg.Update()
         return _get_output(alg)
+
+    def extract_neighbors(dataset, ind):
+        """Extracts the topological cell neighbors.
+
+        Parameters
+        ----------
+        ind : int
+            Cell ID.
+
+        Returns
+        -------
+        subgrid : pyvista.UnstructuredGrid
+            Subselected grid.
+
+        """
+        coord = dataset.cell_coords(ind)
+        coord = np.asarray(coord)
+        indices = []
+        for x in [(-1, 0, 0), (1, 0, 0),
+                  (0, -1, 0), (0, 1, 0),
+                  (0, 0, -1), (0, 0, 1)]:
+            n = coord + x
+            i = dataset.cell_id(n)
+            indices.append(i)
+        subgrid = dataset.extract_cells(indices)
+        return subgrid

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -4561,7 +4561,22 @@ class UnstructuredGridFilters(DataSetFilters):
             dataset['BLOCK_I'] = ii.flatten()
             dataset['BLOCK_J'] = jj.flatten()
             dataset['BLOCK_K'] = kk.flatten()
+        # Attention:
+        #
+        # VTK is producing the following error during the cell blanking of
+        # explicit structured grid:
+        #
+        #   2020-12-20 18:04:08.844 (   0.727s) [                ]
+        #   vtkPolyData.cxx:1068   ERR| vtkPolyData (0000021F5F0E44E0):
+        #   Invalid cell type: 0
+        #
+        # self.GlobalWarningDisplayOff() is used provisionally to overcome the
+        # problem.
+        #
+        # See <https://discourse.vtk.org/t/error-during-the-cell-blanking-of-
+        # explicit-structured-grid/4863>
         alg = vtk.vtkUnstructuredGridToExplicitStructuredGrid()
+        alg.GlobalWarningDisplayOff()
         alg.SetInputData(dataset)
         alg.SetInputArrayToProcess(0, 0, 0, 1, 'BLOCK_I')
         alg.SetInputArrayToProcess(1, 0, 0, 1, 'BLOCK_J')

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -4567,11 +4567,7 @@ class UnstructuredGridFilters(DataSetFilters):
         alg.SetInputArrayToProcess(1, 0, 0, 1, 'BLOCK_J')
         alg.SetInputArrayToProcess(2, 0, 0, 1, 'BLOCK_K')
         alg.Update()
-        output = _get_output(alg)
-        s1.add('ConnectivityFlags')
-        for k in s1:
-            del output.cell_arrays[k]
-        return output
+        return _get_output(alg)
 
 
 @abstract_class

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1091,6 +1091,15 @@ class ExplicitStructuredGrid(vtkExplicitStructuredGrid, PointGrid,
         self.SetPoints(points)
         self.SetCells(cells)
 
+    @property
+    def dimensions(self):
+        """Returns the grid dimensions."""
+        xmin, xmax, ymin, ymax, zmin, zmax = self.extent
+        nx = xmax - xmin + 1
+        ny = ymax - ymin + 1
+        nz = zmax - zmin + 1
+        return (nx, ny, nz)
+
     def save(self, filename, binary=True):
         """Saves this VTK object to file.
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1177,3 +1177,20 @@ class ExplicitStructuredGrid(vtkExplicitStructuredGrid, PointGrid,
         nx, ny, nz = self._compute_dimensions()
         coords = np.unravel_index(ind, (nx-1, ny-1, nz-1), order='F')
         return coords
+
+    def cell_n_points(self, ind):
+        """Returns the number of points in a cell."""
+        return self.GetCell(ind).GetPoints().GetNumberOfPoints()
+
+    def cell_points(self, ind):
+        """Returns the points in a cell."""
+        points = self.GetCell(ind).GetPoints().GetData()
+        return vtk_to_numpy(points)
+
+    def cell_bounds(self, ind):
+        """Returns the bounds of a cell."""
+        return self.GetCell(ind).GetBounds()
+
+    def cell_type(self, ind):
+        """Returns the type of a cell."""
+        return self.GetCellType(ind)

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1041,7 +1041,6 @@ class ExplicitStructuredGrid(vtkExplicitStructuredGrid, PointGrid,
             if isinstance(args[0], vtk.vtkExplicitStructuredGrid):
                 self.deep_copy(args[0])
             elif isinstance(args[0], str):
-                self.GlobalWarningDisplayOff()  # see self.hide_cells()
                 grid = UnstructuredGrid(args[0])
                 grid = grid.explicit_structured_grid()
                 self.deep_copy(grid)
@@ -1151,3 +1150,15 @@ class ExplicitStructuredGrid(vtkExplicitStructuredGrid, PointGrid,
         ghost_cells[ind] = vtk.vtkDataSetAttributes.HIDDENCELL
         array_name = vtk.vtkDataSetAttributes.GhostArrayName()
         self.cell_arrays[array_name] = ghost_cells
+
+    @property
+    def visible_bounds(self):
+        """Return the bounding box of the visible grid cells."""
+        array_name = vtk.vtkDataSetAttributes.GhostArrayName()
+        if array_name in self.cell_arrays.keys():
+            array = self.cell_arrays[array_name]
+            grid = self.extract_cells(array == 0)
+            bounds = grid.GetBounds()
+        else:
+            bounds = self.GetBounds()
+        return list(bounds)

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1090,14 +1090,18 @@ class ExplicitStructuredGrid(vtkExplicitStructuredGrid, PointGrid,
         self.SetPoints(points)
         self.SetCells(cells)
 
-    @property
-    def dimensions(self):
-        """Returns the grid dimensions."""
+    def _compute_dimensions(self):
+        """Computes the grid dimensions."""
         xmin, xmax, ymin, ymax, zmin, zmax = self.extent
         nx = xmax - xmin + 1
         ny = ymax - ymin + 1
         nz = zmax - zmin + 1
         return (nx, ny, nz)
+
+    @property
+    def dimensions(self):
+        """Returns the grid dimensions."""
+        return self._compute_dimensions()
 
     def save(self, filename, binary=True):
         """Saves this VTK object to file.
@@ -1162,3 +1166,14 @@ class ExplicitStructuredGrid(vtkExplicitStructuredGrid, PointGrid,
         else:
             bounds = self.GetBounds()
         return list(bounds)
+
+    def compute_cell_id(self, coords):
+        """Computes the cell ID."""
+        i, j, k = coords
+        return self.ComputeCellId(i, j, k, False)
+
+    def compute_cell_coords(self, ind):
+        """Computes the cell structured coordinates."""
+        nx, ny, nz = self._compute_dimensions()
+        coords = np.unravel_index(ind, (nx-1, ny-1, nz-1), order='F')
+        return coords

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -98,6 +98,10 @@ class PointSet(Common):
         if not inplace:
             return target
 
+    def copy_structure(self, dataset):
+        """Copy the geometric and topological structure of an input dataset."""
+        self.CopyStructure(dataset)
+
 
 class PolyData(vtkPolyData, PointSet, PolyDataFilters):
     """Extend the functionality of a vtk.vtkPolyData object.

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3270,15 +3270,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.remove_actor(f'{name}-labels', reset_camera=False)
 
         # add points
-        if show_points:
-            style = 'points'
-        else:
-            style = 'surface'
-        self.add_mesh(vtkpoints, style=style, color=point_color,
-                      point_size=point_size, name=f'{name}-points',
-                      pickable=pickable,
-                      render_points_as_spheres=render_points_as_spheres,
-                      reset_camera=reset_camera)
+        if show_points is True:
+            self.add_mesh(vtkpoints, color=point_color, point_size=point_size,
+                          name=f'{name}-points', pickable=pickable,
+                          render_points_as_spheres=render_points_as_spheres,
+                          reset_camera=reset_camera)
 
         labelActor = vtk.vtkActor2D()
         labelActor.SetMapper(labelMapper)

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -483,6 +483,7 @@ def wrap(dataset):
 
     """
     wrappers = {
+        'vtkExplicitStructuredGrid': pyvista.ExplicitStructuredGrid,
         'vtkUnstructuredGrid': pyvista.UnstructuredGrid,
         'vtkRectilinearGrid': pyvista.RectilinearGrid,
         'vtkStructuredGrid': pyvista.StructuredGrid,


### PR DESCRIPTION
### Overview

See https://github.com/pyvista/pyvista-support/issues/319

### Details

This pull request includes:

- A class to create an explicit structured grid (`ExplicitStructuredGrid`)
- A class to apply explicit structured grid filters (`ExplicitStructuredGridFilters`)
- A example for creating an explicit structured grid (`create-explicit-structured-grid.py`)
- A method to convert an explicit structured grid into an unstructured grid (`UnstructuredGridFilters.explicit_structured_grid`)
- A method to copy the data attributes of a dataset (`Common.copy_attributes`)
- A method to copy the geometric and topological structure of a dataset (`Common.copy_structure`)
- A method to return the actual size of a dataset (`DataObject.actual_memory_size`)
- A method to reflect a dataset across a plane (`DataSetFilters.reflect`)
