### PR TITLE
Return actor from add_mesh_threshold

### DIFF
--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1293,7 +1293,7 @@ class WidgetHelper:
         )
 
         kwargs.setdefault("reset_camera", False)
-        self.add_mesh(threshold_mesh, scalars=scalars, **kwargs)
+        return self.add_mesh(threshold_mesh, scalars=scalars, **kwargs)
 
     def add_mesh_isovalue(
         self,


### PR DESCRIPTION
### Overview

Simply returns the actor from the method `add_mesh_threshold` of `WidgetHelper` to be consistent with the docstring and other add mesh methods.

