### PR TITLE
Fix core/index

### DIFF
--- a/docs/core/dataset.rst
+++ b/docs/core/dataset.rst
@@ -20,7 +20,7 @@ set of common functionality which we wrap into the base class
 
 
 The DataSet Model
-----------------
+-----------------
 
 The :class:`pyvista.DataSet` class holds attributes that are *common* to all
 spatially referenced datasets in PyVista.

--- a/docs/core/index.rst
+++ b/docs/core/index.rst
@@ -34,7 +34,7 @@ PyVista has the following mesh types:
    :maxdepth: 2
 
    objects
-   common
+   dataset
    points
    point-grids
    grids


### PR DESCRIPTION
### Fix Core/index

During the refactor of common --> dataset, core/index.rst wasn't changed.  There's an old reference to `common` and no reference to `dataset`.  This PR corrects that.