### PR TITLE
Move VerifyImageCache to be in testing module

### DIFF
--- a/pyvista/testing/__init__.py
+++ b/pyvista/testing/__init__.py
@@ -1,0 +1,1 @@
+"""Testing modules."""

--- a/pyvista/testing/regression.py
+++ b/pyvista/testing/regression.py
@@ -1,0 +1,125 @@
+"""Regression testing."""
+
+import os
+import re
+import warnings
+
+import pyvista
+
+
+class VerifyImageCache:
+    """Control image caching for testing.
+
+    Image cache files are names according to ``test_name``.
+    Multiple calls to an instance of this class will append
+    `_X` to the name after the first one.  That is, files
+    ``{test_name}``, ``{test_name}_1``, and ``{test_name}_2``
+    will be saved if called 3 times.
+
+    Parameters
+    ----------
+    test_name : str
+        Name of test to save.  Sets name of image cache file.
+
+    """
+
+    reset_image_cache = False
+    ignore_image_cache = False
+    fail_extra_image_cache = False
+
+    def __init__(
+        self,
+        test_name,
+        cache_dir,
+        *,
+        error_value=500,
+        warning_value=200,
+        var_error_value=1000,
+        var_warning_value=1000,
+        high_variance_tests=None,
+        skip_tests=None,
+    ):
+        """Init VerifyImageCache."""
+        self.test_name = test_name
+
+        self.cache_dir = cache_dir
+
+        if not os.path.isdir(self.cache_dir):
+            os.mkdir(self.cache_dir)
+
+        self.error_value = error_value
+        self.warning_value = warning_value
+
+        self.var_error_value = var_error_value
+        self.var_warning_value = var_warning_value
+
+        if high_variance_tests is not None:
+            self.high_variance_tester = re.compile("|".join(high_variance_tests))
+        else:
+            self.high_variance_tester = None
+
+        if skip_tests is not None:
+            self.skip_tester = re.compile("|".join(skip_tests))
+        else:
+            self.skip_tester = None
+
+        self.skip = False
+        self.n_calls = 0
+
+    def __call__(self, plotter):
+        """Either store or validate an image.
+
+        Parameters
+        ----------
+        plotter : pyvista.Plotter
+            The Plotter object that is being closed.
+
+        """
+        if self.skip:
+            return
+
+        if self.ignore_image_cache:
+            return
+
+        if self.skip_tester is not None and self.skip_tester.search(self.test_name):
+            return
+
+        if self.n_calls > 0:
+            test_name = f"{self.test_name}_{self.n_calls}"
+        else:
+            test_name = self.test_name
+        self.n_calls += 1
+
+        if self.high_variance_tester is not None and self.high_variance_tester.search(
+            self.test_name
+        ):
+            allowed_error = self.var_error_value
+            allowed_warning = self.var_warning_value
+        else:
+            allowed_error = self.error_value
+            allowed_warning = self.warning_value
+
+        # cached image name
+        image_filename = os.path.join(self.cache_dir, test_name[5:] + '.png')
+
+        if not os.path.isfile(image_filename) and self.fail_extra_image_cache:
+            raise RuntimeError(f"{image_filename} does not exist in image cache")
+        # simply save the last screenshot if it doesn't exist or the cache
+        # is being reset.
+        if self.reset_image_cache or not os.path.isfile(image_filename):
+            return plotter.screenshot(image_filename)
+
+        # otherwise, compare with the existing cached image
+        error = pyvista.compare_images(image_filename, plotter)
+        if error > allowed_error:
+            raise RuntimeError(
+                f'{test_name} Exceeded image regression error of '
+                f'{allowed_error} with an image error of '
+                f'{error}'
+            )
+        if error > allowed_warning:
+            warnings.warn(
+                f'{test_name} Exceeded image regression warning of '
+                f'{allowed_warning} with an image error of '
+                f'{error}'
+            )

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -10,7 +10,6 @@ import pathlib
 import platform
 import re
 import time
-import warnings
 
 from PIL import Image
 import imageio
@@ -24,6 +23,7 @@ from pyvista._vtk import VTK9
 from pyvista.core.errors import DeprecationError
 from pyvista.plotting import system_supports_plotting
 from pyvista.plotting.plotting import SUPPORTED_FORMATS
+from pyvista.testing.regression import VerifyImageCache
 from pyvista.utilities.misc import can_create_mpl_figure
 
 # skip all tests if unable to render
@@ -158,128 +158,6 @@ def get_cmd_opt(pytestconfig):
     VerifyImageCache.fail_extra_image_cache = pytestconfig.getoption('fail_extra_image_cache')
 
 
-class VerifyImageCache:
-    """Control image caching for testing.
-
-    Image cache files are names according to ``test_name``.
-    Multiple calls to an instance of this class will append
-    `_X` to the name after the first one.  That is, files
-    ``{test_name}``, ``{test_name}_1``, and ``{test_name}_2``
-    will be saved if called 3 times.
-
-    Parameters
-    ----------
-    test_name : str
-        Name of test to save.  Sets name of image cache file.
-
-    """
-
-    reset_image_cache = False
-    ignore_image_cache = False
-    fail_extra_image_cache = False
-
-    def __init__(
-        self,
-        test_name,
-        *,
-        cache_dir=None,
-        error_value=500,
-        warning_value=200,
-        var_error_value=1000,
-        var_warning_value=1000,
-        high_variance_tests=None,
-        skip_tests=None,
-    ):
-        self.test_name = test_name
-
-        if cache_dir is None:
-            # Reset image cache with new images
-            this_path = pathlib.Path(__file__).parent.absolute()
-            self.cache_dir = os.path.join(this_path, 'image_cache')
-        else:
-            self.cache_dir = cache_dir
-
-        if not os.path.isdir(self.cache_dir):
-            os.mkdir(self.cache_dir)
-
-        self.error_value = error_value
-        self.warning_value = warning_value
-
-        self.var_error_value = var_error_value
-        self.var_warning_value = var_warning_value
-
-        if high_variance_tests is not None:
-            self.high_variance_tester = re.compile("|".join(high_variance_tests))
-        else:
-            self.high_variance_tester = None
-
-        if skip_tests is not None:
-            self.skip_tester = re.compile("|".join(skip_tests))
-        else:
-            self.skip_tester = None
-
-        self.skip = False
-        self.n_calls = 0
-
-    def __call__(self, plotter):
-        """Either store or validate an image.
-
-        Parameters
-        ----------
-        plotter : pyvista.Plotter
-            The Plotter object that is being closed.
-
-        """
-        if self.skip:
-            return
-
-        if self.ignore_image_cache:
-            return
-
-        if self.skip_tester is not None and self.skip_tester.search(self.test_name):
-            return
-
-        if self.n_calls > 0:
-            test_name = f"{self.test_name}_{self.n_calls}"
-        else:
-            test_name = self.test_name
-        self.n_calls += 1
-
-        if self.high_variance_tester is not None and self.high_variance_tester.search(
-            self.test_name
-        ):
-            allowed_error = self.var_error_value
-            allowed_warning = self.var_warning_value
-        else:
-            allowed_error = self.error_value
-            allowed_warning = self.warning_value
-
-        # cached image name
-        image_filename = os.path.join(self.cache_dir, test_name[5:] + '.png')
-
-        if not os.path.isfile(image_filename) and self.fail_extra_image_cache:
-            raise RuntimeError(f"{image_filename} does not exist in image cache")
-        # simply save the last screenshot if it doesn't exist or the cache
-        # is being reset.
-        if self.reset_image_cache or not os.path.isfile(image_filename):
-            return plotter.screenshot(image_filename)
-
-        # otherwise, compare with the existing cached image
-        error = pyvista.compare_images(image_filename, plotter)
-        if error > allowed_error:
-            raise RuntimeError(
-                f'{test_name} Exceeded image regression error of '
-                f'{allowed_error} with an image error of '
-                f'{error}'
-            )
-        if error > allowed_warning:
-            warnings.warn(
-                f'{test_name} Exceeded image regression warning of '
-                f'{allowed_warning} with an image error of '
-                f'{error}'
-            )
-
-
 @pytest.fixture(autouse=True)
 def verify_image_cache(request):
     skip_tests = None
@@ -296,7 +174,10 @@ def verify_image_cache(request):
         VerifyImageCache.ignore_image_cache = True
 
     verify_image_cache = VerifyImageCache(
-        request.node.name, high_variance_tests=HIGH_VARIANCE_TESTS, skip_tests=skip_tests
+        request.node.name,
+        os.path.join(THIS_PATH, "image_cache"),
+        high_variance_tests=HIGH_VARIANCE_TESTS,
+        skip_tests=skip_tests,
     )
     pyvista.global_theme.before_close_callback = verify_image_cache
     return verify_image_cache

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -209,12 +209,12 @@ class VerifyImageCache:
         self.var_warning_value = var_warning_value
 
         if high_variance_tests is not None:
-            self.high_variance_tester = re.compile(r"|".join(high_variance_tests))
+            self.high_variance_tester = re.compile("|".join(high_variance_tests))
         else:
             self.high_variance_tester = None
 
         if skip_tests is not None:
-            self.skip_tester = re.compile(r"|".join(skip_tests))
+            self.skip_tester = re.compile("|".join(skip_tests))
         else:
             self.skip_tester = None
 


### PR DESCRIPTION
### Overview

This PR is currently a work in progress, more than usual anyway. It is helpful to have the tests run on the CI during development to see if there are any failures related to other OS or vtk versions.  

The aim is to create a pytest plugin that is used internally as well as usable by downstream libraries.


### Details

TODO:
- [x] Abstract out as much PyVista information from `VerifyImageCache` -> move into PyVista specific fixture.
- [x] Use regex for test classification (high variance and skipping)
- [ ] Create setters/getters for attributes like `skip` that are meant to be modified after instantiation.
- [ ] Better document behavior of the class docstring.
- [x] Move to `pytest.testing`.
- [ ] Add examples (maybe `doctest`-able?)
- [ ] Add tests
- [ ] Add to API documentation.
