### PR TITLE
Skip flaky windows test

### DIFF
--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -101,6 +101,7 @@ WINDOWS_SKIP_IMAGE_CACHE = {
     'test_user_annotations_scalar_bar_volume',
     'test_plot_string_array',
     'test_cmap_list',
+    'test_multi_plot_scalars',  # flaky
     'test_collision_plot',
     'test_enable_stereo_render',
     'test_plot_complex_value',


### PR DESCRIPTION
Skip the `test_multi_plot_scalars` test:
```
        # otherwise, compare with the existing cached image
        error = pyvista.compare_images(image_filename, plotter)
        if error > allowed_error:
>           raise RuntimeError(
                'Exceeded image regression error of '
                f'{IMAGE_REGRESSION_ERROR} with an image error of '
                f'{error}'
            )
E           RuntimeError: Exceeded image regression error of 500 with an image error of 4867.983006535952
FAILED tests/plotting/test_plotting.py::test_multi_plot_scalars - RuntimeErro...
```