### PR TITLE
Support Actor-based picking

### DIFF
--- a/examples/02-plot/mesh-picking.py
+++ b/examples/02-plot/mesh-picking.py
@@ -43,3 +43,32 @@ pl.add_mesh(sphere, color='r')
 pl.add_mesh(cube, color='b')
 pl.enable_mesh_picking(callback=callback, left_clicking=True, show=False)
 pl.show()
+
+
+###############################################################################
+# Pick based on Actors
+# ++++++++++++++++++++
+# Return the picked actor to the callback
+
+pl = pv.Plotter()
+pl.add_mesh(pv.Cone(center=(0, 0, 0)), name='Cone')
+pl.add_mesh(pv.Cube(center=(1, 0, 0)), name='Cube')
+pl.add_mesh(pv.Sphere(center=(1, 1, 0)), name='Sphere')
+pl.add_mesh(pv.Cylinder(center=(0, 1, 0)), name='Cylinder')
+
+
+def reset():
+    for a in pl.actors.values():
+        if isinstance(a, pv.Actor):
+            a.prop.color = 'tan'
+            a.prop.show_edges = False
+
+
+def callback(actor):
+    reset()
+    actor.prop.color = 'green'
+    actor.prop.show_edges = True
+
+
+pl.enable_mesh_picking(callback, use_actor=True, show=False)
+pl.show()

--- a/examples/02-plot/mesh-picking.py
+++ b/examples/02-plot/mesh-picking.py
@@ -58,7 +58,7 @@ pl.add_mesh(pv.Cylinder(center=(0, 1, 0)), name='Cylinder')
 
 
 def reset():
-    for a in pl.actors.values():
+    for a in pl.renderer.actors.values():
         if isinstance(a, pv.Actor):
             a.prop.color = 'tan'
             a.prop.show_edges = False

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -61,6 +61,7 @@ class PickingHelper:
         color='pink',
         font_size=18,
         left_clicking=False,
+        use_actor=False,
         **kwargs,
     ):
         """Enable picking of a mesh.
@@ -104,6 +105,10 @@ class PickingHelper:
                If enabled, left-clicking will **not** display the bounding box
                around the picked point.
 
+        use_actor : bool, default: False
+            If True, the callback will be passed the picked actor instead of
+            the mesh object.
+
         **kwargs : dict, optional
             All remaining keyword arguments are used to control how
             the picked path is interactively displayed.
@@ -144,7 +149,10 @@ class PickingHelper:
                 self_()._picked_mesh = mesh
 
             if callback and is_valid_selection:
-                try_callback(callback, mesh)
+                if use_actor:
+                    try_callback(callback, actor)
+                else:
+                    try_callback(callback, mesh)
 
             if show and is_valid_selection:
 

--- a/tests/test_picking.py
+++ b/tests/test_picking.py
@@ -127,6 +127,37 @@ def test_enable_mesh_picking(sphere, left_clicking):
     assert pl.picked_mesh is None
 
 
+def test_enable_mesh_picking_actor(sphere):
+    picked = []
+
+    def callback(picked_actor):
+        picked.append(picked_actor)
+
+    pl = pyvista.Plotter()
+    actor = pl.add_mesh(sphere)
+    pl.enable_mesh_picking(callback=callback, use_actor=True)
+    pl.show(auto_close=False)
+
+    width, height = pl.window_size
+
+    # clicking is to "activate" the renderer
+    pl.iren._mouse_left_button_press(width // 2, height // 2)
+    pl.iren._mouse_left_button_release(width, height)
+    pl.iren._mouse_move(width // 2, height // 2)
+    pl.iren._simulate_keypress('p')
+
+    assert actor in picked
+    assert pl.picked_mesh == sphere
+
+    # invalid selection
+    pl.iren._mouse_left_button_press(0, 0)
+    pl.iren._mouse_left_button_release(0, 0)
+    pl.iren._mouse_move(0, 0)
+    pl.iren._simulate_keypress('p')
+
+    assert pl.picked_mesh is None
+
+
 @pytest.mark.parametrize('left_clicking', [False, True])
 def test_enable_surface_picking(sphere, left_clicking):
     picked = []


### PR DESCRIPTION
Enables support for picking individual actors. This is useful if you want the picking operation to modify how the actor is displayed.

NOTE: the example requires the new `actors` property on the `BasePlotter` from #3385 