### PR TITLE
Allow conda CI failure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -155,18 +155,21 @@ jobs:
         conda activate pyvista-vtk$(VTK.VERSION)
         pytest -v --ignore=tests/plotting
       displayName: 'Test Core API'
+      continueOnError: true  # 'true' if future steps should run even if this step fails; defaults to 'false'
 
     - script: |
         source /usr/share/miniconda/etc/profile.d/conda.sh
         conda activate pyvista-vtk$(VTK.VERSION)
         pytest -v tests/plotting --cov-report html
       displayName: 'Test Core Plotting API'
+      continueOnError: true  # 'true' if future steps should run even if this step fails; defaults to 'false'
 
     - script: |
         source /usr/share/miniconda/etc/profile.d/conda.sh
         conda activate pyvista-vtk$(VTK.VERSION)
         pytest -v --doctest-modules pyvista
       displayName: 'Test Package Docstrings against VTK'
+      continueOnError: true  # 'true' if future steps should run even if this step fails; defaults to 'false'
   condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))
 
 


### PR DESCRIPTION
### Allow failure on conda build

Conda CI runs have always been flaky.  I'm not sure if this is due to the specific VTK binaries packaged with the build or the conda enviornment, but I sometimes see flaky failures with conda that are not reproduceable on my local linux env.

For the time being, I'm allowing failures on conda for the main unit tests.  These will still result in notifications within Azure devops, but won't fail the build 
