### PR TITLE
Add reflect filter and other methods

### DIFF
--- a/examples/01-filter/reflect.py
+++ b/examples/01-filter/reflect.py
@@ -17,7 +17,7 @@ from pyvista import examples
 airplane = examples.load_airplane()
 
 ###############################################################################
-# Reflects the mesh across a plane parallel to Z plane and centered in -100
+# Reflect the mesh across a plane parallel to Z plane and centered in -100
 # (the geometry input is copied to the output):
 airplane = airplane.reflect('z', copy=True, center=-100)
 

--- a/examples/01-filter/reflect.py
+++ b/examples/01-filter/reflect.py
@@ -13,7 +13,7 @@ from pyvista import examples
 ###############################################################################
 # This example demonstrates how to reflect a mesh across a plane.
 #
-# Loads an example mesh:
+# Load an example mesh:
 airplane = examples.load_airplane()
 
 ###############################################################################

--- a/examples/01-filter/reflect.py
+++ b/examples/01-filter/reflect.py
@@ -22,5 +22,5 @@ airplane = examples.load_airplane()
 airplane = airplane.reflect('z', copy=True, center=-100)
 
 ###############################################################################
-# Plots the reflected mesh:
+# Plot the reflected mesh:
 airplane.plot(show_edges=True)

--- a/examples/01-filter/reflect.py
+++ b/examples/01-filter/reflect.py
@@ -1,0 +1,26 @@
+"""
+.. _ref_reflect_example:
+
+Reflect Meshes
+~~~~~~~~~~~~~~
+
+Reflects a mesh across a plane.
+
+"""
+
+from pyvista import examples
+
+###############################################################################
+# This example demonstrates how to reflect a mesh across a plane.
+#
+# Loads an example mesh:
+airplane = examples.load_airplane()
+
+###############################################################################
+# Reflects the mesh across a plane parallel to Z plane and centered in -100
+# (the geometry input is copied to the output):
+airplane = airplane.reflect('z', copy=True, center=-100)
+
+###############################################################################
+# Plots the reflected mesh:
+airplane.plot(show_edges=True)

--- a/examples/01-filter/reflect.py
+++ b/examples/01-filter/reflect.py
@@ -4,7 +4,7 @@
 Reflect Meshes
 ~~~~~~~~~~~~~~
 
-Reflects a mesh across a plane.
+This example reflects a mesh across a plane.
 
 """
 

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -1098,8 +1098,7 @@ class Common(DataSetFilters, DataObject):
             The limits of the cell in the X, Y and Z directions respectivelly.
 
         """
-        bounds = self.GetCell(ind).GetBounds()
-        return list(bounds)
+        return list(self.GetCell(ind).GetBounds())
 
     def cell_type(self, ind):
         """Return the type of a cell.

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -238,15 +238,50 @@ class DataObject:
 
     @property
     def actual_memory_size(self):
-        """Return the actual size of the dataset object in kibibytes (1024 bytes)."""
+        """Return the actual size of the dataset object in kibibytes (1024 bytes).
+
+        Returns
+        -------
+        int
+            The actual size of the dataset object in kibibytes (1024 bytes).
+
+        Examples
+        --------
+        >>> from pyvista import examples
+        >>> mesh = examples.load_airplane()
+        >>> mesh.actual_memory_size
+        93
+
+        """
         return self.GetActualMemorySize()
 
     def copy_structure(self, dataset):
-        """Copy the structure (geometry and topology) of the input dataset object."""
+        """Copy the structure (geometry and topology) of the input dataset object.
+
+        Examples
+        --------
+        >>> import pyvista as pv
+        >>> source = pv.UniformGrid((10, 10, 5))
+        >>> target = pv.UniformGrid()
+        >>> target.copy_structure(source)
+        >>> target.plot(show_edges=True)
+
+        """
         self.CopyStructure(dataset)
 
     def copy_attributes(self, dataset):
-        """Copy the data attributes of the input dataset object."""
+        """Copy the data attributes of the input dataset object.
+
+        Examples
+        --------
+        >>> import pyvista as pv
+        >>> source = pv.UniformGrid((10, 10, 5))
+        >>> source = source.compute_cell_sizes()
+        >>> target = pv.UniformGrid((10, 10, 5))
+        >>> target.copy_attributes(source)
+        >>> target.plot(scalars='Volume', show_edges=True)
+
+        """
         self.CopyAttributes(dataset)
 
 
@@ -1063,6 +1098,13 @@ class Common(DataSetFilters, DataObject):
         int
             Number of points in the cell.
 
+        Examples
+        --------
+        >>> from pyvista import examples
+        >>> mesh = examples.load_airplane()
+        >>> mesh.cell_n_points(0)
+        3
+
         """
         return self.GetCell(ind).GetPoints().GetNumberOfPoints()
 
@@ -1079,6 +1121,15 @@ class Common(DataSetFilters, DataObject):
         numpy.ndarray
             An array of floats with shape (number of points, 3) containing the coordinates of the
             cell corners.
+
+        Examples
+        --------
+        >>> from pyvista import examples
+        >>> mesh = examples.load_airplane()
+        >>> mesh.cell_points(0)
+        [[896.99401855  48.76010132  82.26560211]
+         [906.59301758  48.76010132  80.74520111]
+         [907.53900146  55.49020004  83.65809631]]
 
         """
         points = self.GetCell(ind).GetPoints().GetData()
@@ -1097,6 +1148,14 @@ class Common(DataSetFilters, DataObject):
         list(float)
             The limits of the cell in the X, Y and Z directions respectivelly.
 
+        Examples
+        --------
+        >>> from pyvista import examples
+        >>> mesh = examples.load_airplane()
+        >>> mesh.cell_bounds(0)
+        [896.9940185546875, 907.5390014648438, 48.760101318359375, 55.49020004272461,
+        80.74520111083984, 83.65809631347656]
+
         """
         return list(self.GetCell(ind).GetBounds())
 
@@ -1111,7 +1170,14 @@ class Common(DataSetFilters, DataObject):
         Returns
         -------
         int
-            VTK cell type.
+            VTK cell type. See <https://vtk.org/doc/nightly/html/vtkCellType_8h_source.html>.
+
+        Examples
+        --------
+        >>> from pyvista import examples
+        >>> mesh = examples.load_airplane()
+        >>> mesh.cell_type(0)
+        5
 
         """
         return self.GetCellType(ind)

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import numpy as np
 import vtk
+from vtk.util.numpy_support import vtk_to_numpy
 
 import pyvista
 from pyvista.utilities import (FieldAssociation, get_array, is_pyvista_dataset,
@@ -1048,3 +1049,70 @@ class Common(DataSetFilters, DataObject):
         locator.BuildLocator()
         closest_cells = np.array([locator.FindCell(node) for node in point])
         return int(closest_cells[0]) if len(closest_cells) == 1 else closest_cells
+
+    def cell_n_points(self, ind):
+        """Return the number of points in a cell.
+
+        Parameters
+        ----------
+        ind : int
+            Cell ID.
+
+        Returns
+        -------
+        int
+            Number of points in the cell.
+
+        """
+        return self.GetCell(ind).GetPoints().GetNumberOfPoints()
+
+    def cell_points(self, ind):
+        """Return the points in a cell.
+
+        Parameters
+        ----------
+        ind : int
+            Cell ID.
+
+        Returns
+        -------
+        numpy.ndarray
+            An array of floats with shape (number of points, 3) containing the coordinates of the
+            cell corners.
+
+        """
+        points = self.GetCell(ind).GetPoints().GetData()
+        return vtk_to_numpy(points)
+
+    def cell_bounds(self, ind):
+        """Return the bounding box of a cell.
+
+        Parameters
+        ----------
+        ind : int
+            Cell ID.
+
+        Returns
+        -------
+        list(float)
+            The limits of the cell in the X, Y and Z directions respectivelly.
+
+        """
+        bounds = self.GetCell(ind).GetBounds()
+        return list(bounds)
+
+    def cell_type(self, ind):
+        """Return the type of a cell.
+
+        Parameters
+        ----------
+        ind : int
+            Cell ID.
+
+        Returns
+        -------
+        int
+            VTK cell type.
+
+        """
+        return self.GetCellType(ind)

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -235,6 +235,19 @@ class DataObject:
         """Get address of the underlying C++ object in format 'Addr=%p'."""
         return self.GetInformation().GetAddressAsString("")
 
+    @property
+    def actual_memory_size(self):
+        """Return the actual size of the dataset object in kibibytes (1024 bytes)."""
+        return self.GetActualMemorySize()
+
+    def copy_structure(self, dataset):
+        """Copy the structure (geometry and topology) of the input dataset object."""
+        self.CopyStructure(dataset)
+
+    def copy_attributes(self, dataset):
+        """Copy the data attributes of the input dataset object."""
+        self.CopyAttributes(dataset)
+
 
 @abstract_class
 class Common(DataSetFilters, DataObject):

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2640,8 +2640,9 @@ class DataSetFilters:
         Parameters
         ----------
         plane : str
-            Reflection plane options: `'xmin'`, `'ymin'`, `'zmin'`, `'xmax'`, `'ymax'`, `'zmax'`,
-            `'x'`, `'y'`, or `'z'`.
+            Reflection plane options: ``'xmin'``, ``'ymin'``,
+            ``'zmin'``, ``'xmax'``, ``'ymax'``, ``'zmax'``, ``'x'``,
+            ``'y'``, or ``'z'``.
         copy : bool
             If `True`, copy the input geometry to the output.
         center : float

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2645,7 +2645,7 @@ class DataSetFilters:
         copy : bool
             If `True`, copy the input geometry to the output.
         center : float
-            If the reflection plane is set to `'x'`, `'y'` or `'z'`, then this parameter is used to
+            If the reflection plane is set to ``'x'``, ``'y'`` or ``'z'``, then this parameter is used to
             set the position of the plane.
 
         Returns

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2634,6 +2634,38 @@ class DataSetFilters:
         if isinstance(dataset, vtk.vtkPolyData):
             return output.extract_surface()
 
+    def reflect(dataset, plane, copy=False, center=0):
+        """Reflect a dataset across a plane.
+
+        Parameters
+        ----------
+        plane : str
+            Reflection plane options: `'xmin'`, `'ymin'`, `'zmin'`, `'xmax'`, `'ymax'`, `'zmax'`,
+            `'x'`, `'y'`, or `'z'`.
+        copy : bool
+            If `True`, copy the input geometry to the output.
+        center : float
+            If the reflection plane is set to `'x'`, `'y'` or `'z'`, then this parameter is used to
+            set the position of the plane.
+
+        Returns
+        -------
+        pyvista.UnstructuredGrid
+            An unstructured grid.
+
+        """
+        planes = {'x': 6, 'xmin': 0, 'xmax': 3,
+                  'y': 7, 'ymin': 1, 'ymax': 4,
+                  'z': 8, 'zmin': 2, 'zmax': 5}
+        alg = vtk.vtkReflectionFilter()
+        alg.SetInputDataObject(dataset)
+        alg.SetPlane(planes[plane])
+        alg.SetCopyInput(copy)
+        alg.SetCenter(center)
+        alg.Update()
+        return _get_output(alg)
+
+
 @abstract_class
 class CompositeFilters:
     """An internal class to manage filtes/algorithms for composite datasets."""

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2640,19 +2640,25 @@ class DataSetFilters:
         Parameters
         ----------
         plane : str
-            Reflection plane options: ``'xmin'``, ``'ymin'``,
-            ``'zmin'``, ``'xmax'``, ``'ymax'``, ``'zmax'``, ``'x'``,
-            ``'y'``, or ``'z'``.
+            Reflection plane options: ``'xmin'``, ``'ymin'``, ``'zmin'``, ``'xmax'``, ``'ymax'``,
+            ``'zmax'``, ``'x'``, ``'y'``, or ``'z'``.
         copy : bool
             If `True`, copy the input geometry to the output.
         center : float
-            If the reflection plane is set to ``'x'``, ``'y'`` or ``'z'``, then this parameter is used to
-            set the position of the plane.
+            If the reflection plane is set to ``'x'``, ``'y'`` or ``'z'``, then this parameter is
+            used to set the position of the plane.
 
         Returns
         -------
         pyvista.UnstructuredGrid
             An unstructured grid.
+
+        Examples
+        --------
+        >>> from pyvista import examples
+        >>> mesh = examples.load_airplane()
+        >>> mesh = mesh.reflect('z', copy=True, center=-100)
+        >>> mesh.plot(show_edges=True)
 
         """
         planes = {'x': 6, 'xmin': 0, 'xmax': 3,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -902,3 +902,63 @@ def test_get_data_range(grid):
     rng = grid.get_data_range('sample_cell_scalars')
     assert len(rng) == 2
     assert np.allclose(rng, (1, 40))
+
+
+def test_actual_memory_size(grid):
+    size = grid.actual_memory_size
+    assert isinstance(size, int)
+    assert size >= 0
+
+
+def test_copy_structure(grid):
+    classname = grid.__class__.__name__
+    copy = eval(f'pyvista.{classname}')()
+    copy.copy_structure(grid)
+    assert copy.n_cells == grid.n_cells
+    assert copy.n_points == grid.n_points
+    assert len(copy.field_arrays) == 0
+    assert len(copy.cell_arrays) == 0
+    assert len(copy.point_arrays) == 0
+
+
+def test_copy_attributes(grid):
+    classname = grid.__class__.__name__
+    copy = eval(f'pyvista.{classname}')()
+    copy.copy_attributes(grid)
+    assert copy.n_cells == 0
+    assert copy.n_points == 0
+    assert copy.field_arrays.keys() == grid.field_arrays.keys()
+    assert copy.cell_arrays.keys() == grid.cell_arrays.keys()
+    assert copy.point_arrays.keys() == grid.point_arrays.keys()
+
+
+def test_cell_n_points(grid):
+    npoints = grid.cell_n_points(0)
+    assert isinstance(npoints, int)
+    assert npoints >= 0
+
+
+def test_cell_points(grid):
+    points = grid.cell_points(0)
+    assert isinstance(points, np.ndarray)
+    assert points.ndim == 2
+    assert points.shape[0] > 0
+    assert points.shape[1] == 3
+
+
+def test_cell_bounds(grid):
+    bounds = grid.cell_bounds(0)
+    assert isinstance(bounds, list)
+    assert len(bounds) == 6
+
+
+def test_cell_type(grid):
+    ctype = grid.cell_type(0)
+    assert isinstance(ctype, int)
+
+
+def test_reflect(grid):
+    reflected = grid.reflect('z', copy=True, center=6)
+    assert isinstance(reflected, pyvista.UnstructuredGrid)
+    assert reflected.n_cells == 2*grid.n_cells
+    assert reflected.n_points == 2*grid.n_points


### PR DESCRIPTION
### Overview

This pull request includes methods to:

- reflect a dataset object across a plane
- return the actual size of a dataset object
- copy the structure (geometry and topology) or the data attributes of a dataset object
- return the number of points, the points, the bounding box or the type of a cell

### Details

This pull request includes the following methods:

- `DataSetFilters.reflect` to reflect a dataset object across a plane
- `DataObject.actual_memory_size` to return the actual size of a dataset object
- `DataObject.copy_structure` to copy the structure (geometry and topology) of a dataset object
- `DataObject.copy_attributes` to copy the data attributes of a dataset object
- `Common.cell_n_points` to return the number of points in a cell
- `Common.cell_points` to return the points of a cell
- `Common.cell_bounds` to return the bounding box of a cell
- `Common.cell_type` to return the type of a cell

Also includes:

- tests for these methods (see `tests/test_common.py`)
- an example for the `reflect` method (see `examples/01-filter/reflect.py`)