### PR TITLE
Add separate cells feature

### DIFF
--- a/examples/02-plot/point-cell-scalars.py
+++ b/examples/02-plot/point-cell-scalars.py
@@ -1,0 +1,79 @@
+"""
+.. _point_cell_scalars_example:
+
+Point Cell Scalars
+~~~~~~~~~~~~~~~~~~
+
+This example demonstrates how to add point scalars for each individual cell to
+a dataset.
+
+
+"""
+import numpy as np
+
+from pyvista import examples
+
+###############################################################################
+# load the first 4 cells from the example UnstructuredGrid. Note how the number
+# of points is less than 32 since all the points are joined in the center.
+grid = examples.load_hexbeam().extract_cells(range(4))
+grid
+
+
+###############################################################################
+# Plot Point Scalars
+# ~~~~~~~~~~~~~~~~~~
+# At this point it's possible to assign only point or cell scalars to this
+# dataset. First, let's just plot some simple point scalars.
+
+grid.point_data['Point Data'] = range(grid.n_points)
+grid.plot(scalars='Point Data')
+
+
+###############################################################################
+# Plot Cell Scalars
+# ~~~~~~~~~~~~~~~~~
+# Next, let's plot cell scalars. We're simply assigning based on the cell
+# index.
+grid.cell_data['Cell Data'] = range(grid.n_cells)
+grid.plot(scalars='Cell Data')
+
+
+###############################################################################
+# Splitting the Cells
+# ~~~~~~~~~~~~~~~~~~~
+# If you wanted to assign data to each point of each cell and plot that, it's
+# simply not possible since these hexahedral cells all share the same
+# points. To split up individual cells, separate them using
+# :func:`pyvista.DataSet.separate_cells`.
+#
+# With this filter the resulting :class:`pyvista.UnstructuredGrid` now contains
+# 32 points, or 8 for each cell. They are now fully separated with no shared
+# points.
+
+split_cells = grid.separate_cells()
+split_cells
+
+
+###############################################################################
+# Plot Point Cell Data
+# ~~~~~~~~~~~~~~~~~~~~
+# Now we can plot values for each point for each cell. This will still be
+# assigned to the point data.
+#
+# Here we use :func:`numpy.hstack` for clarity, but as long as the length of
+# the data matches the number of points, you'll be able to use this approach.
+#
+# See how the plotted values appear continuous within a cell and discontinuous
+# between cells. This matches how stresses and strains are calculated from
+# finite element solutions.
+
+split_cells.point_data['Point Cell Data'] = np.hstack(
+    (
+        np.linspace(0, 8, 8),  # cell 0
+        np.linspace(0, 12, 8),  # cell 1
+        np.linspace(0, 16, 8),  # cell 2
+        np.linspace(0, 20, 8),  # cell 3
+    )
+)
+split_cells.plot(scalars='Point Cell Data')

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5213,3 +5213,35 @@ class DataSetFilters:
         alg.SetDivideAllCellDataByVolume(False)
         _update_alg(alg, progress_bar, 'Integrating Variables')
         return _get_output(alg)
+
+    def separate_cells(self):
+        """Return a copy of the dataset with separated cells with no shared points.
+
+        This method may be useful when datasets have scalars that need to be
+        associated to each point of each cell rather than either each cell or
+        just the points of the dataset.
+
+        Returns
+        -------
+        pyvista.UnstructuredGrid
+            UnstructuredGrid with isolated cells.
+
+        Examples
+        --------
+        Load the example hex beam and separate its cells. This increases the
+        total number of points in the dataset since points are no longer
+        shared.
+
+        >>> from pyvista import examples
+        >>> grid = examples.load_hexbeam()
+        >>> grid.n_points
+        99
+        >>> sep_grid = grid.separate_cells()
+        >>> sep_grid.n_points
+        320
+
+        See the :ref:`point_cell_scalars_example` for a more detailed example
+        using this filter.
+
+        """
+        return self.shrink(1.0)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1447,3 +1447,9 @@ def test_cast_to_pointset(sphere, deep):
         assert not np.allclose(sphere.points, pointset.points)
     else:
         assert np.allclose(sphere.points, pointset.points)
+
+
+def test_separate_cells(hexbeam):
+    assert hexbeam.n_points != hexbeam.n_cells * 8
+    sep_grid = hexbeam.separate_cells()
+    assert sep_grid.n_points == hexbeam.n_cells * 8


### PR DESCRIPTION
Adds `separate_cells` as a public method to `pyvista.DataSet` and an example that demonstrates its usage.

While `separate_cells` is a (very) thin wrapper around `shrink(1.0)`, I think we all prefer to be explicit and we don't have an obvious way to separate all the individual cells of a dataset. This is absolutely necessary to be able to assign individual values to each point for each cell, which is needed for finite element results which are continuous within a cell and discontinuous between cells.

Here's a cool plot demonstrating it's usage.

![tmp](https://user-images.githubusercontent.com/11981631/182077751-3f1c7783-792d-477a-b7da-b4067c365ed3.png)

