### PR TITLE
Ensure same name arrays do not shallow copy

### DIFF
--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -774,10 +774,8 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
                 if data.flags.c_contiguous:
                     # no reason to return a shallow copy if the array and name
                     # are identical, just return the underlying array name
-                    if not deep_copy:
-                        if isinstance(name, str):
-                            if data.VTKObject.GetName() == name:
-                                return data.VTKObject
+                    if not deep_copy and isinstance(name, str) and data.VTKObject.GetName() == name:
+                        return data.VTKObject
 
                     vtk_arr = copy_vtk_array(data.VTKObject, deep=deep_copy)
                     if isinstance(name, str):

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -772,6 +772,13 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
                 # VTK doesn't support strides, therefore we can't directly
                 # point to the underlying object
                 if data.flags.c_contiguous:
+                    # no reason to return a shallow copy if the array and name
+                    # are identical, just return the underlying array name
+                    if not deep_copy:
+                        if isinstance(name, str):
+                            if data.VTKObject.GetName() == name:
+                                return data.VTKObject
+
                     vtk_arr = copy_vtk_array(data.VTKObject, deep=deep_copy)
                     if isinstance(name, str):
                         vtk_arr.SetName(name)


### PR DESCRIPTION
Resolves #2864 by ensuring that same named arrays are not shallow copied, but rather have their reference directly returned by `_prepare_array`.

For whatever reason, arrays that have been shallow copied still have their underlying arrays collected by VTK despite that they're used.

You can reproduce the memory issue (from a fresh python shell) with:
```py
import numpy as np
import pyvista

points = np.zeros((10000000, 3))
dataset = pyvista.PointSet(points)
data = np.arange(dataset.n_points, dtype=float)

dataset['scalars'] = data.copy()
dataset['scalars'] *= 0.5
print(dataset['scalars'])
```