### PR TITLE
Update install dependencies in installation docs

### DIFF
--- a/doc/getting-started/installation.rst
+++ b/doc/getting-started/installation.rst
@@ -21,9 +21,11 @@ the following projects are required dependencies of PyVista:
 
 * `vtk <https://pypi.org/project/vtk/>`_ - PyVista directly inherits types from the VTK library.
 * `NumPy <https://pypi.org/project/numpy/>`_ - NumPy arrays provide a core foundation for PyVista's data array access.
-* `imageio <https://pypi.org/project/imageio/>`_ - This library is used for saving screenshots.
-* `appdirs <https://pypi.org/project/appdirs/>`_ - Data management for our example datasets so users can download tutorials on the fly.
+* `pillow <https://pypi.org/project/Pillow/>`_ - PIL fork used for saving screenshots.
+* `imageio <https://pypi.org/project/imageio/>`_ - This library is used for reading images and writing animations.
+* `pooch <https://pypi.org/project/pooch/>`_ - Data management for our example datasets so users can download tutorials on the fly.
 * `scooby <https://github.com/banesullivan/scooby>`_ - Reporting and debugging tools.
+* `typing-extensions <https://pypi.org/project/typing-extensions/>`_ - only required on Python 3.7.
 
 
 Optional Dependencies


### PR DESCRIPTION
I noticed that `appdirs` was still mentioned in the installation documentation. Taking a closer look I saw that the list was incomplete in other ways. I've tried updating this section to be more up to date; I'm not sure about the blurbs I added to some of the items (pillow and imageio, mainly).

`typing-extensions` is specified as "`python_version < 3.8`", but the package itself is 3.7 or higher, so I only kept 3.7 in the docs.

I also noticed that some of these required dependencies (`imageio` and `PIL`) are present in nested imports. I'm not sure this makes sense now that these are mandatory; it might be cleaner to pull out these imports into the global namespace where they belong? Should we do this? (Even if yes, probably in a separate PR.)