### PR TITLE
Fix chart examples.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -319,6 +319,8 @@ sphinx_gallery_conf = {
     "filename_pattern": r"\.py" if has_osmnx else r"(?!osmnx-example)\.py",
     # Remove the "Download all examples" button from the top level gallery
     "download_all_examples": False,
+    # Remove sphinx configuration comments from code blocks
+    "remove_config_comments": True,
     # Sort gallery example by file name instead of number of lines (default)
     "within_subsection_order": FileNameSortKey,
     # directory where function granular galleries are stored

--- a/examples/02-plot/chart_overlays.py
+++ b/examples/02-plot/chart_overlays.py
@@ -27,17 +27,19 @@ h = np.sin(t)
 v = np.cos(t)
 
 ###############################################################################
-# Define Matplotlib figure
-# Use a tight layout to keep axis labels visible on smaller figures
+# Define a Matplotlib figure.
+# Use a tight layout to keep axis labels visible on smaller figures.
 
 f, ax = plt.subplots(tight_layout=True)
 h_line = ax.plot(t[:1], h[:1])[0]
 ax.set_ylim([-1, 1])
 ax.set_xlabel('Time (s)')
-ax.set_ylabel('Height (m)')
+_ = ax.set_ylabel('Height (m)')
+# sphinx_gallery_defer_figures
 
 ###############################################################################
-# Define plotter, add matplotlib figure as first chart and define second chart
+# Define plotter, add the created matplotlib figure as the first (left) chart
+# to the scene, and define a second (right) chart.
 
 p = pv.Plotter()
 h_chart = pv.ChartMPL(f, size=(0.46, 0.25), loc=(0.02, 0.06))
@@ -53,7 +55,6 @@ p.show(auto_close=False, interactive=True, interactive_update=True)
 
 
 # Method and slider to update all visuals based on the time selection
-
 def update_time(time):
     k = np.count_nonzero(t < time)
     h_line.set_xdata(t[:k+1])

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -1031,6 +1031,9 @@ class _Chart(DocSubs):
         if loc is not None:
             self.loc = loc
 
+    def deep_clean(self):
+        """Clean up the chart."""
+
     @property
     def _scene(self):
         """Get a reference to the vtkScene in which this chart is drawn."""
@@ -3957,6 +3960,22 @@ class ChartMPL(_vtk.vtkImageItem, _Chart):
 
         self._redraw()
 
+    def deep_clean(self):
+        """Clean up the chart.
+
+        Notes
+        -----
+        The underlying matplotlib figure is closed and cleaned up.
+        This is necessary while creating the sphinx gallery, as otherwise
+        these charts are drawn twice in example scripts: once as a
+        pyvista plot (fetched by the 'pyvista' scraper) and once as a
+        matplotlib figure (fetched by the 'matplotlib' scraper).
+        """
+        import matplotlib.pyplot as plt
+        plt.close(self._fig)
+        self._fig = None
+        self._canvas = None
+
     @property
     def figure(self):
         """Retrieve the matplotlib figure associated with this chart.
@@ -4138,6 +4157,7 @@ class Charts:
             charts = [*self._charts]  # Make a copy, as this list will be modified by remove_plot
             for chart in charts:
                 self.remove_chart(chart)
+                chart.deep_clean()
             self._renderer.RemoveActor(self._actor)
         self._scene = None
         self._actor = None


### PR DESCRIPTION
### Overview

While browsing the chart docs and examples I noticed some issues with the parsed example scripts that slipped through.


### Details

- After these changes, ChartMPL plots are no longer drawn twice. This was caused by the two image scrapers that are used while building the sphinx gallery. The 'pyvista' scraper picked up the plotting window containing the chart (ok), while the 'matplotlib' scraper picked up the unclosed figure used by the ChartMPL (not ok). As a fix, I added a `deep_clean` method to chart objects, which closes the underlying matplotlib figure for ChartMPL instances.
- In the 'chart overlays' example, the unfinished matplotlib figure is no longer drawn after the third codeblock by using [the `sphinx_gallery_defer_figures` configuration comment](https://sphinx-gallery.github.io/stable/configuration.html#using-multiple-code-blocks-to-create-a-single-figure).

