### PR TITLE
🚧 Fix error message for scalars of multiple dimensions

### DIFF
--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -722,7 +722,7 @@ def raise_not_matching(scalars, mesh):
     """Raise exception about inconsistencies."""
     if isinstance(mesh, _vtk.vtkTable):
         raise ValueError(f'Number of scalars ({scalars.size}) must match number of rows ({mesh.n_rows}).')
-    raise ValueError(f'Number of scalars ({scalars.size}) '
+    raise ValueError(f'First dimension of scalars ({scalars.shape[0]}) '
                      f'must match either the number of points ({mesh.n_points}) '
                      f'or the number of cells ({mesh.n_cells}).')
 


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->
This gives the error message to indicate that it is the first dimension size that must match.  All current usages of `raise_not_matching` seem to provide a `DataSet`.
 

### Details
Related to #1319 and https://github.com/pyvista/pyvista-support/issues/425

If we can get rid of, or split out, the `vtkTable` piece, we could also consider having this function also check whether the scalars should be applied to points or cells.  This would very minorly simplify the consuming functions.

This refactoring would also provide a central location to do reshaping like suggested in https://github.com/pyvista/pyvista/issues/1319#issuecomment-842699249. #