### PR TITLE
Add split sharp edges to theme

### DIFF
--- a/pyvista/conftest.py
+++ b/pyvista/conftest.py
@@ -17,4 +17,5 @@ def reset_gloal_theme():
     """Reset global_theme."""
     # this stops any doctest-module tests from overriding the global theme and
     # creating test side effects
+    yield
     pyvista.global_theme.restore_defaults()

--- a/pyvista/conftest.py
+++ b/pyvista/conftest.py
@@ -10,3 +10,11 @@ def autoclose_plotters():
     """Close all plotters."""
     yield
     pyvista.close_all()
+
+
+@pytest.fixture(autouse=True)
+def reset_gloal_theme():
+    """Reset global_theme."""
+    # this stops any doctest-module tests from overriding the global theme and
+    # creating test side effects
+    pyvista.global_theme.restore_defaults()

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2055,6 +2055,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             show_scalar_bar = self._theme.show_scalar_bar
         if lighting is None:
             lighting = self._theme.lighting
+        feature_angle = kwargs.pop('feature_angle', self._theme.sharp_edges_feature_angle)
 
         if smooth_shading is None:
             if pbr:
@@ -2087,7 +2088,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
             culling = 'backface'
 
         rgb = kwargs.pop('rgba', rgb)
-        feature_angle = kwargs.pop('feature_angle', 30)
 
         # account for legacy behavior
         if 'stitle' in kwargs:  # pragma: no cover

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1675,7 +1675,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         render_points_as_spheres=None,
         render_lines_as_tubes=False,
         smooth_shading=None,
-        split_sharp_edges=False,
+        split_sharp_edges=None,
         ambient=0.0,
         diffuse=1.0,
         specular=0.0,
@@ -1845,11 +1845,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
             See :ref:`shading_example`.
 
         split_sharp_edges : bool, optional
-            Split sharp edges exceeding 30 degrees when plotting with
-            smooth shading.  Control the angle with the optional
-            keyword argument ``feature_angle``.  By default this is
-            ``False``.  Note that enabling this will create a copy of
-            the input mesh within the plotter.  See
+            Split sharp edges exceeding 30 degrees when plotting with smooth
+            shading.  Control the angle with the optional keyword argument
+            ``feature_angle``.  By default this is ``False`` unless overridden
+            by the global or plotter theme.  Note that enabling this will
+            create a copy of the input mesh within the plotter.  See
             :ref:`shading_example`.
 
         ambient : float, optional
@@ -2046,12 +2046,13 @@ class BasePlotter(PickingHelper, WidgetHelper):
         else:
             scalar_bar_args = scalar_bar_args.copy()
 
+        # theme based parameters
         if show_edges is None:
             show_edges = self._theme.show_edges
-
+        if split_sharp_edges is None:
+            split_sharp_edges = self._theme.split_sharp_edges
         if show_scalar_bar is None:
             show_scalar_bar = self._theme.show_scalar_bar
-
         if lighting is None:
             lighting = self._theme.lighting
 

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1145,6 +1145,7 @@ class DefaultTheme(_ThemeConfig):
         '_hidden_line_removal',
         '_antialiasing',
         '_enable_camera_orientation_widget',
+        '_split_sharp_edges',
     ]
 
     def __init__(self):
@@ -1188,6 +1189,7 @@ class DefaultTheme(_ThemeConfig):
         self._transparent_background = False
         self._title = 'PyVista'
         self._axes = _AxesConfig()
+        self._split_sharp_edges = False
 
         # Grab system flag for anti-aliasing
         try:
@@ -2090,6 +2092,7 @@ class DefaultTheme(_ThemeConfig):
             'Return Camera Position': 'return_cpos',
             'Hidden Line Removal': 'hidden_line_removal',
             'Anti-Aliasing': '_antialiasing',
+            'Split sharp edges': '_split_sharp_edges',
         }
         for name, attr in parm.items():
             setting = getattr(self, attr)
@@ -2197,6 +2200,28 @@ class DefaultTheme(_ThemeConfig):
             self.jupyter_backend = 'ipyvtklink'
         else:
             self.jupyter_backend = 'static'
+
+    @property
+    def split_sharp_edges(self) -> bool:
+        """Set or return splitting sharp edges.
+
+        See :ref:`shading_example` for an example showing split sharp edges.
+
+        Examples
+        --------
+        Enable the splitting of sharp edges globally.
+
+        >>> import pyvista
+        >>> pyvista.global_theme.split_sharp_edges = True
+        >>> pyvista.global_theme.split_sharp_edges
+        True
+
+        """
+        return self._split_sharp_edges
+
+    @split_sharp_edges.setter
+    def split_sharp_edges(self, value: bool):
+        self._split_sharp_edges = value
 
 
 class DarkTheme(DefaultTheme):

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -5,16 +5,16 @@ Examples
 Apply a built-in theme
 
 >>> import pyvista
->>> pyvista.set_plot_theme('default')  # doctest:+SKIP
->>> pyvista.set_plot_theme('document')  # doctest:+SKIP
->>> pyvista.set_plot_theme('dark')  # doctest:+SKIP
->>> pyvista.set_plot_theme('paraview')  # doctest:+SKIP
+>>> pyvista.set_plot_theme('default')
+>>> pyvista.set_plot_theme('document')
+>>> pyvista.set_plot_theme('dark')
+>>> pyvista.set_plot_theme('paraview')
 
 Load a theme into pyvista
 
 >>> theme = pyvista.themes.DefaultTheme()
->>> theme.save('my_theme.json')  # doctest:+SKIP
->>> loaded_theme = pyvista.load_theme('my_theme.json')  # doctest:+SKIP
+>>> theme.save('my_theme.json')
+>>> loaded_theme = pyvista.load_theme('my_theme.json')
 
 Create a custom theme from the default theme and load it into
 pyvista.
@@ -24,8 +24,8 @@ pyvista.
 >>> my_theme.font.title_size = 40
 >>> my_theme.cmap = 'jet'
 ...
->>> pyvista.global_theme.load_theme(my_theme)  # doctest:+SKIP
->>> pyvista.global_theme.font.size  # doctest:+SKIP
+>>> pyvista.global_theme.load_theme(my_theme)
+>>> pyvista.global_theme.font.size
 20
 
 """
@@ -84,8 +84,8 @@ def load_theme(filename):
     --------
     >>> import pyvista
     >>> theme = pyvista.themes.DefaultTheme()
-    >>> theme.save('my_theme.json')  # doctest:+SKIP
-    >>> loaded_theme = pyvista.load_theme('my_theme.json')  # doctest:+SKIP
+    >>> theme.save('my_theme.json')
+    >>> loaded_theme = pyvista.load_theme('my_theme.json')
 
     """
     with open(filename) as f:
@@ -107,19 +107,19 @@ def set_plot_theme(theme):
     Set to the default theme.
 
     >>> import pyvista
-    >>> pyvista.set_plot_theme('default')  # doctest:+SKIP
+    >>> pyvista.set_plot_theme('default')
 
     Set to the document theme.
 
-    >>> pyvista.set_plot_theme('document')  # doctest:+SKIP
+    >>> pyvista.set_plot_theme('document')
 
     Set to the dark theme.
 
-    >>> pyvista.set_plot_theme('dark')  # doctest:+SKIP
+    >>> pyvista.set_plot_theme('dark')
 
     Set to the ParaView theme.
 
-    >>> pyvista.set_plot_theme('paraview')  # doctest:+SKIP
+    >>> pyvista.set_plot_theme('paraview')
 
     """
     import pyvista
@@ -216,9 +216,9 @@ class _DepthPeelingConfig(_ThemeConfig):
     Set global depth peeling parameters.
 
     >>> import pyvista
-    >>> pyvista.global_theme.depth_peeling.number_of_peels = 1  # doctest:+SKIP
-    >>> pyvista.global_theme.depth_peeling.occlusion_ratio = 0.0  # doctest:+SKIP
-    >>> pyvista.global_theme.depth_peeling.enabled = True  # doctest:+SKIP
+    >>> pyvista.global_theme.depth_peeling.number_of_peels = 1
+    >>> pyvista.global_theme.depth_peeling.occlusion_ratio = 0.0
+    >>> pyvista.global_theme.depth_peeling.enabled = True
 
     """
 
@@ -236,7 +236,7 @@ class _DepthPeelingConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.depth_peeling.number_of_peels = 1  # doctest:+SKIP
+        >>> pyvista.global_theme.depth_peeling.number_of_peels = 1
 
         """
         return self._number_of_peels
@@ -252,7 +252,7 @@ class _DepthPeelingConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.depth_peeling.occlusion_ratio = 0.0  # doctest:+SKIP
+        >>> pyvista.global_theme.depth_peeling.occlusion_ratio = 0.0
 
         """
         return self._occlusion_ratio
@@ -268,7 +268,7 @@ class _DepthPeelingConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.depth_peeling.enabled = True  # doctest:+SKIP
+        >>> pyvista.global_theme.depth_peeling.enabled = True
 
         """
         return self._enabled
@@ -298,9 +298,9 @@ class _SilhouetteConfig(_ThemeConfig):
     Set global silhouette parameters.
 
     >>> import pyvista
-    >>> pyvista.global_theme.silhouette.color = 'grey'  # doctest:+SKIP
-    >>> pyvista.global_theme.silhouette.line_width = 2  # doctest:+SKIP
-    >>> pyvista.global_theme.silhouette.feature_angle = 20  # doctest:+SKIP
+    >>> pyvista.global_theme.silhouette.color = 'grey'
+    >>> pyvista.global_theme.silhouette.line_width = 2
+    >>> pyvista.global_theme.silhouette.feature_angle = 20
 
     """
 
@@ -320,7 +320,7 @@ class _SilhouetteConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.silhouette.color = 'red'  # doctest:+SKIP
+        >>> pyvista.global_theme.silhouette.color = 'red'
 
         """
         return self._color
@@ -336,7 +336,7 @@ class _SilhouetteConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.silhouette.line_width = 2.0  # doctest:+SKIP
+        >>> pyvista.global_theme.silhouette.line_width = 2.0
 
         """
         return self._line_width
@@ -352,7 +352,7 @@ class _SilhouetteConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.silhouette.opacity = 1.0  # doctest:+SKIP
+        >>> pyvista.global_theme.silhouette.opacity = 1.0
 
         """
         return self._opacity
@@ -369,7 +369,7 @@ class _SilhouetteConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.silhouette.feature_angle = 20.0  # doctest:+SKIP
+        >>> pyvista.global_theme.silhouette.feature_angle = 20.0
 
         """
         return self._feature_angle
@@ -387,7 +387,7 @@ class _SilhouetteConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.silhouette.decimate = 0.9  # doctest:+SKIP
+        >>> pyvista.global_theme.silhouette.decimate = 0.9
 
         """
         return self._decimate
@@ -420,7 +420,7 @@ class _ColorbarConfig(_ThemeConfig):
     Set the colorbar width.
 
     >>> import pyvista
-    >>> pyvista.global_theme.colorbar_horizontal.width = 0.2  # doctest:+SKIP
+    >>> pyvista.global_theme.colorbar_horizontal.width = 0.2
 
     """
 
@@ -439,7 +439,7 @@ class _ColorbarConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.colorbar_horizontal.width = 0.2  # doctest:+SKIP
+        >>> pyvista.global_theme.colorbar_horizontal.width = 0.2
 
         """
         return self._width
@@ -455,7 +455,7 @@ class _ColorbarConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.colorbar_horizontal.height = 0.2  # doctest:+SKIP
+        >>> pyvista.global_theme.colorbar_horizontal.height = 0.2
 
         """
         return self._height
@@ -471,7 +471,7 @@ class _ColorbarConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.colorbar_horizontal.position_x = 0.2  # doctest:+SKIP
+        >>> pyvista.global_theme.colorbar_horizontal.position_x = 0.2
 
         """
         return self._position_x
@@ -487,7 +487,7 @@ class _ColorbarConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.colorbar_horizontal.position_y = 0.2  # doctest:+SKIP
+        >>> pyvista.global_theme.colorbar_horizontal.position_y = 0.2
 
         """
         return self._position_y
@@ -519,15 +519,15 @@ class _AxesConfig(_ThemeConfig):
     Set the x axis color to black.
 
     >>> import pyvista
-    >>> pyvista.global_theme.axes.x_color = 'black'  # doctest:+SKIP
+    >>> pyvista.global_theme.axes.x_color = 'black'
 
     Show axes by default.
 
-    >>> pyvista.global_theme.axes.show = True  # doctest:+SKIP
+    >>> pyvista.global_theme.axes.show = True
 
     Use the ``vtk.vtkCubeAxesActor``.
 
-    >>> pyvista.global_theme.axes.box = True  # doctest:+SKIP
+    >>> pyvista.global_theme.axes.box = True
 
     """
 
@@ -562,7 +562,7 @@ class _AxesConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.axes.x_color = 'red'  # doctest:+SKIP
+        >>> pyvista.global_theme.axes.x_color = 'red'
         """
         return self._x_color
 
@@ -577,7 +577,7 @@ class _AxesConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.axes.y_color = 'red'  # doctest:+SKIP
+        >>> pyvista.global_theme.axes.y_color = 'red'
         """
         return self._y_color
 
@@ -592,7 +592,7 @@ class _AxesConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.axes.z_color = 'red'  # doctest:+SKIP
+        >>> pyvista.global_theme.axes.z_color = 'red'
         """
         return self._z_color
 
@@ -607,7 +607,7 @@ class _AxesConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.axes.box = True  # doctest:+SKIP
+        >>> pyvista.global_theme.axes.box = True
 
         """
         return self._box
@@ -625,7 +625,7 @@ class _AxesConfig(_ThemeConfig):
         Hide the axes by default.
 
         >>> import pyvista
-        >>> pyvista.global_theme.axes.show = False  # doctest:+SKIP
+        >>> pyvista.global_theme.axes.show = False
 
         """
         return self._show
@@ -644,27 +644,27 @@ class _Font(_ThemeConfig):
     'arial', 'courier', or 'times'.
 
     >>> import pyvista
-    >>> pyvista.global_theme.font.family = 'arial'  # doctest:+SKIP
+    >>> pyvista.global_theme.font.family = 'arial'
 
     Set the default font size to 20.
 
-    >>> pyvista.global_theme.font.size = 20  # doctest:+SKIP
+    >>> pyvista.global_theme.font.size = 20
 
     Set the default title size to 40
 
-    >>> pyvista.global_theme.font.title_size = 40  # doctest:+SKIP
+    >>> pyvista.global_theme.font.title_size = 40
 
     Set the default label size to 10
 
-    >>> pyvista.global_theme.font.label_size = 10  # doctest:+SKIP
+    >>> pyvista.global_theme.font.label_size = 10
 
     Set the default text color to 'grey'
 
-    >>> pyvista.global_theme.font.color = 'grey'  # doctest:+SKIP
+    >>> pyvista.global_theme.font.color = 'grey'
 
     Set the string formatter used to format numerical data to '%.6e'
 
-    >>> pyvista.global_theme.font.fmt = '%.6e'  # doctest:+SKIP
+    >>> pyvista.global_theme.font.fmt = '%.6e'
 
     """
 
@@ -709,7 +709,7 @@ class _Font(_ThemeConfig):
         Set the default global font family to 'courier'.
 
         >>> import pyvista
-        >>> pyvista.global_theme.font.family = 'courier'  # doctest:+SKIP
+        >>> pyvista.global_theme.font.family = 'courier'
 
         """
         return self._family
@@ -726,7 +726,7 @@ class _Font(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.font.size = 20  # doctest:+SKIP
+        >>> pyvista.global_theme.font.size = 20
 
         """
         return self._size
@@ -744,7 +744,7 @@ class _Font(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.font.title_size = 20  # doctest:+SKIP
+        >>> pyvista.global_theme.font.title_size = 20
         """
         return self._title_size
 
@@ -764,7 +764,7 @@ class _Font(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.font.label_size = 20  # doctest:+SKIP
+        >>> pyvista.global_theme.font.label_size = 20
         """
         return self._label_size
 
@@ -782,7 +782,7 @@ class _Font(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.font.color = 'black'  # doctest:+SKIP
+        >>> pyvista.global_theme.font.color = 'black'
         """
         return self._color
 
@@ -799,7 +799,7 @@ class _Font(_ThemeConfig):
         Set the string formatter used to format numerical data to '%.6e'.
 
         >>> import pyvista
-        >>> pyvista.global_theme.font.fmt = '%.6e'  # doctest:+SKIP
+        >>> pyvista.global_theme.font.fmt = '%.6e'
 
         """
         return self._fmt
@@ -852,7 +852,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_styles.modern.cap_width = 0.02  # doctest:+SKIP
+        >>> pyvista.global_theme.slider_styles.modern.cap_width = 0.02
 
         """
         return self._cap_width
@@ -868,7 +868,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_styles.modern.cap_length = 0.01  # doctest:+SKIP
+        >>> pyvista.global_theme.slider_styles.modern.cap_length = 0.01
 
         """
         return self._cap_length
@@ -884,7 +884,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_styles.modern.cap_opacity = 1.0  # doctest:+SKIP
+        >>> pyvista.global_theme.slider_styles.modern.cap_opacity = 1.0
 
         """
         return self._cap_opacity
@@ -900,7 +900,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_styles.modern.tube_color = 'black'  # doctest:+SKIP
+        >>> pyvista.global_theme.slider_styles.modern.tube_color = 'black'
         """
         return self._tube_color
 
@@ -915,7 +915,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_styles.modern.tube_width = 0.005  # doctest:+SKIP
+        >>> pyvista.global_theme.slider_styles.modern.tube_width = 0.005
 
         """
         return self._tube_width
@@ -931,7 +931,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_styles.modern.slider_color = 'grey'  # doctest:+SKIP
+        >>> pyvista.global_theme.slider_styles.modern.slider_color = 'grey'
 
         """
         return self._slider_color
@@ -947,7 +947,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_styles.modern.slider_width = 0.04  # doctest:+SKIP
+        >>> pyvista.global_theme.slider_styles.modern.slider_width = 0.04
 
         """
         return self._slider_width
@@ -963,7 +963,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_styles.modern.slider_length = 0.02  # doctest:+SKIP
+        >>> pyvista.global_theme.slider_styles.modern.slider_length = 0.02
 
         """
         return self._slider_length
@@ -1092,18 +1092,18 @@ class DefaultTheme(_ThemeConfig):
     Change the global default background color to white.
 
     >>> import pyvista
-    >>> pyvista.global_theme.color = 'white'  # doctest:+SKIP
+    >>> pyvista.global_theme.color = 'white'
 
     Show edges by default.
 
-    >>> pyvista.global_theme.show_edges = True  # doctest:+SKIP
+    >>> pyvista.global_theme.show_edges = True
 
     Create a new theme from the default theme and apply it globally.
 
     >>> my_theme = pyvista.themes.DefaultTheme()
     >>> my_theme.color = 'red'
     >>> my_theme.background = 'white'
-    >>> pyvista.global_theme.load_theme(my_theme)  # doctest:+SKIP
+    >>> pyvista.global_theme.load_theme(my_theme)
 
     """
 
@@ -1231,8 +1231,8 @@ class DefaultTheme(_ThemeConfig):
         Enable hidden line removal.
 
         >>> import pyvista
-        >>> pyvista.global_theme.hidden_line_removal = True  # doctest:+SKIP
-        >>> pyvista.global_theme.hidden_line_removal  # doctest:+SKIP
+        >>> pyvista.global_theme.hidden_line_removal = True
+        >>> pyvista.global_theme.hidden_line_removal
         True
 
         """
@@ -1251,7 +1251,7 @@ class DefaultTheme(_ThemeConfig):
         Disable returning camera position by ``show`` and ``plot`` methods.
 
         >>> import pyvista
-        >>> pyvista.global_theme.return_cpos = False  # doctest:+SKIP
+        >>> pyvista.global_theme.return_cpos = False
         """
 
     @return_cpos.setter
@@ -1267,7 +1267,7 @@ class DefaultTheme(_ThemeConfig):
         Set the default global background of all plots to white.
 
         >>> import pyvista
-        >>> pyvista.global_theme.background = 'white'  # doctest:+SKIP
+        >>> pyvista.global_theme.background = 'white'
         """
         return self._background
 
@@ -1321,24 +1321,24 @@ class DefaultTheme(_ThemeConfig):
         Enable the pythreejs backend.
 
         >>> import pyvista as pv
-        >>> pv.set_jupyter_backend('pythreejs')  # doctest:+SKIP
+        >>> pv.set_jupyter_backend('pythreejs')
 
         Enable the ipygany backend.
 
         >>> import pyvista as pv
-        >>> pv.set_jupyter_backend('ipygany')  # doctest:+SKIP
+        >>> pv.set_jupyter_backend('ipygany')
 
         Enable the panel backend.
 
-        >>> pv.set_jupyter_backend('panel')  # doctest:+SKIP
+        >>> pv.set_jupyter_backend('panel')
 
         Enable the ipyvtklink backend.
 
-        >>> pv.set_jupyter_backend('ipyvtklink')  # doctest:+SKIP
+        >>> pv.set_jupyter_backend('ipyvtklink')
 
         Just show static images.
 
-        >>> pv.set_jupyter_backend('static')  # doctest:+SKIP
+        >>> pv.set_jupyter_backend('static')
 
         Disable all plotting within JupyterLab and display using a
         standard desktop VTK render window.
@@ -1364,7 +1364,7 @@ class DefaultTheme(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.auto_close = False  # doctest:+SKIP
+        >>> pyvista.global_theme.auto_close = False
 
         """
         return self._auto_close
@@ -1382,7 +1382,7 @@ class DefaultTheme(_ThemeConfig):
         Set windows to be full screen by default.
 
         >>> import pyvista
-        >>> pyvista.global_theme.full_screen = True  # doctest:+SKIP
+        >>> pyvista.global_theme.full_screen = True
         """
         return self._full_screen
 
@@ -1397,8 +1397,8 @@ class DefaultTheme(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.enable_camera_orientation_widget = True  # doctest:+SKIP
-        >>> pyvista.global_theme.enable_camera_orientation_widget  # doctest:+SKIP
+        >>> pyvista.global_theme.enable_camera_orientation_widget = True
+        >>> pyvista.global_theme.enable_camera_orientation_widget
         True
 
         """
@@ -1417,16 +1417,16 @@ class DefaultTheme(_ThemeConfig):
         Set both the position and view of the camera.
 
         >>> import pyvista
-        >>> pyvista.global_theme.camera = {'position': [1, 1, 1],  # doctest:+SKIP
-        ...                                'viewup': [0, 0, 1]}  # doctest:+SKIP
+        >>> pyvista.global_theme.camera = {'position': [1, 1, 1],
+        ...                                'viewup': [0, 0, 1]}
 
         Set the default position of the camera.
 
-        >>> pyvista.global_theme.camera['position'] = [1, 1, 1]  # doctest:+SKIP
+        >>> pyvista.global_theme.camera['position'] = [1, 1, 1]
 
         Set the default view of the camera.
 
-        >>> pyvista.global_theme.camera['viewup'] = [0, 0, 1]  # doctest:+SKIP
+        >>> pyvista.global_theme.camera['viewup'] = [0, 0, 1]
 
         """
         return self._camera
@@ -1456,7 +1456,7 @@ class DefaultTheme(_ThemeConfig):
         Disable all jupyter notebook plotting.
 
         >>> import pyvista
-        >>> pyvista.global_theme.notebook = False  # doctest:+SKIP
+        >>> pyvista.global_theme.notebook = False
 
         """
         return self._notebook
@@ -1474,7 +1474,7 @@ class DefaultTheme(_ThemeConfig):
         Set window size to ``[400, 400]``.
 
         >>> import pyvista
-        >>> pyvista.global_theme.window_size = [400, 400]  # doctest:+SKIP
+        >>> pyvista.global_theme.window_size = [400, 400]
 
         """
         return self._window_size
@@ -1500,27 +1500,27 @@ class DefaultTheme(_ThemeConfig):
         'arial', 'courier', or 'times'.
 
         >>> import pyvista
-        >>> pyvista.global_theme.font.family = 'arial'  # doctest:+SKIP
+        >>> pyvista.global_theme.font.family = 'arial'
 
         Set the default font size to 20.
 
-        >>> pyvista.global_theme.font.size = 20  # doctest:+SKIP
+        >>> pyvista.global_theme.font.size = 20
 
         Set the default title size to 40.
 
-        >>> pyvista.global_theme.font.title_size = 40  # doctest:+SKIP
+        >>> pyvista.global_theme.font.title_size = 40
 
         Set the default label size to 10.
 
-        >>> pyvista.global_theme.font.label_size = 10  # doctest:+SKIP
+        >>> pyvista.global_theme.font.label_size = 10
 
         Set the default text color to 'grey'.
 
-        >>> pyvista.global_theme.font.color = 'grey'  # doctest:+SKIP
+        >>> pyvista.global_theme.font.color = 'grey'
 
         String formatter used to format numerical data to '%.6e'.
 
-        >>> pyvista.global_theme.font.fmt = '%.6e'  # doctest:+SKIP
+        >>> pyvista.global_theme.font.fmt = '%.6e'
 
         """
         return self._font
@@ -1549,7 +1549,7 @@ class DefaultTheme(_ThemeConfig):
         Set the default global colormap to 'jet'.
 
         >>> import pyvista
-        >>> pyvista.global_theme.cmap = 'jet'  # doctest:+SKIP
+        >>> pyvista.global_theme.cmap = 'jet'
 
         """
         return self._cmap
@@ -1578,7 +1578,7 @@ class DefaultTheme(_ThemeConfig):
         Set the default mesh color to 'red'.
 
         >>> import pyvista
-        >>> pyvista.global_theme.color = 'red'  # doctest:+SKIP
+        >>> pyvista.global_theme.color = 'red'
 
         """
         return self._color
@@ -1596,7 +1596,7 @@ class DefaultTheme(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.nan_color = 'darkgray'  # doctest:+SKIP
+        >>> pyvista.global_theme.nan_color = 'darkgray'
 
         """
         return self._nan_color
@@ -1614,7 +1614,7 @@ class DefaultTheme(_ThemeConfig):
         Set the global edge color to 'blue'.
 
         >>> import pyvista
-        >>> pyvista.global_theme.edge_color = 'blue'  # doctest:+SKIP
+        >>> pyvista.global_theme.edge_color = 'blue'
 
         """
         return self._edge_color
@@ -1630,7 +1630,7 @@ class DefaultTheme(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.outline_color = 'white'  # doctest:+SKIP
+        >>> pyvista.global_theme.outline_color = 'white'
 
         """
         return self._outline_color
@@ -1646,7 +1646,7 @@ class DefaultTheme(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.floor_color = 'black'  # doctest:+SKIP
+        >>> pyvista.global_theme.floor_color = 'black'
 
         """
         return self._floor_color
@@ -1664,7 +1664,7 @@ class DefaultTheme(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.colorbar_orientation = 'horizontal'  # doctest:+SKIP
+        >>> pyvista.global_theme.colorbar_orientation = 'horizontal'
 
         """
         return self._colorbar_orientation
@@ -1684,11 +1684,11 @@ class DefaultTheme(_ThemeConfig):
         Set the default horizontal colorbar width to 0.6.
 
         >>> import pyvista
-        >>> pyvista.global_theme.colorbar_horizontal.width = 0.6  # doctest:+SKIP
+        >>> pyvista.global_theme.colorbar_horizontal.width = 0.6
 
         Set the default horizontal colorbar height to 0.2.
 
-        >>> pyvista.global_theme.colorbar_horizontal.height = 0.2  # doctest:+SKIP
+        >>> pyvista.global_theme.colorbar_horizontal.height = 0.2
 
         """
         return self._colorbar_horizontal
@@ -1708,12 +1708,12 @@ class DefaultTheme(_ThemeConfig):
         Set the default colorbar width to 0.45.
 
         >>> import pyvista
-        >>> pyvista.global_theme.colorbar_vertical.width = 0.45  # doctest:+SKIP
+        >>> pyvista.global_theme.colorbar_vertical.width = 0.45
 
         Set the default colorbar height to 0.8.
 
         >>> import pyvista
-        >>> pyvista.global_theme.colorbar_vertical.height = 0.8  # doctest:+SKIP
+        >>> pyvista.global_theme.colorbar_vertical.height = 0.8
 
         """
         return self._colorbar_vertical
@@ -1733,7 +1733,7 @@ class DefaultTheme(_ThemeConfig):
         Show the scalar bar by default when scalars are available.
 
         >>> import pyvista
-        >>> pyvista.global_theme.show_scalar_bar = True  # doctest:+SKIP
+        >>> pyvista.global_theme.show_scalar_bar = True
 
         """
         return self._show_scalar_bar
@@ -1751,7 +1751,7 @@ class DefaultTheme(_ThemeConfig):
         Show edges globally by default.
 
         >>> import pyvista
-        >>> pyvista.global_theme.show_edges = True  # doctest:+SKIP
+        >>> pyvista.global_theme.show_edges = True
 
         """
         return self._show_edges
@@ -1769,7 +1769,7 @@ class DefaultTheme(_ThemeConfig):
         Disable lighting globally.
 
         >>> import pyvista
-        >>> pyvista.global_theme.lighting = False  # doctest:+SKIP
+        >>> pyvista.global_theme.lighting = False
         """
         return self._lighting
 
@@ -1786,7 +1786,7 @@ class DefaultTheme(_ThemeConfig):
         Make all plots non-interactive globally.
 
         >>> import pyvista
-        >>> pyvista.global_theme.interactive = False  # doctest:+SKIP
+        >>> pyvista.global_theme.interactive = False
         """
         return self._interactive
 
@@ -1803,7 +1803,7 @@ class DefaultTheme(_ThemeConfig):
         Render points as spheres by default globally.
 
         >>> import pyvista
-        >>> pyvista.global_theme.render_points_as_spheres = True  # doctest:+SKIP
+        >>> pyvista.global_theme.render_points_as_spheres = True
         """
         return self._render_points_as_spheres
 
@@ -1820,7 +1820,7 @@ class DefaultTheme(_ThemeConfig):
         Set transparent_background globally to ``True``.
 
         >>> import pyvista
-        >>> pyvista.global_theme.transparent_background = True  # doctest:+SKIP
+        >>> pyvista.global_theme.transparent_background = True
 
         """
         return self._transparent_background
@@ -1840,7 +1840,7 @@ class DefaultTheme(_ThemeConfig):
         Set title globally to 'plot'.
 
         >>> import pyvista
-        >>> pyvista.global_theme.title = 'plot'  # doctest:+SKIP
+        >>> pyvista.global_theme.title = 'plot'
 
         """
         return self._title
@@ -1858,8 +1858,8 @@ class DefaultTheme(_ThemeConfig):
         Enable anti-aliasing in the global theme.
 
         >>> import pyvista
-        >>> pyvista.global_theme.antialiasing = True  # doctest:+SKIP
-        >>> pyvista.global_theme.antialiasing  # doctest:+SKIP
+        >>> pyvista.global_theme.antialiasing = True
+        >>> pyvista.global_theme.antialiasing
         True
 
         """
@@ -1880,7 +1880,7 @@ class DefaultTheme(_ThemeConfig):
         Set the default number of multisamples to 2.
 
         >>> import pyvista
-        >>> pyvista.global_theme.multi_samples = 2  # doctest:+SKIP
+        >>> pyvista.global_theme.multi_samples = 2
 
         """
         return self._multi_samples
@@ -1899,7 +1899,7 @@ class DefaultTheme(_ThemeConfig):
         middle of the window).
 
         >>> import pyvista
-        >>> pyvista.global_theme.multi_rendering_splitting_position = 0.5  # doctest:+SKIP
+        >>> pyvista.global_theme.multi_rendering_splitting_position = 0.5
 
         """
         return self._multi_rendering_splitting_position
@@ -1925,7 +1925,7 @@ class DefaultTheme(_ThemeConfig):
         Set default volume mapper globally to 'gpu'.
 
         >>> import pyvista
-        >>> pyvista.global_theme.volume_mapper = 'gpu'  # doctest:+SKIP
+        >>> pyvista.global_theme.volume_mapper = 'gpu'
 
         """
         return self._volume_mapper
@@ -1950,7 +1950,7 @@ class DefaultTheme(_ThemeConfig):
         Set the global smooth_shading parameter default to ``True``.
 
         >>> import pyvista
-        >>> pyvista.global_theme.smooth_shading = True  # doctest:+SKIP
+        >>> pyvista.global_theme.smooth_shading = True
 
         """
         return self._smooth_shading
@@ -1969,9 +1969,9 @@ class DefaultTheme(_ThemeConfig):
         with 8 peels.
 
         >>> import pyvista
-        >>> pyvista.global_theme.depth_peeling.number_of_peels = 8  # doctest:+SKIP
-        >>> pyvista.global_theme.depth_peeling.occlusion_ratio = 0.0  # doctest:+SKIP
-        >>> pyvista.global_theme.depth_peeling.enabled = True  # doctest:+SKIP
+        >>> pyvista.global_theme.depth_peeling.number_of_peels = 8
+        >>> pyvista.global_theme.depth_peeling.occlusion_ratio = 0.0
+        >>> pyvista.global_theme.depth_peeling.enabled = True
 
         """
         return self._depth_peeling
@@ -1991,9 +1991,9 @@ class DefaultTheme(_ThemeConfig):
         Set parameters of the silhouette.
 
         >>> import pyvista
-        >>> pyvista.global_theme.silhouette.color = 'grey'  # doctest:+SKIP
-        >>> pyvista.global_theme.silhouette.line_width = 2.0  # doctest:+SKIP
-        >>> pyvista.global_theme.silhouette.feature_angle = 20  # doctest:+SKIP
+        >>> pyvista.global_theme.silhouette.color = 'grey'
+        >>> pyvista.global_theme.silhouette.line_width = 2.0
+        >>> pyvista.global_theme.silhouette.feature_angle = 20
 
         """
         return self._silhouette
@@ -2024,15 +2024,15 @@ class DefaultTheme(_ThemeConfig):
         Set the x axis color to black.
 
         >>> import pyvista
-        >>> pyvista.global_theme.axes.x_color = 'black'  # doctest:+SKIP
+        >>> pyvista.global_theme.axes.x_color = 'black'
 
         Show axes by default.
 
-        >>> pyvista.global_theme.axes.show = True  # doctest:+SKIP
+        >>> pyvista.global_theme.axes.show = True
 
         Use the ``vtk.vtkCubeAxesActor``.
 
-        >>> pyvista.global_theme.axes.box = True  # doctest:+SKIP
+        >>> pyvista.global_theme.axes.box = True
 
         """
         return self._axes
@@ -2049,7 +2049,7 @@ class DefaultTheme(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.restore_defaults()  # doctest:+SKIP
+        >>> pyvista.global_theme.restore_defaults()
 
         """
         self.__init__()
@@ -2132,8 +2132,8 @@ class DefaultTheme(_ThemeConfig):
         >>> my_theme.font.title_size = 40
         >>> my_theme.cmap = 'jet'
         ...
-        >>> pyvista.global_theme.load_theme(my_theme)  # doctest:+SKIP
-        >>> pyvista.global_theme.font.size  # doctest:+SKIP
+        >>> pyvista.global_theme.load_theme(my_theme)
+        >>> pyvista.global_theme.font.size
         20
 
         Create a custom theme from the dark theme and load it into
@@ -2142,8 +2142,8 @@ class DefaultTheme(_ThemeConfig):
         >>> from pyvista.themes import DarkTheme
         >>> my_theme = DarkTheme()
         >>> my_theme.show_edges = True
-        >>> pyvista.global_theme.load_theme(my_theme)  # doctest:+SKIP
-        >>> pyvista.global_theme.show_edges  # doctest:+SKIP
+        >>> pyvista.global_theme.load_theme(my_theme)
+        >>> pyvista.global_theme.show_edges
         True
 
         """
@@ -2173,8 +2173,8 @@ class DefaultTheme(_ThemeConfig):
         >>> import pyvista
         >>> theme = pyvista.themes.DefaultTheme()
         >>> theme.background = 'white'
-        >>> theme.save('my_theme.json')  # doctest:+SKIP
-        >>> loaded_theme = pyvista.load_theme('my_theme.json')  # doctest:+SKIP
+        >>> theme.save('my_theme.json')
+        >>> loaded_theme = pyvista.load_theme('my_theme.json')
 
         """
         with open(filename, 'w') as f:
@@ -2215,8 +2215,8 @@ class DefaultTheme(_ThemeConfig):
         Enable the splitting of sharp edges globally.
 
         >>> import pyvista
-        >>> pyvista.global_theme.split_sharp_edges = True  # doctest:+SKIP
-        >>> pyvista.global_theme.split_sharp_edges  # doctest:+SKIP
+        >>> pyvista.global_theme.split_sharp_edges = True
+        >>> pyvista.global_theme.split_sharp_edges
         True
 
         """
@@ -2237,8 +2237,8 @@ class DefaultTheme(_ThemeConfig):
         Change the sharp edges feature angle to 45 degrees.
 
         >>> import pyvista
-        >>> pyvista.global_theme.sharp_edges_feature_angle = 45.0  # doctest:+SKIP
-        >>> pyvista.global_theme.sharp_edges_feature_angle  # doctest:+SKIP
+        >>> pyvista.global_theme.sharp_edges_feature_angle = 45.0
+        >>> pyvista.global_theme.sharp_edges_feature_angle
         45.0
 
         """
@@ -2260,11 +2260,11 @@ class DarkTheme(DefaultTheme):
 
     >>> import pyvista
     >>> from pyvista import themes
-    >>> pyvista.set_plot_theme(themes.DarkTheme())  # doctest:+SKIP
+    >>> pyvista.set_plot_theme(themes.DarkTheme())
 
     Alternatively, set via a string.
 
-    >>> pyvista.set_plot_theme('dark')  # doctest:+SKIP
+    >>> pyvista.set_plot_theme('dark')
 
     """
 
@@ -2293,11 +2293,11 @@ class ParaViewTheme(DefaultTheme):
 
     >>> import pyvista
     >>> from pyvista import themes
-    >>> pyvista.set_plot_theme(themes.ParaViewTheme())  # doctest:+SKIP
+    >>> pyvista.set_plot_theme(themes.ParaViewTheme())
 
     Alternatively, set via a string.
 
-    >>> pyvista.set_plot_theme('paraview')  # doctest:+SKIP
+    >>> pyvista.set_plot_theme('paraview')
 
     """
 
@@ -2338,11 +2338,11 @@ class DocumentTheme(DefaultTheme):
 
     >>> import pyvista
     >>> from pyvista import themes
-    >>> pyvista.set_plot_theme(themes.DocumentTheme())  # doctest:+SKIP
+    >>> pyvista.set_plot_theme(themes.DocumentTheme())
 
     Alternatively, set via a string.
 
-    >>> pyvista.set_plot_theme('document')  # doctest:+SKIP
+    >>> pyvista.set_plot_theme('document')
 
     """
 

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -2095,7 +2095,7 @@ class DefaultTheme(_ThemeConfig):
             'Hidden Line Removal': 'hidden_line_removal',
             'Anti-Aliasing': '_antialiasing',
             'Split sharp edges': '_split_sharp_edges',
-            'Sharp edges feature angle': '_sharp_edges_feature_angle',
+            'Sharp edges feat. angle': '_sharp_edges_feature_angle',
         }
         for name, attr in parm.items():
             setting = getattr(self, attr)

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -2095,6 +2095,7 @@ class DefaultTheme(_ThemeConfig):
             'Hidden Line Removal': 'hidden_line_removal',
             'Anti-Aliasing': '_antialiasing',
             'Split sharp edges': '_split_sharp_edges',
+            'Sharp edges feature angle': '_sharp_edges_feature_angle',
         }
         for name, attr in parm.items():
             setting = getattr(self, attr)
@@ -2214,8 +2215,8 @@ class DefaultTheme(_ThemeConfig):
         Enable the splitting of sharp edges globally.
 
         >>> import pyvista
-        >>> pyvista.global_theme.split_sharp_edges = True
-        >>> pyvista.global_theme.split_sharp_edges
+        >>> pyvista.global_theme.split_sharp_edges = True  # doctest:+SKIP
+        >>> pyvista.global_theme.split_sharp_edges  # doctest:+SKIP
         True
 
         """
@@ -2236,8 +2237,8 @@ class DefaultTheme(_ThemeConfig):
         Change the sharp edges feature angle to 45 degrees.
 
         >>> import pyvista
-        >>> pyvista.global_theme.sharp_edges_feature_angle = 45.0
-        >>> pyvista.global_theme.sharp_edges_feature_angle
+        >>> pyvista.global_theme.sharp_edges_feature_angle = 45.0  # doctest:+SKIP
+        >>> pyvista.global_theme.sharp_edges_feature_angle  # doctest:+SKIP
         45.0
 
         """

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1146,6 +1146,7 @@ class DefaultTheme(_ThemeConfig):
         '_antialiasing',
         '_enable_camera_orientation_widget',
         '_split_sharp_edges',
+        '_sharp_edges_feature_angle',
     ]
 
     def __init__(self):
@@ -1190,6 +1191,7 @@ class DefaultTheme(_ThemeConfig):
         self._title = 'PyVista'
         self._axes = _AxesConfig()
         self._split_sharp_edges = False
+        self._sharp_edges_feature_angle = 30.0
 
         # Grab system flag for anti-aliasing
         try:
@@ -2222,6 +2224,28 @@ class DefaultTheme(_ThemeConfig):
     @split_sharp_edges.setter
     def split_sharp_edges(self, value: bool):
         self._split_sharp_edges = value
+
+    @property
+    def sharp_edges_feature_angle(self) -> float:
+        """Set or return the angle of the sharp edges feature angle.
+
+        See :ref:`shading_example` for an example showing split sharp edges.
+
+        Examples
+        --------
+        Change the sharp edges feature angle to 45 degrees.
+
+        >>> import pyvista
+        >>> pyvista.global_theme.sharp_edges_feature_angle = 45.0
+        >>> pyvista.global_theme.sharp_edges_feature_angle
+        45.0
+
+        """
+        return self._sharp_edges_feature_angle
+
+    @sharp_edges_feature_angle.setter
+    def sharp_edges_feature_angle(self, value: float):
+        self._sharp_edges_feature_angle = float(value)
 
 
 class DarkTheme(DefaultTheme):

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -387,8 +387,8 @@ def test_repr(default_theme):
     # of the key in the repr or the key length is increased
     for line in rep.splitlines():
         if ':' in line:
-            colon_loc = line.find(':')
-            assert line[colon_loc - 1] == ' ', "Key str too long or need to raise key length"
+            pref, *rest = line.split(':', 1)
+            assert pref.endswith(' '), f"Key str too long or need to raise key length:\n{pref!r}"
 
 
 def test_theme_slots(default_theme):

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -348,6 +348,7 @@ def test_set_hidden_line_removal(default_theme):
         ('multi_rendering_splitting_position', 0.1),
         ('smooth_shading', True),
         ('name', 'test_theme'),
+        ('split_sharp_edges', True),
     ],
 )
 def test_theme_parm(default_theme, parm):

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -382,6 +382,14 @@ def test_repr(default_theme):
     assert str(default_theme.colorbar_orientation) in rep
     assert default_theme._name.capitalize() in rep
 
+    # verify that the key for each line in the repr is less than the minimum
+    # key size. This makes sure that any new keys are either less than the size
+    # of the key in the repr or the key length is increased
+    for line in rep.splitlines():
+        if ':' in line:
+            colon_loc = line.find(':')
+            assert line[colon_loc - 1] == ' ', "Key str too long or need to raise key length"
+
 
 def test_theme_slots(default_theme):
     # verify we can't create an arbitrary attribute

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -349,6 +349,7 @@ def test_set_hidden_line_removal(default_theme):
         ('smooth_shading', True),
         ('name', 'test_theme'),
         ('split_sharp_edges', True),
+        ('sharp_edges_feature_angle', 45.0),
     ],
 )
 def test_theme_parm(default_theme, parm):


### PR DESCRIPTION
Add in the ability to set splitting of sharp edges in the global theme. This makes it easier to set default edge splitting for plots with sharp edges (like CAD-like geometry).

```py
>>> import pyvista
>>> pyvista.global_theme.sharp_edges_feature_angle = 45
>>> pyvista.global_theme.split_sharp_edges = True
>>> pyvista.global_theme.split_sharp_edges
True
```

### Bonus (there always is)
- Add a fixture to reset the global theme so it's not modified during docstring testing.
- Remove `doctest:+SKIP` within `theme.py` as it is no longer necessary due to proper theme resetting.