### PR TITLE
Move google_analytics_id to analytics in pydata-sphinx-theme

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -433,7 +433,7 @@ html_show_sourcelink = False
 # documentation.
 #
 html_theme_options = {
-    "google_analytics_id": "UA-140243896-1",
+    "analytics": "UA-140243896-1",
     "show_prev_next": False,
     "github_url": "https://github.com/pyvista/pyvista",
     "collapse_navigation": True,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -433,7 +433,6 @@ html_show_sourcelink = False
 # documentation.
 #
 html_theme_options = {
-    "analytics": analytics_options,
     "show_prev_next": False,
     "github_url": "https://github.com/pyvista/pyvista",
     "collapse_navigation": True,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -433,7 +433,7 @@ html_show_sourcelink = False
 # documentation.
 #
 html_theme_options = {
-    "analytics": "UA-140243896-1",
+    "analytics": analytics_options,
     "show_prev_next": False,
     "github_url": "https://github.com/pyvista/pyvista",
     "collapse_navigation": True,
@@ -460,6 +460,9 @@ html_theme_options = {
             "icon": "fa fa-file-text fa-fw",
         },
     ],
+}
+html_theme_options["analytics"] = {
+    "google_analytics_id": "UA-140243896-1",
 }
 
 # sphinx-panels shouldn't add bootstrap css since the pydata-sphinx-theme

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -433,6 +433,7 @@ html_show_sourcelink = False
 # documentation.
 #
 html_theme_options = {
+    "analytics": {"google_analytics_id": "UA-140243896-1"},
     "show_prev_next": False,
     "github_url": "https://github.com/pyvista/pyvista",
     "collapse_navigation": True,
@@ -459,9 +460,6 @@ html_theme_options = {
             "icon": "fa fa-file-text fa-fw",
         },
     ],
-}
-html_theme_options["analytics"] = {
-    "google_analytics_id": "UA-140243896-1",
 }
 
 # sphinx-panels shouldn't add bootstrap css since the pydata-sphinx-theme

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -16,7 +16,7 @@ numpydoc==1.5.0
 osmnx==1.2.2
 panel==0.14.1
 param==1.12.2  # due to panel bug
-pydata-sphinx-theme==0.11.0
+pydata-sphinx-theme==0.12.0
 pypandoc==1.10
 pytest-sphinx==0.5.0
 pythreejs==2.4.1


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
`google_analytics_id` is deprecated in pydata-sphinx-theme after 0.12. Use `analytics` instead.

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 
https://github.com/pyvista/pyvista/pull/3611

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- See https://github.com/pydata/pydata-sphinx-theme/pull/828.
