### PR TITLE
Add copy_mesh argument to plotter.add_mesh

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1861,7 +1861,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         roughness=0.5,
         render=True,
         component=None,
-        copy_mesh=True,
+        copy_mesh=False,
         **kwargs,
     ):
         """Add any PyVista/VTK mesh or dataset that PyVista can wrap to the scene.
@@ -2135,12 +2135,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
             the vector is plotted.
 
         copy_mesh : bool, optional
-            If True, a copy of the mesh will be made before adding it to the plotter.
+            If ``False``, a copy of the mesh will be made before adding it to the plotter.
             This is useful if e.g. you would like to add the same mesh to a plotter multiple
-            times and display different scalars. Setting `copy_mesh` to False is necessary
+            times and display different scalars. Setting ``copy_mesh`` to ``False`` is necessary
             if you would like to update the mesh after adding it to the plotter and have these
             updates rendered, e.g. by changing the active scalars or through an interactive widget.
-            Defaults to True.
+            Defaults to ``False``.
 
         **kwargs : dict, optional
             Optional developer keyword arguments.

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2135,7 +2135,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             the vector is plotted.
 
         copy_mesh : bool, optional
-            If ``False``, a copy of the mesh will be made before adding it to the plotter.
+            If ``True``, a copy of the mesh will be made before adding it to the plotter.
             This is useful if e.g. you would like to add the same mesh to a plotter multiple
             times and display different scalars. Setting ``copy_mesh`` to ``False`` is necessary
             if you would like to update the mesh after adding it to the plotter and have these

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2203,10 +2203,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
         elif isinstance(mesh, pyvista.PointSet):
             # cast to PointSet to PolyData
             mesh = mesh.cast_to_polydata(deep=False)
-        else:
-            # A shallow copy of `mesh` is here so when we set (or add) scalars
-            # active, it doesn't modify the original input mesh.
-            mesh = mesh.copy(deep=False)
+        #else:
+        #    # A shallow copy of `mesh` is here so when we set (or add) scalars
+        #    # active, it doesn't modify the original input mesh.
+        #    mesh = mesh.copy(deep=False)
 
         ##### Parse arguments to be used for all meshes #####
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1861,6 +1861,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         roughness=0.5,
         render=True,
         component=None,
+        copy_mesh=True,
         **kwargs,
     ):
         """Add any PyVista/VTK mesh or dataset that PyVista can wrap to the scene.
@@ -2133,6 +2134,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
             nonnegative, if supplied. If ``None``, the magnitude of
             the vector is plotted.
 
+        copy_mesh : bool, optional
+            If True, a copy of the mesh will be made before adding it to the plotter.
+            This is useful if e.g. you would like to add the same mesh to a plotter multiple
+            times and display different scalars. Setting `copy_mesh` to False is necessary
+            if you would like to update the mesh after adding it to the plotter and have these
+            updates rendered, e.g. by changing the active scalars or through an interactive widget.
+            Defaults to True.
+
         **kwargs : dict, optional
             Optional developer keyword arguments.
 
@@ -2203,10 +2212,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
         elif isinstance(mesh, pyvista.PointSet):
             # cast to PointSet to PolyData
             mesh = mesh.cast_to_polydata(deep=False)
-        #else:
-        #    # A shallow copy of `mesh` is here so when we set (or add) scalars
-        #    # active, it doesn't modify the original input mesh.
-        #    mesh = mesh.copy(deep=False)
+        elif copy_mesh:
+            # A shallow copy of `mesh` is made here so when we set (or add) scalars
+            # active, it doesn't modify the original input mesh.
+            mesh = mesh.copy(deep=False)
 
         ##### Parse arguments to be used for all meshes #####
 

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -269,7 +269,7 @@ class WidgetHelper:
             interaction_event=interaction_event,
         )
 
-        return self.add_mesh(box_clipped_mesh, reset_camera=False, **kwargs)
+        return self.add_mesh(box_clipped_mesh, reset_camera=False, copy_mesh=False, **kwargs)
 
     def add_plane_widget(
         self,
@@ -620,7 +620,7 @@ class WidgetHelper:
             interaction_event=interaction_event,
         )
 
-        return self.add_mesh(plane_clipped_mesh, **kwargs)
+        return self.add_mesh(plane_clipped_mesh, copy_mesh=False, **kwargs)
 
     def add_mesh_slice(
         self,
@@ -745,7 +745,7 @@ class WidgetHelper:
             interaction_event=interaction_event,
         )
 
-        return self.add_mesh(plane_sliced_mesh, **kwargs)
+        return self.add_mesh(plane_sliced_mesh, copy_mesh=False, **kwargs)
 
     def add_mesh_slice_orthogonal(
         self,
@@ -1340,7 +1340,7 @@ class WidgetHelper:
         )
 
         kwargs.setdefault("reset_camera", False)
-        return self.add_mesh(threshold_mesh, scalars=scalars, **kwargs)
+        return self.add_mesh(threshold_mesh, scalars=scalars, copy_mesh=False, **kwargs)
 
     def add_mesh_isovalue(
         self,
@@ -1476,7 +1476,7 @@ class WidgetHelper:
         )
 
         kwargs.setdefault("reset_camera", False)
-        return self.add_mesh(isovalue_mesh, scalars=scalars, **kwargs)
+        return self.add_mesh(isovalue_mesh, scalars=scalars, copy_mesh=False, **kwargs)
 
     def add_spline_widget(
         self,
@@ -1733,7 +1733,7 @@ class WidgetHelper:
             interaction_event=interaction_event,
         )
 
-        return self.add_mesh(spline_sliced_mesh, **kwargs)
+        return self.add_mesh(spline_sliced_mesh, copy_mesh=False, **kwargs)
 
     def add_sphere_widget(
         self,

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -269,7 +269,7 @@ class WidgetHelper:
             interaction_event=interaction_event,
         )
 
-        return self.add_mesh(box_clipped_mesh, reset_camera=False, copy_mesh=False, **kwargs)
+        return self.add_mesh(box_clipped_mesh, reset_camera=False, **kwargs)
 
     def add_plane_widget(
         self,
@@ -620,7 +620,7 @@ class WidgetHelper:
             interaction_event=interaction_event,
         )
 
-        return self.add_mesh(plane_clipped_mesh, copy_mesh=False, **kwargs)
+        return self.add_mesh(plane_clipped_mesh, **kwargs)
 
     def add_mesh_slice(
         self,
@@ -745,7 +745,7 @@ class WidgetHelper:
             interaction_event=interaction_event,
         )
 
-        return self.add_mesh(plane_sliced_mesh, copy_mesh=False, **kwargs)
+        return self.add_mesh(plane_sliced_mesh, **kwargs)
 
     def add_mesh_slice_orthogonal(
         self,
@@ -1340,7 +1340,7 @@ class WidgetHelper:
         )
 
         kwargs.setdefault("reset_camera", False)
-        return self.add_mesh(threshold_mesh, scalars=scalars, copy_mesh=False, **kwargs)
+        return self.add_mesh(threshold_mesh, scalars=scalars, **kwargs)
 
     def add_mesh_isovalue(
         self,
@@ -1476,7 +1476,7 @@ class WidgetHelper:
         )
 
         kwargs.setdefault("reset_camera", False)
-        return self.add_mesh(isovalue_mesh, scalars=scalars, copy_mesh=False, **kwargs)
+        return self.add_mesh(isovalue_mesh, scalars=scalars, **kwargs)
 
     def add_spline_widget(
         self,
@@ -1733,7 +1733,7 @@ class WidgetHelper:
             interaction_event=interaction_event,
         )
 
-        return self.add_mesh(spline_sliced_mesh, copy_mesh=False, **kwargs)
+        return self.add_mesh(spline_sliced_mesh, **kwargs)
 
     def add_sphere_widget(
         self,

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -2499,10 +2499,10 @@ def test_multi_plot_scalars():
     pl = pyvista.Plotter(shape=(1, 2))
     pl.subplot(0, 0)
     pl.add_text('"u" point scalars')
-    pl.add_mesh(plane, scalars='u')
+    pl.add_mesh(plane, scalars='u', copy_mesh=True)
     pl.subplot(0, 1)
     pl.add_text('"v" point scalars')
-    pl.add_mesh(plane, scalars='v')
+    pl.add_mesh(plane, scalars='v', copy_mesh=True)
     pl.show(before_close_callback=verify_cache_image)
 
 

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -103,13 +103,13 @@ def test_get_datasets(sphere, hexbeam):
 
 
 def test_remove_scalars_single(sphere, hexbeam):
-    """Ensure no scalars are added when plotting datasets."""
+    """Ensure no scalars are added when plotting datasets if copy_mesh=True."""
     # test single component scalars
     sphere.clear_data()
     hexbeam.clear_data()
     pl = pyvista.Plotter()
-    pl.add_mesh(sphere, scalars=range(sphere.n_points))
-    pl.add_mesh(hexbeam, scalars=range(hexbeam.n_cells))
+    pl.add_mesh(sphere, scalars=range(sphere.n_points), copy_mesh=True)
+    pl.add_mesh(hexbeam, scalars=range(hexbeam.n_cells), copy_mesh=True)
 
     # arrays will be added to the mesh
     pl.mesh.n_arrays == 1
@@ -122,7 +122,7 @@ def test_remove_scalars_single(sphere, hexbeam):
 
 
 def test_active_scalars_remain(sphere, hexbeam):
-    """Ensure active scalars remain active despite plotting different scalars."""
+    """Ensure active scalars remain active despite plotting different scalars when copy_mesh=True."""
     point_data_name = "point_data"
     cell_data_name = "cell_data"
     sphere[point_data_name] = np.random.random(sphere.n_points)
@@ -131,8 +131,8 @@ def test_active_scalars_remain(sphere, hexbeam):
     assert hexbeam.cell_data.active_scalars_name == cell_data_name
 
     pl = pyvista.Plotter()
-    pl.add_mesh(sphere, scalars=range(sphere.n_points))
-    pl.add_mesh(hexbeam, scalars=range(hexbeam.n_cells))
+    pl.add_mesh(sphere, scalars=range(sphere.n_points), copy_mesh=True)
+    pl.add_mesh(hexbeam, scalars=range(hexbeam.n_cells), copy_mesh=True)
     pl.close()
 
     assert sphere.point_data.active_scalars_name == point_data_name
@@ -172,10 +172,10 @@ def test_add_multiple(sphere):
     point_data_name = 'data'
     sphere[point_data_name] = np.random.random(sphere.n_points)
     pl = pyvista.Plotter()
-    pl.add_mesh(sphere)
-    pl.add_mesh(sphere, scalars=np.arange(sphere.n_points))
-    pl.add_mesh(sphere, scalars=np.arange(sphere.n_cells))
-    pl.add_mesh(sphere, scalars='data')
+    pl.add_mesh(sphere, copy_mesh=True)
+    pl.add_mesh(sphere, scalars=np.arange(sphere.n_points), copy_mesh=True)
+    pl.add_mesh(sphere, scalars=np.arange(sphere.n_cells), copy_mesh=True)
+    pl.add_mesh(sphere, scalars='data', copy_mesh=True)
     pl.show()
     assert sphere.n_arrays == 1
 


### PR DESCRIPTION
### Overview
resolves #3079
resolves #3066

Fix use of widgets with a plotter and updating active scalars of a mesh after it has been added to a plotter.

### Details

There is a tension between:
- being able to to add a mesh to a plotter multiple times and visualise different scalars
- being able to use widgets with a plotter

The first requires that a copy of the mesh is made so that when active scalars are set on the added mesh(es), they are not changed for the original mesh.

The second requires that a copy of the mesh is **not** made, so that when changes are made to the original mesh they are updated in the plotter.

I've added a `copy_mesh` argument to `plotter.add_mesh`. By default it is set to `True`. All widgets will need to set it the `False`.

I'm not sure if there's a better solution to this? Would be happy to hear if there is!
