### PR TITLE
Fix the URL link of discretize

### DIFF
--- a/doc/make_external_gallery.py
+++ b/doc/make_external_gallery.py
@@ -60,7 +60,7 @@ articles = dict(
     discretize=Example(
         title="3D Rendering with Discretize",
         description="3D Rendering with Discretize",
-        link="http://discretize.simpeg.xyz/en/master/examples/plot_pyvista_laguna.html",
+        link="http://discretize.simpeg.xyz/en/main/examples/plot_pyvista_laguna.html",
         image="discretize.png",
     ),
     open_foam=Example(


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Fix the URL link of [discretize](http://discretize.simpeg.xyz/en/main/examples/plot_pyvista_laguna.html).

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None

