### PR TITLE
Add fname option to plot_over methods

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2085,7 +2085,7 @@ class DataSetFilters:
 
     def plot_over_line(dataset, pointa, pointb, resolution=None, scalars=None,
                        title=None, ylabel=None, figsize=None, figure=True,
-                       show=True, tolerance=None):
+                       show=True, tolerance=None, fname=None):
         """Sample a dataset along a high resolution line and plot.
 
         Plot the variables of interest in 2D where the X-axis is distance from
@@ -2127,6 +2127,9 @@ class DataSetFilters:
             Tolerance used to compute whether a point in the source is in a
             cell of the input.  If not given, tolerance is automatically generated.
 
+        fname : str
+            The string file name of the save figure.
+
         """
         # Ensure matplotlib is available
         try:
@@ -2162,6 +2165,8 @@ class DataSetFilters:
             plt.title(f'{scalars} Profile')
         else:
             plt.title(title)
+        if fname:
+            plt.savefig(fname)
         if show:  # pragma: no cover
             return plt.show()
 
@@ -2270,7 +2275,7 @@ class DataSetFilters:
     def plot_over_circular_arc(dataset, pointa, pointb, center,
                                resolution=None, scalars=None,
                                title=None, ylabel=None, figsize=None,
-                               figure=True, show=True, tolerance=None):
+                               figure=True, show=True, tolerance=None, fname=None):
         """Sample a dataset along a circular arc and plot it.
 
         Plot the variables of interest in 2D where the X-axis is
@@ -2316,6 +2321,9 @@ class DataSetFilters:
             Tolerance used to compute whether a point in the source is
             in a cell of the input.  If not given, tolerance is
             automatically generated.
+
+        fname : str
+            The string file name of the save figure.
 
         Examples
         --------
@@ -2367,13 +2375,15 @@ class DataSetFilters:
             plt.title(f'{scalars} Profile')
         else:
             plt.title(title)
+        if fname:
+            plt.savefig(fname)
         if show:  # pragma: no cover
             return plt.show()
 
     def plot_over_circular_arc_normal(dataset, center, resolution=None, normal=None,
                                       polar=None, angle=None, scalars=None,
                                       title=None, ylabel=None, figsize=None,
-                                      figure=True, show=True, tolerance=None):
+                                      figure=True, show=True, tolerance=None, fname=None):
         """Sample a dataset along a resolution circular arc defined by a normal and polar vector and plot it.
 
         Plot the variables of interest in 2D where the X-axis is
@@ -2425,6 +2435,9 @@ class DataSetFilters:
             Tolerance used to compute whether a point in the source is
             in a cell of the input.  If not given, tolerance is
             automatically generated.
+
+        fname : str
+            The string file name of the save figure.
 
         Examples
         --------
@@ -2479,6 +2492,8 @@ class DataSetFilters:
             plt.title(f'{scalars} Profile')
         else:
             plt.title(title)
+        if fname:
+            plt.savefig(fname)
         if show:  # pragma: no cover
             return plt.show()
 

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2322,8 +2322,8 @@ class DataSetFilters:
             in a cell of the input.  If not given, tolerance is
             automatically generated.
 
-        fname : str
-            The string file name of the save figure.
+        fname : str, optional
+            Save the figure this file name when set.
 
         Examples
         --------

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2127,8 +2127,8 @@ class DataSetFilters:
             Tolerance used to compute whether a point in the source is in a
             cell of the input.  If not given, tolerance is automatically generated.
 
-        fname : str
-            The string file name of the save figure.
+        fname : str, optional
+            Save the figure this file name when set.
 
         """
         # Ensure matplotlib is available

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2436,8 +2436,8 @@ class DataSetFilters:
             in a cell of the input.  If not given, tolerance is
             automatically generated.
 
-        fname : str
-            The string file name of the save figure.
+        fname : str, optional
+            Save the figure this file name when set.
 
         Examples
         --------

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -745,9 +745,11 @@ def test_sample_over_line():
     assert isinstance(sampled_from_sphere, pyvista.PolyData)
 
 
-def test_plot_over_line():
+def test_plot_over_line(tmpdir):
     """this requires matplotlib"""
     pytest.importorskip('matplotlib')
+    tmp_dir = tmpdir.mkdir("tmpdir")
+    filename = str(tmp_dir.join('tmp.png'))
     mesh = examples.load_uniform()
     # Make two points to construct the line between
     a = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
@@ -756,7 +758,8 @@ def test_plot_over_line():
     # Test multicomponent
     mesh['foo'] = np.random.rand(mesh.n_cells, 3)
     mesh.plot_over_line(a, b, resolution=None, scalars='foo',
-                        title='My Stuff', ylabel='3 Values', show=False)
+                        title='My Stuff', ylabel='3 Values', show=False, fname=filename)
+    assert os.path.isfile(filename)
     # Should fail if scalar name does not exist
     with pytest.raises(KeyError):
         mesh.plot_over_line(a, b, resolution=None, scalars='invalid_array_name',
@@ -826,17 +829,20 @@ def test_sample_over_circular_arc_normal():
     assert isinstance(sampled_from_sphere, pyvista.PolyData)
 
 
-def test_plot_over_circular_arc():
+def test_plot_over_circular_arc(tmpdir):
     """this requires matplotlib"""
 
     pytest.importorskip('matplotlib')
     mesh = examples.load_uniform()
+    tmp_dir = tmpdir.mkdir("tmpdir")
+    filename = str(tmp_dir.join('tmp.png'))
 
     # Make two points and center to construct the circular arc between
     a = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[5]]
     b = [mesh.bounds[1], mesh.bounds[2], mesh.bounds[4]]
     center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
-    mesh.plot_over_circular_arc(a, b, center, resolution=1000, show=False)
+    mesh.plot_over_circular_arc(a, b, center, resolution=1000, show=False, fname=filename)
+    assert os.path.isfile(filename)
 
     # Test multicomponent
     mesh['foo'] = np.random.rand(mesh.n_cells, 3)
@@ -851,18 +857,21 @@ def test_plot_over_circular_arc():
                                     show=False)
 
 
-def test_plot_over_circular_arc_normal():
+def test_plot_over_circular_arc_normal(tmpdir):
     """this requires matplotlib"""
 
     pytest.importorskip('matplotlib')
     mesh = examples.load_uniform()
+    tmp_dir = tmpdir.mkdir("tmpdir")
+    filename = str(tmp_dir.join('tmp.png'))
 
     # Make center and normal/polar vector to construct the circular arc between
     normal = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[5]]
     polar = [mesh.bounds[0], mesh.bounds[3], mesh.bounds[4]]
     angle = 90
     center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
-    mesh.plot_over_circular_arc_normal(center, polar=polar, angle=angle, show=False)
+    mesh.plot_over_circular_arc_normal(center, polar=polar, angle=angle, show=False, fname=filename)
+    assert os.path.isfile(filename)
 
     # Test multicomponent
     mesh['foo'] = np.random.rand(mesh.n_cells, 3)


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Add fname option to plot_over methods

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- We can save figure like follwing.
```python
import pyvista as pv
from pyvista import examples

mesh = examples.download_kitchen()

a = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
b = [mesh.bounds[1], mesh.bounds[3], mesh.bounds[5]]

mesh.plot_over_line(a, b, resolution=100, fname="kitchen.png")
```
![kitchen](https://user-images.githubusercontent.com/7513610/113503197-3e0cd600-956b-11eb-8496-3e0661d457c4.png)
