### PR TITLE
Clean up documentation build

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2110,7 +2110,14 @@ class DataSetFilters:
             alg.SetExtractionModeToAllRegions()
         alg.SetColorRegions(True)
         _update_alg(alg, progress_bar, 'Finding and Labeling Connected Bodies/Volumes.')
-        return _get_output(alg)
+        output = _get_output(alg)
+
+        # remove regionID from the output when extraction mode is set to the
+        # largest to avoid the VTK warning:
+        # the Cell array RegionId ... has X tuples but there are only Y cells
+        # if largest:
+        # output.cell_data.pop('RegionId', None)
+        return output
 
     def extract_largest(self, inplace=False, progress_bar=False):
         """Extract largest connected set in mesh.

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2115,8 +2115,8 @@ class DataSetFilters:
         # remove regionID from the output when extraction mode is set to the
         # largest to avoid the VTK warning:
         # the Cell array RegionId ... has X tuples but there are only Y cells
-        # if largest:
-        # output.cell_data.pop('RegionId', None)
+        if largest:
+            output.cell_data.pop('RegionId', None)
         return output
 
     def extract_largest(self, inplace=False, progress_bar=False):

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -3772,7 +3772,13 @@ def download_cgns_multi(load=True):  # pragma: no cover
     filename, _ = _download_file('cgns/multi.cgns')
     if not load:
         return filename
-    return pyvista.get_reader(filename).read()
+    reader = pyvista.get_reader(filename)
+
+    # disable reading the boundary patch. As of VTK 9.1.0 this generates
+    # messages like "Skipping BC_t node: BC_t type 'BCFarfield' not supported
+    # yet."
+    reader.load_boundary_patch = False
+    return reader.read()
 
 
 def download_dicom_stack(load: bool = True) -> Union[pyvista.UniformGrid, str]:  # pragma: no cover

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -13,8 +13,8 @@ Apply a built-in theme
 Load a theme into pyvista
 
 >>> theme = pyvista.themes.DefaultTheme()
->>> theme.save('my_theme.json')
->>> loaded_theme = pyvista.load_theme('my_theme.json')
+>>> theme.save('my_theme.json')  # doctest:+SKIP
+>>> loaded_theme = pyvista.load_theme('my_theme.json')  # doctest:+SKIP
 
 Create a custom theme from the default theme and load it into
 pyvista.


### PR DESCRIPTION
This PR fixes a few annoying warnings that occur during our documentation build.


### `examples/01-filter/compute-volume.py`

```
2022-05-31 20:51:29.891 (   0.661s) [        A417A000]         vtkDataSet.cxx:632   WARN| vtkUnstructuredGrid (0x3449120): Cell array RegionId with 1 components, has 553 tuples but there are only 518 cells
2022-05-31 20:51:29.929 (   0.699s) [        A417A000]         vtkDataSet.cxx:632   WARN| vtkUnstructuredGrid (0x3449120): Cell array RegionId with 1 components, has 553 tuples but there are only 518 cells
```
This is caused by a malformed regionID array when `largest=True` when using the ``connectivity`` filter. Since there's no reason to include this array in the first place when only extracting one region, simply remove it.


### `pyvista.examples.downloads.download_cgns_multi`:
```
2022-05-30T22:45:01.7704924Z 2022-05-30 22:45:01.770 ( 410.807s) [        2EFFE740]      vtkCGNSReader.cxx:2079  WARN| vtkCGNSReader (0x55fe9a6272b0): Skipping BC_t node: BC_t type 'BCSymmetryPlane' not supported yet.
2022-05-30T22:45:01.7706086Z 2022-05-30 22:45:01.770 ( 410.807s) [        2EFFE740]      vtkCGNSReader.cxx:2079  WARN| vtkCGNSReader (0x55fe9a6272b0): Skipping BC_t node: BC_t type 'BCExtrapolate' not supported yet.
2022-05-30T22:45:01.7707238Z 2022-05-30 22:45:01.770 ( 410.807s) [        2EFFE740]      vtkCGNSReader.cxx:2079  WARN| vtkCGNSReader (0x55fe9a6272b0): Skipping BC_t node: BC_t type 'BCFarfield' not supported yet.
2022-05-30T22:45:01.7708011Z 2022-05-30 22:45:01.770 ( 410.807s) [        2EFFE740]      vtkCGNSReader.cxx:2079  WARN| vtkCGNSReader (0x55fe9a6272b0): Skipping BC_t node: BC_t type 'BCFarfield' not supported yet.
```

This is caused by loading the boundary patch `load_boundary_patch`. This has been disabled for this dataset.

### Unnecessary file
The file `my_theme.json` is written when running doctests. The fix is to skip this test.
