### PR TITLE
Disable warning on missing xserver also when using OSMesa

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -90,7 +90,8 @@ def _warn_xserver():  # pragma: no cover
             return
 
         # Check if VTK has EGL support
-        if 'EGL' in str(type(_vtk.vtkRenderWindow())):
+        ren_win_str = str(type(_vtk.vtkRenderWindow()))
+        if 'EGL' in ren_win_str or 'OSOpenGL' in ren_win_str:
             return
 
         warnings.warn('\n'


### PR DESCRIPTION
Currently Pyvista prints a warning when there are no X server or display present, and if the underlying VTK library is not using EGL:
```
UserWarning: 
This system does not appear to be running an xserver.
PyVista will likely segfault when rendering.

Try starting a virtual frame buffer with xvfb, or using
  ``pyvista.start_xvfb()``
```
If the underlying VTK renderer is vtkEGLRenderWindow, there is no warning.

There is also a second option for using VTK rendering with pyvista, that is to have VTK compiled with OSMesa for offscreen software rendering purely on the CPU. However, pyvista still prints this annoying warning even if OSMesa, VTK and pyvista works perfectly well.

This very tiny patch disables the warning if the vtkRenderWindow is also vtkOSOpenGLRenderWindow, i.e. using OSMesa software rendering.

For reference, here is the different available vtkRenderWindow classes: https://vtk.org/doc/nightly/html/classvtkRenderWindow.html