### PR TITLE
add additional kwargs to open_gif

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3413,6 +3413,13 @@ class BasePlotter(PickingHelper, WidgetHelper):
         **kwargs : dict, optional
             See the documentation for ``imageio.get_writer`` for additional kwargs.
 
+        Notes
+        -----
+        Consider using `pygifsicle
+        <https://github.com/LucaCappelletti94/pygifsicle>`_ to reduce the final
+        size of the gif. See `Optimizing a GIF using pygifsicle
+        <https://imageio.readthedocs.io/en/stable/examples.html#optimizing-a-gif-using-pygifsicle>`_
+
         Examples
         --------
         Open a gif file, setting the framerate to 8 frames per second and

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3383,7 +3383,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             filename = os.path.join(pyvista.FIGURE_PATH, filename)
         self.mwriter = get_writer(filename, fps=framerate, quality=quality, **kwargs)
 
-    def open_gif(self, filename):
+    def open_gif(self, filename, loop=0, fps=10, palettesize=256, subrectangles=False, **kwargs):
         """Open a gif file.
 
         Parameters
@@ -3391,13 +3391,38 @@ class BasePlotter(PickingHelper, WidgetHelper):
         filename : str
             Filename of the gif to open.  Filename must end in ``"gif"``.
 
+        loop : int, optional
+            The number of iterations. Default 0 (meaning loop indefinitely).
+
+        fps : float, optional
+            The number of frames per second. If duration is not given, the
+            duration for each frame is set to 1/fps. Default 10.
+
+        palettesize : int, optional
+            The number of colors to quantize the image to. Is rounded to the
+            nearest power of two. Must be between 2 and 256. Default 256.
+
+        subrectangles : bool, optional
+            If ``True``, will try and optimize the GIF by storing only the rectangular
+            parts of each frame that change with respect to the previous. Default
+            ``False``.
+
+            .. note::
+               Setting this to ``True`` may help reduce jitter in colorbars.
+
+        **kwargs : dict, optional
+            See the documentation for ``imageio.get_writer`` for additional kwargs.
+
         Examples
         --------
-        Open a gif file.
+        Open a gif file, setting the framerate to 8 frames per second and
+        reducing the colorspace to 64.
 
         >>> import pyvista
-        >>> pl = pyvista.Plotter
-        >>> pl.open_gif('movie.gif')  # doctest:+SKIP
+        >>> pl = pyvista.Plotter()
+        >>> pl.open_gif('movie.gif', fps=8, palettesize=64)  # doctest:+SKIP
+
+        See :ref:`gif_movie_example` for a full example using this method.
 
         """
         from imageio import get_writer
@@ -3407,7 +3432,15 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if isinstance(pyvista.FIGURE_PATH, str) and not os.path.isabs(filename):
             filename = os.path.join(pyvista.FIGURE_PATH, filename)
         self._gif_filename = os.path.abspath(filename)
-        self.mwriter = get_writer(filename, mode='I')
+        self.mwriter = get_writer(
+            filename,
+            mode='I',
+            loop=loop,
+            fps=fps,
+            palettesize=palettesize,
+            subrectangles=subrectangles,
+            **kwargs,
+        )
 
     def write_frame(self):
         """Write a single frame to the movie file.

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -2235,3 +2235,17 @@ def test_pointset_plot_as_points(pointset):
     pl = pyvista.Plotter()
     pl.add_points(pointset, scalars=range(pointset.n_points), show_scalar_bar=False)
     pl.show(before_close_callback=verify_cache_image)
+
+
+def test_write_gif(sphere, tmpdir):
+    basename = 'write_gif.gif'
+    path = str(tmpdir.join(basename))
+    pl = pyvista.Plotter()
+    pl.open_gif(path)
+    pl.add_mesh(sphere)
+    pl.write_frame()
+    pl.close()
+
+    # assert file exists and is not empty
+    assert os.path.isfile(path)
+    assert os.path.getsize(path)


### PR DESCRIPTION
Resolve #2468 by adding additional keyword arguments to open_gif and improving the docstring.

### Bonus (there always is)
Added a unit test for `open_gif`, because apparently it's part of the 6.33 we're not covering in our tests.