### PR TITLE
Add check if the path exists before removing it.

### DIFF
--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -84,7 +84,7 @@ def delete_downloads():
 
     """
     _check_examples_path()
-    if os.path.exists(pyvista.EXAMPLES_PATH):
+    if os.path.isdir(pyvista.EXAMPLES_PATH):
         shutil.rmtree(pyvista.EXAMPLES_PATH)
     os.makedirs(pyvista.EXAMPLES_PATH)
     return True

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -84,7 +84,8 @@ def delete_downloads():
 
     """
     _check_examples_path()
-    shutil.rmtree(pyvista.EXAMPLES_PATH)
+    if os.path.exists(pyvista.EXAMPLES_PATH):
+        shutil.rmtree(pyvista.EXAMPLES_PATH)
     os.makedirs(pyvista.EXAMPLES_PATH)
     return True
 

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -106,3 +106,20 @@ def test_delete_downloads(tmpdir):
         assert not os.path.isfile(tmp_file)
     finally:
         pyvista.EXAMPLES_PATH = old_path
+
+
+def test_delete_downloads_does_not_exist(tmpdir):
+    # change the path so we don't delete the examples cache
+    old_path = pyvista.EXAMPLES_PATH
+    new_path = str(tmpdir.join('doesnotexist'))
+
+    try:
+        pyvista.EXAMPLES_PATH = new_path
+        assert not os.path.isdir(pyvista.EXAMPLES_PATH)
+        examples.delete_downloads()
+    except FileNotFoundError as e:
+        # Delete downloads for an empty directory should not fail. Reraise if
+        # it does
+        raise e
+    finally:
+        pyvista.EXAMPLES_PATH = old_path

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -114,12 +114,9 @@ def test_delete_downloads_does_not_exist(tmpdir):
     new_path = str(tmpdir.join('doesnotexist'))
 
     try:
+        # delete_downloads for a missing directory should not fail.
         pyvista.EXAMPLES_PATH = new_path
         assert not os.path.isdir(pyvista.EXAMPLES_PATH)
         examples.delete_downloads()
-    except FileNotFoundError as e:
-        # Delete downloads for an empty directory should not fail. Reraise if
-        # it does
-        raise e
     finally:
         pyvista.EXAMPLES_PATH = old_path


### PR DESCRIPTION
### Overview

This is a fix for a minor bug that might happen when trying to delete downloads in a path that doesn't exist.


### Details

- function delete_downloads() tries to remove dirs/files in not existing directory which causes errors:
```
==================================== ERRORS ====================================
__________ ERROR collecting tests/branches/test_branch_operations.py ___________
tests/branches/test_branch_operations.py:5: in <module>
    import pyvista as pv
/opt/conda/lib/python3.7/site-packages/pyvista/__init__.py:104: in <module>
    _verify_cache_integrity()
/opt/conda/lib/python3.7/site-packages/pyvista/examples/downloads.py:64: in _verify_cache_integrity
    delete_downloads()
/opt/conda/lib/python3.7/site-packages/pyvista/examples/downloads.py:87: in delete_downloads
    shutil.rmtree(pyvista.EXAMPLES_PATH)
/opt/conda/lib/python3.7/shutil.py:498: in rmtree
    onerror(os.rmdir, path, sys.exc_info())
/opt/conda/lib/python3.7/shutil.py:496: in rmtree
    os.rmdir(path)
E   FileNotFoundError: [Errno 2] No such file or directory: '/root/.local/share/pyvista/examples'
```

