### PR TITLE
Replaced pyvista.wrap(alg.GetOutput()) with _get_output(alg)

### DIFF
--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2590,7 +2590,7 @@ class PolyDataFilters(DataSetFilters):
         alg.SetInputData(self)
         alg.SetCapping(capping)
         _update_alg(alg, progress_bar, 'Extruding')
-        output = pyvista.wrap(alg.GetOutput())
+        output = _get_output(alg)
         if inplace:
             self.overwrite(output)
             return self

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -6,6 +6,7 @@ import numpy as np
 
 import pyvista
 from pyvista import _vtk
+from pyvista.core.filters import _get_output
 from pyvista.utilities import (
     NORMALS,
     generate_plane,
@@ -534,7 +535,7 @@ class WidgetHelper:
 
         if not hasattr(self, "plane_clipped_meshes"):
             self.plane_clipped_meshes = []
-        plane_clipped_mesh = pyvista.wrap(alg.GetOutput())
+        plane_clipped_mesh = _get_output(alg)
         self.plane_clipped_meshes.append(plane_clipped_mesh)
 
         def callback(normal, origin):


### PR DESCRIPTION
Replaced pyvista.wrap(alg.GetOutput()) with _get_output(alg)
Can close https://github.com/pyvista/pyvista/issues/2226

But I do have a question

![image](https://user-images.githubusercontent.com/87297355/154427834-f178393d-cdaa-43fd-b26f-a008d3beffc6.png)

Should the pyvista.wrap(alg.GetOutput(port)) also be changed? 
If yes , how do I change it to a format that uses _get_output(alg) ?
