### PR TITLE
Use built-in typing when possible

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -3,10 +3,11 @@
 import warnings
 import collections.abc
 import logging
+import sys
 from typing import Optional, List, Tuple, Iterable, Union, Any, Dict
-try:
+if sys.version_info >= (3, 8):
     from typing import Literal
-except ImportError:
+else:
     # Python <=3.7
     from typing_extensions import Literal
 

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -8,7 +8,6 @@ from typing import Optional, List, Tuple, Iterable, Union, Any, Dict
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
-    # Python <=3.7
     from typing_extensions import Literal
 
 import numpy as np

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -4,7 +4,11 @@ import warnings
 import collections.abc
 import logging
 from typing import Optional, List, Tuple, Iterable, Union, Any, Dict
-from typing_extensions import Literal # for python versions <3.8
+try:
+    from typing import Literal
+except ImportError:
+    # Python <=3.7
+    from typing_extensions import Literal
 
 import numpy as np
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = ['numpy',
                     'meshio>=4.0.3, <5.0',
                     'vtk',
                     'dataclasses;python_version=="3.6"',
-                    'typing_extensions',
+                    'typing_extensions;python_version<="3.7"',
                     ]
 
 readme_file = os.path.join(filepath, 'README.rst')


### PR DESCRIPTION
### Overview

#1658 added `typing_extensions` as a required dependency for all installs.  This was required by #1592 which imported `typing_extensions`.  However, this is not required for `Python>=3.8`.  This PR uses built-in `typing` when possible, and `typing_extensions` when not possible.  Additionally, `typing_extensions` is only installed when `Python<=3.7`.

cc @akaszynski if you want to test on the failure you noted.

