### PR TITLE
Add hydrogen 3d orbital example

### DIFF
--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -4933,6 +4933,48 @@ def download_dikhololo_night():  # pragma: no cover
     return texture
 
 
+def download_hydrogen_orbital(load=True):
+    """Download a model of the electron cloud of the hydrogen atom.
+
+    Dataset originally hosted at
+    https://www.it.uu.se/edu/course/homepage/vetvis/ht11/ComputerExercises/data/a1/hydrogen.vtk
+
+    Parameters
+    ----------
+    load : bool, default: True
+        Load the dataset after downloading it when ``True``.  Set this
+        to ``False`` and only the filename will be returned.
+
+    Returns
+    -------
+    pyvista.UniformGrid or str
+        DataSet or filename depending on ``load``.
+
+    Examples
+    --------
+    Download and plot the dataset.
+
+    >>> from pyvista import examples
+    >>> mesh = examples.download_hydrogen_orbital()
+    >>> mesh.plot(volume=True, zoom=2)
+
+    Return the statistics of the dataset.
+
+    >>> grid  # doctest:+SKIP
+    UniformGrid (0x7f0e67f3c2e0)
+      N Cells:      250047
+      N Points:     262144
+      X Bounds:     0.000e+00, 6.300e+01
+      Y Bounds:     0.000e+00, 6.300e+01
+      Z Bounds:     0.000e+00, 6.300e+01
+      Dimensions:   64, 64, 64
+      Spacing:      1.000e+00, 1.000e+00, 1.000e+00
+      N Arrays:     1
+
+    """
+    return _download_and_read('hydrogen/hydrogen.vti', load=load)
+
+
 def download_cad_model_case(load=True):  # pragma: no cover
     """Download a CAD model of a Raspberry PI 4 case.
 

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -4945,6 +4945,9 @@ def download_hydrogen_orbital(load=True):  # pragma: no cover
     `Scientific Visualization - Computer exercises and assignments
     <https://www.it.uu.se/edu/course/homepage/vetvis/ht11/ComputerExercises/data/a1/hydrogen.vtk>`_
 
+    For additional information, see `pyvista/pyvista #3811
+    <https://github.com/pyvista/pyvista/pull/3811>`_
+
     Parameters
     ----------
     load : bool, default: True

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -4937,12 +4937,13 @@ def download_hydrogen_orbital(load=True):  # pragma: no cover
     """Download a model of the 3d orbital of a hydrogen atom.
 
     The ground state of a hydrogen atom is one electron in the 1s orbital.
-    This atom's single electron has been excited to the 3d orbital and visualized here
-    as a probability distribution within the ``point_data`` of a
-    :class:`pyvista.UniformGrid`.
+    This atom's single electron has been excited to the 3d orbital and
+    visualized here as a probability distribution within the ``point_data`` of
+    a :class:`pyvista.UniformGrid`.
 
     Dataset originally hosted at
-    https://www.it.uu.se/edu/course/homepage/vetvis/ht11/ComputerExercises/data/a1/hydrogen.vtk
+    `Scientific Visualization - Computer exercises and assignments
+    <https://www.it.uu.se/edu/course/homepage/vetvis/ht11/ComputerExercises/data/a1/hydrogen.vtk>`_
 
     Parameters
     ----------
@@ -4957,11 +4958,25 @@ def download_hydrogen_orbital(load=True):  # pragma: no cover
 
     Examples
     --------
-    Download and plot the dataset.
+    Download and plot the dataset as a volume.
 
     >>> from pyvista import examples
     >>> mesh = examples.download_hydrogen_orbital()
-    >>> mesh.plot(volume=True, zoom=2)
+    >>> mesh.plot(volume=True, zoom=2.5, opacity=[0.0, 0.1, 0.4, 0.4, 0.8, 0.9, 1.0])
+
+    Plot the dataset as contours.
+
+    >>> import numpy as np
+    >>> import pyvista as pv
+    >>> import pyvista.examples
+    >>> orbital = pv.examples.download_hydrogen_orbital()
+    >>> contours = orbital.contour(
+    ...     [orbital.active_scalars.max() * 0.1], method="marching_cubes"
+    ... ).connectivity()
+    >>> colors = np.array([[255, 215, 0], [0, 128, 128], [255, 215, 0]])[
+    ...     contours.point_data["RegionId"]
+    ... ]
+    >>> contours.plot(scalars=colors, rgb=True, smooth_shading=True)
 
     Return the statistics of the dataset.
 

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -4933,7 +4933,7 @@ def download_dikhololo_night():  # pragma: no cover
     return texture
 
 
-def download_hydrogen_orbital(load=True):
+def download_hydrogen_orbital(load=True):  # pragma: no cover
     """Download a model of the electron cloud of the hydrogen atom.
 
     Dataset originally hosted at

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -4934,7 +4934,12 @@ def download_dikhololo_night():  # pragma: no cover
 
 
 def download_hydrogen_orbital(load=True):  # pragma: no cover
-    """Download a model of the electron cloud of the hydrogen atom.
+    """Download a model of the 3d orbital of a hydrogen atom.
+
+    The ground state of a hydrogen atom is one electron in the 1s orbital.
+    This atom's single electron has been excited to the 3d orbital and visualized here
+    as a probability distribution within the ``point_data`` of a
+    :class:`pyvista.UniformGrid`.
 
     Dataset originally hosted at
     https://www.it.uu.se/edu/course/homepage/vetvis/ht11/ComputerExercises/data/a1/hydrogen.vtk

--- a/tests/examples/test_download_files.py
+++ b/tests/examples/test_download_files.py
@@ -925,6 +925,16 @@ def test_cad_model_case():
     assert dataset.n_points == 7677
 
 
+def test_download_hydrogen_orbital():
+    filename = examples.download_hydrogen_orbital(load=False)
+    assert os.path.isfile(filename)
+    assert filename.endswith('vti')
+
+    dataset = examples.download_hydrogen_orbital()
+    assert isinstance(dataset, pv.UniformGrid)
+    assert dataset.n_points == 262144
+
+
 def test_load_sun():
     mesh = examples.planets.load_sun()
     assert mesh.n_cells


### PR DESCRIPTION
Discovered a nifty dataset from https://github.com/pyvista/pyvista/discussions/3810 and through to expose it in `pyvista`:

```py

>>> from pyvista import examples
>>> mesh = examples.download_hydrogen_orbital()
>>> mesh.plot(volume=True, zoom=2)

```
![tmp](https://user-images.githubusercontent.com/11981631/211691756-28543e30-7966-40ca-9249-b7bd1199f4dc.png)

