### PR TITLE
improve performance of is_all_triangles

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -335,7 +335,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         if not len(faces) or len(self.lines) > 0 or len(self.verts) > 0:
             return False
 
-        # all we have are faces, check if all faces are indeed triangles
+        # All we have are faces, check if all faces are indeed triangles
         if faces.size % 4 == 0:
             return (faces[::4] == 3).all()
         return False

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -317,7 +317,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
 
     @property
     def faces(self):
-        """Return a pointer to the points as a numpy object."""
+        """Return a pointer to the faces as a numpy object."""
         return _vtk.vtk_to_numpy(self.GetPolys().GetData())
 
     @faces.setter
@@ -329,12 +329,16 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
             self.SetPolys(CellArray(faces))
 
     def is_all_triangles(self):
-        """Return True if all the faces of the polydata are triangles."""
+        """Return ``True`` if all the faces of the ``PolyData`` are triangles."""
         # Need to make sure there are only face cells and no lines/verts
-        if not len(self.faces) or len(self.lines) > 0 or len(self.verts) > 0:
+        faces = self.faces  # grab once as this takes time to build
+        if not len(faces) or len(self.lines) > 0 or len(self.verts) > 0:
             return False
-        # All we have are faces, check if all faces are indeed triangles
-        return self.faces.size % 4 == 0 and (self.faces.reshape(-1, 4)[:, 0] == 3).all()
+
+        # all we have are faces, check if all faces are indeed triangles
+        if faces.size % 4 == 0:
+            return (faces[::4] == 3).all()
+        return False
 
     def __sub__(self, cutting_mesh):
         """Subtract two meshes."""


### PR DESCRIPTION
### Improve performance of ``is_all_triangles``.

Our ``is_all_triangles`` checks the ``faces`` array to determine if each face in ``PolyData`` is indeed a triangle.  However, when we check this, we rebuild the ``faces`` array each time, which in ``vtk>=9.0`` is rebuit within each time ``GetPolys`` is called.

To improve performance, we simply cache `faces` and then verify the shape and content:

### Test code:

```py
import pyvista as pv
from pyvista import examples
mesh = examples.download_nefertiti()
```

#### This branch

```py
>>> mesh.is_all_triangles()
# 18.5 ms ± 555 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

#### Master

```py
>>> mesh.is_all_triangles()
# 46.6 ms ± 103 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
