### PR TITLE
Release 0.36.0

### DIFF
--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -15,7 +15,7 @@ Denotes the first release candidate.
 
 """
 # major, minor, patch
-version_info = 0, 36, 'dev0'
+version_info = 0, 37, 'dev0'
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
We're releasing 0.36 fairly quickly after 0.35 as 0.35 introduced a regression that showed up in MNE. See [mne comment](https://github.com/pyvista/pyvista/pull/2980#issuecomment-1197252385). Thanks @adeak, @larsoner, and @p-j-smith for working through this issue so quckly.

I'd have prefered a patch release, but #3088 modified our API, which necesitates a minor release per our "user contract."

Release steps are the usual:

- [ ] This PR: Bump main to next minor `0.37.dev0`. Don't delete the release branch.
- [ ] Bump version of this branch to `0.36.0`, tag with `v0.36.0` and push tags.
- [ ] Update the release notes.
- [ ] Update documentation manually (I have a plan to fix this for 0.37.0).
- [ ] Approve the conda PR when it comes.


As an aside, you can now select the prior tag of the release notes, saving a ton of busy work. See [Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes), step 4.
