### PR TITLE
Delete sidebar-nav-bs.html

### DIFF
--- a/doc/_templates/sidebar-nav-bs.html
+++ b/doc/_templates/sidebar-nav-bs.html
@@ -1,9 +1,0 @@
-<nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
-  <div class="bd-toc-item active">
-    {% if pagename.startswith("api") %}
-    {{ generate_toctree_html("sidebar", maxdepth=4, collapse=True, includehidden=True, titles_only=True) }}
-    {% else %}
-    {{ generate_toctree_html("sidebar", maxdepth=4, collapse=False, includehidden=True, titles_only=True) }}
-    {% endif %}
-  </div>
-</nav>


### PR DESCRIPTION
Delete the sidebar `sidebar-nav-bs.html`. This is causing the sidebar navigation to fail to render correctly.

Now that we only build individual documentation pages on `main`, it's acceptable for the doc build to take longer and it's no longer necessary to take steps to minimize the build time. We can reimplement this if needed.