### PR TITLE
Fix inplace filters usage of copy_from

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1960,13 +1960,22 @@ class DataSet(DataSetFilters, DataObject):
         """Return the object string representation."""
         return self.head(display=False, html=False)
 
-    def copy_from(self, mesh: _vtk.vtkDataSet):
+    def copy_from(self, mesh: _vtk.vtkDataSet, deep=False):
         """Overwrite this dataset inplace with the new dataset's geometries and data.
+
+        .. versionchanged:: 0.38.0
+            This would deep copy by default prior to version ``0.38.0`` and
+            has been modified to shallow copy by default moving forward
+            to fix issues where in-place filters were producing deep copy
+            outputs.
 
         Parameters
         ----------
         mesh : vtk.vtkDataSet
             The overwriting mesh.
+
+        deep : bool, default: False
+            Whether to perform a deep or shallow copy.
 
         Examples
         --------
@@ -1987,7 +1996,10 @@ class DataSet(DataSetFilters, DataObject):
                 f'The Input DataSet type {type(mesh)} must be '
                 f'compatible with the one being overwritten {type(self)}'
             )
-        self.deep_copy(mesh)
+        if deep:
+            self.deep_copy(mesh)
+        else:
+            self.shallow_copy(mesh)
         if is_pyvista_dataset(mesh):
             self.copy_meta_from(mesh, deep=True)
 

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1960,21 +1960,15 @@ class DataSet(DataSetFilters, DataObject):
         """Return the object string representation."""
         return self.head(display=False, html=False)
 
-    def copy_from(self, mesh: _vtk.vtkDataSet, deep=False):
+    def copy_from(self, mesh: _vtk.vtkDataSet, deep: bool = True):
         """Overwrite this dataset inplace with the new dataset's geometries and data.
-
-        .. versionchanged:: 0.38.0
-            This would deep copy by default prior to version ``0.38.0`` and
-            has been modified to shallow copy by default moving forward
-            to fix issues where in-place filters were producing deep copy
-            outputs.
 
         Parameters
         ----------
         mesh : vtk.vtkDataSet
             The overwriting mesh.
 
-        deep : bool, default: False
+        deep : bool, default: True
             Whether to perform a deep or shallow copy.
 
         Examples

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2001,7 +2001,7 @@ class DataSet(DataSetFilters, DataObject):
         else:
             self.shallow_copy(mesh)
         if is_pyvista_dataset(mesh):
-            self.copy_meta_from(mesh, deep=True)
+            self.copy_meta_from(mesh, deep=deep)
 
     def overwrite(self, mesh: _vtk.vtkDataSet):
         """Overwrite this dataset inplace with the new dataset's geometries and data.

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -163,10 +163,10 @@ class DataSetFilters:
         )
         if inplace:
             if return_clipped:
-                self.copy_from(result[0])
+                self.copy_from(result[0], deep=False)
                 return self, result[1]
             else:
-                self.copy_from(result)
+                self.copy_from(result, deep=False)
                 return self
         return result
 
@@ -423,7 +423,7 @@ class DataSetFilters:
         result0 = _get_output(alg)
 
         if inplace:
-            self.copy_from(result0)
+            self.copy_from(result0, deep=False)
             result0 = self
 
         if both:
@@ -2277,7 +2277,7 @@ class DataSetFilters:
         """
         mesh = DataSetFilters.connectivity(self, largest=True, progress_bar=False)
         if inplace:
-            self.copy_from(mesh)
+            self.copy_from(mesh, deep=False)
             return self
         return mesh
 
@@ -2410,7 +2410,7 @@ class DataSetFilters:
         if inplace:
             if isinstance(self, (_vtk.vtkImageData, _vtk.vtkRectilinearGrid)):
                 raise TypeError("This filter cannot be applied inplace for this mesh type.")
-            self.copy_from(output)
+            self.copy_from(output, deep=False)
             return self
         return output
 
@@ -2484,7 +2484,7 @@ class DataSetFilters:
         _update_alg(alg, progress_bar, 'Warping by Vector')
         warped_mesh = _get_output(alg)
         if inplace:
-            self.copy_from(warped_mesh)
+            self.copy_from(warped_mesh, deep=False)
             return self
         else:
             return warped_mesh
@@ -2703,7 +2703,7 @@ class DataSetFilters:
 
         mesh = _get_output(alg)
         if inplace:
-            self.copy_from(mesh)
+            self.copy_from(mesh, deep=False)
             return self
         return mesh
 
@@ -5208,7 +5208,7 @@ class DataSetFilters:
             res.cell_data.active_scalars_name = active_cell_scalars_name
 
         if inplace:
-            self.copy_from(res)
+            self.copy_from(res, deep=False)
             return self
 
         # The output from the transform filter contains a shallow copy

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5218,7 +5218,7 @@ class DataSetFilters:
             output = pyvista.StructuredGrid()
         else:
             output = self.__class__()
-        output.copy_from(res)
+        output.copy_from(res, deep=True)
         return output
 
     def reflect(

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -653,7 +653,7 @@ class PolyDataFilters(DataSetFilters):
 
         mesh = _get_output(trifilter)
         if inplace:
-            self.copy_from(mesh)
+            self.copy_from(mesh, deep=False)
             return self
         return mesh
 
@@ -745,7 +745,7 @@ class PolyDataFilters(DataSetFilters):
 
         mesh = _get_output(alg)
         if inplace:
-            self.copy_from(mesh)
+            self.copy_from(mesh, deep=False)
             return self
         return mesh
 
@@ -869,7 +869,7 @@ class PolyDataFilters(DataSetFilters):
 
         mesh = _get_output(alg)
         if inplace:
-            self.copy_from(mesh)
+            self.copy_from(mesh, deep=False)
             return self
         return mesh
 
@@ -988,7 +988,7 @@ class PolyDataFilters(DataSetFilters):
 
         mesh = _get_output(alg)
         if inplace:
-            self.copy_from(mesh)
+            self.copy_from(mesh, deep=False)
             return self
 
         return mesh
@@ -1092,7 +1092,7 @@ class PolyDataFilters(DataSetFilters):
 
         mesh = _get_output(tube)
         if inplace:
-            poly_data.copy_from(mesh)
+            poly_data.copy_from(mesh, deep=False)
             return poly_data
         return mesh
 
@@ -1191,7 +1191,7 @@ class PolyDataFilters(DataSetFilters):
 
         submesh = _get_output(sfilter)
         if inplace:
-            self.copy_from(submesh)
+            self.copy_from(submesh, deep=False)
             return self
 
         return submesh
@@ -1295,7 +1295,7 @@ class PolyDataFilters(DataSetFilters):
         submesh = _get_output(sfilter)
 
         if inplace:
-            self.copy_from(submesh)
+            self.copy_from(submesh, deep=False)
             return self
 
         return submesh
@@ -1434,7 +1434,7 @@ class PolyDataFilters(DataSetFilters):
 
         mesh = _get_output(alg)
         if inplace:
-            self.copy_from(mesh)
+            self.copy_from(mesh, deep=False)
             return self
 
         return mesh
@@ -1587,7 +1587,7 @@ class PolyDataFilters(DataSetFilters):
             mesh.GetCellData().SetActiveNormals('Normals')
 
         if inplace:
-            self.copy_from(mesh)
+            self.copy_from(mesh, deep=False)
             return self
 
         return mesh
@@ -1680,7 +1680,7 @@ class PolyDataFilters(DataSetFilters):
         result = _get_output(alg)
 
         if inplace:
-            self.copy_from(result)
+            self.copy_from(result, deep=False)
             return self
         else:
             return result
@@ -1735,7 +1735,7 @@ class PolyDataFilters(DataSetFilters):
 
         mesh = _get_output(alg)
         if inplace:
-            self.copy_from(mesh)
+            self.copy_from(mesh, deep=False)
             return self
         return mesh
 
@@ -1836,7 +1836,7 @@ class PolyDataFilters(DataSetFilters):
             raise ValueError('Clean tolerance is too high. Empty mesh returned.')
 
         if inplace:
-            self.copy_from(output)
+            self.copy_from(output, deep=False)
             return self
         return output
 
@@ -1937,7 +1937,7 @@ class PolyDataFilters(DataSetFilters):
             output["vtkOriginalPointIds"] = output["vtkOriginalPointIds"][::-1]
 
         if inplace:
-            self.copy_from(output)
+            self.copy_from(output, deep=False)
             return self
 
         return output
@@ -2395,7 +2395,7 @@ class PolyDataFilters(DataSetFilters):
 
         # Return vtk surface and reverse indexing array
         if inplace:
-            self.copy_from(newmesh)
+            self.copy_from(newmesh, deep=False)
             return self, ridx
         return newmesh, ridx
 
@@ -2534,7 +2534,7 @@ class PolyDataFilters(DataSetFilters):
         # `.triangulate()` filter cleans those
         mesh = _get_output(alg).triangulate()
         if inplace:
-            self.copy_from(mesh)
+            self.copy_from(mesh, deep=False)
             return self
         return mesh
 
@@ -2824,7 +2824,7 @@ class PolyDataFilters(DataSetFilters):
         _update_alg(alg, progress_bar, 'Extruding')
         output = _get_output(alg)
         if inplace:
-            self.copy_from(output)
+            self.copy_from(output, deep=False)
             return self
         return output
 
@@ -2978,7 +2978,7 @@ class PolyDataFilters(DataSetFilters):
         _update_alg(alg, progress_bar, 'Extruding')
         output = pyvista.wrap(alg.GetOutput())
         if inplace:
-            self.copy_from(output)
+            self.copy_from(output, deep=False)
             return self
         return output
 
@@ -3087,7 +3087,7 @@ class PolyDataFilters(DataSetFilters):
         _update_alg(alg, progress_bar, 'Extruding with trimming')
         output = pyvista.wrap(alg.GetOutput())
         if inplace:
-            self.copy_from(output)
+            self.copy_from(output, deep=False)
             return self
         return output
 

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -93,6 +93,24 @@ def test_prepare_smooth_shading_not_poly(hexbeam):
     assert np.allclose(mesh[scalars_name], expected_mesh[scalars_name])
 
 
+def test_smooth_shading_shallow_copy(sphere):
+    """See also ``test_compute_normals_inplace``."""
+    sphere.point_data['numbers'] = np.arange(sphere.n_points)
+    sphere2 = sphere.copy(deep=False)
+
+    sphere['numbers'] *= -1  # sphere2 'numbers' are also modified
+    assert np.array_equal(sphere['numbers'], sphere2['numbers'])
+    assert np.shares_memory(sphere['numbers'], sphere2['numbers'])
+
+    pl = pyvista.Plotter()
+    pl.add_mesh(sphere, scalars=None, smooth_shading=True)
+    # Modify after adding and using compute_normals via smooth_shading
+    sphere['numbers'] *= -1
+    assert np.array_equal(sphere['numbers'], sphere2['numbers'])
+    assert np.shares_memory(sphere['numbers'], sphere2['numbers'])
+    pl.close()
+
+
 def test_get_datasets(sphere, hexbeam):
     """Test pyvista.Plotter._datasets."""
     pl = pyvista.Plotter()

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -548,6 +548,25 @@ def test_compute_normals(sphere):
     assert cell_normals.shape[0] == sphere.n_cells
 
 
+def test_compute_normals_inplace(sphere):
+    sphere.point_data['numbers'] = np.arange(sphere.n_points)
+    sphere2 = sphere.copy(deep=False)
+
+    sphere['numbers'] *= -1  # sphere2 'numbers' are also modified
+
+    assert np.array_equal(sphere['numbers'], sphere2['numbers'])
+    assert np.shares_memory(sphere['numbers'], sphere2['numbers'])
+
+    sphere.compute_normals(inplace=True)
+
+    sphere[
+        'numbers'
+    ] *= -1  # sphere2 'numbers' are also modified after adding to Plotter.  (See  issue #2461)
+
+    assert np.array_equal(sphere['numbers'], sphere2['numbers'])
+    assert np.shares_memory(sphere['numbers'], sphere2['numbers'])
+
+
 def test_compute_normals_split_vertices(cube):
     # verify edge splitting occurs and point IDs are tracked
     cube_split_norm = cube.compute_normals(split_vertices=True)


### PR DESCRIPTION
Resolves #3069 and closes #3087 

cc @akaszynski and @p-j-smith

`copy_from()` is being used throughout internally as an assumed shallow copy (see its use for the `inplace=True` scenarios of filters). This PR corrects the internal usage of `copy_from()` to be a shallow copy operation where needed by adding a keyword argument to opt-in to a shallow copy if desired