### PR TITLE
Add to streamlines Example for using `IntegrationTime`

### DIFF
--- a/examples/01-filter/streamlines.py
+++ b/examples/01-filter/streamlines.py
@@ -63,8 +63,9 @@ streamlines, src = mesh.streamlines(
 ###############################################################################
 boundary = mesh.decimate_boundary().extract_all_edges()
 
+sargs=dict(vertical=True, title_font_size=16)
 p = pv.Plotter()
-p.add_mesh(streamlines.tube(radius=0.2), lighting=False)
+p.add_mesh(streamlines.tube(radius=0.2), lighting=False, scalar_bar_args=sargs)
 p.add_mesh(src)
 p.add_mesh(boundary, color="grey", opacity=0.25)
 p.camera_position = [(10, 9.5, -43), (87.0, 73.5, 123.0), (-0.5, -0.7, 0.5)]
@@ -89,9 +90,11 @@ print([array_name for array_name in streamlines.array_names if array_name not in
 ###############################################################################
 # Plot streamlines colored by the time along the streamlines.
 
+sargs=dict(vertical=True, title_font_size=16)
 p = pv.Plotter()
 p.add_mesh(streamlines.tube(radius=0.2),
-           scalars="IntegrationTime", clim=[0, 1000], lighting=False)
+           scalars="IntegrationTime", clim=[0, 1000], lighting=False,
+           scalar_bar_args=sargs)
 p.add_mesh(boundary, color="grey", opacity=0.25)
 p.add_mesh(source_mesh, color="red")
 p.camera_position = [(10, 9.5, -43), (87.0, 73.5, 123.0), (-0.5, -0.7, 0.5)]

--- a/examples/01-filter/streamlines.py
+++ b/examples/01-filter/streamlines.py
@@ -72,21 +72,26 @@ p.show()
 
 
 ###############################################################################
-# A source mesh can also be provided using the `streamlines_from_source` 
+# A source mesh can also be provided using the 
+# :func:`pyvista.DataSetFilters.streamlines_from_source` 
 # filter, for example if an inlet surface is available.  In this example, the
 # inlet surface is extracted just inside the domain for use as the seed for
 # the streamlines.
-
 
 source_mesh = mesh.slice('z', origin=(0, 0, 182))  # inlet surface
 # thin out ~40% points to get a nice density of streamlines
 seed_mesh = source_mesh.decimate_boundary(0.4)
 streamlines = mesh.streamlines_from_source(seed_mesh, integration_direction="forward")
-
+# print *only* added arrays from streamlines filter
+print("Added arrays from streamlines filter:")
+print([array_name for array_name in streamlines.array_names if array_name not in mesh.array_names])
 
 ###############################################################################
+# Plot streamlines colored by the time along the streamlines.
+
 p = pv.Plotter()
-p.add_mesh(streamlines.tube(radius=0.2), lighting=False)
+p.add_mesh(streamlines.tube(radius=0.2),
+           scalars="IntegrationTime", clim=[0, 1000], lighting=False)
 p.add_mesh(boundary, color="grey", opacity=0.25)
 p.add_mesh(source_mesh, color="red")
 p.camera_position = [(10, 9.5, -43), (87.0, 73.5, 123.0), (-0.5, -0.7, 0.5)]


### PR DESCRIPTION
### Overview

This PR addresses https://github.com/pyvista/pyvista-support/issues/357, where it is unclear what information is provided by streamlines.


We could also consider adding these values into the docstring of `streamlines` and `streamlines_from_source`, but it depends on `vtk` so it would be a maintenance burden in case the list gets added to in the future.


### Details

The changed figure looks like:

![image](https://user-images.githubusercontent.com/39341281/120503629-770dcf00-c391-11eb-9ee4-0907af683053.png)


The added output is:

```txt
Added arrays from streamlines filter:
['IntegrationTime', 'Vorticity', 'Rotation', 'AngularVelocity', 'Normals', 'ReasonForTermination', 'SeedIds']
```

The `streamlines_from_source` is now linked correctly.

