### PR TITLE
Use numpy stable documentation for intersphinx

### DIFF
--- a/.github/workflows/intersphinx-update-pull-request.yml
+++ b/.github/workflows/intersphinx-update-pull-request.yml
@@ -17,7 +17,7 @@ jobs:
     - name: scipy
       run: curl https://docs.scipy.org/doc/scipy/reference/objects.inv > doc/intersphinx/scipy-inv.txt
     - name: numpy
-      run: curl https://numpy.org/devdocs/objects.inv > doc/intersphinx/numpy-inv.txt
+      run: curl https://numpy.org/doc/stable/objects.inv > doc/intersphinx/numpy-inv.txt
     - name: matplotlib
       run: curl https://matplotlib.org/stable/objects.inv > doc/intersphinx/matplotlib-inv.txt
     - name: imageio

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -163,7 +163,7 @@ add_module_names = False
 intersphinx_mapping = {
     'python': ('https://docs.python.org/dev', (None, 'intersphinx/python-inv.txt')),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', (None, 'intersphinx/scipy-inv.txt')),
-    'numpy': ('https://numpy.org/devdocs', (None, 'intersphinx/numpy-inv.txt')),
+    'numpy': ('https://numpy.org/doc/stable', (None, 'intersphinx/numpy-inv.txt')),
     'matplotlib': ('https://matplotlib.org/stable', (None, 'intersphinx/matplotlib-inv.txt')),
     'imageio': ('https://imageio.readthedocs.io/en/stable', (None, 'intersphinx/imageio-inv.txt')),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable', (None, 'intersphinx/pandas-inv.txt')),


### PR DESCRIPTION
### Overview
This PR switches the documentation to use the stable documentation from numpy rather than the devdocs.

