### PR TITLE
Patch default scalars plotting edge case

### DIFF
--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -73,3 +73,6 @@ FLOAT_FORMAT = "{:.3e}"
 
 # Serialization format to be used when pickling `DataObject`
 PICKLE_FORMAT = 'xml'
+
+# Name used for unnamed scalars
+DEFAULT_SCALARS_NAME = 'Data'

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -409,12 +409,18 @@ class DataSetMapper(_vtk.vtkDataSetMapper, _BaseMapper):
 
         # Scalars interpolation approach
         if use_points:
-            if scalars_name not in self.dataset.point_data:
+            if (
+                scalars_name not in self.dataset.point_data
+                or scalars_name == pv.DEFAULT_SCALARS_NAME
+            ):
                 self.dataset.point_data.set_array(scalars, scalars_name, False)
             self.dataset.active_scalars_name = scalars_name
             self.scalar_map_mode = 'point'
         elif use_cells:
-            if scalars_name not in self.dataset.cell_data:
+            if (
+                scalars_name not in self.dataset.cell_data
+                or scalars_name == pv.DEFAULT_SCALARS_NAME
+            ):
                 self.dataset.cell_data.set_array(scalars, scalars_name, False)
             self.dataset.active_scalars_name = scalars_name
             self.scalar_map_mode = 'cell'

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -66,7 +66,6 @@ from .widgets import WidgetHelper
 SUPPORTED_FORMATS = [".png", ".jpeg", ".jpg", ".bmp", ".tif", ".tiff"]
 VERY_FIRST_RENDER = True  # windows plotter helper
 
-
 # EXPERIMENTAL: permit pyvista to kill the render window
 KILL_DISPLAY = platform.system() == 'Linux' and os.environ.get('PYVISTA_KILL_DISPLAY')
 if KILL_DISPLAY:  # pragma: no cover
@@ -3005,7 +3004,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         # Make sure scalars is a numpy array after this point
         original_scalar_name = None
-        scalars_name = 'Data'
+        scalars_name = pyvista.DEFAULT_SCALARS_NAME
         if isinstance(scalars, str):
             self.mapper.array_name = scalars
 


### PR DESCRIPTION
Ran into an edge case today where a dataset with default plotting scalars will not be overridden with new data. This is due to a check where we see if an array with scalars already exists in the dataset before adding it.

```py
import numpy as np
import pyvista as pv

mesh = pv.Sphere()
mesh['Data'] = np.zeros(mesh.n_points)
mesh.plot(scalars=range(mesh.n_points))
```
