### PR TITLE
set active scalars to be visible in collision example

### DIFF
--- a/examples/01-filter/collisions.py
+++ b/examples/01-filter/collisions.py
@@ -52,7 +52,7 @@ sphere1 = pv.Sphere(radius=0.6, center=(-1, 0, 0))
 
 pl = pv.Plotter()
 pl.enable_hidden_line_removal()
-pl.add_mesh(sphere0, show_scalar_bar=False, cmap='bwr')
+pl.add_mesh(sphere0, scalars='collisions', show_scalar_bar=False, cmap='bwr')
 pl.camera_position = 'xz'
 pl.add_mesh(sphere1, style='wireframe', color='green', line_width=5)
 


### PR DESCRIPTION
| `main` | this branch |
|---|---|
|![sphx_glr_collisions_001](https://user-images.githubusercontent.com/22067021/189161128-5ed064ea-058b-45e6-94d1-91173c0d0ed1.gif) | ![collision_movie](https://user-images.githubusercontent.com/22067021/189161173-0682f7de-9f54-4dc5-a893-69daf85aa48f.gif) |

The active scalars behavior has changed since this example was written. This example is supposed to show the active "collisions" scalar, but it wasn't. I bet there are a ton of other examples missing this as well since the behavior of active scalars drastically changed not too long ago.
