### PR TITLE
Fix all-triangles checking for polyfilters

### DIFF
--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2097,7 +2097,7 @@ class PolyDataFilters(DataSetFilters):
         'Rays intersected at (0.499, 0.000, 0.000), (0.000, 0.497, 0.000), (0.000, 0.000, 0.500)'
 
         """
-        if not self.is_all_triangles:
+        if not self.is_all_triangles:  # pragma: no cover
             raise NotAllTrianglesError("Input mesh for multi_ray_trace must be all triangles.")
 
         try:

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -968,6 +968,9 @@ class PolyDataFilters(DataSetFilters):
         See :ref:`decimate_example` for more examples using this filter.
 
         """
+        if not self.is_all_triangles:
+            raise NotAllTrianglesError("Input mesh for decimation must be all triangles.")
+
         alg = _vtk.vtkDecimatePro()
         alg.SetInputData(self)
         alg.SetTargetReduction(reduction)
@@ -1400,6 +1403,9 @@ class PolyDataFilters(DataSetFilters):
         See :ref:`decimate_example` for more examples using this filter.
 
         """
+        if not self.is_all_triangles:
+            raise NotAllTrianglesError("Input mesh for decimation must be all triangles.")
+
         # create decimation filter
         alg = _vtk.vtkQuadricDecimation()
 
@@ -2092,7 +2098,7 @@ class PolyDataFilters(DataSetFilters):
 
         """
         if not self.is_all_triangles:
-            raise NotAllTrianglesError
+            raise NotAllTrianglesError("Input mesh for multi_ray_trace must be all triangles.")
 
         try:
             import pyembree  # noqa

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -1159,6 +1159,9 @@ class PolyDataFilters(DataSetFilters):
         >>> submesh.plot(show_edges=True, line_width=3)
 
         """
+        if not self.is_all_triangles:
+            raise NotAllTrianglesError("Input mesh for subdivision must be all triangles.")
+
         subfilter = subfilter.lower()
         if subfilter == 'linear':
             sfilter = _vtk.vtkLinearSubdivisionFilter()
@@ -1265,6 +1268,9 @@ class PolyDataFilters(DataSetFilters):
         >>> submesh.plot(show_edges=True)
 
         """
+        if not self.is_all_triangles:
+            raise NotAllTrianglesError("Input mesh for subdivision must be all triangles.")
+
         sfilter = _vtk.vtkAdaptiveSubdivisionFilter()
         if max_edge_len:
             sfilter.SetMaximumEdgeLength(max_edge_len)

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2040,7 +2040,9 @@ class PolyDataFilters(DataSetFilters):
 
         return intersection_points, intersection_cells
 
-    def multi_ray_trace(self, origins, directions, first_point=False, retry=False):
+    def multi_ray_trace(
+        self, origins, directions, first_point=False, retry=False
+    ):  # pragma: no cover
         """Perform multiple ray trace calculations.
 
         This requires a mesh with only triangular faces, an array of
@@ -2097,7 +2099,7 @@ class PolyDataFilters(DataSetFilters):
         'Rays intersected at (0.499, 0.000, 0.000), (0.000, 0.497, 0.000), (0.000, 0.000, 0.500)'
 
         """
-        if not self.is_all_triangles:  # pragma: no cover
+        if not self.is_all_triangles:
             raise NotAllTrianglesError("Input mesh for multi_ray_trace must be all triangles.")
 
         try:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -11,7 +11,7 @@ from vtk import VTK_QUADRATIC_HEXAHEDRON
 import pyvista
 from pyvista import examples
 from pyvista._vtk import VTK9, vtkStaticCellLocator
-from pyvista.core.errors import VTKVersionError
+from pyvista.core.errors import NotAllTrianglesError, VTKVersionError
 from pyvista.errors import MissingDataError
 from pyvista.utilities.misc import can_create_mpl_figure
 
@@ -2487,6 +2487,12 @@ def test_subdivide_adaptive(sphere, inplace):
     assert sub.n_faces > orig_n_faces
     if inplace:
         assert sphere.n_faces == sub.n_faces
+
+
+def test_invalid_subdivide_adaptive(cube):
+    # check non-triangulated
+    with pytest.raises(NotAllTrianglesError):
+        cube.subdivide_adaptive()
 
 
 @pytest.mark.skipif(not VTK9, reason='Only supported on VTK v9 or newer')

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -249,6 +249,11 @@ def test_multi_ray_trace(sphere):
     assert np.any(ind_r)
     assert np.any(ind_t)
 
+    # check non-triangulated
+    mesh = pyvista.Cylinder()
+    with pytest.raises(NotAllTrianglesError):
+        mesh.multi_ray_trace(origins, directions)
+
 
 @skip_plotting
 def test_plot_curvature(sphere):
@@ -480,6 +485,11 @@ def test_invalid_subdivision(sphere):
     with pytest.raises(ValueError):
         sphere.subdivide(1, 'not valid')
 
+    # check non-triangulated
+    mesh = pyvista.Cylinder()
+    with pytest.raises(NotAllTrianglesError):
+        mesh.subdivide(1)
+
 
 def test_extract_feature_edges(sphere):
     # Test extraction of NO edges
@@ -500,6 +510,11 @@ def test_decimate(sphere):
     assert mesh.n_points < sphere.n_points
     assert mesh.n_faces < sphere.n_faces
 
+    # check non-triangulated
+    mesh = pyvista.Cylinder()
+    with pytest.raises(NotAllTrianglesError):
+        mesh.decimate(0.5)
+
 
 def test_decimate_pro(sphere):
     mesh = sphere.decimate_pro(0.5, progress_bar=True, max_degree=10)
@@ -509,6 +524,11 @@ def test_decimate_pro(sphere):
     mesh.decimate_pro(0.5, inplace=True, progress_bar=True)
     assert mesh.n_points < sphere.n_points
     assert mesh.n_faces < sphere.n_faces
+
+    # check non-triangulated
+    mesh = pyvista.Cylinder()
+    with pytest.raises(NotAllTrianglesError):
+        mesh.decimate_pro(0.5)
 
 
 def test_compute_normals(sphere):


### PR DESCRIPTION
We have a few filters that need all-triangle meshes (and this is even documented), but there was no check for this.

The result for non-triangular meshes varies, e.g.
```py
>>> import pyvista as pv
>>> pv.Cube().decimate(0.5)
2022-07-03 17:48:56.522 (   6.404s) [        1C510740]vtkQuadricDecimation.cx:214    ERR| vtkQuadricDecimation (0x2b11330): Can only decimate triangles
ERROR:root:Can only decimate triangles
PolyData (0x7fde1bfa6dc0)
  N Cells:	0
  N Points:	0
  X Bounds:	1.000e+299, -1.000e+299
  Y Bounds:	1.000e+299, -1.000e+299
  Z Bounds:	1.000e+299, -1.000e+299
  N Arrays:	0
```

```py
>>> pv.Cube().decimate_pro(0.5)
2022-07-03 17:49:09.501 (  19.383s) [        1C510740]     vtkDecimatePro.cxx:191    ERR| vtkDecimatePro (0x2b11330): DecimatePro does not accept polygons that are not triangles.
ERROR:root:DecimatePro does not accept polygons that are not triangles.
PolyData (0x7fddfd94fdc0)
  N Cells:	6
  N Points:	8
  X Bounds:	-5.000e-01, 5.000e-01
  Y Bounds:	-5.000e-01, 5.000e-01
  Z Bounds:	-5.000e-01, 5.000e-01
  N Arrays:	3
```