### PR TITLE
Use has_module

### DIFF
--- a/pyvista/plotting/_plotting.py
+++ b/pyvista/plotting/_plotting.py
@@ -9,15 +9,6 @@ from pyvista.utilities import get_array
 from .tools import opacity_transfer_function
 
 
-def _has_matplotlib():
-    try:
-        import matplotlib  # noqa
-
-        return True
-    except ImportError:  # pragma: no cover
-        return False
-
-
 def prepare_smooth_shading(mesh, scalars, texture, split_sharp_edges, feature_angle, preference):
     """Prepare a dataset for smooth shading.
 

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -973,7 +973,7 @@ def get_cmap_safe(cmap):
         if not has_module('matplotlib'):
             raise ImportError(
                 'The use of custom colormaps requires the installation of matplotlib.'
-            )
+            )  # pragma: no cover
 
         from matplotlib.cm import get_cmap
 
@@ -987,7 +987,7 @@ def get_cmap_safe(cmap):
         if not has_module('matplotlib'):
             raise ImportError(
                 'The use of custom colormaps requires the installation of matplotlib.'
-            )
+            )  # pragma: no cover
 
         from matplotlib.colors import ListedColormap
 

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -6,8 +6,8 @@ import numpy as np
 
 from pyvista import _vtk
 from pyvista.utilities import convert_array, convert_string_array, raise_not_matching
+from pyvista.utilities.misc import has_module
 
-from ._plotting import _has_matplotlib
 from .colors import Color, get_cmap_safe
 from .tools import normalize
 
@@ -80,7 +80,7 @@ def make_mapper(mapper_class):
         ):
             """Set the scalars on this mapper."""
             if cmap is None:  # Set default map if matplotlib is available
-                if _has_matplotlib():
+                if has_module('matplotlib'):
                     cmap = theme.cmap
 
             # Set the array title for when it is added back to the mesh
@@ -180,7 +180,7 @@ def make_mapper(mapper_class):
 
                     check_colormap(cmap)
                 else:
-                    if not _has_matplotlib():
+                    if not has_module('matplotlib'):
                         cmap = None
                         logging.warning('Please install matplotlib for color maps.')
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -32,9 +32,9 @@ from pyvista.utilities import (
     wrap,
 )
 
-from ..utilities.misc import PyvistaDeprecationWarning, uses_egl
+from ..utilities.misc import PyvistaDeprecationWarning, has_module, uses_egl
 from ..utilities.regression import image_from_window
-from ._plotting import _has_matplotlib, prepare_smooth_shading, process_opacity
+from ._plotting import prepare_smooth_shading, process_opacity
 from .colors import Color, get_cmap_safe
 from .export_vtkjs import export_plotter_vtkjs
 from .mapper import make_mapper
@@ -2250,7 +2250,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
             if multi_colors:
                 # Compute unique colors for each index of the block
-                if _has_matplotlib():
+                if has_module('matplotlib'):
                     from itertools import cycle
 
                     import matplotlib
@@ -2926,11 +2926,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 table.SetAnnotation(float(val), str(anno))
 
         if cmap is None:  # Set default map if matplotlib is available
-            if _has_matplotlib():
+            if has_module('matplotlib'):
                 cmap = self._theme.cmap
 
         if cmap is not None:
-            if not _has_matplotlib():
+            if not has_module('matplotlib'):
                 raise ImportError('Please install matplotlib for volume rendering.')
 
             cmap = get_cmap_safe(cmap)

--- a/pyvista/utilities/misc.py
+++ b/pyvista/utilities/misc.py
@@ -1,5 +1,7 @@
 """Miscellaneous pyvista functions."""
 from collections import namedtuple
+from functools import lru_cache
+import importlib
 import os
 import warnings
 
@@ -22,6 +24,13 @@ def _set_plot_theme_from_env():
                 f'\n\nInvalid PYVISTA_PLOT_THEME environment variable "{theme}". '
                 f'Should be one of the following: {allowed}'
             )
+
+
+@lru_cache(maxsize=None)
+def has_module(module_name):
+    """Return if a module can be imported."""
+    module_spec = importlib.util.find_spec(module_name)
+    return module_spec is not None
 
 
 def raise_has_duplicates(arr):

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -1,0 +1,34 @@
+import pytest
+
+from pyvista.plotting.colors import get_cmap_safe
+
+COLORMAPS = []
+
+try:
+    import matplotlib
+
+    COLORMAPS.append('Greys')
+    HAS_MATPLOTLIB = True
+except:
+    HAS_MATPLOTLIB = False
+
+try:
+    import cmocean  # noqa: F401
+
+    COLORMAPS.append('algae')
+except ImportError:
+    pass
+
+
+try:
+    import colorcet  # noqa: F401
+
+    COLORMAPS.append('fire')
+except:
+    pass
+
+
+@pytest.mark.skipif(not HAS_MATPLOTLIB, reason='Requires matplotlib')
+@pytest.mark.parametrize("cmap", COLORMAPS)
+def test_get_cmap_safe(cmap):
+    assert isinstance(get_cmap_safe(cmap), matplotlib.colors.LinearSegmentedColormap)

--- a/tests/utilities/test_misc.py
+++ b/tests/utilities/test_misc.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from pyvista.utilities.misc import _set_plot_theme_from_env
+from pyvista.utilities.misc import _set_plot_theme_from_env, has_module
 
 
 def test_set_plot_theme_from_env():
@@ -12,3 +12,8 @@ def test_set_plot_theme_from_env():
             _set_plot_theme_from_env()
     finally:
         os.environ.pop('PYVISTA_PLOT_THEME', None)
+
+
+def test_has_module():
+    assert has_module('pytest')
+    assert not has_module('not_a_module')


### PR DESCRIPTION
In `colors.py` we check for the installation of `colorcet`, `matplotlib`, and `cmocean`. Assuming that the user does not have at least one of those modules installed, there's a signifiant cost to check if a module is installed:

```py
def try_import():
    try:
        import not_a_module
        return True
    except:
        pass

```

```py
>>> timeit try_import()
82.6 µs ± 87.4 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

This PR proposes the use of caching and `importlib` to check if a libary can be imported.

```py
import importlib
from functools import lru_cache


@lru_cache(maxsize=None)
def has_module(module_name):
    """Return if a module can be imported."""
    module_spec = importlib.util.find_spec(module_name)
    return module_spec is not None
```

```py
>>> timeit try_import('not_a_module')
43.7 ns ± 0.164 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
```
