### PR TITLE
add backwards compat for parse_color

### DIFF
--- a/pyvista/plotting/theme.py
+++ b/pyvista/plotting/theme.py
@@ -1,3 +1,4 @@
 """Here for backwards compatibility with pyvistaqt."""
 
 from pyvista import rcParams  # pragma: no cover
+from ..themes import parse_color  # pragma: no cover


### PR DESCRIPTION
This PR resolves #1377.  This is a critical fix as we've broken some downstream packages with the theme PR.
