### PR TITLE
Fix matplotlib backend setting for test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,12 +8,12 @@ from pyvista import examples
 pyvista.OFF_SCREEN = True
 
 
-@fixture(scope='session')
+@fixture(scope='session', autouse=True)
 def set_mpl():
     """Avoid matplotlib windows popping up."""
     try:
         import matplotlib
-    except Exception:
+    except ImportError:
         pass
     else:
         matplotlib.use('agg', force=True)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,0 +1,13 @@
+"""Meta-tests for the test suite.
+
+Module for tests that test the test setup itself, and in general
+anything that's beyond testing actual library code.
+
+"""
+
+
+def test_mpl_backend():
+    """Check if the backend is correctly set for testing."""
+    import matplotlib
+
+    assert matplotlib.get_backend() == 'agg'

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -8,6 +8,10 @@ anything that's beyond testing actual library code.
 
 def test_mpl_backend():
     """Check if the backend is correctly set for testing."""
-    import matplotlib
+    # only fail if matplotlib is otherwise available
+    try:
+        import matplotlib
+    except ImportError:
+        return
 
     assert matplotlib.get_backend() == 'agg'


### PR DESCRIPTION
This is to complement https://github.com/pyvista/pyvista/pull/2823.

The backend choice issue got me thinking. We only seem to be setting the backend for tests in one place:
https://github.com/pyvista/pyvista/blob/5d6101b1bd9f209d7f85b2eac2f7ce39314bfe54/tests/conftest.py#L11-L19

However, [looking at the pytest docs](https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#autouse-fixtures-fixtures-you-don-t-have-to-request) there's no explicit mention of session-scoped fixtures also being autouse (in fact for the example module-scoped fixture the opposite is true: example tests request it).

If I add a dummy test that does
```py
def test_mpl_backend():
    import matplotlib
    assert matplotlib.get_backend() == 'agg'
```
this promptly fails with `pytest -v -k test_mpl_backend`, and changing the fixture to autouse makes this test pass. I think this is what's missing.

I wondered if I should actually add this test to the test suite, but it would be sort of a meta-test, testing our test setup rather than the library code. So I've left it out for now, let me know if you think otherwise.