### PR TITLE
Add setup and teardown functionality to plot_directive

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -351,6 +351,13 @@ from numpydoc.docscrape_sphinx import SphinxDocString
 IMPORT_PYVISTA_RE = r'\b(import +pyvista|from +pyvista +import)\b'
 IMPORT_MATPLOTLIB_RE = r'\b(import +matplotlib|from +matplotlib +import)\b'
 
+plot_setup = """
+from pyvista import set_plot_theme as __s_p_t
+__s_p_t('document')
+del __s_p_t
+"""
+plot_cleanup = plot_setup
+
 
 def _str_examples(self):
     examples_str = "\n".join(self['Examples'])

--- a/doc/extras/plot_directive.rst
+++ b/doc/extras/plot_directive.rst
@@ -3,7 +3,7 @@
 Sphinx PyVista Plot Directive
 =============================
 You can generate static images of pyvista plots using the
-``.. pyvista-plot`` directive by adding the following to your
+``.. pyvista-plot::`` directive by adding the following to your
 ``conf.py`` when building your documentation using Sphinx.
 
 .. code:: python
@@ -14,7 +14,7 @@ You can generate static images of pyvista plots using the
    ]
 
 You can then issue the plotting directive within your sphinx
-documentation files:
+documentation files::
 
    .. pyvista-plot::
       :caption: A sphere

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -380,7 +380,7 @@ def render_figures(
                     image_file = ImageFile(output_dir, f"{output_base}_{i:02d}_{j:02d}.png")
                     try:
                         plotter.screenshot(image_file.filename)
-                    except RuntimeError:
+                    except RuntimeError:  # pragma no cover
                         # ignore closed, unrendered plotters
                         continue
                 images.append(image_file)

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -3,7 +3,7 @@
 A directive for including a PyVista plot in a Sphinx document
 =============================================================
 
-The `.. pyvista-plot::` sphinx directive will include an inline
+The ``.. pyvista-plot::`` sphinx directive will include an inline
 ``.png`` image.
 
 The source code for the plot may be included in one of two ways:

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -192,8 +192,8 @@ def setup(app):
     app.add_config_value('plot_basedir', None, True)
     app.add_config_value('plot_html_show_formats', True, True)
     app.add_config_value('plot_template', None, True)
-    app.add_config_value('plot_setup', '', True)
-    app.add_config_value('plot_cleanup', '', True)
+    app.add_config_value('plot_setup', None, True)
+    app.add_config_value('plot_cleanup', None, True)
     return {'parallel_read_safe': True, 'parallel_write_safe': True, 'version': pyvista.__version__}
 
 

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -75,19 +75,28 @@ Configuration options
 ---------------------
 The plot directive has the following configuration options:
 
-    plot_include_source
-        Default value for the include-source option.
+    plot_include_source : bool
+        Default value for the include-source option. Default is ``True``.
 
-    plot_basedir
+    plot_basedir : str
         Base directory, to which ``plot::`` file names are relative
-        to.  (If ``None`` or empty, file names are relative to the
-        directory where the file containing the directive is.)
+        to.  If ``None`` or unset, file names are relative to the
+        directory where the file containing the directive is.
 
-    plot_html_show_formats
-        Whether to show links to the files in HTML.
+    plot_html_show_formats : bool
+        Whether to show links to the files in HTML. Default ``True``.
 
-    plot_template
-        Provide a customized template for preparing restructured text.
+    plot_template : str
+        Provide a customized Jinja2 template for preparing restructured text.
+
+    plot_setup : str
+        Python code to be run before every plot directive block.
+
+    plot_cleanup : str
+        Python code to be run after every plot directive block.
+
+These options can be set by defining global variables of the same name in
+:file:`conf.py`.
 
 """
 

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -342,7 +342,8 @@ def render_figures(
     """Run a pyplot script and save the images in *output_dir*.
 
     Save the images under *output_dir* with file names derived from
-    *output_base*
+    *output_base*. Closed plotters are ignored if they were never
+    rendered.
     """
     # Try to determine if all images already exist
     is_doctest, code_pieces = _split_code_at_show(code)
@@ -377,7 +378,11 @@ def render_figures(
                     shutil.move(plotter._gif_filename, image_file.filename)
                 else:
                     image_file = ImageFile(output_dir, f"{output_base}_{i:02d}_{j:02d}.png")
-                    plotter.screenshot(image_file.filename)
+                    try:
+                        plotter.screenshot(image_file.filename)
+                    except RuntimeError:
+                        # ignore closed, unrendered plotters
+                        continue
                 images.append(image_file)
 
             pyvista.close_all()  # close and clear all plotters

--- a/tests/tinypages/conf.py
+++ b/tests/tinypages/conf.py
@@ -17,6 +17,9 @@ release = '0.1'
 exclude_patterns = ['_build']
 pygments_style = 'sphinx'
 
+# -- Plot directive specific configuration --------------------------------
+plot_setup = plot_cleanup = 'import pyvista'
+
 # -- Options for HTML output ----------------------------------------------
 
 if parse_version(sphinx.__version__) >= parse_version('1.3'):


### PR DESCRIPTION
This is an alternative to https://github.com/pyvista/pyvista/pull/2892 and https://github.com/pyvista/pyvista/pull/2896, resolves https://github.com/pyvista/pyvista/issues/2832, resolves https://github.com/pyvista/pyvista/issues/2900.

Going by @tkoyama010's suggestion I tried adding setup/teardown to the plot directive itself. To follow the existing naming I've added the `plot_setup` and `plot_cleanup` config variables that are executed before/after each plot directive block. The suffix matches setup/cleanup used by [sphinx](https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html#confval-doctest_global_setup)

Going forward I think we should rename these from `plot_setup` etc to `pyvista_plot_setup` etc, because the `plot_` prefix might be too general. This change would follow e.g. `sphinx_gallery_conf`.

TODO:

- [x] document added functionality
- [x] ignore closed plotters if screenshot fails
- [x] ~rename `plot_*` config to `pyvista_plot_*`?~