### PR TITLE
Use generic interactor

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -301,8 +301,6 @@ jobs:
 
   # run this three times since VTK9 fails to close render windows
   - script: |
-      make -C doc phtml || true  # will fail on VTK9
-      make -C doc phtml || true  # need it again due to all our docstring examples
       make -C doc phtml -b coverage SPHINXOPTS="-W"
       cat doc/_build/coverage/python.txt
     displayName: 'Build documentation'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -299,7 +299,6 @@ jobs:
       path: '$(Build.SourcesDirectory)/doc/examples'
     displayName: Build pyvista doc examples cache
 
-  # run this three times since VTK9 fails to close render windows
   - script: |
       make -C doc phtml -b coverage SPHINXOPTS="-W"
       cat doc/_build/coverage/python.txt

--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -151,6 +151,7 @@ if VTK9:
                                                    vtkAnnotatedCubeActor,
                                                    vtkLegendBoxActor,
                                                    vtkCubeAxesActor)
+    from vtkmodules.vtkRenderingUI import vtkGenericRenderWindowInteractor
     from vtkmodules.vtkRenderingCore import (vtkTexture,
                                              vtkSkybox,
                                              vtkPropAssembly,

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1940,12 +1940,12 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         Examples
         --------
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
-        >>> grid.hide_cells(range(80, 120))  # doctest:+SKIP
-        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest:+SKIP
+        >>> grid = examples.load_explicit_structured()
+        >>> _ = grid.hide_cells(range(80, 120), inplace=True)
+        >>> grid.plot(color='w', show_edges=True, show_bounds=True)
 
-        >>> grid.show_cells()  # doctest:+SKIP
-        >>> grid.plot(color='w', show_edges=True, show_bounds=True)  # doctest:+SKIP
+        >>> _ = grid.show_cells(inplace=True)
+        >>> grid.plot(color='w', show_edges=True, show_bounds=True)
 
         """
         if inplace:

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4471,9 +4471,16 @@ class Plotter(BasePlotter):
 
         if self.off_screen:
             self.ren_win.SetOffScreenRendering(1)
+            # vtkGenericRenderWindowInteractor has no event loop and
+            # allows the display client to close on Linux when
+            # off_screen
+            interactor = _vtk.vtkGenericRenderWindowInteractor()
+        else:
+            interactor = None
 
         # Add ren win and interactor
-        self.iren = RenderWindowInteractor(self, light_follow_camera=False)
+        self.iren = RenderWindowInteractor(self, light_follow_camera=False,
+                                           interactor=interactor)
         self.iren.set_render_window(self.ren_win)
         self.enable_trackball_style()  # internally calls update_style()
         self.iren.add_observer("KeyPressEvent", self.key_press_event)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4473,7 +4473,9 @@ class Plotter(BasePlotter):
             self.ren_win.SetOffScreenRendering(1)
             # vtkGenericRenderWindowInteractor has no event loop and
             # allows the display client to close on Linux when
-            # off_screen
+            # off_screen.  We still want an interactor for off screen
+            # plotting since there are some widgets (like the axes
+            # widget) that need an interactor
             interactor = _vtk.vtkGenericRenderWindowInteractor()
         else:
             interactor = None


### PR DESCRIPTION
This PR is an attempt to use the generic window interactor when plotting off screen.  The `vtkGenericRenderWindowInteractor` does not have an event loop, which appears to be why the display isn't closing.
