### PR TITLE
Fix Plotter and children for proper garbage collection

### DIFF
--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -4370,7 +4370,7 @@ class Charts:
         # needed.
         self._scene = None
         self._actor = None
-        self._renderer = renderer
+        self._renderer = weakref.proxy(renderer)
 
     def _setup_scene(self):
         """Set up a new context scene and actor for these charts."""

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -4370,7 +4370,16 @@ class Charts:
         # needed.
         self._scene = None
         self._actor = None
-        self._renderer = weakref.proxy(renderer)
+
+        # a weakref.proxy would be nice here, but that doesn't play
+        # nicely with SetRenderer, so instead we'll use a weak reference
+        # plus a property to call it
+        self.__renderer = weakref.ref(renderer)
+
+    @property
+    def _renderer(self):
+        """Return the weakly dereferenced renderer, maybe None."""
+        return self.__renderer()
 
     def _setup_scene(self):
         """Set up a new context scene and actor for these charts."""

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -4468,6 +4468,6 @@ class Charts:
         for chart in self._charts:
             yield chart
 
-    def __del__(self):  # pragma: no cover
+    def __del__(self):
         """Clean up before being destroyed."""
         self.deep_clean()

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -2760,6 +2760,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             self.disable_shadows()
         if self.__charts is not None:
             self.__charts.deep_clean()
+            self.__charts = None
 
         self.remove_floors(render=render)
         self.remove_legend(render=render)

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -203,7 +203,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         """Initialize the renderer."""
         super().__init__()
         self._actors = {}
-        self.parent = parent  # the plotter
+        self.parent = parent  # weakref.proxy to the plotter from Renderers
         self._theme = parent.theme
         self.camera_set = False
         self.bounding_box_actor = None

--- a/pyvista/plotting/renderers.py
+++ b/pyvista/plotting/renderers.py
@@ -1,5 +1,6 @@
 """Organize Renderers for ``pyvista.Plotter``."""
 import collections
+from weakref import proxy
 
 import numpy as np
 
@@ -26,7 +27,7 @@ class Renderers:
     ):
         """Initialize renderers."""
         self._active_index = 0  # index of the active renderer
-        self._plotter = plotter
+        self._plotter = proxy(plotter)
         self._renderers = []
 
         # by default add border for multiple plots

--- a/tests/plotting/test_collection.py
+++ b/tests/plotting/test_collection.py
@@ -1,4 +1,5 @@
 """This module contains any tests which cause memory leaks."""
+import gc
 import weakref
 
 import numpy as np
@@ -40,3 +41,23 @@ def test_add_array(sphere):
     """Ensure data added dynamically to a plotter is collected."""
     pl = pv.Plotter()
     pl.add_mesh(sphere, scalars=range(sphere.n_points))
+
+
+def test_plotting_collection():
+    """Ensure that we don't leak Plotter, Renderer and Charts instances."""
+    pl = pv.Plotter()
+    ref_plotter = weakref.ref(pl)
+    ref_renderers = weakref.ref(pl.renderers)
+    ref_renderer = weakref.ref(pl.renderer)
+    ref_charts = weakref.ref(pl.renderer._charts)  # instantiated on the fly
+
+    # delete known references to Plotter
+    del pv.plotting._ALL_PLOTTERS[pl._id_name]
+    del pl
+
+    # check that everything is eventually destroyed
+    gc.collect()  # small reference cycles allowed
+    assert ref_plotter() is None, gc.get_referrers(ref_plotter())
+    assert ref_renderers() is None
+    assert ref_renderer() is None
+    assert ref_charts() is None


### PR DESCRIPTION
**tl;dr** We were leaking Plotters and some children. I think I've fixed it, even though I don't fully understand some related paranormal activity.

### Part 1

Plotters don't get garbage collected. Consider this script:
```py
import gc
import weakref
import sys

import pyvista as pv

pl = pv.Plotter()
wref = weakref.ref(pl)
print('initial: ', sys.getrefcount(wref()))
del pl
gc.collect()

assert wref() is not None
print('after del: ', sys.getrefcount(wref()))
pv.plotting._ALL_PLOTTERS.clear()
gc.collect()
assert wref() is not None
print('after _ALL_PLOTTERS clear: ', sys.getrefcount(wref()))
```

On main, this prints
```
initial:  10
after del:  9
after _ALL_PLOTTERS clear:  8
```

This means that even if we
1. delete the only direct reference to a plotter
2. clear the `pv.plotting._ALL_PLOTTERS` dict (which should be the only place where plotters are kept track of)
the plotter doesn't get garbage collected.

Replacing strong references to the plotter in `Renderers`, `Renderer` and `Charts` (i.e. the first commit of this PR) changes the output to
```
initial:  7
after del:  6
```
and an assertion error, because in this case the plotter gets garbage collected once it's also cleared from `_ALL_PLOTTERS`!

### Part 2

There's a different, lot more subtle issue too, which caused me to find this bug in the first place. The problem is that `Charts` objects don't get garbage collected at all!

Consider this script:
```py
import gc
import weakref

import pyvista as pv

pl = pv.Plotter()
pwr = weakref.ref(pl)
rwr = weakref.ref(pl.renderer)
cwr = weakref.ref(pl.renderer._charts)

del pl
pv.plotting._ALL_PLOTTERS.clear()
gc.collect()

assert pwr() is None  # OK, plotter destroyed
assert rwr() is None  # OK, renderer destroyed
assert cwr() is None  # not OK, wat?!
```

The `Plotter` is collected (see Part 1), so is its only `Renderer`. However, the `Charts` object created when we accessed `pl.renderer._charts` sticks around!

### Part 2.5

The reall weird part is _how_ that `Charts` objects sticks around. I have no sane explanation (i.e. I suspect C-land shenanigans via VTK). Consider this script:

```py
import gc
import weakref
import sys

import pyvista as pv

pl = pv.Plotter()
rwr = weakref.ref(pl.renderer)
renderer_dict = rwr().__dict__  # the __dict__/vars() of the Renderer
cwr = weakref.ref(pl.renderer._charts)

del pl
pv.plotting._ALL_PLOTTERS.clear()
gc.collect()

assert rwr() is None  # OK, renderer destroyed
assert cwr() is not None  # just left here for proof

print('Remaining refcount of the Charts:', sys.getrefcount(cwr()) - 1)  # one reference is held by sys.getrefcount() itself

assert sys.getrefcount(cwr()) - 1 == len(gc.get_referrers(cwr())) == 1  # one referrer left somewhere
referrer = gc.get_referrers(cwr())[0]  # the one referrer
assert referrer is renderer_dict  # the one referrer is the __dict__ of the collected Renderer, wat?!
```

This prints
```
Remaining refcount of the Charts: 1
```
with no (assertion) errors.

To recap:
1. we created a `Plotter` -> (`Renderers` ->) `Renderer` -> `Charts` object
2. the plotter and renderer instances are destroyed, the `Charts` instance sticks around because it has a remaining reference to it
3. that one reference is somehow the exact `pl.renderer.__dict__`, even though the instance this dict belongs to is dead!

### Part 2.75 (Appendix)
Normally, the `__dict__` of an instance should die when the instance dies. Consider this example (unfortunately we can't create weakrefs to dicts):
```py
import gc
import weakref
import sys

class Foo:  # pretend Renderer
    pass
class Bar:  # pretend Plotter
    def __init__(self):
        self.renderer = Foo()
pl = Bar()
pwr = weakref.ref(pl)
rwr = weakref.ref(pl.renderer)
renderer_dict_ref = pl.renderer.__dict__
print('Before "plotter" destruction:', sys.getrefcount(renderer_dict_ref) - 1)  # one reference held by sys.getrefcount() itself

del pl
gc.collect()
assert pwr() is None  # "plotter" destroyed
assert rwr() is None  # "renderer" destroyed
print('After "plotter" destruction:', sys.getrefcount(renderer_dict_ref) - 1)  # one reference held by sys.getrefcount() itself
```

This prints
```
Before "plotter" destruction: 2
After "plotter" destruction: 1
```
Which makes sense:
1. destroying the "renderer" decreases the refcount of "renderer"'s `__dict__` by 1
2. the one reference left after all this is the strong reference in `renderer_dict_ref`.

So I'm thinking that we can't end up with the weird situation we have with `charts` vs `plotter.renderer.__dict__` unless there's some C-world reference keeping this `__dict__` alive, which in turn keeps the `Charts` instance alive.

### Part 3 (Prologue)
Even though I don't understand what's going on, I finally realised how I can prevent this weird situation. If we reassign the `__charts` private attribute referencing the `Charts` while the `Renderer` is alive, the `Charts` instance dies!

```py
import gc
import weakref

import pyvista as pv

pl = pv.Plotter()
rwr = weakref.ref(pl.renderer)
cwr = weakref.ref(pl.renderer._charts)

# way to let Charts die: replace them while the Renderer is still alive
rwr()._Renderer__charts = None
assert cwr() is None  # now it's instantly dead
```

So if we just make sure to reassign `None` to `renderer.__charts` in `renderer.__del__()` -> `renderer.deep_clean()`, the problem goes away. I'd love to understand what's going on here, but at least this removes the whole issue.

---

Labelling this as [review-critical] because weakrefs might have unintended side-effects, e.g. I originally used a `weakref.proxy` in `Charts` to refer to the renderer, but this broke the `SetRenderer()` calls. I ended up replacing that with a `weakref.ref`, which is called in a property so that we don't have to write `self.renderer()` anywhere. (I think I may have even seen precedent for this in the codebase.) I might even have to replace the other `weakref.proxy`s I've added here to use a similar dereferencing trick, to ensure that the corresponding attributes are _bone fide_ instances of the referenced type.