### PR TITLE
Fix `download_single_sphere_animation`

### DIFF
--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -3442,9 +3442,27 @@ def download_single_sphere_animation(load=True):  # pragma: no cover
     pyvista.MultiBlock or str
         DataSet or filename depending on ``load``.
 
+    Examples
+    --------
+    >>> import pyvista
+    >>> from pyvista import examples
+    >>> filename = examples.download_single_sphere_animation(load=False)
+    >>> reader = pyvista.PVDReader(filename)
+    >>> plotter = pyvista.Plotter()
+    >>> plotter.open_gif("single_sphere_pvd.gif")
+    >>> for time_value in reader.time_values:
+    ...     reader.set_active_time_value(time_value)
+    ...     mesh = reader.read()
+    ...     _ = plotter.add_mesh(mesh, smooth_shading=True)
+    ...     _ = plotter.add_text(f"Time: {time_value:.0f}", color="black")
+    ...     plotter.write_frame()
+    ...     plotter.clear()
+    ...     plotter.enable_lightkit()
+    >>> plotter.close()
+
     """
+    _download_file('PVD/paraview/singleSphereAnimation.zip')
     filename, _ = _download_file('PVD/paraview/singleSphereAnimation.pvd')
-    folder, _ = _download_file('PVD/paraview/singleSphereAnimation')
     if not load:
         return filename
     return pyvista.PVDReader(filename).read()


### PR DESCRIPTION
### Overview

This download function was trying to download a folder.  This is corrected to use a zip file. 

This requires https://github.com/pyvista/vtk-data/pull/11 to be merged first.

### Details

An example was added similar to `download_dual_sphere_animation`

