### PR TITLE
Add and improve examples

### DIFF
--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -226,7 +226,7 @@ class DataObject:
         >>> source = pv.UniformGrid((10, 10, 5))
         >>> target = pv.UniformGrid()
         >>> target.copy_structure(source)
-        >>> cpos = target.plot(show_edges=True)
+        >>> target.plot(show_edges=True)
 
         """
         self.CopyStructure(dataset)
@@ -241,7 +241,7 @@ class DataObject:
         >>> source = source.compute_cell_sizes()
         >>> target = pv.UniformGrid((10, 10, 5))
         >>> target.copy_attributes(source)
-        >>> cpos = target.plot(scalars='Volume', show_edges=True)
+        >>> target.plot(scalars='Volume', show_edges=True)
 
         """
         self.CopyAttributes(dataset)

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -228,7 +228,7 @@ class DataSetFilters:
         >>> pl = pv.Plotter()
         >>> _ = pl.add_mesh(sphere, scalars='implicit_distance', cmap='bwr')
         >>> _ = pl.add_mesh(plane, color='w', style='wireframe')
-        >>> cpos = pl.show()
+        >>> pl.show()
 
         """
         function = _vtk.vtkImplicitPolyDataDistance()
@@ -3196,7 +3196,7 @@ class DataSetFilters:
         ...                              [0, 0, 1, 200],
         ...                              [0, 0, 0, 1]])
         >>> transformed = mesh.transform(transform_matrix)
-        >>> cpos = transformed.plot(show_edges=True)
+        >>> transformed.plot(show_edges=True)
 
         """
         if isinstance(trans, _vtk.vtkMatrix4x4):
@@ -3284,7 +3284,7 @@ class DataSetFilters:
         >>> from pyvista import examples
         >>> mesh = examples.load_airplane()
         >>> mesh = mesh.reflect((0, 0, 1), point=(0, 0, -100))
-        >>> cpos = mesh.plot(show_edges=True)
+        >>> mesh.plot(show_edges=True)
 
         """
         t = transformations.reflection(normal, point=point)

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -321,7 +321,7 @@ class PolyDataFilters(DataSetFilters):
 
         >>> from pyvista import examples
         >>> hills = examples.load_random_hills()
-        >>> cpos = hills.plot_curvature(smooth_shading=True)
+        >>> hills.plot_curvature(smooth_shading=True)
 
         """
         kwargs.setdefault('scalar_bar_args',
@@ -1261,7 +1261,7 @@ class PolyDataFilters(DataSetFilters):
         >>> pl = pv.Plotter()
         >>> actor = pl.add_mesh(sphere)
         >>> actor = pl.add_mesh(path, line_width=5, color='k')
-        >>> cpos = pl.show()
+        >>> pl.show()
 
         """
         if not (0 <= start_vertex < poly_data.n_points and
@@ -1560,7 +1560,7 @@ class PolyDataFilters(DataSetFilters):
 
         >>> import pyvista as pv
         >>> sphere = pv.Sphere()
-        >>> cpos = sphere.plot_normals(mag=0.1)
+        >>> sphere.plot_normals(mag=0.1)
 
         """
         plotter = pyvista.Plotter(off_screen=kwargs.pop('off_screen', None),
@@ -1679,9 +1679,9 @@ class PolyDataFilters(DataSetFilters):
 
         >>> import pyvista as pv
         >>> sphere = pv.Sphere()
-        >>> cpos = sphere.plot_normals(mag=0.1)
+        >>> sphere.plot_normals(mag=0.1)
         >>> sphere.flip_normals()
-        >>> cpos = sphere.plot_normals(mag=0.1)
+        >>> sphere.plot_normals(mag=0.1)
 
         """
         if not poly_data.is_all_triangles:
@@ -1800,7 +1800,7 @@ class PolyDataFilters(DataSetFilters):
         You can also plot the arc_length
 
         >>> arc = path.compute_arc_length()
-        >>> cpos = arc.plot(scalars="arc_length")
+        >>> arc.plot(scalars="arc_length")
 
         """
         alg = _vtk.vtkAppendArcLength()
@@ -1889,7 +1889,7 @@ class PolyDataFilters(DataSetFilters):
         >>> sphere = pv.Sphere()
         >>> path = sphere.geodesic(0, 100)
         >>> ribbon = path.ribbon()
-        >>> cpos = pv.plot([sphere, ribbon])
+        >>> pv.plot([sphere, ribbon])
 
         Notes
         -----
@@ -1977,7 +1977,7 @@ class PolyDataFilters(DataSetFilters):
         >>> import pyvista
         >>> arc = pyvista.CircularArc([-1, 0, 0], [1, 0, 0], [0, 0, 0])
         >>> mesh = arc.extrude([0, 0, 1])
-        >>> cpos = mesh.plot()
+        >>> mesh.plot()
 
         """
         alg = _vtk.vtkLinearExtrusionFilter()
@@ -2051,7 +2051,7 @@ class PolyDataFilters(DataSetFilters):
         >>> import pyvista
         >>> line = pyvista.Line(pointa=(0, 0, 0), pointb=(1, 0, 0))
         >>> mesh = line.extrude_rotate(resolution = 4)
-        >>> cpos = mesh.plot()
+        >>> mesh.plot()
 
         """
         if resolution <= 0:

--- a/pyvista/examples/examples.py
+++ b/pyvista/examples/examples.py
@@ -141,7 +141,7 @@ def beam_example(off_screen=None, notebook=None):
                      rng=[-d.max(), d.max()], cmap=cmap)
     plotter.camera_position = cpos
     plotter.add_text('Static Beam Example')
-    cpos = plotter.show()  # store camera position
+    plotter.show()
 
 
 def plot_wave(fps=30, frequency=1, wavetime=3, interactive=False,

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -221,7 +221,7 @@ def plot_arrows(cent, direction, **kwargs):
     >>> import pyvista
     >>> cent = np.random.random(3)
     >>> direction = np.random.random(3)
-    >>> cpos = pyvista.plot_arrows(cent, direction)
+    >>> pyvista.plot_arrows(cent, direction)
 
     Plot 100 random arrows.
 
@@ -229,7 +229,7 @@ def plot_arrows(cent, direction, **kwargs):
     >>> import pyvista
     >>> cent = np.random.random((100, 3))
     >>> direction = np.random.random((100, 3))
-    >>> cpos = pyvista.plot_arrows(cent, direction)
+    >>> pyvista.plot_arrows(cent, direction)
 
     """
     return plot([cent, direction], **kwargs)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3402,7 +3402,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> _ = plotter.add_mesh(mesh)
         >>> _ = plotter.add_mesh(othermesh, 'k')
         >>> _ = plotter.add_legend(legend_entries)
-        >>> cpos = plotter.show()
+        >>> plotter.show()
 
         """
         self.legend = _vtk.vtkLegendBoxActor()
@@ -3642,7 +3642,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> plotter = pyvista.Plotter()
         >>> actor = plotter.add_mesh(pyvista.Sphere())
         >>> plotter.add_background_image(examples.mapfile)
-        >>> cpos = plotter.show()
+        >>> plotter.show()
 
         """
         if self.renderers.has_active_background_renderer:
@@ -3707,7 +3707,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> _ = plotter.add_mesh(pv.Cube())
         >>> light = pv.Light(color='cyan', light_type='headlight')
         >>> plotter.add_light(light)
-        >>> cpos = plotter.show()
+        >>> plotter.show()
 
         """
         renderers = [self.renderer] if only_active else self.renderers
@@ -3859,7 +3859,7 @@ class Plotter(BasePlotter):
     >>> plotter = pyvista.Plotter()
     >>> actor = plotter.add_mesh(mesh, color='red')
     >>> actor = plotter.add_mesh(another_mesh, color='blue')
-    >>> cpos = plotter.show()
+    >>> plotter.show()
 
     """
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1,4 +1,4 @@
-"""PyVista plotting module."""
+r"""PyVista plotting module."""
 
 import sys
 import pathlib
@@ -637,10 +637,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.renderer.reset_camera(*args, **kwargs)
         self.render()
 
-    @wraps(Renderer.isometric_view)
-    def isometric_view(self, *args, **kwargs):
-        """Wrap ``Renderer.isometric_view``."""
-        return self.renderer.isometric_view(*args, **kwargs)
+    def isometric_view(self):
+        """DEPRECATED: Please use ``view_isometric``."""
+        from pyvista.core.errors import DeprecationError
+        raise DeprecationError('Please use ``view_isometric``.')
 
     @wraps(Renderer.view_isometric)
     def view_isometric(self, *args, **kwarg):

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1,4 +1,4 @@
-r"""PyVista plotting module."""
+"""PyVista plotting module."""
 
 import sys
 import pathlib
@@ -344,8 +344,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> _ = pl.add_mesh(pyvista.Cube())
         >>> pl.show()
         >>> image = pl.last_image
-        >>> type(image)
-        numpy.ndarray
+        >>> type(image)  # doctest:+SKIP
+        <class 'numpy.ndarray'>
 
         """
         return self._store_image
@@ -638,7 +638,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.render()
 
     def isometric_view(self):
-        """DEPRECATED: Please use ``view_isometric``."""
+        """Please use ``view_isometric``, this method has been deprecated."""
         from pyvista.core.errors import DeprecationError
         raise DeprecationError('Please use ``view_isometric``.')
 
@@ -3734,7 +3734,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> plotter.remove_all_lights()
         >>> plotter.renderer.lights
         []
-        >>> plotter.add_mesh(pv.Sphere(), show_edges=True)
+        >>> _ = plotter.add_mesh(pv.Sphere(), show_edges=True)
         >>> plotter.show()
 
         Note how this differs from a plot with default lighting

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -404,6 +404,18 @@ class BasePlotter(PickingHelper, WidgetHelper):
             If ``True``, only change the active renderer. The default
             is that every renderer is affected.
 
+        Examples
+        --------
+        >>> from pyvista import demos
+        >>> pl = demos.orientation_plotter()
+        >>> pl.enable_3_lights()
+        >>> pl.show()
+
+        Note how this varies from the default plotting.
+
+        >>> pl = demos.orientation_plotter()
+        >>> pl.show()
+
         """
         def _to_pos(elevation, azimuth):
             theta = azimuth * np.pi / 180.0
@@ -445,6 +457,17 @@ class BasePlotter(PickingHelper, WidgetHelper):
         only_active : bool
             If ``True``, only change the active renderer. The default is that
             every renderer is affected.
+
+        Examples
+        --------
+        Create a plotter without any lights and then enable the
+        default light kit.
+
+        >>> import pyvista
+        >>> pl = pyvista.Plotter(lighting=None)
+        >>> pl.enable_lightkit()
+        >>> actor = pl.add_mesh(pyvista.Cube(), show_edges=True)
+        >>> pl.show()
 
         """
         renderers = [self.renderer] if only_active else self.renderers

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -637,10 +637,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.renderer.reset_camera(*args, **kwargs)
         self.render()
 
-    def isometric_view(self):
-        """Please use ``view_isometric``, this method has been deprecated."""
-        from pyvista.core.errors import DeprecationError
-        raise DeprecationError('Please use ``view_isometric``.')
+    @wraps(Renderer.isometric_view)
+    def isometric_view(self, *args, **kwargs):
+        """Wrap ``Renderer.isometric_view``."""
+        return self.renderer.isometric_view(*args, **kwargs)
 
     @wraps(Renderer.view_isometric)
     def view_isometric(self, *args, **kwarg):

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -315,12 +315,39 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     @property
     def renderer(self):
-        """Return the active renderer."""
+        """Return the active renderer.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.renderer  # doctest:+SKIP
+        (Renderer)0x7f916129bfa0
+
+        """
         return self.renderers.active_renderer
 
     @property
     def store_image(self):
-        """Return if an image will be saved on close."""
+        """Store last rendered frame on close.
+
+        This is normally disabled to avoid caching the image, and is
+        enabled by default by setting:
+
+        ``pyvista.BUILDING_GALLERY = True``
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter(off_screen=True)
+        >>> pl.store_image = True
+        >>> _ = pl.add_mesh(pyvista.Cube())
+        >>> pl.show()
+        >>> image = pl.last_image
+        >>> type(image)
+        numpy.ndarray
+
+        """
         return self._store_image
 
     @store_image.setter
@@ -338,6 +365,20 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         index_column : int
             Index of the subplot to activate along the columns.
+
+        Examples
+        --------
+        Create a 2 wide plot and set the background of right-hand plot
+        to orange.  Add a cube to the left plot and a sphere to the
+        right.
+
+        >>> import pyvista
+        >>> pl = pyvista.Plotter(shape=(1, 2))
+        >>> actor = pl.add_mesh(pyvista.Cube())
+        >>> pl.subplot(0, 1)
+        >>> actor = pl.add_mesh(pyvista.Sphere())
+        >>> pl.set_background('orange', all_renderers=False)
+        >>> pl.show()
 
         """
         self.renderers.set_active_renderer(index_row, index_column)
@@ -3656,19 +3697,26 @@ class BasePlotter(PickingHelper, WidgetHelper):
         Parameters
         ----------
         only_active : bool
-            If ``True``, only remove lights from the active renderer. The default
-            is that lights are stripped from every renderer.
+            If ``True``, only remove lights from the active
+            renderer. The default is that lights are stripped from
+            every renderer.
 
         Examples
         --------
-        Create a plotter, forget to initialize it without default lighting,
-        correct the mistake after instantiation.
+        Create a plotter and remove all lights after initialization.
+        Note how the mesh rendered is completely flat
 
         >>> import pyvista as pv
         >>> plotter = pv.Plotter()
         >>> plotter.remove_all_lights()
         >>> plotter.renderer.lights
         []
+        >>> plotter.add_mesh(pv.Sphere(), show_edges=True)
+        >>> plotter.show()
+
+        Note how this differs from a plot with default lighting
+
+        >>> pv.Sphere().plot(show_edges=True, lighting=True)
 
         """
         renderers = [self.renderer] if only_active else self.renderers
@@ -3714,17 +3762,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
 class Plotter(BasePlotter):
     """Plotting object to display vtk meshes or numpy arrays.
-
-    Example
-    -------
-    >>> import pyvista
-    >>> from pyvista import examples
-    >>> mesh = examples.load_hexbeam()
-    >>> another_mesh = examples.load_uniform()
-    >>> plotter = pyvista.Plotter()
-    >>> actor = plotter.add_mesh(mesh, color='red')
-    >>> actor = plotter.add_mesh(another_mesh, color='blue')
-    >>> cpos = plotter.show()
 
     Parameters
     ----------
@@ -3789,6 +3826,17 @@ class Plotter(BasePlotter):
 
     theme : pyvista.themes.DefaultTheme, optional
         Plot-specific theme.
+
+    Examples
+    --------
+    >>> import pyvista
+    >>> from pyvista import examples
+    >>> mesh = examples.load_hexbeam()
+    >>> another_mesh = examples.load_uniform()
+    >>> plotter = pyvista.Plotter()
+    >>> actor = plotter.add_mesh(mesh, color='red')
+    >>> actor = plotter.add_mesh(another_mesh, color='blue')
+    >>> cpos = plotter.show()
 
     """
 

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -829,7 +829,7 @@ class Renderer(_vtk.vtkRenderer):
         >>> actor = plotter.add_mesh(mesh)
         >>> actor = plotter.show_bounds(grid='front', location='outer', 
         ...                             all_edges=True)
-        >>> cpos = plotter.show()
+        >>> plotter.show()
 
         """
         self.remove_bounds_axes()

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -585,14 +585,14 @@ class Renderer(_vtk.vtkRenderer):
             Show a box orientation marker. Use ``box_args`` to adjust.
             See :any:`pyvista.create_axes_orientation_box` for details.
 
-        xcolor : str, optional
-            Text used for the x axis.
+        x_color : str, optional
+            Color used for the x axis arrow.  Defaults to theme axes parameters.
 
-        ycolor : str, optional
-            Text used for the y axis.
+        y_color : str, optional
+            Color used for the y axis arrow.  Defaults to theme axes parameters.
 
-        zcolor : str, optional
-            Text used for the z axis.
+        z_color : str, optional
+            Color used for the z axis arrow.  Defaults to theme axes parameters.
 
         xlabel : str, optional
             Text used for the x axis.
@@ -608,7 +608,12 @@ class Renderer(_vtk.vtkRenderer):
 
         box : bool, optional
             When ``True`` use the axes orientation widget instead of
-            the default arrows.
+            the default arrows. Defaults to theme axes parameters.
+
+        box_args : dict, optional
+            Parameters for the orientation box widget when
+            ``box=True``. See the parameters of
+            :func:`pyvista.create_axes_orientation_box`.
 
         Examples
         --------

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -383,10 +383,11 @@ class Renderer(_vtk.vtkRenderer):
             Resets the camera when true.
 
         culling : str, optional
-            Does not render faces that are culled. Options are ``'front'`` or
-            ``'back'``. This can be helpful for dense surface meshes,
-            especially when edges are visible, but can cause flat
-            meshes to be partially displayed.  Default False.
+            Does not render faces that are culled. Options are
+            ``'front'`` or ``'back'``. This can be helpful for dense
+            surface meshes, especially when edges are visible, but can
+            cause flat meshes to be partially displayed.  Default
+            False.
 
         Returns
         -------
@@ -395,7 +396,6 @@ class Renderer(_vtk.vtkRenderer):
 
         actor_properties : vtk.Properties
             Actor properties.
-
         """
         # Remove actor by that name if present
         rv = self.remove_actor(name, reset_camera=False, render=False)
@@ -455,10 +455,46 @@ class Renderer(_vtk.vtkRenderer):
                            labels_off=False):
         """Add axes actor at origin.
 
+        Parameters
+        ----------
+        x_color : string or 3 item sequence, optional
+            The color of the x axes arror.
+
+        y_color : string or 3 item sequence, optional
+            The color of the y axes arror.
+
+        z_color : string or 3 item sequence, optional
+            The color of the z axes arror.
+
+        xlabel : str, optional
+            The label of the x axes arror.
+
+        ylabel : str, optional
+            The label of the y axes arror.
+
+        zlabel : str, optional
+            The label of the z axes arror.
+
+        line_width : int, optional
+            Width of the arrows.
+
+        labels_off : bool, optional
+            Disables the label text when ``True``.
+
         Returns
         -------
-        marker_actor : vtk.vtkAxesActor
-            vtkAxesActor actor
+        vtk.vtkAxesActor
+            Actor of the axes.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> _ = pl.add_mesh(pyvista.Sphere(center=(2, 0, 0)), color='r')
+        >>> _ = pl.add_mesh(pyvista.Sphere(center=(0, 2, 0)), color='g')
+        >>> _ = pl.add_mesh(pyvista.Sphere(center=(0, 0, 2)), color='b')
+        >>> _ = pl.add_axes_at_origin()
+        >>> pl.show()
 
         """
         self.marker_actor = create_axes_marker(line_width=line_width,
@@ -481,11 +517,26 @@ class Renderer(_vtk.vtkRenderer):
         actor : vtk.vtkActor or pyvista.DataSet
             The mesh or actor to use as the marker.
 
+        interactive : bool
+            Control if the orientation widget is interactive.  By
+            default uses the value from ``theme.interactive``.
+
         color : string, optional
-            The color of the actor.
+            The color of the actor.  This only applies if ``actor`` is
+            a ``pyvista.DataSet``
 
         opacity : int or float, optional
             Opacity of the marker.
+
+        Examples
+        --------
+        Use an Arrow as the orientation widget.
+
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> actor = pl.add_mesh(pyvista.Cube(), show_edges=True)
+        >>> actor = pl.add_orientation_widget(pyvista.Arrow(), color='r')
+        >>> pl.show()
 
         """
         if isinstance(actor, pyvista.DataSet):
@@ -527,15 +578,55 @@ class Renderer(_vtk.vtkRenderer):
         interacitve : bool
             Enable this orientation widget to be moved by the user.
 
-        line_width : int
+        line_width : int, optional
             The width of the marker lines
 
-        box : bool
+        box : bool, optional
             Show a box orientation marker. Use ``box_args`` to adjust.
             See :any:`pyvista.create_axes_orientation_box` for details.
 
-        opacity : int or float, optional
-            The opacity of the marker.
+        xcolor : str, optional
+            Text used for the x axis.
+
+        ycolor : str, optional
+            Text used for the y axis.
+
+        zcolor : str, optional
+            Text used for the z axis.
+
+        xlabel : str, optional
+            Text used for the x axis.
+
+        ylabel : str, optional
+            Text used for the y axis.
+
+        zlabel : str, optional
+            Text used for the z axis.
+
+        labels_off : bool, optional
+            Enable or disable the text labels for the axes.
+
+        box : bool, optional
+            When ``True`` use the axes orientation widget instead of
+            the default arrows.
+
+        Examples
+        --------
+        Show axes without labels and with thick lines.
+
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> actor = pl.add_mesh(pyvista.Box(), show_edges=True)
+        >>> pl.add_axes(line_width=5, labels_off=True)
+        >>> pl.show()
+
+        Use the axes orientation widget instead of the default arrows.
+
+        >>> pl = pyvista.Plotter()
+        >>> actor = pl.add_mesh(pyvista.Sphere())
+        >>> pl.add_axes(box=True)
+        >>> pl.show()
+
         """
         if interactive is None:
             interactive = self._theme.interactive
@@ -563,13 +654,29 @@ class Renderer(_vtk.vtkRenderer):
         return self.axes_actor
 
     def hide_axes(self):
-        """Hide the axes orientation widget."""
+        """Hide the axes orientation widget.
+
+        Examples
+        --------
+        >>> import pyvista as pv
+        >>> pv.Plotter()
+        >>> pv.hide_axes()
+
+        """
         if hasattr(self, 'axes_widget') and self.axes_widget.GetEnabled():
             self.axes_widget.EnabledOff()
             self.Modified()
 
     def show_axes(self):
-        """Show the axes orientation widget."""
+        """Show the axes orientation widget.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.hide_axes()
+
+        """
         if hasattr(self, 'axes_widget'):
             self.axes_widget.EnabledOn()
             self.axes_widget.SetCurrentRenderer(self)
@@ -579,7 +686,17 @@ class Renderer(_vtk.vtkRenderer):
 
     @property
     def axes_enabled(self):
-        """Return ``True`` when axes are enabled."""
+        """Return ``True`` when axes are enabled.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.hide_axes()
+        >>> pl.renderer.axes_enabled
+        False
+
+        """
         if hasattr(self, 'axes_widget'):
             return bool(self.axes_widget.GetEnabled())
         return False
@@ -710,7 +827,8 @@ class Renderer(_vtk.vtkRenderer):
         >>> mesh = pyvista.Sphere()
         >>> plotter = pyvista.Plotter()
         >>> actor = plotter.add_mesh(mesh)
-        >>> actor = plotter.show_bounds(grid='front', location='outer', all_edges=True)
+        >>> actor = plotter.show_bounds(grid='front', location='outer', 
+        ...                             all_edges=True)
         >>> cpos = plotter.show()
 
         """
@@ -884,7 +1002,21 @@ class Renderer(_vtk.vtkRenderer):
         return self.show_bounds(**kwargs)
 
     def remove_bounding_box(self, render=True):
-        """Remove bounding box."""
+        """Remove bounding box.
+
+        Parameters
+        ----------
+        render : bool, optional
+            Trigger a render once the bounding box is removed.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> _ = pl.add_bounding_box()
+        >>> pl.remove_bounding_box()
+
+        """
         if hasattr(self, '_box_object'):
             actor = self.bounding_box_actor
             self.bounding_box_actor = None
@@ -898,19 +1030,14 @@ class Renderer(_vtk.vtkRenderer):
                          culling='front'):
         """Add an unlabeled and unticked box at the boundaries of plot.
 
-        Useful for when wanting to plot outer grids while still retaining all
-        edges of the boundary.
+        Useful for when wanting to plot outer grids while still
+        retaining all edges of the boundary.
 
         Parameters
         ----------
         corner_factor : float, optional
-            If ``all_edges``, this is the factor along each axis to
-            draw the default box. Dafuault is 0.5 to show the full
-            box.
-
-        corner_factor : float, optional
             This is the factor along each axis to draw the default
-            box. Dafuault is 0.5 to show the full box.
+            box. Default is 0.5 to show the full box.
 
         line_width : float, optional
             Thickness of lines.
@@ -918,13 +1045,32 @@ class Renderer(_vtk.vtkRenderer):
         opacity : float, optional
             Opacity of mesh.  Should be between 0 and 1.  Default 1.0
 
+        render_lines_as_tubes : bool, optional
+            Show lines as thick tubes rather than flat lines.  Control
+            the width with ``line_width``.
+
+        lighting : bool, optional
+            Enable or disable directional lighting for this actor.
+
+        reset_camera : bool, optional
+            Reset camera position when ``True`` to include all actors.
+
         outline : bool
-            Default is ``True``. when False, a box with faces is shown with
-            the specified culling
+            Default is ``True``. when ``False``, a box with faces is shown
+            with the specified culling
 
         culling : str, optional
-            Does not render faces that are culled. Options are ``'front'`` or
-            ``'back'``. Default is ``'front'`` for bounding box.
+            Does not render faces that are culled. Options are
+            ``'front'`` or ``'back'``. Default is ``'front'`` for
+            bounding box.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> _ = pl.add_mesh(pyvista.Sphere())
+        >>> pl.add_bounding_box(line_width=5, color='black')
+        >>> pl.show()
 
         """
         if lighting is None:
@@ -1171,7 +1317,25 @@ class Renderer(_vtk.vtkRenderer):
 
     @property
     def lights(self):
-        """Return a list of all lights in the renderer."""
+        """Return a list of all lights in the renderer.
+
+        Returns
+        -------
+        list
+            Lights in the renderer.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.renderer.lights   # doctest:+SKIP
+        [<Light (Headlight) at 0x7f1dd8155820>,
+         <Light (Camera Light) at 0x7f1dd8155760>,
+         <Light (Camera Light) at 0x7f1dd8155340>,
+         <Light (Camera Light) at 0x7f1dd8155460>,
+         <Light (Camera Light) at 0x7f1dd8155f40>]
+
+        """
         return list(self.GetLights())
 
     def remove_all_lights(self):
@@ -1205,6 +1369,14 @@ class Renderer(_vtk.vtkRenderer):
 
         Examples
         --------
+        >>> import pyvista
+        >>> mesh = pyvista.Cube()
+        >>> pl = pyvista.Plotter()
+        >>> _ = pl.add_mesh(mesh, show_edges=True)
+        >>> _ = pl.add_point_labels([mesh.points[1]], ["Focus"])
+        >>> _ = pl.camera  # this initialzes the camera
+        >>> pl.set_focus(mesh.points[1])
+        >>> pl.show()
 
         """
         if isinstance(point, np.ndarray):
@@ -1215,7 +1387,25 @@ class Renderer(_vtk.vtkRenderer):
         self.Modified()
 
     def set_position(self, point, reset=False):
-        """Set camera position to a point."""
+        """Set camera position to a point.
+
+        Parameters
+        ----------
+        point : sequence
+            Cartesian point to focus on in the form of ``[x, y, z]``.
+
+        Examples
+        --------
+        Move the camera far away to ``[7, 7, 7]``.
+
+        >>> import pyvista
+        >>> mesh = pyvista.Cube()
+        >>> pl = pyvista.Plotter()
+        >>> _ = pl.add_mesh(mesh, show_edges=True)
+        >>> pl.set_position([7, 7, 7])
+        >>> pl.show()
+
+        """
         if isinstance(point, np.ndarray):
             if point.ndim != 1:
                 point = point.ravel()
@@ -1226,7 +1416,24 @@ class Renderer(_vtk.vtkRenderer):
         self.Modified()
 
     def set_viewup(self, vector):
-        """Set camera viewup vector."""
+        """Set camera viewup vector.
+
+        Parameters
+        ----------
+        vector : sequence
+            New 3 value camera viewup vector.
+
+        Examples
+        --------
+        Look from the top down by setting view up to ``[0, 1, 0]``.
+        Notice how the Y axis appears vertical.
+
+        >>> from pyvista import demos
+        >>> pl = demos.orientation_plotter()
+        >>> pl.set_viewup([0, 1, 0])
+        >>> pl.show()
+
+        """
         if isinstance(vector, np.ndarray):
             if vector.ndim != 1:
                 vector = vector.ravel()
@@ -1240,6 +1447,14 @@ class Renderer(_vtk.vtkRenderer):
         The camera will have a parallel projection. Parallel projection is
         often useful when viewing images or 2D datasets.
 
+        Examples
+        --------
+        >>> import pyvista
+        >>> from pyvista import demos
+        >>> pl = pyvista.demos.orientation_plotter()
+        >>> pl.enable_parallel_projection()
+        >>> pl.show()
+
         """
         # Fix the 'reset camera' effect produced by the VTK when parallel
         # projection is enabled.
@@ -1250,7 +1465,17 @@ class Renderer(_vtk.vtkRenderer):
         self.Modified()
 
     def disable_parallel_projection(self):
-        """Reset the camera to use perspective projection."""
+        """Reset the camera to use perspective projection.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> from pyvista import demos
+        >>> pl = pyvista.demos.orientation_plotter()
+        >>> pl.disable_parallel_projection()
+        >>> pl.show()
+
+        """
         # Fix the 'reset camera' effect produced by the VTK when parallel
         # projection is disabled.
         focus = self.camera.focal_point
@@ -1265,10 +1490,18 @@ class Renderer(_vtk.vtkRenderer):
 
         self.camera.disable_parallel_projection()
         self.Modified()
-
     @property
     def parallel_projection(self):
-        """Return parallel projection state of active render window."""
+        """Return parallel projection state of active render window.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.parallel_projection = False
+        >>> pl.parallel_projection
+        False
+        """
         return self.camera.parallel_projection
 
     @parallel_projection.setter
@@ -1279,7 +1512,14 @@ class Renderer(_vtk.vtkRenderer):
 
     @property
     def parallel_scale(self):
-        """Return parallel scale of active render window."""
+        """Return parallel scale of active render window.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.parallel_scale = 2
+        """
         return self.camera.parallel_scale
 
     @parallel_scale.setter
@@ -1294,10 +1534,11 @@ class Renderer(_vtk.vtkRenderer):
         Parameters
         ----------
         actor : str, vtk.vtkActor, list or tuple
-            If the type is ``str``, removes the previously added actor with
-            the given name. If the type is ``vtk.vtkActor``, removes the actor
-            if it's previously added to the Renderer. If ``list`` or ``tuple``,
-            removes iteratively each actor.
+            If the type is ``str``, removes the previously added actor
+            with the given name. If the type is ``vtk.vtkActor``,
+            removes the actor if it's previously added to the
+            Renderer. If ``list`` or ``tuple``, removes iteratively
+            each actor.
 
         reset_camera : bool, optional
             Resets camera so all actors can be seen.
@@ -1311,6 +1552,18 @@ class Renderer(_vtk.vtkRenderer):
         success : bool
             True when actor removed.  False when actor has not been
             removed.
+
+        Examples
+        --------
+        Add two meshes to a plotter and then remove the sphere actor.
+
+        >>> import pyvista
+        >>> mesh = pyvista.Cube()
+        >>> pl = pyvista.Plotter()
+        >>> cube_actor = pl.add_mesh(pyvista.Cube(), show_edges=True)
+        >>> sphere_actor = pl.add_mesh(pyvista.Sphere(), show_edges=True)
+        >>> pl.remove_actor(cube_actor)
+        >>> pl.show()
 
         """
         name = None
@@ -1363,6 +1616,31 @@ class Renderer(_vtk.vtkRenderer):
 
         Scaling in performed independently on the X, Y and Z axis.
         A scale of zero is illegal and will be replaced with one.
+
+        Parameters
+        ----------
+        xscale : float, optional
+            Scaling in the x direction.
+
+        yscale : float, optional
+            Scaling in the y direction.
+
+        zscale : float, optional
+            Scaling in the z direction.
+
+        reset_camera : bool, optional
+            Resets camera so all actors can be seen.  Default ``True``.
+
+        Examples
+        --------
+        Set the scale in the z direction to be 5 times that of
+        nominal.  Leave the other axes unscaled.
+
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.set_scale(zscale=5)
+        >>> _ = pl.add_mesh(pyvista.Sphere())  # perfect sphere
+        >>> pl.show()
 
         """
         if xscale is None:
@@ -1433,6 +1711,18 @@ class Renderer(_vtk.vtkRenderer):
             Automatically set up the camera based on a specified bounding box
             ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
 
+        Examples
+        --------
+        Add a mesh and place the camera position too close to the
+        mesh.  Then reset the camera and show the mesh.
+
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> actor = pl.add_mesh(pyvista.Sphere(), show_edges=True)
+        >>> pl.set_position((0, 0.1, 0.1))
+        >>> pl.reset_camera()
+        >>> pl.show()
+
         """
         if bounds is not None:
             self.ResetCamera(*bounds)
@@ -1442,22 +1732,36 @@ class Renderer(_vtk.vtkRenderer):
             self.parent.render()
         self.Modified()
 
-    def isometric_view(self):
-        """Reset the camera to a default isometric view.
-
-        DEPRECATED: Please use ``view_isometric``.
-
-        """
-        return self.view_isometric()
-
     def view_isometric(self, negative=False):
         """Reset the camera to a default isometric view.
 
         The view will show all the actors in the scene.
 
+        Parameters
+        ----------
+        negative : bool, optional
+            View from the other isometric direction.
+
+        Examples
+        --------
+        Isometric view.
+
+        >>> from pyvista import demos
+        >>> pl = demos.orientation_plotter()
+        >>> pl.view_isometric()
+        >>> pl.show()
+
+        Negative isometric view.
+
+        >>> from pyvista import demos
+        >>> pl = demos.orientation_plotter()
+        >>> pl.view_isometric(negative=True)
+        >>> pl.show()
+
         """
-        self.camera_position = CameraPosition(*self.get_default_cam_pos(negative=negative))
-        self.camera_set = False
+        position = self.get_default_cam_pos(negative=negative)
+        self.camera_position = CameraPosition(*position)
+        self.camera_set = negative
         return self.reset_camera()
 
     def view_vector(self, vector, viewup=None):
@@ -1527,7 +1831,20 @@ class Renderer(_vtk.vtkRenderer):
         return self.SetInteractive(1)
 
     def enable_eye_dome_lighting(self):
-        """Enable eye dome lighting (EDL)."""
+        """Enable eye dome lighting (EDL).
+
+        Returns
+        -------
+        vtk.vtkOpenGLRenderer
+            VTK renderer with eye dome lighting pass.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> _ = pl.enable_eye_dome_lighting()
+
+        """
         if hasattr(self, 'edl_pass'):
             return self
         # create the basic VTK render steps
@@ -1544,7 +1861,15 @@ class Renderer(_vtk.vtkRenderer):
         return self.glrenderer
 
     def disable_eye_dome_lighting(self):
-        """Disable eye dome lighting (EDL)."""
+        """Disable eye dome lighting (EDL).
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.disable_eye_dome_lighting()
+
+        """
         if not hasattr(self, 'edl_pass'):
             return
         self.SetPass(None)
@@ -1553,7 +1878,36 @@ class Renderer(_vtk.vtkRenderer):
         self.Modified()
 
     def enable_shadows(self):
-        """Enable shadows."""
+        """Enable shadows.
+
+        Examples
+        --------
+        First, plot without shadows enabled (default)
+
+        >>> import pyvista
+        >>> mesh = pyvista.Sphere()
+        >>> pl = pyvista.Plotter(lighting='none', window_size=(1000, 1000))
+        >>> light = pyvista.Light()
+        >>> light.set_direction_angle(20, -20)
+        >>> pl.add_light(light)
+        >>> _ = pl.add_mesh(mesh, color='white', smooth_shading=True)
+        >>> _ = pl.add_mesh(pyvista.Box((-1.2, -1, -1, 1, -1, 1)))
+        >>> pl.show()
+
+        Now, enable shadows.
+
+        >>> import pyvista
+        >>> mesh = pyvista.Sphere()
+        >>> pl = pyvista.Plotter(lighting='none', window_size=(1000, 1000))
+        >>> light = pyvista.Light()
+        >>> light.set_direction_angle(20, -20)
+        >>> pl.add_light(light)
+        >>> pl.add_mesh(mesh, color='white', smooth_shading=True)
+        >>> pl.add_mesh(pyvista.Box((-1.2, -1, -1, 1, -1, 1)))
+        >>> pl.enable_shadows()
+        >>> pl.show()
+
+        """
         if self._shadow_pass is not None:
             # shadows are already enabled for this renderer
             return
@@ -1574,7 +1928,15 @@ class Renderer(_vtk.vtkRenderer):
         self.Modified()
 
     def disable_shadows(self):
-        """Disable shadows."""
+        """Disable shadows.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.disable_shadows()
+
+        """
         if self._shadow_pass is None:
             # shadows are already disabled
             return
@@ -1586,7 +1948,14 @@ class Renderer(_vtk.vtkRenderer):
         self.Modified()
 
     def get_pick_position(self):
-        """Get the pick position/area as x0, y0, x1, y1."""
+        """Get the pick position/area as ``x0, y0, x1, y1``.
+
+        Returns
+        -------
+        tuple
+            Pick position as ``x0, y0, x1, y1``.
+
+        """
         x0 = int(self.GetPickX1())
         x1 = int(self.GetPickX2())
         y0 = int(self.GetPickY1())
@@ -1594,23 +1963,34 @@ class Renderer(_vtk.vtkRenderer):
         return x0, y0, x1, y1
 
     def set_background(self, color, top=None):
-        """Set the background color.
+        """Set the background color of this renderer.
 
         Parameters
         ----------
-        color : string or 3 item list, optional, defaults to white
-            Either a string, rgb list, or hex color string.  For example:
+        color : string or 3 item list, optional
+            Either a string, rgb list, or hex color string.  Defaults
+            to theme default.  For example:
 
             * ``color='white'``
             * ``color='w'``
             * ``color=[1, 1, 1]``
             * ``color='#FFFFFF'``
 
-        top : string or 3 item list, optional, defaults to None
+        top : string or 3 item list, optional
             If given, this will enable a gradient background where the
             ``color`` argument is at the bottom and the color given in
             ``top`` will be the color at the top of the renderer.
 
+        Examples
+        --------
+        Set the background color to black with a gradient to white at
+        the top of the plot.
+
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> actor = pl.add_mesh(pyvista.Cone())
+        >>> pl.set_background('black', top='white')
+        >>> pl.show()
         """
         if color is None:
             color = self._theme.background

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1732,6 +1732,14 @@ class Renderer(_vtk.vtkRenderer):
             self.parent.render()
         self.Modified()
 
+    def isometric_view(self):
+        """Reset the camera to a default isometric view.
+
+        DEPRECATED: Please use ``view_isometric``.
+
+        """
+        return self.view_isometric()
+
     def view_isometric(self, negative=False):
         """Reset the camera to a default isometric view.
 

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -302,7 +302,7 @@ class Renderer(_vtk.vtkRenderer):
     def enable_anti_aliasing(self):
         """Enable anti-aliasing using FXAA.
 
-        This tends to make edges appear software and less pixelated.
+        This tends to make edges appear softer and less pixelated.
 
         Examples
         --------
@@ -387,7 +387,7 @@ class Renderer(_vtk.vtkRenderer):
             ``'front'`` or ``'back'``. This can be helpful for dense
             surface meshes, especially when edges are visible, but can
             cause flat meshes to be partially displayed.  Default
-            False.
+            ``False``.
 
         Returns
         -------
@@ -458,22 +458,22 @@ class Renderer(_vtk.vtkRenderer):
         Parameters
         ----------
         x_color : string or 3 item sequence, optional
-            The color of the x axes arror.
+            The color of the x axes arrow.
 
         y_color : string or 3 item sequence, optional
-            The color of the y axes arror.
+            The color of the y axes arrow.
 
         z_color : string or 3 item sequence, optional
-            The color of the z axes arror.
+            The color of the z axes arrow.
 
         xlabel : str, optional
-            The label of the x axes arror.
+            The label of the x axes arrow.
 
         ylabel : str, optional
-            The label of the y axes arror.
+            The label of the y axes arrow.
 
         zlabel : str, optional
-            The label of the z axes arror.
+            The label of the z axes arrow.
 
         line_width : int, optional
             Width of the arrows.
@@ -674,7 +674,7 @@ class Renderer(_vtk.vtkRenderer):
         --------
         >>> import pyvista
         >>> pl = pyvista.Plotter()
-        >>> pl.hide_axes()
+        >>> pl.show_axes()
 
         """
         if hasattr(self, 'axes_widget'):
@@ -1620,13 +1620,13 @@ class Renderer(_vtk.vtkRenderer):
         Parameters
         ----------
         xscale : float, optional
-            Scaling in the x direction.
+            Scaling in the x direction.  Default is ``None``, which does not change existing scaling.
 
         yscale : float, optional
-            Scaling in the y direction.
+            Scaling in the y direction.  Default is ``None``, which does not change existing scaling.
 
         zscale : float, optional
-            Scaling in the z direction.
+            Scaling in the z direction.  Default is ``None``, which does not change existing scaling.
 
         reset_camera : bool, optional
             Resets camera so all actors can be seen.  Default ``True``.
@@ -1991,6 +1991,7 @@ class Renderer(_vtk.vtkRenderer):
         >>> actor = pl.add_mesh(pyvista.Cone())
         >>> pl.set_background('black', top='white')
         >>> pl.show()
+
         """
         if color is None:
             color = self._theme.background

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -309,7 +309,7 @@ class Renderer(_vtk.vtkRenderer):
         >>> import pyvista
         >>> pl = pyvista.Plotter()
         >>> pl.enable_anti_aliasing()
-        >>> pl.add_mesh(pyvista.Sphere(), show_edges=True)
+        >>> _ = pl.add_mesh(pyvista.Sphere(), show_edges=True)
         >>> pl.show()
 
         """
@@ -324,7 +324,7 @@ class Renderer(_vtk.vtkRenderer):
         >>> import pyvista
         >>> pl = pyvista.Plotter()
         >>> pl.disable_anti_aliasing()
-        >>> pl.add_mesh(pyvista.Sphere(), show_edges=True)
+        >>> _ = pl.add_mesh(pyvista.Sphere(), show_edges=True)
         >>> pl.show()
 
         """
@@ -617,14 +617,14 @@ class Renderer(_vtk.vtkRenderer):
         >>> import pyvista
         >>> pl = pyvista.Plotter()
         >>> actor = pl.add_mesh(pyvista.Box(), show_edges=True)
-        >>> pl.add_axes(line_width=5, labels_off=True)
+        >>> _ = pl.add_axes(line_width=5, labels_off=True)
         >>> pl.show()
 
         Use the axes orientation widget instead of the default arrows.
 
         >>> pl = pyvista.Plotter()
         >>> actor = pl.add_mesh(pyvista.Sphere())
-        >>> pl.add_axes(box=True)
+        >>> _ = pl.add_axes(box=True)
         >>> pl.show()
 
         """
@@ -659,8 +659,8 @@ class Renderer(_vtk.vtkRenderer):
         Examples
         --------
         >>> import pyvista as pv
-        >>> pv.Plotter()
-        >>> pv.hide_axes()
+        >>> pl = pv.Plotter()
+        >>> pl.hide_axes()
 
         """
         if hasattr(self, 'axes_widget') and self.axes_widget.GetEnabled():
@@ -1069,7 +1069,7 @@ class Renderer(_vtk.vtkRenderer):
         >>> import pyvista
         >>> pl = pyvista.Plotter()
         >>> _ = pl.add_mesh(pyvista.Sphere())
-        >>> pl.add_bounding_box(line_width=5, color='black')
+        >>> _ = pl.add_bounding_box(line_width=5, color='black')
         >>> pl.show()
 
         """
@@ -1374,7 +1374,7 @@ class Renderer(_vtk.vtkRenderer):
         >>> pl = pyvista.Plotter()
         >>> _ = pl.add_mesh(mesh, show_edges=True)
         >>> _ = pl.add_point_labels([mesh.points[1]], ["Focus"])
-        >>> _ = pl.camera  # this initialzes the camera
+        >>> _ = pl.camera  # this initializes the camera
         >>> pl.set_focus(mesh.points[1])
         >>> pl.show()
 
@@ -1562,7 +1562,7 @@ class Renderer(_vtk.vtkRenderer):
         >>> pl = pyvista.Plotter()
         >>> cube_actor = pl.add_mesh(pyvista.Cube(), show_edges=True)
         >>> sphere_actor = pl.add_mesh(pyvista.Sphere(), show_edges=True)
-        >>> pl.remove_actor(cube_actor)
+        >>> _ = pl.remove_actor(cube_actor)
         >>> pl.show()
 
         """
@@ -1902,8 +1902,8 @@ class Renderer(_vtk.vtkRenderer):
         >>> light = pyvista.Light()
         >>> light.set_direction_angle(20, -20)
         >>> pl.add_light(light)
-        >>> pl.add_mesh(mesh, color='white', smooth_shading=True)
-        >>> pl.add_mesh(pyvista.Box((-1.2, -1, -1, 1, -1, 1)))
+        >>> _ = pl.add_mesh(mesh, color='white', smooth_shading=True)
+        >>> _ = pl.add_mesh(pyvista.Box((-1.2, -1, -1, 1, -1, 1)))
         >>> pl.enable_shadows()
         >>> pl.show()
 

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -300,12 +300,34 @@ class Renderer(_vtk.vtkRenderer):
         self.Modified()
 
     def enable_anti_aliasing(self):
-        """Enable anti-aliasing FXAA."""
+        """Enable anti-aliasing using FXAA.
+
+        This tends to make edges appear software and less pixelated.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.enable_anti_aliasing()
+        >>> pl.add_mesh(pyvista.Sphere(), show_edges=True)
+        >>> pl.show()
+
+        """
         self.SetUseFXAA(True)
         self.Modified()
 
     def disable_anti_aliasing(self):
-        """Disable anti-aliasing FXAA."""
+        """Disable anti-aliasing.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.disable_anti_aliasing()
+        >>> pl.add_mesh(pyvista.Sphere(), show_edges=True)
+        >>> pl.show()
+
+        """
         self.SetUseFXAA(False)
         self.Modified()
 
@@ -1009,7 +1031,7 @@ class Renderer(_vtk.vtkRenderer):
         >>> pl = pyvista.Plotter()
         >>> actor = pl.add_mesh(pyvista.Sphere())
         >>> actor = pl.add_floor()
-        >>> cpos = pl.show()
+        >>> pl.show()
 
         """
         if store_floor_kwargs:
@@ -1094,7 +1116,28 @@ class Renderer(_vtk.vtkRenderer):
         return actor
 
     def remove_floors(self, clear_kwargs=True, render=True):
-        """Remove all floor actors."""
+        """Remove all floor actors.
+
+        Parameters
+        ----------
+        clear_kwargs : bool, optional
+            Clear default floor arguments.  Default ``True``.
+
+        render : bool, optional
+            Render upon removing the floor.  Default ``True``.
+
+        Examples
+        --------
+        Add a floor below a sphere, remove it, and then plot it.
+
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> actor = pl.add_mesh(pyvista.Sphere())
+        >>> actor = pl.add_floor()
+        >>> pl.remove_floors()
+        >>> pl.show()
+
+        """
         if getattr(self, '_floor', None) is not None:
             self._floor.ReleaseData()
             self._floor = None
@@ -1153,7 +1196,17 @@ class Renderer(_vtk.vtkRenderer):
         self._scalar_bar_slot_lookup = {}
 
     def set_focus(self, point):
-        """Set focus to a point."""
+        """Set focus to a point.
+
+        Parameters
+        ----------
+        point : sequence
+            Cartesian point to focus on in the form of ``[x, y, z]``.
+
+        Examples
+        --------
+
+        """
         if isinstance(point, np.ndarray):
             if point.ndim != 1:
                 point = point.ravel()

--- a/pyvista/plotting/renderers.py
+++ b/pyvista/plotting/renderers.py
@@ -367,22 +367,23 @@ class Renderers():
 
         Parameters
         ----------
-        color : string or 3 item list, optional, defaults to white
-            Either a string, rgb list, or hex color string.  For example:
+        color : string or 3 item sequence, optional
+            Either a string, rgb list, or hex color string.  Defaults
+            to current theme parameters.  For example:
 
             * ``color='white'``
             * ``color='w'``
             * ``color=[1, 1, 1]``
             * ``color='#FFFFFF'``
 
-        top : string or 3 item list, optional, defaults to None
+        top : string or 3 item sequence, optional
             If given, this will enable a gradient background where the
             ``color`` argument is at the bottom and the color given in ``top``
             will be the color at the top of the renderer.
 
         all_renderers : bool
-            If True, applies to all renderers in subplots. If False, then
-            only applies to the active renderer.
+            If ``True``, applies to all renderers in subplots. If ``False``,
+            then only applies to the active renderer.
 
         Examples
         --------
@@ -394,13 +395,14 @@ class Renderers():
         >>> plotter.background_color
         (0.0, 0.0, 0.0)
 
-        Set the background color to white.
+        Set the background color at the bottom to black and white at
+        the top.  Display a cone as well.
 
         >>> import pyvista
-        >>> plotter = pyvista.Plotter()
-        >>> plotter.set_background('white')
-        >>> plotter.background_color
-        (1.0, 1.0, 1.0)
+        >>> pl = pyvista.Plotter()
+        >>> actor = pl.add_mesh(pyvista.Cone())
+        >>> pl.set_background('black', top='white')
+        >>> pl.show()
 
         """
         if all_renderers:

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -844,7 +844,7 @@ class WidgetHelper:
         ...     fmt="%0.9f",
         ...     title_height=0.08,
         ... )
-        >>> cpos = pl.show()
+        >>> pl.show()
         """
         if not hasattr(self, "slider_widgets"):
             self.slider_widgets = []

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -1,4 +1,3 @@
-
 """Module managing errors."""
 
 import logging

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -1,3 +1,4 @@
+
 """Module managing errors."""
 
 import logging

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -91,7 +91,7 @@ def Cylinder(center=(0.0, 0.0, 0.0), direction=(1.0, 0.0, 0.0),
     >>> import numpy as np
     >>> cylinder = pyvista.Cylinder(center=[1, 2, 3], direction=[1, 1, 1], 
     ...                             radius=1, height=2)
-    >>> cpos = cylinder.plot(show_edges=True, line_width=5, cpos='xy')
+    >>> cylinder.plot(show_edges=True, line_width=5, cpos='xy')
     """
     capping = kwargs.pop('cap_ends', capping)
     assert_empty_kwargs(**kwargs)
@@ -310,7 +310,7 @@ def Sphere(radius=0.5, center=(0, 0, 0), direction=(0, 0, 1), theta_resolution=3
 
     >>> import pyvista
     >>> sphere = pyvista.Sphere()
-    >>> cpos = sphere.plot(show_edges=True)
+    >>> sphere.plot(show_edges=True)
 
     Create a quarter sphere by setting ``end_theta``.
 
@@ -835,7 +835,7 @@ def CircularArc(pointa, pointb, center, resolution=100, negative=False):
     >>> _ = pl.add_mesh(arc, color='k', line_width=10)
     >>> _ = pl.show_bounds(location='all', font_size=30, use_2d=True)
     >>> _ = pl.view_xy()
-    >>> cpos = pl.show()
+    >>> pl.show()
     """
     check_valid_vector(pointa, 'pointa')
     check_valid_vector(pointb, 'pointb')
@@ -910,7 +910,7 @@ def CircularArcFromNormal(center, resolution=100, normal=None,
     >>> _ = pl.add_mesh(arc, color='k', line_width=10)
     >>> _ = pl.show_bounds(location='all', font_size=30, use_2d=True)
     >>> _ = pl.view_xy()
-    >>> cpos = pl.show()
+    >>> pl.show()
     """
     check_valid_vector(center, 'center')
     if normal is None:
@@ -964,7 +964,7 @@ def Pyramid(points):
     >>> pointd = [1.0, -1.0, 0.0]
     >>> pointe = [0.0, 0.0, 1.67]
     >>> pyramid = pyvista.Pyramid([pointa, pointb, pointc, pointd, pointe])
-    >>> cpos = pyramid.plot(show_edges=True, line_width=5)
+    >>> pyramid.plot(show_edges=True, line_width=5)
     """
     if len(points) != 5:
         raise TypeError('Points must be given as length 5 np.ndarray or list')

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -307,7 +307,7 @@ def line_segments_from_points(points):
     >>> import numpy as np
     >>> points = np.array([[0, 0, 0], [1, 0, 0], [1, 0, 0], [1, 1, 0]])
     >>> lines = pyvista.lines_from_points(points)
-    >>> cpos = lines.plot()
+    >>> lines.plot()
 
     """
     if len(points) % 2 != 0:
@@ -399,7 +399,7 @@ def make_tri_mesh(points, faces):
     >>> faces = np.array([[0, 1, 4], [4, 7, 6], [2, 5, 4], [4, 5, 8],
     ...                   [0, 4, 3], [3, 4, 6], [1, 2, 4], [4, 8, 7]])
     >>> tri_mesh = pyvista.make_tri_mesh(points, faces)
-    >>> cpos = tri_mesh.plot(show_edges=True, line_width=5)
+    >>> tri_mesh.plot(show_edges=True, line_width=5)
 
     """
     if points.shape[1] != 3:

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -72,7 +72,7 @@ def ParametricBohemianDome(a=None, **kwargs):
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricBohemianDome()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricBohemianDome()
@@ -102,7 +102,7 @@ def ParametricBour(**kwargs):
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricBour()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricBour()
@@ -142,7 +142,7 @@ def ParametricBoy(zscale=None, **kwargs):
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricBoy()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricBoy()
@@ -176,7 +176,7 @@ def ParametricCatalanMinimal(**kwargs):
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricCatalanMinimal()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricCatalanMinimal()
@@ -229,7 +229,7 @@ def ParametricConicSpiral(a=None, b=None, c=None, n=None, **kwargs):
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricConicSpiral()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricConicSpiral()
@@ -272,7 +272,7 @@ def ParametricCrossCap(**kwargs):
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricCrossCap()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricCrossCap()
@@ -315,7 +315,7 @@ def ParametricDini(a=None, b=None, **kwargs):
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricDini()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricDini()
@@ -366,7 +366,7 @@ def ParametricEllipsoid(xradius=None, yradius=None, zradius=None,
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricEllipsoid()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricEllipsoid()
@@ -416,7 +416,7 @@ def ParametricEnneper(**kwargs):
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricEnneper()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricEnneper()
@@ -453,7 +453,7 @@ def ParametricFigure8Klein(radius=None, **kwargs):
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricFigure8Klein()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricFigure8Klein()
@@ -483,7 +483,7 @@ def ParametricHenneberg(**kwargs):
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricHenneberg()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricHenneberg()
@@ -516,7 +516,7 @@ def ParametricKlein(**kwargs):
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricKlein()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricKlein()
@@ -556,7 +556,7 @@ def ParametricKuen(deltav0=None, **kwargs):
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricKuen()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricKuen()
@@ -591,7 +591,7 @@ def ParametricMobius(radius=None, **kwargs):
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricMobius()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricMobius()
@@ -632,7 +632,7 @@ def ParametricPluckerConoid(n=None, **kwargs):
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricPluckerConoid()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricPluckerConoid()
@@ -667,7 +667,7 @@ def ParametricPseudosphere(**kwargs):
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricPseudosphere()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricPseudosphere()
@@ -742,7 +742,7 @@ def ParametricRandomHills(numberofhills=None, hillxvariance=None,
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricRandomHills()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricRandomHills()
@@ -798,7 +798,7 @@ def ParametricRoman(radius=None, **kwargs):
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricRoman()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricRoman()
@@ -851,7 +851,7 @@ def ParametricSuperEllipsoid(xradius=None, yradius=None, zradius=None,
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricSuperEllipsoid()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricSuperEllipsoid()
@@ -929,7 +929,7 @@ def ParametricSuperToroid(ringradius=None, crosssectionradius=None,
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricSuperToroid()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricSuperToroid()
@@ -986,7 +986,7 @@ def ParametricTorus(ringradius=None, crosssectionradius=None, **kwargs):
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricTorus()
-    >>> cpos = mesh.plot(color='w', smooth_shading=True)
+    >>> mesh.plot(color='w', smooth_shading=True)
 
     """
     parametric_function = _vtk.vtkParametricTorus()


### PR DESCRIPTION
With #1457, we can start to improve our documentation examples.  Combined with isolated documentation pages for each method, we can have examples match how `numpy`, `scipy`, and `pandas` create their examples.

![tmp](https://user-images.githubusercontent.com/11981631/124230817-bcc2d200-dacc-11eb-869e-c290c92c1e92.png)
