### PR TITLE
Fix docstring default for log_scale in add_mesh

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2099,7 +2099,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         log_scale : bool, optional
             Use log scale when mapping data to colors. Scalars less
             than zero are mapped to the smallest representable
-            positive float. Default: ``True``.
+            positive float. Default: ``False``.
 
         pbr : bool, optional
             Enable physics based rendering (PBR) if the mesh is


### PR DESCRIPTION
### Overview

Fixes description of default `log_scale` in `add_mesh`.


### Details

See https://github.com/pyvista/pyvista/blob/647181b7b52d4b6c14130deb68c48ba5e025d7f3/pyvista/plotting/plotting.py#L1854

