### PR TITLE
Refactor MultiBlock and slice_along_axis

### DIFF
--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -224,12 +224,7 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
         1.7348
 
         """
-        volume = 0.0
-        for block in self:
-            if block is None:
-                continue
-            volume += block.volume
-        return volume
+        return sum(block.volume for block in self if block)
 
     def get_data_range(self, name: str) -> Tuple[float, float]:  # type: ignore
         """Get the min/max of an array given its name across all blocks."""

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -135,25 +135,12 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
         [-0.5, 2.5, -0.5, 2.5, -0.5, 0.5]
 
         """
-        bounds = [np.inf, -np.inf, np.inf, -np.inf, np.inf, -np.inf]
-
-        def update_bounds(ax, nb, bounds):
-            """Update bounds while keeping track (internal helper)."""
-            if nb[2*ax] < bounds[2*ax]:
-                bounds[2*ax] = nb[2*ax]
-            if nb[2*ax+1] > bounds[2*ax+1]:
-                bounds[2*ax+1] = nb[2*ax+1]
-            return bounds
-
-        # get bounds for each block and update
-        for i in range(self.n_blocks):
-            if self[i] is None:
-                continue
-            bnds = self[i].bounds  # type: ignore
-            for a in range(3):
-                bounds = update_bounds(a, bnds, bounds)
-
-        return bounds
+        # apply reduction of min and max over each block
+        all_bounds = [block.bounds for block in self if block]
+        minima = np.minimum.reduce(all_bounds)[::2]
+        maxima = np.maximum.reduce(all_bounds)[1::2]
+        # interleave minima and maxima for bounds
+        return np.stack([minima, maxima]).ravel('F').tolist()
 
     @property
     def center(self) -> Any:

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -514,7 +514,7 @@ class DataSetFilters:
             The tolerance to the edge of the dataset bounds to create
             the slices. The ``n`` slices are placed equidistantly with
             an absolute padding of ``tolerance`` inside each side of the
-            ``bounds``- along the specified axis. Defaults to 1% of the
+            ``bounds`` along the specified axis. Defaults to 1% of the
             ``bounds`` along the specified axis.
 
         generate_triangles: bool, optional

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -23,7 +23,7 @@ def pyvista_multi():
 
 def multi_from_datasets(*datasets):
     """Return pyvista multiblock composed of any number of datasets."""
-    return MultiBlock([*datasets])
+    return MultiBlock(datasets)
 
 
 def test_multi_block_init_vtk():
@@ -358,7 +358,8 @@ def test_multi_block_list_index(ant, sphere, uniform, airplane, globe):
 
 def test_multi_block_volume(ant, airplane, sphere, uniform):
     multi = multi_from_datasets(ant, sphere, uniform, airplane, None)
-    assert multi.volume
+    vols = ant.volume + sphere.volume + uniform.volume + airplane.volume
+    assert multi.volume == pytest.approx(vols)
 
 
 def test_multi_block_length(ant, sphere, uniform, airplane):


### PR DESCRIPTION
Some refactors that came up during https://github.com/pyvista/pyvista/pull/1482. Closes https://github.com/pyvista/pyvista/issues/1494.

- [x] https://github.com/pyvista/pyvista/pull/1482#discussion_r664015140 (refactor `MultiBlock.bounds`)
- [x] https://github.com/pyvista/pyvista/pull/1482#discussion_r664019043 (refactor `MultiBlock.volume`)
- [x] ~~https://github.com/pyvista/pyvista/pull/1482#discussion_r664022363 (refactor `MultiBlock.get_block_name`)~~ we can't actually refactor this because we'd need `.keys()` and `.keys()` is defined in terms of `get_block_name`...
- [x] https://github.com/pyvista/pyvista/pull/1482#discussion_r664094024 (refactor `DataSetFilters.slice_along_axis`)