### PR TITLE
Improve and correct vtkThreshold usage

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -977,13 +977,15 @@ class DataSetFilters:
         scalars : str, optional
             Name of scalars to threshold on. Defaults to currently active scalars.
 
-        invert : bool, optional
+        invert : bool, default: False
             Invert the threshold results. That is, cells that would have been
             in the output with this option off are excluded, while cells that
             would have been excluded from the output are included.
-            WARNING: This option is not supported for VTK<9.
 
-        continuous : bool, optional
+            .. warning::
+                This option is only support for VTK version 9+
+
+        continuous : bool, default: False
             When True, the continuous interval [minimum cell scalar,
             maximum cell scalar] will be used to intersect the threshold bound,
             rather than the set of discrete scalar values from the vertices.
@@ -996,14 +998,14 @@ class DataSetFilters:
             cell-wise operation, we prefer cell data for thresholding
             operations.
 
-        all_scalars : bool, optional
+        all_scalars : bool, default: False
             If using scalars from point data, all
             points in a cell must satisfy the threshold when this
             value is ``True``.  When ``False``, any point of the cell
             with a scalar value satisfying the threshold criterion
             will extract the cell. Has no effect when using cell data.
 
-        progress_bar : bool, optional
+        progress_bar : bool, default: False
             Display a progress bar to indicate progress.
 
         component_mode : {'selected', 'all', 'any'}
@@ -1144,20 +1146,20 @@ class DataSetFilters:
         scalars : str, optional
             Name of scalars to threshold on. Defaults to currently active scalars.
 
-        invert : bool, optional
+        invert : bool, default: False
             When invert is ``True`` cells are kept when their values are
             below the percentage of the range.  When invert is
             ``False``, cells are kept when their value is above the
             percentage of the range. Default is ``False``: yielding
             above the threshold ``"value"``.
 
-        continuous : bool, optional
+        continuous : bool, default: False
             When ``True``, the continuous interval [minimum cell scalar,
             maximum cell scalar] will be used to intersect the threshold
             bound, rather than the set of discrete scalar values from
             the vertices.
 
-        preference : str, optional
+        preference : str, default: 'cell'
             When ``scalars`` is specified, this is the preferred array
             type to search for in the dataset.  Must be either
             ``'point'`` or ``'cell'``.

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -989,7 +989,7 @@ class DataSetFilters:
             type to search for in the dataset.  Must be either
             ``'point'`` or ``'cell'``. Throughout PyVista, the preference
             is typically ``'point'` but since the threshold filter is a
-            cell-wise operation, we prefere cell data for thresholding
+            cell-wise operation, we prefer cell data for thresholding
             operations.
 
         all_scalars : bool, optional

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -968,7 +968,7 @@ class DataSetFilters:
         Parameters
         ----------
         value : float or sequence, optional
-            Single value or (min, max) to be used for the data threshold.  If
+            Single value or (min, max) to be used for the data threshold. If
             a sequence, then length must be 2. If no value is specified, the
             non-NaN data range will be used to remove any NaN values.
             Please reference the ``method`` parameter for how single values
@@ -978,11 +978,9 @@ class DataSetFilters:
             Name of scalars to threshold on. Defaults to currently active scalars.
 
         invert : bool, optional
-            If value is a single value, when invert is ``True`` cells
-            are kept when their values are below parameter ``"value"``.
-            When invert is ``False`` cells are kept when their value is
-            above the threshold ``"value"``.  Default is ``False``:
-            yielding above the threshold ``"value"``.
+            Invert the threshold results. That is, cells that would have been
+            in the output with this option off are excluded, while cells that
+            would have been excluded from the output are included.
             WARNING: This option is not supported for VTK<9.
 
         continuous : bool, optional

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -984,10 +984,13 @@ class DataSetFilters:
             maximum cell scalar] will be used to intersect the threshold bound,
             rather than the set of discrete scalar values from the vertices.
 
-        preference : str, optional
+        preference : str, default: 'cell'
             When ``scalars`` is specified, this is the preferred array
             type to search for in the dataset.  Must be either
-            ``'point'`` or ``'cell'``.
+            ``'point'`` or ``'cell'``. Throughout PyVista, the preference
+            is typically ``'point'` but since the threshold filter is a
+            cell-wise operation, we prefere cell data for thresholding
+            operations.
 
         all_scalars : bool, optional
             If using scalars from point data, all

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5507,6 +5507,11 @@ def _set_threshold_limit(alg, value, method, invert):
         alg.SetInvert(invert)
     elif invert:
         raise ValueError('PyVista no longer supports inverted thresholds for VTK<9.')
+    # Check range
+    if isinstance(value, (np.ndarray, collections.abc.Sequence)) and value[0] > value[1]:
+        raise ValueError(
+            'Value sequence is invalid, please use (min, max). The provided first value is greater than the second.'
+        )
     # Set values and function
     if pyvista.vtk_version_info >= (9, 1):
         if isinstance(value, (np.ndarray, collections.abc.Sequence)):

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -983,7 +983,7 @@ class DataSetFilters:
             would have been excluded from the output are included.
 
             .. warning::
-                This option is only support for VTK version 9+
+                This option is only supported for VTK version 9+
 
         continuous : bool, default: False
             When True, the continuous interval [minimum cell scalar,

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -992,7 +992,7 @@ class DataSetFilters:
             When ``scalars`` is specified, this is the preferred array
             type to search for in the dataset.  Must be either
             ``'point'`` or ``'cell'``. Throughout PyVista, the preference
-            is typically ``'point'` but since the threshold filter is a
+            is typically ``'point'`` but since the threshold filter is a
             cell-wise operation, we prefer cell data for thresholding
             operations.
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1147,11 +1147,12 @@ class DataSetFilters:
             Name of scalars to threshold on. Defaults to currently active scalars.
 
         invert : bool, default: False
-            When invert is ``True`` cells are kept when their values are
-            below the percentage of the range.  When invert is
-            ``False``, cells are kept when their value is above the
-            percentage of the range. Default is ``False``: yielding
-            above the threshold ``"value"``.
+            Invert the threshold results. That is, cells that would have been
+            in the output with this option off are excluded, while cells that
+            would have been excluded from the output are included.
+
+            .. warning::
+                This option is only supported for VTK version 9+
 
         continuous : bool, default: False
             When ``True``, the continuous interval [minimum cell scalar,

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -940,6 +940,7 @@ class DataSetFilters:
         progress_bar=False,
         component_mode="all",
         component=0,
+        method='between',
     ):
         """Apply a ``vtkThreshold`` filter to the input dataset.
 
@@ -1003,6 +1004,13 @@ class DataSetFilters:
         component : int, default: 0
             When using ``component_mode='selected'``, this sets
             which component to threshold on.
+
+        method : str, default: 'between'
+            Set the threshold method, defining which threshold bounds to use.
+            The default is ``'between'``. ``'lower'`` will extract data lower
+            than the lower ``value``. ``'upper'`` will extract data larger
+            than the upper ``value``. ``'between'`` will extract data between
+            the lower and upper values.
 
         Returns
         -------
@@ -1123,6 +1131,18 @@ class DataSetFilters:
         else:
             raise ValueError(
                 f"component_mode must be 'component', 'all', or 'any' got: {component_mode}"
+            )
+        # Set the threshold method
+        methods = {
+            'between': _vtk.vtkThreshold.THRESHOLD_BETWEEN,
+            'lower': _vtk.vtkThreshold.THRESHOLD_BETWEEN,
+            'upper': _vtk.vtkThreshold.THRESHOLD_UPPER,
+        }
+        try:
+            alg.SetThresholdFunction(methods[method.lower()])
+        except KeyError:
+            raise ValueError(
+                f"Threshold method '{method}' not implemented. Choices are 'lower', 'upper', and 'between'"
             )
         # Run the threshold
         _update_alg(alg, progress_bar, 'Thresholding')

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5511,7 +5511,10 @@ def _set_threshold_limit(alg, value, method, invert):
     else:  # pragma: no cover
         # ThresholdByLower, ThresholdByUpper, ThresholdBetween
         if isinstance(value, (np.ndarray, collections.abc.Sequence)):
-            alg.ThresholdBetween(value[0], value[1])
+            if invert:
+                alg.ThresholdBetween(value[1], value[0])
+            else:
+                alg.ThresholdBetween(value[0], value[1])
         else:
             # Single value
             if method.lower() == 'lower':

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1123,8 +1123,8 @@ class DataSetFilters:
         invert=False,
         continuous=False,
         preference='cell',
-        progress_bar=False,
         method='upper',
+        progress_bar=False,
     ):
         """Threshold the dataset by a percentage of its range on the active scalars array.
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -957,6 +957,14 @@ class DataSetFilters:
            thresholding depends on whether that point is part of a cell that
            is kept after thresholding.
 
+           Please also note the default ``preference`` choice for CELL data
+           over POINT data. This is contrary to most other places in PyVista's
+           API where the preference typically defaults to POINT data. We chose
+           to prefer CELL data here so that if thresholding by a named array
+           that exists for both the POINT and CELL data, this filter will
+           default to the CELL data array while performing the CELL-wise
+           operation.
+
         Parameters
         ----------
         value : float or sequence, optional

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -937,10 +937,10 @@ class DataSetFilters:
         continuous=False,
         preference='cell',
         all_scalars=False,
-        progress_bar=False,
         component_mode='all',
         component=0,
         method='upper',
+        progress_bar=False,
     ):
         """Apply a ``vtkThreshold`` filter to the input dataset.
 
@@ -1005,9 +1005,6 @@ class DataSetFilters:
             with a scalar value satisfying the threshold criterion
             will extract the cell. Has no effect when using cell data.
 
-        progress_bar : bool, default: False
-            Display a progress bar to indicate progress.
-
         component_mode : {'selected', 'all', 'any'}
             The method to satisfy the criteria for the threshold of
             multicomponent scalars.  'selected' (default)
@@ -1026,6 +1023,9 @@ class DataSetFilters:
             values. For single values, ``'lower'`` will extract data
             lower than the  ``value``. ``'upper'`` will extract data
             larger than the ``value``.
+
+        progress_bar : bool, default: False
+            Display a progress bar to indicate progress.
 
         Returns
         -------
@@ -1155,15 +1155,17 @@ class DataSetFilters:
                 This option is only supported for VTK version 9+
 
         continuous : bool, default: False
-            When ``True``, the continuous interval [minimum cell scalar,
-            maximum cell scalar] will be used to intersect the threshold
-            bound, rather than the set of discrete scalar values from
-            the vertices.
+            When True, the continuous interval [minimum cell scalar,
+            maximum cell scalar] will be used to intersect the threshold bound,
+            rather than the set of discrete scalar values from the vertices.
 
         preference : str, default: 'cell'
             When ``scalars`` is specified, this is the preferred array
             type to search for in the dataset.  Must be either
-            ``'point'`` or ``'cell'``.
+            ``'point'`` or ``'cell'``. Throughout PyVista, the preference
+            is typically ``'point'`` but since the threshold filter is a
+            cell-wise operation, we prefer cell data for thresholding
+            operations.
 
         method : str, default: 'upper'
             Set the threshold method for single-values, defining which
@@ -1173,7 +1175,7 @@ class DataSetFilters:
             lower than the  ``value``. ``'upper'`` will extract data
             larger than the ``value``.
 
-        progress_bar : bool, optional
+        progress_bar : bool, default: False
             Display a progress bar to indicate progress.
 
         Returns

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2304,7 +2304,7 @@ class DataSetFilters:
         bodies = pyvista.MultiBlock()
         for vid in np.unique(classifier):
             # Now extract it:
-            b = labeled.threshold([vid - 0.5, vid + 0.5], scalars='RegionId', progress_bar=progress_bar)
+            b = labeled.threshold([vid - 0.5, vid + 0.5], scalars='RegionId', progress_bar=False)
             if not label:
                 # strange behavior:
                 # must use this method rather than deleting from the point_data

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5505,7 +5505,7 @@ def _set_threshold_limit(alg, value, method, invert):
         raise TypeError('Value must either be a single scalar or a sequence.')
     if pyvista.vtk_version_info >= (9,):
         alg.SetInvert(invert)
-    elif invert:
+    elif invert:  # pragma: no cover
         raise ValueError('PyVista no longer supports inverted thresholds for VTK<9.')
     # Check range
     if isinstance(value, (np.ndarray, collections.abc.Sequence)) and value[0] > value[1]:

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1084,7 +1084,7 @@ class DataSetFilters:
         if value is None:
             value = self.get_data_range(scalars)
 
-        _set_threshold_limit(alg, value, method)
+        _set_threshold_limit(alg, value, method, invert)
 
         if component_mode == "component":
             alg.SetComponentModeToUseSelected()

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5501,17 +5501,17 @@ def _set_threshold_limit(alg, value, method, invert):
             raise ValueError(
                 f'Value range must be length one for a float value or two for min/max; not ({value}).'
             )
+        # Check range
+        if value[0] > value[1]:
+            raise ValueError(
+                'Value sequence is invalid, please use (min, max). The provided first value is greater than the second.'
+            )
     elif isinstance(value, collections.abc.Iterable):
         raise TypeError('Value must either be a single scalar or a sequence.')
     if pyvista.vtk_version_info >= (9,):
         alg.SetInvert(invert)
     elif invert:  # pragma: no cover
         raise ValueError('PyVista no longer supports inverted thresholds for VTK<9.')
-    # Check range
-    if isinstance(value, (np.ndarray, collections.abc.Sequence)) and value[0] > value[1]:
-        raise ValueError(
-            'Value sequence is invalid, please use (min, max). The provided first value is greater than the second.'
-        )
     # Set values and function
     if pyvista.vtk_version_info >= (9, 1):
         if isinstance(value, (np.ndarray, collections.abc.Sequence)):

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1267,8 +1267,13 @@ class WidgetHelper:
         scalars : str, optional
             The string name of the scalars on the mesh to threshold and display.
 
-        invert : bool, optional
-            Invert (flip) the threshold.
+        invert : bool, default: False
+            Invert the threshold results. That is, cells that would have been
+            in the output with this option off are excluded, while cells that
+            would have been excluded from the output are included.
+
+            .. warning::
+                This option is only supported for VTK version 9+
 
         widget_color : color_like, optional
             Color of the widget.  Either a string, RGB sequence, or
@@ -1279,7 +1284,7 @@ class WidgetHelper:
             * ``color=[1.0, 1.0, 1.0]``
             * ``color='#FFFFFF'``
 
-        preference : str, optional
+        preference : str, default: 'cell'
             When ``mesh.n_points == mesh.n_cells`` and setting
             scalars, this parameter sets how the scalars will be
             mapped to the mesh.  Default ``'cell'``, causes the
@@ -1289,21 +1294,21 @@ class WidgetHelper:
         title : str, optional
             The string label of the slider widget.
 
-        pointa : sequence, optional
+        pointa : sequence, default: (0.4, 0.9)
             The relative coordinates of the left point of the slider
             on the display port.
 
-        pointb : sequence, optional
+        pointb : sequence, default: (0.9, 0.9)
             The relative coordinates of the right point of the slider
             on the display port.
 
-        continuous : bool, optional
+        continuous : bool, default: False
             If this is enabled (default is ``False``), use the continuous
             interval ``[minimum cell scalar, maximum cell scalar]``
             to intersect the threshold bound, rather than the set of
             discrete scalar values from the vertices.
 
-        all_scalars : bool, optional
+        all_scalars : bool, default: False
             If using scalars from point data, all
             points in a cell must satisfy the threshold when this
             value is ``True``.  When ``False``, any point of the cell
@@ -1355,6 +1360,7 @@ class WidgetHelper:
             0, 0, 0, field.value, scalars
         )  # args: (idx, port, connection, field, name)
         alg.SetUseContinuousCellRange(continuous)
+        alg.SetAllScalars(all_scalars)
 
         threshold_mesh = pyvista.wrap(alg.GetOutput())
         self.threshold_meshes.append(threshold_mesh)

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1247,6 +1247,8 @@ class WidgetHelper:
         pointa=(0.4, 0.9),
         pointb=(0.9, 0.9),
         continuous=False,
+        all_scalars=False,
+        method='upper',
         **kwargs,
     ):
         """Apply a threshold on a mesh with a slider.
@@ -1301,6 +1303,21 @@ class WidgetHelper:
             to intersect the threshold bound, rather than the set of
             discrete scalar values from the vertices.
 
+        all_scalars : bool, optional
+            If using scalars from point data, all
+            points in a cell must satisfy the threshold when this
+            value is ``True``.  When ``False``, any point of the cell
+            with a scalar value satisfying the threshold criterion
+            will extract the cell. Has no effect when using cell data.
+
+        method : str, default: 'upper'
+            Set the threshold method for single-values, defining which
+            threshold bounds to use. If the ``value`` is a range, this
+            parameter will be ignored, extracting data between the two
+            values. For single values, ``'lower'`` will extract data
+            lower than the  ``value``. ``'upper'`` will extract data
+            larger than the ``value``.
+
         **kwargs : dict, optional
             All additional keyword arguments are passed to ``add_mesh`` to
             control how the mesh is displayed.
@@ -1333,6 +1350,7 @@ class WidgetHelper:
         self.add_mesh(mesh.outline(), name=f"{name}-outline", opacity=0.0)
 
         alg = _vtk.vtkThreshold()
+        alg.SetInvert(invert)
         alg.SetInputDataObject(mesh)
         alg.SetInputArrayToProcess(
             0, 0, 0, field.value, scalars
@@ -1343,7 +1361,7 @@ class WidgetHelper:
         self.threshold_meshes.append(threshold_mesh)
 
         def callback(value):
-            _set_threshold_limit(alg, value, invert)
+            _set_threshold_limit(alg, value, method)
             alg.Update()
             threshold_mesh.shallow_copy(alg.GetOutput())
 

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1350,7 +1350,6 @@ class WidgetHelper:
         self.add_mesh(mesh.outline(), name=f"{name}-outline", opacity=0.0)
 
         alg = _vtk.vtkThreshold()
-        alg.SetInvert(invert)
         alg.SetInputDataObject(mesh)
         alg.SetInputArrayToProcess(
             0, 0, 0, field.value, scalars
@@ -1361,7 +1360,7 @@ class WidgetHelper:
         self.threshold_meshes.append(threshold_mesh)
 
         def callback(value):
-            _set_threshold_limit(alg, value, method)
+            _set_threshold_limit(alg, value, method, invert)
             alg.Update()
             threshold_mesh.shallow_copy(alg.GetOutput())
 

--- a/tests/plotting/test_widgets.py
+++ b/tests/plotting/test_widgets.py
@@ -150,10 +150,12 @@ def test_widget_slider(uniform):
     p.add_slider_widget(callback=func, rng=[0, 10], style="modern", pass_widget=True)
     p.close()
 
-    p = pyvista.Plotter()
-    p.add_mesh_threshold(uniform, invert=True)
-    p.add_mesh(uniform.outline())
-    p.close()
+    if pyvista.vtk_version_info >= (9,):
+        # Invert not support for VTK8.1.2
+        p = pyvista.Plotter()
+        p.add_mesh_threshold(uniform, invert=True)
+        p.add_mesh(uniform.outline())
+        p.close()
 
     p = pyvista.Plotter()
     p.add_mesh_threshold(uniform, invert=False)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -450,7 +450,7 @@ def test_threshold_percent(datasets):
         dataset.threshold_percent({18.0, 85.0})
 
 
-def test_threshold_paraview_consistence():
+def test_threshold_paraview_consistency():
     """Validate expected results that match ParaView."""
     x = np.arange(5, dtype=float)
     y = np.arange(6, dtype=float)
@@ -485,6 +485,7 @@ def test_threshold_paraview_consistence():
     #    [3, 4, 4, 4, 4]]
     thresh = mesh.threshold(0, invert=True, method='lower')
     assert thresh.n_cells == 16
+    assert thresh.get_data_range() == (1, 4)
 
     # upper(2)
     #   [[         2, 2],
@@ -492,11 +493,13 @@ def test_threshold_paraview_consistence():
     #    [3, 4, 4, 4, 4]]
     thresh = mesh.threshold(2, invert=False, method='upper')
     assert thresh.n_cells == 12
+    assert thresh.get_data_range() == (2, 4)
     # upper(2),invert
     #   [[0, 0, 0, 0, 1],
     #    [1, 1, 1,     ]]
     thresh = mesh.threshold(2, invert=True, method='upper')
     assert thresh.n_cells == 8
+    assert thresh.get_data_range() == (0, 1)
 
     # lower(2)
     #   [[0, 0, 0, 0, 1],
@@ -504,11 +507,13 @@ def test_threshold_paraview_consistence():
     #    [2, 2,        ]]
     thresh = mesh.threshold(2, invert=False, method='lower')
     assert thresh.n_cells == 12
+    assert thresh.get_data_range() == (0, 2)
     # lower(2),invert
     #   [[      3, 3, 3],
     #    [3, 4, 4, 4, 4]]
     thresh = mesh.threshold(2, invert=True, method='lower')
     assert thresh.n_cells == 8
+    assert thresh.get_data_range() == (3, 4)
 
     # between(0, 0)
     #   [[0, 0, 0, 0   ]]
@@ -522,6 +527,7 @@ def test_threshold_paraview_consistence():
     #    [3, 4, 4, 4, 4]]
     thresh = mesh.threshold((0, 0), invert=True)
     assert thresh.n_cells == 16
+    assert thresh.get_data_range() == (1, 4)
 
 
 def test_outline(datasets):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -348,9 +348,10 @@ def test_threshold(datasets):
     thresh = dataset.threshold([100, 500], invert=False, progress_bar=True)
     assert thresh is not None
     assert isinstance(thresh, pyvista.UnstructuredGrid)
-    thresh = dataset.threshold([100, 500], invert=True, progress_bar=True)
-    assert thresh is not None
-    assert isinstance(thresh, pyvista.UnstructuredGrid)
+    if pyvista.vtk_version_info >= (9,):
+        thresh = dataset.threshold([100, 500], invert=True, progress_bar=True)
+        assert thresh is not None
+        assert isinstance(thresh, pyvista.UnstructuredGrid)
     # allow Sequence but not Iterable
     with pytest.raises(TypeError):
         dataset.threshold({100, 500}, progress_bar=True)
@@ -434,6 +435,8 @@ def test_threshold_percent(datasets):
     inverts = [False, True, False, True, False]
     # Only test data sets that have arrays
     for i, dataset in enumerate(datasets[0:3]):
+        if inverts[i] and pyvista.vtk_version_info < (9,):
+            continue
         thresh = dataset.threshold_percent(
             percent=percents[i], invert=inverts[i], progress_bar=True
         )
@@ -450,6 +453,10 @@ def test_threshold_percent(datasets):
         dataset.threshold_percent({18.0, 85.0})
 
 
+@pytest.mark.skipif(
+    pyvista.vtk_version_info < (9,),
+    reason='The invert parameter is not supported for VTK<9. The general logic for the API differences is tested for VTK<9.1 though.',
+)
 def test_threshold_paraview_consistency():
     """Validate expected results that match ParaView."""
     x = np.arange(5, dtype=float)
@@ -991,6 +998,10 @@ def test_glyph_orient_and_scale():
     assert glyph4.bounds[0] == geom.bounds[0] and glyph4.bounds[1] == geom.bounds[1]
 
 
+@pytest.mark.skipif(
+    pyvista.vtk_version_info < (9,),
+    reason='The invert parameter is not supported for VTK<9.',
+)
 def test_split_and_connectivity():
     # Load a simple example mesh
     dataset = examples.load_uniform()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -372,6 +372,9 @@ def test_threshold(datasets):
     with pytest.raises(ValueError):
         dataset.threshold(100, method='between')
 
+    with pytest.raises(ValueError):
+        dataset.threshold((2, 1))
+
 
 def test_threshold_all_scalars():
     mesh = pyvista.Sphere()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -450,7 +450,7 @@ def test_threshold_percent(datasets):
         dataset.threshold_percent({18.0, 85.0})
 
 
-def threshold_paraview_consistence():
+def test_threshold_paraview_consistence():
     """Validate expected results that match ParaView."""
     x = np.arange(5, dtype=float)
     y = np.arange(6, dtype=float)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -365,6 +365,13 @@ def test_threshold(datasets):
     with pytest.raises(ValueError):
         dataset.threshold([10, 100, 300], progress_bar=True)
 
+    if pyvista.vtk_version_info < (9,):
+        with pytest.raises(ValueError):
+            dataset.threshold([100, 500], invert=True)
+
+    with pytest.raises(ValueError):
+        dataset.threshold(100, method='between')
+
 
 def test_threshold_all_scalars():
     mesh = pyvista.Sphere()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -543,6 +543,22 @@ def test_threshold_paraview_consistency():
     assert thresh.n_cells == 16
     assert thresh.get_data_range() == (1, 4)
 
+    # between(2,3)
+    #   [[         2, 2],
+    #    [2, 2, 3, 3, 3],
+    #    [3,           ]]
+    thresh = mesh.threshold((2, 3), invert=False)
+    assert thresh.n_cells == 8
+    assert thresh.get_data_range() == (2, 3)
+    # between(2,3),invert
+    #   [[0, 0, 0, 0, 1],
+    #    [1, 1, 1,     ],
+    #    [             ],
+    #    [   4, 4, 4, 4]]
+    thresh = mesh.threshold((2, 3), invert=True)
+    assert thresh.n_cells == 12
+    assert thresh.get_data_range() == (0, 4)
+
 
 def test_outline(datasets):
     for dataset in datasets:


### PR DESCRIPTION
This should resolve #3610 

cc @mwtoews, would you please review if you can?

`vtkThreshold` has seen a few recent API changes, so we have to set the threshold limits and thresholding functions differently across VTK 8.1, 9.0, and 9.1+

This should keep backward compatibility (at least for our tests/examples)... there were obviously edge cases where the results were incorrect, and this should fix that. While this is labeled a breaking change for other reasons (see below on the `invert` parameter) and the results of this filter are indeed changing for many cases, they are changing in a correcting, rather than breaking, fashion.

@pyvista/developers, I'd appreciate a sanity check and close review to double-check what I've done here.

This also notes how we have a CELL preference for thresholding filters as opposed to a POINT preference pretty much everywhere else (ref #3744)

### Breaking Change: `invert` is no longer supported for VTK 8.1.2

Due to the fact that the invert option was not exposed on the `vtkThreshold` algorithm until VTK 9.0 and the complexity supporting this across 8.1.2, 9.0.x, and 9.1+, I am dropping support for the `invert` parameter for VTK<9 in PyVista. Thus the `invert` option is only valid for VTK 9+. To me, this seems like a fair compromise when trying to maintain support for an algorithm that has had significant API changes across multiple versions.

### Related

* https://github.com/pyvista/pyvista/issues/2850
* https://github.com/pyvista/pyvista/issues/3610
* https://discourse.vtk.org/t/unnecessary-vtk-api-change/9929

