### PR TITLE
Add constrained triangulation example

### DIFF
--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2489,7 +2489,7 @@ class PolyDataFilters(DataSetFilters):
         >>> circ1 = pv.Polygon(center=(-2, -3, 0), n_sides=30, radius=1)
         >>> comb = circ0 + circ1 + squar
         >>> tess = comb.delaunay_2d(edge_source=comb)
-        >>> tess.plot(cpos='xy')
+        >>> tess.plot(cpos='xy', show_edges=True)
 
         See :ref:`triangulated_surface` for more examples using this filter.
 

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2423,33 +2423,32 @@ class PolyDataFilters(DataSetFilters):
 
         Parameters
         ----------
-        tol : float, optional
+        tol : float, default: 1e-05
             Specify a tolerance to control discarding of closely
             spaced points. This tolerance is specified as a fraction
             of the diagonal length of the bounding box of the points.
-            Defaults to ``1e-05``.
 
-        alpha : float, optional
+        alpha : float, default: 0.0
             Specify alpha (or distance) value to control output of
             this filter. For a non-zero alpha value, only edges or
             triangles contained within a sphere centered at mesh
             vertices will be output. Otherwise, only triangles will be
-            output. Defaults to ``0.0``.
+            output.
 
-        offset : float, optional
+        offset : float, default: 1.0
             Specify a multiplier to control the size of the initial,
-            bounding Delaunay triangulation. Defaults to ``1.0``.
+            bounding Delaunay triangulation.
 
-        bound : bool, optional
+        bound : bool, default: False
             Boolean controls whether bounding triangulation points
             and associated triangles are included in the
             output. These are introduced as an initial triangulation
             to begin the triangulation process. This feature is nice
-            for debugging output. Default ``False``.
+            for debugging output.
 
-        inplace : bool, optional
+        inplace : bool, default: False
             If ``True``, overwrite this mesh with the triangulated
-            mesh. Default ``False``.
+            mesh.
 
         edge_source : pyvista.PolyData, optional
             Specify the source object used to specify constrained
@@ -2459,9 +2458,8 @@ class PolyDataFilters(DataSetFilters):
             (i.e. point ids are identical in the input and
             source).
 
-        progress_bar : bool, optional
-            Display a progress bar to indicate progress. Default
-            ``False``.
+        progress_bar : bool, default: False
+            Display a progress bar to indicate progress.
 
         Returns
         -------
@@ -2472,15 +2470,26 @@ class PolyDataFilters(DataSetFilters):
         --------
         First, generate 30 points on circle and plot them.
 
-        >>> import pyvista
-        >>> points = pyvista.Polygon(n_sides=30).points
-        >>> circle = pyvista.PolyData(points)
+        >>> import pyvista as pv
+        >>> points = pv.Polygon(n_sides=30).points
+        >>> circle = pv.PolyData(points)
         >>> circle.plot(show_edges=True, point_size=15)
 
         Use :func:`delaunay_2d` to fill the interior of the circle.
 
         >>> filled_circle = circle.delaunay_2d()
         >>> filled_circle.plot(show_edges=True, line_width=5)
+
+        Use the ``edge_source`` parameter to create a constrained delaunay
+        triangulation and plot it.
+
+        >>> squar = pv.Polygon(n_sides=4, radius=8, fill=False)
+        >>> squar = squar.rotate_z(45, inplace=False)
+        >>> circ0 = pv.Polygon(center=(2, 3, 0), n_sides=30, radius=1)
+        >>> circ1 = pv.Polygon(center=(-2, -3, 0), n_sides=30, radius=1)
+        >>> comb = circ0 + circ1 + squar
+        >>> tess = comb.delaunay_2d(edge_source=comb)
+        >>> tess.plot(cpos='xy')
 
         See :ref:`triangulated_surface` for more examples using this filter.
 


### PR DESCRIPTION
The docstring of the `delaunay_2d` filter is missing a constrained tesselation example.

```py
import pyvista as pv

squar = pv.Polygon(n_sides=4, radius=8, fill=False).rotate_z(45, inplace=False)
circ0 = pv.Polygon(center=(2, 3, 0), n_sides=30, radius=1)
circ1 = pv.Polygon(center=(-2, -3, 0), n_sides=30, radius=1)
comb = circ0 + circ1 + squar
tess = comb.delaunay_2d(edge_source=comb)
tess.plot(cpos='xy')
```

![tmp](https://user-images.githubusercontent.com/11981631/195188321-443bc1c9-d4e6-40ba-b2c9-d979f3367b95.png)

---

As a bonus, converts `optional` to `default` in the docstring of this method.
