### PR TITLE
Add non-included plot directive that resets theme

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -369,9 +369,19 @@ def _str_examples(self):
     elif re.search(IMPORT_PYVISTA_RE, examples_str) and 'plot-pyvista::' not in examples_str:
         out = []
         out += self._str_header('Examples')
+        # inject hack to reset theme before every example block
+        out += ['.. pyvista-plot::', '   :include-source: False', '']
+        out += self._str_indent(
+            ['>>> import pyvista; pyvista.set_plot_theme("document"); del pyvista', '']
+        )
         out += ['.. pyvista-plot::', '']
         out += self._str_indent(self['Examples'])
         out += ['']
+        # inject same hack after every example block
+        out += ['.. pyvista-plot::', '   :include-source: False', '']
+        out += self._str_indent(
+            ['>>> import pyvista; pyvista.set_plot_theme("document"); del pyvista', '']
+        )
         return out
     else:
         return self._str_section('Examples')


### PR DESCRIPTION
This is an alternative to https://github.com/pyvista/pyvista/pull/2892, resolves https://github.com/pyvista/pyvista/issues/2832.

Using the same directive injection that we use anyway for examples we can add non-rendered setup blocks before and after each API example block that resets the document theme.

In a local test this seemed to fix the issue without breaking anything else, but since then I've also added the same fix _after_ each example block. We'll have to take a close look at the build artifact to see if everything works as intended.