### PR TITLE
Skip theme doctests (again) to prevent theme changes leaking into doc build

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -18,28 +18,35 @@ jobs:
     - uses: actions-ecosystem/action-add-labels@v1
       if: startsWith(github.event.pull_request.head.ref, 'doc/') || startsWith(github.event.pull_request.head.ref, 'docs')
       with:
+        github_token: "${{ secrets.GITHUB_TOKEN }}"
         labels: documentation
     - uses: actions-ecosystem/action-add-labels@v1
       if: startsWith(github.event.pull_request.head.ref, 'docker')
       with:
+        github_token: "${{ secrets.GITHUB_TOKEN }}"
         labels: docker
     - uses: actions-ecosystem/action-add-labels@v1
       if: startsWith(github.event.pull_request.head.ref, 'maint') || startsWith(github.event.pull_request.head.ref, 'no-ci') || startsWith(github.event.pull_request.head.ref, 'ci')
       with:
+        github_token: "${{ secrets.GITHUB_TOKEN }}"
         labels: maintenance
     - uses: actions-ecosystem/action-add-labels@v1
       if: startsWith(github.event.pull_request.head.ref, 'junk')
       with:
+        github_token: "${{ secrets.GITHUB_TOKEN }}"
         labels: ignore-for-release
     - uses: actions-ecosystem/action-add-labels@v1
       if: startsWith(github.event.pull_request.head.ref, 'feat')
       with:
+        github_token: "${{ secrets.GITHUB_TOKEN }}"
         labels: enhancement
     - uses: actions-ecosystem/action-add-labels@v1
       if: startsWith(github.event.pull_request.head.ref, 'fix') || startsWith(github.event.pull_request.head.ref, 'patch')
       with:
+        github_token: "${{ secrets.GITHUB_TOKEN }}"
         labels: bug
     - uses: actions-ecosystem/action-add-labels@v1
       if: startsWith(github.event.pull_request.head.ref, 'release')
       with:
+        github_token: "${{ secrets.GITHUB_TOKEN }}"
         labels: release

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -5,10 +5,10 @@ Examples
 Apply a built-in theme
 
 >>> import pyvista
->>> pyvista.set_plot_theme('default')
->>> pyvista.set_plot_theme('document')
->>> pyvista.set_plot_theme('dark')
->>> pyvista.set_plot_theme('paraview')
+>>> pyvista.set_plot_theme('default')  # doctest:+SKIP
+>>> pyvista.set_plot_theme('document')  # doctest:+SKIP
+>>> pyvista.set_plot_theme('dark')  # doctest:+SKIP
+>>> pyvista.set_plot_theme('paraview')  # doctest:+SKIP
 
 Load a theme into pyvista
 
@@ -24,8 +24,8 @@ pyvista.
 >>> my_theme.font.title_size = 40
 >>> my_theme.cmap = 'jet'
 ...
->>> pyvista.global_theme.load_theme(my_theme)
->>> pyvista.global_theme.font.size
+>>> pyvista.global_theme.load_theme(my_theme)  # doctest:+SKIP
+>>> pyvista.global_theme.font.size  # doctest:+SKIP
 20
 
 """
@@ -107,19 +107,19 @@ def set_plot_theme(theme):
     Set to the default theme.
 
     >>> import pyvista
-    >>> pyvista.set_plot_theme('default')
+    >>> pyvista.set_plot_theme('default')  # doctest:+SKIP
 
     Set to the document theme.
 
-    >>> pyvista.set_plot_theme('document')
+    >>> pyvista.set_plot_theme('document')  # doctest:+SKIP
 
     Set to the dark theme.
 
-    >>> pyvista.set_plot_theme('dark')
+    >>> pyvista.set_plot_theme('dark')  # doctest:+SKIP
 
     Set to the ParaView theme.
 
-    >>> pyvista.set_plot_theme('paraview')
+    >>> pyvista.set_plot_theme('paraview')  # doctest:+SKIP
 
     """
     import pyvista
@@ -216,9 +216,9 @@ class _DepthPeelingConfig(_ThemeConfig):
     Set global depth peeling parameters.
 
     >>> import pyvista
-    >>> pyvista.global_theme.depth_peeling.number_of_peels = 1
-    >>> pyvista.global_theme.depth_peeling.occlusion_ratio = 0.0
-    >>> pyvista.global_theme.depth_peeling.enabled = True
+    >>> pyvista.global_theme.depth_peeling.number_of_peels = 1  # doctest:+SKIP
+    >>> pyvista.global_theme.depth_peeling.occlusion_ratio = 0.0  # doctest:+SKIP
+    >>> pyvista.global_theme.depth_peeling.enabled = True  # doctest:+SKIP
 
     """
 
@@ -236,7 +236,7 @@ class _DepthPeelingConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.depth_peeling.number_of_peels = 1
+        >>> pyvista.global_theme.depth_peeling.number_of_peels = 1  # doctest:+SKIP
 
         """
         return self._number_of_peels
@@ -252,7 +252,7 @@ class _DepthPeelingConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.depth_peeling.occlusion_ratio = 0.0
+        >>> pyvista.global_theme.depth_peeling.occlusion_ratio = 0.0  # doctest:+SKIP
 
         """
         return self._occlusion_ratio
@@ -268,7 +268,7 @@ class _DepthPeelingConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.depth_peeling.enabled = True
+        >>> pyvista.global_theme.depth_peeling.enabled = True  # doctest:+SKIP
 
         """
         return self._enabled
@@ -298,9 +298,9 @@ class _SilhouetteConfig(_ThemeConfig):
     Set global silhouette parameters.
 
     >>> import pyvista
-    >>> pyvista.global_theme.silhouette.color = 'grey'
-    >>> pyvista.global_theme.silhouette.line_width = 2
-    >>> pyvista.global_theme.silhouette.feature_angle = 20
+    >>> pyvista.global_theme.silhouette.color = 'grey'  # doctest:+SKIP
+    >>> pyvista.global_theme.silhouette.line_width = 2  # doctest:+SKIP
+    >>> pyvista.global_theme.silhouette.feature_angle = 20  # doctest:+SKIP
 
     """
 
@@ -320,7 +320,7 @@ class _SilhouetteConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.silhouette.color = 'red'
+        >>> pyvista.global_theme.silhouette.color = 'red'  # doctest:+SKIP
 
         """
         return self._color
@@ -336,7 +336,7 @@ class _SilhouetteConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.silhouette.line_width = 2.0
+        >>> pyvista.global_theme.silhouette.line_width = 2.0  # doctest:+SKIP
 
         """
         return self._line_width
@@ -352,7 +352,7 @@ class _SilhouetteConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.silhouette.opacity = 1.0
+        >>> pyvista.global_theme.silhouette.opacity = 1.0  # doctest:+SKIP
 
         """
         return self._opacity
@@ -369,7 +369,7 @@ class _SilhouetteConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.silhouette.feature_angle = 20.0
+        >>> pyvista.global_theme.silhouette.feature_angle = 20.0  # doctest:+SKIP
 
         """
         return self._feature_angle
@@ -387,7 +387,7 @@ class _SilhouetteConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.silhouette.decimate = 0.9
+        >>> pyvista.global_theme.silhouette.decimate = 0.9  # doctest:+SKIP
 
         """
         return self._decimate
@@ -420,7 +420,7 @@ class _ColorbarConfig(_ThemeConfig):
     Set the colorbar width.
 
     >>> import pyvista
-    >>> pyvista.global_theme.colorbar_horizontal.width = 0.2
+    >>> pyvista.global_theme.colorbar_horizontal.width = 0.2  # doctest:+SKIP
 
     """
 
@@ -439,7 +439,7 @@ class _ColorbarConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.colorbar_horizontal.width = 0.2
+        >>> pyvista.global_theme.colorbar_horizontal.width = 0.2  # doctest:+SKIP
 
         """
         return self._width
@@ -455,7 +455,7 @@ class _ColorbarConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.colorbar_horizontal.height = 0.2
+        >>> pyvista.global_theme.colorbar_horizontal.height = 0.2  # doctest:+SKIP
 
         """
         return self._height
@@ -471,7 +471,7 @@ class _ColorbarConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.colorbar_horizontal.position_x = 0.2
+        >>> pyvista.global_theme.colorbar_horizontal.position_x = 0.2  # doctest:+SKIP
 
         """
         return self._position_x
@@ -487,7 +487,7 @@ class _ColorbarConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.colorbar_horizontal.position_y = 0.2
+        >>> pyvista.global_theme.colorbar_horizontal.position_y = 0.2  # doctest:+SKIP
 
         """
         return self._position_y
@@ -519,15 +519,15 @@ class _AxesConfig(_ThemeConfig):
     Set the x axis color to black.
 
     >>> import pyvista
-    >>> pyvista.global_theme.axes.x_color = 'black'
+    >>> pyvista.global_theme.axes.x_color = 'black'  # doctest:+SKIP
 
     Show axes by default.
 
-    >>> pyvista.global_theme.axes.show = True
+    >>> pyvista.global_theme.axes.show = True  # doctest:+SKIP
 
     Use the ``vtk.vtkCubeAxesActor``.
 
-    >>> pyvista.global_theme.axes.box = True
+    >>> pyvista.global_theme.axes.box = True  # doctest:+SKIP
 
     """
 
@@ -562,7 +562,7 @@ class _AxesConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.axes.x_color = 'red'
+        >>> pyvista.global_theme.axes.x_color = 'red'  # doctest:+SKIP
         """
         return self._x_color
 
@@ -577,7 +577,7 @@ class _AxesConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.axes.y_color = 'red'
+        >>> pyvista.global_theme.axes.y_color = 'red'  # doctest:+SKIP
         """
         return self._y_color
 
@@ -592,7 +592,7 @@ class _AxesConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.axes.z_color = 'red'
+        >>> pyvista.global_theme.axes.z_color = 'red'  # doctest:+SKIP
         """
         return self._z_color
 
@@ -607,7 +607,7 @@ class _AxesConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.axes.box = True
+        >>> pyvista.global_theme.axes.box = True  # doctest:+SKIP
 
         """
         return self._box
@@ -625,7 +625,7 @@ class _AxesConfig(_ThemeConfig):
         Hide the axes by default.
 
         >>> import pyvista
-        >>> pyvista.global_theme.axes.show = False
+        >>> pyvista.global_theme.axes.show = False  # doctest:+SKIP
 
         """
         return self._show
@@ -644,27 +644,27 @@ class _Font(_ThemeConfig):
     'arial', 'courier', or 'times'.
 
     >>> import pyvista
-    >>> pyvista.global_theme.font.family = 'arial'
+    >>> pyvista.global_theme.font.family = 'arial'  # doctest:+SKIP
 
     Set the default font size to 20.
 
-    >>> pyvista.global_theme.font.size = 20
+    >>> pyvista.global_theme.font.size = 20  # doctest:+SKIP
 
     Set the default title size to 40
 
-    >>> pyvista.global_theme.font.title_size = 40
+    >>> pyvista.global_theme.font.title_size = 40  # doctest:+SKIP
 
     Set the default label size to 10
 
-    >>> pyvista.global_theme.font.label_size = 10
+    >>> pyvista.global_theme.font.label_size = 10  # doctest:+SKIP
 
     Set the default text color to 'grey'
 
-    >>> pyvista.global_theme.font.color = 'grey'
+    >>> pyvista.global_theme.font.color = 'grey'  # doctest:+SKIP
 
     Set the string formatter used to format numerical data to '%.6e'
 
-    >>> pyvista.global_theme.font.fmt = '%.6e'
+    >>> pyvista.global_theme.font.fmt = '%.6e'  # doctest:+SKIP
 
     """
 
@@ -709,7 +709,7 @@ class _Font(_ThemeConfig):
         Set the default global font family to 'courier'.
 
         >>> import pyvista
-        >>> pyvista.global_theme.font.family = 'courier'
+        >>> pyvista.global_theme.font.family = 'courier'  # doctest:+SKIP
 
         """
         return self._family
@@ -726,7 +726,7 @@ class _Font(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.font.size = 20
+        >>> pyvista.global_theme.font.size = 20  # doctest:+SKIP
 
         """
         return self._size
@@ -744,7 +744,7 @@ class _Font(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.font.title_size = 20
+        >>> pyvista.global_theme.font.title_size = 20  # doctest:+SKIP
         """
         return self._title_size
 
@@ -764,7 +764,7 @@ class _Font(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.font.label_size = 20
+        >>> pyvista.global_theme.font.label_size = 20  # doctest:+SKIP
         """
         return self._label_size
 
@@ -782,7 +782,7 @@ class _Font(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.font.color = 'black'
+        >>> pyvista.global_theme.font.color = 'black'  # doctest:+SKIP
         """
         return self._color
 
@@ -799,7 +799,7 @@ class _Font(_ThemeConfig):
         Set the string formatter used to format numerical data to '%.6e'.
 
         >>> import pyvista
-        >>> pyvista.global_theme.font.fmt = '%.6e'
+        >>> pyvista.global_theme.font.fmt = '%.6e'  # doctest:+SKIP
 
         """
         return self._fmt
@@ -852,7 +852,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_styles.modern.cap_width = 0.02
+        >>> pyvista.global_theme.slider_styles.modern.cap_width = 0.02  # doctest:+SKIP
 
         """
         return self._cap_width
@@ -868,7 +868,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_styles.modern.cap_length = 0.01
+        >>> pyvista.global_theme.slider_styles.modern.cap_length = 0.01  # doctest:+SKIP
 
         """
         return self._cap_length
@@ -884,7 +884,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_styles.modern.cap_opacity = 1.0
+        >>> pyvista.global_theme.slider_styles.modern.cap_opacity = 1.0  # doctest:+SKIP
 
         """
         return self._cap_opacity
@@ -900,7 +900,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_styles.modern.tube_color = 'black'
+        >>> pyvista.global_theme.slider_styles.modern.tube_color = 'black'  # doctest:+SKIP
         """
         return self._tube_color
 
@@ -915,7 +915,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_styles.modern.tube_width = 0.005
+        >>> pyvista.global_theme.slider_styles.modern.tube_width = 0.005  # doctest:+SKIP
 
         """
         return self._tube_width
@@ -931,7 +931,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_styles.modern.slider_color = 'grey'
+        >>> pyvista.global_theme.slider_styles.modern.slider_color = 'grey'  # doctest:+SKIP
 
         """
         return self._slider_color
@@ -947,7 +947,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_styles.modern.slider_width = 0.04
+        >>> pyvista.global_theme.slider_styles.modern.slider_width = 0.04  # doctest:+SKIP
 
         """
         return self._slider_width
@@ -963,7 +963,7 @@ class _SliderStyleConfig(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.slider_styles.modern.slider_length = 0.02
+        >>> pyvista.global_theme.slider_styles.modern.slider_length = 0.02  # doctest:+SKIP
 
         """
         return self._slider_length
@@ -998,25 +998,25 @@ class _SliderConfig(_ThemeConfig):
     Set the classic slider configuration.
 
     >>> import pyvista
-    >>> pyvista.global_theme.slider_styles.classic.slider_length = 0.02
-    >>> pyvista.global_theme.slider_styles.classic.slider_width = 0.04
-    >>> pyvista.global_theme.slider_styles.classic.slider_color = (0.5, 0.5, 0.5)
-    >>> pyvista.global_theme.slider_styles.classic.tube_width = 0.005
-    >>> pyvista.global_theme.slider_styles.classic.tube_color = (1.0, 1.0, 1.0)
-    >>> pyvista.global_theme.slider_styles.classic.cap_opacity = 1
-    >>> pyvista.global_theme.slider_styles.classic.cap_length = 0.01
-    >>> pyvista.global_theme.slider_styles.classic.cap_width = 0.02
+    >>> pyvista.global_theme.slider_styles.classic.slider_length = 0.02  # doctest:+SKIP
+    >>> pyvista.global_theme.slider_styles.classic.slider_width = 0.04  # doctest:+SKIP
+    >>> pyvista.global_theme.slider_styles.classic.slider_color = (0.5, 0.5, 0.5)  # doctest:+SKIP
+    >>> pyvista.global_theme.slider_styles.classic.tube_width = 0.005  # doctest:+SKIP
+    >>> pyvista.global_theme.slider_styles.classic.tube_color = (1.0, 1.0, 1.0)  # doctest:+SKIP
+    >>> pyvista.global_theme.slider_styles.classic.cap_opacity = 1  # doctest:+SKIP
+    >>> pyvista.global_theme.slider_styles.classic.cap_length = 0.01  # doctest:+SKIP
+    >>> pyvista.global_theme.slider_styles.classic.cap_width = 0.02  # doctest:+SKIP
 
     Set the modern slider configuration.
 
-    >>> pyvista.global_theme.slider_styles.modern.slider_length = 0.02
-    >>> pyvista.global_theme.slider_styles.modern.slider_width = 0.04
-    >>> pyvista.global_theme.slider_styles.modern.slider_color = (0.43, 0.44, 0.45)
-    >>> pyvista.global_theme.slider_styles.modern.tube_width = 0.04
-    >>> pyvista.global_theme.slider_styles.modern.tube_color = (0.69, 0.70, 0.709)
-    >>> pyvista.global_theme.slider_styles.modern.cap_opacity = 0
-    >>> pyvista.global_theme.slider_styles.modern.cap_length = 0.01
-    >>> pyvista.global_theme.slider_styles.modern.cap_width = 0.02
+    >>> pyvista.global_theme.slider_styles.modern.slider_length = 0.02  # doctest:+SKIP
+    >>> pyvista.global_theme.slider_styles.modern.slider_width = 0.04  # doctest:+SKIP
+    >>> pyvista.global_theme.slider_styles.modern.slider_color = (0.43, 0.44, 0.45)  # doctest:+SKIP
+    >>> pyvista.global_theme.slider_styles.modern.tube_width = 0.04  # doctest:+SKIP
+    >>> pyvista.global_theme.slider_styles.modern.tube_color = (0.69, 0.70, 0.709)  # doctest:+SKIP
+    >>> pyvista.global_theme.slider_styles.modern.cap_opacity = 0  # doctest:+SKIP
+    >>> pyvista.global_theme.slider_styles.modern.cap_length = 0.01  # doctest:+SKIP
+    >>> pyvista.global_theme.slider_styles.modern.cap_width = 0.02  # doctest:+SKIP
 
     """
 
@@ -1092,18 +1092,18 @@ class DefaultTheme(_ThemeConfig):
     Change the global default background color to white.
 
     >>> import pyvista
-    >>> pyvista.global_theme.color = 'white'
+    >>> pyvista.global_theme.color = 'white'  # doctest:+SKIP
 
     Show edges by default.
 
-    >>> pyvista.global_theme.show_edges = True
+    >>> pyvista.global_theme.show_edges = True  # doctest:+SKIP
 
     Create a new theme from the default theme and apply it globally.
 
     >>> my_theme = pyvista.themes.DefaultTheme()
     >>> my_theme.color = 'red'
     >>> my_theme.background = 'white'
-    >>> pyvista.global_theme.load_theme(my_theme)
+    >>> pyvista.global_theme.load_theme(my_theme)  # doctest:+SKIP
 
     """
 
@@ -1231,8 +1231,8 @@ class DefaultTheme(_ThemeConfig):
         Enable hidden line removal.
 
         >>> import pyvista
-        >>> pyvista.global_theme.hidden_line_removal = True
-        >>> pyvista.global_theme.hidden_line_removal
+        >>> pyvista.global_theme.hidden_line_removal = True  # doctest:+SKIP
+        >>> pyvista.global_theme.hidden_line_removal  # doctest:+SKIP
         True
 
         """
@@ -1251,7 +1251,7 @@ class DefaultTheme(_ThemeConfig):
         Disable returning camera position by ``show`` and ``plot`` methods.
 
         >>> import pyvista
-        >>> pyvista.global_theme.return_cpos = False
+        >>> pyvista.global_theme.return_cpos = False  # doctest:+SKIP
         """
 
     @return_cpos.setter
@@ -1267,7 +1267,7 @@ class DefaultTheme(_ThemeConfig):
         Set the default global background of all plots to white.
 
         >>> import pyvista
-        >>> pyvista.global_theme.background = 'white'
+        >>> pyvista.global_theme.background = 'white'  # doctest:+SKIP
         """
         return self._background
 
@@ -1364,7 +1364,7 @@ class DefaultTheme(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.auto_close = False
+        >>> pyvista.global_theme.auto_close = False  # doctest:+SKIP
 
         """
         return self._auto_close
@@ -1382,7 +1382,7 @@ class DefaultTheme(_ThemeConfig):
         Set windows to be full screen by default.
 
         >>> import pyvista
-        >>> pyvista.global_theme.full_screen = True
+        >>> pyvista.global_theme.full_screen = True  # doctest:+SKIP
         """
         return self._full_screen
 
@@ -1397,8 +1397,8 @@ class DefaultTheme(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.enable_camera_orientation_widget = True
-        >>> pyvista.global_theme.enable_camera_orientation_widget
+        >>> pyvista.global_theme.enable_camera_orientation_widget = True  # doctest:+SKIP
+        >>> pyvista.global_theme.enable_camera_orientation_widget  # doctest:+SKIP
         True
 
         """
@@ -1417,16 +1417,16 @@ class DefaultTheme(_ThemeConfig):
         Set both the position and view of the camera.
 
         >>> import pyvista
-        >>> pyvista.global_theme.camera = {'position': [1, 1, 1],
-        ...                                'viewup': [0, 0, 1]}
+        >>> pyvista.global_theme.camera = {'position': [1, 1, 1],  # doctest:+SKIP
+        ...                                'viewup': [0, 0, 1]}  # doctest:+SKIP
 
         Set the default position of the camera.
 
-        >>> pyvista.global_theme.camera['position'] = [1, 1, 1]
+        >>> pyvista.global_theme.camera['position'] = [1, 1, 1]  # doctest:+SKIP
 
         Set the default view of the camera.
 
-        >>> pyvista.global_theme.camera['viewup'] = [0, 0, 1]
+        >>> pyvista.global_theme.camera['viewup'] = [0, 0, 1]  # doctest:+SKIP
 
         """
         return self._camera
@@ -1456,7 +1456,7 @@ class DefaultTheme(_ThemeConfig):
         Disable all jupyter notebook plotting.
 
         >>> import pyvista
-        >>> pyvista.global_theme.notebook = False
+        >>> pyvista.global_theme.notebook = False  # doctest:+SKIP
 
         """
         return self._notebook
@@ -1474,7 +1474,7 @@ class DefaultTheme(_ThemeConfig):
         Set window size to ``[400, 400]``.
 
         >>> import pyvista
-        >>> pyvista.global_theme.window_size = [400, 400]
+        >>> pyvista.global_theme.window_size = [400, 400]  # doctest:+SKIP
 
         """
         return self._window_size
@@ -1500,27 +1500,27 @@ class DefaultTheme(_ThemeConfig):
         'arial', 'courier', or 'times'.
 
         >>> import pyvista
-        >>> pyvista.global_theme.font.family = 'arial'
+        >>> pyvista.global_theme.font.family = 'arial'  # doctest:+SKIP
 
         Set the default font size to 20.
 
-        >>> pyvista.global_theme.font.size = 20
+        >>> pyvista.global_theme.font.size = 20  # doctest:+SKIP
 
         Set the default title size to 40.
 
-        >>> pyvista.global_theme.font.title_size = 40
+        >>> pyvista.global_theme.font.title_size = 40  # doctest:+SKIP
 
         Set the default label size to 10.
 
-        >>> pyvista.global_theme.font.label_size = 10
+        >>> pyvista.global_theme.font.label_size = 10  # doctest:+SKIP
 
         Set the default text color to 'grey'.
 
-        >>> pyvista.global_theme.font.color = 'grey'
+        >>> pyvista.global_theme.font.color = 'grey'  # doctest:+SKIP
 
         String formatter used to format numerical data to '%.6e'.
 
-        >>> pyvista.global_theme.font.fmt = '%.6e'
+        >>> pyvista.global_theme.font.fmt = '%.6e'  # doctest:+SKIP
 
         """
         return self._font
@@ -1549,7 +1549,7 @@ class DefaultTheme(_ThemeConfig):
         Set the default global colormap to 'jet'.
 
         >>> import pyvista
-        >>> pyvista.global_theme.cmap = 'jet'
+        >>> pyvista.global_theme.cmap = 'jet'  # doctest:+SKIP
 
         """
         return self._cmap
@@ -1585,7 +1585,7 @@ class DefaultTheme(_ThemeConfig):
         Set the default mesh color to 'red'.
 
         >>> import pyvista
-        >>> pyvista.global_theme.color = 'red'
+        >>> pyvista.global_theme.color = 'red'  # doctest:+SKIP
 
         """
         return self._color
@@ -1603,7 +1603,7 @@ class DefaultTheme(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.nan_color = 'darkgray'
+        >>> pyvista.global_theme.nan_color = 'darkgray'  # doctest:+SKIP
 
         """
         return self._nan_color
@@ -1621,7 +1621,7 @@ class DefaultTheme(_ThemeConfig):
         Set the global edge color to 'blue'.
 
         >>> import pyvista
-        >>> pyvista.global_theme.edge_color = 'blue'
+        >>> pyvista.global_theme.edge_color = 'blue'  # doctest:+SKIP
 
         """
         return self._edge_color
@@ -1637,7 +1637,7 @@ class DefaultTheme(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.outline_color = 'white'
+        >>> pyvista.global_theme.outline_color = 'white'  # doctest:+SKIP
 
         """
         return self._outline_color
@@ -1653,7 +1653,7 @@ class DefaultTheme(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.floor_color = 'black'
+        >>> pyvista.global_theme.floor_color = 'black'  # doctest:+SKIP
 
         """
         return self._floor_color
@@ -1671,7 +1671,7 @@ class DefaultTheme(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.colorbar_orientation = 'horizontal'
+        >>> pyvista.global_theme.colorbar_orientation = 'horizontal'  # doctest:+SKIP
 
         """
         return self._colorbar_orientation
@@ -1691,11 +1691,11 @@ class DefaultTheme(_ThemeConfig):
         Set the default horizontal colorbar width to 0.6.
 
         >>> import pyvista
-        >>> pyvista.global_theme.colorbar_horizontal.width = 0.6
+        >>> pyvista.global_theme.colorbar_horizontal.width = 0.6  # doctest:+SKIP
 
         Set the default horizontal colorbar height to 0.2.
 
-        >>> pyvista.global_theme.colorbar_horizontal.height = 0.2
+        >>> pyvista.global_theme.colorbar_horizontal.height = 0.2  # doctest:+SKIP
 
         """
         return self._colorbar_horizontal
@@ -1715,12 +1715,12 @@ class DefaultTheme(_ThemeConfig):
         Set the default colorbar width to 0.45.
 
         >>> import pyvista
-        >>> pyvista.global_theme.colorbar_vertical.width = 0.45
+        >>> pyvista.global_theme.colorbar_vertical.width = 0.45  # doctest:+SKIP
 
         Set the default colorbar height to 0.8.
 
         >>> import pyvista
-        >>> pyvista.global_theme.colorbar_vertical.height = 0.8
+        >>> pyvista.global_theme.colorbar_vertical.height = 0.8  # doctest:+SKIP
 
         """
         return self._colorbar_vertical
@@ -1740,7 +1740,7 @@ class DefaultTheme(_ThemeConfig):
         Show the scalar bar by default when scalars are available.
 
         >>> import pyvista
-        >>> pyvista.global_theme.show_scalar_bar = True
+        >>> pyvista.global_theme.show_scalar_bar = True  # doctest:+SKIP
 
         """
         return self._show_scalar_bar
@@ -1758,7 +1758,7 @@ class DefaultTheme(_ThemeConfig):
         Show edges globally by default.
 
         >>> import pyvista
-        >>> pyvista.global_theme.show_edges = True
+        >>> pyvista.global_theme.show_edges = True  # doctest:+SKIP
 
         """
         return self._show_edges
@@ -1776,7 +1776,7 @@ class DefaultTheme(_ThemeConfig):
         Disable lighting globally.
 
         >>> import pyvista
-        >>> pyvista.global_theme.lighting = False
+        >>> pyvista.global_theme.lighting = False  # doctest:+SKIP
         """
         return self._lighting
 
@@ -1793,7 +1793,7 @@ class DefaultTheme(_ThemeConfig):
         Make all plots non-interactive globally.
 
         >>> import pyvista
-        >>> pyvista.global_theme.interactive = False
+        >>> pyvista.global_theme.interactive = False  # doctest:+SKIP
         """
         return self._interactive
 
@@ -1810,7 +1810,7 @@ class DefaultTheme(_ThemeConfig):
         Render points as spheres by default globally.
 
         >>> import pyvista
-        >>> pyvista.global_theme.render_points_as_spheres = True
+        >>> pyvista.global_theme.render_points_as_spheres = True  # doctest:+SKIP
         """
         return self._render_points_as_spheres
 
@@ -1827,7 +1827,7 @@ class DefaultTheme(_ThemeConfig):
         Set transparent_background globally to ``True``.
 
         >>> import pyvista
-        >>> pyvista.global_theme.transparent_background = True
+        >>> pyvista.global_theme.transparent_background = True  # doctest:+SKIP
 
         """
         return self._transparent_background
@@ -1847,7 +1847,7 @@ class DefaultTheme(_ThemeConfig):
         Set title globally to 'plot'.
 
         >>> import pyvista
-        >>> pyvista.global_theme.title = 'plot'
+        >>> pyvista.global_theme.title = 'plot'  # doctest:+SKIP
 
         """
         return self._title
@@ -1865,8 +1865,8 @@ class DefaultTheme(_ThemeConfig):
         Enable anti-aliasing in the global theme.
 
         >>> import pyvista
-        >>> pyvista.global_theme.antialiasing = True
-        >>> pyvista.global_theme.antialiasing
+        >>> pyvista.global_theme.antialiasing = True  # doctest:+SKIP
+        >>> pyvista.global_theme.antialiasing  # doctest:+SKIP
         True
 
         """
@@ -1887,7 +1887,7 @@ class DefaultTheme(_ThemeConfig):
         Set the default number of multisamples to 2.
 
         >>> import pyvista
-        >>> pyvista.global_theme.multi_samples = 2
+        >>> pyvista.global_theme.multi_samples = 2  # doctest:+SKIP
 
         """
         return self._multi_samples
@@ -1906,7 +1906,7 @@ class DefaultTheme(_ThemeConfig):
         middle of the window).
 
         >>> import pyvista
-        >>> pyvista.global_theme.multi_rendering_splitting_position = 0.5
+        >>> pyvista.global_theme.multi_rendering_splitting_position = 0.5  # doctest:+SKIP
 
         """
         return self._multi_rendering_splitting_position
@@ -1932,7 +1932,7 @@ class DefaultTheme(_ThemeConfig):
         Set default volume mapper globally to 'gpu'.
 
         >>> import pyvista
-        >>> pyvista.global_theme.volume_mapper = 'gpu'
+        >>> pyvista.global_theme.volume_mapper = 'gpu'  # doctest:+SKIP
 
         """
         return self._volume_mapper
@@ -1957,7 +1957,7 @@ class DefaultTheme(_ThemeConfig):
         Set the global smooth_shading parameter default to ``True``.
 
         >>> import pyvista
-        >>> pyvista.global_theme.smooth_shading = True
+        >>> pyvista.global_theme.smooth_shading = True  # doctest:+SKIP
 
         """
         return self._smooth_shading
@@ -1976,9 +1976,9 @@ class DefaultTheme(_ThemeConfig):
         with 8 peels.
 
         >>> import pyvista
-        >>> pyvista.global_theme.depth_peeling.number_of_peels = 8
-        >>> pyvista.global_theme.depth_peeling.occlusion_ratio = 0.0
-        >>> pyvista.global_theme.depth_peeling.enabled = True
+        >>> pyvista.global_theme.depth_peeling.number_of_peels = 8  # doctest:+SKIP
+        >>> pyvista.global_theme.depth_peeling.occlusion_ratio = 0.0  # doctest:+SKIP
+        >>> pyvista.global_theme.depth_peeling.enabled = True  # doctest:+SKIP
 
         """
         return self._depth_peeling
@@ -1998,9 +1998,9 @@ class DefaultTheme(_ThemeConfig):
         Set parameters of the silhouette.
 
         >>> import pyvista
-        >>> pyvista.global_theme.silhouette.color = 'grey'
-        >>> pyvista.global_theme.silhouette.line_width = 2.0
-        >>> pyvista.global_theme.silhouette.feature_angle = 20
+        >>> pyvista.global_theme.silhouette.color = 'grey'  # doctest:+SKIP
+        >>> pyvista.global_theme.silhouette.line_width = 2.0  # doctest:+SKIP
+        >>> pyvista.global_theme.silhouette.feature_angle = 20  # doctest:+SKIP
 
         """
         return self._silhouette
@@ -2031,15 +2031,15 @@ class DefaultTheme(_ThemeConfig):
         Set the x axis color to black.
 
         >>> import pyvista
-        >>> pyvista.global_theme.axes.x_color = 'black'
+        >>> pyvista.global_theme.axes.x_color = 'black'  # doctest:+SKIP
 
         Show axes by default.
 
-        >>> pyvista.global_theme.axes.show = True
+        >>> pyvista.global_theme.axes.show = True  # doctest:+SKIP
 
         Use the ``vtk.vtkCubeAxesActor``.
 
-        >>> pyvista.global_theme.axes.box = True
+        >>> pyvista.global_theme.axes.box = True  # doctest:+SKIP
 
         """
         return self._axes
@@ -2056,7 +2056,7 @@ class DefaultTheme(_ThemeConfig):
         Examples
         --------
         >>> import pyvista
-        >>> pyvista.global_theme.restore_defaults()
+        >>> pyvista.global_theme.restore_defaults()  # doctest:+SKIP
 
         """
         self.__init__()
@@ -2139,8 +2139,8 @@ class DefaultTheme(_ThemeConfig):
         >>> my_theme.font.title_size = 40
         >>> my_theme.cmap = 'jet'
         ...
-        >>> pyvista.global_theme.load_theme(my_theme)
-        >>> pyvista.global_theme.font.size
+        >>> pyvista.global_theme.load_theme(my_theme)  # doctest:+SKIP
+        >>> pyvista.global_theme.font.size  # doctest:+SKIP
         20
 
         Create a custom theme from the dark theme and load it into
@@ -2149,8 +2149,8 @@ class DefaultTheme(_ThemeConfig):
         >>> from pyvista.themes import DarkTheme
         >>> my_theme = DarkTheme()
         >>> my_theme.show_edges = True
-        >>> pyvista.global_theme.load_theme(my_theme)
-        >>> pyvista.global_theme.show_edges
+        >>> pyvista.global_theme.load_theme(my_theme)  # doctest:+SKIP
+        >>> pyvista.global_theme.show_edges  # doctest:+SKIP
         True
 
         """
@@ -2222,15 +2222,15 @@ class DefaultTheme(_ThemeConfig):
         Enable the splitting of sharp edges globally.
 
         >>> import pyvista
-        >>> pyvista.global_theme.split_sharp_edges = True
-        >>> pyvista.global_theme.split_sharp_edges
+        >>> pyvista.global_theme.split_sharp_edges = True  # doctest:+SKIP
+        >>> pyvista.global_theme.split_sharp_edges  # doctest:+SKIP
         True
 
         Disable the splitting of sharp edges globally.
 
         >>> import pyvista
-        >>> pyvista.global_theme.split_sharp_edges = False
-        >>> pyvista.global_theme.split_sharp_edges
+        >>> pyvista.global_theme.split_sharp_edges = False  # doctest:+SKIP
+        >>> pyvista.global_theme.split_sharp_edges  # doctest:+SKIP
         False
 
         """
@@ -2251,8 +2251,8 @@ class DefaultTheme(_ThemeConfig):
         Change the sharp edges feature angle to 45 degrees.
 
         >>> import pyvista
-        >>> pyvista.global_theme.sharp_edges_feature_angle = 45.0
-        >>> pyvista.global_theme.sharp_edges_feature_angle
+        >>> pyvista.global_theme.sharp_edges_feature_angle = 45.0  # doctest:+SKIP
+        >>> pyvista.global_theme.sharp_edges_feature_angle  # doctest:+SKIP
         45.0
 
         """
@@ -2274,11 +2274,11 @@ class DarkTheme(DefaultTheme):
 
     >>> import pyvista
     >>> from pyvista import themes
-    >>> pyvista.set_plot_theme(themes.DarkTheme())
+    >>> pyvista.set_plot_theme(themes.DarkTheme())  # doctest:+SKIP
 
     Alternatively, set via a string.
 
-    >>> pyvista.set_plot_theme('dark')
+    >>> pyvista.set_plot_theme('dark')  # doctest:+SKIP
 
     """
 
@@ -2307,11 +2307,11 @@ class ParaViewTheme(DefaultTheme):
 
     >>> import pyvista
     >>> from pyvista import themes
-    >>> pyvista.set_plot_theme(themes.ParaViewTheme())
+    >>> pyvista.set_plot_theme(themes.ParaViewTheme())  # doctest:+SKIP
 
     Alternatively, set via a string.
 
-    >>> pyvista.set_plot_theme('paraview')
+    >>> pyvista.set_plot_theme('paraview')  # doctest:+SKIP
 
     """
 
@@ -2352,11 +2352,11 @@ class DocumentTheme(DefaultTheme):
 
     >>> import pyvista
     >>> from pyvista import themes
-    >>> pyvista.set_plot_theme(themes.DocumentTheme())
+    >>> pyvista.set_plot_theme(themes.DocumentTheme())  # doctest:+SKIP
 
     Alternatively, set via a string.
 
-    >>> pyvista.set_plot_theme('document')
+    >>> pyvista.set_plot_theme('document')  # doctest:+SKIP
 
     """
 

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -66,7 +66,7 @@ def read_legacy(filename, progress_bar=False):
 
     >>> import pyvista
     >>> from pyvista import examples
-    >>> mesh = pyvista.read_legacy(examples.uniformfile)
+    >>> mesh = pyvista.read_legacy(examples.uniformfile)  # doctest:+SKIP
 
     """
     warnings.warn(


### PR DESCRIPTION
This is a stopgap until we figure out how to fix the underlying problem. (Plus an additional skip of a deprecated reader that keeps emitting warnings during doc building.)

As noted in https://github.com/pyvista/pyvista/issues/2832, our dragons turned black in the devdocs. Similarly, https://docs.pyvista.org/user-guide/data_model.html#cell-data used to have plots like

![data_model-7_00_00](https://user-images.githubusercontent.com/17914410/176067444-06c32a9d-ee14-4f0a-b640-f561155a0989.png)

But in the devdocs they look like https://dev.pyvista.org/user-guide/data_model.html#cell-data

![data_model-7_00_00](https://user-images.githubusercontent.com/17914410/176067526-33ba01a5-0974-49f1-a201-21f144db4eaf.png)

I bisected the history and traced the bug back to https://github.com/pyvista/pyvista/pull/2575. Clearly the unskipped doctests are affecting the global theme, e.g. by setting the window size to `[400, 400]` and showing all edges (which makes the dragons black).

---

We have machinery to prevent this from happening:

https://github.com/pyvista/pyvista/blob/6bdedb7fda4937c7709777307777e5e414326ce5/doc/conf.py#L289-L306

https://github.com/pyvista/pyvista/blob/6bdedb7fda4937c7709777307777e5e414326ce5/doc/conf.py#L342-L343

What this _should_ do is run the reset function before and after every example, preventing leakage. However, it turns out that this only runs for literal examples inside `examples/`, but not for figures generated from doctests, nor for things in e.g. `doc/user_guide`. So what happens is that the doctests mess with the global plot theme, which then affects building the `doc/user_guide` and friends.

We also have
https://github.com/pyvista/pyvista/blob/6bdedb7fda4937c7709777307777e5e414326ce5/pyvista/conftest.py#L15-L21
but I confirmed that this doesn't get run during sphinx' doctest runs.

---

My hunch is that this is a bug or missing feature in sphinx-gallery, or there's a switch we could use to enforce resetting for _everything_ being built. In any case I think we should first skip these theme tests for the time being, so that the impending release will have unbroken figures.