### PR TITLE
Release 0.33.0

### DIFF
--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -15,7 +15,7 @@ Denotes the first release candidate.
 
 """
 # major, minor, patch
-version_info = 0, 33, 'dev0'
+version_info = 0, 34, 'dev0'
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
#### Proposing a release of `pyvista==0.33.0`.

First step is to bump our `main` branch version to `pyvista==0.34.dev0` in this PR. Next step will be to bump the version in this branch to `0.33.0` and push a tag `v0.33.0`.

@pyvista/developers if there are any reservations, please let me know.