### PR TITLE
[HOTFIX] VTK 9.0.3  + NumPy<1.24 CI

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -136,7 +136,7 @@ jobs:
           - python-version: '3.7'
             vtk-version: '8.1.2'
           - python-version: '3.8'
-            vtk-version: '9.0.3'
+            vtk-version: '9.0.3'  # Requires numpy<1.24
           - python-version: '3.9'
             vtk-version: '9.1'
           - python-version: '3.10'
@@ -177,6 +177,10 @@ jobs:
 
       - name: Install Testing Requirements
         run: pip install -r requirements_test.txt
+
+      - name: Limit NumPy for VTK 9.0.3
+        if: ${{ matrix.vtk-version == '9.0.3' }}
+        run: pip install 'numpy<1.24'
 
       - name: Software Report
         run: |


### PR DESCRIPTION
NumPy 1.24.0 was released yesterday which deprecated `np.bool`. VTK 9.0.3 relied on that:

```py
/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/vtkmodules/util/numpy_support.py:216: in vtk_to_numpy
    assert typ in get_vtk_to_numpy_typemap().keys(), \
/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/vtkmodules/util/numpy_support.py:74: in get_vtk_to_numpy_typemap
    _vtk_np = {vtkConstants.VTK_BIT:numpy.bool,
/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/numpy/__init__.py:284: in __getattr__
    raise AttributeError("module {!r} has no attribute "
E   AttributeError: module 'numpy' has no attribute 'bool'
```

These changes limit NumPy for our VTK 9.0.3 CI