### PR TITLE
Speed up pytest collection using testpaths

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,4 @@ filterwarnings =
     ignore:.*numpy.ufunc size changed.*:RuntimeWarning
     ignore:.*Given trait value dtype "float64":UserWarning
 doctest_optionflags = NUMBER ELLIPSIS
+testpaths = tests


### PR DESCRIPTION
This adds `testpaths = test` to greatly speed up test collection using pytest.  I see a noticeable improvement using this directly on the command line, and a very very large improvement when using the test collection inside VSCode.