### PR TITLE
Make label action work for first time contributors

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
 
 jobs:


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->
#2136 shows that the label workflow won't work for first time contributors due to Actions permissions.  Using `pull_request_target` makes the label use the PR base branch rather than the PR merged in.

### Details

- < feature1 or bug1 description >
- < feature2 or bug2 description >

