### PR TITLE
Use numpydoc

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ jobs:
     displayName: 'Install test dependencies'
 
   - script: |
-      xvfb-run pytest -v -n 2 --doctest-modules pyvista
+      xvfb-run pytest -v --doctest-modules pyvista
     displayName: 'Test Package Docstrings'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ jobs:
     displayName: 'Install test dependencies'
 
   - script: |
-      xvfb-run pytest -v --doctest-modules pyvista
+      xvfb-run pytest -v -n 2 --doctest-modules pyvista
     displayName: 'Test Package Docstrings'
 
   - script: |

--- a/doc/_templates/custom-class-template.rst
+++ b/doc/_templates/custom-class-template.rst
@@ -10,7 +10,7 @@
    .. rubric:: {{ _('Methods') }}
 
    .. autosummary::
-      :toctree: _autosummary
+      :toctree:
    {% for item in methods %}
       {% if item != "__init__" %}
       {{ name }}.{{ item }}
@@ -24,7 +24,7 @@
    .. rubric:: {{ _('Attributes') }}
 
    .. autosummary::
-      :toctree: _autosummary
+      :toctree:
    {% for item in attributes %}
       {% if item.0 != item.upper().0 %}
       {{ name }}.{{ item }}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -83,7 +83,7 @@ numpydoc_validation_checks = {
     "GL01",  # Contradicts numpydoc examples
     "GL02",  # Permit a blank line after the end of our docstring
     "GL03",  # Considering enforcing
-    "PR01",  # not enabling due to abstract classes (consider enabling)
+    "PR01",  # in-progress
     "RT01",  # Disabled as we will not enforce return sections for None
     "SA01",  # Not all docstrings need a see also
     "SA04",  # See also section does not need descriptions
@@ -94,7 +94,45 @@ numpydoc_validation_checks = {
 }
 numpydoc_validation_exclude = {  # set of regex
     r'\.Plotter$',  # Issue with class parameter documentation
+
+    r'\.from_dict$',
+    r'\.__init__$',
+
+    # parm of abstract classes
+    r'\.CompositeFilters$',
+    r'\.PolyDataFilters$',
+    r'\.CompositeFilters$',
+    r'\.PolyDataFilters$',
+    r'\.UniformGridFilters$',
+    r'\.DataSetFilters$',
+    r'\.UnstructuredGridFilters$',
+    r'\.MultiBlock$',
+    r'\.DataSet$',
+    r'\.DataSetFilters$',
+    r'\.PolyDataFilters$',
+    r'\.UnstructuredGridFilters$',
+    r'\.UniformGridFilters$',
+    r'\.CompositeFilters$',
+    r'\.Grid$',
+    r'\.RectilinearGrid$',
+    r'\.UniformGrid$',
+    r'\.DataObject$',
+    r'\.Table.save$',
+    r'\.Table$',
+    r'\.Table.save$',
+    r'\.UnstructuredGrid$',
+    r'\.ExplicitStructuredGrid$',
+    r'\.StructuredGrid$',
+    r'\.PointGrid$',
+
+    # inherit from BaseReader
+    r'\.Reader$',
+
+    # depricated
+    r'\.PolyDataFilters.boolean_add$'
+    r'\.PolyDataFilters.boolean_cut$'
 }
+
 
 add_module_names = False
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -75,19 +75,26 @@ extensions = [
 numpydoc_use_plots = True
 numpydoc_show_class_members = False
 numpydoc_xref_param_type = True
-numpydoc_validation_checks = {
-    # "GL01",  # "Docstring text (summary) should start in the line immediately after the opening quotes
-    # "GL02",  # Closing quotes should be placed in the line after the last text in the docstring.
-    # "GL03",  # Double line break found
-    "GL05",  # Tabs found at the start of line
-    "GL06",  # Found unknown section
-    "GL07",  # Sections are in the wrong order.
-    "PR04",  # 'Parameter has no type'
-    "PR07",  # 'Parameter has no description'
-    "PR08",  # 'Parameter description should start with a capital letter",
-    # "EX01",  # "No examples section found"
-}
 
+# see https://github.com/pyvista/pyvista/pull/1612
+numpydoc_validate = True
+numpydoc_validation_checks = {
+    "all",  # all but the following:
+    "GL01",  # Contradicts numpydoc examples
+    "GL02",  # Permit a blank line after the end of our docstring
+    "GL03",  # Considering enforcing
+    "PR01",  # not enabling due to abstract classes (consider enabling)
+    "RT01",  # Disabled as we will not enforce return sections for None
+    "SA01",  # Not all docstrings need a see also
+    "SA04",  # See also section does not need descriptions
+    "SS05",  # Appears to be broken.
+    "ES01",  # not all docstrings need an extend summary.
+    "EX01",  # Will eventually enforce
+    "YD01",  # No plan to enforce
+}
+numpydoc_validation_exclude = {  # set of regex
+    r'\.Plotter$',  # Issue with class parameter documentation
+}
 
 add_module_names = False
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -83,7 +83,7 @@ numpydoc_validation_checks = {
     "GL01",  # Contradicts numpydoc examples
     "GL02",  # Permit a blank line after the end of our docstring
     "GL03",  # Considering enforcing
-    # "RT01",  # Disabled as we will not enforce return sections for None
+    "RT01",  # In progress
     "SA01",  # Not all docstrings need a see also
     "SA04",  # See also section does not need descriptions
     "SS05",  # Appears to be broken.
@@ -134,6 +134,7 @@ numpydoc_validation_exclude = {  # set of regex
     r'\.*boolean_add$',
     r'\.*boolean_cut$',
     r'\.*add_field_array$',
+    r'\.*add_field_array$',
 
     # methods we probably should make private
     r'\.store_click_position$',
@@ -146,6 +147,10 @@ numpydoc_validation_exclude = {  # set of regex
     r'\.*PlotterITK$',
     r'\.*MultiBlock.copy_meta_from$',
     r'\.DataObject.copy_meta_from$',
+
+    # wraps
+    r'\.*Plotter.enable_depth_peeling$',
+    r'\.*add_scalar_bar$',
 
 }
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -83,7 +83,7 @@ numpydoc_validation_checks = {
     "GL01",  # Contradicts numpydoc examples
     "GL02",  # Permit a blank line after the end of our docstring
     "GL03",  # Considering enforcing
-    "RT01",  # Disabled as we will not enforce return sections for None
+    # "RT01",  # Disabled as we will not enforce return sections for None
     "SA01",  # Not all docstrings need a see also
     "SA04",  # See also section does not need descriptions
     "SS05",  # Appears to be broken.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -83,14 +83,13 @@ numpydoc_validation_checks = {
     "GL01",  # Contradicts numpydoc examples
     "GL02",  # Permit a blank line after the end of our docstring
     "GL03",  # Considering enforcing
-    "PR01",  # in-progress
     "RT01",  # Disabled as we will not enforce return sections for None
     "SA01",  # Not all docstrings need a see also
     "SA04",  # See also section does not need descriptions
     "SS05",  # Appears to be broken.
-    "ES01",  # not all docstrings need an extend summary.
-    "EX01",  # Will eventually enforce
-    "YD01",  # No plan to enforce
+    "ES01",  # Not all docstrings need an extend summary.
+    "EX01",  # Examples: Will eventually enforce
+    "YD01",  # Yields: No plan to enforce
 }
 numpydoc_validation_exclude = {  # set of regex
     r'\.Plotter$',  # Issue with class parameter documentation
@@ -125,12 +124,29 @@ numpydoc_validation_exclude = {  # set of regex
     r'\.StructuredGrid$',
     r'\.PointGrid$',
 
-    # inherit from BaseReader
-    r'\.Reader$',
+    # classes inherit from BaseReader
+    r'\.*Reader$',
+
+    # internal
+    r'\.Renderer$',
 
     # deprecated
-    r'\.PolyDataFilters.boolean_add$'
-    r'\.PolyDataFilters.boolean_cut$'
+    r'\.*boolean_add$',
+    r'\.*boolean_cut$',
+    r'\.*add_field_array$',
+
+    # methods we probably should make private
+    r'\.store_click_position$',
+    r'\.store_mouse_position$',
+    r'\.*fly_to_mouse_position$',
+    r'\.*key_press_event$',
+    r'\.*left_button_down$',
+
+    # MISC
+    r'\.*PlotterITK$',
+    r'\.*MultiBlock.copy_meta_from$',
+    r'\.DataObject.copy_meta_from$',
+
 }
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -75,6 +75,19 @@ extensions = [
 numpydoc_use_plots = True
 numpydoc_show_class_members = False
 numpydoc_xref_param_type = True
+numpydoc_validation_checks = {
+    # "GL01",  # "Docstring text (summary) should start in the line immediately after the opening quotes
+    # "GL02",  # Closing quotes should be placed in the line after the last text in the docstring.
+    # "GL03",  # Double line break found
+    "GL05",  # Tabs found at the start of line
+    "GL06",  # Found unknown section
+    "GL07",  # Sections are in the wrong order.
+    "PR04",  # 'Parameter has no type'
+    "PR07",  # 'Parameter has no description'
+    "PR08",  # 'Parameter description should start with a capital letter",
+    # "EX01",  # "No examples section found"
+}
+
 
 add_module_names = False
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -83,7 +83,6 @@ numpydoc_validation_checks = {
     "GL01",  # Contradicts numpydoc examples
     "GL02",  # Permit a blank line after the end of our docstring
     "GL03",  # Considering enforcing
-    "RT01",  # In progress
     "SA01",  # Not all docstrings need a see also
     "SA04",  # See also section does not need descriptions
     "SS05",  # Appears to be broken.
@@ -151,6 +150,9 @@ numpydoc_validation_exclude = {  # set of regex
     # wraps
     r'\.*Plotter.enable_depth_peeling$',
     r'\.*add_scalar_bar$',
+
+    # pending refactor
+    r'\.*MultiBlock.next$',
 
 }
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -128,7 +128,7 @@ numpydoc_validation_exclude = {  # set of regex
     # inherit from BaseReader
     r'\.Reader$',
 
-    # depricated
+    # deprecated
     r'\.PolyDataFilters.boolean_add$'
     r'\.PolyDataFilters.boolean_cut$'
 }

--- a/doc/user-guide/what-is-a-mesh.rst
+++ b/doc/user-guide/what-is-a-mesh.rst
@@ -152,7 +152,7 @@ that attribute.
 .. pyvista-plot::
     :context:
 
-    mesh.cell_arrays['my cell values'] = np.arange(mesh.n_cells)
+    mesh.cell_data['my cell values'] = np.arange(mesh.n_cells)
     mesh.plot(scalars='my cell values', cpos=cpos, show_edges=True)
 
 
@@ -183,7 +183,7 @@ generate cube containing 6 faces and assign each face an integer from
     :context:
 
     cube = pv.Cube()
-    cube.cell_arrays['myscalars'] = range(6)
+    cube.cell_data['myscalars'] = range(6)
     cube.plot(cmap='bwr')
 
 Note how this varies from assigning scalars to each point

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -113,7 +113,6 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
             block = self.GetBlock(i)
             if not is_pyvista_dataset(block):
                 self.SetBlock(i, pyvista.wrap(block))
-        return
 
     @property
     def bounds(self) -> List[float]:
@@ -220,6 +219,11 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
         ----------
         name : str
             Name of the array.
+
+        Returns
+        -------
+        tuple
+            ``(min, max)`` of the named array.
 
         """
         mini, maxi = np.inf, -np.inf
@@ -329,6 +333,11 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
         index : int or str
             Index or name of the dataset within the multiblock.
 
+        Returns
+        -------
+        pyvista.DataSet
+            Dataset from the given index.
+
         """
         return self[index]
 
@@ -389,6 +398,11 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
     def keys(self) -> List[Optional[str]]:
         """Get all the block names in the dataset.
 
+        Returns
+        -------
+        list
+            List of block names.
+
         Examples
         --------
         >>> import pyvista as pv
@@ -398,10 +412,7 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
         ['cube', 'sphere']
 
         """
-        names = []
-        for i in range(self.n_blocks):
-            names.append(self.get_block_name(i))
-        return names
+        return [self.get_block_name(i) for i in range(self.n_blocks)]
 
     def _ipython_key_completions_(self) -> List[Optional[str]]:
         return self.keys()
@@ -477,6 +488,11 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
         index : int or str
             Index or name of the dataset within the multiblock.
 
+        Returns
+        -------
+        pyvista.DataSet
+            Dataset from the given index.
+
         """
         data = self[index]
         del self[index]
@@ -517,7 +533,6 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
             # Cast as int because windows is super annoying
             del self[int(null_blocks[i])]
             null_blocks -= 1
-        return
 
     def _get_attrs(self):
         """Return the representation methods (internal helper)."""

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -434,7 +434,7 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
         """Remove any null blocks in place.
 
         Parameters
-        -----------
+        ----------
         empty : bool
             Remove any meshes that are empty as well (have zero points).
 

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -198,7 +198,7 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
         Returns
         -------
-        volume : float
+        float
             Total volume of the mesh.
 
         Examples

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -214,7 +214,14 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
         return sum(block.volume for block in self if block)
 
     def get_data_range(self, name: str) -> Tuple[float, float]:  # type: ignore
-        """Get the min/max of an array given its name across all blocks."""
+        """Get the min/max of an array given its name across all blocks.
+
+        Parameters
+        ----------
+        name : str
+            Name of the array.
+
+        """
         mini, maxi = np.inf, -np.inf
         for i in range(self.n_blocks):
             data = self[i]
@@ -230,6 +237,16 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
     def get_index_by_name(self, name: str) -> int:
         """Find the index number by block name.
+
+        Parameters
+        ----------
+        name : str
+            Name of the block.
+
+        Returns
+        -------
+        int
+            Index of the block.
 
         Examples
         --------
@@ -280,8 +297,13 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
             self.refs.append(data)
         return data
 
-    def append(self, data: DataSet):
+    def append(self, dataset: DataSet):
         """Add a data set to the next block index.
+
+        Parameters
+        ----------
+        dataset : pyvista.DataSet
+            Dataset to append to this multi-block.
 
         Examples
         --------
@@ -294,19 +316,32 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
         """
         index = self.n_blocks  # note off by one so use as index
-        self[index] = data
-        self.refs.append(data)
+        self[index] = dataset
+        self.refs.append(dataset)
 
     def get(self, index: Union[int, str]) -> Optional['MultiBlock']:
         """Get a block by its index or name.
 
         If the name is non-unique then returns the first occurrence.
 
+        Parameters
+        ----------
+        index : int or str
+            Index or name of the dataset within the multiblock.
+
         """
         return self[index]
 
     def set_block_name(self, index: int, name: str):
         """Set a block's string name at the specified index.
+
+        Parameters
+        ----------
+        index : int
+            Index or the dataset within the multiblock.
+
+        name : str
+            Name to assign to the block at ``index``.
 
         Examples
         --------
@@ -326,6 +361,16 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
     def get_block_name(self, index: int) -> Optional[str]:
         """Return the string name of the block at the given index.
+
+        Parameters
+        ----------
+        index : int
+            Index of the block to get the name of.
+
+        Returns
+        -------
+        str
+            Name of the block at the given index.
 
         Examples
         --------
@@ -425,7 +470,14 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
     __next__ = next
 
     def pop(self, index: Union[int, str]) -> Optional['MultiBlock']:
-        """Pop off a block at the specified index."""
+        """Pop off a block at the specified index.
+
+        Parameters
+        ----------
+        index : int or str
+            Index or name of the dataset within the multiblock.
+
+        """
         data = self[index]
         del self[index]
         return data

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -550,8 +550,8 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
 
         Returns
         -------
-        newobject : same as input
-           Deep or shallow copy of the input.
+        pyvista.DataSet
+           Deep or shallow copy of the input.  Type matches input.
 
         Examples
         --------

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -70,7 +70,6 @@ class DataObject:
 
         binary : bool, optional
             If ``True``, write as binary.  Otherwise, write as ASCII.
-            
 
         texture : str, np.ndarray, optional
             Write a single texture array to file when using a PLY

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -48,7 +48,7 @@ class DataObject:
             Data object to perform a shallow copy from.
 
         """
-        return self.ShallowCopy(to_copy)
+        self.ShallowCopy(to_copy)
 
     def deep_copy(self, to_copy: _vtk.vtkDataObject) -> _vtk.vtkDataObject:
         """Overwrite this data object with another data object as a deep copy.
@@ -59,7 +59,7 @@ class DataObject:
             Data object to perform a deep copy from.
 
         """
-        return self.DeepCopy(to_copy)
+        self.DeepCopy(to_copy)
 
     def _from_file(self, filename: Union[str, Path], **kwargs):
         data = pyvista.read(filename, **kwargs)
@@ -158,6 +158,11 @@ class DataObject:
         html : bool, optional
             Generate the output as HTML.
 
+        Returns
+        -------
+        str
+            Header statistics.
+
         """
         # Generate the output
         if html:
@@ -219,8 +224,9 @@ class DataObject:
 
         Returns
         -------
-        :class:`pyvista.DataSet`
-            Deep or shallow copy of the input.  Type is identical to the input.
+        pyvista.DataSet
+            Deep or shallow copy of the input.  Type is identical to
+            the input.
 
         Examples
         --------

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -387,7 +387,7 @@ class DataObject:
             "Use `clear_field_data` instead.",
             PyvistaDeprecationWarning
         )
-        return self.field_data
+        self.field_data
 
     def clear_field_data(self):
         """Remove all field data.

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -423,6 +423,11 @@ class DataObject:
     def copy_attributes(self, dataset: _vtk.vtkDataSet):
         """Copy the data attributes of the input dataset object.
 
+        Parameters
+        ----------
+        dataset : pyvista.DataSet
+            Dataset to copy the data attributes from.
+
         Examples
         --------
         >>> import pyvista as pv

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -40,11 +40,25 @@ class DataObject:
         return super().__getattribute__(item)
 
     def shallow_copy(self, to_copy: _vtk.vtkDataObject) -> _vtk.vtkDataObject:
-        """Shallow copy the given mesh to this mesh."""
+        """Shallow copy the given mesh to this mesh.
+
+        Parameters
+        ----------
+        to_copy : pyvista.DataObject or vtk.vtkDataObject
+            Data object to perform a shallow copy from.
+
+        """
         return self.ShallowCopy(to_copy)
 
     def deep_copy(self, to_copy: _vtk.vtkDataObject) -> _vtk.vtkDataObject:
-        """Overwrite this mesh with the given mesh as a deep copy."""
+        """Overwrite this data object with another data object as a deep copy.
+
+        Parameters
+        ----------
+        to_copy : pyvista.DataObject or vtk.vtkDataObject
+            Data object to perform a deep copy from.
+
+        """
         return self.DeepCopy(to_copy)
 
     def _from_file(self, filename: Union[str, Path], **kwargs):
@@ -133,7 +147,16 @@ class DataObject:
     def head(self, display=True, html: bool = None):
         """Return the header stats of this dataset.
 
-        If in IPython, this will be formatted to HTML. Otherwise returns a console friendly string.
+        If in IPython, this will be formatted to HTML. Otherwise
+        returns a console friendly string.
+
+        Parameters
+        ----------
+        display : bool, optional
+            Display this header in iPython.
+
+        html : bool, optional
+            Generate the output as HTML.
 
         """
         # Generate the output
@@ -251,7 +274,7 @@ class DataObject:
         """Add field data.
 
         .. deprecated:: 0.32.0
-           Use :func:`DataObject.clear_point_arrays` instead.
+           Use :func:`DataObject.add_field_data` instead.
         """
         warnings.warn( "Use of `clear_point_arrays` is deprecated. "
             "Use `clear_point_data` instead.",
@@ -259,12 +282,24 @@ class DataObject:
         )
         return self.clear_point_data()
 
-    def add_field_data(self, scalars: np.ndarray, name: str, deep=True):
+    def add_field_data(self, array: np.ndarray, name: str, deep=True):
         """Add field data.
 
         Use field data when size of the data you wish to associate
         with the dataset does not match the number of points or cells
         of the dataset.
+
+        Parameters
+        ----------
+        array : sequence
+            Array of data to add to the dataset as a field array.
+
+        name : str
+            Name to assign the field array.
+
+        deep : bool, optional
+            Perform a deep copy of the data when adding it to the
+            dataset.  Default ``True``.
 
         Examples
         --------
@@ -295,7 +330,7 @@ class DataObject:
         pyvista_ndarray([1, 2, 3])
 
         """
-        self.field_data.set_array(scalars, name, deep_copy=deep)
+        self.field_data.set_array(array, name, deep_copy=deep)
 
     @property
     def field_arrays(self) -> DataSetAttributes:  # pragma: no cover
@@ -408,6 +443,11 @@ class DataObject:
 
     def copy_structure(self, dataset: _vtk.vtkDataSet):
         """Copy the structure (geometry and topology) of the input dataset object.
+
+        Parameters
+        ----------
+        dataset : vtk.vtkDataSet
+            Dataset to copy the geometry and topology from.
 
         Examples
         --------

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1441,7 +1441,7 @@ class DataSet(DataSetFilters, DataObject):
         preference : str, optional
             When scalars is specified, this is the preferred array
             type to search for in the dataset.  Must be either
-            ``'point'``, ``'cell'``, or ``'field'``
+            ``'point'``, ``'cell'``, or ``'field'``.
 
         Examples
         --------
@@ -1487,10 +1487,7 @@ class DataSet(DataSetFilters, DataObject):
         preference : str, optional
             When scalars is specified, this is the preferred array
             type to search for in the dataset.  Must be either
-            ``'point'``, ``'cell'``, or ``'field'``
-        err : bool, optional
-            Boolean to control whether to throw an error if array is
-            not present.
+            ``'point'``, ``'cell'``, or ``'field'``.
 
         Examples
         --------
@@ -1789,7 +1786,7 @@ class DataSet(DataSetFilters, DataObject):
 
         Returns
         -------
-        index : int or np.ndarray
+        int or numpy.ndarray
             Index or indices of the cell in this mesh that is closest
             to the given point.
 

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -608,6 +608,18 @@ class DataSet(DataSetFilters, DataObject):
         """Find the scalars by name and appropriately sets it as active.
 
         To deactivate any active scalars, pass ``None`` as the ``name``.
+
+        Parameters
+        ----------
+        name : str
+            Name of the scalars array to assign as active.
+
+        preference : str, optional
+            If there are two arrays of the same name associated with
+            points, cells, or field data, it will prioritize an array
+            matching this type.  Can be either ``'cell'``,
+            ``'field'``, or ``'point'``.
+
         """
         if name is None:
             self.GetCellData().SetActiveScalars(None)
@@ -631,6 +643,18 @@ class DataSet(DataSetFilters, DataObject):
         """Find the vectors by name and appropriately sets it as active.
 
         To deactivate any active vectors, pass ``None`` as the ``name``.
+
+        Parameters
+        ----------
+        name : str
+            Name of the vectors array to assign as active.
+
+        preference : str, optional
+            If there are two arrays of the same name associated with
+            points, cells, or field data, it will prioritize an array
+            matching this type.  Can be either ``'cell'``,
+            ``'field'``, or ``'point'``.
+
         """
         if name is None:
             self.GetCellData().SetActiveVectors(None)
@@ -654,6 +678,18 @@ class DataSet(DataSetFilters, DataObject):
         """Find the tensors by name and appropriately sets it as active.
 
         To deactivate any active tensors, pass ``None`` as the ``name``.
+
+        Parameters
+        ----------
+        name : str
+            Name of the tensors array to assign as active.
+
+        preference : str, optional
+            If there are two arrays of the same name associated with
+            points, cells, or field data, it will prioritize an array
+            matching this type.  Can be either ``'cell'``,
+            ``'field'``, or ``'point'``.
+
         """
         if name is None:
             self.GetCellData().SetActiveTensors(None)
@@ -1088,7 +1124,14 @@ class DataSet(DataSetFilters, DataObject):
         self.transform(t, transform_all_input_vectors=transform_all_input_vectors, inplace=True)
 
     def copy_meta_from(self, ido: 'DataSet'):
-        """Copy pyvista meta data onto this object from another object."""
+        """Copy pyvista meta data onto this object from another object.
+
+        Parameters
+        ----------
+        ido : pyvista.DataSet
+            Dataset to copy the metadata from.
+
+        """
         self._active_scalars_info = ido.active_scalars_info
         self._active_vectors_info = ido.active_vectors_info
         self.clear_textures()

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -411,7 +411,7 @@ class DataSet(DataSetFilters, DataObject):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             Active vectors represented as arrows.
 
         Examples
@@ -1462,7 +1462,7 @@ class DataSet(DataSetFilters, DataObject):
 
         Returns
         -------
-        volume : float
+        float
             Total volume of the mesh.
 
         Examples

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -114,6 +114,12 @@ class DataSet(DataSetFilters, DataObject):
             The scalars info in an object with namedtuple semantics,
             with attributes ``association`` and ``name``.
 
+        Notes
+        -----
+        If both cell and point scalars are present and neither have
+        been set active within at the dataset level, point scalars
+        will be made active.
+
         Examples
         --------
         Create a mesh, add scalars to the mesh, and return the active
@@ -125,12 +131,6 @@ class DataSet(DataSetFilters, DataObject):
         >>> mesh['Z Height'] = mesh.points[:, 2]
         >>> mesh.active_scalars_info
         ActiveArrayInfo(association=<FieldAssociation.POINT: 0>, name='Z Height')
-
-        Notes
-        -----
-        If both cell and point scalars are present and neither have
-        been set active within at the dataset level, point scalars
-        will be made active.
 
         """
         field, name = self._active_scalars_info
@@ -170,6 +170,12 @@ class DataSet(DataSetFilters, DataObject):
             The vectors info in an object with namedtuple semantics,
             with attributes ``association`` and ``name``.
 
+        Notes
+        -----
+        If both cell and point vectors are present and neither have
+        been set active within at the dataset level, point vectors
+        will be made active.
+
         Examples
         --------
         Create a mesh, compute the normals inplace, set the active
@@ -182,12 +188,6 @@ class DataSet(DataSetFilters, DataObject):
         >>> mesh.active_vectors_name = 'Normals'
         >>> mesh.active_vectors_info
         ActiveArrayInfo(association=<FieldAssociation.POINT: 0>, name='Normals')
-
-        Notes
-        -----
-        If both cell and point vectors are present and neither have
-        been set active within at the dataset level, point vectors
-        will be made active.
 
         """
         field, name = self._active_vectors_info
@@ -1309,6 +1309,11 @@ class DataSet(DataSetFilters, DataObject):
     def n_cells(self) -> int:
         """Return the number of cells in the entire dataset.
 
+        Notes
+        -----
+        This is identical to :attr:`n_faces <pyvista.PolyData.n_faces>`
+        in :class:`pyvista.PolyData`.
+
         Examples
         --------
         Create a mesh and return the number of cells in the
@@ -1318,11 +1323,6 @@ class DataSet(DataSetFilters, DataObject):
         >>> cube = pyvista.Cube().clean()
         >>> cube.n_cells
         6
-
-        Notes
-        -----
-        This is identical to :attr:`n_faces <pyvista.PolyData.n_faces>`
-        in :class:`pyvista.PolyData`.
 
         """
         return self.GetNumberOfCells()
@@ -1484,12 +1484,10 @@ class DataSet(DataSetFilters, DataObject):
         ----------
         name : str
             Name of the array.
-
         preference : str, optional
             When scalars is specified, this is the preferred array
             type to search for in the dataset.  Must be either
             ``'point'``, ``'cell'``, or ``'field'``
-
         err : bool, optional
             Boolean to control whether to throw an error if array is
             not present.

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -786,6 +786,11 @@ class DataSet(DataSetFilters, DataObject):
             to search for in the dataset.  Must be either ``'point'``,
             ``'cell'``, or ``'field'``.
 
+        Returns
+        -------
+        tuple
+            ``(min, max)`` of the named array.
+
         """
         if arr_var is None:  # use active scalars array
             _, arr_var = self.active_scalars_info
@@ -1203,7 +1208,7 @@ class DataSet(DataSetFilters, DataObject):
             "Use `clear_point_data` instead.",
             PyvistaDeprecationWarning
         )
-        return self.clear_point_data()
+        self.clear_point_data()
 
     def clear_point_data(self):
         """Remove all point arrays.
@@ -1236,7 +1241,7 @@ class DataSet(DataSetFilters, DataObject):
             "Use `clear_cell_data` instead.",
             PyvistaDeprecationWarning
         )
-        return self.clear_cell_data()
+        self.clear_cell_data()
 
     def clear_cell_data(self):
         """Remove all cell arrays."""
@@ -1254,7 +1259,7 @@ class DataSet(DataSetFilters, DataObject):
             "Use `clear_data` instead.",
             PyvistaDeprecationWarning
         )
-        return self.clear_data()
+        self.clear_data()
 
     def clear_data(self):
         """Remove all arrays from point/cell/field data.
@@ -1486,6 +1491,11 @@ class DataSet(DataSetFilters, DataObject):
             type to search for in the dataset.  Must be either
             ``'point'``, ``'cell'``, or ``'field'``.
 
+        Returns
+        -------
+        pyvista.pyvista_ndarray
+            Requested array.
+
         Examples
         --------
         Create a DataSet with a variety of arrays.
@@ -1531,6 +1541,11 @@ class DataSet(DataSetFilters, DataObject):
             When scalars is specified, this is the preferred array
             type to search for in the dataset.  Must be either
             ``'point'``, ``'cell'``, or ``'field'``.
+
+        Returns
+        -------
+        pyvista.FieldAssociation
+            Field association of the array.
 
         Examples
         --------
@@ -1742,7 +1757,7 @@ class DataSet(DataSetFilters, DataObject):
 
         Returns
         -------
-        :class:`pyvista.UnstructuredGrid`
+        pyvista.UnstructuredGrid
             Dataset cast into a :class:`pyvista.UnstructuredGrid`.
 
         Examples

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -391,7 +391,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
         Returns
         -------
-        :class:`pyvista.pyvista_ndarray`
+        pyvista.pyvista_ndarray
             Array of the active texture coordinates.
 
         Examples
@@ -485,7 +485,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
         Returns
         -------
-        pyvista.pyvista_ndarray or ``vtkDataArray``
+        pyvista.pyvista_ndarray or vtkDataArray
             Returns a :class:`pyvista.pyvista_ndarray` if the
             underlying array is either a ``vtk.vtkDataArray`` or
             ``vtk.vtkStringArray``.  Otherwise, returns a
@@ -871,7 +871,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
         Returns
         -------
-        :class:`pyvista_ndarray`
+        pyvista_ndarray
             Requested array.
 
         Examples
@@ -1105,7 +1105,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
         Returns
         -------
-        :class:`pyvista_ndarray`
+        pyvista_ndarray
             Normals of this dataset attributes.  ``None`` if no
             normals have been set.
 

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -485,7 +485,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
         Returns
         -------
-        :class:`pyvista.pyvista_ndarray` or ``vtkDataArray``
+        pyvista.pyvista_ndarray or ``vtkDataArray``
             Returns a :class:`pyvista.pyvista_ndarray` if the
             underlying array is either a ``vtk.vtkDataArray`` or
             ``vtk.vtkStringArray``.  Otherwise, returns a

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -622,6 +622,11 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         deep_copy : bool, optional
             When ``True`` makes a full copy of the array.
 
+        Notes
+        -----
+        When adding directional data (such as velocity vectors), use
+        :func:`DataSetAttributes.set_vectors`.
+
         Examples
         --------
         >>> import pyvista
@@ -638,11 +643,6 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         Active Normals  : None
         Contains arrays :
             my-scalars              int64    (8,)                 SCALARS
-
-        See Also
-        --------
-        When adding directional data (such as velocity vectors), use
-        :func:`DataSetAttributes.set_vectors`.
 
         """
         vtk_arr = self._prepare_array(scalars, name, deep_copy)
@@ -702,8 +702,6 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         rotated along with the geometry when the DataSet is passed
         through a transformation filter.
 
-        See Also
-        --------
         When adding non-directional data (such temperature values or
         multi-component scalars like RGBA values), you can also use
         :func:`DataSetAttributes.set_scalars`.

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -8,7 +8,7 @@ from pyvista.core.filters.data_set import DataSetFilters
 class CompositeFilters:
     """An internal class to manage filters/algorithms for composite datasets."""
 
-    def extract_geometry(composite):
+    def extract_geometry(self):
         """Combine the geometry of all blocks into a single ``PolyData`` object.
 
         Place this filter at the end of a pipeline before a polydata
@@ -17,11 +17,11 @@ class CompositeFilters:
 
         """
         gf = _vtk.vtkCompositeDataGeometryFilter()
-        gf.SetInputData(composite)
+        gf.SetInputData(self)
         gf.Update()
         return wrap(gf.GetOutputDataObject(0))
 
-    def combine(composite, merge_points=False, tolerance=0.0):
+    def combine(self, merge_points=False, tolerance=0.0):
         """Combine all blocks into a single unstructured grid.
 
         Parameters
@@ -52,7 +52,7 @@ class CompositeFilters:
 
         """
         alg = _vtk.vtkAppendFilter()
-        for block in composite:
+        for block in self:
             if isinstance(block, _vtk.vtkMultiBlockDataSet):
                 block = CompositeFilters.combine(block, merge_points=merge_points,
                                                  tolerance=tolerance)
@@ -88,7 +88,7 @@ class CompositeFilters:
 
     triangulate = DataSetFilters.triangulate
 
-    def outline(composite, generate_faces=False, nested=False, progress_bar=False):
+    def outline(self, generate_faces=False, nested=False, progress_bar=False):
         """Produce an outline of the full extent for the all blocks in this composite dataset.
 
         Parameters
@@ -104,11 +104,11 @@ class CompositeFilters:
 
         """
         if nested:
-            return DataSetFilters.outline(composite, generate_faces=generate_faces, progress_bar=progress_bar)
-        box = pyvista.Box(bounds=composite.bounds)
+            return DataSetFilters.outline(self, generate_faces=generate_faces, progress_bar=progress_bar)
+        box = pyvista.Box(bounds=self.bounds)
         return box.outline(generate_faces=generate_faces, progress_bar=progress_bar)
 
-    def outline_corners(composite, factor=0.2, nested=False, progress_bar=False):
+    def outline_corners(self, factor=0.2, nested=False, progress_bar=False):
         """Produce an outline of the corners for the all blocks in this composite dataset.
 
         Parameters
@@ -125,6 +125,6 @@ class CompositeFilters:
 
         """
         if nested:
-            return DataSetFilters.outline_corners(composite, factor=factor, progress_bar=progress_bar)
-        box = pyvista.Box(bounds=composite.bounds)
+            return DataSetFilters.outline_corners(self, factor=factor, progress_bar=progress_bar)
+        box = pyvista.Box(bounds=self.bounds)
         return box.outline_corners(factor=factor, progress_bar=progress_bar)

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -114,11 +114,11 @@ class CompositeFilters:
         Parameters
         ----------
         factor : float, optional
-            controls the relative size of the corners to the length of the
-            corresponding bounds
+            Controls the relative size of the corners to the length of
+            the corresponding bounds
 
         nested : bool, optional
-            If True, these creates individual outlines for each nested dataset
+            If ``True``, these creates individual outlines for each nested dataset
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -94,10 +94,10 @@ class CompositeFilters:
         Parameters
         ----------
         generate_faces : bool, optional
-            Generate solid faces for the box. This is off by default
+            Generate solid faces for the box. This is disabled by default.
 
         nested : bool, optional
-            If True, these creates individual outlines for each nested dataset
+            If ``True``, these creates individual outlines for each nested dataset.
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
@@ -115,10 +115,10 @@ class CompositeFilters:
         ----------
         factor : float, optional
             Controls the relative size of the corners to the length of
-            the corresponding bounds
+            the corresponding bounds.
 
         nested : bool, optional
-            If ``True``, these creates individual outlines for each nested dataset
+            If ``True``, these creates individual outlines for each nested dataset.
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -9,11 +9,16 @@ class CompositeFilters:
     """An internal class to manage filters/algorithms for composite datasets."""
 
     def extract_geometry(self):
-        """Combine the geometry of all blocks into a single ``PolyData`` object.
+        """Extract the surface the geometry of all blocks.
 
         Place this filter at the end of a pipeline before a polydata
-        consumer such as a polydata mapper to extract geometry from all blocks
-        and append them to one polydata object.
+        consumer such as a polydata mapper to extract geometry from
+        all blocks and append them to one polydata object.
+
+        Returns
+        -------
+        pyvista.PolyData
+            Surface of the composite dataset.
 
         """
         gf = _vtk.vtkCompositeDataGeometryFilter()
@@ -32,6 +37,11 @@ class CompositeFilters:
         tolerance : float, optional
             The absolute tolerance to use to find coincident points when
             ``merge_points=True``.
+
+        Returns
+        -------
+        pyvista.UnstructuredGrid
+            Combined blocks.
 
         Examples
         --------
@@ -102,9 +112,15 @@ class CompositeFilters:
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        Returns
+        -------
+        pyvista.PolyData
+            Mesh containing the outline.
+
         """
         if nested:
-            return DataSetFilters.outline(self, generate_faces=generate_faces, progress_bar=progress_bar)
+            return DataSetFilters.outline(self, generate_faces=generate_faces,
+                                          progress_bar=progress_bar)
         box = pyvista.Box(bounds=self.bounds)
         return box.outline(generate_faces=generate_faces, progress_bar=progress_bar)
 
@@ -123,8 +139,14 @@ class CompositeFilters:
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        Returns
+        -------
+        pyvista.PolyData
+            Mesh containing outlined corners.
+
         """
         if nested:
-            return DataSetFilters.outline_corners(self, factor=factor, progress_bar=progress_bar)
+            return DataSetFilters.outline_corners(self, factor=factor,
+                                                  progress_bar=progress_bar)
         box = pyvista.Box(bounds=self.bounds)
         return box.outline_corners(factor=factor, progress_bar=progress_bar)

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -20,7 +20,8 @@ from pyvista.utilities.cells import numpy_to_idarr
 class DataSetFilters:
     """A set of common filters that can be applied to any vtkDataSet."""
 
-    def _clip_with_function(self, function, invert=True, value=0.0, return_clipped=False, progress_bar=False):
+    def _clip_with_function(self, function, invert=True, value=0.0,
+                            return_clipped=False, progress_bar=False):
         """Clip using an implicit function (internal helper)."""
         if isinstance(self, _vtk.vtkPolyData):
             alg = _vtk.vtkClipPolyData()
@@ -125,8 +126,7 @@ class DataSetFilters:
             else:
                 self.overwrite(result)
                 return self
-        else:
-            return result
+        return result
 
     def clip_box(self, bounds=None, invert=True, factor=0.35, progress_bar=False):
         """Clip a dataset by a bounding box defined by the bounds.
@@ -135,7 +135,7 @@ class DataSetFilters:
 
         Parameters
         ----------
-        bounds : tuple(float)
+        bounds : tuple(float), optional
             Length 6 sequence of floats: (xmin, xmax, ymin, ymax, zmin, zmax).
             Length 3 sequence of floats: distances from the min coordinate of
             of the input mesh. Single float value: uniform distance from the
@@ -145,7 +145,7 @@ class DataSetFilters:
             a box with 6 faces that all form a standard box, then planes will
             be extracted from the box to define the clipping region.
 
-        invert : bool
+        invert : bool, optional
             Flag on whether to flip/invert the clip.
 
         factor : float, optional
@@ -154,6 +154,11 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.UnstructuredGrid
+            Clipped dataset.
 
         Examples
         --------
@@ -221,11 +226,17 @@ class DataSetFilters:
         surface : pyvista.DataSet
             The surface used to compute the distance.
 
-        inplace : bool
+        inplace : bool, optional
             If ``True``, a new scalar array will be added to the
             ``point_data`` of this mesh and the modified mesh will
             be returned. Otherwise a copy of this mesh is returned
             with that scalar field added.
+
+        Returns
+        -------
+        pyvista.DataSet
+            Dataset containing the ``'implicit_distance'`` array in
+            ``point_data``.
 
         Examples
         --------
@@ -291,8 +302,9 @@ class DataSetFilters:
 
         Returns
         -------
-        :class:`pyvista.PolyData` or tuple
-            Clipped dataset if ``both=False``.  If ``both=True`` then returns a tuple of both clipped datasets.
+        pyvista.PolyData or tuple
+            Clipped dataset if ``both=False``.  If ``both=True`` then
+            returns a tuple of both clipped datasets.
 
         Examples
         --------
@@ -346,8 +358,7 @@ class DataSetFilters:
                 # For some reason vtkClipPolyData with SetGenerateClippedOutput on leaves unreferenced vertices
                 result0, result1 = (r.clean() for r in (result0, result1))
             return result0, result1
-        else:
-            return result0
+        return result0
 
     def clip_surface(self, surface, invert=True, value=0.0,
                      compute_distance=False, progress_bar=False):
@@ -360,9 +371,9 @@ class DataSetFilters:
         Parameters
         ----------
         surface : pyvista.PolyData
-            The ``PolyData`` surface mesh to use as a clipping function.
-            If this mesh is not ``PolyData``, the external surface will
-            be extracted.
+            The ``PolyData`` surface mesh to use as a clipping
+            function.  If this input mesh is not a :class`pyvista.PolyData`,
+            the external surface will be extracted.
 
         invert : bool, optional
             Flag on whether to flip/invert the clip.
@@ -379,6 +390,11 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.PolyData
+            Clipped surface.
 
         Examples
         --------
@@ -436,6 +452,11 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.PolyData
+            Sliced dataset.
 
         Examples
         --------
@@ -498,6 +519,11 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.PolyData
+            Sliced dataset.
 
         Examples
         --------
@@ -572,6 +598,11 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.PolyData
+            Sliced dataset.
 
         Examples
         --------
@@ -653,6 +684,11 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.PolyData
+            Sliced dataset.
 
         Examples
         --------
@@ -747,6 +783,11 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.UnstructuredGrid
+            Dataset containing geometry that meets the threshold requirements.
 
         Examples
         --------
@@ -875,6 +916,11 @@ class DataSetFilters:
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        Returns
+        -------
+        pyvista.UnstructuredGrid
+            Dataset containing geometry that meets the threshold requirements.
+
         Examples
         --------
         Apply a 50% threshold filter.
@@ -940,6 +986,11 @@ class DataSetFilters:
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        Returns
+        -------
+        pyvista.PolyData
+            Mesh containing an outline of the original dataset.
+
         Examples
         --------
         Generate and plot the outline of a sphere.  This is
@@ -970,6 +1021,11 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.PolyData
+            Mesh containing outlined corners.
 
         Examples
         --------
@@ -1111,6 +1167,12 @@ class DataSetFilters:
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        Returns
+        -------
+        pyvista.DataSet
+            Dataset containing elevation scalars in the
+            ``"Elevation"`` array in ``point_data``.
+
         Examples
         --------
         Generate the "elevation" scalars for a sphere mesh.  This is
@@ -1207,6 +1269,11 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.PolyData
+            Contoured surface.
 
         Examples
         --------
@@ -1372,6 +1439,12 @@ class DataSetFilters:
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        Returns
+        -------
+        pyvista.DataSet
+            Dataset containing the texture mapped to a sphere.  Return
+            type matches input.
+
         Examples
         --------
         See :ref:`ref_texture_example`.
@@ -1385,7 +1458,7 @@ class DataSetFilters:
             alg.SetCenter(center)
         alg.SetPreventSeam(prevent_seam)
         alg.SetInputDataObject(self)
-        _update_alg(alg, progress_bar, 'Texturing Map to Sphere')
+        _update_alg(alg, progress_bar, 'Maping texture to sphere')
         output = _get_output(alg)
         if not inplace:
             return output
@@ -1415,6 +1488,18 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.DataSet
+            Dataset with `cell_data` containing the ``"Length"``,
+            ``"Area"``, and ``"Volume"`` arrays if set in the
+            parameters.  Return type matches input.
+
+        Notes
+        -----
+        If cells do not have a dimension (for example, the length of
+        hexahedral cells), the corresponding array will be all zeros.
 
         Examples
         --------
@@ -1447,6 +1532,12 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.PolyData
+            Polydata where the points are the cell centers of the
+            original dataset.
 
         Examples
         --------
@@ -1657,6 +1748,12 @@ class DataSetFilters:
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        Returns
+        -------
+        pyvista.DataSet
+            Dataset with labeled connected bodies.  Return type
+            matches input.
+
         Examples
         --------
         Join two meshes together and plot their connectivity.
@@ -1696,8 +1793,8 @@ class DataSetFilters:
 
         Returns
         -------
-        pyvista.PolyData
-            Largest connected set in mesh.
+        pyvista.DataSet
+            Largest connected set in the dataset.  Return type matches input.
 
         Examples
         --------
@@ -1717,14 +1814,13 @@ class DataSetFilters:
         if inplace:
             self.overwrite(mesh)
             return self
-        else:
-            return mesh
+        return mesh
 
     def split_bodies(self, label=False, progress_bar=False):
         """Find, label, and split connected bodies/volumes.
 
         This splits different connected bodies into blocks in a
-        ``MultiBlock`` dataset.
+        :class:`pyvista.MultiBlock` dataset.
 
         Parameters
         ----------
@@ -1734,6 +1830,11 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.MultiBlock
+            MultiBlock with a split bodies.
 
         Examples
         --------
@@ -1797,6 +1898,11 @@ class DataSetFilters:
         **kwargs : dict, optional
             Accepts ``scale_factor`` instead of ``factor``.
 
+        Returns
+        -------
+        pyvista.DataSet
+            Warped Dataset.  Return type matches input.
+
         Examples
         --------
         First, plot the unwarped mesh.
@@ -1837,8 +1943,7 @@ class DataSetFilters:
                 raise TypeError("This filter cannot be applied inplace for this mesh type.")
             self.overwrite(output)
             return self
-        else:
-            return output
+        return output
 
     def warp_by_vector(self, vectors=None, factor=1.0, inplace=False,
                        progress_bar=False):
@@ -1934,6 +2039,12 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.DataSet
+            Dataset with the point data transformed into cell data.
+            Return type matches input.
 
         Examples
         --------
@@ -2051,6 +2162,12 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.DataSet
+            Dataset with the point data transformed into cell data.
+            Return type matches input.
 
         """
         return DataSetFilters.point_data_to_cell_data(self, pass_point_data=pass_point_data, progress_bar=progress_bar)
@@ -2274,7 +2391,7 @@ class DataSetFilters:
 
         Returns
         -------
-        :class:`pyvista.DataSet`
+        pyvista.DataSet
             Dataset containing the probed data.
 
         Examples
@@ -2430,6 +2547,11 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.DataSet
+            Interpolated dataset.  Return type matches input.
 
         Examples
         --------
@@ -2849,11 +2971,12 @@ class DataSetFilters:
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             This produces polylines as the output, with each cell
-            (i.e., polyline) representing a streamline. The attribute values
-            associated with each streamline are stored in the cell data, whereas
-            those associated with streamline-points are stored in the point data.
+            (i.e., polyline) representing a streamline. The attribute
+            values associated with each streamline are stored in the
+            cell data, whereas those associated with streamline-points
+            are stored in the point data.
 
         Examples
         --------
@@ -3106,7 +3229,7 @@ class DataSetFilters:
         if fname:
             plt.savefig(fname)
         if show:  # pragma: no cover
-            return plt.show()
+            plt.show()
 
     def sample_over_circular_arc(self, pointa, pointb, center,
                                  resolution=None, tolerance=None,
@@ -3353,7 +3476,7 @@ class DataSetFilters:
         if fname:
             plt.savefig(fname)
         if show:  # pragma: no cover
-            return plt.show()
+            plt.show()
 
     def plot_over_circular_arc_normal(self, center, resolution=None, normal=None,
                                       polar=None, angle=None, scalars=None,
@@ -3475,7 +3598,7 @@ class DataSetFilters:
         if fname:
             plt.savefig(fname)
         if show:  # pragma: no cover
-            return plt.show()
+            plt.show()
 
     def extract_cells(self, ind, progress_bar=False):
         """Return a subset of the grid.
@@ -3839,8 +3962,7 @@ class DataSetFilters:
                 return self
             else:
                 raise TypeError(f"Mesh type {type(self)} cannot be overridden by output.")
-        else:
-            return merged
+        return merged
 
     def __add__(self, grid):
         """Combine this mesh with another into an :class:`pyvista.UnstructuredGrid`."""
@@ -4093,6 +4215,11 @@ class DataSetFilters:
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        Returns
+        -------
+        pyvista.DataSet
+            Dataset with shrunk faces.  Return type matches input.
+
         Examples
         --------
         First, plot the original cube.
@@ -4133,7 +4260,6 @@ class DataSetFilters:
             is to store the three components as separate scalar
             arrays.
 
-
         Parameters
         ----------
         trans : vtk.vtkMatrix4x4, vtk.vtkTransform, or np.ndarray
@@ -4150,6 +4276,11 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.DataSet
+            Transformed dataset.  Return type matches input.
 
         Examples
         --------
@@ -4231,8 +4362,7 @@ class DataSetFilters:
         if inplace:
             self.overwrite(res)
             return self
-        else:
-            return res
+        return res
 
     def reflect(self, normal, point=None, inplace=False,
                 transform_all_input_vectors=False, progress_bar=False):
@@ -4256,6 +4386,11 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.DataSet
+            Reflected dataset.  Return type matches input.
 
         Examples
         --------

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1794,6 +1794,9 @@ class DataSetFilters:
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        **kwargs : dict, optional
+            Accepts ``scale_factor`` instead of ``factor``.
+
         Examples
         --------
         First, plot the unwarped mesh.
@@ -2526,6 +2529,9 @@ class DataSetFilters:
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        **kwargs : dict, optional
+            See :func:`pyvista.DataSetFilters.streamlines_from_source`.
+
         Returns
         -------
         streamlines : pyvista.PolyData
@@ -2650,16 +2656,16 @@ class DataSetFilters:
             Vorticity computation at streamline points. Necessary for generating
             proper stream-ribbons using the ``vtkRibbonFilter``.
 
+        rotation_scale : float, optional
+            This can be used to scale the rate with which the streamribbons
+            twist. The default is 1.
+
         interpolator_type : str, optional
             Set the type of the velocity field interpolator to locate cells
             during streamline integration either by points or cells.
             The cell locator is more robust then the point locator. Options
             are ``'point'`` or ``'cell'`` (abbreviations of ``'p'`` and ``'c'``
             are also supported).
-
-        rotation_scale : float, optional
-            This can be used to scale the rate with which the streamribbons
-            twist. The default is 1.
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -80,7 +80,7 @@ class DataSetFilters:
 
         Returns
         -------
-        mesh : pyvista.PolyData or tuple(pyvista.PolyData)
+        pyvista.PolyData or tuple(pyvista.PolyData)
             Clipped mesh when ``return_clipped=False``,
             otherwise a tuple containing the unclipped and clipped datasets.
 
@@ -735,7 +735,7 @@ class DataSetFilters:
             rather than the set of discrete scalar values from the vertices.
 
         preference : str, optional
-            When scalars is specified, this is the preferred array
+            When ``scalars`` is specified, this is the preferred array
             type to search for in the dataset.  Must be either
             ``'point'`` or ``'cell'``.
 
@@ -936,7 +936,7 @@ class DataSetFilters:
         Parameters
         ----------
         generate_faces : bool, optional
-            Generate solid faces for the box. This is off by default
+            Generate solid faces for the box. This is disabled by default.
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
@@ -967,7 +967,7 @@ class DataSetFilters:
         ----------
         factor : float, optional
             Controls the relative size of the corners to the length of
-            the corresponding bounds
+            the corresponding bounds.
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
@@ -1696,8 +1696,8 @@ class DataSetFilters:
 
         Returns
         -------
-        mesh : pyvista.PolyData
-            Largest connected set in mesh
+        pyvista.PolyData
+            Largest connected set in mesh.
 
         Examples
         --------
@@ -1926,8 +1926,8 @@ class DataSetFilters:
 
         Parameters
         ----------
-        pass_cell_data : bool
-            If enabled, pass the input cell data through to the output
+        pass_cell_data : bool, optional
+            If enabled, pass the input cell data through to the output.
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
@@ -1984,8 +1984,8 @@ class DataSetFilters:
 
         Parameters
         ----------
-        pass_point_data : bool
-            If enabled, pass the input point data through to the output
+        pass_point_data : bool, optional
+            If enabled, pass the input point data through to the output.
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
@@ -2229,7 +2229,7 @@ class DataSetFilters:
         ----------
         dataset : pyvista.DataSet
             The mesh to probe from - point and cell arrays from
-            this object are probed onto the nodes of the ``points`` mesh
+            this object are probed onto the points of the ``points`` mesh.
 
         points : pyvista.DataSet
             The points to probe values on to. This should be a PyVista mesh
@@ -2642,7 +2642,7 @@ class DataSetFilters:
 
         max_steps : int, optional
             Maximum number of steps for integrating a streamline.
-            Defaults to ``2000``
+            Defaults to ``2000``.
 
         terminal_speed : float, optional
             Terminal speed value, below which integration is terminated.
@@ -2795,7 +2795,7 @@ class DataSetFilters:
 
         max_steps : int, optional
             Maximum number of steps for integrating a streamline.
-            Defaults to ``2000``
+            Defaults to ``2000``.
 
         terminal_speed : float, optional
             Terminal speed value, below which integration is terminated.
@@ -3125,7 +3125,7 @@ class DataSetFilters:
         Returns
         -------
         pyvista.PolyData
-            Arc containing the sampled data
+            Arc containing the sampled data.
 
         Examples
         --------
@@ -3190,6 +3190,11 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.PolyData
+            Sampled Dataset.
 
         Examples
         --------
@@ -3376,7 +3381,7 @@ class DataSetFilters:
             The string title of the `matplotlib` figure.
 
         ylabel : str, optional
-            The string label of the Y-axis. Defaults to variable name
+            The string label of the Y-axis. Defaults to variable name.
 
         figsize : tuple(int), optional
             The size of the new figure.
@@ -3385,7 +3390,7 @@ class DataSetFilters:
             Flag on whether or not to create a new figure.
 
         show : bool, optional
-            Shows the matplotlib figure
+            Shows the matplotlib figure.
 
         tolerance : float, optional
             Tolerance used to compute whether a point in the source is
@@ -3468,7 +3473,7 @@ class DataSetFilters:
         Returns
         -------
         subgrid : pyvista.UnstructuredGrid
-            Subselected grid
+            Subselected grid.
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
@@ -3580,11 +3585,11 @@ class DataSetFilters:
         ----------
         pass_pointid : bool, optional
             Adds a point array "vtkOriginalPointIds" that idenfities which
-            original points these surface points correspond to
+            original points these surface points correspond to.
 
         pass_cellid : bool, optional
             Adds a cell array "vtkOriginalPointIds" that idenfities which
-            original cells these surface cells correspond to
+            original cells these surface cells correspond to.
 
         nonlinear_subdivision : int, optional
             If the input is an unstructured grid with nonlinear faces,
@@ -3707,7 +3712,7 @@ class DataSetFilters:
 
         Returns
         -------
-        edges : pyvista.PolyData
+        pyvista.PolyData
             Extracted edges.
 
         Examples

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2093,6 +2093,12 @@ class DataSetFilters:
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        Returns
+        -------
+        pyvista.DataSet
+            Dataset with the cell data transformed into point data.
+            Return type matches input.
+
         """
         return DataSetFilters.cell_data_to_point_data(self, pass_cell_data=pass_cell_data, progress_bar=progress_bar)
 
@@ -2111,6 +2117,12 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.DataSet
+            Dataset with the point data transformed into cell data.
+            Return type matches input.
 
         Examples
         --------

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1974,6 +1974,14 @@ class DataSetFilters:
         This method is an alias for
         :func:`pyvista.DataSetFilters.cell_data_to_point_data`.
 
+        Parameters
+        ----------
+        pass_cell_data : bool, optional
+            If enabled, pass the input cell data through to the output.
+
+        progress_bar : bool, optional
+            Display a progress bar to indicate progress.
+
         """
         return DataSetFilters.cell_data_to_point_data(self, pass_cell_data=pass_cell_data, progress_bar=progress_bar)
 
@@ -2035,6 +2043,14 @@ class DataSetFilters:
 
         This method is an alias for
         :func:`pyvista.DataSetFilters.point_data_to_cell_data`.
+
+        Parameters
+        ----------
+        pass_point_data : bool, optional
+            If enabled, pass the input point data through to the output.
+
+        progress_bar : bool, optional
+            Display a progress bar to indicate progress.
 
         """
         return DataSetFilters.point_data_to_cell_data(self, pass_point_data=pass_point_data, progress_bar=progress_bar)
@@ -2383,12 +2399,6 @@ class DataSetFilters:
         radius : float, optional
             Specify the radius within which the basis points must lie.
 
-        n_points : int, optional
-            If given, specifies the number of the closest points used to form
-            the interpolation basis. This will invalidate the radius argument
-            in favor of an N closest points approach. This typically has poorer
-            results.
-
         strategy : str, optional
             Specify a strategy to use when encountering a "null" point during
             the interpolation process. Null points occur when the local
@@ -2405,6 +2415,12 @@ class DataSetFilters:
             Specify the null point value. When a null point is encountered
             then all components of each null tuple are set to this value. By
             default the null value is set to zero.
+
+        n_points : int, optional
+            If given, specifies the number of the closest points used to form
+            the interpolation basis. This will invalidate the radius argument
+            in favor of an N closest points approach. This typically has poorer
+            results.
 
         pass_cell_arrays : bool, optional
             Preserve input mesh's original cell data arrays.
@@ -3469,13 +3485,13 @@ class DataSetFilters:
         ind : np.ndarray
             Numpy array of cell indices to be extracted.
 
-        Returns
-        -------
-        subgrid : pyvista.UnstructuredGrid
-            Subselected grid.
-
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.UnstructuredGrid
+            Subselected grid.
 
         Examples
         --------

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -532,8 +532,7 @@ class DataSetFilters:
 
     def slice_along_axis(self, n=5, axis='x', tolerance=None,
                          generate_triangles=False, contour=False,
-                         bounds=None, center=None, slice=False,
-                         progress_bar=False):
+                         bounds=None, center=None, progress_bar=False):
         """Create many slices of the input dataset along a specified axis.
 
         Parameters

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -426,7 +426,7 @@ class DataSetFilters:
             The center ``(x, y, z)`` coordinate of the plane on which
             the slice occurs.
 
-        generate_triangles: bool, optional
+        generate_triangles : bool, optional
             If this is enabled (``False`` by default), the output will
             be triangles. Otherwise the output will be the intersection
             polygons.
@@ -488,7 +488,7 @@ class DataSetFilters:
         z : float, optional
             The Z location of the XY slice.
 
-        generate_triangles: bool, optional
+        generate_triangles : bool, optional
             If this is enabled (``False`` by default), the output will
             be triangles. Otherwise the output will be the intersection
             polygons.
@@ -553,7 +553,7 @@ class DataSetFilters:
             ``bounds`` along the specified axis. Defaults to 1% of the
             ``bounds`` along the specified axis.
 
-        generate_triangles: bool, optional
+        generate_triangles : bool, optional
             If this is enabled (``False`` by default), the output will
             be triangles. Otherwise the output will be the intersection
             polygons.
@@ -644,7 +644,7 @@ class DataSetFilters:
         line : pyvista.PolyData
             A PolyData object containing one single PolyLine cell.
 
-        generate_triangles: bool, optional
+        generate_triangles : bool, optional
             If this is enabled (``False`` by default), the output will
             be triangles. Otherwise the output will be the intersection
             polygons.
@@ -1519,10 +1519,10 @@ class DataSetFilters:
         absolute : bool, optional
             Control if ``tolerance`` is an absolute distance or a fraction.
 
-        clamping: bool, optional
+        clamping : bool, optional
             Turn on/off clamping of "scalar" values to range. Default ``False``.
 
-        rng: tuple(float), optional
+        rng : tuple(float), optional
             Set the range of values to be considered by the filter
             when scalars values are provided.
 
@@ -1531,7 +1531,7 @@ class DataSetFilters:
 
         Returns
         -------
-        glyphs : pyvista.PolyData
+        pyvista.PolyData
             Glyphs at either the cell centers or points.
 
         Examples
@@ -2254,7 +2254,7 @@ class DataSetFilters:
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
-        locator: vtkAbstractCellLocator, optional
+        locator : vtkAbstractCellLocator, optional
             Prototype cell locator to perform the FindCell() operation.
 
         Returns
@@ -2302,23 +2302,23 @@ class DataSetFilters:
 
         Parameters
         ----------
-        dataset: pyvista.DataSet
-            The source vtk data object as the mesh to sample values on to
+        dataset : pyvista.DataSet
+            The source vtk data object as the mesh to sample values on to.
 
-        target: pyvista.DataSet
+        target : pyvista.DataSet
             The vtk data object to sample from - point and cell arrays from
-            this object are sampled onto the nodes of the ``dataset`` mesh
+            this object are sampled onto the nodes of the ``dataset`` mesh.
 
-        tolerance: float, optional
+        tolerance : float, optional
             Tolerance used to compute whether a point in the source is
             in a cell of the input.  If not given, tolerance is
             automatically generated.
 
-        pass_cell_arrays: bool, optional
-            Preserve source mesh's original cell data arrays
+        pass_cell_arrays : bool, optional
+            Preserve source mesh's original cell data arrays.
 
-        pass_point_data: bool, optional
-            Preserve source mesh's original point data arrays
+        pass_point_data : bool, optional
+            Preserve source mesh's original point data arrays.
 
         categorical : bool, optional
             Control whether the source point data is to be treated as
@@ -2375,8 +2375,8 @@ class DataSetFilters:
 
         Parameters
         ----------
-        target: pyvista.DataSet
-            The vtk data object to sample from - point and cell arrays from
+        target : pyvista.DataSet
+            The vtk data object to sample from. Point and cell arrays from
             this object are interpolated onto this mesh.
 
         sharpness : float, optional
@@ -2410,10 +2410,10 @@ class DataSetFilters:
             then all components of each null tuple are set to this value. By
             default the null value is set to zero.
 
-        pass_cell_arrays: bool, optional
+        pass_cell_arrays : bool, optional
             Preserve input mesh's original cell data arrays.
 
-        pass_point_data: bool, optional
+        pass_point_data : bool, optional
             Preserve input mesh's original point data arrays.
 
         progress_bar : bool, optional
@@ -2766,6 +2766,10 @@ class DataSetFilters:
         that do not result in too much memory being utilized.  The
         default unit is cell length.
 
+        .. warning::
+            This filter is unstable for ``vtk<9.0``.
+            See `pyvista issue 1508 <https://github.com/pyvista/pyvista/issues/1508>`_.
+
         Parameters
         ----------
         vectors : str, optional
@@ -2835,11 +2839,6 @@ class DataSetFilters:
             (i.e., polyline) representing a streamline. The attribute values
             associated with each streamline are stored in the cell data, whereas
             those associated with streamline-points are stored in the point data.
-
-        Warnings
-        --------
-        This filter is unstable for ``vtk<9.0``.
-        See `pyvista issue 1508 <https://github.com/pyvista/pyvista/issues/1508>`_.
 
         Examples
         --------
@@ -2958,7 +2957,7 @@ class DataSetFilters:
             Number of pieces to divide line into. Defaults to number of cells
             in the input mesh. Must be a positive integer.
 
-        tolerance: float, optional
+        tolerance : float, optional
             Tolerance used to compute whether a point in the source is in a
             cell of the input.  If not given, tolerance is automatically generated.
 
@@ -3018,7 +3017,7 @@ class DataSetFilters:
             Location in ``[x, y, z]``.
 
         resolution : int, optional
-            number of pieces to divide line into. Defaults to number of cells
+            Number of pieces to divide line into. Defaults to number of cells
             in the input mesh. Must be a positive integer.
 
         scalars : str, optional
@@ -3040,7 +3039,7 @@ class DataSetFilters:
         show : bool, optional
             Shows the matplotlib figure.
 
-        tolerance: float, optional
+        tolerance : float, optional
             Tolerance used to compute whether a point in the source is in a
             cell of the input.  If not given, tolerance is automatically generated.
 
@@ -3115,7 +3114,7 @@ class DataSetFilters:
             number of cells in the input mesh. Must be a positive
             integer.
 
-        tolerance: float, optional
+        tolerance : float, optional
             Tolerance used to compute whether a point in the source is
             in a cell of the input.  If not given, tolerance is
             automatically generated.
@@ -3184,7 +3183,7 @@ class DataSetFilters:
             Arc length (in degrees), beginning at the polar vector.  The
             direction is counterclockwise.  By default it is 360.
 
-        tolerance: float, optional
+        tolerance : float, optional
             Tolerance used to compute whether a point in the source is
             in a cell of the input.  If not given, tolerance is
             automatically generated.
@@ -3268,7 +3267,7 @@ class DataSetFilters:
         show : bool, optional
             Shows the ``matplotlib`` figure when ``True``.
 
-        tolerance: float, optional
+        tolerance : float, optional
             Tolerance used to compute whether a point in the source is
             in a cell of the input.  If not given, tolerance is
             automatically generated.
@@ -3353,7 +3352,7 @@ class DataSetFilters:
             Location in ``[x, y, z]``.
 
         resolution : int, optional
-            number of pieces to divide circular arc into. Defaults to
+            Number of pieces to divide circular arc into. Defaults to
             number of cells in the input mesh. Must be a positive
             integer.
 
@@ -3362,8 +3361,8 @@ class DataSetFilters:
             points in the positive Z direction.
 
         polar : np.ndarray or list, optional
-            (starting point of the arc).  By default it is the unit vector
-            in the positive x direction.
+            Starting point of the arc in polar coordinates.  By
+            default it is the unit vector in the positive x direction.
 
         angle : float, optional
             Arc length (in degrees), beginning at the polar vector.  The
@@ -3374,21 +3373,21 @@ class DataSetFilters:
             probe. The active scalar is used by default.
 
         title : str, optional
-            The string title of the `matplotlib` figure
+            The string title of the `matplotlib` figure.
 
         ylabel : str, optional
             The string label of the Y-axis. Defaults to variable name
 
         figsize : tuple(int), optional
-            the size of the new figure
+            The size of the new figure.
 
         figure : bool, optional
-            flag on whether or not to create a new figure
+            Flag on whether or not to create a new figure.
 
         show : bool, optional
             Shows the matplotlib figure
 
-        tolerance: float, optional
+        tolerance : float, optional
             Tolerance used to compute whether a point in the source is
             in a cell of the input.  If not given, tolerance is
             automatically generated.
@@ -3960,34 +3959,34 @@ class DataSetFilters:
             derivative quantities.  Defaults to the active scalars in
             the dataset.
 
-        gradient: bool, str, optional
+        gradient : bool, str, optional
             Calculate gradient. If a string is passed, the string will be used
             for the resulting array name. Otherwise, array name will be
             ``'gradient'``. Default ``True``.
 
-        divergence: bool, str, optional
+        divergence : bool, str, optional
             Calculate divergence. If a string is passed, the string will be
             used for the resulting array name. Otherwise, array name will be
             ``'divergence'``. Default ``None``.
 
-        vorticity: bool, str, optional
+        vorticity : bool, str, optional
             Calculate vorticity. If a string is passed, the string will be used
             for the resulting array name. Otherwise, array name will be
             ``'vorticity'``. Default ``None``.
 
-        qcriterion: bool, str, optional
+        qcriterion : bool, str, optional
             Calculate qcriterion. If a string is passed, the string will be
             used for the resulting array name. Otherwise, array name will be
             ``'qcriterion'``. Default ``None``.
 
-        faster: bool, optional
+        faster : bool, optional
             Use faster algorithm for computing derivative quantities. Result is
             less accurate and performs fewer derivative calculations,
             increasing computation speed. The error will feature smoothing of
             the output and possibly errors at boundaries. Option has no effect
             if DataSet is not UnstructuredGrid. Default ``False``.
 
-        preference: str, optional
+        preference : str, optional
             Data type preference. Either ``'point'`` or ``'cell'``.
 
         progress_bar : bool, optional
@@ -4103,13 +4102,24 @@ class DataSetFilters:
                   transform_all_input_vectors=False, inplace=True, progress_bar=False):
         """Transform this mesh with a 4x4 transform.
 
+        .. warning::
+            When using ``transform_all_input_vectors=True``, there is
+            no distinction in VTK between vectors and arrays with
+            three components.  This may be an issue if you have scalar
+            data with three components (e.g. RGB data).  This will be
+            improperly transformed as if it was vector data rather
+            than scalar data.  One possible (albeit ugly) workaround
+            is to store the three components as separate scalar
+            arrays.
+
+
         Parameters
         ----------
         trans : vtk.vtkMatrix4x4, vtk.vtkTransform, or np.ndarray
             Accepts a vtk transformation object or a 4x4
             transformation matrix.
 
-        transform_all_input_vectors: bool, optional
+        transform_all_input_vectors : bool, optional
             When ``True``, all arrays with three components are
             transformed. Otherwise, only the normals and vectors are
             transformed.  See the warning for more details.
@@ -4138,16 +4148,6 @@ class DataSetFilters:
         ...                              [0, 0, 0, 1]])
         >>> transformed = mesh.transform(transform_matrix)
         >>> transformed.plot(show_edges=True)
-
-        Warnings
-        --------
-        When using ``transform_all_input_vectors=True``, there is no
-        distinction in VTK between vectors and arrays with three
-        components.  This may be an issue if you have scalar data with
-        three components (e.g. RGB data).  This will be improperly
-        transformed as if it was vector data rather than scalar data.
-        One possible (albeit ugly) workaround is to store the three
-        components as separate scalar arrays.
 
         """
         if isinstance(trans, _vtk.vtkMatrix4x4):
@@ -4229,7 +4229,7 @@ class DataSetFilters:
         inplace : bool, optional
             When ``True``, modifies the dataset inplace.
 
-        transform_all_input_vectors: bool, optional
+        transform_all_input_vectors : bool, optional
             When ``True``, all input vectors are transformed. Otherwise,
             only the points, normals and active vectors are transformed.
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -3804,7 +3804,7 @@ class DataSetFilters:
 
         Returns
         -------
-        np.ndarray
+        numpy.ndarray
             Indices of the surface points.
 
         Examples

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -18,7 +18,7 @@ from pyvista.core.filters.data_set import DataSetFilters
 class PolyDataFilters(DataSetFilters):
     """An internal class to manage filters/algorithms for polydata datasets."""
 
-    def edge_mask(poly_data, angle, progress_bar=False):
+    def edge_mask(self, angle, progress_bar=False):
         """Return a mask of the points of a surface mesh that has a surface angle greater than angle.
 
         Parameters
@@ -46,6 +46,7 @@ class PolyDataFilters(DataSetFilters):
         >>> mesh.plot(scalars=mask)
 
         """
+        poly_data = self
         if not isinstance(poly_data, pyvista.PolyData):  # pragma: no cover
             poly_data = pyvista.PolyData(poly_data)
         poly_data.point_data['point_ind'] = np.arange(poly_data.n_points)
@@ -63,11 +64,11 @@ class PolyDataFilters(DataSetFilters):
         return np.in1d(poly_data.point_data['point_ind'], orig_id,
                        assume_unique=True)
 
-    def _boolean(poly_data, btype, other_mesh, tolerance, progress_bar=False):
+    def _boolean(self, btype, other_mesh, tolerance, progress_bar=False):
         """Perform boolean operation."""
         if not isinstance(other_mesh, pyvista.PolyData):
             raise TypeError("Input mesh must be PolyData.")
-        if not poly_data.is_all_triangles or not other_mesh.is_all_triangles:
+        if not self.is_all_triangles or not other_mesh.is_all_triangles:
             raise NotAllTrianglesError("Make sure both the input and output are triangulated.")
 
         bfilter = _vtk.vtkBooleanOperationPolyDataFilter()
@@ -79,7 +80,7 @@ class PolyDataFilters(DataSetFilters):
             bfilter.SetOperationToDifference()
         else:  # pragma: no cover
             raise ValueError(f'Invalid btype {btype}')
-        bfilter.SetInputData(0, poly_data)
+        bfilter.SetInputData(0, self)
         bfilter.SetInputData(1, other_mesh)
         bfilter.ReorientDifferenceCellsOn()  # this is already default
         bfilter.SetTolerance(tolerance)
@@ -87,7 +88,7 @@ class PolyDataFilters(DataSetFilters):
 
         return _get_output(bfilter)
 
-    def boolean_cut(poly_data, *args, **kwargs):  # pragma: no cover
+    def boolean_cut(self, *args, **kwargs):  # pragma: no cover
         """Cut two meshes.
 
         .. deprecated:: 0.32.0
@@ -97,7 +98,7 @@ class PolyDataFilters(DataSetFilters):
         raise DeprecationError('``boolean_cut`` has been deprecated.  '
                                'Please use ``boolean_difference``.')
 
-    def boolean_add(poly_data, *args, **kwargs):  # pragma: no cover
+    def boolean_add(self, *args, **kwargs):  # pragma: no cover
         """Merge two meshes together.
 
         .. deprecated:: 0.32.0
@@ -107,7 +108,7 @@ class PolyDataFilters(DataSetFilters):
         raise DeprecationError('``boolean_add`` has been deprecated.  '
                                'Please use ``merge``.')
 
-    def boolean_union(poly_data, other_mesh, tolerance=1E-5, progress_bar=False):
+    def boolean_union(self, other_mesh, tolerance=1E-5, progress_bar=False):
         """Perform a boolean union operation on two meshes.
 
         Essentially, boolean union, difference, and intersection are
@@ -174,9 +175,9 @@ class PolyDataFilters(DataSetFilters):
         See :ref:`boolean_example` for more examples using this filter.
 
         """
-        return poly_data._boolean('union', other_mesh, tolerance, progress_bar=progress_bar)
+        return self._boolean('union', other_mesh, tolerance, progress_bar=progress_bar)
 
-    def boolean_intersection(poly_data, other_mesh, tolerance=1E-5, progress_bar=False):
+    def boolean_intersection(self, other_mesh, tolerance=1E-5, progress_bar=False):
         """Perform a boolean intersection operation on two meshes.
 
         Essentially, boolean union, difference, and intersection are
@@ -243,9 +244,9 @@ class PolyDataFilters(DataSetFilters):
         See :ref:`boolean_example` for more examples using this filter.
 
         """
-        return poly_data._boolean('intersection', other_mesh, tolerance, progress_bar=progress_bar)
+        return self._boolean('intersection', other_mesh, tolerance, progress_bar=progress_bar)
 
-    def boolean_difference(poly_data, other_mesh, tolerance=1E-5, progress_bar=False):
+    def boolean_difference(self, other_mesh, tolerance=1E-5, progress_bar=False):
         """Perform a boolean difference operation between two meshes.
 
         Essentially, boolean union, difference, and intersection are
@@ -306,13 +307,13 @@ class PolyDataFilters(DataSetFilters):
         See :ref:`boolean_example` for more examples using this filter.
 
         """
-        return poly_data._boolean('difference', other_mesh, tolerance, progress_bar=progress_bar)
+        return self._boolean('difference', other_mesh, tolerance, progress_bar=progress_bar)
 
-    def __add__(poly_data, dataset):
+    def __add__(self, dataset):
         """Merge these two meshes."""
-        return poly_data.merge(dataset)
+        return self.merge(dataset)
 
-    def merge(poly_data, dataset, merge_points=True, inplace=False,
+    def merge(self, dataset, merge_points=True, inplace=False,
               main_has_priority=True, progress_bar=False):
         """Merge this mesh with one or more datasets.
 
@@ -366,12 +367,12 @@ class PolyDataFilters(DataSetFilters):
 
         # use dataset merge if not polydata
         if not_pd:
-            return DataSetFilters.merge(poly_data, dataset,
+            return DataSetFilters.merge(self, dataset,
                                         merge_points=merge_points,
                                         inplace=inplace)
 
         append_filter = pyvista._vtk.vtkAppendPolyData()
-        append_filter.AddInputData(poly_data)
+        append_filter.AddInputData(self)
 
         if isinstance(dataset, pyvista.DataSet):
             append_filter.AddInputData(dataset)
@@ -391,7 +392,7 @@ class PolyDataFilters(DataSetFilters):
 
         return merged
 
-    def intersection(poly_data, mesh, split_first=True, split_second=True, progress_bar=False):
+    def intersection(self, mesh, split_first=True, split_second=True, progress_bar=False):
         """Compute the intersection between two meshes.
 
         .. note::
@@ -456,7 +457,7 @@ class PolyDataFilters(DataSetFilters):
 
         """
         intfilter = _vtk.vtkIntersectionPolyDataFilter()
-        intfilter.SetInputDataObject(0, poly_data)
+        intfilter.SetInputDataObject(0, self)
         intfilter.SetInputDataObject(1, mesh)
         intfilter.SetComputeIntersectionPointArray(True)
         intfilter.SetSplitFirstOutput(split_first)
@@ -469,14 +470,11 @@ class PolyDataFilters(DataSetFilters):
 
         return intersection, first, second
 
-    def curvature(poly_data, curv_type='mean', progress_bar=False):
+    def curvature(self, curv_type='mean', progress_bar=False):
         """Return the pointwise curvature of a mesh.
 
         Parameters
         ----------
-        poly_data : pyvista.PolyData
-            Input mesh to compute curvature on.
-
         curv_type : str, optional
             Curvature type.  One of the following:
 
@@ -513,7 +511,7 @@ class PolyDataFilters(DataSetFilters):
 
         # Create curve filter and compute curvature
         curvefilter = _vtk.vtkCurvatures()
-        curvefilter.SetInputData(poly_data)
+        curvefilter.SetInputData(self)
         if curv_type == 'mean':
             curvefilter.SetCurvatureTypeToMean()
         elif curv_type == 'gaussian':
@@ -531,7 +529,7 @@ class PolyDataFilters(DataSetFilters):
         curv = _get_output(curvefilter)
         return _vtk.vtk_to_numpy(curv.GetPointData().GetScalars())
 
-    def plot_curvature(poly_data, curv_type='mean', **kwargs):
+    def plot_curvature(self, curv_type='mean', **kwargs):
         """Plot the curvature.
 
         Parameters
@@ -567,19 +565,15 @@ class PolyDataFilters(DataSetFilters):
         """
         kwargs.setdefault('scalar_bar_args',
                           {'title': f'{curv_type.capitalize()} Curvature'})
-        return poly_data.plot(scalars=poly_data.curvature(curv_type),
-                              **kwargs)
+        return self.plot(scalars=self.curvature(curv_type), **kwargs)
 
-    def triangulate(poly_data, inplace=False, progress_bar=False):
+    def triangulate(self, inplace=False, progress_bar=False):
         """Return an all triangle mesh.
 
         More complex polygons will be broken down into triangles.
 
         Parameters
         ----------
-        poly_data : pyvista.PolyData
-            Input mesh to convert to an all triangle mesh.
-
         inplace : bool, optional
             Whether to update the mesh in-place.
 
@@ -607,18 +601,18 @@ class PolyDataFilters(DataSetFilters):
 
         """
         trifilter = _vtk.vtkTriangleFilter()
-        trifilter.SetInputData(poly_data)
+        trifilter.SetInputData(self)
         trifilter.PassVertsOff()
         trifilter.PassLinesOff()
         _update_alg(trifilter, progress_bar, 'Computing Triangle Mesh')
 
         mesh = _get_output(trifilter)
         if inplace:
-            poly_data.overwrite(mesh)
-            return poly_data
+            self.overwrite(mesh)
+            return self
         return mesh
 
-    def smooth(poly_data, n_iter=20, relaxation_factor=0.01, convergence=0.0,
+    def smooth(self, n_iter=20, relaxation_factor=0.01, convergence=0.0,
                edge_angle=15, feature_angle=45,
                boundary_smoothing=True, feature_smoothing=False, inplace=False,
                progress_bar=False):
@@ -683,7 +677,7 @@ class PolyDataFilters(DataSetFilters):
 
         """
         alg = _vtk.vtkSmoothPolyDataFilter()
-        alg.SetInputData(poly_data)
+        alg.SetInputData(self)
         alg.SetNumberOfIterations(n_iter)
         alg.SetConvergence(convergence)
         alg.SetFeatureEdgeSmoothing(feature_smoothing)
@@ -695,12 +689,12 @@ class PolyDataFilters(DataSetFilters):
 
         mesh = _get_output(alg)
         if inplace:
-            poly_data.overwrite(mesh)
-            return poly_data
+            self.overwrite(mesh)
+            return self
 
         return mesh
 
-    def decimate_pro(poly_data, reduction, feature_angle=45.0,
+    def decimate_pro(self, reduction, feature_angle=45.0,
                      split_angle=75.0, splitting=True,
                      pre_split_mesh=False, preserve_topology=False,
                      inplace=False, progress_bar=False):
@@ -775,7 +769,7 @@ class PolyDataFilters(DataSetFilters):
 
         """
         alg = _vtk.vtkDecimatePro()
-        alg.SetInputData(poly_data)
+        alg.SetInputData(self)
         alg.SetTargetReduction(reduction)
         alg.SetPreserveTopology(preserve_topology)
         alg.SetFeatureAngle(feature_angle)
@@ -786,12 +780,12 @@ class PolyDataFilters(DataSetFilters):
 
         mesh = _get_output(alg)
         if inplace:
-            poly_data.overwrite(mesh)
-            return poly_data
+            self.overwrite(mesh)
+            return self
 
         return mesh
 
-    def tube(poly_data, radius=None, scalars=None, capping=True, n_sides=20,
+    def tube(self, radius=None, scalars=None, capping=True, n_sides=20,
              radius_factor=10, preference='point', inplace=False, progress_bar=False):
         """Generate a tube around each input line.
 
@@ -849,6 +843,7 @@ class PolyDataFilters(DataSetFilters):
         See :ref:`ref_create_spline` for more examples using this filter.
 
         """
+        poly_data = self
         if not isinstance(poly_data, pyvista.PolyData):
             poly_data = pyvista.PolyData(poly_data)
         if n_sides < 3:
@@ -878,7 +873,7 @@ class PolyDataFilters(DataSetFilters):
             return poly_data
         return mesh
 
-    def subdivide(poly_data, nsub, subfilter='linear', inplace=False, progress_bar=False):
+    def subdivide(self, nsub, subfilter='linear', inplace=False, progress_bar=False):
         """Increase the number of triangles in a single, connected triangular mesh.
 
         Uses one of the following vtk subdivision filters to subdivide a mesh:
@@ -963,17 +958,17 @@ class PolyDataFilters(DataSetFilters):
 
         # Subdivide
         sfilter.SetNumberOfSubdivisions(nsub)
-        sfilter.SetInputData(poly_data)
+        sfilter.SetInputData(self)
         _update_alg(sfilter, progress_bar, 'Subdividing Mesh')
 
         submesh = _get_output(sfilter)
         if inplace:
-            poly_data.overwrite(submesh)
-            return poly_data
+            self.overwrite(submesh)
+            return self
 
         return submesh
 
-    def subdivide_adaptive(poly_data, max_edge_len=None, max_tri_area=None,
+    def subdivide_adaptive(self, max_edge_len=None, max_tri_area=None,
                            max_n_tris=None, max_n_passes=None, inplace=False,
                            progress_bar=False):
         """Increase the number of triangles in a triangular mesh based on edge and/or area metrics.
@@ -1058,17 +1053,17 @@ class PolyDataFilters(DataSetFilters):
         if max_n_passes:
             sfilter.SetMaximumNumberOfPasses(max_n_passes)
 
-        sfilter.SetInputData(poly_data)
+        sfilter.SetInputData(self)
         _update_alg(sfilter, progress_bar, 'Adaptively Subdividing Mesh')
         submesh = _get_output(sfilter)
 
         if inplace:
-            poly_data.overwrite(submesh)
-            return poly_data
+            self.overwrite(submesh)
+            return self
 
         return submesh
 
-    def decimate(poly_data, target_reduction, volume_preservation=False,
+    def decimate(self, target_reduction, volume_preservation=False,
                  attribute_error=False, scalars=True, vectors=True,
                  normals=False, tcoords=True, tensors=True, scalars_weight=0.1,
                  vectors_weight=0.1, normals_weight=0.1, tcoords_weight=0.1,
@@ -1077,9 +1072,6 @@ class PolyDataFilters(DataSetFilters):
 
         Parameters
         ----------
-        poly_data : vtk.PolyData
-            Mesh to decimate.
-
         target_reduction : float
             Fraction of the original mesh to remove.
             If ``target_reduction`` is set to 0.9, this filter will try
@@ -1184,17 +1176,17 @@ class PolyDataFilters(DataSetFilters):
         alg.SetTensorsWeight(tensors_weight)
         alg.SetTargetReduction(target_reduction)
 
-        alg.SetInputData(poly_data)
+        alg.SetInputData(self)
         _update_alg(alg, progress_bar, 'Decimating Mesh')
 
         mesh = _get_output(alg)
         if inplace:
-            poly_data.overwrite(mesh)
-            return poly_data
+            self.overwrite(mesh)
+            return self
 
         return mesh
 
-    def compute_normals(poly_data, cell_normals=True,
+    def compute_normals(self, cell_normals=True,
                         point_normals=True, split_vertices=False,
                         flip_normals=False, consistent_normals=True,
                         auto_orient_normals=False,
@@ -1319,7 +1311,7 @@ class PolyDataFilters(DataSetFilters):
         normal.SetAutoOrientNormals(auto_orient_normals)
         normal.SetNonManifoldTraversal(non_manifold_traversal)
         normal.SetFeatureAngle(feature_angle)
-        normal.SetInputData(poly_data)
+        normal.SetInputData(self)
         _update_alg(normal, progress_bar, 'Computing Normals')
 
         mesh = _get_output(normal)
@@ -1329,12 +1321,12 @@ class PolyDataFilters(DataSetFilters):
             mesh.GetCellData().SetActiveNormals('Normals')
 
         if inplace:
-            poly_data.overwrite(mesh)
-            return poly_data
+            self.overwrite(mesh)
+            return self
 
         return mesh
 
-    def clip_closed_surface(poly_data, normal='x', origin=None,
+    def clip_closed_surface(self, normal='x', origin=None,
                             tolerance=1e-06, inplace=False, progress_bar=False):
         """Clip a closed polydata surface with a plane.
 
@@ -1399,13 +1391,13 @@ class PolyDataFilters(DataSetFilters):
 
         """
         # verify it is manifold
-        if poly_data.n_open_edges > 0:
+        if self.n_open_edges > 0:
             raise ValueError("This surface appears to be non-manifold.")
         if isinstance(normal, str):
             normal = NORMALS[normal.lower()]
         # find center of data if origin not specified
         if origin is None:
-            origin = poly_data.center
+            origin = self.center
 
         # create the plane for clipping
         plane = generate_plane(normal, origin)
@@ -1414,19 +1406,19 @@ class PolyDataFilters(DataSetFilters):
 
         alg = _vtk.vtkClipClosedSurface()
         alg.SetGenerateFaces(True)
-        alg.SetInputDataObject(poly_data)
+        alg.SetInputDataObject(self)
         alg.SetTolerance(tolerance)
         alg.SetClippingPlanes(collection)
         _update_alg(alg, progress_bar, 'Clipping Closed Surface')
         result = _get_output(alg)
 
         if inplace:
-            poly_data.overwrite(result)
-            return poly_data
+            self.overwrite(result)
+            return self
         else:
             return result
 
-    def fill_holes(poly_data, hole_size, inplace=False, progress_bar=False):  # pragma: no cover
+    def fill_holes(self, hole_size, inplace=False, progress_bar=False):  # pragma: no cover
         """Fill holes in a pyvista.PolyData or vtk.vtkPolyData object.
 
         Holes are identified by locating boundary edges, linking them
@@ -1473,16 +1465,16 @@ class PolyDataFilters(DataSetFilters):
                         'Use at your own risk')
         alg = _vtk.vtkFillHolesFilter()
         alg.SetHoleSize(hole_size)
-        alg.SetInputData(poly_data)
+        alg.SetInputData(self)
         _update_alg(alg, progress_bar, 'Filling Holes')
 
         mesh = _get_output(alg)
         if inplace:
-            poly_data.overwrite(mesh)
-            return poly_data
+            self.overwrite(mesh)
+            return self
         return mesh
 
-    def clean(poly_data, point_merging=True, tolerance=None, lines_to_points=True,
+    def clean(self, point_merging=True, tolerance=None, lines_to_points=True,
               polys_to_lines=True, strips_to_polys=True, inplace=False,
               absolute=True, progress_bar=False, **kwargs):
         """Clean the mesh.
@@ -1557,7 +1549,7 @@ class PolyDataFilters(DataSetFilters):
                 alg.SetAbsoluteTolerance(tolerance)
             else:
                 alg.SetTolerance(tolerance)
-        alg.SetInputData(poly_data)
+        alg.SetInputData(self)
         _update_alg(alg, progress_bar, 'Cleaning')
         output = _get_output(alg)
 
@@ -1566,12 +1558,12 @@ class PolyDataFilters(DataSetFilters):
             raise ValueError('Clean tolerance is too high. Empty mesh returned.')
 
         if inplace:
-            poly_data.overwrite(output)
-            return poly_data
+            self.overwrite(output)
+            return self
         else:
             return output
 
-    def geodesic(poly_data, start_vertex, end_vertex, inplace=False,
+    def geodesic(self, start_vertex, end_vertex, inplace=False,
                  keep_order=True, progress_bar=False):
         """Calculate the geodesic path between two vertices using Dijkstra's algorithm.
 
@@ -1625,14 +1617,14 @@ class PolyDataFilters(DataSetFilters):
         See :ref:`geodesic_example` for more examples using this filter.
 
         """
-        if not (0 <= start_vertex < poly_data.n_points and
-                0 <= end_vertex < poly_data.n_points):
+        if not (0 <= start_vertex < self.n_points and
+                0 <= end_vertex < self.n_points):
             raise IndexError('Invalid point indices.')
-        if not poly_data.is_all_triangles:
+        if not self.is_all_triangles:
             raise NotAllTrianglesError("Input mesh for geodesic path must be all triangles.")
 
         dijkstra = _vtk.vtkDijkstraGraphGeodesicPath()
-        dijkstra.SetInputData(poly_data)
+        dijkstra.SetInputData(self)
         dijkstra.SetStartVertex(start_vertex)
         dijkstra.SetEndVertex(end_vertex)
         _update_alg(dijkstra, progress_bar, 'Calculating the Geodesic Path')
@@ -1650,12 +1642,12 @@ class PolyDataFilters(DataSetFilters):
             output["vtkOriginalPointIds"] = output["vtkOriginalPointIds"][::-1]
 
         if inplace:
-            poly_data.overwrite(output)
-            return poly_data
+            self.overwrite(output)
+            return self
 
         return output
 
-    def geodesic_distance(poly_data, start_vertex, end_vertex, progress_bar=False):
+    def geodesic_distance(self, start_vertex, end_vertex, progress_bar=False):
         """Calculate the geodesic distance between two vertices using Dijkstra's algorithm.
 
         Parameters
@@ -1685,14 +1677,14 @@ class PolyDataFilters(DataSetFilters):
         See :ref:`geodesic_example` for more examples using this filter.
 
         """
-        path = poly_data.geodesic(start_vertex, end_vertex)
+        path = self.geodesic(start_vertex, end_vertex)
         sizes = path.compute_cell_sizes(length=True, area=False, volume=False, progress_bar=progress_bar)
         distance = np.sum(sizes['Length'])
         del path
         del sizes
         return distance
 
-    def ray_trace(poly_data, origin, end_point, first_point=False, plot=False,
+    def ray_trace(self, origin, end_point, first_point=False, plot=False,
                   off_screen=None):
         """Perform a single ray trace calculation.
 
@@ -1747,9 +1739,9 @@ class PolyDataFilters(DataSetFilters):
         """
         points = _vtk.vtkPoints()
         cell_ids = _vtk.vtkIdList()
-        poly_data.obbTree.IntersectWithLine(np.array(origin),
-                                            np.array(end_point),
-                                            points, cell_ids)
+        self.obbTree.IntersectWithLine(np.array(origin),
+                                       np.array(end_point),
+                                       points, cell_ids)
 
         intersection_points = _vtk.vtk_to_numpy(points.GetData())
         if first_point and intersection_points.shape[0] >= 1:
@@ -1767,7 +1759,7 @@ class PolyDataFilters(DataSetFilters):
 
         if plot:
             plotter = pyvista.Plotter(off_screen=off_screen)
-            plotter.add_mesh(poly_data, label='Test Mesh')
+            plotter.add_mesh(self, label='Test Mesh')
             segment = np.array([origin, end_point])
             plotter.add_lines(segment, 'b', label='Ray Segment')
             plotter.add_mesh(intersection_points, 'r', point_size=10,
@@ -1778,7 +1770,7 @@ class PolyDataFilters(DataSetFilters):
 
         return intersection_points, intersection_cells
 
-    def multi_ray_trace(poly_data, origins, directions, first_point=False, retry=False):
+    def multi_ray_trace(self, origins, directions, first_point=False, retry=False):
         """Perform multiple ray trace calculations.
 
         This requires a mesh with only triangular faces, an array of
@@ -1835,7 +1827,7 @@ class PolyDataFilters(DataSetFilters):
         'Rays intersected at (0.499, 0.000, 0.000), (0.000, 0.497, 0.000), (0.000, 0.000, 0.500)'
 
         """
-        if not poly_data.is_all_triangles:
+        if not self.is_all_triangles:
             raise NotAllTrianglesError
 
         try:
@@ -1848,8 +1840,8 @@ class PolyDataFilters(DataSetFilters):
 
         origins = np.asarray(origins)
         directions = np.asarray(directions)
-        faces_as_array = poly_data.faces.reshape((poly_data.n_faces, 4))[:, 1:]
-        tmesh = trimesh.Trimesh(poly_data.points, faces_as_array)
+        faces_as_array = self.faces.reshape((self.n_faces, 4))[:, 1:]
+        tmesh = trimesh.Trimesh(self.points, faces_as_array)
         locations, index_ray, index_tri = tmesh.ray.intersects_location(
             origins, directions, multiple_hits=not first_point
         )
@@ -1866,10 +1858,10 @@ class PolyDataFilters(DataSetFilters):
             directions_retry = directions[retry_ray_indices, :]
             unit_directions = directions_retry / np.linalg.norm(directions_retry,
                                                                 axis=1, keepdims=True)
-            second_points = origins_retry + unit_directions * poly_data.length  # shape (n_retry, 3)
+            second_points = origins_retry + unit_directions * self.length  # shape (n_retry, 3)
 
             for id_r, origin, second_point in zip(retry_ray_indices, origins_retry, second_points):
-                locs, indices = poly_data.ray_trace(origin, second_point, first_point=first_point)
+                locs, indices = self.ray_trace(origin, second_point, first_point=first_point)
                 if locs.any():
                     if first_point:
                         locs = locs.reshape([1, 3])
@@ -1886,7 +1878,7 @@ class PolyDataFilters(DataSetFilters):
 
         return locations, index_ray, index_tri
 
-    def plot_boundaries(poly_data, edge_color="red", line_width=None,
+    def plot_boundaries(self, edge_color="red", line_width=None,
                         progress_bar=False, **kwargs):
         """Plot boundaries of a mesh.
 
@@ -1918,17 +1910,17 @@ class PolyDataFilters(DataSetFilters):
         >>> hills.plot_boundaries(line_width=10)
 
         """
-        edges = DataSetFilters.extract_feature_edges(poly_data, progress_bar=progress_bar)
+        edges = DataSetFilters.extract_feature_edges(self, progress_bar=progress_bar)
 
         plotter = pyvista.Plotter(off_screen=kwargs.pop('off_screen', None),
                                   notebook=kwargs.pop('notebook', None))
         plotter.add_mesh(edges, color=edge_color, style='wireframe', label='Edges',
                          line_width=line_width)
-        plotter.add_mesh(poly_data, label='Mesh', **kwargs)
+        plotter.add_mesh(self, label='Mesh', **kwargs)
         plotter.add_legend()
         return plotter.show()
 
-    def plot_normals(poly_data, show_mesh=True, mag=1.0, flip=False,
+    def plot_normals(self, show_mesh=True, mag=1.0, flip=False,
                      use_every=1, color=None, **kwargs):
         """Plot the point normals of a mesh.
 
@@ -1971,19 +1963,19 @@ class PolyDataFilters(DataSetFilters):
         plotter = pyvista.Plotter(off_screen=kwargs.pop('off_screen', None),
                                   notebook=kwargs.pop('notebook', None))
         if show_mesh:
-            plotter.add_mesh(poly_data, **kwargs)
+            plotter.add_mesh(self, **kwargs)
 
         if color is None:
             color = pyvista.global_theme.edge_color
 
-        normals = poly_data.point_normals
+        normals = self.point_normals
         if flip:
             normals *= -1
-        plotter.add_arrows(poly_data.points[::use_every], normals[::use_every],
+        plotter.add_arrows(self.points[::use_every], normals[::use_every],
                            mag=mag, color=color, show_scalar_bar=False)
         return plotter.show()
 
-    def remove_points(poly_data, remove, mode='any', keep_scalars=True, inplace=False):
+    def remove_points(self, remove, mode='any', keep_scalars=True, inplace=False):
         """Rebuild a mesh by removing points.
 
         Only valid for all-triangle meshes.
@@ -2031,17 +2023,17 @@ class PolyDataFilters(DataSetFilters):
             raise TypeError('Remove must be either a mask or an integer array-like')
 
         if remove.dtype == np.bool_:
-            if remove.size != poly_data.n_points:
+            if remove.size != self.n_points:
                 raise ValueError('Mask different size than n_points')
             remove_mask = remove
         else:
-            remove_mask = np.zeros(poly_data.n_points, np.bool_)
+            remove_mask = np.zeros(self.n_points, np.bool_)
             remove_mask[remove] = True
 
-        if not poly_data.is_all_triangles:
+        if not self.is_all_triangles:
             raise NotAllTrianglesError
 
-        f = poly_data.faces.reshape(-1, 4)[:, 1:]
+        f = self.faces.reshape(-1, 4)[:, 1:]
         vmask = remove_mask.take(f)
         if mode == 'all':
             fmask = ~(vmask).all(1)
@@ -2050,7 +2042,7 @@ class PolyDataFilters(DataSetFilters):
 
         # Regenerate face and point arrays
         uni = np.unique(f.compress(fmask, 0), return_inverse=True)
-        new_points = poly_data.points.take(uni[0], 0)
+        new_points = self.points.take(uni[0], 0)
 
         nfaces = fmask.sum()
         faces = np.empty((nfaces, 4), dtype=pyvista.ID_TYPE)
@@ -2062,23 +2054,23 @@ class PolyDataFilters(DataSetFilters):
 
         # Add scalars back to mesh if requested
         if keep_scalars:
-            for key in poly_data.point_data:
-                newmesh.point_data[key] = poly_data.point_data[key][ridx]
+            for key in self.point_data:
+                newmesh.point_data[key] = self.point_data[key][ridx]
 
-            for key in poly_data.cell_data:
+            for key in self.cell_data:
                 try:
-                    newmesh.cell_data[key] = poly_data.cell_data[key][fmask]
+                    newmesh.cell_data[key] = self.cell_data[key][fmask]
                 except:
                     logging.warning(f'Unable to pass cell key {key} onto reduced mesh')
 
         # Return vtk surface and reverse indexing array
         if inplace:
-            poly_data.overwrite(newmesh)
-            return poly_data, ridx
+            self.overwrite(newmesh)
+            return self, ridx
         else:
             return newmesh, ridx
 
-    def flip_normals(poly_data):
+    def flip_normals(self):
         """Flip normals of a triangular mesh by reversing the point ordering.
 
         Examples
@@ -2093,23 +2085,23 @@ class PolyDataFilters(DataSetFilters):
         >>> sphere.plot_normals(mag=0.1, opacity=0.5)
 
         """
-        if not poly_data.is_all_triangles:
+        if not self.is_all_triangles:
             raise NotAllTrianglesError('Can only flip normals on an all triangle mesh.')
 
         if _vtk.VTK9:
             # use new connectivity API
-            f = poly_data._connectivity_array
+            f = self._connectivity_array
 
             # swap first and last point index in-place
             # See: https://stackoverflow.com/a/33362288/3369879
             f[::3], f[2::3] = f[2::3], f[::3].copy()
 
         else:  # pragma: no cover
-            f = poly_data.faces
+            f = self.faces
             f[1::4], f[3::4] = f[3::4], f[1::4].copy()
-            poly_data.faces[:] = f
+            self.faces[:] = f
 
-    def delaunay_2d(poly_data, tol=1e-05, alpha=0.0, offset=1.0, bound=False,
+    def delaunay_2d(self, tol=1e-05, alpha=0.0, offset=1.0, bound=False,
                     inplace=False, edge_source=None, progress_bar=False):
         """Apply a 2D Delaunay filter along the best fitting plane.
 
@@ -2174,7 +2166,7 @@ class PolyDataFilters(DataSetFilters):
         """
         alg = _vtk.vtkDelaunay2D()
         alg.SetProjectionPlaneMode(_vtk.VTK_BEST_FITTING_PLANE)
-        alg.SetInputDataObject(poly_data)
+        alg.SetInputDataObject(self)
         alg.SetTolerance(tol)
         alg.SetAlpha(alpha)
         alg.SetOffset(offset)
@@ -2187,11 +2179,11 @@ class PolyDataFilters(DataSetFilters):
         # `.triangulate()` filter cleans those
         mesh = _get_output(alg).triangulate()
         if inplace:
-            poly_data.overwrite(mesh)
-            return poly_data
+            self.overwrite(mesh)
+            return self
         return mesh
 
-    def compute_arc_length(poly_data, progress_bar=False):
+    def compute_arc_length(self, progress_bar=False):
         """Compute the arc length over the length of the probed line.
 
         It adds a new point-data array named ``"arc_length"`` with the
@@ -2231,11 +2223,11 @@ class PolyDataFilters(DataSetFilters):
 
         """
         alg = _vtk.vtkAppendArcLength()
-        alg.SetInputData(poly_data)
+        alg.SetInputData(self)
         _update_alg(alg, progress_bar, 'Computing the Arc Length')
         return _get_output(alg)
 
-    def project_points_to_plane(poly_data, origin=None, normal=(0, 0, 1),
+    def project_points_to_plane(self, origin=None, normal=(0, 0, 1),
                                 inplace=False):
         """Project points of this mesh to a plane.
 
@@ -2266,12 +2258,12 @@ class PolyDataFilters(DataSetFilters):
         if not isinstance(normal, (np.ndarray, collections.abc.Sequence)) or len(normal) != 3:
             raise TypeError('Normal must be a length three vector')
         if origin is None:
-            origin = np.array(poly_data.center) - np.array(normal)*poly_data.length/2.
+            origin = np.array(self.center) - np.array(normal)*self.length/2.
         # choose what mesh to use
         if not inplace:
-            mesh = poly_data.copy()
+            mesh = self.copy()
         else:
-            mesh = poly_data
+            mesh = self
         # Make plane
         plane = generate_plane(normal, origin)
         # Perform projection in place on the copied mesh
@@ -2279,7 +2271,7 @@ class PolyDataFilters(DataSetFilters):
         np.apply_along_axis(f, 1, mesh.points)
         return mesh
 
-    def ribbon(poly_data, width=None, scalars=None, angle=0.0, factor=2.0,
+    def ribbon(self, width=None, scalars=None, angle=0.0, factor=2.0,
                normal=None, tcoords=False, preference='points', progress_bar=False):
         """Create a ribbon of the lines in this dataset.
 
@@ -2338,11 +2330,11 @@ class PolyDataFilters(DataSetFilters):
 
         """
         if scalars is not None:
-            field = get_array_association(poly_data, scalars, preference=preference)
+            field = get_array_association(self, scalars, preference=preference)
         if width is None:
-            width = poly_data.length * 0.1
+            width = self.length * 0.1
         alg = _vtk.vtkRibbonFilter()
-        alg.SetInputDataObject(poly_data)
+        alg.SetInputDataObject(self)
         alg.SetWidth(width)
         if normal is not None:
             alg.SetUseDefaultNormal(True)
@@ -2368,7 +2360,7 @@ class PolyDataFilters(DataSetFilters):
         _update_alg(alg, progress_bar, 'Creating a Ribbon')
         return _get_output(alg)
 
-    def extrude(poly_data, vector, capping=False, inplace=False, progress_bar=False):
+    def extrude(self, vector, capping=False, inplace=False, progress_bar=False):
         """Sweep polygonal data creating a "skirt" from free edges.
 
         This will create a line from vertices.
@@ -2388,9 +2380,6 @@ class PolyDataFilters(DataSetFilters):
 
         Parameters
         ----------
-        poly_data : pyvista.PolyData
-            Mesh to extrude.
-
         vector : numpy.ndarray or sequence
             Direction and length to extrude the mesh in.
 
@@ -2427,16 +2416,16 @@ class PolyDataFilters(DataSetFilters):
         alg = _vtk.vtkLinearExtrusionFilter()
         alg.SetExtrusionTypeToVectorExtrusion()
         alg.SetVector(*vector)
-        alg.SetInputData(poly_data)
+        alg.SetInputData(self)
         alg.SetCapping(capping)
         _update_alg(alg, progress_bar, 'Extruding')
         output = pyvista.wrap(alg.GetOutput())
         if inplace:
-            poly_data.overwrite(output)
-            return poly_data
+            self.overwrite(output)
+            return self
         return output
 
-    def extrude_rotate(poly_data, resolution=30, inplace=False,
+    def extrude_rotate(self, resolution=30, inplace=False,
                        translation=0.0, dradius=0.0, angle=360.0,
                        capping=False, progress_bar=False):
         """Sweep polygonal data creating "skirt" from free edges and lines, and lines from vertices.
@@ -2525,7 +2514,7 @@ class PolyDataFilters(DataSetFilters):
         if resolution <= 0:
             raise ValueError('`resolution` should be positive')
         alg = _vtk.vtkRotationalExtrusionFilter()
-        alg.SetInputData(poly_data)
+        alg.SetInputData(self)
         alg.SetResolution(resolution)
         alg.SetTranslation(translation)
         alg.SetDeltaRadius(dradius)
@@ -2534,11 +2523,11 @@ class PolyDataFilters(DataSetFilters):
         _update_alg(alg, progress_bar, 'Extruding')
         output = pyvista.wrap(alg.GetOutput())
         if inplace:
-            poly_data.overwrite(output)
-            return poly_data
+            self.overwrite(output)
+            return self
         return output
 
-    def strip(poly_data, join=False, max_length=1000, pass_cell_data=False,
+    def strip(self, join=False, max_length=1000, pass_cell_data=False,
               pass_cell_ids=False, pass_point_ids=False, progress_bar=False):
         """Strip poly data cells.
 
@@ -2607,7 +2596,7 @@ class PolyDataFilters(DataSetFilters):
 
         """
         alg = _vtk.vtkStripper()
-        alg.SetInputDataObject(poly_data)
+        alg.SetInputDataObject(self)
         alg.SetJoinContiguousSegments(join)
         alg.SetMaximumLength(max_length)
         alg.SetPassCellDataAsFieldData(pass_cell_data)
@@ -2616,7 +2605,7 @@ class PolyDataFilters(DataSetFilters):
         _update_alg(alg, progress_bar, 'Stripping Mesh')
         return _get_output(alg)
 
-    def collision(poly_data, other_mesh, contact_mode=0, box_tolerance=0.001,
+    def collision(self, other_mesh, contact_mode=0, box_tolerance=0.001,
                   cell_tolerance=0.0, n_cells_per_node=2, generate_scalars=False,
                   progress_bar=False):
         """Perform collision determination between two polyhedral surfaces.
@@ -2736,6 +2725,7 @@ class PolyDataFilters(DataSetFilters):
             other_mesh = other_mesh.extract_surface()
 
         # according to VTK limitations
+        poly_data = self
         if not poly_data.is_all_triangles:
             poly_data = poly_data.triangulate()
         if not other_mesh.is_all_triangles:

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -152,7 +152,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             The result of the boolean operation.
 
         Examples
@@ -221,7 +221,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             The result of the boolean operation.
 
         Examples
@@ -284,7 +284,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             The result of the boolean operation.
 
         Examples
@@ -344,7 +344,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData` or :class:`pyvista.UnstructuredGrid`
+        pyvista.DataSet
             :class:`pyvista.PolyData` if ``dataset`` is a
             :class:`pyvista.PolyData`, otherwise a
             :class:`pyvista.UnstructuredGrid`.
@@ -419,14 +419,14 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             The intersection line.
 
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             The first mesh split along the intersection. Returns the
             original first mesh if ``split_first=False``.
 
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             The second mesh split along the intersection. Returns the
             original second mesh if ``split_second=False``.
 
@@ -544,7 +544,7 @@ class PolyDataFilters(DataSetFilters):
             * ``'Maximum'``
             * ``'Minimum'``
 
-        **kwargs : optional
+        **kwargs : dict, optional
             See :func:`pyvista.plot`.
 
         Returns
@@ -588,7 +588,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             Mesh containing only triangles.
 
         Examples
@@ -661,7 +661,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             Smoothed mesh.
 
         Examples
@@ -755,7 +755,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             Decimated mesh.
 
         Examples
@@ -830,7 +830,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             Tube-filtered mesh.
 
         Examples
@@ -907,7 +907,7 @@ class PolyDataFilters(DataSetFilters):
             ``nface*4**nsub`` where ``nface`` is the current number of
             faces.
 
-        subfilter : string, optional
+        subfilter : str, optional
             Can be one of the following:
 
             * ``'butterfly'``
@@ -922,7 +922,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             Subdivided mesh.
 
         Examples
@@ -1030,8 +1030,8 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
-            Subdivided mesh
+        pyvista.PolyData
+            Subdivided mesh.
 
         Examples
         --------
@@ -1075,14 +1075,9 @@ class PolyDataFilters(DataSetFilters):
                  tensors_weight=0.1, inplace=False, progress_bar=False):
         """Reduce the number of triangles in a triangular mesh using ``vtkQuadricDecimation``.
 
-        .. note::
-           If you encounter a segmentation fault or other error,
-           consider using :func:`pyvista.clean` to remove any invalid
-           cells before using this filter.
-
         Parameters
         ----------
-        mesh : vtk.PolyData
+        poly_data : vtk.PolyData
             Mesh to decimate.
 
         target_reduction : float
@@ -1147,8 +1142,14 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             Decimated mesh.
+
+        Notes
+        -----
+        If you encounter a segmentation fault or other error,
+        consider using :func:`pyvista.clean` to remove any invalid
+        cells before using this filter.
 
         Examples
         --------
@@ -1266,7 +1267,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             Updated mesh with cell and point normals.
 
         Notes
@@ -1376,7 +1377,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             The clipped mesh.
 
         Examples
@@ -1453,7 +1454,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             Mesh with holes filled if ``inplace=False``.
 
         Examples
@@ -1524,7 +1525,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             Cleaned mesh.
 
         Examples
@@ -1603,7 +1604,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             ``PolyData`` object consisting of the line segment between the
             two given vertices. If ``inplace`` is ``True`` this is the
             same object as the input mesh.
@@ -1789,33 +1790,34 @@ class PolyDataFilters(DataSetFilters):
         implementation would return an intersection.  If the result
         appears to be missing some intersection points, set
         ``retry=True`` to run a second pass over rays that returned no
-        intersections, using the VTK ``ray_trace`` implementation.
+        intersections, using :func:`PolyDataFilters.ray_trace`.
 
         Parameters
         ----------
-        origins : np.ndarray or list
+        origins : sequence
             Starting point for each trace.
 
-        directions : np.ndarray or list
+        directions : sequence
             Direction vector for each trace.
 
         first_point : bool, optional
             Returns intersection of first point only.
 
         retry : bool, optional
-            Will retry rays that return no intersections using the ray_trace
+            Will retry rays that return no intersections using
+            :func:`PolyDataFilters.ray_trace`.
 
         Returns
         -------
-        intersection_points : :class:`np.ndarray`
+        intersection_points : numpy.ndarray
             Location of the intersection points.  Empty array if no
             intersections.
 
-        intersection_rays : :class:`np.ndarray`
+        intersection_rays : numpy.ndarray
             Indices of the ray for each intersection point. Empty array if no
             intersections.
 
-        intersection_cells : :class:`np.ndarray`
+        intersection_cells : numpy.ndarray
             Indices of the intersection cells.  Empty array if no
             intersections.
 
@@ -1884,7 +1886,8 @@ class PolyDataFilters(DataSetFilters):
 
         return locations, index_ray, index_tri
 
-    def plot_boundaries(poly_data, edge_color="red", line_width=None, progress_bar=False, **kwargs):
+    def plot_boundaries(poly_data, edge_color="red", line_width=None,
+                        progress_bar=False, **kwargs):
         """Plot boundaries of a mesh.
 
         Parameters
@@ -1895,16 +1898,16 @@ class PolyDataFilters(DataSetFilters):
         line_width : int, optional
             Width of the boundary lines.
 
-        kwargs : optional
-            All additional keyword arguments will be passed to
-            :func:`pyvista.BasePlotter.add_mesh`
-
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        **kwargs : dict, optional
+            All additional keyword arguments will be passed to
+            :func:`pyvista.BasePlotter.add_mesh`.
+
         Returns
         -------
-        :class:`pyvista.CameraPosition`
+        pyvista.CameraPosition
             List of camera position, focal point, and view up.
             Returned when ``return_cpos`` is ``True``.
 
@@ -2005,10 +2008,10 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             Mesh without the points flagged for removal.
 
-        :class:`np.ndarray`
+        numpy.ndarray
             Indices of new points relative to the original mesh.
 
         Examples
@@ -2301,7 +2304,7 @@ class PolyDataFilters(DataSetFilters):
 
         factor : float, optional
             Set the maximum ribbon width in terms of a multiple of the
-            minimum width. The default is 2.0
+            minimum width. The default is 2.0.
 
         normal : tuple(float), optional
             Normal to use as default.
@@ -2385,10 +2388,10 @@ class PolyDataFilters(DataSetFilters):
 
         Parameters
         ----------
-        mesh : pyvista.PolyData
+        poly_data : pyvista.PolyData
             Mesh to extrude.
 
-        vector : np.ndarray or list
+        vector : numpy.ndarray or sequence
             Direction and length to extrude the mesh in.
 
         capping : bool, optional
@@ -2402,7 +2405,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             Extruded mesh.
 
         Examples
@@ -2488,7 +2491,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             Rotationally extruded mesh.
 
         Examples
@@ -2589,7 +2592,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             Stripped mesh.
 
         Examples
@@ -2667,7 +2670,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.PolyData`
+        pyvista.PolyData
             Mesh containing collisions in the ``field_data``
             attribute named ``"ContactCells"``.  Array only exists
             when there are collisions.

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -31,7 +31,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`numpy.ndarray`
+        numpy.ndarray
             Mask of points with an angle greater than ``angle``.
 
         Examples
@@ -489,7 +489,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`numpy.ndarray`
+        numpy.ndarray
             Array of curvature values.
 
         Examples
@@ -1519,7 +1519,6 @@ class PolyDataFilters(DataSetFilters):
             Accepts for ``merge_tol`` to replace the ``tolerance``
             keyword argument.  This may be deprecated in future.
 
-
         Returns
         -------
         pyvista.PolyData
@@ -1565,8 +1564,7 @@ class PolyDataFilters(DataSetFilters):
         if inplace:
             self.overwrite(output)
             return self
-        else:
-            return output
+        return output
 
     def geodesic(self, start_vertex, end_vertex, inplace=False,
                  keep_order=True, progress_bar=False):
@@ -1668,7 +1666,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`float`
+        float
             Length of the geodesic segment.
 
         Examples
@@ -1715,11 +1713,11 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        intersection_points : :class:`np.ndarray`
+        intersection_points : numpy.ndarray
             Location of the intersection points.  Empty array if no
             intersections.
 
-        intersection_cells : :class:`np.ndarray`
+        intersection_cells : numpy.ndarray
             Indices of the intersection cells.  Empty array if no
             intersections.
 
@@ -2076,8 +2074,7 @@ class PolyDataFilters(DataSetFilters):
         if inplace:
             self.overwrite(newmesh)
             return self, ridx
-        else:
-            return newmesh, ridx
+        return newmesh, ridx
 
     def flip_normals(self):
         """Flip normals of a triangular mesh by reversing the point ordering.
@@ -2156,6 +2153,11 @@ class PolyDataFilters(DataSetFilters):
             Display a progress bar to indicate progress. Default
             ``False``.
 
+        Returns
+        -------
+        pyvista.PolyData
+            Mesh from the 2D delaunay filter.
+
         Examples
         --------
         First, generate 30 points on circle and plot them.
@@ -2207,7 +2209,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`float`
+        float
             Arc length of the length of the probed line.
 
         Examples
@@ -2242,17 +2244,22 @@ class PolyDataFilters(DataSetFilters):
 
         Parameters
         ----------
-        origin : np.ndarray or collections.abc.Sequence, optional
+        origin : numpy.ndarray or collections.abc.Sequence, optional
             Plane origin.  Defaults to the approximate center of the
             input mesh minus half the length of the input mesh in the
             direction of the normal.
 
-        normal : np.ndarray or collections.abc.Sequence, optional
+        normal : numpy.ndarray or collections.abc.Sequence, optional
             Plane normal.  Defaults to +Z, i.e. ``[0, 0, 1]``.
 
         inplace : bool, optional
             Whether to overwrite the original mesh with the projected
             points.
+
+        Returns
+        -------
+        pyvista.PolyData
+            The points of this mesh projected onto a plane.
 
         Examples
         --------

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -1269,6 +1269,21 @@ class PolyDataFilters(DataSetFilters):
         :class:`pyvista.PolyData`
             Updated mesh with cell and point normals.
 
+        Notes
+        -----
+        Previous arrays named ``"Normals"`` will be overwritten.
+
+        Normals are computed only for polygons and triangle
+        strips. Normals are not computed for lines or vertices.
+
+        Triangle strips are broken up into triangle polygons. You may
+        want to restrip the triangles.
+
+        It may be easier to run
+        :func:`pyvista.PolyData.point_normals` or
+        :func:`pyvista.PolyData.cell_normals` if you would just
+        like the array of point or cell normals.
+
         Examples
         --------
         Compute the point normals of the surface of a sphere.
@@ -1292,21 +1307,6 @@ class PolyDataFilters(DataSetFilters):
         (1680, 3)
 
         See :ref:`surface_normal_example` for more examples using this filter.
-
-        Notes
-        -----
-        Previous arrays named ``"Normals"`` will be overwritten.
-
-        Normals are computed only for polygons and triangle
-        strips. Normals are not computed for lines or vertices.
-
-        Triangle strips are broken up into triangle polygons. You may
-        want to restrip the triangles.
-
-        It may be easier to run
-        :func:`pyvista.PolyData.point_normals` or
-        :func:`pyvista.PolyData.cell_normals` if you would just
-        like the array of point or cell normals.
 
         """
         normal = _vtk.vtkPolyDataNormals()
@@ -2622,6 +2622,12 @@ class PolyDataFilters(DataSetFilters):
         be lines of contact. If ``collision_mode`` is first contact or half
         contacts then the Contacts output will be vertices.
 
+        .. warning::
+            Currently only triangles are processed. Use
+            :func:`PolyDataFilters.triangulate` to convert any strips
+            or polygons to triangles.  Otherwise, the mesh will be
+            converted for you within this method.
+
         Parameters
         ----------
         other_mesh : pyvista.DataSet
@@ -2720,13 +2726,6 @@ class PolyDataFilters(DataSetFilters):
         >>> collision.plot()
 
         See :ref:`collision_example` for more examples using this filter.
-
-        Warnings
-        --------
-        Currently only triangles are processed. Use
-        :func:`PolyDataFilters.triangulate` to convert any strips or
-        polygons to triangles.  Otherwise, the mesh will be converted
-        for you within this method.
 
         """
         # other mesh must be a polydata

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -547,7 +547,7 @@ class PolyDataFilters(DataSetFilters):
 
         Returns
         -------
-        :class:`pyvista.CameraPosition`
+        pyvista.CameraPosition
             List of camera position, focal point, and view up.
             Returned when ``return_cpos`` is ``True``.
 

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -343,7 +343,7 @@ class PolyDataFilters(DataSetFilters):
             Display a progress bar to indicate progress.
 
         Returns
-        --------
+        -------
         :class:`pyvista.PolyData` or :class:`pyvista.UnstructuredGrid`
             :class:`pyvista.PolyData` if ``dataset`` is a
             :class:`pyvista.PolyData`, otherwise a
@@ -1825,11 +1825,11 @@ class PolyDataFilters(DataSetFilters):
         directions ``[1, 0, 0]``, ``[0, 1, 0]`` and ``[0, 0, 1]``, and
         a sphere with radius 0.5 centered at the origin
 
-        >>> import pyvista as pv # doctest: +SKIP
-        >>> sphere = pv.Sphere() # doctest: +SKIP
-        >>> points, rays, cells = sphere.multi_ray_trace([[0, 0, 0]]*3, [[1, 0, 0], [0, 1, 0], [0, 0, 1]], first_point=True) # doctest: +SKIP
-        >>> string = ", ".join([f"({point[0]:.3f}, {point[1]:.3f}, {point[2]:.3f})" for point in points]) # doctest: +SKIP
-        >>> f'Rays intersected at {string}' # doctest: +SKIP
+        >>> import pyvista as pv  # doctest:+SKIP
+        >>> sphere = pv.Sphere()  # doctest:+SKIP
+        >>> points, rays, cells = sphere.multi_ray_trace([[0, 0, 0]]*3, [[1, 0, 0], [0, 1, 0], [0, 0, 1]], first_point=True)  # doctest:+SKIP
+        >>> string = ", ".join([f"({point[0]:.3f}, {point[1]:.3f}, {point[2]:.3f})" for point in points]) # doctest:+SKIP
+        >>> f'Rays intersected at {string}' # doctest:+SKIP
         'Rays intersected at (0.499, 0.000, 0.000), (0.000, 0.497, 0.000), (0.000, 0.000, 0.500)'
 
         """

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -1517,7 +1517,8 @@ class PolyDataFilters(DataSetFilters):
 
         **kwargs : dict, optional
             Accepts for ``merge_tol`` to replace the ``tolerance``
-            keyword argument.  This may be depricated in future.
+            keyword argument.  This may be deprecated in future.
+
 
         Returns
         -------

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -1515,6 +1515,10 @@ class PolyDataFilters(DataSetFilters):
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        **kwargs : dict, optional
+            Accepts for ``merge_tol`` to replace the ``tolerance``
+            keyword argument.  This may be depricated in future.
+
         Returns
         -------
         pyvista.PolyData
@@ -1945,9 +1949,13 @@ class PolyDataFilters(DataSetFilters):
             Color of the arrows.  Defaults to
             :attr:`pyvista.themes.DefaultTheme.edge_color`.
 
+        **kwargs : dict, optional
+            All additional keyword arguments will be passed to
+            :func:`pyvista.BasePlotter.add_mesh`.
+
         Returns
         -------
-        :class:`pyvista.CameraPosition`
+        pyvista.CameraPosition
             List of camera position, focal point, and view up.
             Returned when ``return_cpos`` is ``True``.
 
@@ -2305,6 +2313,10 @@ class PolyDataFilters(DataSetFilters):
             If ``True``, generate texture coordinates along the
             ribbon. This can also be specified to generate the texture
             coordinates with either ``'length'`` or ``'normalized'``.
+
+        preference : str, optional
+            The field preference when searching for the scalars array by
+            name.
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2329,6 +2329,11 @@ class PolyDataFilters(DataSetFilters):
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        Returns
+        -------
+        pyvista.PolyData
+            Ribbon mesh.  Empty if there are no lines in the input dataset.
+
         Examples
         --------
         Convert a line to a ribbon and plot it.

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -11,7 +11,7 @@ from pyvista.core.filters.data_set import DataSetFilters
 class UniformGridFilters(DataSetFilters):
     """An internal class to manage filters/algorithms for uniform grid datasets."""
 
-    def gaussian_smooth(dataset, radius_factor=1.5, std_dev=2.,
+    def gaussian_smooth(self, radius_factor=1.5, std_dev=2.,
                         scalars=None, preference='points', progress_bar=False):
         """Smooth the data with a Gaussian kernel.
 
@@ -36,11 +36,11 @@ class UniformGridFilters(DataSetFilters):
 
         """
         alg = _vtk.vtkImageGaussianSmooth()
-        alg.SetInputDataObject(dataset)
+        alg.SetInputDataObject(self)
         if scalars is None:
-            field, scalars = dataset.active_scalars_info
+            field, scalars = self.active_scalars_info
         else:
-            field = dataset.get_array_association(scalars, preference=preference)
+            field = self.get_array_association(scalars, preference=preference)
         alg.SetInputArrayToProcess(0, 0, 0, field.value, scalars) # args: (idx, port, connection, field, name)
         if isinstance(radius_factor, collections.abc.Iterable):
             alg.SetRadiusFactors(radius_factor)
@@ -53,7 +53,7 @@ class UniformGridFilters(DataSetFilters):
         _update_alg(alg, progress_bar, 'Performing Gaussian Smoothing')
         return _get_output(alg)
 
-    def extract_subset(dataset, voi, rate=(1, 1, 1), boundary=False, progress_bar=False):
+    def extract_subset(self, voi, rate=(1, 1, 1), boundary=False, progress_bar=False):
         """Select piece (e.g., volume of interest).
 
         To use this filter set the VOI ivar which are i-j-k min/max indices
@@ -91,7 +91,7 @@ class UniformGridFilters(DataSetFilters):
         """
         alg = _vtk.vtkExtractVOI()
         alg.SetVOI(voi)
-        alg.SetInputDataObject(dataset)
+        alg.SetInputDataObject(self)
         alg.SetSampleRate(rate)
         alg.SetIncludeBoundary(boundary)
         _update_alg(alg, progress_bar, 'Extracting Subset')

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -34,6 +34,11 @@ class UniformGridFilters(DataSetFilters):
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        Returns
+        -------
+        pyvista.UniformGrid
+            Uniform grid with smoothed scalars.
+
         """
         alg = _vtk.vtkImageGaussianSmooth()
         alg.SetInputDataObject(self)
@@ -88,6 +93,10 @@ class UniformGridFilters(DataSetFilters):
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        Returns
+        -------
+        pyvista.UniformGrid
+            UniformGrid subset.
         """
         alg = _vtk.vtkExtractVOI()
         alg.SetVOI(voi)

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -27,8 +27,9 @@ class UniformGridFilters(DataSetFilters):
             Name of scalars to process. Defaults to currently active scalars.
 
         preference : str, optional
-            When scalars is specified, this is the preferred array type to
-            search for in the dataset.  Must be either ``'point'`` or ``'cell'``
+            When scalars is specified, this is the preferred array
+            type to search for in the dataset.  Must be either
+            ``'point'`` or ``'cell'``.
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
@@ -71,17 +72,18 @@ class UniformGridFilters(DataSetFilters):
             These bounds specify the volume of interest in i-j-k min/max
             indices.
 
-        rate : tuple(int)
+        rate : tuple(int), optional
             Length 3 iterable of ints: ``(xrate, yrate, zrate)``.
-            Default: ``(1, 1, 1)``
+            Default: ``(1, 1, 1)``.
 
-        boundary : bool
-            Control whether to enforce that the "boundary" of the grid is
-            output in the subsampling process. (This only has effect
-            when the rate in any direction is not equal to 1). When
-            this is on, the subsampling will always include the boundary of
-            the grid even though the sample rate is not an even multiple of
-            the grid dimensions. (By default this is off.)
+        boundary : bool, optional
+            Control whether to enforce that the "boundary" of the grid
+            is output in the subsampling process. This only has effect
+            when the rate in any direction is not equal to 1. When
+            this is enabled, the subsampling will always include the
+            boundary of the grid even though the sample rate is not an
+            even multiple of the grid dimensions. By default this is
+            disabled.
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.

--- a/pyvista/core/filters/unstructured_grid.py
+++ b/pyvista/core/filters/unstructured_grid.py
@@ -45,7 +45,7 @@ class UnstructuredGridFilters(DataSetFilters):
             Display a progress bar to indicate progress.
 
         """
-        return pyvista.PolyData(ugrid.points).delaunay_2d(tol=tol, alpha=alpha,
-                                                          offset=offset,
-                                                          bound=bound,
-                                                          progress_bar=progress_bar)
+        return pyvista.PolyData(self.points).delaunay_2d(tol=tol, alpha=alpha,
+                                                         offset=offset,
+                                                         bound=bound,
+                                                         progress_bar=progress_bar)

--- a/pyvista/core/filters/unstructured_grid.py
+++ b/pyvista/core/filters/unstructured_grid.py
@@ -8,7 +8,7 @@ from pyvista.core.filters.data_set import DataSetFilters
 class UnstructuredGridFilters(DataSetFilters):
     """An internal class to manage filters/algorithms for unstructured grid datasets."""
 
-    def delaunay_2d(ugrid, tol=1e-05, alpha=0.0, offset=1.0, bound=False,
+    def delaunay_2d(self, tol=1e-05, alpha=0.0, offset=1.0, bound=False,
                     progress_bar=False):
         """Apply a delaunay 2D filter along the best fitting plane.
 
@@ -17,6 +17,30 @@ class UnstructuredGridFilters(DataSetFilters):
 
         Parameters
         ----------
+        tol : float, optional
+            Specify a tolerance to control discarding of closely
+            spaced points. This tolerance is specified as a fraction
+            of the diagonal length of the bounding box of the points.
+            Defaults to ``1e-05``.
+
+        alpha : float, optional
+            Specify alpha (or distance) value to control output of
+            this filter. For a non-zero alpha value, only edges or
+            triangles contained within a sphere centered at mesh
+            vertices will be output. Otherwise, only triangles will be
+            output. Defaults to ``0.0``.
+
+        offset : float, optional
+            Specify a multiplier to control the size of the initial,
+            bounding Delaunay triangulation. Defaults to ``1.0``.
+
+        bound : bool, optional
+            Boolean controls whether bounding triangulation points
+            and associated triangles are included in the
+            output. These are introduced as an initial triangulation
+            to begin the triangulation process. This feature is nice
+            for debugging output. Default ``False``.
+
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 

--- a/pyvista/core/filters/unstructured_grid.py
+++ b/pyvista/core/filters/unstructured_grid.py
@@ -44,6 +44,11 @@ class UnstructuredGridFilters(DataSetFilters):
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        Returns
+        -------
+        pyvista.PolyData
+            Surface mesh containing the delaunay filter.
+
         """
         return pyvista.PolyData(self.points).delaunay_2d(tol=tol, alpha=alpha,
                                                          offset=offset,

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -227,10 +227,18 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
     @Grid.dimensions.setter  # type: ignore
     def dimensions(self, dims):
         """Do not let the dimensions of the RectilinearGrid be set."""
-        raise AttributeError("The dimensions of a `RectilinearGrid` are implicitly defined and thus cannot be set.")
+        raise AttributeError("The dimensions of a `RectilinearGrid` are implicitly "
+                             "defined and thus cannot be set.")
 
     def cast_to_structured_grid(self):
-        """Cast this rectilinear grid to a :class:`pyvista.StructuredGrid`."""
+        """Cast this rectilinear grid to a structured grid.
+
+        Returns
+        -------
+        pyvista.StructuredGrid
+            This grid as a structured grid.
+
+        """
         alg = _vtk.vtkRectilinearGridToPointSet()
         alg.SetInputData(self)
         alg.Update()
@@ -421,14 +429,28 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         return attrs
 
     def cast_to_structured_grid(self):
-        """Cast this uniform grid to a :class:`pyvista.StructuredGrid`."""
+        """Cast this uniform grid to a structured grid.
+
+        Returns
+        -------
+        pyvista.StructuredGrid
+            This grid as a structured grid.
+
+        """
         alg = _vtk.vtkImageToStructuredGrid()
         alg.SetInputData(self)
         alg.Update()
         return _get_output(alg)
 
     def cast_to_rectilinear_grid(self):
-        """Cast this uniform grid to a :class:`pyvista.RectilinearGrid`."""
+        """Cast this uniform grid to a rectilinear grid.
+
+        Returns
+        -------
+        pyvista.RectilinearGrid
+            This uniform grid as a rectilinear grid.
+
+        """
         def gen_coords(i):
             coords = np.cumsum(np.insert(np.full(self.dimensions[i] - 1,
                                                  self.spacing[i]), 0, 0)

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -126,11 +126,25 @@ class Table(_vtk.vtkTable, DataObject):
         return self.row_arrays.values()
 
     def update(self, data):
-        """Set the table data."""
+        """Set the table data using a dict-like update.
+
+        Parameters
+        ----------
+        data : DataSetAttributes
+            Other dataset attributes to update from.
+
+        """
         self.row_arrays.update(data)
 
     def pop(self, name):
-        """Pop off an array by the specified name."""
+        """Pop off an array by the specified name.
+
+        Parameters
+        ----------
+        name : int or str
+            Index or name of the row array.
+
+        """
         return self.row_arrays.pop(name)
 
     def _add_row_array(self, scalars, name, deep=True):
@@ -159,7 +173,13 @@ class Table(_vtk.vtkTable, DataObject):
         return self.keys()
 
     def get(self, index):
-        """Get an array by its name."""
+        """Get an array by its name.
+
+        Parameters
+        ----------
+        index : int or str
+            Index or name of the row.
+        """
         return self[index]
 
     def __setitem__(self, name, scalars):

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -19,8 +19,8 @@ class Table(_vtk.vtkTable, DataObject):
     Create by passing a 2D NumPy array of shape (``n_rows`` by ``n_columns``)
     or from a dictionary containing NumPy arrays.
 
-    Example
-    -------
+    Examples
+    --------
     >>> import pyvista as pv
     >>> import numpy as np
     >>> arrays = np.random.rand(100, 3)

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -130,7 +130,7 @@ class Table(_vtk.vtkTable, DataObject):
         self.row_arrays.update(data)
 
     def pop(self, name):
-        """Pops off an array by the specified name."""
+        """Pop off an array by the specified name."""
         return self.row_arrays.pop(name)
 
     def _add_row_array(self, scalars, name, deep=True):
@@ -258,9 +258,9 @@ class Table(_vtk.vtkTable, DataObject):
 
         Parameters
         ----------
-        arr : str, np.ndarray, optional
-            The name of the array to get the range. If None, the active scalar
-            is used
+        arr : str, numpy.ndarray, optional
+            The name of the array to get the range. If ``None``, the active scalar
+            is used.
 
         preference : str, optional
             When scalars is specified, this is the preferred array type

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -53,7 +53,6 @@ class Table(_vtk.vtkTable, DataObject):
         np_table = arrays.T
         for i, array in enumerate(np_table):
             self.row_arrays[f'Array {i}'] = array
-        return
 
     def _from_dict(self, array_dict):
         for array in array_dict.values():
@@ -61,7 +60,6 @@ class Table(_vtk.vtkTable, DataObject):
                 raise ValueError('Dictionary must contain only NumPy arrays with maximum of 2D.')
         for name, array in array_dict.items():
             self.row_arrays[name] = array
-        return
 
     def _from_pandas(self, data_frame):
         for name in data_frame.keys():
@@ -101,8 +99,8 @@ class Table(_vtk.vtkTable, DataObject):
 
         Returns
         -------
-        :class:`numpy.ndarray`
-            Numpy array of scalars
+        numpy.ndarray
+            Numpy array of the row.
 
         """
         return self.row_arrays.get_array(name)
@@ -114,15 +112,36 @@ class Table(_vtk.vtkTable, DataObject):
                                  association=FieldAssociation.ROW)
 
     def keys(self):
-        """Return the table keys."""
+        """Return the table keys.
+
+        Returns
+        -------
+        list
+            List of the array names of this table.
+
+        """
         return self.row_arrays.keys()
 
     def items(self):
-        """Return the table items."""
+        """Return the table items.
+
+        Returns
+        -------
+        list
+            List containing tuples pairs of the name and array of the table arrays.
+
+        """
         return self.row_arrays.items()
 
     def values(self):
-        """Return the table values."""
+        """Return the table values.
+
+        Returns
+        -------
+        list
+            List of the table arrays.
+
+        """
         return self.row_arrays.values()
 
     def update(self, data):
@@ -143,6 +162,11 @@ class Table(_vtk.vtkTable, DataObject):
         ----------
         name : int or str
             Index or name of the row array.
+
+        Returns
+        -------
+        pyvista.pyvista_ndarray
+            PyVista array.
 
         """
         return self.row_arrays.pop(name)
@@ -179,6 +203,11 @@ class Table(_vtk.vtkTable, DataObject):
         ----------
         index : int or str
             Index or name of the row.
+
+        Returns
+        -------
+        pyvista.pyvista_ndarray
+            PyVista array.
         """
         return self[index]
 
@@ -258,7 +287,14 @@ class Table(_vtk.vtkTable, DataObject):
         return self.head(display=False, html=False)
 
     def to_pandas(self):
-        """Create a Pandas DataFrame from this Table."""
+        """Create a Pandas DataFrame from this Table.
+
+        Returns
+        -------
+        pandas.DataFrame
+            This table represented as a pandas dataframe.
+
+        """
         try:
             import pandas as pd
         except ImportError:  # pragma: no cover
@@ -286,6 +322,11 @@ class Table(_vtk.vtkTable, DataObject):
             When scalars is specified, this is the preferred array type
             to search for in the dataset.  Must be either ``'row'`` or
             ``'field'``.
+
+        Returns
+        -------
+        tuple
+            ``(min, max)`` of the array.
 
         """
         if arr is None:
@@ -337,7 +378,7 @@ class Texture(_vtk.vtkTexture, DataObject):
         if not isinstance(image, pyvista.UniformGrid):
             image = pyvista.UniformGrid(image)
         self.SetInputDataObject(image)
-        return self.Update()
+        self.Update()
 
     def _from_array(self, image):
         """Create a texture from a np.ndarray."""
@@ -355,7 +396,7 @@ class Texture(_vtk.vtkTexture, DataObject):
         grid = pyvista.UniformGrid((image.shape[1], image.shape[0], 1))
         grid.point_data['Image'] = np.flip(image.swapaxes(0, 1), axis=1).reshape((-1, n_components), order='F')
         grid.set_active_scalars('Image')
-        return self._from_image_data(grid)
+        self._from_image_data(grid)
 
     @property
     def repeat(self):
@@ -378,14 +419,28 @@ class Texture(_vtk.vtkTexture, DataObject):
             raise ValueError(f"Axis {axis} out of bounds")
         array = self.to_array()
         array = np.flip(array, axis=1 - axis)
-        return self._from_array(array)
+        self._from_array(array)
 
     def to_image(self):
-        """Return the texture as an image."""
+        """Return the texture as an image.
+
+        Returns
+        -------
+        pyvista.UniformGrid
+            Texture represented as a uniform grid.
+
+        """
         return self.GetInput()
 
     def to_array(self):
-        """Return the texture as a np.ndarray."""
+        """Return the texture as an array.
+
+        Returns
+        -------
+        numpy.ndarray
+            Texture as a numpy array
+
+        """
         image = self.to_image()
 
         if image.active_scalars.ndim > 1:
@@ -416,11 +471,24 @@ class Texture(_vtk.vtkTexture, DataObject):
         self.SetCubeMap(flag)
 
     def copy(self):
-        """Make a copy of this texture."""
+        """Make a copy of this texture.
+
+        Returns
+        -------
+        pyvista.Texture
+            Copied texture.
+        """
         return Texture(self.to_image().copy())
 
     def to_skybox(self):
-        """Return the texture as a ``vtkSkybox`` if cube mapping is enabled."""
+        """Return the texture as a ``vtkSkybox`` if cube mapping is enabled.
+
+        Returns
+        -------
+        vtk.vtkSkybox
+            Skybox if cube mapping is enabled.  Otherwise, ``None``.
+
+        """
         if self.cube_map:
             skybox = _vtk.vtkSkybox()
             skybox.SetTexture(self)

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -412,6 +412,12 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
             ``True`` if all the faces of the :class:`pyvista.PolyData`
             are triangles and does not contain any vertices or lines.
 
+        Notes
+        -----
+        The return value is not a ``bool`` for compatibility
+        reasons, though this behavior will change in a future
+        release.  Future versions will simply return a ``bool``.
+
         Examples
         --------
         Show a mesh from :func:`pyvista.Plane` is not composed of all
@@ -428,12 +434,6 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         >>> sphere = pyvista.Sphere()
         >>> sphere.is_all_triangles
         True <CallableBool>
-
-        Notes
-        -----
-        The return value is not a ``bool`` for compatibility
-        reasons, though this behavior will change in a future
-        release.  Future versions will simply return a ``bool``.
 
         """
         class CallableBool(int):  # pragma: no cover
@@ -595,6 +595,11 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
             .. note::
                This feature is only available when saving PLY files. 
 
+        Notes
+        -----
+        Binary files write much faster than ASCII and have a smaller
+        file size.
+
         Examples
         --------
         Save a mesh as a STL.
@@ -628,11 +633,6 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
 
         >>> sphere = pyvista.Sphere()
         >>> sphere.save('my_mesh.vtk')  # doctest:+SKIP
-
-        Notes
-        -----
-        Binary files write much faster than ASCII and have a smaller
-        file size.
 
         """
         filename = os.path.abspath(os.path.expanduser(str(filename)))
@@ -1797,8 +1797,13 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
             ``'BLOCK_J'`` and ``'BLOCK_K'`` cell arrays. These arrays
             are required to restore the explicit structured grid.
 
-        Warnings
+        See Also
         --------
+        pyvista.DataSetFilters.extract_cells : Extract a subset of a dataset.
+        pyvista.UnstructuredGrid.cast_to_explicit_structured_grid : Cast an unstructured grid to an explicit structured grid.
+
+        Notes
+        -----
         The ghost cell array is disabled before casting the
         unstructured grid in order to allow the original structure
         and attributes data of the explicit structured grid to be
@@ -1807,11 +1812,6 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         grid from the visible subgrid, use the ``extract_cells``
         filter and the cell indices where the ghost cell array is
         ``0``.
-
-        See Also
-        --------
-        pyvista.DataSetFilters.extract_cells : Extract a subset of a dataset.
-        pyvista.UnstructuredGrid.cast_to_explicit_structured_grid : Cast an unstructured grid to an explicit structured grid.
 
         Examples
         --------
@@ -1849,8 +1849,8 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         binary : bool, optional
             If ``True`` (default), write as binary, else ASCII.
 
-        Warnings
-        --------
+        Notes
+        -----
         VTK adds the ``'BLOCK_I'``, ``'BLOCK_J'`` and ``'BLOCK_K'``
         cell arrays. These arrays are required to restore the explicit
         structured grid.

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -43,7 +43,7 @@ class PointSet(DataSet):
 
         Returns
         -------
-        center : numpy.ndarray, float
+        numpy.ndarray
             Coordinates for the center of mass.
 
         Examples
@@ -1133,7 +1133,7 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
 
         Returns
         -------
-        cells_dict : dict
+        dict
             A dictionary mapping containing all cells of this unstructured grid.
             Structure: vtk_enum_type (int) -> cells (np.ndarray)
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -39,11 +39,11 @@ class PointSet(DataSet):
         Parameters
         ----------
         scalars_weight : bool, optional
-            Flag for using the mesh scalars as weights. Defaults to False.
+            Flag for using the mesh scalars as weights. Defaults to ``False``.
 
         Returns
         -------
-        center : np.ndarray, float
+        center : numpy.ndarray, float
             Coordinates for the center of mass.
 
         Examples
@@ -61,7 +61,7 @@ class PointSet(DataSet):
         return np.array(alg.GetCenter())
 
     def shallow_copy(self, to_copy):
-        """Do a shallow copy the pointset."""
+        """Create a shallow copy the pointset."""
         # Set default points if needed
         if not to_copy.GetPoints():
             to_copy.SetPoints(_vtk.vtkPoints())
@@ -77,7 +77,7 @@ class PointSet(DataSet):
             boolean array of the same size as the number of cells.
 
         inplace : bool, optional
-            Updates mesh in-place while returning nothing when ``True``.
+            Updates mesh in-place.
 
         Examples
         --------
@@ -574,7 +574,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
             Filename of mesh to be written.  File type is inferred from
             the extension of the filename unless overridden with
             ftype.  Can be one of many of the supported  the following
-            types (``'.ply'``, ``'.stl'``, ``'.vtk``)
+            types (``'.ply'``, ``'.stl'``, ``'.vtk``).
 
         binary : bool, optional
             Writes the file as binary when ``True`` and ASCII when ``False``.
@@ -853,12 +853,12 @@ class PointGrid(PointSet):
             - ``'maximum'``
             - ``'minimum'``
 
-        **kwargs : optional
-            Optional keyword arguments.  See :func:`pyvista.plot`
+        **kwargs : dict, optional
+            Optional keyword arguments.  See :func:`pyvista.plot`.
 
         Returns
         -------
-        cpos : list
+        list
             Camera position, focal point, and view up.  Returned when
             ``return_cpos`` is ``True``.
 
@@ -1625,7 +1625,7 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
     def hide_cells(self, ind):
         """Hide cells without deleting them.
 
-        Hides cells by setting the ghost_cells array to HIDDEN_CELL.
+        Hides cells by setting the ghost_cells array to ``HIDDEN_CELL``.
 
         Parameters
         ----------
@@ -1674,7 +1674,7 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
 
 
 class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
-    """Extend the functionality of a ``vtk.vtkExplicitStructuredGrid`` object.
+    """Extend the functionality of the ``vtk.vtkExplicitStructuredGrid`` class.
 
     Can be initialized by the following:
 
@@ -1890,7 +1890,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
 
         Returns
         -------
-        grid : ExplicitStructuredGrid or None
+        ExplicitStructuredGrid or None
             A deep copy of this grid if ``inplace=False`` or ``None`` otherwise.
 
         Examples
@@ -1927,7 +1927,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
 
         Returns
         -------
-        grid : ExplicitStructuredGrid
+        ExplicitStructuredGrid
             A deep copy of this grid if ``inplace=False`` with the
             hidden cells shown.  Otherwise, this dataset with the
             shown cells.
@@ -2029,7 +2029,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
 
         Returns
         -------
-        ind : int, numpy.ndarray or None
+        int, numpy.ndarray, or None
             Cell IDs. ``None`` if ``coords`` is outside the grid extent.
 
         See Also
@@ -2078,7 +2078,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
 
         Returns
         -------
-        coords : tuple(int), numpy.ndarray or None
+        tuple(int), numpy.ndarray, or None
             Cell structured coordinates. ``None`` if ``ind`` is
             outside the grid extent.
 
@@ -2131,7 +2131,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
 
         Returns
         -------
-        indices : list(int)
+        list(int)
             Indices of neighboring cells.
 
         Examples
@@ -2256,7 +2256,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
 
         Returns
         -------
-        grid : ExplicitStructuredGrid
+        ExplicitStructuredGrid
             A deep copy of this grid if ``inplace=False``.
 
         See Also
@@ -2295,7 +2295,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
 
         Returns
         -------
-        grid : ExplicitStructuredGrid or None
+        ExplicitStructuredGrid or None
             A deep copy of this grid if ``inplace=False`` or ``None`` otherwise.
 
         See Also

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -601,12 +601,12 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
 
         >>> import pyvista
         >>> sphere = pyvista.Sphere()
-        >>> sphere.save('my_mesh.stl')  # doctest: +SKIP
+        >>> sphere.save('my_mesh.stl')  # doctest:+SKIP
 
         Save a mesh as a PLY.
 
         >>> sphere = pyvista.Sphere()
-        >>> sphere.save('my_mesh.ply')  # doctest: +SKIP
+        >>> sphere.save('my_mesh.ply')  # doctest:+SKIP
 
         Save a mesh as a PLY with a texture array.  Here we also
         create a simple RGB array representing the texture.
@@ -616,18 +616,18 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         >>> texture = np.zeros((sphere.n_points, 3), np.uint8)
         >>> texture[:, 1] = np.arange(sphere.n_points)[::-1]  # just blue channel
         >>> sphere.point_data['my_texture'] = texture
-        >>> sphere.save('my_mesh.ply', texture='my_texture')  # doctest: +SKIP
+        >>> sphere.save('my_mesh.ply', texture='my_texture')  # doctest:+SKIP
 
         Alternatively, provide just the texture array.  This will be
         written to the file as ``'RGB'`` since it does not contain an
         alpha channel.
 
-        >>> sphere.save('my_mesh.ply', texture=texture)  # doctest: +SKIP
+        >>> sphere.save('my_mesh.ply', texture=texture)  # doctest:+SKIP
 
         Save a mesh as a VTK file.
 
         >>> sphere = pyvista.Sphere()
-        >>> sphere.save('my_mesh.vtk')  # doctest: +SKIP
+        >>> sphere.save('my_mesh.vtk')  # doctest:+SKIP
 
         Notes
         -----
@@ -714,7 +714,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         --------
         >>> import pyvista
         >>> sphere = pyvista.Sphere()
-        >>> sphere.point_normals  # doctest: +SKIP
+        >>> sphere.point_normals  # doctest:+SKIP
         pyvista_ndarray([[-2.48721432e-10, -1.08815623e-09, -1.00000000e+00],
                          [-2.48721432e-10, -1.08815623e-09,  1.00000000e+00],
                          [-1.18888125e-01,  3.40539310e-03, -9.92901802e-01],
@@ -741,7 +741,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         --------
         >>> import pyvista
         >>> sphere = pyvista.Sphere()
-        >>> sphere.cell_normals  # doctest: +SKIP
+        >>> sphere.cell_normals  # doctest:+SKIP
         pyvista_ndarray([[-0.05413816,  0.00569015, -0.9985172 ],
                          [-0.05177207,  0.01682176, -0.9985172 ],
                          [-0.04714328,  0.02721819, -0.9985172 ],
@@ -769,7 +769,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         --------
         >>> import pyvista
         >>> sphere = pyvista.Sphere()
-        >>> sphere.face_normals  # doctest: +SKIP
+        >>> sphere.face_normals  # doctest:+SKIP
         pyvista_ndarray([[-0.05413816,  0.00569015, -0.9985172 ],
                          [-0.05177207,  0.01682176, -0.9985172 ],
                          [-0.04714328,  0.02721819, -0.9985172 ],
@@ -1111,7 +1111,7 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
         >>> import pyvista
         >>> from pyvista import examples
         >>> hex_beam = pyvista.read(examples.hexbeamfile)
-        >>> hex_beam.cells[:18]  # doctest: +SKIP
+        >>> hex_beam.cells[:18]  # doctest:+SKIP
         array([ 8,  0,  2,  8,  7, 27, 36, 90, 81,  8,  2,  1,  4,  
                 8, 36, 18, 54, 90])
 
@@ -1146,7 +1146,7 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
         >>> import pyvista
         >>> from pyvista import examples
         >>> hex_beam = pyvista.read(examples.hexbeamfile)
-        >>> hex_beam.cells_dict  # doctest: +SKIP
+        >>> hex_beam.cells_dict  # doctest:+SKIP
         {12: array([[ 0,  2,  8,  7, 27, 36, 90, 81],
                 [ 2,  1,  4,  8, 36, 18, 54, 90],
                 [ 7,  8,  6,  5, 81, 90, 72, 63],
@@ -1321,7 +1321,7 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
         >>> import pyvista
         >>> from pyvista import examples
         >>> hex_beam = pyvista.read(examples.hexbeamfile)
-        >>> hex_beam.celltypes  # doctest: +SKIP
+        >>> hex_beam.celltypes  # doctest:+SKIP
         array([12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12,
                12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12,
                12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12],
@@ -1385,8 +1385,7 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
 
         See Also
         --------
-        ExplicitStructuredGrid.cast_to_unstructured_grid
-            Cast an explicit structured grid to an unstructured grid.
+        pyvista.ExplicitStructuredGrid.cast_to_unstructured_grid
 
         Examples
         --------
@@ -1709,7 +1708,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
     >>> dims = np.array([ni, nj, nk]) + 1
     >>> grid = pv.ExplicitStructuredGrid(dims, corners)
     >>> _ = grid.compute_connectivity()
-    >>> grid.plot(show_edges=True)  # doctest: +SKIP
+    >>> grid.plot(show_edges=True)  # doctest:+SKIP
 
     """
 
@@ -1800,37 +1799,34 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
 
         Warnings
         --------
-            The ghost cell array is disabled before casting the
-            unstructured grid in order to allow the original structure
-            and attributes data of the explicit structured grid to be
-            restored. If you don't need to restore the explicit
-            structured grid later or want to extract an unstructured
-            grid from the visible subgrid, use the ``extract_cells``
-            filter and the cell indices where the ghost cell array is
-            ``0``.
+        The ghost cell array is disabled before casting the
+        unstructured grid in order to allow the original structure
+        and attributes data of the explicit structured grid to be
+        restored. If you don't need to restore the explicit
+        structured grid later or want to extract an unstructured
+        grid from the visible subgrid, use the ``extract_cells``
+        filter and the cell indices where the ghost cell array is
+        ``0``.
 
         See Also
         --------
-        DataSetFilters.extract_cells :
-            Extract a subset of a dataset.
-
-        UnstructuredGrid.cast_to_explicit_structured_grid :
-            Cast an unstructured grid to an explicit structured grid.
+        pyvista.DataSetFilters.extract_cells : Extract a subset of a dataset.
+        pyvista.UnstructuredGrid.cast_to_explicit_structured_grid : Cast an unstructured grid to an explicit structured grid.
 
         Examples
         --------
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest: +SKIP
-        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest: +SKIP
+        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
+        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest:+SKIP
 
-        >>> grid.hide_cells(range(80, 120))  # doctest: +SKIP
-        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest: +SKIP
+        >>> grid.hide_cells(range(80, 120))  # doctest:+SKIP
+        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest:+SKIP
 
-        >>> grid = grid.cast_to_unstructured_grid()  # doctest: +SKIP
-        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest: +SKIP
+        >>> grid = grid.cast_to_unstructured_grid()  # doctest:+SKIP
+        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest:+SKIP
 
-        >>> grid = grid.cast_to_explicit_structured_grid()  # doctest: +SKIP
-        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest: +SKIP
+        >>> grid = grid.cast_to_explicit_structured_grid()  # doctest:+SKIP
+        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest:+SKIP
 
         """
         grid = ExplicitStructuredGrid()
@@ -1863,15 +1859,15 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         --------
         >>> import pyvista as pv
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest: +SKIP
-        >>> grid.hide_cells(range(80, 120))  # doctest: +SKIP
-        >>> grid.save('grid.vtu')  # doctest: +SKIP
+        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
+        >>> grid.hide_cells(range(80, 120))  # doctest:+SKIP
+        >>> grid.save('grid.vtu')  # doctest:+SKIP
 
-        >>> grid = pv.ExplicitStructuredGrid('grid.vtu')  # doctest: +SKIP
-        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest: +SKIP
+        >>> grid = pv.ExplicitStructuredGrid('grid.vtu')  # doctest:+SKIP
+        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest:+SKIP
 
-        >>> grid.show_cells()  # doctest: +SKIP
-        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest: +SKIP
+        >>> grid.show_cells()  # doctest:+SKIP
+        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest:+SKIP
 
         """
         grid = self.cast_to_unstructured_grid()
@@ -1900,9 +1896,9 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         Examples
         --------
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest: +SKIP
-        >>> grid.hide_cells(range(80, 120))  # doctest: +SKIP
-        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest: +SKIP
+        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
+        >>> grid.hide_cells(range(80, 120))  # doctest:+SKIP
+        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest:+SKIP
 
         """
         if inplace:
@@ -1939,12 +1935,12 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         Examples
         --------
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest: +SKIP
-        >>> grid.hide_cells(range(80, 120))  # doctest: +SKIP
-        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest: +SKIP
+        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
+        >>> grid.hide_cells(range(80, 120))  # doctest:+SKIP
+        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest:+SKIP
 
-        >>> grid.show_cells()  # doctest: +SKIP
-        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest: +SKIP
+        >>> grid.show_cells()  # doctest:+SKIP
+        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest:+SKIP
 
         """
         if inplace:
@@ -1981,8 +1977,8 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         Examples
         --------
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest: +SKIP
-        >>> grid.dimensions  # doctest: +SKIP
+        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
+        >>> grid.dimensions  # doctest:+SKIP
         array([5, 6, 7])
 
         """
@@ -2006,12 +2002,12 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         Examples
         --------
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest: +SKIP
-        >>> grid.hide_cells(range(80, 120))  # doctest: +SKIP
-        >>> grid.bounds  # doctest: +SKIP
+        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
+        >>> grid.hide_cells(range(80, 120))  # doctest:+SKIP
+        >>> grid.bounds  # doctest:+SKIP
         [0.0, 80.0, 0.0, 50.0, 0.0, 6.0]
 
-        >>> grid.visible_bounds  # doctest: +SKIP
+        >>> grid.visible_bounds  # doctest:+SKIP
         [0.0, 80.0, 0.0, 50.0, 0.0, 4.0]
 
         """
@@ -2038,21 +2034,20 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
 
         See Also
         --------
-        ExplicitStructuredGrid.cell_coords :
-            Return the cell structured coordinates.
+        pyvista.ExplicitStructuredGrid.cell_coords : Return the cell structured coordinates.
 
         Examples
         --------
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest: +SKIP
-        >>> grid.cell_id((3, 4, 0))  # doctest: +SKIP
+        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
+        >>> grid.cell_id((3, 4, 0))  # doctest:+SKIP
         19
 
         >>> coords = [(3, 4, 0),
         ...           (3, 2, 1),
         ...           (1, 0, 2),
         ...           (2, 3, 2)]
-        >>> grid.cell_id(coords)  # doctest: +SKIP
+        >>> grid.cell_id(coords)  # doctest:+SKIP
         array([19, 31, 41, 54])
 
         """
@@ -2089,17 +2084,16 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
 
         See Also
         --------
-        ExplicitStructuredGrid.cell_id :
-            Return the cell ID.
+        pyvista.ExplicitStructuredGrid.cell_id : Return the cell ID.
 
         Examples
         --------
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest: +SKIP
-        >>> grid.cell_coords(19)  # doctest: +SKIP
+        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
+        >>> grid.cell_coords(19)  # doctest:+SKIP
         (3, 4, 0)
 
-        >>> grid.cell_coords((19, 31, 41, 54))  # doctest: +SKIP
+        >>> grid.cell_coords((19, 31, 41, 54))  # doctest:+SKIP
         array([[3, 4, 0],
                [3, 2, 1],
                [1, 0, 2],
@@ -2144,16 +2138,16 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         --------
         >>> import pyvista as pv
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest: +SKIP
-        >>> cell = grid.extract_cells(31)  # doctest: +SKIP
-        >>> ind = grid.neighbors(31)  # doctest: +SKIP
-        >>> neighbors = grid.extract_cells(ind)  # doctest: +SKIP
+        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
+        >>> cell = grid.extract_cells(31)  # doctest:+SKIP
+        >>> ind = grid.neighbors(31)  # doctest:+SKIP
+        >>> neighbors = grid.extract_cells(ind)  # doctest:+SKIP
         >>> 
         >>> plotter = pv.Plotter()
-        >>> plotter.add_axes()  # doctest: +SKIP
-        >>> plotter.add_mesh(cell, color='r', show_edges=True)  # doctest: +SKIP
-        >>> plotter.add_mesh(neighbors, color='w', show_edges=True)  # doctest: +SKIP
-        >>> plotter.show()  # doctest: +SKIP
+        >>> plotter.add_axes()  # doctest:+SKIP
+        >>> plotter.add_mesh(cell, color='r', show_edges=True)  # doctest:+SKIP
+        >>> plotter.add_mesh(neighbors, color='w', show_edges=True)  # doctest:+SKIP
+        >>> plotter.show()  # doctest:+SKIP
 
         """
         def connectivity(ind):
@@ -2267,16 +2261,15 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
 
         See Also
         --------
-        ExplicitStructuredGrid.compute_connections :
-            Compute an array with the number of connected cell faces.
+        ExplicitStructuredGrid.compute_connections : Compute an array with the number of connected cell faces.
 
         Examples
         --------
         >>> from pyvista import examples
         >>> 
-        >>> grid = examples.load_explicit_structured()  # doctest: +SKIP
-        >>> grid.compute_connectivity()  # doctest: +SKIP
-        >>> grid.plot(show_edges=True)  # doctest: +SKIP
+        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
+        >>> grid.compute_connectivity()  # doctest:+SKIP
+        >>> grid.plot(show_edges=True)  # doctest:+SKIP
 
         """
         if inplace:
@@ -2307,15 +2300,14 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
 
         See Also
         --------
-        ExplicitStructuredGrid.compute_connectivity :
-            Compute the faces connectivity flags array.
+        ExplicitStructuredGrid.compute_connectivity : Compute the faces connectivity flags array.
 
         Examples
         --------
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest: +SKIP
-        >>> grid.compute_connections()  # doctest: +SKIP
-        >>> grid.plot(show_edges=True)  # doctest: +SKIP
+        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
+        >>> grid.compute_connections()  # doctest:+SKIP
+        >>> grid.plot(show_edges=True)  # doctest:+SKIP
 
         """
         if inplace:

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -165,6 +165,11 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         original arrays can be modified outside the mesh without
         affecting the mesh. Default is ``False``.
 
+    force_ext : str, optional
+        If initializing from a file, force the reader to treat the
+        file as if it had this extension as opposed to the one in the
+        file.
+
     Examples
     --------
     >>> import vtk

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -66,7 +66,7 @@ def _retrieve_file(retriever, filename):
         return a tuple like (file_path, resp), where file_path is
         the path to the file to use.
     filename : str
-        The name of the file
+        The name of the file.
     """
     _check_examples_path()
     # First check if file has already been downloaded

--- a/pyvista/examples/examples.py
+++ b/pyvista/examples/examples.py
@@ -295,8 +295,8 @@ def load_explicit_structured(dims=(5, 6, 7), spacing=(20, 10, 1)):
     Examples
     --------
     >>> from pyvista import examples
-    >>> grid = examples.load_explicit_structured()  # doctest: +SKIP
-    >>> grid.plot(show_edges=True)  # doctest: +SKIP
+    >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
+    >>> grid.plot(show_edges=True)  # doctest:+SKIP
 
     """
     ni, nj, nk = np.asarray(dims)-1

--- a/pyvista/examples/examples.py
+++ b/pyvista/examples/examples.py
@@ -171,7 +171,7 @@ def plot_wave(fps=30, frequency=1, wavetime=3, interactive=False,
 
     Returns
     -------
-    points : np.ndarray
+    numpy.ndarray
         Position of points at last frame.
 
     """
@@ -289,7 +289,7 @@ def load_explicit_structured(dims=(5, 6, 7), spacing=(20, 10, 1)):
 
     Returns
     -------
-    grid : pyvista.ExplicitStructuredGrid
+    pyvista.ExplicitStructuredGrid
         An explicit structured grid.
 
     Examples

--- a/pyvista/jupyter/itkplotter.py
+++ b/pyvista/jupyter/itkplotter.py
@@ -237,6 +237,9 @@ class PlotterITK():
         show_bounds : bool, optional
             Show the bounding box.  Default ``False``.
 
+        **kwargs : dict, optional
+            Additional arguments to pass to ``itkwidgets.Viewer``.
+
         Returns
         -------
         itkwidgets.Viewer

--- a/pyvista/jupyter/itkplotter.py
+++ b/pyvista/jupyter/itkplotter.py
@@ -239,7 +239,7 @@ class PlotterITK():
             Size of the points displayed in the
 
         Returns
-        --------
+        -------
         viewer : itkwidgets.Viewer
             ``ITKwidgets`` viewer.
         """

--- a/pyvista/jupyter/itkplotter.py
+++ b/pyvista/jupyter/itkplotter.py
@@ -49,21 +49,22 @@ class PlotterITK():
 
         Parameters
         ----------
-        points : np.ndarray or pyvista.DataSet
+        points : numpy.ndarray or pyvista.DataSet
             An ``n x 3`` numpy array of points or PyVista dataset with
             points.
 
-        color : string or 3 item list, optional
-            Either a string, rgb list, or hex color string.  For example:
+        color : str or sequence, optional
+            Either a string, RGB sequence, or hex color string.  For one
+            of the following.
 
-            ``color='white'``
-            ``color='w'``
-            ``color=[1, 1, 1]``
-            ``color='#FFFFFF'``
+            * ``color='white'``
+            * ``color='w'``
+            * ``color=[1, 1, 1]``
+            * ``color='#FFFFFF'``
 
         point_size : float, optional
             Point size of any nodes in the dataset plotted. Also applicable
-            when style='points'. Default ``3.0``
+            when style='points'. Default ``3.0``.
 
         Examples
         --------
@@ -108,7 +109,7 @@ class PlotterITK():
             that :func:`pyvista.wrap` can handle including NumPy arrays of XYZ
             points.
 
-        color : string or 3 item list, optional, defaults to white
+        color : str sequence, optional
             Use to make the entire mesh have a single solid color.
             Either a string, RGB list, or hex color string.  For example:
             ``color='white'``, ``color='w'``, ``color=[1, 1, 1]``, or
@@ -126,12 +127,12 @@ class PlotterITK():
         opacity : float, optional
             Opacity of the mesh. If a single float value is given, it will be
             the global opacity of the mesh and uniformly applied everywhere -
-            should be between 0 and 1.  Default 1.0
+            should be between 0 and 1.  Default 1.0.
 
         smooth_shading : bool, optional
             Smooth mesh surface mesh by taking into account surface
             normals.  Surface will appear smoother while sharp edges
-            will still look sharp.  Default False.
+            will still look sharp.  Default ``False``.
 
         """
         if not pv.is_pyvista_dataset(mesh):
@@ -234,14 +235,11 @@ class PlotterITK():
             Appears to be computationally intensive.
 
         show_bounds : bool, optional
-            Show the bounding box.  Default False
-
-        point_size : int, optional
-            Size of the points displayed in the
+            Show the bounding box.  Default ``False``.
 
         Returns
         -------
-        viewer : itkwidgets.Viewer
+        itkwidgets.Viewer
             ``ITKwidgets`` viewer.
         """
         if self._background_color is not None:

--- a/pyvista/jupyter/itkplotter.py
+++ b/pyvista/jupyter/itkplotter.py
@@ -50,9 +50,10 @@ class PlotterITK():
         Parameters
         ----------
         points : np.ndarray or pyvista.DataSet
-            n x 3 numpy array of points or pyvista dataset with points.
+            An ``n x 3`` numpy array of points or PyVista dataset with
+            points.
 
-        color : string or 3 item list, optional. Color of points (if visible).
+        color : string or 3 item list, optional
             Either a string, rgb list, or hex color string.  For example:
 
             ``color='white'``

--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -425,7 +425,7 @@ class Camera(_vtk.vtkCamera):
         --------
         >>> import pyvista
         >>> plotter = pyvista.Plotter()
-        >>> plotter.camera.direction  # doctest: +SKIP
+        >>> plotter.camera.direction  # doctest:+SKIP
         (0.0, 0.0, -1.0)
 
         """

--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -12,6 +12,11 @@ from pyvista.utilities.misc import PyvistaDeprecationWarning
 class Camera(_vtk.vtkCamera):
     """PyVista wrapper for the VTK Camera class.
 
+    Parameters
+    ----------
+    renderer : pyvista.Renderer, optional
+        Renderer to attach the camera to.
+
     Examples
     --------
     Create a camera at the pyvista module level.
@@ -268,6 +273,11 @@ class Camera(_vtk.vtkCamera):
         In parallel mode, decrease the parallel scale by the specified
         factor. A value greater than 1 is a zoom-in, a value less than
         1 is a zoom-out.
+
+        Parameters
+        ----------
+        value : float
+            Zoom of the camera.  Must be greater than 0.
 
         Examples
         --------

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -19,20 +19,20 @@ def plot(var_item, off_screen=None, full_screen=None, screenshot=None,
 
     Parameters
     ----------
-    item : vtk or numpy object
+    var_item : pyvista.Dataset, vtk, or numpy object
         VTK object or ``numpy`` array to be plotted.
 
-    off_screen : bool
+    off_screen : bool, optional
         Plots off screen when ``True``.  Helpful for saving screenshots
         without a window popping up.  Defaults to active theme setting in
         :attr:`pyvista.global_theme.full_screen
-        <pyvista.themes.DefaultTheme.full_screen`
+        <pyvista.themes.DefaultTheme.full_screen`.
 
     full_screen : bool, optional
         Opens window in full screen.  When enabled, ignores
         ``window_size``.  Defaults to active theme setting in
         :attr:`pyvista.global_theme.full_screen
-        <pyvista.themes.DefaultTheme.full_screen`
+        <pyvista.themes.DefaultTheme.full_screen`.
 
     screenshot : str or bool, optional
         Saves screenshot to file when enabled.  See:
@@ -48,7 +48,7 @@ def plot(var_item, off_screen=None, full_screen=None, screenshot=None,
 
     window_size : list, optional
         Window size in pixels.  Defaults to global theme
-        :attr:`pyvista.global_theme.window_size <pyvista.themes.DefaultTheme.window_size>`
+        :attr:`pyvista.global_theme.window_size <pyvista.themes.DefaultTheme.window_size>`.
 
     show_bounds : bool, optional
         Shows mesh bounds when ``True``.  Default ``False``.
@@ -59,7 +59,7 @@ def plot(var_item, off_screen=None, full_screen=None, screenshot=None,
 
     show_axes : bool, optional
         Shows a vtk axes widget.  If ``None``, enabled according to
-        :attr:`pyvista.global_theme.axes.show <pyvista.themes._AxesConfig.show>`
+        :attr:`pyvista.global_theme.axes.show <pyvista.themes._AxesConfig.show>`.
 
     text : str, optional
         Adds text at the bottom of the plot.
@@ -227,19 +227,19 @@ def plot_arrows(cent, direction, **kwargs):
 
     Parameters
     ----------
-    cent : np.ndarray
+    cent : numpy.ndarray
         Accepts a single 3d point or array of 3d points.
 
-    directions : np.ndarray
+    direction : numpy.ndarray
         Accepts a single 3d point or array of 3d vectors.
-        Must contain the same number of items as cent.
+        Must contain the same number of items as ``cent``.
 
-    **kwargs : additional arguments, optional
+    **kwargs : dict, optional
         See :func:`pyvista.plot`.
 
-    Returns
-    -------
-    See :func:`pyvista.plot`.
+    See Also
+    --------
+    :func:`pyvista.plot`
 
     Examples
     --------
@@ -319,7 +319,7 @@ def plot_itk(mesh, color=None, scalars=None, opacity=1.0,
         :func:`pyvista.wrap` can handle including NumPy arrays of XYZ
         points.
 
-    color : string or 3 item list, optional, defaults to white
+    color : str or 3 item list, optional, defaults to white
         Use to make the entire mesh have a single solid color.  Either
         a string, RGB list, or hex color string.  For example:
         ``color='white'``, ``color='w'``, ``color=[1, 1, 1]``, or

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -46,6 +46,9 @@ def plot(var_item, off_screen=None, full_screen=None, screenshot=None,
         Allows user to pan and move figure.  Defaults to
         :attr:`pyvista.global_theme.interactive <pyvista.themes.DefaultTheme.interactive>`.
 
+    cpos : list, optional
+        List of camera position, focal point, and view up.
+
     window_size : list, optional
         Window size in pixels.  Defaults to global theme
         :attr:`pyvista.global_theme.window_size <pyvista.themes.DefaultTheme.window_size>`.
@@ -53,19 +56,32 @@ def plot(var_item, off_screen=None, full_screen=None, screenshot=None,
     show_bounds : bool, optional
         Shows mesh bounds when ``True``.  Default ``False``.
 
-    notebook : bool, optional
-        When ``True``, the resulting plot is placed inline a jupyter
-        notebook.  Assumes a jupyter console is active.
-
     show_axes : bool, optional
         Shows a vtk axes widget.  If ``None``, enabled according to
         :attr:`pyvista.global_theme.axes.show <pyvista.themes._AxesConfig.show>`.
 
+    notebook : bool, optional
+        When ``True``, the resulting plot is placed inline a jupyter
+        notebook.  Assumes a jupyter console is active.
+
+    background : str or sequence, optional
+        Color of the background.
+
     text : str, optional
         Adds text at the bottom of the plot.
 
+    return_img : bool, optional
+        Returns numpy array of the last image rendered.
+
+    eye_dome_lighting : bool, optional
+        Enables eye dome lighting.
+
     volume : bool, optional
-        Use the :func:`Plotter.add_volume() <pyvista.Plotter.add_volume>` method for volume rendering.
+        Use the :func:`Plotter.add_volume()
+        <pyvista.Plotter.add_volume>` method for volume rendering.
+
+    parallel_projection : bool, optional
+        Enable parallel projection.
 
     use_ipyvtk : bool, optional
         Deprecated.  Instead, set the backend either globally with
@@ -84,9 +100,6 @@ def plot(var_item, off_screen=None, full_screen=None, screenshot=None,
         This can also be set globally with
         :func:`pyvista.set_jupyter_backend`.
 
-    jupyter_kwargs : dict, optional
-        Keyword arguments for the Jupyter notebook plotting backend.
-
     return_viewer : bool, optional
         Return the jupyterlab viewer, scene, or display object
         when plotting with jupyter notebook.
@@ -94,6 +107,9 @@ def plot(var_item, off_screen=None, full_screen=None, screenshot=None,
     return_cpos : bool, optional
         Return the last camera position from the render window
         when enabled.  Defaults to value in theme settings.
+
+    jupyter_kwargs : dict, optional
+        Keyword arguments for the Jupyter notebook plotting backend.
 
     theme : pyvista.themes.DefaultTheme, optional
         Plot-specific theme.

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -366,7 +366,7 @@ def plot_itk(mesh, color=None, scalars=None, opacity=1.0,
 
     Returns
     --------
-    plotter : itkwidgets.Viewer
+    itkwidgets.Viewer
         ITKwidgets viewer.
     """
     pl = pyvista.PlotterITK()

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -253,6 +253,11 @@ def plot_arrows(cent, direction, **kwargs):
     **kwargs : dict, optional
         See :func:`pyvista.plot`.
 
+    Returns
+    -------
+    tuple
+        See the returns of :func:`pyvista.plot`.
+
     See Also
     --------
     :func:`pyvista.plot`

--- a/pyvista/plotting/lights.py
+++ b/pyvista/plotting/lights.py
@@ -44,11 +44,11 @@ class Light(vtkLight):
         has a transformation matrix.  See also the
         :py:attr:`focal_point` property.
 
-    color : string or 3-length sequence, optional
+    color : str or 3-length sequence, optional
         The color of the light. The ambient, diffuse and specular
         colors will all be set to this color on creation.
 
-    light_type : string or int, optional
+    light_type : str or int, optional
         The type of the light. If a string, one of ``'headlight'``,
         ``'camera light'`` or ``'scene light'``. If an int, one of 1,
         2 or 3, respectively. The class constants ``Light.HEADLIGHT``,

--- a/pyvista/plotting/lights.py
+++ b/pyvista/plotting/lights.py
@@ -1174,7 +1174,14 @@ class Light(vtkLight):
         return self._renderers
 
     def add_renderer(self, renderer):
-        """Attach a renderer to this light."""
+        """Attach a renderer to this light.
+
+        Parameters
+        ----------
+        renderer : vtk.vtkRenderer
+            Renderer.
+
+        """
         # quick check to avoid adding twice
         if renderer not in self.renderers:
             self.renderers.append(renderer)

--- a/pyvista/plotting/lights.py
+++ b/pyvista/plotting/lights.py
@@ -968,16 +968,21 @@ class Light(vtkLight):
     def copy(self, deep=True):
         """Return a shallow or a deep copy of the light.
 
-        The only mutable attribute of ``Light`` objects is the
+        The only mutable attribute of :class:`pyvista.Light` is the
         transformation matrix (if it exists). Thus asking for a
         shallow copy merely implies that the returned light and the
         original share the transformation matrix instance.
 
         Parameters
         ----------
-        deep : bool
+        deep : bool, optional
             Whether to return a deep copy rather than a shallow
             one. Default ``True``.
+
+        Returns
+        -------
+        pyvista.Light
+            Copied light.
 
         Examples
         --------

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -40,6 +40,11 @@ class PickingHelper:
 
         Uses last input mesh for input by default.
 
+        .. warning::
+           Visible cell picking (``through=False``) will only work if
+           the mesh is displayed with a ``'surface'`` representation
+           style (the default).
+
         Parameters
         ----------
         mesh : pyvista.DataSet, optional
@@ -88,12 +93,6 @@ class PickingHelper:
         kwargs : optional
             All remaining keyword arguments are used to control how
             the selection is interactively displayed.
-
-        Warnings
-        --------
-        Visible cell picking (``through=False``) will only work if the
-        mesh is displayed with a ``'surface'`` representation style
-        (the default).
 
         """
         if mesh is None:

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -40,12 +40,6 @@ class PickingHelper:
 
         Uses last input mesh for input by default.
 
-        Warning
-        -------
-        Visible cell picking (``through=False``) will only work if the
-        mesh is displayed with a ``'surface'`` representation style
-        (the default).
-
         Parameters
         ----------
         mesh : pyvista.DataSet, optional
@@ -94,6 +88,12 @@ class PickingHelper:
         kwargs : optional
             All remaining keyword arguments are used to control how
             the selection is interactively displayed.
+
+        Warnings
+        --------
+        Visible cell picking (``through=False``) will only work if the
+        mesh is displayed with a ``'surface'`` representation style
+        (the default).
 
         """
         if mesh is None:

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -20,7 +20,14 @@ class PickingHelper:
     picked_horizon = None
 
     def get_pick_position(self):
-        """Get the pick position/area as x0, y0, x1, y1."""
+        """Get the pick position or area.
+
+        Returns
+        -------
+        sequence
+            Picked position or area as ``(x0, y0, x1, y1)``.
+
+        """
         return self.renderer.get_pick_position()
 
     def enable_cell_picking(self, mesh=None, callback=None, through=True,

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -220,8 +220,6 @@ class PickingHelper:
         if start:
             self.iren._style_class.StartSelect()
 
-        return
-
     def enable_point_picking(self, callback=None, show_message=True,
                              font_size=18, color='pink', point_size=10,
                              use_mesh=False, show_point=True, tolerance=0.025,
@@ -306,8 +304,6 @@ class PickingHelper:
             self.add_text(str(show_message), font_size=font_size,
                           name='_point_picking_message')
 
-        return
-
     def enable_path_picking(self, callback=None, show_message=True,
                             font_size=18, color='pink', point_size=10,
                             line_width=5, show_path=True, tolerance=0.025,
@@ -385,21 +381,21 @@ class PickingHelper:
                               reset_camera=False, **kwargs)
             if callable(callback):
                 try_callback(callback, self.picked_path)
-            return
 
         def _clear_path_event_watcher():
             del the_points[:]
             del the_ids[:]
             self.remove_actor('_picked_path')
-            return
 
         self.add_key_event('c', _clear_path_event_watcher)
         if show_message is True:
             show_message = "Press P to pick under the mouse\nPress C to clear"
 
-        return self.enable_point_picking(callback=_the_callback, use_mesh=True,
-                font_size=font_size, show_message=show_message,
-                show_point=False, tolerance=tolerance)
+        self.enable_point_picking(callback=_the_callback,
+                                  use_mesh=True, font_size=font_size,
+                                  show_message=show_message,
+                                  show_point=False,
+                                  tolerance=tolerance)
 
     def enable_geodesic_picking(self, callback=None, show_message=True,
                                 font_size=18, color='pink', point_size=10,
@@ -439,7 +435,7 @@ class PickingHelper:
             Thickness of path representation if ``show_path`` is
             ``True``.  Default 5.
 
-        tolerance : float
+        tolerance : float, optional
             Specify tolerance for performing pick operation. Tolerance
             is specified as fraction of rendering window
             size.  Rendering window size is measured across diagonal.
@@ -499,21 +495,21 @@ class PickingHelper:
                               reset_camera=False, **kwargs)
             if callable(callback):
                 try_callback(callback, self.picked_geodesic)
-            return
 
         def _clear_g_path_event_watcher():
             self.picked_geodesic = pyvista.PolyData()
             self.remove_actor('_picked_path')
             self._last_picked_idx = None
-            return
 
         self.add_key_event('c', _clear_g_path_event_watcher)
         if show_message is True:
             show_message = "Press P to pick under the mouse\nPress C to clear"
 
-        return self.enable_point_picking(callback=_the_callback, use_mesh=True,
-                font_size=font_size, show_message=show_message,
-                tolerance=tolerance, show_point=False)
+        self.enable_point_picking(callback=_the_callback,
+                                  use_mesh=True, font_size=font_size,
+                                  show_message=show_message,
+                                  tolerance=tolerance,
+                                  show_point=False)
 
     def enable_horizon_picking(self, callback=None, normal=(0,0,1),
                                width=None, show_message=True,
@@ -597,7 +593,14 @@ class PickingHelper:
             **kwargs)
 
     def pick_click_position(self):
-        """Get corresponding click location in the 3D plot."""
+        """Get corresponding click location in the 3D plot.
+
+        Returns
+        -------
+        tuple
+            Three item tuple with the 3D picked position.
+
+        """
         if self.click_position is None:
             self.store_click_position()
         picker = _vtk.vtkWorldPointPicker()
@@ -605,7 +608,14 @@ class PickingHelper:
         return picker.GetPickPosition()
 
     def pick_mouse_position(self):
-        """Get corresponding mouse location in the 3D plot."""
+        """Get corresponding mouse location in the 3D plot.
+
+        Returns
+        -------
+        tuple
+            Three item tuple with the 3D picked position.
+
+        """
         if self.mouse_position is None:
             self.store_mouse_position()
         picker = _vtk.vtkWorldPointPicker()

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -69,6 +69,10 @@ class PickingHelper:
         show : bool
             Show the selection interactively.
 
+        show_message : bool or str, optional
+            Show the message about how to use the cell picking tool. If this
+            is a string, that will be the message shown.
+
         style : str
             Visualization style of the selection.  One of the
             following: ``style='surface'``, ``style='wireframe'``, or
@@ -80,17 +84,13 @@ class PickingHelper:
         color : str, optional
             The color of the selected mesh is shown.
 
-        show_message : bool or str, optional
-            Show the message about how to use the cell picking tool. If this
-            is a string, that will be the message shown.
-
         font_size : int, optional
             Sets the font size of the message.
 
         start : bool, optional
             Automatically start the cell selection tool.
 
-        kwargs : optional
+        **kwargs : dict, optional
             All remaining keyword arguments are used to control how
             the selection is interactively displayed.
 
@@ -237,17 +237,12 @@ class PickingHelper:
 
         Parameters
         ----------
-        callback : function, optional
+        callback : callable, optional
             When input, calls this function after a pick is made.  The
             picked point is input as the first parameter to this
             function.  If ``use_mesh`` is ``True``, the callback
             function will be passed a pointer to the picked mesh and
             the point ID of the selected mesh.
-
-        use_mesh : bool, optional
-            If ``True``, the callback function will be passed a
-            pointer to the picked mesh and the point ID of the
-            selected mesh.
 
         show_message : bool or str, optional
             Show the message about how to use the point picking
@@ -256,21 +251,29 @@ class PickingHelper:
         font_size : int, optional
             Sets the size of the message.
 
+        color : str, optional
+            The color of the selected mesh is shown.
+
         point_size : int, optional
             Size of picked points if ``show_point`` is
             ``True``. Default 10.
 
-        color : str, optional
-            The color of the selected mesh is shown.
+        use_mesh : bool, optional
+            If ``True``, the callback function will be passed a
+            pointer to the picked mesh and the point ID of the
+            selected mesh.
+
+        show_point : bool, optional
+            Show the picked point after clicking.
 
         tolerance : float, optional
             Specify tolerance for performing pick operation. Tolerance
             is specified as fraction of rendering window
-            size. (Rendering window size is measured across diagonal.)
+            size. Rendering window size is measured across diagonal.
 
-        kwargs : optional, optional
+        **kwargs : dict, optional
             All remaining keyword arguments are used to control how
-            the picked point is interactively displayed
+            the picked point is interactively displayed.
 
         """
 
@@ -311,16 +314,16 @@ class PickingHelper:
                             **kwargs):
         """Enable picking at paths.
 
-        This is a convenience method for ``enable_point_picking`` to
-        keep track of the picked points and create a line using those
-        points.
+        This is a convenience method for :func:`enable_point_picking
+        <PickingHelper.enable_point_picking>` to keep track of the
+        picked points and create a line using those points.
 
         The line is saved to the ``.picked_path`` attribute of this
         plotter
 
         Parameters
         ----------
-        callback : callable
+        callback : callable, optional
             When given, calls this function after a pick is made.  The
             entire picked path is passed as the only parameter to this
             function.
@@ -329,31 +332,31 @@ class PickingHelper:
             Show the message about how to use the point picking
             tool. If this is a string, that will be the message shown.
 
-        show_path : bool, optional
-            Show the picked path interactively
-
         font_size : int, optional
             Sets the size of the message.
+
+        color : str, optional
+            The color of the selected mesh is shown.
 
         point_size : int, optional
             Size of picked points if ``show_path`` is
             ``True``. Default 10.
 
-        color : str, optional
-            The color of the selected mesh is shown.
-
         line_width : float, optional
             Thickness of path representation if ``show_path`` is
             ``True``.  Default 5.
+
+        show_path : bool, optional
+            Show the picked path interactively.
 
         tolerance : float, optional
             Specify tolerance for performing pick operation. Tolerance
             is specified as fraction of rendering window
             size.  Rendering window size is measured across diagonal.
 
-        kwargs : optional
+        **kwargs : dict, optional
             All remaining keyword arguments are used to control how
-            the picked path is interactively displayed
+            the picked path is interactively displayed.
 
         """
         kwargs.setdefault('pickable', False)
@@ -418,9 +421,6 @@ class PickingHelper:
             entire picked, geodesic path is passed as the only
             parameter to this function.
 
-        show_path : bool, optional
-            Show the picked path interactively
-
         show_message : bool or str, optional
             Show the message about how to use the point picking
             tool. If this is a string, that will be the message shown.
@@ -428,12 +428,12 @@ class PickingHelper:
         font_size : int, optional
             Sets the size of the message.
 
+        color : str, optional
+            The color of the selected mesh is shown.
+
         point_size : int, optional
             Size of picked points if ``show_path`` is
             ``True``. Default 10.
-
-        color : str, optional
-            The color of the selected mesh is shown.
 
         line_width : float, optional
             Thickness of path representation if ``show_path`` is
@@ -443,6 +443,9 @@ class PickingHelper:
             Specify tolerance for performing pick operation. Tolerance
             is specified as fraction of rendering window
             size.  Rendering window size is measured across diagonal.
+
+        show_path : bool, optional
+            Show the picked path interactively.
 
         keep_order : bool, optional
             If ``True``, the created geodesic path is a single ordered
@@ -457,7 +460,7 @@ class PickingHelper:
 
             .. versionadded:: 0.32.0
 
-        kwargs : optional
+        **kwargs : dict, optional
             All remaining keyword arguments are used to control how
             the picked path is interactively displayed.
 
@@ -531,19 +534,12 @@ class PickingHelper:
             function.
 
         normal : tuple(float), optional
-            The normal to the horizon surface's projection plane
+            The normal to the horizon surface's projection plane.
 
         width : float, optional
             The width of the horizon surface. Default behaviour will
             dynamically change the surface width depending on its
             length.
-
-        show_horizon : bool, optional
-            Show the picked horizon surface interactively.
-
-        show_path : bool, optional
-            Show the picked path that the horizon is built from
-            interactively.
 
         show_message : bool or str, optional
             Show the message about how to use the horizon picking
@@ -552,28 +548,30 @@ class PickingHelper:
         font_size : int, optional
             Sets the font size of the message.
 
+        color : str, optional
+            The color of the horizon surface if shown.
+
         point_size : int, optional
             Size of picked points if ``show_horizon`` is
             ``True``. Default 10.
-
-        color : str, optional
-            The color of the horizon surface if shown.
 
         line_width : float, optional
             Thickness of path representation if ``show_horizon`` is
             ``True``.  Default 5.
 
+        show_path : bool, optional
+            Show the picked path that the horizon is built from
+            interactively.
+
         opacity : float, optional
             The opacity of the horizon surface if shown.
 
-        tolerance : float, optional
-            Specify tolerance for performing pick operation. Tolerance
-            is specified as fraction of rendering window
-            size. Rendering window size is measured across diagonal.
+        show_horizon : bool, optional
+            Show the picked horizon surface interactively.
 
-        kwargs : optional
+        **kwargs : dict, optional
             All remaining keyword arguments are used to control how
-            the picked path is interactively displayed
+            the picked path is interactively displayed.
 
         """
         name = '_horizon'
@@ -630,6 +628,12 @@ class PickingHelper:
         A convenience method to track right click positions and fly to
         the picked point in the scene. The callback will be passed the
         point in 3D space.
+
+        Parameters
+        ----------
+        callback : callable
+            Callback function to call immediately after right
+            clicking.
 
         """
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -50,7 +50,14 @@ SUPPORTED_FORMATS = [".png", ".jpeg", ".jpg", ".bmp", ".tif", ".tiff"]
 VERY_FIRST_RENDER = True  # windows plotter helper
 
 def close_all():
-    """Close all open/active plotters and clean up memory."""
+    """Close all open/active plotters and clean up memory.
+
+    Returns
+    -------
+    bool
+        ``True`` when all plotters have been closed.
+
+    """
     for key, p in _ALL_PLOTTERS.items():
         if not p._closed:
             p.close()
@@ -844,7 +851,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
     @wraps(Renderer.disable_eye_dome_lighting)
     def disable_eye_dome_lighting(self, *args, **kwargs):
         """Wrap ``Renderer.disable_eye_dome_lighting``."""
-        return self.renderer.disable_eye_dome_lighting(*args, **kwargs)
+        self.renderer.disable_eye_dome_lighting(*args, **kwargs)
 
     @wraps(Renderer.reset_camera)
     def reset_camera(self, *args, **kwargs):
@@ -855,57 +862,57 @@ class BasePlotter(PickingHelper, WidgetHelper):
     @wraps(Renderer.isometric_view)
     def isometric_view(self, *args, **kwargs):
         """Wrap ``Renderer.isometric_view``."""
-        return self.renderer.isometric_view(*args, **kwargs)
+        self.renderer.isometric_view(*args, **kwargs)
 
     @wraps(Renderer.view_isometric)
     def view_isometric(self, *args, **kwarg):
         """Wrap ``Renderer.view_isometric``."""
-        return self.renderer.view_isometric(*args, **kwarg)
+        self.renderer.view_isometric(*args, **kwarg)
 
     @wraps(Renderer.view_vector)
     def view_vector(self, *args, **kwarg):
         """Wrap ``Renderer.view_vector``."""
-        return self.renderer.view_vector(*args, **kwarg)
+        self.renderer.view_vector(*args, **kwarg)
 
     @wraps(Renderer.view_xy)
     def view_xy(self, *args, **kwarg):
         """Wrap ``Renderer.view_xy``."""
-        return self.renderer.view_xy(*args, **kwarg)
+        self.renderer.view_xy(*args, **kwarg)
 
     @wraps(Renderer.view_yx)
     def view_yx(self, *args, **kwarg):
         """Wrap ``Renderer.view_yx``."""
-        return self.renderer.view_yx(*args, **kwarg)
+        self.renderer.view_yx(*args, **kwarg)
 
     @wraps(Renderer.view_xz)
     def view_xz(self, *args, **kwarg):
         """Wrap ``Renderer.view_xz``."""
-        return self.renderer.view_xz(*args, **kwarg)
+        self.renderer.view_xz(*args, **kwarg)
 
     @wraps(Renderer.view_zx)
     def view_zx(self, *args, **kwarg):
         """Wrap ``Renderer.view_zx``."""
-        return self.renderer.view_zx(*args, **kwarg)
+        self.renderer.view_zx(*args, **kwarg)
 
     @wraps(Renderer.view_yz)
     def view_yz(self, *args, **kwarg):
         """Wrap ``Renderer.view_yz``."""
-        return self.renderer.view_yz(*args, **kwarg)
+        self.renderer.view_yz(*args, **kwarg)
 
     @wraps(Renderer.view_zy)
     def view_zy(self, *args, **kwarg):
         """Wrap ``Renderer.view_zy``."""
-        return self.renderer.view_zy(*args, **kwarg)
+        self.renderer.view_zy(*args, **kwarg)
 
     @wraps(Renderer.disable)
     def disable(self, *args, **kwarg):
         """Wrap ``Renderer.disable``."""
-        return self.renderer.disable(*args, **kwarg)
+        self.renderer.disable(*args, **kwarg)
 
     @wraps(Renderer.enable)
     def enable(self, *args, **kwarg):
         """Wrap ``Renderer.enable``."""
-        return self.renderer.enable(*args, **kwarg)
+        self.renderer.enable(*args, **kwarg)
 
     @wraps(Renderer.enable_depth_peeling)
     def enable_depth_peeling(self, *args, **kwargs):
@@ -914,7 +921,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
             result = self.renderer.enable_depth_peeling(*args, **kwargs)
             if result:
                 self.ren_win.AlphaBitPlanesOn()
-
         return result
 
     @wraps(Renderer.disable_depth_peeling)
@@ -2171,7 +2177,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
             self.add_scalar_bar(**scalar_bar_args)
 
         self.renderer.Modified()
-
         return actor
 
     def add_volume(self, volume, scalars=None, clim=None, resolution=None,
@@ -3445,12 +3450,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
                           render_points_as_spheres=render_points_as_spheres,
                           reset_camera=reset_camera, render=render)
 
-        labelActor = _vtk.vtkActor2D()
-        labelActor.SetMapper(labelMapper)
-        self.add_actor(labelActor, reset_camera=False,
+        label_actor = _vtk.vtkActor2D()
+        label_actor.SetMapper(labelMapper)
+        self.add_actor(label_actor, reset_camera=False,
                        name=f'{name}-labels', pickable=False)
-
-        return labelActor
+        return label_actor
 
     def add_point_scalar_labels(self, points, labels, fmt=None, preamble='', **kwargs):
         """Label the points from a dataset with the values of their scalars.
@@ -3474,6 +3478,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         **kwargs : dict, optional
             Keyword arguments passed to
             :func:`pyvista.BasePlotter.add_point_labels`.
+
+        Returns
+        -------
+        vtk.vtkActor2D
+            VTK label actor.  Can be used to change properties of the labels.
 
         """
         if not is_pyvista_dataset(points):
@@ -3952,7 +3961,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Point to fly to in the form of ``(x, y, z)``.
 
         """
-        return self.iren.fly_to(self.renderer, point)
+        self.iren.fly_to(self.renderer, point)
 
     def orbit_on_path(self, path=None, focus=None, step=0.5, viewup=None,
                       write_frames=False, threaded=False, progress_bar=False):
@@ -4055,8 +4064,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         else:
             orbit()
 
-        return
-
     def export_vtkjs(self, filename, compress_arrays=False):
         """Export the current rendering scene as a VTKjs scene.
 
@@ -4077,7 +4084,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
             filename = os.path.join(pyvista.FIGURE_PATH, filename)
         else:
             filename = os.path.abspath(os.path.expanduser(filename))
-        return export_plotter_vtkjs(self, filename, compress_arrays=compress_arrays)
+
+        export_plotter_vtkjs(self, filename, compress_arrays=compress_arrays)
 
     def export_obj(self, filename):
         """Export scene to OBJ format.

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2941,15 +2941,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         vtk.vtkTextActor
             Text actor added to plot.
 
-        Examples
-        --------
-        Add ``'hello world'`` to the plotter.
-
-        >>> import pyvista
-        >>> pl = pyvista.Plotter()
-        >>> _ = pl.add_text('hello world', font_size=24)
-        >>> pl.show()
-
         """
         if font is None:
             font = self._theme.font.family

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1163,8 +1163,13 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def increment_point_size_and_line_width(self, increment):
         """Increment point size and line width of all actors.
 
-        For every actor in the scene, increment both its point size and
-        line width by the given value.
+        For every actor in the scene, increment both its point size
+        and line width by the given value.
+
+        Parameters
+        ----------
+        increment : float
+            Amount to increment point size and line width.
 
         """
         for renderer in self.renderers:
@@ -3531,6 +3536,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
         mag : float, optional
             Amount to scale the direction vectors.
 
+        **kwargs : dict, optional
+            See :func:`pyvista.BasePlotter.add_mesh` for optional
+            keyword arguments.
+
         Examples
         --------
         Plot a random field of vectors and save a screenshot of it.
@@ -3596,8 +3605,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if return_img:
             return image
 
-    def save_graphic(self, filename, title='PyVista Export', raster=True, painter=True):
+    def save_graphic(self, filename, title='PyVista Export',
+                     raster=True, painter=True):
         """Save a screenshot of the rendering window as a graphic file.
+
+        This can be helpful for publication documents.
 
         The supported formats are: 
 
@@ -3607,6 +3619,22 @@ class BasePlotter(PickingHelper, WidgetHelper):
         * ``'.pdf'``
         * ``'.tex'``
 
+        Parameters
+        ----------
+        filename : str
+            Path to fsave the graphic file to.
+
+        title : str, optional
+            Title to use within the file properties.
+
+        raster : bool, optional
+            Attempt to write 3D properties as a raster image.
+
+        painter : bool, optional
+            Configure the exporter to expect a painter-ordered 2D
+            rendering, that is, a rendering at a fixed depth where
+            primitives are drawn from the bottom up.
+
         """
         if not hasattr(self, 'ren_win'):
             raise AttributeError('This plotter is closed and unable to save a screenshot.')
@@ -3614,9 +3642,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             filename = os.path.join(pyvista.FIGURE_PATH, filename)
         filename = os.path.abspath(os.path.expanduser(filename))
         extension = pyvista.fileio.get_ext(filename)
-        valid = ['.svg', '.eps', '.ps', '.pdf', '.tex']
-        if extension not in valid:
-            raise ValueError(f"Extension ({extension}) is an invalid choice. Valid options include: {', '.join(valid)}")
+
         writer = _vtk.lazy_vtkGL2PSExporter()
         modes = {
             '.svg': writer.SetFileFormatToSVG,
@@ -3625,6 +3651,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
             '.pdf': writer.SetFileFormatToPDF,
             '.tex': writer.SetFileFormatToTeX,
         }
+        if extension not in modes:
+            raise ValueError(f"Extension ({extension}) is an invalid choice.\n\n"
+                             f"Valid options include: {', '.join(modes.keys())}")
         writer.CompressOff()
         writer.SetFilePrefix(filename.replace(extension, ''))
         writer.SetInput(self.ren_win)
@@ -3634,7 +3663,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if painter:
             writer.UsePainterSettings()
         writer.Update()
-        return
 
     def screenshot(self, filename=None, transparent_background=None,
                    return_img=True, window_size=None):
@@ -4483,10 +4511,6 @@ class Plotter(BasePlotter):
             ``window_size``.  Defaults to
             :attr:`pyvista.global_theme.full_screen <pyvista.themes.DefaultTheme.full_screen>`.
 
-        cpos : list(tuple(floats))
-            The camera position.  You can also set this with
-            :attr:`Plotter.camera_position`.
-
         screenshot : str or bool, optional
             Take a screenshot of the initial state of the plot.
             If a string, it specifies the path to which the screenshot
@@ -4500,6 +4524,10 @@ class Plotter(BasePlotter):
         return_img : bool
             Returns a numpy array representing the last image along
             with the camera position.
+
+        cpos : list(tuple(floats))
+            The camera position.  You can also set this with
+            :attr:`Plotter.camera_position`.
 
         use_ipyvtk : bool, optional
             Deprecated.  Instead, set the backend either globally with
@@ -4526,6 +4554,9 @@ class Plotter(BasePlotter):
             Return the last camera position from the render window
             when enabled.  Default based on theme setting.  See
             :attr:`pyvista.themes.DefaultTheme.return_cpos`.
+
+        **kwargs : dict, optional
+            Developer keyword arguments.
 
         Returns
         -------

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3549,6 +3549,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
             See :func:`pyvista.BasePlotter.add_mesh` for optional
             keyword arguments.
 
+        Returns
+        -------
+        vtk.vtkActor
+            VTK actor of the arrows.
+
         Examples
         --------
         Plot a random field of vectors and save a screenshot of it.
@@ -3923,6 +3928,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         shift : float, optional
             Shift the plane up/down from the center of the scene by
             this amount.
+
+        Returns
+        -------
+        pyvista.PolyData
+            PolyData containing the orbital path.
 
         Examples
         --------

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2573,8 +2573,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         Parameters
         ----------
-        2 item list
-            The new range of scalar bar. Example: ``[-1, 2]``.
+        clim: list
+            The new range of scalar bar. Two item list (e.g. ``[-1, 2]``).
 
         name : str, optional
             The title of the scalar bar to update
@@ -3075,6 +3075,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Image of depth values from camera orthogonal to image
             plane.
 
+        Notes
+        -----
+        Values in image_depth are negative to adhere to a
+        right-handed coordinate system.
+
         Examples
         --------
         >>> import pyvista
@@ -3083,11 +3088,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> plotter.store_image = True
         >>> plotter.show()
         >>> zval = plotter.get_image_depth()
-
-        Notes
-        -----
-        Values in image_depth are negative to adhere to a
-        right-handed coordinate system.
 
         """
         # allow no render window
@@ -3210,7 +3210,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         Parameters
         ----------
         points : np.ndarray or pyvista.DataSet
-            n x 3 numpy array of points or pyvista dataset with points
+            An ``n x 3`` numpy array of points or pyvista dataset with points.
 
         labels : list or str
             List of labels.  Must be the same length as points. If a string name
@@ -3271,14 +3271,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
         margin : int, optional
             The size of the margin on the label background shape. Default is 3.
 
-        shape_opacity : float
+        shape_opacity : float, optional
             The opacity of the shape between zero and one.
 
-        tolerance : float
-            a tolerance to use to determine whether a point label is visible.
-            A tolerance is usually required because the conversion from world
-            space to display space during rendering introduces numerical
-            round-off.
+        tolerance : float, optional
+            A tolerance to use to determine whether a point label is
+            visible.  A tolerance is usually required because the
+            conversion from world space to display space during
+            rendering introduces numerical round-off.
 
         reset_camera : bool, optional
             Reset the camera after adding the points to the scene.
@@ -3395,12 +3395,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
         Parameters
         ----------
         points : np.ndarray or pyvista.DataSet
-            n x 3 numpy array of points or pyvista dataset with points
+            An ``n x 3`` numpy array of points or pyvista dataset with points.
 
-        labels : str
+        labels : str, optional
             String name of the point data array to use.
 
-        fmt : str
+        fmt : str, optional
             String formatter used to format numerical data.
 
         """
@@ -3871,7 +3871,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             The timestep between flying to each camera position.
 
         viewup : list(float), optional
-            the normal to the orbital plane
+            The normal to the orbital plane
 
         write_frames : bool, optional
             Assume a file is open and write a frame on each camera
@@ -4365,12 +4365,6 @@ class Plotter(BasePlotter):
              **kwargs):
         """Display the plotting window.
 
-        Notes
-        -----
-        Please use the ``q``-key to close the plotter as some
-        operating systems (namely Windows) will experience issues
-        saving a screenshot if the exit button in the GUI is pressed.
-
         Parameters
         ----------
         title : string, optional
@@ -4391,7 +4385,7 @@ class Plotter(BasePlotter):
             interactive is ``True``.  Defaults to
             :attr:`pyvista.global_theme.auto_close <pyvista.themes.DefaultTheme.auto_close>`.
 
-        interactive_update: bool, optional
+        interactive_update : bool, optional
             Disabled by default.  Allows user to non-blocking draw,
             user should call :func:`BasePlotter.update` in each iteration.
 
@@ -4465,6 +4459,12 @@ class Plotter(BasePlotter):
 
         widget
             IPython widget when ``return_viewer=True``.
+
+        Notes
+        -----
+        Please use the ``q``-key to close the plotter as some
+        operating systems (namely Windows) will experience issues
+        saving a screenshot if the exit button in the GUI is pressed.
 
         Examples
         --------

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -409,15 +409,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
         Wireframe geometry will be drawn using hidden line removal if
         the rendering engine supports it.
 
+        Disable this with :func:`disable_hidden_line_removal
+        <BasePlotter.disable_hidden_line_removal>`
+
         Parameters
         ----------
         all_renderers : bool
             If ``True``, applies to all renderers in subplots. If
             ``False``, then only applies to the active renderer.
-
-        See Also
-        --------
-        :func:`disable_hidden_line_removal <BasePlotter.disable_hidden_line_removal>`
 
         Examples
         --------
@@ -447,15 +446,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def disable_hidden_line_removal(self, all_renderers=True):
         """Disable hidden line removal.
 
+        Enable again with :func:`enable_hidden_line_removal
+        <BasePlotter.enable_hidden_line_removal>`
+
         Parameters
         ----------
         all_renderers : bool
             If ``True``, applies to all renderers in subplots. If
             ``False``, then only applies to the active renderer.
-
-        See Also
-        --------
-        :func:`enable_hidden_line_removal <BasePlotter.enable_hidden_line_removal>`
 
         Examples
         --------
@@ -2976,6 +2974,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         **kwargs : dict
             See the documentation for ``imageio.get_writer`` for additional kwargs.
 
+        Notes
+        -----
+        See the documentation for `imageio.get_writer
+        <https://imageio.readthedocs.io/en/stable/userapi.html#imageio.get_writer>`_
+
         Examples
         --------
         Open a MP4 movie and set the quality to maximum.
@@ -2983,11 +2986,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> import pyvista
         >>> pl = pyvista.Plotter
         >>> pl.open_movie('movie.mp4', quality=10)  # doctest:+SKIP
-
-        See Also
-        --------
-        See the documentation for `imageio.get_writer
-        <https://imageio.readthedocs.io/en/stable/userapi.html#imageio.get_writer>`_
 
         """
         from imageio import get_writer
@@ -3432,7 +3430,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             keyword arguments
 
         Returns
-        --------
+        -------
         vtk.vtkActor
             Actor of the mesh.
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2947,7 +2947,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         >>> import pyvista
         >>> pl = pyvista.Plotter()
-        >>> pl.add_text('hello world', font_size=24)
+        >>> _ = pl.add_text('hello world', font_size=24)
         >>> pl.show()
 
         """

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -129,7 +129,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
     border : bool, optional
         Draw a border around each render window.  Default ``False``.
 
-    border_color : string or 3 item list, optional
+    border_color : str or sequence, optional
         Either a string, rgb list, or hex color string.  For example:
 
             * ``color='white'``
@@ -1104,7 +1104,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
             self.iren.add_key_event(*args, **kwargs)
 
     def clear_events_for_key(self, key):
-        """Remove the callbacks associated to the key."""
+        """Remove the callbacks associated to the key.
+
+        Parameters
+        ----------
+        key : str
+            Key to clear events for.
+
+        """
         self.iren.clear_events_for_key(key)
 
     def store_mouse_position(self, *args):
@@ -1329,14 +1336,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
             that :func:`pyvista.wrap` can handle including NumPy
             arrays of XYZ points.
 
-        color : string or 3 item list, optional, defaults to white
+        color : str or 3 item list, optional, defaults to white
             Use to make the entire mesh have a single solid color.
             Either a string, RGB list, or hex color string.  For example:
             ``color='white'``, ``color='w'``, ``color=[1, 1, 1]``, or
             ``color='#FFFFFF'``. Color will be overridden if scalars are
             specified.
 
-        style : string, optional
+        style : str, optional
             Visualization style of the mesh.  One of the following:
             ``style='surface'``, ``style='wireframe'``, ``style='points'``.
             Defaults to ``'surface'``. Note that ``'wireframe'`` only shows a
@@ -1359,7 +1366,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Shows the edges of a mesh.  Does not apply to a wireframe
             representation.
 
-        edge_color : string or 3 item list, optional, defaults to black
+        edge_color : str or 3 item list, optional, defaults to black
             The solid color to give the edges when ``show_edges=True``.
             Either a string, RGB list, or hex color string.
 
@@ -1412,14 +1419,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
             You can also specify a list of colors to override an
             existing colormap with a custom one.  For example, to
             create a three color colormap you might specify
-            ``['green', 'red', 'blue']``
+            ``['green', 'red', 'blue']``.
 
         label : str, optional
             String label to use when adding a legend to the scene with
-            :func:`pyvista.BasePlotter.add_legend`
+            :func:`pyvista.BasePlotter.add_legend`.
 
         reset_camera : bool, optional
-            Reset the camera after adding this mesh to the scene
+            Reset the camera after adding this mesh to the scene.
 
         scalar_bar_args : dict, optional
             Dictionary of keyword arguments to pass when adding the
@@ -1439,7 +1446,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             updated.  If an actor of this name already exists in the
             rendering window, it will be replaced by the new actor.
 
-        texture : vtk.vtkTexture or np.ndarray or boolean, optional
+        texture : vtk.vtkTexture or np.ndarray or bool, optional
             A texture to apply if the input mesh has texture
             coordinates.  This will not work with MultiBlock
             datasets. If set to ``True``, the first available texture
@@ -1461,26 +1468,27 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Automatically enabled when ``pbr=True``.
 
         ambient : float, optional
-            When lighting is enabled, this is the amount of light from
-            0 to 1 that reaches the actor when not directed at the
-            light source emitted from the viewer.  Default 0.0
+            When lighting is enabled, this is the amount of light in
+            the range of 0 to 1 (default 0.0) that reaches the actor
+            when not directed at the light source emitted from the
+            viewer.
 
         diffuse : float, optional
-            The diffuse lighting coefficient. Default 1.0
+            The diffuse lighting coefficient. Default 1.0.
 
         specular : float, optional
-            The specular lighting coefficient. Default 0.0
+            The specular lighting coefficient. Default 0.0.
 
         specular_power : float, optional
-            The specular power. Between 0.0 and 128.0
+            The specular power. Between 0.0 and 128.0.
 
-        nan_color : string or 3 item list, optional, defaults to gray
+        nan_color : str or 3 item list, optional, defaults to gray
             The color to use for all ``NaN`` values in the plotted
             scalar array.
 
         nan_opacity : float, optional
             Opacity of ``NaN`` values.  Should be between 0 and 1.
-            Default 1.0
+            Default 1.0.
 
         culling : str, optional
             Does not render faces that are culled. Options are
@@ -1519,12 +1527,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Invert the opacity mappings and make the values correspond
             to transparency.
 
-        below_color : string or 3 item list, optional
+        below_color : str or 3 item list, optional
             Solid color for values below the scalars range
             (``clim``). This will automatically set the scalar bar
             ``below_label`` to ``'Below'``.
 
-        above_color : string or 3 item list, optional
+        above_color : str or 3 item list, optional
             Solid color for values below the scalars range
             (``clim``). This will automatically set the scalar bar
             ``above_label`` to ``'Above'``.
@@ -1535,7 +1543,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             and the values are the the string annotations.
 
         pickable : bool, optional
-            Set whether this mesh is pickable.
+            Set whether this actor is pickable.
 
         preference : str, optional
             When ``mesh.n_points == mesh.n_cells`` and setting
@@ -1573,9 +1581,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
             nonnegative, if supplied. If ``None``, the magnitude of
             the vector is plotted.
 
+        **kwargs : dict, optional
+            Optional developer keyword arguments.
+
         Returns
         -------
-        actor : vtk.vtkActor
+        vtk.vtkActor
             VTK actor of the mesh.
 
         Examples
@@ -2189,7 +2200,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
             maximum of scalars array.  Example: ``[-1, 2]``. ``rng``
             is also an accepted alias for this.
 
-        opacity : string or numpy.ndarray, optional
+        resolution : list, optional
+            Block resolution.
+
+        opacity : str or numpy.ndarray, optional
             Opacity mapping for the scalars array.
             A string can also be specified to map the scalars range to a
             predefined opacity transfer function (options include: 'linear',
@@ -2213,7 +2227,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             this as well.
 
         reset_camera : bool, optional
-            Reset the camera after adding this mesh to the scene
+            Reset the camera after adding this mesh to the scene.
 
         name : str, optional
             The name for the added actor so that it can be easily
@@ -2225,15 +2239,15 @@ class BasePlotter(PickingHelper, WidgetHelper):
             0 to 1 that reaches the actor when not directed at the
             light source emitted from the viewer.  Default 0.0.
 
+        categories : bool, optional
+            If set to ``True``, then the number of unique values in the scalar
+            array will be used as the ``n_colors`` argument.
+
         culling : str, optional
             Does not render faces that are culled. Options are ``'front'`` or
             ``'back'``. This can be helpful for dense surface meshes,
             especially when edges are visible, but can cause flat
             meshes to be partially displayed.  Defaults ``False``.
-
-        categories : bool, optional
-            If set to ``True``, then the number of unique values in the scalar
-            array will be used as the ``n_colors`` argument.
 
         multi_colors : bool, optional
             Whether or not to use multiple colors when plotting MultiBlock
@@ -2265,6 +2279,16 @@ class BasePlotter(PickingHelper, WidgetHelper):
             values in the scalars range to annotate on the scalar bar
             and the values are the the string annotations.
 
+        pickable : bool, optional
+            Set whether this mesh is pickable.
+
+        preference : str, optional
+            When ``mesh.n_points == mesh.n_cells`` and setting
+            scalars, this parameter sets how the scalars will be
+            mapped to the mesh.  Default ``'points'``, causes the
+            scalars will be associated with the mesh points.  Can be
+            either ``'points'`` or ``'cells'``.
+
         opacity_unit_distance : float
             Set/Get the unit distance on which the scalar opacity
             transfer function is defined. Meaning that over that
@@ -2282,16 +2306,19 @@ class BasePlotter(PickingHelper, WidgetHelper):
             flag is on.
 
         diffuse : float, optional
-            The diffuse lighting coefficient. Default 1.0
+            The diffuse lighting coefficient. Default ``1.0``.
 
         specular : float, optional
-            The specular lighting coefficient. Default 0.0
+            The specular lighting coefficient. Default ``0.0``.
 
         specular_power : float, optional
-            The specular power. Between 0.0 and 128.0
+            The specular power. Between ``0.0`` and ``128.0``.
 
         render : bool, optional
             Force a render when True.  Default ``True``.
+
+        **kwargs : dict, optional
+            Optional keyword arguments.
 
         Returns
         -------
@@ -2338,7 +2365,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             if isinstance(volume, np.ndarray):
                 volume = wrap(volume)
                 if resolution is None:
-                    resolution = [1,1,1]
+                    resolution = [1, 1, 1]
                 elif len(resolution) != 3:
                     raise ValueError('Invalid resolution dimensions.')
                 volume.spacing = resolution
@@ -2573,11 +2600,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         Parameters
         ----------
-        clim: list
+        clim : sequence
             The new range of scalar bar. Two item list (e.g. ``[-1, 2]``).
 
         name : str, optional
-            The title of the scalar bar to update
+            The title of the scalar bar to update.
 
         """
         if isinstance(clim, float) or isinstance(clim, int):
@@ -2797,7 +2824,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
             del self.ren_win
 
     def close(self, render=False):
-        """Close the render window."""
+        """Close the render window.
+
+        Parameters
+        ----------
+        render : bool
+            Unused argument.
+
+        """
         # optionally run just prior to exiting the plotter
         if self._before_close_callback is not None:
             self._before_close_callback(self)
@@ -2858,9 +2892,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
         Parameters
         ----------
         text : str
-            The text to add the rendering
+            The text to add the rendering.
 
-        position : str, tuple(float)
+        position : str, tuple(float), optional
             Position to place the bottom left corner of the text box.
             If tuple is used, the position of the text uses the pixel
             coordinate system (default). In this case,
@@ -2871,28 +2905,50 @@ class BasePlotter(PickingHelper, WidgetHelper):
             and place text box up there. Available position: ``'lower_left'``,
             ``'lower_right'``, ``'upper_left'``, ``'upper_right'``,
             ``'lower_edge'``, ``'upper_edge'``, ``'right_edge'``, and
-            ``'left_edge'``
+            ``'left_edge'``.
 
-        font : string, optional
-            Font name may be courier, times, or arial
+        font_size : float, optional
+            Sets the size of the title font.  Defaults to 18.
+
+        color : str or sequence, optional
+            Either a string, RGB list, or hex color string.  For example:
+
+            * ``color='white'``
+            * ``color='w'``
+            * ``color=[1, 1, 1]``
+            * ``color='#FFFFFF'``
+
+            Defaults to :attr:`pyvista.global_theme.font.color <pyvista.themes._Font.color>`.
+
+        font : str, optional
+            Font name may be ``'courier'``, ``'times'``, or ``'arial'``.
 
         shadow : bool, optional
-            Adds a black shadow to the text.  Defaults to False
+            Adds a black shadow to the text.  Defaults to ``False``.
 
         name : str, optional
             The name for the added actor so that it can be easily updated.
             If an actor of this name already exists in the rendering window, it
             will be replaced by the new actor.
 
-        viewport: bool
-            If True and position is a tuple of float, uses
-            the normalized viewport coordinate system (values between 0.0
+        viewport : bool, optional
+            If ``True`` and position is a tuple of float, uses the
+            normalized viewport coordinate system (values between 0.0
             and 1.0 and support for HiDPI).
 
         Returns
         -------
-        textActor : vtk.vtkTextActor
-            Text actor added to plot
+        vtk.vtkTextActor
+            Text actor added to plot.
+
+        Examples
+        --------
+        Add ``'hello world'`` to the plotter.
+
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.add_text('hello world', font_size=24)
+        >>> pl.show()
 
         """
         if font is None:
@@ -2962,7 +3018,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         ----------
         filename : str
             Filename of the movie to open.  Filename should end in mp4,
-            but other filetypes may be supported.  See ``imagio.get_writer``
+            but other filetypes may be supported.  See ``imagio.get_writer``.
 
         framerate : int, optional
             Frames per second.
@@ -2971,7 +3027,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Quality 10 is the top possible quality for any codec. The
             range is ``0 - 10``.  Higher quality leads to a larger file.
 
-        **kwargs : dict
+        **kwargs : dict, optional
             See the documentation for ``imageio.get_writer`` for additional kwargs.
 
         Notes
@@ -3071,7 +3127,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         Returns
         -------
-        image_depth : numpy.ndarray
+        numpy.ndarray
             Image of depth values from camera orthogonal to image
             plane.
 
@@ -3134,12 +3190,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         Parameters
         ----------
         lines : np.ndarray or pyvista.PolyData
-            Points representing line segments.  For example, two line segments
-            would be represented as:
+            Points representing line segments.  For example, two line
+            segments would be represented as ``np.array([[0, 0, 0],
+            [1, 0, 0], [1, 0, 0], [1, 1, 0]])``.
 
-            np.array([[0, 0, 0], [1, 0, 0], [1, 0, 0], [1, 1, 0]])
-
-        color : string or 3 item list, optional, defaults to white
+        color : str or sequence, optional
             Either a string, rgb list, or hex color string.  For example:
 
             * ``color='white'``
@@ -3148,7 +3203,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
             * ``color='#FFFFFF'``
 
         width : float, optional
-            Thickness of lines
+            Thickness of lines.
+
+        label : str, optional
+            String label to use when adding a legend to the scene with
+            :func:`pyvista.BasePlotter.add_legend`.
 
         name : str, optional
             The name for the added actor so that it can be easily updated.
@@ -3157,7 +3216,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         Returns
         -------
-        actor : vtk.vtkActor
+        vtk.vtkActor
             Lines actor.
 
         """
@@ -3209,61 +3268,65 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         Parameters
         ----------
-        points : np.ndarray or pyvista.DataSet
-            An ``n x 3`` numpy array of points or pyvista dataset with points.
+        points : sequence or pyvista.DataSet
+            An ``n x 3`` sequence points or pyvista dataset with points.
 
         labels : list or str
-            List of labels.  Must be the same length as points. If a string name
-            is given with a pyvista.DataSet input for points, then these are fetched.
+            List of labels.  Must be the same length as points. If a
+            string name is given with a :class:`pyvista.DataSet` input for
+            points, then these are fetched.
 
         italic : bool, optional
-            Italicises title and bar labels.  Default False.
+            Italicises title and bar labels.  Default ``False``.
 
         bold : bool, optional
-            Bolds title and bar labels.  Default True
+            Bolds title and bar labels.  Default ``True``.
 
         font_size : float, optional
             Sets the size of the title font.  Defaults to 16.
 
-        text_color : string or 3 item list, optional
-            Color of text. Either a string, rgb list, or hex color string.
+        text_color : str or 3 item list, optional
+            Color of text. Either a string, RGB sequence, or hex color string.
 
-                text_color='white'
-                text_color='w'
-                text_color=[1, 1, 1]
-                text_color='#FFFFFF'
+            * ``text_color='white'``
+            * ``text_color='w'``
+            * ``text_color=[1, 1, 1]``
+            * ``text_color='#FFFFFF'``
 
-        font_family : string, optional
-            Font family.  Must be either courier, times, or arial.
+        font_family : str, optional
+            Font family.  Must be either ``'courier'``, ``'times'``,
+            or ``'arial``.
 
         shadow : bool, optional
-            Adds a black shadow to the text.  Defaults to False
+            Adds a black shadow to the text.  Defaults to ``False``.
 
         show_points : bool, optional
-            Controls if points are visible.  Default True
+            Controls if points are visible.  Default ``True``.
 
-        point_color : string or 3 item list, optional. Color of points (if visible).
-            Either a string, rgb list, or hex color string.  For example:
+        point_color : str or sequence, optional
+            Either a string, rgb list, or hex color string.  One of
+            the following.
 
-            * ``color='white'``
-            * ``color='w'``
-            * ``color=[1, 1, 1]``
-            * ``color='#FFFFFF'``
+            * ``point_color='white'``
+            * ``point_color='w'``
+            * ``point_color=[1, 1, 1]``
+            * ``point_color='#FFFFFF'``
 
         point_size : float, optional
-            Size of points (if visible)
+            Size of points if visible.
 
         name : str, optional
-            The name for the added actor so that it can be easily updated.
-            If an actor of this name already exists in the rendering window, it
-            will be replaced by the new actor.
+            The name for the added actor so that it can be easily
+            updated.  If an actor of this name already exists in the
+            rendering window, it will be replaced by the new actor.
 
-        shape_color : string or 3 item list, optional. Color of points (if visible).
-            Either a string, rgb list, or hex color string.  For example:
+        shape_color : str or sequence, optional
+            Color of points (if visible).  Either a string, rgb
+            sequence, or hex color string.
 
         shape : str, optional
             The string name of the shape to use. Options are ``'rect'`` or
-            ``'rounded_rect'``. If you want no shape, pass ``None``
+            ``'rounded_rect'``. If you want no shape, pass ``None``.
 
         fill_shape : bool, optional
             Fill the shape with the ``shape_color``. Outlines if ``False``.
@@ -3272,7 +3335,13 @@ class BasePlotter(PickingHelper, WidgetHelper):
             The size of the margin on the label background shape. Default is 3.
 
         shape_opacity : float, optional
-            The opacity of the shape between zero and one.
+            The opacity of the shape in the range of ``[0, 1]``.
+
+        pickable : bool, optional
+            Set whether this actor is pickable.
+
+        render_points_as_spheres : bool, optional
+            Render points as spheres rather than dots.
 
         tolerance : float, optional
             A tolerance to use to determine whether a point label is
@@ -3291,7 +3360,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         Returns
         -------
-        labelActor : vtk.vtkActor2D
+        vtk.vtkActor2D
             VTK label actor.  Can be used to change properties of the labels.
 
         """
@@ -3394,14 +3463,21 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         Parameters
         ----------
-        points : np.ndarray or pyvista.DataSet
-            An ``n x 3`` numpy array of points or pyvista dataset with points.
+        points : numpy.ndarray or pyvista.DataSet
+            An ``n x 3`` numpy.ndarray or pyvista dataset with points.
 
         labels : str, optional
             String name of the point data array to use.
 
         fmt : str, optional
             String formatter used to format numerical data.
+
+        preamble : str, optional
+            Text before the start of each label.
+
+        **kwargs : dict, optional
+            Keyword arguments passed to
+            :func:`pyvista.BasePlotter.add_point_labels`.
 
         """
         if not is_pyvista_dataset(points):
@@ -3422,12 +3498,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         Parameters
         ----------
-        points : np.ndarray or pyvista.
+        points : numpy.ndarray or pyvista.DataSet
             Array of points or the points from a pyvista object.
 
-        **kwargs : optional keyword arguments
+        **kwargs : dict, optional
             See :func:`pyvista.BasePlotter.add_mesh` for optional
-            keyword arguments
+            keyword arguments.
 
         Returns
         -------
@@ -3592,7 +3668,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         Returns
         -------
-        img : numpy.ndarray
+        numpy.ndarray
             Array containing pixel RGB and alpha.  Sized:
 
             * [Window height x Window width x 3] if
@@ -3652,16 +3728,16 @@ class BasePlotter(PickingHelper, WidgetHelper):
         labels : list, optional
             When set to None, uses existing labels as specified by
 
-            - add_mesh
-            - add_lines
-            - add_points
+            - :func:`add_mesh <BasePlotter.add_mesh>`
+            - :func:`add_lines <BasePlotter.add_lines>`
+            - :func:`add_points <BasePlotter.add_points>`
 
             List containing one entry for each item to be added to the
             legend.  Each entry must contain two strings, [label,
             color], where label is the name of the item to add, and
             color is the color of the label to add.
 
-        bcolor : list or string, optional
+        bcolor : list or str, optional
             Background color, either a three item 0 to 1 RGB color
             list, or a matplotlib color string (e.g. 'w' or 'white'
             for a white color).  If None, legend background is
@@ -3697,7 +3773,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         Returns
         -------
-        legend : vtk.vtkLegendBoxActor
+        vtk.vtkLegendBoxActor
             Actor for the legend.
 
         Examples
@@ -3851,6 +3927,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         The movement is animated over the number of frames specified in
         NumberOfFlyFrames. The LOD desired frame rate is used.
 
+        Parameters
+        ----------
+        point : sequence
+            Point to fly to in the form of ``(x, y, z)``.
+
         """
         return self.iren.fly_to(self.renderer, point)
 
@@ -3871,7 +3952,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             The timestep between flying to each camera position.
 
         viewup : list(float), optional
-            The normal to the orbital plane
+            The normal to the orbital plane.
 
         write_frames : bool, optional
             Assume a file is open and write a frame on each camera
@@ -3962,6 +4043,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         It can be used for rendering in a web browser.
 
+        Parameters
+        ----------
+        filename : str
+            Filename to export the scene to.  A filename extension of
+            ``'.vtkjs'`` will be added.
+
+        compress_arrays : bool, optional
+            Enable array compression.
         """
         if not hasattr(self, 'ren_win'):
             raise RuntimeError('Export must be called before showing/closing the scene.')
@@ -3972,7 +4061,19 @@ class BasePlotter(PickingHelper, WidgetHelper):
         return export_plotter_vtkjs(self, filename, compress_arrays=compress_arrays)
 
     def export_obj(self, filename):
-        """Export scene to OBJ format."""
+        """Export scene to OBJ format.
+
+        Parameters
+        ----------
+        filename : str
+            Filename to export the scene to.  Should end in ``'.obj'``.
+
+        Returns
+        -------
+        vtkOBJExporter
+            Object exporter.
+
+        """
         # lazy import vtkOBJExporter here as it takes a long time to
         # load and is not always used
         try:
@@ -4151,7 +4252,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         Returns
         -------
-        places : list(tuple(int))
+        list(tuple(int))
             A list with the subplot coordinates of the actor.
 
         Examples
@@ -4198,13 +4299,13 @@ class Plotter(BasePlotter):
         with ``shape=(2, 2)``.  By default there is only one render
         window.  Can also accept a string descriptor as shape. E.g.:
 
-            * ``shape="3|1"`` means 3 plots on the left and 1 on the right,
-            * ``shape="4/2"`` means 4 plots on top and 2 at the bottom.
+        * ``shape="3|1"`` means 3 plots on the left and 1 on the right,
+        * ``shape="4/2"`` means 4 plots on top and 2 at the bottom.
 
     border : bool, optional
         Draw a border around each render window.  Default ``False``.
 
-    border_color : string or 3 item list, optional
+    border_color : str or 3 item list, optional
         Either a string, rgb list, or hex color string.  For example:
 
             * ``color='white'``
@@ -4224,9 +4325,6 @@ class Plotter(BasePlotter):
 
     line_smoothing : bool, optional
         If ``True``, enable line smoothing.
-
-    point_smoothing : bool, optional
-        If ``True``, enable point smoothing.
 
     polygon_smoothing : bool, optional
         If ``True``, enable polygon smoothing.
@@ -4367,7 +4465,7 @@ class Plotter(BasePlotter):
 
         Parameters
         ----------
-        title : string, optional
+        title : str, optional
             Title of plotting window.  Defaults to
             :attr:`pyvista.global_theme.title <pyvista.themes.DefaultTheme.title>`.
 
@@ -4652,7 +4750,7 @@ class Plotter(BasePlotter):
             Sets the size of the title font.  Defaults to 16 or the
             value of the global theme if set.
 
-        color : string or 3 item list, optional, 
+        color : str or 3 item list, optional, 
             Either a string, rgb list, or hex color string.  Defaults
             to white or the value of the global theme if set.  For
             example:
@@ -4662,7 +4760,7 @@ class Plotter(BasePlotter):
             * ``color=[1, 1, 1]``
             * ``color='#FFFFFF'``
 
-        font : string, optional
+        font : str, optional
             Font name may be ``'courier'``, ``'times'``, or ``'arial'``.
 
         shadow : bool, optional

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2332,8 +2332,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         Returns
         -------
-        actor: vtk.vtkVolume
-            VTK volume of the input data.
+        vtk.vtkActor
+            VTK actor of the volume.
 
         """
         # Handle default arguments

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -419,7 +419,7 @@ class RenderWindowInteractor():
         """
         self._style = 'Terrain'
         self._style_class = None
-        return_value = self.update_style()
+        self.update_style()
 
         if mouse_wheel_zooms:
             def wheel_zoom_callback(obj, event):  # pragma: no cover
@@ -452,8 +452,6 @@ class RenderWindowInteractor():
 
             for event in 'LeftButtonPressEvent', 'LeftButtonReleaseEvent':
                 self._style_class.AddObserver(event, callback)
-
-        return return_value
 
     def enable_rubber_band_style(self):
         """Set the interactive style to Rubber Band Picking.
@@ -568,19 +566,44 @@ class RenderWindowInteractor():
         self.interactor.MouseMoveEvent()
 
     def get_event_position(self):
-        """Get the event position."""
+        """Get the event position.
+
+        Returns
+        -------
+        tuple
+            The ``(x, y)`` coordinate position.
+
+        """
         return self.interactor.GetEventPosition()
 
     def get_interactor_style(self):
-        """Get the interactor style."""
+        """Get the interactor style.
+
+        Returns
+        -------
+        vtk.vtkInteractorStyle
+            VTK interactor style.
+        """
         return self.interactor.GetInteractorStyle()
 
     def get_desired_update_rate(self):
-        """Get the desired update rate."""
+        """Get the desired update rate.
+
+        Returns
+        -------
+        float
+            Desired update rate.
+        """
         return self.interactor.GetDesiredUpdateRate()
 
     def create_repeating_timer(self, stime):
-        """Create a repeating timer."""
+        """Create a repeating timer.
+
+        Returns
+        -------
+        int
+            Timer ID.
+        """
         timer_id = self.interactor.CreateRepeatingTimer(stime)
         if hasattr(self.interactor, 'ProcessEvents'):
             self.process_events()
@@ -615,7 +638,13 @@ class RenderWindowInteractor():
         return self.interactor.GetInitialized()
 
     def get_picker(self):
-        """Get the piccker."""
+        """Get the picker.
+
+        Returns
+        -------
+        vtk.vtkAbstractPicker
+            VTK picker.
+        """
         return self.interactor.GetPicker()
 
     def set_picker(self, picker):

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -160,7 +160,7 @@ class RenderWindowInteractor():
         if self._style_class is None:
             # We need an actually custom style to handle button up events
             self._style_class = _style_factory(self._style)(self)
-        return self.interactor.SetInteractorStyle(self._style_class)
+        self.interactor.SetInteractorStyle(self._style_class)
 
     def enable_trackball_style(self):
         """Set the interactive style to Trackball Camera.
@@ -190,7 +190,7 @@ class RenderWindowInteractor():
         """
         self._style = 'TrackballCamera'
         self._style_class = None
-        return self.update_style()
+        self.update_style()
 
     def enable_trackball_actor_style(self):
         """Set the interactive style to Trackball Actor.
@@ -221,7 +221,7 @@ class RenderWindowInteractor():
         """
         self._style = 'TrackballActor'
         self._style_class = None
-        return self.update_style()
+        self.update_style()
 
     def enable_image_style(self):
         """Set the interactive style to Image.
@@ -251,7 +251,7 @@ class RenderWindowInteractor():
         """
         self._style = 'Image'
         self._style_class = None
-        return self.update_style()
+        self.update_style()
 
     def enable_joystick_style(self):
         """Set the interactive style to Joystick Camera.
@@ -284,7 +284,7 @@ class RenderWindowInteractor():
         """
         self._style = 'JoystickCamera'
         self._style_class = None
-        return self.update_style()
+        self.update_style()
 
     def enable_joystick_actor_style(self):
         """Set the interactive style to Joystick Actor.
@@ -318,7 +318,7 @@ class RenderWindowInteractor():
         """
         self._style = 'JoystickActor'
         self._style_class = None
-        return self.update_style()
+        self.update_style()
 
     def enable_zoom_style(self):
         """Set the interactive style to Rubber Band Zoom.
@@ -344,7 +344,7 @@ class RenderWindowInteractor():
         """
         self._style = 'RubberBandZoom'
         self._style_class = None
-        return self.update_style()
+        self.update_style()
 
     def enable_terrain_style(self, mouse_wheel_zooms=False, shift_pans=False):
         """Set the interactive style to Terrain.
@@ -484,7 +484,7 @@ class RenderWindowInteractor():
         """
         self._style = 'RubberBandPick'
         self._style_class = None
-        return self.update_style()
+        self.update_style()
 
     def enable_rubber_band_2d_style(self):
         """Set the interactive style to Rubber Band 2D.
@@ -519,7 +519,7 @@ class RenderWindowInteractor():
         """
         self._style = 'RubberBand2D'
         self._style_class = None
-        return self.update_style()
+        self.update_style()
 
     def _simulate_keypress(self, key):  # pragma: no cover
         """Simulate a keypress."""

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -110,7 +110,7 @@ class RenderWindowInteractor():
             The side of the mouse for the button to track (left or
             right).  Default is left. Also accepts ``'r'`` or ``'l'``.
 
-        viewport: bool, optional
+        viewport : bool, optional
             If ``True``, uses the normalized viewport coordinate
             system (values between 0.0 and 1.0 and support for HiDPI)
             when passing the click position to the callback.

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -51,10 +51,10 @@ class RenderWindowInteractor():
         Parameters
         ----------
         key : str
-            The key to trigger the event
+            The key to trigger the event.
 
         callback : callable
-            A callable that takes no arguments
+            A callable that takes no arguments.
 
         """
         if not callable(callback):

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1002,6 +1002,12 @@ class Renderer(_vtk.vtkRenderer):
         outer edges. This is intended to be similar to
         ``matplotlib``'s ``grid`` function.
 
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            See :func:`Renderer.show_bounds` for additional keyword
+            arguments.
+
         """
         kwargs.setdefault('grid', 'back')
         kwargs.setdefault('location', 'outer')
@@ -1692,6 +1698,11 @@ class Renderer(_vtk.vtkRenderer):
 
         Uses ResetCamera to make a useful view.
 
+        Parameters
+        ----------
+        negative : bool
+            View from the opposite direction.
+
         """
         focal_pt = self.center
         if any(np.isnan(focal_pt)):
@@ -1810,7 +1821,14 @@ class Renderer(_vtk.vtkRenderer):
         return self.reset_camera()
 
     def view_xy(self, negative=False):
-        """View the XY plane."""
+        """View the XY plane.
+
+        Parameters
+        ----------
+        negative : bool, optional
+            View from the opposite direction.
+
+        """
         vec = np.array([0,0,1])
         viewup = np.array([0,1,0])
         if negative:
@@ -1818,7 +1836,14 @@ class Renderer(_vtk.vtkRenderer):
         return self.view_vector(vec, viewup)
 
     def view_yx(self, negative=False):
-        """View the YX plane."""
+        """View the YX plane.
+
+        Parameters
+        ----------
+        negative : bool, optional
+            View from the opposite direction.
+
+        """
         vec = np.array([0,0,-1])
         viewup = np.array([1,0,0])
         if negative:
@@ -1826,7 +1851,14 @@ class Renderer(_vtk.vtkRenderer):
         return self.view_vector(vec, viewup)
 
     def view_xz(self, negative=False):
-        """View the XZ plane."""
+        """View the XZ plane.
+
+        Parameters
+        ----------
+        negative : bool, optional
+            View from the opposite direction.
+
+        """
         vec = np.array([0,-1,0])
         viewup = np.array([0,0,1])
         if negative:
@@ -1834,7 +1866,14 @@ class Renderer(_vtk.vtkRenderer):
         return self.view_vector(vec, viewup)
 
     def view_zx(self, negative=False):
-        """View the ZX plane."""
+        """View the ZX plane.
+
+        Parameters
+        ----------
+        negative : bool, optional
+            View from the opposite direction.
+
+        """
         vec = np.array([0,1,0])
         viewup = np.array([1,0,0])
         if negative:
@@ -1842,7 +1881,14 @@ class Renderer(_vtk.vtkRenderer):
         return self.view_vector(vec, viewup)
 
     def view_yz(self, negative=False):
-        """View the YZ plane."""
+        """View the YZ plane.
+
+        Parameters
+        ----------
+        negative : bool, optional
+            View from the opposite direction.
+
+        """
         vec = np.array([1,0,0])
         viewup = np.array([0,0,1])
         if negative:
@@ -1850,7 +1896,14 @@ class Renderer(_vtk.vtkRenderer):
         return self.view_vector(vec, viewup)
 
     def view_zy(self, negative=False):
-        """View the ZY plane."""
+        """View the ZY plane.
+
+        Parameters
+        ----------
+        negative : bool, optional
+            View from the opposite direction.
+
+        """
         vec = np.array([-1,0,0])
         viewup = np.array([0,1,0])
         if negative:

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1962,11 +1962,11 @@ class Renderer(_vtk.vtkRenderer):
 
     def disable(self):
         """Disable this renderer's camera from being interactive."""
-        return self.SetInteractive(0)
+        self.SetInteractive(0)
 
     def enable(self):
         """Enable this renderer's camera to be interactive."""
-        return self.SetInteractive(1)
+        self.SetInteractive(1)
 
     def enable_eye_dome_lighting(self):
         """Enable eye dome lighting (EDL).
@@ -2145,7 +2145,6 @@ class Renderer(_vtk.vtkRenderer):
         else:
             self.GradientBackgroundOff()
         self.Modified()
-        return
 
     def set_environment_texture(self, texture):
         """Set the environment texture used for image based lighting.

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -457,13 +457,13 @@ class Renderer(_vtk.vtkRenderer):
 
         Parameters
         ----------
-        x_color : string or 3 item sequence, optional
+        x_color : str or 3 item sequence, optional
             The color of the x axes arrow.
 
-        y_color : string or 3 item sequence, optional
+        y_color : str or 3 item sequence, optional
             The color of the y axes arrow.
 
-        z_color : string or 3 item sequence, optional
+        z_color : str or 3 item sequence, optional
             The color of the z axes arrow.
 
         xlabel : str, optional
@@ -517,13 +517,15 @@ class Renderer(_vtk.vtkRenderer):
         actor : vtk.vtkActor or pyvista.DataSet
             The mesh or actor to use as the marker.
 
-        interactive : bool
+        interactive : bool, optional
             Control if the orientation widget is interactive.  By
-            default uses the value from ``theme.interactive``.
+            default uses the value from
+            :attr:`pyvista.global_theme.interactive
+            <pyvista.themes.DefaultTheme.interactive>`.
 
-        color : string, optional
+        color : str or sequence, optional
             The color of the actor.  This only applies if ``actor`` is
-            a ``pyvista.DataSet``
+            a :class:`pyvista.DataSet`.
 
         opacity : int or float, optional
             Opacity of the marker.
@@ -575,11 +577,11 @@ class Renderer(_vtk.vtkRenderer):
 
         Parameters
         ----------
-        interacitve : bool
+        interactive : bool, optional
             Enable this orientation widget to be moved by the user.
 
         line_width : int, optional
-            The width of the marker lines
+            The width of the marker lines.
 
         box : bool, optional
             Show a box orientation marker. Use ``box_args`` to adjust.
@@ -726,8 +728,8 @@ class Renderer(_vtk.vtkRenderer):
             Input mesh to draw bounds axes around.
 
         bounds : list or tuple, optional
-            Bounds to override mesh bounds.
-            ``[xmin, xmax, ymin, ymax, zmin, zmax]``
+            Bounds to override mesh bounds in the form ``[xmin, xmax,
+            ymin, ymax, zmin, zmax]``.
 
         show_xaxis : bool, optional
             Makes x axis visible.  Default ``True``.
@@ -753,11 +755,11 @@ class Renderer(_vtk.vtkRenderer):
         font_size : float, optional
             Sets the size of the label font.  Defaults to 16.
 
-        font_family : string, optional
+        font_family : str, optional
             Font family.  Must be either ``'courier'``, ``'times'``,
             or ``'arial'``.
 
-        color : string or 3 item list, optional
+        color : str or 3 item list, optional
             Color of all labels and axis titles.  Default white.
             Either a string, rgb list, or hex color string.  For
             example:
@@ -767,13 +769,13 @@ class Renderer(_vtk.vtkRenderer):
             * ``color=[1, 1, 1]``
             * ``color='#FFFFFF'``
 
-        xlabel : string, optional
+        xlabel : str, optional
             Title of the x axis.  Default ``"X Axis"``.
 
-        ylabel : string, optional
+        ylabel : str, optional
             Title of the y axis.  Default ``"Y Axis"``.
 
-        zlabel : string, optional
+        zlabel : str, optional
             Title of the z axis.  Default ``"Z Axis"``.
 
         use_2d : bool, optional
@@ -823,7 +825,7 @@ class Renderer(_vtk.vtkRenderer):
 
         Returns
         -------
-        cube_axes_actor : vtk.vtkCubeAxesActor
+        vtk.vtkCubeAxesActor
             Bounds actor.
 
         Examples
@@ -1040,6 +1042,16 @@ class Renderer(_vtk.vtkRenderer):
 
         Parameters
         ----------
+        color : str or sequence, optional
+            Color of all labels and axis titles.  Default white.
+            Either a string, rgb sequence, or hex color string.  For
+            example:
+
+            * ``color='white'``
+            * ``color='w'``
+            * ``color=[1, 1, 1]``
+            * ``color='#FFFFFF'``
+
         corner_factor : float, optional
             This is the factor along each axis to draw the default
             box. Default is 0.5 to show the full box.
@@ -1048,7 +1060,7 @@ class Renderer(_vtk.vtkRenderer):
             Thickness of lines.
 
         opacity : float, optional
-            Opacity of mesh.  Should be between 0 and 1.  Default 1.0
+            Opacity of mesh.  Default 1.0 and should be between 0 and 1.
 
         render_lines_as_tubes : bool, optional
             Show lines as thick tubes rather than flat lines.  Control
@@ -1062,7 +1074,7 @@ class Renderer(_vtk.vtkRenderer):
 
         outline : bool
             Default is ``True``. when ``False``, a box with faces is shown
-            with the specified culling
+            with the specified culling.
 
         culling : str, optional
             Does not render faces that are culled. Options are
@@ -1143,7 +1155,7 @@ class Renderer(_vtk.vtkRenderer):
         j_resolution : int, optional
             Number of points on the plane in the j direction.
 
-        color : string or 3 item list, optional
+        color : str or 3 item list, optional
             Color of all labels and axis titles.  Default gray.
             Either a string, rgb list, or hex color string.
 
@@ -1157,7 +1169,7 @@ class Renderer(_vtk.vtkRenderer):
         show_edges : bool, optional
             Flag on whether to show the mesh edges for tiling.
 
-        ine_width : float, optional
+        line_width : float, optional
             Thickness of lines.  Only valid for wireframe and surface
             representations.  Default ``None``.
 
@@ -1165,14 +1177,24 @@ class Renderer(_vtk.vtkRenderer):
             Enable or disable view direction lighting.  Default
             ``False``.
 
-        edge_color : string or 3 item list, optional
+        edge_color : str or 3 item sequence, optional
             Color of of the edges of the mesh.
+
+        reset_camera : bool, optional
+            Resets the camera when ``True`` after adding the floor.
 
         pad : float, optional
             Percentage padding between 0 and 1.
 
         offset : float, optional
             Percentage offset along plane normal.
+
+        pickable : bool, optional
+            Make this floor actor pickable in the renderer.
+
+        store_floor_kwargs : bool, optional
+            Stores the kwargs used when adding this floor.  Useful
+            when updating the bounds and regenerating the floor.
 
         Examples
         --------
@@ -1554,9 +1576,9 @@ class Renderer(_vtk.vtkRenderer):
 
         Returns
         -------
-        success : bool
-            True when actor removed.  False when actor has not been
-            removed.
+        bool
+            ``True`` when actor removed.  ``False`` when actor has not
+            been removed.
 
         Examples
         --------
@@ -1980,7 +2002,7 @@ class Renderer(_vtk.vtkRenderer):
 
         Parameters
         ----------
-        color : string or 3 item list, optional
+        color : str or 3 item list, optional
             Either a string, rgb list, or hex color string.  Defaults
             to theme default.  For example:
 
@@ -1989,7 +2011,7 @@ class Renderer(_vtk.vtkRenderer):
             * ``color=[1, 1, 1]``
             * ``color='#FFFFFF'``
 
-        top : string or 3 item list, optional
+        top : str or 3 item list, optional
             If given, this will enable a gradient background where the
             ``color`` argument is at the bottom and the color given in
             ``top`` will be the color at the top of the renderer.

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -332,7 +332,22 @@ class Renderer(_vtk.vtkRenderer):
         self.Modified()
 
     def add_border(self, color=[1, 1, 1], width=2.0):
-        """Add borders around the frame."""
+        """Add borders around the frame.
+
+        Parameters
+        ----------
+        color : str or sequence, optional
+            Color of the border.
+
+        width : float, optional
+            Width of the border.
+
+        Returns
+        -------
+        vtk.vtkActor2D
+            Border actor.
+
+        """
         points = np.array([[1., 1., 0.],
                            [0., 1., 0.],
                            [0., 0., 0.],
@@ -380,7 +395,10 @@ class Renderer(_vtk.vtkRenderer):
             Vtk mapper or vtk actor to be added.
 
         reset_camera : bool, optional
-            Resets the camera when true.
+            Resets the camera when ``True``.
+
+        name : str, optional
+            Name to assign to the actor.  Defaults to the memory address.
 
         culling : str, optional
             Does not render faces that are culled. Options are
@@ -388,6 +406,14 @@ class Renderer(_vtk.vtkRenderer):
             surface meshes, especially when edges are visible, but can
             cause flat meshes to be partially displayed.  Default
             ``False``.
+
+        pickable : bool, optional
+            Whether to allow this actor to be pickable within the
+            render window.
+
+        render : bool, optional
+            If the render window is being shown, trigger a render
+            after adding the actor.
 
         Returns
         -------
@@ -583,17 +609,16 @@ class Renderer(_vtk.vtkRenderer):
         line_width : int, optional
             The width of the marker lines.
 
-        box : bool, optional
-            Show a box orientation marker. Use ``box_args`` to adjust.
-            See :func:`pyvista.create_axes_orientation_box` for details.
+        color : str or sequence, optional
+            Color of the labels.
 
-        x_color : str, optional
+        x_color : str or sequence, optional
             Color used for the x axis arrow.  Defaults to theme axes parameters.
 
-        y_color : str, optional
+        y_color : str or sequence, optional
             Color used for the y axis arrow.  Defaults to theme axes parameters.
 
-        z_color : str, optional
+        z_color : str or sequence, optional
             Color used for the z axis arrow.  Defaults to theme axes parameters.
 
         xlabel : str, optional
@@ -609,8 +634,8 @@ class Renderer(_vtk.vtkRenderer):
             Enable or disable the text labels for the axes.
 
         box : bool, optional
-            When ``True`` use the axes orientation widget instead of
-            the default arrows. Defaults to theme axes parameters.
+            Show a box orientation marker. Use ``box_args`` to adjust.
+            See :func:`pyvista.create_axes_orientation_box` for details.
 
         box_args : dict, optional
             Parameters for the orientation box widget when
@@ -822,6 +847,10 @@ class Renderer(_vtk.vtkRenderer):
             An optional percent padding along each axial direction to
             cushion the datasets in the scene from the axes
             annotations. Defaults to 0 (no padding).
+
+        render : bool, optional
+            If the render window is being shown, trigger a render
+            after showing bounds.
 
         Returns
         -------
@@ -1333,7 +1362,14 @@ class Renderer(_vtk.vtkRenderer):
             self.Modified()
 
     def add_light(self, light):
-        """Add a light to the renderer."""
+        """Add a light to the renderer.
+
+        Parameters
+        ----------
+        light : vtk.vtkLight or pyvista.Light
+            Light to add.
+
+        """
         # convert from a vtk type if applicable
         if isinstance(light, _vtk.vtkLight) and not isinstance(light, pyvista.Light):
             light = pyvista.Light.from_vtk(light)
@@ -1426,6 +1462,10 @@ class Renderer(_vtk.vtkRenderer):
         ----------
         point : sequence
             Cartesian point to focus on in the form of ``[x, y, z]``.
+
+        reset : bool, optional
+            Whether to reset the camera after setting the camera
+            position.
 
         Examples
         --------
@@ -1811,14 +1851,24 @@ class Renderer(_vtk.vtkRenderer):
         return self.reset_camera()
 
     def view_vector(self, vector, viewup=None):
-        """Point the camera in the direction of the given vector."""
+        """Point the camera in the direction of the given vector.
+
+        Parameters
+        ----------
+        vector : sequence
+            Three item sequence to point the camera in.
+
+        viewup : sequence, optional
+            Three item sequence describing the view up of the camera.
+
+        """
         focal_pt = self.center
         if viewup is None:
             viewup = self._theme.camera['viewup']
         cpos = CameraPosition(vector + np.array(focal_pt),
                 focal_pt, viewup)
         self.camera_position = cpos
-        return self.reset_camera()
+        self.reset_camera()
 
     def view_xy(self, negative=False):
         """View the XY plane.
@@ -2108,6 +2158,11 @@ class Renderer(_vtk.vtkRenderer):
         must be expressed in linear color space. If the texture is in
         sRGB color space, set the color flag on the texture or set the
         argument isSRGB to true.
+
+        Parameters
+        ----------
+        texture : vtk.vtkTexture
+            Texture.
         """
         self.UseImageBasedLightingOn()
         self.SetEnvironmentTexture(texture)
@@ -2126,7 +2181,15 @@ class Renderer(_vtk.vtkRenderer):
             self._empty_str = None
 
     def deep_clean(self, render=False):
-        """Clean the renderer of the memory."""
+        """Clean the renderer of the memory.
+
+        Parameters
+        ----------
+        render : bool, optional
+            Render the render window after removing the bounding box
+            (if applicable).
+
+        """
         if hasattr(self, 'cube_axes_actor'):
             del self.cube_axes_actor
         if hasattr(self, 'edl_pass'):

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -30,6 +30,11 @@ def scale_point(camera, point, invert=False):
         transform a point from world coordinates to the camera's
         transformed space.
 
+    Returns
+    -------
+    tuple
+        Scaling of the camera in ``(x, y, z)``.
+
     """
     if invert:
         mtx = _vtk.vtkMatrix4x4()
@@ -51,7 +56,21 @@ class CameraPosition:
         self._viewup = viewup
 
     def to_list(self):
-        """Convert to a list of the position, focal point, and viewup."""
+        """Convert to a list of the position, focal point, and viewup.
+
+        Returns
+        -------
+        list
+            List of the position, focal point, and view up of the camera.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.camera_position.to_list()
+        [(0.0, 0.0, 1.0), (0.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+
+        """
         return [self._position, self._focal_point, self._viewup]
 
     def __repr__(self):
@@ -134,11 +153,16 @@ class Renderer(_vtk.vtkRenderer):
         if border:
             self.add_border(border_color, border_width)
 
-    #### Properties ####
-
     @property
     def camera_position(self):
-        """Return camera position of active render window."""
+        """Return camera position of active render window.
+
+        Returns
+        -------
+        pyvista.CameraPosition
+            Camera position.
+
+        """
         return CameraPosition(
             scale_point(self.camera, self.camera.position, invert=True),
             scale_point(self.camera, self.camera.focal_point, invert=True),
@@ -236,12 +260,25 @@ class Renderer(_vtk.vtkRenderer):
 
     @property
     def length(self):
-        """Return the length of the diagonal of the bounding box of the scene."""
+        """Return the length of the diagonal of the bounding box of the scene.
+
+        Returns
+        -------
+        float
+            Length of the diagional of the bounding box.
+        """
         return pyvista.Box(self.bounds).length
 
     @property
     def center(self):
-        """Return the center of the bounding box around all data present in the scene."""
+        """Return the center of the bounding box around all data present in the scene.
+
+        Returns
+        -------
+        list
+            Cartesian coordinates of the center.
+
+        """
         bounds = self.bounds
         x = (bounds[1] + bounds[0])/2
         y = (bounds[3] + bounds[2])/2
@@ -258,8 +295,6 @@ class Renderer(_vtk.vtkRenderer):
         """Set the background color of this renderer."""
         self.set_background(color)
         self.Modified()
-
-    #### Everything else ####
 
     def enable_depth_peeling(self, number_of_peels=None, occlusion_ratio=None):
         """Enable depth peeling to improve rendering of translucent geometry.
@@ -279,6 +314,11 @@ class Renderer(_vtk.vtkRenderer):
             area. Initial value is 0.0, meaning rendering has to be
             exact. Greater values may speed up the rendering with
             small impact on the quality.
+
+        Returns
+        -------
+        bool
+            If depth peeling is supported.
 
         """
         if number_of_peels is None:
@@ -556,6 +596,11 @@ class Renderer(_vtk.vtkRenderer):
         opacity : int or float, optional
             Opacity of the marker.
 
+        Returns
+        -------
+        vtk.vtkOrientationMarkerWidget
+            Orientation marker widget.
+
         Examples
         --------
         Use an Arrow as the orientation widget.
@@ -641,6 +686,11 @@ class Renderer(_vtk.vtkRenderer):
             Parameters for the orientation box widget when
             ``box=True``. See the parameters of
             :func:`pyvista.create_axes_orientation_box`.
+
+        Returns
+        -------
+        vtk.vtkAxesActor
+            Axes actor.
 
         Examples
         --------
@@ -1037,6 +1087,11 @@ class Renderer(_vtk.vtkRenderer):
             See :func:`Renderer.show_bounds` for additional keyword
             arguments.
 
+        Returns
+        -------
+        vtk.vtkAxesActor
+            Bounds actor.
+
         """
         kwargs.setdefault('grid', 'back')
         kwargs.setdefault('location', 'outer')
@@ -1108,13 +1163,18 @@ class Renderer(_vtk.vtkRenderer):
             Reset camera position when ``True`` to include all actors.
 
         outline : bool
-            Default is ``True``. when ``False``, a box with faces is shown
-            with the specified culling.
+            Default is ``True``. when ``False``, a box with faces is
+            shown with the specified culling.
 
         culling : str, optional
             Does not render faces that are culled. Options are
             ``'front'`` or ``'back'``. Default is ``'front'`` for
             bounding box.
+
+        Returns
+        -------
+        vtk.vtkActor
+            VTK actor of the floor.
 
         Examples
         --------
@@ -1178,11 +1238,12 @@ class Renderer(_vtk.vtkRenderer):
         Parameters
         ----------
         face : str, optional
-            The face at which to place the plane. Options are (``'-z'``,
-            ``'-y'``, ``'-x'``, ``'+z'``, ``'+y'``, and ``'+z'``). Where the -/+
-            sign indicates on which side of the axis the plane will
-            lie.  For example, ``'-z'`` would generate a floor on the
-            XY-plane and the bottom of the scene (minimum z).
+            The face at which to place the plane. Options are
+            (``'-z'``, ``'-y'``, ``'-x'``, ``'+z'``, ``'+y'``, and
+            ``'+z'``). Where the ``-/+`` sign indicates on which side of
+            the axis the plane will lie.  For example, ``'-z'`` would
+            generate a floor on the XY-plane and the bottom of the
+            scene (minimum z).
 
         i_resolution : int, optional
             Number of points on the plane in the i direction.
@@ -1212,7 +1273,7 @@ class Renderer(_vtk.vtkRenderer):
             Enable or disable view direction lighting.  Default
             ``False``.
 
-        edge_color : str or 3 item sequence, optional
+        edge_color : str or sequence, optional
             Color of of the edges of the mesh.
 
         reset_camera : bool, optional
@@ -1228,8 +1289,14 @@ class Renderer(_vtk.vtkRenderer):
             Make this floor actor pickable in the renderer.
 
         store_floor_kwargs : bool, optional
-            Stores the kwargs used when adding this floor.  Useful
-            when updating the bounds and regenerating the floor.
+            Stores the keyword arguments used when adding this floor.
+            Useful when updating the bounds and regenerating the
+            floor.
+
+        Returns
+        -------
+        vtk.vtkActor
+            VTK actor of the floor.
 
         Examples
         --------
@@ -1563,6 +1630,7 @@ class Renderer(_vtk.vtkRenderer):
 
         self.camera.disable_parallel_projection()
         self.Modified()
+
     @property
     def parallel_projection(self):
         """Return parallel projection state of active render window.
@@ -1693,13 +1761,16 @@ class Renderer(_vtk.vtkRenderer):
         Parameters
         ----------
         xscale : float, optional
-            Scaling in the x direction.  Default is ``None``, which does not change existing scaling.
+            Scaling in the x direction.  Default is ``None``, which
+            does not change existing scaling.
 
         yscale : float, optional
-            Scaling in the y direction.  Default is ``None``, which does not change existing scaling.
+            Scaling in the y direction.  Default is ``None``, which
+            does not change existing scaling.
 
         zscale : float, optional
-            Scaling in the z direction.  Default is ``None``, which does not change existing scaling.
+            Scaling in the z direction.  Default is ``None``, which
+            does not change existing scaling.
 
         reset_camera : bool, optional
             Resets camera so all actors can be seen.  Default ``True``.
@@ -1742,6 +1813,15 @@ class Renderer(_vtk.vtkRenderer):
         ----------
         negative : bool
             View from the opposite direction.
+
+        Returns
+        -------
+        list
+            List of camera position:
+
+            * Position
+            * Focal point
+            * View up
 
         """
         focal_pt = self.center
@@ -1816,7 +1896,7 @@ class Renderer(_vtk.vtkRenderer):
         DEPRECATED: Please use ``view_isometric``.
 
         """
-        return self.view_isometric()
+        self.view_isometric()
 
     def view_isometric(self, negative=False):
         """Reset the camera to a default isometric view.
@@ -1848,7 +1928,7 @@ class Renderer(_vtk.vtkRenderer):
         position = self.get_default_cam_pos(negative=negative)
         self.camera_position = CameraPosition(*position)
         self.camera_set = negative
-        return self.reset_camera()
+        self.reset_camera()
 
     def view_vector(self, vector, viewup=None):
         """Point the camera in the direction of the given vector.
@@ -1883,7 +1963,7 @@ class Renderer(_vtk.vtkRenderer):
         viewup = np.array([0,1,0])
         if negative:
             vec *= -1
-        return self.view_vector(vec, viewup)
+        self.view_vector(vec, viewup)
 
     def view_yx(self, negative=False):
         """View the YX plane.
@@ -1898,7 +1978,7 @@ class Renderer(_vtk.vtkRenderer):
         viewup = np.array([1,0,0])
         if negative:
             vec *= -1
-        return self.view_vector(vec, viewup)
+        self.view_vector(vec, viewup)
 
     def view_xz(self, negative=False):
         """View the XZ plane.
@@ -1913,7 +1993,7 @@ class Renderer(_vtk.vtkRenderer):
         viewup = np.array([0,0,1])
         if negative:
             vec *= -1
-        return self.view_vector(vec, viewup)
+        self.view_vector(vec, viewup)
 
     def view_zx(self, negative=False):
         """View the ZX plane.
@@ -1928,7 +2008,7 @@ class Renderer(_vtk.vtkRenderer):
         viewup = np.array([1,0,0])
         if negative:
             vec *= -1
-        return self.view_vector(vec, viewup)
+        self.view_vector(vec, viewup)
 
     def view_yz(self, negative=False):
         """View the YZ plane.
@@ -1943,7 +2023,7 @@ class Renderer(_vtk.vtkRenderer):
         viewup = np.array([0,0,1])
         if negative:
             vec *= -1
-        return self.view_vector(vec, viewup)
+        self.view_vector(vec, viewup)
 
     def view_zy(self, negative=False):
         """View the ZY plane.
@@ -1958,7 +2038,7 @@ class Renderer(_vtk.vtkRenderer):
         viewup = np.array([0,1,0])
         if negative:
             vec *= -1
-        return self.view_vector(vec, viewup)
+        self.view_vector(vec, viewup)
 
     def disable(self):
         """Disable this renderer's camera from being interactive."""

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -377,7 +377,7 @@ class Renderer(_vtk.vtkRenderer):
         Parameters
         ----------
         uinput : vtk.vtkMapper or vtk.vtkActor
-            vtk mapper or vtk actor to be added.
+            Vtk mapper or vtk actor to be added.
 
         reset_camera : bool, optional
             Resets the camera when true.

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -583,7 +583,7 @@ class Renderer(_vtk.vtkRenderer):
 
         box : bool, optional
             Show a box orientation marker. Use ``box_args`` to adjust.
-            See :any:`pyvista.create_axes_orientation_box` for details.
+            See :func:`pyvista.create_axes_orientation_box` for details.
 
         x_color : str, optional
             Color used for the x axis arrow.  Defaults to theme axes parameters.

--- a/pyvista/plotting/renderers.py
+++ b/pyvista/plotting/renderers.py
@@ -368,7 +368,7 @@ class Renderers():
 
         Parameters
         ----------
-        color : string or 3 item sequence, optional
+        color : str or 3 item sequence, optional
             Either a string, rgb list, or hex color string.  Defaults
             to current theme parameters.  For example:
 
@@ -377,7 +377,7 @@ class Renderers():
             * ``color=[1, 1, 1]``
             * ``color='#FFFFFF'``
 
-        top : string or 3 item sequence, optional
+        top : str or 3 item sequence, optional
             If given, this will enable a gradient background where the
             ``color`` argument is at the bottom and the color given in ``top``
             will be the color at the top of the renderer.

--- a/pyvista/plotting/renderers.py
+++ b/pyvista/plotting/renderers.py
@@ -306,7 +306,7 @@ class Renderers():
 
         Returns
         -------
-        :class:`pyvista.BackgroundRenderer`
+        pyvista.BackgroundRenderer
             Newly created background renderer.
 
         """

--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -139,7 +139,7 @@ class ScalarBars():
 
         Parameters
         ----------
-        title : string, optional
+        title : str, optional
             Title of the scalar bar.  Default ``''`` which is
             rendered as an empty title.
 
@@ -164,7 +164,7 @@ class ScalarBars():
             Sets the size of the title font.  Defaults to ``None`` and is sized
             according to :attr:`pyvista.themes.DefaultTheme.font`.
 
-        color : string or 3 item list, optional
+        color : str or 3 item list, optional
             Either a string, rgb list, or hex color string.  Default
             set by :attr:`pyvista.themes.DefaultTheme.font`.  Can be
             in one of the following formats:

--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -257,6 +257,11 @@ class ScalarBars():
             ``Plotter``, will use the plotter theme.  Setting to
             ``None`` will use the global theme.
 
+        Returns
+        -------
+        vtk.vtkScalarBarActor
+            Scalar bar actor.
+
         Notes
         -----
         Setting ``title_font_size``, or ``label_font_size`` disables

--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -257,6 +257,11 @@ class ScalarBars():
             ``Plotter``, will use the plotter theme.  Setting to
             ``None`` will use the global theme.
 
+        Notes
+        -----
+        Setting ``title_font_size``, or ``label_font_size`` disables
+        automatic font sizing for both the title and label.
+
         Examples
         --------
         Add a custom interactive scalar bar that is horizontal, has an
@@ -272,11 +277,6 @@ class ScalarBars():
         ...                            label_font_size=30,
         ...                            outline=True, fmt='%10.5f')
         >>> plotter.show()
-
-        Notes
-        -----
-        Setting ``title_font_size``, or ``label_font_size`` disables
-        automatic font sizing for both the title and label.
 
         """
         if mapper is None:

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -77,7 +77,7 @@ def system_supports_plotting():
 
     Returns
     -------
-    system_supports_plotting : bool
+    bool
         ``True`` when system supports plotting.
 
     """
@@ -89,8 +89,8 @@ def system_supports_plotting():
     return SUPPORTS_PLOTTING
 
 
-def update_axes_label_color(axes_actor, color=None):
-    """Set the axes label color (internale helper)."""
+def _update_axes_label_color(axes_actor, color=None):
+    """Set the axes label color (internal helper)."""
     if color is None:
         color = pyvista.global_theme.font.color
     color = parse_color(color)
@@ -104,13 +104,47 @@ def update_axes_label_color(axes_actor, color=None):
     elif isinstance(axes_actor, _vtk.vtkAnnotatedCubeActor):
         axes_actor.GetTextEdgesProperty().SetColor(color)
 
-    return
-
 
 def create_axes_marker(label_color=None, x_color=None, y_color=None,
                        z_color=None, xlabel='X', ylabel='Y', zlabel='Z',
                        labels_off=False, line_width=2):
-    """Return an axis actor to add in the scene."""
+    """Create an axis actor.
+
+    Parameters
+    ----------
+    label_color : str or sequence, optional
+        Unknown
+
+    x_color : str or sequence, optional
+        Color of the x axis text.
+
+    y_color : str or sequence, optional
+        Color of the y axis text.
+
+    z_color : str or sequence, optional
+        Color of the z axis text.
+
+    xlabel : str, optional
+        Text used for the x axis.
+
+    ylabel : str, optional
+        Text used for the y axis.
+
+    zlabel : str, optional
+        Text used for the z axis.
+
+    labels_off : bool, optional
+        Enable or disable the text labels for the axes.
+
+    line_width : float, optional
+        The width of the marker lines.
+
+    Returns
+    -------
+    vtk.vtkAxesActor
+        Axes actor.
+
+    """
     if x_color is None:
         x_color = pyvista.global_theme.axes.x_color
     if y_color is None:
@@ -135,7 +169,7 @@ def create_axes_marker(label_color=None, x_color=None, y_color=None,
     axes_actor.GetYAxisShaftProperty().SetLineWidth(line_width)
     axes_actor.GetZAxisShaftProperty().SetLineWidth(line_width)
 
-    update_axes_label_color(axes_actor, label_color)
+    _update_axes_label_color(axes_actor, label_color)
 
     return axes_actor
 
@@ -148,8 +182,83 @@ def create_axes_orientation_box(line_width=1, text_scale=0.366667,
                                 y_face_color='green',
                                 z_face_color='blue',
                                 color_box=False, label_color=None,
-                                labels_off=False, opacity=0.5,):
-    """Create a Box axes orientation widget with labels."""
+                                labels_off=False, opacity=0.5):
+    """Create a Box axes orientation widget with labels.
+
+    Parameters
+    ----------
+    line_width : float, optional
+        The width of the marker lines.
+
+    text_scale : float, optional
+        Size of the text relative to the faces.
+
+    edge_color : str or sequence, optional
+        Color of the edges.
+
+    x_color : str or sequence, optional
+        Color of the x axis text.
+
+    y_color : str or sequence, optional
+        Color of the y axis text.
+
+    z_color : str or sequence, optional
+        Color of the z axis text.
+
+    xlabel : str, optional
+        Text used for the x axis.
+
+    ylabel : str, optional
+        Text used for the y axis.
+
+    zlabel : str, optional
+        Text used for the z axis.
+
+    x_face_color : str or sequence, optional
+        Color used for the x axis arrow.  Defaults to theme axes
+        parameters.
+
+    y_face_color : str or sequence, optional
+        Color used for the y axis arrow.  Defaults to theme axes
+        parameters.
+
+    z_face_color : str or sequence, optional
+        Color used for the z axis arrow.  Defaults to theme axes
+        parameters.
+
+    color_box : bool, optional
+        Enable or disable the face colors.  Otherwise, box is white.
+
+    label_color : str or sequence, optional
+        Color of the labels.
+
+    labels_off : bool, optional
+        Enable or disable the text labels for the axes.
+
+    opacity : float, optional
+        Opacity in the range of ``[0, 1]`` of the orientation box.
+
+    Returns
+    -------
+    vtk.vtkAnnotatedCubeActor
+        Annotated cube actor.
+
+    Examples
+    --------
+    Create and plot an orientation box
+    >>> import pyvista
+    >>> actor = pyvista.create_axes_orientation_box(
+    ...    line_width=1, text_scale=0.53,
+    ...    edge_color='black', x_color='k',
+    ...    y_color=None, z_color=None,
+    ...    xlabel='X', ylabel='Y', zlabel='Z',
+    ...    color_box=False,
+    ...    labels_off=False, opacity=1.0)
+    >>> pl = pyvista.Plotter()
+    >>> pl.add_actor(actor)
+    >>> pl.show()  # doctest:+SKIP
+
+    """
     if x_color is None:
         x_color = pyvista.global_theme.axes.x_color
     if y_color is None:
@@ -222,7 +331,7 @@ def create_axes_orientation_box(line_width=1, text_scale=0.366667,
     else:
         actor = axes_actor
 
-    update_axes_label_color(actor, label_color)
+    _update_axes_label_color(actor, label_color)
 
     return actor
 

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -255,7 +255,7 @@ def create_axes_orientation_box(line_width=1, text_scale=0.366667,
     ...    color_box=False,
     ...    labels_off=False, opacity=1.0)
     >>> pl = pyvista.Plotter()
-    >>> pl.add_actor(actor)
+    >>> _ = pl.add_actor(actor)
     >>> pl.show()  # doctest:+SKIP
 
     """

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -21,27 +21,30 @@ class WidgetHelper:
                        outline_translation=True, pass_widget=False):
         """Add a box widget to the scene.
 
-        This is useless without a callback function. You can pass a callable
-        function that takes a single argument, the PolyData box output from
-        this widget, and performs a task with that box.
+        This is useless without a callback function. You can pass a
+        callable function that takes a single argument, the PolyData
+        box output from this widget, and performs a task with that
+        box.
 
         Parameters
         ----------
         callback : callable
-            The method called every time the box is updated. This has two
-            options: Take a single argument, the ``PolyData`` box (default) or
-            if ``use_planes=True``, then it takes a single argument of the
-            plane collection as a ``vtkPlanes`` object.
+            The method called every time the box is updated. This has
+            two options: Take a single argument, the ``PolyData`` box
+            (default) or if ``use_planes=True``, then it takes a
+            single argument of the plane collection as a ``vtkPlanes``
+            object.
 
         bounds : tuple(float)
-            Length 6 tuple of the bounding box where the widget is placed.
+            Length 6 tuple of the bounding box where the widget is
+            placed.
 
         factor : float, optional
             An inflation factor to expand on the bounds when placing.
 
         rotation_enabled : bool, optional
-            If ``False``, the box widget cannot be rotated and is strictly
-            orthogonal to the cartesian axes.
+            If ``False``, the box widget cannot be rotated and is
+            strictly orthogonal to the cartesian axes.
 
         color : str or sequence, optional
             Either a string, rgb sequence, or hex color string.
@@ -49,16 +52,21 @@ class WidgetHelper:
             <pyvista.themes._Font.color>`.
 
         use_planes : bool, optional
-            Changes the arguments passed to the callback to the planes that
-            make up the box.
+            Changes the arguments passed to the callback to the planes
+            that make up the box.
 
         outline_translation : bool, optional
-            If ``False``, the box widget cannot be translated and is strictly
-            placed at the given bounds.
+            If ``False``, the box widget cannot be translated and is
+            strictly placed at the given bounds.
 
         pass_widget : bool, optional
-            If ``True``, the widget will be passed as the last argument of the
-            callback.
+            If ``True``, the widget will be passed as the last
+            argument of the callback.
+
+        Returns
+        -------
+        vtk.vtkBoxWidget
+            Box widget.
 
         """
         if not hasattr(self, "box_widgets"):
@@ -148,6 +156,11 @@ class WidgetHelper:
             :func:`BasePlotter.add_mesh` to control how the mesh is
             displayed.
 
+        Returns
+        -------
+        vtk.vtkActor
+            VTK actor of the mesh.
+
         """
         name = kwargs.get('name', mesh.memory_address)
         rng = mesh.get_data_range(kwargs.get('scalars', None))
@@ -183,10 +196,7 @@ class WidgetHelper:
                             use_planes=True, color=widget_color,
                             outline_translation=outline_translation)
 
-        actor = self.add_mesh(box_clipped_mesh, reset_camera=False,
-                              **kwargs)
-
-        return actor
+        return self.add_mesh(box_clipped_mesh, reset_camera=False, **kwargs)
 
     def add_plane_widget(self, callback, normal='x', origin=None,
                          bounds=None, factor=1.25, color=None,
@@ -197,16 +207,17 @@ class WidgetHelper:
                          normal_rotation=True):
         """Add a plane widget to the scene.
 
-        This is useless without a callback function. You can pass a callable
-        function that takes two arguments, the normal and origin of the plane
-        in that order output from this widget, and performs a task with that
-        plane.
+        This is useless without a callback function. You can pass a
+        callable function that takes two arguments, the normal and
+        origin of the plane in that order output from this widget, and
+        performs a task with that plane.
 
         Parameters
         ----------
         callback : callable
-            The method called every time the plane is updated. Takes two
-            arguments, the normal and origin of the plane in that order.
+            The method called every time the plane is updated. Takes
+            two arguments, the normal and origin of the plane in that
+            order.
 
         normal : str or tuple(float)
             The starting normal vector of the plane.
@@ -224,39 +235,46 @@ class WidgetHelper:
             Either a string, rgb list, or hex color string.
 
         assign_to_axis : str or int, optional
-            Assign the normal of the plane to be parallel with a given axis:
-            options are ``(0, 'x')``, ``(1, 'y')``, or ``(2, 'z')``.
+            Assign the normal of the plane to be parallel with a given
+            axis: options are ``(0, 'x')``, ``(1, 'y')``, or ``(2,
+            'z')``.
 
         tubing : bool, optional
-            When using an implicit plane wiget, this controls whether or not
-            tubing is shown around the plane's boundaries.
+            When using an implicit plane wiget, this controls whether
+            or not tubing is shown around the plane's boundaries.
 
         outline_translation : bool, optional
-            If ``False``, the plane widget cannot be translated and is strictly
-            placed at the given bounds. Only valid when using an implicit
-            plane.
-
-        origin_translation : bool, optional
-            If ``False``, the plane widget cannot be translated by its origin
-            and is strictly placed at the given origin. Only valid when using
+            If ``False``, the plane widget cannot be translated and is
+            strictly placed at the given bounds. Only valid when using
             an implicit plane.
 
+        origin_translation : bool, optional
+            If ``False``, the plane widget cannot be translated by its
+            origin and is strictly placed at the given origin. Only
+            valid when using an implicit plane.
+
         implicit : bool, optional
-            When ``True``, a ``vtkImplicitPlaneWidget`` is used and when
-            ``False``, a ``vtkPlaneWidget`` is used.
+            When ``True``, a ``vtkImplicitPlaneWidget`` is used and
+            when ``False``, a ``vtkPlaneWidget`` is used.
 
         pass_widget : bool, optional
-            If ``True``, the widget will be passed as the last argument of the
-            callback.
+            If ``True``, the widget will be passed as the last
+            argument of the callback.
 
         test_callback : bool, optional
-            If ``True``, run the callback function after the widget is created.
+            If ``True``, run the callback function after the widget is
+            created.
 
         normal_rotation : bool, optional
             Set the opacity of the normal vector arrow to 0 such that
             it is effectively disabled. This prevents the user from
             rotating the normal. This is forced to ``False`` when
             ``assign_to_axis`` is set.
+
+        Returns
+        -------
+        vtk.vtkImplicitPlaneWidget or vtk.vtkPlaneWidget
+            Plane widget.
 
         """
         if not hasattr(self, "plane_widgets"):
@@ -372,7 +390,6 @@ class WidgetHelper:
             for widget in self.plane_widgets:
                 widget.Off()
             del self.plane_widgets
-        return
 
     def add_mesh_clip_plane(self, mesh, normal='x', invert=False,
                             widget_color=None, value=0.0, assign_to_axis=None,
@@ -384,8 +401,8 @@ class WidgetHelper:
         Add a mesh to the scene with a plane widget that is used to clip
         the mesh interactively.
 
-        The clipped mesh is saved to the ``.plane_clipped_meshes`` attribute on
-        the plotter.
+        The clipped mesh is saved to the ``.plane_clipped_meshes``
+        attribute on the plotter.
 
         Parameters
         ----------
@@ -411,17 +428,17 @@ class WidgetHelper:
             'z')``.
 
         tubing : bool, optional
-            When using an implicit plane wiget, this controls whether or not
-            tubing is shown around the plane's boundaries.
+            When using an implicit plane wiget, this controls whether
+            or not tubing is shown around the plane's boundaries.
 
         origin_translation : bool, optional
-            If ``False``, the plane widget cannot be translated by its origin
-            and is strictly placed at the given origin. Only valid when using
-            an implicit plane.
+            If ``False``, the plane widget cannot be translated by its
+            origin and is strictly placed at the given origin. Only
+            valid when using an implicit plane.
 
         outline_translation : bool, optional
-            If ``False``, the box widget cannot be translated and is strictly
-            placed at the given bounds.
+            If ``False``, the box widget cannot be translated and is
+            strictly placed at the given bounds.
 
         implicit : bool, optional
             When ``True``, a ``vtkImplicitPlaneWidget`` is used and
@@ -437,6 +454,11 @@ class WidgetHelper:
             All additional keyword arguments are passed to
             :func:`BasePlotter.add_mesh` to control how the mesh is
             displayed.
+
+        Returns
+        -------
+        vtk.vtkActor
+            VTK actor of the mesh.
 
         """
         name = kwargs.get('name', mesh.memory_address)
@@ -477,9 +499,7 @@ class WidgetHelper:
                               implicit=implicit, origin=mesh.center,
                               normal_rotation=normal_rotation)
 
-        actor = self.add_mesh(plane_clipped_mesh, **kwargs)
-
-        return actor
+        return self.add_mesh(plane_clipped_mesh, **kwargs)
 
     def add_mesh_slice(self, mesh, normal='x', generate_triangles=False,
                        widget_color=None, assign_to_axis=None,
@@ -506,8 +526,8 @@ class WidgetHelper:
             If this is enabled (``False`` by default), the output will be
             triangles otherwise, the output will be the intersection polygons.
 
-        widget_color : str or 3 item list, optional
-            Either a string, rgb list, or hex color string.  Defaults
+        widget_color : str or sequence, optional
+            Either a string, RGB sequence, or hex color string.  Defaults
             to ``'white'``.
 
         assign_to_axis : str or int, optional
@@ -540,6 +560,11 @@ class WidgetHelper:
             All additional keyword arguments are passed to
             :func:`BasePlotter.add_mesh` to control how the mesh is
             displayed.
+
+        Returns
+        -------
+        vtk.vtkActor
+            VTK actor of the mesh.
 
         """
         name = kwargs.get('name', mesh.memory_address)
@@ -575,9 +600,7 @@ class WidgetHelper:
                               implicit=implicit, origin=mesh.center,
                               normal_rotation=normal_rotation)
 
-        actor = self.add_mesh(plane_sliced_mesh, **kwargs)
-
-        return actor
+        return self.add_mesh(plane_sliced_mesh, **kwargs)
 
     def add_mesh_slice_orthogonal(self, mesh, generate_triangles=False,
                                   widget_color=None, tubing=False, **kwargs):
@@ -613,6 +636,11 @@ class WidgetHelper:
             :func:`BasePlotter.add_mesh` to control how the mesh is
             displayed.
 
+        Returns
+        -------
+        list
+            List of vtk.vtkActor(s).
+
         """
         actors = []
         for ax in ["x", "y", "z"]:
@@ -631,20 +659,22 @@ class WidgetHelper:
                         pass_widget=False):
         """Add a line widget to the scene.
 
-        This is useless without a callback function. You can pass a callable
-        function that takes a single argument, the PolyData line output from this
-        widget, and performs a task with that line.
+        This is useless without a callback function. You can pass a
+        callable function that takes a single argument, the PolyData
+        line output from this widget, and performs a task with that
+        line.
 
         Parameters
         ----------
         callback : callable
-            The method called every time the line is updated. This has two
-            options: Take a single argument, the ``PolyData`` line (default) or
-            if ``use_vertices=True``, then it can take two arguments of the
-            coordinates of the line's end points.
+            The method called every time the line is updated. This has
+            two options: Take a single argument, the ``PolyData`` line
+            (default) or if ``use_vertices=True``, then it can take
+            two arguments of the coordinates of the line's end points.
 
         bounds : tuple(float), optional
-            Length 6 tuple of the bounding box where the widget is placed.
+            Length 6 tuple of the bounding box where the widget is
+            placed.
 
         factor : float, optional
             An inflation factor to expand on the bounds when placing.
@@ -653,15 +683,20 @@ class WidgetHelper:
             The number of points in the line created.
 
         color : str or 3 item sequence, optional, defaults to white
-            Either a string, rgb list, or hex color string.
+            Either a string, rgb sequence, or hex color string.
 
         use_vertices : bool, optional
-            Changess the arguments of the callback method to take the end
+            Changes the arguments of the callback method to take the end
             points of the line instead of a PolyData object.
 
         pass_widget : boollist
-            If ``True``, the widget will be passed as the last argument of the
-            callback.
+            If ``True``, the widget will be passed as the last
+            argument of the callback.
+
+        Returns
+        -------
+        vtk.vtkLineWidget
+            Created line widget.
 
         """
         if not hasattr(self, "line_widgets"):
@@ -685,7 +720,6 @@ class WidgetHelper:
                 if pass_widget:
                     args.append(widget)
                 try_callback(callback, *args)
-            return
 
         line_widget = _vtk.vtkLineWidget()
         line_widget.GetLineProperty().SetColor(parse_color(color))
@@ -708,7 +742,6 @@ class WidgetHelper:
             for widget in self.line_widgets:
                 widget.Off()
             del self.line_widgets
-        return
 
     def add_text_slider_widget(self, callback, data, value=None,
                               pointa=(.4, .9), pointb=(.9, .9),
@@ -756,7 +789,7 @@ class WidgetHelper:
 
         Returns
         -------
-        slider_widget: vtk.vtkSliderWidget
+        vtk.vtkSliderWidget
             The VTK slider widget configured to display text.
 
         """
@@ -841,7 +874,7 @@ class WidgetHelper:
             The relative coordinates of the left point of the slider
             on the display port.
 
-        pointb : tuple(float)
+        pointb : tuple(float), optional
             The relative coordinates of the right point of the slider
             on the display port.
 
@@ -870,13 +903,18 @@ class WidgetHelper:
         title_opacity : float, optional
             Opacity of title. Defaults to 1.0.
 
-        title_color : str or 3 item list, optional
-            Either a string, rgb list, or hex color string.  Defaults
+        title_color : str or sequence, optional
+            Either a string, RGB sequence, or hex color string.  Defaults
             to the value given in ``color``.
 
         fmt : str, optional
             String formatter used to format numerical data. Defaults
             to ``None``.
+
+        Returns
+        -------
+        vtk.vtkSliderWidget
+            Slider widget.
 
         Examples
         --------
@@ -993,7 +1031,6 @@ class WidgetHelper:
             for widget in self.slider_widgets:
                 widget.Off()
             del self.slider_widgets
-        return
 
     def add_mesh_threshold(self, mesh, scalars=None, invert=False,
                            widget_color=None, preference='cell',
@@ -1055,6 +1092,11 @@ class WidgetHelper:
             All additional keyword arguments are passed to ``add_mesh`` to
             control how the mesh is displayed.
 
+        Returns
+        -------
+        vtk.vtkActor
+            VTK actor of the mesh.
+
         """
         if isinstance(mesh, pyvista.MultiBlock):
             raise TypeError('MultiBlock datasets are not supported for threshold widget.')
@@ -1097,9 +1139,7 @@ class WidgetHelper:
                                pointb=pointb)
 
         kwargs.setdefault("reset_camera", False)
-        actor = self.add_mesh(threshold_mesh, scalars=scalars, **kwargs)
-
-        return actor
+        self.add_mesh(threshold_mesh, scalars=scalars, **kwargs)
 
     def add_mesh_isovalue(self, mesh, scalars=None, compute_normals=False,
                           compute_gradients=False, compute_scalars=True,
@@ -1169,6 +1209,11 @@ class WidgetHelper:
             :func:`BasePlotter.add_mesh` to control how the mesh is
             displayed.
 
+        Returns
+        -------
+        vtk.vtkActor
+            VTK actor of the mesh.
+
         """
         if isinstance(mesh, pyvista.MultiBlock):
             raise TypeError('MultiBlock datasets are not supported for this widget.')
@@ -1215,9 +1260,7 @@ class WidgetHelper:
                                pointb=pointb)
 
         kwargs.setdefault("reset_camera", False)
-        actor = self.add_mesh(isovalue_mesh, scalars=scalars, **kwargs)
-
-        return actor
+        return self.add_mesh(isovalue_mesh, scalars=scalars, **kwargs)
 
     def add_spline_widget(self, callback, bounds=None, factor=1.25,
                           n_handles=5, resolution=25, color="yellow",
@@ -1237,7 +1280,7 @@ class WidgetHelper:
             :class:`pyvista.PolyData` object to the callback function of the
             generated spline.
 
-        bounds : tuple(float)
+        bounds : tuple(float), optional
             Length 6 tuple of the bounding box where the widget is placed.
 
         factor : float, optional
@@ -1251,7 +1294,7 @@ class WidgetHelper:
             The number of points in the spline created between all the handles.
 
         color : str or sequence, optional
-            Either a string, rgb list, or hex color string.
+            Either a string, RGB sequence, or hex color string.
 
         show_ribbon : bool, optional
             If ``True``, the poly plane used for slicing will also be shown.
@@ -1272,9 +1315,15 @@ class WidgetHelper:
             Make the spline a closed loop.
 
         initial_points : sequence, optional
-            The points to initialize the widget placement. Must have same
-            number of elements as ``n_handles``. If the first and last point
-            are the same, this will be a closed loop spline.
+            The points to initialize the widget placement. Must have
+            same number of elements as ``n_handles``. If the first and
+            last point are the same, this will be a closed loop
+            spline.
+
+        Returns
+        -------
+        vtk.vtkSplineWidget
+            The newly created spline widget.
 
         Notes
         -----
@@ -1402,6 +1451,11 @@ class WidgetHelper:
             :func:`BasePlotter.add_mesh` to control how the mesh is
             displayed.
 
+        Returns
+        -------
+        vtk.vtkActor
+            VTK actor of the mesh.
+
         """
         name = kwargs.get('name', mesh.memory_address)
         rng = mesh.get_data_range(kwargs.get('scalars', None))
@@ -1502,6 +1556,11 @@ class WidgetHelper:
             If ``True``, run the callback function after the widget is
             created.
 
+        Returns
+        -------
+        vtk.vtkSphereWidget
+            The sphere widget.
+
         """
         if not hasattr(self, "sphere_widgets"):
             self.sphere_widgets = []
@@ -1576,7 +1635,6 @@ class WidgetHelper:
             for widget in self.sphere_widgets:
                 widget.Off()
             del self.sphere_widgets
-        return
 
     def add_checkbox_button_widget(self, callback, value=False,
                                    position=(10., 10.), size=50, border_size=5,
@@ -1678,7 +1736,6 @@ class WidgetHelper:
             for widget in self.button_widgets:
                 widget.Off()
             del self.button_widgets
-        return
 
     def close(self):
         """Close the widgets."""

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -419,6 +419,10 @@ class WidgetHelper:
             and is strictly placed at the given origin. Only valid when using
             an implicit plane.
 
+        outline_translation : bool, optional
+            If ``False``, the box widget cannot be translated and is strictly
+            placed at the given bounds.
+
         implicit : bool, optional
             When ``True``, a ``vtkImplicitPlaneWidget`` is used and
             when ``False``, a ``vtkPlaneWidget`` is used.
@@ -518,6 +522,10 @@ class WidgetHelper:
             If ``False``, the plane widget cannot be translated by its origin
             and is strictly placed at the given origin. Only valid when using
             an implicit plane.
+
+        outline_translation : bool, optional
+            If ``False``, the box widget cannot be translated and is strictly
+            placed at the given bounds.
 
         implicit : bool, optional
             When ``True``, a ``vtkImplicitPlaneWidget`` is used and when
@@ -859,7 +867,7 @@ class WidgetHelper:
             Relative height of the title as compared to the length of
             the slider.
 
-        title_opacity : str, optional
+        title_opacity : float, optional
             Opacity of title. Defaults to 1.0.
 
         title_color : str or 3 item list, optional
@@ -1248,6 +1256,14 @@ class WidgetHelper:
         show_ribbon : bool, optional
             If ``True``, the poly plane used for slicing will also be shown.
 
+        ribbon_color : str or sequence, optional
+            Color of the ribbon.  Either a string, RGB sequence, or
+            hex color string.
+
+        ribbon_opacity : float, optional
+            Opacity of ribbon. Defaults to 1.0 and must be between
+            ``[0, 1]``.
+
         pass_widget : bool, optional
             If ``True``, the widget will be passed as the last argument of the
             callback.
@@ -1346,6 +1362,41 @@ class WidgetHelper:
             If this is enabled (``False`` by default), the output will be
             triangles otherwise, the output will be the intersection polygons.
 
+        n_handles : int, optional
+            The number of interactive spheres to control the spline's
+            parametric function.
+
+        resolution : int, optional
+            The number of points to generate on the spline.
+
+        widget_color : str or sequence, optional
+            Color of the widget.  Either a string, RGB sequence, or
+            hex color string.  For example:
+
+            * ``color='white'``
+            * ``color='w'``
+            * ``color=[1, 1, 1]``
+            * ``color='#FFFFFF'``
+
+        show_ribbon : bool, optional
+            If ``True``, the poly plane used for slicing will also be shown.
+
+        ribbon_color : str or sequence, optional
+            Color of the ribbon.  Either a string, RGB sequence, or
+            hex color string.
+
+        ribbon_opacity : float, optional
+            Opacity of ribbon. Defaults to 1.0 and must be between
+            ``[0, 1]``.
+
+        initial_points : sequence, optional
+            The points to initialize the widget placement. Must have same
+            number of elements as ``n_handles``. If the first and last point
+            are the same, this will be a closed loop spline.
+
+        closed : bool, optional
+            Make the spline a closed loop.
+
         **kwargs : dict, optional
             All additional keyword arguments are passed to
             :func:`BasePlotter.add_mesh` to control how the mesh is
@@ -1439,6 +1490,9 @@ class WidgetHelper:
 
         selected_color : str, optional
             Color of the widget when selected during interaction.
+
+        indices : sequence, optional
+            Indices to assign the sphere widgets.
 
         pass_widget : bool, optional
             If ``True``, the widget will be passed as the last

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1103,11 +1103,6 @@ class WidgetHelper:
         used to control a parametric function for building this spline. Click
         directly on the line to translate the widget.
 
-        Note
-        ----
-        This widget has trouble displaying certain colors. Use only simple
-        colors (white, black, yellow).
-
         Parameters
         ----------
         callback : callable
@@ -1145,6 +1140,11 @@ class WidgetHelper:
             The points to initialize the widget placement. Must have same
             number of elements as ``n_handles``. If the first and last point
             are the same, this will be a closed loop spline.
+
+        Notes
+        -----
+        This widget has trouble displaying certain colors. Use only simple
+        colors (white, black, yellow).
 
         """
         if initial_points is not None and len(initial_points) != n_handles:

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -481,45 +481,45 @@ class WidgetHelper:
         mesh : pyvista.DataSet
             The input dataset to add to the scene and slice
 
-        normal : str or tuple(float)
-            The starting normal vector of the plane
+        normal : str or tuple(float), optional
+            The starting normal vector of the plane.
 
-        generate_triangles: bool, optional
+        generate_triangles : bool, optional
             If this is enabled (``False`` by default), the output will be
             triangles otherwise, the output will be the intersection polygons.
 
-        widget_color : string or 3 item list, optional, defaults to white
-            Either a string, rgb list, or hex color string.
+        widget_color : string or 3 item list, optional
+            Either a string, rgb list, or hex color string.  Defaults
+            to ``'white'``.
 
-        assign_to_axis : str or int
+        assign_to_axis : str or int, optional
             Assign the normal of the plane to be parallel with a given axis:
             options are (0, 'x'), (1, 'y'), or (2, 'z').
 
-        tubing : bool
+        tubing : bool, optional
             When using an implicit plane wiget, this controls whether or not
             tubing is shown around the plane's boundaries.
 
-        outline_translation : bool
+        outline_translation : bool, optional
             If ``False``, the plane widget cannot be translated and is strictly
             placed at the given bounds. Only valid when using an implicit
             plane.
 
-        origin_translation : bool
+        origin_translation : bool, optional
             If ``False``, the plane widget cannot be translated by its origin
             and is strictly placed at the given origin. Only valid when using
             an implicit plane.
 
-        implicit : bool
+        implicit : bool, optional
             When ``True``, a ``vtkImplicitPlaneWidget`` is used and when
             ``False``, a ``vtkPlaneWidget`` is used.
 
-        normal_rotation : bool
+        normal_rotation : bool, optional
             Set the opacity of the normal vector arrow to 0 such that it is
             effectively disabled. This prevents the user from rotating the
             normal. This is forced to ``False`` when ``assign_to_axis`` is set.
 
-
-        kwargs : dict
+        kwargs : dict, optional
             All additional keyword arguments are passed to ``add_mesh`` to
             control how the mesh is displayed.
 
@@ -813,11 +813,11 @@ class WidgetHelper:
             are in ``pyvista.global_theme.slider_styles``. Defaults to
             ``None``.
 
-        title_height: float, optional
+        title_height : float, optional
             Relative height of the title as compared to the length of
             the slider.
 
-        title_opacity: str, optional
+        title_opacity : str, optional
             Opacity of title. Defaults to 1.0.
 
         title_color : string or 3 item list, optional
@@ -1223,11 +1223,11 @@ class WidgetHelper:
         mesh : pyvista.DataSet
             The input dataset to add to the scene and slice along the spline
 
-        generate_triangles: bool, optional
+        generate_triangles : bool, optional
             If this is enabled (``False`` by default), the output will be
             triangles otherwise, the output will be the intersection polygons.
 
-        kwargs : dict
+        kwargs : dict, optional
             All additional keyword arguments are passed to ``add_mesh`` to
             control how the mesh is displayed.
 
@@ -1297,7 +1297,7 @@ class WidgetHelper:
         radius : float, optional
             The radius of the sphere.
 
-        theta_resolution: int, optional
+        theta_resolution : int, optional
             Set the number of points in the longitude direction.
 
         phi_resolution : int, optional
@@ -1324,8 +1324,8 @@ class WidgetHelper:
             If ``True``, the widget will be passed as the last
             argument of the callback.
 
-        test_callback: bool, optional
-            if ``True``, run the callback function after the widget is
+        test_callback : bool, optional
+            If ``True``, run the callback function after the widget is
             created.
 
         """

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -37,26 +37,28 @@ class WidgetHelper:
             Length 6 tuple of the bounding box where the widget is placed.
 
         factor : float, optional
-            An inflation factor to expand on the bounds when placing
+            An inflation factor to expand on the bounds when placing.
 
-        rotation_enabled : bool
+        rotation_enabled : bool, optional
             If ``False``, the box widget cannot be rotated and is strictly
             orthogonal to the cartesian axes.
 
-        color : string or 3 item list, optional, defaults to white
-            Either a string, rgb list, or hex color string.
+        color : str or sequence, optional
+            Either a string, rgb sequence, or hex color string.
+            Defaults to :attr:`pyvista.global_theme.font.color
+            <pyvista.themes._Font.color>`.
 
         use_planes : bool, optional
             Changes the arguments passed to the callback to the planes that
             make up the box.
 
-        outline_translation : bool
+        outline_translation : bool, optional
             If ``False``, the box widget cannot be translated and is strictly
             placed at the given bounds.
 
-        pass_widget : bool
-            If true, the widget will be passed as the last argument of the
-            callback
+        pass_widget : bool, optional
+            If ``True``, the widget will be passed as the last argument of the
+            callback.
 
         """
         if not hasattr(self, "box_widgets"):
@@ -104,7 +106,6 @@ class WidgetHelper:
             for widget in self.box_widgets:
                 widget.Off()
             del self.box_widgets
-        return
 
     def add_mesh_clip_box(self, mesh, invert=False, rotation_enabled=True,
                           widget_color=None, outline_translation=True,
@@ -120,18 +121,32 @@ class WidgetHelper:
         Parameters
         ----------
         mesh : pyvista.DataSet
-            The input dataset to add to the scene and clip
+            The input dataset to add to the scene and clip.
 
-        invert : bool
-            Flag on whether to flip/invert the clip
+        invert : bool, optional
+            Flag on whether to flip/invert the clip.
 
-        rotation_enabled : bool
+        rotation_enabled : bool, optional
             If ``False``, the box widget cannot be rotated and is strictly
             orthogonal to the cartesian axes.
 
-        kwargs : dict
-            All additional keyword arguments are passed to ``add_mesh`` to
-            control how the mesh is displayed.
+        widget_color : str or sequence, optional
+            Color of the widget.  Either a string, RGB sequence, or
+            hex color string.  For example:
+
+            * ``color='white'``
+            * ``color='w'``
+            * ``color=[1, 1, 1]``
+            * ``color='#FFFFFF'``
+
+        outline_translation : bool, optional
+            If ``False``, the plane widget cannot be translated and is
+            strictly placed at the given bounds.
+
+        **kwargs : dict, optional
+            All additional keyword arguments are passed to
+            :func:`BasePlotter.add_mesh` to control how the mesh is
+            displayed.
 
         """
         name = kwargs.get('name', mesh.memory_address)
@@ -194,53 +209,54 @@ class WidgetHelper:
             arguments, the normal and origin of the plane in that order.
 
         normal : str or tuple(float)
-            The starting normal vector of the plane
+            The starting normal vector of the plane.
 
         origin : tuple(float)
-            The starting coordinate of the center of the place
+            The starting coordinate of the center of the place.
 
         bounds : tuple(float)
             Length 6 tuple of the bounding box where the widget is placed.
 
         factor : float, optional
-            An inflation factor to expand on the bounds when placing
+            An inflation factor to expand on the bounds when placing.
 
-        color : string or 3 item list, optional, defaults to white
+        color : str or sequence, optional
             Either a string, rgb list, or hex color string.
 
-        assign_to_axis : str or int
+        assign_to_axis : str or int, optional
             Assign the normal of the plane to be parallel with a given axis:
-            options are (0, 'x'), (1, 'y'), or (2, 'z').
+            options are ``(0, 'x')``, ``(1, 'y')``, or ``(2, 'z')``.
 
-        tubing : bool
+        tubing : bool, optional
             When using an implicit plane wiget, this controls whether or not
             tubing is shown around the plane's boundaries.
 
-        outline_translation : bool
+        outline_translation : bool, optional
             If ``False``, the plane widget cannot be translated and is strictly
             placed at the given bounds. Only valid when using an implicit
             plane.
 
-        origin_translation : bool
+        origin_translation : bool, optional
             If ``False``, the plane widget cannot be translated by its origin
             and is strictly placed at the given origin. Only valid when using
             an implicit plane.
 
-        implicit : bool
+        implicit : bool, optional
             When ``True``, a ``vtkImplicitPlaneWidget`` is used and when
             ``False``, a ``vtkPlaneWidget`` is used.
 
-        pass_widget : bool
-            If true, the widget will be passed as the last argument of the
-            callback
+        pass_widget : bool, optional
+            If ``True``, the widget will be passed as the last argument of the
+            callback.
 
-        test_callback : bool
-            If true, run the callback function after the widget is created.
+        test_callback : bool, optional
+            If ``True``, run the callback function after the widget is created.
 
-        normal_rotation : bool
-            Set the opacity of the normal vector arrow to 0 such that it is
-            effectively disabled. This prevents the user from rotating the
-            normal. This is forced to ``False`` when ``assign_to_axis`` is set.
+        normal_rotation : bool, optional
+            Set the opacity of the normal vector arrow to 0 such that
+            it is effectively disabled. This prevents the user from
+            rotating the normal. This is forced to ``False`` when
+            ``assign_to_axis`` is set.
 
         """
         if not hasattr(self, "plane_widgets"):
@@ -374,51 +390,49 @@ class WidgetHelper:
         Parameters
         ----------
         mesh : pyvista.DataSet
-            The input dataset to add to the scene and clip
+            The input dataset to add to the scene and clip.
 
-        normal : str or tuple(float)
-            The starting normal vector of the plane
+        normal : str or tuple(float), optional
+            The starting normal vector of the plane.
 
-        invert : bool
-            Flag on whether to flip/invert the clip
+        invert : bool, optional
+            Flag on whether to flip/invert the clip.
 
-        widget_color : string or 3 item list, optional, defaults to white
-            Either a string, rgb list, or hex color string.
+        widget_color : str or sequence, optional
+            Either a string, RGB list, or hex color string.
 
         value : float, optional
             Set the clipping value along the normal direction.
             The default value is 0.0.
 
-        assign_to_axis : str or int
-            Assign the normal of the plane to be parallel with a given axis:
-            options are (0, 'x'), (1, 'y'), or (2, 'z').
+        assign_to_axis : str or int, optional
+            Assign the normal of the plane to be parallel with a given
+            axis.  Options are ``(0, 'x')``, ``(1, 'y')``, or ``(2,
+            'z')``.
 
-        tubing : bool
+        tubing : bool, optional
             When using an implicit plane wiget, this controls whether or not
             tubing is shown around the plane's boundaries.
 
-        outline_translation : bool
-            If ``False``, the plane widget cannot be translated and is strictly
-            placed at the given bounds. Only valid when using an implicit
-            plane.
-
-        origin_translation : bool
+        origin_translation : bool, optional
             If ``False``, the plane widget cannot be translated by its origin
             and is strictly placed at the given origin. Only valid when using
             an implicit plane.
 
-        implicit : bool
-            When ``True``, a ``vtkImplicitPlaneWidget`` is used and when
-            ``False``, a ``vtkPlaneWidget`` is used.
+        implicit : bool, optional
+            When ``True``, a ``vtkImplicitPlaneWidget`` is used and
+            when ``False``, a ``vtkPlaneWidget`` is used.
 
-        normal_rotation : bool
-            Set the opacity of the normal vector arrow to 0 such that it is
-            effectively disabled. This prevents the user from rotating the
-            normal. This is forced to ``False`` when ``assign_to_axis`` is set.
+        normal_rotation : bool, optional
+            Set the opacity of the normal vector arrow to 0 such that
+            it is effectively disabled. This prevents the user from
+            rotating the normal. This is forced to ``False`` when
+            ``assign_to_axis`` is set.
 
-        kwargs : dict
-            All additional keyword arguments are passed to ``add_mesh`` to
-            control how the mesh is displayed.
+        **kwargs : dict, optional
+            All additional keyword arguments are passed to
+            :func:`BasePlotter.add_mesh` to control how the mesh is
+            displayed.
 
         """
         name = kwargs.get('name', mesh.memory_address)
@@ -479,7 +493,7 @@ class WidgetHelper:
         Parameters
         ----------
         mesh : pyvista.DataSet
-            The input dataset to add to the scene and slice
+            The input dataset to add to the scene and slice.
 
         normal : str or tuple(float), optional
             The starting normal vector of the plane.
@@ -488,7 +502,7 @@ class WidgetHelper:
             If this is enabled (``False`` by default), the output will be
             triangles otherwise, the output will be the intersection polygons.
 
-        widget_color : string or 3 item list, optional
+        widget_color : str or 3 item list, optional
             Either a string, rgb list, or hex color string.  Defaults
             to ``'white'``.
 
@@ -499,11 +513,6 @@ class WidgetHelper:
         tubing : bool, optional
             When using an implicit plane wiget, this controls whether or not
             tubing is shown around the plane's boundaries.
-
-        outline_translation : bool, optional
-            If ``False``, the plane widget cannot be translated and is strictly
-            placed at the given bounds. Only valid when using an implicit
-            plane.
 
         origin_translation : bool, optional
             If ``False``, the plane widget cannot be translated by its origin
@@ -519,9 +528,10 @@ class WidgetHelper:
             effectively disabled. This prevents the user from rotating the
             normal. This is forced to ``False`` when ``assign_to_axis`` is set.
 
-        kwargs : dict, optional
-            All additional keyword arguments are passed to ``add_mesh`` to
-            control how the mesh is displayed.
+        **kwargs : dict, optional
+            All additional keyword arguments are passed to
+            :func:`BasePlotter.add_mesh` to control how the mesh is
+            displayed.
 
         """
         name = kwargs.get('name', mesh.memory_address)
@@ -568,6 +578,33 @@ class WidgetHelper:
         Adds three interactive plane slicing widgets for orthogonal slicing
         along each cartesian axis.
 
+        Parameters
+        ----------
+        mesh : pyvista.DataSet
+            The input dataset to add to the scene and threshold.
+        
+        generate_triangles : bool, optional
+            If this is enabled (``False`` by default), the output will be
+            triangles otherwise, the output will be the intersection polygons.
+
+        widget_color : str or sequence, optional
+            Color of the widget.  Either a string, RGB sequence, or
+            hex color string.  For example:
+
+            * ``color='white'``
+            * ``color='w'``
+            * ``color=[1, 1, 1]``
+            * ``color='#FFFFFF'``
+
+        tubing : bool, optional
+            When using an implicit plane wiget, this controls whether or not
+            tubing is shown around the plane's boundaries.
+
+        **kwargs : dict, optional
+            All additional keyword arguments are passed to
+            :func:`BasePlotter.add_mesh` to control how the mesh is
+            displayed.
+
         """
         actors = []
         for ax in ["x", "y", "z"]:
@@ -598,25 +635,25 @@ class WidgetHelper:
             if ``use_vertices=True``, then it can take two arguments of the
             coordinates of the line's end points.
 
-        bounds : tuple(float)
+        bounds : tuple(float), optional
             Length 6 tuple of the bounding box where the widget is placed.
 
         factor : float, optional
-            An inflation factor to expand on the bounds when placing
+            An inflation factor to expand on the bounds when placing.
 
-        resolution : int
-            The number of points in the line created
+        resolution : int, optional
+            The number of points in the line created.
 
-        color : string or 3 item list, optional, defaults to white
+        color : str or 3 item sequence, optional, defaults to white
             Either a string, rgb list, or hex color string.
 
         use_vertices : bool, optional
             Changess the arguments of the callback method to take the end
             points of the line instead of a PolyData object.
 
-        pass_widget : bool
-            If true, the widget will be passed as the last argument of the
-            callback
+        pass_widget : boollist
+            If ``True``, the widget will be passed as the last argument of the
+            callback.
 
         """
         if not hasattr(self, "line_widgets"):
@@ -679,28 +716,30 @@ class WidgetHelper:
         ----------
         callback : callable
             The method called every time the slider is updated. This should take
-            a single parameter: the float value of the slider
+            a single parameter: the float value of the slider.
 
-        data: list
-            The list of possible values displayed on the slider bar
+        data : list
+            The list of possible values displayed on the slider bar.
 
         value : float, optional
-            The starting value of the slider
+            The starting value of the slider.
 
-        pointa : tuple(float)
+        pointa : tuple(float), optional
             The relative coordinates of the left point of the slider on the
-            display port
+            display port.
 
-        pointb : tuple(float)
+        pointb : tuple(float), optional
             The relative coordinates of the right point of the slider on the
-            display port
+            display port.
 
-        color : string or 3 item list, optional, defaults to white
-            Either a string, rgb list, or hex color string.
+        color : str or sequence, optional
+            Either a string, RGB list, or hex color string.  Defaults
+            to :attr:`pyvista.global_theme.font.color
+            <pyvista.themes._Font.color>`.
 
-        event_type: str
-            Either 'start', 'end' or 'always', this defines how often the
-            slider interacts with the callback.
+        event_type : str, optional
+            Either ``'start'``, ``'end'`` or ``'always'``, this
+            defines how often the slider interacts with the callback.
 
         style : str, optional
             The name of the slider style. The list of available styles
@@ -765,7 +804,8 @@ class WidgetHelper:
                           pointa=(.4, .9), pointb=(.9, .9),
                           color=None, pass_widget=False,
                           event_type='end', style=None,
-                          title_height=0.03, title_opacity=1.0, title_color=None, fmt=None):
+                          title_height=0.03, title_opacity=1.0, title_color=None,
+                          fmt=None):
         """Add a slider bar widget.
 
         This is useless without a callback function. You can pass a
@@ -795,10 +835,12 @@ class WidgetHelper:
 
         pointb : tuple(float)
             The relative coordinates of the right point of the slider
-            on the display port
+            on the display port.
 
-        color : string or 3 item list, optional
-            Either a string, rgb list, or hex color string.
+        color : str or sequence, optional
+            Either a string, RGB list, or hex color string.  Defaults
+            to :attr:`pyvista.global_theme.font.color
+            <pyvista.themes._Font.color>`.
 
         pass_widget : bool, optional
             If ``True``, the widget will be passed as the last
@@ -820,7 +862,7 @@ class WidgetHelper:
         title_opacity : str, optional
             Opacity of title. Defaults to 1.0.
 
-        title_color : string or 3 item list, optional
+        title_color : str or 3 item list, optional
             Either a string, rgb list, or hex color string.  Defaults
             to the value given in ``color``.
 
@@ -960,15 +1002,48 @@ class WidgetHelper:
         Parameters
         ----------
         mesh : pyvista.DataSet
-            The input dataset to add to the scene and threshold
+            The input dataset to add to the scene and threshold.
 
-        scalars : str
-            The string name of the scalars on the mesh to threshold and display
+        scalars : str, optional
+            The string name of the scalars on the mesh to threshold and display.
 
-        invert : bool
-            Invert/flip the threshold
+        invert : bool, optional
+            Invert (flip) the threshold.
 
-        kwargs : dict
+        widget_color : str or sequence, optional
+            Color of the widget.  Either a string, RGB sequence, or
+            hex color string.  For example:
+
+            * ``color='white'``
+            * ``color='w'``
+            * ``color=[1, 1, 1]``
+            * ``color='#FFFFFF'``
+
+        preference : str, optional
+            When ``mesh.n_points == mesh.n_cells`` and setting
+            scalars, this parameter sets how the scalars will be
+            mapped to the mesh.  Default ``'points'``, causes the
+            scalars will be associated with the mesh points.  Can be
+            either ``'points'`` or ``'cells'``.
+
+        title : str, optional
+            The string label of the slider widget.
+
+        pointa : sequence, optional
+            The relative coordinates of the left point of the slider
+            on the display port.
+
+        pointb : sequence, optional
+            The relative coordinates of the right point of the slider
+            on the display port.
+
+        continuous : bool, optional
+            If this is enabled (default is ``False``), use the continuous
+            interval ``[minimum cell scalar, maxmimum cell scalar]``
+            to intersect the threshold bound, rather than the set of
+            discrete scalar values from the vertices.
+
+        **kwargs : dict, optional
             All additional keyword arguments are passed to ``add_mesh`` to
             control how the mesh is displayed.
 
@@ -1025,22 +1100,66 @@ class WidgetHelper:
         """Create a contour of a mesh with a slider.
 
         Add a mesh to the scene with a slider widget that is used to
-        contour at an isovalue of the *point* data on the mesh interactively.
+        contour at an isovalue of the *point* data on the mesh
+        interactively.
 
-        The isovalue mesh is saved to the ``.isovalue_meshes`` attribute on
-        the plotter.
+        The isovalue mesh is saved to the ``.isovalue_meshes``
+        attribute on the plotter.
 
         Parameters
         ----------
         mesh : pyvista.DataSet
-            The input dataset to add to the scene and contour
+            The input dataset to add to the scene and contour.
 
-        scalars : str
-            The string name of the scalars on the mesh to contour and display
+        scalars : str, optional
+            The string name of the scalars on the mesh to contour and display.
 
-        kwargs : dict
-            All additional keyword arguments are passed to ``add_mesh`` to
-            control how the mesh is displayed.
+        compute_normals : bool, optional
+            Enable or disable the computation of normals.  If the
+            output data will be processed by filters that modify
+            topology or geometry, it may be wise to disable computing
+            normals.
+
+        compute_gradients : bool, optional
+            Enable or disable the computation of gradients.  If the
+            output data will be processed by filters that modify
+            topology or geometry, it may be wise to disable computing
+            gradients.
+
+        compute_scalars : bool, optional
+            Enable or disable the computation of scalars.
+
+        preference : str, optional
+            When ``mesh.n_points == mesh.n_cells`` and setting
+            scalars, this parameter sets how the scalars will be
+            mapped to the mesh.  Default ``'points'``, causes the
+            scalars will be associated with the mesh points.  Can be
+            either ``'points'`` or ``'cells'``.
+
+        title : str, optional
+            The string label of the slider widget.
+
+        pointa : sequence, optional
+            The relative coordinates of the left point of the slider
+            on the display port.
+
+        pointb : sequence
+            The relative coordinates of the right point of the slider
+            on the display port.
+
+        widget_color : str or sequence, optional
+            Color of the widget.  Either a string, RGB sequence, or
+            hex color string.  For example:
+
+            * ``color='white'``
+            * ``color='w'``
+            * ``color=[1, 1, 1]``
+            * ``color='#FFFFFF'``
+
+        **kwargs : dict, optional
+            All additional keyword arguments are passed to
+            :func:`BasePlotter.add_mesh` to control how the mesh is
+            displayed.
 
         """
         if isinstance(mesh, pyvista.MultiBlock):
@@ -1114,29 +1233,29 @@ class WidgetHelper:
             Length 6 tuple of the bounding box where the widget is placed.
 
         factor : float, optional
-            An inflation factor to expand on the bounds when placing
+            An inflation factor to expand on the bounds when placing.
 
-        n_handles : int
+        n_handles : int, optional
             The number of interactive spheres to control the spline's
             parametric function.
 
-        resolution : int
-            The number of points in the spline created between all the handles
+        resolution : int, optional
+            The number of points in the spline created between all the handles.
 
-        color : string or 3 item list, optional, defaults to white
+        color : str or sequence, optional
             Either a string, rgb list, or hex color string.
 
-        show_ribbon : bool
+        show_ribbon : bool, optional
             If ``True``, the poly plane used for slicing will also be shown.
 
-        pass_widget : bool
-            If true, the widget will be passed as the last argument of the
-            callback
+        pass_widget : bool, optional
+            If ``True``, the widget will be passed as the last argument of the
+            callback.
 
-        closed : bool
+        closed : bool, optional
             Make the spline a closed loop.
 
-        initial_points : np.ndarray
+        initial_points : sequence, optional
             The points to initialize the widget placement. Must have same
             number of elements as ``n_handles``. If the first and last point
             are the same, this will be a closed loop spline.
@@ -1221,15 +1340,16 @@ class WidgetHelper:
         Parameters
         ----------
         mesh : pyvista.DataSet
-            The input dataset to add to the scene and slice along the spline
+            The input dataset to add to the scene and slice along the spline.
 
         generate_triangles : bool, optional
             If this is enabled (``False`` by default), the output will be
             triangles otherwise, the output will be the intersection polygons.
 
-        kwargs : dict, optional
-            All additional keyword arguments are passed to ``add_mesh`` to
-            control how the mesh is displayed.
+        **kwargs : dict, optional
+            All additional keyword arguments are passed to
+            :func:`BasePlotter.add_mesh` to control how the mesh is
+            displayed.
 
         """
         name = kwargs.get('name', mesh.memory_address)
@@ -1303,7 +1423,7 @@ class WidgetHelper:
         phi_resolution : int, optional
             Set the number of points in the latitude direction.
 
-        color : string or 3 item iterable, optional
+        color : str or 3 item iterable, optional
             The color of the sphere's surface.  If multiple centers
             are passed, then this must be a list of colors.  Each
             color is either a string, rgb list, or hex color string.
@@ -1418,32 +1538,32 @@ class WidgetHelper:
         ----------
         callback : callable
             The method called every time the button is clicked. This should take
-            a single parameter: the bool value of the button
+            a single parameter: the bool value of the button.
 
-        value : bool
-            The default state of the button
+        value : bool, optional
+            The default state of the button.
 
-        position: tuple(float)
-            The absolute coordinates of the bottom left point of the button
+        position : tuple(float), optional
+            The absolute coordinates of the bottom left point of the button.
 
-        size : int
-            The size of the button in number of pixels
+        size : int, optional
+            The size of the button in number of pixels.
 
-        border_size : int
-            The size of the borders of the button in pixels
+        border_size : int, optional
+            The size of the borders of the button in pixels.
 
-        color_on : string or 3 item list, optional
-            The color used when the button is checked. Default is 'blue'
+        color_on : str or 3 item list, optional
+            The color used when the button is checked. Default is ``'blue'``.
 
-        color_off : string or 3 item list, optional
-            The color used when the button is not checked. Default is 'grey'
+        color_off : str or 3 item list, optional
+            The color used when the button is not checked. Default is ``'grey'``.
 
-        background_color : string or 3 item list, optional
-            The background color of the button. Default is 'white'
+        background_color : str or sequence, optional
+            The background color of the button. Default is ``'white'``.
 
         Returns
         -------
-        button_widget: vtk.vtkButtonWidget
+        vtk.vtkButtonWidget
             The VTK button widget configured as a checkbox button.
 
         """

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -2099,6 +2099,11 @@ class DefaultTheme(_ThemeConfig):
     def save(self, filename):
         """Serialize this theme to a json file.
 
+        Parameters
+        ----------
+        filename : str
+            Path to save the theme to.  Should end in ``'.json'``.
+
         Examples
         --------
         Export and then load back in a theme.

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -2054,6 +2054,11 @@ class DefaultTheme(_ThemeConfig):
     def load_theme(self, theme):
         """Overwrite the current theme with a theme.
 
+        Parameters
+        ----------
+        theme : pyvista.DefaultTheme
+            Theme to use to overwrite this theme.
+
         Examples
         --------
         Create a custom theme from the default theme and load it into

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1214,6 +1214,10 @@ class DefaultTheme(_ThemeConfig):
         Wireframe geometry will be drawn using hidden line removal if
         the rendering engine supports it.
 
+        See Also
+        --------
+        pyvista.BasePlotter.enable_hidden_line_removal
+
         Examples
         --------
         Enable hidden line removal.
@@ -1222,10 +1226,6 @@ class DefaultTheme(_ThemeConfig):
         >>> pyvista.global_theme.hidden_line_removal = True
         >>> pyvista.global_theme.hidden_line_removal
         True
-
-        See Also
-        --------
-        pyvista.BasePlotter.enable_hidden_line_removal
 
         """
         return self._hidden_line_removal

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -149,7 +149,14 @@ class _ThemeConfig():
         return inst
 
     def to_dict(self) -> dict:
-        """Return theme config parameters as a dictionary."""
+        """Return theme config parameters as a dictionary.
+
+        Returns
+        -------
+        dict
+            This theme parameter represented as a dictionary.
+
+        """
         # remove the first underscore in each entry
         dict_ = {}
         for key in self.__slots__:

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1214,10 +1214,6 @@ class DefaultTheme(_ThemeConfig):
         Wireframe geometry will be drawn using hidden line removal if
         the rendering engine supports it.
 
-        See Also
-        --------
-        :func:`Plotter.enable_hidden_line_removal <BasePlotter.enable_hidden_line_removal>`
-
         Examples
         --------
         Enable hidden line removal.
@@ -1226,6 +1222,11 @@ class DefaultTheme(_ThemeConfig):
         >>> pyvista.global_theme.hidden_line_removal = True
         >>> pyvista.global_theme.hidden_line_removal
         True
+
+        See Also
+        --------
+        pyvista.BasePlotter.enable_hidden_line_removal
+
         """
         return self._hidden_line_removal
 

--- a/pyvista/utilities/cells.py
+++ b/pyvista/utilities/cells.py
@@ -132,7 +132,7 @@ def generate_cell_offsets_loop(cells, cell_types):
 
     Returns
     -------
-    offset : np.ndarray (int)
+    numpy.ndarray
         Array of VTK offsets
 
     Raises
@@ -176,7 +176,7 @@ def generate_cell_offsets(cells, cell_types):
 
     Returns
     -------
-    offset : np.ndarray (int)
+    numpy.ndarray
         Array of VTK offsets
 
     Raises
@@ -232,13 +232,13 @@ def create_mixed_cells(mixed_cell_dict, nr_points=None):
 
     Returns
     -------
-    cell_types : np.ndarray (uint8)
+    cell_types : numpy.ndarray (uint8)
         Types of each cell
 
-    cell_arr : np.ndarray (int)
+    cell_arr : numpy.ndarray (int)
         VTK-cell array. Format depends if the VTK version is < 9.0 or not.
 
-    cell_offsets : np.ndarray (int)
+    cell_offsets : numpy.ndarray (int)
         Array of VTK offsets.  Only for VTK versions < 9.0
 
     Raises
@@ -327,7 +327,7 @@ def get_mixed_cells(vtkobj):
 
     Returns
     -------
-    cells_dict : dict
+    dict
         Dictionary of cells.
 
     Raises

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -16,7 +16,14 @@ import collections
 
 
 def set_error_output_file(filename):
-    """Set a file to write out the VTK errors."""
+    """Set a file to write out the VTK errors.
+
+    Parameters
+    ----------
+    filename : str
+        Path to the file to write VTK errors to.
+
+    """
     filename = os.path.abspath(os.path.expanduser(filename))
     fileOutputWindow = _vtk.vtkFileOutputWindow()
     fileOutputWindow.SetFileName(filename)

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -23,6 +23,13 @@ def set_error_output_file(filename):
     filename : str
         Path to the file to write VTK errors to.
 
+    Returns
+    -------
+    vtkFileOutputWindow
+        VTK file output window.
+    vtkOutputWindow
+        VTK output window.
+
     """
     filename = os.path.abspath(os.path.expanduser(filename))
     fileOutputWindow = _vtk.vtkFileOutputWindow()

--- a/pyvista/utilities/features.py
+++ b/pyvista/utilities/features.py
@@ -26,7 +26,7 @@ def voxelize(mesh, density=None, check_surface=True):
 
     Returns
     -------
-    :class:`pyvista.core.pointset.UnstructuredGrid`
+    pyvista.UnstructuredGrid
         Voxelized unstructured grid of the original mesh.
 
     Examples
@@ -119,15 +119,15 @@ def grid_from_sph_coords(theta, phi, r):
     Parameters
     ----------
     theta: array-like
-        Azimuthal angle in degrees [0, 360)
+        Azimuthal angle in degrees ``[0, 360]``.
     phi: array-like
-        Polar (zenith) angle in degrees [0, 180]
+        Polar (zenith) angle in degrees ``[0, 180]``.
     r: array-like
-        Distance (radius) from the point of origin
+        Distance (radius) from the point of origin.
 
     Returns
     -------
-    :class:`pyvista.StructuredGrid`
+    pyvista.StructuredGrid
         Structured grid.
 
     """
@@ -147,22 +147,22 @@ def transform_vectors_sph_to_cart(theta, phi, r, u, v, w):
 
     Parameters
     ----------
-    theta: array-like
-        Azimuthal angle in degrees [0, 360) of shape (M,)
-    phi: array-like
-        Polar (zenith) angle in degrees [0, 180] of shape (N,)
-    r: array-like
+    theta : sequence
+        Azimuthal angle in degrees ``[0, 360]`` of shape (M,)
+    phi : sequence
+        Polar (zenith) angle in degrees ``[0, 180]`` of shape (N,)
+    r : sequence
         Distance (radius) from the point of origin of shape (P,)
-    u: array-like
+    u : sequence
         X-component of the vector of shape (P, N, M)
-    v: array-like
+    v : sequence
         Y-component of the vector of shape (P, N, M)
-    w: array-like
+    w : sequence
         Z-component of the vector of shape (P, N, M)
 
     Returns
     -------
-    u_t, v_t, w_t: :class:`numpy.ndarray`
+    u_t, v_t, w_t : :class:`numpy.ndarray`
         Arrays of transformed x-, y-, z-components, respectively.
 
     """

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -180,7 +180,7 @@ def read_legacy(filename):
     Returns
     -------
     :class:`pyvista.DataSet`
-        Wrapped pyvista mesh
+        Wrapped pyvista mesh.
 
     Notes
     -----
@@ -305,7 +305,7 @@ def read(filename, attrs=None, force_ext=None, file_format=None):
     Returns
     -------
     :class:`pyvista.DataSet`
-        Wrapped pyvista mesh
+        Wrapped PyVista dataset.
 
     Examples
     --------
@@ -471,7 +471,7 @@ def read_exodus(filename,
     Returns
     -------
     :class:`pyvista.DataSet`
-        Wrapped pyvista mesh
+        Wrapped PyVista dataset.
 
     Examples
     --------
@@ -659,7 +659,7 @@ def save_meshio(filename, mesh, file_format=None, **kwargs):
         is normally inferred from the extension but this can be
         overridden.
 
-    kwargs : additional keyword arguments
+    **kwargs : dict, optional
         Additional keyword arguments.  See
         ``meshio.write_points_cells`` for more details.
 

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -182,19 +182,19 @@ def read_legacy(filename):
     :class:`pyvista.DataSet`
         Wrapped pyvista mesh
 
+    Notes
+    -----
+    Normally, you should use :func:`pyvista.read` to read in meshes
+    from file, and this reader will automatically used for ``'.vtk'``
+    and ``'.pvtk'`` files.
+
     Examples
     --------
-    Load an example mesh using the legacy reader
+    Load an example mesh using the legacy reader.
 
     >>> import pyvista
     >>> from pyvista import examples
     >>> mesh = pyvista.read_legacy(examples.uniformfile)
-
-    Notes
-    -----
-    Normally, you should use :func:`pyvista.read` to read in meshes
-    from file, and this reader will automatically used for ``'.vtk'`` and
-    ``'.pvtk'`` files.
 
     """
     filename = os.path.abspath(os.path.expanduser(str(filename)))
@@ -279,7 +279,7 @@ def read(filename, attrs=None, force_ext=None, file_format=None):
        * ``'.foam'``
 
     .. note::
-       See https://github.com/nschloe/meshio for formats supported by ``meshio``
+       See https://github.com/nschloe/meshio for formats supported by ``meshio``.
 
     Parameters
     ----------
@@ -294,7 +294,7 @@ def read(filename, attrs=None, force_ext=None, file_format=None):
         arguments passed to those calls. If you do not have any
         attributes to call, pass ``None`` as the value.
 
-    force_ext: str, optional
+    force_ext : str, optional
         If specified, the reader will be chosen by an extension which
         is different to its actual extension. For example, ``'.vts'``,
         ``'.vtu'``.

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -179,7 +179,7 @@ def read_legacy(filename):
 
     Returns
     -------
-    :class:`pyvista.DataSet`
+    pyvista.DataSet
         Wrapped pyvista mesh.
 
     Notes
@@ -304,7 +304,7 @@ def read(filename, attrs=None, force_ext=None, file_format=None):
 
     Returns
     -------
-    :class:`pyvista.DataSet`
+    pyvista.DataSet
         Wrapped PyVista dataset.
 
     Examples
@@ -397,7 +397,7 @@ def read_texture(filename, attrs=None):
 
     Returns
     -------
-    :class:`pyvista.Texture`
+    pyvista.Texture
         PyVista texture object.
 
     Examples
@@ -470,7 +470,7 @@ def read_exodus(filename,
 
     Returns
     -------
-    :class:`pyvista.DataSet`
+    pyvista.DataSet
         Wrapped PyVista dataset.
 
     Examples
@@ -541,7 +541,7 @@ def read_plot3d(filename, q_filenames=(), auto_detect=True, attrs=None):
 
     Returns
     -------
-    :class:`pyvista.MultiBlock`
+    pyvista.MultiBlock
         Data read from the file.
 
     """

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -276,10 +276,10 @@ def Sphere(radius=0.5, center=(0, 0, 0), direction=(0, 0, 1), theta_resolution=3
     center : np.ndarray or list, optional
         Center in ``[x, y, z]``.
 
-    direction : list or tuple or np.ndarray
+    direction : list or tuple or np.ndarray, optional
         Direction the top of the sphere points to in ``[x, y, z]``.
 
-    theta_resolution: int , optional
+    theta_resolution : int , optional
         Set the number of points in the longitude direction (ranging
         from ``start_theta`` to ``end_theta``).
 
@@ -446,13 +446,13 @@ def Cube(center=(0., 0., 0.), x_length=1.0, y_length=1.0,
         Center in ``[x, y, z]``.
 
     x_length : float, optional
-        length of the cube in the x-direction.
+        Length of the cube in the x-direction.
 
     y_length : float, optional
-        length of the cube in the y-direction.
+        Length of the cube in the y-direction.
 
     z_length : float, optional
-        length of the cube in the z-direction.
+        Length of the cube in the z-direction.
 
     bounds : iterable, optional
         Specify the bounding box of the cube. If given, all other arguments are
@@ -654,10 +654,10 @@ def Disc(center=(0., 0., 0.), inner=0.25, outer=0.5, normal=(0, 0, 1), r_res=1,
     normal : iterable
         Direction vector in ``[x, y, z]``. Orientation vector of the disc.
 
-    r_res: int, optional
+    r_res : int, optional
         Number of points in radial direction.
 
-    c_res: int, optional
+    c_res : int, optional
         Number of points in circumferential direction.
 
     Examples

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -62,19 +62,19 @@ def Cylinder(center=(0.0, 0.0, 0.0), direction=(1.0, 0.0, 0.0),
 
     Parameters
     ----------
-    center : list or tuple or np.ndarray
+    center : sequence, optional
         Location of the centroid in ``[x, y, z]``.
 
-    direction : list or tuple or np.ndarray
+    direction : sequence, optional
         Direction cylinder points to  in ``[x, y, z]``.
 
-    radius : float
+    radius : float, optional
         Radius of the cylinder.
 
-    height : float
+    height : float, optional
         Height of the cylinder.
 
-    resolution : int
+    resolution : int, optional
         Number of points on the circular face of the cylinder.
 
     capping : bool, optional
@@ -82,7 +82,7 @@ def Cylinder(center=(0.0, 0.0, 0.0), direction=(1.0, 0.0, 0.0),
 
     Returns
     -------
-    :class:`pyvista.PolyData`
+    pyvista.PolyData
         Cylinder surface.
 
     Examples
@@ -118,26 +118,26 @@ def CylinderStructured(radius=0.5, height=1.0,
 
     Parameters
     ----------
-    radius : float, iterable, optional
-        Radius of the cylinder. If an iterable, then describes the
+    radius : float, sequence, optional
+        Radius of the cylinder. If a sequence, then describes the
         radial coordinates of the cells as a range of values as
         specified by the ``radius``.
 
     height : float, optional
         Height of the cylinder along its Z-axis.
 
-    center : list or tuple or np.ndarray
-        Location of the centroid in ``[x, y, z]``
+    center : sequence
+        Location of the centroid in ``[x, y, z]``.
 
-    direction : list or tuple or np.ndarray
+    direction : sequence
         Direction cylinder Z-axis in ``[x, y, z]``.
 
-    theta_resolution : int
+    theta_resolution : int, optional
         Number of points on the circular face of the cylinder.
         Ignored if ``radius`` is an iterable.
 
-    z_resolution : int
-        Number of points along the height (Z-axis) of the cylinder
+    z_resolution : int, optional
+        Number of points along the height (Z-axis) of the cylinder.
 
     Examples
     --------
@@ -231,7 +231,7 @@ def Arrow(start=(0., 0., 0.), direction=(1., 0., 0.), tip_length=0.25,
 
     Returns
     -------
-    :class:`pyvista.PolyData`
+    pyvista.PolyData
         Arrow mesh.
 
     Examples
@@ -301,7 +301,7 @@ def Sphere(radius=0.5, center=(0, 0, 0), direction=(0, 0, 1), theta_resolution=3
 
     Returns
     -------
-    :class:`pyvista.PolyData`
+    pyvista.PolyData
         Sphere mesh.
 
     Examples
@@ -359,7 +359,7 @@ def Plane(center=(0, 0, 0), direction=(0, 0, 1), i_size=1, j_size=1,
 
     Returns
     -------
-    :class:`pyvista.PolyData`
+    pyvista.PolyData
         Plane mesh.
 
     Examples
@@ -401,7 +401,7 @@ def Line(pointa=(-0.5, 0., 0.), pointb=(0.5, 0., 0.), resolution=1):
 
     Returns
     -------
-    :class:`pyvista.PolyData`
+    pyvista.PolyData
         Line mesh.
 
     Examples
@@ -442,7 +442,7 @@ def Cube(center=(0., 0., 0.), x_length=1.0, y_length=1.0,
 
     Parameters
     ----------
-    center : iterable, optional
+    center : sequence, optional
         Center in ``[x, y, z]``.
 
     x_length : float, optional
@@ -454,13 +454,13 @@ def Cube(center=(0., 0., 0.), x_length=1.0, y_length=1.0,
     z_length : float, optional
         Length of the cube in the z-direction.
 
-    bounds : iterable, optional
+    bounds : sequence, optional
         Specify the bounding box of the cube. If given, all other arguments are
-        ignored. ``(xMin, xMax, yMin, yMax, zMin, zMax)``
+        ignored. ``(xMin, xMax, yMin, yMax, zMin, zMax)``.
 
     Returns
     -------
-    :class:`pyvista.PolyData`
+    pyvista.PolyData
         Mesh of the cube.
 
     Examples
@@ -493,7 +493,7 @@ def Box(bounds=(-1., 1., -1., 1., -1., 1.), level=0, quads=True):
     ----------
     bounds : iterable, optional
         Specify the bounding box of the cube.
-        ``(xMin, xMax, yMin, yMax, zMin, zMax)``
+        ``(xMin, xMax, yMin, yMax, zMin, zMax)``.
 
     level : int, optional
         Level of subdivision of the faces.
@@ -504,7 +504,7 @@ def Box(bounds=(-1., 1., -1., 1., -1., 1.), level=0, quads=True):
 
     Returns
     -------
-    :class:`pyvista.PolyData`
+    pyvista.PolyData
         Mesh of the box.
 
     Examples
@@ -562,7 +562,7 @@ def Cone(center=(0., 0., 0.), direction=(1., 0., 0.), height=1.0, radius=None,
 
     Returns
     -------
-    :class:`pyvista.PolyData`
+    pyvista.PolyData
         Cone mesh.
 
     Examples
@@ -611,7 +611,7 @@ def Polygon(center=(0., 0., 0.), radius=1, normal=(0, 0, 1), n_sides=6):
 
     Returns
     -------
-    :class:`pyvista.PolyData`
+    pyvista.PolyData
         Mesh of the polygon.
 
     Examples
@@ -727,9 +727,9 @@ def Wavelet(extent=(-10, 10, -10, 10, -10, 10), center=(0, 0, 0), maximum=255,
 
     Parameters
     ----------
-    extent : list or tuple, optional
+    extent : sequence, optional
         Set/Get the extent of the whole output image.  Default
-        ``(-10, 10, -10, 10, -10, 10)``
+        ``(-10, 10, -10, 10, -10, 10)``.
 
     center : list, optional
         Center of the wavelet.
@@ -1009,7 +1009,7 @@ def Triangle(points=None):
 
     Returns
     -------
-    :class:`pyvista.PolyData`
+    pyvista.PolyData
         Triangle mesh.
 
     Examples
@@ -1045,7 +1045,7 @@ def Rectangle(points=None):
 
     Returns
     -------
-    :class:`pyvista.PolyData`
+    pyvista.PolyData
         Rectangle mesh.
 
     Examples
@@ -1086,7 +1086,7 @@ def Circle(radius=0.5, resolution=100):
 
     Returns
     -------
-    :class:`pyvista.PolyData`
+    pyvista.PolyData
         Circle mesh.
 
     Examples

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -54,8 +54,7 @@ def translate(surf, center=[0., 0., 0.], direction=[1., 0., 0.]):
 
 
 def Cylinder(center=(0.0, 0.0, 0.0), direction=(1.0, 0.0, 0.0),
-             radius=0.5, height=1.0, resolution=100, capping=True,
-             **kwargs):
+             radius=0.5, height=1.0, resolution=100, capping=True):
     """Create the surface of a cylinder.
 
     See also :func:`pyvista.CylinderStructured`.
@@ -93,8 +92,6 @@ def Cylinder(center=(0.0, 0.0, 0.0), direction=(1.0, 0.0, 0.0),
     ...                             radius=1, height=2)
     >>> cylinder.plot(show_edges=True, line_width=5, cpos='xy')
     """
-    capping = kwargs.pop('cap_ends', capping)
-    assert_empty_kwargs(**kwargs)
     cylinderSource = _vtk.vtkCylinderSource()
     cylinderSource.SetRadius(radius)
     cylinderSource.SetHeight(height)

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -136,6 +136,11 @@ def CylinderStructured(radius=0.5, height=1.0,
     z_resolution : int, optional
         Number of points along the height (Z-axis) of the cylinder.
 
+    Returns
+    -------
+    pyvista.StructuredGrid
+        Structured cylinder.
+
     Examples
     --------
     Default structured cylinder
@@ -189,7 +194,6 @@ def CylinderStructured(radius=0.5, height=1.0,
     # Translate to given center
     grid.points -= np.array(grid.center)
     grid.points += np.array(center)
-
     return grid
 
 
@@ -657,6 +661,11 @@ def Disc(center=(0., 0., 0.), inner=0.25, outer=0.5, normal=(0, 0, 1), r_res=1,
     c_res : int, optional
         Number of points in circumferential direction.
 
+    Returns
+    -------
+    pyvista.PolyData
+        Disk mesh.
+
     Examples
     --------
     Create a disc with 50 points in the circumferential direction.
@@ -690,6 +699,11 @@ def Text3D(string, depth=0.5):
 
     depth : float, optional
         Depth of the text.  Defaults to ``0.5``.
+
+    Returns
+    -------
+    pyvista.PolyData
+        3D text mesh.
 
     Examples
     --------
@@ -758,6 +772,11 @@ def Wavelet(extent=(-10, 10, -10, 10, -10, 10), center=(0, 0, 0), maximum=255,
     subsample_rate : int, optional
         The sub-sample rate.
 
+    Returns
+    -------
+    pyvista.PolyData
+        Wavelet mesh.
+
     Examples
     --------
     >>> import pyvista
@@ -801,13 +820,13 @@ def CircularArc(pointa, pointb, center, resolution=100, negative=False):
 
     Parameters
     ----------
-    pointa : np.ndarray or list
+    pointa : sequence
         Position of the first end point.
 
-    pointb : np.ndarray or list
+    pointb : sequence
         Position of the other end point.
 
-    center : np.ndarray or list
+    center : sequence
         Center of the circle that defines the arc.
 
     resolution : int, optional
@@ -821,6 +840,11 @@ def CircularArc(pointa, pointb, center, resolution=100, negative=False):
         By setting this to ``True``, the longest angular sector is
         used instead (i.e. the negative coterminal angle to the
         shortest one).
+
+    Returns
+    -------
+    pyvista.PolyData
+        Circular arc mesh.
 
     Examples
     --------
@@ -876,24 +900,29 @@ def CircularArcFromNormal(center, resolution=100, normal=None,
 
     Parameters
     ----------
-    center : np.ndarray or list
+    center : sequence
         Center of the circle that defines the arc.
 
     resolution : int, optional
         The number of segments of the polyline that draws the arc.
         Resolution of 1 will just create a line.
 
-    normal : np.ndarray or list, optional
+    normal : sequence, optional
         The normal vector to the plane of the arc.  By default it
         points in the positive Z direction.
 
-    polar : np.ndarray or list, optional
+    polar : sequence, optional
         Starting point of the arc in polar coordinates.  By default it
         is the unit vector in the positive x direction.
 
     angle : float, optional
         Arc length (in degrees) beginning at the polar vector.  The
         direction is counterclockwise.  By default it is 90.
+
+    Returns
+    -------
+    pyvista.PolyData
+        Circular arc mesh.
 
     Examples
     --------
@@ -951,7 +980,7 @@ def Pyramid(points=None):
 
     Returns
     -------
-    :class:`pyvista.UnstructuredGrid`
+    pyvista.UnstructuredGrid
         Unstructured grid containing a single pyramid cell.
 
     Examples

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -400,7 +400,7 @@ def Line(pointa=(-0.5, 0., 0.), pointb=(0.5, 0., 0.), resolution=1):
         Number of pieces to divide line into.
 
     Returns
-    --------
+    -------
     :class:`pyvista.PolyData`
         Line mesh.
 

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -1189,7 +1189,7 @@ class ProgressMonitor():
         VTK algorithm or filter.
 
     message : str, optional
-        Mesage to display in the progress bar.
+        Message to display in the progress bar.
 
     scaling : float, optional
         Unused keyword argument.

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -87,7 +87,7 @@ def convert_array(arr, name=None, deep=False, array_type=None):
     Parameters
     ----------
     arr : np.ndarray or vtkDataArray
-        A numpy array or vtkDataArry to convert
+        A numpy array or vtkDataArry to convert.
     name : str, optional
         The name of the data array for VTK.
     deep : bool, optional
@@ -95,7 +95,7 @@ def convert_array(arr, name=None, deep=False, array_type=None):
 
     Returns
     -------
-    vtkDataArray, ndarray, or DataFrame
+    vtkDataArray, numpy.ndarray, or DataFrame
         The converted array.  If input is a :class:`numpy.ndarray` then
         returns ``vtkDataArray`` or is input is ``vtkDataArray`` then
         returns NumPy ``ndarray``.
@@ -186,7 +186,7 @@ def get_array(mesh, name, preference='cell', err=False) -> Optional[np.ndarray]:
 
     Parameters
     ----------
-    mesh : Dataset
+    mesh : pyvista.DataSet
         Dataset to get the array from.
 
     name : str
@@ -195,10 +195,10 @@ def get_array(mesh, name, preference='cell', err=False) -> Optional[np.ndarray]:
     preference : str, optional
         When scalars is specified, this is the preferred array type to
         search for in the dataset.  Must be either ``'point'``,
-        ``'cell'``, or ``'field'``
+        ``'cell'``, or ``'field'``.
 
-    err : bool
-        Boolean to control whether to throw an error if array is not present.
+    err : bool, optional
+        Whether to throw an error if array is not present.
 
     """
     if isinstance(mesh, _vtk.vtkTable):
@@ -246,7 +246,7 @@ def get_array_association(mesh, name, preference='cell', err=False) -> FieldAsso
     preference : str, optional
         When scalars is specified, this is the preferred array type to
         search for in the dataset.  Must be either ``'point'``,
-        ``'cell'``, or ``'field'``
+        ``'cell'``, or ``'field'``.
 
     err : bool, optional
         Boolean to control whether to throw an error if array is not present.
@@ -286,22 +286,22 @@ def get_array_association(mesh, name, preference='cell', err=False) -> FieldAsso
     return FieldAssociation.NONE
 
 def vtk_points(points, deep=True):
-    """Convert numpy array or array-like to a vtkPoints object.
+    """Convert numpy array or array-like to a ``vtkPoints`` object.
 
     Parameters
     ----------
-    points : np.ndarray or sequence
+    points : numpy.ndarray or sequence
         Points to convert.  Should be 1 or 2 dimensional.  Accepts a
         single point or several points.
 
     deep : bool, optional
         Perform a deep copy of the array.  Only applicable if
-        ``points`` is a ``np.ndarray``.
+        ``points`` is a :class:`numpy.ndarray`.
 
     Returns
     -------
     vtk.vtkPoints
-        vtkPoints object.
+        The vtkPoints object.
 
     Examples
     --------
@@ -347,17 +347,15 @@ def line_segments_from_points(points):
 
     Parameters
     ----------
-    points : np.ndarray
+    points : numpy.ndarray
         Points representing line segments. An even number must be
         given as every two vertices represent a single line
         segment. For example, two line segments would be represented
-        as:
-
-        ``np.array([[0, 0, 0], [1, 0, 0], [1, 0, 0], [1, 1, 0]])``
+        as ``np.array([[0, 0, 0], [1, 0, 0], [1, 0, 0], [1, 1, 0]])``.
 
     Returns
     -------
-    lines : pyvista.PolyData
+    pyvista.PolyData
         PolyData with lines and cells.
 
     Examples
@@ -391,10 +389,9 @@ def lines_from_points(points, close=False):
     Parameters
     ----------
     points : np.ndarray
-        Points representing the vertices of the connected segments. For
-        example, two line segments would be represented as:
-
-        ``np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0]])``
+        Points representing the vertices of the connected
+        segments. For example, two line segments would be represented
+        as ``np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0]])``.
 
     close : bool, optional
         If ``True``, close the line segments into a loop.
@@ -444,7 +441,7 @@ def make_tri_mesh(points, faces):
 
     Returns
     -------
-    tri_mesh : pyvista.PolyData
+    pyvista.PolyData
         PolyData instance containing the triangle mesh.
 
     Examples
@@ -632,7 +629,7 @@ def is_meshio_mesh(mesh):
 
 
 def wrap(dataset):
-    """Wrap any given VTK data object to its appropriate pyvista data object.
+    """Wrap any given VTK data object to its appropriate PyVista data object.
 
     Other formats that are supported include:
 
@@ -648,8 +645,8 @@ def wrap(dataset):
 
     Returns
     -------
-    wrapped_dataset : pyvista class
-        The `pyvista` wrapped dataset.
+    pyvista.DataSet
+        The PyVista wrapped dataset.
 
     Examples
     --------
@@ -1099,14 +1096,14 @@ def cubemap(path='', prefix='', ext='.jpg'):
 
     Parameters
     ----------
+    path : str, optional
+        Directory containing the cubemap images.
+
     prefix : str, optional
         Prefix to the filename.
 
     ext : str, optional
         The filename extension.  For example ``'.jpg'``.
-
-    path : str, optional
-        Directory containing the cubemap images.
 
     Returns
     -------

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -335,6 +335,12 @@ def get_array(mesh, name, preference='cell', err=False) -> Optional[np.ndarray]:
     err : bool, optional
         Whether to throw an error if array is not present.
 
+    Returns
+    -------
+    pyvista.pyvista_ndarray or ``None``
+        Requested array.  Return ``None`` if there is no array
+        matching the ``name`` and ``err=False``.
+
     """
     if isinstance(mesh, _vtk.vtkTable):
         arr = row_array(mesh, name)
@@ -707,13 +713,18 @@ def trans_from_matrix(matrix):  # pragma: no cover
 
 
 def array_from_vtkmatrix(matrix):
-    """Convert a vtk matrix to a ``numpy.ndarray``.
+    """Convert a vtk matrix to an array.
 
     Parameters
     ----------
     matrix : vtk.vtkMatrix3x3 or vtk.vtkMatrix4x4
         The vtk matrix to be converted to a ``numpy.ndarray``.
         Returned ndarray has shape (3, 3) or (4, 4) as appropriate.
+
+    Returns
+    -------
+    numpy.ndarray
+        Numpy array containing the data from ``matrix``.
 
     """
     if isinstance(matrix, _vtk.vtkMatrix3x3):
@@ -740,6 +751,11 @@ def vtkmatrix_from_array(array):
         Shape (3, 3) gets converted to a ``vtk.vtkMatrix3x3``, shape (4, 4)
         gets converted to a ``vtk.vtkMatrix4x4``. No other shapes are valid.
 
+    Returns
+    -------
+    vtk.vtkMatrix3x3 or vtk.vtkMatrix4x4
+        VTK matrix.
+
     """
     array = np.asarray(array)
     if array.shape == (3, 3):
@@ -755,11 +771,23 @@ def vtkmatrix_from_array(array):
     return matrix
 
 
-def is_meshio_mesh(mesh):
-    """Test if passed object is instance of ``meshio.Mesh``."""
+def is_meshio_mesh(obj):
+    """Test if passed object is instance of ``meshio.Mesh``.
+
+    Parameters
+    ----------
+    obj
+        Any object.
+
+    Returns
+    -------
+    bool
+        ``True`` if ``obj`` is an ``meshio.Mesh``.
+
+    """
     try:
         import meshio
-        return isinstance(mesh, meshio.Mesh)
+        return isinstance(obj, meshio.Mesh)
     except ImportError:
         return False
 
@@ -938,6 +966,11 @@ def is_inside_bounds(point, bounds):
 
     bounds : sequence
         Six item bounds in the form of ``(xMin, xMax, yMin, yMax, zMin, zMax)``.
+
+    Returns
+    -------
+    bool
+        ``True`` when ``point`` is inside ``bounds``.
 
     """
     if isinstance(point, (int, float)):

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -394,7 +394,7 @@ def get_array_association(mesh, name, preference='cell', err=False) -> FieldAsso
 
     Returns
     -------
-    :class:`pyvista.FieldAssociation`
+    pyvista.FieldAssociation
         Association of the array
 
     """

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -81,25 +81,24 @@ def convert_string_array(arr, name=None):
     ########################################
 
 
-def convert_array(arr, name=None, deep=0, array_type=None):
+def convert_array(arr, name=None, deep=False, array_type=None):
     """Convert a NumPy array to a vtkDataArray or vice versa.
 
     Parameters
     ----------
-    arr : np.ndarray or vtkDataArry
+    arr : np.ndarray or vtkDataArray
         A numpy array or vtkDataArry to convert
-    name : str
-        The name of the data array for VTK
-    deep : bool
-        if input is numpy array then deep copy values
+    name : str, optional
+        The name of the data array for VTK.
+    deep : bool, optional
+        If input is numpy array then deep copy values.
 
     Returns
     -------
-    vtkDataArray, ndarray, or DataFrame:
-        the converted array (if input is a NumPy ndaray then returns
-        ``vtkDataArray`` or is input is ``vtkDataArray`` then returns NumPy
-        ``ndarray``). If pdf==True and the input is ``vtkDataArry``,
-        return a pandas DataFrame.
+    vtkDataArray, ndarray, or DataFrame
+        The converted array.  If input is a :class:`numpy.ndarray` then
+        returns ``vtkDataArray`` or is input is ``vtkDataArray`` then
+        returns NumPy ``ndarray``.
 
     """
     if arr is None:

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -85,8 +85,8 @@ def convert_array(arr, name=None, deep=0, array_type=None):
     """Convert a NumPy array to a vtkDataArray or vice versa.
 
     Parameters
-    -----------
-    arr : ndarray or vtkDataArry
+    ----------
+    arr : np.ndarray or vtkDataArry
         A numpy array or vtkDataArry to convert
     name : str
         The name of the data array for VTK

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -1186,6 +1186,9 @@ def parametric_keywords(parametric_function, min_u=0, max_u=2*pi,
 
     Parameters
     ----------
+    parametric_function : vtk.vtkParametricFunction
+        Parametric function to generate mesh from.
+
     min_u : float, optional
         The minimum u-value.
 

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -997,11 +997,11 @@ def ParametricSuperToroid(ringradius=None, crosssectionradius=None,
     ----------
     ringradius : float, optional
         The radius from the center to the middle of the ring of the
-      supertoroid. Default is 1.
+        supertoroid. Default is 1.
 
     crosssectionradius : float, optional
         The radius of the cross section of ring of the supertoroid.
-      Default = 0.5.
+        Default = 0.5.
 
     xradius : float, optional
         The scaling factor for the x-axis. Default is 1.

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -161,6 +161,9 @@ def ParametricBohemianDome(a=None, **kwargs):
     a : float, optional
         Bohemian dome surface parameter.
 
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
+
     Returns
     -------
     pyvista.PolyData
@@ -190,6 +193,11 @@ def ParametricBohemianDome(a=None, **kwargs):
 
 def ParametricBour(**kwargs):
     """Generate Bour's minimal surface.
+
+    Parameters
+    ----------
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
 
     Returns
     -------
@@ -231,6 +239,9 @@ def ParametricBoy(zscale=None, **kwargs):
     zscale : float, optional
         The scale factor for the z-coordinate.
 
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
+
     Returns
     -------
     pyvista.PolyData
@@ -264,6 +275,11 @@ def ParametricCatalanMinimal(**kwargs):
     ParametricCatalanMinimal generates Catalan's minimal surface
     parametrically. This minimal surface contains the cycloid as a
     geodesic.
+
+    Parameters
+    ----------
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
 
     Returns
     -------
@@ -318,6 +334,9 @@ def ParametricConicSpiral(a=None, b=None, c=None, n=None, **kwargs):
         See the definition in Parametric surfaces referred to above.
         Default is 2.
 
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
+
     Returns
     -------
     pyvista.PolyData
@@ -361,6 +380,11 @@ def ParametricCrossCap(**kwargs):
     self-intersecting single-sided surface.  This is one possible
     image of a projective plane in three-space.
 
+    Parameters
+    ----------
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
+
     Returns
     -------
     pyvista.PolyData
@@ -401,6 +425,9 @@ def ParametricDini(a=None, b=None, **kwargs):
     b : float, optional
         The scale factor.  See the definition in Parametric surfaces
         referred to above.  Default is 0.2.
+
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
 
     Returns
     -------
@@ -453,6 +480,10 @@ def ParametricEllipsoid(xradius=None, yradius=None, zradius=None,
     zradius : float, optional
         The scaling factor for the z-axis. Default is 1.
 
+    **kwargs : dict, optional
+        See :func:`surface_from_para` and :func:`parametric_keywords`
+        for additional keyword arguments.
+
     Returns
     -------
     pyvista.PolyData
@@ -503,6 +534,11 @@ def ParametricEnneper(**kwargs):
     is a self-intersecting minimal surface possessing constant
     negative Gaussian curvature.
 
+    Parameters
+    ----------
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
+
     Returns
     -------
     pyvista.PolyData
@@ -539,6 +575,8 @@ def ParametricFigure8Klein(radius=None, **kwargs):
     ----------
     radius : float, optional
         The radius of the bottle. Default is 1.
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
 
     Returns
     -------
@@ -569,6 +607,11 @@ def ParametricFigure8Klein(radius=None, **kwargs):
 
 def ParametricHenneberg(**kwargs):
     """Generate Henneberg's minimal surface.
+
+    Parameters
+    ----------
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
 
     Returns
     -------
@@ -602,6 +645,11 @@ def ParametricKlein(**kwargs):
     bottle.  A Klein bottle is a closed surface with no interior and only one
     surface.  It is unrealisable in 3 dimensions without intersecting
     surfaces.
+
+    Parameters
+    ----------
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
 
     Returns
     -------
@@ -637,11 +685,14 @@ def ParametricKuen(deltav0=None, **kwargs):
     Parameters
     ----------
     deltav0 : float, optional
-        The value to use when V == 0.
+        The value to use when ``V == 0``.
         Default is 0.05, giving the best appearance with the default settings.
         Setting it to a value less than 0.05 extrapolates the surface
         towards a pole in the -z direction.
         Setting it to 0 retains the pole whose z-value is -inf.
+
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
 
     Returns
     -------
@@ -677,6 +728,9 @@ def ParametricMobius(radius=None, **kwargs):
     ----------
     radius : float, optional
         The radius of the Mobius strip. Default is 1.
+
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
 
     Returns
     -------
@@ -718,6 +772,9 @@ def ParametricPluckerConoid(n=None, **kwargs):
     n : int, optional
         This is the number of folds in the conoid.
 
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
+
     Returns
     -------
     pyvista.PolyData
@@ -752,6 +809,11 @@ def ParametricPseudosphere(**kwargs):
     pseudosphere is generated as a surface of revolution of the
     tractrix about it's asymptote, and is a surface of constant
     negative Gaussian curvature.
+
+    Parameters
+    ----------
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
 
     Returns
     -------
@@ -828,6 +890,9 @@ def ParametricRandomHills(numberofhills=None, hillxvariance=None,
         The scaling factor for the amplitude.
         Default is 13.
 
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
+
     Returns
     -------
     pyvista.PolyData
@@ -884,6 +949,9 @@ def ParametricRoman(radius=None, **kwargs):
     radius : float, optional
         The radius. Default is 1.
 
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
+
     Returns
     -------
     pyvista.PolyData
@@ -936,6 +1004,9 @@ def ParametricSuperEllipsoid(xradius=None, yradius=None, zradius=None,
 
     n2 : float, optional
         The "squareness" parameter in the x-y plane. Default is 1.
+
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
 
     Returns
     -------
@@ -1015,6 +1086,9 @@ def ParametricSuperToroid(ringradius=None, crosssectionradius=None,
     n2 : float, optional
         The shape of the cross section of the ring. Default is 1.
 
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
+
     Returns
     -------
     pyvista.PolyData
@@ -1071,6 +1145,9 @@ def ParametricTorus(ringradius=None, crosssectionradius=None, **kwargs):
 
     crosssectionradius : float, optional
         The radius of the cross section of ring of the torus. Default is 0.5.
+
+    **kwargs : dict, optional
+        See :func:`surface_from_para` for additional keyword arguments.
 
     Returns
     -------
@@ -1153,8 +1230,7 @@ def parametric_keywords(parametric_function, min_u=0, max_u=2*pi,
     parametric_function.SetClockwiseOrdering(clockwise)
 
 
-def surface_from_para(parametric_function, u_res=100, v_res=100,
-                      w_res=100):
+def surface_from_para(parametric_function, u_res=100, v_res=100, w_res=100):
     """Construct a mesh from a parametric function.
 
     Parameters

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -710,25 +710,24 @@ def ParametricMobius(radius=None, **kwargs):
 def ParametricPluckerConoid(n=None, **kwargs):
     """Generate Plucker's conoid surface.
 
-    ParametricPluckerConoid generates Plucker's conoid surface parametrically.
-    Plucker's conoid is a ruled surface, named after Julius Plucker. It is
-    possible to set the number of folds in this class via the parameter 'N'.
+    ParametricPluckerConoid generates Plucker's conoid surface
+    parametrically.  Plucker's conoid is a ruled surface, named after
+    Julius Plucker. It is possible to set the number of folds in this
+    class via the parameter 'n'.
 
     Parameters
     ----------
     n : int, optional
         This is the number of folds in the conoid.
 
-    vtkGetMacro(N, int);
-
     Returns
     -------
-    surf : pyvista.PolyData
-        ParametricPluckerConoid surface
+    pyvista.PolyData
+        ParametricPluckerConoid surface.
 
     Examples
     --------
-    Create a ParametricPluckerConoid mesh
+    Create a ParametricPluckerConoid mesh.
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricPluckerConoid()

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -83,7 +83,7 @@ def KochanekSpline(points, tension=None, bias=None, continuity=None, n_points=No
 
     Returns
     -------
-    :class:`pyvista.PolyData`
+    pyvista.PolyData
         Kochanek spline.
 
     Examples

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -193,7 +193,7 @@ def ParametricBour(**kwargs):
 
     Returns
     -------
-    surf : pyvista.PolyData
+    pyvista.PolyData
         ParametricBour surface.
 
     Examples
@@ -233,7 +233,7 @@ def ParametricBoy(zscale=None, **kwargs):
 
     Returns
     -------
-    surf : pyvista.PolyData
+    pyvista.PolyData
         ParametricBoy surface.
 
     Examples
@@ -267,7 +267,7 @@ def ParametricCatalanMinimal(**kwargs):
 
     Returns
     -------
-    surf : pyvista.PolyData
+    pyvista.PolyData
         ParametricCatalanMinimal surface.
 
     Example
@@ -320,7 +320,7 @@ def ParametricConicSpiral(a=None, b=None, c=None, n=None, **kwargs):
 
     Returns
     -------
-    surf : pyvista.PolyData
+    pyvista.PolyData
         ParametricConicSpiral surface
 
     Examples
@@ -363,7 +363,7 @@ def ParametricCrossCap(**kwargs):
 
     Returns
     -------
-    surf : pyvista.PolyData
+    pyvista.PolyData
         ParametricCrossCap surface.
 
     Examples
@@ -395,19 +395,17 @@ def ParametricDini(a=None, b=None, **kwargs):
     Parameters
     ----------
     a : float, optional
-        The scale factor.
-        See the definition in Parametric surfaces referred to above.
-        Default is 1.
+        The scale factor.  See the definition in Parametric surfaces
+        referred to above.  Default is 1.
 
     b : float, optional
-        The scale factor.
-        See the definition in Parametric surfaces referred to above.
-        Default is 0.2
+        The scale factor.  See the definition in Parametric surfaces
+        referred to above.  Default is 0.2.
 
     Returns
     -------
-    surf : pyvista.PolyData
-        ParametricDini surface
+    pyvista.PolyData
+        ParametricDini surface.
 
     Examples
     --------
@@ -457,8 +455,8 @@ def ParametricEllipsoid(xradius=None, yradius=None, zradius=None,
 
     Returns
     -------
-    surf : pyvista.PolyData
-        ParametricEllipsoid surface
+    pyvista.PolyData
+        ParametricEllipsoid surface.
 
     Examples
     --------
@@ -507,12 +505,12 @@ def ParametricEnneper(**kwargs):
 
     Returns
     -------
-    surf : pyvista.PolyData
-        ParametricEnneper surface
+    pyvista.PolyData
+        ParametricEnneper surface.
 
     Examples
     --------
-    Create a ParametricEnneper mesh
+    Create a ParametricEnneper mesh.
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricEnneper()
@@ -544,7 +542,7 @@ def ParametricFigure8Klein(radius=None, **kwargs):
 
     Returns
     -------
-    surf : pyvista.PolyData
+    pyvista.PolyData
         ParametricFigure8Klein surface.
 
     Examples
@@ -574,8 +572,8 @@ def ParametricHenneberg(**kwargs):
 
     Returns
     -------
-    surf : pyvista.PolyData
-        ParametricHenneberg surface
+    pyvista.PolyData
+        ParametricHenneberg surface.
 
     Examples
     --------
@@ -607,8 +605,8 @@ def ParametricKlein(**kwargs):
 
     Returns
     -------
-    surf : pyvista.PolyData
-        ParametricKlein surface
+    pyvista.PolyData
+        ParametricKlein surface.
 
     Examples
     --------
@@ -647,12 +645,12 @@ def ParametricKuen(deltav0=None, **kwargs):
 
     Returns
     -------
-    surf : pyvista.PolyData
-        ParametricKuen surface
+    pyvista.PolyData
+        ParametricKuen surface.
 
     Examples
     --------
-    Create a ParametricKuen mesh
+    Create a ParametricKuen mesh.
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricKuen()
@@ -682,12 +680,12 @@ def ParametricMobius(radius=None, **kwargs):
 
     Returns
     -------
-    surf : pyvista.PolyData
-        ParametricMobius surface
+    pyvista.PolyData
+        ParametricMobius surface.
 
     Examples
     --------
-    Create a ParametricMobius mesh
+    Create a ParametricMobius mesh.
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricMobius()
@@ -757,12 +755,12 @@ def ParametricPseudosphere(**kwargs):
 
     Returns
     -------
-    surf : pyvista.PolyData
-        ParametricPseudosphere surface
+    pyvista.PolyData
+        ParametricPseudosphere surface.
 
     Examples
     --------
-    Create a ParametricPseudosphere mesh
+    Create a ParametricPseudosphere mesh.
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricPseudosphere()
@@ -832,12 +830,12 @@ def ParametricRandomHills(numberofhills=None, hillxvariance=None,
 
     Returns
     -------
-    surf : pyvista.PolyData
-        ParametricRandomHills surface
+    pyvista.PolyData
+        ParametricRandomHills surface.
 
     Examples
     --------
-    Create a ParametricRandomHills mesh
+    Create a ParametricRandomHills mesh.
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricRandomHills()
@@ -888,12 +886,12 @@ def ParametricRoman(radius=None, **kwargs):
 
     Returns
     -------
-    surf : pyvista.PolyData
-        ParametricRoman surface
+    pyvista.PolyData
+        ParametricRoman surface.
 
     Examples
     --------
-    Create a ParametricRoman mesh
+    Create a ParametricRoman mesh.
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricRoman()
@@ -941,12 +939,12 @@ def ParametricSuperEllipsoid(xradius=None, yradius=None, zradius=None,
 
     Returns
     -------
-    surf : pyvista.PolyData
-        ParametricSuperEllipsoid surface
+    pyvista.PolyData
+        ParametricSuperEllipsoid surface.
 
     Examples
     --------
-    Create a ParametricSuperEllipsoid mesh
+    Create a ParametricSuperEllipsoid mesh.
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricSuperEllipsoid()
@@ -1019,12 +1017,12 @@ def ParametricSuperToroid(ringradius=None, crosssectionradius=None,
 
     Returns
     -------
-    surf : pyvista.PolyData
-        ParametricSuperToroid surface
+    pyvista.PolyData
+        ParametricSuperToroid surface.
 
     Examples
     --------
-    Create a ParametricSuperToroid mesh
+    Create a ParametricSuperToroid mesh.
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricSuperToroid()
@@ -1076,12 +1074,12 @@ def ParametricTorus(ringradius=None, crosssectionradius=None, **kwargs):
 
     Returns
     -------
-    surf : pyvista.PolyData
-        ParametricTorus surface
+    pyvista.PolyData
+        ParametricTorus surface.
 
     Examples
     --------
-    Create a ParametricTorus mesh
+    Create a ParametricTorus mesh.
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricTorus()

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -1250,6 +1250,11 @@ def surface_from_para(parametric_function, u_res=100, v_res=100, w_res=100):
     w_res : int, optional
         Resolution in the w direction.
 
+    Returns
+    -------
+    pyvista.PolyData
+        Surface from the parametric function.
+
     """
     # convert to a mesh
     para_source = _vtk.vtkParametricFunctionSource()

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -64,8 +64,8 @@ def get_reader(filename):
 
     Returns
     -------
-    :class:`pyvista.BaseReader`
-        A subclass of `pyvista.BaseReader` is returned based on file type.
+    pyvista.BaseReader
+        A subclass of :class:`pyvista.BaseReader` is returned based on file type.
 
     Examples
     --------
@@ -145,7 +145,7 @@ class BaseReader:
 
         Returns
         -------
-        :class:`pyvista.DataSet`
+        pyvista.DataSet
             PyVista Dataset.
         """
         self._update()

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -295,7 +295,7 @@ class PointCellDataSelection:
         Parameters
         ----------
         name: str
-            Cell array name
+            Cell array name.
 
         """
         self.reader.SetCellArrayStatus(name, 1)
@@ -306,7 +306,7 @@ class PointCellDataSelection:
         Parameters
         ----------
         name: str
-            Cell array name
+            Cell array name.
 
         """
         self.reader.SetCellArrayStatus(name, 0)
@@ -317,6 +317,7 @@ class PointCellDataSelection:
         Parameters
         ----------
         name: str
+            Cell array name.
 
         Returns
         -------
@@ -373,7 +374,8 @@ class XMLRectilinearGridReader(BaseReader, PointCellDataSelection):
     >>> reader = pyvista.get_reader(filename)
     >>> mesh = reader.read()
     >>> sliced_mesh = mesh.slice('y')
-    >>> sliced_mesh.plot(scalars='Void Volume Fraction', cpos='xz', show_scalar_bar=False)
+    >>> sliced_mesh.plot(scalars='Void Volume Fraction', cpos='xz',
+    ...                  show_scalar_bar=False)
 
     """
 

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -142,7 +142,7 @@ class BaseReader:
         Returns
         -------
         :class:`pyvista.DataSet`
-
+            PyVista Dataset.
         """
         self._update()
         data = wrap(self.reader.GetOutputDataObject(0))
@@ -212,8 +212,8 @@ class PointCellDataSelection:
 
         Parameters
         ----------
-        name: str
-            Point array name
+        name : str
+            Point array name.
 
         """
         self.reader.SetPointArrayStatus(name, 1)
@@ -223,8 +223,8 @@ class PointCellDataSelection:
 
         Parameters
         ----------
-        name: str
-            Point array name
+        name : str
+            Point array name.
 
         """
         self.reader.SetPointArrayStatus(name, 0)
@@ -234,12 +234,13 @@ class PointCellDataSelection:
 
         Parameters
         ----------
-        name: str
-            Point array name
+        name : str
+            Point array name.
 
         Returns
         -------
         bool
+            Whether reading the cell array is enabled.
 
         """
         if self.reader.GetPointArrayStatus(name):
@@ -294,7 +295,7 @@ class PointCellDataSelection:
 
         Parameters
         ----------
-        name: str
+        name : str
             Cell array name.
 
         """
@@ -305,7 +306,7 @@ class PointCellDataSelection:
 
         Parameters
         ----------
-        name: str
+        name : str
             Cell array name.
 
         """
@@ -316,12 +317,13 @@ class PointCellDataSelection:
 
         Parameters
         ----------
-        name: str
+        name : str
             Cell array name.
 
         Returns
         -------
         bool
+            Whether reading the cell array is enabled.
 
         """
         if self.reader.GetCellArrayStatus(name):

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -100,7 +100,11 @@ class BaseReader:
     and allowing access to the underlying vtk reader. See
     :func:`pyvista.get_reader` for an example using
     a built-in subclass.
-    
+
+    Parameters
+    ----------
+    filename : str
+        Path of the file to read.
     """
 
     _class_reader: Any = None

--- a/pyvista/utilities/regression.py
+++ b/pyvista/utilities/regression.py
@@ -56,20 +56,20 @@ def compare_images(im1, im2, threshold=1, use_vtk=True):
 
     Parameters
     ----------
-    im1 : filename, np.ndarray, vtkRenderWindow, or vtkImageData
+    im1 : filename, numpy.ndarray, vtkRenderWindow, or vtkImageData
         Render window, numpy array representing the output of a render
-        window, or ``vtkImageData``
+        window, or ``vtkImageData``.
 
-    im2 : filename, np.ndarray, vtkRenderWindow, or vtkImageData
+    im2 : filename, numpy.ndarray, vtkRenderWindow, or vtkImageData
         Render window, numpy array representing the output of a render
-        window, or ``vtkImageData``
+        window, or ``vtkImageData``.
 
-    threshold : int
+    threshold : int, optional
         Threshold tolerance for pixel differences.  This should be
         greater than 0, otherwise it will always return an error, even
         on identical images.
 
-    use_vtk : bool
+    use_vtk : bool, optional
         When disabled, computes the mean pixel error over the entire
         image using numpy.  The difference between pixel is calculated
         for each RGB channel, summed, and then divided by the number
@@ -78,7 +78,7 @@ def compare_images(im1, im2, threshold=1, use_vtk=True):
 
     Returns
     -------
-    error : float
+    float
         Total error between the images if using ``use_vtk=True``, and
         the mean pixel error when ``use_vtk=False``.
 

--- a/pyvista/utilities/transformations.py
+++ b/pyvista/utilities/transformations.py
@@ -227,7 +227,7 @@ def apply_transformation_to_points(transformation, points, inplace=False):
 
     Returns
     -------
-    new_points : np.ndarray
+    numpy.ndarray
         Transformed points.
 
     Examples

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -10,6 +10,7 @@ lxml
 matplotlib
 mypy
 mypy-extensions
+numpydoc
 panel
 param==1.10.1  # due to panel bug
 pydata-sphinx-theme

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -10,7 +10,7 @@ lxml
 matplotlib
 mypy
 mypy-extensions
-numpydoc
+https://github.com/numpy/numpydoc/archive/main.zip  # need latest
 panel
 param==1.10.1  # due to panel bug
 pydata-sphinx-theme


### PR DESCRIPTION
### Use numpydoc

This PR switches our docstring build to use `numpydoc` rather than `sphinx.ext.napoleon`.  This decision was made based on a variety of factors:

- Eventual inclusion of the `pyvista-plot` directive into `numpydoc`.  It's easier to do with `numpydoc` and it's more likely that the PR will be merged.
- Better parameters hyperlinks with `numpydoc_xref_param_type`.
- Includes `matplotlib` plots in examples.  We can add those in now.
- Can enable `numpydoc_validation_checks`.  This will be really useful for encouraging good documentation beyond the basic checks we have right now.

#### Comparison (`numpydoc` (new) left,  `sphinx.ext.napoleon` (old) right)
![sc_sphinx](https://user-images.githubusercontent.com/11981631/131078689-92af5176-2870-4951-b462-5f2abdf3e04b.png)


Further down:
![sc_both](https://user-images.githubusercontent.com/11981631/131078893-811d6068-9601-4998-8130-11a5ec8ceafe.png)

As you can see, `numpydoc` is doing a much better job picking up on class links, even though we didn't specify the `:class:` directive for these.  Furthermore, the docs are more spread out (which I personally prefer) versus the less compressed in `sphinx.ext.napoleon`.

#### Additional Changes
`numpydoc` is less forgiving with docstrings compared with `napoleon`, which is good and bad depending on your perspective.

- Simplified directive monkey patch.  Still not perfect, but this is cleaner.
- Cleaned up the `See Also` and `Notes` sections
- Fixed section heading lengths
- `numpydoc` requires `doctest: +SKIP` to be `doctest:+SKIP`.  Interestingly, we used both.
- Fixed some indentations

#### Enabled Validation Checks
-  ~~GL01~~ No plan to enable.  See https://github.com/numpy/numpydoc/issues/241
- ~~GL02~~ No plan to enable.  Can discuss.
- ~~GL03~~ Needs discussion.
- GL05: Tabs found at the start of line.  We already meet this requirement.
- GL06: Found unknown section.  We used a `Warning` section.  That's been replaced with the `warning::` directive.
- GL07: Sections are in the wrong order.  Easy fix.
- PR04: Parameter has no type.  This was a common error caused by no space between the parameter and `:`
- PR07: Parameter has no description.  Rare, cleaned up
- PR08: Parameter description should start with a capital letter. Rare, cleaned up.

Would really like to implement:
- EX01: No examples section found
