### PR TITLE
Remove quadruple backticks in docstrings

### DIFF
--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -236,7 +236,7 @@ class PickingHelper:
         meshes to the scene.
 
         When multiple meshes are being picked, the picked cells
-        in ````self.picked_cells`` will be a :class:`MultiBlock`
+        in ``self.picked_cells`` will be a :class:`MultiBlock`
         dataset for each mesh's selection.
 
         Uses last input mesh for input by default.

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1212,7 +1212,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             still retaining all edges of the boundary.
 
         corner_factor : float, optional
-            If ``all_edges````, this is the factor along each axis to
+            If ``all_edges``, this is the factor along each axis to
             draw the default box. Default is 0.5 to show the full box.
 
         fmt : str, optional

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -499,7 +499,7 @@ def test_anti_aliasing_msaa(default_theme):
     assert pl.ren_win.GetMultiSamples() == default_theme.multi_samples
 
 
-def test_antialiasing_deprication(default_theme):
+def test_antialiasing_deprecation(default_theme):
     with pytest.warns(PyVistaDeprecationWarning, match='anti_aliasing'):
         default_theme.antialiasing
     with pytest.warns(PyVistaDeprecationWarning, match='anti_aliasing'):


### PR DESCRIPTION
I noticed quadruple backticks in a recent PR, there was another one I found via `git grep`.