### PR TITLE
Fix a few minor contour()-related issues

### DIFF
--- a/examples/01-filter/flying_edges.py
+++ b/examples/01-filter/flying_edges.py
@@ -46,7 +46,7 @@ x, y, z = grid.points.T
 
 # sample and plot
 values = spider_cage(x, y, z)
-mesh = grid.contour(1, values, method='marching_cubes', rng=[1, 0])
+mesh = grid.contour(1, values, method='marching_cubes', rng=[1, 1])
 dist = np.linalg.norm(mesh.points, axis=1)
 mesh.plot(scalars=dist, smooth_shading=True, specular=5, cmap="plasma", show_scalar_bar=False)
 
@@ -88,7 +88,7 @@ x, y, z = grid.points.T
 
 # sample and plot
 values = barth_sextic(x, y, z)
-mesh = grid.contour(1, values, method='flying_edges', rng=[-0.0, 0])
+mesh = grid.contour([1], values, method='flying_edges')
 dist = np.linalg.norm(mesh.points, axis=1)
 mesh.plot(scalars=dist, smooth_shading=True, specular=5, cmap="plasma", show_scalar_bar=False)
 
@@ -104,7 +104,7 @@ def angle_to_range(angle):
     return -2 * np.sin(angle)
 
 
-mesh = grid.contour(1, values, method='flying_edges', rng=[angle_to_range(0), 0])
+mesh = grid.contour([angle_to_range(0)], values, method='flying_edges')
 dist = np.linalg.norm(mesh.points, axis=1)
 
 pl = pv.Plotter()
@@ -120,7 +120,7 @@ pl.add_mesh(
 pl.open_gif('barth_sextic.gif')
 
 for angle in np.linspace(0, np.pi, 15)[:-1]:
-    new_mesh = grid.contour(1, values, method='flying_edges', rng=[angle_to_range(angle), 0])
+    new_mesh = grid.contour([angle_to_range(angle)], values, method='flying_edges')
     mesh.overwrite(new_mesh)
     pl.update_scalars(np.linalg.norm(new_mesh.points, axis=1), render=False)
     pl.write_frame()

--- a/examples/01-filter/flying_edges.py
+++ b/examples/01-filter/flying_edges.py
@@ -46,7 +46,7 @@ x, y, z = grid.points.T
 
 # sample and plot
 values = spider_cage(x, y, z)
-mesh = grid.contour(1, values, method='marching_cubes', rng=[1, 1])
+mesh = grid.contour([1], values, method='marching_cubes')
 dist = np.linalg.norm(mesh.points, axis=1)
 mesh.plot(scalars=dist, smooth_shading=True, specular=5, cmap="plasma", show_scalar_bar=False)
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1554,6 +1554,9 @@ class DataSetFilters:
         if rng is not None:
             if not isinstance(rng, (np.ndarray, collections.abc.Sequence)):
                 raise TypeError(f'Array-like rng expected, got {type(rng).__name__}.')
+            rng_shape = np.shape(rng)
+            if rng_shape != (2,):
+                raise ValueError(f'rng must be a two-length array-like, not {rng}.')
             if rng[0] > rng[1]:
                 raise ValueError(f'rng must be a sorted min-max pair, not {rng}.')
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1551,6 +1551,12 @@ class DataSetFilters:
         else:
             raise ValueError(f"Method '{method}' is not supported")
 
+        if rng is not None:
+            if not isinstance(rng, (np.ndarray, collections.abc.Sequence)):
+                raise TypeError(f'Array-like rng expected, got {type(rng).__name__}.')
+            if rng[0] > rng[1]:
+                raise ValueError(f'rng must be a sorted min-max pair, not {rng}.')
+
         if isinstance(scalars, np.ndarray):
             scalars_name = 'Contour Input'
             self[scalars_name] = scalars

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1585,9 +1585,7 @@ class DataSetFilters:
             field = get_array_association(self, scalars, preference=preference)
         # NOTE: only point data is allowed? well cells works but seems buggy?
         if field != FieldAssociation.POINT:
-            raise TypeError(
-                f'Contour filter only works on Point data. Array ({scalars}) is in the Cell data.'
-            )
+            raise TypeError('Contour filter only works on point data.')
         alg.SetInputArrayToProcess(
             0, 0, 0, field.value, scalars
         )  # args: (idx, port, connection, field, name)

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1557,10 +1557,17 @@ class DataSetFilters:
             if rng[0] > rng[1]:
                 raise ValueError(f'rng must be a sorted min-max pair, not {rng}.')
 
-        if isinstance(scalars, np.ndarray):
+        if scalars is None or isinstance(scalars, str):
+            pass
+        elif isinstance(scalars, (np.ndarray, collections.abc.Sequence)):
             scalars_name = 'Contour Input'
             self[scalars_name] = scalars
             scalars = scalars_name
+        else:
+            raise TypeError(
+                f'Invalid scalars of type {type(scalars).__name__}, '
+                'expected array-like or string.'
+            )
 
         # Make sure the input has scalars to contour on
         if self.n_arrays < 1:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -538,6 +538,12 @@ def test_contour_errors(uniform):
         uniform.contour()
     with pytest.raises(ValueError):
         uniform.contour(method='invalid method')
+    with pytest.raises(TypeError):
+        uniform.contour(rng={})
+    with pytest.raises(ValueError, match='rng must be a two-length'):
+        uniform.contour(rng=[1])
+    with pytest.raises(ValueError, match='rng must be a sorted'):
+        uniform.contour(rng=[2, 1])
 
 
 def test_elevation():


### PR DESCRIPTION
This is a collection of minor things I came across while debugging https://github.com/pyvista/pyvista/issues/2901.

1. The `rng` range in `contour()` should be a sorted `(min, max)` pair, otherwise we raise.
2. The contour examples in the Flying Edges example should use a single contour value specified explicitly instead of specifying a degenerate range containing the same value twice (the original unsorted values probably only worked due to how VTK handles non-sorted cases).
3. Scalars to `contour()` should be allowed to be lists and other array-likes.
4. The original error in case of missing point scalars was confusing, because it did this:
  ```py
  >>> pv.Sphere().contour(1, scalars='potato')
  Traceback (most recent call last):
    File "<stdin>", line 1, in <module>
    File "/home/adeak/pyvista/pyvista/core/filters/data_set.py", line 1588, in contour
      raise TypeError(
  TypeError: Contour filter only works on Point data. Array (potato) is in the Cell data.
  ```
  Since the same error appears when (i) the scalar name is invalid, and (ii) when it refers to cell scalars, and (iii) when the explicit scalars array passed is consistent with cell scalars, I decided to simplify it just to say that we need point scalars.