### PR TITLE
fix widget garbage collection

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -153,6 +153,7 @@ numpydoc_validation_checks = {
 }
 numpydoc_validation_exclude = {  # set of regex
     r'\.Plotter$',  # Issue with class parameter documentation
+    r'\.WidgetHelper$',
     r'\.from_dict$',
     r'\.to_dict$',
     r'\.__init__$',

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -24,15 +24,18 @@ def _launch_pick_event(interactor, event):
 class PickingHelper:
     """An internal class to hold picking related features."""
 
-    picked_cells = None
-    _picked_point = None
-    _picked_mesh = None
-    picked_path = None
-    picked_geodesic = None
-    picked_horizon = None
-    _picking_left_clicking_observer = None
-    _picking_text = None
-    _picker = None
+    def __init__(self, *args, **kwargs):
+        """Initialize the picking helper."""
+        super().__init__(*args, **kwargs)
+        self.picked_cells = None
+        self._picked_point = None
+        self._picked_mesh = None
+        self.picked_path = None
+        self.picked_geodesic = None
+        self.picked_horizon = None
+        self._picking_left_clicking_observer = None
+        self._picking_text = None
+        self._picker = None
 
     def get_pick_position(self):
         """Get the pick position or area.

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -195,9 +195,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
         col_weights=None,
         lighting='light kit',
         theme=None,
+        **kwargs,
     ):
         """Initialize base plotter."""
-        super().__init__()  # cooperative multiple inheritance
+        super().__init__(**kwargs)  # cooperative multiple inheritance
         log.debug('BasePlotter init start')
         self._theme = pyvista.themes.DefaultTheme()
         if theme is None:

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -278,6 +278,22 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if self.theme.antialiasing:
             self.enable_anti_aliasing()
 
+        # widgets
+        self.camera_widgets = []
+        self.box_widgets = []
+        self.box_clipped_meshes = []
+        self.plane_widgets = []
+        self.plane_clipped_meshes = []
+        self.plane_sliced_meshes = []
+        self.line_widgets = []
+        self.slider_widgets = []
+        self.threshold_meshes = []
+        self.isovalue_meshes = []
+        self.spline_widgets = []
+        self.spline_sliced_meshes = []
+        self.sphere_widgets = []
+        self.button_widgets = []
+
     @property
     def theme(self):
         """Return or set the theme used for this plotter.

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -197,6 +197,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         theme=None,
     ):
         """Initialize base plotter."""
+        super().__init__()  # cooperative multiple inheritance
         log.debug('BasePlotter init start')
         self._theme = pyvista.themes.DefaultTheme()
         if theme is None:
@@ -277,22 +278,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         # set antialiasing based on theme
         if self.theme.antialiasing:
             self.enable_anti_aliasing()
-
-        # widgets
-        self.camera_widgets = []
-        self.box_widgets = []
-        self.box_clipped_meshes = []
-        self.plane_widgets = []
-        self.plane_clipped_meshes = []
-        self.plane_sliced_meshes = []
-        self.line_widgets = []
-        self.slider_widgets = []
-        self.threshold_meshes = []
-        self.isovalue_meshes = []
-        self.spline_widgets = []
-        self.spline_sliced_meshes = []
-        self.sphere_widgets = []
-        self.button_widgets = []
 
     @property
     def theme(self):

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -136,7 +136,7 @@ class WidgetHelper:
         # this is necessary for garbage collection
         for widget in self.box_widgets:
             widget.Off()
-        self.box_widgets = []
+        self.box_widgets.clear()
 
     def add_mesh_clip_box(
         self,
@@ -448,7 +448,7 @@ class WidgetHelper:
         """Disable all of the plane widgets."""
         for widget in self.plane_widgets:
             widget.Off()
-        self.plane_widgets = []
+        self.plane_widgets.clear()
 
     def add_mesh_clip_plane(
         self,
@@ -846,7 +846,7 @@ class WidgetHelper:
         """Disable all of the line widgets."""
         for widget in self.line_widgets:
             widget.Off()
-        self.line_widgets = []
+        self.line_widgets.clear()
 
     def add_text_slider_widget(
         self,
@@ -1156,7 +1156,7 @@ class WidgetHelper:
         """Disable all of the slider widgets."""
         for widget in self.slider_widgets:
             widget.Off()
-        self.slider_widgets = []
+        self.slider_widgets.clear()
 
     def add_mesh_threshold(
         self,
@@ -1546,7 +1546,7 @@ class WidgetHelper:
         """Disable all of the spline widgets."""
         for widget in self.spline_widgets:
             widget.Off()
-        self.spline_widgets = []
+        self.spline_widgets.clear()
 
     def add_mesh_slice_spline(
         self,
@@ -1811,7 +1811,7 @@ class WidgetHelper:
         """Disable all of the sphere widgets."""
         for widget in self.sphere_widgets:
             widget.Off()
-        self.sphere_widgets = []
+        self.sphere_widgets.clear()
 
     def add_checkbox_button_widget(
         self,
@@ -1964,13 +1964,13 @@ class WidgetHelper:
         """Disable all of the camera widgets."""
         for widget in self.camera_widgets:
             widget.Off()
-        self.camera_widgets = []
+        self.camera_widgets.clear()
 
     def clear_button_widgets(self):
         """Disable all of the button widgets."""
         for widget in self.button_widgets:
             widget.Off()
-        self.button_widgets = []
+        self.button_widgets.clear()
 
     def close(self):
         """Close the widgets."""

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -22,6 +22,24 @@ class WidgetHelper:
 
     """
 
+    def __init__(self, *args, **kwargs):
+        """Initialize widget helper."""
+        super().__init__(*args, **kwargs)
+        self.camera_widgets = []
+        self.box_widgets = []
+        self.box_clipped_meshes = []
+        self.plane_widgets = []
+        self.plane_clipped_meshes = []
+        self.plane_sliced_meshes = []
+        self.line_widgets = []
+        self.slider_widgets = []
+        self.threshold_meshes = []
+        self.isovalue_meshes = []
+        self.spline_widgets = []
+        self.spline_sliced_meshes = []
+        self.sphere_widgets = []
+        self.button_widgets = []
+
     def add_box_widget(
         self,
         callback,
@@ -132,10 +150,7 @@ class WidgetHelper:
         return box_widget
 
     def clear_box_widgets(self):
-        """Disable all of the box widgets."""
-        # this is necessary for garbage collection
-        for widget in self.box_widgets:
-            widget.Off()
+        """Remove all of the box widgets."""
         self.box_widgets.clear()
 
     def add_mesh_clip_box(
@@ -445,9 +460,7 @@ class WidgetHelper:
         return plane_widget
 
     def clear_plane_widgets(self):
-        """Disable all of the plane widgets."""
-        for widget in self.plane_widgets:
-            widget.Off()
+        """Remove all of the plane widgets."""
         self.plane_widgets.clear()
 
     def add_mesh_clip_plane(
@@ -843,9 +856,7 @@ class WidgetHelper:
         return line_widget
 
     def clear_line_widgets(self):
-        """Disable all of the line widgets."""
-        for widget in self.line_widgets:
-            widget.Off()
+        """Remove all of the line widgets."""
         self.line_widgets.clear()
 
     def add_text_slider_widget(
@@ -1153,9 +1164,7 @@ class WidgetHelper:
         return slider_widget
 
     def clear_slider_widgets(self):
-        """Disable all of the slider widgets."""
-        for widget in self.slider_widgets:
-            widget.Off()
+        """Remove all of the slider widgets."""
         self.slider_widgets.clear()
 
     def add_mesh_threshold(
@@ -1543,9 +1552,7 @@ class WidgetHelper:
         return spline_widget
 
     def clear_spline_widgets(self):
-        """Disable all of the spline widgets."""
-        for widget in self.spline_widgets:
-            widget.Off()
+        """Remove all of the spline widgets."""
         self.spline_widgets.clear()
 
     def add_mesh_slice_spline(
@@ -1808,9 +1815,7 @@ class WidgetHelper:
         return sphere_widget
 
     def clear_sphere_widgets(self):
-        """Disable all of the sphere widgets."""
-        for widget in self.sphere_widgets:
-            widget.Off()
+        """Remove all of the sphere widgets."""
         self.sphere_widgets.clear()
 
     def add_checkbox_button_widget(
@@ -1961,15 +1966,11 @@ class WidgetHelper:
         return widget
 
     def clear_camera_widgets(self):
-        """Disable all of the camera widgets."""
-        for widget in self.camera_widgets:
-            widget.Off()
+        """Remove all of the camera widgets."""
         self.camera_widgets.clear()
 
     def clear_button_widgets(self):
-        """Disable all of the button widgets."""
-        for widget in self.button_widgets:
-            widget.Off()
+        """Remove all of the button widgets."""
         self.button_widgets.clear()
 
     def close(self):

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1,7 +1,5 @@
 """Module dedicated to widgets."""
 
-from typing import List
-
 import numpy as np
 
 import pyvista
@@ -23,9 +21,6 @@ class WidgetHelper:
     It also manages and other helper methods involving widgets.
 
     """
-
-    _camera_widgets: List[object] = []
-    box_widgets: List[object] = []
 
     def add_box_widget(
         self,
@@ -139,9 +134,8 @@ class WidgetHelper:
     def clear_box_widgets(self):
         """Disable all of the box widgets."""
         # this is necessary for garbage collection
-        for widget in list(self.box_widgets):
-            self.box_widgets.remove(widget)
-
+        for widget in self.box_widgets:
+            widget.Off()
         self.box_widgets = []
 
     def add_mesh_clip_box(
@@ -225,8 +219,6 @@ class WidgetHelper:
         alg.SetInputDataObject(mesh)
         alg.GenerateClippedOutputOn()
 
-        if not hasattr(self, "box_clipped_meshes"):
-            self.box_clipped_meshes = []
         box_clipped_mesh = pyvista.wrap(alg.GetOutput(port))
         self.box_clipped_meshes.append(box_clipped_mesh)
 
@@ -345,9 +337,6 @@ class WidgetHelper:
             Plane widget.
 
         """
-        if not hasattr(self, "plane_widgets"):
-            self.plane_widgets = []
-
         if origin is None:
             origin = self.center
         if bounds is None:
@@ -457,10 +446,9 @@ class WidgetHelper:
 
     def clear_plane_widgets(self):
         """Disable all of the plane widgets."""
-        if hasattr(self, 'plane_widgets'):
-            for widget in self.plane_widgets:
-                widget.Off()
-            del self.plane_widgets
+        for widget in self.plane_widgets:
+            widget.Off()
+        self.plane_widgets = []
 
     def add_mesh_clip_plane(
         self,
@@ -569,8 +557,6 @@ class WidgetHelper:
         alg.SetValue(value)
         alg.SetInsideOut(invert)  # invert the clip if needed
 
-        if not hasattr(self, "plane_clipped_meshes"):
-            self.plane_clipped_meshes = []
         plane_clipped_mesh = _get_output(alg)
         self.plane_clipped_meshes.append(plane_clipped_mesh)
 
@@ -687,8 +673,6 @@ class WidgetHelper:
         if not generate_triangles:
             alg.GenerateTrianglesOff()
 
-        if not hasattr(self, "plane_sliced_meshes"):
-            self.plane_sliced_meshes = []
         plane_sliced_mesh = pyvista.wrap(alg.GetOutput())
         self.plane_sliced_meshes.append(plane_sliced_mesh)
 
@@ -825,9 +809,6 @@ class WidgetHelper:
             Created line widget.
 
         """
-        if not hasattr(self, "line_widgets"):
-            self.line_widgets = []
-
         if bounds is None:
             bounds = self.bounds
 
@@ -863,10 +844,9 @@ class WidgetHelper:
 
     def clear_line_widgets(self):
         """Disable all of the line widgets."""
-        if hasattr(self, 'line_widgets'):
-            for widget in self.line_widgets:
-                widget.Off()
-            del self.line_widgets
+        for widget in self.line_widgets:
+            widget.Off()
+        self.line_widgets = []
 
     def add_text_slider_widget(
         self,
@@ -1086,9 +1066,6 @@ class WidgetHelper:
         ... )
         >>> pl.show()
         """
-        if not hasattr(self, "slider_widgets"):
-            self.slider_widgets = []
-
         if value is None:
             value = ((rng[1] - rng[0]) / 2) + rng[0]
 
@@ -1177,10 +1154,9 @@ class WidgetHelper:
 
     def clear_slider_widgets(self):
         """Disable all of the slider widgets."""
-        if hasattr(self, 'slider_widgets'):
-            for widget in self.slider_widgets:
-                widget.Off()
-            del self.slider_widgets
+        for widget in self.slider_widgets:
+            widget.Off()
+        self.slider_widgets = []
 
     def add_mesh_threshold(
         self,
@@ -1282,8 +1258,6 @@ class WidgetHelper:
         )  # args: (idx, port, connection, field, name)
         alg.SetUseContinuousCellRange(continuous)
 
-        if not hasattr(self, "threshold_meshes"):
-            self.threshold_meshes = []
         threshold_mesh = pyvista.wrap(alg.GetOutput())
         self.threshold_meshes.append(threshold_mesh)
 
@@ -1423,8 +1397,6 @@ class WidgetHelper:
 
         self.add_mesh(mesh.outline(), name=name + "outline", opacity=0.0)
 
-        if not hasattr(self, "isovalue_meshes"):
-            self.isovalue_meshes = []
         isovalue_mesh = pyvista.wrap(alg.GetOutput())
         self.isovalue_meshes.append(isovalue_mesh)
 
@@ -1527,9 +1499,6 @@ class WidgetHelper:
         if initial_points is not None and len(initial_points) != n_handles:
             raise ValueError("`initial_points` must be length `n_handles`.")
 
-        if not hasattr(self, "spline_widgets"):
-            self.spline_widgets = []
-
         color = Color(color, default_color=pyvista.global_theme.color)
 
         if bounds is None:
@@ -1575,10 +1544,9 @@ class WidgetHelper:
 
     def clear_spline_widgets(self):
         """Disable all of the spline widgets."""
-        if hasattr(self, 'spline_widgets'):
-            for widget in self.spline_widgets:
-                widget.Off()
-            del self.spline_widgets
+        for widget in self.spline_widgets:
+            widget.Off()
+        self.spline_widgets = []
 
     def add_mesh_slice_spline(
         self,
@@ -1669,8 +1637,6 @@ class WidgetHelper:
         if not generate_triangles:
             alg.GenerateTrianglesOff()
 
-        if not hasattr(self, "spline_sliced_meshes"):
-            self.spline_sliced_meshes = []
         spline_sliced_mesh = pyvista.wrap(alg.GetOutput())
         self.spline_sliced_meshes.append(spline_sliced_mesh)
 
@@ -1776,9 +1742,6 @@ class WidgetHelper:
             The sphere widget.
 
         """
-        if not hasattr(self, "sphere_widgets"):
-            self.sphere_widgets = []
-
         if color is None:
             color = pyvista.global_theme.color.float_rgb
         selected_color = Color(selected_color)
@@ -1846,10 +1809,9 @@ class WidgetHelper:
 
     def clear_sphere_widgets(self):
         """Disable all of the sphere widgets."""
-        if hasattr(self, 'sphere_widgets'):
-            for widget in self.sphere_widgets:
-                widget.Off()
-            del self.sphere_widgets
+        for widget in self.sphere_widgets:
+            widget.Off()
+        self.sphere_widgets = []
 
     def add_checkbox_button_widget(
         self,
@@ -1916,8 +1878,6 @@ class WidgetHelper:
         Download the interactive example at :ref:`checkbox_widget_example`.
 
         """
-        if not hasattr(self, "button_widgets"):
-            self.button_widgets = []
 
         def create_button(color1, color2, color3, dims=(size, size, 1)):
             color1 = np.array(Color(color1).int_rgb)
@@ -1997,22 +1957,20 @@ class WidgetHelper:
         widget.SetAnimate(animate)
         widget.SetAnimatorTotalFrames(n_frames)
         widget.On()
-        self._camera_widgets.append(widget)
+        self.camera_widgets.append(widget)
         return widget
 
     def clear_camera_widgets(self):
         """Disable all of the camera widgets."""
-        for widget in list(self._camera_widgets):
+        for widget in self.camera_widgets:
             widget.Off()
-            self._camera_widgets.remove(widget)  # this is necessary
-        self._camera_widgets = []
+        self.camera_widgets = []
 
     def clear_button_widgets(self):
         """Disable all of the button widgets."""
-        if hasattr(self, 'button_widgets'):
-            for widget in self.button_widgets:
-                widget.Off()
-            del self.button_widgets
+        for widget in self.button_widgets:
+            widget.Off()
+        self.button_widgets = []
 
     def close(self):
         """Close the widgets."""

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -25,6 +25,7 @@ class WidgetHelper:
     """
 
     _camera_widgets: List[object] = []
+    box_widgets: List[object] = []
 
     def add_box_widget(
         self,
@@ -100,9 +101,6 @@ class WidgetHelper:
         Download the interactive example at :ref:`box_widget_example`.
 
         """
-        if not hasattr(self, "box_widgets"):
-            self.box_widgets = []
-
         if bounds is None:
             bounds = self.bounds
 
@@ -140,10 +138,11 @@ class WidgetHelper:
 
     def clear_box_widgets(self):
         """Disable all of the box widgets."""
-        if hasattr(self, 'box_widgets'):
-            for widget in self.box_widgets:
-                widget.Off()
-            del self.box_widgets
+        # this is necessary for garbage collection
+        for widget in list(self.box_widgets):
+            self.box_widgets.remove(widget)
+
+        self.box_widgets = []
 
     def add_mesh_clip_box(
         self,
@@ -2003,8 +2002,9 @@ class WidgetHelper:
 
     def clear_camera_widgets(self):
         """Disable all of the camera widgets."""
-        for widget in self._camera_widgets:
+        for widget in list(self._camera_widgets):
             widget.Off()
+            self._camera_widgets.remove(widget)  # this is necessary
         self._camera_widgets = []
 
     def clear_button_widgets(self):

--- a/tests/plotting/test_widgets.py
+++ b/tests/plotting/test_widgets.py
@@ -234,6 +234,6 @@ def test_widget_checkbox_button(uniform):
 def test_add_camera_orientation_widget(uniform):
     p = pyvista.Plotter()
     p.add_camera_orientation_widget()
-    assert p._camera_widgets
+    assert p.camera_widgets
     p.close()
-    assert not p._camera_widgets
+    assert not p.camera_widgets

--- a/tests/plotting/test_widgets.py
+++ b/tests/plotting/test_widgets.py
@@ -12,31 +12,31 @@ if not system_supports_plotting():
     pytestmark = pytest.mark.skip
 
 
-def test_widget_box():
+def test_widget_box(sphere):
     p = pyvista.Plotter()
     func = lambda box: box  # Does nothing
-    p.add_mesh(mesh)
+    p.add_mesh(sphere)
     p.add_box_widget(callback=func)
     p.close()
 
     p = pyvista.Plotter()
     func = lambda box, widget: box  # Does nothing
-    p.add_mesh(mesh)
+    p.add_mesh(sphere)
     p.add_box_widget(callback=func, pass_widget=True)
     p.close()
 
     # clip box with and without crinkle
     p = pyvista.Plotter()
-    p.add_mesh_clip_box(mesh)
+    p.add_mesh_clip_box(sphere)
     p.close()
 
     p = pyvista.Plotter()
-    p.add_mesh_clip_box(mesh, crinkle=True)
+    p.add_mesh_clip_box(sphere, crinkle=True)
     p.close()
 
     p = pyvista.Plotter()
     # merge_points=True is the default and is tested above
-    p.add_mesh_clip_box(mesh, merge_points=False)
+    p.add_mesh_clip_box(sphere, merge_points=False)
     p.close()
 
 

--- a/tests/plotting/test_widgets.py
+++ b/tests/plotting/test_widgets.py
@@ -2,122 +2,119 @@ import numpy as np
 import pytest
 
 import pyvista
-from pyvista import examples
 from pyvista.plotting import system_supports_plotting
-
-mesh = examples.load_uniform()
 
 # skip all tests if unable to render
 if not system_supports_plotting():
     pytestmark = pytest.mark.skip
 
 
-def test_widget_box(sphere):
+def test_widget_box(uniform):
     p = pyvista.Plotter()
     func = lambda box: box  # Does nothing
-    p.add_mesh(sphere)
+    p.add_mesh(uniform)
     p.add_box_widget(callback=func)
     p.close()
 
     p = pyvista.Plotter()
     func = lambda box, widget: box  # Does nothing
-    p.add_mesh(sphere)
+    p.add_mesh(uniform)
     p.add_box_widget(callback=func, pass_widget=True)
     p.close()
 
     # clip box with and without crinkle
     p = pyvista.Plotter()
-    p.add_mesh_clip_box(sphere)
+    p.add_mesh_clip_box(uniform)
     p.close()
 
     p = pyvista.Plotter()
-    p.add_mesh_clip_box(sphere, crinkle=True)
+    p.add_mesh_clip_box(uniform, crinkle=True)
     p.close()
 
     p = pyvista.Plotter()
     # merge_points=True is the default and is tested above
-    p.add_mesh_clip_box(sphere, merge_points=False)
+    p.add_mesh_clip_box(uniform, merge_points=False)
     p.close()
 
 
-def test_widget_plane():
+def test_widget_plane(uniform):
     p = pyvista.Plotter()
     func = lambda normal, origin: normal  # Does nothing
-    p.add_mesh(mesh)
+    p.add_mesh(uniform)
     p.add_plane_widget(callback=func, implicit=True)
     p.close()
 
     p = pyvista.Plotter()
     func = lambda normal, origin, widget: normal  # Does nothing
-    p.add_mesh(mesh)
+    p.add_mesh(uniform)
     p.add_plane_widget(callback=func, pass_widget=True, implicit=True)
     p.close()
 
     p = pyvista.Plotter()
     func = lambda normal, origin: normal  # Does nothing
-    p.add_mesh(mesh)
+    p.add_mesh(uniform)
     p.add_plane_widget(callback=func, implicit=False)
     p.close()
 
     p = pyvista.Plotter()
     func = lambda normal, origin, widget: normal  # Does nothing
-    p.add_mesh(mesh)
+    p.add_mesh(uniform)
     p.add_plane_widget(callback=func, pass_widget=True, implicit=False)
     p.close()
 
     p = pyvista.Plotter()
     func = lambda normal, origin: normal  # Does nothing
-    p.add_mesh(mesh)
+    p.add_mesh(uniform)
     p.add_plane_widget(callback=func, assign_to_axis='z', implicit=True)
     p.close()
 
     p = pyvista.Plotter()
     func = lambda normal, origin: normal  # Does nothing
-    p.add_mesh(mesh)
+    p.add_mesh(uniform)
     p.add_plane_widget(callback=func, normal_rotation=False, implicit=False)
     p.close()
 
     p = pyvista.Plotter()
-    p.add_mesh_clip_plane(mesh)
+    p.add_mesh_clip_plane(uniform)
     p.close()
 
     p = pyvista.Plotter()
-    p.add_mesh_clip_plane(mesh, crinkle=True)
+    p.add_mesh_clip_plane(uniform, crinkle=True)
     p.close()
 
     p = pyvista.Plotter()
-    p.add_mesh_slice(mesh)
+    p.add_mesh_slice(uniform)
     p.close()
 
     p = pyvista.Plotter()
-    p.add_mesh_slice_orthogonal(mesh)
+    p.add_mesh_slice_orthogonal(uniform)
     p.close()
 
 
-def test_widget_line():
+def test_widget_line(uniform):
     p = pyvista.Plotter()
     func = lambda line: line  # Does nothing
-    p.add_mesh(mesh)
+    p.add_mesh(uniform)
     p.add_line_widget(callback=func)
     p.close()
 
     p = pyvista.Plotter()
     func = lambda line, widget: line  # Does nothing
-    p.add_mesh(mesh)
+    p.add_mesh(uniform)
     p.add_line_widget(callback=func, pass_widget=True)
     p.close()
 
     p = pyvista.Plotter()
     func = lambda a, b: (a, b)  # Does nothing
-    p.add_mesh(mesh)
+    p.add_mesh(uniform)
     p.add_line_widget(callback=func, use_vertices=True)
     p.close()
 
 
-def test_widget_text_slider():
+def test_widget_text_slider(uniform):
     p = pyvista.Plotter()
     func = lambda value: value  # Does nothing
-    p.add_mesh(mesh)
+    p.add_mesh(uniform)
     with pytest.raises(TypeError, match='must be a list'):
         p.add_text_slider_widget(callback=func, data='foo')
     with pytest.raises(ValueError, match='list of values is empty'):
@@ -127,10 +124,10 @@ def test_widget_text_slider():
     p.close()
 
 
-def test_widget_slider():
+def test_widget_slider(uniform):
     p = pyvista.Plotter()
     func = lambda value: value  # Does nothing
-    p.add_mesh(mesh)
+    p.add_mesh(uniform)
     p.add_slider_widget(callback=func, rng=[0, 10], style="classic")
     p.close()
 
@@ -149,22 +146,22 @@ def test_widget_slider():
 
     p = pyvista.Plotter()
     func = lambda value, widget: value  # Does nothing
-    p.add_mesh(mesh)
+    p.add_mesh(uniform)
     p.add_slider_widget(callback=func, rng=[0, 10], style="modern", pass_widget=True)
     p.close()
 
     p = pyvista.Plotter()
-    p.add_mesh_threshold(mesh, invert=True)
-    p.add_mesh(mesh.outline())
+    p.add_mesh_threshold(uniform, invert=True)
+    p.add_mesh(uniform.outline())
     p.close()
 
     p = pyvista.Plotter()
-    p.add_mesh_threshold(mesh, invert=False)
-    p.add_mesh(mesh.outline())
+    p.add_mesh_threshold(uniform, invert=False)
+    p.add_mesh(uniform.outline())
     p.close()
 
     p = pyvista.Plotter()
-    p.add_mesh_isovalue(mesh)
+    p.add_mesh_isovalue(uniform)
     p.close()
 
     p = pyvista.Plotter()
@@ -194,25 +191,25 @@ def test_widget_slider():
     p.close()
 
 
-def test_widget_spline():
+def test_widget_spline(uniform):
     p = pyvista.Plotter()
     func = lambda spline: spline  # Does nothing
-    p.add_mesh(mesh)
+    p.add_mesh(uniform)
     p.add_spline_widget(callback=func)
     p.close()
 
     p = pyvista.Plotter()
     func = lambda spline, widget: spline  # Does nothing
-    p.add_mesh(mesh)
+    p.add_mesh(uniform)
     p.add_spline_widget(callback=func, pass_widget=True, color=None, show_ribbon=True)
     p.close()
 
     p = pyvista.Plotter()
-    p.add_mesh_slice_spline(mesh)
+    p.add_mesh_slice_spline(uniform)
     p.close()
 
 
-def test_widget_sphere():
+def test_widget_uniform(uniform):
     p = pyvista.Plotter()
     func = lambda center: center  # Does nothing
     p.add_sphere_widget(callback=func, center=(0, 0, 0))
@@ -225,16 +222,16 @@ def test_widget_sphere():
     p.close()
 
 
-def test_widget_checkbox_button():
+def test_widget_checkbox_button(uniform):
     p = pyvista.Plotter()
     func = lambda value: value  # Does nothing
-    p.add_mesh(mesh)
+    p.add_mesh(uniform)
     p.add_checkbox_button_widget(callback=func)
     p.close()
 
 
 @pytest.mark.skipif(pyvista.vtk_version_info < (9, 1), reason="Requires vtk>=9.1")
-def test_add_camera_orientation_widget():
+def test_add_camera_orientation_widget(uniform):
     p = pyvista.Plotter()
     p.add_camera_orientation_widget()
     assert p._camera_widgets


### PR DESCRIPTION
While working on #2547, it was discovered that widgets aren't being garbage collected correctly, leading to a segfault when rendering an example.

This PR moves `test_widgets.py` to take advantage of `check_gc` garbage collection fixture and verifys garbage collection of our widgets.

You can reproduce this issue (on Linux) on `main` with `vtk==9.1.0` with:
```py
import pyvista as pv
mesh = pv.ParametricConicSpiral()
pl = pv.Plotter()
_ = pl.add_mesh_clip_box(mesh, color='white')
pl.show()
```