### PR TITLE
Fix dataobject repr

### DIFF
--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -228,14 +228,19 @@ class DataObject:
         # Otherwise return a string that is Python console friendly
         fmt = f"{type(self).__name__} ({hex(id(self))})\n"
         # now make a call on the object to get its attributes as a list of len 2 tuples
-        row = "  {}:\t{}\n"
+        # get longest row header
+        max_len = max(len(attr[0]) for attr in self._get_attrs()) + 4
+
+        # now make a call on the object to get its attributes as a list of len
+        # 2 tuples
+        row = "  {:%ds}{}\n" % max_len
         for attr in self._get_attrs():
             try:
-                fmt += row.format(attr[0], attr[2].format(*attr[1]))
+                fmt += row.format(attr[0] + ':', attr[2].format(*attr[1]))
             except:
-                fmt += row.format(attr[0], attr[2].format(attr[1]))
+                fmt += row.format(attr[0] + ':', attr[2].format(attr[1]))
         if hasattr(self, 'n_arrays'):
-            fmt += row.format('N Arrays', self.n_arrays)
+            fmt += row.format('N Arrays:', self.n_arrays)
         return fmt
 
     def _repr_html_(self):  # pragma: no cover

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -654,11 +654,11 @@ def test_no_copy_rectilinear_grid():
 def test_grid_repr(struct_grid):
     str_ = str(struct_grid)
     assert 'StructuredGrid' in str_
-    assert f'N Points:\t{struct_grid.n_points}\n' in str_
+    assert f'N Points:     {struct_grid.n_points}\n' in str_
 
     repr_ = repr(struct_grid)
     assert 'StructuredGrid' in repr_
-    assert f'N Points:\t{struct_grid.n_points}\n' in repr_
+    assert f'N Points:     {struct_grid.n_points}\n' in repr_
 
 
 def test_slice_structured(struct_grid):


### PR DESCRIPTION
Simple fix: use spaces rather than tabs in our `__repr__` for `pyvista.DataObject`.

Reasoning: When copying the `__repr__`, the tabs are often shifted by too little or two much and have to be manually converted when copying them into examples. Using spaces alleviates this issue, and follows PEP8's recommendation:

> Spaces are the preferred indentation method

I think that this should be applied to `__repr__` as well, and since we should avoid mixing tabs and spaces, this PR proposes to just go with spaces.
