### PR TITLE
Use --fail_extra_image_cache on CI

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -49,7 +49,7 @@ jobs:
         run: pytest -v --ignore=tests/plotting
 
       - name: Test Plotting
-        run: pytest -v tests/plotting
+        run: pytest -v tests/plotting --fail_extra_image_cache
 
 
   LinuxConda:
@@ -120,7 +120,7 @@ jobs:
         run: |
           source /usr/share/miniconda/etc/profile.d/conda.sh
           conda activate ${{ env.conda_env }}
-          pytest -v tests/plotting --cov-report html
+          pytest -v tests/plotting --cov-report html --fail_extra_image_cache
 
   Linux:
     name: Linux Unit Testing
@@ -187,7 +187,7 @@ jobs:
           pip list
 
       - name: Unit Testing
-        run: xvfb-run coverage run -m --source=pyvista --module pytest  --skip_image_cache_vtk8
+        run: xvfb-run coverage run -m --source=pyvista --module pytest --skip_image_cache_vtk8 --fail_extra_image_cache
 
       - uses: codecov/codecov-action@v3
         if: matrix.python-version == '3.9'
@@ -255,4 +255,4 @@ jobs:
         run: python -m pytest -v --ignore=tests/plotting
 
       - name: Test Plotting
-        run: python -m pytest -v tests/plotting
+        run: python -m pytest -v tests/plotting --fail_extra_image_cache


### PR DESCRIPTION
`pytest-pyvista` has an option for `fail_extra_image_cache` which will fail if the test is missing its image in the cache. We need to be using this option on CI but NOT locally. This will make sure that new Plotting API tests have an image added to the cache (which is currently not the case and tests might be silently failing)