### PR TITLE
Update enable_cell_picking

### DIFF
--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -124,8 +124,9 @@ class PickingHelper:
                 self_().render()
             elif not is_valid_selection:
                 self.remove_actor('_cell_picking_selection')
+                self_().picked_cells = None
 
-            if callback is not None and is_valid_selection:
+            if callback is not None:
                 try_callback(callback, self_().picked_cells)
 
             # TODO: Deactivate selection tool


### PR DESCRIPTION
### Overview

This PR updates `PickingHelper.enable_cell_picking` to:

1. set `picked_cells` as `None` (default value) if no cell is selected.
2. call `callback` even when no cell is selected.

### Details

1. `picked_cells` returns `None` before `enable_cell_picking` is called, and an empty `MultiBlock` after.
2. `callback` should be called even when no cell is selected to update the `callback`. An practical example:

This screenshot shown an software where the grid cells selected by an user in the left renderer are shown in the right renderer. The right renderer needs to be cleaned when no cells are selected. Otherwise, the last selected cell is always shown.

![image](https://user-images.githubusercontent.com/1608652/107550427-c98f6980-6baf-11eb-8f14-e1af02d94813.png)

