### PR TITLE
Fix imports of vtkExtractEdges and vtkCellTreeLocator

### DIFF
--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -24,6 +24,19 @@ except ImportError:  # pragma: no cover
 _has_vtkRenderingContextOpenGL2 = False
 
 if VTK9:
+    # vtkExtractEdges moved from vtkFiltersExtraction to vtkFiltersCore in
+    # VTK commit d9981b9aeb93b42d1371c6e295d76bfdc18430bd
+    try:
+        from vtkmodules.vtkFiltersCore import vtkExtractEdges
+    except ImportError:
+        from vtkmodules.vtkFiltersExtraction import vtkExtractEdges
+
+    # vtkCellTreeLocator moved from vtkFiltersGeneral to vtkCommonDataModel in
+    # VTK commit 4a29e6f7dd9acb460644fe487d2e80aac65f7be9
+    try:
+        from vtkmodules.vtkCommonDataModel import vtkCellTreeLocator
+    except ImportError:
+        from vtkmodules.vtkFiltersGeneral import vtkCellTreeLocator
 
     from vtkmodules.numpy_interface.dataset_adapter import (
         VTKArray,
@@ -198,7 +211,6 @@ if VTK9:
         vtkUnstructuredGridToExplicitStructuredGrid,
     )
     from vtkmodules.vtkFiltersExtraction import (
-        vtkExtractEdges,
         vtkExtractGeometry,
         vtkExtractGrid,
         vtkExtractSelection,
@@ -208,7 +220,6 @@ if VTK9:
         vtkAxes,
         vtkBooleanOperationPolyDataFilter,
         vtkBoxClipDataSet,
-        vtkCellTreeLocator,
         vtkClipClosedSurface,
         vtkCursor3D,
         vtkCurvatures,


### PR DESCRIPTION
These classes have been moved in VTK and imports failed. This checks for VTK versions/builds and imports them accordingly.

This PR resolve issue #2580 along with another class (vtkCellTreeLocator) that also has moved since the release of 9.1. Now "import pyvista" succeed with VTK build date 20220509.

This is an alternative (and better) implementation suggested by @adeak in the discussion of PR https://github.com/pyvista/pyvista/pull/2582