### PR TITLE
Add find_containing_cell

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2166,12 +2166,12 @@ class DataSet(DataSetFilters, DataObject):
             closest_cells.append(int(cellId))
         return closest_cells[0] if len(closest_cells) == 1 else np.array(closest_cells)
 
-    def find_containing_cell(self, point: Union[int, np.ndarray]) -> Union[int, np.ndarray]:
+    def find_containing_cell(self, point: Union[Sequence, np.ndarray]) -> Union[int, np.ndarray]:
         """Find index of a cell that contains the given point.
 
         Parameters
         ----------
-        point : iterable(float) or np.ndarray
+        point : Sequence(float) or np.ndarray
             Coordinates of point to query (length 3) or a ``numpy`` array of ``n``
             points with shape ``(n, 3)``.
 

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2226,10 +2226,7 @@ class DataSet(DataSetFilters, DataObject):
         locator.SetDataSet(self)
         locator.BuildLocator()
 
-        containing_cells = []
-        for node in point:
-            index = locator.FindCell(node)
-            containing_cells.append(index)
+        containing_cells = [locator.FindCell(node) for node in point]
         return containing_cells[0] if len(containing_cells) == 1 else np.array(containing_cells)
 
     def find_cells_along_line(

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2181,6 +2181,13 @@ class DataSet(DataSetFilters, DataObject):
             Index or indices of the cell in this mesh that contains
             the given point.
 
+        See Also
+        --------
+        DataSet.find_closest_point
+        DataSet.find_closest_cell
+        DataSet.find_cells_along_line
+        DataSet.find_cells_within_bounds
+
         Examples
         --------
         A unit square with 16 equal sized cells is created and a cell

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2188,7 +2188,7 @@ class DataSet(DataSetFilters, DataObject):
 
         >>> import pyvista
         >>> mesh = pyvista.UniformGrid(dims=[5, 5, 1], spacing=[1/4, 1/4, 0])
-        >>> mesh # doctest:+ELLIPSIS
+        >>> mesh
         UniformGrid...
         >>> mesh.find_containing_cell([0.3, 0.3, 0.0])
         5
@@ -2211,16 +2211,17 @@ class DataSet(DataSetFilters, DataObject):
         # check if this is an array of points
         if isinstance(point, np.ndarray):
             if point.ndim > 2:
-                raise ValueError("Array of points must be 2D")
+                raise ValueError("Array of points must be 1D or 2D")
             if point.ndim == 2:
                 if point.shape[1] != 3:
-                    raise ValueError("Array of points must have three values per point")
+                    raise ValueError("Array of points must have three values per point "
+                                     "(shape (n, 3))")
             else:
                 if point.size != 3:
                     raise ValueError("Given point must have three values")
                 point = np.array([point])
         else:
-            raise TypeError("Given point must be an iterable or an array.")
+            raise TypeError("Given point must be a sequence or an array.")
 
         locator = _vtk.vtkCellLocator()
         locator.SetDataSet(self)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -907,6 +907,38 @@ def test_find_closest_cells():
     assert np.allclose(indices, np.arange(mesh.n_faces))
 
 
+def test_find_containing_cell():
+    mesh = pyvista.UniformGrid(dims=[5, 5, 1], spacing=[1/4, 1/4, 0])
+    node = np.array([0.3, 0.3, 0.0])
+
+    with pytest.raises(ValueError):
+        mesh.find_containing_cell([1, 2])
+
+    with pytest.raises(TypeError):
+        # allow Sequence but not Iterable
+        mesh.find_containing_cell({1, 2, 3})
+
+    # array but bad size
+    with pytest.raises(ValueError):
+        mesh.find_containing_cell(np.empty(4))
+
+    index = mesh.find_containing_cell(node)
+    assert index == 5
+
+
+def test_find_containing_cells():
+    mesh = pyvista.UniformGrid(dims=[5, 5, 1], spacing=[1/4, 1/4, 0])
+    # invalid array dim
+    with pytest.raises(ValueError):
+        mesh.find_containing_cell(np.empty((1, 1, 1)))
+
+    # test invalid array size
+    with pytest.raises(ValueError):
+        mesh.find_containing_cell(np.empty((4, 4)))
+
+    indices = mesh.find_containing_cell([[0.3, 0.3, 0], [0.6, 0.6, 0]])
+    assert np.allclose(indices, [5, 10])
+
 def test_find_cells_along_line():
     mesh = pyvista.Cube()
     indices = mesh.find_cells_along_line([0, 0, -1], [0, 0, 1])


### PR DESCRIPTION
### Overview

`find_closest_cell` used to find the containing cell, which was not correct but still useful.  This was corrected in #1740 .  This PR implements the cell containing a point functionality to `find_containing_cell`.

See https://github.com/pyvista/pyvista/discussions/1986#discussioncomment-1991733 for an example of how it is useful.


### Details

This implementation uses the `FindCell` overload that accepts only a single array of length 3, and this was the version used prior to #1740.  This overload has a warning that is not thread safe.  It also has a tolerance of 0.  Another overload allows for choosing tolerance and is possibly thread safe.  But I could not figure out how to implement it without getting segfaults.

