### PR TITLE
Improve gif animation examples

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ on:
       - '*'
 
 env:
-  USE_CACHE: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.cache == 'true') || (github.event_name == 'pull_request') }}
+  USE_CACHE: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.cache == 'true') || (github.event_name == 'pull_request') || (github.event_name == 'push') }}
 
 jobs:
   doc:

--- a/examples/00-load/reader.py
+++ b/examples/00-load/reader.py
@@ -152,9 +152,8 @@ plotter.open_gif("wave_pvd.gif")
 for time_value in reader.time_values:
     reader.set_active_time_value(time_value)
     mesh = reader.read()[0]  # This dataset only has 1 block
-    plotter.add_mesh(mesh, scalars='z', show_scalar_bar=False)
+    plotter.add_mesh(mesh, scalars='z', show_scalar_bar=False, lighting=False)
     plotter.add_text(f"Time: {time_value:.0f}", color="black")
-    plotter.render()
     plotter.write_frame()
     plotter.clear()
 

--- a/examples/02-plot/gif.py
+++ b/examples/02-plot/gif.py
@@ -3,16 +3,20 @@
 
 Create a GIF Movie
 ~~~~~~~~~~~~~~~~~~
+Generate a moving gif from an active plotter.
 
-Generate a moving gif from an active plotter
+.. note::
+   Use ``lighting=False`` to reduce the size of the color space to avoid
+   "jittery" GIFs, especially for the scalar bar.
+
 """
 
 import numpy as np
 
 import pyvista as pv
 
-x = np.arange(-10, 10, 0.25)
-y = np.arange(-10, 10, 0.25)
+x = np.arange(-10, 10, 0.5)
+y = np.arange(-10, 10, 0.5)
 x, y = np.meshgrid(x, y)
 r = np.sqrt(x ** 2 + y ** 2)
 z = np.sin(r)
@@ -22,7 +26,14 @@ grid = pv.StructuredGrid(x, y, z)
 
 # Create a plotter object and set the scalars to the Z height
 plotter = pv.Plotter(notebook=False, off_screen=True)
-plotter.add_mesh(grid, scalars=z.ravel(), smooth_shading=True)
+plotter.add_mesh(
+    grid,
+    scalars=z.ravel(),
+    lighting=False,
+    show_edges=True,
+    scalar_bar_args={"title": "Height"},
+    clim=[-1, 1],
+)
 
 # Open a gif
 plotter.open_gif("wave.gif")
@@ -37,9 +48,7 @@ for phase in np.linspace(0, 2 * np.pi, nframe + 1)[:nframe]:
     plotter.update_coordinates(pts, render=False)
     plotter.update_scalars(z.ravel(), render=False)
 
-    # must update normals when smooth shading is enabled
-    plotter.mesh.compute_normals(cell_normals=False, inplace=True)
-    plotter.render()
+    # Write a frame. This triggers a render.
     plotter.write_frame()
 
 # Closes and finalizes movie

--- a/examples/02-plot/isovalue.py
+++ b/examples/02-plot/isovalue.py
@@ -34,12 +34,17 @@ surface = surfaces[0].copy()
 
 filename = "isovalue.gif"
 
-plotter = pv.Plotter()
+plotter = pv.Plotter(off_screen=True)
 # Open a movie file
 plotter.open_gif(filename)
 
 # Add initial mesh
-plotter.add_mesh(surface, opacity=0.5, clim=vol.get_data_range())
+plotter.add_mesh(
+    surface,
+    opacity=0.5,
+    clim=vol.get_data_range(),
+    show_scalar_bar=False,
+)
 # Add outline for reference
 plotter.add_mesh(vol.outline_corners(), color='k')
 

--- a/examples/02-plot/orbit.py
+++ b/examples/02-plot/orbit.py
@@ -12,7 +12,13 @@ Orbit around a scene.
    ``p.open_gif('orbit.gif')``
 
 For orbiting to work you first have to show the scene and leave the plotter open
-with ``.show(auto_close=False)``.
+with ``.show(auto_close=False)``.  You may also have to set
+``pv.Plotter(off_screen=True)``
+
+.. note::
+   Use ``lighting=False`` to reduce the size of the color space to avoid
+   "jittery" GIFs when showing the scalar bar.
+
 """
 
 # sphinx_gallery_thumbnail_number = 2
@@ -22,19 +28,22 @@ from pyvista import examples
 mesh = examples.download_st_helens().warp_by_scalar()
 
 ###############################################################################
+# Orbit around the Mt. St Helens dataset.
 
 p = pv.Plotter()
-p.add_mesh(mesh)
+p.add_mesh(mesh, lighting=False)
+p.camera.zoom(1.5)
 p.show(auto_close=False)
 path = p.generate_orbital_path(n_points=36, shift=mesh.length)
 p.open_gif("orbit.gif")
 p.orbit_on_path(path, write_frames=True)
 p.close()
 
+
 ###############################################################################
 
 p = pv.Plotter()
-p.add_mesh(mesh)
+p.add_mesh(mesh, lighting=False)
 p.show_grid()
 p.show(auto_close=False)
 viewup = [0.5, 0.5, 1]

--- a/examples/02-plot/texture.py
+++ b/examples/02-plot/texture.py
@@ -143,7 +143,6 @@ for phase in np.linspace(0, 2 * np.pi, nframe + 1)[:nframe]:
 
     # must update normals when smooth shading is enabled
     plotter.mesh.compute_normals(cell_normals=False, inplace=True)
-    plotter.render()
     plotter.write_frame()
     plotter.clear()
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -817,23 +817,26 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.renderer.disable_anti_aliasing(*args, **kwargs)
 
     @wraps(Renderer.set_focus)
-    def set_focus(self, *args, **kwargs):
+    def set_focus(self, *args, render=True, **kwargs):
         """Wrap ``Renderer.set_focus``."""
         log.debug('set_focus: %s, %s', str(args), str(kwargs))
         self.renderer.set_focus(*args, **kwargs)
-        self.render()
+        if render:
+            self.render()
 
     @wraps(Renderer.set_position)
-    def set_position(self, *args, **kwargs):
+    def set_position(self, *args, render=True, **kwargs):
         """Wrap ``Renderer.set_position``."""
         self.renderer.set_position(*args, **kwargs)
-        self.render()
+        if render:
+            self.render()
 
     @wraps(Renderer.set_viewup)
-    def set_viewup(self, *args, **kwargs):
+    def set_viewup(self, *args, render=True, **kwargs):
         """Wrap ``Renderer.set_viewup``."""
         self.renderer.set_viewup(*args, **kwargs)
-        self.render()
+        if render:
+            self.render()
 
     @wraps(Renderer.add_orientation_widget)
     def add_orientation_widget(self, *args, **kwargs):
@@ -4073,9 +4076,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
             for point in points_seq:
                 tstart = time.time()  # include the render time in the step time
-                self.set_position(point)
-                self.set_focus(focus)
-                self.set_viewup(viewup)
+                self.set_position(point, render=False)
+                self.set_focus(focus, render=False)
+                self.set_viewup(viewup, render=False)
                 self.renderer.ResetCameraClippingRange()
                 if write_frames:
                     self.write_frame()


### PR DESCRIPTION
This PR resolves #2073 by adding a note in our [Create a GIF Movie](https://docs.pyvista.org/examples/02-plot/gif.html) by noting that when you are using a scalar bar, it's best to turn lighting off.

Additional fixes:
- We actually call the render pipeline 4 times in `orbit()` as setting the camera position and orientation triggers a render. This PR also adds a keyword argument within `pyvista.Plotter` to allow you to disable that.
- Minor documentation fixes
- Minor tweaks to the `Create a GIF Movie` example.
- Ensure we save cache on the `main` branch.