### PR TITLE
fix collections.abc deprecation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 CODE_DIRS ?= doc examples examples_flask pyvista tests
 # Files in top level directory
 CODE_FILES ?= *.py *.rst *.md
-CODESPELL_SKIP ?= "*.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.vtu,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,./doc/_build/*,./doc/images/*,./dist/*,*~,.hypothesis*,./doc/examples/*,*.mypy_cache/*,*cover,./tests/tinypages/_build/*,*/_autosummary/*"
+CODESPELL_SKIP ?= "*.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.vtu,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,./doc/_build/_static/*,./doc/images/*,./dist/*,*~,.hypothesis*,./doc/examples/*,*.mypy_cache/*,*cover,./tests/tinypages/_build/*,*/_autosummary/*"
 CODESPELL_IGNORE ?= "ignore_words.txt"
 
 # doctest modules must be off screen to avoid plotting everything

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1,5 +1,5 @@
 """Sub-classes and wrappers for vtk.vtkPointSet."""
-import collections
+from collections.abc import Iterable
 from functools import wraps
 import logging
 import numbers
@@ -1884,7 +1884,7 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
         if len(key) != 3:
             raise RuntimeError('Slices must have exactly 3 dimensions.')
         for i, k in enumerate(key):
-            if isinstance(k, collections.Iterable):
+            if isinstance(k, Iterable):
                 raise RuntimeError('Fancy indexing is not supported.')
             if isinstance(k, numbers.Integral):
                 start = stop = k


### PR DESCRIPTION
Fix Python 3.10 bug due to deprication of importing from `collections.abc`.  See:
https://programmerah.com/solved-python-using-or-importing-the-abcs-from-collections-instead-of-from-collections-abc-is-deprecate-32596/

---

I'll be putting #2044 into draft as it's too much to "officially" support Python 3.10 via CI/CD until Kitware can generate a wheel for Python 3.10. I'm hoping based on their latest press releases that it will happen this Spring with the release of 9.2.
