### PR TITLE
Track Actor names better and improve add_actor

### DIFF
--- a/pyvista/plotting/actor.py
+++ b/pyvista/plotting/actor.py
@@ -76,8 +76,7 @@ class Actor(Prop3D, _vtk.vtkActor):
 
     """
 
-    _renderer = None
-    _name = None
+    _new_attr_exceptions = ['_renderer', '_name']
 
     def __init__(self, mapper=None, prop=None, name=None):
         """Initialize actor."""
@@ -86,16 +85,20 @@ class Actor(Prop3D, _vtk.vtkActor):
             self.mapper = mapper
         if prop is None:
             self.prop = Property()
+        self._name = name
+        self._renderer = None
 
     @property
     def name(self) -> str:
         """Get or set the unique name identifier used by PyVista."""
         if self._name is None:
-            self._name = self.GetAddressAsString("")
+            self._name = f'{type(self).__name__}({self.memory_address})'
         return self._name
 
     @name.setter
     def name(self, value: str):
+        if not value:
+            raise ValueError('Name must be truthy.')
         self._name = value
 
     @property

--- a/pyvista/plotting/actor.py
+++ b/pyvista/plotting/actor.py
@@ -32,6 +32,9 @@ class Actor(Prop3D, _vtk.vtkActor):
     prop : pyvista.Property, optional
         Property of the actor.
 
+    name : str, optional
+        The name of this actor used when tracking on a plotter.
+
     Examples
     --------
     Create an actor without using :class:`pyvista.Plotter`.

--- a/pyvista/plotting/actor.py
+++ b/pyvista/plotting/actor.py
@@ -1,7 +1,6 @@
 """Wrap vtkActor."""
 
 from typing import Optional, Union
-import weakref
 
 import numpy as np
 
@@ -79,7 +78,7 @@ class Actor(Prop3D, _vtk.vtkActor):
 
     """
 
-    _new_attr_exceptions = ['_renderer', '_name']
+    _new_attr_exceptions = ['_name']
 
     def __init__(self, mapper=None, prop=None, name=None):
         """Initialize actor."""
@@ -89,7 +88,6 @@ class Actor(Prop3D, _vtk.vtkActor):
         if prop is None:
             self.prop = Property()
         self._name = name
-        self._renderer = None
 
     @property
     def name(self) -> str:
@@ -195,17 +193,6 @@ class Actor(Prop3D, _vtk.vtkActor):
     @texture.setter
     def texture(self, obj):
         self.SetTexture(obj)
-
-    @property
-    def renderer(self):
-        """Return the renderer associated with this actor."""
-        return self._renderer
-
-    @renderer.setter
-    def renderer(self, obj):
-        if not isinstance(obj, weakref.ProxyType):
-            raise TypeError("Only a ProxyType can be assigned to `renderer`")
-        self._renderer = obj
 
     @property
     def memory_address(self):

--- a/pyvista/plotting/actor.py
+++ b/pyvista/plotting/actor.py
@@ -77,14 +77,26 @@ class Actor(Prop3D, _vtk.vtkActor):
     """
 
     _renderer = None
+    _name = None
 
-    def __init__(self, mapper=None, prop=None):
+    def __init__(self, mapper=None, prop=None, name=None):
         """Initialize actor."""
         super().__init__()
         if mapper is not None:
             self.mapper = mapper
         if prop is None:
             self.prop = Property()
+
+    @property
+    def name(self) -> str:
+        """Get or set the unique name identifier used by PyVista."""
+        if self._name is None:
+            self._name = self.GetAddressAsString("")
+        return self._name
+
+    @name.setter
+    def name(self, value: str):
+        self._name = value
 
     @property
     def mapper(self) -> _BaseMapper:

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -754,6 +754,8 @@ class Renderer(_vtk.vtkOpenGLRenderer):
                 # e.g., vtkScalarBarActor
                 name = actor.GetAddressAsString("")
 
+        actor.SetPickable(pickable)
+        self.AddActor(actor)  # must add actor before resetting camera
         self._actors[name] = actor
 
         if reset_camera:
@@ -782,8 +784,6 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             else:
                 raise ValueError(f'Culling option ({culling}) not understood.')
 
-        actor.SetPickable(pickable)
-        self.AddActor(actor)
         self.Modified()
 
         prop = None

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -4,7 +4,6 @@ import collections.abc
 from functools import partial
 from typing import Sequence, cast
 import warnings
-from weakref import proxy
 
 import numpy as np
 
@@ -742,9 +741,6 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         if isinstance(actor, Actor) and name:
             # WARNING: this will override the name if already set on Actor
             actor.name = name
-
-        if isinstance(actor, Actor):
-            actor.renderer = proxy(self)
 
         if name is None:
             if isinstance(actor, Actor):

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -695,8 +695,8 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         Parameters
         ----------
-        actor : vtk.vtkMapper or vtk.vtkActor
-            vtkMapper or vtkActor to be added.
+        actor : vtk.vtkActor or vtk.vtkMapper
+            The actor to be added. Can be either ``vtkActor`` or ``vtkMapper``.
 
         reset_camera : bool, optional
             Resets the camera when ``True``.

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -736,18 +736,16 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             rv = self.remove_actor(name, reset_camera=False, render=False)
 
         if isinstance(uinput, _vtk.vtkMapper):
-            actor = Actor()
+            actor = Actor(name=name)
             actor.SetMapper(uinput)
         else:
             actor = uinput
+            actor.name = name
 
         self.AddActor(actor)
         actor.renderer = proxy(self)
 
-        if name is None:
-            name = actor.GetAddressAsString("")
-
-        self._actors[name] = actor
+        self._actors[actor.name] = actor
 
         if reset_camera:
             self.reset_camera(render)

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -765,13 +765,16 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         self.update_bounds_axes()
 
+        if isinstance(culling, str):
+            culling = culling.lower()
+
         if culling:
-            if culling.lower() in [True, 'back', 'backface', 'b']:
+            if culling in [True, 'back', 'backface', 'b']:
                 try:
                     actor.GetProperty().BackfaceCullingOn()
                 except AttributeError:  # pragma: no cover
                     pass
-            elif culling.lower() in ['front', 'frontface', 'f']:
+            elif culling in ['front', 'frontface', 'f']:
                 try:
                     actor.GetProperty().FrontfaceCullingOn()
                 except AttributeError:  # pragma: no cover

--- a/pyvista/utilities/misc.py
+++ b/pyvista/utilities/misc.py
@@ -167,10 +167,12 @@ def set_pickle_format(format: str):
 
 def no_new_attr(cls):
     """Override __setattr__ to not permit new attributes."""
+    if not hasattr(cls, '_new_attr_exceptions'):
+        cls._new_attr_exceptions = []
 
     def __setattr__(self, name, value):
         """Do not allow setting attributes."""
-        if hasattr(self, name):
+        if hasattr(self, name) or name in cls._new_attr_exceptions:
             object.__setattr__(self, name, value)
         else:
             raise AttributeError(

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -36,9 +36,6 @@ def test_actor_init_empty():
     with pytest.raises(AttributeError):
         actor.not_an_attribute = None
 
-    with pytest.raises(TypeError):
-        actor.renderer = None
-
     assert actor.memory_address == actor.GetAddressAsString("")
 
 


### PR DESCRIPTION
PyVista's `BasePlotter` tracks all `Actor`s added to the scene with a unique name. This is a widely used feature and is tested quite well. Prior to this PR, the `Actor`s themselves are unaware of their names, and I think PyVista's `Actor` class should track this value.

I don't like to add attributes that do not map to existing attributes/properties that exist in VTK, but in my opinion, this is a valid exception for a feature we've implemented specifically for PyVista.


Additionally, this adds support for explicit exceptions when using the `@no_new_attr` decorator. `_renderer` was a class attribute on `Actor` previous to this and I don't think it was actually working as expected. Through the use of `_new_attr_exceptions`, now classes can have a few explicit exceptions for new instance attributes like `_renderer` and `_name` for `Actor`
