### PR TITLE
Convert integer point and data arrays to float32 in transform()

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -870,6 +870,11 @@ class DataSet(DataSetFilters, DataObject):
     ):
         """Rotate mesh about the x-axis.
 
+        .. note::
+            See also the notes at :func:`transform()
+            <DataSetFilters.transform>` which is used by this filter
+            under the hood.
+
         Parameters
         ----------
         angle : float
@@ -921,6 +926,11 @@ class DataSet(DataSetFilters, DataObject):
     ):
         """Rotate mesh about the y-axis.
 
+        .. note::
+            See also the notes at :func:`transform()
+            <DataSetFilters.transform>` which is used by this filter
+            under the hood.
+
         Parameters
         ----------
         angle : float
@@ -971,6 +981,11 @@ class DataSet(DataSetFilters, DataObject):
             inplace=False
     ):
         """Rotate mesh about the z-axis.
+
+        .. note::
+            See also the notes at :func:`transform()
+            <DataSetFilters.transform>` which is used by this filter
+            under the hood.
 
         Parameters
         ----------
@@ -1024,6 +1039,11 @@ class DataSet(DataSetFilters, DataObject):
     ):
         """Rotate mesh about a vector.
 
+        .. note::
+            See also the notes at :func:`transform()
+            <DataSetFilters.transform>` which is used by this filter
+            under the hood.
+
         Parameters
         ----------
         vector : Iterable
@@ -1073,6 +1093,11 @@ class DataSet(DataSetFilters, DataObject):
     def translate(self, xyz: Union[list, tuple, np.ndarray], transform_all_input_vectors=False, inplace=False):
         """Translate the mesh.
 
+        .. note::
+            See also the notes at :func:`transform()
+            <DataSetFilters.transform>` which is used by this filter
+            under the hood.
+
         Parameters
         ----------
         xyz : list or tuple or np.ndarray
@@ -1110,6 +1135,11 @@ class DataSet(DataSetFilters, DataObject):
 
     def scale(self, xyz: Union[list, tuple, np.ndarray], transform_all_input_vectors=False, inplace=False):
         """Scale the mesh.
+
+        .. note::
+            See also the notes at :func:`transform()
+            <DataSetFilters.transform>` which is used by this filter
+            under the hood.
 
         Parameters
         ----------
@@ -1152,6 +1182,11 @@ class DataSet(DataSetFilters, DataObject):
 
     def flip_x(self, point=None, transform_all_input_vectors=False, inplace=False):
         """Flip mesh about the x-axis.
+
+        .. note::
+            See also the notes at :func:`transform()
+            <DataSetFilters.transform>` which is used by this filter
+            under the hood.
 
         Parameters
         ----------
@@ -1196,6 +1231,11 @@ class DataSet(DataSetFilters, DataObject):
     def flip_y(self, point=None, transform_all_input_vectors=False, inplace=False):
         """Flip mesh about the y-axis.
 
+        .. note::
+            See also the notes at :func:`transform()
+            <DataSetFilters.transform>` which is used by this filter
+            under the hood.
+
         Parameters
         ----------
         point : list, optional
@@ -1239,6 +1279,11 @@ class DataSet(DataSetFilters, DataObject):
     def flip_z(self, point=None, transform_all_input_vectors=False, inplace=False):
         """Flip mesh about the z-axis.
 
+        .. note::
+            See also the notes at :func:`transform()
+            <DataSetFilters.transform>` which is used by this filter
+            under the hood.
+
         Parameters
         ----------
         point : list, optional
@@ -1281,6 +1326,11 @@ class DataSet(DataSetFilters, DataObject):
 
     def flip_normal(self, normal: List[float], point=None, transform_all_input_vectors=False, inplace=False):
         """Flip mesh about the normal.
+
+        .. note::
+            See also the notes at :func:`transform()
+            <DataSetFilters.transform>` which is used by this filter
+            under the hood.
 
         Parameters
         ----------

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1,6 +1,7 @@
 """Filters module with a class of common filters that can be applied to any vtkDataSet."""
 import collections.abc
 from typing import Union
+import warnings
 
 import numpy as np
 
@@ -4405,9 +4406,7 @@ class DataSetFilters:
             t = trans
             m = trans.GetMatrix()
         elif isinstance(trans, np.ndarray):
-            if trans.ndim != 2:
-                raise ValueError('Transformation array must be 4x4')
-            elif trans.shape[0] != 4 or trans.shape[1] != 4:
+            if trans.shape != (4, 4):
                 raise ValueError('Transformation array must be 4x4')
             m = pyvista.vtkmatrix_from_array(trans)
             t = _vtk.vtkTransform()
@@ -4421,6 +4420,51 @@ class DataSetFilters:
         if m.GetElement(3, 3) == 0:
             raise ValueError(
                 "Transform element (3,3), the inverse scale term, is zero")
+
+        # vtkTransformFilter truncates the result if the input is an integer type
+        # so convert input points and relevant vectors to float
+        # (creating a new copy would be harmful much more often)
+        converted_ints = False
+        if not np.issubdtype(self.points.dtype, np.floating):
+            self.points = self.points.astype(np.float32)
+            converted_ints = True
+        if transform_all_input_vectors:
+            # all vector-shaped data will be transformed
+            point_vectors = [
+                name for name, data in self.point_data.items()
+                if data.shape == (self.n_points, 3)
+            ]
+            cell_vectors = [
+                name for name, data in self.cell_data.items()
+                if data.shape == (self.n_points, 3)
+            ]
+        else:
+            # we'll only transform active vectors and normals
+            point_vectors = [
+                self.point_data.active_vectors_name,
+                self.point_data.active_normals_name,
+            ]
+            cell_vectors = [
+                self.cell_data.active_vectors_name,
+                self.cell_data.active_normals_name,
+            ]
+        # dynamically convert each self.point_data[name] etc. to float32
+        all_vectors = [point_vectors, cell_vectors]
+        all_dataset_attrs = [self.point_data, self.cell_data]
+        for vector_names, dataset_attrs in zip(all_vectors, all_dataset_attrs):
+            for vector_name in vector_names:
+                if vector_name is None:
+                    continue
+                vector_arr = dataset_attrs[vector_name]
+                if not np.issubdtype(vector_arr.dtype, np.floating):
+                    dataset_attrs[vector_name] = vector_arr.astype(np.float32)
+                    converted_ints = True
+        if converted_ints:
+            warnings.warn(
+                'Integer points, vector and normal data (if any) of the input mesh '
+                'have been converted to ``np.float32``. This is necessary in order '
+                'to transform properly.'
+            )
 
         # vtkTransformFilter doesn't respect active scalars.  We need to track this
         active_point_scalars_name = self.point_data.active_scalars_name

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -4351,6 +4351,15 @@ class DataSetFilters:
             is to store the three components as separate scalar
             arrays.
 
+        .. warning::
+            In general, transformations give non-integer results. This
+            method converts integer-typed vector data to float before
+            performing the transformation. This applies to the points
+            array, as well as any vector-valued data that is affected
+            by the transformation. To prevent subtle bugs arising from
+            in-place transformations truncating the result to integers,
+            this conversion always applies to the input mesh.
+
         Parameters
         ----------
         trans : vtk.vtkMatrix4x4, vtk.vtkTransform, or np.ndarray

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -4480,7 +4480,7 @@ class DataSetFilters:
 
         if hasattr(f, 'SetTransformAllInputVectors'):
             f.SetTransformAllInputVectors(transform_all_input_vectors)
-        else:
+        else:  # pragma: no cover
             # In VTK 8.1.2 and earlier, vtkTransformFilter does not
             # support the transformation of all input vectors.
             # Raise an error if the user requested for input vectors

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -35,7 +35,7 @@ NORMALS = {
 
 
 def translate(surf, center=[0., 0., 0.], direction=[1., 0., 0.]):
-    """Translate and orientate a mesh to a new center and direction.
+    """Translate and orient a mesh to a new center and direction.
 
     By default, the input mesh is considered centered at the origin
     and facing in the x direction.

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -223,7 +223,7 @@ def test_translate_should_fail_given_none(grid):
         grid.transform(None)
 
 
-def test_translate_deprication(grid):
+def test_translate_deprecation(grid):
     with pytest.warns(PyvistaDeprecationWarning):
         grid.translate((0.0, 0.0, 0.0))
 
@@ -1140,7 +1140,7 @@ def test_rotate_z():
 
 
 @pytest.mark.parametrize('method', ['rotate_x', 'rotate_y', 'rotate_z'])
-def test_deprication_rotate(sphere, method):
+def test_deprecation_rotate(sphere, method):
     meth = getattr(sphere, method)
     with pytest.warns(PyvistaDeprecationWarning):
         meth(30)
@@ -1203,7 +1203,7 @@ def test_transform_integers_vtkbug_present():
     assert poly.points[-1, 1] != 0
 
 
-def test_deprication_vector(sphere):
+def test_deprecation_vector(sphere):
     with pytest.warns(PyvistaDeprecationWarning):
         sphere.rotate_vector([1, 1, 1], 33)
 


### PR DESCRIPTION
This together with https://github.com/pyvista/pyvista/pull/1964 fully resolves https://github.com/pyvista/pyvista/issues/1943.

I haven't checked the VTK implementation, but the issue seems to be the same as here:
```py
>>> import numpy as np
>>> arr = np.arange(5)
>>> arr[...] = arr + 0.5
>>> arr
array([0, 1, 2, 3, 4])
```
When assigning back to an array of a given dtype, the right hand side gets converted which leads to subtle truncation of floating values to ints. Trying to use augmented assignment helpfully crashes:
```py
>>> arr += 0.5
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
numpy.core._exceptions.UFuncTypeError: Cannot cast ufunc 'add' output from dtype('float64') to dtype('int64') with casting rule 'same_kind'
```

https://github.com/pyvista/pyvista/pull/1964 prevents the problem by ensuring that `PolyData` always have float points. I'm of the opinion that `transform()` itself makes no sense in the general case unless the data being transformed has float dtype.

For this reason I've opted to automatically convert all relevant arrays to floats in `transform()`, and emit a warning that this has happened. "Relevant array" means
1. points always
2. active vectors and normals always
3. all vector-valued data if `transform_all_input_vectors=True` is passed.

Alternatives I could think of:
1.  Raise an error when trying to transform integral data. Pro: loud and clear. Con: forces the user to do more work, when they can't reasonably expect transformation to always work with ints.
2. Create a copy of the input mesh and only convert that. Pro: the input to `transform()` will be unchanged. Con: in-place transforms are going to silently overwrite the integer input with this new copy anyway. And doing a copy can lead to needless memory bloat. I guessed that it's more harmful to copy than to convert in a sane way.
3. Do what I'm doing now but add a bool flag that lets the user choose between conversion and copy. Pro: gives the choice to the user. Con: inflates the API across a chain of transform methods, for something that I don't think is worth it.
4. Add a flag that allows the user to skip the conversion. Pro: old behaviour can be recovered. Con: old behaviour makes no sense.

The PR is not entirely complete because the regression test needs to test the conversion of vector data as well, but I want to open this PR for discussion while I find time to do that. We might have to do something similar in https://github.com/pyvista/pyvista/pull/1964 as well, but I'll raise that in a comment there.

I've also added an XFAIL test that checks that the VTK bug is still there. It's a soft XFAIL, so if it starts XPASSing it won't break CI (the warning I raise in `transform()` might have to be handled though).