### PR TITLE
Fix `Renderer.show_bounds()` docs

### DIFF
--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -603,14 +603,8 @@ class Renderer(_vtk.vtkRenderer):
         show_zlabels : bool, optional
             Shows z labels.  Default ``True``.
 
-        italic : bool, optional
-            Italicises axis labels and numbers.  Default ``False``.
-
         bold : bool, optional
             Bolds axis labels and numbers.  Default ``True``.
-
-        shadow : bool, optional
-            Adds a black shadow to the text.  Default ``False``.
 
         font_size : float, optional
             Sets the size of the label font.  Defaults to 16.
@@ -671,6 +665,13 @@ class Renderer(_vtk.vtkRenderer):
             If ``all_edges````, this is the factor along each axis to
             draw the default box. Default is 0.5 to show the full box.
 
+        fmt : str, optional
+            A format string defining how tick labels are generated from
+            tick positions. A default is looked up on the active theme.
+
+        minor_ticks : bool, optional
+            If ``True``, also plot minor ticks on all axes.
+
         padding : float, optional
             An optional percent padding along each axial direction to
             cushion the datasets in the scene from the axes
@@ -684,7 +685,6 @@ class Renderer(_vtk.vtkRenderer):
         Examples
         --------
         >>> import pyvista
-        >>> from pyvista import examples
         >>> mesh = pyvista.Sphere()
         >>> plotter = pyvista.Plotter()
         >>> actor = plotter.add_mesh(mesh)


### PR DESCRIPTION
The docs of `Renderer.show_bounds()` had a few kwargs that didn't exist, and it was missing a few kwargs that do exist. There was also an unnecessary import in the doctest.

In related news, I couldn't actually get the `fmt` kwarg to do anything using the VTK dev wheels. But if this is broken then that's probably not our fault. I know that it _could_ work in 2019: https://discourse.vtk.org/t/set-vtkcubeaxesactor-label-format-and-remove-exponent/457