### PR TITLE
Wait until auto label is added

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -44,6 +44,9 @@ jobs:
       if: startsWith(github.event.pull_request.head.ref, 'release')
       with:
         labels: release
+    - name: Wait until auto label is add
+      run: sleep 120s
+      shell: bash
     - uses: mheap/github-action-required-labels@v2
       with:
         mode: minimum


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
When auto label is added in first commit. We need to wait until label is added.

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None

