### PR TITLE
Create CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.2.0
+message: "If you are using PyVista in your research, please help our scientific visibility by citing our work!"
+preferred-citation:
+  type: article
+  authors:
+  - family-names: "Sullivan"
+    given-names: "Bane"
+    orcid: "https://orcid.org/0000-0001-8628-4566"
+  - family-names: "Kaszynski"
+    given-names: "Alexander"
+    orcid: "https://orcid.org/0000-0002-8232-7212"
+  doi: "10.21105/joss.01450"
+  journal: "Journal of Open Source Software"
+  publisher: "The Open Journal"
+  month: 5
+  title: "PyVista: 3D plotting and mesh analysis through a streamlined interface for the Visualization Toolkit (VTK)"
+  volume: 4
+  number: 37
+  year: 2019
+  url: "https://github.com/pyvista/pyvista"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-message: "If you use this software, please cite it as below."
+message: "If you are using PyVista in your research, please help our scientific visibility by citing our work!"
 preferred-citation:
   type: article
   authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-message: "If you are using PyVista in your research, please help our scientific visibility by citing our work!"
+message: "If you use this software, please cite it as below."
 preferred-citation:
   type: article
   authors:
@@ -11,10 +11,12 @@ preferred-citation:
     orcid: "https://orcid.org/0000-0002-8232-7212"
   doi: "10.21105/joss.01450"
   journal: "Journal of Open Source Software"
-  publisher: "The Open Journal"
-  month: 5
+  publisher: 
+    name: "The Open Journal"
+  month: May
   title: "PyVista: 3D plotting and mesh analysis through a streamlined interface for the Visualization Toolkit (VTK)"
   volume: 4
-  number: 37
+  issue: 37
+  start: 1450
   year: 2019
   url: "https://github.com/pyvista/pyvista"

--- a/CITATION.rst
+++ b/CITATION.rst
@@ -25,7 +25,7 @@ BibTex:
       volume = {4},
       number = {37},
       pages = {1450},
-      author = {C. Bane Sullivan and Alexander Kaszynski},
+      author = {Bane Sullivan and Alexander Kaszynski},
       title = {{PyVista}: {3D} plotting and mesh analysis through a streamlined interface for the {Visualization Toolkit} ({VTK})},
       journal = {Journal of Open Source Software}
     }

--- a/README.rst
+++ b/README.rst
@@ -253,7 +253,7 @@ BibTex:
       volume = {4},
       number = {37},
       pages = {1450},
-      author = {C. Bane Sullivan and Alexander Kaszynski},
+      author = {Bane Sullivan and Alexander Kaszynski},
       title = {{PyVista}: {3D} plotting and mesh analysis through a streamlined interface for the {Visualization Toolkit} ({VTK})},
       journal = {Journal of Open Source Software}
     }

--- a/joss/paper.md
+++ b/joss/paper.md
@@ -5,7 +5,7 @@ tags:
   - visualization
   - 3D
 authors:
-  - name: C. Bane Sullivan
+  - name: Bane Sullivan
     orcid: 0000-0001-8628-4566
     affiliation: 1
   - name: Alexander A. Kaszynski


### PR DESCRIPTION
This utilizes a nifty feature of GitHub where the citation will be automatically generated in the sidebar:

In a test repo, this looks like:

![Screen Shot 2022-02-14 at 10 46 31 PM](https://user-images.githubusercontent.com/22067021/154000126-9e77f621-6409-427b-95e5-821f9301af89.png)


reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files

Which renders as:

> Sullivan, B., & Kaszynski, A. (2019). PyVista: 3D plotting and mesh analysis through a streamlined interface for the Visualization Toolkit (VTK). Journal of Open Source Software, 4(). https://doi.org/10.21105/joss.01450

```
@article{Sullivan_PyVista_3D_plotting_2019,
author = {Sullivan, Bane and Kaszynski, Alexander},
doi = {10.21105/joss.01450},
journal = {Journal of Open Source Software},
month = {5},
title = {{PyVista: 3D plotting and mesh analysis through a streamlined interface for the Visualization Toolkit (VTK)}},
url = {https://github.com/pyvista/pyvista},
volume = {4},
year = {2019}
}
```

These do not perfectly match the citations we have in `CITATION.rst` which were copied directly from JOSS. Perhaps a JOSS editor could help us make sure this is done right? cc @leouieda


----

Additionally, I updated my name in the citation from "C. Bane Sullivan" to "Bane Sullivan" for consistency and the fact that I want it to forever be a mystery what the C stands for... could be "Cowboy", could be "Coolasacucumber", could be "Charles".... you'll never know, and I plan on keeping it that way.
