### PR TITLE
Add POpenFOAMReader

### DIFF
--- a/doc/api/readers/index.rst
+++ b/doc/api/readers/index.rst
@@ -42,6 +42,7 @@ Reader Classes
     NRRDReader
     OBJReader
     OpenFOAMReader
+    POpenFOAMReader
     PLYReader
     PNGReader
     PNMReader

--- a/examples/99-advanced/openfoam-example.py
+++ b/examples/99-advanced/openfoam-example.py
@@ -11,7 +11,7 @@ from pyvista import examples
 
 ###############################################################################
 # This example uses data from a lid-driven cavity flow.  It is recommended to
-# use :class:`pyvista.OpenFOAMReader` for reading OpenFOAM files for more
+# use :class:`pyvista.POpenFOAMReader` for reading OpenFOAM files for more
 # control over reading data.
 #
 # This example will only run correctly in versions of vtk>=9.1.0.  The names

--- a/examples/99-advanced/openfoam-example.py
+++ b/examples/99-advanced/openfoam-example.py
@@ -19,7 +19,7 @@ from pyvista import examples
 # in prior versions.
 
 filename = examples.download_cavity(load=False)
-reader = pyvista.OpenFOAMReader(filename)
+reader = pyvista.POpenFOAMReader(filename)
 
 ###############################################################################
 # OpenFOAM datasets include multiple sub-datasets including the internal mesh

--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -290,7 +290,6 @@ if VTK9:
         vtkMCubesReader,
         vtkMFIXReader,
         vtkOBJReader,
-        vtkOpenFOAMReader,
         vtkPTSReader,
         vtkSTLReader,
         vtkSTLWriter,

--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -505,8 +505,12 @@ if VTK9:
     def lazy_vtkPOpenFOAMReader():
         """Lazy import of the vtkPOpenFOAMReader."""
         from vtkmodules.vtkIOParallel import vtkPOpenFOAMReader
+        from vtkmodules.vtkParallelCore import vtkDummyController
 
-        return vtkPOpenFOAMReader()
+        # Workaround waiting for the fix to be uptream (MR 9195 gitlab.kitware.com/vtk/vtk)
+        reader = vtkPOpenFOAMReader()
+        reader.SetController(vtkDummyController())
+        return reader
 
 else:  # pragma: no cover
 

--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -507,7 +507,7 @@ if VTK9:
         from vtkmodules.vtkIOParallel import vtkPOpenFOAMReader
         from vtkmodules.vtkParallelCore import vtkDummyController
 
-        # Workaround waiting for the fix to be uptream (MR 9195 gitlab.kitware.com/vtk/vtk)
+        # Workaround waiting for the fix to be upstream (MR 9195 gitlab.kitware.com/vtk/vtk)
         reader = vtkPOpenFOAMReader()
         reader.SetController(vtkDummyController())
         return reader

--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -558,6 +558,14 @@ else:  # pragma: no cover
         """Lazy import of the vtkCGNSReader."""
         raise VTKVersionError('vtk.CGNSReader requires VTK v9.1.0 or newer')
 
+    def lazy_vtkPOpenFOAMReader():
+        """Lazy import of the vtkPOpenFOAMReader."""
+        # Workaround to fix the following issue: https://gitlab.kitware.com/vtk/vtk/-/issues/18143
+        # Fixed in vtk > 9.1.0
+        reader = vtk.vtkPOpenFOAMReader()
+        reader.SetController(vtk.vtkDummyController())
+        return reader
+
     def lazy_vtkHDFReader():
         """Lazy import of the vtkHDFReader."""
         raise VTKVersionError('vtk.HDFReader requires VTK v9.1.0 or newer')

--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -290,6 +290,7 @@ if VTK9:
         vtkMCubesReader,
         vtkMFIXReader,
         vtkOBJReader,
+        vtkOpenFOAMReader,
         vtkPTSReader,
         vtkSTLReader,
         vtkSTLWriter,

--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -502,6 +502,12 @@ if VTK9:
 
         return vtkCGNSReader()
 
+    def lazy_vtkPOpenFOAMReader():
+        """Lazy import of the vtkPOpenFOAMReader."""
+        from vtkmodules.vtkIOParallel import vtkPOpenFOAMReader
+
+        return vtkPOpenFOAMReader()
+
 else:  # pragma: no cover
 
     # maintain VTK 8.2 compatibility

--- a/pyvista/utilities/__init__.py
+++ b/pyvista/utilities/__init__.py
@@ -40,6 +40,7 @@ from .reader import (
     NRRDReader,
     OBJReader,
     OpenFOAMReader,
+    POpenFOAMReader,
     Plot3DMetaReader,
     PLYReader,
     PNGReader,

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -57,7 +57,7 @@ READERS = {
     # '.dat': _vtk.vtkFLUENTReader, # TODO: not working
     # '.cube': _vtk.vtkGaussianCubeReader, # Contains `atom_types` which are note supported?
     '.res': _vtk.vtkMFIXReader,  # TODO: not tested
-    '.foam': _vtk.lazy_vtkPOpenFOAMReader,
+    '.foam': _vtk.vtkOpenFOAMReader,
     # '.pdb': _vtk.vtkPDBReader, # Contains `atom_types` which are note supported?
     '.p3d': _vtk.lazy_vtkPlot3DMetaReader,
     '.pts': _vtk.vtkPTSReader,

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -57,7 +57,7 @@ READERS = {
     # '.dat': _vtk.vtkFLUENTReader, # TODO: not working
     # '.cube': _vtk.vtkGaussianCubeReader, # Contains `atom_types` which are note supported?
     '.res': _vtk.vtkMFIXReader,  # TODO: not tested
-    '.foam': _vtk.vtkOpenFOAMReader,
+    '.foam': _vtk.lazy_vtkPOpenFOAMReader,
     # '.pdb': _vtk.vtkPDBReader, # Contains `atom_types` which are note supported?
     '.p3d': _vtk.lazy_vtkPlot3DMetaReader,
     '.pts': _vtk.vtkPTSReader,

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -1008,6 +1008,7 @@ class POpenFOAMReader(OpenFOAMReader):
     """Parallel OpenFOAM Reader for .foam files.
 
     Can read parallel-decomposed mesh information and time dependent data.
+    This reader can be used both for parallel reconstructed data and decomposed data.
     """
 
     _class_reader = staticmethod(_vtk.lazy_vtkPOpenFOAMReader)
@@ -1032,7 +1033,7 @@ class POpenFOAMReader(OpenFOAMReader):
         >>> import pyvista
         >>> from pyvista import examples
         >>> filename = examples.download_cavity(load=False)
-        >>> reader = pyvista.OpenFOAMReader(filename)
+        >>> reader = pyvista.POpenFOAMReader(filename)
         >>> reader.case_type = 'reconstructed'
         >>> reader.case_type
         'reconstructed'

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -1941,7 +1941,7 @@ CLASS_READERS = {
     '.dcm': DICOMReader,
     '.dem': DEMReader,
     '.facet': FacetReader,
-    '.foam': (OpenFOAMReader, POpenFOAMReader),
+    '.foam': OpenFOAMReader,
     '.g': BYUReader,
     '.glb': GLTFReader,
     '.gltf': GLTFReader,

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -995,7 +995,7 @@ class POpenFOAMReader(OpenFOAMReader):
 
     @property
     def case_type(self):
-        """The property indicates whether decomposed mesh or reconstructed mesh should be read.
+        """Indicate whether decomposed mesh or reconstructed mesh should be read.
 
         Returns
         -------
@@ -1007,7 +1007,7 @@ class POpenFOAMReader(OpenFOAMReader):
         >>> import pyvista
         >>> from pyvista import examples
         >>> filename = examples.download_cavity(load=False)
-        >>> reader = pyvista.OpenFOAMReader(filename)
+        >>> reader = pyvista.POpenFOAMReader(filename)
         >>> reader.case_type = 1
         >>> reader.case_type
         1
@@ -1941,7 +1941,7 @@ CLASS_READERS = {
     '.dcm': DICOMReader,
     '.dem': DEMReader,
     '.facet': FacetReader,
-    '.foam': OpenFOAMReader,
+    '.foam': (OpenFOAMReader, POpenFOAMReader),
     '.g': BYUReader,
     '.glb': GLTFReader,
     '.gltf': GLTFReader,

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -32,7 +32,7 @@ def get_reader(filename):
     +----------------+---------------------------------------------+
     | ``.facet``     | :class:`pyvista.FacetReader`                |
     +----------------+---------------------------------------------+
-    | ``.foam``      | :class:`pyvista.OpenFOAMReader`             |
+    | ``.foam``      | :class:`pyvista.POpenFOAMReader`            |
     +----------------+---------------------------------------------+
     | ``.g``         | :class:`pyvista.BYUReader`                  |
     +----------------+---------------------------------------------+
@@ -986,6 +986,15 @@ class OpenFOAMReader(BaseReader, PointCellDataSelection, TimeReader):
 
         """
         return {name: self.patch_array_status(name) for name in self.patch_array_names}
+
+
+class POpenFOAMReader(OpenFOAMReader):
+    """Parallel OpenFOAM Reader for .foam files.
+
+    Can read parallel-decomposed mesh information and time dependent data.
+    """
+
+    _class_reader = staticmethod(_vtk.lazy_vtkPOpenFOAMReader)
 
     @property
     def case_type(self):
@@ -1945,7 +1954,7 @@ CLASS_READERS = {
     '.dcm': DICOMReader,
     '.dem': DEMReader,
     '.facet': FacetReader,
-    '.foam': OpenFOAMReader,
+    '.foam': POpenFOAMReader,
     '.g': BYUReader,
     '.glb': GLTFReader,
     '.gltf': GLTFReader,

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -994,8 +994,13 @@ class OpenFOAMReader(BaseReader, PointCellDataSelection, TimeReader):
         Returns
         -------
         int
-            If ``"reconstructed"``, reconstructed mesh should be read.
-            If ``"decomposed"``, decomposed mesh should be read.
+            If ``'reconstructed'``, reconstructed mesh should be read.
+            If ``'decomposed'``, decomposed mesh should be read.
+
+        Raises
+        ------
+        ValueError
+            If the value is not in ['reconstructed', 'decomposed']
 
         Examples
         --------
@@ -1003,17 +1008,17 @@ class OpenFOAMReader(BaseReader, PointCellDataSelection, TimeReader):
         >>> from pyvista import examples
         >>> filename = examples.download_cavity(load=False)
         >>> reader = pyvista.OpenFOAMReader(filename)
-        >>> reader.case_type = "reconstructed"
+        >>> reader.case_type = 'reconstructed'
         >>> reader.case_type
-        "reconstructed"
+        'reconstructed'
         """
-        return "reconstructed" if self.reader.GetCaseType() else "decomposed"
+        return 'reconstructed' if self.reader.GetCaseType() else 'decomposed'
 
     @case_type.setter
     def case_type(self, value):
-        if value == "reconstructed":
+        if value == 'reconstructed':
             self.reader.SetCaseType(1)
-        elif value == "decomposed":
+        elif value == 'decomposed':
             self.reader.SetCaseType(0)
         else:
             raise ValueError("Unknown case type '" + str(value) + "'.")

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -724,7 +724,7 @@ class EnSightReader(BaseReader, PointCellDataSelection, TimeReader):
 class OpenFOAMReader(BaseReader, PointCellDataSelection, TimeReader):
     """OpenFOAM Reader for .foam files."""
 
-    _class_reader = staticmethod(_vtk.lazy_vtkPOpenFOAMReader)
+    _class_reader = _vtk.vtkOpenFOAMReader
 
     def __init__(self, path):
         """Initialize OpenFOAMReader.
@@ -1002,7 +1002,7 @@ class POpenFOAMReader(OpenFOAMReader):
 
         Returns
         -------
-        int
+        str
             If ``'reconstructed'``, reconstructed mesh should be read.
             If ``'decomposed'``, decomposed mesh should be read.
 
@@ -1030,7 +1030,7 @@ class POpenFOAMReader(OpenFOAMReader):
         elif value == 'decomposed':
             self.reader.SetCaseType(0)
         else:
-            raise ValueError("Unknown case type '" + str(value) + "'.")
+            raise ValueError(f"Unknown case type '{value}'.")
 
         self._update_information()
 

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -1008,7 +1008,8 @@ class POpenFOAMReader(OpenFOAMReader):
     """Parallel OpenFOAM Reader for .foam files.
 
     Can read parallel-decomposed mesh information and time dependent data.
-    This reader can be used both for parallel reconstructed data and decomposed data.
+    This reader can be used for serial generated data,
+    parallel reconstructed data, and decomposed data.
     """
 
     _class_reader = staticmethod(_vtk.lazy_vtkPOpenFOAMReader)

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -995,6 +995,23 @@ class POpenFOAMReader(OpenFOAMReader):
 
     @property
     def case_type(self):
+        """The property indicates whether decomposed mesh or reconstructed mesh should be read.
+
+        Returns
+        -------
+        int
+            If ``1``, reconstructed mesh should be read. If ``0``, decomposed mesh should be read.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> from pyvista import examples
+        >>> filename = examples.download_cavity(load=False)
+        >>> reader = pyvista.OpenFOAMReader(filename)
+        >>> reader.case_type = 1
+        >>> reader.case_type
+        1
+        """
         return self.reader.GetCaseType()
 
     @case_type.setter

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -988,6 +988,23 @@ class OpenFOAMReader(BaseReader, PointCellDataSelection, TimeReader):
         return {name: self.patch_array_status(name) for name in self.patch_array_names}
 
 
+class POpenFOAMReader(OpenFOAMReader):
+    """POpenFOAM Reader for .foam files."""
+
+    _class_reader = staticmethod(_vtk.lazy_vtkPOpenFOAMReader)
+
+    @property
+    def case_type(self):
+        return self.reader.GetCaseType()
+
+    @case_type.setter
+    def case_type(self, value):
+        if value:
+            self.reader.SetCaseType(1)
+        else:
+            self.reader.SetCaseType(0)
+
+
 class PLYReader(BaseReader):
     """PLY Reader for reading .ply files.
 

--- a/tests/utilities/test_reader.py
+++ b/tests/utilities/test_reader.py
@@ -571,6 +571,16 @@ def test_openfoam_patch_arrays():
     assert mesh[patch_array_key].keys() == ['movingWall', 'fixedWalls', 'frontAndBack']
 
 
+def test_openfoam_case_type():
+    reader = get_cavity_reader()
+    reader.case_type = 'decomposed'
+    assert reader.case_type == 'decomposed'
+    reader.case_type = 'reconstructed'
+    assert reader.case_type == 'reconstructed'
+    with pytest.raises(ValueError, match="Unknown case type 'wrong_value'."):
+        reader.case_type = 'wrong_value'
+
+
 @pytest.mark.skipif(pyvista.vtk_version_info < (9, 1), reason="Requires VTK v9.1.0 or newer")
 def test_read_hdf():
     can = examples.download_can(partial=True)


### PR DESCRIPTION
### Overview

We would like to be able to import and manipulate OpenFOAM files which are produced from a parallel computation. Thus, we need to expose the vtkPOpenFOAMReader ([class definition](https://vtk.org/doc/nightly/html/classvtkPOpenFOAMReader.html)).

It has been discussed here: #924 

This PR resolves #2590 

### Details

A first idea was to replace the reader in the current OpenFOAMReader because vtkPOpenFOAMReader inherits from vtkOpenFOAMReader in vtk. Thus we would just need to add the `CaseType` property to allow users to chose whether reconstructed mesh or decomposed mesh should be read.

However since we are not 100% sure vtkPOpenFOAMReader can propose the exact same services as the vtkOpenFOAMReader we decided to create a class (`POpenFOAMReader`) which inherits from OpenFOAMReader with a new property (`case_type`).

### Work to be done
- [x] Add POpenFOAMReader to the list of available readers
- [x] Write basic tests
- [ ] Find a testing dataset to test more advanced properties when using the case_type property