### PR TITLE
Test MathText for conda CI

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -120,7 +120,7 @@ jobs:
         run: |
           source /usr/share/miniconda/etc/profile.d/conda.sh
           conda activate ${{ env.conda_env }}
-          pytest -v tests/plotting --cov-report html --fail_extra_image_cache -k 'not test_add_text_latex'
+          pytest -v tests/plotting --cov-report html --fail_extra_image_cache
 
   Linux:
     name: Linux Unit Testing

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - vtk
   - scooby>=0.5.1
   - meshio
-  - matplotlib<3.6
+  - matplotlib
   - imageio>=2.5.0
   - imageio-ffmpeg
   - colorcet

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - vtk
   - scooby>=0.5.1
   - meshio
-  - matplotlib
+  - matplotlib<3.6
   - imageio>=2.5.0
   - imageio-ffmpeg
   - colorcet


### PR DESCRIPTION
Follow up to https://github.com/pyvista/pyvista/pull/3781

FYI https://github.com/conda-forge/vtk-feedstock/issues/79

The VTK feedstock just bumped to 9.2.5 and thus no longer matplotlib<3.6 for MathText/LaTeX symbol rendering.