### PR TITLE
Correct reference to time values

### DIFF
--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -772,7 +772,7 @@ class OpenFOAMReader(BaseReader, PointCellDataSelection, TimeReader):
     def set_active_time_value(self, time_value):  # noqa: D102
         if time_value not in self.time_values:
             raise ValueError(
-                f"Not a valid time {time_value} from available time values: {self.reader_time_values}"
+                f"Not a valid time {time_value} from available time values: {self.time_values}"
             )
         self.reader.UpdateTimeStep(time_value)
 

--- a/tests/utilities/test_reader.py
+++ b/tests/utilities/test_reader.py
@@ -461,6 +461,11 @@ def test_openfoamreader_active_time():
     reader.set_active_time_value(1.0)
     assert reader.active_time_value == 1.0
 
+    with pytest.raises(
+        ValueError, match=r'Not a valid .* time values: \[0.0, 0.5, 1.0, 1.5, 2.0, 2.5\]'
+    ):
+        reader.set_active_time_value(1000)
+
 
 def test_openfoamreader_read_data_time_value():
     reader = get_cavity_reader()


### PR DESCRIPTION
### Overview

`self.reader_time_values` is undefined in the OpenFOAMReader class and was resulting in a `NameError` instead of the intended `ValueError`.
