### PR TITLE
BUG: Provide default for renderer.enable_anti_aliasing

### DIFF
--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -439,7 +439,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         self.SetUseDepthPeeling(False)
         self.Modified()
 
-    def enable_anti_aliasing(self, aa_type):
+    def enable_anti_aliasing(self, aa_type='fxaa'):
         """Enable anti-aliasing.
 
         Parameters


### PR DESCRIPTION
Maintain backward compat by adding the old default

