### PR TITLE
Add the Tableau Palette colors

### DIFF
--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -152,6 +152,16 @@ white
 whitesmoke
 yellow
 yellowgreen
+tab:blue
+tab:orange
+tab:green
+tab:red
+tab:purple
+tab:brown
+tab:pink
+tab:gray
+tab:olive
+tab:cyan
 
 """
 
@@ -305,7 +315,17 @@ hexcolors = {
     'white':                '#FFFFFF',
     'whitesmoke':           '#F5F5F5',
     'yellow':               '#FFFF00',
-    'yellowgreen':          '#9ACD32'}
+    'yellowgreen':          '#9ACD32',
+    'tab:blue':             '#1f77b4',
+    'tab:orange':           '#ff7f0e',
+    'tab:green':            '#2ca02c',
+    'tab:red':              '#d62728',
+    'tab:purple':           '#9467bd',
+    'tab:brown':            '#8c564b',
+    'tab:pink':             '#e377c2',
+    'tab:gray':             '#7f7f7f',
+    'tab:olive':            '#bcbd22',
+    'tab:cyan':             '#17becf'}
 
 color_char_to_word = {
         'b': 'blue',


### PR DESCRIPTION
### Overview

This PR adds the **Tableau Palette** colors avaliable in the [matplotlib](https://matplotlib.org/stable/gallery/color/named_colors.html) package.

![image](https://user-images.githubusercontent.com/1608652/107862910-f1d8cb80-6e2e-11eb-9774-f0396364384a.png)

