### PR TITLE
Fix adaptive_subdivide example - set max_n_passes=2 to reduce time in CI

### DIFF
--- a/pyvista/core/filters.py
+++ b/pyvista/core/filters.py
@@ -4022,11 +4022,11 @@ class PolyDataFilters(DataSetFilters):
         >>> from pyvista import examples
         >>> import pyvista
         >>> mesh = pyvista.PolyData(examples.planefile)
-        >>> submesh = mesh.subdivide_adaptive(max_edge_len=1)
+        >>> submesh = mesh.subdivide_adaptive(max_n_passes=2)
 
         Alternatively, update the mesh in-place.
 
-        >>> submesh = mesh.subdivide_adaptive(max_edge_len=1, inplace=True)
+        >>> submesh = mesh.subdivide_adaptive(max_n_passes=2, inplace=True)
 
         """
         sfilter = _vtk.vtkAdaptiveSubdivisionFilter()


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

The `adaptive_subdivide` example, merged with #1375, was taking an hour in CI. This makes it fast.
