### PR TITLE
Add style parameter in text slider widgets

### DIFF
--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -582,7 +582,8 @@ class WidgetHelper:
 
     def add_text_slider_widget(self, callback, data, value=None,
                               pointa=(.4, .9), pointb=(.9, .9),
-                              color=None, event_type='end'):
+                              color=None, event_type='end',
+                              style=None):
         """Add a text slider bar widget.
 
         This is useless without a callback function. You can pass a callable
@@ -616,6 +617,10 @@ class WidgetHelper:
             Either 'start', 'end' or 'always', this defines how often the
             slider interacts with the callback.
 
+        style : str, optional
+            The name of the slider style. The list of available styles are in
+            ``rcParams['slider_style']``. Defaults to None.
+
         Returns
         -------
         slider_widget: vtk.vtkSliderWidget
@@ -645,7 +650,8 @@ class WidgetHelper:
         slider_widget = self.add_slider_widget(callback=_the_callback, rng=[0, n_states - 1],
                                                value=value,
                                                pointa=pointa, pointb=pointb,
-                                               color=color, event_type=event_type)
+                                               color=color, event_type=event_type,
+                                               style=style)
         slider_rep = slider_widget.GetRepresentation()
         slider_rep.ShowSliderLabelOff()
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -3,7 +3,7 @@ import pytest
 
 import pyvista
 from pyvista import examples
-from pyvista.plotting import system_supports_plotting
+from pyvista.plotting import system_supports_plotting, rcParams
 
 NO_PLOTTING = not system_supports_plotting()
 mesh = examples.load_uniform()
@@ -97,7 +97,8 @@ def test_widget_text_slider():
         p.add_text_slider_widget(callback=func, data='foo')
     with pytest.raises(ValueError, match='list of values is empty'):
         p.add_text_slider_widget(callback=func, data=[])
-    p.add_text_slider_widget(callback=func, data=['foo', 'bar'])
+    for style in rcParams["slider_style"].keys():
+        p.add_text_slider_widget(callback=func, data=['foo', 'bar'], style=style)
     p.close()
 
 


### PR DESCRIPTION
This PR exposes the `style` parameter for text slider widgets:

```py
import pyvista as pv

data = ['red', 'green', 'blue', 'purple', 'orange']
cone = pv.Cone()


def set_color(color):
    color = pv.parse_color(color)
    cone.point_arrays['color'] = [color] * cone.n_points


p = pv.Plotter()
p.add_text_slider_widget(set_color, data=data, event_type='always', style='modern')
p.add_mesh(cone, scalars='color', rgba=True)
p.show()
```

![image](https://user-images.githubusercontent.com/18143289/104893822-311d1500-5974-11eb-8dc6-ca0052e6d306.png)

https://user-images.githubusercontent.com/18143289/104893980-66c1fe00-5974-11eb-818e-d941893e9979.mp4

Closes https://github.com/pyvista/pyvista/issues/1059