### PR TITLE
Change unresolved BasePlotter intersphinx refs to Plotter

### DIFF
--- a/examples/02-plot/multi-window.py
+++ b/examples/02-plot/multi-window.py
@@ -12,7 +12,7 @@ from pyvista import examples
 ###############################################################################
 # This example shows how to create a multi-window plotter by specifying the
 # ``shape`` parameter.  The window generated is a two by two window by setting
-# ``shape=(2, 2)``. Use the :func:`pyvista.BasePlotter.subplot` function to
+# ``shape=(2, 2)``. Use the :func:`pyvista.Plotter.subplot` function to
 # select the subplot you wish to be the active subplot.
 
 plotter = pv.Plotter(shape=(2, 2))
@@ -116,8 +116,9 @@ groups = [
 
 plotter = pv.Plotter(shape=shape, row_weights=row_weights, col_weights=col_weights, groups=groups)
 
+###############################################################################
 # A grouped subplot can be activated through any of its composing cells using
-# the :func:`pyvista.BasePlotter.subplot` function.
+# the :func:`pyvista.Plotter.subplot` method.
 
 # Access all subplots and groups and plot something:
 plotter.subplot(0, 0)

--- a/examples/02-plot/multi-window.py
+++ b/examples/02-plot/multi-window.py
@@ -12,7 +12,7 @@ from pyvista import examples
 ###############################################################################
 # This example shows how to create a multi-window plotter by specifying the
 # ``shape`` parameter.  The window generated is a two by two window by setting
-# ``shape=(2, 2)``. Use the :func:`pyvista.Plotter.subplot` function to
+# ``shape=(2, 2)``. Use the :func:`pyvista.Plotter.subplot` method to
 # select the subplot you wish to be the active subplot.
 
 plotter = pv.Plotter(shape=(2, 2))

--- a/examples/02-plot/multi-window.py
+++ b/examples/02-plot/multi-window.py
@@ -116,9 +116,8 @@ groups = [
 
 plotter = pv.Plotter(shape=shape, row_weights=row_weights, col_weights=col_weights, groups=groups)
 
-###############################################################################
 # A grouped subplot can be activated through any of its composing cells using
-# the :func:`pyvista.Plotter.subplot` method.
+# the subplot() method.
 
 # Access all subplots and groups and plot something:
 plotter.subplot(0, 0)

--- a/examples/02-plot/scalar-bars.py
+++ b/examples/02-plot/scalar-bars.py
@@ -34,8 +34,8 @@ p.show()
 # We could also plot the scene with an interactive scalar bar to move around
 # and place where we like by specifying passing keyword arguments to control
 # the scalar bar via the ``scalar_bar_args`` parameter in
-# :func:`pyvista.BasePlotter.add_mesh`. The keyword arguments to control the
-# scalar bar are defined in :func:`pyvista.BasePlotter.add_scalar_bar`.
+# :func:`pyvista.Plotter.add_mesh`. The keyword arguments to control the
+# scalar bar are defined in :func:`pyvista.Plotter.add_scalar_bar`.
 
 # create dictionary of parameters to control scalar bar
 sargs = dict(interactive=True)  # Simply make the bar interactive

--- a/examples/02-plot/volume.py
+++ b/examples/02-plot/volume.py
@@ -35,7 +35,7 @@ vol.plot(volume=True, cmap="bone", cpos=cpos)
 # Opacity Mappings
 # ++++++++++++++++
 #
-# Or use the :func:`pyvista.BasePlotter.add_volume` method like below.
+# Or use the :func:`pyvista.Plotter.add_volume` method like below.
 # Note that here we use a non-default opacity mapping to a sigmoid:
 
 p = pv.Plotter()

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2192,7 +2192,7 @@ class PolyDataFilters(DataSetFilters):
 
         **kwargs : dict, optional
             All additional keyword arguments will be passed to
-            :func:`pyvista.BasePlotter.add_mesh`.
+            :func:`pyvista.Plotter.add_mesh`.
 
         Returns
         -------
@@ -2250,7 +2250,7 @@ class PolyDataFilters(DataSetFilters):
 
         **kwargs : dict, optional
             All additional keyword arguments will be passed to
-            :func:`pyvista.BasePlotter.add_mesh`.
+            :func:`pyvista.Plotter.add_mesh`.
 
         Returns
         -------

--- a/pyvista/plotting/composite_mapper.py
+++ b/pyvista/plotting/composite_mapper.py
@@ -701,7 +701,7 @@ class CompositePolyDataMapper(_vtk.vtkCompositePolyDataMapper2, _BaseMapper):
         scalar_bar_args : dict
             Dictionary of keyword arguments to pass when adding the
             scalar bar to the scene. For options, see
-            :func:`pyvista.BasePlotter.add_scalar_bar`.
+            :func:`pyvista.Plotter.add_scalar_bar`.
 
         n_colors : int
             Number of colors to use when displaying scalars.

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -468,7 +468,7 @@ class DataSetMapper(_vtk.vtkDataSetMapper, _BaseMapper):
         scalar_bar_args : dict, optional
             Dictionary of keyword arguments to pass when adding the
             scalar bar to the scene. For options, see
-            :func:`pyvista.BasePlotter.add_scalar_bar`.
+            :func:`pyvista.Plotter.add_scalar_bar`.
 
         rgb : bool, default: False
             If an 2 dimensional array is passed as the scalars, plot

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -659,7 +659,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         the rendering engine supports it.
 
         Disable this with :func:`disable_hidden_line_removal
-        <BasePlotter.disable_hidden_line_removal>`
+        <Plotter.disable_hidden_line_removal>`.
 
         Parameters
         ----------
@@ -696,7 +696,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         """Disable hidden line removal.
 
         Enable again with :func:`enable_hidden_line_removal
-        <BasePlotter.enable_hidden_line_removal>`
+        <Plotter.enable_hidden_line_removal>`.
 
         Parameters
         ----------
@@ -1637,7 +1637,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         This will potentially slow down the interactor. No callbacks
         supported here - use
-        :func:`pyvista.BasePlotter.track_click_position` instead.
+        :func:`pyvista.Plotter.track_click_position` instead.
 
         """
         self.iren.track_mouse_position(self.store_mouse_position)
@@ -1837,7 +1837,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         """Enable anaglyph stereo rendering.
 
         Disable this with :func:`disable_stereo_render
-        <BasePlotter.disable_stereo_render>`
+        <Plotter.disable_stereo_render>`
 
         Examples
         --------
@@ -1858,7 +1858,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         """Disable anaglyph stereo rendering.
 
         Enable again with :func:`enable_stereo_render
-        <BasePlotter.enable_stereo_render>`
+        <Plotter.enable_stereo_render>`
 
         Examples
         --------
@@ -2087,7 +2087,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         label : str, optional
             String label to use when adding a legend to the scene with
-            :func:`pyvista.BasePlotter.add_legend`.
+            :func:`pyvista.Plotter.add_legend`.
 
         reset_camera : bool, optional
             Reset the camera after adding this mesh to the scene. The default
@@ -2099,7 +2099,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         scalar_bar_args : dict, optional
             Dictionary of keyword arguments to pass when adding the
             scalar bar to the scene. For options, see
-            :func:`pyvista.BasePlotter.add_scalar_bar`.
+            :func:`pyvista.Plotter.add_scalar_bar`.
 
         show_scalar_bar : bool
             If ``False``, a scalar bar will not be added to the
@@ -2497,7 +2497,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         This method is using a mesh representation to view the surfaces
         and/or geometry of datasets. For volume rendering, see
-        :func:`pyvista.BasePlotter.add_volume`.
+        :func:`pyvista.Plotter.add_volume`.
 
         To see the what most of the following parameters look like in action,
         please refer to :class:`pyvista.Property`.
@@ -2607,7 +2607,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         label : str, optional
             String label to use when adding a legend to the scene with
-            :func:`pyvista.BasePlotter.add_legend`.
+            :func:`pyvista.Plotter.add_legend`.
 
         reset_camera : bool, optional
             Reset the camera after adding this mesh to the scene. The default
@@ -2619,7 +2619,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         scalar_bar_args : dict, optional
             Dictionary of keyword arguments to pass when adding the
             scalar bar to the scene. For options, see
-            :func:`pyvista.BasePlotter.add_scalar_bar`.
+            :func:`pyvista.Plotter.add_scalar_bar`.
 
         show_scalar_bar : bool
             If ``False``, a scalar bar will not be added to the
@@ -3337,7 +3337,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         scalar_bar_args : dict, optional
             Dictionary of keyword arguments to pass when adding the
             scalar bar to the scene. For options, see
-            :func:`pyvista.BasePlotter.add_scalar_bar`.
+            :func:`pyvista.Plotter.add_scalar_bar`.
 
         show_scalar_bar : bool
             If ``False``, a scalar bar will not be added to the
@@ -4472,7 +4472,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         label : str, optional
             String label to use when adding a legend to the scene with
-            :func:`pyvista.BasePlotter.add_legend`.
+            :func:`pyvista.Plotter.add_legend`.
 
         name : str, optional
             The name for the added actor so that it can be easily updated.
@@ -4761,7 +4761,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def add_point_scalar_labels(self, points, labels, fmt=None, preamble='', **kwargs):
         """Label the points from a dataset with the values of their scalars.
 
-        Wrapper for :func:`pyvista.BasePlotter.add_point_labels`.
+        Wrapper for :func:`pyvista.Plotter.add_point_labels`.
 
         Parameters
         ----------
@@ -4781,7 +4781,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         **kwargs : dict, optional
             Keyword arguments passed to
-            :func:`pyvista.BasePlotter.add_point_labels`.
+            :func:`pyvista.Plotter.add_point_labels`.
 
         Returns
         -------
@@ -4822,7 +4822,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             ``render_points_as_spheres`` options.
 
         **kwargs : dict, optional
-            See :func:`pyvista.BasePlotter.add_mesh` for optional
+            See :func:`pyvista.Plotter.add_mesh` for optional
             keyword arguments.
 
         Returns
@@ -4872,7 +4872,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Amount to scale the direction vectors.
 
         **kwargs : dict, optional
-            See :func:`pyvista.BasePlotter.add_mesh` for optional
+            See :func:`pyvista.Plotter.add_mesh` for optional
             keyword arguments.
 
         Returns
@@ -5940,7 +5940,7 @@ class Plotter(BasePlotter):
 
         interactive_update : bool, optional
             Disabled by default.  Allows user to non-blocking draw,
-            user should call :func:`BasePlotter.update` in each iteration.
+            user should call :func:`Plotter.update` in each iteration.
 
         full_screen : bool, optional
             Opens window in full screen.  When enabled, ignores

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -178,7 +178,7 @@ class RenderWindowInteractor:
         """Keep track of the mouse position.
 
         This will potentially slow down the interactor. No callbacks supported
-        here - use :func:`pyvista.BasePlotter.track_click_position` instead.
+        here - use :func:`pyvista.Plotter.track_click_position` instead.
 
         """
         self.add_observer(_vtk.vtkCommand.MouseMoveEvent, callback)


### PR DESCRIPTION
I noticed that `BasePlotter` method references don't resolve in the docs:

![screenshot from outside plotting.py showing red, unresolved pyvista.BasePlotter.subplot() reference](https://user-images.githubusercontent.com/17914410/203657996-3ad3cbfc-b525-4f7e-8b06-c6c2f06d4733.png)

![screenshot from within plotting.py showing red, unresolved BasePlotter.update reference](https://user-images.githubusercontent.com/17914410/203658017-b121cce6-0903-4fb3-a8f9-66a65b19ff6c.png)

Switching the references to `Plotter` should fix the issue (existing links referring to `pyvista.Plotter`, or within `plotting.py` to `Plotter`, get resolved correctly).