### PR TITLE
allow missing matplotlib when setting themes

### DIFF
--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -948,7 +948,9 @@ def get_cmap_safe(cmap):
     try:
         from matplotlib.cm import get_cmap
     except ImportError:  # pragma: no cover
-        raise ImportError('The use of custom colormaps requires the installation of matplotlib') from None
+        raise ImportError(
+            'The use of custom colormaps requires the installation of matplotlib'
+        ) from None
 
     if isinstance(cmap, str):
         # check if this colormap has been mapped between ipygany

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -948,7 +948,7 @@ def get_cmap_safe(cmap):
     try:
         from matplotlib.cm import get_cmap
     except ImportError:  # pragma: no cover
-        raise ImportError('The use of custom colormaps requires the installation of matplotlib')
+        raise ImportError('The use of custom colormaps requires the installation of matplotlib') from None
 
     if isinstance(cmap, str):
         # check if this colormap has been mapped between ipygany

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -948,7 +948,8 @@ def get_cmap_safe(cmap):
     try:
         from matplotlib.cm import get_cmap
     except ImportError:
-        raise ImportError('cmap requires matplotlib')
+        raise ImportError('The use of custom colormaps requires the installation of matplotlib')
+
     if isinstance(cmap, str):
         # check if this colormap has been mapped between ipygany
         if cmap in IPYGANY_MAP:
@@ -974,11 +975,15 @@ def get_cmap_safe(cmap):
             return cmap
         # Else use Matplotlib
         cmap = get_cmap(cmap)
+
     elif isinstance(cmap, list):
         for item in cmap:
             if not isinstance(item, str):
                 raise TypeError('When inputting a list as a cmap, each item should be a string.')
-        from matplotlib.colors import ListedColormap
+        try:
+            from matplotlib.colors import ListedColormap
+        except ImportError:
+            raise ImportError('Listed colormaps require the installation of matplotlib')
 
         cmap = ListedColormap(cmap)
 

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -947,7 +947,7 @@ def get_cmap_safe(cmap):
     """Fetch a colormap by name from matplotlib, colorcet, or cmocean."""
     try:
         from matplotlib.cm import get_cmap
-    except ImportError:
+    except ImportError:  # pragma: no cover
         raise ImportError('The use of custom colormaps requires the installation of matplotlib')
 
     if isinstance(cmap, str):
@@ -982,7 +982,7 @@ def get_cmap_safe(cmap):
                 raise TypeError('When inputting a list as a cmap, each item should be a string.')
         try:
             from matplotlib.colors import ListedColormap
-        except ImportError:
+        except ImportError:  # pragma: no cover
             raise ImportError('Listed colormaps require the installation of matplotlib')
 
         cmap = ListedColormap(cmap)

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -985,7 +985,7 @@ def get_cmap_safe(cmap):
         try:
             from matplotlib.colors import ListedColormap
         except ImportError:  # pragma: no cover
-            raise ImportError('Listed colormaps require the installation of matplotlib')
+            raise ImportError('Listed colormaps require the installation of matplotlib') from None
 
         cmap = ListedColormap(cmap)
 

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -982,10 +982,7 @@ def get_cmap_safe(cmap):
         for item in cmap:
             if not isinstance(item, str):
                 raise TypeError('When inputting a list as a cmap, each item should be a string.')
-        try:
-            from matplotlib.colors import ListedColormap
-        except ImportError:  # pragma: no cover
-            raise ImportError('Listed colormaps require the installation of matplotlib') from None
+        from matplotlib.colors import ListedColormap
 
         cmap = ListedColormap(cmap)
 

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1562,8 +1562,9 @@ class DefaultTheme(_ThemeConfig):
         except ImportError:  # pragma: no cover
             warnings.warn(
                 'Unable to set a default theme colormap without matplotlib. '
-                'The builtin "jet" colormap will be used.'
+                'The builtin VTK "jet" colormap will be used.'
             )
+            self._cmap = None
 
     @property
     def color(self) -> Color:

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1556,8 +1556,14 @@ class DefaultTheme(_ThemeConfig):
 
     @cmap.setter
     def cmap(self, cmap):
-        get_cmap_safe(cmap)  # for validation
-        self._cmap = cmap
+        try:
+            get_cmap_safe(cmap)  # for validation
+            self._cmap = cmap
+        except ImportError:  # pragma: no cover
+            warnings.warn(
+                'Unable to set a default theme colormap without matplotlib. '
+                'The builtin "jet" colormap will be used.'
+            )
 
     @property
     def color(self) -> Color:


### PR DESCRIPTION
Fully resolves #2144.

Makes it possible to change global themes using `pyvista.set_plot_theme('document')` even when missing `matplotlib`. The colormap will be ignored but the user will be warned.
