### PR TITLE
Python 3 style using pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,12 @@ repos:
     "typing-extensions==4.1.1",
   ]
 
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.2.2
+  hooks:
+  - id: pyupgrade
+    args: [--py37-plus, --keep-runtime-typing]
+
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0
   hooks:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,5 @@
 import datetime
+import faulthandler
 import locale
 import os
 import sys
@@ -6,10 +7,7 @@ import sys
 # Otherwise VTK reader issues on some systems, causing sphinx to crash. See also #226.
 locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
 
-if sys.version_info >= (3, 0):
-    import faulthandler
-
-    faulthandler.enable()
+faulthandler.enable()
 
 sys.path.insert(0, os.path.abspath("."))
 import make_external_gallery

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -250,8 +250,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
     def __iter__(self) -> Iterator[str]:
         """Implement for loop iteration."""
-        for array in self.keys():
-            yield array
+        yield from self.keys()
 
     def __len__(self) -> int:
         """Return the number of arrays."""

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2144,7 +2144,7 @@ class PolyDataFilters(DataSetFilters):
         )
         if retry:
             # gather intersecting rays in lists
-            loc_lst, ray_lst, tri_lst = [arr.tolist() for arr in [locations, index_ray, index_tri]]
+            loc_lst, ray_lst, tri_lst = (arr.tolist() for arr in [locations, index_ray, index_tri])
 
             # find indices that trimesh failed on
             all_ray_indices = np.arange(len(origins))

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2144,7 +2144,9 @@ class PolyDataFilters(DataSetFilters):
         )
         if retry:
             # gather intersecting rays in lists
-            loc_lst, ray_lst, tri_lst = (arr.tolist() for arr in [locations, index_ray, index_tri])
+            loc_lst = locations.tolist()
+            ray_lst = index_ray.tolist()
+            tri_lst = index_tri.tolist()
 
             # find indices that trimesh failed on
             all_ray_indices = np.arange(len(origins))

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1,5 +1,5 @@
 """Sub-classes and wrappers for vtk.vtkPointSet."""
-import collections.abc as collections
+import collections.abc
 from functools import wraps
 import numbers
 import os
@@ -1293,9 +1293,9 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
             self._check_for_consistency()
 
         elif len(args) == 3:  # and VTK9:
-            arg0_is_seq = isinstance(args[0], (np.ndarray, collections.Sequence))
-            arg1_is_seq = isinstance(args[1], (np.ndarray, collections.Sequence))
-            arg2_is_seq = isinstance(args[2], (np.ndarray, collections.Sequence))
+            arg0_is_seq = isinstance(args[0], (np.ndarray, collections.abc.Sequence))
+            arg1_is_seq = isinstance(args[1], (np.ndarray, collections.abc.Sequence))
+            arg2_is_seq = isinstance(args[2], (np.ndarray, collections.abc.Sequence))
 
             if all([arg0_is_seq, arg1_is_seq, arg2_is_seq]):
                 self._from_arrays(None, args[0], args[1], args[2], deep, **kwargs)
@@ -1304,10 +1304,10 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
                 raise TypeError('All input types must be sequences.')
 
         elif len(args) == 4:  # pragma: no cover
-            arg0_is_arr = isinstance(args[0], (np.ndarray, collections.Sequence))
-            arg1_is_arr = isinstance(args[1], (np.ndarray, collections.Sequence))
-            arg2_is_arr = isinstance(args[2], (np.ndarray, collections.Sequence))
-            arg3_is_arr = isinstance(args[3], (np.ndarray, collections.Sequence))
+            arg0_is_arr = isinstance(args[0], (np.ndarray, collections.abc.Sequence))
+            arg1_is_arr = isinstance(args[1], (np.ndarray, collections.abc.Sequence))
+            arg2_is_arr = isinstance(args[2], (np.ndarray, collections.abc.Sequence))
+            arg3_is_arr = isinstance(args[3], (np.ndarray, collections.abc.Sequence))
 
             if all([arg0_is_arr, arg1_is_arr, arg2_is_arr, arg3_is_arr]):
                 self._from_arrays(args[0], args[1], args[2], args[3], deep)
@@ -2044,7 +2044,7 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
         if len(key) != 3:
             raise RuntimeError('Slices must have exactly 3 dimensions.')
         for i, k in enumerate(key):
-            if isinstance(k, collections.Iterable):
+            if isinstance(k, collections.abc.Iterable):
                 raise RuntimeError('Fancy indexing is not supported.')
             if isinstance(k, numbers.Integral):
                 start = stop = k

--- a/pyvista/ext/coverage.py
+++ b/pyvista/ext/coverage.py
@@ -215,7 +215,7 @@ class CoverageBuilder(Builder):
                     # is not defined in this module
                     continue
 
-                full_name = '%s.%s' % (mod_name, name)
+                full_name = f'{mod_name}.{name}'
                 if self.ignore_pyobj(full_name):
                     continue
 
@@ -257,7 +257,7 @@ class CoverageBuilder(Builder):
                             if skip_undoc and not attr.__doc__:
                                 # skip methods without docstring if wished
                                 continue
-                            full_attr_name = '%s.%s' % (full_name, attr_name)
+                            full_attr_name = f'{full_name}.{attr_name}'
                             if self.ignore_pyobj(full_attr_name):
                                 continue
                             if full_attr_name not in objects:

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -538,7 +538,7 @@ def run(arguments, content, options, state_machine, state, lineno):
             images = []
 
         opts = [
-            ':%s: %s' % (key, val)
+            f':{key}: {val}'
             for key, val in options.items()
             if key in ('alt', 'height', 'width', 'scale', 'align')
         ]

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -41,7 +41,7 @@ class _vtkWrapperMeta(type):
         return obj
 
 
-class _vtkWrapper(object, metaclass=_vtkWrapperMeta):
+class _vtkWrapper(metaclass=_vtkWrapperMeta):
     def __getattribute__(self, item):
         unwrapped_attrs = ["_wrapped", "__class__", "__init__"]
         wrapped = super().__getattribute__("_wrapped")
@@ -978,7 +978,7 @@ class Axis(_vtkWrapper, _vtk.vtkAxis):
 
 
 class _CustomContextItem(_vtk.vtkPythonItem):
-    class ItemWrapper(object):
+    class ItemWrapper:
         def Initialize(self, item):
             # item is the _CustomContextItem subclass instance
             return True
@@ -3419,8 +3419,7 @@ class Chart2D(_vtk.vtkChartXY, _Chart):
         """
         plot_types = self.PLOT_TYPES.keys() if plot_type is None else [plot_type]
         for plot_type in plot_types:
-            for plot in self._plots[plot_type]:
-                yield plot
+            yield from self._plots[plot_type]
 
     def remove_plot(self, plot):
         """Remove the given plot from this chart.
@@ -4475,8 +4474,7 @@ class Charts:
 
     def __iter__(self):
         """Return an iterable of charts."""
-        for chart in self._charts:
-            yield chart
+        yield from self._charts
 
     def __del__(self):
         """Clean up before being destroyed."""

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -586,9 +586,9 @@ class Color:
         try:
             if len(rgba) != 4:
                 raise ValueError("Invalid length for RGBA sequence.")
-            self._red, self._green, self._blue, self._opacity = [
+            self._red, self._green, self._blue, self._opacity = (
                 self.convert_color_channel(c) for c in rgba
-            ]
+            )
         except ValueError:
             raise ValueError(f"Invalid RGB(A) sequence: {arg}") from None
 

--- a/pyvista/plotting/renderers.py
+++ b/pyvista/plotting/renderers.py
@@ -246,8 +246,7 @@ class Renderers:
 
     def __iter__(self):
         """Return a iterable of renderers."""
-        for renderer in self._renderers:
-            yield renderer
+        yield from self._renderers
 
     @property
     def active_index(self):

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1609,7 +1609,7 @@ class WidgetHelper:
         spline_widget.PlaceWidget(bounds)
         spline_widget.SetResolution(resolution)
         if initial_points is not None:
-            spline_widget.InitializeHandles(pyvista.vtk_points((initial_points)))
+            spline_widget.InitializeHandles(pyvista.vtk_points(initial_points))
         else:
             spline_widget.SetClosed(closed)
         spline_widget.Modified()

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -179,13 +179,13 @@ def read(filename, attrs=None, force_ext=None, file_format=None, progress_bar=Fa
     except ValueError:
         # if using force_ext, we are explicitly only using vtk readers
         if force_ext is not None:
-            raise IOError("This file was not able to be automatically read by pvista.")
+            raise OSError("This file was not able to be automatically read by pvista.")
         from meshio._exceptions import ReadError
 
         try:
             return read_meshio(filename)
         except ReadError:
-            raise IOError("This file was not able to be automatically read by pyvista.")
+            raise OSError("This file was not able to be automatically read by pyvista.")
     else:
         observer = pyvista.utilities.errors.Observer()
         observer.observe(reader.reader)

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -1896,7 +1896,7 @@ class PVDReader(BaseReader, TimeReader):
                 )
             )
         self._datasets = sorted(datasets)
-        self._time_values = sorted(list(set([dataset.time for dataset in self.datasets])))
+        self._time_values = sorted({dataset.time for dataset in self.datasets})
 
         self.set_active_time_value(self.time_values[0])
 

--- a/tests/check_doctest_names.py
+++ b/tests/check_doctest_names.py
@@ -128,7 +128,7 @@ def check_doctests(modules=None, respect_skips=True, verbose=True):
         of failed doctests under the specified modules.
 
     """
-    skip_pattern = re.compile('doctest: *\+SKIP')  # noqa: W605
+    skip_pattern = re.compile(r'doctest: *\+SKIP')
 
     if modules is None:
         modules = discover_modules()

--- a/tests/plotting/conftest.py
+++ b/tests/plotting/conftest.py
@@ -22,7 +22,7 @@ def _is_vtk(obj):
 @pytest.fixture(autouse=True)
 def check_gc(request):
     """Ensure that all VTK objects are garbage-collected by Python."""
-    before = set(id(o) for o in gc.get_objects() if _is_vtk(o))
+    before = {id(o) for o in gc.get_objects() if _is_vtk(o)}
     yield
 
     # Do not check for collection if the test session failed. Tests that fail

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -2085,7 +2085,7 @@ def test_index_vs_loc():
     with pytest.raises(TypeError):
         pl.renderers.index_to_loc(1.5)
     with pytest.raises(IndexError):
-        pl.renderers.index_to_loc((-1))
+        pl.renderers.index_to_loc(-1)
     with pytest.raises(TypeError):
         pl.renderers.index_to_loc((1, 2))
     with pytest.raises(IndexError):

--- a/tests/plotting/test_widgets.py
+++ b/tests/plotting/test_widgets.py
@@ -208,6 +208,14 @@ def test_widget_spline(uniform):
     p.close()
 
     p = pyvista.Plotter()
+    p.add_mesh(uniform)
+    pts = np.array([[1, 5, 4], [2, 4, 9], [3, 6, 2]])
+    with pytest.raises(ValueError, match='`initial_points` must be length `n_handles`'):
+        p.add_spline_widget(callback=func, n_handles=4, initial_points=pts)
+    p.add_spline_widget(callback=func, n_handles=3, initial_points=pts)
+    p.close()
+
+    p = pyvista.Plotter()
     func = lambda spline, widget: spline  # Does nothing
     p.add_mesh(uniform)
     p.add_spline_widget(callback=func, pass_widget=True, color=None, show_ribbon=True)


### PR DESCRIPTION
### Overview

This upgrades a few Python 3 styles, automated using [pyupgrade](https://github.com/asottile/pyupgrade), using the command:
```shell
$ pyupgrade --py37-plus `find . -name "*.py*"`
```
with a few manual edits for quality control.

### Details

- Use "yield from" where possible
- Use f-strings where possible
- Updates to python modules faulthandler and collections.abc
- No need to inherit classes from object anymore
- IOError is an alias for OSError
- Correction to use a raw string `r'doctest: *\+SKIP')`; I believe "noqa: [W605](https://www.flake8rules.com/rules/W605.html)" was incorrect and should not have been ignored
- Remove unnecessary parentheses
- Use `set` comprehension and literals

If any of these styles are objectionable and the current is preferred, note these and I'll restore them.