### PR TITLE
Expose more options of `MultiBlockPlot3DReader` (`vtkMultiBlockPlot3DReader`)

### DIFF
--- a/doc/api/readers/enums.rst
+++ b/doc/api/readers/enums.rst
@@ -3,4 +3,6 @@ Reader Enumerations
 
 .. currentmodule:: pyvista
 
+Plot3DFunctionEnum
+------------------
 .. autoenum:: Plot3DFunctionEnum

--- a/doc/api/readers/enums.rst
+++ b/doc/api/readers/enums.rst
@@ -1,4 +1,6 @@
 Reader Enumerations
 ===================
 
+.. currentmodule:: pyvista
+
 .. autoenum:: Plot3DFunctionEnum

--- a/doc/api/readers/enums.rst
+++ b/doc/api/readers/enums.rst
@@ -1,0 +1,4 @@
+Reader Enumerations
+===================
+
+.. autoenum:: Plot3DFunctionEnum

--- a/doc/api/readers/index.rst
+++ b/doc/api/readers/index.rst
@@ -93,4 +93,8 @@ Enumerations
 
 Enumerations are available to simplify inputs to certain readers.
 
-.. autoenum:: Plot3DFunctionEnum
+.. toctree::
+    :maxdepth: 2
+
+    enums
+

--- a/doc/api/readers/index.rst
+++ b/doc/api/readers/index.rst
@@ -50,6 +50,7 @@ Reader Classes
     PTSReader
     PVDReader
     Plot3DMetaReader
+    Plot3DFunctionEnum
     SLCReader
     STLReader
     SegYReader

--- a/doc/api/readers/index.rst
+++ b/doc/api/readers/index.rst
@@ -93,7 +93,4 @@ Enumerations
 
 Enumerations are available to simplify inputs to certain readers.
 
-.. autoenum::
-    :toctree: _autosummary
-
-    Plot3DFunctionEnum
+.. autoenum:: Plot3DFunctionEnum

--- a/doc/api/readers/index.rst
+++ b/doc/api/readers/index.rst
@@ -50,7 +50,6 @@ Reader Classes
     PTSReader
     PVDReader
     Plot3DMetaReader
-    Plot3DFunctionEnum
     SLCReader
     STLReader
     SegYReader
@@ -87,3 +86,14 @@ and setting time or iterations for reading.
    BaseReader
    PointCellDataSelection
    TimeReader
+
+
+Enumerations
+~~~~~~~~~~~~
+
+Enumerations are available to simplify inputs to certain readers.
+
+.. autoenum::
+    :toctree: _autosummary
+
+    Plot3DFunctionEnum

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,6 +66,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
     "sphinx.ext.autosummary",
+    "enum_tools.autoenum",
     "notfound.extension",
     "sphinx_copybutton",
     "sphinx_gallery.gen_gallery",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -212,7 +212,7 @@ numpydoc_validation_exclude = {  # set of regex
     r'\.MultiBlock\.index$',
     r'\.MultiBlock\.remove$',
     # Enumerations
-    r'\.reader.Plot3DFunctionEnum$',
+    r'\.Plot3DFunctionEnum$',
 }
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -211,6 +211,8 @@ numpydoc_validation_exclude = {  # set of regex
     r'\.MultiBlock\.count$',
     r'\.MultiBlock\.index$',
     r'\.MultiBlock\.remove$',
+    # Enumerations
+    r'\.reader.Plot3DFunctionEnum$',
 }
 
 

--- a/pyvista/utilities/__init__.py
+++ b/pyvista/utilities/__init__.py
@@ -43,6 +43,7 @@ from .reader import (
     OBJReader,
     OpenFOAMReader,
     POpenFOAMReader,
+    Plot3DFunctionEnum,
     Plot3DMetaReader,
     PLYReader,
     PNGReader,

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -1250,7 +1250,7 @@ class Plot3DMetaReader(BaseReader):
 
 
 class Plot3DFunctionEnum(enum.IntEnum):
-    """An enumeration for the functions used in `MultiBlockPlot3DReader`."""
+    """An enumeration for the functions used in :class:`MultiBlockPlot3DReader`."""
 
     DENSITY = 100
     PRESSURE = 110
@@ -1276,8 +1276,8 @@ class Plot3DFunctionEnum(enum.IntEnum):
 class MultiBlockPlot3DReader(BaseReader):
     """MultiBlock Plot3D Reader.
 
-    The methods :meth:``add_function()`` and :meth:``remove_function()`` accept values from
-    :class:``Plot3DFunctionEnum``. For convenience, the values of that enumeration are available as class variables,
+    The methods :meth:`add_function()` and :meth:`remove_function()` accept values from
+    :class:`Plot3DFunctionEnum`. For convenience, the values of that enumeration are available as class variables,
     as shown below.
 
         - ``MultiBlockPlot3DReader.DENSITY = Plot3DFunctionEnum.DENSITY``

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -1382,7 +1382,9 @@ class MultiBlockPlot3DReader(BaseReader):
         Example
         -------
         >>> import pyvista
-        >>> reader = pyvista.reader.MultiBlockPlot3DReader('grid.x')
+        >>> from pyvista import examples
+        >>> filename, _  = examples.downloads._download_file('multi-bin.xyz')
+        >>> reader = pyvista.reader.MultiBlockPlot3DReader(filename)
         >>> reader.add_function(112)  # add a function by its integer value
         >>> reader.add_function(reader.PRESSURE_COEFFICIENT)  # add a function by enumeration via class variable alias
 

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -1274,9 +1274,54 @@ class Plot3DFunctionEnum(enum.IntEnum):
 
 
 class MultiBlockPlot3DReader(BaseReader):
-    """MultiBlock Plot3D Reader."""
+    """MultiBlock Plot3D Reader.
+
+    The methods ``add_function()`` and ``remove_function()`` accept values from :class:``Plot3DFunctionEnum``.
+    For convenience, the values of that enumeration are available as class variables, as shown below.
+
+    - ``MultiBlockPlot3DReader.DENSITY = Plot3DFunctionEnum.DENSITY``
+    - ``MultiBlockPlot3DReader.PRESSURE = Plot3DFunctionEnum.PRESSURE``
+    - ``MultiBlockPlot3DReader.PRESSURE_COEFFICIENT = Plot3DFunctionEnum.PRESSURE_COEFFICIENT``
+    - ``MultiBlockPlot3DReader.MACH = Plot3DFunctionEnum.MACH``
+    - ``MultiBlockPlot3DReader.SPEED_OF_SOUND = Plot3DFunctionEnum.SPEED_OF_SOUND``
+    - ``MultiBlockPlot3DReader.TEMPERATURE = Plot3DFunctionEnum.TEMPERATURE``
+    - ``MultiBlockPlot3DReader.ENTHALPY = Plot3DFunctionEnum.ENTHALPY``
+    - ``MultiBlockPlot3DReader.INTERNAL_ENERGY = Plot3DFunctionEnum.INTERNAL_ENERGY``
+    - ``MultiBlockPlot3DReader.KINETIC_ENERGY = Plot3DFunctionEnum.KINETIC_ENERGY``
+    - ``MultiBlockPlot3DReader.VELOCITY_MAGNITUDE = Plot3DFunctionEnum.VELOCITY_MAGNITUDE``
+    - ``MultiBlockPlot3DReader.STAGNATION_ENERGY = Plot3DFunctionEnum.STAGNATION_ENERGY``
+    - ``MultiBlockPlot3DReader.ENTROPY = Plot3DFunctionEnum.ENTROPY``
+    - ``MultiBlockPlot3DReader.SWIRL = Plot3DFunctionEnum.SWIRL``
+    - ``MultiBlockPlot3DReader.VELOCITY = Plot3DFunctionEnum.VELOCITY``
+    - ``MultiBlockPlot3DReader.VORTICITY = Plot3DFunctionEnum.VORTICITY``
+    - ``MultiBlockPlot3DReader.MOMENTUM = Plot3DFunctionEnum.MOMENTUM``
+    - ``MultiBlockPlot3DReader.PRESSURE_GRADIENT = Plot3DFunctionEnum.PRESSURE_GRADIENT``
+    - ``MultiBlockPlot3DReader.STRAIN_RATE = Plot3DFunctionEnum.STRAIN_RATE``
+    - ``MultiBlockPlot3DReader.VORTICITY_MAGNITUDE = Plot3DFunctionEnum.VORTICITY_MAGNITUDE``
+    """
 
     _class_reader = staticmethod(_vtk.lazy_vtkMultiBlockPLOT3DReader)
+
+    # pull in function name enum values as class constants
+    DENSITY = Plot3DFunctionEnum.DENSITY
+    PRESSURE = Plot3DFunctionEnum.PRESSURE
+    PRESSURE_COEFFICIENT = Plot3DFunctionEnum.PRESSURE_COEFFICIENT
+    MACH = Plot3DFunctionEnum.MACH
+    SPEED_OF_SOUND = Plot3DFunctionEnum.SPEED_OF_SOUND
+    TEMPERATURE = Plot3DFunctionEnum.TEMPERATURE
+    ENTHALPY = Plot3DFunctionEnum.ENTHALPY
+    INTERNAL_ENERGY = Plot3DFunctionEnum.INTERNAL_ENERGY
+    KINETIC_ENERGY = Plot3DFunctionEnum.KINETIC_ENERGY
+    VELOCITY_MAGNITUDE = Plot3DFunctionEnum.VELOCITY_MAGNITUDE
+    STAGNATION_ENERGY = Plot3DFunctionEnum.STAGNATION_ENERGY
+    ENTROPY = Plot3DFunctionEnum.ENTROPY
+    SWIRL = Plot3DFunctionEnum.SWIRL
+    VELOCITY = Plot3DFunctionEnum.VELOCITY
+    VORTICITY = Plot3DFunctionEnum.VORTICITY
+    MOMENTUM = Plot3DFunctionEnum.MOMENTUM
+    PRESSURE_GRADIENT = Plot3DFunctionEnum.PRESSURE_GRADIENT
+    STRAIN_RATE = Plot3DFunctionEnum.STRAIN_RATE
+    VORTICITY_MAGNITUDE = Plot3DFunctionEnum.VORTICITY_MAGNITUDE
 
     def _set_defaults(self):
         self.auto_detect_format = True

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -1276,28 +1276,29 @@ class Plot3DFunctionEnum(enum.IntEnum):
 class MultiBlockPlot3DReader(BaseReader):
     """MultiBlock Plot3D Reader.
 
-    The methods ``add_function()`` and ``remove_function()`` accept values from :class:``Plot3DFunctionEnum``.
-    For convenience, the values of that enumeration are available as class variables, as shown below.
+    The methods :meth:``add_function()`` and :meth:``remove_function()`` accept values from
+    :class:``Plot3DFunctionEnum``. For convenience, the values of that enumeration are available as class variables,
+    as shown below.
 
-    - ``MultiBlockPlot3DReader.DENSITY = Plot3DFunctionEnum.DENSITY``
-    - ``MultiBlockPlot3DReader.PRESSURE = Plot3DFunctionEnum.PRESSURE``
-    - ``MultiBlockPlot3DReader.PRESSURE_COEFFICIENT = Plot3DFunctionEnum.PRESSURE_COEFFICIENT``
-    - ``MultiBlockPlot3DReader.MACH = Plot3DFunctionEnum.MACH``
-    - ``MultiBlockPlot3DReader.SPEED_OF_SOUND = Plot3DFunctionEnum.SPEED_OF_SOUND``
-    - ``MultiBlockPlot3DReader.TEMPERATURE = Plot3DFunctionEnum.TEMPERATURE``
-    - ``MultiBlockPlot3DReader.ENTHALPY = Plot3DFunctionEnum.ENTHALPY``
-    - ``MultiBlockPlot3DReader.INTERNAL_ENERGY = Plot3DFunctionEnum.INTERNAL_ENERGY``
-    - ``MultiBlockPlot3DReader.KINETIC_ENERGY = Plot3DFunctionEnum.KINETIC_ENERGY``
-    - ``MultiBlockPlot3DReader.VELOCITY_MAGNITUDE = Plot3DFunctionEnum.VELOCITY_MAGNITUDE``
-    - ``MultiBlockPlot3DReader.STAGNATION_ENERGY = Plot3DFunctionEnum.STAGNATION_ENERGY``
-    - ``MultiBlockPlot3DReader.ENTROPY = Plot3DFunctionEnum.ENTROPY``
-    - ``MultiBlockPlot3DReader.SWIRL = Plot3DFunctionEnum.SWIRL``
-    - ``MultiBlockPlot3DReader.VELOCITY = Plot3DFunctionEnum.VELOCITY``
-    - ``MultiBlockPlot3DReader.VORTICITY = Plot3DFunctionEnum.VORTICITY``
-    - ``MultiBlockPlot3DReader.MOMENTUM = Plot3DFunctionEnum.MOMENTUM``
-    - ``MultiBlockPlot3DReader.PRESSURE_GRADIENT = Plot3DFunctionEnum.PRESSURE_GRADIENT``
-    - ``MultiBlockPlot3DReader.STRAIN_RATE = Plot3DFunctionEnum.STRAIN_RATE``
-    - ``MultiBlockPlot3DReader.VORTICITY_MAGNITUDE = Plot3DFunctionEnum.VORTICITY_MAGNITUDE``
+        - ``MultiBlockPlot3DReader.DENSITY = Plot3DFunctionEnum.DENSITY``
+        - ``MultiBlockPlot3DReader.PRESSURE = Plot3DFunctionEnum.PRESSURE``
+        - ``MultiBlockPlot3DReader.PRESSURE_COEFFICIENT = Plot3DFunctionEnum.PRESSURE_COEFFICIENT``
+        - ``MultiBlockPlot3DReader.MACH = Plot3DFunctionEnum.MACH``
+        - ``MultiBlockPlot3DReader.SPEED_OF_SOUND = Plot3DFunctionEnum.SPEED_OF_SOUND``
+        - ``MultiBlockPlot3DReader.TEMPERATURE = Plot3DFunctionEnum.TEMPERATURE``
+        - ``MultiBlockPlot3DReader.ENTHALPY = Plot3DFunctionEnum.ENTHALPY``
+        - ``MultiBlockPlot3DReader.INTERNAL_ENERGY = Plot3DFunctionEnum.INTERNAL_ENERGY``
+        - ``MultiBlockPlot3DReader.KINETIC_ENERGY = Plot3DFunctionEnum.KINETIC_ENERGY``
+        - ``MultiBlockPlot3DReader.VELOCITY_MAGNITUDE = Plot3DFunctionEnum.VELOCITY_MAGNITUDE``
+        - ``MultiBlockPlot3DReader.STAGNATION_ENERGY = Plot3DFunctionEnum.STAGNATION_ENERGY``
+        - ``MultiBlockPlot3DReader.ENTROPY = Plot3DFunctionEnum.ENTROPY``
+        - ``MultiBlockPlot3DReader.SWIRL = Plot3DFunctionEnum.SWIRL``
+        - ``MultiBlockPlot3DReader.VELOCITY = Plot3DFunctionEnum.VELOCITY``
+        - ``MultiBlockPlot3DReader.VORTICITY = Plot3DFunctionEnum.VORTICITY``
+        - ``MultiBlockPlot3DReader.MOMENTUM = Plot3DFunctionEnum.MOMENTUM``
+        - ``MultiBlockPlot3DReader.PRESSURE_GRADIENT = Plot3DFunctionEnum.PRESSURE_GRADIENT``
+        - ``MultiBlockPlot3DReader.STRAIN_RATE = Plot3DFunctionEnum.STRAIN_RATE``
+        - ``MultiBlockPlot3DReader.VORTICITY_MAGNITUDE = Plot3DFunctionEnum.VORTICITY_MAGNITUDE``
     """
 
     _class_reader = staticmethod(_vtk.lazy_vtkMultiBlockPLOT3DReader)
@@ -1368,13 +1369,23 @@ class MultiBlockPlot3DReader(BaseReader):
     def add_function(self, value: Union[int, Plot3DFunctionEnum]):
         """Specify additional functions to compute.
 
-        The available functions are enumerated in :class:`Plot3DFunctionEnum`. Multiple functions may be requested by
-        calling this method multiple times.
+        The available functions are enumerated in :class:`Plot3DFunctionEnum`. The members of this enumeration are most
+        easily accessed by their aliases as class variables.
+
+        Multiple functions may be requested by calling this method multiple times.
 
         Parameters
         ----------
         value : int or Plot3DFunctionEnum
             The function to add.
+
+        Example
+        -------
+        >>> import pyvista
+        >>> reader = pyvista.reader.MultiBlockPlot3DReader('grid.x')
+        >>> reader.add_function(112)  # add a function by its integer value
+        >>> reader.add_function(reader.PRESSURE_COEFFICIENT)  # add a function by enumeration via class variable alias
+
         """
         if isinstance(value, enum.Enum):
             value = value.value
@@ -1382,6 +1393,8 @@ class MultiBlockPlot3DReader(BaseReader):
 
     def remove_function(self, value: Union[int, Plot3DFunctionEnum]):
         """Remove one function from list of functions to compute.
+
+        For details on the types of accepted values, see :meth:``add_function``.
 
         Parameters
         ----------

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -1250,7 +1250,7 @@ class Plot3DMetaReader(BaseReader):
 
 
 class Plot3DFunctionEnum(enum.IntEnum):
-    """Enum for functions used in `MultiBLockPlot3DReader`."""
+    """An enumeration for the functions used in `MultiBlockPlot3DReader`."""
 
     DENSITY = 100
     PRESSURE = 110

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -1321,31 +1321,34 @@ class MultiBlockPlot3DReader(BaseReader):
         self.reader.SetAutoDetectFormat(value)
 
     def add_function(self, value: Union[int, Plot3DFunctionEnum]):
-        """Specify additional functions to read.
+        """Specify additional functions to compute.
+
+        The available functions are enumerated in :class:`Plot3DFunctionEnum`. Multiple functions may be requested by
+        calling this method multiple times.
 
         Parameters
         ----------
-        value
-            An integer or `Plot3DFunctionEnum`.
+        value : int or Plot3DFunctionEnum
+            The function to add.
         """
         if isinstance(value, enum.Enum):
             value = value.value
         self.reader.AddFunction(value)
 
     def remove_function(self, value: Union[int, Plot3DFunctionEnum]):
-        """Remove one function from list of functions to read.
+        """Remove one function from list of functions to compute.
 
         Parameters
         ----------
-        value
-            An integer or `Plot3DFunctionEnum`.
+        value : int or Plot3DFunctionEnum
+            The function to remove.
         """
         if isinstance(value, enum.Enum):
             value = value.value
         self.reader.RemoveFunction(value)
 
     def remove_all_functions(self):
-        """Remove all functions from list of functions to read."""
+        """Remove all functions from list of functions to compute."""
         self.reader.RemoveAllFunctions()
 
     @property

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -1379,8 +1379,8 @@ class MultiBlockPlot3DReader(BaseReader):
         value : int or Plot3DFunctionEnum
             The function to add.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import pyvista
         >>> from pyvista import examples
         >>> filename, _  = examples.downloads._download_file('multi-bin.xyz')

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,7 +1,7 @@
 Sphinx==4.5.0
 cmocean==2.0
 colorcet==3.0.0
-enum_tools
+enum-tools==0.9.0.post1
 imageio-ffmpeg==0.4.7
 imageio>=2.5.0
 ipygany==0.5.0

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -27,7 +27,7 @@ sphinx-copybutton==0.5.0
 sphinx-gallery==0.11.0
 sphinx-notfound-page==0.8.3
 sphinx-panels==0.6.0
-sphinx-toolbox
+sphinx-toolbox==3.2.0
 sphinxcontrib-websupport==1.2.4
 trimesh==3.13.5
 typed-ast==1.5.4

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,6 +1,7 @@
 Sphinx==4.5.0
 cmocean==2.0
 colorcet==3.0.0
+enum_tools
 imageio-ffmpeg==0.4.7
 imageio>=2.5.0
 ipygany==0.5.0
@@ -26,6 +27,7 @@ sphinx-copybutton==0.5.0
 sphinx-gallery==0.11.0
 sphinx-notfound-page==0.8.3
 sphinx-panels==0.6.0
+sphinx-toolbox
 sphinxcontrib-websupport==1.2.4
 trimesh==3.13.5
 typed-ast==1.5.4

--- a/tests/utilities/test_reader.py
+++ b/tests/utilities/test_reader.py
@@ -384,14 +384,21 @@ def test_multiblockplot3dreader():
     # Reader doesn't yet support reusability
     reader = pyvista.MultiBlockPlot3DReader(filename)
     reader.add_q_files(q_filename)
+
     reader.add_function(112)  # add by int
     reader.add_function(pyvista.reader.Plot3DFunctionEnum.PRESSURE_GRADIENT)  # add by enum
+    reader.add_function(reader.KINETIC_ENERGY)  # add by class variable (alias to enum value)
+    reader.add_function(reader.ENTROPY)  # add ENTROPY by class variable
+    reader.remove_function(170)  # remove ENTROPY by int
+
     mesh = reader.read()
     for m in mesh:
         assert len(m.array_names) > 0
 
     assert 'MachNumber' in mesh[0].point_data
     assert 'PressureGradient' in mesh[0].point_data
+    assert 'KineticEnergy' in mesh[0].point_data
+    assert 'Entropy' not in mesh[0].point_data
 
     reader = pyvista.MultiBlockPlot3DReader(filename)
     reader.add_q_files([q_filename])

--- a/tests/utilities/test_reader.py
+++ b/tests/utilities/test_reader.py
@@ -391,6 +391,9 @@ def test_multiblockplot3dreader():
     reader.add_function(reader.ENTROPY)  # add ENTROPY by class variable
     reader.remove_function(170)  # remove ENTROPY by int
 
+    reader.add_function(reader.ENTROPY)
+    reader.remove_function(reader.ENTROPY)  # remove by class variable
+
     mesh = reader.read()
     for m in mesh:
         assert len(m.array_names) > 0
@@ -431,6 +434,14 @@ def test_multiblockplot3dreader():
     assert reader.r_gas_constant == 5
     reader.r_gas_constant = 10
     assert reader.r_gas_constant == 10
+
+    # check removing all functions
+    reader = pyvista.MultiBlockPlot3DReader(filename)
+    reader.add_q_files(q_filename)
+    reader.add_function(reader.ENTROPY)
+    reader.remove_all_functions()
+    mesh_no_functions = reader.read()
+    assert 'ENTROPY' not in mesh_no_functions[0].point_data
 
 
 def test_binarymarchingcubesreader():

--- a/tests/utilities/test_reader.py
+++ b/tests/utilities/test_reader.py
@@ -384,21 +384,46 @@ def test_multiblockplot3dreader():
     # Reader doesn't yet support reusability
     reader = pyvista.MultiBlockPlot3DReader(filename)
     reader.add_q_files(q_filename)
+    reader.add_function(112)  # add by int
+    reader.add_function(pyvista.reader.Plot3DFunctionEnum.PRESSURE_GRADIENT)  # add by enum
+    mesh = reader.read()
+    for m in mesh:
+        assert len(m.array_names) > 0
+
+    assert 'MachNumber' in mesh[0].point_data
+    assert 'PressureGradient' in mesh[0].point_data
+
+    reader = pyvista.MultiBlockPlot3DReader(filename)
+    reader.add_q_files([q_filename])
     mesh = reader.read()
     for m in mesh:
         assert len(m.array_names) > 0
 
     reader = pyvista.MultiBlockPlot3DReader(filename)
-    q_filename = reader.add_q_files([q_filename])
-    mesh = reader.read()
-    for m in mesh:
-        assert len(m.array_names) > 0
 
-    reader = pyvista.MultiBlockPlot3DReader(filename)
+    # get/set of `auto_detect_format`
     reader.auto_detect_format = False
     assert reader.auto_detect_format is False
     reader.auto_detect_format = True
     assert reader.auto_detect_format is True
+
+    # get/set of `preserve_intermediate_functions`
+    reader.preserve_intermediate_functions = False
+    assert reader.preserve_intermediate_functions is False
+    reader.preserve_intermediate_functions = True
+    assert reader.preserve_intermediate_functions is True
+
+    # get/set of `gamma`
+    reader.gamma = 1.5
+    assert reader.gamma == 1.5
+    reader.gamma = 99
+    assert reader.gamma == 99
+
+    # get/set of `r_gas_constant`
+    reader.r_gas_constant = 5
+    assert reader.r_gas_constant == 5
+    reader.r_gas_constant = 10
+    assert reader.r_gas_constant == 10
 
 
 def test_binarymarchingcubesreader():


### PR DESCRIPTION
Expose options in `MultiBlockPlot3DReader` related to _functions_ - derived scalar/vector fields computed from the point data living in Plot3D files.

This PR adds an enum to map useful names to their int values required by the `add_function()` method. There may be a better place for this enum to live.

There are still many methods from the `vtkMultiBlockPlot3DReader` available I chose not to expose, mainly relating to the format of the target file. The VTK documentation states that most binary files can be read without calling these methods, so long as "auto-detect" is on - in PyVista, it is by default. Thus, for simplicity, I chose not to expose the many reading flags. A user can still set them directly on the VTK reader instance if necessary.
