### PR TITLE
Add ability to use cell data with glyph filter

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1149,8 +1149,9 @@ class DataSetFilters:
         The glyph may be oriented along the input vectors, and it may
         be scaled according to scalar data or vector
         magnitude. Passing a table of glyphs to choose from based on
-        scalars or vector magnitudes is also supported.  Orient and scale must 
-        be either both point data or both cell data.
+        scalars or vector magnitudes is also supported.  The arrays
+        used for ``orient` and ``scale`` must be either both point data
+        or both cell data.
 
         Parameters
         ----------
@@ -1163,7 +1164,7 @@ class DataSetFilters:
             If string, the scalar array to use to scale the glyphs.
 
         factor : float, optional
-            Scale factor applied to scaling array
+            Scale factor applied to scaling array.
 
         geom : vtk.vtkDataSet or tuple(vtk.vtkDataSet), optional
             The geometry to use for the glyph. If missing, an arrow glyph
@@ -1189,8 +1190,8 @@ class DataSetFilters:
         absolute : bool, optional
             Control if ``tolerance`` is an absolute distance or a fraction.
 
-        clamping: bool
-            Turn on/off clamping of "scalar" values to range.
+        clamping: bool, optional
+            Turn on/off clamping of "scalar" values to range. Default ``False``.
 
         rng: tuple(float), optional
             Set the range of values to be considered by the filter when scalars
@@ -1282,7 +1283,8 @@ class DataSetFilters:
             ):
                 source_data = dataset
             else:
-                raise ValueError("Both scale and orient must use point data or cell data")
+                raise ValueError("Both ``scale`` and ``orient`` must use "
+                                 "point data or cell data.")
         else:
             source_data = dataset
         if rng is not None:

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1152,7 +1152,7 @@ class DataSetFilters:
         be scaled according to scalar data or vector
         magnitude. Passing a table of glyphs to choose from based on
         scalars or vector magnitudes is also supported.  The arrays
-        used for ``orient` and ``scale`` must be either both point data
+        used for ``orient`` and ``scale`` must be either both point data
         or both cell data.
 
         Parameters

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1215,7 +1215,7 @@ class DataSetFilters:
         >>> import pyvista as pv
         >>> from pyvista import examples
         >>> mesh = examples.download_carotid().threshold(145, scalars="scalars")  # doctest:+SKIP
-        >>> glyph = mesh.glyph(orient="vectors", scale="scalars", factor=0.01)
+        >>> glyph = mesh.glyph(orient="vectors", scale="scalars", factor=0.01)  # doctest:+SKIP
 
         """
         # Clean the points before glyphing

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1207,11 +1207,12 @@ class DataSetFilters:
         Examples
         --------
         Create arrow glyphs oriented by vectors and scaled by scalars.
+        Factor parameter is used to reduce the size of the arrows.
 
         >>> import pyvista as pv
         >>> from pyvista import examples
         >>> mesh = examples.download_carotid().threshold(145, scalars="scalars")
-        >>> glyph = mesh.glyph(orient="vectors", scale="scalars")
+        >>> glyph = mesh.glyph(orient="vectors", scale="scalars", factor=0.01)
         """
         # Clean the points before glyphing
         if tolerance is not None:

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1072,6 +1072,7 @@ class DataSetFilters:
         >>> sphere = sphere.texture_map_to_sphere()
         >>> tex = examples.download_puppy_texture()  # doctest:+SKIP
         >>> cpos = sphere.plot(texture=tex)  # doctest:+SKIP
+
         """
         alg = _vtk.vtkTextureMapToSphere()
         if center is None:
@@ -1143,8 +1144,7 @@ class DataSetFilters:
     def glyph(dataset, orient=True, scale=True, factor=1.0, geom=None,
               indices=None, tolerance=None, absolute=False, clamping=False,
               rng=None, progress_bar=False):
-        """
-        Copy a geometric representation (called a glyph) to the input dataset.
+        """Copy a geometric representation (called a glyph) to the input dataset.
 
         The glyph may be oriented along the input vectors, and it may
         be scaled according to scalar data or vector
@@ -1160,7 +1160,7 @@ class DataSetFilters:
 
         scale : bool or str, optional
             If ``True``, use the active scalars to scale the glyphs.
-            If string, the  scalar array to use to scale the glyphs.
+            If string, the scalar array to use to scale the glyphs.
 
         factor : float, optional
             Scale factor applied to scaling array
@@ -1184,7 +1184,7 @@ class DataSetFilters:
             Specify tolerance in terms of fraction of bounding box length.
             Float value is between 0 and 1. Default is None. If ``absolute``
             is ``True`` then the tolerance can be an absolute distance.
-            If None, points merging as a preprocessing step is disabled.
+            If ``None``, points merging as a preprocessing step is disabled.
 
         absolute : bool, optional
             Control if ``tolerance`` is an absolute distance or a fraction.
@@ -1213,6 +1213,7 @@ class DataSetFilters:
         >>> from pyvista import examples
         >>> mesh = examples.download_carotid().threshold(145, scalars="scalars")
         >>> glyph = mesh.glyph(orient="vectors", scale="scalars", factor=0.01)
+
         """
         # Clean the points before glyphing
         if tolerance is not None:

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1214,7 +1214,7 @@ class DataSetFilters:
 
         >>> import pyvista as pv
         >>> from pyvista import examples
-        >>> mesh = examples.download_carotid().threshold(145, scalars="scalars")
+        >>> mesh = examples.download_carotid().threshold(145, scalars="scalars")  # doctest:+SKIP
         >>> glyph = mesh.glyph(orient="vectors", scale="scalars", factor=0.01)
 
         """

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -331,6 +331,7 @@ class DataSetFilters:
         >>> from pyvista import examples
         >>> dataset = examples.load_hexbeam()
         >>> clipped = dataset.clip_scalar(value=100, invert=False)
+
         """
         if isinstance(dataset, _vtk.vtkPolyData):
             alg = _vtk.vtkClipPolyData()
@@ -633,6 +634,7 @@ class DataSetFilters:
         >>> volume[:3] = 1
         >>> v = pyvista.wrap(volume)
         >>> threshed = v.threshold(0.1)
+
         """
         # set the scalaras to threshold on
         if scalars is None:
@@ -1600,6 +1602,7 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
         """
         alg = _vtk.vtkDelaunay3D()
         alg.SetInputData(dataset)
@@ -1930,6 +1933,7 @@ class DataSetFilters:
         source : pyvista.PolyData
             The points of the source are the seed points for the streamlines.
             Only returned if ``return_source=True``.
+
         """
         if source_center is None:
             source_center = dataset.center
@@ -2058,6 +2062,7 @@ class DataSetFilters:
             (i.e., polyline) representing a streamline. The attribute values
             associated with each streamline are stored in the cell data, whereas
             those associated with streamline-points are stored in the point data.
+
         """
         integration_direction = str(integration_direction).strip().lower()
         if integration_direction not in ['both', 'back', 'backward', 'forward']:
@@ -2160,6 +2165,7 @@ class DataSetFilters:
         -------
         sampled_line : pv.PolyData
             Line object with sampled data from dataset.
+
         """
         if resolution is None:
             resolution = int(dataset.n_cells)
@@ -2292,6 +2298,7 @@ class DataSetFilters:
         >>> pointb = [uniform.bounds[1], uniform.bounds[2], uniform.bounds[4]]
         >>> center = [uniform.bounds[0], uniform.bounds[2], uniform.bounds[4]]
         >>> sampled_arc = uniform.sample_over_circular_arc(pointa, pointb, center)
+
         """
         if resolution is None:
             resolution = int(dataset.n_cells)
@@ -2346,6 +2353,7 @@ class DataSetFilters:
         >>> polar = [uniform.bounds[0], uniform.bounds[2], uniform.bounds[5]]
         >>> center = [uniform.bounds[0], uniform.bounds[2], uniform.bounds[4]]
         >>> sampled_arc = uniform.sample_over_circular_arc_normal(center, normal=normal, polar=polar)
+
         """
         if resolution is None:
             resolution = int(dataset.n_cells)
@@ -2422,6 +2430,7 @@ class DataSetFilters:
         >>> b = [mesh.bounds[1], mesh.bounds[2], mesh.bounds[4]]
         >>> center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
         >>> mesh.plot_over_circular_arc(a, b, center, resolution=1000, show=False)
+
         """
         # Ensure matplotlib is available
         try:
@@ -3079,6 +3088,7 @@ class DataSetFilters:
         >>> import pyvista
         >>> mesh = pyvista.Sphere()
         >>> shrunk_mesh = mesh.shrink(shrink_factor=0.8)
+
         """
         if not (0.0 <= shrink_factor <= 1.0):
             raise ValueError('`shrink_factor` should be between 0.0 and 1.0')
@@ -3126,6 +3136,7 @@ class DataSetFilters:
         ...                              [0, 0, 0, 1]])
         >>> transformed = mesh.transform(transform_matrix)
         >>> cpos = transformed.plot(show_edges=True)
+
         """
         if isinstance(trans, _vtk.vtkMatrix4x4):
             m = trans
@@ -3626,6 +3637,7 @@ class PolyDataFilters(DataSetFilters):
         >>> from pyvista import examples
         >>> hills = examples.load_random_hills()
         >>> cpos = hills.plot_curvature(smooth_shading=True)
+
         """
         kwargs.setdefault('scalar_bar_args',
                           {'title': f'{curv_type.capitalize()} Curvature'})
@@ -3716,6 +3728,7 @@ class PolyDataFilters(DataSetFilters):
         Sharp Edges on Cube:        384
         >>> print(f'Sharp Edges on Smooth Cube: {n_smooth_cells}')
         Sharp Edges on Smooth Cube: 12
+
         """
         alg = _vtk.vtkSmoothPolyDataFilter()
         alg.SetInputData(poly_data)
@@ -4648,6 +4661,7 @@ class PolyDataFilters(DataSetFilters):
         ... string = ", ".join([f"({point[0]:.3f}, {point[1]:.3f}, {point[2]:.3f})" for point in points])
         ... print(f'Rays intersected at {string}')
         Rays intersected at (0.499, 0.000, 0.000), (0.000, 0.497, 0.000), (0.000, 0.000, 0.500)
+
         """
         if not poly_data.is_all_triangles():
             raise NotAllTrianglesError
@@ -5152,6 +5166,7 @@ class PolyDataFilters(DataSetFilters):
         >>> arc = pyvista.CircularArc([-1, 0, 0], [1, 0, 0], [0, 0, 0])
         >>> mesh = arc.extrude([0, 0, 1])
         >>> cpos = mesh.plot()
+
         """
         alg = _vtk.vtkLinearExtrusionFilter()
         alg.SetExtrusionTypeToVectorExtrusion()
@@ -5225,6 +5240,7 @@ class PolyDataFilters(DataSetFilters):
         >>> line = pyvista.Line(pointa=(0, 0, 0), pointb=(1, 0, 0))
         >>> mesh = line.extrude_rotate(resolution = 4)
         >>> cpos = mesh.plot()
+
         """
         if resolution <= 0:
             raise ValueError('`resolution` should be positive')
@@ -5299,6 +5315,7 @@ class PolyDataFilters(DataSetFilters):
         >>> stripped = slc.strip()
         >>> stripped.n_cells
         1
+
         """
         alg = _vtk.vtkStripper()
         alg.SetInputDataObject(poly_data)
@@ -5326,6 +5343,7 @@ class UnstructuredGridFilters(DataSetFilters):
         ----------
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
         """
         return pyvista.PolyData(ugrid.points).delaunay_2d(tol=tol, alpha=alpha,
                                                           offset=offset,
@@ -5386,6 +5404,7 @@ class StructuredGridFilters(DataSetFilters):
 
         >>> joined = voi_1.concatenate(voi_2, axis=1)
         >>> assert np.allclose(grid.points, joined.points)
+
         """
         alg = _vtk.vtkExtractGrid()
         alg.SetVOI(voi)
@@ -5432,6 +5451,7 @@ class StructuredGridFilters(DataSetFilters):
         >>> joined = voi_1.concatenate(voi_2, axis=1)
         >>> print(grid.dimensions, 'same as', joined.dimensions)
         [80, 80, 1] same as [80, 80, 1]
+
         """
         if axis > 2:
             raise RuntimeError('Concatenation axis must be <= 2.')
@@ -5529,6 +5549,7 @@ class UniformGridFilters(DataSetFilters):
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
         """
         alg = _vtk.vtkImageGaussianSmooth()
         alg.SetInputDataObject(dataset)
@@ -5578,6 +5599,7 @@ class UniformGridFilters(DataSetFilters):
             this is on, the subsampling will always include the boundary of
             the grid even though the sample rate is not an even multiple of
             the grid dimensions. (By default this is off.)
+
         """
         alg = _vtk.vtkExtractVOI()
         alg.SetVOI(voi)

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1203,6 +1203,15 @@ class DataSetFilters:
         -------
         glyphs : pyvista.PolyData
             Glyphs at either the cell centers or points.
+
+        Examples
+        --------
+        Create arrow glyphs oriented by vectors and scaled by scalars.
+
+        >>> import pyvista as pv
+        >>> from pyvista import examples
+        >>> mesh = examples.download_carotid().threshold(145, scalars="scalars")
+        >>> glyph = mesh.glyph(orient="vectors", scale="scalars")
         """
         # Clean the points before glyphing
         if tolerance is not None:

--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1144,8 +1144,7 @@ class DataSetFilters:
               indices=None, tolerance=None, absolute=False, clamping=False,
               rng=None, progress_bar=False):
         """
-        Copy a geometric representation (called a glyph) to every point or cell center
-        in the input dataset.
+        Copy a geometric representation (called a glyph) to the input dataset.
 
         The glyph may be oriented along the input vectors, and it may
         be scaled according to scalar data or vector

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,3 +76,13 @@ def spline():
 def tri_cylinder():
     """Triangulated cylinder"""
     return pyvista.Cylinder().triangulate()
+
+@fixture()
+def datasets():
+    return [
+        examples.load_uniform(),  # UniformGrid
+        examples.load_rectilinear(),  # RectilinearGrid
+        examples.load_hexbeam(),  # UnstructuredGrid
+        examples.load_airplane(),  # PolyData
+        examples.load_structured(),  # StructuredGrid
+    ]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1006,17 +1006,21 @@ def test_serialize_deserialize(datasets):
 
         for attr in ('cells', 'points'):
             if hasattr(dataset, attr):
-                assert getattr(dataset_2, attr) == \
-                    pytest.approx(getattr(dataset, attr))
+                arr_have = getattr(dataset_2, attr)
+                arr_expected = getattr(dataset, attr)
+                assert arr_have == pytest.approx(arr_expected)
 
         for name in dataset.point_arrays:
-            assert dataset_2.point_arrays[name] == \
-                pytest.approx(dataset.point_arrays[name])
+            arr_have = dataset_2.point_arrays[name]
+            arr_expected = dataset.point_arrays[name]
+            assert arr_have == pytest.approx(arr_expected)
 
         for name in dataset.cell_arrays:
-            assert dataset_2.cell_arrays[name] == \
-                pytest.approx(dataset.cell_arrays[name])
+            arr_have = dataset_2.cell_arrays[name]
+            arr_expected = dataset.cell_arrays[name]
+            assert arr_have == pytest.approx(arr_expected)
 
         for name in dataset.field_arrays:
-            assert dataset_2.field_arrays[name] == \
-                pytest.approx(dataset.field_arrays[name])
+            arr_have = dataset_2.field_arrays[name]
+            arr_expected = dataset.field_arrays[name]
+            assert arr_have == pytest.approx(arr_expected)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -7,8 +7,6 @@ from hypothesis.extra.numpy import arrays, array_shapes
 from hypothesis.strategies import composite, integers, floats, one_of
 from vtk.util.numpy_support import vtk_to_numpy
 
-from .test_filters import DATASETS
-
 import pyvista
 from pyvista import examples, Texture
 
@@ -992,32 +990,33 @@ def test_cell_type(grid):
     assert isinstance(ctype, int)
 
 
-@pytest.mark.parametrize('dataset', DATASETS)
-def test_serialize_deserialize(dataset):
-    dataset_2 = pickle.loads(pickle.dumps(dataset))
 
-    # check python attributes are the same
-    for attr in dataset.__dict__:
-        assert getattr(dataset_2, attr) == getattr(dataset, attr)
+def test_serialize_deserialize(datasets):
+    for dataset in datasets:
+        dataset_2 = pickle.loads(pickle.dumps(dataset))
 
-    # check data is the same
-    for attr in ('n_cells', 'n_points', 'n_arrays'):
-        if hasattr(dataset, attr):
+        # check python attributes are the same
+        for attr in dataset.__dict__:
             assert getattr(dataset_2, attr) == getattr(dataset, attr)
 
-    for attr in ('cells', 'points'):
-        if hasattr(dataset, attr):
-            assert getattr(dataset_2, attr) == \
-                   pytest.approx(getattr(dataset, attr))
+        # check data is the same
+        for attr in ('n_cells', 'n_points', 'n_arrays'):
+            if hasattr(dataset, attr):
+                assert getattr(dataset_2, attr) == getattr(dataset, attr)
 
-    for name in dataset.point_arrays:
-        assert dataset_2.point_arrays[name] == \
-               pytest.approx(dataset.point_arrays[name])
+        for attr in ('cells', 'points'):
+            if hasattr(dataset, attr):
+                assert getattr(dataset_2, attr) == \
+                    pytest.approx(getattr(dataset, attr))
 
-    for name in dataset.cell_arrays:
-        assert dataset_2.cell_arrays[name] == \
-               pytest.approx(dataset.cell_arrays[name])
+        for name in dataset.point_arrays:
+            assert dataset_2.point_arrays[name] == \
+                pytest.approx(dataset.point_arrays[name])
 
-    for name in dataset.field_arrays:
-        assert dataset_2.field_arrays[name] == \
-               pytest.approx(dataset.field_arrays[name])
+        for name in dataset.cell_arrays:
+            assert dataset_2.cell_arrays[name] == \
+                pytest.approx(dataset.cell_arrays[name])
+
+        for name in dataset.field_arrays:
+            assert dataset_2.field_arrays[name] == \
+                pytest.approx(dataset.field_arrays[name])

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -13,17 +13,7 @@ from pyvista import examples
 from pyvista.core.errors import VTKVersionError
 
 
-DATASETS = [
-    examples.load_uniform(),  # UniformGrid
-    examples.load_rectilinear(),  # RectilinearGrid
-    examples.load_hexbeam(),  # UnstructuredGrid
-    examples.load_airplane(),  # PolyData
-    examples.load_structured(),  # StructuredGrid
-    ]
-
 normals = ['x', 'y', '-z', (1, 1, 1), (3.3, 5.4, 0.8)]
-
-COMPOSITE = pyvista.MultiBlock(DATASETS, deep=True)
 
 skip_py2_nobind = pytest.mark.skipif(int(sys.version[0]) < 3,
                                      reason="Python 2 doesn't support binding methods")
@@ -42,6 +32,9 @@ def datasets():
     examples.load_structured(),  # StructuredGrid
     ]
 
+@pytest.fixture
+def composite(datasets):
+    return pyvista.MultiBlock(datasets)
 
 @pytest.fixture()
 def grid():
@@ -103,10 +96,10 @@ def test_clip_by_scalars_filter(datasets):
 
 
 @skip_py2_nobind
-def test_clip_filter_composite():
+def test_clip_filter_composite(composite):
     # Now test composite data structures
-    output = COMPOSITE.clip(normal=normals[0], invert=False)
-    assert output.n_blocks == COMPOSITE.n_blocks
+    output = composite.clip(normal=normals[0], invert=False)
+    assert output.n_blocks == composite.n_blocks
 
 
 def test_clip_box(datasets):
@@ -140,10 +133,10 @@ def test_clip_box(datasets):
 
 
 @skip_py2_nobind
-def test_clip_box_composite():
+def test_clip_box_composite(composite):
     # Now test composite data structures
-    output = COMPOSITE.clip_box(invert=False)
-    assert output.n_blocks == COMPOSITE.n_blocks
+    output = composite.clip_box(invert=False)
+    assert output.n_blocks == composite.n_blocks
 
 
 def test_clip_surface():
@@ -196,10 +189,10 @@ def test_slice_filter(datasets):
 
 
 @skip_py2_nobind
-def test_slice_filter_composite():
+def test_slice_filter_composite(composite):
     # Now test composite data structures
-    output = COMPOSITE.slice(normal=normals[0])
-    assert output.n_blocks == COMPOSITE.n_blocks
+    output = composite.slice(normal=normals[0])
+    assert output.n_blocks == composite.n_blocks
 
 
 def test_slice_orthogonal_filter(datasets):
@@ -215,10 +208,10 @@ def test_slice_orthogonal_filter(datasets):
 
 
 @skip_py2_nobind
-def test_slice_orthogonal_filter_composite():
+def test_slice_orthogonal_filter_composite(composite):
     # Now test composite data structures
-    output = COMPOSITE.slice_orthogonal()
-    assert output.n_blocks == COMPOSITE.n_blocks
+    output = composite.slice_orthogonal()
+    assert output.n_blocks == composite.n_blocks
 
 
 def test_slice_along_axis(datasets):
@@ -238,10 +231,10 @@ def test_slice_along_axis(datasets):
 
 
 @skip_py2_nobind
-def test_slice_along_axis_composite():
+def test_slice_along_axis_composite(composite):
     # Now test composite data structures
-    output = COMPOSITE.slice_along_axis()
-    assert output.n_blocks == COMPOSITE.n_blocks
+    output = composite.slice_along_axis()
+    assert output.n_blocks == composite.n_blocks
 
 
 def test_threshold(datasets):
@@ -303,16 +296,16 @@ def test_outline(datasets):
 
 
 @skip_py2_nobind
-def test_outline_composite():
+def test_outline_composite(composite):
     # Now test composite data structures
-    output = COMPOSITE.outline()
+    output = composite.outline()
     assert isinstance(output, pyvista.PolyData)
-    output = COMPOSITE.outline(nested=True)
+    output = composite.outline(nested=True)
 
     # vtk 9.0.0 returns polydata
     assert isinstance(output, (pyvista.MultiBlock, pyvista.PolyData))
     if isinstance(output, pyvista.MultiBlock):
-        assert output.n_blocks == COMPOSITE.n_blocks
+        assert output.n_blocks == composite.n_blocks
 
 
 def test_outline_corners(datasets):
@@ -323,21 +316,21 @@ def test_outline_corners(datasets):
 
 
 @skip_py2_nobind
-def test_outline_corners_composite():
+def test_outline_corners_composite(composite):
     # Now test composite data structures
-    output = COMPOSITE.outline_corners()
+    output = composite.outline_corners()
     assert isinstance(output, pyvista.PolyData)
-    output = COMPOSITE.outline_corners(nested=True)
-    assert output.n_blocks == COMPOSITE.n_blocks
+    output = composite.outline_corners(nested=True)
+    assert output.n_blocks == composite.n_blocks
 
 
-def test_extract_geometry(datasets):
+def test_extract_geometry(datasets, composite):
     for i, dataset in enumerate(datasets):
         outline = dataset.extract_geometry()
         assert outline is not None
         assert isinstance(outline, pyvista.PolyData)
     # Now test composite data structures
-    output = COMPOSITE.extract_geometry()
+    output = composite.extract_geometry()
     assert isinstance(output, pyvista.PolyData)
 
 
@@ -349,10 +342,10 @@ def test_wireframe(datasets):
 
 
 @skip_py2_nobind
-def test_wireframe_composite():
+def test_wireframe_composite(composite):
     # Now test composite data structures
-    output = COMPOSITE.extract_all_edges()
-    assert output.n_blocks == COMPOSITE.n_blocks
+    output = composite.extract_all_edges()
+    assert output.n_blocks == composite.n_blocks
 
 
 def test_delaunay_2d(datasets):
@@ -423,10 +416,10 @@ def test_elevation():
 
 
 @skip_py2_nobind
-def test_elevation_composite():
+def test_elevation_composite(composite):
     # Now test composite data structures
-    output = COMPOSITE.elevation()
-    assert output.n_blocks == COMPOSITE.n_blocks
+    output = composite.elevation()
+    assert output.n_blocks == composite.n_blocks
 
 
 def test_texture_map_to_plane():
@@ -475,10 +468,10 @@ def test_compute_cell_sizes(datasets):
 
 
 @skip_py2_nobind
-def test_compute_cell_sizes_composite():
+def test_compute_cell_sizes_composite(composite):
     # Now test composite data structures
-    output = COMPOSITE.compute_cell_sizes()
-    assert output.n_blocks == COMPOSITE.n_blocks
+    output = composite.compute_cell_sizes()
+    assert output.n_blocks == composite.n_blocks
 
 
 def test_cell_centers(datasets):
@@ -489,10 +482,10 @@ def test_cell_centers(datasets):
 
 
 @skip_py2_nobind
-def test_cell_centers_composite():
+def test_cell_centers_composite(composite):
     # Now test composite data structures
-    output = COMPOSITE.cell_centers()
-    assert output.n_blocks == COMPOSITE.n_blocks
+    output = composite.cell_centers()
+    assert output.n_blocks == composite.n_blocks
 
 
 def test_glyph(datasets):
@@ -645,10 +638,10 @@ def test_cell_data_to_point_data():
 
 
 @skip_py2_nobind
-def test_cell_data_to_point_data_composite():
+def test_cell_data_to_point_data_composite(composite):
     # Now test composite data structures
-    output = COMPOSITE.cell_data_to_point_data()
-    assert output.n_blocks == COMPOSITE.n_blocks
+    output = composite.cell_data_to_point_data()
+    assert output.n_blocks == composite.n_blocks
 
 
 def test_point_data_to_cell_data():
@@ -660,10 +653,10 @@ def test_point_data_to_cell_data():
 
 
 @skip_py2_nobind
-def test_point_data_to_cell_data_composite():
+def test_point_data_to_cell_data_composite(composite):
     # Now test composite data structures
-    output = COMPOSITE.point_data_to_cell_data()
-    assert output.n_blocks == COMPOSITE.n_blocks
+    output = composite.point_data_to_cell_data()
+    assert output.n_blocks == composite.n_blocks
 
 
 def test_triangulate():
@@ -674,10 +667,10 @@ def test_triangulate():
 
 
 @skip_py2_nobind
-def test_triangulate_composite():
+def test_triangulate_composite(composite):
     # Now test composite data structures
-    output = COMPOSITE.triangulate()
-    assert output.n_blocks == COMPOSITE.n_blocks
+    output = composite.triangulate()
+    assert output.n_blocks == composite.n_blocks
 
 
 def test_delaunay_3d():
@@ -1024,13 +1017,13 @@ def test_extract_points():
     assert sub_surf_nocells.cells[0] == 1
 
 @skip_py2_nobind
-def test_slice_along_line_composite():
+def test_slice_along_line_composite(composite):
     # Now test composite data structures
-    a = [COMPOSITE.bounds[0], COMPOSITE.bounds[2], COMPOSITE.bounds[4]]
-    b = [COMPOSITE.bounds[1], COMPOSITE.bounds[3], COMPOSITE.bounds[5]]
+    a = [composite.bounds[0], composite.bounds[2], composite.bounds[4]]
+    b = [composite.bounds[1], composite.bounds[3], composite.bounds[5]]
     line = pyvista.Line(a, b, resolution=10)
-    output = COMPOSITE.slice_along_line(line)
-    assert output.n_blocks == COMPOSITE.n_blocks
+    output = composite.slice_along_line(line)
+    assert output.n_blocks == composite.n_blocks
 
 
 def test_interpolate():

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -486,14 +486,9 @@ def test_glyph(datasets):
         assert result is not None
         assert isinstance(result, pyvista.PolyData)
     # Test different options for glyph filter
-    sphere = pyvista.Sphere(radius=3.14, theta_resolution=5, phi_resolution=5)
+    sphere = pyvista.Sphere()
     sphere_sans_arrays = sphere.copy()
-    # make cool swirly pattern
-    vectors = np.vstack((np.sin(sphere.points[:, 0]),
-                        np.cos(sphere.points[:, 1]),
-                        np.cos(sphere.points[:, 2]))).T
-    # add and scale
-    sphere.vectors = vectors*0.3
+    sphere.vectors = np.ones([sphere.n_points,3])
     sphere.point_arrays['arr'] = np.ones(sphere.n_points)
 
     assert sphere.glyph(scale=False)
@@ -525,29 +520,19 @@ def test_glyph(datasets):
 
 
 def test_glyph_cell_point_data():
-    sphere = pyvista.Sphere(radius=3.14, theta_resolution=5, phi_resolution=5)
-    # make cool swirly pattern
-    vectors = np.vstack((np.sin(sphere.points[:, 0]),
-                         np.cos(sphere.points[:, 1]),
-                         np.cos(sphere.points[:, 2]))).T
+    sphere = pyvista.Sphere()
 
-    sphere_center_points = sphere.cell_centers()
-    vectors_centers = np.vstack((np.sin(sphere_center_points.points[:, 0]),
-                                 np.cos(sphere_center_points.points[:, 1]),
-                                 np.cos(sphere_center_points.points[:, 2]))).T
-
-    sphere_center = sphere.copy()
-    sphere_center['vectors_cell'] = vectors_centers * 0.3
-    sphere_center['vectors_points'] = vectors * 0.3
-    sphere_center['arr_cell'] = np.ones(sphere.n_cells)
-    sphere_center['arr_points'] = np.ones(sphere.n_points)
+    sphere['vectors_cell'] = np.ones([sphere.n_cells,3])
+    sphere['vectors_points'] = np.ones([sphere.n_points,3])
+    sphere['arr_cell'] = np.ones(sphere.n_cells)
+    sphere['arr_points'] = np.ones(sphere.n_points)
     
-    assert sphere_center.glyph(orient='vectors_cell', scale='arr_cell')
-    assert sphere_center.glyph(orient='vectors_points', scale='arr_points')
+    assert sphere.glyph(orient='vectors_cell', scale='arr_cell')
+    assert sphere.glyph(orient='vectors_points', scale='arr_points')
     with pytest.raises(ValueError):
-        sphere_center.glyph(orient='vectors_cell', scale='arr_points')
+        sphere.glyph(orient='vectors_cell', scale='arr_points')
     with pytest.raises(ValueError):
-        sphere_center.glyph(orient='vectors_points', scale='arr_cell')
+        sphere.glyph(orient='vectors_points', scale='arr_cell')
 
 
 def test_split_and_connectivity():

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1327,71 +1327,73 @@ def test_shrink():
     assert shrunk.area < mesh.area
 
 
-@pytest.mark.parametrize('dataset,num_cell_arrays,num_point_arrays',
-                         itertools.product(DATASETS, [0, 1, 2], [0, 1, 2]))
-def test_transform_mesh(dataset, num_cell_arrays, num_point_arrays):
+@pytest.mark.parametrize('num_cell_arrays,num_point_arrays',
+                         itertools.product([0, 1, 2], [0, 1, 2]))
+def test_transform_mesh(datasets, num_cell_arrays, num_point_arrays):
     # rotate about x-axis by 90 degrees
-    tf = pyvista.transformations.axis_angle_rotation((1, 0, 0), 90)
+    for dataset in datasets:
+        tf = pyvista.transformations.axis_angle_rotation((1, 0, 0), 90)
 
-    for i in range(num_cell_arrays):
-        dataset.cell_arrays['C%d' % i] = np.random.rand(dataset.n_cells, 3)
+        for i in range(num_cell_arrays):
+            dataset.cell_arrays['C%d' % i] = np.random.rand(dataset.n_cells, 3)
 
-    for i in range(num_point_arrays):
-        dataset.point_arrays['P%d' % i] = np.random.rand(dataset.n_points, 3)
+        for i in range(num_point_arrays):
+            dataset.point_arrays['P%d' % i] = np.random.rand(dataset.n_points, 3)
 
-    # deactivate any active vectors!
-    # even if transform_all_input_vectors is False, vtkTransformfilter will
-    # transform active vectors
-    dataset.set_active_vectors(None)
+        # deactivate any active vectors!
+        # even if transform_all_input_vectors is False, vtkTransformfilter will
+        # transform active vectors
+        dataset.set_active_vectors(None)
 
-    transformed = dataset.transform(tf, transform_all_input_vectors=False, inplace=False)
+        transformed = dataset.transform(tf, transform_all_input_vectors=False, inplace=False)
 
-    assert dataset.points[:, 0] == pytest.approx(transformed.points[:, 0])
-    assert dataset.points[:, 2] == pytest.approx(-transformed.points[:, 1])
-    assert dataset.points[:, 1] == pytest.approx(transformed.points[:, 2])
+        assert dataset.points[:, 0] == pytest.approx(transformed.points[:, 0])
+        assert dataset.points[:, 2] == pytest.approx(-transformed.points[:, 1])
+        assert dataset.points[:, 1] == pytest.approx(transformed.points[:, 2])
 
-    # ensure that none of the vector data is changed
-    for name, array in dataset.point_arrays.items():
-        assert transformed.point_arrays[name] == pytest.approx(array)
+        # ensure that none of the vector data is changed
+        for name, array in dataset.point_arrays.items():
+            assert transformed.point_arrays[name] == pytest.approx(array)
 
-    for name, array in dataset.cell_arrays.items():
-        assert transformed.cell_arrays[name] == pytest.approx(array)
+        for name, array in dataset.cell_arrays.items():
+            assert transformed.cell_arrays[name] == pytest.approx(array)
 
 
-@pytest.mark.parametrize('dataset,num_cell_arrays,num_point_arrays',
-                         itertools.product(DATASETS, [0, 1, 2], [0, 1, 2]))
-def test_transform_mesh_and_vectors(dataset, num_cell_arrays, num_point_arrays):
-      # rotate about x-axis by 90 degrees
-    tf = pyvista.transformations.axis_angle_rotation((1, 0, 0), 90)
+@pytest.mark.parametrize('num_cell_arrays,num_point_arrays',
+                         itertools.product([0, 1, 2], [0, 1, 2]))
+def test_transform_mesh_and_vectors(datasets, num_cell_arrays, num_point_arrays):
+    for dataset in datasets:
+        # rotate about x-axis by 90 degrees
+        tf = pyvista.transformations.axis_angle_rotation((1, 0, 0), 90)
 
-    for i in range(num_cell_arrays):
-        dataset.cell_arrays['C%d' % i] = np.random.rand(dataset.n_cells, 3)
+        for i in range(num_cell_arrays):
+            dataset.cell_arrays['C%d' % i] = np.random.rand(dataset.n_cells, 3)
 
-    for i in range(num_point_arrays):
-        dataset.point_arrays['P%d' % i] = np.random.rand(dataset.n_points, 3)
+        for i in range(num_point_arrays):
+            dataset.point_arrays['P%d' % i] = np.random.rand(dataset.n_points, 3)
 
-    # handle
-    f = pyvista._vtk.vtkTransformFilter()
-    if not hasattr(f, 'SetTransformAllInputVectors'):
-        with pytest.raises(VTKVersionError):
-            transformed = dataset.transform(tf, transform_all_input_vectors=True, inplace=False)
-        return
+        # handle
+        f = pyvista._vtk.vtkTransformFilter()
+        if not hasattr(f, 'SetTransformAllInputVectors'):
+            with pytest.raises(VTKVersionError):
+                transformed = dataset.transform(tf, transform_all_input_vectors=True, inplace=False)
+            return
 
-    transformed = dataset.transform(tf, transform_all_input_vectors=True, inplace=False)
+        transformed = dataset.transform(tf, transform_all_input_vectors=True, inplace=False)
 
-    assert dataset.points[:, 0] == pytest.approx(transformed.points[:, 0])
-    assert dataset.points[:, 2] == pytest.approx(-transformed.points[:, 1])
-    assert dataset.points[:, 1] == pytest.approx(transformed.points[:, 2])
+        assert dataset.points[:, 0] == pytest.approx(transformed.points[:, 0])
+        assert dataset.points[:, 2] == pytest.approx(-transformed.points[:, 1])
+        assert dataset.points[:, 1] == pytest.approx(transformed.points[:, 2])
 
-    for i in range(num_cell_arrays):
-        assert dataset.cell_arrays['C%d' % i][:, 0] == pytest.approx( transformed.cell_arrays['C%d' % i][:, 0])
-        assert dataset.cell_arrays['C%d' % i][:, 2] == pytest.approx(-transformed.cell_arrays['C%d' % i][:, 1])
-        assert dataset.cell_arrays['C%d' % i][:, 1] == pytest.approx( transformed.cell_arrays['C%d' % i][:, 2])
+        for i in range(num_cell_arrays):
+            assert dataset.cell_arrays['C%d' % i][:, 0] == pytest.approx( transformed.cell_arrays['C%d' % i][:, 0])
+            assert dataset.cell_arrays['C%d' % i][:, 2] == pytest.approx(-transformed.cell_arrays['C%d' % i][:, 1])
+            assert dataset.cell_arrays['C%d' % i][:, 1] == pytest.approx( transformed.cell_arrays['C%d' % i][:, 2])
 
-    for i in range(num_point_arrays):
-        assert dataset.point_arrays['P%d' % i][:, 0] == pytest.approx( transformed.point_arrays['P%d' % i][:, 0])
-        assert dataset.point_arrays['P%d' % i][:, 2] == pytest.approx(-transformed.point_arrays['P%d' % i][:, 1])
-        assert dataset.point_arrays['P%d' % i][:, 1] == pytest.approx( transformed.point_arrays['P%d' % i][:, 2])
+        for i in range(num_point_arrays):
+            assert dataset.point_arrays['P%d' % i][:, 0] == pytest.approx( transformed.point_arrays['P%d' % i][:, 0])
+            assert dataset.point_arrays['P%d' % i][:, 2] == pytest.approx(-transformed.point_arrays['P%d' % i][:, 1])
+            assert dataset.point_arrays['P%d' % i][:, 1] == pytest.approx( transformed.point_arrays['P%d' % i][:, 2])
 
 
 @pytest.mark.parametrize('dataset', [
@@ -1405,48 +1407,48 @@ def test_transform_inplace_bad_types(dataset):
         dataset.transform(tf, inplace=True)
 
 
-@pytest.mark.parametrize('dataset', DATASETS)
-def test_reflect_mesh_about_point(dataset):
-    x_plane = 500
-    reflected = dataset.reflect((1, 0, 0), point=(x_plane, 0, 0))
-    assert reflected.n_cells == dataset.n_cells
-    assert reflected.n_points == dataset.n_points
-    assert np.allclose(x_plane - dataset.points[:, 0], reflected.points[:, 0] - x_plane)
-    assert np.allclose(dataset.points[:, 1:], reflected.points[:, 1:])
+def test_reflect_mesh_about_point(datasets):
+    for dataset in datasets:
+        x_plane = 500
+        reflected = dataset.reflect((1, 0, 0), point=(x_plane, 0, 0))
+        assert reflected.n_cells == dataset.n_cells
+        assert reflected.n_points == dataset.n_points
+        assert np.allclose(x_plane - dataset.points[:, 0], reflected.points[:, 0] - x_plane)
+        assert np.allclose(dataset.points[:, 1:], reflected.points[:, 1:])
 
 
 @pytest.mark.skipif(not VTK9, reason='Only supported on VTK v9 or newer')
-@pytest.mark.parametrize('dataset', DATASETS)
-def test_reflect_mesh_with_vectors(dataset):
-    if hasattr(dataset, 'compute_normals'):
-        dataset.compute_normals(inplace=True)
+def test_reflect_mesh_with_vectors(datasets):
+    for dataset in datasets:
+        if hasattr(dataset, 'compute_normals'):
+            dataset.compute_normals(inplace=True)
 
-    # add vector data to cell and point arrays
-    dataset.cell_arrays['C'] = np.arange(dataset.n_cells)[:, np.newaxis] * \
-                                np.array([1, 2, 3], dtype=float).reshape((1, 3))
-    dataset.point_arrays['P'] = np.arange(dataset.n_points)[:, np.newaxis] * \
-                                np.array([1, 2, 3], dtype=float).reshape((1, 3))
+        # add vector data to cell and point arrays
+        dataset.cell_arrays['C'] = np.arange(dataset.n_cells)[:, np.newaxis] * \
+            np.array([1, 2, 3], dtype=float).reshape((1, 3))
+        dataset.point_arrays['P'] = np.arange(dataset.n_points)[:, np.newaxis] * \
+            np.array([1, 2, 3], dtype=float).reshape((1, 3))
 
-    reflected = dataset.reflect((1, 0, 0), transform_all_input_vectors=True, inplace=False)
+        reflected = dataset.reflect((1, 0, 0), transform_all_input_vectors=True, inplace=False)
 
-    # assert isinstance(reflected, type(dataset))
-    assert reflected.n_cells == dataset.n_cells
-    assert reflected.n_points == dataset.n_points
-    assert np.allclose(dataset.points[:, 0], -reflected.points[:, 0])
-    assert np.allclose(dataset.points[:, 1:], reflected.points[:, 1:])
+        # assert isinstance(reflected, type(dataset))
+        assert reflected.n_cells == dataset.n_cells
+        assert reflected.n_points == dataset.n_points
+        assert np.allclose(dataset.points[:, 0], -reflected.points[:, 0])
+        assert np.allclose(dataset.points[:, 1:], reflected.points[:, 1:])
 
-    # assert normals are reflected
-    if hasattr(dataset, 'compute_normals'):
-        assert np.allclose(dataset.cell_arrays['Normals'][:, 0], -reflected.cell_arrays['Normals'][:, 0])
-        assert np.allclose(dataset.cell_arrays['Normals'][:, 1:], reflected.cell_arrays['Normals'][:, 1:])
-        assert np.allclose(dataset.point_arrays['Normals'][:, 0], -reflected.point_arrays['Normals'][:, 0])
-        assert np.allclose(dataset.point_arrays['Normals'][:, 1:], reflected.point_arrays['Normals'][:, 1:])
+        # assert normals are reflected
+        if hasattr(dataset, 'compute_normals'):
+            assert np.allclose(dataset.cell_arrays['Normals'][:, 0], -reflected.cell_arrays['Normals'][:, 0])
+            assert np.allclose(dataset.cell_arrays['Normals'][:, 1:], reflected.cell_arrays['Normals'][:, 1:])
+            assert np.allclose(dataset.point_arrays['Normals'][:, 0], -reflected.point_arrays['Normals'][:, 0])
+            assert np.allclose(dataset.point_arrays['Normals'][:, 1:], reflected.point_arrays['Normals'][:, 1:])
 
-    # assert other vector fields are reflected
-    assert np.allclose(dataset.cell_arrays['C'][:, 0], -reflected.cell_arrays['C'][:, 0])
-    assert np.allclose(dataset.cell_arrays['C'][:, 1:], reflected.cell_arrays['C'][:, 1:])
-    assert np.allclose(dataset.point_arrays['P'][:, 0], -reflected.point_arrays['P'][:, 0])
-    assert np.allclose(dataset.point_arrays['P'][:, 1:], reflected.point_arrays['P'][:, 1:])
+        # assert other vector fields are reflected
+        assert np.allclose(dataset.cell_arrays['C'][:, 0], -reflected.cell_arrays['C'][:, 0])
+        assert np.allclose(dataset.cell_arrays['C'][:, 1:], reflected.cell_arrays['C'][:, 1:])
+        assert np.allclose(dataset.point_arrays['P'][:, 0], -reflected.point_arrays['P'][:, 0])
+        assert np.allclose(dataset.point_arrays['P'][:, 1:], reflected.point_arrays['P'][:, 1:])
 
 
 @pytest.mark.parametrize('dataset', [

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -479,15 +479,15 @@ def test_cell_centers_composite(composite):
     assert output.n_blocks == composite.n_blocks
 
 
-def test_glyph(datasets):
+def test_glyph(datasets, sphere):
     for i, dataset in enumerate(datasets):
         dataset.vectors = np.ones_like(dataset.points)
         result = dataset.glyph()
         assert result is not None
         assert isinstance(result, pyvista.PolyData)
     # Test different options for glyph filter
-    sphere = pyvista.Sphere()
     sphere_sans_arrays = sphere.copy()
+    sphere.compute_normals(inplace=True)
     sphere.vectors = np.ones([sphere.n_points,3])
     sphere.point_arrays['arr'] = np.ones(sphere.n_points)
 
@@ -519,9 +519,7 @@ def test_glyph(datasets):
         sphere.glyph(geom=geoms, indices=indices[:-1])
 
 
-def test_glyph_cell_point_data():
-    sphere = pyvista.Sphere()
-
+def test_glyph_cell_point_data(sphere):
     sphere['vectors_cell'] = np.ones([sphere.n_cells,3])
     sphere['vectors_points'] = np.ones([sphere.n_points,3])
     sphere['arr_cell'] = np.ones(sphere.n_cells)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -525,24 +525,22 @@ def test_glyph(datasets):
 
 
 def test_glyph_cell_point_data():
-
     sphere = pyvista.Sphere(radius=3.14, theta_resolution=5, phi_resolution=5)
     # make cool swirly pattern
     vectors = np.vstack((np.sin(sphere.points[:, 0]),
-                        np.cos(sphere.points[:, 1]),
-                        np.cos(sphere.points[:, 2]))).T
+                         np.cos(sphere.points[:, 1]),
+                         np.cos(sphere.points[:, 2]))).T
 
     sphere_center_points = sphere.cell_centers()
     vectors_centers = np.vstack((np.sin(sphere_center_points.points[:, 0]),
-                        np.cos(sphere_center_points.points[:, 1]),
-                        np.cos(sphere_center_points.points[:, 2]))).T
+                                 np.cos(sphere_center_points.points[:, 1]),
+                                 np.cos(sphere_center_points.points[:, 2]))).T
 
     sphere_center = sphere.copy()
     sphere_center['vectors_cell'] = vectors_centers * 0.3
     sphere_center['vectors_points'] = vectors * 0.3
     sphere_center['arr_cell'] = np.ones(sphere.n_cells)
     sphere_center['arr_points'] = np.ones(sphere.n_points)
-
     
     assert sphere_center.glyph(orient='vectors_cell', scale='arr_cell')
     assert sphere_center.glyph(orient='vectors_points', scale='arr_points')
@@ -550,6 +548,7 @@ def test_glyph_cell_point_data():
         sphere_center.glyph(orient='vectors_cell', scale='arr_points')
     with pytest.raises(ValueError):
         sphere_center.glyph(orient='vectors_points', scale='arr_cell')
+
 
 def test_split_and_connectivity():
     # Load a simple example mesh
@@ -742,6 +741,7 @@ def test_streamlines_start_position(uniform_vec):
     stream = uniform_vec.streamlines('vectors', start_position=(0.5, 0.0, 0.0))
 
     assert all([stream.n_points, stream.n_cells])
+
 
 def test_streamlines_errors(uniform_vec):
     with pytest.raises(ValueError):
@@ -1006,6 +1006,7 @@ def test_extract_points():
     assert sub_surf_adj.n_points == 9
     assert sub_surf_adj.n_cells == 4
     assert sub_surf_nocells.cells[0] == 1
+
 
 @skip_py2_nobind
 def test_slice_along_line_composite(composite):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -538,18 +538,18 @@ def test_glyph_cell_point_data():
                         np.cos(sphere_center_points.points[:, 2]))).T
 
     sphere_center = sphere.copy()
-    sphere_center["vectors_cell"] = vectors_centers*0.3
-    sphere_center["vectors_points"] = vectors*0.3
+    sphere_center['vectors_cell'] = vectors_centers * 0.3
+    sphere_center['vectors_points'] = vectors * 0.3
     sphere_center['arr_cell'] = np.ones(sphere.n_cells)
     sphere_center['arr_points'] = np.ones(sphere.n_points)
 
     
-    assert sphere_center.glyph(orient="vectors_cell", scale = "arr_cell")
-    assert sphere_center.glyph(orient="vectors_points", scale = "arr_points")
+    assert sphere_center.glyph(orient='vectors_cell', scale='arr_cell')
+    assert sphere_center.glyph(orient='vectors_points', scale='arr_points')
     with pytest.raises(ValueError):
-        sphere_center.glyph(orient="vectors_cell",scale = "arr_points")
+        sphere_center.glyph(orient='vectors_cell', scale='arr_points')
     with pytest.raises(ValueError):
-        sphere_center.glyph(orient="vectors_points", scale="arr_cell")
+        sphere_center.glyph(orient='vectors_points', scale='arr_cell')
 
 def test_split_and_connectivity():
     # Load a simple example mesh

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -547,8 +547,8 @@ def test_glyph_cell_point_data():
     assert sphere_center.glyph(orient="vectors_cell", scale = "arr_cell")
     assert sphere_center.glyph(orient="vectors_points", scale = "arr_points")
     with pytest.raises(ValueError):
-        sphere_center.glyph(orient="vectors_cell",scale = 'arr_cell')
         sphere_center.glyph(orient="vectors_cell",scale = "arr_points")
+    with pytest.raises(ValueError):
         sphere_center.glyph(orient="vectors_points", scale="arr_cell")
 
 def test_split_and_connectivity():

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -19,7 +19,8 @@ DATASETS = [
     examples.load_hexbeam(),  # UnstructuredGrid
     examples.load_airplane(),  # PolyData
     examples.load_structured(),  # StructuredGrid
-]
+    ]
+
 normals = ['x', 'y', '-z', (1, 1, 1), (3.3, 5.4, 0.8)]
 
 COMPOSITE = pyvista.MultiBlock(DATASETS, deep=True)
@@ -29,6 +30,17 @@ skip_py2_nobind = pytest.mark.skipif(int(sys.version[0]) < 3,
 
 skip_windows = pytest.mark.skipif(os.name == 'nt', reason="Flaky Windows tests")
 skip_mac = pytest.mark.skipif(platform.system() == 'Darwin', reason="Flaky Mac tests")
+
+
+@pytest.fixture()
+def datasets():
+    return [
+    examples.load_uniform(),  # UniformGrid
+    examples.load_rectilinear(),  # RectilinearGrid
+    examples.load_hexbeam(),  # UnstructuredGrid
+    examples.load_airplane(),  # PolyData
+    examples.load_structured(),  # StructuredGrid
+    ]
 
 
 @pytest.fixture()
@@ -51,9 +63,9 @@ def test_datasetfilters_init():
 
 
 @skip_windows
-def test_clip_filter():
+def test_clip_filter(datasets):
     """This tests the clip filter on all datatypes available filters"""
-    for i, dataset in enumerate(DATASETS):
+    for i, dataset in enumerate(datasets):
         clp = dataset.clip(normal=normals[i], invert=True)
         assert clp is not None
         if isinstance(dataset, pyvista.PolyData):
@@ -62,7 +74,7 @@ def test_clip_filter():
             assert isinstance(clp, pyvista.UnstructuredGrid)
 
     # clip with get_clipped=True
-    for i, dataset in enumerate(DATASETS):
+    for i, dataset in enumerate(datasets):
         clp1, clp2 = dataset.clip(normal=normals[i], invert=True, return_clipped=True)
         for clp in (clp1, clp2):
             if isinstance(dataset, pyvista.PolyData):
@@ -72,9 +84,9 @@ def test_clip_filter():
 
 @skip_windows
 @skip_mac
-def test_clip_by_scalars_filter():
+def test_clip_by_scalars_filter(datasets):
     """This tests the clip filter on all datatypes available filters"""
-    for i, dataset_in in enumerate(DATASETS):
+    for i, dataset_in in enumerate(datasets):
         dataset = dataset_in.copy()  # don't modify in-place
         if dataset.active_scalars_info.name is None:
             dataset['scalars'] = np.arange(dataset.n_points)
@@ -97,8 +109,8 @@ def test_clip_filter_composite():
     assert output.n_blocks == COMPOSITE.n_blocks
 
 
-def test_clip_box():
-    for i, dataset in enumerate(DATASETS):
+def test_clip_box(datasets):
+    for i, dataset in enumerate(datasets):
         clp = dataset.clip_box(invert=True)
         assert clp is not None
         assert isinstance(clp, pyvista.UnstructuredGrid)
@@ -169,9 +181,9 @@ def test_implicit_distance():
     assert "implicit_distance" in dataset.point_arrays
 
 
-def test_slice_filter():
+def test_slice_filter(datasets):
     """This tests the slice filter on all datatypes available filters"""
-    for i, dataset in enumerate(DATASETS):
+    for i, dataset in enumerate(datasets):
         slc = dataset.slice(normal=normals[i])
         assert slc is not None
         assert isinstance(slc, pyvista.PolyData)
@@ -190,10 +202,10 @@ def test_slice_filter_composite():
     assert output.n_blocks == COMPOSITE.n_blocks
 
 
-def test_slice_orthogonal_filter():
+def test_slice_orthogonal_filter(datasets):
     """This tests the slice filter on all datatypes available filters"""
 
-    for i, dataset in enumerate(DATASETS):
+    for i, dataset in enumerate(datasets):
         slices = dataset.slice_orthogonal()
         assert slices is not None
         assert isinstance(slices, pyvista.MultiBlock)
@@ -209,11 +221,11 @@ def test_slice_orthogonal_filter_composite():
     assert output.n_blocks == COMPOSITE.n_blocks
 
 
-def test_slice_along_axis():
+def test_slice_along_axis(datasets):
     """Test the many slices along axis filter """
     axii = ['x', 'y', 'z', 'y', 0]
     ns = [2, 3, 4, 10, 20, 13]
-    for i, dataset in enumerate(DATASETS):
+    for i, dataset in enumerate(datasets):
         slices = dataset.slice_along_axis(n=ns[i], axis=axii[i])
         assert slices is not None
         assert isinstance(slices, pyvista.MultiBlock)
@@ -232,8 +244,8 @@ def test_slice_along_axis_composite():
     assert output.n_blocks == COMPOSITE.n_blocks
 
 
-def test_threshold():
-    for i, dataset in enumerate(DATASETS[0:3]):
+def test_threshold(datasets):
+    for i, dataset in enumerate(datasets[0:3]):
         thresh = dataset.threshold()
         assert thresh is not None
         assert isinstance(thresh, pyvista.UnstructuredGrid)
@@ -253,7 +265,7 @@ def test_threshold():
         dataset.threshold({100, 500})
     # Now test DATASETS without arrays
     with pytest.raises(ValueError):
-        for i, dataset in enumerate(DATASETS[3:-1]):
+        for i, dataset in enumerate(datasets[3:-1]):
             thresh = dataset.threshold()
             assert thresh is not None
             assert isinstance(thresh, pyvista.UnstructuredGrid)
@@ -261,14 +273,14 @@ def test_threshold():
     with pytest.raises(ValueError):
         dataset.threshold([10, 100, 300])
     with pytest.raises(ValueError):
-        DATASETS[0].threshold([10, 500], scalars='Spatial Point Data',
+        datasets[0].threshold([10, 500], scalars='Spatial Point Data',
                               all_scalars=True)
 
-def test_threshold_percent():
+def test_threshold_percent(datasets):
     percents = [25, 50, [18.0, 85.0], [19.0, 80.0], 0.70]
     inverts = [False, True, False, True, False]
     # Only test data sets that have arrays
-    for i, dataset in enumerate(DATASETS[0:3]):
+    for i, dataset in enumerate(datasets[0:3]):
         thresh = dataset.threshold_percent(percent=percents[i], invert=inverts[i])
         assert thresh is not None
         assert isinstance(thresh, pyvista.UnstructuredGrid)
@@ -283,8 +295,8 @@ def test_threshold_percent():
         dataset.threshold_percent({18.0, 85.0})
 
 
-def test_outline():
-    for i, dataset in enumerate(DATASETS):
+def test_outline(datasets):
+    for i, dataset in enumerate(datasets):
         outline = dataset.outline()
         assert outline is not None
         assert isinstance(outline, pyvista.PolyData)
@@ -303,8 +315,8 @@ def test_outline_composite():
         assert output.n_blocks == COMPOSITE.n_blocks
 
 
-def test_outline_corners():
-    for i, dataset in enumerate(DATASETS):
+def test_outline_corners(datasets):
+    for i, dataset in enumerate(datasets):
         outline = dataset.outline_corners()
         assert outline is not None
         assert isinstance(outline, pyvista.PolyData)
@@ -319,8 +331,8 @@ def test_outline_corners_composite():
     assert output.n_blocks == COMPOSITE.n_blocks
 
 
-def test_extract_geometry():
-    for i, dataset in enumerate(DATASETS):
+def test_extract_geometry(datasets):
+    for i, dataset in enumerate(datasets):
         outline = dataset.extract_geometry()
         assert outline is not None
         assert isinstance(outline, pyvista.PolyData)
@@ -329,8 +341,8 @@ def test_extract_geometry():
     assert isinstance(output, pyvista.PolyData)
 
 
-def test_wireframe():
-    for i, dataset in enumerate(DATASETS):
+def test_wireframe(datasets):
+    for i, dataset in enumerate(datasets):
         wire = dataset.extract_all_edges()
         assert wire is not None
         assert isinstance(wire, pyvista.PolyData)
@@ -343,8 +355,8 @@ def test_wireframe_composite():
     assert output.n_blocks == COMPOSITE.n_blocks
 
 
-def test_delaunay_2d():
-    mesh = DATASETS[2].delaunay_2d()  # UnstructuredGrid
+def test_delaunay_2d(datasets):
+    mesh = datasets[2].delaunay_2d()  # UnstructuredGrid
     assert isinstance(mesh, pyvista.PolyData)
     assert mesh.n_points
 
@@ -449,8 +461,8 @@ def test_texture_map_to_sphere():
     assert 'Texture Coordinates' in dataset.array_names
 
 
-def test_compute_cell_sizes():
-    for i, dataset in enumerate(DATASETS):
+def test_compute_cell_sizes(datasets):
+    for i, dataset in enumerate(datasets):
         result = dataset.compute_cell_sizes()
         assert result is not None
         assert isinstance(result, type(dataset))
@@ -469,8 +481,8 @@ def test_compute_cell_sizes_composite():
     assert output.n_blocks == COMPOSITE.n_blocks
 
 
-def test_cell_centers():
-    for i, dataset in enumerate(DATASETS):
+def test_cell_centers(datasets):
+    for i, dataset in enumerate(datasets):
         result = dataset.cell_centers()
         assert result is not None
         assert isinstance(result, pyvista.PolyData)
@@ -483,8 +495,8 @@ def test_cell_centers_composite():
     assert output.n_blocks == COMPOSITE.n_blocks
 
 
-def test_glyph():
-    for i, dataset in enumerate(DATASETS):
+def test_glyph(datasets):
+    for i, dataset in enumerate(datasets):
         dataset.vectors = np.ones_like(dataset.points)
         result = dataset.glyph()
         assert result is not None

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -22,19 +22,10 @@ skip_windows = pytest.mark.skipif(os.name == 'nt', reason="Flaky Windows tests")
 skip_mac = pytest.mark.skipif(platform.system() == 'Darwin', reason="Flaky Mac tests")
 
 
-@pytest.fixture()
-def datasets():
-    return [
-    examples.load_uniform(),  # UniformGrid
-    examples.load_rectilinear(),  # RectilinearGrid
-    examples.load_hexbeam(),  # UnstructuredGrid
-    examples.load_airplane(),  # PolyData
-    examples.load_structured(),  # StructuredGrid
-    ]
-
 @pytest.fixture
 def composite(datasets):
     return pyvista.MultiBlock(datasets)
+
 
 @pytest.fixture()
 def grid():


### PR DESCRIPTION
### Overview
This PR adds the capability to use cell centered data with glyphs. 

If cell centered data is provided, by the scale and/or the orient data, the glyphs are positioned on the cells.  If point valued data is provided, by the scale and/or the orient data, the glyphs are positioned on the points.



### Details

When implementing this, some of the datasets used in the test were found to either have cell-centered vector data or not have vector data.  The default is to orient the glyphs, so I added in the vector data to account for this.

Also in the tests, I used several `assert` statements instead of using `result =` since `result` was not used oftentimes.

Closes #1327. 


### Future Directions

I'd like to add the option to control the coloring of the glyphs next, but it hits a bit of a snag with the way the parameters are currently specified.  Currently, we pass in a string to `scale` to set the active scalars.  But we cannot allow this for both `color` and `scale`.  It would be better if it were only allowed to pass in a `bool` for `scale` and a `bool` for `color` and a `scalars` argument for the active scalar.  Then we would mirror this for `orient` and add `vectors`.

The other snag is that the most useful use case, IMO, is to scale by vector magnitude and color by a scalar value.  This will require a `scale_mode` and a `color_mode`.  I suppose `index_mode` would also have to be added in this case.

I put this here in case it flags anything in the way this is PR is implemented.

Edit: I'm realizing that coloring can be done after generating the glyphs, allthough there are some use cases that require extra steps.  For example, the vector data does not get carried over to the generated glyphs, so it can't be colored according to the vector data unless there is preprocessing done to save the vector data as scalar data.  I believe that the `ColorMode` in `vtkGlyph3D` could potentially address this.