### PR TITLE
fix(add_volume): use memory-efficient rescaling

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2934,7 +2934,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         if scalars is None:
             # Make sure scalars components are not vectors/tuples
-            scalars = volume.active_scalars
+            scalars = volume.active_scalars.copy()
             # Don't allow plotting of string arrays by default
             if scalars is not None and np.issubdtype(scalars.dtype, np.number):
                 scalar_bar_args.setdefault('title', volume.active_scalars_info[1])
@@ -2970,8 +2970,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         # Scalars interpolation approach
         if scalars.shape[0] == volume.n_points:
+            volume.point_data.set_array(scalars, title, True)
             self.mapper.SetScalarModeToUsePointData()
         elif scalars.shape[0] == volume.n_cells:
+            volume.cell_data.set_array(scalars, title, True)
             self.mapper.SetScalarModeToUseCellData()
         else:
             raise_not_matching(scalars, volume)

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2965,15 +2965,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
         elif isinstance(clim, float) or isinstance(clim, int):
             clim = [-clim, clim]
 
+        # convert the scalars to np.uint8 and scale between 0 and 255 within clim
         clim = np.asarray(clim, dtype=scalars.dtype)
-
         scalars.clip(clim[0], clim[1], out=scalars)
-
         min_ = np.nanmin(scalars)
         max_ = np.nanmax(scalars)
-
         np.true_divide((scalars - min_), (max_ - min_) / 255, out=scalars, casting='unsafe')
-
         volume[title] = np.array(scalars, dtype=np.uint8)
 
         self.mapper.scalar_range = clim

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -2611,7 +2611,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         scalars=None,
         clim=None,
         resolution=None,
-        opacity="linear",
+        opacity='linear',
         n_colors=256,
         cmap=None,
         flip_scalars=False,
@@ -2621,13 +2621,13 @@ class BasePlotter(PickingHelper, WidgetHelper):
         categories=False,
         culling=False,
         multi_colors=False,
-        blending="composite",
+        blending='composite',
         mapper=None,
         scalar_bar_args=None,
         show_scalar_bar=None,
         annotations=None,
         pickable=True,
-        preference='point',
+        preference="point",
         opacity_unit_distance=None,
         shade=False,
         diffuse=0.7,
@@ -2819,9 +2819,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
         cmap = kwargs.pop('colormap', cmap)
         culling = kwargs.pop('backface_culling', culling)
 
-        if 'scalar' in kwargs:
+        if "scalar" in kwargs:
             raise TypeError(
-                '`scalar` is an invalid keyword argument for `add_mesh`. Perhaps you mean `scalars` with an s?'
+                "`scalar` is an invalid keyword argument for `add_mesh`. Perhaps you mean `scalars` with an s?"
             )
         assert_empty_kwargs(**kwargs)
 


### PR DESCRIPTION
### Overview

Inefficient `numpy` copies causes memory leak for large volume
data sets. Use a vectorized rescaling instead.

Fixes `pyvista/support` Issue [#500](https://github.com/pyvista/pyvista-support/issues/500)

