### PR TITLE
Fix broken clip_box behavior

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -217,7 +217,7 @@ class DataSetFilters:
             if poly.n_cells != 6:
                 raise ValueError("The bounds mesh must have only 6 faces.")
             bounds = []
-            poly.compute_normals()
+            poly.compute_normals(inplace=True)
             for cid in range(6):
                 cell = poly.extract_cells(cid)
                 normal = cell["Normals"][0]


### PR DESCRIPTION
### Overview

Fix clip_box clipping unexpected portions of a mesh.

resolves #2305

### Details

Add missing `inplace=True` parameter missing from the `compute_normals` call made in clip_box,
which resulted in unexpected clip behavior.

Co-authored-by: Andras Deak <adeak@users.noreply.github.com>
