### PR TITLE
Allow linking views across different Plotters

### DIFF
--- a/examples/01-filter/decimate.ipynb
+++ b/examples/01-filter/decimate.ipynb
@@ -1,0 +1,365 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'\\n.. _decimate_example:\\n\\nDecimation\\n~~~~~~~~~~\\n\\nDecimate a mesh\\n\\n'"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\"\"\"\n",
+    ".. _decimate_example:\n",
+    "\n",
+    "Decimation\n",
+    "~~~~~~~~~~\n",
+    "\n",
+    "Decimate a mesh\n",
+    "\n",
+    "\"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sphinx_gallery_thumbnail_number = 4\n",
+    "import pyvista as pv\n",
+    "from pyvista import examples\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/Users/paul/github/pyvista/pyvista/__init__.py'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pv.__file__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mesh = examples.download_face()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define a camera potion the shows this mesh properly\n",
+    "cpos = [(0.4, -0.07, -0.31), (0.05, -0.13, -0.06), (-0.1, 1, 0.08)]\n",
+    "dargs = dict(show_edges=True, color=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cedbfa3d73fa4bc88dfb78012ff57931",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "ViewInteractiveWidget(height=768, layout=Layout(height='auto', width='100%'), width=1024)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Preview the mesh\n",
+    "mesh.plot(cpos=cpos, **dargs)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reducing 70.0 percent out of the original mesh\n"
+     ]
+    }
+   ],
+   "source": [
+    "###############################################################################\n",
+    "#  Now let's define a target reduction and compare the\n",
+    "# :func:`pyvista.PolyData.decimate` and :func:`pyvista.PolyData.decimate_pro`\n",
+    "# filters.\n",
+    "target_reduction = 0.7\n",
+    "print(f\"Reducing {target_reduction * 100.0} percent out of the original mesh\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1caed125c21843c98eb7e5281255960c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "ViewInteractiveWidget(height=768, layout=Layout(height='auto', width='100%'), width=1024)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "###############################################################################\n",
+    "decimated = mesh.decimate(target_reduction)\n",
+    "\n",
+    "decimated.plot(cpos=cpos, **dargs)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6a85e91f14914fd082ac45159d177462",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "ViewInteractiveWidget(height=768, layout=Layout(height='auto', width='100%'), width=1024)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "###############################################################################\n",
+    "pro_decimated = mesh.decimate_pro(target_reduction, preserve_topology=True)\n",
+    "\n",
+    "pro_decimated.plot(cpos=cpos, **dargs)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9e03f58409c843da92682af568241242",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "ViewInteractiveWidget(height=768, layout=Layout(height='auto', width='100%'), width=1024)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "###############################################################################\n",
+    "# Side by side comparison:\n",
+    "\n",
+    "p = pv.Plotter(shape=(1, 3))\n",
+    "p.add_mesh(mesh, **dargs)\n",
+    "p.add_text(\"Input mesh\", font_size=24)\n",
+    "p.camera_position = cpos\n",
+    "p.reset_camera()\n",
+    "p.subplot(0, 1)\n",
+    "p.add_mesh(decimated, **dargs)\n",
+    "p.add_text(\"Decimated mesh\", font_size=24)\n",
+    "p.camera_position = cpos\n",
+    "p.reset_camera()\n",
+    "p.subplot(0, 2)\n",
+    "p.add_mesh(pro_decimated, **dargs)\n",
+    "p.add_text(\"Pro Decimated mesh\", font_size=24)\n",
+    "p.camera_position = cpos\n",
+    "p.reset_camera()\n",
+    "p.link_views()\n",
+    "p.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mesh_plotter = pv.Plotter()\n",
+    "mesh_plotter.add_mesh(mesh)\n",
+    "\n",
+    "decimated_plotter = pv.Plotter()\n",
+    "decimated_plotter.add_mesh(decimated)\n",
+    "\n",
+    "pro_decimated_plotter = pv.Plotter()\n",
+    "pro_decimated_plotter.add_mesh(pro_decimated)\n",
+    "\n",
+    "mesh_plotter.link_views([decimated_plotter, pro_decimated_plotter])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# The camera position doesn't update until the image is clicked on"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fb31aef398814b06b24e21dc1104646b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "ViewInteractiveWidget(height=768, layout=Layout(height='auto', width='100%'), width=1024)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "mesh_plotter.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "06430338119242189551287d9984e581",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "ViewInteractiveWidget(height=768, layout=Layout(height='auto', width='100%'), width=1024)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "decimated_plotter.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4fe71b5195994834948dea7f228b2b81",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "ViewInteractiveWidget(height=768, layout=Layout(height='auto', width='100%'), width=1024)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pro_decimated_plotter.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "6dc1fca1cf41f317878f5a789a68bf7f78861ce5f86b5e2757eec5f934aedd60"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.8.12 64-bit ('pyvista-dev': conda)",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2873,7 +2873,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         Parameters
         ----------
-        views : int | tuple or list
+        views : int | Plotter | tuple or list of ints | tuple or list of Plotters
             If ``views`` is int, link the views to the given view
             index or if ``views`` is a tuple or a list, link the given
             views cameras.
@@ -2883,13 +2883,22 @@ class BasePlotter(PickingHelper, WidgetHelper):
             for renderer in self.renderers:
                 renderer.camera = self.renderers[views].camera
             return
+        elif issubclass(views.__class__, pyvista.plotting.BasePlotter):
+            for renderer in views.renderers:
+                renderer.camera = self.renderers[0].camera
+            return
+
         views = np.asarray(views)
         if np.issubdtype(views.dtype, np.integer):
             for view_index in views:
                 self.renderers[view_index].camera = \
                     self.renderers[views[0]].camera
+        elif all([issubclass(view.__class__, pyvista.plotting.BasePlotter) for view in views]):
+            for plotter in views:
+                for renderer in plotter.renderers:
+                    renderer.camera = self.renderers[0].camera
         else:
-            raise TypeError('Expected type is int, list or tuple:'
+            raise TypeError('Expected type is int, Plotter, or list or tuple of ints or Plotters:'
                             f'{type(views)} is given')
 
     def unlink_views(self, views=None):


### PR DESCRIPTION
### Overview

Fixes #1792 

Allows to link the views of two different Plotters.

### Details

* `pyvista.plotting.plotting.BasePlotter.link_views` has been modified to accept either an int, list or tuple of ints, a subclass of `BasePlotter`, or a list or tuple of subclasses of `BasePlotters`. I'm fairly new to pyvista (have been using it for the past month or so), and this would be my first contribution, so this may well not be the best approach, but I would be keen to hear you suggestions.

* Currently, the views link okay but the cameras do not update in real time. By this I mean, say I link plotter 1 and plotter 2 and then show both meshes. If I rotate the view of plotter 1, the view of plotter 2 doesn't change. However, when I click on the image of plotter 2, the view will update to that of the rotated plotter 1. This need to click on the second image is not ideal. Not sure if you have any ideas for how to get the camera position to update in real time?

* Added an example notebook to `pyvista.examples.01-filter.decimate.ipynb`. I'm not intending for it to remain in the codebase, I just added it in case you would like to play around with the functionality.

