### PR TITLE
Remove "all" target in makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ CODESPELL_IGNORE ?= "ignore_words.txt"
 doctest-modules: export PYVISTA_OFF_SCREEN = True
 doctest-modules-local-namespace: export PYVISTA_OFF_SCREEN = True
 
-all: doctest
-
 doctest: codespell pydocstyle
 
 codespell:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -17,11 +17,6 @@ help:
 
 .PHONY: help Makefile
 
-.PHONY: all
-
-all:
-	echo PYVISTA_OFF_SCREEN: $$PYVISTA_OFF_SCREEN
-
 clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf examples/


### PR DESCRIPTION
As I tried noting in https://github.com/pyvista/pyvista/pull/1618#discussion_r698847177, currently the `all` target in the `doc/Makefile` is either broken or unintuitive beyond repair:
```
$ make all
echo PYVISTA_OFF_SCREEN: $PYVISTA_OFF_SCREEN
PYVISTA_OFF_SCREEN: True
```
and that's it. This is exactly what the rule said:
```makefile
all:
	echo PYVISTA_OFF_SCREEN: $$PYVISTA_OFF_SCREEN
```

This doesn't sound like an appropriate `all` target, which should instead build "all" known targets.

The next problem is that there are two "known targets" in the makefile: `(p)html` and `deploy`. We would never want to run `deploy` with `all`, so that leaves the former, at which point `all` seems redundant. So this PR just removes the pointless-looking `all` target as a basis for negotiation.

This also means that someone doing `make all` will wind up running sphinx anyway thanks to a catch-all target:
```makefile
# Catch-all target: route all unknown targets to Sphinx using the new
# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
%: Makefile
        @$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
```
We might want to prevent this, but a no-op `all` seems like the wrong way to do it.

Finally, I noticed that the `all` target of the main `Makefile` is again problematic a bit:
```makefile
all: doctest

doctest: codespell pydocstyle

codespell:
        @echo "Running codespell"
        @codespell $(CODESPELL_DIRS) -S $(CODESPELL_SKIP) -I $(CODESPELL_IGNORE)

pydocstyle:
        @echo "Running pydocstyle"
        @pydocstyle pyvista

doctest-modules:
        @echo "Runnnig module doctesting"
        pytest -v --doctest-modules pyvista

doctest-modules-local-namespace:
        @echo "Running module doctesting using docstring local namespace"
        python tests/check_doctest_names.py

example-coverage:
        python -m ansys.tools.example_coverage -f pyvista

coverage:
        @echo "Running coverage"
        @pytest -v --cov pyvista

coverage-xml:
        @echo "Reporting XML coverage"
        @pytest -v --cov pyvista --cov-report xml

coverage-html:
        @echo "Reporting HTML coverage"
        @pytest -v --cov pyvista --cov-report html

mypy:
        @echo "Running mypy static type checking"
        mypy pyvista/core/ --no-incremental
        mypy pyvista/themes.py --no-incremental
```
It would be preferable if `all` did more than 2 out of about 8 distinct targets. But I can accept that this might be a pragmatic choice. Then again if `all` is a synonym for `doctest` then perhaps current uses of `all` should be replaced with uses of `doctest`. ~(But I haven't touched this yet; only in the complaining phase for now.)~