### PR TITLE
MAINT: Bump to 3.7 minimum

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,3 @@ updates:
     labels:
       - "maintenance"
       - "dependencies"
-    ignore:
-      - dependency-name: "hypothesis"
-        # for hypothesis, ignore upgrades due to Python 3.6 availability

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -135,7 +135,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9']
         vtk-version: ['latest']
         include:
           - python-version: '3.9'
@@ -218,7 +218,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
 

--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ Installation
 ============
 
 PyVista can be installed from `PyPI <https://pypi.org/project/pyvista/>`_
-using ``pip`` on Python >= 3.6::
+using ``pip`` on Python >= 3.7::
 
     pip install pyvista
 

--- a/doc/extras/building_vtk.rst
+++ b/doc/extras/building_vtk.rst
@@ -81,7 +81,7 @@ modifying the above ``cmake`` command with:
 
    # install build dependencies (Linux/Debian)
    apt-get update
-   apt-get install -y ninja-build cmake libegl1-mesa-dev python3-dev 
+   apt-get install -y ninja-build cmake libegl1-mesa-dev python3-dev
 
    # build using EGL
    git clone https://github.com/Kitware/VTK
@@ -175,15 +175,6 @@ built on.  You can work around this by building your wheels using a
     # build based on python version from args
     PYTHON_VERSION="$1"
     case $PYTHON_VERSION in
-    2.7)
-      PYBIN="/opt/python/cp27-cp27m/bin/python"
-      ;;
-    3.5)
-      PYBIN="/opt/python/cp35-cp35m/bin/python"
-      ;;
-    3.6)
-      PYBIN="/opt/python/cp36-cp36m/bin/python"
-      ;;
     3.7)
       PYBIN="/opt/python/cp37-cp37m/bin/python"
       ;;
@@ -192,6 +183,9 @@ built on.  You can work around this by building your wheels using a
       ;;
     3.9)
       PYBIN="/opt/python/cp39-cp39/bin/python"
+      ;;
+    3.10)
+      PYBIN="/opt/python/cp310-cp310/bin/python"
       ;;
     esac
 
@@ -255,7 +249,7 @@ the ``quay.io/pypa/manylinux2014_aarch64`` image.  Run the following:
 
 .. code-block:: bash
 
-    PYTHON_VERSION=3.6
+    PYTHON_VERSION=3.7
     rm -rf build
     docker run -e \
            --rm -v `pwd`:/io quay.io/pypa/manylinux2014_aarch64 \
@@ -273,15 +267,6 @@ Where ``build_wheels.sh`` is:
     # build based on python version from args
     PYTHON_VERSION="$1"
     case $PYTHON_VERSION in
-    2.7)
-      PYBIN="/opt/python/cp27-cp27m/bin/python"
-      ;;
-    3.5)
-      PYBIN="/opt/python/cp35-cp35m/bin/python"
-      ;;
-    3.6)
-      PYBIN="/opt/python/cp36-cp36m/bin/python"
-      ;;
     3.7)
       PYBIN="/opt/python/cp37-cp37m/bin/python"
       ;;
@@ -290,6 +275,9 @@ Where ``build_wheels.sh`` is:
       ;;
     3.9)
       PYBIN="/opt/python/cp39-cp39/bin/python"
+      ;;
+    3.10)
+      PYBIN="/opt/python/cp310-cp310/bin/python"
       ;;
     esac
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,11 +1,11 @@
-# Note: using < here to maintain compatability with Python3.6
+# Note: using < here to reduce breakages
 # See: https://github.com/pyvista/pyvista/pull/2038
 
 Sphinx<4.5.0
 cmocean<2.1
 codecov<2.2.0
 colorcet<3.1.0
-hypothesis<6.31.6  # not latest due to python3.6 compatibility
+hypothesis<6.38
 imageio-ffmpeg<0.5.0
 imageio<2.17.0
 ipygany<0.6.0

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,6 @@ install_requires = [
     'appdirs',
     'scooby>=0.5.1',
     'vtk',
-    'dataclasses;python_version=="3.6"',
-    'typing_extensions;python_version<="3.7"',
 ]
 
 readme_file = os.path.join(filepath, 'README.rst')
@@ -53,7 +51,6 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Operating System :: MacOS',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -74,7 +71,7 @@ setup(
             '2k_earth_daymap.jpg',
         ],
     },
-    python_requires='>=3.6.*',
+    python_requires='>=3.7',
     install_requires=install_requires,
     extras_require={
         'all': ['matplotlib', 'colorcet', 'cmocean', 'meshio'],


### PR DESCRIPTION
3.6 is EOL, bump to 3.7 minimum

Most scientific python libs have done this in the last 6-12 mo