### PR TITLE
Wrap pyvista_ndarray

### DIFF
--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -123,6 +123,17 @@ def verify_cache_image(plotter):
 
 
 @skip_no_plotting
+def test_plot_pyvista_ndarray(sphere):
+    # verify we can plot pyvista_ndarray
+    pyvista.plot(sphere.points)
+
+    plotter = pyvista.Plotter()
+    plotter.add_points(sphere.points)
+    plotter.add_points(sphere.points + 1)
+    plotter.show()
+
+
+@skip_no_plotting
 def test_plot(tmpdir):
     tmp_dir = tmpdir.mkdir("tmpdir2")
     filename = str(tmp_dir.join('tmp.png'))

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -12,6 +12,7 @@ from .test_filters import DATASETS
 import pyvista
 from pyvista import examples, Texture
 
+HYPOTHESIS_MAX_EXAMPLES = 20
 
 @pytest.fixture()
 def grid():
@@ -181,7 +182,8 @@ def test_copy(grid):
     assert np.all(grid_copy_shallow.points[0] == grid.points[0])
 
 
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture],
+          max_examples=HYPOTHESIS_MAX_EXAMPLES)
 @given(rotate_amounts=n_numbers(4), translate_amounts=n_numbers(3))
 def test_translate_should_match_vtk_transformation(rotate_amounts, translate_amounts, grid):
     trans = vtk.vtkTransform()
@@ -195,6 +197,9 @@ def test_translate_should_match_vtk_transformation(rotate_amounts, translate_amo
     grid_a.transform(trans)
     grid_b.transform(trans.GetMatrix())
     grid_c.transform(pyvista.array_from_vtkmatrix(trans.GetMatrix()))
+
+    # treat INF as NAN (necessary for allclose)
+    grid_a.points[np.isinf(grid_a.points)] = np.nan
     assert np.allclose(grid_a.points, grid_b.points, equal_nan=True)
     assert np.allclose(grid_a.points, grid_c.points, equal_nan=True)
 
@@ -230,7 +235,8 @@ def test_translate_should_fail_bad_points_or_transform(grid):
 
 
 
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture],
+          max_examples=HYPOTHESIS_MAX_EXAMPLES)
 @given(array=arrays(dtype=np.float32, shape=array_shapes(max_dims=5, max_side=5)))
 def test_transform_should_fail_given_wrong_numpy_shape(array, grid):
     assume(array.shape != (4, 4))
@@ -247,7 +253,8 @@ def test_translate_should_translate_grid(grid, axis_amounts):
     assert np.allclose(grid_copy.points, grid_points)
 
 
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture],
+          max_examples=HYPOTHESIS_MAX_EXAMPLES)
 @given(angle=one_of(floats(allow_infinity=False, allow_nan=False), integers()))
 @pytest.mark.parametrize('axis', ('x', 'y', 'z'))
 def test_rotate_should_match_vtk_rotation(angle, axis, grid):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,8 +5,12 @@ import numpy as np
 import pyvista
 
 
+def test_wrap_none():
+    # check against the "None" edge case
+    assert pyvista.wrap(None) is None
+
+
 def test_wrap_pyvista_ndarray(sphere):
-    # sphere = pyvista.Sphere()
     pd = pyvista.wrap(sphere.points)
     assert isinstance(pd, pyvista.PolyData)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,6 +5,12 @@ import numpy as np
 import pyvista
 
 
+def test_wrap_pyvista_ndarray(sphere):
+    # sphere = pyvista.Sphere()
+    pd = pyvista.wrap(sphere.points)
+    assert isinstance(pd, pyvista.PolyData)
+
+
 def test_wrap_trimesh():
     points = [[0, 0, 0], [0, 0, 1], [0, 1, 0]]
     faces = [[0, 1, 2]]


### PR DESCRIPTION
Resolves #1210 by properly wrapping a `pyvista_ndarray`.  The wrapping method needs some more work, but this is sufficient for this release.  The major issue was that we first tested if our input `dataset` had a vtk property, and our `pyvista_ndarray` is basically both (a numpy array that's also a wrapping of a VTK object).  I think it makes sense to treat it identical to a `numpy` array.

Inputs welcome, but this fixes a common problem:
```py
import pyvista
pyvista.plot(pyvista.Sphere().points)
```

Also fixes semi-flaky `hypothesis` test where VTK returns INF and we return NAN.