### PR TITLE
Feat/add median filter

### DIFF
--- a/examples/02-plot/moving_cmap.py
+++ b/examples/02-plot/moving_cmap.py
@@ -1,0 +1,80 @@
+"""
+.. _moving_cmap_example:
+
+Create a GIF Movie of a Static Object with a Moving Colormap
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Generate a gif movie of a Hopf torus with a moving colormap,
+by updating the scalars.
+
+"""
+
+import numpy as np
+
+import pyvista as pv
+
+
+# A spherical curve
+def scurve(t):
+    alpha = np.pi / 2 - (np.pi / 2 - 0.44) * np.cos(3 * t)
+    beta = t + 0.44 * np.sin(6 * t)
+    return np.array(
+        [
+          np.sin(alpha) * np.cos(beta),
+          np.sin(alpha) * np.sin(beta),
+          np.cos(alpha)
+        ]
+    )
+
+# Hopf fiber
+def hopf_fiber(p, phi):
+    return (
+        np.array(
+            [
+                (1 + p[2]) * np.cos(phi),
+                p[0] * np.sin(phi) - p[1] * np.cos(phi),
+                p[0] * np.cos(phi) + p[1] * np.sin(phi),
+                (1 + p[2]) * np.sin(phi),
+            ]
+        )
+        / np.sqrt(2 * (1 + p[2]))
+    )
+
+# Stereographic projection
+def stereo_proj(q):
+    return q[0:3] / (1 - q[3])
+
+# Parameterization of the Hopf torus
+def hopf_torus(t, phi):
+    return stereo_proj(hopf_fiber(scurve(t), phi))
+
+# Create the mesh
+angle_u = np.linspace(-np.pi, np.pi, 400)
+angle_v = np.linspace(0, np.pi, 200)
+u, v = np.meshgrid(angle_u, angle_v)
+x, y, z = hopf_torus(u, v)
+grid = pv.StructuredGrid(x, y, z)
+mesh = grid.extract_geometry().clean(tolerance=1e-6)
+
+# Distances normalized to [0, 2*pi]
+dists = np.linalg.norm(mesh.points, axis=1)
+dists = 2 * np.pi * (dists - dists.min()) / (dists.max() - dists.min())
+
+# Make the movie
+pltr = pv.Plotter(window_size=[512, 512])
+pltr.set_focus([0, 0, 0])
+pltr.set_position([40, 0, 0])
+pltr.add_mesh(
+    mesh,
+    scalars=np.sin(dists),
+    smooth_shading=True,
+    specular=10,
+    cmap="nipy_spectral",
+    show_scalar_bar=False,
+)
+pltr.open_gif("Hopf_torus.gif")
+
+for t in np.linspace(0, 2 * np.pi, 60, endpoint=False):
+    pltr.update_scalars(np.sin(dists - t), render=False)
+    pltr.write_frame()
+
+pltr.show()

--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -334,7 +334,7 @@ if VTK9:
         vtkImageFlip,
         vtkRTAnalyticSource,
     )
-    from vtkmodules.vtkImagingGeneral import vtkImageGaussianSmooth
+    from vtkmodules.vtkImagingGeneral import vtkImageGaussianSmooth, vtkImageMedian3D
     from vtkmodules.vtkImagingHybrid import vtkSampleFunction, vtkSurfaceReconstructionFilter
     from vtkmodules.vtkInteractionWidgets import (
         vtkBoxWidget,

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -58,14 +58,17 @@ class UniformGridFilters(DataSetFilters):
         _update_alg(alg, progress_bar, 'Performing Gaussian Smoothing')
         return _get_output(alg)
 
-    def median_smooth(self, kernel_size=3,
+    def median_smooth(self, kernel_size=[3,3,3],
                       scalars=None, preference='points', progress_bar=False):
         ''' Smooth data using a median filter.
 
         Parameters
         ----------
-        kernel_size : int or iterable, optional
-            Size of the kernel in each direction (units of voxels)
+        kernel_size : int or iterable of three ints, optional
+            Size of the kernel in each dimensions (units of voxels). Default is
+            a 3D median filter. If you want to do a 2D median filter, provide
+            a list or tuple of three sizes and set the size to 1 in the
+            dimension you don't want to filter over.
 
         scalars : str, optional
             Name of scalars to process. Defaults to currently active scalars.
@@ -89,7 +92,10 @@ class UniformGridFilters(DataSetFilters):
 
         alg.SetInputArrayToProcess(0, 0, 0, field.value, scalars) # args: (idx, port, connection, field, name)
 
-        
+        # check what dimensions of the dataset have size > 1
+        dim_greaterthan_one =
+
+
 
     def extract_subset(self, voi, rate=(1, 1, 1), boundary=False, progress_bar=False):
         """Select piece (e.g., volume of interest).

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -60,7 +60,7 @@ class UniformGridFilters(DataSetFilters):
 
     def median_smooth(self, kernel_size=[3,3,3],
                       scalars=None, preference='points', progress_bar=False):
-        ''' Smooth data using a median filter.
+        """ Smooth data using a median filter.
 
         Parameters
         ----------
@@ -80,23 +80,17 @@ class UniformGridFilters(DataSetFilters):
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
-        '''
-
+        """
         alg = _vtk.vtkImageMedian3D()
         alg.SetInputDataObject(self)
-
         if scalars is None:
             field, scalars = self.active_scalars_info
         else:
             field = self.get_array_association(scalars, preference=preference)
-
         alg.SetInputArrayToProcess(0, 0, 0, field.value, scalars) # args: (idx, port, connection, field, name)
-
         alg.SetKernelSize(kernel_size[0],kernel_size[1],kernel_size[2])
-
         _update_alg(alg, progress_bar, 'Performing Median Smoothing')
         return _get_output(alg)
-
 
     def extract_subset(self, voi, rate=(1, 1, 1), boundary=False, progress_bar=False):
         """Select piece (e.g., volume of interest).

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -64,7 +64,7 @@ class UniformGridFilters(DataSetFilters):
 
         Parameters
         ----------
-        kernel_size : int or iterable of three ints, optional
+        kernel_size : iterable of three ints
             Size of the kernel in each dimensions (units of voxels). Default is
             a 3D median filter. If you want to do a 2D median filter, provide
             a list or tuple of three sizes and set the size to 1 in the

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -64,7 +64,7 @@ class UniformGridFilters(DataSetFilters):
 
         Parameters
         ----------
-        kernel_size : list(int) or tuple(int)
+        kernel_size : list(int) or tuple(int), optional
             Length 3 list or tuple of ints : ``(x_size, y_size, z_size)``
             Size of the kernel in each dimension (units of voxels). Default is
             a 3D median filter. If you want to do a 2D median filter, set the

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -78,7 +78,9 @@ class UniformGridFilters(DataSetFilters):
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
         '''
-        pass
+
+        alg = _vtk.vtkImageMedian3D()
+        alg.SetInputDataObject(self)
 
     def extract_subset(self, voi, rate=(1, 1, 1), boundary=False, progress_bar=False):
         """Select piece (e.g., volume of interest).

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -89,6 +89,8 @@ class UniformGridFilters(DataSetFilters):
 
         alg.SetInputArrayToProcess(0, 0, 0, field.value, scalars) # args: (idx, port, connection, field, name)
 
+        
+
     def extract_subset(self, voi, rate=(1, 1, 1), boundary=False, progress_bar=False):
         """Select piece (e.g., volume of interest).
 

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -92,9 +92,10 @@ class UniformGridFilters(DataSetFilters):
 
         alg.SetInputArrayToProcess(0, 0, 0, field.value, scalars) # args: (idx, port, connection, field, name)
 
-        # check what dimensions of the dataset have size > 1
-        dim_greaterthan_one =
+        alg.SetKernelSize(kernel_size[0],kernel_size[1],kernel_size[2])
 
+        _update_alg(alg, progress_bar, 'Performing Median Smoothing')
+        return _get_output(alg)
 
 
     def extract_subset(self, voi, rate=(1, 1, 1), boundary=False, progress_bar=False):

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -66,9 +66,8 @@ class UniformGridFilters(DataSetFilters):
         ----------
         kernel_size : iterable of three ints
             Size of the kernel in each dimensions (units of voxels). Default is
-            a 3D median filter. If you want to do a 2D median filter, provide
-            a list or tuple of three sizes and set the size to 1 in the
-            dimension you don't want to filter over.
+            a 3D median filter. If you want to do a 2D median filter, set the
+            size to 1 in the dimension you don't want to filter over.
 
         scalars : str, optional
             Name of scalars to process. Defaults to currently active scalars.

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -64,8 +64,9 @@ class UniformGridFilters(DataSetFilters):
 
         Parameters
         ----------
-        kernel_size : iterable of three ints
-            Size of the kernel in each dimensions (units of voxels). Default is
+        kernel_size : list(int) or tuple(int)
+            Length 3 list or tuple of ints : ``(x_size, y_size, z_size)``
+            Size of the kernel in each dimension (units of voxels). Default is
             a 3D median filter. If you want to do a 2D median filter, set the
             size to 1 in the dimension you don't want to filter over.
 

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -58,6 +58,28 @@ class UniformGridFilters(DataSetFilters):
         _update_alg(alg, progress_bar, 'Performing Gaussian Smoothing')
         return _get_output(alg)
 
+    def median_smooth(self, kernel_size=3,
+                      scalars=None, preference='points', progress_bar=False):
+        ''' Smooth data using a median filter.
+
+        Parameters
+        ----------
+        kernel_size : int or iterable, optional
+            Size of the kernel in each direction (units of voxels)
+
+        scalars : str, optional
+            Name of scalars to process. Defaults to currently active scalars.
+
+        preference : str, optional
+            When scalars is specified, this is the preferred array
+            type to search for in the dataset.  Must be either
+            ``'point'`` or ``'cell'``.
+
+        progress_bar : bool, optional
+            Display a progress bar to indicate progress.
+        '''
+        pass
+
     def extract_subset(self, voi, rate=(1, 1, 1), boundary=False, progress_bar=False):
         """Select piece (e.g., volume of interest).
 

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -94,7 +94,7 @@ class UniformGridFilters(DataSetFilters):
         else:
             field = self.get_array_association(scalars, preference=preference)
         alg.SetInputArrayToProcess(0, 0, 0, field.value, scalars) # args: (idx, port, connection, field, name)
-        alg.SetKernelSize(kernel_size[0],kernel_size[1],kernel_size[2])
+        alg.SetKernelSize(kernel_size[0], kernel_size[1], kernel_size[2])
         _update_alg(alg, progress_bar, 'Performing Median Smoothing')
         return _get_output(alg)
 

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -82,6 +82,13 @@ class UniformGridFilters(DataSetFilters):
         alg = _vtk.vtkImageMedian3D()
         alg.SetInputDataObject(self)
 
+        if scalars is None:
+            field, scalars = self.active_scalars_info
+        else:
+            field = self.get_array_association(scalars, preference=preference)
+
+        alg.SetInputArrayToProcess(0, 0, 0, field.value, scalars) # args: (idx, port, connection, field, name)
+
     def extract_subset(self, voi, rate=(1, 1, 1), boundary=False, progress_bar=False):
         """Select piece (e.g., volume of interest).
 

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -60,7 +60,7 @@ class UniformGridFilters(DataSetFilters):
 
     def median_smooth(self, kernel_size=[3,3,3],
                       scalars=None, preference='points', progress_bar=False):
-        """ Smooth data using a median filter.
+        """Smooth data using a median filter.
 
         Parameters
         ----------
@@ -80,6 +80,12 @@ class UniformGridFilters(DataSetFilters):
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.UniformGrid
+            Uniform grid with smoothed scalars.
+
         """
         alg = _vtk.vtkImageMedian3D()
         alg.SetInputDataObject(self)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1394,6 +1394,9 @@ def test_extract_subset():
     #   https://gitlab.kitware.com/vtk/vtk/-/issues/17938
     assert voi.origin == voi.bounds[::2]
 
+def test_gaussian_smooth():
+    volume = examples.load_uniform()
+    volume_smooth = volume.gaussian_smooth()
 
 def test_extract_subset_structured():
     structured = examples.load_structured()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1397,6 +1397,7 @@ def test_extract_subset():
 def test_gaussian_smooth():
     volume = examples.load_uniform()
     volume_smooth = volume.gaussian_smooth()
+    assert isinstance(volume_smooth, pyvista.UniformGrid)
 
 def test_extract_subset_structured():
     structured = examples.load_structured()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1395,7 +1395,7 @@ def test_extract_subset():
     assert voi.origin == voi.bounds[::2]
 
 
-def test_gaussian_smooth():
+def test_gaussian_smooth_output_type():
     volume = examples.load_uniform()
     volume_smooth = volume.gaussian_smooth()
     assert isinstance(volume_smooth, pyvista.UniformGrid)
@@ -1403,12 +1403,38 @@ def test_gaussian_smooth():
     assert isinstance(volume_smooth, pyvista.UniformGrid)
 
 
-def test_median_smooth():
+def test_gaussian_smooth_constant_data():
+    point_data = np.ones((10,10,10))
+    volume = pv.UniformGrid(dims=(10,10,10))
+    volume.point_data['point_data'] = point_data.flatten(order='F')
+    volume_smoothed = volume.gaussian_smooth()
+    assert np.array_equal(volume.point_data['point_data'],
+                          volume_smoothed.point_data['point_data'])
+
+
+def test_gaussian_smooth_outlier():
+    pass
+
+
+def test_median_smooth_output_type():
     volume = examples.load_uniform()
     volume_smooth = volume.median_smooth()
     assert isinstance(volume_smooth, pyvista.UniformGrid)
     volume_smooth = volume.median_smooth(scalars='Spatial Point Data')
     assert isinstance(volume_smooth, pyvista.UniformGrid)
+
+
+def test_median_smooth_constant_data():
+    point_data = np.ones((10,10,10))
+    volume = pv.UniformGrid(dims=(10,10,10))
+    volume.point_data['point_data'] = point_data.flatten(order='F')
+    volume_smoothed = volume.median_smooth()
+    assert np.array_equal(volume.point_data['point_data'],
+                          volume_smoothed.point_data['point_data'])
+
+
+def test_median_smooth_outlier():
+    pass
 
 
 def test_extract_subset_structured():

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1405,7 +1405,7 @@ def test_gaussian_smooth_output_type():
 
 def test_gaussian_smooth_constant_data():
     point_data = np.ones((10,10,10))
-    volume = pv.UniformGrid(dims=(10,10,10))
+    volume = pyvista.UniformGrid(dims=(10,10,10))
     volume.point_data['point_data'] = point_data.flatten(order='F')
     volume_smoothed = volume.gaussian_smooth()
     assert np.array_equal(volume.point_data['point_data'],
@@ -1415,7 +1415,7 @@ def test_gaussian_smooth_constant_data():
 def test_gaussian_smooth_outlier():
     point_data = np.ones((10,10,10))
     point_data[4,4,4] = 100
-    volume = pv.UniformGrid(dims=(10,10,10))
+    volume = pyvista.UniformGrid(dims=(10,10,10))
     volume.point_data['point_data'] = point_data.flatten(order='F')
     volume_smoothed = volume.gaussian_smooth()
     assert (volume_smoothed.get_data_range()[1]<volume.get_data_range()[1])
@@ -1431,7 +1431,7 @@ def test_median_smooth_output_type():
 
 def test_median_smooth_constant_data():
     point_data = np.ones((10,10,10))
-    volume = pv.UniformGrid(dims=(10,10,10))
+    volume = pyvista.UniformGrid(dims=(10,10,10))
     volume.point_data['point_data'] = point_data.flatten(order='F')
     volume_smoothed = volume.median_smooth()
     assert np.array_equal(volume.point_data['point_data'],
@@ -1442,9 +1442,9 @@ def test_median_smooth_outlier():
     point_data = np.ones((10,10,10))
     point_data_outlier = point_data.copy()
     point_data_outlier[4,4,4] = 100
-    volume = pv.UniformGrid(dims=(10,10,10))
+    volume = pyvista.UniformGrid(dims=(10,10,10))
     volume.point_data['point_data'] = point_data.flatten(order='F')
-    volume_outlier = pv.UniformGrid(dims=(10,10,10))
+    volume_outlier = pyvista.UniformGrid(dims=(10,10,10))
     volume_outlier.point_data['point_data'] = point_data_outlier.flatten(order='F')
     volume_outlier_smoothed = volume_outlier.median_smooth()
     assert np.array_equal(volume.point_data['point_data'],

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1413,7 +1413,12 @@ def test_gaussian_smooth_constant_data():
 
 
 def test_gaussian_smooth_outlier():
-    pass
+    point_data = np.ones((10,10,10))
+    point_data[4,4,4] = 100
+    volume = pv.UniformGrid(dims=(10,10,10))
+    volume.point_data['point_data'] = point_data.flatten(order='F')
+    volume_smoothed = volume.gaussian_smooth()
+    assert (volume_smoothed.get_data_range()[1]<volume.get_data_range()[1])
 
 
 def test_median_smooth_output_type():

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1399,11 +1399,15 @@ def test_gaussian_smooth():
     volume = examples.load_uniform()
     volume_smooth = volume.gaussian_smooth()
     assert isinstance(volume_smooth, pyvista.UniformGrid)
+    volume_smooth = volume.gaussian_smooth(scalars='Spatial Point Data')
+    assert isinstance(volume_smooth, pyvista.UniformGrid)
 
 
 def test_median_smooth():
     volume = examples.load_uniform()
     volume_smooth = volume.median_smooth()
+    assert isinstance(volume_smooth, pyvista.UniformGrid)
+    volume_smooth = volume.median_smooth(scalars='Spatial Point Data')
     assert isinstance(volume_smooth, pyvista.UniformGrid)
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1408,8 +1408,8 @@ def test_gaussian_smooth_constant_data():
     volume = pyvista.UniformGrid(dims=(10,10,10))
     volume.point_data['point_data'] = point_data.flatten(order='F')
     volume_smoothed = volume.gaussian_smooth()
-    assert np.array_equal(volume.point_data['point_data'],
-                          volume_smoothed.point_data['point_data'])
+    assert np.allclose(volume.point_data['point_data'],
+                       volume_smoothed.point_data['point_data'])
 
 
 def test_gaussian_smooth_outlier():

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1394,15 +1394,18 @@ def test_extract_subset():
     #   https://gitlab.kitware.com/vtk/vtk/-/issues/17938
     assert voi.origin == voi.bounds[::2]
 
+
 def test_gaussian_smooth():
     volume = examples.load_uniform()
     volume_smooth = volume.gaussian_smooth()
     assert isinstance(volume_smooth, pyvista.UniformGrid)
 
+
 def test_median_smooth():
     volume = examples.load_uniform()
     volume_smooth = volume.median_smooth()
     assert isinstance(volume_smooth, pyvista.UniformGrid)
+
 
 def test_extract_subset_structured():
     structured = examples.load_structured()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1399,6 +1399,11 @@ def test_gaussian_smooth():
     volume_smooth = volume.gaussian_smooth()
     assert isinstance(volume_smooth, pyvista.UniformGrid)
 
+def test_median_smooth():
+    volume = examples.load_uniform()
+    volume_smooth = volume.median_smooth()
+    assert isinstance(volume_smooth, pyvista.UniformGrid)
+
 def test_extract_subset_structured():
     structured = examples.load_structured()
     voi = structured.extract_subset([0, 3, 1, 4, 0, 1])

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1434,7 +1434,16 @@ def test_median_smooth_constant_data():
 
 
 def test_median_smooth_outlier():
-    pass
+    point_data = np.ones((10,10,10))
+    point_data_outlier = point_data.copy()
+    point_data_outlier[4,4,4] = 100
+    volume = pv.UniformGrid(dims=(10,10,10))
+    volume.point_data['point_data'] = point_data.flatten(order='F')
+    volume_outlier = pv.UniformGrid(dims=(10,10,10))
+    volume_outlier.point_data['point_data'] = point_data_outlier.flatten(order='F')
+    volume_outlier_smoothed = volume_outlier.median_smooth()
+    assert np.array_equal(volume.point_data['point_data'],
+                          volume_outlier_smoothed.point_data['point_data'])
 
 
 def test_extract_subset_structured():


### PR DESCRIPTION
### Overview

Added a wrapper for the VTK filter vtkImageMedian3D for uniform data.

Resolves: #2114 

### Details

1. In pyvista/pyvista/core/filters/uniform_grid.py:

Added a method "median_smooth" to the abstract class UniformGridFilters called "median_smooth." The filter-specific method parameter "kernel_size" corresponds to the ".SetKernelSize" method for the vtkImageMedian3D, which requires 3 integers. Compared to gaussian smoothing, the method for median filtering is a bit less flexible in terms of how parameters are set, but this is also true for the underlying VTK classes.

It's possible we want a bit more flexibility, say have it be possible for the user to just give a single number for kernel size and then set the kernel size to be that given value, except set the size to 1 in dimensions where the shape of the underlying scalar data is 1. I wanted to do this originally but I couldn't think of an elegant way to detect this since self.dimension might give a shape of 2 for a flat dimension if the data is on cells, and when you do dataset[value].shape it's ravelled. We can leave it as-is or maybe someone could give me a pointer on a simple way to check the shape of the scalar data elegantly.

2. In pyvista/pyvista/_vtk.py:

Added vtkImageMedian3D to be imported along with vtkImageGaussianSmooth
