### PR TITLE
Maintenance: add vtk 9.0.3 to CI

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -127,6 +127,10 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9']
+        vtk-version: ['latest']
+        include:
+          - python-version: '3.9'
+            vtk-version: '9.0.3'
     env:
       SHELLOPTS: 'errexit:pipefail'
 
@@ -141,7 +145,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements_test.txt') }}
+          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.vtk-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements_test.txt') }}
           restore-keys: |
             Python-${{ runner.os }}-${{ matrix.python-version }}
 
@@ -150,6 +154,10 @@ jobs:
           pip install wheel
           python setup.py bdist_wheel
           pip install dist/pyvista*.whl
+
+      - name: Setup vtk
+        if: ${{ matrix.vtk-version != 'latest' }}
+        run: pip install vtk==${{ matrix.vtk-version }}
 
       - name: Install Testing Requirements
         run: |


### PR DESCRIPTION
### Overview

Adds vtk 9.0.3 to CI.  Currently we only test on 8.2 and 9.1 and we won't be able to catch any problems with 9.0.x.

### Details

For consideration:  we could also think about pinning the latest version of vtk across all the python versions to 9.1.0 to prevent a vtk upgrade from immediately breaking the Ci.  I think that it is better to learn that it breaks, so I would prefer to keep the current state.

Opening as a draft initially for testing on CI, will convert to non-draft when ready.


