### PR TITLE
Build documentation using Python 3.9 and latest OSMesa wheel

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - uses: syphar/restore-virtualenv@v1
         id: cache-virtualenv
@@ -51,7 +51,7 @@ jobs:
           sudo apt-get install libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime
 
       - name: Install OSMesa VTK
-        run: pip install https://github.com/pyvista/pyvista-wheels/raw/add_v9_1_0/vtk-osmesa-9.1.0-cp38-cp38-linux_x86_64.whl
+        run: pip install https://github.com/pyvista/pyvista-wheels/raw/main/vtk-osmesa-9.1.0-cp39-cp39-linux_x86_64.whl
 
       - name: Install PyVista
         run: |
@@ -164,7 +164,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install Dependencies
         run: |
           pip install cookiecutter


### PR DESCRIPTION
In support of #2839, this PR updates the documentation build to use the latest Python 3.9 OSMesa wheel built on Ubuntu ~22.04~ 20.04. This wheel was built following VTK's build procedures, as noted in the updated [PyVista-Wheels README](https://github.com/pyvista/pyvista-wheels/blob/main/README.md#build-process-for-the-python-39-osmesa-wheel).