### PR TITLE
Define pytest markers for skipping tests based on vtk version

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,6 @@ filterwarnings =
     ignore:.*The NumPy module was reloaded*:UserWarning
 doctest_optionflags = NUMBER ELLIPSIS
 testpaths = tests
+markers =
+    needs_vtk9: skip test unless VTK is 9.0 or newer.
+    needs_vtk_version(version): skip test unless VTK version is at least as specified.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.random import default_rng
-from pytest import fixture
+from pytest import fixture, skip
 
 import pyvista
 from pyvista import examples
@@ -119,3 +119,27 @@ def pytest_addoption(parser):
     parser.addoption("--reset_image_cache", action='store_true', default=False)
     parser.addoption("--ignore_image_cache", action='store_true', default=False)
     parser.addoption("--fail_extra_image_cache", action='store_true', default=False)
+
+
+def pytest_runtest_setup(item):
+    """Custom setup to handle skips based on VTK version.
+
+    See pytest.mark.needs_vtk9 and pytest.mark.needs_vtk_version
+    in pytest.ini.
+
+    """
+    for mark in item.iter_markers('needs_vtk9'):
+        # this test needs VTK 9 or newer
+        if not pyvista._vtk.VTK9:
+            skip('Test needs VTK 9 or newer.')
+    for mark in item.iter_markers('needs_vtk_version'):
+        # this test needs the given VTK version
+        # allow both needs_vtk_version(9, 1) and needs_vtk_version((9, 1))
+        args = mark.args
+        if len(args) == 1 and isinstance(args[0], tuple):
+            version_needed = args[0]
+        else:
+            version_needed = args
+        if pyvista.vtk_version < version_needed:
+            version_str = '.'.join(map(str, version_needed))
+            skip(f'Test needs VTK {version_str} or newer.')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,6 @@ def pytest_runtest_setup(item):
             version_needed = args[0]
         else:
             version_needed = args
-        if pyvista.vtk_version < version_needed:
+        if pyvista.vtk_version_info < version_needed:
             version_str = '.'.join(map(str, version_needed))
             skip(f'Test needs VTK {version_str} or newer.')

--- a/tests/jupyter/test_pythreejs.py
+++ b/tests/jupyter/test_pythreejs.py
@@ -9,7 +9,6 @@ except:  # noqa: E722
     pytestmark = pytest.mark.skip
 
 import pyvista
-from pyvista._vtk import VTK9
 from pyvista.jupyter import pv_pythreejs
 
 
@@ -111,7 +110,7 @@ def test_cast_to_min_size(max_index):
             buf_attr = pv_pythreejs.cast_to_min_size(np.arange(1000), max_index)
 
 
-@pytest.mark.skipif(not VTK9, reason='Only supported on VTK v9 or newer')
+@pytest.mark.needs_vtk9
 def test_pbr(sphere):
     pl = pyvista.Plotter()
     pl.add_mesh(sphere, scalars=range(sphere.n_cells), pbr=True)

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -61,8 +61,6 @@ if not os.path.isdir(IMAGE_CACHE_DIR):
 # always set on Windows CI
 CI_WINDOWS = os.environ.get('CI_WINDOWS', 'false').lower() == 'true'
 
-skip_not_vtk9 = pytest.mark.skipif(not VTK9, reason="Test requires >=VTK v9")
-
 skip_mac = pytest.mark.skipif(
     platform.system() == 'Darwin', reason='MacOS CI fails when downloading examples'
 )
@@ -205,7 +203,7 @@ def verify_cache_image(plotter):
         )
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 def test_import_gltf():
     filename = os.path.join(THIS_PATH, '..', 'example_files', 'Box.glb')
     pl = pyvista.Plotter()
@@ -217,7 +215,7 @@ def test_import_gltf():
     pl.show(before_close_callback=verify_cache_image)
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 def test_export_gltf(tmpdir, sphere, airplane, hexbeam):
     filename = str(tmpdir.mkdir("tmpdir").join('tmp.gltf'))
 
@@ -262,7 +260,7 @@ def test_export_vrml(tmpdir, sphere, airplane, hexbeam):
         pl_import.export_vrml(filename)
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 @skip_windows
 @pytest.mark.skipif(CI_WINDOWS, reason="Windows CI testing segfaults on pbr")
 def test_pbr(sphere):
@@ -287,7 +285,7 @@ def test_pbr(sphere):
     pl.show(before_close_callback=verify_cache_image)
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 @skip_windows
 @skip_mac
 def test_set_environment_texture_cubemap(sphere):
@@ -305,7 +303,7 @@ def test_set_environment_texture_cubemap(sphere):
         pl.show()
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 @skip_windows
 @skip_mac
 def test_remove_environment_texture_cubemap(sphere):
@@ -338,7 +336,7 @@ def test_plot_increment_point_size():
     pl.show(before_close_callback=verify_cache_image)
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 def test_plot_update(sphere):
     pl = pyvista.Plotter()
     pl.add_mesh(sphere)
@@ -2222,7 +2220,7 @@ def test_scalar_cell_priorities():
     plotter.show(before_close_callback=verify_cache_image)
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 def test_collision_plot():
     """Verify rgba arrays automatically plot"""
     sphere0 = pyvista.Sphere()

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -45,7 +45,7 @@ except:  # noqa: E722
 # These tests fail with mesa opengl on windows
 skip_windows = pytest.mark.skipif(os.name == 'nt', reason='Test fails on Windows')
 
-skip_9_1_0 = pytest.mark.skipif(pyvista.vtk_version_info < (9, 1, 0), reason="Requires VTK>=9.1.0")
+skip_9_1_0 = pytest.mark.needs_vtk_version(9, 1, 0)
 
 skip_no_mpl_figure = pytest.mark.skipif(
     not can_create_mpl_figure(), reason="Cannot create a figure using matplotlib"
@@ -2234,7 +2234,7 @@ def test_collision_plot():
 
 
 @skip_mac
-@pytest.mark.skipif(pyvista.vtk_version_info < (9, 2, 0), reason="Requires VTK>=9.2.0")
+@pytest.mark.needs_vtk_version(9, 2, 0)
 def test_chart_plot():
     """Basic test to verify chart plots correctly"""
     # Chart 1 (bottom left)

--- a/tests/plotting/test_widgets.py
+++ b/tests/plotting/test_widgets.py
@@ -230,7 +230,7 @@ def test_widget_checkbox_button(uniform):
     p.close()
 
 
-@pytest.mark.skipif(pyvista.vtk_version_info < (9, 1), reason="Requires vtk>=9.1")
+@pytest.mark.needs_vtk_version(9, 1)
 def test_add_camera_orientation_widget(uniform):
     p = pyvista.Plotter()
     p.add_camera_orientation_widget()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -22,7 +22,6 @@ skip_py2_nobind = pytest.mark.skipif(
 )
 
 skip_mac = pytest.mark.skipif(platform.system() == 'Darwin', reason="Flaky Mac tests")
-skip_not_vtk9 = pytest.mark.skipif(not VTK9, reason="Test requires >=VTK v9")
 skip_no_mpl_figure = pytest.mark.skipif(
     not can_create_mpl_figure(), reason="Cannot create a figure using matplotlib"
 )
@@ -1169,7 +1168,7 @@ def test_streamlines_from_source_structured_grids():
     assert all([stream.n_points, stream.n_cells])
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 def mesh_2D_velocity():
     mesh = pyvista.Plane(i_resolution=100, j_resolution=100)
     velocity = np.zeros([mesh.n_points, 3])
@@ -1179,28 +1178,28 @@ def mesh_2D_velocity():
     return mesh
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 def test_streamlines_evenly_spaced_2D():
     mesh = mesh_2D_velocity()
     streams = mesh.streamlines_evenly_spaced_2D(progress_bar=True)
     assert all([streams.n_points, streams.n_cells])
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 def test_streamlines_evenly_spaced_2D_sep_dist_ratio():
     mesh = mesh_2D_velocity()
     streams = mesh.streamlines_evenly_spaced_2D(separating_distance_ratio=0.1, progress_bar=True)
     assert all([streams.n_points, streams.n_cells])
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 def test_streamlines_evenly_spaced_2D_start_position():
     mesh = mesh_2D_velocity()
     streams = mesh.streamlines_evenly_spaced_2D(start_position=(-0.1, 0.1, 0.0), progress_bar=True)
     assert all([streams.n_points, streams.n_cells])
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 def test_streamlines_evenly_spaced_2D_vectors():
     mesh = mesh_2D_velocity()
     mesh.set_active_vectors(None)
@@ -1208,14 +1207,14 @@ def test_streamlines_evenly_spaced_2D_vectors():
     assert all([streams.n_points, streams.n_cells])
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 def test_streamlines_evenly_spaced_2D_integrator_type():
     mesh = mesh_2D_velocity()
     streams = mesh.streamlines_evenly_spaced_2D(integrator_type=4, progress_bar=True)
     assert all([streams.n_points, streams.n_cells])
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 def test_streamlines_evenly_spaced_2D_interpolator_type():
     mesh = mesh_2D_velocity()
     streams = mesh.streamlines_evenly_spaced_2D(interpolator_type='cell', progress_bar=True)
@@ -1657,7 +1656,7 @@ def test_extract_surface():
 
     cells = np.hstack((20, np.arange(20))).astype(np.int64, copy=False)
     celltypes = np.array([VTK_QUADRATIC_HEXAHEDRON])
-    if pyvista._vtk.VTK9:
+    if VTK9:
         grid = pyvista.UnstructuredGrid(cells, celltypes, pts)
     else:
         grid = pyvista.UnstructuredGrid(np.array([0]), cells, celltypes, pts)
@@ -2257,7 +2256,7 @@ def test_transform_mesh_and_vectors(datasets, num_cell_arrays, num_point_data):
             )
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 @pytest.mark.parametrize("num_cell_arrays,num_point_data", itertools.product([0, 1, 2], [0, 1, 2]))
 def test_transform_int_vectors_warning(datasets, num_cell_arrays, num_point_data):
     for dataset in datasets:
@@ -2302,7 +2301,7 @@ def test_reflect_mesh_about_point(datasets):
         assert np.allclose(dataset.points[:, 1:], reflected.points[:, 1:])
 
 
-@pytest.mark.skipif(not VTK9, reason='Only supported on VTK v9 or newer')
+@pytest.mark.needs_vtk9
 def test_reflect_mesh_with_vectors(datasets):
     for dataset in datasets:
         if hasattr(dataset, 'compute_normals'):
@@ -2438,7 +2437,7 @@ def test_extrude_rotate_inplace():
     assert poly.n_points == (resolution + 1) * old_line.n_points
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 def test_extrude_trim():
     direction = (0, 0, 1)
     mesh = pyvista.Plane(
@@ -2451,7 +2450,7 @@ def test_extrude_trim():
     assert np.isclose(poly.volume, 1.0)
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 @pytest.mark.parametrize('extrusion', ["boundary_edges", "all_edges"])
 @pytest.mark.parametrize(
     'capping', ["intersection", "minimum_distance", "maximum_distance", "average_distance"]
@@ -2488,7 +2487,7 @@ def test_extrude_trim_catch():
         _ = mesh.extrude_trim([1, 2], trim_surface)
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 def test_extrude_trim_inplace():
     direction = (0, 0, 1)
     mesh = pyvista.Plane(
@@ -2516,7 +2515,7 @@ def test_invalid_subdivide_adaptive(cube):
         cube.subdivide_adaptive()
 
 
-@pytest.mark.skipif(not VTK9, reason='Only supported on VTK v9 or newer')
+@pytest.mark.needs_vtk9
 def test_collision(sphere):
     moved_sphere = sphere.translate((0.5, 0, 0), inplace=False)
     output, n_collision = sphere.collision(moved_sphere)
@@ -2530,7 +2529,7 @@ def test_collision(sphere):
     assert not n_collision
 
 
-@pytest.mark.skipif(not VTK9, reason='Only supported on VTK v9 or newer')
+@pytest.mark.needs_vtk9
 def test_collision_solid_non_triangle(hexbeam):
     # test non-triangular mesh with a unstructured grid
     cube = pyvista.Cube()
@@ -2558,7 +2557,7 @@ def test_reconstruct_surface_unstructured():
     assert mesh.n_points
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 def test_integrate_data_datasets(datasets):
     """Test multiple dataset types."""
     for dataset in datasets:
@@ -2571,7 +2570,7 @@ def test_integrate_data_datasets(datasets):
             raise ValueError("Unexpected integration")
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 def test_integrate_data():
     """Test specific case."""
     # sphere with radius = 0.5, area = pi

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1149,7 +1149,7 @@ def test_set_extent():
     assert np.array_equal(uni_grid.extent, extent)
 
 
-@pytest.mark.skipif(not VTK9, reason='VTK 9 or higher is required')
+@pytest.mark.needs_vtk9
 def test_UnstructuredGrid_cast_to_explicit_structured_grid():
     grid = examples.load_explicit_structured()
     grid = grid.hide_cells(range(80, 120))
@@ -1165,7 +1165,7 @@ def test_UnstructuredGrid_cast_to_explicit_structured_grid():
     assert np.count_nonzero(grid.cell_data['vtkGhostType']) == 40
 
 
-@pytest.mark.skipif(not VTK9, reason='VTK 9 or higher is required')
+@pytest.mark.needs_vtk9
 def test_ExplicitStructuredGrid_init():
     grid = examples.load_explicit_structured()
     assert isinstance(grid, pyvista.ExplicitStructuredGrid)
@@ -1178,7 +1178,7 @@ def test_ExplicitStructuredGrid_init():
     assert 'N Arrays' in str(grid)
 
 
-@pytest.mark.skipif(not VTK9, reason='VTK 9 or higher is required')
+@pytest.mark.needs_vtk9
 def test_ExplicitStructuredGrid_cast_to_unstructured_grid():
     block_i = np.fromstring(
         '''
@@ -1224,7 +1224,7 @@ def test_ExplicitStructuredGrid_cast_to_unstructured_grid():
     assert np.array_equal(grid.cell_data['BLOCK_K'], block_k)
 
 
-@pytest.mark.skipif(not VTK9, reason='VTK 9 or higher is required')
+@pytest.mark.needs_vtk9
 def test_ExplicitStructuredGrid_save():
     grid = examples.load_explicit_structured()
     grid = grid.hide_cells(range(80, 120))
@@ -1237,7 +1237,7 @@ def test_ExplicitStructuredGrid_save():
     os.remove('grid.vtu')
 
 
-@pytest.mark.skipif(not VTK9, reason='VTK 9 or higher is required')
+@pytest.mark.needs_vtk9
 def test_ExplicitStructuredGrid_hide_cells():
     ghost = np.asarray(
         '''
@@ -1264,7 +1264,7 @@ def test_ExplicitStructuredGrid_hide_cells():
     assert np.array_equal(grid.cell_data['vtkGhostType'], ghost)
 
 
-@pytest.mark.skipif(not VTK9, reason='VTK 9 or higher is required')
+@pytest.mark.needs_vtk9
 def test_ExplicitStructuredGrid_show_cells():
     grid = examples.load_explicit_structured()
     grid.hide_cells(range(80, 120), inplace=True)
@@ -1280,7 +1280,7 @@ def test_ExplicitStructuredGrid_show_cells():
     assert np.count_nonzero(grid.cell_data['vtkGhostType']) == 0
 
 
-@pytest.mark.skipif(not VTK9, reason='VTK 9 or higher is required')
+@pytest.mark.needs_vtk9
 def test_ExplicitStructuredGrid_dimensions():
     grid = examples.load_explicit_structured()
     assert isinstance(grid.dimensions, tuple)
@@ -1289,7 +1289,7 @@ def test_ExplicitStructuredGrid_dimensions():
     assert grid.dimensions == (5, 6, 7)
 
 
-@pytest.mark.skipif(not VTK9, reason='VTK 9 or higher is required')
+@pytest.mark.needs_vtk9
 def test_ExplicitStructuredGrid_visible_bounds():
     grid = examples.load_explicit_structured()
     grid = grid.hide_cells(range(80, 120))
@@ -1299,7 +1299,7 @@ def test_ExplicitStructuredGrid_visible_bounds():
     assert grid.visible_bounds == (0.0, 80.0, 0.0, 50.0, 0.0, 4.0)
 
 
-@pytest.mark.skipif(not VTK9, reason='VTK 9 or higher is required')
+@pytest.mark.needs_vtk9
 def test_ExplicitStructuredGrid_cell_id():
     grid = examples.load_explicit_structured()
 
@@ -1313,7 +1313,7 @@ def test_ExplicitStructuredGrid_cell_id():
     assert np.array_equal(ind, [19, 31, 41, 54])
 
 
-@pytest.mark.skipif(not VTK9, reason='VTK 9 or higher is required')
+@pytest.mark.needs_vtk9
 def test_ExplicitStructuredGrid_cell_coords():
     grid = examples.load_explicit_structured()
 
@@ -1328,7 +1328,7 @@ def test_ExplicitStructuredGrid_cell_coords():
     assert np.array_equal(coords, [(3, 4, 0), (3, 2, 1), (1, 0, 2), (2, 3, 2)])
 
 
-@pytest.mark.skipif(not VTK9, reason='VTK 9 or higher is required')
+@pytest.mark.needs_vtk9
 def test_ExplicitStructuredGrid_neighbors():
     grid = examples.load_explicit_structured()
 
@@ -1348,7 +1348,7 @@ def test_ExplicitStructuredGrid_neighbors():
     assert indices == [1, 4, 20]
 
 
-@pytest.mark.skipif(not VTK9, reason='VTK 9 or higher is required')
+@pytest.mark.needs_vtk9
 def test_ExplicitStructuredGrid_compute_connectivity():
     connectivity = np.asarray(
         '''
@@ -1376,7 +1376,7 @@ def test_ExplicitStructuredGrid_compute_connectivity():
     assert np.array_equal(grid.cell_data['ConnectivityFlags'], connectivity)
 
 
-@pytest.mark.skipif(not VTK9, reason='VTK 9 or higher is required')
+@pytest.mark.needs_vtk9
 def test_ExplicitStructuredGrid_compute_connections():
     connections = np.asarray(
         '''

--- a/tests/test_picking.py
+++ b/tests/test_picking.py
@@ -4,14 +4,13 @@ import pyvista
 from pyvista.plotting import system_supports_plotting
 
 NO_PLOTTING = not system_supports_plotting()
-skip_no_vtk9 = pytest.mark.skipif(pyvista.vtk_version_info < (9,), reason="Requires VTK v9+")
 
 # skip all tests if unable to render
 if not system_supports_plotting():
     pytestmark = pytest.mark.skip
 
 
-@skip_no_vtk9
+@pytest.mark.needs_vtk9
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_cell_picking():
     with pytest.raises(AttributeError, match="mesh"):
@@ -195,7 +194,7 @@ def test_enable_cell_picking_interactive_two_ren_win():
     assert n_cells[0]
 
 
-@skip_no_vtk9
+@pytest.mark.needs_vtk9
 @pytest.mark.parametrize('left_clicking', [False, True])
 def test_point_picking(left_clicking):
     sphere = pyvista.Sphere()
@@ -226,7 +225,7 @@ def test_point_picking(left_clicking):
         plotter.close()
 
 
-@skip_no_vtk9
+@pytest.mark.needs_vtk9
 def test_point_picking_window_not_pickable():
 
     plotter = pyvista.Plotter(
@@ -262,7 +261,7 @@ def test_point_picking_window_not_pickable():
     plotter.close()
 
 
-@skip_no_vtk9
+@pytest.mark.needs_vtk9
 def test_path_picking():
     sphere = pyvista.Sphere()
     plotter = pyvista.Plotter(
@@ -285,7 +284,7 @@ def test_path_picking():
     plotter.close()
 
 
-@skip_no_vtk9
+@pytest.mark.needs_vtk9
 def test_geodesic_picking():
     sphere = pyvista.Sphere()
     plotter = pyvista.Plotter(
@@ -313,7 +312,7 @@ def test_geodesic_picking():
     plotter.close()
 
 
-@skip_no_vtk9
+@pytest.mark.needs_vtk9
 def test_horizon_picking():
     sphere = pyvista.Sphere()
     plotter = pyvista.Plotter(

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -7,7 +7,6 @@ import pytest
 
 import pyvista
 from pyvista import examples
-from pyvista._vtk import VTK9
 from pyvista.core.errors import NotAllTrianglesError
 from pyvista.plotting import system_supports_plotting
 from pyvista.utilities.misc import PyvistaFutureWarning
@@ -17,8 +16,6 @@ radius = 0.5
 skip_plotting = pytest.mark.skipif(
     not system_supports_plotting(), reason="Requires system to support plotting"
 )
-
-skip_not_vtk9 = pytest.mark.skipif(not VTK9, reason="Test requires >=VTK v9")
 
 
 @pytest.fixture
@@ -862,7 +859,7 @@ def test_n_lines():
     assert mesh.n_lines == 1
 
 
-@skip_not_vtk9
+@pytest.mark.needs_vtk9
 def test_geodesic_disconnected(sphere, sphere_shifted):
     # the sphere and sphere_shifted are disconnected - no path between them
     combined = sphere + sphere_shifted

--- a/tests/test_render_window_interactor.py
+++ b/tests/test_render_window_interactor.py
@@ -10,16 +10,12 @@ skip_no_plotting = pytest.mark.skipif(
     not system_supports_plotting(), reason="Requires system to support plotting"
 )
 
-skip_needs_vtk_9 = pytest.mark.skipif(
-    pyvista.vtk_version_info < (9, 1, 0), reason="Requires VTK>=9.1.0"
-)
-
 
 def empty_callback():
     return
 
 
-@skip_needs_vtk_9
+@pytest.mark.needs_vtk_version(9, 1)
 def test_observers():
     pl = pyvista.Plotter()
 

--- a/tests/utilities/test_reader.py
+++ b/tests/utilities/test_reader.py
@@ -669,7 +669,7 @@ def test_openfoam_case_type():
         reader.case_type = 'wrong_value'
 
 
-@pytest.mark.skipif(pyvista.vtk_version_info < (9, 1), reason="Requires VTK v9.1.0 or newer")
+@pytest.mark.needs_vtk_version(9, 1)
 def test_read_cgns():
     filename = examples.download_cgns_structured(load=False)
     reader = pyvista.get_reader(filename)
@@ -813,7 +813,7 @@ def test_tiff_reader():
     assert all([mesh.n_points, mesh.n_cells])
 
 
-@pytest.mark.skipif(pyvista.vtk_version_info < (9, 0), reason="Requires VTK v9.0.0 or newer")
+@pytest.mark.needs_vtk9
 def test_hdr_reader():
     filename = examples.download_parched_canal_4k(load=False)
     reader = pyvista.get_reader(filename)
@@ -834,7 +834,7 @@ def test_avsucd_reader():
     assert all([mesh.n_points, mesh.n_cells])
 
 
-@pytest.mark.skipif(pyvista.vtk_version_info < (9, 1), reason="Requires VTK v9.1.0 or newer")
+@pytest.mark.needs_vtk_version(9, 1)
 def test_hdf_reader():
     filename = examples.download_can_crushed_hdf(load=False)
     reader = pyvista.get_reader(filename)


### PR DESCRIPTION
There's a common occurence in our tests that we want to skip some based on VTK version, most commonly things that require VTK 9. This is also the main source of reliance of tests on `pyvista._vtk`, which we might try to avoid as much as possible (at least according to a comment somewhere by @akaszynski, suggesting that tests should act like third parties to the library, so they shouldn't rely on `pyvista._vtk`).

This PR adds two custom pytest markers:
```
$ pytest --markers |head -3
@pytest.mark.needs_vtk9: skip test unless VTK is 9.0 or newer.

@pytest.mark.needs_vtk_version(version): skip test unless VTK version is at least as specified.
```

And test skips are rewritten to use these. There are a few notable exceptions: ones that have nontrivial skip messages, i.e.
https://github.com/pyvista/pyvista/blob/afe4dc32e5ad9a256c0f395607d03b739469acc6/tests/test_init.py#L16

https://github.com/pyvista/pyvista/blob/afe4dc32e5ad9a256c0f395607d03b739469acc6/tests/test_pointset.py#L9-L11

We could make the markers accept an optional reason, but I figured that would increase their complexity beyond usefulness.