### PR TITLE
Added decompose_polyhedra property in OpenFOAMReader

### DIFF
--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -772,6 +772,16 @@ class OpenFOAMReader(BaseReader, PointCellDataSelection, TimeReader):
         bool
             If ``True``, decompose polyhedra into tetrahedra and pyramids.
 
+        Examples
+        --------
+        >>> import pyvista
+        >>> from pyvista import examples
+        >>> filename = examples.download_cavity(load=False)
+        >>> reader = pyvista.OpenFOAMReader(filename)
+        >>> reader.decompose_polyhedra = False
+        >>> reader.decompose_polyhedra
+        False
+
         """
         return bool(self.reader.GetDecomposePolyhedra())
 

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -764,6 +764,25 @@ class OpenFOAMReader(BaseReader, PointCellDataSelection, TimeReader):
         self.reader.UpdateTimeStep(self.time_point_value(time_point))
 
     @property
+    def decompose_polyhedra(self):
+        """Whether polyhedra are to be decomposed when read.
+
+        Returns
+        -------
+        bool
+            If ``True``, decompose polyhedra into tetrahedra and pyramids.
+
+        """
+        return bool(self.reader.GetDecomposePolyhedra())
+
+    @decompose_polyhedra.setter
+    def decompose_polyhedra(self, value):
+        if value:
+            self.reader.DecomposePolyhedraOn()
+        else:
+            self.reader.DecomposePolyhedraOff()
+
+    @property
     def cell_to_point_creation(self):
         """Whether cell data is translated to point data when read.
 

--- a/tests/utilities/test_reader.py
+++ b/tests/utilities/test_reader.py
@@ -487,6 +487,14 @@ def test_openfoamreader_read_data_time_point():
     assert np.isclose(data.cell_data["U"][:, 1].mean(), 4.525951953837648e-05, 0.0, 1e-10)
 
 
+def test_openfoam_decompose_polyhedra():
+    reader = get_cavity_reader()
+    reader.decompose_polyhedra = False
+    assert reader.decompose_polyhedra is True
+    reader.decompose_polyhedra = True
+    assert reader.decompose_polyhedra is True
+
+
 def test_openfoam_cell_to_point_default():
     reader = get_cavity_reader()
     mesh = reader.read()

--- a/tests/utilities/test_reader.py
+++ b/tests/utilities/test_reader.py
@@ -490,7 +490,7 @@ def test_openfoamreader_read_data_time_point():
 def test_openfoam_decompose_polyhedra():
     reader = get_cavity_reader()
     reader.decompose_polyhedra = False
-    assert reader.decompose_polyhedra is True
+    assert reader.decompose_polyhedra is False
     reader.decompose_polyhedra = True
     assert reader.decompose_polyhedra is True
 


### PR DESCRIPTION
### Overview

This new feature exposes the `DecomposePolyhedra` property from vtk to OpenFOAMReader.

This resolves #2559.

### Details

We would like to expose the `DecomposePolyhedra` property from the vtkOpenFOAMReader ([class definition](https://vtk.org/doc/nightly/html/classvtkOpenFOAMReader.html#a18ae532b114baee4653303b2ba05d161)). So we decided to add a property named `decompose_polyhedra` to OpenFOAMReader.