### PR TITLE
ignore mappers not containing datasets

### DIFF
--- a/pyvista/jupyter/pv_pythreejs.py
+++ b/pyvista/jupyter/pv_pythreejs.py
@@ -13,21 +13,6 @@ from ipywidgets import GridspecLayout
 
 import pyvista as pv
 
-# TODO: Consider adding sprites for point labels
-# def add_sprite():
-#     text = tjs.TextTexture('hi', size=60, color='black')
-#     sprite = tjs.Sprite(tjs.SpriteMaterial(map=text,
-#                                            sizeAttenuation=False,
-#                                            transparent=False,
-#                                            # depthWrite=False,
-#                                            # depthTest=False
-#                                            useScreenCoordinates=True,
-#                                            ),
-#                         scale=(.1,.1,.1),
-#                         center=(0.0, 0.0)
-#                         )
-#     children.append(sprite)
-
 
 def segment_poly_cells(mesh):
     """Segment lines from a mesh into line segments."""
@@ -428,7 +413,12 @@ def actor_to_mesh(actor, focal_point):
     if mapper is None:
         return
 
+    # ignore any mappers whose inputs are not datasets
+    if not hasattr(mapper, 'GetInputAsDataSet'):
+        return
+
     dataset = mapper.GetInputAsDataSet()
+
     has_faces = True
     if hasattr(dataset, 'faces'):
         has_faces = np.any(dataset.faces)

--- a/tests/jupyter/test_pythreejs.py
+++ b/tests/jupyter/test_pythreejs.py
@@ -202,3 +202,15 @@ def test_non_standard_shape():
     pl = pyvista.Plotter(shape='2|3')
     with pytest.raises(RuntimeError, match='Unsupported plotter shape'):
         pv_pythreejs.convert_plotter(pl)
+
+
+def test_labels():
+    poly = pyvista.PolyData(np.random.rand(10, 3))
+    poly["My Labels"] = [f"Label {i}" for i in range(poly.n_points)]
+
+    pl = pyvista.Plotter()
+    pl.add_point_labels(poly, "My Labels", point_size=20, font_size=36)
+
+    # ensure that we ignore labels
+    with pytest.warns(UserWarning):
+        pv_pythreejs.convert_plotter(pl)


### PR DESCRIPTION
Simple hotfix to ignore mappers that do not contain datasets.

This fixes the following error:

```py
import pyvista as pv
import numpy as np
pv.set_jupyter_backend('pythreejs')

# Make some random points
poly = pv.PolyData(np.random.rand(10, 3))

poly["My Labels"] = [f"Label {i}" for i in range(poly.n_points)]

plotter = pv.Plotter()
plotter.add_point_labels(poly, "My Labels", point_size=20, font_size=36)
plotter.show()
```

```
vtkmodules.vtkRenderingLabel.vtkLabelPlacementMapp' object has no attribute 'GetInputAsDataSet'
```

It's not perfect as we really should be able to support plotting labels, but it will at least allow plotting of scenes containing labels.
