### PR TITLE
Use `python -m pip` in windows ci

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -229,7 +229,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Upgrade pip
-        run: pip install --upgrade 'pip<22.0'
+        run: python -m pip install --upgrade
 
       - name: Set pip cache dir as env variable
         run: |

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -229,7 +229,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Upgrade pip
-        run: python -m pip install --upgrade
+        run: python -m pip install --upgrade pip
 
       - name: Set pip cache dir as env variable
         run: |


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

Windows CI is failing again due to pip permissions issues.

I think previously pinning pip only served to prevent it from updating.  They must have changed the default pip version on the ci image and now it is trying to change versions again.

Windows is weird.  I always use `python -m pip install pip` to avoid problems on windows.  
