### PR TITLE
DOC: Fix citation bibtex entry and spell out two authors

### DIFF
--- a/CITATION.rst
+++ b/CITATION.rst
@@ -9,7 +9,7 @@ If you are using PyVista in your scientific research, please help our scientific
 visibility by citing our work!
 
 
-    Sullivan et al., (2019). PyVista: 3D plotting and mesh analysis through a streamlined interface for the Visualization Toolkit (VTK). Journal of Open Source Software, 4(37), 1450, https://doi.org/10.21105/joss.01450
+    Sullivan and Kaszynski, (2019). PyVista: 3D plotting and mesh analysis through a streamlined interface for the Visualization Toolkit (VTK). Journal of Open Source Software, 4(37), 1450, https://doi.org/10.21105/joss.01450
 
 
 BibTex:
@@ -20,12 +20,12 @@ BibTex:
       doi = {10.21105/joss.01450},
       url = {https://doi.org/10.21105/joss.01450},
       year = {2019},
-      month = {may},
+      month = {May},
       publisher = {The Open Journal},
       volume = {4},
       number = {37},
       pages = {1450},
       author = {C. Bane Sullivan and Alexander Kaszynski},
-      title = {{PyVista}: 3D plotting and mesh analysis through a streamlined interface for the Visualization Toolkit ({VTK})},
+      title = {{PyVista}: {3D} plotting and mesh analysis through a streamlined interface for the {Visualization Toolkit} ({VTK})},
       journal = {Journal of Open Source Software}
     }


### PR DESCRIPTION
The BibTex entry for the paper had some capitalized words (3D, Visualization Toolkit) that weren't protected with braces. These would be rendered in lowercase. And "may" for the month field was lowercase as it often is with autogenerated bib entries.

I also changed *"Sullivan et al."* to *"Sullivan and Kaszynski"* in the docs; it's customary to spell out two authors (and technically "et al.", short for "et alii/aliae/alia", means "and others").