### PR TITLE
Fix markup bug in show() docstring

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3880,7 +3880,7 @@ class Plotter(BasePlotter):
             it's recommended to first call ``show()`` with
             ``auto_close=False`` to set the scene, then save the
             screenshot in a separate call to ``show()`` or
-            ``screenshot()`.
+            ``screenshot()``.
 
         return_img : bool
             Returns a numpy array representing the last image along


### PR DESCRIPTION
I missed a broken piece of markup in my recent PR. Since the change is trivial and the broken version wasn't caught by CI anyway, I'm pushing this as no-ci.