### PR TITLE
Add PolyData intersection filter

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2927,8 +2927,8 @@ class PolyDataFilters(DataSetFilters):
         off for either mesh individually.
 
         >>> intersection, _, s2_split = s1.intersection(s2,
-        >>>                                             split_first=False,
-        >>>                                             split_second=True)
+                                                        split_first=False,
+                                                        split_second=True)
 
         """
         intfilter = vtk.vtkIntersectionPolyDataFilter()

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2884,6 +2884,50 @@ class PolyDataFilters(DataSetFilters):
         else:
             return mesh
 
+    def intersection(poly_data, mesh, split_first=True, split_second=True):
+        """Compute the intersection between two meshes.
+
+        Parameters
+        ----------
+        mesh : pyvista.PolyData
+            The mesh to intersect with.
+
+        split_first : bool, optional
+            If `True`, return the first input mesh split by the intersection with the
+            second input mesh.
+
+        split_second : bool, optional
+            If `True`, return the second input mesh split by the intersection with the
+            first input mesh.
+
+        Return
+        ------
+        intersection: pyvista.PolyData
+            The intersection line.
+
+        first_split: pyvista.PolyData
+            The first mesh split along the intersection. Returns the original first mesh
+            if `split_first` is False.
+
+        second_split: pyvista.PolyData
+            The second mesh split along the intersection. Returns the original second mesh
+            if `split_second` is False.
+        """
+
+        intfilter = vtk.vtkIntersectionPolyDataFilter()
+        intfilter.SetInputDataObject(0, poly_data)
+        intfilter.SetInputDataObject(1, mesh)
+        intfilter.SetComputeIntersectionPointArray(True)
+        intfilter.SetSplitFirstOutput(split_first)
+        intfilter.SetSplitSecondOutput(split_second)
+        intfilter.Update()
+
+        intersection = _get_output(intfilter, oport=0)
+        first = _get_output(intfilter, oport=1)
+        second = _get_output(intfilter, oport=2)
+
+        return intersection, first, second
+
     def curvature(poly_data, curv_type='mean'):
         """Return the pointwise curvature of a mesh.
 

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2701,7 +2701,7 @@ class CompositeFilters:
             controls the relative size of the corners to the length of the
             corresponding bounds
 
-        ested : bool, optional
+        nested : bool, optional
             If True, these creates individual outlines for each nested dataset
 
         """

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2912,6 +2912,24 @@ class PolyDataFilters(DataSetFilters):
         second_split: pyvista.PolyData
             The second mesh split along the intersection. Returns the original second mesh
             if `split_second` is False.
+
+        Examples
+        --------
+        Intersect two spheres, returning the intersection and both spheres
+        which have new points/cells along the intersection line.
+
+        >>> import pyvista as pv
+        >>> s1 = pv.Sphere()
+        >>> s2 = pv.Sphere(center=(0.25, 0, 0))
+        >>> intersection, s1_split, s2_split = s1.intersection(s2)
+
+        The mesh splitting takes additional time and can be turned
+        off for either mesh individually.
+
+        >>> intersection, _, s2_split = s1.intersection(s2,
+        >>>                                             split_first=False,
+        >>>                                             split_second=True)
+
         """
         intfilter = vtk.vtkIntersectionPolyDataFilter()
         intfilter.SetInputDataObject(0, poly_data)

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2913,7 +2913,6 @@ class PolyDataFilters(DataSetFilters):
             The second mesh split along the intersection. Returns the original second mesh
             if `split_second` is False.
         """
-
         intfilter = vtk.vtkIntersectionPolyDataFilter()
         intfilter.SetInputDataObject(0, poly_data)
         intfilter.SetInputDataObject(1, mesh)

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2926,8 +2926,8 @@ class PolyDataFilters(DataSetFilters):
         The mesh splitting takes additional time and can be turned
         off for either mesh individually.
 
-        >>> intersection, _, s2_split = s1.intersection(s2,
-                                                        split_first=False,
+        >>> intersection, _, s2_split = s1.intersection(s2, \
+                                                        split_first=False, \
                                                         split_second=True)
 
         """

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -296,6 +296,21 @@ def test_boolean_difference():
     assert sub_mesh.n_cells
 
 
+def test_intersection():
+    sphere = SPHERE.copy()
+    sphere_shifted = SPHERE_SHIFTED.copy()
+    intersection, first, second = sphere.intersection(sphere_shifted, split_first=True, split_second=True)
+
+    assert intersection.n_points
+    assert first.n_points > sphere.n_points
+    assert second.n_points > sphere_shifted.n_points
+
+    intersection, first, second = sphere.intersection(sphere_shifted, split_first=False, split_second=False)
+    assert intersection.n_points
+    assert first.n_points == sphere.n_points
+    assert second.n_points == sphere_shifted.n_points
+
+
 @pytest.mark.parametrize('curv_type', ['mean', 'gaussian', 'maximum', 'minimum'])
 def test_curvature(curv_type):
     sphere = SPHERE.copy()


### PR DESCRIPTION
### Overview

Add `PolyData.intersection` filter ([vtkIntersectionPolyData](https://vtk.org/doc/nightly/html/classvtkIntersectionPolyDataFilter.html)).

### Details

I think this is a useful capability to wrap, and I also need it for my own uses (https://discourse.vtk.org/t/splitting-cells-on-a-polydata/5021/7)

<details>
<summary>code for demo</summary>

```python
import pyvista as pv

s1 = pv.Sphere(center=(0, 0, 0), radius=10)
s2 = pv.Sphere(center=(5, 0, 0), radius=10)

intersection, s1_new, s2_new = s1.intersection(s2)

p = pv.Plotter()
p.add_mesh(intersection, color='r')
p.add_mesh(s1, opacity=0.5)
p.add_mesh(s2, opacity=0.5)
p.show()
```
</details>

![image](https://user-images.githubusercontent.com/2186528/104856264-f90fc680-58ce-11eb-8ff1-a20dfec8eaf3.png)
