### PR TITLE
Rename dims kwarg for UniformGrid to dimensions

### DIFF
--- a/doc/user-guide/data_model.rst
+++ b/doc/user-guide/data_model.rst
@@ -395,7 +395,7 @@ a simple mesh containing four isometric cells by starting with a
 
 .. jupyter-execute::
 
-   >>> grid = pyvista.UniformGrid(dims=(3, 3, 1))
+   >>> grid = pyvista.UniformGrid(dimensions=(3, 3, 1))
    >>> ugrid = grid.cast_to_unstructured_grid()
    >>> ugrid
 
@@ -405,7 +405,7 @@ Let's also plot this basic mesh:
    :context:
    :include-source: False
 
-   >>> grid = pyvista.UniformGrid(dims=(3, 3, 1))
+   >>> grid = pyvista.UniformGrid(dimensions=(3, 3, 1))
    >>> ugrid = grid.cast_to_unstructured_grid()
 
 .. pyvista-plot::

--- a/doc/user-guide/vtk_to_pyvista.rst
+++ b/doc/user-guide/vtk_to_pyvista.rst
@@ -59,7 +59,7 @@ PyVista is:
 
    Create the grid.  Note how the values must use Fortran ordering.
 
-   >>> grid = pyvista.UniformGrid(dims=(300, 300, 1))
+   >>> grid = pyvista.UniformGrid(dimensions=(300, 300, 1))
    >>> grid.point_data["values"] = values.flatten(order="F")
 
 Here, PyVista has done several things for us:
@@ -142,7 +142,7 @@ However, with PyVista you only need:
    xi = np.arange(300)
    x, y = np.meshgrid(xi, xi)
    values = 127.5 + (1.0 + np.sin(x/25.0)*np.cos(y/25.0))
-   grid = pv.UniformGrid(dims=(300, 300, 1))
+   grid = pv.UniformGrid(dimensions=(300, 300, 1))
    grid.point_data["values"] = values.flatten(order="F")
    grid.plot(cpos='xy', show_scalar_bar=False, cmap='coolwarm')
 

--- a/examples/01-filter/cell-centers.py
+++ b/examples/01-filter/cell-centers.py
@@ -89,7 +89,7 @@ pl.show()
 # There is not a method to add labels to cells.
 # If you want to label it, you need to extract the position to label it.
 
-grid = pv.UniformGrid(dims=(10, 10, 1))
+grid = pv.UniformGrid(dimensions=(10, 10, 1))
 points = grid.cell_centers().points
 
 pl = pv.Plotter()

--- a/examples/01-filter/flying_edges.py
+++ b/examples/01-filter/flying_edges.py
@@ -38,7 +38,7 @@ def spider_cage(x, y, z):
 n = 100
 x_min, y_min, z_min = -5, -5, -3
 grid = pv.UniformGrid(
-    dims=(n, n, n),
+    dimensions=(n, n, n),
     spacing=(abs(x_min) / n * 2, abs(y_min) / n * 2, abs(z_min) / n * 2),
     origin=(x_min, y_min, z_min),
 )
@@ -80,7 +80,7 @@ n = 100
 k = 2.0
 x_min, y_min, z_min = -k, -k, -k
 grid = pv.UniformGrid(
-    dims=(n, n, n),
+    dimensions=(n, n, n),
     spacing=(abs(x_min) / n * 2, abs(y_min) / n * 2, abs(z_min) / n * 2),
     origin=(x_min, y_min, z_min),
 )

--- a/examples/01-filter/image-fft-perlin-noise.py
+++ b/examples/01-filter/image-fft-perlin-noise.py
@@ -128,7 +128,7 @@ warped_high_pass.plot(show_scalar_bar=False, text='High Pass of the Perlin Noise
 # ~~~~~~~~~~~~~~~~~~~~~
 # Show that the sum of the low and high passes equals the original noise.
 
-grid = pv.UniformGrid(dims=sampled.dimensions, spacing=sampled.spacing)
+grid = pv.UniformGrid(dimensions=sampled.dimensions, spacing=sampled.spacing)
 grid['scalars'] = high_pass['scalars'] + low_pass['scalars']
 
 print(

--- a/examples/01-filter/streamlines.py
+++ b/examples/01-filter/streamlines.py
@@ -139,7 +139,7 @@ ny = 15
 nz = 5
 
 origin = (-(nx - 1) * 0.1 / 2, -(ny - 1) * 0.1 / 2, -(nz - 1) * 0.1 / 2)
-mesh = pv.UniformGrid(dims=(nx, ny, nz), spacing=(0.1, 0.1, 0.1), origin=origin)
+mesh = pv.UniformGrid(dimensions=(nx, ny, nz), spacing=(0.1, 0.1, 0.1), origin=origin)
 x = mesh.points[:, 0]
 y = mesh.points[:, 1]
 z = mesh.points[:, 2]

--- a/examples/02-plot/blurring.py
+++ b/examples/02-plot/blurring.py
@@ -18,7 +18,7 @@ import pyvista as pv
 
 # We use a uniform grid here simply to create equidistantly spaced points for
 # our glyph filter
-grid = pv.UniformGrid(dims=(4, 4, 4), spacing=(1, 1, 1))
+grid = pv.UniformGrid(dimensions=(4, 4, 4), spacing=(1, 1, 1))
 
 spheres = grid.glyph(geom=pv.Sphere(), scale=False, orient=False)
 

--- a/examples/02-plot/depth_of_field.py
+++ b/examples/02-plot/depth_of_field.py
@@ -26,7 +26,7 @@ mesh = mesh.rotate_x(90, inplace=False).rotate_z(90, inplace=False).scale(4, 4, 
 
 # We use a uniform grid here simply to create equidistantly spaced points for
 # our glyph filter
-grid = pv.UniformGrid(dims=(4, 3, 3), spacing=(3, 1, 1))
+grid = pv.UniformGrid(dimensions=(4, 3, 3), spacing=(3, 1, 1))
 
 bunnies = grid.glyph(geom=mesh, scale=False, orient=False)
 bunnies

--- a/examples/02-plot/ssao.py
+++ b/examples/02-plot/ssao.py
@@ -22,7 +22,7 @@ See `Kitware: Screen-Space Ambient Occlusion
 import pyvista as pv
 from pyvista import examples
 
-grid = pv.UniformGrid(dims=(5, 5, 5)).explode(0.2)
+grid = pv.UniformGrid(dimensions=(5, 5, 5)).explode(0.2)
 
 ###############################################################################
 # Plot with defaults

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -368,7 +368,7 @@ class DataObject:
 
         Add field data to a UniformGrid dataset.
 
-        >>> mesh = pyvista.UniformGrid(dims=(2, 2, 1))
+        >>> mesh = pyvista.UniformGrid(dimensions=(2, 2, 1))
         >>> mesh.add_field_data(['I could', 'write', 'notes', 'here'],
         ...                      'my-field-data')
         >>> mesh['my-field-data']
@@ -506,7 +506,7 @@ class DataObject:
         Examples
         --------
         >>> import pyvista as pv
-        >>> source = pv.UniformGrid(dims=(10, 10, 5))
+        >>> source = pv.UniformGrid(dimensions=(10, 10, 5))
         >>> target = pv.UniformGrid()
         >>> target.copy_structure(source)
         >>> target.plot(show_edges=True)
@@ -525,9 +525,9 @@ class DataObject:
         Examples
         --------
         >>> import pyvista as pv
-        >>> source = pv.UniformGrid(dims=(10, 10, 5))
+        >>> source = pv.UniformGrid(dimensions=(10, 10, 5))
         >>> source = source.compute_cell_sizes()
-        >>> target = pv.UniformGrid(dims=(10, 10, 5))
+        >>> target = pv.UniformGrid(dimensions=(10, 10, 5))
         >>> target.copy_attributes(source)
         >>> target.plot(scalars='Volume', show_edges=True)
 

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1772,13 +1772,13 @@ class DataSet(DataSetFilters, DataObject):
         Note that there are 5 points in each direction.
 
         >>> import pyvista as pv
-        >>> mesh = pv.UniformGrid(dims=(5, 5, 5))
+        >>> mesh = pv.UniformGrid(dimensions=(5, 5, 5))
         >>> mesh.volume
         64.0
 
         A mesh with 2D cells has no volume.
 
-        >>> mesh = pv.UniformGrid(dims=(5, 5, 1))
+        >>> mesh = pv.UniformGrid(dimensions=(5, 5, 1))
         >>> mesh.volume
         0.0
 
@@ -1810,7 +1810,7 @@ class DataSet(DataSetFilters, DataObject):
         Note 5 points in each direction.
 
         >>> import pyvista as pv
-        >>> mesh = pv.UniformGrid(dims=(5, 5, 1))
+        >>> mesh = pv.UniformGrid(dimensions=(5, 5, 1))
         >>> mesh.area
         16.0
 
@@ -1818,7 +1818,7 @@ class DataSet(DataSetFilters, DataObject):
         the outer surface area, first extract the surface using
         :func:`pyvista.DataSetFilters.extract_surface`.
 
-        >>> mesh = pv.UniformGrid(dims=(5, 5, 5))
+        >>> mesh = pv.UniformGrid(dimensions=(5, 5, 5))
         >>> mesh.area
         0.0
 
@@ -2423,7 +2423,7 @@ class DataSet(DataSetFilters, DataObject):
         containing the point ``[0.3, 0.3, 0.0]`` is found.
 
         >>> import pyvista
-        >>> mesh = pyvista.UniformGrid(dims=[5, 5, 1], spacing=[1/4, 1/4, 0])
+        >>> mesh = pyvista.UniformGrid(dimensions=[5, 5, 1], spacing=[1/4, 1/4, 0])
         >>> mesh
         UniformGrid...
         >>> mesh.find_containing_cell([0.3, 0.3, 0.0])

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1616,7 +1616,7 @@ class DataSetFilters:
         >>> n = 100
         >>> x_min, y_min, z_min = -1.35, -1.7, -0.65
         >>> grid = pv.UniformGrid(
-        ...     dims=(n, n, n),
+        ...     dimensions=(n, n, n),
         ...     spacing=(abs(x_min)/n*2, abs(y_min)/n*2, abs(z_min)/n*2),
         ...     origin=(x_min, y_min, z_min),
         ... )
@@ -5433,7 +5433,7 @@ class DataSetFilters:
          containing each partition.
 
          >>> import pyvista as pv
-         >>> grid = pv.UniformGrid(dims=(5, 5, 5))
+         >>> grid = pv.UniformGrid(dimensions=(5, 5, 5))
          >>> out = grid.partition(4, as_composite=True)
          >>> out.plot(multi_colors=True, show_edges=True)
 

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -11,7 +11,7 @@ import pyvista
 from pyvista import _vtk
 from pyvista.core.dataset import DataSet
 from pyvista.core.filters import RectilinearGridFilters, UniformGridFilters, _get_output
-from pyvista.utilities import abstract_class
+from pyvista.utilities import abstract_class, assert_empty_kwargs
 import pyvista.utilities.helpers as helpers
 from pyvista.utilities.misc import PyVistaDeprecationWarning, raise_has_duplicates
 
@@ -39,7 +39,7 @@ class Grid(DataSet):
         Create a uniform grid with dimensions ``(1, 2, 3)``.
 
         >>> import pyvista
-        >>> grid = pyvista.UniformGrid(dims=(2, 3, 4))
+        >>> grid = pyvista.UniformGrid(dimensions=(2, 3, 4))
         >>> grid.dimensions
         (2, 3, 4)
         >>> grid.plot(show_edges=True)
@@ -447,19 +447,19 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
     Initialize using using just the grid dimensions and default
     spacing and origin. These must be keyword arguments.
 
-    >>> grid = pyvista.UniformGrid(dims=(10, 10, 10))
+    >>> grid = pyvista.UniformGrid(dimensions=(10, 10, 10))
 
     Initialize using dimensions and spacing.
 
     >>> grid = pyvista.UniformGrid(
-    ...     dims=(10, 10, 10),
+    ...     dimensions=(10, 10, 10),
     ...     spacing=(2, 1, 5),
     ... )
 
     Initialize using dimensions, spacing, and an origin.
 
     >>> grid = pyvista.UniformGrid(
-    ...     dims=(10, 10, 10),
+    ...     dimensions=(10, 10, 10),
     ...     spacing=(2, 1, 5),
     ...     origin=(10, 35, 50),
     ... )
@@ -467,7 +467,7 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
     Initialize from another UniformGrid.
 
     >>> grid = pyvista.UniformGrid(
-    ...     dims=(10, 10, 10),
+    ...     dimensions=(10, 10, 10),
     ...     spacing=(2, 1, 5),
     ...     origin=(10, 35, 50),
     ... )
@@ -483,10 +483,11 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         self,
         uinput=None,
         *args,
-        dims=None,
+        dimensions=None,
         spacing=(1.0, 1.0, 1.0),
         origin=(0.0, 0.0, 0.0),
         deep=False,
+        **kwargs,
     ):
         """Initialize the uniform grid."""
         super().__init__()
@@ -498,15 +499,22 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
                 "either a ``vtk.vtkImageData`` or path.",
                 PyVistaDeprecationWarning,
             )
-            dims = uinput
+            dimensions = uinput
             uinput = None
+
+        if dimensions is None and 'dims' in kwargs:
+            dimensions = kwargs.pop('dims')
+            warnings.warn(
+                '`dims` argument is deprecated. Please use `dimensions`.', PyVistaDeprecationWarning
+            )
+        assert_empty_kwargs(**kwargs)
 
         if args:
             warnings.warn(
                 "Behavior of pyvista.UniformGrid has changed. Use keyword arguments "
                 "to specify dimensions, spacing, and origin. For example:\n\n"
                 "    >>> grid = pyvista.UniformGrid(\n"
-                "    ...     dims=(10, 10, 10),\n"
+                "    ...     dimensions=(10, 10, 10),\n"
                 "    ...     spacing=(2, 1, 5),\n"
                 "    ...     origin=(10, 35, 50),\n"
                 "    ... )\n",
@@ -536,13 +544,13 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
                     f"or a path, not {type(uinput)}.  Use keyword arguments to "
                     "specify dimensions, spacing, and origin. For example:\n\n"
                     "    >>> grid = pyvista.UniformGrid(\n"
-                    "    ...     dims=(10, 10, 10),\n"
+                    "    ...     dimensions=(10, 10, 10),\n"
                     "    ...     spacing=(2, 1, 5),\n"
                     "    ...     origin=(10, 35, 50),\n"
                     "    ... )\n"
                 )
-        elif dims is not None:
-            self._from_specs(dims, spacing, origin)
+        elif dimensions is not None:
+            self._from_specs(dimensions, spacing, origin)
 
     def __repr__(self):
         """Return the default representation."""
@@ -589,7 +597,7 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         Examples
         --------
         >>> import pyvista
-        >>> grid = pyvista.UniformGrid(dims=(2, 2, 2))
+        >>> grid = pyvista.UniformGrid(dimensions=(2, 2, 2))
         >>> grid.points
         array([[0., 0., 0.],
                [1., 0., 0.],
@@ -637,7 +645,7 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         Examples
         --------
         >>> import pyvista
-        >>> grid = pyvista.UniformGrid(dims=(2, 2, 2))
+        >>> grid = pyvista.UniformGrid(dimensions=(2, 2, 2))
         >>> grid.x
         array([0., 1., 0., 1., 0., 1., 0., 1.])
 
@@ -651,7 +659,7 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         Examples
         --------
         >>> import pyvista
-        >>> grid = pyvista.UniformGrid(dims=(2, 2, 2))
+        >>> grid = pyvista.UniformGrid(dimensions=(2, 2, 2))
         >>> grid.y
         array([0., 0., 1., 1., 0., 0., 1., 1.])
 
@@ -665,7 +673,7 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         Examples
         --------
         >>> import pyvista
-        >>> grid = pyvista.UniformGrid(dims=(2, 2, 2))
+        >>> grid = pyvista.UniformGrid(dimensions=(2, 2, 2))
         >>> grid.z
         array([0., 0., 0., 0., 1., 1., 1., 1.])
 
@@ -679,7 +687,7 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         Examples
         --------
         >>> import pyvista
-        >>> grid = pyvista.UniformGrid(dims=(5, 5, 5))
+        >>> grid = pyvista.UniformGrid(dimensions=(5, 5, 5))
         >>> grid.origin
         (0.0, 0.0, 0.0)
 
@@ -726,7 +734,7 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         Create a 5 x 5 x 5 uniform grid.
 
         >>> import pyvista
-        >>> grid = pyvista.UniformGrid(dims=(5, 5, 5))
+        >>> grid = pyvista.UniformGrid(dimensions=(5, 5, 5))
         >>> grid.spacing
         (1.0, 1.0, 1.0)
         >>> grid.plot(show_edges=True)
@@ -806,7 +814,7 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         Create a ``UniformGrid`` and show its extent.
 
         >>> import pyvista
-        >>> grid = pyvista.UniformGrid(dims=(10, 10, 10))
+        >>> grid = pyvista.UniformGrid(dimensions=(10, 10, 10))
         >>> grid.extent
         (0, 9, 0, 9, 0, 9)
 

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -411,13 +411,16 @@ class UniformGrid(_vtk.vtkImageData, Grid, UniformGridFilters):
         ``vtk.vtkImageData``. Use keyword arguments to specify the
         dimensions, spacing, and origin of the uniform grid.
 
+    .. versionchanged:: 0.37.0
+        The ``dims`` parameter has been renamed to ``dimensions``.
+
     Parameters
     ----------
     uinput : str, vtk.vtkImageData, pyvista.UniformGrid, optional
         Filename or dataset to initialize the uniform grid from.  If
         set, remainder of arguments are ignored.
 
-    dims : iterable, optional
+    dimensions : iterable, optional
         Dimensions of the uniform grid.
 
     spacing : iterable, optional

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -409,7 +409,7 @@ class Texture(_vtk.vtkTexture, DataObject):
         elif image.ndim == 2:
             n_components = 1
 
-        grid = pyvista.UniformGrid(dims=(image.shape[1], image.shape[0], 1))
+        grid = pyvista.UniformGrid(dimensions=(image.shape[1], image.shape[0], 1))
         grid.point_data['Image'] = np.flip(image.swapaxes(0, 1), axis=1).reshape(
             (-1, n_components), order='F'
         )

--- a/pyvista/demos/demos.py
+++ b/pyvista/demos/demos.py
@@ -474,7 +474,7 @@ def plot_datasets(dataset_type=None):
 
     ###########################################################################
     # uniform grid
-    image = pv.UniformGrid(dims=(6, 6, 1))
+    image = pv.UniformGrid(dimensions=(6, 6, 1))
     image.spacing = (3, 2, 1)
 
     ###########################################################################

--- a/pyvista/examples/examples.py
+++ b/pyvista/examples/examples.py
@@ -350,7 +350,7 @@ def load_explicit_structured(dimensions=(5, 6, 7), spacing=(20, 10, 1)):
 
     Parameters
     ----------
-    dims : tuple(int), optional
+    dimensions : tuple(int), optional
         Grid dimensions. Default is (5, 6, 7).
     spacing : tuple(int), optional
         Grid spacing. Default is (20, 10, 1).

--- a/pyvista/examples/examples.py
+++ b/pyvista/examples/examples.py
@@ -345,7 +345,7 @@ def load_sphere_vectors():
     return sphere
 
 
-def load_explicit_structured(dims=(5, 6, 7), spacing=(20, 10, 1)):
+def load_explicit_structured(dimensions=(5, 6, 7), spacing=(20, 10, 1)):
     """Load a simple explicit structured grid.
 
     Parameters
@@ -367,7 +367,7 @@ def load_explicit_structured(dims=(5, 6, 7), spacing=(20, 10, 1)):
     >>> grid.plot(show_edges=True)
 
     """
-    ni, nj, nk = np.asarray(dims) - 1
+    ni, nj, nk = np.asarray(dimensions) - 1
     si, sj, sk = spacing
 
     xcorn = np.arange(0, (ni + 1) * si, si)
@@ -390,7 +390,7 @@ def load_explicit_structured(dims=(5, 6, 7), spacing=(20, 10, 1)):
     corners = np.stack((xcorn, ycorn, zcorn))
     corners = corners.transpose()
 
-    grid = pyvista.ExplicitStructuredGrid(dims, corners)
+    grid = pyvista.ExplicitStructuredGrid(dimensions, corners)
     return grid
 
 

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -210,7 +210,7 @@ def plot(
     UniformGrid. Note ``volume=True`` is passed.
 
     >>> import numpy as np
-    >>> grid = pv.UniformGrid(dims=(32, 32, 32), spacing=(0.5, 0.5, 0.5))
+    >>> grid = pv.UniformGrid(dimensions=(32, 32, 32), spacing=(0.5, 0.5, 0.5))
     >>> grid['data'] = np.linalg.norm(grid.center - grid.points, axis=1)
     >>> grid['data'] = np.abs(grid['data'] - grid['data'].max())**3
     >>> grid.plot(volume=True)

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -2732,7 +2732,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         nearby each other and plot it without SSAO.
 
         >>> import pyvista as pv
-        >>> ugrid = pv.UniformGrid(dims=(3, 2, 2)).to_tetrahedra(12)
+        >>> ugrid = pv.UniformGrid(dimensions=(3, 2, 2)).to_tetrahedra(12)
         >>> exploded = ugrid.explode()
         >>> exploded.plot()
 

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1975,7 +1975,7 @@ class WidgetHelper:
             color3 = np.array(Color(color3).int_rgb)
 
             n_points = dims[0] * dims[1]
-            button = pyvista.UniformGrid(dims=dims)
+            button = pyvista.UniformGrid(dimensions=dims)
             arr = np.array([color1] * n_points).reshape(dims[0], dims[1], 3)  # fill with color1
             arr[1 : dims[0] - 1, 1 : dims[1] - 1] = color2  # apply color2
             arr[

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -943,7 +943,7 @@ def wrap(dataset):
         if dataset.ndim > 1 and dataset.ndim < 3 and dataset.shape[1] == 3:
             return pyvista.PolyData(dataset)
         elif dataset.ndim == 3:
-            mesh = pyvista.UniformGrid(dims=dataset.shape)
+            mesh = pyvista.UniformGrid(dimensions=dataset.shape)
             if isinstance(dataset, pyvista.pyvista_ndarray):
                 # this gets rid of pesky VTK reference since we're raveling this
                 dataset = np.array(dataset, copy=False)

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -2285,7 +2285,7 @@ class _GIFReader:
         from PIL import Image, ImageSequence
 
         img = Image.open(self._filename)
-        self._data_object = pyvista.UniformGrid(dims=(img.size[0], img.size[1], 1))
+        self._data_object = pyvista.UniformGrid(dimensions=(img.size[0], img.size[1], 1))
 
         # load each frame to the grid (RGB since gifs do not support transparency
         self._n_frames = img.n_frames

--- a/tests/filters/test_rectilinear_grid.py
+++ b/tests/filters/test_rectilinear_grid.py
@@ -44,4 +44,4 @@ def test_to_tetrahedral_mixed(tiny_rectilinear):
 
 def test_to_tetrahedral_edge_case():
     with pytest.raises(RuntimeError, match='is 1'):
-        pv.UniformGrid(dims=(1, 2, 2)).to_tetrahedra(tetra_per_cell=12)
+        pv.UniformGrid(dimensions=(1, 2, 2)).to_tetrahedra(tetra_per_cell=12)

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -2608,7 +2608,7 @@ def test_ssaa_pass():
 
 @skip_windows_mesa
 def test_ssao_pass():
-    ugrid = pyvista.UniformGrid(dims=(2, 2, 2)).to_tetrahedra(5).explode()
+    ugrid = pyvista.UniformGrid(dimensions=(2, 2, 2)).to_tetrahedra(5).explode()
     pl = pyvista.Plotter()
     pl.add_mesh(ugrid)
 
@@ -2628,7 +2628,7 @@ def test_ssao_pass():
 
 @skip_mesa
 def test_ssao_pass_from_helper():
-    ugrid = pyvista.UniformGrid(dims=(2, 2, 2)).to_tetrahedra(5).explode()
+    ugrid = pyvista.UniformGrid(dimensions=(2, 2, 2)).to_tetrahedra(5).explode()
 
     if pyvista.vtk_version_info < (9,):
         with pytest.raises(pyvista.core.errors.VTKVersionError):
@@ -2924,7 +2924,7 @@ def test_plot_cell():
 
 
 def test_tight_square_padding():
-    grid = pyvista.UniformGrid(dims=(200, 100, 1))
+    grid = pyvista.UniformGrid(dimensions=(200, 100, 1))
     grid['data'] = np.arange(grid.n_points)
     pl = pyvista.Plotter(window_size=(150, 150))
     pl.add_mesh(grid, show_scalar_bar=False)
@@ -2936,7 +2936,7 @@ def test_tight_square_padding():
 
 
 def test_tight_tall():
-    grid = pyvista.UniformGrid(dims=(100, 200, 1))
+    grid = pyvista.UniformGrid(dimensions=(100, 200, 1))
     grid['data'] = np.arange(grid.n_points)
     pl = pyvista.Plotter(window_size=(150, 150))
     pl.add_mesh(grid, show_scalar_bar=False)
@@ -2950,7 +2950,7 @@ def test_tight_tall():
 
 
 def test_tight_wide():
-    grid = pyvista.UniformGrid(dims=(200, 100, 1))
+    grid = pyvista.UniformGrid(dimensions=(200, 100, 1))
     grid['data'] = np.arange(grid.n_points)
     pl = pyvista.Plotter(window_size=(150, 150))
     pl.add_mesh(grid, show_scalar_bar=False)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -797,7 +797,7 @@ def test_string_arrays():
 
 def test_clear_data():
     # First try on an empty mesh
-    grid = pyvista.UniformGrid(dims=(10, 10, 10))
+    grid = pyvista.UniformGrid(dimensions=(10, 10, 10))
     # Now try something more complicated
     grid.clear_data()
     grid['foo-p'] = np.random.rand(grid.n_points)
@@ -946,14 +946,14 @@ def test_find_closest_cell_surface_point():
 
 
 def test_find_containing_cell():
-    mesh = pyvista.UniformGrid(dims=[5, 5, 1], spacing=[1 / 4, 1 / 4, 0])
+    mesh = pyvista.UniformGrid(dimensions=[5, 5, 1], spacing=[1 / 4, 1 / 4, 0])
     node = np.array([0.3, 0.3, 0.0])
     index = mesh.find_containing_cell(node)
     assert index == 5
 
 
 def test_find_containing_cells():
-    mesh = pyvista.UniformGrid(dims=[5, 5, 1], spacing=[1 / 4, 1 / 4, 0])
+    mesh = pyvista.UniformGrid(dimensions=[5, 5, 1], spacing=[1 / 4, 1 / 4, 0])
     points = np.array([[0.3, 0.3, 0], [0.6, 0.6, 0]])
     points_copy = points.copy()
     indices = mesh.find_containing_cell(points)
@@ -1111,7 +1111,7 @@ def test_cell_type(grid):
 
 
 def test_point_is_inside_cell():
-    grid = pyvista.UniformGrid(dims=(2, 2, 2))
+    grid = pyvista.UniformGrid(dimensions=(2, 2, 2))
     assert grid.point_is_inside_cell(0, [0.5, 0.5, 0.5])
     assert not grid.point_is_inside_cell(0, [-0.5, -0.5, -0.5])
 
@@ -1514,11 +1514,11 @@ def test_volume_area():
         assert np.isclose(grid.area, 16.0)
 
     # UniformGrid 3D size 4x4x4
-    vol_grid = pyvista.UniformGrid(dims=(5, 5, 5))
+    vol_grid = pyvista.UniformGrid(dimensions=(5, 5, 5))
     assert_volume(vol_grid)
 
     # 2D grid size 4x4
-    surf_grid = pyvista.UniformGrid(dims=(5, 5, 1))
+    surf_grid = pyvista.UniformGrid(dimensions=(5, 5, 1))
     assert_area(surf_grid)
 
     # UnstructuredGrid
@@ -1536,6 +1536,6 @@ def test_volume_area():
     # PolyData
     # cube of size 4
     # PolyData is special because it is a 2D surface that can enclose a volume
-    grid = pyvista.UniformGrid(dims=(5, 5, 5)).extract_surface()
+    grid = pyvista.UniformGrid(dimensions=(5, 5, 5)).extract_surface()
     assert np.isclose(grid.volume, 64.0)
     assert np.isclose(grid.area, 96.0)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -73,7 +73,7 @@ def grid():
 def uniform_vec():
     nx, ny, nz = 20, 15, 5
     origin = (-(nx - 1) * 0.1 / 2, -(ny - 1) * 0.1 / 2, -(nz - 1) * 0.1 / 2)
-    mesh = pyvista.UniformGrid(dims=(nx, ny, nz), spacing=(0.1, 0.1, 0.1), origin=origin)
+    mesh = pyvista.UniformGrid(dimensions=(nx, ny, nz), spacing=(0.1, 0.1, 0.1), origin=origin)
     mesh['vectors'] = mesh.points
     return mesh
 
@@ -658,7 +658,7 @@ def test_compute_cell_sizes(datasets):
         assert 'Area' in result.array_names
         assert 'Volume' in result.array_names
     # Test the volume property
-    grid = pyvista.UniformGrid(dims=(10, 10, 10))
+    grid = pyvista.UniformGrid(dimensions=(10, 10, 10))
     volume = float(np.prod(np.array(grid.dimensions) - 1))
     assert np.allclose(grid.volume, volume)
 
@@ -896,7 +896,7 @@ def test_glyph_settings(sphere):
 
 
 def test_glyph_orient_and_scale():
-    grid = pyvista.UniformGrid(dims=(1, 1, 1))
+    grid = pyvista.UniformGrid(dimensions=(1, 1, 1))
     geom = pyvista.Line()
     scale = 10.0
     orient = np.array([[0.0, 0.0, 1.0]])
@@ -1163,7 +1163,7 @@ def test_streamlines_from_source(uniform_vec):
     stream = uniform_vec.streamlines_from_source(source, 'vectors', progress_bar=True)
     assert all([stream.n_points, stream.n_cells])
 
-    source = pyvista.UniformGrid(dims=[5, 5, 5], spacing=[0.1, 0.1, 0.1], origin=[0, 0, 0])
+    source = pyvista.UniformGrid(dimensions=[5, 5, 5], spacing=[0.1, 0.1, 0.1], origin=[0, 0, 0])
     stream = uniform_vec.streamlines_from_source(source, 'vectors', progress_bar=True)
     assert all([stream.n_points, stream.n_cells])
 
@@ -1840,7 +1840,7 @@ def test_gaussian_smooth_output_type():
 
 def test_gaussian_smooth_constant_data():
     point_data = np.ones((10, 10, 10))
-    volume = pyvista.UniformGrid(dims=(10, 10, 10))
+    volume = pyvista.UniformGrid(dimensions=(10, 10, 10))
     volume.point_data['point_data'] = point_data.flatten(order='F')
     volume_smoothed = volume.gaussian_smooth()
     assert np.allclose(volume.point_data['point_data'], volume_smoothed.point_data['point_data'])
@@ -1849,7 +1849,7 @@ def test_gaussian_smooth_constant_data():
 def test_gaussian_smooth_outlier():
     point_data = np.ones((10, 10, 10))
     point_data[4, 4, 4] = 100
-    volume = pyvista.UniformGrid(dims=(10, 10, 10))
+    volume = pyvista.UniformGrid(dimensions=(10, 10, 10))
     volume.point_data['point_data'] = point_data.flatten(order='F')
     volume_smoothed = volume.gaussian_smooth()
     assert volume_smoothed.get_data_range()[1] < volume.get_data_range()[1]
@@ -1858,7 +1858,7 @@ def test_gaussian_smooth_outlier():
 def test_gaussian_smooth_cell_data_specified():
     point_data = np.zeros((10, 10, 10))
     cell_data = np.zeros((9, 9, 9))
-    volume = pyvista.UniformGrid(dims=(10, 10, 10))
+    volume = pyvista.UniformGrid(dimensions=(10, 10, 10))
     volume.point_data['point_data'] = point_data.flatten(order='F')
     volume.cell_data['cell_data'] = cell_data.flatten(order='F')
     with pytest.raises(ValueError):
@@ -1868,7 +1868,7 @@ def test_gaussian_smooth_cell_data_specified():
 def test_gaussian_smooth_cell_data_active():
     point_data = np.zeros((10, 10, 10))
     cell_data = np.zeros((9, 9, 9))
-    volume = pyvista.UniformGrid(dims=(10, 10, 10))
+    volume = pyvista.UniformGrid(dimensions=(10, 10, 10))
     volume.point_data['point_data'] = point_data.flatten(order='F')
     volume.cell_data['cell_data'] = cell_data.flatten(order='F')
     volume.set_active_scalars('cell_data')
@@ -1886,7 +1886,7 @@ def test_median_smooth_output_type():
 
 def test_median_smooth_constant_data():
     point_data = np.ones((10, 10, 10))
-    volume = pyvista.UniformGrid(dims=(10, 10, 10))
+    volume = pyvista.UniformGrid(dimensions=(10, 10, 10))
     volume.point_data['point_data'] = point_data.flatten(order='F')
     volume_smoothed = volume.median_smooth()
     assert np.array_equal(volume.point_data['point_data'], volume_smoothed.point_data['point_data'])
@@ -1896,9 +1896,9 @@ def test_median_smooth_outlier():
     point_data = np.ones((10, 10, 10))
     point_data_outlier = point_data.copy()
     point_data_outlier[4, 4, 4] = 100
-    volume = pyvista.UniformGrid(dims=(10, 10, 10))
+    volume = pyvista.UniformGrid(dimensions=(10, 10, 10))
     volume.point_data['point_data'] = point_data.flatten(order='F')
-    volume_outlier = pyvista.UniformGrid(dims=(10, 10, 10))
+    volume_outlier = pyvista.UniformGrid(dimensions=(10, 10, 10))
     volume_outlier.point_data['point_data'] = point_data_outlier.flatten(order='F')
     volume_outlier_smoothed = volume_outlier.median_smooth()
     assert np.array_equal(
@@ -1909,7 +1909,7 @@ def test_median_smooth_outlier():
 def test_image_dilate_erode_output_type():
     point_data = np.zeros((10, 10, 10))
     point_data[4, 4, 4] = 1
-    volume = pyvista.UniformGrid(dims=(10, 10, 10))
+    volume = pyvista.UniformGrid(dimensions=(10, 10, 10))
     volume.point_data['point_data'] = point_data.flatten(order='F')
     volume_dilate_erode = volume.image_dilate_erode()
     assert isinstance(volume_dilate_erode, pyvista.UniformGrid)
@@ -1924,7 +1924,7 @@ def test_image_dilate_erode_dilation():
     point_data_dilated[3:6, 3:6, 4] = 1  # "activate" all voxels within diameter 3 around (4,4,4)
     point_data_dilated[3:6, 4, 3:6] = 1
     point_data_dilated[4, 3:6, 3:6] = 1
-    volume = pyvista.UniformGrid(dims=(10, 10, 10))
+    volume = pyvista.UniformGrid(dimensions=(10, 10, 10))
     volume.point_data['point_data'] = point_data.flatten(order='F')
     volume_dilated = volume.image_dilate_erode()  # default is binary dilation
     assert np.array_equal(
@@ -1936,7 +1936,7 @@ def test_image_dilate_erode_erosion():
     point_data = np.zeros((10, 10, 10))
     point_data[4, 4, 4] = 1
     point_data_eroded = np.zeros((10, 10, 10))
-    volume = pyvista.UniformGrid(dims=(10, 10, 10))
+    volume = pyvista.UniformGrid(dimensions=(10, 10, 10))
     volume.point_data['point_data'] = point_data.flatten(order='F')
     volume_eroded = volume.image_dilate_erode(0, 1)  # binary erosion
     assert np.array_equal(
@@ -1947,7 +1947,7 @@ def test_image_dilate_erode_erosion():
 def test_image_dilate_erode_cell_data_specified():
     point_data = np.zeros((10, 10, 10))
     cell_data = np.zeros((9, 9, 9))
-    volume = pyvista.UniformGrid(dims=(10, 10, 10))
+    volume = pyvista.UniformGrid(dimensions=(10, 10, 10))
     volume.point_data['point_data'] = point_data.flatten(order='F')
     volume.cell_data['cell_data'] = cell_data.flatten(order='F')
     with pytest.raises(ValueError):
@@ -1957,7 +1957,7 @@ def test_image_dilate_erode_cell_data_specified():
 def test_image_dilate_erode_cell_data_active():
     point_data = np.zeros((10, 10, 10))
     cell_data = np.zeros((9, 9, 9))
-    volume = pyvista.UniformGrid(dims=(10, 10, 10))
+    volume = pyvista.UniformGrid(dimensions=(10, 10, 10))
     volume.point_data['point_data'] = point_data.flatten(order='F')
     volume.cell_data['cell_data'] = cell_data.flatten(order='F')
     volume.set_active_scalars('cell_data')
@@ -1999,7 +1999,7 @@ def test_image_threshold_upper(in_value, out_value):
     in_value_mask[in_value_location] = True
     point_data[in_value_mask] = 100  # the only 'in' value
     point_data[~in_value_mask] = -100  # out values
-    volume = pyvista.UniformGrid(dims=array_shape)
+    volume = pyvista.UniformGrid(dimensions=array_shape)
     volume.point_data['point_data'] = point_data.flatten(order='F')
     point_data_thresholded = point_data.copy()
     if in_value is not None:
@@ -2025,7 +2025,7 @@ def test_image_threshold_between(in_value, out_value):
     point_data[in_value_mask] = 0  # the only 'in' value
     point_data[~in_value_mask] = 100  # out values
     point_data[low_value_location] = -100  # add a value below the threshold also
-    volume = pyvista.UniformGrid(dims=array_shape)
+    volume = pyvista.UniformGrid(dimensions=array_shape)
     volume.point_data['point_data'] = point_data.flatten(order='F')
     point_data_thresholded = point_data.copy()
     if in_value is not None:

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -842,7 +842,7 @@ def test_create_uniform_grid_from_specs():
 
     # create UniformGrid
     dims = (10, 10, 10)
-    grid = pyvista.UniformGrid(dims=dims)  # Using default spacing and origin
+    grid = pyvista.UniformGrid(dimensions=dims)  # Using default spacing and origin
     assert grid.dimensions == dims
     assert grid.extent == (0, 9, 0, 9, 0, 9)
     assert grid.origin == (0.0, 0.0, 0.0)
@@ -850,21 +850,21 @@ def test_create_uniform_grid_from_specs():
 
     # Using default origin
     spacing = (2, 1, 5)
-    grid = pyvista.UniformGrid(dims=dims, spacing=spacing)
+    grid = pyvista.UniformGrid(dimensions=dims, spacing=spacing)
     assert grid.dimensions == dims
     assert grid.origin == (0.0, 0.0, 0.0)
     assert grid.spacing == spacing
     origin = (10, 35, 50)
 
     # Everything is specified
-    grid = pyvista.UniformGrid(dims=dims, spacing=spacing, origin=origin)
+    grid = pyvista.UniformGrid(dimensions=dims, spacing=spacing, origin=origin)
     assert grid.dimensions == dims
     assert grid.origin == origin
     assert grid.spacing == spacing
 
     # ensure negative spacing is not allowed
     with pytest.raises(ValueError, match="Spacing must be non-negative"):
-        grid = pyvista.UniformGrid(dims=dims, spacing=(-1, 1, 1))
+        grid = pyvista.UniformGrid(dimensions=dims, spacing=(-1, 1, 1))
 
     # all args (deprecated)
     with pytest.warns(
@@ -882,8 +882,16 @@ def test_create_uniform_grid_from_specs():
         grid = pyvista.UniformGrid(dims)
         assert grid.dimensions == dims
 
+    with pytest.warns(
+        PyVistaDeprecationWarning,
+        match='`dims` argument is deprecated. Please use `dimensions`.',
+    ):
+        grid = pyvista.UniformGrid(dims=dims)
+    with pytest.raises(TypeError):
+        grid = pyvista.UniformGrid(dimensions=dims, dims=dims)
+
     # uniform grid from a uniform grid
-    grid = pyvista.UniformGrid(dims=dims, spacing=spacing, origin=origin)
+    grid = pyvista.UniformGrid(dimensions=dims, spacing=spacing, origin=origin)
     grid_from_grid = pyvista.UniformGrid(grid)
     assert grid == grid_from_grid
 
@@ -959,13 +967,13 @@ def test_cast_uniform_to_rectilinear():
 
 
 def test_uniform_grid_to_tetrahedra():
-    grid = pyvista.UniformGrid(dims=(2, 2, 2))
+    grid = pyvista.UniformGrid(dimensions=(2, 2, 2))
     ugrid = grid.to_tetrahedra()
     assert ugrid.n_cells == 5
 
 
 def test_fft_and_rfft(noise_2d):
-    grid = pyvista.UniformGrid(dims=(10, 10, 1))
+    grid = pyvista.UniformGrid(dimensions=(10, 10, 1))
     with pytest.raises(MissingDataError, match='FFT filter requires point scalars'):
         grid.fft()
 
@@ -1182,7 +1190,7 @@ def test_hide_points(ind, struct_grid):
 
 
 def test_set_extent():
-    uni_grid = pyvista.UniformGrid(dims=[10, 10, 10])
+    uni_grid = pyvista.UniformGrid(dimensions=[10, 10, 10])
     with pytest.raises(ValueError):
         uni_grid.extent = [0, 1]
 

--- a/tests/utilities/test_reader.py
+++ b/tests/utilities/test_reader.py
@@ -914,7 +914,7 @@ def test_gif_reader(gif_file):
     assert grid.n_arrays == 3
 
     img = Image.open(gif_file)
-    new_grid = pyvista.UniformGrid(dims=(img.size[0], img.size[1], 1))
+    new_grid = pyvista.UniformGrid(dimensions=(img.size[0], img.size[1], 1))
 
     # load each frame to the grid
     for i, frame in enumerate(ImageSequence.Iterator(img)):


### PR DESCRIPTION
`UniformGrid` has `dims` as a keyword argument for setting the `dimensions` property - this mismatch is confusing, internally inconsistent, and inconsistent with VTK.

These changes make the API a bit more consistent and intuitive.

Partially addresses #3313