### PR TITLE
Fix docstring in add_point_labels

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3226,7 +3226,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
             If an actor of this name already exists in the rendering window, it
             will be replaced by the new actor.
 
-
         shape_color : string or 3 item list, optional. Color of points (if visible).
             Either a string, rgb list, or hex color string.  For example:
 


### PR DESCRIPTION
### Overview

This PR fix a simple problem with `docstring` in `add_point_labels`:

![image](https://user-images.githubusercontent.com/1608652/108280608-37620500-715d-11eb-85ea-ac7fd97c5473.png)

