### PR TITLE
Add Platonic solids

### DIFF
--- a/doc/api/utilities/geometric.rst
+++ b/doc/api/utilities/geometric.rst
@@ -19,13 +19,18 @@ additional details see :ref:`ref_geometric_example` example.
    Cylinder
    CylinderStructured
    Disc
+   Dodecahedron
+   Icosahedron
    Line
+   Octahedron
    Plane
+   PlatonicSolid
    Polygon
    Pyramid
    Rectangle
    Sphere
    Spline
+   Tetrahedron
    Text3D
    Triangle
    Wavelet

--- a/examples/00-load/create-platonic-solids.py
+++ b/examples/00-load/create-platonic-solids.py
@@ -1,0 +1,74 @@
+"""
+.. _platonic_example:
+
+Platonic Solids
+~~~~~~~~~~~~~~~
+
+PyVista wraps the ``vtk.vtkPlatonicSolid`` filter as
+:func:`pyvista.PlatonicSolid`.
+"""
+import numpy as np
+import pyvista as pv
+from pyvista import examples
+
+###############################################################################
+# We can either use the generic :func:`PlatonicSolid() <pyvista.PlatonicSolid>`
+# and specify the different kinds of solids to generate, or we can use the thin
+# wrappers
+#
+#     * :func:`pyvista.Tetrahedron`
+#     * :func:`pyvista.Octahedron`
+#     * :func:`pyvista.Dodecahedron`
+#     * :func:`pyvista.Icosahedron`
+#
+# (:func:`PlatonicSolid() <pyvista.PlatonicSolid>` can also return a cube, but
+# PyVista's existing :func:`pyvista.Cube` helper isn't based on the
+# ``vtkPlatonicSolid`` filter.)
+#
+# Let's generate all the Platonic solids, along with the :func:`teapotahedron
+# <pyvista.examples.downloads.download_teapot>`.
+
+kinds = [
+    'tetrahedron',
+    'cube',
+    'octahedron',
+    'dodecahedron',
+    'icosahedron',
+]
+centers = [
+    ( 0, 1, 0),
+    ( 0, 0, 0),
+    ( 0, 2, 0),
+    (-1, 0, 0),
+    (-1, 2, 0),
+]
+
+solids = [
+    pv.PlatonicSolid(kind, radius=0.4, center=center)
+    for kind, center in zip(kinds, centers)
+]
+
+# download and align teapotahedron
+teapot = examples.download_teapot()
+teapot.rotate_x(90)
+teapot.rotate_z(-45)
+teapot.scale(0.16)
+teapot.points += np.array([-1, 1, 0]) - teapot.center
+solids.append(teapot)
+
+###############################################################################
+# Now let's plot them all.
+
+p = pv.Plotter()
+for ind, solid in enumerate(solids):
+    # only use smooth shading for the teapot
+    smooth_shading = ind == len(solids) - 1
+    p.add_mesh(solid, color='silver', smooth_shading=smooth_shading,
+               specular=1.0, specular_power=10)
+p.view_vector((5.0, 2, 3))
+p.add_floor('-z', lighting=True, color='navy', pad=1.0)
+p.show()
+
+###############################################################################
+# The conventional Platonic solids come with cell scalars that index each face
+# of the solids (unlike the output of :func:`pyvista.Cube`).

--- a/examples/00-load/create-struss.py
+++ b/examples/00-load/create-struss.py
@@ -1,5 +1,5 @@
 """
-.. _ref_create_explicit_structured_grid:
+.. _create_truss:
 
 Plot Truss-like FEA Solution with Cylinders
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -309,6 +309,7 @@ if VTK9:
                                               vtkDiskSource,
                                               vtkRegularPolygonSource,
                                               vtkPointSource,
+                                              vtkPlatonicSolidSource,
                                               vtkFrustumSource)
     from vtkmodules.vtkFiltersGeometry import (vtkGeometryFilter,
                                                vtkStructuredGridGeometryFilter,

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -1164,6 +1164,7 @@ def PlatonicSolid(kind='tetrahedron', radius=1.0, center=(0.0, 0.0, 0.0)):
     Examples
     --------
     Create and plot a dodecahedron
+
     >>> import pyvista
     >>> dodeca = pyvista.PlatonicSolid('dodecahedron')
     >>> dodeca.plot(categories=True)
@@ -1222,6 +1223,7 @@ def Tetrahedron(radius=1.0, center=(0.0, 0.0, 0.0)):
     Examples
     --------
     Create and plot a tetrahedron
+
     >>> import pyvista
     >>> tetra = pyvista.Tetrahedron()
     >>> tetra.plot(categories=True)
@@ -1253,6 +1255,7 @@ def Octahedron(radius=1.0, center=(0.0, 0.0, 0.0)):
     Examples
     --------
     Create and plot an octahedron
+
     >>> import pyvista
     >>> tetra = pyvista.Octahedron()
     >>> tetra.plot(categories=True)
@@ -1283,6 +1286,7 @@ def Dodecahedron(radius=1.0, center=(0.0, 0.0, 0.0)):
     Examples
     --------
     Create and plot a dodecahedron
+
     >>> import pyvista
     >>> tetra = pyvista.Dodecahedron()
     >>> tetra.plot(categories=True)
@@ -1314,6 +1318,7 @@ def Icosahedron(radius=1.0, center=(0.0, 0.0, 0.0)):
     Examples
     --------
     Create and plot an icosahedron
+
     >>> import pyvista
     >>> tetra = pyvista.Icosahedron()
     >>> tetra.plot(categories=True)

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -12,6 +12,9 @@ vtkConeSource
 vtkDiskSource
 vtkRegularPolygonSource
 vtkPyramid
+vtkPlatonicSolidSource
+
+as well as some pure-python helpers.
 
 """
 import numpy as np
@@ -1128,3 +1131,192 @@ def Circle(radius=0.5, resolution=100):
     points[:, 1] = radius * np.sin(theta)
     cells = np.array([np.append(np.array([resolution]), np.arange(resolution))])
     return pyvista.wrap(pyvista.PolyData(points, cells))
+
+
+def PlatonicSolid(kind='tetrahedron', radius=1.0, center=(0.0, 0.0, 0.0)):
+    """Create a Platonic solid of a given size.
+
+    Parameters
+    ----------
+    kind : str or int, optional
+        The kind of Platonic solid to create. Either the name of the
+        polyhedron or an integer index:
+
+            * ``'tetrahedron'`` or ``0``
+            * ``'cube'`` or ``1``
+            * ``'octahedron'`` or ``2``
+            * ``'icosahedron'`` or ``3``
+            * ``'dodecahedron'`` or ``4``
+
+    radius : float, optional
+        The radius of the circumscribed sphere for the solid to create.
+
+    center : sequence, optional
+        Three-length sequence defining the center of the solid to create.
+
+    Returns
+    -------
+    pyvista.PolyData
+        One of the five Platonic solids. Cell scalars are defined that
+        assign integer labels to each face (with array name
+        ``"FaceIndex"``).
+
+    Examples
+    --------
+    Create and plot a dodecahedron
+    >>> import pyvista
+    >>> dodeca = pyvista.PlatonicSolid('dodecahedron')
+    >>> dodeca.plot(categories=True)
+
+    """
+    kinds = {
+        'tetrahedron': 0,
+        'cube': 1,
+        'octahedron': 2,
+        'icosahedron': 3,
+        'dodecahedron': 4,
+    }
+    if isinstance(kind, str):
+        if kind not in kinds:
+            raise ValueError(f'Invalid Platonic solid kind "{kind}".')
+        kind = kinds[kind]
+    elif isinstance(kind, int) and kind not in range(5):
+        raise ValueError(f'Invalid Platonic solid index "{kind}".')
+    elif not isinstance(kind, int):
+        raise ValueError('Invalid Platonic solid index type '
+                         f'"{type(kind).__name__}".')
+    check_valid_vector(center, 'center')
+
+    solid = _vtk.vtkPlatonicSolidSource()
+    solid.SetSolidType(kind)
+    solid.Update()
+    solid = pyvista.wrap(solid.GetOutput())
+    solid.scale(radius)
+    solid.points += np.asanyarray(center) - solid.center
+    # rename and activate cell scalars
+    cell_data = solid.get_array(0)
+    solid.clear_data()
+    solid.cell_data['FaceIndex'] = cell_data
+    return solid
+
+
+def Tetrahedron(radius=1.0, center=(0.0, 0.0, 0.0)):
+    """Create a tetrahedron of a given size.
+
+    A tetrahedron is composed of four congruent equilateral triangles.
+
+    Parameters
+    ----------
+    radius : float, optional
+        The radius of the circumscribed sphere for the tetrahedron.
+
+    center : sequence, optional
+        Three-length sequence defining the center of the tetrahedron.
+
+    Returns
+    -------
+    pyvista.PolyData
+        Mesh for the tetrahedron. Cell scalars are defined that assign
+        integer labels to each face (with array name ``"FaceIndex"``).
+
+    Examples
+    --------
+    Create and plot a tetrahedron
+    >>> import pyvista
+    >>> tetra = pyvista.Tetrahedron()
+    >>> tetra.plot(categories=True)
+
+    """
+    return PlatonicSolid(kind='tetrahedron', radius=radius, center=center)
+
+
+def Octahedron(radius=1.0, center=(0.0, 0.0, 0.0)):
+    """Create an octahedron of a given size.
+
+    An octahedron is composed of eight congruent equilateral
+    triangles.
+
+    Parameters
+    ----------
+    radius : float, optional
+        The radius of the circumscribed sphere for the octahedron.
+
+    center : sequence, optional
+        Three-length sequence defining the center of the octahedron.
+
+    Returns
+    -------
+    pyvista.PolyData
+        Mesh for the octahedron. Cell scalars are defined that assign
+        integer labels to each face (with array name ``"FaceIndex"``).
+
+    Examples
+    --------
+    Create and plot an octahedron
+    >>> import pyvista
+    >>> tetra = pyvista.Octahedron()
+    >>> tetra.plot(categories=True)
+
+    """
+    return PlatonicSolid(kind='octahedron', radius=radius, center=center)
+
+
+def Dodecahedron(radius=1.0, center=(0.0, 0.0, 0.0)):
+    """Create a dodecahedron of a given size.
+
+    A dodecahedron is composed of twelve congruent regular pentagons.
+
+    Parameters
+    ----------
+    radius : float, optional
+        The radius of the circumscribed sphere for the dodecahedron.
+
+    center : sequence, optional
+        Three-length sequence defining the center of the dodecahedron.
+
+    Returns
+    -------
+    pyvista.PolyData
+        Mesh for the dodecahedron. Cell scalars are defined that assign
+        integer labels to each face (with array name ``"FaceIndex"``).
+
+    Examples
+    --------
+    Create and plot a dodecahedron
+    >>> import pyvista
+    >>> tetra = pyvista.Dodecahedron()
+    >>> tetra.plot(categories=True)
+
+    """
+    return PlatonicSolid(kind='dodecahedron', radius=radius, center=center)
+
+
+def Icosahedron(radius=1.0, center=(0.0, 0.0, 0.0)):
+    """Create an icosahedron of a given size.
+
+    An icosahedron is composed of twenty congruent equilateral
+    triangles.
+
+    Parameters
+    ----------
+    radius : float, optional
+        The radius of the circumscribed sphere for the icosahedron.
+
+    center : sequence, optional
+        Three-length sequence defining the center of the icosahedron.
+
+    Returns
+    -------
+    pyvista.PolyData
+        Mesh for the icosahedron. Cell scalars are defined that assign
+        integer labels to each face (with array name ``"FaceIndex"``).
+
+    Examples
+    --------
+    Create and plot an icosahedron
+    >>> import pyvista
+    >>> tetra = pyvista.Icosahedron()
+    >>> tetra.plot(categories=True)
+
+    """
+    return PlatonicSolid(kind='icosahedron', radius=radius, center=center)

--- a/tests/test_geometric_objects.py
+++ b/tests/test_geometric_objects.py
@@ -219,3 +219,80 @@ def test_circle():
     assert mesh.n_cells
     diameter = np.max(mesh.points[:, 0]) - np.min(mesh.points[:, 0])
     assert np.isclose(diameter, radius*2.0, rtol=1e-3)
+
+
+@pytest.mark.parametrize(
+    'kind_str, kind_int, n_vertices, n_faces',
+    zip(
+        ['tetrahedron', 'cube', 'octahedron', 'icosahedron', 'dodecahedron'],
+        range(5),
+        [4, 8, 6, 12, 20],
+        [4, 6, 8, 20, 12],
+    )
+)
+def test_platonic_solids(kind_str, kind_int, n_vertices, n_faces):
+    # verify integer mapping
+    solid_from_str = pyvista.PlatonicSolid(kind_str)
+    solid_from_int = pyvista.PlatonicSolid(kind_int)
+    assert solid_from_str == solid_from_int
+
+    # verify type of solid
+    assert solid_from_str.n_points == n_vertices
+    assert solid_from_str.n_faces == n_faces
+
+
+def test_platonic_invalids():
+    with pytest.raises(ValueError):
+        solid = pyvista.PlatonicSolid(kind='invalid')
+    with pytest.raises(ValueError):
+        solid = pyvista.PlatonicSolid(kind=42)
+    with pytest.raises(ValueError):
+        solid = pyvista.PlatonicSolid(kind=[])
+
+
+def test_tetrahedron():
+    radius = 1.7
+    center = (1, -2, 3)
+    solid = pyvista.Tetrahedron(radius=radius, center=center)
+    assert solid.n_points == 4
+    assert solid.n_faces == 4
+    assert np.allclose(solid.center, center)
+
+    doubled_solid = pyvista.Tetrahedron(radius=2*radius, center=center)
+    assert np.isclose(doubled_solid.length, 2*solid.length)
+
+
+def test_octahedron():
+    radius = 1.7
+    center = (1, -2, 3)
+    solid = pyvista.Octahedron(radius=radius, center=center)
+    assert solid.n_points == 6
+    assert solid.n_faces == 8
+    assert np.allclose(solid.center, center)
+
+    doubled_solid = pyvista.Octahedron(radius=2*radius, center=center)
+    assert np.isclose(doubled_solid.length, 2*solid.length)
+
+
+def test_dodecahedron():
+    radius = 1.7
+    center = (1, -2, 3)
+    solid = pyvista.Dodecahedron(radius=radius, center=center)
+    assert solid.n_points == 20
+    assert solid.n_faces == 12
+    assert np.allclose(solid.center, center)
+
+    doubled_solid = pyvista.Dodecahedron(radius=2*radius, center=center)
+    assert np.isclose(doubled_solid.length, 2*solid.length)
+
+
+def test_icosahedron():
+    radius = 1.7
+    center = (1, -2, 3)
+    solid = pyvista.Icosahedron(radius=radius, center=center)
+    assert solid.n_points == 12
+    assert solid.n_faces == 20
+    assert np.allclose(solid.center, center)
+
+    doubled_solid = pyvista.Icosahedron(radius=2*radius, center=center)
+    assert np.isclose(doubled_solid.length, 2*solid.length)


### PR DESCRIPTION
We have no Platonic solids, and there's a `vtkPlatonicSolidSource` filter. We should wrap it.

The PR adds
1. the `pv.PlatonicSolid` function to generate all conventional solids
2. the `pv.Tetrahedron`, `pv.Octahedron`, `pv.Dodecahedron` and `pv.Icosahedron` functions
3. an example showcasing the solids (an homage to the famous [teapotahedron cover](https://en.wikipedia.org/wiki/File:The_Six_Platonic_Solids.png)).

We already have `pv.Cube` which is the fifth Platonic solid. I wondered about adding it as `pv.Hexahedron`, but it would be quite redundant. The main difference between `pv.Cube` and `pv.PlatonicSolid('cube')` is that the latter defines cell scalars that indexes the six faces. If others think this is enough reason to add the hexahedron, I'm all for it.

![Screenshot from 2021-09-26 19-53-41](https://user-images.githubusercontent.com/17914410/134818688-add12552-b83e-4567-88e9-aa30deba25d4.png)

Questions:
1. I noticed that the new truss example is called `create-struss.py`. Is the "s" in the filename a mistake? If it is, we can change it here (I already fixed a duplicate label in that example).
2. Do we want to link to the example from each of the docstrings?
3. I named the cell scalars myself (partly due to a bug I'll open an issue for). Is the name `'FaceIndex'` OK?
