### PR TITLE
Create PyvistaFutureWarning, use it to warn about extrude capping changes

### DIFF
--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -17,7 +17,7 @@ from pyvista import (
 from pyvista.core.errors import DeprecationError, NotAllTrianglesError, VTKVersionError
 from pyvista.core.filters import _get_output, _update_alg
 from pyvista.core.filters.data_set import DataSetFilters
-from pyvista.utilities.misc import PyvistaDeprecationWarning
+from pyvista.utilities.misc import PyvistaFutureWarning
 
 
 @abstract_class
@@ -2605,7 +2605,7 @@ class PolyDataFilters(DataSetFilters):
                 'The default value of the ``capping`` keyword argument will change in '
                 'a future version to ``True`` to match the behavior of VTK. We recommend '
                 'passing the keyword explicitly to prevent future surprises.',
-                PyvistaDeprecationWarning,
+                PyvistaFutureWarning,
             )
 
         alg = _vtk.vtkLinearExtrusionFilter()
@@ -2735,7 +2735,7 @@ class PolyDataFilters(DataSetFilters):
                 'The default value of the ``capping`` keyword argument will change in '
                 'a future version to ``True`` to match the behavior of VTK. We recommend '
                 'passing the keyword explicitly to prevent future surprises.',
-                PyvistaDeprecationWarning,
+                PyvistaFutureWarning,
             )
 
         if resolution <= 0:

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -17,6 +17,7 @@ from pyvista import (
 from pyvista.core.errors import DeprecationError, NotAllTrianglesError, VTKVersionError
 from pyvista.core.filters import _get_output, _update_alg
 from pyvista.core.filters.data_set import DataSetFilters
+from pyvista.utilities.misc import PyvistaDeprecationWarning
 
 
 @abstract_class
@@ -2530,7 +2531,7 @@ class PolyDataFilters(DataSetFilters):
         _update_alg(alg, progress_bar, 'Creating a Ribbon')
         return _get_output(alg)
 
-    def extrude(self, vector, capping=False, inplace=False, progress_bar=False):
+    def extrude(self, vector, capping=None, inplace=False, progress_bar=False):
         """Sweep polygonal data creating a "skirt" from free edges.
 
         This will create a line from vertices.
@@ -2551,6 +2552,8 @@ class PolyDataFilters(DataSetFilters):
         .. versionchanged:: 0.32.0
            The ``capping`` keyword was added with a default of ``False``.
            The previously used VTK default corresponds to ``capping=True``.
+           In a future version the default will be changed to ``True`` to
+           match the behavior of the underlying VTK filter.
 
         Parameters
         ----------
@@ -2558,7 +2561,16 @@ class PolyDataFilters(DataSetFilters):
             Direction and length to extrude the mesh in.
 
         capping : bool, optional
-            Control if the sweep of a 2D object is capped.
+            Control if the sweep of a 2D object is capped. The default is
+            ``False``, which differs from VTK's default.
+
+            .. warning::
+               The ``capping`` keyword was added in version 0.32.0 with a
+               default value of ``False``. In a future version this default
+               will be changed to ``True`` to match the behavior of the
+               underlying VTK filter. It is recommended to explicitly pass
+               a value for this keyword argument to prevent future changes
+               in behavior and warnings.
 
         inplace : bool, optional
             Overwrites the original mesh in-place.
@@ -2587,6 +2599,15 @@ class PolyDataFilters(DataSetFilters):
         >>> mesh.plot(line_width=5, show_edges=True)
 
         """
+        if capping is None:
+            capping = False
+            warnings.warn(
+                'The default value of the ``capping`` keyword argument will change in '
+                'a future version to ``True`` to match the behavior of VTK. We recommend '
+                'passing the keyword explicitly to prevent future surprises.',
+                PyvistaDeprecationWarning,
+            )
+
         alg = _vtk.vtkLinearExtrusionFilter()
         alg.SetExtrusionTypeToVectorExtrusion()
         alg.SetVector(*vector)
@@ -2606,7 +2627,7 @@ class PolyDataFilters(DataSetFilters):
         translation=0.0,
         dradius=0.0,
         angle=360.0,
-        capping=False,
+        capping=None,
         progress_bar=False,
     ):
         """Sweep polygonal data creating "skirt" from free edges and lines, and lines from vertices.
@@ -2639,6 +2660,8 @@ class PolyDataFilters(DataSetFilters):
         .. versionchanged:: 0.32.0
            The ``capping`` keyword was added with a default of ``False``.
            The previously used VTK default corresponds to ``capping=True``.
+           In a future version the default will be changed to ``True`` to
+           match the behavior of the underlying VTK filter.
 
         Parameters
         ----------
@@ -2658,7 +2681,16 @@ class PolyDataFilters(DataSetFilters):
             The angle of rotation in degrees.
 
         capping : bool, optional
-            Control if the sweep of a 2D object is capped.
+            Control if the sweep of a 2D object is capped. The default is
+            ``False``, which differs from VTK's default.
+
+            .. warning::
+               The ``capping`` keyword was added in version 0.32.0 with a
+               default value of ``False``. In a future version this default
+               will be changed to ``True`` to match the behavior of the
+               underlying VTK filter. It is recommended to explicitly pass
+               a value for this keyword argument to prevent future changes
+               in behavior and warnings.
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
@@ -2676,7 +2708,8 @@ class PolyDataFilters(DataSetFilters):
         >>> profile = pyvista.Polygon(center=[1.25, 0.0, 0.0], radius=0.2,
         ...                           normal=(0, 1, 0), n_sides=30)
         >>> extruded = profile.extrude_rotate(resolution=360, translation=4.0,
-        ...                                   dradius=.5, angle=1500.0)
+        ...                                   dradius=0.5, angle=1500.0,
+        ...                                   capping=True)
         >>> extruded.plot(smooth_shading=True)
 
         Create a "wine glass" using the rotational extrusion filter.
@@ -2696,6 +2729,15 @@ class PolyDataFilters(DataSetFilters):
         >>> extruded.plot(color='tan')
 
         """
+        if capping is None:
+            capping = False
+            warnings.warn(
+                'The default value of the ``capping`` keyword argument will change in '
+                'a future version to ``True`` to match the behavior of VTK. We recommend '
+                'passing the keyword explicitly to prevent future surprises.',
+                PyvistaDeprecationWarning,
+            )
+
         if resolution <= 0:
             raise ValueError('`resolution` should be positive')
         alg = _vtk.vtkRotationalExtrusionFilter()

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2590,7 +2590,7 @@ class PolyDataFilters(DataSetFilters):
 
         >>> import pyvista
         >>> arc = pyvista.CircularArc([-1, 0, 0], [1, 0, 0], [0, 0, 0])
-        >>> mesh = arc.extrude([0, 0, 1])
+        >>> mesh = arc.extrude([0, 0, 1], capping=False)
         >>> mesh.plot(color='tan')
 
         Extrude and cap an 8 sided polygon.
@@ -2726,7 +2726,7 @@ class PolyDataFilters(DataSetFilters):
         ...                    [-0.1, 0, 0.8],
         ...                    [-0.2, 0, 1.0]])
         >>> spline = pyvista.Spline(points, 30)
-        >>> extruded = spline.extrude_rotate(resolution=20)
+        >>> extruded = spline.extrude_rotate(resolution=20, capping=False)
         >>> extruded.plot(color='tan')
 
         """

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2599,7 +2599,7 @@ class PolyDataFilters(DataSetFilters):
         >>> mesh.plot(line_width=5, show_edges=True)
 
         """
-        if capping is None:
+        if capping is None:  # pragma: no cover
             capping = False
             warnings.warn(
                 'The default value of the ``capping`` keyword argument will change in '
@@ -2729,7 +2729,7 @@ class PolyDataFilters(DataSetFilters):
         >>> extruded.plot(color='tan')
 
         """
-        if capping is None:
+        if capping is None:  # pragma: no cover
             capping = False
             warnings.warn(
                 'The default value of the ``capping`` keyword argument will change in '

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2600,7 +2600,7 @@ class PolyDataFilters(DataSetFilters):
         >>> mesh.plot(line_width=5, show_edges=True)
 
         """
-        if capping is None:  # pragma: no cover
+        if capping is None:
             capping = False
             warnings.warn(
                 'The default value of the ``capping`` keyword argument will change in '
@@ -2730,7 +2730,7 @@ class PolyDataFilters(DataSetFilters):
         >>> extruded.plot(color='tan')
 
         """
-        if capping is None:  # pragma: no cover
+        if capping is None:
             capping = False
             warnings.warn(
                 'The default value of the ``capping`` keyword argument will change in '

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -1,6 +1,7 @@
 """Filters module with a class to manage filters/algorithms for polydata datasets."""
 import collections.abc
 import logging
+import warnings
 
 import numpy as np
 

--- a/pyvista/utilities/misc.py
+++ b/pyvista/utilities/misc.py
@@ -23,6 +23,12 @@ class PyvistaDeprecationWarning(Warning):
     pass
 
 
+class PyvistaFutureWarning(Warning):
+    """Non-supressed Future Warning."""
+
+    pass
+
+
 def VTKVersionInfo():
     """Return the vtk version as a namedtuple."""
     version_info = namedtuple('VTKVersionInfo', ['major', 'minor', 'micro'])

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1999,21 +1999,26 @@ def test_extrude_rotate():
     line = pyvista.Line(pointa=(0, 0, 0), pointb=(1, 0, 0))
 
     with pytest.raises(ValueError):
-        line.extrude_rotate(resolution=0)
+        line.extrude_rotate(resolution=0, capping=True)
 
-    poly = line.extrude_rotate(resolution=resolution, progress_bar=True)
+    poly = line.extrude_rotate(resolution=resolution, progress_bar=True, capping=True)
     assert poly.n_cells == line.n_points - 1
     assert poly.n_points == (resolution + 1) * line.n_points
 
     translation = 10.0
     dradius = 1.0
-    poly = line.extrude_rotate(translation=translation, dradius=dradius, progress_bar=True)
+    poly = line.extrude_rotate(
+        translation=translation,
+        dradius=dradius,
+        progress_bar=True,
+        capping=True,
+    )
     zmax = poly.bounds[5]
     assert zmax == translation
     xmax = poly.bounds[1]
     assert xmax == line.bounds[1] + dradius
 
-    poly = line.extrude_rotate(angle=90.0, progress_bar=True)
+    poly = line.extrude_rotate(angle=90.0, progress_bar=True, capping=True)
     xmin = poly.bounds[0]
     xmax = poly.bounds[1]
     ymin = poly.bounds[2]
@@ -2030,7 +2035,7 @@ def test_extrude_rotate_inplace():
     resolution = 4
     poly = pyvista.Line(pointa=(0, 0, 0), pointb=(1, 0, 0))
     old_line = poly.copy()
-    poly.extrude_rotate(resolution=resolution, inplace=True, progress_bar=True)
+    poly.extrude_rotate(resolution=resolution, inplace=True, progress_bar=True, capping=True)
     assert poly.n_cells == old_line.n_points - 1
     assert poly.n_points == (resolution + 1) * old_line.n_points
 

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -781,9 +781,9 @@ def test_extrude():
 def test_extrude_capping_warnings():
     arc = pyvista.CircularArc([-1, 0, 0], [1, 0, 0], [0, 0, 0])
     with pytest.warns(PyvistaFutureWarning, match='default value of the ``capping`` keyword'):
-        poly = arc.extrude([0, 0, 1])
+        arc.extrude([0, 0, 1])
     with pytest.warns(PyvistaFutureWarning, match='default value of the ``capping`` keyword'):
-        poly = arc.extrude_rotate()
+        arc.extrude_rotate()
 
 
 def test_flip_normals(sphere, plane):

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -768,12 +768,12 @@ def test_is_all_triangles():
 
 def test_extrude():
     arc = pyvista.CircularArc([-1, 0, 0], [1, 0, 0], [0, 0, 0])
-    poly = arc.extrude([0, 0, 1], progress_bar=True)
+    poly = arc.extrude([0, 0, 1], progress_bar=True, capping=True)
     assert poly.n_points
     assert poly.n_cells
 
     n_points_old = arc.n_points
-    arc.extrude([0, 0, 1], inplace=True)
+    arc.extrude([0, 0, 1], inplace=True, capping=True)
     assert arc.n_points != n_points_old
 
 

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -9,6 +9,7 @@ import pyvista
 from pyvista import examples
 from pyvista.core.errors import NotAllTrianglesError
 from pyvista.plotting import system_supports_plotting
+from pyvista.utilities.misc import PyvistaFutureWarning
 
 radius = 0.5
 
@@ -775,6 +776,14 @@ def test_extrude():
     n_points_old = arc.n_points
     arc.extrude([0, 0, 1], inplace=True, capping=True)
     assert arc.n_points != n_points_old
+
+
+def test_extrude_capping_warnings():
+    arc = pyvista.CircularArc([-1, 0, 0], [1, 0, 0], [0, 0, 0])
+    with pytest.warns(PyvistaFutureWarning, match='default value of the ``capping`` keyword'):
+        poly = arc.extrude([0, 0, 1])
+    with pytest.warns(PyvistaFutureWarning, match='default value of the ``capping`` keyword'):
+        poly = arc.extrude_rotate()
 
 
 def test_flip_normals(sphere, plane):


### PR DESCRIPTION
### Overview

As per the discussion in https://github.com/pyvista/pyvista/pull/2339 we should change back the value of the `capping` kwarg to `True` to match VTK. As a first approach I kept the original kwarg but added a future warning (with a new non-silenced warning class), because code written in the last 6 months might rely on the new `False` default.

We could also argue that the change in default behaviour was a bug and we could also fix it (i.e. just revert the default to `True`). Let me know if this would be preferred.

I haven't built the docs locally, I'll check the CI artifact.