### PR TITLE
Fix resetting `_wrappers` in `sphinx-gallery`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -283,6 +283,16 @@ todo_include_todos = False
 # -- Sphinx Gallery Options
 from sphinx_gallery.sorting import FileNameSortKey
 
+
+def reset_pyvista(gallery_conf, fname):
+    """Reset pyvista module to default settings
+
+    If default documentation settings are modified in any example, reset here.
+    """
+    import pyvista
+    pyvista._wrappers['vtkPolyData'] = pyvista.PolyData
+
+
 sphinx_gallery_conf = {
     # convert rst to md for ipynb
     "pypandoc": True,
@@ -305,9 +315,8 @@ sphinx_gallery_conf = {
         "%matplotlib inline\n"
         "from pyvista import set_plot_theme\n"
         "set_plot_theme('document')\n"
-        # Reset all values of wrapping `vtkPolyData` in examples
-        "pyvista._wrappers['vtkPolyData'] = pyvista.PolyData\n"
     ),
+    "reset_modules": (reset_pyvista, ),
 }
 
 # -- .. pyvista-plot:: directive ----------------------------------------------


### PR DESCRIPTION
### Overview

See #1711. The usage of `first_notebook_cell` only adds code when downloading the example.  It is not used when generating the examples.  #1584 added lines that break downloaded examples since `pyvista` isn't yet imported.  The lines were intended to run during documentation building to guard against leaking out a modified `pyvista` module from the example that modifies `pyvista._wrappers`.

The correct configuration is to use `reset_modules` which is run _before_ all examples.  This leads to an edge case where if the last example modifies the `pyvista` import, then it is never reset.  I have raised an issue for that  https://github.com/sphinx-gallery/sphinx-gallery/issues/866.  This is particularly troubling when developing a new example that modifies the `pyvista` import as sphinx will by default only rebuild the changed examples.  I'm not sure if it is possible to additionally call this function after `sphinx-gallery` completes.


### Details

We should use this functionality to reset any changes in the pyvista object during example generation.  I have added that suggestion to the docstring of the new function.

