### PR TITLE
Add missing examples import to texture_map_to_sphere docs

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -1068,6 +1068,7 @@ class DataSetFilters:
         Map a puppy texture to a sphere
 
         >>> import pyvista
+        >>> from pyvista import examples
         >>> sphere = pyvista.Sphere()
         >>> sphere = sphere.texture_map_to_sphere()
         >>> tex = examples.download_puppy_texture()  # doctest:+SKIP


### PR DESCRIPTION
There was a missing import of `examples` in the doctest of the `texture_map_to_sphere` filter (which didn't raise an error because doctests in the same file share a global namespace).

It would be great if we could somehow catch these automatically, but I couldn't find a way to force sphinx's doctests to use a clean environment for each function being tested.