### PR TITLE
Replace np.dtype identity check with equivalence 

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -4115,7 +4115,7 @@ class DataSetFilters:
 
         # extracts only in float32
         if subgrid.n_points:
-            if self.points.dtype is not np.dtype('float32'):
+            if self.points.dtype != np.dtype('float32'):
                 ind = subgrid.point_data['vtkOriginalPointIds']
                 subgrid.points = self.points[ind]
 

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -156,7 +156,7 @@ def convert_array(arr, name=None, deep=False, array_type=None):
     if arr is None:
         return
     if isinstance(arr, np.ndarray):
-        if arr.dtype is np.dtype('O'):
+        if arr.dtype == np.dtype('O'):
             arr = arr.astype('|S')
         arr = np.ascontiguousarray(arr)
         if arr.dtype.type in (np.str_, np.bytes_):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,6 +1,7 @@
 """ test pyvista.utilities """
 import os
 import pathlib
+import pickle
 import shutil
 import unittest.mock as mock
 import warnings
@@ -730,3 +731,12 @@ def test_color():
     # Check sRGB conversion
     assert pyvista.Color('gray', 0.5).linear_to_srgb() == '#bcbcbcbc'
     assert pyvista.Color('#bcbcbcbc').srgb_to_linear() == '#80808080'
+
+
+def test_convert_array():
+    arr = np.arange(4).astype('O')
+    arr2 = pyvista.utilities.convert_array(arr, array_type=np.dtype('O'))
+
+    # https://github.com/pyvista/pyvista/issues/2370
+    arr3 = pyvista.utilities.convert_array(pickle.loads(pickle.dumps(np.arange(4).astype('O'))),
+                                           array_type=np.dtype('O'))


### PR DESCRIPTION
### Overview
Addresses #2370 , the discussion of which has more details.

tl;dr - Don't use identity to compare dtypes (see https://stackoverflow.com/questions/26921836/correct-way-to-test-for-numpy-dtype)

A minimal failing test is added.
