### PR TITLE
Don't raise on missing iren key events to clear by default

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1608,16 +1608,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if hasattr(self, 'iren'):
             self.iren.add_key_event(*args, **kwargs)
 
-    def clear_events_for_key(self, key):
-        """Remove the callbacks associated to the key.
-
-        Parameters
-        ----------
-        key : str
-            Key to clear events for.
-
-        """
-        self.iren.clear_events_for_key(key)
+    @wraps(RenderWindowInteractor.clear_events_for_key)
+    def clear_events_for_key(self, *args, **kwargs):
+        """Wrap RenderWindowInteractor.clear_events_for_key."""
+        if hasattr(self, 'iren'):
+            self.iren.clear_events_for_key(*args, **kwargs)
 
     def store_mouse_position(self, *args):
         """Store mouse position."""

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -178,7 +178,7 @@ class RenderWindowInteractor:
         key : str
             Key to clear events for.
 
-        raise_on_missing : bool, default=False
+        raise_on_missing : bool, default: False
             Whether to raise a :class:`ValueError` if there are no events
             registered for the given key.
         """

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -170,9 +170,23 @@ class RenderWindowInteractor:
         for observer in observers:
             self.remove_observer(observer)
 
-    def clear_events_for_key(self, key):
-        """Remove the callbacks associated to the key."""
-        self._key_press_event_callbacks.pop(key)
+    def clear_events_for_key(self, key, raise_on_missing=False):
+        """Remove the callbacks associated to the key.
+
+        Parameters
+        ----------
+        key : str
+            Key to clear events for.
+
+        raise_on_missing : bool, default=False
+            Whether to raise a :class:`ValueError` if there are no events
+            registered for the given key.
+        """
+        try:
+            self._key_press_event_callbacks.pop(key)
+        except KeyError:
+            if raise_on_missing:
+                raise ValueError(f'No events found for key {key}.') from None
 
     def track_mouse_position(self, callback):
         """Keep track of the mouse position.

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -186,7 +186,7 @@ class RenderWindowInteractor:
             self._key_press_event_callbacks.pop(key)
         except KeyError:
             if raise_on_missing:
-                raise ValueError(f'No events found for key {key}.') from None
+                raise ValueError(f'No events found for key {key!r}.') from None
 
     def track_mouse_position(self, callback):
         """Keep track of the mouse position.

--- a/tests/test_render_window_interactor.py
+++ b/tests/test_render_window_interactor.py
@@ -28,6 +28,10 @@ def test_observers():
     assert key in pl.iren._key_press_event_callbacks
     pl.clear_events_for_key(key)
     assert key not in pl.iren._key_press_event_callbacks
+    # attempting to clear non-existing events doesn't raise by default
+    pl.clear_events_for_key(key)
+    with pytest.raises(ValueError, match='No events found for key'):
+        pl.clear_events_for_key(key, raise_on_missing=True)
 
     # Custom events
     assert not pl.iren.interactor.HasObserver(


### PR DESCRIPTION
Currently `RenderWindowInteractor.clear_events_for_key()` (wrapped by `Plotter.clear_events_for_key()`) will raise if we try to remove events for a key that has none:
```py
>>> import pyvista as pv
>>> pv.Plotter().clear_events_for_key('a')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/adeak/pyvista/pyvista/plotting/plotting.py", line 1620, in clear_events_for_key
    self.iren.clear_events_for_key(key)
  File "/home/adeak/pyvista/pyvista/plotting/render_window_interactor.py", line 175, in clear_events_for_key
    self._key_press_event_callbacks.pop(key)
KeyError: 'a'
```
I think this would be better if it didn't raise by default, and if it did, raised something else. (I'm on the fence on whether this is actually a bug, labelling with "enhancement" for now.)

There are multiple potential approaches here, the first one I took for this PR is to change the default not to raise, and allow the old behaviour using a keyword argument. But still the error type is replaced. Many of these details could be changed, and I'm open for alternatives, this was just the most logical path for me.

After the patch:
```py
>>> import pyvista as pv
>>> pv.Plotter().clear_events_for_key('a')
>>> pv.Plotter().clear_events_for_key('a', raise_on_missing=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/adeak/pyvista/pyvista/plotting/plotting.py", line 1615, in clear_events_for_key
    self.iren.clear_events_for_key(*args, **kwargs)
  File "/home/adeak/pyvista/pyvista/plotting/render_window_interactor.py", line 189, in clear_events_for_key
    raise ValueError(f'No events found for key {key!r}.') from None
ValueError: No events found for key 'a'.
```

Labelling this as a breaking change, if we decide to change what we do here then we'll have to reconsider whether the label is necessary.