### PR TITLE
Add gLTF warning

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -485,11 +485,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
                             if mapper is None:
                                 continue
                             dataset = mapper.GetInputAsDataSet()
-                            if isinstance(dataset, pyvista.UnstructuredGrid):
+                            if not isinstance(dataset, pyvista.PolyData):
                                 warnings.warn(
-                                    "UnstructuredGrid is not supported by gLTF. Convert to "
-                                    "a PolyData with extract_surface and add that to the "
-                                    "plotter instead"
+                                    f"{type(dataset).__name__} is not supported by gLTF. "
+                                    "Convert to a PolyData with extract_surface and add "
+                                    "that to the plotter instead."
                                 )
                             if 'Normals' in dataset.point_data:
                                 # By default VTK uses the 'Normals' point data for normals

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -485,6 +485,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
                             if mapper is None:
                                 continue
                             dataset = mapper.GetInputAsDataSet()
+                            if isinstance(dataset, pyvista.UnstructuredGrid):
+                                warnings.warn(
+                                    "UnstructuredGrid is not supported by gLTF. Convert to "
+                                    "a PolyData with extract_surface and add that to the "
+                                    "plotter instead"
+                                )
                             if 'Normals' in dataset.point_data:
                                 # By default VTK uses the 'Normals' point data for normals
                                 # but gLTF uses NORMAL.

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -175,13 +175,15 @@ def test_import_gltf():
 
 
 @skip_not_vtk9
-def test_export_gltf(tmpdir, sphere, airplane):
+def test_export_gltf(tmpdir, sphere, airplane, hexbeam):
     filename = str(tmpdir.mkdir("tmpdir").join('tmp.gltf'))
 
     pl = pyvista.Plotter()
     pl.add_mesh(sphere, smooth_shading=True)
     pl.add_mesh(airplane)
-    pl.export_gltf(filename)
+    pl.add_mesh(hexbeam)  # to check warning
+    with pytest.warns(UserWarning, match='UnstructuredGrid is not supported by gLTF'):
+        pl.export_gltf(filename)
 
     pl_import = pyvista.Plotter()
     pl_import.import_gltf(filename)


### PR DESCRIPTION
Resolves #2359 by converting non-polydata datasets to polydata within the Plotter object when exporting to gltf.
