### PR TITLE
Add the example of "Add labels to cells"

### DIFF
--- a/examples/01-filter/cell-centers.py
+++ b/examples/01-filter/cell-centers.py
@@ -89,7 +89,6 @@ pl.show()
 # There is not a method to add labels to cells.
 # If you want to label it, you need to extract the position to label it.
 
-grid.cell_centers().points
 grid = pv.UniformGrid(dims=(10, 10, 1))
 points = grid.cell_centers().points
 

--- a/examples/01-filter/cell-centers.py
+++ b/examples/01-filter/cell-centers.py
@@ -81,3 +81,19 @@ pl.add_points(
     point_size=20,
 )
 pl.show()
+
+
+###############################################################################
+# Add labels to cells
+# ~~~~~~~~~~~~~~~~~~~
+# There is not a method to add labels to cells.
+# If you want to label it, you need to extract the position to label it.
+
+grid.cell_centers().points
+grid = pv.UniformGrid(dims=(10, 10, 1))
+points = grid.cell_centers().points
+
+pl = pv.Plotter()
+pl.add_mesh(grid, show_edges=True)
+pl.add_point_labels(points, labels=[f"{i}" for i in range(points.shape[0])])
+pl.show(cpos="xy")


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
#### Add labels to cells

There is not a method to add labels to cells.
If you want to label it, you need to extract the position to label it.

```python
import pyvista as pv

grid = pv.UniformGrid(dims=(10, 10, 1))                                                                                                                                                                         
points = grid.cell_centers().points                                                                                                                                                                             
                                                                                                                                                                                                                  
pl = pv.Plotter()                                                                                                                                                                                               
pl.add_mesh(grid, show_edges=True)                                                                                                                                                                              
pl.add_point_labels(points, labels=[f"{i}" for i in range(points.shape[0])])                                                                                                                                    
pl.show(cpos="xy")
```
![add-labels-to-cells](https://user-images.githubusercontent.com/7513610/188289901-c3aa4aa4-731e-4d3c-8237-854dcd99e517.png)

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->
resolves #3237

### Details

- None

