### PR TITLE
Revert "Add github-actions's comment when no labels"

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -43,15 +43,3 @@ jobs:
       if: startsWith(github.event.pull_request.head.ref, 'release')
       with:
         labels: release
-    - uses: peter-evans/create-or-update-comment@v2
-      if: |
-        not contains(github.event.pull_request.labels.*.name, 'enhancement') &&
-        not contains(github.event.pull_request.labels.*.name, 'documentation') &&
-        not contains(github.event.pull_request.labels.*.name, 'maintenance')
-      with:
-        issue-number: ${{ github.event.pull_request.number }}
-        body: |
-          Please add one of the following labels to add this contribution to the Release Notes :point_down:
-          - [enhancement](https://github.com/pyvista/pyvista/pulls?q=label%3Aenhancement+)
-          - [documentation](https://github.com/pyvista/pyvista/pulls?q=label%3Adocumentation+)
-          - [maintenance](https://github.com/pyvista/pyvista/pulls?q=label%3Amaintenance+)


### PR DESCRIPTION
Reverts pyvista/pyvista#2447 Resolve #2493
@MatthewFlamm Thanks for pointing #2493 out. I am opening #2453 to resolve this, but it still takes time. So please let me revert the Actions to work properly first.