### PR TITLE
Add the Grad-Descent-Visualizer package to the external examples.

### DIFF
--- a/doc/make_external_gallery.py
+++ b/doc/make_external_gallery.py
@@ -165,6 +165,12 @@ articles = dict(
         link="https://gmshmodel.readthedocs.io/en/latest/",
         image="gmsh_model.png",
     ),
+    grad_descent_visualizer=Example(
+        title="Gradient Descent Visualizer",
+        description="A Python package used to visualize the gradient descent of function landscapes.",
+        link="https://github.com/JacobBumgarner/grad-descent-visualizer",
+        image="grad_descent_visualizer.gif"
+    )
     # entry=Example(title="",
     #     description="",
     #     link="",

--- a/doc/make_external_gallery.py
+++ b/doc/make_external_gallery.py
@@ -169,8 +169,8 @@ articles = dict(
         title="Gradient Descent Visualizer",
         description="A Python package used to visualize the gradient descent of function landscapes.",
         link="https://github.com/JacobBumgarner/grad-descent-visualizer",
-        image="grad_descent_visualizer.gif"
-    )
+        image="grad_descent_visualizer.gif",
+    ),
     # entry=Example(title="",
     #     description="",
     #     link="",


### PR DESCRIPTION
### Overview
As discussed in #3078, this PR adds the [grad-descent-visualizer]() package to the external examples.

Also seen in discussion #3074.