### PR TITLE
narrow mac version testing

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -13,7 +13,7 @@ jobs:
     name: Mac OS Unit Testing
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8']
 
     env:
       ALLOW_PLOTTING: true


### PR DESCRIPTION
### Narrow MacOS CI version testing to 3.7 and 3.8

MacOS concurrency limits are a quarter that of Windows and Linux [GitHub Actions Limits](https://docs.github.com/en/actions/reference/usage-limits-billing-and-administration), and our MacOS CI is sometimes quite backed up.  This PR limits MacOS testing to just the two most popular versions according to [PyPi Download Stats - PyVista](https://docs.github.com/en/actions/reference/usage-limits-billing-and-administration).



