### PR TITLE
Use dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# 
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,7 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# 
-
 version: 2
 updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
+    insecure-external-code-execution: allow
     schedule:
-      interval: "weekly"
+      interval: "daily"


### PR DESCRIPTION
This PR proposes that we start using [dependabot](https://github.com/dependabot). Reasoning being:
- By specifying our requirements in requirement files, especially for testing and documentation building, we can immediately identify when something upstream breaks our build or testing rather than having to guess.
- On the other hand, like in the case of `requirements_static.py` or `requirements_style.py`, we no longer need to manually update the versions and validate that they pass.

