### PR TITLE
Add a badge for the supported Python version.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,11 +51,14 @@ PyVista
   :target: https://github.com/psf/black
   :alt: black
 
+.. |python| image:: https://img.shields.io/badge/python-3.7+-blue.svg
+   :target: https://www.python.org/downloads/
+
 
 +----------------------+-----------+------------+
 | Deployment           | |pypi|    |   |conda|  |
 +----------------------+-----------+------------+
-| Build Status         | |GH-CI|                |
+| Build Status         | |GH-CI|   |  |python|  |
 +----------------------+-----------+------------+
 | Metrics              | |codacy|  |  |codecov| |
 +----------------------+-----------+------------+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -236,10 +236,13 @@ Status
 .. |discuss| image:: https://img.shields.io/badge/GitHub-Discussions-green?logo=github
    :target: https://github.com/pyvista/pyvista/discussions
 
+.. |python| image:: https://img.shields.io/badge/python-3.7+-blue.svg
+   :target: https://www.python.org/downloads/
+
 +----------------------+----------------+-------------+
 | Deployment           | |pypi|         | |conda|     |
 +----------------------+----------------+-------------+
-| Build Status         | |GH-CI|                      |
+| Build Status         | |GH-CI|        |  |python|   |
 +----------------------+----------------+-------------+
 | Metrics              | |codacy|       | |codecov|   |
 +----------------------+----------------+-------------+


### PR DESCRIPTION
### Overview

Add a badge to display the Python version supported by PyVista.
Even if this info is already available in the `readme.rst` file, badges are user friendly and expose all the info about the package at the same location.

The target of the badge points to the `python.org` in case a user needs to download the proper Python version.

