### PR TITLE
Add examples for view_* functions

### DIFF
--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1980,6 +1980,18 @@ class Renderer(_vtk.vtkRenderer):
         negative : bool, optional
             View from the opposite direction.
 
+        Examples
+        --------
+        View the XY plane of a built-in mesh example.
+        
+        >>> from pyvista import examples
+        >>> import pyvista as pv
+        >>> airplane = examples.load_airplane()
+        >>> pl = pv.Plotter()
+        >>> _ = pl.add_mesh(airplane)
+        >>> pl.view_xy()
+        >>> pl.show()
+
         """
         vec = np.array([0,0,1])
         viewup = np.array([0,1,0])
@@ -1995,6 +2007,18 @@ class Renderer(_vtk.vtkRenderer):
         negative : bool, optional
             View from the opposite direction.
 
+        Examples
+        --------
+        View the YX plane of a built-in mesh example.
+        
+        >>> from pyvista import examples
+        >>> import pyvista as pv
+        >>> airplane = examples.load_airplane()
+        >>> pl = pv.Plotter()
+        >>> _ = pl.add_mesh(airplane)
+        >>> pl.view_yx()
+        >>> pl.show()
+        
         """
         vec = np.array([0,0,-1])
         viewup = np.array([1,0,0])
@@ -2009,6 +2033,18 @@ class Renderer(_vtk.vtkRenderer):
         ----------
         negative : bool, optional
             View from the opposite direction.
+
+        Examples
+        --------
+        View the XZ plane of a built-in mesh example.
+        
+        >>> from pyvista import examples
+        >>> import pyvista as pv
+        >>> airplane = examples.load_airplane()
+        >>> pl = pv.Plotter()
+        >>> _ = pl.add_mesh(airplane)
+        >>> pl.view_xz()
+        >>> pl.show()
 
         """
         vec = np.array([0,-1,0])
@@ -2025,6 +2061,18 @@ class Renderer(_vtk.vtkRenderer):
         negative : bool, optional
             View from the opposite direction.
 
+        Examples
+        --------
+        View the ZX plane of a built-in mesh example.
+        
+        >>> from pyvista import examples
+        >>> import pyvista as pv
+        >>> airplane = examples.load_airplane()
+        >>> pl = pv.Plotter()
+        >>> _ = pl.add_mesh(airplane)
+        >>> pl.view_zx()
+        >>> pl.show()
+
         """
         vec = np.array([0,1,0])
         viewup = np.array([1,0,0])
@@ -2040,6 +2088,18 @@ class Renderer(_vtk.vtkRenderer):
         negative : bool, optional
             View from the opposite direction.
 
+        Examples
+        --------
+        View the YZ plane of a built-in mesh example.
+        
+        >>> from pyvista import examples
+        >>> import pyvista as pv
+        >>> airplane = examples.load_airplane()
+        >>> pl = pv.Plotter()
+        >>> _ = pl.add_mesh(airplane)
+        >>> pl.view_yz()
+        >>> pl.show()
+
         """
         vec = np.array([1,0,0])
         viewup = np.array([0,0,1])
@@ -2054,6 +2114,18 @@ class Renderer(_vtk.vtkRenderer):
         ----------
         negative : bool, optional
             View from the opposite direction.
+
+        Examples
+        --------
+        View the ZY plane of a built-in mesh example.
+        
+        >>> from pyvista import examples
+        >>> import pyvista as pv
+        >>> airplane = examples.load_airplane()
+        >>> pl = pv.Plotter()
+        >>> _ = pl.add_mesh(airplane)
+        >>> pl.view_zy()
+        >>> pl.show()
 
         """
         vec = np.array([-1,0,0])


### PR DESCRIPTION
### Overview

Add minimal examples of an airplane model in different views for #1629 

### Details

`view_*` functions in `plotter.py` are wraps of `renderer.py` functions so the examples are in `renderer.py` instead. Updated functions are as follows.
- `view_xy`
- `view_yx`
- `view_xz`
- `view_zx`
- `view_yz`
- `view_zy`

