### PR TITLE
Fix some links and typos in examples

### DIFF
--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v2
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Simple makefile to simplify repetitive build env management tasks under posix
 
 CODESPELL_DIRS ?= ./
-CODESPELL_SKIP ?= "*.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,./doc/_build/*,./doc/images/*,./dist/*,*~,.hypothesis*,./doc/examples/*,*.mypy_cache/*,*cover,./tests/tinypages/_build/*,*/_autosummary/*"
+CODESPELL_SKIP ?= "*.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.vtu,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,./doc/_build/*,./doc/images/*,./dist/*,*~,.hypothesis*,./doc/examples/*,*.mypy_cache/*,*cover,./tests/tinypages/_build/*,*/_autosummary/*"
 CODESPELL_IGNORE ?= "ignore_words.txt"
 
 # doctest modules must be off screen to avoid plotting everything

--- a/doc/user-guide/jupyter/index.rst
+++ b/doc/user-guide/jupyter/index.rst
@@ -2,7 +2,7 @@
 
 Jupyter Notebook Plotting
 =========================
-Plot with ``pyvista`` interactively within a `Juptyer
+Plot with ``pyvista`` interactively within a `Jupyter
 <https://jupyter.org/>`_ notebook!
 
 

--- a/examples/00-load/load-gltf.py
+++ b/examples/00-load/load-gltf.py
@@ -1,9 +1,9 @@
 """
 .. _load_gltf:
 
-Working with a glTF Files
-~~~~~~~~~~~~~~~~~~~~~~~~~
-Import a glTF directly into a PyVista plotting scene.  For more
+Working with glTF Files
+~~~~~~~~~~~~~~~~~~~~~~~
+Import a glTF file directly into a PyVista plotting scene.  For more
 details regarding the glTF format, see:
 https://www.khronos.org/gltf/
 

--- a/examples/01-filter/flying_edges.py
+++ b/examples/01-filter/flying_edges.py
@@ -5,10 +5,10 @@ Marching Cubes
 ~~~~~~~~~~~~~~
 
 Generate a surface from a scalar field using the flying edges and
-marching cubes filters as provided by the `contour
-<pyvista.core.filters.data_set.DataSetFilters.contour>` filter.
+marching cubes filters as provided by the :func:`contour
+<pyvista.DataSetFilters.contour>` filter.
 
-Special thanks to GitHub user `stla <https://gist.github.com/stla>`
+Special thanks to GitHub user `stla <https://gist.github.com/stla>`_
 for providing examples.
 
 """
@@ -57,7 +57,7 @@ mesh.plot(
 # Barth Sextic
 # ~~~~~~~~~~~~
 # Use the flying edges algorithm to extract the isosurface
-# generated from the barth sextic function.
+# generated from the Barth sextic function.
 
 
 phi = (1 + np.sqrt(5)) / 2
@@ -87,7 +87,7 @@ x, y, z = grid.points.T
 
 # sample and plot
 values = barth_sextic(x, y, z)
-mesh = grid.contour(1, values, method='marching_cubes', rng=[-0.0, 0])
+mesh = grid.contour(1, values, method='flying_edges', rng=[-0.0, 0])
 dist = np.linalg.norm(mesh.points, axis=1)
 mesh.plot(
     scalars=dist, smooth_shading=True, specular=5,
@@ -98,14 +98,14 @@ mesh.plot(
 ###############################################################################
 # Animate Barth Sextic
 # ~~~~~~~~~~~~~~~~~~~~
-# Show 15 frames of various isocurves extracted from the barth sextic
+# Show 15 frames of various isocurves extracted from the Barth sextic
 # function.
 
 def angle_to_range(angle):
     return -2*np.sin(angle)
 
 mesh = grid.contour(
-    1, values, method='marching_cubes', rng=[angle_to_range(0), 0]
+    1, values, method='flying_edges', rng=[angle_to_range(0), 0]
 )
 dist = np.linalg.norm(mesh.points, axis=1)
 
@@ -118,7 +118,7 @@ pl.open_gif('barth_sextic.gif')
 
 for angle in np.linspace(0, np.pi, 15)[:-1]:
     new_mesh = grid.contour(
-        1, values, method='marching_cubes', rng=[angle_to_range(angle), 0]
+        1, values, method='flying_edges', rng=[angle_to_range(angle), 0]
     )
     mesh.overwrite(new_mesh)
     pl.update_scalars(np.linalg.norm(new_mesh.points, axis=1), render=False)

--- a/examples/01-filter/streamlines_2D.py
+++ b/examples/01-filter/streamlines_2D.py
@@ -15,20 +15,21 @@ import pyvista as pv
 from pyvista import examples
 
 ###############################################################################
-# The data is multiblock with the fluid_data as the first block.
-# The data lies in the xy plane, i.e. z=0, with no z velocity.
+# The data is multiblock with the fluid data as the first block.
+# The data lies in the `xy` plane, i.e. `z=0`, with no `z` velocity.
 
 mesh = examples.download_cylinder_crossflow()
 fluid_mesh = mesh[0]
 print(fluid_mesh)
 
 ###############################################################################
-# The default behavior of the :func:`pyvista.DataSetFilters.streamlines` filter is to use
-# a 3D sphere source as the seed points.  This often will not generate any
-# seed points on the 2D plane of interest.  Instead, a single streamlines
-# can be generated using the `start_position` argument.
-# `surface_streamlines=True` argument is be needed if the dataset has
-# nonzero normal velocity component.  This is not the case in this dataset.
+# The default behavior of the :func:`streamlines()
+# <pyvista.DataSetFilters.streamlines>` filter is to use a 3D sphere source as
+# the seed points.  This often will not generate any seed points on the 2D
+# plane of interest.  Instead, a single streamline can be generated using the
+# ``start_position`` argument. The ``surface_streamlines=True`` argument is
+# also needed if the dataset has nonzero normal velocity component.  This is
+# not the case in this dataset.
 
 one_streamline = fluid_mesh.streamlines(
     start_position = (0., 0.4, 0.),
@@ -51,8 +52,8 @@ p.view_xy()
 p.show(cpos=camera_position)
 
 ###############################################################################
-# To generate multiple streamlines, a line source can be used with the `pointa`
-# and `pointb` parameters.
+# To generate multiple streamlines, a line source can be used with the ``pointa``
+# and ``pointb`` parameters.
 
 line_streamlines = fluid_mesh.streamlines(
     pointa=(0, -5, 0),
@@ -73,11 +74,11 @@ p.show(cpos=camera_position)
 # The behavior immediately downstream of the cylinder is still not apparent
 # using streamlines at the inlet.
 #
-# Another method is to use
-# :func:`pyvista.DataSetFilters.streamlines_evenly_spaced_2D`.
+# Another method is to use :func:`streamlines_evenly_spaced_2D()
+# <pyvista.DataSetFilters.streamlines_evenly_spaced_2D>`.
 # This filter only works with 2D data that lies on the xy plane. This method
 # can quickly run of memory, so particular attention must be paid to the input
-# parameters.  The defaults are in cell_length units.
+# parameters.  The defaults are in cell length units.
 
 line_streamlines = fluid_mesh.streamlines_evenly_spaced_2D(
     start_position=(4, 0.1, 0.),


### PR DESCRIPTION
I came across some minor mistakes while browsing some examples.

Some notes:
1. In the [Marching Cubes](https://dev.pyvista.org/examples/01-filter/flying_edges.html#sphx-glr-examples-01-filter-flying-edges-py) example the text said "flying edges" but the code said `marching_cubes` for the latter part of the example. Since flying edges works too, I changed to code accordingly.
2. In my local build of the [2D streamlines](https://dev.pyvista.org/examples/01-filter/streamlines_2D.html#sphx-glr-examples-01-filter-streamlines-2d-py) example the first block of code with the sphinx gallery comment is somehow empty. Don't know why. I wonder if we should merge that line of code with the subsequent imports, but then the text would read a bit clumsier, so we might also have to rephrase that a bit.
3. In the online docs the [Types of Shading](https://dev.pyvista.org/examples/02-plot/shading.html#sphx-glr-examples-02-plot-shading-py) example has blank black figures at the end (looks fine in [the released `docs.pyvista.org` version](https://docs.pyvista.org/examples/02-plot/shading.html#sphx-glr-examples-02-plot-shading-py)). I wonder if this is somehow related to antialiasing. In any case my local build works fine for these figures.
4. I've expanded the main makefile so that codespell ignores .vtu files. Otherwise my pre-commit hook mentioned in https://github.com/pyvista/pyvista/pull/2029#issuecomment-1013499721 would block committing.