### PR TITLE
Clarify camera distance

### DIFF
--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -200,7 +200,11 @@ class Camera(_vtk.vtkCamera):
 
     @property
     def distance(self):
-        """Return or set the distance from the camera position to the focal point.
+        """Return or set the distance of the focal point from the camera.
+        
+        Notes
+        -----
+        Setting the distance keeps the camera fixed and moves the focal point.
 
         Examples
         --------


### PR DESCRIPTION
### Overview
This clarifies the documentation of camera distance. Fixes https://github.com/pyvista/pyvista/issues/1931. See https://vtk.org/doc/nightly/html/classvtkCamera.html#a98f6dd235b4ecf71841ca32fcd94635d for the relevant upstream VTK documentation.


### Details

- < feature1 or bug1 description >
- < feature2 or bug2 description >

