### PR TITLE
Left click to pick points

### DIFF
--- a/examples/02-plot/point-picking.py
+++ b/examples/02-plot/point-picking.py
@@ -52,3 +52,14 @@ p.enable_point_picking(pickable_window=False)
 p.pickable_actors = [sphere_actor, cube_actor]  # now both are pickable
 p.view_xy()
 p.show()
+
+###############################################################################
+# Pick using the left-mouse button
+# ++++++++++++++++++++++++++++++++
+#
+sphere = pv.Sphere()
+
+p = pv.Plotter()
+p.add_mesh(sphere, pickable=True)
+p.enable_point_picking(left_clicking=True)
+p.show()

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -375,7 +375,7 @@ class PickingHelper:
         self.iren.set_picker(point_picker)
 
         if left_clicking:
-            self.iren.interactor.AddObserver( 
+            self.iren.interactor.AddObserver(
                 "LeftButtonPressEvent",
                 partial(try_callback, _launch_pick_event),
             )
@@ -383,7 +383,7 @@ class PickingHelper:
         # Now add text about cell-selection
         if show_message:
             if show_message is True:
-                show_message = "Left-click or press P to pick under the mouse" if left_clicking else  "Press P to pick under the mouse"
+                show_message = "Left-click or press P to pick under the mouse" if left_clicking else "Press P to pick under the mouse"
             self.add_text(str(show_message), font_size=font_size, name='_point_picking_message')
 
     def enable_path_picking(

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -1,5 +1,6 @@
 """Module managing picking events."""
 
+from functools import partial
 import logging
 import weakref
 
@@ -257,6 +258,7 @@ class PickingHelper:
         show_point=True,
         tolerance=0.025,
         pickable_window=False,
+        left_clicking=False,
         **kwargs,
     ):
         """Enable picking at points.
@@ -307,6 +309,11 @@ class PickingHelper:
         pickable_window : bool, optional
             When True, points in the 3D window are pickable. Default to ``True``.
 
+        left_clicking : bool, optional
+            When True, points can be picked by clicking the left mousebutton.
+            Default to ``False``. Note, if enabled, left-clicking will **not**
+            display the bounding box around the picked point.
+
         **kwargs : dict, optional
             All remaining keyword arguments are used to control how
             the picked point is interactively displayed.
@@ -324,6 +331,16 @@ class PickingHelper:
         See :ref:`point_picking_example` for a full example using this method.
 
         """
+
+        def _launch_pick_event(interactor, event):
+            """Create a Pick event based on coordinate or left-click"""
+
+            click_x, click_y = interactor.GetEventPosition()
+            click_z = 0
+
+            picker = interactor.GetPicker()
+            renderer = interactor.GetInteractorStyle()._parent()._plotter.renderer
+            picker.Pick(click_x, click_y, click_z, renderer)
 
         def _end_pick_event(picker, event):
 
@@ -358,10 +375,16 @@ class PickingHelper:
         self.enable_trackball_style()
         self.iren.set_picker(point_picker)
 
+        if left_clicking:
+            self.iren.interactor.AddObserver( 
+                "LeftButtonPressEvent",
+                partial(try_callback, _launch_pick_event),
+            )
+
         # Now add text about cell-selection
         if show_message:
             if show_message is True:
-                show_message = "Press P to pick under the mouse"
+                show_message = "Left-click or press P to pick under the mouse" if left_clicking else  "Press P to pick under the mouse"
             self.add_text(str(show_message), font_size=font_size, name='_point_picking_message')
 
     def enable_path_picking(

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -382,8 +382,10 @@ class PickingHelper:
 
         # Now add text about cell-selection
         if show_message:
-            if show_message is True:
-                show_message = "Left-click or press P to pick under the mouse" if left_clicking else "Press P to pick under the mouse"
+            if show_message is True and left_clicking:
+                show_message = "Left-click or press P to pick under the mouse"
+            elif show_message is True:
+                show_message = "Press P to pick under the mouse"
             self.add_text(str(show_message), font_size=font_size, name='_point_picking_message')
 
     def enable_path_picking(

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -332,7 +332,7 @@ class PickingHelper:
 
         """
 
-        def _launch_pick_event(interactor, event):
+        def _launch_pick_event(interactor, event):  # pragma: no cover
             """Create a Pick event based on coordinate or left-click."""
             click_x, click_y = interactor.GetEventPosition()
             click_z = 0

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -333,8 +333,7 @@ class PickingHelper:
         """
 
         def _launch_pick_event(interactor, event):
-            """Create a Pick event based on coordinate or left-click"""
-
+            """Create a Pick event based on coordinate or left-click."""
             click_x, click_y = interactor.GetEventPosition()
             click_z = 0
 

--- a/tests/test_picking.py
+++ b/tests/test_picking.py
@@ -119,9 +119,9 @@ def test_point_picking(left_clicking):
         )
         # simulate the pick
         if left_clicking:
-             width, height = plotter.window_size
-             plotter.iren._mouse_left_button_press(width // 2, height // 2)
-             plotter.iren._mouse_left_button_release(width, height)
+            width, height = plotter.window_size
+            plotter.iren._mouse_left_button_press(width // 2, height // 2)
+            plotter.iren._mouse_left_button_release(width, height)
         else:
             renderer = plotter.renderer
             picker = plotter.iren.get_picker()

--- a/tests/test_picking.py
+++ b/tests/test_picking.py
@@ -103,7 +103,8 @@ def test_enable_cell_picking_interactive_two_ren_win():
 
 @skip_no_vtk9
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
-def test_point_picking():
+@pytest.mark.parametrize('left_clicking', [False, True])
+def test_point_picking(left_clicking):
     sphere = pyvista.Sphere()
     for use_mesh in (False, True):
         plotter = pyvista.Plotter(
@@ -113,12 +114,18 @@ def test_point_picking():
         plotter.enable_point_picking(
             show_message=True,
             use_mesh=use_mesh,
+            left_clicking=left_clicking,
             callback=lambda: None,
         )
         # simulate the pick
-        renderer = plotter.renderer
-        picker = plotter.iren.get_picker()
-        picker.Pick(50, 50, 0, renderer)
+        if left_clicking:
+             width, height = plotter.window_size
+             plotter.iren._mouse_left_button_press(width // 2, height // 2)
+             plotter.iren._mouse_left_button_release(width, height)
+        else:
+            renderer = plotter.renderer
+            picker = plotter.iren.get_picker()
+            picker.Pick(50, 50, 0, renderer)
         plotter.close()
 
 


### PR DESCRIPTION
### Overview

Resolves #2193 
Indirectly addresses: #1285 https://github.com/pyvista/pyvista-support/issues/249

Hi, I've added the ability to pick points on a mesh by clicking the left mouse button.

### Details

I've added an optional `left_clicking` keyword to `enable_point_picking`. If set to True, an observer is added to the interactor that will launch a pick event when the left button is clicked. 

Because the pick event is not created using by pressing 'P', there is no red box around the picked point (I think the red box is generated by a `KeyReleaseEvent` associated with `vtkRenderWindowInteractor` on the C++ side, and cannot be disabled from Python).

I'm not sure this is the best way to go about adding this functionality, so I've not yet added tests. I've added a simple example to the end of`examples/02_plot/point_picking.py`.
