### PR TITLE
Clean up after #1571

### DIFF
--- a/doc/api/core/composite.rst
+++ b/doc/api/core/composite.rst
@@ -1,7 +1,7 @@
 Composite Datasets
 ==================
 
-The :class:`pyvista.MultiBlock` class is composite class to hold many
+The :class:`pyvista.MultiBlock` class is a composite class to hold many
 data sets which can be iterated over.
 
 You can think of MultiBlock like lists or dictionaries as we can

--- a/doc/api/core/grids.rst
+++ b/doc/api/core/grids.rst
@@ -14,7 +14,7 @@ classes.  These classes inherit from the `vtkRectilinearGrid`_ and
 volumetric data.
 
 A :class:`pyvista.RectilinearGrid` is used for modeling datasets with
-regular variable spacing in the three coordinate directions.
+variable spacing in the three coordinate directions.
 
 .. pyvista-plot::
    :include-source: False
@@ -24,7 +24,7 @@ regular variable spacing in the three coordinate directions.
 
 
 A :class:`pyvista.UniformGrid` is used for modeling datasets with
-regular uniform spacing in the three coordinate directions.
+uniform spacing in the three coordinate directions.
 
 .. pyvista-plot::
    :include-source: False

--- a/doc/api/core/index.rst
+++ b/doc/api/core/index.rst
@@ -17,18 +17,18 @@ PyVista has the following mesh types:
 
 - :class:`pyvista.PolyData` consists of any 1D or 2D geometries to construct vertices, lines, polygons, and triangles. We generally use :class:`pyvista.PolyData` to construct scattered points and closed/open surfaces (non-volumetric datasets). The :class:`pyvista.PolyData` class is an extension of `vtk.vtkPolyData`_.
 
-- An :class:`pyvista.UnstructuredGrid` is the most general dataset type that can hold any 1D, 2D, or 3D cell geometries. You can think of this as a 3D extension of :class:`pyvista.PolyData` that allows volumetric cells to be present. It's fairly uncommon to explicitly make unstructured grids but they are often the result of different processing routines that might extract subsets of larger datasets. The :class:`pyvista.UnstructuredGrid` class is an extension of `vtk.UnstructuredGrid`_.
+- A :class:`pyvista.UnstructuredGrid` is the most general dataset type that can hold any 1D, 2D, or 3D cell geometries. You can think of this as a 3D extension of :class:`pyvista.PolyData` that allows volumetric cells to be present. It's fairly uncommon to explicitly make unstructured grids but they are often the result of different processing routines that might extract subsets of larger datasets. The :class:`pyvista.UnstructuredGrid` class is an extension of `vtk.vtkUnstructuredGrid`_.
 
-- A :class:`pyvista.StructuredGrid` is a regular lattice of points aligned with an internal coordinate axes such that the connectivity can be defined by a grid ordering. These are commonly made from :func:`numpy.meshgrid`. The cell types of structured grids must be 2D Quads or 3D Hexahedrons. The :class:`pyvista.StructuredGrid` class is an extension of `vtk.vtkStructuredGrid`_.
+- A :class:`pyvista.StructuredGrid` is a regular lattice of points aligned with internal coordinate axes such that the connectivity can be defined by a grid ordering. These are commonly made from :func:`numpy.meshgrid`. The cell types of structured grids must be 2D quads or 3D hexahedra. The :class:`pyvista.StructuredGrid` class is an extension of `vtk.vtkStructuredGrid`_.
 
-- A :class:`pyvista.RectilinearGrid` defines meshes with implicit geometries along the axes directions that are rectangular and regular. The :class:`pyvista.RectilinearGrid` class is an extension of `vtk.vtkRectilinearGrid`_.
+- A :class:`pyvista.RectilinearGrid` defines meshes with implicit geometries along the axis directions that are rectangular and regular. The :class:`pyvista.RectilinearGrid` class is an extension of `vtk.vtkRectilinearGrid`_.
 
-- Image data, commonly referenced to as uniform grids, and defined by the :class:`pyvista.UniformGrid` class are meshes with implicit geometries where cell sizes are uniformly assigned along each axis and the spatial reference is built out from an origin point. The :class:`pyvista.UniformGrid` class is an extension of `vtk.vtkImageData`_.
+- Image data, commonly referred to as uniform grids, and defined by the :class:`pyvista.UniformGrid` class are meshes with implicit geometries where cell sizes are uniformly assigned along each axis and the spatial reference is built out from an origin point. The :class:`pyvista.UniformGrid` class is an extension of `vtk.vtkImageData`_.
 
 - :class:`pyvista.MultiBlock` datasets are containers to hold several VTK datasets in one accessible and spatially referenced object. The :class:`pyvista.MultiBlock` class is an extension of `vtk.vtkMultiBlockDataSet`_.
 
 .. _vtk.vtkPolyData: https://vtk.org/doc/nightly/html/classvtkPolyData.html
-.. _vtk.UnstructuredGrid: https://vtk.org/doc/nightly/html/classvtkUnstructuredGrid.html
+.. _vtk.vtkUnstructuredGrid: https://vtk.org/doc/nightly/html/classvtkUnstructuredGrid.html
 .. _vtk.vtkStructuredGrid: https://vtk.org/doc/nightly/html/classvtkStructuredGrid.html
 .. _vtk.vtkRectilinearGrid: https://vtk.org/doc/nightly/html/classvtkRectilinearGrid.html
 .. _vtk.vtkImageData: https://vtk.org/doc/nightly/html/classvtkImageData.html

--- a/doc/api/core/pointsets.rst
+++ b/doc/api/core/pointsets.rst
@@ -19,7 +19,7 @@ combinations of all possible cell types:
    demos.plot_datasets('UnstructuredGrid')
 
 
-The :class:`pyvista.PolyData`, is used for datasets consisting of surface
+The :class:`pyvista.PolyData` is used for datasets consisting of surface
 geometry (e.g. vertices, lines, and polygons):
 
 .. pyvista-plot::
@@ -30,7 +30,7 @@ geometry (e.g. vertices, lines, and polygons):
 
 
 The :class:`pyvista.StructuredGrid` is used for topologically regular arrays of
-data.
+data:
 
 .. pyvista-plot::
    :include-source: False
@@ -100,7 +100,7 @@ these can be loaded with:
     mesh = pyvista.PolyData(examples.planefile)
     mesh
 
-This mesh can then be written to a vtk file using:
+This mesh can then be written to a .vtk file using:
 
 .. code:: python
 
@@ -122,9 +122,9 @@ Meshes can be directly manipulated using NumPy or with the built-in
 translation and rotation routines.  This example loads two meshes and
 moves, scales, copies them, and finally plots them.
 
-To plot more than one mesh a plotting class must be created to manage
-the plotting.  The following code creates the class and plots the
-meshes with various colors.
+To plot more than one mesh a :class:`pyvista.Plotter` instance must be
+created to manage the plotting.  The following code creates a plotter
+and plots the meshes with various colors.
 
 
 .. pyvista-plot::
@@ -146,7 +146,7 @@ meshes with various colors.
     ant_copy = ant.copy()
     ant_copy.translate([30, 0, -10])
 
-    # Create plotting object
+    # Create plotter object
     plotter = pyvista.Plotter()
     plotter.add_mesh(ant, 'r')
     plotter.add_mesh(ant_copy, 'b')

--- a/doc/api/utilities/geometric.rst
+++ b/doc/api/utilities/geometric.rst
@@ -11,6 +11,7 @@ additional details see :ref:`ref_geometric_example` example.
 
    Arrow
    Box
+   Circle
    CircularArc
    CircularArcFromNormal
    Cone
@@ -22,7 +23,9 @@ additional details see :ref:`ref_geometric_example` example.
    Plane
    Polygon
    Pyramid
+   Rectangle
    Sphere
    Spline
    Text3D
+   Triangle
    Wavelet

--- a/doc/getting-started/why.rst
+++ b/doc/getting-started/why.rst
@@ -4,7 +4,7 @@ Why PyVista?
 .. jupyter-execute::
    :hide-code:
 
-   # jupyterlab boiler plate setup
+   # jupyterlab boilerplate setup
    import pyvista
    pyvista.set_plot_theme('document')
 
@@ -36,7 +36,7 @@ requires a few lines of code.
    ...               (-0.15446, 0.939031, -0.3071841)]
 
 +-------------------------------------------+-------------------------------------+
-| Read and plot stl file using `vtk`_       | Read a stl file using PyVista       |
+| Read and plot STL file using `vtk`_       | Read an STL file using PyVista      |
 +===========================================+=====================================+
 | .. code:: python                          | .. code:: python                    |
 |                                           |                                     |
@@ -68,10 +68,10 @@ by exposing a simplified, but functional, interface to VTK's classes.
 In :func:`pyvista.read`, PyVista automatically determines the correct
 file reader based on the file extension and returns a DataSet object.
 This dataset object contains all the methods that are available to a
-:class:`pyvista.PolyData` class, including the :func:`pyvista.plot`
-method, allowing you to instantly generate a plot of the mesh.
-Garbage collection is taken care of automatically and the renderer is
-cleaned up after the user closes the plotting window.
+:class:`pyvista.PolyData` class, including the :func:`plot
+<pyvista.plot>` method, allowing you to instantly generate a plot of
+the mesh.  Garbage collection is taken care of automatically and the
+renderer is cleaned up after the user closes the plotting window.
 
 For more details comparing the two APIs, please see
 :ref:`pyvista_data_model` and :ref:`pyvista_to_vtk_docs`.
@@ -80,8 +80,8 @@ PyVista API
 ~~~~~~~~~~~
 For example, triangular surface meshes in VTK can be subdivided but
 every other object in VTK cannot.  It then makes sense that a
-subdivided method be added to the existing triangular surface mesh.
-That way, subdivision can be performed with:
+:func:`subdivide` method be added to the existing triangular surface
+mesh.  That way, subdivision can be performed with:
 
 .. jupyter-execute::
 
@@ -98,7 +98,7 @@ to a description of how to use those methods:
 .. figure:: ../images/gifs/documentation.gif
 
 
-Interfacing with other Libraries
+Interfacing With Other Libraries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PyVista is heavily dependent on `numpy <https://numpy.org/>`_ and uses
 it to represent point, cell, field, and other data from the VTK
@@ -142,8 +142,8 @@ field of arrows using :func:`numpy.meshgrid`:
     pl.show()
 
 PyVista has connections to several other libraries, such as `meshio
-<https://github.com/nschloe/meshio>`_, `matplotlib
+<https://github.com/nschloe/meshio>`_ and `matplotlib
 <https://matplotlib.org/>`_, allowing PyVista to extend VTK with
-functionality from the python ecosystem.
+functionality from the Python ecosystem.
 
 .. _vtk: https://vtk.org/

--- a/doc/getting-started/why.rst
+++ b/doc/getting-started/why.rst
@@ -74,7 +74,7 @@ the mesh.  Garbage collection is taken care of automatically and the
 renderer is cleaned up after the user closes the plotting window.
 
 For more details comparing the two APIs, please see
-:ref:`pyvista_data_model` and :ref:`pyvista_to_vtk_docs`.
+:ref:`pyvista_data_model` and :ref:`vtk_to_pyvista_docs`.
 
 PyVista API
 ~~~~~~~~~~~

--- a/doc/getting-started/why.rst
+++ b/doc/getting-started/why.rst
@@ -111,7 +111,7 @@ of a circle from pyvista can be accessed with:
    circle = pyvista.Circle()
    circle.points[:10]
 
-And these points can be operated on as if it was a ``numpy`` array,
+And these points can be operated on as if it was a NumPy array,
 all without losing connection to the underlying VTK data array.
 
 At the same time, a variety of PyVista objects can be generated

--- a/doc/user-guide/data_model.rst
+++ b/doc/user-guide/data_model.rst
@@ -13,7 +13,7 @@ place data within datasets.
    not require that you have knowledge of VTK.  For those who wish to
    see a detailed comparison to VTK or translate code written for the
    Python bindings of VTK to PyVista, please see
-   :ref:`pyvista_to_vtk_docs`.
+   :ref:`vtk_to_pyvista_docs`.
 
 For a more general description of our API, see :ref:`what_is_a_mesh`.
 
@@ -347,7 +347,7 @@ In this representation we see:
 * Number of data arrays :attr:`n_arrays <pyvista.DataSet.n_arrays>`
 
 This is vastly different from the output from VTK.  See
-:ref:`pyvista_vs_vtk_object_repr` for the comparison between the two
+:ref:`vtk_vs_pyvista_object_repr` for the comparison between the two
 representations.
 
 This mesh contains no data arrays as it consists only of geometry. This

--- a/doc/user-guide/data_model.rst
+++ b/doc/user-guide/data_model.rst
@@ -55,7 +55,7 @@ and attributes describing that geometry in the form of point, cell, or
 field arrays.
 
 Geometry in PyVista is represented as points and cells.  For example,
-consider a single cell within a `PolyData`_:
+consider a single cell within a |PolyData|:
 
 .. jupyter-execute::
    :hide-code:
@@ -89,22 +89,22 @@ shapes. The most important dataset classes are shown below:
 
 Here, the above datasets are ordered from most (5) to least complex
 (1). That is, every dataset can be represented as an
-`UnstructuredGrid`_, but the
-`UnstructuredGrid`_ class takes the most amount of
+|UnstructuredGrid|, but the
+|UnstructuredGrid| class takes the most amount of
 memory to store since they must account for every individual point and
 cell . On the other hand, since `vtkImageData`_
-(`UniformGrid`_) is uniformly spaced, a few integers and
+(|UniformGrid|) is uniformly spaced, a few integers and
 floats can describe the shape, so it takes the least amount of memory
 to store.
 
-This is because in `PolyData`_ or
-`UnstructuredGrid`_, points and cells must be explicitly
-defined.  In other data types, such as `UniformGrid`_,
+This is because in |PolyData| or
+|UnstructuredGrid|, points and cells must be explicitly
+defined.  In other data types, such as |UniformGrid|,
 the cells (and even points) are defined as an emergent property based
 on the dimensionality of the grid.
 
 To see this in practice, let's create the simplest surface represented
-as a `PolyData`_. First, we need to define our points.
+as a |PolyData|. First, we need to define our points.
 
 
 Points and Arrays Within PyVista
@@ -210,7 +210,7 @@ of lists via:
    ...           [1, 0, 0],
    ...           [0.5, 0.667, 0]]
 
-When used in the context of `PolyData`_ to create the
+When used in the context of |PolyData| to create the
 mesh, this list will automatically be wrapped using NumPy and then
 passed to VTK. This avoids any looping overhead and while still
 allowing you to use native python classes.
@@ -275,16 +275,16 @@ in the same order as we defined earlier.
 
 .. note::
    Observe how we had to insert a leading ``3`` to tell VTK that our
-   face will contain three points. In our `PolyData`_ VTK
+   face will contain three points. In our |PolyData| VTK
    doesn't assume that faces always contain three points, so we have
    to define that. This actually gives us the flexibility to define
    as many (or as few as one) points per cell as we wish.
 
 
 Now we have all the necessary pieces to assemble an instance of
-`PolyData`_ that contains a single triangle. To do
+|PolyData| that contains a single triangle. To do
 this, we simply provide the ``points`` and ``cells`` to the
-constructor of a `PolyData`_. We can see from the
+constructor of a |PolyData|. We can see from the
 representation that this geometry contains three points and one cell
 
 .. jupyter-execute::
@@ -378,8 +378,9 @@ or cells and attached to the mesh in general.
 To illustrate data arrays within PyVista, let's first construct a
 slightly more complex mesh than our previous example.  Here, we create
 a simple mesh containing four isometric cells by starting with a
-`UniformGrid`_ and then casting it to an `UnstructuredGrid`_ with
-`cast_to_unstructured_grid`_.
+|UniformGrid| and then casting it to an |UnstructuredGrid| with
+:func:`cast_to_unstructured_grid
+<pyvista.DataSet.cast_to_unstructured_grid>`.
 
 .. jupyter-execute::
 
@@ -435,7 +436,7 @@ The easiest way to add scalar data to a :class:`DataSet
 Continuing with our example above, let's assign each cell a single
 integer.  We can do this using a Python :class:`list` and making it
 the same length as the number of cells in the
-`UnstructuredGrid`_. Or as an even simpler example, using a
+|UnstructuredGrid|. Or as an even simpler example, using a
 :func:`range` of the appropriate length.  Here we create the range, add
 it to the :attr:`cell_data <pyvista.DataSet.cell_data>`, and then access
 it using the ``[]`` operator.
@@ -713,7 +714,6 @@ these vectors represent quantities with direction.
 .. _vtkImageData: https://vtk.org/doc/nightly/html/classvtkImageData.html
 .. _vtk.vtkMultiBlockDataSet: https://vtk.org/doc/nightly/html/classvtkMultiBlockDataSet.html
 
-.. _PolyData: :class:`PolyData <pyvista.PolyData>`
-.. _UnstructuredGrid: :class:`UnstructuredGrid <pyvista.UnstructuredGrid>`
-.. _UniformGrid: :class:`UniformGrid <pyvista.UniformGrid>`
-.. _cast_to_unstructured_grid: :func:`cast_to_unstructured_grid <pyvista.DataSet.cast_to_unstructured_grid>`
+.. |PolyData| replace:: :class:`PolyData <pyvista.PolyData>`
+.. |UnstructuredGrid| replace:: :class:`UnstructuredGrid <pyvista.UnstructuredGrid>`
+.. |UniformGrid| replace:: :class:`UniformGrid <pyvista.UniformGrid>`

--- a/doc/user-guide/data_model.rst
+++ b/doc/user-guide/data_model.rst
@@ -378,7 +378,7 @@ To illustrate data arrays within PyVista, let's first construct a
 slightly more complex mesh than our previous example.  Here, we create
 a simple mesh containing four isometric cells by starting with a
 |UniformGrid| and then casting it to an |UnstructuredGrid| with
-:func:`cast_to_unstructured_grid
+:func:`cast_to_unstructured_grid()
 <pyvista.DataSet.cast_to_unstructured_grid>`.
 
 .. jupyter-execute::
@@ -608,7 +608,7 @@ at once, and this data can be obtained from :attr:`active_scalars_info
 
 Note that the active scalars are by default the point scalars.  You
 can change this by setting the active scalars with
-:func:`set_active_scalars
+:func:`set_active_scalars()
 <pyvista.DataSet.set_active_scalars>`.  Note that if you
 want to set the active scalars and both the point and cell data have
 an array of the same name, you must specify the ``preference``:
@@ -691,7 +691,7 @@ to be non-directional even if they contain several components (as in
 the case of RGB data).
 
 Vectors are treated differently within VTK than scalars when
-performing transformations using the :func:`transform
+performing transformations using the :func:`transform()
 <pyvista.DataSet.transform>` filter.  Unlike scalar
 arrays, vector arrays will be transformed along with the geometry as
 these vectors represent quantities with direction.
@@ -700,7 +700,7 @@ these vectors represent quantities with direction.
 
    VTK permits only one "active" vector.  If you have multiple vector
    arrays that you wish to transform, set
-   ``transform_all_input_vectors=True`` in :func:`transform
+   ``transform_all_input_vectors=True`` in :func:`transform()
    <pyvista.DataSet.transform>`.  Be aware that this will
    transform any array with three components, so multi-component
    scalar arrays like RGB arrays will have to be discarded after

--- a/doc/user-guide/data_model.rst
+++ b/doc/user-guide/data_model.rst
@@ -371,8 +371,7 @@ Data Arrays
 Each :class:`DataSet <pyvista.DataSet>` contains
 attributes that allow you to access the underlying numeric data.  This
 numerical data may be associated with the :attr:`points
-<pyvista.DataSet.points>`, :attr:`cells
-<pyvista.DataSet.cells>`, or not associated with points
+<pyvista.DataSet.points>`, cells, or not associated with points
 or cells and attached to the mesh in general.
 
 To illustrate data arrays within PyVista, let's first construct a
@@ -437,7 +436,7 @@ Continuing with our example above, let's assign each cell a single
 integer.  We can do this using a Python :class:`list` and making it
 the same length as the number of cells in the
 |UnstructuredGrid|. Or as an even simpler example, using a
-:func:`range` of the appropriate length.  Here we create the range, add
+:class:`range` of the appropriate length.  Here we create the range, add
 it to the :attr:`cell_data <pyvista.DataSet.cell_data>`, and then access
 it using the ``[]`` operator.
 
@@ -486,7 +485,7 @@ assigned.
 We can continue to assign cell data to our :class:`DataSet
 <pyvista.DataSet>` using the ``[]`` operator, but if you
 do not wish the new array to become the active array, you can add it
-using :func:`set_array <pyvista.DataSet.set_array>`
+using :func:`set_array() <pyvista.DataSetAttributes.set_array>`
 
 .. jupyter-execute::
 
@@ -561,8 +560,8 @@ lowest value at ``Point 0`` to the highest value at ``Point 8``.
    >>> pl.show()
 
 As in :ref:`pyvista_data_model_cell_data`, we can assign multiple
-arrays to :attr:`point_data <pyvista.dataset.DataSet.point_data>`
-using :func:`set_array <pyvista.DataSet.set_array>`.
+arrays to :attr:`point_data <pyvista.DataSet.point_data>`
+using :func:`set_array() <pyvista.DataSetAttributes.set_array>`.
 
 .. jupyter-execute::
 

--- a/doc/user-guide/data_model.rst
+++ b/doc/user-guide/data_model.rst
@@ -150,7 +150,7 @@ class, but there's a better, and more pythonic alternative by using
 
 Using NumPy with PyVista
 ~~~~~~~~~~~~~~~~~~~~~~~~
-You could create a `NumPy <https://numpy.org/>`_ points array with:
+You can create a `NumPy <https://numpy.org/>`_ points array with:
 
 .. jupyter-execute::
 
@@ -619,7 +619,8 @@ an array of the same name, you must specify the ``preference``:
    >>> ugrid.active_scalars_info
 
 This can also be set when plotting using the ``preference``
-parameter in :func:`add_mesh() <pyvista.Plotter.add_mesh>`.
+parameter in :func:`add_mesh() <pyvista.Plotter.add_mesh>` or
+:func:`pyvista.plot`.
 
 
 Field Data

--- a/doc/user-guide/data_model.rst
+++ b/doc/user-guide/data_model.rst
@@ -15,20 +15,20 @@ place data within datasets.
    Python bindings of VTK to PyVista, please see
    :ref:`pyvista_to_vtk_docs`.
 
-For a more general description of our api, see :ref:`what_is_a_mesh`.
+For a more general description of our API, see :ref:`what_is_a_mesh`.
 
 
 The PyVista DataSet
 -------------------
 To visualize data in VTK or PyVista, two pieces of information are
 required: the data's geometry, which describes where the data is
-positioned in space and what is values are, and its topology, which
+positioned in space and what its values are, and its topology, which
 describes how points in the dataset are connected to one another.
 
 At the top level, we have `vtkDataObject`_, which are just "blobs" of
 data without geometry or topology. These contain arrays of
 `vtkFieldData`_. Under this are `vtkDataSet`_, which add geometry and
-topolgy to `vtkDataObject`_. Associated with every point and cell in
+topology to `vtkDataObject`_. Associated with every point or cell in
 the dataset is a specific value. Since these values must be positioned
 and connected in space, they are held in the `vtkDataArray`_ class,
 which are simply memory buffers on the heap. In PyVista, 99% of the
@@ -36,16 +36,16 @@ time we interact with `vtkDataSet`_ objects rather than with
 `vtkDataObject`_ objects. PyVista uses the same data types as VTK, but
 structures them in a more pythonic manner for ease of use.
 
-If you'd like a background for how VTK structures its data, see
+If you'd like some background for how VTK structures its data, see
 `Introduction to VTK in Python by Kitware
 <https://vimeo.com/32232190>`_, as well as the numerous code examples
 on `Kitware's GitHub site
 <https://kitware.github.io/vtk-examples/site/>`_. An excellent
-introduction to mathematical concept relevant to 3D modeling in
+introduction to mathematical concepts relevant to 3D modeling in
 general implemented in VTK is provided by the `Discrete Differential
 Geometry YouTube Series
 <https://www.youtube.com/playlist?list=PL9_jI1bdZmz0hIrNCMQW1YmZysAiIYSSS>`_
-by Prof. Keenan Crane at Carnegie Melon. The concepts taught here
+by Prof. Keenan Crane at Carnegie Mellon. The concepts taught here
 will help improve your understanding of why data sets are structured
 the way they are in libraries like VTK.
 
@@ -100,19 +100,19 @@ to store.
 This is because in `PolyData`_ or
 `UnstructuredGrid`_, points and cells must be explicitly
 defined.  In other data types, such as `UniformGrid`_,
-the cells (and even points) are defined as a emergent property based
+the cells (and even points) are defined as an emergent property based
 on the dimensionality of the grid.
 
 To see this in practice, let's create the simplest surface represented
 as a `PolyData`_. First, we need to define our points.
 
 
-Points and Arrays within in PyVista
------------------------------------
+Points and Arrays Within PyVista
+--------------------------------
 There are a variety of ways to create points within PyVista, and this section shows how to efficiently create an array of points by either:
 
 * Wrapping a VTK array
-* Using a :class:`numpy.ndarray` array
+* Using a :class:`numpy.ndarray`
 * Or just using a :class:`list`
 
 PyVista provides pythonic methods for all three approaches so you can
@@ -150,9 +150,7 @@ class, but there's a better, and more pythonic alternative by using
 
 Using NumPy with PyVista
 ~~~~~~~~~~~~~~~~~~~~~~~~
-However, there's no reason to do this since Python already has the
-excellent C array library `NumPy <https://numpy.org/>`_. You could
-more create a points array with:
+You could create a `NumPy <https://numpy.org/>`_ points array with:
 
 .. jupyter-execute::
 
@@ -162,9 +160,9 @@ more create a points array with:
    ...                       [0.5, 0.667, 0]])
    >>> np_points
 
-We use a :class:`numpy.ndarray` here so that PyVista directly "point"
+We use a :class:`numpy.ndarray` here so that PyVista directly "points"
 the underlying C array to VTK. VTK already has APIs to directly read
-in the C arrays from ``numpy``, and since VTK is written in C++,
+in the C arrays from NumPy, and since VTK is written in C++,
 everything from Python that is transferred over to VTK needs to be in a
 format that VTK can process.
 
@@ -180,10 +178,11 @@ representation of the data. For example:
 
 Note that when wrapping the underlying VTK array, we actually perform
 a shallow copy of the data. In other words, we pass the pointer from
-the underlying C array to the numpy :class:`numpy.ndarray`, meaning
-that the two arrays are now efficiently linked. This means that we
-can change the array using numpy array indexing and have it modified
-on the "VTK side".
+the underlying C array to the :class:`numpy.ndarray`, meaning
+that the two arrays are now efficiently linked (in NumPy terminology,
+the returned array is a view into the underlying VTK data). This means
+that we can change the array using numpy array indexing and have it
+modified on the "VTK side".
 
 .. jupyter-execute::
 
@@ -202,7 +201,7 @@ the numpy wrapped array. Let's change the value back:
 Using Python Lists or Tuples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PyVista supports the use of Python sequences (i.e. :class:`list` or
-:class:`tuple`, and you could define a your points using a nested list
+:class:`tuple`), and you could define your points using a nested list
 of lists via:
 
 .. jupyter-execute::
@@ -212,7 +211,7 @@ of lists via:
    ...           [0.5, 0.667, 0]]
 
 When used in the context of `PolyData`_ to create the
-mesh, this list will automatically be wrapped using numpy and then
+mesh, this list will automatically be wrapped using NumPy and then
 passed to VTK. This avoids any looping overhead and while still
 allowing you to use native python classes.
 
@@ -257,12 +256,12 @@ can see the entire process.
    >>> mesh.plot(show_bounds=True, cpos='xy', point_size=20)
 
 We'll get into PyVista's data classes and attributes later, but for
-now we've shown how create a simple geometry containing just points.
+now we've shown how to create a simple geometry containing just points.
 To create a surface, we must specify the connectivity of the geometry,
 and to do that we need to specify the cells (or faces) of this surface.
 
 
-Geometry and Mesh Connectivity/Topology within PyVista
+Geometry and Mesh Connectivity/Topology Within PyVista
 ------------------------------------------------------
 With our previous example, we defined our "mesh" as three disconnected
 points. While this is useful for representing "point clouds", if we
@@ -275,8 +274,8 @@ in the same order as we defined earlier.
    >>> cells = [3, 0, 1, 2]
 
 .. note::
-   Observe how we had insert a leading ``3`` to tell VTK that our face
-   will contain three points. In our `PolyData`_ VTK
+   Observe how we had to insert a leading ``3`` to tell VTK that our
+   face will contain three points. In our `PolyData`_ VTK
    doesn't assume that faces always contain three points, so we have
    to define that. This actually gives us the flexibility to define
    as many (or as few as one) points per cell as we wish.
@@ -308,7 +307,8 @@ While we're at it, let's annotate this plot to describe this mesh.
 
    >>> pl = pyvista.Plotter()
    >>> pl.add_mesh(mesh, show_edges=True, line_width=5)
-   >>> pl.add_point_labels(mesh.points, [f'Point {i}' for i in range(3)], 
+   >>> label_coords = mesh.points + [0, 0, 0.01]
+   >>> pl.add_point_labels(label_coords, [f'Point {i}' for i in range(3)], 
    ...                     font_size=20, point_size=20)
    >>> pl.add_point_labels([0.43, 0.2, 0], ['Cell 0'], font_size=20)
    >>> pl.camera_position = 'xy'
@@ -350,7 +350,7 @@ This is vastly different from the output from VTK.  See
 :ref:`pyvista_vs_vtk_object_repr` for the comparison between the two
 representations.
 
-This mesh contains no data arrays consists only of geometry.  This
+This mesh contains no data arrays as it consists only of geometry. This
 makes it useful for plotting just the geometry of the mesh, but
 datasets often contain more than just geometry.  For example:
 
@@ -377,9 +377,9 @@ or cells and attached to the mesh in general.
 
 To illustrate data arrays within PyVista, let's first construct a
 slightly more complex mesh than our previous example.  Here, we create
-a simple mesh containing four equal cells by starting with a
-`UniformGrid`_ and then casting it to an
-`UnstructuredGrid`_ with `cast_to_unstructured_grid`_.
+a simple mesh containing four isometric cells by starting with a
+`UniformGrid`_ and then casting it to an `UnstructuredGrid`_ with
+`cast_to_unstructured_grid`_.
 
 .. jupyter-execute::
 
@@ -401,8 +401,9 @@ Let's also plot this basic mesh:
 
    >>> pl = pyvista.Plotter()
    >>> pl.add_mesh(ugrid, show_edges=True, line_width=5)
+   >>> label_coords = ugrid.points + [0, 0, 0.02]
    >>> point_labels = [f'Point {i}' for i in range(ugrid.n_points)]
-   >>> pl.add_point_labels(ugrid.points, point_labels,
+   >>> pl.add_point_labels(label_coords, point_labels,
    ...                     font_size=25, point_size=20)
    >>> cell_labels = [f'Cell {i}' for i in range(ugrid.n_cells)]
    >>> pl.add_point_labels(ugrid.cell_centers(), cell_labels, font_size=25)
@@ -410,17 +411,17 @@ Let's also plot this basic mesh:
    >>> pl.show()
 
 Now that we have a simple mesh to work with, we can start assigning it
-data.  There are two main types of data that can be associated with
-mesh, scalar data and vector data. Scalar data is single or
+data.  There are two main types of data that can be associated with a
+mesh: scalar data and vector data. Scalar data is single or
 multi-component data that is non directional and may include values
 like temperature, or in the case of multi-component data, RGBA values.
-Vector data contains magnitude and direction and is represented as
-arrays containing three components.
+Vector data has magnitude and direction and is represented as
+arrays containing three components per data point.
 
 When plotting, we can easily display scalar data, but this data must
 be "associated" with either points or cells.  For example, we may wish
 to assign values to the cells of our example mesh, which we can do by
-accessing the `attr:`cell_data <pyvista.DataSet.cell_data>`
+accessing the :attr:`cell_data <pyvista.DataSet.cell_data>`
 attribute of our mesh.
 
 
@@ -432,16 +433,17 @@ Cell Data
 The easiest way to add scalar data to a :class:`DataSet
 <pyvista.DataSet>` is to use the ``[]`` operator.
 Continuing with our example above, let's assign each cell a single
-integer.  We can do this using a python :class:`list` and making it
+integer.  We can do this using a Python :class:`list` and making it
 the same length as the number of cells in the
-`UnstructuredGrid`_.  Here we create the list, add it to
-the `attr:`cell_data <pyvista.DataSet.cell_data>`, and then access
+`UnstructuredGrid`_. Or as an even simpler example, using a
+:func:`range` of the appropriate length.  Here we create the range, add
+it to the :attr:`cell_data <pyvista.DataSet.cell_data>`, and then access
 it using the ``[]`` operator.
 
 .. jupyter-execute::
 
-   >>> simple_list = range(ugrid.n_cells)
-   >>> ugrid.cell_data['my-data'] = simple_list
+   >>> simple_range = range(ugrid.n_cells)
+   >>> ugrid.cell_data['my-data'] = simple_range
    >>> ugrid.cell_data['my-data']
 
 Note how we are returned a :class:`pyvista.pyvista_ndarray`.  Since
@@ -466,9 +468,12 @@ Note how we did not have to specify which cell data to plot as the
 
    >>> ugrid.cell_data
 
-We can also labels to our plot to show which cells are assigned which
-scalars.  Note how this is in the same order as the scalars we
+We can also add labels to our plot to show which cells are assigned
+which scalars.  Note how this is in the same order as the scalars we
 assigned.
+
+.. pyvista-plot::
+   :context:
 
    >>> pl = pyvista.Plotter()
    >>> pl.add_mesh(ugrid, show_edges=True, line_width=5)
@@ -479,7 +484,7 @@ assigned.
 
 We can continue to assign cell data to our :class:`DataSet
 <pyvista.DataSet>` using the ``[]`` operator, but if you
-do no wish the new array to become the active array, you can add it
+do not wish the new array to become the active array, you can add it
 using :func:`set_array <pyvista.DataSet.set_array>`
 
 .. jupyter-execute::
@@ -492,10 +497,10 @@ Now, ``ugrid`` contains two arrays, one of which is the "active"
 scalars.  This set of active scalars will be the one plotted
 automatically when ``scalars`` is unset in either :func:`add_mesh()
 <pyvista.Plotter.add_mesh>` or :func:`pyvista.plot`.  This makes it
-possible to have an many cell arrays associated with a dataset and
+possible to have many cell arrays associated with a dataset and
 track which one will plotted as the active cell scalars by default.
 
-The active scalars can also be accessed or set via
+The active scalars can also be accessed via
 :attr:`active_scalars <pyvista.DataSet.active_scalars>`,
 and the name of the active scalars array can be accessed or set with
 :attr:`active_scalars_name
@@ -518,7 +523,7 @@ list to the points using the ``[]`` operator.
 
 .. jupyter-execute::
 
-   >>> simple_list = range(ugrid.n_points)
+   >>> simple_list = list(range(ugrid.n_points))
    >>> ugrid.point_data['my-data'] = simple_list
    >>> ugrid.point_data['my-data']
 
@@ -527,13 +532,12 @@ default by using the ``[]`` operator:
 
 .. jupyter-execute::
 
-   >>> simple_list = range(ugrid.n_points)
    >>> ugrid.point_data
 
 Let's plot the point data.  Note how this varies from the cell data
 plot; each individual point is assigned a scalar value which is
 interpolated across a cell to create a smooth color map between the
-lowest value at ``Point 0`` to the highest value at ``Point 9``.
+lowest value at ``Point 0`` to the highest value at ``Point 8``.
 
 .. pyvista-plot::
    :context:
@@ -548,15 +552,16 @@ lowest value at ``Point 0`` to the highest value at ``Point 9``.
 
    >>> pl = pyvista.Plotter()
    >>> pl.add_mesh(ugrid, show_edges=True, line_width=5)
+   >>> label_coords = ugrid.points + [0, 0, 0.02]
    >>> point_labels = [f'Point {i}' for i in range(ugrid.n_points)]
-   >>> pl.add_point_labels(ugrid.points, point_labels,
+   >>> pl.add_point_labels(label_coords, point_labels,
    ...                     font_size=25, point_size=20)
    >>> pl.camera_position = 'xy'
    >>> pl.show()
 
 As in :ref:`pyvista_data_model_cell_data`, we can assign multiple
 arrays to :attr:`point_data <pyvista.dataset.DataSet.point_data>`
-using :func:`set_array() <pyvista.DataSet.set_array>`.
+using :func:`set_array <pyvista.DataSet.set_array>`.
 
 .. jupyter-execute::
 
@@ -565,8 +570,8 @@ using :func:`set_array() <pyvista.DataSet.set_array>`.
    >>> ugrid.point_data
 
 Again, here there are now two arrays associated to the point data, and
-only one is the "active" scalars.  Like as in the cell data, can set
-or retrieve this with :attr:`active_scalars
+only one is the "active" scalars array.  Like as in the cell data, we
+can retrieve this with :attr:`active_scalars
 <pyvista.DataSet.active_scalars>`, and the name of the
 active scalars array can be accessed or set with
 :attr:`active_scalars_name
@@ -593,8 +598,8 @@ contains both point and cell data:
 
 There are active scalars in both point and cell data, but only one
 type of scalars can be "active" at the dataset level.  The reason for
-this is only one scalar type (be it point or cell) can be plotted at
-once, and this data can be obtained from :attr:`active_scalars_info
+this is that only one scalar type (be it point or cell) can be plotted
+at once, and this data can be obtained from :attr:`active_scalars_info
 <pyvista.DataSet.active_scalars_info>`:
 
 .. jupyter-execute::
@@ -614,8 +619,7 @@ an array of the same name, you must specify the ``preference``:
    >>> ugrid.active_scalars_info
 
 This can also be set when plotting using the ``preference``
-parameter in :func:`add_mesh() <pyvista.Plotter.add_mesh>` or
-:func:`pyvista.plot`.
+parameter in :func:`add_mesh() <pyvista.Plotter.add_mesh>`.
 
 
 Field Data
@@ -626,7 +630,7 @@ Field arrays are different from :attr:`point_data
 the geometry of the :class:`DataSet <pyvista.DataSet>`.
 This means that while it's not possible to designate the field data as
 active scalars or vectors, you can use it to "attach" arrays of any
-row and columns.  You can even add string arrays in the field data:
+shape.  You can even add string arrays in the field data:
 
 .. jupyter-execute::
 
@@ -647,9 +651,9 @@ cannot be made so because field data is not expected to match the
 number of cells or points.  As such, it also cannot be plotted.
 
 
-Vectors, Textures, and Normals Attributes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Both cell and point data can also store the following "special" attributes in addition to :attr:`active_scalars <pyvista.DataSet.active_scalars>`
+Vectors, Texture Coords, and Normals Attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Both cell and point data can also store the following "special" attributes in addition to :attr:`active_scalars <pyvista.DataSet.active_scalars>`:
 
 * :attr:`active_normals <pyvista.DataSet.active_normals>`
 * :attr:`active_t_coords <pyvista.DataSet.active_t_coords>`
@@ -659,16 +663,17 @@ Both cell and point data can also store the following "special" attributes in ad
 Active Normals
 ~~~~~~~~~~~~~~
 The :attr:`active_normals
-<pyvista.DataSet.active_normals>` array is a special
-array that is used for creating physically based rendering or
-rendering smooth shading using the phong interpolation.  If this array
+<pyvista.DataSet.active_normals>` array is a special array that
+specifies the local normal direction of meshes. It is used for
+creating physically based rendering, rendering smooth shading using
+Phong interpolation, warping by scalars, etc.  If this array
 is not set when plotting with ``smooth_shading=True`` or ``pbr=True``,
 it will be computed.
 
 
 Active Texture Coordinates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-The :attr:`active_tcoords
+The :attr:`active_t_coords
 <pyvista.DataSet.active_t_coords>` array is used for
 rendering textures.  See :ref:`ref_texture_example` for examples using
 this array.

--- a/doc/user-guide/data_model.rst
+++ b/doc/user-guide/data_model.rst
@@ -711,7 +711,6 @@ these vectors represent quantities with direction.
 .. _vtkFieldData: https://vtk.org/doc/nightly/html/classvtkFieldData.html
 .. _vtkDataObject: https://vtk.org/doc/nightly/html/classvtkDataObject.html
 .. _vtkImageData: https://vtk.org/doc/nightly/html/classvtkImageData.html
-.. _vtk.vtkMultiBlockDataSet: https://vtk.org/doc/nightly/html/classvtkMultiBlockDataSet.html
 
 .. |PolyData| replace:: :class:`PolyData <pyvista.PolyData>`
 .. |UnstructuredGrid| replace:: :class:`UnstructuredGrid <pyvista.UnstructuredGrid>`

--- a/doc/user-guide/data_model.rst
+++ b/doc/user-guide/data_model.rst
@@ -55,7 +55,7 @@ and attributes describing that geometry in the form of point, cell, or
 field arrays.
 
 Geometry in PyVista is represented as points and cells.  For example,
-consider a single cell within a :class:`pyvista.PolyData`:
+consider a single cell within a `PolyData`_:
 
 .. jupyter-execute::
    :hide-code:
@@ -89,22 +89,22 @@ shapes. The most important dataset classes are shown below:
 
 Here, the above datasets are ordered from most (5) to least complex
 (1). That is, every dataset can be represented as an
-:class:`pyvista.UnstructuredGrid`, but the
-:class:`pyvista.UnstructuredGrid` class takes the most amount of
+`UnstructuredGrid`_, but the
+`UnstructuredGrid`_ class takes the most amount of
 memory to store since they must account for every individual point and
 cell . On the other hand, since `vtkImageData`_
-(:class:`pyvista.UniformGrid`) is uniformly spaced, a few integers and
+(`UniformGrid`_) is uniformly spaced, a few integers and
 floats can describe the shape, so it takes the least amount of memory
 to store.
 
-This is because in :class:`pyvista.PolyData` or
-:class:`pyvista.UnstructuredGrid`, points and cells must be explicitly
-defined.  In other data types, such as :class:`pyvista.UniformGrid`,
+This is because in `PolyData`_ or
+`UnstructuredGrid`_, points and cells must be explicitly
+defined.  In other data types, such as `UniformGrid`_,
 the cells (and even points) are defined as a emergent property based
 on the dimensionality of the grid.
 
 To see this in practice, let's create the simplest surface represented
-as a :class:`pyvista.PolyData`. First, we need to define our points.
+as a `PolyData`_. First, we need to define our points.
 
 
 Points and Arrays within in PyVista
@@ -211,7 +211,7 @@ of lists via:
    ...           [1, 0, 0],
    ...           [0.5, 0.667, 0]]
 
-When used in the context of :class:`pyvista.PolyData` to create the
+When used in the context of `PolyData`_ to create the
 mesh, this list will automatically be wrapped using numpy and then
 passed to VTK. This avoids any looping overhead and while still
 allowing you to use native python classes.
@@ -276,16 +276,16 @@ in the same order as we defined earlier.
 
 .. note::
    Observe how we had insert a leading ``3`` to tell VTK that our face
-   will contain three points. In our :class:`pyvista.PolyData` VTK
+   will contain three points. In our `PolyData`_ VTK
    doesn't assume that faces always contain three points, so we have
    to define that. This actually gives us the flexibility to define
    as many (or as few as one) points per cell as we wish.
 
 
 Now we have all the necessary pieces to assemble an instance of
-:class:`pyvista.PolyData` that contains a single triangle. To do
+`PolyData`_ that contains a single triangle. To do
 this, we simply provide the ``points`` and ``cells`` to the
-constructor of a :class:`pyvista.PolyData`. We can see from the
+constructor of a `PolyData`_. We can see from the
 representation that this geometry contains three points and one cell
 
 .. jupyter-execute::
@@ -320,7 +320,7 @@ connectivity of the points.
 This instance has several attributes to access the underlying data of
 the mesh. For example, if you wish to access or modify the points of
 the mesh, you can simply access the points attribute with
-:attr:`points <pyvista.core.dataset.DataSet.points>`.
+:attr:`points <pyvista.DataSet.points>`.
 
 .. jupyter-execute::
 
@@ -341,10 +341,10 @@ Or we could simply get the representation of the mesh with:
 
 In this representation we see:
 
-* Number of points :attr:`n_points <pyvista.core.dataset.DataSet.n_points>`
-* Number of cells :attr:`n_points <pyvista.core.dataset.DataSet.n_cells>`
-* Bounds of the mesh :attr:`bounds <pyvista.core.dataset.DataSet.bounds>`
-* Number of data arrays :attr:`n_arrays <pyvista.core.dataset.DataSet.n_arrays>`
+* Number of cells :attr:`n_cells <pyvista.DataSet.n_cells>`
+* Number of points :attr:`n_points <pyvista.DataSet.n_points>`
+* Bounds of the mesh :attr:`bounds <pyvista.DataSet.bounds>`
+* Number of data arrays :attr:`n_arrays <pyvista.DataSet.n_arrays>`
 
 This is vastly different from the output from VTK.  See
 :ref:`pyvista_vs_vtk_object_repr` for the comparison between the two
@@ -368,18 +368,18 @@ geometry.
 
 Data Arrays
 -----------
-Each :class:`pyvista.DataSet <pyvista.core.dataset.DataSet>` contains
+Each :class:`DataSet <pyvista.DataSet>` contains
 attributes that allow you to access the underlying numeric data.  This
 numerical data may be associated with the :attr:`points
-<pyvista.core.dataset.DataSet.points>`, :attr:`cells
-<pyvista.core.dataset.DataSet.cells>`, or not associated with points
+<pyvista.DataSet.points>`, :attr:`cells
+<pyvista.DataSet.cells>`, or not associated with points
 or cells and attached to the mesh in general.
 
 To illustrate data arrays within PyVista, let's first construct a
 slightly more complex mesh than our previous example.  Here, we create
 a simple mesh containing four equal cells by starting with a
-:class:`pyvista.UniformGrid` and then casting it to a
-:class:`pyvista.UnstructuredGrid` with with :func:`cast_to_unstructured_grid <pyvista.core.dataset.DataSet.cast_to_unstructured_grid`.
+`UniformGrid`_ and then casting it to an
+`UnstructuredGrid`_ with `cast_to_unstructured_grid`_.
 
 .. jupyter-execute::
 
@@ -430,11 +430,11 @@ attribute of our mesh.
 Cell Data
 ~~~~~~~~~
 The easiest way to add scalar data to a :class:`DataSet
-<pyvista.core.dataset.DataSet>` is to use the ``[]`` operator.
+<pyvista.DataSet>` is to use the ``[]`` operator.
 Continuing with our example above, let's assign each cell a single
 integer.  We can do this using a python :class:`list` and making it
 the same length as the number of cells in the
-:class:`pyvista.UnstructuredGrid`.  Here we create the list, add it to
+`UnstructuredGrid`_.  Here we create the list, add it to
 the `attr:`cell_data <pyvista.DataSet.cell_data>`, and then access
 it using the ``[]`` operator.
 
@@ -478,9 +478,9 @@ assigned.
    >>> pl.show()
 
 We can continue to assign cell data to our :class:`DataSet
-<pyvista.core.dataset.DataSet>` using the ``[]`` operator, but if you
+<pyvista.DataSet>` using the ``[]`` operator, but if you
 do no wish the new array to become the active array, you can add it
-using :func:`set_array() <pyvista.DataSet.set_array>`
+using :func:`set_array <pyvista.DataSet.set_array>`
 
 .. jupyter-execute::
 
@@ -496,10 +496,10 @@ possible to have an many cell arrays associated with a dataset and
 track which one will plotted as the active cell scalars by default.
 
 The active scalars can also be accessed or set via
-:attr:`active_scalars <pyvista.core.dataset.DataSet.active_scalars>`,
+:attr:`active_scalars <pyvista.DataSet.active_scalars>`,
 and the name of the active scalars array can be accessed or set with
 :attr:`active_scalars_name
-<pyvista.core.dataset.DataSet.active_scalars_name>`.
+<pyvista.DataSet.active_scalars_name>`.
 
 .. jupyter-execute::
 
@@ -513,7 +513,7 @@ Data can be associated to points in the same manner as in
 :ref:`pyvista_data_model_cell_data`.  The :attr:`point_data
 <pyvista.DataSet.point_data>` attribute allows you to associate point
 data to the points of a :class:`DataSet
-<pyvista.core.dataset.DataSet>`.  Here, we will associate a simple
+<pyvista.DataSet>`.  Here, we will associate a simple
 list to the points using the ``[]`` operator.
 
 .. jupyter-execute::
@@ -567,10 +567,10 @@ using :func:`set_array() <pyvista.DataSet.set_array>`.
 Again, here there are now two arrays associated to the point data, and
 only one is the "active" scalars.  Like as in the cell data, can set
 or retrieve this with :attr:`active_scalars
-<pyvista.core.dataset.DataSet.active_scalars>`, and the name of the
+<pyvista.DataSet.active_scalars>`, and the name of the
 active scalars array can be accessed or set with
 :attr:`active_scalars_name
-<pyvista.core.dataset.DataSet.active_scalars_name>`.
+<pyvista.DataSet.active_scalars_name>`.
 
 .. jupyter-execute::
 
@@ -595,7 +595,7 @@ There are active scalars in both point and cell data, but only one
 type of scalars can be "active" at the dataset level.  The reason for
 this is only one scalar type (be it point or cell) can be plotted at
 once, and this data can be obtained from :attr:`active_scalars_info
-<pyvista.core.dataset.DataSet.active_scalars_info>`:
+<pyvista.DataSet.active_scalars_info>`:
 
 .. jupyter-execute::
 
@@ -604,7 +604,7 @@ once, and this data can be obtained from :attr:`active_scalars_info
 Note that the active scalars are by default the point scalars.  You
 can change this by setting the active scalars with
 :func:`set_active_scalars
-<pyvista.core.dataset.DataSet.set_active_scalars>`.  Note that if you
+<pyvista.DataSet.set_active_scalars>`.  Note that if you
 want to set the active scalars and both the point and cell data have
 an array of the same name, you must specify the ``preference``:
 
@@ -623,7 +623,7 @@ Field Data
 Field arrays are different from :attr:`point_data
 <pyvista.DataSet.point_data>` and :attr:`cell_data
 <pyvista.DataSet.cell_data>` in that they are not associated with
-the geometry of the :class:`DataSet <pyvista.core.dataset.DataSet>`.
+the geometry of the :class:`DataSet <pyvista.DataSet>`.
 This means that while it's not possible to designate the field data as
 active scalars or vectors, you can use it to "attach" arrays of any
 row and columns.  You can even add string arrays in the field data:
@@ -649,17 +649,17 @@ number of cells or points.  As such, it also cannot be plotted.
 
 Vectors, Textures, and Normals Attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Both cell and point data can also store the following "special" attributes in addition to :attr:`active_scalars <pyvista.core.dataset.DataSet.active_scalars>`
+Both cell and point data can also store the following "special" attributes in addition to :attr:`active_scalars <pyvista.DataSet.active_scalars>`
 
-* :attr:`active_normals <pyvista.core.dataset.DataSet.active_normals>`
-* :attr:`active_t_coords <pyvista.core.dataset.DataSet.active_t_coords>`
-* :attr:`active_vectors <pyvista.core.dataset.DataSet.active_vectors>`
+* :attr:`active_normals <pyvista.DataSet.active_normals>`
+* :attr:`active_t_coords <pyvista.DataSet.active_t_coords>`
+* :attr:`active_vectors <pyvista.DataSet.active_vectors>`
 
 
 Active Normals
 ~~~~~~~~~~~~~~
 The :attr:`active_normals
-<pyvista.core.dataset.DataSet.active_normals>` array is a special
+<pyvista.DataSet.active_normals>` array is a special
 array that is used for creating physically based rendering or
 rendering smooth shading using the phong interpolation.  If this array
 is not set when plotting with ``smooth_shading=True`` or ``pbr=True``,
@@ -669,7 +669,7 @@ it will be computed.
 Active Texture Coordinates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 The :attr:`active_tcoords
-<pyvista.core.dataset.DataSet.active_t_coords>` array is used for
+<pyvista.DataSet.active_t_coords>` array is used for
 rendering textures.  See :ref:`ref_texture_example` for examples using
 this array.
 
@@ -677,17 +677,17 @@ this array.
 Active Vectors
 ~~~~~~~~~~~~~~
 The :attr:`active_vectors
-<pyvista.core.dataset.DataSet.active_vectors>` is an array containing
+<pyvista.DataSet.active_vectors>` is an array containing
 quantities that have magnitude and direction (specifically, three
 components).  For example, a vector field containing the wind speed at
 various coordinates.  This differs from :attr:`active_scalars
-<pyvista.core.dataset.DataSet.active_scalars>` as scalars are expected
+<pyvista.DataSet.active_scalars>` as scalars are expected
 to be non-directional even if they contain several components (as in
 the case of RGB data).
 
 Vectors are treated differently within VTK than scalars when
-performing transformations using the :func:`transform()
-<pyvista.core.dataset.DataSet.transform>` filter.  Unlike scalar
+performing transformations using the :func:`transform
+<pyvista.DataSet.transform>` filter.  Unlike scalar
 arrays, vector arrays will be transformed along with the geometry as
 these vectors represent quantities with direction.
 
@@ -695,22 +695,20 @@ these vectors represent quantities with direction.
 
    VTK permits only one "active" vector.  If you have multiple vector
    arrays that you wish to transform, set
-   ``transform_all_input_vectors=True`` in :func:`transform()
-   <pyvista.core.dataset.DataSet.transform>`.  Be aware that this will
+   ``transform_all_input_vectors=True`` in :func:`transform
+   <pyvista.DataSet.transform>`.  Be aware that this will
    transform any array with three components, so multi-component
    scalar arrays like RGB arrays will have to be discarded after
    transformation.
-
 
 .. _vtkDataArray: https://vtk.org/doc/nightly/html/classvtkDataArray.html
 .. _vtkDataSet: https://vtk.org/doc/nightly/html/classvtkDataSet.html
 .. _vtkFieldData: https://vtk.org/doc/nightly/html/classvtkFieldData.html
 .. _vtkDataObject: https://vtk.org/doc/nightly/html/classvtkDataObject.html
-.. _vtk.vtkPolyData: https://vtk.org/doc/nightly/html/classvtkPolyData.html
-.. _vtk.UnstructuredGrid: https://vtk.org/doc/nightly/html/classvtkUnstructuredGrid.html
-.. _vtk.vtkStructuredGrid: https://vtk.org/doc/nightly/html/classvtkStructuredGrid.html
-.. _vtk.vtkRectilinearGrid: https://vtk.org/doc/nightly/html/classvtkRectilinearGrid.html
 .. _vtkImageData: https://vtk.org/doc/nightly/html/classvtkImageData.html
 .. _vtk.vtkMultiBlockDataSet: https://vtk.org/doc/nightly/html/classvtkMultiBlockDataSet.html
 
-.. _cast_to_unstructured_grid: :func:`cast_to_unstructured_grid <pyvista.core.dataset.DataSet.cast_to_unstructured_grid>`
+.. _PolyData: :class:`PolyData <pyvista.PolyData>`
+.. _UnstructuredGrid: :class:`UnstructuredGrid <pyvista.UnstructuredGrid>`
+.. _UniformGrid: :class:`UniformGrid <pyvista.UniformGrid>`
+.. _cast_to_unstructured_grid: :func:`cast_to_unstructured_grid <pyvista.DataSet.cast_to_unstructured_grid>`

--- a/doc/user-guide/index.rst
+++ b/doc/user-guide/index.rst
@@ -56,7 +56,7 @@ User Guide Contents
    what-is-a-mesh
    simple
    data_model
-   pyvista_to_vtk
+   vtk_to_pyvista
    themes
    jupyter/index
    optional_features

--- a/doc/user-guide/optional_features.rst
+++ b/doc/user-guide/optional_features.rst
@@ -95,7 +95,7 @@ projecting the random_hills example data to a triangular plane.
     elevations = data.point_data["Elevation"][data_inds]
 
     # Mask points on planes
-    planes.cell_data["Elevation"] = np.zeros((planes.n_cells,))
+    planes.cell_data["Elevation"] = np.zeros(planes.n_cells)
     planes.cell_data["Elevation"][pt_inds] = elevations
 
     # Create axes

--- a/doc/user-guide/pyvista_to_vtk.rst
+++ b/doc/user-guide/pyvista_to_vtk.rst
@@ -39,7 +39,7 @@ structure using VTK Python's bindings, one would write the following:
 
    >>> image_data.GetPointData().SetScalars(points)
 
-As you can see, there is quite a bit of boiler-plate that goes into
+As you can see, there is quite a bit of boilerplate that goes into
 the creation of a simple `vtk.vtkImageData`_ dataset, PyVista provides
 a much cleaner syntax that is both more readable and intuitive. The
 equivalent code in pyvista is:
@@ -50,8 +50,8 @@ equivalent code in pyvista is:
    >>> import pyvista
    >>> import numpy as np
 
-   Use the meshgrid method to create 2D "grids" of the x and y values.
-   This section effectively replaces ``vtkDoubleArray``
+   Use the meshgrid function to create 2D "grids" of the x and y values.
+   This section effectively replaces the vtkDoubleArray.
 
    >>> xi = np.arange(300)
    >>> x, y = np.meshgrid(xi, xi)
@@ -74,13 +74,13 @@ Here, PyVista has done several things for us:
 
 #. :class:`pyvista.UniformGrid` wraps `vtk.vtkImageData`_, just with a
    better name; they are both containers of evenly spaced points. Your
-   data does not have to be an "image" to use it with vtk.vtkImageData;
-   rather, like images, values in the dataset are evenly spaced apart
-   like pixels in an image.
+   data does not have to be an "image" to use it with
+   `vtk.vtkImageData`_; rather, like images, values in the dataset are
+   evenly spaced apart like pixels in an image.
 
    Furthermore, since we know the container is for uniformly spaced data,
    pyvista sets the origin and spacing by default to ``(0, 0, 0)`` and
-   ``(1, 1, 1)``. This is another great thing about PyVista and python!
+   ``(1, 1, 1)``. This is another great thing about PyVista and Python!
    Rather than having to know everything about the VTK library up front,
    you can get started very easily! Once you get more familiar with it
    and need to do something more complex, you can dive deeper. For
@@ -93,18 +93,18 @@ Here, PyVista has done several things for us:
 
 #. The name for the :attr:`point_array <pyvista.point_array>` is given
    directly in dictionary-style fashion. Also, since VTK stores data
-   on the heap (linear segments of RAM memory; a C++ concept), the
-   data must be flattened and put in FORTRAN ordering (controls the
-   data "endianness"; numpy uses "C"-style endianness by
-   default). This is why in our earlier example, the first argument to
-   ``SetValue()`` was written as ``x*300 + y``. Here, numpy takes care of
-   this for us quite nicely and it's made more explicit in the code,
-   following the Python best practice of "Explicit is better than
-   implicit".
+   on the heap (linear segments of RAM; a C++ concept), the
+   data must be flattened and put in FORTRAN ordering (which controls
+   how multidimensional data is laid out in physically 1d memory; numpy
+   uses "C"-style memory layout by default). This is why in our earlier
+   example, the first argument to ``SetValue()`` was written as
+   ``x*300 + y``. Here, numpy takes care of this for us quite nicely
+   and it's made more explicit in the code, following the Python best
+   practice of "Explicit is better than implicit".
 
 Finally, with PyVista, each geometry class contains methods that allow
 you to immediately plot the mesh without also setting up the plot.
-For example, in VTK you would:
+For example, in VTK you would have to do:
 
 .. code:: python
 
@@ -198,7 +198,7 @@ Since the end goal is to construct a :class:`pyvista.DataSet
    >>> import pyvista
    >>> poly_data = pyvista.PolyData(np_points)
 
-Whereas in VTK you would have to:
+Whereas in VTK you would have to do:
 
 .. jupyter-execute::
 
@@ -220,7 +220,7 @@ and then assign it to `vtkPolyData`_:
    >>> vtk_poly_data.SetPolys(cell_arr)
 
 In PyVista, we can assign this directly in the constructor and then
-access it (or change it) from from the :attr:`faces
+access it (or change it) from the :attr:`faces
 <pyvista.PolyData.faces>` attribute.
 
 .. jupyter-execute::
@@ -236,15 +236,16 @@ Object Representation
 Both VTK and PyVista provide representations for their objects.
 
 VTK provides a verbose representation of their datatypes that can be
-accessed via ``print`` as their ``__repr__`` is exposed from
-``__str__``:
+accessed via ``print``, as the ``__repr__`` (unlike ``__str__``) only
+provides minimal information about each object:
 
 .. jupyter-execute::
 
    >>> print(vtk_poly_data)
 
-PyVista provides minimal set of data and prefers to have attributes
-accessed dynamically.  For example:
+PyVista chooses to show minimal data in the :func:`repr`, preferring
+explicit attribute access on meshes for the bulk of attributes.
+For example:
 
 .. jupyter-execute::
 
@@ -252,17 +253,17 @@ accessed dynamically.  For example:
 
 In this representation we see:
 
-* Number of points :attr:`n_points <pyvista.core.dataset.DataSet.n_points>`
-* Number of cells :attr:`n_points <pyvista.core.dataset.DataSet.n_cells>`
-* Bounds of the mesh :attr:`bounds <pyvista.core.dataset.DataSet.bounds>`
-* Number of data arrays :attr:`n_arrays <pyvista.core.dataset.DataSet.n_arrays>`
+* Number of cells :attr:`n_cells <pyvista.DataSet.n_cells>`
+* Number of points :attr:`n_points <pyvista.DataSet.n_points>`
+* Bounds of the mesh :attr:`bounds <pyvista.DataSet.bounds>`
+* Number of data arrays :attr:`n_arrays <pyvista.DataSet.n_arrays>`
 
 All other attributes like :attr:`lines <pyvista.PolyData.lines>`,
-:attr:`point_data <pyvista.core.dataset.DataSet.point_data>`, or
-:attr:`cell_data <pyvista.core.dataset.DataSet.cell_data>` can be
+:attr:`point_data <pyvista.DataSet.point_data>`, or
+:attr:`cell_data <pyvista.DataSet.cell_data>` can be
 accessed directly from the object.  This approach was chosen to allow
-for a brief summary showing key parts of the :class:`pyvista.DataSet
-<pyvista.core.dataset.DataSet>` without overwhelming the user.
+for a brief summary showing key parts of the :class:`DataSet
+<pyvista.DataSet>` without overwhelming the user.
 
 Tradeoffs
 ---------
@@ -288,11 +289,11 @@ example:
    pl.camera_position = 'xy'
    pl.show()
 
-Under the hood, the collision filter detects mesh collisions using a
+Under the hood, the collision filter detects mesh collisions using
 oriented bounding box (OBB) trees.  For a single collision, this filter
-is as performant as the vtk counterpart, but when computing multiple
+is as performant as the VTK counterpart, but when computing multiple
 collisions with the same meshes, as in the :ref:`collision_example`
-example, it is more efficient (though less convienent) to use the VTK
+example, it is more efficient (though less convenient) to use the
 underlying `vtkCollisionDetectionFilter
 <https://vtk.org/doc/nightly/html/classvtkCollisionDetectionFilter.html>`_,
 as the OBB tree is computed once for each mesh.  In most cases, pure

--- a/doc/user-guide/simple.rst
+++ b/doc/user-guide/simple.rst
@@ -165,15 +165,15 @@ code after calling :func:`show() <pyvista.Plotter.show>`.
     plotter.show()            # show the rendering window
 
 
-Note that by default :func:`show() <pyvista.Plotter.show>` will return
+Optionally :func:`show() <pyvista.Plotter.show>` can return
 the last used camera position of the rendering window in case you want
 to choose a camera position and use it again later. The camera
 position is also available as the :attr:`camera_position
 <pyvista.Plotter.camera_position>` attribute of the plotter (even
 after it's closed).
 
-You can then use this cached camera for additional plotting without having to
-manually interact with the plotting window:
+You can then use this cached camera position for additional plotting
+without having to manually interact with the plotting window:
 
 .. code:: python
 
@@ -185,10 +185,14 @@ manually interact with the plotting window:
     plotter.show(screenshot='airplane.png')
 
 
-Be sure to check out all the available plotters for your use case:
+Be sure to check out all the available plotters and their options for
+your use case:
 
-* :class:`pyvista.Plotter`: The standard plotter that pauses the code until closed
-* :class:`pyvistaqt.BackgroundPlotter`: Creates a rendering window that is interactive and does not pause the code execution (for more information see the `pyvistaqt`_ package)
+* :class:`pyvista.Plotter`: The standard plotter that pauses the code
+  until closed
+* :class:`pyvistaqt.BackgroundPlotter`: Creates a rendering window that
+  is interactive and does not pause the code execution (for more
+  information see the `pyvistaqt`_ package)
 
 .. _pyvistaqt: https://qtdocs.pyvista.org/
 

--- a/doc/user-guide/vtk_to_pyvista.rst
+++ b/doc/user-guide/vtk_to_pyvista.rst
@@ -57,7 +57,7 @@ equivalent code in pyvista is:
    >>> x, y = np.meshgrid(xi, xi)
    >>> values = 127.5 + (1.0 + np.sin(x/25.0)*np.cos(y/25.0))
 
-   Create the grid.  Note how the values must use FORTRAN ordering.
+   Create the grid.  Note how the values must use Fortran ordering.
 
    >>> grid = pyvista.UniformGrid((300, 300, 1))
    >>> grid.point_data["values"] = values.flatten(order="F")
@@ -94,7 +94,7 @@ Here, PyVista has done several things for us:
 #. The name for the :attr:`point_array <pyvista.point_array>` is given
    directly in dictionary-style fashion. Also, since VTK stores data
    on the heap (linear segments of RAM; a C++ concept), the
-   data must be flattened and put in FORTRAN ordering (which controls
+   data must be flattened and put in Fortran ordering (which controls
    how multidimensional data is laid out in physically 1d memory; numpy
    uses "C"-style memory layout by default). This is why in our earlier
    example, the first argument to ``SetValue()`` was written as

--- a/doc/user-guide/vtk_to_pyvista.rst
+++ b/doc/user-guide/vtk_to_pyvista.rst
@@ -206,9 +206,9 @@ Whereas in VTK you would have to do:
    >>> vtk_poly_data.SetPoints(vtk_points)
 
 The same goes with assigning face or cell connectivity/topology.  With
-VTK you would normally have to loop using ``InsertNextCell`` and
-``InsertCellPoint``.  For example, to create a single cell (triangle)
-and then assign it to `vtkPolyData`_:
+VTK you would normally have to loop using :func:`InsertNextCell` and
+:func:`InsertCellPoint`.  For example, to create a single cell
+(triangle) and then assign it to `vtkPolyData`_:
 
 .. jupyter-execute::
 
@@ -236,8 +236,8 @@ Object Representation
 Both VTK and PyVista provide representations for their objects.
 
 VTK provides a verbose representation of their datatypes that can be
-accessed via ``print``, as the ``__repr__`` (unlike ``__str__``) only
-provides minimal information about each object:
+accessed via :func:`print`, as the ``__repr__`` (unlike ``__str__``)
+only provides minimal information about each object:
 
 .. jupyter-execute::
 

--- a/doc/user-guide/vtk_to_pyvista.rst
+++ b/doc/user-guide/vtk_to_pyvista.rst
@@ -1,4 +1,4 @@
-.. _pyvista_to_vtk_docs:
+.. _vtk_to_pyvista_docs:
 
 
 Transitioning from VTK to PyVista
@@ -229,7 +229,7 @@ access it (or change it) from the :attr:`faces
    >>> poly_data = pyvista.PolyData(np_points, faces)
    >>> poly_data.faces
 
-.. _pyvista_vs_vtk_object_repr:
+.. _vtk_vs_pyvista_object_repr:
 
 Object Representation
 ---------------------

--- a/doc/user-guide/what-is-a-mesh.rst
+++ b/doc/user-guide/what-is-a-mesh.rst
@@ -6,14 +6,14 @@ In PyVista, a mesh is any spatially referenced information and usually
 consists of geometrical representations of a surface or volume in 3D
 space.  We commonly refer to any spatially referenced dataset as a
 mesh, so often the distinction between a mesh, a grid, and a volume
-can get fuzzy - but that does not matter in PyVista. If you have a
+can get fuzzy – but that does not matter in PyVista. If you have a
 dataset that is a surface mesh with 2D geometries like triangles, we
-call it a mesh and if you have a dataset with 3D geometries like
-voxels, tetrahedrals, hexahedrons, etc., then we also call that a
+call it a mesh, and if you have a dataset with 3D geometries like
+voxels, tetrahedra, hexahedra, etc., then we also call that a
 mesh! Why? Because it is simple that way.
 
 In all spatially referenced datasets, there lies an underlying mesh structure
-- the connectivity or geometry between nodes to define cells. Whether those
+– the connectivity or geometry between nodes to define cells. Whether those
 cells are 2D or 3D is not always of importance and we've worked hard to make
 PyVista work for datasets of either or mixed geometries so that you as a user
 do not have to get bogged down in the nuances.
@@ -26,16 +26,16 @@ do not have to get bogged down in the nuances.
 
 What is a point?
 ----------------
-Points are the vertices of the mesh - the Cartesian coordinates of the
+Points are the vertices of the mesh – the Cartesian coordinates of the
 underlying structure. All PyVista datasets (meshes!) have points and
-sometimes, you can have a mesh that only has points - like a point
+sometimes, you can have a mesh that only has points – like a point
 cloud.
 
 For example, you can create a point cloud mesh using the
 :class:`pyvista.PolyData` class which is built for meshes that have 1D
 and 2D cell types (we'll get into what a cell is briefly).
 
-Let's start with a point cloud - this is a mesh type that only has vertices.
+Let's start with a point cloud – this is a mesh type that only has vertices.
 You can create one by defining a 2D array of Cartesian coordinates like so:
 
 
@@ -50,7 +50,7 @@ You can create one by defining a 2D array of Cartesian coordinates like so:
     mesh.plot(point_size=30, render_points_as_spheres=True)
 
 
-But it's import to note that most meshes have some sort of
+But it's important to note that most meshes have some sort of
 connectivity between points such as this gridded mesh:
 
 
@@ -98,7 +98,7 @@ What is a Cell?
 A cell is the geometry between points that defines the connectivity or
 topology of a mesh. In the examples above, cells are defined by the
 lines (edges colored in black) connecting points (colored in red).
-For example, a cell in the beam example is a a voxel defined by region
+For example, a cell in the beam example is a voxel defined by the region
 between eight points in that mesh:
 
 .. pyvista-plot::
@@ -135,15 +135,15 @@ attributes can be accessed in a dictionary-like attribute attached to
 any PyVista mesh accessible as one of the following:
 
 * :attr:`point_data <pyvista.core.dataset.DataSet.point_data>`
-* :attr:`cell_data <pyvista.core.dataset.DataSet.cell_data>`.
-* :attr:`field_data <pyvista.core.dataset.DataSet.field_data>`.
+* :attr:`cell_data <pyvista.core.dataset.DataSet.cell_data>`
+* :attr:`field_data <pyvista.core.dataset.DataSet.field_data>`
 
 Point Data
 ~~~~~~~~~~
 Point data refers to arrays of values (scalars, vectors, etc.) that
-live on each point of the mesh.  Each element in an attribute array must
-correspond to a point or cell in the mesh.  Let's create some point
-data for the beam mesh.  When plotting the values between points are
+live on each point of the mesh.  Each element in an attribute array
+corresponds to a point in the mesh.  Let's create some point
+data for the beam mesh.  When plotting, the values between points are
 interpolated across the cells.
 
 .. pyvista-plot::
@@ -183,8 +183,8 @@ data which has a single value across the cell's domain:
 Field Data
 ~~~~~~~~~~
 Field data is not directly associated with either the points or cells
-but still should be attached the mesh.  This may be a string array
-storing notes, or even an of indices of a collision.
+but still should be attached to the mesh.  This may be a string array
+storing notes, or even indices of a :ref:`collision_example`.
 
 
 Assigning Scalars to a Mesh

--- a/examples/00-load/create-kochanek-spline.py
+++ b/examples/00-load/create-kochanek-spline.py
@@ -4,7 +4,7 @@
 Create a Kochanek Spline
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Create a kochanek spline/polyline from a numpy array of XYZ vertices.
+Create a Kochanek spline/polyline from a numpy array of XYZ vertices.
 """
 
 import pyvista as pv
@@ -29,9 +29,9 @@ points = make_points()
 points[0:5, :]
 
 ###############################################################################
-# Interpolate those points onto a parametric kochanek spline
+# Interpolate those points onto a parametric Kochanek spline
 
-# Create kochanek spline with 6 interpolation points
+# Create Kochanek spline with 6 interpolation points
 p = pv.Plotter(shape=(3, 5))
 
 c = [-1.0, -0.5, 0.0, 0.5, 1.0]

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -793,8 +793,8 @@ class DataSet(DataSetFilters, DataObject):
         Examples
         --------
         Compute normals on an example sphere mesh and return the
-        active normals for the dataset.  Show that this is the same as
-        the number of points.
+        active normals for the dataset.  Show that this is the same size
+        as the number of points.
 
         >>> import pyvista
         >>> mesh = pyvista.Sphere()
@@ -803,7 +803,7 @@ class DataSet(DataSetFilters, DataObject):
         >>> normals.shape
         (842, 3)
         >>> mesh.n_points
-
+        842
         """
         if self.point_data.active_normals is not None:
             return self.point_data.active_normals

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -776,6 +776,39 @@ class DataSet(DataSetFilters, DataObject):
                 return None
         return None
 
+    @property
+    def active_normals(self) -> Optional[pyvista_ndarray]:
+        """Return the active normals as an array.
+
+        Returns
+        -------
+        pyvista_ndarray
+            Active normals of this dataset.
+
+        Notes
+        -----
+        If both point and cell normals exist, this returns point
+        normals by default.
+
+        Examples
+        --------
+        Compute normals on an example sphere mesh and return the
+        active normals for the dataset.  Show that this is the same as
+        the number of points.
+
+        >>> import pyvista
+        >>> mesh = pyvista.Sphere()
+        >>> mesh = mesh.compute_normals()
+        >>> normals = mesh.active_normals
+        >>> normals.shape
+        (842, 3)
+        >>> mesh.n_points
+
+        """
+        if self.point_data.active_normals is not None:
+            return self.point_data.active_normals
+        return self.cell_data.active_normals
+
     def get_data_range(self,
                        arr_var: Optional[Union[str, np.ndarray]] = None,
                        preference='cell') -> Tuple[Union[float, np.ndarray], Union[float, np.ndarray]]:

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -619,7 +619,7 @@ class DataSet(DataSetFilters, DataObject):
         preference : str, optional
             If there are two arrays of the same name associated with
             points or cells, it will prioritize an array matching this
-            type.  Can be either ``'cell'``, or ``'point'``.
+            type.  Can be either ``'cell'`` or ``'point'``.
 
         """
         if preference not in ['point', 'cell', FieldAssociation.CELL,

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -758,7 +758,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         if data.ndim == 3:
             # Array of matrices. We need to make sure the order in
             # memory is right.  If row major (C/C++),
-            # transpose. VTK wants column major (FORTRAN order). The deep
+            # transpose. VTK wants column major (Fortran order). The deep
             # copy later will make sure that the array is contiguous.
             # If column order but not contiguous, transpose so that the
             # deep copy below does not happen.

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -1112,7 +1112,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         Returns
         -------
         pyvista_ndarray
-            Normals of this dataset attributes.  ``None`` if no
+            Normals of this dataset attribute.  ``None`` if no
             normals have been set.
 
         Examples

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -47,7 +47,7 @@ class Grid(DataSet):
 
 
 class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
-    """Dataset with regular variable spacing in the three coordinate directions.
+    """Dataset with variable spacing in the three coordinate directions.
 
     Can be initialized in several ways:
 
@@ -248,7 +248,7 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
 
 
 class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
-    """Models datasets with regular uniform spacing in the three coordinate directions.
+    """Models datasets with uniform spacing in the three coordinate directions.
 
     Can be initialized in several ways:
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -61,23 +61,20 @@ class PointSet(DataSet):
         return np.array(alg.GetCenter())
 
     def shallow_copy(self, to_copy):
-        """Create a shallow copy from different dataset into this dataset.
+        """Create a shallow copy from a different dataset into this one.
+
+        This method mutates this dataset and returns ``None``.
 
         Parameters
         ----------
         to_copy : pyvista.DataSet
-            Data object to perform a shallow copy from.
-
-        Returns
-        -------
-        pyvista.DataSet
-            Same return type as the input ``to_copy`` dataset.
+            Data object to perform the shallow copy from.
 
         """
         # Set default points if needed
         if not to_copy.GetPoints():
             to_copy.SetPoints(_vtk.vtkPoints())
-        return DataSet.shallow_copy(self, to_copy)
+        DataSet.shallow_copy(self, to_copy)
 
     def remove_cells(self, ind, inplace=True):
         """Remove cells.

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -86,7 +86,7 @@ class PointSet(DataSet):
             boolean array of the same size as the number of cells.
 
         inplace : bool, optional
-            Updates mesh in-place.
+            Whether to update the mesh in-place.
 
         Returns
         -------

--- a/pyvista/demos/demos.py
+++ b/pyvista/demos/demos.py
@@ -439,11 +439,6 @@ def plot_datasets(dataset_type=None):
         * ``'RectilinearGrid'``
         * ``'StructuredGrid'``
 
-    Returns
-    -------
-    dict or None
-        Dictionary of the datasets if ``return_datasets`` is ``True``.
-
     Examples
     --------
     >>> from pyvista import demos

--- a/pyvista/demos/demos.py
+++ b/pyvista/demos/demos.py
@@ -460,6 +460,7 @@ def plot_datasets(dataset_type=None):
     ###########################################################################
     # uniform grid
     image = pv.UniformGrid((6, 6, 1))
+    image.spacing = (3, 2, 1)
 
     ###########################################################################
     # RectilinearGrid

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -57,12 +57,12 @@ def Spline(points, n_points=None):
 
 
 def KochanekSpline(points, tension=None, bias=None, continuity=None, n_points=None):
-    """Create a kochanek spline from points.
+    """Create a Kochanek spline from points.
 
     Parameters
     ----------
     points : sequence
-        Array of points to build a kochanek spline out of.  Array must
+        Array of points to build a Kochanek spline out of.  Array must
         be 3D and directionally ordered.
 
     tension : sequence, optional
@@ -88,7 +88,7 @@ def KochanekSpline(points, tension=None, bias=None, continuity=None, n_points=No
 
     Examples
     --------
-    Construct a kochanek spline
+    Construct a Kochanek spline.
 
     >>> import numpy as np
     >>> import pyvista as pv
@@ -127,7 +127,7 @@ def KochanekSpline(points, tension=None, bias=None, continuity=None, n_points=No
     spline_function = _vtk.vtkParametricSpline()
     spline_function.SetPoints(pyvista.vtk_points(points, False))
 
-    # set kochanek spline for each direction
+    # set Kochanek spline for each direction
     xspline = _vtk.vtkKochanekSpline()
     yspline = _vtk.vtkKochanekSpline()
     zspline = _vtk.vtkKochanekSpline()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,3 +1,5 @@
+# TODO: This file really should be named test_dataset.py
+
 import pickle
 import numpy as np
 import pytest
@@ -1119,3 +1121,12 @@ def test_flip_normal():
     flip_normal5.flip_normal(normal=[0.0, 0.0, 1.0])
     flip_normal6.flip_z()
     assert np.allclose(flip_normal5.points, flip_normal6.points)
+
+
+def test_active_normals(sphere):
+    # both cell and point normals
+    mesh = sphere.compute_normals()
+    assert mesh.active_normals.shape[0] == mesh.n_points
+
+    mesh = sphere.compute_normals(point_normals=False)
+    assert mesh.active_normals.shape[0] == mesh.n_cells


### PR DESCRIPTION
Cleanup after https://github.com/pyvista/pyvista/pull/1571, mostly but not entirely proofreading.

Remarks:
1. I see empty figures in devdocs and local builds in doc/getting-started/why.rst https://dev.pyvista.org/getting-started/why.html#pyvista-api
2. PyVistaQt intersphinx links are missing, e.g. doc/user-guide/simple.rst BackgroundPlotter ref at https://dev.pyvista.org/user-guide/simple.html#plotting. Might need intersphinx for pyvistaqt, haven't checked yet.
3. I was annoyed to realise that `:func:` directives with an optional name (in angle brackets) don't automatically add parentheses...

I'll also add a handful of review comments which make more sense in context.

Two things that would make sense in context but they are too far from changes to be able to comment on:
1. around https://github.com/pyvista/pyvista/blob/a41d447f035214832f6dfe685adeb14fe60b0f31/doc/api/core/pointsets.rst#L78-L85
I don't really like that this paragraph pretends that assigning points and faces arrays to that empty `PolyData` is not a thing.

2. I/we should make sure that https://github.com/pyvista/pyvista/blob/a41d447f035214832f6dfe685adeb14fe60b0f31/pyvista/core/dataset.py#L632-L634
can not be tripped by requesting field arrays. If it can, perhaps we should consider special-casing field array names here, to give a better error message.