### PR TITLE
Remove pip cache in docker-package.yml

### DIFF
--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -37,7 +37,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
-          cache: 'pip'
 
       - name: Create PyVista package
         run: |


### PR DESCRIPTION
Our CI regularly fails on the docker build step due to:
```
Cache folder path is retrieved for pip but doesn't exist on disk: /home/runner/.cache/pip
```
I've yet to see the cache hit and it's not worth the possibility of the docker step failing on main. Let's remove this.