### PR TITLE
Report number of scalars instead of size in error about scalars shape mismatch

### DIFF
--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -1124,10 +1124,10 @@ def raise_not_matching(scalars, dataset):
     """
     if isinstance(dataset, _vtk.vtkTable):
         raise ValueError(
-            f'Number of scalars ({scalars.size}) must match number of rows ({dataset.n_rows}).'
+            f'Number of scalars ({scalars.shape[0]}) must match number of rows ({dataset.n_rows}).'
         )
     raise ValueError(
-        f'Number of scalars ({scalars.size}) '
+        f'Number of scalars ({scalars.shape[0]}) '
         f'must match either the number of points ({dataset.n_points}) '
         f'or the number of cells ({dataset.n_cells}).'
     )


### PR DESCRIPTION
I ran into this less than helpful error:
```
>>> import numpy as np
>>> import pyvista as pv
>>> 
>>> mesh = pv.PolyData(np.arange(4 * 3.0).reshape(4, 3))
>>> mesh['scalars'] = np.arange(mesh.n_points).reshape(-1, 2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/adeak/pyvista/pyvista/core/dataset.py", line 1907, in __setitem__
    raise_not_matching(scalars, self)
  File "/home/adeak/pyvista/pyvista/utilities/helpers.py", line 1129, in raise_not_matching
    raise ValueError(
ValueError: Number of scalars (4) must match either the number of points (4) or the number of cells (4).
```
The issue is that the checks check `scalars.shape[0]`, but the error reports `scalars.size`. In case the total number of scalars is correct but the shape is wrong (like it was in my case), the error can be confusing.

I didn't thoroughly check every appearance of this helper, I came across it via `DataSet.__setitem__()`. But it should only ever be called for scalars, and I assume the fix is valid for every scalars case.

Closes https://github.com/pyvista/pyvista/issues/1761.