### PR TITLE
Fix docstring examples with broken rendering

### DIFF
--- a/doc/api/utilities/parametric.rst
+++ b/doc/api/utilities/parametric.rst
@@ -13,6 +13,9 @@ see additional examples, see :ref:`ref_parametric_example`.
    ParametricBour
    ParametricBoy
    ParametricDini
+   ParametricCatalanMinimal
+   ParametricConicSpiral
+   ParametricCrossCap
    ParametricEllipsoid
    ParametricEnneper
    ParametricFigure8Klein

--- a/doc/api/utilities/utilities.rst
+++ b/doc/api/utilities/utilities.rst
@@ -8,6 +8,7 @@ General Utilities
    utilities.VtkErrorCatcher
    utilities.set_error_output_file
    utilities.is_inside_bounds
+   utilities.axis_rotation
 
 
 Object Conversions

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1192,6 +1192,7 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
         Examples
         --------
         Return the cell connectivity for the first two cells.
+
         >>> import pyvista
         >>> from pyvista import examples
         >>> hex_beam = pyvista.read(examples.hexbeamfile)

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -246,6 +246,7 @@ def create_axes_orientation_box(line_width=1, text_scale=0.366667,
     Examples
     --------
     Create and plot an orientation box
+
     >>> import pyvista
     >>> actor = pyvista.create_axes_orientation_box(
     ...    line_width=1, text_scale=0.53,
@@ -256,7 +257,7 @@ def create_axes_orientation_box(line_width=1, text_scale=0.366667,
     ...    labels_off=False, opacity=1.0)
     >>> pl = pyvista.Plotter()
     >>> _ = pl.add_actor(actor)
-    >>> pl.show()  # doctest:+SKIP
+    >>> pl.show()
 
     """
     if x_color is None:

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -1334,6 +1334,7 @@ def axis_rotation(points, angle, inplace=False, deg=True, axis='z'):
     Examples
     --------
     Rotate a set of points by 90 degrees about the x-axis in-place.
+
     >>> import numpy as np
     >>> import pyvista
     >>> from pyvista import examples

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -1305,12 +1305,12 @@ def abstract_class(cls_):
 
 
 def axis_rotation(points, angle, inplace=False, deg=True, axis='z'):
-    """Rotate points angle (in deg) about an axis.
+    """Rotate points by angle about an axis.
 
     Parameters
     ----------
     points : numpy.ndarray
-        Array of points with shape ``(N, 3)``
+        Array of points with shape ``(N, 3)``.
 
     angle : float
         Rotation angle.
@@ -1319,8 +1319,8 @@ def axis_rotation(points, angle, inplace=False, deg=True, axis='z'):
         Updates points in-place while returning nothing.
 
     deg : bool, optional
-        If `True`, the angle is interpreted as degrees instead of
-        radians. Default is `True`.
+        If ``True``, the angle is interpreted as degrees instead of
+        radians. Default is ``True``.
 
     axis : str, optional
         Name of axis to rotate about. Valid options are ``'x'``, ``'y'``,

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -28,7 +28,7 @@ def Spline(points, n_points=None):
 
     Examples
     --------
-    Construct a spline
+    Construct a spline.
 
     >>> import numpy as np
     >>> import pyvista as pv
@@ -247,7 +247,7 @@ def ParametricBoy(zscale=None, **kwargs):
 
     Examples
     --------
-    Create a ParametricBoy mesh
+    Create a ParametricBoy mesh.
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricBoy()
@@ -283,9 +283,9 @@ def ParametricCatalanMinimal(**kwargs):
     pyvista.PolyData
         ParametricCatalanMinimal surface.
 
-    Example
-    -------
-    Create a ParametricCatalanMinimal mesh
+    Examples
+    --------
+    Create a ParametricCatalanMinimal mesh.
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricCatalanMinimal()
@@ -337,11 +337,11 @@ def ParametricConicSpiral(a=None, b=None, c=None, n=None, **kwargs):
     Returns
     -------
     pyvista.PolyData
-        ParametricConicSpiral surface
+        ParametricConicSpiral surface.
 
     Examples
     --------
-    Create a ParametricConicSpiral mesh
+    Create a ParametricConicSpiral mesh.
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricConicSpiral()
@@ -433,7 +433,7 @@ def ParametricDini(a=None, b=None, **kwargs):
 
     Examples
     --------
-    Create a ParametricDini mesh
+    Create a ParametricDini mesh.
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricDini()
@@ -488,7 +488,7 @@ def ParametricEllipsoid(xradius=None, yradius=None, zradius=None,
 
     Examples
     --------
-    Create a ParametricEllipsoid mesh
+    Create a ParametricEllipsoid mesh.
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricEllipsoid()
@@ -581,7 +581,7 @@ def ParametricFigure8Klein(radius=None, **kwargs):
 
     Examples
     --------
-    Create a ParametricFigure8Klein mesh
+    Create a ParametricFigure8Klein mesh.
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricFigure8Klein()
@@ -615,7 +615,7 @@ def ParametricHenneberg(**kwargs):
 
     Examples
     --------
-    Create a ParametricHenneberg mesh
+    Create a ParametricHenneberg mesh.
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricHenneberg()
@@ -653,7 +653,7 @@ def ParametricKlein(**kwargs):
 
     Examples
     --------
-    Create a ParametricKlein mesh
+    Create a ParametricKlein mesh.
 
     >>> import pyvista
     >>> mesh = pyvista.ParametricKlein()


### PR DESCRIPTION
A few examples were rendered incorrectly due to a missing blank line between text before the example and the actual code block:
![Screenshot from 2021-11-01 19-22-45](https://user-images.githubusercontent.com/17914410/139721395-d5b01e8e-2159-4056-a60f-d380a19f2b9e.png)

Adding the blank lines fixes these:
![Screenshot from 2021-11-01 19-23-56](https://user-images.githubusercontent.com/17914410/139721525-a004f52e-7137-4a59-aa1f-8beda41484de.png)

Additionally, I've added the docs of three parametric surfaces that seemed to be missing from the online docs.

Two questions:
1. One of the affected functions is `axis_rotation()` in `pyvista/utilities/helpers.py`. This function, however, is not documented in the sense that it's not included in the online docs. It can be used to rotate a set of points (in an array) around one of the principal axes. Within PyVista it's only used by its own test. We have the documented `rotate_[xyz]` and `rotate_vector` filters that transform meshes. (And we have the also-undocumented `axis_angle_rotation()` in `transformations` that gives you a 4x4 transformation matrix). Many other helpers in `pyvista/utilities/helpers.py` are documented online; I'm wondering if this should be done for `axis_rotation()` as well. Or the opposite end of the spectrum: maybe remove it if it's not fully documented and unused in PyVista? (Probably not.)
2. I noticed that when I change a docstring and run `make -C doc html`, the whole "writing output" phase is repeated, which takes a lot of time on my laptop without an SSD. This used to be different a while ago, where small changes to a few files would only rebuild and write the respective documentation. Has something changed, and can we change it back?