### PR TITLE
Add .git-blame-ignore-revs file with black PR commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
 # enforce unified code style with black
 28914fc2236cd5850f536b151d0ef383855d8519
+db0691cfb6b033e55664ffba25deb456a386a48c

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# enforce unified code style with black
+28914fc2236cd5850f536b151d0ef383855d8519


### PR DESCRIPTION
[GitHub has finally added support for ignoring commits in blames](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view)! I've been using a local `.git-blame-ignore-revs` file to ignore The Blackening, but now it makes sense to add it to the repo itself.

Some resources:
  * [Github's explanation](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view)
  * [`git blame`'s doc](https://www.git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt)
  * [`git config`'s doc for configuring a local ignore-revs file](https://git-scm.com/docs/git-config#Documentation/git-config.txt-blameignoreRevsFile).
  
GitHub's blame view of https://github.com/pyvista/pyvista/blame/main/examples/00-load/create-point-cloud.py before adding this file:
![screenshot with multiple commits shown in blame due to black](https://user-images.githubusercontent.com/17914410/169824027-a74284d8-24f2-4959-867c-55f4383c169f.png)

and after:
![screenshot with black commits hidden](https://user-images.githubusercontent.com/17914410/169824047-726809ff-f96d-4e75-9bae-e0741e1ea7fc.png)

It would be nice if we could somehow add the configuration of the ignore-revs-file to pre-commit or some other setup steps, but I haven't investigated this yet.