### PR TITLE
Fix image-fft example

### DIFF
--- a/examples/01-filter/image-fft.py
+++ b/examples/01-filter/image-fft.py
@@ -64,6 +64,7 @@ fft_image.plot(
     theme=grey_theme,
     log_scale=True,
     text='Moon Landing Image FFT',
+    copy_mesh=True,  # don't overwrite scalars when plotting
 )
 
 
@@ -95,6 +96,7 @@ fft_image.plot(
     theme=grey_theme,
     log_scale=True,
     text='Moon Landing Image FFT with Noise Removed',
+    copy_mesh=True,  # don't overwrite scalars when plotting
 )
 
 


### PR DESCRIPTION
Fixes the documentation build by specifying `copy_mesh` as `True` so we don't activate non-complex scalars. This is because `add_mesh` modifies the active scalars, which is a side effect of `copy_mesh=False` by default.

See https://github.com/pyvista/pyvista/pull/3105#issuecomment-1200264077

I still think that a long term solution is to make `copy_mesh=True` by default as this ensures that side effects don't occur when adding scalars, but this is a topic for a later date. We just need this PR to restore legacy behavior by ensuring that we don't make a shallow copy unless we explicitly set it.
