### PR TITLE
🩹 plot_over_line should fail if scalar name does not exist

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -608,7 +608,7 @@ class DataSet(DataSetFilters, DataObject):
 
     def get_array(self, name: str, preference='cell', info=False) -> Union[Tuple, np.ndarray]:
         """Search both point, cell and field data for an array."""
-        return get_array(self, name, preference=preference, info=info)
+        return get_array(self, name, preference=preference, info=info, err=True)
 
     def __getitem__(self, index: Union[Iterable, str]) -> Union[Tuple, np.ndarray]:
         """Search both point, cell, and field data for an array."""

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -754,6 +754,10 @@ def test_plot_over_line():
     mesh['foo'] = np.random.rand(mesh.n_cells, 3)
     mesh.plot_over_line(a, b, resolution=None, scalars='foo',
                         title='My Stuff', ylabel='3 Values', show=False)
+    # Should fail if scalar name does not exist
+    with pytest.raises(KeyError):
+        mesh.plot_over_line(a, b, resolution=None, scalars='invalid_array_name',
+                            title='My Stuff', ylabel='3 Values', show=False)
 
 
 def test_slice_along_line():


### PR DESCRIPTION
### Overview
When I select a invalid array name in `plot_over_line` , pyvista occures the following error.

```
line 2144, in plot_over_line
    if values.ndim > 1:
AttributeError: 'NoneType' object has no attribute 'ndim'
```

It is better to raise KeyError in `get_array`.

````
KeyError: 'Data array (invalid_array_name) not present in this dataset.'
````

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None

