### PR TITLE
Replace calls to deprecated ThresholdBetween

### DIFF
--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -391,7 +391,8 @@ class UniformGridFilters(DataSetFilters):
                 raise ValueError(
                     f'Threshold must be length one for a float value or two for min/max; not ({threshold}).'
                 )
-            alg.ThresholdBetween(threshold[0], threshold[1])
+            alg.ThresholdByLower(threshold[0])
+            alg.ThresholdByUpper(threshold[1])
         elif isinstance(threshold, collections.abc.Iterable):
             raise TypeError('Threshold must either be a single scalar or a sequence.')
         else:


### PR DESCRIPTION
### Overview

Addresses
```
2022-04-23 08:44:05.763 (   0.473s) [          41C2C8]       vtkThreshold.cxx:96    WARN| vtkThreshold::ThresholdBetween was deprecated for VTK 9.1 and will be removed in a future version.
```
by using `ThresholdByUpper` and `ThresholdByLower`, which exist as far back as VTK 8.2.0 and perhaps earlier. I'm not really sure why this method is being deprecated, and can't find anything about it on the VTK GitLab, but this at least gets rid of the warning text.