### PR TITLE
Clarify that interpolate only maps point data to point data

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -3011,7 +3011,11 @@ class DataSetFilters:
     ):
         """Interpolate values onto this mesh from a given dataset.
 
-        The input dataset is typically a point cloud.
+        The input dataset is typically a point cloud. Only point data from
+        the source mesh will be interpolated onto points of this mesh. Whether
+        preexisting point and cell data of this mesh are preserved in the
+        output can be customized with the ``pass_point_data`` and
+        ``pass_cell_data`` parameters.
 
         This uses a Gaussian interpolation kernel. Use the ``sharpness`` and
         ``radius`` parameters to adjust this kernel. You can also switch this


### PR DESCRIPTION
I came across the fact that `interpolate()` only maps point data to point data:
```py
import pyvista as pv

source = pv.Sphere()
target = pv.Icosahedron(radius=0.6)
for mesh in source, target:
    mesh.clear_data()

# add data to source and target
target.point_data['point old'] = range(target.n_points)
target.cell_data['cell old'] = range(target.n_cells)
source.point_data['point new'] = range(source.n_points)
source.cell_data['cell new'] = range(source.n_cells)

# interpolate
target = target.interpolate(source)
print(f'{target.point_data.keys()=}')
print(f'{target.cell_data.keys()=}')

# output:
# target.point_data.keys()=['point new', 'point old']
# target.cell_data.keys()=['cell old']
```
Cell data on the source is ignored, and point data is interpolated to point data on the target mesh. This seems worth clarifying in the docs. (The arrays `'point old'` and `'cell old'` are preserved due to the default `pass_point_data=True, pass_cell_data=True` values, and this is clearly explained in the docs already, but I also pointed this out at the start of the docstring anyway.)

I also noticed that together with `probe()` and `sample()` these three functions seems to show three different behaviours in this regard... to a varying degree of being specified in their docs.