### PR TITLE
Fix Circle to remove singular edge

### DIFF
--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -1291,8 +1291,9 @@ def Circle(radius=0.5, resolution=100):
 
     Notes
     -----
-    Prior to version 0.38, this method had incorrect results, which
-    are now fixed. See pull request 3710 for details.
+    .. versionchanged:: 0.38.0
+       Prior to version 0.38, this method had incorrect results, producing
+       inconsistent edge lengths and a duplicated point which is now fixed.
 
     """
     points = np.zeros((resolution, 3))

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -1291,10 +1291,9 @@ def Circle(radius=0.5, resolution=100):
 
     Notes
     --------
-
     prior to version 0.38,
         this method had incorrect results, which are now fixed.
-    See [#3710](https://github.com/pyvista/pyvista/pull/3710) for details.
+    See pull request 3710 for details.
     """
     points = np.zeros((resolution, 3))
     theta = np.linspace(0.0, 2.0 * np.pi, resolution, endpoint=False)

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -1288,6 +1288,13 @@ def Circle(radius=0.5, resolution=100):
     >>> radius = 0.5
     >>> circle = pyvista.Circle(radius)
     >>> circle.plot(show_edges=True, line_width=5)
+
+    Notes
+    --------
+
+    prior to version 0.38,
+        this method had incorrect results, which are now fixed.
+    See [#3710](https://github.com/pyvista/pyvista/pull/3710) for details.
     """
     points = np.zeros((resolution, 3))
     theta = np.linspace(0.0, 2.0 * np.pi, resolution, endpoint=False)

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -1290,10 +1290,10 @@ def Circle(radius=0.5, resolution=100):
     >>> circle.plot(show_edges=True, line_width=5)
 
     Notes
-    --------
-    prior to version 0.38,
-        this method had incorrect results, which are now fixed.
-    See pull request 3710 for details.
+    -----
+    Prior to version 0.38, this method had incorrect results, which
+    are now fixed. See pull request 3710 for details.
+
     """
     points = np.zeros((resolution, 3))
     theta = np.linspace(0.0, 2.0 * np.pi, resolution, endpoint=False)

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -1290,7 +1290,7 @@ def Circle(radius=0.5, resolution=100):
     >>> circle.plot(show_edges=True, line_width=5)
     """
     points = np.zeros((resolution, 3))
-    theta = np.linspace(0.0, 2.0 * np.pi, resolution)
+    theta = np.linspace(0.0, 2.0 * np.pi, resolution, endpoint=False)
     points[:, 0] = radius * np.cos(theta)
     points[:, 1] = radius * np.sin(theta)
     cells = np.array([np.append(np.array([resolution]), np.arange(resolution))])

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -1282,18 +1282,18 @@ def Circle(radius=0.5, resolution=100):
     pyvista.PolyData
         Circle mesh.
 
+    Notes
+    -----
+    .. versionchanged:: 0.38.0
+       Prior to version 0.38, this method had incorrect results, producing
+       inconsistent edge lengths and a duplicated point which is now fixed.
+
     Examples
     --------
     >>> import pyvista
     >>> radius = 0.5
     >>> circle = pyvista.Circle(radius)
     >>> circle.plot(show_edges=True, line_width=5)
-
-    Notes
-    -----
-    .. versionchanged:: 0.38.0
-       Prior to version 0.38, this method had incorrect results, producing
-       inconsistent edge lengths and a duplicated point which is now fixed.
 
     """
     points = np.zeros((resolution, 3))

--- a/tests/test_geometric_objects.py
+++ b/tests/test_geometric_objects.py
@@ -275,6 +275,11 @@ def test_circle():
     assert mesh.n_cells
     diameter = np.max(mesh.points[:, 0]) - np.min(mesh.points[:, 0])
     assert np.isclose(diameter, radius * 2.0, rtol=1e-3)
+    line_lengths = np.linalg.norm(
+        np.roll(mesh.points, shift=1, axis=0) - mesh.points,
+        axis=1,
+    )
+    assert np.allclose(line_lengths[0], line_lengths)
 
 
 def test_ellipse():


### PR DESCRIPTION
### Commits
- added test assert for circle:   all edges of the circle should have approx the same length
- Remove duplicate point, by setting endpoint=False for theta This will not change the total number of points, but the spacing of theta, now passes the updated test

### Overview

<!-- Please insert a high-level description of this pull request here. -->
Fixing bugg in pv.Circle. 
See linked issue below, for a more detailed bugg description:
resolves #3709 

### Breaking Change:
This change can break functions depending on pyvista.Circle
#### Example of broken function:

The fallowing function works with current pyvista, but with the suggested changes it will be broken.
With the changes, the hexagon function will incorrectly create a 7-sided polygon.
```python
import pyvista as pv


def hexagon(r: float) -> pv.PolyData:
    """
    creates a regular hexagon(polygon with 6 equal sides) in plane: Z=0,
     with points <r> distance from origo
    """
    # create one extra point and edge, since circle always make one incorrect edge
    hex = pv.Circle(radius=r, resolution=6 + 1)
    return hex.clean(tolerance=0.001)  # clean away the edge with near zero length
```
With the suggested pyvista changes, the hexagon implementation would need too be updated like so:
 
```python
import pyvista as pv

def hexagon(r: float) -> pv.PolyData:
    """
    creates a regular hexagon(polygon with 6 equal sides) in plane: Z=0,
     with points <r> distance from origo
    """
    hex = pv.Circle(radius=r, resolution=6)
    return hex
```

### Details

- < feature1 or bug1 description >

```python
import pyvista as pv
import numpy as np

circle4 = pv.Circle(radius=1, resolution=4)
edge_vectors = np.roll(circle4.points, shift=1, axis=0)/4  - circle4.points
print(edge_vectors)
circle4.plot()
```
#### now prints:
>[[-1., -1.,  0.],
[ 1., -1.,  0.],
[ 1.,  1.,  0.],
[-1.,  1.,  0.]])

#### old prints:
>[[ 0.     -0.      0.    ]
 [ 1.5    -0.866   0.    ]
 [ 0.      1.7321  0.    ]
 [-1.5    -0.866   0.    ]]

### plots
#### new
![circle4](https://user-images.githubusercontent.com/107837123/207076452-cad8a6c2-686f-4ef6-982c-0f0cf7af39da.png)

#### old
![old](https://user-images.githubusercontent.com/107837123/207076121-f38ad095-d5d5-42c1-8743-feb88f2986e0.png)


