### PR TITLE
Use vtkTransformFilter in DataSet.transform()

### DIFF
--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -266,7 +266,8 @@ if VTK9:
                                               vtkDataSetTriangleFilter,
                                               vtkGradientFilter,
                                               vtkShrinkFilter,
-                                              vtkBooleanOperationPolyDataFilter)
+                                              vtkBooleanOperationPolyDataFilter,
+                                              vtkTransformFilter)
     from vtkmodules.vtkFiltersModeling import (vtkOutlineFilter,
                                                vtkRibbonFilter,
                                                vtkLinearExtrusionFilter,

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -457,7 +457,7 @@ class DataSet(DataSetFilters, DataObject):
         if self.points.dtype != np.double:
             self.points = self.points.astype(np.double)
 
-    def rotate_x(self, angle: float):
+    def rotate_x(self, angle: float, transform_all_input_vectors=False):
         """Rotate mesh about the x-axis.
 
         Parameters
@@ -466,9 +466,10 @@ class DataSet(DataSetFilters, DataObject):
             Angle in degrees to rotate about the x-axis.
 
         """
-        axis_rotation(self.points, angle, inplace=True, axis='x')
+        t = transformations.axis_angle_rotation((1, 0, 0), angle, deg=True)
+        self.transform(t, transform_all_input_vectors=transform_all_input_vectors, inplace=True)
 
-    def rotate_y(self, angle: float):
+    def rotate_y(self, angle: float, transform_all_input_vectors=False):
         """Rotate mesh about the y-axis.
 
         Parameters
@@ -477,9 +478,10 @@ class DataSet(DataSetFilters, DataObject):
             Angle in degrees to rotate about the y-axis.
 
         """
-        axis_rotation(self.points, angle, inplace=True, axis='y')
+        t = transformations.axis_angle_rotation((0, 1, 0), angle, deg=True)
+        self.transform(t, transform_all_input_vectors=transform_all_input_vectors, inplace=True)
 
-    def rotate_z(self, angle: float):
+    def rotate_z(self, angle: float, transform_all_input_vectors=False):
         """Rotate mesh about the z-axis.
 
         Parameters
@@ -488,7 +490,8 @@ class DataSet(DataSetFilters, DataObject):
             Angle in degrees to rotate about the z-axis.
 
         """
-        axis_rotation(self.points, angle, inplace=True, axis='z')
+        t = transformations.axis_angle_rotation((0, 0, 1), angle, deg=True)
+        self.transform(t, transform_all_input_vectors=transform_all_input_vectors, inplace=True)
 
     def translate(self, xyz: Union[list, tuple, np.ndarray]):
         """Translate the mesh.

--- a/pyvista/core/errors.py
+++ b/pyvista/core/errors.py
@@ -36,3 +36,11 @@ class DeprecationError(RuntimeError):
     def __init__(self, message='This feature has been depreciated'):
         """Empty init."""
         RuntimeError.__init__(self, message)
+
+
+class VTKVersionError(RuntimeError):
+    """Requested feature is not supported by the installed VTK version."""
+
+    def __init__(self, message='The requested feature is not supported by the installed VTK version.'):
+        """Empty init."""
+        RuntimeError.__init__(self, message)

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2640,7 +2640,8 @@ class DataSetFilters:
         if isinstance(dataset, _vtk.vtkPolyData):
             return output.extract_surface()
 
-    def transform(dataset, trans: Union[_vtk.vtkMatrix4x4, _vtk.vtkTransform, np.ndarray],
+    def transform(dataset: _vtk.vtkDataSet,
+                  trans: Union[_vtk.vtkMatrix4x4, _vtk.vtkTransform, np.ndarray],
                   transform_all_input_vectors=False, inplace=True):
         """Transform this mesh with a 4x4 transform.
 
@@ -2696,8 +2697,9 @@ class DataSetFilters:
 
         if inplace:
             if not isinstance(res, type(dataset)):
-                raise ValueError('Unable to perform in-place transformation. Input was `%s` but output is `%s`.' %
-                                 (dataset.GetClassName(), res.GetClassName()))
+                raise ValueError('Unable to perform in-place transformation. '
+                                 f'Input was `{dataset.GetClassName()}` '
+                                 f'but output is `{res.GetClassName()}`.')
             dataset.overwrite(res)
         else:
             return res

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2719,12 +2719,8 @@ class DataSetFilters:
 
         """
         t = transformations.reflection(normal, point=point)
-        if inplace:
-            dataset.transform(t, transform_all_input_vectors=transform_all_input_vectors)
-        else:
-            mirror = dataset.copy()
-            mirror.transform(t, transform_all_input_vectors=transform_all_input_vectors)
-            return mirror
+        return dataset.transform(t, transform_all_input_vectors=transform_all_input_vectors,
+                                 inplace=inplace)
 
 
 @abstract_class

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2640,7 +2640,7 @@ class DataSetFilters:
         if isinstance(dataset, _vtk.vtkPolyData):
             return output.extract_surface()
 
-    def transform(dataset, trans: Union[vtk.vtkMatrix4x4, vtk.vtkTransform, np.ndarray],
+    def transform(dataset, trans: Union[_vtk.vtkMatrix4x4, _vtk.vtkTransform, np.ndarray],
                   transform_all_input_vectors=False, inplace=True):
         """Transform this mesh with a 4x4 transform.
 
@@ -2653,11 +2653,11 @@ class DataSetFilters:
             When ``True``, all input vectors are transformed. Otherwise, only the
             points, normals and active vectors are transformed.
         """
-        if isinstance(trans, vtk.vtkMatrix4x4):
+        if isinstance(trans, _vtk.vtkMatrix4x4):
             m = trans
-            t = vtk.vtkTransform()
+            t = _vtk.vtkTransform()
             t.SetMatrix(m)
-        elif isinstance(trans, vtk.vtkTransform):
+        elif isinstance(trans, _vtk.vtkTransform):
             t = trans
             m = trans.GetMatrix()
         elif isinstance(trans, np.ndarray):
@@ -2666,7 +2666,7 @@ class DataSetFilters:
             elif trans.shape[0] != 4 or trans.shape[1] != 4:
                 raise ValueError('Transformation array must be 4x4')
             m = pyvista.vtkmatrix_from_array(trans)
-            t = vtk.vtkTransform()
+            t = _vtk.vtkTransform()
             t.SetMatrix(m)
         else:
             raise TypeError('Input transform must be either:\n'
@@ -2683,7 +2683,7 @@ class DataSetFilters:
         active_scalars_name = dataset.active_scalars_name
         dataset.set_active_scalars(None)
 
-        f = vtk.vtkTransformFilter()
+        f = _vtk.vtkTransformFilter()
         f.SetInputDataObject(dataset)
         f.SetTransform(t)
         f.SetTransformAllInputVectors(transform_all_input_vectors)

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2653,6 +2653,20 @@ class DataSetFilters:
         transform_all_input_vectors: bool, optional
             When ``True``, all input vectors are transformed. Otherwise, only the
             points, normals and active vectors are transformed.
+
+        Examples
+        --------
+        Translate a mesh by (50, 100, 200)
+
+        >>> from pyvista import examples
+        >>> mesh = examples.load_airplane()
+
+        Here is a 4x4 NumPy array is used, but vtk.vtkMatrix4x4 and
+        vtk.vtkTransform are also accepted.
+
+        >>> transform_matrix = np.array([[1, 0, 0, 50], [0, 1, 0, 100], [0, 0, 1, 200], [0, 0, 0, 1]])
+        >>> mesh.transform(transform_matrix, inplace=True)
+        >>> mesh.plot(show_edges=True)  # doctest:+SKIP
         """
         if isinstance(trans, _vtk.vtkMatrix4x4):
             m = trans

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -38,6 +38,7 @@ from pyvista.utilities import transformations
 
 from typing import Union
 
+
 def _update_alg(alg, progress_bar=False, message=''):
     """Update an algorithm with or without a progress bar."""
     if progress_bar:
@@ -2719,7 +2720,7 @@ class DataSetFilters:
             When ``True``, modifies the dataset and returns nothing.
 
         transform_all_input_vectors: bool, optional
-            When ``True``, all input vectors are reflected. Otherwise, only the
+            When ``True``, all input vectors are transformed. Otherwise, only the
             points, normals and active vectors are transformed.
 
         Examples

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2638,7 +2638,8 @@ class DataSetFilters:
         if isinstance(dataset, _vtk.vtkPolyData):
             return output.extract_surface()
 
-    def reflect(dataset, normal, point=None, inplace=False):
+    def reflect(dataset, normal, point=None, inplace=False,
+                transform_all_input_vectors=False):
         """Reflect a dataset across a plane.
 
         Parameters
@@ -2653,6 +2654,10 @@ class DataSetFilters:
         inplace : bool, optional
             When ``True``, modifies the dataset and returns nothing.
 
+        transform_all_input_vectors: bool, optional
+            When ``True``, all input vectors are reflected. Otherwise, only the
+            points and the normals are reflected.
+
         Examples
         --------
         >>> from pyvista import examples
@@ -2663,10 +2668,10 @@ class DataSetFilters:
         """
         t = transformations.reflection(normal, point=point)
         if inplace:
-            dataset.transform(t)
+            dataset.transform(t, transform_all_input_vectors=transform_all_input_vectors)
         else:
             mirror = dataset.copy()
-            mirror.transform(t)
+            mirror.transform(t, transform_all_input_vectors=transform_all_input_vectors)
             return mirror
 
 

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2640,7 +2640,7 @@ class DataSetFilters:
             return output.extract_surface()
 
     def transform(dataset, trans: Union[vtk.vtkMatrix4x4, vtk.vtkTransform, np.ndarray],
-                  transform_all_input_vectors=True, inplace=True):
+                  transform_all_input_vectors=False, inplace=True):
         """Compute a transformation in place using a 4x4 transform.
 
         Parameters
@@ -2648,6 +2648,9 @@ class DataSetFilters:
         trans : vtk.vtkMatrix4x4, vtk.vtkTransform, or np.ndarray
             Accepts a vtk transformation object or a 4x4 transformation matrix.
 
+        transform_all_input_vectors: bool, optional
+            When ``True``, all input vectors are reflected. Otherwise, only the
+            points and the normals are reflected.
         """
         if isinstance(trans, vtk.vtkMatrix4x4):
             m = trans

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2641,7 +2641,7 @@ class DataSetFilters:
 
     def transform(dataset, trans: Union[vtk.vtkMatrix4x4, vtk.vtkTransform, np.ndarray],
                   transform_all_input_vectors=False, inplace=True):
-        """Compute a transformation in place using a 4x4 transform.
+        """Transform this mesh with a 4x4 transform.
 
         Parameters
         ----------
@@ -2649,8 +2649,8 @@ class DataSetFilters:
             Accepts a vtk transformation object or a 4x4 transformation matrix.
 
         transform_all_input_vectors: bool, optional
-            When ``True``, all input vectors are reflected. Otherwise, only the
-            points and the normals are reflected.
+            When ``True``, all input vectors are transformed. Otherwise, only the
+            points, normals and active vectors are transformed.
         """
         if isinstance(trans, vtk.vtkMatrix4x4):
             m = trans
@@ -2720,7 +2720,7 @@ class DataSetFilters:
 
         transform_all_input_vectors: bool, optional
             When ``True``, all input vectors are reflected. Otherwise, only the
-            points and the normals are reflected.
+            points, normals and active vectors are transformed.
 
         Examples
         --------

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1089,14 +1089,31 @@ def test_reflect_struct_grid(struct_grid):
     assert reflected.n_points == struct_grid.n_points
 
 
-def test_reflect_mesh(airplane):
+def test_reflect_mesh_points(airplane):
+    airplane.compute_normals(inplace=True)
+    airplane.cell_arrays['C'] = np.arange(airplane.n_cells)[:, np.newaxis] * \
+                                np.array([1, 2, 3]).reshape((1, 3))
+    airplane.point_arrays['P'] = np.arange(airplane.n_points)[:, np.newaxis] * \
+                                np.array([1, 2, 3]).reshape((1, 3))
     reflected = airplane.reflect((1, 0, 0))
+
     assert isinstance(reflected, type(airplane))
     assert reflected.n_cells == airplane.n_cells
     assert reflected.n_points == airplane.n_points
-
     assert np.allclose(airplane.points[:, 0], -reflected.points[:, 0])
     assert np.allclose(airplane.points[:, 1:], reflected.points[:, 1:])
+
+    # normals are reflected
+    assert np.allclose(airplane.cell_arrays['Normals'][:, 0], -reflected.cell_arrays['Normals'][:, 0])
+    assert np.allclose(airplane.cell_arrays['Normals'][:, 1:], reflected.cell_arrays['Normals'][:, 1:])
+    assert np.allclose(airplane.point_arrays['Normals'][:, 0], -reflected.point_arrays['Normals'][:, 0])
+    assert np.allclose(airplane.point_arrays['Normals'][:, 1:], reflected.point_arrays['Normals'][:, 1:])
+
+    # check other vector fields are reflected
+    assert np.allclose(airplane.cell_arrays['C'][:, 0], -reflected.cell_arrays['C'][:, 0])
+    assert np.allclose(airplane.cell_arrays['C'][:, 1:], reflected.cell_arrays['C'][:, 1:])
+    assert np.allclose(airplane.point_arrays['P'][:, 0], -reflected.point_arrays['P'][:, 0])
+    assert np.allclose(airplane.point_arrays['P'][:, 1:], reflected.point_arrays['P'][:, 1:])
 
 
 def test_reflect_mesh_about_point(airplane):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1091,9 +1091,9 @@ def test_transform_mesh_and_vectors(dataset):
 
     # add vector data to cell and point arrays
     dataset.cell_arrays['C'] = np.arange(dataset.n_cells)[:, np.newaxis] * \
-                                np.array([1, 2, 3]).reshape((1, 3))
+                                np.array([1, 2, 3], dtype=float).reshape((1, 3))
     dataset.point_arrays['P'] = np.arange(dataset.n_points)[:, np.newaxis] * \
-                                np.array([1, 2, 3]).reshape((1, 3))
+                                np.array([1, 2, 3], dtype=float).reshape((1, 3))
 
     transformed = dataset.transform(tf, transform_all_input_vectors=True, inplace=False)
 
@@ -1138,9 +1138,9 @@ def test_reflect_mesh_with_vectors(dataset):
 
     # add vector data to cell and point arrays
     dataset.cell_arrays['C'] = np.arange(dataset.n_cells)[:, np.newaxis] * \
-                                np.array([1, 2, 3]).reshape((1, 3))
+                                np.array([1, 2, 3], dtype=float).reshape((1, 3))
     dataset.point_arrays['P'] = np.arange(dataset.n_points)[:, np.newaxis] * \
-                                np.array([1, 2, 3]).reshape((1, 3))
+                                np.array([1, 2, 3], dtype=float).reshape((1, 3))
 
     reflected = dataset.reflect((1, 0, 0), transform_all_input_vectors=True, inplace=False)
 


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

In trying to actually use some of the features added in #1127, I realized that the transformations in PyVista are for geometry only, and don't handle transformations of any vector/tensor arrays. This is true of `DataSet.rotate_x()`, `DataSet.rotate_y()`, `DataSet.rotate_z()`, and `DataSet.transform()`, all of which just transform points.

While we could transform vector fields manually, [`vtkTransformFilter`](https://vtk.org/doc/nightly/html/classvtkTransformFilter.html) also does. Is there a good reason not to use it?

This PR shows that might look like for `DataSet.transform()`. Some logic could be cleaned up a bit by creating a helper class to manage the various 4x4 `ndarray`/`vtkMatrix`/`vtkTransform` types that might be passed in. There's also work to do in implementing this across the other transform methods, but I wanted to get some of your thoughts before proceeding (@akaszynski ?).

