### PR TITLE
Prevent AttributeError when deleting a partially initialized Plotter

### DIFF
--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -1157,13 +1157,12 @@ class PickingHelper:
         >>> pl.disable_picking()
 
         """
-        if self._picker is not None:
+        if getattr(self, '_picker', None):
             self._picker.RemoveObservers(_vtk.vtkCommand.EndPickEvent)
 
         # remove left clicking observer if available
-        if hasattr(self, 'iren'):
-            if self.iren is not None:
-                self.iren.remove_observer(self._picking_left_clicking_observer)
+        if getattr(self, 'iren', None):
+            self.iren.remove_observer(self._picking_left_clicking_observer)
         self._picking_left_clicking_observer = None
 
         # remove any picking text


### PR DESCRIPTION
Breaking a `Plotter` on `__init__()` led to _two_ errors:
```py
>>> pv.Plotter(potato='invalid')
Exception ignored in: <function BasePlotter.__del__ at 0x7fe0183279d0>
Traceback (most recent call last):
  File "/home/adeak/pyvista/pyvista/plotting/plotting.py", line 4595, in __del__
    self.deep_clean()
  File "/home/adeak/pyvista/pyvista/plotting/plotting.py", line 3348, in deep_clean
    self.disable_picking()
  File "/home/adeak/pyvista/pyvista/plotting/picking.py", line 1160, in disable_picking
    if self._picker is not None:
AttributeError: 'Plotter' object has no attribute '_picker'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __init__() got an unexpected keyword argument 'potato'
```

Guarding against attribute access of `self._picker` in `Plotter.disable_picking()` (called during `__del__()`) fixes this:
```py
>>> pv.Plotter(potato='invalid')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __init__() got an unexpected keyword argument 'potato'
```