### PR TITLE
No copy init for StructuredGrid and RectilinearGrid

### DIFF
--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -12,7 +12,7 @@ from pyvista.core.dataset import DataSet
 from pyvista.core.filters import UniformGridFilters, _get_output
 from pyvista.utilities import abstract_class
 import pyvista.utilities.helpers as helpers
-from pyvista.utilities.misc import PyvistaDeprecationWarning
+from pyvista.utilities.misc import PyvistaDeprecationWarning, get_duplicates
 
 log = logging.getLogger(__name__)
 log.setLevel('CRITICAL')
@@ -162,12 +162,22 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
             Coordinates of the points in z direction.
 
         """
+
+        def raise_not_unique(arr, name):
+            """Raise a ValueError if an array is not unique."""
+            dup = get_duplicates(arr)
+            if dup.size != 0:
+                raise ValueError(f"`{name}` has duplicates of values {dup}. It must be unique.")
+
         # Set the coordinates along each axial direction
         # Must at least be an x array
+        raise_not_unique(x, "x")
         self.SetXCoordinates(helpers.convert_array(x.ravel()))
         if y is not None:
+            raise_not_unique(y, "y")
             self.SetYCoordinates(helpers.convert_array(y.ravel()))
         if z is not None:
+            raise_not_unique(z, "z")
             self.SetZCoordinates(helpers.convert_array(z.ravel()))
         # Ensure dimensions are properly set
         self._update_dimensions()

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -11,6 +11,7 @@ from pyvista import _vtk
 from pyvista.core.dataset import DataSet
 from pyvista.core.filters import UniformGridFilters, _get_output
 from pyvista.utilities import abstract_class
+import pyvista.utilities.helpers as helpers
 from pyvista.utilities.misc import PyvistaDeprecationWarning
 
 log = logging.getLogger(__name__)
@@ -163,14 +164,11 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
         """
         # Set the coordinates along each axial direction
         # Must at least be an x array
-        x = np.unique(x.ravel())
-        self.SetXCoordinates(_vtk.numpy_to_vtk(x))
+        self.SetXCoordinates(helpers.convert_array(x.ravel()))
         if y is not None:
-            y = np.unique(y.ravel())
-            self.SetYCoordinates(_vtk.numpy_to_vtk(y))
+            self.SetYCoordinates(helpers.convert_array(y.ravel()))
         if z is not None:
-            z = np.unique(z.ravel())
-            self.SetZCoordinates(_vtk.numpy_to_vtk(z))
+            self.SetZCoordinates(helpers.convert_array(z.ravel()))
         # Ensure dimensions are properly set
         self._update_dimensions()
 
@@ -259,7 +257,7 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
     @x.setter
     def x(self, coords: Sequence):
         """Set the coordinates along the X-direction."""
-        self.SetXCoordinates(_vtk.numpy_to_vtk(coords))
+        self.SetXCoordinates(helpers.convert_array(coords))
         self._update_dimensions()
         self.Modified()
 
@@ -292,7 +290,7 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
     @y.setter
     def y(self, coords: Sequence):
         """Set the coordinates along the Y-direction."""
-        self.SetYCoordinates(_vtk.numpy_to_vtk(coords))
+        self.SetYCoordinates(helpers.convert_array(coords))
         self._update_dimensions()
         self.Modified()
 
@@ -325,7 +323,7 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
     @z.setter
     def z(self, coords: Sequence):
         """Set the coordinates along the Z-direction."""
-        self.SetZCoordinates(_vtk.numpy_to_vtk(coords))
+        self.SetZCoordinates(helpers.convert_array(coords))
         self._update_dimensions()
         self.Modified()
 

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -12,7 +12,7 @@ from pyvista.core.dataset import DataSet
 from pyvista.core.filters import UniformGridFilters, _get_output
 from pyvista.utilities import abstract_class
 import pyvista.utilities.helpers as helpers
-from pyvista.utilities.misc import PyvistaDeprecationWarning, get_duplicates
+from pyvista.utilities.misc import PyvistaDeprecationWarning, raise_has_duplicates
 
 log = logging.getLogger(__name__)
 log.setLevel('CRITICAL')
@@ -162,22 +162,15 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
             Coordinates of the points in z direction.
 
         """
-
-        def raise_not_unique(arr, name):
-            """Raise a ValueError if an array is not unique."""
-            dup = get_duplicates(arr)
-            if dup.size != 0:
-                raise ValueError(f"`{name}` has duplicates of values {dup}. It must be unique.")
-
         # Set the coordinates along each axial direction
         # Must at least be an x array
-        raise_not_unique(x, "x")
+        raise_has_duplicates(x)
         self.SetXCoordinates(helpers.convert_array(x.ravel()))
         if y is not None:
-            raise_not_unique(y, "y")
+            raise_has_duplicates(y)
             self.SetYCoordinates(helpers.convert_array(y.ravel()))
         if z is not None:
-            raise_not_unique(z, "z")
+            raise_has_duplicates(z)
             self.SetZCoordinates(helpers.convert_array(z.ravel()))
         # Ensure dimensions are properly set
         self._update_dimensions()

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -69,12 +69,27 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
 
     Can be initialized in several ways:
 
-    - Create empty grid
-    - Initialize from a vtk.vtkRectilinearGrid object
-    - Initialize directly from the point arrays
+    * Create empty grid
+    * Initialize from a ``vtk.vtkRectilinearGrid`` object
+    * Initialize directly from the point arrays
 
-    See _from_arrays in the documentation for more details on initializing
-    from point arrays
+    Parameters
+    ----------
+    uinput : str, pathlib.Path, vtk.vtkRectilinearGrid, numpy.ndarray, optional
+        Filename, dataset, or array to initialize the uniform grid from. If a
+        filename is passed, pyvista will attempt to load it as a
+        :class:`RectilinearGrid`. If passed a ``vtk.vtkRectilinearGrid``, it
+        will be wrapped. If a :class:`numpy.ndarray` is passed, this will be
+        loaded as the x range.
+    y : numpy.ndarray, optional
+        Coordinates of the points in y direction. If this is passed, ``uinput``
+        must be a :class:`numpy.ndarray`.
+    z : np.ndarray, optional
+        Coordinates of the points in z direction. If this is passed, ``uinput`` and ``y``
+        must be a :class:`numpy.ndarray`.
+    check_duplicates : bool, optional
+        Check for duplications in any arrays that are passed. Defaults to
+        ``False``.
 
     Examples
     --------
@@ -102,7 +117,7 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
 
     _WRITERS = {'.vtk': _vtk.vtkRectilinearGridWriter, '.vtr': _vtk.vtkXMLRectilinearGridWriter}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, check_duplicates=False, **kwargs):
         """Initialize the rectilinear grid."""
         super().__init__()
 
@@ -112,7 +127,7 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
             elif isinstance(args[0], (str, pathlib.Path)):
                 self._from_file(args[0])
             elif isinstance(args[0], np.ndarray):
-                self._from_arrays(args[0], None, None)
+                self._from_arrays(args[0], None, None, check_duplicates)
             else:
                 raise TypeError(f'Type ({type(args[0])}) not understood by `RectilinearGrid`')
 
@@ -125,9 +140,9 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
                 arg2_is_arr = False
 
             if all([arg0_is_arr, arg1_is_arr, arg2_is_arr]):
-                self._from_arrays(args[0], args[1], args[2])
+                self._from_arrays(args[0], args[1], args[2], check_duplicates)
             elif all([arg0_is_arr, arg1_is_arr]):
-                self._from_arrays(args[0], args[1], None)
+                self._from_arrays(args[0], args[1], None, check_duplicates)
             else:
                 raise TypeError("Arguments not understood by `RectilinearGrid`.")
 
@@ -143,7 +158,9 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
         """Update the dimensions if coordinates have changed."""
         return self.SetDimensions(len(self.x), len(self.y), len(self.z))
 
-    def _from_arrays(self, x: np.ndarray, y: np.ndarray, z: np.ndarray):
+    def _from_arrays(
+        self, x: np.ndarray, y: np.ndarray, z: np.ndarray, check_duplicates: bool = False
+    ):
         """Create VTK rectilinear grid directly from numpy arrays.
 
         Each array gives the uniques coordinates of the mesh along each axial
@@ -152,25 +169,28 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
 
         Parameters
         ----------
-        x : np.ndarray
+        x : numpy.ndarray
             Coordinates of the points in x direction.
-
-        y : np.ndarray
+        y : numpy.ndarray
             Coordinates of the points in y direction.
-
-        z : np.ndarray
+        z : numpy.ndarray
             Coordinates of the points in z direction.
+        check_duplicates
+            Check for duplications in any arrays that are passed.
 
         """
         # Set the coordinates along each axial direction
         # Must at least be an x array
-        raise_has_duplicates(x)
+        if check_duplicates:
+            raise_has_duplicates(x)
         self.SetXCoordinates(helpers.convert_array(x.ravel()))
         if y is not None:
-            raise_has_duplicates(y)
+            if check_duplicates:
+                raise_has_duplicates(y)
             self.SetYCoordinates(helpers.convert_array(y.ravel()))
         if z is not None:
-            raise_has_duplicates(z)
+            if check_duplicates:
+                raise_has_duplicates(z)
             self.SetZCoordinates(helpers.convert_array(z.ravel()))
         # Ensure dimensions are properly set
         self._update_dimensions()

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -252,7 +252,7 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
         array([-10.,   0.,  10.])
 
         """
-        return _vtk.vtk_to_numpy(self.GetXCoordinates())
+        return helpers.convert_array(self.GetXCoordinates())
 
     @x.setter
     def x(self, coords: Sequence):
@@ -285,7 +285,7 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
         array([-10.,   0.,  10.])
 
         """
-        return _vtk.vtk_to_numpy(self.GetYCoordinates())
+        return helpers.convert_array(self.GetYCoordinates())
 
     @y.setter
     def y(self, coords: Sequence):
@@ -318,7 +318,7 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
         array([-10.,   0.,  10.])
 
         """
-        return _vtk.vtk_to_numpy(self.GetZCoordinates())
+        return helpers.convert_array(self.GetZCoordinates())
 
     @z.setter
     def z(self, coords: Sequence):

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1893,6 +1893,8 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
                 self.deep_copy(args[0])
             elif isinstance(args[0], (str, pathlib.Path)):
                 self._from_file(args[0], **kwargs)
+            elif isinstance(args[0], np.ndarray):
+                self.points = args[0]
 
         elif len(args) == 3:
             arg0_is_arr = isinstance(args[0], np.ndarray)

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -156,6 +156,8 @@ def convert_array(arr, name=None, deep=False, array_type=None):
     """
     if arr is None:
         return
+    if isinstance(arr, (list, tuple)):
+        arr = np.array(arr)
     if isinstance(arr, np.ndarray):
         if arr.dtype == np.dtype('O'):
             arr = arr.astype('|S')

--- a/pyvista/utilities/misc.py
+++ b/pyvista/utilities/misc.py
@@ -7,6 +7,12 @@ import numpy as np
 from pyvista import _vtk
 
 
+def get_duplicates(arr):
+    """Return any duplicates of an array."""
+    s = np.sort(arr, axis=None)
+    return s[:-1][s[1:] == s[:-1]]
+
+
 def _get_vtk_id_type():
     """Return the numpy datatype responding to ``vtk.vtkIdTypeArray``."""
     VTK_ID_TYPE_SIZE = _vtk.vtkIdTypeArray().GetDataTypeSize()

--- a/pyvista/utilities/misc.py
+++ b/pyvista/utilities/misc.py
@@ -7,10 +7,16 @@ import numpy as np
 from pyvista import _vtk
 
 
-def get_duplicates(arr):
-    """Return any duplicates of an array."""
+def raise_has_duplicates(arr):
+    """Raise a ValueError if an array is not unique."""
+    if has_duplicates(arr):
+        raise ValueError("Array contains duplicate values.")
+
+
+def has_duplicates(arr):
+    """Return if an array has any duplicates."""
     s = np.sort(arr, axis=None)
-    return s[:-1][s[1:] == s[:-1]]
+    return (s[:-1][s[1:] == s[:-1]]).any()
 
 
 def _get_vtk_id_type():

--- a/tests/test_create_no_copy.py
+++ b/tests/test_create_no_copy.py
@@ -117,4 +117,4 @@ def test_no_copy_rectilinear_grid():
 def test_raise_rectilinear_grid_non_unique():
     rng = np.array([0, 1, 2, 2], dtype=float)
     with pytest.raises(ValueError, match="Array contains duplicate values"):
-        pyvista.RectilinearGrid(rng)
+        pyvista.RectilinearGrid(rng, check_duplicates=True)

--- a/tests/test_create_no_copy.py
+++ b/tests/test_create_no_copy.py
@@ -37,14 +37,13 @@ def test_no_copy_polydata_points_setter():
     assert np.allclose(mesh.points, source)
 
 
-# TODO
-# def test_no_copy_structured_mesh_init(structured_points):
-#     source = structured_points
-#     mesh = pyvista.StructuredGrid(source)
-#     pts = mesh.points
-#     pts /= 2
-#     assert np.allclose(mesh.points, pts)
-#     assert np.allclose(mesh.points, source)
+def test_no_copy_structured_mesh_init(structured_points):
+    source = structured_points
+    mesh = pyvista.StructuredGrid(source)
+    pts = mesh.points
+    pts /= 2
+    assert np.allclose(mesh.points, pts)
+    assert np.allclose(mesh.points, source)
 
 
 def test_no_copy_structured_mesh_points_setter(structured_points):

--- a/tests/test_create_no_copy.py
+++ b/tests/test_create_no_copy.py
@@ -112,3 +112,9 @@ def test_no_copy_rectilinear_grid():
     z /= 2
     assert np.allclose(mesh.z, z)
     assert np.allclose(mesh.z, zrng)
+
+
+def test_raise_rectilinear_grid_non_unique():
+    rng = np.array([0, 1, 2, 2], dtype=float)
+    with pytest.raises(ValueError, match="has duplicates"):
+        pyvista.RectilinearGrid(rng)

--- a/tests/test_create_no_copy.py
+++ b/tests/test_create_no_copy.py
@@ -87,3 +87,22 @@ def test_no_copy_unstructured_grid_points_setter():
     pts /= 2
     assert np.allclose(mesh.points, pts)
     assert np.allclose(mesh.points, source)
+
+
+def test_no_copy_rectilinear_grid():
+    xrng = np.arange(-10, 10, 2, dtype=float)
+    yrng = np.arange(-10, 10, 5, dtype=float)
+    zrng = np.arange(-10, 10, 1, dtype=float)
+    mesh = pyvista.RectilinearGrid(xrng, yrng, zrng)
+    x = mesh.x
+    x /= 2
+    assert np.allclose(mesh.x, x)
+    assert np.allclose(mesh.x, xrng)
+    y = mesh.y
+    y /= 2
+    assert np.allclose(mesh.y, y)
+    assert np.allclose(mesh.y, yrng)
+    z = mesh.z
+    z /= 2
+    assert np.allclose(mesh.z, z)
+    assert np.allclose(mesh.z, zrng)

--- a/tests/test_create_no_copy.py
+++ b/tests/test_create_no_copy.py
@@ -116,5 +116,5 @@ def test_no_copy_rectilinear_grid():
 
 def test_raise_rectilinear_grid_non_unique():
     rng = np.array([0, 1, 2, 2], dtype=float)
-    with pytest.raises(ValueError, match="has duplicates"):
+    with pytest.raises(ValueError, match="Array contains duplicate values"):
         pyvista.RectilinearGrid(rng)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -23,6 +23,7 @@ from pyvista.utilities import (
     helpers,
     transformations,
 )
+from pyvista.utilities.misc import get_duplicates
 
 
 def test_version():
@@ -763,3 +764,14 @@ def test_convert_array():
         pickle.loads(pickle.dumps(np.arange(4).astype('O'))), array_type=np.dtype('O')
     )
     assert arr3.GetNumberOfValues() == 4
+
+    # check lists work
+    my_list = [1, 2, 3]
+    arr4 = pyvista.utilities.convert_array(my_list)
+    assert arr4.GetNumberOfValues() == len(my_list)
+
+
+def test_get_duplicates():
+    assert get_duplicates(np.arange(100)).size == 0
+    assert np.allclose(get_duplicates(np.array([0, 1, 2, 2])), np.array([2]))
+    assert np.allclose(get_duplicates(np.array([[0, 1, 2], [0, 1, 2]])), np.array([0, 1, 2]))

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -23,7 +23,7 @@ from pyvista.utilities import (
     helpers,
     transformations,
 )
-from pyvista.utilities.misc import get_duplicates
+from pyvista.utilities.misc import has_duplicates, raise_has_duplicates
 
 
 def test_version():
@@ -771,7 +771,10 @@ def test_convert_array():
     assert arr4.GetNumberOfValues() == len(my_list)
 
 
-def test_get_duplicates():
-    assert get_duplicates(np.arange(100)).size == 0
-    assert np.allclose(get_duplicates(np.array([0, 1, 2, 2])), np.array([2]))
-    assert np.allclose(get_duplicates(np.array([[0, 1, 2], [0, 1, 2]])), np.array([0, 1, 2]))
+def test_has_duplicates():
+    assert not has_duplicates(np.arange(100))
+    assert has_duplicates(np.array([0, 1, 2, 2]))
+    assert has_duplicates(np.array([[0, 1, 2], [0, 1, 2]]))
+
+    with pytest.raises(ValueError):
+        raise_has_duplicates(np.array([0, 1, 2, 2]))


### PR DESCRIPTION
Some changes to include in #2697 - note the base branch

This improves the inits of the `StructuredGrid` and `RectilinearGrid` classes such that they can be initialized without copying the source array data.

There is a slight potential for the changes to `RectlinearGrid` to not be backward compatible as it would previously take the `np.unique` values of the input array (producing a copy). IMO, and from the documentation on that class, the arrays should be provided as unique values and so the internal call to `np.unique` is unneeded and causes undesired data copying. While in some corner cases, this is not backward compatible, I would argue that those corner cases should not be supported and the original implementation was the library version of synatic sugar.