### PR TITLE
support subtype when in transform

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2748,7 +2748,7 @@ class DataSetFilters:
         res.set_active_scalars(active_scalars_name)
 
         if inplace:
-            if not isinstance(res, type(dataset)):
+            if not isinstance(dataset, type(res)):
                 raise ValueError('Unable to perform in-place transformation. '
                                  f'Input was `{dataset.GetClassName()}` '
                                  f'but output is `{res.GetClassName()}`.')

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -182,8 +182,7 @@ def test_copy(grid):
     assert np.all(grid_copy_shallow.points[0] == grid.points[0])
 
 
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture],
-          max_examples=HYPOTHESIS_MAX_EXAMPLES)
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 @given(rotate_amounts=n_numbers(4), translate_amounts=n_numbers(3))
 def test_translate_should_match_vtk_transformation(rotate_amounts, translate_amounts, grid):
     trans = vtk.vtkTransform()


### PR DESCRIPTION
A closed source project subclasses `pyvista.PolyData`, and I noticed that `transform` now produces the following error:

```
        if inplace:
            if not isinstance(res, type(dataset)):
>               raise ValueError('Unable to perform in-place transformation. '
                                 f'Input was `{dataset.GetClassName()}` '
                                 f'but output is `{res.GetClassName()}`.')
E               ValueError: Unable to perform in-place transformation. Input was `vtkPolyData` but output is `vtkPolyData`.
```

Turns out that the issue is because we're testing against the type of `dataset` instead of the type of `res`.  Or, in other words, `isinstance` supports inheritance, but only in one direction (it seems).  For example:

```py
>>> isinstance(<class>, <subclass>)
False

>>> isinstance(<subclass>, <class>)
True
```

Simple fix for this is to simply reverse the order in our code.
