### PR TITLE
Update the active scalar bar when cmap is changed

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2536,6 +2536,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 mapper.scalar_range = clim[0], clim[1]
                 self._scalar_bar_mappers[title].append(mapper)
                 self._scalar_bar_ranges[title] = clim
+                self.scalar_bar.SetLookupTable(mapper.lookup_table)
                 # Color bar already present and ready to be used so returning
                 return
 


### PR DESCRIPTION
### Overview

This PR force the updating the active scalar bar when `cmap` in `add_mesh` is changed.

### Details

#### Before:

![antes](https://user-images.githubusercontent.com/1608652/107833535-55e98a00-6d72-11eb-996f-f8f9a1a71c28.gif)

#### Now:

![depois](https://user-images.githubusercontent.com/1608652/107833538-584be400-6d72-11eb-87dd-cdba39acd39c.gif)

