### PR TITLE
Optimize when docker CI workflow is run on PRs

### DIFF
--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -1,5 +1,6 @@
 name: Docker Package
 on:
+  workflow_dispatch:
   push:
     tags: "*"
     branches:

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -13,7 +13,8 @@ env:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository )
+    # For Pull Requests, only runs from `feat`, `fix`, `patch`, or `dependabot`
+    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (startsWith(github.ref, 'refs/heads/feat') || startsWith(github.ref, 'refs/heads/fix') || startsWith(github.ref, 'refs/heads/patch') || startsWith(github.ref, 'refs/heads/dependabot')) )
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -14,7 +14,7 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     # For Pull Requests, only runs from `docker`, `feat`, `fix`, `patch`, or `dependabot`
-    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (startsWith(github.ref, 'refs/heads/feat') || startsWith(github.ref, 'refs/heads/fix') || startsWith(github.ref, 'refs/heads/patch') || startsWith(github.ref, 'refs/heads/dependabot') || startsWith(github.ref, 'refs/heads/docker') )
+    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (startsWith(github.ref, 'refs/heads/feat') || startsWith(github.ref, 'refs/heads/fix') || startsWith(github.ref, 'refs/heads/patch') || startsWith(github.ref, 'refs/heads/dependabot') || startsWith(github.ref, 'refs/heads/docker') ))
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -13,8 +13,8 @@ env:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
-    # For Pull Requests, only runs from `feat`, `fix`, `patch`, or `dependabot`
-    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (startsWith(github.ref, 'refs/heads/feat') || startsWith(github.ref, 'refs/heads/fix') || startsWith(github.ref, 'refs/heads/patch') || startsWith(github.ref, 'refs/heads/dependabot')) )
+    # For Pull Requests, only runs from `docker`, `feat`, `fix`, `patch`, or `dependabot`
+    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (startsWith(github.ref, 'refs/heads/feat') || startsWith(github.ref, 'refs/heads/fix') || startsWith(github.ref, 'refs/heads/patch') || startsWith(github.ref, 'refs/heads/dependabot') || startsWith(github.ref, 'refs/heads/docker') )
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
This changes when the docker CI workflow runs and publishes an image to the container registry. To optimize build times and package storage space, these changes make it so that only PRs from the following branches are built:

- `docker/*`
- `feat/*`
- `patch/*`
- `fix/*`
- `dependabot/*`

My reasoning is that we only need to pull docker images for code-changing PRs - other PRs, e.g. `maint/`, push a lot of noise to the container package (adding too many labels) and eating up storage space.

Please note this adds a `workflow_dispatch` trigger that can run the workflow for any branch regardless of these conditions