### PR TITLE
Use Mamba to speed up the conda build

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -101,7 +101,7 @@ jobs:
           conda install -n base conda-libmamba-solver
 
       - name: 'Workaround for mamba-org/mamba#488'
-        run: rm /usr/local/miniconda/pkgs/cache/*.json
+        run: rm /usr/local/miniconda/pkgs/cache/*
 
       - name: Create Anaconda environment
         run: |

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -122,7 +122,6 @@ jobs:
           python -c "import pyvista; print(pyvista.EXAMPLES_PATH)"
 
       - name: Test Core API
-        continue-on-error: true
         run: |
           source /usr/share/miniconda/etc/profile.d/conda.sh
           conda activate ${{ env.conda_env }}
@@ -130,18 +129,10 @@ jobs:
           pytest -v --ignore=tests/plotting
 
       - name: Test Core Plotting
-        continue-on-error: true
         run: |
           source /usr/share/miniconda/etc/profile.d/conda.sh
           conda activate ${{ env.conda_env }}
           pytest -v tests/plotting --cov-report html
-
-      - name: Test Package Docstrings
-        continue-on-error: true
-        run: |
-          source /usr/share/miniconda/etc/profile.d/conda.sh
-          conda activate ${{ env.conda_env }}
-          pytest -v --doctest-modules pyvista
 
   Linux:
     name: Linux Unit Testing

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -92,11 +92,19 @@ jobs:
           restore-keys: |
             Examples-1-
 
-      - name: Create Anaconda environment
+      # See: https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community
+      - name: Install mamba
         run: |
+          source /usr/share/miniconda/etc/profile.d/conda.sh
           conda config --set channel_priority strict
           conda update -n base conda
           conda install -n base conda-libmamba-solver
+
+      - name: 'Workaround for mamba-org/mamba#488'
+        run: rm /usr/local/miniconda/pkgs/cache/*.json
+
+      - name: Create Anaconda environment
+        run: |
           source /usr/share/miniconda/etc/profile.d/conda.sh
           conda config --add channels conda-forge
           sed -i -e 's/- vtk$/- vtk= ${{ env.VTK_VERSION }} /' environment.yml

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -92,16 +92,11 @@ jobs:
           restore-keys: |
             Examples-1-
 
-      # https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community
-      - name: Install mamba
+      - name: Create Anaconda environment
         run: |
-          source /usr/share/miniconda/etc/profile.d/conda.sh
           conda config --set channel_priority strict
           conda update -n base conda
           conda install -n base conda-libmamba-solver
-
-      - name: Create Anaconda environment
-        run: |
           source /usr/share/miniconda/etc/profile.d/conda.sh
           conda config --add channels conda-forge
           sed -i -e 's/- vtk$/- vtk= ${{ env.VTK_VERSION }} /' environment.yml

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -101,7 +101,7 @@ jobs:
           conda install -n base conda-libmamba-solver
 
       - name: 'Workaround for mamba-org/mamba#488'
-        run: rm /usr/local/miniconda/pkgs/cache/*
+        run: rm /usr/share/miniconda/pkgs/cache/*.json                
 
       - name: Create Anaconda environment
         run: |

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@v1
 
-      - name: Cache Conda
+      - name: Cache Conda Packages
         uses: actions/cache@v3
         with:
           path: ~/anaconda3/pkgs
@@ -92,13 +92,20 @@ jobs:
           restore-keys: |
             Examples-1-
 
+      # https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community
+      - name: Install mamba
+        run: |
+          source /usr/share/miniconda/etc/profile.d/conda.sh
+          conda config --set channel_priority strict
+          conda update -n base conda
+          conda install -n base conda-libmamba-solver
+
       - name: Create Anaconda environment
         run: |
           source /usr/share/miniconda/etc/profile.d/conda.sh
           conda config --add channels conda-forge
-          conda config --set channel_priority strict
           sed -i -e 's/- vtk$/- vtk= ${{ env.VTK_VERSION }} /' environment.yml
-          conda env create --quiet -n ${{ env.conda_env }} --file environment.yml
+          conda env create --quiet -n ${{ env.conda_env }} --file environment.yml --experimental-solver=libmamba
           conda activate ${{ env.conda_env }}
           conda list
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - numpy
   - vtk
   - scooby>=0.5.1
-  - meshio>=4.0.3, <5.0
+  - meshio
   - matplotlib
   - appdirs
   - pyqt


### PR DESCRIPTION
Conda builds take forever to create the environment. This PR proposes we speed that up by using the mamba solver.

After speaking with a few of the guys from anaconda, I think that they're highly considering bringing it from "experimental" to just making it an option. Considering that Anaconda now includes `Libmamba` in their main channel (see (this blog)[https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community]) I think it's safe to say that it's safe that we rely on this for testing.

A few thoughts when going over this PR:
- Is any of this even necessary? We ignore test failures and while I think it's really important that we support anaconda, I don't really think it's critical that we have to test it unless we can get the solution on par with pip's solution speed
- Can we drop testing package dostrings? Part of the reason why we're testing here is to support VTK 8.2, which is only available on conda, and our docstrings are always going to fail here, hence why we ignore test failures.

In short, I think we should either remove or at the very least prune this workflow.
