### PR TITLE
Fix chart related warnings during doc building.

### DIFF
--- a/examples/02-plot/chart_basics.py
+++ b/examples/02-plot/chart_basics.py
@@ -110,7 +110,7 @@ chart.show()
 # other dedicated charts you can create. The example below shows how a pie
 # chart can be created.
 
-data = np.array([8.4,6.1,2.7,2.4,0.9])
+data = np.array([8.4, 6.1, 2.7, 2.4, 0.9])
 chart = pv.ChartPie(data)
 chart.plot.labels = [f"slice {i}" for i in range(len(data))]
 chart.show()

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -3962,7 +3962,7 @@ class ChartMPL(_vtk.vtkImageItem, _Chart):
         # once as a pyvista plot (fetched by the 'pyvista' scraper) and once as a
         # matplotlib figure (fetched by the 'matplotlib' scraper).
         # See #1999 and #2031.
-        if pyvista.BUILDING_GALLERY:
+        if pyvista.BUILDING_GALLERY:  # pragma: no cover
             plt.close(self._fig)
 
     @property

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -1031,9 +1031,6 @@ class _Chart(DocSubs):
         if loc is not None:
             self.loc = loc
 
-    def deep_clean(self):
-        """Clean up the chart."""
-
     @property
     def _scene(self):
         """Get a reference to the vtkScene in which this chart is drawn."""
@@ -3960,21 +3957,13 @@ class ChartMPL(_vtk.vtkImageItem, _Chart):
 
         self._redraw()
 
-    def deep_clean(self):
-        """Clean up the chart.
-
-        Notes
-        -----
-        The underlying matplotlib figure is closed and cleaned up.
-        This is necessary while creating the sphinx gallery, as otherwise
-        these charts are drawn twice in example scripts: once as a
-        pyvista plot (fetched by the 'pyvista' scraper) and once as a
-        matplotlib figure (fetched by the 'matplotlib' scraper).
-        """
-        import matplotlib.pyplot as plt
-        plt.close(self._fig)
-        self._fig = None
-        self._canvas = None
+        # Close the underlying matplotlib figure when creating the sphinx gallery.
+        # This prevents the charts from being drawn twice in example scripts:
+        # once as a pyvista plot (fetched by the 'pyvista' scraper) and once as a
+        # matplotlib figure (fetched by the 'matplotlib' scraper).
+        # See #1999 and #2031.
+        if pyvista.BUILDING_GALLERY:
+            plt.close(self._fig)
 
     @property
     def figure(self):
@@ -4157,7 +4146,6 @@ class Charts:
             charts = [*self._charts]  # Make a copy, as this list will be modified by remove_plot
             for chart in charts:
                 self.remove_chart(chart)
-                chart.deep_clean()
             self._renderer.RemoveActor(self._actor)
         self._scene = None
         self._actor = None


### PR DESCRIPTION
### Overview

Partial fix of #2004 (chart related warnings only).


### Details

The solution to #2004 without breaking the examples fixed in #1999 turned out to be easier than I thought. Closing matplotlib figures using `plt.close(fig)` ensures the matplotlib scraper does not insert an image in the rst file, while it still allows the figure to be correctly displayed/embedded in a `ChartMPL`.
