### PR TITLE
Remove progressbar from pooch fetch

### DIFF
--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -182,7 +182,6 @@ def _download_file(filename, progress_bar):
         filename,
         processor=Unzip() if filename.endswith('.zip') else None,
         downloader=_file_copier if _FILE_CACHE else None,
-        progressbar=progress_bar,
     )
 
 


### PR DESCRIPTION
As pointed out [in a question on Stack Overflow](https://stackoverflow.com/questions/74652965/pyvista-download-of-examples-raises-error), PyVista breaks on anything older than the currently newest `pooch` (1.6.0, released in January 2022).

Removing the `progressbar` kwarg from the call to `fetch()` makes us compatible with `pooch` 1.3.0 the oldest, which was [released 2 years ago](https://github.com/fatiando/pooch/releases/tag/v1.3.0). 1.3.0 added the `retry_if_failed` feature, which is something we should keep, so this should be an acceptable compromise. 