### PR TITLE
Disable highlighting for web search results

### DIFF
--- a/doc/_static/no_search_highlight.css
+++ b/doc/_static/no_search_highlight.css
@@ -1,0 +1,3 @@
+/* No search term highlighting, see https://stackoverflow.com/a/48771802 */
+span.highlighted {
+    background-color: transparent;

--- a/doc/_static/no_search_highlight.css
+++ b/doc/_static/no_search_highlight.css
@@ -1,3 +1,4 @@
 /* No search term highlighting, see https://stackoverflow.com/a/48771802 */
 span.highlighted {
     background-color: transparent;
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -565,3 +565,4 @@ def setup(app):
     AutoAutoSummary.app = app
     app.add_directive("autoautosummary", AutoAutoSummary)
     app.add_css_file("copybutton.css")
+    app.add_css_file("no_search_highlight.css")


### PR DESCRIPTION
I've always been bugged by the fact that sphinx search results automatically highlight the search hits on the target page. This usually looks like this:
![Screenshot from 2022-01-07 21-34-44](https://user-images.githubusercontent.com/17914410/148603992-8529b6aa-e8e0-406f-9a66-ed98909b0a19.png)
Note the noisy highlights of each appearance of "plot", even in the left sidebar in unrelated words.

I've done some digging and it seems there's no way to disable this feature altogether, at least I couldn't find anything in [the sphinx docs](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_style) nor in [the pydata-sphinx-theme docs](https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/customizing.html). I did find a workaround [in this Stack Overflow answer](https://stackoverflow.com/a/48771802/5067311) that suggests hacking the highlight colour to be transparent in CSS.

So this PR does exactly that by creating an auxiliary .css file (similarly to the one we already have for the copy button), and injects it in conf.py (the same way that we do for the copy button). The result is nice:
![Screenshot from 2022-01-07 21-35-02](https://user-images.githubusercontent.com/17914410/148604575-0db3eef2-a0aa-449e-b4e8-30a5a076d436.png)
But note that this will still have the `?highlight=...` parameter in the URL, it will merely be a no-op. This is not great but I prefer this to the working highlight feature.

Furthermore, I don't actually know what I'm doing here (at all!) so labelling this as review-critical :sweat_smile: And of course if you think we should keep the default highlighting (cc @pyvista/developers) then we can just close this.