### PR TITLE
fix f-string

### DIFF
--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -584,5 +584,5 @@ def parse_font_family(font_family):
     font_family = font_family.lower()
     fonts = [font.name for font in FONTS]
     if font_family not in fonts:
-        raise ValueError('Font must one of the following:\n{", ".join(fonts)}')
+        raise ValueError(f'Font must one of the following:\n{", ".join(fonts)}')
     return FONTS[font_family].value


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->
ValueError raised when the `font_family` is missing from fonts had a broken f-string
resolves #2222 



### Details

- f-string wasn't working because of the missing "f"
```diff
    if font_family not in fonts:
-       raise ValueError('Font must one of the following:\n{", ".join(fonts)}')
+       raise ValueError(f'Font must one of the following:\n{", ".join(fonts)}')
```


