### PR TITLE
Add interrogate to .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,13 @@ repos:
     "typing-extensions==4.1.1",
   ]
 
+- repo: https://github.com/econchick/interrogate
+  rev: 1.5.0
+  hooks:
+  - id: interrogate
+    exclude: ^(doc/|tests/|examples/|pyvista/ext/|examples_flask/)
+    args: [--fail-under=80, --verbose]
+
 - repo: https://github.com/asottile/pyupgrade
   rev: v3.2.2
   hooks:


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Add [interrogate](https://interrogate.readthedocs.io/en/latest/): measure docstring coverage to .pre-commit-config.yaml.
<p align="center">
    <img width="200" src="https://interrogate.readthedocs.io/en/latest/_static/logo_pink.png" alt="interrogate logo pink">
</p>

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- We have already passed coverage so there may not be a need to add it, but I decided to suggest it for future coverage drops.
- An error will occur if coverage of 80% (the recommended value for interrogate) is not met.
