### PR TITLE
Use stable version python for intersphinx links

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -222,7 +222,7 @@ add_module_names = False
 # NOTE: if these are changed, then doc/intersphinx/update.sh
 # must be changed accordingly to keep auto-updated mappings working
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/dev', (None, 'intersphinx/python-objects.inv')),
+    'python': ('https://docs.python.org/3', (None, 'intersphinx/python-objects.inv')),
     'scipy': (
         'https://docs.scipy.org/doc/scipy/',
         (None, 'intersphinx/scipy-objects.inv'),

--- a/doc/intersphinx/update.sh
+++ b/doc/intersphinx/update.sh
@@ -2,7 +2,7 @@
 
 # this script updates the intersphinx files here
 # make sure to follow potential redirects
-curl -L https://docs.python.org/dev/objects.inv > python-objects.inv
+curl -L https://docs.python.org/3/objects.inv > python-objects.inv
 curl -L https://docs.scipy.org/doc/scipy/objects.inv > scipy-objects.inv
 curl -L https://numpy.org/doc/stable/objects.inv > numpy-objects.inv
 curl -L https://matplotlib.org/stable/objects.inv > matplotlib-objects.inv


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

Current documentation links to dev version of python, which is now 3.12.  Use latest stable version instead.