### PR TITLE
Fix greetings ci for PRs

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 name: Greetings
 
-on: [pull_request, issues]
+on: [pull_request_target, issues]
 
 jobs:
   greeting:


### PR DESCRIPTION
Fixes #1837.  Using `pull_reqest_target` runs the action on the base commit ref rather than the merged commit.

The warning form the docs mainly mention checkout, building, or running untrusted code.

> Warning: The pull_request_target event is granted a read/write repository token and can access secrets, even when it is triggered from a fork.

See https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request_target.  I do not think this applies to this action.