### PR TITLE
Binary pickling

### DIFF
--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -492,9 +492,9 @@ class DataObject:
         writer = _vtk.vtkDataSetWriter()
         writer.SetInputDataObject(self)
         writer.SetWriteToOutputString(True)
-        writer.SetFileTypeToASCII()
+        writer.SetFileTypeToBinary()
         writer.Write()
-        to_serialize = writer.GetOutputString()
+        to_serialize = writer.GetOutputStdString()
         state['vtk_serialized'] = to_serialize
         return state
 
@@ -502,10 +502,9 @@ class DataObject:
         """Support unpickle."""
         vtk_serialized = state.pop('vtk_serialized')
         self.__dict__.update(state)
-
         reader = _vtk.vtkDataSetReader()
         reader.ReadFromInputStringOn()
-        reader.SetInputString(vtk_serialized)
+        reader.SetBinaryInputString(vtk_serialized, len(vtk_serialized))
         reader.Update()
         mesh = pyvista.wrap(reader.GetOutput())
 

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -504,7 +504,10 @@ class DataObject:
         self.__dict__.update(state)
         reader = _vtk.vtkDataSetReader()
         reader.ReadFromInputStringOn()
-        reader.SetBinaryInputString(vtk_serialized, len(vtk_serialized))
+        if isinstance(vtk_serialized, bytes):
+            reader.SetBinaryInputString(vtk_serialized, len(vtk_serialized))
+        elif isinstance(vtk_serialized, str):
+            reader.SetInputString(vtk_serialized)
         reader.Update()
         mesh = pyvista.wrap(reader.GetOutput())
 


### PR DESCRIPTION
### Overview

Data objects pickle with binary instead of ASCII.

Resolves #1768 

Turns out this was way simpler than the discussion in the issue thread. The magic was to use `writer.GetOutputStdString()` instead of `writer.GetOutputString()`. The output of `GetOutputString()` did not actually contain data (inexplicably). Perhaps there is something lost in the `char*` return type when it comes back to Python; the `vtkStandardString` return of `GetOutputString` comes back as `bytes`.

## Size comparison, discussion
Below are some comparisons of the `len` of the serialized data objects. For some cases the size of the data object is more than halved, and for others it is nearly doubled.

I'm not really sure why the binary serialization of the `RectilinearGrid` is so much worse; it almost seems like it's being serialized as a `StructuredGrid`, although the type does come back correctly upon deserialization.

Based on these numbers, I'm not sure if this is a sure winner. There might be some performance benefit from the binary version but I didn't run any timing tests. It would probably be more meaningful to do that on larger datasets than the examples.

|                                                 | length before | length after | ratio   |   |
|-------------------------------------------------|---------------|--------------|---------|---|
| examples.load_uniform(),  # UniformGrid         |         14094 |         5544 |  39.34% |   |
| examples.load_rectilinear(),  # RectilinearGrid |        130032 |       228473 | 175.71% |   |
| examples.load_hexbeam(),  # UnstructuredGrid    |          7502 |         3207 |  42.75% |   |
| examples.load_airplane(),  # PolyData           |         94641 |        75467 |  79.74% |   |
| examples.load_structured(),  # StructuredGrid   |        153708 |       152658 |  99.32% |   |