### PR TITLE
Bump to 0.35.dev0 for release

### DIFF
--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -15,7 +15,7 @@ Denotes the first release candidate.
 
 """
 # major, minor, patch
-version_info = 0, 34, 'dev0'
+version_info = 0, 34, 0
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -15,7 +15,7 @@ Denotes the first release candidate.
 
 """
 # major, minor, patch
-version_info = 0, 34, 0
+version_info = 0, 35, 'dev0'
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
Let's publish the next minor release of PyVista!

While not super urgent, we have several bug fixes and a few major house keeping PRs that should get out soon, especially dropping support for 3.6 in #1716 and improving our comparison language in #2177.

When merged, this PR will bump our `main` branch version to 0.35.dev0 in preparation for a v0.34.0 release on this same branch.

Thanks again for all of those who tirelessly contribute to this project!

---
## Waiting on the following PRs:

- [x] https://github.com/pyvista/pyvista/pull/2266 
- [x] https://github.com/pyvista/pyvista/pull/2131
- [x] https://github.com/pyvista/pyvista/pull/2117
- [x] https://github.com/pyvista/pyvista/pull/2388
- [x] https://github.com/pyvista/pyvista/pull/2366
- [x] #1178
- [x] #2403 
- [x] #2404 