### PR TITLE
updated show_bounds

### DIFF
--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1032,6 +1032,7 @@ class Renderer(_vtk.vtkRenderer):
         self,
         mesh=None,
         bounds=None,
+        bounds_range=None,
         show_xaxis=True,
         show_yaxis=True,
         show_zaxis=True,
@@ -1069,6 +1070,11 @@ class Renderer(_vtk.vtkRenderer):
         bounds : list or tuple, optional
             Bounds to override mesh bounds in the form ``[xmin, xmax,
             ymin, ymax, zmin, zmax]``.
+            
+        bounds_range : list or tuple, optional
+            Bounds that can be used to separate the physical bounds of the mesh
+            and the values of the bounds shown on the axes. In the form 
+            ``[xmin, xmax, ymin, ymax, zmin, zmax]``.
 
         show_xaxis : bool, optional
             Makes x axis visible.  Default ``True``.
@@ -1266,6 +1272,15 @@ class Renderer(_vtk.vtkRenderer):
         else:
             raise ValueError(f'padding ({padding}) not understood. Must be float between 0 and 1')
         cube_axes_actor.SetBounds(bounds)
+        
+        # update the values of range of each axis
+        if isinstance(bounds_range, (list, tuple)):
+            if len(bounds_range) == 6:
+                cube_axes_actor.SetXAxisRange(bounds_range[0], bounds_range[1])
+                cube_axes_actor.SetYAxisRange(bounds_range[2], bounds_range[3])
+                cube_axes_actor.SetZAxisRange(bounds_range[4], bounds_range[5])
+            else:
+                raise ValueError("bounds_range must be passed as a [xmin, xmax, ymin, ymax, zmin, zmax] list or tuple")
 
         # show or hide axes
         cube_axes_actor.SetXAxisVisibility(show_xaxis)

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1280,7 +1280,7 @@ class Renderer(_vtk.vtkRenderer):
                 cube_axes_actor.SetYAxisRange(bounds_range[2], bounds_range[3])
                 cube_axes_actor.SetZAxisRange(bounds_range[4], bounds_range[5])
             else:
-                raise ValueError("bounds_range must be passed as a [xmin, xmax, ymin, ymax, zmin, zmax] list or tuple")
+                raise ValueError('bounds_range must be passed as a [xmin, xmax, ymin, ymax, zmin, zmax] list or tuple')
 
         # show or hide axes
         cube_axes_actor.SetXAxisVisibility(show_xaxis)


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Sometimes when plotting, the physical bounds of the plotter don't match the values of the values shown on the bounds axis bar. For example, when plotting datasets in [VesselVio](https://github.com/jacobbumgarner/vesselvio/), the vasculature from all datasets is normalized prior to plotting. This means that when calling `plotter.show_bounds()`, the scale of the bounds axis will be incorrect if the input resolution wasn't 1.

@adeak and I had a brief discussion about this, and he found that the vtkCubeAxesActor can indeed take specific calls to separate the physical bounds of the mesh from the numerical bounds shown on the axes.

### Details

To implement this, an optional `bounds_range` argument was added to the `def show_bounds()` function in the `Renderer` class from the `renderer.py` module.

As seen in the file change, the arg takes a `[xmin, xmax, ymin, ymax, zmin, zmax]` list/tuple and sets the values on the axes accordingly.

Because the semantics of the plotter bounds vs. the axis actor bounds might be tricky, I decided to use the `range` vocabulary based on the functions that are called on the vtkCubeAxesActor ([see doc](https://vtk.org/doc/nightly/html/classvtkCubeAxesActor.html)). Not sure if it's perfect, but it's a starting point!