### PR TITLE
reset camera clipping range when changing position

### DIFF
--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -37,6 +37,8 @@ class Camera(_vtk.vtkCamera):
                 raise TypeError('Camera only accepts a pyvista.Renderer or None as '
                                 'the ``renderer`` argument')
             self._renderer = proxy(renderer)
+        else:
+            self._renderer = None
 
     @property
     def position(self):

--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -77,7 +77,7 @@ class Camera(_vtk.vtkCamera):
         --------
         >>> import pyvista
         >>> pl = pyvista.Plotter()
-        >>> pl.add_mesh(pyvista.Sphere())
+        >>> _ = pl.add_mesh(pyvista.Sphere())
         >>> pl.camera.clipping_range = (1, 2)
         >>> pl.camera.reset_clipping_range()  # doctest:+SKIP
         (0.0039213485598532955, 3.9213485598532953)

--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -1,4 +1,5 @@
 """Module containing pyvista implementation of vtkCamera."""
+from weakref import proxy
 
 import numpy as np
 
@@ -25,11 +26,17 @@ class Camera(_vtk.vtkCamera):
 
     """
 
-    def __init__(self):
+    def __init__(self, renderer=None):
         """Initialize a new camera descriptor."""
         self._is_parallel_projection = False
         self._elevation = 0.0
         self._azimuth = 0.0
+
+        if renderer:
+            if not isinstance(renderer, pyvista.Renderer):
+                raise TypeError('Camera only accepts a pyvista.Renderer or None as '
+                                'the ``renderer`` argument')
+            self._renderer = proxy(renderer)
 
     @property
     def position(self):
@@ -58,6 +65,26 @@ class Camera(_vtk.vtkCamera):
         self.SetPosition(value)
         self._elevation = 0.0
         self._azimuth = 0.0
+        if self._renderer:
+            self.reset_clipping_range()
+
+    def reset_clipping_range(self):
+        """Reset the camera clipping range based on the bounds of the visible actors.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.add_mesh(pyvista.Sphere())
+        >>> pl.camera.clipping_range = (1, 2)
+        >>> pl.camera.reset_clipping_range()  # doctest:+SKIP
+        (0.0039213485598532955, 3.9213485598532953)
+
+        """
+        if self._renderer is None:
+            raise AttributeError('Camera is must be associated with a renderer to '
+                                 'reset its clipping range.')
+        self._renderer.reset_camera_clipping_range()
 
     @property
     def focal_point(self):

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -121,7 +121,7 @@ class Renderer(_vtk.vtkRenderer):
         self._floor_kwargs = []
         # this keeps track of lights added manually to prevent garbage collection
         self._lights = []
-        self._camera = Camera()
+        self._camera = Camera(self)
         self.SetActiveCamera(self._camera)
         self._empty_str = None  # used to track reference to a vtkStringArray
         self._shadow_pass = None
@@ -177,9 +177,16 @@ class Renderer(_vtk.vtkRenderer):
             self.camera.up = camera_location[2]
 
         # reset clipping range
-        self.ResetCameraClippingRange()
+        self.reset_camera_clipping_range()
         self.camera_set = True
         self.Modified()
+
+    def reset_camera_clipping_range(self):
+        """Reset the camera clipping range based on the bounds of the visible actors.
+
+        This ensures that no props are cut off
+        """
+        self.ResetCameraClippingRange()
 
     @property
     def camera(self):

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -9,6 +9,11 @@ def camera():
     return pyvista.Camera()
 
 
+def test_invalid_init():
+    with pytest.raises(TypeError):
+        pyvista.Camera(1)
+
+
 def test_camera_position(camera):
     position = np.random.random(3)
     camera.position = position
@@ -89,6 +94,20 @@ def test_clipping_range(camera):
         far_point = near_point - np.random.random(1)
         points = (near_point, far_point)
         camera.clipping_range = points
+
+
+def test_reset_clipping_range(camera):
+    with pytest.raises(AttributeError):
+        camera.reset_clipping_range()
+
+    # requires renderer for this method
+    crng = (1, 2)
+    pl = pyvista.Plotter()
+    pl.add_mesh(pyvista.Sphere())
+    pl.camera.clipping_range = crng
+    assert pl.camera.clipping_range == crng
+    pl.camera.reset_clipping_range()
+    assert pl.camera.clipping_range != crng
 
 
 def test_view_angle(camera):


### PR DESCRIPTION
### Reset Camera Clipping Range when Changing Position
Normally the clipping range is setup when starting the scene render, but if the camera position is set after actors have been added to the scene, the mesh disappears.

This PR automatically resets the clipping range when changing the position.

Resolves #1445