### PR TITLE
Expose GetClippedOutput from vtkClipPolyData

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -51,6 +51,14 @@ def test_clip_filter():
         else:
             assert isinstance(clp, pyvista.UnstructuredGrid)
 
+    # clip with get_clipped=True
+    for i, dataset in enumerate(DATASETS):
+        clp1, clp2 = dataset.clip(normal=normals[i], invert=True, return_clipped=True)
+        for clp in (clp1, clp2):
+            if isinstance(dataset, pyvista.PolyData):
+                assert isinstance(clp, pyvista.PolyData)
+            else:
+                assert isinstance(clp, pyvista.UnstructuredGrid)
 
 @skip_windows
 @skip_mac


### PR DESCRIPTION
### Overview

Expose GetClippedOutput() from vtkClipPolyData, which returns the "other side" of the clip. This is a bit faster than calling `clip` twice, once with `invert=False` and once with `invert=True`. The performance difference is greater for small meshes. This probably won't affect a lot of people, but it will help me.

### Details
Some simple benchmarking is shown below.

<details>
<summary>code to generate plot</summary>

```
from pyvista import examples
import time

n_cells = []
t_orig = []
t_new = []
for i in range(9):
    print(i)
    dataset = examples.load_hexbeam().extract_surface().triangulate().subdivide(i)
    n_cells.append(dataset.number_of_cells)

    # do two clips with invert
    t0 = time.time()
    c1 = dataset.clip(invert=False)
    c2 = dataset.clip(invert=True)
    t_orig.append(time.time() - t0)

    # do one clip with return_clipped=True
    t0 = time.time()
    c1, c2 = dataset.clip(invert=False, return_clipped=True)
    t_new.append(time.time() - t0)

import matplotlib.pyplot as plt
plt.figure()
plt.loglog(n_cells, t_orig, '-o', label='two clips')
plt.loglog(n_cells, t_new, '-o', label='one clip w/ clipped')
plt.legend()
plt.grid(True)
plt.xlabel('number of cells')
plt.ylabel('execution time [s]')
plt.show()
```
</details>

![image](https://user-images.githubusercontent.com/2186528/104794824-715b7800-5767-11eb-8d6b-e47d0a66b544.png)
