### PR TITLE
`PolyData.*_normals` properties use existing `Normals` if they exist

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1088,7 +1088,7 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
     def point_normals(self) -> 'pyvista.pyvista_ndarray':
         """Return the point normals.
 
-        If the point data already contains an array named ``Normals``, this array will be returned. Otherwise, the
+        If the point data already contains an array named ``'Normals'``, this array will be returned. Otherwise, the
         normals will be computed using the default options of :func:`PolyData.compute_normals()` and returned.
 
         Returns

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1121,7 +1121,7 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
     def cell_normals(self) -> 'pyvista.pyvista_ndarray':
         """Return the cell normals.
 
-        If the cell data already contains an array named ``Normals``, this array will be returned. Otherwise, the
+        If the cell data already contains an array named ``'Normals'``, this array will be returned. Otherwise, the
         normals will be computed using the default options of :func:`PolyData.compute_normals()` and returned.
 
         Returns

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1088,6 +1088,9 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
     def point_normals(self) -> 'pyvista.pyvista_ndarray':
         """Return the point normals.
 
+        If the point data already contains an array named ``Normals``, this array will be returned. Otherwise, the
+        normals will be computed using the default options of :func:`PolyData.compute_normals()` and returned.
+
         Returns
         -------
         pyvista.pyvista_ndarray
@@ -1108,12 +1111,18 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
                         dtype=float32)
 
         """
-        mesh = self.compute_normals(cell_normals=False, inplace=False)
-        return mesh.point_data['Normals']
+        if 'Normals' in self.point_data:
+            normals = self.point_data['Normals']
+        else:
+            normals = self.compute_normals(cell_normals=False, inplace=False).point_data['Normals']
+        return normals
 
     @property
     def cell_normals(self) -> 'pyvista.pyvista_ndarray':
         """Return the cell normals.
+
+        If the cell data already contains an array named ``Normals``, this array will be returned. Otherwise, the
+        normals will be computed using the default options of :func:`PolyData.compute_normals()` and returned.
 
         Returns
         -------
@@ -1134,8 +1143,11 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
                          [-0.1617585 , -0.01700151,  0.9866839 ]], dtype=float32)
 
         """
-        mesh = self.compute_normals(point_normals=False, inplace=False)
-        return mesh.cell_data['Normals']
+        if 'Normals' in self.cell_data:
+            normals = self.cell_data['Normals']
+        else:
+            normals = self.compute_normals(point_normals=False, inplace=False).cell_data['Normals']
+        return normals
 
     @property
     def face_normals(self) -> 'pyvista.pyvista_ndarray':

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -522,11 +522,33 @@ def test_compute_normals(sphere):
 
 
 def test_point_normals(sphere):
-    assert sphere.point_normals.shape[0] == sphere.n_points
+    sphere = sphere.compute_normals(cell_normals=False, point_normals=True)
+
+    # when `Normals` already exist, make sure they are returned
+    normals = sphere.point_normals
+    assert normals.shape[0] == sphere.n_points
+    assert np.all(normals == sphere.point_data['Normals'])
+    assert np.shares_memory(normals, sphere.point_data['Normals'])
+
+    # when they don't, compute them
+    sphere.point_data.pop('Normals')
+    normals = sphere.point_normals
+    assert normals.shape[0] == sphere.n_points
 
 
 def test_cell_normals(sphere):
-    assert sphere.cell_normals.shape[0] == sphere.n_cells
+    sphere = sphere.compute_normals(cell_normals=True, point_normals=False)
+
+    # when `Normals` already exist, make sure they are returned
+    normals = sphere.cell_normals
+    assert normals.shape[0] == sphere.n_cells
+    assert np.all(normals == sphere.cell_data['Normals'])
+    assert np.shares_memory(normals, sphere.cell_data['Normals'])
+
+    # when they don't, compute them
+    sphere.cell_data.pop('Normals')
+    normals = sphere.cell_normals
+    assert normals.shape[0] == sphere.n_cells
 
 
 def test_face_normals(sphere):


### PR DESCRIPTION
### Overview

`PolyData.*_normals` properties use existing `Normals` if they exist. Based on discussion in #2728 