### PR TITLE
`clip_scalar` option to return both meshes

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -342,7 +342,11 @@ class DataSetFilters:
             result0 = dataset
 
         if both:
-            return result0, _get_output(alg, oport=1)
+            result1 = _get_output(alg, oport=1)
+            if isinstance(dataset, _vtk.vtkPolyData):
+                # For some reason vtkClipPolyData with SetGenerateClippedOutput on leaves unreferenced vertices
+                result0, result1 = (r.clean() for r in (result0, result1))
+            return result0, result1
         else:
             return result0
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -308,7 +308,7 @@ class DataSetFilters:
         >>> import pyvista as pv
         >>> from pyvista import examples
         >>> dataset = examples.load_hexbeam()
-        >>> below, above = dataset.clip_scalar(scalars="sample_point_scalars", value=100, both=True)
+        >>> _below, _above = dataset.clip_scalar(scalars="sample_point_scalars", value=100, both=True)
 
         Remove the part of the mesh with "sample_point_scalars" below
         100.  Since these scalars are already active, there's no need

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -310,14 +310,12 @@ class DataSetFilters:
         >>> dataset = examples.load_hexbeam()
         >>> _below, _above = dataset.clip_scalar(scalars="sample_point_scalars", value=100, both=True)
 
-        Remove the part of the mesh with "sample_point_scalars" below
-        100.  Since these scalars are already active, there's no need
-        to specify ``scalars=``
-
+        Remove the part of the mesh with "sample_point_scalars" below 100.
+        
         >>> import pyvista as pv
         >>> from pyvista import examples
         >>> dataset = examples.load_hexbeam()
-        >>> clipped = dataset.clip_scalar(value=100, invert=False)
+        >>> clipped = dataset.clip_scalar(scalars="sample_point_scalars", value=100, invert=False)
         >>> clipped.plot()
 
         """

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -285,13 +285,13 @@ class DataSetFilters:
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
-        both : bool, optional (default False)
-            If true, also returns the complementary clipped mesh.
+        both : bool, optional
+            If ``True``, also returns the complementary clipped mesh.
 
         Returns
         -------
-        pdata : pyvista.PolyData (if `both` is False), tuple(pyvista.PolyData, pyvista.PolyData) otherwise
-            Clipped dataset(s).
+        :class:`pyvista.PolyData` or tuple
+            Clipped dataset if ``both=False``.  If ``both=True`` then returns a tuple of both clipped datasets.
 
         Examples
         --------
@@ -303,7 +303,8 @@ class DataSetFilters:
         >>> clipped = dataset.clip_scalar(scalars="sample_point_scalars", value=100)
         >>> clipped.plot()
 
-        Get clipped meshes corresponding to the portions of the mesh above and below 100
+        Get clipped meshes corresponding to the portions of the mesh above and below 100.
+
         >>> import pyvista as pv
         >>> from pyvista import examples
         >>> dataset = examples.load_hexbeam()
@@ -344,8 +345,7 @@ class DataSetFilters:
             result0 = dataset
 
         if both:
-            result1 = _get_output(alg, oport=1)
-            return result0, result1
+            return result0, _get_output(alg, oport=1)
         else:
             return result0
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -77,16 +77,16 @@ def test_clip_by_scalars_filter(datasets, both, invert):
 
     for i, dataset_in in enumerate(datasets):
         dataset = dataset_in.copy()  # don't modify in-place
-        if dataset.active_scalars_info.name is None:
-            dataset['scalars'] = np.arange(dataset.n_points)
+        dataset.point_arrays['to_clip'] = np.arange(dataset.n_points)
+
         clip_value = dataset.n_points/2
 
         if both:
-            clps = dataset.clip_scalar(value=clip_value, both=True, invert=invert)
+            clps = dataset.clip_scalar(scalars='to_clip', value=clip_value, both=True, invert=invert)
             assert len(clps) == 2
             expect_les = (invert, not invert)
         else:
-            clps = dataset.clip_scalar(value=clip_value, both=False, invert=invert),
+            clps = dataset.clip_scalar(scalars='to_clip', value=clip_value, both=False, invert=invert),
             assert len(clps) == 1
             expect_les = invert,
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -98,9 +98,9 @@ def test_clip_by_scalars_filter(datasets, both, invert):
                 assert isinstance(clp, pyvista.UnstructuredGrid)
 
             if expect_le:
-                assert clp.active_scalars.min() <= clip_value
+                assert clp.point_arrays['to_clip'].min() <= clip_value
             else:
-                assert clp.active_scalars.max() >= clip_value
+                assert clp.point_arrays['to_clip'].max() >= clip_value
 
 
 @skip_py2_nobind

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -68,13 +68,13 @@ def test_clip_filter(datasets):
                 assert isinstance(clp, pyvista.UnstructuredGrid)
 
 
-# @skip_windows
+@skip_windows
 @skip_mac
 @pytest.mark.parametrize('both', [False, True])
 @pytest.mark.parametrize('invert', [False, True])
-def test_clip_by_scalars_filter(both, invert):
+def test_clip_by_scalars_filter(datasets, both, invert):
     """This tests the clip filter on all datatypes available filters"""
-    datasets = [Sphere()]
+
     for i, dataset_in in enumerate(datasets):
         dataset = dataset_in.copy()  # don't modify in-place
         if dataset.active_scalars_info.name is None:
@@ -101,8 +101,6 @@ def test_clip_by_scalars_filter(both, invert):
                 assert clp.active_scalars.min() <= clip_value
             else:
                 assert clp.active_scalars.max() >= clip_value
-
-
 
 
 @skip_py2_nobind

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -9,7 +9,7 @@ from vtk import VTK_QUADRATIC_HEXAHEDRON
 
 from pyvista._vtk import VTK9
 import pyvista
-from pyvista import examples
+from pyvista import examples, Sphere
 from pyvista.core.errors import VTKVersionError
 
 
@@ -68,12 +68,13 @@ def test_clip_filter(datasets):
                 assert isinstance(clp, pyvista.UnstructuredGrid)
 
 
-@skip_windows
+# @skip_windows
 @skip_mac
 @pytest.mark.parametrize('both', [False, True])
 @pytest.mark.parametrize('invert', [False, True])
-def test_clip_by_scalars_filter(datasets, both, invert):
+def test_clip_by_scalars_filter(both, invert):
     """This tests the clip filter on all datatypes available filters"""
+    datasets = [Sphere()]
     for i, dataset_in in enumerate(datasets):
         dataset = dataset_in.copy()  # don't modify in-place
         if dataset.active_scalars_info.name is None:
@@ -97,9 +98,11 @@ def test_clip_by_scalars_filter(datasets, both, invert):
                 assert isinstance(clp, pyvista.UnstructuredGrid)
 
             if expect_le:
-                assert dataset.active_scalars.max() <= clip_value
+                assert clp.active_scalars.min() <= clip_value
             else:
-                assert dataset.active_scalars.min() >= clip_value
+                assert clp.active_scalars.max() >= clip_value
+
+
 
 
 @skip_py2_nobind

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -74,7 +74,6 @@ def test_clip_filter(datasets):
 @pytest.mark.parametrize('invert', [False, True])
 def test_clip_by_scalars_filter(datasets, both, invert):
     """This tests the clip filter on all datatypes available filters"""
-
     for i, dataset_in in enumerate(datasets):
         dataset = dataset_in.copy()  # don't modify in-place
         dataset.point_arrays['to_clip'] = np.arange(dataset.n_points)


### PR DESCRIPTION
Adds an optional argument to the `clip_scalar` filter to return both meshes. This corresponds to `GenerateClippedOutput` in VTK, a name I find a little confusing so it's just called `both` here.

