### PR TITLE
Add only_one in add_scalar_bar

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2390,7 +2390,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                        outline=False, nan_annotation=False,
                        below_label=None, above_label=None,
                        background_color=None, n_colors=None, fill=False,
-                       render=True):
+                       render=True, only_one=True):
         """Create scalar bar using the ranges as set by the last input mesh.
 
         Parameters
@@ -2475,6 +2475,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
         render : bool, optional
             Force a render when True.  Default ``True``.
 
+        only_one : bool, optional
+            Use only one scalar bar when scalars already been plotted.
+
         Notes
         -----
         Setting title_font_size, or label_font_size disables automatic font
@@ -2520,7 +2523,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                                      'Add a mesh with scalars first.')
             mapper = self.mapper
 
-        if title:
+        if only_one and title:
             # Check that this data hasn't already been plotted
             if title in list(self._scalar_bar_ranges.keys()):
                 clim = list(self._scalar_bar_ranges[title])


### PR DESCRIPTION
### Overview

Scalar bars with same name are removed from the second renderer upwards. There are situations where the user may not want this to happen. This PR add the `only_one` parameter in `add_scalar_bar` to let the user choose.

### Details

```python
 1   import pyvista as pv
 2
 3   coarse = pv.UnstructuredGrid('coarse.vtu')
 4   fine = pv.UnstructuredGrid('fine.vtu')
 5
 6   plotter = pv.Plotter(shape=(1, 2))
 7   plotter.subplot(0, 0)
 8   plotter.add_axes()
 9   plotter.add_mesh(coarse, show_edges=True)
10   plotter.subplot(0, 1)
11   plotter.add_axes()
12   plotter.add_mesh(fine, show_edges=True)
13   plotter.show()
```

![image](https://user-images.githubusercontent.com/1608652/107771941-476f8400-6d1a-11eb-86d7-c70669c18a46.png)

```python
12   plotter.add_mesh(fine, show_edges=True, scalar_bar_args={'only_one': False})
13   plotter.show()
```

![image](https://user-images.githubusercontent.com/1608652/107772089-7c7bd680-6d1a-11eb-8a64-61a6ee9aafe1.png)
