### PR TITLE
Add read_plot3d, other minor reader improvements

### DIFF
--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -2,6 +2,7 @@
 
 import pathlib
 import os
+from packaging import version
 
 import numpy as np
 import vtk
@@ -66,10 +67,10 @@ READERS = {
     '.inp': vtk.vtkAVSucdReader,
 }
 
-VTK_MAJOR = vtk.vtkVersion().GetVTKMajorVersion()
-VTK_MINOR = vtk.vtkVersion().GetVTKMinorVersion()
+VTK_VERSION = str(vtk.vtkVersion().GetVTKMajorVersion()) + \
+              str(vtk.vtkVersion().GetVTKMinorVersion())
 
-if (VTK_MAJOR >= 8 and VTK_MINOR >= 2):
+if version.parse(VTK_VERSION) >= version.parse('8.2'):
     try:
         READERS['.sgy'] = vtk.vtkSegYReader
         READERS['.segy'] = vtk.vtkSegYReader

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -205,7 +205,9 @@ def read(filename, attrs=None, file_format=None):
                 name = os.path.basename(str(each))
             else:
                 name = None
-            multi[-1, name] = read(each)
+            multi[-1, name] = read(each, attrs=attrs,
+                                   override_ext=override_ext,
+                                   file_format=file_format)
         return multi
     filename = os.path.abspath(os.path.expanduser(str(filename)))
     if not os.path.isfile(filename):

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -2,7 +2,6 @@
 
 import pathlib
 import os
-from packaging import version
 
 import numpy as np
 import vtk
@@ -67,10 +66,10 @@ READERS = {
     '.inp': vtk.vtkAVSucdReader,
 }
 
-VTK_VERSION = str(vtk.vtkVersion().GetVTKMajorVersion()) + \
-              str(vtk.vtkVersion().GetVTKMinorVersion())
+VTK_MAJOR = vtk.vtkVersion().GetVTKMajorVersion()
+VTK_MINOR = vtk.vtkVersion().GetVTKMinorVersion()
 
-if version.parse(VTK_VERSION) >= version.parse('8.2'):
+if (VTK_MAJOR >= 8 and VTK_MINOR >= 2):
     try:
         READERS['.sgy'] = vtk.vtkSegYReader
         READERS['.segy'] = vtk.vtkSegYReader

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -330,8 +330,7 @@ def read_plot3d(filename, q_filenames=(), auto_detect=True, attrs=None):
         reader.AddFileName(q_filename)
 
     attrs = {} if not attrs else attrs
-    if auto_detect:
-        attrs['SetAutoDetectFormat'] = True
+    attrs['SetAutoDetectFormat'] = auto_detect
 
     return standard_reader_routine(reader, filename=None, attrs=attrs)
 

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -310,7 +310,6 @@ def read_exodus(filename,
 
 def read_plot3d(filename, q_filenames=(), auto_detect=True, attrs=None):
     """Read a Plot3D grid file (grid.in) and optional q file(s)."""
-
     filename = _process_filename(filename)
 
     reader = vtk.vtkMultiBlockPLOT3DReader()

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -322,8 +322,19 @@ def read_plot3d(filename, q_filenames=(), auto_detect=True, attrs=None):
             q_filenames = [q_filenames]
     q_filenames = [_process_filename(f) for f in q_filenames]
 
-    for q_filename in q_filenames:
-        reader.AddFileName(q_filename)
+    if hasattr(reader, 'AddFileName'):
+        # AddFileName was added to vtkMultiBlockPLOT3DReader sometime around
+        # VTK 8.2. This method supports reading multiple q files.
+        for q_filename in q_filenames:
+            reader.AddFileName(q_filename)
+    else:
+        # SetQFileName is used to add a single q file to be read, and is still
+        # supported in VTK9.
+        if len(q_filenames) > 0:
+            if len(q_filenames) > 1:
+                raise RuntimeError('Reading of multiple q files is not supported '
+                                   'with this version of VTK.')
+            reader.SetQFileName(q_filenames[0])
 
     attrs = {} if not attrs else attrs
     attrs['SetAutoDetectFormat'] = auto_detect

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -311,6 +311,29 @@ def read_exodus(filename,
     return standard_reader_routine(reader, filename=None, attrs=None)
 
 
+def read_plot3d(filename, q_filenames=(), auto_detect=True, attrs=None):
+    """Read a Plot3D grid file (grid.in) and optional q file(s)."""
+
+    filename = _process_filename(filename)
+
+    reader = vtk.vtkMultiBlockPLOT3DReader()
+    reader.SetFileName(filename)
+
+    # q_filenames may be a list or a single filename
+    if q_filenames:
+        if isinstance(q_filenames, (str, pathlib.Path)):
+            q_filenames = [q_filenames]
+    q_filenames = [_process_filename(f) for f in q_filenames]
+
+    for q_filename in q_filenames:
+        reader.AddFileName(q_filename)
+
+    attrs = {} if not attrs else attrs
+    if auto_detect:
+        attrs['SetAutoDetectFormat'] = True
+
+    return standard_reader_routine(reader, filename=None, attrs=attrs)
+
 
 def from_meshio(mesh):
     """Convert a ``meshio`` mesh instance to a PyVista mesh."""

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -156,11 +156,10 @@ def read_legacy(filename):
     reader.ReadAllTCoordsOn()
     reader.ReadAllVectorsOn()
     # Perform the read
-    reader.Update()
-    output = reader.GetOutputDataObject(0)
+    output = standard_reader_routine(reader, None)
     if output is None:
         raise RuntimeError('No output when using VTKs legacy reader')
-    return pyvista.wrap(output)
+    return output
 
 
 def read(filename, attrs=None, override_ext=None, file_format=None):

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -128,7 +128,8 @@ def standard_reader_routine(reader, filename, attrs=None):
         attrs = {}
     if not isinstance(attrs, dict):
         raise TypeError('Attributes must be a dictionary of name and arguments.')
-    reader.SetFileName(filename)
+    if filename is not None:
+        reader.SetFileName(filename)
     # Apply any attributes listed
     for name, args in attrs.items():
         attr = getattr(reader, name)
@@ -206,7 +207,6 @@ def read(filename, attrs=None, file_format=None):
             else:
                 name = None
             multi[-1, name] = read(each, attrs=attrs,
-                                   override_ext=override_ext,
                                    file_format=file_format)
         return multi
     filename = os.path.abspath(os.path.expanduser(str(filename)))
@@ -478,3 +478,6 @@ def save_meshio(filename, mesh, file_format = None, **kwargs):
         file_format=file_format,
         **kwargs
     )
+
+def _process_filename(filename):
+    return os.path.abspath(os.path.expanduser(str(filename)))

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -128,9 +128,7 @@ def standard_reader_routine(reader, filename, attrs=None):
         attrs = {}
     if not isinstance(attrs, dict):
         raise TypeError('Attributes must be a dictionary of name and arguments.')
-    if filename is not None:
-        # allow this method to be used with readers where the filename has already been set
-        reader.SetFileName(filename)
+    reader.SetFileName(filename)
     # Apply any attributes listed
     for name, args in attrs.items():
         attr = getattr(reader, name)
@@ -162,7 +160,7 @@ def read_legacy(filename):
     return output
 
 
-def read(filename, attrs=None, override_ext=None, file_format=None):
+def read(filename, attrs=None, file_format=None):
     """Read any VTK file.
 
     It will figure out what reader to use then wrap the VTK object for
@@ -180,10 +178,6 @@ def read(filename, attrs=None, override_ext=None, file_format=None):
         dictionary are the attribute/method names and values are the
         arguments passed to those calls. If you do not have any
         attributes to call, pass ``None`` as the value.
-
-    override_ext : str, optional
-        Use the reader corresponding to the given extension (e.g.,
-        ``.vtu``) instead of the actual extension of the filename.
 
     file_format : str, optional
         Format of file to read with meshio.
@@ -213,10 +207,10 @@ def read(filename, attrs=None, override_ext=None, file_format=None):
                 name = None
             multi[-1, name] = read(each)
         return multi
-    filename = _process_filename(filename)
+    filename = os.path.abspath(os.path.expanduser(str(filename)))
     if not os.path.isfile(filename):
         raise FileNotFoundError(f'File ({filename}) not found')
-    ext = get_ext(filename) if override_ext is None else override_ext
+    ext = get_ext(filename)
 
     # Read file using meshio.read if file_format is present
     if file_format:
@@ -308,7 +302,8 @@ def read_exodus(filename,
 
         reader.SetSideSetArrayStatus(name, 1)
 
-    return standard_reader_routine(reader, filename=None, attrs=None)
+    reader.Update()
+    return pyvista.wrap(reader.GetOutput())
 
 
 def read_plot3d(filename, q_filenames=(), auto_detect=True, attrs=None):
@@ -481,7 +476,3 @@ def save_meshio(filename, mesh, file_format = None, **kwargs):
         file_format=file_format,
         **kwargs
     )
-
-
-def _process_filename(filename):
-    return os.path.abspath(os.path.expanduser(str(filename)))

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -309,7 +309,33 @@ def read_exodus(filename,
 
 
 def read_plot3d(filename, q_filenames=(), auto_detect=True, attrs=None):
-    """Read a Plot3D grid file (grid.in) and optional q file(s)."""
+    """Read a Plot3D grid file (e.g., grid.in) and optional q file(s).
+    
+    Parameters
+    ----------
+    filename : str
+        The string filename to the data file to read.
+
+    q_filenames : str or tuple(str), optional
+        The string filename of the q-file, or iterable of such filenames.
+
+    auto_detect : bool, optional
+        When this option is turned on, the reader will try to figure out the
+        values of various options such as byte order, byte count etc. Default is
+        True.
+
+    attrs : dict, optional
+        A dictionary of attributes to call on the reader. Keys of dictionary are
+        the attribute/method names and values are the arguments passed to those
+        calls. If you do not have any attributes to call, pass ``None`` as the
+        value.
+
+    Returns
+    -------
+    mesh : pyvista.MultiBlock
+        Data read from the file.
+
+    """
     filename = _process_filename(filename)
 
     reader = vtk.vtkMultiBlockPLOT3DReader()

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -183,7 +183,8 @@ def read(filename, attrs=None, override_ext=None, file_format=None):
         attributes to call, pass ``None`` as the value.
 
     override_ext : str, optional
-        Override the file extension (e.g., ``.vtu``)
+        Use the reader corresponding to the given extension (e.g.,
+        ``.vtu``) instead of the actual extension of the filename.
 
     file_format : str, optional
         Format of file to read with meshio.

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -4,6 +4,8 @@ import os
 
 import numpy as np
 import pytest
+import unittest.mock as mock
+
 import vtk
 
 import pyvista
@@ -82,6 +84,32 @@ def test_read(tmpdir, use_pathlib):
     assert multi.n_blocks == 2
     assert isinstance(multi[1], pyvista.MultiBlock)
     assert multi[1].n_blocks == 2
+
+
+@pytest.mark.parametrize('auto_detect', (True, False))
+@mock.patch('pyvista.utilities.fileio.standard_reader_routine')
+def test_read_plot3d(srr_mock, auto_detect):
+    # with grid only
+    pyvista.read_plot3d(filename='grid.in', auto_detect=auto_detect)
+    srr_mock.assert_called_once()
+    args, kwargs = srr_mock.call_args
+    reader = args[0]
+    assert isinstance(reader, vtk.vtkMultiBlockPLOT3DReader)
+    assert reader.GetFileName().endswith('grid.in')
+    assert kwargs['filename'] == None
+    assert kwargs['attrs'] == {'SetAutoDetectFormat': auto_detect}
+
+    # with grid and q
+    srr_mock.reset_mock()
+    pyvista.read_plot3d(filename='grid.in', q_filenames='q1.save',
+                        auto_detect=auto_detect)
+    args, kwargs = srr_mock.call_args
+    reader = args[0]
+    assert isinstance(reader, vtk.vtkMultiBlockPLOT3DReader)
+    assert reader.GetFileName().endswith('grid.in')
+    assert args[0].GetQFileName().endswith('q1.save')
+    assert kwargs['filename'] == None
+    assert kwargs['attrs'] == {'SetAutoDetectFormat': auto_detect}
 
 
 def test_get_array():

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -56,6 +56,7 @@ def test_read(tmpdir, use_pathlib):
     types = (pyvista.PolyData, pyvista.PolyData, pyvista.UnstructuredGrid,
              pyvista.PolyData, pyvista.UniformGrid, pyvista.RectilinearGrid)
     for i, filename in enumerate(fnames):
+        print(filename)
         obj = fileio.read(filename)
         assert isinstance(obj, types[i])
     # Now test the standard_reader_routine

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -56,7 +56,6 @@ def test_read(tmpdir, use_pathlib):
     types = (pyvista.PolyData, pyvista.PolyData, pyvista.UnstructuredGrid,
              pyvista.PolyData, pyvista.UniformGrid, pyvista.RectilinearGrid)
     for i, filename in enumerate(fnames):
-        print(filename)
         obj = fileio.read(filename)
         assert isinstance(obj, types[i])
     # Now test the standard_reader_routine

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -86,6 +86,22 @@ def test_read(tmpdir, use_pathlib):
     assert multi[1].n_blocks == 2
 
 
+@mock.patch('pyvista.utilities.fileio.standard_reader_routine')
+def test_read_legacy(srr_mock):
+    srr_mock.return_value = pyvista.read(ex.planefile)
+    pyvista.read_legacy('legacy.vtk')
+    args, kwargs = srr_mock.call_args
+    reader = args[0]
+    assert isinstance(reader, vtk.vtkDataSetReader)
+    assert reader.GetFileName().endswith('legacy.vtk')
+
+    # check error is raised when no data returned
+    srr_mock.reset_mock()
+    srr_mock.return_value = None
+    with pytest.raises(RuntimeError):
+        pyvista.read_legacy('legacy.vtk')
+
+
 @pytest.mark.parametrize('auto_detect', (True, False))
 @mock.patch('pyvista.utilities.fileio.standard_reader_routine')
 def test_read_plot3d(srr_mock, auto_detect):


### PR DESCRIPTION
### Overview

Add `read_plot3d()` method, another non-standard reader in the same vein as `read_exodus`.

Other minor changes:
- Use `standard_reader_routine()` where possible to avoid repetition.
    - Allow `standard_reader_routine()` to take in `None` for the filename to make it work for non-standard readers which were initialized ahead of time.
- Pass options through when reading multiple files with `pv.read()`
- ~~Add `override_ext` to `pv.read()` to manually specify which reader should be used (useful when you want to use a reader which doesn't match the file extension)~~ _Tried this but ran into issues with things like `UnstructuredGrid._from_file()` checking for appropriate file extensions._

### Details

Adds simple tests for `read_plot3d()` and `read_legacy()` by mocking `standard_reader_routine`.