### PR TITLE
Build and publish Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-dist/
 build/
 *.egg-info
 .pytest_cache

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+dist/
+build/
+*.egg-info
+.pytest_cache
+*.pyc
+.ipynb_checkpoints
+htmlcov
+.hypothesis

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -1,0 +1,35 @@
+name: Docker Package
+on:
+  push:
+    tags: "*"
+    branches:
+      - main
+  pull_request:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Log into the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata for the Docker image
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push the Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -30,6 +30,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          file: docker/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -15,17 +15,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+
+      - name: Create PyVista package
+        run: |
+          python setup.py sdist
+
       - name: Log into the Container registry
         uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract metadata for the Docker image
         id: meta
         uses: docker/metadata-action@v3
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
       - name: Build and push the Docker image
         uses: docker/build-push-action@v2
         with:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM jupyter/base-notebook:python-3.8.6
-LABEL maintainer="pyvista Developers"
+LABEL maintainer="PyVista Developers"
 
 USER root
 RUN apt-get update \
@@ -11,12 +11,9 @@ RUN apt-get update \
 USER jovyan
 
 # setup the itkwidgets conda environment
-COPY environment.yml labextensions.txt /tmp/
+COPY ../environment.yml labextensions.txt /tmp/
 RUN conda env update --name base --file /tmp/environment.yml
-RUN conda run conda install -y nodejs
 RUN conda run jupyter labextension install $(cat /tmp/labextensions.txt)
-
-RUN pip install ipyvtklink==0.2.1
 
 # allow jupyterlab for ipyvtk
 ENV DISPLAY=:99.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="PyVista Developers"
 USER root
 RUN apt-get update \
  && apt-get install  -yq --no-install-recommends \
-    libgl1-mesa-glx \
-    libglu1-mesa \
     libfontconfig1 \
     libxrender1 \
     libosmesa6 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/base-notebook:python-3.8.6
+FROM jupyter/base-notebook:python-3.9.7
 LABEL maintainer="PyVista Developers"
 
 USER root
@@ -8,25 +8,24 @@ RUN apt-get update \
     libglu1-mesa \
     libfontconfig1 \
     libxrender1 \
-    xvfb \
+    libosmesa6 \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 USER jovyan
 
-COPY pyvista/ /build-context/pyvista/
-COPY setup.py /build-context/
+COPY dist/*.tar.gz /build-context/
 COPY README.rst /build-context/
 COPY LICENSE /build-context/
 COPY requirements*.txt /build-context/
 WORKDIR /build-context/
+
+# Install our custom vtk wheel
+RUN pip install https://github.com/pyvista/pyvista-wheels/raw/main/vtk-osmesa-9.1.0-cp39-cp39-linux_x86_64.whl
+
+RUN pip install pyvista*.tar.gz
 RUN pip install -r requirements_docs.txt -r requirements_test.txt
-RUN pip install .
 
 WORKDIR $HOME
 
 # allow jupyterlab for ipyvtk
-ENV DISPLAY=:99.0
 ENV JUPYTER_ENABLE_LAB=yes
 ENV PYVISTA_USE_IPYVTK=true
-
-# modify the CMD to start a background Xvfb process first
-CMD /bin/bash -c "Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &" && start-notebook.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,9 +11,8 @@ RUN apt-get update \
 USER jovyan
 
 # setup the itkwidgets conda environment
-COPY ../environment.yml labextensions.txt /tmp/
+COPY environment.yml /tmp/
 RUN conda env update --name base --file /tmp/environment.yml
-RUN conda run jupyter labextension install $(cat /tmp/labextensions.txt)
 
 # allow jupyterlab for ipyvtk
 ENV DISPLAY=:99.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,19 +6,27 @@ RUN apt-get update \
  && apt-get install  -yq --no-install-recommends \
     libgl1-mesa-glx \
     libglu1-mesa \
+    libfontconfig1 \
+    libxrender1 \
     xvfb \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 USER jovyan
 
-# setup the itkwidgets conda environment
-COPY environment.yml /tmp/
-RUN conda env update --name base --file /tmp/environment.yml
+COPY pyvista/ /build-context/pyvista/
+COPY setup.py /build-context/
+COPY README.rst /build-context/
+COPY LICENSE /build-context/
+COPY requirements*.txt /build-context/
+WORKDIR /build-context/
+RUN pip install -r requirements_docs.txt -r requirements_test.txt
 RUN pip install .
+
+WORKDIR $HOME
 
 # allow jupyterlab for ipyvtk
 ENV DISPLAY=:99.0
 ENV JUPYTER_ENABLE_LAB=yes
 ENV PYVISTA_USE_IPYVTK=true
 
-# modify the CMD and start a background server first
+# modify the CMD to start a background Xvfb process first
 CMD /bin/bash -c "Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &" && start-notebook.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,7 @@ USER jovyan
 # setup the itkwidgets conda environment
 COPY environment.yml /tmp/
 RUN conda env update --name base --file /tmp/environment.yml
+RUN pip install .
 
 # allow jupyterlab for ipyvtk
 ENV DISPLAY=:99.0

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,28 +1,24 @@
 ### PyVista within a Docker Container
 
-You can use ``pyvista`` from within a docker container with jupyterlab.
+You can use PyVista from within a docker container with Jupyter Lab.
+
 To create a local docker image install ``docker`` and be sure you've logged into docker by following the directions at [Configuring Docker for use with GitHub Packages](https://docs.github.com/en/free-pro-team@latest/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages#authenticating-with-a-personal-access-token)
 
 Next, pull, and run the image with:
 
 ```bash
-docker pull docker.pkg.github.com/pyvista/pyvista/pyvista-jupyterlab:v0.27.0
-docker run -p 8888:8888 docker.pkg.github.com/pyvista/pyvista/pyvista-jupyterlab:v0.27.0
+docker pull ghcr.io/pyvista/pyvista:latest
+docker run -p 8888:8888 ghcr.io/pyvista/pyvista:latest
 ```
 
 Finally, open the link that shows up and start playing around with
-pyvista in jupyterlab!  For example:
+PyVista in Jupyter Lab!
 
-```
-http://127.0.0.1:8888/?token=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-```
 
-### Create your own Docker Container with `pyvista`
+### Build PyVista Docker Image Locally
 
-Clone pyvista and cd into this directory to create your own customized docker image.
+Clone PyVista and run the following at the top level of the project:
 
 ```bash
-IMAGE=my-pyvista-jupyterlab:v0.1.0
-docker build -t $IMAGE .
-docker push $IMAGE
+docker build -t my-pyvista-jupyterlab -f docker/Dockerfile
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,5 @@
-### Pyvista within a Docker Container
+### PyVista within a Docker Container
+
 You can use ``pyvista`` from within a docker container with jupyterlab.
 To create a local docker image install ``docker`` and be sure you've logged into docker by following the directions at [Configuring Docker for use with GitHub Packages](https://docs.github.com/en/free-pro-team@latest/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages#authenticating-with-a-personal-access-token)
 

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -1,6 +1,0 @@
-channels:
-  - conda-forge
-  - defaults
-dependencies:
-  - itkwidgets=0.32.0
-  - ipywidgets=7.5.1

--- a/docker/labextensions.txt
+++ b/docker/labextensions.txt
@@ -1,4 +1,0 @@
-@jupyter-widgets/jupyterlab-manager@2.0
-itkwidgets@0.32.0
-ipycanvas@0.6.1
-ipyevents@1.8.1

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,15 +1,11 @@
 cmocean
 colorcet
 imageio-ffmpeg
-imageio>=2.5.0
+imageio
 ipygany
 ipyvtklink
-lxml
 matplotlib
 meshio
-osmnx==1.1.1
 panel
-param==1.10.1  # due to panel bug
-scipy
 trimesh
 pythreejs


### PR DESCRIPTION
This sets up a CI workflow to build and publish a docker image with PyVista set up for use in JupyterLab. This will push to the GitHub container registry for this repo and it will label the images on release and per PR as well as consistently building for `main`

The image size is rather large at 2.47GB ... we may want to see if we can reduce that

There is a new package for this repo here: https://github.com/pyvista/pyvista/pkgs/container/pyvista

Note that there is a tag for this PR (`pr-2011`) here: https://github.com/pyvista/pyvista/pkgs/container/pyvista/12896063?tag=pr-2011

This will make it even easier to test out PRs in an isolated environment by pulling the tag for a given PR

Note that the `latest` tag is only updated on Git tags - we may need to manually push the `latest` tag for the last release

I am going to delete the old package here: https://github.com/pyvista/pyvista/pkgs/container/pyvista%2Fpyvista-jupyterlab