### PR TITLE
add trivial module for backwards compatability

### DIFF
--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -1,0 +1,3 @@
+"""Here for backwards compatibility with pyvistaqt"""
+
+from pyvista import rcParams

--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -1,3 +1,3 @@
-"""Here for backwards compatibility with pyvistaqt"""
+"""Here for backwards compatibility with pyvistaqt."""
 
-from pyvista import rcParams
+from pyvista import rcParams  # pragma: no cover


### PR DESCRIPTION
This PR adds a trivial file to make our recent theme changes compatible with `pyvistaqt`.  I don't want our theme changes to be a breaking change as this needs to be out soon in support of another project https://github.com/pyansys/pymapdl.
