### PR TITLE
Fix log scale in scalar bar

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1409,6 +1409,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
         pickable : bool
             Set whether this mesh is pickable
 
+        log_scale : bool, optional
+            Use log scale when mapping data to colors.
+
         render : bool, optional
             Force a render when True.  Default ``True``.
 
@@ -1727,10 +1730,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
                     self.mapper.SetColorModeToMapScalars()
                 return
 
+            if log_scale:
+                scalars[scalars < 1] = 1
+                scalars = np.log10(scalars)
+
             prepare_mapper(scalars)
             table = self.mapper.GetLookupTable()
-            if log_scale:
-                table.SetScaleToLog10()
+            # if log_scale:
+            #     table.SetScaleToLog10()
 
             if _using_labels:
                 table.SetAnnotations(convert_array(values), convert_string_array(cats))

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1,5 +1,6 @@
 """Pyvista plotting module."""
 
+import sys
 import pathlib
 import collections.abc
 from functools import partial
@@ -1410,8 +1411,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Set whether this mesh is pickable
 
         log_scale : bool, optional
-            Use log scale when mapping data to colors. Values < 1 are changed
-            to 1. Default: ``True``.
+            Use log scale when mapping data to colors. Scalars less than zero
+            are mapped to the smallest representable positive float. Default:
+            ``True``.
 
         render : bool, optional
             Force a render when True.  Default ``True``.
@@ -1731,14 +1733,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
                     self.mapper.SetColorModeToMapScalars()
                 return
 
-            if log_scale:
-                scalars[scalars < 1] = 1
-                scalars = np.log10(scalars)
-
             prepare_mapper(scalars)
             table = self.mapper.GetLookupTable()
-            # if log_scale:
-            #     table.SetScaleToLog10()
 
             if _using_labels:
                 table.SetAnnotations(convert_array(values), convert_string_array(cats))
@@ -1752,6 +1748,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 clim = [np.nanmin(scalars), np.nanmax(scalars)]
             elif isinstance(clim, float) or isinstance(clim, int):
                 clim = [-clim, clim]
+
+            if log_scale:
+                if clim[0] <= 0:
+                    clim = [sys.float_info.min, clim[1]]
+                table.SetScaleToLog10()
 
             if np.any(clim) and not rgb:
                 self.mapper.scalar_range = clim[0], clim[1]

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1410,7 +1410,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Set whether this mesh is pickable
 
         log_scale : bool, optional
-            Use log scale when mapping data to colors.
+            Use log scale when mapping data to colors. Values < 1 are changed
+            to 1. Default: ``True``.
 
         render : bool, optional
             Force a render when True.  Default ``True``.

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1532,3 +1532,11 @@ def test_where_is():
     assert isinstance(places, list)
     for loc in places:
         assert isinstance(loc, tuple)
+
+
+@skip_no_plotting
+def test_log_scale():
+    mesh = examples.load_uniform()
+    plotter = pyvista.Plotter()
+    plotter.add_mesh(mesh, log_scale=True)
+    plotter.show()


### PR DESCRIPTION
### Overview

This PR solves problem with scalar bar when `log_scale=True`. This problem origins from VTK, when the scalars have values < 1.

### Details

```python
plotter.add_mesh(grid, show_edges=True, scalars='BLOCK_I')
```
![image](https://user-images.githubusercontent.com/1608652/108070676-8ca9f380-7043-11eb-9f81-1ddbf45570de.png)

```python
plotter.add_mesh(grid, show_edges=True, scalars='BLOCK_I', log_scale=True)
```
![image](https://user-images.githubusercontent.com/1608652/108070503-5bc9be80-7043-11eb-8960-cb8262293c12.png)

```python
plotter.add_mesh(grid, show_edges=True, scalars='BLOCK_I', log_scale=True)
```
![image](https://user-images.githubusercontent.com/1608652/108070512-5ec4af00-7043-11eb-8236-e8a0d420953b.png)


