### PR TITLE
Make Plotter.theme's setter actually set the theme

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -287,7 +287,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             raise TypeError('Expected a pyvista theme like '
                             '``pyvista.themes.DefaultTheme``, '
                             f'not {type(theme).__name__}.')
-        self._theme.load_theme(pyvista.global_theme)
+        self._theme.load_theme(theme)
 
     def import_gltf(self, filename, set_camera=True):
         """Import a glTF file into the plotter.

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -395,6 +395,12 @@ def test_plotter_set_theme():
     assert pl.theme.color == my_theme.color
     assert pyvista.global_theme.color != pl.theme.color
 
+    pl = pyvista.Plotter()
+    assert pl.theme == pyvista.global_theme
+    pl.theme = my_theme
+    assert pl.theme != pyvista.global_theme
+    assert pl.theme == my_theme
+
 
 def test_load_theme(tmpdir, default_theme):
     filename = str(tmpdir.mkdir("tmpdir").join('tmp.json'))


### PR DESCRIPTION
Due to a bug `plotter.theme = new_theme` would load the currently active global theme rather than `new_theme`.

Side note: I noticed that we have both a [bug] and a [bug-fix] label. For issues the former would make more sense, for PRs the latter would make more sense, and our automatic release mechanism uses [bug] for PRs. Are we happy with this or should we change this? (By merging the two tags, or switching from [bug] to [bug-fix] on PRs, or something else). Cc. @tkoyama010 