### PR TITLE
Minor fix: replace "is 0" comparison with "== 0" in filters.py

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -3708,7 +3708,7 @@ class PolyDataFilters(DataSetFilters):
         >>> sphere_with_hole = pv.Sphere(end_theta=330)
         >>> sphere_with_hole.fill_holes(1000, inplace=True)
         >>> edges = sphere_with_hole.extract_feature_edges(feature_edges=False, manifold_edges=False)
-        >>> assert edges.n_cells is 0
+        >>> assert edges.n_cells == 0
 
         """
         logging.warning('pyvista.PolyData.fill_holes is known to segfault. '


### PR DESCRIPTION
There was a buggy comparison in the docstring of `filters.PolyDataFilters.fill_holes()` that was raising a warning in doctests:
```py
assert edges.n_cells is 0
```

This works in CPython as an implementation detail (not that it's likely that alternative Python implementations don't cache 0). The warning is [new in Python 3.8](https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior) (see also https://bugs.python.org/issue34850):
```
SyntaxWarning: "is" with a literal. Did you mean "=="?
```