### PR TITLE
Align vtkDataSetReader usage and add more ReadAll* calls by default

### DIFF
--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -206,6 +206,9 @@ def read_legacy(filename):
     reader.ReadAllNormalsOn()
     reader.ReadAllTCoordsOn()
     reader.ReadAllVectorsOn()
+    reader.ReadAllFieldsOn()
+    reader.ReadAllTensorsOn()
+
     # Perform the read
     output = standard_reader_routine(reader, None)
     if output is None:

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -686,6 +686,12 @@ class STLReader(BaseReader):
 class VTKDataSetReader(BaseReader):
     """VTK Data Set Reader for .vtk files.
     
+    Notes
+    -----
+    This reader calls `ReadAllScalarsOn`, `ReadAllColorScalarsOn`,
+    `ReadAllNormalsOn`, `ReadAllTCoordsOn`, `ReadAllVectorsOn`,
+    and `ReadAllFieldsOn` on the underlying `vtkDataSetReader`.
+
     Examples
     --------
     >>> import pyvista
@@ -701,6 +707,18 @@ class VTKDataSetReader(BaseReader):
     """
 
     _class_reader = _vtk.vtkDataSetReader
+
+    def __init__(self, filename):
+        """Initialize VTKDataSetReader with filename."""
+        super().__init__(filename)
+        # Provide consistency with defaults in pyvista.read
+        self.reader.ReadAllScalarsOn()
+        self.reader.ReadAllColorScalarsOn()
+        self.reader.ReadAllNormalsOn()
+        self.reader.ReadAllTCoordsOn()
+        self.reader.ReadAllVectorsOn()
+        self.reader.ReadAllFieldsOn()
+        self.reader.ReadAllTensorsOn()
 
 
 class VTKPDataSetReader(BaseReader):


### PR DESCRIPTION
### Overview

Fixes #1632.  This PR aligns the default behavior of vtkDataSetReader between the pyvista Reader class and the `pyvista.read` methods.  It also adds calling all of the `ReadAll*` methods by default.


### Details

I was intending to expose all of these methods and the ones that turn off the `ReadAll*` methods in the pyvista API, but I think they are only used in special cases, when mutliple arrays are specified for vectors, for example.  Power users can still modify the underlying reader to turn off the behavior using, for example,

```py
reader.reader.ReadAllVectorsOff()
```

After this PR, I think it is possible in `pyvista.utilities.fileio` to use the Reader classes directly.  This way the two methods should always stay in sync.
