### PR TITLE
Add typing_extensions install dependency for Python < 3.8

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -29,4 +29,3 @@ sphinx-panels==0.6.0
 sphinxcontrib-websupport==1.2.4
 trimesh==3.13.1
 typed-ast==1.5.4
-typing_extensions==4.3.0

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ install_requires = [
     'appdirs',
     'scooby>=0.5.1',
     'vtk',
+    "typing-extensions; python_version < '3.8'",
 ]
 
 readme_file = os.path.join(filepath, 'README.rst')


### PR DESCRIPTION
We have this in `pyvista/core/dataset.py`:

https://github.com/pyvista/pyvista/blob/9011e13c018e3cbd7c0474425987c9b1fe9ca658/pyvista/core/dataset.py#L10-L13

This causes `typing_extensions` to be a runtime dependency on Python 3.7 and lower starting from the moment someone does `import pyvista`. This wasn't revealed in CI because we have `typing_extensions` specified in `requirements_docs.txt`.

Furthermore, this is what I see:
```
$ git grep typing_extensions
pyvista/core/dataset.py:    from typing_extensions import Literal
requirements_docs.txt:typing_extensions==4.3.0
```

It seems to me that we could remove the dependency from `requirements_docs`, because this is the only place where `typing_extensions` is still used. Could there be implicit dependencies somehow that need the version pin (mostly: version pin for this dependency of our dependency)? I haven't touched this yet.