### PR TITLE
Fix issue template typo and code placeholders

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -23,11 +23,9 @@ body:
       label: Steps to reproduce the bug.
       description: |
         Please provide a list of steps to reproduce the bug.
-        Please include a code snippet to reproduce the big in the text box below.
+        Please include a code snippet to reproduce the bug in the text box below.
       placeholder: Provide some code for us to reproduce the bug!
-      value: "```python \n
-      Insert code here \n
-      ```"
+      value: "```python\nInsert code here\n```"
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -27,8 +27,4 @@ body:
       label: Pseudocode or Screenshots
       description: Feel free to include pseudocode or screenshots of the requested outcome.
       placeholder: Provide some code for us to reproduce the bug!
-      value: "```python \n
-      Insert code here \n
-      ```\n
-      Or drag your screenshot here!
-      "
+      value: "```python\nInsert code here\n```\nOr drag your screenshot here!"

--- a/.github/ISSUE_TEMPLATE/maintenance-request.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance-request.yml
@@ -27,8 +27,4 @@ body:
       label: Pseudocode or Screenshots
       description: Feel free to include pseudocode or screenshots of the requested outcome.
       placeholder: Provide some code for us to reproduce the bug!
-      value: "```python \n
-      Insert code here \n
-      ```\n
-      Or drag your screenshot here!
-      "
+      value: "```python\nInsert code here\n```\nOr drag your screenshot here!"


### PR DESCRIPTION
Aside from a small typo, the issue templates have spurious spaces in the prefilled code placeholders:
![Screenshot from 2022-08-08 17-14-54](https://user-images.githubusercontent.com/17914410/183452024-5b6b3af6-1c29-44c5-a0ba-291c14afba6b.png)

Since we already have the raw linefeeds in the strings, we can remove the additional linebreaks with indents that seem to cause the issue.