### PR TITLE
Remove legacy numpy aliases removed in 1.24.0

### DIFF
--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -17,9 +17,9 @@ from pyvista.utilities.misc import PyVistaDeprecationWarning
 test_path = os.path.dirname(os.path.abspath(__file__))
 
 # must be manually set until pytest adds parametrize with fixture feature
-HEXBEAM_CELLS_BOOL = np.ones(40, np.bool_)  # matches hexbeam.n_cells == 40
-STRUCTGRID_CELLS_BOOL = np.ones(729, np.bool_)  # struct_grid.n_cells == 729
-STRUCTGRID_POINTS_BOOL = np.ones(1000, np.bool_)  # struct_grid.n_points == 1000
+HEXBEAM_CELLS_BOOL = np.ones(40, dtype=bool)  # matches hexbeam.n_cells == 40
+STRUCTGRID_CELLS_BOOL = np.ones(729, dtype=bool)  # struct_grid.n_cells == 729
+STRUCTGRID_POINTS_BOOL = np.ones(1000, dtype=bool)  # struct_grid.n_points == 1000
 
 pointsetmark = pytest.mark.skipif(
     pyvista.vtk_version_info < (9, 1, 0), reason="Requires VTK>=9.1.0 for a concrete PointSet class"
@@ -454,7 +454,7 @@ def test_extract_cells(hexbeam):
     assert part_beam.n_points < hexbeam.n_points
     assert np.allclose(part_beam.cell_data['vtkOriginalCellIds'], ind)
 
-    mask = np.zeros(hexbeam.n_cells, np.bool_)
+    mask = np.zeros(hexbeam.n_cells, dtype=bool)
     mask[ind] = True
     part_beam = hexbeam.extract_cells(mask)
     assert part_beam.n_cells == len(ind)
@@ -1164,7 +1164,7 @@ def test_remove_cells_not_inplace(ind, hexbeam):
 def test_remove_cells_invalid(hexbeam):
     grid_copy = hexbeam.copy()
     with pytest.raises(ValueError):
-        grid_copy.remove_cells(np.ones(10, np.bool_), inplace=True)
+        grid_copy.remove_cells(np.ones(10, dtype=bool), inplace=True)
 
 
 @pytest.mark.parametrize('ind', [range(10), np.arange(10), STRUCTGRID_CELLS_BOOL])
@@ -1177,7 +1177,7 @@ def test_hide_cells(ind, struct_grid):
     assert out.HasAnyBlankCells()
 
     with pytest.raises(ValueError, match='Boolean array size must match'):
-        struct_grid.hide_cells(np.ones(10, dtype=np.bool), inplace=True)
+        struct_grid.hide_cells(np.ones(10, dtype=bool), inplace=True)
 
 
 @pytest.mark.parametrize('ind', [range(10), np.arange(10), STRUCTGRID_POINTS_BOOL])
@@ -1186,7 +1186,7 @@ def test_hide_points(ind, struct_grid):
     assert struct_grid.HasAnyBlankPoints()
 
     with pytest.raises(ValueError, match='Boolean array size must match'):
-        struct_grid.hide_points(np.ones(10, dtype=np.bool))
+        struct_grid.hide_points(np.ones(10, dtype=bool))
 
 
 def test_set_extent():

--- a/tests/utilities/test_reader.py
+++ b/tests/utilities/test_reader.py
@@ -466,7 +466,7 @@ def test_pvdreader():
 
     assert reader.number_time_points == 15
     assert reader.time_point_value(1) == 1.0
-    assert np.array_equal(reader.time_values, np.arange(0, 15, dtype=np.float))
+    assert np.array_equal(reader.time_values, np.arange(0, 15, dtype=float))
 
     assert reader.active_time_value == reader.time_values[0]
 


### PR DESCRIPTION
NumPy 1.24.0rc1 is out. We have a handful of test failures arising from the inevitable removal of legacy aliases:
```py
# numpy<1.24.0
print(all([np.int is int, np.float is float, np.bool is bool, np.complex is complex]))
# True; plus a screenful of deprecation warnings
```

We can fix some of these that have snuck back into PyVista since the last purge, but there's also an issue that ITK (at least 0.32.3 which is the newest one matching our requirements for Python < 3.10) breaks due to this:
```py
>>> import itkwidgets
In the future `np.bool` will be defined as the corresponding NumPy scalar.  (This may have returned Python scalars in past versions.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/adeak/tmp_test_env_py39/lib/python3.9/site-packages/itkwidgets/__init__.py", line 13, in <module>
    from .widget_viewer import Viewer, view
  File "/home/adeak/tmp_test_env_py39/lib/python3.9/site-packages/itkwidgets/widget_viewer.py", line 14, in <module>
    import itk
  File "/home/adeak/tmp_test_env_py39/lib/python3.9/site-packages/itk/__init__.py", line 28, in <module>
    from itk.support.extras import *
  File "/home/adeak/tmp_test_env_py39/lib/python3.9/site-packages/itk/support/extras.py", line 35, in <module>
    import itk.support.types as itkt
  File "/home/adeak/tmp_test_env_py39/lib/python3.9/site-packages/itk/support/types.py", line 175, in <module>
    ) = itkCType.initialize_c_types_once()
  File "/home/adeak/tmp_test_env_py39/lib/python3.9/site-packages/itk/support/types.py", line 140, in initialize_c_types_once
    _B: "itkCType" = itkCType("bool", "B", np.bool)
  File "/home/adeak/tmp_test_env_py39/lib/python3.9/site-packages/numpy/__init__.py", line 284, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'bool'
```

This breaks our `tests/jupyter/test_itk_plotting.py`, and it breaks `pyvista.Report()` due to its import of `itkwidgets`. We'll have to wait with bumping 1.24 until upstream fixes this, until then we should make sure our own codebase stays clean.