### PR TITLE
Fix Points Setter

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -202,6 +202,18 @@ class DataSet(DataSetFilters, DataObject):
     @points.setter
     def points(self, points: np.ndarray):
         """Set points without copying."""
+        if isinstance(points, pyvista_ndarray):
+            # simply set the underlying data
+            if points.VTKObject is not None:
+                try:
+                    self.GetPoints().SetData(points.VTKObject)
+                    self.GetPoints().Modified()
+                    self.Modified()
+                    return
+                except TypeError:
+                    pass
+
+        # otherwise, wrap and use the array
         if not isinstance(points, np.ndarray):
             raise TypeError('Points must be a numpy array')
         vtk_points = pyvista.vtk_points(points, False)

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -50,7 +50,7 @@ def translate(surf, center=[0., 0., 0.], direction=[1., 0., 0.]):
 
     surf.transform(trans)
     if not np.allclose(center, [0., 0., 0.]):
-        surf.points[:] += np.array(center)
+        surf.points += np.array(center)
 
 
 def Cylinder(center=(0.0, 0.0, 0.0), direction=(1.0, 0.0, 0.0),

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -113,8 +113,8 @@ def convert_array(arr, name=None, deep=0, array_type=None):
         else:
             # This will handle numerical data
             arr = np.ascontiguousarray(arr)
-            vtk_data = _vtk.numpy_to_vtk(num_array=arr, deep=deep, array_type=array_type)
-
+            vtk_data = _vtk.numpy_to_vtk(num_array=arr, deep=deep,
+                                         array_type=array_type)
         if isinstance(name, str):
             vtk_data.SetName(name)
         return vtk_data
@@ -252,7 +252,7 @@ def get_array(mesh, name, preference='cell', info=False, err=False):
 
 def vtk_points(points, deep=True):
     """Convert numpy array or array-like to a vtkPoints object."""
-    points = np.asarray(points)
+    points = np.asanyarray(points)
 
     # verify is numeric
     if not np.issubdtype(points.dtype, np.number):
@@ -271,26 +271,29 @@ def vtk_points(points, deep=True):
                          f'Shape is {points.shape} and should be (X, 3)')
 
     # points must be contiguous
-    points = np.ascontiguousarray(points)
+    if not points.flags['C_CONTIGUOUS']:
+        points = np.ascontiguousarray(points)
     vtkpts = _vtk.vtkPoints()
-    vtkpts.SetData(_vtk.numpy_to_vtk(points, deep=deep))
+    vtk_arr = _vtk.numpy_to_vtk(points, deep=deep)
+    vtkpts.SetData(vtk_arr)
     return vtkpts
 
 
 def line_segments_from_points(points):
     """Generate non-connected line segments from points.
 
-    Assumes points are ordered as line segments and an even number of points
-    are
+    Assumes points are ordered as line segments and an even number of
+    points.
 
     Parameters
     ----------
     points : np.ndarray
-        Points representing line segments. An even number must be given as
-        every two vertices represent a single line segment. For example, two
-        line segments would be represented as:
+        Points representing line segments. An even number must be
+        given as every two vertices represent a single line
+        segment. For example, two line segments would be represented
+        as:
 
-        np.array([[0, 0, 0], [1, 0, 0], [1, 0, 0], [1, 1, 0]])
+        ``np.array([[0, 0, 0], [1, 0, 0], [1, 0, 0], [1, 1, 0]])``
 
     Returns
     -------


### PR DESCRIPTION
### Overview

When setting points inplace, we perform a shallow copy operation:
https://github.com/pyvista/pyvista/blob/6e61f8abff5f883bdc28234c39bb33c0b99ae12d/pyvista/core/dataset.py#L202-L214

Turns out, when the input array is a `pyvista_ndarray`, we keep around an extra reference, which was discovered in #1248 and #1247.  This PR resolves #1248 by simply setting the data directly from the pyvista_ndarray since it contains a reference to the original VTKObject.
