### PR TITLE
Specify optional parameters in mapper.py and plotting.py

### DIFF
--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -471,7 +471,7 @@ class DataSetMapper(_vtk.vtkDataSetMapper, _BaseMapper):
             than zero are mapped to the smallest representable
             positive float.
 
-        nan_color : color_like
+        nan_color : color_like, optional
             The color to use for all ``NaN`` values in the plotted
             scalar array.
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -5894,11 +5894,11 @@ class Plotter(BasePlotter):
             screenshot in a separate call to ``show()`` or
             :func:`Plotter.screenshot`.
 
-        return_img : bool
+        return_img : bool, default: False
             Returns a numpy array representing the last image along
             with the camera position.
 
-        cpos : list(tuple(floats))
+        cpos : list(tuple(floats)), optional
             The camera position.  You can also set this with
             :attr:`Plotter.camera_position`.
 
@@ -6220,7 +6220,7 @@ class Plotter(BasePlotter):
 
         Parameters
         ----------
-        bounds : length 6 sequence
+        bounds : length 6 sequence, default: (-1.0, 1.0, -1.0, 1.0, -1.0, 1.0)
             Specify the bounds in the format of:
 
             - ``(xmin, xmax, ymin, ymax, zmin, zmax)``


### PR DESCRIPTION
### Overview

Optional parameters in `mapper.py` and `plotting.py` as listed in #3347 are specified in docstring.

### Details

- "nan_color" in `set_scalars()` in `mapper.py`
- "bounds" in `add_cursor()` in `plotting.py`
- "return_img" in `show()` in `plotting.py`
- "cpos" in `show()` in `plotting.py`

