### PR TITLE
Add fill arg to Polygon

### DIFF
--- a/doc/user-guide/vtk_to_pyvista.rst
+++ b/doc/user-guide/vtk_to_pyvista.rst
@@ -333,7 +333,7 @@ In this manner, you can get the "best of both worlds" should you need
 the flexibility of PyVista and the raw power of VTK.
 
 .. note::
-   You can use :func:`pyvista.Circle` for a one line replacement of
+   You can use :func:`pyvista.Polygon` for a one line replacement of
    the above VTK code.
 
 

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -750,7 +750,7 @@ def Cone(
     return pyvista.wrap(src.GetOutput())
 
 
-def Polygon(center=(0.0, 0.0, 0.0), radius=1, normal=(0, 0, 1), n_sides=6):
+def Polygon(center=(0.0, 0.0, 0.0), radius=1, normal=(0, 0, 1), n_sides=6, generate_polygon=True):
     """Create a polygon.
 
     Parameters
@@ -768,6 +768,9 @@ def Polygon(center=(0.0, 0.0, 0.0), radius=1, normal=(0, 0, 1), n_sides=6):
     n_sides : int, optional
         Number of sides of the polygon.
 
+    generate_polygon : bool, optional
+        Enable or disable the producing filled polygons.
+
     Returns
     -------
     pyvista.PolyData
@@ -783,6 +786,10 @@ def Polygon(center=(0.0, 0.0, 0.0), radius=1, normal=(0, 0, 1), n_sides=6):
 
     """
     src = _vtk.vtkRegularPolygonSource()
+    if generate_polygon:
+        src.GeneratePolygonOn()
+    else:
+        src.GeneratePolygonOff()
     src.SetCenter(center)
     src.SetNumberOfSides(n_sides)
     src.SetRadius(radius)

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -750,7 +750,7 @@ def Cone(
     return pyvista.wrap(src.GetOutput())
 
 
-def Polygon(center=(0.0, 0.0, 0.0), radius=1, normal=(0, 0, 1), n_sides=6, generate_polygon=True):
+def Polygon(center=(0.0, 0.0, 0.0), radius=1, normal=(0, 0, 1), n_sides=6, fill=True):
     """Create a polygon.
 
     Parameters
@@ -768,8 +768,8 @@ def Polygon(center=(0.0, 0.0, 0.0), radius=1, normal=(0, 0, 1), n_sides=6, gener
     n_sides : int, optional
         Number of sides of the polygon.
 
-    generate_polygon : bool, optional
-        Enable or disable the producing filled polygons.
+    fill : bool, optional
+        Enable or disable producing filled polygons.
 
     Returns
     -------
@@ -786,10 +786,7 @@ def Polygon(center=(0.0, 0.0, 0.0), radius=1, normal=(0, 0, 1), n_sides=6, gener
 
     """
     src = _vtk.vtkRegularPolygonSource()
-    if generate_polygon:
-        src.GeneratePolygonOn()
-    else:
-        src.GeneratePolygonOff()
+    src.SetGeneratePolygon(generate_polygon)
     src.SetCenter(center)
     src.SetNumberOfSides(n_sides)
     src.SetRadius(radius)

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -786,7 +786,7 @@ def Polygon(center=(0.0, 0.0, 0.0), radius=1, normal=(0, 0, 1), n_sides=6, fill=
 
     """
     src = _vtk.vtkRegularPolygonSource()
-    src.SetGeneratePolygon(generate_polygon)
+    src.SetGeneratePolygon(fill)
     src.SetCenter(center)
     src.SetNumberOfSides(n_sides)
     src.SetRadius(radius)

--- a/tests/test_geometric_objects.py
+++ b/tests/test_geometric_objects.py
@@ -141,6 +141,11 @@ def test_polygon():
     geom = pyvista.Polygon()
     assert np.any(geom.points)
 
+    geom1 = pyvista.Polygon(generate_polygon=True)
+    assert geom.n_cells == 2
+    geom2 = pyvista.Polygon(generate_polygon=False)
+    assert geom.n_cells == 1
+
 
 def test_disc():
     geom = pyvista.Disc()

--- a/tests/test_geometric_objects.py
+++ b/tests/test_geometric_objects.py
@@ -142,9 +142,9 @@ def test_polygon():
     assert np.any(geom.points)
 
     geom1 = pyvista.Polygon(generate_polygon=True)
-    assert geom.n_cells == 2
+    assert geom1.n_cells == 2
     geom2 = pyvista.Polygon(generate_polygon=False)
-    assert geom.n_cells == 1
+    assert geom2.n_cells == 1
 
 
 def test_disc():

--- a/tests/test_geometric_objects.py
+++ b/tests/test_geometric_objects.py
@@ -141,9 +141,9 @@ def test_polygon():
     geom = pyvista.Polygon()
     assert np.any(geom.points)
 
-    geom1 = pyvista.Polygon(generate_polygon=True)
+    geom1 = pyvista.Polygon(fill=True)
     assert geom1.n_cells == 2
-    geom2 = pyvista.Polygon(generate_polygon=False)
+    geom2 = pyvista.Polygon(fill=False)
     assert geom2.n_cells == 1
 
 


### PR DESCRIPTION
### Overview

Add `fill` arg to `Polygon` function to realize the [content of the document](https://docs.pyvista.org/user-guide/vtk_to_pyvista.html#tradeoffs).

```python
import pyvista


geom1 = pyvista.Polygon(fill=True)
geom2 = pyvista.Polygon(fill=False)

pl = pyvista.Plotter(shape=(1, 2))
pl.subplot(0, 0)
pl.add_text("fill=True")
pl.add_mesh(geom1)
pl.subplot(0, 1)
pl.add_text("fill=False")
pl.add_mesh(geom2)
pl.show(cpos="xy")
```
![test](https://user-images.githubusercontent.com/7513610/173181663-389feaca-0e2d-4c7b-9bda-40f4e1ac955e.png)


<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- Inspired from https://docs.pyvista.org/user-guide/vtk_to_pyvista.html#tradeoffs
- [VTK document](https://vtk.org/doc/nightly/html/classvtkRegularPolygonSource.html#a35a78b78294e362cfd5c46494e048561).

