### PR TITLE
Add deploy section to doc Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -43,7 +43,7 @@ deploy:
 	cd _build/html && git init
 	cd _build/html && git add .
 	cd _build/html && git checkout -b gh-pages
-	export TAG=$(git describe --tags) && cd _build/html && git commit -am "Manual build from $TAG"
+	cd _build/html && git commit -am "manual build"
 	cd _build/html && git remote add origin https://github.com/pyvista/pyvista-docs
 	cd _build/html && git push -u origin gh-pages --force
 	rm -rf _build/html/.git

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -32,3 +32,18 @@ clean:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+# deploy to https://github.com/pyvista/pyvista-docs
+# WARNING: Use with care as this overwrites history of gh-pages
+deploy:
+	cp README.md _build/html
+	cp ads.txt _build/html
+	touch _build/html/.nojekyll
+	echo "docs.pyvista.org" >> _build/html/CNAME
+	cd _build/html && git init
+	cd _build/html && git add .
+	cd _build/html && git checkout -b gh-pages
+	export TAG=$(git describe --tags) && cd _build/html && git commit -am "Manual build from $TAG"
+	cd _build/html && git remote add origin https://github.com/pyvista/pyvista-docs
+	cd _build/html && git push -u origin gh-pages --force
+	rm -rf _build/html/.git


### PR DESCRIPTION
### Overview

This PR adds a documentation deployment step to our documentation `Makefile`.  This makes deployment of our documentation easy as it can be deployed with simply `make doc deploy`, but quite dangerous as we're overwriting history.  We could git pull and then push as we do in our current CI, but it's not necessary to keep the history of `gh-pages`, only the releases.


To protect this branch a bit, I've generated a `release/0.31` branch for docs.  This way even if we overwrite the branch with garbage for some reason, we can always reselect a release branch from the "Pages" tab and simply display a different release.

The whole idea of this PR is to allow for local doc builds to avoid issues with the virtual framebuffer as pointed out by @adeak in https://github.com/pyvista/pyvista/issues/1355.
