### PR TITLE
vtk==9.0.20210612.dev0 fixes and patch leaks

### DIFF
--- a/pyvista/plotting/export_vtkjs.py
+++ b/pyvista/plotting/export_vtkjs.py
@@ -426,6 +426,8 @@ def mkdir_p(path):
 
 def export_plotter_vtkjs(plotter, filename, compress_arrays=False):
     """Export a plotter's rendering window to the VTKjs format."""
+    arrays = []  # assist in cleaning up references
+
     # import here to avoid circular imports
     from pyvista import _vtk
     sceneName = os.path.split(filename)[1]
@@ -509,6 +511,9 @@ def export_plotter_vtkjs(plotter, filename, compress_arrays=False):
                         colorArrayName = '__CustomRGBColorArray__'
                         colorArray.SetName(colorArrayName)
                         colorMode = 0
+
+                        # track arrays for cleanup
+                        arrays.append(colorArray)
                     else:
                         colorArrayName = ''
 
@@ -634,7 +639,10 @@ def export_plotter_vtkjs(plotter, filename, compress_arrays=False):
 
     shutil.rmtree(output_dir)
 
-    print('Finished exporting dataset to: ', sceneFileName)
+    # this must occur to avoid leaks
+    scDirs.clear()
+    for array in arrays:
+        array.SetReferenceCount(0)
 
 
 def convert_dropbox_url(url):

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -169,6 +169,7 @@ class PickingHelper:
                 selector.SetRenderer(renderer_())
                 selector.SetArea(x0, y0, x1, y1)
                 selection = selector.Select()
+
                 for node in range(selection.GetNumberOfNodes()):
                     selection_node = selection.GetNode(node)
                     if selection_node is None:
@@ -184,6 +185,9 @@ class PickingHelper:
                     tri_smesh = smesh.extract_surface().triangulate()
                     cids_to_get = tri_smesh.extract_cells(cids)["original_cell_ids"]
                     picked.append(smesh.extract_cells(cids_to_get))
+
+                # memory leak issues on vtk==9.0.20210612.dev0
+                selection.UnRegister(selection)
 
             if len(picked) == 1:
                 self_().picked_cells = picked[0]

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -583,7 +583,7 @@ class RenderWindowInteractor():
         """Create a repeating timer."""
         timer_id = self.interactor.CreateRepeatingTimer(stime)
         if hasattr(self.interactor, 'ProcessEvents'):
-            self.interactor.ProcessEvents()
+            self.process_events()
         else:
             self.interactor.Start()
         self.interactor.DestroyTimer(timer_id)

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -628,7 +628,8 @@ class RenderWindowInteractor():
 
     def terminate_app(self):
         """Terminate the app."""
-        self.interactor.TerminateApp()
+        if self.initialized:
+            self.interactor.TerminateApp()
 
 
 def _style_factory(klass):

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -582,7 +582,10 @@ class RenderWindowInteractor():
     def create_repeating_timer(self, stime):
         """Create a repeating timer."""
         timer_id = self.interactor.CreateRepeatingTimer(stime)
-        self.interactor.Start()
+        if hasattr(self.interactor, 'ProcessEvents'):
+            self.interactor.ProcessEvents()
+        else:
+            self.interactor.Start()
         self.interactor.DestroyTimer(timer_id)
         return timer_id
 

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -636,7 +636,7 @@ class Renderer(_vtk.vtkRenderer):
 
             .. warning::
                A bug with vtk 6.3 in Windows seems to cause this
-               function to crash
+               function to crash.
 
         grid : bool or str, optional
             Add grid lines to the backface (``True``, ``'back'``, or
@@ -649,11 +649,11 @@ class Renderer(_vtk.vtkRenderer):
             static closest to the origin (``'origin'``), or outer
             edges (``'outer'``) in relation to the camera
             position. Options include: ``'all', 'front', 'back',
-            'origin', 'outer'``
+            'origin', 'outer'``.
 
         ticks : str, optional
             Set how the ticks are drawn on the axes grid. Options include:
-            ``'inside', 'outside', 'both'``
+            ``'inside', 'outside', 'both'``.
 
         all_edges : bool, optional
             Adds an unlabeled and unticked box at the boundaries of

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -632,9 +632,11 @@ class Renderer(_vtk.vtkRenderer):
             Title of the z axis.  Default ``"Z Axis"``.
 
         use_2d : bool, optional
-            A bug with vtk 6.3 in Windows seems to cause this function
-            to crash this can be enabled for smoother plotting for
-            other environments.
+            This can be enabled for smoother plotting.
+
+            .. warning::
+               A bug with vtk 6.3 in Windows seems to cause this
+               function to crash
 
         grid : bool or str, optional
             Add grid lines to the backface (``True``, ``'back'``, or
@@ -782,6 +784,7 @@ class Renderer(_vtk.vtkRenderer):
         cube_axes_actor.GetZAxesLinesProperty().SetColor(color)
 
         # empty arr
+        # TODO: vtk 9.0.20210612.dev0 reports a leak here
         empty_str = _vtk.vtkStringArray()
         empty_str.InsertNextValue('')
 

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -1,5 +1,6 @@
 """Module containing useful plotting tools."""
 
+import sys
 from enum import Enum
 import platform
 import os
@@ -330,12 +331,17 @@ def opacity_transfer_function(mapping, n_colors, interpolate=True,
                     raise ValueError('No interpolation.')
                 # Use a quadratic interp if scipy is available
                 from scipy.interpolate import interp1d
+
                 # quadratic has best/smoothest results
                 f = interp1d(xo, mapping, kind=kind)
                 vals = f(xx)
                 vals[vals < 0] = 0.0
                 vals[vals > 1.0] = 1.0
                 mapping = (vals * 255.).astype(np.uint8)
+                # nasty issue on Python 3.9 with 9.0.20210612.dev0
+                if sys.version_info.minor == 9:
+                    import gc; gc.collect()
+
             except (ImportError, ValueError):
                 # Otherwise use simple linear interp
                 mapping = (np.interp(xx, xo, mapping) * 255).astype(np.uint8)

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -338,9 +338,6 @@ def opacity_transfer_function(mapping, n_colors, interpolate=True,
                 vals[vals < 0] = 0.0
                 vals[vals > 1.0] = 1.0
                 mapping = (vals * 255.).astype(np.uint8)
-                # nasty issue on Python 3.9 with 9.0.20210612.dev0
-                if sys.version_info.minor == 9:
-                    import gc; gc.collect()
 
             except (ImportError, ValueError):
                 # Otherwise use simple linear interp

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -172,10 +172,12 @@ def test_plot_increment_point_size():
 def test_plot_update(sphere):
     pl = pyvista.Plotter()
     pl.add_mesh(sphere)
+    pl.show(auto_close=False)
     pl.update()
     time.sleep(0.1)
     pl.update()
     pl.update(force_redraw=True)
+    pl.close()
 
 
 @skip_no_plotting

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -363,6 +363,7 @@ def test_lighting_init_invalid():
     with pytest.raises(ValueError):
         pyvista.Plotter(lighting='invalid')
 
+
 @skip_no_plotting
 def test_plotter_shape_invalid():
     # wrong size

--- a/tests/test_picking.py
+++ b/tests/test_picking.py
@@ -11,7 +11,7 @@ skip_no_vtk9 = pytest.mark.skipif(not vtk.vtkVersion().GetVTKMajorVersion() >= 9
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_cell_picking():
     with pytest.raises(AttributeError, match="mesh"):
-        plotter = pyvista.Plotter(off_screen=False)
+        plotter = pyvista.Plotter()
         plotter.enable_cell_picking(mesh=None)
 
     sphere = pyvista.Sphere()
@@ -19,14 +19,19 @@ def test_cell_picking():
         plotter = pyvista.Plotter(
             window_size=(100, 100),
         )
+
+        def callback(*args, **kwargs):
+            pass
+
         plotter.enable_cell_picking(
             mesh=sphere,
             start=True,
             show=True,
-            callback=lambda: None,
+            callback=callback,
             through=through,
         )
         plotter.add_mesh(sphere)
+        plotter.show(auto_close=False)  # must start renderer first
 
         # simulate the pick
         renderer = plotter.renderer


### PR DESCRIPTION
### Patches due to ``vtk==9.0.20210612.dev0``

In the first of likely many patches, this PR accounts for a nasty segfault on Linux and windows due to the usage of ``Start`` instead of ``ProcessEvents`` when using a repeating timer with ``vtk==9.0.20210612``.
