### PR TITLE
Fix doc build encoding issue

### DIFF
--- a/doc/make_external_gallery.py
+++ b/doc/make_external_gallery.py
@@ -240,7 +240,7 @@ glad to add it!
 
     # write if different or does not exist
     if new_text != existing:
-        with open(path, "w") as fid:
+        with open(path, "w", encoding="utf-8") as fid:
             fid.write(new_text)
 
     return

--- a/doc/make_tables.py
+++ b/doc/make_tables.py
@@ -59,7 +59,7 @@ class DocTable:
 
         # write if there is any text to write. This avoids resetting the documentation cache
         if new_txt:
-            with open(cls.path, 'w') as fout:
+            with open(cls.path, 'w', encoding="utf-8") as fout:
                 fout.write(new_txt)
 
         pv.close_all()


### PR DESCRIPTION
### Overview

When doing a clean build of the documentation on Windows 10, I needed these changes to the file writing encoding for the build to succeed.
