### PR TITLE
build docs twice

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -248,7 +248,8 @@ jobs:
 
   # run this twice since VTK9 fails to close render windows
   - script: |
-      (make -C docs html -b coverage SPHINXOPTS="-W"; make -C docs html -b coverage SPHINXOPTS="-W")
+      make -C docs html || true  # will fail on VTK9
+      make -C docs html -b coverage SPHINXOPTS="-W"
       cat docs/_build/coverage/python.txt
     displayName: 'Build documentation'
 


### PR DESCRIPTION
Our current doc build fails on VTK9 without the changes in this PR.
