### PR TITLE
Make reconstruct_surface a PolyDataFilter

### DIFF
--- a/examples/01-filter/surface_reconstruction.py
+++ b/examples/01-filter/surface_reconstruction.py
@@ -5,7 +5,7 @@ Surface Reconstruction
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Surface reconstruction has a dedicated filter in PyVista and is
-handled by :func:`pyvista.DataSetFilters.reconstruct_surface`.  This
+handled by :func:`pyvista.PolyDataFilters.reconstruct_surface`.  This
 tends to perform much better than :func:`DataSetFilters.delaunay_3d`.
 
 """

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2233,7 +2233,7 @@ class DataSetFilters:
         This filter can be used to generate a 3D tetrahedral mesh from
         a surface or scattered points.  If you want to create a
         surface from a point cloud, see
-        :func:`pyvista.DataSetFilters.reconstruct_surface`.
+        :func:`pyvista.PolyDataFilters.reconstruct_surface`.
 
         Parameters
         ----------
@@ -4459,82 +4459,3 @@ class DataSetFilters:
             t, transform_all_input_vectors=transform_all_input_vectors,
             inplace=inplace, progress_bar=progress_bar
         )
-
-    def reconstruct_surface(self, nbr_sz=None, sample_spacing=None,
-                            progress_bar=False):
-        """Reconstruct a surface from the points in this dataset.
-
-        This filter takes a list of points assumed to lie on the
-        surface of a solid 3D object. A signed measure of the distance
-        to the surface is computed and sampled on a regular grid. The
-        grid can then be contoured at zero to extract the surface. The
-        default values for neighborhood size and sample spacing should
-        give reasonable results for most uses but can be set if
-        desired.
-
-        This is helpful when generating surfaces from point clouds and
-        is more reliable than :func:`DataSetFilters.delaunay_3d`.
-
-        Parameters
-        ----------
-        nbr_sz : int, optional
-            Specify the number of neighbors each point has, used for
-            estimating the local surface orientation.
-
-            The default value of 20 should be fine for most
-            applications, higher values can be specified if the spread
-            of points is uneven. Values as low as 10 may yield
-            adequate results for some surfaces. Higher values cause
-            the algorithm to take longer and will cause
-            errors on sharp boundaries.
-
-        sample_spacing : float, optional
-            The spacing of the 3D sampling grid.  If not set, a
-            reasonable guess will be made.
-
-        progress_bar : bool, optional
-            Display a progress bar to indicate progress.
-
-        Returns
-        -------
-        pyvista.PolyData
-            Reconstructed surface.
-
-        Examples
-        --------
-        Create a point cloud out of a sphere and reconstruct a surface
-        from it.
-
-        >>> import pyvista as pv
-        >>> points = pv.wrap(pv.Sphere().points)
-        >>> surf = points.reconstruct_surface()
-
-        >>> pl = pv.Plotter(shape=(1,2))
-        >>> _ = pl.add_mesh(points)
-        >>> _ = pl.add_title('Point Cloud of 3D Surface')
-        >>> pl.subplot(0,1)
-        >>> _ = pl.add_mesh(surf, color=True, show_edges=True)
-        >>> _ = pl.add_title('Reconstructed Surface')
-        >>> pl.show()
-
-        See :ref:`surface_reconstruction_example` for more examples
-        using this filter.
-
-        """
-        alg = _vtk.vtkSurfaceReconstructionFilter()
-        alg.SetInputDataObject(self)
-        if nbr_sz is not None:
-            alg.SetNeighborhoodSize(nbr_sz)
-        if sample_spacing is not None:
-            alg.SetSampleSpacing(sample_spacing)
-
-        # connect using ports as this will be slightly faster
-        mc = _vtk.vtkMarchingCubes()
-        mc.SetComputeNormals(False)
-        mc.SetComputeScalars(False)
-        mc.SetComputeGradients(False)
-        mc.SetInputConnection(alg.GetOutputPort())
-        mc.SetValue(0, 0.0)
-        _update_alg(mc, progress_bar, 'Reconstructing surface')
-        surf = pyvista.wrap(mc.GetOutput())
-        return surf

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2165,7 +2165,7 @@ class PolyDataFilters(DataSetFilters):
 
         This filter can be used to generate a 2d surface from a set of
         points on a plane.  If you want to create a surface from a
-        point cloud, see :func:`pyvista.DataSetFilters.reconstruct_surface`.
+        point cloud, see :func:`pyvista.PolyDataFilters.reconstruct_surface`.
 
         Parameters
         ----------
@@ -2840,3 +2840,82 @@ class PolyDataFilters(DataSetFilters):
             output.cell_data.GetAbstractArray(0).SetName('collision_rgba')
 
         return output, alg.GetNumberOfContacts()
+
+    def reconstruct_surface(self, nbr_sz=None, sample_spacing=None,
+                            progress_bar=False):
+        """Reconstruct a surface from the points in this dataset.
+
+        This filter takes a list of points assumed to lie on the
+        surface of a solid 3D object. A signed measure of the distance
+        to the surface is computed and sampled on a regular grid. The
+        grid can then be contoured at zero to extract the surface. The
+        default values for neighborhood size and sample spacing should
+        give reasonable results for most uses but can be set if
+        desired.
+
+        This is helpful when generating surfaces from point clouds and
+        is more reliable than :func:`DataSetFilters.delaunay_3d`.
+
+        Parameters
+        ----------
+        nbr_sz : int, optional
+            Specify the number of neighbors each point has, used for
+            estimating the local surface orientation.
+
+            The default value of 20 should be fine for most
+            applications, higher values can be specified if the spread
+            of points is uneven. Values as low as 10 may yield
+            adequate results for some surfaces. Higher values cause
+            the algorithm to take longer and will cause
+            errors on sharp boundaries.
+
+        sample_spacing : float, optional
+            The spacing of the 3D sampling grid.  If not set, a
+            reasonable guess will be made.
+
+        progress_bar : bool, optional
+            Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.PolyData
+            Reconstructed surface.
+
+        Examples
+        --------
+        Create a point cloud out of a sphere and reconstruct a surface
+        from it.
+
+        >>> import pyvista as pv
+        >>> points = pv.wrap(pv.Sphere().points)
+        >>> surf = points.reconstruct_surface()
+
+        >>> pl = pv.Plotter(shape=(1,2))
+        >>> _ = pl.add_mesh(points)
+        >>> _ = pl.add_title('Point Cloud of 3D Surface')
+        >>> pl.subplot(0,1)
+        >>> _ = pl.add_mesh(surf, color=True, show_edges=True)
+        >>> _ = pl.add_title('Reconstructed Surface')
+        >>> pl.show()
+
+        See :ref:`surface_reconstruction_example` for more examples
+        using this filter.
+
+        """
+        alg = _vtk.vtkSurfaceReconstructionFilter()
+        alg.SetInputDataObject(self)
+        if nbr_sz is not None:
+            alg.SetNeighborhoodSize(nbr_sz)
+        if sample_spacing is not None:
+            alg.SetSampleSpacing(sample_spacing)
+
+        # connect using ports as this will be slightly faster
+        mc = _vtk.vtkMarchingCubes()
+        mc.SetComputeNormals(False)
+        mc.SetComputeScalars(False)
+        mc.SetComputeGradients(False)
+        mc.SetInputConnection(alg.GetOutputPort())
+        mc.SetValue(0, 0.0)
+        _update_alg(mc, progress_bar, 'Reconstructing surface')
+        surf = pyvista.wrap(mc.GetOutput())
+        return surf

--- a/pyvista/core/filters/unstructured_grid.py
+++ b/pyvista/core/filters/unstructured_grid.py
@@ -1,6 +1,9 @@
 """Filters module with a class to manage filters/algorithms for unstructured grid datasets."""
+from functools import wraps
+
 import pyvista
 from pyvista import abstract_class
+from pyvista.core.filters.poly_data import PolyDataFilters
 from pyvista.core.filters.data_set import DataSetFilters
 
 
@@ -8,49 +11,12 @@ from pyvista.core.filters.data_set import DataSetFilters
 class UnstructuredGridFilters(DataSetFilters):
     """An internal class to manage filters/algorithms for unstructured grid datasets."""
 
-    def delaunay_2d(self, tol=1e-05, alpha=0.0, offset=1.0, bound=False,
-                    progress_bar=False):
-        """Apply a delaunay 2D filter along the best fitting plane.
+    @wraps(PolyDataFilters.delaunay_2d)
+    def delaunay_2d(self, *args, **kwargs):
+        """Wrap ``PolyDataFilters.delaunay_2d``."""
+        return PolyDataFilters.delaunay_2d(self, *args, **kwargs)
 
-        This extracts the grid's points and performs the triangulation
-        on those alone.
-
-        Parameters
-        ----------
-        tol : float, optional
-            Specify a tolerance to control discarding of closely
-            spaced points. This tolerance is specified as a fraction
-            of the diagonal length of the bounding box of the points.
-            Defaults to ``1e-05``.
-
-        alpha : float, optional
-            Specify alpha (or distance) value to control output of
-            this filter. For a non-zero alpha value, only edges or
-            triangles contained within a sphere centered at mesh
-            vertices will be output. Otherwise, only triangles will be
-            output. Defaults to ``0.0``.
-
-        offset : float, optional
-            Specify a multiplier to control the size of the initial,
-            bounding Delaunay triangulation. Defaults to ``1.0``.
-
-        bound : bool, optional
-            Boolean controls whether bounding triangulation points
-            and associated triangles are included in the
-            output. These are introduced as an initial triangulation
-            to begin the triangulation process. This feature is nice
-            for debugging output. Default ``False``.
-
-        progress_bar : bool, optional
-            Display a progress bar to indicate progress.
-
-        Returns
-        -------
-        pyvista.PolyData
-            Surface mesh containing the delaunay filter.
-
-        """
-        return pyvista.PolyData(self.points).delaunay_2d(tol=tol, alpha=alpha,
-                                                         offset=offset,
-                                                         bound=bound,
-                                                         progress_bar=progress_bar)
+    @wraps(PolyDataFilters.reconstruct_surface)
+    def reconstruct_surface(self, *args, **kwargs):
+        """Wrap ``PolyDataFilters.reconstruct_surface``."""
+        return PolyDataFilters.reconstruct_surface(self, *args, **kwargs)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -384,10 +384,11 @@ def test_wireframe_composite(composite):
     assert output.n_blocks == composite.n_blocks
 
 
-def test_delaunay_2d(datasets):
-    mesh = datasets[2].delaunay_2d(progress_bar=True)  # UnstructuredGrid
+def test_delaunay_2d_unstructured(datasets):
+    mesh = examples.load_hexbeam().delaunay_2d(progress_bar=True)  # UnstructuredGrid
     assert isinstance(mesh, pyvista.PolyData)
     assert mesh.n_points
+    assert len(mesh.point_data.keys()) > 0
 
 
 @pytest.mark.parametrize('method', ['contour', 'marching_cubes',
@@ -1701,7 +1702,13 @@ def test_collision_solid_non_triangle(hexbeam):
     assert output.is_all_triangles
 
 
-def test_reconstruct_surface(sphere):
+def test_reconstruct_surface_poly(sphere):
     pc = pyvista.wrap(sphere.points)
     surf = pc.reconstruct_surface(nbr_sz=10, sample_spacing=50)
     assert surf.is_all_triangles
+
+
+def test_reconstruct_surface_unstructured(datasets):
+    mesh = examples.load_hexbeam().reconstruct_surface()
+    assert isinstance(mesh, pyvista.PolyData)
+    assert mesh.n_points


### PR DESCRIPTION
Resolve #1862 

I propose moving the `reconstruct_surface` filter to be a `PolyDataFilter` much like the `delaunay_2d` filter. 

The `reconstruct_surface` filter only works with the points of the input data set to reconstruct a surface and in my opinion it does not make any sense to reconstruct a surface from mesh types that already have a well defined surface or volume: `RectilinearGrid`, `StructuredGrid`, or `UniformGrid`. It is my belief that the `reconstruct_surface` should only be intended for point clouds and thus should be a `PolyData`-specific filter. 

For the case of `UnstructuredGrid` types, because it makes sense to have a point cloud in this data type as well and because `delaunay_2d` is wrapped there I wrapped the `reconstruct_surface` in `UnstructuredGridFilters`. When doing so, I noticed that the wrapping of `delaunay_2d` for `UnstructuredGridFilters` was done incorrectly and it would not transfer any point arrays so I fixed this and added a test.

