### PR TITLE
add disable picking

### DIFF
--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -190,7 +190,7 @@ class PickingHelper:
             )
 
         if left_clicking:
-            self.iren.interactor.AddObserver(
+            self._picking_left_clicking_observer = self.iren.interactor.AddObserver(
                 "LeftButtonPressEvent",
                 partial(try_callback, _launch_pick_event),
             )
@@ -578,7 +578,7 @@ class PickingHelper:
         self.iren.set_picker(picker)
 
         if left_clicking:
-            self.iren.interactor.AddObserver(
+            self._picking_left_clicking_observer = self.iren.interactor.AddObserver(
                 "LeftButtonPressEvent",
                 partial(try_callback, _launch_pick_event),
             )

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3193,6 +3193,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     def deep_clean(self):
         """Clean the plotter of the memory."""
+        self.disable_picking()
         if hasattr(self, 'renderers'):
             self.renderers.deep_clean()
         if getattr(self, 'mesh', None) is not None:

--- a/tests/test_picking.py
+++ b/tests/test_picking.py
@@ -124,6 +124,35 @@ def test_enable_surface_picking(sphere, left_clicking):
     assert pl.picked_point is None
 
 
+@pytest.mark.parametrize('left_clicking', [False, True])
+def test_disable_picking(sphere, left_clicking):
+    picked = []
+
+    def callback(point):
+        picked.append(point)
+
+    pl = pyvista.Plotter()
+    pl.add_mesh(sphere)
+    pl.enable_surface_picking(callback=callback, left_clicking=left_clicking)
+    pl.disable_picking()
+    pl.show(auto_close=False)
+
+    width, height = pl.window_size
+
+    # clicking is to "activate" the renderer
+    pl.iren._mouse_left_button_press(width // 2, height // 2)
+    pl.iren._mouse_left_button_release(width, height)
+    pl.iren._mouse_move(width // 2, height // 2)
+    if not left_clicking:
+        pl.iren._simulate_keypress('p')
+
+    assert pl.picked_point is None
+
+    # ensure it can safely be called twice
+    pl.disable_picking()
+    assert pl._picking_text not in pl.renderer.actors
+
+
 def test_enable_cell_picking_interactive():
 
     n_cells = []

--- a/tests/test_picking.py
+++ b/tests/test_picking.py
@@ -126,14 +126,10 @@ def test_enable_surface_picking(sphere, left_clicking):
 
 @pytest.mark.parametrize('left_clicking', [False, True])
 def test_disable_picking(sphere, left_clicking):
-    picked = []
-
-    def callback(point):
-        picked.append(point)
 
     pl = pyvista.Plotter()
     pl.add_mesh(sphere)
-    pl.enable_surface_picking(callback=callback, left_clicking=left_clicking)
+    pl.enable_surface_picking(left_clicking=left_clicking)
     pl.disable_picking()
     pl.show(auto_close=False)
 


### PR DESCRIPTION
Resolve #1069 by adding a method to `PickingHelper` to disable picking.

Example usage:

```py
import pyvista as pv
mesh = pv.Sphere(center=(1, 0, 0))
cube = pv.Cube()
pl = pv.Plotter()
_ = pl.add_mesh(mesh)
_ = pl.add_mesh(cube)
_ = pl.enable_mesh_picking(left_clicking=False)

# or
# _ = pl.enable_surface_picking(left_clicking=True)
# _ = pl.enable_point_picking(left_clicking=True)

pl.disable_picking()
pl.show()

```
