### PR TITLE
Allow for an extension to be specified in pyvista.read(), rework reading

### DIFF
--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -62,9 +62,6 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
     # Bind pyvista.plotting.plot to the object
     plot = pyvista.plot
-    _READERS = {'.vtm': _vtk.vtkXMLMultiBlockDataReader,
-                '.vtmb': _vtk.vtkXMLMultiBlockDataReader,
-                '.case': _vtk.vtkGenericEnSightReader}
     _WRITERS = dict.fromkeys(['.vtm', '.vtmb'], _vtk.vtkXMLMultiBlockDataWriter)
 
     def __init__(self, *args, **kwargs) -> None:
@@ -83,7 +80,7 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
                 for block in args[0]:
                     self.append(block)
             elif isinstance(args[0], (str, pathlib.Path)):
-                self._from_file(args[0])
+                self._from_file(args[0], **kwargs)
             elif isinstance(args[0], dict):
                 idx = 0
                 for key, block in args[0].items():

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -70,7 +70,7 @@ class DataObject:
         self._post_file_load_processing()
 
     def _post_file_load_processing(self):
-        """Executed after loading a dataset from file, to be optionally overridden by subclasses."""
+        """Execute after loading a dataset from file, to be optionally overridden by subclasses."""
         pass
 
     def save(self, filename: str, binary=True):

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -24,7 +24,6 @@ DEFAULT_VECTOR_KEY = '_vectors'
 class DataObject:
     """Methods common to all wrapped data objects."""
 
-    _READERS: Dict[str, Union[Type[_vtk.vtkXMLReader], Type[_vtk.vtkDataReader]]] = {}
     _WRITERS: Dict[str, Union[Type[_vtk.vtkXMLWriter], Type[_vtk.vtkDataWriter]]] = {}
 
     def __init__(self, *args, **kwargs) -> None:
@@ -60,32 +59,18 @@ class DataObject:
         Binary files load much faster than ASCII.
 
         """
-        if self._READERS is None:
-            raise NotImplementedError(f'{self.__class__.__name__} readers are not specified,'
-                                      ' this should be a dict of (file extension: vtkReader type)')
-
-        file_path = Path(filename)
-        file_path = file_path.expanduser()
-        file_path = file_path.resolve()
-        if not file_path.exists():
-            raise FileNotFoundError(f'File {filename} does not exist')
-
-        file_ext = file_path.suffix
-        if file_ext not in self._READERS:
-            valid_extensions = ', '.join(self._READERS.keys())
-            raise ValueError(f'Invalid file extension for {self.__class__.__name__}({file_ext}).'
-                             f' Must be one of: {valid_extensions}')
-
-        reader = self._READERS[file_ext]()
-        if file_ext == ".case":
-            reader.SetCaseFileName(str(file_path))
-        else:
-            reader.SetFileName(str(file_path))
-        reader.Update()
-        return reader.GetOutputDataObject(0)
+        return pyvista.read(filename)
 
     def _from_file(self, filename: Union[str, Path]):
-        self.shallow_copy(self._load_file(filename))
+        data = self._load_file(filename)
+        if not isinstance(self, type(data)):
+            raise RuntimeError
+        self.shallow_copy(data)
+        self._post_file_load_processing()
+
+    def _post_file_load_processing(self):
+        """Executed after loading a dataset from file, to be optionally overridden by subclasses."""
+        pass
 
     def save(self, filename: str, binary=True):
         """Save this vtk object to file.

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -45,24 +45,8 @@ class DataObject:
         """Overwrite this mesh with the given mesh as a deep copy."""
         return self.DeepCopy(to_copy)
 
-    def _load_file(self, filename: Union[str, Path]) -> _vtk.vtkDataObject:
-        """Generically load a vtk object from file.
-
-        Parameters
-        ----------
-        filename : str, pathlib.Path
-            Filename of object to be loaded.  File/reader type is inferred from the
-            extension of the filename.
-
-        Notes
-        -----
-        Binary files load much faster than ASCII.
-
-        """
-        return pyvista.read(filename)
-
-    def _from_file(self, filename: Union[str, Path]):
-        data = self._load_file(filename)
+    def _from_file(self, filename: Union[str, Path], **kwargs):
+        data = pyvista.read(filename, **kwargs)
         if not isinstance(self, type(data)):
             raise ValueError(f'Reading file returned data of `{data.GetClassName()}`, '
                              f'but `{self.GetClassName()}` was expected.')

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -64,7 +64,8 @@ class DataObject:
     def _from_file(self, filename: Union[str, Path]):
         data = self._load_file(filename)
         if not isinstance(self, type(data)):
-            raise RuntimeError
+            raise ValueError(f'Reading file returned data of `{data.GetClassName()}`, '
+                             f'but `{self.GetClassName()}` was expected.')
         self.shallow_copy(data)
         self._post_file_load_processing()
 

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -80,8 +80,6 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
 
     """
 
-    _READERS = {'.vtk': _vtk.vtkRectilinearGridReader,
-                '.vtr': _vtk.vtkXMLRectilinearGridReader}
     _WRITERS = {'.vtk': _vtk.vtkRectilinearGridWriter,
                 '.vtr': _vtk.vtkXMLRectilinearGridWriter}
 
@@ -278,7 +276,6 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
 
     """
 
-    _READERS = {'.vtk': _vtk.vtkDataSetReader, '.vti': _vtk.vtkXMLImageDataReader}
     _WRITERS = {'.vtk': _vtk.vtkDataSetWriter, '.vti': _vtk.vtkXMLImageDataWriter}
 
     def __init__(self, *args, **kwargs):

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -285,7 +285,6 @@ class Texture(_vtk.vtkTexture, DataObject):
     def __init__(self, *args, **kwargs):
         """Initialize the texture."""
         super().__init__(*args, **kwargs)
-        assert_empty_kwargs(**kwargs)
 
         if len(args) == 1:
             if isinstance(args[0], _vtk.vtkTexture):
@@ -295,13 +294,13 @@ class Texture(_vtk.vtkTexture, DataObject):
             elif isinstance(args[0], _vtk.vtkImageData):
                 self._from_image_data(args[0])
             elif isinstance(args[0], str):
-                self._from_file(filename=args[0])
+                self._from_file(filename=args[0], **kwargs)
             else:
                 raise TypeError(f'Texture unable to be made from ({type(args[0])})')
 
-    def _from_file(self, filename):
+    def _from_file(self, filename, **kwargs):
         try:
-            image = pyvista.read(filename)
+            image = pyvista.read(filename, **kwargs)
             if image.GetNumberOfPoints() < 2:
                 raise ValueError("Problem reading the image with VTK.")
             self._from_image_data(image)

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -282,21 +282,6 @@ class Table(_vtk.vtkTable, DataObject):
 class Texture(_vtk.vtkTexture, DataObject):
     """A helper class for vtkTextures."""
 
-    _READERS = {'.bmp': _vtk.vtkBMPReader,
-                '.dem': _vtk.vtkDEMReader,
-                '.dcm': _vtk.vtkDICOMImageReader,
-                '.img': _vtk.vtkDICOMImageReader,
-                '.jpeg': _vtk.vtkJPEGReader,
-                '.jpg': _vtk.vtkJPEGReader,
-                '.mhd': _vtk.vtkMetaImageReader,
-                '.nrrd': _vtk.vtkNrrdReader,
-                '.nhdr': _vtk.vtkNrrdReader,
-                '.png': _vtk.vtkPNGReader,
-                '.pnm': _vtk.vtkPNMReader,
-                '.slc': _vtk.vtkSLCReader,
-                '.tiff': _vtk.vtkTIFFReader,
-                '.tif': _vtk.vtkTIFFReader}
-
     def __init__(self, *args, **kwargs):
         """Initialize the texture."""
         super().__init__(*args, **kwargs)

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -316,7 +316,7 @@ class Texture(_vtk.vtkTexture, DataObject):
 
     def _from_file(self, filename):
         try:
-            image = self._load_file(filename)
+            image = pyvista.read(filename)
             if image.GetNumberOfPoints() < 2:
                 raise ValueError("Problem reading the image with VTK.")
             self._from_image_data(image)

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -297,7 +297,7 @@ class Texture(_vtk.vtkTexture, DataObject):
             elif isinstance(args[0], str):
                 self._from_file(filename=args[0])
             else:
-                raise TypeError(f'Table unable to be made from ({type(args[0])})')
+                raise TypeError(f'Texture unable to be made from ({type(args[0])})')
 
     def _from_file(self, filename):
         try:

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -200,7 +200,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
                 '.vtk': _vtk.vtkPolyDataWriter}
 
     def __init__(self, var_inp=None, faces=None, n_faces=None, lines=None,
-                 n_lines=None, deep=False) -> None:
+                 n_lines=None, deep=False, force_ext=None) -> None:
         """Initialize the polydata."""
         local_parms = locals()
         super().__init__()
@@ -216,7 +216,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
                 if local_parms[kwarg]:
                     raise ValueError('No other arguments should be set when first '
                                      'parameter is a string')
-            self._from_file(var_inp)  # is filename
+            self._from_file(var_inp, force_ext=force_ext)  # is filename
 
             return
 
@@ -564,7 +564,7 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
                     self.shallow_copy(args[0])
 
             elif isinstance(args[0], (str, pathlib.Path)):
-                self._from_file(args[0])
+                self._from_file(args[0], **kwargs)
 
             elif isinstance(args[0], _vtk.vtkStructuredGrid):
                 vtkappend = _vtk.vtkAppendFilter()
@@ -953,7 +953,7 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
             if isinstance(args[0], _vtk.vtkStructuredGrid):
                 self.deep_copy(args[0])
             elif isinstance(args[0], (str, pathlib.Path)):
-                self._from_file(args[0])
+                self._from_file(args[0], **kwargs)
 
         elif len(args) == 3:
             arg0_is_arr = isinstance(args[0], np.ndarray)

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -952,7 +952,7 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
         if len(args) == 1:
             if isinstance(args[0], _vtk.vtkStructuredGrid):
                 self.deep_copy(args[0])
-            elif isinstance(args[0], str):
+            elif isinstance(args[0], (str, pathlib.Path)):
                 self._from_file(args[0])
 
         elif len(args) == 3:
@@ -1180,7 +1180,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
             elif isinstance(arg0, _vtk.vtkUnstructuredGrid):
                 grid = arg0.cast_to_explicit_structured_grid()
                 self.deep_copy(grid)
-            elif isinstance(arg0, str):
+            elif isinstance(arg0, (str, pathlib.Path)):
                 grid = UnstructuredGrid(arg0)
                 grid = grid.cast_to_explicit_structured_grid()
                 self.deep_copy(grid)

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -194,11 +194,6 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
 
     """
 
-    _READERS = {'.ply': _vtk.vtkPLYReader,
-                '.stl': _vtk.vtkSTLReader,
-                '.vtk': _vtk.vtkPolyDataReader,
-                '.vtp': _vtk.vtkXMLPolyDataReader,
-                '.obj': _vtk.vtkOBJReader}
     _WRITERS = {'.ply': _vtk.vtkPLYWriter,
                 '.vtp': _vtk.vtkXMLPolyDataWriter,
                 '.stl': _vtk.vtkSTLWriter,
@@ -222,12 +217,6 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
                     raise ValueError('No other arguments should be set when first '
                                      'parameter is a string')
             self._from_file(var_inp)  # is filename
-
-            # When loading files with just point arrays, create and
-            # set the polydata vertices
-            if self.n_points > 0 and self.n_cells == 0:
-                verts = self._make_vertex_cells(self.n_points)
-                self.verts = CellArray(verts, self.n_points, deep)
 
             return
 
@@ -273,6 +262,14 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         if lines is not None:
             # here we use CellArray since we must specify deep and n_lines
             self.lines = CellArray(lines, n_lines, deep)
+
+    def _post_file_load_processing(self):
+        """Executed after loading a PolyData from file."""
+        # When loading files with just point arrays, create and
+        # set the polydata vertices
+        if self.n_points > 0 and self.n_cells == 0:
+            verts = self._make_vertex_cells(self.n_points)
+            self.verts = CellArray(verts, self.n_points, deep=False)
 
     def __repr__(self):
         """Return the standard representation."""
@@ -549,8 +546,6 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
 
     """
 
-    _READERS = {'.vtu': _vtk.vtkXMLUnstructuredGridReader,
-                '.vtk': _vtk.vtkUnstructuredGridReader}
     _WRITERS = {'.vtu': _vtk.vtkXMLUnstructuredGridWriter,
                 '.vtk': _vtk.vtkUnstructuredGridWriter}
 
@@ -947,8 +942,6 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
 
     """
 
-    _READERS = {'.vtk': _vtk.vtkStructuredGridReader,
-                '.vts': _vtk.vtkXMLStructuredGridReader}
     _WRITERS = {'.vtk': _vtk.vtkStructuredGridWriter,
                 '.vts': _vtk.vtkXMLStructuredGridWriter}
 
@@ -1171,8 +1164,6 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
 
     """
 
-    _READERS = {'.vtu': _vtk.vtkXMLUnstructuredGridReader,
-                '.vtk': _vtk.vtkUnstructuredGridReader}
     _WRITERS = {'.vtu': _vtk.vtkXMLUnstructuredGridWriter,
                 '.vtk': _vtk.vtkUnstructuredGridWriter}
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -264,7 +264,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
             self.lines = CellArray(lines, n_lines, deep)
 
     def _post_file_load_processing(self):
-        """Executed after loading a PolyData from file."""
+        """Execute after loading a PolyData from file."""
         # When loading files with just point arrays, create and
         # set the polydata vertices
         if self.n_points > 0 and self.n_cells == 0:

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -67,7 +67,7 @@ class Observer:
             self.log_message(kind, alert)
 
     def has_event_occurred(self):
-        """Ask self if an error has occurred since last querried.
+        """Ask self if an error has occurred since last queried.
 
         This resets the observer's status.
 

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -135,7 +135,7 @@ def standard_reader_routine(reader, filename, attrs=None):
         if hasattr(reader, 'SetCaseFileName'):
             reader.SetCaseFileName(filename)
         else:
-        reader.SetFileName(filename)
+            reader.SetFileName(filename)
     # Apply any attributes listed
     for name, args in attrs.items():
         attr = getattr(reader, name)

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -193,6 +193,11 @@ def read(filename, attrs=None, force_ext=None, file_format=None):
         arguments passed to those calls. If you do not have any
         attributes to call, pass ``None`` as the value.
 
+    force_ext: str, optional
+        If specified, the reader will be chosen by an extension which
+        is different to its actual extension. For example, ``'.vts'``,
+        ``'.vtu'``.
+
     file_format : str, optional
         Format of file to read with meshio.
 
@@ -212,6 +217,9 @@ def read(filename, attrs=None, force_ext=None, file_format=None):
 
     >>> mesh = pyvista.read("mesh.obj")  # doctest:+SKIP
     """
+    if file_format is not None and force_ext is not None:
+        raise ValueError('Only one of `file_format` and `force_ext` may be specified.')
+
     if isinstance(filename, (list, tuple)):
         multi = pyvista.MultiBlock()
         for each in filename:
@@ -251,6 +259,11 @@ def read(filename, attrs=None, force_ext=None, file_format=None):
             reader = get_reader(filename, force_ext=ext)
             return standard_reader_routine(reader, filename)
         except KeyError:
+            # Don't fall back to meshio if using `force_ext`, which is really
+            # just intended to be used with the native PyVista readers
+            if force_ext is not None:
+                from meshio._exceptions import ReadError
+                raise ReadError
             # Attempt read with meshio
             try:
                 from meshio._exceptions import ReadError

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -153,23 +153,12 @@ def standard_reader_routine(reader, filename, attrs=None):
     # Perform the read
     reader.Update()
 
-    data = pyvista.wrap(reader.GetOutputDataObject(0))
-    data._post_file_load_processing()
-
     # Check reader for errors
     if observer.has_event_occurred():
         raise IOError(f'Error loading file using `{reader.GetClassName()}`.\n\t{observer.get_message()}')
 
-    # Check if data is empty - observer doesn't seem to work reliably?
-    data_empty = False
-    if isinstance(data, pyvista.MultiBlock):
-        data_empty = len(data) == 0
-    elif data.n_points == 0:
-        data_empty = True
-
-    if data_empty:
-        raise IOError(f'Error loading file using `{reader.GetClassName()}`.\n\tReturned empty dataset.')
-
+    data = pyvista.wrap(reader.GetOutputDataObject(0))
+    data._post_file_load_processing()
     return data
 
 

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -75,6 +75,13 @@ if (VTK_MAJOR >= 8 and VTK_MINOR >= 2):
         pass
 
 
+def _get_ext_force(filename, force_ext=None):
+    if force_ext:
+        return str(force_ext).lower()
+    else:
+        return get_ext(filename)
+
+
 def get_ext(filename):
     """Extract the extension of the filename."""
     ext = os.path.splitext(filename)[1].lower()
@@ -83,10 +90,7 @@ def get_ext(filename):
 
 def get_reader(filename, force_ext=None):
     """Get the corresponding reader based on file extension and instantiates it."""
-    if not force_ext:
-        ext = get_ext(filename)
-    else:
-        ext = force_ext
+    ext = _get_ext_force(filename, force_ext=force_ext)
     return READERS[ext]() # Get and instantiate the reader
 
 
@@ -234,10 +238,8 @@ def read(filename, attrs=None, force_ext=None, file_format=None):
     filename = os.path.abspath(os.path.expanduser(str(filename)))
     if not os.path.isfile(filename):
         raise FileNotFoundError(f'File ({filename}) not found')
-    if force_ext:
-        ext = str(force_ext).lower()
-    else:
-        ext = get_ext(filename)
+
+    ext = _get_ext_force(filename, force_ext)
 
     # Read file using meshio.read if file_format is present
     if file_format:

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -2,6 +2,7 @@
 
 import pathlib
 import os
+import warnings
 
 import numpy as np
 
@@ -129,6 +130,9 @@ def standard_reader_routine(reader, filename, attrs=None):
         value.
 
     """
+    observer = pyvista.utilities.errors.Observer()
+    observer.observe(reader)
+
     if attrs is None:
         attrs = {}
     if not isinstance(attrs, dict):
@@ -149,6 +153,11 @@ def standard_reader_routine(reader, filename, attrs=None):
             attr()
     # Perform the read
     reader.Update()
+
+    # Check reader for errors
+    if observer.has_event_occurred():
+        warnings.warn(f'The VTK reader `{reader.GetClassName()}` raised an error while reading the file.\n'
+                      f'\t"{observer.get_message()}"')
 
     data = pyvista.wrap(reader.GetOutputDataObject(0))
     data._post_file_load_processing()

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -129,8 +129,6 @@ def standard_reader_routine(reader, filename, attrs=None):
         value.
 
     """
-    observer = pyvista.utilities.errors.Observer()
-    observer.observe(reader)
 
     if attrs is None:
         attrs = {}
@@ -152,10 +150,6 @@ def standard_reader_routine(reader, filename, attrs=None):
             attr()
     # Perform the read
     reader.Update()
-
-    # Check reader for errors
-    if observer.has_event_occurred():
-        raise IOError(f'Error loading file using `{reader.GetClassName()}`.\n\t{observer.get_message()}')
 
     data = pyvista.wrap(reader.GetOutputDataObject(0))
     data._post_file_load_processing()

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -238,6 +238,13 @@ def read(filename, attrs=None, force_ext=None, file_format=None):
     if attrs is not None:
         reader = get_reader(filename, force_ext=ext)
         return standard_reader_routine(reader, filename, attrs=attrs)
+    elif ext in ['.e', '.exo']:
+        return read_exodus(filename)
+    elif ext in ['.vtk']:
+        # Attempt to use the legacy reader...
+        return read_legacy(filename)
+    elif ext in ['.jpeg', '.jpg']:
+        return pyvista.Texture(filename).to_image()
     else:
         # Attempt find a reader in the readers mapping
         try:

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -126,7 +126,8 @@ def standard_reader_routine(reader, filename, attrs=None):
 
     """
     observer = pyvista.utilities.errors.Observer()
-    reader.AddObserver('ErrorEvent', observer)
+    observer.observe(reader)
+
     if attrs is None:
         attrs = {}
     if not isinstance(attrs, dict):
@@ -152,7 +153,7 @@ def standard_reader_routine(reader, filename, attrs=None):
     if observer.has_event_occurred():
         raise IOError(f'Error loading file using `{reader.GetClassName()}`.\n\t{observer.get_message()}')
 
-    data =  pyvista.wrap(reader.GetOutputDataObject(0))
+    data = pyvista.wrap(reader.GetOutputDataObject(0))
     data._post_file_load_processing()
     return data
 

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -133,9 +133,9 @@ def standard_reader_routine(reader, filename, attrs=None):
     if not isinstance(attrs, dict):
         raise TypeError('Attributes must be a dictionary of name and arguments.')
     if filename is not None:
-        if hasattr(reader, 'SetCaseFileName'):
+        try:
             reader.SetCaseFileName(filename)
-        else:
+        except AttributeError:
             reader.SetFileName(filename)
     # Apply any attributes listed
     for name, args in attrs.items():

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -132,6 +132,9 @@ def standard_reader_routine(reader, filename, attrs=None):
     if not isinstance(attrs, dict):
         raise TypeError('Attributes must be a dictionary of name and arguments.')
     if filename is not None:
+        if hasattr(reader, 'SetCaseFileName'):
+            reader.SetCaseFileName(filename)
+        else:
         reader.SetFileName(filename)
     # Apply any attributes listed
     for name, args in attrs.items():

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -129,7 +129,6 @@ def standard_reader_routine(reader, filename, attrs=None):
         value.
 
     """
-
     if attrs is None:
         attrs = {}
     if not isinstance(attrs, dict):

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -252,8 +252,6 @@ def read(filename, attrs=None, force_ext=None, file_format=None):
     elif ext in ['.vtk']:
         # Attempt to use the legacy reader...
         return read_legacy(filename)
-    elif ext in ['.jpeg', '.jpg']:
-        return pyvista.Texture(filename).to_image()
     else:
         # Attempt find a reader in the readers mapping
         try:

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -153,12 +153,23 @@ def standard_reader_routine(reader, filename, attrs=None):
     # Perform the read
     reader.Update()
 
+    data = pyvista.wrap(reader.GetOutputDataObject(0))
+    data._post_file_load_processing()
+
     # Check reader for errors
     if observer.has_event_occurred():
         raise IOError(f'Error loading file using `{reader.GetClassName()}`.\n\t{observer.get_message()}')
 
-    data = pyvista.wrap(reader.GetOutputDataObject(0))
-    data._post_file_load_processing()
+    # Check if data is empty - observer doesn't seem to work reliably?
+    data_empty = False
+    if isinstance(data, pyvista.MultiBlock):
+        data_empty = len(data) == 0
+    elif data.n_points == 0:
+        data_empty = True
+
+    if data_empty:
+        raise IOError(f'Error loading file using `{reader.GetClassName()}`.\n\tReturned empty dataset.')
+
     return data
 
 

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -259,7 +259,7 @@ def test_multi_io_erros(tmpdir):
     with pytest.raises(FileNotFoundError):
         _ = MultiBlock('foo.vtm')
     # Load bad extension
-    with pytest.raises(ValueError):
+    with pytest.raises(IOError):
         _ = MultiBlock(bad_ext_name)
 
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -719,7 +719,7 @@ def test_cast_uniform_to_rectilinear():
 
 
 @pytest.mark.parametrize('binary', [True, False])
-@pytest.mark.parametrize('extension', pyvista.core.grid.RectilinearGrid._READERS)
+@pytest.mark.parametrize('extension', ['.vtk', '.vtr'])
 def test_save_rectilinear(extension, binary, tmpdir):
     filename = str(tmpdir.mkdir("tmpdir").join(f'tmp.{extension}'))
     ogrid = examples.load_rectilinear()
@@ -740,7 +740,7 @@ def test_save_rectilinear(extension, binary, tmpdir):
 
 
 @pytest.mark.parametrize('binary', [True, False])
-@pytest.mark.parametrize('extension', pyvista.core.grid.UniformGrid._READERS)
+@pytest.mark.parametrize('extension', ['.vtk', '.vti'])
 def test_save_uniform(extension, binary, tmpdir):
     filename = str(tmpdir.mkdir("tmpdir").join(f'tmp.{extension}'))
     ogrid = examples.load_uniform()

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -352,7 +352,7 @@ def test_pathlib_read_write(tmpdir, hexbeam):
 
 def test_init_bad_filename():
     filename = os.path.join(test_path, 'test_grid.py')
-    with pytest.raises(ValueError):
+    with pytest.raises(IOError):
         grid = pyvista.UnstructuredGrid(filename)
 
     with pytest.raises(FileNotFoundError):
@@ -528,7 +528,7 @@ def test_load_structured_bad_filename():
         pyvista.StructuredGrid('not a file')
 
     filename = os.path.join(test_path, 'test_grid.py')
-    with pytest.raises(ValueError):
+    with pytest.raises(IOError):
         grid = pyvista.StructuredGrid(filename)
 
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -532,6 +532,37 @@ def test_load_structured_bad_filename():
         grid = pyvista.StructuredGrid(filename)
 
 
+def test_instantiate_by_filename():
+    ex = examples
+
+    # actual mapping of example file to datatype
+    fname_to_right_type = {
+        ex.antfile: pyvista.PolyData,
+        ex.planefile: pyvista.PolyData,
+        ex.hexbeamfile: pyvista.UnstructuredGrid,
+        ex.spherefile: pyvista.PolyData,
+        ex.uniformfile: pyvista.UniformGrid,
+        ex.rectfile: pyvista.RectilinearGrid
+    }
+
+    # a few combinations of wrong type
+    fname_to_wrong_type = {
+        ex.antfile: pyvista.UnstructuredGrid,   # actual data is PolyData
+        ex.planefile: pyvista.StructuredGrid,   # actual data is PolyData
+        ex.rectfile: pyvista.UnstructuredGrid,  # actual data is StructuredGrid
+    }
+
+    # load the files into the right types
+    for fname, right_type in fname_to_right_type.items():
+        data = right_type(fname)
+        assert data.n_points > 0
+
+    # load the files into the wrong types
+    for fname, wrong_type in fname_to_wrong_type.items():
+        with pytest.raises(ValueError):
+            data = wrong_type(fname)
+
+
 def test_create_rectilinear_grid_from_specs():
     # 3D example
     xrng = np.arange(-10, 10, 2)

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -172,7 +172,7 @@ def test_invalid_file():
     with pytest.raises(FileNotFoundError):
         pyvista.PolyData('file.bad')
 
-    with pytest.raises(ValueError):
+    with pytest.raises(IOError):
         filename = os.path.join(test_path, 'test_polydata.py')
         pyvista.PolyData(filename)
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -155,16 +155,6 @@ def test_pyvista_read_exodus(read_exodus_mock):
     assert filename == ex.globefile
 
 
-@mock.patch('pyvista.Texture')
-def test_pyvista_read_texture(texture_mock):
-    # check that reading a file with extension .jpg calls Texture constructor
-    # use the globefile as a dummy because pv.read() checks for the existence of the file
-    pyvista.read(ex.globefile, force_ext='.jpg')
-    args, kwargs = texture_mock.call_args
-    filename = args[0]
-    assert filename == ex.globefile
-
-
 @pytest.mark.parametrize('auto_detect', (True, False))
 @mock.patch('pyvista.utilities.fileio.standard_reader_routine')
 def test_read_plot3d(srr_mock, auto_detect):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -106,17 +106,19 @@ def test_read_force_ext(tmpdir):
 
 def test_read_force_ext_wrong_extension(tmpdir):
     # try to read a .vtu file as .vts
-    # vtkXMLStructuredGridReader throws an error about the validity of the XML file
+    # vtkXMLStructuredGridReader throws a VTK error about the validity of the XML file
+    # the returned dataset is empty
     fname = tmpdir / 'airplane.vtu'
     ex.load_airplane().cast_to_unstructured_grid().save(fname)
-    with pytest.raises(IOError):
-        fileio.read(fname, force_ext='.vts')
+    data = fileio.read(fname, force_ext='.vts')
+    assert data.n_points == 0
 
     # try to read a .ply file as .vtm
-    # vtkXMLMultiBlockDataReader throws an error about the validity of the XML file
+    # vtkXMLMultiBlockDataReader throws a VTK error about the validity of the XML file
+    # the returned dataset is empty
     fname = ex.planefile
-    with pytest.raises(IOError):
-        fileio.read(fname, force_ext='.vtm')
+    data = fileio.read(fname, force_ext='.vtm')
+    assert len(data) == 0
 
 
 @mock.patch('pyvista.utilities.fileio.standard_reader_routine')

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -135,6 +135,36 @@ def test_read_legacy(srr_mock):
         pyvista.read_legacy('legacy.vtk')
 
 
+@mock.patch('pyvista.utilities.fileio.read_legacy')
+def test_pyvista_read_legacy(read_legacy_mock):
+    # check that reading a file with extension .vtk calls `read_legacy`
+    # use the globefile as a dummy because pv.read() checks for the existence of the file
+    pyvista.read(ex.globefile)
+    args, kwargs = read_legacy_mock.call_args
+    filename = args[0]
+    assert filename == ex.globefile
+
+
+@mock.patch('pyvista.utilities.fileio.read_exodus')
+def test_pyvista_read_exodus(read_exodus_mock):
+    # check that reading a file with extension .e calls `read_exodus`
+    # use the globefile as a dummy because pv.read() checks for the existence of the file
+    pyvista.read(ex.globefile, force_ext='.e')
+    args, kwargs = read_exodus_mock.call_args
+    filename = args[0]
+    assert filename == ex.globefile
+
+
+@mock.patch('pyvista.Texture')
+def test_pyvista_read_texture(texture_mock):
+    # check that reading a file with extension .jpg calls Texture constructor
+    # use the globefile as a dummy because pv.read() checks for the existence of the file
+    pyvista.read(ex.globefile, force_ext='.jpg')
+    args, kwargs = texture_mock.call_args
+    filename = args[0]
+    assert filename == ex.globefile
+
+
 @pytest.mark.parametrize('auto_detect', (True, False))
 @mock.patch('pyvista.utilities.fileio.standard_reader_routine')
 def test_read_plot3d(srr_mock, auto_detect):


### PR DESCRIPTION
### Overview

Resolves #1227, enabling user to specify a specific reader via `pyvista.read(my_file, force_ext='.vts')`. Reworks the reader logic a bit to do so. This is entirely open for discussion.

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details
The mapping for file extension to reader type was partially duplicated in `pyvista.read()` and in the individual data structure class definitions (using `_READERS` dict). In addition, `DataObject._load_file()` was basically doing the same thing as `_standard_reader_routine()`.

In this PR, `_READERS` is removed entirely. `DataObject._load_file()` delegates to `pyvista.read()`, and all determination of the appropriate file type for a given extension is handled by that method.

One side effect is that the file extension for any particular data object cannot be validated directly. In the current version of PyVista, the following would throw an error by noting that `.vtm` is not an appropriate extension for UnstructuredGrid.
```python
pv.UnstructuredGrid('my.vtm')
```
On this branch, a data object has no awareness of its "appropriate" file extensions, and will instead load `my.vtm` using `pyvista.read()`, note that the data output is incorrect (MultiBlock instead of UnstructuredGrid), and then raise ValueError.

This PR also adds an error observer into the reader class used by `standard_reader_routine()`. If the VTK reader throws a VTK error, then a Python warning is raised. ~~This is more strict than previous behavior, which would permit read errors and likely return empty datasets.~~
