### PR TITLE
Fix four doctest NameErrors

### DIFF
--- a/pyvista/core/common_data.py
+++ b/pyvista/core/common_data.py
@@ -47,7 +47,7 @@ def perlin_noise(amplitude, freq: Sequence[float], phase: Sequence[float]):
     for all axes of 1, and a phase of 0 for all axes.
 
     >>> import pyvista
-    >>> noise = perlin_noise(0.1, (1, 1, 1), (0, 0, 0))
+    >>> noise = pyvista.perlin_noise(0.1, (1, 1, 1), (0, 0, 0))
 
     Apply the perlin noise function to 
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -657,7 +657,7 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
 
         Examples
         --------
-        >>> import numpy
+        >>> import numpy as np
         >>> import vtk
         >>> import pyvista
         >>> offset = np.array([0, 9])

--- a/pyvista/utilities/cells.py
+++ b/pyvista/utilities/cells.py
@@ -254,6 +254,7 @@ def create_mixed_cells(mixed_cell_dict, nr_points=None):
     This will generate cell arrays to generate a mesh with two
     disconnected triangles from 6 points.
 
+    >>> import numpy as np
     >>> import vtk
     >>> from pyvista.utilities.cells import create_mixed_cells
     >>> cell_arrays = create_mixed_cells({vtk.VTK_TRIANGLE: np.array([[0, 1, 2], [3, 4, 5]])})

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -384,7 +384,7 @@ def make_tri_mesh(points, faces):
     nine vertices and eight faces.
 
     >>> import numpy as np
-    >>> import pyvista as pv
+    >>> import pyvista
     >>> points = np.array([[0, 0, 0], [0.5, 0, 0], [1, 0, 0], [0, 0.5, 0],
     ...                    [0.5, 0.5, 0], [1, 0.5, 0], [0, 1, 0], [0.5, 1, 0],
     ...                    [1, 1, 0]])


### PR DESCRIPTION
Fix four `NameErrors` in doctests found via https://github.com/pyvista/pyvista/pull/1439.

We might want to merge this only after that PR, so that if `main` ever gets merged back into that PR we'll still have the failing cases for testing.

Also, the `perlin_noise` example is missing half a doctest: https://github.com/pyvista/pyvista/blob/f383040c8fd71aef1d6d12bd07e3a0696df91452/pyvista/core/common_data.py#L52-L53

@akaszynski  do you remember what you wanted to write there?