### PR TITLE
Read .mha files via vtkMetaImageReader

### DIFF
--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -1473,6 +1473,33 @@ def download_frog(load=True):  # pragma: no cover
     return _download_and_read('froggy/frog.mhd', load=load)
 
 
+def download_chest(load=True):  # pragma: no cover
+    """Download chest dataset.
+
+    Parameters
+    ----------
+    load : bool, optional
+        Load the dataset after downloading it when ``True``.  Set this
+        to ``False`` and only the filename will be returned.
+
+    Returns
+    -------
+    pyvista.UniformGrid or str
+        DataSet or filename depending on ``load``.
+
+    Examples
+    --------
+    >>> from pyvista import examples
+    >>> dataset = examples.download_chest()
+    >>> dataset.plot(cpos="xy")
+
+    See :ref:`volume_rendering_example` for an example using
+    this dataset.
+
+    """
+    return _download_and_read('MetaIO/ChestCT-SHORT.mha', load=load)
+
+
 def download_prostate(load=True):  # pragma: no cover
     """Download prostate dataset.
 

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -34,6 +34,7 @@ READERS = {
     '.img': _vtk.vtkDICOMImageReader,
     '.jpeg': _vtk.vtkJPEGReader,
     '.jpg': _vtk.vtkJPEGReader,
+    '.mha': _vtk.vtkMetaImageReader,
     '.mhd': _vtk.vtkMetaImageReader,
     '.nrrd': _vtk.vtkNrrdReader,
     '.nhdr': _vtk.vtkNrrdReader,
@@ -285,6 +286,7 @@ def read(filename, attrs=None, force_ext=None, file_format=None, progress_bar=Fa
     * ``'.img'``
     * ``'.jpeg'``
     * ``'.jpg'``
+    * ``'.mha'``
     * ``'.mhd'``
     * ``'.nrrd'``
     * ``'.nhdr'``

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -229,6 +229,10 @@ if TEST_DOWNLOADS:
         data = examples.download_frog()
         assert data.n_cells
 
+    def test_download_chest():
+        data = examples.download_chest()
+        assert data.n_cells
+
     def test_download_prostate():
         data = examples.download_prostate()
         assert data.n_cells


### PR DESCRIPTION
### Overview

Support reading of MetaImage format with .mha extension (.mhd + .raw packed into a single file)

### Details

- support for .mha image format 
- exposes example chest dataset (CT volume)

