### PR TITLE
Move `cast_to_pointset` to `_PointSet`

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2144,37 +2144,6 @@ class DataSet(DataSetFilters, DataObject):
         alg.Update()
         return _get_output(alg)
 
-    def cast_to_pointset(self, deep: bool = False) -> 'pyvista.PointSet':
-        """Get a new representation of this object as a :class:`pyvista.PointSet`.
-
-        Parameters
-        ----------
-        deep : bool, optional
-            When ``True`` makes a full copy of the object.  When ``False``,
-            performs a shallow copy where the points and data arrays are
-            references to the original object.
-
-        Returns
-        -------
-        pyvista.PointSet
-            Dataset cast into a :class:`pyvista.PointSet`.
-
-        Examples
-        --------
-        >>> import pyvista
-        >>> mesh = pyvista.Sphere()
-        >>> pointset = mesh.cast_to_pointset()
-        >>> type(pointset)
-        <class 'pyvista.core.pointset.PointSet'>
-
-        """
-        pset = pyvista.PointSet()
-        pset.SetPoints(self.GetPoints())
-        pset.GetPointData().ShallowCopy(self.GetPointData())
-        if deep:
-            return pset.copy(deep=True)
-        return pset
-
     def find_closest_point(self, point: Iterable[float], n=1) -> int:
         """Find index of closest point in this mesh to the given point.
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -336,6 +336,37 @@ class _PointSet(DataSet):
             kwargs['inplace'] = True
         return super().rotate_vector(*args, **kwargs)
 
+    def cast_to_pointset(self, deep: bool = False) -> 'pyvista.PointSet':
+        """Get a new representation of this object as a :class:`pyvista.PointSet`.
+
+        Parameters
+        ----------
+        deep : bool, optional
+            When ``True`` makes a full copy of the object.  When ``False``,
+            performs a shallow copy where the points and data arrays are
+            references to the original object.
+
+        Returns
+        -------
+        pyvista.PointSet
+            Dataset cast into a :class:`pyvista.PointSet`.
+
+        Examples
+        --------
+        >>> import pyvista
+        >>> mesh = pyvista.Sphere()
+        >>> pointset = mesh.cast_to_pointset()
+        >>> type(pointset)
+        <class 'pyvista.core.pointset.PointSet'>
+
+        """
+        pset = pyvista.PointSet()
+        pset.SetPoints(self.GetPoints())
+        pset.GetPointData().ShallowCopy(self.GetPointData())
+        if deep:
+            return pset.copy(deep=True)
+        return pset
+
 
 class PointSet(_vtk.vtkPointSet, _PointSet):
     """Concrete class for storing a set of points.


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

Not all `DataSet`s can be converted directly to `PointSet`, at least using the current method.  In particular `UniformGrid` and `RectilinearGrid` are either missing the `GetPoints` method entirely, or have a different form of the method.

### Details

It may be possible to implement this method in a different way for `UniformGrid` and `RectilinearGrid`, but I'm not proposing to do that in this PR.  It is possible to do `grid.cast_to_unstructured_grid().cast_to_pointset()` in the interim, albeit with probably more memory/cpu usage then needed.

If this PR is merged, I will update #3164 to be about how the method is missing for others who may want to investigate implementing that method.

