### PR TITLE
add tuple as type hint for vectors

### DIFF
--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -634,7 +634,7 @@ class Common(DataSetFilters, DataObject):
 
         Parameters
         ----------
-        xyz : list or np.ndarray
+        xyz : list or tuple or np.ndarray
             Length 3 list or array.
 
         """

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -635,7 +635,7 @@ class Common(DataSetFilters, DataObject):
         Parameters
         ----------
         xyz : list or tuple or np.ndarray
-            Length 3 list or array.
+            Length 3 list, tuple or array.
 
         """
         self.points += np.asarray(xyz)

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -60,10 +60,10 @@ def Cylinder(center=(0.,0.,0.), direction=(1.,0.,0.), radius=0.5, height=1.0,
 
     Parameters
     ----------
-    center : list or np.ndarray
+    center : list or tuple or np.ndarray
         Location of the centroid in [x, y, z]
 
-    direction : list or np.ndarray
+    direction : list or tuple or np.ndarray
         Direction cylinder points to  in [x, y, z]
 
     radius : float
@@ -121,10 +121,10 @@ def CylinderStructured(radius=0.5, height=1.0,
     height : float
         Height (length) of the cylinder along its Z-axis
 
-    center : list or np.ndarray
+    center : list or tuple or np.ndarray
         Location of the centroid in [x, y, z]
 
-    direction : list or np.ndarray
+    direction : list or tuple or np.ndarray
         Direction cylinder Z-axis in [x, y, z]
 
     theta_resolution : int
@@ -185,7 +185,7 @@ def Arrow(start=(0.,0.,0.), direction=(1.,0.,0.), tip_length=0.25,
     start : np.ndarray
         Start location in [x, y, z]
 
-    direction : list or np.ndarray
+    direction : list or tuple or np.ndarray
         Direction the arrow points to in [x, y, z]
 
     tip_length : float, optional
@@ -246,7 +246,7 @@ def Sphere(radius=0.5, center=(0, 0, 0), direction=(0, 0, 1), theta_resolution=3
     center : np.ndarray or list, optional
         Center in [x, y, z]
 
-    direction : list or np.ndarray
+    direction : list or tuple or np.ndarray
         Direction the top of the sphere points to in [x, y, z]
 
     theta_resolution: int , optional
@@ -296,10 +296,10 @@ def Plane(center=(0, 0, 0), direction=(0, 0, 1), i_size=1, j_size=1,
 
     Parameters
     ----------
-    center : list or np.ndarray
+    center : list or tuple or np.ndarray
         Location of the centroid in [x, y, z]
 
-    direction : list or np.ndarray
+    direction : list or tuple or np.ndarray
         Direction cylinder points to  in [x, y, z]
 
     i_size : float


### PR DESCRIPTION
### Overview

Where vectors are specified as function arguments in the docstrings, it provides only list and ndarray as type hints.
Even though the typing library is not used in pyvista, I find in Pycharm I still get type warnings, which suggests it is pulling the type hints directly from the docstrings.

Given the default values of vectors are usually tuples (which makes sense), it's a no-brainer for tuples to also be a hinted type, which removes the warnings in my IDE and probably others also.


### Details

Project wide find and replace "list or np.ndarray" -> "list or tuple or np.ndarray"

