### PR TITLE
Ensure that views of pyvista_ndarray remain associated

### DIFF
--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -40,9 +40,10 @@ class pyvista_ndarray(np.ndarray):
         # convention, but here we just map those over to the appropriate
         # attributes of this class
         VTKArray.__array_finalize__(self, obj)
-        self.dataset = getattr(obj, 'dataset', None)
-        self.association = getattr(obj, 'association', None)
-        self.VTKObject = getattr(obj, 'VTKObject', None)
+        if np.shares_memory(self, obj):
+            self.dataset = getattr(obj, 'dataset', None)
+            self.association = getattr(obj, 'association', None)
+            self.VTKObject = getattr(obj, 'VTKObject', None)
 
     def __setitem__(self, key: int, value):
         """Implement [] set operator.

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -31,7 +31,18 @@ class pyvista_ndarray(np.ndarray):
             obj.dataset.Set(dataset)
         return obj
 
-    __array_finalize__ = VTKArray.__array_finalize__
+    def __array_finalize__(self, obj):
+        # this is necessary to ensure that views/slices of pyvista_ndarray
+        # objects stay associated with those of their parents.
+        #
+        # the VTKArray class uses attributes called `DataSet` and `Assocation`
+        # to hold this data. I don't know why this class doesn't use the same
+        # convention, but here we just map those over to the appropriate
+        # attributes of this class
+        VTKArray.__array_finalize__(self, obj)
+        self.dataset = getattr(obj, 'dataset', None)
+        self.association = getattr(obj, 'association', None)
+        self.VTKObject = getattr(obj, 'VTKObject', None)
 
     def __setitem__(self, key: int, value):
         """Implement [] set operator.

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -32,6 +32,7 @@ class pyvista_ndarray(np.ndarray):
         return obj
 
     def __array_finalize__(self, obj):
+        """Finalize array (associate with parent metadata)."""
         # this is necessary to ensure that views/slices of pyvista_ndarray
         # objects stay associated with those of their parents.
         #

--- a/tests/test_pyvista_ndarray.py
+++ b/tests/test_pyvista_ndarray.py
@@ -1,0 +1,26 @@
+import pytest
+
+from pyvista import pyvista_ndarray
+from pyvista import examples
+
+
+def test_slices_are_associated():
+    dataset = examples.load_structured()
+    points = pyvista_ndarray(dataset.GetPoints().GetData(), dataset=dataset)
+
+    # check that slices of pyvista_ndarray are associated correctly
+    assert points[1, :].VTKObject == points.VTKObject
+    assert points[1, :].dataset.Get() == points.dataset.Get()
+    assert points[1, :].association == points.association
+
+
+# TODO: This currently doesn't work for single element indexing operations!
+# in these cases, the __array_finalize__ method is not called
+@pytest.mark.skip
+def test_slices_are_associated_single_index():
+    dataset = examples.load_structured()
+    points = pyvista_ndarray(dataset.GetPoints().GetData(), dataset=dataset)
+
+    assert points[1, 1].VTKObject == points.VTKObject
+    assert points[1, 1].dataset.Get() == points.dataset.Get()
+    assert points[1, 1].association == points.association


### PR DESCRIPTION
### Overview

Views of `pyvista_ndarray` were not remaining associated with the VTKObject of their parents, so setting elements of the views did not call `Modified()` on the parent VTKObject, even though the data in the array was being modified. This PR fixes the issue by modifying `pyvista_ndarray.__array_finalize__`.

Annoyingly, a single element slice does not return an array, so `my_array[1, 1] = 5`) will _not_ call the `Modified()` method of the associated VTK object of `my_array`. I added a skipped test to demonstrate this.

I don't fully understand the design choices for `pyvista_ndarray`, so somebody with more expertise in this please feel free to chime in.


