### PR TITLE
Specify all optional parameters in #3347

### DIFF
--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -786,7 +786,7 @@ class MultiBlock(
 
         Parameters
         ----------
-        empty : bool
+        empty : bool, default=True
             Remove any meshes that are empty as well (have zero points).
 
         Examples

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -643,7 +643,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
             A ``pyvista_ndarray``, ``numpy.ndarray``, ``list``,
             ``tuple`` or scalar value.
 
-        name : str
+        name : str, default='scalars'
             Name to assign the scalars.
 
         deep_copy : bool, optional

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -86,7 +86,7 @@ class DataSetFilters:
 
         Parameters
         ----------
-        normal : tuple(float) or str
+        normal : tuple(float) or str, default='x'
             Length 3 tuple for the normal vector direction. Can also
             be specified as a string conventional direction such as
             ``'x'`` for ``(1,0,0)`` or ``'-x'`` for ``(-1,0,0)``, etc.
@@ -527,12 +527,12 @@ class DataSetFilters:
 
         Parameters
         ----------
-        normal : tuple(float) or str
+        normal : tuple(float) or str, default='x'
             Length 3 tuple for the normal vector direction. Can also be
             specified as a string conventional direction such as ``'x'`` for
             ``(1, 0, 0)`` or ``'-x'`` for ``(-1, 0, 0)``, etc.
 
-        origin : tuple(float)
+        origin : tuple(float), optional
             The center ``(x, y, z)`` coordinate of the plane on which
             the slice occurs.
 
@@ -695,7 +695,7 @@ class DataSetFilters:
         n : int, optional
             The number of slices to create.
 
-        axis : str or int
+        axis : str or int, default='x'
             The axis to generate the slices along. Perpendicular to the
             slices. Can be string name (``'x'``, ``'y'``, or ``'z'``) or
             axis index (``0``, ``1``, or ``2``).
@@ -948,7 +948,7 @@ class DataSetFilters:
             components to meet criteria.  'any' is when
             any component satisfies the criteria.
 
-        component : int
+        component : int, default=0
             When using ``component_mode='selected'``, this sets
             which component to threshold on.  Default is ``0``.
 
@@ -1756,7 +1756,7 @@ class DataSetFilters:
 
         Parameters
         ----------
-        center : tuple(float)
+        center : tuple(float), optional
             Length 3 iterable of floats defining the XYZ coordinates of the
             center of the sphere. If ``None``, this will be automatically
             calculated.
@@ -1870,7 +1870,7 @@ class DataSetFilters:
 
         Parameters
         ----------
-        vertex : bool
+        vertex : bool, default=True
             Enable or disable the generation of vertex cells.
 
         progress_bar : bool, optional
@@ -2139,7 +2139,7 @@ class DataSetFilters:
 
         Parameters
         ----------
-        largest : bool
+        largest : bool, default=False
             Extract the largest connected part of the mesh.
 
         progress_bar : bool, optional
@@ -3640,7 +3640,7 @@ class DataSetFilters:
 
         Parameters
         ----------
-        target_reduction : float
+        target_reduction : float, default=0.5
             Fraction of the original mesh to remove. Default is ``0.5``
             TargetReduction is set to ``0.9``, this filter will try to reduce
             the data set to 10% of its original size and will remove 90%
@@ -4584,7 +4584,7 @@ class DataSetFilters:
 
         Parameters
         ----------
-        grid : vtk.UnstructuredGrid or list of vtk.UnstructuredGrids
+        grid : vtk.UnstructuredGrid or list of vtk.UnstructuredGrids, optional
             Grids to merge to this grid.
 
         merge_points : bool, optional
@@ -4720,10 +4720,10 @@ class DataSetFilters:
 
         Parameters
         ----------
-        quality_measure : str
+        quality_measure : str, default='scaled_jacobian'
             The cell quality measure to use.
 
-        null_value : float
+        null_value : float, default=-1.0
             Float value for undefined quality. Undefined quality are qualities
             that could be addressed by this filter but is not well defined for
             the particular geometry of cell in question, e.g. a volume query

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -1011,7 +1011,7 @@ class PolyDataFilters(DataSetFilters):
 
         Parameters
         ----------
-        radius : float
+        radius : float, optional
             Minimum tube radius (minimum because the tube radius may
             vary).
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1707,7 +1707,7 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
 
         Parameters
         ----------
-        deep : bool
+        deep : bool, default=False
             When ``True``, makes a copy of the points array.  Default
             ``False``.  Cells and cell types are always copied.
 

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -1374,7 +1374,7 @@ class _Chart(DocSubs):
 
         Parameters
         ----------
-        off_screen : bool
+        off_screen : bool, optional
             Plots off screen when ``True``.  Helpful for saving screenshots
             without a window popping up.  Defaults to active theme setting in
             :attr:`pyvista.global_theme.full_screen
@@ -4129,7 +4129,7 @@ class ChartMPL(_vtk.vtkImageItem, _Chart):
 
     Parameters
     ----------
-    figure : matplotlib.figure.Figure
+    figure : matplotlib.figure.Figure, optional
         The matplotlib figure to draw.
 
     size : list or tuple, optional

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -404,12 +404,12 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         Parameters
         ----------
-        number_of_peels : int
+        number_of_peels : int, optional
             The maximum number of peeling layers. Initial value is 4
             and is set in the ``pyvista.global_theme``. A special value of
             0 means no maximum limit.  It has to be a positive value.
 
-        occlusion_ratio : float
+        occlusion_ratio : float, optional
             The threshold under which the depth peeling algorithm
             stops to iterate over peel layers. This is the ratio of
             the number of pixels that have been touched by the last
@@ -446,7 +446,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         Parameters
         ----------
-        aa_type : str
+        aa_type : str, default='fxaa'
             Anti-aliasing type. Either ``"fxaa"`` or ``"ssaa"``.
 
         """
@@ -1115,7 +1115,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         Parameters
         ----------
-        mesh : pyvista.DataSet or pyvista.MultiBlock
+        mesh : pyvista.DataSet or pyvista.MultiBlock, optional
             Input mesh to draw bounds axes around.
 
         bounds : list or tuple, optional
@@ -1556,7 +1556,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         reset_camera : bool, optional
             Reset camera position when ``True`` to include all actors.
 
-        outline : bool
+        outline : bool, default=True
             Default is ``True``. when ``False``, a box with faces is
             shown with the specified culling.
 
@@ -2243,7 +2243,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         Parameters
         ----------
-        negative : bool
+        negative : bool, default=False
             View from the opposite direction.
 
         Returns
@@ -2297,9 +2297,9 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         Parameters
         ----------
-        render : bool
+        render : bool, default=True
             Trigger a render after resetting the camera.
-        bounds : iterable(int)
+        bounds : iterable(int), optional
             Automatically set up the camera based on a specified bounding box
             ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
 

--- a/pyvista/utilities/common.py
+++ b/pyvista/utilities/common.py
@@ -104,14 +104,14 @@ def sample_function(
         Implicit function to evaluate.  For example, the function
         generated from :func:`pyvista.perlin_noise`.
 
-    bounds : length 6 sequence
+    bounds : length 6 sequence, default=(-1.0, 1.0, -1.0, 1.0, -1.0, 1.0)
         Specify the bounds in the format of:
 
         - ``(xmin, xmax, ymin, ymax, zmin, zmax)``
 
         Defaults to ``(-1.0, 1.0, -1.0, 1.0, -1.0, 1.0)``.
 
-    dim : length 3 sequence
+    dim : length 3 sequence, default=(50, 50, 50)
         Dimensions of the data on which to sample in the format of
         ``(xdim, ydim, zdim)``.  Defaults to ``(50, 50, 50)``.
 

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -139,10 +139,10 @@ def CylinderStructured(
     height : float, optional
         Height of the cylinder along its Z-axis.
 
-    center : sequence
+    center : sequence, default=(0.0, 0.0, 0.0)
         Location of the centroid in ``[x, y, z]``.
 
-    direction : sequence
+    direction : sequence, default=(1.0, 0.0, 0.0)
         Direction cylinder Z-axis in ``[x, y, z]``.
 
     theta_resolution : int, optional
@@ -373,22 +373,22 @@ def Plane(
 
     Parameters
     ----------
-    center : list or tuple or np.ndarray
+    center : list or tuple or np.ndarray, default=(0, 0, 0)
         Location of the centroid in ``[x, y, z]``.
 
-    direction : list or tuple or np.ndarray
+    direction : list or tuple or np.ndarray, default=(0, 0, 1)
         Direction of the plane's normal in ``[x, y, z]``.
 
-    i_size : float
+    i_size : float, default=1
         Size of the plane in the i direction.
 
-    j_size : float
+    j_size : float, default=1
         Size of the plane in the j direction.
 
-    i_resolution : int
+    i_resolution : int, default=10
         Number of points on the plane in the i direction.
 
-    j_resolution : int
+    j_resolution : int, default=10
         Number of points on the plane in the j direction.
 
     Returns
@@ -801,7 +801,7 @@ def Disc(center=(0.0, 0.0, 0.0), inner=0.25, outer=0.5, normal=(0, 0, 1), r_res=
 
     Parameters
     ----------
-    center : iterable
+    center : iterable, default=(0.0, 0.0, 0.0)
         Center in ``[x, y, z]``. Middle of the axis of the disc.
 
     inner : float, optional
@@ -810,7 +810,7 @@ def Disc(center=(0.0, 0.0, 0.0), inner=0.25, outer=0.5, normal=(0, 0, 1), r_res=
     outer : float, optional
         The outer radius.
 
-    normal : iterable
+    normal : iterable, default=(0, 0, 1)
         Direction vector in ``[x, y, z]``. Orientation vector of the disc.
 
     r_res : int, optional


### PR DESCRIPTION
### Overview

All optional parameters in #3347 are specified in docstring. This should resolve #3347 

### Details
 
Per discussion in #3444 `optional` is used when the default value is `None` and `default=...` is specified when the default value is other than `None`.

