### PR TITLE
move doc coverage to makefile and out of pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,11 @@ coverage-html:
 	@echo "Reporting HTML coverage"
 	@pytest -v --cov pyvista --cov-report html
 
+coverage-docs:
+	@echo "Reporting documentation coverage"
+	@make -C doc html SPHINXOPTS="-Q" -b coverage
+	@cat doc/_build/coverage/python.txt
+
 mypy:
 	@echo "Running mypy static type checking"
 	mypy pyvista/core/ --no-incremental

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,13 +141,6 @@ jobs:
       python doc/print_errors.py
     displayName: Check for warnings
 
-  # report coverage.  This must be run separately as to not overwrite
-  # build errors file.  Run quietly since we've already run sphinx.
-  - script: |
-      make -C doc html SPHINXOPTS="-Q" -b coverage
-      cat doc/_build/coverage/python.txt
-    displayName: Report documentation coverage
-
   # Push example notebooks to pyvista-examples
   - script: |
       pip install cookiecutter


### PR DESCRIPTION
Move the documentation coverage step out of the Azure CI and into the makefile. This shaves 7 minutes our already long documentation build.
