### PR TITLE
fix vtk version support

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -138,12 +138,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+
+      # see discussion at https://github.com/pyvista/pyvista/issues/2867
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
-        vtk-version: ['latest']
         include:
-          - python-version: '3.9'
+          - python-version: '3.7'
+            vtk-version: '8.1.2'
+          - python-version: '3.8'
             vtk-version: '9.0.3'
+          - python-version: '3.9'
+            vtk-version: '9.1'
+          - python-version: '3.10'
+            vtk-version: 'latest'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -464,6 +464,18 @@ if VTK9:
     from vtkmodules.vtkViewsContext2D import vtkContextInteractorStyle
 
     # lazy import for some of the less used readers
+    def lazy_vtkVRMLImporter():
+        """Lazy import of the vtkVRMLImporter."""
+        from vtkmodules.vtkIOImport import vtkVRMLImporter
+
+        return vtkVRMLImporter()
+
+    def lazy_vtkVRMLExporter():
+        """Lazy import of the vtkVRMLImporter."""
+        from vtkmodules.vtkIOImport import vtkVRMLExporter
+
+        return vtkVRMLExporter()
+
     def lazy_vtkGL2PSExporter():
         """Lazy import of the vtkGL2PSExporter."""
         from vtkmodules.vtkIOExportGL2PS import vtkGL2PSExporter
@@ -544,6 +556,14 @@ else:  # pragma: no cover
     )
 
     # match the imports for VTK9
+    def lazy_vtkVRMLImporter():
+        """Lazy import of the vtkVRMLImporter."""
+        return vtk.vtkVRMLImporter()
+
+    def lazy_vtkVRMLExporter():
+        """Lazy import of the vtkVRMLExporter."""
+        return vtk.vtkVRMLExporter()
+
     def lazy_vtkGL2PSExporter():
         """Lazy import of the vtkGL2PSExporter."""
         return vtk.vtkGL2PSExporter()

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5172,7 +5172,8 @@ class DataSetFilters:
         Area or volume is also provided in point data.
 
         This filter uses the VTK `vtkIntegrateAttributes
-        <https://vtk.org/doc/nightly/html/classvtkIntegrateAttributes.html>`_.
+        <https://vtk.org/doc/nightly/html/classvtkIntegrateAttributes.html>`_
+        and requires VTK v9.1.0 or newer.
 
         Parameters
         ----------
@@ -5182,7 +5183,8 @@ class DataSetFilters:
         Returns
         -------
         pyvista.UnstructuredGird
-            Mesh with 1 point and 1 vertex cell with integrated data in point and cell data.
+            Mesh with 1 point and 1 vertex cell with integrated data in point
+            and cell data.
 
         Examples
         --------
@@ -5204,8 +5206,11 @@ class DataSetFilters:
         See the :ref:`integrate_example` for more examples using this filter.
 
         """
-        filter = _vtk.vtkIntegrateAttributes()
-        filter.SetInputData(self)
-        filter.SetDivideAllCellDataByVolume(False)
-        _update_alg(filter, progress_bar, 'Integrating Variables')
-        return _get_output(filter)
+        if not hasattr(_vtk, 'vtkIntegrateAttributes'):  # pragma: no cover
+            raise VTKVersionError('`integrate_data` requires VTK 9.1.0 or newer.')
+
+        alg = _vtk.vtkIntegrateAttributes()
+        alg.SetInputData(self)
+        alg.SetDivideAllCellDataByVolume(False)
+        _update_alg(alg, progress_bar, 'Integrating Variables')
+        return _get_output(alg)

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -3035,6 +3035,9 @@ class PolyDataFilters(DataSetFilters):
         else:
             raise TypeError('Invalid type given to `capping`. Must be a string.')
 
+        if not hasattr(_vtk, 'vtkTrimmedExtrusionFilter'):  # pragma: no cover
+            raise VTKVersionError('extrude_trim requires VTK 9.0.0 or newer.')
+
         alg = _vtk.vtkTrimmedExtrusionFilter()
         alg.SetInputData(self)
         alg.SetExtrusionDirection(*direction)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -389,9 +389,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             raise FileNotFoundError(f'Unable to locate {filename}')
 
         # lazy import here to avoid importing unused modules
-        from vtkmodules.vtkIOImport import vtkVRMLImporter
-
-        importer = vtkVRMLImporter()
+        importer = _vtk.lazy_vtkVRMLImporter()
         importer.SetFileName(filename)
         importer.SetRenderWindow(self.ren_win)
         importer.Update()
@@ -644,10 +642,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if not hasattr(self, "ren_win"):
             raise RuntimeError("This plotter has been closed and cannot be shown.")
 
-        # lazy import here to avoid importing unused modules
-        from vtkmodules.vtkIOExport import vtkVRMLExporter
-
-        exporter = vtkVRMLExporter()
+        exporter = _vtk.lazy_vtkVRMLExporter()
         exporter.SetFileName(filename)
         exporter.SetRenderWindow(self.ren_win)
         exporter.Write()

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     'pillow',
     'appdirs',
     'scooby>=0.5.1',
-    'vtk',
+    'vtk>=8.1.2,<=9.2',
 ]
 
 readme_file = os.path.join(filepath, 'README.rst')
@@ -54,6 +54,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     url='https://github.com/pyvista/pyvista',
     keywords='vtk numpy plotting mesh',

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 
 import numpy as np
 import pytest
-from vtk import VTK_QUADRATIC_HEXAHEDRON
+from vtk import VTK_QUADRATIC_HEXAHEDRON, VTK_QUADRATIC_TRIANGLE
 
 import pyvista
 from pyvista import examples
@@ -1721,7 +1721,7 @@ def test_iadd_general(uniform, hexbeam, sphere):
 
 
 def test_compute_cell_quality():
-    mesh = pyvista.ParametricEllipsoid().decimate(0.8)
+    mesh = pyvista.ParametricEllipsoid().triangulate().decimate(0.8)
     qual = mesh.compute_cell_quality(progress_bar=True)
     assert 'CellQuality' in qual.array_names
     with pytest.raises(KeyError):
@@ -2149,7 +2149,7 @@ def test_tessellate():
         ]
     )
     cells = np.array([6, 0, 1, 2, 3, 4, 5])
-    cell_types = np.array([69])
+    cell_types = np.array([VTK_QUADRATIC_TRIANGLE])
     ugrid = pyvista.UnstructuredGrid(cells, cell_types, points)
     tessellated = ugrid.tessellate(progress_bar=True)
     assert tessellated.n_cells > ugrid.n_cells
@@ -2257,6 +2257,7 @@ def test_transform_mesh_and_vectors(datasets, num_cell_arrays, num_point_data):
             )
 
 
+@skip_not_vtk9
 @pytest.mark.parametrize("num_cell_arrays,num_point_data", itertools.product([0, 1, 2], [0, 1, 2]))
 def test_transform_int_vectors_warning(datasets, num_cell_arrays, num_point_data):
     for dataset in datasets:
@@ -2416,7 +2417,7 @@ def test_extrude_rotate():
     rotation_axis = (0, 1, 0)
     if not pyvista.vtk_version_info >= (9, 1, 0):
         with pytest.raises(VTKVersionError):
-            poly = line.extrude_rotate(rotation_axis=rotation_axis)
+            poly = line.extrude_rotate(rotation_axis=rotation_axis, capping=True)
     else:
         poly = line.extrude_rotate(
             rotation_axis=rotation_axis, resolution=resolution, progress_bar=True, capping=True
@@ -2437,6 +2438,7 @@ def test_extrude_rotate_inplace():
     assert poly.n_points == (resolution + 1) * old_line.n_points
 
 
+@skip_not_vtk9
 def test_extrude_trim():
     direction = (0, 0, 1)
     mesh = pyvista.Plane(
@@ -2449,6 +2451,7 @@ def test_extrude_trim():
     assert np.isclose(poly.volume, 1.0)
 
 
+@skip_not_vtk9
 @pytest.mark.parametrize('extrusion', ["boundary_edges", "all_edges"])
 @pytest.mark.parametrize(
     'capping', ["intersection", "minimum_distance", "maximum_distance", "average_distance"]
@@ -2485,6 +2488,7 @@ def test_extrude_trim_catch():
         _ = mesh.extrude_trim([1, 2], trim_surface)
 
 
+@skip_not_vtk9
 def test_extrude_trim_inplace():
     direction = (0, 0, 1)
     mesh = pyvista.Plane(
@@ -2554,6 +2558,7 @@ def test_reconstruct_surface_unstructured():
     assert mesh.n_points
 
 
+@skip_not_vtk9
 def test_integrate_data_datasets(datasets):
     """Test multiple dataset types."""
     for dataset in datasets:
@@ -2566,6 +2571,7 @@ def test_integrate_data_datasets(datasets):
             raise ValueError("Unexpected integration")
 
 
+@skip_not_vtk9
 def test_integrate_data():
     """Test specific case."""
     # sphere with radius = 0.5, area = pi

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -9,6 +9,7 @@ import vtk
 import pyvista
 from pyvista import examples
 from pyvista._vtk import VTK9
+from pyvista.core.errors import VTKVersionError
 from pyvista.errors import AmbiguousDataError, MissingDataError
 from pyvista.plotting import system_supports_plotting
 from pyvista.utilities.misc import PyvistaDeprecationWarning
@@ -148,7 +149,7 @@ def test_init_from_arrays(specify_offset):
     if VTK9:
         assert np.allclose(grid.cell_connectivity, np.arange(16))
     else:
-        with pytest.raises(AttributeError):
+        with pytest.raises(VTKVersionError):
             grid.cell_connectivity
 
 
@@ -194,7 +195,7 @@ def test_init_from_dict(multiple_cell_types, flat_cells):
             grid.cell_connectivity, (np.arange(20) if multiple_cell_types else np.arange(16))
         )
     else:
-        with pytest.raises(AttributeError):
+        with pytest.raises(VTKVersionError):
             grid.cell_connectivity
 
     # Now fetch the arrays

--- a/tests/test_render_window_interactor.py
+++ b/tests/test_render_window_interactor.py
@@ -10,11 +10,16 @@ skip_no_plotting = pytest.mark.skipif(
     not system_supports_plotting(), reason="Requires system to support plotting"
 )
 
+skip_needs_vtk_9 = pytest.mark.skipif(
+    pyvista.vtk_version_info < (9, 1, 0), reason="Requires VTK>=9.1.0"
+)
+
 
 def empty_callback():
     return
 
 
+@skip_needs_vtk_9
 def test_observers():
     pl = pyvista.Plotter()
 

--- a/tests/utilities/test_reader.py
+++ b/tests/utilities/test_reader.py
@@ -790,6 +790,7 @@ def test_tiff_reader():
     assert all([mesh.n_points, mesh.n_cells])
 
 
+@pytest.mark.skipif(pyvista.vtk_version_info < (9, 0), reason="Requires VTK v9.0.0 or newer")
 def test_hdr_reader():
     filename = examples.download_parched_canal_4k(load=False)
     reader = pyvista.get_reader(filename)


### PR DESCRIPTION
Resolves #2867 by implementing matrix testing for VTK and Python.

- Python 3.7 --> ``vtk==8.1.2``
- Python 3.8 --> ``vtk==9.0.3``
- Python 3.9 --> ``vtk==9.1``
- Python 3.10 --> ``vtk==9.2.0``

Additionally, because we aren't testing Python 3.7 with 8.1.2, we've had some VTK version support regressions only discovered when locally testing 3.7. This PR fixes those regressions.

---

Also, I propose that we support the oldest VTK version with a viable wheel available for [actively supported versions of Python](https://endoflife.date/python)  available on PyPI. For example, the lowest supported version of Python as of this PR is Python 3.7, and the lowest supported version of VTK for 3.7 is [vtk==8.1.2](https://pypi.org/project/vtk/8.1.2/).

This is reflected in the ``install_requires`` in our ``setup.py``.

As soon as support for Python 3.7 is dropped, we can then drop support for both Python 3.7 and VTK 8.1.2 in both our ``python_requires`` and ``install_requires``.

As much as I would prefer to follow NumPy's version support [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html) deprecation policy, I know of many who are stuck using older versions of Python and need support for older versions of VTK and cannot upgrade agressively. With this approach we can still depricate support for older versions of VTK and Python, but in a manner that works for all that use this library with any currently supported version of Python.

