### PR TITLE
Add support for vtkHDFReader

### DIFF
--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -472,6 +472,12 @@ if VTK9:
 
         return vtkSegYReader()
 
+    def lazy_vtkHDFReader():
+        """Lazy import of the vtkHDFReader."""
+        from vtkmodules.vtkIOHDF import vtkHDFReader
+
+        return vtkHDFReader()
+
 else:  # pragma: no cover
 
     # maintain VTK 8.2 compatibility
@@ -549,6 +555,15 @@ else:  # pragma: no cover
             from pyvista.core.errors import VTKVersionError
 
             raise VTKVersionError('Charts requires VTK v9 or newer')
+
+    class vtkHDFReader:  # type: ignore
+        """Empty placeholder for VTK9 compatibility."""
+
+        def __init__(self):  # pragma: no cover
+            """Raise version error on init."""
+            from pyvista.core.errors import VTKVersionError
+
+            raise VTKVersionError('vtkHDFReader requires VTK v9 or newer')
 
 
 # lazy import as this was added in 9.1.0

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -3563,3 +3563,43 @@ def download_lucy(load=True):  # pragma: no cover
 
     """
     return _download_and_read('lucy.ply', load=load)
+
+
+def download_can(partial=False):  # pragma: no cover
+    """Download the can dataset mesh.
+
+    Original downloaded from Testing/Data/FileSeriesat from paraview.org. Used
+    for testing hdf files.
+
+    Parameters
+    ----------
+    partial : bool, optional
+        Load part of the dataset. Defaults to to ``False`` and
+        filename will be returned.
+
+    Returns
+    -------
+    pyvista.PolyData
+        The example ParaView can DataSet.
+
+    Examples
+    --------
+    Plot the can dataset.
+
+    >>> from pyvista import examples
+    >>> import pyvista
+    >>> dataset = examples.download_can()
+    >>> dataset.plot(scalars='VEL', smooth_shading=True)
+
+    """
+    can_0 = _download_and_read('hdf/can_0.hdf')
+    if partial:
+        return can_0
+
+    return pyvista.merge(
+        [
+            can_0,
+            _download_and_read('hdf/can_1.hdf'),
+            _download_and_read('hdf/can_2.hdf'),
+        ]
+    )

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -82,7 +82,7 @@ if VTK_MAJOR >= 8 and VTK_MINOR >= 2:
 if VTK_MAJOR >= 9 and VTK_MINOR >= 0:
     try:
         READERS['.hdf'] = _vtk.lazy_vtkHDFReader
-    except AttributeError:
+    except AttributeError:  # pragma: no cover
         pass
 
 

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -79,6 +79,13 @@ if VTK_MAJOR >= 8 and VTK_MINOR >= 2:
         pass
 
 
+if VTK_MAJOR >= 9 and VTK_MINOR >= 0:
+    try:
+        READERS['.hdf'] = _vtk.lazy_vtkHDFReader
+    except AttributeError:
+        pass
+
+
 def _get_ext_force(filename, force_ext=None):
     if force_ext:
         return str(force_ext).lower()

--- a/tests/utilities/test_reader.py
+++ b/tests/utilities/test_reader.py
@@ -477,6 +477,7 @@ def test_openfoam_patch_arrays():
     assert mesh[patch_array_key].keys() == ['movingWall', 'fixedWalls', 'frontAndBack']
 
 
+@pytest.mark.skipif(pyvista.vtk_version_info < (9, 1), reason="Requires VTK v9.1.0 or newer")
 def test_read_hdf():
     can = examples.download_can(partial=True)
     assert can.n_points == 6724

--- a/tests/utilities/test_reader.py
+++ b/tests/utilities/test_reader.py
@@ -475,3 +475,10 @@ def test_openfoam_patch_arrays():
     assert mesh.n_blocks == 1
     assert patch_array_key in mesh.keys()
     assert mesh[patch_array_key].keys() == ['movingWall', 'fixedWalls', 'frontAndBack']
+
+
+def test_read_hdf():
+    can = examples.download_can(partial=True)
+    assert can.n_points == 6724
+    assert 'VEL' in can.point_data
+    assert can.n_cells == 4800


### PR DESCRIPTION
### Overview

A new VTKHDF format for unstructured meshes was added in VTK (see [this PR](https://gitlab.kitware.com/vtk/vtk/-/merge_requests/7552)) and to Paraview ([readers_iohdf.xml](https://gitlab.kitware.com/paraview/paraview/-/blob/master/Remoting/Application/Resources/readers_iohdf.xml))

### Details

Tested with Paraview 5.10 and VTK 9.1 on Arch Linux.
