### PR TITLE
Fix render_window_interactor observers

### DIFF
--- a/examples/02-plot/chart_overlays.py
+++ b/examples/02-plot/chart_overlays.py
@@ -7,9 +7,9 @@ Chart Overlays
 This example shows how you can combine multiple charts as overlays in
 the same renderer. For an overview of the different chart types you
 can use, please refer to :ref:`chart_basics_example`. Interaction with
-a chart can be enabled by right clicking on top of it. Note that this
+a chart can be enabled by a double left click on top of it. Note that this
 will disable interaction with the 3D scene. To stop interacting with
-the chart, perform another right click. This will either enable
+the chart, perform another double left click. This will either enable
 interaction with another chart (if clicked on top of it) or re-enable
 interaction with the 3D scene.
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1304,9 +1304,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
         """Wrap RenderWindowInteractor.track_click_position."""
         self.iren.track_click_position(*args, **kwargs)
 
-    def untrack_click_position(self):
+    @wraps(RenderWindowInteractor.untrack_click_position)
+    def untrack_click_position(self, *args, **kwargs):
         """Stop tracking the click position."""
-        self.iren.untrack_click_position()
+        self.iren.untrack_click_position(*args, **kwargs)
 
     @property
     def pickable_actors(self):

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -74,7 +74,31 @@ class RenderWindowInteractor:
         return _vtk.vtkCommand.GetStringFromEventId(event)
 
     def add_observer(self, event, call):
-        """Add an observer."""
+        """Add an observer for the given event.
+
+        Parameters
+        ----------
+        event : str or int
+            The event to observe. Either the name of this event (string) or
+            a VTK event identifier (int).
+
+        call : callable
+            Callback to be called when the event is invoked.
+
+        Returns
+        -------
+        int
+            The identifier of the added observer.
+
+        Examples
+        --------
+        Add a custom observer.
+
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> obs_enter = pl.iren.add_observer("EnterEvent", lambda *_: print('Enter!'))
+
+        """
         call = partial(try_callback, call)
         event = self._get_event_str(event)
         observer = self.interactor.AddObserver(event, call)
@@ -82,13 +106,47 @@ class RenderWindowInteractor:
         return observer
 
     def remove_observer(self, observer):
-        """Remove an observer."""
+        """Remove an observer.
+
+        Parameters
+        ----------
+        observer : int
+            The identifier of the observer to remove.
+
+        Examples
+        --------
+        Add an observer and immediately remove it.
+
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> obs_enter = pl.iren.add_observer("EnterEvent", lambda *_: print('Enter!'))
+        >>> pl.iren.remove_observer(obs_enter)
+
+        """
         if observer in self._observers:
             self.interactor.RemoveObserver(observer)
             del self._observers[observer]
 
     def remove_observers(self, event=None):
-        """Remove all observers."""
+        """Remove all observers.
+
+        Parameters
+        ----------
+        event : str or int, optional
+            If provided, only removes observers of the given event. Otherwise,
+            if it is ``None``, removes all observers.
+
+        Examples
+        --------
+        Add two observers and immediately remove them.
+
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> obs_enter = pl.iren.add_observer("EnterEvent", lambda *_: print('Enter!'))
+        >>> obs_leave = pl.iren.add_observer("LeaveEvent", lambda *_: print('Leave!'))
+        >>> pl.iren.remove_observers()
+
+        """
         if event is None:
             observers = list(self._observers.keys())
         else:
@@ -136,8 +194,8 @@ class RenderWindowInteractor:
             the click position as a length two tuple.
 
         side : str, optional
-            The side of the mouse for the button to track (left or
-            right).  Default is left. Also accepts ``'r'`` or ``'l'``.
+            The mouse button to track (either ``'left'`` or ``'right'``).
+            Default is ``'right'``. Also accepts ``'r'`` or ``'l'``.
 
         viewport : bool, optional
             If ``True``, uses the normalized viewport coordinate
@@ -158,7 +216,16 @@ class RenderWindowInteractor:
         self.add_observer(event, _click_callback)
 
     def untrack_click_position(self, side="right"):
-        """Stop tracking the click position."""
+        """Stop tracking the click position.
+
+        Parameters
+        ----------
+        side : str, optional
+            The mouse button to stop tracking (either ``'left'`` or
+            ``'right'``). Default is ``'right'``. Also accepts ``'r'``
+            or ``'l'``.
+
+        """
         self.remove_observers(self._get_click_event(side))
 
     def clear_key_event_callbacks(self):

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -85,6 +85,8 @@ class RenderWindowInteractor:
         if event is None:
             observers = list(self._observers.keys())
         else:
+            if not isinstance(event, str):
+                event = _vtk.vtkCommand.GetStringFromEventId(event)
             observers = [obs for obs, ev in self._observers.items() if event == ev]
         for observer in observers:
             self.remove_observer(observer)

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -981,15 +981,15 @@ def test_iren_context_style(pl):
     style = pl.iren._style
     style_class = pl.iren._style_class
 
-    # Simulate right click on the chart:
-    pl.iren._mouse_right_button_press(int(0.75 * win_size[0]), int(0.75 * win_size[1]))
+    # Simulate double left click on the chart:
+    pl.iren._mouse_left_button_click(int(0.75 * win_size[0]), int(0.75 * win_size[1]), count=2)
     assert chart.GetInteractive()
     assert pl.iren._style == "Context"
     assert pl.iren._style_class == pl.iren._context_style
     assert pl.iren._context_style.GetScene().__this__ == chart._scene.__this__
 
     # Simulate right click outside the chart:
-    pl.iren._mouse_right_button_press(0, 0)
+    pl.iren._mouse_left_button_click(0, 0, count=2)
     assert not chart.GetInteractive()
     assert pl.iren._style == style
     assert pl.iren._style_class == style_class

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -856,7 +856,7 @@ def test_chart_box(pl, chart_box, box_plot):
     pl.show(auto_close=False)
     assert np.allclose(chart._geometry, (0, 0, r_w, r_h))
     pl.window_size = (int(pl.window_size[0] / 2), int(pl.window_size[1] / 2))
-    pl.show()  # This will also call chart._resize
+    pl.show(auto_close=False)  # This will also call chart._resize
     assert np.allclose(chart._geometry, (0, 0, r_w / 2, r_h / 2))
 
     # Test remaining properties
@@ -887,7 +887,7 @@ def test_chart_pie(pl, chart_pie, pie_plot):
     pl.show(auto_close=False)
     assert np.allclose(chart._geometry, (0, 0, r_w, r_h))
     pl.window_size = (int(pl.window_size[0] / 2), int(pl.window_size[1] / 2))
-    pl.show()  # This will also call chart._resize
+    pl.show(auto_close=False)  # This will also call chart._resize
     assert np.allclose(chart._geometry, (0, 0, r_w / 2, r_h / 2))
 
     # Test remaining properties
@@ -918,7 +918,7 @@ def test_chart_mpl(pl, chart_mpl):
     assert np.allclose(chart.position, (loc[0] * r_w, loc[1] * r_h))
     assert np.allclose(chart._canvas.get_width_height(), (size[0] * r_w, size[1] * r_h))
     pl.window_size = (int(pl.window_size[0] / 2), int(pl.window_size[1] / 2))
-    pl.show()  # This will also call chart._resize
+    pl.show(auto_close=False)  # This will also call chart._resize
     assert np.allclose(
         chart._geometry, (loc[0] * r_w / 2, loc[1] * r_h / 2, size[0] * r_w / 2, size[1] * r_h / 2)
     )

--- a/tests/test_render_window_interactor.py
+++ b/tests/test_render_window_interactor.py
@@ -24,25 +24,32 @@ def test_observers():
     assert key not in pl.iren._key_press_event_callbacks
 
     # Custom events
-    assert not pl.iren.interactor.HasObserver("PickEvent"), "Subsequent PickEvent observer tests are wrong if this fails."
+    assert not pl.iren.interactor.HasObserver(
+        "PickEvent"
+    ), "Subsequent PickEvent HasObserver tests are wrong if this fails."
+    # Add different observers
     obs_move = pl.iren.add_observer(_vtk.vtkCommand.MouseMoveEvent, empty_callback)
     obs_double1 = pl.iren.add_observer(_vtk.vtkCommand.LeftButtonDoubleClickEvent, empty_callback)
     obs_double2 = pl.iren.add_observer("LeftButtonDoubleClickEvent", empty_callback)
     obs_picks = tuple(pl.iren.add_observer("PickEvent", empty_callback) for _ in range(5))
-    obs_select = pl.iren.add_observer("SelectionChangedEvent", empty_callback)
-    assert pl.iren._observers[obs_move] == "MouseMoveEvent" and pl.iren.interactor.HasObserver("MouseMoveEvent")
-    assert pl.iren._observers[obs_double1] == "LeftButtonDoubleClickEvent" and pl.iren._observers[obs_double2] == "LeftButtonDoubleClickEvent"
+    pl.iren.add_observer("SelectionChangedEvent", empty_callback)
+    assert pl.iren._observers[obs_move] == "MouseMoveEvent"
+    assert pl.iren.interactor.HasObserver("MouseMoveEvent")
+    assert pl.iren._observers[obs_double1] == "LeftButtonDoubleClickEvent"
+    assert pl.iren._observers[obs_double2] == "LeftButtonDoubleClickEvent"
     assert pl.iren.interactor.HasObserver("LeftButtonDoubleClickEvent")
     assert all(pl.iren._observers[obs_pick] == "PickEvent" for obs_pick in obs_picks)
     assert pl.iren.interactor.HasObserver("SelectionChangedEvent")
-    pl.iren.remove_observer(obs_move)  # Remove specific observer
+    # Remove a specific observer
+    pl.iren.remove_observer(obs_move)
     assert obs_move not in pl.iren._observers
-    pl.iren.remove_observers(_vtk.vtkCommand.LeftButtonDoubleClickEvent)  # Remove all observers of specific event
+    # Remove all observers of a specific event
+    pl.iren.remove_observers(_vtk.vtkCommand.LeftButtonDoubleClickEvent)
     assert obs_double1 not in pl.iren._observers and obs_double2 not in pl.iren._observers
-    pl.iren.remove_observers()  # Remove all (remaining) observers
-    assert all(obs_pick not in pl.iren._observers for obs_pick in obs_picks)
+    # Remove all (remaining) observers
+    pl.iren.remove_observers()
+    assert len(pl.iren._observers) == 0
     assert not pl.iren.interactor.HasObserver("PickEvent")
-    assert obs_select not in pl.iren._observers
 
 
 def test_clear_key_event_callbacks():
@@ -76,6 +83,7 @@ def test_track_click_position_multi_render():
     pl.track_click_position(callback=callback, side='left', viewport=True)
     pl.show(auto_close=False)
     x, y = 10, 20
+    pl.iren._mouse_right_button_click(2 * x, 2 * y)
     pl.iren._mouse_left_button_click(x, y)
     assert points[0] == (x, y)
 

--- a/tests/test_render_window_interactor.py
+++ b/tests/test_render_window_interactor.py
@@ -24,17 +24,25 @@ def test_observers():
     assert key not in pl.iren._key_press_event_callbacks
 
     # Custom events
+    assert not pl.iren.interactor.HasObserver("PickEvent"), "Subsequent PickEvent observer tests are wrong if this fails."
     obs_move = pl.iren.add_observer(_vtk.vtkCommand.MouseMoveEvent, empty_callback)
     obs_double1 = pl.iren.add_observer(_vtk.vtkCommand.LeftButtonDoubleClickEvent, empty_callback)
     obs_double2 = pl.iren.add_observer("LeftButtonDoubleClickEvent", empty_callback)
-    assert pl.iren._observers[obs_move] == "MouseMoveEvent"
-    assert pl.iren._observers[obs_double1] == "LeftButtonDoubleClickEvent"
-    assert pl.iren._observers[obs_double2] == "LeftButtonDoubleClickEvent"
-    pl.iren.remove_observer(obs_move)
+    obs_picks = tuple(pl.iren.add_observer("PickEvent", empty_callback) for _ in range(5))
+    obs_select = pl.iren.add_observer("SelectionChangedEvent", empty_callback)
+    assert pl.iren._observers[obs_move] == "MouseMoveEvent" and pl.iren.interactor.HasObserver("MouseMoveEvent")
+    assert pl.iren._observers[obs_double1] == "LeftButtonDoubleClickEvent" and pl.iren._observers[obs_double2] == "LeftButtonDoubleClickEvent"
+    assert pl.iren.interactor.HasObserver("LeftButtonDoubleClickEvent")
+    assert all(pl.iren._observers[obs_pick] == "PickEvent" for obs_pick in obs_picks)
+    assert pl.iren.interactor.HasObserver("SelectionChangedEvent")
+    pl.iren.remove_observer(obs_move)  # Remove specific observer
     assert obs_move not in pl.iren._observers
-    pl.iren.remove_observers(_vtk.vtkCommand.LeftButtonDoubleClickEvent)
-    assert obs_double1 not in pl.iren._observers
-    assert obs_double2 not in pl.iren._observers
+    pl.iren.remove_observers(_vtk.vtkCommand.LeftButtonDoubleClickEvent)  # Remove all observers of specific event
+    assert obs_double1 not in pl.iren._observers and obs_double2 not in pl.iren._observers
+    pl.iren.remove_observers()  # Remove all (remaining) observers
+    assert all(obs_pick not in pl.iren._observers for obs_pick in obs_picks)
+    assert not pl.iren.interactor.HasObserver("PickEvent")
+    assert obs_select not in pl.iren._observers
 
 
 def test_clear_key_event_callbacks():
@@ -55,7 +63,7 @@ def test_track_mouse_position():
     assert "MouseMoveEvent" not in pl.iren._observers.values()
 
 
-def test_track_click_position_multi_render():  # TODO: verify why this test was not failing?
+def test_track_click_position_multi_render():
     points = []
 
     def callback(mouse_point):
@@ -68,10 +76,10 @@ def test_track_click_position_multi_render():  # TODO: verify why this test was 
     pl.track_click_position(callback=callback, side='left', viewport=True)
     pl.show(auto_close=False)
     x, y = 10, 20
-    pl.iren._mouse_left_button_press(x, y)
+    pl.iren._mouse_left_button_click(x, y)
     assert points[0] == (x, y)
 
     # disable and ensure that clicking is no longer being tracked
-    pl.untrack_click_position()
-    pl.iren._mouse_left_button_press(50, 50)
+    pl.untrack_click_position(side='left')
+    pl.iren._mouse_left_button_click(50, 50)
     assert len(points) == 1


### PR DESCRIPTION
### Overview

The `remove_observer` method in the `RenderWindowInteractor` class was a bit ambiguous and used incorrectly in some methods (such as `untrack_mouse_position` and `untrack_click_position`).
Resolves #2253 and resolves #1729.


### Details

- `add_observer` would overwrite previously added observers for the same event. In this PR support is added for multiple observers (while keeping track of them all and correctly removing them all).
- `remove_observer` accepted an `event` argument, but only worked correctly when an 'observer id' was passed. In this PR the method is changed to only accept an 'observer id' to be removed.
- to support the old behaviour of passing an `event` and remove the corresponding observers, an extra `event` argument is added to the `remove_observers` method that does exactly that.
- Added support for double click callbacks. Chart activation now requires a double left click instead of a single right click, as a single right click is normally used to select data within a chart (see #1733).


### Tasks

- [x] Improve documentation
- [x] Investigate and change `test_track_click_position` test, as this test should have failed and catched this bug but didn't.
- [x] Investigate failing charts tests.

