### PR TITLE
Fix and update some sphinx docs

### DIFF
--- a/docs/plotting/notebook_plotting/itk_plotting.rst
+++ b/docs/plotting/notebook_plotting/itk_plotting.rst
@@ -9,8 +9,9 @@ within a jupyter notebook.  For those who prefer plotting within
 jupyter, this is an great way of visualizing using ``VTK`` and
 ``pyvista``.
 
-Special thanks to @thewtex for the `itkwidgets`_ library.
+Special thanks to `@thewtex`_ for the `itkwidgets`_ library.
 
+.. _@thewtex: https://github.com/thewtex
 .. _itkwidgets: https://github.com/InsightSoftwareConsortium/itkwidgets
 
 
@@ -62,10 +63,6 @@ For convenience, figures can also be plotted using the ``plot_itk`` function:
     # Plot using the ITKplotter
     pv.plot_itk(mesh, scalars=z)
 
-
-Additional examples can be found at `binder`_.
-
-.. _binder: https://hub.gke.mybinder.org/user/insightsoftware-tium-itkwidgets-p2yw6xvh/lab
 
 .. rubric:: Attributes
 

--- a/docs/plotting/notebook_plotting/itk_plotting.rst
+++ b/docs/plotting/notebook_plotting/itk_plotting.rst
@@ -9,15 +9,15 @@ within a jupyter notebook.  For those who prefer plotting within
 jupyter, this is an great way of visualizing using ``VTK`` and
 ``pyvista``.
 
-Special thanks to thewtex
+Special thanks to @thewtex for the `itkwidgets`_ library.
+
 .. _itkwidgets: https://github.com/InsightSoftwareConsortium/itkwidgets
 
 
 Installation
 ++++++++++++
 To use `PlotterITK` you'll need to install ``itkwidgets>=0.25.2``.
-Follow the installation steps here:
-.. _itkwidgets: https://github.com/InsightSoftwareConsortium/itkwidgets#installation
+Follow the installation steps `here <https://github.com/InsightSoftwareConsortium/itkwidgets#installation>`_.
 
 You can install everything with `pip` if you prefer not using conda,
 but be sure your juptyerlab is up-to-date.  If you encounter problems,
@@ -63,9 +63,9 @@ For convenience, figures can also be plotted using the ``plot_itk`` function:
     pv.plot_itk(mesh, scalars=z)
 
 
-Additional binder examples can be found at:
+Additional examples can be found at `binder`_.
 
-.. _itkwidgets_binder: https://hub.gke.mybinder.org/user/insightsoftware-tium-itkwidgets-p2yw6xvh/lab
+.. _binder: https://hub.gke.mybinder.org/user/insightsoftware-tium-itkwidgets-p2yw6xvh/lab
 
 .. rubric:: Attributes
 

--- a/examples/01-filter/glyphs_table.py
+++ b/examples/01-filter/glyphs_table.py
@@ -1,10 +1,11 @@
 """
-.. _glyph_example:
+.. _glyph_table_example:
 
-Plotting Glyphs (PolyData)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Table of Glyphs
+~~~~~~~~~~~~~~~
 
-Use parameters in a dataset to plot and orient glyphs/geometric objects.
+``vtk`` supports tables of glyphs from which glyphs are looked
+up. This example demonstrates this functionality.
 """
 
 import pyvista as pv
@@ -12,16 +13,13 @@ import numpy as np
 
 
 ###############################################################################
-# Table of Glyphs
-#
-# ``vtk`` supports tables of glyphs from which glyphs are looked
-# up. This example demonstrates this functionality.
 #
 # We can allow tables of glyphs in a backward-compatible way by
 # allowing a sequence of geometries as well as single (scalar)
-# geometries to be passed as the geom kwarg of glyph. An indices
-# optional keyword is added, which is mandatory in case geom is a
-# sequence, and in this case has to be the same length.
+# geometries to be passed as the ``geom`` kwarg of :func:`pyvista.DataSetFilters.glyph`.
+# An ``indices`` optional keyword specifies the index of each glyph geometry in
+# the table, and it has to be the same length as ``geom`` if specified. If it is
+# absent a default value of ``range(len(geom))`` is assumed.
 
 # get dataset for the glyphs: supertoroids in xy plane
 # use N random kinds of toroids over a mesh with 27 points


### PR DESCRIPTION
A few sphinx references and links were broken. Along the way I also touched up the glyph table example a bit.

Changes:
  * Fix the syntax of two links in https://github.com/adeak/pyvista/blob/17f6d5921cbc45c59dc6bd69f681efdfe303b299/docs/plotting/notebook_plotting/itk_plotting.rst, changing to named links. These were broken: https://docs.pyvista.org/plotting/notebook_plotting/itk_plotting.html 
  * In the same file change "thanks to thewtex" to "thanks to `@thewtex`" (code markdown only here to break a possible ping in this PR) to make it more obvious that this is a github handle
  * There was a duplicate ref in https://github.com/adeak/pyvista/blob/17f6d5921cbc45c59dc6bd69f681efdfe303b299/examples/01-filter/glyphs_table.py which I renamed to resolve
  * There was also some text in that example duplicating the main glyph example. I've removed it and rephrased the example's text a bit, along with fixing the explanation of how the ``indices`` keyword behaves.
  
Questions:
  * perhaps "`@thewtex`" in `docs/plotting/notebook_plotting/itk_plotting.rst` should be spelled out with a full name instead?
  * the binder link in the same file seems to be broken, but I couldn't figure out if we have an appropriate replacement. Either the link should be updated or the whole sentence removed.