### PR TITLE
Rotate teapot for flip_z() doctest example

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,7 +1,7 @@
 name: "Pull Request Labeler"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, reopened]
   workflow_dispatch:
 
 jobs:

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1196,6 +1196,7 @@ class DataSet(DataSetFilters, DataObject):
         >>> mesh2 = mesh1.scale([10.0, 10.0, 10.0], inplace=False)
         >>> _ = pl.add_mesh(mesh2)
         >>> pl.show(cpos="xy")
+
         """
         if isinstance(xyz, (float, int, np.number)):
             xyz = [xyz] * 3
@@ -1247,6 +1248,7 @@ class DataSet(DataSetFilters, DataObject):
         >>> mesh2 = mesh1.flip_x(inplace=False)
         >>> _ = pl.add_mesh(mesh2)
         >>> pl.show(cpos="xy")
+
         """
         if point is None:
             point = self.center
@@ -1297,6 +1299,7 @@ class DataSet(DataSetFilters, DataObject):
         >>> mesh2 = mesh1.flip_y(inplace=False)
         >>> _ = pl.add_mesh(mesh2)
         >>> pl.show(cpos="xy")
+
         """
         if point is None:
             point = self.center
@@ -1347,6 +1350,7 @@ class DataSet(DataSetFilters, DataObject):
         >>> mesh2 = mesh1.flip_z(inplace=False)
         >>> _ = pl.add_mesh(mesh2)
         >>> pl.show(cpos="xz")
+
         """
         if point is None:
             point = self.center
@@ -1402,6 +1406,7 @@ class DataSet(DataSetFilters, DataObject):
         >>> mesh2 = mesh1.flip_normal([1.0, 1.0, 1.0], inplace=False)
         >>> _ = pl.add_mesh(mesh2)
         >>> pl.show(cpos="xy")
+
         """
         if point is None:
             point = self.center

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1340,13 +1340,13 @@ class DataSet(DataSetFilters, DataObject):
         >>> pl = pyvista.Plotter(shape=(1, 2))
         >>> pl.subplot(0, 0)
         >>> pl.show_axes()
-        >>> mesh1 = examples.download_teapot()
+        >>> mesh1 = examples.download_teapot().rotate_x(90, inplace=False)
         >>> _ = pl.add_mesh(mesh1)
         >>> pl.subplot(0, 1)
         >>> pl.show_axes()
         >>> mesh2 = mesh1.flip_z(inplace=False)
         >>> _ = pl.add_mesh(mesh2)
-        >>> pl.show(cpos="xy")
+        >>> pl.show(cpos="xz")
         """
         if point is None:
             point = self.center


### PR DESCRIPTION
The `flip_z()` doctest result looks like this:

![two identical-looking teapots, before and after `flip_z()`](https://user-images.githubusercontent.com/17914410/176039086-8c82a780-fa7d-4e3c-b5f7-8489f7a8c131.png)

The teapots look identical because the xy plane in this configuration is parallel to the symmetry plane of the teapot.

If we first rotate the teapot around `x` we get a more meaningful result:

![two teapots, one of them upside down](https://user-images.githubusercontent.com/17914410/176039156-a952c135-9b62-429a-9cef-fadd31b29592.png)

This makes the test slightly different from `flip_x()` and `flip_y()`, but it's probably more important to have the example be useful in isolation.