### PR TITLE
Add save texture for PLY

### DIFF
--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -67,7 +67,8 @@ class DataObject:
             the extension of the filename.
 
         binary : bool, optional
-            If True, write as binary, else ASCII.
+            If ``True``, write as binary.  Otherwise, write as ASCII.
+            
 
         texture : str, np.ndarray, optional
             Write a single texture array to file when using a PLY

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -115,7 +115,7 @@ class DataObject:
                 writer.SetArrayName(array_name)
 
             # enable alpha channel if applicable
-            if self[array_name].shape[-1] == 4:
+            if self[array_name].shape[-1] == 4:  # type: ignore
                 writer.SetEnableAlpha(True)
         writer.Write()
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -406,6 +406,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         Save a mesh as a PLY with a texture array.  Here we also
         create a simple RGB array representing the texture.
 
+        >>> import numpy as np
         >>> sphere = pyvista.Sphere()
         >>> texture = np.zeros((sphere.n_points, 3), np.uint8)
         >>> texture[:, 1] = np.arange(sphere.n_points)[::-1]  # just blue channel

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -372,7 +372,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
             types (``'.ply'``, ``'.stl'``, ``'.vtk``)
 
         binary : bool, optional
-            Writes the file as binary when True and ASCII when False.
+            Writes the file as binary when ``True`` and ASCII when ``False``.
 
         texture : str, np.ndarray, optional
             Write a single texture array to file when using a PLY

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1,4 +1,5 @@
 """Sub-classes and wrappers for vtk.vtkPointSet."""
+from pathlib import Path
 from textwrap import dedent
 import pathlib
 import logging
@@ -355,7 +356,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         raise DeprecationError('``number_of_faces`` has been depreciated.  '
                                'Please use ``n_faces``')
 
-    def save(self, filename, binary=True):
+    def save(self, filename, binary=True, texture=None):
         """Write a surface mesh to disk.
 
         Written file may be an ASCII or binary ply, stl, or vtk mesh
@@ -367,11 +368,60 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         filename : str
             Filename of mesh to be written.  File type is inferred from
             the extension of the filename unless overridden with
-            ftype.  Can be one of the following types (.ply, .stl,
-            .vtk)
+            ftype.  Can be one of many of the supported  the following
+            types (``'.ply'``, ``'.stl'``, ``'.vtk``)
 
         binary : bool, optional
             Writes the file as binary when True and ASCII when False.
+
+        texture : str, np.ndarray, optional
+            Write a single texture array to file when using a PLY
+            file.  Texture array must be a 3 or 4 component array with
+            the datatype ``np.uint8``.  Array may be a cell array or a
+            point array, and may also be a string if the array already
+            exists in the PolyData.
+
+            If a string is provided, the texture array will be saved
+            to disk as that name.  If an array is provided, the
+            texture array will be saved as ``'RGBA'`` if the array
+            contains an alpha channel (i.e. 4 component array), or
+            as ``'RGB'`` if the array is just a 3 component array.
+
+            .. note::
+               This feature is only available when saving PLY files. 
+
+        Examples
+        --------
+        Save a mesh as a STL.
+
+        >>> import pyvista
+        >>> sphere = pyvista.Sphere()
+        >>> sphere.save('my_mesh.stl')  # doctest: +SKIP
+
+        Save a mesh as a PLY.
+
+        >>> sphere = pyvista.Sphere()
+        >>> sphere.save('my_mesh.ply')  # doctest: +SKIP
+
+        Save a mesh as a PLY with a texture array.  Here we also
+        create a simple RGB array representing the texture.
+
+        >>> sphere = pyvista.Sphere()
+        >>> texture = np.zeros((sphere.n_points, 3), np.uint8)
+        >>> texture[:, 1] = np.arange(sphere.n_points)[::-1]  # just blue channel
+        >>> sphere.point_arrays['my_texture'] = texture
+        >>> sphere.save('my_mesh.ply', texture='my_texture')  # doctest: +SKIP
+
+        Alternatively, provide just the texture array.  This will be
+        written to the file as ``'RGB'`` since it does not contain an
+        alpha channel.
+
+        >>> sphere.save('my_mesh.ply', texture=texture)  # doctest: +SKIP
+
+        Save a mesh as a VTK file.
+
+        >>> sphere = pyvista.Sphere()
+        >>> sphere.save('my_mesh.vtk')  # doctest: +SKIP
 
         Notes
         -----
@@ -383,9 +433,24 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         ftype = get_ext(filename)
         # Recompute normals prior to save.  Corrects a bug were some
         # triangular meshes are not saved correctly
-        if ftype in ['stl', 'ply']:
+        if ftype in ['.stl', '.ply']:
             self.compute_normals(inplace=True)
-        super().save(filename, binary)
+
+        # validate texture
+        if ftype == '.ply' and texture is not None:
+            if isinstance(texture, str):
+                if self[texture].dtype != np.uint8:
+                    raise ValueError(f'Invalid datatype {self[texture].dtype} of '
+                                     f'texture array "{texture}"')
+            elif isinstance(texture, np.ndarray):
+                if texture.dtype != np.uint8:
+                    raise ValueError(f'Invalid datatype {texture.dtype} of texture array')
+            else:
+                raise TypeError(f'Invalid type {type(texture)} for texture.  '
+                                'Should be either a string representing a point or '
+                                'cell array, or an array.')
+
+        super().save(filename, binary, texture=texture)
 
     @property
     def area(self):

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -449,7 +449,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
             else:
                 raise TypeError(f'Invalid type {type(texture)} for texture.  '
                                 'Should be either a string representing a point or '
-                                'cell array, or an array.')
+                                'cell array, or a numpy array.')
 
         super().save(filename, binary, texture=texture)
 

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -384,6 +384,40 @@ def test_save(sphere, extension, binary, tmpdir):
     assert mesh.points.shape == sphere.points.shape
 
 
+@pytest.mark.parametrize('as_str', [True, False])
+@pytest.mark.parametrize('ndim', [3, 4])
+def test_save_ply_texture_array(sphere, ndim, as_str, tmpdir):
+    filename = str(tmpdir.mkdir("tmpdir").join(f'tmp.ply'))
+
+    texture = np.ones((sphere.n_points, ndim), np.uint8)
+    texture[:, 2] = np.arange(sphere.n_points)[::-1]
+    if as_str:
+        sphere.point_arrays['texture'] = texture
+        sphere.save(filename, texture='texture')
+    else:
+        sphere.save(filename, texture=texture)
+
+    mesh = pyvista.PolyData(filename)
+    color_array_name = 'RGB' if ndim == 3 else 'RGBA'
+    assert np.allclose(mesh[color_array_name], texture)
+
+
+@pytest.mark.parametrize('as_str', [True, False])
+def test_save_ply_texture_array_catch(sphere, as_str, tmpdir):
+    filename = str(tmpdir.mkdir("tmpdir").join(f'tmp.ply'))
+
+    texture = np.ones((sphere.n_points, 3), np.float32)
+    with pytest.raises(ValueError, match='Invalid datatype'):
+        if as_str:
+            sphere.point_arrays['texture'] = texture
+            sphere.save(filename, texture='texture')
+        else:
+            sphere.save(filename, texture=texture)
+
+    with pytest.raises(TypeError):
+        sphere.save(filename, texture=[1, 2, 3])
+
+
 def test_pathlib_read_write(tmpdir, sphere):
     path = pathlib.Path(str(tmpdir.mkdir("tmpdir").join('tmp.vtk')))
     sphere.save(path)


### PR DESCRIPTION
This PR adds the ability to save textures when writing PLY files.  Resolves #1503.

```py
Save a mesh as a PLY with a texture array.  Here we also
create a simple RGB array representing the texture.

>>> import pyvista
>>> sphere = pyvista.Sphere()
>>> texture = np.zeros((sphere.n_points, 3), np.uint8)
>>> texture[:, 1] = np.arange(sphere.n_points)[::-1]  # just blue channel
>>> sphere.point_arrays['my_texture'] = texture
>>> sphere.save('my_mesh.ply', texture='my_texture')

```
