### PR TITLE
add back in missing import

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -46,7 +46,7 @@ from .tools import (  # noqa
     normalize,
     opacity_transfer_function,
     parse_color,
-    parse_font_family
+    parse_font_family,
 )
 from .widgets import WidgetHelper
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -41,7 +41,13 @@ from .render_window_interactor import RenderWindowInteractor
 from .renderer import Camera, Renderer
 from .renderers import Renderers
 from .scalar_bars import ScalarBars
-from .tools import FONTS, opacity_transfer_function, parse_color, parse_font_family
+from .tools import (  # noqa
+    FONTS,
+    normalize,
+    opacity_transfer_function,
+    parse_color,
+    parse_font_family
+)
 from .widgets import WidgetHelper
 
 SUPPORTED_FORMATS = [".png", ".jpeg", ".jpg", ".bmp", ".tif", ".tiff"]


### PR DESCRIPTION
Adds back in a missing import to `plotting.py` that is used by `examples/02-plot/cmap.py`