### PR TITLE
Set stereo type before turning on stereo

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1852,8 +1852,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         """
         if hasattr(self, 'ren_win'):
-            self.ren_win.StereoRenderOn()
             self.ren_win.SetStereoTypeToAnaglyph()
+            self.ren_win.StereoRenderOn()
 
     def disable_stereo_render(self):
         """Disable stereo rendering.

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1835,7 +1835,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.iren.enable_rubber_band_2d_style()
 
     def enable_stereo_render(self):
-        """Enable stereo rendering.
+        """Enable anaglyph stereo rendering.
 
         Disable this with :func:`disable_stereo_render
         <BasePlotter.disable_stereo_render>`

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1856,7 +1856,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             self.ren_win.StereoRenderOn()
 
     def disable_stereo_render(self):
-        """Disable stereo rendering.
+        """Disable anaglyph stereo rendering.
 
         Enable again with :func:`enable_stereo_render
         <BasePlotter.enable_stereo_render>`


### PR DESCRIPTION
According [to a question on Stack Overflow](https://stackoverflow.com/questions/74054264/how-can-i-show-the-3d-imaging-render-with-stereo) we might end up tripping a spurious VTK warning about trying to use an unsupported kind of stereo type. Setting the stereo type to anaglyph (the only mode we're supporting right now) before turning on stereo should make this warning go away.

As I noted in my answer on that page, I don't see this on my linux system, but it's possible that some VTK version and/or some platform-specific render window subclass has this behaviour.