### PR TITLE
Class ScalarBars: correct annotation text scaling setting, when fixed font size is given

### DIFF
--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -420,7 +420,7 @@ class ScalarBars():
 
         if label_font_size is not None or title_font_size is not None:
             scalar_bar.UnconstrainedFontSizeOn()
-            scalar_bar.AnnotationTextScalingOn()
+            scalar_bar.AnnotationTextScalingOff()
 
         label_text = scalar_bar.GetLabelTextProperty()
         anno_text = scalar_bar.GetAnnotationTextProperty()


### PR DESCRIPTION
### Overview

Even if a label font size was given, size of `below_label` and `above_label` was scaled with the view port.

### Details

- Line 423 must be `SetAnnotationTextScalingOff` (value 0) for no scaling,
see <https://vtk.org/doc/nightly/html/classvtkScalarBarActor.html#acfe97b358b89cd544df5e7826d59e4f7>

