### PR TITLE
Add missing parameters and clean up `add_scalar_bar` docstring

### DIFF
--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -104,13 +104,13 @@ class ScalarBars():
 
         Parameters
         ----------
-        mapper : vtkMapper, optional
-            Mapper used for the scalar bar.  Defaults to the last
-            mapper created by the plotter.
-
         title : string, optional
             Title of the scalar bar.  Default ``''`` which is
             rendered as an empty title.
+
+        mapper : vtkMapper, optional
+            Mapper used for the scalar bar.  Defaults to the last
+            mapper created by the plotter.
 
         n_labels : int, optional
             Number of labels to use for the scalar bar.
@@ -123,58 +123,72 @@ class ScalarBars():
 
         title_font_size : float, optional
             Sets the size of the title font.  Defaults to None and is sized
-            automatically.
+            according to ``pyvista.global_theme``.
 
         label_font_size : float, optional
             Sets the size of the title font.  Defaults to None and is sized
-            automatically.
+            according to ``pyvista.global_theme``.
 
-        color : string or 3 item list, optional, defaults to white
-            Either a string, rgb list, or hex color string.  For example:
+        color : string or 3 item list, optional
+            Either a string, rgb list, or hex color string.  Defaults to white.
+            For example:
 
             * ``color='white'``
             * ``color='w'``
             * ``color=[1, 1, 1]``
             * ``color='#FFFFFF'``
 
-        font_family : string, optional
-            Font family.  Must be either courier, times, or arial.
+        font_family : {'courier', 'times', 'arial'}
+            Font family.  Default is set by ``pyvista.global_theme``.
 
         shadow : bool, optional
-            Adds a black shadow to the text.  Defaults to False
+            Adds a black shadow to the text.  Defaults to False.
 
         width : float, optional
-            The percentage (0 to 1) width of the window for the colorbar
+            The percentage (0 to 1) width of the window for the colorbar.
+            Default set by ``pyvista.global_theme``.
 
         height : float, optional
-            The percentage (0 to 1) height of the window for the colorbar
+            The percentage (0 to 1) height of the window for the colorbar.
+            Default set by ``pyvista.global_theme``.
 
         position_x : float, optional
             The percentage (0 to 1) along the windows's horizontal
-            direction to place the bottom left corner of the colorbar
+            direction to place the bottom left corner of the colorbar.
+            Default is automatic placement.
 
         position_y : float, optional
             The percentage (0 to 1) along the windows's vertical
-            direction to place the bottom left corner of the colorbar
+            direction to place the bottom left corner of the colorbar.
+            Default is automatic placement.
+
+        vertical : bool, optional
+            Use vertical or horizontal scalar bar.
+            Default set by ``pyvista.global_theme``.
 
         interactive : bool, optional
             Use a widget to control the size and location of the scalar bar.
+            Default set by ``pyvista.global_theme``.
+
+        fmt : str, optional
+            ``printf`` format for labels.
+            Default set by ``pyvista.global_theme``.
 
         use_opacity : bool, optional
-            Optionally display the opacity mapping on the scalar bar
+            Optionally display the opacity mapping on the scalar bar.
 
         outline : bool, optional
             Optionally outline the scalar bar to make opacity mappings more
             obvious.
 
         nan_annotation : bool, optional
-            Annotate the NaN color
+            Annotate the NaN color.
 
         below_label : str, optional
-            String annotation for values below the scalars range
+            String annotation for values below the scalars range.
 
         above_label : str, optional
-            String annotation for values above the scalars range
+            String annotation for values above the scalars range.
 
         background_color : array, optional
             The color used for the background in RGB format.
@@ -182,9 +196,9 @@ class ScalarBars():
         n_colors : int, optional
             The maximum number of color displayed in the scalar bar.
 
-        fill : bool
+        fill : bool, optional
             Draw a filled box behind the scalar bar with the
-            ``background_color``
+            ``background_color``.
 
         render : bool, optional
             Force a render when True.  Default ``True``.

--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -122,7 +122,7 @@ class ScalarBars():
             Bolds title and bar labels.  Default True
 
         title_font_size : float, optional
-            Sets the size of the title font.  Defaults to None and is sized
+            Sets the size of the title font.  Defaults to ``None`` and is sized
             according to ``pyvista.global_theme``.
 
         label_font_size : float, optional

--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -142,7 +142,7 @@ class ScalarBars():
             Font family.  Default is set by ``pyvista.global_theme``.
 
         shadow : bool, optional
-            Adds a black shadow to the text.  Defaults to False.
+            Adds a black shadow to the text.  Defaults to ``False``.
 
         width : float, optional
             The percentage (0 to 1) width of the window for the colorbar.

--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -126,7 +126,7 @@ class ScalarBars():
             according to ``pyvista.global_theme``.
 
         label_font_size : float, optional
-            Sets the size of the title font.  Defaults to None and is sized
+            Sets the size of the title font.  Defaults to ``None`` and is sized
             according to ``pyvista.global_theme``.
 
         color : string or 3 item list, optional


### PR DESCRIPTION
### Overview

`fmt` and `vertical` were missing.  

A few defaults are still missing, because in those cases I wasn't sure what would be the accurate description.  For example, I'm not sure what not setting `n_colors` does; it depends on `vtk` behavior.

I opted to specifically call out when the default inherits from `pyvista.global_theme`, except for `position_x` and `position_y`, which are more complex.

I used the `numpydoc` style preference for when only a set of values is accepted for `font_family`.

See https://numpydoc.readthedocs.io/en/latest/format.html#parameters.

### Details



