### PR TITLE
Fix issues with cell picking

### DIFF
--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -392,6 +392,12 @@ class PickingHelper:
                     cids = pyvista.convert_array(selection_node.GetSelectionList())
                     actor = selection_node.GetProperties().Get(_vtk.vtkSelectionNode.PROP())
 
+                    # TODO: this is too hacky - find better way to avoid non-dataset actors
+                    if not actor.GetMapper() or not hasattr(
+                        actor.GetProperty(), 'GetRepresentation'
+                    ):
+                        continue
+
                     # if not a surface
                     if actor.GetProperty().GetRepresentation() != 2:  # pragma: no cover
                         logging.warning(

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -209,7 +209,6 @@ class PickingHelper:
 
     def enable_cell_picking(
         self,
-        mesh=None,
         callback=None,
         through=True,
         show=True,
@@ -228,9 +227,14 @@ class PickingHelper:
         ``self.picked_cells``. Also press ``"p"`` to pick a single
         cell under the mouse location.
 
-        When using ``through=False``, and multiple cells are being
-        picked, the picked cells in ````self.picked_cells`` will be a
-        :class:`MultiBlock` dataset for each mesh's selection.
+        All meshes in the scene are available for picking by default.
+        If you would like to only pick a single mesh in the scene,
+        use the ``pickable=False`` argument when adding the other
+        meshes to the scene.
+
+        When multiple meshes are being picked, the picked cells
+        in ````self.picked_cells`` will be a :class:`MultiBlock`
+        dataset for each mesh's selection.
 
         Uses last input mesh for input by default.
 
@@ -239,17 +243,12 @@ class PickingHelper:
            the mesh is displayed with a ``'surface'`` representation
            style (the default).
 
+        .. warning::
+            Cell picking can only be enabled for a single renderer
+            or subplot at a time.
+
         Parameters
         ----------
-        mesh : pyvista.DataSet, optional
-            Mesh to select cells from. When ``through`` is ``True``,
-            uses last input mesh by default. When ``through`` is
-            ``False``, all meshes in the scene are available for
-            picking and this argument is ignored. If you would like to
-            only pick a single mesh in the scene, use the
-            ``pickable=False`` argument when adding the other meshes
-            to the scene.
-
         callback : function, optional
             When input, calls this function after a selection is made.
             The picked_cells are input as the first parameter to this
@@ -257,8 +256,8 @@ class PickingHelper:
 
         through : bool, optional
             When ``True`` (default) the picker will select all cells
-            through the mesh. When ``False``, the picker will select
-            only visible cells on the mesh's surface.
+            through the mesh(es). When ``False``, the picker will select
+            only visible cells on the selected surface(s).
 
         show : bool, optional
             Show the selection interactively.
@@ -301,12 +300,6 @@ class PickingHelper:
         >>> _ = pl.enable_cell_picking(left_clicking=True)
 
         """
-        if mesh is None:
-            if not hasattr(self, 'mesh') or self.mesh is None:
-                raise AttributeError(
-                    'Input a mesh into the Plotter class first or or set it in this function'
-                )
-            mesh = self.mesh
         self_ = weakref.ref(self)
 
         # make sure to consistently use renderer
@@ -330,7 +323,7 @@ class PickingHelper:
                     renderer = self.renderers[index]
                     for actor in renderer._actors.values():
                         mapper = actor.GetMapper()
-                        if isinstance(mapper, _vtk.vtkDataSetMapper) and mapper.GetInput() == mesh:
+                        if isinstance(mapper, _vtk.vtkDataSetMapper):
                             loc = self_().renderers.index_to_loc(index)
                             self_().subplot(*loc)
                             break
@@ -364,12 +357,21 @@ class PickingHelper:
             return
 
         def through_pick_call_back(picker, event_id):
-            extract = _vtk.vtkExtractGeometry()
-            mesh.cell_data['orig_extract_id'] = np.arange(mesh.n_cells)
-            extract.SetInputData(mesh)
-            extract.SetImplicitFunction(picker.GetFrustum())
-            extract.Update()
-            self_().picked_cells = pyvista.wrap(extract.GetOutput())
+            picked = pyvista.MultiBlock()
+            for actor in renderer_().actors.values():
+                if actor.GetMapper() and actor.GetPickable():
+                    input_mesh = pyvista.wrap(actor.GetMapper().GetInputAsDataSet())
+                    input_mesh.cell_data['orig_extract_id'] = np.arange(input_mesh.n_cells)
+                    extract = _vtk.vtkExtractGeometry()
+                    extract.SetInputData(input_mesh)
+                    extract.SetImplicitFunction(picker.GetFrustum())
+                    extract.Update()
+                    picked.append(pyvista.wrap(extract.GetOutput()))
+
+            if len(picked) == 1:
+                self_().picked_cells = picked[0]
+            else:
+                self_().picked_cells = picked
             return end_pick_helper(picker, event_id)
 
         def visible_pick_call_back(picker, event_id):
@@ -395,7 +397,7 @@ class PickingHelper:
                         logging.warning(
                             "Display representations other than `surface` will result in incorrect results."
                         )
-                    smesh = actor.GetMapper().GetInputAsDataSet()
+                    smesh = pyvista.wrap(actor.GetMapper().GetInputAsDataSet())
                     smesh = smesh.copy()
                     smesh["original_cell_ids"] = np.arange(smesh.n_cells)
                     tri_smesh = smesh.extract_surface().triangulate()

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -137,7 +137,7 @@ class PickingHelper:
             self_ = weakref.ref(self)
             actor = picked.GetActor()
             if actor:
-                mesh = actor.GetMapper().GetInput()
+                mesh = actor.GetMapper().GetInputAsDataSet()
                 is_valid_selection = True
 
             if is_valid_selection:
@@ -154,7 +154,10 @@ class PickingHelper:
                     renderer = self.renderers[index]
                     for actor in renderer._actors.values():
                         mapper = actor.GetMapper()
-                        if isinstance(mapper, _vtk.vtkDataSetMapper) and mapper.GetInput() == mesh:
+                        if (
+                            isinstance(mapper, _vtk.vtkDataSetMapper)
+                            and mapper.GetInputAsDataSet() == mesh
+                        ):
                             loc = self_().renderers.index_to_loc(index)
                             self_().subplot(*loc)
                             break

--- a/tests/test_picking.py
+++ b/tests/test_picking.py
@@ -81,7 +81,7 @@ def test_multi_cell_picking(through):
     plotter.close()
 
     assert isinstance(plotter.picked_cells, pyvista.MultiBlock)
-    # Seletion should return 2 submeshes
+    # Selection should return 2 submeshes
     assert len(plotter.picked_cells) == 2
 
     merged = plotter.picked_cells.combine()

--- a/tests/test_picking.py
+++ b/tests/test_picking.py
@@ -1,4 +1,5 @@
 import pytest
+import vtk
 
 import pyvista
 from pyvista.plotting import system_supports_plotting
@@ -11,47 +12,85 @@ if not system_supports_plotting():
 
 
 @pytest.mark.needs_vtk9
-def test_cell_picking():
-    with pytest.raises(AttributeError, match="mesh"):
-        plotter = pyvista.Plotter()
-        plotter.enable_cell_picking(mesh=None)
-
+def test_single_cell_picking():
     sphere = pyvista.Sphere()
-    for through in (False, True):
-        plotter = pyvista.Plotter(
-            window_size=(100, 100),
-        )
+    width, height = 100, 100
 
-        def callback(*args, **kwargs):
-            pass
+    class PickCallback:
+        def __init__(self):
+            self.called = False
 
-        plotter.enable_cell_picking(
-            mesh=sphere,
-            start=True,
-            show=True,
-            callback=callback,
-            through=through,
-        )
-        plotter.add_mesh(sphere)
-        plotter.show(auto_close=False)  # must start renderer first
+        def __call__(self, *args, **kwargs):
+            self.called = True
 
-        # simulate the pick
-        renderer = plotter.renderer
-        picker = plotter.iren.get_picker()
-        picker.Pick(50, 50, 0, renderer)
+    plotter = pyvista.Plotter(
+        window_size=(width, height),
+    )
 
-        # pick nothing
-        picker.Pick(0, 0, 0, renderer)
+    callback = PickCallback()
+    plotter.enable_cell_picking(
+        start=False,
+        show=True,
+        callback=callback,
+        through=False,  # Single cell visible picking
+    )
+    plotter.add_mesh(sphere)
+    plotter.show(auto_close=False)  # must start renderer first
 
-        plotter.get_pick_position()
-        plotter.close()
+    width, height = plotter.window_size
+    plotter.iren._mouse_move(width // 2, height // 2)
+    plotter.iren._simulate_keypress('p')
 
-    # multiblock
-    plotter = pyvista.Plotter()
-    multi = pyvista.MultiBlock([sphere])
-    plotter.add_mesh(multi)
-    plotter.enable_cell_picking()
     plotter.close()
+
+    assert callback.called
+    assert isinstance(plotter.picked_cells, pyvista.UnstructuredGrid)
+    assert plotter.picked_cells.n_cells == 1
+
+
+@pytest.mark.needs_vtk9
+@pytest.mark.parametrize('through', [False, True])
+def test_multi_cell_picking(through):
+    cube = pyvista.Cube()
+
+    # Test with algorithm source to make sure connections work with picking
+    src = vtk.vtkSphereSource()
+    src.SetCenter((1, 0, 0))
+    mapper = vtk.vtkDataSetMapper()
+    mapper.SetInputConnection(src.GetOutputPort())
+    actor = vtk.vtkActor()
+    actor.SetMapper(mapper)
+    actor.SetPickable(True)
+
+    plotter = pyvista.Plotter(window_size=(1024, 768))
+    plotter.add_mesh(cube, pickable=True)
+    plotter.add_actor(actor)
+    plotter.enable_cell_picking(
+        color='blue',
+        through=through,
+        start=True,
+        show=True,
+    )
+    plotter.show(auto_close=False)  # must start renderer first
+
+    # simulate the pick (169, 113, 875, 684)
+    plotter.iren._mouse_left_button_press(169, 113)
+    plotter.iren._mouse_move(875, 684)
+    plotter.iren._mouse_left_button_release()
+
+    plotter.close()
+
+    assert isinstance(plotter.picked_cells, pyvista.MultiBlock)
+    # Seletion should return 2 submeshes
+    assert len(plotter.picked_cells) == 2
+
+    merged = plotter.picked_cells.combine()
+    n_sphere_cells = pyvista.wrap(src.GetOutput()).n_cells
+    if through:
+        # all cells should have been selected
+        assert merged.n_cells == cube.n_cells + n_sphere_cells
+    else:
+        assert merged.n_cells < cube.n_cells + n_sphere_cells
 
 
 @pytest.mark.parametrize('left_clicking', [False, True])


### PR DESCRIPTION
Resolves #3317, cc @adam-grant-hendry

This fixes an issue where cell picking would only work for the last mesh added before enabling picking.

Further, this changes the API to be consistent with the other `enable_*_picking` methods -- none of the other methods accept a mesh as an argument, so I decided to remove this from `enable_cell_picking`. I've updated the docstring to detail how `enable_cell_picking` should work (by specifying `pickable` when adding a mesh to the plotter).

Further, I looked into an older issue #1012 while doing this to see if we could improve picking across subplots. I think it would take *significant* work to handle subplot picking properly and I'm inclined to warn users against doing any picking at all with subplots at this time.

This also improves the tests for cell picking to capture the issue in #3317
