### PR TITLE
Fix two other closed geometric objects.

### DIFF
--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -157,6 +157,12 @@ def CylinderStructured(
     pyvista.StructuredGrid
         Structured cylinder.
 
+    Notes
+    -----
+    .. versionchanged:: 0.38.0
+       Prior to version 0.38, this method had incorrect results, producing
+       inconsistent number of points on the circular face of the cylinder.
+
     Examples
     --------
     Default structured cylinder
@@ -176,7 +182,7 @@ def CylinderStructured(
     # Define grid in polar coordinates
     r = np.array([radius]).ravel()
     nr = len(r)
-    theta = np.linspace(0, 2 * np.pi, num=theta_resolution)
+    theta = np.linspace(0, 2 * np.pi, num=theta_resolution + 1)
     radius_matrix, theta_matrix = np.meshgrid(r, theta)
 
     # Transform to cartesian space
@@ -195,7 +201,7 @@ def CylinderStructured(
     # Create the grid
     grid = pyvista.StructuredGrid()
     grid.points = np.c_[xx, yy, zz]
-    grid.dimensions = [nr, theta_resolution, z_resolution]
+    grid.dimensions = [nr, theta_resolution + 1, z_resolution]
 
     # Orient properly in user direction
     vx = np.array([0.0, 0.0, 1.0])
@@ -1323,6 +1329,12 @@ def Ellipse(semi_major_axis=0.5, semi_minor_axis=0.2, resolution=100):
     pyvista.PolyData
         Ellipse mesh.
 
+    Notes
+    -----
+    .. versionchanged:: 0.38.0
+       Prior to version 0.38, this method had incorrect results, producing
+       inconsistent edge lengths and a duplicated point which is now fixed.
+
     Examples
     --------
     >>> import pyvista
@@ -1330,7 +1342,7 @@ def Ellipse(semi_major_axis=0.5, semi_minor_axis=0.2, resolution=100):
     >>> ellipse.plot(show_edges=True, line_width=5)
     """
     points = np.zeros((resolution, 3))
-    theta = np.linspace(0.0, 2.0 * np.pi, resolution)
+    theta = np.linspace(0.0, 2.0 * np.pi, resolution, endpoint=False)
     points[:, 0] = semi_major_axis * np.cos(theta)
     points[:, 1] = semi_minor_axis * np.sin(theta)
     cells = np.array([np.append(np.array([resolution]), np.arange(resolution))])


### PR DESCRIPTION
### Overview

As per my comment in #3710, there are two other closed geometric objects that require a fix in my opinion.

### Details

<details open>
<summary><b>Ellipse</b></summary>

```py
pyvista.Ellipse(resolution=4).plot()
```
| Before | After |
| ------- | ------ |
| ![image](https://user-images.githubusercontent.com/15089458/208305619-a8fe307a-e064-4dd2-ba08-e271ca3b99aa.png) | ![image](https://user-images.githubusercontent.com/15089458/208305652-a724bb88-de90-431c-ba54-6b88051023cb.png) |

Duplicate endpoints and inconsistent edge lengths; similar fix as in #3710.

</details>

<details open>
<summary><b>CylinderStructured</b></summary>

```py
pyvista.CylinderStructured(theta_resolution=4).plot()
```
| Before | After |
| ------- | ------ |
| ![image](https://user-images.githubusercontent.com/15089458/208305386-d3ca8e27-02ff-41cb-9ae6-2cd388b40e7c.png) | ![image](https://user-images.githubusercontent.com/15089458/208305415-a9b4db39-7f44-43fe-97ab-82279f66d279.png) |

Inconsistent number of edges/faces when compared to `Cylinder`; as this is a `StructuredGrid` duplicate endpoints are needed in this case I believe (correct me if I'm wrong), so the fix is different than for the `Ellipse` above.

</details>
