### PR TITLE
modify uniformgrid filters

### DIFF
--- a/doc/api/core/index.rst
+++ b/doc/api/core/index.rst
@@ -49,3 +49,4 @@ PyVista has the following mesh types:
    camera
    lights
    helpers
+   misc

--- a/doc/api/core/misc.rst
+++ b/doc/api/core/misc.rst
@@ -1,0 +1,10 @@
+Miscellaneous
+=============
+
+This micellaneous methods are used to support imaging or data sampling.
+
+.. autosummary::
+   :toctree: _autosummary
+
+   pyvista.core.imaging.sample_function
+   pyvista.core.common_data.perlin_noise

--- a/doc/api/core/misc.rst
+++ b/doc/api/core/misc.rst
@@ -1,7 +1,7 @@
 Miscellaneous
 =============
 
-This micellaneous methods are used to support imaging or data sampling.
+These miscellaneous methods are used to support imaging or data sampling.
 
 .. autosummary::
    :toctree: _autosummary

--- a/examples/01-filter/gaussian-smoothing.py
+++ b/examples/01-filter/gaussian-smoothing.py
@@ -7,9 +7,11 @@ Gaussian Smoothing
 Perform a Gaussian convolution on a uniformly gridded data set.
 
 :class:`pyvista.UniformGrid` data sets (a.k.a. images) a can be smoothed by
-convolving the  image data set with a Gaussian for one- to three-dimensional
+convolving the image data set with a Gaussian for one- to three-dimensional
 inputs. This is commonly referred to as Gaussian blurring and typically used
-to reduce noise or decrease the detail of an image dataset
+to reduce noise or decrease the detail of an image dataset.
+
+See also :func:`pyvista.UniformGrid.gaussian_smooth`.
 
 """
 # sphinx_gallery_thumbnail_number = 2
@@ -28,28 +30,32 @@ cp = [(319.5, 239.5, 1053.7372980874645), (319.5, 239.5, 0.0), (0.0, 1.0, 0.0)]
 p = pv.Plotter(shape=(2, 2))
 
 p.subplot(0, 0)
-p.add_text("Original Image", font_size=24)
+p.add_text("Original Image", font_size=14)
 p.add_mesh(data, rgb=True)
 p.camera_position = cp
 
 p.subplot(0, 1)
-p.add_text("Gaussian smoothing, std=2", font_size=24)
+p.add_text("Gaussian smoothing, std=2", font_size=14)
 p.add_mesh(data.gaussian_smooth(std_dev=2.0), rgb=True)
 p.camera_position = cp
 
 p.subplot(1, 0)
-p.add_text("Gaussian smoothing, std=4", font_size=24)
+p.add_text("Gaussian smoothing, std=4", font_size=14)
 p.add_mesh(data.gaussian_smooth(std_dev=4.0), rgb=True)
 p.camera_position = cp
 
 p.subplot(1, 1)
-p.add_text("Gaussian smoothing, std=8", font_size=24)
+p.add_text("Gaussian smoothing, std=8", font_size=14)
 p.add_mesh(data.gaussian_smooth(std_dev=8.0), rgb=True)
 p.camera_position = cp
 
 p.show()
 
 ###############################################################################
+# |
+#
+# Volume Rendering
+# ~~~~~~~~~~~~~~~~
 # Now let's see an example on a 3D dataset with volume rendering:
 data = examples.download_brain()
 

--- a/pyvista/core/common_data.py
+++ b/pyvista/core/common_data.py
@@ -41,6 +41,13 @@ def perlin_noise(amplitude, freq: Sequence[float], phase: Sequence[float]):
         scale). Phase tends to repeat about every unit, so a phase of
         0.5 is a half-cycle shift.
 
+    Returns
+    -------
+    vtk.vtkPerlinNoise
+        Instance of ``vtk.vtkPerlinNoise`` to a Perlin noise field as an
+        implicit function. Use with :func:`pyvista.sample_function()
+        <pyvista.core.imaging.sample_function>`.
+
     Examples
     --------
     Create a Perlin noise function with an amplitude of 0.1, frequency

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -65,7 +65,9 @@ class UniformGridFilters(DataSetFilters):
     def median_smooth(
         self, kernel_size=(3, 3, 3), scalars=None, preference='points', progress_bar=False
     ):
-        """Smooth data using a median filter.
+        """Smooth data using a median filter. Warning: applying this filter to
+        cell data will send the output to a new point array with the same name,
+        overwriting any existing point data array with the same name.
 
         Parameters
         ----------

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -14,9 +14,9 @@ class UniformGridFilters(DataSetFilters):
     """An internal class to manage filters/algorithms for uniform grid datasets."""
 
     def gaussian_smooth(
-        self, radius_factor=1.5, std_dev=2.0, scalars=None, preference='points', progress_bar=False
+        self, radius_factor=1.5, std_dev=2.0, scalars=None, progress_bar=False
     ):
-        """Smooth the data with a Gaussian kernel.
+        """Smooth the data with a Gaussian kernel. Only supported for point data.
 
         Parameters
         ----------
@@ -28,11 +28,6 @@ class UniformGridFilters(DataSetFilters):
 
         scalars : str, optional
             Name of scalars to process. Defaults to currently active scalars.
-
-        preference : str, optional
-            When scalars is specified, this is the preferred array
-            type to search for in the dataset.  Must be either
-            ``'point'`` or ``'cell'``.
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
@@ -47,8 +42,12 @@ class UniformGridFilters(DataSetFilters):
         alg.SetInputDataObject(self)
         if scalars is None:
             field, scalars = self.active_scalars_info
+            if field.value == 1:
+                raise ValueError('If `scalars` not given, active scalars must be point array.')
         else:
-            field = self.get_array_association(scalars, preference=preference)
+            field = self.get_array_association(scalars, preference='point')
+            if field.value == 1:
+                raise ValueError('Can only process point data, given `scalars` are cell data.')
         alg.SetInputArrayToProcess(
             0, 0, 0, field.value, scalars
         )  # args: (idx, port, connection, field, name)

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -229,8 +229,6 @@ class UniformGridFilters(DataSetFilters):
     ):
         """Dilates one value and erodes another.
 
-        Only supported for point data.
-
         ``image_dilate_erode`` will dilate one value and erode another. It uses
         an elliptical footprint, and only erodes/dilates on the boundary of the
         two values. The filter is restricted to the X, Y, and Z axes for now.
@@ -260,6 +258,12 @@ class UniformGridFilters(DataSetFilters):
         -------
         pyvista.UniformGrid
             Dataset that has been dilated/eroded on the boundary of the specified scalars.
+
+        Notes
+        -----
+        This filter only supports point data. Consider converting any cell
+        data to point data using the :func:`DataSet.cell_data_to_point_data`
+        filter to convert ny cell data to point data.
 
         Examples
         --------

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -202,11 +202,6 @@ class UniformGridFilters(DataSetFilters):
         scalars : str, optional
             Name of scalars to process. Defaults to currently active scalars.
 
-        preference : str, optional
-            When scalars are specified, this is the preferred array
-            type to search for in the dataset.  Must be either
-            ``'point'`` or ``'cell'``.
-
         progress_bar : bool, optional
             Display a progress bar to indicate progress. Default ``False``.
 

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -16,7 +16,9 @@ class UniformGridFilters(DataSetFilters):
     def gaussian_smooth(
         self, radius_factor=1.5, std_dev=2.0, scalars=None, progress_bar=False
     ):
-        """Smooth the data with a Gaussian kernel. Only supported for point data.
+        """Smooth the data with a Gaussian kernel.
+
+        Only supported for point data.
 
         Parameters
         ----------
@@ -65,9 +67,11 @@ class UniformGridFilters(DataSetFilters):
     def median_smooth(
         self, kernel_size=(3, 3, 3), scalars=None, preference='points', progress_bar=False
     ):
-        """Smooth data using a median filter. Warning: applying this filter to
-        cell data will send the output to a new point array with the same name,
-        overwriting any existing point data array with the same name.
+        """Smooth data using a median filter.
+
+        Warning: applying this filter to cell data will send the output to a
+        new point array with the same name, overwriting any existing point data
+        array with the same name.
 
         Parameters
         ----------
@@ -172,10 +176,11 @@ class UniformGridFilters(DataSetFilters):
         erode_value=0,
         kernel_size=(3, 3, 3),
         scalars=None,
-        preference='points',
         progress_bar=False,
     ):
         """Dilates one value and erodes another.
+
+        Only supported for point data.
 
         ``image_dilate_erode`` will dilate one value and erode another. It uses
         an elliptical footprint, and only erodes/dilates on the boundary of the
@@ -238,8 +243,12 @@ class UniformGridFilters(DataSetFilters):
         alg.SetInputDataObject(self)
         if scalars is None:
             field, scalars = self.active_scalars_info
+            if field.value == 1:
+                raise ValueError('If `scalars` not given, active scalars must be point array.')
         else:
-            field = self.get_array_association(scalars, preference=preference)
+            field = self.get_array_association(scalars, preference='point')
+            if field.value == 1:
+                raise ValueError('Can only process point data, given `scalars` are cell data.')
         alg.SetInputArrayToProcess(
             0, 0, 0, field.value, scalars
         )  # args: (idx, port, connection, field, name)
@@ -267,6 +276,10 @@ class UniformGridFilters(DataSetFilters):
 
         If ``None`` is given for ``in_value``, scalars that are ``'in'`` will not be replaced.
         If ``None`` is given for ``out_value``, scalars that are ``'out'`` will not be replaced.
+
+        Warning: applying this filter to cell data will send the output to a
+        new point array with the same name, overwriting any existing point data
+        array with the same name.
 
         Parameters
         ----------

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -16,8 +16,6 @@ class UniformGridFilters(DataSetFilters):
     def gaussian_smooth(self, radius_factor=1.5, std_dev=2.0, scalars=None, progress_bar=False):
         """Smooth the data with a Gaussian kernel.
 
-        Only supported for point data.
-
         Parameters
         ----------
         radius_factor : float or iterable, optional
@@ -36,6 +34,31 @@ class UniformGridFilters(DataSetFilters):
         -------
         pyvista.UniformGrid
             Uniform grid with smoothed scalars.
+
+        Notes
+        -----
+        This filter only supports point data. Consider converting any cell
+        data to point data using the :func:`DataSet.cell_data_to_point_data`
+        filter to convert ny cell data to point data.
+
+        Examples
+        --------
+        First, create sample data to smooth. Here, we use
+        :func:`pyvista.perlin_noise() <pyvista.core.common_data.perlin_noise>`
+        to create meaningful data.
+
+        >>> import numpy as np
+        >>> import pyvista
+        >>> noise = pyvista.perlin_noise(0.1, (2, 5, 8), (0, 0, 0))
+        >>> grid = pyvista.sample_function(noise, [0, 1, 0, 1, 0, 1], dim=(20, 20, 20))
+        >>> grid.plot(show_scalar_bar=False)
+
+        Next, smooth the sample data.
+
+        >>> smoothed = grid.gaussian_smooth()
+        >>> smoothed.plot(show_scalar_bar=False)
+
+        See :ref:`gaussian_smoothing_example` for a full example using this filter.
 
         """
         alg = _vtk.vtkImageGaussianSmooth()
@@ -67,9 +90,14 @@ class UniformGridFilters(DataSetFilters):
     ):
         """Smooth data using a median filter.
 
-        Warning: applying this filter to cell data will send the output to a
-        new point array with the same name, overwriting any existing point data
-        array with the same name.
+        The Median filter that replaces each pixel with the median value from a
+        rectangular neighborhood around that pixel. Neighborhoods can be no
+        more than 3 dimensional. Setting one axis of the neighborhood
+        kernelSize to 1 changes the filter into a 2D median.
+
+        See `vtkImageMedian3D
+        <https://vtk.org/doc/nightly/html/classvtkImageMedian3D.html#details>`_
+        for more details.
 
         Parameters
         ----------
@@ -94,6 +122,29 @@ class UniformGridFilters(DataSetFilters):
         -------
         pyvista.UniformGrid
             Uniform grid with smoothed scalars.
+
+        Warnings
+        --------
+        Applying this filter to cell data will send the output to a new point
+        array with the same name, overwriting any existing point data array
+        with the same name.
+
+        Examples
+        --------
+        First, create sample data to smooth. Here, we use
+        :func:`pyvista.perlin_noise() <pyvista.core.common_data.perlin_noise>`
+        to create meaningful data.
+
+        >>> import numpy as np
+        >>> import pyvista
+        >>> noise = pyvista.perlin_noise(0.1, (2, 5, 8), (0, 0, 0))
+        >>> grid = pyvista.sample_function(noise, [0, 1, 0, 1, 0, 1], dim=(20, 20, 20))
+        >>> grid.plot(show_scalar_bar=False)
+
+        Next, smooth the sample data.
+
+        >>> smoothed = grid.median_smooth(kernel_size=(10, 10, 10))
+        >>> smoothed.plot(show_scalar_bar=False)
 
         """
         alg = _vtk.vtkImageMedian3D()

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -13,9 +13,7 @@ from pyvista.core.filters.data_set import DataSetFilters
 class UniformGridFilters(DataSetFilters):
     """An internal class to manage filters/algorithms for uniform grid datasets."""
 
-    def gaussian_smooth(
-        self, radius_factor=1.5, std_dev=2.0, scalars=None, progress_bar=False
-    ):
+    def gaussian_smooth(self, radius_factor=1.5, std_dev=2.0, scalars=None, progress_bar=False):
         """Smooth the data with a Gaussian kernel.
 
         Only supported for point data.

--- a/pyvista/core/imaging.py
+++ b/pyvista/core/imaging.py
@@ -38,7 +38,7 @@ def sample_function(
     ----------
     function : vtk.vtkImplicitFunction
         Implicit function to evaluate.  For example, the function
-        generated from ``perlin_noise``.
+        generated from :func:`pyvista.perlin_noise`.
 
     bounds : length 6 sequence
         Specify the bounds in the format of:
@@ -80,15 +80,20 @@ def sample_function(
 
     scalar_arr_name : str, optional
         Set the scalar array name for this data set.  Defaults to
-        ``"scalars"``
+        ``"scalars"``.
 
     normal_arr_name : str, optional
         Set the normal array name for this data set.  Defaults to
-        ``"normals"``
+        ``"normals"``.
 
     progress_bar : bool, optional
         Display a progress bar to indicate progress.  Default
         ``False``.
+
+    Returns
+    -------
+    pyvista.UniformGrid
+        Uniform grid with sampled data.
 
     Examples
     --------

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1607,7 +1607,7 @@ def test_gaussian_smooth_cell_data_specified():
     volume.point_data['point_data'] = point_data.flatten(order='F')
     volume.cell_data['cell_data'] = cell_data.flatten(order='F')
     with pytest.raises(ValueError):
-        volume_smoothed = volume.gaussian_smooth(scalars='cell_data')
+        volume.gaussian_smooth(scalars='cell_data')
 
 
 def test_gaussian_smooth_cell_data_active():
@@ -1618,7 +1618,7 @@ def test_gaussian_smooth_cell_data_active():
     volume.cell_data['cell_data'] = cell_data.flatten(order='F')
     volume.set_active_scalars('cell_data')
     with pytest.raises(ValueError):
-        volume_smoothed = volume.gaussian_smooth()
+        volume.gaussian_smooth()
 
 
 def test_median_smooth_output_type():
@@ -1696,7 +1696,7 @@ def test_image_dilate_erode_cell_data_specified():
     volume.point_data['point_data'] = point_data.flatten(order='F')
     volume.cell_data['cell_data'] = cell_data.flatten(order='F')
     with pytest.raises(ValueError):
-        volume_smoothed = volume.image_dilate_erode(scalars='cell_data')
+        volume.image_dilate_erode(scalars='cell_data')
 
 
 def test_image_dilate_erode_cell_data_active():
@@ -1707,7 +1707,7 @@ def test_image_dilate_erode_cell_data_active():
     volume.cell_data['cell_data'] = cell_data.flatten(order='F')
     volume.set_active_scalars('cell_data')
     with pytest.raises(ValueError):
-        volume_smoothed = volume.image_dilate_erode()
+        volume.image_dilate_erode()
 
 
 def test_image_threshold_output_type():

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1600,6 +1600,27 @@ def test_gaussian_smooth_outlier():
     assert volume_smoothed.get_data_range()[1] < volume.get_data_range()[1]
 
 
+def test_gaussian_smooth_cell_data_specified():
+    point_data = np.zeros((10, 10, 10))
+    cell_data = np.zeros((9, 9, 9))
+    volume = pyvista.UniformGrid(dims=(10, 10, 10))
+    volume.point_data['point_data'] = point_data.flatten(order='F')
+    volume.cell_data['cell_data'] = cell_data.flatten(order='F')
+    with pytest.raises(ValueError):
+        volume_smoothed = volume.gaussian_smooth(scalars='cell_data')
+
+
+def test_gaussian_smooth_cell_data_active():
+    point_data = np.zeros((10, 10, 10))
+    cell_data = np.zeros((9, 9, 9))
+    volume = pyvista.UniformGrid(dims=(10, 10, 10))
+    volume.point_data['point_data'] = point_data.flatten(order='F')
+    volume.cell_data['cell_data'] = cell_data.flatten(order='F')
+    volume.set_active_scalars('cell_data')
+    with pytest.raises(ValueError):
+        volume_smoothed = volume.gaussian_smooth()
+
+
 def test_median_smooth_output_type():
     volume = examples.load_uniform()
     volume_smooth = volume.median_smooth()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1689,6 +1689,27 @@ def test_image_dilate_erode_erosion():
     )
 
 
+def test_image_dilate_erode_cell_data_specified():
+    point_data = np.zeros((10, 10, 10))
+    cell_data = np.zeros((9, 9, 9))
+    volume = pyvista.UniformGrid(dims=(10, 10, 10))
+    volume.point_data['point_data'] = point_data.flatten(order='F')
+    volume.cell_data['cell_data'] = cell_data.flatten(order='F')
+    with pytest.raises(ValueError):
+        volume_smoothed = volume.image_dilate_erode(scalars='cell_data')
+
+
+def test_image_dilate_erode_cell_data_active():
+    point_data = np.zeros((10, 10, 10))
+    cell_data = np.zeros((9, 9, 9))
+    volume = pyvista.UniformGrid(dims=(10, 10, 10))
+    volume.point_data['point_data'] = point_data.flatten(order='F')
+    volume.cell_data['cell_data'] = cell_data.flatten(order='F')
+    volume.set_active_scalars('cell_data')
+    with pytest.raises(ValueError):
+        volume_smoothed = volume.image_dilate_erode()
+
+
 def test_image_threshold_output_type():
     threshold = 10  # 'random' value
     volume = examples.load_uniform()


### PR DESCRIPTION
### Overview

I discovered a while ago that many of the UniformGrid (vtkImageData) specific filters do not play nicely with cell data. The purpose of this PR is to throw a band-aid on the problem for the UniformGrid filters that I have added to PyVista so that users don't try to use one of them with cell data and get confused by the results. Some filters simply needed the documentation updated with a warning / explanation of behaviour with cell data, and some needed functionality modified to prohibit use of them with cell data.

Perhaps in the future someone can figure out what is going on under the hood and there could be a more elegant solution to these issues. We could also consider doing something like automatically moving cell arrays to point arrays, processing, and moving back, but it gets messy with potential name collisions. If a user really wants to apply one of these filters to cell data then they can do that conversion manually (just as they would have to if they wanted to do something analogous in VTK).

Resolves #2217


### Details

gaussian_smooth and dilate_erode: using it with cell data does not seem to work at all, so I removed the `preferences` kwarg and added ValueErrors that trigger if the user tries to use it with cell data (if cell data is the active scalar or if the `scalar` kwarg points to cell data exclusively)

median_smooth and image_threshold: you can use this with cell data, but it will send the output to a point data array and overwrite any existing point data array of the same name. Warning added.

