### PR TITLE
Use Python 3.9 for codecov

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -196,7 +196,7 @@ jobs:
           xvfb-run pytest -v --cov pyvista --cov-report xml --fail_extra_image_cache
 
       - uses: codecov/codecov-action@v3
-        if: matrix.python-version == '3.8'
+        if: matrix.python-version == '3.9'
         name: 'Upload coverage to CodeCov'
 
       - name: Check package


### PR DESCRIPTION
Update the CI/CD to use Python 3.9 when uploading codecov. This corrects the `codecov/project` reporting for code coverage since Python 3.9 uses `vtk==9.1.0`.
