### PR TITLE
Pyvista -> PyVista

### DIFF
--- a/doc/api/plotting/qt_plotting.rst
+++ b/doc/api/plotting/qt_plotting.rst
@@ -1,6 +1,6 @@
 .. _qt_plotting:
 
-Pyvista and PyQt
+PyVista and PyQt
 ----------------
 
 Using `pyqt` you can embed the `Plotter` class within a `pyqt` widget to add `pyvista` to a `Qt` application within Python.  You can also have a plot in a separate thread from the main python thread using a background plotter class.  For more details, see `pyvistaqt <https://qtdocs.pyvista.org>`_!

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -309,7 +309,7 @@ todo_include_todos = False
 from sphinx_gallery.sorting import FileNameSortKey
 
 
-class ResetPyvista:
+class ResetPyVista:
     """Reset pyvista module to default settings."""
 
     def __call__(self, gallery_conf, fname):
@@ -323,10 +323,10 @@ class ResetPyvista:
         pyvista.set_plot_theme('document')
 
     def __repr__(self):
-        return 'ResetPyvista'
+        return 'ResetPyVista'
 
 
-reset_pyvista = ResetPyvista()
+reset_pyvista = ResetPyVista()
 
 
 # skip building the osmnx example if osmnx is not installed

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -12,7 +12,7 @@ import numpy as np
 import pyvista
 from pyvista import _vtk
 from pyvista.utilities import FieldAssociation, abstract_class, fileio
-from pyvista.utilities.misc import PyvistaDeprecationWarning
+from pyvista.utilities.misc import PyVistaDeprecationWarning
 
 from .datasetattributes import DataSetAttributes
 
@@ -332,7 +332,7 @@ class DataObject:
         """
         warnings.warn(
             "Use of `clear_point_arrays` is deprecated. Use `clear_point_data` instead.",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         return self.clear_point_data()
 
@@ -396,7 +396,7 @@ class DataObject:
         """
         warnings.warn(
             "Use of `field_arrays` is deprecated. Use `field_data` instead.",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         return self.field_data
 
@@ -433,7 +433,7 @@ class DataObject:
         """
         warnings.warn(
             "Use of `clear_field_arrays` is deprecated. Use `clear_field_data` instead.",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         self.field_data
 

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -28,7 +28,7 @@ from pyvista.utilities import (
 )
 from pyvista.utilities.common import _coerce_pointslike_arg
 from pyvista.utilities.errors import check_valid_vector
-from pyvista.utilities.misc import PyvistaDeprecationWarning
+from pyvista.utilities.misc import PyVistaDeprecationWarning
 
 from .._typing import Number, NumericArray, Vector, VectorArray
 from .dataobject import DataObject
@@ -473,7 +473,7 @@ class DataSet(DataSetFilters, DataObject):
         """
         warnings.warn(
             "Use of `DataSet.vectors` is deprecated. Use `DataSet.active_vectors` instead.",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         return self.active_vectors
 
@@ -483,7 +483,7 @@ class DataSet(DataSetFilters, DataObject):
             "Use of `DataSet.vectors` to add vector data is deprecated. "
             "Use `DataSet['vector_name'] = data`. "
             "Use `DataSet.active_vectors_name = 'vector_name' to make active.",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         if array.ndim != 2:
             raise ValueError('vector array must be a 2-dimensional array')
@@ -506,7 +506,7 @@ class DataSet(DataSetFilters, DataObject):
         """
         warnings.warn(
             "Use of `DataSet.t_coords` is deprecated. Use `DataSet.active_t_coords` instead.",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         return self.active_t_coords
 
@@ -514,7 +514,7 @@ class DataSet(DataSetFilters, DataObject):
     def t_coords(self, t_coords: np.ndarray):  # pragma: no cover
         warnings.warn(
             "Use of `DataSet.t_coords` is deprecated. Use `DataSet.active_t_coords` instead.",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         self.active_t_coords = t_coords  # type: ignore
 
@@ -1473,7 +1473,7 @@ class DataSet(DataSetFilters, DataObject):
         """
         warnings.warn(
             "Use of `point_arrays` is deprecated. Use `point_data` instead.",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         return self.point_data
 
@@ -1526,7 +1526,7 @@ class DataSet(DataSetFilters, DataObject):
         """
         warnings.warn(
             "Use of `clear_point_arrays` is deprecated. Use `clear_point_data` instead.",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         self.clear_point_data()
 
@@ -1558,7 +1558,7 @@ class DataSet(DataSetFilters, DataObject):
         """
         warnings.warn(
             "Use of `clear_cell_arrays` is deprecated. Use `clear_cell_data` instead.",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         self.clear_cell_data()
 
@@ -1575,7 +1575,7 @@ class DataSet(DataSetFilters, DataObject):
         """
         warnings.warn(
             "Use of `clear_arrays` is deprecated. Use `clear_data` instead.",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         self.clear_data()
 
@@ -1610,7 +1610,7 @@ class DataSet(DataSetFilters, DataObject):
         """
         warnings.warn(
             "Use of `cell_arrays` is deprecated. Use `cell_data` instead.",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         return self.cell_data
 

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -8,7 +8,7 @@ import numpy as np
 from pyvista import _vtk
 import pyvista.utilities.helpers as helpers
 from pyvista.utilities.helpers import FieldAssociation
-from pyvista.utilities.misc import PyvistaDeprecationWarning, copy_vtk_array
+from pyvista.utilities.misc import PyVistaDeprecationWarning, copy_vtk_array
 
 from .._typing import Number
 from .pyvista_ndarray import pyvista_ndarray
@@ -291,7 +291,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
             "  - `DataSetAttributes.set_scalars`\n"
             "  - `DataSetAttributes.active_scalars_name`\n"
             "  - The [] operator",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         self.active_scalars_name = name
 
@@ -334,7 +334,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
             "deprecated.  Use:\n\n"
             "  - `DataSetAttributes.set_vectors`\n"
             "  - `DataSetAttributes.active_vectors_name`\n",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         self.active_vectors_name = name
 
@@ -380,7 +380,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         warnings.warn(
             "Use of `DataSetAttributes.t_coords` is deprecated. "
             "Use `DataSetAttributes.active_t_coords` instead.",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         return self.active_t_coords
 
@@ -389,7 +389,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         warnings.warn(
             "Use of `DataSetAttributes.t_coords` is deprecated. "
             "Use `DataSetAttributes.active_t_coords` instead.",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         self.active_t_coords = t_coords  # type: ignore
 
@@ -454,7 +454,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         """
         warnings.warn(
             "Use of `active_texture_name` is deprecated. Use `active_t_coords_name` instead.",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         return self.active_t_coords_name
 
@@ -898,7 +898,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
             "  - `DataSetAttributes.set_scalars`\n"
             "  - `DataSetAttributes.set_vectors`\n"
             "  - The [] operator",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         if active_vectors:  # pragma: no cover
             raise ValueError('Use set_vectors to set vector data')

--- a/pyvista/core/errors.py
+++ b/pyvista/core/errors.py
@@ -1,4 +1,4 @@
-"""Pyvista specific errors."""
+"""PyVista specific errors."""
 
 CAMERA_ERROR_MESSAGE = """Invalid camera description
 Camera description must be one of the following:

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -18,7 +18,7 @@ from pyvista import (
 from pyvista.core.errors import DeprecationError, NotAllTrianglesError, VTKVersionError
 from pyvista.core.filters import _get_output, _update_alg
 from pyvista.core.filters.data_set import DataSetFilters
-from pyvista.utilities.misc import PyvistaFutureWarning
+from pyvista.utilities.misc import PyVistaFutureWarning
 
 
 @abstract_class
@@ -2779,7 +2779,7 @@ class PolyDataFilters(DataSetFilters):
                 'The default value of the ``capping`` keyword argument will change in '
                 'a future version to ``True`` to match the behavior of VTK. We recommend '
                 'passing the keyword explicitly to prevent future surprises.',
-                PyvistaFutureWarning,
+                PyVistaFutureWarning,
             )
 
         alg = _vtk.vtkLinearExtrusionFilter()
@@ -2914,7 +2914,7 @@ class PolyDataFilters(DataSetFilters):
                 'The default value of the ``capping`` keyword argument will change in '
                 'a future version to ``True`` to match the behavior of VTK. We recommend '
                 'passing the keyword explicitly to prevent future surprises.',
-                PyvistaFutureWarning,
+                PyVistaFutureWarning,
             )
 
         if (

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -12,7 +12,7 @@ from pyvista.core.dataset import DataSet
 from pyvista.core.filters import RectilinearGridFilters, UniformGridFilters, _get_output
 from pyvista.utilities import abstract_class
 import pyvista.utilities.helpers as helpers
-from pyvista.utilities.misc import PyvistaDeprecationWarning, raise_has_duplicates
+from pyvista.utilities.misc import PyVistaDeprecationWarning, raise_has_duplicates
 
 log = logging.getLogger(__name__)
 log.setLevel('CRITICAL')
@@ -495,7 +495,7 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
             warnings.warn(
                 "Behavior of pyvista.UniformGrid has changed. First argument must be "
                 "either a ``vtk.vtkImageData`` or path.",
-                PyvistaDeprecationWarning,
+                PyVistaDeprecationWarning,
             )
             dims = uinput
             uinput = None
@@ -509,7 +509,7 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
                 "    ...     spacing=(2, 1, 5),\n"
                 "    ...     origin=(10, 35, 50),\n"
                 "    ... )\n",
-                PyvistaDeprecationWarning,
+                PyVistaDeprecationWarning,
             )
             origin = args[0]
             if len(args) > 1:

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -13,7 +13,7 @@ import numpy as np
 
 import pyvista
 from pyvista import _vtk
-from pyvista.utilities import PyvistaDeprecationWarning, abstract_class
+from pyvista.utilities import PyVistaDeprecationWarning, abstract_class
 from pyvista.utilities.cells import (
     CellArray,
     create_mixed_cells,
@@ -202,7 +202,7 @@ class _PointSet(DataSet):
         """
         if inplace is None:
             # Deprecated on v0.32.0, estimated removal on v0.35.0
-            warnings.warn(DEFAULT_INPLACE_WARNING, PyvistaDeprecationWarning)
+            warnings.warn(DEFAULT_INPLACE_WARNING, PyVistaDeprecationWarning)
             inplace = True
         if inplace:
             self.points += np.asarray(xyz)  # type: ignore
@@ -258,7 +258,7 @@ class _PointSet(DataSet):
         """
         if inplace is None:
             # Deprecated on v0.32.0, estimated removal on v0.35.0
-            warnings.warn(DEFAULT_INPLACE_WARNING, PyvistaDeprecationWarning)
+            warnings.warn(DEFAULT_INPLACE_WARNING, PyVistaDeprecationWarning)
             inplace = True
         return super().scale(
             xyz, transform_all_input_vectors=transform_all_input_vectors, inplace=inplace
@@ -269,7 +269,7 @@ class _PointSet(DataSet):
         """Wrap ``DataSet.flip_x``."""
         if kwargs.get('inplace') is None:
             # Deprecated on v0.32.0, estimated removal on v0.35.0
-            warnings.warn(DEFAULT_INPLACE_WARNING, PyvistaDeprecationWarning)
+            warnings.warn(DEFAULT_INPLACE_WARNING, PyVistaDeprecationWarning)
             kwargs['inplace'] = True
         return super().flip_x(*args, **kwargs)
 
@@ -278,7 +278,7 @@ class _PointSet(DataSet):
         """Wrap ``DataSet.flip_y``."""
         if kwargs.get('inplace') is None:
             # Deprecated on v0.32.0, estimated removal on v0.35.0
-            warnings.warn(DEFAULT_INPLACE_WARNING, PyvistaDeprecationWarning)
+            warnings.warn(DEFAULT_INPLACE_WARNING, PyVistaDeprecationWarning)
             kwargs['inplace'] = True
         return super().flip_y(*args, **kwargs)
 
@@ -287,7 +287,7 @@ class _PointSet(DataSet):
         """Wrap ``DataSet.flip_z``."""
         if kwargs.get('inplace') is None:
             # Deprecated on v0.32.0, estimated removal on v0.35.0
-            warnings.warn(DEFAULT_INPLACE_WARNING, PyvistaDeprecationWarning)
+            warnings.warn(DEFAULT_INPLACE_WARNING, PyVistaDeprecationWarning)
             kwargs['inplace'] = True
         return super().flip_z(*args, **kwargs)
 
@@ -296,7 +296,7 @@ class _PointSet(DataSet):
         """Wrap ``DataSet.flip_normal``."""
         if kwargs.get('inplace') is None:
             # Deprecated on v0.32.0, estimated removal on v0.35.0
-            warnings.warn(DEFAULT_INPLACE_WARNING, PyvistaDeprecationWarning)
+            warnings.warn(DEFAULT_INPLACE_WARNING, PyVistaDeprecationWarning)
             kwargs['inplace'] = True
         return super().flip_normal(*args, **kwargs)
 
@@ -305,7 +305,7 @@ class _PointSet(DataSet):
         """Wrap ``DataSet.rotate_x``."""
         if kwargs.get('inplace') is None:
             # Deprecated on v0.32.0, estimated removal on v0.35.0
-            warnings.warn(DEFAULT_INPLACE_WARNING, PyvistaDeprecationWarning)
+            warnings.warn(DEFAULT_INPLACE_WARNING, PyVistaDeprecationWarning)
             kwargs['inplace'] = True
         return super().rotate_x(*args, **kwargs)
 
@@ -314,7 +314,7 @@ class _PointSet(DataSet):
         """Wrap ``DataSet.rotate_y``."""
         if kwargs.get('inplace') is None:
             # Deprecated on v0.32.0, estimated removal on v0.35.0
-            warnings.warn(DEFAULT_INPLACE_WARNING, PyvistaDeprecationWarning)
+            warnings.warn(DEFAULT_INPLACE_WARNING, PyVistaDeprecationWarning)
             kwargs['inplace'] = True
         return super().rotate_y(*args, **kwargs)
 
@@ -323,7 +323,7 @@ class _PointSet(DataSet):
         """Wrap ``DataSet.rotate_z``."""
         if kwargs.get('inplace') is None:
             # Deprecated on v0.32.0, estimated removal on v0.35.0
-            warnings.warn(DEFAULT_INPLACE_WARNING, PyvistaDeprecationWarning)
+            warnings.warn(DEFAULT_INPLACE_WARNING, PyVistaDeprecationWarning)
             kwargs['inplace'] = True
         return super().rotate_z(*args, **kwargs)
 
@@ -332,7 +332,7 @@ class _PointSet(DataSet):
         """Wrap ``DataSet.rotate_vector``."""
         if kwargs.get('inplace') is None:
             # Deprecated on v0.32.0, estimated removal on v0.35.0
-            warnings.warn(DEFAULT_INPLACE_WARNING, PyvistaDeprecationWarning)
+            warnings.warn(DEFAULT_INPLACE_WARNING, PyVistaDeprecationWarning)
             kwargs['inplace'] = True
         return super().rotate_vector(*args, **kwargs)
 

--- a/pyvista/demos/__init__.py
+++ b/pyvista/demos/__init__.py
@@ -1,4 +1,4 @@
-"""Pyvista Demos."""
+"""PyVista Demos."""
 from pyvista.demos.demos import (
     glyphs,
     plot_glyphs,

--- a/pyvista/errors.py
+++ b/pyvista/errors.py
@@ -1,4 +1,4 @@
-"""Pyvista specific errors."""
+"""PyVista specific errors."""
 
 
 class MissingDataError(ValueError):

--- a/pyvista/plotting/_plotting.py
+++ b/pyvista/plotting/_plotting.py
@@ -6,7 +6,7 @@ import numpy as np
 import pyvista
 from pyvista.utilities import assert_empty_kwargs, get_array
 
-from ..utilities.misc import PyvistaDeprecationWarning
+from ..utilities.misc import PyVistaDeprecationWarning
 from .colors import Color
 from .tools import opacity_transfer_function
 
@@ -269,7 +269,7 @@ def _common_arg_parser(
 
     # account for legacy behavior
     if 'stitle' in kwargs:  # pragma: no cover
-        warnings.warn(USE_SCALAR_BAR_ARGS, PyvistaDeprecationWarning)
+        warnings.warn(USE_SCALAR_BAR_ARGS, PyVistaDeprecationWarning)
         scalar_bar_args.setdefault('title', kwargs.pop('stitle'))
 
     if "scalar" in kwargs:

--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -6,7 +6,7 @@ import numpy as np
 
 import pyvista
 from pyvista import _vtk
-from pyvista.utilities.misc import PyvistaDeprecationWarning
+from pyvista.utilities.misc import PyVistaDeprecationWarning
 
 
 class Camera(_vtk.vtkCamera):
@@ -197,7 +197,7 @@ class Camera(_vtk.vtkCamera):
         warnings.warn(
             "Use of `Camera.is_parallel_projection` is deprecated. "
             "Use `Camera.parallel_projection` instead.",
-            PyvistaDeprecationWarning,
+            PyVistaDeprecationWarning,
         )
         return self._parallel_projection
 

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -177,7 +177,7 @@ import numpy as np
 import pyvista
 from pyvista import _vtk
 from pyvista._typing import color_like
-from pyvista.utilities import PyvistaDeprecationWarning
+from pyvista.utilities import PyVistaDeprecationWarning
 from pyvista.utilities.misc import has_module
 
 IPYGANY_MAP = {
@@ -916,7 +916,7 @@ def hex_to_rgb(h):  # pragma: no cover
     # Deprecated on v0.34.0, estimated removal on v0.37.0
     warnings.warn(
         "The usage of `hex_to_rgb` is deprecated in favor of the new `Color` class.",
-        PyvistaDeprecationWarning,
+        PyVistaDeprecationWarning,
     )
     return Color(h).float_rgb
 
@@ -939,7 +939,7 @@ def string_to_rgb(string):  # pragma: no cover
     # Deprecated on v0.34.0, estimated removal on v0.37.0
     warnings.warn(
         "The usage of `string_to_rgb` is deprecated in favor of the new `Color` class.",
-        PyvistaDeprecationWarning,
+        PyVistaDeprecationWarning,
     )
     return Color(string).float_rgb
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -32,7 +32,7 @@ from pyvista.utilities import (
     wrap,
 )
 
-from ..utilities.misc import PyvistaDeprecationWarning, has_module, uses_egl
+from ..utilities.misc import PyVistaDeprecationWarning, has_module, uses_egl
 from ..utilities.regression import image_from_window
 from ._plotting import (
     USE_SCALAR_BAR_ARGS,
@@ -3209,7 +3209,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             scalar_bar_args = scalar_bar_args.copy()
         # account for legacy behavior
         if 'stitle' in kwargs:  # pragma: no cover
-            warnings.warn(USE_SCALAR_BAR_ARGS, PyvistaDeprecationWarning)
+            warnings.warn(USE_SCALAR_BAR_ARGS, PyVistaDeprecationWarning)
             scalar_bar_args.setdefault('title', kwargs.pop('stitle'))
 
         if show_scalar_bar is None:

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -11,7 +11,7 @@ import numpy as np
 
 import pyvista
 from pyvista import _vtk
-from pyvista.utilities import PyvistaDeprecationWarning
+from pyvista.utilities import PyVistaDeprecationWarning
 
 from .colors import Color
 
@@ -570,7 +570,7 @@ def parse_color(color, opacity=None, default_color=None):  # pragma: no cover
     # Deprecated on v0.34.0, estimated removal on v0.37.0
     warnings.warn(
         "The usage of `parse_color` is deprecated in favor of the new `Color` class.",
-        PyvistaDeprecationWarning,
+        PyVistaDeprecationWarning,
     )
     color_valid = True
     if color is None:

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -39,7 +39,7 @@ import warnings
 from ._typing import color_like
 from .plotting.colors import Color, get_cmap_safe
 from .plotting.tools import parse_font_family
-from .utilities.misc import PyvistaDeprecationWarning
+from .utilities.misc import PyVistaDeprecationWarning
 
 
 class _rcParams(dict):  # pragma: no cover
@@ -127,7 +127,7 @@ def set_plot_theme(theme):
     if isinstance(theme, str):
         theme = theme.lower()
         if theme == 'night':  # pragma: no cover
-            warnings.warn('use "dark" instead of "night" theme', PyvistaDeprecationWarning)
+            warnings.warn('use "dark" instead of "night" theme', PyVistaDeprecationWarning)
             theme = 'dark'
         new_theme_type = _ALLOWED_THEMES[theme].value
         pyvista.global_theme.load_theme(new_theme_type())

--- a/pyvista/utilities/features.py
+++ b/pyvista/utilities/features.py
@@ -6,7 +6,7 @@ import warnings
 import numpy as np
 
 import pyvista
-from pyvista.utilities.misc import PyvistaDeprecationWarning
+from pyvista.utilities.misc import PyVistaDeprecationWarning
 
 
 def voxelize(mesh, density=None, check_surface=True):
@@ -105,7 +105,7 @@ def single_triangle():  # pragma: no cover
     """Create a single PolyData triangle."""
     warnings.warn(
         "Use of `single_triangle` is deprecated. Use `pyvista.Triangle` instead.",
-        PyvistaDeprecationWarning,
+        PyVistaDeprecationWarning,
     )
     points = np.zeros((3, 3))
     points[1] = [1, 0, 0]

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -8,7 +8,7 @@ import numpy as np
 
 import pyvista
 from pyvista import _vtk
-from pyvista.utilities.misc import PyvistaDeprecationWarning
+from pyvista.utilities.misc import PyVistaDeprecationWarning
 
 
 def _get_ext_force(filename, force_ext=None):
@@ -70,7 +70,7 @@ def read_legacy(filename, progress_bar=False):
 
     """
     warnings.warn(
-        "Using read_legacy is deprecated. Use pyvista.read instead", PyvistaDeprecationWarning
+        "Using read_legacy is deprecated. Use pyvista.read instead", PyVistaDeprecationWarning
     )
     filename = os.path.abspath(os.path.expanduser(str(filename)))
     return read(filename, progress_bar=progress_bar)
@@ -209,7 +209,7 @@ def _apply_attrs_to_reader(reader, attrs):
     """
     warnings.warn(
         "attrs use is deprecated.  Use a Reader class for more flexible control",
-        PyvistaDeprecationWarning,
+        PyVistaDeprecationWarning,
     )
     for name, args in attrs.items():
         attr = getattr(reader.reader, name)
@@ -399,7 +399,7 @@ def read_plot3d(filename, q_filenames=(), auto_detect=True, attrs=None, progress
     """
     warnings.warn(
         "Using read_plot3d is deprecated.  Use :class:`pyvista.MultiBlockPlot3DReader`",
-        PyvistaDeprecationWarning,
+        PyVistaDeprecationWarning,
     )
 
     filename = _process_filename(filename)

--- a/pyvista/utilities/misc.py
+++ b/pyvista/utilities/misc.py
@@ -55,19 +55,19 @@ def _get_vtk_id_type():
     return np.int32
 
 
-class PyvistaDeprecationWarning(Warning):
+class PyVistaDeprecationWarning(Warning):
     """Non-supressed Depreciation Warning."""
 
     pass
 
 
-class PyvistaFutureWarning(Warning):
+class PyVistaFutureWarning(Warning):
     """Non-supressed Future Warning."""
 
     pass
 
 
-class PyvistaEfficiencyWarning(Warning):
+class PyVistaEfficiencyWarning(Warning):
     """Efficiency warning."""
 
     pass

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import pyvista
-from pyvista.utilities.misc import PyvistaDeprecationWarning
+from pyvista.utilities.misc import PyVistaDeprecationWarning
 
 # pyvista attr -- value -- vtk name triples:
 configuration = [
@@ -225,5 +225,5 @@ def test_copy():
 
 
 def test_deprecation_warning_of_is_parallel_projection(camera):
-    with pytest.warns(PyvistaDeprecationWarning):
+    with pytest.warns(PyVistaDeprecationWarning):
         _ = camera.is_parallel_projection

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -13,7 +13,7 @@ from vtk.util.numpy_support import vtk_to_numpy
 import pyvista
 from pyvista import Texture, examples
 from pyvista.core.errors import VTKVersionError
-from pyvista.utilities.misc import PyvistaDeprecationWarning
+from pyvista.utilities.misc import PyVistaDeprecationWarning
 
 HYPOTHESIS_MAX_EXAMPLES = 20
 
@@ -268,7 +268,7 @@ def test_translate_should_fail_given_none(grid):
 
 
 def test_translate_deprecation(grid):
-    with pytest.warns(PyvistaDeprecationWarning):
+    with pytest.warns(PyVistaDeprecationWarning):
         grid.translate((0.0, 0.0, 0.0))
 
 
@@ -1238,7 +1238,7 @@ def test_rotate_z():
 @pytest.mark.parametrize('method', ['rotate_x', 'rotate_y', 'rotate_z'])
 def test_deprecation_rotate(sphere, method):
     meth = getattr(sphere, method)
-    with pytest.warns(PyvistaDeprecationWarning):
+    with pytest.warns(PyVistaDeprecationWarning):
         meth(30)
 
 
@@ -1322,7 +1322,7 @@ def test_transform_integers_vtkbug_present():
 
 
 def test_deprecation_vector(sphere):
-    with pytest.warns(PyvistaDeprecationWarning):
+    with pytest.warns(PyVistaDeprecationWarning):
         sphere.rotate_vector([1, 1, 1], 33)
 
 
@@ -1348,7 +1348,7 @@ def test_scale():
     mesh = examples.load_uniform()
     out = mesh.scale(xyz)
     assert isinstance(out, pyvista.StructuredGrid)
-    with pytest.warns(PyvistaDeprecationWarning):
+    with pytest.warns(PyVistaDeprecationWarning):
         scale1.scale(xyz)
 
 
@@ -1363,7 +1363,7 @@ def test_flip_x():
     mesh = examples.load_uniform()
     out = mesh.flip_x()
     assert isinstance(out, pyvista.StructuredGrid)
-    with pytest.warns(PyvistaDeprecationWarning):
+    with pytest.warns(PyVistaDeprecationWarning):
         flip_x1.flip_x(point=(0, 0, 0))
 
 
@@ -1378,7 +1378,7 @@ def test_flip_y():
     mesh = examples.load_uniform()
     out = mesh.flip_y()
     assert isinstance(out, pyvista.StructuredGrid)
-    with pytest.warns(PyvistaDeprecationWarning):
+    with pytest.warns(PyVistaDeprecationWarning):
         flip_y1.flip_y(point=(0, 0, 0))
 
 
@@ -1393,7 +1393,7 @@ def test_flip_z():
     mesh = examples.load_uniform()
     out = mesh.flip_z()
     assert isinstance(out, pyvista.StructuredGrid)
-    with pytest.warns(PyvistaDeprecationWarning):
+    with pytest.warns(PyVistaDeprecationWarning):
         flip_z1.flip_z(point=(0, 0, 0))
 
 
@@ -1417,7 +1417,7 @@ def test_flip_normal():
     flip_normal6.flip_z(inplace=True)
     assert np.allclose(flip_normal5.points, flip_normal6.points)
 
-    with pytest.warns(PyvistaDeprecationWarning):
+    with pytest.warns(PyVistaDeprecationWarning):
         flip_normal5.flip_normal(normal=[0.0, 0.0, 1.0])
 
     # Test non-point-based mesh doesn't fail

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -12,7 +12,7 @@ from pyvista._vtk import VTK9
 from pyvista.core.errors import VTKVersionError
 from pyvista.errors import AmbiguousDataError, MissingDataError
 from pyvista.plotting import system_supports_plotting
-from pyvista.utilities.misc import PyvistaDeprecationWarning
+from pyvista.utilities.misc import PyVistaDeprecationWarning
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -843,7 +843,7 @@ def test_create_uniform_grid_from_specs():
 
     # all args (deprecated)
     with pytest.warns(
-        PyvistaDeprecationWarning, match="Behavior of pyvista.UniformGrid has changed"
+        PyVistaDeprecationWarning, match="Behavior of pyvista.UniformGrid has changed"
     ):
         grid = pyvista.UniformGrid(dims, origin, spacing)
         assert grid.dimensions == dims
@@ -852,7 +852,7 @@ def test_create_uniform_grid_from_specs():
 
     # just dims (deprecated)
     with pytest.warns(
-        PyvistaDeprecationWarning, match="Behavior of pyvista.UniformGrid has changed"
+        PyVistaDeprecationWarning, match="Behavior of pyvista.UniformGrid has changed"
     ):
         grid = pyvista.UniformGrid(dims)
         assert grid.dimensions == dims
@@ -869,7 +869,7 @@ def test_create_uniform_grid_from_specs():
 
 def test_uniform_grid_invald_args():
     with pytest.warns(
-        PyvistaDeprecationWarning, match="Behavior of pyvista.UniformGrid has changed"
+        PyVistaDeprecationWarning, match="Behavior of pyvista.UniformGrid has changed"
     ):
         pyvista.UniformGrid((1, 1, 1))
 

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -9,7 +9,7 @@ import pyvista
 from pyvista import examples
 from pyvista.core.errors import NotAllTrianglesError
 from pyvista.plotting import system_supports_plotting
-from pyvista.utilities.misc import PyvistaFutureWarning
+from pyvista.utilities.misc import PyVistaFutureWarning
 
 radius = 0.5
 
@@ -830,9 +830,9 @@ def test_extrude():
 
 def test_extrude_capping_warnings():
     arc = pyvista.CircularArc([-1, 0, 0], [1, 0, 0], [0, 0, 0])
-    with pytest.warns(PyvistaFutureWarning, match='default value of the ``capping`` keyword'):
+    with pytest.warns(PyVistaFutureWarning, match='default value of the ``capping`` keyword'):
         arc.extrude([0, 0, 1])
-    with pytest.warns(PyvistaFutureWarning, match='default value of the ``capping`` keyword'):
+    with pytest.warns(PyVistaFutureWarning, match='default value of the ``capping`` keyword'):
         arc.extrude_rotate()
 
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -24,7 +24,7 @@ from pyvista.utilities import (
     helpers,
     transformations,
 )
-from pyvista.utilities.misc import PyvistaDeprecationWarning, has_duplicates, raise_has_duplicates
+from pyvista.utilities.misc import PyVistaDeprecationWarning, has_duplicates, raise_has_duplicates
 
 skip_no_plotting = pytest.mark.skipif(
     not system_supports_plotting(), reason="Requires system to support plotting"
@@ -88,7 +88,7 @@ def test_read(tmpdir, use_pathlib):
     # Now test the standard_reader_routine
     for i, filename in enumerate(fnames):
         # Pass attrs to for the standard_reader_routine to be used
-        with pytest.warns(PyvistaDeprecationWarning):
+        with pytest.warns(PyVistaDeprecationWarning):
             obj = fileio.read(filename, attrs={'DebugOn': None})
         assert isinstance(obj, types[i])
     # this is also tested for each mesh types init from file tests
@@ -138,12 +138,12 @@ def test_read_force_ext(tmpdir):
 @mock.patch('pyvista.BaseReader.reader')
 def test_read_attrs(mock_reader, mock_read):
     """Test passing attrs in read."""
-    with pytest.warns(PyvistaDeprecationWarning):
+    with pytest.warns(PyVistaDeprecationWarning):
         pyvista.read(ex.antfile, attrs={'test': 'test_arg'})
     mock_reader.test.assert_called_once_with('test_arg')
 
     mock_reader.reset_mock()
-    with pytest.warns(PyvistaDeprecationWarning):
+    with pytest.warns(PyVistaDeprecationWarning):
         pyvista.read(ex.antfile, attrs={'test': ['test_arg1', 'test_arg2']})
     mock_reader.test.assert_called_once_with('test_arg1', 'test_arg2')
 
@@ -184,7 +184,7 @@ def test_read_force_ext_wrong_extension(tmpdir):
 
 @mock.patch('pyvista.utilities.fileio.read')
 def test_read_legacy(read_mock):
-    with pytest.warns(PyvistaDeprecationWarning):
+    with pytest.warns(PyVistaDeprecationWarning):
         pyvista.read_legacy(ex.globefile, progress_bar=False)
     read_mock.assert_called_once_with(ex.globefile, progress_bar=False)
 
@@ -204,13 +204,13 @@ def test_pyvista_read_exodus(read_exodus_mock):
 @mock.patch('pyvista.utilities.reader.BaseReader.path')
 def test_read_plot3d(path_mock, read_mock, auto_detect):
     # with grid only
-    with pytest.warns(PyvistaDeprecationWarning):
+    with pytest.warns(PyVistaDeprecationWarning):
         pyvista.read_plot3d(filename='grid.in', auto_detect=auto_detect)
     read_mock.assert_called_once()
 
     # with grid and q
     read_mock.reset_mock()
-    with pytest.warns(PyvistaDeprecationWarning):
+    with pytest.warns(PyVistaDeprecationWarning):
         pyvista.read_plot3d(filename='grid.in', q_filenames='q1.save', auto_detect=auto_detect)
     read_mock.assert_called_once()
 


### PR DESCRIPTION
Many places in the documentation and class names have PyVista improperly capitalized as "Pyvista". This PR bulk changes occurrences of "Pyvista" to "PyVista".

This does affect class names, notably `ResetPyVista`, `PyVistaDeprecationWarning`, and `PyVistaFutureWarning`. I believe these are intended for internal use and so I did not add a deprecation notice.

Note: we should probably add Pyvista -> PyVista upstream in codespell.
