### PR TITLE
Fix shrink filter output

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -4279,6 +4279,7 @@ class DataSetFilters:
         output = pyvista.wrap(alg.GetOutput())
         if isinstance(self, _vtk.vtkPolyData):
             return output.extract_surface()
+        return output
 
     def transform(self: _vtk.vtkDataSet,
                   trans: Union[_vtk.vtkMatrix4x4, _vtk.vtkTransform, np.ndarray],

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1466,6 +1466,10 @@ def test_shrink():
     shrunk = mesh.shrink(shrink_factor=0.8, progress_bar=True)
     assert shrunk.n_cells == mesh.n_cells
     assert shrunk.area < mesh.area
+    mesh = examples.load_uniform()
+    shrunk = mesh.shrink(shrink_factor=0.8, progress_bar=True)
+    assert shrunk.n_cells == mesh.n_cells
+    assert shrunk.volume < mesh.volume
 
 
 @pytest.mark.parametrize('num_cell_arrays,num_point_data',


### PR DESCRIPTION
### Overview

The shrink filter failed to return anything for non-PolyData inputs


### Details

```py
from pyvista import examples

mesh = examples.load_uniform()

out = mesh.shrink(0.5)
assert out
```
```
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
/var/folders/2x/4df66vz13pv4hj_ysv23tyyc0000gn/T/ipykernel_93284/2185457562.py in <module>
      4 
      5 out = mesh.shrink(0.5)
----> 6 assert out

AssertionError: 
```

------

This branch:

```py
import pyvista as pv
from pyvista import examples

mesh = examples.load_uniform()

out = mesh.shrink(0.5)

p = pv.Plotter(shape=(1,2))
p.add_mesh(mesh)
p.subplot(0,1)
p.add_mesh(out)
p.link_views()
p.show()
```
<img width="529" alt="Screen Shot 2021-11-26 at 12 16 10 PM" src="https://user-images.githubusercontent.com/22067021/143622874-f84b903f-7833-4be5-b6fa-5c83d90a63c5.png">



