### PR TITLE
🌐 Add Options for gettext output

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -203,6 +203,10 @@ latex_documents = [
      author, 'manual'),
 ]
 
+# -- Options for gettext output -------------------------------------------
+
+# To specify names to enable gettext extracting and translation applying for i18n additionally. You can specify below names:
+gettext_additional_targets = ['raw'] 
 
 # -- Options for manual page output ---------------------------------------
 


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Add Options for gettext output. This option is need for translate the raw contents in sphinx document.

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 
relate to: https://github.com/enthought/mayavi/pull/841

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details
This is where I want to translate.
https://pyvista-doc.readthedocs.io/ja/latest/

![image](https://user-images.githubusercontent.com/7513610/104140970-a8442d80-53f7-11eb-988a-d8d277293a13.png)


