### PR TITLE
Add support for meshio >=5.2

### DIFF
--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -583,7 +583,8 @@ def read_plot3d(filename, q_filenames=(), auto_detect=True, attrs=None):
 
 def from_meshio(mesh):
     """Convert a ``meshio`` mesh instance to a PyVista mesh."""
-    from meshio.vtk._vtk import meshio_to_vtk_type, vtk_type_to_numnodes
+    from meshio._vtk_common import meshio_to_vtk_type
+    from meshio.vtk._vtk_42 import vtk_type_to_numnodes
 
     # Extract cells from meshio.Mesh object
     offset = []
@@ -689,7 +690,7 @@ def save_meshio(filename, mesh, file_format=None, **kwargs):
             "pip install meshio"
         )
 
-    from meshio.vtk._vtk import vtk_to_meshio_type
+    from meshio._vtk_common import vtk_to_meshio_type
 
     # Make sure relative paths will work
     filename = os.path.abspath(os.path.expanduser(str(filename)))

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -583,8 +583,11 @@ def read_plot3d(filename, q_filenames=(), auto_detect=True, attrs=None):
 
 def from_meshio(mesh):
     """Convert a ``meshio`` mesh instance to a PyVista mesh."""
-    from meshio._vtk_common import meshio_to_vtk_type
-    from meshio.vtk._vtk_42 import vtk_type_to_numnodes
+    try:  # meshio<5.0 compatibility
+        from meshio.vtk._vtk import meshio_to_vtk_type, vtk_type_to_numnodes
+    except ImportError:  # pragma: no cover
+        from meshio._vtk_common import meshio_to_vtk_type
+        from meshio.vtk._vtk_42 import vtk_type_to_numnodes
 
     # Extract cells from meshio.Mesh object
     offset = []
@@ -690,7 +693,10 @@ def save_meshio(filename, mesh, file_format=None, **kwargs):
             "pip install meshio"
         )
 
-    from meshio._vtk_common import vtk_to_meshio_type
+    try:  # for meshio<5.0 compatibility
+        from meshio.vtk._vtk import vtk_to_meshio_type
+    except:  # pragma: no cover
+        from meshio._vtk_common import vtk_to_meshio_type
 
     # Make sure relative paths will work
     filename = os.path.abspath(os.path.expanduser(str(filename)))

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -19,4 +19,4 @@ param==1.10.1
 ipygany
 pytest-xdist
 pythreejs
-meshio>=4.0.3, <5.0
+meshio

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,6 @@ setup(
     extras_require={
         'all': ['matplotlib', 'colorcet', 'cmocean', 'meshio'],
         'colormaps': ['matplotlib', 'colorcet', 'cmocean'],
-        'io': ['meshio>=4.0.3, <5.0'],
+        'io': ['meshio>=5.2'],
     },
 )


### PR DESCRIPTION
### Overview

Hi, I noticed `pyvista` does not work with the latest version of `meshio`, because of some import errors:

`ModuleNotFoundError: No module named 'meshio.vtk._vtk'`.

I don't know if this is on your radar at the moment, but this PR fixes the import error and updates the version requirement. Let me know what you think!

