### PR TITLE
Add volume mapper choice notes

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3422,11 +3422,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
             .. note::
                 The ``'smart'`` mapper chooses one of the other listed
                 mappers based on rendering parameters and available
-                hardware.
+                hardware. Most of the time the ``'smart'`` simply checks
+                if a GPU is available and if so, uses the ``'gpu'``
+                mapper, otherwise using the ``'fixed_point'`` mapper.
 
             .. warning::
-                If your volume contains NaN values, you may want to use
-                ``'fixed_point'`` mapper with some graphics hardware.
+                The ``'fixed_point'`` mapper is CPU-based and will have
+                lower performance than the ``'gpu'`` or ``'open_gl'``
+                mappers.
 
         scalar_bar_args : dict, optional
             Dictionary of keyword arguments to pass when adding the

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3419,6 +3419,15 @@ class BasePlotter(PickingHelper, WidgetHelper):
             ``self._theme`` is used. If using ``'fixed_point'``,
             only ``UniformGrid`` types can be used.
 
+            .. note::
+                The ``'smart'`` mapper chooses one of the other listed
+                mappers based on rendering parameters and available
+                hardware.
+
+            .. warning::
+                If your volume contains NaN values, you may want to use
+                ``'fixed_point'`` mapper.
+
         scalar_bar_args : dict, optional
             Dictionary of keyword arguments to pass when adding the
             scalar bar to the scene. For options, see

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3426,7 +3426,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
             .. warning::
                 If your volume contains NaN values, you may want to use
-                ``'fixed_point'`` mapper.
+                ``'fixed_point'`` mapper with some graphics hardware.
 
         scalar_bar_args : dict, optional
             Dictionary of keyword arguments to pass when adding the


### PR DESCRIPTION
The `'smart'` mapper chooses one of the other available mappers based on rendering parameters and available hardware. I added some notes on how that decision is made.

I also added a waring about the `fixed_point` mapper and how it CPU-based



## Addition notes not included in docs

I noticed on my machine today that when datasets have `NaN` values, the `'fixed_point'` mapper might work best, but the `'smart'` mapper was choosing something different. I added these notes to the docstring to help others. I do not want to change the default behavior as the `'smart'` mapper usually chooses the best mapper for the given hardware and autoselecting `'fixed_point'` in the presence of `NaN` values could fail for some hardware.

I'm seeing this issue on my M2 Mac but *not* my Linux machine with an NVIDIA graphics card


```py
import pyvista as pv
from pyvista import examples
import numpy as np

volume = examples.download_knee_full()

volume['SLCImage'] = volume['SLCImage'].astype(float)
volume['SLCImage'][volume['SLCImage'] < 40] = np.nan

p = pv.Plotter()
p.add_volume(volume, cmap="coolwarm", mapper='fixed_point')
p.show()
```