### PR TITLE
enforce consistent API

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -3,7 +3,7 @@
 import collections.abc
 import logging
 import sys
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 import warnings
 
 if sys.version_info >= (3, 8):
@@ -1634,10 +1634,10 @@ class DataSet(DataSetFilters, DataObject):
         return self.GetNumberOfCells()
 
     @property
-    def bounds(self) -> List[float]:
+    def bounds(self) -> Tuple[float, float, float, float, float, float]:
         """Return the bounding box of this dataset.
 
-        The form is: ``[xmin, xmax, ymin, ymax, zmin, zmax]``.
+        The form is: ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
 
         Examples
         --------
@@ -1646,10 +1646,10 @@ class DataSet(DataSetFilters, DataObject):
         >>> import pyvista
         >>> cube = pyvista.Cube()
         >>> cube.bounds
-        [-0.5, 0.5, -0.5, 0.5, -0.5, 0.5]
+        (-0.5, 0.5, -0.5, 0.5, -0.5, 0.5)
 
         """
-        return list(self.GetBounds())
+        return self.GetBounds()
 
     @property
     def length(self) -> float:
@@ -1686,16 +1686,16 @@ class DataSet(DataSetFilters, DataObject):
         return list(self.GetCenter())
 
     @property
-    def extent(self) -> Optional[list]:
+    def extent(self) -> Optional[tuple]:
         """Return the range of the bounding box."""
         try:
-            _extent = list(self.GetExtent())
+            _extent = self.GetExtent()
         except AttributeError:
             return None
         return _extent
 
     @extent.setter
-    def extent(self, extent: List[float]):
+    def extent(self, extent: Sequence[float]):
         """Set the range of the bounding box."""
         if hasattr(self, 'SetExtent'):
             if len(extent) != 6:
@@ -2294,7 +2294,7 @@ class DataSet(DataSetFilters, DataObject):
         points = _vtk.vtk_to_numpy(points)
         return points.copy()
 
-    def cell_bounds(self, ind: int) -> List[float]:
+    def cell_bounds(self, ind: int) -> Tuple[float, float, float, float, float, float]:
         """Return the bounding box of a cell.
 
         Parameters
@@ -2304,7 +2304,7 @@ class DataSet(DataSetFilters, DataObject):
 
         Returns
         -------
-        list(float)
+        tuple(float)
             The limits of the cell in the X, Y and Z directions respectivelly.
 
         Examples
@@ -2312,10 +2312,10 @@ class DataSet(DataSetFilters, DataObject):
         >>> from pyvista import examples
         >>> mesh = examples.load_airplane()
         >>> mesh.cell_bounds(0)
-        [896.9940185546875, 907.5390014648438, 48.760101318359375, 55.49020004272461, 80.74520111083984, 83.65809631347656]
+        (896.9940185546875, 907.5390014648438, 48.760101318359375, 55.49020004272461, 80.74520111083984, 83.65809631347656)
 
         """
-        return list(self.GetCell(ind).GetBounds())
+        return self.GetCell(ind).GetBounds()
 
     def cell_type(self, ind: int) -> int:
         """Return the type of a cell.

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -1,18 +1,17 @@
 """Sub-classes for vtk.vtkRectilinearGrid and vtk.vtkImageData."""
-from collections import Sequence
 import logging
 import pathlib
+from typing import Sequence, Tuple, Union
 import warnings
 
 import numpy as np
 
 import pyvista
 from pyvista import _vtk
+from pyvista.core.dataset import DataSet
+from pyvista.core.filters import UniformGridFilters, _get_output
 from pyvista.utilities import abstract_class
 from pyvista.utilities.misc import PyvistaDeprecationWarning
-
-from .dataset import DataSet
-from .filters import UniformGridFilters, _get_output
 
 log = logging.getLogger(__name__)
 log.setLevel('CRITICAL')
@@ -27,19 +26,34 @@ class Grid(DataSet):
         super().__init__()
 
     @property
-    def dimensions(self):
-        """Return a length 3 tuple of the grid's dimensions.
+    def dimensions(self) -> Tuple[int, int, int]:
+        """Return the grid's dimensions.
 
-        These are effectively the number of nodes along each of the three dataset axes.
+        These are effectively the number of points along each of the
+        three dataset axes.
+
+        Examples
+        --------
+        Create a uniform grid with dimensions ``(1, 2, 3)``.
+
+        >>> import pyvista
+        >>> grid = pyvista.UniformGrid(dims=(2, 3, 4))
+        >>> grid.dimensions
+        (2, 3, 4)
+        >>> grid.plot(show_edges=True)
+
+        Set the dimensions to ``(3, 4, 5)``
+
+        >>> grid.dimensions = (3, 4, 5)
+        >>> grid.plot(show_edges=True)
 
         """
-        return list(self.GetDimensions())
+        return self.GetDimensions()
 
     @dimensions.setter
-    def dimensions(self, dims):
-        """Set the dataset dimensions. Pass a length three tuple of integers."""
-        nx, ny, nz = dims[0], dims[1], dims[2]
-        self.SetDimensions(nx, ny, nz)
+    def dimensions(self, dims: Sequence[int]):
+        """Set the dataset dimensions."""
+        self.SetDimensions(*dims)
         self.Modified()
 
     def _get_attrs(self):
@@ -129,7 +143,7 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
         """Update the dimensions if coordinates have changed."""
         return self.SetDimensions(len(self.x), len(self.y), len(self.z))
 
-    def _from_arrays(self, x, y, z):
+    def _from_arrays(self, x: np.ndarray, y: np.ndarray, z: np.ndarray):
         """Create VTK rectilinear grid directly from numpy arrays.
 
         Each array gives the uniques coordinates of the mesh along each axial
@@ -139,13 +153,13 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
         Parameters
         ----------
         x : np.ndarray
-            Coordinates of the nodes in x direction.
+            Coordinates of the points in x direction.
 
         y : np.ndarray
-            Coordinates of the nodes in y direction.
+            Coordinates of the points in y direction.
 
         z : np.ndarray
-            Coordinates of the nodes in z direction.
+            Coordinates of the points in z direction.
 
         """
         # Set the coordinates along each axial direction
@@ -162,31 +176,54 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
         self._update_dimensions()
 
     @property
-    def meshgrid(self):
+    def meshgrid(self) -> list:
         """Return a meshgrid of numpy arrays for this mesh.
 
-        This simply returns a ``numpy.meshgrid`` of the coordinates for this
-        mesh in ``ij`` indexing. These are a copy of the points of this mesh.
+        This simply returns a :func:`numpy.meshgrid` of the
+        coordinates for this mesh in ``ij`` indexing. These are a copy
+        of the points of this mesh.
 
         """
         return np.meshgrid(self.x, self.y, self.z, indexing='ij')
 
-    @property
-    def points(self):
-        """Return a copy of the points as an n by 3 numpy array."""
+    @property  # type: ignore
+    def points(self) -> np.ndarray:  # type: ignore
+        """Return a copy of the points as an n by 3 numpy array.
+
+        Notes
+        -----
+        Points of a :class:`pyvista.RectilinearGrid` cannot be
+        set. Set point coordinates with :attr:`RectilinearGrid.x`,
+        :attr:`RectilinearGrid.y`, or :attr:`RectilinearGrid.z`.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> import pyvista
+        >>> xrng = np.arange(-10, 10, 10, dtype=float)
+        >>> yrng = np.arange(-10, 10, 10, dtype=float)
+        >>> zrng = np.arange(-10, 10, 10, dtype=float)
+        >>> grid = pyvista.RectilinearGrid(xrng, yrng, zrng)
+        >>> grid.points
+        array([[-10., -10., -10.],
+               [  0., -10., -10.],
+               [-10.,   0., -10.],
+               [  0.,   0., -10.],
+               [-10., -10.,   0.],
+               [  0., -10.,   0.],
+               [-10.,   0.,   0.],
+               [  0.,   0.,   0.]])
+
+        """
         xx, yy, zz = self.meshgrid
         return np.c_[xx.ravel(order='F'), yy.ravel(order='F'), zz.ravel(order='F')]
 
     @points.setter
     def points(self, points):
-        """Points must be set along each axial direction.
+        """Raise an AttributeError.
 
-        Please set the point coordinates with the ``x``, ``y``, and ``z``
-        setters.
-
-        This setter overrides the base class's setter to ensure a user does not
-        attempt to set them.
-
+        This setter overrides the base class's setter to ensure a user
+        does not attempt to set them.
         """
         raise AttributeError("The points cannot be set. The points of "
             "`RectilinearGrid` are defined in each axial direction. Please "
@@ -194,36 +231,99 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
             )
 
     @property
-    def x(self):
-        """Get the coordinates along the X-direction."""
+    def x(self) -> np.ndarray:
+        """Return or set the coordinates along the X-direction.
+
+        Examples
+        --------
+        Return the x coordinates of a RectilinearGrid.
+
+        >>> import numpy as np
+        >>> import pyvista
+        >>> xrng = np.arange(-10, 10, 10, dtype=float)
+        >>> yrng = np.arange(-10, 10, 10, dtype=float)
+        >>> zrng = np.arange(-10, 10, 10, dtype=float)
+        >>> grid = pyvista.RectilinearGrid(xrng, yrng, zrng)
+        >>> grid.x
+        array([-10.,   0.])
+
+        Set the x coordinates of a RectilinearGrid.
+
+        >>> grid.x = [-10.0, 0.0, 10.0]
+        >>> grid.x
+        array([-10.,   0.,  10.])
+
+        """
         return _vtk.vtk_to_numpy(self.GetXCoordinates())
 
     @x.setter
-    def x(self, coords):
+    def x(self, coords: Sequence):
         """Set the coordinates along the X-direction."""
         self.SetXCoordinates(_vtk.numpy_to_vtk(coords))
         self._update_dimensions()
         self.Modified()
 
     @property
-    def y(self):
-        """Get the coordinates along the Y-direction."""
+    def y(self) -> np.ndarray:
+        """Return or set the coordinates along the X-direction.
+
+        Examples
+        --------
+        Return the y coordinates of a RectilinearGrid.
+
+        >>> import numpy as np
+        >>> import pyvista
+        >>> xrng = np.arange(-10, 10, 10, dtype=float)
+        >>> yrng = np.arange(-10, 10, 10, dtype=float)
+        >>> zrng = np.arange(-10, 10, 10, dtype=float)
+        >>> grid = pyvista.RectilinearGrid(xrng, yrng, zrng)
+        >>> grid.y
+        array([-10.,   0.])
+
+        Set the y coordinates of a RectilinearGrid.
+
+        >>> grid.y = [-10.0, 0.0, 10.0]
+        >>> grid.y
+        array([-10.,   0.,  10.])
+
+        """
         return _vtk.vtk_to_numpy(self.GetYCoordinates())
 
     @y.setter
-    def y(self, coords):
+    def y(self, coords: Sequence):
         """Set the coordinates along the Y-direction."""
         self.SetYCoordinates(_vtk.numpy_to_vtk(coords))
         self._update_dimensions()
         self.Modified()
 
     @property
-    def z(self):
-        """Get the coordinates along the Z-direction."""
+    def z(self) -> np.ndarray:
+        """Return or set the coordinates along the Z-direction.
+
+        Examples
+        --------
+        Return the z coordinates of a RectilinearGrid.
+
+        >>> import numpy as np
+        >>> import pyvista
+        >>> xrng = np.arange(-10, 10, 10, dtype=float)
+        >>> yrng = np.arange(-10, 10, 10, dtype=float)
+        >>> zrng = np.arange(-10, 10, 10, dtype=float)
+        >>> grid = pyvista.RectilinearGrid(xrng, yrng, zrng)
+        >>> grid.z
+        array([-10.,   0.])
+
+        Set the z coordinates of a RectilinearGrid.
+
+        >>> grid.z = [-10.0, 0.0, 10.0]
+        >>> grid.z
+        array([-10.,   0.,  10.])
+
+        """
         return _vtk.vtk_to_numpy(self.GetZCoordinates())
 
     @z.setter
-    def z(self, coords):
+    def z(self, coords: Sequence):
         """Set the coordinates along the Z-direction."""
         self.SetZCoordinates(_vtk.numpy_to_vtk(coords))
         self._update_dimensions()
@@ -235,7 +335,7 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
         raise AttributeError("The dimensions of a `RectilinearGrid` are implicitly "
                              "defined and thus cannot be set.")
 
-    def cast_to_structured_grid(self):
+    def cast_to_structured_grid(self) -> 'pyvista.StructuredGrid':
         """Cast this rectilinear grid to a structured grid.
 
         Returns
@@ -275,7 +375,7 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
 
     spacing : iterable, optional
         Spacing of the uniform in each dimension.  Defaults to
-        ``(1.0, 1.0, 1.0)``.
+        ``(1.0, 1.0, 1.0)``. Must be positive.
 
     origin : iterable, optional
         Origin of the uniform grid.  Defaults to ``(0.0, 0.0, 0.0)``.
@@ -397,35 +497,60 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         """Return the default str representation."""
         return DataSet.__str__(self)
 
-    def _from_specs(self, dims, spacing=(1.0, 1.0, 1.0), origin=(0.0, 0.0, 0.0)):
+    def _from_specs(
+            self,
+            dims: Sequence[int],
+            spacing=(1.0, 1.0, 1.0),
+            origin=(0.0, 0.0, 0.0)
+    ):
         """Create VTK image data directly from numpy arrays.
 
-        A uniform grid is defined by the node spacings for each axis
-        (uniform along each individual axis) and the number of nodes on each axis.
+        A uniform grid is defined by the point spacings for each axis
+        (uniform along each individual axis) and the number of points on each axis.
         These are relative to a specified origin (default is ``(0.0, 0.0, 0.0)``).
 
         Parameters
         ----------
         dims : tuple(int)
-            Length 3 tuple of ints specifying how many nodes along each axis.
+            Length 3 tuple of ints specifying how many points along each axis.
 
         spacing : tuple(float)
-            Length 3 tuple of floats/ints specifying the node spacings for each axis.
+            Length 3 tuple of floats/ints specifying the point spacings
+            for each axis. Must be positive.
 
         origin : tuple(float)
             Length 3 tuple of floats/ints specifying minimum value for each axis.
 
         """
         xn, yn, zn = dims[0], dims[1], dims[2]
-        xs, ys, zs = spacing[0], spacing[1], spacing[2]
         xo, yo, zo = origin[0], origin[1], origin[2]
         self.SetDimensions(xn, yn, zn)
         self.SetOrigin(xo, yo, zo)
-        self.SetSpacing(xs, ys, zs)
+        self.spacing = (spacing[0], spacing[1], spacing[2])
 
-    @property
-    def points(self):
-        """Build a copy of the implicitly defined points as a numpy array."""
+    @property  # type: ignore
+    def points(self) -> np.ndarray:  # type: ignore
+        """Build a copy of the implicitly defined points as a numpy array.
+
+        Notes
+        -----
+        The ``points`` for a :class:`pyvista.UniformGrid` cannot be set.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> grid = pyvista.UniformGrid(dims=(2, 2, 2))
+        >>> grid.points
+        array([[0., 0., 0.],
+               [1., 0., 0.],
+               [0., 1., 0.],
+               [1., 1., 0.],
+               [0., 0., 1.],
+               [1., 0., 1.],
+               [0., 1., 1.],
+               [1., 1., 1.]])
+
+        """
         # Get grid dimensions
         nx, ny, nz = self.dimensions
         nx -= 1
@@ -434,7 +559,7 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         # get the points and convert to spacings
         dx, dy, dz = self.spacing
         # Now make the cell arrays
-        ox, oy, oz = np.array(self.origin) + np.array(self.extent[::2])
+        ox, oy, oz = np.array(self.origin) + np.array(self.extent[::2])  # type: ignore
         x = np.insert(np.cumsum(np.full(nx, dx)), 0, 0.0) + ox
         y = np.insert(np.cumsum(np.full(ny, dy)), 0, 0.0) + oy
         z = np.insert(np.cumsum(np.full(nz, dz)), 0, 0.0) + oz
@@ -455,46 +580,120 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
             )
 
     @property
-    def x(self):
-        """Return all the X points."""
+    def x(self) -> np.ndarray:
+        """Return all the X points.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> grid = pyvista.UniformGrid(dims=(2, 2, 2))
+        >>> grid.y
+        array([0., 1., 0., 1., 0., 1., 0., 1.])
+
+        """
         return self.points[:, 0]
 
     @property
-    def y(self):
-        """Return all the Y points."""
+    def y(self) -> np.ndarray:
+        """Return all the Y points.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> grid = pyvista.UniformGrid(dims=(2, 2, 2))
+        >>> grid.y
+        array([0., 0., 1., 1., 0., 0., 1., 1.])
+
+        """
         return self.points[:, 1]
 
     @property
-    def z(self):
-        """Return all the Z points."""
+    def z(self) -> np.ndarray:
+        """Return all the Z points.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> grid = pyvista.UniformGrid(dims=(2, 2, 2))
+        >>> grid.z
+        array([0., 0., 0., 0., 1., 1., 1., 1.])
+
+        """
         return self.points[:, 2]
 
     @property
-    def origin(self):
-        """Return the origin of the grid (bottom southwest corner)."""
-        return list(self.GetOrigin())
+    def origin(self) -> Tuple[float]:
+        """Return the origin of the grid (bottom southwest corner).
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> grid = pyvista.UniformGrid(dims=(5, 5, 5))
+        >>> grid.origin
+        (0.0, 0.0, 0.0)
+
+        Show how the origin is in the bottom "southwest" corner of the
+        UniformGrid.
+
+        >>> pl = pyvista.Plotter()
+        >>> _ = pl.add_mesh(grid, show_edges=True)
+        >>> _ = pl.add_axes_at_origin(ylabel=None)
+        >>> pl.camera_position = 'xz'
+        >>> pl.show()
+
+        Set the origin to ``(1, 1, 1)`` and show how this shifts the
+        UniformGrid.
+
+        >>> grid.origin = (1, 1, 1)
+        >>> pl = pyvista.Plotter()
+        >>> _ = pl.add_mesh(grid, show_edges=True)
+        >>> _ = pl.add_axes_at_origin(ylabel=None)
+        >>> pl.camera_position = 'xz'
+        >>> pl.show()
+
+        """
+        return self.GetOrigin()
 
     @origin.setter
-    def origin(self, origin):
-        """Set the origin. Pass a length three tuple of floats."""
-        ox, oy, oz = origin[0], origin[1], origin[2]
-        self.SetOrigin(ox, oy, oz)
+    def origin(self, origin: Sequence[Union[float, int]]):
+        """Set the origin."""
+        self.SetOrigin(origin[0], origin[1], origin[2])
         self.Modified()
 
     @property
-    def spacing(self):
-        """Get the spacing for each axial direction."""
-        return list(self.GetSpacing())
+    def spacing(self) -> Tuple[float, float, float]:
+        """Return or set the spacing for each axial direction.
 
-    @spacing.setter
-    def spacing(self, spacing):
-        """Set the spacing in each axial direction.
+        Notes
+        -----
+        Spacing must be non-negative. While VTK accepts negative
+        spacing, this results in unexpected behavior. See:
+        https://github.com/pyvista/pyvista/issues/1967
 
-        Pass a length three tuple of floats.
+        Examples
+        --------
+        Create a 5 x 5 x 5 uniform grid.
+
+        >>> import pyvista
+        >>> grid = pyvista.UniformGrid(dims=(5, 5, 5))
+        >>> grid.spacing
+        (1.0, 1.0, 1.0)
+        >>> grid.plot(show_edges=True)
+
+        Modify the spacing to ``(1, 2, 3)``
+
+        >>> grid.spacing = (1, 2, 3)
+        >>> grid.plot(show_edges=True)
 
         """
-        dx, dy, dz = spacing[0], spacing[1], spacing[2]
-        self.SetSpacing(dx, dy, dz)
+        return self.GetSpacing()
+
+    @spacing.setter
+    def spacing(self, spacing: Sequence[Union[float, int]]):
+        """Set spacing."""
+        if min(spacing) < 0:
+            raise ValueError(f"Spacing must be non-negative, got {spacing}")
+        self.SetSpacing(*spacing)
         self.Modified()
 
     def _get_attrs(self):
@@ -504,7 +703,7 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         attrs.append(("Spacing", self.spacing, fmt))
         return attrs
 
-    def cast_to_structured_grid(self):
+    def cast_to_structured_grid(self) -> 'pyvista.StructuredGrid':
         """Cast this uniform grid to a structured grid.
 
         Returns
@@ -518,7 +717,7 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         alg.Update()
         return _get_output(alg)
 
-    def cast_to_rectilinear_grid(self):
+    def cast_to_rectilinear_grid(self) -> 'RectilinearGrid':
         """Cast this uniform grid to a rectilinear grid.
 
         Returns

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -6,7 +6,7 @@ import numbers
 import os
 import pathlib
 from textwrap import dedent
-from typing import Union
+from typing import Sequence, Tuple, Union
 import warnings
 
 import numpy as np
@@ -205,7 +205,12 @@ class PointSet(DataSet):
             return self
         return super().translate(xyz, transform_all_input_vectors=transform_all_input_vectors, inplace=inplace)
 
-    def scale(self, xyz: Union[list, tuple, np.ndarray], transform_all_input_vectors=False, inplace=None):
+    def scale(
+            self,
+            xyz: Union[list, tuple, np.ndarray],
+            transform_all_input_vectors=False,
+            inplace=None
+    ):
         """Scale the mesh.
 
         Parameters
@@ -525,7 +530,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         return cells
 
     @property
-    def verts(self):
+    def verts(self) -> np.ndarray:
         """Get the vertex cells.
 
         Returns
@@ -564,7 +569,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
             self.SetVerts(CellArray(verts))
 
     @property
-    def lines(self):
+    def lines(self) -> np.ndarray:
         """Return a pointer to the lines as a numpy array.
 
         Examples
@@ -590,7 +595,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
             self.SetLines(CellArray(lines))
 
     @property
-    def faces(self):
+    def faces(self) -> np.ndarray:
         """Return a pointer to the faces as a numpy array.
 
         Returns
@@ -738,7 +743,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
             raise VTKVersionError('Connectivity array implemented in VTK 9 or newer.')
 
     @property
-    def n_lines(self):
+    def n_lines(self) -> int:
         """Return the number of lines.
 
         Examples
@@ -752,7 +757,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         return self.GetNumberOfLines()
 
     @property
-    def n_verts(self):
+    def n_verts(self) -> int:
         """Return the number of vertices.
 
         Examples
@@ -769,7 +774,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         return self.GetNumberOfVerts()
 
     @property
-    def n_faces(self):
+    def n_faces(self) -> int:
         """Return the number of cells.
 
         Alias for ``n_cells``.
@@ -888,7 +893,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         super().save(filename, binary, texture=texture)
 
     @property
-    def area(self):
+    def area(self) -> float:
         """Return the mesh surface area.
 
         Returns
@@ -908,8 +913,8 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         return np.sum(areas)
 
     @property
-    def volume(self):
-        """Return the mesh volume.
+    def volume(self) -> float:
+        """Return the volume of the dataset.
 
         This will throw a VTK error/warning if not a closed surface.
 
@@ -931,12 +936,12 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         return mprop.GetVolume()
 
     @property
-    def point_normals(self):
+    def point_normals(self) -> 'pyvista.pyvista_ndarray':
         """Return the point normals.
 
         Returns
         -------
-        numpy.ndarray
+        pyvista.pyvista_ndarray
             Array of point normals.
 
         Examples
@@ -958,12 +963,12 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         return mesh.point_data['Normals']
 
     @property
-    def cell_normals(self):
+    def cell_normals(self) -> 'pyvista.pyvista_ndarray':
         """Return the cell normals.
 
         Returns
         -------
-        numpy.ndarray
+        pyvista.pyvista_ndarray
             Array of cell normals.
 
         Examples
@@ -984,14 +989,14 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         return mesh.cell_data['Normals']
 
     @property
-    def face_normals(self):
+    def face_normals(self) -> 'pyvista.pyvista_ndarray':
         """Return the cell normals.
 
         Alias to :func:`PolyData.cell_normals`.
 
         Returns
         -------
-        numpy.ndarray
+        pyvista.pyvista_ndarray
             Array of face normals.
 
         Examples
@@ -1028,7 +1033,7 @@ class PolyData(_vtk.vtkPolyData, PointSet, PolyDataFilters):
         return self._obbTree
 
     @property
-    def n_open_edges(self):
+    def n_open_edges(self) -> int:
         """Return the number of open edges on this mesh.
 
         Examples
@@ -1115,7 +1120,7 @@ class PointGrid(PointSet):
         return trisurf.plot_curvature(curv_type, **kwargs)
 
     @property
-    def volume(self):
+    def volume(self) -> float:
         """Compute the volume of the point grid.
 
         This extracts the external surface and computes the interior
@@ -1345,7 +1350,7 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
                                  f'must match the number of cells ({self.n_cells})')
 
     @property
-    def cells(self):
+    def cells(self) -> np.ndarray:
         """Return a pointer to the cells as a numpy object.
 
         Examples
@@ -1365,7 +1370,7 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
         return _vtk.vtk_to_numpy(self.GetCells().GetData())
 
     @property
-    def cells_dict(self):
+    def cells_dict(self) -> dict:
         """Return a dictionary that contains all cells mapped from cell types.
 
         This function returns a :class:`numpy.ndarray` for each cell
@@ -1404,7 +1409,7 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
         return get_mixed_cells(self)
 
     @property
-    def cell_connectivity(self):
+    def cell_connectivity(self) -> np.ndarray:
         """Return a the vtk cell connectivity as a numpy array.
 
         This is effecively :attr:`UnstructuredGrid.cells` without the
@@ -1514,7 +1519,7 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
         return lgrid
 
     @property
-    def celltypes(self):
+    def celltypes(self) -> np.ndarray:
         """Return the cell types array.
 
         Returns
@@ -1577,7 +1582,7 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
         return _vtk.vtk_to_numpy(self.GetCellTypesArray())
 
     @property
-    def offset(self):
+    def offset(self) -> np.ndarray:
         """Return the cell locations array.
 
         In VTK 9, this is the location of the start of each cell in
@@ -2050,21 +2055,21 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         """Return the standard ``str`` representation."""
         return DataSet.__str__(self)
 
-    def _from_arrays(self, dims, corners):
+    def _from_arrays(self, dims: Sequence, corners: Sequence) -> None:
         """Create a VTK explicit structured grid from NumPy arrays.
 
         Parameters
         ----------
-        dims : numpy.ndarray
-            An array of integers with shape (3,) containing the
+        dims : Sequence
+            A sequence of integers with shape (3,) containing the
             topological dimensions of the grid.
 
-        corners : numpy.ndarray
-            An array of floats with shape (number of corners, 3)
+        corners : Sequence
+            A sequence of floats with shape (number of corners, 3)
             containing the coordinates of the corner points.
 
         """
-        shape0 = dims-1
+        shape0 = np.asanyarray(dims) - 1
         shape1 = 2*shape0
         ncells = np.prod(shape0)
         cells = 8*np.ones((ncells, 9), dtype=int)
@@ -2086,7 +2091,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         self.SetPoints(points)
         self.SetCells(cells)
 
-    def cast_to_unstructured_grid(self):
+    def cast_to_unstructured_grid(self) -> 'UnstructuredGrid':
         """Cast to an unstructured grid.
 
         Returns
@@ -2172,14 +2177,14 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         grid = self.cast_to_unstructured_grid()
         grid.save(filename, binary)
 
-    def hide_cells(self, ind, inplace=False):
+    def hide_cells(self, ind: Sequence[int], inplace=False) -> 'ExplicitStructuredGrid':
         """Hide specific cells.
 
         Hides cells by setting the ghost cell array to ``HIDDENCELL``.
 
         Parameters
         ----------
-        ind : int or iterable(int)
+        ind : sequence(int)
             Cell indices to be hidden. A boolean array of the same
             size as the number of cells also is acceptable.
 
@@ -2202,11 +2207,11 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         >>> grid.plot(color='w', show_edges=True, show_bounds=True)
 
         """
-        ind = np.asarray(ind)
+        ind_arr = np.asanyarray(ind)
 
         if inplace:
             array = np.zeros(self.n_cells, dtype=np.uint8)
-            array[ind] = _vtk.vtkDataSetAttributes.HIDDENCELL
+            array[ind_arr] = _vtk.vtkDataSetAttributes.HIDDENCELL
             name = _vtk.vtkDataSetAttributes.GhostArrayName()
             self.cell_data[name] = array
             return self
@@ -2215,7 +2220,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         grid.hide_cells(ind, inplace=True)
         return grid
 
-    def show_cells(self, inplace=False):
+    def show_cells(self, inplace=False) -> 'ExplicitStructuredGrid':
         """Show hidden cells.
 
         Shows hidden cells by setting the ghost cell array to ``0``
@@ -2264,11 +2269,11 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         dims = self.extent
         dims = np.reshape(dims, (3, 2))
         dims = np.diff(dims, axis=1)
-        dims = dims.flatten()
-        return dims+1
+        dims = dims.flatten() + 1
+        return int(dims[0]), int(dims[1]), int(dims[2])
 
     @property
-    def dimensions(self):
+    def dimensions(self) -> Tuple[int, int, int]:
         """Return the topological dimensions of the grid.
 
         Returns
@@ -2281,13 +2286,13 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         >>> from pyvista import examples
         >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
         >>> grid.dimensions  # doctest:+SKIP
-        array([5, 6, 7])
+        (5, 6, 7)
 
         """
         return self._dimensions()
 
     @property
-    def visible_bounds(self):
+    def visible_bounds(self) -> Tuple[float, float, float, float, float, float]:
         """Return the bounding box of the visible cells.
 
         Different from `bounds`, which returns the bounding box of the
@@ -2297,7 +2302,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
 
         Returns
         -------
-        list(float)
+        tuple(float)
             The limits of the visible grid in the X, Y and Z
             directions respectively.
 
@@ -2321,7 +2326,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         else:
             return self.bounds
 
-    def cell_id(self, coords):
+    def cell_id(self, coords) -> Union[int, np.ndarray, None]:
         """Return the cell ID.
 
         Parameters
@@ -2364,7 +2369,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
             coords = tuple(coords)
         dims = self._dimensions()
         try:
-            ind = np.ravel_multi_index(coords, dims-1, order='F')
+            ind = np.ravel_multi_index(coords, np.array(dims) - 1, order='F')
         except ValueError:
             return None
         else:
@@ -2404,7 +2409,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         """
         dims = self._dimensions()
         try:
-            coords = np.unravel_index(ind, dims-1, order='F')
+            coords = np.unravel_index(ind, np.array(dims) - 1, order='F')
         except ValueError:
             return None
         else:
@@ -2412,7 +2417,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
                 coords = np.stack(coords, axis=1)
             return coords
 
-    def neighbors(self, ind, rel='connectivity'):
+    def neighbors(self, ind, rel='connectivity') -> list:
         """Return the indices of neighboring cells.
 
         Parameters
@@ -2536,7 +2541,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
             indices.update(rel(i))
         return sorted(indices)
 
-    def compute_connectivity(self, inplace=False):
+    def compute_connectivity(self, inplace=False) -> 'ExplicitStructuredGrid':
         """Compute the faces connectivity flags array.
 
         This method checks the faces connectivity of the cells with
@@ -2559,7 +2564,8 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         Returns
         -------
         ExplicitStructuredGrid
-            A deep copy of this grid if ``inplace=False``.
+            A deep copy of this grid if ``inplace=False``, or this
+            DataSet if otherwise.
 
         See Also
         --------
@@ -2597,8 +2603,9 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
 
         Returns
         -------
-        ExplicitStructuredGrid or None
-            A deep copy of this grid if ``inplace=False`` or ``None`` otherwise.
+        ExplicitStructuredGrid
+            A deep copy of this grid if ``inplace=False`` or this
+            DataSet if otherwise.
 
         See Also
         --------

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -50,7 +50,7 @@ class pyvista_ndarray(np.ndarray):
             self.association = FieldAssociation.NONE
             self.VTKObject = None
 
-    def __setitem__(self, key: int, value):
+    def __setitem__(self, key: Union[int, np.ndarray], value):
         """Implement [] set operator.
 
         When the array is changed it triggers "Modified()" which updates

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1026,7 +1026,7 @@ def test_cell_points(grid):
 
 def test_cell_bounds(grid):
     bounds = grid.cell_bounds(0)
-    assert isinstance(bounds, list)
+    assert isinstance(bounds, tuple)
     assert len(bounds) == 6
 
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -680,6 +680,10 @@ def test_create_uniform_grid_from_specs():
     assert grid.origin == origin
     assert grid.spacing == spacing
 
+    # ensure negative spacing is not allowed
+    with pytest.raises(ValueError, match="Spacing must be non-negative"):
+        grid = pyvista.UniformGrid(dims=dims, spacing=(-1, 1, 1))
+
     # all args (deprecated)
     with pytest.warns(
             PyvistaDeprecationWarning,

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -581,7 +581,7 @@ def test_create_rectilinear_grid_from_specs():
     grid = pyvista.RectilinearGrid(xrng, yrng, zrng)
     assert grid.n_cells == 9*3*19
     assert grid.n_points == 10*4*20
-    assert grid.bounds == [-10.0,8.0, -10.0,5.0, -10.0,9.0]
+    assert grid.bounds == (-10.0, 8.0, -10.0, 5.0, -10.0, 9.0)
     # 2D example
     cell_spacings = np.array([1., 1., 2., 2., 5., 10.])
     x_coordinates = np.cumsum(cell_spacings)
@@ -589,20 +589,20 @@ def test_create_rectilinear_grid_from_specs():
     grid = pyvista.RectilinearGrid(x_coordinates, y_coordinates)
     assert grid.n_cells == 5*5
     assert grid.n_points == 6*6
-    assert grid.bounds == [1.,21., 1.,21., 0.,0.]
+    assert grid.bounds == (1., 21., 1., 21., 0., 0.)
 
 
 def test_create_rectilinear_after_init():
-    x = np.array([0,1,2])
-    y = np.array([0,5,8])
-    z = np.array([3,2,1])
+    x = np.array([0, 1, 2])
+    y = np.array([0, 5, 8])
+    z = np.array([3, 2, 1])
     grid = pyvista.RectilinearGrid()
     grid.x = x
-    assert grid.dimensions == [3, 1, 1]
+    assert grid.dimensions == (3, 1, 1)
     grid.y = y
-    assert grid.dimensions == [3, 3, 1]
+    assert grid.dimensions == (3, 3, 1)
     grid.z = z
-    assert grid.dimensions == [3, 3, 3]
+    assert grid.dimensions == (3, 3, 3)
     assert np.allclose(grid.x, x)
     assert np.allclose(grid.y, y)
     assert np.allclose(grid.z, z)
@@ -612,7 +612,7 @@ def test_create_rectilinear_grid_from_file():
     grid = examples.load_rectilinear()
     assert grid.n_cells == 16146
     assert grid.n_points == 18144
-    assert grid.bounds == [-350.0,1350.0, -400.0,1350.0, -850.0,0.0]
+    assert grid.bounds == (-350.0,1350.0, -400.0,1350.0, -850.0,0.0)
     assert grid.n_arrays == 1
 
 
@@ -620,7 +620,7 @@ def test_read_rectilinear_grid_from_file():
     grid = pyvista.read(examples.rectfile)
     assert grid.n_cells == 16146
     assert grid.n_points == 18144
-    assert grid.bounds == [-350.0,1350.0, -400.0,1350.0, -850.0,0.0]
+    assert grid.bounds == (-350.0, 1350.0, -400.0, 1350.0, -850.0, 0.0)
     assert grid.n_arrays == 1
 
 
@@ -628,7 +628,7 @@ def test_read_rectilinear_grid_from_pathlib():
     grid = pyvista.RectilinearGrid(pathlib.Path(examples.rectfile))
     assert grid.n_cells == 16146
     assert grid.n_points == 18144
-    assert grid.bounds == [-350.0, 1350.0, -400.0, 1350.0, -850.0, 0.0]
+    assert grid.bounds == (-350.0, 1350.0, -400.0, 1350.0, -850.0, 0.0)
     assert grid.n_arrays == 1
 
 
@@ -650,20 +650,20 @@ def test_create_uniform_grid_from_specs():
     grid = pyvista.UniformGrid()
 
     # create UniformGrid
-    dims = [10, 10, 10]
+    dims = (10, 10, 10)
     grid = pyvista.UniformGrid(dims=dims) # Using default spacing and origin
     assert grid.dimensions == dims
-    assert grid.extent == [0, 9, 0, 9, 0, 9]
-    assert grid.origin == [0.0, 0.0, 0.0]
-    assert grid.spacing == [1.0, 1.0, 1.0]
+    assert grid.extent == (0, 9, 0, 9, 0, 9)
+    assert grid.origin == (0.0, 0.0, 0.0)
+    assert grid.spacing == (1.0, 1.0, 1.0)
 
     # Using default origin
-    spacing = [2, 1, 5]
+    spacing = (2, 1, 5)
     grid = pyvista.UniformGrid(dims=dims, spacing=spacing)
     assert grid.dimensions == dims
-    assert grid.origin == [0.0, 0.0, 0.0]
+    assert grid.origin == (0.0, 0.0, 0.0)
     assert grid.spacing == spacing
-    origin = [10, 35, 50]
+    origin = (10, 35, 50)
 
     # Everything is specified
     grid = pyvista.UniformGrid(dims=dims, spacing=spacing, origin=origin)
@@ -695,7 +695,7 @@ def test_create_uniform_grid_from_specs():
     assert grid == grid_from_grid
 
     # and is a copy
-    grid.origin = [0, 0, 0]
+    grid.origin = (0, 0, 0)
     assert grid != grid_from_grid
 
 
@@ -712,42 +712,42 @@ def test_uniform_grid_invald_args():
 
 def test_uniform_setters():
     grid = pyvista.UniformGrid()
-    grid.dimensions = [10, 10, 10]
+    grid.dimensions = (10, 10, 10)
     assert grid.GetDimensions() == (10, 10, 10)
-    assert grid.dimensions == [10, 10, 10]
-    grid.spacing = [5, 2, 1]
+    assert grid.dimensions == (10, 10, 10)
+    grid.spacing = (5, 2, 1)
     assert grid.GetSpacing() == (5, 2, 1)
-    assert grid.spacing == [5, 2, 1]
-    grid.origin = [6, 27.7, 19.8]
+    assert grid.spacing == (5, 2, 1)
+    grid.origin = (6, 27.7, 19.8)
     assert grid.GetOrigin() == (6, 27.7, 19.8)
-    assert grid.origin == [6, 27.7, 19.8]
+    assert grid.origin == (6, 27.7, 19.8)
 
 
 def test_create_uniform_grid_from_file():
     grid = examples.load_uniform()
     assert grid.n_cells == 729
     assert grid.n_points == 1000
-    assert grid.bounds == [0.0,9.0, 0.0,9.0, 0.0,9.0]
+    assert grid.bounds == (0.0, 9.0, 0.0, 9.0, 0.0, 9.0)
     assert grid.n_arrays == 2
-    assert grid.dimensions == [10, 10, 10]
+    assert grid.dimensions == (10, 10, 10)
 
 
 def test_read_uniform_grid_from_file():
     grid = pyvista.read(examples.uniformfile)
     assert grid.n_cells == 729
     assert grid.n_points == 1000
-    assert grid.bounds == [0.0,9.0, 0.0,9.0, 0.0,9.0]
+    assert grid.bounds == (0.0, 9.0, 0.0, 9.0, 0.0, 9.0)
     assert grid.n_arrays == 2
-    assert grid.dimensions == [10, 10, 10]
+    assert grid.dimensions == (10, 10, 10)
 
 
 def test_read_uniform_grid_from_pathlib():
     grid = pyvista.UniformGrid(pathlib.Path(examples.uniformfile))
     assert grid.n_cells == 729
     assert grid.n_points == 1000
-    assert grid.bounds == [0.0, 9.0, 0.0, 9.0, 0.0, 9.0]
+    assert grid.bounds == (0.0, 9.0, 0.0, 9.0, 0.0, 9.0)
     assert grid.n_arrays == 2
-    assert grid.dimensions == [10, 10, 10]
+    assert grid.dimensions == (10, 10, 10)
 
 
 def test_cast_uniform_to_structured():
@@ -848,7 +848,7 @@ def test_grid_points():
     grid.x = x
     grid.y = y
     grid.z = z
-    assert grid.dimensions == [3, 3, 2]
+    assert grid.dimensions == (3, 3, 2)
     assert np.allclose(grid.meshgrid, (xx, yy, zz))
     assert np.allclose(grid.points, np.c_[xx.ravel(order='F'), yy.ravel(order='F'), zz.ravel(order='F')])
 
@@ -933,7 +933,7 @@ def test_UnstructuredGrid_cast_to_explicit_structured_grid():
     grid = grid.cast_to_explicit_structured_grid()
     assert grid.n_cells == 120
     assert grid.n_points == 210
-    assert grid.bounds == [0.0, 80.0, 0.0, 50.0, 0.0, 6.0]
+    assert grid.bounds == (0.0, 80.0, 0.0, 50.0, 0.0, 6.0)
     assert 'BLOCK_I' in grid.cell_data
     assert 'BLOCK_J' in grid.cell_data
     assert 'BLOCK_K' in grid.cell_data
@@ -947,7 +947,7 @@ def test_ExplicitStructuredGrid_init():
     assert isinstance(grid, pyvista.ExplicitStructuredGrid)
     assert grid.n_cells == 120
     assert grid.n_points == 210
-    assert grid.bounds == [0.0, 80.0, 0.0, 50.0, 0.0, 6.0]
+    assert grid.bounds == (0.0, 80.0, 0.0, 50.0, 0.0, 6.0)
     assert repr(grid) == str(grid)
     assert 'N Cells' in str(grid)
     assert 'N Points' in str(grid)
@@ -996,7 +996,7 @@ def test_ExplicitStructuredGrid_save():
     grid = pyvista.ExplicitStructuredGrid('grid.vtu')
     assert grid.n_cells == 120
     assert grid.n_points == 210
-    assert grid.bounds == [0.0, 80.0, 0.0, 50.0, 0.0, 6.0]
+    assert grid.bounds == (0.0, 80.0, 0.0, 50.0, 0.0, 6.0)
     assert np.count_nonzero(grid.cell_data['vtkGhostType']) == 40
     os.remove('grid.vtu')
 
@@ -1044,20 +1044,20 @@ def test_ExplicitStructuredGrid_show_cells():
 @pytest.mark.skipif(not VTK9, reason='VTK 9 or higher is required')
 def test_ExplicitStructuredGrid_dimensions():
     grid = examples.load_explicit_structured()
-    assert isinstance(grid.dimensions, np.ndarray)
-    assert np.issubdtype(grid.dimensions.dtype, np.integer)
-    assert grid.dimensions.shape == (3,)
-    assert np.array_equal(grid.dimensions, [5, 6, 7])
+    assert isinstance(grid.dimensions, tuple)
+    assert isinstance(grid.dimensions[0], int)
+    assert len(grid.dimensions) == 3
+    assert grid.dimensions == (5, 6, 7)
 
 
 @pytest.mark.skipif(not VTK9, reason='VTK 9 or higher is required')
 def test_ExplicitStructuredGrid_visible_bounds():
     grid = examples.load_explicit_structured()
     grid = grid.hide_cells(range(80, 120))
-    assert isinstance(grid.visible_bounds, list)
+    assert isinstance(grid.visible_bounds, tuple)
     assert all(isinstance(x, float) for x in grid.visible_bounds)
     assert len(grid.visible_bounds) == 6
-    assert grid.visible_bounds == [0.0, 80.0, 0.0, 50.0, 0.0, 4.0]
+    assert grid.visible_bounds == (0.0, 80.0, 0.0, 50.0, 0.0, 4.0)
 
 
 @pytest.mark.skipif(not VTK9, reason='VTK 9 or higher is required')


### PR DESCRIPTION
#### Overview
In keeping with our goal to be consistent with `numpy`, this PR changes the behavior for several methods to return `tuple` rather than lists or `numpy.ndarray`. This includes:

- `pyvista.DataSet.bounds` `list` -> `tuple`
- `pyvista.DataSet.extent` `list` -> `tuple`
- `pyvista.DataSet.cell_bounds` `list` -> `tuple`
- `pyvista.Grid.dimensions` `list` -> `tuple`
- `pyvista.UniformGrid.origin` `list` -> `tuple`
- `pyvista.UniformGrid.spacing` `list` -> `tuple`
- `pyvista.ExplicitStructuredGrid.spacing` `np.ndarray` -> `tuple`
- `pyvista.ExplicitStructuredGrid.visible_bounds` `list` -> `tuple`

#### Why?
There's no reason for returning a `list`, which are more flexible than tuples and imply that there's a reason to append or manipulate the data. Rather, the immutability of the `tuple` implies that the data returned is "read only". And because VTK already returns `tuple`s as the default datatype for `GetBounds` and other class methods, this actually simplifies our code. Plus, this matches `numpy`'s `shape`, `ndim` and other properties.

#### Other Changes
- `ExplicitStructuredGrid.hide_cells` and `show_cells` now accepts sequences rather than just `numpy.ndarray`.
- Added type hints to several methods.
- Improved the documentation of `grid.py` in several places, including adding examples to the docstrings.
- Resolve #1967 by disallowing negative spacing.
