### PR TITLE
Remove almost all remaining doctest prints

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -919,7 +919,7 @@ class DataSet(DataSetFilters, DataObject):
         >>> import numpy as np
         >>> points = np.random.random((1000, 3))
         >>> indices = mesh.find_closest_cell(points)
-        >>> print(indices.shape)
+        >>> indices.shape
         (1000,)
         """
         if isinstance(point, collections.abc.Sequence):

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -229,8 +229,8 @@ class DataSetFilters:
         >>> plane = pv.Plane()
         >>> _ = sphere.compute_implicit_distance(plane, inplace=True)
         >>> dist = sphere['implicit_distance']
-        >>> print(type(dist))
-        <class 'numpy.ndarray'>
+        >>> type(dist)
+        numpy.ndarray
 
         Plot these distances as a heatmap
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -230,7 +230,7 @@ class DataSetFilters:
         >>> _ = sphere.compute_implicit_distance(plane, inplace=True)
         >>> dist = sphere['implicit_distance']
         >>> type(dist)
-        numpy.ndarray
+        <class 'numpy.ndarray'>
 
         Plot these distances as a heatmap
 

--- a/pyvista/core/filters/structured_grid.py
+++ b/pyvista/core/filters/structured_grid.py
@@ -105,8 +105,8 @@ class StructuredGridFilters(DataSetFilters):
         >>> voi_1 = grid.extract_subset([0, 80, 0, 40, 0, 1], boundary=True)
         >>> voi_2 = grid.extract_subset([0, 80, 40, 80, 0, 1], boundary=True)
         >>> joined = voi_1.concatenate(voi_2, axis=1)
-        >>> print(grid.dimensions, 'same as', joined.dimensions)
-        [80, 80, 1] same as [80, 80, 1]
+        >>> f'{grid.dimensions} same as {joined.dimensions}'
+        '[80, 80, 1] same as [80, 80, 1]'
 
         """
         if axis > 2:


### PR DESCRIPTION
Some doctests still have a few prints that pollute logs. This removes 3 out of 4. The last one would be hard to remove, because I don't have docker, I don't have nvidia, and it's a multiline string which we'd need display without printing: https://github.com/pyvista/pyvista/blob/d4931b6cc3366b09f7d546baa85156f3c0163550/doc/extras/docker.rst#L95-L106

So I left this last one.