### PR TITLE
Fix get_array_association() preference bug

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -631,7 +631,7 @@ class DataSet(DataSetFilters, DataObject):
             return
         field = get_array_association(self, name, preference=preference)
         if field == FieldAssociation.NONE:
-            raise KeyError(f'Data field {name} does not exist')
+            raise KeyError(f'Data named "{name}" is a field array which cannot be active.')
         self._last_active_scalars_name = self.active_scalars_info.name
         if field == FieldAssociation.POINT:
             ret = self.GetPointData().SetActiveScalars(name)
@@ -1569,16 +1569,18 @@ class DataSet(DataSetFilters, DataObject):
             raise RuntimeError  # this should never be reached with err=True
         return arr
 
-    def get_array_association(self, name: str, preference: Literal['cell', 'point', 'field']='cell') -> FieldAssociation:
+    def get_array_association(self, name: str,
+                              preference: Literal['cell', 'point', 'field'] = 'cell') -> FieldAssociation:
         """Get the association of an array.
 
         Parameters
         ----------
         name : str
             Name of the array.
+
         preference : str, optional
-            When scalars is specified, this is the preferred array
-            type to search for in the dataset.  Must be either
+            When ``name`` is specified, this is the preferred array
+            association to search for in the dataset.  Must be either
             ``'point'``, ``'cell'``, or ``'field'``.
 
         Returns

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -390,12 +390,14 @@ def get_array_association(mesh, name, preference='cell', err=False) -> FieldAsso
         ``'cell'``, or ``'field'``.
 
     err : bool, optional
-        Boolean to control whether to throw an error if array is not present.
+        Boolean to control whether to throw an error if array is not
+        present.
 
     Returns
     -------
     pyvista.FieldAssociation
-        Association of the array
+        Association of the array. If array is not present and ``err`` is
+        ``False``, ``FieldAssociation.NONE`` is returned.
 
     """
     if isinstance(mesh, _vtk.vtkTable):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -137,3 +137,47 @@ def test_skybox(tmpdir):
 
     with pytest.raises(FileNotFoundError, match='Unable to locate'):
         pyvista.cubemap('')
+
+
+def test_array_association():
+    # TODO: cover vtkTable/ROW association case
+    mesh = pyvista.PolyData()
+    FieldAssociation = pyvista.FieldAssociation
+
+    # single match cases
+    mesh.point_data['p'] = []
+    mesh.cell_data['c'] = []
+    mesh.field_data['f'] = ['foo']
+    for preference in 'point', 'cell', 'field':
+        assoc = mesh.get_array_association('p', preference=preference)
+        assert assoc == FieldAssociation.POINT
+        assoc = mesh.get_array_association('c', preference=preference)
+        assert assoc == FieldAssociation.CELL
+        assoc = mesh.get_array_association('f', preference=preference)
+        assert assoc == FieldAssociation.NONE
+
+    # multiple match case
+    mesh.point_data['common'] = []
+    mesh.cell_data['common'] = []
+    mesh.field_data['common'] = ['foo']
+    assoc = mesh.get_array_association('common', preference='point')
+    assert assoc == FieldAssociation.POINT
+    assoc = mesh.get_array_association('common', preference='cell')
+    assert assoc == FieldAssociation.CELL
+    assoc = mesh.get_array_association('common', preference='field')
+    assert assoc == FieldAssociation.NONE
+
+    # regression test against overly suggestive preference
+    mesh.clear_cell_data()  # point and field left
+    assoc = mesh.get_array_association('common', 'cell')
+    assert assoc != FieldAssociation.CELL
+
+    # missing cases
+    mesh.clear_data()
+    with pytest.raises(KeyError, match='not present in this dataset.'):
+        assoc = mesh.get_array_association('missing')
+    assoc = pyvista.get_array_association(mesh, 'missing', err=False)
+    assert assoc == FieldAssociation.NONE
+
+    with pytest.raises(ValueError, match='not supported.'):
+        mesh.get_array_association('name', preference='invalid')

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -180,4 +180,4 @@ def test_array_association():
     assert assoc == FieldAssociation.NONE
 
     with pytest.raises(ValueError, match='not supported.'):
-        mesh.get_array_association('name', preference='invalid')
+        mesh.get_array_association('name', preference='row')


### PR DESCRIPTION
The logic for applying the preference in `get_array_association()` was buggy:
```py
>>> import pyvista as pv
>>> mesh = pv.PolyData()
>>> mesh.point_data['foo'] = []
>>> mesh.field_data['foo'] = ['bar']
>>> mesh.get_array_association('foo', preference='cell')
<FieldAssociation.CELL: 1>
```

I changed (hopefully simplified) the logic and added dedicated unit tests for `helpers.get_array_association()` (mostly proxied through `DataSet.get_array_association()`, except for the `err=False` case). I've also clarified some error messages which is why I was looking at this in the first place.

Ideally we should also cover the ROW association case at the top of the function, but I can't do that right now. I've added a corresponding TODO in the test.