### PR TITLE
Add variable length density to voxelize

### DIFF
--- a/pyvista/utilities/features.py
+++ b/pyvista/utilities/features.py
@@ -30,7 +30,7 @@ def voxelize(mesh, density=None, check_surface=True):
         density = mesh.length / 100
     if isinstance(density, (int, float)):
         density_x, density_y, density_z = [density] * 3
-    if isinstance(density, (list, set, np.ndarray)):
+    if isinstance(density, (list, set, tuple)):
         density_x, density_y, density_z = density
         
     x_min, x_max, y_min, y_max, z_min, z_max = mesh.bounds

--- a/pyvista/utilities/features.py
+++ b/pyvista/utilities/features.py
@@ -12,8 +12,10 @@ def voxelize(mesh, density=None, check_surface=True):
 
     Parameters
     ----------
-    density : float
-        The uniform size of the voxels. Defaults to 1/100th of the mesh length.
+    density : float or list
+        The uniform size of the voxels when single float passed.
+        A list of densities along x,y,z directions.
+        Defaults to 1/100th of the mesh length.
 
     check_surface : bool
         Specify whether to check the surface for closure. If on, then the
@@ -26,10 +28,15 @@ def voxelize(mesh, density=None, check_surface=True):
         mesh = pyvista.wrap(mesh)
     if density is None:
         density = mesh.length / 100
+    if isinstance(density, (int, float)):
+        density_x, density_y, density_z = [density] * 3
+    if isinstance(density, (list, set, np.ndarray)):
+        density_x, density_y, density_z = density
+        
     x_min, x_max, y_min, y_max, z_min, z_max = mesh.bounds
-    x = np.arange(x_min, x_max, density)
-    y = np.arange(y_min, y_max, density)
-    z = np.arange(z_min, z_max, density)
+    x = np.arange(x_min, x_max, density_x)
+    y = np.arange(y_min, y_max, density_y)
+    z = np.arange(z_min, z_max, density_z)
     x, y, z = np.meshgrid(x, y, z)
 
     # Create unstructured grid from the structured grid

--- a/pyvista/utilities/features.py
+++ b/pyvista/utilities/features.py
@@ -23,6 +23,27 @@ def voxelize(mesh, density=None, check_surface=True):
         manifold. If the surface is not closed and manifold, a runtime
         error is raised.
 
+    Returns
+    -------
+    vox : pyvista.core.pointset.UnstructuredGrid
+        voxelized unstructured grid for original mesh
+
+    Examples
+    --------
+    This example creates an equal density voxelized mesh.
+
+    >>> import pyvista as pv
+    >>> import pyvista.examples as ex
+    >>> mesh = pv.PolyData(ex.load_uniform().points)
+    >>> vox = pv.voxelize(mesh, density=0.5)
+
+    This example creates a voxelized mesh using unequal density dimensions
+
+    >>> import pyvista as pv
+    >>> import pyvista.examples as ex
+    >>> mesh = pv.PolyData(ex.load_uniform().points)
+    >>> vox = pv.voxelize(mesh, density=[0.5, 0.9, 1.4])
+
     """
     if not pyvista.is_pyvista_dataset(mesh):
         mesh = pyvista.wrap(mesh)
@@ -50,8 +71,8 @@ def voxelize(mesh, density=None, check_surface=True):
     mask = selection.point_arrays['SelectedPoints'].view(np.bool_)
 
     # extract cells from point indices
-    return ugrid.extract_points(mask)
-
+    vox = ugrid.extract_points(mask)
+    return vox
 
 def create_grid(dataset, dimensions=(101, 101, 101)):
     """Create a uniform grid surrounding the given dataset.

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -169,6 +169,16 @@ def test_voxelize():
     vox = pyvista.voxelize(mesh, 0.5)
     assert vox.n_cells
 
+def test_voxelize_non_uniform_desnity():
+    mesh = pyvista.PolyData(ex.load_uniform().points)
+    vox = pyvista.voxelize(mesh, [0.5, 0.3, 0.2])
+    assert vox.n_cells
+
+def test_voxelize_throws_when_density_is_not_length_3():
+    with pytest.raises(ValueError) as e:
+        mesh = pyvista.PolyData(ex.load_uniform().points)
+        vox = pyvista.voxelize(mesh, [0.5, 0.3])
+    assert "not enough values to unpack" in str(e.value)
 
 def test_report():
     report = pyvista.Report(gpu=True)


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Add non-uniform density to `pyvista.voxelize`.



<!-- Be sure to link other PRs or issues that relate to this PR here. --> 
Mentioned potentially implementing in in this issue: https://github.com/pyvista/pyvista-support/issues/338#issuecomment-764265944

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- Allows for `density` in `pyvista.voxelize` to be `float/int` or `list/set/tuple` of `float/int` for non uniform density.

Example similar to [test](https://github.com/pyvista/pyvista/pull/1100/files#diff-b259521308ad9b898000f4fea3040c6196bee7fd89e8608a85606e86c8c2c70bR172-R175)
```python
import pyvista
import pyvista.examples as ex

mesh = pyvista.PolyData(ex.load_uniform().points)
vox = pyvista.voxelize(mesh, density=[0.5, 0.3, 0.2])
```

