### PR TITLE
Add make_tri_mesh helper

### DIFF
--- a/docs/core/helpers.rst
+++ b/docs/core/helpers.rst
@@ -1,0 +1,35 @@
+Helpers
+=======
+
+The ``pyvista`` module contains several functions to simplify the
+creation and manipulation of meshes or interfacing with VTK datasets.
+
+
+Wrap a VTK Dataset
+~~~~~~~~~~~~~~~~~~
+.. automethod:: pyvista.helpers.wrap
+
+
+Simplified Triangular Mesh Construction
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: pyvista.helpers.make_tri_mesh
+
+
+Lines from Points
+~~~~~~~~~~~~~~~~~
+.. automethod:: pyvista.helpers.lines_from_points
+
+
+Line Segments from Points
+~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: pyvista.helpers.line_segments_from_points
+             
+
+Convert to and from VTK Datatypes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: pyvista.helpers.convert_array
+
+
+Fit Plane to Points
+~~~~~~~~~~~~~~~~~~~
+.. automethod:: pyvista.helpers.fit_plane_to_points

--- a/docs/core/index.rst
+++ b/docs/core/index.rst
@@ -40,3 +40,4 @@ PyVista has the following mesh types:
    grids
    composite
    filters
+   helpers

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -337,9 +337,12 @@ def lines_from_points(points, close=False):
 
 
 def make_tri_mesh(points, faces):
-    """Construct a pyvista.PolyData from an Nx3 array of points and an
-    Mx3 array of triangle indices, resulting in a mesh with N vertices and
-    M triangles.
+    """Construct a ``pyvista.PolyData`` mesh using points and faces arrays.
+
+    Construct a mesh from an Nx3 array of points and an Mx3 array of
+    triangle indices, resulting in a mesh with N vertices and M
+    triangles.  This function does not require the standard VTK
+    "padding" column and simplifies mesh creation.
 
     Parameters
     ----------

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -337,9 +337,9 @@ def lines_from_points(points, close=False):
 
 
 def make_tri_mesh(points, faces):
-    """Construct a pyvista.PolyData from an Nx3 array of points and an Mx3
-array of triangle indices, resulting in a mesh with N vertices and M
-triangles.
+    """Construct a pyvista.PolyData from an Nx3 array of points and an
+    Mx3 array of triangle indices, resulting in a mesh with N vertices and
+    M triangles.
 
     Parameters
     ----------
@@ -374,7 +374,7 @@ triangles.
     """
     if points.shape[1] != 3:
         raise ValueError("Points array should have shape (N, 3).")
-    if faces.shape[1] != 3:
+    if faces.ndim != 2 or faces.shape[1] != 3:
         raise ValueError("Face array should have shape (M, 3).")
     cells = np.empty((faces.shape[0], 4), dtype=faces.dtype)
     cells[:, 0] = 3

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -336,6 +336,52 @@ def lines_from_points(points, close=False):
     return poly
 
 
+def make_tri_mesh(points, faces):
+    """Construct a pyvista.PolyData from an Nx3 array of points and an Mx3
+array of triangle indices, resulting in a mesh with N vertices and M
+triangles.
+
+    Parameters
+    ----------
+    points : np.ndarray
+        Array of points with shape (N, 3) storing the vertices of the
+        triangle mesh.
+
+    faces : np.ndarray
+        Array of indices with shape (M, 3) containing the triangle
+        indices.
+
+    Returns
+    -------
+    tri_mesh : pyvista.PolyData
+        PolyData instance containing the triangle mesh.
+
+    Examples
+    --------
+    This example discretizes the unit square into a triangle mesh with
+    nine vertices and eight faces.
+
+    >>> import numpy as np
+    >>> import pyvista as pv
+    >>> points = np.array([[0, 0, 0], [0.5, 0, 0], [1, 0, 0], [0, 0.5, 0],
+    ...                    [0.5, 0.5, 0], [1, 0.5, 0], [0, 1, 0], [0.5, 1, 0],
+    ...                    [1, 1, 0]])
+    >>> faces = np.array([[0, 1, 4], [4, 7, 6], [2, 5, 4], [4, 5, 8],
+    ...                   [0, 4, 3], [3, 4, 6], [1, 2, 4], [4, 8, 7]])
+    >>> tri_mesh = pyvista.make_tri_mesh(points, faces)
+    >>> tri_mesh.plot(show_edges=True) # doctest:+SKIP
+
+    """
+    if points.shape[1] != 3:
+        raise ValueError("Points array should have shape (N, 3).")
+    if faces.shape[1] != 3:
+        raise ValueError("Face array should have shape (M, 3).")
+    cells = np.empty((faces.shape[0], 4), dtype=faces.dtype)
+    cells[:, 0] = 3
+    cells[:, 1:] = faces
+    return pyvista.PolyData(points, cells)
+
+
 def vector_poly_data(orig, vec):
     """Create a vtkPolyData object composed of vectors."""
     # shape, dimension checking

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,8 @@
-import pyvista
+import pytest
 import trimesh
 import numpy as np
+
+import pyvista
 
 
 def test_wrap_trimesh():
@@ -12,3 +14,17 @@ def test_wrap_trimesh():
 
     assert np.allclose(tmesh.vertices, mesh.points)
     assert np.allclose(tmesh.faces, mesh.faces[1:])
+
+
+def test_make_tri_mesh(sphere):
+    with pytest.raises(ValueError):
+        pyvista.make_tri_mesh(sphere.points, sphere.faces)
+
+    with pytest.raises(ValueError):
+        pyvista.make_tri_mesh(sphere.points[:, :1], sphere.faces)
+
+    faces = sphere.faces.reshape(-1, 4)[:, 1:]
+    mesh = pyvista.make_tri_mesh(sphere.points, faces)
+
+    assert np.allclose(sphere.points, mesh.points)
+    assert np.allclose(sphere.faces, mesh.faces)


### PR DESCRIPTION
### Overview

Add a helper method for the common use case of building a `pyvista.PolyData` from an `Nx3` point array and `Mx3` face array. This is mentioned in https://github.com/pyvista/pyvista/issues/1097.

### Details

Pretty simple: take some pain out of manually putting together the vtk-style cell array when we know that our mesh consists only of triangles, since doing this kind of thing is so common.