### PR TITLE
Default set active vectors for filters

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2299,6 +2299,7 @@ class DataSetFilters:
 
         """
         if vectors is None:
+            pyvista.set_default_active_vectors(self)
             field, vectors = self.active_vectors_info
         arr = get_array(self, vectors, preference='point')
         field = get_array_association(self, vectors, preference='point')

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -3401,6 +3401,8 @@ class DataSetFilters:
         if isinstance(vectors, str):
             self.set_active_scalars(vectors)
             self.set_active_vectors(vectors)
+        elif vectors is None:
+            pyvista.set_default_active_vectors(self)
 
         loop_angle = loop_angle * np.pi / 180
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -9,6 +9,7 @@ import pyvista
 from pyvista import FieldAssociation, _vtk
 from pyvista.core.errors import VTKVersionError
 from pyvista.core.filters import _get_output, _update_alg
+from pyvista.errors import AmbiguousDataError, MissingDataError
 from pyvista.utilities import (
     NORMALS,
     abstract_class,
@@ -1992,7 +1993,15 @@ class DataSetFilters:
             dataset.active_vectors_name = orient
             orient = True
         elif isinstance(orient, bool) and orient:
-            pyvista.set_default_active_vectors(self)
+            try:
+                pyvista.set_default_active_vectors(self)
+            except MissingDataError:
+                warnings.warn("No vector-like data to use for orient. orient will be set to False.")
+                orient = False
+            except AmbiguousDataError as err:
+                warnings.warn(
+                    f"{err}\nIt is unclear which one to use. orient will be set to False."
+                )
 
         if scale and orient:
             if (

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1991,6 +1991,8 @@ class DataSetFilters:
         if isinstance(orient, str):
             dataset.active_vectors_name = orient
             orient = True
+        elif isinstance(orient, bool) and orient:
+            pyvista.set_default_active_vectors(self)
 
         if scale and orient:
             if (

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2002,6 +2002,7 @@ class DataSetFilters:
                 warnings.warn(
                     f"{err}\nIt is unclear which one to use. orient will be set to False."
                 )
+                orient = False
 
         if scale and orient:
             if (

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -3202,6 +3202,9 @@ class DataSetFilters:
         if isinstance(vectors, str):
             self.set_active_scalars(vectors)
             self.set_active_vectors(vectors)
+        elif vectors is None:
+            pyvista.set_default_active_vectors(self)
+
         if max_time is None:
             max_velocity = self.get_data_range()[-1]
             max_time = 4.0 * self.GetLength() / max_velocity

--- a/pyvista/errors.py
+++ b/pyvista/errors.py
@@ -1,0 +1,9 @@
+"""Pyvista specific errors."""
+
+
+class MissingDataError(ValueError):
+    """Exception when data is missing, e.g. no active scalars can be set."""
+
+
+class AmbiguousDataError(ValueError):
+    """Exception when data is ambiguous, e.g. multiple active scalars can be set."""

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -16,6 +16,7 @@ import numpy as np
 
 import pyvista
 from pyvista import _vtk
+from pyvista.errors import AmbiguousDataError, MissingDataError
 
 from . import transformations
 from .fileio import from_meshio
@@ -1475,10 +1476,12 @@ def set_default_active_vectors(mesh: 'pyvista.DataSet') -> None:
     mesh : pyvista.DataSet
         Dataset to set default active vectors.
 
-    Raises
+     Raises
     ------
-    ValueError
-        If zero or more than one vector-like arrays exist.
+    MissingDataError
+        If no vector-like arrays exist.
+    AmbiguousDataError
+        If more than one vector-like arrays exist.
 
     """
     if mesh.active_vectors_name is not None:
@@ -1503,9 +1506,9 @@ def set_default_active_vectors(mesh: 'pyvista.DataSet') -> None:
         else:
             mesh.set_active_vectors(possible_vectors_cell[0], preference='cell')
     elif n_possible_vectors < 1:
-        raise ValueError("No vector-like data available.")
+        raise MissingDataError("No vector-like data available.")
     elif n_possible_vectors > 1:
-        raise ValueError(
+        raise AmbiguousDataError(
             f"Multiple vector-like data available: {possible_vectors}.\n"
             "Set one as active using DataSet.set_active_vectors(name)"
         )

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -1460,7 +1460,7 @@ def cubemap(path='', prefix='', ext='.jpg'):
     return texture
 
 
-def set_default_active_vectors(mesh) -> None:
+def set_default_active_vectors(mesh: 'pyvista.DataSet') -> None:
     """Set a default vectors on mesh, if not already set.
 
     If an active vector already exists, no changes are made.
@@ -1473,7 +1473,7 @@ def set_default_active_vectors(mesh) -> None:
     Parameters
     ----------
     mesh : pyvista.DataSet
-        Dataset to get the array from.
+        Dataset to set default active vectors.
 
     Raises
     ------

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -1462,14 +1462,13 @@ def cubemap(path='', prefix='', ext='.jpg'):
 
 
 def set_default_active_vectors(mesh: 'pyvista.DataSet') -> None:
-    """Set a default vectors on mesh, if not already set.
+    """Set a default vectors array on mesh, if not already set.
 
     If an active vector already exists, no changes are made.
 
     If an active vectors does not exist, it checks for possibly cell
     or point arrays with shape ``(n, 3)``.  If only one exists, then
-    it is set as the active vectors.  If none or more than one exists,
-    then a ValueError is raised.
+    it is set as the active vectors.  Otherwise, an error is raised.
 
     Parameters
     ----------

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -1488,10 +1488,10 @@ def set_default_active_vectors(mesh) -> None:
     cell_data = mesh.cell_data
 
     possible_vectors_point = [
-        name for name, value in point_data.items() if value.ndim != 2 or value.shape[1] == 3
+        name for name, value in point_data.items() if value.ndim == 2 and value.shape[1] == 3
     ]
     possible_vectors_cell = [
-        name for name, value in cell_data.items() if value.ndim != 2 or value.shape[1] == 3
+        name for name, value in cell_data.items() if value.ndim == 2 and value.shape[1] == 3
     ]
 
     possible_vectors = possible_vectors_point + possible_vectors_cell

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -1510,6 +1510,8 @@ def set_default_active_vectors(mesh: 'pyvista.DataSet') -> None:
         raise MissingDataError("No vector-like data available.")
     elif n_possible_vectors > 1:
         raise AmbiguousDataError(
-            f"Multiple vector-like data available: {possible_vectors}.\n"
-            "Set one as active using DataSet.set_active_vectors(name)"
+            "Multiple vector-like data available\n"
+            f"cell data: {possible_vectors_cell}.\n"
+            f"point data: {possible_vectors_point}.\n"
+            "Set one as active using DataSet.set_active_vectors(name, preference=type)"
         )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -631,7 +631,15 @@ def test_glyph(datasets, sphere):
         geom=geoms, scale='arr', orient='Normals', factor=0.1, tolerance=0.1, progress_bar=True
     )
     assert sphere.glyph(geom=geoms[:1], indices=[None], progress_bar=True)
-    assert sphere_sans_arrays.glyph(geom=geoms, progress_bar=True)
+
+    with pytest.warns(Warning):  # tries to orient but no orientation vector available
+        assert sphere_sans_arrays.glyph(geom=geoms, progress_bar=True)
+
+    sphere_sans_arrays["vec1"] = np.ones((sphere_sans_arrays.n_points, 3))
+    sphere_sans_arrays["vec2"] = np.ones((sphere_sans_arrays.n_points, 3))
+    with pytest.warns(Warning):  # tries to orient but multiple orientation vectors are possible
+        assert sphere_sans_arrays.glyph(geom=geoms, progress_bar=True)
+
     with pytest.raises(TypeError):
         # wrong type for the glyph
         sphere.glyph(geom=pyvista.StructuredGrid())

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,6 +8,7 @@ import vtk
 
 import pyvista
 from pyvista import _vtk
+from pyvista.errors import AmbiguousDataError, MissingDataError
 
 
 def test_wrap_none():
@@ -207,13 +208,13 @@ def test_set_default_active_vectors():
     mesh.clear_data()
 
     # Raises if no data is present
-    with pytest.raises(ValueError):
+    with pytest.raises(MissingDataError):
         pyvista.set_default_active_vectors(mesh)
     assert mesh.active_vectors_name is None
 
     # Raises if no vector-like data is present
     mesh["scalar_data"] = np.ones((mesh.n_points, 1))
-    with pytest.raises(ValueError):
+    with pytest.raises(MissingDataError):
         pyvista.set_default_active_vectors(mesh)
     assert mesh.active_vectors_name is None
     mesh.clear_data()
@@ -221,7 +222,7 @@ def test_set_default_active_vectors():
     # Raises if multiple vector-like data is present
     mesh["vec_data1"] = np.ones((mesh.n_points, 3))
     mesh["vec_data2"] = np.ones((mesh.n_points, 3))
-    with pytest.raises(ValueError):
+    with pytest.raises(AmbiguousDataError):
         pyvista.set_default_active_vectors(mesh)
     assert mesh.active_vectors_name is None
     mesh.clear_data()
@@ -229,6 +230,13 @@ def test_set_default_active_vectors():
     # Raises if multiple vector-like data in cell and point
     mesh["vec_data1"] = np.ones((mesh.n_points, 3))
     mesh["vec_data2"] = np.ones((mesh.n_cells, 3))
-    with pytest.raises(ValueError):
+    with pytest.raises(AmbiguousDataError):
+        pyvista.set_default_active_vectors(mesh)
+    assert mesh.active_vectors_name is None
+
+    # Raises if multiple vector-like data with same name
+    mesh["vec_data"] = np.ones((mesh.n_points, 3))
+    mesh["vec_data"] = np.ones((mesh.n_cells, 3))
+    with pytest.raises(AmbiguousDataError):
         pyvista.set_default_active_vectors(mesh)
     assert mesh.active_vectors_name is None

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -224,3 +224,11 @@ def test_set_default_active_vectors():
     with pytest.raises(ValueError):
         pyvista.set_default_active_vectors(mesh)
     assert mesh.active_vectors_name is None
+    mesh.clear_data()
+
+    # Raises if multiple vector-like data in cell and point
+    mesh["vec_data1"] = np.ones((mesh.n_points, 3))
+    mesh["vec_data2"] = np.ones((mesh.n_cells, 3))
+    with pytest.raises(ValueError):
+        pyvista.set_default_active_vectors(mesh)
+    assert mesh.active_vectors_name is None

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -186,3 +186,41 @@ def test_array_association():
 
     with pytest.raises(ValueError, match='not supported.'):
         mesh.get_array_association('name', preference='row')
+
+
+def test_set_default_active_vectors():
+    mesh = pyvista.Sphere()
+    mesh.clear_data()  # make sure we have a clean mesh with no arrays to start
+
+    assert mesh.active_vectors_name is None
+
+    # Point data vectors
+    mesh["vec_point"] = np.ones((mesh.n_points, 3))
+    pyvista.set_default_active_vectors(mesh)
+    assert mesh.active_vectors_name == "vec_point"
+    mesh.clear_data()
+
+    # Cell data vectors
+    mesh["vec_cell"] = np.ones((mesh.n_cells, 3))
+    pyvista.set_default_active_vectors(mesh)
+    assert mesh.active_vectors_name == "vec_cell"
+    mesh.clear_data()
+
+    # Raises if no data is present
+    with pytest.raises(ValueError):
+        pyvista.set_default_active_vectors(mesh)
+    assert mesh.active_vectors_name is None
+
+    # Raises if no vector-like data is present
+    mesh["scalar_data"] = np.ones((mesh.n_points, 1))
+    with pytest.raises(ValueError):
+        pyvista.set_default_active_vectors(mesh)
+    assert mesh.active_vectors_name is None
+    mesh.clear_data()
+
+    # Raises if multiple vector-like data is present
+    mesh["vec_data1"] = np.ones((mesh.n_points, 3))
+    mesh["vec_data2"] = np.ones((mesh.n_points, 3))
+    with pytest.raises(ValueError):
+        pyvista.set_default_active_vectors(mesh)
+    assert mesh.active_vectors_name is None


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

This PR implements a common helper to set a default for active_vectors on a mesh.  This currently implements option #2 from https://github.com/pyvista/pyvista/issues/2334#issuecomment-1065702247.  Reproduced here:

> 1. Raise if there are no active vectors ("explicit is better than implicit").
> 2. Activate vectors if they are unambiguous, and maybe warn while doing so. Otherwise raise ("in the face of ambiguity refuse the temptation to guess").
> 3. Always activate some vector-looking data and warn the user that this happened ("practicality beats purity").


### Details

The logic used here is to set a default active_vectors only if there is one vector-like array, i.e. shape `(n, 3)`.  It is still possible that the vector-like array is not truly a vector in the vtk sense (RGB array for example), but in this case the user should be aware of what is happening since it is unambiguous what the intent is.