### PR TITLE
Fix use of a slice tuple for numpy 1.23

### DIFF
--- a/pyvista/core/filters/structured_grid.py
+++ b/pyvista/core/filters/structured_grid.py
@@ -147,6 +147,7 @@ class StructuredGridFilters(DataSetFilters):
         # slice to cut off the repeated grid face
         slice_spec = [slice(None, None, None)] * 3
         slice_spec[axis] = slice(0, -1, None)
+        slice_spec = tuple(slice_spec)  # trigger basic indexing
 
         # concatenate points, cutting off duplicate
         new_points = np.concatenate(


### PR DESCRIPTION
NumPy 1.23 is almost out.

This is in NumPy 1.22:
```py
>>> import numpy as np
>>> np.arange(3)[[slice(None)]]
<stdin>:1: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
array([0, 1, 2])
```

And as promised, this raises in NumPy 1.23.0rc2:
```py
>>> import numpy as np
>>> np.arange(3)[[slice(None)]]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
```

The poblem is that multidimensional indices like `arr[i, j, k]` are syntactical sugar for tuples: `arr[(i, j, k)]`. Using a list instead as in `arr[[i, j, k]]` should trigger advanced (fancy) indexing. There used to be some leeway that interpreted the latter as the former when a 1d fancy index with the wrong length equal to the number of dimensions was found, and this magic is what was deprecated in favour of writing more exact code.

We had two test failures (with one source) due to this, which has a simple fix.