### PR TITLE
fix extent documentation and implementation

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -4,7 +4,7 @@ import collections.abc
 from copy import deepcopy
 import logging
 import sys
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 import warnings
 
 if sys.version_info >= (3, 8):
@@ -1733,25 +1733,6 @@ class DataSet(DataSetFilters, DataObject):
 
         """
         return list(self.GetCenter())
-
-    @property
-    def extent(self) -> Optional[tuple]:
-        """Return the range of the bounding box."""
-        try:
-            _extent = self.GetExtent()
-        except AttributeError:
-            return None
-        return _extent
-
-    @extent.setter
-    def extent(self, extent: Sequence[float]):
-        """Set the range of the bounding box."""
-        if hasattr(self, 'SetExtent'):
-            if len(extent) != 6:
-                raise ValueError('Extent must be a vector of 6 values.')
-            self.SetExtent(extent)
-        else:
-            raise AttributeError('This mesh type does not handle extents.')
 
     @property
     def volume(self) -> float:

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -86,14 +86,14 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
         Coordinates of the points in y direction. If this is passed, ``uinput``
         must be a :class:`numpy.ndarray`.
 
-    z : np.ndarray, optional
-        Coordinates of the points in z direction. If this is passed, ``uinput`` and ``y``
-        must be a :class:`numpy.ndarray`.
+    z : numpy.ndarray, optional
+        Coordinates of the points in z direction. If this is passed, ``uinput``
+        and ``y`` must be a :class:`numpy.ndarray`.
 
     check_duplicates : bool, optional
         Check for duplications in any arrays that are passed. Defaults to
-        ``False``. If ``True``, an error is raised if there are any duplicate values
-        in any of the array-valued input arguments.
+        ``False``. If ``True``, an error is raised if there are any duplicate
+        values in any of the array-valued input arguments.
 
     Examples
     --------
@@ -101,7 +101,7 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
     >>> import vtk
     >>> import numpy as np
 
-    Create an empty grid
+    Create an empty grid.
 
     >>> grid = pyvista.RectilinearGrid()
 
@@ -110,11 +110,11 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid):
     >>> vtkgrid = vtk.vtkRectilinearGrid()
     >>> grid = pyvista.RectilinearGrid(vtkgrid)
 
-    Create from NumPy arrays
+    Create from NumPy arrays.
 
     >>> xrng = np.arange(-10, 10, 2)
     >>> yrng = np.arange(-10, 10, 5)
-    >>> zrng = np.arange(-10, 10, 1)
+    >>> zrng = np.arange(-10, 10, 1.1)
     >>> grid = pyvista.RectilinearGrid(xrng, yrng, zrng)
 
     """
@@ -764,3 +764,41 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         grid.field_data.update(self.field_data)
         grid.copy_meta_from(self, deep=True)
         return grid
+
+    @property
+    def extent(self) -> tuple:
+        """Return or set the extent of the UniformGrid.
+
+        This is the same as :class:`Grid.dimensions` with the upper bounds
+        minus one.
+
+        Examples
+        --------
+        Create a ``UniformGrid`` and show its extent.
+
+        >>> import pyvista
+        >>> grid = pyvista.UniformGrid(dims=(10, 10, 10))
+        >>> grid.extent
+        (0, 9, 0, 9, 0, 9)
+
+        >>> grid.extent = (2, 5, 2, 5, 2, 5)
+        >>> grid.extent
+        (2, 5, 2, 5, 2, 5)
+
+        Note how this changes the bounds as well. Since we use default spacing
+        of 1 here, the bounds match the extent. The dimensions also make sense.
+
+        >>> grid.bounds
+        (2.0, 5.0, 2.0, 5.0, 2.0, 5.0)
+        >>> grid.dimensions
+        (4, 4, 4)
+
+        """
+        return self.GetExtent()
+
+    @extent.setter
+    def extent(self, extent: Sequence[int]):
+        """Set the extent of the UniformGrid."""
+        if len(extent) != 6:
+            raise ValueError('Extent must be a vector of 6 values.')
+        self.SetExtent(extent)

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -2518,8 +2518,8 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         Examples
         --------
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
-        >>> grid.dimensions  # doctest:+SKIP
+        >>> grid = examples.load_explicit_structured()
+        >>> grid.dimensions
         (5, 6, 7)
 
         """

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -2500,7 +2500,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         # This method is required to avoid conflict if a developer extends `ExplicitStructuredGrid`
         # and reimplements `dimensions` to return, for example, the number of cells in the I, J and
         # K directions.
-        dims = self.extent
+        dims = self.GetExtent()
         dims = np.reshape(dims, (3, 2))
         dims = np.diff(dims, axis=1)
         dims = dims.flatten() + 1

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -721,25 +721,6 @@ def test_get_cell_array_fail():
         sphere.cell_data[None]
 
 
-def test_extent_none(grid):
-    assert grid.extent is None
-
-
-def test_set_extent_expect_error(grid):
-    with pytest.raises(AttributeError):
-        grid.extent = [1, 2, 3]
-
-
-def test_set_extent():
-    uni_grid = pyvista.UniformGrid(dims=[10, 10, 10])
-    with pytest.raises(ValueError):
-        uni_grid.extent = [0, 1]
-
-    extent = [0, 1, 0, 1, 0, 1]
-    uni_grid.extent = extent
-    assert np.allclose(uni_grid.extent, extent)
-
-
 def test_get_item(grid):
     with pytest.raises(KeyError):
         grid[0]

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1072,6 +1072,16 @@ def test_hide_points(ind, struct_grid):
         struct_grid.hide_points(np.ones(10, dtype=np.bool))
 
 
+def test_set_extent():
+    uni_grid = pyvista.UniformGrid(dims=[10, 10, 10])
+    with pytest.raises(ValueError):
+        uni_grid.extent = [0, 1]
+
+    extent = [0, 1, 0, 1, 0, 1]
+    uni_grid.extent = extent
+    assert np.allclose(uni_grid.extent, extent)
+
+
 @pytest.mark.skipif(not VTK9, reason='VTK 9 or higher is required')
 def test_UnstructuredGrid_cast_to_explicit_structured_grid():
     grid = examples.load_explicit_structured()


### PR DESCRIPTION
Resolves #2821 by moving the implementation to `pyvista.UniformGrid`. It should not be a `pyvista.DataSet` attribute as this attribute is not applicable for all `pyvista.DataSet`s. Just like how we do not implement `dimension` for a `pyvista.PolyData`, there's no reason to implement `extent` for anything except for the classes that have extent.

While other "Grid-like" classes have `GetExtent` and `SetExtent` implemented, `SetExtent` requires `int` and does not accept floats, making it poorly suited for these classes as they can return a float extent but cannot accept one.
