### PR TITLE
Update hypothesis requirement 5.8.0->6.0.3

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,7 +9,7 @@ colorcet
 cmocean
 itkwidgets>=0.25.2
 tqdm
-hypothesis>=5.8.0
+hypothesis>=6.0.3
 sphinx_gallery
 trimesh
 ipyvtk-simple>=0.1.2


### PR DESCRIPTION
### Overview

#1080 uses HealthCheck.function_scoped_fixture but this does not exist in the requirements.txt hypothesis version. This updates the requirement to latest 6.0.3.

