### PR TITLE
Fix usage of assert in production code

### DIFF
--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -1101,7 +1101,7 @@ class _Chart(DocSubs):
     @size.setter
     def size(self, val):
         if not (len(val) == 2 and 0 <= val[0] <= 1 and 0 <= val[1] <= 1):
-            raise ValueError('invalid size')
+            raise ValueError(f'Invalid size {val}.')
         self._size = val
 
     @property  # type: ignore
@@ -1128,7 +1128,7 @@ class _Chart(DocSubs):
     @loc.setter
     def loc(self, val):
         if not (len(val) == 2 and 0 <= val[0] <= 1 and 0 <= val[1] <= 1):
-            raise ValueError('invalid loc')
+            raise ValueError(f'Invalid loc {val}.')
         self._loc = val
 
     @property  # type: ignore
@@ -4053,8 +4053,8 @@ class ChartMPL(_vtk.vtkImageItem, _Chart):
 
     @position.setter
     def position(self, val):
-        if not (len(val) == 2):
-            raise ValueError('invalid position, must be length 2')
+        if len(val) != 2:
+            raise ValueError(f'Invalid position {val}, must be length 2.')
         self.SetPosition(*val)
 
     @property

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -4168,8 +4168,8 @@ class Charts:
     def remove_chart(self, chart_or_index):
         """Remove a chart from the collection."""
         chart = self._charts[chart_or_index] if isinstance(chart_or_index, int) else chart_or_index
-        if not (chart in self._charts):
-            raise ValueError('chart_index not present.')
+        if chart not in self._charts:
+            raise ValueError('chart_index not present in charts collection.')
         self._charts.remove(chart)
         self._scene.RemoveItem(chart)
         self._scene.RemoveItem(chart._background)

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -126,7 +126,9 @@ def doc_subs(member):
     necessary because mypy cannot handle decorated properties (see
     https://github.com/python/mypy/issues/1362)
     """
-    assert callable(member)  # Ensure we are operating on a method
+    # Ensure we are operating on a method
+    if not callable(member):
+        raise ValueError('`member` must be a callable.')
     member.__doc__ = DocSubs._DOC_TAG + member.__doc__
     return member
 #endregion
@@ -1098,7 +1100,8 @@ class _Chart(DocSubs):
 
     @size.setter
     def size(self, val):
-        assert len(val) == 2 and 0 <= val[0] <= 1 and 0 <= val[1] <= 1
+        if not (len(val) == 2 and 0 <= val[0] <= 1 and 0 <= val[1] <= 1):
+            raise ValueError('invalid size')
         self._size = val
 
     @property  # type: ignore
@@ -1124,7 +1127,8 @@ class _Chart(DocSubs):
 
     @loc.setter
     def loc(self, val):
-        assert len(val) == 2 and 0 <= val[0] <= 1 and 0 <= val[1] <= 1
+        if not (len(val) == 2 and 0 <= val[0] <= 1 and 0 <= val[1] <= 1):
+            raise ValueError('invalid loc')
         self._loc = val
 
     @property  # type: ignore
@@ -4049,7 +4053,8 @@ class ChartMPL(_vtk.vtkImageItem, _Chart):
 
     @position.setter
     def position(self, val):
-        assert len(val) == 2
+        if not (len(val) == 2):
+            raise ValueError('invalid position, must be length 2')
         self.SetPosition(*val)
 
     @property
@@ -4163,7 +4168,8 @@ class Charts:
     def remove_chart(self, chart_or_index):
         """Remove a chart from the collection."""
         chart = self._charts[chart_or_index] if isinstance(chart_or_index, int) else chart_or_index
-        assert chart in self._charts
+        if not (chart in self._charts):
+            raise ValueError('chart_index not present.')
         self._charts.remove(chart)
         self._scene.RemoveItem(chart)
         self._scene.RemoveItem(chart._background)


### PR DESCRIPTION
The usage of assert in production code is widely frowned upon mainly because running Python in optimized mode (__debug__=False and python -o producing *.pyo files) will skip/ignore the assert statements. 

I turned off the check for `assert` statements due to https://github.com/pyvista/pyvista/pull/2070#issuecomment-1028833556 so we need to be sure not to let these find their way into the library code moving forward.

There is likely a listing rule we can add to our existing lint checks to handle this