### PR TITLE
Fix screenshot things

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3075,15 +3075,15 @@ class BasePlotter(PickingHelper, WidgetHelper):
         return self.add_mesh(arrows, **kwargs)
 
     @staticmethod
-    def _save_image(image, filename, return_img=None):
-        """Save a NumPy image array.
+    def _save_image(image, filename, return_img):
+        """Save to file and/or return a NumPy image array.
 
         This is an internal helper.
 
         """
         if not image.size:
             raise ValueError('Empty image. Have you run plot() first?')
-        # write screenshot to file
+        # write screenshot to file if requested
         if isinstance(filename, (str, pathlib.Path)):
             from PIL import Image
             filename = pathlib.Path(filename)
@@ -3096,9 +3096,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
                                  f'Must be one of the following: {SUPPORTED_FORMATS}')
             image_path = os.path.abspath(os.path.expanduser(str(filename)))
             Image.fromarray(image).save(image_path)
-            if not return_img:
-                return image
-        return image
+        # return image array if requested
+        if return_img:
+            return image
 
     def save_graphic(self, filename, title='PyVista Export', raster=True, painter=True):
         """Save a screenshot of the rendering window as a graphic file.
@@ -3135,7 +3135,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         return
 
     def screenshot(self, filename=None, transparent_background=None,
-                   return_img=None, window_size=None):
+                   return_img=True, window_size=None):
         """Take screenshot at current camera position.
 
         Parameters
@@ -3183,7 +3183,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.image_transparent_background = transparent_background
 
         # This if statement allows you to save screenshots of closed plotters
-        # This is needed for the sphinx-gallery work
+        # This is needed for the sphinx-gallery to work
         if not hasattr(self, 'ren_win'):
             # If plotter has been closed...
             # check if last_image exists
@@ -3191,7 +3191,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 # Save last image
                 return self._save_image(self.last_image, filename, return_img)
             # Plotter hasn't been rendered or was improperly closed
-            raise AttributeError('This plotter is closed and unable to save a screenshot.')
+            raise RuntimeError('This plotter is closed and unable to save a screenshot.')
 
         if self._first_time and not self.off_screen:
             raise RuntimeError("Nothing to screenshot - call .show first or "

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3141,21 +3141,29 @@ class BasePlotter(PickingHelper, WidgetHelper):
         Parameters
         ----------
         filename : str, optional
-            Location to write image to.  If None, no image is written.
+            Location to write image to.  If ``None``, no image is written.
 
         transparent_background : bool, optional
-            Makes the background transparent.  Default False.
+            Whether to make the background transparent.  The default is
+            looked up on the plotter's theme.
 
         return_img : bool, optional
-            If a string filename is given and this is true, a NumPy array of
-            the image will be returned.
+            If ``True`` (the default), a NumPy array of the image will
+            be returned.
+
+        window_size : 2-length tuple, optional
+            Set the plotter's size to this ``(width, height)`` before
+            taking the screenshot.
 
         Returns
         -------
-        img :  numpy.ndarray
+        img : numpy.ndarray
             Array containing pixel RGB and alpha.  Sized:
-            [Window height x Window width x 3] for transparent_background=False
-            [Window height x Window width x 4] for transparent_background=True
+
+            * [Window height x Window width x 3] if
+              ``transparent_background`` is set to ``False``.
+            * [Window height x Window width x 4] if
+              ``transparent_background`` is set to ``True``.
 
         Examples
         --------
@@ -3864,6 +3872,16 @@ class Plotter(BasePlotter):
             The camera position.  You can also set this with
             ``Plotter.camera_position``.
 
+        screenshot : str or bool, optional
+            Take a screenshot of the initial state of the plot.
+            If a string, it specifies the path to which the screenshot
+            is saved. If ``True``, the screenshot is returned as an
+            array. Defaults to ``False``. For interactive screenshots
+            it's recommended to first call ``show()`` with
+            ``auto_close=False`` to set the scene, then save the
+            screenshot in a separate call to ``show()`` or
+            ``screenshot()`.
+
         return_img : bool
             Returns a numpy array representing the last image along
             with the camera position.
@@ -3909,13 +3927,21 @@ class Plotter(BasePlotter):
 
         Examples
         --------
-        Simply show the plot.
+        Simply show the plot of a mesh.
 
+        >>> import pyvista as pv
+        >>> pl = pv.Plotter()
+        >>> _ = pl.add_mesh(pv.Cube())
         >>> pl.show()  # doctest:+SKIP
 
         Take a screenshot interactively.  Screenshot will be of the
-        last image shown.
+        first image shown, so use the first call with
+        ``auto_close=False`` to set the scene before taking the
+        screenshot.
 
+        >>> pl = pv.Plotter()
+        >>> _ = pl.add_mesh(pv.Cube())
+        >>> pl.show(auto_close=False)  # doctest:+SKIP
         >>> pl.show(screenshot='my_image.png')  # doctest:+SKIP
 
         Display an ``ipygany`` scene within a jupyter notebook

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -892,6 +892,15 @@ def test_screenshot(tmpdir):
     filename = str(tmpdir.mkdir("tmpdir").join('export-graphic.svg'))
     plotter.save_graphic(filename)
 
+    # test window and array size
+    w, h = 20, 10
+    img = plotter.screenshot(transparent_background=False,
+                             window_size=(w, h))
+    assert img.shape == (h, w, 3)
+    img = plotter.screenshot(transparent_background=True,
+                             window_size=(w, h))
+    assert img.shape == (h, w, 4)
+
     # checking if plotter closes
     ref = proxy(plotter)
     plotter.close()
@@ -900,6 +909,12 @@ def test_screenshot(tmpdir):
         ref
     except:
         raise RuntimeError('Plotter did not close')
+
+    # check error before first render
+    plotter = pyvista.Plotter(off_screen=False)
+    plotter.add_mesh(pyvista.Sphere())
+    with pytest.raises(RuntimeError):
+        plotter.screenshot()
 
 
 @skip_no_plotting

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -901,15 +901,6 @@ def test_screenshot(tmpdir):
                              window_size=(w, h))
     assert img.shape == (h, w, 4)
 
-    # checking if plotter closes
-    ref = proxy(plotter)
-    plotter.close()
-
-    try:
-        ref
-    except:
-        raise RuntimeError('Plotter did not close')
-
     # check error before first render
     plotter = pyvista.Plotter(off_screen=False)
     plotter.add_mesh(pyvista.Sphere())


### PR DESCRIPTION
This started out as a trivial fix for https://github.com/pyvista/pyvista/pull/1342#issuecomment-851174143 but I've run into some weirdness surrounding screenshots.

Notable changes:
  1. `_save_image()` used to always return the image array. This was twice a bug, because there was a redundant `if` that had the logic backwards.
  2. `screenshot()` delegated the image array returning to `_save_image()`, so this also always returned the image array.

I kept the original intent of the `return_img` keyword and fixed its behaviour by returning from `_save_image()` only when requested, so this is now also mirrored in the actual behaviour of `screenshot()`.

  3. Some docstring extensions including the originally intended doctest fixes. There's also weirdness here: the docs claimed that `screenshot=True` in `show()` will take the last state of the plotter. This doesn't seem to be the case, going back in versions as far as 2019. I've kept the behaviour and changed the documentation, recommending an initial interactive call to `show()` with `auto_close=False`. It might be nicer to take the last image before closing, but I suspect that might be hard to do.
  4. I changed an error type for when the plotter was improperly closed.

As an additional point that I haven't touched yet: [this part](https://github.com/adeak/pyvista/blob/77722f23088ce79ff75249b9f8122a8ba3b80ffd/tests/plotting/test_plotting.py#L904-L911) of the original `test_screenshot` seems _very_ suspicious to me:
```py
    from weakref import proxy
    ...

    # checking if plotter closes
    ref = proxy(plotter)
    plotter.close()

    try:
        ref
    except:
        raise RuntimeError('Plotter did not close')
```
Accessing the `proxy`'s name would only raise if the referenced object were deallocated. But the plotter object is still bound to the `plotter` local name, so there's no way the object could be deallocated. Furthermore, the (bare...) `except` would raise exactly when the `plotter` is somehow gone, yet the custom error mesage mentions the plotter not closing. If the plotter didn't close I'd expect exactly that the object is still around, and there's even less of an error in the `try` block...

So I think we should just remove this part of the test. Is there a reason for its existence that I'm missing?