### PR TITLE
Add dataset attributes to the docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 CODE_DIRS ?= doc examples examples_flask pyvista tests
 # Files in top level directory
 CODE_FILES ?= *.py *.rst *.md
-CODESPELL_SKIP ?= "*.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.vtu,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,./doc/_build/*,./doc/images/*,./dist/*,*~,.hypothesis*,./doc/examples/*,*.mypy_cache/*,*cover,./tests/tinypages/_build/*,*/_autosummary/*"
+CODESPELL_SKIP ?= "*.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.vtu,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,doc/_build/*,./doc/images/*,./dist/*,*~,.hypothesis*,./doc/examples/*,*.mypy_cache/*,*cover,./tests/tinypages/_build/*,*/_autosummary/*"
 CODESPELL_IGNORE ?= "ignore_words.txt"
 
 # doctest modules must be off screen to avoid plotting everything

--- a/doc/api/core/dataset.rst
+++ b/doc/api/core/dataset.rst
@@ -10,8 +10,10 @@ In VTK, datasets consist of geometry, topology, and attributes to which PyVista
 provides direct access:
 
 * Geometry is the collection of points and cells in 2D or 3D space.
-* Topology defines the structure of the dataset, or how the points are connected to each other to form a cells making a surface or volume.
-* Attributes are any data values that are associated to either the points or cells of the dataset
+* Topology defines the structure of the dataset, or how the points are connected
+  to each other to form a cells making a surface or volume.
+* Attributes are any data values that are associated to either the points or
+  cells of the dataset
 
 All of the following data types are listed subclasses of a dataset and share a
 set of common functionality which we wrap into the base class
@@ -27,11 +29,13 @@ The :class:`pyvista.DataSet` class holds attributes that
 are *common* to all spatially referenced datasets in PyVista.  This
 base class is analogous to VTK's `vtk.vtkDataSet`_ class.
 
+The :class:`pyvista.DataSetAttributes` class contains the methods to access arrays associated with cells, points, and the DataSet in general (fields).
+
 .. autosummary::
    :toctree: _autosummary
    :template: custom-class-template.rst
 
    pyvista.DataSet
-
+   pyvista.DataSetAttributes
 
 .. _vtk.vtkDataSet: https://vtk.org/doc/nightly/html/classvtkDataSet.html

--- a/doc/api/core/dataset.rst
+++ b/doc/api/core/dataset.rst
@@ -29,7 +29,8 @@ The :class:`pyvista.DataSet` class holds attributes that
 are *common* to all spatially referenced datasets in PyVista.  This
 base class is analogous to VTK's `vtk.vtkDataSet`_ class.
 
-The :class:`pyvista.DataSetAttributes` class contains the methods to access arrays associated with cells, points, and the DataSet in general (fields).
+The :class:`pyvista.DataSetAttributes` class contains the methods to access
+arrays associated with cells, points, and the DataSet in general (fields).
 
 .. autosummary::
    :toctree: _autosummary

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -196,6 +196,7 @@ numpydoc_validation_exclude = {  # set of regex
     r'\.*boolean_cut$',
     r'\.*add_field_array$',
     r'\.*add_field_array$',
+    r'DataSetAttributes.append$',
 
     # methods we probably should make private
     r'\.store_click_position$',

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -69,6 +69,15 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
     association : FieldAssociation
         The array association type of the vtkobject.
 
+    Notes
+    -----
+    When printing out the point arrays, you can see which arrays are
+    the active scalars, vectors, normals, and texture coordinates.
+    In the arrays list, ``SCALARS`` denotes that these are the active
+    scalars, ``VECTORS`` denotes that these arrays are tagged as the
+    active vectors data (i.e. data with magnitude and direction) and
+    so on.
+
     Examples
     --------
     Store data with point association in a DataSet.
@@ -85,6 +94,11 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
     >>> data[:] = 0
     >>> mesh.point_data['my_data']
     pyvista_ndarray([0, 0, 0, 0, 0, 0, 0, 0])
+
+    Remove the array.
+
+    >>> del mesh.point_data['my_data']
+    >>> 'my_data' in mesh.point_data
 
     Print the available arrays from dataset attributes.
 
@@ -110,15 +124,6 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         my-other-data           int64    (4,)
         vectors1                float64  (4, 3)               VECTORS
         vectors0                float64  (4, 3)
-
-    Notes
-    -----
-    When printing out the point arrays, you can see which arrays are
-    the active scalars, vectors, normals, and texture coordinates.
-    In the arrays list, ``SCALARS`` denotes that these are the active
-    scalars, ``VECTORS`` denotes that these arrays are tagged as the
-    active vectors data (i.e. data with magnitude and direction) and
-    so on.
 
     """
 
@@ -496,6 +501,13 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         KeyError
             If the key does not exist.
 
+        Notes
+        -----
+        This is provided since arrays are ordered within VTK and can
+        be indexed via an int.  When getting an array, you can just
+        use the key of the array with the ``[]`` operator with the
+        name of the array.
+
         Examples
         --------
         Store data with point association in a DataSet.
@@ -514,13 +526,6 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
         >>> mesh.point_data.get_array('my_data')
         pyvista_ndarray([0, 1, 2, 3, 4, 5, 6, 7])
-
-        Notes
-        -----
-        This is provided since arrays are ordered within VTK and can
-        be indexed via an int.  When getting an array, you can just
-        use the key of the array with the ``[]`` operator with the
-        name of the array.
 
         """
         self._raise_index_out_of_bounds(index=key)
@@ -562,6 +567,12 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         deep_copy : bool, optional
             When ``True`` makes a full copy of the array.
 
+        Notes
+        -----
+        You can simply use the ``[]`` operator to add an array to the
+        dataset.  Note that this will automatically become the active
+        scalars.
+
         Examples
         --------
         Add a point array to a mesh.
@@ -586,12 +597,6 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         >>> mesh.field_data.set_array(field_data, 'my-data')
         >>> mesh.field_data['my-data']
         pyvista_ndarray([0, 1, 2])
-
-        Notes
-        -----
-        You can simply use the ``[]`` operator to add an array to the
-        dataset.  Note that this will automatically become the active
-        scalars.
 
         """
         vtk_arr = self._prepare_array(data, name, deep_copy)
@@ -675,6 +680,17 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
             ``False``, the data references the original array
             without copying it.
 
+        Notes
+        -----
+        PyVista and VTK treats vectors and scalars differently when
+        performing operations. Vector data, unlike scalar data, is
+        rotated along with the geometry when the DataSet is passed
+        through a transformation filter.
+
+        When adding non-directional data (such temperature values or
+        multi-component scalars like RGBA values), you can also use
+        :func:`DataSetAttributes.set_scalars`.
+
         Examples
         --------
         Add random vectors to a mesh as point data.
@@ -694,17 +710,6 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         Active Normals  : None
         Contains arrays :
             my-vectors              float64  (8, 3)               VECTORS
-
-        Notes
-        -----
-        PyVista and VTK treats vectors and scalars differently when
-        performing operations. Vector data, unlike scalar data, is
-        rotated along with the geometry when the DataSet is passed
-        through a transformation filter.
-
-        When adding non-directional data (such temperature values or
-        multi-component scalars like RGBA values), you can also use
-        :func:`DataSetAttributes.set_scalars`.
 
         """
         # prepare the array and add an attribute so that we can track this as a vector
@@ -825,6 +830,10 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         key : str
             The name of the array to remove.
 
+        Notes
+        -----
+        You can also use the ``del`` statement.
+
         Examples
         --------
         Add a point data array to a DataSet and then remove it.
@@ -838,10 +847,6 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
         >>> 'my_data' in mesh.point_data
         False
-
-        Notes
-        -----
-        You can also use the ``del`` statement.
 
         """
         if not isinstance(key, str):
@@ -906,6 +911,11 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
     def items(self) -> List[Tuple[str, pyvista_ndarray]]:
         """Return a list of (array name, array value) tuples.
 
+        Returns
+        -------
+        list
+            List of keys and values.
+
         Examples
         --------
         >>> import pyvista
@@ -921,6 +931,11 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
     def keys(self) -> List[str]:
         """Return the names of the arrays as a list.
+
+        Returns
+        -------
+        list
+            List of keys.
 
         Examples
         --------
@@ -948,6 +963,11 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
     def values(self) -> List[pyvista_ndarray]:
         """Return the arrays as a list.
+
+        Returns
+        -------
+        list
+            List of arrays.
 
         Examples
         --------
@@ -992,13 +1012,39 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
     def update(self, array_dict: Union[Dict[str, np.ndarray], 'DataSetAttributes']):
         """Update arrays in this object.
 
-        For each key, value given, add the pair, if it already exists,
+        For each key, value given, add the pair. If it already exists,
         update it.
 
         Parameters
         ----------
         array_dict : dict
-            A dictionary of (array name, numpy.ndarray)
+            A dictionary of ``(array name, numpy.ndarray)``.
+
+        Examples
+        --------
+        Add two arrays using ``update``.
+
+        >>> import numpy as np
+        >>> from pyvista import examples
+        >>> mesh = examples.load_uniform()
+        >>> n = len(mesh.point_data)
+        >>> arrays = {
+        ...     'foo': np.arange(mesh.n_points),
+        ...     'rand': np.random.random(mesh.n_points),
+        ... }
+        >>> mesh.point_data.update(arrays)
+        >>> mesh.point_data
+        pyvista DataSetAttributes
+        Association     : POINT
+        Active Scalars  : rand
+        Active Vectors  : None
+        Active Texture  : None
+        Active Normals  : None
+        Contains arrays :
+            Spatial Point Data      float64  (1000,)
+            foo                     int64    (1000,)
+            rand                    float64  (1000,)              SCALARS
+
         """
         for name, array in array_dict.items():
             self[name] = array.copy()
@@ -1111,6 +1157,10 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
             Normals of this dataset attribute.  ``None`` if no
             normals have been set.
 
+        Notes
+        -----
+        Field data will have no normals.
+
         Examples
         --------
         First, compute cell normals.
@@ -1149,10 +1199,6 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         Contains arrays :
             Normals                 float64  (1, 3)               NORMALS
 
-        Notes
-        -----
-        Field data will have no normals.
-
         """
         self._raise_no_normals()
         vtk_normals = self.GetNormals()
@@ -1183,7 +1229,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         """Return or set the name of the normals array.
 
         Returns
-        --------
+        -------
         str
             Name of the active normals array.
 

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -99,6 +99,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
     >>> del mesh.point_data['my_data']
     >>> 'my_data' in mesh.point_data
+    False
 
     Print the available arrays from dataset attributes.
 


### PR DESCRIPTION
As pointed out in https://github.com/pyvista/pyvista/discussions/2097#discussioncomment-2070356 by @MatthewFlamm, we're missing documentation for ``pyvista.DataSetAttributes``.

This PR add the documentation and fixes the class and method docstrings due to the various numpydoc validation warnings.
