### PR TITLE
Fix double blocking of `plotter.show` in script mode on Windows

### DIFF
--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -114,3 +114,6 @@ except KeyError:
 FLOAT_FORMAT = "{:.3e}"
 
 VERY_FIRST_RENDER = [True]
+
+# Check if python is running in interactive mode (see https://stackoverflow.com/a/64523765)
+IS_INTERACTIVE = hasattr(sys, 'ps1')

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4139,13 +4139,15 @@ class Plotter(BasePlotter):
         self._on_first_render_request(cpos)
 
         # Render
-        # For Windows issues. Resolves #186 and #1018
-        if os.name == 'nt' and not pyvista.VERY_FIRST_RENDER:
+        # For Windows issues. Resolves #186, #1018 and #1078
+        if os.name == 'nt' and pyvista.IS_INTERACTIVE and not pyvista.VERY_FIRST_RENDER:
             if interactive and (not self.off_screen):
                 self.iren.Start()
         pyvista.VERY_FIRST_RENDER = False
         # for some reason iren needs to start before rendering on
-        # Windows (but not after the very first render window
+        # Windows when running in interactive mode (python console,
+        # Ipython console, Jupyter notebook) but only after the very
+        # first render window
 
         self.render()
 


### PR DESCRIPTION
### Overview

Resolves #1078.
After closer investigation I was able to reproduce #1018 while in an interactive (native) python shell, an IPython shell or a Jupyter notebook on Windows 10. However the fix in #1049 resulted in a double blocking of the plotter window while executed from a script (see example code in #1078).


### Details

This PR adds an extra check to see whether we are running on Windows in interactive mode. In that case the fix in #1049 is applied. Otherwise (e.g. in script mode on Windows) the old behaviour is retained, solving the double blocking.

