### PR TITLE
Update intersphinx action

### DIFF
--- a/.github/workflows/intersphinx-update-pull-request.yml
+++ b/.github/workflows/intersphinx-update-pull-request.yml
@@ -1,0 +1,18 @@
+name: Update Local Intersphinx Mappings
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 1 * *"
+
+
+jobs:
+  intersphinx_update:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: curl
+      uses: wei/curl@v1
+      with:
+        args: https://docs.python.org/dev/objects.inv --output intersphinx/python-inv.txt
+    - uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/intersphinx-update-pull-request.yml
+++ b/.github/workflows/intersphinx-update-pull-request.yml
@@ -34,3 +34,4 @@ jobs:
         body: |
           Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
           These changes update all the intersphinx mappings. To run CI close and reopen PR.
+        title: "Automated PR: Update Local Intersphinx"

--- a/.github/workflows/intersphinx-update-pull-request.yml
+++ b/.github/workflows/intersphinx-update-pull-request.yml
@@ -11,8 +11,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: curl
-      uses: wei/curl@v1
+
+    - name: python
+      run: curl https://docs.python.org/dev/objects.inv > doc/intersphinx/python-inv.txt
+    - name: scipy
+      run: curl https://docs.scipy.org/doc/scipy/reference/objects.inv > doc/intersphinx/scipy-inv.txt
+    - name: numpy
+      run: curl https://numpy.org/devdocs/objects.inv > doc/intersphinx/numpy-inv.txt
+    - name: matplotlib
+      run: curl https://matplotlib.org/stable/objects.inv > doc/intersphinx/matplotlib-inv.txt
+    - name: imageio
+      run: curl https://imageio.readthedocs.io/en/stable/objects.inv > doc/intersphinx/imageio-inv.txt
+    - name: pandas
+      run: curl https://pandas.pydata.org/pandas-docs/stable/objects.inv > doc/intersphinx/pandas-inv.txt
+    - name: pytest
+      run: curl https://docs.pytest.org/en/stable/objects.inv > doc/intersphinx/pytest-inv.txt
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
       with:
-        args: https://docs.python.org/dev/objects.inv --output intersphinx/python-inv.txt
-    - uses: peter-evans/create-pull-request@v3
+        commit-message: "[create-pull-request] update local intersphinx"
+        body: |
+          Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
+          These changes update all the intersphinx mappings. To run CI close and reopen PR.


### PR DESCRIPTION
### Overview

This PR adds an action that either runs on demand or on a monthly schedule to update all the local intersphinx documents.

GitHub does not allow a PR created from an action to run other actions using the default GITHUB_TOKEN.  It would be required to close and then reopen the PR to get the CI to run.  There are [other options](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs) including using a Personal Access Token. In my view, all the options require some downsides, some of which are security related.  The downside to closing and reopening a PR is a small one IMO.

### Details

Is there a reason we are using the devdocs for numpy?  Should we change to use the regular documentation?
