### PR TITLE
Prevent warning in polystrips example coming from extrude

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -802,7 +802,7 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         --------
         >>> import pyvista as pv
         >>> polygon = pv.Rectangle()
-        >>> extruded = polygon.extrude((0, 0, 1))
+        >>> extruded = polygon.extrude((0, 0, 1), capping=False)
         >>> extruded.strips
         array([4, 0, 1, 4, 5, 4, 1, 2, 5, 6, 4, 2, 3, 6, 7, 4, 3, 0, 7, 4])
         """


### PR DESCRIPTION
Full doc builds emit a warning:
```
/home/adeak/pyvista/pyvista/core/filters/poly_data.py:2778: PyVistaFutureWarning: The default value of the ``capping`` keyword argument will change in a future version to ``True`` to match the behavior of VTK. We recommend passing the keyword explicitly to prevent future surprises.
```

This is caused by the doctest of the new poly `strips` not specifying the `capping` kwarg. I decided to keep the old behaviour which will mean that use of the kwarg is still relevant when we flip the switch on the default value of `capping` (from `False` to `True`).