### PR TITLE
fix normals output in gltf export

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -432,7 +432,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Rotate scene to be compatible with the glTF specifications.
 
         save_normals : bool, optional
-            Saves the point array ``'Normals'`` as ``'NORMALS'`` in
+            Saves the point array ``'Normals'`` as ``'NORMAL'`` in
             the outputted scene.
 
         Examples
@@ -485,9 +485,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
                                 continue
                             dataset = mapper.GetInputAsDataSet()
                             if 'Normals' in dataset.point_data:
-                                # ensure normals are active
-                                normals = dataset.point_data['Normals']
-                                dataset.point_data.active_normals = normals.copy()
+                                # By default VTK uses the 'Normals' point data for normals
+                                # but gLTF uses NORMAL. We have to both copy this as an
+                                # inactive array and then change the name of the active
+                                # normals to get `SetSaveNormal` to work.
+                                dataset.point_data.set_array(
+                                    dataset.point_data['Normals'].copy(), "NORMAL"
+                                )
+                                dataset.active_normals_name = "NORMAL"
                         except:  # noqa: E722
                             pass
 


### PR DESCRIPTION
### Overview

This PR fixes the normal output in `gltf_export` by renaming the normals array to `"NORMAL"`. You can test this (and previous) behavior at a gltf viewer like https://sandbox.babylonjs.com/ with a simple script:


```py
import pyvista as pv
pd = pv.Sphere()
pd.point_data['arng'] = np.arange(pd.n_points, dtype=np.double)

pl = pv.Plotter()
pl.add_mesh(pd, smooth_shading=True)
pl.export_gltf("sphere.gltf")
```

### `main`
![image](https://user-images.githubusercontent.com/11981631/160388855-cfe99f18-77e0-442f-9d0b-9139c40c062f.png)


### This branch

![image](https://user-images.githubusercontent.com/11981631/160389095-ed9364e2-1b6e-4d7f-93b8-b878a3d18728.png)