### PR TITLE
Remove vtk requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     'pillow',
     'appdirs',
     'scooby>=0.5.1',
-    'vtk>=8.1.2',
+    'vtk',
 ]
 
 readme_file = os.path.join(filepath, 'README.rst')

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,7 @@ install_requires = [
     'pillow',
     'appdirs',
     'scooby>=0.5.1',
-    'vtk>=8.1.2, <=9.2.0; python_version < "3.10"',
-    'vtk~=9.2.0rc1; python_version == "3.10"',
+    'vtk>=8.1.2',
 ]
 
 readme_file = os.path.join(filepath, 'README.rst')


### PR DESCRIPTION
Resolves #3116 by removing any version requirement for vtk. I would have prefered to keep at least `vtk>=8.1.2`, but having any sort of version requirement for vtk means that the release candidates will not install for Python 3.10, meaning PyVista becomes unusable for Python 3.10 unless you use conda.

We will one day set a minimum version for vtk, but to @larsoner's point, we plan on supporting the oldest version of vtk available on PyPI for the oldest version of currently supported Python.