### PR TITLE
Fix filesystem races caused by pyvista.examples.downloads

### DIFF
--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -98,11 +98,6 @@ except Exception as e:
     )
     EXAMPLES_PATH = ''
 
-# verify example cache integrity
-from pyvista.examples.downloads import _verify_cache_integrity
-
-_verify_cache_integrity()
-
 # Send VTK messages to the logging module:
 send_errors_to_logging()
 

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -4828,3 +4828,7 @@ def download_sea_vase(load=True, progress_bar=False):  # pragma: no cover
     if load:
         return pyvista.read(filename)
     return filename
+
+
+# verify example cache integrity
+_verify_cache_integrity()


### PR DESCRIPTION
### Overview

This PR resolves #3145.

The solution is to move the call to `_verify_cache_integrity` inside `pyvista.examples.downloads`, where it's relevant. As long as the `examples` module (and subsequently `examples.downloads`) is not loaded, we will not interact with the filesystem.

