### PR TITLE
🚩 Add option level and quads to function Box

### DIFF
--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -408,17 +408,33 @@ def Cube(center=(0., 0., 0.), x_length=1.0, y_length=1.0, z_length=1.0, bounds=N
     return pyvista.wrap(src.GetOutput())
 
 
-def Box(bounds=(-1.,1.,-1.,1.,-1.,1.)):
+def Box(bounds=(-1.,1.,-1.,1.,-1.,1.), level = 0, quads = True):
     """Create a box with solid faces for the given bounds.
 
     Parameters
     ----------
     bounds : np.ndarray or list
-        Specify the bounding box of the cube. If given, all other arguments are
-        ignored. ``(xMin,xMax, yMin,yMax, zMin,zMax)``
+        Specify the bounding box of the cube.
+        ``(xMin,xMax, yMin,yMax, zMin,zMax)``
+
+    level : int
+        Level of subdivision of the faces.
+
+    quads : bool, optional
+        Flag to tell the source to generate either a quad or two triangle for a set of four points.  Default True
 
     """
-    return Cube(bounds=bounds)
+    if np.array(bounds).size != 6:
+        raise TypeError('Bounds must be given as length 6 tuple: (xMin,xMax, yMin,yMax, zMin,zMax)')
+    src = vtk.vtkTessellatedBoxSource()
+    src.SetLevel(level)
+    if quads is True:
+       src.QuadsOn()
+    else:
+       src.QuadsOff()
+    src.SetBounds(bounds)
+    src.Update()
+    return pyvista.wrap(src.GetOutput())
 
 
 def Cone(center=(0.,0.,0.), direction=(1.,0.,0.), height=1.0, radius=None,

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -408,27 +408,28 @@ def Cube(center=(0., 0., 0.), x_length=1.0, y_length=1.0, z_length=1.0, bounds=N
     return pyvista.wrap(src.GetOutput())
 
 
-def Box(bounds=(-1.,1.,-1.,1.,-1.,1.), level = 0, quads = True):
+def Box(bounds=(-1., 1., -1., 1., -1., 1.), level=0, quads=True):
     """Create a box with solid faces for the given bounds.
 
     Parameters
     ----------
     bounds : np.ndarray or list
         Specify the bounding box of the cube.
-        ``(xMin,xMax, yMin,yMax, zMin,zMax)``
+        ``(xMin, xMax, yMin, yMax, zMin, zMax)``
 
     level : int
         Level of subdivision of the faces.
 
     quads : bool, optional
-        Flag to tell the source to generate either a quad or two triangle for a set of four points.  Default True
+        Flag to tell the source to generate either a quad or two
+        triangle for a set of four points.  Default ``True``.
 
     """
     if np.array(bounds).size != 6:
-        raise TypeError('Bounds must be given as length 6 tuple: (xMin,xMax, yMin,yMax, zMin,zMax)')
+        raise TypeError('Bounds must be given as length 6 tuple: (xMin, xMax, yMin, yMax, zMin, zMax)')
     src = vtk.vtkTessellatedBoxSource()
     src.SetLevel(level)
-    if quads is True:
+    if quads:
        src.QuadsOn()
     else:
        src.QuadsOff()

--- a/tests/test_geometric_objects.py
+++ b/tests/test_geometric_objects.py
@@ -79,6 +79,17 @@ def test_box():
     geom = pyvista.Box()
     assert np.any(geom.points)
 
+    bounds = [-10.0, 10.0, 10.0, 20.0, -5.0, 5.0]
+    level = 3
+    quads = True
+    mesh1 = pyvista.Box(bounds, level, quads)
+    assert mesh1.n_cells == (level + 1) * (level + 1) * 6
+    assert np.allclose(mesh1.bounds, bounds)
+
+    quads = False
+    mesh2 = pyvista.Box(bounds, level, quads)
+    assert mesh2.n_cells == mesh1.n_cells*2
+
 
 def test_polygon():
     geom = pyvista.Polygon()


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
:triangular_flag_on_post: Add option level and quads to function Box. This also replace the Cube to vtkTessellatedBoxSource in Box function.
```python
>>> import pyvista
>>> bounds = [-10.0, 10.0, 10.0, 20.0, -5.0, 5.0]
>>> level = 3
>>> quads = True
>>> mesh1 = pyvista.Box(bounds, level, quads)
>>> mesh1.plot()
```
![mesh2](https://user-images.githubusercontent.com/7513610/105571747-df222800-5d95-11eb-91bb-405f0de8b11e.png)

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

This Pull Request is reproduce the example. 
https://lorensen.github.io/VTKExamples/site/Python/GeometricObjects/TessellatedBoxSource/

