### PR TITLE
fix clean example

### DIFF
--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -1801,7 +1801,7 @@ class PolyDataFilters(DataSetFilters):
         >>> import pyvista as pv
         >>> import numpy as np
         >>> points = np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0]], dtype=np.float32)
-        >>> faces = np.array([3, 0, 1, 2, 3, 0, 3, 3])
+        >>> faces = np.array([3, 0, 1, 2, 3, 0, 2, 2])
         >>> mesh = pv.PolyData(points, faces)
         >>> mout = mesh.clean()
         >>> mout.faces  # doctest:+SKIP


### PR DESCRIPTION
Resolves #3172.

The example in the `clean` filter documentation specified a face referring to non-existent points, leading to an unexpected point in the cleaned output.

