### PR TITLE
Fix doctest failure in BasePlotter.where_is

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4029,14 +4029,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> import pyvista as pv
         >>> plotter = pv.Plotter(shape=(2, 2))
         >>> plotter.subplot(0, 0)
-        >>> plotter.add_mesh(pv.Box(), name='box')  # doctest:+SKIP
+        >>> _ = plotter.add_mesh(pv.Box(), name='box')
         >>> plotter.subplot(0, 1)
-        >>> plotter.add_mesh(pv.Sphere(), name='sphere')  # doctest:+SKIP
+        >>> _ = plotter.add_mesh(pv.Sphere(), name='sphere')
         >>> plotter.subplot(1, 0)
-        >>> plotter.add_mesh(pv.Box(), name='box')  # doctest:+SKIP
+        >>> _ = plotter.add_mesh(pv.Box(), name='box')
         >>> plotter.subplot(1, 1)
-        >>> plotter.add_mesh(pv.Cone(), name='cone')  # doctest:+SKIP
-        >>> plotter.where_is('box')  # doctest:+SKIP
+        >>> _ = plotter.add_mesh(pv.Cone(), name='cone')
+        >>> plotter.where_is('box')
         [(0, 0), (1, 0)]
 
         """


### PR DESCRIPTION
Doctests for the new `BasePlotter.where_is()` method were failing, as per https://github.com/pyvista/pyvista/issues/1181.

The issue seems to be that the doctest SKIPs for the `add_mesh()` calls are skipped entirely (i.e. not even executed, rather than merely ignoring their output). Removing the skips and discarding their return value seems to fix the doctest.

Resolves https://github.com/pyvista/pyvista/issues/1181
