### PR TITLE
Include MultipleLines in documentation

### DIFF
--- a/doc/api/utilities/geometric.rst
+++ b/doc/api/utilities/geometric.rst
@@ -22,6 +22,7 @@ additional details see :ref:`ref_geometric_example` example.
    Dodecahedron
    Icosahedron
    Line
+   MultipleLines
    Tube
    Octahedron
    Plane

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -477,6 +477,7 @@ def MultipleLines(points=[[-0.5, 0.0, 0.0], [0.5, 0.0, 0.0]]):
     Returns
     -------
     pyvista.PolyData
+        Line mesh.
 
     Examples
     --------


### PR DESCRIPTION

### Overview
MultipleLines was introduced in #2304 but not included in the documentation.
Fix numpydoc warning "RT03: Return value has no description" by adding a description.
Resolves #2679.
<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->



