### PR TITLE
disable caching of build directory

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,13 +74,6 @@ jobs:
           path: doc/examples/
           key: doc-examples-${{ hashFiles('pyvista/_version.py') }}
 
-      - name: Cache docs _build directory
-        uses: actions/cache@v3
-        if: env.USE_CACHE == 'true'
-        with:
-          path: doc/_build/
-          key: doc-_build-${{ hashFiles('pyvista/_version.py') }}-${{ hashFiles('doc/conf.py') }}
-
       - name: Cache example data
         uses: actions/cache@v3
         if: env.USE_CACHE == 'true'


### PR DESCRIPTION
Disable the caching of the build directory as this is causing builds to fail. The cache isn't working correctly anyway, so removing this cache will actually speed up the documentation build.
