### PR TITLE
Fix static checks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,9 +44,6 @@ jobs:
     inputs:
       versionSpec: '3.8'
   - script: |
-      pip install .
-    displayName: 'Install pyvista'
-  - script: |
       pip install -r requirements_static.txt
       make mypy
     displayName: 'Run static code check'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
       pip install .
     displayName: 'Install pyvista'
   - script: |
-      pip install mypy
+      pip install -r requirements_static.txt
       make mypy
     displayName: 'Run static code check'
 

--- a/requirements_static.txt
+++ b/requirements_static.txt
@@ -1,0 +1,4 @@
+mypy==0.902
+mypy-extensions==0.4.3
+toml==0.10.2
+typing-extensions==3.10.0.0

--- a/requirements_static.txt
+++ b/requirements_static.txt
@@ -2,4 +2,3 @@ mypy==0.902
 mypy-extensions==0.4.3
 toml==0.10.2
 typing-extensions==3.10.0.0
-numpy==1.21.0

--- a/requirements_static.txt
+++ b/requirements_static.txt
@@ -2,3 +2,4 @@ mypy==0.902
 mypy-extensions==0.4.3
 toml==0.10.2
 typing-extensions==3.10.0.0
+numpy==1.21.0


### PR DESCRIPTION
This PR freezes the mypy version to avoid sudden failures due to changes in `mypy`'s latest release.  It also removes the install step from the static check in azure CI.
