### PR TITLE
Fix inplace return values

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -111,7 +111,7 @@ class DataSet(DataSetFilters, DataObject):
 
         Association refers to the data association (e.g. point, cell, or
         field) of the active scalars.
-        
+
         Returns
         -------
         ActiveArrayInfo
@@ -167,7 +167,7 @@ class DataSet(DataSetFilters, DataObject):
 
         Association refers to the data association (e.g. point, cell, or
         field) of the active vectors.
-        
+
         Returns
         -------
         ActiveArrayInfo
@@ -188,7 +188,7 @@ class DataSet(DataSetFilters, DataObject):
 
         >>> import pyvista
         >>> mesh = pyvista.Sphere()
-        >>> _ = mesh.compute_normals(inplace=True)
+        >>> mesh.compute_normals(inplace=True)
         >>> mesh.active_vectors_name = 'Normals'
         >>> mesh.active_vectors_info
         ActiveArrayInfo(association=<FieldAssociation.POINT: 0>, name='Normals')
@@ -232,7 +232,7 @@ class DataSet(DataSetFilters, DataObject):
 
         >>> import pyvista
         >>> mesh = pyvista.Sphere()
-        >>> _ = mesh.compute_normals(inplace=True)
+        >>> mesh.compute_normals(inplace=True)
         >>> mesh.active_vectors  # doctest:+SKIP
         pyvista_ndarray([[-2.48721432e-10, -1.08815623e-09, -1.00000000e+00],
                          [-2.48721432e-10, -1.08815623e-09,  1.00000000e+00],
@@ -1346,7 +1346,7 @@ class DataSet(DataSetFilters, DataObject):
 
         Examples
         --------
-        Add cell arrays to a mesh and list the available ``cell_data``. 
+        Add cell arrays to a mesh and list the available ``cell_data``.
 
         >>> import pyvista
         >>> import numpy as np

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -125,7 +125,7 @@ class DataSetFilters:
                 return self, result[1]
             else:
                 self.overwrite(result)
-                return self
+                return
         return result
 
     def clip_box(self, bounds=None, invert=True, factor=0.35, progress_bar=False):
@@ -246,7 +246,7 @@ class DataSetFilters:
         >>> import pyvista as pv
         >>> sphere = pv.Sphere()
         >>> plane = pv.Plane()
-        >>> _ = sphere.compute_implicit_distance(plane, inplace=True)
+        >>> sphere.compute_implicit_distance(plane, inplace=True)
         >>> dist = sphere['implicit_distance']
         >>> type(dist)
         <class 'numpy.ndarray'>
@@ -270,7 +270,7 @@ class DataSetFilters:
         function.FunctionValue(points, dists)
         if inplace:
             self.point_data['implicit_distance'] = pyvista.convert_array(dists)
-            return self
+            return
         result = self.copy()
         result.point_data['implicit_distance'] = pyvista.convert_array(dists)
         return result
@@ -324,7 +324,7 @@ class DataSetFilters:
         >>> _below, _above = dataset.clip_scalar(scalars="sample_point_scalars", value=100, both=True)
 
         Remove the part of the mesh with "sample_point_scalars" below 100.
-        
+
         >>> import pyvista as pv
         >>> from pyvista import examples
         >>> dataset = examples.load_hexbeam()
@@ -1401,7 +1401,7 @@ class DataSetFilters:
         self.GetPointData().AddArray(t_coords)
         # CRITICAL:
         self.GetPointData().AddArray(otc) # Add old ones back at the end
-        return self
+        return
 
     def texture_map_to_sphere(self, center=None, prevent_seam=True,
                               inplace=False, name='Texture Coordinates',
@@ -1469,7 +1469,7 @@ class DataSetFilters:
         self.GetPointData().AddArray(t_coords)
         # CRITICAL:
         self.GetPointData().AddArray(otc)  # Add old ones back at the end
-        return self
+        return
 
     def compute_cell_sizes(self, length=True, area=True, volume=True,
                            progress_bar=False):
@@ -1813,7 +1813,7 @@ class DataSetFilters:
         mesh = DataSetFilters.connectivity(self, largest=True, progress_bar=False)
         if inplace:
             self.overwrite(mesh)
-            return self
+            return
         return mesh
 
     def split_bodies(self, label=False, progress_bar=False):
@@ -1942,7 +1942,7 @@ class DataSetFilters:
             if isinstance(self, (_vtk.vtkImageData, _vtk.vtkRectilinearGrid)):
                 raise TypeError("This filter cannot be applied inplace for this mesh type.")
             self.overwrite(output)
-            return self
+            return
         return output
 
     def warp_by_vector(self, vectors=None, factor=1.0, inplace=False,
@@ -2015,7 +2015,7 @@ class DataSetFilters:
         warped_mesh = _get_output(alg)
         if inplace:
             self.overwrite(warped_mesh)
-            return self
+            return
         else:
             return warped_mesh
 
@@ -2224,7 +2224,6 @@ class DataSetFilters:
         mesh = _get_output(alg)
         if inplace:
             self.overwrite(mesh)
-            return self
         return mesh
 
     def delaunay_3d(self, alpha=0, tol=0.001, offset=2.5, progress_bar=False):
@@ -3976,7 +3975,7 @@ class DataSetFilters:
         if inplace:
             if type(self) == type(merged):
                 self.deep_copy(merged)
-                return self
+                return
             else:
                 raise TypeError(f"Mesh type {type(self)} cannot be overridden by output.")
         return merged
@@ -4403,7 +4402,7 @@ class DataSetFilters:
 
         if inplace:
             self.overwrite(res)
-            return self
+            return
 
         # The output from the transform filter contains a shallow copy
         # of the original dataset except for the point arrays.  Here

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -200,7 +200,7 @@ class PolyDataFilters(DataSetFilters):
            meshes whereas the :func:`PolyDataFilters.intersection`
            filter returns the surface intersection between two meshes
            (which often resolves as a line).
-           
+
 
         .. note::
            Both meshes must be composed of all triangles.  Check with
@@ -423,7 +423,7 @@ class PolyDataFilters(DataSetFilters):
 
         if inplace:
             self.deep_copy(merged)
-            return self
+            return
 
         return merged
 
@@ -594,7 +594,7 @@ class PolyDataFilters(DataSetFilters):
 
         >>> from pyvista import examples
         >>> hills = examples.load_random_hills()
-        >>> hills.plot_curvature(curv_type='gaussian', smooth_shading=True, 
+        >>> hills.plot_curvature(curv_type='gaussian', smooth_shading=True,
         ...                      clim=[0, 1])
 
         """
@@ -644,7 +644,7 @@ class PolyDataFilters(DataSetFilters):
         mesh = _get_output(trifilter)
         if inplace:
             self.overwrite(mesh)
-            return self
+            return
         return mesh
 
     def smooth(self, n_iter=20, relaxation_factor=0.01, convergence=0.0,
@@ -725,7 +725,7 @@ class PolyDataFilters(DataSetFilters):
         mesh = _get_output(alg)
         if inplace:
             self.overwrite(mesh)
-            return self
+            return
 
         return mesh
 
@@ -816,7 +816,7 @@ class PolyDataFilters(DataSetFilters):
         mesh = _get_output(alg)
         if inplace:
             self.overwrite(mesh)
-            return self
+            return
 
         return mesh
 
@@ -999,7 +999,7 @@ class PolyDataFilters(DataSetFilters):
         submesh = _get_output(sfilter)
         if inplace:
             self.overwrite(submesh)
-            return self
+            return
 
         return submesh
 
@@ -1094,7 +1094,7 @@ class PolyDataFilters(DataSetFilters):
 
         if inplace:
             self.overwrite(submesh)
-            return self
+            return
 
         return submesh
 
@@ -1217,7 +1217,7 @@ class PolyDataFilters(DataSetFilters):
         mesh = _get_output(alg)
         if inplace:
             self.overwrite(mesh)
-            return self
+            return
 
         return mesh
 
@@ -1357,7 +1357,7 @@ class PolyDataFilters(DataSetFilters):
 
         if inplace:
             self.overwrite(mesh)
-            return self
+            return
 
         return mesh
 
@@ -1449,7 +1449,7 @@ class PolyDataFilters(DataSetFilters):
 
         if inplace:
             self.overwrite(result)
-            return self
+            return
         else:
             return result
 
@@ -1506,7 +1506,7 @@ class PolyDataFilters(DataSetFilters):
         mesh = _get_output(alg)
         if inplace:
             self.overwrite(mesh)
-            return self
+            return
         return mesh
 
     def clean(self, point_merging=True, tolerance=None, lines_to_points=True,
@@ -1598,7 +1598,7 @@ class PolyDataFilters(DataSetFilters):
 
         if inplace:
             self.overwrite(output)
-            return self
+            return
         return output
 
     def geodesic(self, start_vertex, end_vertex, inplace=False,
@@ -1681,7 +1681,7 @@ class PolyDataFilters(DataSetFilters):
 
         if inplace:
             self.overwrite(output)
-            return self
+            return
 
         return output
 
@@ -2125,7 +2125,7 @@ class PolyDataFilters(DataSetFilters):
         # Return vtk surface and reverse indexing array
         if inplace:
             self.overwrite(newmesh)
-            return self, ridx
+            return ridx
         return newmesh, ridx
 
     def flip_normals(self):
@@ -2247,7 +2247,7 @@ class PolyDataFilters(DataSetFilters):
         mesh = _get_output(alg).triangulate()
         if inplace:
             self.overwrite(mesh)
-            return self
+            return
         return mesh
 
     def compute_arc_length(self, progress_bar=False):
@@ -2503,7 +2503,7 @@ class PolyDataFilters(DataSetFilters):
         output = pyvista.wrap(alg.GetOutput())
         if inplace:
             self.overwrite(output)
-            return self
+            return
         return output
 
     def extrude_rotate(self, resolution=30, inplace=False,
@@ -2605,7 +2605,7 @@ class PolyDataFilters(DataSetFilters):
         output = pyvista.wrap(alg.GetOutput())
         if inplace:
             self.overwrite(output)
-            return self
+            return
         return output
 
     def strip(self, join=False, max_length=1000, pass_cell_data=False,

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -118,6 +118,8 @@ class PointSet(DataSet):
 
         target.cell_data[_vtk.vtkDataSetAttributes.GhostArrayName()] = ghost_cells
         target.RemoveGhostCells()
+        if inplace:
+            return
         return target
 
 
@@ -319,7 +321,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
     def verts(self):
         """Get the vertex cells.
 
-        Returns 
+        Returns
         -------
         numpy.ndarray
             Array of vertex cell indices.
@@ -424,7 +426,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
            ``is_all_triangles`` is now a property.  Calling this value
            will warn the user that this should not be called.
            Additionally, the ``is`` operator will not work the return
-           value of this property since it is not a ``bool``           
+           value of this property since it is not a ``bool``
 
         Returns
         -------
@@ -475,7 +477,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
                 https://jfine-python-classes.readthedocs.io/en/latest/subclass-int.html#emulating-bool-using-new
 
                 """
-                return int.__new__(cls, bool(value))        
+                return int.__new__(cls, bool(value))
 
             def __call__(self):
                 """Return a ``bool`` of self."""
@@ -613,7 +615,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
             as ``'RGB'`` if the array is just a 3 component array.
 
             .. note::
-               This feature is only available when saving PLY files. 
+               This feature is only available when saving PLY files.
 
         Notes
         -----
@@ -1129,7 +1131,7 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
         >>> from pyvista import examples
         >>> hex_beam = pyvista.read(examples.hexbeamfile)
         >>> hex_beam.cells[:18]  # doctest:+SKIP
-        array([ 8,  0,  2,  8,  7, 27, 36, 90, 81,  8,  2,  1,  4,  
+        array([ 8,  0,  2,  8,  7, 27, 36, 90, 81,  8,  2,  1,  4,
                 8, 36, 18, 54, 90])
 
         """
@@ -1556,7 +1558,7 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
         >>> grid = pyvista.StructuredGrid(x, y, z)
         >>> grid.dimensions
         (10, 20, 4)
-        
+
         """
         return tuple(self.GetDimensions())
 
@@ -1741,24 +1743,24 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
     --------
     >>> import numpy as np
     >>> import pyvista as pv
-    >>> 
+    >>>
     >>> # grid size: ni*nj*nk cells; si, sj, sk steps
     >>> ni, nj, nk = 4, 5, 6
     >>> si, sj, sk = 20, 10, 1
-    >>> 
+    >>>
     >>> # create raw coordinate grid
     >>> grid_ijk = np.mgrid[:(ni+1)*si:si, :(nj+1)*sj:sj, :(nk+1)*sk:sk]
-    >>> 
+    >>>
     >>> # repeat array along each Cartesian axis for connectivity
     >>> for axis in range(1, 4):
     ...     grid_ijk = grid_ijk.repeat(2, axis=axis)
-    >>> 
+    >>>
     >>> # slice off unnecessarily doubled edge coordinates
     >>> grid_ijk = grid_ijk[:, 1:-1, 1:-1, 1:-1]
-    >>> 
+    >>>
     >>> # reorder and reshape to VTK order
     >>> corners = grid_ijk.transpose().reshape(-1, 3)
-    >>> 
+    >>>
     >>> dims = np.array([ni, nj, nk]) + 1
     >>> grid = pv.ExplicitStructuredGrid(dims, corners)
     >>> _ = grid.compute_connectivity()
@@ -1964,10 +1966,12 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
             array[ind] = _vtk.vtkDataSetAttributes.HIDDENCELL
             name = _vtk.vtkDataSetAttributes.GhostArrayName()
             self.cell_data[name] = array
-            return self
+            return
 
         grid = self.copy()
         grid.hide_cells(ind)
+        if inplace:
+            return
         return grid
 
     def show_cells(self, inplace=True):
@@ -1993,10 +1997,10 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         --------
         >>> from pyvista import examples
         >>> grid = examples.load_explicit_structured()
-        >>> _ = grid.hide_cells(range(80, 120), inplace=True)
+        >>> grid.hide_cells(range(80, 120), inplace=True)
         >>> grid.plot(color='w', show_edges=True, show_bounds=True)
 
-        >>> _ = grid.show_cells(inplace=True)
+        >>> grid.show_cells(inplace=True)
         >>> grid.plot(color='w', show_edges=True, show_bounds=True)
 
         """
@@ -2006,7 +2010,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
                 array = self.cell_data[name]
                 ind = np.argwhere(array == _vtk.vtkDataSetAttributes.HIDDENCELL)
                 array[ind] = 0
-            return self
+            return
         else:
             grid = self.copy()
             grid.show_cells()
@@ -2199,7 +2203,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         >>> cell = grid.extract_cells(31)  # doctest:+SKIP
         >>> ind = grid.neighbors(31)  # doctest:+SKIP
         >>> neighbors = grid.extract_cells(ind)  # doctest:+SKIP
-        >>> 
+        >>>
         >>> plotter = pv.Plotter()
         >>> plotter.add_axes()  # doctest:+SKIP
         >>> plotter.add_mesh(cell, color='r', show_edges=True)  # doctest:+SKIP
@@ -2323,7 +2327,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         Examples
         --------
         >>> from pyvista import examples
-        >>> 
+        >>>
         >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
         >>> grid.compute_connectivity()  # doctest:+SKIP
         >>> grid.plot(show_edges=True)  # doctest:+SKIP
@@ -2331,7 +2335,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         """
         if inplace:
             self.ComputeFacesConnectivityFlagsArray()
-            return self
+            return
         else:
             grid = self.copy()
             grid.compute_connectivity()
@@ -2378,7 +2382,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
             array = np.unpackbits(array, axis=1)
             array = array.sum(axis=1)
             self.cell_data['number_of_connections'] = array
-            return self
+            return
         else:
             grid = self.copy()
             grid.compute_connections()


### PR DESCRIPTION
### Overview

If `inplace=True` there should be *no return value*


### Details

Addresses concerns in #1855, see comment: https://github.com/pyvista/pyvista/issues/1855#issuecomment-979774232

The established PyVista syntax/convention is:
```py
result = source.filter(options)
```
There have been previous discussions that established this convention and these filters do not adhere by editing the `source` AND producing `result`. When a `filter` edits the `source` (the case with `inplace=True`) then there should be no `result`.

Futhermore, this is consistent with inplace operation like `random.shuffle`: https://docs.python.org/3/library/random.html#random.shuffle

