### PR TITLE
change default window size to 1024 x 768

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,10 +23,10 @@ pyvista.set_error_output_file("errors.txt")
 pyvista.OFF_SCREEN = True  # Not necessary - simply an insurance policy
 # Preferred plotting style for documentation
 pyvista.set_plot_theme("document")
-pyvista.global_theme.window_size = np.array([1024, 768]) * 2
-pyvista.global_theme.font.size = 40
-pyvista.global_theme.font.label_size = 40
-pyvista.global_theme.font.title_size = 40
+pyvista.global_theme.window_size = [1024, 768]
+pyvista.global_theme.font.size = 22
+pyvista.global_theme.font.label_size = 22
+pyvista.global_theme.font.title_size = 22
 pyvista.global_theme.return_cpos = False
 pyvista.set_jupyter_backend(None)
 # Save figures in specified directory


### PR DESCRIPTION
### Change default documentation build figure size to 1024 x 768

This has been bugging me for a while.  Currently, our docs are built at 2x the default window size (2048 x 1536), and this causes a variety of issues since the DPI is effectively double.  Most noticeable is fonts and line widths are scaled down to the point of obscurity or unreliability, and this has been especially bad in #1432.

This PR proposes going back to ``1024 x 768``, which displays quite well for our docs, and even improves documentation build times.
