### PR TITLE
fix/windows plotter closing

### DIFF
--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -95,12 +95,5 @@ try:
 except KeyError:
     pass
 
-
 # Set a parameter to control default print format for floats
 FLOAT_FORMAT = "{:.3e}"
-
-VERY_FIRST_RENDER = [True]
-
-# Check if python is running in interactive mode (see
-# https://stackoverflow.com/a/64523765)
-IS_INTERACTIVE = hasattr(sys, 'ps1')

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -48,7 +48,7 @@ def _has_matplotlib():
 
 
 SUPPORTED_FORMATS = [".png", ".jpeg", ".jpg", ".bmp", ".tif", ".tiff"]
-
+VERY_FIRST_RENDER = [True]  # windows plotter helper
 
 def close_all():
     """Close all open/active plotters and clean up memory."""
@@ -3883,15 +3883,11 @@ class Plotter(BasePlotter):
         self._on_first_render_request(cpos)
 
         # Render
-        # For Windows issues. Resolves #186, #1018 and #1078
-        if os.name == 'nt' and pyvista.IS_INTERACTIVE and not pyvista.VERY_FIRST_RENDER:
-            if interactive and (not self.off_screen):
-                self.iren.start()
-        pyvista.VERY_FIRST_RENDER = False
-        # for some reason iren needs to start before rendering on
-        # Windows when running in interactive mode (python console,
-        # Ipython console, Jupyter notebook) but only after the very
-        # first render window
+        # For Windows issues opening/closing plotting window.  Resolves #1260
+        if os.name == 'nt' and not VERY_FIRST_RENDER[0]:
+            if interactive and not self.off_screen:
+                self.iren.interactor.Start()
+        VERY_FIRST_RENDER[0] = False
 
         # handle plotter notebook
         if jupyter_backend and not self.notebook:
@@ -3925,12 +3921,12 @@ class Plotter(BasePlotter):
             self.last_image_depth = self.get_image_depth()
 
         # See: https://github.com/pyvista/pyvista/issues/186#issuecomment-550993270
-        if interactive and (not self.off_screen):
+        if interactive and not self.off_screen:
             try:  # interrupts will be caught here
                 log.debug('Starting iren')
                 self.iren.update_style()
                 if not interactive_update:
-                    self.iren.start()
+                    self.iren.interactor.Start()
                 self.iren.initialize()
             except KeyboardInterrupt:
                 log.debug('KeyboardInterrupt')

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3882,13 +3882,6 @@ class Plotter(BasePlotter):
         # reset unless camera for the first render unless camera is set
         self._on_first_render_request(cpos)
 
-        # Render
-        # For Windows issues opening/closing plotting window.  Resolves #1260
-        if os.name == 'nt' and not VERY_FIRST_RENDER[0]:
-            if interactive and not self.off_screen:
-                self.iren.interactor.Start()
-        VERY_FIRST_RENDER[0] = False
-
         # handle plotter notebook
         if jupyter_backend and not self.notebook:
             warnings.warn('Not within a jupyter notebook environment.\n'
@@ -3926,7 +3919,9 @@ class Plotter(BasePlotter):
                 log.debug('Starting iren')
                 self.iren.update_style()
                 if not interactive_update:
-                    self.iren.interactor.Start()
+                    if os.name == 'nt':
+                        self.iren.interactor.ProcessEvents()  # Resolves #1260
+                    self.iren.start()
                 self.iren.initialize()
             except KeyboardInterrupt:
                 log.debug('KeyboardInterrupt')

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3920,7 +3920,7 @@ class Plotter(BasePlotter):
                 self.iren.update_style()
                 if not interactive_update:
                     if os.name == 'nt':
-                        self.iren.interactor.ProcessEvents()  # Resolves #1260
+                        self.iren.process_events()  # Resolves #1260
                     self.iren.start()
                 self.iren.initialize()
             except KeyboardInterrupt:

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -348,7 +348,6 @@ class RenderWindowInteractor():
 
     def start(self):
         """Start interactions."""
-        print('start')
         self.interactor.Start()
 
     def initialize(self):

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -348,6 +348,7 @@ class RenderWindowInteractor():
 
     def start(self):
         """Start interactions."""
+        print('start')
         self.interactor.Start()
 
     def initialize(self):

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -358,6 +358,10 @@ class RenderWindowInteractor():
         """Set the render window."""
         self.interactor.SetRenderWindow(ren_win)
 
+    def process_events(self):
+        """Process events."""
+        self.interactor.ProcessEvents()
+
     def get_picker(self):
         """Get the piccker."""
         return self.interactor.GetPicker()


### PR DESCRIPTION
### Stop MS Windows Render Window from Closing

For some reason, unbeknownst to man or beast, the render window on windows closes out on the second show.  This can be duplicated easily with:

```py
import pyvista as pv
pv.Sphere().plot(color='blue')
pv.Sphere().plot(color='red')
```

Where only the blue sphere shows.

See #186, #1018 and #1078 for other issues related to this one. This is a reoccurring issue and is cited in `plotter.py` and was an absolute pain to fix.

Turns out the trick is to `ProcessEvents`.  I have no idea why we have to call it, and there's likely something left around in VTK memory, some object not collected, but it appears that there's something left over and needs to be flushed out.