### PR TITLE
Make colors iterable and indexable

### DIFF
--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -875,6 +875,16 @@ class Color:
         """Hash calculation."""
         return hash((self._red, self._green, self._blue, self._opacity))
 
+    def __getitem__(self, item):
+        """Support indexing for backward compatibility."""
+        if item < 0 or item > 3:
+            raise IndexError("Colors have only 4 channels.")
+        return self.float_rgba[item]
+
+    def __iter__(self):
+        """Support iterable for backward compatibility."""
+        return iter(self.float_rgba)
+
     def __repr__(self):  # pragma: no cover
         """Human readable representation."""
         kwargs = f"hex={self.hex_rgba!r}"

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -452,12 +452,14 @@ class Color:
     """
 
     # Supported names for each color channel.
-    CHANNEL_NAMES = [
-        {'red', 'r'},  # 0
-        {'green', 'g'},  # 1
-        {'blue', 'b'},  # 2
-        {'alpha', 'a', 'opacity'},  # 3
-    ]
+    CHANNEL_NAMES = tuple(
+        [
+            {'red', 'r'},  # 0
+            {'green', 'g'},  # 1
+            {'blue', 'b'},  # 2
+            {'alpha', 'a', 'opacity'},  # 3
+        ]
+    )
 
     def __init__(
         self,
@@ -884,12 +886,15 @@ class Color:
 
     def __getitem__(self, item):
         """Support indexing the float RGBA representation for backward compatibility."""
-        for i, cnames in enumerate(self.CHANNEL_NAMES):
-            if item in cnames:
-                item = i
-        if item < 0 or item > 3:
-            raise IndexError("Colors have only 4 channels.")
-        return self.float_rgba[item]
+        if isinstance(item, (str, int, np.integer)):
+            for i, cnames in enumerate(self.CHANNEL_NAMES):
+                if item in cnames:
+                    item = i
+            if item < 0 or item > 3:
+                raise IndexError("Colors have only 4 channels.")
+            return self.float_rgba[item]
+        else:
+            raise TypeError("Invalid index specified, only strings and integers are supported.")
 
     def __iter__(self):
         """Support iteration over the float RGBA representation for backward compatibility."""

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -452,13 +452,11 @@ class Color:
     """
 
     # Supported names for each color channel.
-    CHANNEL_NAMES = tuple(
-        [
-            {'red', 'r'},  # 0
-            {'green', 'g'},  # 1
-            {'blue', 'b'},  # 2
-            {'alpha', 'a', 'opacity'},  # 3
-        ]
+    CHANNEL_NAMES = (
+        {'red', 'r'},  # 0
+        {'green', 'g'},  # 1
+        {'blue', 'b'},  # 2
+        {'alpha', 'a', 'opacity'},  # 3
     )
 
     def __init__(
@@ -886,15 +884,18 @@ class Color:
 
     def __getitem__(self, item):
         """Support indexing the float RGBA representation for backward compatibility."""
-        if isinstance(item, (str, int, np.integer)):
+        if not isinstance(item, (str, int, np.integer)):
+            raise TypeError("Invalid index specified, only strings and integers are supported.")
+        if isinstance(item, str):
             for i, cnames in enumerate(self.CHANNEL_NAMES):
                 if item in cnames:
                     item = i
-            if item < 0 or item > 3:
-                raise IndexError("Colors have only 4 channels.")
-            return self.float_rgba[item]
-        else:
-            raise TypeError("Invalid index specified, only strings and integers are supported.")
+                    break
+            else:
+                raise ValueError(f"Invalid string index {item!r}.")
+        if not 0 <= item < 4:
+            raise IndexError("Colors have only 4 channels.")
+        return self.float_rgba[item]
 
     def __iter__(self):
         """Support iteration over the float RGBA representation for backward compatibility."""

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -884,7 +884,7 @@ class Color:
 
     def __getitem__(self, item):
         """Support indexing the float RGBA representation for backward compatibility."""
-        if not isinstance(item, (str, int, np.integer)):
+        if not isinstance(item, (str, slice, int, np.integer)):
             raise TypeError("Invalid index specified, only strings and integers are supported.")
         if isinstance(item, str):
             for i, cnames in enumerate(self.CHANNEL_NAMES):
@@ -893,8 +893,6 @@ class Color:
                     break
             else:
                 raise ValueError(f"Invalid string index {item!r}.")
-        if not 0 <= item < 4:
-            raise IndexError("Colors have only 4 channels.")
         return self.float_rgba[item]
 
     def __iter__(self):

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -451,6 +451,14 @@ class Color:
 
     """
 
+    # Supported names for each color channel.
+    CHANNEL_NAMES = [
+        {'red', 'r'},  # 0
+        {'green', 'g'},  # 1
+        {'blue', 'b'},  # 2
+        {'alpha', 'a', 'opacity'},  # 3
+    ]
+
     def __init__(
         self,
         color: Optional[color_like] = None,
@@ -588,11 +596,10 @@ class Color:
     def _from_dict(self, dct):
         """Construct color from an RGB(A) dictionary."""
         # Get any of the keys associated with each color channel (or None).
-        r = next((dct[key] for key in {'r', 'red'} if key in dct), None)
-        g = next((dct[key] for key in {'g', 'green'} if key in dct), None)
-        b = next((dct[key] for key in {'b', 'blue'} if key in dct), None)
-        a = next((dct[key] for key in {'a', 'alpha', 'opacity'} if key in dct), None)
-        self._from_rgba([r, g, b, a])
+        rgba = [
+            next((dct[key] for key in cnames if key in dct), None) for cnames in self.CHANNEL_NAMES
+        ]
+        self._from_rgba(rgba)
 
     def _from_hex(self, h):
         """Construct color from a hex string."""
@@ -876,13 +883,16 @@ class Color:
         return hash((self._red, self._green, self._blue, self._opacity))
 
     def __getitem__(self, item):
-        """Support indexing for backward compatibility."""
+        """Support indexing the float RGBA representation for backward compatibility."""
+        for i, cnames in enumerate(self.CHANNEL_NAMES):
+            if item in cnames:
+                item = i
         if item < 0 or item > 3:
             raise IndexError("Colors have only 4 channels.")
         return self.float_rgba[item]
 
     def __iter__(self):
-        """Support iterable for backward compatibility."""
+        """Support iteration over the float RGBA representation for backward compatibility."""
         return iter(self.float_rgba)
 
     def __repr__(self):  # pragma: no cover

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -743,6 +743,12 @@ def test_color():
     for i, cnames in enumerate(pyvista.Color.CHANNEL_NAMES):
         assert c[i] == f_rgba[i]
         assert all(c[i] == c[cname] for cname in cnames)
+    with pytest.raises(TypeError):
+        c[None]  # Invalid index type
+    with pytest.raises(ValueError):
+        c["invalid_name"]  # Invalid string index
+    with pytest.raises(IndexError):
+        c[4]  # Invalid integer index
 
 
 def test_convert_array():

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,4 +1,5 @@
 """ test pyvista.utilities """
+import itertools
 import os
 import pathlib
 import pickle
@@ -679,6 +680,7 @@ def test_color():
         (0, 0),
         "#hh0000",
         "invalid_name",
+        {"invalid_name": 100},
     )
     invalid_opacities = (275, -50, 2.4, -1.2, "#zz")
     i_types = (int, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64)
@@ -703,6 +705,10 @@ def test_color():
     # Check hex
     for h_prefix in h_prefixes:
         assert pyvista.Color(h_prefix + h) == i_rgba
+    # Check dict
+    for channels in itertools.product(*pyvista.Color.CHANNEL_NAMES):
+        dct = dict(zip(channels, i_rgba))
+        assert pyvista.Color(dct) == i_rgba
     # Check opacity
     for opacity in (i_opacity, f_opacity, h_opacity):
         # No opacity in color provided => use opacity
@@ -731,6 +737,12 @@ def test_color():
     # Check sRGB conversion
     assert pyvista.Color('gray', 0.5).linear_to_srgb() == '#bcbcbcbc'
     assert pyvista.Color('#bcbcbcbc').srgb_to_linear() == '#80808080'
+    # Check iteration and indexing
+    c = pyvista.Color(i_rgba)
+    assert all(ci == fi for ci, fi in zip(c, f_rgba))
+    for i, cnames in enumerate(pyvista.Color.CHANNEL_NAMES):
+        assert c[i] == f_rgba[i]
+        assert all(c[i] == c[cname] for cname in cnames)
 
 
 def test_convert_array():

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -743,6 +743,8 @@ def test_color():
     for i, cnames in enumerate(pyvista.Color.CHANNEL_NAMES):
         assert c[i] == f_rgba[i]
         assert all(c[i] == c[cname] for cname in cnames)
+    assert c[-1] == f_rgba[-1]
+    assert c[1:3] == f_rgba[1:3]
     with pytest.raises(TypeError):
         c[None]  # Invalid index type
     with pytest.raises(ValueError):


### PR DESCRIPTION
### Overview

Support for `pyvista.Color()[i]` and `for c in pyvista.Color()` to make it backwards compatible with the old 'float tuple' representation.
Fixes #2409.

### Details

The `float_rgba` representation is used for indexing and iteration.
