### PR TITLE
run CI on push to main only

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -8,6 +8,8 @@ on:
   push:
     tags:
       - "*"
+    branches:
+      - main
 
 jobs:
   macOS:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,9 @@ trigger:
   tags:
     include:
     - '*'
+  branches:
+    include:
+    - 'main'
 
 pr:
   branches:


### PR DESCRIPTION
This PR adjusts the CI to run when pushing to main.  This is necessary to validate PRs as well as to update our dev docs.
