### PR TITLE
Update flake8 URL for precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
   hooks:
   - id: isort
 
-- repo: https://gitlab.com/PyCQA/flake8
+- repo: https://github.com/PyCQA/flake8
   rev: 3.9.2
   hooks:
   - id: flake8


### PR DESCRIPTION
### Overview
Gitlab repository of flake8 is mirror repository of GitHub.
updates:

- https://gitlab.com/PyCQA/flake8 → https://github.com/PyCQA/flake8


### Details
- None