### PR TITLE
Fail when regression image is missing on CI

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -189,7 +189,7 @@ jobs:
 
       - name: Unit Testing
         run: |
-          xvfb-run pytest -v --cov pyvista --cov-report xml
+          xvfb-run pytest -v --cov pyvista --cov-report xml --fail_extra_image_cache
 
       - uses: codecov/codecov-action@v2
         if: matrix.python-version == '3.8'
@@ -270,4 +270,4 @@ jobs:
         run: pip install -r requirements_test.txt
 
       - name: Test Core API
-        run: python -m pytest --cov -v . --fail_extra_image_cache
+        run: python -m pytest --cov -v .

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -270,4 +270,4 @@ jobs:
         run: pip install -r requirements_test.txt
 
       - name: Test Core API
-        run: python -m pytest --cov -v .
+        run: python -m pytest --cov -v . --fail_extra_image_cache

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,3 +101,9 @@ def pointset():
     rng = default_rng(0)
     points = rng.random((10, 3))
     return pyvista.PointSet(points)
+
+
+def pytest_addoption(parser):
+    parser.addoption("--reset_image_cache", action='store_true', default=False)
+    parser.addoption("--ignore_image_cache", action='store_true', default=False)
+    parser.addoption("--fail_extra_image_cache", action='store_true', default=False)

--- a/tests/plotting/conftest.py
+++ b/tests/plotting/conftest.py
@@ -12,11 +12,6 @@ pyvista.global_theme.load_theme(pyvista.themes._TestingTheme())
 pyvista.OFF_SCREEN = True
 
 
-def pytest_addoption(parser):
-    parser.addoption("--reset_image_cache", action='store_true', default=False)
-    parser.addoption("--ignore_image_cache", action='store_true', default=False)
-
-
 def _is_vtk(obj):
     try:
         return obj.__class__.__name__.startswith('vtk')

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -2337,12 +2337,3 @@ def test_ruler(sphere):
     plotter.add_ruler([-0.6, -0.6, 0], [0.6, -0.6, 0], font_size_factor=1.2)
     plotter.view_xy()
     plotter.show(before_close_callback=verify_cache_image)
-
-
-def test_no_image(sphere):
-    sphere = pyvista.Sphere()
-    plotter = pyvista.Plotter()
-    plotter.add_mesh(sphere)
-    plotter.add_ruler([-0.6, -0.6, 0], [0.6, -0.6, 0], font_size_factor=1.2)
-    plotter.view_xy()
-    plotter.show(before_close_callback=verify_cache_image)

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -104,9 +104,10 @@ WINDOWS_SKIP_IMAGE_CACHE = {
 # this must be a session fixture to ensure this runs before any other test
 @pytest.fixture(scope="session", autouse=True)
 def get_cmd_opt(pytestconfig):
-    global glb_reset_image_cache, glb_ignore_image_cache
+    global glb_reset_image_cache, glb_ignore_image_cache, glb_fail_extra_image_cache
     glb_reset_image_cache = pytestconfig.getoption('reset_image_cache')
     glb_ignore_image_cache = pytestconfig.getoption('ignore_image_cache')
+    glb_fail_extra_image_cache = pytestconfig.getoption('fail_extra_image_cache')
 
 
 def verify_cache_image(plotter):
@@ -126,7 +127,7 @@ def verify_cache_image(plotter):
     plotter.show(before_close_callback=verify_cache_image)
 
     """
-    global glb_reset_image_cache, glb_ignore_image_cache
+    global glb_reset_image_cache, glb_ignore_image_cache, glb_fail_extra_image_cache
 
     # Image cache is only valid for VTK9+
     if not VTK9:
@@ -161,13 +162,15 @@ def verify_cache_image(plotter):
     # cached image name
     image_filename = os.path.join(IMAGE_CACHE_DIR, test_name[5:] + '.png')
 
+    if glb_ignore_image_cache:
+        return
+
+    if not os.path.isfile(image_filename) and glb_fail_extra_image_cache:
+        raise RuntimeError(f"{image_filename} does not exist in image cache")
     # simply save the last screenshot if it doesn't exist or the cache
     # is being reset.
     if glb_reset_image_cache or not os.path.isfile(image_filename):
         return plotter.screenshot(image_filename)
-
-    if glb_ignore_image_cache:
-        return
 
     # otherwise, compare with the existing cached image
     error = pyvista.compare_images(image_filename, plotter)
@@ -2328,6 +2331,15 @@ def test_write_gif(sphere, tmpdir):
 
 
 def test_ruler(sphere):
+    sphere = pyvista.Sphere()
+    plotter = pyvista.Plotter()
+    plotter.add_mesh(sphere)
+    plotter.add_ruler([-0.6, -0.6, 0], [0.6, -0.6, 0], font_size_factor=1.2)
+    plotter.view_xy()
+    plotter.show(before_close_callback=verify_cache_image)
+
+
+def test_no_image(sphere):
     sphere = pyvista.Sphere()
     plotter = pyvista.Plotter()
     plotter.add_mesh(sphere)


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->
Closes #2766.  This PR adds option to pytest to fail image regression test when image is missing.

This is used is in the CI.

### Details

The first commit has a test without an image to test CI, will make "ready to review" when removed.