### PR TITLE
Cancel concurrent workflows

### DIFF
--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -8,6 +8,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   USE_CACHE: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.cache == 'true') || (github.event_name == 'pull_request') || (github.event_name == 'push') }}
 

--- a/.github/workflows/style_docstr.yml
+++ b/.github/workflows/style_docstr.yml
@@ -3,6 +3,10 @@ name: Style and Docstring Check
 
 on: [pull_request, workflow_dispatch]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   stylecheck:
     runs-on: ubuntu-20.04

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   ALLOW_PLOTTING: true
   SHELLOPTS: 'errexit:pipefail'


### PR DESCRIPTION
### Problem

Change the GitHub actions CI/CD to cancel old workflows when a new commit that supersedes the old one. For example:

- You open a PR.
- Immediately determine something is broken (e.g. style guide or unit tests fail).
- Submit a new PR.
- Old workflows are still on-going (like docs).

While we don't pay for the actions, it does mean that new workflows have to wait if we end up saturating GitHub.

### Solution

Simply set `cancel-in-progress` to `true` for `concurrency. For details, see [Using Concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency).