### PR TITLE
Check all_scalars before assigning scalars by default

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -589,14 +589,14 @@ class DataSetFilters:
         >>> threshed = v.threshold(0.1)
 
         """
-        # set the scalaras to threshold on
+        if all_scalars and scalars is not None:
+            raise ValueError('Setting `all_scalars=True` and designating `scalars` '
+                             'is incompatible.  Set one or the other but not both.')
+
+        # set the scalars to threshold on
         if scalars is None:
             field, scalars = dataset.active_scalars_info
         arr, field = get_array(dataset, scalars, preference=preference, info=True)
-
-        if all_scalars and scalars is not None:
-            raise ValueError('Setting `all_scalars=True` and designating `scalars` '
-                             'is incompatible.  Set one or the other but not both')
 
         if arr is None:
             raise ValueError('No arrays present to threshold.')


### PR DESCRIPTION
The `threshold()` filter supports the `all_scalars` kwarg:
```
        all_scalars : bool, optional
            If using scalars from point data, all scalars for all
            points in a cell must satisfy the threshold when this
            value is ``True``.  When ``False``, any point of the cell
            with a scalar value satisfying the threshold criterion
            will extract the cell.
```

When enabling this keyword we get an error:
```py
>>> import pyvista as pv
>>> mesh = pv.Cube()
>>> mesh['scalars'] = mesh.points[:, -1]
>>> mesh.threshold(all_scalars=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/adeak/pyvista/pyvista/core/filters/data_set.py", line 598, in threshold
    raise ValueError('Setting `all_scalars=True` and designating `scalars` '
ValueError: Setting `all_scalars=True` and designating `scalars` is incompatible.  Set one or the other but not both
```

We didn't set any scalars! The check for this error came after a reassignment of `scalars` when it was `None`:
```py
        # set the scalaras to threshold on
        if scalars is None:
            field, scalars = dataset.active_scalars_info
        arr, field = get_array(dataset, scalars, preference=preference, info=True)

        if all_scalars and scalars is not None:
            raise ValueError('Setting `all_scalars=True` and designating `scalars` '
                             'is incompatible.  Set one or the other but not both')
```

Since we need scalars to threshold (we even get an error when there are no scalars), it seems the second check should just be moved before the first check.

I also don't see why `scalars='something'` and `all_scalars=True` are mutually exclusive. Is there really a good reason for this?