### PR TITLE
Add Maintenance Request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: Bug Report
 about: Create a report to help us fix broken features
 title: ''
-labels: 'bug'
+labels: bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -2,7 +2,7 @@
 name: Feature Request
 about: Request that a feature be added to PyVista
 title: ''
-labels: 'feature-request'
+labels: feature-request
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/maintenance-request.md
+++ b/.github/ISSUE_TEMPLATE/maintenance-request.md
@@ -1,6 +1,6 @@
 ---
 name: Maintenance Request
-about: Request that a maintenance need to PyVista
+about: Request general maintenance to code, CI, deployment, or otherwise
 title: ''
 labels: maintenance
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/maintenance-request.md
+++ b/.github/ISSUE_TEMPLATE/maintenance-request.md
@@ -1,0 +1,18 @@
+---
+name: Maintenance Request
+about: Request that a maintenance need to PyVista
+title: ''
+labels: maintenance
+assignees: ''
+
+---
+
+**Describe what maintenance you would like added.**
+
+A clear and concise description of the maintenance problem.
+
+If you are requesting maintenance for a specific line of source code, please include the permanent link for that line.
+
+Feel free to include pseudocode or screenshots of the requested outcome.
+
+-----


### PR DESCRIPTION
When I created #2226, I noticed that there was no template for maintenance requests. This is useful when you notice a need for maintenance but don't have the resources to create a pull request, or to create a maintenance-related good-first-issue.