### PR TITLE
Add volume clipper

### DIFF
--- a/examples/03-widgets/clip-volume.py
+++ b/examples/03-widgets/clip-volume.py
@@ -8,13 +8,9 @@ If you have a structured dataset like a :class:`pyvista.UniformGrid` or
 :func:`pyvista.Plotter.add_volume_clipper` widget to better see the internal
 structure of the dataset.
 
-../../images/gifs/volume-clip-plane-widget.gif
+.. image:: ../../images/gifs/volume-clip-plane-widget.gif
 
 """
-
-import numpy as np
-
-import pyvista as pv
 
 ###############################################################################
 # Create the Dataset
@@ -22,6 +18,10 @@ import pyvista as pv
 # Create a dense :class:`pyvista.UniformGrid` with dimensions ``(200, 200,
 # 200)`` and set the active scalars to distance from the :attr:`center
 # <pyvista.UniformGrid.center>` of the grid.
+
+import numpy as np
+
+import pyvista as pv
 
 grid = pv.UniformGrid(dimensions=(200, 200, 200))
 grid['scalars'] = np.linalg.norm(grid.center - grid.points, axis=1)

--- a/examples/03-widgets/clip-volume.py
+++ b/examples/03-widgets/clip-volume.py
@@ -1,0 +1,40 @@
+"""
+.. _clip_volume_widget_example:
+
+Clip Volume Widget
+------------------
+If you have a structured dataset like :class:`pyvista.UniformGrid`, or
+:class:`pyvista.RectilinearGrid` you can clip it using the
+:func:`pyvista.Plotter.add_volume_clipper` widget.  .. image::
+
+../../images/gifs/box-clip.gif
+
+"""
+
+import numpy as np
+
+import pyvista as pv
+
+###############################################################################
+# Create the Dataset
+# ~~~~~~~~~~~~~~~~~~
+# Create a dense :class:`pyvista.UniformGrid` with dimensions ``(200, 200,
+# 200)`` and set the active scalars to distance from the :attr:`center
+# <pyvista.UniformGrid.center>` of the grid.
+
+grid = pv.UniformGrid(dimensions=(200, 200, 200))
+
+scalars = np.linalg.norm(grid.center - grid.points, axis=1)
+# scalars = np.abs(scalars.max() - scalars)
+grid['scalars'] = scalars
+
+opacity = np.zeros(100)
+opacity[::10] = np.geomspace(0.01, 0.5, 10)
+x = np.linspace(0, 1, len(opacity))
+
+
+pl = pv.Plotter()
+vol = pl.add_volume(grid, opacity=opacity)
+vol.prop.interpolation_type = 'linear'
+pl.add_volume_clip_plane(vol, event_type='always')
+pl.show()

--- a/examples/03-widgets/clip-volume.py
+++ b/examples/03-widgets/clip-volume.py
@@ -3,11 +3,12 @@
 
 Clip Volume Widget
 ------------------
-If you have a structured dataset like :class:`pyvista.UniformGrid`, or
-:class:`pyvista.RectilinearGrid` you can clip it using the
-:func:`pyvista.Plotter.add_volume_clipper` widget.  .. image::
+If you have a structured dataset like a :class:`pyvista.UniformGrid` or
+:class:`pyvista.RectilinearGrid`, you can clip it using the
+:func:`pyvista.Plotter.add_volume_clipper` widget to better see the internal
+structure of the dataset.
 
-../../images/gifs/box-clip.gif
+../../images/gifs/volume-clip-plane-widget.gif
 
 """
 
@@ -23,18 +24,56 @@ import pyvista as pv
 # <pyvista.UniformGrid.center>` of the grid.
 
 grid = pv.UniformGrid(dimensions=(200, 200, 200))
+grid['scalars'] = np.linalg.norm(grid.center - grid.points, axis=1)
+grid
 
-scalars = np.linalg.norm(grid.center - grid.points, axis=1)
-# scalars = np.abs(scalars.max() - scalars)
-grid['scalars'] = scalars
+
+###############################################################################
+# Generate the Opacity Array
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Create a banded opacity array such that our dataset shows "rings" at certain
+# values. Have this increase such that higher values (values farther away from
+# the center) are more opaque.
 
 opacity = np.zeros(100)
-opacity[::10] = np.geomspace(0.01, 0.5, 10)
-x = np.linspace(0, 1, len(opacity))
+opacity[::10] = np.geomspace(0.01, 0.75, 10)
 
+
+###############################################################################
+# Plot a Single Clip Plane Dataset
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Plot the volume with a single clip plane.
+#
+# Reverse the opacity array such that portions closer to the center are more
+# opaque.
+
+pl = pv.Plotter()
+pl.add_volume_clip_plane(grid, normal='-x', opacity=opacity[::-1], cmap='magma')
+pl.show()
+
+
+###############################################################################
+# Plot Multiple Clip Planes
+# ~~~~~~~~~~~~~~~~~~~~~~~~~
+# Plot the dataset using the :func:`pyvista.Plotter.add_volume_clip_plane` with
+# the output from :func:`pyvista.Plotter.add_volume` Enable constant
+# interaction by setting the ``interaction_event`` to ``'always'``.
+#
+# Disable the arrows to make the plot a bit clearer and flip the opacity array.
 
 pl = pv.Plotter()
 vol = pl.add_volume(grid, opacity=opacity)
 vol.prop.interpolation_type = 'linear'
-pl.add_volume_clip_plane(vol, event_type='always')
+pl.add_volume_clip_plane(
+    vol,
+    normal='-x',
+    interaction_event='always',
+    normal_rotation=False,
+)
+pl.add_volume_clip_plane(
+    vol,
+    normal='-y',
+    interaction_event='always',
+    normal_rotation=False,
+)
 pl.show()

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -270,7 +270,7 @@ class _BaseMapper(_vtk.vtkAbstractMapper):
     def scalar_map_mode(self, scalar_mode: Union[str, FieldAssociation]):
         if isinstance(scalar_mode, FieldAssociation):
             scalar_mode = scalar_mode.name
-        scalar_mode = scalar_mode.lower()
+        scalar_mode = scalar_mode.lower()  # type: ignore
         if scalar_mode == 'default':
             self.SetScalarModeToDefault()
         elif scalar_mode == 'point':

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -270,7 +270,7 @@ class _BaseMapper(_vtk.vtkAbstractMapper):
     def scalar_map_mode(self, scalar_mode: Union[str, FieldAssociation]):
         if isinstance(scalar_mode, FieldAssociation):
             scalar_mode = scalar_mode.name
-        scalar_mode = scalar_mode.lower()  # type: ignore
+        scalar_mode = scalar_mode.lower()
         if scalar_mode == 'default':
             self.SetScalarModeToDefault()
         elif scalar_mode == 'point':

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -51,7 +51,7 @@ def _parse_interaction_event(interaction_event):
             "Expected value for `interaction_event` is 'start', "
             f"'end', or 'always'. {interaction_event} was given."
         )
-    else:
+    elif not isinstance(interaction_event, _vtk.vtkCommand.EventIds):
         raise TypeError(
             "Expected type for `interaction_event` is either a str "
             "or an instance of `vtk.vtkCommand.EventIds`."

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -736,7 +736,7 @@ class WidgetHelper:
 
         Parameters
         ----------
-        volume : pyvista.plotting.Volume, pyvista.UniformGrid, pyvista.RectilinearGrid
+        volume : pyvista.plotting.Volume or pyvista.UniformGrid or pyvista.RectilinearGrid
             New dataset of type :class:`pyvista.UniformGrid` or
             :class:`pyvista.RectilinearGrid`, or the return value from
             :class:`pyvista.plotting.Volume` from :func:`BasePlotter.add_volume`.
@@ -812,12 +812,11 @@ class WidgetHelper:
             assert_empty_kwargs(**kwargs)
 
         plane = _vtk.vtkPlane()
-        _widget = []
 
-        def callback(*args):
+        def callback(normal, origin):
             """Update the plane used to clip the volume."""
-            if len(_widget):
-                _widget[0].GetPlane(plane)
+            plane.SetNormal(normal)
+            plane.SetOrigin(origin)
 
         widget = self.add_plane_widget(
             callback=callback,
@@ -835,10 +834,9 @@ class WidgetHelper:
             interaction_event=interaction_event,
         )
         widget.GetPlane(plane)
-        _widget.append(widget)
+        volume.mapper.AddClippingPlane(plane)
         self.plane_widgets.append(widget)
 
-        volume.mapper.AddClippingPlane(plane)
         return widget
 
     def add_mesh_slice(

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -122,7 +122,7 @@ class WidgetHelper:
 
         rotation_enabled : bool, optional
             If ``False``, the box widget cannot be rotated and is
-            strictly orthogonal to the cartesian axes.
+            strictly orthogonal to the Cartesian axes.
 
         color : ColorLike, optional
             Either a string, rgb sequence, or hex color string.
@@ -141,8 +141,13 @@ class WidgetHelper:
             If ``True``, the widget will be passed as the last
             argument of the callback.
 
-        interaction_event : vtk.vtkCommand.EventIds, optional
-            The VTK interaction event to use for triggering the callback.
+        interaction_event : vtk.vtkCommand.EventIds, str, optional
+            The VTK interaction event to use for triggering the
+            callback. Accepts either the strings ``'start'``, ``'end'``,
+            ``'always'`` or a ``vtk.vtkCommand.EventIds``.
+
+            .. versionchanged:: 0.38.0
+               Now accepts either strings or ``vtk.vtkCommand.EventIds``.
 
         Returns
         -------
@@ -254,8 +259,14 @@ class WidgetHelper:
         crinkle : bool, optional
             Crinkle the clip by extracting the entire cells along the clip.
 
-        interaction_event : vtk.vtkCommand.EventIds, optional
-            The VTK interaction event to use for triggering the callback.
+        interaction_event : vtk.vtkCommand.EventIds, str, optional
+            The VTK interaction event to use for triggering the
+            callback. Accepts either the strings ``'start'``, ``'end'``,
+            ``'always'`` or a ``vtk.vtkCommand.EventIds``.
+
+            .. versionchanged:: 0.38.0
+               Changed from ``event_type`` to ``interaction_event`` and now
+               accepts either strings and ``vtk.vtkCommand.EventIds``.
 
         **kwargs : dict, optional
             All additional keyword arguments are passed to
@@ -414,8 +425,11 @@ class WidgetHelper:
 
         interaction_event : vtk.vtkCommand.EventIds, str, optional
             The VTK interaction event to use for triggering the
-            callback. Accepts either the strings ``'end'``, ``'always'``, or a
-            ``vtk.vtkCommand.EventIds``.
+            callback. Accepts either the strings ``'start'``, ``'end'``,
+            ``'always'`` or a ``vtk.vtkCommand.EventIds``.
+
+            .. versionchanged:: 0.38.0
+               Now accepts either strings and ``vtk.vtkCommand.EventIds``.
 
         Returns
         -------
@@ -616,8 +630,13 @@ class WidgetHelper:
         crinkle : bool, optional
             Crinkle the clip by extracting the entire cells along the clip.
 
-        interaction_event : vtk.vtkCommand.EventIds, optional
-            The VTK interaction event to use for triggering the callback.
+        interaction_event : vtk.vtkCommand.EventIds, str, optional
+            The VTK interaction event to use for triggering the
+            callback. Accepts either the strings ``'start'``, ``'end'``,
+            ``'always'`` or a ``vtk.vtkCommand.EventIds``.
+
+            .. versionchanged:: 0.38.0
+               Now accepts either strings or ``vtk.vtkCommand.EventIds``.
 
         origin : tuple(float), optional
             The starting coordinate of the center of the plane.
@@ -1164,8 +1183,8 @@ class WidgetHelper:
             ``'always'`` or a ``vtk.vtkCommand.EventIds``.
 
             .. versionchanged:: 0.38.0
-               Changed from ``event_type`` to ``interaction_event`` and now accepts
-               either strings and ``vtk.vtkCommand.EventIds``.
+               Changed from ``event_type`` to ``interaction_event`` and now
+               accepts either strings or ``vtk.vtkCommand.EventIds``.
 
         style : str, optional
             The name of the slider style. The list of available styles
@@ -1299,7 +1318,7 @@ class WidgetHelper:
 
             .. versionchanged:: 0.38.0
                Changed from ``event_type`` to ``interaction_event`` and now accepts
-               either strings and ``vtk.vtkCommand.EventIds``.
+               either strings or ``vtk.vtkCommand.EventIds``.
 
         style : str, optional
             The name of the slider style. The list of available styles

--- a/tests/plotting/test_widgets.py
+++ b/tests/plotting/test_widgets.py
@@ -133,16 +133,16 @@ def test_widget_slider(uniform):
     p.close()
 
     p = pyvista.Plotter()
-    for event_type in ['start', 'end', 'always']:
-        p.add_slider_widget(callback=func, rng=[0, 10], event_type=event_type)
+    for interaction_event in ['start', 'end', 'always']:
+        p.add_slider_widget(callback=func, rng=[0, 10], interaction_event=interaction_event)
     with pytest.raises(TypeError, match='type for ``style``'):
         p.add_slider_widget(callback=func, rng=[0, 10], style=0)
     with pytest.raises(AttributeError):
         p.add_slider_widget(callback=func, rng=[0, 10], style="foo")
-    with pytest.raises(TypeError, match='type for `event_type`'):
-        p.add_slider_widget(callback=func, rng=[0, 10], event_type=0)
-    with pytest.raises(ValueError, match='value for `event_type`'):
-        p.add_slider_widget(callback=func, rng=[0, 10], event_type='foo')
+    with pytest.raises(TypeError, match='Expected type for `interaction_event`'):
+        p.add_slider_widget(callback=func, rng=[0, 10], interaction_event=0)
+    with pytest.raises(ValueError, match='Expected value for `interaction_event`'):
+        p.add_slider_widget(callback=func, rng=[0, 10], interaction_event='foo')
     p.close()
 
     p = pyvista.Plotter()

--- a/tests/plotting/test_widgets.py
+++ b/tests/plotting/test_widgets.py
@@ -297,6 +297,24 @@ def test_plot_algorithm_widgets():
     pl.close()
 
 
+def test_add_volume_clip_plane(uniform):
+    pl = pyvista.Plotter()
+    with pytest.raises(TypeError, match='The `volume` parameter type must'):
+        pl.add_volume_clip_plane(pyvista.Sphere())
+
+    widget = pl.add_volume_clip_plane(uniform)
+    assert isinstance(widget, vtk.vtkImplicitPlaneWidget)
+    assert pl.volume.mapper.GetClippingPlanes().GetNumberOfItems() == 1
+    pl.close()
+
+    pl = pyvista.Plotter()
+    vol = pl.add_volume(uniform)
+    assert vol.mapper.GetClippingPlanes() is None
+    pl.add_volume_clip_plane(vol)
+    assert vol.mapper.GetClippingPlanes().GetNumberOfItems() == 1
+    pl.close()
+
+
 @pytest.mark.needs_vtk_version(9, 1, 0)
 def test_plot_pointset_widgets(pointset):
     pointset = pointset.elevation()


### PR DESCRIPTION
Add a volume clipper widget.

![volume-clip-plane-widget](https://user-images.githubusercontent.com/11981631/212829706-b4d68925-5cc2-4680-8114-7adae91b10e0.gif)

```py
import numpy as np
import pyvista as pv

grid = pv.UniformGrid(dimensions=(200, 200, 200))
grid['scalars'] = np.linalg.norm(grid.center - grid.points, axis=1)
opacity = np.zeros(100)
opacity[::10] = np.geomspace(0.01, 0.75, 10)

pl = pv.Plotter()
pl.add_volume_clip_plane(grid, normal='-x', opacity=opacity[::-1], cmap='magma')
pl.show()
```

Bonus Modifications
- Change `event_type` to `interaction_event` for consistency.
- Consistently accept strings in `interaction_event` everywhere.