### PR TITLE
only allow dataset types to be active

### DIFF
--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -85,7 +85,9 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
     def active_scalars(self, name: str) -> None:
         """Set the active scalars by name."""
         self._raise_field_data_no_scalars_vectors()
-        self.SetActiveScalars(name)
+        dtype = self[name].dtype
+        if np.issubdtype(dtype, np.number) or dtype == bool:
+            self.SetActiveScalars(name)
 
     @property
     def active_vectors(self) -> Optional[np.ndarray]:
@@ -175,19 +177,20 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         Parameters
         ----------
         narray : array_like, scalar value
-            A pyvista_ndarray, numpy.ndarray, list, tuple or scalar value.
+            A ``pyvista_ndarray``, ``numpy.ndarray``, ``list``,
+            ``tuple`` or scalar value.
 
         name : str
             Name of the array to add.
 
         deep_copy : bool
-            When True makes a full copy of the array.
+            When ``True`` makes a full copy of the array.
 
         active_vectors : bool
-            If True, make this the active vector array.
+            If ``True``, make this the active vector array.
 
-        active_scalars : bool:
-            If True, make this the active scalar array.
+        active_scalars : bool
+            If ``True``, make this the active scalar array.
         """
         if narray is None:
             raise TypeError('narray cannot be None.')
@@ -206,7 +209,6 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
             tmparray = np.empty(array_len)
             tmparray.fill(narray)
             narray = tmparray
-
         if narray.shape[0] != array_len:
             raise ValueError(f'narray length of ({narray.shape[0]}) != required length ({array_len})')
 

--- a/tests/test_datasetattributes.py
+++ b/tests/test_datasetattributes.py
@@ -279,3 +279,10 @@ def test_preserve_field_arrays_after_extract_cells(hexbeam, arr):
     hexbeam.field_arrays["foo"] = arr
     extracted = hexbeam.extract_cells([0, 1, 2, 3])
     assert "foo" in extracted.field_arrays
+
+
+def test_assign_labels_to_points(hexbeam):
+    hexbeam.point_arrays.clear()
+    labels = [f"Label {i}" for i in range(hexbeam.n_points)]
+    hexbeam['labels'] = labels
+    assert np.all(hexbeam.active_scalars == labels)


### PR DESCRIPTION
Resolves #1450.

VTK issues warnings when attempting to set non vtkDataArtray subclasses to be active attributes.  This PR changes the default behavior of our `active_scalars` setter to only set numeric and boolean types to be active on the VTK side.
