### PR TITLE
Add gallery building flag to environment variables

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,6 +40,7 @@ if not os.path.exists(pyvista.FIGURE_PATH):
 
 # necessary when building the sphinx gallery
 pyvista.BUILDING_GALLERY = True
+os.environ['PYVISTA_BUILDING_GALLERY'] = 'true'
 
 # SG warnings
 import warnings


### PR DESCRIPTION
This is an alternative to https://github.com/pyvista/pyvista/pull/2744, cc. @akaszynski 

I could reproduce the warnings being emitted during a local doc build with OSMesa-built VTK. The only possible cause is that the `pyvista.BUILDING_GALLERY` flag was sometimes unset during doc building, for which the only reasonable explanation is that `sphinx` spawns subprocesses that don't themselves execute `doc/conf.py`. So setting the `PYVISTA_BUILDING_GALLERY` envvar should set up child processes, and this seems to fix my local doc build.

Side note: when I use [our OSMesa-built VTK](https://github.com/pyvista/pyvista-wheels/raw/main/vtk-osmesa-9.1.0-cp39-cp39-linux_x86_64.whl) with `libosmesa6` on debian, I get a bunch of the following errors:
```
 2022-06-05 13:33:24.714 (1293.272s) [        31440740]   vtkTextureObject.cxx:1025   ERR| vtkTextureObject (0x1bd06450): Attempt to use a texture buffer exceeding your hardware's limits. This can happen when trying to color by cell data with a large dataset. Hardware limit is 65536 values while 871306 was requested.
```
I don't know if this is due to the VTK build or the libosmesa system package, but I wonder if we can do something about this, and whether this poses an issue during the actual doc build.