### PR TITLE
change default points_gaussian representation

### DIFF
--- a/doc/api/utilities/color_table/color_table.rst
+++ b/doc/api/utilities/color_table/color_table.rst
@@ -1,0 +1,914 @@
+
+.. list-table::
+   :widths: 50 20 30
+   :header-rows: 1
+
+   * - Name
+     - Hex value
+     - Example
+
+   * - ``"aliceblue"``
+     - ``#F0F8FF``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #F0F8FF;'>&nbsp;</span>
+
+   * - ``"antiquewhite"``
+     - ``#FAEBD7``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FAEBD7;'>&nbsp;</span>
+
+   * - ``"aquamarine"``
+     - ``#7FFFD4``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #7FFFD4;'>&nbsp;</span>
+
+   * - ``"azure"``
+     - ``#F0FFFF``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #F0FFFF;'>&nbsp;</span>
+
+   * - ``"beige"``
+     - ``#F5F5DC``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #F5F5DC;'>&nbsp;</span>
+
+   * - ``"bisque"``
+     - ``#FFE4C4``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFE4C4;'>&nbsp;</span>
+
+   * - ``"black"`` or ``"k"``
+     - ``#000000``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #000000;'>&nbsp;</span>
+
+   * - ``"blanchedalmond"``
+     - ``#FFEBCD``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFEBCD;'>&nbsp;</span>
+
+   * - ``"blue"`` or ``"b"``
+     - ``#0000FF``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #0000FF;'>&nbsp;</span>
+
+   * - ``"blueviolet"``
+     - ``#8A2BE2``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #8A2BE2;'>&nbsp;</span>
+
+   * - ``"brown"``
+     - ``#654321``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #654321;'>&nbsp;</span>
+
+   * - ``"burlywood"``
+     - ``#DEB887``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #DEB887;'>&nbsp;</span>
+
+   * - ``"cadetblue"``
+     - ``#5F9EA0``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #5F9EA0;'>&nbsp;</span>
+
+   * - ``"chartreuse"``
+     - ``#7FFF00``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #7FFF00;'>&nbsp;</span>
+
+   * - ``"chocolate"``
+     - ``#D2691E``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #D2691E;'>&nbsp;</span>
+
+   * - ``"coral"``
+     - ``#FF7F50``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FF7F50;'>&nbsp;</span>
+
+   * - ``"cornflowerblue"``
+     - ``#6495ED``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #6495ED;'>&nbsp;</span>
+
+   * - ``"cornsilk"``
+     - ``#FFF8DC``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFF8DC;'>&nbsp;</span>
+
+   * - ``"crimson"``
+     - ``#DC143C``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #DC143C;'>&nbsp;</span>
+
+   * - ``"cyan"`` or ``"c"`` or ``"aqua"``
+     - ``#00FFFF``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #00FFFF;'>&nbsp;</span>
+
+   * - ``"darkblue"``
+     - ``#00008B``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #00008B;'>&nbsp;</span>
+
+   * - ``"darkcyan"``
+     - ``#008B8B``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #008B8B;'>&nbsp;</span>
+
+   * - ``"darkgoldenrod"``
+     - ``#B8860B``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #B8860B;'>&nbsp;</span>
+
+   * - ``"darkgray"`` or ``"darkgrey"``
+     - ``#A9A9A9``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #A9A9A9;'>&nbsp;</span>
+
+   * - ``"darkgreen"``
+     - ``#006400``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #006400;'>&nbsp;</span>
+
+   * - ``"darkkhaki"``
+     - ``#BDB76B``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #BDB76B;'>&nbsp;</span>
+
+   * - ``"darkmagenta"``
+     - ``#8B008B``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #8B008B;'>&nbsp;</span>
+
+   * - ``"darkolivegreen"``
+     - ``#556B2F``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #556B2F;'>&nbsp;</span>
+
+   * - ``"darkorange"``
+     - ``#FF8C00``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FF8C00;'>&nbsp;</span>
+
+   * - ``"darkorchid"``
+     - ``#9932CC``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #9932CC;'>&nbsp;</span>
+
+   * - ``"darkred"``
+     - ``#8B0000``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #8B0000;'>&nbsp;</span>
+
+   * - ``"darksalmon"``
+     - ``#E9967A``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #E9967A;'>&nbsp;</span>
+
+   * - ``"darkseagreen"``
+     - ``#8FBC8F``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #8FBC8F;'>&nbsp;</span>
+
+   * - ``"darkslateblue"``
+     - ``#483D8B``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #483D8B;'>&nbsp;</span>
+
+   * - ``"darkslategray"`` or ``"darkslategrey"``
+     - ``#2F4F4F``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #2F4F4F;'>&nbsp;</span>
+
+   * - ``"darkturquoise"``
+     - ``#00CED1``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #00CED1;'>&nbsp;</span>
+
+   * - ``"darkviolet"``
+     - ``#9400D3``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #9400D3;'>&nbsp;</span>
+
+   * - ``"deeppink"``
+     - ``#FF1493``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FF1493;'>&nbsp;</span>
+
+   * - ``"deepskyblue"``
+     - ``#00BFFF``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #00BFFF;'>&nbsp;</span>
+
+   * - ``"dimgray"`` or ``"dimgrey"``
+     - ``#696969``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #696969;'>&nbsp;</span>
+
+   * - ``"dodgerblue"``
+     - ``#1E90FF``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #1E90FF;'>&nbsp;</span>
+
+   * - ``"firebrick"``
+     - ``#B22222``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #B22222;'>&nbsp;</span>
+
+   * - ``"floralwhite"``
+     - ``#FFFAF0``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFFAF0;'>&nbsp;</span>
+
+   * - ``"forestgreen"``
+     - ``#228B22``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #228B22;'>&nbsp;</span>
+
+   * - ``"gainsboro"``
+     - ``#DCDCDC``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #DCDCDC;'>&nbsp;</span>
+
+   * - ``"ghostwhite"``
+     - ``#F8F8FF``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #F8F8FF;'>&nbsp;</span>
+
+   * - ``"gold"``
+     - ``#FFD700``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFD700;'>&nbsp;</span>
+
+   * - ``"goldenrod"``
+     - ``#DAA520``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #DAA520;'>&nbsp;</span>
+
+   * - ``"gray"`` or ``"grey"``
+     - ``#808080``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #808080;'>&nbsp;</span>
+
+   * - ``"green"`` or ``"g"``
+     - ``#008000``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #008000;'>&nbsp;</span>
+
+   * - ``"greenyellow"``
+     - ``#ADFF2F``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #ADFF2F;'>&nbsp;</span>
+
+   * - ``"honeydew"``
+     - ``#F0FFF0``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #F0FFF0;'>&nbsp;</span>
+
+   * - ``"hotpink"``
+     - ``#FF69B4``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FF69B4;'>&nbsp;</span>
+
+   * - ``"indianred"``
+     - ``#CD5C5C``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #CD5C5C;'>&nbsp;</span>
+
+   * - ``"indigo"``
+     - ``#4B0082``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #4B0082;'>&nbsp;</span>
+
+   * - ``"ivory"``
+     - ``#FFFFF0``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFFFF0;'>&nbsp;</span>
+
+   * - ``"khaki"``
+     - ``#F0E68C``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #F0E68C;'>&nbsp;</span>
+
+   * - ``"lavender"``
+     - ``#E6E6FA``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #E6E6FA;'>&nbsp;</span>
+
+   * - ``"lavenderblush"``
+     - ``#FFF0F5``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFF0F5;'>&nbsp;</span>
+
+   * - ``"lawngreen"``
+     - ``#7CFC00``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #7CFC00;'>&nbsp;</span>
+
+   * - ``"lemonchiffon"``
+     - ``#FFFACD``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFFACD;'>&nbsp;</span>
+
+   * - ``"lightblue"``
+     - ``#ADD8E6``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #ADD8E6;'>&nbsp;</span>
+
+   * - ``"lightcoral"``
+     - ``#F08080``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #F08080;'>&nbsp;</span>
+
+   * - ``"lightcyan"``
+     - ``#E0FFFF``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #E0FFFF;'>&nbsp;</span>
+
+   * - ``"lightgoldenrodyellow"``
+     - ``#FAFAD2``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FAFAD2;'>&nbsp;</span>
+
+   * - ``"lightgray"`` or ``"lightgrey"``
+     - ``#D3D3D3``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #D3D3D3;'>&nbsp;</span>
+
+   * - ``"lightgreen"``
+     - ``#90EE90``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #90EE90;'>&nbsp;</span>
+
+   * - ``"lightpink"``
+     - ``#FFB6C1``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFB6C1;'>&nbsp;</span>
+
+   * - ``"lightsalmon"``
+     - ``#FFA07A``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFA07A;'>&nbsp;</span>
+
+   * - ``"lightseagreen"``
+     - ``#20B2AA``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #20B2AA;'>&nbsp;</span>
+
+   * - ``"lightskyblue"``
+     - ``#87CEFA``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #87CEFA;'>&nbsp;</span>
+
+   * - ``"lightslategray"`` or ``"lightslategrey"``
+     - ``#778899``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #778899;'>&nbsp;</span>
+
+   * - ``"lightsteelblue"``
+     - ``#B0C4DE``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #B0C4DE;'>&nbsp;</span>
+
+   * - ``"lightyellow"``
+     - ``#FFFFE0``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFFFE0;'>&nbsp;</span>
+
+   * - ``"lime"``
+     - ``#00FF00``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #00FF00;'>&nbsp;</span>
+
+   * - ``"limegreen"``
+     - ``#32CD32``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #32CD32;'>&nbsp;</span>
+
+   * - ``"linen"``
+     - ``#FAF0E6``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FAF0E6;'>&nbsp;</span>
+
+   * - ``"magenta"`` or ``"m"`` or ``"fuchsia"``
+     - ``#FF00FF``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FF00FF;'>&nbsp;</span>
+
+   * - ``"maroon"``
+     - ``#800000``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #800000;'>&nbsp;</span>
+
+   * - ``"mediumaquamarine"``
+     - ``#66CDAA``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #66CDAA;'>&nbsp;</span>
+
+   * - ``"mediumblue"``
+     - ``#0000CD``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #0000CD;'>&nbsp;</span>
+
+   * - ``"mediumorchid"``
+     - ``#BA55D3``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #BA55D3;'>&nbsp;</span>
+
+   * - ``"mediumpurple"``
+     - ``#9370DB``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #9370DB;'>&nbsp;</span>
+
+   * - ``"mediumseagreen"``
+     - ``#3CB371``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #3CB371;'>&nbsp;</span>
+
+   * - ``"mediumslateblue"``
+     - ``#7B68EE``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #7B68EE;'>&nbsp;</span>
+
+   * - ``"mediumspringgreen"``
+     - ``#00FA9A``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #00FA9A;'>&nbsp;</span>
+
+   * - ``"mediumturquoise"``
+     - ``#48D1CC``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #48D1CC;'>&nbsp;</span>
+
+   * - ``"mediumvioletred"``
+     - ``#C71585``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #C71585;'>&nbsp;</span>
+
+   * - ``"midnightblue"``
+     - ``#191970``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #191970;'>&nbsp;</span>
+
+   * - ``"mintcream"``
+     - ``#F5FFFA``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #F5FFFA;'>&nbsp;</span>
+
+   * - ``"mistyrose"``
+     - ``#FFE4E1``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFE4E1;'>&nbsp;</span>
+
+   * - ``"moccasin"``
+     - ``#FFE4B5``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFE4B5;'>&nbsp;</span>
+
+   * - ``"navajowhite"``
+     - ``#FFDEAD``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFDEAD;'>&nbsp;</span>
+
+   * - ``"navy"``
+     - ``#000080``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #000080;'>&nbsp;</span>
+
+   * - ``"oldlace"``
+     - ``#FDF5E6``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FDF5E6;'>&nbsp;</span>
+
+   * - ``"olive"``
+     - ``#808000``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #808000;'>&nbsp;</span>
+
+   * - ``"olivedrab"``
+     - ``#6B8E23``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #6B8E23;'>&nbsp;</span>
+
+   * - ``"orange"``
+     - ``#FFA500``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFA500;'>&nbsp;</span>
+
+   * - ``"orangered"``
+     - ``#FF4500``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FF4500;'>&nbsp;</span>
+
+   * - ``"orchid"``
+     - ``#DA70D6``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #DA70D6;'>&nbsp;</span>
+
+   * - ``"palegoldenrod"``
+     - ``#EEE8AA``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #EEE8AA;'>&nbsp;</span>
+
+   * - ``"palegreen"``
+     - ``#98FB98``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #98FB98;'>&nbsp;</span>
+
+   * - ``"paleturquoise"``
+     - ``#AFEEEE``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #AFEEEE;'>&nbsp;</span>
+
+   * - ``"palevioletred"``
+     - ``#DB7093``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #DB7093;'>&nbsp;</span>
+
+   * - ``"papayawhip"``
+     - ``#FFEFD5``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFEFD5;'>&nbsp;</span>
+
+   * - ``"paraview_background"`` or ``"pv"`` or ``"paraview"``
+     - ``#52576e``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #52576e;'>&nbsp;</span>
+
+   * - ``"peachpuff"``
+     - ``#FFDAB9``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFDAB9;'>&nbsp;</span>
+
+   * - ``"peru"``
+     - ``#CD853F``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #CD853F;'>&nbsp;</span>
+
+   * - ``"pink"``
+     - ``#FFC0CB``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFC0CB;'>&nbsp;</span>
+
+   * - ``"plum"``
+     - ``#DDA0DD``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #DDA0DD;'>&nbsp;</span>
+
+   * - ``"powderblue"``
+     - ``#B0E0E6``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #B0E0E6;'>&nbsp;</span>
+
+   * - ``"purple"``
+     - ``#800080``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #800080;'>&nbsp;</span>
+
+   * - ``"raw_sienna"``
+     - ``#965434``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #965434;'>&nbsp;</span>
+
+   * - ``"rebeccapurple"``
+     - ``#663399``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #663399;'>&nbsp;</span>
+
+   * - ``"red"`` or ``"r"``
+     - ``#FF0000``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FF0000;'>&nbsp;</span>
+
+   * - ``"rosybrown"``
+     - ``#BC8F8F``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #BC8F8F;'>&nbsp;</span>
+
+   * - ``"royalblue"``
+     - ``#4169E1``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #4169E1;'>&nbsp;</span>
+
+   * - ``"saddlebrown"``
+     - ``#8B4513``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #8B4513;'>&nbsp;</span>
+
+   * - ``"salmon"``
+     - ``#FA8072``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FA8072;'>&nbsp;</span>
+
+   * - ``"sandybrown"``
+     - ``#F4A460``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #F4A460;'>&nbsp;</span>
+
+   * - ``"seagreen"``
+     - ``#2E8B57``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #2E8B57;'>&nbsp;</span>
+
+   * - ``"seashell"``
+     - ``#FFF5EE``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFF5EE;'>&nbsp;</span>
+
+   * - ``"sienna"``
+     - ``#A0522D``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #A0522D;'>&nbsp;</span>
+
+   * - ``"silver"``
+     - ``#C0C0C0``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #C0C0C0;'>&nbsp;</span>
+
+   * - ``"skyblue"``
+     - ``#87CEEB``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #87CEEB;'>&nbsp;</span>
+
+   * - ``"slateblue"``
+     - ``#6A5ACD``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #6A5ACD;'>&nbsp;</span>
+
+   * - ``"slategray"`` or ``"slategrey"``
+     - ``#708090``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #708090;'>&nbsp;</span>
+
+   * - ``"snow"``
+     - ``#FFFAFA``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFFAFA;'>&nbsp;</span>
+
+   * - ``"springgreen"``
+     - ``#00FF7F``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #00FF7F;'>&nbsp;</span>
+
+   * - ``"steelblue"``
+     - ``#4682B4``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #4682B4;'>&nbsp;</span>
+
+   * - ``"tan"``
+     - ``#D2B48C``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #D2B48C;'>&nbsp;</span>
+
+   * - ``"teal"``
+     - ``#008080``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #008080;'>&nbsp;</span>
+
+   * - ``"thistle"``
+     - ``#D8BFD8``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #D8BFD8;'>&nbsp;</span>
+
+   * - ``"tomato"``
+     - ``#FF6347``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FF6347;'>&nbsp;</span>
+
+   * - ``"turquoise"``
+     - ``#40E0D0``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #40E0D0;'>&nbsp;</span>
+
+   * - ``"violet"``
+     - ``#EE82EE``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #EE82EE;'>&nbsp;</span>
+
+   * - ``"wheat"``
+     - ``#F5DEB3``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #F5DEB3;'>&nbsp;</span>
+
+   * - ``"white"`` or ``"w"``
+     - ``#FFFFFF``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFFFFF;'>&nbsp;</span>
+
+   * - ``"whitesmoke"``
+     - ``#F5F5F5``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #F5F5F5;'>&nbsp;</span>
+
+   * - ``"yellow"`` or ``"y"``
+     - ``#FFFF00``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #FFFF00;'>&nbsp;</span>
+
+   * - ``"yellowgreen"``
+     - ``#9ACD32``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #9ACD32;'>&nbsp;</span>
+
+   * - ``"tab:blue"``
+     - ``#1f77b4``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #1f77b4;'>&nbsp;</span>
+
+   * - ``"tab:orange"``
+     - ``#ff7f0e``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #ff7f0e;'>&nbsp;</span>
+
+   * - ``"tab:green"``
+     - ``#2ca02c``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #2ca02c;'>&nbsp;</span>
+
+   * - ``"tab:red"``
+     - ``#d62728``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #d62728;'>&nbsp;</span>
+
+   * - ``"tab:purple"``
+     - ``#9467bd``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #9467bd;'>&nbsp;</span>
+
+   * - ``"tab:brown"``
+     - ``#8c564b``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #8c564b;'>&nbsp;</span>
+
+   * - ``"tab:pink"``
+     - ``#e377c2``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #e377c2;'>&nbsp;</span>
+
+   * - ``"tab:gray"``
+     - ``#7f7f7f``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #7f7f7f;'>&nbsp;</span>
+
+   * - ``"tab:olive"``
+     - ``#bcbd22``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #bcbd22;'>&nbsp;</span>
+
+   * - ``"tab:cyan"``
+     - ``#17becf``
+     - .. raw:: html
+
+          <span style='width:100%; height:100%; display:block; background-color: #17becf;'>&nbsp;</span>

--- a/examples/02-plot/point-clouds.py
+++ b/examples/02-plot/point-clouds.py
@@ -89,7 +89,7 @@ actor = pl.add_points(
     point_size=10,
     ambient=0.7,
 )
-pl.add_text('"points" not as spheres')
+pl.add_text('"points" not as spheres', color='w')
 
 # Gaussian points
 pl.subplot(0, 1)
@@ -104,7 +104,7 @@ actor = pl.add_points(
     point_size=10,
     ambient=1.0,
 )
-pl.add_text('"points_gaussian" not as spheres\nemissive=False')
+pl.add_text('"points_gaussian" not as spheres\nemissive=False', color='w')
 
 # Gaussian points with emissive=True
 pl.subplot(1, 0)
@@ -115,12 +115,11 @@ actor = pl.add_points(
     emissive=True,
     scalars=rgba,
     rgba=True,
-    # opacity=0.999999,  # does not work and _must_ be 1.0
     point_size=10,
 )
-pl.add_text('"points_gaussian" not as spheres\nemissive=True')
+pl.add_text('"points_gaussian" not as spheres\nemissive=True', color='w')
 
-# Gaussian points with emissive=True
+# With render_points_as_spheres=True
 pl.subplot(1, 1)
 actor = pl.add_points(
     points,
@@ -130,11 +129,10 @@ actor = pl.add_points(
     rgba=True,
     point_size=10,
 )
-pl.add_text('"points_gaussian" as spheres')
+pl.add_text('"points_gaussian" as spheres', color='w')
 
 pl.background_color = 'k'
 pl.link_views()
-# pl.reset_camera()
 pl.camera_position = 'xy'
 pl.camera.zoom(1.2)
 pl.show()

--- a/pyvista/plotting/_plotting.py
+++ b/pyvista/plotting/_plotting.py
@@ -235,7 +235,7 @@ def _common_arg_parser(
     feature_angle = kwargs.pop('feature_angle', theme.sharp_edges_feature_angle)
     if render_points_as_spheres is None:
         if style == 'points_gaussian':
-            render_points_as_spheres = True
+            render_points_as_spheres = False
         else:
             render_points_as_spheres = theme.render_points_as_spheres
 

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -429,7 +429,7 @@ class Color:
 
        <details><summary>Refer to the table below for a list of supported colors.</summary>
 
-    .. include:: ../colors.rst
+    .. include:: ../color_table/color_table.rst
 
     .. raw:: html
 


### PR DESCRIPTION
This PR changes the default points_gaussian to use `render_points_as_spheres=False`. This is a bit more of a sensible default as `emissive=False` by default and it has no issues rendering on a white background.

Also moves `colors.rst` into a new directory and renames it to `colors_table` as sphinx was complaining about a recursive include locally despite clean builds. I'm not sure why it's not occuring in our builds, but I'd like to make sure this issue doesn't occur for others.
