### PR TITLE
Add new script to catch doctest name errors

### DIFF
--- a/tests/check_doctest_names.py
+++ b/tests/check_doctest_names.py
@@ -15,7 +15,7 @@ like this:
 
 there will be a ``NameError`` when the code block is copied into Python
 because the ``np`` name is undefined. However, pytest and sphinx test
-runs will not catch this, as the np name is typically also available in
+runs will not catch this, as the ``np`` name is typically also available in
 the global namespace of the module where the doctest resides.
 
 In order to fix this, we build a tree of pyvista's public and private

--- a/tests/check_doctest_names.py
+++ b/tests/check_doctest_names.py
@@ -1,7 +1,11 @@
 """A helper script to check names in doctests.
 
-The problem is that pytest doctests (following the stdlib doctest
-module) see the module-global namespace. So when a doctest looks
+This module is intended to be called from pyvista's root directory with
+
+    python tests/check_doctest_names.py
+
+The problem is that pytest doctests (following the standard-library
+doctest module) see the module-global namespace. So when a doctest looks
 like this:
 
     Examples
@@ -15,8 +19,8 @@ like this:
 
 there will be a ``NameError`` when the code block is copied into Python
 because the ``np`` name is undefined. However, pytest and sphinx test
-runs will not catch this, as the ``np`` name is typically also available in
-the global namespace of the module where the doctest resides.
+runs will not catch this, as the ``np`` name is typically also available
+in the global namespace of the module where the doctest resides.
 
 In order to fix this, we build a tree of pyvista's public and private
 API, using the standard-library doctest module as a doctest parser. We
@@ -30,8 +34,8 @@ as the examples run without error, this module will be happy.
 The implementation is not very robust or smart, it just gets the job
 done to find the rare name mistake in our examples.
 
-This module is executable. If you need off-screen plotting, set the
-``PYVISTA_OFF_SCREEN`` environmental variable to ``True``.
+If you need off-screen plotting, set the ``PYVISTA_OFF_SCREEN``
+environmental variable to ``True`` before running the script.
 """
 
 import re

--- a/tests/check_doctest_names.py
+++ b/tests/check_doctest_names.py
@@ -14,9 +14,9 @@ like this:
     >>> cell_type = np.array([vtk.VTK_HEXAHEDRON, vtk.VTK_HEXAHEDRON], np.int8)
 
 there will be a ``NameError`` when the code block is copied into Python
-because the ``np`` name is undefined. However, pytest and sphinx test runs
-will not catch this, as the np name is typically also available in the
-global namespace of the module where the doctest resides.
+because the ``np`` name is undefined. However, pytest and sphinx test
+runs will not catch this, as the np name is typically also available in
+the global namespace of the module where the doctest resides.
 
 In order to fix this, we build a tree of pyvista's public and private
 API, using the standard-library doctest module as a doctest parser. We
@@ -30,11 +30,11 @@ as the examples run without error, this module will be happy.
 The implementation is not very robust or smart, it just gets the job
 done to find the rare name mistake in our examples.
 
+This module is executable. If you need off-screen plotting, set the
+``PYVISTA_OFF_SCREEN`` environmental variable to ``True``.
 """
 
 import re
-import sys
-import traceback
 from doctest import DocTestFinder
 from types import ModuleType
 from textwrap import indent
@@ -92,8 +92,7 @@ def discover_modules(entry=pyvista, recurse=True):
     return found_modules
 
 
-def check_doctests(modules=None, respect_skips=True, verbose=True,
-                   off_screen=True):
+def check_doctests(modules=None, respect_skips=True, verbose=True):
     """Check whether doctests can be run as-is without errors.
 
     Parameters
@@ -111,18 +110,11 @@ def check_doctests(modules=None, respect_skips=True, verbose=True,
         Whether to print passes/failures as the testing progresses.
         Failures are printed at the end in every case.
 
-    off_screen : bool, optional
-        Whether to enable off-screen rendering for the tests.
-
     """
     skip_pattern = re.compile('doctest: *\+SKIP')
 
     if modules is None:
         modules = discover_modules()
-
-    if off_screen:
-        orig_off_screen = pyvista.OFF_SCREEN
-        pyvista.OFF_SCREEN = True
 
     # find and parse all docstrings; this will also remove any duplicates
     doctests = {
@@ -174,9 +166,6 @@ def check_doctests(modules=None, respect_skips=True, verbose=True,
         print(indent(erroring_code, '    '))
         print(repr(exc))
     print('-' * 60)
-
-    if off_screen:
-        pyvista.OFF_SCREEN = orig_off_screen
 
 
 if __name__ == "__main__":

--- a/tests/check_doctest_names.py
+++ b/tests/check_doctest_names.py
@@ -39,6 +39,7 @@ import sys
 from doctest import DocTestFinder
 from types import ModuleType
 from textwrap import indent
+from argparse import ArgumentParser
 
 import pyvista
 
@@ -167,7 +168,8 @@ def check_doctests(modules=None, respect_skips=True, verbose=True):
     total = len(doctests)
     fails = len(failures)
     passes = total - fails
-    print(f'\n{passes} passes and {fails} failures out of {total} total doctests.\n')
+    print(f'\n{passes} passes and {fails} failures '
+          f'out of {total} total doctests.\n')
     if not fails:
         return failures
 
@@ -183,7 +185,15 @@ def check_doctests(modules=None, respect_skips=True, verbose=True):
 
 
 if __name__ == "__main__":
-    failures = check_doctests()
+    parser = ArgumentParser(description='Look for name errors in doctests.')
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='print passes and failures as tests progress')
+    parser.add_argument('--no-respect-skips', action='store_false',
+                        dest='respect_skips')
+    args = parser.parse_args()
+
+    failures = check_doctests(verbose=args.verbose,
+                              respect_skips=args.respect_skips)
 
     if failures:
         # raise a red flag for CI

--- a/tests/check_doctest_names.py
+++ b/tests/check_doctest_names.py
@@ -164,6 +164,9 @@ def check_doctests(modules=None, respect_skips=True, verbose=True,
     fails = len(failures)
     passes = total - fails
     print(f'\n{passes} passes and {fails} failures out of {total} total doctests.\n')
+    if not fails:
+        return
+
     print('List of failures:')
     for name, (exc, erroring_code) in failures.items():
         print('-' * 60)

--- a/tests/check_doctest_names.py
+++ b/tests/check_doctest_names.py
@@ -1,0 +1,180 @@
+"""A helper script to check names in doctests.
+
+The problem is that pytest doctests (following the stdlib doctest
+module) see the module-global namespace. So when a doctest looks
+like this:
+
+    Examples
+    --------
+    >>> import numpy
+    >>> import vtk
+    >>> import pyvista
+    >>> offset = np.array([0, 9])
+    >>> cells = np.array([8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 9, 10, 11, 12, 13, 14, 15])
+    >>> cell_type = np.array([vtk.VTK_HEXAHEDRON, vtk.VTK_HEXAHEDRON], np.int8)
+
+there will be a ``NameError`` when the code block is copied into Python
+because the ``np`` name is undefined. However, pytest and sphinx test runs
+will not catch this, as the np name is typically also available in the
+global namespace of the module where the doctest resides.
+
+In order to fix this, we build a tree of pyvista's public and private
+API, using the standard-library doctest module as a doctest parser. We
+execute examples with a clean empty namespace to ensure that mistakes
+such as the above can be caught.
+
+Note that we don't try to verify that the actual results from each
+example are correct; that's still pytest's responsibility. As long
+as the examples run without error, this module will be happy.
+
+The implementation is not very robust or smart, it just gets the job
+done to find the rare name mistake in our examples.
+
+"""
+
+import re
+import sys
+import traceback
+from doctest import DocTestFinder
+from types import ModuleType
+from textwrap import indent
+
+import pyvista
+
+
+def discover_modules(entry=pyvista, recurse=True):
+    """Discover the submodules present under an entry point.
+
+    If ``recurse=True``, search goes all the way into descendants of the
+    entry point. Only modules are gathered, because within a module
+    ``doctest``'s discovery can work recursively.
+
+    Should work for ``pyvista`` as entry, but no promises for its more
+    general applicability.
+
+    Parameters
+    ----------
+    entry : module, optional
+        The entry point of the submodule search. Defaults to the main
+        ``pyvista`` module.
+
+    recurse : bool, optional
+        Whether to recurse into submodules.
+
+    """
+    entry_name = entry.__name__
+    found_modules = {}
+    next_entries = {entry}
+    while next_entries:
+        next_modules = {}
+        for entry in next_entries:
+            for attr_short_name in dir(entry):
+                attr = getattr(entry, attr_short_name)
+                if not isinstance(attr, ModuleType):
+                    continue
+        
+                module_name = attr.__name__
+        
+                if module_name.startswith(entry_name):
+                    next_modules[module_name] = attr
+
+        if not recurse:
+            return next_modules
+
+        # find as-of-yet-undiscovered submodules
+        next_entries = {
+            module
+            for module_name, module in next_modules.items()
+            if module_name not in found_modules
+        }
+        found_modules.update(next_modules)
+
+    return found_modules
+
+
+def check_doctests(modules=None, respect_skips=True, verbose=True,
+                   off_screen=True):
+    """Check whether doctests can be run as-is without errors.
+
+    Parameters
+    ----------
+    modules : dict, optional
+        (module name -> module) mapping of submodules defined in a
+        package as returned by ``discover_modules()``. If omitted,
+        ``discover_modules()`` will be called for ``pyvista``.
+
+    respect_skips : bool, optional
+        Whether to ignore doctest examples that contain a DOCTEST:+SKIP
+        directive.
+
+    verbose : bool, optional
+        Whether to print passes/failures as the testing progresses.
+        Failures are printed at the end in every case.
+
+    off_screen : bool, optional
+        Whether to enable off-screen rendering for the tests.
+
+    """
+    skip_pattern = re.compile('doctest: *\+SKIP')
+
+    if modules is None:
+        modules = discover_modules()
+
+    if off_screen:
+        orig_off_screen = pyvista.OFF_SCREEN
+        pyvista.OFF_SCREEN = True
+
+    # find and parse all docstrings; this will also remove any duplicates
+    doctests = {
+        dt.name: dt
+        for module_name, module in modules.items()
+        for dt in DocTestFinder(recurse=True).find(module, globs={})
+    }
+
+    # loop over doctests in alphabetical order for sanity
+    sorted_names = sorted(doctests)
+    failures = {}
+    for dt_name in sorted_names:
+        dt = doctests[dt_name]
+        if not dt.examples:
+            continue
+
+        # mock print to suppress output from a few talkative tests
+        globs = {'print': (lambda *args, **kwargs: ...)}
+        for iline, example in enumerate(dt.examples, start=1):
+            if (not example.source.strip()
+                    or (respect_skips and skip_pattern.search(example.source))):
+                continue
+            try:
+                exec(example.source, globs)
+            except Exception as exc:
+                if verbose:
+                    print(f'FAILED: {dt.name} -- {repr(exc)}')
+                erroring_code = ''.join([
+                    example.source
+                    for example in dt.examples[:iline]
+                ])
+                failures[dt_name] = exc, erroring_code
+                break
+        else:
+            if verbose:
+                print(f'PASSED: {dt.name}')
+
+    total = len(doctests)
+    fails = len(failures)
+    passes = total - fails
+    print(f'\n{passes} passes and {fails} failures out of {total} total doctests.\n')
+    print('List of failures:')
+    for name, (exc, erroring_code) in failures.items():
+        print('-' * 60)
+        print(f'{name}:')
+        print(indent(erroring_code, '    '))
+        print(repr(exc))
+    print('-' * 60)
+
+    if off_screen:
+        pyvista.OFF_SCREEN = orig_off_screen
+
+
+if __name__ == "__main__":
+    check_doctests()

--- a/tests/check_doctest_names.py
+++ b/tests/check_doctest_names.py
@@ -35,6 +35,7 @@ This module is executable. If you need off-screen plotting, set the
 """
 
 import re
+import sys
 from doctest import DocTestFinder
 from types import ModuleType
 from textwrap import indent
@@ -60,6 +61,11 @@ def discover_modules(entry=pyvista, recurse=True):
 
     recurse : bool, optional
         Whether to recurse into submodules.
+
+    Returns
+    -------
+    modules : dict of modules
+        A (module name -> module) mapping of submodules under ``entry``.
 
     """
     entry_name = entry.__name__
@@ -110,6 +116,12 @@ def check_doctests(modules=None, respect_skips=True, verbose=True):
         Whether to print passes/failures as the testing progresses.
         Failures are printed at the end in every case.
 
+    Returns
+    -------
+    failures : dict of (Exception, str)  tuples
+        An (object name -> (exception raised, failing code)) mapping
+        of failed doctests under the specified modules.
+
     """
     skip_pattern = re.compile('doctest: *\+SKIP')
 
@@ -157,7 +169,7 @@ def check_doctests(modules=None, respect_skips=True, verbose=True):
     passes = total - fails
     print(f'\n{passes} passes and {fails} failures out of {total} total doctests.\n')
     if not fails:
-        return
+        return failures
 
     print('List of failures:')
     for name, (exc, erroring_code) in failures.items():
@@ -167,6 +179,12 @@ def check_doctests(modules=None, respect_skips=True, verbose=True):
         print(repr(exc))
     print('-' * 60)
 
+    return failures
+
 
 if __name__ == "__main__":
-    check_doctests()
+    failures = check_doctests()
+
+    if failures:
+        # raise a red flag for CI
+        sys.exit(1)

--- a/tests/check_doctest_names.py
+++ b/tests/check_doctest_names.py
@@ -189,7 +189,8 @@ if __name__ == "__main__":
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='print passes and failures as tests progress')
     parser.add_argument('--no-respect-skips', action='store_false',
-                        dest='respect_skips')
+                        dest='respect_skips',
+                        help='ignore doctest SKIP directives')
     args = parser.parse_args()
 
     failures = check_doctests(verbose=args.verbose,


### PR DESCRIPTION
### Overview

We have some history of struggling with the occasional doctest where names are inconsistent or missing, which leads to errors when users try to copy-paste examples. Some recent PRs fixing these on a case-by-case basis:
* https://github.com/pyvista/pyvista/pull/1342
* https://github.com/pyvista/pyvista/pull/1424
* https://github.com/pyvista/pyvista/pull/1425

It would be nice if CI could catch this, but it can't because doctests see the module global namespace where missing imports are usually hiding (due to [how stdlib `doctest` works](https://docs.python.org/3/library/doctest.html#what-s-the-execution-context)). It turns out that [pytest can't change this either](https://github.com/pytest-dev/pytest/discussions/8791).

So I'm trying to add a script of our own that gathers and executes doctests in isolated, clean namespaces to catch these kinds of mistakes.

### Details

There are still quite a few details to hammer out, but the rough idea is this:
1. Start from `pyvista` and explore all its submodues,
2. use `doctest` to gather the doctests for each class and function/method in a submodule,
3. run each module/class/function/method doctest ourselves with clean `globals`.

The design is largely up for debate. For now I've created a standalone script `tests/check_doctest_names.py`. This is executable as-is to run a test suite, but inside it has two functions (one of which could be called to do this work):

* `discover_modules()` returns a dict of submodules starting from an object (normally a module, and `pyvista` by default)
* `check_doctests()` takes said dict of submodules and runs the doctests for them.

In non-verbose mode the latter function prints this (ignoring VTK warnings and errors that might be due to my VTK dev wheels, and an error in `Plotter.add_background_image()` that's due to the default off-screen rendering):
```
1107 passes and 4 failures out of 1111 total doctests.

List of failures:
------------------------------------------------------------
pyvista.core.common_data.perlin_noise:
    import pyvista
    noise = perlin_noise(0.1, (1, 1, 1), (0, 0, 0))

NameError("name 'perlin_noise' is not defined")
------------------------------------------------------------
pyvista.core.pointset.UnstructuredGrid._from_arrays:
    import numpy
    import vtk
    import pyvista
    offset = np.array([0, 9])

NameError("name 'np' is not defined")
------------------------------------------------------------
pyvista.utilities.cells.create_mixed_cells:
    import vtk
    from pyvista.utilities.cells import create_mixed_cells
    cell_arrays = create_mixed_cells({vtk.VTK_TRIANGLE: np.array([[0, 1, 2], [3, 4, 5]])})

NameError("name 'np' is not defined")
------------------------------------------------------------
pyvista.utilities.helpers.make_tri_mesh:
    import numpy as np
    import pyvista as pv
    points = np.array([[0, 0, 0], [0.5, 0, 0], [1, 0, 0], [0, 0.5, 0],
                       [0.5, 0.5, 0], [1, 0.5, 0], [0, 1, 0], [0.5, 1, 0],
                       [1, 1, 0]])
    faces = np.array([[0, 1, 4], [4, 7, 6], [2, 5, 4], [4, 5, 8],
                      [0, 4, 3], [3, 4, 6], [1, 2, 4], [4, 8, 7]])
    tri_mesh = pyvista.make_tri_mesh(points, faces)

NameError("name 'pyvista' is not defined")
------------------------------------------------------------
```

With the default verbose mode every doctest's status gets printed:
<details>
  <summary>Click for lots of output</summary>
                                           
  ```
  $ python tests/check_doctest_names.py 
  FAILED: pyvista.core.common_data.perlin_noise -- NameError("name 'perlin_noise' is not defined")
  PASSED: pyvista.core.composite.MultiBlock
  PASSED: pyvista.core.composite.MultiBlock.__setitem__
  PASSED: pyvista.core.dataobject.DataObject.actual_memory_size
  PASSED: pyvista.core.dataobject.DataObject.copy_attributes
  PASSED: pyvista.core.dataobject.DataObject.copy_structure
  PASSED: pyvista.core.dataset.DataSet.cell_bounds
  PASSED: pyvista.core.dataset.DataSet.cell_n_points
  PASSED: pyvista.core.dataset.DataSet.cell_points
  PASSED: pyvista.core.dataset.DataSet.cell_type
  PASSED: pyvista.core.dataset.DataSet.find_closest_cell
  PASSED: pyvista.core.filters
  PASSED: pyvista.core.filters.data_set.DataSetFilters.clip
  PASSED: pyvista.core.filters.data_set.DataSetFilters.clip_box
  PASSED: pyvista.core.filters.data_set.DataSetFilters.clip_scalar
  PASSED: pyvista.core.filters.data_set.DataSetFilters.compute_implicit_distance
  PASSED: pyvista.core.filters.data_set.DataSetFilters.extract_surface
  PASSED: pyvista.core.filters.data_set.DataSetFilters.glyph
  PASSED: pyvista.core.filters.data_set.DataSetFilters.plot_over_circular_arc
  PASSED: pyvista.core.filters.data_set.DataSetFilters.plot_over_circular_arc_normal
  PASSED: pyvista.core.filters.data_set.DataSetFilters.probe
  PASSED: pyvista.core.filters.data_set.DataSetFilters.reflect
  PASSED: pyvista.core.filters.data_set.DataSetFilters.sample_over_circular_arc
  PASSED: pyvista.core.filters.data_set.DataSetFilters.sample_over_circular_arc_normal
  PASSED: pyvista.core.filters.data_set.DataSetFilters.shrink
  PASSED: pyvista.core.filters.data_set.DataSetFilters.texture_map_to_sphere
  PASSED: pyvista.core.filters.data_set.DataSetFilters.threshold
  PASSED: pyvista.core.filters.data_set.DataSetFilters.transform
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.clean
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.clip_closed_surface
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.compute_arc_length
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.compute_normals
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.decimate
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.delaunay_2d
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.extrude
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.extrude_rotate
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.fill_holes
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.flip_normals
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.geodesic
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.geodesic_distance
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.intersection
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.multi_ray_trace
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.plot_curvature
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.plot_normals
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.project_points_to_plane
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.ray_trace
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.remove_points
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.ribbon
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.smooth
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.strip
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.subdivide
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.subdivide_adaptive
  PASSED: pyvista.core.filters.poly_data.PolyDataFilters.tube
  PASSED: pyvista.core.filters.structured_grid.StructuredGridFilters.concatenate
  PASSED: pyvista.core.filters.structured_grid.StructuredGridFilters.extract_subset
  PASSED: pyvista.core.grid.RectilinearGrid
  PASSED: pyvista.core.grid.UniformGrid
  PASSED: pyvista.core.imaging.sample_function
  PASSED: pyvista.core.objects.Table
  PASSED: pyvista.core.pointset.ExplicitStructuredGrid
  PASSED: pyvista.core.pointset.ExplicitStructuredGrid.cast_to_unstructured_grid
  PASSED: pyvista.core.pointset.ExplicitStructuredGrid.cell_coords
  PASSED: pyvista.core.pointset.ExplicitStructuredGrid.cell_id
  PASSED: pyvista.core.pointset.ExplicitStructuredGrid.compute_connections
  PASSED: pyvista.core.pointset.ExplicitStructuredGrid.compute_connectivity
  PASSED: pyvista.core.pointset.ExplicitStructuredGrid.dimensions
  PASSED: pyvista.core.pointset.ExplicitStructuredGrid.hide_cells
  PASSED: pyvista.core.pointset.ExplicitStructuredGrid.neighbors
  PASSED: pyvista.core.pointset.ExplicitStructuredGrid.save
  PASSED: pyvista.core.pointset.ExplicitStructuredGrid.show_cells
  PASSED: pyvista.core.pointset.ExplicitStructuredGrid.visible_bounds
  PASSED: pyvista.core.pointset.PointSet.remove_cells
  PASSED: pyvista.core.pointset.PolyData
  PASSED: pyvista.core.pointset.StructuredGrid
  PASSED: pyvista.core.pointset.StructuredGrid.hide_cells
  PASSED: pyvista.core.pointset.UnstructuredGrid
  FAILED: pyvista.core.pointset.UnstructuredGrid._from_arrays -- NameError("name 'np' is not defined")
  PASSED: pyvista.core.pointset.UnstructuredGrid.cast_to_explicit_structured_grid
  PASSED: pyvista.jupyter.itkplotter.PlotterITK
  PASSED: pyvista.jupyter.itkplotter.PlotterITK.add_points
  PASSED: pyvista.jupyter.set_jupyter_backend
  PASSED: pyvista.plotting.axes.Axes
  PASSED: pyvista.plotting.axes.Axes.hide_actor
  PASSED: pyvista.plotting.axes.Axes.hide_symmetric
  PASSED: pyvista.plotting.axes.Axes.origin
  PASSED: pyvista.plotting.axes.Axes.show_actor
  PASSED: pyvista.plotting.axes.Axes.show_symmetric
  PASSED: pyvista.plotting.camera.Camera
  PASSED: pyvista.plotting.camera.Camera.azimuth
  PASSED: pyvista.plotting.camera.Camera.clipping_range
  PASSED: pyvista.plotting.camera.Camera.direction
  PASSED: pyvista.plotting.camera.Camera.distance
  PASSED: pyvista.plotting.camera.Camera.elevation
  PASSED: pyvista.plotting.camera.Camera.focal_point
  PASSED: pyvista.plotting.camera.Camera.model_transform_matrix
  PASSED: pyvista.plotting.camera.Camera.parallel_scale
  PASSED: pyvista.plotting.camera.Camera.position
  PASSED: pyvista.plotting.camera.Camera.roll
  PASSED: pyvista.plotting.camera.Camera.thickness
  PASSED: pyvista.plotting.camera.Camera.up
  PASSED: pyvista.plotting.camera.Camera.view_angle
  PASSED: pyvista.plotting.camera.Camera.view_frustum
  PASSED: pyvista.plotting.camera.Camera.zoom
  PASSED: pyvista.plotting.lights.Light
  PASSED: pyvista.plotting.lights.Light.ambient_color
  PASSED: pyvista.plotting.lights.Light.attenuation_values
  PASSED: pyvista.plotting.lights.Light.cone_angle
  PASSED: pyvista.plotting.lights.Light.copy
  PASSED: pyvista.plotting.lights.Light.diffuse_color
  PASSED: pyvista.plotting.lights.Light.exponent
  PASSED: pyvista.plotting.lights.Light.focal_point
  PASSED: pyvista.plotting.lights.Light.intensity
  PASSED: pyvista.plotting.lights.Light.is_camera_light
  PASSED: pyvista.plotting.lights.Light.is_headlight
  PASSED: pyvista.plotting.lights.Light.is_scene_light
  PASSED: pyvista.plotting.lights.Light.light_type
  PASSED: pyvista.plotting.lights.Light.on
  PASSED: pyvista.plotting.lights.Light.position
  PASSED: pyvista.plotting.lights.Light.positional
  PASSED: pyvista.plotting.lights.Light.set_direction_angle
  PASSED: pyvista.plotting.lights.Light.shadow_attenuation
  PASSED: pyvista.plotting.lights.Light.show_actor
  PASSED: pyvista.plotting.lights.Light.specular_color
  PASSED: pyvista.plotting.lights.Light.switch_off
  PASSED: pyvista.plotting.lights.Light.switch_on
  PASSED: pyvista.plotting.lights.Light.transform_matrix
  PASSED: pyvista.plotting.lights.Light.world_focal_point
  PASSED: pyvista.plotting.lights.Light.world_position
  PASSED: pyvista.plotting.plotting.BasePlotter.add_arrows
  PASSED: pyvista.plotting.plotting.BasePlotter.add_background_image
  PASSED: pyvista.plotting.plotting.BasePlotter.add_legend
  PASSED: pyvista.plotting.plotting.BasePlotter.add_light
  PASSED: pyvista.plotting.plotting.BasePlotter.add_mesh
  PASSED: pyvista.plotting.plotting.BasePlotter.get_image_depth
  PASSED: pyvista.plotting.plotting.BasePlotter.remove_all_lights
  PASSED: pyvista.plotting.plotting.BasePlotter.scalar_bars
  PASSED: pyvista.plotting.plotting.BasePlotter.screenshot
  PASSED: pyvista.plotting.plotting.BasePlotter.shape
  PASSED: pyvista.plotting.plotting.BasePlotter.theme
  PASSED: pyvista.plotting.plotting.BasePlotter.where_is
  PASSED: pyvista.plotting.plotting.Plotter
  PASSED: pyvista.plotting.plotting.Plotter.show
  PASSED: pyvista.plotting.render_window_interactor.RenderWindowInteractor.enable_image_style
  PASSED: pyvista.plotting.render_window_interactor.RenderWindowInteractor.enable_joystick_actor_style
  PASSED: pyvista.plotting.render_window_interactor.RenderWindowInteractor.enable_joystick_style
  PASSED: pyvista.plotting.render_window_interactor.RenderWindowInteractor.enable_rubber_band_2d_style
  PASSED: pyvista.plotting.render_window_interactor.RenderWindowInteractor.enable_rubber_band_style
  PASSED: pyvista.plotting.render_window_interactor.RenderWindowInteractor.enable_terrain_style
  PASSED: pyvista.plotting.render_window_interactor.RenderWindowInteractor.enable_trackball_actor_style
  PASSED: pyvista.plotting.render_window_interactor.RenderWindowInteractor.enable_trackball_style
  PASSED: pyvista.plotting.render_window_interactor.RenderWindowInteractor.enable_zoom_style
  PASSED: pyvista.plotting.renderer.Renderer.add_floor
  PASSED: pyvista.plotting.renderer.Renderer.show_bounds
  PASSED: pyvista.plotting.renderers.Renderers.set_background
  PASSED: pyvista.plotting.scalar_bars.ScalarBars.add_scalar_bar
  PASSED: pyvista.plotting.tools.opacity_transfer_function
  PASSED: pyvista.plotting.widgets.WidgetHelper.add_slider_widget
  PASSED: pyvista.themes
  PASSED: pyvista.themes.DarkTheme
  PASSED: pyvista.themes.DefaultTheme
  PASSED: pyvista.themes.DefaultTheme.auto_close
  PASSED: pyvista.themes.DefaultTheme.axes
  PASSED: pyvista.themes.DefaultTheme.background
  PASSED: pyvista.themes.DefaultTheme.camera
  PASSED: pyvista.themes.DefaultTheme.cmap
  PASSED: pyvista.themes.DefaultTheme.color
  PASSED: pyvista.themes.DefaultTheme.colorbar_horizontal
  PASSED: pyvista.themes.DefaultTheme.colorbar_orientation
  PASSED: pyvista.themes.DefaultTheme.colorbar_vertical
  PASSED: pyvista.themes.DefaultTheme.depth_peeling
  PASSED: pyvista.themes.DefaultTheme.edge_color
  PASSED: pyvista.themes.DefaultTheme.floor_color
  PASSED: pyvista.themes.DefaultTheme.font
  PASSED: pyvista.themes.DefaultTheme.full_screen
  PASSED: pyvista.themes.DefaultTheme.interactive
  PASSED: pyvista.themes.DefaultTheme.jupyter_backend
  PASSED: pyvista.themes.DefaultTheme.lighting
  PASSED: pyvista.themes.DefaultTheme.load_theme
  PASSED: pyvista.themes.DefaultTheme.multi_rendering_splitting_position
  PASSED: pyvista.themes.DefaultTheme.multi_samples
  PASSED: pyvista.themes.DefaultTheme.nan_color
  PASSED: pyvista.themes.DefaultTheme.notebook
  PASSED: pyvista.themes.DefaultTheme.outline_color
  PASSED: pyvista.themes.DefaultTheme.render_points_as_spheres
  PASSED: pyvista.themes.DefaultTheme.restore_defaults
  PASSED: pyvista.themes.DefaultTheme.save
  PASSED: pyvista.themes.DefaultTheme.show_edges
  PASSED: pyvista.themes.DefaultTheme.show_scalar_bar
  PASSED: pyvista.themes.DefaultTheme.silhouette
  PASSED: pyvista.themes.DefaultTheme.smooth_shading
  PASSED: pyvista.themes.DefaultTheme.title
  PASSED: pyvista.themes.DefaultTheme.transparent_background
  PASSED: pyvista.themes.DefaultTheme.volume_mapper
  PASSED: pyvista.themes.DefaultTheme.window_size
  PASSED: pyvista.themes.DocumentTheme
  PASSED: pyvista.themes.ParaViewTheme
  PASSED: pyvista.themes._AxesConfig
  PASSED: pyvista.themes._AxesConfig.box
  PASSED: pyvista.themes._AxesConfig.show
  PASSED: pyvista.themes._AxesConfig.x_color
  PASSED: pyvista.themes._AxesConfig.y_color
  PASSED: pyvista.themes._AxesConfig.z_color
  PASSED: pyvista.themes._ColorbarConfig
  PASSED: pyvista.themes._ColorbarConfig.height
  PASSED: pyvista.themes._ColorbarConfig.position_x
  PASSED: pyvista.themes._ColorbarConfig.position_y
  PASSED: pyvista.themes._ColorbarConfig.width
  PASSED: pyvista.themes._DepthPeelingConfig
  PASSED: pyvista.themes._DepthPeelingConfig.enabled
  PASSED: pyvista.themes._DepthPeelingConfig.number_of_peels
  PASSED: pyvista.themes._DepthPeelingConfig.occlusion_ratio
  PASSED: pyvista.themes._Font
  PASSED: pyvista.themes._Font.color
  PASSED: pyvista.themes._Font.family
  PASSED: pyvista.themes._Font.fmt
  PASSED: pyvista.themes._Font.label_size
  PASSED: pyvista.themes._Font.size
  PASSED: pyvista.themes._Font.title_size
  PASSED: pyvista.themes._SilhouetteConfig
  PASSED: pyvista.themes._SilhouetteConfig.color
  PASSED: pyvista.themes._SilhouetteConfig.decimate
  PASSED: pyvista.themes._SilhouetteConfig.feature_angle
  PASSED: pyvista.themes._SilhouetteConfig.line_width
  PASSED: pyvista.themes._SilhouetteConfig.opacity
  PASSED: pyvista.themes._SliderConfig
  PASSED: pyvista.themes._SliderStyleConfig.cap_length
  PASSED: pyvista.themes._SliderStyleConfig.cap_opacity
  PASSED: pyvista.themes._SliderStyleConfig.cap_width
  PASSED: pyvista.themes._SliderStyleConfig.slider_color
  PASSED: pyvista.themes._SliderStyleConfig.slider_length
  PASSED: pyvista.themes._SliderStyleConfig.slider_width
  PASSED: pyvista.themes._SliderStyleConfig.tube_color
  PASSED: pyvista.themes._SliderStyleConfig.tube_width
  PASSED: pyvista.themes.load_theme
  PASSED: pyvista.themes.set_plot_theme
  PASSED: pyvista.utilities.cells.CellArray
  FAILED: pyvista.utilities.cells.create_mixed_cells -- NameError("name 'np' is not defined")
  PASSED: pyvista.utilities.errors.VtkErrorCatcher
  PASSED: pyvista.utilities.features.voxelize
  PASSED: pyvista.utilities.fileio.read
  PASSED: pyvista.utilities.fileio.read_exodus
  PASSED: pyvista.utilities.geometric_objects.CircularArc
  PASSED: pyvista.utilities.geometric_objects.CircularArcFromNormal
  PASSED: pyvista.utilities.geometric_objects.Cylinder
  PASSED: pyvista.utilities.geometric_objects.Pyramid
  PASSED: pyvista.utilities.helpers.axis_rotation
  PASSED: pyvista.utilities.helpers.cubemap
  PASSED: pyvista.utilities.helpers.line_segments_from_points
  FAILED: pyvista.utilities.helpers.make_tri_mesh -- NameError("name 'pyvista' is not defined")
  PASSED: pyvista.utilities.helpers.wrap
  PASSED: pyvista.utilities.parametric_objects.ParametricBohemianDome
  PASSED: pyvista.utilities.parametric_objects.ParametricBour
  PASSED: pyvista.utilities.parametric_objects.ParametricBoy
  PASSED: pyvista.utilities.parametric_objects.ParametricCatalanMinimal
  PASSED: pyvista.utilities.parametric_objects.ParametricConicSpiral
  PASSED: pyvista.utilities.parametric_objects.ParametricCrossCap
  PASSED: pyvista.utilities.parametric_objects.ParametricDini
  PASSED: pyvista.utilities.parametric_objects.ParametricEllipsoid
  PASSED: pyvista.utilities.parametric_objects.ParametricEnneper
  PASSED: pyvista.utilities.parametric_objects.ParametricFigure8Klein
  PASSED: pyvista.utilities.parametric_objects.ParametricHenneberg
  PASSED: pyvista.utilities.parametric_objects.ParametricKlein
  PASSED: pyvista.utilities.parametric_objects.ParametricKuen
  PASSED: pyvista.utilities.parametric_objects.ParametricMobius
  PASSED: pyvista.utilities.parametric_objects.ParametricPluckerConoid
  PASSED: pyvista.utilities.parametric_objects.ParametricPseudosphere
  PASSED: pyvista.utilities.parametric_objects.ParametricRandomHills
  PASSED: pyvista.utilities.parametric_objects.ParametricRoman
  PASSED: pyvista.utilities.parametric_objects.ParametricSuperEllipsoid
  PASSED: pyvista.utilities.parametric_objects.ParametricSuperToroid
  PASSED: pyvista.utilities.parametric_objects.ParametricTorus
  PASSED: pyvista.utilities.parametric_objects.Spline
  PASSED: pyvista.utilities.regression.compare_images
  PASSED: pyvista.utilities.transformations.apply_transformation_to_points
  PASSED: pyvista.utilities.xvfb.start_xvfb
  
  1107 passes and 4 failures out of 1111 total doctests.
  
  List of failures:
  ------------------------------------------------------------
  pyvista.core.common_data.perlin_noise:
      import pyvista
      noise = perlin_noise(0.1, (1, 1, 1), (0, 0, 0))
  
  NameError("name 'perlin_noise' is not defined")
  ------------------------------------------------------------
  pyvista.core.pointset.UnstructuredGrid._from_arrays:
      import numpy
      import vtk
      import pyvista
      offset = np.array([0, 9])
  
  NameError("name 'np' is not defined")
  ------------------------------------------------------------
  pyvista.utilities.cells.create_mixed_cells:
      import vtk
      from pyvista.utilities.cells import create_mixed_cells
      cell_arrays = create_mixed_cells({vtk.VTK_TRIANGLE: np.array([[0, 1, 2], [3, 4, 5]])})
  
  NameError("name 'np' is not defined")
  ------------------------------------------------------------
  pyvista.utilities.helpers.make_tri_mesh:
      import numpy as np
      import pyvista as pv
      points = np.array([[0, 0, 0], [0.5, 0, 0], [1, 0, 0], [0, 0.5, 0],
                         [0.5, 0.5, 0], [1, 0.5, 0], [0, 1, 0], [0.5, 1, 0],
                         [1, 1, 0]])
      faces = np.array([[0, 1, 4], [4, 7, 6], [2, 5, 4], [4, 5, 8],
                        [0, 4, 3], [3, 4, 6], [1, 2, 4], [4, 8, 7]])
      tri_mesh = pyvista.make_tri_mesh(points, faces)
  
  NameError("name 'pyvista' is not defined")
  ------------------------------------------------------------
  ```                                      
</details>

As you can see it successfully finds a lot of doctests, and it catches 4 legitimate mistakes. (I'm going to fix these in a separate PR so that we can keep playing with these errors in this PR.)

There are still a lot of open questions, such as:
- [x] Does the general design even make sense? Is it robust enough? Is it a problem if it isn't, as long as it works for pyvista?
- [x] Is the script in the right place? Is it OK for it to be executable? I had CI in mind when I wrote it this way, but I guess nothing stops CI from doing `python -c 'from tests.check_doctest_names import check_doctests; check_doctests()'.`
- [x] If it stays executable we should consider adding argument parsing to be able to support `-v` and setting `OFF_SCREEN` and the like.
- [x] Can we do better reporting? Automatic tracebacks aren't really meaningful (at least I couldn't wrangle them to play ball in multiple failed attempts). I figured printing the offending doctests up to the point of the failure should be good enough.

---

After feedback from @akaszynski I've added some argument parsing:
```
$ python check_doctest_names.py -h
usage: check_doctest_names.py [-h] [-v] [--no-respect-skips]

Look for name errors in doctests.

optional arguments:
  -h, --help          show this help message and exit
  -v, --verbose       print passes and failures as tests progress
  --no-respect-skips  ignore doctest SKIP directives
```

Example options:
```sh
python check_doctest_names.py  # silent run
python check_doctest_names.py -v  # verbose run
python check_doctest_names.py --verbose  # verbose run
python check_doctest_names.py --no-respect-skips  # silent run executing SKIPped lines
```

If there are any failures, the script exits with status 1, which should trip CI. Otherwise the exit status is 0.