### PR TITLE
warn invalid texture dtype

### DIFF
--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -1003,14 +1003,31 @@ def numpy_to_texture(image):
     Parameters
     ----------
     image : numpy.ndarray
-        Numpy image array.
+        Numpy image array. Texture datatype expected to be ``np.uint8``.
 
     Returns
     -------
-    vtkTexture
-        VTK texture.
+    pyvista.Texture
+        PyVista texture.
+
+    Examples
+    --------
+    Create an all white texture.
+
+    >>> import pyvista as pv
+    >>> import numpy as np
+    >>> tex_arr = np.ones((1024, 1024, 3), dtype=np.uint8) * 255
+    >>> tex = pv.numpy_to_texture(tex_im)
 
     """
+    if image.dtype != np.uint8:
+        image = image.astype(np.uint8)
+        warnings.warn(
+            'Expected `image` dtype to be ``np.uint8``. `image` has been copied '
+            'and converted to np.uint8.',
+            UserWarning,
+        )
+
     return pyvista.Texture(image)
 
 

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -1017,7 +1017,7 @@ def numpy_to_texture(image):
     >>> import pyvista as pv
     >>> import numpy as np
     >>> tex_arr = np.ones((1024, 1024, 3), dtype=np.uint8) * 255
-    >>> tex = pv.numpy_to_texture(tex_im)
+    >>> tex = pv.numpy_to_texture(tex_arr)
 
     """
     if image.dtype != np.uint8:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -154,6 +154,14 @@ def test_skybox(tmpdir):
         pyvista.cubemap_from_filenames(image_paths=['/path'])
 
 
+def test_numpy_to_texture():
+    tex_im = np.ones((1024, 1024, 3), dtype=np.float64) * 255
+    with pytest.warns(UserWarning, match='np.uint8'):
+        tex = pyvista.numpy_to_texture(tex_im)
+    assert isinstance(tex, pyvista.Texture)
+    assert tex.to_array().dtype == np.uint8
+
+
 def test_array_association():
     # TODO: cover vtkTable/ROW association case
     mesh = pyvista.PolyData()


### PR DESCRIPTION
Resolve #3125 by checking the datatype of the input array.
