### PR TITLE
Fix boolean behavior

### DIFF
--- a/examples/01-filter/boolean-operations.py
+++ b/examples/01-filter/boolean-operations.py
@@ -42,19 +42,8 @@ meshes in PyVista to cut the first mesh by the second.
 import pyvista as pv
 import numpy as np
 
-def make_cube():
-    x = np.linspace(-0.5, 0.5, 25)
-    grid = pv.StructuredGrid(*np.meshgrid(x, x, x))
-    return grid.extract_surface().triangulate()
-
-# Create to example PolyData meshes for boolean operations
-sphere = pv.Sphere(radius=0.65, center=(0, 0, 0))
-cube = make_cube()
-
-p = pv.Plotter()
-p.add_mesh(sphere, color="yellow", opacity=0.5, show_edges=True)
-p.add_mesh(cube, color="royalblue", opacity=0.5, show_edges=True)
-p.show()
+sphere_a = pv.Sphere()
+sphere_b = pv.Sphere(center=(0.5, 0, 0))
 
 
 ###############################################################################
@@ -69,8 +58,14 @@ p.show()
 #
 # Order of operations does not matter for boolean union.
 
-add = sphere.boolean_union(cube)
-add.plot(opacity=0.5, color=True, show_edges=True)
+result = sphere_a.boolean_union(sphere_b)
+pl = pv.Plotter()
+_ = pl.add_mesh(sphere_a, color='r', style='wireframe', line_width=3)
+_ = pl.add_mesh(sphere_b, color='b', style='wireframe', line_width=3)
+_ = pl.add_mesh(result, color='tan')
+pl.camera_position = 'xz'
+pl.show()
+
 
 
 ###############################################################################
@@ -86,11 +81,13 @@ add.plot(opacity=0.5, color=True, show_edges=True)
 #
 # Order of operations matters for boolean cut.
 
-cut = cube - sphere
-
-p = pv.Plotter()
-p.add_mesh(cut, opacity=0.5, show_edges=True, color=True)
-p.show()
+result = sphere_a.boolean_difference(sphere_b)
+pl = pv.Plotter()
+_ = pl.add_mesh(sphere_a, color='r', style='wireframe', line_width=3)
+_ = pl.add_mesh(sphere_b, color='b', style='wireframe', line_width=3)
+_ = pl.add_mesh(result, color='tan')
+pl.camera_position = 'xz'
+pl.show()
 
 
 ###############################################################################
@@ -105,11 +102,15 @@ p.show()
 #
 # Order of operations does not matter for intersection.
 
-intersect = sphere.boolean_intersection(cube)
+result = sphere_a.boolean_intersection(sphere_b)
+pl = pv.Plotter()
+_ = pl.add_mesh(sphere_a, color='r', style='wireframe', line_width=3)
+_ = pl.add_mesh(sphere_b, color='b', style='wireframe', line_width=3)
+_ = pl.add_mesh(result, color='tan')
+pl.camera_position = 'xz'
+pl.show()
 
-p = pv.Plotter()
-p.add_mesh(intersect, opacity=0.5, show_edges=True, color=True)
-p.show()
+
 
 ###############################################################################
 # Behavior due to flipped normals
@@ -120,18 +121,21 @@ p.show()
 # Boolean difference with both cube and sphere normals pointed
 # outward.  This is the "normal" behavior.
 
-cube = pv.Cube().triangulate().subdivide(3).clean()
+cube = pv.Cube().clean().triangulate().subdivide(3).clean()
 sphere = pv.Sphere(radius=0.6)
 result = cube.boolean_difference(sphere)
 result.plot(color='tan')
 
+
 ###############################################################################
 # Boolean difference with cube normals outward, sphere inward.
+
 cube = pv.Cube().triangulate().subdivide(3).clean()
 sphere = pv.Sphere(radius=0.6)
 sphere.flip_normals()
 result = cube.boolean_difference(sphere)
 result.plot(color='tan')
+
 
 ###############################################################################
 # Boolean difference with cube normals inward, sphere outward.
@@ -141,6 +145,7 @@ cube.flip_normals()
 sphere = pv.Sphere(radius=0.6)
 result = cube.boolean_difference(sphere)
 result.plot(color='tan')
+
 
 ###############################################################################
 # Both cube and sphere normals inward.

--- a/examples/01-filter/boolean-operations.py
+++ b/examples/01-filter/boolean-operations.py
@@ -21,7 +21,9 @@ same operation. Just different parts of the objects are kept at the
 end.
 
 The ``-`` operator can be used between any two :class:`pyvista.PolyData`
-meshes in PyVista to cut the first mesh by the second.
+meshes in PyVista to cut the first mesh by the second.  These meshes
+must be all triangule meshes, which you can check with
+:func:`PolyData.is_all_triangles`.
 
 .. note::
    For merging, the ``+`` operator can be used between any two meshes

--- a/examples/01-filter/boolean-operations.py
+++ b/examples/01-filter/boolean-operations.py
@@ -26,14 +26,15 @@ meshes in PyVista to cut the first mesh by the second.
 .. note::
    For merging, the ``+`` operator can be used between any two meshes
    in PyVista which simply calls the ``.merge()`` filter to combine
-   any two meshes.  This is difference than ``boolean_union`` as it
-   simply adds the two meshes together without operating on them.
+   any two meshes.  This is different from ``boolean_union`` as it
+   simply superimposes the two meshes without performing additional
+   calculations on the result.
 
 .. warning::
    If your boolean operations don't react the way you think they
    should (i.e. the wrong parts disappear), one of your meshes
    probably has its normals pointing inward. Use
-   :func:`PolyDataFilters.plot_normals` visualize the normals.
+   :func:`pyvista.PolyDataFilters.plot_normals` to visualize the normals.
 
 
 """
@@ -50,13 +51,14 @@ sphere_b = pv.Sphere(center=(0.5, 0, 0))
 # Boolean Union
 # +++++++++++++
 #
-# Perform a boolean union of ``A`` and ``B``.
+# Perform a boolean union of ``A`` and ``B`` using the
 # :func:`pyvista.PolyDataFilters.boolean_union` filter.
 #
 # The union of two manifold meshes ``A`` and ``B`` is the mesh
 # which is in ``A``, in ``B``, or in both ``A`` and ``B``.
 #
-# Order of operations does not matter for boolean union.
+# Order of operands does not matter for boolean union (the operation is
+# commutative).
 
 result = sphere_a.boolean_union(sphere_b)
 pl = pv.Plotter()
@@ -72,14 +74,14 @@ pl.show()
 # Boolean Difference
 # ++++++++++++++++++
 #
-# Perform a boolean difference of ``A`` and ``B``.
+# Perform a boolean difference of ``A`` and ``B`` using the
 # :func:`pyvista.PolyDataFilters.boolean_difference` filter or the
 # ``-`` operator since both meshes are :class:`pyvista.PolyData`.
 #
 # The difference of two manifold meshes ``A`` and ``B`` is the volume
 # of the mesh in ``A`` not belonging to ``B``.
 #
-# Order of operations matters for boolean cut.
+# Order of operands matters for boolean difference.
 
 result = sphere_a.boolean_difference(sphere_b)
 pl = pv.Plotter()
@@ -94,13 +96,14 @@ pl.show()
 # Boolean Intersection
 # ++++++++++++++++++++
 #
-# Perform a boolean intersection of ``A`` and ``B``.
+# Perform a boolean intersection of ``A`` and ``B`` using the
 # :func:`pyvista.PolyDataFilters.boolean_intersection` filter.
 #
 # The intersection of two manifold meshes ``A`` and ``B`` is the mesh
 # which is the volume of ``A`` that is also in ``B``.
 #
-# Order of operations does not matter for intersection.
+# Order of operands does not matter for boolean intersection (the
+# operation is commutative).
 
 result = sphere_a.boolean_intersection(sphere_b)
 pl = pv.Plotter()

--- a/examples/01-filter/boolean-operations.py
+++ b/examples/01-filter/boolean-operations.py
@@ -1,23 +1,34 @@
 """
+.. _boolean_example:
+
 Boolean Operations
 ~~~~~~~~~~~~~~~~~~
 
-Perform boolean operations with closed surfaces (intersect, cut, etc.).
+Perform boolean operations with closed (manifold) surfaces.
 
-Boolean/topological operations (intersect, cut, etc.) methods are implemented
-for :class:`pyvista.PolyData` mesh types only and are accessible directly from
-any :class:`pyvista.PolyData` mesh. Check out :class:`pyvista.PolyDataFilters`
-and take a look at the following filters:
+Boolean/topological operations (intersect, union, difference) methods
+are implemented for :class:`pyvista.PolyData` mesh types only and are
+accessible directly from any :class:`pyvista.PolyData` mesh. Check out
+:class:`pyvista.PolyDataFilters` and take a look at the following
+filters:
 
-* :func:`pyvista.PolyDataFilters.boolean_add`
-* :func:`pyvista.PolyDataFilters.boolean_cut`
 * :func:`pyvista.PolyDataFilters.boolean_difference`
 * :func:`pyvista.PolyDataFilters.boolean_union`
+* :func:`pyvista.PolyDataFilters.boolean_intersection`
 
-For merging, the ``+`` operator can be used between any two meshes in PyVista
-which simply calls the ``.merge()`` filter to combine any two meshes.
-Similarly, the ``-`` operator can be used between any two :class:`pyvista.PolyData`
+Essentially, boolean union, difference, and intersection are all the
+same operation. Just different parts of the objects are kept at the
+end.
+
+The ``-`` operator can be used between any two :class:`pyvista.PolyData`
 meshes in PyVista to cut the first mesh by the second.
+
+.. note::
+   For merging, the ``+`` operator can be used between any two meshes
+   in PyVista which simply calls the ``.merge()`` filter to combine
+   any two meshes.  This is difference than ``boolean_union`` as it
+   simply adds the two meshes together without operating on them.
+
 """
 
 # sphinx_gallery_thumbnail_number = 6
@@ -38,29 +49,35 @@ p.add_mesh(sphere, color="yellow", opacity=0.5, show_edges=True)
 p.add_mesh(cube, color="royalblue", opacity=0.5, show_edges=True)
 p.show()
 
-###############################################################################
-# Boolean Add
-# +++++++++++
-#
-# Add all of the two meshes together using the
-# :func:`pyvista.PolyDataFilters.boolean_add` filter or the ``+`` operator.
-#
-# Order of operations does not matter for boolean add as the entirety of both
-# meshes are appended together.
 
-add = sphere + cube
+###############################################################################
+# Boolean Union
+# +++++++++++++
+#
+# Perform a boolean union of ``A`` and ``B``.
+# :func:`pyvista.PolyDataFilters.boolean_union` filter.
+#
+# The union of two manifold meshes ``A`` and ``B`` is the mesh
+# which is in ``A``, in ``B``, or in both ``A`` and ``B``.
+#
+# Order of operations does not matter for boolean union.
+
+add = sphere.boolean_union(cube)
 add.plot(opacity=0.5, color=True, show_edges=True)
 
 
 ###############################################################################
-# Boolean Cut
-# +++++++++++
+# Boolean Difference
+# ++++++++++++++++++
 #
-# Perform a boolean cut of ``a`` using ``b`` with the
-# :func:`pyvista.PolyDataFilters.boolean_cut` filter or the ``-`` operator
-# since both meshes are :class:`pyvista.PolyData`.
+# Perform a boolean difference of ``A`` and ``B``.
+# :func:`pyvista.PolyDataFilters.boolean_difference` filter or the
+# ``-`` operator since both meshes are :class:`pyvista.PolyData`.
 #
-# Order of operations does not matter for boolean cut.
+# The difference of two manifold meshes ``A`` and ``B`` is the volume
+# of the mesh in ``A`` not belonging to ``B``.
+#
+# Order of operations matters for boolean cut.
 
 cut = cube - sphere
 
@@ -70,41 +87,20 @@ p.show()
 
 
 ###############################################################################
-# Boolean Difference
-# ++++++++++++++++++
+# Boolean Intersection
+# ++++++++++++++++++++
 #
-# Combine two meshes and retains only the volume in common between the meshes
-# using the :func:`pyvista.PolyDataFilters.boolean_difference` method.
+# Perform a boolean intersection of ``A`` and ``B``.
+# :func:`pyvista.PolyDataFilters.boolean_intersection` filter.
 #
-# Note that the order of operations for a boolean difference will affect the
-# results.
+# The intersection of two manifold meshes ``A`` and ``B`` is the mesh
+# which is the volume of ``A`` that is also in ``B``.
+#
+# Order of operations does not matter for intersection.
 
-diff = sphere.boolean_difference(cube)
+intersect = sphere.boolean_intersection(cube)
 
 p = pv.Plotter()
-p.add_mesh(diff, opacity=0.5, show_edges=True, color=True)
+p.add_mesh(intersect, opacity=0.5, show_edges=True, color=True)
 p.show()
 
-
-###############################################################################
-
-diff = cube.boolean_difference(sphere)
-
-p = pv.Plotter()
-p.add_mesh(diff, opacity=0.5, show_edges=True, color=True)
-p.show()
-
-###############################################################################
-# Boolean Union
-# +++++++++++++
-#
-# Combine two meshes and attempts to create a manifold mesh using the
-# :func:`pyvista.PolyDataFilters.boolean_union` method.
-#
-# Order of operations does not matter for boolean union.
-
-union = sphere.boolean_union(cube)
-
-p = pv.Plotter()
-p.add_mesh(union,  opacity=0.5, show_edges=True, color=True)
-p.show()

--- a/examples/01-filter/boolean-operations.py
+++ b/examples/01-filter/boolean-operations.py
@@ -29,6 +29,13 @@ meshes in PyVista to cut the first mesh by the second.
    any two meshes.  This is difference than ``boolean_union`` as it
    simply adds the two meshes together without operating on them.
 
+.. warning::
+   If your boolean operations don't react the way you think they
+   should (i.e. the wrong parts disappear), one of your meshes
+   probably has its normals pointing inward. Use
+   :func:`PolyDataFilters.plot_normals` visualize the normals.
+
+
 """
 
 # sphinx_gallery_thumbnail_number = 6
@@ -103,4 +110,45 @@ intersect = sphere.boolean_intersection(cube)
 p = pv.Plotter()
 p.add_mesh(intersect, opacity=0.5, show_edges=True, color=True)
 p.show()
+
+###############################################################################
+# Behavior due to flipped normals
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Note that these boolean filters behave differently depending on the
+# orientation of the normals.
+#
+# Boolean difference with both cube and sphere normals pointed
+# outward.  This is the "normal" behavior.
+
+cube = pv.Cube().triangulate().subdivide(3).clean()
+sphere = pv.Sphere(radius=0.6)
+result = cube.boolean_difference(sphere)
+result.plot(color='tan')
+
+###############################################################################
+# Boolean difference with cube normals outward, sphere inward.
+cube = pv.Cube().triangulate().subdivide(3).clean()
+sphere = pv.Sphere(radius=0.6)
+sphere.flip_normals()
+result = cube.boolean_difference(sphere)
+result.plot(color='tan')
+
+###############################################################################
+# Boolean difference with cube normals inward, sphere outward.
+
+cube = pv.Cube().triangulate().subdivide(3).clean()
+cube.flip_normals()
+sphere = pv.Sphere(radius=0.6)
+result = cube.boolean_difference(sphere)
+result.plot(color='tan')
+
+###############################################################################
+# Both cube and sphere normals inward.
+
+cube = pv.Cube().triangulate().subdivide(3).clean()
+cube.flip_normals()
+sphere = pv.Sphere(radius=0.6)
+sphere.flip_normals()
+result = cube.boolean_difference(sphere)
+result.plot(color='tan')
 

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -153,7 +153,7 @@ class PolyDataFilters(DataSetFilters):
         else:
             return mesh
 
-    def boolean_union(poly_data, mesh, inplace=False):
+    def boolean_intersection(poly_data, mesh, inplace=False):
         """Combine two meshes and retains only the volume in common between the meshes.
 
         Parameters

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -71,20 +71,22 @@ class PolyDataFilters(DataSetFilters):
     def boolean_cut(poly_data, *args, **kwargs):  # pragma: no cover
         """Cut two meshes.
 
-        .. deprecated:: 0.31.0
+        .. deprecated:: 0.32.0
            Use :func:`PolyDataFilters.boolean_difference` instead.
 
         """
-        DeprecationError('``boolean_cut`` has ben deprecated.  Please use ``boolean_difference``.')
+        raise DeprecationError('``boolean_cut`` has been deprecated.  '
+                               'Please use ``boolean_difference``.')
 
     def boolean_add(poly_data, *args, **kwargs):  # pragma: no cover
         """Merge two meshes together.
 
-        .. deprecated:: 0.31.0
+        .. deprecated:: 0.32.0
            Use :func:`PolyDataFilters.merge` instead.
 
         """
-        DeprecationError('``boolean_add`` has been deprecated.  Please use ``merge``.')
+        raise DeprecationError('``boolean_add`` has been deprecated.  '
+                               'Please use ``merge``.')
 
     def boolean_union(poly_data, other_mesh, tolerance=1E-5):
         """Perform a boolean union operation on two meshes.
@@ -100,7 +102,8 @@ class PolyDataFilters(DataSetFilters):
            If your boolean operations don't react the way you think they
            should (i.e. the wrong parts disappear), one of your meshes
            probably has its normals pointing inward. Use
-           :func:`PolyDataFilters.plot_normals` visualize the normals.
+           :func:`PolyDataFilters.plot_normals` to visualize the
+           normals.
 
         .. note::
            The behavior of this filter varies from the
@@ -108,7 +111,7 @@ class PolyDataFilters(DataSetFilters):
            to create a manifold mesh and will not include internal
            surfaces when two meshes overlap.
 
-        .. versionchanged:: 0.31.0
+        .. versionchanged:: 0.32.0
            Behavior changed to match default VTK behavior.
 
         Parameters
@@ -160,9 +163,10 @@ class PolyDataFilters(DataSetFilters):
            If your boolean operations don't react the way you think they
            should (i.e. the wrong parts disappear), one of your meshes
            probably has its normals pointing inward. Use
-           :func:`PolyDataFilters.plot_normals` visualize the normals.
+           :func:`PolyDataFilters.plot_normals` to visualize the
+           normals.
 
-        .. versionadded:: 0.31.0
+        .. versionadded:: 0.32.0
 
         Parameters
         ----------
@@ -209,7 +213,14 @@ class PolyDataFilters(DataSetFilters):
         The difference of two manifold meshes ``A`` and ``B`` is the
         volume of the mesh in ``A`` not belonging to ``B``.
 
-        .. versionchanged:: 0.31.0
+        .. note::
+           If your boolean operations don't react the way you think they
+           should (i.e. the wrong parts disappear), one of your meshes
+           probably has its normals pointing inward. Use
+           :func:`PolyDataFilters.plot_normals` to visualize the
+           normals.
+
+        .. versionchanged:: 0.32.0
            Behavior changed to match default VTK behavior.
 
         Parameters
@@ -264,15 +275,16 @@ class PolyDataFilters(DataSetFilters):
         Returns
         --------
         pyvista.PolyData or pyvista.UnstructuredGrid
-            pyvista.PolyData if ``dataset`` is a pyvista.PolyData,
-            otherwise a pyvista.UnstructuredGrid.
+            :class:`pyvista.PolyData` if ``dataset`` is a
+            :class:`pyvista.PolyData`, otherwise a
+            :class:`pyvista.UnstructuredGrid`.
 
         inplace : bool, optional
-            Updates grid inplace when True if the input type is an
+            Updates grid inplace when ``True`` if the input type is a
             :class:`pyvista.UnstructuredGrid`.
 
         main_has_priority : bool, optional
-            When this parameter is true and merge_points is true,
+            When this parameter is ``True`` and ``merge_points=True``,
             the arrays of the merging grids will be overwritten
             by the original main mesh.
 

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -59,7 +59,7 @@ class PolyDataFilters(DataSetFilters):
         elif btype == 'difference':
             bfilter.SetOperationToDifference()
         else:  # pragma: no cover
-            ValueError(f'Invalid btype {btype}')
+            raise ValueError(f'Invalid btype {btype}')
         bfilter.SetInputData(0, poly_data)
         bfilter.SetInputData(1, other_mesh)
         bfilter.ReorientDifferenceCellsOn()  # this is already default

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -172,6 +172,13 @@ class PolyDataFilters(DataSetFilters):
            normals.
 
         .. note::
+           This method returns the "volume" intersection between two
+           meshes whereas the :func:`PolyDataFilters.intersection`
+           filter returns the surface intersection between two meshes
+           (which often resolves as a line).
+           
+
+        .. note::
            Both meshes must be composed of all triangles.  Check with
            :func:`PolyData.is_all_triangles` and convert with
            :func:`PolyDataFilters.triangulate`.
@@ -347,6 +354,12 @@ class PolyDataFilters(DataSetFilters):
 
     def intersection(poly_data, mesh, split_first=True, split_second=True):
         """Compute the intersection between two meshes.
+
+        .. note::
+           This method returns the surface interection from two meshes
+           (which often resolves as a line), whereas the
+           :func:`PolyDataFilters.boolean_intersection` filter returns
+           the "volume" intersection between two meshes.
 
         Parameters
         ----------

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -111,6 +111,11 @@ class PolyDataFilters(DataSetFilters):
            to create a manifold mesh and will not include internal
            surfaces when two meshes overlap.
 
+        .. note::
+           Both meshes must be composed of all triangles.  Check with
+           :func:`PolyData.is_all_triangles` and convert with
+           :func:`PolyDataFilters.triangulate`.
+
         .. versionchanged:: 0.32.0
            Behavior changed to match default VTK behavior.
 
@@ -166,6 +171,11 @@ class PolyDataFilters(DataSetFilters):
            :func:`PolyDataFilters.plot_normals` to visualize the
            normals.
 
+        .. note::
+           Both meshes must be composed of all triangles.  Check with
+           :func:`PolyData.is_all_triangles` and convert with
+           :func:`PolyDataFilters.triangulate`.
+
         .. versionadded:: 0.32.0
 
         Parameters
@@ -219,6 +229,11 @@ class PolyDataFilters(DataSetFilters):
            probably has its normals pointing inward. Use
            :func:`PolyDataFilters.plot_normals` to visualize the
            normals.
+
+        .. note::
+           Both meshes must be composed of all triangles.  Check with
+           :func:`PolyData.is_all_triangles` and convert with
+           :func:`PolyDataFilters.triangulate`.
 
         .. versionchanged:: 0.32.0
            Behavior changed to match default VTK behavior.

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -25,6 +25,22 @@ class PolyDataFilters(DataSetFilters):
         angle : float
             Angle to consider an edge.
 
+        Returns
+        -------
+        numpy.ndarray
+            Mask of points with an angle greater than ``angle``.
+
+        Examples
+        --------
+        Plot the mask of points that exceed 45 degrees.
+
+        >>> import pyvista
+        >>> mesh = pyvista.Cube().triangulate().subdivide(4).clean()
+        >>> mask = mesh.edge_mask(45)
+        >>> mask  # doctest:+SKIP
+        array([ True,  True,  True, ..., False, False, False])
+        >>> mesh.plot(scalars=mask)
+
         """
         if not isinstance(poly_data, pyvista.PolyData):  # pragma: no cover
             poly_data = pyvista.PolyData(poly_data)
@@ -56,8 +72,27 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        mesh : pyvista.PolyData
+        pyvista.PolyData
             The cut mesh.
+
+        Examples
+        --------
+        Create a cube and a sphere and plot them
+
+        >>> import pyvista
+        >>> cube = pyvista.Cube().triangulate().subdivide(2).clean()
+        >>> sphere = pyvista.Sphere(center=(0.5, 0.5, 0.5))
+        >>> pyvista.plot([cube, sphere], style='wireframe', cpos='xz')
+
+        Cut the sphere with the cube.
+
+        >>> cube_cutting_sphere = sphere.boolean_cut(cube)
+        >>> cube_cutting_sphere.plot(cpos='xz', show_edges=True)
+
+        Reverse the order and cut the cube with the sphere.
+
+        >>> sphere_cutting_cube = cube.boolean_cut(sphere)
+        >>> sphere_cutting_cube.plot(show_edges=True)
 
         """
         if not isinstance(cut, pyvista.PolyData):
@@ -66,8 +101,7 @@ class PolyDataFilters(DataSetFilters):
             raise NotAllTrianglesError("Make sure both the input and output are triangulated.")
 
         bfilter = _vtk.vtkBooleanOperationPolyDataFilter()
-        bfilter.SetOperationToIntersection()
-        # bfilter.SetOperationToDifference()
+        bfilter.SetOperationToDifference()
 
         bfilter.SetInputData(1, cut)
         bfilter.SetInputData(0, poly_data)
@@ -79,8 +113,7 @@ class PolyDataFilters(DataSetFilters):
         if inplace:
             poly_data.overwrite(mesh)
             return poly_data
-        else:
-            return mesh
+        return mesh
 
     def boolean_add(poly_data, mesh, inplace=False):
         """Add a mesh to the current mesh.

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -113,9 +113,9 @@ class PolyDataFilters(DataSetFilters):
         >>> sphere_b = pyvista.Sphere(center=(0.5, 0, 0))
         >>> result = sphere_a.boolean_union(sphere_b)
         >>> pl = pyvista.Plotter()
-        >>> pl.add_mesh(sphere_a, color='r', style='wireframe', line_width=3)
-        >>> pl.add_mesh(sphere_b, color='b', style='wireframe', line_width=3)
-        >>> pl.add_mesh(result, color='tan')
+        >>> _ = pl.add_mesh(sphere_a, color='r', style='wireframe', line_width=3)
+        >>> _ = pl.add_mesh(sphere_b, color='b', style='wireframe', line_width=3)
+        >>> _ = pl.add_mesh(result, color='tan')
         >>> pl.camera_position = 'xz'
         >>> pl.show()
 
@@ -164,9 +164,9 @@ class PolyDataFilters(DataSetFilters):
         >>> sphere_b = pyvista.Sphere(center=(0.5, 0, 0))
         >>> result = sphere_a.boolean_intersection(sphere_b)
         >>> pl = pyvista.Plotter()
-        >>> pl.add_mesh(sphere_a, color='r', style='wireframe', line_width=3)
-        >>> pl.add_mesh(sphere_b, color='b', style='wireframe', line_width=3)
-        >>> pl.add_mesh(result, color='tan')
+        >>> _ = pl.add_mesh(sphere_a, color='r', style='wireframe', line_width=3)
+        >>> _ = pl.add_mesh(sphere_b, color='b', style='wireframe', line_width=3)
+        >>> _ = pl.add_mesh(result, color='tan')
         >>> pl.camera_position = 'xz'
         >>> pl.show()
 
@@ -209,9 +209,9 @@ class PolyDataFilters(DataSetFilters):
         >>> sphere_b = pyvista.Sphere(center=(0.5, 0, 0))
         >>> result = sphere_a.boolean_difference(sphere_b)
         >>> pl = pyvista.Plotter()
-        >>> pl.add_mesh(sphere_a, color='r', style='wireframe', line_width=3)
-        >>> pl.add_mesh(sphere_b, color='b', style='wireframe', line_width=3)
-        >>> pl.add_mesh(result, color='tan')
+        >>> _ = pl.add_mesh(sphere_a, color='r', style='wireframe', line_width=3)
+        >>> _ = pl.add_mesh(sphere_b, color='b', style='wireframe', line_width=3)
+        >>> _ = pl.add_mesh(result, color='tan')
         >>> pl.camera_position = 'xz'
         >>> pl.show()
 

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -297,18 +297,17 @@ class PolyDataFilters(DataSetFilters):
         >>> merged.plot(style='wireframe', color='tan')
 
         """
+        # check if dataset or datasets are not polydata
+        if isinstance(dataset, (list, tuple, pyvista.MultiBlock)):
+            not_pd = any(not isinstance(data, pyvista.PolyData) for data in dataset)
+        else:
+            not_pd = not isinstance(dataset, pyvista.PolyData)
+
         # use dataset merge if not polydata
-        if not isinstance(dataset, pyvista.PolyData):
-            if isinstance(dataset, (list, tuple, pyvista.MultiBlock)):
-                for data in dataset:
-                    if not isinstance(data, pyvista.PolyData):
-                        return DataSetFilters.merge(poly_data, dataset,
-                                                    merge_points=merge_points,
-                                                    inplace=inplace)
-            else:
-                return DataSetFilters.merge(poly_data, dataset,
-                                            merge_points=merge_points,
-                                            inplace=inplace)
+        if not_pd:
+            return DataSetFilters.merge(poly_data, dataset,
+                                        merge_points=merge_points,
+                                        inplace=inplace)
 
         append_filter = pyvista._vtk.vtkAppendPolyData()
         append_filter.AddInputData(poly_data)

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -44,7 +44,7 @@ class PolyDataFilters(DataSetFilters):
                        assume_unique=True)
 
     def _boolean(poly_data, btype, other_mesh, tolerance):
-        """Perform boolean operation"""
+        """Perform boolean operation."""
         if not isinstance(other_mesh, pyvista.PolyData):
             raise TypeError("Input mesh must be PolyData.")
         if not poly_data.is_all_triangles() or not other_mesh.is_all_triangles():
@@ -103,35 +103,15 @@ class PolyDataFilters(DataSetFilters):
         outward.  This is the "normal" behavior.
 
         >>> import pyvista
-        >>> cube = pyvista.Cube().triangulate().subdivide(3).clean()
-        >>> sphere = pyvista.Sphere(radius=0.6)
-        >>> result = cube.boolean_union(sphere)
-        >>> result.plot(color='tan')
-
-        Boolean union with cube normals outward, sphere inward.
-
-        >>> cube = pyvista.Cube().triangulate().subdivide(3).clean()
-        >>> sphere = pyvista.Sphere(radius=0.6)
-        >>> sphere.flip_normals()
-        >>> result = cube.boolean_union(sphere)
-        >>> result.plot(color='tan')
-
-        Boolean union with cube normals inward, sphere outward.
-
-        >>> cube = pyvista.Cube().triangulate().subdivide(3).clean()
-        >>> cube.flip_normals()
-        >>> sphere = pyvista.Sphere(radius=0.6)
-        >>> result = cube.boolean_union(sphere)
-        >>> result.plot(color='tan')
-
-        Both cube and sphere normals inward.
-
-        >>> cube = pyvista.Cube().triangulate().subdivide(3).clean()
-        >>> cube.flip_normals()
-        >>> sphere = pyvista.Sphere(radius=0.6)
-        >>> sphere.flip_normals()
-        >>> result = cube.boolean_union(sphere)
-        >>> result.plot(color='tan')
+        >>> sphere_a = pyvista.Sphere()
+        >>> sphere_b = pyvista.Sphere(center=(0.5, 0, 0))
+        >>> result = sphere_a.boolean_union(sphere_b)
+        >>> pl = pyvista.Plotter()
+        >>> pl.add_mesh(sphere_a, color='r', style='wireframe')
+        >>> pl.add_mesh(sphere_b, color='b', style='wireframe')
+        >>> pl.add_mesh(result, color='tan')
+        >>> pl.camera_position = 'yz'
+        >>> pl.show()
 
         See :ref:`boolean_example` for more examples using this filter.
 

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -153,7 +153,7 @@ class PolyDataFilters(DataSetFilters):
         else:
             return mesh
 
-    def boolean_difference(poly_data, mesh, inplace=False):
+    def boolean_union(poly_data, mesh, inplace=False):
         """Combine two meshes and retains only the volume in common between the meshes.
 
         Parameters
@@ -174,7 +174,7 @@ class PolyDataFilters(DataSetFilters):
             raise TypeError("Input mesh must be PolyData.")
 
         bfilter = _vtk.vtkBooleanOperationPolyDataFilter()
-        bfilter.SetOperationToDifference()
+        bfilter.SetOperationToIntersection()
         bfilter.SetInputData(1, mesh)
         bfilter.SetInputData(0, poly_data)
         bfilter.ReorientDifferenceCellsOff()

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -6,9 +6,10 @@ import numpy as np
 
 import pyvista
 from pyvista import (
-    abstract_class, _vtk, NORMALS, generate_plane, assert_empty_kwargs, vtk_id_list_to_array, get_array
+    abstract_class, _vtk, NORMALS, generate_plane, assert_empty_kwargs,
+    vtk_id_list_to_array, get_array
 )
-from pyvista.core.errors import NotAllTrianglesError
+from pyvista.core.errors import NotAllTrianglesError, DeprecationError
 from pyvista.core.filters import _get_output, _update_alg
 from pyvista.core.filters.data_set import DataSetFilters
 
@@ -67,6 +68,24 @@ class PolyDataFilters(DataSetFilters):
 
         return _get_output(bfilter)
 
+    def boolean_cut(poly_data, *args, **kwargs):  # pragma: no cover
+        """Cut two meshes.
+
+        .. deprecated:: 0.31.0
+           Use :func:`PolyDataFilters.boolean_difference` instead.
+
+        """
+        DeprecationError('``boolean_cut`` has ben deprecated.  Please use ``boolean_difference``.')
+
+    def boolean_add(poly_data, *args, **kwargs):  # pragma: no cover
+        """Merge two meshes together.
+
+        .. deprecated:: 0.31.0
+           Use :func:`PolyDataFilters.merge` instead.
+
+        """
+        DeprecationError('``boolean_add`` has been deprecated.  Please use ``merge``.')
+
     def boolean_union(poly_data, other_mesh, tolerance=1E-5):
         """Perform a boolean union operation on two meshes.
 
@@ -88,6 +107,9 @@ class PolyDataFilters(DataSetFilters):
            :func:`PolyDataFilters.merge` filter.  This filter attempts
            to create a manifold mesh and will not include internal
            surfaces when two meshes overlap.
+
+        .. versionchanged:: 0.31.0
+           Behavior changed to match default VTK behavior.
 
         Parameters
         ----------
@@ -140,6 +162,8 @@ class PolyDataFilters(DataSetFilters):
            probably has its normals pointing inward. Use
            :func:`PolyDataFilters.plot_normals` visualize the normals.
 
+        .. versionadded:: 0.31.0
+
         Parameters
         ----------
         other_mesh : pyvista.PolyData
@@ -184,6 +208,9 @@ class PolyDataFilters(DataSetFilters):
 
         The difference of two manifold meshes ``A`` and ``B`` is the
         volume of the mesh in ``A`` not belonging to ``B``.
+
+        .. versionchanged:: 0.31.0
+           Behavior changed to match default VTK behavior.
 
         Parameters
         ----------

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -102,7 +102,6 @@ class PolyDataFilters(DataSetFilters):
 
         bfilter = _vtk.vtkBooleanOperationPolyDataFilter()
         bfilter.SetOperationToDifference()
-
         bfilter.SetInputData(1, cut)
         bfilter.SetInputData(0, poly_data)
         bfilter.ReorientDifferenceCellsOff()

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -25,22 +25,6 @@ class PolyDataFilters(DataSetFilters):
         angle : float
             Angle to consider an edge.
 
-        Returns
-        -------
-        numpy.ndarray
-            Mask of points with an angle greater than ``angle``.
-
-        Examples
-        --------
-        Plot the mask of points that exceed 45 degrees.
-
-        >>> import pyvista
-        >>> mesh = pyvista.Cube().triangulate().subdivide(4).clean()
-        >>> mask = mesh.edge_mask(45)
-        >>> mask  # doctest:+SKIP
-        array([ True,  True,  True, ..., False, False, False])
-        >>> mesh.plot(scalars=mask)
-
         """
         if not isinstance(poly_data, pyvista.PolyData):  # pragma: no cover
             poly_data = pyvista.PolyData(poly_data)
@@ -72,27 +56,8 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        pyvista.PolyData
+        mesh : pyvista.PolyData
             The cut mesh.
-
-        Examples
-        --------
-        Create a cube and a sphere and plot them
-
-        >>> import pyvista
-        >>> cube = pyvista.Cube().triangulate().subdivide(2).clean()
-        >>> sphere = pyvista.Sphere(center=(0.5, 0.5, 0.5))
-        >>> pyvista.plot([cube, sphere], style='wireframe', cpos='xz')
-
-        Cut the sphere with the cube.
-
-        >>> cube_cutting_sphere = sphere.boolean_cut(cube)
-        >>> cube_cutting_sphere.plot(cpos='xz', show_edges=True)
-
-        Reverse the order and cut the cube with the sphere.
-
-        >>> sphere_cutting_cube = cube.boolean_cut(sphere)
-        >>> sphere_cutting_cube.plot(show_edges=True)
 
         """
         if not isinstance(cut, pyvista.PolyData):

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -337,7 +337,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         return False
 
     def __sub__(self, cutting_mesh):
-        """Subtract difference of two meshes."""
+        """Compute boolean difference of two meshes."""
         return self.boolean_difference(cutting_mesh)
 
     @property

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -337,8 +337,8 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         return False
 
     def __sub__(self, cutting_mesh):
-        """Subtract two meshes."""
-        return self.boolean_cut(cutting_mesh)
+        """Subtract difference of two meshes."""
+        return self.boolean_difference(cutting_mesh)
 
     @property
     def n_faces(self):

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -280,7 +280,7 @@ def test_boolean_union(sphere, sphere_shifted):
 
     # union is volume of sphere + sphere_shifted minus the part intersecting
     expected_volume = sphere.volume + sphere_shifted.volume - intersection.volume
-    np.allclose(union.volume, expected_volume, atol=1E-3)
+    assert np.isclose(union.volume, expected_volume, atol=1E-3)
 
 
 def test_boolean_intersection(sphere, sphere_shifted):
@@ -288,7 +288,7 @@ def test_boolean_intersection(sphere, sphere_shifted):
     union = sphere.boolean_union(sphere_shifted)
 
     expected_volume = union.volume - (sphere.volume + sphere_shifted.volume)
-    np.allclose(intersection.volume, expected_volume, atol=1E-3)
+    assert np.isclose(intersection.volume, expected_volume, atol=1E-3)
 
 
 def test_boolean_difference(sphere, sphere_shifted):
@@ -296,7 +296,7 @@ def test_boolean_difference(sphere, sphere_shifted):
     intersection = sphere.boolean_intersection(sphere_shifted)
 
     expected_volume = sphere.volume - intersection.volume
-    np.allclose(difference.volume, expected_volume, atol=1E-3)
+    assert np.isclose(difference.volume, expected_volume, atol=1E-3)
 
 
 def test_boolean_difference_fail(plane):

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -287,7 +287,7 @@ def test_boolean_intersection(sphere, sphere_shifted):
     intersection = sphere.boolean_intersection(sphere_shifted)
     union = sphere.boolean_union(sphere_shifted)
 
-    expected_volume = union.volume - (sphere.volume + sphere_shifted.volume)
+    expected_volume = sphere.volume + sphere_shifted.volume - union.volume
     assert np.isclose(intersection.volume, expected_volume, atol=1E-3)
 
 

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -309,7 +309,7 @@ def test_boolean_add_inplace(sphere, sphere_shifted):
     assert sub_mesh.n_cells
 
 
-def test_boolean_union_inplace(sphere, sphere_shifted):
+def test_boolean_union(sphere, sphere_shifted):
     sub_mesh = sphere.boolean_union(sphere_shifted)
     assert sub_mesh.n_points
     assert sub_mesh.n_cells
@@ -320,13 +320,13 @@ def test_boolean_union_inplace(sphere, sphere_shifted):
     assert sub_mesh.n_cells
 
 
-def test_boolean_union(sphere, sphere_shifted):
-    sub_mesh = sphere.copy()
-    sub_mesh.boolean_union(sphere_shifted, inplace=True)
+def test_boolean_intersection(sphere, sphere_shifted):
+    sub_mesh = sphere.boolean_intersection(sphere_shifted)
     assert sub_mesh.n_points
     assert sub_mesh.n_cells
 
-    sub_mesh = sphere.boolean_union(sphere_shifted)
+    sub_mesh = sphere
+    sub_mesh.boolean_intersection(sphere_shifted, inplace=True)
     assert sub_mesh.n_points
     assert sub_mesh.n_cells
 

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -274,7 +274,7 @@ def test_edge_mask(sphere):
     mask = sphere.edge_mask(10)
 
 
-def test_boolean_union(sphere, sphere_shifted):
+def test_boolean_union_intersection(sphere, sphere_shifted):
     union = sphere.boolean_union(sphere_shifted)
     intersection = sphere.boolean_intersection(sphere_shifted)
 
@@ -282,11 +282,7 @@ def test_boolean_union(sphere, sphere_shifted):
     expected_volume = sphere.volume + sphere_shifted.volume - intersection.volume
     assert np.isclose(union.volume, expected_volume, atol=1E-3)
 
-
-def test_boolean_intersection(sphere, sphere_shifted):
-    intersection = sphere.boolean_intersection(sphere_shifted)
-    union = sphere.boolean_union(sphere_shifted)
-
+    # intersection volume is the volume of both isolated meshes minus the union
     expected_volume = sphere.volume + sphere_shifted.volume - union.volume
     assert np.isclose(intersection.volume, expected_volume, atol=1E-3)
 

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -320,13 +320,13 @@ def test_boolean_union_inplace(sphere, sphere_shifted):
     assert sub_mesh.n_cells
 
 
-def test_boolean_difference(sphere, sphere_shifted):
+def test_boolean_union(sphere, sphere_shifted):
     sub_mesh = sphere.copy()
-    sub_mesh.boolean_difference(sphere_shifted, inplace=True)
+    sub_mesh.boolean_union(sphere_shifted, inplace=True)
     assert sub_mesh.n_points
     assert sub_mesh.n_cells
 
-    sub_mesh = sphere.boolean_difference(sphere_shifted)
+    sub_mesh = sphere.boolean_union(sphere_shifted)
     assert sub_mesh.n_points
     assert sub_mesh.n_cells
 

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -309,14 +309,37 @@ def test_subtract(sphere, sphere_shifted):
     assert sub_mesh.n_points == sphere.boolean_difference(sphere_shifted).n_points
 
 
+def test_merge(sphere, sphere_shifted, hexbeam):
+    merged = sphere.merge(hexbeam)
+    assert merged.n_points == (sphere.n_points + hexbeam.n_points)
+    assert isinstance(merged, pyvista.UnstructuredGrid)
+
+    # list with unstructuredgrid case
+    merged = sphere.merge([hexbeam, hexbeam], merge_points=False)
+    assert merged.n_points == (sphere.n_points + hexbeam.n_points*2)
+    assert isinstance(merged, pyvista.UnstructuredGrid)
+
+    # with polydata
+    merged = sphere.merge(sphere_shifted)
+    assert isinstance(merged, pyvista.PolyData)
+    assert merged.n_points == sphere.n_points + sphere_shifted.n_points
+
+    # with polydata list (no merge)
+    merged = sphere.merge([sphere_shifted, sphere_shifted], merge_points=False)
+    assert isinstance(merged, pyvista.PolyData)
+    assert merged.n_points == sphere.n_points + sphere_shifted.n_points*2
+
+    # with polydata list (merge)
+    merged = sphere.merge([sphere_shifted, sphere_shifted])
+    assert isinstance(merged, pyvista.PolyData)
+    assert merged.n_points == sphere.n_points + sphere_shifted.n_points
+
+
 def test_add(sphere, sphere_shifted):
-    add_mesh = sphere + sphere_shifted
-
-    npoints = sphere.n_points + sphere_shifted.n_points
-    assert add_mesh.n_points == npoints
-
-    nfaces = sphere.n_cells + sphere_shifted.n_cells
-    assert add_mesh.n_faces == nfaces
+    merged = sphere + sphere_shifted
+    assert isinstance(merged, pyvista.PolyData)
+    assert merged.n_points == sphere.n_points + sphere_shifted.n_points
+    assert merged.n_faces == sphere.n_cells + sphere_shifted.n_cells
 
 
 def test_intersection(sphere, sphere_shifted):


### PR DESCRIPTION
Current behavior of boolean cut uses ``SetOperationToIntersection``, which does not produce the desired behavior of actually cutting.  For example:

```py
>>> import pyvista
>>> cube = pyvista.Cube().triangulate().subdivide(2).clean()
>>> sphere = pyvista.Sphere(center=(0.5, 0.5, 0.5))
>>> sphere_cutting_cube = cube.boolean_cut(sphere)
>>> sphere_cutting_cube.plot(show_edges=True)
```

Produces the union of the two meshes:
![wrong](https://user-images.githubusercontent.com/11981631/124370237-5657c400-dc32-11eb-9461-a849be7261f6.png)

---

This PR corrects this behavior to instead use ``SetOperationToDifference``, which returns the correct mesh:
![right](https://user-images.githubusercontent.com/11981631/124370238-5bb50e80-dc32-11eb-8a7a-b8dd67c782a9.png)


### Fix ``boolean_difference``
Boolean difference is now ``boolean_cut``.  Needing a `intersection` operation, this PR also changes ``boolean_difference`` to ``boolean_intersection``, which ironically already has a docstring matching the behavior of `SetOperationToIntersection`.