### PR TITLE
✨ Add plot_over_circular_arc

### DIFF
--- a/examples/02-plot/plot-over-circular-arc.py
+++ b/examples/02-plot/plot-over-circular-arc.py
@@ -40,4 +40,4 @@ p.show()
 
 ###############################################################################
 # Run the filter and produce a line plot.
-mesh.plot_over_circular_arc2(center, 100, normal, polar, angle, 'height')
+mesh.plot_over_circular_arc_normal(center, 100, normal, polar, angle, 'height')

--- a/examples/02-plot/plot-over-circular-arc.py
+++ b/examples/02-plot/plot-over-circular-arc.py
@@ -1,0 +1,39 @@
+"""
+Plot Over Circular Arc
+~~~~~~~~~~~~~~~~~~~~~~
+
+Plot the height of a dataset over a circular arc through that dataset
+"""
+
+# sphinx_gallery_thumbnail_number = 2
+import pyvista as pv
+from pyvista import examples
+
+###############################################################################
+# Volumetric Mesh
+# +++++++++++++++
+#
+# First a 3D mesh example to demonstrate
+mesh = examples.load_uniform()
+mesh['height'] = mesh.points[:, 2]
+
+# Make two points and center to construct the circular arc between
+a = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[5]]
+b = [mesh.bounds[1], mesh.bounds[2], mesh.bounds[4]]
+center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
+
+# Preview how this circular arc intersects this mesh
+arc = pv.CircularArc(a, b, center)
+
+p = pv.Plotter()
+p.add_mesh(mesh, style="wireframe", color="w")
+p.add_mesh(arc, color="b")
+p.add_point_labels(
+    [a, b], ["A", "B"], font_size=48, point_color="red", text_color="red"
+)
+p.show()
+
+###############################################################################
+# Run the filter and produce a line plot
+mesh.plot_over_circular_arc(a, b, center, resolution=100, scalars='height')
+

--- a/examples/02-plot/plot-over-circular-arc.py
+++ b/examples/02-plot/plot-over-circular-arc.py
@@ -1,8 +1,10 @@
 """
-Plot Over Circular Arc
-~~~~~~~~~~~~~~~~~~~~~~
+Plot Scalars Over a Circular Arc
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Plot the height of a dataset over a circular arc through that dataset
+Interpolate the scalars of a dataset over a circular arc through that
+dataset.
+
 """
 
 # sphinx_gallery_thumbnail_number = 2
@@ -13,11 +15,12 @@ from pyvista import examples
 # Volumetric Mesh
 # +++++++++++++++
 #
-# First a 3D mesh example to demonstrate
+# Add the height scalars to a uniform 3D mesh
 mesh = examples.load_uniform()
 mesh['height'] = mesh.points[:, 2]
 
-# Make two points and center to construct the circular arc between
+# Make two points at the bounds of the mesh and one at the center to
+# construct a circular arc.
 a = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[5]]
 b = [mesh.bounds[1], mesh.bounds[2], mesh.bounds[4]]
 center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
@@ -36,4 +39,3 @@ p.show()
 ###############################################################################
 # Run the filter and produce a line plot
 mesh.plot_over_circular_arc(a, b, center, resolution=100, scalars='height')
-

--- a/examples/02-plot/plot-over-circular-arc.py
+++ b/examples/02-plot/plot-over-circular-arc.py
@@ -42,4 +42,3 @@ p.show()
 ###############################################################################
 # Run the filter and produce a line plot
 mesh.plot_over_circular_arc2(center, 100, normal, polar, angle, 'height')
-p.show()

--- a/examples/02-plot/plot-over-circular-arc.py
+++ b/examples/02-plot/plot-over-circular-arc.py
@@ -21,16 +21,19 @@ mesh['height'] = mesh.points[:, 2]
 
 # Make two points at the bounds of the mesh and one at the center to
 # construct a circular arc.
-a = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[5]]
-b = [mesh.bounds[1], mesh.bounds[2], mesh.bounds[4]]
+normal = [0, 1, 0]
+polar = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[5]]
 center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
+angle = 90.0
 
 # Preview how this circular arc intersects this mesh
-arc = pv.CircularArc(a, b, center)
+arc = pv.CircularArc2(center, 100, normal, polar, angle)
 
 p = pv.Plotter()
 p.add_mesh(mesh, style="wireframe", color="w")
 p.add_mesh(arc, color="b")
+a = arc.points[0]
+b = arc.points[-1]
 p.add_point_labels(
     [a, b], ["A", "B"], font_size=48, point_color="red", text_color="red"
 )
@@ -38,4 +41,5 @@ p.show()
 
 ###############################################################################
 # Run the filter and produce a line plot
-mesh.plot_over_circular_arc(a, b, center, resolution=100, scalars='height')
+mesh.plot_over_circular_arc2(center, 100, normal, polar, angle, 'height')
+p.show()

--- a/examples/02-plot/plot-over-circular-arc.py
+++ b/examples/02-plot/plot-over-circular-arc.py
@@ -2,8 +2,7 @@
 Plot Scalars Over a Circular Arc
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Interpolate the scalars of a dataset over a circular arc through that
-dataset.
+Interpolate the scalars of a dataset over a circular arc.
 
 """
 
@@ -15,7 +14,7 @@ from pyvista import examples
 # Volumetric Mesh
 # +++++++++++++++
 #
-# Add the height scalars to a uniform 3D mesh
+# Add the height scalars to a uniform 3D mesh.
 mesh = examples.load_uniform()
 mesh['height'] = mesh.points[:, 2]
 
@@ -27,7 +26,7 @@ center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
 angle = 90.0
 
 # Preview how this circular arc intersects this mesh
-arc = pv.CircularArc2(center, 100, normal, polar, angle)
+arc = pv.CircularArcFromNormal(center, 100, normal, polar, angle)
 
 p = pv.Plotter()
 p.add_mesh(mesh, style="wireframe", color="w")
@@ -40,5 +39,5 @@ p.add_point_labels(
 p.show()
 
 ###############################################################################
-# Run the filter and produce a line plot
+# Run the filter and produce a line plot.
 mesh.plot_over_circular_arc2(center, 100, normal, polar, angle, 'height')

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2259,7 +2259,7 @@ class DataSetFilters:
         if resolution is None:
             resolution = int(dataset.n_cells)
         # Make a circular arc and sample the dataset
-        circular_arc = pyvista.CircularArc2(center, resolution=resolution, normal=normal, polar=polar)
+        circular_arc = pyvista.CircularArcFromNormal(center, resolution=resolution, normal=normal, polar=polar)
 
         sampled_circular_arc = circular_arc.sample(dataset, tolerance=tolerance)
         return sampled_circular_arc

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2210,12 +2210,12 @@ class DataSetFilters:
         sampled_circular_arc = circular_arc.sample(dataset, tolerance=tolerance)
         return sampled_circular_arc
 
-    def sample_over_circular_arc2(dataset, center, resolution=None, normal=None,
-                                  polar=None, angle=None, tolerance=None):
-        """Sample a dataset over a circular arc.
+    def sample_over_circular_arc_normal(dataset, center, resolution=None, normal=None,
+                                        polar=None, angle=None, tolerance=None):
+        """Sample a dataset over a circular arc defined by a normal and polar vector and plot it.
 
-        The number of segments composing the polyline is controlled by setting the
-        object resolution.
+        The number of segments composing the polyline is controlled by
+        setting the object resolution.
 
         Parameters
         ----------
@@ -2232,8 +2232,8 @@ class DataSetFilters:
             points in the positive Z direction.
 
         polar : np.ndarray or list, optional
-            (starting point of the arc).  By default it is the unit vector
-            in the positive x direction.
+            Starting point of the arc in polar coordinates.  By
+            default it is the unit vector in the positive x direction.
 
         angle : float, optional
             Arc length (in degrees), beginning at the polar vector.  The
@@ -2254,12 +2254,15 @@ class DataSetFilters:
         >>> normal = [0, 0, 1]
         >>> polar = [uniform.bounds[0], uniform.bounds[2], uniform.bounds[5]]
         >>> center = [uniform.bounds[0], uniform.bounds[2], uniform.bounds[4]]
-        >>> sampled_arc = uniform.sample_over_circular_arc2(center, normal=normal, polar=polar)
+        >>> sampled_arc = uniform.sample_over_circular_arc_normal(center, normal=normal, polar=polar)
         """
         if resolution is None:
             resolution = int(dataset.n_cells)
         # Make a circular arc and sample the dataset
-        circular_arc = pyvista.CircularArcFromNormal(center, resolution=resolution, normal=normal, polar=polar)
+        circular_arc = pyvista.CircularArcFromNormal(center,
+                                                     resolution=resolution,
+                                                     normal=normal,
+                                                     polar=polar)
 
         sampled_circular_arc = circular_arc.sample(dataset, tolerance=tolerance)
         return sampled_circular_arc
@@ -2268,11 +2271,11 @@ class DataSetFilters:
                                resolution=None, scalars=None,
                                title=None, ylabel=None, figsize=None,
                                figure=True, show=True, tolerance=None):
-        """Sample a dataset along a high resolution circular arc and plot.
+        """Sample a dataset along a circular arc and plot it.
 
         Plot the variables of interest in 2D where the X-axis is
         distance from Point A and the Y-axis is the variable of
-        interest. Note that this filter returns None.
+        interest. Note that this filter returns ``None``.
 
         Parameters
         ----------
@@ -2286,8 +2289,8 @@ class DataSetFilters:
             Location in ``[x, y, z]``.
 
         resolution : int, optional
-            number of pieces to divide circular arc into. Defaults to
-            number of cells in the input mesh. Must be a positive
+            Number of pieces to divide the circular arc into. Defaults
+            to number of cells in the input mesh. Must be a positive
             integer.
 
         scalars : str, optional
@@ -2295,19 +2298,19 @@ class DataSetFilters:
             probe. The active scalar is used by default.
 
         title : str, optional
-            The string title of the `matplotlib` figure
+            The string title of the ``matplotlib`` figure.
 
         ylabel : str, optional
-            The string label of the Y-axis. Defaults to variable name
+            The string label of the Y-axis. Defaults to the variable name.
 
         figsize : tuple(int), optional
-            the size of the new figure
+            The size of the new figure.
 
         figure : bool, optional
-            flag on whether or not to create a new figure
+            Flag on whether or not to create a new figure.
 
         show : bool, optional
-            Shows the matplotlib figure
+            Shows the ``matplotlib`` figure when ``True``.
 
         tolerance: float, optional
             Tolerance used to compute whether a point in the source is
@@ -2332,8 +2335,12 @@ class DataSetFilters:
             raise ImportError('matplotlib must be installed to use this filter.')
 
         # Sample on circular arc
-        sampled = DataSetFilters.sample_over_circular_arc(dataset, pointa, pointb,
-                                                          center, resolution, tolerance)
+        sampled = DataSetFilters.sample_over_circular_arc(dataset,
+                                                          pointa,
+                                                          pointb,
+                                                          center,
+                                                          resolution,
+                                                          tolerance)
 
         # Get variable of interest
         if scalars is None:
@@ -2363,15 +2370,15 @@ class DataSetFilters:
         if show:  # pragma: no cover
             return plt.show()
 
-    def plot_over_circular_arc2(dataset, center, resolution=None, normal=None,
-                                polar=None, angle=None, scalars=None,
-                                title=None, ylabel=None, figsize=None,
-                                figure=True, show=True, tolerance=None):
-        """Sample a dataset along a high resolution circular arc and plot.
+    def plot_over_circular_arc_normal(dataset, center, resolution=None, normal=None,
+                                      polar=None, angle=None, scalars=None,
+                                      title=None, ylabel=None, figsize=None,
+                                      figure=True, show=True, tolerance=None):
+        """Sample a dataset along a resolution circular arc defined by a normal and polar vector and plot it.
 
         Plot the variables of interest in 2D where the X-axis is
         distance from Point A and the Y-axis is the variable of
-        interest. Note that this filter returns None.
+        interest. Note that this filter returns ``None``.
 
         Parameters
         ----------
@@ -2429,7 +2436,7 @@ class DataSetFilters:
         >>> polar = [mesh.bounds[0], mesh.bounds[3], mesh.bounds[4]]
         >>> angle = 90
         >>> center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
-        >>> mesh.plot_over_circular_arc2(center, polar, angle)  # doctest:+SKIP
+        >>> mesh.plot_over_circular_arc_normal(center, polar, angle)  # doctest:+SKIP
 
         """
         # Ensure matplotlib is available
@@ -2439,8 +2446,13 @@ class DataSetFilters:
             raise ImportError('matplotlib must be installed to use this filter.')
 
         # Sample on circular arc
-        sampled = DataSetFilters.sample_over_circular_arc2(dataset, center, resolution, normal,
-                                                           polar, angle, tolerance)
+        sampled = DataSetFilters.sample_over_circular_arc_normal(dataset,
+                                                                 center,
+                                                                 resolution,
+                                                                 normal,
+                                                                 polar,
+                                                                 angle,
+                                                                 tolerance)
 
         # Get variable of interest
         if scalars is None:

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2252,8 +2252,8 @@ class DataSetFilters:
         >>> uniform = examples.load_uniform()
         >>> uniform["height"] = uniform.points[:, 2]
         >>> normal = [0, 0, 1]
-        >>> polar = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[5]]
-        >>> center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
+        >>> polar = [uniform.bounds[0], uniform.bounds[2], uniform.bounds[5]]
+        >>> center = [uniform.bounds[0], uniform.bounds[2], uniform.bounds[4]]
         >>> sampled_arc = uniform.sample_over_circular_arc2(center, normal=normal, polar=polar)
         """
         if resolution is None:

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2197,9 +2197,9 @@ class DataSetFilters:
         >>> from pyvista import examples
         >>> uniform = examples.load_uniform()
         >>> uniform["height"] = uniform.points[:, 2]
-        >>> pointa = [4.5, 4.5, 0.0]
-        >>> pointb = [4.5, 4.5, 9.0]
-        >>> center = [0.0, 0.0, 0.0]
+        >>> pointa = [uniform.bounds[0], uniform.bounds[2], uniform.bounds[5]]
+        >>> pointb = [uniform.bounds[1], uniform.bounds[2], uniform.bounds[4]]
+        >>> center = [uniform.bounds[0], uniform.bounds[2], uniform.bounds[4]]
         >>> sampled_arc = uniform.sample_over_circular_arc(pointa, pointb, center)
         """
         if resolution is None:

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2193,7 +2193,7 @@ class DataSetFilters:
 
         >>> import pyvista
         >>> uniform = examples.load_uniform()
-        >>> uniform[name] = uniform.points[:, 2]
+        >>> uniform["height"] = uniform.points[:, 2]
         >>> pointa = [4.5, 4.5, 0.0]
         >>> pointb = [4.5, 4.5, 9.0]
         >>> center = [0.0, 0.0, 0.0]

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2165,31 +2165,34 @@ class DataSetFilters:
         if show:  # pragma: no cover
             return plt.show()
 
-    def sample_over_circular_arc(dataset, pointa, pointb, center, resolution=None, tolerance=None):
-        """Sample a dataset onto a circular arc.
+    def sample_over_circular_arc(dataset, pointa, pointb, center,
+                                 resolution=None, tolerance=None):
+        """Sample a dataset over a circular arc.
 
         Parameters
         ----------
         pointa : np.ndarray or list
-            Location in [x, y, z].
+            Location in ``[x, y, z]``.
 
         pointb : np.ndarray or list
-            Location in [x, y, z].
+            Location in ``[x, y, z]``.
 
         center : np.ndarray or list
-            Location in [x, y, z].
+            Location in ``[x, y, z]``.
 
-        resolution : int
-            Number of pieces to divide circular arc into. Defaults to number of cells
-            in the input mesh. Must be a positive integer.
+        resolution : int, optional
+            Number of pieces to divide circular arc into. Defaults to
+            number of cells in the input mesh. Must be a positive
+            integer.
 
         tolerance: float, optional
-            Tolerance used to compute whether a point in the source is in a
-            cell of the input.  If not given, tolerance is automatically generated.
+            Tolerance used to compute whether a point in the source is
+            in a cell of the input.  If not given, tolerance is
+            automatically generated.
 
         Examples
         --------
-        Sample a dataset onto a circular arc.
+        Sample a dataset over a circular arc.
 
         >>> from pyvista import examples
         >>> uniform = examples.load_uniform()
@@ -2207,52 +2210,55 @@ class DataSetFilters:
         sampled_circular_arc = circular_arc.sample(dataset, tolerance=tolerance)
         return sampled_circular_arc
 
-    def plot_over_circular_arc(dataset, pointa, pointb, center, resolution=None, scalars=None,
-                               title=None, ylabel=None, figsize=None, figure=True,
-                               show=True, tolerance=None):
+    def plot_over_circular_arc(dataset, pointa, pointb, center,
+                               resolution=None, scalars=None,
+                               title=None, ylabel=None, figsize=None,
+                               figure=True, show=True, tolerance=None):
         """Sample a dataset along a high resolution circular arc and plot.
 
-        Plot the variables of interest in 2D where the X-axis is distance from
-        Point A and the Y-axis is the variable of interest. Note that this filter
-        returns None.
+        Plot the variables of interest in 2D where the X-axis is
+        distance from Point A and the Y-axis is the variable of
+        interest. Note that this filter returns None.
 
         Parameters
         ----------
         pointa : np.ndarray or list
-            Location in [x, y, z].
+            Location in ``[x, y, z]``.
 
         pointb : np.ndarray or list
-            Location in [x, y, z].
+            Location in ``[x, y, z]``.
 
         center : np.ndarray or list
-            Location in [x, y, z].
+            Location in ``[x, y, z]``.
 
-        resolution : int
-            number of pieces to divide circular arc into. Defaults to number of cells
-            in the input mesh. Must be a positive integer.
+        resolution : int, optional
+            number of pieces to divide circular arc into. Defaults to
+            number of cells in the input mesh. Must be a positive
+            integer.
 
-        scalars : str
-            The string name of the variable in the input dataset to probe. The
-            active scalar is used by default.
+        scalars : str, optional
+            The string name of the variable in the input dataset to
+            probe. The active scalar is used by default.
 
-        title : str
+        title : str, optional
             The string title of the `matplotlib` figure
 
-        ylabel : str
+        ylabel : str, optional
             The string label of the Y-axis. Defaults to variable name
 
-        figsize : tuple(int)
+        figsize : tuple(int), optional
             the size of the new figure
 
-        figure : bool
+        figure : bool, optional
             flag on whether or not to create a new figure
 
-        show : bool
+        show : bool, optional
             Shows the matplotlib figure
 
         tolerance: float, optional
-            Tolerance used to compute whether a point in the source is in a
-            cell of the input.  If not given, tolerance is automatically generated.
+            Tolerance used to compute whether a point in the source is
+            in a cell of the input.  If not given, tolerance is
+            automatically generated.
 
         Examples
         --------
@@ -2269,10 +2275,11 @@ class DataSetFilters:
         try:
             import matplotlib.pyplot as plt
         except ImportError:  # pragma: no cover
-            raise ImportError('matplotlib must be available to use this filter.')
+            raise ImportError('matplotlib must be installed to use this filter.')
 
         # Sample on circular arc
-        sampled = DataSetFilters.sample_over_circular_arc(dataset, pointa, pointb, center, resolution, tolerance)
+        sampled = DataSetFilters.sample_over_circular_arc(dataset, pointa, pointb,
+                                                          center, resolution, tolerance)
 
         # Get variable of interest
         if scalars is None:
@@ -2280,7 +2287,7 @@ class DataSetFilters:
         values = sampled.get_array(scalars)
         distance = sampled['Distance']
 
-        # Remainder is plotting
+        # create the matplotlib figure
         if figure:
             plt.figure(figsize=figsize)
         # Plot it in 2D

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2210,6 +2210,60 @@ class DataSetFilters:
         sampled_circular_arc = circular_arc.sample(dataset, tolerance=tolerance)
         return sampled_circular_arc
 
+    def sample_over_circular_arc2(dataset, center, resolution=None, normal=None,
+                                  polar=None, angle=None, tolerance=None):
+        """Sample a dataset over a circular arc.
+
+        The number of segments composing the polyline is controlled by setting the
+        object resolution.
+
+        Parameters
+        ----------
+        center : np.ndarray or list
+            Location in ``[x, y, z]``.
+
+        resolution : int, optional
+            Number of pieces to divide circular arc into. Defaults to
+            number of cells in the input mesh. Must be a positive
+            integer.
+
+        normal : np.ndarray or list, optional
+            The normal vector to the plane of the arc.  By default it
+            points in the positive Z direction.
+
+        polar : np.ndarray or list, optional
+            (starting point of the arc).  By default it is the unit vector
+            in the positive x direction.
+
+        angle : float, optional
+            Arc length (in degrees), beginning at the polar vector.  The
+            direction is counterclockwise.  By default it is 360.
+
+        tolerance: float, optional
+            Tolerance used to compute whether a point in the source is
+            in a cell of the input.  If not given, tolerance is
+            automatically generated.
+
+        Examples
+        --------
+        Sample a dataset over a circular arc.
+
+        >>> from pyvista import examples
+        >>> uniform = examples.load_uniform()
+        >>> uniform["height"] = uniform.points[:, 2]
+        >>> normal = [0, 0, 1]
+        >>> polar = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[5]]
+        >>> center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
+        >>> sampled_arc = uniform.sample_over_circular_arc2(center, normal=normal, polar=polar)
+        """
+        if resolution is None:
+            resolution = int(dataset.n_cells)
+        # Make a circular arc and sample the dataset
+        circular_arc = pyvista.CircularArc2(center, resolution=resolution, normal=normal, polar=polar)
+
+        sampled_circular_arc = circular_arc.sample(dataset, tolerance=tolerance)
+        return sampled_circular_arc
+
     def plot_over_circular_arc(dataset, pointa, pointb, center,
                                resolution=None, scalars=None,
                                title=None, ylabel=None, figsize=None,
@@ -2280,6 +2334,113 @@ class DataSetFilters:
         # Sample on circular arc
         sampled = DataSetFilters.sample_over_circular_arc(dataset, pointa, pointb,
                                                           center, resolution, tolerance)
+
+        # Get variable of interest
+        if scalars is None:
+            field, scalars = dataset.active_scalars_info
+        values = sampled.get_array(scalars)
+        distance = sampled['Distance']
+
+        # create the matplotlib figure
+        if figure:
+            plt.figure(figsize=figsize)
+        # Plot it in 2D
+        if values.ndim > 1:
+            for i in range(values.shape[1]):
+                plt.plot(distance, values[:, i], label=f'Component {i}')
+            plt.legend()
+        else:
+            plt.plot(distance, values)
+        plt.xlabel('Distance')
+        if ylabel is None:
+            plt.ylabel(scalars)
+        else:
+            plt.ylabel(ylabel)
+        if title is None:
+            plt.title(f'{scalars} Profile')
+        else:
+            plt.title(title)
+        if show:  # pragma: no cover
+            return plt.show()
+
+    def plot_over_circular_arc2(dataset, center, resolution=None, normal=None,
+                                polar=None, angle=None, scalars=None,
+                                title=None, ylabel=None, figsize=None,
+                                figure=True, show=True, tolerance=None):
+        """Sample a dataset along a high resolution circular arc and plot.
+
+        Plot the variables of interest in 2D where the X-axis is
+        distance from Point A and the Y-axis is the variable of
+        interest. Note that this filter returns None.
+
+        Parameters
+        ----------
+        center : np.ndarray or list
+            Location in ``[x, y, z]``.
+
+        resolution : int, optional
+            number of pieces to divide circular arc into. Defaults to
+            number of cells in the input mesh. Must be a positive
+            integer.
+
+        normal : np.ndarray or list, optional
+            The normal vector to the plane of the arc.  By default it
+            points in the positive Z direction.
+
+        polar : np.ndarray or list, optional
+            (starting point of the arc).  By default it is the unit vector
+            in the positive x direction.
+
+        angle : float, optional
+            Arc length (in degrees), beginning at the polar vector.  The
+            direction is counterclockwise.  By default it is 360.
+
+        scalars : str, optional
+            The string name of the variable in the input dataset to
+            probe. The active scalar is used by default.
+
+        title : str, optional
+            The string title of the `matplotlib` figure
+
+        ylabel : str, optional
+            The string label of the Y-axis. Defaults to variable name
+
+        figsize : tuple(int), optional
+            the size of the new figure
+
+        figure : bool, optional
+            flag on whether or not to create a new figure
+
+        show : bool, optional
+            Shows the matplotlib figure
+
+        tolerance: float, optional
+            Tolerance used to compute whether a point in the source is
+            in a cell of the input.  If not given, tolerance is
+            automatically generated.
+
+        Examples
+        --------
+        Sample a dataset along a high resolution circular arc and plot.
+
+        >>> from pyvista import examples
+        >>> mesh = examples.load_uniform()
+        >>> normal = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[5]]
+        >>> polar = [mesh.bounds[0], mesh.bounds[3], mesh.bounds[4]]
+        >>> angle = 90
+        >>> center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
+        >>> mesh.plot_over_circular_arc2(center, polar, angle)  # doctest:+SKIP
+
+        """
+        # Ensure matplotlib is available
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError:  # pragma: no cover
+            raise ImportError('matplotlib must be installed to use this filter.')
+
+        # Sample on circular arc
+        sampled = DataSetFilters.sample_over_circular_arc2(dataset, center, resolution, normal,
+                                                           polar, angle, tolerance)
 
         # Get variable of interest
         if scalars is None:

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2191,7 +2191,7 @@ class DataSetFilters:
         --------
         Sample a dataset onto a circular arc.
 
-        >>> import pyvista
+        >>> from pyvista import examples
         >>> uniform = examples.load_uniform()
         >>> uniform["height"] = uniform.points[:, 2]
         >>> pointa = [4.5, 4.5, 0.0]

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -692,7 +692,11 @@ def CircularArc(pointa, pointb, center, resolution=100, normal=None,
             arc.SetAngle(angle)
 
     arc.Update()
-    return pyvista.wrap(arc.GetOutput())
+    arc = pyvista.wrap(arc.GetOutput())
+    # Compute distance of every point along circular arc
+    distance = np.cumsum(np.append(0.0, np.sqrt(np.sum((arc.points[:-1]-arc.points[1:])**2, axis=1))))
+    arc['Distance'] = distance
+    return arc
 
 
 def Pyramid(points):

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -695,15 +695,12 @@ def CircularArc(pointa, pointb, center, resolution=100, normal=None,
     arc = pyvista.wrap(arc.GetOutput())
     # Compute distance of every point along circular arc
     pointa = np.array(pointa)
+    center = np.array(center)
     points = arc.points
-    if resolution == 1:
-        arc['Distance'] = np.sqrt(np.sum((points - pointa)**2, axis=1))
-    else:
-        center = np.array(center)
-        radius = np.sqrt(np.sum((pointa - center)**2, axis=0))
-        chords = np.sqrt(np.sum((np.append([[0.0, 0.0, 0.0]], np.diff(points, axis=0), axis=0))**2, axis=1))
-        thetas = 2.0*np.arcsin(chords/(2.0*radius))
-        arc['Distance'] = np.cumsum(radius*thetas)
+    radius = np.sqrt(np.sum((pointa-center)**2, axis=0))
+    chords = np.sqrt(np.sum((points-pointa)**2, axis=1))
+    thetas = 2.0*np.arcsin(chords/(2.0*radius))
+    arc['Distance'] = radius*thetas
     return arc
 
 

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -692,15 +692,13 @@ def CircularArc(pointa, pointb, center, resolution=100, normal=None,
             arc.SetAngle(angle)
 
     arc.Update()
+    angle = np.deg2rad(arc.GetAngle())
     arc = pyvista.wrap(arc.GetOutput())
     # Compute distance of every point along circular arc
-    pointa = np.array(pointa)
     center = np.array(center)
-    points = arc.points
-    radius = np.sqrt(np.sum((pointa-center)**2, axis=0))
-    chords = np.sqrt(np.sum((points-pointa)**2, axis=1))
-    thetas = 2.0*np.arcsin(chords/(2.0*radius))
-    arc['Distance'] = radius*thetas
+    radius = np.sqrt(np.sum((arc.points[0]-center)**2, axis=0))
+    angles = np.arange(0.0, 1.0 + 1.0/resolution, 1.0/resolution) * angle
+    arc['Distance'] = radius * angles
     return arc
 
 

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -619,15 +619,16 @@ def CircularArc(pointa, pointb, center, resolution=100, negative=False):
         Resolution of 1 will just create a line.
 
     negative : bool, optional
-        By default the arc spans the shortest angular sector point1 and point2.
+        By default the arc spans the shortest angular sector between
+        ``pointa`` and ``pointb``.
 
-        By setting this to true, the longest angular sector is used
-        instead (i.e. the negative coterminal angle to the shortest
-        one).
+        By setting this to ``True``, the longest angular sector is
+        used instead (i.e. the negative coterminal angle to the
+        shortest one).
 
     Examples
     --------
-    Quarter arc centered at the origin in the xy plane
+    Create a quarter arc centered at the origin in the xy plane.
 
     >>> import pyvista
     >>> arc = pyvista.CircularArc([-1, 0, 0], [0, 1, 0], [0, 0, 0])
@@ -670,11 +671,12 @@ def CircularArc(pointa, pointb, center, resolution=100, negative=False):
     return arc
 
 
-def CircularArc2(center, resolution=100, normal=None, polar=None, angle=None):
+def CircularArcFromNormal(center, resolution=100, normal=None,
+                          polar=None, angle=None):
     """Create a circular arc defined by normal to the plane of the arc, and an angle.
 
-    The number of segments composing the polyline is controlled by setting the
-    object resolution.
+    The number of segments composing the polyline is controlled by
+    setting the object resolution.
 
     Parameters
     ----------
@@ -690,21 +692,21 @@ def CircularArc2(center, resolution=100, normal=None, polar=None, angle=None):
         points in the positive Z direction.
 
     polar : np.ndarray or list, optional
-        (starting point of the arc).  By default it is the unit vector
-        in the positive x direction.
+        Starting point of the arc in polar coordinates.  By default it
+        is the unit vector in the positive x direction.
 
     angle : float, optional
-        Arc length (in degrees), beginning at the polar vector.  The
+        Arc length (in degrees) beginning at the polar vector.  The
         direction is counterclockwise.  By default it is 360.
 
     Examples
     --------
-    Quarter arc centered at the origin in the xy plane
+    Quarter arc centered at the origin in the xy plane.
 
     >>> import pyvista
     >>> normal = [0, 0, 1]
     >>> polar = [-1, 0, 0]
-    >>> arc = pyvista.CircularArc2([0, 0, 0], normal=normal, polar=polar)
+    >>> arc = pyvista.CircularArcFromNormal([0, 0, 0], normal=normal, polar=polar)
     >>> pl = pyvista.Plotter()
     >>> _ = pl.add_mesh(arc, color='k', line_width=4)
     >>> _ = pl.show_bounds(location='all')
@@ -713,11 +715,11 @@ def CircularArc2(center, resolution=100, normal=None, polar=None, angle=None):
     """
     check_valid_vector(center, 'center')
     if normal is None:
-       normal = [0, 0, 1]
+        normal = [0, 0, 1]
     if polar is None:
-       polar = [1, 0, 0]
+        polar = [1, 0, 0]
     if angle is None:
-       angle = 90.0
+        angle = 90.0
 
     arc = _vtk.vtkArcSource()
     arc.SetCenter(*center)
@@ -734,7 +736,7 @@ def CircularArc2(center, resolution=100, normal=None, polar=None, angle=None):
     arc = pyvista.wrap(arc.GetOutput())
     # Compute distance of every point along circular arc
     center = np.array(center)
-    radius = np.sqrt(np.sum((arc.points[0]-center)**2, axis=0))
+    radius = np.sqrt(np.sum((arc.points[0] - center)**2, axis=0))
     angles = np.arange(0.0, 1.0 + 1.0/resolution, 1.0/resolution) * angle
     arc['Distance'] = radius * angles
     return arc

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -694,8 +694,13 @@ def CircularArc(pointa, pointb, center, resolution=100, normal=None,
     arc.Update()
     arc = pyvista.wrap(arc.GetOutput())
     # Compute distance of every point along circular arc
-    distance = np.cumsum(np.append(0.0, np.sqrt(np.sum((arc.points[:-1]-arc.points[1:])**2, axis=1))))
-    arc['Distance'] = distance
+    pointa = np.array(pointa)
+    center = np.array(center)
+    points = arc.points
+    radius = np.sqrt(np.sum((pointa-center)**2, axis=0))
+    chords = np.sqrt(np.sum((points-pointa)**2, axis=1))
+    thetas = 2.0*np.arcsin(chords/(2.0*radius))
+    arc['Distance'] = radius*thetas
     return arc
 
 

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -665,6 +665,11 @@ def CircularArc(pointa, pointb, center, resolution=100, normal=None,
     check_valid_vector(pointa, 'pointa')
     check_valid_vector(pointb, 'pointb')
     check_valid_vector(center, 'center')
+    if not np.isclose(
+        np.linalg.norm(np.array(pointa) - np.array(center)),
+        np.linalg.norm(np.array(pointb) - np.array(center)),
+    ):
+        raise ValueError("pointa and pointb are not equidistant from center")
 
     # fix half-arc bug: if a half arc travels directly through the
     # center point, it becomes a line

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -695,12 +695,15 @@ def CircularArc(pointa, pointb, center, resolution=100, normal=None,
     arc = pyvista.wrap(arc.GetOutput())
     # Compute distance of every point along circular arc
     pointa = np.array(pointa)
-    center = np.array(center)
     points = arc.points
-    radius = np.sqrt(np.sum((pointa-center)**2, axis=0))
-    chords = np.sqrt(np.sum((points-pointa)**2, axis=1))
-    thetas = 2.0*np.arcsin(chords/(2.0*radius))
-    arc['Distance'] = radius*thetas
+    if resolution == 1:
+        arc['Distance'] = np.sqrt(np.sum((points - pointa)**2, axis=1))
+    else:
+        center = np.array(center)
+        radius = np.sqrt(np.sum((pointa - center)**2, axis=0))
+        chords = np.sqrt(np.sum((np.append([[0.0, 0.0, 0.0]], np.diff(points, axis=0), axis=0))**2, axis=1))
+        thetas = 2.0*np.arcsin(chords/(2.0*radius))
+        arc['Distance'] = np.cumsum(radius*thetas)
     return arc
 
 

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -597,16 +597,11 @@ def Wavelet(extent=(-10,10,-10,10,-10,10), center=(0,0,0), maximum=255,
     return pyvista.wrap(wavelet_source.GetOutput())
 
 
-def CircularArc(pointa, pointb, center, resolution=100, normal=None,
-                polar=None, angle=None, negative=False):
+def CircularArc(pointa, pointb, center, resolution=100, negative=False):
     """Create a circular arc defined by two endpoints and a center.
 
     The number of segments composing the polyline is controlled by
-    setting the object resolution.  Alternatively, one can use a
-    better API (that does not allow for inconsistent nor ambiguous
-    inputs), using a starting point (polar vector, measured from the
-    arc's center), a normal to the plane of the arc, and an angle
-    defining the arc length.
+    setting the object resolution.
 
     Parameters
     ----------
@@ -623,27 +618,12 @@ def CircularArc(pointa, pointb, center, resolution=100, normal=None,
         The number of segments of the polyline that draws the arc.
         Resolution of 1 will just create a line.
 
-    normal : np.ndarray or list
-        The normal vector to the plane of the arc.  By default it
-        points in the positive Z direction.
-
-    polar : np.ndarray or list
-        (starting point of the arc).  By default it is the unit vector
-        in the positive x direction. Note: This is only used when
-        normal has been input.
-
-    angle : float
-        Arc length (in degrees), beginning at the polar vector.  The
-        direction is counterclockwise by default; a negative value
-        draws the arc in the clockwise direction.  Note: This is only
-        used when normal has been input.
-
     negative : bool, optional
         By default the arc spans the shortest angular sector point1 and point2.
 
         By setting this to true, the longest angular sector is used
         instead (i.e. the negative coterminal angle to the shortest
-        one). This is only used when normal has not been input
+        one).
 
     Examples
     --------
@@ -656,11 +636,6 @@ def CircularArc(pointa, pointb, center, resolution=100, normal=None,
     >>> _ = pl.show_bounds(location='all')
     >>> _ = pl.view_xy()
     >>> pl.show() # doctest:+SKIP
-
-    Quarter arc centered at the origin in the xz plane
-
-    >>> arc = pyvista.CircularArc([-1, 0, 0], [1, 0, 0], [0, 0, 0], normal=[0, 0, 1])
-    >>> arc.plot() # doctest:+SKIP
     """
     check_valid_vector(pointa, 'pointa')
     check_valid_vector(pointb, 'pointb')
@@ -684,18 +659,76 @@ def CircularArc(pointa, pointb, center, resolution=100, normal=None,
     arc.SetResolution(resolution)
     arc.SetNegative(negative)
 
-    if normal is not None:
-        arc.UseNormalAndAngleOn()
-        check_valid_vector(normal, 'normal')
-        arc.SetNormal(*normal)
+    arc.Update()
+    angle = np.deg2rad(arc.GetAngle())
+    arc = pyvista.wrap(arc.GetOutput())
+    # Compute distance of every point along circular arc
+    center = np.array(center)
+    radius = np.sqrt(np.sum((arc.points[0]-center)**2, axis=0))
+    angles = np.arange(0.0, 1.0 + 1.0/resolution, 1.0/resolution) * angle
+    arc['Distance'] = radius * angles
+    return arc
 
-        if polar is not None:
-            check_valid_vector(polar, 'polar')
-            arc.SetPolarVector(*polar)
 
-        if angle is not None:
-            arc.SetAngle(angle)
+def CircularArc2(center, resolution=100, normal=None, polar=None, angle=None):
+    """Create a circular arc defined by normal to the plane of the arc, and an angle.
 
+    The number of segments composing the polyline is controlled by setting the
+    object resolution.
+
+    Parameters
+    ----------
+    center : np.ndarray or list
+        Center of the circle that defines the arc.
+
+    resolution : int, optional
+        The number of segments of the polyline that draws the arc.
+        Resolution of 1 will just create a line.
+
+    normal : np.ndarray or list, optional
+        The normal vector to the plane of the arc.  By default it
+        points in the positive Z direction.
+
+    polar : np.ndarray or list, optional
+        (starting point of the arc).  By default it is the unit vector
+        in the positive x direction.
+
+    angle : float, optional
+        Arc length (in degrees), beginning at the polar vector.  The
+        direction is counterclockwise.  By default it is 360.
+
+    Examples
+    --------
+    Quarter arc centered at the origin in the xy plane
+
+    >>> import pyvista
+    >>> normal = [0, 0, 1]
+    >>> polar = [-1, 0, 0]
+    >>> arc = pyvista.CircularArc2([0, 0, 0], normal=normal, polar=polar)
+    >>> pl = pyvista.Plotter()
+    >>> _ = pl.add_mesh(arc, color='k', line_width=4)
+    >>> _ = pl.show_bounds(location='all')
+    >>> _ = pl.view_xy()
+    >>> pl.show() # doctest:+SKIP
+    """
+    check_valid_vector(center, 'center')
+    if normal is None:
+       normal = [0, 0, 1]
+    if polar is None:
+       polar = [1, 0, 0]
+    if angle is None:
+       angle = 90.0
+
+    arc = _vtk.vtkArcSource()
+    arc.SetCenter(*center)
+    arc.SetResolution(resolution)
+    arc.UseNormalAndAngleOn()
+    check_valid_vector(normal, 'normal')
+    arc.SetNormal(*normal)
+    check_valid_vector(polar, 'polar')
+    arc.SetPolarVector(*polar)
+    assert np.allclose(np.array(arc.GetPolarVector()), np.array(polar))
+    arc.SetAngle(angle)
     arc.Update()
     angle = np.deg2rad(arc.GetAngle())
     arc = pyvista.wrap(arc.GetOutput())

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -778,7 +778,7 @@ def test_sample_over_circular_arc():
     center = [xmin, ymin, zmin]
     sampled_arc = uniform.sample_over_circular_arc(pointa, pointb, center, 2)
 
-    expected_result = np.array([zmax, zmin+(zmax-zmin)*np.sin(np.pi/4.0), zmin])
+    expected_result = zmin+(zmax-zmin)*np.sin([np.pi/2.0, np.pi/4.0, 0.0])
     assert np.allclose(sampled_arc[name], expected_result)
     assert name in sampled_arc.array_names # is name in sampled result
 
@@ -810,7 +810,7 @@ def test_sample_over_circular_arc2():
     center = [xmin, ymin, zmin]
     sampled_arc2 = uniform.sample_over_circular_arc2(center, resolution=2, normal=normal, polar=polar, angle=angle)
 
-    expected_result = np.array([zmax, zmin+(zmax-zmin)*np.sin(np.pi/4.0), zmin])
+    expected_result = zmin+(zmax-zmin)*np.sin([np.pi/2.0, np.pi/4.0, 0.0])
     assert np.allclose(sampled_arc2[name], expected_result)
     assert name in sampled_arc2.array_names # is name in sampled result
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -760,6 +760,55 @@ def test_plot_over_line():
                             title='My Stuff', ylabel='3 Values', show=False)
 
 
+def test_sample_over_circular_arc():
+    """Test that we get a circular arc."""
+
+    name = 'values'
+
+    uniform = examples.load_uniform()
+    uniform[name] = uniform.points[:, 2]
+
+    pointa = [4.5, 4.5, 0.0]
+    pointb = [4.5, 4.5, 9.0]
+    center = [0.0, 0.0, 0.0]
+    sampled_arc = uniform.sample_over_circular_arc(pointa, pointb, center)
+
+    expected_result = sampled_arc.points[:, 2]
+    assert np.allclose(sampled_arc[name], expected_result)
+    assert name in sampled_arc.array_names # is name in sampled result
+
+    # test no resolution
+    sphere = pyvista.Sphere(center=(4.5,4.5,4.5), radius=4.5)
+    sampled_from_sphere = sphere.sample_over_circular_arc([3, 1, 1], [-3, -1, -1], [0, 0, 0])
+    assert sampled_from_sphere.n_points == sphere.n_cells + 1
+
+    # is sampled result a polydata object
+    assert isinstance(sampled_from_sphere, pyvista.PolyData)
+
+
+def test_plot_over_circular_arc():
+    """this requires matplotlib"""
+
+    pytest.importorskip('matplotlib')
+    mesh = examples.load_uniform()
+
+    # Make two points and center to construct the circular arc between
+    a = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[5]]
+    b = [mesh.bounds[1], mesh.bounds[2], mesh.bounds[4]]
+    center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
+    mesh.plot_over_circular_arc(a, b, center, resolution=1000, show=False)
+
+    # Test multicomponent
+    mesh['foo'] = np.random.rand(mesh.n_cells, 3)
+    mesh.plot_over_circular_arc(a, b, center, resolution=None, scalars='foo',
+                                title='My Stuff', ylabel='3 Values', show=False)
+
+    # Should fail if scalar name does not exist
+    with pytest.raises(KeyError):
+        mesh.plot_over_circular_arc(a, b, center, resolution=None, scalars='invalid_array_name',
+                                    title='My Stuff', ylabel='3 Values', show=False)
+
+
 def test_slice_along_line():
     model = examples.load_uniform()
     n = 5

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -820,7 +820,7 @@ def test_plot_over_circular_arc2():
     polar = [mesh.bounds[0], mesh.bounds[3], mesh.bounds[4]]
     angle = 90
     center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
-    mesh.plot_over_circular_arc2(center, polar=polar, angle=angle)
+    mesh.plot_over_circular_arc2(center, polar=polar, angle=angle, show=False)
 
     # Test multicomponent
     mesh['foo'] = np.random.rand(mesh.n_cells, 3)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -768,18 +768,55 @@ def test_sample_over_circular_arc():
     uniform = examples.load_uniform()
     uniform[name] = uniform.points[:, 2]
 
-    pointa = [uniform.bounds[0], uniform.bounds[2], uniform.bounds[5]]
-    pointb = [uniform.bounds[1], uniform.bounds[2], uniform.bounds[4]]
-    center = [uniform.bounds[0], uniform.bounds[2], uniform.bounds[4]]
-    sampled_arc = uniform.sample_over_circular_arc(pointa, pointb, center)
+    xmin = uniform.bounds[0]
+    xmax = uniform.bounds[1]
+    ymin = uniform.bounds[2]
+    zmin = uniform.bounds[4]
+    zmax = uniform.bounds[5]
+    pointa = [xmin, ymin, zmax]
+    pointb = [xmax, ymin, zmin]
+    center = [xmin, ymin, zmin]
+    sampled_arc = uniform.sample_over_circular_arc(pointa, pointb, center, 2)
 
-    expected_result = sampled_arc.points[:, 2]
+    expected_result = np.array([zmax, zmin+(zmax-zmin)*np.sin(np.pi/4.0), zmin])
     assert np.allclose(sampled_arc[name], expected_result)
     assert name in sampled_arc.array_names # is name in sampled result
 
     # test no resolution
     sphere = pyvista.Sphere(center=(4.5,4.5,4.5), radius=4.5)
     sampled_from_sphere = sphere.sample_over_circular_arc([3, 1, 1], [-3, -1, -1], [0, 0, 0])
+    assert sampled_from_sphere.n_points == sphere.n_cells + 1
+
+    # is sampled result a polydata object
+    assert isinstance(sampled_from_sphere, pyvista.PolyData)
+
+
+def test_sample_over_circular_arc2():
+    """Test that we get a circular arc2."""
+
+    name = 'values'
+
+    uniform = examples.load_uniform()
+    uniform[name] = uniform.points[:, 2]
+
+    xmin = uniform.bounds[0]
+    ymin = uniform.bounds[2]
+    ymax = uniform.bounds[3]
+    zmin = uniform.bounds[4]
+    zmax = uniform.bounds[5]
+    normal = [xmin, ymax, zmin]
+    polar = [xmin, ymin, zmax]
+    angle = 90
+    center = [xmin, ymin, zmin]
+    sampled_arc2 = uniform.sample_over_circular_arc2(center, resolution=2, normal=normal, polar=polar, angle=angle)
+
+    expected_result = np.array([zmax, zmin+(zmax-zmin)*np.sin(np.pi/4.0), zmin])
+    assert np.allclose(sampled_arc2[name], expected_result)
+    assert name in sampled_arc2.array_names # is name in sampled result
+
+    # test no resolution
+    sphere = pyvista.Sphere(center=(4.5,4.5,4.5), radius=4.5)
+    sampled_from_sphere = sphere.sample_over_circular_arc2([0, 0, 0], polar=[3, 1, 1], angle=180)
     assert sampled_from_sphere.n_points == sphere.n_cells + 1
 
     # is sampled result a polydata object

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -791,8 +791,8 @@ def test_sample_over_circular_arc():
     assert isinstance(sampled_from_sphere, pyvista.PolyData)
 
 
-def test_sample_over_circular_arc2():
-    """Test that we get a circular arc2."""
+def test_sample_over_circular_arc_normal():
+    """Test that we get a circular arc_normal."""
 
     name = 'values'
 
@@ -808,15 +808,15 @@ def test_sample_over_circular_arc2():
     polar = [xmin, ymin, zmax]
     angle = 90
     center = [xmin, ymin, zmin]
-    sampled_arc2 = uniform.sample_over_circular_arc2(center, resolution=2, normal=normal, polar=polar, angle=angle)
+    sampled_arc_normal = uniform.sample_over_circular_arc_normal(center, resolution=2, normal=normal, polar=polar, angle=angle)
 
     expected_result = zmin+(zmax-zmin)*np.sin([np.pi/2.0, np.pi/4.0, 0.0])
-    assert np.allclose(sampled_arc2[name], expected_result)
-    assert name in sampled_arc2.array_names # is name in sampled result
+    assert np.allclose(sampled_arc_normal[name], expected_result)
+    assert name in sampled_arc_normal.array_names # is name in sampled result
 
     # test no resolution
     sphere = pyvista.Sphere(center=(4.5,4.5,4.5), radius=4.5)
-    sampled_from_sphere = sphere.sample_over_circular_arc2([0, 0, 0], polar=[3, 1, 1], angle=180)
+    sampled_from_sphere = sphere.sample_over_circular_arc_normal([0, 0, 0], polar=[3, 1, 1], angle=180)
     assert sampled_from_sphere.n_points == sphere.n_cells + 1
 
     # is sampled result a polydata object
@@ -842,11 +842,13 @@ def test_plot_over_circular_arc():
 
     # Should fail if scalar name does not exist
     with pytest.raises(KeyError):
-        mesh.plot_over_circular_arc(a, b, center, resolution=None, scalars='invalid_array_name',
-                                    title='My Stuff', ylabel='3 Values', show=False)
+        mesh.plot_over_circular_arc(a, b, center, resolution=None,
+                                    scalars='invalid_array_name',
+                                    title='My Stuff', ylabel='3 Values',
+                                    show=False)
 
 
-def test_plot_over_circular_arc2():
+def test_plot_over_circular_arc_normal():
     """this requires matplotlib"""
 
     pytest.importorskip('matplotlib')
@@ -857,24 +859,29 @@ def test_plot_over_circular_arc2():
     polar = [mesh.bounds[0], mesh.bounds[3], mesh.bounds[4]]
     angle = 90
     center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
-    mesh.plot_over_circular_arc2(center, polar=polar, angle=angle, show=False)
+    mesh.plot_over_circular_arc_normal(center, polar=polar, angle=angle, show=False)
 
     # Test multicomponent
     mesh['foo'] = np.random.rand(mesh.n_cells, 3)
-    mesh.plot_over_circular_arc2(center, polar=polar, angle=angle, resolution=None, scalars='foo',
-                                 title='My Stuff', ylabel='3 Values', show=False)
+    mesh.plot_over_circular_arc_normal(center, polar=polar,
+                                       angle=angle, resolution=None,
+                                       scalars='foo', title='My Stuff',
+                                       ylabel='3 Values', show=False)
 
     # Should fail if scalar name does not exist
     with pytest.raises(KeyError):
-        mesh.plot_over_circular_arc2(center, polar=polar, angle=angle, resolution=None, scalars='invalid_array_name',
-                                     title='My Stuff', ylabel='3 Values', show=False)
+        mesh.plot_over_circular_arc_normal(center, polar=polar,
+                                           angle=angle, resolution=None,
+                                           scalars='invalid_array_name',
+                                           title='My Stuff', ylabel='3 Values',
+                                           show=False)
 
 
 def test_slice_along_line():
     model = examples.load_uniform()
     n = 5
     x = y = z = np.linspace(model.bounds[0], model.bounds[1], num=n)
-    points = np.c_[x,y,z]
+    points = np.c_[x, y, z]
     spline = pyvista.Spline(points, n)
     slc = model.slice_along_line(spline)
     assert slc.n_points > 0

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -809,6 +809,30 @@ def test_plot_over_circular_arc():
                                     title='My Stuff', ylabel='3 Values', show=False)
 
 
+def test_plot_over_circular_arc2():
+    """this requires matplotlib"""
+
+    pytest.importorskip('matplotlib')
+    mesh = examples.load_uniform()
+
+    # Make center and normal/polar vector to construct the circular arc between
+    normal = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[5]]
+    polar = [mesh.bounds[0], mesh.bounds[3], mesh.bounds[4]]
+    angle = 90
+    center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
+    mesh.plot_over_circular_arc2(center, polar=polar, angle=angle)
+
+    # Test multicomponent
+    mesh['foo'] = np.random.rand(mesh.n_cells, 3)
+    mesh.plot_over_circular_arc2(center, polar=polar, angle=angle, resolution=None, scalars='foo',
+                                 title='My Stuff', ylabel='3 Values', show=False)
+
+    # Should fail if scalar name does not exist
+    with pytest.raises(KeyError):
+        mesh.plot_over_circular_arc2(center, polar=polar, angle=angle, resolution=None, scalars='invalid_array_name',
+                                     title='My Stuff', ylabel='3 Values', show=False)
+
+
 def test_slice_along_line():
     model = examples.load_uniform()
     n = 5

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -768,9 +768,9 @@ def test_sample_over_circular_arc():
     uniform = examples.load_uniform()
     uniform[name] = uniform.points[:, 2]
 
-    pointa = [4.5, 4.5, 0.0]
-    pointb = [4.5, 4.5, 9.0]
-    center = [0.0, 0.0, 0.0]
+    pointa = [uniform.bounds[0], uniform.bounds[2], uniform.bounds[5]]
+    pointb = [uniform.bounds[1], uniform.bounds[2], uniform.bounds[4]]
+    center = [uniform.bounds[0], uniform.bounds[2], uniform.bounds[4]]
     sampled_arc = uniform.sample_over_circular_arc(pointa, pointb, center)
 
     expected_result = sampled_arc.points[:, 2]

--- a/tests/test_geometric_objects.py
+++ b/tests/test_geometric_objects.py
@@ -144,8 +144,8 @@ def test_circular_arc():
     resolution = 100
 
     mesh = pyvista.CircularArc(pointa, pointb, center, resolution)
-    assert mesh.n_points
-    assert mesh.n_cells
+    assert mesh.n_points == resolution + 1
+    assert mesh.n_cells == 1
     distance = np.arange(0.0, 1.0 + 0.01, 0.01)*np.pi/2.0
     assert np.allclose(mesh['Distance'], distance)
 
@@ -154,16 +154,16 @@ def test_circular_arc():
         mesh = pyvista.CircularArc([-1, 0, 0], [-0.99, 0.001, 0], [0, 0, 0], 100)
 
 
-def test_circular_arc2():
+def test_circular_arc_from_normal():
     center = [0, 0, 0]
     normal = [0, 0, 1]
     polar = [-2.0, 0, 0]
     angle = 90
     resolution = 100
 
-    mesh = pyvista.CircularArc2(center, resolution, normal, polar, angle)
-    assert mesh.n_points
-    assert mesh.n_cells
+    mesh = pyvista.CircularArcFromNormal(center, resolution, normal, polar, angle)
+    assert mesh.n_points == resolution + 1
+    assert mesh.n_cells == 1
     distance = np.arange(0.0, 1.0 + 0.01, 0.01)*np.pi
     assert np.allclose(mesh['Distance'], distance)
 

--- a/tests/test_geometric_objects.py
+++ b/tests/test_geometric_objects.py
@@ -146,21 +146,11 @@ def test_circular_arc():
     mesh = pyvista.CircularArc(pointa, pointb, center, resolution)
     assert mesh.n_points
     assert mesh.n_cells
-    distance = np.arange(0.0, 1.0 + 0.01, 0.01)*np.pi/2.0
-    assert np.allclose(mesh["Distance"], distance)
 
     mesh = pyvista.CircularArc([-1, 0, 0], [0, 0, 1], [0, 0, 0], normal=[0, 0, 1],
                                polar=[1, 0, 1], negative=True, angle=180)
     assert mesh.n_points
     assert mesh.n_cells
-    distance = np.arange(0.0, 1.0 + 0.01, 0.01)*np.pi*3.0/2.0
-    assert np.allclose(mesh["Distance"], distance)
-
-    mesh = pyvista.CircularArc(pointa, pointb, center, resolution=1)
-    assert mesh.n_points
-    assert mesh.n_cells
-    distance = np.array([0.0, 1.0])
-    assert np.allclose(mesh["Distance"], distance)
 
 
 def test_pyramid():

--- a/tests/test_geometric_objects.py
+++ b/tests/test_geometric_objects.py
@@ -149,16 +149,23 @@ def test_circular_arc():
     distance = np.arange(0.0, 1.0 + 0.01, 0.01)*np.pi/2.0
     assert np.allclose(mesh['Distance'], distance)
 
-    mesh = pyvista.CircularArc([-1, 0, 0], [0, 0, 1], [0, 0, 0], normal=[0, 0, 1],
-                               polar=[1, 0, 1], negative=True, angle=180)
-    assert mesh.n_points
-    assert mesh.n_cells
-    distance = np.arange(0.0, 1.0 + 0.01, 0.01)*np.sqrt(2.0)*np.pi
-    assert np.allclose(mesh['Distance'], distance)
-
     # pointa and pointb are not equidistant from center
     with pytest.raises(ValueError):
         mesh = pyvista.CircularArc([-1, 0, 0], [-0.99, 0.001, 0], [0, 0, 0], 100)
+
+
+def test_circular_arc2():
+    center = [0, 0, 0]
+    normal = [0, 0, 1]
+    polar = [-2.0, 0, 0]
+    angle = 90
+    resolution = 100
+
+    mesh = pyvista.CircularArc2(center, resolution, normal, polar, angle)
+    assert mesh.n_points
+    assert mesh.n_cells
+    distance = np.arange(0.0, 1.0 + 0.01, 0.01)*np.pi
+    assert np.allclose(mesh['Distance'], distance)
 
 
 def test_pyramid():

--- a/tests/test_geometric_objects.py
+++ b/tests/test_geometric_objects.py
@@ -146,11 +146,21 @@ def test_circular_arc():
     mesh = pyvista.CircularArc(pointa, pointb, center, resolution)
     assert mesh.n_points
     assert mesh.n_cells
+    distance = np.arange(0.0, 1.0 + 0.01, 0.01)*np.pi/2.0
+    assert np.allclose(mesh["Distance"], distance)
 
     mesh = pyvista.CircularArc([-1, 0, 0], [0, 0, 1], [0, 0, 0], normal=[0, 0, 1],
                                polar=[1, 0, 1], negative=True, angle=180)
     assert mesh.n_points
     assert mesh.n_cells
+    distance = np.arange(0.0, 1.0 + 0.01, 0.01)*np.pi*3.0/2.0
+    assert np.allclose(mesh["Distance"], distance)
+
+    mesh = pyvista.CircularArc(pointa, pointb, center, resolution=1)
+    assert mesh.n_points
+    assert mesh.n_cells
+    distance = np.array([0.0, 1.0])
+    assert np.allclose(mesh["Distance"], distance)
 
 
 def test_pyramid():

--- a/tests/test_geometric_objects.py
+++ b/tests/test_geometric_objects.py
@@ -156,6 +156,10 @@ def test_circular_arc():
     distance = np.arange(0.0, 1.0 + 0.01, 0.01)*np.sqrt(2.0)*np.pi
     assert np.allclose(mesh['Distance'], distance)
 
+    # pointa and pointb are not equidistant from center
+    with pytest.raises(ValueError):
+        mesh = pyvista.CircularArc([-1, 0, 0], [-0.99, 0.001, 0], [0, 0, 0], 100)
+
 
 def test_pyramid():
     pointa = [1.0, 1.0, 1.0]

--- a/tests/test_geometric_objects.py
+++ b/tests/test_geometric_objects.py
@@ -146,11 +146,15 @@ def test_circular_arc():
     mesh = pyvista.CircularArc(pointa, pointb, center, resolution)
     assert mesh.n_points
     assert mesh.n_cells
+    distance = np.arange(0.0, 1.0 + 0.01, 0.01)*np.pi/2.0
+    assert np.allclose(mesh['Distance'], distance)
 
     mesh = pyvista.CircularArc([-1, 0, 0], [0, 0, 1], [0, 0, 0], normal=[0, 0, 1],
                                polar=[1, 0, 1], negative=True, angle=180)
     assert mesh.n_points
     assert mesh.n_cells
+    distance = np.arange(0.0, 1.0 + 0.01, 0.01)*np.sqrt(2.0)*np.pi
+    assert np.allclose(mesh['Distance'], distance)
 
 
 def test_pyramid():


### PR DESCRIPTION
### Overview

Adding method `plot_over_circular_arc` .

#### Example
Plot the height of a dataset over a circular arc through that dataset
```python
import pyvista as pv
from pyvista import examples

###############################################################################
# Volumetric Mesh
# +++++++++++++++
#
# Add the height scalars to a uniform 3D mesh
mesh = examples.load_uniform()
mesh['height'] = mesh.points[:, 2]

# Make two points at the bounds of the mesh and one at the center to
# construct a circular arc.
a = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[5]]
b = [mesh.bounds[1], mesh.bounds[2], mesh.bounds[4]]
center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]

# Preview how this circular arc intersects this mesh
arc = pv.CircularArc(a, b, center)

p = pv.Plotter()
p.add_mesh(mesh, style="wireframe", color="w")
p.add_mesh(arc, color="b")
p.add_point_labels(
    [a, b], ["A", "B"], font_size=48, point_color="red", text_color="red"
)
p.show()
```
![sphx_glr_plot-over-circular-arc_001](https://user-images.githubusercontent.com/7513610/110189341-1d653980-7e62-11eb-92e9-44b8072f40b0.png)
Run the filter and produce a line plot
```python
###############################################################################
# Run the filter and produce a line plot
mesh.plot_over_circular_arc(a, b, center, resolution=100, scalars='height')
```
![sphx_glr_plot-over-circular-arc_002](https://user-images.githubusercontent.com/7513610/110189414-58676d00-7e62-11eb-9ffb-d1ec51bb91ef.png)

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None

