### PR TITLE
Add reflect filter and other methods

### DIFF
--- a/examples/01-filter/reflect.py
+++ b/examples/01-filter/reflect.py
@@ -1,0 +1,26 @@
+"""
+.. _ref_reflect_example:
+
+Reflect Meshes
+~~~~~~~~~~~~~~
+
+This example reflects a mesh across a plane.
+
+"""
+
+from pyvista import examples
+
+###############################################################################
+# This example demonstrates how to reflect a mesh across a plane.
+#
+# Load an example mesh:
+airplane = examples.load_airplane()
+
+###############################################################################
+# Reflect the mesh across a plane parallel to Z plane and centered in -100
+# (the geometry input is copied to the output):
+airplane = airplane.reflect('z', copy=True, center=-100)
+
+###############################################################################
+# Plot the reflected mesh:
+airplane.plot(show_edges=True)

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -249,8 +249,8 @@ class DataObject:
         --------
         >>> from pyvista import examples
         >>> mesh = examples.load_airplane()
-        >>> mesh.actual_memory_size
-        94
+        >>> mesh.actual_memory_size  # doctest:+SKIP
+        93
 
         """
         return self.GetActualMemorySize()

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import numpy as np
 import vtk
+from vtk.util.numpy_support import vtk_to_numpy
 
 import pyvista
 from pyvista.utilities import (FieldAssociation, get_array, is_pyvista_dataset,
@@ -234,6 +235,54 @@ class DataObject:
     def memory_address(self):
         """Get address of the underlying C++ object in format 'Addr=%p'."""
         return self.GetInformation().GetAddressAsString("")
+
+    @property
+    def actual_memory_size(self):
+        """Return the actual size of the dataset object.
+
+        Returns
+        -------
+        int
+            The actual size of the dataset object in kibibytes (1024 bytes).
+
+        Examples
+        --------
+        >>> from pyvista import examples
+        >>> mesh = examples.load_airplane()
+        >>> mesh.actual_memory_size
+        94
+
+        """
+        return self.GetActualMemorySize()
+
+    def copy_structure(self, dataset):
+        """Copy the structure (geometry and topology) of the input dataset object.
+
+        Examples
+        --------
+        >>> import pyvista as pv
+        >>> source = pv.UniformGrid((10, 10, 5))
+        >>> target = pv.UniformGrid()
+        >>> target.copy_structure(source)
+        >>> target.plot(show_edges=True)  # doctest:+SKIP
+
+        """
+        self.CopyStructure(dataset)
+
+    def copy_attributes(self, dataset):
+        """Copy the data attributes of the input dataset object.
+
+        Examples
+        --------
+        >>> import pyvista as pv
+        >>> source = pv.UniformGrid((10, 10, 5))
+        >>> source = source.compute_cell_sizes()
+        >>> target = pv.UniformGrid((10, 10, 5))
+        >>> target.copy_attributes(source)
+        >>> target.plot(scalars='Volume', show_edges=True)  # doctest:+SKIP
+
+        """
+        self.CopyAttributes(dataset)
 
 
 @abstract_class
@@ -1035,3 +1084,99 @@ class Common(DataSetFilters, DataObject):
         locator.BuildLocator()
         closest_cells = np.array([locator.FindCell(node) for node in point])
         return int(closest_cells[0]) if len(closest_cells) == 1 else closest_cells
+
+    def cell_n_points(self, ind):
+        """Return the number of points in a cell.
+
+        Parameters
+        ----------
+        ind : int
+            Cell ID.
+
+        Returns
+        -------
+        int
+            Number of points in the cell.
+
+        Examples
+        --------
+        >>> from pyvista import examples
+        >>> mesh = examples.load_airplane()
+        >>> mesh.cell_n_points(0)
+        3
+
+        """
+        return self.GetCell(ind).GetPoints().GetNumberOfPoints()
+
+    def cell_points(self, ind):
+        """Return the points in a cell.
+
+        Parameters
+        ----------
+        ind : int
+            Cell ID.
+
+        Returns
+        -------
+        numpy.ndarray
+            An array of floats with shape (number of points, 3) containing the coordinates of the
+            cell corners.
+
+        Examples
+        --------
+        >>> from pyvista import examples
+        >>> mesh = examples.load_airplane()
+        >>> mesh.cell_points(0)  # doctest:+SKIP
+        [[896.99401855  48.76010132  82.26560211]
+         [906.59301758  48.76010132  80.74520111]
+         [907.53900146  55.49020004  83.65809631]]
+
+        """
+        points = self.GetCell(ind).GetPoints().GetData()
+        return vtk_to_numpy(points)
+
+    def cell_bounds(self, ind):
+        """Return the bounding box of a cell.
+
+        Parameters
+        ----------
+        ind : int
+            Cell ID.
+
+        Returns
+        -------
+        list(float)
+            The limits of the cell in the X, Y and Z directions respectivelly.
+
+        Examples
+        --------
+        >>> from pyvista import examples
+        >>> mesh = examples.load_airplane()
+        >>> mesh.cell_bounds(0)
+        [896.9940185546875, 907.5390014648438, 48.760101318359375, 55.49020004272461, 80.74520111083984, 83.65809631347656]
+
+        """
+        return list(self.GetCell(ind).GetBounds())
+
+    def cell_type(self, ind):
+        """Return the type of a cell.
+
+        Parameters
+        ----------
+        ind : int
+            Cell ID.
+
+        Returns
+        -------
+        int
+            VTK cell type. See <https://vtk.org/doc/nightly/html/vtkCellType_8h_source.html>.
+
+        Examples
+        --------
+        >>> from pyvista import examples
+        >>> mesh = examples.load_airplane()
+        >>> mesh.cell_type(0)
+        5
+
+        """
+        return self.GetCellType(ind)

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2634,24 +2634,33 @@ class DataSetFilters:
         if isinstance(dataset, vtk.vtkPolyData):
             return output.extract_surface()
 
-    def reflect(dataset, plane, copy=False, center=0):
+    def reflect(dataset, plane, copy=False, center=0, inplace=False):
         """Reflect a dataset across a plane.
 
         Parameters
         ----------
         plane : str
-            Reflection plane options: ``'xmin'``, ``'ymin'``, ``'zmin'``, ``'xmax'``, ``'ymax'``,
-            ``'zmax'``, ``'x'``, ``'y'``, or ``'z'``.
+            Reflection plane options: ``'xmin'``, ``'ymin'``,
+            ``'zmin'``, ``'xmax'``, ``'ymax'``, ``'zmax'``, ``'x'``,
+            ``'y'``, or ``'z'``.
+
         copy : bool
             If ``True``, copy the input geometry to the output.
+
         center : float
-            If the reflection plane is set to ``'x'``, ``'y'`` or ``'z'``, then this parameter is
-            used to set the position of the plane.
+            If the reflection plane is set to ``'x'``, ``'y'`` or
+            ``'z'``, then this parameter is used to set the position
+            of the plane.
+
+        inplace : bool, optional
+            When ``True``, modifies the dataset and returns nothing.
+            Not valid when ``copy`` is ``True``.
 
         Returns
         -------
-        pyvista.UnstructuredGrid
-            An unstructured grid.
+        pyvista.UnstructuredGrid, pyvista.PolyData, or None
+            PolyData when input is a PolyData, UnstructuredGrid
+            otherwise unless ``inplace`` is ``True`` then ``None``.
 
         Examples
         --------
@@ -2664,13 +2673,41 @@ class DataSetFilters:
         planes = {'x': 6, 'xmin': 0, 'xmax': 3,
                   'y': 7, 'ymin': 1, 'ymax': 4,
                   'z': 8, 'zmin': 2, 'zmax': 5}
+
+        if inplace and copy:
+            raise ValueError('Cannot copy and modify inplace.  Pick only one.')
+
+        if plane not in planes:
+            raise ValueError('Invalid ``plane``.  Pick one of the following:\n'
+                             + ", ".join([f'"{key}"' for key in planes]))
+
         alg = vtk.vtkReflectionFilter()
         alg.SetInputDataObject(dataset)
         alg.SetPlane(planes[plane])
         alg.SetCopyInput(copy)
         alg.SetCenter(center)
         alg.Update()
-        return _get_output(alg)
+        grid = _get_output(alg)
+
+        # simply update inplace
+        if inplace:
+            dataset.points = grid.points
+            return
+
+        # output is always an UnstructuredGrid.  Ensure datatype
+        # matches when a polydata is input.
+        if isinstance(dataset, vtk.vtkPolyData):
+            if copy:
+                # this is faster than adding two meshes together
+                return grid.extract_surface()
+
+            # and this is faster since we can simply "copy" and then
+            # modify inplace
+            mesh = dataset.copy()
+            mesh.points = grid.points
+            return mesh
+
+        return grid
 
 
 @abstract_class

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2634,6 +2634,45 @@ class DataSetFilters:
         if isinstance(dataset, vtk.vtkPolyData):
             return output.extract_surface()
 
+    def reflect(dataset, plane, copy=False, center=0):
+        """Reflect a dataset across a plane.
+
+        Parameters
+        ----------
+        plane : str
+            Reflection plane options: ``'xmin'``, ``'ymin'``, ``'zmin'``, ``'xmax'``, ``'ymax'``,
+            ``'zmax'``, ``'x'``, ``'y'``, or ``'z'``.
+        copy : bool
+            If ``True``, copy the input geometry to the output.
+        center : float
+            If the reflection plane is set to ``'x'``, ``'y'`` or ``'z'``, then this parameter is
+            used to set the position of the plane.
+
+        Returns
+        -------
+        pyvista.UnstructuredGrid
+            An unstructured grid.
+
+        Examples
+        --------
+        >>> from pyvista import examples
+        >>> mesh = examples.load_airplane()
+        >>> mesh = mesh.reflect('z', copy=True, center=-100)
+        >>> mesh.plot(show_edges=True)  # doctest:+SKIP
+
+        """
+        planes = {'x': 6, 'xmin': 0, 'xmax': 3,
+                  'y': 7, 'ymin': 1, 'ymax': 4,
+                  'z': 8, 'zmin': 2, 'zmax': 5}
+        alg = vtk.vtkReflectionFilter()
+        alg.SetInputDataObject(dataset)
+        alg.SetPlane(planes[plane])
+        alg.SetCopyInput(copy)
+        alg.SetCenter(center)
+        alg.Update()
+        return _get_output(alg)
+
+
 @abstract_class
 class CompositeFilters:
     """An internal class to manage filters/algorithms for composite datasets."""

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -955,10 +955,3 @@ def test_cell_bounds(grid):
 def test_cell_type(grid):
     ctype = grid.cell_type(0)
     assert isinstance(ctype, int)
-
-
-def test_reflect(grid):
-    reflected = grid.reflect('z', copy=True, center=6)
-    assert isinstance(reflected, pyvista.UnstructuredGrid)
-    assert reflected.n_cells == 2*grid.n_cells
-    assert reflected.n_points == 2*grid.n_points

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -902,3 +902,63 @@ def test_get_data_range(grid):
     rng = grid.get_data_range('sample_cell_scalars')
     assert len(rng) == 2
     assert np.allclose(rng, (1, 40))
+
+
+def test_actual_memory_size(grid):
+    size = grid.actual_memory_size
+    assert isinstance(size, int)
+    assert size >= 0
+
+
+def test_copy_structure(grid):
+    classname = grid.__class__.__name__
+    copy = eval(f'pyvista.{classname}')()
+    copy.copy_structure(grid)
+    assert copy.n_cells == grid.n_cells
+    assert copy.n_points == grid.n_points
+    assert len(copy.field_arrays) == 0
+    assert len(copy.cell_arrays) == 0
+    assert len(copy.point_arrays) == 0
+
+
+def test_copy_attributes(grid):
+    classname = grid.__class__.__name__
+    copy = eval(f'pyvista.{classname}')()
+    copy.copy_attributes(grid)
+    assert copy.n_cells == 0
+    assert copy.n_points == 0
+    assert copy.field_arrays.keys() == grid.field_arrays.keys()
+    assert copy.cell_arrays.keys() == grid.cell_arrays.keys()
+    assert copy.point_arrays.keys() == grid.point_arrays.keys()
+
+
+def test_cell_n_points(grid):
+    npoints = grid.cell_n_points(0)
+    assert isinstance(npoints, int)
+    assert npoints >= 0
+
+
+def test_cell_points(grid):
+    points = grid.cell_points(0)
+    assert isinstance(points, np.ndarray)
+    assert points.ndim == 2
+    assert points.shape[0] > 0
+    assert points.shape[1] == 3
+
+
+def test_cell_bounds(grid):
+    bounds = grid.cell_bounds(0)
+    assert isinstance(bounds, list)
+    assert len(bounds) == 6
+
+
+def test_cell_type(grid):
+    ctype = grid.cell_type(0)
+    assert isinstance(ctype, int)
+
+
+def test_reflect(grid):
+    reflected = grid.reflect('z', copy=True, center=6)
+    assert isinstance(reflected, pyvista.UnstructuredGrid)
+    assert reflected.n_cells == 2*grid.n_cells
+    assert reflected.n_points == 2*grid.n_points


### PR DESCRIPTION
### Overview

This pull request includes methods to:

- reflect a dataset object across a plane
- return the actual size of a dataset object
- copy the structure (geometry and topology) or the data attributes of a dataset object
- return the number of points, the points, the bounding box or the type of a cell

### Details

This pull request includes the following methods:

- `DataSetFilters.reflect` to reflect a dataset object across a plane
- `DataObject.actual_memory_size` to return the actual size of a dataset object
- `DataObject.copy_structure` to copy the structure (geometry and topology) of a dataset object
- `DataObject.copy_attributes` to copy the data attributes of a dataset object
- `Common.cell_n_points` to return the number of points in a cell
- `Common.cell_points` to return the points of a cell
- `Common.cell_bounds` to return the bounding box of a cell
- `Common.cell_type` to return the type of a cell

Also includes:

- tests for these methods (see `tests/test_common.py`)
- an example for the reflect method (see `examples/01-filter/reflect.py`)

