### PR TITLE
fix/backwards compat ipyvtk

### DIFF
--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -2063,10 +2063,15 @@ class DefaultTheme(_ThemeConfig):
     @property
     def use_ipyvtk(self):  # pragma: no cover
         """Depricated in favor of ``jupyter_backend``."""
+        warnings.warn('use_ipyvtk is deprecated.  Please use '
+                      '``pyvista.jupyter_backend``', DeprecationWarning)
         return self._use_ipyvtk
 
     @use_ipyvtk.setter
     def use_ipyvtk(self, value):  # pragma: no cover
+        warnings.warn('use_ipyvtk is deprecated.  Please use '
+                      '``pyvista.jupyter_backend``', DeprecationWarning)
+
         if value:
             self.jupyter_backend = 'ipyvtklink'
         else:

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -2071,7 +2071,7 @@ class DefaultTheme(_ThemeConfig):
     @use_ipyvtk.setter
     def use_ipyvtk(self, value):  # pragma: no cover
         warnings.warn('use_ipyvtk is deprecated.  Please use '
-                      '``pyvista.global_theme.jupyter_backend = "ipyvtklink"``', DeprecationWarning)
+                      '``pyvista.global_theme.jupyter_backend``', DeprecationWarning)
 
         if value:
             self.jupyter_backend = 'ipyvtklink'

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -2062,7 +2062,7 @@ class DefaultTheme(_ThemeConfig):
 
     @property
     def use_ipyvtk(self):  # pragma: no cover
-        """Set or return the usage if "ipyvtk".
+        """Set or return the usage of "ipyvtk" as a jupyter backend.
 
         Deprecated in favor of ``jupyter_backend``."""
         warnings.warn('use_ipyvtk is deprecated.  Please use '

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -2062,7 +2062,9 @@ class DefaultTheme(_ThemeConfig):
 
     @property
     def use_ipyvtk(self):  # pragma: no cover
-        """Depricated in favor of ``jupyter_backend``."""
+        """Set or return the usage if "ipyvtk".
+
+        Deprecated in favor of ``jupyter_backend``."""
         warnings.warn('use_ipyvtk is deprecated.  Please use '
                       '``pyvista.jupyter_backend``', DeprecationWarning)
         return self._use_ipyvtk

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -2064,7 +2064,8 @@ class DefaultTheme(_ThemeConfig):
     def use_ipyvtk(self):  # pragma: no cover
         """Set or return the usage of "ipyvtk" as a jupyter backend.
 
-        Deprecated in favor of ``jupyter_backend``."""
+        Deprecated in favor of ``jupyter_backend``.
+        """
         warnings.warn('use_ipyvtk is deprecated.  Please use '
                       '``pyvista.jupyter_backend``', DeprecationWarning)
         return self._use_ipyvtk

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1140,7 +1140,8 @@ class DefaultTheme(_ThemeConfig):
                  '_smooth_shading',
                  '_depth_peeling',
                  '_silhouette',
-                 '_slider_styles']
+                 '_slider_styles',
+                 '_use_ipyvtk']
 
     def __init__(self):
         """Initialize the theme."""
@@ -1194,6 +1195,7 @@ class DefaultTheme(_ThemeConfig):
         self._auto_close = os.environ.get('PYVISTA_AUTO_CLOSE', '').lower() != 'false'
 
         self._jupyter_backend = os.environ.get('PYVISTA_JUPYTER_BACKEND', 'ipyvtklink')
+        self._use_ipyvtk = self._jupyter_backend == 'ipyvtklink'
 
         self._multi_rendering_splitting_position = None
         self._volume_mapper = 'fixed_point' if os.name == 'nt' else 'smart'
@@ -2057,6 +2059,18 @@ class DefaultTheme(_ThemeConfig):
         """
         with open(filename, 'w') as f:
             json.dump(self.to_dict(), f)
+
+    @property
+    def use_ipyvtk(self):  # pragma: no cover
+        """Depricated in favor of ``jupyter_backend``."""
+        return self._use_ipyvtk
+
+    @use_ipyvtk.setter
+    def use_ipyvtk(self, value):  # pragma: no cover
+        if value:
+            self.jupyter_backend = 'ipyvtklink'
+        else:
+            self.jupyter_backend = 'static'
 
 
 class DarkTheme(DefaultTheme):

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -2067,13 +2067,13 @@ class DefaultTheme(_ThemeConfig):
         Deprecated in favor of ``jupyter_backend``.
         """
         warnings.warn('use_ipyvtk is deprecated.  Please use '
-                      '``pyvista.jupyter_backend``', DeprecationWarning)
+                      '``pyvista.global_theme.jupyter_backend =``', DeprecationWarning)
         return self._use_ipyvtk
 
     @use_ipyvtk.setter
     def use_ipyvtk(self, value):  # pragma: no cover
         warnings.warn('use_ipyvtk is deprecated.  Please use '
-                      '``pyvista.jupyter_backend``', DeprecationWarning)
+                      '``pyvista.global_theme.jupyter_backend =``', DeprecationWarning)
 
         if value:
             self.jupyter_backend = 'ipyvtklink'

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1194,7 +1194,6 @@ class DefaultTheme(_ThemeConfig):
         self._auto_close = os.environ.get('PYVISTA_AUTO_CLOSE', '').lower() != 'false'
 
         self._jupyter_backend = os.environ.get('PYVISTA_JUPYTER_BACKEND', 'ipyvtklink')
-        self._jupyter_backend == 'ipyvtklink'
 
         self._multi_rendering_splitting_position = None
         self._volume_mapper = 'fixed_point' if os.name == 'nt' else 'smart'
@@ -2067,7 +2066,7 @@ class DefaultTheme(_ThemeConfig):
         """
         warnings.warn('use_ipyvtk is deprecated.  Please use '
                       '``pyvista.global_theme.jupyter_backend =``', DeprecationWarning)
-        return self.jupyter_backend
+        return self.jupyter_backend == 'ipyvtklink'
 
     @use_ipyvtk.setter
     def use_ipyvtk(self, value):  # pragma: no cover

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1140,8 +1140,7 @@ class DefaultTheme(_ThemeConfig):
                  '_smooth_shading',
                  '_depth_peeling',
                  '_silhouette',
-                 '_slider_styles',
-                 '_use_ipyvtk']
+                 '_slider_styles']
 
     def __init__(self):
         """Initialize the theme."""
@@ -1195,7 +1194,7 @@ class DefaultTheme(_ThemeConfig):
         self._auto_close = os.environ.get('PYVISTA_AUTO_CLOSE', '').lower() != 'false'
 
         self._jupyter_backend = os.environ.get('PYVISTA_JUPYTER_BACKEND', 'ipyvtklink')
-        self._use_ipyvtk = self._jupyter_backend == 'ipyvtklink'
+        self._jupyter_backend == 'ipyvtklink'
 
         self._multi_rendering_splitting_position = None
         self._volume_mapper = 'fixed_point' if os.name == 'nt' else 'smart'
@@ -2068,7 +2067,7 @@ class DefaultTheme(_ThemeConfig):
         """
         warnings.warn('use_ipyvtk is deprecated.  Please use '
                       '``pyvista.global_theme.jupyter_backend =``', DeprecationWarning)
-        return self._use_ipyvtk
+        return self.jupyter_backend
 
     @use_ipyvtk.setter
     def use_ipyvtk(self, value):  # pragma: no cover

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -2065,13 +2065,13 @@ class DefaultTheme(_ThemeConfig):
         Deprecated in favor of ``jupyter_backend``.
         """
         warnings.warn('use_ipyvtk is deprecated.  Please use '
-                      '``pyvista.global_theme.jupyter_backend =``', DeprecationWarning)
+                      '``pyvista.global_theme.jupyter_backend``', DeprecationWarning)
         return self.jupyter_backend == 'ipyvtklink'
 
     @use_ipyvtk.setter
     def use_ipyvtk(self, value):  # pragma: no cover
         warnings.warn('use_ipyvtk is deprecated.  Please use '
-                      '``pyvista.global_theme.jupyter_backend =``', DeprecationWarning)
+                      '``pyvista.global_theme.jupyter_backend = "ipyvtklink"``', DeprecationWarning)
 
         if value:
             self.jupyter_backend = 'ipyvtklink'


### PR DESCRIPTION
In keeping with maintaining backwards compatibility with the old rcParams interface, this PR adds back in ``use_ipyvtk``, which was removed when refactoring to use ``global_theme``.

This issues a `DeprecationWarning`, which we can change to `PyvistaDeprecationWarning` after a few minor releases.
