### PR TITLE
Support complex64 and save complex data

### DIFF
--- a/examples/01-filter/image-fft.py
+++ b/examples/01-filter/image-fft.py
@@ -64,6 +64,7 @@ fft_image.plot(
     theme=grey_theme,
     log_scale=True,
     text='Moon Landing Image FFT',
+    copy_mesh=True,  # don't overwrite scalars when plotting
 )
 
 
@@ -95,6 +96,7 @@ fft_image.plot(
     theme=grey_theme,
     log_scale=True,
     text='Moon Landing Image FFT with Noise Removed',
+    copy_mesh=True,  # don't overwrite scalars when plotting
 )
 
 

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -127,6 +127,9 @@ class DataObject:
                 f' Must be one of: {self._WRITERS.keys()}'
             )
 
+        # store complex and bitarray types as field data
+        self._store_metadata()
+
         writer = self._WRITERS[file_ext]()
         fileio.set_vtkwriter_mode(vtk_writer=writer, use_binary=binary)
         writer.SetFileName(str(file_path))
@@ -144,6 +147,34 @@ class DataObject:
             if self[array_name].shape[-1] == 4:  # type: ignore
                 writer.SetEnableAlpha(True)
         writer.Write()
+
+    def _store_metadata(self):
+        """Store metadata as field data."""
+        fdata = self.field_data
+        for assoc_name in ('bitarray', 'complex'):
+            for assoc_type in ('POINT', 'CELL'):
+                assoc_data = getattr(self, f'_association_{assoc_name}_names')
+                if assoc_type in assoc_data:
+                    if assoc_data[assoc_type]:
+                        key = f'_PYVISTA_{assoc_name}_{assoc_type}_'.upper()
+                        fdata[key] = list(assoc_data[assoc_type])
+
+    def _restore_metadata(self):
+        """Restore PyVista metadata from field data.
+
+        Metadata is stored using ``_store_metadata`` and contains entries in
+        the format of f'_PYVISTA_{assoc_name}_{assoc_type}_'. These entries are
+        removed when calling this method.
+
+        """
+        fdata = self.field_data
+        for assoc_name in ('bitarray', 'complex'):
+            for assoc_type in ('POINT', 'CELL'):
+                key = f'_PYVISTA_{assoc_name}_{assoc_type}_'.upper()
+                if key in fdata:
+                    assoc_data = getattr(self, f'_association_{assoc_name}_names')
+                    assoc_data[assoc_type] = set(fdata[key])
+                    del fdata[key]
 
     @abstractmethod
     def get_data_range(self):  # pragma: no cover

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -154,10 +154,10 @@ class DataObject:
         for assoc_name in ('bitarray', 'complex'):
             for assoc_type in ('POINT', 'CELL'):
                 assoc_data = getattr(self, f'_association_{assoc_name}_names')
-                if assoc_type in assoc_data:
-                    if assoc_data[assoc_type]:
-                        key = f'_PYVISTA_{assoc_name}_{assoc_type}_'.upper()
-                        fdata[key] = list(assoc_data[assoc_type])
+                array_names = assoc_data.get(assoc_type)
+                if array_names:
+                    key = f'_PYVISTA_{assoc_name}_{assoc_type}_'.upper()
+                    fdata[key] = list(array_names)
 
     def _restore_metadata(self):
         """Restore PyVista metadata from field data.

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -277,9 +277,10 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         """
         self._raise_field_data_no_scalars_vectors()
         if self.GetScalars() is not None:
-            return pyvista_ndarray(
+            array = pyvista_ndarray(
                 self.GetScalars(), dataset=self.dataset, association=self.association
             )
+            return self._patch_type(array)
         return None
 
     @active_scalars.setter
@@ -540,17 +541,21 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
             if vtk_arr is None:
                 raise KeyError(f'{key}')
         narray = pyvista_ndarray(vtk_arr, dataset=self.dataset, association=self.association)
+        return self._patch_type(narray)
 
-        # check if array needs to be represented as a different type
-        name = vtk_arr.GetName()
+    def _patch_type(self, narray):
+        """Check if array needs to be represented as a different type."""
+        name = narray.VTKObject.GetName()
         if name in self.dataset._association_bitarray_names[self.association.name]:
             narray = narray.view(np.bool_)  # type: ignore
         elif name in self.dataset._association_complex_names[self.association.name]:
-            narray = narray.view(np.complex128)  # type: ignore
+            if narray.dtype == np.float32:
+                narray = narray.view(np.complex64)  # type: ignore
+            if narray.dtype == np.float64:
+                narray = narray.view(np.complex128)  # type: ignore
             # remove singleton dimensions to match the behavior of the rest of 1D
             # VTK arrays
             narray = narray.squeeze()
-
         return narray
 
     def set_array(
@@ -814,9 +819,10 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
             self.dataset._association_bitarray_names[self.association.name].add(name)
             data = data.view(np.uint8)
         elif np.issubdtype(data.dtype, np.complexfloating):
-            if data.dtype != np.complex128:
+            if data.dtype not in (np.complex64, np.complex128):
                 raise ValueError(
-                    'Only numpy.complex128 is supported when setting dataset attributes'
+                    'Only numpy.complex64 or numpy.complex128 is supported when '
+                    'setting dataset attributes'
                 )
 
             if data.ndim != 1:
@@ -825,8 +831,11 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
             self.dataset._association_complex_names[self.association.name].add(name)
 
             # complex data is stored internally as a contiguous 2 component
-            # float64 array
-            data = data.view(np.float64).reshape(-1, 2)
+            # float arrays
+            if data.dtype == np.complex64:
+                data = data.view(np.float32).reshape(-1, 2)
+            else:
+                data = data.view(np.float64).reshape(-1, 2)
 
         shape = data.shape
         if data.ndim == 3:

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -750,11 +750,9 @@ class UniformGridFilters(DataSetFilters):
             else:
                 raise MissingDataError('FFT filters require point scalars.')
 
-        scalars = self.point_data.active_scalars
-
-        meets_req = scalars.ndim == 2 and scalars.shape[1] == 2
-        if not meets_req:
+        if not np.issubdtype(self.point_data.active_scalars.dtype, np.complexfloating):
             raise ValueError(
                 'Active scalars must be complex data for this filter, represented '
-                'as an array with `dtype=numpy.complex128`.'
+                'as an array with a datatype of `numpy.complex64` or '
+                '`numpy.complex128`.'
             )

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -306,6 +306,9 @@ class BaseReader:
         if data is None:  # pragma: no cover
             raise RuntimeError("Failed to read file.")
         data._post_file_load_processing()
+
+        # check for any pyvista metadata
+        data._restore_metadata()
         return data
 
     def _update_information(self):

--- a/tests/test_dataobject.py
+++ b/tests/test_dataobject.py
@@ -72,3 +72,33 @@ def test_unstructured_grid_eq(hexbeam):
     else:
         hexbeam.cells[0] += 1
     assert hexbeam != copy
+
+
+def test_metadata_save(hexbeam, tmpdir):
+    """Test if complex and bool metadata is saved and restored."""
+    filename = tmpdir.join('hexbeam.vtk')
+
+    hexbeam.clear_data()
+    point_data = np.arange(hexbeam.n_points)
+    hexbeam.point_data['pt_data0'] = point_data + 1j * point_data
+
+    bool_pt_data = np.zeros(hexbeam.n_points, dtype=bool)
+    bool_pt_data[::2] = 1
+    hexbeam.point_data['bool_data'] = bool_pt_data
+
+    cell_data = np.arange(hexbeam.n_cells)
+    bool_cell_data = np.zeros(hexbeam.n_cells, dtype=bool)
+    bool_cell_data[::2] = 1
+    hexbeam.cell_data['my_complex_cell_data'] = cell_data + 1j * cell_data
+    hexbeam.cell_data['bool_data'] = bool_cell_data
+
+    # verify that complex data is restored
+    hexbeam.save(filename)
+    hexbeam_in = pyvista.read(filename)
+    assert hexbeam_in.point_data['pt_data0'].dtype == np.complex128
+    assert hexbeam_in.point_data['bool_data'].dtype == bool
+    assert hexbeam_in.cell_data['my_complex_cell_data'].dtype == np.complex128
+    assert hexbeam_in.cell_data['bool_data'].dtype == bool
+
+    # metadata should be removed from the field data
+    assert not hexbeam_in.field_data

--- a/tests/test_dataobject.py
+++ b/tests/test_dataobject.py
@@ -90,6 +90,7 @@ def test_metadata_save(hexbeam, tmpdir):
     bool_cell_data = np.zeros(hexbeam.n_cells, dtype=bool)
     bool_cell_data[::2] = 1
     hexbeam.cell_data['my_complex_cell_data'] = cell_data + 1j * cell_data
+    hexbeam.cell_data['my_other_complex_cell_data'] = -cell_data - 1j * cell_data
     hexbeam.cell_data['bool_data'] = bool_cell_data
 
     # verify that complex data is restored
@@ -98,6 +99,7 @@ def test_metadata_save(hexbeam, tmpdir):
     assert hexbeam_in.point_data['pt_data0'].dtype == np.complex128
     assert hexbeam_in.point_data['bool_data'].dtype == bool
     assert hexbeam_in.cell_data['my_complex_cell_data'].dtype == np.complex128
+    assert hexbeam_in.cell_data['my_other_complex_cell_data'].dtype == np.complex128
     assert hexbeam_in.cell_data['bool_data'].dtype == bool
 
     # metadata should be removed from the field data

--- a/tests/test_datasetattributes.py
+++ b/tests/test_datasetattributes.py
@@ -1,3 +1,4 @@
+import os
 from string import ascii_letters, digits, whitespace
 import sys
 
@@ -9,6 +10,8 @@ from pytest import fixture, mark, raises
 
 import pyvista
 from pyvista.utilities import FieldAssociation
+
+skip_windows = mark.skipif(os.name == 'nt', reason='Test fails on Windows')
 
 
 @fixture()
@@ -574,25 +577,32 @@ def test_active_t_coords_name(plane):
         plane.field_data.active_t_coords_name = 'arr'
 
 
-def test_complex(plane):
+@skip_windows  # windows doesn't support np.complex256
+def test_complex_raises(plane):
+    with raises(ValueError, match='Only numpy.complex64'):
+        plane.point_data['data'] = np.empty(plane.n_points, dtype=np.complex256)
+
+
+@mark.parametrize('dtype_str', ['complex64', 'complex128'])
+def test_complex(plane, dtype_str):
     """Test if complex data can be properly represented in datasetattributes."""
+    dtype = np.dtype(dtype_str)
     name = 'my_data'
-    with raises(ValueError, match='Only numpy.complex128'):
-        plane.point_data[name] = np.empty(plane.n_points, dtype=np.complex64)
 
     with raises(ValueError, match='Complex data must be single dimensional'):
-        plane.point_data[name] = np.empty((plane.n_points, 2), dtype=np.complex128)
+        plane.point_data[name] = np.empty((plane.n_points, 2), dtype=dtype)
 
-    data = np.random.random((plane.n_points, 2)).view(np.complex128).ravel()
+    real_type = np.float32 if dtype == np.complex64 else np.float64
+    data = np.random.random((plane.n_points, 2)).astype(real_type).view(dtype).ravel()
     plane.point_data[name] = data
     assert np.allclose(plane.point_data[name], data)
 
-    assert 'complex128' in str(plane.point_data)
+    assert dtype_str in str(plane.point_data)
 
     # test setter
     plane.active_scalars_name = name
 
     # ensure that association is removed when changing datatype
-    assert plane.point_data[name].dtype == np.complex128
+    assert plane.point_data[name].dtype == dtype
     plane.point_data[name] = plane.point_data[name].real
-    assert np.issubdtype(plane.point_data[name].dtype, float)
+    assert np.issubdtype(plane.point_data[name].dtype, real_type)

--- a/tests/test_datasetattributes.py
+++ b/tests/test_datasetattributes.py
@@ -595,7 +595,7 @@ def test_complex(plane, dtype_str):
     real_type = np.float32 if dtype == np.complex64 else np.float64
     data = np.random.random((plane.n_points, 2)).astype(real_type).view(dtype).ravel()
     plane.point_data[name] = data
-    assert np.allclose(plane.point_data[name], data)
+    assert np.array_equal(plane.point_data[name], data)
 
     assert dtype_str in str(plane.point_data)
 


### PR DESCRIPTION
Resolves #3057 by storing array type associations as field metadata (as recommended [by Kitware](https://discourse.paraview.org/t/solved-adding-metadata-to-a-vtkinformation-or-a-grid-object-flowing-through-the-pipeline/318). Field data is written on save and restored (and removed) on load.

This PR also resolves #2873.
