### PR TITLE
Add `PolyDataFilters.find_closest_point_on_surface`

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5132,3 +5132,33 @@ class DataSetFilters:
             inplace=inplace,
             progress_bar=progress_bar,
         )
+
+    def find_closest_point_on_surface(self, point, return_distance=False):
+        """Find the closest point _on the surface_ to a given target point.
+
+        This differs from :func:`find_closest_point`, which returns the index of the closest mesh node, not the closest
+        point on the surface.
+
+        Parameters
+        ----------
+        point : list
+            The target point.
+
+        return_distance : bool, optional
+            Set to true to return the signed distance between the closest point and the target point.
+
+        Returns
+        -------
+        np.ndarray
+            The coordinates of the closest point.
+
+        float
+            The distance to the closest point. Only returned if ``return_distance`` is set to ``True``.
+        """
+        alg = _vtk.vtkImplicitPolyDataDistance()
+        alg.SetInput(self)
+        closest = np.zeros(3)
+        distance = alg.EvaluateFunctionAndGetClosestPoint(point, closest)
+        if return_distance:
+            return closest, distance
+        return closest

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -269,6 +269,26 @@ def test_implicit_distance():
     assert "implicit_distance" in dataset.point_data
 
 
+def test_find_closest_point_on_surface():
+    surface = pyvista.Plane(center=(0, 0, 0), direction=(0, 0, 1), i_size=1, j_size=1, i_resolution=1, j_resolution=1)
+
+    target = ((0, 0, 0))  # this point is on the surface but is not one of the nodes
+    closest_point_on_surface = surface.find_closest_point_on_surface(target)
+    assert closest_point_on_surface == pytest.approx((0, 0, 0))
+    closest_point = surface.points[surface.find_closest_point(target)]
+    assert np.linalg.norm((closest_point - closest_point_on_surface)) == pytest.approx(np.linalg.norm((0.5, 0.5)))
+
+    target = ((0, 0, 0.25))  # this point is below the surface
+    closest_point_on_surface, distance_to_surface = surface.find_closest_point_on_surface(target, return_distance=True)
+    assert closest_point_on_surface == pytest.approx((0, 0, 0))
+    assert distance_to_surface == pytest.approx(-0.25)
+
+    target = ((0, 0, -0.25))  # this point is above the surface
+    closest_point_on_surface, distance_to_surface = surface.find_closest_point_on_surface(target, return_distance=True)
+    assert closest_point_on_surface == pytest.approx((0, 0, 0))
+    assert distance_to_surface == pytest.approx(0.25)
+
+
 def test_slice_filter(datasets):
     """This tests the slice filter on all datatypes available filters"""
     for i, dataset in enumerate(datasets):


### PR DESCRIPTION
### Overview

Finds the closest point on a `PolyData` to a target point, and optionally return the distance to it.

I don't think it is possible to do this with existing filters, but happy to close this if it can.

