### PR TITLE
Modifying arrays calls Modified() on associated datasets.

### DIFF
--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -54,4 +54,9 @@ class pyvista_ndarray(np.ndarray):
         if self.VTKObject is not None:
             self.VTKObject.Modified()
 
+        # the associated dataset should also be marked as modified
+        dataset = self.dataset.Get()
+        if dataset is not None:
+            dataset.Modified()
+
     __getattr__ = _vtk.VTKArray.__getattr__

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -39,11 +39,11 @@ class pyvista_ndarray(np.ndarray):
         # attributes of this class
         _vtk.VTKArray.__array_finalize__(self, obj)
         if np.shares_memory(self, obj):
-            self.dataset = getattr(obj, 'dataset', _vtk.vtkWeakReference())
+            self.dataset = getattr(obj, 'dataset', None)
             self.association = getattr(obj, 'association', FieldAssociation.NONE)
             self.VTKObject = getattr(obj, 'VTKObject', None)
         else:
-            self.dataset = _vtk.vtkWeakReference()
+            self.dataset = None
             self.association = FieldAssociation.NONE
             self.VTKObject = None
 
@@ -60,8 +60,7 @@ class pyvista_ndarray(np.ndarray):
 
         # the associated dataset should also be marked as modified
         dataset = self.dataset
-        if dataset is not None:
-            if dataset.Get():
-                dataset.Get().Modified()
+        if dataset is not None and dataset.Get():
+            dataset.Get().Modified()
 
     __getattr__ = _vtk.VTKArray.__getattr__

--- a/tests/test_pyvista_ndarray.py
+++ b/tests/test_pyvista_ndarray.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from pyvista import pyvista_ndarray
@@ -13,6 +14,27 @@ def test_slices_are_associated():
     assert points[1, :].dataset.Get() == points.dataset.Get()
     assert points[1, :].association == points.association
 
+
+def test_copies_are_not_associated():
+    dataset = examples.load_structured()
+    points = pyvista_ndarray(dataset.GetPoints().GetData(), dataset=dataset)
+    points_2 = points.copy()
+
+    # check that copies of pyvista_ndarray are dissociated from the original dataset
+    assert points_2.VTKObject is None
+    assert points_2.dataset.Get() is None
+    assert points_2.association.name == 'NONE'
+    assert not np.shares_memory(points, points_2)
+
+
+def test_isequal():
+    dataset = examples.load_structured()
+    dataset_2 = examples.load_structured()
+
+    dataset.points[:, -1] = np.inf
+    dataset_2.points[:, -1] = np.inf
+
+    assert np.allclose(dataset.points, dataset_2.points, equal_nan=True)
 
 # TODO: This currently doesn't work for single element indexing operations!
 # in these cases, the __array_finalize__ method is not called

--- a/tests/test_pyvista_ndarray.py
+++ b/tests/test_pyvista_ndarray.py
@@ -23,7 +23,7 @@ def test_copies_are_not_associated():
 
     # check that copies of pyvista_ndarray are dissociated from the original dataset
     assert points_2.VTKObject is None
-    assert points_2.dataset.Get() is None
+    assert points_2.dataset is None
     assert points_2.association.name == 'NONE'
     assert not np.shares_memory(points, points_2)
 


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Addresses #1262.

Modifies `pyvista_ndarray` so that it calls `Modifed()` on any associated dataset (if there is one).

In my local testing with pyvistaqt's BackgroundPlotter, I can update the view without any interaction in the render window. It's not instantaneous, but it updates in < 1 s.

```python
import numpy as np
from pyvista import examples

mesh = examples.load_hexbeam()

from pyvistaqt import BackgroundPlotter
p = BackgroundPlotter()
p.add_mesh(mesh, show_edges=True)

#%% 
#execute this cell manually
mesh['sample_point_scalars'] = np.zeros(mesh.n_points)

#%%
# execute this cell manually
mesh.points *= 2.0

```

Seems related to:
- https://github.com/pyvista/pyvista/pull/1264
- https://github.com/Kitware/ipyvtklink/issues/29
