### PR TITLE
add use all points to the extract edges filter

### DIFF
--- a/doc/_templates/sidebar-nav-bs.html
+++ b/doc/_templates/sidebar-nav-bs.html
@@ -1,9 +1,0 @@
-<nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
-  <div class="bd-toc-item active">
-    {% if pagename.startswith("api") %}
-    {{ generate_toctree_html("sidebar", maxdepth=4, collapse=True, includehidden=True, titles_only=True) }}
-    {% else %}
-    {{ generate_toctree_html("sidebar", maxdepth=4, collapse=False, includehidden=True, titles_only=True) }}
-    {% endif %}
-  </div>
-</nav>

--- a/doc/_templates/sidebar-nav-bs.html
+++ b/doc/_templates/sidebar-nav-bs.html
@@ -1,0 +1,9 @@
+<nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
+  <div class="bd-toc-item active">
+    {% if pagename.startswith("api") %}
+    {{ generate_toctree_html("sidebar", maxdepth=4, collapse=True, includehidden=True, titles_only=True) }}
+    {% else %}
+    {{ generate_toctree_html("sidebar", maxdepth=4, collapse=False, includehidden=True, titles_only=True) }}
+    {% endif %}
+  </div>
+</nav>

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1308,13 +1308,22 @@ class DataSetFilters:
         _update_alg(alg, progress_bar, 'Extracting Geometry')
         return _get_output(alg)
 
-    def extract_all_edges(self, progress_bar=False):
+    def extract_all_edges(self, use_all_points=False, progress_bar=False):
         """Extract all the internal/external edges of the dataset as PolyData.
 
         This produces a full wireframe representation of the input dataset.
 
         Parameters
         ----------
+        use_all_points : bool, default: False
+            Indicates whether all of the points of the input mesh should exist
+            in the output. When ``True`` enables point renumbering.  If set to
+            ``True``, then a threaded approach is used which avoids the use of
+            a point locator and is quicker.
+
+            By default this is set to ``False``, and unused points are omitted
+            from the output.
+
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
@@ -1339,6 +1348,11 @@ class DataSetFilters:
         """
         alg = _vtk.vtkExtractEdges()
         alg.SetInputDataObject(self)
+        if use_all_points:
+            try:
+                alg.SetUseAllPoints(use_all_points)
+            except AttributeError:  # pragma: no cover
+                raise VTKVersionError('This version of VTK does not support `use_all_points=True`.')
         _update_alg(alg, progress_bar, 'Extracting All Edges')
         return _get_output(alg)
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1324,6 +1324,8 @@ class DataSetFilters:
             By default this is set to ``False``, and unused points are omitted
             from the output.
 
+            This parameter can only be set to ``True`` with ``vtk==9.1.0`` or newer.
+
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
@@ -1352,7 +1354,10 @@ class DataSetFilters:
             try:
                 alg.SetUseAllPoints(use_all_points)
             except AttributeError:  # pragma: no cover
-                raise VTKVersionError('This version of VTK does not support `use_all_points=True`.')
+                raise VTKVersionError(
+                    'This version of VTK does not support `use_all_points=True`. '
+                    'VTK v9.1 or newer is required.'
+                )
         _update_alg(alg, progress_bar, 'Extracting All Edges')
         return _get_output(alg)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -502,11 +502,18 @@ def test_extract_geometry_extent(uniform):
     assert geom.bounds == (0.0, 5.0, 0.0, 9.0, 0.0, 9.0)
 
 
-def test_wireframe(datasets):
+def test_extract_all_edges(datasets):
     for dataset in datasets:
-        wire = dataset.extract_all_edges(progress_bar=True)
-        assert wire is not None
-        assert isinstance(wire, pyvista.PolyData)
+        edges = dataset.extract_all_edges()
+        assert edges is not None
+        assert isinstance(edges, pyvista.PolyData)
+
+    if pyvista.vtk_version_info < (9,):
+        with pytest.raises(VTKVersionError):
+            datasets[0].extract_all_edges(use_all_points=True)
+    else:
+        edges = datasets[0].extract_all_edges(use_all_points=True)
+        assert edges.n_lines
 
 
 @skip_py2_nobind

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -508,7 +508,7 @@ def test_extract_all_edges(datasets):
         assert edges is not None
         assert isinstance(edges, pyvista.PolyData)
 
-    if pyvista.vtk_version_info < (9,):
+    if pyvista.vtk_version_info < (9, 1):
         with pytest.raises(VTKVersionError):
             datasets[0].extract_all_edges(use_all_points=True)
     else:


### PR DESCRIPTION
Enable the usage of ``SetUseAllPoints``. This improves the performance of the `extract_all_edges` at the potential expense increased memory usage.
