### PR TITLE
Add ".xyz" extension to PointSet.save

### DIFF
--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -307,6 +307,7 @@ if VTK9:
         vtkPolyDataWriter,
         vtkRectilinearGridReader,
         vtkRectilinearGridWriter,
+        vtkSimplePointsWriter,
         vtkStructuredGridReader,
         vtkStructuredGridWriter,
         vtkUnstructuredGridReader,

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -43,6 +43,8 @@ class _PointSet(DataSet):
     This holds methods common to PolyData and UnstructuredGrid.
     """
 
+    _WRITERS = {".xyz": _vtk.vtkSimplePointsWriter}
+
     def center_of_mass(self, scalars_weight=False):
         """Return the coordinates for the center of mass of the mesh.
 

--- a/tests/test_pointset.py
+++ b/tests/test_pointset.py
@@ -34,8 +34,11 @@ def test_pointset(pointset, tmpdir):
     pointset.points = np.ones((10, 3))
     assert np.allclose(pointset.points, 1)
 
+def test_save(extension, tmpdir, pointset):
     filename = str(tmpdir.mkdir("tmpdir").join(f'{"tmp.xyz"}'))
     pointset.save(filename)
+    points = np.loadtxt(filename)
+    assert np.all(points == pointset.points)
 
 
 @pytest.mark.parametrize('deep', [True, False])

--- a/tests/test_pointset.py
+++ b/tests/test_pointset.py
@@ -38,7 +38,7 @@ def test_save(tmpdir, pointset):
     filename = str(tmpdir.mkdir("tmpdir").join(f'{"tmp.xyz"}'))
     pointset.save(filename)
     points = np.loadtxt(filename)
-    assert np.all(points == pointset.points)
+    assert np.allclose(points, pointset.points)
 
 
 @pytest.mark.parametrize('deep', [True, False])

--- a/tests/test_pointset.py
+++ b/tests/test_pointset.py
@@ -34,7 +34,7 @@ def test_pointset(pointset, tmpdir):
     pointset.points = np.ones((10, 3))
     assert np.allclose(pointset.points, 1)
 
-    filename = str(tmpdir.mkdir("tmpdir").join(f'tmp.xyz'))
+    filename = str(tmpdir.mkdir("tmpdir").join(f'{"tmp.xyz"}'))
     pointset.save(filename)
 
 

--- a/tests/test_pointset.py
+++ b/tests/test_pointset.py
@@ -34,6 +34,9 @@ def test_pointset(pointset):
     pointset.points = np.ones((10, 3))
     assert np.allclose(pointset.points, 1)
 
+    filename = str(tmpdir.mkdir("tmpdir").join(f'tmp.xyz'))
+    pointset.save("")
+
 
 @pytest.mark.parametrize('deep', [True, False])
 def test_cast_to_polydata(pointset, deep):

--- a/tests/test_pointset.py
+++ b/tests/test_pointset.py
@@ -20,7 +20,7 @@ def test_pointset_basic():
     assert 'PointSet' in repr(pset)
 
 
-def test_pointset(pointset):
+def test_pointset(pointset, tmpdir):
     assert pointset.n_points == pointset.points.shape[0]
     assert pointset.n_cells == 0
 
@@ -35,7 +35,7 @@ def test_pointset(pointset):
     assert np.allclose(pointset.points, 1)
 
     filename = str(tmpdir.mkdir("tmpdir").join(f'tmp.xyz'))
-    pointset.save("filename")
+    pointset.save(filename)
 
 
 @pytest.mark.parametrize('deep', [True, False])

--- a/tests/test_pointset.py
+++ b/tests/test_pointset.py
@@ -34,6 +34,7 @@ def test_pointset(pointset, tmpdir):
     pointset.points = np.ones((10, 3))
     assert np.allclose(pointset.points, 1)
 
+
 def test_save(tmpdir, pointset):
     filename = str(tmpdir.mkdir("tmpdir").join(f'{"tmp.xyz"}'))
     pointset.save(filename)

--- a/tests/test_pointset.py
+++ b/tests/test_pointset.py
@@ -35,7 +35,7 @@ def test_pointset(pointset):
     assert np.allclose(pointset.points, 1)
 
     filename = str(tmpdir.mkdir("tmpdir").join(f'tmp.xyz'))
-    pointset.save("")
+    pointset.save("filename")
 
 
 @pytest.mark.parametrize('deep', [True, False])

--- a/tests/test_pointset.py
+++ b/tests/test_pointset.py
@@ -34,7 +34,7 @@ def test_pointset(pointset, tmpdir):
     pointset.points = np.ones((10, 3))
     assert np.allclose(pointset.points, 1)
 
-def test_save(extension, tmpdir, pointset):
+def test_save(tmpdir, pointset):
     filename = str(tmpdir.mkdir("tmpdir").join(f'{"tmp.xyz"}'))
     pointset.save(filename)
     points = np.loadtxt(filename)

--- a/tests/test_pointset.py
+++ b/tests/test_pointset.py
@@ -20,7 +20,7 @@ def test_pointset_basic():
     assert 'PointSet' in repr(pset)
 
 
-def test_pointset(pointset, tmpdir):
+def test_pointset(pointset):
     assert pointset.n_points == pointset.points.shape[0]
     assert pointset.n_cells == 0
 


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
`PointSet.save` cannot be written because `_WRITER` does not exist, and an error always occurs. Therefore, in this PR, I have clarified which extension to specify by defining `_WRITER`. IMO, the only Writer object that can be used with `PointSet` is `vtkSimplePointsWriter`, which creates [xyz file](https://www.cgl.ucsf.edu/chimera/docs/UsersGuide/xyz.html). (If there are other Writers that can be added, please point them out.)
<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->
resolves #2556

### Details

```python
import numpy as np
import pyvista

rng = np.random.default_rng()
points = rng.random((10, 3))
pset = pyvista.PointSet(points)
pset.save("pset.xyz")
```
