### PR TITLE
Fix Binary Writer

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -139,10 +139,10 @@ class PolyData(vtkPolyData, PointSet, PolyDataFilters):
     """
 
     _READERS = {'.ply': vtk.vtkPLYReader, '.stl': vtk.vtkSTLReader,
-                    '.vtk': vtk.vtkPolyDataReader, '.vtp': vtk.vtkXMLPolyDataReader,
-                    '.obj': vtk.vtkOBJReader}
+                '.vtk': vtk.vtkPolyDataReader, '.vtp': vtk.vtkXMLPolyDataReader,
+                '.obj': vtk.vtkOBJReader}
     _WRITERS = {'.ply': vtk.vtkPLYWriter, '.vtp': vtk.vtkXMLPolyDataWriter,
-                    '.stl': vtk.vtkSTLWriter, '.vtk': vtk.vtkPolyDataWriter}
+                '.stl': vtk.vtkSTLWriter, '.vtk': vtk.vtkPolyDataWriter}
 
     def __init__(self, *args, **kwargs):
         """Initialize the polydata."""

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -96,7 +96,7 @@ def set_vtkwriter_mode(vtk_writer, use_binary=True):
             vtk_writer.SetFileTypeToBinary()
         else:
             vtk_writer.SetFileTypeToASCII()
-    elif isinstance(vtk_writer, vtk.vtkXMLWriter):
+    elif isinstance(vtk_writer, (vtk.vtkXMLWriter, vtk.vtkXMLPolyDataWriter)):
         if use_binary:
             vtk_writer.SetDataModeToBinary()
         else:

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -91,7 +91,7 @@ def get_reader(filename):
 
 def set_vtkwriter_mode(vtk_writer, use_binary=True):
     """Set any vtk writer to write as binary or ascii."""
-    if isinstance(vtk_writer, (vtk.vtkDataWriter, vtk.vtkPLYWriter)):
+    if isinstance(vtk_writer, (vtk.vtkDataWriter, vtk.vtkPLYWriter, vtk.vtkSTLWriter)):
         if use_binary:
             vtk_writer.SetFileTypeToBinary()
         else:

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -96,7 +96,7 @@ def set_vtkwriter_mode(vtk_writer, use_binary=True):
             vtk_writer.SetFileTypeToBinary()
         else:
             vtk_writer.SetFileTypeToASCII()
-    elif isinstance(vtk_writer, (vtk.vtkXMLWriter, vtk.vtkXMLPolyDataWriter)):
+    elif isinstance(vtk_writer, vtk.vtkXMLWriter):
         if use_binary:
             vtk_writer.SetDataModeToBinary()
         else:

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -28,6 +28,14 @@ except KeyError:
     CONDA_ENV = False
 
 
+def is_binary(filename):
+    """Return ``True`` when a file is binary"""
+    textchars = bytearray({7, 8, 9, 10, 12, 13, 27} | set(range(0x20, 0x100)) - {0x7f})
+    with open(filename, 'rb') as f:
+        data = f.read(1024)
+    return bool(data.translate(None, textchars))
+
+
 def test_init():
     mesh = pyvista.PolyData()
     assert not mesh.n_points
@@ -332,7 +340,12 @@ def test_save(extension, binary, tmpdir):
     filename = str(tmpdir.mkdir("tmpdir").join(f'tmp{extension}'))
     sphere.save(filename, binary)
 
-    if not binary:
+    if binary:
+        if extension == '.vtp':
+            assert 'binary' in open(filename).read(1000)
+        else:
+            is_binary(filename)
+    else:
         with open(filename) as f:
             fst = f.read(100).lower()
             assert 'ascii' in fst or 'xml' in fst or 'solid' in fst


### PR DESCRIPTION
### Add additional tests for binary writer

We've been adding binary writer checks in a piecemeal manner.  This PR adds support for writing STL and *.vtp files along with checking if the files written are binary or ASCII.

I tried pushing to #1147, but there was a problem with the `gh` client and I ended up just making a new branch.  I've been able to include your commit, so you'll be a partial author of this PR as well.

Resolves #1146 