### PR TITLE
Add 10-second intersphinx timeout to doc build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -234,6 +234,7 @@ intersphinx_mapping = {
     'pytest': ('https://docs.pytest.org/en/stable', (None, 'intersphinx/pytest-objects.inv')),
     'pyvistaqt': ('https://qtdocs.pyvista.org/', (None, 'intersphinx/pyvistaqt-objects.inv')),
 }
+intersphinx_timeout = 10
 
 linkcheck_retries = 3
 linkcheck_timeout = 500


### PR DESCRIPTION
Thanks to numpy.org having gone down, I noticed that local doc builds take about 4.5 minutes for intersphinx inventory fetching to time out. This is unreasonably long: if it doesn't work for 10-30 seconds there's probably not much point stalling the doc build with it, especially since we have a local intersphinx inventory to fall back on.

There's a slight catch though: [`intersphinx` has a config named `intersphinx_timeout`](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_timeout), but this only raises if the server fails to respond during that time interval. However, the default (which we've had until now) means "no timeout", and the error I'm eventually getting is
```
WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://numpy.org/doc/stable/objects.inv' not fetchable due to <class 'requests.exceptions.ConnectionError'>: HTTPSConnectionPool(host='numpy.org', port=443): Max retries exceeded with url: /doc/stable/objects.inv (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7fafa93bf2e0>: Failed to establish a new connection: [Errno 101] Network is unreachable'))
```
So this is not a timeout error, this is a "too many retries" error. Which makes sense, since the original default was "no timeout", and numpy.org is down so the client can't even start to negotiate a connection.

Now here's the weird part: if I set `intersphinx_timeout = 30` (30 seconds timeout for getting a response), the time until the "max retries exceeded" error goes down to 70 seconds. If I set it to `10`, the error happens at 28 seconds! So even though this is not a "timeout" in the expected sense, it affects the time that our doc builds get stalled.

One caveat: in order to get a ~30-second wait during doc build when a target server is down, we need a 10 second timeout. This means that if a server is up but slow to reply, intersphinx will give up waiting for a response in 10 seconds. I am personally OK with this, but I want to make sure that this is indeed OK to have. If we want to be safe we can increase the timeout in order to make this less harmful (at the cost of stalling doc builds for longer). (Intersphinx' docs makes it clear that the timeout doesn't apply once a download has started, this is only about making the GET(?) request.)