### PR TITLE
Remove extra references

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3316,15 +3316,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
             self.last_image = self.screenshot(None, return_img=True)
             self.last_image_depth = self.get_image_depth()
 
-        # reset scalar bars
+        # reset scalar bars and clear the render window
         self.clear()
-
-        # grab the display id before clearing the window
-        # this is an experimental feature
-        # if KILL_DISPLAY:  # pragma: no cover
-        #     disp_id = None
-        #     if hasattr(self, 'ren_win'):
-        #         disp_id = self.ren_win.GetGenericDisplayId()
         self._clear_ren_win()
 
         if hasattr(self, 'iren') and self.iren is not None:

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -8,24 +8,9 @@ import weakref
 from pyvista import _vtk
 from pyvista.utilities import try_callback
 
-# import warnings
-
-
 log = logging.getLogger(__name__)
 log.setLevel('CRITICAL')
 log.addHandler(logging.StreamHandler())
-
-
-# EXPERIMENTAL: permit pyvista to kill the render window
-# KILL_DISPLAY = platform.system() == 'Linux' and os.environ.get('PYVISTA_KILL_DISPLAY')
-# if KILL_DISPLAY:  # pragma: no cover
-#     # this won't work under wayland
-#     try:
-#         X11 = ctypes.CDLL("libX11.so")
-#         X11.XCloseDisplay.argtypes = [ctypes.c_void_p]
-#     except OSError:
-#         warnings.warn('PYVISTA_KILL_DISPLAY: Unable to load X11.\nProbably using wayland')
-#         KILL_DISPLAY = False
 
 
 class RenderWindowInteractor:
@@ -808,8 +793,6 @@ class RenderWindowInteractor:
             self._style_class.remove_observers()
 
         self.terminate_app()
-        # if KILL_DISPLAY:  # pragma: no cover
-        #     _kill_display(disp_id)
 
     def set_render_window(self, ren_win):
         """Set the render window."""
@@ -908,28 +891,3 @@ def _style_factory(klass):
                 self.RemoveObserver(obs)
 
     return CustomStyle
-
-
-# def _kill_display(disp_id):  # pragma: no cover
-#     """Forcibly close the display on Linux.
-
-#     See: https://gitlab.kitware.com/vtk/vtk/-/issues/17917#note_783584
-
-#     And more details into why...
-#     https://stackoverflow.com/questions/64811503
-
-#     Notes
-#     -----
-#     This is to be used experimentally and is known to cause issues
-#     on `pyvistaqt`
-
-#     """
-#     if platform.system() != 'Linux':
-#         raise OSError('This method only works on Linux')
-
-#     if disp_id:
-#         cdisp_id = int(disp_id[1:].split('_')[0], 16)
-
-#         # this is unsafe as events might be queued, but sometimes the
-#         # window fails to close if we don't just close it
-#         Thread(target=X11.XCloseDisplay, args=(cdisp_id,)).start()

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -216,8 +216,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         self._floor_kwargs = []
         # this keeps track of lights added manually to prevent garbage collection
         self._lights = []
-        self._camera = Camera(self)
-        self.SetActiveCamera(self._camera)
+        self.SetActiveCamera(Camera(self))
         self._empty_str = None  # used to track reference to a vtkStringArray
         self._shadow_pass = None
 
@@ -305,13 +304,12 @@ class Renderer(_vtk.vtkOpenGLRenderer):
     @property
     def camera(self):
         """Return the active camera for the rendering scene."""
-        return self._camera
+        return self.GetActiveCamera()
 
     @camera.setter
     def camera(self, source):
         """Set the active camera for the rendering scene."""
-        self._camera = source
-        self.SetActiveCamera(self._camera)
+        self.SetActiveCamera(source)
         self.camera_position = CameraPosition(
             scale_point(source, source.position, invert=True),
             scale_point(source, source.focal_point, invert=True),
@@ -2763,7 +2761,6 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         self.remove_legend(render=render)
         self.RemoveAllViewProps()
         self._actors = {}
-        self._camera = None
         self._bounding_box = None
         self._marker_actor = None
         self._border_actor = None

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -203,7 +203,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         """Initialize the renderer."""
         super().__init__()
         self._actors = {}
-        self.parent = parent  # the plotter
+        self.parent = proxy(parent)  # the plotter
         self._theme = parent.theme
         self.camera_set = False
         self.bounding_box_actor = None
@@ -2114,7 +2114,8 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         self._labels.pop(actor.GetAddressAsString(""), None)
 
         # ensure any scalar bars associated with this actor are removed
-        self.parent.scalar_bars._remove_mapper_from_plotter(actor)
+        if self.parent is not None:
+            self.parent.scalar_bars._remove_mapper_from_plotter(actor)
         self.RemoveActor(actor)
 
         if name is None:
@@ -2127,7 +2128,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             self.reset_camera()
         elif not self.camera_set and reset_camera is None:
             self.reset_camera()
-        elif render:
+        elif render and self.parent is not None:
             self.parent.render()
 
         self.Modified()

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1026,8 +1026,8 @@ def test_plot_clim(sphere):
         clim=10,
         show_scalar_bar=False,
     )
-    plotter.show(before_close_callback=verify_cache_image)
     assert plotter.mapper.GetScalarRange() == (-10, 10)
+    plotter.show(before_close_callback=verify_cache_image)
 
 
 def test_invalid_n_arrays(sphere):


### PR DESCRIPTION
Partial resolves #2577 by removing internal references that are causing `pyvista.Plotter` to not be collected.

Thanks @WesleyTheGeolien for pointing this out.

Memory leak for 1000 plotters goes from ~60 MB to ~7. It's some improvement but it's still annoying that these references aren't being collected.
