### PR TITLE
Handle invalid theme on init

### DIFF
--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -12,7 +12,7 @@ from pyvista._version import __version__
 from pyvista.plotting import *
 from pyvista.utilities import *
 from pyvista.core import *
-from pyvista.utilities.misc import _get_vtk_id_type, vtk_version_info
+from pyvista.utilities.misc import _get_vtk_id_type, vtk_version_info, _set_plot_theme_from_env
 from pyvista import _vtk
 from pyvista.jupyter import set_jupyter_backend, PlotterITK
 from pyvista.themes import set_plot_theme, load_theme, _rcParams
@@ -27,8 +27,7 @@ global_theme = _GlobalTheme()
 rcParams = _rcParams()  # raises DeprecationError when used
 
 # Set preferred plot theme
-if 'PYVISTA_PLOT_THEME' in os.environ:
-    set_plot_theme(os.environ['PYVISTA_PLOT_THEME'].lower())
+_set_plot_theme_from_env()
 
 # get the int type from vtk
 ID_TYPE = _get_vtk_id_type()

--- a/pyvista/utilities/misc.py
+++ b/pyvista/utilities/misc.py
@@ -1,10 +1,26 @@
 """Miscellaneous pyvista functions."""
 from collections import namedtuple
+import os
 import warnings
 
 import numpy as np
 
 from pyvista import _vtk
+
+
+def _set_plot_theme_from_env():
+    from pyvista.themes import _ALLOWED_THEMES, set_plot_theme
+
+    if 'PYVISTA_PLOT_THEME' in os.environ:
+        try:
+            theme = os.environ['PYVISTA_PLOT_THEME']
+            set_plot_theme(theme.lower())
+        except KeyError:
+            allowed = ', '.join([item.name for item in _ALLOWED_THEMES])
+            warnings.warn(
+                f'\n\nInvalid PYVISTA_PLOT_THEME environment variable "{theme}". '
+                f'Should be one of the following: {allowed}'
+            )
 
 
 def raise_has_duplicates(arr):

--- a/pyvista/utilities/misc.py
+++ b/pyvista/utilities/misc.py
@@ -9,7 +9,7 @@ from pyvista import _vtk
 
 
 def _set_plot_theme_from_env():
-    """Set plot theme from an enviroment variable."""
+    """Set plot theme from an environment variable."""
     from pyvista.themes import _ALLOWED_THEMES, set_plot_theme
 
     if 'PYVISTA_PLOT_THEME' in os.environ:

--- a/pyvista/utilities/misc.py
+++ b/pyvista/utilities/misc.py
@@ -9,6 +9,7 @@ from pyvista import _vtk
 
 
 def _set_plot_theme_from_env():
+    """Set plot theme from an enviroment variable."""
     from pyvista.themes import _ALLOWED_THEMES, set_plot_theme
 
     if 'PYVISTA_PLOT_THEME' in os.environ:

--- a/tests/utilities/test_misc.py
+++ b/tests/utilities/test_misc.py
@@ -1,0 +1,14 @@
+import os
+
+import pytest
+
+from pyvista.utilities.misc import _set_plot_theme_from_env
+
+
+def test_set_plot_theme_from_env():
+    os.environ['PYVISTA_PLOT_THEME'] = 'not a valid theme'
+    try:
+        with pytest.warns(UserWarning, match='Invalid'):
+            _set_plot_theme_from_env()
+    finally:
+        os.environ.pop('PYVISTA_PLOT_THEME', None)


### PR DESCRIPTION
As noted in #2910, if an invalid theme is set in `PYVISTA_PLOT_THEME`, you will simply be unable to `import pyvista` and potentially get a cryptic error.

This PR fixes this behavior by warning rather than raising.
