### PR TITLE
Fix glyphs when orienting with cell data

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -655,7 +655,9 @@ class DataSet(DataSetFilters, DataObject):
             raise ValueError(f'Data field ({name}) with type ({field}) not usable')
 
         if ret < 0:
-            raise ValueError(f'Data field ({name}) with type ({field}) could not be set as the active scalars')
+            raise ValueError(
+                f'Data field ({name}) with type ({field}) could not be set as the active scalars'
+            )
 
         self._active_scalars_info = ActiveArrayInfo(field, name)
 
@@ -690,7 +692,9 @@ class DataSet(DataSetFilters, DataObject):
                 raise ValueError(f'Data field ({name}) with type ({field}) not usable')
 
             if ret < 0:
-                raise ValueError(f'Data field ({name}) with type ({field}) could not be set as the active vectors')
+                raise ValueError(
+                    f'Data field ({name}) with type ({field}) could not be set as the active vectors'
+                )
 
         self._active_vectors_info = ActiveArrayInfo(field, name)
 
@@ -725,7 +729,9 @@ class DataSet(DataSetFilters, DataObject):
                 raise ValueError(f'Data field ({name}) with type ({field}) not usable')
 
             if ret < 0:
-                raise ValueError(f'Data field ({name}) with type ({field}) could not be set as the active tensors')
+                raise ValueError(
+                    f'Data field ({name}) with type ({field}) could not be set as the active tensors'
+                )
 
         self._active_tensors_info = ActiveArrayInfo(field, name)
 

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -652,10 +652,10 @@ class DataSet(DataSetFilters, DataObject):
         elif field == FieldAssociation.CELL:
             ret = self.GetCellData().SetActiveScalars(name)
         else:
-            raise ValueError(f'Data field ({name}) not usable')
+            raise ValueError(f'Data field ({name}) with type ({field}) not usable')
 
         if ret < 0:
-            raise ValueError(f'Data field ({name}) could not be set as the active scalars')
+            raise ValueError(f'Data field ({name}) with type ({field}) could not be set as the active scalars')
 
         self._active_scalars_info = ActiveArrayInfo(field, name)
 
@@ -687,10 +687,10 @@ class DataSet(DataSetFilters, DataObject):
             elif field == FieldAssociation.CELL:
                 ret = self.GetCellData().SetActiveVectors(name)
             else:
-                raise ValueError(f'Data field ({name}) not usable')
+                raise ValueError(f'Data field ({name}) with type ({field}) not usable')
 
             if ret < 0:
-                raise ValueError(f'Data field ({name}) could not be set as the active vectors')
+                raise ValueError(f'Data field ({name}) with type ({field}) could not be set as the active vectors')
 
         self._active_vectors_info = ActiveArrayInfo(field, name)
 
@@ -722,10 +722,10 @@ class DataSet(DataSetFilters, DataObject):
             elif field == FieldAssociation.CELL:
                 ret = self.GetCellData().SetActiveTensors(name)
             else:
-                raise ValueError(f'Data field ({name}) not usable')
+                raise ValueError(f'Data field ({name}) with type ({field}) not usable')
 
             if ret < 0:
-                raise ValueError(f'Data field ({name}) could not be set as the active tensors')
+                raise ValueError(f'Data field ({name}) with type ({field}) could not be set as the active tensors')
 
         self._active_tensors_info = ActiveArrayInfo(field, name)
 

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -652,10 +652,10 @@ class DataSet(DataSetFilters, DataObject):
         elif field == FieldAssociation.CELL:
             ret = self.GetCellData().SetActiveScalars(name)
         else:
-            raise ValueError(f'Data field ({field}) not usable')
+            raise ValueError(f'Data field ({name}) not usable')
 
         if ret < 0:
-            raise ValueError(f'Data field ({field}) could not be set as the active scalars')
+            raise ValueError(f'Data field ({name}) could not be set as the active scalars')
 
         self._active_scalars_info = ActiveArrayInfo(field, name)
 
@@ -722,10 +722,10 @@ class DataSet(DataSetFilters, DataObject):
             elif field == FieldAssociation.CELL:
                 ret = self.GetCellData().SetActiveTensors(name)
             else:
-                raise ValueError(f'Data field ({field}) not usable')
+                raise ValueError(f'Data field ({name}) not usable')
 
             if ret < 0:
-                raise ValueError(f'Data field ({field}) could not be set as the active tensors')
+                raise ValueError(f'Data field ({name}) could not be set as the active tensors')
 
         self._active_tensors_info = ActiveArrayInfo(field, name)
 

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -645,7 +645,7 @@ class DataSet(DataSetFilters, DataObject):
             return
         field = get_array_association(self, name, preference=preference)
         if field == FieldAssociation.NONE:
-            raise KeyError(f'Data named "{name}" is a field array which cannot be active.')
+            raise KeyError(f'Data named ({name}) is a field array which cannot be active.')
         self._last_active_scalars_name = self.active_scalars_info.name
         if field == FieldAssociation.POINT:
             ret = self.GetPointData().SetActiveScalars(name)

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -687,10 +687,10 @@ class DataSet(DataSetFilters, DataObject):
             elif field == FieldAssociation.CELL:
                 ret = self.GetCellData().SetActiveVectors(name)
             else:
-                raise ValueError(f'Data field ({field}) not usable')
+                raise ValueError(f'Data field "{name}" not usable')
 
             if ret < 0:
-                raise ValueError(f'Data field ({field}) could not be set as the active vectors')
+                raise ValueError(f'Data field "{name}" could not be set as the active vectors')
 
         self._active_vectors_info = ActiveArrayInfo(field, name)
 

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -687,10 +687,10 @@ class DataSet(DataSetFilters, DataObject):
             elif field == FieldAssociation.CELL:
                 ret = self.GetCellData().SetActiveVectors(name)
             else:
-                raise ValueError(f'Data field "{name}" not usable')
+                raise ValueError(f'Data field ({name}) not usable')
 
             if ret < 0:
-                raise ValueError(f'Data field "{name}" could not be set as the active vectors')
+                raise ValueError(f'Data field ({name}) could not be set as the active vectors')
 
         self._active_vectors_info = ActiveArrayInfo(field, name)
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2011,7 +2011,9 @@ class DataSetFilters:
 
         # Clean the points before glyphing
         if tolerance is not None:
-            source_data = source_data.clean(
+            small = pyvista.PolyData(source_data.points)
+            small.point_data.update(source_data.point_data)
+            source_data = small.clean(
                 point_merging=True,
                 merge_tol=tolerance,
                 lines_to_points=False,

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1964,7 +1964,7 @@ class DataSetFilters:
                 alg.SetIndexModeToOff()
 
         if isinstance(scale, str):
-            dataset.set_active_scalars(scale, 'cell')
+            dataset.set_active_scalars(scale, 'point')
             scale = True
 
         if scale:
@@ -1977,7 +1977,8 @@ class DataSetFilters:
             alg.SetScaleModeToDataScalingOff()
 
         if isinstance(orient, str):
-            dataset.set_active_vectors(orient, 'cell')
+            prefer = 'cell' if dataset.active_scalars_info.association == FieldAssociation.CELL else 'point'
+            dataset.set_active_vectors(orient, prefer)
             orient = True
 
         if orient:

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1996,18 +1996,18 @@ class DataSetFilters:
                 )
                 orient = False
 
-        set_active_scalars_vectors = False
-
         if scale and orient:
             if dataset.active_vectors_info.association != dataset.active_scalars_info.association:
                 raise ValueError("Both ``scale`` and ``orient`` must use point data or cell data.")
 
         source_data = dataset
+        set_actives_on_source_data = False
+
         if (scale and dataset.active_scalars_info.association == FieldAssociation.CELL) or (
             orient and dataset.active_vectors_info.association == FieldAssociation.CELL
         ):
             source_data = dataset.cell_centers()
-            set_active_scalars_vectors = True
+            set_actives_on_source_data = True
 
         # Clean the points before glyphing
         if tolerance is not None:
@@ -2023,11 +2023,11 @@ class DataSetFilters:
                 absolute=absolute,
                 progress_bar=progress_bar,
             )
-            set_active_scalars_vectors = True
+            set_actives_on_source_data = True
 
-        # converting from cell -> points and the point merging operation both destroy the active vectors, so set them
-        # again
-        if set_active_scalars_vectors:
+        # upstream operations (cell to point conversion, point merging) may have unset the correct active
+        # scalars/vectors, so set them again
+        if set_actives_on_source_data:
             if scale:
                 source_data.set_active_scalars(dataset.active_scalars_name, preference='point')
             if orient:

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2029,9 +2029,9 @@ class DataSetFilters:
         # again
         if set_active_scalars_vectors:
             if scale:
-                source_data.set_active_scalars(dataset.active_scalars_name, 'point')
+                source_data.set_active_scalars(dataset.active_scalars_name, preference='point')
             if orient:
-                source_data.set_active_vectors(dataset.active_vectors_name, 'point')
+                source_data.set_active_vectors(dataset.active_vectors_name, preference='point')
 
         if rng is not None:
             alg.SetRange(rng)

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2029,9 +2029,9 @@ class DataSetFilters:
         # again
         if set_active_scalars_vectors:
             if scale:
-                source_data.set_active_scalars(dataset.active_scalars_name, 'point', err=True)
+                source_data.set_active_scalars(dataset.active_scalars_name, 'point')
             if orient:
-                source_data.set_active_vectors(dataset.active_vectors_name, 'point', err=True)
+                source_data.set_active_vectors(dataset.active_vectors_name, 'point')
 
         if rng is not None:
             alg.SetRange(rng)

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1996,11 +1996,15 @@ class DataSetFilters:
 
         if scale and orient:
             if dataset.active_vectors_info.association != dataset.active_scalars_info.association:
-                raise ValueError("Both ``scale`` and ``orient`` must use " "point data or cell data.")
+                raise ValueError(
+                    "Both ``scale`` and ``orient`` must use " "point data or cell data."
+                )
 
         source_data = dataset
-        if dataset.active_scalars_info.association == FieldAssociation.CELL or \
-                dataset.active_vectors_info.association == FieldAssociation.CELL:
+        if (
+            dataset.active_scalars_info.association == FieldAssociation.CELL
+            or dataset.active_vectors_info.association == FieldAssociation.CELL
+        ):
             source_data = dataset.cell_centers()
             set_active_scalars_vectors = True
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1927,8 +1927,9 @@ class DataSetFilters:
         dataset = self
         # Clean the points before glyphing
         if tolerance is not None:
-            small = pyvista.PolyData(dataset.points)
+            small = pyvista.PolyData(dataset.points, faces=dataset.faces)
             small.point_data.update(dataset.point_data)
+            small.cell_data.update(dataset.cell_data)
             dataset = small.clean(
                 point_merging=True,
                 merge_tol=tolerance,
@@ -2009,7 +2010,9 @@ class DataSetFilters:
                 dataset.active_vectors_info.association == FieldAssociation.CELL
                 and dataset.active_scalars_info.association == FieldAssociation.CELL
             ):
+                active_vectors_name = dataset.active_vectors_name
                 source_data = dataset.cell_centers()
+                source_data.set_active_vectors(active_vectors_name, 'point')
             elif (
                 dataset.active_vectors_info.association == FieldAssociation.POINT
                 and dataset.active_scalars_info.association == FieldAssociation.POINT

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1977,7 +1977,11 @@ class DataSetFilters:
             alg.SetScaleModeToDataScalingOff()
 
         if isinstance(orient, str):
-            prefer = 'cell' if dataset.active_scalars_info.association == FieldAssociation.CELL else 'point'
+            prefer = (
+                'cell'
+                if dataset.active_scalars_info.association == FieldAssociation.CELL
+                else 'point'
+            )
             dataset.set_active_vectors(orient, prefer)
             orient = True
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1964,7 +1964,7 @@ class DataSetFilters:
                 alg.SetIndexModeToOff()
 
         if isinstance(scale, str):
-            dataset.set_active_scalars(scale, 'point')
+            dataset.set_active_scalars(scale, preference='cell')
             scale = True
 
         if scale:
@@ -1981,7 +1981,7 @@ class DataSetFilters:
                 prefer = 'cell'
             else:
                 prefer = 'point'
-            dataset.set_active_vectors(orient, prefer)
+            dataset.set_active_vectors(orient, preference=prefer)
             orient = True
 
         if orient:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -54,12 +54,6 @@ class GetOutput:
     def latest_algorithm(self):
         return self._mock.call_args_list[-1][0][0]
 
-    @property
-    def algorithms_of_class(self, alg_class):
-        return filter(
-            lambda alg: isinstance(alg, alg_class), [args[0] for args in self._mock.call_args_list]
-        )
-
 
 @pytest.fixture
 def composite(datasets):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -734,7 +734,9 @@ def test_glyph_settings(sphere):
     assert alg.scale_mode == 'ScaleByScalar'
 
     # cell orient with cell scale and tolerance
-    alg: InterrogateVtkGlyph3D = sphere.glyph(scale='arr_cell', orient='vectors_cell', tolerance=0.05)
+    alg: InterrogateVtkGlyph3D = sphere.glyph(
+        scale='arr_cell', orient='vectors_cell', tolerance=0.05
+    )
     assert alg.input_active_scalars_info.name == 'arr_cell'
     assert alg.input_active_vectors_info.name == 'vectors_cell'
     assert alg.scale_mode == 'ScaleByScalar'
@@ -751,7 +753,9 @@ def test_glyph_settings(sphere):
     assert alg.scale_mode == 'ScaleByScalar'
 
     # point orient with point scale and tolerance
-    alg: InterrogateVtkGlyph3D = sphere.glyph(scale='arr_points', orient='vectors_points', tolerance=0.05)
+    alg: InterrogateVtkGlyph3D = sphere.glyph(
+        scale='arr_points', orient='vectors_points', tolerance=0.05
+    )
     assert alg.input_active_scalars_info.name == 'arr_points'
     assert alg.input_active_vectors_info.name == 'vectors_points'
     assert alg.scale_mode == 'ScaleByScalar'

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -735,6 +735,13 @@ def test_glyph_settings(sphere):
     sphere.set_active_scalars('active_vectors_points')
 
     with patch('pyvista.core.filters.data_set._get_output', GetOutput()) as go:
+        # no orient with cell scale
+        sphere.glyph(scale='arr_cell', orient=False)
+        alg = InterrogateVtkGlyph3D(go.latest_algorithm)
+        assert alg.input_active_scalars_info.name == 'arr_cell'
+        assert alg.scale_mode == 'ScaleByScalar'
+        go.reset()
+
         # cell orient with no scale
         sphere.glyph(scale=False, orient='vectors_cell')
         alg = InterrogateVtkGlyph3D(go.latest_algorithm)
@@ -755,6 +762,13 @@ def test_glyph_settings(sphere):
         alg = InterrogateVtkGlyph3D(go.latest_algorithm)
         assert alg.input_active_scalars_info.name == 'arr_cell'
         assert alg.input_active_vectors_info.name == 'vectors_cell'
+        assert alg.scale_mode == 'ScaleByScalar'
+        go.reset()
+
+        # no orient with point scale
+        sphere.glyph(scale='arr_points', orient=False)
+        alg = InterrogateVtkGlyph3D(go.latest_algorithm)
+        assert alg.input_active_scalars_info.name == 'arr_points'
         assert alg.scale_mode == 'ScaleByScalar'
         go.reset()
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -716,6 +716,16 @@ def test_glyph_settings(sphere):
     sphere['vectors_points'] = np.ones([sphere.n_points, 3])
     sphere['arr_cell'] = np.ones(sphere.n_cells)
     sphere['arr_points'] = np.ones(sphere.n_points)
+    sphere['active_arr_points'] = np.ones(sphere.n_points)
+    sphere['active_vectors_points'] = np.ones(sphere.n_points)
+
+    sphere.set_active_scalars('active_arr_points')
+    sphere.set_active_scalars('active_vectors_points')
+
+    # cell orient with no scale
+    alg: InterrogateVtkGlyph3D = sphere.glyph(scale=False, orient='vectors_cell')
+    assert alg.input_active_vectors_info.name == 'vectors_cell'
+    assert alg.scale_mode == 'DataScalingOff'
 
     # cell orient with cell scale
     alg: InterrogateVtkGlyph3D = sphere.glyph(scale='arr_cell', orient='vectors_cell')
@@ -723,21 +733,28 @@ def test_glyph_settings(sphere):
     assert alg.input_active_vectors_info.name == 'vectors_cell'
     assert alg.scale_mode == 'ScaleByScalar'
 
+    # cell orient with cell scale and tolerance
+    alg: InterrogateVtkGlyph3D = sphere.glyph(scale='arr_cell', orient='vectors_cell', tolerance=0.05)
+    assert alg.input_active_scalars_info.name == 'arr_cell'
+    assert alg.input_active_vectors_info.name == 'vectors_cell'
+    assert alg.scale_mode == 'ScaleByScalar'
+
+    # point orient with no scale
+    alg: InterrogateVtkGlyph3D = sphere.glyph(scale=False, orient='vectors_points')
+    assert alg.input_active_vectors_info.name == 'vectors_points'
+    assert alg.scale_mode == 'DataScalingOff'
+
     # point orient with point scale
     alg: InterrogateVtkGlyph3D = sphere.glyph(scale='arr_points', orient='vectors_points')
     assert alg.input_active_scalars_info.name == 'arr_points'
     assert alg.input_active_vectors_info.name == 'vectors_points'
     assert alg.scale_mode == 'ScaleByScalar'
 
-    # cell orient with no scale
-    alg: InterrogateVtkGlyph3D = sphere.glyph(scale=False, orient='vectors_cell')
-    assert alg.input_active_vectors_info.name == 'vectors_cell'
-    assert alg.scale_mode == 'DataScalingOff'
-
-    # point orient with no scale
-    alg: InterrogateVtkGlyph3D = sphere.glyph(scale=False, orient='vectors_points')
+    # point orient with point scale and tolerance
+    alg: InterrogateVtkGlyph3D = sphere.glyph(scale='arr_points', orient='vectors_points', tolerance=0.05)
+    assert alg.input_active_scalars_info.name == 'arr_points'
     assert alg.input_active_vectors_info.name == 'vectors_points'
-    assert alg.scale_mode == 'DataScalingOff'
+    assert alg.scale_mode == 'ScaleByScalar'
 
     # point orient with point scale + factor
     alg: InterrogateVtkGlyph3D = sphere.glyph(scale='arr_points', orient='vectors_points', factor=5)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -686,7 +686,7 @@ def test_glyph_cell_point_data(sphere):
         sphere.glyph(orient='vectors_points', scale='arr_cell', progress_bar=True)
 
 
-class InterrogateVtkGlyph3D:
+class InterrogateVTKGlyph3D:
     def __init__(self, alg: pyvista._vtk.vtkGlyph3D):
         self.alg = alg
 
@@ -740,21 +740,21 @@ def test_glyph_settings(sphere):
     with patch('pyvista.core.filters.data_set._get_output', GetOutput()) as go:
         # no orient with cell scale
         sphere.glyph(scale='arr_cell', orient=False)
-        alg = InterrogateVtkGlyph3D(go.latest_algorithm)
+        alg = InterrogateVTKGlyph3D(go.latest_algorithm)
         assert alg.input_active_scalars_info.name == 'arr_cell'
         assert alg.scale_mode == 'ScaleByScalar'
         go.reset()
 
         # cell orient with no scale
         sphere.glyph(scale=False, orient='vectors_cell')
-        alg = InterrogateVtkGlyph3D(go.latest_algorithm)
+        alg = InterrogateVTKGlyph3D(go.latest_algorithm)
         assert alg.input_active_vectors_info.name == 'vectors_cell'
         assert alg.scale_mode == 'DataScalingOff'
         go.reset()
 
         # cell orient with cell scale
         sphere.glyph(scale='arr_cell', orient='vectors_cell')
-        alg = InterrogateVtkGlyph3D(go.latest_algorithm)
+        alg = InterrogateVTKGlyph3D(go.latest_algorithm)
         assert alg.input_active_scalars_info.name == 'arr_cell'
         assert alg.input_active_vectors_info.name == 'vectors_cell'
         assert alg.scale_mode == 'ScaleByScalar'
@@ -762,7 +762,7 @@ def test_glyph_settings(sphere):
 
         # cell orient with cell scale and tolerance
         sphere.glyph(scale='arr_cell', orient='vectors_cell', tolerance=0.05)
-        alg = InterrogateVtkGlyph3D(go.latest_algorithm)
+        alg = InterrogateVTKGlyph3D(go.latest_algorithm)
         assert alg.input_active_scalars_info.name == 'arr_cell'
         assert alg.input_active_vectors_info.name == 'vectors_cell'
         assert alg.scale_mode == 'ScaleByScalar'
@@ -770,21 +770,21 @@ def test_glyph_settings(sphere):
 
         # no orient with point scale
         sphere.glyph(scale='arr_points', orient=False)
-        alg = InterrogateVtkGlyph3D(go.latest_algorithm)
+        alg = InterrogateVTKGlyph3D(go.latest_algorithm)
         assert alg.input_active_scalars_info.name == 'arr_points'
         assert alg.scale_mode == 'ScaleByScalar'
         go.reset()
 
         # point orient with no scale
         sphere.glyph(scale=False, orient='vectors_points')
-        alg = InterrogateVtkGlyph3D(go.latest_algorithm)
+        alg = InterrogateVTKGlyph3D(go.latest_algorithm)
         assert alg.input_active_vectors_info.name == 'vectors_points'
         assert alg.scale_mode == 'DataScalingOff'
         go.reset()
 
         # point orient with point scale
         sphere.glyph(scale='arr_points', orient='vectors_points')
-        alg = InterrogateVtkGlyph3D(go.latest_algorithm)
+        alg = InterrogateVTKGlyph3D(go.latest_algorithm)
         assert alg.input_active_scalars_info.name == 'arr_points'
         assert alg.input_active_vectors_info.name == 'vectors_points'
         assert alg.scale_mode == 'ScaleByScalar'
@@ -792,7 +792,7 @@ def test_glyph_settings(sphere):
 
         # point orient with point scale and tolerance
         sphere.glyph(scale='arr_points', orient='vectors_points', tolerance=0.05)
-        alg = InterrogateVtkGlyph3D(go.latest_algorithm)
+        alg = InterrogateVTKGlyph3D(go.latest_algorithm)
         assert alg.input_active_scalars_info.name == 'arr_points'
         assert alg.input_active_vectors_info.name == 'vectors_points'
         assert alg.scale_mode == 'ScaleByScalar'
@@ -800,14 +800,14 @@ def test_glyph_settings(sphere):
 
         # point orient with point scale + factor
         sphere.glyph(scale='arr_points', orient='vectors_points', factor=5)
-        alg = InterrogateVtkGlyph3D(go.latest_algorithm)
+        alg = InterrogateVTKGlyph3D(go.latest_algorithm)
         assert alg.input_active_scalars_info.name == 'arr_points'
         assert alg.input_active_vectors_info.name == 'vectors_points'
         assert alg.scale_factor == 5
 
         # ambiguous point/cell prefers points
         sphere.glyph(scale='arr_both', orient='vectors_both')
-        alg = InterrogateVtkGlyph3D(go.latest_algorithm)
+        alg = InterrogateVTKGlyph3D(go.latest_algorithm)
         assert alg.input_active_scalars_info.name == 'arr_both'
         assert alg.input_active_vectors_info.name == 'vectors_both'
         ## Test the length of the field and not the FieldAssociation, because the vtkGlyph3D filter takes POINT data
@@ -818,7 +818,7 @@ def test_glyph_settings(sphere):
         sphere.set_active_scalars('active_arr_points')
         sphere.set_active_vectors('active_vectors_points')
         sphere.glyph(scale=True, orient=True)
-        alg = InterrogateVtkGlyph3D(go.latest_algorithm)
+        alg = InterrogateVTKGlyph3D(go.latest_algorithm)
         assert alg.input_active_scalars_info.name == 'active_arr_points'
         assert alg.input_active_vectors_info.name == 'active_vectors_points'
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -52,7 +52,7 @@ class GetOutput:
 
     @property
     def latest_algorithm(self):
-        return self._mock.call_args_list[-1].args[0]
+        return self._mock.call_args_list[-1][0][0]
 
     @property
     def algorithms_of_class(self, alg_class):


### PR DESCRIPTION
### Overview

Fixes glyphs for cell data.

Description of the behavior:
- When trying to use `orient=` with the name of a cell vector array, the glyphs were not properly oriented.
- When trying to use `orient=` with the name of a cell vector array AND `tol=` with anything but `None`, the glyph filter would fail with `KeyError`

### Details

This PR fixes the problem by:
1. Ensuring that the desired `orient` array is active just prior to the glyphing
2. Moving the point merging to just before the glyphing. Before, the point merging was done on the raw data set, which makes sense for point data, but less so for cell data. In the case of cell data glyphs, the glyph origins would potentially be the centers of cells which aren't in the original dataset at all. The behavior is now changed so that the point merging is done on the dataset for the glyph source itself, which for cell glyphs is a dataset containing cell center points.

Glyphs seem to be quite hard to test. Below is an example script and some screenshots showing the behavior before and after.

```python
import pyvista as pv

# glyph with cell normals
s = pv.Sphere(phi_resolution=20, theta_resolution=20)
s = s.compute_normals(cell_normals=True, point_normals=False)
arrows = s.glyph(orient='Normals', scale='Normals', factor=0.1, tolerance=None)

p = pv.Plotter()
p.add_mesh(arrows, color='black')
p.add_mesh(s, color='k', style='wireframe')
p.add_mesh(s.copy(), color='white')
p.show()

# glyph with cell normals and tolerance
s = pv.Sphere(phi_resolution=20, theta_resolution=20)
s = s.compute_normals(cell_normals=True, point_normals=False)
arrows = s.glyph(orient='Normals', scale='Normals', factor=0.1, tolerance=0.05)

p = pv.Plotter()
p.add_mesh(arrows, color='black')
p.add_mesh(s, color='k', style='wireframe')
p.add_mesh(s.copy(), color='white')
p.show()
```

#### Before
![before](https://user-images.githubusercontent.com/2186528/164758641-28532ef9-a7e0-4d4b-8c4d-5870bba86708.png)

#### After
![after](https://user-images.githubusercontent.com/2186528/164758652-3e8d3849-436e-4138-89b2-ad1d3a0918db.png)
![after_with_tol](https://user-images.githubusercontent.com/2186528/164758663-3dcf7ce8-2d60-4426-98f8-029356801873.png)

