### PR TITLE
Make VTK version error clear when PointSet is still abstract

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -152,6 +152,7 @@ numpydoc_validation_checks = {
     "YD01",  # Yields: No plan to enforce
 }
 numpydoc_validation_exclude = {  # set of regex
+    r'\.PointSet$',  # necessary for this abstract class
     r'\.Plotter$',  # Issue with class parameter documentation
     r'\.from_dict$',
     r'\.to_dict$',

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -395,9 +395,9 @@ class PointSet(_vtk.vtkPointSet, _PointSet):
 
         Wrapping this is necessary for us to show an informative error
         message when the VTK version is too old, causing PointSet to be
-        an abstract class. Since we inherit ``vtk.vtkPointSet``'s __new__
-        method, we would otherwise see a generic error about the class
-        being abstract.
+        an abstract class. Since we inherit the ``__new__()`` method of
+        ``vtk.vtkPointSet``, we would otherwise see a generic error about
+        the class being abstract.
 
         """
         if pyvista.vtk_version_info < (9, 1, 0):

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -390,11 +390,22 @@ class PointSet(_vtk.vtkPointSet, _PointSet):
 
     """
 
+    def __new__(cls, *args, **kwargs):
+        """Construct a new PointSet object.
+
+        Wrapping this is necessary for us to show an informative error
+        message when the VTK version is too old, causing PointSet to be
+        an abstract class. Since we inherit ``vtk.vtkPointSet``'s __new__
+        method, we would otherwise see a generic error about the class
+        being abstract.
+
+        """
+        if pyvista.vtk_version_info < (9, 1, 0):
+            raise VTKVersionError("pyvista.PointSet requires VTK >= 9.1.0")
+        return super().__new__(cls, *args, **kwargs)
+
     def __init__(self, points=None, deep=False, force_float=True):
         """Initialize the pointset."""
-        if pyvista.vtk_version_info < (9, 1, 0):  # pragma: no cover
-            raise VTKVersionError("pyvista.PointSet requires VTK >= 9.1.0")
-
         super().__init__()
         if points is not None:
             self.SetPoints(pyvista.vtk_points(points, deep=deep, force_float=force_float))


### PR DESCRIPTION
As of version 0.34.0 we support VTK 9.1's concrete `PointSet` class. However the error we tried to raise in `__init__` isn't visible when you try to instantiate the class on old VTK:
```py
>>> import pyvista as pv
>>> pv.vtk_version_info
VTKVersionInfo(major=9, minor=0, micro=3)
>>> pv.PointSet()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: this is an abstract class and cannot be instantiated
```

The reason for this is that our `PointSet` inherits its `__new__` method from `vtk.vtkPointSet`, which raises this error. The reason why other subclasses work is that they inherint from the corresponding concrete vtk subclasses, e.g. `PolyData` from `vtkPolyData`.

If we move the version check to a newly defined thin `__new__` wrapper it seems to work:
```py
>>> pv.PointSet()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/adeak/pyvista/pyvista/core/pointset.py", line 404, in __new__
    raise VTKVersionError("pyvista.PointSet requires VTK >= 9.1.0")
pyvista.core.errors.VTKVersionError: pyvista.PointSet requires VTK >= 9.1.0
```
The test suite seems to pass, so hopefully the wrapping works otherwise.

I don't know if we need a `# pragma: no cover` for the error's branch, I've omitted for now. If codecov screams I'll add it back.