### PR TITLE
Fix texture coordinates overwriting bug

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1400,7 +1400,9 @@ class DataSetFilters:
         self.GetPointData().SetTCoords(t_coords)
         self.GetPointData().AddArray(t_coords)
         # CRITICAL:
-        self.GetPointData().AddArray(otc) # Add old ones back at the end
+        if otc and otc.GetName() != name:
+            # Add old ones back at the end if different name
+            self.GetPointData().AddArray(otc)
         return self
 
     def texture_map_to_sphere(self, center=None, prevent_seam=True,
@@ -1468,7 +1470,9 @@ class DataSetFilters:
         self.GetPointData().SetTCoords(t_coords)
         self.GetPointData().AddArray(t_coords)
         # CRITICAL:
-        self.GetPointData().AddArray(otc)  # Add old ones back at the end
+        if otc and otc.GetName() != name:
+            # Add old ones back at the end if different name
+            self.GetPointData().AddArray(otc)
         return self
 
     def compute_cell_sizes(self, length=True, area=True, volume=True,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -431,7 +431,7 @@ def test_texture():
     assert len(mesh.textures) == 0
 
 
-def test_texture_airplane():
+def test_multiple_texture_coordinates():
     mesh = examples.load_airplane()
     mesh.texture_map_to_plane(inplace=True, name="tex_a", use_bounds=False)
     mesh.texture_map_to_plane(inplace=True, name="tex_b", use_bounds=True)
@@ -449,6 +449,14 @@ def test_texture_airplane():
     assert len(cmesh.textures) == 2
     assert "tex_a" in cmesh.textures
     assert "tex_b" in cmesh.textures
+
+
+def test_inplace_no_overwrite_texture_coordinates():
+    mesh = pyvista.Box()
+    truth = mesh.texture_map_to_plane(inplace=False)
+    mesh.texture_map_to_sphere(inplace=True)
+    test = mesh.texture_map_to_plane(inplace=True)
+    assert np.allclose(truth.active_t_coords, test.active_t_coords)
 
 
 def test_invalid_vector(grid):


### PR DESCRIPTION
Resolve #1866 by making sure that the texture mapping filters will not overwrite new textures with old textures when the arrays have the same name

