### PR TITLE
More descriptive error message when no geodesic path exists between vertices on a mesh

### DIFF
--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -1903,7 +1903,13 @@ class PolyDataFilters(DataSetFilters):
         original_ids = vtk_id_list_to_array(dijkstra.GetIdList())
 
         output = _get_output(dijkstra)
-        output["vtkOriginalPointIds"] = original_ids
+
+        try:
+            output["vtkOriginalPointIds"] = original_ids
+        except ValueError as e:
+            if str(e) != 'Number of scalars (1) must match either the number of points (0) or the number of cells (0).':
+                raise
+            raise ValueError(f"There is no path between vertices {start_vertex} and {end_vertex}.")
 
         # Do not copy textures from input
         output.clear_textures()

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -1903,13 +1903,12 @@ class PolyDataFilters(DataSetFilters):
         original_ids = vtk_id_list_to_array(dijkstra.GetIdList())
 
         output = _get_output(dijkstra)
+        if output.n_points == 0:
+            raise ValueError(f"There is no path between vertices {start_vertex} and {end_vertex}. ",
+                "It is likely the vertices belong to disconnected regions."
+            )
 
-        try:
-            output["vtkOriginalPointIds"] = original_ids
-        except ValueError as e:
-            if str(e) != 'Number of scalars (1) must match either the number of points (0) or the number of cells (0).':
-                raise
-            raise ValueError(f"There is no path between vertices {start_vertex} and {end_vertex}.")
+        output["vtkOriginalPointIds"] = original_ids
 
         # Do not copy textures from input
         output.clear_textures()

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -1904,8 +1904,9 @@ class PolyDataFilters(DataSetFilters):
 
         output = _get_output(dijkstra)
         if output.n_points == 0:
-            raise ValueError(f"There is no path between vertices {start_vertex} and {end_vertex}. ",
-                "It is likely the vertices belong to disconnected regions."
+            raise ValueError(
+                f"There is no path between vertices {start_vertex} and {end_vertex}. ",
+                "It is likely the vertices belong to disconnected regions.",
             )
 
         output["vtkOriginalPointIds"] = original_ids

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -7,6 +7,7 @@ import pytest
 
 import pyvista
 from pyvista import examples
+from pyvista._vtk import VTK9
 from pyvista.core.errors import NotAllTrianglesError
 from pyvista.plotting import system_supports_plotting
 from pyvista.utilities.misc import PyvistaFutureWarning
@@ -16,6 +17,8 @@ radius = 0.5
 skip_plotting = pytest.mark.skipif(
     not system_supports_plotting(), reason="Requires system to support plotting"
 )
+
+skip_not_vtk9 = pytest.mark.skipif(not VTK9, reason="Test requires >=VTK v9")
 
 
 @pytest.fixture
@@ -859,11 +862,11 @@ def test_n_lines():
     assert mesh.n_lines == 1
 
 
-def test_geodesic_error_message(sphere, sphere_shifted):
+@skip_not_vtk9
+def test_geodesic_disconnected(sphere, sphere_shifted):
 
-    combined = (
-        sphere + sphere_shifted
-    )  # the sphere and sphere_shifted are disconnected - no path between them
+    # the sphere and sphere_shifted are disconnected - no path between them
+    combined = sphere + sphere_shifted
     start_vertex = 0
     end_vertex = combined.n_points - 1
     match = f"There is no path between vertices {start_vertex} and {end_vertex}."

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -861,9 +861,11 @@ def test_n_lines():
 
 def test_geodesic_error_message(sphere, sphere_shifted):
 
-    combined = sphere + sphere_shifted  # the sphere and sphere_shifted are disconnected - no path between them
+    combined = (
+        sphere + sphere_shifted
+    )  # the sphere and sphere_shifted are disconnected - no path between them
     start_vertex = 0
-    end_vertex = combined.n_points-1
+    end_vertex = combined.n_points - 1
     match = f"There is no path between vertices {start_vertex} and {end_vertex}."
 
     with pytest.raises(ValueError, match=match):

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -864,7 +864,6 @@ def test_n_lines():
 
 @skip_not_vtk9
 def test_geodesic_disconnected(sphere, sphere_shifted):
-
     # the sphere and sphere_shifted are disconnected - no path between them
     combined = sphere + sphere_shifted
     start_vertex = 0

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -857,3 +857,17 @@ def test_n_verts():
 def test_n_lines():
     mesh = pyvista.Line()
     assert mesh.n_lines == 1
+
+
+def test_geodesic_error_message(sphere, sphere_shifted):
+
+    combined = sphere + sphere_shifted  # the sphere and sphere_shifted are disconnected - no path between them
+    start_vertex = 0
+    end_vertex = combined.n_points-1
+    match = f"There is no path between vertices {start_vertex} and {end_vertex}."
+
+    with pytest.raises(ValueError, match=match):
+        combined.geodesic(start_vertex, end_vertex)
+
+    with pytest.raises(ValueError, match=match):
+        combined.geodesic_distance(start_vertex, end_vertex)


### PR DESCRIPTION
### Overview

resolves #1734

* If there is no geodesic path between two vertices, `PolyData.geodesic` and `PolyData.geodesic_distance` now raise clearer error messages.
* Added tests to check error message is raised

### Details

Previously, the error raised was:
```
Number of scalars (1) must match either the number of points (0) or the number of cells (0).
```


This was raised by trying to assign the indices of points in the path (i.e. the start index) to the output mesh, which has zero points and cells.

Now the following error message is raised:
```
f"There is no path between vertices {start_vertex} and {end_vertex}."
```