### PR TITLE
line to include PolyData Normals uncommented (line 362 in ./plotting/…

### DIFF
--- a/pyvista/plotting/export_vtkjs.py
+++ b/pyvista/plotting/export_vtkjs.py
@@ -359,7 +359,7 @@ def dump_poly_data(dataset_dir, data_dir, dataset, color_array_info, root=None, 
 
     # PointData TCoords
     dump_t_coords(dataset_dir, data_dir, dataset, container, compress)
-    # dump_normals(dataset_dir, data_dir, dataset, container, compress)
+    dump_normals(dataset_dir, data_dir, dataset, container, compress)
 
     return root
 


### PR DESCRIPTION
…export_vtkjs.py)

### Overview

Line 362 from ./plotting/export_vtkjs.py was uncommented to include normals. 

This resolves issue #3339 : export_vtkjs Does not Include PolyData Normals.
