### PR TITLE
Fix label mismatch of bug-fix and bug

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -39,4 +39,4 @@ jobs:
     - uses: actions-ecosystem/action-add-labels@v1
       if: startsWith(github.event.pull_request.head.ref, 'fix') || startsWith(github.event.pull_request.head.ref, 'patch')
       with:
-        labels: bug-fix
+        labels: bug


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Fixing the label `bug-fix` of 
https://github.com/pyvista/pyvista/blob/10141a1979d81504806316c008af3d1619d14737/.github/workflows/label.yml#L42
is mismatching with
https://github.com/pyvista/pyvista/blob/10141a1979d81504806316c008af3d1619d14737/.github/release.yml#L13
found in #2139.

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None

