### PR TITLE
Add slice_implicit filter for slicing with arbitrary implicit functions: spheres, cylinders, etc

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -632,8 +632,12 @@ class DataSetFilters:
             origin = self.center
         # create the plane for clipping
         plane = generate_plane(normal, origin)
-        return self.slice_implicit(
-            plane, generate_triangles=generate_triangles, contour=contour, progress_bar=progress_bar
+        return DataSetFilters.slice_implicit(
+            self,
+            plane,
+            generate_triangles=generate_triangles,
+            contour=contour,
+            progress_bar=progress_bar,
         )
 
     def slice_orthogonal(

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -528,14 +528,14 @@ class DataSetFilters:
         implicit_function : vtk.vtkImplicitFunction
             Specify the implicit function to perform the cutting.
 
-        generate_triangles : bool, optional
+        generate_triangles : bool, default: False
             If this is enabled (``False`` by default), the output will
             be triangles. Otherwise the output will be the intersection
             polygons. If the cutting function is not a plane, the
-            output will be 3D poygons, which might be nice to look at
+            output will be 3D polygons, which might be nice to look at
             but hard to compute with downstream.
 
-        contour : bool, optional
+        contour : bool, default: False
             If ``True``, apply a ``contour`` filter after slicing.
 
         progress_bar : bool, optional

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -564,8 +564,6 @@ class DataSetFilters:
         >>> slice = mesh.slice_implicit(sphere)
         >>> slice.plot(show_edges=True, line_width=5)
 
-        See :ref:`slice_example` for more examples using this filter.
-
         """
         alg = _vtk.vtkCutter()  # Construct the cutter object
         alg.SetInputDataObject(self)  # Use the grid as the data we desire to cut

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -531,7 +531,9 @@ class DataSetFilters:
         generate_triangles : bool, optional
             If this is enabled (``False`` by default), the output will
             be triangles. Otherwise the output will be the intersection
-            polygons.
+            polygons. If the cutting function is not a plane, the
+            output will be 3D poygons, which might be nice to look at
+            but hard to compute with downstream.
 
         contour : bool, optional
             If ``True``, apply a ``contour`` filter after slicing.
@@ -568,8 +570,7 @@ class DataSetFilters:
         alg = _vtk.vtkCutter()  # Construct the cutter object
         alg.SetInputDataObject(self)  # Use the grid as the data we desire to cut
         alg.SetCutFunction(implicit_function)  # the cutter to use the function
-        if not generate_triangles:
-            alg.GenerateTrianglesOff()
+        alg.SetGenerateTriangles(generate_triangles)
         _update_alg(alg, progress_bar, 'Slicing')
         output = _get_output(alg)
         if contour:


### PR DESCRIPTION
Resolves #2286 by re-implementing the `slice` filter to have an abstract implementation that will accept any VTK implicit function: https://vtk.org/doc/nightly/html/classvtkImplicitFunction.html


```py
import pyvista as pv
import vtk

sphere = vtk.vtkCylinder()
sphere.SetRadius(10)

mesh = pv.Wavelet()

slice = mesh.slice_implicit(sphere)
slice.plot(show_edges=True, line_width=5, notebook=0)
```
<img width="624" alt="Screen Shot 2022-10-26 at 9 34 34 PM" src="https://user-images.githubusercontent.com/22067021/198170490-2f885122-527c-4c60-a74b-c4f129a043ac.png">


