### PR TITLE
Clean up community-reviewed label wording

### DIFF
--- a/.github/workflows/community-review.yml
+++ b/.github/workflows/community-review.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          stale-pr-message: "This PR is reviewd by community because it has been open 1 day with no activity."
+          stale-pr-message: "This PR has been approved by reviewers for 1 day with no activity."
           days-before-issue-stale: -1
           days-before-issue-close: -1
           days-before-pr-stale: 1

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -433,12 +433,12 @@ The main features of our branching model are:
 Labels
 ~~~~~~
 
-The appropriate label will be added to pull request by CI. This will
+Appropriate labels will be added to pull requests by CI. This will
 be used for future release notes. CI will also verify that the necessary
-labels have been added. If CI doesn't add a label, please it manually.
+labels have been added. If CI doesn't add a label, please add it manually.
 The ``community-reviewed`` label is required for merging. This is added
 when there has been no reviewer action for one day since the last
-pull request action. This system is designed to give reviewers in all
+approving review. This system is designed to give reviewers in all
 time zones a chance to review.
 
 Minor Release Steps


### PR DESCRIPTION
Small cleanup after https://github.com/pyvista/pyvista/pull/2851.

One point though: I've added "approval" to the language. I can't tell from #2851 whether this is actually the case, but it should be: we need the label to only consider _approving_ reviews. In any case @tkoyama010 please check if you agree with the changes here, and whether they make sense :)

OK, now I see that https://github.com/pyvista/pyvista/pull/2517#issuecomment-1166180176 got the comment even though there are no approving reviews there. In fact there are no reviews at all!