### PR TITLE
Add DataSet.cell_point_ids

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2552,3 +2552,33 @@ class DataSet(DataSetFilters, DataObject):
 
         """
         return self.GetCellType(ind)
+
+    def cell_point_ids(self, ind: int) -> List[int]:
+        """Return the point ids in a cell.
+
+        Parameters
+        ----------
+        ind : int
+            Cell ID.
+
+        Returns
+        -------
+        list[int]
+            Point Ids that are associated with the cell.
+
+        Examples
+        --------
+        >>> from pyvista import examples
+        >>> mesh = examples.load_airplane()
+        >>> mesh.cell_type(0)
+        5
+
+        Cell type of 5 is a triangular cell with three points.
+
+        >>> mesh.cell_point_ids(0)
+        [0, 1, 2]
+
+        """
+        cell = self.GetCell(ind)
+        point_ids = cell.GetPointIds()
+        return [point_ids.GetId(i) for i in range(point_ids.GetNumberOfIds())]

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2573,7 +2573,7 @@ class DataSet(DataSetFilters, DataObject):
         >>> mesh.cell_type(0)
         5
 
-        Cell type of 5 is a triangular cell with three points.
+        Cell type 5 is a triangular cell with three points.
 
         >>> mesh.cell_point_ids(0)
         [0, 1, 2]

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1107,6 +1107,7 @@ def test_cell_point_ids(grid):
     assert isinstance(point_ids, list)
     assert len(point_ids) == grid.cell_n_points(0)
     assert all([isinstance(id, int) for id in point_ids])
+    assert all([0 <= id < grid.n_points for id in point_ids])
 
 
 def test_cell_bounds(grid):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1102,6 +1102,13 @@ def test_cell_points(grid):
     assert points.shape[1] == 3
 
 
+def test_cell_point_ids(grid):
+    point_ids = grid.cell_point_ids(0)
+    assert isinstance(point_ids, list)
+    assert len(point_ids) == grid.cell_n_points(0)
+    assert all([isinstance(id, int) for id in point_ids])
+
+
 def test_cell_bounds(grid):
     bounds = grid.cell_bounds(0)
     assert isinstance(bounds, tuple)


### PR DESCRIPTION
### Overview

Adds method to obtain point ids from a cell id.  This addresses #2838.  

### Details

There was some discussion in #2838 on whether we could instead have a more full featured `vtkCell` implementation.  We could deprecate all the `cell_*` methods that implement one-at-a-time functionality from `vtkCell` at that time.
