### PR TITLE
Fix for function from_meshio

### DIFF
--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -445,14 +445,14 @@ def from_meshio(mesh):
 
     if _vtk.VTK9:
         grid = pyvista.UnstructuredGrid(
-            np.concatenate(cells),
+            np.concatenate(cells).astype(np.int64, copy=False),
             np.array(cell_type),
             np.array(points, np.float64),
         )
     else:
         grid = pyvista.UnstructuredGrid(
             np.array(offset),
-            np.concatenate(cells),
+            np.concatenate(cells).astype(np.int64, copy=False),
             np.array(cell_type),
             np.array(points, np.float64),
         )

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -429,7 +429,8 @@ def from_meshio(mesh):
     for c in mesh.cells:
         vtk_type = meshio_to_vtk_type[c.type]
         numnodes = vtk_type_to_numnodes[vtk_type]
-        cells.append(np.hstack((np.full((len(c.data), 1), numnodes), c.data)).ravel())
+        fill_values = np.full((len(c.data), 1), numnodes, dtype=c.data.dtype)
+        cells.append(np.hstack((fill_values, c.data)).ravel())
         cell_type += [vtk_type] * len(c.data)
         if not _vtk.VTK9:
             offset += [next_offset + i * (numnodes + 1) for i in range(len(c.data))]
@@ -440,8 +441,11 @@ def from_meshio(mesh):
 
     # Create pyvista.UnstructuredGrid object
     points = mesh.points
+
+    # convert to 3D if points are 2D
     if points.shape[1] == 2:
-        points = np.hstack((points, np.zeros((len(points), 1))))
+        zero_points = np.zeros((len(points), 1), dtype=points.dtype)
+        points = np.hstack((points, zero_points))
 
     if _vtk.VTK9:
         grid = pyvista.UnstructuredGrid(

--- a/tests/test_meshio.py
+++ b/tests/test_meshio.py
@@ -3,16 +3,24 @@ import pathlib
 import numpy as np
 import pytest
 
+import meshio
 import pyvista
 from pyvista import examples
 
 beam = pyvista.UnstructuredGrid(examples.hexbeamfile)
 airplane = examples.load_airplane().cast_to_unstructured_grid()
 uniform = examples.load_uniform().cast_to_unstructured_grid()
+mesh2d = meshio.Mesh(
+    points=[[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]],
+    cells=[("triangle", [[0, 1, 2], [1, 3, 2]])],
+)
 
 
-@pytest.mark.parametrize("mesh_in", [beam, airplane, uniform])
+@pytest.mark.parametrize("mesh_in", [beam, airplane, uniform, mesh2d])
 def test_meshio(mesh_in, tmpdir):
+    if isinstance(mesh_in, meshio.Mesh):
+        mesh_in = pyvista.from_meshio(mesh_in)
+
     # Save and read reference mesh using meshio
     filename = tmpdir.mkdir("tmpdir").join("test_mesh.vtk")
     pyvista.save_meshio(filename, mesh_in)

--- a/tests/test_meshio.py
+++ b/tests/test_meshio.py
@@ -1,9 +1,9 @@
 import pathlib
 
+import meshio
 import numpy as np
 import pytest
 
-import meshio
 import pyvista
 from pyvista import examples
 


### PR DESCRIPTION
### Overview

- Fixed: function `pyvista.from_meshio` when cells data type is `np.uint64`.

### Details

The following code raises an error:

```python
import pygmsh
import pyvista

with pygmsh.geo.Geometry() as geom:
    geom.add_polygon(
        [
            [0.0, 0.0],
            [1.0, -0.2],
            [1.1, 1.2],
            [0.1, 0.7],
        ],
        mesh_size=0.1,
    )
    mesh = geom.generate_mesh()

mesh = pyvista.from_meshio(mesh)
```

This error is due to `np.hstack` somehow returning an array of type `np.float64` when input array data type is `np.uint64`:

```python
x = np.array([[0, 1], [2, 3]], dtype=np.uint64)
y = np.hstack((np.full((len(x), 1), 0), x))
print(y.dtype)
```

Output:
```
float64
```