### PR TITLE
Release 0.29

### DIFF
--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -5,9 +5,17 @@ For example:
 
 version_info = 0, 27, 'dev0'
 
+---
+
+When generating pre-release wheels, use '0rcN', for example:
+
+version_info = 0, 28, '0rc1'
+
+Denotes the first release candidate.
+
 """
 # major, minor, patch
-version_info = 0, 28, 'dev0'
+version_info = 0, 29, '0rc1'
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -15,7 +15,7 @@ Denotes the first release candidate.
 
 """
 # major, minor, patch
-version_info = 0, 29, '0rc1'
+version_info = 0, 29, 0
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
### Release 0.29

We keep adding features and it's time for another minor release, with about 50 PRs merged since the 0.28.  Thanks again to all who contributed!

The idea behind these (sorta) monthly releases is to balance keeping a stable API and PyPi package with adding new features and bug-fixes.  We're likely to break something with each release, but since we're following [Trunk Based Development](https://trunkbaseddevelopment.com/), we can always apply a hotfix to that release branch without having to create a complete new release including all the features added to master.

Having a 4-6 week cadence to these releases keeps things fresh without introuducing signifiant instability in our "stable" packages.  Let me know on slack if the release tempo nees to be sped up or slowed down.

---


### Release Candidate Testing
@pyvista/developers and any willing testers, the latest release candidate package can be downloaded from pypi with:

```
pip install pyvista==0.29.0rc1
```

See:

https://pypi.org/project/pyvista/0.29.0rc1/


### Proposed Release Notes:

Please propose changes if anything here needs to be updated:

---

# Release 0.29: Under the hood changes for VTK9

This minor release of ``pyvista==0.29.0`` includes a variety of changes and new features.  The most major is improving our load-time by only loading in the VTK libraries used through lazy loading or selective imports using `vtkmodules``.  It was quite an overhaul and should improve load time, reduce memory usage, and potentially the size of the frozen package.

Other new features and bug-fixes include:


#### New Features
- add subdivision option to extract_surface (#1174)
- Add a silhouette parameter to add_mesh (#1211)
- add new colors (#1173)
- Add pickle support to DataObject (#1143)
- Add where_is in BasePlotter (#1175)
- Create an explicit structured grid (#1133)

#### Documentation
- Fix and update some sphinx docs (#1149)
- :memo: Add new function to geometric.rst (#1170)
- Update what-is-a-mesh.rst (#1176)
- Fix docstring in add_point_labels (#1188)

#### API Changes
- Improve PolyData Import (#1213)
- Use vtkTransformFilter in DataSet.transform() (#1166)
- Improve Exodus Reader (#1191)
- Add bounds in reset_camera (#1161)
- Add option to hide plane widget vector (#1150)
- add origin kwarg to plotter.add_legend (#1153)
- Expose start_xvfb (#1151)
- Add render=True in add_point_labels (#1152)
- add transforms3d (#1142)

#### Bug Fixes
- Fix the "reset camera" effect when parallel projection is enabled/disabled (#1221)
- Wrap pyvista_ndarray (#1222)
- Fix vtk not defined (#1217)
- plot_over_line should fail if scalar name does not exist (#1214)
- Fix labels (#1201)
- remove faulthandler (#1187)
- Fix log scale in scalar bar (#1183)
- Fix bugs in enable_cell_picking (#1158)
- fix add_actor (#1182)
- Fix Binary Writer (#1148)
- Reimplement Light.copy to get around VTK8.1 bug (#1137)
- Update enable_cell_picking (#1157)
- Update the active scalar bar when cmap is changed (#1169)
- Fix scalar bar moving upward (#1171)

#### Miscellaneous/Testing
- Minor fix of plot_over_line's test #525 (#1216)
- common --> dataset (#1209)
- :art: Minor fix of format of the code. (#1199)
- Fix doctest failure in BasePlotter.where_is (#1192)
- Use vtkmodules (#1163)
- Move Common, DataObject to dataset.py, dataobject.py (#1160)
- Partially add type hints to /core/ (#1145)
- improve import speed (#1156)

#### Contributors (alphabetical)

- @adeak
- @akaszynski
- @banesullivan
- @d-chambers
- @GuillaumeFavelier
- @JevinJ
- @Keou0007
- @RichardScottOZ
- @rodrigomologni
- @tkoyama010
- @whophil
- @yienyien
