### PR TITLE
Fix UniformGrid.x docstring

### DIFF
--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -580,7 +580,7 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         --------
         >>> import pyvista
         >>> grid = pyvista.UniformGrid(dims=(2, 2, 2))
-        >>> grid.y
+        >>> grid.x
         array([0., 1., 0., 1., 0., 1., 0., 1.])
 
         """


### PR DESCRIPTION
### Overview

When implementing #2510, this bug was found.  I'm not sure how this could pass the current doctest since it compares the strings  🤷 

