### PR TITLE
Add schedule for GitHub Actions

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -1,6 +1,11 @@
 name: Unit Testing
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
 
 jobs:
   macOS:


### PR DESCRIPTION
This PR follows https://github.com/pyvista/pyvistaqt/pull/83#issuecomment-778653533 and adds a schedule to run the CIs every day at 4:00 UTC.

I'm not 100% sure about the syntax but the [documentation](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on) says:

> You must append a colon (:) to all events, including events without configuration.