### PR TITLE
FIX: Bump version

### DIFF
--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -15,7 +15,7 @@ Denotes the first release candidate.
 
 """
 # major, minor, patch
-version_info = 0, 32, 'dev0'
+version_info = 0, 33, 'dev0'
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
It's standard AFAICT across scientific library packages (matplotlib, numpy, scipy, scikit-learn, etc.) to release a version (e.g., 0.32.0) and then bump `main` to the next planned non-bugfix release version plus `.dev0`, e.g. `0.33.dev0` as I've done here. It makes checks like `LooseVersion(pyvista.__version__) >= LooseVersion('0.32')` (and newer, non-deprecated variants of the same thing) pass, which they definitely should if you're on a dev version of the library post 0.32 release (as we are now).