### PR TITLE
disable warning when using pythreejs backend

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -114,7 +114,7 @@ def _warn_xserver():  # pragma: no cover
             return
 
         # finally, check if using a backend that doesn't require an xserver
-        if pyvista.global_theme.jupyter_backend in ['ipygany']:
+        if pyvista.global_theme.jupyter_backend in ['ipygany', 'pythreejs']:
             return
 
         # Check if VTK has EGL support


### PR DESCRIPTION
When running without an xserver (e.g. in docker without xvfb) but using pythreejs with a jupyter notebook, the following warning is given:

```
This system does not appear to be running an xserver.
PyVista will likely segfault when rendering.

Try starting a virtual frame buffer with xvfb, or using
  ``pyvista.start_xvfb()``
```

This PR corrects this behavior.