### PR TITLE
Allow dataset source for streamlines

### DIFF
--- a/examples/01-filter/streamlines.py
+++ b/examples/01-filter/streamlines.py
@@ -22,7 +22,8 @@ from pyvista import examples
 mesh = examples.download_carotid()
 
 ###############################################################################
-# Run the stream line filtering algorithm.
+# Run the stream line filtering algorithm using random seed points inside a 
+# sphere with radius of 2.0.
 
 streamlines, src = mesh.streamlines(
     return_source=True,
@@ -66,6 +67,28 @@ p = pv.Plotter()
 p.add_mesh(streamlines.tube(radius=0.2), lighting=False)
 p.add_mesh(src)
 p.add_mesh(boundary, color="grey", opacity=0.25)
+p.camera_position = [(10, 9.5, -43), (87.0, 73.5, 123.0), (-0.5, -0.7, 0.5)]
+p.show()
+
+
+###############################################################################
+# A source mesh can also be provided using the `streamlines_from_source` 
+# filter, for example if an inlet surface is available.  In this example, the
+# inlet surfaces are extracted just inside the domain for use as the seed for
+# the streamlines.
+
+
+source_mesh = mesh.slice('z', origin=(0, 0, 182))  # inlet surface
+# thin out ~40% points to get a nice density of streamlines
+seed_mesh = source_mesh.decimate_boundary(0.4)
+streamlines = mesh.streamlines_from_source(seed_mesh, integration_direction="forward")
+
+
+###############################################################################
+p = pv.Plotter()
+p.add_mesh(streamlines.tube(radius=0.2), lighting=False)
+p.add_mesh(boundary, color="grey", opacity=0.25)
+p.add_mesh(source_mesh, color="red")
 p.camera_position = [(10, 9.5, -43), (87.0, 73.5, 123.0), (-0.5, -0.7, 0.5)]
 p.show()
 

--- a/examples/01-filter/streamlines.py
+++ b/examples/01-filter/streamlines.py
@@ -74,7 +74,7 @@ p.show()
 ###############################################################################
 # A source mesh can also be provided using the `streamlines_from_source` 
 # filter, for example if an inlet surface is available.  In this example, the
-# inlet surfaces are extracted just inside the domain for use as the seed for
+# inlet surface is extracted just inside the domain for use as the seed for
 # the streamlines.
 
 

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1852,18 +1852,25 @@ class DataSetFilters:
 
         The integration is performed using a specified integrator, by default
         Runge-Kutta2. This supports integration through any type of dataset.
-        Thus if the dataset contains 2D cells like polygons or triangles, the
-        integration is constrained to lie on the surface defined by 2D cells.
+        If the dataset contains 2D cells like polygons or triangles and the
+        ``surface_streamlines`` parameter is used, the integration is constrained
+        to lie on the surface defined by 2D cells.
 
         This produces polylines as the output, with each cell
         (i.e., polyline) representing a streamline. The attribute values
         associated with each streamline are stored in the cell data, whereas
         those associated with streamline-points are stored in the point data.
 
-        This uses a Sphere as the source - set it's location and radius via
-        the ``source_center`` and ``source_radius`` keyword arguments.
-        You can retrieve the source as :class:`pyvista.PolyData` by specifying
-        ``return_source=True``.
+        The default behavior uses a Sphere as the source - set it's location and 
+        radius via the ``source_center`` and ``source_radius`` keyword arguments.
+        ``n_points`` defines the number of starting points on the sphere surface.
+
+        Alternatively, a Line source can be used by specifying ``pointa`` and ``pointb``.
+        ``n_points`` again defines the number of points on the line.  You can retrieve the
+        source as :class:`pyvista.PolyData` by specifying ``return_source=True``.
+        
+        An arbitrary ``pyvista.DataSet`` can also be provided for the starting points using
+        the ``source`` keyword argument.
 
         Parameters
         ----------
@@ -1879,7 +1886,7 @@ class DataSetFilters:
             the diagonal of the dataset's spatial extent
 
         n_points : int
-            Number of particles present in source sphere
+            Number of particles present in source sphere or line
 
         integrator_type : int
             The integrator type to be used for streamline generation.
@@ -1954,7 +1961,7 @@ class DataSetFilters:
             will override the sphere point source.
 
         source : pyvista.DataSet <- TODO this isn't correct, what is the right type?
-            A point object, the points of which provide the starting points of the
+            The points of the source provide the starting points of the
             streamlines.  This will override both sphere and line sources.
 
         """

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1894,7 +1894,7 @@ class DataSetFilters:
 
         source : pyvista.PolyData
             The points of the source are the seed points for the streamlines.
-            Only returned if `return_source=True`.
+            Only returned if ``return_source=True``.
         """
         if source_center is None:
             source_center = dataset.center

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1846,12 +1846,6 @@ class DataSetFilters:
                     **kwargs):
         """Integrate a vector field to generate streamlines.
 
-        The integration is performed using a specified integrator, by default
-        Runge-Kutta2. This supports integration through any type of dataset.
-        If the dataset contains 2D cells like polygons or triangles and the
-        ``surface_streamlines`` parameter is used, the integration is constrained
-        to lie on the surface defined by 2D cells.
-
         The default behavior uses a Sphere as the source - set it's location and 
         radius via the ``source_center`` and ``source_radius`` keyword arguments.
         ``n_points`` defines the number of starting points on the sphere surface.
@@ -1860,24 +1854,24 @@ class DataSetFilters:
         
         You can retrieve the source by specifying ``return_source=True``.
         
-        Optional parameters from ``streamlines_from_source`` can be used here to
+        Optional keyword parameters from ``streamlines_from_source`` can be used here to
         control the generation of streamlines.
 
         Parameters
         ----------
         vectors : str, optional
-            The string name of the active vector field to integrate across
+            The string name of the active vector field to integrate across.
 
         source_center : tuple(float), optional
             Length 3 tuple of floats defining the center of the source
-            particles. Defaults to the center of the dataset
+            particles. Defaults to the center of the dataset.
 
         source_radius : float, optional
             Float radius of the source particle cloud. Defaults to one-tenth of
-            the diagonal of the dataset's spatial extent
+            the diagonal of the dataset's spatial extent.
 
         n_points : int, optional
-            Number of particles present in source sphere or line
+            Number of particles present in source sphere or line.
 
         start_position : tuple(float), optional
             A single point.  This will override the sphere point source.
@@ -1899,7 +1893,8 @@ class DataSetFilters:
             those associated with streamline-points are stored in the point data.
 
         source : pyvista.PolyData
-            Only returned if `return_source=True`
+            The points of the source are the seed points for the streamlines.
+            Only returned if `return_source=True`.
         """
         if source_center is None:
             source_center = dataset.center
@@ -1945,73 +1940,79 @@ class DataSetFilters:
         """
         Generate streamlines of vectors from the points of a source mesh.
         
+        The integration is performed using a specified integrator, by default
+        Runge-Kutta2. This supports integration through any type of dataset.
+        If the dataset contains 2D cells like polygons or triangles and the
+        ``surface_streamlines`` parameter is used, the integration is constrained
+        to lie on the surface defined by 2D cells.
+
         Parameters:
         -----------
         source : pyvista.DataSet
             The points of the source provide the starting points of the
             streamlines.  This will override both sphere and line sources.
 
-        vectors : str
-            The string name of the active vector field to integrate across
+        vectors : str, optional
+            The string name of the active vector field to integrate across.
         
-        integrator_type : int
+        integrator_type : int, optional
             The integrator type to be used for streamline generation.
             The default is Runge-Kutta45. The recognized solvers are:
             RUNGE_KUTTA2 (``2``),  RUNGE_KUTTA4 (``4``), and RUNGE_KUTTA45
             (``45``). Options are ``2``, ``4``, or ``45``. Default is ``45``.
 
-        integration_direction : str
+        integration_direction : str, optional
             Specify whether the streamline is integrated in the upstream or
             downstream directions (or both). Options are ``'both'``,
             ``'backward'``, or ``'forward'``.
 
-        surface_streamlines : bool
-            Compute streamlines on a surface. Default ``False``
+        surface_streamlines : bool, optional
+            Compute streamlines on a surface. Default ``False``.
 
-        initial_step_length : float
+        initial_step_length : float, optional
             Initial step size used for line integration, expressed ib length
             unitsL or cell length units (see ``step_unit`` parameter).
             either the starting size for an adaptive integrator, e.g., RK45, or
-            the constant / fixed size for non-adaptive ones, i.e., RK2 and RK4)
+            the constant / fixed size for non-adaptive ones, i.e., RK2 and RK4).
 
-        step_unit : str
+        step_unit : str, optional
             Uniform integration step unit. The valid unit is now limited to
             only LENGTH_UNIT (``'l'``) and CELL_LENGTH_UNIT (``'cl'``).
             Default is CELL_LENGTH_UNIT: ``'cl'``.
 
-        min_step_length : float
+        min_step_length : float, optional
             Minimum step size used for line integration, expressed in length or
-            cell length units. Only valid for an adaptive integrator, e.g., RK45
+            cell length units. Only valid for an adaptive integrator, e.g., RK45.
 
-        max_step_length : float
+        max_step_length : float, optional
             Maximum step size used for line integration, expressed in length or
-            cell length units. Only valid for an adaptive integrator, e.g., RK45
+            cell length units. Only valid for an adaptive integrator, e.g., RK45.
 
-        max_steps : int
+        max_steps : int, optional
             Maximum number of steps for integrating a streamline.
             Defaults to ``2000``
 
-        terminal_speed : float
+        terminal_speed : float, optional
             Terminal speed value, below which integration is terminated.
 
-        max_error : float
+        max_error : float, optional
             Maximum error tolerated throughout streamline integration.
 
-        max_time : float
+        max_time : float, optional
             Specify the maximum length of a streamline expressed in LENGTH_UNIT.
 
-        compute_vorticity : bool
+        compute_vorticity : bool, optional
             Vorticity computation at streamline points (necessary for generating
             proper stream-ribbons using the ``vtkRibbonFilter``.
 
-        interpolator_type : str
+        interpolator_type : str, optional
             Set the type of the velocity field interpolator to locate cells
             during streamline integration either by points or cells.
             The cell locator is more robust then the point locator. Options
             are ``'point'`` or ``'cell'`` (abbreviations of ``'p'`` and ``'c'``
             are also supported).
 
-        rotation_scale : float
+        rotation_scale : float, optional
             This can be used to scale the rate with which the streamribbons
             twist. The default is 1.
 

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1988,7 +1988,7 @@ class DataSetFilters:
             source_center = dataset.center
         if source_radius is None:
             source_radius = dataset.length / 10.0
-        # TODO check that type of input_source is OK
+        # TODO check that type of source is OK
 
         # Build the algorithm
         alg = _vtk.vtkStreamTracer()
@@ -1996,16 +1996,16 @@ class DataSetFilters:
         alg.SetInputDataObject(dataset)
         if source is None:
             if pointa is not None and pointb is not None:
-                source = _vtk.vtkLineSource()
-                source.SetPoint1(pointa)
-                source.SetPoint2(pointb)
-                source.SetResolution(n_points)
+                input_source = _vtk.vtkLineSource()
+                input_source.SetPoint1(pointa)
+                input_source.SetPoint2(pointb)
+                input_source.SetResolution(n_points)
             else:
-                source = _vtk.vtkPointSource()
-                source.SetCenter(source_center)
-                source.SetRadius(source_radius)
-                source.SetNumberOfPoints(n_points)
-            alg.SetSourceConnection(source.GetOutputPort())
+                input_source = _vtk.vtkPointSource()
+                input_source.SetCenter(source_center)
+                input_source.SetRadius(source_radius)
+                input_source.SetNumberOfPoints(n_points)
+            alg.SetSourceConnection(input_source.GetOutputPort())
         else:
             alg.SetSourceData(source)
 
@@ -2045,9 +2045,10 @@ class DataSetFilters:
         alg.Update()
         output = _get_output(alg)
         if return_source:
-            source.Update()
-            src = pyvista.wrap(source.GetOutput())
-            return output, src
+            if not source:
+                input_source.Update()
+                source = pyvista.wrap(input_source.GetOutput())
+            return output, source
         return output
 
     def decimate_boundary(dataset, target_reduction=0.5):

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1854,8 +1854,8 @@ class DataSetFilters:
         
         You can retrieve the source by specifying ``return_source=True``.
         
-        Optional keyword parameters from ``streamlines_from_source`` can be used here to
-        control the generation of streamlines.
+        Optional keyword parameters from :func:`pyvista.DataSetFilters.streamlines_from_source`
+        can be used here to control the generation of streamlines.
 
         Parameters
         ----------

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1852,19 +1852,13 @@ class DataSetFilters:
         ``surface_streamlines`` parameter is used, the integration is constrained
         to lie on the surface defined by 2D cells.
 
-        This produces polylines as the output, with each cell
-        (i.e., polyline) representing a streamline. The attribute values
-        associated with each streamline are stored in the cell data, whereas
-        those associated with streamline-points are stored in the point data.
-
         The default behavior uses a Sphere as the source - set it's location and 
         radius via the ``source_center`` and ``source_radius`` keyword arguments.
         ``n_points`` defines the number of starting points on the sphere surface.
         Alternatively, a Line source can be used by specifying ``pointa`` and ``pointb``.
         ``n_points`` again defines the number of points on the line.
         
-        You can retrieve the
-        source as :class:`pyvista.PolyData` by specifying ``return_source=True``.
+        You can retrieve the source by specifying ``return_source=True``.
         
         Optional parameters from ``streamlines_from_source`` can be used here to
         control the generation of streamlines.
@@ -1895,6 +1889,17 @@ class DataSetFilters:
         pointa, pointb : tuple(float), optional
             The coordinates of a start and end point for a line source. This
             will override the sphere and start_position point source.
+
+        Returns:
+        --------
+        streamlines : pyvista.PolyData
+            This produces polylines as the output, with each cell
+            (i.e., polyline) representing a streamline. The attribute values
+            associated with each streamline are stored in the cell data, whereas
+            those associated with streamline-points are stored in the point data.
+
+        source : pyvista.PolyData
+            Only returned if `return_source=True`
         """
         if source_center is None:
             source_center = dataset.center
@@ -2009,6 +2014,14 @@ class DataSetFilters:
         rotation_scale : float
             This can be used to scale the rate with which the streamribbons
             twist. The default is 1.
+
+        Returns:
+        --------
+        streamlines : pyvista.PolyData
+            This produces polylines as the output, with each cell
+            (i.e., polyline) representing a streamline. The attribute values
+            associated with each streamline are stored in the cell data, whereas
+            those associated with streamline-points are stored in the point data.
         """
         integration_direction = str(integration_direction).strip().lower()
         if integration_direction not in ['both', 'back', 'backward', 'forward']:

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1896,7 +1896,6 @@ class DataSetFilters:
             The coordinates of a start and end point for a line source. This
             will override the sphere and start_position point source.
         """
-
         if source_center is None:
             source_center = dataset.center
         if source_radius is None:

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1943,7 +1943,7 @@ class DataSetFilters:
         
         Parameters:
         -----------
-        source : pyvista.DataSet <- TODO this isn't correct, what is the right type?
+        source : pyvista.DataSet
             The points of the source provide the starting points of the
             streamlines.  This will override both sphere and line sources.
 
@@ -2010,7 +2010,6 @@ class DataSetFilters:
         rotation_scale : float
             This can be used to scale the rate with which the streamribbons
             twist. The default is 1.
-        
         """
         integration_direction = str(integration_direction).strip().lower()
         if integration_direction not in ['both', 'back', 'backward', 'forward']:
@@ -2030,7 +2029,9 @@ class DataSetFilters:
         if max_time is None:
             max_velocity = dataset.get_data_range()[-1]
             max_time = 4.0 * dataset.GetLength() / max_velocity
-        
+        if not isinstance(source, pyvista.DataSet):
+            raise TypeError("source must be a pyvista.DataSet")
+
         # Build the algorithm
         alg = _vtk.vtkStreamTracer()
         # Inputs

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -714,6 +714,11 @@ def test_streamlines_return_source(uniform_vec):
     assert all([stream.n_points, stream.n_cells, src.n_points])
 
 
+def test_streamlines_start_position(uniform_vec):
+    stream = uniform_vec.streamlines('vectors', start_position=(0.5, 0.0, 0.0))
+
+    assert all([stream.n_points, stream.n_cells])
+
 def test_streamlines_errors(uniform_vec):
     with pytest.raises(ValueError):
         uniform_vec.streamlines('vectors', integration_direction='not valid')
@@ -727,20 +732,21 @@ def test_streamlines_errors(uniform_vec):
     with pytest.raises(ValueError):
         uniform_vec.streamlines('vectors', step_unit='not valid')
 
+    with pytest.raises(ValueError):
+        uniform_vec.streamlines('vectors', pointa=(0, 0, 0))
+    with pytest.raises(ValueError):
+        uniform_vec.streamlines('vectors', pointb=(0, 0, 0))
 
-def test_streamlines_dataset(uniform_vec):
-    vertices = np.array([[0, 0, 0], [1, 0, 0], [1, 0.5, 0], [0, 0.5, 0]])
+
+def test_streamlines_from_source(uniform_vec):
+    vertices = np.array([[0, 0, 0], [0.5, 0, 0], [0.5, 0.5, 0], [0, 0.5, 0]])
     source = pyvista.PolyData(vertices)
-    stream = uniform_vec.streamlines('vectors', source=source)
+    stream = uniform_vec.streamlines_from_source(source, 'vectors')
     assert all([stream.n_points, stream.n_cells])
 
-    stream, src = uniform_vec.streamlines('vectors', source=source, return_source=True)
-    assert src == source
-
-    # this one fails
-    # source = pyvista.UniformGrid([3, 3, 3], [1, 1, 1], [0, 0, 0])
-    # stream = uniform_vec.streamlines('vectors', source=source)
-    # assert all([stream.n_points, stream.n_cells])
+    source = pyvista.UniformGrid([5, 5, 5], [0.1, 0.1, 0.1], [0, 0, 0])
+    stream = uniform_vec.streamlines_from_source(source, 'vectors')
+    assert all([stream.n_points, stream.n_cells])
 
 
 def test_sample_over_line():

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -725,6 +725,18 @@ def test_streamlines(uniform_vec):
         uniform_vec.streamlines('vectors', step_unit='not valid')
 
 
+def test_streamlines_dataset(uniform_vec):
+    vertices = np.array([[0, 0, 0], [1, 0, 0], [1, 0.5, 0], [0, 0.5, 0]])
+    source = pyvista.PolyData(vertices)
+    stream = uniform_vec.streamlines('vectors', source=source)
+    assert all([stream.n_points, stream.n_cells])
+
+    # this one fails
+    # source = pyvista.UniformGrid([3, 3, 3], [1, 1, 1], [0, 0, 0])
+    # stream = uniform_vec.streamlines('vectors', source=source)
+    # assert all([stream.n_points, stream.n_cells])
+
+
 def test_sample_over_line():
     """Test that we get a sampled line."""
     name = 'values'

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -706,12 +706,15 @@ def test_streamlines_cell_point(uniform_vec, interpolator_type):
     assert all([stream.n_points, stream.n_cells])
 
 
-def test_streamlines(uniform_vec):
+def test_streamlines_return_source(uniform_vec):
     stream, src = uniform_vec.streamlines('vectors', return_source=True,
                                           pointa=(0.0, 0.0, 0.0),
                                           pointb=(1.1, 1.1, 0.1))
+    assert isinstance(src, pyvista.DataSet)
     assert all([stream.n_points, stream.n_cells, src.n_points])
 
+
+def test_streamlines_errors(uniform_vec):
     with pytest.raises(ValueError):
         uniform_vec.streamlines('vectors', integration_direction='not valid')
 
@@ -730,6 +733,9 @@ def test_streamlines_dataset(uniform_vec):
     source = pyvista.PolyData(vertices)
     stream = uniform_vec.streamlines('vectors', source=source)
     assert all([stream.n_points, stream.n_cells])
+
+    stream, src = uniform_vec.streamlines('vectors', source=source, return_source=True)
+    assert src == source
 
     # this one fails
     # source = pyvista.UniformGrid([3, 3, 3], [1, 1, 1], [0, 0, 0])

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -700,7 +700,7 @@ def test_streamlines_type(uniform_vec, integrator_type):
 
 
 @pytest.mark.parametrize('interpolator_type', ['point', 'cell'])
-def test_streamlines(uniform_vec, interpolator_type):
+def test_streamlines_cell_point(uniform_vec, interpolator_type):
     stream = uniform_vec.streamlines('vectors',
                                      interpolator_type=interpolator_type)
     assert all([stream.n_points, stream.n_cells])


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

It would be nice to be able to specify a custom source for streamlines based on any dataset type.  ~~This PR adds an optional `source` parameter that overrides the sphere or line functionality of streamlines, if provided.  Otherwise, the behavior is unchanged.~~

This PR adds a new `streamlines_from_source` filter and restructures `streamlines` to call this new filter.

This was inspired by https://github.com/pyvista/pyvista-support/issues/414


### Details

One use case is to use a surface of an inlet to the domain as the source seed for the streamlines.  Or a uniform grid, etc.

This PR fixes #1291 by explicitly creating a single point at `start_position` instead of setting it directly on `vtkStreamTracer`.


