### PR TITLE
use pandas template to avoid nested links

### DIFF
--- a/doc/_templates/sidebar-nav-bs.html
+++ b/doc/_templates/sidebar-nav-bs.html
@@ -1,0 +1,9 @@
+<nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
+  <div class="bd-toc-item active">
+    {% if pagename.startswith("api") %}
+    {{ generate_nav_html("sidebar", maxdepth=4, collapse=True, includehidden=True, titles_only=True) }}
+    {% else %}
+    {{ generate_nav_html("sidebar", maxdepth=4, collapse=False, includehidden=True, titles_only=True) }}
+    {% endif %}
+  </div>
+</nav>


### PR DESCRIPTION
### Overview

This PR provides a 3x speedup to our docbuild by using the `sidebar-nav-bs.html` from `pandas`.  The trick is to avoid nested links in our API documentation as avoiding this causes a ``O(n**2)`` scaling with our link build time.

