### PR TITLE
add dataset_adapter to hidden imports

### DIFF
--- a/docs/extras/pyinstaller.rst
+++ b/docs/extras/pyinstaller.rst
@@ -1,6 +1,6 @@
 .. _ref_pyinstaller:
 
-Freezing pyvista with pyinstaller
+Freezing PyVista with pyinstaller
 =================================
 You can make some fantastic standalone programs with ``pyinstaller``
 and ``pyvista``, and you can even make a graphical user interface
@@ -23,6 +23,7 @@ When running VTK v9, you need to add several additional
                                 'vtkmodules.qt.QVTKRenderWindowInteractor',
                                 'vtkmodules.util',
                                 'vtkmodules.util.numpy_support',
+                                'vtkmodules.numpy_interface.dataset_adapter',
                                ],
 
 From there, you can freeze an application using ``pyvista`` and create


### PR DESCRIPTION
#### Update Hidden Imports

#1244 pointed out that our hidden imports with `pyinstaller` is missing ``vtkmodules.numpy_interface.dataset_adapter``.
