### PR TITLE
[hotfix] Use latest VTK version for conda tests

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -56,8 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CONDA_ALWAYS_YES: 1
-      VTK_VERSION: 8.2
-      conda_env: pyvista-vtk8.2
+      VTK_VERSION: 9.2.2
+      conda_env: pyvista-vtk9.2.2
       DISPLAY: ':99.0'
       PYVISTA_OFF_SCREEN: True
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -56,8 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CONDA_ALWAYS_YES: 1
-      VTK_VERSION: 9.2.2
-      conda_env: pyvista-vtk9.2.2
+      conda_env: pyvista-vtk
       DISPLAY: ':99.0'
       PYVISTA_OFF_SCREEN: True
 
@@ -97,7 +96,6 @@ jobs:
         run: |
           source /usr/share/miniconda/etc/profile.d/conda.sh
           conda config --add channels conda-forge
-          sed -i -e 's/- vtk$/- vtk= ${{ env.VTK_VERSION }} /' environment.yml
           conda env create --quiet -n ${{ env.conda_env }} --file environment.yml --experimental-solver=libmamba
           conda activate ${{ env.conda_env }}
           conda list


### PR DESCRIPTION
The conda tests were using VTK 8.2... why? This updates conda to use whatever the latest version is which seems most appropriate to me. Other versions of VTK are checked in other CI routines.

Either way, this needs to be updated because VTK8.2.2 is incompatible with the latest NumPy 1.24

@pyvista/developers, I plan on merging this quickly to fix broken CI