### PR TITLE
Return correct scalar type for pyvista_ndarray

### DIFF
--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -1,11 +1,33 @@
 """Contains pyvista_ndarray a numpy ndarray type used in pyvista."""
 from collections.abc import Iterable
+from functools import wraps
 from typing import Union
 
 import numpy as np
 
 from pyvista import _vtk
 from pyvista.utilities.helpers import FieldAssociation, convert_array
+
+
+def _to_numpy_dtype(array):
+    """Return a NumPy dtype when an array is 0d.
+
+    Otherwise, returns the array.
+
+    Parameters
+    ----------
+    array : numpy.ndarray
+        NumPy array.
+
+    Returns
+    -------
+    numpy.ndarray or np.dtype
+        NumPy dtype when an array is 0d. Otherwise, returns the array.
+
+    """
+    if array.shape == ():
+        return array.dtype.type(array.item(0))
+    return array
 
 
 class pyvista_ndarray(np.ndarray):
@@ -71,5 +93,40 @@ class pyvista_ndarray(np.ndarray):
         dataset = self.dataset
         if dataset is not None and dataset.Get():
             dataset.Get().Modified()
+
+    @wraps(np.min)
+    def min(self, *args, **kwargs):
+        """Wrap numpy.min to return a single value when applicable."""
+        return _to_numpy_dtype(super().min(*args, **kwargs))
+
+    @wraps(np.mean)
+    def mean(self, *args, **kwargs):
+        """Wrap numpy.mean to return a single value when applicable."""
+        return _to_numpy_dtype(super().mean(*args, **kwargs))
+
+    @wraps(np.max)
+    def max(self, *args, **kwargs):
+        """Wrap numpy.max to return a single value when applicable."""
+        return _to_numpy_dtype(super().max(*args, **kwargs))
+
+    @wraps(np.sum)
+    def sum(self, *args, **kwargs):
+        """Wrap numpy.sum to return a single value when applicable."""
+        return _to_numpy_dtype(super().sum(*args, **kwargs))
+
+    @wraps(np.prod)
+    def prod(self, *args, **kwargs):
+        """Wrap numpy.prod to return a single value when applicable."""
+        return _to_numpy_dtype(super().prod(*args, **kwargs))
+
+    @wraps(np.std)
+    def std(self, *args, **kwargs):
+        """Wrap numpy.std to return a single value when applicable."""
+        return _to_numpy_dtype(super().std(*args, **kwargs))
+
+    @wraps(np.ptp)
+    def ptp(self, *args, **kwargs):
+        """Wrap numpy.ptp to return a single value when applicable."""
+        return _to_numpy_dtype(super().ptp(*args, **kwargs))
 
     __getattr__ = _vtk.VTKArray.__getattr__

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -82,6 +82,6 @@ class pyvista_ndarray(np.ndarray):
             return np.ndarray.__array_wrap__(self, out_arr, context)
 
         # Match numpy's behavior and return a numpy dtype scalar
-        return out_arr.dtype.type(out_arr.item(0))
+        return out_arr[()]
 
     __getattr__ = _vtk.VTKArray.__getattr__

--- a/tests/test_pyvista_ndarray.py
+++ b/tests/test_pyvista_ndarray.py
@@ -75,13 +75,13 @@ def test_min(pv_ndarray_1d):
     arr = np.array(pv_ndarray_1d)
     assert pv_ndarray_1d.min() == arr.min()
 
-    # also ensure that methods like return float-like values just like numpy
+    # also ensure that methods return float-like values just like numpy
     assert isinstance(pv_ndarray_1d.min(), type(arr.min()))
 
 
 def test_squeeze(pv_ndarray_1d):
     reshaped_pvarr = pv_ndarray_1d.reshape((3, 1))
-    assert np.allclose(reshaped_pvarr.squeeze(), np.array(reshaped_pvarr.squeeze()))
+    assert np.array_equal(reshaped_pvarr.squeeze(), np.array(reshaped_pvarr.squeeze()))
 
 
 def test_tobytes(pv_ndarray_1d):
@@ -92,4 +92,4 @@ def test_add_1d():
     # ensure that 1d single value arrays match numpy
     pv_arr = pyvista_ndarray([1]) + pyvista_ndarray([1])
     np_arr = np.array([1]) + np.array([1])
-    assert np.allclose(pv_arr, np_arr)
+    assert np.array_equal(pv_arr, np_arr)

--- a/tests/test_pyvista_ndarray.py
+++ b/tests/test_pyvista_ndarray.py
@@ -64,3 +64,17 @@ def test_slices_are_associated_single_index():
     assert points[1, 1].VTKObject == points.VTKObject
     assert points[1, 1].dataset.Get() == points.dataset.Get()
     assert points[1, 1].association == points.association
+
+
+def test_methods_return_float():
+    # ensure that methods like np.sum return float-like values just like numpy
+    data = [1.2, 1.3]
+    arr = np.array(data)
+    pvarr = pyvista_ndarray(data)
+    assert isinstance(pvarr.min(), type(arr.min()))
+    assert isinstance(pvarr.mean(), type(arr.mean()))
+    assert isinstance(pvarr.max(), type(arr.max()))
+    assert isinstance(pvarr.sum(), type(arr.sum()))
+    assert isinstance(pvarr.prod(), type(arr.prod()))
+    assert isinstance(pvarr.std(), type(arr.std()))
+    assert isinstance(pvarr.ptp(), type(arr.ptp()))

--- a/tests/test_pyvista_ndarray.py
+++ b/tests/test_pyvista_ndarray.py
@@ -7,6 +7,11 @@ import vtk as _vtk
 from pyvista import examples, pyvista_ndarray
 
 
+@pytest.fixture
+def pv_ndarray_1d():
+    return pyvista_ndarray([1.0, 2.0, 3.0])
+
+
 def test_slices_are_associated():
     dataset = examples.load_structured()
     points = pyvista_ndarray(dataset.GetPoints().GetData(), dataset=dataset)
@@ -66,15 +71,25 @@ def test_slices_are_associated_single_index():
     assert points[1, 1].association == points.association
 
 
-def test_methods_return_float():
-    # ensure that methods like np.sum return float-like values just like numpy
-    data = [1.2, 1.3]
-    arr = np.array(data)
-    pvarr = pyvista_ndarray(data)
-    assert isinstance(pvarr.min(), type(arr.min()))
-    assert isinstance(pvarr.mean(), type(arr.mean()))
-    assert isinstance(pvarr.max(), type(arr.max()))
-    assert isinstance(pvarr.sum(), type(arr.sum()))
-    assert isinstance(pvarr.prod(), type(arr.prod()))
-    assert isinstance(pvarr.std(), type(arr.std()))
-    assert isinstance(pvarr.ptp(), type(arr.ptp()))
+def test_min(pv_ndarray_1d):
+    arr = np.array(pv_ndarray_1d)
+    assert pv_ndarray_1d.min() == arr.min()
+
+    # also ensure that methods like return float-like values just like numpy
+    assert isinstance(pv_ndarray_1d.min(), type(arr.min()))
+
+
+def test_squeeze(pv_ndarray_1d):
+    reshaped_pvarr = pv_ndarray_1d.reshape((3, 1))
+    assert np.allclose(reshaped_pvarr.squeeze(), np.array(reshaped_pvarr.squeeze()))
+
+
+def test_tobytes(pv_ndarray_1d):
+    assert pv_ndarray_1d.tobytes() == np.array(pv_ndarray_1d).tobytes()
+
+
+def test_add_1d():
+    # ensure that 1d single value arrays match numpy
+    pv_arr = pyvista_ndarray([1]) + pyvista_ndarray([1])
+    np_arr = np.array([1]) + np.array([1])
+    assert np.allclose(pv_arr, np_arr)


### PR DESCRIPTION
### Problem

In our current implementation, the return value `pyvista.pyvista_ndarray` of ufuncs like `numpy.max` or `numpy.sum` varies from the return value of `numpy.ndarray`. For example:

```py
>>> import numpy as np
>>> import pyvista as pv

Numpy returns a single numpy int

>>> arr = np.array([1, 2, 3])
>>> arr.max()
3
>>> type(arr.max())
np.int64

While pyvista returns a 0d array.

>>> pvarr = py.pyvista_ndarray([1, 2, 3])
>>> pvarr.max()
pyvista_ndarray(3)
>>> type(pvarr.max())
pyvista.core.pyvista_ndarray.pyvista_ndarray
```

This leads to weird results (and confusion) when computing things as simple as:

```py
>>> sphere = pv.Sphere()
>>> pv.Sphere().points[:, 0].max()
pyvista_ndarray(0.4992667, dtype=float32)
```

### Proposal

This is a known issue and is discussed in [numpy #5819](https://github.com/numpy/numpy/issues/5819), and one of the suggestions is to override `__array_wrap__`. This PR suggests we modify the behavior to return a numpy scalar whenever the return type is 0d, thus matching numpy's behavior for any ufunc that are direct attributes to the `pyvista_ndarray` like `.sum()` or `.max()`.

Since the underlying [vtkAbstractArray](https://vtk.org/doc/nightly/html/classvtkAbstractArray.html) does not support 0d arrays, it makes sense that we always return a scalar.

As for matching ``numpy``'s scalar type, in the rare, rare edge case outlined by @adeak in [this comment](https://github.com/pyvista/pyvista/pull/1953#issuecomment-1146896567), and for consistency with numpy, it is best to also return a numpy dtype rather than a native Python scalar.

As an aside, I had no idea that ``numpy.max`` returned numpy data like `numpy.int64` types rather than native Python types (e.g. `int`).
