### PR TITLE
Add multicomponent threshold options

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -927,7 +927,6 @@ class DataSetFilters:
         arr = get_array(self, scalars, preference=preference, err=False)
         if arr is None:
             raise ValueError('No arrays present to threshold.')
-
         field = get_array_association(self, scalars, preference=preference)
 
         # If using an inverted range, merge the result of two filters:
@@ -984,6 +983,11 @@ class DataSetFilters:
                 alg.ThresholdByUpper(value)
         if component_mode == "component":
             alg.SetComponentModeToUseSelected()
+            dim = arr.shape[1]
+            if component > (dim - 1) or component < 0:
+                raise ValueError(
+                    f"scalars has {dim} components: supplied component {component} not in range"
+                )
             alg.SetSelectedComponent(component)
         elif component_mode == "all":
             alg.SetComponentModeToUseAll()

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -984,6 +984,8 @@ class DataSetFilters:
         if component_mode == "component":
             alg.SetComponentModeToUseSelected()
             dim = arr.shape[1]
+            if not isinstance(component, (int, np.integer)):
+                raise TypeError("component must be int")
             if component > (dim - 1) or component < 0:
                 raise ValueError(
                     f"scalars has {dim} components: supplied component {component} not in range"

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -813,6 +813,8 @@ class DataSetFilters:
         preference='cell',
         all_scalars=False,
         progress_bar=False,
+        component_mode="all",
+        component=0,
     ):
         """Apply a ``vtkThreshold`` filter to the input dataset.
 
@@ -858,6 +860,17 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        component_mode : {'selected', 'all', 'any'}
+            The method to satsfy the criteria for threshold for
+            multicomponent scalars.  'selected' (default)
+            uses only the ``component``.  'all' requires all
+            components to meet criteria.  'any' is when
+            any component satisfies the criteria.
+
+        component : int
+            When using ``component_mode='selected'``, this sets
+            which component to threshold on.  Default is ``0``.
 
         Returns
         -------
@@ -969,6 +982,17 @@ class DataSetFilters:
                 alg.ThresholdByLower(value)
             else:
                 alg.ThresholdByUpper(value)
+        if component_mode == "component":
+            alg.SetComponentModeToUseSelected()
+            alg.SetSelectedComponent(component)
+        elif component_mode == "all":
+            alg.SetComponentModeToUseAll()
+        elif component_mode == "any":
+            alg.SetComponentModeToUseAny()
+        else:
+            raise ValueError(
+                f"component_mode must be 'component', 'all', or 'any' got: {component_mode}"
+            )
         # Run the threshold
         _update_alg(alg, progress_bar, 'Thresholding')
         return _get_output(alg)

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -927,6 +927,7 @@ class DataSetFilters:
         arr = get_array(self, scalars, preference=preference, err=False)
         if arr is None:
             raise ValueError('No arrays present to threshold.')
+
         field = get_array_association(self, scalars, preference=preference)
 
         # If using an inverted range, merge the result of two filters:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -348,6 +348,9 @@ def test_threshold_multicomponent():
     with pytest.raises(ValueError):
         mesh.threshold(value=0.5, scalars="data", component_mode="component", component=3)
 
+    with pytest.raises(TypeError):
+        mesh.threshold(value=0.5, scalars="data", component_mode="component", component=0.5)
+
 
 def test_threshold_percent(datasets):
     percents = [25, 50, [18.0, 85.0], [19.0, 80.0], 0.70]

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -322,7 +322,7 @@ def test_threshold(datasets):
         )
 
 
-def test_threshold_vector():
+def test_threshold_multicomponent():
     mesh = pyvista.Plane()
     data = np.zeros((mesh.n_cells, 3))
     data[0:3, 0] = 1
@@ -341,6 +341,12 @@ def test_threshold_vector():
 
     with pytest.raises(ValueError):
         mesh.threshold(value=0.5, scalars="data", component_mode="not a mode")
+
+    with pytest.raises(ValueError):
+        mesh.threshold(value=0.5, scalars="data", component_mode="component", component=-1)
+
+    with pytest.raises(ValueError):
+        mesh.threshold(value=0.5, scalars="data", component_mode="component", component=3)
 
 
 def test_threshold_percent(datasets):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -322,6 +322,27 @@ def test_threshold(datasets):
         )
 
 
+def test_threshold_vector():
+    mesh = pyvista.Plane()
+    data = np.zeros((mesh.n_cells, 3))
+    data[0:3, 0] = 1
+    data[2:4, 1] = 2
+    data[2, 2] = 3
+    mesh["data"] = data
+
+    thresh = mesh.threshold(value=0.5, scalars="data", component_mode="component", component=0)
+    assert thresh.n_cells == 3
+    thresh = mesh.threshold(value=0.5, scalars="data", component_mode="component", component=1)
+    assert thresh.n_cells == 2
+    thresh = mesh.threshold(value=0.5, scalars="data", component_mode="all")
+    assert thresh.n_cells == 1
+    thresh = mesh.threshold(value=0.5, scalars="data", component_mode="any")
+    assert thresh.n_cells == 4
+
+    with pytest.raises(ValueError):
+        mesh.threshold(value=0.5, scalars="data", component_mode="not a mode")
+
+
 def test_threshold_percent(datasets):
     percents = [25, 50, [18.0, 85.0], [19.0, 80.0], 0.70]
     inverts = [False, True, False, True, False]


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->
#2347 showed that options were missing from threshold filter to handle multicomponent scalars.  This PR exposes available functionality from [vtkThreshold](https://vtk.org/doc/nightly/html/classvtkThreshold.html).

### Details


