### PR TITLE
deep/shallow copy metadata

### DIFF
--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -651,7 +651,7 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
         """Return the number of blocks."""
         return self.n_blocks
 
-    def copy_meta_from(self, ido):
+    def copy_meta_from(self, ido, deep):
         """Copy pyvista meta data onto this object from another object."""
         # Note that `pyvista.MultiBlock` datasets currently don't have any meta.
         # This method is here for consistency with the rest of the API and
@@ -687,6 +687,6 @@ class MultiBlock(_vtk.vtkMultiBlockDataSet, CompositeFilters, DataObject):
             newobject.deep_copy(self)
         else:
             newobject.shallow_copy(self)
-        newobject.copy_meta_from(self)
+        newobject.copy_meta_from(self, deep)
         newobject.wrap_nested()
         return newobject

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -218,7 +218,7 @@ class DataObject:
         """
         raise NotImplementedError('Called only by the inherited class')
 
-    def copy_meta_from(self, ido):  # pragma: no cover
+    def copy_meta_from(self, ido, deep):  # pragma: no cover
         """Copy pyvista meta data onto this object from another object."""
         pass  # called only by the inherited class
 
@@ -256,7 +256,7 @@ class DataObject:
             newobject.deep_copy(self)
         else:
             newobject.shallow_copy(self)
-        newobject.copy_meta_from(self)
+        newobject.copy_meta_from(self, deep)
         return newobject
 
     def __eq__(self, other):

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -50,6 +50,10 @@ class ActiveArrayInfo:
         self.association = association
         self.name = name
 
+    def copy(self):
+        """Return a copy of this object."""
+        return ActiveArrayInfo(self.association, self.name)
+
     def __getstate__(self):
         """Support pickling."""
         state = self.__dict__.copy()
@@ -1407,7 +1411,7 @@ class DataSet(DataSetFilters, DataObject):
             t, transform_all_input_vectors=transform_all_input_vectors, inplace=inplace
         )
 
-    def copy_meta_from(self, ido: 'DataSet'):
+    def copy_meta_from(self, ido: 'DataSet', deep: bool = True):
         """Copy pyvista meta data onto this object from another object.
 
         Parameters
@@ -1415,11 +1419,20 @@ class DataSet(DataSetFilters, DataObject):
         ido : pyvista.DataSet
             Dataset to copy the metadata from.
 
+        deep : bool, optional
+            Deep or shallow copy.
+
         """
-        self._active_scalars_info = ido.active_scalars_info
-        self._active_vectors_info = ido.active_vectors_info
         self.clear_textures()
-        self._textures = {name: tex.copy() for name, tex in ido.textures.items()}
+
+        if deep:
+            self._active_scalars_info = ido.active_scalars_info.copy()
+            self._active_vectors_info = ido.active_vectors_info.copy()
+            self._textures = {name: tex.copy() for name, tex in ido.textures.items()}
+        else:
+            self._active_scalars_info = ido.active_scalars_info
+            self._active_vectors_info = ido.active_vectors_info
+            self._textures = ido.textures
 
     @property
     def point_arrays(self) -> DataSetAttributes:  # pragma: no cover
@@ -2035,7 +2048,7 @@ class DataSet(DataSetFilters, DataObject):
             )
         self.deep_copy(mesh)
         if is_pyvista_dataset(mesh):
-            self.copy_meta_from(mesh)
+            self.copy_meta_from(mesh, deep=True)
 
     def cast_to_unstructured_grid(self) -> 'pyvista.UnstructuredGrid':
         """Get a new representation of this object as a :class:`pyvista.UnstructuredGrid`.

--- a/pyvista/core/filters/__init__.py
+++ b/pyvista/core/filters/__init__.py
@@ -43,7 +43,7 @@ def _get_output(
     ido = algorithm.GetInputDataObject(iport, iconnection)
     data = wrap(algorithm.GetOutputDataObject(oport))
     if not isinstance(data, pyvista.MultiBlock):
-        data.copy_meta_from(ido)
+        data.copy_meta_from(ido, deep=False)
         if not data.field_data and ido.field_data:
             data.field_data.update(ido.field_data)
         if active_scalars is not None:

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -218,7 +218,7 @@ class UniformGridFilters(DataSetFilters):
         fixed.point_data.update(result.point_data)
         fixed.cell_data.update(result.cell_data)
         fixed.field_data.update(result.field_data)
-        fixed.copy_meta_from(result)
+        fixed.copy_meta_from(result, deep=True)
         return fixed
 
     def image_dilate_erode(

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -762,5 +762,5 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         grid.point_data.update(self.point_data)
         grid.cell_data.update(self.cell_data)
         grid.field_data.update(self.field_data)
-        grid.copy_meta_from(self)
+        grid.copy_meta_from(self, deep=True)
         return grid

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -185,6 +185,23 @@ def test_copy(grid):
     assert np.all(grid_copy_shallow.points[0] == grid.points[0])
 
 
+def test_copy_metadata(globe):
+    """Ensure metadata is copied correctly."""
+
+    globe_shallow = globe.copy(deep=False)
+    assert globe_shallow._active_scalars_info is globe._active_scalars_info
+    assert globe.textures is globe_shallow.textures
+
+    globe_deep = globe.copy(deep=True)
+    assert globe_deep._active_scalars_info is not globe._active_scalars_info
+    assert globe_deep.textures is not globe_shallow.textures
+
+    globe.clear_textures()
+    assert not globe.textures
+    assert globe_deep.textures
+    assert not globe_shallow.textures
+
+
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=None)
 @given(rotate_amounts=n_numbers(4), translate_amounts=n_numbers(3))
 def test_translate_should_match_vtk_transformation(rotate_amounts, translate_amounts, grid):


### PR DESCRIPTION
### Problem

As pointed out in [this comment](https://github.com/pyvista/pyvista/pull/2773#discussion_r895136088), metadata is always shallow copied (or not at all) when copying datasets:

```py
>>> import numpy as np
>>> import pyvista as pv
>>> sphere_a = pv.Sphere()
>>> sphere_a['data0'] = np.random.random((sphere_a.n_points, 3))

>>> sphere_b = sphere_a.copy(deep=True)
>>> sphere_a._active_scalars_info is sphere_b._active_scalars_info
True
```

This should be `False`.

On the other hand, the textures themselves are always shallow copied, but a new set is created, being neither a shallow or deep copy.


### Solution

This PR cleans up `copy_meta_from` and cleans up the implementation to either perform a true "deep copy" or "shallow copy" depending on the `deep` parameter.
