### PR TITLE
Release graphics resources in EDL

### DIFF
--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1398,6 +1398,7 @@ class Renderer(vtkRenderer):
         if not hasattr(self, 'edl_pass'):
             return
         self.SetPass(None)
+        self.edl_pass.ReleaseGraphicsResources(self.parent.ren_win)
         del self.edl_pass
         self.Modified()
         return


### PR DESCRIPTION
This PR fixes a bug reported in https://github.com/pyvista/pyvistaqt/issues/71

So with this, it's possible to enable and disable EDL without the following:

```
2020-11-09 14:18:38.460 (  18.067s) [                ]      vtkEDLShading.cxx:97     ERR| vtkEDLShading (0000021B60885D80): FrameBufferObject should have been deleted in ReleaseGraphicsResources().
2020-11-09 14:18:38.461 (  18.067s) [                ]      vtkEDLShading.cxx:102    ERR| vtkEDLShading (0000021B60885D80): ColorTexture should have been deleted in ReleaseGraphicsResources().
2020-11-09 14:18:38.461 (  18.068s) [                ]      vtkEDLShading.cxx:107    ERR| vtkEDLShading (0000021B60885D80): DepthTexture should have been deleted in ReleaseGraphicsResources().
2020-11-09 14:18:38.462 (  18.069s) [                ]      vtkEDLShading.cxx:112    ERR| vtkEDLShading (0000021B60885D80): FrameBufferObject should have been deleted in ReleaseGraphicsResources().
2020-11-09 14:18:38.463 (  18.070s) [                ]      vtkEDLShading.cxx:117    ERR| vtkEDLShading (0000021B60885D80): ColorTexture should have been deleted in ReleaseGraphicsResources().
2020-11-09 14:18:38.463 (  18.070s) [                ]      vtkEDLShading.cxx:122    ERR| vtkEDLShading (0000021B60885D80): FrameBufferObject should have been deleted in ReleaseGraphicsResources().
2020-11-09 14:18:38.464 (  18.071s) [                ]      vtkEDLShading.cxx:127    ERR| vtkEDLShading (0000021B60885D80): ColorTexture should have been deleted in ReleaseGraphicsResources().
2020-11-09 14:18:38.465 (  18.072s) [                ]      vtkEDLShading.cxx:132    ERR| vtkEDLShading (0000021B60885D80): ColorTexture should have been deleted in ReleaseGraphicsResources().
```

With `pyvista.Plottter`:

https://user-images.githubusercontent.com/18143289/105871902-11cc5a80-5ffa-11eb-87ad-43c708d7e4d7.mp4

<details>

```py
import pyvista
from pyvista import examples

nefertiti = examples.download_nefertiti()
point_cloud = examples.download_lidar()

plotter = pyvista.Plotter(window_size=(800, 600))
plotter.add_mesh(nefertiti, color=True)


def toggle_edl(state):
    if state:
        plotter.enable_eye_dome_lighting()
    else:
        plotter.disable_eye_dome_lighting()


plotter.add_checkbox_button_widget(toggle_edl, value=False, color_on='green')
plotter.show()
```
</details>

With `pyvistaqt.MultiPlotter`:

https://user-images.githubusercontent.com/18143289/105871889-0d07a680-5ffa-11eb-9d71-e8e39bf2baf7.mp4

<details>

```py
from functools import partial
import pyvistaqt as pvqt
from pyvista import examples

nefertiti = examples.download_nefertiti()
point_cloud = examples.download_lidar()

mp = pvqt.MultiPlotter(shape=(1, 2), window_size=(800, 600))


def toggle_edl(state, idx):
    if state:
        mp._plotters[idx].enable_eye_dome_lighting()
    else:
        mp._plotters[idx].disable_eye_dome_lighting()


plotter = mp.select((0, 0))
plotter.add_mesh(nefertiti, color=True)
plotter.add_checkbox_button_widget(partial(toggle_edl, idx=0), value=False)

plotter = mp.select((0, 1))
plotter.add_mesh(point_cloud, color=True)
plotter.add_checkbox_button_widget(partial(toggle_edl, idx=1), value=False)

mp.show()
```

</details>

Closes pyvista/pyvistaqt#71