### PR TITLE
Updates for streamlines-evenly-spaced-2D: warnings, defaults, returns

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2697,7 +2697,7 @@ class DataSetFilters:
 
         Returns
         -------
-        pyvista.PolyData
+        :class:`pyvista.PolyData`
             This produces polylines as the output, with each cell
             (i.e., polyline) representing a streamline. The attribute values
             associated with each streamline are stored in the cell data, whereas
@@ -2705,11 +2705,11 @@ class DataSetFilters:
 
         Warnings
         --------
-        This filter is unstable for vtk versions<9.0.
-        See https://github.com/pyvista/pyvista/issues/1508
+        This filter is unstable for ``vtk<9.0``.
+        See `pyvista issue 1508 <https://github.com/pyvista/pyvista/issues/1508>`_,
 
-        Example
-        -------
+        Examples
+        --------
         Plot evenly spaced streamlines for cylinder in a crossflow.
         This dataset is a multiblock dataset, and the fluid velocity is in the
         first block.

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2706,7 +2706,7 @@ class DataSetFilters:
         Warnings
         --------
         This filter is unstable for ``vtk<9.0``.
-        See `pyvista issue 1508 <https://github.com/pyvista/pyvista/issues/1508>`_,
+        See `pyvista issue 1508 <https://github.com/pyvista/pyvista/issues/1508>`_.
 
         Examples
         --------

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2626,7 +2626,7 @@ class DataSetFilters:
     def streamlines_evenly_spaced_2D(dataset, vectors=None, start_position=None,
                                     integrator_type=2, step_length=0.5, step_unit='cl',
                                     max_steps=2000, terminal_speed=1e-12, interpolator_type='point',
-                                    separating_distance=10, separating_distance_ratio=None,
+                                    separating_distance=10, separating_distance_ratio=0.5,
                                     closed_loop_maximum_distance=0.5, loop_angle=20,  
                                     minimum_number_of_loop_points=4, compute_vorticity=True):
         """Generate evenly spaced streamlines on a 2D dataset.
@@ -2679,7 +2679,6 @@ class DataSetFilters:
         separating_distance_ratio : float, optional
             Streamline integration is stopped if streamlines are closer than
             ``SeparatingDistance*SeparatingDistanceRatio`` to other streamlines.
-            The default behavior is set by vtk.
 
         closed_loop_maximum_distance : float, optional
             The distance between points on a streamline to determine a 
@@ -2698,11 +2697,16 @@ class DataSetFilters:
 
         Returns
         -------
-        streamlines : pyvista.PolyData
+        pyvista.PolyData
             This produces polylines as the output, with each cell
             (i.e., polyline) representing a streamline. The attribute values
             associated with each streamline are stored in the cell data, whereas
             those associated with streamline-points are stored in the point data.
+
+        Warnings
+        --------
+        This filter is unstable for vtk versions<9.0.
+        See https://github.com/pyvista/pyvista/issues/1508
 
         Example
         -------


### PR DESCRIPTION
### Overview

#1508 uncovered a bug in earlier versions of vtk, this is added as a warning to the docstring.  numpydoc style suggests a heading like this and discourages a `.. warning` directive.  I also see an example of this kind of heading in the library pointset module.

### Details

This PR also supplies a default parameter for `separating_distance_ratio`, which I took from the [vtk filter](https://github.com/Kitware/VTK/blob/6a9c565da01bcd6295d0bcbb66c0a9d0d2eaa69e/Filters/FlowPaths/vtkEvenlySpacedStreamlines2D.cxx#L65).   

The current choice for default for `separating_distance` , 10, is much larger than the vtk choice, 1.  A higher value is less likely to crash, so I still like this choice as a default.  I _think_ all the other choices are consistent.

Finally the return doesn't need a named value, just the type.