### PR TITLE
Improve comparison language

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -18,7 +18,8 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
+* Demonstrating empathy and kindness toward other people, other software, and
+  the communities who have worked diligently to build (un-)related tools.
 * Being respectful of differing opinions, viewpoints, and experiences
 * Giving and gracefully accepting constructive feedback
 * Accepting responsibility and apologizing to those affected by our mistakes,
@@ -30,6 +31,8 @@ Examples of unacceptable behavior include:
 
 * The use of sexualized language or imagery, and sexual attention or advances of
   any kind
+* Talking down in a way that portrays other people or their works in a negative
+  light.
 * Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
 * Publishing others' private information, such as a physical or email address,

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -18,8 +18,7 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people, other software, and
-  the communities who have worked diligently to build (un-)related tools.
+* Demonstrating empathy and kindness toward other people
 * Being respectful of differing opinions, viewpoints, and experiences
 * Giving and gracefully accepting constructive feedback
 * Accepting responsibility and apologizing to those affected by our mistakes,
@@ -31,8 +30,6 @@ Examples of unacceptable behavior include:
 
 * The use of sexualized language or imagery, and sexual attention or advances of
   any kind
-* Talking down in a way that portrays other people or their works in a negative
-  light.
 * Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
 * Publishing others' private information, such as a physical or email address,

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -11,6 +11,15 @@ tool for all users.
 This page is dedicated to outline where you should start with your
 question, concern, feature request, or desire to contribute.
 
+Being Respectful
+----------------
+
+Please demonstrate empathy and kindness toward other people, other software,
+and the communities who have worked diligently to build (un-)related tools.
+
+Please do not talk down in Pull Requests, Issues, or otherwise in a way that
+portrays other people or their works in a negative light.
+
 Cloning the Source Repository
 -----------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ PyVista
 
 PyVista is...
 
-* *"VTK for humans"*: a high-level API to the `Visualization Toolkit`_ (VTK)
+* *Pythonic VTK*: a high-level API to the `Visualization Toolkit`_ (VTK)
 * mesh data structures and filtering methods for spatial datasets
 * 3D plotting made simple and built for large/complex data geometries
 

--- a/doc/getting-started/authors.rst
+++ b/doc/getting-started/authors.rst
@@ -8,6 +8,14 @@ section, please be sure to head over to the `Contributors Graph`_.
 .. _Contributors Graph: https://github.com/pyvista/pyvista/graphs/contributors/
 
 
+.. note::
+
+  PyVista stands on the shoulders of giants, namely the Visualization Toolkit
+  (VTK) and NumPy. We owe so many thanks to the companies and communities that
+  have worked diligently to build the software stack that makes PyVista
+  possible.
+
+
 .. include:: ../../CITATION.rst
 
 

--- a/doc/getting-started/authors.rst
+++ b/doc/getting-started/authors.rst
@@ -2,7 +2,7 @@ Authors & Citation
 ==================
 
 PyVista is an open-source project with a community of contributors.
-While most of PyVista's contributors are listed in the :ref:`authors_ref`
+While many of PyVista's contributors are listed in the :ref:`authors_ref`
 section, please be sure to head over to the `Contributors Graph`_.
 
 .. _Contributors Graph: https://github.com/pyvista/pyvista/graphs/contributors/

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,7 +17,7 @@
 
 PyVista is...
 
-* *"VTK for humans"*: a high-level API to the `Visualization Toolkit`_ (VTK)
+* *Pythonic VTK*: a high-level API to the `Visualization Toolkit`_ (VTK)
 * mesh data structures and filtering methods for spatial datasets
 * 3D plotting made simple and built for large/complex data geometries
 

--- a/doc/user-guide/vtk_to_pyvista.rst
+++ b/doc/user-guide/vtk_to_pyvista.rst
@@ -40,9 +40,9 @@ structure using VTK Python's bindings, one would write the following:
    >>> image_data.GetPointData().SetScalars(points)
 
 As you can see, there is quite a bit of boilerplate that goes into
-the creation of a simple `vtk.vtkImageData`_ dataset, PyVista provides
-a much cleaner syntax that is more "Pythonic". The equivalent code in
-pyvista is:
+the creation of a simple `vtk.vtkImageData`_ dataset. PyVista provides
+much more concise syntax that is more "Pythonic". The equivalent code in
+PyVista is:
 
 
 .. code:: python

--- a/doc/user-guide/vtk_to_pyvista.rst
+++ b/doc/user-guide/vtk_to_pyvista.rst
@@ -41,8 +41,8 @@ structure using VTK Python's bindings, one would write the following:
 
 As you can see, there is quite a bit of boilerplate that goes into
 the creation of a simple `vtk.vtkImageData`_ dataset, PyVista provides
-a much cleaner syntax that is both more readable and intuitive. The
-equivalent code in pyvista is:
+a much cleaner syntax that is more "Pythonic". The equivalent code in
+pyvista is:
 
 
 .. code:: python
@@ -73,7 +73,7 @@ Here, PyVista has done several things for us:
    variable.
 
 #. :class:`pyvista.UniformGrid` wraps `vtk.vtkImageData`_, just with a
-   better name; they are both containers of evenly spaced points. Your
+   different name; they are both containers of evenly spaced points. Your
    data does not have to be an "image" to use it with
    `vtk.vtkImageData`_; rather, like images, values in the dataset are
    evenly spaced apart like pixels in an image.
@@ -121,7 +121,7 @@ For example, in VTK you would have to do:
    >>> renWin.Render()
    >>> iren.Start()
 
-However, with PyVista you simply need:
+However, with PyVista you only need:
 
 .. code:: python
 
@@ -235,9 +235,9 @@ Object Representation
 ---------------------
 Both VTK and PyVista provide representations for their objects.
 
-VTK provides a verbose representation of their datatypes that can be
-accessed via :func:`print`, as the ``__repr__`` (unlike ``__str__``)
-only provides minimal information about each object:
+VTK provides a verbose representation (useful for debugging) of their datatypes
+that can be accessed via :func:`print`, as the ``__repr__``
+(unlike ``__str__``) only provides minimal information about each object:
 
 .. jupyter-execute::
 
@@ -303,8 +303,7 @@ Under the hood, the collision filter detects mesh collisions using
 oriented bounding box (OBB) trees.  For a single collision, this filter
 is as performant as the VTK counterpart, but when computing multiple
 collisions with the same meshes, as in the :ref:`collision_example`
-example, it is more efficient (though less convenient) to use the
-underlying `vtkCollisionDetectionFilter
+example, it is more efficient to use the `vtkCollisionDetectionFilter
 <https://vtk.org/doc/nightly/html/classvtkCollisionDetectionFilter.html>`_,
 as the OBB tree is computed once for each mesh.  In most cases, pure
 PyVista is sufficient for most data science, but there are times when
@@ -314,7 +313,7 @@ Note that nothing stops you from using VTK classes and then wrapping
 the output with PyVista.  For example:
 
 .. jupyter-execute::
-   
+
    import vtk
    import pyvista
 
@@ -331,7 +330,7 @@ the output with PyVista.  For example:
    mesh.plot(line_width=3, cpos='xy', color='k')
 
 In this manner, you can get the "best of both worlds" should you need
-the flexibility of PyVista and the functionality of VTK.
+the flexibility of PyVista and the raw power of VTK.
 
 .. note::
    You can use :func:`pyvista.Circle` for a one line replacement of


### PR DESCRIPTION
Upon reflection, some of the language used in PyVista's documentation is not inline with the values I believe we should hold. 

Specifically, some language in PyVista's documentation comparing PyVista to VTK sheds a negative light on VTK, failing to acknowledge the hard work of those who developed VTK and the value VTK has proven to hold in its 20+ year history.

I believe it is of the utmost importance to consider the fact that PyVista stands on shoulders of giants, namely VTK and NumPy, and that we should acknowledge that fact while being respectful to the broader communities behind those software.

This pull request specifically changes a few concerning language choices:

- "VTK for humans" -> "Pythonic VTK": while the phrasing was originally contributed by a member of our community, inline with many other tools providing a simplified API to a powerful library (e.g., [requests](https://2.python-requests.org/en/master/)'s wrapping of `urllib3` and "HTTP for Humans™" tagline), and capturing the beauty of PyVista's simplified API, it demonstrates a lack of respect for the humans who created VTK and their hard work building the backbone of PyVista.
- I also noticed a few places where the documentation provides a comparison of PyVista and VTK that portrays VTK in a negative light. While the intent was good (to demonstrate the API that the PyVista community has come to love), it is not fair or respectful to shed a negative light on VTK. The use cases for PyVista and VTK Python are different; both have their advantages and drawbacks and we should be sure to honor that.

Additionally, I added some notes to our Code of Conduct to encourage the use of respectful language moving forward.

I suspect I most likely did not capture all occurrences of non-flattering language and would like to ask @pyvista/developers to please follow up in other Pull Requests to improve our language across the documentation