### PR TITLE
Add anti-aliasing to theme settings

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -257,6 +257,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if self.theme.hidden_line_removal:
             self.enable_hidden_line_removal()
 
+        # set antialiasing based on theme
+        if self.theme.antialiasing:
+            self.enable_anti_aliasing()
+
     @property
     def theme(self):
         """Return or set the theme used for this plotter.

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1150,6 +1150,7 @@ class DefaultTheme(_ThemeConfig):
                  '_slider_styles',
                  '_return_cpos',
                  '_hidden_line_removal',
+                 '_antialiasing',
     ]
 
     def __init__(self):
@@ -1213,6 +1214,7 @@ class DefaultTheme(_ThemeConfig):
         self._slider_styles = _SliderConfig()
         self._return_cpos = True
         self._hidden_line_removal = False
+        self._antialiasing = False
 
     @property
     def hidden_line_removal(self) -> bool:
@@ -1821,6 +1823,26 @@ class DefaultTheme(_ThemeConfig):
         self._title = title
 
     @property
+    def antialiasing(self) -> bool:
+        """Enable or disable antialiasing.
+
+        Examples
+        --------
+        Enable or antialiasing.
+
+        >>> import pyvista
+        >>> pyvista.global_theme.antialiasing = True
+        >>> pyvista.global_theme.antialiasing
+        True
+
+        """
+        return self._antialiasing
+
+    @antialiasing.setter
+    def antialiasing(self, antialiasing: bool):
+        self._antialiasing = antialiasing
+
+    @property
     def multi_samples(self) -> int:
         """Return or set the default ``multi_samples`` parameter.
 
@@ -2042,6 +2064,7 @@ class DefaultTheme(_ThemeConfig):
             'Slider Styles': 'slider_styles',
             'Return Camera Position': 'return_cpos',
             'Hidden Line Removal': 'hidden_line_removal',
+            'Anti-Aliasing': '_antialiasing',
         }
         for name, attr in parm.items():
             setting = getattr(self, attr)

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1828,7 +1828,7 @@ class DefaultTheme(_ThemeConfig):
 
         Examples
         --------
-        Enable or antialiasing.
+        Enable antialiasing.
 
         >>> import pyvista
         >>> pyvista.global_theme.antialiasing = True

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1824,11 +1824,11 @@ class DefaultTheme(_ThemeConfig):
 
     @property
     def antialiasing(self) -> bool:
-        """Enable or disable antialiasing.
+        """Enable or disable anti-aliasing.
 
         Examples
         --------
-        Enable antialiasing.
+        Enable anti-aliasing in the global theme.
 
         >>> import pyvista
         >>> pyvista.global_theme.antialiasing = True

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -410,3 +410,6 @@ def test_antialiasing(default_theme):
     for value in [True, False]:
         default_theme.antialiasing = value
         assert default_theme.antialiasing is value
+        pl = pyvista.Plotter(theme=default_theme)
+        assert pl.renderer.GetUseFXAA() is value
+

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -404,3 +404,11 @@ def test_load_theme(tmpdir, default_theme):
 
     default_theme.load_theme(filename)
     assert default_theme == pyvista.themes.DarkTheme()
+
+
+def test_antialiasing(default_theme):
+    default_theme.antialiasing = True
+    assert default_theme.antialiasing is True
+
+    default_theme.antialiasing = False
+    assert default_theme.antialiasing is False

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -407,8 +407,6 @@ def test_load_theme(tmpdir, default_theme):
 
 
 def test_antialiasing(default_theme):
-    default_theme.antialiasing = True
-    assert default_theme.antialiasing is True
-
-    default_theme.antialiasing = False
-    assert default_theme.antialiasing is False
+    for value in [True, False]:
+        default_theme.antialiasing = value
+        assert default_theme.antialiasing is value


### PR DESCRIPTION
### Add anti-aliasing to the theme

This PR adds anti-aliasing to the theme settings.

```py
>>> import pyvista
>>> pyvista.set_plot_theme('document')
>>> mesh = pyvista.Sphere()
>>> mesh.plot(show_edges=True)
>>> pyvista.global_theme.antialiasing = True

>>> mesh.plot(show_edges=True)

```
![sc0](https://user-images.githubusercontent.com/11981631/132048050-795b6299-cc17-488a-aea4-500f911d23e4.png)


```py
>>> mesh.plot(show_edges=True)
```
![sc1](https://user-images.githubusercontent.com/11981631/132048063-1d848402-198e-4391-b5e2-87b09f60aa32.png)
