### PR TITLE
Update label.yml

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -44,8 +44,3 @@ jobs:
       if: startsWith(github.event.pull_request.head.ref, 'release')
       with:
         labels: release
-    - uses: mheap/github-action-required-labels@v2
-      with:
-        mode: minimum
-        count: 1
-        labels: "documentation, docker, maintenance, ignore-for-release, enhancement, bug, release"


### PR DESCRIPTION
Remove required labels. This is broken for fresh PRs and should be disabled until https://github.com/mheap/github-action-required-labels/issues/33 is resolved.