### PR TITLE
`probe` filter supports SetCellLocatorPrototype

### DIFF
--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -121,6 +121,7 @@ if VTK9:
                                                vtkDataSet,
                                                vtkPointLocator,
                                                vtkCellLocator,
+                                               vtkStaticCellLocator,
                                                vtkMultiBlockDataSet,
                                                vtkCompositeDataSet,
                                                vtkFieldData,

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2209,7 +2209,8 @@ class DataSetFilters:
         return out
 
     def probe(dataset, points, tolerance=None, pass_cell_arrays=True,
-              pass_point_arrays=True, categorical=False, progress_bar=False):
+              pass_point_arrays=True, categorical=False, progress_bar=False,
+              locator=None):
         """Sample data values at specified point locations.
 
         This uses :class:`vtk.vtkProbeFilter`.
@@ -2242,6 +2243,9 @@ class DataSetFilters:
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        locator: vtkAbstractCellLocator, optional
+            Prototype cell locator to perform the FindCell() operation.
+
         Returns
         -------
         pyvista.DataSet
@@ -2268,9 +2272,14 @@ class DataSetFilters:
         alg.SetPassCellArrays(pass_cell_arrays)
         alg.SetPassPointArrays(pass_point_arrays)
         alg.SetCategoricalData(categorical)
+
         if tolerance is not None:
             alg.SetComputeTolerance(False)
             alg.SetTolerance(tolerance)
+
+        if locator:
+            alg.SetCellLocatorPrototype(locator)
+
         _update_alg(alg, progress_bar, 'Sampling Data Values at Specified Point Locations')
         return _get_output(alg)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from vtk import VTK_QUADRATIC_HEXAHEDRON
 
-from pyvista._vtk import VTK9
+from pyvista._vtk import VTK9, vtkStaticCellLocator
 import pyvista
 from pyvista import examples, Sphere
 from pyvista.core.errors import VTKVersionError
@@ -721,14 +721,15 @@ def test_resample():
 
 @pytest.mark.parametrize('use_points', [True, False])
 @pytest.mark.parametrize('categorical', [True, False])
-def test_probe(categorical, use_points):
+@pytest.mark.parametrize('locator', [None, vtkStaticCellLocator()])
+def test_probe(categorical, use_points, locator):
     mesh = pyvista.Sphere(center=(4.5, 4.5, 4.5), radius=4.5)
     data_to_probe = examples.load_uniform()
     if use_points:
         dataset = np.array(mesh.points)
     else:
         dataset = mesh
-    result = data_to_probe.probe(dataset, tolerance=1E-5, categorical=categorical, progress_bar=True)
+    result = data_to_probe.probe(dataset, tolerance=1E-5, categorical=categorical, progress_bar=True, locator=locator)
     name = 'Spatial Point Data'
     assert name in result.array_names
     assert isinstance(result, type(mesh))


### PR DESCRIPTION
Had some confusing behavior with the `probe` filter today that I don't really understand but specifying a cell locator fixed it.