### PR TITLE
Add clean UnstructuredGrid  filter

### DIFF
--- a/pyvista/core/filters/__init__.py
+++ b/pyvista/core/filters/__init__.py
@@ -28,7 +28,20 @@ from pyvista.utilities import wrap, ProgressMonitor
 
 
 def _update_alg(alg, progress_bar=False, message=''):
-    """Update an algorithm with or without a progress bar."""
+    """Update an algorithm with or without a progress bar.
+
+    Parameters
+    ----------
+    alg : vtkAlgorithm
+        VTK algorithm.
+
+    progress_bar : bool, default: False
+        Display a progress bar to indicate progress.
+
+    message : str, default: ''
+        Message to display when the progress bar is shown.
+
+    """
     if progress_bar:
         with ProgressMonitor(alg, message=message):
             alg.Update()

--- a/tests/filters/test_unstructured_grid.py
+++ b/tests/filters/test_unstructured_grid.py
@@ -1,4 +1,5 @@
 """Test unstructured grid filters."""
+import numpy as np
 import pytest
 
 
@@ -8,7 +9,19 @@ def test_clean(hexbeam):
     hexbeam_b.points[:, 0] += 1
     merged = hexbeam.merge(hexbeam_b, merge_points=False)
     merged.n_points
+    merged['comp_6_pt'] = np.random.random((merged.n_points, 6))
+    merged['comp_6_cell'] = np.random.random((merged.n_cells, 6))
 
     cleaned = merged.clean()
     assert cleaned.n_cells == merged.n_cells
     assert cleaned.n_points < merged.n_points
+
+    assert 'comp_6_pt' in cleaned.point_data
+    assert 'comp_6_cell' in cleaned.cell_data
+    assert 'OriginalPointIds' in cleaned.point_data
+
+    # ids = cleaned.point_data['OriginalPointIds']
+    # breakpoint()
+    # assert np.allclose(cleaned.points, merged.points[ids])
+    # diff = np.linalg.norm(cleaned.points- merged.points[ids],axis=1) > 0
+    # cleaned.plot(scalars=diff, off_screen=False)

--- a/tests/filters/test_unstructured_grid.py
+++ b/tests/filters/test_unstructured_grid.py
@@ -1,0 +1,14 @@
+"""Test unstructured grid filters."""
+import pytest
+
+
+@pytest.mark.needs_vtk_version(9, 0, 3)
+def test_clean(hexbeam):
+    hexbeam_b = hexbeam.copy()
+    hexbeam_b.points[:, 0] += 1
+    merged = hexbeam.merge(hexbeam_b, merge_points=False)
+    merged.n_points
+
+    cleaned = merged.clean()
+    assert cleaned.n_cells == merged.n_cells
+    assert cleaned.n_points < merged.n_points


### PR DESCRIPTION
Seems that this was added back in `vtk==9.0.3`: [vtkmCleanGrid](https://vtk.org/doc/nightly/html/classvtkmCleanGrid.html)

Works quite well to clean up unmerged points from the parallel vtu reader.