### PR TITLE
🐛 Fix: sampling arc angle and resolution

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -2267,7 +2267,8 @@ class DataSetFilters:
         circular_arc = pyvista.CircularArcFromNormal(center,
                                                      resolution=resolution,
                                                      normal=normal,
-                                                     polar=polar)
+                                                     polar=polar,
+                                                     angle=angle)
 
         sampled_circular_arc = circular_arc.sample(dataset, tolerance=tolerance)
         return sampled_circular_arc

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -738,7 +738,7 @@ def CircularArcFromNormal(center, resolution=100, normal=None,
     # Compute distance of every point along circular arc
     center = np.array(center)
     radius = np.sqrt(np.sum((arc.points[0] - center)**2, axis=0))
-    angles = np.arange(0.0, 1.0 + 1.0/resolution, 1.0/resolution) * angle
+    angles = np.linspace(0.0, angle, resolution+1)
     arc['Distance'] = radius * angles
     return arc
 

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -698,7 +698,7 @@ def CircularArcFromNormal(center, resolution=100, normal=None,
 
     angle : float, optional
         Arc length (in degrees) beginning at the polar vector.  The
-        direction is counterclockwise.  By default it is 360.
+        direction is counterclockwise.  By default it is 90.
 
     Examples
     --------

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -813,11 +813,13 @@ def test_sample_over_circular_arc_normal():
     zmax = uniform.bounds[5]
     normal = [xmin, ymax, zmin]
     polar = [xmin, ymin, zmax]
-    angle = 90
+    angle = 90.0*np.random.rand()
+    resolution = np.random.randint(10000)
     center = [xmin, ymin, zmin]
-    sampled_arc_normal = uniform.sample_over_circular_arc_normal(center, resolution=2, normal=normal, polar=polar, angle=angle)
+    sampled_arc_normal = uniform.sample_over_circular_arc_normal(center, resolution=resolution, normal=normal, polar=polar, angle=angle)
+    angles = np.linspace(np.pi/2.0, np.pi/2.0-np.deg2rad(angle), resolution+1)
 
-    expected_result = zmin+(zmax-zmin)*np.sin([np.pi/2.0, np.pi/4.0, 0.0])
+    expected_result = zmin+(zmax-zmin)*np.sin(angles)
     assert np.allclose(sampled_arc_normal[name], expected_result)
     assert name in sampled_arc_normal.array_names # is name in sampled result
 


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
🐛 Fix: sampling arc angle is always 90.0 degree even if degree arg is set another degree.

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 
#1218

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None

