### PR TITLE
Add notes regarding optional dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,7 +163,7 @@ You can also visit `PyPI <https://pypi.org/project/pyvista/>`_,
 `GitHub <https://github.com/pyvista/pyvista>`_ to download the source.
 
 See the `Installation <http://docs.pyvista.org/getting-started/installation.html#install-ref.>`_
-for more details if the installation through pip doesn't work out.
+for more details regarding optional dependencies or if the installation through pip doesn't work out.
 
 
 Connections

--- a/doc/getting-started/installation.rst
+++ b/doc/getting-started/installation.rst
@@ -27,7 +27,7 @@ the following projects are required dependencies of PyVista:
 
 Optional Dependencies
 ~~~~~~~~~~~~~~~~~~~~~
-PyVista includes several optional dependencies for visualization and file IO, including:
+PyVista includes several optional dependencies for visualization and reading a variety of additional file formats, including:
 
 * `cmocean <https://pypi.org/project/cmocean/>`_ - Colormaps for Oceanography.
 * `colorcet <https://colorcet.holoviz.org/>`_ - Perceptually accurate 256-color colormaps for use with Python.
@@ -48,7 +48,7 @@ using ``pip``::
 
     pip install pyvista
 
-To install all the additional packages that extend pyvista, install using
+To install all the additional packages that extend PyVista, install using
 ``pip`` with::
 
     pip install pyvista[all]

--- a/doc/getting-started/installation.rst
+++ b/doc/getting-started/installation.rst
@@ -22,8 +22,20 @@ the following projects are required dependencies of PyVista:
 * `NumPy <https://pypi.org/project/numpy/>`_ - NumPy arrays provide a core foundation for PyVista's data array access.
 * `imageio <https://pypi.org/project/imageio/>`_ - This library is used for saving screenshots.
 * `appdirs <https://pypi.org/project/appdirs/>`_ - Data management for our example datasets so users can download tutorials on the fly.
+* `scooby <https://github.com/banesullivan/scooby>`_ - Reporting and debugging tools.
+
+
+Optional Dependencies
+~~~~~~~~~~~~~~~~~~~~~
+PyVista includes several optional dependencies for visualization and file IO, including:
+
+* `cmocean <https://pypi.org/project/cmocean/>`_ - Colormaps for Oceanography.
+* `colorcet <https://colorcet.holoviz.org/>`_ - Perceptually accurate 256-color colormaps for use with Python.
+* `ipyvtklink <https://github.com/Kitware/ipyvtklink>`_ - Minimalist ipywidget to interface with any Python vtkRenderWindow.
+* `matplotlib <https://pypi.org/project/matplotlib/>`_ - Used for colormaps and 2D plotting with :class:`pyvista.ChartMPL`.
 * `meshio <https://pypi.org/project/meshio/>`_ - Input/Output for many mesh formats.
-* `scooby <https://github.com/banesullivan/scooby>`_ - Debugging tools
+* `pythreejs <https://pythreejs.readthedocs.io/en/stable/>`_ - Jupyter widgets based notebook extension that allows Jupyter to leverage the WebGL capabilities of modern browsers.
+
 
 PyPI
 ~~~~
@@ -35,6 +47,11 @@ PyVista can be installed from `PyPI <https://pypi.org/project/pyvista/>`_
 using ``pip``::
 
     pip install pyvista
+
+To install all the additional packages that extend pyvista, install using
+``pip`` with::
+
+    pip install pyvista[all]
 
 
 Anaconda

--- a/setup.py
+++ b/setup.py
@@ -79,8 +79,9 @@ setup(
     python_requires='>=3.7.*',
     install_requires=install_requires,
     extras_require={
-        'all': ['matplotlib', 'colorcet', 'cmocean', 'meshio'],
+        'all': ['matplotlib', 'colorcet', 'cmocean', 'meshio>=5.2', 'ipyvtklink', 'pythreejs'],
         'colormaps': ['matplotlib', 'colorcet', 'cmocean'],
         'io': ['meshio>=5.2'],
+        'jupyter': ['ipyvtklink', 'pythreejs'],
     },
 )


### PR DESCRIPTION
Resolve #2688 by adding notes on the optional dependencies.

Also includes `ipyvtklink` and `pythreejs` as optional dependencies to both `[all]` and the new `[jupyter]` sections. Given the rise and popularity of `jupyterlab`, I think we should have this included.
