### PR TITLE
add version check for mpl

### DIFF
--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -975,7 +975,18 @@ def get_cmap_safe(cmap):
                 'The use of custom colormaps requires the installation of matplotlib.'
             )  # pragma: no cover
 
-        from matplotlib import colormaps, colors
+        try:
+            from matplotlib import colormaps, colors
+        except ImportError:  # pragma: no cover
+            import matplotlib
+            import scooby
+
+            min_req = '3.5.0'
+            if not scooby.meets_version(matplotlib.__version__, min_req):
+                raise ImportError(
+                    'The use of custom colormaps requires the installation of '
+                    f'matplotlib>={min_req}.'
+                ) from None
 
         if not isinstance(cmap, colors.Colormap):
             cmap = colormaps[cmap]


### PR DESCRIPTION
With

```py
from matplotlib import colormaps, colors
```

In `pyvista/plotting/colors.py` if `matplotlib<3.5.0` we get an `ImportError`. Since we don't specify a minimum version for `matplotlib` since it's not a direct dependency, and neither does `vtk`, we can either try to make our imports backwards compatible or just complain about a minimum supported version.

Since `3.5.0` was out around a year ago, I think it's safe to simply require it, even though it seems a little restrictive. We can implement a follow-up PR with some additional logic if we deem it necessary. For now, this is a improvement over the current implementation.