### PR TITLE
Various minor (and less minor) docfixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -219,7 +219,7 @@ If you are using PyVista in your scientific research, please help our scientific
 visibility by citing our work!
 
 
-    Sullivan et al., (2019). PyVista: 3D plotting and mesh analysis through a streamlined interface for the Visualization Toolkit (VTK). Journal of Open Source Software, 4(37), 1450, https://doi.org/10.21105/joss.01450
+    Sullivan and Kaszynski, (2019). PyVista: 3D plotting and mesh analysis through a streamlined interface for the Visualization Toolkit (VTK). Journal of Open Source Software, 4(37), 1450, https://doi.org/10.21105/joss.01450
 
 
 BibTex:
@@ -230,12 +230,12 @@ BibTex:
       doi = {10.21105/joss.01450},
       url = {https://doi.org/10.21105/joss.01450},
       year = {2019},
-      month = {may},
+      month = {May},
       publisher = {The Open Journal},
       volume = {4},
       number = {37},
       pages = {1450},
       author = {C. Bane Sullivan and Alexander Kaszynski},
-      title = {{PyVista}: 3D plotting and mesh analysis through a streamlined interface for the Visualization Toolkit ({VTK})},
+      title = {{PyVista}: {3D} plotting and mesh analysis through a streamlined interface for the {Visualization Toolkit} ({VTK})},
       journal = {Journal of Open Source Software}
     }

--- a/doc/api/core/point-grids.rst
+++ b/doc/api/core/point-grids.rst
@@ -303,7 +303,7 @@ scalar bar to show the exact value of certain points.
     plotter.show()
 
 
-pv.Unstructured Grid Class Methods
+pv.UnstructuredGrid Class Methods
 ----------------------------------
 The following is a description of the methods available to a
 ``pv.UnstructuredGrid`` object.  It inherits all methods from the original
@@ -343,7 +343,7 @@ Explicit Structured Grid
    :undoc-members:
 
 
-pv.Structured Grid Class Methods
+pv.StructuredGrid Class Methods
 --------------------------------
 The following is a description of the methods available to a
 ``pv.StructuredGrid`` object.  It inherits all methods from the original

--- a/doc/api/core/point-grids.rst
+++ b/doc/api/core/point-grids.rst
@@ -1,11 +1,11 @@
 Point-Based Grids
 =================
 
-Structured and unstructured grids are designed to manage cells whereas a
-polydata object manage surfaces.  The ``vtk.UnstructuredGrid`` is a derived class
+Structured and unstructured grids are designed to manage cells whereas polydata
+objects manage surfaces.  The ``pyvista.UnstructuredGrid`` is a derived class
 from ``vtk.vtkUnstructuredGrid`` designed to make creation, array access, and
-plotting more straightforward than using the vtk object.  The same applies to a
-``vtk.StructuredGrid``.
+plotting more straightforward than using the VTK object.  The same applies to a
+``pyvista.StructuredGrid``.
 
 
 Unstructured Grid Creation

--- a/doc/api/core/point-grids.rst
+++ b/doc/api/core/point-grids.rst
@@ -304,7 +304,7 @@ scalar bar to show the exact value of certain points.
 
 
 pv.UnstructuredGrid Class Methods
-----------------------------------
+---------------------------------
 The following is a description of the methods available to a
 ``pv.UnstructuredGrid`` object.  It inherits all methods from the original
 ``vtk`` object, `vtk.vtkUnstructuredGrid <https://www.vtk.org/doc/nightly/html/classvtkUnstructuredGrid.html>`_.
@@ -344,7 +344,7 @@ Explicit Structured Grid
 
 
 pv.StructuredGrid Class Methods
---------------------------------
+-------------------------------
 The following is a description of the methods available to a
 ``pv.StructuredGrid`` object.  It inherits all methods from the original
 ``vtk`` object, `vtk.vtkStructuredGrid <https://www.vtk.org/doc/nightly/html/classvtkStructuredGrid.html>`_.

--- a/doc/api/utilities/geometric.rst
+++ b/doc/api/utilities/geometric.rst
@@ -1,8 +1,8 @@
 Geometric Objects
 -----------------
 PyVista includes a few functions to generate simple geometric objects.
-The code documentation for these functions are on this page; to see what these
-functions create, check out the example: :ref:`ref_geometric_example`.
+The API reference for these functions is on this page; to see what these
+functions create, check out the :ref:`ref_geometric_example` example.
 
 .. currentmodule:: pyvista
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -264,7 +264,8 @@ notfound_no_urls_prefix = True
 
 # Copy button customization ---------------------------------------------------
 # exclude traditional Python prompts from the copied code
-copybutton_prompt_text = ">>> "
+copybutton_prompt_text = r'>>> |\.\.\. '
+copybutton_prompt_is_regexp = True
 
 
 # -- Autosummary options

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1134,30 +1134,24 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
     >>> import numpy as np
     >>> import pyvista as pv
     >>>
+    >>> # grid size: ni*nj*nk cells; si, sj, sk steps
     >>> ni, nj, nk = 4, 5, 6
     >>> si, sj, sk = 20, 10, 1
     >>>
-    >>> xcorn = np.arange(0, (ni+1)*si, si)
-    >>> xcorn = np.repeat(xcorn, 2)
-    >>> xcorn = xcorn[1:-1]
-    >>> xcorn = np.tile(xcorn, 4*nj*nk)
+    >>> # create raw coordinate grid
+    >>> grid_ijk = np.mgrid[:(ni+1)*si:si, :(nj+1)*sj:sj, :(nk+1)*sk:sk]
     >>>
-    >>> ycorn = np.arange(0, (nj+1)*sj, sj)
-    >>> ycorn = np.repeat(ycorn, 2)
-    >>> ycorn = ycorn[1:-1]
-    >>> ycorn = np.tile(ycorn, (2*ni, 2*nk))
-    >>> ycorn = np.transpose(ycorn)
-    >>> ycorn = ycorn.flatten()
+    >>> # repeat array along each Cartesian axis for connectivity
+    >>> for axis in range(1, 4):
+    ...     grid_ijk = grid_ijk.repeat(2, axis=axis)
     >>>
-    >>> zcorn = np.arange(0, (nk+1)*sk, sk)
-    >>> zcorn = np.repeat(zcorn, 2)
-    >>> zcorn = zcorn[1:-1]
-    >>> zcorn = np.repeat(zcorn, (4*ni*nj))
+    >>> # slice off unnecessarily doubled edge coordinates
+    >>> grid_ijk = grid_ijk[:, 1:-1, 1:-1, 1:-1]
     >>>
-    >>> corners = np.stack((xcorn, ycorn, zcorn))
-    >>> corners = corners.transpose()
+    >>> # reorder and reshape to VTK order
+    >>> corners = grid_ijk.transpose().reshape(-1, 3)
     >>>
-    >>> dims = np.asarray((ni, nj, nk))+1
+    >>> dims = np.array([ni, nj, nk]) + 1
     >>> grid = pv.ExplicitStructuredGrid(dims, corners)  # doctest: +SKIP
     >>> grid.compute_connectivity()  # doctest: +SKIP
     >>> grid.plot(show_edges=True)  # doctest: +SKIP

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1153,7 +1153,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
     >>>
     >>> dims = np.array([ni, nj, nk]) + 1
     >>> grid = pv.ExplicitStructuredGrid(dims, corners)
-    >>> grid.compute_connectivity()
+    >>> _ = grid.compute_connectivity()
     >>> grid.plot(show_edges=True)  # doctest: +SKIP
 
     """

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1152,8 +1152,8 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
     >>> corners = grid_ijk.transpose().reshape(-1, 3)
     >>>
     >>> dims = np.array([ni, nj, nk]) + 1
-    >>> grid = pv.ExplicitStructuredGrid(dims, corners)  # doctest: +SKIP
-    >>> grid.compute_connectivity()  # doctest: +SKIP
+    >>> grid = pv.ExplicitStructuredGrid(dims, corners)
+    >>> grid.compute_connectivity()
     >>> grid.plot(show_edges=True)  # doctest: +SKIP
 
     """

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1537,7 +1537,7 @@ def test_opacity_by_array_user_transform(uniform):
     p.show()  # note: =verify_cache_image does not work between Xvfb
 
 
-def test_opactity_mismatched_fail(uniform):
+def test_opacity_mismatched_fail(uniform):
     opac = uniform['Spatial Point Data'] / uniform['Spatial Point Data'].max()
     uniform['unc'] = opac
 


### PR DESCRIPTION
A collection of small doc issues I've ran into these past few days. Most of them grammatical or style.

One notable exception is a rewrite of the `ExplicitStructuredGrid` construction example, from
```py
import numpy as np
import pyvista as pv

ni, nj, nk = 4, 5, 6
si, sj, sk = 20, 10, 1

xcorn = np.arange(0, (ni+1)*si, si)
xcorn = np.repeat(xcorn, 2)
xcorn = xcorn[1:-1]
xcorn = np.tile(xcorn, 4*nj*nk)

ycorn = np.arange(0, (nj+1)*sj, sj)
ycorn = np.repeat(ycorn, 2)
ycorn = ycorn[1:-1]
ycorn = np.tile(ycorn, (2*ni, 2*nk))
ycorn = np.transpose(ycorn)
ycorn = ycorn.flatten()

zcorn = np.arange(0, (nk+1)*sk, sk)
zcorn = np.repeat(zcorn, 2)
zcorn = zcorn[1:-1]
zcorn = np.repeat(zcorn, (4*ni*nj))

corners = np.stack((xcorn, ycorn, zcorn))
corners = corners.transpose()

dims = np.asarray((ni, nj, nk))+1
grid = pv.ExplicitStructuredGrid(dims, corners)  
grid.compute_connectivity()  
grid.plot(show_edges=True)  
```

to

```py
import numpy as np
import pyvista as pv

# grid size: ni*nj*nk cells; si, sj, sk steps
ni, nj, nk = 4, 5, 6
si, sj, sk = 20, 10, 1

# create raw coordinate grid
grid_ijk = np.mgrid[:(ni+1)*si:si, :(nj+1)*sj:sj, :(nk+1)*sk:sk]

# repeat array along each Cartesian axis for connectivity
for axis in range(1, 4):
    grid_ijk = grid_ijk.repeat(2, axis=axis)

# slice off unnecessarily doubled edge coordinates
grid_ijk = grid_ijk[:, 1:-1, 1:-1, 1:-1]

# reorder and reshape to VTK order
corners = grid_ijk.transpose().reshape(-1, 3)

dims = np.array([ni, nj, nk]) + 1
grid = pv.ExplicitStructuredGrid(dims, corners)  # doctest: +SKIP
grid.compute_connectivity()  # doctest: +SKIP
grid.plot(show_edges=True)  # doctest: +SKIP
```

The two `corners` arrays should be the exact same. The original didn't have any explanation, so I don't feel too bad about the more concise but potentially more obscure example.

Two questions regarding this:
1. Do we really need the SKIPs before the call to `plot()`?
2.  One related bug: if I press the "copy" icon in the top right corner of the code block in the generated docs, I get this:
```py
import numpy as np
import pyvista as pv
# grid size: ni*nj*nk cells; si, sj, sk steps
ni, nj, nk = 4, 5, 6
si, sj, sk = 20, 10, 1
# create raw coordinate grid
grid_ijk = np.mgrid[:(ni+1)*si:si, :(nj+1)*sj:sj, :(nk+1)*sk:sk]
# repeat array along each Cartesian axis for connectivity
for axis in range(1, 4):
# slice off unnecessarily doubled edge coordinates
grid_ijk = grid_ijk[:, 1:-1, 1:-1, 1:-1]
# reorder and reshape to VTK order
corners = grid_ijk.transpose().reshape(-1, 3)
dims = np.array([ni, nj, nk]) + 1
grid = pv.ExplicitStructuredGrid(dims, corners)  
grid.compute_connectivity()  
grid.plot(show_edges=True)  
```

For one, empty spacer lines are gone, but that's sort of understandable since the `>>>` is also coloured differently on those lines. However, notice that the copy-paste silently swallowed the contents of the `for` loop starting with `...`. This will lead to a `SyntaxError` if you paste it! And just selecting the code block with the mouse also won't work, because this will include the `>>>` on the spacer lines...

Can we fix this? I'd hate to type out the three `repeat` calls by hand.

---

And on a happier note: with the VTK dev wheels (both on Python 3.8 and 3.9) plotters are closing now again! Probably thanks to the fixes made by @akaszynski.