### PR TITLE
Convert scalar bar keys to list

### DIFF
--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -46,7 +46,8 @@ class ScalarBars():
         except AttributeError:
             return
 
-        for name in self._scalar_bar_mappers:
+        # NOTE: keys to list to prevent iterator changing during loop
+        for name in list(self._scalar_bar_mappers):
             try:
                 self._scalar_bar_mappers[name].remove(mapper)
             except ValueError:


### PR DESCRIPTION
Reverts a minor change made in #1553 whereby the ``_scalar_bar_mappers`` dict keys can change during the iteration.  Response to https://github.com/pyvista/pyvista/pull/1553#discussion_r680499176
