### PR TITLE
write frame needs update

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2957,6 +2957,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         """Write a single frame to the movie file."""
         if not hasattr(self, 'mwriter'):
             raise RuntimeError('This plotter has not opened a movie or GIF file.')
+        self.update()
         self.mwriter.append_data(self.image)
 
     def _run_image_filter(self, ifilter):


### PR DESCRIPTION
#1098 pointed out that our `movie.py` example is broken.  Turns out my changes to improve the render speed introduced a side effect in our `write_frame` method.  This PR patches it with a simple fix.
