### PR TITLE
Fix pythreejs indexing issue when number of lines != number of cells

### DIFF
--- a/pyvista/jupyter/pv_pythreejs.py
+++ b/pyvista/jupyter/pv_pythreejs.py
@@ -21,9 +21,10 @@ def segment_poly_cells(mesh):
     polylines = []
     offset = 0
     cc = mesh.lines  # fetch up front
-    while offset < len(cc):
+    ncc = len(cc)
+    while offset < ncc:
         nn = cc[offset]
-        polylines.append(cc[offset + 1 : offset + 1 + nn])
+        polylines.append(cc[offset + 1:offset + 1 + nn])
         offset += nn + 1
 
     lines = []

--- a/pyvista/jupyter/pv_pythreejs.py
+++ b/pyvista/jupyter/pv_pythreejs.py
@@ -24,7 +24,7 @@ def segment_poly_cells(mesh):
     ncc = len(cc)
     while offset < ncc:
         nn = cc[offset]
-        polylines.append(cc[offset + 1:offset + 1 + nn])
+        polylines.append(cc[offset + 1 : offset + 1 + nn])
         offset += nn + 1
 
     lines = []

--- a/pyvista/jupyter/pv_pythreejs.py
+++ b/pyvista/jupyter/pv_pythreejs.py
@@ -19,13 +19,12 @@ def segment_poly_cells(mesh):
     if not pv.is_pyvista_dataset(mesh):  # pragma: no cover
         mesh = pv.wrap(mesh)
     polylines = []
-    i, offset = 0, 0
+    offset = 0
     cc = mesh.lines  # fetch up front
-    while i < mesh.n_cells:
+    while offset < len(cc):
         nn = cc[offset]
         polylines.append(cc[offset + 1 : offset + 1 + nn])
         offset += nn + 1
-        i += 1
 
     lines = []
     for poly in polylines:


### PR DESCRIPTION
### Overview

Fixes issue with converting meshes to pythreejs when the number of lines is not equal to the number of cells.
I don't exactly know when this occurs; but I have a feeling it's an uncommon case. Nevertheless, it seems safer to end this loop based on the value in `lines` rather than on `n_cells`.

Addresses #1557 

