### PR TITLE
Do not return cpos by default

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -24,6 +24,7 @@ pyvista.OFF_SCREEN = True  # Not necessary - simply an insurance policy
 # Preferred plotting style for documentation
 pyvista.set_plot_theme("document")
 pyvista.global_theme.window_size = np.array([1024, 768]) * 2
+pyvista.global_theme.return_cpos = False
 # Save figures in specified directory
 pyvista.FIGURE_PATH = os.path.join(os.path.abspath("./images/"), "auto-generated/")
 if not os.path.exists(pyvista.FIGURE_PATH):

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -43,7 +43,6 @@ warnings.filterwarnings(
 
 # -- General configuration ------------------------------------------------
 numfig = False
-html_show_sourcelink = False
 html_logo = "./_static/pyvista_logo_sm.png"
 
 sys.path.append(os.path.abspath("./_ext"))
@@ -234,7 +233,9 @@ html_theme_options = {
     ],
 }
 
-html_sidebars = {"**": ["search-field.html", "sidebar-nav-bs.html"]}
+# sphinx-panels shouldn't add bootstrap css since the pydata-sphinx-theme
+# already loads it
+panels_add_bootstrap_css = False
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,6 +25,7 @@ pyvista.OFF_SCREEN = True  # Not necessary - simply an insurance policy
 pyvista.set_plot_theme("document")
 pyvista.global_theme.window_size = np.array([1024, 768]) * 2
 pyvista.global_theme.return_cpos = False
+pyvista.set_jupyter_backend(None)
 # Save figures in specified directory
 pyvista.FIGURE_PATH = os.path.join(os.path.abspath("./images/"), "auto-generated/")
 if not os.path.exists(pyvista.FIGURE_PATH):

--- a/doc/user-guide/jupyter/ipyvtk_plotting.rst
+++ b/doc/user-guide/jupyter/ipyvtk_plotting.rst
@@ -28,7 +28,7 @@ within JupyterLab:
     sphere = pv.Sphere()
 
     # short example
-    cpos, image = sphere.plot(use_ipyvtk=True)
+    image = sphere.plot(use_ipyvtk=True, return_cpos=False)
 
     # long example
     plotter = pv.Plotter(notebook=True)

--- a/doc/user-guide/simple.rst
+++ b/doc/user-guide/simple.rst
@@ -153,15 +153,18 @@ execution of the code after calling ``show``.
     plotter.show()            # show the rendering window
 
 
-Note that the ``show`` method will return the last used camera position of the
-rendering window in case you want to chose a camera position and use it again
-later.
+Note that by default the ``show`` method will return the last used camera position
+of the rendering window in case you want to choose a camera position and use it
+again later. The camera position is also available as the ``camera_position``
+attribute of the plotter (even after it's closed).
 
 You can then use this cached camera for additional plotting without having to
 manually interact with the plotting window:
 
 .. code-block:: python
 
+    # reuse the camera position from the previous plotter
+    cpos = plotter.camera_position
     plotter = pv.Plotter(off_screen=True)
     plotter.add_mesh(mesh, color='tan')
     plotter.camera_position = cpos

--- a/doc/user-guide/simple.rst
+++ b/doc/user-guide/simple.rst
@@ -150,7 +150,7 @@ execution of the code after calling ``show``.
 
     plotter = pv.Plotter()    # instantiate the plotter
     plotter.add_mesh(mesh)    # add a mesh to the scene
-    cpos = plotter.show()     # show the rendering window
+    plotter.show()            # show the rendering window
 
 
 Note that the ``show`` method will return the last used camera position of the

--- a/doc/user-guide/what-is-a-mesh.rst
+++ b/doc/user-guide/what-is-a-mesh.rst
@@ -58,15 +58,15 @@ connectivity between nodes such as this gridded mesh:
     from pyvista import examples
 
     mesh = examples.load_hexbeam()
-    bcpos = [(6.20, 3.00, 7.50),
-             (0.16, 0.13, 2.65),
-             (-0.28, 0.94, -0.21)]
+    cpos = [(6.20, 3.00, 7.50),
+            (0.16, 0.13, 2.65),
+            (-0.28, 0.94, -0.21)]
 
     pl = pv.Plotter()
     pl.add_mesh(mesh, show_edges=True, color='white')
     pl.add_mesh(pv.PolyData(mesh.points), color='red',
            point_size=10, render_points_as_spheres=True)
-    pl.camera_position = bcpos
+    pl.camera_position = cpos
     pl.show()
 
 Or this triangulated surface:
@@ -140,7 +140,7 @@ plotting the values between nodes are interpolated across the cells.
 
     mesh.point_arrays['my point values'] = np.arange(mesh.n_points)
 
-    mesh.plot(scalars='my point values', cpos=bcpos,
+    mesh.plot(scalars='my point values', cpos=cpos,
               show_edges=True)
 
 
@@ -152,7 +152,7 @@ that attribute.
 .. jupyter-execute::
 
     mesh.cell_arrays['my cell values'] = np.arange(mesh.n_cells)
-    mesh.plot(scalars='my cell values', cpos=bcpos,
+    mesh.plot(scalars='my cell values', cpos=cpos,
               show_edges=True)
 
 

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -314,6 +314,7 @@ class PolyDataFilters(DataSetFilters):
         -------
         cpos : list
             List of camera position, focal point, and view up.
+            Returned when ``return_cpos`` is ``True``.
 
         Examples
         --------

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -494,8 +494,8 @@ class PointGrid(PointSet):
         Returns
         -------
         cpos : list
-            Camera position, focal point, and view up.  Used for storing and
-            setting camera view.
+            Camera position, focal point, and view up.  Returned when
+            ``return_cpos`` is ``True``.
 
         """
         trisurf = self.extract_surface().triangulate()

--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -100,19 +100,19 @@ def set_jupyter_backend(backend):
     Enable the ipygany backend.
 
     >>> import pyvista as pv
-    >>> pv.set_jupyter_backend('ipygany')
+    >>> pv.set_jupyter_backend('ipygany')  # doctest:+SKIP
 
     Enable the panel backend.
 
-    >>> pv.set_jupyter_backend('panel')
+    >>> pv.set_jupyter_backend('panel')  # doctest:+SKIP
 
     Enable the ipyvtklink backend.
 
-    >>> pv.set_jupyter_backend('ipyvtklink')
+    >>> pv.set_jupyter_backend('ipyvtklink')  # doctest:+SKIP
 
     Just show static images.
 
-    >>> pv.set_jupyter_backend('static')
+    >>> pv.set_jupyter_backend('static')  # doctest:+SKIP
 
     Disable all plotting within JupyterLab and display using a
     standard desktop VTK render window.

--- a/pyvista/jupyter/pv_ipygany.py
+++ b/pyvista/jupyter/pv_ipygany.py
@@ -115,7 +115,7 @@ def check_colormap(cmap):
 
     if cmap not in colormaps:
         allowed = ', '.join([f"'{clmp}'" for clmp in colormaps.keys()])
-        raise ValueError(f'``cmap`` "{cmap} is not supported by ``ipygany``\n'
+        raise ValueError(f'``cmap`` "{cmap}" is not supported by ``ipygany``\n'
                          'Pick from one of the following:\n'
                          + allowed)
     return cmap

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -13,7 +13,8 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
          show_bounds=False, show_axes=None, notebook=None, background=None,
          text='', return_img=False, eye_dome_lighting=False, volume=False,
          parallel_projection=False, use_ipyvtk=None, jupyter_backend=None,
-         return_viewer=False, jupyter_kwargs={}, theme=None, **kwargs):
+         return_viewer=False, return_cpos=False, jupyter_kwargs={},
+         theme=None, **kwargs):
     """Plot a vtk or numpy object.
 
     Parameters
@@ -77,6 +78,14 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
     jupyter_kwargs : dict, optional
         Keyword arguments for the Jupyter notebook plotting backend.
 
+    return_viewer : bool, optional
+        Return the jupyterlab viewer, scene, or display object
+        when plotting with jupyter notebook.
+
+    return_cpos : bool, optional
+        Return the last camera position from the render window
+        when enabled.  Default ``False``.
+
     theme : pyvista.themes.DefaultTheme, optional
         Plot-specific theme.
 
@@ -86,7 +95,8 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
     Returns
     -------
     cpos : list
-        List of camera position, focal point, and view up.
+        List of camera position, focal point, and view up.  Returned
+        only when ``return_cpos=True``.
 
     img : numpy.ndarray
         Array containing pixel RGB and optionally alpha values.
@@ -187,11 +197,15 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
                           jupyter_backend=jupyter_backend,
                           before_close_callback=before_close_callback,
                           jupyter_kwargs=jupyter_kwargs,
-                          return_viewer=return_viewer,
-                          return_cpos=return_cpos)
+                          return_viewer=return_viewer)
 
-    # Result will be handled by plotter.show(): cpos or [cpos, img] or
-    # the jupyterlab scene when return_viewer is True
+    # show will not return camera position, get this from the plotter
+    if return_cpos:
+        cpos_out = plotter.camera_position
+        if result is not None:
+            return cpos_out, result
+        return cpos_out
+
     return result
 
 

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -95,19 +95,23 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
     Returns
     -------
     cpos : list
-        List of camera position, focal point, and view up.  Returned
-        only when ``return_cpos=True``.
+        List of camera position, focal point, and view up.
+        Returned only when ``return_cpos=True`` or set in the
+        default global or plot theme.  Not returned when in a
+        jupyter notebook and ``return_viewer=True``.
 
-    img : numpy.ndarray
-        Array containing pixel RGB and optionally alpha values.
-        Sized:
+    image : np.ndarray
+        Numpy array of the last image when either ``return_img=True``
+        or ``screenshot=True`` is set. Optionally contains alpha
+        values. Sized:
 
         * [Window height x Window width x 3] if the theme sets
           ``transparent_background=False``.
         * [Window height x Window width x 4] if the theme sets
           ``transparent_background=True``.
 
-        Returned only when ``screenshot=True``.
+        Returned only when ``screenshot=True`` and not in a
+        jupyter notebook with ``return_viewer=True``.
 
     widget
         IPython widget when ``return_viewer=True``.

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -199,7 +199,8 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
                           jupyter_backend=jupyter_backend,
                           before_close_callback=before_close_callback,
                           jupyter_kwargs=jupyter_kwargs,
-                          return_viewer=return_viewer)
+                          return_viewer=return_viewer,
+                          return_cpos=return_cpos)
 
     # Result will be handled by plotter.show(): cpos or [cpos, img] or
     # the jupyterlab scene when return_viewer is True

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -109,6 +109,9 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
 
         Returned only when ``screenshot=True``.
 
+    widget
+        IPython widget when ``return_viewer=True``.
+
     Examples
     --------
     Plot a simple sphere while showing its edges.

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -102,16 +102,14 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
 
     image : np.ndarray
         Numpy array of the last image when either ``return_img=True``
-        or ``screenshot=True`` is set. Optionally contains alpha
-        values. Sized:
+        or ``screenshot=True`` is set. Not returned when in a
+        jupyter notebook with ``return_viewer=True``. Optionally
+        contains alpha values. Sized:
 
         * [Window height x Window width x 3] if the theme sets
           ``transparent_background=False``.
         * [Window height x Window width x 4] if the theme sets
           ``transparent_background=True``.
-
-        Returned only when ``screenshot=True`` and not in a
-        jupyter notebook with ``return_viewer=True``.
 
     widget
         IPython widget when ``return_viewer=True``.

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -84,7 +84,7 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
 
     return_cpos : bool, optional
         Return the last camera position from the render window
-        when enabled.  Default ``False``.
+        when enabled.  Defaults to value in theme settings.
 
     theme : pyvista.themes.DefaultTheme, optional
         Plot-specific theme.
@@ -187,27 +187,18 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
     if parallel_projection:
         plotter.enable_parallel_projection()
 
-    result = plotter.show(window_size=window_size,
-                          auto_close=auto_close,
-                          interactive=interactive,
-                          full_screen=full_screen,
-                          screenshot=screenshot,
-                          return_img=return_img,
-                          use_ipyvtk=use_ipyvtk,
-                          jupyter_backend=jupyter_backend,
-                          before_close_callback=before_close_callback,
-                          jupyter_kwargs=jupyter_kwargs,
-                          return_viewer=return_viewer)
-
-    # show will not return camera position, get this from the plotter
-    if return_cpos:
-        cpos_out = plotter.camera_position
-        if result is not None:
-            return cpos_out, result
-        return cpos_out
-
-    return result
-
+    return plotter.show(window_size=window_size,
+                        auto_close=auto_close,
+                        interactive=interactive,
+                        full_screen=full_screen,
+                        screenshot=screenshot,
+                        return_img=return_img,
+                        use_ipyvtk=use_ipyvtk,
+                        jupyter_backend=jupyter_backend,
+                        before_close_callback=before_close_callback,
+                        jupyter_kwargs=jupyter_kwargs,
+                        return_viewer=return_viewer,
+                        return_cpos=return_cpos)
 
 def plot_arrows(cent, direction, **kwargs):
     """Plot arrows as vectors.

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -13,25 +13,26 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
          show_bounds=False, show_axes=None, notebook=None, background=None,
          text='', return_img=False, eye_dome_lighting=False, volume=False,
          parallel_projection=False, use_ipyvtk=None, jupyter_backend=None,
-         return_viewer=False, jupyter_kwargs={}, theme=None, **kwargs):
+         return_viewer=False, return_cpos=False, jupyter_kwargs={},
+         theme=None, **kwargs):
     """Plot a vtk or numpy object.
 
     Parameters
     ----------
-    item : vtk or numpy object
-        VTK object or ``numpy`` array to be plotted.
+    item : pyvista.DataSet, pyvista.MultiBlock, or numpy.ndarray
+        PyVista, VTK object, or ``numpy`` array to be plotted.
 
-    off_screen : bool
-        Plots off screen when ``True``.  Helpful for saving screenshots
-        without a window popping up.
+    off_screen : bool, optional
+        Plots off screen when ``True``.  Helpful for saving
+        screenshots without a window popping up.
 
     full_screen : bool, optional
         Opens window in full screen.  When enabled, ignores
         ``window_size``.  Default ``False``.
 
     screenshot : str or bool, optional
-        Saves screenshot to file when enabled.  See:
-        ``help(pyvista.Plotter.screenshot)``.  Default ``False``.
+        Saves screenshot to file when enabled. See
+        :func:`pyvista.Plotter.screenshot`.  Default ``False``.
 
         When ``True``, takes screenshot and returns ``numpy`` array of
         image.
@@ -72,7 +73,14 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
         * ``'panel'`` : Show a ``panel`` widget.
 
         This can also be set globally with
-        ``pyvista.set_jupyter_backend``
+        :func:`pyvista.set_jupyter_backend`.
+
+    return_viewer : bool, optional
+        Return the jupyterlab viewer, scene, or display object
+        when plotting with jupyter notebook.
+
+    return_cpos : bool, optional
+        Return the camera position when enabled.  Default ``False``.
 
     jupyter_kwargs : dict, optional
         Keyword arguments for the Jupyter notebook plotting backend.
@@ -85,19 +93,23 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
 
     Returns
     -------
-    cpos : list
-        List of camera position, focal point, and view up.
+    list
+        List of camera position, focal point, and view up.  Only
+        returned when ``return_cpos=True``.
 
-    img : numpy.ndarray
+    numpy.ndarray
         Array containing pixel RGB and optionally alpha values.
         Sized:
 
-        * [Window height x Window width x 3] if the theme sets
+        * ``[Window height x Window width x 3]`` if the theme sets
           ``transparent_background=False``.
-        * [Window height x Window width x 4] if the theme sets
+        * ``[Window height x Window width x 4]`` if the theme sets
           ``transparent_background=True``.
 
         Returned only when ``screenshot=True``.
+
+    widget
+        IPython widget when ``return_viewer=True``.
 
     Examples
     --------
@@ -105,7 +117,7 @@ def plot(var_item, off_screen=None, full_screen=False, screenshot=None,
 
     >>> import pyvista
     >>> mesh = pyvista.Sphere()
-    >>> mesh.plot(show_edges=True)  # doctest:+SKIP
+    >>> mesh.plot(show_edges=True)
 
     """
     if notebook is None:
@@ -204,14 +216,14 @@ def plot_arrows(cent, direction, **kwargs):
 
     directions : np.ndarray
         Accepts a single 3d point or array of 3d vectors.
-        Must contain the same number of items as cent.
+        Must contain the same number of items as ``cent``.
 
     **kwargs : additional arguments, optional
-        See ``help(pyvista.plot)``.
+        See :func:`pyvista.plot`.
 
     Returns
     -------
-    Same as ``pyvista.plot``.  See ``help(pyvista.plot)``.
+    Same as ``pyvista.plot``.  See :func:`pyvista.plot`.
 
     Examples
     --------

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4011,6 +4011,17 @@ class Plotter(BasePlotter):
 
         >>> pl.show(jupyter_backend='ipygany', return_viewer=True)  # doctest:+SKIP
 
+        Obtain the camera position after closing the plotter
+
+        >>> pl = pyvista.Plotter()
+        >>> _ = pl.add_mesh(pyvista.Sphere())
+        >>> pl.show()   # doctest:+SKIP
+        >>> pl.camera_position  # doctest:+SKIP
+        [(2.223005211686484, -0.3126909484828709, 2.4686209867735065),
+        (0.0, 0.0, 0.0),
+        (-0.6839951597283509, -0.47207319712073137, 0.5561452310578585)]
+
+
         """
         # developer keyword argument: runs a function immediately prior to ``close``
         self._before_close_callback = kwargs.pop('before_close_callback', None)
@@ -4132,7 +4143,7 @@ class Plotter(BasePlotter):
         #       See issues #135 and #186 for insight before editing the
         #       remainder of this function.
 
-        # Get camera position before closing
+        # Get camera position before closing.  This caches the camera position
         cpos = self.camera_position
 
         # Cleanup
@@ -4142,11 +4153,7 @@ class Plotter(BasePlotter):
         # If user asked for screenshot, return as numpy array after camera
         # position
         if return_img or screenshot is True:
-            return cpos, self.last_image
-
-        # Return last used camera position unless within a doctest
-        if '_pytest.doctest' not in sys.modules:
-            return cpos
+            return self.last_image
 
     def add_title(self, title, font_size=18, color=None, font=None,
                   shadow=False):

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4054,7 +4054,8 @@ class Plotter(BasePlotter):
         cpos : list
             List of camera position, focal point, and view up.
             Returned only when ``return_cpos=True`` or set in the
-            default global or plot theme.
+            default global or plot theme.  Not returned when in a
+            jupyter notebook and ``return_viewer=True``.
 
         image : np.ndarray
             Numpy array of the last image when either ``return_img=True``
@@ -4065,6 +4066,9 @@ class Plotter(BasePlotter):
               ``transparent_background=False``.
             * [Window height x Window width x 4] if the theme sets
               ``transparent_background=True``.
+
+            Returned only when ``screenshot=True`` and not in a
+            jupyter notebook with ``return_viewer=True``.
 
         widget
             IPython widget when ``return_viewer=True``.

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4017,7 +4017,7 @@ class Plotter(BasePlotter):
             it's recommended to first call ``show()`` with
             ``auto_close=False`` to set the scene, then save the
             screenshot in a separate call to ``show()`` or
-            :func:`Plotter.screenshot()`.
+            :func:`Plotter.screenshot`.
 
         return_img : bool
             Returns a numpy array representing the last image along
@@ -4038,7 +4038,7 @@ class Plotter(BasePlotter):
             * ``'panel'`` : Show a ``panel`` widget.
 
             This can also be set globally with
-            :func:`pyvista.set_jupyter_backend`
+            :func:`pyvista.set_jupyter_backend`.
 
         return_viewer : bool, optional
             Return the jupyterlab viewer, scene, or display object

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3630,8 +3630,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
         only_active : bool, optional
             If ``True``, only add the light to the active
             renderer. The default is that every renderer adds the
-            light. To add the light to an arbitrary renderer, see the
-            ``add_light`` method of the Renderer class.
+            light. To add the light to an arbitrary renderer, see
+            :func:`pyvista.plotting.renderer.Renderer.add_light`.
 
         Examples
         --------

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4013,14 +4013,13 @@ class Plotter(BasePlotter):
 
         Obtain the camera position after closing the plotter
 
-        >>> pl = pyvista.Plotter()
+        >>> pl = pv.Plotter()
         >>> _ = pl.add_mesh(pyvista.Sphere())
         >>> pl.show()   # doctest:+SKIP
         >>> pl.camera_position  # doctest:+SKIP
         [(2.223005211686484, -0.3126909484828709, 2.4686209867735065),
         (0.0, 0.0, 0.0),
         (-0.6839951597283509, -0.47207319712073137, 0.5561452310578585)]
-
 
         """
         # developer keyword argument: runs a function immediately prior to ``close``

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3895,7 +3895,7 @@ class Plotter(BasePlotter):
     def show(self, title=None, window_size=None, interactive=True,
              auto_close=None, interactive_update=False, full_screen=None,
              screenshot=False, return_img=False, cpos=None, use_ipyvtk=None,
-             jupyter_backend=None, return_viewer=False, **kwargs):
+             jupyter_backend=None, return_viewer=False, return_cpos=False, **kwargs):
         """Display the plotting window.
 
         Notes
@@ -3966,19 +3966,24 @@ class Plotter(BasePlotter):
             Return the jupyterlab viewer, scene, or display object
             when plotting with jupyter notebook.
 
+        return_cpos : bool, optional
+            Return the camera position when enabled.  Default
+            ``False``.
+
         Returns
         -------
-        cpos : list
-            List of camera position, focal point, and view up.
+        list
+            List of camera position, focal point, and view up.  Only
+            returned when ``return_cpos=True``.
 
-        image : np.ndarray
+        numpy.ndarray
             Numpy array of the last image when either ``return_img=True``
             or ``screenshot=True`` is set. Optionally contains alpha
             values. Sized:
 
-            * [Window height x Window width x 3] if the theme sets
+            * ``[Window height x Window width x 3]`` if the theme sets
               ``transparent_background=False``.
-            * [Window height x Window width x 4] if the theme sets
+            * ``[Window height x Window width x 4]`` if the theme sets
               ``transparent_background=True``.
 
         widget
@@ -4139,13 +4144,15 @@ class Plotter(BasePlotter):
         if auto_close:
             self.close()
 
-        # If user asked for screenshot, return as numpy array after camera
-        # position
+        # If user requested screenshot return the last image
         if return_img or screenshot is True:
-            return cpos, self.last_image
+            if return_cpos:
+                return cpos, self.last_image
+            else:
+                self.last_image
 
         # Return last used camera position unless within a doctest
-        if '_pytest.doctest' not in sys.modules:
+        if return_cpos:
             return cpos
 
     def add_title(self, title, font_size=18, color=None, font=None,

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3966,7 +3966,8 @@ class Plotter(BasePlotter):
     def show(self, title=None, window_size=None, interactive=True,
              auto_close=None, interactive_update=False, full_screen=None,
              screenshot=False, return_img=False, cpos=None, use_ipyvtk=None,
-             jupyter_backend=None, return_viewer=False, **kwargs):
+             jupyter_backend=None, return_viewer=False, return_cpos=None,
+             **kwargs):
         """Display the plotting window.
 
         Notes
@@ -3978,29 +3979,35 @@ class Plotter(BasePlotter):
         Parameters
         ----------
         title : string, optional
-            Title of plotting window.
+            Title of plotting window.  Defaults to
+            :attr:`pyvista.themes.DefaultTheme.title`.
 
         window_size : list, optional
-            Window size in pixels.  Defaults to ``[1024, 768]``
+            Window size in pixels.  Defaults to
+            :attr:`pyvista.themes.DefaultTheme.window_size`.
 
         interactive : bool, optional
             Enabled by default.  Allows user to pan and move figure.
+            Defaults to
+            :attr:`pyvista.themes.DefaultTheme.interacitve`.
 
         auto_close : bool, optional
-            Enabled by default.  Exits plotting session when user
-            closes the window when interactive is ``True``.
+            Exits plotting session when user closes the window when
+            interactive is ``True``.  Defaults to
+            :attr:`pyvista.themes.DefaultTheme.auto_close`.
 
         interactive_update: bool, optional
             Disabled by default.  Allows user to non-blocking draw,
-            user should call ``Update()`` in each iteration.
+            user should call :func:`BasePlotter.update` in each iteration.
 
         full_screen : bool, optional
             Opens window in full screen.  When enabled, ignores
-            ``window_size``.  Default ``False``.
+            ``window_size``.  Defaults to
+            :attr:`pyvista.themes.DefaultTheme.full_screen`.
 
         cpos : list(tuple(floats))
             The camera position.  You can also set this with
-            ``Plotter.camera_position``.
+            :attr:`Plotter.camera_position`.
 
         screenshot : str or bool, optional
             Take a screenshot of the initial state of the plot.
@@ -4010,7 +4017,7 @@ class Plotter(BasePlotter):
             it's recommended to first call ``show()`` with
             ``auto_close=False`` to set the scene, then save the
             screenshot in a separate call to ``show()`` or
-            ``screenshot()``.
+            :func:`Plotter.screenshot()`.
 
         return_img : bool
             Returns a numpy array representing the last image along
@@ -4031,16 +4038,23 @@ class Plotter(BasePlotter):
             * ``'panel'`` : Show a ``panel`` widget.
 
             This can also be set globally with
-            ``pyvista.set_jupyter_backend``
+            :func:`pyvista.set_jupyter_backend`
 
         return_viewer : bool, optional
             Return the jupyterlab viewer, scene, or display object
             when plotting with jupyter notebook.
 
+        return_cpos : bool, optional
+            Return the last camera position from the render window
+            when enabled.  Default based on theme setting.  See
+            :attr:`pyvista.themes.DefaultTheme.return_cpos`.
+
         Returns
         -------
         cpos : list
             List of camera position, focal point, and view up.
+            Returned only when ``return_cpos=True`` or set in the
+            default global or plot theme.
 
         image : np.ndarray
             Numpy array of the last image when either ``return_img=True``
@@ -4082,12 +4096,11 @@ class Plotter(BasePlotter):
 
         >>> pl.show(jupyter_backend='ipygany', return_viewer=True)  # doctest:+SKIP
 
-        Obtain the camera position after closing the plotter
+        Obtain the camera position when using ``show``.
 
         >>> pl = pv.Plotter()
         >>> _ = pl.add_mesh(pv.Sphere())
-        >>> pl.show()   # doctest:+SKIP
-        >>> pl.camera_position  # doctest:+SKIP
+        >>> pl.show(return_cpos=True)   # doctest:+SKIP
         [(2.223005211686484, -0.3126909484828709, 2.4686209867735065),
         (0.0, 0.0, 0.0),
         (-0.6839951597283509, -0.47207319712073137, 0.5561452310578585)]
@@ -4213,17 +4226,18 @@ class Plotter(BasePlotter):
         #       See issues #135 and #186 for insight before editing the
         #       remainder of this function.
 
-        # Get camera position before closing.  This caches the camera position
-        cpos = self.camera_position
-
-        # Cleanup
+        # Close the render window if requested
         if auto_close:
             self.close()
 
         # If user asked for screenshot, return as numpy array after camera
         # position
         if return_img or screenshot is True:
-            return self.last_image
+            if return_cpos:
+                return self.camera_position, self.last_image
+
+        if return_cpos:
+            return self.camera_position
 
     def add_title(self, title, font_size=18, color=None, font=None,
                   shadow=False):

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4059,16 +4059,14 @@ class Plotter(BasePlotter):
 
         image : np.ndarray
             Numpy array of the last image when either ``return_img=True``
-            or ``screenshot=True`` is set. Optionally contains alpha
-            values. Sized:
+            or ``screenshot=True`` is set. Not returned when in a
+            jupyter notebook with ``return_viewer=True``. Optionally
+            contains alpha values. Sized:
 
             * [Window height x Window width x 3] if the theme sets
               ``transparent_background=False``.
             * [Window height x Window width x 4] if the theme sets
               ``transparent_background=True``.
-
-            Returned only when ``screenshot=True`` and not in a
-            jupyter notebook with ``return_viewer=True``.
 
         widget
             IPython widget when ``return_viewer=True``.

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1140,7 +1140,8 @@ class DefaultTheme(_ThemeConfig):
                  '_smooth_shading',
                  '_depth_peeling',
                  '_silhouette',
-                 '_slider_styles']
+                 '_slider_styles',
+                 '_return_cpos']
 
     def __init__(self):
         """Initialize the theme."""
@@ -1201,6 +1202,23 @@ class DefaultTheme(_ThemeConfig):
         self._depth_peeling = _DepthPeelingConfig()
         self._silhouette = _SilhouetteConfig()
         self._slider_styles = _SliderConfig()
+        self._return_cpos = True
+
+    @property
+    def return_cpos(self) -> bool:
+        """Return or set the default behavior of returning the camera position.
+
+        Examples
+        --------
+        Disable returning camera position.
+
+        >>> import pyvista
+        >>> pyvista.global_theme.return_cpos = False
+        """
+
+    @return_cpos.setter
+    def return_cpos(self, value: bool):
+        self._return_cpos = value
 
     @property
     def background(self):
@@ -1985,6 +2003,7 @@ class DefaultTheme(_ThemeConfig):
             'Depth peeling': 'depth_peeling',
             'Silhouette': 'silhouette',
             'Slider Styles': 'slider_styles',
+            'Return Camera Position': 'return_cpos',
         }
         for name, attr in parm.items():
             setting = getattr(self, attr)
@@ -2187,6 +2206,7 @@ class DocumentTheme(DefaultTheme):
         self.axes.x_color = 'tomato'
         self.axes.y_color = 'seagreen'
         self.axes.z_color = 'blue'
+        self.return_cpos = False
 
 
 class _TestingTheme(DefaultTheme):
@@ -2195,6 +2215,10 @@ class _TestingTheme(DefaultTheme):
     Necessary for image regression.  Xvfb doesn't support
     multi-sampling, it's disabled for consistency between desktops and
     remote testing.
+
+    Also disables ``return_cpos`` to make it easier for us to write
+    examples without returning camera positions.
+
     """
 
     def __init__(self):
@@ -2203,6 +2227,7 @@ class _TestingTheme(DefaultTheme):
         self.multi_samples = 1
         self.window_size = [400, 400]
         self.axes.show = False
+        self.return_cpos = False
 
 
 class _ALLOWED_THEMES(Enum):

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -2206,7 +2206,6 @@ class DocumentTheme(DefaultTheme):
         self.axes.x_color = 'tomato'
         self.axes.y_color = 'seagreen'
         self.axes.z_color = 'blue'
-        self.return_cpos = False
 
 
 class _TestingTheme(DefaultTheme):

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1210,7 +1210,7 @@ class DefaultTheme(_ThemeConfig):
 
         Examples
         --------
-        Disable returning camera position.
+        Disable returning camera position by ``show`` and `plot`` methods.
 
         >>> import pyvista
         >>> pyvista.global_theme.return_cpos = False

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1277,19 +1277,19 @@ class DefaultTheme(_ThemeConfig):
         Enable the ipygany backend.
 
         >>> import pyvista as pv
-        >>> pv.set_jupyter_backend('ipygany')
+        >>> pv.set_jupyter_backend('ipygany')  # doctest:+SKIP
 
         Enable the panel backend.
 
-        >>> pv.set_jupyter_backend('panel')
+        >>> pv.set_jupyter_backend('panel')  # doctest:+SKIP
 
         Enable the ipyvtklink backend.
 
-        >>> pv.set_jupyter_backend('ipyvtklink')
+        >>> pv.set_jupyter_backend('ipyvtklink')  # doctest:+SKIP
 
         Just show static images.
 
-        >>> pv.set_jupyter_backend('static')
+        >>> pv.set_jupyter_backend('static')  # doctest:+SKIP
 
         Disable all plotting within JupyterLab and display using a
         standard desktop VTK render window.

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,4 +1,3 @@
-
 cmocean
 colorcet
 imageio-ffmpeg
@@ -12,6 +11,7 @@ matplotlib
 mypy
 mypy-extensions
 panel
+param==1.10.1  # due to panel bug
 pydata-sphinx-theme
 pypandoc
 pytest-sphinx

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -15,5 +15,6 @@ sphinx_gallery
 trimesh
 ipyvtklink>=0.2.1
 panel
+param==1.10.1
 ipygany
 pytest-xdist

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -220,13 +220,14 @@ def test_plot(sphere, tmpdir):
                              interpolate_before_map=True,
                              screenshot=filename,
                              return_img=True,
-                             before_close_callback=verify_cache_image)
+                             before_close_callback=verify_cache_image,
+                             return_cpos=True)
     assert isinstance(cpos, pyvista.CameraPosition)
     assert isinstance(img, np.ndarray)
     assert os.path.isfile(filename)
 
     filename = pathlib.Path(str(tmp_dir.join('tmp2.png')))
-    cpos = pyvista.plot(sphere, screenshot=filename)
+    pyvista.plot(sphere, screenshot=filename)
 
     # Ensure it added a PNG extension by default
     assert filename.with_suffix(".png").is_file()
@@ -235,6 +236,11 @@ def test_plot(sphere, tmpdir):
     with pytest.raises(ValueError):
         filename = pathlib.Path(str(tmp_dir.join('tmp3.foo')))
         pyvista.plot(sphere, screenshot=filename)
+
+
+def test_plot_return_cpos(sphere):
+    cpos = sphere.plot(return_cpos=True)
+    assert isinstance(cpos, pyvista.CameraPosition)
 
 
 @skip_no_plotting
@@ -1983,3 +1989,6 @@ def test_plotter_image():
     plotter.store_image = True
     plotter.show()
     assert plotter.image.shape[:2] == wsz
+
+
+    

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -241,6 +241,7 @@ def test_plot(sphere, tmpdir):
 def test_plot_return_cpos(sphere):
     cpos = sphere.plot(return_cpos=True)
     assert isinstance(cpos, pyvista.CameraPosition)
+    assert sphere.plot(return_cpos=False) is None
 
 
 @skip_no_plotting
@@ -1989,6 +1990,3 @@ def test_plotter_image():
     plotter.store_image = True
     plotter.show()
     assert plotter.image.shape[:2] == wsz
-
-
-    

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -22,7 +22,7 @@ def test_export_single(tmpdir):
     plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
     plotter.add_mesh(data)
     plotter.export_vtkjs(filename)
-    cpos_out = plotter.show() # Export must be called before showing!
+    plotter.show() # Export must be called before showing!
     plotter.close()
     # Now make sure the file is there
     assert os.path.isfile(f'{filename}.vtkjs')
@@ -42,7 +42,7 @@ def test_export_multi(tmpdir):
     plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
     plotter.add_mesh(multi)
     plotter.export_vtkjs(filename, compress_arrays=True)
-    cpos_out = plotter.show() # Export must be called before showing!
+    plotter.show() # Export must be called before showing!
     plotter.close()
     # Now make sure the file is there
     assert os.path.isfile(f'{filename}.vtkjs')
@@ -56,7 +56,7 @@ def test_export_texture(tmpdir):
     plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
     plotter.add_mesh(data, texture=True)
     plotter.export_vtkjs(filename)
-    cpos_out = plotter.show() # Export must be called before showing!
+    plotter.show() # Export must be called before showing!
     plotter.close()
     # Now make sure the file is there
     assert os.path.isfile(f'{filename}.vtkjs')
@@ -70,7 +70,7 @@ def test_export_verts(tmpdir):
     plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
     plotter.add_mesh(data)
     plotter.export_vtkjs(filename)
-    cpos_out = plotter.show() # Export must be called before showing!
+    plotter.show() # Export must be called before showing!
     plotter.close()
     # Now make sure the file is there
     assert os.path.isfile(f'{filename}.vtkjs')
@@ -84,7 +84,7 @@ def test_export_color(tmpdir):
     plotter = pyvista.Plotter(off_screen=OFF_SCREEN)
     plotter.add_mesh(data, color='yellow')
     plotter.export_vtkjs(filename)
-    cpos_out = plotter.show() # Export must be called before showing!
+    plotter.show() # Export must be called before showing!
     plotter.close()
     # Now make sure the file is there
     assert os.path.isfile(f'{filename}.vtkjs')

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -267,9 +267,7 @@ def test_multi_ray_trace(sphere):
 
 @pytest.mark.skipif(not system_supports_plotting(), reason="Requires system to support plotting")
 def test_plot_curvature(sphere):
-    cpos = sphere.plot_curvature(off_screen=True)
-    # cpos is None within unit testing
-    assert cpos is None
+    sphere.plot_curvature(off_screen=True)
 
 
 def test_edge_mask(sphere):


### PR DESCRIPTION
This PR resolves #1467 by addressing the discussion in #1457 by not returning the camera position by default.

Also, fixes an issue that has been bothering me for our docs.  The sidebar is offset and removing ``html_show_sourcelink = False`` fixes it.  This is important as we make our API documentation one method per page and the sidebar gets clobbered without this fix.
