### PR TITLE
Deprecate `DataSet.vectors`

### DIFF
--- a/examples/01-filter/glyphs.py
+++ b/examples/01-filter/glyphs.py
@@ -50,7 +50,7 @@ vectors = np.vstack(
 ).T
 
 # add and scale
-sphere.vectors = vectors * 0.3
+sphere["vector"] = vectors * 0.3
 
 # plot just the arrows
 sphere.arrows.plot(scalars='GlyphScale')

--- a/examples/01-filter/glyphs.py
+++ b/examples/01-filter/glyphs.py
@@ -50,7 +50,8 @@ vectors = np.vstack(
 ).T
 
 # add and scale
-sphere["vector"] = vectors * 0.3
+sphere["vectors"] = vectors * 0.3
+sphere.set_active_vectors("vectors")
 
 # plot just the arrows
 sphere.arrows.plot(scalars='GlyphScale')

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -254,11 +254,11 @@ class DataSet(DataSetFilters, DataObject):
     def vectors(self, array: np.ndarray):
         """Set the active vector."""
         warnings.warn(
-            "Use of `DataSet.vectors` to add vector data is deprecated."
-            "Use `DataSet['my_vector_data'] = data or "
-            "DataSet.point_arrays['my_vector_data']=data or"
-            "DataSet.cell_arrays['my_vector_data']=data."
-            "Use DataSet.set_active_vectors_name to make active."
+            "Use of `DataSet.vectors` to add vector data is deprecated. "
+            "Use `DataSet['my_vector_data'] = data` or "
+            "`DataSet.point_arrays['my_vector_data']=data` or "
+            "`DataSet.cell_arrays['my_vector_data']=data`. "
+            "Use `DataSet.set_active_vectors` to make active."
             ,
             PyvistaDeprecationWarning
         )

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -255,10 +255,11 @@ class DataSet(DataSetFilters, DataObject):
         """Set the active vector."""
         warnings.warn(
             "Use of `DataSet.vectors` to add vector data is deprecated. "
-            "Use `DataSet['my_vector_data'] = data` or "
-            "`DataSet.point_arrays['my_vector_data']=data` or "
-            "`DataSet.cell_arrays['my_vector_data']=data`. "
-            "Use `DataSet.set_active_vectors` to make active."
+            "Use `DataSet['vector_name'] = data` or "
+            "`DataSet.point_arrays['vector_name'] = data` or "
+            "`DataSet.cell_arrays['vector_name'] = data`. "
+            "Use `DataSet.set_active_vectors('vector_name')` or "
+            "`DataSet.active_vectors_name = 'vector_name' to make active."
             ,
             PyvistaDeprecationWarning
         )

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -253,13 +253,9 @@ class DataSet(DataSetFilters, DataObject):
     @vectors.setter
     def vectors(self, array: np.ndarray):
         """Set the active vector."""
-        warnings.warn(
-            "Use of `DataSet.vectors` to add vector data is deprecated. "
-            "Use `DataSet['vector_name'] = data` or "
-            "`DataSet.point_arrays['vector_name'] = data` or "
-            "`DataSet.cell_arrays['vector_name'] = data`. "
-            "Use `DataSet.set_active_vectors('vector_name')` or "
-            "`DataSet.active_vectors_name = 'vector_name' to make active."
+        warnings.warn("Use of `DataSet.vectors` to add vector data is deprecated. "
+            "Use `DataSet['vector_name'] = data`. "
+            "Use `DataSet.active_vectors_name = 'vector_name' to make active."
             ,
             PyvistaDeprecationWarning
         )

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -244,8 +244,8 @@ class DataSet(DataSetFilters, DataObject):
     @property
     def vectors(self) -> Optional[pyvista_ndarray]:
         """Return active vectors."""
-        warnings.warn(
-            "Use of `DataSet.vectors` is deprecated.  Use `DataSet.active_vectors` instead.",
+        warnings.warn( "Use of `DataSet.vectors` is deprecated. "
+            "Use `DataSet.active_vectors` instead.",
             PyvistaDeprecationWarning
         )
         return self.active_vectors

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -3,6 +3,7 @@
 import collections.abc
 import logging
 from typing import Optional, List, Tuple, Iterable, Union, Any, Dict
+import warnings
 
 import numpy as np
 
@@ -11,6 +12,7 @@ from pyvista import _vtk
 from pyvista.utilities import (FieldAssociation, get_array, is_pyvista_dataset,
                                raise_not_matching, vtk_id_list_to_array,
                                abstract_class, axis_rotation, transformations)
+from pyvista.utilities.misc import PyvistaDeprecationWarning
 from .dataobject import DataObject
 from .datasetattributes import DataSetAttributes
 from .filters import DataSetFilters, _get_output
@@ -242,11 +244,24 @@ class DataSet(DataSetFilters, DataObject):
     @property
     def vectors(self) -> Optional[pyvista_ndarray]:
         """Return active vectors."""
+        warnings.warn(
+            "Use of `DataSet.vectors` is deprecated.  Use `DataSet.active_vectors` instead.",
+            PyvistaDeprecationWarning
+        )
         return self.active_vectors
 
     @vectors.setter
     def vectors(self, array: np.ndarray):
         """Set the active vector."""
+        warnings.warn(
+            "Use of `DataSet.vectors` to add vector data is deprecated."
+            "Use `DataSet['my_vector_data'] = data or "
+            "DataSet.point_arrays['my_vector_data']=data or"
+            "DataSet.cell_arrays['my_vector_data']=data."
+            "Use DataSet.set_active_vectors_name to make active."
+            ,
+            PyvistaDeprecationWarning
+        )
         if array.ndim != 2:
             raise ValueError('vector array must be a 2-dimensional array')
         elif array.shape[1] != 3:

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -3081,6 +3081,7 @@ class DataSetFilters:
         --------
         Translate a mesh by ``(50, 100, 200)``.
 
+        >>> import numpy as np
         >>> from pyvista import examples
         >>> mesh = examples.load_airplane()
 

--- a/pyvista/examples/examples.py
+++ b/pyvista/examples/examples.py
@@ -270,7 +270,8 @@ def load_sphere_vectors():
     ).T
 
     # add and scale
-    sphere.vectors = vectors * 0.3
+    sphere["vectors"] = vectors * 0.3
+    sphere.set_active_vectors = "vectors"
     return sphere
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -451,13 +451,13 @@ def test_texture_airplane():
 
 def test_invalid_vector(grid):
     with pytest.raises(ValueError):
-        grid.vectors = np.empty(10)
+        grid["vectors"] = np.empty(10)
 
     with pytest.raises(ValueError):
-        grid.vectors = np.empty((3, 2))
+        grid["vectors"] = np.empty((3, 2))
 
     with pytest.raises(ValueError):
-        grid.vectors = np.empty((3, 3))
+        grid["vectors"] = np.empty((3, 3))
 
 
 def test_no_t_coords(grid):
@@ -468,7 +468,7 @@ def test_no_arrows(grid):
     assert grid.arrows is None
 
 
-def test_arrows(grid):
+def test_arrows():
     sphere = pyvista.Sphere(radius=3.14)
 
     # make cool swirly pattern
@@ -477,16 +477,16 @@ def test_arrows(grid):
                          np.cos(sphere.points[:, 2]))).T
 
     # add and scales
-    sphere.vectors = vectors*0.3
+    sphere["vectors"] = vectors*0.3
+    sphere.set_active_vectors("vectors")
     assert np.allclose(sphere.active_vectors, vectors*0.3)
-    assert np.allclose(sphere.vectors, vectors*0.3)
+    assert np.allclose(sphere["vectors"], vectors*0.3)
 
-    assert sphere.active_vectors_info[1] == '_vectors'
+    assert sphere.active_vectors_info[1] == 'vectors'
     arrows = sphere.arrows
     assert isinstance(arrows, pyvista.PolyData)
     assert np.any(arrows.points)
-    sphere.set_active_vectors('_vectors')
-    assert sphere.active_vectors_name == '_vectors'
+    assert arrows.active_vectors_name == 'vectors'
 
 
 def active_component_consistency_check(grid, component_type, field_association="point"):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -481,14 +481,15 @@ def test_cell_centers_composite(composite):
 
 def test_glyph(datasets, sphere):
     for i, dataset in enumerate(datasets):
-        dataset.vectors = np.ones_like(dataset.points)
+        dataset["vectors"] = np.ones_like(dataset.points)
         result = dataset.glyph()
         assert result is not None
         assert isinstance(result, pyvista.PolyData)
     # Test different options for glyph filter
     sphere_sans_arrays = sphere.copy()
     sphere.compute_normals(inplace=True)
-    sphere.vectors = np.ones([sphere.n_points,3])
+    sphere["vectors"] = np.ones([sphere.n_points,3])
+    sphere.set_active_vectors("vectors")
     sphere.point_arrays['arr'] = np.ones(sphere.n_points)
 
     assert sphere.glyph(scale=False)
@@ -765,8 +766,9 @@ def test_streamlines_from_source_structured_grids():
         np.arange(-1, 1, 0.5), np.arange(-1, 1, 0.5), np.arange(-1, 1, 0.5)
     )
     mesh2 = pyvista.StructuredGrid(x2, y2, z2)
-    mesh.vectors = np.ones([mesh.n_points, 3])
-    
+    mesh["vectors"]= np.ones([mesh.n_points, 3])
+    mesh.set_active_vectors("vectors")
+
     with pyvista.VtkErrorCatcher(raise_errors=True):
         stream = mesh.streamlines_from_source(mesh2)
     assert all([stream.n_points, stream.n_cells])


### PR DESCRIPTION
### Overview

As discussed in #1430, this PR deprecates the usage of `DataSet.vectors` to set and retrieve vector data.  Today, pyvista does not explicitly distinguish between vector and scalar data other than `DataSet.active_vectors` and related methods.

The `DataSet.vectors` usage is a simple shorthand for 

```py
DataSet['_vectors'] = data
DataSet.active_vectors_name = "_vectors"
```

This however leads to confusion as there is no special method for setting/retrieving scalars, tensors, etc.... (see https://github.com/pyvista/pyvista-support/issues/448). It is also unintuitive to have a key with a leading underscore, which suggest that this shouldn't be used by users.


### Details

Related to #1431, but not directly.

Closes #1430.

The warning message looks like:

```txt
pyvista/pyvista/core/dataset.py:256: PyvistaDeprecationWarning: Use of `DataSet.vectors` to add vector data is deprecated. Use `DataSet['vector_name'] = data` or `DataSet.point_arrays['vector_name'] = data` or `DataSet.cell_arrays['vector_name'] = data`. Use `DataSet.set_active_vectors('vector_name')` or `DataSet.active_vectors_name = 'vector_name' to make active.
```

I'm not sure why there is a hanging `warnings.warn(` at the end.  I think I followed the same logic as the other deprecations in the codebase.
