### PR TITLE
Lessen memory usage for wrapping vtk datasets

### DIFF
--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -427,7 +427,7 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         Origin of the uniform grid.  Defaults to ``(0.0, 0.0, 0.0)``.
 
     deep : bool, optional
-        Whether to deep copy a vtkImage3Data object.
+        Whether to deep copy a vtkImageData object.
         Default is ``False``.  Keyword only.
 
     Examples

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -95,6 +95,10 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid, RectilinearGridFilters):
         ``False``. If ``True``, an error is raised if there are any duplicate
         values in any of the array-valued input arguments.
 
+    deep : bool, optional
+        Whether to deep copy a vtkRectilinearGrid object.
+        Default is ``False``.  Keyword only.
+
     Examples
     --------
     >>> import pyvista
@@ -122,13 +126,16 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid, RectilinearGridFilters):
 
     _WRITERS = {'.vtk': _vtk.vtkRectilinearGridWriter, '.vtr': _vtk.vtkXMLRectilinearGridWriter}
 
-    def __init__(self, *args, check_duplicates=False, **kwargs):
+    def __init__(self, *args, check_duplicates=False, deep=False, **kwargs):
         """Initialize the rectilinear grid."""
         super().__init__()
 
         if len(args) == 1:
             if isinstance(args[0], _vtk.vtkRectilinearGrid):
-                self.deep_copy(args[0])
+                if deep:
+                    self.deep_copy(args[0])
+                else:
+                    self.shallow_copy(args[0])
             elif isinstance(args[0], (str, pathlib.Path)):
                 self._from_file(args[0], **kwargs)
             elif isinstance(args[0], np.ndarray):
@@ -419,6 +426,10 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
     origin : iterable, optional
         Origin of the uniform grid.  Defaults to ``(0.0, 0.0, 0.0)``.
 
+    deep : bool, optional
+        Whether to deep copy a vtkImage3Data object.
+        Default is ``False``.  Keyword only.
+
     Examples
     --------
     Create an empty UniformGrid.
@@ -468,7 +479,13 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
     _WRITERS = {'.vtk': _vtk.vtkDataSetWriter, '.vti': _vtk.vtkXMLImageDataWriter}
 
     def __init__(
-        self, uinput=None, *args, dims=None, spacing=(1.0, 1.0, 1.0), origin=(0.0, 0.0, 0.0)
+        self,
+        uinput=None,
+        *args,
+        dims=None,
+        spacing=(1.0, 1.0, 1.0),
+        origin=(0.0, 0.0, 0.0),
+        deep=False,
     ):
         """Initialize the uniform grid."""
         super().__init__()
@@ -506,7 +523,10 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         # first argument must be either vtkImageData or a path
         if uinput is not None:
             if isinstance(uinput, _vtk.vtkImageData):
-                self.deep_copy(uinput)
+                if deep:
+                    self.deep_copy(uinput)
+                else:
+                    self.shallow_copy(uinput)
             elif isinstance(uinput, (str, pathlib.Path)):
                 self._from_file(uinput)
             else:

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -96,7 +96,7 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid, RectilinearGridFilters):
         values in any of the array-valued input arguments.
 
     deep : bool, optional
-        Whether to deep copy a vtkRectilinearGrid object.
+        Whether to deep copy a ``vtk.vtkRectilinearGrid`` object.
         Default is ``False``.  Keyword only.
 
     Examples
@@ -427,7 +427,7 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         Origin of the uniform grid.  Defaults to ``(0.0, 0.0, 0.0)``.
 
     deep : bool, optional
-        Whether to deep copy a vtkImageData object.
+        Whether to deep copy a ``vtk.vtkImageData`` object.
         Default is ``False``.  Keyword only.
 
     Examples

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1300,7 +1300,7 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
     Parameters
     ----------
     args : various
-        See below examples
+        See below examples.
     deep : optional
         Whether to deep copy a vtkUnstructuredGrid object.
         Default is ``False``.  Keyword only.
@@ -2240,6 +2240,14 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
     - From a ``vtk.vtkExplicitStructuredGrid`` or ``vtk.vtkUnstructuredGrid`` object
     - From a VTU or VTK file
     - From ``dims`` and ``corners`` arrays
+
+    Parameters
+    ----------
+    args : various
+        See below examples.
+    deep : optional
+        Whether to deep copy a vtkUnstructuredGrid object.
+        Default is ``False``.  Keyword only.
 
     Examples
     --------

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1297,6 +1297,14 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
     - From cell, offset, and node arrays
     - From a file
 
+    Parameters
+    ----------
+    args : various
+        See below examples
+    deep : optional
+        Whether to deep copy a vtkUnstructuredGrid object.
+        Default is ``False``.  Keyword only.
+
     Examples
     --------
     >>> import pyvista
@@ -1326,10 +1334,9 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
 
     _WRITERS = {'.vtu': _vtk.vtkXMLUnstructuredGridWriter, '.vtk': _vtk.vtkUnstructuredGridWriter}
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args, deep=False, **kwargs) -> None:
         """Initialize the unstructured grid."""
         super().__init__()
-        deep = kwargs.pop('deep', False)
 
         if not len(args):
             return
@@ -1889,6 +1896,10 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
         Coordinates of the points in z direction. If this is passed, ``uinput``
         and ``y`` must be a :class:`numpy.ndarray` and match the shape of ``z``.
 
+    deep : optional
+        Whether to deep copy a StructuredGrid object.
+        Default is ``False``.  Keyword only.
+
     **kwargs : dict, optional
         Additional keyword arguments passed when reading from a file or loading
         from arrays.
@@ -1929,12 +1940,18 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
 
     _WRITERS = {'.vtk': _vtk.vtkStructuredGridWriter, '.vts': _vtk.vtkXMLStructuredGridWriter}
 
-    def __init__(self, uinput=None, y=None, z=None, **kwargs) -> None:
+    def __init__(self, uinput=None, y=None, z=None, *args, deep=False, **kwargs) -> None:
         """Initialize the structured grid."""
         super().__init__()
 
+        if args:
+            raise ValueError("Too many args to create StructuredGrid.")
+
         if isinstance(uinput, _vtk.vtkStructuredGrid):
-            self.deep_copy(uinput)
+            if deep:
+                self.deep_copy(uinput)
+            else:
+                self.shallow_copy(uinput)
         elif isinstance(uinput, (str, pathlib.Path)):
             self._from_file(uinput, **kwargs)
         elif (
@@ -2255,23 +2272,28 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
 
     _WRITERS = {'.vtu': _vtk.vtkXMLUnstructuredGridWriter, '.vtk': _vtk.vtkUnstructuredGridWriter}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, deep=False, **kwargs):
         """Initialize the explicit structured grid."""
         if not _vtk.VTK9:
             raise VTKVersionError('VTK 9 or higher is required')  # pragma: no cover
         super().__init__()
         n = len(args)
+        if n > 2:
+            raise ValueError("Too many args to create ExplicitStructuredGrid.")
         if n == 1:
             arg0 = args[0]
             if isinstance(arg0, _vtk.vtkExplicitStructuredGrid):
-                self.deep_copy(arg0)
+                if deep:
+                    self.deep_copy(arg0)
+                else:
+                    self.shallow_copy(arg0)
             elif isinstance(arg0, _vtk.vtkUnstructuredGrid):
                 grid = arg0.cast_to_explicit_structured_grid()
-                self.deep_copy(grid)
+                self.shallow_copy(grid)
             elif isinstance(arg0, (str, pathlib.Path)):
                 grid = UnstructuredGrid(arg0)
                 grid = grid.cast_to_explicit_structured_grid()
-                self.deep_copy(grid)
+                self.shallow_copy(grid)
         elif n == 2:
             arg0, arg1 = args
             if isinstance(arg0, tuple):

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -2246,7 +2246,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
     args : various
         See below examples.
     deep : optional
-        Whether to deep copy a vtkUnstructuredGrid object.
+        Whether to deep copy a ``vtk.vtkUnstructuredGrid`` object.
         Default is ``False``.  Keyword only.
 
     Examples

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,13 @@ def datasets():
 
 
 @fixture()
+def datasets_vtk9():
+    return [
+        examples.load_explicit_structured(),
+    ]
+
+
+@fixture()
 def pointset():
     rng = default_rng(0)
     points = rng.random((10, 3))

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -56,6 +56,10 @@ def test_init_from_unstructured(hexbeam):
     grid.points += 1
     assert not np.any(grid.points == hexbeam.points)
 
+    grid = pyvista.UnstructuredGrid(hexbeam)
+    grid.points += 1
+    assert np.array_equal(grid.points, hexbeam.points)
+
 
 def test_init_from_numpy_arrays():
     offset = np.array([0, 9])
@@ -487,8 +491,13 @@ def test_init_structured(struct_grid):
     assert np.allclose(struct_grid.y, y)
     assert np.allclose(struct_grid.z, z)
 
+    grid_a = pyvista.StructuredGrid(grid, deep=True)
+    grid_a.points += 1
+    assert not np.any(grid_a.points == grid.points)
+
     grid_a = pyvista.StructuredGrid(grid)
-    assert np.allclose(grid_a.points, grid.points)
+    grid_a.points += 1
+    assert np.array_equal(grid_a.points, grid.points)
 
 
 @pytest.fixture
@@ -1400,3 +1409,21 @@ def test_ExplicitStructuredGrid_compute_connections():
     grid.compute_connections(inplace=True)
     assert 'number_of_connections' in grid.cell_data
     assert np.array_equal(grid.cell_data['number_of_connections'], connections)
+
+
+def test_copy_no_copy_wrap_object(datasets):
+    for dataset in datasets:
+        # different dataset tyoes have different copy behavior for points
+        # use point data which is common
+        dataset["data"] = np.ones(dataset.n_points)
+        new_dataset = type(dataset)(dataset)
+        new_dataset["data"] += 1
+        assert np.array_equal(new_dataset["data"], dataset["data"])
+
+    for dataset in datasets:
+        # different dataset tyoes have different copy behavior for points
+        # use point data which is common
+        dataset["data"] = np.ones(dataset.n_points)
+        new_dataset = type(dataset)(dataset, deep=True)
+        new_dataset["data"] += 1
+        assert not np.any(new_dataset["data"] == dataset["data"])

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -479,6 +479,8 @@ def test_merge_invalid(hexbeam, sphere):
 def test_init_structured_raise():
     with pytest.raises(TypeError, match="Invalid parameters"):
         pyvista.StructuredGrid(['a', 'b', 'c'])
+    with pytest.raises(ValueError, match="Too many args"):
+        pyvista.StructuredGrid([0, 1], [0, 1], [0, 1], [0, 1])
 
 
 def test_init_structured(struct_grid):
@@ -1409,6 +1411,12 @@ def test_ExplicitStructuredGrid_compute_connections():
     grid.compute_connections(inplace=True)
     assert 'number_of_connections' in grid.cell_data
     assert np.array_equal(grid.cell_data['number_of_connections'], connections)
+
+
+@pytest.mark.needs_vtk9
+def test_ExplicitStructuredGrid_raise_init():
+    with pytest.raises(ValueError, match="Too many args"):
+        pyvista.ExplicitStructuredGrid(1, 2, True)
 
 
 def test_copy_no_copy_wrap_object(datasets):

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1427,3 +1427,22 @@ def test_copy_no_copy_wrap_object(datasets):
         new_dataset = type(dataset)(dataset, deep=True)
         new_dataset["data"] += 1
         assert not np.any(new_dataset["data"] == dataset["data"])
+
+
+@pytest.mark.needs_vtk9
+def test_copy_no_copy_wrap_object_vtk9(datasets_vtk9):
+    for dataset in datasets_vtk9:
+        # different dataset tyoes have different copy behavior for points
+        # use point data which is common
+        dataset["data"] = np.ones(dataset.n_points)
+        new_dataset = type(dataset)(dataset)
+        new_dataset["data"] += 1
+        assert np.array_equal(new_dataset["data"], dataset["data"])
+
+    for dataset in datasets_vtk9:
+        # different dataset tyoes have different copy behavior for points
+        # use point data which is common
+        dataset["data"] = np.ones(dataset.n_points)
+        new_dataset = type(dataset)(dataset, deep=True)
+        new_dataset["data"] += 1
+        assert not np.any(new_dataset["data"] == dataset["data"])

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1413,7 +1413,7 @@ def test_ExplicitStructuredGrid_compute_connections():
 
 def test_copy_no_copy_wrap_object(datasets):
     for dataset in datasets:
-        # different dataset tyoes have different copy behavior for points
+        # different dataset types have different copy behavior for points
         # use point data which is common
         dataset["data"] = np.ones(dataset.n_points)
         new_dataset = type(dataset)(dataset)
@@ -1421,7 +1421,7 @@ def test_copy_no_copy_wrap_object(datasets):
         assert np.array_equal(new_dataset["data"], dataset["data"])
 
     for dataset in datasets:
-        # different dataset tyoes have different copy behavior for points
+        # different dataset types have different copy behavior for points
         # use point data which is common
         dataset["data"] = np.ones(dataset.n_points)
         new_dataset = type(dataset)(dataset, deep=True)


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->
This PR adds a `deep` kwarg to all pyvista `DataSets` with default `False`.  This keyword is used when passing in a `vtkDataSet`. Some datasets already did this.  Some only did deep copy.

Closes #3178 

### Details

We could also consider using this kwarg when passing in arrays or other, but I haven't touched that logic here.

TODO:
- [x] add more tests

### Breaking Change

Previously, some pyvista `DataSet`s copied vtk `DataSet`s when wrapping them.  This PR changes the default to not copy for all `DataSet`s.  Any changes to the pyvista object will also change the original vtk object.  A kwarg `deep` was added to obtain the prior behavior, if needed.