### PR TITLE
Fix typo of threshold docstring

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -862,7 +862,7 @@ class DataSetFilters:
             Display a progress bar to indicate progress.
 
         component_mode : {'selected', 'all', 'any'}
-            The method to satisfy the criteria for the threshold for
+            The method to satisfy the criteria for the threshold of
             multicomponent scalars.  'selected' (default)
             uses only the ``component``.  'all' requires all
             components to meet criteria.  'any' is when

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -862,7 +862,7 @@ class DataSetFilters:
             Display a progress bar to indicate progress.
 
         component_mode : {'selected', 'all', 'any'}
-            The method to satsfy the criteria for threshold for
+            The method to satisfy the criteria for the threshold for
             multicomponent scalars.  'selected' (default)
             uses only the ``component``.  'all' requires all
             components to meet criteria.  'any' is when


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Fix typo of threshold docstring by https://github.com/pyvista/pyvista/pull/2349. (Sorry I couldn't find it in review.)

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 


<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None

