### PR TITLE
Replace SetTimeValue with UpdateTimeStep and add tests

### DIFF
--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -652,10 +652,10 @@ class OpenFOAMReader(BaseReader, PointCellDataSelection, TimeReader):
             raise ValueError(
                 f"Not a valid time {time_value} from available time values: {self.reader_time_values}"
             )
-        self.reader.SetTimeValue(time_value)
+        self.reader.UpdateTimeStep(time_value)
 
     def set_active_time_point(self, time_point):  # noqa: D102
-        self.reader.SetTimeValue(self.time_point_value(time_point))
+        self.reader.UpdateTimeStep(self.time_point_value(time_point))
 
     @property
     def cell_to_point_creation(self):

--- a/tests/utilities/test_reader.py
+++ b/tests/utilities/test_reader.py
@@ -406,27 +406,27 @@ def test_openfoamreader_read_data_time_value():
 
     reader.set_active_time_value(0.0)
     data = reader.read()["internalMesh"]
-    assert np.isclose(data.cell_data["U"][:, 1].mean(), 0., 0., 1e-10)
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 0.0, 0.0, 1e-10)
 
     reader.set_active_time_value(0.5)
     data = reader.read()["internalMesh"]
-    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.524879113887437e-05, 0., 1e-10)
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.524879113887437e-05, 0.0, 1e-10)
 
     reader.set_active_time_value(1.0)
     data = reader.read()["internalMesh"]
-    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.5253094867803156e-05, 0., 1e-10)
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.5253094867803156e-05, 0.0, 1e-10)
 
     reader.set_active_time_value(1.5)
     data = reader.read()["internalMesh"]
-    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.525657641352154e-05, 0., 1e-10)
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.525657641352154e-05, 0.0, 1e-10)
 
     reader.set_active_time_value(2.0)
     data = reader.read()["internalMesh"]
-    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.5258551836013794e-05, 0., 1e-10)
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.5258551836013794e-05, 0.0, 1e-10)
 
     reader.set_active_time_value(2.5)
     data = reader.read()["internalMesh"]
-    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.525951953837648e-05, 0., 1e-10)
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.525951953837648e-05, 0.0, 1e-10)
 
 
 def test_openfoamreader_read_data_time_point():
@@ -434,27 +434,27 @@ def test_openfoamreader_read_data_time_point():
 
     reader.set_active_time_point(0)
     data = reader.read()["internalMesh"]
-    assert np.isclose(data.cell_data["U"][:, 1].mean(), 0., 0., 1e-10)
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 0.0, 0.0, 1e-10)
 
     reader.set_active_time_point(1)
     data = reader.read()["internalMesh"]
-    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.524879113887437e-05, 0., 1e-10)
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.524879113887437e-05, 0.0, 1e-10)
 
     reader.set_active_time_point(2)
     data = reader.read()["internalMesh"]
-    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.5253094867803156e-05, 0., 1e-10)
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.5253094867803156e-05, 0.0, 1e-10)
 
     reader.set_active_time_point(3)
     data = reader.read()["internalMesh"]
-    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.525657641352154e-05, 0., 1e-10)
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.525657641352154e-05, 0.0, 1e-10)
 
     reader.set_active_time_point(4)
     data = reader.read()["internalMesh"]
-    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.5258551836013794e-05, 0., 1e-10)
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.5258551836013794e-05, 0.0, 1e-10)
 
     reader.set_active_time_point(5)
     data = reader.read()["internalMesh"]
-    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.525951953837648e-05, 0., 1e-10)
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.525951953837648e-05, 0.0, 1e-10)
 
 
 def test_openfoam_cell_to_point_default():

--- a/tests/utilities/test_reader.py
+++ b/tests/utilities/test_reader.py
@@ -401,6 +401,62 @@ def test_openfoamreader_active_time():
     assert reader.active_time_value == 1.0
 
 
+def test_openfoamreader_read_data_time_value():
+    reader = get_cavity_reader()
+
+    reader.set_active_time_value(0.0)
+    data = reader.read()["internalMesh"]
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 0., 0., 1e-10)
+
+    reader.set_active_time_value(0.5)
+    data = reader.read()["internalMesh"]
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.524879113887437e-05, 0., 1e-10)
+
+    reader.set_active_time_value(1.0)
+    data = reader.read()["internalMesh"]
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.5253094867803156e-05, 0., 1e-10)
+
+    reader.set_active_time_value(1.5)
+    data = reader.read()["internalMesh"]
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.525657641352154e-05, 0., 1e-10)
+
+    reader.set_active_time_value(2.0)
+    data = reader.read()["internalMesh"]
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.5258551836013794e-05, 0., 1e-10)
+
+    reader.set_active_time_value(2.5)
+    data = reader.read()["internalMesh"]
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.525951953837648e-05, 0., 1e-10)
+
+
+def test_openfoamreader_read_data_time_point():
+    reader = get_cavity_reader()
+
+    reader.set_active_time_point(0)
+    data = reader.read()["internalMesh"]
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 0., 0., 1e-10)
+
+    reader.set_active_time_point(1)
+    data = reader.read()["internalMesh"]
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.524879113887437e-05, 0., 1e-10)
+
+    reader.set_active_time_point(2)
+    data = reader.read()["internalMesh"]
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.5253094867803156e-05, 0., 1e-10)
+
+    reader.set_active_time_point(3)
+    data = reader.read()["internalMesh"]
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.525657641352154e-05, 0., 1e-10)
+
+    reader.set_active_time_point(4)
+    data = reader.read()["internalMesh"]
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.5258551836013794e-05, 0., 1e-10)
+
+    reader.set_active_time_point(5)
+    data = reader.read()["internalMesh"]
+    assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.525951953837648e-05, 0., 1e-10)
+
+
 def test_openfoam_cell_to_point_default():
     reader = get_cavity_reader()
     mesh = reader.read()


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

This PR replaces the `SetTimeValue` used by `OpenFOAMReader.set_active_time_value` and `OpenFOAMReader.set_active_time_point`  with `UpdateTimeStep` per the discussion in #2473.

It also adds tests to actually read in temporal data and check if changing the time value works in terms of reading data.

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

The PR resolves #2473.

### Details

Originally, changing the time value of an `OpenFOAMReader` instance through `set_active_time_value` only has an effect for the first encounter of `read()`. After the first `read()`, changing the time value only affects the active time property but does not actually read corresponding temporal data.

Replacing `SetTimeValue` with `UpdateTimeStep` solves the issue. Reference: https://public.kitware.com/pipermail/vtkusers/2016-November/097070.html

