### PR TITLE
Add bounds in reset_camera

### DIFF
--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1312,9 +1312,7 @@ class Renderer(vtkRenderer):
             ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
 
         """
-        if isinstance(bounds, np.ndarray):
-            bounds = bounds.tolist()
-        if bounds:
+        if bounds is not None:
             self.ResetCamera(*bounds)
         else:
             self.ResetCamera()

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1307,11 +1307,13 @@ class Renderer(vtkRenderer):
         ----------
         render : bool
             Trigger a render after resetting the camera.
-        bounds : tuple(int)
+        bounds : iterable(int)
             Automatically set up the camera based on a specified bounding box
             ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
 
         """
+        if isinstance(bounds, np.ndarray):
+            bounds = bounds.tolist()
         if bounds:
             self.ResetCamera(*bounds)
         else:

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1297,7 +1297,7 @@ class Renderer(vtkRenderer):
                 self.cube_axes_actor.SetUse2DMode(False)
             self.Modified()
 
-    def reset_camera(self, render=True):
+    def reset_camera(self, render=True, bounds=None):
         """Reset the camera of the active render window.
 
         The camera slides along the vector defined from camera
@@ -1307,9 +1307,15 @@ class Renderer(vtkRenderer):
         ----------
         render : bool
             Trigger a render after resetting the camera.
+        bounds : tuple(int)
+            Automatically set up the camera based on a specified bounding box
+            ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
 
         """
-        self.ResetCamera()
+        if bounds:
+            self.ResetCamera(*bounds)
+        else:
+            self.ResetCamera()
         if render:
             self.parent.render()
         self.Modified()

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -27,3 +27,8 @@ def test_plotter_camera_position():
 def test_renderer_set_viewup():
     plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
     plotter.renderer.set_viewup([1, 1, 1])
+
+
+def test_reset_camera():
+    plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
+    plotter.reset_camera(bounds=(-1, 1, -1, 1, -1, 1))


### PR DESCRIPTION
### Overview

This PR updates `reset_camera` to set up the camera based on a specified bounding box (`bounds`).
