### PR TITLE
Transforms via transform3d

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ docs/external_examples.rst
 
 # benchmark cache from pytest-benchmark
 .benchmarks
+
+# PyCharm
+.idea/

--- a/examples/01-filter/reflect.py
+++ b/examples/01-filter/reflect.py
@@ -8,6 +8,7 @@ This example reflects a mesh across a plane.
 
 """
 
+import pyvista
 from pyvista import examples
 
 ###############################################################################
@@ -17,10 +18,14 @@ from pyvista import examples
 airplane = examples.load_airplane()
 
 ###############################################################################
-# Reflect the mesh across a plane parallel to Z plane and centered in -100
-# (the geometry input is copied to the output):
-airplane = airplane.reflect('z', copy=True, center=-100)
+# Reflect the mesh across a plane parallel to Z plane and coincident with
+# (0, 0, -100)
+airplane_reflected = airplane.reflect((0, 0, 1), point=(0, 0, -100))
 
 ###############################################################################
 # Plot the reflected mesh:
-airplane.plot(show_edges=True)
+p = pyvista.Plotter()
+p.add_mesh(airplane, show_edges=True)
+p.add_mesh(airplane_reflected, show_edges=True)
+p.show()
+

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -12,7 +12,7 @@ from vtk.util.numpy_support import vtk_to_numpy
 import pyvista
 from pyvista.utilities import (FieldAssociation, get_array, is_pyvista_dataset,
                                raise_not_matching, vtk_id_list_to_array, fileio,
-                               abstract_class, axis_rotation)
+                               abstract_class, axis_rotation, apply_transformation_to_points)
 from .datasetattributes import DataSetAttributes
 from .filters import DataSetFilters
 
@@ -718,17 +718,8 @@ class Common(DataSetFilters, DataObject):
             raise ValueError(
                 "Transform element (3,3), the inverse scale term, is zero")
 
-        # Normalize the transformation to account for the scale
-        t /= t[3, 3]
+        apply_transformation_to_points(t, self.points, inplace=True)
 
-        x = (self.points*t[0, :3]).sum(1) + t[0, -1]
-        y = (self.points*t[1, :3]).sum(1) + t[1, -1]
-        z = (self.points*t[2, :3]).sum(1) + t[2, -1]
-
-        # overwrite points
-        self.points[:, 0] = x
-        self.points[:, 1] = y
-        self.points[:, 2] = z
 
     def copy_meta_from(self, ido):
         """Copy pyvista meta data onto this object from another object."""

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -12,7 +12,7 @@ from vtk.util.numpy_support import vtk_to_numpy
 import pyvista
 from pyvista.utilities import (FieldAssociation, get_array, is_pyvista_dataset,
                                raise_not_matching, vtk_id_list_to_array, fileio,
-                               abstract_class, axis_rotation, apply_transformation_to_points)
+                               abstract_class, axis_rotation, transformations)
 from .datasetattributes import DataSetAttributes
 from .filters import DataSetFilters
 
@@ -718,7 +718,7 @@ class Common(DataSetFilters, DataObject):
             raise ValueError(
                 "Transform element (3,3), the inverse scale term, is zero")
 
-        apply_transformation_to_points(t, self.points, inplace=True)
+        transformations.apply_transformation_to_points(t, self.points, inplace=True)
 
 
     def copy_meta_from(self, ido):

--- a/pyvista/utilities/__init__.py
+++ b/pyvista/utilities/__init__.py
@@ -9,3 +9,4 @@ from .helpers import *
 from .parametric_objects import *
 from .sphinx_gallery import Scraper, _get_sg_image_scraper
 from .regression import compare_images
+from .transformations import *

--- a/pyvista/utilities/__init__.py
+++ b/pyvista/utilities/__init__.py
@@ -9,4 +9,4 @@ from .helpers import *
 from .parametric_objects import *
 from .sphinx_gallery import Scraper, _get_sg_image_scraper
 from .regression import compare_images
-from .transformations import *
+from . import transformations

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -871,7 +871,7 @@ def axis_rotation(points, angle, inplace=False, deg=True, axis='z'):
     }
 
     if axis not in axis_to_vec:
-        raise ValueError
+        raise ValueError('Invalid axis. Must be either "x", "y", or "z"')
 
     rot_mat = transformations.axis_angle_rotation(axis_to_vec[axis], angle, deg=deg)
     return transformations.apply_transformation_to_points(rot_mat, points, inplace=inplace)

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -887,6 +887,19 @@ def axis_rotation(points, angle, inplace=False, deg=True, axis='z'):
     -------
     points : numpy.ndarray
         Rotated points.
+
+    Examples
+    --------
+    Rotate a set of points by 90 degrees about the x-axis in-place.
+    >>> import numpy as np
+    >>> import pyvista
+    >>> from pyvista import examples
+    >>> points = examples.load_airplane().points
+    >>> points_orig = points.copy()
+    >>> pyvista.axis_rotation(points, 90, axis='x', deg=True, inplace=True)
+    >>> assert np.all(np.isclose(points[:, 0], points_orig[:, 0]))
+    >>> assert np.all(np.isclose(points[:, 1], -points_orig[:, 2]))
+    >>> assert np.all(np.isclose(points[:, 2], points_orig[:, 1]))
     """
     axis = axis.lower()
     axis_to_vec = {

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -862,7 +862,32 @@ def abstract_class(cls_):
 
 
 def axis_rotation(points, angle, inplace=False, deg=True, axis='z'):
-    """Rotate points angle (in deg) about an axis."""
+    """Rotate points angle (in deg) about an axis.
+
+    Parameters
+    ----------
+    points : numpy.ndarray
+        Array of points with shape ``(N, 3)``
+
+    angle : float
+        Rotation angle.
+
+    inplace : bool, optional
+        Updates points in-place while returning nothing.
+
+    deg : bool, optional
+        If `True`, the angle is interpreted as degrees instead of
+        radians. Default is `True`.
+
+    axis : str, optional
+        Name of axis to rotate about. Valid options are ``'x'``, ``'y'``,
+        and ``'z'``. Default value is ``'z'``.
+
+    Returns
+    -------
+    points : numpy.ndarray
+        Rotated points.
+    """
     axis = axis.lower()
     axis_to_vec = {
         'x': (1, 0, 0),

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -17,6 +17,7 @@ import vtk.util.numpy_support as nps
 
 import pyvista
 from .fileio import from_meshio
+from . import transformations
 
 
 class FieldAssociation(enum.Enum):
@@ -863,32 +864,14 @@ def abstract_class(cls_):
 def axis_rotation(points, angle, inplace=False, deg=True, axis='z'):
     """Rotate points angle (in deg) about an axis."""
     axis = axis.lower()
+    axis_to_vec = {
+        'x': (1, 0, 0),
+        'y': (0, 1, 0),
+        'z': (0, 0, 1)
+    }
 
-    # Copy original array to if not inplace
-    if not inplace:
-        points = points.copy()
+    if axis not in axis_to_vec:
+        raise ValueError
 
-    # Convert angle to radians
-    if deg:
-        angle *= np.pi / 180
-
-    if axis == 'x':
-        y = points[:, 1] * np.cos(angle) - points[:, 2] * np.sin(angle)
-        z = points[:, 1] * np.sin(angle) + points[:, 2] * np.cos(angle)
-        points[:, 1] = y
-        points[:, 2] = z
-    elif axis == 'y':
-        x = points[:, 0] * np.cos(angle) + points[:, 2] * np.sin(angle)
-        z = - points[:, 0] * np.sin(angle) + points[:, 2] * np.cos(angle)
-        points[:, 0] = x
-        points[:, 2] = z
-    elif axis == 'z':
-        x = points[:, 0] * np.cos(angle) - points[:, 1] * np.sin(angle)
-        y = points[:, 0] * np.sin(angle) + points[:, 1] * np.cos(angle)
-        points[:, 0] = x
-        points[:, 1] = y
-    else:
-        raise ValueError('invalid axis. Must be either "x", "y", or "z"')
-
-    if not inplace:
-        return points
+    rot_mat = transformations.axis_angle_rotation(axis_to_vec[axis], angle, deg=deg)
+    return transformations.apply_transformation_to_points(rot_mat, points, inplace=inplace)

--- a/pyvista/utilities/transformations.py
+++ b/pyvista/utilities/transformations.py
@@ -16,13 +16,42 @@ def reflection(normal, point=None):
 
 
 def apply_transformation_to_points(transformation, points, inplace=False):
-    """Apply a given transformation matrix (3x3 or 4x4) to a set of points."""
-    if transformation.shape not in ((3, 3), (4, 4)):
-        raise ValueError('`transformation` must be of shape (3, 3) or (4, 4)')
+    """Apply a given transformation matrix (3x3 or 4x4) to a set of points.
 
-    if transformation.shape[1] == 4:
-        # a stack is a copy
-        points_2 = np.hstack((points, np.ones((len(points), 1))))
+    Parameters
+    ----------
+    transformation : np.ndarray
+        Transformation matrix of shape (3, 3) or (4, 4).
+
+    points : np.ndarray
+        Array of points to be transformed of shape (N, 3).
+
+    inplace : bool, optional
+        Updates points in-place while returning nothing.
+
+    Returns
+    -------
+    new_points : np.ndarray
+        Transformed points.
+    """
+    transformation_shape = transformation.shape
+    if transformation_shape not in ((3, 3), (4, 4)):
+        raise ValueError('`transformation` must be of shape (3, 3) or (4, 4).')
+
+    if points.shape[1] != 3:
+        raise ValueError('`points` must be of shape (N, 3).')
+
+    is_homogeneous = transformation_shape[0] == 4
+
+    if is_homogeneous:
+        # Divide by scale factor
+        transformation /= transformation[3, 3]
+
+        # Add the homogeneous coordinate
+        # `points_2` is a copy of the data, not a view
+        points_2 = np.empty((len(points), 4))
+        points_2[:, :-1] = points
+        points_2[:, -1] = 1
     else:
         points_2 = points
 

--- a/pyvista/utilities/transformations.py
+++ b/pyvista/utilities/transformations.py
@@ -1,0 +1,27 @@
+"""Transformations leveraging transforms3d library."""
+import numpy as np
+import transforms3d as tf3d
+
+
+def axis_angle_rotation(axis, angle, point=None, deg=True):
+    """Return a 4x4 matrix for rotation about an axis by given angle, optionally about a given point."""
+    if deg:
+        angle *= np.pi / 180
+    return tf3d.axangles.axangle2aff(axis, angle, point=point)
+
+
+def apply_transformation_to_points(transformation, points, inplace=False):
+    """Apply a given transformation matrix (3x3 or 4x4) to a set of points."""
+    if transformation.shape not in ((3, 3), (4, 4)):
+        raise RuntimeError('`transformation` must be of shape (3, 3) or (4, 4)')
+
+    # Copy original array to if not inplace
+    if not inplace:
+        points = points.copy()
+
+    if transformation.shape[1] == 4:
+        points_homogeneous = np.hstack((points, np.ones((len(points), 1))))
+    points[:, :3] = np.matmul(transformation[np.newaxis, :, :], points_homogeneous.T)[0, :3, :].T
+
+    if not inplace:
+        return points

--- a/pyvista/utilities/transformations.py
+++ b/pyvista/utilities/transformations.py
@@ -10,13 +10,18 @@ def axis_angle_rotation(axis, angle, point=None, deg=True):
     return tf3d.axangles.axangle2aff(axis, angle, point=point)
 
 
+def reflection(normal, point=None):
+    """Return a 4x4 matrix for reflection across a normal about a point."""
+    return tf3d.reflections.rfnorm2aff(normal, point=None)
+
+
 def apply_transformation_to_points(transformation, points, inplace=False):
     """Apply a given transformation matrix (3x3 or 4x4) to a set of points."""
     if transformation.shape not in ((3, 3), (4, 4)):
         raise RuntimeError('`transformation` must be of shape (3, 3) or (4, 4)')
 
-    # Copy original array to if not inplace
     if transformation.shape[1] == 4:
+        # a stack is a copy
         points_2 = np.hstack((points, np.ones((len(points), 1))))
     else:
         points_2 = points
@@ -26,7 +31,9 @@ def apply_transformation_to_points(transformation, points, inplace=False):
     points_2 = np.matmul(transformation[np.newaxis, :, :],
                          points_2.T)[0, :3, :].T
 
+    # If inplace, set the points
     if inplace:
         points[:] = points_2
     else:
+        # otherwise return the new points
         return points_2

--- a/pyvista/utilities/transformations.py
+++ b/pyvista/utilities/transformations.py
@@ -56,10 +56,8 @@ def apply_transformation_to_points(transformation, points, inplace=False):
     if points.shape[1] != 3:
         raise ValueError('`points` must be of shape (N, 3).')
 
-    is_homogeneous = transformation_shape[0] == 4
-
-    if is_homogeneous:
-        # Divide by scale factor
+    if transformation_shape[0] == 4:
+        # Divide by scale factor when homogeneous
         transformation /= transformation[3, 3]
 
         # Add the homogeneous coordinate

--- a/pyvista/utilities/transformations.py
+++ b/pyvista/utilities/transformations.py
@@ -18,7 +18,7 @@ def reflection(normal, point=None):
 def apply_transformation_to_points(transformation, points, inplace=False):
     """Apply a given transformation matrix (3x3 or 4x4) to a set of points."""
     if transformation.shape not in ((3, 3), (4, 4)):
-        raise RuntimeError('`transformation` must be of shape (3, 3) or (4, 4)')
+        raise ValueError('`transformation` must be of shape (3, 3) or (4, 4)')
 
     if transformation.shape[1] == 4:
         # a stack is a copy

--- a/pyvista/utilities/transformations.py
+++ b/pyvista/utilities/transformations.py
@@ -33,6 +33,21 @@ def apply_transformation_to_points(transformation, points, inplace=False):
     -------
     new_points : np.ndarray
         Transformed points.
+
+    Examples
+    --------
+    Scale a set of points in-place.
+
+    >>> import numpy as np
+    >>> import pyvista
+    >>> from pyvista import examples
+    >>> points = examples.load_airplane().points
+    >>> points_orig = points.copy()
+    >>> scale_factor = 2
+    >>> tf = scale_factor * np.eye(4)
+    >>> tf[3, 3,] = 1
+    >>> pyvista.transformations.apply_transformation_to_points(tf, points, inplace=True)
+    >>> assert np.all(np.isclose(points, scale_factor * points_orig))
     """
     transformation_shape = transformation.shape
     if transformation_shape not in ((3, 3), (4, 4)):

--- a/pyvista/utilities/transformations.py
+++ b/pyvista/utilities/transformations.py
@@ -28,8 +28,7 @@ def apply_transformation_to_points(transformation, points, inplace=False):
 
     # Paged matrix multiplication. For arrays with ndim > 2, matmul assumes
     # that the matrices to be multiplied lie in the last two dimensions.
-    points_2 = np.matmul(transformation[np.newaxis, :, :],
-                         points_2.T)[0, :3, :].T
+    points_2 = (transformation[np.newaxis, :, :] @ points_2.T)[0, :3, :].T
 
     # If inplace, set the points
     if inplace:

--- a/pyvista/utilities/transformations.py
+++ b/pyvista/utilities/transformations.py
@@ -16,12 +16,17 @@ def apply_transformation_to_points(transformation, points, inplace=False):
         raise RuntimeError('`transformation` must be of shape (3, 3) or (4, 4)')
 
     # Copy original array to if not inplace
-    if not inplace:
-        points = points.copy()
-
     if transformation.shape[1] == 4:
-        points_homogeneous = np.hstack((points, np.ones((len(points), 1))))
-    points[:, :3] = np.matmul(transformation[np.newaxis, :, :], points_homogeneous.T)[0, :3, :].T
+        points_2 = np.hstack((points, np.ones((len(points), 1))))
+    else:
+        points_2 = points
 
-    if not inplace:
-        return points
+    # Paged matrix multiplication. For arrays with ndim > 2, matmul assumes
+    # that the matrices to be multiplied lie in the last two dimensions.
+    points_2 = np.matmul(transformation[np.newaxis, :, :],
+                         points_2.T)[0, :3, :].T
+
+    if inplace:
+        points[:] = points_2
+    else:
+        return points_2

--- a/pyvista/utilities/transformations.py
+++ b/pyvista/utilities/transformations.py
@@ -12,7 +12,7 @@ def axis_angle_rotation(axis, angle, point=None, deg=True):
 
 def reflection(normal, point=None):
     """Return a 4x4 matrix for reflection across a normal about a point."""
-    return tf3d.reflections.rfnorm2aff(normal, point=None)
+    return tf3d.reflections.rfnorm2aff(normal, point=point)
 
 
 def apply_transformation_to_points(transformation, points, inplace=False):

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,9 @@ install_requires = ['numpy',
                     'appdirs',
                     'scooby>=0.5.1',
                     'meshio>=4.0.3, <5.0',
-                    'vtk']
+                    'vtk',
+                    'transforms3d==0.3.1'
+                    ]
 
 readme_file = os.path.join(filepath, 'README.rst')
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -201,6 +201,19 @@ def test_translate_should_fail_given_none(grid):
         grid.transform(None)
 
 
+def test_translate_should_fail_bad_points(grid):
+    points = np.random.random((10, 2))
+    bad_points = np.random.random((10, 2))
+    trans = np.random.random((4, 4))
+    bad_trans = np.random.random((2, 4))
+    with pytest.raises(ValueError):
+        pyvista.utilities.transformations.apply_transformation_to_points(trans, bad_points)
+
+    with pytest.raises(ValueError):
+        pyvista.utilities.transformations.apply_transformation_to_points(bad_trans, points)
+
+
+
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 @given(array=arrays(dtype=np.float32, shape=array_shapes(max_dims=5, max_side=5)))
 def test_transform_should_fail_given_wrong_numpy_shape(array, grid):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1076,18 +1076,22 @@ def test_shrink():
 
 
 def test_reflect_grid(grid):
-    with pytest.raises(ValueError):
-        grid.reflect('not_valid')
+    reflected = grid.reflect((0, 0, 1), point=(0, 0, 6))
+    assert isinstance(reflected, type(grid))
+    assert reflected.n_cells == grid.n_cells
+    assert reflected.n_points == grid.n_points
 
-    reflected = grid.reflect('z', copy=True, center=6)
-    assert isinstance(reflected, pyvista.UnstructuredGrid)
-    assert reflected.n_cells == 2*grid.n_cells
-    assert reflected.n_points == 2*grid.n_points
+
+def test_reflect_struct_grid(struct_grid):
+    reflected = struct_grid.reflect((0, 0, 1), point=(0, 0, 6))
+    assert isinstance(reflected, type(struct_grid))
+    assert reflected.n_cells == struct_grid.n_cells
+    assert reflected.n_points == struct_grid.n_points
 
 
 def test_reflect_mesh(airplane):
-    reflected = airplane.reflect('x')
-    assert isinstance(reflected, pyvista.PolyData)
+    reflected = airplane.reflect((1, 0, 0))
+    assert isinstance(reflected, type(airplane))
     assert reflected.n_cells == airplane.n_cells
     assert reflected.n_points == airplane.n_points
 
@@ -1095,18 +1099,21 @@ def test_reflect_mesh(airplane):
     assert np.allclose(airplane.points[:, 1:], reflected.points[:, 1:])
 
 
-def test_reflect_mesh_copy(airplane):
-    reflected = airplane.reflect('x', copy=True)
-    assert isinstance(reflected, pyvista.PolyData)
-    assert reflected.n_cells == 2*airplane.n_cells
-    assert reflected.n_points == 2*airplane.n_points
+def test_reflect_mesh(airplane):
+    reflected = airplane.reflect((1, 0, 0))
+    assert isinstance(reflected, type(airplane))
+    assert reflected.n_cells == airplane.n_cells
+    assert reflected.n_points == airplane.n_points
+
+    assert np.allclose(airplane.points[:, 0], -reflected.points[:, 0])
+    assert np.allclose(airplane.points[:, 1:], reflected.points[:, 1:])
 
 
 def test_reflect_inplace(airplane):
-    with pytest.raises(ValueError):
-        airplane.reflect('x', copy=True, inplace=True)
-
     orig = airplane.copy()
-    airplane.reflect('x', inplace=True)
+    airplane.reflect_2((1, 0, 0), inplace=True)
     assert airplane.n_cells == orig.n_cells
     assert airplane.n_points == orig.n_points
+
+    assert np.allclose(airplane.points[:, 0], -orig.points[:, 0])
+    assert np.allclose(airplane.points[:, 1:], orig.points[:, 1:])

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1099,19 +1099,20 @@ def test_reflect_mesh(airplane):
     assert np.allclose(airplane.points[:, 1:], reflected.points[:, 1:])
 
 
-def test_reflect_mesh(airplane):
-    reflected = airplane.reflect((1, 0, 0))
+def test_reflect_mesh_about_point(airplane):
+    x_plane = 500
+    reflected = airplane.reflect((1, 0, 0), point=(x_plane, 0, 0))
     assert isinstance(reflected, type(airplane))
     assert reflected.n_cells == airplane.n_cells
     assert reflected.n_points == airplane.n_points
 
-    assert np.allclose(airplane.points[:, 0], -reflected.points[:, 0])
+    assert np.allclose(x_plane - airplane.points[:, 0], reflected.points[:, 0] - x_plane)
     assert np.allclose(airplane.points[:, 1:], reflected.points[:, 1:])
 
 
 def test_reflect_inplace(airplane):
     orig = airplane.copy()
-    airplane.reflect_2((1, 0, 0), inplace=True)
+    airplane.reflect((1, 0, 0), inplace=True)
     assert airplane.n_cells == orig.n_cells
     assert airplane.n_points == orig.n_points
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -17,7 +17,8 @@ from pyvista.utilities import (
     GPUInfo,
     helpers,
     Observer,
-    cells
+    cells,
+    transformations
 )
 
 # Only set this here just the once.
@@ -391,3 +392,25 @@ def test_cells_dict_utils():
     np.all(cells.generate_cell_offsets(cells_arr, cells_types) ==
            cells.generate_cell_offsets(cells_arr, np.array([255, 255])))
 
+
+def test_apply_transformation_to_points():
+    mesh = ex.load_airplane()
+    points = mesh.points
+    points_orig = points.copy()
+
+    # identity 3 x 3
+    tf = np.eye(3)
+    points_new = transformations.apply_transformation_to_points(tf, points, inplace=False)
+    assert points_new == pytest.approx(points)
+
+    # identity 4 x 4
+    tf = np.eye(4)
+    points_new = transformations.apply_transformation_to_points(tf, points, inplace=False)
+    assert points_new == pytest.approx(points)
+
+    # scale in-place
+    tf = np.eye(4) * 2
+    tf[3, 3] = 1
+    r = transformations.apply_transformation_to_points(tf, points, inplace=True)
+    assert r is None
+    assert mesh.points == pytest.approx(2 * points_orig)


### PR DESCRIPTION
### Overview

`DataSetFilters.transform(tf)` takes a 4x4 transformation matrix, but there wasn't a nice way inside PyVista to generate such matrices. A method for generating rotation matrices lived in `utilties.helpers.axis_rotation`, but only about x/y/z axes.

This PR adds code to generate transformation matrices via https://github.com/matthew-brett/transforms3d, (new dependency). This library has methods to generate a variety of 3x3 and 4x4 transformations (axis-angle/Euler/Tait-Bryan rotations) as well as reflections, shears, zooms, and more.

In this PR I have wrapped only axis/angle rotations and reflections in PyVista-friendly form (see `utilities.transformations`).

In addition, this totally refactors `DataSetFilters.reflection()` which was added very recently in #1122. I wanted to open this PR ASAP since I don't think the official 0.28 has been cut yet. The new version of the reflection filter takes in a normal and (optional) point which define the reflection plane. The input object is either modified in place, or a reflected object of the same class as the input is returned. Given this behavior, the `copy` option of the previous filter is gone, as it doesn't make sense to try to combine two disconnected structured grids into one.

This is not a knock on the previous implementation, but rather on `vtkReflectionFilter` itself. It just doesn't make a whole lot of sense to me. Why only return unstructured grids? What about structured, rectilinear, etc.?

@rodrigomologni what are your thoughts on this?

### Details

Other notes:
- The matrix multiplication that previously lived in `Common.transform()` is moved to `utilties.transformations.apply_transformation_to_points()`. A single call to `matmul` is used. @akaszynski 
- I don't know how deep the documentation for public methods needs to go. Are utilities documented?

