### PR TITLE
Fix streamlines_from_source doc markup and whitespace

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1938,8 +1938,7 @@ class DataSetFilters:
                     max_steps=2000, terminal_speed=1e-12, max_error=1e-6,
                     max_time=None, compute_vorticity=True, rotation_scale=1.0,
                     interpolator_type='point'):
-        """
-        Generate streamlines of vectors from the points of a source mesh.
+        """Generate streamlines of vectors from the points of a source mesh.
         
         The integration is performed using a specified integrator, by default
         Runge-Kutta2. This supports integration through any type of dataset.
@@ -1947,8 +1946,8 @@ class DataSetFilters:
         ``surface_streamlines`` parameter is used, the integration is constrained
         to lie on the surface defined by 2D cells.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         source : pyvista.DataSet
             The points of the source provide the starting points of the
             streamlines.  This will override both sphere and line sources.
@@ -2024,6 +2023,7 @@ class DataSetFilters:
             (i.e., polyline) representing a streamline. The attribute values
             associated with each streamline are stored in the cell data, whereas
             those associated with streamline-points are stored in the point data.
+
         """
         integration_direction = str(integration_direction).strip().lower()
         if integration_direction not in ['both', 'back', 'backward', 'forward']:


### PR DESCRIPTION
There were a few style issues left over in the docstring of the new `streamlines_from_source` filter, one of which led to a warning in the doctest build:
```bash
docstring of pyvista.core.filters.DataSetFilters.streamlines_from_source:10: WARNING: Unexpected section title.
```

The reason was the colon after `Parameters` which also broke the built documentation's markup.

Before:
![Screenshot 2021-05-30 at 01-39-20 Filters — PyVista 0 30 dev0 documentation](https://user-images.githubusercontent.com/17914410/120087447-4b1bf080-c0e8-11eb-8966-369d9cd4c20e.png)

After:
![Screenshot 2021-05-30 at 01-41-44 Filters — PyVista 0 30 dev0 documentation](https://user-images.githubusercontent.com/17914410/120087448-5242fe80-c0e8-11eb-8b18-eca8e93f2f45.png)
