### PR TITLE
Enforce scalar output for contour filter

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1460,9 +1460,10 @@ class DataSetFilters:
             Number of isosurfaces to compute across valid data range or a
             sequence of float values to explicitly use as the isosurfaces.
 
-        scalars : str, numpy.ndarray, optional
-            Name or array of scalars to threshold on. Defaults to
-            currently active scalars.
+        scalars : str, collections.abc.Sequence, numpy.ndarray, optional
+            Name or array of scalars to threshold on. If this is an array, the
+            output of this filter will save them as ``"Contour Data"``.
+            Defaults to currently active scalars.
 
         compute_normals : bool, optional
             Compute normals for the dataset.
@@ -1533,7 +1534,7 @@ class DataSetFilters:
         >>> x, y, z = grid.points.T
         >>> values = f(x, y, z)
         >>> out = grid.contour(
-        ...     1, scalars=values, rng=[0, 0], method='flying_edges'
+        ...     1, scalars=values, rng=[0, 0], method='flying_edges',
         ... )
         >>> out.plot(color='tan', smooth_shading=True)
 
@@ -1551,10 +1552,16 @@ class DataSetFilters:
         else:
             raise ValueError(f"Method '{method}' is not supported")
 
-        if isinstance(scalars, np.ndarray):
-            scalars_name = 'Contour Input'
+        if isinstance(scalars, str):
+            scalars_name = scalars
+        elif isinstance(scalars, (collections.abc.Sequence, np.ndarray)):
+            scalars_name = 'Contour Data'
             self[scalars_name] = scalars
-            scalars = scalars_name
+        elif scalars is not None:
+            raise TypeError(
+                f'Invalid type ({type(scalars)}) for `scalars`. Should be either '
+                'a numpy.ndarray or a string.'
+            )
 
         # Make sure the input has scalars to contour on
         if self.n_arrays < 1:
@@ -1567,22 +1574,26 @@ class DataSetFilters:
         # set the array to contour on
         if scalars is None:
             pyvista.set_default_active_scalars(self)
-            field, scalars = self.active_scalars_info
+            field, scalars_name = self.active_scalars_info
         else:
-            field = get_array_association(self, scalars, preference=preference)
+            field = get_array_association(self, scalars_name, preference=preference)
         # NOTE: only point data is allowed? well cells works but seems buggy?
         if field != FieldAssociation.POINT:
             raise TypeError(
                 f'Contour filter only works on Point data. Array ({scalars}) is in the Cell data.'
             )
         alg.SetInputArrayToProcess(
-            0, 0, 0, field.value, scalars
+            0,
+            0,
+            0,
+            field.value,
+            scalars_name,
         )  # args: (idx, port, connection, field, name)
         # set the isosurfaces
         if isinstance(isosurfaces, int):
             # generate values
             if rng is None:
-                rng = self.get_data_range(scalars)
+                rng = self.get_data_range(scalars_name)
             alg.GenerateValues(isosurfaces, rng)
         elif isinstance(isosurfaces, (np.ndarray, collections.abc.Sequence)):
             alg.SetNumberOfContours(len(isosurfaces))
@@ -1591,7 +1602,14 @@ class DataSetFilters:
         else:
             raise TypeError('isosurfaces not understood.')
         _update_alg(alg, progress_bar, 'Computing Contour')
-        return _get_output(alg)
+        output = _get_output(alg)
+
+        # some of these filters fail to correctly name the array
+        if scalars_name not in output.point_data:
+            if 'Unnamed_0' in output.point_data:
+                output.point_data[scalars_name] = output.point_data.pop('Unnamed_0')
+
+        return output
 
     def texture_map_to_plane(
         self,

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -525,6 +525,15 @@ def test_contour(uniform, method):
     iso = uniform.contour(isosurfaces=[100, 300, 500], method=method, progress_bar=True)
     assert iso is not None
 
+    # ensure filter can work with non-string inputs
+    iso_new_scalars = uniform.contour(
+        isosurfaces=[100, 300, 500],
+        scalars=range(uniform.n_points),
+        method=method,
+    )
+
+    assert 'Contour Data' in iso_new_scalars.point_data
+
 
 def test_contour_errors(uniform):
     with pytest.raises(TypeError):


### PR DESCRIPTION
Resolve #2901 by enforcing scalar output array name.

Bonus: Permits `numpy.ndarray` and sequences in ``scalars``.

Thanks @adeak for pointing out the issues and producing a minimnum working example that replicates the error.
