### PR TITLE
Fix `find_closest_cell` not finding closest cells

### DIFF
--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -121,6 +121,7 @@ if VTK9:
                                                vtkPlaneCollection,
                                                vtkDataSet,
                                                vtkPointLocator,
+                                               vtkGenericCell,
                                                vtkCellLocator,
                                                vtkStaticCellLocator,
                                                vtkMultiBlockDataSet,
@@ -228,7 +229,8 @@ if VTK9:
                                           vtkLookupTable,
                                           VTK_UNSIGNED_CHAR,
                                           vtkAbstractArray,
-                                          vtkDoubleArray)
+                                          vtkDoubleArray,
+                                          mutable)
     from vtkmodules.vtkCommonMath import (vtkMatrix4x4,
                                           vtkMatrix3x3)
     from vtkmodules.vtkCommonTransforms import vtkTransform

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1885,7 +1885,7 @@ class DataSet(DataSetFilters, DataObject):
         ----------
         point : iterable(float) or np.ndarray
             Coordinates of point to query (length 3) or a ``numpy`` array of ``n``
-            points (size ``n``x3).
+            points with shape ``nx3``.
 
         Returns
         -------

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1885,7 +1885,7 @@ class DataSet(DataSetFilters, DataObject):
         ----------
         point : iterable(float) or np.ndarray
             Coordinates of point to query (length 3) or a ``numpy`` array of ``n``
-            points with shape ``nx3``.
+            points with shape ``(n, 3)``.
 
         Returns
         -------

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1885,7 +1885,7 @@ class DataSet(DataSetFilters, DataObject):
         ----------
         point : iterable(float) or np.ndarray
             Coordinates of point to query (length 3) or a ``numpy`` array of ``n``
-            points (size ``n``x3)
+            points (size ``n``x3).
 
         Returns
         -------

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1925,6 +1925,7 @@ class DataSet(DataSetFilters, DataObject):
         >>> avg_pos = cell_center_mesh.points[indices, :].mean(axis=0)
         >>> np.linalg.norm(avg_pos) < 0.02
         True
+
         """
         if isinstance(point, collections.abc.Sequence):
             point = np.array(point)

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1893,6 +1893,11 @@ class DataSet(DataSetFilters, DataObject):
             Index or indices of the cell in this mesh that is closest
             to the given point.
 
+        Warnings
+        --------
+        This method may still return a valid cell index even if the point
+        contains a value like ``numpy.inf`` or ``numpy.nan``.
+
         Examples
         --------
         Find nearest cell to a point on a sphere, centered on the

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -885,16 +885,12 @@ def test_find_closest_cells():
     with pytest.raises(ValueError):
         mesh.find_closest_cell(np.empty((4, 4)))
 
-    # simply get the face centers
+    # simply get the face centers, ordered by cell Id
     fcent = mesh.points[mesh.faces.reshape(-1, 4)[:, 1:]].mean(1)
     indices = mesh.find_closest_cell(fcent)
 
-    # this will miss a few...
-    mask = indices == -1
-    assert mask.sum() < 10
-
     # Make sure we match the face centers
-    assert np.allclose(indices[~mask], np.arange(mesh.n_faces)[~mask])
+    assert np.allclose(indices, np.arange(mesh.n_faces))
 
 
 def test_find_cells_along_line():


### PR DESCRIPTION
### Overview

Fixes #1739.  Currently `find_closest_cell` finds only the cell that _contains_ a point.  This PR fixes the behavior to find the closest cell.  

The correct vtk method also returns other information like the closest point in the cell that matches the supplied point, the distance, etc.  We could consider another optional input parameter like `extra_info=False` that would optionally return this information in addition.


### Details

This function will no longer return `-1` in my testing although it will return valid indices even when it is impossible to find a closest cell, e.g.. when the `point` has `np.nan` or `np.inf`.  I have clarified this in a warning.

