### PR TITLE
Add tetra to the unstructured grid example

### DIFF
--- a/examples/00-load/create-unstructured-surface.py
+++ b/examples/00-load/create-unstructured-surface.py
@@ -174,69 +174,33 @@ _ = grid.plot(show_edges=True)
 ###############################################################################
 # Tetrahedral Grid
 # ~~~~~~~~~~~~~~~~
-# Here's an unstructured tetrahedral grid.
+# Here how we can create an unstructured tetrahedral grid.
 
 # There are 10 cells here, each cell is [4, INDEX0, INDEX1, INDEX2, INDEX3]
 # where INDEX is one of the corners of the tetrahedral.
+#
+# Note that the array does not need to be shaped like this, we could have a
+# flat array, but it's easier to make out the structure of the array this way.
 cells = np.array(
     [
-        4,
-        6,
-        5,
-        8,
-        7,
-        4,
-        7,
-        3,
-        8,
-        9,
-        4,
-        7,
-        3,
-        1,
-        5,
-        4,
-        9,
-        3,
-        1,
-        7,
-        4,
-        2,
-        6,
-        5,
-        8,
-        4,
-        2,
-        6,
-        0,
-        4,
-        4,
-        6,
-        2,
-        0,
-        8,
-        4,
-        5,
-        2,
-        8,
-        3,
-        4,
-        5,
-        3,
-        8,
-        7,
-        4,
-        2,
-        6,
-        4,
-        5,
+        [4, 6, 5, 8, 7],
+        [4, 7, 3, 8, 9],
+        [4, 7, 3, 1, 5],
+        [4, 9, 3, 1, 7],
+        [4, 2, 6, 5, 8],
+        [4, 2, 6, 0, 4],
+        [4, 6, 2, 0, 8],
+        [4, 5, 2, 8, 3],
+        [4, 5, 3, 8, 7],
+        [4, 2, 6, 4, 5],
     ]
 )
 
-# This is just vtk.VTK_TETRA
+# 10 is just vtk.VTK_TETRA
 celltypes = np.array([10, 10, 10, 10, 10, 10, 10, 10, 10, 10], dtype=np.uint8)
 
-# These are the 10 points. The number of cells does not need to match the number of points, they just happen to.
+# These are the 10 points. The number of cells does not need to match the
+# number of points, they just happen to in this example
 points = np.array(
     [
         [-0.0, 0.0, -0.5],
@@ -258,7 +222,8 @@ grid.plot(show_edges=True)
 
 
 ###############################################################################
-# for fun, lets separate all the cells and plot out the individual cells. shift them a little bit from the center to "explode it"
+# for fun, lets separate all the cells and plot out the individual cells. shift
+# them a little bit from the center to create an "exploded view".
 
 split_cells = pv.MultiBlock()
 for index in range(10):

--- a/examples/00-load/create-unstructured-surface.py
+++ b/examples/00-load/create-unstructured-surface.py
@@ -169,3 +169,101 @@ grid = pv.UnstructuredGrid(
 
 # plot the grid (and suppress the camera position output)
 _ = grid.plot(show_edges=True)
+
+
+###############################################################################
+# Tetrahedral Grid
+# ~~~~~~~~~~~~~~~~
+# Here's an unstructured tetrahedral grid.
+
+# There are 10 cells here, each cell is [4, INDEX0, INDEX1, INDEX2, INDEX3]
+# where INDEX is one of the corners of the tetrahedral.
+cells = np.array(
+    [
+        4,
+        6,
+        5,
+        8,
+        7,
+        4,
+        7,
+        3,
+        8,
+        9,
+        4,
+        7,
+        3,
+        1,
+        5,
+        4,
+        9,
+        3,
+        1,
+        7,
+        4,
+        2,
+        6,
+        5,
+        8,
+        4,
+        2,
+        6,
+        0,
+        4,
+        4,
+        6,
+        2,
+        0,
+        8,
+        4,
+        5,
+        2,
+        8,
+        3,
+        4,
+        5,
+        3,
+        8,
+        7,
+        4,
+        2,
+        6,
+        4,
+        5,
+    ]
+)
+
+# This is just vtk.VTK_TETRA
+celltypes = np.array([10, 10, 10, 10, 10, 10, 10, 10, 10, 10], dtype=np.uint8)
+
+# These are the 10 points. The number of cells does not need to match the number of points, they just happen to.
+points = np.array(
+    [
+        [-0.0, 0.0, -0.5],
+        [0.0, 0.0, 0.5],
+        [-0.43, 0.0, -0.25],
+        [-0.43, 0.0, 0.25],
+        [-0.0, 0.43, -0.25],
+        [0.0, 0.43, 0.25],
+        [0.43, 0.0, -0.25],
+        [0.43, 0.0, 0.25],
+        [0.0, -0.43, -0.25],
+        [0.0, -0.43, 0.25],
+    ]
+)
+
+# Create and plot the unstructured grid
+grid = pv.UnstructuredGrid(cells, celltypes, points)
+grid.plot(show_edges=True)
+
+
+###############################################################################
+# for fun, lets separate all the cells and plot out the individual cells. shift them a little bit from the center to "explode it"
+
+split_cells = pv.MultiBlock()
+for index in range(10):
+    single_cell = grid.extract_cells([index])
+    single_cell.points += (np.array(single_cell.center) - np.array(grid.center)) * 0.5
+    split_cells.append(single_cell)
+
+split_cells.plot(show_edges=True)

--- a/examples/00-load/create-unstructured-surface.py
+++ b/examples/00-load/create-unstructured-surface.py
@@ -177,7 +177,7 @@ _ = grid.plot(show_edges=True)
 # Here is how we can create an unstructured tetrahedral grid.
 
 # There are 10 cells here, each cell is [4, INDEX0, INDEX1, INDEX2, INDEX3]
-# where INDEX is one of the corners of the tetrahedral.
+# where INDEX is one of the corners of the tetrahedron.
 #
 # Note that the array does not need to be shaped like this, we could have a
 # flat array, but it's easier to make out the structure of the array this way.
@@ -222,7 +222,7 @@ grid.plot(show_edges=True)
 
 
 ###############################################################################
-# For fun, let's separate all the cells and plot out the individual cells. shift
+# For fun, let's separate all the cells and plot out the individual cells. Shift
 # them a little bit from the center to create an "exploded view".
 
 split_cells = pv.MultiBlock()

--- a/examples/00-load/create-unstructured-surface.py
+++ b/examples/00-load/create-unstructured-surface.py
@@ -174,7 +174,7 @@ _ = grid.plot(show_edges=True)
 ###############################################################################
 # Tetrahedral Grid
 # ~~~~~~~~~~~~~~~~
-# Here how we can create an unstructured tetrahedral grid.
+# Here is how we can create an unstructured tetrahedral grid.
 
 # There are 10 cells here, each cell is [4, INDEX0, INDEX1, INDEX2, INDEX3]
 # where INDEX is one of the corners of the tetrahedral.
@@ -222,7 +222,7 @@ grid.plot(show_edges=True)
 
 
 ###############################################################################
-# for fun, lets separate all the cells and plot out the individual cells. shift
+# For fun, let's separate all the cells and plot out the individual cells. shift
 # them a little bit from the center to create an "exploded view".
 
 split_cells = pv.MultiBlock()


### PR DESCRIPTION
Simply adds a tetrahedral mesh to our unstructured grid example.

![image](https://user-images.githubusercontent.com/11981631/181871668-32ed5b60-0a2b-4840-8357-6cb4103f484a.png)