### PR TITLE
add merge to utilities

### DIFF
--- a/pyvista/utilities/features.py
+++ b/pyvista/utilities/features.py
@@ -184,7 +184,7 @@ def merge(
         datasets,
         merge_points=True,
         main_has_priority=True,
-        progress_bar=False
+        progress_bar=False,
     ):
     """Merge several datasets.
 
@@ -199,11 +199,6 @@ def merge(
 
     merge_points : bool, optional
         Merge equivalent points when ``True``. Defaults to ``True``.
-
-    main_has_priority : bool, optional
-        When this parameter is ``True`` and ``merge_points=True``,
-        the arrays of the merging grids will be overwritten
-        by the original main mesh.
 
     main_has_priority : bool, optional
         When this parameter is ``True`` and ``merge_points=True``,
@@ -232,14 +227,14 @@ def merge(
 
     """
     if not isinstance(datasets, collections.Sequence):
-        raise TypeError(f"Expected a sequence, got {type(datasets)}")
+        raise TypeError(f"Expected a sequence, got {type(datasets).__name__}")
 
     if len(datasets) < 1:
         raise ValueError("Expected at least one dataset.")
 
     first = datasets[0]
     if not isinstance(first, pyvista.DataSet):
-        raise TypeError(f"Expected pyvista.DataSet, not {type(first)}")
+        raise TypeError(f"Expected pyvista.DataSet, not {type(first).__name__}")
 
     return datasets[0].merge(
         datasets[1:],

--- a/pyvista/utilities/features.py
+++ b/pyvista/utilities/features.py
@@ -1,5 +1,6 @@
 """Module containing geometry helper functions."""
 
+import collections
 import warnings
 
 import numpy as np
@@ -74,6 +75,7 @@ def voxelize(mesh, density=None, check_surface=True):
     # extract cells from point indices
     vox = ugrid.extract_points(mask)
     return vox
+
 
 def create_grid(dataset, dimensions=(101, 101, 101)):
     """Create a uniform grid surrounding the given dataset.
@@ -176,3 +178,72 @@ def transform_vectors_sph_to_cart(theta, phi, r, u, v, w):
     w_t = np.cos(ph) * w - np.sin(ph) * v
 
     return u_t, v_t, w_t
+
+
+def merge(
+        datasets,
+        merge_points=True,
+        main_has_priority=True,
+        progress_bar=False
+    ):
+    """Merge several datasets.
+
+    .. note::
+       The behavior of this filter varies from the
+       :func:`PolyDataFilters.boolean_union` filter. This filter
+       does not attempt to create a manifold mesh and will include
+       internal surfaces when two meshes overlap.
+
+    datasets : sequence of :class:`pyvista.Dataset`
+        Sequence of datasets. Can be of any :class:`pyvista.Dataset`
+
+    merge_points : bool, optional
+        Merge equivalent points when ``True``. Defaults to ``True``.
+
+    main_has_priority : bool, optional
+        When this parameter is ``True`` and ``merge_points=True``,
+        the arrays of the merging grids will be overwritten
+        by the original main mesh.
+
+    main_has_priority : bool, optional
+        When this parameter is ``True`` and ``merge_points=True``,
+        the arrays of the merging grids will be overwritten
+        by the original main mesh.
+
+    progress_bar : bool, optional
+        Display a progress bar to indicate progress.
+
+    Returns
+    -------
+    pyvista.DataSet
+        :class:`pyvista.PolyData` if all items in datasets are
+        :class:`pyvista.PolyData`, otherwise returns a
+        :class:`pyvista.UnstructuredGrid`.
+
+    Examples
+    --------
+    Merge two polydata datasets.
+
+    >>> import pyvista
+    >>> sphere = pyvista.Sphere(center=(0, 0, 1))
+    >>> cube = pyvista.Cube()
+    >>> mesh = pyvista.merge([cube, sphere])
+    >>> mesh.plot()
+
+    """
+    if not isinstance(datasets, collections.Sequence):
+        raise TypeError(f"Expected a sequence, got {type(datasets)}")
+
+    if len(datasets) < 1:
+        raise ValueError("Expected at least one dataset.")
+
+    first = datasets[0]
+    if not isinstance(first, pyvista.DataSet):
+        raise TypeError(f"Expected pyvista.DataSet, not {type(first)}")
+
+    return datasets[0].merge(
+        datasets[1:],
+        merge_points=merge_points,
+        main_has_priority=main_has_priority,
+        progress_bar=progress_bar,
+    )

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -627,4 +627,23 @@ def test_merge(sphere, cube, datasets):
     merged_ugrid = pyvista.merge(datasets, merge_points=False)
     assert isinstance(merged_ugrid, pyvista.UnstructuredGrid)
     assert merged_ugrid.n_points == sum([ds.n_points for ds in datasets])
+    # check main has priority
+    sphere_a = sphere.copy()
+    sphere_b = sphere.copy()
+    sphere_a['data'] = np.zeros(sphere_a.n_points)
+    sphere_b['data'] = np.ones(sphere_a.n_points)
+
+    merged = pyvista.merge(
+        [sphere_a, sphere_b],
+        merge_points=True,
+        main_has_priority=False,
+    )
+    assert np.allclose(merged['data'], 1)
+
+    merged = pyvista.merge(
+        [sphere_a, sphere_b],
+        merge_points=True,
+        main_has_priority=True,
+    )
+    assert np.allclose(merged['data'], 0)
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -600,3 +600,31 @@ def test_reflection():
         transformations.reflection(normal, point=[1, 0, 0, 0])
     with pytest.raises(ValueError):
         transformations.reflection([0, 0, 0])
+
+
+def test_merge(sphere, cube, datasets):
+    with pytest.raises(TypeError, match="Expected a sequence"):
+        pyvista.merge(None)
+
+    with pytest.raises(ValueError, match="Expected at least one"):
+        pyvista.merge([])
+
+    with pytest.raises(TypeError, match="Expected pyvista.DataSet"):
+        pyvista.merge([None, sphere])
+
+    # check polydata
+    merged_poly = pyvista.merge([sphere, cube])
+    assert isinstance(merged_poly, pyvista.PolyData)
+    assert merged_poly.n_points == sphere.n_points + cube.n_points
+
+    merged = pyvista.merge([sphere, sphere], merge_points=True)
+    assert merged.n_points == sphere.n_points
+
+    merged = pyvista.merge([sphere, sphere], merge_points=False)
+    assert merged.n_points == sphere.n_points*2
+
+    # check unstructured
+    merged_ugrid = pyvista.merge(datasets, merge_points=False)
+    assert isinstance(merged_ugrid, pyvista.UnstructuredGrid)
+    assert merged_ugrid.n_points == sum([ds.n_points for ds in datasets])
+


### PR DESCRIPTION
Simple feature based on local usage: `pyvista.merge()`

```py
>>> import pyvista
>>> sphere = pyvista.Sphere(center=(0, 0, 1))
>>> cube = pyvista.Cube()
>>> mesh = pyvista.merge([cube, sphere])
>>> mesh.plot()
```

Always felt that it was valuable to be able to merge multiple datasets with a simple function directly from `pyvista` rather than `datasets[0].merge(datasets[1:])`, which always felt like a hack.
