### PR TITLE
Add pickle support to DataObject

### DIFF
--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -59,6 +59,9 @@ class ActiveArrayInfo:
     def __setitem__(self, key, value):
         self._namedtuple.__setitem__(key, value)
 
+    def __getattr__(self, item):
+        self._namedtuple.__getattr__(item)
+
     def __eq__(self, other):
         """Check equivalence (useful for serialize/deserialize tests)."""
         return self.name == other.name and \

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -41,15 +41,23 @@ class ActiveArrayInfo:
         self.__dict__ = state.copy()
         self.association = FieldAssociation(state['association'])
 
+    @property
+    def _namedtuple(self):
+        """Build a namedtuple on the fly to provide legacy support."""
+        named_tuple = collections.namedtuple('ActiveArrayInfo', ['association', 'name'])
+        return named_tuple(self.association, self.name)
+
     def __iter__(self):
-        """Provide legacy __iter__ behavior (like collections.namedtuple)."""
-        for v in (self.association, self.name):
-            yield v
+        return self._namedtuple.__iter__()
 
     def __repr__(self):
-        """Provide legacy __repr__ behavior (like collections.namedtuple)."""
-        named_tuple = collections.namedtuple('ActiveArrayInfo', ['association', 'name'])
-        return named_tuple(self.association, self.name).__repr__()
+        return self._namedtuple.__repr__()
+
+    def __getitem__(self, item):
+        return self._namedtuple.__getitem__(item)
+
+    def __setitem__(self, key, value):
+        self._namedtuple.__setitem__(key, value)
 
     def __eq__(self, other):
         """Check equivalence (useful for serialize/deserialize tests)."""

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -64,7 +64,7 @@ class ActiveArrayInfo:
         return self._namedtuple.__getitem__(item)
 
     def __setitem__(self, key, value):
-        """Provide namedtuple-like __getitem__."""
+        """Provide namedtuple-like __setitem__."""
         self._namedtuple.__setitem__(key, value)
 
     def __getattr__(self, item):

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -328,8 +328,7 @@ class DataObject:
         writer.SetFileTypeToASCII()
         writer.Write()
         to_serialize = writer.GetOutputString()
-        state['vtk_serialized'] = pickle.dumps(to_serialize,
-                                               protocol=pickle.HIGHEST_PROTOCOL)
+        state['vtk_serialized'] = to_serialize
         return state
 
     def __setstate__(self, state):
@@ -338,7 +337,7 @@ class DataObject:
 
         reader = vtk.vtkDataSetReader()
         reader.ReadFromInputStringOn()
-        reader.SetInputString(pickle.loads(vtk_serialized))
+        reader.SetInputString(vtk_serialized)
         reader.Update()
         mesh = pyvista.wrap(reader.GetOutput())
 

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -341,6 +341,7 @@ class DataObject:
         self.CopyAttributes(dataset)
 
     def __getstate__(self):
+        """Support pickle. Serialize the VTK object to ASCII string."""
         state = self.__dict__.copy()
         writer = vtk.vtkDataSetWriter()
         writer.SetInputDataObject(self)
@@ -352,6 +353,7 @@ class DataObject:
         return state
 
     def __setstate__(self, state):
+        """Support unpickle."""
         vtk_serialized = state.pop('vtk_serialized')
         self.__dict__.update(state)
 

--- a/pyvista/core/common.py
+++ b/pyvista/core/common.py
@@ -28,16 +28,20 @@ DEFAULT_VECTOR_KEY = '_vectors'
 
 class ActiveArrayInfo:
     """Active array info class with support for pickling."""
+
     def __init__(self, association, name):
+        """Initialize."""
         self.association = association
         self.name = name
 
     def __getstate__(self):
+        """Support pickling."""
         state = self.__dict__.copy()
         state['association'] = int(self.association.value)
         return state
 
     def __setstate__(self, state):
+        """Support unpickling."""
         self.__dict__ = state.copy()
         self.association = FieldAssociation(state['association'])
 
@@ -48,18 +52,23 @@ class ActiveArrayInfo:
         return named_tuple(self.association, self.name)
 
     def __iter__(self):
+        """Provide namedtuple-like __iter__."""
         return self._namedtuple.__iter__()
 
     def __repr__(self):
+        """Provide namedtuple-like __repr__."""
         return self._namedtuple.__repr__()
 
     def __getitem__(self, item):
+        """Provide namedtuple-like __getitem__."""
         return self._namedtuple.__getitem__(item)
 
     def __setitem__(self, key, value):
+        """Provide namedtuple-like __getitem__."""
         self._namedtuple.__setitem__(key, value)
 
     def __getattr__(self, item):
+        """Provide namedtuple-like __getattr__."""
         self._namedtuple.__getattr__(item)
 
     def __eq__(self, other):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -986,5 +986,23 @@ def test_cell_type(grid):
 
 def test_serialize_deserialize(grid):
     grid_2 = pickle.loads(pickle.dumps(grid))
+
+    # check python attributes are the same
     for attr in grid.__dict__:
         assert getattr(grid, attr) == getattr(grid_2, attr)
+
+    # check data is the same
+    for attr in ('n_cells', 'n_points', 'n_arrays'):
+        assert getattr(grid, attr) == getattr(grid_2, attr)
+
+    for attr in ('cells', 'points'):
+        assert np.all(getattr(grid, attr) == getattr(grid_2, attr))
+
+    for name in grid.point_arrays:
+        assert np.all(grid.point_arrays[name] == grid_2.point_arrays[name])
+
+    for name in grid.cell_arrays:
+        assert np.all(grid.cell_arrays[name] == grid_2.cell_arrays[name])
+
+    for name in grid.field_arrays:
+        assert np.all(grid.field_arrays[name] == grid_2.field_arrays[name])

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,3 +1,4 @@
+import pickle
 import numpy as np
 import pytest
 import vtk
@@ -981,3 +982,9 @@ def test_cell_bounds(grid):
 def test_cell_type(grid):
     ctype = grid.cell_type(0)
     assert isinstance(ctype, int)
+
+
+def test_serialize_deserialize(grid):
+    grid_2 = pickle.loads(pickle.dumps(grid))
+    for attr in grid.__dict__:
+        assert getattr(grid, attr) == getattr(grid_2, attr)


### PR DESCRIPTION
### Overview

Adds simple pickle support to DataObject via `__getstate__` and `__setstate__`.

```python
import pyvista
from pyvista import examples

grid = pyvista.UnstructuredGrid(examples.hexbeamfile)
grid_2 = pickle.loads(pickle.dumps(grid))
```

It also enables DataObjects to be used in parallel workflows, for example, in this workflow which clips a dataset three ways in parallel using `concurrent.futures`. All of the deserialized objects are copies, so this requires N-times memory.

```python
import concurrent.futures as cf
import numpy as np

import pyvista
from pyvista import examples

m = examples.load_airplane()
m.cell_arrays['cell'] = np.ones((m.n_cells, 1))

def clip_mesh(mesh, normal):
    return mesh.clip(normal=normal)

p = cf.ProcessPoolExecutor()
futures = [p.submit(clip_mesh, m, normal) for normal in ('x', 'y', 'z')]
results = [f.result() for f in futures]

p = pyvista.Plotter(shape=(1, 3))
for i in range(3):
    p.subplot(0, i)
    p.add_mesh(results[i])
p.show()

```
![image](https://user-images.githubusercontent.com/2186528/106773312-c87d9b80-65f5-11eb-8666-9f2fe9a31869.png)

### Details

The implementation is similar to the one described in https://github.com/pyvista/pyvista-support/issues/59. As @banesullivan , I also encountered the issue when trying to serialize to binary; in this PR the serialization medium is still unfortunately an ASCII string. At least one other person (see https://stackoverflow.com/questions/38747801/) has run into this binary issue, so perhaps this is something which needs to be fixed on the VTK side.

ActiveArrayInfo, formerly a `namedtuple`, is rewritten as a class to support serialization because the FieldAssociation class (stored in attributes of ActiveArrayInfo) uses VTK enums which are not serializable. `namedtuple` cannot be inherited in a normal way, so legacy support for `__getitem__`, `__setitem__`, `__repr__`, `__iter__` is added by means of a `namedtuple` built on-the-fly. Perhaps there's a better way to do this...
