### PR TITLE
fix Jinja requirements

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,4 @@
+Jinja2==3.0.3
 Sphinx==4.4.0
 cmocean==2.0
 colorcet==3.0.0


### PR DESCRIPTION
The release of `Jinja2` has broken the import of `panel`. Until the next version of `panel` is released, this PR pins `Jinja2` to `3.0.3`.

See https://github.com/holoviz/panel/issues/3257 for further details.
