### PR TITLE
Implement __iadd__ for meshes

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -3979,9 +3979,22 @@ class DataSetFilters:
                 raise TypeError(f"Mesh type {type(self)} cannot be overridden by output.")
         return merged
 
-    def __add__(self, grid):
-        """Combine this mesh with another into an :class:`pyvista.UnstructuredGrid`."""
-        return DataSetFilters.merge(self, grid)
+    def __add__(self, dataset):
+        """Combine this mesh with another into a :class:`pyvista.UnstructuredGrid`."""
+        return DataSetFilters.merge(self, dataset)
+
+    def __iadd__(self, dataset):
+        """Merge another mesh into this one if possible.
+
+        "If possible" means that ``self`` is a :class:`pyvista.UnstructuredGrid`.
+        Otherwise we have to return a new object.
+
+        """
+        try:
+            merged = DataSetFilters.merge(self, dataset, inplace=True)
+        except TypeError:
+            merged = DataSetFilters.merge(self, dataset)
+        return merged
 
     def compute_cell_quality(self, quality_measure='scaled_jacobian', null_value=-1.0, progress_bar=False):
         """Compute a function of (geometric) quality for each cell of a mesh.

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -3907,7 +3907,9 @@ class DataSetFilters:
 
         .. note::
            The ``+`` operator between two meshes uses this filter with
-           the default parameters.
+           the default parameters. When the target mesh is already a
+           :class:`pyvista.UnstructuredGrid`, in-place merging via
+           ``+=`` is similarly possible.
 
         Parameters
         ----------
@@ -3987,15 +3989,19 @@ class DataSetFilters:
         """Merge another mesh into this one if possible.
 
         "If possible" means that ``self`` is a :class:`pyvista.UnstructuredGrid`.
-        Otherwise we have to return a new object.
+        Otherwise we have to return a new object, and the attempted in-place
+        merge will raise.
 
         """
         try:
             merged = DataSetFilters.merge(self, dataset, inplace=True)
         except TypeError:
-            return NotImplemented
-        else:
-            return merged
+            raise TypeError(
+                'In-place merge only possible if the target mesh '
+                'is an UnstructuredGrid.\nPlease use `mesh + other_mesh` '
+                'instead, which returns a new UnstructuredGrid.'
+            ) from None
+        return merged
 
     def compute_cell_quality(self, quality_measure='scaled_jacobian', null_value=-1.0, progress_bar=False):
         """Compute a function of (geometric) quality for each cell of a mesh.

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -3993,8 +3993,9 @@ class DataSetFilters:
         try:
             merged = DataSetFilters.merge(self, dataset, inplace=True)
         except TypeError:
-            merged = DataSetFilters.merge(self, dataset)
-        return merged
+            return NotImplemented
+        else:
+            return merged
 
     def compute_cell_quality(self, quality_measure='scaled_jacobian', null_value=-1.0, progress_bar=False):
         """Compute a function of (geometric) quality for each cell of a mesh.

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -318,15 +318,19 @@ class PolyDataFilters(DataSetFilters):
         """Merge another mesh into this one if possible.
 
         "If possible" means that ``dataset`` is also a :class:`PolyData`.
-        Otherwise we have to return a :class:`pyvista.UnstructuredGrid`.
+        Otherwise we have to return a :class:`pyvista.UnstructuredGrid`,
+        so the in-place merge attempt will raise.
 
         """
         try:
             merged = self.merge(dataset, inplace=True)
         except TypeError:
-            return NotImplemented
-        else:
-            return merged
+            raise TypeError(
+                'In-place merge only possible if the other mesh '
+                'is also a PolyData.\nPlease use `mesh + other_mesh` '
+                'instead, which returns a new UnstructuredGrid.'
+            ) from None
+        return merged
 
     def merge(self, dataset, merge_points=True, inplace=False,
               main_has_priority=True, progress_bar=False):
@@ -337,6 +341,12 @@ class PolyDataFilters(DataSetFilters):
            :func:`PolyDataFilters.boolean_union` filter.  This filter
            does not attempt to create a manifold mesh and will include
            internal surfaces when two meshes overlap.
+
+        .. note::
+           The ``+`` operator between two meshes uses this filter with
+           the default parameters. When the other mesh is also a
+           :class:`pyvista.PolyData`, in-place merging via ``+=`` is
+           similarly possible.
 
         Parameters
         ----------

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -324,8 +324,9 @@ class PolyDataFilters(DataSetFilters):
         try:
             merged = self.merge(dataset, inplace=True)
         except TypeError:
-            merged = self.merge(dataset)
-        return merged
+            return NotImplemented
+        else:
+            return merged
 
     def merge(self, dataset, merge_points=True, inplace=False,
               main_has_priority=True, progress_bar=False):

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -314,6 +314,19 @@ class PolyDataFilters(DataSetFilters):
         """Merge these two meshes."""
         return self.merge(dataset)
 
+    def __iadd__(self, dataset):
+        """Merge another mesh into this one if possible.
+
+        "If possible" means that ``dataset`` is also a :class:`PolyData`.
+        Otherwise we have to return a :class:`pyvista.UnstructuredGrid`.
+
+        """
+        try:
+            merged = self.merge(dataset, inplace=True)
+        except TypeError:
+            merged = self.merge(dataset)
+        return merged
+
     def merge(self, dataset, merge_points=True, inplace=False,
               main_has_priority=True, progress_bar=False):
         """Merge this mesh with one or more datasets.

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1261,23 +1261,17 @@ def test_iadd_general(uniform, hexbeam, sphere):
 
     # failing case: poly += non-poly
     merged = sphere
-    merged += uniform
-    assert merged is not sphere
-    assert isinstance(merged, pyvista.UnstructuredGrid)
+    with pytest.raises(TypeError):
+        merged += uniform
 
     # failing case: uniform += anything
     merged = uniform
-    merged += uniform
-    assert merged is not uniform
-    assert isinstance(merged, pyvista.UnstructuredGrid)
-    merged = uniform
-    merged += unstructured
-    assert merged is not uniform
-    assert isinstance(merged, pyvista.UnstructuredGrid)
-    merged = uniform
-    merged += sphere
-    assert merged is not uniform
-    assert isinstance(merged, pyvista.UnstructuredGrid)
+    with pytest.raises(TypeError):
+        merged += uniform
+    with pytest.raises(TypeError):
+        merged += unstructured
+    with pytest.raises(TypeError):
+        merged += sphere
 
 
 def test_compute_cell_quality():

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1229,17 +1229,55 @@ def test_extract_surface():
     assert surf_no_subdivide.n_faces == 6
 
 
-def test_merge_general():
-    mesh = examples.load_uniform()
-    thresh = mesh.threshold_percent([0.2, 0.5], progress_bar=True)  # unstructured grid
-    con = mesh.contour()  # poly data
+def test_merge_general(uniform):
+    thresh = uniform.threshold_percent([0.2, 0.5], progress_bar=True)  # unstructured grid
+    con = uniform.contour()  # poly data
     merged = thresh + con
     assert isinstance(merged, pyvista.UnstructuredGrid)
     merged = con + thresh
     assert isinstance(merged, pyvista.UnstructuredGrid)
     # Pure PolyData inputs should yield poly data output
-    merged = mesh.extract_surface() + con
+    merged = uniform.extract_surface() + con
     assert isinstance(merged, pyvista.PolyData)
+
+
+def test_iadd_general(uniform, hexbeam, sphere):
+    unstructured = hexbeam
+    sphere_shifted = sphere.copy()
+    sphere_shifted.points += [1, 1, 1]
+    # successful case: poly += poly
+    merged = sphere
+    merged += sphere_shifted
+    assert merged is sphere
+
+    # successful case: unstructured += anything
+    merged = unstructured
+    merged += uniform
+    assert merged is unstructured
+    merged += unstructured
+    assert merged is unstructured
+    merged += sphere
+    assert merged is unstructured
+
+    # failing case: poly += non-poly
+    merged = sphere
+    merged += uniform
+    assert merged is not sphere
+    assert isinstance(merged, pyvista.UnstructuredGrid)
+
+    # failing case: uniform += anything
+    merged = uniform
+    merged += uniform
+    assert merged is not uniform
+    assert isinstance(merged, pyvista.UnstructuredGrid)
+    merged = uniform
+    merged += unstructured
+    assert merged is not uniform
+    assert isinstance(merged, pyvista.UnstructuredGrid)
+    merged = uniform
+    merged += sphere
+    assert merged is not uniform
+    assert isinstance(merged, pyvista.UnstructuredGrid)
 
 
 def test_compute_cell_quality():


### PR DESCRIPTION
### Overview

We have syntactical sugar in the form of `__add__` (implementing `+`) that calls `merge()` on the two operand datasets. It's straightforward to implement `+=` as well.

### Python types

Native python sequences implement `+=` pretty regularly:
  1. if the type is mutable, mutate the original
  2. if the type is immutable, return a new instance (this probably happens without even defining `__iadd__`, which falls back on `__add__` when the former is missing)

### PyVista

The situation is less clear for us, because merging two datasets is a bit more complex. Here's what the output type is for `mesh1.merge(mesh2)`, based on the input type of the meshes:
```
     Unif Rect Unst Poly Stru
Unif ['UnstructuredGrid', 'UnstructuredGrid', 'UnstructuredGrid', 'UnstructuredGrid', 'UnstructuredGrid']
Rect ['UnstructuredGrid', 'UnstructuredGrid', 'UnstructuredGrid', 'UnstructuredGrid', 'UnstructuredGrid']
Unst ['UnstructuredGrid', 'UnstructuredGrid', 'UnstructuredGrid', 'UnstructuredGrid', 'UnstructuredGrid']
Poly ['UnstructuredGrid', 'UnstructuredGrid', 'UnstructuredGrid', 'PolyData', 'UnstructuredGrid']
Stru ['UnstructuredGrid', 'UnstructuredGrid', 'UnstructuredGrid', 'UnstructuredGrid', 'UnstructuredGrid']
```

The rule is "poly + poly = poly", anything else gives an unstructured grid. This implies that `mesh1.merge(mesh2, inplace=True)` either mutates the input or raises an error:
```
     Unif Rect Unst Poly Stru
Unif ['e', 'e', 'e', 'e', 'e']
Rect ['e', 'e', 'e', 'e', 'e']
Unst ['m', 'm', 'm', 'm', 'm']
Poly ['e', 'e', 'e', 'm', 'e']
Stru ['e', 'e', 'e', 'e', 'e']
```
(`'m'` for mutate, `'e'` for error)
  1. `poly.merge(poly, inplace=True)` works
  2. `unstructured.merge(anything, inplace=True)` works
  3. any other combination raises a `TypeError` (because the return value from `merge()` would have to be an `UnstructuredGrid` which doesn't match the type of `self`).

Due to the lack of `__iadd__`, the current behaviour of `mesh1 += mesh2` is the following:
```
     Unif Rect Unst Poly Stru
Unif ['c', 'c', 'c', 'c', 'c']
Rect ['c', 'c', 'c', 'c', 'c']
Unst ['c', 'c', 'c', 'c', 'c']
Poly ['c', 'c', 'c', 'c', 'c']
Stru ['c', 'c', 'c', 'c', 'c']
```
(where `'c'` means that a copy is returned from the operation). This is understandable since when `__iadd__` is not defined, Python falls back onto `mesh1 = mesh1 + mesh2`.

### This PR

**Note:** the below explanation is outdated, we decided that `+=` should always be in-place, raising when in-place merging is not possible.

Implementing `__iadd__` can give us this table instead for `mesh1 += mesh2`:
```
     Unif Rect Unst Poly Stru
Unif ['c', 'c', 'c', 'c', 'c']
Rect ['c', 'c', 'c', 'c', 'c']
Unst ['m', 'm', 'm', 'm', 'm']
Poly ['c', 'c', 'c', 'm', 'c']
Stru ['c', 'c', 'c', 'c', 'c']
```
(where `'m'` stands for mutate, and `'c'` stands for copy).

So `unstructured += anything` mutates the original, `poly += poly` mutates the original, anything else is equivalent to `mesh = mesh + other`, returning a new mesh (which is an `UnstructuredGrid`).

It's less nice than native Python that the same mesh type (namely `PolyData`) can both be mutated or not when applying `+=` to it. Furthermore, it might be surprising that `mesh1 += mesh2` can leave you with a different type of `mesh1` than the original. But the behaviour is unambiguously identified by the types of the input meshes, so I think this is still OK. The alternative would be to raise in `PolyDataFilters.__iadd__` (and `DataSetFilters.__iadd__` when `self` is not an `UnstructuredGrid`...) when an in-place merge is unsuccessful. My hunch is that falling back to returning an `UnstructuredGrid` is the preferred choice.


And whether this is a bugfix or an enhancement is up to the reader.

### Script
I generated the tables above with similar scripts:
```py
import pyvista as pv
from pyvista import examples

meshes = [
    examples.load_uniform(),  # UniformGrid
    examples.load_rectilinear(),  # RectilinearGrid
    examples.load_hexbeam(),  # UnstructuredGrid
    examples.load_airplane(),  # PolyData
    examples.load_structured(),  # StructuredGrid
]

res = []
for i in range(len(meshes)):
    res.append([])
    mesh1 = meshes[i]
    for j in range(len(meshes)):
        mesh2 = meshes[j]
        mesh = mesh_ref = mesh1.copy()
        try:
            mesh += mesh2
        except Exception as exc:
            # 'e' for error
            val = 'e'
        else:
            # 'm' for mutate, 'c' for copy
            val = 'm' if mesh is mesh_ref else 'c'
        res[-1].append(val)

labels = '     Unif Rect Unst Poly Stru'
print(labels)
for label, row in zip(labels.split(), res):
    print(label, row)
```

### TODO
 - [x] maybe document this behaviour somewhere that gets rendered in the online docs? Dunder methods don't seem to end up there. So perhaps some example? I think I saw explanations of `+` someplace...
 - [x] `return NotImplemented` in the unsuccessful case?
 - [x] raise in the unsuccessful case