### PR TITLE
Define type alias for length-6 tuple of numbers for mesh bounds, rename color_like type

### DIFF
--- a/doc/api/utilities/utilities.rst
+++ b/doc/api/utilities/utilities.rst
@@ -79,7 +79,7 @@ Miscellaneous
 .. autosummary::
    :toctree: _autosummary
 
-   color_like
+   ColorLike
    start_xvfb
 
 .. autosummary::

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -129,7 +129,7 @@ coverage_ignore_modules = [
 
 # Configuration for sphinx.ext.autodoc
 # Do not expand following type aliases when generating the docs
-autodoc_type_aliases = {"color_like": "pyvista.color_like"}
+autodoc_type_aliases = {"ColorLike": "pyvista.ColorLike"}
 
 
 # See https://numpydoc.readthedocs.io/en/latest/install.html
@@ -201,7 +201,7 @@ numpydoc_validation_exclude = {  # set of regex
     # called from inherited
     r'\.Table\.copy_meta_from$',
     # Type alias
-    r'\.color_like$',
+    r'\.ColorLike$',
     # Mixin methods from collections.abc
     r'\.MultiBlock\.clear$',
     r'\.MultiBlock\.count$',

--- a/pyvista/_typing.py
+++ b/pyvista/_typing.py
@@ -15,7 +15,7 @@ Vector = Union[List[float], Tuple[float, float, float], np.ndarray]
 VectorArray = Union[np.ndarray, Sequence[Vector]]
 Number = Union[float, int, np.number]
 NumericArray = Union[Sequence[Number], np.ndarray]
-color_like = Union[
+ColorLike = Union[
     Tuple[int, int, int],
     Tuple[int, int, int, int],
     Tuple[float, float, float],
@@ -30,5 +30,5 @@ color_like = Union[
 ]
 # Overwrite default docstring, as sphinx is not able to capture the docstring
 # when it is put beneath the definition somehow?
-color_like.__doc__ = """Any object convertible to a :class:`Color`."""
+ColorLike.__doc__ = "Any object convertible to a :class:`Color`."
 BoundsLike = Tuple[Number, Number, Number, Number, Number, Number]

--- a/pyvista/_typing.py
+++ b/pyvista/_typing.py
@@ -31,4 +31,4 @@ color_like = Union[
 # Overwrite default docstring, as sphinx is not able to capture the docstring
 # when it is put beneath the definition somehow?
 color_like.__doc__ = """Any object convertible to a :class:`Color`."""
-bounds_like = Tuple[Number, Number, Number, Number, Number, Number]
+BoundsLike = Tuple[Number, Number, Number, Number, Number, Number]

--- a/pyvista/_typing.py
+++ b/pyvista/_typing.py
@@ -31,3 +31,4 @@ color_like = Union[
 # Overwrite default docstring, as sphinx is not able to capture the docstring
 # when it is put beneath the definition somehow?
 color_like.__doc__ = """Any object convertible to a :class:`Color`."""
+bounds_like = Tuple[Number, Number, Number, Number, Number, Number]

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -14,6 +14,7 @@ import pyvista
 from pyvista import _vtk
 from pyvista.utilities import FieldAssociation, is_pyvista_dataset, wrap
 
+from .._typing import bounds_like
 from .dataset import DataObject, DataSet
 from .filters import CompositeFilters
 from .pyvista_ndarray import pyvista_ndarray
@@ -132,7 +133,7 @@ class MultiBlock(
                 self.SetBlock(i, pyvista.wrap(block))
 
     @property
-    def bounds(self) -> Tuple[float, float, float, float, float, float]:
+    def bounds(self) -> bounds_like:
         """Find min/max for bounds across blocks.
 
         Returns
@@ -152,7 +153,7 @@ class MultiBlock(
 
         """
         # apply reduction of min and max over each block
-        all_bounds = [block.bounds for block in self if block]
+        all_bounds = [cast(list, block.bounds) for block in self if block]
         # edge case where block has no bounds
         if not all_bounds:  # pragma: no cover
             minima = np.array([0.0, 0.0, 0.0])
@@ -164,7 +165,7 @@ class MultiBlock(
         # interleave minima and maxima for bounds
         the_bounds = np.stack([minima, maxima]).ravel('F')
 
-        return cast(Tuple[float, float, float, float, float, float], tuple(the_bounds))
+        return cast(bounds_like, tuple(the_bounds))
 
     @property
     def center(self) -> Any:
@@ -179,7 +180,7 @@ class MultiBlock(
         array([1., 1., 0.])
 
         """
-        return np.reshape(self.bounds, (3, 2)).mean(axis=1)
+        return np.reshape(cast(list, self.bounds), (3, 2)).mean(axis=1)
 
     @property
     def length(self) -> float:

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -14,7 +14,7 @@ import pyvista
 from pyvista import _vtk
 from pyvista.utilities import FieldAssociation, is_pyvista_dataset, wrap
 
-from .._typing import bounds_like
+from .._typing import BoundsLike
 from .dataset import DataObject, DataSet
 from .filters import CompositeFilters
 from .pyvista_ndarray import pyvista_ndarray
@@ -133,7 +133,7 @@ class MultiBlock(
                 self.SetBlock(i, pyvista.wrap(block))
 
     @property
-    def bounds(self) -> bounds_like:
+    def bounds(self) -> BoundsLike:
         """Find min/max for bounds across blocks.
 
         Returns
@@ -153,6 +153,7 @@ class MultiBlock(
 
         """
         # apply reduction of min and max over each block
+        # (typing.cast necessary to make mypy happy with ufunc.reduce() later)
         all_bounds = [cast(list, block.bounds) for block in self if block]
         # edge case where block has no bounds
         if not all_bounds:  # pragma: no cover
@@ -165,7 +166,7 @@ class MultiBlock(
         # interleave minima and maxima for bounds
         the_bounds = np.stack([minima, maxima]).ravel('F')
 
-        return cast(bounds_like, tuple(the_bounds))
+        return cast(BoundsLike, tuple(the_bounds))
 
     @property
     def center(self) -> Any:
@@ -180,6 +181,7 @@ class MultiBlock(
         array([1., 1., 0.])
 
         """
+        # (typing.cast necessary to make mypy happy with np.reshape())
         return np.reshape(cast(list, self.bounds), (3, 2)).mean(axis=1)
 
     @property

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -3,7 +3,7 @@
 import collections.abc
 from copy import deepcopy
 import sys
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, cast
 import warnings
 
 if sys.version_info >= (3, 8):
@@ -29,7 +29,7 @@ from pyvista.utilities.arrays import _coerce_pointslike_arg
 from pyvista.utilities.errors import check_valid_vector
 from pyvista.utilities.misc import PyVistaDeprecationWarning
 
-from .._typing import Number, NumericArray, Vector, VectorArray
+from .._typing import Number, NumericArray, Vector, VectorArray, bounds_like
 from .dataobject import DataObject
 from .datasetattributes import DataSetAttributes
 from .filters import DataSetFilters, _get_output
@@ -1578,7 +1578,7 @@ class DataSet(DataSetFilters, DataObject):
         return self.GetNumberOfCells()
 
     @property
-    def bounds(self) -> Tuple[float, float, float, float, float, float]:
+    def bounds(self) -> bounds_like:
         """Return the bounding box of this dataset.
 
         The form is: ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
@@ -1593,7 +1593,7 @@ class DataSet(DataSetFilters, DataObject):
         (-0.5, 0.5, -0.5, 0.5, -0.5, 0.5)
 
         """
-        return self.GetBounds()
+        return cast(bounds_like, self.GetBounds())
 
     @property
     def length(self) -> float:
@@ -2532,7 +2532,7 @@ class DataSet(DataSetFilters, DataObject):
         points = _vtk.vtk_to_numpy(points)
         return points.copy()
 
-    def cell_bounds(self, ind: int) -> Tuple[float, float, float, float, float, float]:
+    def cell_bounds(self, ind: int) -> bounds_like:
         """Return the bounding box of a cell.
 
         Parameters

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -29,7 +29,7 @@ from pyvista.utilities.arrays import _coerce_pointslike_arg
 from pyvista.utilities.errors import check_valid_vector
 from pyvista.utilities.misc import PyVistaDeprecationWarning
 
-from .._typing import Number, NumericArray, Vector, VectorArray, bounds_like
+from .._typing import BoundsLike, Number, NumericArray, Vector, VectorArray
 from .dataobject import DataObject
 from .datasetattributes import DataSetAttributes
 from .filters import DataSetFilters, _get_output
@@ -1578,7 +1578,7 @@ class DataSet(DataSetFilters, DataObject):
         return self.GetNumberOfCells()
 
     @property
-    def bounds(self) -> bounds_like:
+    def bounds(self) -> BoundsLike:
         """Return the bounding box of this dataset.
 
         The form is: ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
@@ -1593,7 +1593,7 @@ class DataSet(DataSetFilters, DataObject):
         (-0.5, 0.5, -0.5, 0.5, -0.5, 0.5)
 
         """
-        return cast(bounds_like, self.GetBounds())
+        return cast(BoundsLike, self.GetBounds())
 
     @property
     def length(self) -> float:
@@ -2532,7 +2532,7 @@ class DataSet(DataSetFilters, DataObject):
         points = _vtk.vtk_to_numpy(points)
         return points.copy()
 
-    def cell_bounds(self, ind: int) -> bounds_like:
+    def cell_bounds(self, ind: int) -> BoundsLike:
         """Return the bounding box of a cell.
 
         Parameters

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2189,7 +2189,7 @@ class PolyDataFilters(DataSetFilters):
 
         Parameters
         ----------
-        edge_color : color_like, optional
+        edge_color : ColorLike, optional
             The color of the edges when they are added to the plotter.
 
         line_width : int, optional
@@ -2252,7 +2252,7 @@ class PolyDataFilters(DataSetFilters):
         faces : bool, optional
             Plot face normals instead of the default point normals.
 
-        color : color_like, optional
+        color : ColorLike, optional
             Color of the arrows.  Defaults to
             :attr:`pyvista.themes.DefaultTheme.edge_color`.
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -21,7 +21,7 @@ from pyvista.utilities.cells import (
     numpy_to_idarr,
 )
 
-from .._typing import bounds_like
+from .._typing import BoundsLike
 from ..utilities.fileio import get_ext
 from .cell import CellType
 from .dataset import DataSet
@@ -2491,7 +2491,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         return self._dimensions()
 
     @property
-    def visible_bounds(self) -> bounds_like:
+    def visible_bounds(self) -> BoundsLike:
         """Return the bounding box of the visible cells.
 
         Different from `bounds`, which returns the bounding box of the

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -21,6 +21,7 @@ from pyvista.utilities.cells import (
     numpy_to_idarr,
 )
 
+from .._typing import bounds_like
 from ..utilities.fileio import get_ext
 from .cell import CellType
 from .dataset import DataSet
@@ -2490,7 +2491,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         return self._dimensions()
 
     @property
-    def visible_bounds(self) -> Tuple[float, float, float, float, float, float]:
+    def visible_bounds(self) -> bounds_like:
         """Return the bounding box of the visible cells.
 
         Different from `bounds`, which returns the bounding box of the

--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -4,7 +4,7 @@ from pyvista import MAX_N_COLOR_BARS
 from .charts import Chart2D, ChartMPL, ChartBox, ChartPie
 from .colors import (
     Color,
-    color_like,
+    ColorLike,
     color_char_to_word,
     get_cmap_safe,
     hexcolors,

--- a/pyvista/plotting/_property.py
+++ b/pyvista/plotting/_property.py
@@ -39,7 +39,7 @@ class Property(_vtk.vtkProperty):
 
         This parameter is case insensitive.
 
-    color : color_like, optional
+    color : ColorLike, optional
         Used to make the entire mesh have a single solid color.
         Either a string, RGB list, or hex color string.  For example:
         ``color='white'``, ``color='w'``, ``color=[1.0, 1.0, 1.0]``, or
@@ -90,7 +90,7 @@ class Property(_vtk.vtkProperty):
         Shows the edges.  Does not apply to a wireframe
         representation.
 
-    edge_color : color_like, optional
+    edge_color : ColorLike, optional
         The solid color to give the edges when ``show_edges=True``.
         Either a string, RGB list, or hex color string.
 

--- a/pyvista/plotting/actor.py
+++ b/pyvista/plotting/actor.py
@@ -8,7 +8,7 @@ import numpy as np
 import pyvista as pv
 from pyvista.utilities.misc import no_new_attr
 
-from .._typing import bounds_like
+from .._typing import BoundsLike
 from ._property import Property
 from .mapper import _BaseMapper
 
@@ -557,7 +557,7 @@ class Actor(pv._vtk.vtkActor):
         self.SetUserMatrix(value)
 
     @property
-    def bounds(self) -> bounds_like:
+    def bounds(self) -> BoundsLike:
         """Return the bounds of the actor.
 
         Bounds are ``(-X, +X, -Y, +Y, -Z, +Z)``

--- a/pyvista/plotting/actor.py
+++ b/pyvista/plotting/actor.py
@@ -1,6 +1,6 @@
 """Wrap vtkActor."""
 
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 import weakref
 
 import numpy as np
@@ -8,6 +8,7 @@ import numpy as np
 import pyvista as pv
 from pyvista.utilities.misc import no_new_attr
 
+from .._typing import bounds_like
 from ._property import Property
 from .mapper import _BaseMapper
 
@@ -556,7 +557,7 @@ class Actor(pv._vtk.vtkActor):
         self.SetUserMatrix(value)
 
     @property
-    def bounds(self) -> Tuple[float, float, float, float, float, float]:
+    def bounds(self) -> bounds_like:
         """Return the bounds of the actor.
 
         Bounds are ``(-X, +X, -Y, +Y, -Z, +Z)``

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -149,7 +149,7 @@ class Pen(_vtkWrapper, _vtk.vtkPen):
 
     Parameters
     ----------
-    color : color_like, optional
+    color : ColorLike, optional
         Color of the lines drawn using this pen. Any color parsable by
         :class:`pyvista.Color` is allowed. Defaults to ``"k"``.
 
@@ -270,7 +270,7 @@ class Brush(_vtkWrapper, _vtk.vtkBrush):
 
     Parameters
     ----------
-    color : color_like, optional
+    color : ColorLike, optional
         Fill color of the shapes drawn using this brush. Any color
         parsable by :class:`pyvista.Color` is allowed.  Defaults to
         ``"k"``.
@@ -1403,7 +1403,7 @@ class _Chart(DocSubs):
             When ``True``, the resulting plot is placed inline a
             jupyter notebook.  Assumes a jupyter console is active.
 
-        background : color_like, optional
+        background : ColorLike, optional
             Use to make the entire mesh have a single solid color.
             Either a string, RGB list, or hex color string.  For example:
             ``color='white'``, ``color='w'``, ``color=[1.0, 1.0, 1.0]``, or
@@ -2099,7 +2099,7 @@ class LinePlot2D(_vtk.vtkPlotLine, _Plot):
     y : array_like
         Y coordinates of the points through which a line should be drawn.
 
-    color : color_like, optional
+    color : ColorLike, optional
         Color of the line drawn in this plot. Any color parsable by :class:`pyvista.Color` is allowed. Defaults
         to ``"b"``.
 
@@ -2231,7 +2231,7 @@ class ScatterPlot2D(_vtk.vtkPlotPoints, _Plot):
     y : array_like
         Y coordinates of the points to draw.
 
-    color : color_like, optional
+    color : ColorLike, optional
         Color of the points drawn in this plot. Any color parsable by :class:`pyvista.Color` is allowed. Defaults
         to ``"b"``.
 
@@ -2435,7 +2435,7 @@ class AreaPlot(_vtk.vtkPlotArea, _Plot):
     y2 : array_like, optional
         Y coordinates of the points on the second outline of the area to draw. Defaults to a sequence of zeros.
 
-    color : color_like, optional
+    color : ColorLike, optional
         Color of the area drawn in this plot. Any color parsable by :class:`pyvista.Color` is allowed. Defaults
         to ``"b"``.
 
@@ -2599,7 +2599,7 @@ class BarPlot(_vtk.vtkPlotBar, _MultiCompPlot):
     y : array_like
         Size of the bars to draw. Multiple bars can be stacked by passing a sequence of sequences.
 
-    color : color_like, optional
+    color : ColorLike, optional
         Color of the bars drawn in this plot. Any color parsable by :class:`pyvista.Color` is allowed. Defaults
         to ``"b"``.
 
@@ -2785,7 +2785,7 @@ class StackPlot(_vtk.vtkPlotStacked, _MultiCompPlot):
         coordinates. Each sequence defines the sizes of one stack
         (area), which are stacked on top of each other.
 
-    colors : list or tuple of color_like, optional
+    colors : list or tuple of ColorLike, optional
         Color of the stacks (areas) drawn in this plot. Any color
         parsable by :class:`pyvista.Color` is allowed.  Defaults to
         ``None``.
@@ -3178,7 +3178,7 @@ class Chart2D(_vtk.vtkChartXY, _Chart):
         y : array_like
             Y coordinates of the points to draw.
 
-        color : color_like, optional
+        color : ColorLike, optional
             Color of the points drawn in this plot. Any color parsable
             by :class:`pyvista.Color` is allowed. Defaults to
             ``"b"``.
@@ -3222,7 +3222,7 @@ class Chart2D(_vtk.vtkChartXY, _Chart):
         y : array_like
             Y coordinates of the points through which a line should be drawn.
 
-        color : color_like, optional
+        color : ColorLike, optional
             Color of the line drawn in this plot. Any color parsable
             by :class:`pyvista.Color` is allowed. Defaults to
             ``"b"``.
@@ -3270,7 +3270,7 @@ class Chart2D(_vtk.vtkChartXY, _Chart):
             Y coordinates of the points on the second outline of the
             area to draw. Defaults to a sequence of zeros.
 
-        color : color_like, optional
+        color : ColorLike, optional
             Color of the area drawn in this plot. Any color parsable
             by :class:`pyvista.Color` is allowed. Defaults to
             ``"b"``.
@@ -3309,7 +3309,7 @@ class Chart2D(_vtk.vtkChartXY, _Chart):
             Size of the bars to draw. Multiple bars can be stacked by
             passing a sequence of sequences.
 
-        color : color_like, optional
+        color : ColorLike, optional
             Color of the bars drawn in this plot. Any color parsable
             by :class:`pyvista.Color` is allowed. Defaults to
             ``"b"``.
@@ -3352,7 +3352,7 @@ class Chart2D(_vtk.vtkChartXY, _Chart):
             coordinates. Each sequence defines the sizes of one stack
             (area), which are stacked on top of each other.
 
-        colors : list or tuple of color_like, optional
+        colors : list or tuple of ColorLike, optional
             Color of the stacks (areas) drawn in this plot. Any color
             parsable by :class:`pyvista.Color` is allowed.  Defaults
             to ``None``.
@@ -3675,7 +3675,7 @@ class BoxPlot(_vtk.vtkPlotBox, _MultiCompPlot):
         Dataset(s) from which the relevant statistics will be
         calculated used to draw the box plot.
 
-    colors : list or tuple of color_like, optional
+    colors : list or tuple of ColorLike, optional
         Color of the boxes drawn in this plot. Any color parsable by
         :class:`pyvista.Color` is allowed.  Defaults to ``None``.
 
@@ -3790,7 +3790,7 @@ class ChartBox(_vtk.vtkChartBox, _Chart):
         Dataset(s) from which the relevant statistics will be
         calculated used to draw the box plot.
 
-    colors : list or tuple of color_like, optional
+    colors : list or tuple of ColorLike, optional
         Color used for each drawn boxplot. Defaults to ``None``, which
         uses the default color scheme.
 
@@ -3912,7 +3912,7 @@ class PiePlot(_vtkWrapper, _vtk.vtkPlotPie, _MultiCompPlot):
     data : array_like
         Relative size of each pie segment.
 
-    colors : list or tuple of color_like, optional
+    colors : list or tuple of ColorLike, optional
         Color of the segments drawn in this plot. Any color parsable
         by :class:`pyvista.Color` is allowed.  Defaults to ``None``.
 
@@ -4008,7 +4008,7 @@ class ChartPie(_vtk.vtkChartPie, _Chart):
     data : array_like
         Relative size of each pie segment.
 
-    colors : list or tuple of color_like, optional
+    colors : list or tuple of ColorLike, optional
         Color used for each pie segment drawn in this plot. Defaults
         to ``None``, which uses the default color scheme.
 

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -175,7 +175,7 @@ import numpy as np
 
 import pyvista
 from pyvista import _vtk
-from pyvista._typing import color_like
+from pyvista._typing import ColorLike
 from pyvista.utilities.misc import has_module
 
 IPYGANY_MAP = {
@@ -372,17 +372,17 @@ color_synonyms = {
 class Color:
     """Helper class to convert between different color representations used in the pyvista library.
 
-    Many pyvista methods accept :data:`color_like` parameters. This helper class
+    Many pyvista methods accept :data:`ColorLike` parameters. This helper class
     is used to convert such parameters to the necessary format, used by
     underlying (VTK) methods. Any color name (``str``), hex string (``str``)
     or RGB(A) sequence (``tuple``, ``list`` or ``numpy.ndarray`` of ``int``
-    or ``float``) is considered a :data:`color_like` parameter and can be converted
+    or ``float``) is considered a :data:`ColorLike` parameter and can be converted
     by this class.
     See :attr:`Color.name` for a list of supported color names.
 
     Parameters
     ----------
-    color : color_like, optional
+    color : ColorLike, optional
         Either a string, RGB sequence, RGBA sequence, or hex color string.
         RGB(A) sequences should either be provided as floats between 0 and 1
         or as ints between 0 and 255. Hex color strings can contain optional
@@ -408,7 +408,7 @@ class Color:
         * ``255``
         * ``'#ff'``
 
-    default_color : color_like, optional
+    default_color : ColorLike, optional
         Default color to use when ``color`` is ``None``. If this value is
         ``None``, then defaults to the global theme color. Format is
         identical to ``color``.
@@ -460,9 +460,9 @@ class Color:
 
     def __init__(
         self,
-        color: Optional[color_like] = None,
+        color: Optional[ColorLike] = None,
         opacity: Optional[Union[int, float, str]] = None,
-        default_color: Optional[color_like] = None,
+        default_color: Optional[ColorLike] = None,
         default_opacity: Union[int, float, str] = 255,
     ):
         """Initialize new instance."""

--- a/pyvista/plotting/composite_mapper.py
+++ b/pyvista/plotting/composite_mapper.py
@@ -706,16 +706,16 @@ class CompositePolyDataMapper(_vtk.vtkCompositePolyDataMapper2, _BaseMapper):
         n_colors : int
             Number of colors to use when displaying scalars.
 
-        nan_color : color_like
+        nan_color : ColorLike
             The color to use for all ``NaN`` values in the plotted
             scalar array.
 
-        above_color : color_like
+        above_color : ColorLike
             Solid color for values below the scalars range
             (``clim``). This will automatically set the scalar bar
             ``above_label`` to ``'Above'``.
 
-        below_color : color_like
+        below_color : ColorLike
             Solid color for values below the scalars range
             (``clim``). This will automatically set the scalar bar
             ``below_label`` to ``'Below'``.

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -88,7 +88,7 @@ def plot(
         When ``True``, the resulting plot is placed inline a jupyter
         notebook.  Assumes a jupyter console is active.
 
-    background : color_like, optional
+    background : ColorLike, optional
         Color of the background.
 
     text : str, optional
@@ -158,7 +158,7 @@ def plot(
     border : bool, optional
         Draw a border around each render window.  Default ``False``.
 
-    border_color : color_like, optional
+    border_color : ColorLike, optional
         Either a string, rgb list, or hex color string.  For example:
 
             * ``color='white'``

--- a/pyvista/plotting/lights.py
+++ b/pyvista/plotting/lights.py
@@ -12,7 +12,7 @@ except ImportError:  # pragma: no cover
     from vtk import vtkLight, vtkLightActor, vtkMatrix4x4
 
 from ..utilities.helpers import vtkmatrix_from_array
-from .colors import Color, color_like
+from .colors import Color, ColorLike
 
 
 class LightType(IntEnum):
@@ -44,7 +44,7 @@ class Light(vtkLight):
         has a transformation matrix.  See also the
         :py:attr:`focal_point` property.
 
-    color : color_like, optional
+    color : ColorLike, optional
         The color of the light. The ambient, diffuse and specular
         colors will all be set to this color on creation.
 
@@ -301,7 +301,7 @@ class Light(vtkLight):
         return Color(self.GetAmbientColor())
 
     @ambient_color.setter
-    def ambient_color(self, color: color_like):
+    def ambient_color(self, color: ColorLike):
         """Set the ambient color of the light."""
         self.SetAmbientColor(Color(color).float_rgb)
 
@@ -331,7 +331,7 @@ class Light(vtkLight):
         return Color(self.GetDiffuseColor())
 
     @diffuse_color.setter
-    def diffuse_color(self, color: color_like):
+    def diffuse_color(self, color: ColorLike):
         """Set the diffuse color of the light."""
         self.SetDiffuseColor(Color(color).float_rgb)
 
@@ -361,7 +361,7 @@ class Light(vtkLight):
         return Color(self.GetSpecularColor())
 
     @specular_color.setter
-    def specular_color(self, color: color_like):
+    def specular_color(self, color: ColorLike):
         """Set the specular color of the light."""
         self.SetSpecularColor(Color(color).float_rgb)
 

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -8,7 +8,7 @@ from pyvista import _vtk
 from pyvista.utilities.helpers import convert_array
 from pyvista.utilities.misc import has_module, no_new_attr
 
-from .._typing import color_like
+from .._typing import ColorLike
 from .colors import Color, get_cmap_safe
 from .tools import opacity_transfer_function
 
@@ -132,13 +132,13 @@ class LookupTable(_vtk.vtkLookupTable):
     log_scale : bool, optional
         Use a log scale when mapping scalar values.
 
-    nan_color : color_like, optional
+    nan_color : ColorLike, optional
         Color to render any values that are NANs.
 
-    above_range_color : color_like, optional
+    above_range_color : ColorLike, optional
         Color to render any values above :attr:`LookupTable.scalar_range`.
 
-    below_range_color : color_like, optional
+    below_range_color : ColorLike, optional
         Color to render any values below :attr:`LookupTable.scalar_range`.
 
     ramp : str, optional
@@ -629,7 +629,7 @@ class LookupTable(_vtk.vtkLookupTable):
         return None
 
     @above_range_color.setter
-    def above_range_color(self, value: Union[bool, color_like]):
+    def above_range_color(self, value: Union[bool, ColorLike]):
         if value in (None, False):
             self.SetUseAboveRangeColor(False)
         elif value is True:
@@ -693,7 +693,7 @@ class LookupTable(_vtk.vtkLookupTable):
         return None
 
     @below_range_color.setter
-    def below_range_color(self, value: Union[bool, color_like]):
+    def below_range_color(self, value: Union[bool, ColorLike]):
         if value in (None, False):
             self.SetUseBelowRangeColor(False)
         elif value is True:

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -501,16 +501,16 @@ class DataSetMapper(_vtk.vtkDataSetMapper, _BaseMapper):
             than zero are mapped to the smallest representable
             positive float.
 
-        nan_color : color_like, optional
+        nan_color : ColorLike, optional
             The color to use for all ``NaN`` values in the plotted
             scalar array.
 
-        above_color : color_like, optional
+        above_color : ColorLike, optional
             Solid color for values below the scalars range
             (``clim``). This will automatically set the scalar bar
             ``above_label`` to ``'Above'``.
 
-        below_color : color_like, optional
+        below_color : ColorLike, optional
             Solid color for values below the scalars range
             (``clim``). This will automatically set the scalar bar
             ``below_label`` to ``'Below'``.
@@ -721,7 +721,7 @@ class DataSetMapper(_vtk.vtkDataSetMapper, _BaseMapper):
             Opacity array to color the dataset. Array length must match either
             the number of points or cells.
 
-        color : color_like
+        color : ColorLike
             The color to use with the opacity array.
 
         n_colors : int

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -90,7 +90,7 @@ class PickingHelper:
         line_width : float, optional
             Thickness of selected mesh edges. Default 5.
 
-        color : color_like, optional
+        color : ColorLike, optional
             The color of the selected mesh when shown.
 
         font_size : int, optional
@@ -277,7 +277,7 @@ class PickingHelper:
         line_width : float, optional
             Thickness of selected mesh edges. Default 5.
 
-        color : color_like, optional
+        color : ColorLike, optional
             The color of the selected mesh when shown.
 
         font_size : int, optional
@@ -524,7 +524,7 @@ class PickingHelper:
         font_size : int, optional
             Sets the font size of the message.
 
-        color : color_like, optional
+        color : ColorLike, optional
             The color of the selected mesh when shown.
 
         show_point : bool, optional
@@ -668,7 +668,7 @@ class PickingHelper:
         font_size : int, optional
             Sets the size of the message.
 
-        color : color_like, optional
+        color : ColorLike, optional
             The color of the selected mesh when shown.
 
         point_size : int, optional
@@ -800,7 +800,7 @@ class PickingHelper:
         font_size : int, optional
             Sets the size of the message.
 
-        color : color_like, optional
+        color : ColorLike, optional
             The color of the selected mesh when shown.
 
         point_size : int, optional
@@ -908,7 +908,7 @@ class PickingHelper:
         font_size : int, optional
             Sets the size of the message.
 
-        color : color_like, optional
+        color : ColorLike, optional
             The color of the selected mesh when shown.
 
         point_size : int, optional
@@ -1049,7 +1049,7 @@ class PickingHelper:
         font_size : int, optional
             Sets the font size of the message.
 
-        color : color_like, optional
+        color : ColorLike, optional
             The color of the horizon surface if shown.
 
         point_size : int, optional

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -156,7 +156,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
     border : bool, optional
         Draw a border around each render window.  Default ``False``.
 
-    border_color : color_like, optional
+    border_color : ColorLike, optional
         Either a string, rgb list, or hex color string.  For example:
 
             * ``color='white'``
@@ -2016,7 +2016,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         dataset : pyvista.MultiBlock
             A :class:`pyvista.MultiBlock` dataset.
 
-        color : color_like, default: :attr:`pyvista.themes.DefaultTheme.color`
+        color : ColorLike, default: :attr:`pyvista.themes.DefaultTheme.color`
             Use to make the entire mesh have a single solid color.
             Either a string, RGB list, or hex color string.  For example:
             ``color='white'``, ``color='w'``, ``color=[1.0, 1.0, 1.0]``, or
@@ -2043,7 +2043,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Shows the edges of a mesh.  Does not apply to a wireframe
             representation.
 
-        edge_color : color_like, default: :attr:`pyvista.global_theme.edge_color`
+        edge_color : ColorLike, default: :attr:`pyvista.global_theme.edge_color`
             The solid color to give the edges when ``show_edges=True``.
             Either a string, RGB list, or hex color string.
 
@@ -2158,7 +2158,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         specular_power : float, default: 1.0
             The specular power. Between 0.0 and 128.0.
 
-        nan_color : color_like, default: :attr:`pyvista.themes.DefaultTheme.nan_color`
+        nan_color : ColorLike, default: :attr:`pyvista.themes.DefaultTheme.nan_color`
             The color to use for all ``NaN`` values in the plotted
             scalar array.
 
@@ -2192,12 +2192,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
             the scalar array will be used as the ``n_colors``
             argument.
 
-        below_color : color_like, optional
+        below_color : ColorLike, optional
             Solid color for values below the scalars range
             (``clim``). This will automatically set the scalar bar
             ``below_label`` to ``'Below'``.
 
-        above_color : color_like, optional
+        above_color : ColorLike, optional
             Solid color for values below the scalars range
             (``clim``). This will automatically set the scalar bar
             ``above_label`` to ``'Above'``.
@@ -2519,7 +2519,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             that :func:`pyvista.wrap` can handle including NumPy
             arrays of XYZ points.
 
-        color : color_like, optional
+        color : ColorLike, optional
             Use to make the entire mesh have a single solid color.
             Either a string, RGB list, or hex color string.  For example:
             ``color='white'``, ``color='w'``, ``color=[1.0, 1.0, 1.0]``, or
@@ -2554,7 +2554,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Shows the edges of a mesh.  Does not apply to a wireframe
             representation.
 
-        edge_color : color_like, optional
+        edge_color : ColorLike, optional
             The solid color to give the edges when ``show_edges=True``.
             Either a string, RGB list, or hex color string.
 
@@ -2688,7 +2688,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         specular_power : float, optional
             The specular power. Between 0.0 and 128.0.
 
-        nan_color : color_like, optional, defaults to gray
+        nan_color : ColorLike, optional, defaults to gray
             The color to use for all ``NaN`` values in the plotted
             scalar array.
 
@@ -2722,7 +2722,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             ``PolyData``.  As a ``dict``, it contains the properties
             of the silhouette to display:
 
-                * ``color``: ``color_like``, color of the silhouette
+                * ``color``: ``ColorLike``, color of the silhouette
                 * ``line_width``: ``float``, edge width
                 * ``opacity``: ``float`` between 0 and 1, edge transparency
                 * ``feature_angle``: If a ``float``, display sharp edges
@@ -2733,12 +2733,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Invert the opacity mappings and make the values correspond
             to transparency.
 
-        below_color : color_like, optional
+        below_color : ColorLike, optional
             Solid color for values below the scalars range
             (``clim``). This will automatically set the scalar bar
             ``below_label`` to ``'Below'``.
 
-        above_color : color_like, optional
+        above_color : ColorLike, optional
             Solid color for values below the scalars range
             (``clim``). This will automatically set the scalar bar
             ``above_label`` to ``'Above'``.
@@ -3691,7 +3691,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         params : dict, optional
 
             * If not supplied, the default theme values will be used.
-            * ``color``: ``color_like``, color of the silhouette
+            * ``color``: ``ColorLike``, color of the silhouette
             * ``line_width``: ``float``, edge width
             * ``opacity``: ``float`` between 0 and 1, edge transparency
             * ``feature_angle``: If a ``float``, display sharp edges
@@ -4146,7 +4146,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         font_size : float, optional
             Sets the size of the title font.  Defaults to 18.
 
-        color : color_like, optional
+        color : ColorLike, optional
             Either a string, RGB list, or hex color string.  For example:
 
             * ``color='white'``
@@ -4478,7 +4478,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             segments would be represented as ``np.array([[0, 0, 0],
             [1, 0, 0], [1, 0, 0], [1, 1, 0]])``.
 
-        color : color_like, default: 'w'
+        color : ColorLike, default: 'w'
             Either a string, rgb list, or hex color string.  For example:
 
             * ``color='white'``
@@ -4589,7 +4589,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         font_size : float, optional
             Sets the size of the title font.  Defaults to 16.
 
-        text_color : color_like, optional
+        text_color : ColorLike, optional
             Color of text. Either a string, RGB sequence, or hex color string.
 
             * ``text_color='white'``
@@ -4607,7 +4607,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         show_points : bool, optional
             Controls if points are visible.  Default ``True``.
 
-        point_color : color_like, optional
+        point_color : ColorLike, optional
             Either a string, rgb list, or hex color string.  One of
             the following.
 
@@ -4624,7 +4624,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             updated.  If an actor of this name already exists in the
             rendering window, it will be replaced by the new actor.
 
-        shape_color : color_like, optional
+        shape_color : ColorLike, optional
             Color of shape (if visible).  Either a string, rgb
             sequence, or hex color string.
 
@@ -5727,7 +5727,7 @@ class Plotter(BasePlotter):
     border : bool, optional
         Draw a border around each render window.  Default ``False``.
 
-    border_color : color_like, optional
+    border_color : ColorLike, optional
         Either a string, rgb list, or hex color string.  For example:
 
             * ``color='white'``
@@ -6267,7 +6267,7 @@ class Plotter(BasePlotter):
             Sets the size of the title font.  Defaults to 16 or the
             value of the global theme if set.
 
-        color : color_like, optional,
+        color : ColorLike, optional,
             Either a string, rgb list, or hex color string.  Defaults
             to white or the value of the global theme if set.  For
             example:
@@ -6333,7 +6333,7 @@ class Plotter(BasePlotter):
 
             Defaults to ``(0.0, 0.0, 0.0)``.
 
-        color : color_like, optional
+        color : ColorLike, optional
             Either a string, RGB sequence, or hex color string.  For one
             of the following.
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -11,7 +11,7 @@ import platform
 import textwrap
 from threading import Thread
 import time
-from typing import Dict, Tuple
+from typing import Dict
 import warnings
 import weakref
 
@@ -34,6 +34,7 @@ from pyvista.utilities import (
 )
 from pyvista.utilities.arrays import _coerce_pointslike_arg
 
+from .._typing import bounds_like
 from ..utilities.misc import PyVistaDeprecationWarning, has_module, uses_egl
 from ..utilities.regression import image_from_window
 from ._plotting import (
@@ -1388,7 +1389,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.renderer.camera_set = is_set
 
     @property
-    def bounds(self) -> Tuple[float, float, float, float, float, float]:
+    def bounds(self) -> bounds_like:
         """Return the bounds of the active renderer.
 
         Returns

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -34,7 +34,7 @@ from pyvista.utilities import (
 )
 from pyvista.utilities.arrays import _coerce_pointslike_arg
 
-from .._typing import bounds_like
+from .._typing import BoundsLike
 from ..utilities.misc import PyVistaDeprecationWarning, has_module, uses_egl
 from ..utilities.regression import image_from_window
 from ._plotting import (
@@ -1389,7 +1389,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.renderer.camera_set = is_set
 
     @property
-    def bounds(self) -> bounds_like:
+    def bounds(self) -> BoundsLike:
         """Return the bounds of the active renderer.
 
         Returns

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -494,7 +494,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         Parameters
         ----------
-        color : color_like, optional
+        color : ColorLike, optional
             Color of the border.
 
         width : float, optional
@@ -747,13 +747,13 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         Parameters
         ----------
-        x_color : color_like, optional
+        x_color : ColorLike, optional
             The color of the x axes arrow.
 
-        y_color : color_like, optional
+        y_color : ColorLike, optional
             The color of the y axes arrow.
 
-        z_color : color_like, optional
+        z_color : ColorLike, optional
             The color of the z axes arrow.
 
         xlabel : str, optional
@@ -819,7 +819,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             :attr:`pyvista.global_theme.interactive
             <pyvista.themes.DefaultTheme.interactive>`.
 
-        color : color_like, optional
+        color : ColorLike, optional
             The color of the actor.  This only applies if ``actor`` is
             a :class:`pyvista.DataSet`.
 
@@ -896,16 +896,16 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         line_width : int, optional
             The width of the marker lines.
 
-        color : color_like, optional
+        color : ColorLike, optional
             Color of the labels.
 
-        x_color : color_like, optional
+        x_color : ColorLike, optional
             Color used for the x axis arrow.  Defaults to theme axes parameters.
 
-        y_color : color_like, optional
+        y_color : ColorLike, optional
             Color used for the y axis arrow.  Defaults to theme axes parameters.
 
-        z_color : color_like, optional
+        z_color : ColorLike, optional
             Color used for the z axis arrow.  Defaults to theme axes parameters.
 
         xlabel : str, optional
@@ -1162,7 +1162,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             or ``'arial'``. Defaults to :attr:`pyvista.global_theme.font.family
             <pyvista.themes._Font.family>`.
 
-        color : color_like, optional
+        color : ColorLike, optional
             Color of all labels and axis titles.  Defaults to
             :attr:`pyvista.global_theme.font.color
             <pyvista.themes._Font.color>`.
@@ -1527,7 +1527,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         Parameters
         ----------
-        color : color_like, optional
+        color : ColorLike, optional
             Color of all labels and axis titles.  Default white.
             Either a string, rgb sequence, or hex color string.  For
             example:
@@ -1655,7 +1655,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         j_resolution : int, optional
             Number of points on the plane in the j direction.
 
-        color : color_like, optional
+        color : ColorLike, optional
             Color of all labels and axis titles.  Default gray.
             Either a string, rgb list, or hex color string.
 
@@ -1677,7 +1677,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             Enable or disable view direction lighting.  Default
             ``False``.
 
-        edge_color : color_like, optional
+        edge_color : ColorLike, optional
             Color of of the edges of the mesh.
 
         reset_camera : bool, optional
@@ -2775,7 +2775,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         Parameters
         ----------
-        color : color_like, optional
+        color : ColorLike, optional
             Either a string, rgb list, or hex color string.  Defaults
             to theme default.  For example:
 
@@ -2784,7 +2784,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             * ``color=[1.0, 1.0, 1.0]``
             * ``color='#FFFFFF'``
 
-        top : color_like, optional
+        top : ColorLike, optional
             If given, this will enable a gradient background where the
             ``color`` argument is at the bottom and the color given in
             ``top`` will be the color at the top of the renderer.
@@ -3018,7 +3018,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             color], where label is the name of the item to add, and
             color is the color of the label to add.
 
-        bcolor : color_like, optional
+        bcolor : ColorLike, optional
             Background color, either a three item 0 to 1 RGB color
             list, or a matplotlib color string (e.g. ``'w'`` or ``'white'``
             for a white color).  If None, legend background is

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -13,7 +13,7 @@ from pyvista import MAX_N_COLOR_BARS, _vtk
 from pyvista.utilities import check_depth_peeling, try_callback, wrap
 from pyvista.utilities.misc import PyVistaDeprecationWarning, uses_egl
 
-from .._typing import bounds_like
+from .._typing import BoundsLike
 from .actor import Actor
 from .camera import Camera
 from .charts import Charts
@@ -326,7 +326,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         self.camera_set = True
 
     @property
-    def bounds(self) -> bounds_like:
+    def bounds(self) -> BoundsLike:
         """Return the bounds of all actors present in the rendering window."""
         the_bounds = np.array([np.inf, -np.inf, np.inf, -np.inf, np.inf, -np.inf])
 
@@ -355,7 +355,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             the_bounds[the_bounds == np.inf] = -1.0
             the_bounds[the_bounds == -np.inf] = 1.0
 
-        return cast(bounds_like, tuple(the_bounds))
+        return cast(BoundsLike, tuple(the_bounds))
 
     @property
     def length(self):

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -2,7 +2,7 @@
 
 import collections.abc
 from functools import partial
-from typing import Sequence, Tuple, cast
+from typing import Sequence, cast
 import warnings
 from weakref import proxy
 
@@ -13,6 +13,7 @@ from pyvista import MAX_N_COLOR_BARS, _vtk
 from pyvista.utilities import check_depth_peeling, try_callback, wrap
 from pyvista.utilities.misc import PyVistaDeprecationWarning, uses_egl
 
+from .._typing import bounds_like
 from .actor import Actor
 from .camera import Camera
 from .charts import Charts
@@ -325,7 +326,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         self.camera_set = True
 
     @property
-    def bounds(self) -> Tuple[float, float, float, float, float, float]:
+    def bounds(self) -> bounds_like:
         """Return the bounds of all actors present in the rendering window."""
         the_bounds = np.array([np.inf, -np.inf, np.inf, -np.inf, np.inf, -np.inf])
 
@@ -354,7 +355,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             the_bounds[the_bounds == np.inf] = -1.0
             the_bounds[the_bounds == -np.inf] = 1.0
 
-        return cast(Tuple[float, float, float, float, float, float], tuple(the_bounds))
+        return cast(bounds_like, tuple(the_bounds))
 
     @property
     def length(self):

--- a/pyvista/plotting/renderers.py
+++ b/pyvista/plotting/renderers.py
@@ -396,7 +396,7 @@ class Renderers:
 
         Parameters
         ----------
-        color : color_like, optional
+        color : ColorLike, optional
             Either a string, rgb list, or hex color string.  Defaults
             to current theme parameters.  For example:
 
@@ -405,7 +405,7 @@ class Renderers:
             * ``color=[1.0, 1.0, 1.0]``
             * ``color='#FFFFFF'``
 
-        top : color_like, optional
+        top : ColorLike, optional
             If given, this will enable a gradient background where the
             ``color`` argument is at the bottom and the color given in ``top``
             will be the color at the top of the renderer.

--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -202,7 +202,7 @@ class ScalarBars:
             Sets the size of the title font.  Defaults to ``None`` and is sized
             according to :attr:`pyvista.themes.DefaultTheme.font`.
 
-        color : color_like, optional
+        color : ColorLike, optional
             Either a string, rgb list, or hex color string.  Default
             set by :attr:`pyvista.themes.DefaultTheme.font`.  Can be
             in one of the following formats:
@@ -277,7 +277,7 @@ class ScalarBars:
         above_label : str, optional
             String annotation for values above the scalars range.
 
-        background_color : color_like, optional
+        background_color : ColorLike, optional
             The color used for the background in RGB format.
 
         n_colors : int, optional

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -123,16 +123,16 @@ def create_axes_marker(
 
     Parameters
     ----------
-    label_color : color_like, optional
+    label_color : ColorLike, optional
         Color of the label text.
 
-    x_color : color_like, optional
+    x_color : ColorLike, optional
         Color of the x axis text.
 
-    y_color : color_like, optional
+    y_color : ColorLike, optional
         Color of the y axis text.
 
-    z_color : color_like, optional
+    z_color : ColorLike, optional
         Color of the z axis text.
 
     xlabel : str, optional
@@ -272,16 +272,16 @@ def create_axes_orientation_box(
     text_scale : float, optional
         Size of the text relative to the faces.
 
-    edge_color : color_like, optional
+    edge_color : ColorLike, optional
         Color of the edges.
 
-    x_color : color_like, optional
+    x_color : ColorLike, optional
         Color of the x axis text.
 
-    y_color : color_like, optional
+    y_color : ColorLike, optional
         Color of the y axis text.
 
-    z_color : color_like, optional
+    z_color : ColorLike, optional
         Color of the z axis text.
 
     xlabel : str, optional
@@ -293,22 +293,22 @@ def create_axes_orientation_box(
     zlabel : str, optional
         Text used for the z axis.
 
-    x_face_color : color_like, optional
+    x_face_color : ColorLike, optional
         Color used for the x axis arrow.  Defaults to theme axes
         parameters.
 
-    y_face_color : color_like, optional
+    y_face_color : ColorLike, optional
         Color used for the y axis arrow.  Defaults to theme axes
         parameters.
 
-    z_face_color : color_like, optional
+    z_face_color : ColorLike, optional
         Color used for the z axis arrow.  Defaults to theme axes
         parameters.
 
     color_box : bool, optional
         Enable or disable the face colors.  Otherwise, box is white.
 
-    label_color : color_like, optional
+    label_color : ColorLike, optional
         Color of the labels.
 
     labels_off : bool, optional

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -79,7 +79,7 @@ class WidgetHelper:
             If ``False``, the box widget cannot be rotated and is
             strictly orthogonal to the cartesian axes.
 
-        color : color_like, optional
+        color : ColorLike, optional
             Either a string, rgb sequence, or hex color string.
             Defaults to :attr:`pyvista.global_theme.font.color
             <pyvista.themes._Font.color>`.
@@ -188,7 +188,7 @@ class WidgetHelper:
             If ``False``, the box widget cannot be rotated and is strictly
             orthogonal to the cartesian axes.
 
-        widget_color : color_like, optional
+        widget_color : ColorLike, optional
             Color of the widget.  Either a string, RGB sequence, or
             hex color string.  For example:
 
@@ -315,7 +315,7 @@ class WidgetHelper:
         factor : float, optional
             An inflation factor to expand on the bounds when placing.
 
-        color : color_like, optional
+        color : ColorLike, optional
             Either a string, rgb list, or hex color string.
 
         assign_to_axis : str or int, optional
@@ -512,7 +512,7 @@ class WidgetHelper:
         invert : bool, optional
             Flag on whether to flip/invert the clip.
 
-        widget_color : color_like, optional
+        widget_color : ColorLike, optional
             Either a string, RGB list, or hex color string.
 
         value : float, optional
@@ -658,7 +658,7 @@ class WidgetHelper:
             If this is enabled (``False`` by default), the output will be
             triangles otherwise, the output will be the intersection polygons.
 
-        widget_color : color_like, optional
+        widget_color : ColorLike, optional
             Either a string, RGB sequence, or hex color string.  Defaults
             to ``'white'``.
 
@@ -770,7 +770,7 @@ class WidgetHelper:
             If this is enabled (``False`` by default), the output will be
             triangles otherwise, the output will be the intersection polygons.
 
-        widget_color : color_like, optional
+        widget_color : ColorLike, optional
             Color of the widget.  Either a string, RGB sequence, or
             hex color string.  For example:
 
@@ -854,7 +854,7 @@ class WidgetHelper:
         resolution : int, optional
             The number of points in the line created.
 
-        color : color_like, optional, defaults to white
+        color : ColorLike, optional, defaults to white
             Either a string, rgb sequence, or hex color string.
 
         use_vertices : bool, optional
@@ -948,7 +948,7 @@ class WidgetHelper:
             The relative coordinates of the right point of the slider on the
             display port.
 
-        color : color_like, optional
+        color : ColorLike, optional
             Either a string, RGB list, or hex color string.  Defaults
             to :attr:`pyvista.global_theme.font.color
             <pyvista.themes._Font.color>`.
@@ -1075,7 +1075,7 @@ class WidgetHelper:
             The relative coordinates of the right point of the slider
             on the display port.
 
-        color : color_like, optional
+        color : ColorLike, optional
             Either a string, RGB list, or hex color string.  Defaults
             to :attr:`pyvista.global_theme.font.color
             <pyvista.themes._Font.color>`.
@@ -1100,7 +1100,7 @@ class WidgetHelper:
         title_opacity : float, optional
             Opacity of title. Defaults to 1.0.
 
-        title_color : color_like, optional
+        title_color : ColorLike, optional
             Either a string, RGB sequence, or hex color string.  Defaults
             to the value given in ``color``.
 
@@ -1275,7 +1275,7 @@ class WidgetHelper:
             .. warning::
                 This option is only supported for VTK version 9+
 
-        widget_color : color_like, optional
+        widget_color : ColorLike, optional
             Color of the widget.  Either a string, RGB sequence, or
             hex color string.  For example:
 
@@ -1446,7 +1446,7 @@ class WidgetHelper:
             The relative coordinates of the right point of the slider
             on the display port.
 
-        widget_color : color_like, optional
+        widget_color : ColorLike, optional
             Color of the widget.  Either a string, RGB sequence, or
             hex color string.  For example:
 
@@ -1560,13 +1560,13 @@ class WidgetHelper:
         resolution : int, optional
             The number of points in the spline created between all the handles.
 
-        color : color_like, optional
+        color : ColorLike, optional
             Either a string, RGB sequence, or hex color string.
 
         show_ribbon : bool, optional
             If ``True``, the poly plane used for slicing will also be shown.
 
-        ribbon_color : color_like, optional
+        ribbon_color : ColorLike, optional
             Color of the ribbon.  Either a string, RGB sequence, or
             hex color string.
 
@@ -1690,7 +1690,7 @@ class WidgetHelper:
         resolution : int, optional
             The number of points to generate on the spline.
 
-        widget_color : color_like, optional
+        widget_color : ColorLike, optional
             Color of the widget.  Either a string, RGB sequence, or
             hex color string.  For example:
 
@@ -1702,7 +1702,7 @@ class WidgetHelper:
         show_ribbon : bool, optional
             If ``True``, the poly plane used for slicing will also be shown.
 
-        ribbon_color : color_like, optional
+        ribbon_color : ColorLike, optional
             Color of the ribbon.  Either a string, RGB sequence, or
             hex color string.
 
@@ -1820,7 +1820,7 @@ class WidgetHelper:
         phi_resolution : int, optional
             Set the number of points in the latitude direction.
 
-        color : color_like, optional
+        color : ColorLike, optional
             The color of the sphere's surface.  If multiple centers
             are passed, then this must be a list of colors.  Each
             color is either a string, rgb list, or hex color string.
@@ -1834,7 +1834,7 @@ class WidgetHelper:
         style : str, optional
             Representation style: ``'surface'`` or ``'wireframe'``.
 
-        selected_color : color_like, optional
+        selected_color : ColorLike, optional
             Color of the widget when selected during interaction.
 
         indices : sequence, optional
@@ -1961,13 +1961,13 @@ class WidgetHelper:
         border_size : int, optional
             The size of the borders of the button in pixels.
 
-        color_on : color_like, optional
+        color_on : ColorLike, optional
             The color used when the button is checked. Default is ``'blue'``.
 
-        color_off : color_like, optional
+        color_off : ColorLike, optional
             The color used when the button is not checked. Default is ``'grey'``.
 
-        background_color : color_like, optional
+        background_color : ColorLike, optional
             The background color of the button. Default is ``'white'``.
 
         Returns

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -36,7 +36,7 @@ import os
 from typing import Callable, List, Optional, Union
 import warnings
 
-from ._typing import color_like
+from ._typing import ColorLike
 from .plotting.colors import Color, get_cmap_safe
 from .plotting.plotting import Plotter
 from .plotting.tools import parse_font_family
@@ -324,7 +324,7 @@ class _SilhouetteConfig(_ThemeConfig):
         return self._color
 
     @color.setter
-    def color(self, color: color_like):
+    def color(self, color: ColorLike):
         self._color = Color(color)
 
     @property
@@ -565,7 +565,7 @@ class _AxesConfig(_ThemeConfig):
         return self._x_color
 
     @x_color.setter
-    def x_color(self, color: color_like):
+    def x_color(self, color: ColorLike):
         self._x_color = Color(color)
 
     @property
@@ -580,7 +580,7 @@ class _AxesConfig(_ThemeConfig):
         return self._y_color
 
     @y_color.setter
-    def y_color(self, color: color_like):
+    def y_color(self, color: ColorLike):
         self._y_color = Color(color)
 
     @property
@@ -595,7 +595,7 @@ class _AxesConfig(_ThemeConfig):
         return self._z_color
 
     @z_color.setter
-    def z_color(self, color: color_like):
+    def z_color(self, color: ColorLike):
         self._z_color = Color(color)
 
     @property
@@ -785,7 +785,7 @@ class _Font(_ThemeConfig):
         return self._color
 
     @color.setter
-    def color(self, color: color_like):
+    def color(self, color: ColorLike):
         self._color = Color(color)
 
     @property
@@ -903,7 +903,7 @@ class _SliderStyleConfig(_ThemeConfig):
         return self._tube_color
 
     @tube_color.setter
-    def tube_color(self, tube_color: color_like):
+    def tube_color(self, tube_color: ColorLike):
         self._tube_color = Color(tube_color)
 
     @property
@@ -935,7 +935,7 @@ class _SliderStyleConfig(_ThemeConfig):
         return self._slider_color
 
     @slider_color.setter
-    def slider_color(self, slider_color: color_like):
+    def slider_color(self, slider_color: ColorLike):
         self._slider_color = Color(slider_color)
 
     @property
@@ -1263,7 +1263,7 @@ class DefaultTheme(_ThemeConfig):
         return self._above_range_color
 
     @above_range_color.setter
-    def above_range_color(self, value: color_like):
+    def above_range_color(self, value: ColorLike):
         self._above_range_color = Color(value)
 
     @property
@@ -1283,7 +1283,7 @@ class DefaultTheme(_ThemeConfig):
         return self._below_range_color
 
     @below_range_color.setter
-    def below_range_color(self, value: color_like):
+    def below_range_color(self, value: ColorLike):
         self._below_range_color = Color(value)
 
     @property
@@ -1317,7 +1317,7 @@ class DefaultTheme(_ThemeConfig):
         return self._background
 
     @background.setter
-    def background(self, new_background: color_like):
+    def background(self, new_background: ColorLike):
         self._background = Color(new_background)
 
     @property
@@ -1636,7 +1636,7 @@ class DefaultTheme(_ThemeConfig):
         return self._color
 
     @color.setter
-    def color(self, color: color_like):
+    def color(self, color: ColorLike):
         self._color = Color(color)
 
     @property
@@ -1654,7 +1654,7 @@ class DefaultTheme(_ThemeConfig):
         return self._nan_color
 
     @nan_color.setter
-    def nan_color(self, nan_color: color_like):
+    def nan_color(self, nan_color: ColorLike):
         self._nan_color = Color(nan_color)
 
     @property
@@ -1672,7 +1672,7 @@ class DefaultTheme(_ThemeConfig):
         return self._edge_color
 
     @edge_color.setter
-    def edge_color(self, edge_color: color_like):
+    def edge_color(self, edge_color: ColorLike):
         self._edge_color = Color(edge_color)
 
     @property
@@ -1688,7 +1688,7 @@ class DefaultTheme(_ThemeConfig):
         return self._outline_color
 
     @outline_color.setter
-    def outline_color(self, outline_color: color_like):
+    def outline_color(self, outline_color: ColorLike):
         self._outline_color = Color(outline_color)
 
     @property
@@ -1704,7 +1704,7 @@ class DefaultTheme(_ThemeConfig):
         return self._floor_color
 
     @floor_color.setter
-    def floor_color(self, floor_color: color_like):
+    def floor_color(self, floor_color: ColorLike):
         self._floor_color = Color(floor_color)
 
     @property


### PR DESCRIPTION
This is a quick take on trying to define a type alias instead of `Tuple[float, float, float, float, float, float]` added in https://github.com/pyvista/pyvista/pull/3747, see also some discussion in https://github.com/pyvista/pyvista/pull/3747#discussion_r1058687553, with the additional complication of allowing numpy numbers and ints here.

Some of the changes necessary for mypy to be happy might render this more trouble than it's worth, see comments below. Some design questions are also open for debate.