### PR TITLE
Fix mypy bug on python 3.11

### DIFF
--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -270,7 +270,7 @@ class _BaseMapper(_vtk.vtkAbstractMapper):
     def scalar_map_mode(self, scalar_mode: Union[str, FieldAssociation]):
         if isinstance(scalar_mode, FieldAssociation):
             scalar_mode = scalar_mode.name
-        scalar_mode = scalar_mode.lower()
+        scalar_mode = scalar_mode.lower()  # type: ignore
         if scalar_mode == 'default':
             self.SetScalarModeToDefault()
         elif scalar_mode == 'point':


### PR DESCRIPTION
On Python 3.11, mypy erroniously reports an error:

```
$ python3.11 -m venv .venv
$ source .venv/bin/activate
$ pip install pre-commit
$ pre-commit run --all-files mypy
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

pyvista/plotting/mapper.py:273: error: Item "FieldAssociation" of "Union[str, FieldAs
sociation]" has no attribute "lower"  [union-attr]                                  
pyvista/core/composite.py:589: note: By default the bodies of untyped functions are n
ot checked, consider using --check-untyped-defs  [annotation-unchecked]             
pyvista/core/composite.py:590: note: By default the bodies of untyped functions are n
ot checked, consider using --check-untyped-defs  [annotation-unchecked]             
Found 1 error in 1 file (checked 89 source files)
```

Temporary solution is to ignore the type check in `mapper.py` so `pre-commit` works in Python 3.11. We can review/remove this later once this is fixed upstream.

Originally pointed out in https://github.com/pyvista/pyvista/pull/3318#discussion_r1067534921 and https://github.com/pyvista/pyvista/pull/3830#discussion_r1072449276.
