### PR TITLE
Avoid creating a deep copy of point/cell data in `Plotter.add_mesh`

### DIFF
--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -252,11 +252,11 @@ def make_mapper(mapper_class):
 
             # Scalars interpolation approach
             if use_points:
-                mesh.point_data.set_array(scalars, title, True)
+                mesh.point_data.set_array(scalars, title, deep_copy=False)
                 mesh.active_scalars_name = title
                 self.SetScalarModeToUsePointData()
             elif use_cells:
-                mesh.cell_data.set_array(scalars, title, True)
+                mesh.cell_data.set_array(scalars, title, deep_copy=False)
                 mesh.active_scalars_name = title
                 self.SetScalarModeToUseCellData()
             else:

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -2235,3 +2235,14 @@ def test_pointset_plot_as_points(pointset):
     pl = pyvista.Plotter()
     pl.add_points(pointset, scalars=range(pointset.n_points), show_scalar_bar=False)
     pl.show(before_close_callback=verify_cache_image)
+
+
+def test_add_mesh_does_not_deepcopy(sphere):
+    sphere.cell_data['ones'] = np.ones((sphere.n_cells,))
+    ones = sphere.cell_data['ones']
+
+    pl = pyvista.Plotter()
+    pl.add_mesh(sphere, scalars='ones')
+    pl.close()
+
+    assert np.shares_memory(ones, sphere.cell_data['ones'])

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -2237,12 +2237,10 @@ def test_pointset_plot_as_points(pointset):
     pl.show(before_close_callback=verify_cache_image)
 
 
-def test_add_mesh_does_not_deepcopy(sphere):
-    sphere.cell_data['ones'] = np.ones((sphere.n_cells,))
-    ones = sphere.cell_data['ones']
-
+def test_add_mesh_does_not_deepcopy():
+    mesh = examples.load_random_hills()
+    elevation = mesh.point_data['Elevation']
     pl = pyvista.Plotter()
-    pl.add_mesh(sphere, scalars='ones')
+    pl.add_mesh(mesh, scalars='Elevation')
     pl.close()
-
-    assert np.shares_memory(ones, sphere.cell_data['ones'])
+    assert np.shares_memory(elevation, mesh.point_data['Elevation'])


### PR DESCRIPTION
### Overview

Fixes an issue where adding a mesh to the plotter was creating a deep copy.

Addresses #2461 

I added a test for this, but it fails on the `check_gc` teardown. I can make the teardown pass by calling `sphere.cell_data.pop('ones')` but that doesn't seem _proper_...