### PR TITLE
📝 Fix indent of docstring

### DIFF
--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -24,17 +24,17 @@ class DataSetAttributes(VTKObjectWrapper):
     Implement a ``dict`` like interface for interacting with vtkDataArrays.
 
     Parameters
-        ----------
-        vtkobject : vtkFieldData
-            The vtk object to wrap as a DataSetAttribute, usually an
-             instance of ``vtk.vtkCellData``, ``vtk.vtkPointData``, or
-             ``vtk.vtkFieldData``.
+    ----------
+    vtkobject : vtkFieldData
+        The vtk object to wrap as a DataSetAttribute, usually an
+        instance of ``vtk.vtkCellData``, ``vtk.vtkPointData``, or
+        ``vtk.vtkFieldData``.
 
-        dataset : vtkDataSet
-            The vtkDataSet containing the vtkobject.
+    dataset : vtkDataSet
+        The vtkDataSet containing the vtkobject.
 
-        association : FieldAssociation
-            The array association type of the vtkobject.
+    association : FieldAssociation
+        The array association type of the vtkobject.
     """
 
     def __init__(self, vtkobject, dataset, association):

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -3900,8 +3900,8 @@ class PolyDataFilters(DataSetFilters):
         """Perform multiple ray trace calculations.
 
         This requires a mesh with only triangular faces,
-         an array of origin points and an equal sized array of
-         direction vectors to trace along.
+        an array of origin points and an equal sized array of
+        direction vectors to trace along.
 
         The embree library used for vectorisation of the ray traces is known to occasionally
         return no intersections where the VTK implementation would return an intersection.
@@ -3915,7 +3915,7 @@ class PolyDataFilters(DataSetFilters):
             Starting point for each trace.
 
         directions : np.ndarray or list
-            direction vector for each trace.
+            Direction vector for each trace.
 
         first_point : bool, optional
             Returns intersection of first point only.

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -314,7 +314,7 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
         Notes
         -----
         Binary files write much faster than ASCII and have a smaller
-         file size.
+        file size.
 
         """
         filename = os.path.abspath(os.path.expanduser(str(filename)))

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1239,11 +1239,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
             result is showing colors that are not present in the color map.
 
         cmap : str, list, optional
-           Name of the Matplotlib colormap to us when mapping the ``scalars``.
-           See available Matplotlib colormaps.  Only applicable for when
-           displaying ``scalars``. Requires Matplotlib to be installed.
-           ``colormap`` is also an accepted alias for this. If ``colorcet`` or
-           ``cmocean`` are installed, their colormaps can be specified by name.
+            Name of the Matplotlib colormap to us when mapping the ``scalars``.
+            See available Matplotlib colormaps.  Only applicable for when
+            displaying ``scalars``. Requires Matplotlib to be installed.
+            ``colormap`` is also an accepted alias for this. If ``colorcet`` or
+            ``cmocean`` are installed, their colormaps can be specified by name.
 
             You can also specify a list of colors to override an
             existing colormap with a custom one.  For example, to
@@ -1860,11 +1860,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
             The scalar bar will also have this many colors.
 
         cmap : str, optional
-           Name of the Matplotlib colormap to us when mapping the ``scalars``.
-           See available Matplotlib colormaps.  Only applicable for when
-           displaying ``scalars``. Requires Matplotlib to be installed.
-           ``colormap`` is also an accepted alias for this. If ``colorcet`` or
-           ``cmocean`` are installed, their colormaps can be specified by name.
+            Name of the Matplotlib colormap to us when mapping the ``scalars``.
+            See available Matplotlib colormaps.  Only applicable for when
+            displaying ``scalars``. Requires Matplotlib to be installed.
+            ``colormap`` is also an accepted alias for this. If ``colorcet`` or
+            ``cmocean`` are installed, their colormaps can be specified by name.
 
         flip_scalars : bool, optional
             Flip direction of cmap. Most colormaps allow ``*_r`` suffix to do
@@ -2360,10 +2360,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         color : string or 3 item list, optional, defaults to white
             Either a string, rgb list, or hex color string.  For example:
-                color='white'
-                color='w'
-                color=[1, 1, 1]
-                color='#FFFFFF'
+
+            * ``color='white'``
+            * ``color='w'``
+            * ``color=[1, 1, 1]``
+            * ``color='#FFFFFF'``
 
         font_family : string, optional
             Font family.  Must be either courier, times, or arial.
@@ -3042,10 +3043,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         color : string or 3 item list, optional, defaults to white
             Either a string, rgb list, or hex color string.  For example:
-                color='white'
-                color='w'
-                color=[1, 1, 1]
-                color='#FFFFFF'
+
+            * ``color='white'``
+            * ``color='w'``
+            * ``color=[1, 1, 1]``
+            * ``color='#FFFFFF'``
 
         width : float, optional
             Thickness of lines
@@ -3144,10 +3146,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
         point_color : string or 3 item list, optional. Color of points (if visible).
             Either a string, rgb list, or hex color string.  For example:
 
-                text_color='white'
-                text_color='w'
-                text_color=[1, 1, 1]
-                text_color='#FFFFFF'
+            * ``color='white'``
+            * ``color='w'``
+            * ``color=[1, 1, 1]``
+            * ``color='#FFFFFF'``
 
         point_size : float, optional
             Size of points (if visible)
@@ -3617,10 +3619,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         ----------
         color : string or 3 item list, optional, defaults to white
             Either a string, rgb list, or hex color string.  For example:
-                color='white'
-                color='w'
-                color=[1, 1, 1]
-                color='#FFFFFF'
+
+            * ``color='white'``
+            * ``color='w'``
+            * ``color=[1, 1, 1]``
+            * ``color='#FFFFFF'``
 
         top : string or 3 item list, optional, defaults to None
             If given, this will enable a gradient background where the

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -591,10 +591,10 @@ class Renderer(vtkRenderer):
             Color of all labels and axis titles.  Default white.
             Either a string, rgb list, or hex color string.  For example:
 
-                color='white'
-                color='w'
-                color=[1, 1, 1]
-                color='#FFFFFF'
+            * ``color='white'``
+            * ``color='w'``
+            * ``color=[1, 1, 1]``
+            * ``color='#FFFFFF'``
 
         xlabel : string, optional
             Title of the x axis.  Default "X Axis"
@@ -1415,10 +1415,11 @@ class Renderer(vtkRenderer):
         ----------
         color : string or 3 item list, optional, defaults to white
             Either a string, rgb list, or hex color string.  For example:
-                color='white'
-                color='w'
-                color=[1, 1, 1]
-                color='#FFFFFF'
+
+            * ``color='white'``
+            * ``color='w'``
+            * ``color=[1, 1, 1]``
+            * ``color='#FFFFFF'``
 
         top : string or 3 item list, optional, defaults to None
             If given, this will enable a gradient background where the

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -233,7 +233,7 @@ class WidgetHelper:
             callback
 
         test_callback: bool
-            if true, run the callback function after the widget is created.
+            If true, run the callback function after the widget is created.
 
         """
         if not hasattr(self, "plane_widgets"):

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -431,13 +431,13 @@ def Cone(center=(0.,0.,0.), direction=(1.,0.,0.), height=1.0, radius=None,
         Center in [x, y, z]. middle of the axis of the cone.
 
     direction : np.ndarray or list
-        direction vector in [x, y, z]. orientation vector of the cone.
+        Direction vector in [x, y, z]. orientation vector of the cone.
 
     height : float
-        height along the cone in its specified direction.
+        Height along the cone in its specified direction.
 
     radius : float
-        base radius of the cone
+        Base radius of the cone
 
     capping : bool
         Turn on/off whether to cap the base of the cone with a polygon.
@@ -446,7 +446,7 @@ def Cone(center=(0.,0.,0.), direction=(1.,0.,0.), height=1.0, radius=None,
         The angle degrees between the axis of the cone and a generatrix.
 
     resolution : int
-        number of facets used to represent the cone
+        Number of facets used to represent the cone
 
     """
     src = vtk.vtkConeSource()
@@ -484,7 +484,7 @@ def Polygon(center=(0.,0.,0.), radius=1, normal=(0,0,1), n_sides=6):
         The radius of the polygon
 
     normal : np.ndarray or list
-        direction vector in [x, y, z]. orientation vector of the cone.
+        Direction vector in [x, y, z]. orientation vector of the cone.
 
     n_sides : int
         Number of sides of the polygon
@@ -519,13 +519,13 @@ def Disc(center=(0.,0.,0.), inner=0.25, outer=0.5, normal=(0,0,1), r_res=1,
         The outer radius
 
     normal : np.ndarray or list
-        direction vector in [x, y, z]. orientation vector of the cone.
+        Direction vector in [x, y, z]. orientation vector of the cone.
 
     r_res: int
-        number of points in radius direction.
+        Number of points in radius direction.
 
     r_res: int
-        number of points in circumferential direction.
+        Number of points in circumferential direction.
 
     """
     src = vtk.vtkDiskSource()

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -749,7 +749,7 @@ def abstract_class(cls_):
     """Decorate a class, overriding __new__.
 
     Preventing a class from being instantiated similar to abc.ABCMeta
-      but does not require an abstract method.
+    but does not require an abstract method.
     """
 
     def __new__(cls, *args, **kwargs):

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -133,7 +133,7 @@ def ParametricBoy(zscale=None, **kwargs):
     ----------
     zscale : double, optional
         The scale factor for the z-coordinate.
-      Default is 18, giving a nice shape.
+        Default is 18, giving a nice shape.
 
     Return
     ------
@@ -1033,7 +1033,7 @@ def parametric_keywords(parametric_function, min_u=0, max_u=2*pi,
         the u direction.
 
     join_v : bool, optional
-        joins the first triangle strip to the last one with a twist in
+        Joins the first triangle strip to the last one with a twist in
         the v direction.
 
     twist_u : bool, optional


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
:memo: Fix indent and others of docstring. I found the error of documentation in
https://docs.pyvista.org/core/points.html#pyvista.PolyData.save
![image](https://user-images.githubusercontent.com/7513610/104816790-9bdd2c00-5860-11eb-9e37-39ea18cb9db3.png)

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None

