### PR TITLE
Add dev Gitpod support 

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,10 +14,6 @@ vscode:
 
 tasks:
   - init: |
-      # this needs to be a proj var
-      export PRE_COMMIT_HOME=/workspace/.precommit
-      [ ! -d venv ] && python -m venv venv
-      source venv/bin/activate
       pip install --no-cache-dir https://github.com/pyvista/pyvista-wheels/raw/main/vtk-osmesa-9.1.0-cp38-cp38-linux_x86_64.whl
       pip install --no-cache-dir -r requirements_test.txt
       pip install --no-cache-dir -r requirements_docs.txt

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,44 @@
+image:
+  file: docker/dev-gitpod.Dockerfile
+
+# --------------------------------------------------------
+# exposing ports for liveserve
+ports:
+  - port: 5500
+    onOpen: notify
+
+vscode:
+  extensions:
+    - ms-python.python
+    - ritwickdey.liveserver
+
+tasks:
+  - init: |
+      # this needs to be a proj var
+      export PRE_COMMIT_HOME=/workspace/.precommit
+      [ ! -d venv ] && python -m venv venv
+      source venv/bin/activate
+      pip install --no-cache-dir https://github.com/pyvista/pyvista-wheels/raw/main/vtk-osmesa-9.1.0-cp38-cp38-linux_x86_64.whl
+      pip install --no-cache-dir -r requirements_test.txt
+      pip install --no-cache-dir -r requirements_docs.txt
+      pip install --no-cache-dir pre-commit
+      pre-commit install --install-hooks
+      pip install -e .
+      make -C doc html
+
+github:
+  prebuilds:
+    # enable for the default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: false
+    # add a check to pull requests (defaults to true)
+    addCheck: false
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: false
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: false

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,6 +6,8 @@ image:
 ports:
   - port: 5500
     onOpen: notify
+  - port: 6080
+    onOpen: open-preview
 
 vscode:
   extensions:
@@ -14,7 +16,6 @@ vscode:
 
 tasks:
   - init: |
-      pip install --no-cache-dir https://github.com/pyvista/pyvista-wheels/raw/main/vtk-osmesa-9.1.0-cp38-cp38-linux_x86_64.whl
       pip install --no-cache-dir -r requirements_test.txt
       pip install --no-cache-dir -r requirements_docs.txt
       pip install --no-cache-dir pre-commit

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -146,7 +146,7 @@ There are two important copyright guidelines:
 Please also take a look at our `Code of
 Conduct <https://github.com/pyvista/pyvista/blob/main/CODE_OF_CONDUCT.md>`_.
 
-Contributing to pyvista through GitHub
+Contributing to PyVista through GitHub
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To submit new code to pyvista, first fork the `pyvista GitHub
@@ -255,6 +255,27 @@ dependencies listed in ``requirements_test.txt``,
 
 Then, if you have everything installed, you can run the various test
 suites.
+
+Using Gitpod workspace
+~~~~~~~~~~~~~~~~~~~~~~
+
+A prebuilt gitpod workspace is available for a quick start development
+environment. To start a workspace from the main branch of pyvista, go
+to `<https://gitpod.io/#https://github.com/pyvista/pyvista>`_. See
+`Gitpod Getting Started
+<https://www.gitpod.io/docs/getting-started>`_ for more details.
+
+The workspace has vnc capability through the browser for
+interactive plotting.  The workspace also has prebuilt
+documentation with a live-viewer.  Hit the ``Go Live`` button
+and browse to ``doc/_build/html``. The workspace is also prebuilt to
+support pre-commit checks.
+
+Workspaces started from the ``pyvista/pyvista`` repo will often
+have prebuilt environments with dependencies installed. Workspaces
+started from forks may not have prebuilt images and will start
+building when starting a new workspace.  It is safe to stop, e.g.
+``Ctrl-C``, the documentation part of the build if unneeded.
 
 Unit Testing
 ~~~~~~~~~~~~

--- a/docker/dev-gitpod.Dockerfile
+++ b/docker/dev-gitpod.Dockerfile
@@ -1,13 +1,13 @@
-FROM gitpod/workspace-full
+FROM gitpod/workspace-full-vnc
 LABEL maintainer="PyVista Developers"
 LABEL repo="https://github.com/pyvista/pyvista"
 
-RUN sudo apt-get install  -yq --no-install-recommends \
-    libosmesa6
+RUN sudo apt-get update \
+  && sudo apt-get install  -yq --no-install-recommends libxrender1
 
 RUN echo "[ ! -d /workspace/venv ] && python -m venv /workspace/venv" > $HOME/.bashrc.d/999-pyvista
 RUN echo "source /workspace/venv/bin/activate" >> $HOME/.bashrc.d/999-pyvista
 
 WORKDIR $HOME
-ENV PYVISTA_OFF_SCREEN=true
+ENV PYVISTA_OFF_SCREEN=false
 ENV PRE_COMMIT_HOME=/workspace/.precommit

--- a/docker/dev-gitpod.Dockerfile
+++ b/docker/dev-gitpod.Dockerfile
@@ -5,8 +5,9 @@ LABEL repo="https://github.com/pyvista/pyvista"
 RUN sudo apt-get install  -yq --no-install-recommends \
     libosmesa6
 
-ENV PYTHONUSERBASE=/workspace/.pip-modules
-ENV PATH=$PYTHONUSERBASE/bin:$PATH
+RUN echo "[ ! -d /workspace/venv ] && python -m venv /workspace/venv" > $HOME/.bashrc.d/999-pyvista
+RUN echo "source /workspace/venv/bin/activate" >> $HOME/.bashrc.d/999-pyvista
 
 WORKDIR $HOME
 ENV PYVISTA_OFF_SCREEN=true
+ENV PRE_COMMIT_HOME=/workspace/.precommit

--- a/docker/dev-gitpod.Dockerfile
+++ b/docker/dev-gitpod.Dockerfile
@@ -1,0 +1,12 @@
+FROM gitpod/workspace-full
+LABEL maintainer="PyVista Developers"
+LABEL repo="https://github.com/pyvista/pyvista"
+
+RUN sudo apt-get install  -yq --no-install-recommends \
+    libosmesa6
+
+ENV PYTHONUSERBASE=/workspace/.pip-modules
+ENV PATH=$PYTHONUSERBASE/bin:$PATH
+
+WORKDIR $HOME
+ENV PYVISTA_OFF_SCREEN=true

--- a/docker/dev-gitpod.Dockerfile
+++ b/docker/dev-gitpod.Dockerfile
@@ -8,6 +8,5 @@ RUN sudo apt-get update \
 RUN echo "[ ! -d /workspace/pv-venv ] && python -m venv /workspace/pv-venv" > $HOME/.bashrc.d/999-pyvista
 RUN echo "source /workspace/pv-venv/bin/activate" >> $HOME/.bashrc.d/999-pyvista
 
-WORKDIR $HOME
 ENV PYVISTA_OFF_SCREEN=false
 ENV PRE_COMMIT_HOME=/workspace/.precommit

--- a/docker/dev-gitpod.Dockerfile
+++ b/docker/dev-gitpod.Dockerfile
@@ -5,8 +5,8 @@ LABEL repo="https://github.com/pyvista/pyvista"
 RUN sudo apt-get update \
   && sudo apt-get install  -yq --no-install-recommends libxrender1
 
-RUN echo "[ ! -d /workspace/venv ] && python -m venv /workspace/venv" > $HOME/.bashrc.d/999-pyvista
-RUN echo "source /workspace/venv/bin/activate" >> $HOME/.bashrc.d/999-pyvista
+RUN echo "[ ! -d /workspace/pv-venv ] && python -m venv /workspace/pv-venv" > $HOME/.bashrc.d/999-pyvista
+RUN echo "source /workspace/pv-venv/bin/activate" >> $HOME/.bashrc.d/999-pyvista
 
 WORKDIR $HOME
 ENV PYVISTA_OFF_SCREEN=false


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

This is another attempt at #2933.  This PR adds initial gitpod support including prebuilt environment including:
- interactive plotting with browser based vnc
- testing
- documentation
  - prebuilt image
  - live viewer
- preinstalling pre-commit hook environments

### Details

Gitpod handles image building and also prebuilding workspaces.  Pre-builds are turned off for pull requests from fork for now.  I'm not certain on the security implications here.

~A few tests fail when run using this environment.  Future PRs could be used to address this.~  Tests failed when using the OSMesa and the accompanying wheel, but not when using the vnc image.

Closes #2959.

TODO:
- [x] feedback on virtual environment approach
- [x] add documentation