### PR TITLE
refactor to warn on int usage

### DIFF
--- a/doc/api/core/pointsets.rst
+++ b/doc/api/core/pointsets.rst
@@ -216,7 +216,7 @@ initializing.
    ...                   [0, 0, 1],
    ...                   [1, 0, 1],
    ...                   [1, 1, 1],
-   ...                   [0, 1, 1]])
+   ...                   [0, 1, 1]], dtype=np.float32)
    >>> cell2 = np.array([[0, 0, 2],
    ...                   [1, 0, 2],
    ...                   [1, 1, 2],
@@ -224,7 +224,7 @@ initializing.
    ...                   [0, 0, 3],
    ...                   [1, 0, 3],
    ...                   [1, 1, 3],
-   ...                   [0, 1, 3]])
+   ...                   [0, 1, 3]], dtype=np.float32)
    >>> points = np.vstack((cell1, cell2))
    >>> grid = pyvista.UnstructuredGrid(cells, cell_type, points)
    >>> grid
@@ -276,9 +276,9 @@ grid from NumPy arrays.
     import pyvista as pv
     import numpy as np
 
-    x = np.arange(-10, 10, 1)
-    y = np.arange(-10, 10, 1)
-    z = np.arange(-10, 10, 2)
+    x = np.arange(-10, 10, 1, dtype=np.float32)
+    y = np.arange(-10, 10, 1, dtype=np.float32)
+    z = np.arange(-10, 10, 2, dtype=np.float32)
     x, y, z = np.meshgrid(x, y, z)
 
     # create the unstructured grid directly from the numpy arrays and plot

--- a/examples/01-filter/glyphs_table.py
+++ b/examples/01-filter/glyphs_table.py
@@ -39,8 +39,8 @@ params = np.array([[1.56821334, 0.99649769],
 geoms = [pv.ParametricSuperToroid(n1=n1, n2=n2) for n1, n2 in params]
 
 # get dataset where to put glyphs
-x, y, z = np.mgrid[:3, :3, :3]
-mesh = pv.StructuredGrid(x, y, z, force_float=False)
+x, y, z = np.mgrid[:3.0, :3.0, :3.0]
+mesh = pv.StructuredGrid(x, y, z)
 
 # add random scalars
 # rng_int = rng.integers(0, N, size=x.size)

--- a/examples/01-filter/glyphs_table.py
+++ b/examples/01-filter/glyphs_table.py
@@ -39,8 +39,8 @@ params = np.array([[1.56821334, 0.99649769],
 geoms = [pv.ParametricSuperToroid(n1=n1, n2=n2) for n1, n2 in params]
 
 # get dataset where to put glyphs
-x,y,z = np.mgrid[:3, :3, :3]
-mesh = pv.StructuredGrid(x, y, z)
+x, y, z = np.mgrid[:3, :3, :3]
+mesh = pv.StructuredGrid(x, y, z, force_float=False)
 
 # add random scalars
 # rng_int = rng.integers(0, N, size=x.size)

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -1570,7 +1570,7 @@ class PolyDataFilters(DataSetFilters):
 
         >>> import pyvista as pv
         >>> import numpy as np
-        >>> points = np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0]])
+        >>> points = np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0]], dtype=np.float32)
         >>> faces = np.array([3, 0, 1, 2, 3, 0, 3, 3])
         >>> mesh = pv.PolyData(points, faces)
         >>> mout = mesh.clean()

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -139,13 +139,13 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
         Parameters
         ----------
         x : np.ndarray
-            Coordinates of the nodes in x direction.
+            Coordinates of the points in x direction.
 
         y : np.ndarray
-            Coordinates of the nodes in y direction.
+            Coordinates of the points in y direction.
 
         z : np.ndarray
-            Coordinates of the nodes in z direction.
+            Coordinates of the points in z direction.
 
         """
         # Set the coordinates along each axial direction
@@ -401,13 +401,13 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         """Create VTK image data directly from numpy arrays.
 
         A uniform grid is defined by the node spacings for each axis
-        (uniform along each individual axis) and the number of nodes on each axis.
+        (uniform along each individual axis) and the number of points on each axis.
         These are relative to a specified origin (default is ``(0.0, 0.0, 0.0)``).
 
         Parameters
         ----------
         dims : tuple(int)
-            Length 3 tuple of ints specifying how many nodes along each axis.
+            Length 3 tuple of ints specifying how many points along each axis.
 
         spacing : tuple(float)
             Length 3 tuple of floats/ints specifying the node spacings for each axis.

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1258,7 +1258,7 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
             self._from_arrays(offset, cells, cell_types, points, deep=deep)
 
     def _from_arrays(
-            self, offset, cells, cell_type, points, deep=True, force_float=True
+            self, offset, cells, cell_type, points, deep=True, force_float=True,
     ):
         """Create VTK unstructured grid from numpy arrays.
 
@@ -1284,10 +1284,10 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
             ``False``.  Cells and cell types are always copied.
 
         force_float : bool, optional
-            Casts the datatype to float32 if points datatype are
-            non-float.  Default ``True``. Set this to ``False`` to
-            allow non-float types, though this may lead to errors when
-            transforming datasets.
+        Casts the datatype to ``float32`` if points datatype are
+        non-float.  Default ``True``. Set this to ``False`` to allow
+        non-float types, though this may lead to intermediate float
+        truncation when rotating datasets.
 
         Examples
         --------
@@ -1767,10 +1767,10 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
             Position of the points in z direction.
 
         force_float : bool, optional
-            Casts the datatype to float32 if points datatype are
-            non-float.  Default ``True``. Set this to ``False`` to
-            allow non-float types, though this may lead to errors when
-            transforming datasets.
+            Casts the datatype to ``float32`` if points datatype are
+            non-float.  Default ``True``. Set this to ``False`` to allow
+            non-float types, though this may lead to intermediate float
+            truncation when rotating datasets.
 
         """
         if not(x.shape == y.shape == z.shape):

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -395,10 +395,10 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         file.
 
     force_float : bool, optional
-        Casts the datatype to float32 if points datatype are
+        Casts the datatype to ``float32`` if points datatype is
         non-float.  Default ``True``. Set this to ``False`` to allow
-        non-float types, though this may lead to errors when rotating
-        datasets.
+        non-float types, though this may lead to truncation of
+        intermediate floats when transforming datasets.
 
     Examples
     --------
@@ -1284,10 +1284,10 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
             ``False``.  Cells and cell types are always copied.
 
         force_float : bool, optional
-        Casts the datatype to ``float32`` if points datatype are
-        non-float.  Default ``True``. Set this to ``False`` to allow
-        non-float types, though this may lead to intermediate float
-        truncation when rotating datasets.
+            Casts the datatype to ``float32`` if points datatype is
+            non-float.  Default ``True``. Set this to ``False`` to allow
+            non-float types, though this may lead to truncation of
+            intermediate floats when transforming datasets.
 
         Examples
         --------
@@ -1767,10 +1767,10 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
             Position of the points in z direction.
 
         force_float : bool, optional
-            Casts the datatype to ``float32`` if points datatype are
+            Casts the datatype to ``float32`` if points datatype is
             non-float.  Default ``True``. Set this to ``False`` to allow
-            non-float types, though this may lead to intermediate float
-            truncation when rotating datasets.
+            non-float types, though this may lead to truncation of
+            intermediate floats when transforming datasets.
 
         """
         if not(x.shape == y.shape == z.shape):

--- a/pyvista/demos/demos.py
+++ b/pyvista/demos/demos.py
@@ -479,7 +479,7 @@ def plot_datasets(dataset_type=None):
 
     ###########################################################################
     # polydata
-    points = pv.PolyData([[1, 2, 2], [2, 2, 2]])
+    points = pv.PolyData([[1.0, 2.0, 2.0], [2.0, 2.0, 2.0]])
 
     line = pv.Line()
     line.points += np.array((2, 0, 0))

--- a/pyvista/demos/demos.py
+++ b/pyvista/demos/demos.py
@@ -44,8 +44,9 @@ def glyphs(grid_sz=3):
     geoms = [pv.ParametricSuperToroid(n1=n1, n2=n2) for n1, n2 in params]
 
     # get dataset where to put glyphs
+    grid_sz = float(grid_sz)
     x, y, z = np.mgrid[:grid_sz, :grid_sz, :grid_sz]
-    mesh = pv.StructuredGrid(x, y, z, force_float=False)
+    mesh = pv.StructuredGrid(x, y, z)
 
     # add random scalars
     rng_int = rng.integers(0, n, size=x.size)

--- a/pyvista/demos/demos.py
+++ b/pyvista/demos/demos.py
@@ -45,7 +45,7 @@ def glyphs(grid_sz=3):
 
     # get dataset where to put glyphs
     x, y, z = np.mgrid[:grid_sz, :grid_sz, :grid_sz]
-    mesh = pv.StructuredGrid(x, y, z)
+    mesh = pv.StructuredGrid(x, y, z, force_float=False)
 
     # add random scalars
     rng_int = rng.integers(0, n, size=x.size)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3514,12 +3514,13 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> import numpy as np
         >>> import pyvista
         >>> pl = pyvista.Plotter()
-        >>> points = np.array([[0, 0, 0],
-        ...                    [1, 1, 0],
-        ...                    [2, 0, 0]])
+        >>> points = np.array([[0.0, 0.0, 0.0],
+        ...                    [1.0, 1.0, 0.0],
+        ...                    [2.0, 0.0, 0.0]])
         >>> labels = ['Point A', 'Point B', 'Point C']
         >>> actor = pl.add_point_labels(points, labels, italic=True, font_size=20,
-        ...                             point_color='red', point_size=20, render_points_as_spheres=True,
+        ...                             point_color='red', point_size=20,
+        ...                             render_points_as_spheres=True,
         ...                             always_visible=True, shadow=True)
         >>> pl.camera_position = 'xy'
         >>> pl.show()

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -59,7 +59,7 @@ def map_loc_to_pos(loc, size, border=0.05):
 def make_legend_face(face):
     """Create the legend face."""
     if face is None:
-        legendface = pyvista.PolyData([0, 0, 0])
+        legendface = pyvista.PolyData([0.0, 0.0, 0.0])
     elif face in ["-", "line"]:
         legendface = _line_for_legend()
     elif face in ["^", "triangle"]:
@@ -2741,7 +2741,7 @@ class Renderer(_vtk.vtkRenderer):
 
                 if face is None:
                     # dummy vtk object
-                    vtk_object = pyvista.PolyData([0, 0, 0])
+                    vtk_object = pyvista.PolyData([0.0, 0.0, 0.0])
 
                 self._legend.SetEntry(i, vtk_object, text, parse_color(color))
 

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -430,7 +430,7 @@ def get_array_association(mesh, name, preference='cell', err=False) -> FieldAsso
     return matches[0]
 
 
-def vtk_points(points, deep=True, force_float=True):
+def vtk_points(points, deep=True):
     """Convert numpy array or array-like to a ``vtkPoints`` object.
 
     Parameters

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -10,6 +10,7 @@ import threading
 from threading import Thread
 import traceback
 from typing import Optional
+import warnings
 
 import numpy as np
 
@@ -430,7 +431,7 @@ def get_array_association(mesh, name, preference='cell', err=False) -> FieldAsso
     return matches[0]
 
 
-def vtk_points(points, deep=True):
+def vtk_points(points, deep=True, force_float=False):
     """Convert numpy array or array-like to a ``vtkPoints`` object.
 
     Parameters
@@ -442,6 +443,11 @@ def vtk_points(points, deep=True):
     deep : bool, optional
         Perform a deep copy of the array.  Only applicable if
         ``points`` is a :class:`numpy.ndarray`.
+
+    force_float : bool, optional
+        Casts the datatype to float32 if points datatype are
+        non-float.  Set this to ``False`` to allow non-float types,
+        though this may lead to errors when transforming datasets.
 
     Returns
     -------
@@ -463,6 +469,16 @@ def vtk_points(points, deep=True):
     # verify is numeric
     if not np.issubdtype(points.dtype, np.number):
         raise TypeError('Points must be a numeric type')
+
+    if force_float:
+        if not np.issubdtype(points.dtype, np.floating):
+            warnings.warn(
+                'Points is not a float type. This can cause issues when '
+                'transforming or applying filters. Casting to '
+                '``np.float32``. Disable this by passing '
+                '``float_float=False``'
+            )
+            points = points.astype(np.float32)
 
     # check dimensionality
     if points.ndim == 1:

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -430,7 +430,7 @@ def get_array_association(mesh, name, preference='cell', err=False) -> FieldAsso
     return matches[0]
 
 
-def vtk_points(points, deep=True):
+def vtk_points(points, deep=True, force_float=True):
     """Convert numpy array or array-like to a ``vtkPoints`` object.
 
     Parameters

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -445,9 +445,10 @@ def vtk_points(points, deep=True, force_float=False):
         ``points`` is a :class:`numpy.ndarray`.
 
     force_float : bool, optional
-        Casts the datatype to float32 if points datatype are
+        Casts the datatype to ``float32`` if points datatype is
         non-float.  Set this to ``False`` to allow non-float types,
-        though this may lead to errors when transforming datasets.
+        though this may lead to truncation of intermediate floats
+        when transforming datasets.
 
     Returns
     -------
@@ -476,7 +477,7 @@ def vtk_points(points, deep=True, force_float=False):
                 'Points is not a float type. This can cause issues when '
                 'transforming or applying filters. Casting to '
                 '``np.float32``. Disable this by passing '
-                '``float_float=False``'
+                '``force_float=False``.'
             )
             points = points.astype(np.float32)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,9 +60,9 @@ def hexbeam():
 
 @fixture()
 def struct_grid():
-    x, y, z = np.meshgrid(np.arange(-10, 10, 2),
-                          np.arange(-10, 10, 2),
-                          np.arange(-10, 10, 2))
+    x, y, z = np.meshgrid(np.arange(-10, 10, 2, dtype=np.float32),
+                          np.arange(-10, 10, 2, dtype=np.float32),
+                          np.arange(-10, 10, 2, dtype=np.float32))
     return pyvista.StructuredGrid(x, y, z)
 
 

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -215,7 +215,7 @@ def test_plot_pyvista_ndarray(sphere):
 
 
 def test_plot_increment_point_size():
-    points = np.array([[0, 0, 0], [1, 0, 0], [1, 0, 0], [1, 1, 0]])
+    points = np.array([[0.0, 0.0, 0.0], [1, 0, 0], [1, 0, 0], [1, 1, 0]])
     pl = pyvista.Plotter()
     pl.add_points(points + 1)
     pl.add_lines(points)
@@ -794,7 +794,7 @@ def test_add_point_labels_always_visible(always_visible):
     # just make sure it runs without exception
     plotter = pyvista.Plotter()
     plotter.add_point_labels(
-        np.array([[0, 0, 0]]), ['hello world'], always_visible=always_visible)
+        np.array([[0.0, 0.0, 0.0]]), ['hello world'], always_visible=always_visible)
     plotter.show()
 
 

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -215,7 +215,7 @@ def test_plot_pyvista_ndarray(sphere):
 
 
 def test_plot_increment_point_size():
-    points = np.array([[0, 0, 0], [1, 0, 0], [1, 0, 0], [1, 1, 0]], dtype=float32)
+    points = np.array([[0, 0, 0], [1, 0, 0], [1, 0, 0], [1, 1, 0]], dtype=np.float32)
     pl = pyvista.Plotter()
     pl.add_points(points + 1)
     pl.add_lines(points)

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -215,7 +215,7 @@ def test_plot_pyvista_ndarray(sphere):
 
 
 def test_plot_increment_point_size():
-    points = np.array([[0.0, 0.0, 0.0], [1, 0, 0], [1, 0, 0], [1, 1, 0]])
+    points = np.array([[0, 0, 0], [1, 0, 0], [1, 0, 0], [1, 1, 0]], dtype=float32)
     pl = pyvista.Plotter()
     pl.add_points(points + 1)
     pl.add_lines(points)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1180,7 +1180,10 @@ def test_transform_integers():
     for key in 'active_v', 'inactive_v', 'active_n', 'inactive_n':
         assert poly.point_data[key].dtype == np.int_
         assert poly.cell_data[key].dtype == np.int_
-    poly.rotate_x(angle=10)
+
+    with pytest.warns(UserWarning):
+        poly.rotate_x(angle=10, inplace=True)
+
     # check that points were converted and transformed correctly
     assert poly.points.dtype == np.float32
     assert poly.points[-1, 1] != 0

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1132,10 +1132,13 @@ def extract_points_invalid(sphere):
 
 def test_extract_points():
     # mesh points (4x4 regular grid)
-    vertices = np.array([[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0],
-                     [0, 1, 0], [1, 1, 0], [2, 1, 0], [3, 1, 0],
-                     [0, 2, 0], [1, 2, 0], [2, 2, 0], [3, 2, 0],
-                     [0, 3, 0], [1, 3, 0], [2, 3, 0], [3, 3, 0]])
+    vertices = np.array(
+        [[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0],
+         [0, 1, 0], [1, 1, 0], [2, 1, 0], [3, 1, 0],
+         [0, 2, 0], [1, 2, 0], [2, 2, 0], [3, 2, 0],
+         [0, 3, 0], [1, 3, 0], [2, 3, 0], [3, 3, 0]],
+        dtype=np.float32
+    )
     # corresponding mesh faces
     faces = np.hstack([[4, 0, 1, 5, 4],  # square
                        [4, 1, 2, 6, 5],  # square

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -69,7 +69,8 @@ def test_init_from_numpy_arrays():
             [1, 0, 1],
             [1, 1, 1],
             [0, 1, 1],
-        ]
+        ],
+        dtype=np.float32
     )
 
     cell2 = np.array(
@@ -82,7 +83,8 @@ def test_init_from_numpy_arrays():
             [1, 0, 3],
             [1, 1, 3],
             [0, 1, 3],
-        ]
+        ],
+        dtype=np.float32
     )
 
     points = np.vstack((cell1, cell2))
@@ -109,28 +111,35 @@ def create_hex_example():
     cells = np.array([8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 9, 10, 11, 12, 13, 14, 15])
     cell_type = np.array([vtk.VTK_HEXAHEDRON, vtk.VTK_HEXAHEDRON], np.int32)
 
-    cell1 = np.array([[0, 0, 0],
-                      [1, 0, 0],
-                      [1, 1, 0],
-                      [0, 1, 0],
-                      [0, 0, 1],
-                      [1, 0, 1],
-                      [1, 1, 1],
-                      [0, 1, 1]])
+    cell1 = np.array(
+        [[0, 0, 0],
+         [1, 0, 0],
+         [1, 1, 0],
+         [0, 1, 0],
+         [0, 0, 1],
+         [1, 0, 1],
+         [1, 1, 1],
+         [0, 1, 1]],
+        dtype=np.float32
+    )
 
-    cell2 = np.array([[0, 0, 2],
-                      [1, 0, 2],
-                      [1, 1, 2],
-                      [0, 1, 2],
-                      [0, 0, 3],
-                      [1, 0, 3],
-                      [1, 1, 3],
-                      [0, 1, 3]])
+    cell2 = np.array(
+        [[0, 0, 2],
+         [1, 0, 2],
+         [1, 1, 2],
+         [0, 1, 2],
+         [0, 0, 3],
+         [1, 0, 3],
+         [1, 1, 3],
+         [0, 1, 3]],
+        dtype=np.float32
+    )
 
-    points = np.vstack((cell1, cell2)).astype(np.int32)
+    points = np.vstack((cell1, cell2))
     offset = np.array([0, 9], np.int8)
 
     return offset, cells, cell_type, points
+
 
 #Try both with and without an offset array
 @pytest.mark.parametrize('specify_offset', [False, True])
@@ -156,6 +165,7 @@ def test_init_from_arrays(specify_offset):
         with pytest.raises(AttributeError):
             grid.cell_connectivity
 
+
 @pytest.mark.parametrize('multiple_cell_types', [False, True])
 @pytest.mark.parametrize('flat_cells', [False, True])
 def test_init_from_dict(multiple_cell_types, flat_cells):
@@ -173,7 +183,6 @@ def test_init_from_dict(multiple_cell_types, flat_cells):
                           [1, 0, -1],
                           [1, 1, -1],
                           [0, 1, -1]])
-
 
         points = np.vstack((points, cell3))
         input_cells_dict[vtk.VTK_QUAD] = cells_quad

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -476,9 +476,9 @@ def test_merge_invalid(hexbeam, sphere):
 
 
 def test_init_structured(struct_grid):
-    xrng = np.arange(-10, 10, 2)
-    yrng = np.arange(-10, 10, 2)
-    zrng = np.arange(-10, 10, 2)
+    xrng = np.arange(-10, 10, 2, dtype=np.float32)
+    yrng = np.arange(-10, 10, 2, dtype=np.float32)
+    zrng = np.arange(-10, 10, 2, dtype=np.float32)
     x, y, z = np.meshgrid(xrng, yrng, zrng)
     grid = pyvista.StructuredGrid(x, y, z)
     assert np.allclose(struct_grid.x, x)

--- a/tests/test_picking.py
+++ b/tests/test_picking.py
@@ -127,12 +127,12 @@ def test_point_picking_window_not_pickable():
 
     # bottom left corner, pickable
     sphere = pyvista.Sphere()
-    sphere.translate([-100, -100, 0])
+    sphere.translate([-100, -100, 0], inplace=True)
     plotter.add_mesh(sphere, pickable=True)
 
     # top right corner, not pickable
     unpickable_sphere = pyvista.Sphere()
-    unpickable_sphere.translate([100, 100, 0])
+    unpickable_sphere.translate([100, 100, 0], inplace=True)
     plotter.add_mesh(unpickable_sphere, pickable=False)
 
     plotter.view_xy()

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -84,6 +84,10 @@ def test_init_from_arrays():
     vertices[0] += 1
     assert not np.allclose(vertices[0], mesh.points[0])
 
+    # ensure that polydata raises a warning when inputting non-float dtype
+    with pytest.warns(Warning):
+        mesh = pyvista.PolyData(vertices.astype(np.int32), faces)
+
 
 def test_init_from_arrays_with_vert():
     vertices = np.array([[0, 0, 0],
@@ -156,7 +160,7 @@ def test_init_as_points():
 
 
 def test_init_as_points_from_list():
-    points = [[0, 0, 0],
+    points = [[0.0, 0.0, 0.0],
               [0, 1, 0],
               [0, 0, 1]]
     mesh = pyvista.PolyData(points)
@@ -165,10 +169,10 @@ def test_init_as_points_from_list():
 
 def test_invalid_init():
     with pytest.raises(ValueError):
-        pyvista.PolyData(np.array([1]))
+        pyvista.PolyData(np.array([1.0]))
 
     with pytest.raises(TypeError):
-        pyvista.PolyData([1, 2, 3], 'woa')
+        pyvista.PolyData([1.0, 2.0, 3.0], 'woa')
 
     with pytest.raises(ValueError):
         pyvista.PolyData('woa', 'woa')
@@ -811,7 +815,7 @@ def test_flip_normals(sphere, plane):
 
 
 def test_n_verts():
-    mesh = pyvista.PolyData([[1, 0, 0], [1, 1, 1]])
+    mesh = pyvista.PolyData([[1.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
     assert mesh.n_verts == 2
 
 

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -161,8 +161,8 @@ def test_init_as_points():
 
 def test_init_as_points_from_list():
     points = [[0.0, 0.0, 0.0],
-              [0, 1, 0],
-              [0, 0, 1]]
+              [0.0, 1.0, 0.0],
+              [0.0, 0.0, 1.0]]
     mesh = pyvista.PolyData(points)
     assert np.allclose(mesh.points, points)
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -72,7 +72,7 @@ def test_bad_legend_origin_and_size(sphere):
 @pytest.mark.parametrize('loc', ACTOR_LOC_MAP)
 def test_add_legend_loc(loc):
     pl = pyvista.Plotter()
-    pl.add_mesh(pyvista.PolyData([0, 0, 0]), label='foo')
+    pl.add_mesh(pyvista.PolyData([0.0, 0.0, 0.0]), label='foo')
     legend = pl.add_legend(loc=loc)
 
     # note: this is only valid with the defaults:
@@ -109,7 +109,7 @@ def test_add_remove_legend(sphere):
 
 
 @pytest.mark.parametrize(
-    'face', ['-', '^', 'o', 'r', None, pyvista.PolyData([0, 0, 0])]
+    'face', ['-', '^', 'o', 'r', None, pyvista.PolyData([0.0, 0.0, 0.0])]
 )
 def test_legend_face(sphere, face):
     pl = pyvista.Plotter()


### PR DESCRIPTION
Resolve #1943 by casting and warning when non-float points are input into UnstructuredGrid and PolyData.  I've personally encountered this issue in the past (on transformations) and think this is reasonable to enforce.

Here's a good example of the phenomenon:
```py
import pyvista
import vtk
import numpy as np
xrng = np.arange(-10, 10, 2)
yrng = np.arange(-10, 10, 2)
zrng = np.arange(-10, 10, 2)
x, y, z = np.meshgrid(xrng, yrng, zrng)
grid = pyvista.StructuredGrid(x, y, z, force_float=False)

grid.rotate_x(30, inplace=True)
grid.plot(show_edges=True)
```

![tmp](https://user-images.githubusercontent.com/11981631/147426044-1cd74a42-b3e7-4061-8ed0-2722534dd3fe.png)

And now with `force_float=True` (default)
![tmp](https://user-images.githubusercontent.com/11981631/147426079-88d93035-53a6-41af-a904-4449fdc00a66.png)
