### PR TITLE
Add where_is in BasePlotter

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4001,9 +4001,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             renderer.remove_all_lights()
 
     def where_is(self, name):
-        """Where is the actor?
-
-        This method returns the subplot coordinates that have a given actor.
+        """Returns the subplot coordinates that have a given actor.
 
         Parameters
         ----------

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4000,6 +4000,44 @@ class BasePlotter(PickingHelper, WidgetHelper):
         for renderer in renderers:
             renderer.remove_all_lights()
 
+    def where_is(self, name):
+        """Where is the actor?
+
+        This method returns the subplot coordinates that have a given actor.
+
+        Parameters
+        ----------
+        name : str
+            Actor's name.
+
+        Returns
+        -------
+        places : list(tuple(int))
+            A list with the subplot coordinates of the actor.
+
+        Examples
+        --------
+        >>> import pyvista as pv
+        >>> plotter = pv.Plotter(shape=(2, 2))
+        >>> plotter.subplot(0, 0)
+        >>> plotter.add_mesh(pv.Box(), name='box')
+        >>> plotter.subplot(0, 1)
+        >>> plotter.add_mesh(pv.Sphere(), name='sphere')
+        >>> plotter.subplot(1, 0)
+        >>> plotter.add_mesh(pv.Box(), name='box')
+        >>> plotter.subplot(1, 1)
+        >>> plotter.add_mesh(pv.Cone(), name='cone')
+        >>> plotter.where_is('box')
+        [(0, 0), (1, 0)]
+
+        """
+        places = []
+        for index in range(len(self.renderers)):
+            if name in self.renderers[index]._actors:
+                places.append(tuple(self.index_to_loc(index)))
+        return places
+
+
 class Plotter(BasePlotter):
     """Plotting object to display vtk meshes or numpy arrays.
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4001,7 +4001,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             renderer.remove_all_lights()
 
     def where_is(self, name):
-        """Return the subplot coordinates that have a given actor.
+        """Return the subplot coordinates of a given actor.
 
         Parameters
         ----------

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4001,7 +4001,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             renderer.remove_all_lights()
 
     def where_is(self, name):
-        """Returns the subplot coordinates that have a given actor.
+        """Return the subplot coordinates that have a given actor.
 
         Parameters
         ----------

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4020,14 +4020,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> import pyvista as pv
         >>> plotter = pv.Plotter(shape=(2, 2))
         >>> plotter.subplot(0, 0)
-        >>> plotter.add_mesh(pv.Box(), name='box')
+        >>> plotter.add_mesh(pv.Box(), name='box')  # doctest:+SKIP
         >>> plotter.subplot(0, 1)
-        >>> plotter.add_mesh(pv.Sphere(), name='sphere')
+        >>> plotter.add_mesh(pv.Sphere(), name='sphere')  # doctest:+SKIP
         >>> plotter.subplot(1, 0)
-        >>> plotter.add_mesh(pv.Box(), name='box')
+        >>> plotter.add_mesh(pv.Box(), name='box')  # doctest:+SKIP
         >>> plotter.subplot(1, 1)
-        >>> plotter.add_mesh(pv.Cone(), name='cone')
-        >>> plotter.where_is('box')
+        >>> plotter.add_mesh(pv.Cone(), name='cone')  # doctest:+SKIP
+        >>> plotter.where_is('box')  # doctest:+SKIP
         [(0, 0), (1, 0)]
 
         """

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1516,3 +1516,19 @@ def test_interactive_update():
     p = pyvista.Plotter()
     with pytest.warns(UserWarning):
         p.show(auto_close=True, interactive_update=True)
+
+
+def test_where_is():
+    plotter = pyvista.Plotter(shape=(2, 2))
+    plotter.subplot(0, 0)
+    plotter.add_mesh(pyvista.Box(), name='box')
+    plotter.subplot(0, 1)
+    plotter.add_mesh(pyvista.Sphere(), name='sphere')
+    plotter.subplot(1, 0)
+    plotter.add_mesh(pyvista.Box(), name='box')
+    plotter.subplot(1, 1)
+    plotter.add_mesh(pyvista.Cone(), name='cone')
+    places = plotter.where_is('box')
+    assert isinstance(places, list)
+    for loc in places:
+        assert isinstance(loc, tuple)


### PR DESCRIPTION
### Overview

This PR introduces the `where_is` method in the `BasePlotter` class. This method returns the subplot coordinates that have a given actor. This is useful, for example, when the user needs to update a mesh in subplots.

### Details

```python
>>> import pyvista as pv
>>> plotter = pv.Plotter(shape=(2, 2))
>>> plotter.subplot(0, 0)
>>> plotter.add_mesh(pv.Box(), name='box')
>>> plotter.subplot(0, 1)
>>> plotter.add_mesh(pv.Sphere(), name='sphere')
>>> plotter.subplot(1, 0)
>>> plotter.add_mesh(pv.Box(), name='box')
>>> plotter.subplot(1, 1)
>>> plotter.add_mesh(pv.Cone(), name='cone')
>>> plotter.where_is('box')
[(0, 0), (1, 0)]
```


