### PR TITLE
Add support for vtkSuperquadric

### DIFF
--- a/doc/api/utilities/geometric.rst
+++ b/doc/api/utilities/geometric.rst
@@ -31,6 +31,7 @@ additional details see :ref:`ref_geometric_example` example.
    Rectangle
    Sphere
    Spline
+   Superquadric
    Tetrahedron
    Text3D
    Triangle

--- a/doc/api/utilities/parametric.rst
+++ b/doc/api/utilities/parametric.rst
@@ -1,6 +1,10 @@
 Parametric Objects
 ------------------
 
+These objects represent surfaces that are parametrised by a set of independent
+variables. Some of these are impossible to represent (correctly or at all)
+using implicit functions, such as the Mobius strip.
+
 The following functions can be used to create parametric surfaces.  To
 see additional examples, see :ref:`ref_parametric_example`.
 

--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -314,6 +314,7 @@ if VTK9:
                                               vtkRegularPolygonSource,
                                               vtkPointSource,
                                               vtkPlatonicSolidSource,
+                                              vtkSuperquadricSource,
                                               vtkFrustumSource)
     from vtkmodules.vtkFiltersGeometry import (vtkGeometryFilter,
                                                vtkStructuredGridGeometryFilter,

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -1220,10 +1220,10 @@ def Circle(radius=0.5, resolution=100):
 
 
 def Superquadric(center=(0., 0., 0.), scale=(1., 1., 1.), size=0.5,
-                 thetaroundness=1., phiroundness=1.,
-                 thetaresolution=16, phiresolution=16,
+                 theta_roundness=1., phi_roundness=1.,
+                 theta_resolution=16, phi_resolution=16,
                  toroidal=False, thickness=1/3):
-    """Create an arrow.
+    """Create a superquadric.
 
     Parameters
     ----------
@@ -1236,19 +1236,19 @@ def Superquadric(center=(0., 0., 0.), scale=(1., 1., 1.), size=0.5,
     size : float, optional
         Superquadric isotropic size.
 
-    thetaroundness : float, optional
+    theta_roundness : float, optional
         Superquadric east/west roundness.
         Values range from 0 (rectangular) to 1 (circular) to higher orders.
 
-    phiroundness : float, optional
+    phi_roundness : float, optional
         Superquadric north/south roundness.
         Values range from 0 (rectangular) to 1 (circular) to higher orders.
 
-    thetaresolution : int, optional
+    theta_resolution : int, optional
         Number of points in the longitude direction.
         Values are rounded to nearest multiple of 4.
 
-    phiresolution : int, optional
+    phi_resolution : int, optional
         Number of points in the latitude direction.
         Values are rounded to nearest multiple of 8.
 
@@ -1275,10 +1275,10 @@ def Superquadric(center=(0., 0., 0.), scale=(1., 1., 1.), size=0.5,
     superquadricSource.SetCenter(center)
     superquadricSource.SetScale(scale)
     superquadricSource.SetSize(size)
-    superquadricSource.SetThetaRoundness(thetaroundness[0])
-    superquadricSource.SetPhiRoundness(phiroundness[1])
-    superquadricSource.SetThetaResolution(round(thetaresolution[0]/4)*4)
-    superquadricSource.SetPhiResolution(round(phiresolution[1]/8)*8)
+    superquadricSource.SetThetaRoundness(theta_roundness)
+    superquadricSource.SetPhiRoundness(phi_roundness)
+    superquadricSource.SetThetaResolution(round(theta_resolution/4)*4)
+    superquadricSource.SetPhiResolution(round(phi_resolution/8)*8)
     superquadricSource.SetToroidal(toroidal)
     superquadricSource.SetThickness(thickness)
     superquadricSource.Update()

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -1264,16 +1264,16 @@ def Superquadric(center=(0., 0., 0.), scale=(1., 1., 1.), size=0.5,
     pyvista.PolyData
         Superquadric mesh.
 
+    See Also
+    --------
+    pyvista.ParametricSuperEllipse : Parametric superquadric if toroidal is 0.
+    pyvista.ParametricSuperToroid : Parametric superquadric if toroidal is 1.
+
     Examples
     --------
     >>> import pyvista
     >>> superquadric = pyvista.Superquadric()
     >>> superquadric.plot(show_edges=True)
-
-    See Also
-    --------
-    pyvista.ParametricSuperEllipse : Parametric superquadric if toroidal is 0.
-    pyvista.ParametricSuperToroid : Parametric superquadric if toroidal is 1.
 
     """
     superquadricSource = _vtk.vtkSuperquadricSource()

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -1270,6 +1270,11 @@ def Superquadric(center=(0., 0., 0.), scale=(1., 1., 1.), size=0.5,
     >>> superquadric = pyvista.Superquadric()
     >>> superquadric.plot(show_edges=True)
 
+    See Also
+    --------
+    pyvista.ParametricSuperEllipse : Parametric superquadric if toroidal is 0.
+    pyvista.ParametricSuperToroid : Parametric superquadric if toroidal is 1.
+
     """
     superquadricSource = _vtk.vtkSuperquadricSource()
     superquadricSource.SetCenter(center)

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -13,6 +13,7 @@ vtkDiskSource
 vtkRegularPolygonSource
 vtkPyramid
 vtkPlatonicSolidSource
+vtkSuperquadricSource
 
 as well as some pure-python helpers.
 
@@ -1216,6 +1217,72 @@ def Circle(radius=0.5, resolution=100):
     points[:, 1] = radius * np.sin(theta)
     cells = np.array([np.append(np.array([resolution]), np.arange(resolution))])
     return pyvista.wrap(pyvista.PolyData(points, cells))
+
+
+def Superquadric(center=(0., 0., 0.), scale=(1., 1., 1.), size=0.5,
+                 thetaroundness=1., phiroundness=1.,
+                 thetaresolution=16, phiresolution=16,
+                 toroidal=False, thickness=1/3):
+    """Create an arrow.
+
+    Parameters
+    ----------
+    center : iterable, optional
+        Center of the superquadric in ``[x, y, z]``.
+
+    scale : iterable, optional
+        Scale factors of the superquadric in ``[x, y, z]``.
+
+    size : float, optional
+        Superquadric isotropic size.
+
+    thetaroundness : float, optional
+        Superquadric east/west roundness.
+        Values range from 0 (rectangular) to 1 (circular) to higher orders.
+
+    phiroundness : float, optional
+        Superquadric north/south roundness.
+        Values range from 0 (rectangular) to 1 (circular) to higher orders.
+
+    thetaresolution : int, optional
+        Number of points in the longitude direction.
+        Values are rounded to nearest multiple of 4.
+
+    phiresolution : int, optional
+        Number of points in the latitude direction.
+        Values are rounded to nearest multiple of 8.
+
+    toroidal : bool, optional
+        Whether or not the superquadric is toroidal (1) or ellipsoidal (0).
+
+    thickness : float, optional
+        Superquadric ring thickness.
+        Only applies if toroidal is set to 1.
+
+    Returns
+    -------
+    pyvista.PolyData
+        Superquadric mesh.
+
+    Examples
+    --------
+    >>> import pyvista
+    >>> superquadric = pyvista.Superquadric()
+    >>> superquadric.plot(show_edges=True)
+
+    """
+    superquadricSource = _vtk.vtkSuperquadricSource()
+    superquadricSource.SetCenter(center)
+    superquadricSource.SetScale(scale)
+    superquadricSource.SetSize(size)
+    superquadricSource.SetThetaRoundness(thetaroundness[0])
+    superquadricSource.SetPhiRoundness(phiroundness[1])
+    superquadricSource.SetThetaResolution(round(thetaresolution[0]/4)*4)
+    superquadricSource.SetPhiResolution(round(phiresolution[1]/8)*8)
+    superquadricSource.SetToroidal(toroidal)
+    superquadricSource.SetThickness(thickness)
+    superquadricSource.Update()
+    return pyvista.wrap(superquadricSource.GetOutput())
 
 
 def PlatonicSolid(kind='tetrahedron', radius=1.0, center=(0.0, 0.0, 0.0)):

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -1272,7 +1272,9 @@ def Superquadric(center=(0., 0., 0.), scale=(1., 1., 1.), size=0.5,
     Examples
     --------
     >>> import pyvista
-    >>> superquadric = pyvista.Superquadric()
+    >>> superquadric = pyvista.Superquadric(scale=(3., 1., 0.5),
+    ...                                     phi_roundness=0.1,
+    ...                                     theta_roundness=0.5)
     >>> superquadric.plot(show_edges=True)
 
     """

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -1253,11 +1253,12 @@ def Superquadric(center=(0., 0., 0.), scale=(1., 1., 1.), size=0.5,
         Values are rounded to nearest multiple of 8.
 
     toroidal : bool, optional
-        Whether or not the superquadric is toroidal (1) or ellipsoidal (0).
+        Whether or not the superquadric is toroidal (``True``)
+        or ellipsoidal (``False``).
 
     thickness : float, optional
         Superquadric ring thickness.
-        Only applies if toroidal is set to 1.
+        Only applies if toroidal is set to ``True``.
 
     Returns
     -------
@@ -1266,8 +1267,10 @@ def Superquadric(center=(0., 0., 0.), scale=(1., 1., 1.), size=0.5,
 
     See Also
     --------
-    pyvista.ParametricSuperEllipsoid : Parametric superquadric if toroidal is 0.
-    pyvista.ParametricSuperToroid : Parametric superquadric if toroidal is 1.
+    pyvista.ParametricSuperEllipsoid :
+        Parametric superquadric if toroidal is ``False``.
+    pyvista.ParametricSuperToroid :
+        Parametric superquadric if toroidal is ``True``.
 
     Examples
     --------

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -1266,7 +1266,7 @@ def Superquadric(center=(0., 0., 0.), scale=(1., 1., 1.), size=0.5,
 
     See Also
     --------
-    pyvista.ParametricSuperEllipse : Parametric superquadric if toroidal is 0.
+    pyvista.ParametricSuperEllipsoid : Parametric superquadric if toroidal is 0.
     pyvista.ParametricSuperToroid : Parametric superquadric if toroidal is 1.
 
     Examples

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -1005,8 +1005,10 @@ def ParametricSuperEllipsoid(xradius=None, yradius=None, zradius=None,
 
     See Also
     --------
-    pyvista.ParametricSuperToroid : Toroidal equivalent of ParametricSuperEllipsoid.
-    pyvista.Superquadric : Geometric object with additional parameters.
+    pyvista.ParametricSuperToroid :
+        Toroidal equivalent of ParametricSuperEllipsoid.
+    pyvista.Superquadric :
+        Geometric object with additional parameters.
 
     Examples
     --------
@@ -1097,8 +1099,10 @@ def ParametricSuperToroid(ringradius=None, crosssectionradius=None,
 
     See Also
     --------
-    pyvista.ParametricSuperEllipsoid : Ellipsoidal equivalent of ParametricSuperToroid.
-    pyvista.Superquadric : Geometric object with additional parameters.
+    pyvista.ParametricSuperEllipsoid :
+        Ellipsoidal equivalent of ParametricSuperToroid.
+    pyvista.Superquadric :
+        Geometric object with additional parameters.
 
     Examples
     --------

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -1,9 +1,4 @@
-"""Module managing parametric objects.
-
-These objects represent surfaces that are parametrised by a set of independent
-variables. Some of these are impossible to represent (correctly or at all)
-using implicit functions, such as the Mobius strip.
-"""
+"""Module managing parametric objects."""
 
 from math import pi
 
@@ -1010,7 +1005,7 @@ def ParametricSuperEllipsoid(xradius=None, yradius=None, zradius=None,
 
     See Also
     --------
-    ParametricSuperToroid : Toroidal equivalent of ParametricSuperEllipsoid.
+    pyvista.ParametricSuperToroid : Toroidal equivalent of ParametricSuperEllipsoid.
     pyvista.Superquadric : Geometric object with additional parameters.
 
     Examples
@@ -1102,7 +1097,7 @@ def ParametricSuperToroid(ringradius=None, crosssectionradius=None,
 
     See Also
     --------
-    ParametricSuperEllipsoid : Ellipsoidal equivalent of ParametricSuperToroid.
+    pyvista.ParametricSuperEllipsoid : Ellipsoidal equivalent of ParametricSuperToroid.
     pyvista.Superquadric : Geometric object with additional parameters.
 
     Examples

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -1008,6 +1008,11 @@ def ParametricSuperEllipsoid(xradius=None, yradius=None, zradius=None,
     pyvista.PolyData
         ParametricSuperEllipsoid surface.
 
+    See Also
+    --------
+    ParametricSuperToroid : Toroidal equivalent of ParametricSuperEllipsoid.
+    pyvista.Superquadric : Geometric object with additional parameters.
+
     Examples
     --------
     Create a ParametricSuperEllipsoid surface that looks like a box
@@ -1021,11 +1026,6 @@ def ParametricSuperEllipsoid(xradius=None, yradius=None, zradius=None,
 
     >>> mesh = pyvista.ParametricSuperEllipsoid(n1=4, n2=0.5)
     >>> mesh.plot(color='w', smooth_shading=True, cpos='xz')
-
-    See Also
-    --------
-    ParametricSuperToroid : Toroidal equivalent of ParametricSuperEllipsoid.
-    pyvista.Superquadric : Geometric object with additional parameters.
 
     """
     parametric_function = _vtk.vtkParametricSuperEllipsoid()
@@ -1100,6 +1100,11 @@ def ParametricSuperToroid(ringradius=None, crosssectionradius=None,
     pyvista.PolyData
         ParametricSuperToroid surface.
 
+    See Also
+    --------
+    ParametricSuperEllipsoid : Ellipsoidal equivalent of ParametricSuperToroid.
+    pyvista.Superquadric : Geometric object with additional parameters.
+
     Examples
     --------
     Create a ParametricSuperToroid mesh.
@@ -1107,11 +1112,6 @@ def ParametricSuperToroid(ringradius=None, crosssectionradius=None,
     >>> import pyvista
     >>> mesh = pyvista.ParametricSuperToroid(n1=2, n2=0.3)
     >>> mesh.plot(color='w', smooth_shading=True)
-
-    See Also
-    --------
-    ParametricSuperEllipsoid : Ellipsoidal equivalent of ParametricSuperToroid.
-    pyvista.Superquadric : Geometric object with additional parameters.
 
     """
     parametric_function = _vtk.vtkParametricSuperToroid()

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -1017,6 +1017,11 @@ def ParametricSuperEllipsoid(xradius=None, yradius=None, zradius=None,
     >>> mesh = pyvista.ParametricSuperEllipsoid(n1=4, n2=0.5)
     >>> mesh.plot(color='w', smooth_shading=True, cpos='xz')
 
+    See Also
+    --------
+    ParametricSuperToroid : Toroidal equivalent of ParametricSuperEllipsoid.
+    pyvista.Superquadric : Geometric object with additional parameters.
+
     """
     parametric_function = _vtk.vtkParametricSuperEllipsoid()
     if xradius is not None:
@@ -1097,6 +1102,11 @@ def ParametricSuperToroid(ringradius=None, crosssectionradius=None,
     >>> import pyvista
     >>> mesh = pyvista.ParametricSuperToroid(n1=2, n2=0.3)
     >>> mesh.plot(color='w', smooth_shading=True)
+
+    See Also
+    --------
+    ParametricSuperEllipsoid : Ellipsoidal equivalent of ParametricSuperToroid.
+    pyvista.Superquadric : Geometric object with additional parameters.
 
     """
     parametric_function = _vtk.vtkParametricSuperToroid()

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -1,4 +1,9 @@
-"""Module managing parametric objects."""
+"""Module managing parametric objects.
+
+These objects represent surfaces that are parametrised by a set of independent
+variables. Some of these are impossible to represent (correctly or at all)
+using implicit functions, such as the Mobius strip.
+"""
 
 from math import pi
 

--- a/tests/test_geometric_objects.py
+++ b/tests/test_geometric_objects.py
@@ -133,6 +133,11 @@ def test_disc():
     )
 
 
+def test_superquadric():
+    geom = pyvista.Superquadric()
+    assert np.any(geom.points)
+
+
 # def test_supertoroid():
 #     geom = pyvista.SuperToroid()
 #     assert np.any(geom.points)


### PR DESCRIPTION
### Overview

Adds support for [vtkSuperquadric](https://vtk.org/doc/nightly/html/classvtkSuperquadric.html) as a geometric object.

Resolves #1841.
