### PR TITLE
Update dataobject.py

### DIFF
--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -274,6 +274,8 @@ class DataObject:
                     return False
 
         return True
+    
+    __hash__ = super(object).__hash__
 
     def add_field_array(self, scalars: np.ndarray, name: str,
                         deep=True):  # pragma: no cover


### PR DESCRIPTION
### Overview

It was not possible to use a DataObject as a key for dictionaries. Add the missing __hash__ method from object enables this feature again.

Resolve #1751

### Details

-  by using the base __hash__ method from object to have __eq__ and __hash__ and allow to use dataobjects to be used as key for dict.

