### PR TITLE
Use imageio intersphinx links

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3361,12 +3361,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
             range is ``0 - 10``.  Higher quality leads to a larger file.
 
         **kwargs : dict, optional
-            See the documentation for ``imageio.get_writer`` for additional kwargs.
+            See the documentation for :func:`imageio.get_writer` for additional kwargs.
 
         Notes
         -----
-        See the documentation for `imageio.get_writer
-        <https://imageio.readthedocs.io/en/stable/userapi.html#imageio.get_writer>`_
+        See the documentation for :func:`imageio.get_writer`.
 
         Examples
         --------
@@ -3411,14 +3410,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
                Setting this to ``True`` may help reduce jitter in colorbars.
 
         **kwargs : dict, optional
-            See the documentation for ``imageio.get_writer`` for additional kwargs.
+            See the documentation for :func:`imageio.get_writer` for additional kwargs.
 
         Notes
         -----
         Consider using `pygifsicle
         <https://github.com/LucaCappelletti94/pygifsicle>`_ to reduce the final
         size of the gif. See `Optimizing a GIF using pygifsicle
-        <https://imageio.readthedocs.io/en/stable/examples.html#optimizing-a-gif-using-pygifsicle>`_
+        <https://imageio.readthedocs.io/en/stable/examples.html#optimizing-a-gif-using-pygifsicle>`_.
 
         Examples
         --------

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3351,7 +3351,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
         ----------
         filename : str
             Filename of the movie to open.  Filename should end in mp4,
-            but other filetypes may be supported.  See ``imagio.get_writer``.
+            but other filetypes may be supported.  See :func:`imageio.get_writer()
+            <imageio.v2.get_writer>`.
 
         framerate : int, optional
             Frames per second.
@@ -3361,11 +3362,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
             range is ``0 - 10``.  Higher quality leads to a larger file.
 
         **kwargs : dict, optional
-            See the documentation for :func:`imageio.get_writer` for additional kwargs.
+            See the documentation for :func:`imageio.get_writer()
+            <imageio.v2.get_writer>` for additional kwargs.
 
         Notes
         -----
-        See the documentation for :func:`imageio.get_writer`.
+        See the documentation for :func:`imageio.get_writer() <imageio.v2.get_writer>`.
 
         Examples
         --------
@@ -3410,7 +3412,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
                Setting this to ``True`` may help reduce jitter in colorbars.
 
         **kwargs : dict, optional
-            See the documentation for :func:`imageio.get_writer` for additional kwargs.
+            See the documentation for :func:`imageio.get_writer() <imageio.v2.get_writer>`
+            for additional kwargs.
 
         Notes
         -----


### PR DESCRIPTION
We have the `imageio` intersphinx inventory located in `doc/conf.py`, but we weren't actually using it. This is a quick fix for this.

However, there's a related can of worms here: the links are kind of stale now, because
  1. there's [a v2 to v3 API migration](https://imageio.readthedocs.io/en/stable/reference/userapi.html#imageio.get_writer)
  2. `get_writer` is no longer documented online
  3. its docstring doesn't actually say much about kwargs which are plugin-specific.

Any recommendation of what we should do on our side? Upgrade our pointers to v3? Can we use a better link for explaining gif/mp4 writer kwargs?