### PR TITLE
Fix Image Segfault

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -188,6 +188,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
         # Keep track of the scale
         self._labels = []
 
+        # track if render window has ever been rendered
+        self._rendered = False
+
         # this helps managing closed plotters
         self._closed = False
 
@@ -730,11 +733,17 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if not hasattr(self, 'ren_win') and hasattr(self, 'last_image'):
             return self.last_image
 
+        if not self._first_time:
+            raise AttributeError('This plotter has not yet been setup and rendered '
+                                 'with ``show``.  Consider setting ``off_screen=True``'
+                                 'For off screen rendering.\n')
+
         data = image_from_window(self.ren_win)
         if self.image_transparent_background:
             return data
-        else:  # ignore alpha channel
-            return data[:, :, :-1]
+
+        # ignore alpha channel
+        return data[:, :, :-1]
 
     def render(self):
         """Render the main window.
@@ -744,6 +753,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if hasattr(self, 'ren_win') and not self._first_time:
             log.debug('Rendering')
             self.ren_win.Render()
+            self._rendered = True
 
     @wraps(RenderWindowInteractor.add_key_event)
     def add_key_event(self, *args, **kwargs):

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -728,15 +728,22 @@ class BasePlotter(PickingHelper, WidgetHelper):
         """Return an image array of current render window.
 
         To retrieve an image after the render window has been closed,
-        set: `plotter.store_image = True` before closing the plotter.
+        set: ``plotter.store_image = True`` before closing the plotter.
         """
         if not hasattr(self, 'ren_win') and hasattr(self, 'last_image'):
             return self.last_image
 
-        if not self._first_time:
-            raise AttributeError('This plotter has not yet been setup and rendered '
-                                 'with ``show``.  Consider setting ``off_screen=True``'
-                                 'For off screen rendering.\n')
+        if not self._rendered:
+            raise AttributeError('\nThis plotter has not yet been setup and rendered '
+                                 'with ``show()``.\n'
+                                 'Consider setting ``off_screen=True`` '
+                                 'for off screen rendering.\n')
+
+        if not hasattr(self, 'ren_win'):
+            raise AttributeError('\n\nTo retrieve an image after the render window '
+                                 'has been closed, set:\n\n'
+                                 ' ``plotter.store_image = True``\n\n'
+                                 'before closing the plotter.')
 
         data = image_from_window(self.ren_win)
         if self.image_transparent_background:

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1930,3 +1930,16 @@ def test_plot_lighting_change_positional_false_true():
     light.positional = True
     plotter.add_mesh(pyvista.Sphere())
     plotter.show(before_close_callback=verify_cache_image)
+
+
+def test_plotter_image():
+    plotter = pyvista.Plotter()
+    plotter.show()
+    with pytest.raises(AttributeError, match='To retrieve an image after'):
+        plotter.image
+
+    plotter = pyvista.Plotter()
+    wsz = tuple(plotter.window_size)
+    plotter.store_image = True
+    plotter.show()
+    assert plotter.image.shape[:2] == wsz

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -1,0 +1,14 @@
+"""Test any plotting that does not require rendering.
+
+All other tests requiring rendering should to in
+./plotting/test_plotting.py
+
+"""
+import pytest
+import pyvista
+
+
+def test_plotter_image():
+    plotter = pyvista.Plotter()
+    with pytest.raises(AttributeError, match='not yet been setup'):
+        plotter.image


### PR DESCRIPTION
### Resolves #1140

Gives the user a helpful message when the attribute ``Plotter.image`` is accessed before the render window has been rendered by adding `_rendered`.

