### PR TITLE
MAINT: Dont allow deep clean to fail

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3370,11 +3370,20 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if hasattr(self, 'renderers'):
             self.renderers.deep_clean()
         if getattr(self, 'mesh', None) is not None:
-            self.mesh.point_data = None
-            self.mesh.cell_data = None
+            try:
+                self.mesh.point_data = None
+            except AttributeError:
+                pass
+            try:
+                self.mesh.cell_data = None
+            except AttributeError:
+                pass
         self.mesh = None
         if getattr(self, 'mapper', None) is not None:
-            self.mapper.lookup_table = None
+            try:
+                self.mapper.lookup_table = None
+            except AttributeError:
+                pass
         self.mapper = None
         self.volume = None
         self.textActor = None


### PR DESCRIPTION
Over in MNE-Python we are getting some [mysterious errors in CIs](https://github.com/mne-tools/mne-python/runs/7304668129?check_suite_focus=true):
```
______________ ERROR at teardown of test_3d_functions[pyvistaqt] _______________
mne/conftest.py:462: in renderer
with _use_backend(request.param, interactive=False) as renderer:
/usr/share/miniconda/envs/mne/lib/python3.10/contextlib.py:142: in __exit__
next(self.gen)
mne/conftest.py:503: in _use_backend
    renderer.backend._close_all()
mne/viz/backends/_pyvista.py:984: in _close_all
    close_all()
/usr/share/miniconda/envs/mne/lib/python3.10/site-packages/pyvista/plotting/plotting.py:75: in close_all
    p.deep_clean()
/usr/share/miniconda/envs/mne/lib/python3.10/site-packages/pyvista/plotting/plotting.py:3373: in deep_clean
self.mesh.point_data = None
E   AttributeError: can't set attribute 'point_data'
```
It seems like `deep_clean` should never fail, so this gets past this issue with a try/except. Not 100% sure it's the right approach but it seems reasonable at least.