### PR TITLE
Fix shared array access on init

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -411,7 +411,7 @@ class DataSet(DataSetFilters, DataObject):
             self.Modified()
             return
         # otherwise, wrap and use the array
-        points = _coerce_pointslike_arg(points)
+        points = _coerce_pointslike_arg(points, copy=False)
         vtk_points = pyvista.vtk_points(points, False)
         if not pdata:
             self.SetPoints(vtk_points)

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -76,20 +76,24 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
     Parameters
     ----------
     uinput : str, pathlib.Path, vtk.vtkRectilinearGrid, numpy.ndarray, optional
-        Filename, dataset, or array to initialize the uniform grid from. If a
+        Filename, dataset, or array to initialize the rectilinear grid from. If a
         filename is passed, pyvista will attempt to load it as a
         :class:`RectilinearGrid`. If passed a ``vtk.vtkRectilinearGrid``, it
         will be wrapped. If a :class:`numpy.ndarray` is passed, this will be
         loaded as the x range.
+
     y : numpy.ndarray, optional
         Coordinates of the points in y direction. If this is passed, ``uinput``
         must be a :class:`numpy.ndarray`.
+
     z : np.ndarray, optional
         Coordinates of the points in z direction. If this is passed, ``uinput`` and ``y``
         must be a :class:`numpy.ndarray`.
+
     check_duplicates : bool, optional
         Check for duplications in any arrays that are passed. Defaults to
-        ``False``.
+        ``False``. If ``True``, an error is raised if there are any duplicate values
+        in any of the array-valued input arguments.
 
     Examples
     --------
@@ -171,11 +175,14 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
         ----------
         x : numpy.ndarray
             Coordinates of the points in x direction.
+
         y : numpy.ndarray
             Coordinates of the points in y direction.
+
         z : numpy.ndarray
             Coordinates of the points in z direction.
-        check_duplicates
+
+        check_duplicates : bool, optional
             Check for duplications in any arrays that are passed.
 
         """

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -129,7 +129,7 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
             if isinstance(args[0], _vtk.vtkRectilinearGrid):
                 self.deep_copy(args[0])
             elif isinstance(args[0], (str, pathlib.Path)):
-                self._from_file(args[0])
+                self._from_file(args[0], **kwargs)
             elif isinstance(args[0], np.ndarray):
                 self._from_arrays(args[0], None, None, check_duplicates)
             else:

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1893,6 +1893,8 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
                 self.deep_copy(args[0])
             elif isinstance(args[0], (str, pathlib.Path)):
                 self._from_file(args[0], **kwargs)
+            elif isinstance(args[0], np.ndarray):
+                self.points = args[0]
 
         elif len(args) == 3:
             arg0_is_arr = isinstance(args[0], np.ndarray)

--- a/pyvista/utilities/common.py
+++ b/pyvista/utilities/common.py
@@ -8,7 +8,7 @@ from pyvista._typing import NumericArray, VectorArray
 
 
 def _coerce_pointslike_arg(
-    points: Union[NumericArray, VectorArray], copy: bool = True
+    points: Union[NumericArray, VectorArray], copy: bool = False
 ) -> np.ndarray:
     """Check and coerce arg to (n, 3) np.ndarray.
 

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -156,6 +156,8 @@ def convert_array(arr, name=None, deep=False, array_type=None):
     """
     if arr is None:
         return
+    if isinstance(arr, (list, tuple)):
+        arr = np.array(arr)
     if isinstance(arr, np.ndarray):
         if arr.dtype == np.dtype('O'):
             arr = arr.astype('|S')

--- a/pyvista/utilities/misc.py
+++ b/pyvista/utilities/misc.py
@@ -16,7 +16,7 @@ def raise_has_duplicates(arr):
 def has_duplicates(arr):
     """Return if an array has any duplicates."""
     s = np.sort(arr, axis=None)
-    return (s[:-1][s[1:] == s[:-1]]).any()
+    return (s[1:] == s[:-1]).any()
 
 
 def _get_vtk_id_type():

--- a/pyvista/utilities/misc.py
+++ b/pyvista/utilities/misc.py
@@ -7,6 +7,18 @@ import numpy as np
 from pyvista import _vtk
 
 
+def raise_has_duplicates(arr):
+    """Raise a ValueError if an array is not unique."""
+    if has_duplicates(arr):
+        raise ValueError("Array contains duplicate values.")
+
+
+def has_duplicates(arr):
+    """Return if an array has any duplicates."""
+    s = np.sort(arr, axis=None)
+    return (s[:-1][s[1:] == s[:-1]]).any()
+
+
 def _get_vtk_id_type():
     """Return the numpy datatype responding to ``vtk.vtkIdTypeArray``."""
     VTK_ID_TYPE_SIZE = _vtk.vtkIdTypeArray().GetDataTypeSize()

--- a/tests/test_create_no_copy.py
+++ b/tests/test_create_no_copy.py
@@ -130,14 +130,3 @@ def test_no_copy_rectilinear_grid():
     assert np.may_share_memory(mesh.z, z)
     assert np.array_equal(mesh.z, zrng)
     assert np.may_share_memory(mesh.z, zrng)
-
-
-def test_raise_rectilinear_grid_non_unique():
-    rng_uniq = np.arange(4.0)
-    rng_dupe = np.array([0, 1, 2, 2], dtype=float)
-    with pytest.raises(ValueError, match="Array contains duplicate values"):
-        pyvista.RectilinearGrid(rng_dupe, check_duplicates=True)
-    with pytest.raises(ValueError, match="Array contains duplicate values"):
-        pyvista.RectilinearGrid(rng_uniq, rng_dupe, check_duplicates=True)
-    with pytest.raises(ValueError, match="Array contains duplicate values"):
-        pyvista.RectilinearGrid(rng_uniq, rng_uniq, rng_dupe, check_duplicates=True)

--- a/tests/test_create_no_copy.py
+++ b/tests/test_create_no_copy.py
@@ -19,7 +19,7 @@ def structured_points():
     source[:, 0] = x.ravel('F')
     source[:, 1] = y.ravel('F')
     source[:, 2] = z.ravel('F')
-    return source
+    return source, (*x.shape, 1)
 
 
 def test_no_copy_polydata_init():
@@ -42,8 +42,9 @@ def test_no_copy_polydata_points_setter():
 
 
 def test_no_copy_structured_mesh_init(structured_points):
-    source = structured_points
+    source, dims = structured_points
     mesh = pyvista.StructuredGrid(source)
+    mesh.dimensions = dims
     pts = mesh.points
     pts /= 2
     assert np.allclose(mesh.points, pts)
@@ -51,9 +52,10 @@ def test_no_copy_structured_mesh_init(structured_points):
 
 
 def test_no_copy_structured_mesh_points_setter(structured_points):
-    source = structured_points
+    source, dims = structured_points
     mesh = pyvista.StructuredGrid()
     mesh.points = source
+    mesh.dimensions = dims
     pts = mesh.points
     pts /= 2
     assert np.allclose(mesh.points, pts)

--- a/tests/test_create_no_copy.py
+++ b/tests/test_create_no_copy.py
@@ -3,6 +3,10 @@ import pytest
 
 import pyvista
 
+pointsetmark = pytest.mark.skipif(
+    pyvista.vtk_version_info < (9, 1, 0), reason="Requires VTK>=9.1.0 for a concrete PointSet class"
+)
+
 
 @pytest.fixture
 def structured_points():
@@ -57,6 +61,7 @@ def test_no_copy_structured_mesh_points_setter(structured_points):
     assert np.allclose(mesh.points, source)
 
 
+@pointsetmark
 def test_no_copy_pointset_init():
     source = np.random.rand(100, 3)
     mesh = pyvista.PointSet(source)
@@ -66,6 +71,7 @@ def test_no_copy_pointset_init():
     assert np.allclose(mesh.points, source)
 
 
+@pointsetmark
 def test_no_copy_pointset_points_setter():
     source = np.random.rand(100, 3)
     mesh = pyvista.PointSet()

--- a/tests/test_create_no_copy.py
+++ b/tests/test_create_no_copy.py
@@ -1,0 +1,90 @@
+import numpy as np
+import pytest
+
+import pyvista
+
+
+@pytest.fixture
+def structured_points():
+    x = np.arange(-10, 10, 0.25)
+    y = np.arange(-10, 10, 0.25)
+    x, y = np.meshgrid(x, y)
+    r = np.sqrt(x**2 + y**2)
+    z = np.sin(r)
+    source = np.empty((x.size, 3), x.dtype)
+    source[:, 0] = x.ravel('F')
+    source[:, 1] = y.ravel('F')
+    source[:, 2] = z.ravel('F')
+    return source
+
+
+def test_no_copy_polydata_init():
+    source = np.random.rand(100, 3)
+    mesh = pyvista.PolyData(source)
+    pts = mesh.points
+    pts /= 2
+    assert np.allclose(mesh.points, pts)
+    assert np.allclose(mesh.points, source)
+
+
+def test_no_copy_polydata_points_setter():
+    source = np.random.rand(100, 3)
+    mesh = pyvista.PolyData()
+    mesh.points = source
+    pts = mesh.points
+    pts /= 2
+    assert np.allclose(mesh.points, pts)
+    assert np.allclose(mesh.points, source)
+
+
+# TODO
+# def test_no_copy_structured_mesh_init(structured_points):
+#     source = structured_points
+#     mesh = pyvista.StructuredGrid(source)
+#     pts = mesh.points
+#     pts /= 2
+#     assert np.allclose(mesh.points, pts)
+#     assert np.allclose(mesh.points, source)
+
+
+def test_no_copy_structured_mesh_points_setter(structured_points):
+    source = structured_points
+    mesh = pyvista.StructuredGrid()
+    mesh.points = source
+    pts = mesh.points
+    pts /= 2
+    assert np.allclose(mesh.points, pts)
+    assert np.allclose(mesh.points, source)
+
+
+def test_no_copy_pointset_init():
+    source = np.random.rand(100, 3)
+    mesh = pyvista.PointSet(source)
+    pts = mesh.points
+    pts /= 2
+    assert np.allclose(mesh.points, pts)
+    assert np.allclose(mesh.points, source)
+
+
+def test_no_copy_pointset_points_setter():
+    source = np.random.rand(100, 3)
+    mesh = pyvista.PointSet()
+    mesh.points = source
+    pts = mesh.points
+    pts /= 2
+    assert np.allclose(mesh.points, pts)
+    assert np.allclose(mesh.points, source)
+
+
+# def test_no_copy_unstructured_grid_init():
+#     ...  # TODO
+
+
+def test_no_copy_unstructured_grid_points_setter():
+    source = np.random.rand(100, 3)
+    mesh = pyvista.UnstructuredGrid()
+    mesh.points = source
+    pts = mesh.points
+    pts /= 2
+    assert np.allclose(mesh.points, pts)
+    assert np.allclose(mesh.points, source)

--- a/tests/test_create_no_copy.py
+++ b/tests/test_create_no_copy.py
@@ -28,7 +28,9 @@ def test_no_copy_polydata_init():
     pts = mesh.points
     pts /= 2
     assert np.allclose(mesh.points, pts)
+    assert np.may_share_memory(mesh.points, pts)
     assert np.allclose(mesh.points, source)
+    assert np.may_share_memory(mesh.points, source)
 
 
 def test_no_copy_polydata_points_setter():
@@ -38,7 +40,9 @@ def test_no_copy_polydata_points_setter():
     pts = mesh.points
     pts /= 2
     assert np.allclose(mesh.points, pts)
+    assert np.may_share_memory(mesh.points, pts)
     assert np.allclose(mesh.points, source)
+    assert np.may_share_memory(mesh.points, source)
 
 
 def test_no_copy_structured_mesh_init(structured_points):
@@ -48,7 +52,9 @@ def test_no_copy_structured_mesh_init(structured_points):
     pts = mesh.points
     pts /= 2
     assert np.allclose(mesh.points, pts)
+    assert np.may_share_memory(mesh.points, pts)
     assert np.allclose(mesh.points, source)
+    assert np.may_share_memory(mesh.points, source)
 
 
 def test_no_copy_structured_mesh_points_setter(structured_points):
@@ -59,7 +65,9 @@ def test_no_copy_structured_mesh_points_setter(structured_points):
     pts = mesh.points
     pts /= 2
     assert np.allclose(mesh.points, pts)
+    assert np.may_share_memory(mesh.points, pts)
     assert np.allclose(mesh.points, source)
+    assert np.may_share_memory(mesh.points, source)
 
 
 @pointsetmark
@@ -69,7 +77,9 @@ def test_no_copy_pointset_init():
     pts = mesh.points
     pts /= 2
     assert np.allclose(mesh.points, pts)
+    assert np.may_share_memory(mesh.points, pts)
     assert np.allclose(mesh.points, source)
+    assert np.may_share_memory(mesh.points, source)
 
 
 @pointsetmark
@@ -80,7 +90,9 @@ def test_no_copy_pointset_points_setter():
     pts = mesh.points
     pts /= 2
     assert np.allclose(mesh.points, pts)
+    assert np.may_share_memory(mesh.points, pts)
     assert np.allclose(mesh.points, source)
+    assert np.may_share_memory(mesh.points, source)
 
 
 def test_no_copy_unstructured_grid_points_setter():
@@ -90,7 +102,9 @@ def test_no_copy_unstructured_grid_points_setter():
     pts = mesh.points
     pts /= 2
     assert np.allclose(mesh.points, pts)
+    assert np.may_share_memory(mesh.points, pts)
     assert np.allclose(mesh.points, source)
+    assert np.may_share_memory(mesh.points, source)
 
 
 def test_no_copy_rectilinear_grid():
@@ -101,15 +115,21 @@ def test_no_copy_rectilinear_grid():
     x = mesh.x
     x /= 2
     assert np.allclose(mesh.x, x)
+    assert np.may_share_memory(mesh.x, x)
     assert np.allclose(mesh.x, xrng)
+    assert np.may_share_memory(mesh.x, xrng)
     y = mesh.y
     y /= 2
     assert np.allclose(mesh.y, y)
+    assert np.may_share_memory(mesh.y, y)
     assert np.allclose(mesh.y, yrng)
+    assert np.may_share_memory(mesh.y, yrng)
     z = mesh.z
     z /= 2
     assert np.allclose(mesh.z, z)
+    assert np.may_share_memory(mesh.z, z)
     assert np.allclose(mesh.z, zrng)
+    assert np.may_share_memory(mesh.z, zrng)
 
 
 def test_raise_rectilinear_grid_non_unique():

--- a/tests/test_create_no_copy.py
+++ b/tests/test_create_no_copy.py
@@ -41,14 +41,13 @@ def test_no_copy_polydata_points_setter():
     assert np.allclose(mesh.points, source)
 
 
-# TODO
-# def test_no_copy_structured_mesh_init(structured_points):
-#     source = structured_points
-#     mesh = pyvista.StructuredGrid(source)
-#     pts = mesh.points
-#     pts /= 2
-#     assert np.allclose(mesh.points, pts)
-#     assert np.allclose(mesh.points, source)
+def test_no_copy_structured_mesh_init(structured_points):
+    source = structured_points
+    mesh = pyvista.StructuredGrid(source)
+    pts = mesh.points
+    pts /= 2
+    assert np.allclose(mesh.points, pts)
+    assert np.allclose(mesh.points, source)
 
 
 def test_no_copy_structured_mesh_points_setter(structured_points):
@@ -94,3 +93,28 @@ def test_no_copy_unstructured_grid_points_setter():
     pts /= 2
     assert np.allclose(mesh.points, pts)
     assert np.allclose(mesh.points, source)
+
+
+def test_no_copy_rectilinear_grid():
+    xrng = np.arange(-10, 10, 2, dtype=float)
+    yrng = np.arange(-10, 10, 5, dtype=float)
+    zrng = np.arange(-10, 10, 1, dtype=float)
+    mesh = pyvista.RectilinearGrid(xrng, yrng, zrng)
+    x = mesh.x
+    x /= 2
+    assert np.allclose(mesh.x, x)
+    assert np.allclose(mesh.x, xrng)
+    y = mesh.y
+    y /= 2
+    assert np.allclose(mesh.y, y)
+    assert np.allclose(mesh.y, yrng)
+    z = mesh.z
+    z /= 2
+    assert np.allclose(mesh.z, z)
+    assert np.allclose(mesh.z, zrng)
+
+
+def test_raise_rectilinear_grid_non_unique():
+    rng = np.array([0, 1, 2, 2], dtype=float)
+    with pytest.raises(ValueError, match="Array contains duplicate values"):
+        pyvista.RectilinearGrid(rng, check_duplicates=True)

--- a/tests/test_create_no_copy.py
+++ b/tests/test_create_no_copy.py
@@ -83,10 +83,6 @@ def test_no_copy_pointset_points_setter():
     assert np.allclose(mesh.points, source)
 
 
-# def test_no_copy_unstructured_grid_init():
-#     ...  # TODO
-
-
 def test_no_copy_unstructured_grid_points_setter():
     source = np.random.rand(100, 3)
     mesh = pyvista.UnstructuredGrid()

--- a/tests/test_create_no_copy.py
+++ b/tests/test_create_no_copy.py
@@ -133,6 +133,11 @@ def test_no_copy_rectilinear_grid():
 
 
 def test_raise_rectilinear_grid_non_unique():
-    rng = np.array([0, 1, 2, 2], dtype=float)
+    rng_uniq = np.arange(4.0)
+    rng_dupe = np.array([0, 1, 2, 2], dtype=float)
     with pytest.raises(ValueError, match="Array contains duplicate values"):
-        pyvista.RectilinearGrid(rng, check_duplicates=True)
+        pyvista.RectilinearGrid(rng_dupe, check_duplicates=True)
+    with pytest.raises(ValueError, match="Array contains duplicate values"):
+        pyvista.RectilinearGrid(rng_uniq, rng_dupe, check_duplicates=True)
+    with pytest.raises(ValueError, match="Array contains duplicate values"):
+        pyvista.RectilinearGrid(rng_uniq, rng_uniq, rng_dupe, check_duplicates=True)

--- a/tests/test_create_no_copy.py
+++ b/tests/test_create_no_copy.py
@@ -27,9 +27,9 @@ def test_no_copy_polydata_init():
     mesh = pyvista.PolyData(source)
     pts = mesh.points
     pts /= 2
-    assert np.allclose(mesh.points, pts)
+    assert np.array_equal(mesh.points, pts)
     assert np.may_share_memory(mesh.points, pts)
-    assert np.allclose(mesh.points, source)
+    assert np.array_equal(mesh.points, source)
     assert np.may_share_memory(mesh.points, source)
 
 
@@ -39,9 +39,9 @@ def test_no_copy_polydata_points_setter():
     mesh.points = source
     pts = mesh.points
     pts /= 2
-    assert np.allclose(mesh.points, pts)
+    assert np.array_equal(mesh.points, pts)
     assert np.may_share_memory(mesh.points, pts)
-    assert np.allclose(mesh.points, source)
+    assert np.array_equal(mesh.points, source)
     assert np.may_share_memory(mesh.points, source)
 
 
@@ -51,9 +51,9 @@ def test_no_copy_structured_mesh_init(structured_points):
     mesh.dimensions = dims
     pts = mesh.points
     pts /= 2
-    assert np.allclose(mesh.points, pts)
+    assert np.array_equal(mesh.points, pts)
     assert np.may_share_memory(mesh.points, pts)
-    assert np.allclose(mesh.points, source)
+    assert np.array_equal(mesh.points, source)
     assert np.may_share_memory(mesh.points, source)
 
 
@@ -64,9 +64,9 @@ def test_no_copy_structured_mesh_points_setter(structured_points):
     mesh.dimensions = dims
     pts = mesh.points
     pts /= 2
-    assert np.allclose(mesh.points, pts)
+    assert np.array_equal(mesh.points, pts)
     assert np.may_share_memory(mesh.points, pts)
-    assert np.allclose(mesh.points, source)
+    assert np.array_equal(mesh.points, source)
     assert np.may_share_memory(mesh.points, source)
 
 
@@ -76,9 +76,9 @@ def test_no_copy_pointset_init():
     mesh = pyvista.PointSet(source)
     pts = mesh.points
     pts /= 2
-    assert np.allclose(mesh.points, pts)
+    assert np.array_equal(mesh.points, pts)
     assert np.may_share_memory(mesh.points, pts)
-    assert np.allclose(mesh.points, source)
+    assert np.array_equal(mesh.points, source)
     assert np.may_share_memory(mesh.points, source)
 
 
@@ -89,9 +89,9 @@ def test_no_copy_pointset_points_setter():
     mesh.points = source
     pts = mesh.points
     pts /= 2
-    assert np.allclose(mesh.points, pts)
+    assert np.array_equal(mesh.points, pts)
     assert np.may_share_memory(mesh.points, pts)
-    assert np.allclose(mesh.points, source)
+    assert np.array_equal(mesh.points, source)
     assert np.may_share_memory(mesh.points, source)
 
 
@@ -101,9 +101,9 @@ def test_no_copy_unstructured_grid_points_setter():
     mesh.points = source
     pts = mesh.points
     pts /= 2
-    assert np.allclose(mesh.points, pts)
+    assert np.array_equal(mesh.points, pts)
     assert np.may_share_memory(mesh.points, pts)
-    assert np.allclose(mesh.points, source)
+    assert np.array_equal(mesh.points, source)
     assert np.may_share_memory(mesh.points, source)
 
 
@@ -114,21 +114,21 @@ def test_no_copy_rectilinear_grid():
     mesh = pyvista.RectilinearGrid(xrng, yrng, zrng)
     x = mesh.x
     x /= 2
-    assert np.allclose(mesh.x, x)
+    assert np.array_equal(mesh.x, x)
     assert np.may_share_memory(mesh.x, x)
-    assert np.allclose(mesh.x, xrng)
+    assert np.array_equal(mesh.x, xrng)
     assert np.may_share_memory(mesh.x, xrng)
     y = mesh.y
     y /= 2
-    assert np.allclose(mesh.y, y)
+    assert np.array_equal(mesh.y, y)
     assert np.may_share_memory(mesh.y, y)
-    assert np.allclose(mesh.y, yrng)
+    assert np.array_equal(mesh.y, yrng)
     assert np.may_share_memory(mesh.y, yrng)
     z = mesh.z
     z /= 2
-    assert np.allclose(mesh.z, z)
+    assert np.array_equal(mesh.z, z)
     assert np.may_share_memory(mesh.z, z)
-    assert np.allclose(mesh.z, zrng)
+    assert np.array_equal(mesh.z, zrng)
     assert np.may_share_memory(mesh.z, zrng)
 
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -631,6 +631,17 @@ def test_read_rectilinear_grid_from_pathlib():
     assert grid.n_arrays == 1
 
 
+def test_raise_rectilinear_grid_non_unique():
+    rng_uniq = np.arange(4.0)
+    rng_dupe = np.array([0, 1, 2, 2], dtype=float)
+    with pytest.raises(ValueError, match="Array contains duplicate values"):
+        pyvista.RectilinearGrid(rng_dupe, check_duplicates=True)
+    with pytest.raises(ValueError, match="Array contains duplicate values"):
+        pyvista.RectilinearGrid(rng_uniq, rng_dupe, check_duplicates=True)
+    with pytest.raises(ValueError, match="Array contains duplicate values"):
+        pyvista.RectilinearGrid(rng_uniq, rng_uniq, rng_dupe, check_duplicates=True)
+
+
 def test_cast_rectilinear_grid():
     grid = pyvista.read(examples.rectfile)
     structured = grid.cast_to_structured_grid()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -23,6 +23,7 @@ from pyvista.utilities import (
     helpers,
     transformations,
 )
+from pyvista.utilities.misc import has_duplicates, raise_has_duplicates
 
 
 def test_version():
@@ -763,3 +764,17 @@ def test_convert_array():
         pickle.loads(pickle.dumps(np.arange(4).astype('O'))), array_type=np.dtype('O')
     )
     assert arr3.GetNumberOfValues() == 4
+
+    # check lists work
+    my_list = [1, 2, 3]
+    arr4 = pyvista.utilities.convert_array(my_list)
+    assert arr4.GetNumberOfValues() == len(my_list)
+
+
+def test_has_duplicates():
+    assert not has_duplicates(np.arange(100))
+    assert has_duplicates(np.array([0, 1, 2, 2]))
+    assert has_duplicates(np.array([[0, 1, 2], [0, 1, 2]]))
+
+    with pytest.raises(ValueError):
+        raise_has_duplicates(np.array([0, 1, 2, 2]))

--- a/tests/utilities/test_common.py
+++ b/tests/utilities/test_common.py
@@ -3,7 +3,6 @@
 import numpy as np
 import pytest
 
-import pyvista
 from pyvista.utilities.common import _coerce_pointslike_arg
 
 
@@ -88,9 +87,6 @@ def test_coerce_point_like_arg_errors():
 
 def test_coerce_points_like_args_does_not_copy():
     source = np.random.rand(100, 3)
-    grid = pyvista.PolyData()
-    grid.points = source
-    pts = grid.points
-    pts /= 2
-    assert np.allclose(grid.points, pts)
-    assert np.allclose(grid.points, source)
+    output = _coerce_pointslike_arg(source)  # test that copy=False is default
+    output /= 2
+    assert np.allclose(output, source)

--- a/tests/utilities/test_common.py
+++ b/tests/utilities/test_common.py
@@ -89,4 +89,5 @@ def test_coerce_points_like_args_does_not_copy():
     source = np.random.rand(100, 3)
     output = _coerce_pointslike_arg(source)  # test that copy=False is default
     output /= 2
-    assert np.allclose(output, source)
+    assert np.array_equal(output, source)
+    assert np.may_share_memory(output, source)

--- a/tests/utilities/test_common.py
+++ b/tests/utilities/test_common.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 
+import pyvista
 from pyvista.utilities.common import _coerce_pointslike_arg
 
 
@@ -83,3 +84,13 @@ def test_coerce_point_like_arg_errors():
     # wrong ndim ndarray
     with pytest.raises(ValueError):
         _coerce_pointslike_arg(np.empty([1, 3, 3]))
+
+
+def test_coerce_points_like_args_does_not_copy():
+    source = np.random.rand(100, 3)
+    grid = pyvista.PolyData()
+    grid.points = source
+    pts = grid.points
+    pts /= 2
+    assert np.allclose(grid.points, pts)
+    assert np.allclose(grid.points, source)


### PR DESCRIPTION
Resolve #2696, depends on #2698, and generally improves how meshes are created without copying source data when possible

@MatthewFlamm, please review as this is a follow up to your #2070

I'd like to add some more/better tests for this scenario

Memory usage comparison

<table>
<tr>
<th>
`main`
</th>
<th>
This branch
</th>
</tr>

<tr>

<td>
<pre>
 Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
     6    138.4 MiB    138.4 MiB           1   @profile
     7                                         def test():
     8
     9   2427.2 MiB   2288.9 MiB           1       source = np.random.rand(100_000_000, 3)
    10
    11   2427.3 MiB      0.1 MiB           1       mesh = pv.PolyData()
    12   4716.2 MiB   2288.9 MiB           1       mesh.points = source
    13
    14   4716.2 MiB      0.0 MiB           1       pts = mesh.points
    15   4716.2 MiB      0.0 MiB           1       pts /= 2
</pre>
</td>

<td>
<pre>
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
     6    138.2 MiB    138.2 MiB           1   @profile
     7                                         def test():
     8
     9   2427.0 MiB   2288.9 MiB           1       source = np.random.rand(100_000_000, 3)
    10
    11   2427.1 MiB      0.1 MiB           1       mesh = pv.PolyData()
    12   2427.2 MiB      0.0 MiB           1       mesh.points = source
    13
    14   2427.2 MiB      0.0 MiB           1       pts = mesh.points
    15   2427.2 MiB      0.0 MiB           1       pts /= 2
</pre>
</td>

</tr>
</table>

