### PR TITLE
Add support to modulate the tube filter's radius in absolute units

### DIFF
--- a/examples/00-load/create-spline.py
+++ b/examples/00-load/create-spline.py
@@ -101,6 +101,15 @@ spline.plot(line_width=4, color="k")
 
 
 ###############################################################################
+# The radius of the tube can be modulated with scalars
+
+spline["theta"] = 0.4 * np.arange(len(spline.points))
+spline["radius"] = np.abs(np.sin(spline["theta"]))
+tube = spline.tube(scalars="radius", absolute=True)
+tube.plot(scalars="theta", smooth_shading=True)
+
+
+###############################################################################
 # Ribbons
 # +++++++
 #

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -1019,29 +1019,27 @@ class PolyDataFilters(DataSetFilters):
         scalars : str, optional
             Scalars array by which the radius varies.
 
-        capping : bool, optional
-            Turn on/off whether to cap the ends with polygons. Default
-            ``True``.
+        capping : bool, default: True
+            Turn on/off whether to cap the ends with polygons.
 
-        n_sides : int, optional
+        n_sides : int, default: 20
             Set the number of sides for the tube. Minimum of 3.
 
-        radius_factor : float, optional
+        radius_factor : float, default: 10
             Maximum tube radius in terms of a multiple of the minimum
             radius.
 
-        absolute : bool, optional
+        absolute : bool, default: False
             Vary the radius with values from scalars in absolute units.
-            Default ``False``.
 
-        preference : str, optional
+        preference : str, default: 'point'
             The field preference when searching for the scalars array by
             name.
 
-        inplace : bool, optional
+        inplace : bool, default: False
             Whether to update the mesh in-place.
 
-        progress_bar : bool, optional
+        progress_bar : bool, default: False
             Display a progress bar to indicate progress.
 
         Returns

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -999,7 +999,7 @@ class PolyDataFilters(DataSetFilters):
         scalars=None,
         capping=True,
         n_sides=20,
-        radius_factor=10,
+        radius_factor=10.0,
         absolute=False,
         preference='point',
         inplace=False,
@@ -1025,7 +1025,7 @@ class PolyDataFilters(DataSetFilters):
         n_sides : int, default: 20
             Set the number of sides for the tube. Minimum of 3.
 
-        radius_factor : float, default: 10
+        radius_factor : float, default: 10.0
             Maximum tube radius in terms of a multiple of the minimum
             radius.
 

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -1000,6 +1000,7 @@ class PolyDataFilters(DataSetFilters):
         capping=True,
         n_sides=20,
         radius_factor=10,
+        absolute=False,
         preference='point',
         inplace=False,
         progress_bar=False,
@@ -1028,6 +1029,10 @@ class PolyDataFilters(DataSetFilters):
         radius_factor : float, optional
             Maximum tube radius in terms of a multiple of the minimum
             radius.
+
+        absolute : float, optional
+            Vary the radius with values from scalars in absolute units.
+            Default ``False``.
 
         preference : str, optional
             The field preference when searching for the scalars array by
@@ -1080,7 +1085,10 @@ class PolyDataFilters(DataSetFilters):
             field = poly_data.get_array_association(scalars, preference=preference)
             # args: (idx, port, connection, field, name)
             tube.SetInputArrayToProcess(0, 0, 0, field.value, scalars)
-            tube.SetVaryRadiusToVaryRadiusByScalar()
+            if not absolute:
+                tube.SetVaryRadiusToVaryRadiusByScalar()
+            else:
+                tube.SetVaryRadiusToVaryRadiusByAbsoluteScalar()
         # Apply the filter
         _update_alg(tube, progress_bar, 'Creating Tube')
 

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -1030,7 +1030,7 @@ class PolyDataFilters(DataSetFilters):
             Maximum tube radius in terms of a multiple of the minimum
             radius.
 
-        absolute : float, optional
+        absolute : bool, optional
             Vary the radius with values from scalars in absolute units.
             Default ``False``.
 

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -1085,10 +1085,10 @@ class PolyDataFilters(DataSetFilters):
             field = poly_data.get_array_association(scalars, preference=preference)
             # args: (idx, port, connection, field, name)
             tube.SetInputArrayToProcess(0, 0, 0, field.value, scalars)
-            if not absolute:
-                tube.SetVaryRadiusToVaryRadiusByScalar()
-            else:
+            if absolute:
                 tube.SetVaryRadiusToVaryRadiusByAbsoluteScalar()
+            else:
+                tube.SetVaryRadiusToVaryRadiusByScalar()
         # Apply the filter
         _update_alg(tube, progress_bar, 'Creating Tube')
 

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -744,6 +744,10 @@ def test_tube(spline):
     tube = spline.tube(radius=0.5, scalars='arc_length', progress_bar=True)
     assert tube.n_points, tube.n_cells
 
+    # Complicated with absolute radius
+    tube = spline.tube(radius=0.5, scalars='arc_length', absolute=True, progress_bar=True)
+    assert tube.n_points, tube.n_cells
+
     with pytest.raises(TypeError):
         spline.tube(scalars=range(10))
 

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -734,7 +734,7 @@ def test_tube(spline):
     # Simple
     line = pyvista.Line()
     tube = line.tube(n_sides=2, progress_bar=True)
-    assert tube.n_points, tube.n_cells
+    assert tube.n_points and tube.n_cells
 
     # inplace
     line.tube(n_sides=2, inplace=True, progress_bar=True)
@@ -742,11 +742,11 @@ def test_tube(spline):
 
     # Complicated
     tube = spline.tube(radius=0.5, scalars='arc_length', progress_bar=True)
-    assert tube.n_points, tube.n_cells
+    assert tube.n_points and tube.n_cells
 
     # Complicated with absolute radius
     tube = spline.tube(radius=0.5, scalars='arc_length', absolute=True, progress_bar=True)
-    assert tube.n_points, tube.n_cells
+    assert tube.n_points and tube.n_cells
 
     with pytest.raises(TypeError):
         spline.tube(scalars=range(10))


### PR DESCRIPTION

### Overview
This PR adds an argument to the tube filter so that the radius can be specified in absolute units for convenience.

```
spline.tube(scalars="radius", absolute=True)
```
Internally, it uses the [SetVaryRadiusToVaryRadiusByAbsoluteScalar](https://vtk.org/doc/nightly/html/classvtkTubeFilter.html#acdb459567a6d41696f3f29e8cd602639) of vtkTubeFilter.

### Details
 - support to modulate the tube's radius in absolute units, the default behavior remains unchanged
 - added an example to the create_spline section
 
![Screenshot from 2022-11-27 01-16-29](https://user-images.githubusercontent.com/1239359/204114105-7462c3de-0e94-473d-a064-4bd1da6dea57.png)
