### PR TITLE
Add perlin noise example

### DIFF
--- a/examples/01-filter/sampling_functions_2d.py
+++ b/examples/01-filter/sampling_functions_2d.py
@@ -1,0 +1,78 @@
+"""
+Sample Function: Perlin Noise in 2D
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Here we use :func:`pyvista.core.imaging.sample_function` to sample
+perlin noise over a region to generate random terrain.
+
+Perlin noise is atype of gradient noise often used by visual effects
+artists to increase the appearance of realism in computer graphics.
+Source:
+https://en.wikipedia.org/wiki/Perlin_noise
+
+The development of Perlin Noise has allowed computer graphics artists
+to better represent the complexity of natural phenomena in visual
+effects for the motion picture industry.
+
+"""
+
+import pyvista as pv
+
+###############################################################################
+# Generate Perlin Noise over a StructuredGrid
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Feel free to change the values of ``freq`` to change the shape of
+# the "mountains".  For example, lowering the frequency will make the
+# terrain seem more like hills rather than mountains.
+freq = [0.689, 0.562, 0.683]
+noise = pv.perlin_noise(1, freq, (0, 0, 0))
+sampled = pv.sample_function(noise,
+                             bounds=(-10, 10, -10, 10, -10, 10),
+                             dim=(500, 500, 1))
+
+
+###############################################################################
+# Warp by scalar
+# ~~~~~~~~~~~~~~~~~
+# Here we warp by scalar to give the terrain some height based on the
+# value of the perlin noise.  This is necessary to the terrain its shape.
+
+mesh = sampled.warp_by_scalar('scalars')
+mesh = mesh.extract_surface()
+
+# clean and smooth a little to reduce perlin noise artifacts
+mesh = mesh.smooth(n_iter=100, inplace=False, relaxation_factor=1)
+
+# This makes the "water" level look flat.
+z = mesh.points[:, 2]
+diff = z.max() - z.min()
+
+# water level at 70%  (change this to change the water level)
+water_percent = 0.7
+water_level = z.max() - water_percent*diff
+mesh.points[z < water_level, 2] = water_level
+
+
+###############################################################################
+# Show the terrain as a contour plot
+
+# make the water blue
+rng = z.max() - z.min()
+clim = (z.max() - rng*1.65, z.max())
+
+pl = pv.Plotter()
+pl.add_mesh(mesh, scalars=z,
+            cmap='gist_earth', n_colors=10, show_scalar_bar=False,
+            smooth_shading=True, clim=clim)
+pl.show()
+
+
+###############################################################################
+# Show the terrain with custom lighting and shadows
+
+pl = pv.Plotter(lighting=None)
+pl.add_light(pv.Light((3, 1, 0.5), show_actor=True, positional=True,
+                      cone_angle=90, intensity=1.2))
+pl.add_mesh(mesh, cmap='gist_earth', show_scalar_bar=False,
+            smooth_shading=True, clim=clim)
+pl.enable_shadows = True
+pl.show()

--- a/examples/01-filter/sampling_functions_2d.py
+++ b/examples/01-filter/sampling_functions_2d.py
@@ -32,7 +32,7 @@ sampled = pv.sample_function(noise,
 
 ###############################################################################
 # Warp by scalar
-# ~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~
 # Here we warp by scalar to give the terrain some height based on the
 # value of the perlin noise.  This is necessary to the terrain its shape.
 

--- a/examples/01-filter/sampling_functions_3d.py
+++ b/examples/01-filter/sampling_functions_3d.py
@@ -1,0 +1,38 @@
+"""
+Sample Function: Perlin Noise in 3D
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Here we use :func:`pyvista.core.imaging.sample_function` to sample
+perlin noise over a region to generate random terrain.
+
+Video games like Minecraft use Perlin noise to create terrain.  Here,
+we create a voxelized mesh similar to a Minecraft "cave".
+
+"""
+
+import pyvista as pv
+
+###############################################################################
+# Generate Perlin Noise over a 3D StructuredGrid
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Feel free to change the values of ``freq`` to change the shape of
+# the "caves".  For example, lowering the frequency will make the
+# caves larger and more expansive, while a higher frequency in any
+# direction will make the caves appear more "vein-like" and less open.
+# 
+# Change the threshold to reduce or increase the percent of the
+# terrain that is open or closed
+
+freq = (1, 1, 1)
+noise = pv.perlin_noise(1, freq, (0, 0, 0))
+grid = pv.sample_function(noise, [0, 3.0, -0, 1.0, 0, 1.0], dim=(120, 40, 40))
+out = grid.threshold(0.02)
+out
+
+###############################################################################
+# color limits without blue
+mn, mx = [out['scalars'].min(), out['scalars'].max()]
+clim = (mn, mx*1.8)
+
+out.plot(cmap='gist_earth_r', background='white',
+         show_scalar_bar=False, lighting=True, clim=clim,
+         show_edges=False)

--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -20,6 +20,7 @@ except ImportError:  # pragma: no cover
 
 if VTK9:
 
+    from vtkmodules.vtkImagingHybrid import vtkSampleFunction
     from vtkmodules.vtkInteractionWidgets import (vtkScalarBarWidget,
                                                   vtkSplineWidget,
                                                   vtkSphereWidget,
@@ -106,7 +107,8 @@ if VTK9:
                                         vtkDataSetWriter,
                                         vtkPolyDataReader,
                                         vtkDataSetReader)
-    from vtkmodules.vtkCommonDataModel import (vtkDataObject,
+    from vtkmodules.vtkCommonDataModel import (vtkImplicitFunction,
+                                               vtkDataObject,
                                                vtkExplicitStructuredGrid,
                                                vtkPyramid,
                                                vtkPlane,
@@ -132,6 +134,7 @@ if VTK9:
                                                vtkStaticPointLocator,
                                                vtkSelectionNode,
                                                vtkSelection,
+                                               vtkPerlinNoise,
                                                VTK_HEXAHEDRON,
                                                VTK_PYRAMID,
                                                VTK_QUAD,

--- a/pyvista/core/__init__.py
+++ b/pyvista/core/__init__.py
@@ -9,3 +9,5 @@ from .grid import Grid, RectilinearGrid, UniformGrid
 from .objects import Table, Texture
 from .pointset import PointGrid, PolyData, StructuredGrid, UnstructuredGrid, ExplicitStructuredGrid
 from .pyvista_ndarray import pyvista_ndarray
+from .common_data import *
+from .imaging import *

--- a/pyvista/core/common_data.py
+++ b/pyvista/core/common_data.py
@@ -1,0 +1,61 @@
+"""
+Contains PyVista mappings from vtkmodules.vtkCommonDataModel.
+"""
+from typing import Sequence
+
+from pyvista import _vtk
+
+
+def perlin_noise(amplitude, freq: Sequence[float], phase: Sequence[float]):
+    """An implicit function that implements Perlin noise.
+
+    Uses ``vtk.vtkPerlinNoise`` and computes a Perlin noise field as
+    an implicit function. ``vtk.vtkPerlinNoise`` is a concrete
+    implementation of ``vtk.vtkImplicitFunction``. Perlin noise,
+    originally described by Ken Perlin, is a non-periodic and
+    continuous noise function useful for modeling real-world objects.
+
+    The amplitude and frequency of the noise pattern are
+    adjustable. This implementation of Perlin noise is derived closely
+    from Greg Ward's version in Graphics Gems II.
+
+    Parameters
+    ----------
+    amplitude : float
+        Amplitude of the noise function.
+
+        ``amplitude`` can be negative. The noise function varies
+        randomly between ``-|Amplitude|`` and
+        ``|Amplitude|``. Therefore the range of values is
+        ``2*|Amplitude|`` large. The initial amplitude is 1.
+
+    freq : Sequence[float, float, float]
+        The frequency, or physical scale, of the noise function
+        (higher is finer scale).
+
+        The frequency can be adjusted per axis, or the same for all axes.
+
+    phase : Sequence[float, float, float]
+        Set/get the phase of the noise function.
+
+        This parameter can be used to shift the noise function within
+        space (perhaps to avoid a beat with a noise pattern at another
+        scale). Phase tends to repeat about every unit, so a phase of
+        0.5 is a half-cycle shift.
+
+    Examples
+    --------
+    Create a perlin noise function with an amplitude of 0.1, frequency
+    for all axes of 1, and a phase of 0 for all axes.
+
+    >>> import pyvista
+    >>> noise = perlin_noise(0.1, (1, 1, 1), (0, 0, 0))
+
+    Apply the perlin noise function to 
+
+    """
+    noise = _vtk.vtkPerlinNoise()
+    noise.SetAmplitude(amplitude)
+    noise.SetFrequency(freq)
+    noise.SetPhase(phase)
+    return noise

--- a/pyvista/core/common_data.py
+++ b/pyvista/core/common_data.py
@@ -1,13 +1,11 @@
-"""
-Contains PyVista mappings from vtkmodules.vtkCommonDataModel.
-"""
+"""Contains PyVista mappings from vtkmodules.vtkCommonDataModel."""
 from typing import Sequence
 
 from pyvista import _vtk
 
 
 def perlin_noise(amplitude, freq: Sequence[float], phase: Sequence[float]):
-    """An implicit function that implements Perlin noise.
+    """Return the implicit function that implements Perlin noise.
 
     Uses ``vtk.vtkPerlinNoise`` and computes a Perlin noise field as
     an implicit function. ``vtk.vtkPerlinNoise`` is a concrete

--- a/pyvista/core/imaging.py
+++ b/pyvista/core/imaging.py
@@ -1,6 +1,6 @@
 """Contains PyVista mappings from vtkmodules.vtkImagingHybrid."""
 from typing import Sequence
-import sys
+import sys, os
 
 import numpy as np
 
@@ -51,7 +51,19 @@ def sample_function(function: _vtk.vtkImplicitFunction,
         Enable or disable the computation of normals.  Default ``False``.
 
     output_type : np.dtype, optional
-        Set the output scalar type.  Defaults to ``np.double``.
+        Set the output scalar type.  Defaults to ``np.double``.  One
+        of the following:
+
+        - ``np.float64``
+        - ``np.float32``
+        - ``np.int64``
+        - ``np.uint64``
+        - ``np.int32``
+        - ``np.uint32``
+        - ``np.int16``
+        - ``np.uint16``
+        - ``np.int8``
+        - ``np.uint8``
 
     capping : bool, optional
         Enable or disable capping.  Default ``False``.  If capping is
@@ -107,8 +119,12 @@ def sample_function(function: _vtk.vtkImplicitFunction,
     elif output_type == np.float32:
         samp.SetOutputScalarTypeToFloat()
     elif output_type == np.int64:
+        if os.name == 'nt':
+            raise ValueError('This function on Windows only supports int32 or smaller')
         samp.SetOutputScalarTypeToLong()
     elif output_type == np.uint64:
+        if os.name == 'nt':
+            raise ValueError('This function on Windows only supports int32 or smaller')
         samp.SetOutputScalarTypeToUnsignedLong()
     elif output_type == np.int32:
         samp.SetOutputScalarTypeToInt()

--- a/pyvista/core/imaging.py
+++ b/pyvista/core/imaging.py
@@ -1,0 +1,128 @@
+"""
+Contains PyVista mappings from vtkmodules.vtkImagingHybrid.
+
+"""
+
+from typing import Sequence
+import sys
+
+import numpy as np
+
+from pyvista import _vtk, wrap
+from .filters import _get_output, _update_alg
+
+
+def sample_function(function: _vtk.vtkImplicitFunction,
+                    bounds: Sequence[float] = (-1.0, 1.0, -1.0, 1.0, -1.0, 1.0),
+                    dim: Sequence[int] = (50, 50, 50),
+                    compute_normals: bool = False,
+                    output_type: np.dtype = np.double,
+                    capping: bool = False,
+                    cap_value: float = sys.float_info.max,
+                    scalar_arr_name: str = "scalars",
+                    normal_arr_name: str = "normals",
+                    progress_bar: bool = False):
+    """Sample an implicit function over a structured point set.
+
+    Uses ``vtk.vtkSampleFunction``
+
+    This method evaluates an implicit function and normals at each
+    point in a ``vtk.vtkStructuredPoints``. The user can specify the
+    sample dimensions and location in space to perform the sampling.
+
+    To create closed surfaces (in conjunction with the
+    vtkContourFilter), capping can be turned on to set a particular
+    value on the boundaries of the sample space.
+
+    Parameters
+    ----------
+    function : vtk.vtkImplicitFunction
+        Implicit function to evaluate.  For example, the function
+        generated from ``perlin_noise``.
+
+    bounds : length 6 sequence
+        Specify the bounds in the format of:
+
+        - ``(xmin, xmax, ymin, ymax, zmin, zmax)``
+
+        Defaults to ``(-1.0, 1.0, -1.0, 1.0, -1.0, 1.0)``.
+
+    dim : length 3 sequence
+        Dimensions of the data on which to sample in the format of
+        ``(xdim, ydim, zdim)``.  Defaults to ``(50, 50, 50)``.
+
+    compute_normals : bool, optional
+        Enable or disable the computation of normals.  Default ``False``.
+
+    output_type : np.dtype, optional
+        Set the output scalar type.  Defaults to ``np.double``.
+
+    capping : bool, optional
+        Enable or disable capping.  Default ``False``.  If capping is
+        enabled, then the outer boundaries of the structured point set
+        are set to cap value. This can be used to ensure surfaces are
+        closed.
+
+    cap_value : float, optional
+        Capping value used with the ``capping`` parameter.
+
+    scalar_arr_name : str, optional
+        Set the scalar array name for this data set.  Defaults to
+        ``"scalars"``
+
+    normal_arr_name : str, optional
+        Set the normal array name for this data set.  Defaults to
+        ``"normals"``
+
+    progress_bar : bool, optional
+        Display a progress bar to indicate progress.  Default
+        ``False``.
+
+    Examples
+    --------
+    Sample the perlin noise over a structured grid.
+
+    >>> import pyvista
+    >>> noise = pyvista.perlin_noise(0.1, (1, 1, 1), (0, 0, 0))
+    >>> grid = pv.sample_function(noise, [0, 3.0, -0, 1.0, 0, 1.0], dim=(60, 20, 20))
+    >>> out.plot(cmap='gist_earth_r', show_scalar_bar=False, show_edges=True)
+
+    >>> 
+
+    """
+    
+    samp = _vtk.vtkSampleFunction()
+    samp.SetImplicitFunction(function)
+    samp.SetSampleDimensions(dim)
+    samp.SetModelBounds(bounds)
+    samp.SetComputeNormals(compute_normals)
+    samp.SetCapping(capping)
+    samp.SetCapValue(cap_value)
+    samp.SetNormalArrayName(normal_arr_name)
+    samp.SetScalarArrayName(scalar_arr_name)
+
+    if output_type == np.float64:
+        samp.SetOutputScalarTypeToDouble()
+    elif output_type == np.float32:
+        samp.SetOutputScalarTypeToFloat()
+    elif output_type == np.int64:
+        samp.SetOutputScalarTypeToLong()
+    elif output_type == np.uint64:
+        samp.SetOutputScalarTypeToUnsignedLong()
+    elif output_type == np.int32:
+        samp.SetOutputScalarTypeToInt()
+    elif output_type == np.uint32:
+        samp.SetOutputScalarTypeToUnsignedInt()
+    elif output_type == np.int16:
+        samp.SetOutputScalarTypeToShort()
+    elif output_type == np.uint16:
+        samp.SetOutputScalarTypeToUnsignedShort()
+    elif output_type == np.int8:
+        samp.SetOutputScalarTypeToChar()
+    elif output_type == np.uint8:
+        samp.SetOutputScalarTypeToUnsignedChar()
+    else:
+        raise ValueError(f'Invalid output_type {output_type}')
+
+    _update_alg(samp, progress_bar=progress_bar, message='Sampling')
+    return wrap(samp.GetOutput())

--- a/pyvista/core/imaging.py
+++ b/pyvista/core/imaging.py
@@ -1,8 +1,4 @@
-"""
-Contains PyVista mappings from vtkmodules.vtkImagingHybrid.
-
-"""
-
+"""Contains PyVista mappings from vtkmodules.vtkImagingHybrid."""
 from typing import Sequence
 import sys
 
@@ -80,17 +76,22 @@ def sample_function(function: _vtk.vtkImplicitFunction,
 
     Examples
     --------
-    Sample the perlin noise over a structured grid.
+    Sample perlin noise over a structured grid in 3D.
 
     >>> import pyvista
     >>> noise = pyvista.perlin_noise(0.1, (1, 1, 1), (0, 0, 0))
-    >>> grid = pv.sample_function(noise, [0, 3.0, -0, 1.0, 0, 1.0], dim=(60, 20, 20))
-    >>> out.plot(cmap='gist_earth_r', show_scalar_bar=False, show_edges=True)
+    >>> grid = pyvista.sample_function(noise, [0, 3.0, -0, 1.0, 0, 1.0],
+    ...                                dim=(60, 20, 20))
+    >>> out.plot(cmap='gist_earth_r', show_scalar_bar=False,
+    ...          show_edges=True)  # doctest:+SKIP
 
-    >>> 
+    Sample perlin noise in 2D and plot it.
+
+    >>> noise = pyvista.perlin_noise(0.1, (5, 5, 5), (0, 0, 0))
+    >>> surf = pyvista.sample_function(noise, dim=(200, 200, 1))
+    >>> surf.plot()    # doctest:+SKIP
 
     """
-    
     samp = _vtk.vtkSampleFunction()
     samp.SetImplicitFunction(function)
     samp.SetSampleDimensions(dim)

--- a/requirements_style.txt
+++ b/requirements_style.txt
@@ -1,2 +1,2 @@
-codespell==1.17.1
+codespell==2.0.0
 pydocstyle==5.1.1

--- a/tests/test_imaging.py
+++ b/tests/test_imaging.py
@@ -1,0 +1,46 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+
+import pyvista as pv
+
+
+def test_perlin_noise():
+    amp = 10
+    freq = (3, 2, 1)
+    phase = (0, 0, 0)
+    perlin = pv.perlin_noise(amp, freq, phase)
+
+    assert_allclose(perlin.GetAmplitude(), amp)
+    assert_allclose(perlin.GetFrequency(), freq)
+    assert_allclose(perlin.GetPhase(), phase)
+
+
+
+@pytest.mark.parametrize('dtype', [
+    np.float64,
+    np.float32,
+    np.int64,
+    np.uint64,
+    np.int32,
+    np.uint32,
+    np.int16,
+    np.uint16,
+    np.int8,
+    np.uint8,
+])
+def test_sample_function(dtype):
+    perlin = pv.perlin_noise(0.1, (1, 1, 1), (0, 0, 0))
+    bounds = (0, 2, 0, 1, -4, 4)
+    dim = (5, 10, 20)
+    scalar_arr_name = 'my_scalars'
+    mesh = pv.sample_function(perlin,
+                              bounds,
+                              dim,
+                              compute_normals=False,
+                              output_type=dtype,
+                              scalar_arr_name=scalar_arr_name)
+    
+    assert_allclose(mesh.dimensions, dim)
+    assert_allclose(mesh.bounds, bounds)
+    assert mesh[scalar_arr_name].dtype == dtype

--- a/tests/test_imaging.py
+++ b/tests/test_imaging.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
@@ -34,13 +36,18 @@ def test_sample_function(dtype):
     bounds = (0, 2, 0, 1, -4, 4)
     dim = (5, 10, 20)
     scalar_arr_name = 'my_scalars'
-    mesh = pv.sample_function(perlin,
-                              bounds,
-                              dim,
-                              compute_normals=False,
-                              output_type=dtype,
-                              scalar_arr_name=scalar_arr_name)
+
+    if os.name == 'nt' and dtype in [np.int64, np.uint64]:
+        with pytest.raises(ValueError):
+            pv.sample_function(perlin, output_type=dtype)
+    else:
+        mesh = pv.sample_function(perlin,
+                                  bounds,
+                                  dim,
+                                  compute_normals=False,
+                                  output_type=dtype,
+                                  scalar_arr_name=scalar_arr_name)
     
-    assert_allclose(mesh.dimensions, dim)
-    assert_allclose(mesh.bounds, bounds)
-    assert mesh[scalar_arr_name].dtype == dtype
+        assert_allclose(mesh.dimensions, dim)
+        assert_allclose(mesh.bounds, bounds)
+        assert mesh[scalar_arr_name].dtype == dtype


### PR DESCRIPTION
### Overview

This PR introduces ``sample_function`` and ``perlin_noise`` to generate natural looking landscapes or voxelized meshes like:
![image](https://user-images.githubusercontent.com/11981631/120375054-8af4fa80-c2d7-11eb-9110-17463e0a8fca.png)

![image](https://user-images.githubusercontent.com/11981631/120375064-921c0880-c2d7-11eb-82e5-e87845265c63.png)

### Example Usage
```py
freq = (1, 1, 1)
noise = pv.perlin_noise(1, freq, (0, 0, 0))
grid = pv.sample_function(noise, [0, 3.0, -0, 1.0, 0, 1.0], dim=(120, 40, 40))
```
