### PR TITLE
add dep to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - scooby>=0.5.1
   - meshio>=4.0.3, <5.0
   - matplotlib
+  - transforms3d==0.3.1
   - appdirs
   - pyqt
   - imageio>=2.5.0


### PR DESCRIPTION
### Missing hard requirement in `environment.yml`

Forgot to add in the `transforms3d` requirement in our conda enviornment yml.  This PR patches that and will be merged to `release/0.28` as well.

See:
https://github.com/conda-forge/pyvista-feedstock/pull/38

Resolves #1141
