### PR TITLE
implement copy on transform

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -4377,6 +4377,19 @@ class DataSetFilters:
         if inplace:
             self.overwrite(res)
             return self
+
+        # The output from the transform filter contains a shallow copy
+        # of the cell array.  We need to perform a deep copy so the
+        # transformed array is a deep copy
+        carr = _vtk.vtkCellArray()
+        if hasattr(self, 'GetPolys'):
+            carr.DeepCopy(self.GetPolys())
+            res.SetPolys(carr)
+        elif hasattr(self, 'GetCells'):
+            carr.DeepCopy(self.GetCells())
+            celltypes = _vtk.numpy_to_vtk(self.celltypes, deep=True)
+            res.SetCells(celltypes, carr)
+
         return res
 
     def reflect(self, normal, point=None, inplace=False,

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -21,7 +21,7 @@ from .dataset import DataSet
 from .filters import (PolyDataFilters, UnstructuredGridFilters,
                       StructuredGridFilters, _get_output)
 from ..utilities.fileio import get_ext
-from .errors import DeprecationError
+from .errors import DeprecationError, VTKVersionError
 
 log = logging.getLogger(__name__)
 log.setLevel('CRITICAL')

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1444,10 +1444,10 @@ def test_transform_mesh(datasets, num_cell_arrays, num_point_data):
         tf = pyvista.transformations.axis_angle_rotation((1, 0, 0), 90)
 
         for i in range(num_cell_arrays):
-            dataset.cell_data['C%d' % i] = np.random.rand(dataset.n_cells, 3)
+            dataset.cell_data[f'C{i}'] = np.random.rand(dataset.n_cells, 3)
 
         for i in range(num_point_data):
-            dataset.point_data['P%d' % i] = np.random.rand(dataset.n_points, 3)
+            dataset.point_data[f'P{i}'] = np.random.rand(dataset.n_points, 3)
 
         # deactivate any active vectors!
         # even if transform_all_input_vectors is False, vtkTransformfilter will
@@ -1466,6 +1466,18 @@ def test_transform_mesh(datasets, num_cell_arrays, num_point_data):
 
         for name, array in dataset.cell_data.items():
             assert transformed.cell_data[name] == pytest.approx(array)
+
+        # verify that the cell connectivity is a deep copy
+        if hasattr(dataset, '_connectivity_array') and VTK9:
+            transformed._connectivity_array[0] += 1
+            assert not np.array_equal(
+                dataset._connectivity_array, transformed._connectivity_array
+            )
+        if hasattr(dataset, 'cell_connectivity') and VTK9:
+            transformed.cell_connectivity[0] += 1
+            assert not np.array_equal(
+                dataset.cell_connectivity, transformed.cell_connectivity
+            )
 
 
 @pytest.mark.parametrize('num_cell_arrays,num_point_data',


### PR DESCRIPTION
As discovered in #1669, the `vtk.vtkTransformFilter` does not actually return a deep copy of the input dataset, but a shallow copy of everything except the point arrays.  This means that when we use `mesh.transform(..., inplace=False)`, we're still returning a shallow copy of the dataset.


```py
>>> from pyvista import examples
>>> import pyvista as pv
>>> import numpy as np

Transform the mesh

>>> mesh = examples.load_hexbeam()
>>> trans = np.diag(np.ones(4))
>>> trans[:, -1] = 1
>>> transformed = mesh.transform(trans, inplace=False)

Modify the cell connectivity of one dataset insitu.  Show that the cell data is still linked

>>> mesh.cell_connectivity[0] += 1
>>> np.array_equal(mesh.cell_connectivity, transformed.cell_connectivity)
True

Same with cell data

>>> mesh.cell_data['sample_cell_scalars'][0] += 10
>>> mesh.cell_data == transformed.cell_data
True

Same with point data

>>> mesh.point_data['sample_point_scalars'][0] += 10
>>> mesh.point_data == transformed.point_data
True

```

The fix for this is to simply create a new instance matching the type of the original dataset and overwrite it with the transformed dataset.
