### PR TITLE
👷 Automate copyright date

### DIFF
--- a/pyvista/ext/coverage.py
+++ b/pyvista/ext/coverage.py
@@ -5,10 +5,10 @@
     Check Python modules and C API for coverage.  Mostly written by Josip
     Dzolonga for the Google Highly Open Participation contest.
 
-    :copyright: Copyright 2007-2021 by the Sphinx team, see AUTHORS.
-    :license: BSD, see LICENSE for details.
-
     Modified slightly for ``pyvista``.
+
+    :copyright: See `Sphinx copyright <https://github.com/sphinx-doc/sphinx>`_.
+    :license: See `Sphinx license <https://github.com/sphinx-doc/sphinx>`_.
 
 """
 

--- a/tests/tinypages/conf.py
+++ b/tests/tinypages/conf.py
@@ -1,4 +1,5 @@
 import datetime
+
 from packaging.version import parse as parse_version
 import sphinx
 

--- a/tests/tinypages/conf.py
+++ b/tests/tinypages/conf.py
@@ -1,3 +1,4 @@
+import datetime
 from packaging.version import parse as parse_version
 import sphinx
 
@@ -8,7 +9,8 @@ templates_path = ['_templates']
 source_suffix = '.rst'
 master_doc = 'index'
 project = 'tinypages'
-copyright = '2021, PyVista developers'
+year = datetime.date.today().year
+copyright = f"2021-{year}, PyVista developers"
 version = '0.1'
 release = '0.1'
 exclude_patterns = ['_build']


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 
See https://github.com/pyvista/pyvista/pull/1989

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- Automate conf.py copyright of tinypages test.
- sphinx.ext.coverage copyright and author refers to [original source](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/ext/coverage.py).

