### PR TITLE
Fix typo

### DIFF
--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -337,7 +337,7 @@ class Camera(_vtk.vtkCamera):
         self.SetParallelProjection(True)
 
     def disable_parallel_projection(self):
-        """Disable the use of perspective projection.
+        """Disable the use of parallel projection.
 
         This is default behavior.
 


### PR DESCRIPTION


### Overview
Fix typo in docstring of `disable_parallel_projection`.
<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->




