### PR TITLE
Implement Theme Class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,4 @@ coverage-html:
 mypy:
 	@echo "Running mypy static type checking"
 	mypy pyvista/core/ --no-incremental
+	mypy pyvista/themes.py --no-incremental

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ pyvista.set_error_output_file("errors.txt")
 pyvista.OFF_SCREEN = True  # Not necessary - simply an insurance policy
 # Preferred plotting style for documentation
 pyvista.set_plot_theme("document")
-pyvista.defaults.window_size = np.array([1024, 768]) * 2
+pyvista.global_theme.window_size = np.array([1024, 768]) * 2
 # Save figures in specified directory
 pyvista.FIGURE_PATH = os.path.join(os.path.abspath("./images/"), "auto-generated/")
 if not os.path.exists(pyvista.FIGURE_PATH):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ pyvista.set_error_output_file("errors.txt")
 pyvista.OFF_SCREEN = True  # Not necessary - simply an insurance policy
 # Preferred plotting style for documentation
 pyvista.set_plot_theme("document")
-pyvista.rcParams["window_size"] = np.array([1024, 768]) * 2
+pyvista.defaults.window_size = np.array([1024, 768]) * 2
 # Save figures in specified directory
 pyvista.FIGURE_PATH = os.path.join(os.path.abspath("./images/"), "auto-generated/")
 if not os.path.exists(pyvista.FIGURE_PATH):

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -245,7 +245,7 @@ In your ``conf.py``, add the following:
 
     # Optional - set parameters like theme or window size
     pyvista.set_plot_theme('document')
-    pyvista.rcParams['window_size'] = np.array([1024, 768]) * 2
+    pyvista.global_theme.window_size = np.array([1024, 768]) * 2
 
     ...
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,7 +68,7 @@ might want to use PyVista:
    # must have this here as our global backend may not be static
    import pyvista
    pyvista.set_jupyter_backend('ipygany')  # using ipyvtk as it loads faster
-   pyvista.rcParams['background'] = [1, 1, 1]
+   pyvista.global_theme.background = 'white'
 
 
 Maps and Geoscience

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -55,7 +55,7 @@ User Guide Contents
    simple
    jupyter/index
    optional_features
-
+   themes
 
 Videos
 ======

--- a/docs/user-guide/jupyter/ipyvtk_plotting.rst
+++ b/docs/user-guide/jupyter/ipyvtk_plotting.rst
@@ -1,7 +1,7 @@
 .. _ipyvtk_plotting:
 
 Using ``ipyvtklink`` with PyVista
-------------------------------------
+---------------------------------
 
 .. note::
    As of version ``0.1.4``, ``ipyvtklink`` does not support
@@ -33,14 +33,14 @@ within JupyterLab:
     # long example
     plotter = pv.Plotter(notebook=True)
     plotter.add_mesh(sphere)
-    plotter.show(use_ipyvtk=True)
+    plotter.show(jupyter_backend='ipyvtklink')
 
-For convenience, you can enable ``use_ipyvtk`` by default with:
+For convenience, you can enable ``ipyvtklink`` by default with:
 
 .. code:: python
 
     import pyvista
-    pyvista.rcParams['use_ipyvtk'] = True
+    pyvista.global_theme.jupyter_backend = 'ipyvtklink'
 
 
 Installation

--- a/docs/user-guide/themes.rst
+++ b/docs/user-guide/themes.rst
@@ -1,0 +1,90 @@
+.. _userguide_themes:
+
+Plotting Themes
+===============
+
+PyVista plotting parameters can be controlled on a plot by plot basis
+or through a global theme, making it possible to control mesh colors
+and styles through one global configuration.
+
+.. jupyter-execute::
+   :hide-code:
+
+   # using ipyvtk as it loads faster
+   import pyvista
+   pyvista.set_jupyter_backend('static')
+
+The default theme parameters in PyVista can be accessed and displayed with:
+
+.. jupyter-execute::
+
+    import pyvista
+    pyvista.global_theme
+
+Default plotting parameters can be accessed individually by their
+attribute names:
+
+.. jupyter-execute::
+
+   pyvista.global_theme.color
+
+Here's an example plot of the Stanford Dragon using default plotting
+parameters:
+
+.. jupyter-execute::
+
+    from pyvista import examples
+    dragon = examples.download_dragon()
+    dragon.plot(cpos='xy')
+
+These parameters can then be modified globally with:
+
+.. jupyter-execute::
+
+   pyvista.global_theme.color = 'red'
+   pyvista.global_theme.background = 'white'
+   pyvista.global_theme.axes.show = False
+
+Now, the mesh will be plotted with the new global parameters:
+
+.. jupyter-execute::
+
+    dragon.plot(cpos='xy')
+
+This is identical to plotting the mesh with the following the parameters:
+
+.. code:: python
+
+   dragon.plot(cpos='xy', color='red', background='white', show_axes=False)
+
+
+Creating A Custom Theme
+-----------------------
+You can customize a theme based on one of the built-in themes and then
+apply it globally with:
+
+.. jupyter-execute::
+
+   # create a theme based off the DocumentTheme
+   my_theme = pyvista.themes.DocumentTheme()
+   my_theme.cmap = 'jet'
+   my_theme.show_edge = True
+
+   # apply it globally
+   pyvista.global_theme.load_theme(my_theme)
+
+Alternatively, you can save the theme to disk to be used later with:
+
+.. code:: python
+
+   my_theme.save('my_theme.json')
+
+And then subsequently loaded in a new session of pyvista with:
+
+   pyvista.global_theme.load_theme('my_theme.json')
+
+
+Theme API
+---------
+.. automodule:: pyvista.themes
+   :members:

--- a/examples/02-plot/depth-peeling.py
+++ b/examples/02-plot/depth-peeling.py
@@ -3,10 +3,11 @@ Depth Peeling
 ~~~~~~~~~~~~~
 
 Depth peeling is a technique to correctly render translucent geometry.
-This is not enabled by default in `pyvista.rcParams` as some operating
+This is not enabled by default in `pyvista.defaults` as some operating
 systems and versions of VTK have issues with this routine.
 
-For this example, we will showcase the difference that depth peeling provides.
+For this example, we will showcase the difference that depth peeling
+provides.
 
 """
 # sphinx_gallery_thumbnail_number = 2
@@ -26,13 +27,13 @@ for i, c in enumerate(centers):
 ###############################################################################
 dargs = dict(opacity=0.5, color="red", smooth_shading=True)
 
-p = pv.Plotter(shape=(1,2), multi_samples=8)
+p = pv.Plotter(shape=(1, 2), multi_samples=8)
 
 p.add_mesh(spheres, **dargs)
 p.enable_depth_peeling(10)
 p.add_text("Depth Peeling")
 
-p.subplot(0,1)
+p.subplot(0, 1)
 p.add_text("Standard")
 p.add_mesh(spheres.copy(), **dargs)
 
@@ -50,7 +51,7 @@ p.show()
 
 room = examples.download_room_surface_mesh()
 
-p = pv.Plotter(shape=(1,2))
+p = pv.Plotter(shape=(1, 2))
 
 p.enable_depth_peeling(number_of_peels=4, occlusion_ratio=0)
 p.add_mesh(room, opacity=0.5, color="tan")
@@ -63,7 +64,7 @@ p.add_mesh(room.copy(), opacity=0.5, color="tan")
 p.link_views()
 p.camera_position = [(43.6, 49.5, 19.8),
                      (0.0, 2.25, 0.0),
-                    (-0.57, 0.70, -0.42)]
+                     (-0.57, 0.70, -0.42)]
 
 p.show()
 

--- a/examples/02-plot/multi-window.py
+++ b/examples/02-plot/multi-window.py
@@ -65,11 +65,11 @@ plotter.show()
 
 # This defines the position of the vertical/horizontal splitting, in this
 # case 40% of the vertical/horizontal dimension of the window
-pv.rcParams['multi_rendering_splitting_position'] = 0.40
+pv.defaults.multi_rendering_splitting_position = 0.40
 
 # shape="3|1" means 3 plots on the left and 1 on the right,
 # shape="4/2" means 4 plots on top of 2 at bottom.
-plotter = pv.Plotter(shape='3|1', window_size=(1000,1200))
+plotter = pv.Plotter(shape='3|1', window_size=(1000, 1200))
 
 plotter.subplot(0)
 plotter.add_text("Airplane Example")

--- a/examples/02-plot/multi-window.py
+++ b/examples/02-plot/multi-window.py
@@ -65,7 +65,7 @@ plotter.show()
 
 # This defines the position of the vertical/horizontal splitting, in this
 # case 40% of the vertical/horizontal dimension of the window
-pv.defaults.multi_rendering_splitting_position = 0.40
+pv.global_theme.multi_rendering_splitting_position = 0.40
 
 # shape="3|1" means 3 plots on the left and 1 on the right,
 # shape="4/2" means 4 plots on top of 2 at bottom.
@@ -99,9 +99,10 @@ plotter.show()
 # and column indices or slices. The group always spans from the smallest to the
 # largest (row or column) id that is passed through the list or slice.
 
-import numpy as np # numpy is imported for a more convenient slice notation through np.s_
+# numpy is imported for a more convenient slice notation through np.s_
+import numpy as np
 
-shape = (5,4) # 5 by 4 grid
+shape = (5, 4)  # 5 by 4 grid
 row_weights = [0.5,1,1,2,1] # First row is half the size and fourth row is double the size of the other rows
 col_weights = [1,1,0.5,2] # Third column is half the size and fourth column is double size of the other columns
 groups = [

--- a/examples/02-plot/themes.py
+++ b/examples/02-plot/themes.py
@@ -75,18 +75,18 @@ plotter.show()
 
 
 ###############################################################################
-# Modifying Global Defaults
-# ~~~~~~~~~~~~~~~~~~~~~~~~~
+# Modifying the Global Theme
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
 # You can control how meshes are displayed by setting individual
 # parameters when plotting like ``mesh.plot(show_edges=True)``, or by
 # setting a global theme.  You can also control individual parameters
-# how all meshes are displayed by default via ``pyvista.defaults``.
+# how all meshes are displayed by default via ``pyvista.global_theme``.
 #
 # Here, we print out the current global defaults for all ``pyvista``
 # meshes.  These values have been changed by the previous "Document"
 # theme.
 
-pv.defaults
+pv.global_theme
 
 
 ###############################################################################
@@ -95,7 +95,7 @@ pv.defaults
 # change this default behavior globally by changing the default
 # parameter.
 
-pv.defaults.show_edges = True
+pv.global_theme.show_edges = True
 pv.Sphere().plot()
 
 
@@ -104,9 +104,9 @@ pv.Sphere().plot()
 # Not that the figure's color was reset to the default "white" color
 # rather than the "tan" color default with the document theme.  Under
 # the hood, each theme applied changes the global plot defaults stored
-# within ``pyvista.defaults.``
+# within ``pyvista.global_theme.``
 
-pv.defaults.restore_defaults()
+pv.global_theme.restore_defaults()
 pv.Sphere().plot()
 
 
@@ -127,7 +127,7 @@ my_theme.lighting = False
 my_theme.show_edges = True
 my_theme.axes['box'] = True
 
-pv.defaults.load_theme(my_theme)
+pv.global_theme.load_theme(my_theme)
 pv.Sphere().plot()
 
 

--- a/examples/02-plot/themes.py
+++ b/examples/02-plot/themes.py
@@ -2,7 +2,8 @@
 Control Global and Local Plotting Themes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-PyVista has a few coloring themes for you to choose!
+PyVista allows you to set global and local plotting themes to easily
+set default plotting parameters.
 
 """
 import pyvista as pv
@@ -29,8 +30,9 @@ def plot_example():
 # screen when working in dark environments.
 #
 # Here's an example of our default plotting theme - this is what you
-# would see by default after running any of our examples.
+# would see by default after running any of our examples locally.
 
+pyvista.set_plot_theme('default')
 plot_example()
 
 ###############################################################################
@@ -56,8 +58,7 @@ pv.set_plot_theme("dark")
 plot_example()
 
 ###############################################################################
-# Demo the ``'document'`` theme.
-
+# Demo the ``'document'`` theme.  This theme is used on our online examples.
 
 pv.set_plot_theme("document")
 
@@ -161,3 +162,8 @@ pl = pv.Plotter(theme=my_theme)
 # pl.theme = my_theme  # alternatively use the setter
 pl.add_mesh(pv.Cube())
 pl.show()
+
+
+###############################################################################
+# Reset to use the document theme
+pv.set_plot_theme("document")

--- a/examples/02-plot/themes.py
+++ b/examples/02-plot/themes.py
@@ -1,8 +1,9 @@
 """
-Change the Theme
-~~~~~~~~~~~~~~~~
+Control Global and Local Plotting Themes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 PyVista has a few coloring themes for you to choose!
+
 """
 import pyvista as pv
 from pyvista import examples
@@ -21,25 +22,23 @@ def plot_example():
 
 
 ###############################################################################
-# PyVista's default color theme is chosen to be generally easy on your eyes
-# and is best used when working long hours on your visualization project.
-# The grey background and warm colormaps are chosen to make sure 3D renderings
-# do not drastically change the brightness of your screen when working in dark
-# environments.
+# PyVista's default color theme is chosen to be generally easy on your
+# eyes and is best used when working long hours on your visualization
+# project.  The grey background and warm colormaps are chosen to make
+# sure 3D renderings do not drastically change the brightness of your
+# screen when working in dark environments.
 #
-# Here's an example of our default plotting theme - this is what you would see
-# by default after running any of our examples.
-
-pv.set_plot_theme("default")
+# Here's an example of our default plotting theme - this is what you
+# would see by default after running any of our examples.
 
 plot_example()
 
 ###############################################################################
 # PyVista also ships with a few plotting themes:
 #
-# * ``'ParaView'``: this is designed to mimic ParaView's default plotting theme
-# * ``'night'``: this is designed to be night-mode friendly with dark backgrounds and color schemes
-# * ``'document'``: this is built for use in document style plotting and making publication quality figures
+# * ``'ParaView'``: this is designed to mimic ParaView's default plotting theme.
+# * ``'night'``: this is designed to be night-mode friendly with dark backgrounds and color schemes.
+# * ``'document'``: this is built for use in document style plotting and making publication quality figures.
 
 ###############################################################################
 # Demo the ``'ParaView'`` theme
@@ -73,3 +72,92 @@ plotter.show_grid()
 # Here we set the gradient
 plotter.set_background("royalblue", top="aliceblue")
 plotter.show()
+
+
+###############################################################################
+# Modifying Global Defaults
+# ~~~~~~~~~~~~~~~~~~~~~~~~~
+# You can control how meshes are displayed by setting individual
+# parameters when plotting like ``mesh.plot(show_edges=True)``, or by
+# setting a global theme.  You can also control individual parameters
+# how all meshes are displayed by default via ``pyvista.defaults``.
+#
+# Here, we print out the current global defaults for all ``pyvista``
+# meshes.  These values have been changed by the previous "Document"
+# theme.
+
+pv.defaults
+
+
+###############################################################################
+# By default, edges are not shown on meshes unless explicitly
+# specified when plotting a mesh via ``show_edges=True``.  You can
+# change this default behavior globally by changing the default
+# parameter.
+
+pv.defaults.show_edges = True
+pv.Sphere().plot()
+
+
+###############################################################################
+# You can reset pyvista to default behavior with ``restore_defaults``.
+# Not that the figure's color was reset to the default "white" color
+# rather than the "tan" color default with the document theme.  Under
+# the hood, each theme applied changes the global plot defaults stored
+# within ``pyvista.defaults.``
+
+pv.defaults.restore_defaults()
+pv.Sphere().plot()
+
+
+###############################################################################
+# Creating a Custom Theme and Applying it Globally
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# You can create a custom theme by modifying one of the existing
+# themes and then loading it into the global plotting defaults.
+#
+# Here, we create a dark theme that plots meshes red by default while
+# showing edges.
+
+from pyvista import themes
+
+my_theme = themes.DarkTheme()
+my_theme.color = 'red'
+my_theme.lighting = False
+my_theme.show_edges = True
+my_theme.axes['box'] = True
+
+pv.defaults.load_theme(my_theme)
+pv.Sphere().plot()
+
+
+###############################################################################
+# Creating a Custom Theme and Applying it to a Single Plotter
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# In this example, we create a custom theme from the base "default"
+# theme and then apply it to a single plotter.  Note that this does
+# not change the behavior of the global "defaults", which are still
+# set to the modified ``DarkTheme``.
+#
+# This approach carries the advantage that you can maintain several
+# themes and apply them to one or more plotters.
+
+from pyvista import themes
+
+my_theme = themes.Theme()
+my_theme.color = 'black'
+my_theme.lighting = True
+my_theme.show_edges = True
+my_theme.edge_color = 'white'
+my_theme.background = 'white'
+
+pv.Sphere().plot(theme=my_theme)
+
+
+###############################################################################
+# Alternatively, set the theme of an instance of ``Plotter``.
+
+pl = pv.Plotter(theme=my_theme)
+# pl.theme = my_theme  # alternatively use the setter
+pl.add_mesh(pv.Cube())
+pl.show()

--- a/examples/02-plot/themes.py
+++ b/examples/02-plot/themes.py
@@ -19,7 +19,7 @@ def plot_example():
     p = pv.Plotter()
     p.add_mesh(mesh)
     p.add_bounding_box()
-    return p.show()
+    p.show()
 
 
 ###############################################################################
@@ -32,7 +32,7 @@ def plot_example():
 # Here's an example of our default plotting theme - this is what you
 # would see by default after running any of our examples locally.
 
-pyvista.set_plot_theme('default')
+pv.set_plot_theme('default')
 plot_example()
 
 ###############################################################################
@@ -72,7 +72,7 @@ plotter.add_mesh(mesh)
 plotter.show_grid()
 # Here we set the gradient
 plotter.set_background("royalblue", top="aliceblue")
-plotter.show()
+cpos = plotter.show()
 
 
 ###############################################################################
@@ -97,7 +97,7 @@ pv.global_theme
 # parameter.
 
 pv.global_theme.show_edges = True
-pv.Sphere().plot()
+cpos = pv.Sphere().plot()
 
 
 ###############################################################################
@@ -108,7 +108,7 @@ pv.Sphere().plot()
 # within ``pyvista.global_theme.``
 
 pv.global_theme.restore_defaults()
-pv.Sphere().plot()
+cpos = pv.Sphere().plot()
 
 
 ###############################################################################
@@ -129,7 +129,7 @@ my_theme.show_edges = True
 my_theme.axes.box = True
 
 pv.global_theme.load_theme(my_theme)
-pv.Sphere().plot()
+cpos = pv.Sphere().plot()
 
 
 ###############################################################################
@@ -152,7 +152,7 @@ my_theme.show_edges = True
 my_theme.edge_color = 'white'
 my_theme.background = 'white'
 
-pv.Sphere().plot(theme=my_theme)
+cpos = pv.Sphere().plot(theme=my_theme)
 
 
 ###############################################################################
@@ -161,7 +161,7 @@ pv.Sphere().plot(theme=my_theme)
 pl = pv.Plotter(theme=my_theme)
 # pl.theme = my_theme  # alternatively use the setter
 pl.add_mesh(pv.Cube())
-pl.show()
+cpos = pl.show()
 
 
 ###############################################################################

--- a/examples/02-plot/themes.py
+++ b/examples/02-plot/themes.py
@@ -37,21 +37,21 @@ plot_example()
 # PyVista also ships with a few plotting themes:
 #
 # * ``'ParaView'``: this is designed to mimic ParaView's default plotting theme.
-# * ``'night'``: this is designed to be night-mode friendly with dark backgrounds and color schemes.
+# * ``'dark'``: this is designed to be night-mode friendly with dark backgrounds and color schemes.
 # * ``'document'``: this is built for use in document style plotting and making publication quality figures.
 
 ###############################################################################
 # Demo the ``'ParaView'`` theme
 
-pv.set_plot_theme("ParaView")
+pv.set_plot_theme("paraview")
 
 plot_example()
 
 
 ###############################################################################
-# Demo the ``'night'`` theme
+# Demo the ``'dark'`` theme
 
-pv.set_plot_theme("night")
+pv.set_plot_theme("dark")
 
 plot_example()
 
@@ -125,7 +125,7 @@ my_theme = themes.DarkTheme()
 my_theme.color = 'red'
 my_theme.lighting = False
 my_theme.show_edges = True
-my_theme.axes['box'] = True
+my_theme.axes.box = True
 
 pv.global_theme.load_theme(my_theme)
 pv.Sphere().plot()

--- a/examples/02-plot/themes.py
+++ b/examples/02-plot/themes.py
@@ -144,7 +144,7 @@ pv.Sphere().plot()
 
 from pyvista import themes
 
-my_theme = themes.Theme()
+my_theme = themes.DefaultTheme()
 my_theme.color = 'black'
 my_theme.lighting = True
 my_theme.show_edges = True

--- a/examples/02-plot/topo-map.py
+++ b/examples/02-plot/topo-map.py
@@ -33,7 +33,7 @@ plt.imshow(topo_map.to_array())
 # method, then you can map that imagery to the surface mesh as follows:
 
 # Bounds of the aerial imagery - given to us
-bounds = (1818000,1824500,5645000,5652500,0,3000)
+bounds = (1818000, 1824500, 5645000, 5652500, 0, 3000)
 # Clip the elevation dataset to the map's extent
 local = elevation.clip_box(bounds, invert=False)
 # Apply texturing coordinates to associate the image to the surface

--- a/examples/03-widgets/line-widget.py
+++ b/examples/03-widgets/line-widget.py
@@ -17,7 +17,7 @@ import pyvista as pv
 from pyvista import examples
 import numpy as np
 
-pv.set_plot_theme('doc')
+pv.set_plot_theme('document')
 
 mesh = examples.download_kitchen()
 furniture = examples.download_kitchen(split=True)

--- a/ignore_words.txt
+++ b/ignore_words.txt
@@ -1,3 +1,4 @@
 lod
 byteorder
 flem
+parm

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -22,6 +22,10 @@ from pyvista.utilities.sphinx_gallery import _get_sg_image_scraper
 
 global_theme = _GlobalTheme()
 
+# Set preferred plot theme
+if 'PYVISTA_PLOT_THEME' in os.environ:
+    set_plot_theme(os.environ['PYVISTA_PLOT_THEME'].lower())
+
 # get the int type from vtk
 ID_TYPE = _get_vtk_id_type()
 
@@ -83,9 +87,7 @@ except Exception as e:
 # Send VTK messages to the logging module:
 send_errors_to_logging()
 
-# Set preferred plot theme
-if 'PYVISTA_PLOT_THEME' in os.environ:
-    set_plot_theme(os.environ['PYVISTA_PLOT_THEME'].lower())
 
-# Set a parameter to control default print format for floats
+# Set a parameter to control default print format for floats outside
+# of the plotter
 FLOAT_FORMAT = "{:.3e}"

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -14,7 +14,8 @@ from pyvista.core import *
 from pyvista.utilities.misc import _get_vtk_id_type
 from pyvista import _vtk
 from pyvista.jupyter import set_jupyter_backend, PlotterITK
-from pyvista.themes import _GlobalTheme, set_plot_theme
+from pyvista.themes import set_plot_theme
+from pyvista.themes import DefaultTheme as _GlobalTheme  # hide this
 
 # Per contract with Sphinx-Gallery, this method must be available at top level
 from pyvista.utilities.sphinx_gallery import _get_sg_image_scraper

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -14,7 +14,7 @@ from pyvista.core import *
 from pyvista.utilities.misc import _get_vtk_id_type
 from pyvista import _vtk
 from pyvista.jupyter import set_jupyter_backend, PlotterITK
-from pyvista.themes import set_plot_theme
+from pyvista.themes import set_plot_theme, load_theme
 from pyvista.themes import DefaultTheme as _GlobalTheme  # hide this
 
 # Per contract with Sphinx-Gallery, this method must be available at top level

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -1,8 +1,12 @@
 """PyVista package for 3D plotting and mesh analysis."""
+
+MAX_N_COLOR_BARS = 10
+
 import warnings
 import os
 import appdirs
 
+# Load default theme.  Must be loaded first.
 from pyvista._version import __version__
 from pyvista.plotting import *
 from pyvista.utilities import *
@@ -10,9 +14,12 @@ from pyvista.core import *
 from pyvista.utilities.misc import _get_vtk_id_type
 from pyvista import _vtk
 from pyvista.jupyter import set_jupyter_backend, PlotterITK
+from pyvista.themes import Defaults, set_plot_theme
 
 # Per contract with Sphinx-Gallery, this method must be available at top level
 from pyvista.utilities.sphinx_gallery import _get_sg_image_scraper
+
+defaults = Defaults()
 
 # get the int type from vtk
 ID_TYPE = _get_vtk_id_type()
@@ -37,19 +44,6 @@ BUILDING_GALLERY = False
 if 'PYVISTA_BUILDING_GALLERY' in os.environ:
     if os.environ['PYVISTA_BUILDING_GALLERY'].lower() == 'true':
         BUILDING_GALLERY = True
-
-# Grab system flag for anti-aliasing
-try:
-    rcParams['multi_samples'] = int(os.environ['PYVISTA_MULTI_SAMPLES'])
-except KeyError:
-    pass
-
-# Grab system flag for auto-closing
-try:
-    # This only sets to false if PYVISTA_AUTO_CLOSE is false
-    rcParams['auto_close'] = not os.environ['PYVISTA_AUTO_CLOSE'].lower() == 'false'
-except KeyError:
-    pass
 
 # A threshold for the max cells to compute a volume for when repr-ing
 REPR_VOLUME_MAX_CELLS = 1e6
@@ -89,11 +83,8 @@ except Exception as e:
 send_errors_to_logging()
 
 # Set preferred plot theme
-try:
-    theme = os.environ['PYVISTA_PLOT_THEME'].lower()
-    set_plot_theme(theme)
-except KeyError:
-    pass
+if 'PYVISTA_PLOT_THEME' in os.environ:
+    set_plot_theme(os.environ['PYVISTA_PLOT_THEME'].lower())
 
 # Set a parameter to control default print format for floats
 FLOAT_FORMAT = "{:.3e}"

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -14,13 +14,14 @@ from pyvista.core import *
 from pyvista.utilities.misc import _get_vtk_id_type
 from pyvista import _vtk
 from pyvista.jupyter import set_jupyter_backend, PlotterITK
-from pyvista.themes import set_plot_theme, load_theme
+from pyvista.themes import set_plot_theme, load_theme, _rcParams
 from pyvista.themes import DefaultTheme as _GlobalTheme  # hide this
 
 # Per contract with Sphinx-Gallery, this method must be available at top level
 from pyvista.utilities.sphinx_gallery import _get_sg_image_scraper
 
 global_theme = _GlobalTheme()
+rcParams = _rcParams()  # raises DeprecationError when used
 
 # Set preferred plot theme
 if 'PYVISTA_PLOT_THEME' in os.environ:

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -14,12 +14,12 @@ from pyvista.core import *
 from pyvista.utilities.misc import _get_vtk_id_type
 from pyvista import _vtk
 from pyvista.jupyter import set_jupyter_backend, PlotterITK
-from pyvista.themes import Defaults, set_plot_theme
+from pyvista.themes import _GlobalTheme, set_plot_theme
 
 # Per contract with Sphinx-Gallery, this method must be available at top level
 from pyvista.utilities.sphinx_gallery import _get_sg_image_scraper
 
-defaults = Defaults()
+global_theme = _GlobalTheme()
 
 # get the int type from vtk
 ID_TYPE = _get_vtk_id_type()

--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -6,6 +6,54 @@ from .itkplotter import PlotterITK
 ALLOWED_BACKENDS = ['ipyvtklink', 'panel', 'ipygany', 'static', 'none']
 
 
+def _validate_jupyter_backend(backend):
+    """Validate a jupyter backend is valid."""
+    # Must be a string
+    if backend is None:
+        backend = 'none'
+    backend = backend.lower()
+
+    try:
+        import IPython
+    except ImportError:  # pragma: no cover
+        raise ImportError('Install IPython to display with pyvista in a notebook.')
+
+    if backend == 'ipyvtk_simple':
+        try:
+            import ipyvtklink
+        except ImportError:
+            raise ImportError('Please install `ipyvtklink`. `ipyvtk_simple` '
+                              'is deprecated.')
+        else:
+            backend = 'ipyvtklink'
+
+    if backend not in ALLOWED_BACKENDS:
+        backend_list_str = ', '.join([f'"{item}"' for item in ALLOWED_BACKENDS])
+        raise ValueError(f'Invalid Jupyter notebook plotting backend "{backend}".\n'
+                         f'Use one of the following:\n{backend_list_str}')
+
+    # verify required packages are installed
+    if backend == 'ipyvtklink':
+        try:
+            import ipyvtklink
+        except ImportError:    # pragma: no cover
+            raise ImportError('Please install `ipyvtklink` to use this feature')
+
+    if backend == 'panel':
+        try:
+            import panel
+        except ImportError:  # pragma: no cover
+            raise ImportError('Please install `panel` to use this feature')
+        panel.extension('vtk')
+
+    if backend == 'ipygany':
+        # raises an import error when fail
+        from pyvista.jupyter import pv_ipygany
+
+    if backend == 'none':
+        backend = None
+    return backend
+
 def set_jupyter_backend(backend):
     """Set the plotting backend for a jupyter notebook.
 
@@ -67,49 +115,4 @@ def set_jupyter_backend(backend):
     >>> pv.set_jupyter_backend(None)  # or 'none'
 
     """
-    # Must be a string
-    if backend is None:
-        backend = 'none'
-    backend = backend.lower()
-
-    try:
-        import IPython
-    except ImportError:  # pragma: no cover
-        raise ImportError('Install IPython to display with pyvista in a notebook.')
-
-    if backend == 'ipyvtk_simple':
-        try:
-            import ipyvtklink
-        except ImportError:
-            raise ImportError('Please install `ipyvtklink`. `ipyvtk_simple` '
-                              'is deprecated.')
-        else:
-            backend = 'ipyvtklink'
-
-    if backend not in ALLOWED_BACKENDS:
-        backend_list_str = ', '.join([f'"{item}"' for item in ALLOWED_BACKENDS])
-        raise ValueError(f'Invalid Jupyter notebook plotting backend "{backend}".\n'
-                         f'Use one of the following:\n{backend_list_str}')
-
-    # verify required packages are installed
-    if backend == 'ipyvtklink':
-        try:
-            import ipyvtklink
-        except ImportError:    # pragma: no cover
-            raise ImportError('Please install `ipyvtklink` to use this feature')
-
-    if backend == 'panel':
-        try:
-            import panel
-        except ImportError:  # pragma: no cover
-            raise ImportError('Please install `panel` to use this feature')
-        panel.extension('vtk')
-
-    if backend == 'ipygany':
-        # raises an import error when fail
-        from pyvista.jupyter import pv_ipygany
-
-    if backend == 'none':
-        backend = None
-
-    pyvista.global_theme._jupyter_backend = backend
+    pyvista.global_theme._jupyter_backend = _validate_jupyter_backend(backend)

--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -7,7 +7,11 @@ ALLOWED_BACKENDS = ['ipyvtklink', 'panel', 'ipygany', 'static', 'none']
 
 
 def _validate_jupyter_backend(backend):
-    """Validate a jupyter backend is valid."""
+    """Validate that a jupyter backend is valid.
+
+    Returns the normalized name of the backend. Raises if the backend is invalid.
+
+    """
     # Must be a string
     if backend is None:
         backend = 'none'
@@ -37,13 +41,13 @@ def _validate_jupyter_backend(backend):
         try:
             import ipyvtklink
         except ImportError:    # pragma: no cover
-            raise ImportError('Please install `ipyvtklink` to use this feature')
+            raise ImportError('Please install `ipyvtklink` to use this feature.')
 
     if backend == 'panel':
         try:
             import panel
         except ImportError:  # pragma: no cover
-            raise ImportError('Please install `panel` to use this feature')
+            raise ImportError('Please install `panel` to use this feature.')
         panel.extension('vtk')
 
     if backend == 'ipygany':
@@ -53,6 +57,7 @@ def _validate_jupyter_backend(backend):
     if backend == 'none':
         backend = None
     return backend
+
 
 def set_jupyter_backend(backend):
     """Set the plotting backend for a jupyter notebook.

--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -119,7 +119,7 @@ def set_jupyter_backend(backend):
     if backend == 'none':
         backend = None
 
-    rcParams['jupyter_backend'] = backend
+    pyvista.theme._jupyter_backend = backend
 
 
 # this will run on __init__ to set the backend

--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -1,16 +1,10 @@
 """Jupyter notebook plotting module."""
 
-import os
-from .. import rcParams
+import pyvista
 from .itkplotter import PlotterITK
 
 ALLOWED_BACKENDS = ['ipyvtklink', 'panel', 'ipygany', 'static', 'none']
 
-
-def check_backend_env_var():
-    """Set ipyvtk_vtk rcParam flag for interactive notebook rendering."""
-    if 'PYVISTA_JUPYTER_BACKEND' in os.environ:
-        set_jupyter_backend(os.environ['PYVISTA_JUPYTER_BACKEND'])
 
 
 def set_jupyter_backend(backend):
@@ -114,13 +108,13 @@ def set_jupyter_backend(backend):
 
     if backend == 'ipygany':
         # raises an import error when fail
-        import pyvista.jupyter.pv_ipygany
+        from pyvista.jupyter import pv_ipygany
 
     if backend == 'none':
         backend = None
 
-    pyvista.theme._jupyter_backend = backend
+    pyvista.defaults._jupyter_backend = backend
 
 
 # this will run on __init__ to set the backend
-check_backend_env_var()
+# check_backend_env_var()

--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -6,7 +6,6 @@ from .itkplotter import PlotterITK
 ALLOWED_BACKENDS = ['ipyvtklink', 'panel', 'ipygany', 'static', 'none']
 
 
-
 def set_jupyter_backend(backend):
     """Set the plotting backend for a jupyter notebook.
 
@@ -113,8 +112,4 @@ def set_jupyter_backend(backend):
     if backend == 'none':
         backend = None
 
-    pyvista.defaults._jupyter_backend = backend
-
-
-# this will run on __init__ to set the backend
-# check_backend_env_var()
+    pyvista.global_theme._jupyter_backend = backend

--- a/pyvista/jupyter/pv_ipygany.py
+++ b/pyvista/jupyter/pv_ipygany.py
@@ -5,7 +5,6 @@ import warnings
 
 import numpy as np
 from IPython import display
-from traitlets import Enum
 
 
 # not to be imported at the init level

--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -1,15 +1,16 @@
 """Plotting routines."""
 
+from pyvista import MAX_N_COLOR_BARS
 from .colors import (color_char_to_word, get_cmap_safe, hex_to_rgb, hexcolors,
                      string_to_rgb, PARAVIEW_BACKGROUND)
 from .export_vtkjs import export_plotter_vtkjs, get_vtkjs_url
 from .helpers import plot, plot_arrows, plot_compare_four, plot_itk
 from .plotting import BasePlotter, Plotter, close_all
 from .renderer import CameraPosition, Renderer, scale_point
-from .theme import (DEFAULT_THEME, FONT_KEYS, MAX_N_COLOR_BARS,
-                    parse_color, parse_font_family, rcParams, set_plot_theme)
 from .tools import (create_axes_marker, create_axes_orientation_box,
-                    opacity_transfer_function, system_supports_plotting)
+                    opacity_transfer_function, FONT_KEYS,
+                    system_supports_plotting, parse_color,
+                    parse_font_family)
 from .widgets import WidgetHelper
 from .lights import Light
 from .camera import Camera

--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -8,7 +8,7 @@ from .helpers import plot, plot_arrows, plot_compare_four, plot_itk
 from .plotting import BasePlotter, Plotter, close_all
 from .renderer import CameraPosition, Renderer, scale_point
 from .tools import (create_axes_marker, create_axes_orientation_box,
-                    opacity_transfer_function, FONT_KEYS,
+                    opacity_transfer_function, FONTS,
                     system_supports_plotting, parse_color,
                     parse_font_family)
 from .widgets import WidgetHelper

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -10,7 +10,7 @@ from .plotting import Plotter
 
 def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
          interactive=True, cpos=None, window_size=None,
-         show_bounds=False, show_axes=True, notebook=None, background=None,
+         show_bounds=False, show_axes=None, notebook=None, background=None,
          text='', return_img=False, eye_dome_lighting=False, volume=False,
          parallel_projection=False, use_ipyvtk=None, jupyter_backend=None,
          return_viewer=False, jupyter_kwargs={}, theme=None, **kwargs):
@@ -48,7 +48,8 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
         notebook.  Assumes a jupyter console is active.
 
     show_axes : bool, optional
-        Shows a vtk axes widget.  Enabled by default.
+        Shows a vtk axes widget.  If ``None``, enabled according to
+        ``pyvista.global_theme.axes.show``.
 
     text : str, optional
         Adds text at the bottom of the plot.
@@ -115,6 +116,9 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
     if notebook:
         off_screen = notebook
     plotter = Plotter(off_screen=off_screen, notebook=notebook, theme=theme)
+
+    if show_axes is None:
+        show_axes = pyvista.global_theme.axes.show
     if show_axes:
         plotter.add_axes()
 

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -76,7 +76,8 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
     jupyter_kwargs : dict, optional
         Keyword arguments for the Jupyter notebook plotting backend.
 
-    
+    theme : pyvista.Theme, optional
+        Plot specific theme.
 
     **kwargs : optional keyword arguments
         See help(Plotter.add_mesh) for additional options.
@@ -109,7 +110,7 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
 
     eye_dome_lighting = kwargs.pop("edl", eye_dome_lighting)
     show_grid = kwargs.pop('show_grid', False)
-    auto_close = kwargs.get('auto_close', pyvista.defaults.auto_close)
+    auto_close = kwargs.get('auto_close', pyvista.global_theme.auto_close)
 
     if notebook:
         off_screen = notebook

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -6,7 +6,6 @@ import scooby
 import pyvista
 from pyvista.utilities import is_pyvista_dataset
 from .plotting import Plotter
-from .theme import rcParams
 
 
 def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
@@ -14,7 +13,7 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
          show_bounds=False, show_axes=True, notebook=None, background=None,
          text='', return_img=False, eye_dome_lighting=False, volume=False,
          parallel_projection=False, use_ipyvtk=None, jupyter_backend=None,
-         return_viewer=False, jupyter_kwargs={}, **kwargs):
+         return_viewer=False, jupyter_kwargs={}, theme=None, **kwargs):
     """Plot a vtk or numpy object.
 
     Parameters
@@ -27,14 +26,15 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
         without a window popping up.
 
     full_screen : bool, optional
-        Opens window in full screen.  When enabled, ignores ``window_size``.
-        Default ``False``.
+        Opens window in full screen.  When enabled, ignores
+        ``window_size``.  Default ``False``.
 
     screenshot : str or bool, optional
         Saves screenshot to file when enabled.  See:
         ``help(pyvista.Plotter.screenshot)``.  Default ``False``.
 
-        When ``True``, takes screenshot and returns ``numpy`` array of image.
+        When ``True``, takes screenshot and returns ``numpy`` array of
+        image.
 
     window_size : list, optional
         Window size in pixels.  Defaults to ``[1024, 768]``
@@ -76,6 +76,8 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
     jupyter_kwargs : dict, optional
         Keyword arguments for the Jupyter notebook plotting backend.
 
+    
+
     **kwargs : optional keyword arguments
         See help(Plotter.add_mesh) for additional options.
 
@@ -90,6 +92,14 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
         [Window height x Window width x 4] for transparent_background=True
         Returned only when screenshot enabled
 
+    Examples
+    --------
+    Plot a simple sphere while showing its edges.
+
+    >>> import pyvista
+    >>> mesh = pyvista.Sphere()
+    >>> mesh.plot(show_edges=True)  # doctest:+SKIP
+
     """
     if notebook is None:
         notebook = scooby.in_ipykernel()
@@ -99,11 +109,11 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
 
     eye_dome_lighting = kwargs.pop("edl", eye_dome_lighting)
     show_grid = kwargs.pop('show_grid', False)
-    auto_close = kwargs.get('auto_close', rcParams['auto_close'])
+    auto_close = kwargs.get('auto_close', pyvista.defaults.auto_close)
 
     if notebook:
         off_screen = notebook
-    plotter = Plotter(off_screen=off_screen, notebook=notebook)
+    plotter = Plotter(off_screen=off_screen, notebook=notebook, theme=theme)
     if show_axes:
         plotter.add_axes()
 

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -77,7 +77,7 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
     jupyter_kwargs : dict, optional
         Keyword arguments for the Jupyter notebook plotting backend.
 
-    theme : pyvista.DefaultTheme, optional
+    theme : pyvista.themes.DefaultTheme, optional
         Plot specific theme.
 
     **kwargs : optional keyword arguments

--- a/pyvista/plotting/lights.py
+++ b/pyvista/plotting/lights.py
@@ -11,7 +11,7 @@ try:
 except ImportError:  # pragma: no cover
     from vtk import vtkLight, vtkLightActor, vtkMatrix4x4
 
-from .theme import parse_color
+from .tools import parse_color
 from ..utilities.helpers import vtkmatrix_from_array
 
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2960,7 +2960,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             String name of the point data array to use.
 
         fmt : str
-            String formatter used to format numerical data
+            String formatter used to format numerical data.
 
         """
         if not is_pyvista_dataset(points):

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -153,7 +153,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         The default is a Light Kit (to be precise, 5 separate lights
         that act like a Light Kit).
 
-    theme : pyvista.DefaultTheme, optional
+    theme : pyvista.themes.DefaultTheme, optional
         Plot-specific theme.
 
     """
@@ -174,8 +174,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
             self._theme.load_theme(pyvista.global_theme)
         else:
             if not isinstance(theme, pyvista.themes.DefaultTheme):
-                raise TypeError('Expected ``pyvista.DefaultTheme`` for ``theme``, not '
-                                f'{type(theme)}')
+                raise TypeError('Expected ``pyvista.themes.DefaultTheme`` for '
+                                f'``theme``, not {type(theme).__name__}.')
             self._theme.load_theme(theme)
 
         self.image_transparent_background = self._theme.transparent_background
@@ -3720,7 +3720,7 @@ class Plotter(BasePlotter):
         The default is a ``'light_kit'`` (to be precise, 5 separate
         lights that act like a Light Kit).
 
-    theme : pyvista.DefaultTheme, optional
+    theme : pyvista.themes.DefaultTheme, optional
         Plot-specific theme.
 
     """

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -25,7 +25,8 @@ from pyvista.utilities import (assert_empty_kwargs, convert_array,
                                is_pyvista_dataset, abstract_class,
                                numpy_to_texture, raise_not_matching,
                                wrap)
-from pyvista.utilities.regression import image_from_window
+from ..utilities.regression import image_from_window
+from ..utilities.misc import PyvistaDeprecationWarning
 from .colors import get_cmap_safe
 from .export_vtkjs import export_plotter_vtkjs
 from .mapper import make_mapper
@@ -37,7 +38,6 @@ from .widgets import WidgetHelper
 from .scalar_bars import ScalarBars
 from .renderers import Renderers
 from .render_window_interactor import RenderWindowInteractor
-
 
 def _has_matplotlib():
     try:
@@ -110,11 +110,6 @@ Use ``scalar_bar_args`` instead.  For example:
 scalar_bar_args={'title': 'Scalar Bar Title'}
 """
 
-class PyvistaDeprecationWarning(Warning):
-    """Non-supressed Depreciation Warning."""
-
-    pass
-
 
 @abstract_class
 class BasePlotter(PickingHelper, WidgetHelper):
@@ -176,10 +171,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if theme is None:
             self._theme = pyvista.global_theme
         else:
-            if not isinstance(theme, pyvista.themes.Theme):
+            if not isinstance(theme, pyvista.themes.DefaultTheme):
                 raise TypeError('Expected pyvista.Theme for ``theme``, not '
                                 f'{type(theme)}')
-            self._theme = theme
+            self._theme = pyvista.themes.DefaultTheme()
+            self._theme.load_theme(theme)
 
         self.image_transparent_background = self._theme.transparent_background
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -30,9 +30,8 @@ from .export_vtkjs import export_plotter_vtkjs
 from .mapper import make_mapper
 from .picking import PickingHelper
 from .renderer import Renderer, Camera
-from .theme import (FONT_KEYS, parse_color, parse_font_family,
-                    rcParams)
-from .tools import normalize, opacity_transfer_function
+from .tools import (normalize, opacity_transfer_function, parse_color,
+                    parse_font_family, FONT_KEYS)
 from .widgets import WidgetHelper
 from .scalar_bars import ScalarBars
 from .renderers import Renderers
@@ -87,7 +86,7 @@ def _warn_xserver():  # pragma: no cover
             return
 
         # finally, check if using a backend that doesn't require an xserver
-        if rcParams['jupyter_backend'] in ['ipygany']:
+        if pyvista.defaults.jupyter_backend in ['ipygany']:
             return
 
         # Check if VTK has EGL support
@@ -159,6 +158,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
         The default is a Light Kit (to be precise, 5 separate lights
         that act like a Light Kit).
 
+    theme : pyvista.Theme, optional
+        Plot specific theme.
+
     """
 
     mouse_position = None
@@ -167,17 +169,25 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def __init__(self, shape=(1, 1), border=None, border_color='k',
                  border_width=2.0, title=None, splitting_position=None,
                  groups=None, row_weights=None, col_weights=None,
-                 lighting='light kit'):
+                 lighting='light kit', theme=None):
         """Initialize base plotter."""
         log.debug('BasePlotter init start')
-        self.image_transparent_background = rcParams['transparent_background']
+        if theme is None:
+            self._theme = pyvista.defaults
+        else:
+            if not isinstance(theme, pyvista.themes.Theme):
+                raise TypeError('Expected pyvista.Theme for ``theme``, not '
+                                f'{type(theme)}')
+            self._theme = theme
+
+        self.image_transparent_background = self._theme.transparent_background
 
         # optional function to be called prior to closing
         self.__before_close_callback = None
         self._store_image = False
         self.mesh = None
         if title is None:
-            title = rcParams['title']
+            title = self._theme.title
         self.title = str(title)
 
         # add renderers
@@ -220,6 +230,29 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self._image_depth_null = None
         self.last_image_depth = None
         self.last_image = None
+
+    @property
+    def theme(self):
+        """Return or set the theme used for this plotter.
+
+        Examples
+        --------
+        Use the dark theme for a plotter.
+
+        >>> import pyvista
+        >>> from pyvista import themes
+        >>> pl = pyvista.Plotter()
+        >>> pl.theme = themes.DarkTheme()
+
+        """
+        return self._theme
+
+    @theme.setter
+    def theme(self, theme):
+        if not isinstance(theme, pyvista.themes.Theme):
+            raise TypeError('Expected an instance of pyvista.Theme, not '
+                            f'{type(theme)}')
+        self._theme = theme
 
     @property
     def scalar_bar(self):
@@ -1270,22 +1303,22 @@ class BasePlotter(PickingHelper, WidgetHelper):
             scalar_bar_args = {'n_colors': n_colors}
 
         if show_edges is None:
-            show_edges = rcParams['show_edges']
+            show_edges = self._theme.show_edges
 
         if edge_color is None:
-            edge_color = rcParams['edge_color']
+            edge_color = self._theme.edge_color
 
         if show_scalar_bar is None:
-            show_scalar_bar = rcParams['show_scalar_bar']
+            show_scalar_bar = self._theme.show_scalar_bar
 
         if lighting is None:
-            lighting = rcParams['lighting']
+            lighting = self._theme.lighting
 
         if smooth_shading is None:
             if pbr:
                 smooth_shading = True
             else:
-                smooth_shading = rcParams['smooth_shading']
+                smooth_shading = self._theme.smooth_shading
 
         # supported aliases
         clim = kwargs.pop('rng', clim)
@@ -1293,17 +1326,17 @@ class BasePlotter(PickingHelper, WidgetHelper):
         culling = kwargs.pop("backface_culling", culling)
 
         if render_points_as_spheres is None:
-            render_points_as_spheres = rcParams['render_points_as_spheres']
+            render_points_as_spheres = self._theme.render_points_as_spheres
 
         if name is None:
             name = f'{type(mesh).__name__}({mesh.memory_address})'
 
         if nan_color is None:
-            nan_color = rcParams['nan_color']
+            nan_color = self._theme.nan_color
         nan_color = list(parse_color(nan_color))
         nan_color.append(nan_opacity)
         if color is True:
-            color = rcParams['color']
+            color = self._theme.color
 
         if texture is False:
             texture = None
@@ -1398,7 +1431,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         ##### Plot a single PyVista mesh #####
 
-        silhouette_params = dict(rcParams['silhouette'])
+        silhouette_params = dict(self._theme.silhouette)
         if isinstance(silhouette, dict):
             silhouette_params.update(silhouette)
             silhouette = True
@@ -1533,7 +1566,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         # Scalars formatting ==================================================
         if cmap is None:  # Set default map if matplotlib is available
             if _has_matplotlib():
-                cmap = rcParams['cmap']
+                cmap = self._theme.cmap
         # Set the array title for when it is added back to the mesh
         if _custom_opac:
             title = '__custom_rgba'
@@ -1648,7 +1681,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 if isinstance(cmap, str):
                     self.mapper.cmap = cmap
                 # ipygany uses different colormaps
-                if rcParams['jupyter_backend'] == 'ipygany':
+                if self._theme.jupyter_backend == 'ipygany':
                     from ..jupyter.pv_ipygany import check_colormap
                     check_colormap(cmap)
                 else:
@@ -1697,7 +1730,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if style == 'wireframe':
             prop.SetRepresentationToWireframe()
             if color is None:
-                color = rcParams['outline_color']
+                color = self._theme.outline_color
         elif style == 'points':
             prop.SetRepresentationToPoints()
         elif style == 'surface':
@@ -1729,7 +1762,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if show_edges:
             prop.EdgeVisibilityOn()
 
-        rgb_color = parse_color(color)
+        rgb_color = parse_color(color, default_color=self._theme.color)
         prop.SetColor(rgb_color)
         if isinstance(opacity, (float, int)):
             prop.SetOpacity(opacity)
@@ -1863,36 +1896,39 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         mapper : str, optional
             Volume mapper to use given by name. Options include:
-            ``'fixed_point'``, ``'gpu'``, ``'open_gl'``, and ``'smart'``.
-            If ``None`` the ``"volume_mapper"`` in the ``rcParams`` is used.
+            ``'fixed_point'``, ``'gpu'``, ``'open_gl'``, and
+            ``'smart'``.  If ``None`` the ``"volume_mapper"`` in the
+            ``self._theme`` is used.
 
         scalar_bar_args : dict, optional
-            Dictionary of keyword arguments to pass when adding the scalar bar
-            to the scene. For options, see
+            Dictionary of keyword arguments to pass when adding the
+            scalar bar to the scene. For options, see
             :func:`pyvista.BasePlotter.add_scalar_bar`.
 
         show_scalar_bar : bool
-            If False, a scalar bar will not be added to the scene. Defaults
-            to ``True``.
+            If ``False``, a scalar bar will not be added to the
+            scene. Defaults to ``True``.
 
         annotations : dict, optional
-            Pass a dictionary of annotations. Keys are the float values in the
-            scalars range to annotate on the scalar bar and the values are the
-            the string annotations.
+            Pass a dictionary of annotations. Keys are the float
+            values in the scalars range to annotate on the scalar bar
+            and the values are the the string annotations.
 
         opacity_unit_distance : float
-            Set/Get the unit distance on which the scalar opacity transfer
-            function is defined. Meaning that over that distance, a given
-            opacity (from the transfer function) is accumulated. This is
-            adjusted for the actual sampling distance during rendering. By
-            default, this is the length of the diagonal of the bounding box of
-            the volume divided by the dimensions.
+            Set/Get the unit distance on which the scalar opacity
+            transfer function is defined. Meaning that over that
+            distance, a given opacity (from the transfer function) is
+            accumulated. This is adjusted for the actual sampling
+            distance during rendering. By default, this is the length
+            of the diagonal of the bounding box of the volume divided
+            by the dimensions.
 
         shade : bool
-            Default off. If shading is turned on, the mapper may perform
-            shading calculations - in some cases shading does not apply
-            (for example, in a maximum intensity projection) and therefore
-            shading will not be performed even if this flag is on.
+            Default off. If shading is turned on, the mapper may
+            perform shading calculations - in some cases shading does
+            not apply (for example, in a maximum intensity projection)
+            and therefore shading will not be performed even if this
+            flag is on.
 
         diffuse : float, optional
             The diffuse lighting coefficient. Default 1.0
@@ -1932,13 +1968,13 @@ class BasePlotter(PickingHelper, WidgetHelper):
             scalar_bar_args = {}
 
         if show_scalar_bar is None:
-            show_scalar_bar = rcParams['show_scalar_bar']
+            show_scalar_bar = self._theme.show_scalar_bar
 
         if culling is True:
             culling = 'backface'
 
         if mapper is None:
-            mapper = rcParams["volume_mapper"]
+            mapper = self._theme.volume_mapper
 
         # only render when the plotter has already been shown
         if render is None:
@@ -2093,7 +2129,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         if cmap is None:  # Set default map if matplotlib is available
             if _has_matplotlib():
-                cmap = rcParams['cmap']
+                cmap = self._theme.cmap
 
         if cmap is not None:
             if not _has_matplotlib():
@@ -2296,7 +2332,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         interactive = kwargs.get('interactive', None)
         if interactive is None:
-            interactive = rcParams['interactive']
+            interactive = self._theme.interactive
             if self.shape != (1, 1):
                 interactive = False
         elif interactive and self.shape != (1, 1):
@@ -2495,11 +2531,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         """
         if font is None:
-            font = rcParams['font']['family']
+            font = self._theme.font['family']
         if font_size is None:
-            font_size = rcParams['font']['size']
+            font_size = self._theme.font['size']
         if color is None:
-            color = rcParams['font']['color']
+            color = self._theme.font['color']
         if position is None:
             # Set the position of the text to the top left corner
             window_size = self.window_size
@@ -2855,13 +2891,13 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         """
         if font_family is None:
-            font_family = rcParams['font']['family']
+            font_family = self._theme.font['family']
         if font_size is None:
-            font_size = rcParams['font']['size']
+            font_size = self._theme.font['size']
         if point_color is None:
-            point_color = rcParams['color']
+            point_color = self._theme.color
         if text_color is None:
-            text_color = rcParams['font']['color']
+            text_color = self._theme.font['color']
 
         if isinstance(points, (list, tuple)):
             points = np.array(points)
@@ -2968,7 +3004,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if not isinstance(labels, str):
             raise TypeError('labels must be a string name of the scalars array to use')
         if fmt is None:
-            fmt = rcParams['font']['fmt']
+            fmt = self._theme.font['fmt']
         if fmt is None:
             fmt = '%.6e'
         scalars = points.point_arrays[labels]
@@ -3131,7 +3167,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         # configure image filter
         if transparent_background is None:
-            transparent_background = rcParams['transparent_background']
+            transparent_background = self._theme.transparent_background
         self.image_transparent_background = transparent_background
 
         # This if statement allows you to save screenshots of closed plotters
@@ -3317,7 +3353,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         """
         if viewup is None:
-            viewup = rcParams['camera']['viewup']
+            viewup = self._theme.camera['viewup']
         center = np.array(self.center)
         bnds = np.array(self.bounds)
         radius = (bnds[1] - bnds[0]) * factor
@@ -3367,7 +3403,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if focus is None:
             focus = self.center
         if viewup is None:
-            viewup = rcParams['camera']['viewup']
+            viewup = self._theme.camera['viewup']
         if path is None:
             path = self.generate_orbital_path(viewup=viewup)
         if not is_pyvista_dataset(path):
@@ -3652,7 +3688,7 @@ class Plotter(BasePlotter):
 
     window_size : list, optional
         Window size in pixels.  Defaults to ``[1024, 768]``, unless
-        set differently in ``rcParams``.
+        set differently in ``self._theme.window_size``.
 
     multi_samples : int, optional
         The number of multi-samples used to mitigate aliasing. 4 is a
@@ -3679,6 +3715,9 @@ class Plotter(BasePlotter):
         The default is a ``'light_kit'`` (to be precise, 5 separate
         lights that act like a Light Kit).
 
+    theme : pyvista.Theme, optional
+        Plot specific theme.
+
     """
 
     last_update_time = 0.0
@@ -3689,7 +3728,8 @@ class Plotter(BasePlotter):
                  border=None, border_color='k', border_width=2.0,
                  window_size=None, multi_samples=None, line_smoothing=False,
                  point_smoothing=False, polygon_smoothing=False,
-                 splitting_position=None, title=None, lighting='light kit'):
+                 splitting_position=None, title=None, lighting='light kit',
+                 theme=None):
         """Initialize a vtk plotting object."""
         super().__init__(shape=shape, border=border,
                          border_color=border_color,
@@ -3697,7 +3737,7 @@ class Plotter(BasePlotter):
                          groups=groups, row_weights=row_weights,
                          col_weights=col_weights,
                          splitting_position=splitting_position,
-                         title=title, lighting=lighting)
+                         title=title, lighting=lighting, theme=theme)
 
         log.debug('Plotter init start')
 
@@ -3713,8 +3753,8 @@ class Plotter(BasePlotter):
             off_screen = pyvista.OFF_SCREEN
 
         if notebook is None:
-            if rcParams['notebook'] is not None:
-                notebook = rcParams['notebook']
+            if self._theme.notebook is not None:
+                notebook = self._theme.notebook
             else:
                 notebook = scooby.in_ipykernel()
 
@@ -3726,11 +3766,11 @@ class Plotter(BasePlotter):
         self._window_size_unset = False
         if window_size is None:
             self._window_size_unset = True
-            window_size = rcParams['window_size']
+            window_size = self._theme.window_size
         self.__prior_window_size = window_size
 
         if multi_samples is None:
-            multi_samples = rcParams['multi_samples']
+            multi_samples = self._theme.multi_samples
 
         # initialize render window
         self.ren_win = _vtk.vtkRenderWindow()
@@ -3766,7 +3806,7 @@ class Plotter(BasePlotter):
         self.iren.add_observer("KeyPressEvent", self.key_press_event)
 
         # Set background
-        self.set_background(rcParams['background'])
+        self.set_background(self._theme.background)
 
         # Set window size
         self.window_size = window_size
@@ -3774,7 +3814,7 @@ class Plotter(BasePlotter):
         # add timer event if interactive render exists
         self.iren.add_observer(_vtk.vtkCommand.TimerEvent, on_timer)
 
-        if rcParams["depth_peeling"]["enabled"]:
+        if self._theme.depth_peeling["enabled"]:
             if self.enable_depth_peeling():
                 for renderer in self.renderers:
                     renderer.enable_depth_peeling()
@@ -3891,7 +3931,7 @@ class Plotter(BasePlotter):
                 """)
             )
         elif auto_close is None:
-            auto_close = rcParams['auto_close']
+            auto_close = self._theme.auto_close
 
         if use_ipyvtk:
             txt = textwrap.dedent("""\
@@ -3906,7 +3946,7 @@ class Plotter(BasePlotter):
             raise RuntimeError("This plotter has been closed and cannot be shown.")
 
         if full_screen is None:
-            full_screen = rcParams['full_screen']
+            full_screen = self._theme.full_screen
 
         if full_screen:
             self.ren_win.SetFullScreen(True)
@@ -3929,7 +3969,7 @@ class Plotter(BasePlotter):
         if self.notebook:
             from ..jupyter.notebook import handle_plotter
             if jupyter_backend is None:
-                jupyter_backend = rcParams['jupyter_backend']
+                jupyter_backend = self._theme.jupyter_backend
 
             if jupyter_backend != 'none':
                 disp = handle_plotter(self, backend=jupyter_backend,

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3682,7 +3682,7 @@ class Plotter(BasePlotter):
     border : bool, optional
         Draw a border around each render window.  Default ``False``.
 
-    border_color : string or 3 item list, optional, defaults to white
+    border_color : string or 3 item list, optional
         Either a string, rgb list, or hex color string.  For example:
 
             * ``color='white'``
@@ -3720,7 +3720,7 @@ class Plotter(BasePlotter):
         The default is a ``'light_kit'`` (to be precise, 5 separate
         lights that act like a Light Kit).
 
-    theme : pyvista.Theme, optional
+    theme : pyvista.DefaultTheme, optional
         Plot-specific theme.
 
     """

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -126,9 +126,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
             * ``shape="4/2"`` means 4 plots on top and 2 at the bottom.
 
     border : bool, optional
-        Draw a border around each render window.  Default False.
+        Draw a border around each render window.  Default ``False``.
 
-    border_color : string or 3 item list, optional, defaults to white
+    border_color : string or 3 item list, optional
         Either a string, rgb list, or hex color string.  For example:
 
             * ``color='white'``
@@ -153,7 +153,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         The default is a Light Kit (to be precise, 5 separate lights
         that act like a Light Kit).
 
-    theme : pyvista.Theme, optional
+    theme : pyvista.DefaultTheme, optional
         Plot-specific theme.
 
     """
@@ -167,13 +167,15 @@ class BasePlotter(PickingHelper, WidgetHelper):
                  lighting='light kit', theme=None):
         """Initialize base plotter."""
         log.debug('BasePlotter init start')
+        self._theme = pyvista.themes.DefaultTheme()
         if theme is None:
-            self._theme = pyvista.global_theme
+            # copy global theme to ensure local plot theme is fixed
+            # after creation.
+            self._theme.load_theme(pyvista.global_theme)
         else:
             if not isinstance(theme, pyvista.themes.DefaultTheme):
-                raise TypeError('Expected pyvista.Theme for ``theme``, not '
+                raise TypeError('Expected ``pyvista.DefaultTheme`` for ``theme``, not '
                                 f'{type(theme)}')
-            self._theme = pyvista.themes.DefaultTheme()
             self._theme.load_theme(theme)
 
         self.image_transparent_background = self._theme.transparent_background

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -19,6 +19,7 @@ import scooby
 
 import pyvista
 from pyvista import _vtk
+from pyvista.themes import DefaultTheme
 from pyvista.utilities import (assert_empty_kwargs, convert_array,
                                convert_string_array, get_array,
                                is_pyvista_dataset, abstract_class,
@@ -86,7 +87,7 @@ def _warn_xserver():  # pragma: no cover
             return
 
         # finally, check if using a backend that doesn't require an xserver
-        if pyvista.defaults.jupyter_backend in ['ipygany']:
+        if pyvista.global_theme.jupyter_backend in ['ipygany']:
             return
 
         # Check if VTK has EGL support
@@ -173,7 +174,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         """Initialize base plotter."""
         log.debug('BasePlotter init start')
         if theme is None:
-            self._theme = pyvista.defaults
+            self._theme = pyvista.global_theme
         else:
             if not isinstance(theme, pyvista.themes.Theme):
                 raise TypeError('Expected pyvista.Theme for ``theme``, not '

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -250,9 +250,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     @theme.setter
     def theme(self, theme):
-        if not isinstance(theme, pyvista.themes.Theme):
-            raise TypeError('Expected an instance of pyvista.Theme, not '
-                            f'{type(theme)}')
+        if not isinstance(theme, pyvista.themes.DefaultTheme):
+            raise TypeError('Expected a pyvista theme like ``pyvista.DefaultTheme``, '
+                            f'not {type(theme)}')
         self._theme = theme
 
     @property

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -11,7 +11,6 @@ from pyvista.utilities import wrap, check_depth_peeling
 from .tools import (create_axes_orientation_box, create_axes_marker,
                     parse_color, parse_font_family)
 from .camera import Camera
-from .lights import LightType
 
 
 def scale_point(camera, point, invert=False):
@@ -276,9 +275,9 @@ class Renderer(_vtk.vtkRenderer):
 
         """
         if number_of_peels is None:
-            number_of_peels = self._theme.depth_peeling["number_of_peels"]
+            number_of_peels = self._theme.depth_peeling.number_of_peels
         if occlusion_ratio is None:
-            occlusion_ratio = self._theme.depth_peeling["occlusion_ratio"]
+            occlusion_ratio = self._theme.depth_peeling.occlusion_ratio
         depth_peeling_supported = check_depth_peeling(number_of_peels,
                                                       occlusion_ratio)
         if depth_peeling_supported:
@@ -516,7 +515,7 @@ class Renderer(_vtk.vtkRenderer):
             self.Modified()
             del self.axes_widget
         if box is None:
-            box = self._theme.axes['box']
+            box = self._theme.axes.box
         if box:
             if box_args is None:
                 box_args = {}
@@ -687,13 +686,13 @@ class Renderer(_vtk.vtkRenderer):
         self.remove_bounds_axes()
 
         if font_family is None:
-            font_family = self._theme.font['family']
+            font_family = self._theme.font.family
         if font_size is None:
-            font_size = self._theme.font['size']
+            font_size = self._theme.font.size
         if color is None:
-            color = self._theme.font['color']
+            color = self._theme.font.color
         if fmt is None:
-            fmt = self._theme.font['fmt']
+            fmt = self._theme.font.fmt
 
         color = parse_color(color)
 

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -262,7 +262,7 @@ class Renderer(_vtk.vtkRenderer):
         ----------
         number_of_peels : int
             The maximum number of peeling layers. Initial value is 4
-            and is set in the ``pyvista.defaults``. A special value of
+            and is set in the ``pyvista.global_theme``. A special value of
             0 means no maximum limit.  It has to be a positive value.
 
         occlusion_ratio : float

--- a/pyvista/plotting/renderers.py
+++ b/pyvista/plotting/renderers.py
@@ -41,7 +41,7 @@ class Renderers():
                 rangem = range(m)
 
             if splitting_position is None:
-                splitting_position = pyvista.defaults.multi_rendering_splitting_position
+                splitting_position = pyvista.global_theme.multi_rendering_splitting_position
 
             if splitting_position is None:
                 if n >= m:

--- a/pyvista/plotting/renderers.py
+++ b/pyvista/plotting/renderers.py
@@ -3,8 +3,8 @@ import collections
 
 import numpy as np
 
+import pyvista
 from .background_renderer import BackgroundRenderer
-from .theme import rcParams
 from .renderer import Renderer
 
 
@@ -41,7 +41,7 @@ class Renderers():
                 rangem = range(m)
 
             if splitting_position is None:
-                splitting_position = rcParams['multi_rendering_splitting_position']
+                splitting_position = pyvista.defaults.multi_rendering_splitting_position
 
             if splitting_position is None:
                 if n >= m:

--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -214,15 +214,15 @@ class ScalarBars():
         if interactive is None:
             interactive = pyvista.global_theme.interactive
         if font_family is None:
-            font_family = pyvista.global_theme.font['family']
+            font_family = pyvista.global_theme.font.family
         if label_font_size is None:
-            label_font_size = pyvista.global_theme.font['label_size']
+            label_font_size = pyvista.global_theme.font.label_size
         if title_font_size is None:
-            title_font_size = pyvista.global_theme.font['title_size']
+            title_font_size = pyvista.global_theme.font.title_size
         if color is None:
-            color = pyvista.global_theme.font['color']
+            color = pyvista.global_theme.font.color
         if fmt is None:
-            fmt = pyvista.global_theme.font['fmt']
+            fmt = pyvista.global_theme.font.fmt
         if vertical is None:
             if pyvista.global_theme.colorbar_orientation.lower() == 'vertical':
                 vertical = True
@@ -230,14 +230,14 @@ class ScalarBars():
         # Automatically choose size if not specified
         if width is None:
             if vertical:
-                width = pyvista.global_theme.colorbar_vertical['width']
+                width = pyvista.global_theme.colorbar_vertical.width
             else:
-                width = pyvista.global_theme.colorbar_horizontal['width']
+                width = pyvista.global_theme.colorbar_horizontal.width
         if height is None:
             if vertical:
-                height = pyvista.global_theme.colorbar_vertical['height']
+                height = pyvista.global_theme.colorbar_vertical.height
             else:
-                height = pyvista.global_theme.colorbar_horizontal['height']
+                height = pyvista.global_theme.colorbar_horizontal.height
 
         # Check that this data hasn't already been plotted
         if title in list(self._scalar_bar_ranges.keys()):
@@ -268,16 +268,16 @@ class ScalarBars():
                 raise RuntimeError('Maximum number of color bars reached.')
             if position_x is None:
                 if vertical:
-                    position_x = pyvista.global_theme.colorbar_vertical['position_x']
+                    position_x = pyvista.global_theme.colorbar_vertical.position_x
                     position_x -= slot * (width + 0.2 * width)
                 else:
-                    position_x = pyvista.global_theme.colorbar_horizontal['position_x']
+                    position_x = pyvista.global_theme.colorbar_horizontal.position_x
 
             if position_y is None:
                 if vertical:
-                    position_y = pyvista.global_theme.colorbar_vertical['position_y']
+                    position_y = pyvista.global_theme.colorbar_vertical.position_y
                 else:
-                    position_y = pyvista.global_theme.colorbar_horizontal['position_y']
+                    position_y = pyvista.global_theme.colorbar_horizontal.position_y
                     position_y += slot * height
 
         # parse color

--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -1,8 +1,9 @@
 """PyVista Scalar bar module."""
 
+import pyvista
 import numpy as np
 from pyvista import _vtk
-from .theme import parse_font_family, parse_color, rcParams
+from .tools import parse_font_family, parse_color
 
 
 class ScalarBars():
@@ -211,32 +212,32 @@ class ScalarBars():
             raise ValueError('Mapper cannot be ``None`` when creating a scalar bar')
 
         if interactive is None:
-            interactive = rcParams['interactive']
+            interactive = pyvista.defaults.interactive
         if font_family is None:
-            font_family = rcParams['font']['family']
+            font_family = pyvista.defaults.font['family']
         if label_font_size is None:
-            label_font_size = rcParams['font']['label_size']
+            label_font_size = pyvista.defaults.font['label_size']
         if title_font_size is None:
-            title_font_size = rcParams['font']['title_size']
+            title_font_size = pyvista.defaults.font['title_size']
         if color is None:
-            color = rcParams['font']['color']
+            color = pyvista.defaults.font['color']
         if fmt is None:
-            fmt = rcParams['font']['fmt']
+            fmt = pyvista.defaults.font['fmt']
         if vertical is None:
-            if rcParams['colorbar_orientation'].lower() == 'vertical':
+            if pyvista.defaults.colorbar_orientation.lower() == 'vertical':
                 vertical = True
 
         # Automatically choose size if not specified
         if width is None:
             if vertical:
-                width = rcParams['colorbar_vertical']['width']
+                width = pyvista.defaults.colorbar_vertical['width']
             else:
-                width = rcParams['colorbar_horizontal']['width']
+                width = pyvista.defaults.colorbar_horizontal['width']
         if height is None:
             if vertical:
-                height = rcParams['colorbar_vertical']['height']
+                height = pyvista.defaults.colorbar_vertical['height']
             else:
-                height = rcParams['colorbar_horizontal']['height']
+                height = pyvista.defaults.colorbar_horizontal['height']
 
         # Check that this data hasn't already been plotted
         if title in list(self._scalar_bar_ranges.keys()):
@@ -267,16 +268,16 @@ class ScalarBars():
                 raise RuntimeError('Maximum number of color bars reached.')
             if position_x is None:
                 if vertical:
-                    position_x = rcParams['colorbar_vertical']['position_x']
+                    position_x = pyvista.defaults.colorbar_vertical['position_x']
                     position_x -= slot * (width + 0.2 * width)
                 else:
-                    position_x = rcParams['colorbar_horizontal']['position_x']
+                    position_x = pyvista.defaults.colorbar_horizontal['position_x']
 
             if position_y is None:
                 if vertical:
-                    position_y = rcParams['colorbar_vertical']['position_y']
+                    position_y = pyvista.defaults.colorbar_vertical['position_y']
                 else:
-                    position_y = rcParams['colorbar_horizontal']['position_y']
+                    position_y = pyvista.defaults.colorbar_horizontal['position_y']
                     position_y += slot * height
 
         # parse color

--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -212,32 +212,32 @@ class ScalarBars():
             raise ValueError('Mapper cannot be ``None`` when creating a scalar bar')
 
         if interactive is None:
-            interactive = pyvista.defaults.interactive
+            interactive = pyvista.global_theme.interactive
         if font_family is None:
-            font_family = pyvista.defaults.font['family']
+            font_family = pyvista.global_theme.font['family']
         if label_font_size is None:
-            label_font_size = pyvista.defaults.font['label_size']
+            label_font_size = pyvista.global_theme.font['label_size']
         if title_font_size is None:
-            title_font_size = pyvista.defaults.font['title_size']
+            title_font_size = pyvista.global_theme.font['title_size']
         if color is None:
-            color = pyvista.defaults.font['color']
+            color = pyvista.global_theme.font['color']
         if fmt is None:
-            fmt = pyvista.defaults.font['fmt']
+            fmt = pyvista.global_theme.font['fmt']
         if vertical is None:
-            if pyvista.defaults.colorbar_orientation.lower() == 'vertical':
+            if pyvista.global_theme.colorbar_orientation.lower() == 'vertical':
                 vertical = True
 
         # Automatically choose size if not specified
         if width is None:
             if vertical:
-                width = pyvista.defaults.colorbar_vertical['width']
+                width = pyvista.global_theme.colorbar_vertical['width']
             else:
-                width = pyvista.defaults.colorbar_horizontal['width']
+                width = pyvista.global_theme.colorbar_horizontal['width']
         if height is None:
             if vertical:
-                height = pyvista.defaults.colorbar_vertical['height']
+                height = pyvista.global_theme.colorbar_vertical['height']
             else:
-                height = pyvista.defaults.colorbar_horizontal['height']
+                height = pyvista.global_theme.colorbar_horizontal['height']
 
         # Check that this data hasn't already been plotted
         if title in list(self._scalar_bar_ranges.keys()):
@@ -268,16 +268,16 @@ class ScalarBars():
                 raise RuntimeError('Maximum number of color bars reached.')
             if position_x is None:
                 if vertical:
-                    position_x = pyvista.defaults.colorbar_vertical['position_x']
+                    position_x = pyvista.global_theme.colorbar_vertical['position_x']
                     position_x -= slot * (width + 0.2 * width)
                 else:
-                    position_x = pyvista.defaults.colorbar_horizontal['position_x']
+                    position_x = pyvista.global_theme.colorbar_horizontal['position_x']
 
             if position_y is None:
                 if vertical:
-                    position_y = pyvista.defaults.colorbar_vertical['position_y']
+                    position_y = pyvista.global_theme.colorbar_vertical['position_y']
                 else:
-                    position_y = pyvista.defaults.colorbar_horizontal['position_y']
+                    position_y = pyvista.global_theme.colorbar_horizontal['position_y']
                     position_y += slot * height
 
         # parse color

--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -29,40 +29,99 @@ class Theme():
 
     def __init__(self):
         """Initialize the theme."""
-        self._jupyter_backend = None
-        self._auto_close = None
-        self._background = None
-        self._full_screen = None
-        self._camera = None
+        self._jupyter_backend = 'ipyvtklink'
+        self._auto_close = True  # DANGER: set to False with extreme caution
+        self._background = [0.3, 0.3, 0.3]
+        self._full_screen = False
+        self._camera = {
+            'position': [1, 1, 1],
+            'viewup': [0, 0, 1],
+        }
+
         self._notebook = None
-        self._window_size = None
-        self._font = None
-        self._cmap = None
-        self._color = None
-        self._nan_color = None
-        self._edge_color = None
-        self._outline_color = None
-        self._floor_color = None
-        self._colorbar_orientation = None
-        self._colorbar_horizontal = None
-        self._colorbar_vertical = None
-        self._show_scalar_bar = None
-        self._show_edges = None
-        self._lighting = None
-        self._interactive = None
-        self._render_points_as_spheres = None
-        self._use_ipyvtk = None
-        self._transparent_background = None
-        self._title = None
-        self._axes = None
-        self._multi_samples = None
+        self._window_size = [1024, 768]
+        self._font = {
+            'family': 'arial',
+            'size': 12,
+            'title_size': None,
+            'label_size': None,
+            'color': [1, 1, 1],
+            'fmt': None,
+        }
+
+        self._cmap = 'viridis'
+        self._color = 'white'
+        self._nan_color = 'darkgray'
+        self._edge_color = 'black'
+        self._outline_color = 'white'
+        self._floor_color = 'gray'
+        self._colorbar_orientation = 'horizontal'
+        self._colorbar_horizontal = {
+            'width': 0.6,
+            'height': 0.08,
+            'position_x': 0.35,
+            'position_y': 0.05,
+        }
+        self._colorbar_vertical = {
+            'width': 0.08,
+            'height': 0.45,
+            'position_x': 0.9,
+            'position_y': 0.02,
+        }
+        self._show_scalar_bar = True
+        self._show_edges = False
+        self._lighting = True
+        self._interactive = False
+        self._render_points_as_spheres = False
+        self._use_ipyvtk = False
+        self._transparent_background = False
+        self._title = 'PyVista'
+        self._axes = {
+            'x_color': 'tomato',
+            'y_color': 'seagreen',
+            'z_color': 'mediumblue',
+            'box': False,
+            'show': True,
+        }
+        self._multi_samples = 4
         self._multi_rendering_splitting_position = None
-        self._volume_mapper = None
-        self._smooth_shading = None
-        self._depth_peeling = None
-        self._silhouette = None
-        self._slider_style = None
-        self.restore_defaults()
+        self._volume_mapper = 'fixed_point' if os.name == 'nt' else 'smart'
+        self._smooth_shading = False
+        self._depth_peeling = {
+            'number_of_peels': 4,
+            'occlusion_ratio': 0.0,
+            'enabled': False,
+        }
+        self._silhouette = {
+            'color': 'black',
+            'line_width': 2,
+            'opacity': 1.0,
+            'feature_angle': False,
+            'decimate': 0.9,
+        },
+        self._slider_style = {
+            'classic': {
+                'slider_length': 0.02,
+                'slider_width': 0.04,
+                'slider_color': (0.5, 0.5, 0.5),
+                'tube_width': 0.005,
+                'tube_color': (1, 1, 1),
+                'cap_opacity': 1,
+                'cap_length': 0.01,
+                'cap_width': 0.02,
+            },
+            'modern': {
+                'slider_length': 0.02,
+                'slider_width': 0.04,
+                'slider_color': (0.43137255, 0.44313725, 0.45882353),
+                'tube_width': 0.04,
+                'tube_color': (0.69803922, 0.70196078, 0.70980392),
+                'cap_opacity': 0,
+                'cap_length': 0.01,
+                'cap_width': 0.02,
+            },
+        },
+
 
     @property
     def background(self):
@@ -662,98 +721,7 @@ class Theme():
 
     def restore_defaults(self):
         """Restore the theme defaults."""
-        self._jupyter_backend = 'ipyvtklink'
-        self._auto_close = True  # DANGER: set to False with extreme caution
-        self._background = [0.3, 0.3, 0.3]
-        self._full_screen = False
-        self._camera = {
-            'position': [1, 1, 1],
-            'viewup': [0, 0, 1],
-        }
-
-        self._notebook = None
-        self._window_size = [1024, 768]
-        self._font = {
-            'family': 'arial',
-            'size': 12,
-            'title_size': None,
-            'label_size': None,
-            'color': [1, 1, 1],
-            'fmt': None,
-        }
-
-        self._cmap = 'viridis'
-        self._color = 'white'
-        self._nan_color = 'darkgray'
-        self._edge_color = 'black'
-        self._outline_color = 'white'
-        self._floor_color = 'gray'
-        self._colorbar_orientation = 'horizontal'
-        self._colorbar_horizontal = {
-            'width': 0.6,
-            'height': 0.08,
-            'position_x': 0.35,
-            'position_y': 0.05,
-        }
-        self._colorbar_vertical = {
-            'width': 0.08,
-            'height': 0.45,
-            'position_x': 0.9,
-            'position_y': 0.02,
-        }
-        self._show_scalar_bar = True
-        self._show_edges = False
-        self._lighting = True
-        self._interactive = False
-        self._render_points_as_spheres = False
-        self._use_ipyvtk = False
-        self._transparent_background = False
-        self._title = 'PyVista'
-        self._axes = {
-            'x_color': 'tomato',
-            'y_color': 'seagreen',
-            'z_color': 'mediumblue',
-            'box': False,
-            'show': True,
-        }
-        self._multi_samples = 4
-        self._multi_rendering_splitting_position = None
-        self._volume_mapper = 'fixed_point' if os.name == 'nt' else 'smart'
-        self._smooth_shading = False
-        self._depth_peeling = {
-            'number_of_peels': 4,
-            'occlusion_ratio': 0.0,
-            'enabled': False,
-        }
-        self._silhouette = {
-            'color': 'black',
-            'line_width': 2,
-            'opacity': 1.0,
-            'feature_angle': False,
-            'decimate': 0.9,
-        },
-        self._slider_style = {
-            'classic': {
-                'slider_length': 0.02,
-                'slider_width': 0.04,
-                'slider_color': (0.5, 0.5, 0.5),
-                'tube_width': 0.005,
-                'tube_color': (1, 1, 1),
-                'cap_opacity': 1,
-                'cap_length': 0.01,
-                'cap_width': 0.02,
-            },
-            'modern': {
-                'slider_length': 0.02,
-                'slider_width': 0.04,
-                'slider_color': (0.43137255, 0.44313725, 0.45882353),
-                'tube_width': 0.04,
-                'tube_color': (0.69803922, 0.70196078, 0.70980392),
-                'cap_opacity': 0,
-                'cap_length': 0.01,
-                'cap_width': 0.02,
-            },
-        },
+        self.__init__()
 
     def __repr__(self):
         """User friendly representation of the pyvista theme."""

--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -2,8 +2,10 @@
 
 import os
 
+import pyvista
 from pyvista import _vtk
 from .colors import string_to_rgb, PARAVIEW_BACKGROUND
+from pyvista.jupyter import ALLOWED_BACKENDS
 
 MAX_N_COLOR_BARS = 10
 FONT_KEYS = {'arial': _vtk.VTK_ARIAL,
@@ -11,85 +13,726 @@ FONT_KEYS = {'arial': _vtk.VTK_ARIAL,
              'times': _vtk.VTK_TIMES}
 
 
-def _load_default():
-    """Generate the default theme.
+class Theme():
+    """PyVista global theme.
 
-    This is generated when called rather than provided statically to
-    avoid parameters internal to the dictionary to being overwritten.
-    These are not protected via ``dict(rcParams)`` as they do not copy
-    internal lists.
+    Stores and sets the global theme in ``pyvista``.
+
+    Examples
+    --------
+    Change the default background color to white.
+
+    >>> import pyvista
+    >>> pyvista.theme.color = 'white'
 
     """
-    return {
-        'jupyter_backend': 'ipyvtklink',
-        'auto_close': True,  # DANGER: set to False with extreme caution
-        'background': [0.3, 0.3, 0.3],
-        'full_screen': False,
-        'camera': {
+
+    def __init__(self):
+        """Initialize the theme."""
+        self._jupyter_backend = None
+        self._auto_close = None
+        self._background = None
+        self._full_screen = None
+        self._camera = None
+        self._notebook = None
+        self._window_size = None
+        self._font = None
+        self._cmap = None
+        self._color = None
+        self._nan_color = None
+        self._edge_color = None
+        self._outline_color = None
+        self._floor_color = None
+        self._colorbar_orientation = None
+        self._colorbar_horizontal = None
+        self._colorbar_vertical = None
+        self._show_scalar_bar = None
+        self._show_edges = None
+        self._lighting = None
+        self._interactive = None
+        self._render_points_as_spheres = None
+        self._use_ipyvtk = None
+        self._transparent_background = None
+        self._title = None
+        self._axes = None
+        self._multi_samples = None
+        self._multi_rendering_splitting_position = None
+        self._volume_mapper = None
+        self._smooth_shading = None
+        self._depth_peeling = None
+        self._silhouette = None
+        self._slider_style = None
+        self.restore_defaults()
+
+    @property
+    def background(self):
+        """Return or set the default background color of a pyvista plot.
+
+        Examples
+        --------
+        Set the default global background of all plots to white.
+
+        >>> import pyvista
+        >>> pyvista.theme.background = 'white'
+        """
+        return self._background
+
+    @background.setter
+    def background(self, new_background):
+        self._background = parse_color(new_background)
+
+    @property
+    def jupyter_backend(self):
+        """Return or set the jupyter notebook plotting backend.
+
+        Jupyter backend to use when plotting.  Must be one of the
+        following:
+
+        * ``'ipyvtklink'`` : Render remotely and stream the
+          resulting VTK images back to the client.  Supports all VTK
+          methods, but suffers from lag due to remote rendering.
+          Requires that a virtual framebuffer be setup when displaying
+          on a headless server.  Must have ``ipyvtklink`` installed.
+
+        * ``'panel'`` : Convert the VTK render window to a vtkjs
+          object and then visualize that within jupyterlab. Supports
+          most VTK objects.  Requires that a virtual framebuffer be
+          setup when displaying on a headless server.  Must have
+          ``panel`` installed.
+
+        * ``'ipygany'`` : Convert all the meshes into ``ipygany``
+          meshes and streams those to be rendered on the client side.
+          Supports VTK meshes, but few others.  Aside from ``none``,
+          this is the only method that does not require a virtual
+          framebuffer.  Must have ``ipygany`` installed.
+
+        * ``'static'`` : Display a single static image within the
+          Jupyterlab environment.  Still requires that a virtual
+          framebuffer be setup when displaying on a headless server,
+          but does not require any additional modules to be installed.
+
+        * ``'none'`` : Do not display any plots within jupyterlab,
+          instead display using dedicated VTK render windows.  This
+          will generate nothing on headless servers even with a
+          virtual framebuffer.
+
+        Examples
+        --------
+        Enable the ipygany backend.
+
+        >>> import pyvista as pv
+        >>> pv.set_jupyter_backend('ipygany')
+
+        Enable the panel backend.
+
+        >>> pv.set_jupyter_backend('panel')
+
+        Enable the ipyvtklink backend.
+
+        >>> pv.set_jupyter_backend('ipyvtklink')
+
+        Just show static images.
+
+        >>> pv.set_jupyter_backend('static')
+
+        Disable all plotting within JupyterLab and display using a
+        standard desktop VTK render window.
+
+        >>> pv.set_jupyter_backend(None)  # or 'none'
+
+        """
+        return self._jupyter_backend
+
+    @jupyter_backend.setter
+    def jupyter_backend(self, value):
+        pyvista.set_jupyter_backend(value)
+
+    @property
+    def auto_close(self):
+        """Automatically close the figures when finished plotting.
+
+        .. DANGER::
+           Set to ``False`` with extreme caution.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pyvista.theme.auto_close = False
+
+        """
+        return self._auto_close
+
+    @auto_close.setter
+    def auto_close(self, value):
+        self._auto_close = value
+
+    @property
+    def full_screen(self):
+        """Return if figures are show in full screen.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pyvista.theme.full_screen = True
+        """
+        return self._full_screen
+
+    @full_screen.setter
+    def full_screen(self, value):
+        self._full_screen = value
+
+    @property
+    def camera(self):
+        """Return or set the default camera position
+
+        Examples
+        --------
+        Set both the position and view of the camera.
+
+        >>> import pyvista
+        >>> pyvista.theme.camera = {'position': [1, 1, 1],
+        ...                         'viewup': [0, 0, 1]}
+
+        Set the default position of the camera
+
+        >>> pyvista.theme.camera['position'] = [1, 1, 1]
+
+        Set the default view of the camera
+
+        >>> pyvista.theme.camera['viewup'] = [0, 0, 1]
+
+        """
+        return self._camera
+
+    @camera.setter
+    def camera(self, camera):
+        if not isinstance(camera, dict):
+            raise TypeError(f'Expected ``camera`` to be a dict, not {type(camera)}')
+
+        if 'position' not in camera:
+            raise ValueError('Expected the "position" key in the camera dictionary')
+        if 'viewup' not in camera:
+            raise ValueError('Expected the "viewup" key in the camera dictionary')
+
+        self._camera = camera
+
+    @property
+    def notebook(self):
+        """Return or set the state of notebook plotting
+
+        Setting this to ``True`` always enables notebook plotting,
+        while setting it to ``False`` disables plotting even when
+        plotting within a jupyter notebook and plots externally.
+
+        Examples
+        --------
+        Disable all jupyter notebook plotting
+
+        >>> import pyvista
+        >>> pyvista.theme.notebook = False
+
+        """
+
+    @notebook.setter
+    def notebook(self, value):
+        self._notebook = value
+
+    @property
+    def window_size(self):
+        """Return or set the default render window size.
+
+        Examples
+        --------
+        Set window size to ``[400, 400]``
+
+        >>> import pyvista
+        >>> pyvista.theme.window_size = [400, 400]
+
+        """
+        return self._window_size
+
+    @window_size.setter
+    def window_size(self, window_size):
+        if not len(window_size) == 2:
+            raise ValueError('Expected a length 2 iterable for ``window_size``')
+
+        # ensure positve size
+        if window_size[0] < 0 or window_size[1] < 0:
+            raise ValueError('Window size must be a positive value')
+
+        self._window_size = window_size
+
+    @property
+    def font(self):
+        """Return or set the default font size, family, and/or color.
+
+        Examples
+        --------
+        Set the default font family to 'arial'.  Must be either
+        'arial', 'courier', or 'times'.
+
+        >>> import pyvista
+        >>> pyvista.theme.font['family'] = 'arial'
+
+        Set the default font size to 20.
+
+        >>> pyvista.theme.font['size'] = 20
+
+        Set the default title size to 40
+
+        >>> pyvista.theme.font['title_size'] = 40
+
+        Set the default label size to 10
+
+        >>> pyvista.theme.font['label_size'] = 10
+
+        Set the default text color to 'grey'
+
+        >>> pyvista.theme.font['color'] = 'grey'
+
+        String formatter used to format numerical data to '%.6e'
+
+        >>> pyvista.theme.font['color'] = '%.6e'
+
+        """
+        return self._font
+
+    @font.setter
+    def font(self, font):
+        self._font = font
+
+    @property
+    def cmap(self):
+        """Return or set the default global colormap of pyvista.
+
+        See available Matplotlib colormaps.  Only applicable for when
+        displaying ``scalars``. Requires Matplotlib to be installed.
+        ``colormap`` is also an accepted alias for this. If
+        ``colorcet`` or ``cmocean`` are installed, their colormaps can
+        be specified by name.
+
+        You can also specify a list of colors to override an existing
+        colormap with a custom one.  For example, to create a three
+        color colormap you might specify ``['green', 'red', 'blue']``
+
+        Examples
+        --------
+        Set the default global colormap to 'jet'
+
+        >>> import pyvista
+        >>> pyvista.theme.cmap = 'jet'
+
+        """
+        return self._cmap
+
+    @cmap.setter
+    def cmap(self, cmap):
+        self._cmap = cmap
+
+    @property
+    def color(self):
+        """Return or set the default color of meshes in pyvista.
+
+        Used for meshes without ``scalars``.
+
+        A string or 3 item list, optional, defaults to white
+        Either a string, rgb list, or hex color string.  For example:
+
+        * ``color='white'``
+        * ``color='w'``
+        * ``color=[1, 1, 1]``
+        * ``color='#FFFFFF'``
+
+        Examples
+        --------
+        Set the default mesh color to 'red'
+
+        >>> import pyvista
+        >>> pyvista.theme.color = 'red'
+
+        """
+        return self._color
+
+    @color.setter
+    def color(self, color):
+        self._color = parse_color(color)
+
+    @property
+    def nan_color(self):
+        """Return or set the default global NAN color.
+
+        This color is used to plot all NAN values.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pyvista.theme.nan_color = 'darkgray'
+        """
+        return self._nan_color
+
+    @nan_color.setter
+    def nan_color(self, nan_color):
+        self._nan_color = parse_color(nan_color)
+
+    @property
+    def edge_color(self):
+        """Return or set the default global edge color.
+
+        Examples
+        --------
+        Set the global edge color to 'blue'
+
+        >>> import pyvista
+        >>> pyvista.theme.edge_color = 'blue'
+        """
+        return self._edge_color
+
+    @edge_color.setter
+    def edge_color(self, edge_color):
+        self._edge_color = parse_color(edge_color)
+
+    @property
+    def outline_color(self):
+        """Return or set the default outline color.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pyvista.theme.outline_color = 'white'
+        """
+        return self._outline_color
+
+    @outline_color.setter
+    def outline_color(self, outline_color):
+        self._outline_color = parse_color(outline_color)
+
+    @property
+    def floor_color(self):
+        """Return or set the default floor color.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pyvista.theme.floor_color = 'black'
+        """
+        return self._floor_color
+
+    @floor_color.setter
+    def floor_color(self, floor_color):
+        self._floor_color = floor_color
+
+    @property
+    def colorbar_orientation(self):
+        """Return or set the default global colorbar orientation
+
+        Must be either ``'vertical'`` or ``'horizontal'``.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pyvista.theme.colorbar_orientation = 'horizontal'
+        """
+        return self._colorbar_orientation
+
+    @colorbar_orientation.setter
+    def colorbar_orientation(self, colorbar_orientation):
+        if colorbar_orientation not in ['vertical', 'horizontal']:
+            raise ValueError('Colorbar orientation must be either "vertical" or '
+                             '"horizontal"')
+        self._colorbar_orientation = colorbar_orientation
+
+    @property
+    def colorbar_horizontal(self):
+        """Default orientation when the colorbar is set to 'horizontal'
+
+        Examples
+        --------
+        Set the default colorbar width to 0.6
+
+        >>> import pyvista
+        >>> pyvista.theme.colorbar_horizontal['width'] = 0.6
+
+        Set all the parameters of the colorbar
+
+        >>> colorbar_parm = {
+        ... 'width': 0.6,
+        ... 'height': 0.08,
+        ... 'position_x': 0.35,
+        ... 'position_y': 0.05}
+        >>> pyvista.theme.colorbar_horizontal = colorbar_parm
+
+        """
+        return self._colorbar_horizontal
+
+    @colorbar_horizontal.setter
+    def colorbar_horizontal(self, colorbar_horizontal):
+        for key in colorbar_horizontal:
+            if key not in self._colorbar_horizontal:
+                raise KeyError(f'Invalid key {key} for colorbar_horizontal')
+        self._colorbar_horizontal = colorbar_horizontal
+
+    @property
+    def colorbar_vertical(self):
+        """Default orientation when the colorbar is set to 'vertical'
+
+        Examples
+        --------
+        Set the default colorbar width to 0.45
+
+        >>> import pyvista
+        >>> pyvista.theme.colorbar_vertical['width'] = 0.45
+
+        Set all the parameters of the colorbar
+
+        >>> colorbar_parm = {
+        ... 'width': 0.08,
+        ... 'height': 0.45,
+        ... 'position_x': 0.9,
+        ... 'position_y': 0.02}
+        >>> pyvista.theme.colorbar_vertical = colorbar_parm
+
+        """
+        return self._colorbar_vertical
+
+    @colorbar_vertical.setter
+    def colorbar_vertical(self, colorbar_vertical):
+        for key in colorbar_vertical:
+            if key not in self._colorbar_vertical:
+                raise KeyError(f'Invalid key {key} for colorbar_vertical')
+        self._colorbar_vertical = colorbar_vertical
+
+    @property
+    def show_scalar_bar(self):
+        """Return or set the default color bar visibility.
+
+        Examples
+        --------
+        Show the scalar bar by default when scalars are available.
+
+        >>> import pyvista
+        >>> pyvista.theme.show_scalar_bar = True
+
+        """
+        return self._show_scalar_bar
+
+    @show_scalar_bar.setter
+    def show_scalar_bar(self, show_scalar_bar):
+        self._show_scalar_bar = show_scalar_bar
+
+    @property
+    def show_edges(self):
+        """Return or set the global default edge visibility.
+
+        Examples
+        --------
+        Show edges globally by default.
+
+        >>> import pyvista
+        >>> pyvista.theme.show_edges = True
+
+        """
+        return self._show_edges
+
+    @show_edges.setter
+    def show_edges(self, show_edges):
+        self._show_edges = show_edges
+
+    @property
+    def lighting(self):
+        """Return or set the default global ``lighting``.
+
+        Examples
+        --------
+        Disable lighting globally
+
+        >>> import pyvista
+        >>> pyvista.theme.lighting = False
+        """
+        return self._lighting
+
+    @lighting.setter
+    def lighting(self, lighting):
+        self._lighting = lighting
+
+    @property
+    def interactive(self):
+        return self._interactive
+
+    @interactive.setter
+    def interactive(self, interactive):
+        self._interactive = interactive
+
+    @property
+    def render_points_as_spheres(self):
+        return self._render_points_as_spheres
+
+    @render_points_as_spheres.setter
+    def render_points_as_spheres(self, render_points_as_spheres):
+        self._render_points_as_spheres = render_points_as_spheres
+
+    @property
+    def use_ipyvtk(self):
+        from pyvista.core.errors import DeprecationError
+        raise DeprecationError('DEPRECATED: Please use ``jupyter_backend``')
+
+    @use_ipyvtk.setter
+    def use_ipyvtk(self, use_ipyvtk):
+        from pyvista.core.errors import DeprecationError
+        raise DeprecationError('DEPRECATED: Please use ``jupyter_backend``')
+
+    @property
+    def transparent_background(self):
+        return self._transparent_background
+
+    @transparent_background.setter
+    def transparent_background(self, transparent_background):
+        self._transparent_background = transparent_background
+
+    @property
+    def title(self):
+        return self._title
+
+    @title.setter
+    def title(self, title):
+        self._title = title
+
+    @property
+    def multi_samples(self):
+        return self._multi_samples
+
+    @multi_samples.setter
+    def multi_samples(self, multi_samples):
+        self._multi_samples = multi_samples
+
+    @property
+    def multi_rendering_splitting_position(self):
+        return self._multi_rendering_splitting_position
+
+    @multi_rendering_splitting_position.setter
+    def multi_rendering_splitting_position(self, multi_rendering_splitting_position):
+        self._multi_rendering_splitting_position = multi_rendering_splitting_position
+
+    @property
+    def volume_mapper(self):
+        return self._volume_mapper
+
+    @volume_mapper.setter
+    def volume_mapper(self, volume_mapper):
+        self._volume_mapper = volume_mapper
+
+    @property
+    def smooth_shading(self):
+        return self._smooth_shading
+
+    @smooth_shading.setter
+    def smooth_shading(self, smooth_shading):
+        self._smooth_shading = smooth_shading
+
+    @property
+    def depth_peeling(self):
+        return self._depth_peeling
+
+    @depth_peeling.setter
+    def depth_peeling(self, depth_peeling):
+        self._depth_peeling = depth_peeling
+
+    @property
+    def silhouette(self):
+        return self._silhouette
+
+    @silhouette.setter
+    def silhouette(self, silhouette):
+        self._silhouette = silhouette
+
+    @property
+    def slider_style(self):
+        return self._slider_style
+
+    @slider_style.setter
+    def slider_style(self, slider_style):
+        self._slider_style = slider_style
+
+    @property
+    def axes(self):
+        return self._axes
+
+    @axes.setter
+    def axes(self, axes):
+        self._axes = axes
+
+    def restore_defaults(self):
+        """Restore the theme defaults."""
+        self._jupyter_backend = 'ipyvtklink'
+        self._auto_close = True  # DANGER: set to False with extreme caution
+        self._background = [0.3, 0.3, 0.3]
+        self._full_screen = False
+        self._camera = {
             'position': [1, 1, 1],
             'viewup': [0, 0, 1],
-        },
-        'notebook': None,
-        'window_size': [1024, 768],
-        'font': {
+        }
+
+        self._notebook = None
+        self._window_size = [1024, 768]
+        self._font = {
             'family': 'arial',
             'size': 12,
             'title_size': None,
             'label_size': None,
             'color': [1, 1, 1],
             'fmt': None,
-        },
-        'cmap': 'viridis',
-        'color': 'white',
-        'nan_color': 'darkgray',
-        'edge_color': 'black',
-        'outline_color': 'white',
-        'floor_color': 'gray',
-        'colorbar_orientation': 'horizontal',
-        'colorbar_horizontal': {
+        }
+
+        self._cmap = 'viridis'
+        self._color = 'white'
+        self._nan_color = 'darkgray'
+        self._edge_color = 'black'
+        self._outline_color = 'white'
+        self._floor_color = 'gray'
+        self._colorbar_orientation = 'horizontal'
+        self._colorbar_horizontal = {
             'width': 0.6,
             'height': 0.08,
             'position_x': 0.35,
             'position_y': 0.05,
-        },
-        'colorbar_vertical': {
+        }
+        self._colorbar_vertical = {
             'width': 0.08,
             'height': 0.45,
             'position_x': 0.9,
             'position_y': 0.02,
-        },
-        'show_scalar_bar': True,
-        'show_edges': False,
-        'lighting': True,
-        'interactive': False,
-        'render_points_as_spheres': False,
-        'use_ipyvtk': False,
-        'transparent_background': False,
-        'title': 'PyVista',
-        'axes': {
+        }
+        self._show_scalar_bar = True
+        self._show_edges = False
+        self._lighting = True
+        self._interactive = False
+        self._render_points_as_spheres = False
+        self._use_ipyvtk = False
+        self._transparent_background = False
+        self._title = 'PyVista'
+        self._axes = {
             'x_color': 'tomato',
             'y_color': 'seagreen',
             'z_color': 'mediumblue',
             'box': False,
             'show': True,
-        },
-        'multi_samples': 4,
-        'multi_rendering_splitting_position': None,
-        'volume_mapper': 'fixed_point' if os.name == 'nt' else 'smart',
-        'smooth_shading': False,
-        'depth_peeling': {
+        }
+        self._multi_samples = 4
+        self._multi_rendering_splitting_position = None
+        self._volume_mapper = 'fixed_point' if os.name == 'nt' else 'smart'
+        self._smooth_shading = False
+        self._depth_peeling = {
             'number_of_peels': 4,
             'occlusion_ratio': 0.0,
             'enabled': False,
-        },
-        'silhouette': {
+        }
+        self._silhouette = {
             'color': 'black',
             'line_width': 2,
             'opacity': 1.0,
             'feature_angle': False,
             'decimate': 0.9,
         },
-        'slider_style': {
+        self._slider_style = {
             'classic': {
                 'slider_length': 0.02,
                 'slider_width': 0.04,
@@ -111,88 +754,97 @@ def _load_default():
                 'cap_width': 0.02,
             },
         },
-    }
 
+    def __repr__(self):
+        """User friendly representation of the pyvista theme."""
+        txt = ['PyVista Theme']
+        txt.append(f'Background Color : {self.background}')
 
-rcParams = _load_default()
-DEFAULT_THEME = dict(rcParams)
+    def set_to_paraview(self):
+        """Set the theme to a paraview-like theme.
 
+        Examples
+        --------
+        >>> import pyvista
+        >>> pyvista.theme.set_to_paraview()
 
-def _reset_rcParams():
-    """Reset rcParams in-place."""
-    rcParams.clear()
-    rcParams.update(_load_default())
+        """
+        self.restore_defaults()
+        self._background = PARAVIEW_BACKGROUND
+        self._cmap = 'coolwarm'
+        self._font['family'] = 'arial'
+        self._font['label_size'] = 16
+        self._font['color'] = 'white'
+        self._show_edges = False
+        self._color = 'white'
+        self._outline_color = 'white'
+        self._edge_color = 'black'
+        self._axes['x_color'] = 'tomato'
+        self._axes['y_color'] = 'gold'
+        self._axes['z_color'] = 'green'
 
+    def set_to_document(self):
+        """Set the global theme to the document theme.
 
-def set_plot_theme(theme):
-    """Set the plotting parameters to a predefined theme."""
-    allowed_themes = ['paraview',
-                      'pv',
-                      'document',
-                      'doc',
-                      'paper',
-                      'report',
-                      'night',
-                      'dark',
-                      'testing',
-                      'default']
+        This theme uses a white background, the "viridis" colormap,
+        disables edges and black fonts.  Best used for presentations,
+        papers, etc.
 
-    if theme.lower() in ['paraview', 'pv']:
-        _reset_rcParams()
-        rcParams['background'] = PARAVIEW_BACKGROUND
-        rcParams['cmap'] = 'coolwarm'
-        rcParams['font']['family'] = 'arial'
-        rcParams['font']['label_size'] = 16
-        rcParams['font']['color'] = 'white'
-        rcParams['show_edges'] = False
-        rcParams['color'] = 'white'
-        rcParams['outline_color'] = 'white'
-        rcParams['edge_color'] = 'black'
-        rcParams['axes']['x_color'] = 'tomato'
-        rcParams['axes']['y_color'] = 'gold'
-        rcParams['axes']['z_color'] = 'green'
-    elif theme.lower() in ['document', 'doc', 'paper', 'report']:
-        _reset_rcParams()
-        rcParams['background'] = 'white'
-        rcParams['cmap'] = 'viridis'
-        rcParams['font']['size'] = 18
-        rcParams['font']['title_size'] = 18
-        rcParams['font']['label_size'] = 18
-        rcParams['font']['color'] = 'black'
-        rcParams['show_edges'] = False
-        rcParams['color'] = 'tan'
-        rcParams['outline_color'] = 'black'
-        rcParams['edge_color'] = 'black'
-        rcParams['axes']['x_color'] = 'tomato'
-        rcParams['axes']['y_color'] = 'seagreen'
-        rcParams['axes']['z_color'] = 'blue'
-    elif theme.lower() in ['night', 'dark']:
-        _reset_rcParams()
-        rcParams['background'] = 'black'
-        rcParams['cmap'] = 'viridis'
-        rcParams['font']['color'] = 'white'
-        rcParams['show_edges'] = False
-        rcParams['color'] = 'tan'
-        rcParams['outline_color'] = 'white'
-        rcParams['edge_color'] = 'white'
-        rcParams['axes']['x_color'] = 'tomato'
-        rcParams['axes']['y_color'] = 'seagreen'
-        rcParams['axes']['z_color'] = 'blue'
-    elif theme.lower() == 'testing':
-        _reset_rcParams()
-        # necessary for image regression.  Xvfb doesn't support
-        # multi-sampling, so we disable it here for consistency between
-        # desktops and remote testing
-        rcParams['off_screen'] = True
-        rcParams['multi_samples'] = 1
-        rcParams['window_size'] = [400, 400]
-    elif theme.lower() in ['default']:
-        # have to clear and overwrite since some rcParams are not set
-        # in the default theme
-        _reset_rcParams()
-    else:
-        raise ValueError(f'Invalid theme {theme}.  Pick one of the following:\n'
-                         f'{allowed_themes}')
+        Examples
+        --------
+        >>> import pyvista
+        >>> pyvista.theme.set_to_document()
+
+        """
+        self.restore_defaults()
+        self._background = 'white'
+        self._cmap = 'viridis'
+        self._font['size'] = 18
+        self._font['title_size'] = 18
+        self._font['label_size'] = 18
+        self._font['color'] = 'black'
+        self._show_edges = False
+        self._color = 'tan'
+        self._outline_color = 'black'
+        self._edge_color = 'black'
+        self._axes['x_color'] = 'tomato'
+        self._axes['y_color'] = 'seagreen'
+        self._axes['z_color'] = 'blue'
+
+    def _set_to_testing(self):
+        """Low resolution testing theme.
+
+        Necessary for image regression.  Xvfb doesn't support
+        multi-sampling, so we disable it here for consistency between
+        desktops and remote testing.
+        """
+        self.restore_defaults()
+        self._off_screen = True
+        self._multi_samples = 1
+        self._window_size = [400, 400]
+
+    def set_to_dark(self):
+        """Set the global theme to dark mode.
+
+        Black background, "viridis" colormap, tan meshes, white (hidden) edges.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pyvista.theme.set_to_dark()
+
+        """
+        self.restore_defaults()
+        self._background = 'black'
+        self._cmap = 'viridis'
+        self._font['color'] = 'white'
+        self._show_edges = False
+        self._color = 'tan'
+        self._outline_color = 'white'
+        self._edge_color = 'white'
+        self._axes['x_color'] = 'tomato'
+        self._axes['y_color'] = 'seagreen'
+        self._axes['z_color'] = 'blue'
 
 
 def parse_color(color, opacity=None):
@@ -202,7 +854,7 @@ def parse_color(color, opacity=None):
 
     """
     if color is None:
-        color = rcParams['color']
+        color = pyvista.theme.color
     if isinstance(color, str):
         color = string_to_rgb(color)
     elif len(color) == 3:

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -356,6 +356,8 @@ def parse_color(color, opacity=None, default_color=None):
             color = pyvista.global_theme.color
         else:
             color = default_color
+    if isinstance(color, float):
+        breakpoint()
     if isinstance(color, str):
         color = string_to_rgb(color)
     elif len(color) == 3:

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -86,7 +86,7 @@ def system_supports_plotting():
 def update_axes_label_color(axes_actor, color=None):
     """Set the axes label color (internale helper)."""
     if color is None:
-        color = pyvista.defaults.font['color']
+        color = pyvista.global_theme.font['color']
     color = parse_color(color)
     if isinstance(axes_actor, _vtk.vtkAxesActor):
         prop_x = axes_actor.GetXAxisCaptionActor2D().GetCaptionTextProperty()
@@ -106,11 +106,11 @@ def create_axes_marker(label_color=None, x_color=None, y_color=None,
                        labels_off=False, line_width=2):
     """Return an axis actor to add in the scene."""
     if x_color is None:
-        x_color = pyvista.defaults.axes['x_color']
+        x_color = pyvista.global_theme.axes['x_color']
     if y_color is None:
-        y_color = pyvista.defaults.axes['y_color']
+        y_color = pyvista.global_theme.axes['y_color']
     if z_color is None:
-        z_color = pyvista.defaults.axes['z_color']
+        z_color = pyvista.global_theme.axes['z_color']
     axes_actor = _vtk.vtkAxesActor()
     axes_actor.GetXAxisShaftProperty().SetColor(parse_color(x_color))
     axes_actor.GetXAxisTipProperty().SetColor(parse_color(x_color))
@@ -145,13 +145,13 @@ def create_axes_orientation_box(line_width=1, text_scale=0.366667,
                                 labels_off=False, opacity=0.5,):
     """Create a Box axes orientation widget with labels."""
     if x_color is None:
-        x_color = pyvista.defaults.axes['x_color']
+        x_color = pyvista.global_theme.axes['x_color']
     if y_color is None:
-        y_color = pyvista.defaults.axes['y_color']
+        y_color = pyvista.global_theme.axes['y_color']
     if z_color is None:
-        z_color = pyvista.defaults.axes['z_color']
+        z_color = pyvista.global_theme.axes['z_color']
     if edge_color is None:
-        edge_color = pyvista.defaults.edge_color
+        edge_color = pyvista.global_theme.edge_color
     axes_actor = _vtk.vtkAnnotatedCubeActor()
     axes_actor.SetFaceTextScale(text_scale)
     if xlabel is not None:
@@ -348,7 +348,7 @@ def parse_color(color, opacity=None, default_color=None):
     """
     if color is None:
         if default_color is None:
-            color = pyvista.defaults.color
+            color = pyvista.global_theme.color
         else:
             color = default_color
     if isinstance(color, str):

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -1,5 +1,6 @@
 """Module containing useful plotting tools."""
 
+from enum import Enum
 import platform
 import os
 from subprocess import PIPE, Popen
@@ -11,9 +12,13 @@ from pyvista import _vtk
 from .colors import string_to_rgb
 
 
-FONT_KEYS = {'arial': _vtk.VTK_ARIAL,
-             'courier': _vtk.VTK_COURIER,
-             'times': _vtk.VTK_TIMES}
+class FONTS(Enum):
+    """Font families available to PyVista."""
+
+    arial = _vtk.VTK_ARIAL
+    courier = _vtk.VTK_COURIER
+    times = _vtk.VTK_TIMES
+
 
 # Track render window support and plotting
 SUPPORTS_OPENGL = None
@@ -86,7 +91,7 @@ def system_supports_plotting():
 def update_axes_label_color(axes_actor, color=None):
     """Set the axes label color (internale helper)."""
     if color is None:
-        color = pyvista.global_theme.font['color']
+        color = pyvista.global_theme.font.color
     color = parse_color(color)
     if isinstance(axes_actor, _vtk.vtkAxesActor):
         prop_x = axes_actor.GetXAxisCaptionActor2D().GetCaptionTextProperty()
@@ -106,11 +111,11 @@ def create_axes_marker(label_color=None, x_color=None, y_color=None,
                        labels_off=False, line_width=2):
     """Return an axis actor to add in the scene."""
     if x_color is None:
-        x_color = pyvista.global_theme.axes['x_color']
+        x_color = pyvista.global_theme.axes.x_color
     if y_color is None:
-        y_color = pyvista.global_theme.axes['y_color']
+        y_color = pyvista.global_theme.axes.y_color
     if z_color is None:
-        z_color = pyvista.global_theme.axes['z_color']
+        z_color = pyvista.global_theme.axes.z_color
     axes_actor = _vtk.vtkAxesActor()
     axes_actor.GetXAxisShaftProperty().SetColor(parse_color(x_color))
     axes_actor.GetXAxisTipProperty().SetColor(parse_color(x_color))
@@ -145,11 +150,11 @@ def create_axes_orientation_box(line_width=1, text_scale=0.366667,
                                 labels_off=False, opacity=0.5,):
     """Create a Box axes orientation widget with labels."""
     if x_color is None:
-        x_color = pyvista.global_theme.axes['x_color']
+        x_color = pyvista.global_theme.axes.x_color
     if y_color is None:
-        y_color = pyvista.global_theme.axes['y_color']
+        y_color = pyvista.global_theme.axes.y_color
     if z_color is None:
-        z_color = pyvista.global_theme.axes['z_color']
+        z_color = pyvista.global_theme.axes.z_color
     if edge_color is None:
         edge_color = pyvista.global_theme.edge_color
     axes_actor = _vtk.vtkAnnotatedCubeActor()
@@ -372,10 +377,9 @@ def parse_color(color, opacity=None, default_color=None):
 
 def parse_font_family(font_family):
     """Check font name."""
-    # check font name
     font_family = font_family.lower()
-    if font_family not in ['courier', 'times', 'arial']:
-        raise ValueError('Font must be either "courier", "times" '
-                         'or "arial"')
+    if font_family not in FONTS._member_names_:
+        raise ValueError('Font must one of the following:\n'
+                         f"{', '.join(FONTS._member_names_)}")
 
-    return FONT_KEYS[font_family]
+    return FONTS[font_family].value

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -378,8 +378,7 @@ def parse_color(color, opacity=None, default_color=None):
 def parse_font_family(font_family):
     """Check font name."""
     font_family = font_family.lower()
-    if font_family not in FONTS._member_names_:
-        raise ValueError('Font must one of the following:\n'
-                         f"{', '.join(FONTS._member_names_)}")
-
+    fonts = [font.name for font in FONTS]
+    if font_family not in fonts:
+        raise ValueError('Font must one of the following:\n{", ".join(fonts)}')
     return FONTS[font_family].value

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -8,12 +8,17 @@ import numpy as np
 
 import pyvista
 from pyvista import _vtk
-from .theme import parse_color, rcParams
+from .colors import string_to_rgb
 
+
+FONT_KEYS = {'arial': _vtk.VTK_ARIAL,
+             'courier': _vtk.VTK_COURIER,
+             'times': _vtk.VTK_TIMES}
 
 # Track render window support and plotting
 SUPPORTS_OPENGL = None
 SUPPORTS_PLOTTING = None
+
 
 def supports_open_gl():
     """Return if the system supports OpenGL."""
@@ -81,7 +86,7 @@ def system_supports_plotting():
 def update_axes_label_color(axes_actor, color=None):
     """Set the axes label color (internale helper)."""
     if color is None:
-        color = rcParams['font']['color']
+        color = pyvista.defaults.font['color']
     color = parse_color(color)
     if isinstance(axes_actor, _vtk.vtkAxesActor):
         prop_x = axes_actor.GetXAxisCaptionActor2D().GetCaptionTextProperty()
@@ -101,11 +106,11 @@ def create_axes_marker(label_color=None, x_color=None, y_color=None,
                        labels_off=False, line_width=2):
     """Return an axis actor to add in the scene."""
     if x_color is None:
-        x_color = rcParams['axes']['x_color']
+        x_color = pyvista.defaults.axes['x_color']
     if y_color is None:
-        y_color = rcParams['axes']['y_color']
+        y_color = pyvista.defaults.axes['y_color']
     if z_color is None:
-        z_color = rcParams['axes']['z_color']
+        z_color = pyvista.defaults.axes['z_color']
     axes_actor = _vtk.vtkAxesActor()
     axes_actor.GetXAxisShaftProperty().SetColor(parse_color(x_color))
     axes_actor.GetXAxisTipProperty().SetColor(parse_color(x_color))
@@ -140,13 +145,13 @@ def create_axes_orientation_box(line_width=1, text_scale=0.366667,
                                 labels_off=False, opacity=0.5,):
     """Create a Box axes orientation widget with labels."""
     if x_color is None:
-        x_color = rcParams['axes']['x_color']
+        x_color = pyvista.defaults.axes['x_color']
     if y_color is None:
-        y_color = rcParams['axes']['y_color']
+        y_color = pyvista.defaults.axes['y_color']
     if z_color is None:
-        z_color = rcParams['axes']['z_color']
+        z_color = pyvista.defaults.axes['z_color']
     if edge_color is None:
-        edge_color = rcParams['edge_color']
+        edge_color = pyvista.defaults.edge_color
     axes_actor = _vtk.vtkAnnotatedCubeActor()
     axes_actor.SetFaceTextScale(text_scale)
     if xlabel is not None:
@@ -333,3 +338,44 @@ def opacity_transfer_function(mapping, n_colors, interpolate=True,
             raise RuntimeError(f'Transfer function cannot have more values than `n_colors`. This has {mapping.size} elements')
         return mapping
     raise TypeError(f'Transfer function type ({type(mapping)}) not understood')
+
+
+def parse_color(color, opacity=None, default_color=None):
+    """Parse color into a vtk friendly rgb list.
+
+    Values returned will be between 0 and 1.
+
+    """
+    if color is None:
+        if default_color is None:
+            color = pyvista.defaults.color
+        else:
+            color = default_color
+    if isinstance(color, str):
+        color = string_to_rgb(color)
+    elif len(color) == 3:
+        pass
+    elif len(color) == 4:
+        color = color[:3]
+    else:
+        raise ValueError(f"""
+    Invalid color input: ({color})
+    Must be string, rgb list, or hex color string.  For example:
+        color='white'
+        color='w'
+        color=[1, 1, 1]
+        color='#FFFFFF'""")
+    if opacity is not None and isinstance(opacity, (float, int)):
+        color = [color[0], color[1], color[2], opacity]
+    return color
+
+
+def parse_font_family(font_family):
+    """Check font name."""
+    # check font name
+    font_family = font_family.lower()
+    if font_family not in ['courier', 'times', 'arial']:
+        raise ValueError('Font must be either "courier", "times" '
+                         'or "arial"')
+
+    return FONT_KEYS[font_family]

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -356,8 +356,6 @@ def parse_color(color, opacity=None, default_color=None):
             color = pyvista.global_theme.color
         else:
             color = default_color
-    if isinstance(color, float):
-        breakpoint()
     if isinstance(color, str):
         color = string_to_rgb(color)
     elif len(color) == 3:

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -5,7 +5,7 @@ import numpy as np
 import pyvista
 from pyvista import _vtk
 from pyvista.utilities import NORMALS, generate_plane, get_array, try_callback
-from .theme import rcParams, parse_color
+from .tools import parse_color
 
 
 class WidgetHelper:
@@ -65,7 +65,7 @@ class WidgetHelper:
             bounds = self.bounds
 
         if color is None:
-            color = rcParams['font']['color']
+            color = pyvista.defaults.font['color']
 
         def _the_callback(box_widget, event_id):
             the_box = pyvista.PolyData()
@@ -254,7 +254,7 @@ class WidgetHelper:
             normal = NORMALS[normal.lower()]
 
         if color is None:
-            color = rcParams['font']['color']
+            color = pyvista.defaults.font['color']
 
         if assign_to_axis:
             normal_rotation = False
@@ -625,7 +625,7 @@ class WidgetHelper:
             bounds = self.bounds
 
         if color is None:
-            color = rcParams['font']['color']
+            color = pyvista.defaults.font['color']
 
         def _the_callback(widget, event_id):
             pointa = widget.GetPoint1()
@@ -702,8 +702,8 @@ class WidgetHelper:
             slider interacts with the callback.
 
         style : str, optional
-            The name of the slider style. The list of available styles are in
-            ``rcParams['slider_style']``. Defaults to None.
+            The name of the slider style. The list of available styles
+            are in ``pyvista.defaults.slider_style``. Defaults to ``None``.
 
         Returns
         -------
@@ -805,8 +805,8 @@ class WidgetHelper:
             slider interacts with the callback.
 
         style : str, optional
-            The name of the slider style. The list of available styles are in
-            ``rcParams['slider_style']``. Defaults to None.
+            The name of the slider style. The list of available styles
+            are in ``pyvista.defaults.slider_style``. Defaults to ``None``.
 
         title_height: float, optional
             Relative height of the title as compared to the length of the slider.
@@ -847,13 +847,13 @@ class WidgetHelper:
             value = ((rng[1] - rng[0]) / 2) + rng[0]
 
         if color is None:
-            color = rcParams['font']['color']
+            color = pyvista.defaults.font['color']
 
         if title_color is None:
             title_color = color
 
         if fmt is None:
-            fmt = rcParams['font']['fmt']
+            fmt = pyvista.defaults.font['fmt']
 
         def normalize(point, viewport):
             return (point[0]*(viewport[2]-viewport[0]),point[1]*(viewport[3]-viewport[1]))
@@ -884,10 +884,10 @@ class WidgetHelper:
             if not isinstance(style, str):
                 raise TypeError("Expected type for ``style`` is str but"
                                 f" {type(style)} was given.")
-            style_params = rcParams['slider_style'].get(style, None)
+            style_params = pyvista.defaults.slider_style.get(style, None)
             if style_params is None:
                 raise KeyError("The requested style does not exist: "
-                               f"{style}. The styles available are {list(rcParams['slider_style'].keys())}.")
+                               f"{style}. The styles available are {list(pyvista.defaults.slider_style.keys())}.")
             slider_rep.SetSliderLength(style_params['slider_length'])
             slider_rep.SetSliderWidth(style_params['slider_width'])
             slider_rep.GetSliderProperty().SetColor(style_params['slider_color'])
@@ -1148,7 +1148,7 @@ class WidgetHelper:
             self.spline_widgets = []
 
         if color is None:
-            color = rcParams['color']
+            color = pyvista.defaults.color
 
         if bounds is None:
             bounds = self.bounds
@@ -1318,7 +1318,7 @@ class WidgetHelper:
             self.sphere_widgets = []
 
         if color is None:
-            color = rcParams['color']
+            color = pyvista.defaults.color
 
         center = np.array(center)
         num = 1

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -65,7 +65,7 @@ class WidgetHelper:
             bounds = self.bounds
 
         if color is None:
-            color = pyvista.global_theme.font['color']
+            color = pyvista.global_theme.font.color
 
         def _the_callback(box_widget, event_id):
             the_box = pyvista.PolyData()
@@ -254,7 +254,7 @@ class WidgetHelper:
             normal = NORMALS[normal.lower()]
 
         if color is None:
-            color = pyvista.global_theme.font['color']
+            color = pyvista.global_theme.font.color
 
         if assign_to_axis:
             normal_rotation = False
@@ -625,7 +625,7 @@ class WidgetHelper:
             bounds = self.bounds
 
         if color is None:
-            color = pyvista.global_theme.font['color']
+            color = pyvista.global_theme.font.color
 
         def _the_callback(widget, event_id):
             pointa = widget.GetPoint1()
@@ -847,16 +847,16 @@ class WidgetHelper:
             value = ((rng[1] - rng[0]) / 2) + rng[0]
 
         if color is None:
-            color = pyvista.global_theme.font['color']
+            color = pyvista.global_theme.font.color
 
         if title_color is None:
             title_color = color
 
         if fmt is None:
-            fmt = pyvista.global_theme.font['fmt']
+            fmt = pyvista.global_theme.font.fmt
 
         def normalize(point, viewport):
-            return (point[0]*(viewport[2]-viewport[0]),point[1]*(viewport[3]-viewport[1]))
+            return (point[0]*(viewport[2]-viewport[0]), point[1]*(viewport[3]-viewport[1]))
 
         pointa = normalize(pointa, self.renderer.GetViewport())
         pointb = normalize(pointb, self.renderer.GetViewport())
@@ -884,18 +884,15 @@ class WidgetHelper:
             if not isinstance(style, str):
                 raise TypeError("Expected type for ``style`` is str but"
                                 f" {type(style)} was given.")
-            style_params = pyvista.global_theme.slider_style.get(style, None)
-            if style_params is None:
-                raise KeyError("The requested style does not exist: "
-                               f"{style}. The styles available are {list(pyvista.global_theme.slider_style.keys())}.")
-            slider_rep.SetSliderLength(style_params['slider_length'])
-            slider_rep.SetSliderWidth(style_params['slider_width'])
-            slider_rep.GetSliderProperty().SetColor(style_params['slider_color'])
-            slider_rep.SetTubeWidth(style_params['tube_width'])
-            slider_rep.GetTubeProperty().SetColor(style_params['tube_color'])
-            slider_rep.GetCapProperty().SetOpacity(style_params['cap_opacity'])
-            slider_rep.SetEndCapLength(style_params['cap_length'])
-            slider_rep.SetEndCapWidth(style_params['cap_width'])
+            slider_style = getattr(pyvista.global_theme.slider_style, style)
+            slider_rep.SetSliderLength(slider_style.slider_length)
+            slider_rep.SetSliderWidth(slider_style.slider_width)
+            slider_rep.GetSliderProperty().SetColor(slider_style.slider_color)
+            slider_rep.SetTubeWidth(slider_style.tube_width)
+            slider_rep.GetTubeProperty().SetColor(slider_style.tube_color)
+            slider_rep.GetCapProperty().SetOpacity(slider_style.cap_opacity)
+            slider_rep.SetEndCapLength(slider_style.cap_length)
+            slider_rep.SetEndCapWidth(slider_style.cap_width)
 
         def _the_callback(widget, event):
             value = widget.GetRepresentation().GetValue()

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -65,7 +65,7 @@ class WidgetHelper:
             bounds = self.bounds
 
         if color is None:
-            color = pyvista.defaults.font['color']
+            color = pyvista.global_theme.font['color']
 
         def _the_callback(box_widget, event_id):
             the_box = pyvista.PolyData()
@@ -254,7 +254,7 @@ class WidgetHelper:
             normal = NORMALS[normal.lower()]
 
         if color is None:
-            color = pyvista.defaults.font['color']
+            color = pyvista.global_theme.font['color']
 
         if assign_to_axis:
             normal_rotation = False
@@ -625,7 +625,7 @@ class WidgetHelper:
             bounds = self.bounds
 
         if color is None:
-            color = pyvista.defaults.font['color']
+            color = pyvista.global_theme.font['color']
 
         def _the_callback(widget, event_id):
             pointa = widget.GetPoint1()
@@ -703,7 +703,7 @@ class WidgetHelper:
 
         style : str, optional
             The name of the slider style. The list of available styles
-            are in ``pyvista.defaults.slider_style``. Defaults to ``None``.
+            are in ``pyvista.global_theme.slider_style``. Defaults to ``None``.
 
         Returns
         -------
@@ -806,7 +806,7 @@ class WidgetHelper:
 
         style : str, optional
             The name of the slider style. The list of available styles
-            are in ``pyvista.defaults.slider_style``. Defaults to ``None``.
+            are in ``pyvista.global_theme.slider_style``. Defaults to ``None``.
 
         title_height: float, optional
             Relative height of the title as compared to the length of the slider.
@@ -847,13 +847,13 @@ class WidgetHelper:
             value = ((rng[1] - rng[0]) / 2) + rng[0]
 
         if color is None:
-            color = pyvista.defaults.font['color']
+            color = pyvista.global_theme.font['color']
 
         if title_color is None:
             title_color = color
 
         if fmt is None:
-            fmt = pyvista.defaults.font['fmt']
+            fmt = pyvista.global_theme.font['fmt']
 
         def normalize(point, viewport):
             return (point[0]*(viewport[2]-viewport[0]),point[1]*(viewport[3]-viewport[1]))
@@ -884,10 +884,10 @@ class WidgetHelper:
             if not isinstance(style, str):
                 raise TypeError("Expected type for ``style`` is str but"
                                 f" {type(style)} was given.")
-            style_params = pyvista.defaults.slider_style.get(style, None)
+            style_params = pyvista.global_theme.slider_style.get(style, None)
             if style_params is None:
                 raise KeyError("The requested style does not exist: "
-                               f"{style}. The styles available are {list(pyvista.defaults.slider_style.keys())}.")
+                               f"{style}. The styles available are {list(pyvista.global_theme.slider_style.keys())}.")
             slider_rep.SetSliderLength(style_params['slider_length'])
             slider_rep.SetSliderWidth(style_params['slider_width'])
             slider_rep.GetSliderProperty().SetColor(style_params['slider_color'])
@@ -1148,7 +1148,7 @@ class WidgetHelper:
             self.spline_widgets = []
 
         if color is None:
-            color = pyvista.defaults.color
+            color = pyvista.global_theme.color
 
         if bounds is None:
             bounds = self.bounds
@@ -1318,7 +1318,7 @@ class WidgetHelper:
             self.sphere_widgets = []
 
         if color is None:
-            color = pyvista.defaults.color
+            color = pyvista.global_theme.color
 
         center = np.array(center)
         num = 1

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1274,41 +1274,48 @@ class WidgetHelper:
         Parameters
         ----------
         callback : callable
-            The function to call back when the widget is modified. It takes a
-            single argument: the center of the sphere as a XYZ coordinate.
+            The function to call back when the widget is modified. It
+            takes a single argument: the center of the sphere as a XYZ
+            coordinate.
 
         center : tuple(float)
-            Length 3 array for the XYZ coordinate of the sphere's center
-            when placing it in the scene. If more than one location is passed,
-            then that many widgets will be added and the callback will also
-            be passed the integer index of that widget.
+            Length 3 array for the XYZ coordinate of the sphere's
+            center when placing it in the scene. If more than one
+            location is passed, then that many widgets will be added
+            and the callback will also be passed the integer index of
+            that widget.
 
-        radius : float
-            The radius of the sphere
+        radius : float, optional
+            The radius of the sphere.
 
         theta_resolution: int , optional
-            Set the number of points in the longitude direction (ranging from
-            start_theta to end_theta).
+            Set the number of points in the longitude direction.
 
         phi_resolution : int, optional
-            Set the number of points in the latitude direction (ranging from
-            start_phi to end_phi).
+            Set the number of points in the latitude direction.
 
-        color : str
-            The color of the sphere's surface
+        color : string or 3 item iterable, optional
+            The color of the sphere's surface.  Either a string, rgb
+            list, or hex color string.  For example:
 
-        style : str
-            Representation style: surface or wireframe
+            * ``color='white'``
+            * ``color='w'``
+            * ``color=[1, 1, 1]``
+            * ``color='#FFFFFF'``
 
-        selected_color : str
+        style : str, optional
+            Representation style: ``'surface'`` or ``'wireframe'``
+
+        selected_color : str, optional
             Color of the widget when selected during interaction
 
         pass_widget : bool
-            If true, the widget will be passed as the last argument of the
-            callback
+            If ``True``, the widget will be passed as the last
+            argument of the callback.
 
-        test_callback: bool
-            if true, run the callback function after the widget is created.
+        test_callback: bool, optional
+            if ``True``, run the callback function after the widget is
+            created.
 
         """
         if not hasattr(self, "sphere_widgets"):
@@ -1323,7 +1330,10 @@ class WidgetHelper:
             num = len(center)
 
         if isinstance(color, (list, tuple, np.ndarray)):
-            colors = color
+            if len(color) == num and not isinstance(color[0], float):
+                colors = color
+            else:
+                colors = [color] * num
         else:
             colors = [color] * num
 

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1245,8 +1245,8 @@ class WidgetHelper:
             # create the plane for clipping
             polyplane = _vtk.vtkPolyPlane()
             polyplane.SetPolyLine(polyline)
-            alg.SetCutFunction(polyplane) # the cutter to use the poly planes
-            alg.Update() # Perform the Cut
+            alg.SetCutFunction(polyplane)  # the cutter to use the poly planes
+            alg.Update()  # Perform the Cut
             spline_sliced_mesh.shallow_copy(alg.GetOutput())
 
         self.add_spline_widget(callback=callback, bounds=mesh.bounds,
@@ -1258,9 +1258,7 @@ class WidgetHelper:
                                initial_points=initial_points,
                                closed=closed)
 
-        actor = self.add_mesh(spline_sliced_mesh, **kwargs)
-
-        return actor
+        return self.add_mesh(spline_sliced_mesh, **kwargs)
 
     def add_sphere_widget(self, callback, center=(0, 0, 0), radius=0.5,
                           theta_resolution=30, phi_resolution=30,

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -703,7 +703,8 @@ class WidgetHelper:
 
         style : str, optional
             The name of the slider style. The list of available styles
-            are in ``pyvista.global_theme.slider_style``. Defaults to ``None``.
+            are in ``pyvista.global_theme.slider_styles``. Defaults to
+            ``None``.
 
         Returns
         -------
@@ -766,60 +767,65 @@ class WidgetHelper:
                           title_height=0.03, title_opacity=1.0, title_color=None, fmt=None):
         """Add a slider bar widget.
 
-        This is useless without a callback function. You can pass a callable
-        function that takes a single argument, the value of this slider widget,
-        and performs a task with that value.
+        This is useless without a callback function. You can pass a
+        callable function that takes a single argument, the value of
+        this slider widget, and performs a task with that value.
 
         Parameters
         ----------
         callback : callable
-            The method called every time the slider is updated. This should take
-            a single parameter: the float value of the slider
+            The method called every time the slider is updated. This
+            should take a single parameter: the float value of the
+            slider.
 
         rng : tuple(float)
-            Length two tuple of the minimum and maximum ranges of the slider
+            Length two tuple of the minimum and maximum ranges of the
+            slider.
 
         value : float, optional
-            The starting value of the slider
+            The starting value of the slider.
 
-        title : str
-            The string label of the slider widget
+        title : str, optional
+            The string label of the slider widget.
 
-        pointa : tuple(float)
-            The relative coordinates of the left point of the slider on the
-            display port
+        pointa : tuple(float), optional
+            The relative coordinates of the left point of the slider
+            on the display port.
 
         pointb : tuple(float)
-            The relative coordinates of the right point of the slider on the
-            display port
+            The relative coordinates of the right point of the slider
+            on the display port
 
-        color : string or 3 item list, optional, defaults to white
+        color : string or 3 item list, optional
             Either a string, rgb list, or hex color string.
 
-        pass_widget : bool
-            If true, the widget will be passed as the last argument of the
-            callback
+        pass_widget : bool, optional
+            If ``True``, the widget will be passed as the last
+            argument of the callback.
 
-        event_type : str
-            Either 'start', 'end' or 'always', this defines how often the
-            slider interacts with the callback.
+        event_type : str, optional
+            Either ``'start'``, ``'end'`` or ``'always'``, this
+            defines how often the slider interacts with the callback.
 
         style : str, optional
             The name of the slider style. The list of available styles
-            are in ``pyvista.global_theme.slider_style``. Defaults to ``None``.
+            are in ``pyvista.global_theme.slider_styles``. Defaults to
+            ``None``.
 
         title_height: float, optional
-            Relative height of the title as compared to the length of the slider.
+            Relative height of the title as compared to the length of
+            the slider.
 
         title_opacity: str, optional
             Opacity of title. Defaults to 1.0.
 
         title_color : string or 3 item list, optional
-            Either a string, rgb list, or hex color string.  Defaults to the value 
-            given in ``color``.
+            Either a string, rgb list, or hex color string.  Defaults
+            to the value given in ``color``.
 
         fmt : str, optional
-            String formatter used to format numerical data. Defaults to ``None``.
+            String formatter used to format numerical data. Defaults
+            to ``None``.
 
         Examples
         --------
@@ -884,7 +890,7 @@ class WidgetHelper:
             if not isinstance(style, str):
                 raise TypeError("Expected type for ``style`` is str but"
                                 f" {type(style)} was given.")
-            slider_style = getattr(pyvista.global_theme.slider_style, style)
+            slider_style = getattr(pyvista.global_theme.slider_styles, style)
             slider_rep.SetSliderLength(slider_style.slider_length)
             slider_rep.SetSliderWidth(slider_style.slider_width)
             slider_rep.GetSliderProperty().SetColor(slider_style.slider_color)
@@ -1274,7 +1280,9 @@ class WidgetHelper:
         callback : callable
             The function to call back when the widget is modified. It
             takes a single argument: the center of the sphere as a XYZ
-            coordinate.
+            coordinate.  If multiple centers are passed in the
+            ``center`` parameter, the callback must accept an index of
+            that widget.
 
         center : tuple(float)
             Length 3 array for the XYZ coordinate of the sphere's
@@ -1293,8 +1301,10 @@ class WidgetHelper:
             Set the number of points in the latitude direction.
 
         color : string or 3 item iterable, optional
-            The color of the sphere's surface.  Either a string, rgb
-            list, or hex color string.  For example:
+            The color of the sphere's surface.  If multiple centers
+            are passed, then this must be a list of colors.  Each
+            color is either a string, rgb list, or hex color string.
+            For example:
 
             * ``color='white'``
             * ``color='w'``

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -39,6 +39,17 @@ import os
 from .plotting.colors import PARAVIEW_BACKGROUND, get_cmap_safe
 from .plotting.tools import parse_color, parse_font_family
 from .utilities.misc import PyvistaDeprecationWarning
+from .core.errors import DeprecationError
+
+
+class _rcParams(dict):  # pragma: no cover
+    """Reference to the deprecated rcParams dictionary."""
+
+    def __getitem__(self, key):
+        raise DeprecationError('rcParams is deprecated.  Please use ``pyvista.global_theme``')
+
+    def __setitem__(self, key, value):
+        raise DeprecationError('rcParams is deprecated.  Please use ``pyvista.global_theme``')
 
 
 def load_theme(filename):

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -113,7 +113,7 @@ def set_plot_theme(theme):
 class _ThemeConfig():
     """Provide common methods for theme configuration classes."""
 
-    __slots__ = []
+    __slots__: List[str] = []
 
     @classmethod
     def from_dict(cls, dict_):

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -772,7 +772,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_style.modern.cap_width = 0.02
+        >>> pyvista.global_theme.slider_styles.modern.cap_width = 0.02
 
         """
         return self._cap_width
@@ -788,7 +788,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_style.modern.cap_length = 0.01
+        >>> pyvista.global_theme.slider_styles.modern.cap_length = 0.01
 
         """
         return self._cap_length
@@ -804,7 +804,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_style.modern.cap_opacity = 1.0
+        >>> pyvista.global_theme.slider_styles.modern.cap_opacity = 1.0
 
         """
         return self._cap_opacity
@@ -820,8 +820,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_style.modern.tube_color = 'black'
-
+        >>> pyvista.global_theme.slider_styles.modern.tube_color = 'black'
         """
         return self._tube_color
 
@@ -836,7 +835,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_style.modern.tube_width = 0.005
+        >>> pyvista.global_theme.slider_styles.modern.tube_width = 0.005
 
         """
         return self._tube_width
@@ -852,7 +851,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_style.modern.slider_color = 'grey'
+        >>> pyvista.global_theme.slider_styles.modern.slider_color = 'grey'
 
         """
         return self._slider_color
@@ -868,7 +867,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_style.modern.slider_width = 0.04
+        >>> pyvista.global_theme.slider_styles.modern.slider_width = 0.04
 
         """
         return self._slider_width
@@ -884,7 +883,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_style.modern.slider_length = 0.02
+        >>> pyvista.global_theme.slider_styles.modern.slider_length = 0.02
 
         """
         return self._slider_length
@@ -919,25 +918,25 @@ class _SliderConfig(_ThemeConfig):
     Set the classic slider configuration.
 
     >>> import pyvista
-    >>> pyvista.global_theme.slider_style.classic.slider_length = 0.02
-    >>> pyvista.global_theme.slider_style.classic.slider_width = 0.04
-    >>> pyvista.global_theme.slider_style.classic.slider_color = (0.5, 0.5, 0.5)
-    >>> pyvista.global_theme.slider_style.classic.tube_width = 0.005
-    >>> pyvista.global_theme.slider_style.classic.tube_color = (1, 1, 1)
-    >>> pyvista.global_theme.slider_style.classic.cap_opacity = 1
-    >>> pyvista.global_theme.slider_style.classic.cap_length = 0.01
-    >>> pyvista.global_theme.slider_style.classic.cap_width = 0.02
+    >>> pyvista.global_theme.slider_styles.classic.slider_length = 0.02
+    >>> pyvista.global_theme.slider_styles.classic.slider_width = 0.04
+    >>> pyvista.global_theme.slider_styles.classic.slider_color = (0.5, 0.5, 0.5)
+    >>> pyvista.global_theme.slider_styles.classic.tube_width = 0.005
+    >>> pyvista.global_theme.slider_styles.classic.tube_color = (1, 1, 1)
+    >>> pyvista.global_theme.slider_styles.classic.cap_opacity = 1
+    >>> pyvista.global_theme.slider_styles.classic.cap_length = 0.01
+    >>> pyvista.global_theme.slider_styles.classic.cap_width = 0.02
 
     Set the modern slider configuration.
 
-    >>> pyvista.global_theme.slider_style.modern.slider_length = 0.02
-    >>> pyvista.global_theme.slider_style.modern.slider_width = 0.04
-    >>> pyvista.global_theme.slider_style.modern.slider_color = (0.43, 0.44, 0.45)
-    >>> pyvista.global_theme.slider_style.modern.tube_width = 0.04
-    >>> pyvista.global_theme.slider_style.modern.tube_color = (0.69, 0.70, 0.709)
-    >>> pyvista.global_theme.slider_style.modern.cap_opacity = 0
-    >>> pyvista.global_theme.slider_style.modern.cap_length = 0.01
-    >>> pyvista.global_theme.slider_style.modern.cap_width = 0.02
+    >>> pyvista.global_theme.slider_styles.modern.slider_length = 0.02
+    >>> pyvista.global_theme.slider_styles.modern.slider_width = 0.04
+    >>> pyvista.global_theme.slider_styles.modern.slider_color = (0.43, 0.44, 0.45)
+    >>> pyvista.global_theme.slider_styles.modern.tube_width = 0.04
+    >>> pyvista.global_theme.slider_styles.modern.tube_color = (0.69, 0.70, 0.709)
+    >>> pyvista.global_theme.slider_styles.modern.cap_opacity = 0
+    >>> pyvista.global_theme.slider_styles.modern.cap_length = 0.01
+    >>> pyvista.global_theme.slider_styles.modern.cap_width = 0.02
 
     """
 
@@ -1084,7 +1083,7 @@ class DefaultTheme(_ThemeConfig):
         self._smooth_shading = False
         self._depth_peeling = _DepthPeelingConfig()
         self._silhouette = _SilhouetteConfig()
-        self._slider_style = _SliderConfig()
+        self._slider_styles = _SliderConfig()
 
     @property
     def background(self):
@@ -1780,15 +1779,15 @@ class DefaultTheme(_ThemeConfig):
         self._silhouette = config
 
     @property
-    def slider_style(self) -> _SliderConfig:
+    def slider_styles(self) -> _SliderConfig:
         """Return the default slider_style configuration."""
-        return self._slider_style
+        return self._slider_styles
 
-    @slider_style.setter
-    def slider_style(self, config: _SliderConfig):
+    @slider_styles.setter
+    def slider_styles(self, config: _SliderConfig):
         if not isinstance(config, _SliderConfig):
             raise TypeError('Configuration type must be `_SliderConfig`')
-        self._slider_style = config
+        self._slider_styles = config
 
     @property
     def axes(self) -> _AxesConfig:
@@ -1865,7 +1864,7 @@ class DefaultTheme(_ThemeConfig):
             'Smooth shading': 'smooth_shading',
             'Depth peeling': 'depth_peeling',
             'Silhouette': 'silhouette',
-            'Slider Style': 'slider_style',
+            'Slider Style': 'slider_styles',
         }
         for name, attr in parm.items():
             setting = getattr(self, attr)

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1282,9 +1282,9 @@ class DefaultTheme(_ThemeConfig):
         return self._jupyter_backend
 
     @jupyter_backend.setter
-    def jupyter_backend(self, value: 'str'):
-        import pyvista
-        pyvista.set_jupyter_backend(value)
+    def jupyter_backend(self, backend: 'str'):
+        from pyvista.jupyter import _validate_jupyter_backend
+        self._jupyter_backend = _validate_jupyter_backend(backend)
 
     @property
     def auto_close(self) -> bool:

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -46,10 +46,22 @@ class _rcParams(dict):  # pragma: no cover
     """Reference to the deprecated rcParams dictionary."""
 
     def __getitem__(self, key):
-        raise DeprecationError('rcParams is deprecated.  Please use ``pyvista.global_theme``')
+        import pyvista  # avoids circular import
+        warnings.warn('rcParams is deprecated.  Please use ``pyvista.global_theme``',
+                      DeprecationWarning)
+        return getattr(pyvista.global_theme, key)
 
     def __setitem__(self, key, value):
-        raise DeprecationError('rcParams is deprecated.  Please use ``pyvista.global_theme``')
+        import pyvista  # avoids circular import
+        warnings.warn('rcParams is deprecated.  Please use ``pyvista.global_theme``',
+                      DeprecationWarning)
+        setattr(pyvista.global_theme, key, value)
+
+    def __repr__(self):
+        """Use the repr of global_theme"""
+        warnings.warn('rcParams is deprecated.  Please use ``pyvista.global_theme``',
+                      DeprecationWarning)
+        return repr(pyvista.global_theme)
 
 
 def load_theme(filename):
@@ -157,6 +169,20 @@ class _ThemeConfig():
                     return False
 
         return True
+
+    def __getitem__(self, key):
+        """Get a value via a key.
+
+        Implemented here for backwards compatibility.
+        """
+        return getattr(self, key)
+
+    def __setitem__(self, key, value):
+        """Set a value via a key.
+
+        Implemented here for backwards compatibility.
+        """
+        setattr(self, key, value)
 
 
 class _DepthPeelingConfig(_ThemeConfig):

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1,7 +1,37 @@
-"""Module managing different plotting theme parameters."""
+"""API description for managing plotting theme parameters in pyvista.
+
+Examples
+--------
+Apply a built-in theme
+
+>>> import pyvista
+>>> pyvista.set_plot_theme('default')
+>>> pyvista.set_plot_theme('document')
+>>> pyvista.set_plot_theme('dark')
+>>> pyvista.set_plot_theme('paraview')
+
+Load a theme into pyvista
+
+>>> theme = pyvista.themes.DefaultTheme()
+>>> theme.save('my_theme.json')  # doctest:+SKIP
+>>> loaded_theme = pyvista.load_theme('my_theme.json')  # doctest:+SKIP
+
+Create a custom theme from the default theme and load it into
+pyvista.
+
+>>> my_theme = pyvista.themes.DefaultTheme()
+>>> my_theme.font.size = 20
+>>> my_theme.font.title_size = 40
+>>> my_theme.cmap = 'jet'
+...
+>>> pyvista.global_theme.load_theme(my_theme)
+>>> pyvista.global_theme.font.size
+20
+
+"""
 
 import json
-from typing import Union, Iterable, Sized, Collection, List
+from typing import Union, List
 import warnings
 from enum import Enum
 import os
@@ -26,13 +56,40 @@ def load_theme(filename):
 
 
 def set_plot_theme(theme):
-    """Set the plotting parameters to a predefined theme."""
+    """Set the plotting parameters to a predefined theme using a string.
+
+    Parameters
+    ----------
+    theme : str
+        Theme name.  Either ``'default'``, ``'document'``, ``'dark'``,
+        or ``'paraview'``.
+
+    Examples
+    --------
+    Set to the default theme.
+
+    >>> import pyvista
+    >>> pyvista.set_plot_theme('default')
+
+    Set to the document theme.
+
+    >>> pyvista.set_plot_theme('document')
+
+    Set to the dark theme.
+
+    >>> pyvista.set_plot_theme('dark')
+
+    Set to the ParaView theme.
+
+    >>> pyvista.set_plot_theme('paraview')
+
+    """
     import pyvista
     if isinstance(theme, str):
         theme = theme.lower()
         if theme == 'night':  # pragma: no cover
             warnings.warn('use "dark" instead of "night" theme', PyvistaDeprecationWarning)
-        new_theme = ALLOWED_THEMES[theme].value()
+        new_theme = _ALLOWED_THEMES[theme].value()
         pyvista.global_theme.load_theme(new_theme)
     elif isinstance(theme, DefaultTheme):
         pyvista.global_theme.load_theme(theme)
@@ -1626,10 +1683,10 @@ class DefaultTheme(_ThemeConfig):
         Must be one of the following strings, which are mapped to the
         following VTK volume mappers.
 
-        ``'fixed_point'`` : ``vtk.vtkFixedPointVolumeRayCastMapper``
-        ``'gpu'`` : ``vtk.vtkGPUVolumeRayCastMapper``
-        ``'open_gl'`` : ``vtk.vtkOpenGLGPUVolumeRayCastMapper``
-        ``'smart'`` : ``vtk.vtkSmartVolumeMapper``
+        * ``'fixed_point'`` : ``vtk.vtkFixedPointVolumeRayCastMapper``
+        * ``'gpu'`` : ``vtk.vtkGPUVolumeRayCastMapper``
+        * ``'open_gl'`` : ``vtk.vtkOpenGLGPUVolumeRayCastMapper``
+        * ``'smart'`` : ``vtk.vtkSmartVolumeMapper``
 
         Examples
         --------
@@ -1846,6 +1903,9 @@ class DefaultTheme(_ThemeConfig):
         True
 
         """
+        if isinstance(theme, str):
+            theme = load_theme(theme)
+
         if not isinstance(theme, DefaultTheme):
             raise TypeError('``theme`` must be a pyvista theme like '
                             '``pyvista.themes.DefaultTheme``')
@@ -1987,10 +2047,11 @@ class _TestingTheme(DefaultTheme):
         self.name = 'testing'
         self.multi_samples = 1
         self.window_size = [400, 400]
+        self.axes.show = False
 
 
-class ALLOWED_THEMES(Enum):
-    """Themes available to PyVista."""
+class _ALLOWED_THEMES(Enum):
+    """Global built-in themes available to PyVista."""
 
     paraview = ParaViewTheme
     document = DocumentTheme

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -101,12 +101,12 @@ def set_plot_theme(theme):
         if theme == 'night':  # pragma: no cover
             warnings.warn('use "dark" instead of "night" theme', PyvistaDeprecationWarning)
             theme = 'dark'
-        new_theme = _ALLOWED_THEMES[theme].value()
-        pyvista.global_theme.load_theme(new_theme)
+        new_theme_type = _ALLOWED_THEMES[theme].value
+        pyvista.global_theme.load_theme(new_theme_type())
     elif isinstance(theme, DefaultTheme):
         pyvista.global_theme.load_theme(theme)
     else:
-        raise TypeError(f'Expected a pyvista.Theme or str, not '
+        raise TypeError(f'Expected a ``pyvista.DefaultTheme`` or ``str``, not '
                         f'a {type(theme).__name__}')
 
 

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -14,17 +14,17 @@ def set_plot_theme(theme):
     import pyvista
     if isinstance(theme, str):
         if theme.lower() in ['paraview', 'pv']:
-            pyvista.defaults.load_theme(ParaViewTheme())
+            pyvista.global_theme.load_theme(ParaViewTheme())
         elif theme.lower() in ['document', 'doc', 'paper', 'report']:
-            pyvista.defaults.load_theme(DocumentTheme())
+            pyvista.global_theme.load_theme(DocumentTheme())
         elif theme.lower() in ['night', 'dark']:
-            pyvista.defaults.load_theme(DarkTheme())
+            pyvista.global_theme.load_theme(DarkTheme())
         elif theme.lower() in ['default']:
-            pyvista.defaults.restore_defaults()
+            pyvista.global_theme.restore_defaults()
         else:
             raise ValueError(f'Expected one of the following themes:\n{ALLOWED_THEMES}')
     elif isinstance(theme, DefaultTheme):
-        pyvista.defaults.load_theme(theme)
+        pyvista.global_theme.load_theme(theme)
     else:
         raise TypeError(f'Expected a pyvista.Theme or str, not '
                         f'a {type(theme)}')
@@ -147,7 +147,7 @@ class DefaultTheme():
         Set the default global background of all plots to white.
 
         >>> import pyvista
-        >>> pyvista.defaults.background = 'white'
+        >>> pyvista.global_theme.background = 'white'
         """
         return self._background
 
@@ -232,7 +232,7 @@ class DefaultTheme():
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.defaults.auto_close = False
+        >>> pyvista.global_theme.auto_close = False
 
         """
         return self._auto_close
@@ -248,7 +248,7 @@ class DefaultTheme():
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.defaults.full_screen = True
+        >>> pyvista.global_theme.full_screen = True
         """
         return self._full_screen
 
@@ -265,16 +265,16 @@ class DefaultTheme():
         Set both the position and view of the camera.
 
         >>> import pyvista
-        >>> pyvista.defaults.camera = {'position': [1, 1, 1],
+        >>> pyvista.global_theme.camera = {'position': [1, 1, 1],
         ...                            'viewup': [0, 0, 1]}
 
         Set the default position of the camera
 
-        >>> pyvista.defaults.camera['position'] = [1, 1, 1]
+        >>> pyvista.global_theme.camera['position'] = [1, 1, 1]
 
         Set the default view of the camera
 
-        >>> pyvista.defaults.camera['viewup'] = [0, 0, 1]
+        >>> pyvista.global_theme.camera['viewup'] = [0, 0, 1]
 
         """
         return self._camera
@@ -304,7 +304,7 @@ class DefaultTheme():
         Disable all jupyter notebook plotting
 
         >>> import pyvista
-        >>> pyvista.defaults.notebook = False
+        >>> pyvista.global_theme.notebook = False
 
         """
 
@@ -321,7 +321,7 @@ class DefaultTheme():
         Set window size to ``[400, 400]``
 
         >>> import pyvista
-        >>> pyvista.defaults.window_size = [400, 400]
+        >>> pyvista.global_theme.window_size = [400, 400]
 
         """
         return self._window_size
@@ -347,27 +347,27 @@ class DefaultTheme():
         'arial', 'courier', or 'times'.
 
         >>> import pyvista
-        >>> pyvista.defaults.font['family'] = 'arial'
+        >>> pyvista.global_theme.font['family'] = 'arial'
 
         Set the default font size to 20.
 
-        >>> pyvista.defaults.font['size'] = 20
+        >>> pyvista.global_theme.font['size'] = 20
 
         Set the default title size to 40
 
-        >>> pyvista.defaults.font['title_size'] = 40
+        >>> pyvista.global_theme.font['title_size'] = 40
 
         Set the default label size to 10
 
-        >>> pyvista.defaults.font['label_size'] = 10
+        >>> pyvista.global_theme.font['label_size'] = 10
 
         Set the default text color to 'grey'
 
-        >>> pyvista.defaults.font['color'] = 'grey'
+        >>> pyvista.global_theme.font['color'] = 'grey'
 
         String formatter used to format numerical data to '%.6e'
 
-        >>> pyvista.defaults.font['color'] = '%.6e'
+        >>> pyvista.global_theme.font['color'] = '%.6e'
 
         """
         return self._font
@@ -395,7 +395,7 @@ class DefaultTheme():
         Set the default global colormap to 'jet'
 
         >>> import pyvista
-        >>> pyvista.defaults.cmap = 'jet'
+        >>> pyvista.global_theme.cmap = 'jet'
 
         """
         return self._cmap
@@ -423,7 +423,7 @@ class DefaultTheme():
         Set the default mesh color to 'red'
 
         >>> import pyvista
-        >>> pyvista.defaults.color = 'red'
+        >>> pyvista.global_theme.color = 'red'
 
         """
         return self._color
@@ -441,7 +441,7 @@ class DefaultTheme():
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.defaults.nan_color = 'darkgray'
+        >>> pyvista.global_theme.nan_color = 'darkgray'
         """
         return self._nan_color
 
@@ -458,7 +458,7 @@ class DefaultTheme():
         Set the global edge color to 'blue'
 
         >>> import pyvista
-        >>> pyvista.defaults.edge_color = 'blue'
+        >>> pyvista.global_theme.edge_color = 'blue'
         """
         return self._edge_color
 
@@ -473,7 +473,7 @@ class DefaultTheme():
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.defaults.outline_color = 'white'
+        >>> pyvista.global_theme.outline_color = 'white'
         """
         return self._outline_color
 
@@ -488,7 +488,7 @@ class DefaultTheme():
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.defaults.floor_color = 'black'
+        >>> pyvista.global_theme.floor_color = 'black'
         """
         return self._floor_color
 
@@ -505,7 +505,7 @@ class DefaultTheme():
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.defaults.colorbar_orientation = 'horizontal'
+        >>> pyvista.global_theme.colorbar_orientation = 'horizontal'
         """
         return self._colorbar_orientation
 
@@ -525,7 +525,7 @@ class DefaultTheme():
         Set the default colorbar width to 0.6
 
         >>> import pyvista
-        >>> pyvista.defaults.colorbar_horizontal['width'] = 0.6
+        >>> pyvista.global_theme.colorbar_horizontal['width'] = 0.6
 
         Set all the parameters of the colorbar
 
@@ -534,7 +534,7 @@ class DefaultTheme():
         ... 'height': 0.08,
         ... 'position_x': 0.35,
         ... 'position_y': 0.05}
-        >>> pyvista.defaults.colorbar_horizontal = colorbar_parm
+        >>> pyvista.global_theme.colorbar_horizontal = colorbar_parm
 
         """
         return self._colorbar_horizontal
@@ -556,7 +556,7 @@ class DefaultTheme():
         Set the default colorbar width to 0.45
 
         >>> import pyvista
-        >>> pyvista.defaults.colorbar_vertical['width'] = 0.45
+        >>> pyvista.global_theme.colorbar_vertical['width'] = 0.45
 
         Set all the parameters of the colorbar
 
@@ -565,7 +565,7 @@ class DefaultTheme():
         ... 'height': 0.45,
         ... 'position_x': 0.9,
         ... 'position_y': 0.02}
-        >>> pyvista.defaults.colorbar_vertical = colorbar_parm
+        >>> pyvista.global_theme.colorbar_vertical = colorbar_parm
 
         """
         return self._colorbar_vertical
@@ -587,7 +587,7 @@ class DefaultTheme():
         Show the scalar bar by default when scalars are available.
 
         >>> import pyvista
-        >>> pyvista.defaults.show_scalar_bar = True
+        >>> pyvista.global_theme.show_scalar_bar = True
 
         """
         return self._show_scalar_bar
@@ -605,7 +605,7 @@ class DefaultTheme():
         Show edges globally by default.
 
         >>> import pyvista
-        >>> pyvista.defaults.show_edges = True
+        >>> pyvista.global_theme.show_edges = True
 
         """
         return self._show_edges
@@ -623,7 +623,7 @@ class DefaultTheme():
         Disable lighting globally
 
         >>> import pyvista
-        >>> pyvista.defaults.lighting = False
+        >>> pyvista.global_theme.lighting = False
         """
         return self._lighting
 
@@ -640,7 +640,7 @@ class DefaultTheme():
         Make all plots non-interactive globally.
 
         >>> import pyvista
-        >>> pyvista.defaults.interactive = False
+        >>> pyvista.global_theme.interactive = False
         """
         return self._interactive
 
@@ -657,7 +657,7 @@ class DefaultTheme():
         Render points as spheres by default globally to ``True``.
 
         >>> import pyvista
-        >>> pyvista.defaults.render_points_as_spheres = True
+        >>> pyvista.global_theme.render_points_as_spheres = True
         """
         return self._render_points_as_spheres
 
@@ -684,7 +684,7 @@ class DefaultTheme():
         Set transparent_background globally to ``True``
 
         >>> import pyvista
-        >>> pyvista.defaults.transparent_background = True
+        >>> pyvista.global_theme.transparent_background = True
         """
         return self._transparent_background
 
@@ -703,7 +703,7 @@ class DefaultTheme():
         Set title globally to 'plot'
 
         >>> import pyvista
-        >>> pyvista.defaults.title = 'plot'
+        >>> pyvista.global_theme.title = 'plot'
         """
         return self._title
 
@@ -722,7 +722,7 @@ class DefaultTheme():
         Set the default number of multisamples to 2.
 
         >>> import pyvista
-        >>> pyvista.defaults.multi_samples = 2
+        >>> pyvista.global_theme.multi_samples = 2
         """
         return self._multi_samples
 
@@ -740,7 +740,7 @@ class DefaultTheme():
         middle of the window).
 
         >>> import pyvista
-        >>> pyvista.defaults.multi_rendering_splitting_position = 0.5
+        >>> pyvista.global_theme.multi_rendering_splitting_position = 0.5
         """
         return self._multi_rendering_splitting_position
 
@@ -765,7 +765,7 @@ class DefaultTheme():
         Set default volume mapper globally to 'gpu'.
 
         >>> import pyvista
-        >>> pyvista.defaults.volume_mapper = 'gpu'
+        >>> pyvista.global_theme.volume_mapper = 'gpu'
         """
         return self._volume_mapper
 
@@ -787,7 +787,7 @@ class DefaultTheme():
         Set the global smooth_shading parameter default to ``True``.
 
         >>> import pyvista
-        >>> pyvista.defaults.smooth_shading = True
+        >>> pyvista.global_theme.smooth_shading = True
         """
         return self._smooth_shading
 
@@ -811,7 +811,7 @@ class DefaultTheme():
         with 8 peels.
 
         >>> import pyvista
-        >>> pyvista.defaults.depth_peeling = {
+        >>> pyvista.global_theme.depth_peeling = {
         ...     'number_of_peels': 8,
         ...     'occlusion_ratio': 0.0,
         ...     'enabled': False}
@@ -835,7 +835,7 @@ class DefaultTheme():
         Set the silhouette parameter dictionary
 
         >>> import pyvista
-        >>> pyvista.defaults.silhouette = {
+        >>> pyvista.global_theme.silhouette = {
         ...    'color': 'black',
         ...    'line_width': 2,
         ...    'opacity': 1.0,
@@ -844,7 +844,7 @@ class DefaultTheme():
 
         Set a single value of the silhouette.
 
-        >>> pyvista.defaults.silhouette['opacity'] = 0.5
+        >>> pyvista.global_theme.silhouette['opacity'] = 0.5
 
         """
         return self._silhouette
@@ -866,7 +866,7 @@ class DefaultTheme():
         Set the ``slider_style`` dictionary.
 
         >>> import pyvista
-        >>> pyvista.defaults.slider_style = {
+        >>> pyvista.global_theme.slider_style = {
         ...     'classic': {
         ...         'slider_length': 0.02,
         ...         'slider_width': 0.04,
@@ -891,7 +891,7 @@ class DefaultTheme():
 
         Set a single slider style parameter
 
-        >>> pyvista.defaults.slider_style['classic']['slider_length'] = 0.05
+        >>> pyvista.global_theme.slider_style['classic']['slider_length'] = 0.05
 
         """
         return self._slider_style
@@ -909,7 +909,7 @@ class DefaultTheme():
         Set the axes dictionary.
 
         >>> import pyvista
-        >>> pyvista.defaults.axes = {
+        >>> pyvista.global_theme.axes = {
         ...     'x_color': 'tomato',
         ...     'y_color': 'seagreen',
         ...     'z_color': 'mediumblue',
@@ -919,7 +919,7 @@ class DefaultTheme():
 
         Set a single axes theme value
 
-        >>> pyvista.defaults.axes['x_color'] = 'black'
+        >>> pyvista.global_theme.axes['x_color'] = 'black'
 
         """
         return self._axes
@@ -934,7 +934,7 @@ class DefaultTheme():
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.defaults.restore_defaults()
+        >>> pyvista.global_theme.restore_defaults()
 
         """
         self.__init__()
@@ -1013,8 +1013,8 @@ class DefaultTheme():
         >>> my_theme.font['title_size'] = 40
         >>> my_theme.cmap = 'jet'
         ...
-        >>> pyvista.defaults.load_theme(my_theme)
-        >>> pyvista.defaults.font['size']
+        >>> pyvista.global_theme.load_theme(my_theme)
+        >>> pyvista.global_theme.font['size']
         20
 
         Create a custom theme from the dark theme and load it into
@@ -1023,8 +1023,8 @@ class DefaultTheme():
         >>> from pyvista.themes import DarkTheme
         >>> my_theme = DarkTheme()
         >>> my_theme.show_edges = True
-        >>> pyvista.defaults.load_theme(my_theme)
-        >>> pyvista.defaults.show_edges
+        >>> pyvista.global_theme.load_theme(my_theme)
+        >>> pyvista.global_theme.show_edges
         True
 
         """
@@ -1163,11 +1163,11 @@ class _GlobalTheme(DefaultTheme):
     Change the default background color to white.
 
     >>> import pyvista
-    >>> pyvista.defaults.color = 'white'
+    >>> pyvista.global_theme.color = 'white'
 
     Show edges by default.
 
-    >>> pyvista.defaults.show_edges = True
+    >>> pyvista.global_theme.show_edges = True
 
     """
 

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -2,12 +2,11 @@
 
 import os
 
-from pyvista import _vtk
 from .plotting.colors import PARAVIEW_BACKGROUND
 from .plotting.tools import parse_color
 
 
-ALLOWED_THEMES = ['paraview', 'document', 'night', 'default']
+ALLOWED_THEMES = ['paraview', 'document', 'dark', 'night', 'default']
 
 
 def set_plot_theme(theme):
@@ -24,14 +23,14 @@ def set_plot_theme(theme):
             pyvista.defaults.restore_defaults()
         else:
             raise ValueError(f'Expected one of the following themes:\n{ALLOWED_THEMES}')
-    elif isinstance(theme, Theme):
+    elif isinstance(theme, DefaultTheme):
         pyvista.defaults.load_theme(theme)
     else:
         raise TypeError(f'Expected a pyvista.Theme or str, not '
                         f'a {type(theme)}')
 
 
-class Theme():
+class DefaultTheme():
     """PyVista default theme."""
 
     def __init__(self):
@@ -999,8 +998,45 @@ class Theme():
     def name(self, name):
         self._name = name
 
+    def load_theme(self, theme):
+        """Overwrite the current them with a theme.
 
-class DarkTheme(Theme):
+        Examples
+        --------
+        Create a custom theme from the default theme and load it into
+        pyvista.
+
+        >>> import pyvista
+        >>> from pyvista.themes import DefaultTheme
+        >>> my_theme = DefaultTheme()
+        >>> my_theme.font['size'] = 20
+        >>> my_theme.font['title_size'] = 40
+        >>> my_theme.cmap = 'jet'
+        ...
+        >>> pyvista.defaults.load_theme(my_theme)
+        >>> pyvista.defaults.font['size']
+        20
+
+        Create a custom theme from the dark theme and load it into
+        pyvista.
+
+        >>> from pyvista.themes import DarkTheme
+        >>> my_theme = DarkTheme()
+        >>> my_theme.show_edges = True
+        >>> pyvista.defaults.load_theme(my_theme)
+        >>> pyvista.defaults.show_edges
+        True
+
+        """
+        if not isinstance(theme, DefaultTheme):
+            raise TypeError('``theme`` must be a pyvista theme like '
+                            '``pyvista.themes.DefaultTheme``')
+
+        for name, value in vars(theme).items():
+            setattr(self, name, value)
+
+
+class DarkTheme(DefaultTheme):
     """Dark mode theme.
 
     Black background, "viridis" colormap, tan meshes, white (hidden) edges.
@@ -1033,7 +1069,7 @@ class DarkTheme(Theme):
         self._axes['z_color'] = 'blue'
 
 
-class ParaViewTheme(Theme):
+class ParaViewTheme(DefaultTheme):
     """Set the theme to a paraview-like theme.
 
     Examples
@@ -1066,7 +1102,7 @@ class ParaViewTheme(Theme):
         self._axes['z_color'] = 'green'
 
 
-class DocumentTheme(Theme):
+class DocumentTheme(DefaultTheme):
     """Set the global theme to the document theme.
 
     This theme uses a white background, the "viridis" colormap,
@@ -1104,7 +1140,7 @@ class DocumentTheme(Theme):
         self._axes['z_color'] = 'blue'
 
 
-class _TestingTheme(Theme):
+class _TestingTheme(DefaultTheme):
     """Low resolution testing theme for ``pytest``.
 
     Necessary for image regression.  Xvfb doesn't support
@@ -1119,8 +1155,8 @@ class _TestingTheme(Theme):
         self._window_size = [400, 400]
 
 
-class Defaults(Theme):
-    """Global PyVista defaults.
+class _GlobalTheme(DefaultTheme):
+    """Global PyVista theme.
 
     Examples
     --------
@@ -1138,39 +1174,3 @@ class Defaults(Theme):
     def __init__(self):
         """Initialize the base theme."""
         super().__init__()
-
-    def load_theme(self, theme):
-        """Overwrite the current defaults with a theme.
-
-        Examples
-        --------
-        Create a custom theme from the default theme and load it into
-        pyvista.
-
-        >>> import pyvista
-        >>> from pyvista.themes import Theme
-        >>> my_theme = Theme()
-        >>> my_theme.font['size'] = 20
-        >>> my_theme.font['title_size'] = 40
-        >>> my_theme.cmap = 'jet'
-        ...
-        >>> pyvista.defaults.load_theme(my_theme)
-        >>> pyvista.defaults.font['size']
-        20
-
-        Create a custom theme from the dark theme and load it into
-        pyvista.
-
-        >>> from pyvista.themes import DarkTheme
-        >>> my_theme = DarkTheme()
-        >>> my_theme.show_edges = True
-        >>> pyvista.defaults.load_theme(my_theme)
-        >>> pyvista.defaults.show_edges
-        True
-
-        """
-        if not isinstance(theme, Theme):
-            raise TypeError('``theme`` must be a ``pyvista.Theme``')
-
-        for name, value in vars(theme).items():
-            setattr(self, name, value)

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -16,6 +16,7 @@ def set_plot_theme(theme):
     """Set the plotting parameters to a predefined theme."""
     import pyvista
     if isinstance(theme, str):
+        theme = theme.lower()
         if theme == 'night':  # pragma: no cover
             warnings.warn('use "dark" instead of "night" theme', PyvistaDeprecationWarning)
         new_theme = ALLOWED_THEMES[theme].value()

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1072,7 +1072,7 @@ class DefaultTheme(_ThemeConfig):
 
     >>> my_theme = pyvista.themes.DefaultTheme()
     >>> my_theme.color = 'red'
-    >>> my_theme.background_color = 'white'
+    >>> my_theme.background = 'white'
     >>> pyvista.global_theme.load_theme(my_theme)
 
     """

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -58,10 +58,16 @@ class _rcParams(dict):  # pragma: no cover
         setattr(pyvista.global_theme, key, value)
 
     def __repr__(self):
-        """Use the repr of global_theme"""
+        """Use the repr of global_theme."""
         warnings.warn('rcParams is deprecated.  Please use ``pyvista.global_theme``',
                       DeprecationWarning)
         return repr(pyvista.global_theme)
+
+
+def _check_between_zero_and_one(value: float, value_name: str = 'value'):
+    """Check if a value is between zero and one."""
+    if value < 0 or value > 1:
+        raise ValueError('{value_name} must be between 0 and 1.')
 
 
 def load_theme(filename):
@@ -132,8 +138,6 @@ class _ThemeConfig():
         """Create from a dictionary."""
         inst = cls()
         for key, value in dict_.items():
-            if not hasattr(inst, key):
-                raise KeyError(f'Invalid key "{key}" for {cls.__name__}')
             attr = getattr(inst, key)
             if hasattr(attr, 'from_dict'):
                 setattr(inst, key, attr.from_dict(value))
@@ -342,6 +346,7 @@ class _SilhouetteConfig(_ThemeConfig):
 
     @opacity.setter
     def opacity(self, opacity: float):
+        _check_between_zero_and_one(opacity, 'opacity')
         self._opacity = float(opacity)
 
     @property
@@ -376,10 +381,7 @@ class _SilhouetteConfig(_ThemeConfig):
 
     @decimate.setter
     def decimate(self, decimate: float):
-        decimate = float(decimate)
-        if not 0 <= decimate <= 1:
-            raise ValueError('Silhouette decimation must be '
-                             'between 0 and 1.')
+        _check_between_zero_and_one(decimate, 'decimate')
         self._decimate = float(decimate)
 
     def __repr__(self):

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -59,6 +59,7 @@ class _rcParams(dict):  # pragma: no cover
 
     def __repr__(self):
         """Use the repr of global_theme."""
+        import pyvista  # avoids circular import
         warnings.warn('rcParams is deprecated.  Please use ``pyvista.global_theme``',
                       DeprecationWarning)
         return repr(pyvista.global_theme)

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -755,9 +755,10 @@ def try_callback(func, *args):
 def check_depth_peeling(number_of_peels=100, occlusion_ratio=0.0):
     """Check if depth peeling is available.
 
-    Attempts to use depth peeling to see if it is available for the current
-    environment. Returns ``True`` if depth peeling is available and has been
-    successfully leveraged, otherwise ``False``.
+    Attempts to use depth peeling to see if it is available for the
+    current environment. Returns ``True`` if depth peeling is
+    available and has been successfully leveraged, otherwise
+    ``False``.
 
     """
     # Try Depth Peeling with a basic scene

--- a/pyvista/utilities/misc.py
+++ b/pyvista/utilities/misc.py
@@ -11,3 +11,9 @@ def _get_vtk_id_type():
     elif VTK_ID_TYPE_SIZE == 8:
         return np.int64
     return np.int32
+
+
+class PyvistaDeprecationWarning(Warning):
+    """Non-supressed Depreciation Warning."""
+
+    pass

--- a/pyvista/utilities/xvfb.py
+++ b/pyvista/utilities/xvfb.py
@@ -32,7 +32,7 @@ def start_xvfb(wait=3, window_size=None):
     >>> pyvista.start_xvfb()  # doctest:+SKIP
 
     """
-    from pyvista import defaults
+    from pyvista import global_theme
 
     if os.name != 'posix':
         raise OSError('`start_xvfb` is only supported on Linux')
@@ -42,8 +42,8 @@ def start_xvfb(wait=3, window_size=None):
 
     # use current default window size
     if window_size is None:
-        window_size = defaults.window_size
-    window_size_parm = '%dx%dx24' % tuple(window_size)
+        window_size = global_theme.window_size
+    window_size_parm = f'{window_size[0]:d}x{window_size[1]:d}x24'
     display_num = ':99'
     os.system(f'Xvfb {display_num} -screen 0 {window_size_parm} > /dev/null 2>&1 &')
     os.environ['DISPLAY'] = display_num

--- a/pyvista/utilities/xvfb.py
+++ b/pyvista/utilities/xvfb.py
@@ -23,11 +23,16 @@ def start_xvfb(wait=3, window_size=None):
         to disable wait.
 
     window_size : list, optional
-        Window size of the virtual frame buffer.  Defaults to the
-        default window size in ``rcParams``.
+        Window size of the virtual frame buffer.  Defaults to
+        ``pyvista.defaults.window_size``.
+
+    Examples
+    --------
+    >>> import pyvista
+    >>> pyvista.start_xvfb()  # doctest:+SKIP
 
     """
-    from pyvista import rcParams
+    from pyvista import defaults
 
     if os.name != 'posix':
         raise OSError('`start_xvfb` is only supported on Linux')
@@ -36,7 +41,9 @@ def start_xvfb(wait=3, window_size=None):
         raise OSError(XVFB_INSTALL_NOTES)
 
     # use current default window size
-    window_size_parm = '%dx%dx24' % tuple(rcParams['window_size'])
+    if window_size is None:
+        window_size = defaults.window_size
+    window_size_parm = '%dx%dx24' % tuple(window_size)
     display_num = ':99'
     os.system(f'Xvfb {display_num} -screen 0 {window_size_parm} > /dev/null 2>&1 &')
     os.environ['DISPLAY'] = display_num

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from pytest import fixture
 import pyvista
 from pyvista import examples
 
-pyvista.defaults.load_theme(pyvista.themes._TestingTheme())
 pyvista.OFF_SCREEN = True
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,10 @@ import os
 import numpy as np
 from pytest import fixture
 
-# env var testing, but be here before any pyvista imports
-os.environ['PYVISTA_JUPYTER_BACKEND'] = 'none'
-
 import pyvista
 from pyvista import examples
 
-pyvista.set_plot_theme('testing')
+pyvista.defaults.load_theme(pyvista.themes._TestingTheme())
 pyvista.OFF_SCREEN = True
 
 

--- a/tests/jupyter/test_ipygany.py
+++ b/tests/jupyter/test_ipygany.py
@@ -16,9 +16,9 @@ skip_no_ipygany = pytest.mark.skipif(not has_ipygany,
 
 @skip_no_ipygany
 def test_set_jupyter_backend_ipygany():
-    pv.set_jupyter_backend('ipygany')
-    assert pv.rcParams['jupyter_backend'] == 'ipygany'
-    pv.set_jupyter_backend(None)
+    pv.defaults.jupyter_backend = 'ipygany'
+    assert pv.defaults.jupyter_backend == 'ipygany'
+    pv.defaults.jupyter_backend = None
 
 
 @skip_no_ipygany

--- a/tests/jupyter/test_ipygany.py
+++ b/tests/jupyter/test_ipygany.py
@@ -16,9 +16,9 @@ skip_no_ipygany = pytest.mark.skipif(not has_ipygany,
 
 @skip_no_ipygany
 def test_set_jupyter_backend_ipygany():
-    pv.defaults.jupyter_backend = 'ipygany'
-    assert pv.defaults.jupyter_backend == 'ipygany'
-    pv.defaults.jupyter_backend = None
+    pv.global_theme.jupyter_backend = 'ipygany'
+    assert pv.global_theme.jupyter_backend == 'ipygany'
+    pv.global_theme.jupyter_backend = None
 
 
 @skip_no_ipygany

--- a/tests/jupyter/test_ipyvtk.py
+++ b/tests/jupyter/test_ipyvtk.py
@@ -17,9 +17,9 @@ skip_no_ipyvtk = pytest.mark.skipif(not has_ipyvtklink,
 
 @skip_no_ipyvtk
 def test_set_jupyter_backend_ipyvtklink():
-    pv.defaults.jupyter_backend = 'ipyvtklink'
-    assert pv.defaults.jupyter_backend == 'ipyvtklink'
-    pv.defaults.jupyter_backend = None
+    pv.global_theme.jupyter_backend = 'ipyvtklink'
+    assert pv.global_theme.jupyter_backend == 'ipyvtklink'
+    pv.global_theme.jupyter_backend = None
 
 
 @skip_no_ipyvtk

--- a/tests/jupyter/test_ipyvtk.py
+++ b/tests/jupyter/test_ipyvtk.py
@@ -17,9 +17,9 @@ skip_no_ipyvtk = pytest.mark.skipif(not has_ipyvtklink,
 
 @skip_no_ipyvtk
 def test_set_jupyter_backend_ipyvtklink():
-    pv.set_jupyter_backend('ipyvtklink')
-    assert pv.rcParams['jupyter_backend'] == 'ipyvtklink'
-    pv.set_jupyter_backend(None)
+    pv.defaults.jupyter_backend = 'ipyvtklink'
+    assert pv.defaults.jupyter_backend == 'ipyvtklink'
+    pv.defaults.jupyter_backend = None
 
 
 @skip_no_ipyvtk

--- a/tests/jupyter/test_itk_plotting.py
+++ b/tests/jupyter/test_itk_plotting.py
@@ -4,10 +4,6 @@ import pytest
 import pyvista
 from pyvista.plotting import system_supports_plotting
 
-# for azure testing and itkwidgets
-# import matplotlib
-# matplotlib.use("agg")
-
 NO_PLOTTING = not system_supports_plotting()
 
 HAS_ITK = False

--- a/tests/jupyter/test_panel.py
+++ b/tests/jupyter/test_panel.py
@@ -14,7 +14,7 @@ skip_no_panel = pytest.mark.skipif(not has_panel, reason='Requires panel')
 @skip_no_panel
 def test_set_jupyter_backend_ipygany():
     pv.set_jupyter_backend('panel')
-    assert pv.rcParams['jupyter_backend'] == 'panel'
+    assert pv.defaults.jupyter_backend == 'panel'
     pv.set_jupyter_backend(None)
 
 

--- a/tests/jupyter/test_panel.py
+++ b/tests/jupyter/test_panel.py
@@ -14,7 +14,7 @@ skip_no_panel = pytest.mark.skipif(not has_panel, reason='Requires panel')
 @skip_no_panel
 def test_set_jupyter_backend_ipygany():
     pv.set_jupyter_backend('panel')
-    assert pv.defaults.jupyter_backend == 'panel'
+    assert pv.global_theme.jupyter_backend == 'panel'
     pv.set_jupyter_backend(None)
 
 

--- a/tests/jupyter/test_static.py
+++ b/tests/jupyter/test_static.py
@@ -23,13 +23,13 @@ def test_set_jupyter_backend_ipygany_fail():
 @pytest.mark.parametrize('backend', [None, 'none'])
 def test_set_jupyter_backend_none(backend):
     pv.set_jupyter_backend(backend)
-    assert pv.defaults.jupyter_backend is None
+    assert pv.global_theme.jupyter_backend is None
 
 
 @skip_no_ipython
 def test_set_jupyter_backend_ipygany():
     pv.set_jupyter_backend('static')
-    assert pv.defaults.jupyter_backend == 'static'
+    assert pv.global_theme.jupyter_backend == 'static'
     pv.set_jupyter_backend(None)
 
 

--- a/tests/jupyter/test_static.py
+++ b/tests/jupyter/test_static.py
@@ -23,13 +23,13 @@ def test_set_jupyter_backend_ipygany_fail():
 @pytest.mark.parametrize('backend', [None, 'none'])
 def test_set_jupyter_backend_none(backend):
     pv.set_jupyter_backend(backend)
-    assert pv.rcParams['jupyter_backend'] is None
+    assert pv.defaults.jupyter_backend is None
 
 
 @skip_no_ipython
 def test_set_jupyter_backend_ipygany():
     pv.set_jupyter_backend('static')
-    assert pv.rcParams['jupyter_backend'] == 'static'
+    assert pv.defaults.jupyter_backend == 'static'
     pv.set_jupyter_backend(None)
 
 

--- a/tests/plotting/conftest.py
+++ b/tests/plotting/conftest.py
@@ -4,12 +4,11 @@ memory leaks for all plotting tests
 import gc
 
 import pytest
-import vtk
 
 import pyvista
 
 # this is set here as well in conftest one level up.
-pyvista.defaults.load_theme(pyvista.themes._TestingTheme())
+pyvista.global_theme.load_theme(pyvista.themes._TestingTheme())
 pyvista.OFF_SCREEN = True
 
 

--- a/tests/plotting/conftest.py
+++ b/tests/plotting/conftest.py
@@ -9,7 +9,7 @@ import vtk
 import pyvista
 
 # this is set here as well in conftest one level up.
-pyvista.set_plot_theme('testing')
+pyvista.defaults.load_theme(pyvista.themes._TestingTheme())
 pyvista.OFF_SCREEN = True
 
 

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -525,9 +525,9 @@ def test_plot_silhouette(tri_cylinder):
     assert len(actors) == 2  # cylinder + silhouette
     actor = actors[0]  # get silhouette actor
     props = actor.GetProperty()
-    assert props.GetColor() == pyvista.parse_color(pyvista.global_theme.silhouette["color"])
-    assert props.GetOpacity() == pyvista.global_theme.silhouette["opacity"]
-    assert props.GetLineWidth() == pyvista.global_theme.silhouette["line_width"]
+    assert props.GetColor() == pyvista.parse_color(pyvista.global_theme.silhouette.color)
+    assert props.GetOpacity() == pyvista.global_theme.silhouette.opacity
+    assert props.GetLineWidth() == pyvista.global_theme.silhouette.line_width
     plotter.show(before_close_callback=verify_cache_image)
 
 
@@ -535,7 +535,7 @@ def test_plot_silhouette(tri_cylinder):
 def test_plot_silhouette_options(tri_cylinder):
     # cover other properties
     plotter = pyvista.Plotter()
-    plotter.add_mesh(tri_cylinder, silhouette=dict(decimate=None, feature_angle=True))
+    plotter.add_mesh(tri_cylinder, silhouette=dict(decimate=None, feature_angle=20))
     plotter.show(before_close_callback=verify_cache_image)
 
 

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -525,9 +525,9 @@ def test_plot_silhouette(tri_cylinder):
     assert len(actors) == 2  # cylinder + silhouette
     actor = actors[0]  # get silhouette actor
     props = actor.GetProperty()
-    assert props.GetColor() == pyvista.parse_color(pyvista.defaults.silhouette["color"])
-    assert props.GetOpacity() == pyvista.defaults.silhouette["opacity"]
-    assert props.GetLineWidth() == pyvista.defaults.silhouette["line_width"]
+    assert props.GetColor() == pyvista.parse_color(pyvista.global_theme.silhouette["color"])
+    assert props.GetOpacity() == pyvista.global_theme.silhouette["opacity"]
+    assert props.GetLineWidth() == pyvista.global_theme.silhouette["line_width"]
     plotter.show(before_close_callback=verify_cache_image)
 
 

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -525,9 +525,9 @@ def test_plot_silhouette(tri_cylinder):
     assert len(actors) == 2  # cylinder + silhouette
     actor = actors[0]  # get silhouette actor
     props = actor.GetProperty()
-    assert props.GetColor() == pyvista.parse_color(pyvista.rcParams["silhouette"]["color"])
-    assert props.GetOpacity() == pyvista.rcParams["silhouette"]["opacity"]
-    assert props.GetLineWidth() == pyvista.rcParams["silhouette"]["line_width"]
+    assert props.GetColor() == pyvista.parse_color(pyvista.defaults.silhouette["color"])
+    assert props.GetOpacity() == pyvista.defaults.silhouette["opacity"]
+    assert props.GetLineWidth() == pyvista.defaults.silhouette["line_width"]
     plotter.show(before_close_callback=verify_cache_image)
 
 
@@ -920,23 +920,6 @@ def test_scalars_by_name():
     data = examples.load_uniform()
     plotter.add_mesh(data, scalars='Spatial Cell Data')
     plotter.show(before_close_callback=verify_cache_image)
-
-
-@pytest.mark.parametrize('theme', ['paraview', 'document', 'night', 'default'])
-def test_themes(theme):
-    pyvista.set_plot_theme(theme)
-    if theme != 'default':
-        assert pyvista.rcParams != pyvista.DEFAULT_THEME
-        pyvista.set_plot_theme('default')
-    assert pyvista.rcParams == pyvista.DEFAULT_THEME
-
-    # always return to testing theme
-    pyvista.set_plot_theme('testing')
-
-
-def test_invalid_theme():
-    with pytest.raises(ValueError, match='Invalid theme'):
-        pyvista.set_plot_theme('this is not a valid theme')
 
 
 @skip_no_plotting

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -360,7 +360,6 @@ def test_lighting_init_invalid():
     with pytest.raises(ValueError):
         pyvista.Plotter(lighting='invalid')
 
-
 @skip_no_plotting
 def test_plotter_shape_invalid():
     # wrong size

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -381,7 +381,7 @@ def test_theme_eq():
     assert defa_theme0 != dark_theme
 
     # for coverage
-    assert defa_theme0 != 'apple', 'wrong type test failed'
+    assert defa_theme0 != 'apple'
 
 
 def test_plotter_set_theme():

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,11 +1,8 @@
-import warnings
-
 import pytest
 import vtk
 
 import pyvista
 from pyvista import colors
-from pyvista.utilities.misc import PyvistaDeprecationWarning
 
 
 @pytest.fixture

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -57,25 +57,25 @@ def test_depth_silhouette_eq(default_theme):
                                   ('cap_length', 0.02),
                                   ('cap_width', 0.04)
 ])
-@pytest.mark.parametrize('slider_type', ('modern', 'classic'))
-def test_slider_style_config(default_theme, parm, slider_type):
+@pytest.mark.parametrize('style', ('modern', 'classic'))
+def test_slider_style_config(default_theme, parm, style):
     attr, value = parm
 
-    slider_style = getattr(default_theme.slider_style, 'modern')
+    slider_style = getattr(default_theme.slider_styles, style)
     assert hasattr(slider_style, attr)
     setattr(slider_style, attr, value)
     assert getattr(slider_style, attr) == value
 
 
 def test_slider_style_config_eq(default_theme):
-    assert default_theme.slider_style.modern != default_theme.slider_style.classic
-    assert default_theme.slider_style.modern != 1
+    assert default_theme.slider_styles.modern != default_theme.slider_styles.classic
+    assert default_theme.slider_styles.modern != 1
 
 
 def test_slider_style_eq(default_theme):
     my_theme = pyvista.themes.DefaultTheme()
-    my_theme.slider_style.modern.slider_length *= 2
-    assert default_theme.slider_style != my_theme.slider_style
+    my_theme.slider_styles.modern.slider_length *= 2
+    assert default_theme.slider_styles != my_theme.slider_styles
 
 
 def test_invalid_color_str_single_char():

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -10,6 +10,17 @@ def default_theme():
     return pyvista.themes.DefaultTheme()
 
 
+def test_backwards_compatibility():
+    color = (0.1, 0.4, 0.7)
+    pyvista.rcParams['color'] = color
+    assert pyvista.rcParams['color'] == color
+
+    # test nested values
+    init_value = pyvista.rcParams['axes']['show']
+    pyvista.rcParams['axes']['show'] = not init_value
+    assert pyvista.rcParams['axes']['show'] is not init_value
+
+
 @pytest.mark.parametrize('parm', [('enabled', True),
                                   ('occlusion_ratio', 0.5),
                                   ('number_of_peels', 2)]

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -26,3 +26,21 @@ def test_font():
     assert font == vtk.VTK_TIMES
     with pytest.raises(ValueError):
         pyvista.parse_font_family('not a font')
+
+
+
+# @pytest.mark.parametrize('theme', ['paraview', 'document', 'night', 'default'])
+# def test_themes(theme):
+#     pyvista.set_plot_theme(theme)
+#     if theme != 'default':
+#         assert pyvista.rcParams != pyvista.DEFAULT_THEME
+#         pyvista.set_plot_theme('default')
+#     assert pyvista.rcParams == pyvista.DEFAULT_THEME
+
+#     # always return to testing theme
+#     pyvista.set_plot_theme('testing')
+
+
+# def test_invalid_theme():
+#     with pytest.raises(ValueError, match='Invalid theme'):
+#         pyvista.set_plot_theme('this is not a valid theme')

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -320,6 +320,12 @@ def test_repr(default_theme):
     assert default_theme._name.capitalize() in rep
 
 
+def test_theme_slots(default_theme):
+    # verify we can't create an arbitrary attribute
+    with pytest.raises(AttributeError, match='has no attribute'):
+        default_theme.new_attr = 1
+
+
 def test_theme_eq():
     defa_theme0 = pyvista.themes.DefaultTheme()
     defa_theme1 = pyvista.themes.DefaultTheme()

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -350,8 +350,8 @@ def test_plotter_set_theme():
         pyvista.global_theme.load_theme(pyvista.themes._TestingTheme())
 
 
-def test_load_theme(default_theme, tmpdir):
+def test_load_theme(tmpdir):
     filename = str(tmpdir.mkdir("tmpdir").join('tmp.json'))
-    default_theme.save(filename)
+    pyvista.themes.DarkTheme().save(filename)
     loaded_theme = pyvista.load_theme(filename)
-    assert loaded_theme == default_theme
+    assert loaded_theme == pyvista.themes.DarkTheme()

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -10,6 +10,74 @@ def default_theme():
     return pyvista.themes.DefaultTheme()
 
 
+@pytest.mark.parametrize('parm', [('enabled', True),
+                                  ('occlusion_ratio', 0.5),
+                                  ('number_of_peels', 2)]
+)
+def test_depth_peeling_config(default_theme, parm):
+    attr, value = parm
+    assert hasattr(default_theme.depth_peeling, attr)
+    setattr(default_theme.depth_peeling, attr, value)
+    assert getattr(default_theme.depth_peeling, attr) == value
+
+
+def test_depth_peeling_eq(default_theme):
+    my_theme = pyvista.themes.DefaultTheme()
+    my_theme.depth_peeling.enabled = not my_theme.depth_peeling.enabled
+    assert my_theme.depth_peeling != default_theme.depth_peeling
+    assert my_theme.depth_peeling != 1
+
+
+@pytest.mark.parametrize('parm', [('color', (0.1, 0.1, 0.1)),
+                                  ('line_width', 1),
+                                  ('opacity', 2.0),
+                                  ('feature_angle', 20),
+                                  ('decimate', 0.5),
+])
+def test_silhouette_config(default_theme, parm):
+    attr, value = parm
+    assert hasattr(default_theme.silhouette, attr)
+    setattr(default_theme.silhouette, attr, value)
+    assert getattr(default_theme.silhouette, attr) == value
+
+
+def test_depth_silhouette_eq(default_theme):
+    my_theme = pyvista.themes.DefaultTheme()
+    my_theme.silhouette.opacity = 0.11111
+    assert my_theme.silhouette != default_theme.silhouette
+    assert my_theme.silhouette != 1
+
+
+@pytest.mark.parametrize('parm', [('slider_length', 0.03),
+                                  ('slider_width', 0.02),
+                                  ('slider_color', (0.5, 0.5, 0.3)),
+                                  ('tube_width', 0.02),
+                                  ('tube_color', (0.5, 0.5, 0.5)),
+                                  ('cap_opacity', 0.5),
+                                  ('cap_length', 0.02),
+                                  ('cap_width', 0.04)
+])
+@pytest.mark.parametrize('slider_type', ('modern', 'classic'))
+def test_slider_style_config(default_theme, parm, slider_type):
+    attr, value = parm
+
+    slider_style = getattr(default_theme.slider_style, 'modern')
+    assert hasattr(slider_style, attr)
+    setattr(slider_style, attr, value)
+    assert getattr(slider_style, attr) == value
+
+
+def test_slider_style_config_eq(default_theme):
+    assert default_theme.slider_style.modern != default_theme.slider_style.classic
+    assert default_theme.slider_style.modern != 1
+
+
+def test_slider_style_eq(default_theme):
+    my_theme = pyvista.themes.DefaultTheme()
+    my_theme.slider_style.modern.slider_length *= 2
+    assert default_theme.slider_style != my_theme.slider_style
+
+
 def test_invalid_color_str_single_char():
     with pytest.raises(ValueError):
         colors.string_to_rgb('x')
@@ -33,6 +101,93 @@ def test_font():
         pyvista.parse_font_family('not a font')
 
 
+def test_font_eq(default_theme):
+    defa_theme = pyvista.themes.DefaultTheme()
+    assert defa_theme.font == default_theme.font
+
+    paraview_theme = pyvista.themes.ParaViewTheme()
+    assert paraview_theme.font != default_theme.font
+    assert paraview_theme.font != 1
+
+
+def test_font_family(default_theme):
+    font = 'courier'
+    default_theme.font.family = font
+    assert default_theme.font.family == font
+
+    with pytest.raises(ValueError):
+        default_theme.font.family = 'bla'
+
+
+def test_font_title_size(default_theme):
+    default_theme.font.title_size = None
+    assert default_theme.font.title_size is None
+
+
+def test_font_label_size(default_theme):
+    default_theme.font.label_size = None
+    assert default_theme.font.label_size is None
+
+
+def test_font_fmt(default_theme):
+    fmt = '%.6e'
+    default_theme.font.fmt = fmt
+    assert default_theme.font.fmt == fmt
+
+
+def test_axes_eq(default_theme):
+    assert default_theme.axes == pyvista.themes.DefaultTheme().axes
+
+    theme = pyvista.themes.DefaultTheme()
+    theme.axes.box = True
+    assert default_theme.axes != theme.axes
+    assert default_theme.axes != 1
+
+
+def test_axes_box(default_theme):
+    new_value = not default_theme.axes.box
+    default_theme.axes.box = new_value
+    assert default_theme.axes.box == new_value
+
+
+def test_axes_show(default_theme):
+    new_value = not default_theme.axes.show
+    default_theme.axes.show = new_value
+    assert default_theme.axes.show == new_value
+
+
+def test_colorbar_eq(default_theme):
+    theme = pyvista.themes.DefaultTheme()
+    assert default_theme.colorbar_horizontal == theme.colorbar_horizontal
+
+    assert default_theme.colorbar_horizontal != 1
+    assert default_theme.colorbar_horizontal != theme.colorbar_vertical
+
+
+def test_colorbar_height(default_theme):
+    height = 0.3
+    default_theme.colorbar_horizontal.height = height
+    assert default_theme.colorbar_horizontal.height == height
+
+
+def test_colorbar_width(default_theme):
+    width = 0.3
+    default_theme.colorbar_horizontal.width = width
+    assert default_theme.colorbar_horizontal.width == width
+
+
+def test_colorbar_position_x(default_theme):
+    position_x = 0.3
+    default_theme.colorbar_horizontal.position_x = position_x
+    assert default_theme.colorbar_horizontal.position_x == position_x
+
+
+def test_colorbar_position_y(default_theme):
+    position_y = 0.3
+    default_theme.colorbar_horizontal.position_y = position_y
+    assert default_theme.colorbar_horizontal.position_y == position_y
+
+
 @pytest.mark.parametrize('theme', pyvista.themes.ALLOWED_THEMES)
 def test_themes(theme):
     try:
@@ -48,25 +203,24 @@ def test_invalid_theme():
         pyvista.set_plot_theme('this is not a valid theme')
 
 
-def test_background(default_theme):
-    color = [0.1, 0.2, 0.3]
-    default_theme.background = color
-    assert default_theme.background == color
+def test_invalid_theme_type_error():
+    with pytest.raises(TypeError):
+        pyvista.set_plot_theme(1)
 
 
-def test_auto_close(default_theme):
-    auto_close = not default_theme.auto_close
-    default_theme.auto_close = auto_close
-    assert default_theme.auto_close == auto_close
+def test_set_theme():
+    theme = pyvista.themes.DarkTheme()
+    try:
+        pyvista.set_plot_theme(theme)
+        assert pyvista.global_theme == theme
+    finally:
+        # always return to testing theme
+        pyvista.set_plot_theme('testing')
 
 
-def test_font(default_theme):
-    font = 'courier'
-    default_theme.auto_close = font
-    assert default_theme.auto_close == font
-
-    # with pytest.raises(ValueError):
-        # default_theme.auto_close = 'bla'
+def test_invalid_load_theme(default_theme):
+    with pytest.raises(TypeError):
+        default_theme.load_theme(123)
 
 
 def test_window_size(default_theme):
@@ -77,20 +231,8 @@ def test_window_size(default_theme):
         default_theme.window_size = [-1, -2]
 
     window_size = [1, 1]
-    default_theme.notebook = window_size
-    assert default_theme.notebook == window_size
-
-
-def test_notebook(default_theme):
-    notebook = not default_theme.notebook
-    default_theme.notebook = notebook
-    assert default_theme.notebook == notebook
-
-
-def test_full_screen(default_theme):
-    full_screen = not default_theme.full_screen
-    default_theme.full_screen = full_screen
-    assert default_theme.full_screen == full_screen
+    default_theme.window_size = window_size
+    assert default_theme.window_size == window_size
 
 
 def test_camera(default_theme):
@@ -108,13 +250,74 @@ def test_camera(default_theme):
     assert default_theme.camera == camera
 
 
-def test_repr():
-    theme = pyvista.themes.DefaultTheme()
-    rep = str(theme)
+def test_cmap(default_theme):
+    cmap = 'jet'
+    default_theme.cmap = cmap
+    assert default_theme.cmap == cmap
+
+    with pytest.raises(ValueError, match='not a valid value'):
+        default_theme.cmap = 'not a color map'
+
+
+def test_volume_mapper(default_theme):
+    assert hasattr(default_theme, 'volume_mapper')
+    volume_mapper = 'gpu'
+    default_theme.volume_mapper = volume_mapper
+    assert default_theme.volume_mapper == volume_mapper
+
+    with pytest.raises(ValueError, match='unknown'):
+        default_theme.volume_mapper = 'invalid'
+
+
+
+@pytest.mark.parametrize('parm', [('background', (0.1, 0.2, 0.3)),
+                                  ('auto_close', False),
+                                  ('notebook', False),
+                                  ('full_screen', True),
+                                  ('nan_color', (0.5, 0.5, 0.5)),
+                                  ('edge_color', (1.0, 0.0, 0.0)),
+                                  ('outline_color', (1.0, 0.0, 0.0)),
+                                  ('floor_color', (1.0, 0.0, 0.0)),
+                                  ('show_scalar_bar', False),
+                                  ('lighting', False),
+                                  ('interactive', 'False'),
+                                  ('render_points_as_spheres', True),
+                                  ('transparent_background', True),
+                                  ('title', 'test_title'),
+                                  ('multi_samples', 10),
+                                  ('multi_rendering_splitting_position', 0.1),
+                                  ('smooth_shading', True),
+                                  ('name', 'test_theme'),
+])
+def test_theme_parm(default_theme, parm):
+    attr, value = parm
+    assert hasattr(default_theme, attr)
+    setattr(default_theme, attr, value)
+    assert getattr(default_theme, attr) == value
+
+
+def test_theme_colorbar_orientation(default_theme):
+    orient = 'vertical'
+    default_theme.colorbar_orientation = orient
+    assert default_theme.colorbar_orientation == orient
+
+    with pytest.raises(ValueError):
+        default_theme.colorbar_orientation = 'invalid'
+
+
+def test_restore_defaults(default_theme):
+    orig_value = default_theme.show_edges
+    default_theme.show_edges = not orig_value
+    default_theme.restore_defaults()
+    assert default_theme.show_edges == orig_value
+
+
+def test_repr(default_theme):
+    rep = str(default_theme)
     assert 'Background' in rep
-    assert theme.cmap in rep
-    assert str(theme.colorbar_orientation) in rep
-    assert theme._name.capitalize() in rep
+    assert default_theme.cmap in rep
+    assert str(default_theme.colorbar_orientation) in rep
+    assert default_theme._name.capitalize() in rep
 
 
 def test_theme_eq():
@@ -145,3 +348,4 @@ def test_plotter_set_theme():
         # need "finally" here if the test fails and we mess up the
         # global defaults
         pyvista.global_theme.load_theme(pyvista.themes._TestingTheme())
+

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -5,6 +5,11 @@ import pyvista
 from pyvista import colors
 
 
+@pytest.fixture
+def default_theme():
+    return pyvista.themes.DefaultTheme()
+
+
 def test_invalid_color_str_single_char():
     with pytest.raises(ValueError):
         colors.string_to_rgb('x')
@@ -28,19 +33,115 @@ def test_font():
         pyvista.parse_font_family('not a font')
 
 
-
-# @pytest.mark.parametrize('theme', ['paraview', 'document', 'night', 'default'])
-# def test_themes(theme):
-#     pyvista.set_plot_theme(theme)
-#     if theme != 'default':
-#         assert pyvista.rcParams != pyvista.DEFAULT_THEME
-#         pyvista.set_plot_theme('default')
-#     assert pyvista.rcParams == pyvista.DEFAULT_THEME
-
-#     # always return to testing theme
-#     pyvista.set_plot_theme('testing')
+@pytest.mark.parametrize('theme', pyvista.themes.ALLOWED_THEMES)
+def test_themes(theme):
+    try:
+        pyvista.set_plot_theme(theme.name)
+        assert pyvista.global_theme == theme.value()
+    finally:
+        # always return to testing theme
+        pyvista.set_plot_theme('testing')
 
 
-# def test_invalid_theme():
-#     with pytest.raises(ValueError, match='Invalid theme'):
-#         pyvista.set_plot_theme('this is not a valid theme')
+def test_invalid_theme():
+    with pytest.raises(KeyError):
+        pyvista.set_plot_theme('this is not a valid theme')
+
+
+def test_background(default_theme):
+    color = [0.1, 0.2, 0.3]
+    default_theme.background = color
+    assert default_theme.background == color
+
+
+def test_auto_close(default_theme):
+    auto_close = not default_theme.auto_close
+    default_theme.auto_close = auto_close
+    assert default_theme.auto_close == auto_close
+
+
+def test_font(default_theme):
+    font = 'courier'
+    default_theme.auto_close = font
+    assert default_theme.auto_close == font
+
+    # with pytest.raises(ValueError):
+        # default_theme.auto_close = 'bla'
+
+
+def test_window_size(default_theme):
+    with pytest.raises(ValueError):
+        default_theme.window_size = [1, 2, 3]
+
+    with pytest.raises(ValueError, match='Window size must be a positive value'):
+        default_theme.window_size = [-1, -2]
+
+    window_size = [1, 1]
+    default_theme.notebook = window_size
+    assert default_theme.notebook == window_size
+
+
+def test_notebook(default_theme):
+    notebook = not default_theme.notebook
+    default_theme.notebook = notebook
+    assert default_theme.notebook == notebook
+
+
+def test_full_screen(default_theme):
+    full_screen = not default_theme.full_screen
+    default_theme.full_screen = full_screen
+    assert default_theme.full_screen == full_screen
+
+
+def test_camera(default_theme):
+    with pytest.raises(TypeError):
+        default_theme.camera = [1, 0, 0]
+    
+    with pytest.raises(KeyError, match='Expected the "viewup"'):
+        default_theme.camera = {'position': [1, 0, 0]}
+
+    with pytest.raises(KeyError, match='Expected the "position"'):
+        default_theme.camera = {'viewup': [1, 0, 0]}
+
+    camera = {'position': [1, 0, 0], 'viewup': [1, 0, 0]}
+    default_theme.camera = camera
+    assert default_theme.camera == camera
+
+
+def test_repr():
+    theme = pyvista.themes.DefaultTheme()
+    rep = str(theme)
+    assert 'Background' in rep
+    assert theme.cmap in rep
+    assert str(theme.colorbar_orientation) in rep
+    assert theme._name.capitalize() in rep
+
+
+def test_theme_eq():
+    defa_theme0 = pyvista.themes.DefaultTheme()
+    defa_theme1 = pyvista.themes.DefaultTheme()
+    assert defa_theme0 == defa_theme1
+    dark_theme = pyvista.themes.DarkTheme()
+    assert defa_theme0 != dark_theme
+
+    # for coverage
+    assert defa_theme0 != 'apple', 'wrong type test failed'
+
+
+def test_plotter_set_theme():
+    # test that the plotter theme is set to the new theme
+    my_theme = pyvista.themes.DefaultTheme()
+    my_theme.color = [1, 0, 0]
+    pl = pyvista.Plotter(theme=my_theme)
+    assert pl.theme.color == my_theme.color
+
+    # test that the plotter theme isn't overridden by the global theme
+    try:
+        other_color = [0, 0, 0]
+        pyvista.global_theme.color = other_color
+        assert pyvista.global_theme.color == other_color
+        assert pl.theme.color == my_theme.color
+    finally:
+        # need "finally" here if the test fails and we mess up the
+        # global defaults
+        pyvista.global_theme.load_theme(pyvista.themes._TestingTheme())

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -349,3 +349,9 @@ def test_plotter_set_theme():
         # global defaults
         pyvista.global_theme.load_theme(pyvista.themes._TestingTheme())
 
+
+def test_load_theme(default_theme, tmpdir):
+    filename = str(tmpdir.mkdir("tmpdir").join('tmp.json'))
+    default_theme.save(filename)
+    loaded_theme = pyvista.load_theme(filename)
+    assert loaded_theme == default_theme

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -188,7 +188,7 @@ def test_colorbar_position_y(default_theme):
     assert default_theme.colorbar_horizontal.position_y == position_y
 
 
-@pytest.mark.parametrize('theme', pyvista.themes.ALLOWED_THEMES)
+@pytest.mark.parametrize('theme', pyvista.themes._ALLOWED_THEMES)
 def test_themes(theme):
     try:
         pyvista.set_plot_theme(theme.name)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,4 +1,5 @@
 """ test pyvista.utilities """
+import warnings
 import pathlib
 import os
 import shutil
@@ -110,14 +111,18 @@ def test_read_force_ext_wrong_extension(tmpdir):
     # the returned dataset is empty
     fname = tmpdir / 'airplane.vtu'
     ex.load_airplane().cast_to_unstructured_grid().save(fname)
-    data = fileio.read(fname, force_ext='.vts')
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        data = fileio.read(fname, force_ext='.vts')
     assert data.n_points == 0
 
     # try to read a .ply file as .vtm
     # vtkXMLMultiBlockDataReader throws a VTK error about the validity of the XML file
     # the returned dataset is empty
     fname = ex.planefile
-    data = fileio.read(fname, force_ext='.vtm')
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        data = fileio.read(fname, force_ext='.vtm')
     assert len(data) == 0
 
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -109,7 +109,7 @@ def test_widget_text_slider():
         p.add_text_slider_widget(callback=func, data='foo')
     with pytest.raises(ValueError, match='list of values is empty'):
         p.add_text_slider_widget(callback=func, data=[])
-    for style in pyvista.global_theme.slider_style.keys():
+    for style in pyvista.global_theme.slider_style:
         p.add_text_slider_widget(callback=func, data=['foo', 'bar'], style=style)
     p.close()
 
@@ -128,20 +128,20 @@ def test_widget_slider():
                             event_type=event_type)
     with pytest.raises(TypeError, match='type for ``style``'):
         p.add_slider_widget(callback=func, rng=[0, 10], style=0)
-    with pytest.raises(KeyError, match='styles available'):
+    with pytest.raises(AttributeError):
         p.add_slider_widget(callback=func, rng=[0, 10], style="foo")
     with pytest.raises(TypeError, match='type for `event_type`'):
-        p.add_slider_widget(callback=func, rng=[0,10],
+        p.add_slider_widget(callback=func, rng=[0, 10],
                             event_type=0)
     with pytest.raises(ValueError, match='value for `event_type`'):
-        p.add_slider_widget(callback=func, rng=[0,10],
+        p.add_slider_widget(callback=func, rng=[0, 10],
                             event_type='foo')
     p.close()
 
     p = pyvista.Plotter()
-    func = lambda value, widget: value # Does nothing
+    func = lambda value, widget: value  # Does nothing
     p.add_mesh(mesh)
-    p.add_slider_widget(callback=func, rng=[0,10], style="modern",
+    p.add_slider_widget(callback=func, rng=[0, 10], style="modern",
                         pass_widget=True)
     p.close()
 
@@ -161,27 +161,28 @@ def test_widget_slider():
 
     p = pyvista.Plotter()
     title_height = np.random.random()
-    s = p.add_slider_widget(callback=func, rng=[0,10], style="classic", title_height=title_height)
+    s = p.add_slider_widget(callback=func, rng=[0, 10], style="classic", title_height=title_height)
     assert s.GetRepresentation().GetTitleHeight() == title_height
     p.close()
 
     p = pyvista.Plotter()
     title_opacity = np.random.random()
-    s = p.add_slider_widget(callback=func, rng=[0,10], style="classic", title_opacity=title_opacity)
+    s = p.add_slider_widget(callback=func, rng=[0, 10], style="classic", title_opacity=title_opacity)
     assert s.GetRepresentation().GetTitleProperty().GetOpacity() == title_opacity
     p.close()
 
     p = pyvista.Plotter()
     title_color = "red"
-    s = p.add_slider_widget(callback=func, rng=[0,10], style="classic", title_color=title_color)
+    s = p.add_slider_widget(callback=func, rng=[0, 10], style="classic", title_color=title_color)
     assert s.GetRepresentation().GetTitleProperty().GetColor() == pyvista.parse_color(title_color)
     p.close()
 
     p = pyvista.Plotter()
     fmt = "%0.9f"
-    s = p.add_slider_widget(callback=func, rng=[0,10], style="classic", fmt=fmt)
+    s = p.add_slider_widget(callback=func, rng=[0, 10], style="classic", fmt=fmt)
     assert s.GetRepresentation().GetLabelFormat() == fmt
     p.close()
+
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_widget_spline():

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -2,8 +2,8 @@ import numpy as np
 import pytest
 
 import pyvista
-from pyvista import examples
-from pyvista.plotting import system_supports_plotting, rcParams
+from pyvista import examples, defaults
+from pyvista.plotting import system_supports_plotting
 
 NO_PLOTTING = not system_supports_plotting()
 mesh = examples.load_uniform()
@@ -109,7 +109,7 @@ def test_widget_text_slider():
         p.add_text_slider_widget(callback=func, data='foo')
     with pytest.raises(ValueError, match='list of values is empty'):
         p.add_text_slider_widget(callback=func, data=[])
-    for style in rcParams["slider_style"].keys():
+    for style in defaults.slider_style.keys():
         p.add_text_slider_widget(callback=func, data=['foo', 'bar'], style=style)
     p.close()
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -109,7 +109,7 @@ def test_widget_text_slider():
         p.add_text_slider_widget(callback=func, data='foo')
     with pytest.raises(ValueError, match='list of values is empty'):
         p.add_text_slider_widget(callback=func, data=[])
-    for style in pyvista.global_theme.slider_style:
+    for style in pyvista.global_theme.slider_styles:
         p.add_text_slider_widget(callback=func, data=['foo', 'bar'], style=style)
     p.close()
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import pyvista
-from pyvista import examples, defaults
+from pyvista import examples
 from pyvista.plotting import system_supports_plotting
 
 NO_PLOTTING = not system_supports_plotting()
@@ -103,13 +103,13 @@ def test_widget_line():
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_widget_text_slider():
     p = pyvista.Plotter()
-    func = lambda value: value # Does nothing
+    func = lambda value: value  # Does nothing
     p.add_mesh(mesh)
     with pytest.raises(TypeError, match='must be a list'):
         p.add_text_slider_widget(callback=func, data='foo')
     with pytest.raises(ValueError, match='list of values is empty'):
         p.add_text_slider_widget(callback=func, data=[])
-    for style in defaults.slider_style.keys():
+    for style in pyvista.global_theme.slider_style.keys():
         p.add_text_slider_widget(callback=func, data=['foo', 'bar'], style=style)
     p.close()
 
@@ -117,19 +117,19 @@ def test_widget_text_slider():
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_widget_slider():
     p = pyvista.Plotter()
-    func = lambda value: value # Does nothing
+    func = lambda value: value  # Does nothing
     p.add_mesh(mesh)
-    p.add_slider_widget(callback=func, rng=[0,10], style="classic")
+    p.add_slider_widget(callback=func, rng=[0, 10], style="classic")
     p.close()
 
     p = pyvista.Plotter()
     for event_type in ['start', 'end', 'always']:
-        p.add_slider_widget(callback=func, rng=[0,10],
+        p.add_slider_widget(callback=func, rng=[0, 10],
                             event_type=event_type)
     with pytest.raises(TypeError, match='type for ``style``'):
-        p.add_slider_widget(callback=func, rng=[0,10], style=0)
+        p.add_slider_widget(callback=func, rng=[0, 10], style=0)
     with pytest.raises(KeyError, match='styles available'):
-        p.add_slider_widget(callback=func, rng=[0,10], style="foo")
+        p.add_slider_widget(callback=func, rng=[0, 10], style="foo")
     with pytest.raises(TypeError, match='type for `event_type`'):
         p.add_slider_widget(callback=func, rng=[0,10],
                             event_type=0)


### PR DESCRIPTION
``pyvista`` implements global themes using ``rcParams``, which is a reasonably good way for implementing a "style sheet" like approach for setting global plotting defaults.  It's very similar to ``matplotlib`` and is likely to be somewhat familiar.  However, there are a few limitations with this approach.

- Not self documenting
- User can set invalid parameters and not realize this until plotting.
- No code completion, has to actually load the dictionary and inspect it.

This PR proposes that instead, we implement a `Theme` class to control global defaults.  This was inspired by the discussion in https://github.com/pyansys/pymapdl/issues/425#issuecomment-839126581.  To summarize, a different user found it difficult to inspect and use the existing theme setter, and it's clear that a `Theme` class would be a better implementation.