### PR TITLE
Reset theme in sphinx gallery and reset before and after examples

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -316,6 +316,7 @@ sphinx_gallery_conf = {
         "set_plot_theme('document')\n"
     ),
     "reset_modules": (reset_pyvista, ),
+    "reset_modules_order": "both",
 }
 
 import re

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -289,6 +289,7 @@ def reset_pyvista(gallery_conf, fname):
     """
     import pyvista
     pyvista._wrappers['vtkPolyData'] = pyvista.PolyData
+    pyvista.set_plot_theme('document')
 
 
 sphinx_gallery_conf = {

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -21,7 +21,7 @@ scipy
 Sphinx>=4.0.0
 sphinx-autobuild
 sphinx-copybutton
-sphinx-gallery>=0.8.1
+sphinx-gallery>=0.10.1
 sphinx-notfound-page>=0.3.0
 sphinx-panels
 sphinxcontrib-napoleon


### PR DESCRIPTION

### Overview
We should reset the plot_theme during example generation to ensure that changes do not leak outside.

This also adds the configuration to reset before and after each example. This requires a newer version of Sphinx-Gallery. The default in Sphinx-Gallery is reset before each example, which can still leak out changes if the last example changes the configuration. We could just do after, but then it is possible that the first example is slightly different than all the others if there is any inconsistency in the Sphinx in conf.py. This is particularly important when regenerating a single or a small number of examples during development, when only a few examples are being built.

See https://sphinx-gallery.github.io/stable/configuration.html#reset-modules-order.

### Details
Had a branch problem in #1912 , this PR is a duplicate with better branch.

This PR is related to https://github.com/pyvista/pyvista/pull/1432#issuecomment-984134175