### PR TITLE
improve camera docs and implementation

### DIFF
--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -259,7 +259,8 @@ class Camera(vtk.vtkCamera):
 
     @clipping_range.setter
     def clipping_range(self, points):
-        """Set the clipping range
+        """Set the clipping range.
+
         Examples
         --------
         >>> import pyvista

--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -5,37 +5,95 @@ import vtk
 
 
 class Camera(vtk.vtkCamera):
-    """Camera class."""
+    """PyVista wrapper for the VTK Camera class.
+
+    Examples
+    --------
+    Create a camera at the pyvista module level
+
+    >>> import pyvista
+    >>> camera = pyvista.Camera()
+
+    Access the active camera of a plotter and get the position of the
+    camera.
+
+    >>> pl = pyvista.Plotter()
+    >>> pl.camera.position
+    (1.0, 1.0, 1.0)
+
+    """
 
     def __init__(self):
         """Initialize a new camera descriptor."""
-        self._position = self.GetPosition()
         self._focus = self.GetFocalPoint()
         self._is_parallel_projection = False
 
     @property
     def position(self):
-        """Position of the camera in world coordinates."""
-        return self._position
+        """Position of the camera in world coordinates.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.camera.position
+        (1.0, 1.0, 1.0)
+
+        """
+        return self.GetPosition()
 
     @position.setter
     def position(self, value):
+        """Set the position of the camera.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.camera.position = 2.0, 1.0, 1.0
+        """
         self.SetPosition(value)
-        self._position = self.GetPosition()
 
     @property
     def focal_point(self):
-        """Location of the camera's focus in world coordinates."""
+        """Location of the camera's focus in world coordinates.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.camera.focal_point
+        (0.0, 0.0, 0.0)
+        """
         return self._focus
 
     @focal_point.setter
     def focal_point(self, point):
+        """Set the location of the camera's focus in world coordinates.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.camera.focal_point = (2.0, 0.0, 0.0)
+        """
         self.SetFocalPoint(point)
         self._focus = self.GetFocalPoint()
 
     @property
     def model_transform_matrix(self):
-        """Model transformation matrix."""
+        """Return the camera's model transformation matrix.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.camera.model_transform_matrix
+        array([[1., 0., 0., 0.],
+               [0., 1., 0., 0.],
+               [0., 0., 1., 0.],
+               [0., 0., 0., 1.]])
+        """
         vtk_matrix = self.GetModelTransformMatrix()
         matrix = np.empty((4, 4))
         vtk_matrix.DeepCopy(matrix.ravel(), vtk_matrix)
@@ -43,6 +101,18 @@ class Camera(vtk.vtkCamera):
 
     @model_transform_matrix.setter
     def model_transform_matrix(self, matrix):
+        """Set the camera's model transformation matrix.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> trans_mat = np.array([[1., 0., 0., 0.],
+                                  [0., 1., 0., 0.],
+                                  [0., 0., 1., 0.],
+                                  [0., 0., 0., 1.]])
+        >>> pl.camera.model_transform_matrix = trans_mat
+        """
         vtk_matrix = vtk.vtkMatrix4x4()
         vtk_matrix.DeepCopy(matrix.ravel())
         self.SetModelTransformMatrix(vtk_matrix)
@@ -54,37 +124,111 @@ class Camera(vtk.vtkCamera):
 
     @property
     def distance(self):
-        """Distance from the camera position to the focal point."""
+        """Distance from the camera position to the focal point.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.camera.distance  # doctest:+SKIP
+        1.732050807568
+        """
         return self.GetDistance()
 
     @property
     def thickness(self):
-        """Distance between clipping planes."""
+        """Return the distance between clipping planes.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.camera.thickness
+        1000.0
+        """
         return self.GetThickness()
 
     @thickness.setter
     def thickness(self, length):
+        """Set the distance between clipping planes.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.camera.thickness = 100
+        """
         self.SetThickness(length)
 
     @property
     def parallel_scale(self):
-        """Scaling used for a parallel projection, i.e."""
+        """Scaling used for a parallel projection.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.camera.parallel_scale
+        1.0
+        """
         return self.GetParallelScale()
 
     @parallel_scale.setter
     def parallel_scale(self, scale):
+        """Set the scaling used for parallel projection.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.camera.parallel_scale = 2.0
+        """
         self.SetParallelScale(scale)
 
     def zoom(self, value):
-        """Zoom of the camera."""
+        """Set the zoom of the camera.
+
+        In perspective mode, decrease the view angle by the specified
+        factor.
+
+        In parallel mode, decrease the parallel scale by the specified
+        factor. A value greater than 1 is a zoom-in, a value less than
+        1 is a zoom-out.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.camera.zoom(2.0)
+
+        """
         self.Zoom(value)
 
-    def up(self, vector=None):
-        """Up of the camera."""
-        if vector is None:
-            return self.GetViewUp()
-        else:
-            self.SetViewUp(vector)
+    @property
+    def up(self):
+        """Return the "up" of the camera.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.camera.up
+        (0.0, 0.0, 1.0)
+
+        """
+        return self.GetViewUp()
+
+    @up.setter
+    def up(self, vector):
+        """Set the "up" of the camera.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.camera.up = (0.410018, 0.217989, 0.885644)
+        """
+        self.SetViewUp(vector)
 
     def enable_parallel_projection(self, flag=True):
         """Enable parallel projection.
@@ -97,18 +241,33 @@ class Camera(vtk.vtkCamera):
         self.SetParallelProjection(flag)
 
     def disable_parallel_projection(self):
-        """Reset the camera to use perspective projection."""
+        """Disable the use of perspective projection."""
         self.enable_parallel_projection(False)
 
     @property
     def clipping_range(self):
-        """Clipping range."""
+        """Return the Clipping range.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.camera.clipping_range
+        (0.01, 1000.01)
+        """
         return self.GetClippingRange()
 
     @clipping_range.setter
     def clipping_range(self, points):
+        """Set the clipping range
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.camera.clipping_range = (1, 10)
+        """
         if points[0] > points[1]:
-            raise ValueError(f'Near point should lower than far point.')
+            raise ValueError(f'Near point must be lower than the far point.')
         self.SetClippingRange(points[0], points[1])
 
     def __del__(self):

--- a/pyvista/plotting/export_vtkjs.py
+++ b/pyvista/plotting/export_vtkjs.py
@@ -595,7 +595,7 @@ def export_plotter_vtkjs(plotter, filename, compress_arrays=False):
         "camera": {
             "focalPoint": plotter.camera.focal_point,
             "position": plotter.camera.position,
-            "viewUp": plotter.camera.up(),
+            "viewUp": plotter.camera.up,
             "clippingRange": [elt for elt in cameraClippingRange],
         },
         "centerOfRotation": plotter.camera.focal_point,

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1,7 +1,6 @@
 """Module containing pyvista implementation of vtkRenderer."""
 
 import collections.abc
-import logging
 from weakref import proxy
 
 import numpy as np
@@ -137,7 +136,7 @@ class Renderer(vtkRenderer):
         return CameraPosition(
             scale_point(self.camera, self.camera.position, invert=True),
             scale_point(self.camera, self.camera.focal_point, invert=True),
-            self.camera.up())
+            self.camera.up)
 
     @camera_position.setter
     def camera_position(self, camera_location):
@@ -169,7 +168,7 @@ class Renderer(vtkRenderer):
             # everything is set explicitly
             self.camera.position = scale_point(self.camera, camera_location[0], invert=False)
             self.camera.focal_point = scale_point(self.camera, camera_location[1], invert=False)
-            self.camera.up(camera_location[2])
+            self.camera.up = camera_location[2]
 
         # reset clipping range
         self.ResetCameraClippingRange()
@@ -189,7 +188,7 @@ class Renderer(vtkRenderer):
         self.camera_position = CameraPosition(
             scale_point(source, source.position, invert=True),
             scale_point(source, source.focal_point, invert=True),
-            source.up()
+            source.up
         )
         self.Modified()
         self.camera_set = True
@@ -1093,7 +1092,7 @@ class Renderer(vtkRenderer):
         if isinstance(point, np.ndarray):
             if point.ndim != 1:
                 point = point.ravel()
-        self.camera.position(scale_point(self.camera, point, invert=False))
+        self.camera.position = scale_point(self.camera, point, invert=False)
         if reset:
             self.reset_camera()
         self.camera_set = True
@@ -1104,7 +1103,7 @@ class Renderer(vtkRenderer):
         if isinstance(vector, np.ndarray):
             if vector.ndim != 1:
                 vector = vector.ravel()
-        self.camera.up(vector)
+        self.camera.up = vector
         self.Modified()
 
     def enable_parallel_projection(self):

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -790,7 +790,7 @@ def test_camera():
     plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
     plotter.add_mesh(sphere)
     plotter.camera.zoom(5)
-    plotter.camera.up([0, 0, 10])
+    plotter.camera.up = 0, 0, 10
     plotter.show()
 
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,54 +1,82 @@
-import sys
-
 import numpy as np
 import pytest
 
 import pyvista
 
 
-def test_camera():
+@pytest.fixture()
+def camera():
+    return pyvista.Camera()
 
-    camera = pyvista.Camera()
 
+def test_camera_position(camera):
     position = np.random.random(3)
     camera.position = position
     assert np.all(camera.GetPosition() == position)
     assert np.all(camera.position == position)
 
+
+def test_focal_point(camera):
     focal_point = np.random.random(3)
     camera.focal_point = focal_point
     assert np.all(camera.GetFocalPoint() == focal_point)
     assert np.all(camera.focal_point == focal_point)
 
+
+def test_model_transform_matrix(camera):
     model_transform_matrix = np.random.random((4, 4))
     camera.model_transform_matrix = model_transform_matrix
     assert np.all(camera.model_transform_matrix == model_transform_matrix)
 
+
+def test_distance(camera):
+    focal_point = np.random.random(3)
+    position = np.random.random(3)
+    camera.position = position
+    camera.focal_point = focal_point
     camera.distance == np.linalg.norm(focal_point - position, ord=2)
 
+
+def test_thickness(camera):
     thickness = np.random.random(1)
     camera.thickness = thickness
     assert camera.thickness == thickness
 
+
+def test_parallel_scale(camera):
     parallel_scale = np.random.random(1)
     camera.parallel_scale = parallel_scale
     assert camera.parallel_scale == parallel_scale
 
+
+def test_zoom(camera):
     value = np.random.random(1)
-    camera.zoom(value)
+    camera.enable_parallel_projection()
+    orig_scale = camera.parallel_scale
+    zoom = 0.5
+    camera.zoom(zoom)
+    assert camera.parallel_scale == orig_scale/zoom
 
-    vector = np.random.random(3)
-    camera.up(vector)
-    camera.up()
 
+def test_up(camera):
+    up = (0.410018, 0.217989, 0.885644)
+    camera.up = up
+    assert np.allclose(camera.up, up)
+
+
+def test_enable_parallel_projection(camera):
     camera.enable_parallel_projection()
     assert camera.GetParallelProjection()
     assert camera.is_parallel_projection
 
+
+def test_disable_parallel_projection(camera):
     camera.disable_parallel_projection()
     assert not camera.GetParallelProjection()
     assert not camera.is_parallel_projection
 
+
+def test_clipping_range(camera):
     near_point = np.random.random(1)
     far_point = near_point + np.random.random(1)
     points = (near_point, far_point)
@@ -60,4 +88,3 @@ def test_camera():
         far_point = near_point - np.random.random(1)
         points = (near_point, far_point)
         camera.clipping_range = points
-

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -17,3 +17,13 @@ def test_camera_position():
     plotter.add_mesh(pyvista.Sphere())
     plotter.show()
     assert isinstance(plotter.camera_position, pyvista.CameraPosition)
+
+
+def test_plotter_camera_position():
+    plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
+    plotter.renderer.set_position([1, 1, 1])
+
+
+def test_renderer_set_viewup():
+    plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
+    plotter.renderer.set_viewup([1, 1, 1])


### PR DESCRIPTION
### Improve Camera Docs

When running the doc build from scratch, I found that the `orbit.py` example was failing as we don't fully test all the methods in `renderer.py` and we were attempting to call rather than use the setter in:
```py
self.camera.position = scale_point(self.camera, point, invert=False)
```

This PR also:
- Adds examples to the documentation strings.
- Implements ``up`` as a property/setter.
- Breaks up the unit tests to individual tests.

