### PR TITLE
Update OpenFOAM example to reuse Reader 

### DIFF
--- a/examples/99-advanced/openfoam-example.py
+++ b/examples/99-advanced/openfoam-example.py
@@ -12,8 +12,7 @@ from pyvista import examples
 ###############################################################################
 # This example uses data from a lid-driven cavity flow.  It is recommended to
 # use :class:`pyvista.OpenFOAMReader` for reading OpenFOAM files for more
-# control over reading data.  The OpenFOAMReader in pyvista must be recreated
-# each time a new mesh is read in, otherwise the same mesh is always returned.
+# control over reading data.
 #
 # This example will only run correctly in versions of vtk>=9.1.0.  The names
 # of the patch arrays and resulting keys in the read mesh will be different
@@ -63,7 +62,6 @@ print(internal_mesh.point_data)
 ###############################################################################
 # This behavior can be turned off if only cell data is required.
 
-reader = pyvista.OpenFOAMReader(filename)
 reader.cell_to_point_creation = False
 internal_mesh = reader.read()["internalMesh"]
 print("Cell Data:")
@@ -74,9 +72,9 @@ print(internal_mesh.point_data)
 ###############################################################################
 # Now we will read in all the data at the last time point.
 
-reader = pyvista.OpenFOAMReader(filename)
 print(f"Available Time Values: {reader.time_values}")
 reader.set_active_time_value(2.5)
+reader.cell_to_point_creation = True  # Need point data for streamlines
 mesh = reader.read()
 internal_mesh = mesh["internalMesh"]
 boundaries = mesh["boundary"]


### PR DESCRIPTION
### Overview

#2485 fixed OpenFOAMReader to be able to reuse the reader object for time steps.  This PR updates the example to take advantage of this.



