### PR TITLE
Rename trans_from_matrix to array_from_vtkmatrix, implement inverse

### DIFF
--- a/docs/utilities/utilities.rst
+++ b/docs/utilities/utilities.rst
@@ -5,8 +5,6 @@ General Utilities
 
 .. autofunction:: pyvista.set_error_output_file
 
-.. autofunction:: pyvista.trans_from_matrix
-
 .. autofunction:: pyvista.is_inside_bounds
 
 
@@ -20,6 +18,10 @@ Object Conversions
 .. autofunction:: pyvista.image_to_texture
 
 .. autofunction:: pyvista.numpy_to_texture
+
+.. autofunction:: pyvista.array_from_vtkmatrix
+
+.. autofunction:: pyvista.vtkmatrix_from_array
 
 
 File IO

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -650,9 +650,9 @@ class Common(DataSetFilters, DataObject):
 
         """
         if isinstance(trans, vtk.vtkMatrix4x4):
-            t = pyvista.trans_from_matrix(trans)
+            t = pyvista.array_from_vtkmatrix(trans)
         elif isinstance(trans, vtk.vtkTransform):
-            t = pyvista.trans_from_matrix(trans.GetMatrix())
+            t = pyvista.array_from_vtkmatrix(trans.GetMatrix())
         elif isinstance(trans, np.ndarray):
             if trans.ndim != 2:
                 raise ValueError('Transformation array must be 4x4')

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1093,7 +1093,7 @@ class Renderer(vtkRenderer):
         if isinstance(point, np.ndarray):
             if point.ndim != 1:
                 point = point.ravel()
-        self.camera.position(scale_point(self.camera, point, invert=False))
+        self.camera.position = scale_point(self.camera, point, invert=False)
         if reset:
             self.reset_camera()
         self.camera_set = True

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -443,16 +443,18 @@ def trans_from_matrix(matrix):  # pragma: no cover
     DEPRECATED: Please use ``array_from_vtkmatrix``.
 
     """
+    # import needs to happen here to prevent a circular import
+    from pyvista.core.errors import DeprecationError
     raise DeprecationError('DEPRECATED: Please use ``array_from_vtkmatrix``.')
 
 
 def array_from_vtkmatrix(matrix):
-    """Convert a vtk matrix to a numpy.ndarray.
+    """Convert a vtk matrix to a ``numpy.ndarray``.
 
     Parameters
     ----------
     matrix : vtk.vtkMatrix3x3 or vtk.vtkMatrix4x4
-        The vtk matrix to be converted to a numpy ndarray.
+        The vtk matrix to be converted to a ``numpy.ndarray``.
         Returned ndarray has shape (3, 3) or (4, 4) as appropriate.
 
     """
@@ -471,14 +473,14 @@ def array_from_vtkmatrix(matrix):
 
 
 def vtkmatrix_from_array(array):
-    """Convert a numpy.ndarray or array-like to a vtk matrix.
+    """Convert a ``numpy.ndarray`` or array-like to a vtk matrix.
 
     Parameters
     ----------
     array : numpy.ndarray or array-like
         The array or array-like to be converted to a vtk matrix.
-        Shape (3, 3) gets converted to vtk.vtkMatrix3x3, shape (4, 4)
-        gets converte dto vtk.vtkMatrix4x4. No other shapes are valid.
+        Shape (3, 3) gets converted to a ``vtk.vtkMatrix3x3``, shape (4, 4)
+        gets converted to a ``vtk.vtkMatrix4x4``. No other shapes are valid.
 
     """
     array = np.asarray(array)

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -437,13 +437,62 @@ def vector_poly_data(orig, vec):
     return pyvista.PolyData(pdata)
 
 
-def trans_from_matrix(matrix):
-    """Convert a vtk matrix to a numpy.ndarray."""
-    t = np.zeros((4, 4))
-    for i in range(4):
-        for j in range(4):
-            t[i, j] = matrix.GetElement(i, j)
-    return t
+def trans_from_matrix(matrix):  # pragma: no cover
+    """Convert a vtk matrix to a numpy.ndarray.
+
+    DEPRECATED: Please use ``array_from_vtkmatrix``.
+
+    """
+    raise DeprecationError('DEPRECATED: Please use ``array_from_vtkmatrix``.')
+
+
+def array_from_vtkmatrix(matrix):
+    """Convert a vtk matrix to a numpy.ndarray.
+
+    Parameters
+    ----------
+    matrix : vtk.vtkMatrix3x3 or vtk.vtkMatrix4x4
+        The vtk matrix to be converted to a numpy ndarray.
+        Returned ndarray has shape (3, 3) or (4, 4) as appropriate.
+
+    """
+    if isinstance(matrix, vtk.vtkMatrix3x3):
+        shape = (3, 3)
+    elif isinstance(matrix, vtk.vtkMatrix4x4):
+        shape = (4, 4)
+    else:
+        raise TypeError('Expected vtk.vtkMatrix3x3 or vtk.vtkMatrix4x4 input,'
+                        f' got {type(matrix).__name__} instead.')
+    array = np.zeros(shape)
+    for i in range(shape[0]):
+        for j in range(shape[1]):
+            array[i, j] = matrix.GetElement(i, j)
+    return array
+
+
+def vtkmatrix_from_array(array):
+    """Convert a numpy.ndarray or array-like to a vtk matrix.
+
+    Parameters
+    ----------
+    array : numpy.ndarray or array-like
+        The array or array-like to be converted to a vtk matrix.
+        Shape (3, 3) gets converted to vtk.vtkMatrix3x3, shape (4, 4)
+        gets converte dto vtk.vtkMatrix4x4. No other shapes are valid.
+
+    """
+    array = np.asarray(array)
+    if array.shape == (3, 3):
+        matrix = vtk.vtkMatrix3x3()
+    elif array.shape == (4, 4):
+        matrix = vtk.vtkMatrix4x4()
+    else:
+        raise ValueError(f'Invalid shape {array.shape}, must be (3, 3) or (4, 4).')
+    m, n = array.shape
+    for i in range(m):
+        for j in range(n):
+            matrix.SetElement(i, j, array[i, j])
+    return matrix
 
 
 def is_meshio_mesh(mesh):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -191,7 +191,7 @@ def test_translate_should_match_vtk_transformation(rotate_amounts, translate_amo
     grid_c = grid.copy()
     grid_a.transform(trans)
     grid_b.transform(trans.GetMatrix())
-    grid_c.transform(pyvista.trans_from_matrix(trans.GetMatrix()))
+    grid_c.transform(pyvista.array_from_vtkmatrix(trans.GetMatrix()))
     assert np.allclose(grid_a.points, grid_b.points, equal_nan=True)
     assert np.allclose(grid_a.points, grid_c.points, equal_nan=True)
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -246,6 +246,44 @@ def test_transform_vectors_sph_to_cart():
     )
 
 
+def test_vtkmatrix_to_from_array():
+    rng = np.random.default_rng()
+    array3x3 = rng.integers(0, 10, size=(3, 3))
+    matrix = pyvista.vtkmatrix_from_array(array3x3)
+    assert isinstance(matrix, vtk.vtkMatrix3x3)
+    for i in range(3):
+        for j in range(3):
+            assert matrix.GetElement(i, j) == array3x3[i, j]
+
+    array = pyvista.array_from_vtkmatrix(matrix)
+    assert isinstance(array, np.ndarray)
+    assert array.shape == (3, 3)
+    for i in range(3):
+        for j in range(3):
+            assert array[i, j] == matrix.GetElement(i, j)
+
+    array4x4 = rng.integers(0, 10, size=(4, 4))
+    matrix = pyvista.vtkmatrix_from_array(array4x4)
+    assert isinstance(matrix, vtk.vtkMatrix4x4)
+    for i in range(4):
+        for j in range(4):
+            assert matrix.GetElement(i, j) == array4x4[i, j]
+
+    array = pyvista.array_from_vtkmatrix(matrix)
+    assert isinstance(array, np.ndarray)
+    assert array.shape == (4, 4)
+    for i in range(4):
+        for j in range(4):
+            assert array[i, j] == matrix.GetElement(i, j)
+
+    # invalid cases
+    with pytest.raises(ValueError):
+        matrix = pyvista.vtkmatrix_from_array(np.arange(3 * 4).reshape(3, 4))
+    with pytest.raises(TypeError):
+        invalid = vtk.vtkTransform()
+        array = pyvista.array_from_vtkmatrix(invalid)
+
+
 def test_assert_empty_kwargs():
     kwargs = {}
     assert errors.assert_empty_kwargs(**kwargs)


### PR DESCRIPTION
### Overview

There's a helper function `trans_from_matrix` which converts vtk matrices to numpy arrays. I need the inverse functionality for a pull request, which this PR is meant to address, along with some clean-up attempts and a deprecation.

### Details

The status quo is that we have `trans_from_matrix` in `pyvista/utilities/helpers.py`. There are a few things I noted about this:

  * The function doesn't have an inverse (array to vtk matrix).
  * The function is listed under ["General Utilities"](https://docs.pyvista.org/utilities/utilities.html#module-pyvista.utilities) in the docs.
  * The function is open to bugs, because it assumes 4x4 vtk matrices but will run with 3x3 vtk matrices as well. This is a problem, because vtk will happily access out-of-bounds memory with `vtkMatrix3x3.GetElement()`. (A quick way to segfault an interpreter is `import vtk; vtk.vtkMatrix3x3().SetElement(1000_000, 1000_000, 1)`.).
  * The function doesn't have any direct tests. This might be because this function is probably meant for internal use, but the previous bullet suggests that tests would be helpful. (The function _is_ covered by tests written for other functions.)
  * The function has a suboptimal name especially if we want to implement its inverse.

Considering all of the above my suggestion (this PR's initial state) is the following:

  * Rename `trans_from_matrix` to `array_from_vtkmatrix`. I think just "matrix" would be insufficient, because numpy matrices are still a thing. I considered being pedantic and using `ndarray_from_vtkmatrix`, but the inverse `vtkmatrix_from_ndarray` would actually accept any array-likes (for instance lists of lists), in which case the more pedantic name would be more misleading. Even though there are other kinds of arrays, even in vtk, but to me they seem to be semantically distant from this use case, which is why I suggested just `array` and not `ndarray`.
  * Deprecate the old name so that it raises a `DeprecationError`.
  * Implement `vtkmatrix_from_array` as an inverse which accepts any array-like as input.
  * Make both functions automatically convert between `(3, 3)`-shaped arrays <-> `vtkMatrix3x3` and `(4, 4)`-shaped arrays <-> `vtkMatrix4x4`.
  * Move both functions from under "General Utilities" to ["Object Conversions"](https://docs.pyvista.org/utilities/utilities.html#object-conversions). It seems to me that these functions are very similar to, say, `pyvista.numpy_to_texture()` which is already there.
  * Write tests for both functions.

What might be a further improvement but I haven't done it yet:
  * Move the functions from `pyvista/utilities/helpers.py` to `pyvista/utilities/features.py`. The former's module docstring says "_Supporting functions for polydata and grid objects_", the latter's "_Module containing geometry helper functions_". The former is technically correct for now, but my use case for the inverse function does not concern polydata nor grids. The `features.py`, on the other hand, already contains `transform_vectors_sph_to_cart` which is slightly similar (it doesn't convert between two coding representations, but rather between two mathematical representations).