### PR TITLE
Improve silhouette decimate parameter check

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3794,7 +3794,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if not isinstance(mesh, pyvista.PolyData):
             raise TypeError(f"Expected type is `PolyData` but {type(mesh)} was given.")
 
-        if isinstance(silhouette_params["decimate"], float):
+        if silhouette_params["decimate"]:
             silhouette_mesh = mesh.decimate(silhouette_params["decimate"])
         else:
             silhouette_mesh = mesh


### PR DESCRIPTION
Ref https://github.com/pyvista/pyvista/pull/3318#discussion_r1066386611

@adeak:

> I know this was here before, but is it not weird to test for `float`ness? Shouldn't we be testing for not `None`ness instead? Or am I missing the point here? If someone passes an int by mistake, we won't raise.

I changed this to check truthy-ness