### PR TITLE
add ci for local namespace; fix two docstrings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ CODESPELL_IGNORE ?= "ignore_words.txt"
 
 # doctest modules must be off screen to avoid plotting everything
 doctest-modules: export PYVISTA_OFF_SCREEN = True
+doctest-modules-local-namespace: export PYVISTA_OFF_SCREEN = True
 
 
 all: doctest
@@ -23,6 +24,10 @@ pydocstyle:
 doctest-modules:
 	@echo "Runnnig module doctesting"
 	pytest -v --doctest-modules pyvista
+
+doctest-modules-local-namespace:
+	@echo "Running module doctesting using docstring local namespace"
+	python tests/check_doctest_names.py
 
 coverage:
 	@echo "Running coverage"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,6 +115,10 @@ jobs:
     displayName: 'Test Package Docstrings'
 
   - script: |
+      make doctest-modules-local-namespace
+    displayName: 'Test Package Docstrings with Local Namespace'
+
+  - script: |
       bash <(curl -s https://codecov.io/bash)
     displayName: 'Upload coverage to codecov.io'
     condition: eq(variables['python.version'], '3.7')

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -608,14 +608,16 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        mesh : Polydata object
-            ``pyvista`` polydata object.
+        pyvista.PolyData
+            Subdivided mesh.
 
         Examples
         --------
+        Subdivide the sphere mesh.
+
         >>> from pyvista import examples
         >>> import pyvista
-        >>> mesh = pyvista.PolyData(examples.planefile)
+        >>> mesh = pyvista.Sphere()
         >>> submesh = mesh.subdivide(1, 'loop')
 
         Alternatively, update the mesh in-place.

--- a/pyvista/plotting/background_renderer.py
+++ b/pyvista/plotting/background_renderer.py
@@ -39,6 +39,8 @@ class BackgroundRenderer(Renderer):
         """Resize a background renderer."""
         if self.parent is None:  # when deleted
             return
+        if not hasattr(self.parent, 'ren_win'):  # BasePlotter
+            return
 
         if self._prior_window_size != self.parent.window_size:
             self._prior_window_size = self.parent.window_size


### PR DESCRIPTION
### Use Local Namespace for Doctests

This PR adds @adeak's recently added `tests/check_doctest_names.py` to our `Makefile` and CI testing.  This is a two part PR.  First part is straightforward as it's a simple modification of our CI.  Second part is fixing two docstring tests that had VTK errors that weren't swallowed by the doctest CI as we `exec` each docstring.

### Doctest VTK errors:

Calling:
```
python tests/check_doctest_names.py -v
```

#### PASSED: pyvista.core.filters.poly_data.PolyDataFilters.subdivide

```
2021-06-26 10:10:16.332 (   2.499s) [        9181C740]vtkLoopSubdivisionFilte:104    ERR| vtkLoopSubdivisionFilter (0x4567fe0): Dataset is non-manifold and cannot be subdivided. Edge shared by 3 cells
ERROR:root:Dataset is non-manifold and cannot be subdivided. Edge shared by 3 cells
2021-06-26 10:10:16.332 (   2.499s) [        9181C740]vtkApproximatingSubdivi:112    ERR| vtkLoopSubdivisionFilter (0x4567fe0): Subdivision failed.
ERROR:root:Subdivision failed.
2021-06-26 10:10:16.332 (   2.499s) [        9181C740]       vtkExecutive.cxx:753    ERR| vtkCompositeDataPipeline (0x454b2a0): Algorithm vtkLoopSubdivisionFilter(0x4567fe0) returned failure for request: vtkInformation (0x442fb30)
  Debug: Off
  Modified Time: 1286695
  Reference Count: 1
  Registered Events: (none)
  Request: REQUEST_DATA
  FROM_OUTPUT_PORT: 0
  ALGORITHM_AFTER_FORWARD: 1
  FORWARD_DIRECTION: 0


ERROR:root:Algorithm vtkLoopSubdivisionFilter(0x4567fe0) returned failure for request: vtkInformation (0x442fb30)
2021-06-26 10:10:16.334 (   2.501s) [        9181C740]vtkLoopSubdivisionFilte:104    ERR| vtkLoopSubdivisionFilter (0x4567fe0): Dataset is non-manifold and cannot be subdivided. Edge shared by 3 cells
ERROR:root:Dataset is non-manifold and cannot be subdivided. Edge shared by 3 cells
2021-06-26 10:10:16.334 (   2.501s) [        9181C740]vtkApproximatingSubdivi:112    ERR| vtkLoopSubdivisionFilter (0x4567fe0): Subdivision failed.
ERROR:root:Subdivision failed.
2021-06-26 10:10:16.334 (   2.501s) [        9181C740]       vtkExecutive.cxx:753    ERR| vtkCompositeDataPipeline (0x454b2a0): Algorithm vtkLoopSubdivisionFilter(0x4567fe0) returned failure for request: vtkInformation (0x4570120)
  Debug: Off
  Modified Time: 1293364
  Reference Count: 1
  Registered Events: (none)
  Request: REQUEST_DATA
  FROM_OUTPUT_PORT: 0
  ALGORITHM_AFTER_FORWARD: 1
  FORWARD_DIRECTION: 0


ERROR:root:Algorithm vtkLoopSubdivisionFilter(0x4567fe0) returned failure for request: vtkInformation (0x4570120)
```

Fixed by using a manifold mesh.


#### PASSED: pyvista.plotting.plotting.BasePlotter.add_background_image

```
WARNING:root:Encountered issue in callback (most recent call last):
  File "/home/alex/python/pyvista/pyvista/plotting/background_renderer.py", line 43, in resize
    if self._prior_window_size != self.parent.window_size:
  File "/home/alex/python/pyvista/pyvista/plotting/plotting.py", line 757, in window_size
    return list(self.ren_win.GetSize())
AttributeError: 'Plotter' object has no attribute 'ren_win'
```

Fixed by checking if plotter has th `ren_win` attribute when before attempting resize.
