### PR TITLE
Fix labels in add_point_labels

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3279,7 +3279,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         elif is_pyvista_dataset(points):
             vtkpoints = pyvista.PolyData(points.points)
             if isinstance(labels, str):
-                labels = points.point_arrays[labels].astype(str)
+                labels = points.point_arrays[labels]
         else:
             raise TypeError(f'Points type not usable: {type(points)}')
 


### PR DESCRIPTION
### Overview

This PR fix a visual problem when `labels` in `add_point_labels` is a vector array.

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/1608652/109007936-76c3b080-768b-11eb-8318-cb944211514f.png) | ![image](https://user-images.githubusercontent.com/1608652/109007953-7cb99180-768b-11eb-8042-82a05897dc4b.png) |

### Details

I only removed `.astype(str)` on line 3282:

```python
3277        if isinstance(points, np.ndarray):
3278            vtkpoints = pyvista.PolyData(points) # Cast to poly data
3279        elif is_pyvista_dataset(points):
3280            vtkpoints = pyvista.PolyData(points.points)
3281            if isinstance(labels, str):
3282                labels = points.point_arrays[labels].astype(str)
```

The label items are already converted to string on line 3295:

```python
3292        vtklabels = _vtk.vtkStringArray()
3293        vtklabels.SetName('labels')
3294        for item in labels:
3295            vtklabels.InsertNextValue(str(item))
3296        vtkpoints.GetPointData().AddArray(vtklabels)
```
