### PR TITLE
ENH: Sandbox the GPU info request

### DIFF
--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -5,11 +5,11 @@ from collections.abc import Iterable
 import logging
 import os
 import re
+import subprocess
 import sys
 
 import scooby
 
-import pyvista
 from pyvista import _vtk
 
 
@@ -177,16 +177,24 @@ def send_errors_to_logging():
     return obs.observe(error_output)
 
 
+_cmd = """\
+import pyvista; \
+plotter = pyvista.Plotter(notebook=False, off_screen=True); \
+plotter.add_mesh(pyvista.Sphere()); \
+plotter.show(auto_close=False); \
+gpu_info = plotter.ren_win.ReportCapabilities(); \
+print(gpu_info); \
+plotter.close()\
+"""
+
+
 def get_gpu_info():
     """Get all information about the GPU."""
     # an OpenGL context MUST be opened before trying to do this.
-    plotter = pyvista.Plotter(notebook=False, off_screen=True)
-    plotter.add_mesh(pyvista.Sphere())
-    plotter.show(auto_close=False)
-    gpu_info = plotter.ren_win.ReportCapabilities()
-    plotter.close()
-    # Remove from list of Plotters
-    pyvista.plotting._ALL_PLOTTERS.pop(plotter._id_name)
+    proc = subprocess.run(
+        [sys.executable, '-c', _cmd],
+        check=False, capture_output=True)
+    gpu_info = '' if proc.returncode else proc.stdout.decode()
     return gpu_info
 
 

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -191,9 +191,7 @@ plotter.close()\
 def get_gpu_info():
     """Get all information about the GPU."""
     # an OpenGL context MUST be opened before trying to do this.
-    proc = subprocess.run(
-        [sys.executable, '-c', _cmd],
-        check=False, capture_output=True)
+    proc = subprocess.run([sys.executable, '-c', _cmd], check=False, capture_output=True)
     gpu_info = '' if proc.returncode else proc.stdout.decode()
     return gpu_info
 

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -210,7 +210,7 @@ class GPUInfo:
         try:
             renderer = regex.findall(self._gpu_info)[0]
         except IndexError:
-            raise RuntimeError("Unable to parse GPU information for the renderer.")
+            raise RuntimeError("Unable to parse GPU information for the renderer.") from None
         return renderer.strip()
 
     @property
@@ -220,7 +220,7 @@ class GPUInfo:
         try:
             version = regex.findall(self._gpu_info)[0]
         except IndexError:
-            raise RuntimeError("Unable to parse GPU information for the version.")
+            raise RuntimeError("Unable to parse GPU information for the version.") from None
         return version.strip()
 
     @property
@@ -230,7 +230,7 @@ class GPUInfo:
         try:
             vendor = regex.findall(self._gpu_info)[0]
         except IndexError:
-            raise RuntimeError("Unable to parse GPU information for the vendor.")
+            raise RuntimeError("Unable to parse GPU information for the vendor.") from None
         return vendor.strip()
 
     def get_info(self):


### PR DESCRIPTION
Closes #2155

One potential solution has been implemented here: use `subprocess.check_call` inside pyvista's report function. It looks like it can segfault even on import of `libGL.so.1` so we can't even reliably `CDLL` our way out of the problem. I think this should work, though...

@hoechenberger can you try it on your linux system that has a problem?