### PR TITLE
add ghost points

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1651,6 +1651,7 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
         >>> x, y, z = np.meshgrid(x, y, z)
         >>> grid = pv.StructuredGrid(x, y, z)
         >>> grid.hide_cells(range(79*30, 79*50))
+        >>> grid.plot(color=True, show_edges=True)
         """
         if isinstance(ind, np.ndarray):
             if ind.dtype == np.bool_ and ind.size != self.n_cells:
@@ -1666,6 +1667,47 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
         # have no effect
 
         self.cell_data[_vtk.vtkDataSetAttributes.GhostArrayName()] = ghost_cells
+
+    def hide_points(self, ind):
+        """Hide points without deleting them.
+
+        Hides points by setting the ghost_points array to ``HIDDEN_CELL``.
+
+        Parameters
+        ----------
+        ind : iterable
+            List or array of point indices to be hidden.  The array
+            can also be a boolean array of the same size as the number
+            of points.
+
+        Examples
+        --------
+        Hide part of the middle of a structured surface.
+
+        >>> import pyvista as pv
+        >>> import numpy as np
+        >>> x = np.arange(-10, 10, 0.25)
+        >>> y = np.arange(-10, 10, 0.25)
+        >>> z = 0
+        >>> x, y, z = np.meshgrid(x, y, z)
+        >>> grid = pv.StructuredGrid(x, y, z)
+        >>> grid.hide_points(range(80*30, 80*50))
+        >>> grid.plot(color=True, show_edges=True)
+        """
+        if isinstance(ind, np.ndarray):
+            if ind.dtype == np.bool_ and ind.size != self.n_points:
+                raise ValueError('Boolean array size must match the '
+                                 f'number of points ({self.n_points})')
+        ghost_points = np.zeros(self.n_points, np.uint8)
+        ghost_points[ind] = _vtk.vtkDataSetAttributes.HIDDENPOINT
+
+        # NOTE: cells cannot be removed from a structured grid, only
+        # hidden setting ghost_points to a value besides
+        # vtk.vtkDataSetAttributes.HIDDENCELL will not hide them
+        # properly, additionally, calling self.RemoveGhostCells will
+        # have no effect
+
+        self.point_data[_vtk.vtkDataSetAttributes.GhostArrayName()] = ghost_points
 
     def _reshape_point_array(self, array):
         """Reshape point data to a 3-D matrix."""

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -72,7 +72,7 @@ class PointSet(DataSet):
 
         Parameters
         ----------
-        ind : iterable
+        ind : sequence
             Cell indices to be removed.  The array can also be a
             boolean array of the same size as the number of cells.
 
@@ -1634,7 +1634,7 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
 
         Parameters
         ----------
-        ind : iterable
+        ind : sequence
             List or array of cell indices to be hidden.  The array can
             also be a boolean array of the same size as the number of
             cells.
@@ -1666,7 +1666,8 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
         # properly, additionally, calling self.RemoveGhostCells will
         # have no effect
 
-        self.cell_data[_vtk.vtkDataSetAttributes.GhostArrayName()] = ghost_cells
+        # add but do not make active
+        self.cell_data.set_array(ghost_cells, _vtk.vtkDataSetAttributes.GhostArrayName())
 
     def hide_points(self, ind):
         """Hide points without deleting them.
@@ -1675,7 +1676,7 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
 
         Parameters
         ----------
-        ind : iterable
+        ind : sequence
             List or array of point indices to be hidden.  The array
             can also be a boolean array of the same size as the number
             of points.
@@ -1701,13 +1702,8 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
         ghost_points = np.zeros(self.n_points, np.uint8)
         ghost_points[ind] = _vtk.vtkDataSetAttributes.HIDDENPOINT
 
-        # NOTE: cells cannot be removed from a structured grid, only
-        # hidden setting ghost_points to a value besides
-        # vtk.vtkDataSetAttributes.HIDDENCELL will not hide them
-        # properly, additionally, calling self.RemoveGhostCells will
-        # have no effect
-
-        self.point_data[_vtk.vtkDataSetAttributes.GhostArrayName()] = ghost_points
+        # add but do not make active
+        self.point_data.set_array(ghost_points, _vtk.vtkDataSetAttributes.GhostArrayName())
 
     def _reshape_point_array(self, array):
         """Reshape point data to a 3-D matrix."""

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -9,14 +9,14 @@ import vtk
 import pyvista
 from pyvista import examples
 from pyvista.plotting import system_supports_plotting
+from pyvista._vtk import VTK9
 
 test_path = os.path.dirname(os.path.abspath(__file__))
-
-VTK9 = vtk.vtkVersion().GetVTKMajorVersion() >= 9
 
 # must be manually set until pytest adds parametrize with fixture feature
 HEXBEAM_CELLS_BOOL = np.ones(40, np.bool_)  # matches hexbeam.n_cells == 40
 STRUCTGRID_CELLS_BOOL = np.ones(729, np.bool_)  # struct_grid.n_cells == 729
+STRUCTGRID_POINTS_BOOL = np.ones(1000, np.bool_)  # struct_grid.n_points == 1000
 
 
 def test_volume(hexbeam):
@@ -853,13 +853,21 @@ def test_remove_cells_invalid(hexbeam):
 @pytest.mark.parametrize('ind', [range(10), np.arange(10),
                                  STRUCTGRID_CELLS_BOOL])
 def test_hide_cells(ind, struct_grid):
-    sgrid_copy = struct_grid.copy()
-    sgrid_copy.hide_cells(ind)
-    assert sgrid_copy.HasAnyBlankCells()
+    struct_grid.hide_cells(ind)
+    assert struct_grid.HasAnyBlankCells()
 
     with pytest.raises(ValueError, match='Boolean array size must match'):
-        sgrid_copy.hide_cells(np.ones(10, dtype=np.bool))
+        struct_grid.hide_cells(np.ones(10, dtype=np.bool))
 
+
+@pytest.mark.parametrize('ind', [range(10), np.arange(10),
+                                 STRUCTGRID_POINTS_BOOL])
+def test_hide_points(ind, struct_grid):
+    struct_grid.hide_points(ind)
+    assert struct_grid.HasAnyBlankPoints()
+
+    with pytest.raises(ValueError, match='Boolean array size must match'):
+        struct_grid.hide_points(np.ones(10, dtype=np.bool))
 
 
 @pytest.mark.skipif(not VTK9, reason='VTK 9 or higher is required')


### PR DESCRIPTION
This PR addresses https://github.com/pyvista/pyvista-support/issues/489

The issue is points are being hidden by setting them to `np.nan` when applying the `warp_by_scalar` filter.  It is preferable to have these points not scaled and instead "hidden". 
