### PR TITLE
Rename pass_cell_arrays and pass_point_arrays in methods of DataSetFilters

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -21,7 +21,6 @@ from pyvista.utilities import (
     wrap,
 )
 from pyvista.utilities.cells import numpy_to_idarr
-from pyvista.utilities.misc import PyVistaFutureWarning
 
 
 @abstract_class
@@ -2826,27 +2825,8 @@ class DataSetFilters:
         True
 
         """
-        if pass_cell_data is None:
-            pass_cell_data = False
-            warnings.warn(
-                'The default value of the ``pass_cell_data`` keyword argument will change in ' 
-                'a future version to ``True`` to match the behavior of VTK. We recommend ' 
-                'passing the keyword explicitly to prevent future surprises.',
-                PyVistaFutureWarning
-            )
-
-        if pass_point_data is None:
-            pass_point_data = False
-            warnings.warn(
-                'The default value of the ``pass_point_data`` keyword argument will change in ' 
-                'a future version to ``True`` to match the behavior of VTK. We recommend ' 
-                'passing the keyword explicitly to prevent future surprises.',
-                PyVistaFutureWarning
-            )
-
         if not pyvista.is_pyvista_dataset(points):
             points = pyvista.wrap(points)
-
         alg = _vtk.vtkProbeFilter()
         alg.SetInputData(points)
         alg.SetSourceData(self)
@@ -2924,27 +2904,8 @@ class DataSetFilters:
         See :ref:`resampling_example` for more examples using this filter.
 
         """
-        if pass_cell_data is None:
-            pass_cell_data = False
-            warnings.warn(
-                'The default value of the ``pass_cell_data`` keyword argument will change in ' 
-                'a future version to ``True`` to match the behavior of VTK. We recommend ' 
-                'passing the keyword explicitly to prevent future surprises.',
-                PyVistaFutureWarning
-            )
-
-        if pass_point_data is None:
-            pass_point_data = False
-            warnings.warn(
-                'The default value of the ``pass_point_data`` keyword argument will change in ' 
-                'a future version to ``True`` to match the behavior of VTK. We recommend ' 
-                'passing the keyword explicitly to prevent future surprises.',
-                PyVistaFutureWarning
-            )
-
         if not pyvista.is_pyvista_dataset(target):
             raise TypeError('`target` must be a PyVista mesh type.')
-
         alg = _vtk.vtkResampleWithDataSet()  # Construct the ResampleWithDataSet object
         alg.SetInputData(self)  # Set the Input data (actually the source i.e. where to sample from)
         # Set the Source data (actually the target, i.e. where to sample to)
@@ -3054,24 +3015,6 @@ class DataSetFilters:
         """
         if not pyvista.is_pyvista_dataset(target):
             raise TypeError('`target` must be a PyVista mesh type.')
-
-        if pass_cell_data is None:
-            pass_cell_data = False
-            warnings.warn(
-                'The default value of the ``pass_cell_data`` keyword argument will change in ' 
-                'a future version to ``True`` to match the behavior of VTK. We recommend ' 
-                'passing the keyword explicitly to prevent future surprises.',
-                PyVistaFutureWarning
-            )
-
-        if pass_point_data is None:
-            pass_point_data = False
-            warnings.warn(
-                'The default value of the ``pass_point_data`` keyword argument will change in ' 
-                'a future version to ``True`` to match the behavior of VTK. We recommend ' 
-                'passing the keyword explicitly to prevent future surprises.',
-                PyVistaFutureWarning
-            )
 
         # Must cast to UnstructuredGrid in some cases (e.g. vtkImageData/vtkRectilinearGrid)
         # I believe the locator and the interpolator call `GetPoints` and not all mesh types have that method

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -21,6 +21,7 @@ from pyvista.utilities import (
     wrap,
 )
 from pyvista.utilities.cells import numpy_to_idarr
+from pyvista.utilities.misc import PyVistaFutureWarning
 
 
 @abstract_class
@@ -2408,7 +2409,7 @@ class DataSetFilters:
         else:
             return warped_mesh
 
-    def cell_data_to_point_data(self, pass_cell_data=False, progress_bar=False):
+    def cell_data_to_point_data(self, pass_cell_data=False, progress_bar=False, **kwargs):
         """Transform cell data into point data.
 
         Point data are specified per node and cell data specified
@@ -2455,6 +2456,13 @@ class DataSetFilters:
         >>> surf.plot(scalars='Area')
 
         """
+        if pass_cell_data is False and 'pass_cell_arrays' in kwargs:
+            pass_cell_data = kwargs.pop('pass_cell_arrays')
+            warnings.warn(
+                'Use of `pass_cell_arrays` is deprecated. Use `pass_cell_data` instead.',
+                PyVistaFutureWarning
+            )
+        assert_empty_kwargs(**kwargs)
         alg = _vtk.vtkCellDataToPointData()
         alg.SetInputDataObject(self)
         alg.SetPassCellData(pass_cell_data)
@@ -2464,7 +2472,7 @@ class DataSetFilters:
             active_scalars = self.active_scalars_name
         return _get_output(alg, active_scalars=active_scalars)
 
-    def ctp(self, pass_cell_data=False, progress_bar=False):
+    def ctp(self, pass_cell_data=False, progress_bar=False, **kwargs):
         """Transform cell data into point data.
 
         Point data are specified per node and cell data specified
@@ -2490,10 +2498,10 @@ class DataSetFilters:
 
         """
         return DataSetFilters.cell_data_to_point_data(
-            self, pass_cell_data=pass_cell_data, progress_bar=progress_bar
+            self, pass_cell_data=pass_cell_data, progress_bar=progress_bar, **kwargs
         )
 
-    def point_data_to_cell_data(self, pass_point_data=False, progress_bar=False):
+    def point_data_to_cell_data(self, pass_point_data=False, progress_bar=False, **kwargs):
         """Transform point data into cell data.
 
         Point data are specified per node and cell data specified within cells.
@@ -2539,6 +2547,13 @@ class DataSetFilters:
         >>> sphere.plot()
 
         """
+        if pass_point_data is False and 'pass_point_arrays' in kwargs:
+            pass_point_data = kwargs.pop('pass_point_arrays')
+            warnings.warn(
+                'Use of `pass_point_arrays` is deprecated. Use `pass_point_data` instead.',
+                PyVistaFutureWarning
+            )
+        assert_empty_kwargs(**kwargs)
         alg = _vtk.vtkPointDataToCellData()
         alg.SetInputDataObject(self)
         alg.SetPassPointData(pass_point_data)
@@ -2548,7 +2563,7 @@ class DataSetFilters:
             active_scalars = self.active_scalars_name
         return _get_output(alg, active_scalars=active_scalars)
 
-    def ptc(self, pass_point_data=False, progress_bar=False):
+    def ptc(self, pass_point_data=False, progress_bar=False, **kwargs):
         """Transform point data into cell data.
 
         Point data are specified per node and cell data specified
@@ -2574,7 +2589,7 @@ class DataSetFilters:
 
         """
         return DataSetFilters.point_data_to_cell_data(
-            self, pass_point_data=pass_point_data, progress_bar=progress_bar
+            self, pass_point_data=pass_point_data, progress_bar=progress_bar, **kwargs
         )
 
     def triangulate(self, inplace=False, progress_bar=False):
@@ -2773,6 +2788,7 @@ class DataSetFilters:
         categorical=False,
         progress_bar=False,
         locator=None,
+        **kwargs
     ):
         """Sample data values at specified point locations.
 
@@ -2825,6 +2841,20 @@ class DataSetFilters:
         True
 
         """
+        if pass_cell_data is True and 'pass_cell_arrays' in kwargs:
+            pass_cell_data = kwargs.pop('pass_cell_arrays')
+            warnings.warn(
+                'Use of `pass_cell_arrays` is deprecated. Use `pass_cell_data` instead.',
+                PyVistaFutureWarning
+            )
+        if pass_point_data is True and 'pass_point_arrays' in kwargs:
+            pass_point_data = kwargs.pop('pass_point_arrays')
+            warnings.warn(
+                'Use of `pass_point_arrays` is deprecated. Use `pass_point_data` instead.',
+                PyVistaFutureWarning
+            )
+        assert_empty_kwargs(**kwargs)
+
         if not pyvista.is_pyvista_dataset(points):
             points = pyvista.wrap(points)
         alg = _vtk.vtkProbeFilter()
@@ -2855,6 +2885,7 @@ class DataSetFilters:
         pass_point_data=True,
         categorical=False,
         progress_bar=False,
+        **kwargs
     ):
         """Resample array data from a passed mesh onto this mesh.
 
@@ -2904,6 +2935,19 @@ class DataSetFilters:
         See :ref:`resampling_example` for more examples using this filter.
 
         """
+        if pass_cell_data is True and 'pass_cell_arrays' in kwargs:
+            pass_cell_data = kwargs.pop('pass_cell_arrays')
+            warnings.warn(
+                'Use of `pass_cell_arrays` is deprecated. Use `pass_cell_data` instead.',
+                PyVistaFutureWarning
+            )
+        if pass_point_data is True and 'pass_point_arrays' in kwargs:
+            pass_point_data = kwargs.pop('pass_point_arrays')
+            warnings.warn(
+                'Use of `pass_point_arrays` is deprecated. Use `pass_point_data` instead.',
+                PyVistaFutureWarning
+            )
+        assert_empty_kwargs(**kwargs)
         if not pyvista.is_pyvista_dataset(target):
             raise TypeError('`target` must be a PyVista mesh type.')
         alg = _vtk.vtkResampleWithDataSet()  # Construct the ResampleWithDataSet object
@@ -2930,6 +2974,7 @@ class DataSetFilters:
         pass_cell_data=True,
         pass_point_data=True,
         progress_bar=False,
+        **kwargs
     ):
         """Interpolate values onto this mesh from a given dataset.
 
@@ -3015,6 +3060,20 @@ class DataSetFilters:
         """
         if not pyvista.is_pyvista_dataset(target):
             raise TypeError('`target` must be a PyVista mesh type.')
+
+        if pass_cell_data is True and 'pass_cell_arrays' in kwargs:
+            pass_cell_data = kwargs.pop('pass_cell_arrays')
+            warnings.warn(
+                'Use of `pass_cell_arrays` is deprecated. Use `pass_cell_data` instead.',
+                PyVistaFutureWarning
+            )
+        if pass_point_data is True and 'pass_point_arrays' in kwargs:
+            pass_point_data = kwargs.pop('pass_point_arrays')
+            warnings.warn(
+                'Use of `pass_point_arrays` is deprecated. Use `pass_point_data` instead.',
+                PyVistaFutureWarning
+            )
+        assert_empty_kwargs(**kwargs)
 
         # Must cast to UnstructuredGrid in some cases (e.g. vtkImageData/vtkRectilinearGrid)
         # I believe the locator and the interpolator call `GetPoints` and not all mesh types have that method

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -21,6 +21,7 @@ from pyvista.utilities import (
     wrap,
 )
 from pyvista.utilities.cells import numpy_to_idarr
+from pyvista.utilities.misc import PyVistaFutureWarning
 
 
 @abstract_class
@@ -2825,8 +2826,27 @@ class DataSetFilters:
         True
 
         """
+        if pass_cell_data is None:
+            pass_cell_data = False
+            warnings.warn(
+                'The default value of the ``pass_cell_data`` keyword argument will change in ' 
+                'a future version to ``True`` to match the behavior of VTK. We recommend ' 
+                'passing the keyword explicitly to prevent future surprises.',
+                PyVistaFutureWarning
+            )
+
+        if pass_point_data is None:
+            pass_point_data = False
+            warnings.warn(
+                'The default value of the ``pass_point_data`` keyword argument will change in ' 
+                'a future version to ``True`` to match the behavior of VTK. We recommend ' 
+                'passing the keyword explicitly to prevent future surprises.',
+                PyVistaFutureWarning
+            )
+
         if not pyvista.is_pyvista_dataset(points):
             points = pyvista.wrap(points)
+
         alg = _vtk.vtkProbeFilter()
         alg.SetInputData(points)
         alg.SetSourceData(self)
@@ -2904,8 +2924,27 @@ class DataSetFilters:
         See :ref:`resampling_example` for more examples using this filter.
 
         """
+        if pass_cell_data is None:
+            pass_cell_data = False
+            warnings.warn(
+                'The default value of the ``pass_cell_data`` keyword argument will change in ' 
+                'a future version to ``True`` to match the behavior of VTK. We recommend ' 
+                'passing the keyword explicitly to prevent future surprises.',
+                PyVistaFutureWarning
+            )
+
+        if pass_point_data is None:
+            pass_point_data = False
+            warnings.warn(
+                'The default value of the ``pass_point_data`` keyword argument will change in ' 
+                'a future version to ``True`` to match the behavior of VTK. We recommend ' 
+                'passing the keyword explicitly to prevent future surprises.',
+                PyVistaFutureWarning
+            )
+
         if not pyvista.is_pyvista_dataset(target):
             raise TypeError('`target` must be a PyVista mesh type.')
+
         alg = _vtk.vtkResampleWithDataSet()  # Construct the ResampleWithDataSet object
         alg.SetInputData(self)  # Set the Input data (actually the source i.e. where to sample from)
         # Set the Source data (actually the target, i.e. where to sample to)
@@ -3015,6 +3054,24 @@ class DataSetFilters:
         """
         if not pyvista.is_pyvista_dataset(target):
             raise TypeError('`target` must be a PyVista mesh type.')
+
+        if pass_cell_data is None:
+            pass_cell_data = False
+            warnings.warn(
+                'The default value of the ``pass_cell_data`` keyword argument will change in ' 
+                'a future version to ``True`` to match the behavior of VTK. We recommend ' 
+                'passing the keyword explicitly to prevent future surprises.',
+                PyVistaFutureWarning
+            )
+
+        if pass_point_data is None:
+            pass_point_data = False
+            warnings.warn(
+                'The default value of the ``pass_point_data`` keyword argument will change in ' 
+                'a future version to ``True`` to match the behavior of VTK. We recommend ' 
+                'passing the keyword explicitly to prevent future surprises.',
+                PyVistaFutureWarning
+            )
 
         # Must cast to UnstructuredGrid in some cases (e.g. vtkImageData/vtkRectilinearGrid)
         # I believe the locator and the interpolator call `GetPoints` and not all mesh types have that method

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2927,7 +2927,7 @@ class DataSetFilters:
         strategy='null_value',
         null_value=0.0,
         n_points=None,
-        pass_cell_arrays=True,
+        pass_cell_data=True,
         pass_point_data=True,
         progress_bar=False,
     ):
@@ -2976,7 +2976,7 @@ class DataSetFilters:
             in favor of an N closest points approach. This typically has poorer
             results.
 
-        pass_cell_arrays : bool, optional
+        pass_cell_data : bool, optional
             Preserve input mesh's original cell data arrays.
 
         pass_point_data : bool, optional
@@ -3048,7 +3048,7 @@ class DataSetFilters:
         else:
             raise ValueError(f'strategy `{strategy}` not supported.')
         interpolator.SetPassPointArrays(pass_point_data)
-        interpolator.SetPassCellArrays(pass_cell_arrays)
+        interpolator.SetPassCellArrays(pass_cell_data)
         _update_alg(interpolator, progress_bar, 'Interpolating')
         return _get_output(interpolator)
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2456,15 +2456,6 @@ class DataSetFilters:
         >>> surf.plot(scalars='Area')
 
         """
-        if pass_cell_data is None:
-            pass_cell_data = False
-            warnings.warn(
-                'The default value of the ``pass_cell_data`` keyword argument will change in ' 
-                'a future version to ``True`` to match the behavior of VTK. We recommend ' 
-                'passing the keyword explicitly to prevent future surprises.',
-                PyVistaFutureWarning
-            )
-
         alg = _vtk.vtkCellDataToPointData()
         alg.SetInputDataObject(self)
         alg.SetPassCellData(pass_cell_data)
@@ -2549,15 +2540,6 @@ class DataSetFilters:
         >>> sphere.plot()
 
         """
-        if pass_point_data is None:
-            pass_point_data = False
-            warnings.warn(
-                'The default value of the ``pass_point_data`` keyword argument will change in ' 
-                'a future version to ``True`` to match the behavior of VTK. We recommend ' 
-                'passing the keyword explicitly to prevent future surprises.',
-                PyVistaFutureWarning
-            )
-
         alg = _vtk.vtkPointDataToCellData()
         alg.SetInputDataObject(self)
         alg.SetPassPointData(pass_point_data)

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2430,6 +2430,9 @@ class DataSetFilters:
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        **kwargs : dict, optional
+            Depreciated keyword argument ``pass_cell_arrays``.
+
         Returns
         -------
         pyvista.DataSet
@@ -2490,6 +2493,9 @@ class DataSetFilters:
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
 
+        **kwargs : dict, optional
+            Depreciated keyword argument ``pass_cell_arrays``.
+
         Returns
         -------
         pyvista.DataSet
@@ -2516,6 +2522,9 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        **kwargs : dict, optional
+            Depreciated keyword argument ``pass_point_arrays``.
 
         Returns
         -------
@@ -2580,6 +2589,9 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        **kwargs : dict, optional
+            Depreciated keyword argument ``pass_point_arrays``.
 
         Returns
         -------
@@ -2823,6 +2835,10 @@ class DataSetFilters:
             Prototype cell locator to perform the ``FindCell()``
             operation.  This requires VTK 9.0.0 or newer.
 
+        **kwargs : dict, optional
+            Depreciated keyword arguments ``pass_cell_arrays`` and
+            ``pass_point_arrays``.
+
         Returns
         -------
         pyvista.DataSet
@@ -2915,6 +2931,10 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        **kwargs : dict, optional
+            Depreciated keyword arguments ``pass_cell_arrays`` and
+            ``pass_point_arrays``.
 
         Returns
         -------
@@ -3029,6 +3049,10 @@ class DataSetFilters:
 
         progress_bar : bool, optional
             Display a progress bar to indicate progress.
+
+        **kwargs : dict, optional
+            Depreciated keyword arguments ``pass_cell_arrays`` and
+            ``pass_point_arrays``.
 
         Returns
         -------

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2456,6 +2456,15 @@ class DataSetFilters:
         >>> surf.plot(scalars='Area')
 
         """
+        if pass_cell_data is None:
+            pass_cell_data = False
+            warnings.warn(
+                'The default value of the ``pass_cell_data`` keyword argument will change in ' 
+                'a future version to ``True`` to match the behavior of VTK. We recommend ' 
+                'passing the keyword explicitly to prevent future surprises.',
+                PyVistaFutureWarning
+            )
+
         alg = _vtk.vtkCellDataToPointData()
         alg.SetInputDataObject(self)
         alg.SetPassCellData(pass_cell_data)
@@ -2540,6 +2549,15 @@ class DataSetFilters:
         >>> sphere.plot()
 
         """
+        if pass_point_data is None:
+            pass_point_data = False
+            warnings.warn(
+                'The default value of the ``pass_point_data`` keyword argument will change in ' 
+                'a future version to ``True`` to match the behavior of VTK. We recommend ' 
+                'passing the keyword explicitly to prevent future surprises.',
+                PyVistaFutureWarning
+            )
+
         alg = _vtk.vtkPointDataToCellData()
         alg.SetInputDataObject(self)
         alg.SetPassPointData(pass_point_data)

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2768,8 +2768,8 @@ class DataSetFilters:
         self,
         points,
         tolerance=None,
-        pass_cell_arrays=True,
-        pass_point_arrays=True,
+        pass_cell_data=True,
+        pass_point_data=True,
         categorical=False,
         progress_bar=False,
         locator=None,
@@ -2789,10 +2789,10 @@ class DataSetFilters:
             in a cell of the input.  If not given, tolerance is
             automatically generated.
 
-        pass_cell_arrays : bool, optional
+        pass_cell_data : bool, optional
             Preserve source mesh's original cell data arrays.
 
-        pass_point_arrays : bool, optional
+        pass_point_data : bool, optional
             Preserve source mesh's original point data arrays.
 
         categorical : bool, optional
@@ -2830,8 +2830,8 @@ class DataSetFilters:
         alg = _vtk.vtkProbeFilter()
         alg.SetInputData(points)
         alg.SetSourceData(self)
-        alg.SetPassCellArrays(pass_cell_arrays)
-        alg.SetPassPointArrays(pass_point_arrays)
+        alg.SetPassCellArrays(pass_cell_data)
+        alg.SetPassPointArrays(pass_point_data)
         alg.SetCategoricalData(categorical)
 
         if tolerance is not None:
@@ -2851,7 +2851,7 @@ class DataSetFilters:
         self,
         target,
         tolerance=None,
-        pass_cell_arrays=True,
+        pass_cell_data=True,
         pass_point_data=True,
         categorical=False,
         progress_bar=False,
@@ -2871,7 +2871,7 @@ class DataSetFilters:
             in a cell of the input.  If not given, tolerance is
             automatically generated.
 
-        pass_cell_arrays : bool, optional
+        pass_cell_data : bool, optional
             Preserve source mesh's original cell data arrays.
 
         pass_point_data : bool, optional
@@ -2910,7 +2910,7 @@ class DataSetFilters:
         alg.SetInputData(self)  # Set the Input data (actually the source i.e. where to sample from)
         # Set the Source data (actually the target, i.e. where to sample to)
         alg.SetSourceData(target)
-        alg.SetPassCellArrays(pass_cell_arrays)
+        alg.SetPassCellArrays(pass_cell_data)
         alg.SetPassPointArrays(pass_point_data)
         alg.SetCategoricalData(categorical)
         if tolerance is not None:

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -21,7 +21,7 @@ from pyvista.utilities import (
     wrap,
 )
 from pyvista.utilities.cells import numpy_to_idarr
-from pyvista.utilities.misc import PyVistaFutureWarning
+from pyvista.utilities.misc import PyVistaDeprecationWarning
 
 
 @abstract_class
@@ -2456,11 +2456,11 @@ class DataSetFilters:
         >>> surf.plot(scalars='Area')
 
         """
-        if pass_cell_data is False and 'pass_cell_arrays' in kwargs:
+        if pass_cell_data is False and 'pass_cell_arrays' in kwargs:  # pragma: no cover
             pass_cell_data = kwargs.pop('pass_cell_arrays')
             warnings.warn(
                 'Use of `pass_cell_arrays` is deprecated. Use `pass_cell_data` instead.',
-                PyVistaFutureWarning
+                PyVistaDeprecationWarning,
             )
         assert_empty_kwargs(**kwargs)
         alg = _vtk.vtkCellDataToPointData()
@@ -2547,11 +2547,11 @@ class DataSetFilters:
         >>> sphere.plot()
 
         """
-        if pass_point_data is False and 'pass_point_arrays' in kwargs:
+        if pass_point_data is False and 'pass_point_arrays' in kwargs:  # pragma: no cover
             pass_point_data = kwargs.pop('pass_point_arrays')
             warnings.warn(
                 'Use of `pass_point_arrays` is deprecated. Use `pass_point_data` instead.',
-                PyVistaFutureWarning
+                PyVistaDeprecationWarning,
             )
         assert_empty_kwargs(**kwargs)
         alg = _vtk.vtkPointDataToCellData()
@@ -2788,7 +2788,7 @@ class DataSetFilters:
         categorical=False,
         progress_bar=False,
         locator=None,
-        **kwargs
+        **kwargs,
     ):
         """Sample data values at specified point locations.
 
@@ -2841,17 +2841,17 @@ class DataSetFilters:
         True
 
         """
-        if pass_cell_data is True and 'pass_cell_arrays' in kwargs:
+        if pass_cell_data is True and 'pass_cell_arrays' in kwargs:  # pragma: no cover
             pass_cell_data = kwargs.pop('pass_cell_arrays')
             warnings.warn(
                 'Use of `pass_cell_arrays` is deprecated. Use `pass_cell_data` instead.',
-                PyVistaFutureWarning
+                PyVistaDeprecationWarning,
             )
-        if pass_point_data is True and 'pass_point_arrays' in kwargs:
+        if pass_point_data is True and 'pass_point_arrays' in kwargs:  # pragma: no cover
             pass_point_data = kwargs.pop('pass_point_arrays')
             warnings.warn(
                 'Use of `pass_point_arrays` is deprecated. Use `pass_point_data` instead.',
-                PyVistaFutureWarning
+                PyVistaDeprecationWarning,
             )
         assert_empty_kwargs(**kwargs)
 
@@ -2885,7 +2885,7 @@ class DataSetFilters:
         pass_point_data=True,
         categorical=False,
         progress_bar=False,
-        **kwargs
+        **kwargs,
     ):
         """Resample array data from a passed mesh onto this mesh.
 
@@ -2935,17 +2935,17 @@ class DataSetFilters:
         See :ref:`resampling_example` for more examples using this filter.
 
         """
-        if pass_cell_data is True and 'pass_cell_arrays' in kwargs:
+        if pass_cell_data is True and 'pass_cell_arrays' in kwargs:  # pragma: no cover
             pass_cell_data = kwargs.pop('pass_cell_arrays')
             warnings.warn(
                 'Use of `pass_cell_arrays` is deprecated. Use `pass_cell_data` instead.',
-                PyVistaFutureWarning
+                PyVistaDeprecationWarning,
             )
-        if pass_point_data is True and 'pass_point_arrays' in kwargs:
+        if pass_point_data is True and 'pass_point_arrays' in kwargs:  # pragma: no cover
             pass_point_data = kwargs.pop('pass_point_arrays')
             warnings.warn(
                 'Use of `pass_point_arrays` is deprecated. Use `pass_point_data` instead.',
-                PyVistaFutureWarning
+                PyVistaDeprecationWarning,
             )
         assert_empty_kwargs(**kwargs)
         if not pyvista.is_pyvista_dataset(target):
@@ -2974,7 +2974,7 @@ class DataSetFilters:
         pass_cell_data=True,
         pass_point_data=True,
         progress_bar=False,
-        **kwargs
+        **kwargs,
     ):
         """Interpolate values onto this mesh from a given dataset.
 
@@ -3061,17 +3061,17 @@ class DataSetFilters:
         if not pyvista.is_pyvista_dataset(target):
             raise TypeError('`target` must be a PyVista mesh type.')
 
-        if pass_cell_data is True and 'pass_cell_arrays' in kwargs:
+        if pass_cell_data is True and 'pass_cell_arrays' in kwargs:  # pragma: no cover
             pass_cell_data = kwargs.pop('pass_cell_arrays')
             warnings.warn(
                 'Use of `pass_cell_arrays` is deprecated. Use `pass_cell_data` instead.',
-                PyVistaFutureWarning
+                PyVistaDeprecationWarning,
             )
-        if pass_point_data is True and 'pass_point_arrays' in kwargs:
+        if pass_point_data is True and 'pass_point_arrays' in kwargs:  # pragma: no cover
             pass_point_data = kwargs.pop('pass_point_arrays')
             warnings.warn(
                 'Use of `pass_point_arrays` is deprecated. Use `pass_point_data` instead.',
-                PyVistaFutureWarning
+                PyVistaDeprecationWarning,
             )
         assert_empty_kwargs(**kwargs)
 
@@ -5462,7 +5462,7 @@ class DataSetFilters:
 def _set_threshold_limit(alg, value, invert):
     """Set vtkThreshold limit.
 
-    Addresses VTK API deprication as pointed out in
+    Addresses VTK API deprecation as pointed out in
     https://github.com/pyvista/pyvista/issues/2850
 
     """


### PR DESCRIPTION
This RP only rename the parameters `pass_cell_arrays` to `pass_cell_data` and `pass_point_arrrays` to `pass_point_data` in methods of `DataSetFilters`.