### PR TITLE
Use PyVista start headless display action

### DIFF
--- a/.github/workflows/style_docstr.yml
+++ b/.github/workflows/style_docstr.yml
@@ -47,19 +47,17 @@ jobs:
       - name: Install pyvista and doctest requirements
         run: pip install . -r requirements_test.txt
 
-      - uses: awalsh128/cache-apt-pkgs-action@v1.1.1
-        with:
-          packages: libgl1-mesa-glx xvfb python-tk
-          version: 3.0
+      - name: Setup headless display
+        uses: pyvista/setup-headless-display-action@v1
 
       - name: Software Report
         run: |
-          xvfb-run python -c "import pyvista; print(pyvista.Report()); print('Examples path:', pyvista.EXAMPLES_PATH)"
+          python -c "import pyvista; print(pyvista.Report()); print('Examples path:', pyvista.EXAMPLES_PATH)"
           which python
           pip list
 
       - name: Test Package Docstrings
-        run: xvfb-run pytest -v --doctest-modules pyvista
+        run: pytest -v --doctest-modules pyvista
 
       - name: Test Package Docstrings with Local Namespace
-        run: xvfb-run make doctest-modules-local-namespace
+        run: make doctest-modules-local-namespace

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -922,7 +922,7 @@ class LookupTable(_vtk.vtkLookupTable):
         Examples
         --------
         >>> import pyvista
-        >>> lut = pv.LookupTable()
+        >>> lut = pyvista.LookupTable()
         >>> rgba_color = lut.map_value(0.0)
         >>> rgba_color
         (1.0, 0.0, 0.0, 1.0)

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -922,7 +922,7 @@ class LookupTable(_vtk.vtkLookupTable):
         Examples
         --------
         >>> import pyvista
-        >>> lut = pyvista.LookupTable()
+        >>> lut = pv.LookupTable()
         >>> rgba_color = lut.map_value(0.0)
         >>> rgba_color
         (1.0, 0.0, 0.0, 1.0)


### PR DESCRIPTION
Use the pyvista start headless display action within the style and docstring check.

Sometimes our workflows fail when starting xvfb multiple times with `xvfb-run` and this should fix it.