### PR TITLE
MAINT: More descriptive comment about optional import

### DIFF
--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -267,7 +267,8 @@ if VTK9:
     try:
         from vtkmodules.vtkFiltersParallelDIY2 import vtkRedistributeDataSetFilter
     except ModuleNotFoundError:  # pragma: no cover
-        pass  # unavailable on macOS M1 VTK 9.2.0rc1
+        # `vtkmodules.vtkFiltersParallelDIY2` is unavailable in some versions of `vtk` from conda-forge
+        pass
     from vtkmodules.vtkFiltersPoints import vtkGaussianKernel, vtkPointInterpolator
     from vtkmodules.vtkFiltersSources import (
         vtkArcSource,


### PR DESCRIPTION
### Overview

Clarifies a comment added in #3195 which describes about the optional import of `vtkRedistributeDataSetFilter` from `vtkmodules.vtkFiltersParallelDIY2`.

