### PR TITLE
Clear charts when clearing plotters

### DIFF
--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -4384,7 +4384,7 @@ class Charts:
     def deep_clean(self):
         """Remove all references to the chart objects and internal objects."""
         if self._scene is not None:
-            charts = [*self._charts]  # Make a copy, as this list will be modified by remove_plot
+            charts = [*self._charts]  # Make a copy, as this list will be modified by remove_chart
             for chart in charts:
                 self.remove_chart(chart)
             self._renderer.RemoveActor(self._actor)
@@ -4458,3 +4458,7 @@ class Charts:
         """Return an iterable of charts."""
         for chart in self._charts:
             yield chart
+
+    def __del__(self):
+        """Clean up before being destroyed."""
+        self.deep_clean()

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -4459,6 +4459,6 @@ class Charts:
         for chart in self._charts:
             yield chart
 
-    def __del__(self):
+    def __del__(self):  # pragma: no cover
         """Clean up before being destroyed."""
         self.deep_clean()

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1868,6 +1868,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
                 except KeyError:
                     pass
 
+        self._charts.deep_clean()
         self.remove_all_lights()
         self.RemoveAllViewProps()
         self.Modified()

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1868,7 +1868,8 @@ class Renderer(_vtk.vtkOpenGLRenderer):
                 except KeyError:
                     pass
 
-        self._charts.deep_clean()
+        if self.__charts is not None:
+            self._charts.deep_clean()
         self.remove_all_lights()
         self.RemoveAllViewProps()
         self.Modified()

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -977,38 +977,38 @@ def test_charts(pl):
 
     # Test add_chart
     pl.add_chart(top_left)
-    assert pl.renderers[0].__this__ == top_left._renderer.__this__
-    assert pl.renderers[0]._charts._scene.__this__ == top_left._scene.__this__
+    assert pl.renderer.__this__ == top_left._renderer.__this__
+    assert pl.renderer._charts._scene.__this__ == top_left._scene.__this__
     pl.add_chart(bottom_right)
-    assert len(pl.renderers[0]._charts) == 2
+    assert len(pl.renderer._charts) == 2
 
     # Test toggle_interaction
     pl.show(auto_close=False)  # We need to plot once to let the charts compute their true geometry
     assert not top_left.GetInteractive()
     assert not bottom_right.GetInteractive()
     assert (
-        pl.renderers[0]._charts.toggle_interaction((0.75 * win_size[0], 0.25 * win_size[1]))
+        pl.renderer._charts.toggle_interaction((0.75 * win_size[0], 0.25 * win_size[1]))
         is bottom_right._scene
     )
     assert not top_left.GetInteractive()
     assert bottom_right.GetInteractive()
-    assert pl.renderers[0]._charts.toggle_interaction((0, 0)) is None
+    assert pl.renderer._charts.toggle_interaction((0, 0)) is None
     assert not top_left.GetInteractive()
     assert not bottom_right.GetInteractive()
 
     # Test remove_chart
     pl.remove_chart(1)
-    assert len(pl.renderers[0]._charts) == 1
-    assert pl.renderers[0]._charts[0] == top_left
-    assert top_left in pl.renderers[0]._charts
+    assert len(pl.renderer._charts) == 1
+    assert pl.renderer._charts[0] == top_left
+    assert top_left in pl.renderer._charts
     pl.remove_chart(top_left)
-    assert len(pl.renderers[0]._charts) == 0
+    assert len(pl.renderer._charts) == 0
 
     # Test deep_clean
     pl.add_chart(top_left, bottom_right)
     pl.deep_clean()
-    assert len(pl.renderers[0]._charts) == 0
-    assert pl.renderers[0]._charts._scene is None
+    assert len(pl.renderer._charts) == 0
+    assert pl.renderer._charts._scene is None
 
     pl.add_chart(top_left, bottom_right)
     pl.clear()  # also calls deep_clean()

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -1010,6 +1010,11 @@ def test_charts(pl):
     assert len(pl.renderers[0]._charts) == 0
     assert pl.renderers[0]._charts._scene is None
 
+    pl.add_chart(top_left, bottom_right)
+    pl.clear()  # also calls deep_clean()
+    assert len(pl.renderer._charts) == 0
+    assert pl.renderer._charts._scene is None
+
 
 @skip_no_plotting
 def test_iren_context_style(pl):


### PR DESCRIPTION
[This Stack Overflow question](https://stackoverflow.com/questions/72985319/pyvista-why-does-the-callback-only-draw-the-3d-entities-and-not-the-2d-one-on-t/) has an excellent minimal example wherein calling `plotter.clear()` doesn't clear the underlying `Charts` object, which prevents replotting from succeeding.

It's still not clear to me what the exact mechanics are that prevent replotting, but it's clear (no pun intended) that
1. we _should_ clear charts on `plotter.clear()`, and
2. doing so fixes the bug.

For others as unfamiliar with these execution paths as I am:
1. `pyvistaqt.QtInteractor` inherits its `.clear()` method from `BasePlotter`
2. `BasePlotter` delegates it to `plotter.renderers.clear()`
3. `Renderers` delegates it to `plotter.renderer.clear()`
4. `Renderer.clear()` is the final source: https://github.com/pyvista/pyvista/blob/8f47b9e479737dcbe1de8bba1eb12c6688b8b9ce/pyvista/plotting/renderer.py#L1862-L1876

Calling `self._charts.deep_clean()` in there will make sure to clear the internal `Charts` object (after creating one from scratch if necessary; this is the cost of not messing with `__charts` directly), then removes the `Charts`' actor from the renderer.

---

A few things stood out to me while I was investigating this:
- There's no `Charts.clear()`, perhaps `deep_clean()` should be called that instead?
- `Charts` doesn't use the renderer's `add_actor()`/`remove_actor()` methods, which doesn't seem nice. E.g. `plotter.renderer._actors` has no knowledge of any chart-related stuff this way. Unless there's a good reason for this, we should fix this (potentially in a different PR; this bugfix would be nice to have in the next patch release).