### PR TITLE
Use Readers in fileio module

### DIFF
--- a/doc/api/readers/index.rst
+++ b/doc/api/readers/index.rst
@@ -39,6 +39,7 @@ Reader Classes
     JPEGReader
     MetaImageReader
     MFIXReader
+    MultiBlockPlot3DReader
     NRRDReader
     OBJReader
     OpenFOAMReader

--- a/doc/api/utilities/utilities.rst
+++ b/doc/api/utilities/utilities.rst
@@ -33,6 +33,7 @@ File IO
    read
    read_exodus
    read_texture
+   read_legacy
    save_meshio
 
 

--- a/doc/api/utilities/utilities.rst
+++ b/doc/api/utilities/utilities.rst
@@ -33,7 +33,6 @@ File IO
    read
    read_exodus
    read_texture
-   read_legacy
    save_meshio
 
 

--- a/pyvista/utilities/__init__.py
+++ b/pyvista/utilities/__init__.py
@@ -37,6 +37,7 @@ from .reader import (
     JPEGReader,
     MetaImageReader,
     MFIXReader,
+    MultiBlockPlot3DReader,
     NRRDReader,
     OBJReader,
     OpenFOAMReader,

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -184,7 +184,6 @@ def read(filename, attrs=None, force_ext=None, file_format=None, progress_bar=Fa
         if attrs is not None:
             _apply_attrs_to_reader(reader, attrs)
         if progress_bar:
-            print(reader)
             reader.show_progress()
         mesh = reader.read()
         if observer.has_event_occurred():

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -365,7 +365,7 @@ def read_plot3d(filename, q_filenames=(), auto_detect=True, attrs=None, progress
 
     .. deprecated:: 0.35.0
         This function is deprecated and will be removed in a future version.
-        Use :class:`pyvista.Plot3DMetaReader`.
+        Use :class:`pyvista.MultiBlockPlot3DReader`.
 
     Parameters
     ----------

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -80,7 +80,8 @@ def read(filename, attrs=None, force_ext=None, file_format=None, progress_bar=Fa
     """Read any file type supported by ``vtk`` or ``meshio``.
 
     .. deprecated:: 0.35.0
-        Use of `attrs` is deprecated.  Use `Reader` directly.
+        Use of `attrs` is deprecated.
+        Use a reader class using :func:`pyvista.get_reader`
 
     Automatically determines the correct reader to use then wraps the
     corresponding mesh as a pyvista object.  Attempts native ``vtk``
@@ -101,6 +102,7 @@ def read(filename, attrs=None, force_ext=None, file_format=None, progress_bar=Fa
         each file being a separate block in the dataset.
 
     attrs : dict, optional
+        Deprecated. Use a Reader class using :func:`pyvista.get_reader`.
         A dictionary of attributes to call on the reader. Keys of
         dictionary are the attribute/method names and values are the
         arguments passed to those calls. If you do not have any

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -130,16 +130,15 @@ def read(filename, attrs=None, force_ext=None, file_format=None, progress_bar=Fa
     try:
         reader = pyvista.get_reader(filename, force_ext)
     except ValueError:
-        try:
-            from meshio._exceptions import ReadError
+        # if using force_ext, we are explicitly only using vtk readers
+        if force_ext is not None:
+            raise IOError("This file was not able to be automatically read by pvista.")
+        from meshio._exceptions import ReadError
 
-            try:
-                return read_meshio(filename)
-            except ReadError:
-                pass
-        except SyntaxError:
-            # https://github.com/pyvista/pyvista/pull/495
-            pass
+        try:
+            return read_meshio(filename)
+        except ReadError:
+            raise IOError("This file was not able to be automatically read by pyvista.")
     else:
         observer = pyvista.utilities.errors.Observer()
         observer.observe(reader.reader)
@@ -155,8 +154,6 @@ def read(filename, attrs=None, force_ext=None, file_format=None, progress_bar=Fa
                 f'\t"{observer.get_message()}"'
             )
         return mesh
-
-    raise IOError("This file was not able to be automatically read by pyvista.")
 
 
 def _apply_attrs_to_reader(reader, attrs):

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -141,11 +141,20 @@ def read(filename, attrs=None, force_ext=None, file_format=None, progress_bar=Fa
             # https://github.com/pyvista/pyvista/pull/495
             pass
     else:
+        observer = pyvista.utilities.errors.Observer()
+        observer.observe(reader.reader)
         if attrs is not None:
             _apply_attrs_to_reader(reader, attrs)
         if progress_bar:
             reader.show_progress()
-        return reader.read()
+        mesh = reader.read()
+        if observer.has_event_occurred():
+            warnings.warn(
+                f"The VTK reader `{reader.reader.GetClassName()}` in pyvista reader `{reader}` raised an error"
+                "while reading the file.\n"
+                f'\t"{observer.get_message()}"'
+            )
+        return mesh
 
     raise IOError("This file was not able to be automatically read by pyvista.")
 

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -145,6 +145,7 @@ def read(filename, attrs=None, force_ext=None, file_format=None, progress_bar=Fa
         if attrs is not None:
             _apply_attrs_to_reader(reader, attrs)
         if progress_bar:
+            print(reader)
             reader.show_progress()
         mesh = reader.read()
         if observer.has_event_occurred():

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -42,10 +42,10 @@ def set_vtkwriter_mode(vtk_writer, use_binary=True):
 def read_legacy(filename, progress_bar=False):
     """Use VTK's legacy reader to read a file.
 
-    This uses ``vtk.vtkDataSetReader`` to read the data.
-
     .. deprecated:: 0.35.0
         This function is deprecated. Use :func:`pyvsista.read` instead.
+
+    This uses ``vtk.vtkDataSetReader`` to read the data.
 
     Parameters
     ----------

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -39,6 +39,43 @@ def set_vtkwriter_mode(vtk_writer, use_binary=True):
     return vtk_writer
 
 
+def read_legacy(filename, progress_bar=False):
+    """Use VTK's legacy reader to read a file.
+
+    This uses ``vtk.vtkDataSetReader`` to read the data.
+
+    .. deprecated:: 0.35.0
+        This function is deprecated. Use :func:`pyvsista.read` instead.
+
+    Parameters
+    ----------
+    filename : str
+        The string path to the file to read.
+
+    progress_bar : bool, optional
+        Optionally show a progress bar. Default ``False``.
+
+    Returns
+    -------
+    pyvista.DataSet
+        Wrapped pyvista mesh.
+
+    Examples
+    --------
+    Load an example mesh using the legacy reader.
+
+    >>> import pyvista
+    >>> from pyvista import examples
+    >>> mesh = pyvista.read_legacy(examples.uniformfile)
+
+    """
+    warnings.warn(
+        "Using read_legacy is deprecated. Use pyvista.read instead", PyvistaDeprecationWarning
+    )
+    filename = os.path.abspath(os.path.expanduser(str(filename)))
+    return read(filename, progress_bar=progress_bar)
+
+
 def read(filename, attrs=None, force_ext=None, file_format=None, progress_bar=False):
     """Read any file type supported by ``vtk`` or ``meshio``.
 

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -7,10 +7,12 @@ from xml.etree import ElementTree
 
 import pyvista
 from pyvista import _vtk
-from pyvista.utilities import abstract_class, get_ext, wrap
+from pyvista.utilities import abstract_class, wrap
+
+from .fileio import _get_ext_force
 
 
-def get_reader(filename):
+def get_reader(filename, force_ext=None):
     """Get a reader for fine-grained control of reading data files.
 
     Supported file types and Readers:
@@ -41,6 +43,8 @@ def get_reader(filename):
     | ``.gltf``      | :class:`pyvista.GLTFReader`                 |
     +----------------+---------------------------------------------+
     | ``.hdf``       | :class:`pyvista.HDFReader`                  |
+    +----------------+---------------------------------------------+
+    | ``.img``       | :class:`pyvista.DICOMReader `               |
     +----------------+---------------------------------------------+
     | ``.inp``       | :class:`pyvista.AVSucdReader`               |
     +----------------+---------------------------------------------+
@@ -139,7 +143,7 @@ def get_reader(filename):
     >>> mesh.plot(color='tan')
 
     """
-    ext = get_ext(filename)
+    ext = _get_ext_force(filename, force_ext)
 
     try:
         Reader = CLASS_READERS[ext]
@@ -1882,6 +1886,7 @@ CLASS_READERS = {
     '.g': BYUReader,
     '.glb': GLTFReader,
     '.gltf': GLTFReader,
+    '.img': DICOMReader,
     '.inp': AVSucdReader,
     '.jpg': JPEGReader,
     '.jpeg': JPEGReader,

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -181,7 +181,9 @@ class BaseReader:
         self._progress_bar = False
         self._progress_msg = None
         self.__directory = None
+        self._set_defaults()
         self.path = path
+        self._set_defaults_post()
 
     def __repr__(self):
         """Representation of a Reader object."""
@@ -297,6 +299,14 @@ class BaseReader:
 
     def _update_information(self):
         self.reader.UpdateInformation()
+
+    def _set_defaults(self):
+        """Set defaults on reader, if needed."""
+        pass
+
+    def _set_defaults_post(self):
+        """Set defaults on reader post setting file, if needed."""
+        pass
 
 
 class PointCellDataSelection:
@@ -730,18 +740,16 @@ class EnSightReader(BaseReader, PointCellDataSelection, TimeReader):
 
 # skip pydocstyle D102 check since docstring is taken from TimeReader
 class OpenFOAMReader(BaseReader, PointCellDataSelection, TimeReader):
-    """OpenFOAM Reader for .foam files."""
+    """OpenFOAM Reader for .foam files.
+
+    By default, pyvista enables all patch arrays.  This is a deviation
+    from the vtk default.
+
+    """
 
     _class_reader = _vtk.vtkOpenFOAMReader
 
-    def __init__(self, path):
-        """Initialize OpenFOAMReader.
-
-        By default, pyvista enables all patch arrays.  This is a deviation
-        from the vtk default.
-
-        """
-        super().__init__(path)
+    def _set_defaults_post(self):
         self.enable_all_patch_arrays()
 
     @property
@@ -1049,10 +1057,7 @@ class VTKDataSetReader(BaseReader):
 
     _class_reader = _vtk.vtkDataSetReader
 
-    def __init__(self, path):
-        """Initialize VTKDataSetReader with filename."""
-        super().__init__(path)
-        # Provide consistency with defaults in pyvista.read
+    def _set_defaults_post(self):
         self.reader.ReadAllScalarsOn()
         self.reader.ReadAllColorScalarsOn()
         self.reader.ReadAllNormalsOn()
@@ -1116,6 +1121,9 @@ class MultiBlockPlot3DReader(BaseReader):
     """MultiBlock Plot3D Reader."""
 
     _class_reader = staticmethod(_vtk.lazy_vtkMultiBlockPLOT3DReader)
+
+    def _set_defaults(self):
+        self.auto_detect_format = True
 
     def add_q_files(self, files):
         """Add q file(s).
@@ -1197,9 +1205,7 @@ class CGNSReader(BaseReader, PointCellDataSelection):
 
     _class_reader = staticmethod(_vtk.lazy_vtkCGNSReader)
 
-    def __init__(self, filename: str):
-        """Initialize CGNSReader with filename."""
-        super().__init__(filename)
+    def _set_defaults_post(self):
         self.enable_all_point_arrays()
         self.enable_all_cell_arrays()
         self.load_boundary_patch = True

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -45,7 +45,7 @@ def get_reader(filename, force_ext=None):
     +----------------+---------------------------------------------+
     | ``.hdf``       | :class:`pyvista.HDFReader`                  |
     +----------------+---------------------------------------------+
-    | ``.img``       | :class:`pyvista.DICOMReader `               |
+    | ``.img``       | :class:`pyvista.DICOMReader`                |
     +----------------+---------------------------------------------+
     | ``.inp``       | :class:`pyvista.AVSucdReader`               |
     +----------------+---------------------------------------------+
@@ -122,6 +122,9 @@ def get_reader(filename, force_ext=None):
     ----------
     filename : str
         The string path to the file to read.
+
+    force_ext : str, optional
+        An extension to force a specific reader to be chosen.
 
     Returns
     -------

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -148,32 +148,6 @@ def test_read_force_ext_wrong_extension(tmpdir):
     assert len(data) == 0
 
 
-@mock.patch('pyvista.utilities.fileio.standard_reader_routine')
-def test_read_legacy(srr_mock):
-    srr_mock.return_value = pyvista.read(ex.planefile)
-    pyvista.read_legacy('legacy.vtk')
-    args, kwargs = srr_mock.call_args
-    reader = args[0]
-    assert isinstance(reader, vtk.vtkDataSetReader)
-    assert reader.GetFileName().endswith('legacy.vtk')
-
-    # check error is raised when no data returned
-    srr_mock.reset_mock()
-    srr_mock.return_value = None
-    with pytest.raises(RuntimeError):
-        pyvista.read_legacy('legacy.vtk')
-
-
-@mock.patch('pyvista.utilities.fileio.read_legacy')
-def test_pyvista_read_legacy(read_legacy_mock):
-    # check that reading a file with extension .vtk calls `read_legacy`
-    # use the globefile as a dummy because pv.read() checks for the existence of the file
-    pyvista.read(ex.globefile)
-    args, kwargs = read_legacy_mock.call_args
-    filename = args[0]
-    assert filename == ex.globefile
-
-
 @mock.patch('pyvista.utilities.fileio.read_exodus')
 def test_pyvista_read_exodus(read_exodus_mock):
     # check that reading a file with extension .e calls `read_exodus`

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -143,6 +143,15 @@ def test_read_attrs(mock_reader, mock_read):
     mock_reader.test.assert_called_once_with('test_arg1', 'test_arg2')
 
 
+@mock.patch('pyvista.BaseReader.read')
+@mock.patch('pyvista.BaseReader.reader')
+@mock.patch('pyvista.BaseReader.show_progress')
+def test_read_progress_bar(mock_show_progress, mock_reader, mock_read):
+    """Test passing attrs in read."""
+    pyvista.read(ex.antfile, progress_bar=True)
+    mock_show_progress.assert_called_once()
+
+
 def test_read_force_ext_wrong_extension(tmpdir):
     # try to read a .vtu file as .vts
     # vtkXMLStructuredGridReader throws a VTK error about the validity of the XML file

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -177,6 +177,13 @@ def test_read_force_ext_wrong_extension(tmpdir):
         fileio.read(fname, force_ext='.not_supported')
 
 
+@mock.patch('pyvista.utilities.fileio.read')
+def test_read_legacy(read_mock):
+    with pytest.warns(PyvistaDeprecationWarning):
+        pyvista.read_legacy(ex.globefile, progress_bar=False)
+    read_mock.assert_called_once_with(ex.globefile, progress_bar=False)
+
+
 @mock.patch('pyvista.utilities.fileio.read_exodus')
 def test_pyvista_read_exodus(read_exodus_mock):
     # check that reading a file with extension .e calls `read_exodus`

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -129,6 +129,20 @@ def test_read_force_ext(tmpdir):
         assert isinstance(data, type)
 
 
+@mock.patch('pyvista.BaseReader.read')
+@mock.patch('pyvista.BaseReader.reader')
+def test_read_attrs(mock_reader, mock_read):
+    """Test passing attrs in read."""
+    with pytest.warns(PyvistaDeprecationWarning):
+        pyvista.read(ex.antfile, attrs={'test': 'test_arg'})
+    mock_reader.test.assert_called_once_with('test_arg')
+
+    mock_reader.reset_mock()
+    with pytest.warns(PyvistaDeprecationWarning):
+        pyvista.read(ex.antfile, attrs={'test': ['test_arg1', 'test_arg2']})
+    mock_reader.test.assert_called_once_with('test_arg1', 'test_arg2')
+
+
 def test_read_force_ext_wrong_extension(tmpdir):
     # try to read a .vtu file as .vts
     # vtkXMLStructuredGridReader throws a VTK error about the validity of the XML file

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -172,6 +172,10 @@ def test_read_force_ext_wrong_extension(tmpdir):
         data = fileio.read(fname, force_ext='.vtm')
     assert len(data) == 0
 
+    fname = ex.planefile
+    with pytest.raises(IOError):
+        fileio.read(fname, force_ext='.not_supported')
+
 
 @mock.patch('pyvista.utilities.fileio.read_exodus')
 def test_pyvista_read_exodus(read_exodus_mock):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -23,6 +23,7 @@ from pyvista.utilities import (
     helpers,
     transformations,
 )
+from pyvista.utilities.misc import PyvistaDeprecationWarning
 
 
 def test_version():
@@ -82,7 +83,8 @@ def test_read(tmpdir, use_pathlib):
     # Now test the standard_reader_routine
     for i, filename in enumerate(fnames):
         # Pass attrs to for the standard_reader_routine to be used
-        obj = fileio.read(filename, attrs={'DebugOn': None})
+        with pytest.warns(PyvistaDeprecationWarning):
+            obj = fileio.read(filename, attrs={'DebugOn': None})
         assert isinstance(obj, types[i])
     # this is also tested for each mesh types init from file tests
     filename = str(tmpdir.mkdir("tmpdir").join('tmp.npy'))
@@ -159,28 +161,19 @@ def test_pyvista_read_exodus(read_exodus_mock):
 
 
 @pytest.mark.parametrize('auto_detect', (True, False))
-@mock.patch('pyvista.utilities.fileio.standard_reader_routine')
-def test_read_plot3d(srr_mock, auto_detect):
+@mock.patch('pyvista.utilities.reader.BaseReader.read')
+@mock.patch('pyvista.utilities.reader.BaseReader.path')
+def test_read_plot3d(path_mock, read_mock, auto_detect):
     # with grid only
-    pyvista.read_plot3d(filename='grid.in', auto_detect=auto_detect)
-    srr_mock.assert_called_once()
-    args, kwargs = srr_mock.call_args
-    reader = args[0]
-    assert isinstance(reader, vtk.vtkMultiBlockPLOT3DReader)
-    assert reader.GetFileName().endswith('grid.in')
-    assert kwargs['filename'] is None
-    assert kwargs['attrs'] == {'SetAutoDetectFormat': auto_detect}
+    with pytest.warns(PyvistaDeprecationWarning):
+        pyvista.read_plot3d(filename='grid.in', auto_detect=auto_detect)
+    read_mock.assert_called_once()
 
     # with grid and q
-    srr_mock.reset_mock()
-    pyvista.read_plot3d(filename='grid.in', q_filenames='q1.save', auto_detect=auto_detect)
-    args, kwargs = srr_mock.call_args
-    reader = args[0]
-    assert isinstance(reader, vtk.vtkMultiBlockPLOT3DReader)
-    assert reader.GetFileName().endswith('grid.in')
-    assert args[0].GetQFileName().endswith('q1.save')
-    assert kwargs['filename'] is None
-    assert kwargs['attrs'] == {'SetAutoDetectFormat': auto_detect}
+    read_mock.reset_mock()
+    with pytest.warns(PyvistaDeprecationWarning):
+        pyvista.read_plot3d(filename='grid.in', q_filenames='q1.save', auto_detect=auto_detect)
+    read_mock.assert_called_once()
 
 
 def test_get_array():

--- a/tests/utilities/test_reader.py
+++ b/tests/utilities/test_reader.py
@@ -337,6 +337,29 @@ def test_plot3dmetareader():
         assert all([m.n_points, m.n_cells])
 
 
+def test_multiblockplot3dreader():
+    filename, _ = _download_file('multi-bin.xyz')
+    _download_file('multi-bin.q')
+    reader = pyvista.MultiBlockPlot3DReader(filename)
+    assert reader.path == filename
+
+    mesh = reader.read()
+    for m in mesh:
+        assert all([m.n_points, m.n_cells])
+
+    # Reader doesn't yet support reusability
+    reader = pyvista.MultiBlockPlot3DReader(filename)
+    reader.add_q_files('multi-bin.q')
+    reader = pyvista.MultiBlockPlot3DReader(filename)
+    reader.add_q_files(['multi-bin.q'])
+
+    reader = pyvista.MultiBlockPlot3DReader(filename)
+    reader.auto_detect_format = False
+    assert reader.auto_detect_format is False
+    reader.auto_detect_format = True
+    assert reader.auto_detect_format is True
+
+
 def test_binarymarchingcubesreader():
     filename = examples.download_pine_roots(load=False)
     reader = pyvista.get_reader(filename)

--- a/tests/utilities/test_reader.py
+++ b/tests/utilities/test_reader.py
@@ -339,19 +339,27 @@ def test_plot3dmetareader():
 
 def test_multiblockplot3dreader():
     filename, _ = _download_file('multi-bin.xyz')
-    _download_file('multi-bin.q')
+    q_filename, _ = _download_file('multi-bin.q')
     reader = pyvista.MultiBlockPlot3DReader(filename)
     assert reader.path == filename
 
     mesh = reader.read()
     for m in mesh:
         assert all([m.n_points, m.n_cells])
+        assert len(m.array_names) == 0
 
     # Reader doesn't yet support reusability
     reader = pyvista.MultiBlockPlot3DReader(filename)
-    reader.add_q_files('multi-bin.q')
+    reader.add_q_files(q_filename)
+    mesh = reader.read()
+    for m in mesh:
+        assert len(m.array_names) > 0
+
     reader = pyvista.MultiBlockPlot3DReader(filename)
-    reader.add_q_files(['multi-bin.q'])
+    q_filename = reader.add_q_files([q_filename])
+    mesh = reader.read()
+    for m in mesh:
+        assert len(m.array_names) > 0
 
     reader = pyvista.MultiBlockPlot3DReader(filename)
     reader.auto_detect_format = False


### PR DESCRIPTION
### Overview

Closes #2494.  This PR uses the machinery in the `pyvista.utilities.reader` module to replace the functionality that the `standard_reader_routine` did.

This enables one location to maintain reading utilities.

### Details

I will leave `read_exodus` out of this PR as there is no Reader class and it is self-contained in fileio.


TODO:
- [x] implement `read_plot3d` functionality into the Reader
- [x] ~~Add error observing functionality into BaseReader?~~ Continue wrapping observer for `pyvista.read`
- [x] Eliminate `standard_reader_routine`

