### PR TITLE
Correct vtk-data url in _download_file docstring

### DIFF
--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -259,7 +259,7 @@ def _retrieve_zip(retriever, filename):
 
 
 def _download_file(filename, progress_bar=False):
-    """Download a file from https://github.com/pyvista/vtk-data/master/Data.
+    """Download a file from https://github.com/pyvista/vtk-data/tree/master/Data.
 
     If ``pyvista.VTK_DATA_PATH`` is set, then the remote repository is expected
     to be a local git repository.
@@ -267,7 +267,7 @@ def _download_file(filename, progress_bar=False):
     Parameters
     ----------
     filename : str
-        Path within https://github.com/pyvista/vtk-data/master/Data to download
+        Path within https://github.com/pyvista/vtk-data/tree/master/Data to download
         the file from.
 
     progress_bar : bool, default: False


### PR DESCRIPTION
### Overview

This corrects the urls in the `_download_file` function docstring.

### Details

The url supplied in the docstring is invalid because "/tree/" needs to be included to list directories.