### PR TITLE
Add slicing, concatenation to StructuredGrid

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -4639,6 +4639,25 @@ class StructuredGridFilters(DataSetFilters):
         alg.Update()
         return _get_output(alg)
 
+    def concatenate(dataset, *structured_grids):
+        """Concatenate other structured grids to this grid.
+
+        Takes the components from multiple inputs and merges them into one output.
+        All inputs must have the same number of scalar components. All inputs must
+        have the same scalar type.
+
+        Parameters
+        ----------
+        *structured_grids : pyvista.StructuredGrid
+            Structured grids to append.
+        """
+        alg = vtk.vtkStructuredGridAppend()
+        alg.AddInputData(dataset)
+        for grid in structured_grids:
+            alg.AddInputData(grid)
+        alg.Update()
+        return _get_output(alg)
+
 
 @abstract_class
 class UniformGridFilters(DataSetFilters):

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -4710,10 +4710,12 @@ class StructuredGridFilters(DataSetFilters):
                                    % (dataset.dimensions, other.dimensions))
 
         # check point/cell variables are the same
-        assert set(dataset.point_arrays.keys()) == \
-               set(other.point_arrays.keys())
-        assert set(dataset.cell_arrays.keys()) == \
-               set(other.cell_arrays.keys())
+        if not set(dataset.point_arrays.keys()) == \
+               set(other.point_arrays.keys()):
+            raise RuntimeError('Grid to concatenate has different point array names.')
+        if not set(dataset.cell_arrays.keys()) == \
+               set(other.cell_arrays.keys()):
+            raise RuntimeError('Grid to concatenate has different cell array names.')
 
         # check that points are coincident (within tolerance) along seam
         if not np.allclose(np.take(dataset.points_matrix, indices=-1, axis=axis),

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2636,7 +2636,7 @@ class DataSetFilters:
 
 @abstract_class
 class CompositeFilters:
-    """An internal class to manage filtes/algorithms for composite datasets."""
+    """An internal class to manage filters/algorithms for composite datasets."""
 
     def extract_geometry(composite):
         """Combine the geomertry of all blocks into a single ``PolyData`` object.
@@ -2733,7 +2733,7 @@ class CompositeFilters:
 
 @abstract_class
 class PolyDataFilters(DataSetFilters):
-    """An internal class to manage filtes/algorithms for polydata datasets."""
+    """An internal class to manage filters/algorithms for polydata datasets."""
 
     def edge_mask(poly_data, angle):
         """Return a mask of the points of a surface mesh that has a surface angle greater than angle.
@@ -4579,7 +4579,7 @@ class PolyDataFilters(DataSetFilters):
 
 @abstract_class
 class UnstructuredGridFilters(DataSetFilters):
-    """An internal class to manage filtes/algorithms for unstructured grid datasets."""
+    """An internal class to manage filters/algorithms for unstructured grid datasets."""
 
     def delaunay_2d(ugrid, tol=1e-05, alpha=0.0, offset=1.0, bound=False,
                     progress_bar=False):
@@ -4600,6 +4600,8 @@ class UnstructuredGridFilters(DataSetFilters):
 
 @abstract_class
 class StructuredGridFilters(DataSetFilters):
+    """An internal class to manage filters/algorithms for structured grid datasets."""
+    
     def extract_subset(dataset, voi, rate=(1, 1, 1), boundary=False):
         """Select piece (e.g., volume of interest).
 
@@ -4661,7 +4663,7 @@ class StructuredGridFilters(DataSetFilters):
 
 @abstract_class
 class UniformGridFilters(DataSetFilters):
-    """An internal class to manage filtes/algorithms for uniform grid datasets."""
+    """An internal class to manage filters/algorithms for uniform grid datasets."""
 
     def gaussian_smooth(dataset, radius_factor=1.5, std_dev=2.,
                         scalars=None, preference='points', progress_bar=False):

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -4647,7 +4647,7 @@ class StructuredGridFilters(DataSetFilters):
         For fun, add the two grids back together and show they are
         identical to the original grid.
 
-        >>> joined = voi_1 + voi_2
+        >>> joined = voi_1.concatenate(voi_2, axis=1)
         >>> assert np.allclose(grid.points, joined.points)
         """
         alg = vtk.vtkExtractGrid()
@@ -4658,32 +4658,29 @@ class StructuredGridFilters(DataSetFilters):
         alg.Update()
         return _get_output(alg)
 
-    def __add__(dataset, other_dataset):
-        """Join two datasets together.
+    def concatenate(dataset, other, axis, tolerance=0.0):
+        """Concatenate a structured grids to this grid.
 
-        When both datasets are structured, concatenate these grids.
-
-        """
-        if isinstance(other_dataset, vtk.vtkStructuredGrid):
-            return dataset.concatenate(dataset, other_dataset)
-        return dataset.merge(other_dataset)
-
-    def concatenate(dataset, *structured_grids):
-        """Concatenate other structured grids to this grid.
-
-        Takes the components from multiple inputs and merges them into
-        one output.  All inputs must have the same number of scalar
-        components. All inputs must have the same scalar type.
+        Joins structured grids into a single structured grid.
+        Grids must be of compatible dimension, and must be coincident
+        along the seam. Grids must have the same point and cell data.
+        Field data is ignored.
 
         Parameters
         ----------
-        *structured_grids : pyvista.StructuredGrid
-            Structured grids to append.
+        other : pyvista.StructuredGrid
+            Structured grid to concatenate.
+
+        axis : int
+            Axis along which to concatenate.
+
+        tolerance : float
+            Tolerance for point coincidence along joining seam.
 
         Returns
         --------
         pyvista.StructuredGrid
-            Concatenated grids.
+            Concatenated grid.
 
         Examples
         --------
@@ -4695,16 +4692,77 @@ class StructuredGridFilters(DataSetFilters):
         >>> grid = examples.load_structured()
         >>> voi_1 = grid.extract_subset([0, 80, 0, 40, 0, 1], boundary=True)
         >>> voi_2 = grid.extract_subset([0, 80, 40, 80, 0, 1], boundary=True)
-        >>> joined = voi_1 + voi_2
+        >>> joined = voi_1.concatenate(voi_2, axis=1)
         >>> print(grid.dimensions, 'same as', joined.dimensions)
         [80, 80, 1] same as [80, 80, 1]
         """
-        alg = vtk.vtkStructuredGridAppend()
-        alg.AddInputData(dataset)
-        for grid in structured_grids:
-            alg.AddInputData(grid)
-        alg.Update()
-        return _get_output(alg)
+        if axis > 2:
+            raise RuntimeError('Concatenation axis must be <= 2.')
+
+        # check dimensions are compatible
+        for i, (dim1, dim2) in enumerate(zip(dataset.dimensions,
+                                             other.dimensions)):
+            if i == axis:
+                continue
+            if dim1 != dim2:
+                raise RuntimeError('StructuredGrids with dimensions %s and %s '
+                                   'are not compatible.'
+                                   % (dataset.dimensions, other.dimensions))
+
+        # check point/cell variables are the same
+        assert set(dataset.point_arrays.keys()) == \
+               set(other.point_arrays.keys())
+        assert set(dataset.cell_arrays.keys()) == \
+               set(other.cell_arrays.keys())
+
+        # check that points are coincident (within tolerance) along seam
+        if not np.allclose(np.take(dataset.points_matrix, indices=-1, axis=axis),
+                           np.take(other.points_matrix, indices=0, axis=axis),
+                           atol=tolerance):
+            raise RuntimeError('Grids cannot be joined along axis %d, as points '
+                               'are not coincident within tolerance of %f.'
+                               % (axis, tolerance))
+
+        # slice to cut off the repeated grid face
+        slice_spec = [slice(None, None, None)] * 3
+        slice_spec[axis] = slice(0, -1, None)
+
+        # concatenate points, cutting off duplicate
+        new_points = np.concatenate((dataset.points_matrix[slice_spec],
+                                     other.points_matrix), axis=axis)
+
+        # concatenate point arrays, cutting off duplicate
+        new_point_data = {}
+        for name, point_array in dataset.point_arrays.items():
+            arr_1 = dataset._reshape_point_array(point_array)
+            arr_2 = other._reshape_point_array(other.point_arrays[name])
+            if not np.array_equal(np.take(arr_1, indices=-1, axis=axis),
+                                  np.take(arr_2, indices=0, axis=axis)):
+                raise RuntimeError('Grids cannot be joined along axis %d, as field '
+                                   '`%s` is not identical along the seam.'
+                                   % (axis, name))
+            new_point_data[name] = np.concatenate((arr_1[slice_spec], arr_2),
+                                                  axis=axis).ravel(order='F')
+
+        new_dims = np.array(dataset.dimensions)
+        new_dims[axis] += other.dimensions[axis] - 1
+
+        # concatenate cell arrays
+        new_cell_data = {}
+        for name, cell_array in dataset.cell_arrays.items():
+            arr_1 = dataset._reshape_cell_array(cell_array)
+            arr_2 = other._reshape_cell_array(other.cell_arrays[name])
+            new_cell_data[name] = np.concatenate((arr_1, arr_2),
+                                                 axis=axis).ravel(order='F')
+
+        # assemble output
+        joined = pyvista.StructuredGrid()
+        joined.dimensions = list(new_dims)
+        joined.points = new_points.reshape((-1, 3), order='F')
+        joined.point_arrays.update(new_point_data)
+        joined.cell_arrays.update(new_cell_data)
+
+        return joined
 
 
 @abstract_class

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -4599,6 +4599,48 @@ class UnstructuredGridFilters(DataSetFilters):
 
 
 @abstract_class
+class StructuredGridFilters(DataSetFilters):
+    def extract_subset(dataset, voi, rate=(1, 1, 1), boundary=False):
+        """Select piece (e.g., volume of interest).
+
+        To use this filter set the VOI ivar which are i-j-k min/max indices
+        that specify a rectangular region in the data. (Note that these are
+        0-offset.) You can also specify a sampling rate to subsample the
+        data.
+
+        Typical applications of this filter are to extract a slice from a
+        volume for image processing, subsampling large volumes to reduce data
+        size, or extracting regions of a volume with interesting data.
+
+        Parameters
+        ----------
+        voi : tuple(int)
+            Length 6 iterable of ints: ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+            These bounds specify the volume of interest in i-j-k min/max
+            indices.
+
+        rate : tuple(int)
+            Length 3 iterable of ints: ``(xrate, yrate, zrate)``.
+            Default: ``(1, 1, 1)``
+
+        boundary : bool
+            Control whether to enforce that the "boundary" of the grid is
+            output in the subsampling process. (This only has effect
+            when the rate in any direction is not equal to 1). When
+            this is on, the subsampling will always include the boundary of
+            the grid even though the sample rate is not an even multiple of
+            the grid dimensions. (By default this is off.)
+        """
+        alg = vtk.vtkExtractGrid()
+        alg.SetVOI(voi)
+        alg.SetInputDataObject(dataset)
+        alg.SetSampleRate(rate)
+        alg.SetIncludeBoundary(boundary)
+        alg.Update()
+        return _get_output(alg)
+
+
+@abstract_class
 class UniformGridFilters(DataSetFilters):
     """An internal class to manage filtes/algorithms for uniform grid datasets."""
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -998,11 +998,11 @@ class StructuredGrid(vtkStructuredGrid, PointGrid, StructuredGridFilters):
         self.cell_arrays[vtk.vtkDataSetAttributes.GhostArrayName()] = ghost_cells
 
     def _reshape_point_array(self, array):
-        """Reshape point data to a 3-D matrix"""
+        """Reshape point data to a 3-D matrix."""
         return array.reshape(self.dimensions, order='F')
 
     def _reshape_cell_array(self, array):
-        """Reshape cell data to a 3-D matrix"""
+        """Reshape cell data to a 3-D matrix."""
         cell_dims = np.array(self.dimensions) - 1
         cell_dims[cell_dims == 0] = 1
         return array.reshape(cell_dims, order='F')

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -935,6 +935,8 @@ class StructuredGrid(vtkStructuredGrid, PointGrid, StructuredGridFilters):
         # convert slice to VOI specification - only "basic indexing" is supported
         voi = []
         rate = []
+        if len(key) != 3:
+            raise RuntimeError('Slices must have exactly 3 dimensions.')
         for i, k in enumerate(key):
             if isinstance(k, collections.Iterable):
                 raise RuntimeError('Fancy indexing is not supported.')

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -928,7 +928,6 @@ class StructuredGrid(vtkStructuredGrid, PointGrid, StructuredGridFilters):
 
     def __getitem__(self, key):
         """Slice subsets of the StructuredGrid, or extract an array field."""
-
         # legacy behavior which looks for a point or cell array
         if not isinstance(key, tuple):
             return super().__getitem__(key)

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -908,17 +908,22 @@ class StructuredGrid(vtkStructuredGrid, PointGrid, StructuredGridFilters):
     @property
     def x(self):
         """Return the X coordinates of all points."""
-        return self.points[:, 0].reshape(self.dimensions, order='F')
+        return self._reshape_point_array(self.points[:, 0])
 
     @property
     def y(self):
         """Return the Y coordinates of all points."""
-        return self.points[:, 1].reshape(self.dimensions, order='F')
+        return self._reshape_point_array(self.points[:, 1])
 
     @property
     def z(self):
         """Return the Z coordinates of all points."""
-        return self.points[:, 2].reshape(self.dimensions, order='F')
+        return self._reshape_point_array(self.points[:, 2])
+
+    @property
+    def points_matrix(self):
+        """Points as a 4-D matrix, with x/y/z along the last dimension."""
+        return self.points.reshape((*self.dimensions, 3), order='F')
 
     def _get_attrs(self):
         """Return the representation methods (internal helper)."""
@@ -991,3 +996,13 @@ class StructuredGrid(vtkStructuredGrid, PointGrid, StructuredGridFilters):
         # have no effect
 
         self.cell_arrays[vtk.vtkDataSetAttributes.GhostArrayName()] = ghost_cells
+
+    def _reshape_point_array(self, array):
+        """Reshape point data to a 3-D matrix"""
+        return array.reshape(self.dimensions, order='F')
+
+    def _reshape_cell_array(self, array):
+        """Reshape cell data to a 3-D matrix"""
+        cell_dims = np.array(self.dimensions) - 1
+        cell_dims[cell_dims == 0] = 1
+        return array.reshape(cell_dims, order='F')

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -18,7 +18,7 @@ import pyvista
 from pyvista.utilities import abstract_class
 from pyvista.utilities.cells import CellArray, numpy_to_idarr, generate_cell_offsets, create_mixed_cells, get_mixed_cells
 from .common import Common
-from .filters import PolyDataFilters, UnstructuredGridFilters
+from .filters import PolyDataFilters, UnstructuredGridFilters, StructuredGridFilters
 from ..utilities.fileio import get_ext
 
 log = logging.getLogger(__name__)
@@ -795,7 +795,7 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
             return vtk_to_numpy(self.GetCellLocationsArray())
 
 
-class StructuredGrid(vtkStructuredGrid, PointGrid):
+class StructuredGrid(vtkStructuredGrid, PointGrid, StructuredGridFilters):
     """Extend the functionality of a vtk.vtkStructuredGrid object.
 
     Can be initialized in several ways:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1033,8 +1033,19 @@ def test_concatenate_structured_bad_point_arrays(structured_grids_split_coincide
 
 
 def test_concatenate_structured_disconnected(structured_grids_split_disconnected):
-    # test disconnected pieces
     voi_1, voi_2 = structured_grids_split_disconnected
+    with pytest.raises(RuntimeError):
+        joined = voi_1.concatenate(voi_2, axis=1)
+
+
+def test_concatenate_structured_different_arrays(structured_grids_split_coincident):
+    voi_1, voi_2, structured = structured_grids_split_coincident
+    point_data = voi_1.point_arrays.pop('point_data')
+    with pytest.raises(RuntimeError):
+        joined = voi_1.concatenate(voi_2, axis=1)
+
+    voi_1.point_arrays['point_data'] = point_data
+    voi_1.cell_arrays.remove('cell_data')
     with pytest.raises(RuntimeError):
         joined = voi_1.concatenate(voi_2, axis=1)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -960,6 +960,11 @@ def test_extract_subset():
     #   https://gitlab.kitware.com/vtk/vtk/-/issues/17938
     assert voi.origin == voi.bounds[::2]
 
+def test_extract_subset_structured():
+    structured = examples.load_structured()
+    voi = structured.extract_subset([0,3,1,4,0,1])
+    assert isinstance(voi, pyvista.StructuredGrid)
+    assert voi.dimensions == [4, 4, 1]
 
 def test_poly_data_strip():
     mesh = examples.load_airplane()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -966,6 +966,18 @@ def test_extract_subset_structured():
     assert isinstance(voi, pyvista.StructuredGrid)
     assert voi.dimensions == [4, 4, 1]
 
+def test_concatenate_structured():
+    structured = examples.load_structured()
+
+    # split the grid into two
+    voi_1 = structured.extract_subset([0, 40, 0, 40, 0, 1], boundary=True)
+    voi_2 = structured.extract_subset([40, 80, 40, 80, 0, 1], boundary=True)
+
+    # then recombine
+    joined = voi_1.concatenate(voi_2)
+    assert structured.points == pytest.approx(joined.points)
+    assert structured.volume == pytest.approx(joined.volume)
+
 def test_poly_data_strip():
     mesh = examples.load_airplane()
     slc = mesh.slice(normal='z', origin=(0,0,-10))

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -952,35 +952,61 @@ def test_compute_derivatives():
     with pytest.raises(TypeError):
         derv = mesh.compute_derivative()
 
+
 def test_extract_subset():
     volume = examples.load_uniform()
-    voi = volume.extract_subset([0,3,1,4,5,7])
+    voi = volume.extract_subset([0, 3, 1, 4, 5, 7])
     assert isinstance(voi, pyvista.UniformGrid)
     # Test that we fix the confusing issue from extents in
     #   https://gitlab.kitware.com/vtk/vtk/-/issues/17938
     assert voi.origin == voi.bounds[::2]
 
+
 def test_extract_subset_structured():
     structured = examples.load_structured()
-    voi = structured.extract_subset([0,3,1,4,0,1])
+    voi = structured.extract_subset([0, 3, 1, 4, 0, 1])
     assert isinstance(voi, pyvista.StructuredGrid)
     assert voi.dimensions == [4, 4, 1]
+
 
 def test_concatenate_structured():
     structured = examples.load_structured()
 
     # split the grid into two
-    voi_1 = structured.extract_subset([0, 40, 0, 40, 0, 1], boundary=True)
-    voi_2 = structured.extract_subset([40, 80, 40, 80, 0, 1], boundary=True)
+    voi_1 = structured.extract_subset([0, 80, 0, 40, 0, 1], boundary=True)
+    voi_2 = structured.extract_subset([0, 80, 40, 80, 0, 1], boundary=True)
 
     # then recombine
     joined = voi_1.concatenate(voi_2)
     assert structured.points == pytest.approx(joined.points)
     assert structured.volume == pytest.approx(joined.volume)
 
+
+def test_structured_add():
+    structured = examples.load_structured()
+
+    # split the grid into two
+    voi_1 = structured.extract_subset([0, 80, 0, 40, 0, 1], boundary=True)
+    voi_2 = structured.extract_subset([0, 80, 40, 80, 0, 1], boundary=True)
+
+    # then recombine
+    joined = voi_1 + voi_2
+
+    # ensure type remains structured
+    assert isinstance(joined, type(voi_1))
+    assert structured.points == pytest.approx(joined.points)
+    assert structured.volume == pytest.approx(joined.volume)
+
+
+def test_structured_add_non_grid():
+    grid = examples.load_structured()
+    merged = grid + examples.load_hexbeam()
+    assert isinstance(merged, pyvista.UnstructuredGrid)
+
+
 def test_poly_data_strip():
     mesh = examples.load_airplane()
-    slc = mesh.slice(normal='z', origin=(0,0,-10))
+    slc = mesh.slice(normal='z', origin=(0, 0, -10))
     stripped = slc.strip()
     assert stripped.n_cells == 1
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -489,6 +489,11 @@ def test_slice_structured(struct_grid):
         # fancy indexing error
         struct_grid[[1, 2, 3], :, 1:3]
 
+    with pytest.raises(RuntimeError):
+        # incorrect number of dims error
+        struct_grid[:, :]
+
+
 
 def test_invalid_init_structured():
     xrng = np.arange(-10, 10, 2)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -476,6 +476,20 @@ def test_init_structured(struct_grid):
     assert np.allclose(grid_a.points, grid.points)
 
 
+def test_slice_structured(struct_grid):
+    sliced = struct_grid[1, :, 1:3]  # three different kinds of slices
+    assert sliced.dimensions == [1, struct_grid.dimensions[1], 2]
+
+    # check that points are in the right place
+    assert struct_grid.x[1, :, 1:3].ravel() == pytest.approx(sliced.x.ravel())
+    assert struct_grid.y[1, :, 1:3].ravel() == pytest.approx(sliced.y.ravel())
+    assert struct_grid.z[1, :, 1:3].ravel() == pytest.approx(sliced.z.ravel())
+
+    with pytest.raises(RuntimeError):
+        # fancy indexing error
+        struct_grid[[1, 2, 3], :, 1:3]
+
+
 def test_invalid_init_structured():
     xrng = np.arange(-10, 10, 2)
     yrng = np.arange(-10, 10, 2)


### PR DESCRIPTION
### Overview

Make working with `StructuredGrid` more natural.
- Add slicing via by implementing `StructuredGridFilters.extract_subset()`, calling vtkExtractGrid. Make this accessible from `StructuredGrid.__getitem__` (also retains legacy behavior)
    - Note that subsets are not views to the original data, which may be confusing if you expect everything to behave NumPy-like.
- Add concatenation by implementing `StructuredGridFilters.concatenate()`, calling vtkStructuredGridAppend

### Details

Demonstration of new features

```python
from pyvista import examples

structured = examples.load_structured()

# add some point data
structured.point_arrays.update({'my_field': structured.z.ravel(order='F')})

# this still works
structured['my_field']

# but you can also specify a numpy-like slice, "basic" indexing only
# here we split the grid into two
voi_1 = structured[:40, :40, :]
voi_2 = structured[40:, 40:, :]

# rejoin it
joined = voi_1.concatenate(voi_2)

print(structured)
print(joined)
```

Outputs:
```
StructuredGrid (0x14268e050)
  N Cells:	6241
  N Points:	6400
  X Bounds:	-1.000e+01, 9.750e+00
  Y Bounds:	-1.000e+01, 9.750e+00
  Z Bounds:	-1.000e+00, 1.000e+00
  Dimensions:	80, 80, 1
  N Arrays:	1

StructuredGrid (0x1426a1a60)
  N Cells:	6241
  N Points:	6400
  X Bounds:	-1.000e+01, 9.750e+00
  Y Bounds:	-1.000e+01, 9.750e+00
  Z Bounds:	-1.000e+00, 1.000e+00
  Dimensions:	80, 80, 1
  N Arrays:	1
```


