### PR TITLE
Fix race conditions in pyvista.__init__

### DIFF
--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -77,9 +77,9 @@ if 'PYVISTA_USERDATA_PATH' in os.environ:
         raise FileNotFoundError(f'Invalid PYVISTA_USERDATA_PATH at {USER_DATA_PATH}')
 
 else:
+    USER_DATA_PATH = appdirs.user_data_dir('pyvista')
     try:
         # Set up data directory
-        USER_DATA_PATH = appdirs.user_data_dir('pyvista')
         os.makedirs(USER_DATA_PATH, exist_ok=True)
     except Exception as e:
         warnings.warn(f'Unable to create `PYVISTA_USERDATA_PATH` at "{USER_DATA_PATH}"\n'
@@ -88,8 +88,8 @@ else:
                       '`PYVISTA_USERDATA_PATH` to a writable path.')
         USER_DATA_PATH = ''
 
+EXAMPLES_PATH = os.path.join(USER_DATA_PATH, 'examples')
 try:
-    EXAMPLES_PATH = os.path.join(USER_DATA_PATH, 'examples')
     os.makedirs(EXAMPLES_PATH, exist_ok=True)
 except Exception as e:
     warnings.warn(f'Unable to create `EXAMPLES_PATH` at "{EXAMPLES_PATH}"\n'

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -79,16 +79,11 @@ if 'PYVISTA_USERDATA_PATH' in os.environ:
 else:
     # Set up data directory
     USER_DATA_PATH = appdirs.user_data_dir('pyvista')
-    if not os.path.exists(USER_DATA_PATH):
-        os.makedirs(USER_DATA_PATH)
+    os.makedirs(USER_DATA_PATH, exist_ok=True)
 
 try:
     EXAMPLES_PATH = os.path.join(USER_DATA_PATH, 'examples')
-    if not os.path.exists(EXAMPLES_PATH):
-        try:
-            os.makedirs(EXAMPLES_PATH)
-        except FileExistsError:  # Edge case due to IO race conditions
-            pass
+    os.makedirs(EXAMPLES_PATH, exist_ok=True)
 except Exception as e:
     warnings.warn(f'Unable to create `EXAMPLES_PATH` at "{EXAMPLES_PATH}"\n'
                   f'Error: {e}\n\n'

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -77,9 +77,16 @@ if 'PYVISTA_USERDATA_PATH' in os.environ:
         raise FileNotFoundError(f'Invalid PYVISTA_USERDATA_PATH at {USER_DATA_PATH}')
 
 else:
-    # Set up data directory
-    USER_DATA_PATH = appdirs.user_data_dir('pyvista')
-    os.makedirs(USER_DATA_PATH, exist_ok=True)
+    try:
+        # Set up data directory
+        USER_DATA_PATH = appdirs.user_data_dir('pyvista')
+        os.makedirs(USER_DATA_PATH, exist_ok=True)
+    except Exception as e:
+        warnings.warn(f'Unable to create `PYVISTA_USERDATA_PATH` at "{USER_DATA_PATH}"\n'
+                      f'Error: {e}\n\n'
+                      'Override the default path by setting the environmental variable '
+                      '`PYVISTA_USERDATA_PATH` to a writable path.')
+        USER_DATA_PATH = ''
 
 try:
     EXAMPLES_PATH = os.path.join(USER_DATA_PATH, 'examples')


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->
Fixes race conditions which occur when a non-existent directory is created by another process at an inopportune moment. This was already being handled for the examples path, but not the user data path.

`os.makedirs(p, exist_ok=True)` addresses this more cleanly than the past solution, as it handles the race condition internally (see https://github.com/python/cpython/blob/fc9b62281931da8d20f85d5ed44cfc24f068d3f4/Lib/os.py#L217)
