### PR TITLE
Release 0.36.1

### DIFF
--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -15,7 +15,7 @@ Denotes the first release candidate.
 
 """
 # major, minor, patch
-version_info = 0, 36, 0
+version_info = 0, 36, 1
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,7 @@ install_requires = [
     'pillow',
     'appdirs',
     'scooby>=0.5.1',
-    'vtk>=8.1.2, <=9.2.0; python_version < "3.10"',
-    'vtk~=9.2.0rc1; python_version == "3.10"',
+    'vtk',
 ]
 
 readme_file = os.path.join(filepath, 'README.rst')


### PR DESCRIPTION
Release 0.36.1

This only includes #3117, which removes vtk version requirement so we can install pyvista on Python 3.10 and support conda.