### PR TITLE
Copy empty spacer lines in docs examples

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -264,7 +264,7 @@ notfound_no_urls_prefix = True
 
 # Copy button customization ---------------------------------------------------
 # exclude traditional Python prompts from the copied code
-copybutton_prompt_text = r'>>> |\.\.\. '
+copybutton_prompt_text = r'>>> ?|\.\.\. '
 copybutton_prompt_is_regexp = True
 
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1133,24 +1133,24 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
     --------
     >>> import numpy as np
     >>> import pyvista as pv
-    >>>
+    >>> 
     >>> # grid size: ni*nj*nk cells; si, sj, sk steps
     >>> ni, nj, nk = 4, 5, 6
     >>> si, sj, sk = 20, 10, 1
-    >>>
+    >>> 
     >>> # create raw coordinate grid
     >>> grid_ijk = np.mgrid[:(ni+1)*si:si, :(nj+1)*sj:sj, :(nk+1)*sk:sk]
-    >>>
+    >>> 
     >>> # repeat array along each Cartesian axis for connectivity
     >>> for axis in range(1, 4):
     ...     grid_ijk = grid_ijk.repeat(2, axis=axis)
-    >>>
+    >>> 
     >>> # slice off unnecessarily doubled edge coordinates
     >>> grid_ijk = grid_ijk[:, 1:-1, 1:-1, 1:-1]
-    >>>
+    >>> 
     >>> # reorder and reshape to VTK order
     >>> corners = grid_ijk.transpose().reshape(-1, 3)
-    >>>
+    >>> 
     >>> dims = np.array([ni, nj, nk]) + 1
     >>> grid = pv.ExplicitStructuredGrid(dims, corners)
     >>> _ = grid.compute_connectivity()
@@ -1593,7 +1593,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         >>> cell = grid.extract_cells(31)  # doctest: +SKIP
         >>> ind = grid.neighbors(31)  # doctest: +SKIP
         >>> neighbors = grid.extract_cells(ind)  # doctest: +SKIP
-        >>>
+        >>> 
         >>> plotter = pv.Plotter()
         >>> plotter.add_axes()  # doctest: +SKIP
         >>> plotter.add_mesh(cell, color='r', show_edges=True)  # doctest: +SKIP
@@ -1718,7 +1718,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         Examples
         --------
         >>> from pyvista import examples
-        >>>
+        >>> 
         >>> grid = examples.load_explicit_structured()  # doctest: +SKIP
         >>> grid.compute_connectivity()  # doctest: +SKIP
         >>> grid.plot(show_edges=True)  # doctest: +SKIP


### PR DESCRIPTION
In a small follow-up to https://github.com/pyvista/pyvista/pull/1422/commits/c69c355200a5e104c5c5334cfbc4d3a62303e91d this allows empty prompt spacers to be copied too. This makes it such that a doctest of
```py
>>> import numpy as np
>>> import pyvista as pv
>>>
>>> # grid size: ni*nj*nk cells; si, sj, sk steps
>>> ni, nj, nk = 4, 5, 6
>>> si, sj, sk = 20, 10, 1
>>>
>>> # create raw coordinate grid
>>> grid_ijk = np.mgrid[:(ni+1)*si:si, :(nj+1)*sj:sj, :(nk+1)*sk:sk]
>>>
>>> # repeat array along each Cartesian axis for connectivity
>>> for axis in range(1, 4):
...     grid_ijk = grid_ijk.repeat(2, axis=axis)
>>>
>>> # slice off unnecessarily doubled edge coordinates
>>> grid_ijk = grid_ijk[:, 1:-1, 1:-1, 1:-1]
>>>
>>> # reorder and reshape to VTK order
>>> corners = grid_ijk.transpose().reshape(-1, 3)
>>>
>>> dims = np.array([ni, nj, nk]) + 1
>>> grid = pv.ExplicitStructuredGrid(dims, corners)
>>> _ = grid.compute_connectivity()
>>> grid.plot(show_edges=True)  # doctest: +SKIP
```
gets pasted correctly as
```py
import numpy as np
import pyvista as pv

# grid size: ni*nj*nk cells; si, sj, sk steps
ni, nj, nk = 4, 5, 6
si, sj, sk = 20, 10, 1

# create raw coordinate grid
grid_ijk = np.mgrid[:(ni+1)*si:si, :(nj+1)*sj:sj, :(nk+1)*sk:sk]

# repeat array along each Cartesian axis for connectivity
for axis in range(1, 4):
    grid_ijk = grid_ijk.repeat(2, axis=axis)

# slice off unnecessarily doubled edge coordinates
grid_ijk = grid_ijk[:, 1:-1, 1:-1, 1:-1]

# reorder and reshape to VTK order
corners = grid_ijk.transpose().reshape(-1, 3)

dims = np.array([ni, nj, nk]) + 1
grid = pv.ExplicitStructuredGrid(dims, corners)
_ = grid.compute_connectivity()
grid.plot(show_edges=True)  
```

Note that part of the issue is that the above doctest was originally missing the trailing whitespace on the spacer lines which would make the markup correct (this is also evident in vim's syntax highlighting, and in the highlighter of the code blocks in the online docs). But
1. it turns out that even if we add that trailing whitespace (done in this PR for every current instance) these don't seem to get rendered in the online docs, and
2. there could always be future doctests that add spacer prompts without a trailing whitespace.