### PR TITLE
Quick fix for docstring of add_volume_clip_plane

### DIFF
--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -792,7 +792,7 @@ class WidgetHelper:
             All additional keyword arguments are passed to
             :func:`BasePlotter.add_volume` to control how the volume is
             displayed. Only applicable if ``volume`` is either a
-            :class:`pyvista.UniformGrid` and :class:`pyvista.RectangularGrid`
+            :class:`pyvista.UniformGrid` and :class:`pyvista.RectangularGrid`.
 
         Returns
         -------


### PR DESCRIPTION
Quick fix to the docstring of `**kwargs` of `add_volume_clip_plane`.