### PR TITLE
Unofficial Python 3.9 Wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 Installation file for python pyvista module
 """
 import os
-# import sys
+import sys
 from io import open as io_open
 from setuptools import setup
 
@@ -14,25 +14,6 @@ version_file = os.path.join(filepath, package_name, '_version.py')
 with io_open(version_file, mode='r') as fd:
     exec(fd.read())
 
-# leaving this out for conda compatibility...
-# python3_9_linux_wheel = 'https://github.com/pyvista/pyvista/releases/download/0.27.0/vtk-9.0.1-cp39-cp39-manylinux2010_x86_64.whl'
-
-# # Python 3.9 isn't supported at the moment
-# if sys.version_info.minor == 9:
-#     # but, the user might have installed vtk from a non-pypi wheel.
-#     try:
-#         import vtk
-#     except ImportError:
-#         note = ''
-#         if os.name == 'linux':
-#             note = '\n\nHowever there is an unofficial Linux wheel build by the ``pyvista`` team at ' + python3_9_linux_wheel
-
-#         raise RuntimeError('There are no official Python 3.9 wheels for VTK on yet.  '
-#                            'Please use Python 3.6 through 3.8, or build and install '
-#                            'VTK from source with a wheel.  Please see:\n'
-#                            'https://docs.pyvista.org/building_vtk.html' + note)
-
-
 # pre-compiled vtk available for python3
 install_requires = ['numpy',
                     'imageio',
@@ -42,7 +23,18 @@ install_requires = ['numpy',
                     'meshio>=4.0.3, <5.0',
                     'vtk',
                     'transforms3d==0.3.1'
-                    ]
+]
+
+# Python 3.9 doesn't have a VTK wheel as of 10 June 2020
+if sys.version_info.minor == 9 and os.name == 'posix':
+    install_requires.remove('vtk')
+
+    # use unofficial wheel if vtk isn't installed (might be egl, etc.)
+    try:
+        import vtk
+    except ImportError:
+        install_requires.append('pyvista-vtk')
+
 
 readme_file = os.path.join(filepath, 'README.rst')
 


### PR DESCRIPTION
### Current Offical Wheel Support

Not sure if this is the best approach, but it's probably going to be some time until we have official wheels for Python 3.9+ from VTK, and even though there's work on getting development wheels on PyPi, I've run into a bunch of issues testing out their latest nightly wheels.  See:
https://gitlab.kitware.com/vtk/vtk/-/pipeline_schedules

I think part of the issue is simply bugs introduced past 9.0.1.


### Unofficial Wheels

I've been able to doctor some wheels in order to rename them as `pyvista-vtk` just to get them on PyPi.  For anyone from Kitware who's reading this, we kept the licencing, etc, and really just need a way of hosting wheels on PyPi.  I've written emails to Kitware asking to upload the very same wheels to your existing PyPi https://pypi.org/project/vtk/, but I've not gotten any responses.  Please email me at akascap@gmail.com and I'll gladly send you over the wheels I built by following https://docs.pyvista.org/extras/building_vtk.html.  Only other modifications was removing duplicate libraries from the wheel to reduce the size by 26 MB.

Please email me, would love to get wheels out in some way.

---

So far, I've uploaded just Python 3.9 for Linux to test PyPi.  Should we decide to support this, we can just upload it to the offical PyPi.

pip install -i https://test.pypi.org/simple/ pyvista-vtk==9.0.1

Plan is to add the wheels at https://github.com/pyvista/pyvista/releases/tag/0.31.0 to PyPi.  ARM64 architecture is supported by numpy and we should support it as well.

### Forseeable Issues

Since we're still fundamentally still installing `vtk` you could run into an issue where you try to install `pyvista-vtk` and then `pyvista-vtk-egl` to get EGL support and have your original install overwritten.  I can't see anyway around this, as we can't really rename the entire `import vtk` within pyvista just to support EGL.

---

Would really like any thoughts from @pyvista/developers.  It's really annoying not having Python 3.9 support.