### PR TITLE
Fix bugs in enable_cell_picking

### DIFF
--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -114,11 +114,26 @@ class PickingHelper:
             is_valid_selection = picked.n_cells > 0
 
             if show and is_valid_selection:
+                # Select the renderer where the mesh is added.
+                active_renderer_index = self_()._active_renderer_index
+                for index in range(len(self.renderers)):
+                    renderer = self.renderers[index]
+                    for actor in renderer._actors.values():
+                        mapper = actor.GetMapper()
+                        if isinstance(mapper, vtk.vtkDataSetMapper) and mapper.GetInput() == mesh:
+                            loc = self_().index_to_loc(index)
+                            self_().subplot(*loc)
+                            break
+
                 # Use try in case selection is empty
                 self_().add_mesh(picked, name='_cell_picking_selection',
                                  style=style, color=color,
                                  line_width=line_width, pickable=False,
                                  reset_camera=False, **kwargs)
+
+                # Reset to the active renderer.
+                loc = self_().index_to_loc(active_renderer_index)
+                self_().subplot(*loc)
 
                 # render here prior to running the callback
                 self_().render()


### PR DESCRIPTION
### Overview

This PR fixes the followings problems in `enable_cell_picking`:

1. The interactive selection is shown in the renderer where the `mesh` is not present.
2. `OverflowError` occurs when the user first clicks on the second renderer.

### Details

Given the following code:

```python
self.plotter = QtInteractor(self, shape=(1, 2))
self.plotter.subplot(0, 0)
self.plotter.add_axes()
self.plotter.add_mesh(self.coarse, color='w', show_edges=True, lighting=False)
self.plotter.enable_cell_picking(self.coarse, callback=self.coarse_cell_picking, through=False, show_message=False)
self.plotter.subplot(0, 1)
self.plotter.add_axes()
self.plotter.show()
```

#### Bugfix 1

The `mesh` is in the left renderer, but the interactive selection is rendered in the right renderer.

![image](https://user-images.githubusercontent.com/1608652/107594058-c4520f00-6bef-11eb-9bcd-7be4c70a25cf.png)

The user must call `self.plotter.subplot(0, 0)` to overcome this problem.

![image](https://user-images.githubusercontent.com/1608652/107594577-029bfe00-6bf1-11eb-83ec-2e6ab2a706c5.png)

The commit `bbc49df` fix this problem. The interactive selection is rendered on the `mesh` regardless of the active renderer.

#### Bugfix 2

The following error occurs when the user first clicks on the right renderer:

```
Traceback (most recent call last):
  File "c:\users\rodrigo mologni\github\pyvista\pyvista\plotting\picking.py", line 149, in visible_pick_call_back
    selector.SetArea(x0,y0,x1,y1)
OverflowError: SetArea argument %Id: %V
```

Reason: `x0 = y0 = x1 = y1 = -1` (default pick position of `vtkRenderer`). The commit `64fdfc4` fix this problem.
