### PR TITLE
add example for Plotter.bounds

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1589,7 +1589,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> pl = pyvista.Plotter(shape=(1, 2))
         >>> _ = pl.add_mesh(pyvista.Sphere())
         >>> pl.subplot(0, 1)
-        >>> pl.add_mesh(pyvista.Cube())
+        >>> _ = pl.add_mesh(pyvista.Cube())
         >>> pl.show()
 
         Now, plot with the orientation widget.

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1150,7 +1150,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         --------
         >>> import pyvista
         >>> pl = pyvista.Plotter()
-        >>> pl.add_mesh(pyvista.Cube())
+        >>> _ = pl.add_mesh(pyvista.Cube())
         >>> pl.bounds
         [-0.5, 0.5, -0.5, 0.5, -0.5, 0.5]
 
@@ -1587,7 +1587,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         >>> import pyvista
         >>> pl = pyvista.Plotter(shape=(1, 2))
-        >>> pl.add_mesh(pyvista.Sphere())
+        >>> _ = pl.add_mesh(pyvista.Sphere())
         >>> pl.subplot(0, 1)
         >>> pl.add_mesh(pyvista.Cube())
         >>> pl.show()
@@ -1595,9 +1595,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
         Now, plot with the orientation widget.
 
         >>> pl = pyvista.Plotter(shape=(1, 2))
-        >>> pl.add_mesh(pyvista.Sphere())
+        >>> _ = pl.add_mesh(pyvista.Sphere())
         >>> pl.subplot(0, 1)
-        >>> pl.add_mesh(pyvista.Cube())
+        >>> _ = pl.add_mesh(pyvista.Cube())
         >>> pl.show_axes_all()
         >>> pl.show()
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1139,7 +1139,22 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     @property
     def bounds(self):
-        """Return the bounds of the active renderer."""
+        """Return the bounds of the active renderer.
+
+        Returns
+        -------
+        list
+            Bounds of the active renderer.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> pl = pyvista.Plotter()
+        >>> pl.add_mesh(pyvista.Cube())
+        >>> pl.bounds
+        [-0.5, 0.5, -0.5, 0.5, -0.5, 0.5]
+
+        """
         return self.renderer.bounds
 
     @property

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1579,7 +1579,29 @@ class BasePlotter(PickingHelper, WidgetHelper):
             renderer.hide_axes()
 
     def show_axes_all(self):
-        """Show the axes orientation widget in all renderers."""
+        """Show the axes orientation widget in all renderers.
+
+        Examples
+        --------
+        First, plot without the orientation widget.
+
+        >>> import pyvista
+        >>> pl = pyvista.Plotter(shape=(1, 2))
+        >>> pl.add_mesh(pyvista.Sphere())
+        >>> pl.subplot(0, 1)
+        >>> pl.add_mesh(pyvista.Cube())
+        >>> pl.show()
+
+        Now, plot with the orientation widget.
+
+        >>> pl = pyvista.Plotter(shape=(1, 2))
+        >>> pl.add_mesh(pyvista.Sphere())
+        >>> pl.subplot(0, 1)
+        >>> pl.add_mesh(pyvista.Cube())
+        >>> pl.show_axes_all()
+        >>> pl.show()
+
+        """
         for renderer in self.renderers:
             renderer.show_axes()
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1579,29 +1579,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             renderer.hide_axes()
 
     def show_axes_all(self):
-        """Show the axes orientation widget in all renderers.
-
-        Examples
-        --------
-        First, plot without the orientation widget.
-
-        >>> import pyvista
-        >>> pl = pyvista.Plotter(shape=(1, 2))
-        >>> _ = pl.add_mesh(pyvista.Sphere())
-        >>> pl.subplot(0, 1)
-        >>> _ = pl.add_mesh(pyvista.Cube())
-        >>> pl.show()
-
-        Now, plot with the orientation widget.
-
-        >>> pl = pyvista.Plotter(shape=(1, 2))
-        >>> _ = pl.add_mesh(pyvista.Sphere())
-        >>> pl.subplot(0, 1)
-        >>> _ = pl.add_mesh(pyvista.Cube())
-        >>> pl.show_axes_all()
-        >>> pl.show()
-
-        """
+        """Show the axes orientation widget in all renderers."""
         for renderer in self.renderers:
             renderer.show_axes()
 


### PR DESCRIPTION
This PR adds a simple example for `Plotter.bounds`.

See #1629
