### PR TITLE
Add image_fft and image_rfft

### DIFF
--- a/examples/00-load/read-image.py
+++ b/examples/00-load/read-image.py
@@ -5,6 +5,7 @@ Read Image Files
 Read and plot image files (JPEG, TIFF, PNG, etc).
 
 """
+import pyvista as pv
 from pyvista import examples
 
 ###############################################################################
@@ -34,18 +35,27 @@ image.plot(rgb=True, cpos="xy")
 image.plot(cpos="xy")
 
 ###############################################################################
-# It is also possible to apply filters to images.
+# Convert rgb to grayscale.
+# https://en.wikipedia.org/wiki/Grayscale#Luma_coding_in_video_systems
 
-fft = image.fft()
-rfft = image.rfft()
-pl = pv.Plotter(1, 3)
-pl.subplot(0, 0)
-pl.add_title("Original")
-pl.add_mesh(image)
-pl.subplot(0, 1)
-pl.add_title("FFT")
-pl.add_mesh(fft)
-pl.subplot(0, 2)
-pl.add_title("rFFT")
-pl.add_mesh(rfft)
-pl.show(cpos="xy")
+r = image["JPEGImage"][:, 0]
+g = image["JPEGImage"][:, 1]
+b = image["JPEGImage"][:, 2]
+image.clear_data()
+image["GrayScale"] = 0.299 * r + 0.587 * g + 0.114 * b
+pv.global_theme.cmap = "gray"
+image.copy().plot(cpos="xy")
+
+###############################################################################
+# It is also possible to apply filters to images. The following is the Fast
+# Fourier Transformed image data.
+
+fft = image.image_fft()
+fft.copy().plot(cpos="xy", log_scale=True)
+
+###############################################################################
+# Once Fast Fourier Transformed, images can also Reverse Fast Fourier
+# Transformed.
+
+rfft = fft.image_rfft()
+rfft.copy().plot(cpos="xy")

--- a/examples/00-load/read-image.py
+++ b/examples/00-load/read-image.py
@@ -32,3 +32,20 @@ image.plot(rgb=True, cpos="xy")
 
 # Mapped image colors
 image.plot(cpos="xy")
+
+###############################################################################
+# It is also possible to apply filters to images.
+
+fft = image.fft()
+rfft = image.rfft()
+pl = pv.Plotter(1, 3)
+pl.subplot(0, 0)
+pl.add_title("Original")
+pl.add_mesh(image)
+pl.subplot(0, 1)
+pl.add_title("FFT")
+pl.add_mesh(fft)
+pl.subplot(0, 2)
+pl.add_title("rFFT")
+pl.add_mesh(rfft)
+pl.show(cpos="xy")

--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -386,6 +386,10 @@ if VTK9:
         vtkOpenGLGPUVolumeRayCastMapper,
         vtkSmartVolumeMapper,
     )
+    from vtkmodules.vtkImagingFourier import (
+        vtkImageFFT,
+        vtkImageRFFT,
+    )
 
     # lazy import for some of the less used readers
     def lazy_vtkGL2PSExporter():

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -116,3 +116,57 @@ class UniformGridFilters(DataSetFilters):
         fixed.field_data.update(result.field_data)
         fixed.copy_meta_from(result)
         return fixed
+
+    def image_fft(self, progress_bar=False):
+        """Fast Fourier Transform.
+
+        The input can have real or complex data in any components and data types,
+        but the output is always complex doubles with real values in component0,
+        and imaginary values in component1. The filter is fastest for images
+        that have power of two sizes. The filter uses a butterfly diagram for
+        each prime factor of the dimension. This makes images with prime number
+        dimensions (i.e. 17x17) much slower to compute. Multi dimensional
+        (i.e volumes) FFT's are decomposed so that each axis executes serially.
+
+        Parameters
+        ----------
+        progress_bar : bool, optional
+            Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.UniformGrid
+            UniformGrid subset.
+        """
+        alg = _vtk.vtkImageFFT()
+        alg.SetInputDataObject(self)
+        _update_alg(alg, progress_bar, 'Fast Fourier Transform.')
+        result = _get_output(alg)
+        return result
+
+    def image_rfft(self, progress_bar=False):
+        """Reverse Fast Fourier Transform.
+
+        The input can have real or complex data in any components and data types,
+        but the output is always complex doubles with real values in component0,
+        and imaginary values in component1. The filter is fastest for images that
+        have power of two sizes. The filter uses a butterfly diagram for each prime
+        factor of the dimension. This makes images with prime number dimensions
+        (i.e. 17x17) much slower to compute. Multi dimensional (i.e volumes)
+        FFT's are decomposed so that each axis executes serially.
+
+        Parameters
+        ----------
+        progress_bar : bool, optional
+            Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.UniformGrid
+            UniformGrid subset.
+        """
+        alg = _vtk.vtkImageRFFT()
+        alg.SetInputDataObject(self)
+        _update_alg(alg, progress_bar, 'Reverse Fast Fourier Transform.')
+        result = _get_output(alg)
+        return result

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -723,13 +723,21 @@ def test_cast_uniform_to_rectilinear():
 
 def test_fft_and_rfft():
     grid = examples.download_puppy()
-    fft = grid.fft()
+    # Convert rgb to grayscale.
+    # https://en.wikipedia.org/wiki/Grayscale#Luma_coding_in_video_systems
+    r = grid['JPEGImage'][:, 0]
+    g = grid['JPEGImage'][:, 1]
+    b = grid['JPEGImage'][:, 2]
+    grid.clear_data()
+    grid['GrayScale'] = 0.299 * r + 0.587 * g + 0.114 * b
+    fft = grid.image_fft()
     assert fft.n_points == grid.n_points
     assert fft.n_arrays == grid.n_arrays
-    rfft = fft.rfft()
+    rfft = fft.image_rfft()
     assert rfft.n_points == grid.n_points
     assert rfft.n_arrays == grid.n_arrays
-    assert np.allclose(rfft['JPEGImage'].real, grid['JPEGImage'])
+    assert np.allclose(rfft['GrayScale'][:, 0], grid['GrayScale'])
+    assert np.allclose(rfft['GrayScale'][:, 1], 0.0)
 
 
 @pytest.mark.parametrize('binary', [True, False])

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -721,6 +721,17 @@ def test_cast_uniform_to_rectilinear():
     assert rectilinear.bounds == grid.bounds
 
 
+def test_fft_and_rfft():
+    grid = examples.download_puppy()
+    fft = grid.fft()
+    assert fft.n_points == grid.n_points
+    assert fft.n_arrays == grid.n_arrays
+    rfft = fft.rfft()
+    assert rfft.n_points == grid.n_points
+    assert rfft.n_arrays == grid.n_arrays
+    assert np.allclose(rfft['JPEGImage'].real, grid['JPEGImage'])
+
+
 @pytest.mark.parametrize('binary', [True, False])
 @pytest.mark.parametrize('extension', ['.vtk', '.vtr'])
 def test_save_rectilinear(extension, binary, tmpdir):


### PR DESCRIPTION
### Overview
Add vtkImageFFT and vtkImageRFFT wrapper.

<!-- Please insert a high-level description of this pull request here. -->
Convert rgb to grayscale (see https://en.wikipedia.org/wiki/Grayscale#Luma_coding_in_video_systems).
```python
r = image["JPEGImage"][:, 0]                                                                                                                                                                                
g = image["JPEGImage"][:, 1]                                                                                                                                                                                
b = image["JPEGImage"][:, 2]                                                                                                                                                                                
image.clear_data()                                                                                                                                                                                          
image["GrayScale"] = 0.299 * r + 0.587 * g + 0.114 * b                                                                                                                                                      
pv.global_theme.cmap = "gray"                                                                                                                                                                               
image.copy().plot(cpos="xy") 
```
![image1](https://user-images.githubusercontent.com/7513610/146647530-84671d79-48a6-4b27-9936-3678bb82ea0a.jpg)

It is also possible to apply filters to images. The following is the Fast Fourier Transformed image data.

```python
fft = image.image_fft()                                                                                                                                                                                     
fft.copy().plot(cpos="xy", log_scale=True)                                                                                                                                                                  
```
![image2](https://user-images.githubusercontent.com/7513610/146647586-b573801a-62ff-4691-bde0-da939e6786a6.jpg)


Once Fast Fourier Transformed, images can also Reverse Fast Fourier Transformed.
```python
fft = fft.image_rfft()                                                                                                                                                                                     
rfft.copy().plot(cpos="xy")
```
![image3](https://user-images.githubusercontent.com/7513610/146647596-26685ab6-b3c7-4036-b130-f6ff45f1c2a6.jpg)



<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None

