### PR TITLE
fix dataset mapper copy docstring

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -435,6 +435,8 @@ html_theme_options = {
     "google_analytics_id": "UA-140243896-1",
     "show_prev_next": False,
     "github_url": "https://github.com/pyvista/pyvista",
+    "collapse_navigation": True,
+    "use_edit_page_button": True,
     "icon_links": [
         {
             "name": "Slack Community",

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -32,6 +32,11 @@ class _BaseMapper(_vtk.vtkAbstractMapper):
     def copy(self) -> '_BaseMapper':
         """Create a copy of this mapper.
 
+        Returns
+        -------
+        pyvista.DataSetMapper
+            A copy of this dataset mapper.
+
         Examples
         --------
         >>> import pyvista as pv


### PR DESCRIPTION
Docs on the main branch are failing due to:

```
2022-10-12T17:21:22.0177142Z executing what-is-a-mesh
2022-10-12T17:21:26.3238930Z 
2022-10-12T17:21:26.3250978Z WARNING: [numpydoc] Validation warnings while processing docstring for 'pyvista.CompositePolyDataMapper.copy':
2022-10-12T17:21:26.3252253Z   RT01: No Returns section found
2022-10-12T17:21:26.3253419Z 
2022-10-12T17:21:26.3254242Z WARNING: [numpydoc] Validation warnings while processing docstring for 'pyvista.CompositePolyDataMapper.copy':
2022-10-12T17:21:26.3254763Z   RT01: No Returns section found
2022-10-12T17:21:26.3257185Z 
2022-10-12T17:21:26.3257519Z looking for now-outdated files... none found
2022-10-12T17:21:26.3303053Z WARNING: [numpydoc] Validation warnings while processing docstring for 'pyvista.DataSetMapper.copy':
2022-10-12T17:21:26.3305764Z   RT01: No Returns section found
2022-10-12T17:21:26.3308057Z 
2022-10-12T17:21:26.3310568Z WARNING: [numpydoc] Validation warnings while processing docstring for 'pyvista.DataSetMapper.copy':
2022-10-12T17:21:26.3313125Z   RT01: No Returns section found
```

This PR adds the needed documentation section, meaning our docs will finally build on `main` and get pushed to dev.pyvista.org, and our examples will cache again.

### Bonus

Adds an [Edit this Page](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/source-buttons.html#add-an-edit-this-page-button) button, which works great.

Collapses the navigation. This retains the behavior of #3410 (and performance) without messing up the sidebar.