### PR TITLE
Fix CI conditionals based on branch names

### DIFF
--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -16,7 +16,15 @@ jobs:
     name: Build and Publish Docker Image
     runs-on: ubuntu-latest
     # For Pull Requests, only runs from `docker`, `feat`, `fix`, `patch`, or `dependabot`
-    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (startsWith(github.ref, 'refs/heads/feat') || startsWith(github.ref, 'refs/heads/fix') || startsWith(github.ref, 'refs/heads/patch') || startsWith(github.ref, 'refs/heads/dependabot') || startsWith(github.ref, 'refs/heads/docker') ))
+    if: github.event_name == 'push' ||
+        ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository &&
+          ( startsWith(github.event.pull_request.head.ref, 'feat') ||
+            startsWith(github.event.pull_request.head.ref, 'fix') ||
+            startsWith(github.event.pull_request.head.ref, 'patch') ||
+            startsWith(github.event.pull_request.head.ref, 'dependabot') ||
+            startsWith(github.event.pull_request.head.ref, 'docker')
+          )
+        )
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -16,9 +16,13 @@ jobs:
 
     # Label based on branch name
     - uses: actions-ecosystem/action-add-labels@v1
-      if: startsWith(github.event.pull_request.head.ref, 'doc')
+      if: startsWith(github.event.pull_request.head.ref, 'doc/') || startsWith(github.event.pull_request.head.ref, 'docs')
       with:
         labels: documentation
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: startsWith(github.event.pull_request.head.ref, 'docker')
+      with:
+        labels: docker
     - uses: actions-ecosystem/action-add-labels@v1
       if: startsWith(github.event.pull_request.head.ref, 'maint') || startsWith(github.event.pull_request.head.ref, 'no-ci') || startsWith(github.event.pull_request.head.ref, 'ci')
       with:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened]
 
 jobs:
@@ -16,23 +16,23 @@ jobs:
 
     # Label based on branch name
     - uses: actions-ecosystem/action-add-labels@v1
-      if: startsWith(github.ref, 'refs/heads/doc')
+      if: startsWith(github.event.pull_request.head.ref, 'doc')
       with:
         labels: documentation
     - uses: actions-ecosystem/action-add-labels@v1
-      if: startsWith(github.ref, 'refs/heads/maint') || startsWith(github.ref, 'refs/heads/no-ci') || startsWith(github.ref, 'refs/heads/ci')
+      if: startsWith(github.event.pull_request.head.ref, 'maint') || startsWith(github.event.pull_request.head.ref, 'no-ci') || startsWith(github.event.pull_request.head.ref, 'ci')
       with:
         labels: maintenance
     - uses: actions-ecosystem/action-add-labels@v1
-      if: startsWith(github.ref, 'refs/heads/junk')
+      if: startsWith(github.event.pull_request.head.ref, 'junk')
       with:
         labels: ignore-for-release
     - uses: actions-ecosystem/action-add-labels@v1
-      if: startsWith(github.ref, 'refs/heads/feat')
+      if: startsWith(github.event.pull_request.head.ref, 'feat')
       with:
         labels: enhancement
 
     - uses: actions-ecosystem/action-add-labels@v1
-      if: startsWith(github.ref, 'refs/heads/fix') || startsWith(github.ref, 'refs/heads/patch')
+      if: startsWith(github.event.pull_request.head.ref, 'fix') || startsWith(github.event.pull_request.head.ref, 'patch')
       with:
         labels: bug-fix


### PR DESCRIPTION
Fixes `if:` conditions on jobs within `pull_request` events. `github.ref` is the target branch on PRs and we need `github.event.pull_request.head.ref` to check the PRs branch name