### PR TITLE
Reimplement Light.copy to get around VTK8.1 bug

### DIFF
--- a/pyvista/plotting/lights.py
+++ b/pyvista/plotting/lights.py
@@ -853,7 +853,8 @@ class Light(vtkLight):
         new_light = Light()
 
         for attr in immutable_attrs:
-            setattr(new_light, attr, getattr(self, attr))
+            value = getattr(self, attr)
+            setattr(new_light, attr, value)
 
         if deep and self.transform_matrix is not None:
             trans = vtk.vtkMatrix4x4()

--- a/pyvista/plotting/lights.py
+++ b/pyvista/plotting/lights.py
@@ -857,11 +857,10 @@ class Light(vtkLight):
             setattr(new_light, attr, value)
 
         if deep and self.transform_matrix is not None:
-            trans = vtk.vtkMatrix4x4()
-            trans.DeepCopy(self.transform_matrix)
+            new_light.transform_matrix = vtk.vtkMatrix4x4()
+            new_light.transform_matrix.DeepCopy(self.transform_matrix)
         else:
-            trans = self.transform_matrix
-        new_light.transform_matrix = trans
+            new_light.transform_matrix = self.transform_matrix
 
         # light actors are private, always copy, but copy visibility state as well
         new_light._actor.SetVisibility(self._actor.GetVisibility())

--- a/pyvista/plotting/lights.py
+++ b/pyvista/plotting/lights.py
@@ -836,13 +836,31 @@ class Light(vtkLight):
         True
 
         """
-        # let vtk do the heavy lifting
-        if deep:
-            other = vtkLight()
-            other.DeepCopy(self)
+        immutable_attrs = [
+            'light_type',
+            'position',
+            'focal_point',
+            'ambient_color',
+            'diffuse_color',
+            'specular_color',
+            'intensity',
+            'on',
+            'positional',
+            'exponent',
+            'cone_angle',
+            'attenuation_values',
+        ]
+        new_light = Light()
+
+        for attr in immutable_attrs:
+            setattr(new_light, attr, getattr(self, attr))
+
+        if deep and self.transform_matrix is not None:
+            trans = vtk.vtkMatrix4x4()
+            trans.DeepCopy(self.transform_matrix)
         else:
-            other = self.ShallowClone()
-        new_light = Light.from_vtk(other)
+            trans = self.transform_matrix
+        new_light.transform_matrix = trans
 
         # light actors are private, always copy, but copy visibility state as well
         new_light._actor.SetVisibility(self._actor.GetVisibility())
@@ -909,8 +927,7 @@ class Light(vtkLight):
         light.cone_angle = vtk_light.GetConeAngle()
         light.attenuation_values = vtk_light.GetAttenuationValues()
         trans = vtk_light.GetTransformMatrix()
-        if trans is not None:
-            light.transform_matrix = trans
+        light.transform_matrix = trans
 
         return light
 

--- a/tests/test_lights.py
+++ b/tests/test_lights.py
@@ -4,8 +4,6 @@ import vtk
 
 import pyvista
 
-VTK9 = vtk.vtkVersion().GetVTKMajorVersion() >= 9
-
 # pyvista attr -- value -- vtk name triples:
 configuration = [
     ('light_type', pyvista.Light.CAMERA_LIGHT, 'SetLightType'),  # resets transformation!
@@ -82,7 +80,6 @@ def test_eq():
     assert light != other
 
 
-@pytest.mark.skipif(not VTK9, reason='VTK <9 does not copy light type correctly')
 def test_copy():
     light = pyvista.Light()
     for name, value, _ in configuration:


### PR DESCRIPTION
### Overview

The original `Light.copy()` implementation relied on `vtkLight.DeepCopy()` and `vtkLight.ShallowClone()`. Since the former was buggy in VTK < 8.2 we now reimplement it from scratch.

I changed so that we always copy manually. I figured it might not be worth the complexity to branch based on VTK version (especially considering testability).