### PR TITLE
Revert "add in warning for anti-aliasing when vtk is compiled with egl"

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -30,7 +30,7 @@ from pyvista.utilities import (
     wrap,
 )
 
-from ..utilities.misc import PyvistaDeprecationWarning, uses_egl
+from ..utilities.misc import PyvistaDeprecationWarning
 from ..utilities.regression import image_from_window
 from ._plotting import _has_matplotlib, prepare_smooth_shading, process_opacity
 from .colors import Color, get_cmap_safe
@@ -108,7 +108,8 @@ def _warn_xserver():  # pragma: no cover
             return
 
         # Check if VTK has EGL support
-        if uses_egl():
+        ren_win_str = str(type(_vtk.vtkRenderWindow()))
+        if 'EGL' in ren_win_str or 'OSOpenGL' in ren_win_str:
             return
 
         warnings.warn(

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -3,7 +3,6 @@
 import collections.abc
 from functools import partial
 from typing import Sequence
-import warnings
 from weakref import proxy
 
 import numpy as np
@@ -11,7 +10,6 @@ import numpy as np
 import pyvista
 from pyvista import MAX_N_COLOR_BARS, _vtk
 from pyvista.utilities import check_depth_peeling, try_callback, wrap
-from pyvista.utilities.misc import uses_egl
 
 from .camera import Camera
 from .charts import Charts
@@ -442,12 +440,6 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         This tends to make edges appear softer and less pixelated.
 
-        Warnings
-        --------
-        Enabling this causes screenshots with vtk compiled with OSMesa to be
-        all black. This cannot be enabled when compiled with OSMesa (EGL). See
-        https://github.com/pyvista/pyvista/issues/2686 for more details.
-
         Examples
         --------
         >>> import pyvista
@@ -457,13 +449,6 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         >>> pl.show()
 
         """
-        if uses_egl():  # pragma: no cover
-            # only display the warning when not building documentation
-            if not pyvista.BUILDING_GALLERY:
-                warnings.warn(
-                    "VTK compiled with OSMesa does not properly support anti-aliasing and anti-aliasing will not be enabled."
-                )
-            return
         self.SetUseFXAA(True)
         self.Modified()
 

--- a/pyvista/utilities/misc.py
+++ b/pyvista/utilities/misc.py
@@ -57,10 +57,4 @@ def VTKVersionInfo():
     return version_info(major, minor, micro)
 
 
-def uses_egl() -> bool:
-    """Check if VTK has been compiled with EGL support via OSMesa."""
-    ren_win_str = str(type(_vtk.vtkRenderWindow()))
-    return 'EGL' in ren_win_str or 'OSOpenGL' in ren_win_str
-
-
 vtk_version_info = VTKVersionInfo()


### PR DESCRIPTION
Suggest reverging pyvista/pyvista#2694

I'd still like to emit a warning when using anti-aliasing with EGL, but for the time being this breaks the doc build.

Better solution would be to emit the warning always, but ignore the warning in the doc build. Suggestions welcome. If we can't come up with something, we can either do a full revert, or potentially even `print`, though I loath printing. Logging is an option too.