### PR TITLE
Fix builds

### DIFF
--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   build-and-publish:
     name: Build and Publish Docker Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # For Pull Requests, only runs from `docker`, `feat`, `fix`, `patch`, or `dependabot`
     if: github.event_name == 'push' ||
         ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository &&

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   doc:
     name: Build Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       PYVISTA_OFF_SCREEN: 'True'
       ALLOW_PLOTTING: true
@@ -106,7 +106,7 @@ jobs:
 
   deploy:
     name: Publish Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: doc
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     steps:
@@ -142,7 +142,7 @@ jobs:
 
   publish-notebooks:
     name: Publish Notebooks for MyBinder
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: doc
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     steps:

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -13,7 +13,7 @@ jobs:
     # This job can create issues/PRs/comments, so
     #   only run on the head `pyvista/pyvista` repo
     if: github.repository_owner == 'pyvista'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/first-interaction@v1
         with:

--- a/.github/workflows/intersphinx-update-pull-request.yml
+++ b/.github/workflows/intersphinx-update-pull-request.yml
@@ -11,7 +11,7 @@ jobs:
     # This job can create issues/PRs/comments, so
     #   only run on the head `pyvista/pyvista` repo
     if: github.repository_owner == 'pyvista'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Label based on changed files
       uses: actions/labeler@v4

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   doc:
     name: Check Links
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       PYVISTA_OFF_SCREEN: "True"
       ALLOW_PLOTTING: true

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -12,7 +12,7 @@ jobs:
     # This job can create issues/PRs/comments, so
     #   only run on the head `pyvista/pyvista` repo
     if: github.repository_owner == 'pyvista'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/style_docstr.yml
+++ b/.github/workflows/style_docstr.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   stylecheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 
@@ -26,7 +26,7 @@ jobs:
         run: pre-commit run --all-files
 
   docstringcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -53,7 +53,7 @@ jobs:
 
 
   LinuxConda:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       CONDA_ALWAYS_YES: 1
       conda_env: pyvista-vtk
@@ -124,7 +124,7 @@ jobs:
 
   Linux:
     name: Linux Unit Testing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
 

--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -162,7 +162,7 @@ class Camera(_vtk.vtkCamera):
         --------
         >>> import pyvista as pv
         >>> pl = pv.Plotter()
-        >>> pl.camera.to_paraview_pvcc("camera.pvcc")
+        >>> pl.camera.to_paraview_pvcc("camera.pvcc")  # doctest:+SKIP
         """
         root = ElementTree.Element("PVCameraConfiguration")
         root.attrib["description"] = "ParaView camera configuration"

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1052,9 +1052,10 @@ class WidgetHelper:
         Parameters
         ----------
         callback : callable
-            The method called every time the slider is updated. This
-            should take a single parameter: the float value of the
-            slider.
+            Called every time the slider is updated. This should take a single
+            parameter: the float value of the slider. If ``pass_widget=True``,
+            callable should take two parameters: the float value of the slider
+            and the widget itself.
 
         rng : tuple(float)
             Length two tuple of the minimum and maximum ranges of the
@@ -1773,11 +1774,12 @@ class WidgetHelper:
         Parameters
         ----------
         callback : callable
-            The function to call back when the widget is modified. It
-            takes a single argument: the center of the sphere as an
-            XYZ coordinate (a 3-length sequence).  If multiple centers
-            are passed in the ``center`` parameter, the callback must
-            also accept an index of that widget.
+            The function to call back when the widget is modified. It takes a
+            single argument: the center of the sphere as an XYZ coordinate (a
+            3-length sequence), unless ``pass_widget=True``, in which case the
+            callback must accept the widget object as the second parameter.  If
+            multiple centers are passed in the ``center`` parameter, the
+            callback must also accept an index of that widget.
 
         center : tuple(float), optional
             Length 3 array for the XYZ coordinate of the sphere's

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -1198,6 +1198,7 @@ def try_callback(func, *args):
         formatted_exception = 'Encountered issue in callback (most recent call last):\n' + ''.join(
             traceback.format_list(stack) + traceback.format_exception_only(etype, exc)
         ).rstrip('\n')
+        1 / 0
         warnings.warn(formatted_exception)
 
 

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -525,18 +525,17 @@ def vtk_points(points, deep=True, force_float=False):
             f'Shape is {points.shape} and should be (X, 3)'
         )
 
-    # use the underlying vtk data if present to avoid memory leaks
-    if not deep and isinstance(points, pyvista.pyvista_ndarray):
-        if points.VTKObject is not None:
-            vtkpts = _vtk.vtkPoints()
-            vtkpts.SetData(points.VTKObject)
-            return vtkpts
-
     # points must be contiguous
     points = np.require(points, requirements=['C'])
     vtkpts = _vtk.vtkPoints()
     vtk_arr = _vtk.numpy_to_vtk(points, deep=deep)
     vtkpts.SetData(vtk_arr)
+
+    # remove the numpy reference to potential circular reference
+    if not deep and isinstance(points, pyvista.pyvista_ndarray):
+        if points.VTKObject is not None:
+            del vtk_arr._numpy_reference
+
     return vtkpts
 
 

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -1198,7 +1198,6 @@ def try_callback(func, *args):
         formatted_exception = 'Encountered issue in callback (most recent call last):\n' + ''.join(
             traceback.format_list(stack) + traceback.format_exception_only(etype, exc)
         ).rstrip('\n')
-        1 / 0
         warnings.warn(formatted_exception)
 
 

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -525,6 +525,13 @@ def vtk_points(points, deep=True, force_float=False):
             f'Shape is {points.shape} and should be (X, 3)'
         )
 
+    # use the underlying vtk data if present to avoid memory leaks
+    if not deep and isinstance(points, pyvista.pyvista_ndarray):
+        if points.VTKObject is not None:
+            vtkpts = _vtk.vtkPoints()
+            vtkpts.SetData(points.VTKObject)
+            return vtkpts
+
     # points must be contiguous
     points = np.require(points, requirements=['C'])
     vtkpts = _vtk.vtkPoints()

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -531,10 +531,10 @@ def vtk_points(points, deep=True, force_float=False):
     vtk_arr = _vtk.numpy_to_vtk(points, deep=deep)
     vtkpts.SetData(vtk_arr)
 
-    # remove the numpy reference to potential circular reference
-    if not deep and isinstance(points, pyvista.pyvista_ndarray):
-        if points.VTKObject is not None:
-            del vtk_arr._numpy_reference
+    # # remove the numpy reference to potential circular reference
+    # if not deep and isinstance(points, pyvista.pyvista_ndarray):
+    #     if points.VTKObject is not None:
+    #         del vtk_arr._numpy_reference
 
     return vtkpts
 

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -525,16 +525,25 @@ def vtk_points(points, deep=True, force_float=False):
             f'Shape is {points.shape} and should be (X, 3)'
         )
 
+    # use the underlying vtk data if present to avoid memory leaks
+    if not deep and isinstance(points, pyvista.pyvista_ndarray):
+        if points.VTKObject is not None:
+            vtk_object = points.VTKObject
+
+            # we can only use the underlying data if `points` is not a slice of
+            # the VTK data object
+            if vtk_object.GetSize() == points.size:
+                vtkpts = _vtk.vtkPoints()
+                vtkpts.SetData(points.VTKObject)
+                return vtkpts
+            else:
+                deep = True
+
     # points must be contiguous
     points = np.require(points, requirements=['C'])
     vtkpts = _vtk.vtkPoints()
     vtk_arr = _vtk.numpy_to_vtk(points, deep=deep)
     vtkpts.SetData(vtk_arr)
-
-    # # remove the numpy reference to potential circular reference
-    # if not deep and isinstance(points, pyvista.pyvista_ndarray):
-    #     if points.VTKObject is not None:
-    #         del vtk_arr._numpy_reference
 
     return vtkpts
 

--- a/tests/plotting/test_collection.py
+++ b/tests/plotting/test_collection.py
@@ -64,12 +64,25 @@ def test_plotting_collection():
     assert ref_charts() is None
 
 
-def test_vtk_points(sphere):
-    orig_points = np.array(sphere.points)
-    pts = pv.vtk_points(sphere.points, deep=False)
+def test_vtk_points_slice():
+    mesh = pv.Sphere()
+    n = 10
+    orig_points = np.array(mesh.points[:n])
+    pts = pv.vtk_points(mesh.points[:n], deep=False)
     assert isinstance(pts, vtk.vtkPoints)
 
-    del sphere
-    pdata = pv.PolyData()
-    pdata.SetPoints(pts)
-    assert np.allclose(pdata.points, orig_points)
+    del mesh
+    gc.collect()
+    assert np.allclose(pv._vtk.vtk_to_numpy(pts.GetData()), orig_points)
+
+
+def test_vtk_points():
+    mesh = pv.Sphere()
+    orig_points = np.array(mesh.points)
+    pts = pv.vtk_points(mesh.points, deep=False)
+    assert isinstance(pts, vtk.vtkPoints)
+    assert np.shares_memory(mesh.points, pv._vtk.vtk_to_numpy(pts.GetData()))
+
+    del mesh
+    gc.collect()
+    assert np.allclose(pv._vtk.vtk_to_numpy(pts.GetData()), orig_points)

--- a/tests/plotting/test_collection.py
+++ b/tests/plotting/test_collection.py
@@ -65,5 +65,11 @@ def test_plotting_collection():
 
 
 def test_vtk_points(sphere):
+    orig_points = np.array(sphere.points)
     pts = pv.vtk_points(sphere.points, deep=False)
     assert isinstance(pts, vtk.vtkPoints)
+
+    del sphere
+    pdata = pv.PolyData()
+    pdata.SetPoints(pts)
+    assert np.allclose(pdata.points, orig_points)

--- a/tests/plotting/test_collection.py
+++ b/tests/plotting/test_collection.py
@@ -3,6 +3,7 @@ import gc
 import weakref
 
 import numpy as np
+import vtk
 
 import pyvista as pv
 
@@ -61,3 +62,8 @@ def test_plotting_collection():
     assert ref_renderers() is None
     assert ref_renderer() is None
     assert ref_charts() is None
+
+
+def test_vtk_points(sphere):
+    pts = pv.vtk_points(sphere.points, deep=False)
+    assert isinstance(pts, vtk.vtkPoints)

--- a/tests/plotting/test_widgets.py
+++ b/tests/plotting/test_widgets.py
@@ -164,6 +164,7 @@ def test_widget_slider(uniform):
     p.add_mesh_isovalue(uniform)
     p.close()
 
+    func = lambda value: value  # Does nothing
     p = pyvista.Plotter()
     title_height = np.random.random()
     s = p.add_slider_widget(callback=func, rng=[0, 10], style="classic", title_height=title_height)
@@ -232,9 +233,10 @@ def test_widget_uniform(uniform):
     p.add_sphere_widget(callback=func, center=(0, 0, 0))
     p.close()
 
+    # pass multiple centers
     nodes = np.array([[-1, -1, -1], [1, 1, 1]])
     p = pyvista.Plotter()
-    func = lambda center: center  # Does nothing
+    func = lambda center, index: center  # Does nothing
     p.add_sphere_widget(callback=func, center=nodes)
     p.close()
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -620,8 +620,11 @@ def test_set_t_coords(grid):
 
 
 def test_activate_texture_none(grid):
-    assert grid._activate_texture('not a key') is None
-    assert grid._activate_texture(True) is None
+    with pytest.warns(UserWarning, match=r'not a key'):
+        assert grid._activate_texture('not a key') is None
+
+    with pytest.warns(UserWarning, match=r'No textures associated'):
+        assert grid._activate_texture(True) is None
 
 
 def test_set_active_vectors_fail(grid):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -353,7 +353,11 @@ def test_vtk_points_deep_shallow():
 @pytest.mark.parametrize("force_float,expected_data_type", [(False, np.int64), (True, np.float32)])
 def test_vtk_points_force_float(force_float, expected_data_type):
     np_points = np.array([[1, 2, 3]], dtype=np.int64)
-    vtk_points = pyvista.vtk_points(np_points, force_float=force_float)
+    if force_float:
+        with pytest.warns(UserWarning, match='Points is not a float type'):
+            vtk_points = pyvista.vtk_points(np_points, force_float=force_float)
+    else:
+        vtk_points = pyvista.vtk_points(np_points, force_float=force_float)
     as_numpy = numpy_support.vtk_to_numpy(vtk_points.GetData())
 
     assert as_numpy.dtype == expected_data_type

--- a/tests/test_picking.py
+++ b/tests/test_picking.py
@@ -240,12 +240,16 @@ def test_point_picking(left_clicking):
         plotter = pyvista.Plotter(
             window_size=(100, 100),
         )
+        if use_mesh:
+            callback = (lambda picked_point, picked_mesh: None,)
+        else:
+            callback = (lambda picked_point: None,)
         plotter.add_mesh(sphere)
         plotter.enable_point_picking(
             show_message=True,
             use_mesh=use_mesh,
             left_clicking=left_clicking,
-            callback=lambda: None,
+            callback=callback,
         )
         # must show to activate the interactive renderer (for left_clicking)
         plotter.show(auto_close=False)
@@ -308,7 +312,7 @@ def test_path_picking():
     plotter.add_mesh(sphere)
     plotter.enable_path_picking(
         show_message=True,
-        callback=lambda: None,
+        callback=lambda path: None,
     )
     # simulate the pick
     renderer = plotter.renderer
@@ -331,7 +335,7 @@ def test_geodesic_picking():
     plotter.add_mesh(sphere)
     plotter.enable_geodesic_picking(
         show_message=True,
-        callback=lambda: None,
+        callback=lambda path: None,
         show_path=True,
         keep_order=True,
     )
@@ -359,7 +363,7 @@ def test_horizon_picking():
     plotter.add_mesh(sphere)
     plotter.enable_horizon_picking(
         show_message=True,
-        callback=lambda: None,
+        callback=lambda path: None,
         show_horizon=True,
     )
     # simulate the pick

--- a/tests/test_pointset.py
+++ b/tests/test_pointset.py
@@ -111,7 +111,11 @@ def test_filters_return_pointset(sphere):
 @pytest.mark.parametrize("force_float,expected_data_type", [(False, np.int64), (True, np.float32)])
 def test_pointset_force_float(force_float, expected_data_type):
     np_points = np.array([[1, 2, 3]], np.int64)
-    pset = pyvista.PointSet(np_points, force_float=force_float)
+    if force_float:
+        with pytest.warns(UserWarning, match='Points is not a float type'):
+            pset = pyvista.PointSet(np_points, force_float=force_float)
+    else:
+        pset = pyvista.PointSet(np_points, force_float=force_float)
     assert pset.points.dtype == expected_data_type
 
 
@@ -123,26 +127,27 @@ def test_center_of_mass():
 
 def test_points_to_double():
     np_points = np.array([[1, 2, 3]], np.int64)
-    pset = pyvista.PointSet(np_points)
+    pset = pyvista.PointSet(np_points, force_float=False)
     assert pset.points_to_double().points.dtype == np.double
 
 
 def test_translate():
     np_points = np.array([1, 2, 3], np.int64)
-    pset = pyvista.PointSet(np_points)
+    with pytest.warns(UserWarning, match='Points is not a float type'):
+        pset = pyvista.PointSet(np_points)
     pset.translate((4, 3, 2), inplace=True)
     assert np.allclose(pset.center, [5, 5, 5])
 
 
 def test_scale():
-    np_points = np.array([1, 2, 3])
+    np_points = np.array([1, 2, 3], dtype=float)
     pset = pyvista.PointSet(np_points)
     pset.scale(2, inplace=True)
     assert np.allclose(pset.points, [2.0, 4.0, 6.0])
 
 
 def test_flip_x():
-    np_points = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    np_points = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=float)
     pset = pyvista.PointSet(np_points)
     pset.flip_x(inplace=True)
     assert np.allclose(
@@ -158,7 +163,7 @@ def test_flip_x():
 
 
 def test_flip_y():
-    np_points = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    np_points = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=float)
     pset = pyvista.PointSet(np_points)
     pset.flip_y(inplace=True)
     assert np.allclose(
@@ -174,7 +179,7 @@ def test_flip_y():
 
 
 def test_flip_z():
-    np_points = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    np_points = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=float)
     pset = pyvista.PointSet(np_points)
     pset.flip_z(inplace=True)
     assert np.allclose(
@@ -190,7 +195,7 @@ def test_flip_z():
 
 
 def test_flip_normal():
-    np_points = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    np_points = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=float)
     pset = pyvista.PointSet(np_points)
     pset.flip_normal([1.0, 1.0, 1.0], inplace=True)
     assert np.allclose(
@@ -206,28 +211,28 @@ def test_flip_normal():
 
 
 def test_rotate_x():
-    np_points = np.array([1, 1, 1])
+    np_points = np.array([1, 1, 1], dtype=float)
     pset = pyvista.PointSet(np_points)
     pset.rotate_x(45, inplace=True)
     assert np.allclose(pset.points, [1.0, 0.0, 1.4142135])
 
 
 def test_rotate_y():
-    np_points = np.array([1, 1, 1])
+    np_points = np.array([1, 1, 1], dtype=float)
     pset = pyvista.PointSet(np_points)
     pset.rotate_y(45, inplace=True)
     assert np.allclose(pset.points, [1.4142135, 1.0, 0.0])
 
 
 def test_rotate_z():
-    np_points = np.array([1, 1, 1])
+    np_points = np.array([1, 1, 1], dtype=float)
     pset = pyvista.PointSet(np_points)
     pset.rotate_z(45, inplace=True)
     assert np.allclose(pset.points, [0.0, 1.4142135, 1.0])
 
 
 def test_rotate_vector():
-    np_points = np.array([1, 1, 1])
+    np_points = np.array([1, 1, 1], dtype=float)
     pset = pyvista.PointSet(np_points)
     pset.rotate_vector([1, 2, 1], 45, inplace=True)
     assert np.allclose(pset.points, [1.1910441, 1.0976311, 0.6136938])


### PR DESCRIPTION
Fix our builds with:
- [x] Downgrade from `ubuntu-22.04` to `ubuntu-20.04`. The slowdown could be for any number of reasons, but I'm guessing it's due to the increased render time by upgrading from `Mesa 21.2.6` to `Mesa 22.0.5`
- [x] Get rid of a whole mess of test warnings that make debugging pyvista a bit more challenging.
- [x] Fix a memory leak issue due to extra pointers when converting `pyvista_ndarray` to `vtkPoints` with `pyvista.vtk_points` ~that only seems to show up on Python 3.11 (`LinuxConda` build)~.

### More details about the memory leak
When `vtk_points` is provided with a `pyvista_ndarray` and `deep=False`, VTK retails a reference to the `pyvista_ndarray` within `numpy_to_vtk`. Since `pyvista_ndarray` contains a reference to the `vtkDataArray`, this results in a circular reference since the `vtkDataArray` is also referenced by the new `vtkDataArray` contained in the new `vtkPoints` object.

One way to work around this is to simply set the new `vtk.vtkPoints`'s data to point to the data referred to by the `pyvista_ndarray`. This way VTK can track references and wif the `pyvista_ndarray` is deallocated there will still be a reference to the underlying data. However, this doesn't work with strides because (as far as I can tell) VTK doesn't support strides the same way that `numpy` does. I could [WriteVoidPointer](https://vtk.org/doc/nightly/html/classvtkDataArray.html#a0c39dda290f319f8e40fa9c8cc094fad), but we would be back at the same place we'd started since void pointers are just that, pointers to a space in memory rather than an object with reference counting.

Voting for get this merged soon since bad builds mean sad developers.