### PR TITLE
add polyhedral example

### DIFF
--- a/examples/00-load/create-poly.py
+++ b/examples/00-load/create-poly.py
@@ -74,7 +74,7 @@ points = np.array(
 face_a = [6, 0, 1, 2, 3, 4, 5]
 face_b = [6, 6, 7, 8, 1, 0, 9]
 face_c = [6, 10, 11, 12, 7, 6, 13]
-faces = np.hstack((face_a, face_b, face_c))
+faces = np.concatenate((face_a, face_b, face_c))
 
 mesh = pv.PolyData(points, faces)
 mesh.plot(show_edges=True, line_width=5)

--- a/examples/00-load/create-poly.py
+++ b/examples/00-load/create-poly.py
@@ -43,9 +43,9 @@ surf.plot(
 
 
 ###############################################################################
-# Polyhedral PolyData
-# ~~~~~~~~~~~~~~~~~~~
-# Create a three face polyhedral mesh directly from points and faces.
+# Polygonal PolyData
+# ~~~~~~~~~~~~~~~~~~
+# Create a three face polygonal mesh directly from points and faces.
 #
 # .. note::
 #    It is generally more efficient to use a numpy array rather than stacking

--- a/examples/00-load/create-poly.py
+++ b/examples/00-load/create-poly.py
@@ -4,8 +4,7 @@
 Create PolyData
 ~~~~~~~~~~~~~~~
 
-Creating a PolyData (triangulated surface) object from NumPy arrays of the
-vertices and faces.
+Creating a :class:`pyvista.PolyData` (surface mesh) from vertices and faces.
 
 """
 
@@ -16,15 +15,66 @@ import pyvista as pv
 ###############################################################################
 # A PolyData object can be created quickly from numpy arrays.  The vertex array
 # contains the locations of the points in the mesh and the face array contains
-# the number of points of each face and the indices of the vertices which comprise that face.
+# the number of points of each face and the indices of the vertices which
+# comprise that face.
 
 # mesh points
 vertices = np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0], [0.5, 0.5, -1]])
 
 # mesh faces
-faces = np.hstack([[4, 0, 1, 2, 3], [3, 0, 1, 4], [3, 1, 2, 4]])  # [square, triangle, triangle]
+faces = np.hstack(
+    [
+        [4, 0, 1, 2, 3],  # square
+        [3, 0, 1, 4],  # triangle
+        [3, 1, 2, 4],  # triangle
+    ]
+)
 
 surf = pv.PolyData(vertices, faces)
 
 # plot each face with a different color
-surf.plot(scalars=np.arange(3), cpos=[-1, 1, 0.5])
+surf.plot(
+    scalars=np.arange(3),
+    cpos=[-1, 1, 0.5],
+    show_scalar_bar=False,
+    show_edges=True,
+    line_width=5,
+)
+
+
+###############################################################################
+# Polyhedral PolyData
+# ~~~~~~~~~~~~~~~~~~~
+# Create a three face polyhedral mesh directly from points and faces.
+#
+# .. note::
+#    It is generally more efficient to use a numpy array rather than stacking
+#    lists for large meshes.
+
+points = np.array(
+    [
+        [0.0480, 0.0349, 0.9982],
+        [0.0305, 0.0411, 0.9987],
+        [0.0207, 0.0329, 0.9992],
+        [0.0218, 0.0158, 0.9996],
+        [0.0377, 0.0095, 0.9992],
+        [0.0485, 0.0163, 0.9987],
+        [0.0572, 0.0603, 0.9965],
+        [0.0390, 0.0666, 0.9970],
+        [0.0289, 0.0576, 0.9979],
+        [0.0582, 0.0423, 0.9974],
+        [0.0661, 0.0859, 0.9941],
+        [0.0476, 0.0922, 0.9946],
+        [0.0372, 0.0827, 0.9959],
+        [0.0674, 0.0683, 0.9954],
+    ],
+)
+
+
+face_a = [6, 0, 1, 2, 3, 4, 5]
+face_b = [6, 6, 7, 8, 1, 0, 9]
+face_c = [6, 10, 11, 12, 7, 6, 13]
+faces = np.hstack((face_a, face_b, face_c))
+
+mesh = pv.PolyData(points, faces)
+mesh.plot(show_edges=True, line_width=5)

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -545,6 +545,8 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
 
     >>> mesh = pyvista.PolyData(examples.antfile)
 
+    See :ref:`ref_create_poly` for more examples.
+
     """
 
     _WRITERS = {


### PR DESCRIPTION
### Polyhedral Example

In response to https://github.com/pyvista/pyvista/discussions/2503, this PR adds a basic polyhedral example to our docs:

```py
points = np.array(
    [[0.0480, 0.0349, 0.9982],
     [0.0305, 0.0411, 0.9987],
     [0.0207, 0.0329, 0.9992],
     [0.0218, 0.0158, 0.9996],
     [0.0377, 0.0095, 0.9992],
     [0.0485, 0.0163, 0.9987],
     [0.0572, 0.0603, 0.9965],
     [0.0390, 0.0666, 0.9970],
     [0.0289, 0.0576, 0.9979],
     [0.0582, 0.0423, 0.9974],
     [0.0661, 0.0859, 0.9941],
     [0.0476, 0.0922, 0.9946],
     [0.0372, 0.0827, 0.9959],
     [0.0674, 0.0683, 0.9954]],
)


face_a = [6, 0, 1, 2, 3, 4, 5]
face_b = [6, 6, 7, 8, 1, 0, 9]
face_c = [6, 10, 11, 12, 7, 6, 13]
faces = np.hstack((face_a, face_b, face_c))

mesh = pv.PolyData(points, faces)
mesh.plot(show_edges=True, line_width=5)
```
![image](https://user-images.githubusercontent.com/11981631/164982640-b0d89bbd-4582-44ae-a3c0-badd5248934c.png)
