### PR TITLE
remove code of conduct checkbox

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -51,4 +51,3 @@ body:
     attributes:
       label: Screenshots
       description: If applicable, please add screenshots to the text box below 
-

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -51,11 +51,4 @@ body:
     attributes:
       label: Screenshots
       description: If applicable, please add screenshots to the text box below 
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/pyvista/pyvista/blob/main/CODE_OF_CONDUCT.md)
-      options:
-        - label: I agree to follow this project's Code of Conduct
-          required: true
+

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -32,11 +32,3 @@ body:
       ```\n
       Or drag your screenshot here!
       "
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/pyvista/pyvista/blob/main/CODE_OF_CONDUCT.md)
-      options:
-        - label: I agree to follow this project's Code of Conduct
-          required: true

--- a/.github/ISSUE_TEMPLATE/maintenance-request.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance-request.yml
@@ -32,11 +32,3 @@ body:
       ```\n
       Or drag your screenshot here!
       "
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/pyvista/pyvista/blob/main/CODE_OF_CONDUCT.md)
-      options:
-        - label: I agree to follow this project's Code of Conduct
-          required: true


### PR DESCRIPTION
Remove the code of conduct checkbox. It's become quite annoying to see "1 task done" for all our issues and I think it clutters our issues.