### PR TITLE
Remove return docstring in export_obj()

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4574,11 +4574,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         filename : str
             Filename to export the scene to.  Should end in ``'.obj'``.
 
-        Returns
-        -------
-        vtkOBJExporter
-            Object exporter.
-
         """
         # lazy import vtkOBJExporter here as it takes a long time to
         # load and is not always used


### PR DESCRIPTION
Update docstring of export_obj by removing return.

### Overview

Update docstring of export_obj to correctly indicate it returns nothing.

Issue https://github.com/pyvista/pyvista/issues/2512.

Resolves issue https://github.com/pyvista/pyvista/issues/2512.

### Details

- < feature1 or bug1 description >
- < feature2 or bug2 description >

