### PR TITLE
fix typos in example/test comments

### DIFF
--- a/examples/00-load/create-geometric-objects.py
+++ b/examples/00-load/create-geometric-objects.py
@@ -9,7 +9,7 @@ The "Hello, world!" of VTK
 import pyvista as pv
 
 ###############################################################################
-# This runs through several of the available geomoetric objects available in
+# This runs through several of the available geometric objects available in
 # VTK which PyVista provides simple convenience methods for generating.
 #
 # Let's run through creating a few geometric objects!

--- a/examples/00-load/create-parametric-geometric-objects.py
+++ b/examples/00-load/create-parametric-geometric-objects.py
@@ -127,7 +127,7 @@ henneberg.plot(color="tan")
 ###############################################################################
 # Klein
 # +++++
-
+Bour
 klein = pv.ParametricKlein()
 klein.plot(color="tan")
 

--- a/examples/00-load/create-parametric-geometric-objects.py
+++ b/examples/00-load/create-parametric-geometric-objects.py
@@ -127,7 +127,6 @@ henneberg.plot(color="tan")
 ###############################################################################
 # Klein
 # +++++
-Bour
 klein = pv.ParametricKlein()
 klein.plot(color="tan")
 

--- a/examples/00-load/create-point-cloud.py
+++ b/examples/00-load/create-point-cloud.py
@@ -16,7 +16,7 @@ from pyvista import examples
 
 ###############################################################################
 # Point clouds are generally constructed in the :class:`pyvista.PolyData` class
-# and can easiy have scalar/vector data arrays associated with the point
+# and can easily have scalar/vector data arrays associated with the point
 # cloud. In this example, we'll work a bit backwards using a point cloud that
 # that is available from our ``examples`` module. This however is no different
 # than creating a PyVista mesh with your own NumPy arrays of vertice locations.

--- a/examples/00-load/create-tri-surface.py
+++ b/examples/00-load/create-tri-surface.py
@@ -10,7 +10,7 @@ import pyvista as pv
 import numpy as np
 
 ###############################################################################
-# Simple Traingulations
+# Simple Triangulations
 # +++++++++++++++++++++
 #
 # First, create some points for the surface.
@@ -68,7 +68,7 @@ surf.plot(cpos="xy", show_edges=True)
 
 ###############################################################################
 # Note that some of the outer edges are unconstrained and the triangulation
-# added unwanted triangles. We cn mitigate that with the ``alpha`` parameter.
+# added unwanted triangles. We can mitigate that with the ``alpha`` parameter.
 surf = cloud.delaunay_2d(alpha=1.0)
 surf.plot(cpos="xy", show_edges=True)
 

--- a/examples/00-load/read-file.py
+++ b/examples/00-load/read-file.py
@@ -56,7 +56,7 @@ mesh.faces.reshape(-1, 4)[:, 1:] # triangular faces
 # Loading other files types is just as easy! Simply pass your file path to the
 # :func:`pyvista.read` function and that's it!
 #
-# Here are a few other examples - siply replace ``examples.download_*`` in the
+# Here are a few other examples - simply replace ``examples.download_*`` in the
 # examples below with ``pyvista.read('path/to/you/file.ext')``
 
 ###############################################################################

--- a/examples/00-load/read-image.py
+++ b/examples/00-load/read-image.py
@@ -8,7 +8,7 @@ Read and plot image files (JPEG, TIFF, PNG, etc).
 from pyvista import examples
 
 ###############################################################################
-# PyVista fully supportes reading images into their own spatially referenced
+# PyVista fully supports reading images into their own spatially referenced
 # data objects (this example) as well as supports texture mapping of images
 # onto datasets (see :ref:`ref_texture_example`).
 #

--- a/examples/00-load/terrain-mesh.py
+++ b/examples/00-load/terrain-mesh.py
@@ -10,7 +10,7 @@ in hydrological modelling (see
 and
 `ParFlow <https://parflow.org>`_).
 
-In this example, we domonstrate a simple way to make a 3D grid/mesh that
+In this example, we demonstrate a simple way to make a 3D grid/mesh that
 follows a given topographic surface. In this example, it is important to note
 that the given digital elevation model (DEM) is structured (gridded and not
 triangulated): this is common for DEMs.

--- a/examples/01-filter/boolean-operations.py
+++ b/examples/01-filter/boolean-operations.py
@@ -29,7 +29,7 @@ def make_cube():
     grid = pv.StructuredGrid(*np.meshgrid(x, x, x))
     return grid.extract_surface().triangulate()
 
-# Create to examplee PolyData meshes for boolean operations
+# Create to example PolyData meshes for boolean operations
 sphere = pv.Sphere(radius=0.65, center=(0, 0, 0))
 cube = make_cube()
 

--- a/examples/01-filter/contouring.py
+++ b/examples/01-filter/contouring.py
@@ -4,8 +4,8 @@ Contouring
 
 Generate iso-lines or -surfaces for the scalars of a surface or volume.
 
-3D meshes can have 2D iso-surfaces of a scalarr field extracted and 2D surface
-meshes can have 1D iso-lines of a scalar field eextracted.
+3D meshes can have 2D iso-surfaces of a scalar field extracted and 2D surface
+meshes can have 1D iso-lines of a scalar field extracted.
 """
 from pyvista import examples
 import pyvista as pv

--- a/examples/01-filter/distance-between-surfaces.py
+++ b/examples/01-filter/distance-between-surfaces.py
@@ -12,7 +12,7 @@ We can compute the thickness between the two surfaces using a few different
 methods. First, we will demo a method where we compute the normals of the
 bottom surface, and then project a ray to the top surface to compute the
 distance along the surface normals. Second, we will use a KDTree to compute
-the distance from eevery point in the bottom mesh to it's closest point in
+the distance from every point in the bottom mesh to it's closest point in
 the top mesh.
 """
 import pyvista as pv
@@ -23,7 +23,7 @@ def hill(seed):
     mesh = pv.ParametricRandomHills(randomseed=seed, u_res=50, v_res=50,
                                     hillamplitude=0.5)
     mesh.rotate_y(-10) # give the surfaces some tilt
-    
+
     return mesh
 
 h0 = hill(1).elevation()
@@ -49,7 +49,7 @@ h0n = h0.compute_normals(point_normals=True, cell_normals=False,
                          auto_orient_normals=True)
 
 ###############################################################################
-# Travel along noramals to the other surface and compute the thickness on each
+# Travel along normals to the other surface and compute the thickness on each
 # vector.
 
 h0n["distances"] = np.empty(h0.n_points)

--- a/examples/01-filter/extract-edges.py
+++ b/examples/01-filter/extract-edges.py
@@ -27,7 +27,7 @@ mesh = examples.download_nefertiti()
 # Extract the edges above a 12 degree feature angle
 edges = mesh.extract_feature_edges(12)
 
-# Render the edge lines ontop of the original mesh
+# Render the edge lines on top of the original mesh
 p = pv.Plotter()
 p.add_mesh(mesh, color=True)
 p.add_mesh(edges, color="red", line_width=5)
@@ -36,7 +36,7 @@ p.camera_position = [(96.0, -197.0, 45.0), (7.0, -109.0, 22.0), (0, 0, 1)]
 p.show()
 
 ###############################################################################
-# We can do this anaylsis for any :class:`pyvista.PolyData` object. Let's try
+# We can do this analysis for any :class:`pyvista.PolyData` object. Let's try
 # the cow mesh example:
 
 mesh = examples.download_cow()

--- a/examples/01-filter/glyphs.py
+++ b/examples/01-filter/glyphs.py
@@ -17,7 +17,7 @@ import numpy as np
 
 mesh = examples.download_carotid().threshold(145, scalars="scalars")
 
-# Make a geometric obhect to use as the glyph
+# Make a geometric object to use as the glyph
 geom = pv.Arrow()  # This could be any dataset
 
 # Perform the glyph

--- a/examples/01-filter/subdivide.py
+++ b/examples/01-filter/subdivide.py
@@ -4,7 +4,7 @@ Subdivide Cells
 
 Increase the number of triangles in a single, connected triangular mesh.
 
-The :func:`pyvista.PolyDataFilters.subdivide` filter utilitizes three different
+The :func:`pyvista.PolyDataFilters.subdivide` filter utilizes three different
 subdivision algorithms to subdivide a mesh's cells: `butterfly`, `loop`,
 or `linear`.
 """

--- a/examples/02-plot/ghost-cells.py
+++ b/examples/02-plot/ghost-cells.py
@@ -4,7 +4,7 @@ Hide Cells with Ghosting
 
 Specify specific cells to hide when plotting.
 
-This is a lightwieght alternative to thresholding to quickly hide cells in a
+This is a lightweight alternative to thresholding to quickly hide cells in a
 mesh without creating a new mesh.
 
 Notably, the mesh must be cast to an :class:`pyvista.UnstructuredGrid` type

--- a/examples/02-plot/interpolate-before-map.py
+++ b/examples/02-plot/interpolate-before-map.py
@@ -31,7 +31,7 @@ import pyvista as pv
 #
 # So lets take a look at the difference:
 
-# Load a cylider which has cells with a wide spread
+# Load a cylinder which has cells with a wide spread
 cyl = pv.Cylinder(direction=(0,0,1), height=2).elevation()
 
 # Common display argument to make sure all else is constant
@@ -74,7 +74,7 @@ p.camera_position = [(-1.67, -5.10, 2.06),
 p.show()
 
 ###############################################################################
-# The cylider mesh above is a great example dataset for this as it has a wide
+# The cylinder mesh above is a great example dataset for this as it has a wide
 # spread between the vertices (points are only at the top and bottom of the
 # cylinder) which means high surface are of the mesh has to be interpolated.
 #
@@ -101,7 +101,7 @@ p.show()
 
 ###############################################################################
 # This time is pretty difficult to notice the differences - they are there,
-# subtle, but present. The differences become more apperant when we decrease
+# subtle, but present. The differences become more apparent when we decrease
 # the number of colors in colormap.
 # Let's take a look at the differences when using eight discrete colors via
 # the ``n_colors`` argument:

--- a/examples/02-plot/logo.py.old
+++ b/examples/02-plot/logo.py.old
@@ -81,7 +81,7 @@ for i in range(k_grid.n_cells):
         #                  scalars=[x_dist + 0.2], rng=[x_min, x_max],
         #                  show_edges=True)
     else:
-        # opactity = opacity
+        # opacity = opacity
         plotter.add_mesh(cell, color='w', show_edges=True, opacity=opacity)
 
 keep_k = k_grid.extract_cells(keep)

--- a/examples/02-plot/spherical.py
+++ b/examples/02-plot/spherical.py
@@ -16,7 +16,7 @@ def _cell_bounds(points, bound_position=0.5):
     Parameters
     ----------
     points: numpy.array
-        One-dimensional array of uniformy spaced values of shape (M,)
+        One-dimensional array of uniformly spaced values of shape (M,)
     bound_position: bool, optional
         The desired position of the bounds relative to the position
         of the points.

--- a/examples/02-plot/themes.py
+++ b/examples/02-plot/themes.py
@@ -28,7 +28,7 @@ def plot_example():
 # environments.
 #
 # Here's an example of our default plotting theme - this is what you would see
-# by default after running any of our examnples.
+# by default after running any of our examples.
 
 pv.set_plot_theme("default")
 

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -665,12 +665,12 @@ def test_scalars_by_name():
 
 
 def test_themes():
-    old_rcParms = dict(pyvista.rcParams)  # must cache old rcParams
+    old_rcParams = dict(pyvista.rcParams)  # must cache old rcParams
     pyvista.set_plot_theme('paraview')
     pyvista.set_plot_theme('document')
     pyvista.set_plot_theme('night')
     pyvista.set_plot_theme('default')
-    for key, value in old_rcParms.items():
+    for key, value in old_rcParams.items():
         pyvista.rcParams[key] = value
 
 
@@ -917,7 +917,7 @@ def test_subplot_groups_fail():
         # Full overlap (outer)
         pyvista.Plotter(shape=(4, 4), groups=[(1, [1, 2]), ([0, 3], np.s_[:])])
 
- 
+
 @skip_no_plotting
 def test_link_views(sphere):
     plotter = pyvista.Plotter(shape=(1, 4))
@@ -1127,7 +1127,7 @@ def test_opacity_by_array_user_transform(uniform):
     p.show()  # note: =verify_cache_image does not work between Xvfb
 
 
-def test_opactity_mismatched_fail(uniform):
+def test_opacity_mismatched_fail(uniform):
     opac = uniform['Spatial Point Data'] / uniform['Spatial Point Data'].max()
     uniform['unc'] = opac
 


### PR DESCRIPTION
### Overview
When browsing the examples online, I found some typos.  This is a simple PR to fix typos in the examples and a few in the testing files.

### Details

- all changes are in comments, except for `tests/plotting/test_plotting.py` changing a variable name from `old_rcParms` to `old_rcParams` within 1 test function.

