### PR TITLE
Add community-review label is need to merge

### DIFF
--- a/.github/workflows/community-review.yml
+++ b/.github/workflows/community-review.yml
@@ -16,3 +16,5 @@ jobs:
           days-before-pr-stale: 1
           days-before-pr-close: -1
           stale-pr-label: "community-reviewed"
+          remove-pr-stale-when-updated: "community-reviewed"
+          labels-to-add-when-unstale: "do-not-merge"

--- a/.github/workflows/community-review.yml
+++ b/.github/workflows/community-review.yml
@@ -1,0 +1,18 @@
+name: Community Review
+on:
+  schedule:
+    - cron: "30 1 * * *"
+permissions:
+  pull-requests: write
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-pr-message: "This PR is reviewd by community because it has been open 1 day with no activity."
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 1
+          days-before-pr-close: -1
+          stale-pr-label: "community-reviewed"

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -1,0 +1,18 @@
+name: Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v2
+        with:
+          mode: exactly
+          count: 1
+          labels: "documentation, docker, maintenance, ignore-for-release, enhancement, bug"
+      - uses: mheap/github-action-required-labels@v2
+        with:
+          mode: exactly
+          count: 1
+          labels: "community-reviewed"

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -16,3 +16,8 @@ jobs:
           mode: exactly
           count: 1
           labels: "community-reviewed"
+      - uses: mheap/github-action-required-labels@v2
+        with:
+          mode: exactly
+          count: 0
+          labels: "do-not-merge"


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
The PyVista community has grown and also the developer community has grown. Nowadays, pull requests are reviewed from multiple locations around the world. Every time zone in the world should have an equal opportunity to review PyVista's pull request. In other words, reviewers should be granted their chance to review for at least 1 day. However, maintainers, myself included, tend to be aggressive in merging (because we want to improve PyVista quickly!). It is also painful to open an uncommented PullRequest after a day pass even though there is an enable auto-merge.

So I built a system to solve this problem with GitHub Action. This system is divided into two parts.

1. Community Review: Here the label `community-review` is added one day after the last action in the PullRequest. If someone takes some action, it will wait another day. If someone comments, the `community-review` label is removed and a `do-not-merge` label is added. This label prevents merging, so please remove it when the discussion is over. You can also add it when you feel a long time discussion is needed.

1. Pull Request Labels: Here we check the labels required for the merge, blocking the merge if they do not meet the criteria. The label "community-reviewed", which is given if 1. is passed, is a required label. do-not-merge" as a label that must not exist. I also need a required label for release notes. This solves the problem of https://github.com/pyvista/pyvista/pull/2453 .

Please review as there may be use cases that I am not anticipating. Reviews are always important!!!

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 
relate to https://github.com/pyvista/pyvista/discussions/2245

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->
resolves #2774

### Details

- https://github.com/marketplace/actions/close-stale-issues
- https://github.com/marketplace/actions/require-labels

