### PR TITLE
skip if unable to create a matplotlib figure

### DIFF
--- a/pyvista/utilities/misc.py
+++ b/pyvista/utilities/misc.py
@@ -106,4 +106,16 @@ def copy_vtk_array(array, deep=True):
     return new_array
 
 
+def can_create_mpl_figure():  # pragma: no cover
+    """Return if a figure can be created with matplotlib."""
+    try:
+        import matplotlib.pyplot as plt
+
+        figure = plt.figure()
+        plt.close(figure)
+        return True
+    except:
+        return False
+
+
 vtk_version_info = VTKVersionInfo()

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -14,7 +14,6 @@ import warnings
 
 from PIL import Image
 import imageio
-import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 import vtk
@@ -25,6 +24,7 @@ from pyvista._vtk import VTK9
 from pyvista.core.errors import DeprecationError
 from pyvista.plotting import system_supports_plotting
 from pyvista.plotting.plotting import SUPPORTED_FORMATS
+from pyvista.utilities.misc import can_create_mpl_figure
 
 # skip all tests if unable to render
 if not system_supports_plotting():
@@ -46,6 +46,10 @@ except:  # noqa: E722
 skip_windows = pytest.mark.skipif(os.name == 'nt', reason='Test fails on Windows')
 
 skip_9_1_0 = pytest.mark.skipif(pyvista.vtk_version_info < (9, 1, 0), reason="Requires VTK>=9.1.0")
+
+skip_no_mpl_figure = pytest.mark.skipif(
+    not can_create_mpl_figure(), reason="Cannot create a figure using matplotlib"
+)
 
 # Reset image cache with new images
 glb_reset_image_cache = False
@@ -2200,8 +2204,11 @@ def test_chart_plot():
 
 
 @skip_9_1_0
+@skip_no_mpl_figure
 def test_chart_matplotlib_plot():
     """Test integration with matplotlib"""
+    import matplotlib.pyplot as plt
+
     rng = np.random.default_rng(1)
     # First, create the matplotlib figure
     # use tight layout to keep axis labels visible on smaller figures

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -3,13 +3,13 @@
 import itertools
 import platform
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
 import pyvista
 from pyvista import examples
 from pyvista.plotting import charts, system_supports_plotting
+from pyvista.utilities.misc import can_create_mpl_figure
 
 skip_mac = pytest.mark.skipif(
     platform.system() == 'Darwin', reason='MacOS CI fails when downloading examples'
@@ -17,6 +17,10 @@ skip_mac = pytest.mark.skipif(
 
 skip_no_plotting = pytest.mark.skipif(
     not system_supports_plotting(), reason="Test requires system to support plotting"
+)
+
+skip_no_mpl_figure = pytest.mark.skipif(
+    not can_create_mpl_figure(), reason="Cannot create a figure using matplotlib"
 )
 
 # skip all tests if VTK<9.1.0
@@ -61,6 +65,8 @@ def chart_pie():
 
 @pytest.fixture
 def chart_mpl():
+    import matplotlib.pyplot as plt
+
     f, ax = plt.subplots()
     ax.plot([0, 1, 2], [3, 1, 2])
     return pyvista.ChartMPL(f)
@@ -331,6 +337,7 @@ def test_axis_label_font_size(chart_2d):
 
 
 @skip_no_plotting
+@skip_no_mpl_figure
 @pytest.mark.parametrize("chart_f", ("chart_2d", "chart_box", "chart_pie", "chart_mpl"))
 def test_chart_common(pl, chart_f, request):
     # Test the common chart functionalities
@@ -905,7 +912,10 @@ def test_chart_pie(pl, chart_pie, pie_plot):
 
 
 @skip_no_plotting
+@skip_no_mpl_figure
 def test_chart_mpl(pl, chart_mpl):
+    import matplotlib.pyplot as plt
+
     size = (0.5, 0.5)
     loc = (0.25, 0.25)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -13,6 +13,7 @@ from pyvista import examples
 from pyvista._vtk import VTK9, vtkStaticCellLocator
 from pyvista.core.errors import VTKVersionError
 from pyvista.errors import MissingDataError
+from pyvista.utilities.misc import can_create_mpl_figure
 
 normals = ['x', 'y', '-z', (1, 1, 1), (3.3, 5.4, 0.8)]
 
@@ -22,6 +23,9 @@ skip_py2_nobind = pytest.mark.skipif(
 
 skip_mac = pytest.mark.skipif(platform.system() == 'Darwin', reason="Flaky Mac tests")
 skip_not_vtk9 = pytest.mark.skipif(not VTK9, reason="Test requires >=VTK v9")
+skip_no_mpl_figure = pytest.mark.skipif(
+    not can_create_mpl_figure(), reason="Cannot create a figure using matplotlib"
+)
 
 
 def aprox_le(a, b, rtol=1e-5, atol=1e-8):
@@ -1226,9 +1230,9 @@ def test_sample_over_line():
     assert isinstance(sampled_from_sphere, pyvista.PolyData)
 
 
+@skip_no_mpl_figure
 def test_plot_over_line(tmpdir):
-    """this requires matplotlib"""
-    pytest.importorskip('matplotlib')
+    """This test requires matplotlib."""
     tmp_dir = tmpdir.mkdir("tmpdir")
     filename = str(tmp_dir.join('tmp.png'))
     mesh = examples.load_uniform()
@@ -1350,10 +1354,9 @@ def test_sample_over_circular_arc_normal():
     assert isinstance(sampled_from_sphere, pyvista.PolyData)
 
 
+@skip_no_mpl_figure
 def test_plot_over_circular_arc(tmpdir):
-    """this requires matplotlib"""
-
-    pytest.importorskip('matplotlib')
+    """This test requires matplotlib."""
     mesh = examples.load_uniform()
     tmp_dir = tmpdir.mkdir("tmpdir")
     filename = str(tmp_dir.join('tmp.png'))
@@ -1395,10 +1398,9 @@ def test_plot_over_circular_arc(tmpdir):
         )
 
 
+@skip_no_mpl_figure
 def test_plot_over_circular_arc_normal(tmpdir):
     """this requires matplotlib"""
-
-    pytest.importorskip('matplotlib')
     mesh = examples.load_uniform()
     tmp_dir = tmpdir.mkdir("tmpdir")
     filename = str(tmp_dir.join('tmp.png'))

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1400,7 +1400,7 @@ def test_plot_over_circular_arc(tmpdir):
 
 @skip_no_mpl_figure
 def test_plot_over_circular_arc_normal(tmpdir):
-    """this requires matplotlib"""
+    """This test requires matplotlib."""
     mesh = examples.load_uniform()
     tmp_dir = tmpdir.mkdir("tmpdir")
     filename = str(tmp_dir.join('tmp.png'))


### PR DESCRIPTION
Some of our recent tests on Windows have showed instability with creating a figure with `matplotlib`. The traceback reads:


```
>       mesh.plot_over_line(a, b, resolution=1000, show=False, progress_bar=True)

...

>       self.tk = _tkinter.create(screenName, baseName, className, interactive, wantobjects, useTk, sync, use)
E       _tkinter.TclError: Can't find a usable init.tcl in the following directories: 
E           {C:\hostedtoolcache\windows\Python\3.8.10\x64\tcl\tcl8.6}
E       
E       C:/hostedtoolcache/windows/Python/3.8.10/x64/tcl/tcl8.6/init.tcl: couldn't read file "C:/hostedtoolcache/windows/Python/3.8.10/x64/tcl/tcl8.6/init.tcl": No error
E       couldn't read file "C:/hostedtoolcache/windows/Python/3.8.10/x64/tcl/tcl8.6/init.tcl": No error
E           while executing
E       "source C:/hostedtoolcache/windows/Python/3.8.10/x64/tcl/tcl8.6/init.tcl"
E           ("uplevel" body line 1)
E           invoked from within
E       "uplevel #0 [list source $tclfile]"
E       
E       
E       This probably means that Tcl wasn't installed properly.
C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\tkinter\__init__.py:2270:
```

Since we're already forcing `matplotlib` to use the `'Agg'` backend, there must be something overriding our settings, or maybe some other weird behavior with `matplotlib`.

This PR introduces a small helper function to test if a `matplotlib` figure can be created. Our unit tests can then use this to check if we should skip over tests requiring `matplotlib`.
