### PR TITLE
Add warning to threshold that it's a cell filter

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -884,6 +884,13 @@ class DataSetFilters:
         criterion.  If ``scalars`` is ``None``, the input's active
         scalars array is used.
 
+        .. warning::
+           Thresholding is inherently a cell operation, even though it can use
+           associated point data for determining whether to keep a cell. In
+           other words, whether or not a given point is included after
+           thresholding depends on whether that point is part of a cell that
+           is kept after thresholding.
+
         Parameters
         ----------
         value : float or sequence, optional
@@ -1075,6 +1082,13 @@ class DataSetFilters:
         progress_bar=False,
     ):
         """Threshold the dataset by a percentage of its range on the active scalars array.
+
+        .. warning::
+           Thresholding is inherently a cell operation, even though it can use
+           associated point data for determining whether to keep a cell. In
+           other words, whether or not a given point is included after
+           thresholding depends on whether that point is part of a cell that
+           is kept after thresholding.
 
         Parameters
         ----------


### PR DESCRIPTION
Closes https://github.com/pyvista/pyvista/issues/2595. As per that issue, it wasn't obvious to me that thresholding always operates on cells. I hope this added warning will help others (including myself 6 months from now) clear this confusion.