### PR TITLE
Add missing function call to triangles check

### DIFF
--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2088,8 +2088,8 @@ class PolyDataFilters(DataSetFilters):
         >>> sphere.plot_normals(mag=0.1, opacity=0.5)
 
         """
-        if not poly_data.is_all_triangles:
-            raise NotAllTrianglesError('Can only flip normals on an all triangle mesh')
+        if not poly_data.is_all_triangles():
+            raise NotAllTrianglesError('Can only flip normals on an all triangle mesh.')
 
         f = poly_data.faces.reshape((-1, 4))
         f[:, 1:] = f[:, 1:][:, ::-1]

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -763,7 +763,7 @@ def test_extrude():
     assert arc.n_points != n_points_old
 
 
-def test_flip_normals(sphere):
+def test_flip_normals(sphere, plane):
     sphere_flipped = sphere.copy()
     sphere_flipped.flip_normals()
 
@@ -771,3 +771,7 @@ def test_flip_normals(sphere):
     sphere_flipped.compute_normals(inplace=True)
     assert np.allclose(sphere_flipped.point_arrays['Normals'],
                        -sphere.point_arrays['Normals'])
+
+    # invalid case
+    with pytest.raises(NotAllTrianglesError):
+        plane.flip_normals()


### PR DESCRIPTION
I ran into something surprising:
```py
In [1]: import pyvista as pv
   ...: 
   ...: mesh = pv.Plane(i_resolution=1000, j_resolution=1000)
   ...: mesh.flip_normals()
Segmentation fault
```

I could also do this:
```py
In [1]: import pyvista as pv
   ...: 
   ...: mesh = pv.Plane(i_resolution=3, j_resolution=3)
   ...: mesh.flip_normals()
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-1-07bfa31e5179> in <module>
      2 
      3 mesh = pv.Plane(i_resolution=3, j_resolution=3)
----> 4 mesh.flip_normals()

~/pyvista/pyvista/core/filters/poly_data.py in flip_normals(poly_data)
   2092             raise NotAllTrianglesError('Can only flip normals on an all triangle mesh.')
   2093 
-> 2094         f = poly_data.faces.reshape((-1, 4))
   2095         f[:, 1:] = f[:, 1:][:, ::-1]
   2096         poly_data.faces = f

ValueError: cannot reshape array of size 45 into shape (4)
```

Turns out there was a missing function call in the check inside `flip_normals`, and objects are truthy by default.

---

While we're at it, I looked at that flipping line:
```py
f = poly_data.faces.reshape((-1, 4))
f[:, 1:] = f[:, 1:][:, ::-1]
```

I thought about writing it like this instead:
```py
f[:, [1, 2, 3]] = f[:, [3, 2, 1]]
```

Some crude timings (calling the original `orig()` and the new one `new()`) using `faces = np.random.randint(low=0, high=1_000_000, size=(n, 4))`:
```
%timeit orig(faces)
%timeit new(faces)

# n = 100
2.4 µs ± 215 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
4.57 µs ± 38.7 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

# n = 1000
12.7 µs ± 55 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
8.2 µs ± 61 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

# n = 10_000
115 µs ± 515 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
52.2 µs ± 608 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

# n = 100_000
1.21 ms ± 5.7 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
588 µs ± 10 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

So changing two basic indexing operations to one fancy indexing seems to be twice as fast for large meshes, with break-even around `n = 400` faces. I haven't added the change to the PR yet, because the newer version would create a copy of most of the `faces` array due to fancy indexing. I'm not sure if this would be more of a concern for large datasets than the slightly slower runtime, which is not really a problem (and `flip_normals()` doesn't sounds like something that's called too often anyway). Just wanted to float this potential change for consideration.