### PR TITLE
skip or avoid creating files in doc build

### DIFF
--- a/examples/00-load/load-vrml.py
+++ b/examples/00-load/load-vrml.py
@@ -1,5 +1,5 @@
 """
-.. _load_vrml:
+.. _load_vrml_example:
 
 Working with VRML Files
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -3469,17 +3469,21 @@ def download_single_sphere_animation(load=True):  # pragma: no cover
     Examples
     --------
     >>> import os
-    >>> import tempfile
+    >>> from tempfile import mkdtemp
     >>> import pyvista
     >>> from pyvista import examples
     >>> filename = examples.download_single_sphere_animation(load=False)
     >>> reader = pyvista.PVDReader(filename)
+
+    Write the gif to a temporary directory. Normally you would write to a local
+    path.
+
+    >>> gif_filename = os.path.join(mkdtemp(), 'single_sphere.gif')
+
+    Generate the animation.
+
     >>> plotter = pyvista.Plotter()
-    >>> filename = os.path.join(
-    ...     tempfile._get_default_tempdir(),
-    ...     next(tempfile._get_candidate_names()) + '.gif'
-    ... )
-    >>> plotter.open_gif(filename)
+    >>> plotter.open_gif(gif_filename)
     >>> for time_value in reader.time_values:
     ...     reader.set_active_time_value(time_value)
     ...     mesh = reader.read()
@@ -3515,17 +3519,21 @@ def download_dual_sphere_animation(load=True):  # pragma: no cover
     Examples
     --------
     >>> import os
-    >>> import tempfile
+    >>> from tempfile import mkdtemp
     >>> import pyvista
     >>> from pyvista import examples
     >>> filename = examples.download_dual_sphere_animation(load=False)
     >>> reader = pyvista.PVDReader(filename)
+
+    Write the gif to a temporary directory. Normally you would write to a local
+    path.
+
+    >>> gif_filename = os.path.join(mkdtemp(), 'dual_sphere.gif')
+
+    Generate the animation.
+
     >>> plotter = pyvista.Plotter()
-    >>> filename = os.path.join(
-    ...     tempfile._get_default_tempdir(),
-    ...     next(tempfile._get_candidate_names()) + '.gif'
-    ... )
-    >>> plotter.open_gif(filename)
+    >>> plotter.open_gif(gif_filename)
     >>> for time_value in reader.time_values:
     ...     reader.set_active_time_value(time_value)
     ...     mesh = reader.read()

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -3468,12 +3468,18 @@ def download_single_sphere_animation(load=True):  # pragma: no cover
 
     Examples
     --------
+    >>> import os
+    >>> import tempfile
     >>> import pyvista
     >>> from pyvista import examples
     >>> filename = examples.download_single_sphere_animation(load=False)
     >>> reader = pyvista.PVDReader(filename)
     >>> plotter = pyvista.Plotter()
-    >>> plotter.open_gif("single_sphere_pvd.gif")
+    >>> filename = os.path.join(
+    ...     tempfile._get_default_tempdir(),
+    ...     next(tempfile._get_candidate_names()) + '.gif'
+    ... )
+    >>> plotter.open_gif(filename)
     >>> for time_value in reader.time_values:
     ...     reader.set_active_time_value(time_value)
     ...     mesh = reader.read()
@@ -3508,12 +3514,18 @@ def download_dual_sphere_animation(load=True):  # pragma: no cover
 
     Examples
     --------
+    >>> import os
+    >>> import tempfile
     >>> import pyvista
     >>> from pyvista import examples
     >>> filename = examples.download_dual_sphere_animation(load=False)
     >>> reader = pyvista.PVDReader(filename)
     >>> plotter = pyvista.Plotter()
-    >>> plotter.open_gif("sphere_pvd.gif")
+    >>> filename = os.path.join(
+    ...     tempfile._get_default_tempdir(),
+    ...     next(tempfile._get_candidate_names()) + '.gif'
+    ... )
+    >>> plotter.open_gif(filename)
     >>> for time_value in reader.time_values:
     ...     reader.set_active_time_value(time_value)
     ...     mesh = reader.read()

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -379,7 +379,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> pl.import_vrml(sextant_file)  # doctest:+SKIP
         >>> pl.show()  # doctest:+SKIP
 
-        See :ref:`load_vrml` for a full example using this method.
+        See :ref:`load_vrml_example` for a full example using this method.
 
         """
         filename = os.path.abspath(os.path.expanduser(str(filename)))
@@ -397,9 +397,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def export_html(self, filename, backend='pythreejs'):
         """Export this plotter as an interactive scene to a HTML file.
 
-        You have the option of exposing the scene using either vtk.js (using ``panel``) or
-        three.js (using ``pythreejs``), both of which are excellent JavaScript libraries to visualize
-        small to moderately complex scenes for scientific visualization.
+        You have the option of exposing the scene using either vtk.js (using
+        ``panel``) or three.js (using ``pythreejs``), both of which are
+        excellent JavaScript libraries to visualize small to moderately complex
+        scenes for scientific visualization.
 
         Parameters
         ----------
@@ -635,7 +636,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> from pyvista import examples
         >>> pl = pyvista.Plotter()
         >>> _ = pl.add_mesh(examples.load_hexbeam())
-        >>> pl.export_vrml("sample")
+        >>> pl.export_vrml("sample")  # doctest:+SKIP
+
         """
         if not hasattr(self, "ren_win"):
             raise RuntimeError("This plotter has been closed and cannot be shown.")

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4450,12 +4450,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         --------
         Plot an orbit around the earth.  Save the gif as a temporary file.
 
-        >>> import tempfile
         >>> import os
+        >>> from tempfile import mkdtemp
         >>> import pyvista
-        >>> filename = os.path.join(tempfile._get_default_tempdir(),
-        ...                         next(tempfile._get_candidate_names()) + '.gif')
         >>> from pyvista import examples
+        >>> filename = os.path.join(mkdtemp(), 'orbit.gif')
         >>> plotter = pyvista.Plotter(window_size=[300, 300])
         >>> _ = plotter.add_mesh(examples.load_globe(), smooth_shading=True)
         >>> plotter.open_gif(filename)

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -84,8 +84,8 @@ def load_theme(filename):
     --------
     >>> import pyvista
     >>> theme = pyvista.themes.DefaultTheme()
-    >>> theme.save('my_theme.json')
-    >>> loaded_theme = pyvista.load_theme('my_theme.json')
+    >>> theme.save('my_theme.json')  # doctest:+SKIP
+    >>> loaded_theme = pyvista.load_theme('my_theme.json')  # doctest:+SKIP
 
     """
     with open(filename) as f:
@@ -2173,8 +2173,8 @@ class DefaultTheme(_ThemeConfig):
         >>> import pyvista
         >>> theme = pyvista.themes.DefaultTheme()
         >>> theme.background = 'white'
-        >>> theme.save('my_theme.json')
-        >>> loaded_theme = pyvista.load_theme('my_theme.json')
+        >>> theme.save('my_theme.json')  # doctest:+SKIP
+        >>> loaded_theme = pyvista.load_theme('my_theme.json')  # doctest:+SKIP
 
         """
         with open(filename, 'w') as f:


### PR DESCRIPTION
The following files are created on a fresh build of the documentation:

- `doc/my_theme.json`
- `doc/sample`
- `my_theme.json`
- `sample`
- `single_sphere_pvd.gif`
- `sphere_pvd.gif`

This cleans up our documentation build by avoiding generating these files by either skipping tests or being smart about how we generate example image files.
