### PR TITLE
run docbuild on main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,8 @@ on:
   push:
     tags:
       - '*'
+    branches:
+      - main
 
 env:
   USE_CACHE: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.cache == 'true') || (github.event_name == 'pull_request') }}


### PR DESCRIPTION
Noticed that we have cache misses for our examples data and many of the other caches. Reason for this from [
Actions/cache: Cache not being hit despite of being present](https://github.community/t/actions-cache-cache-not-being-hit-despite-of-being-present/17956):

> It’s recommended that you have a workflow run on your default branch (usually master ) so that worklows on other branches will have a cache to restore from.

This PR makes our docbuild run on `main`, which is needed for the `deploy` step to update our dev docs.
