### PR TITLE
Add `clear_actors` methods to plotter

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3769,6 +3769,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
             raise KeyError('Name ({}) not valid/not found in this plotter.')
         return
 
+    def clear_actors(self):
+        """Clear actors from all renderers."""
+        self.renderers.clear_actors()
+
     def clear(self):
         """Clear plot by removing all actors and properties.
 

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1895,15 +1895,19 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         self.RemoveAllLights()
         self._lights.clear()
 
-    def clear(self):
-        """Remove all actors and properties."""
+    def clear_actors(self):
+        """Remove all actors (keep lights and properties)."""
         if self._actors:
             for actor in list(self._actors):
                 try:
                     self.remove_actor(actor, reset_camera=False, render=False)
                 except KeyError:
                     pass
+            self.Modified()
 
+    def clear(self):
+        """Remove all actors and properties."""
+        self.clear_actors()
         if self.__charts is not None:
             self._charts.deep_clean()
         self.remove_all_lights()

--- a/pyvista/plotting/renderers.py
+++ b/pyvista/plotting/renderers.py
@@ -359,6 +359,11 @@ class Renderers:
             if renderer is not None:
                 renderer.clear()
 
+    def clear_actors(self):
+        """Clear actors from all renderers."""
+        for renderer in self:
+            renderer.clear_actors()
+
     def clear(self):
         """Clear all renders."""
         for renderer in self:

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -214,6 +214,15 @@ def test_add_points_invalid_style(sphere):
         pl.add_points(sphere, style='wireframe')
 
 
+def test_clear_actors(cube, sphere):
+    pl = pyvista.Plotter()
+    pl.add_mesh(cube)
+    pl.add_mesh(sphere)
+    assert len(pl.renderer.actors) == 2
+    pl.clear_actors()
+    assert len(pl.renderer.actors) == 0
+
+
 def test_anti_aliasing_multiplot(sphere):
     pl = pyvista.Plotter(shape=(1, 2))
     pl.enable_anti_aliasing('fxaa', all_renderers=False)


### PR DESCRIPTION
This addresses (maybe solves) #3522

Adds a new `clear_actors()` method to only clear actors in a scene -- not lights/view props
