### PR TITLE
Cache apt

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           requirement_files: requirements_docs.txt
 
-      - uses: awalsh128/cache-apt-pkgs-action@v1.03
+      - uses: awalsh128/cache-apt-pkgs-action@v1.0.3
         with:
           packages: libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime
           version: 1.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           requirement_files: requirements_docs.txt
 
-      - uses: awalsh128/cache-apt-pkgs-action@v1.1
+      - uses: awalsh128/cache-apt-pkgs-action@v1.03
         with:
           packages: libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime
           version: 1.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           requirement_files: requirements_docs.txt
 
-      - uses: awalsh128/cache-apt-pkgs-action@v1.0.2
+      - uses: awalsh128/cache-apt-pkgs-action@v1.1
         with:
           packages: libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime
           version: 1.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           packages: libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime
           version: 1.0
+          refresh: true # Force refresh / upgrade v1.0 cache.
 
       - name: Install OSMesa VTK
         run: pip install https://github.com/pyvista/pyvista-wheels/raw/main/vtk-osmesa-9.1.0-cp39-cp39-linux_x86_64.whl

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,10 +45,10 @@ jobs:
         with:
           requirement_files: requirements_docs.txt
 
-      - name: Install OS Packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime
+      - uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime
+          version: 1.0
 
       - name: Install OSMesa VTK
         run: pip install https://github.com/pyvista/pyvista-wheels/raw/main/vtk-osmesa-9.1.0-cp39-cp39-linux_x86_64.whl

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           requirement_files: requirements_docs.txt
 
-      - uses: awalsh128/cache-apt-pkgs-action@v1
+      - uses: awalsh128/cache-apt-pkgs-action@v1.0.2
         with:
           packages: libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime
           version: 1.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,6 @@ jobs:
         with:
           packages: libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime
           version: 1.0
-          refresh: true # Force refresh / upgrade v1.0 cache.
 
       - name: Install OSMesa VTK
         run: pip install https://github.com/pyvista/pyvista-wheels/raw/main/vtk-osmesa-9.1.0-cp39-cp39-linux_x86_64.whl

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -178,11 +178,13 @@ jobs:
         if: ${{ matrix.vtk-version != 'latest' }}
         run: pip install vtk==${{ matrix.vtk-version }}
 
+      - uses: awalsh128/cache-apt-pkgs-action@v1.0.3
+        with:
+          packages: libgl1-mesa-glx xvfb python-tk
+          version: 1.0
+
       - name: Install Testing Requirements
-        run: |
-          sudo apt-get update
-          sudo apt-get install libgl1-mesa-glx xvfb python-tk -y
-          pip install -r requirements_test.txt
+        run: pip install -r requirements_test.txt
 
       - name: Software Report
         run: |


### PR DESCRIPTION
Cache packages from `apt-get`.

Shaves a minute or two off the documentation and Linux CI/CD time depending on time of day.
