### PR TITLE
Update ipyvtklink docs

### DIFF
--- a/doc/user-guide/jupyter/ipyvtk_plotting.rst
+++ b/doc/user-guide/jupyter/ipyvtk_plotting.rst
@@ -53,7 +53,7 @@ Where environment.yml is:
       - conda-forge
       - defaults
     dependencies:
-      - jupyterlab
+      - jupyterlab >=3
       - ipywidgets
       - pyvista
       - ipyvtklink
@@ -62,7 +62,7 @@ Using pip, you can setup your jupyterlab environment with:
 
 .. code::
 
-    pip install jupyterlab ipywidgets pyvista[all] ipyvtklink
+    pip install 'jupyterlab>=3' ipywidgets 'pyvista[all]' ipyvtklink
 
 
 

--- a/doc/user-guide/jupyter/ipyvtk_plotting.rst
+++ b/doc/user-guide/jupyter/ipyvtk_plotting.rst
@@ -58,12 +58,13 @@ Where environment.yml is:
       - jupyterlab
       - ipywidgets
       - pyvista
+      - ipyvtklink
 
 On Linux, you can setup your jupyterlab environment with:
 
 .. code::
 
-    pip install jupyterlab ipywidgets pyvista
+    pip install jupyterlab ipywidgets pyvista ipyvtklink
     sudo apt install nodejs
     jupyter labextension install @jupyter-widgets/jupyterlab-manager@2.0 ipycanvas@0.6.1 ipyevents@1.8.1
 

--- a/doc/user-guide/jupyter/ipyvtk_plotting.rst
+++ b/doc/user-guide/jupyter/ipyvtk_plotting.rst
@@ -3,11 +3,6 @@
 Using ``ipyvtklink`` with PyVista
 ---------------------------------
 
-.. note::
-   As of version ``0.1.4``, ``ipyvtklink`` does not support
-   Jupyterlab 3.  Attempting to run the following will return a
-   ``Model not found`` error within jupyterlab.
-
 ``pyvista`` has the ability to display fully featured plots within a
 JupyterLab environment using ``ipyvtklink``.  This feature works by
 streaming the current render window to a canvas within JupyterLab and
@@ -16,8 +11,7 @@ window.
 
 While this isn't an exciting feature when JupyterLab is being run
 locally, this has huge implications when plotting remotely as you can
-display any plot (except for those with multiple render windows) from
-JupyterLab.
+display any plot, with subplots and widgets, from JupyterLab.
 
 For example, both sections of code will display an interactive canvas
 within JupyterLab:
@@ -40,7 +34,7 @@ For convenience, you can enable ``ipyvtklink`` by default with:
 .. code:: python
 
     import pyvista
-    pyvista.global_theme.jupyter_backend = 'ipyvtklink'
+    pyvista.set_jupyter_backend('ipyvtklink')
 
 
 Installation
@@ -51,7 +45,7 @@ If you're using an Anaconda environment, installation is the quite straightforwa
 
     conda env update --name base --file environment.yml
     conda run conda install -y nodejs
-    conda run jupyter labextension install @jupyter-widgets/jupyterlab-manager@2.0 itkwidgets@0.32.0 ipycanvas@0.6.1 ipyevents@1.8.1
+    conda run jupyter labextension install @jupyter-widgets/jupyterlab-manager@2.0 ipycanvas@0.6.1 ipyevents@1.8.1
 
 Where environment.yml is:
 
@@ -61,18 +55,17 @@ Where environment.yml is:
       - conda-forge
       - defaults
     dependencies:
-      - jupyterlab=2.2.9
-      - itkwidgets=0.32.0
-      - ipywidgets=7.5.1
-      - pyvista=0.27.0
+      - jupyterlab
+      - ipywidgets
+      - pyvista
 
 On Linux, you can setup your jupyterlab environment with:
 
 .. code::
 
-    pip install jupyterlab itkwidgets==0.32.0 ipywidgets=7.5.1 pyvista
+    pip install jupyterlab ipywidgets pyvista
     sudo apt install nodejs
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager@2.0 itkwidgets@0.32.0 ipycanvas@0.6.1 ipyevents@1.8.1
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager@2.0 ipycanvas@0.6.1 ipyevents@1.8.1
 
 
 

--- a/doc/user-guide/jupyter/ipyvtk_plotting.rst
+++ b/doc/user-guide/jupyter/ipyvtk_plotting.rst
@@ -57,6 +57,7 @@ Where environment.yml is:
       - ipywidgets
       - pyvista
       - ipyvtklink
+      - matplotlib
 
 Using pip, you can setup your jupyterlab environment with:
 

--- a/doc/user-guide/jupyter/ipyvtk_plotting.rst
+++ b/doc/user-guide/jupyter/ipyvtk_plotting.rst
@@ -43,9 +43,7 @@ If you're using an Anaconda environment, installation is the quite straightforwa
 
 .. code::
 
-    conda env update --name base --file environment.yml
-    conda run conda install -y nodejs
-    conda run jupyter labextension install @jupyter-widgets/jupyterlab-manager ipycanvas ipyevents
+    conda env create --name pyvista --file environment.yml
 
 Where environment.yml is:
 
@@ -65,8 +63,6 @@ Using pip, you can setup your jupyterlab environment with:
 .. code::
 
     pip install jupyterlab ipywidgets pyvista[all] ipyvtklink
-    sudo apt install nodejs
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager ipycanvas ipyevents
 
 
 

--- a/doc/user-guide/jupyter/ipyvtk_plotting.rst
+++ b/doc/user-guide/jupyter/ipyvtk_plotting.rst
@@ -64,7 +64,7 @@ On Linux, you can setup your jupyterlab environment with:
 
 .. code::
 
-    pip install jupyterlab ipywidgets pyvista ipyvtklink
+    pip install jupyterlab ipywidgets pyvista[all] ipyvtklink
     sudo apt install nodejs
     jupyter labextension install @jupyter-widgets/jupyterlab-manager ipycanvas ipyevents
 

--- a/doc/user-guide/jupyter/ipyvtk_plotting.rst
+++ b/doc/user-guide/jupyter/ipyvtk_plotting.rst
@@ -60,7 +60,7 @@ Where environment.yml is:
       - pyvista
       - ipyvtklink
 
-On Linux, you can setup your jupyterlab environment with:
+Using pip, you can setup your jupyterlab environment with:
 
 .. code::
 

--- a/doc/user-guide/jupyter/ipyvtk_plotting.rst
+++ b/doc/user-guide/jupyter/ipyvtk_plotting.rst
@@ -45,7 +45,7 @@ If you're using an Anaconda environment, installation is the quite straightforwa
 
     conda env update --name base --file environment.yml
     conda run conda install -y nodejs
-    conda run jupyter labextension install @jupyter-widgets/jupyterlab-manager@2.0 ipycanvas@0.6.1 ipyevents@1.8.1
+    conda run jupyter labextension install @jupyter-widgets/jupyterlab-manager ipycanvas ipyevents
 
 Where environment.yml is:
 
@@ -66,7 +66,7 @@ On Linux, you can setup your jupyterlab environment with:
 
     pip install jupyterlab ipywidgets pyvista ipyvtklink
     sudo apt install nodejs
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager@2.0 ipycanvas@0.6.1 ipyevents@1.8.1
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager ipycanvas ipyevents
 
 
 


### PR DESCRIPTION
Resolves #2050 to update the documentation for using `ipyvtklink`

Changes:

- Do not pin versions of packages
- Do not include itkwidgets
- Update notes about JupyterLab 3 as ipyvtklinks dependencies handle it now
- Update to use `set_jupyter_backend` in example
- Remove `labextension` commands
- Explicitly require JupyterLab `>=3`