### PR TITLE
Avoid awaiting the Trame Jupyter backend

### DIFF
--- a/doc/user-guide/jupyter/index.rst
+++ b/doc/user-guide/jupyter/index.rst
@@ -153,14 +153,11 @@ either :func:`Plotter.show() <pyvista.Plotter.show>` or :func:`dataset.plot()
 <pyvista.DataSet.plot>`.  You can also set it globally with the
 :func:`pyvista.set_jupyter_backend`.  For further details:
 
-.. note::
-   Some backends, notably the trame-based backends require :func:`pyvista.set_jupyter_backend`
-   to be awaited.
 
-   .. code:: python
+.. code:: python
 
-      import pyvista as pv
-      await pv.set_jupyter_backend('trame')
+   import pyvista as pv
+   pv.set_jupyter_backend('trame')
 
 .. autofunction:: pyvista.set_jupyter_backend
 

--- a/doc/user-guide/jupyter/trame.rst
+++ b/doc/user-guide/jupyter/trame.rst
@@ -34,10 +34,7 @@ For convenience, you can enable ``trame`` by default with:
 .. code:: python
 
     import pyvista as pv
-    await pv.set_jupyter_backend('trame')
-
-.. note::
-    It is critical to ``await`` the call to :func:`set_jupyter_backend() <pyvista.set_jupyter_backend>` when using Trame in Jupyter.
+    pv.set_jupyter_backend('trame')
 
 
 Trame Jupyter Modes
@@ -50,17 +47,13 @@ as three separate backend choices):
 * ``'server'``: Uses a view that is purely server-rendering.
 * ``'client'``: Uses a view that is purely client-rendering (generally safe without a virtual frame buffer)
 
-With any of these Trame-based backend choices, you must await the call to
-:func:`set_jupyter_backend() <pyvista.set_jupyter_backend>`
-as mentioned above.
-
 You can choose your backend either by using :func:`set_jupyter_backend() <pyvista.set_jupyter_backend>`
 or passing ``jupyter_backend`` on the :func:`show() <pyvista.Plotter.show>` call.
 
 .. code:: python
 
     import pyvista as pv
-    await pv.set_jupyter_backend('client')
+    pv.set_jupyter_backend('client')
 
     pv.Cone().plot()
 
@@ -68,7 +61,7 @@ or passing ``jupyter_backend`` on the :func:`show() <pyvista.Plotter.show>` call
 .. code:: python
 
     import pyvista as pv
-    await pv.set_jupyter_backend('trame')
+    pv.set_jupyter_backend('trame')
 
     pl = pv.Plotter()
     pl.add_mesh(pv.Cone())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,20 +54,20 @@ colormaps = [
 io = ['meshio>=5.2']
 jupyter = [
     'ipyvtklink',
+    'jupyter-server-proxy',
+    'nest_asyncio',
     'panel',
     'pythreejs',
     'trame>=2.2.6',
     'trame-client>=2.4.2',
     'trame-server>=2.8.0',
     'trame-vtk>=2.0.15',
-    'jupyter-server-proxy',
 ]
 trame = [
     'trame>=2.2.6',
     'trame-client>=2.4.2',
     'trame-server>=2.8.0',
     'trame-vtk>=2.0.15',
-    'jupyter-server-proxy',
 ]
 
 [project.urls]

--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -189,4 +189,4 @@ def set_jupyter_backend(backend):
         # Launch the trame server
         from pyvista.trame.jupyter import elegantly_launch
 
-        return elegantly_launch()
+        return elegantly_launch(pyvista.global_theme.trame.jupyter_server_name)

--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -91,7 +91,7 @@ def _validate_jupyter_backend(backend):
     return backend
 
 
-def set_jupyter_backend(backend) -> Awaitable[bool]:
+def set_jupyter_backend(backend):
     """Set the plotting backend for a jupyter notebook.
 
     Parameters
@@ -150,11 +150,6 @@ def set_jupyter_backend(backend) -> Awaitable[bool]:
           will generate nothing on headless servers even with a
           virtual framebuffer.
 
-    Returns
-    -------
-    Awaitable[bool]
-        An awaitable future that will finalize when the backend is ready.
-
     Examples
     --------
     Enable the pythreejs backend.
@@ -177,7 +172,7 @@ def set_jupyter_backend(backend) -> Awaitable[bool]:
 
     Enable the trame Trame backend.
 
-    >>> await pv.set_jupyter_backend('trame')  # doctest:+SKIP
+    >>> pv.set_jupyter_backend('trame')  # doctest:+SKIP
 
     Just show static images.
 
@@ -192,12 +187,6 @@ def set_jupyter_backend(backend) -> Awaitable[bool]:
     pyvista.global_theme._jupyter_backend = _validate_jupyter_backend(backend)
     if backend in ['server', 'client', 'trame']:
         # Launch the trame server
-        from pyvista.trame.jupyter import launch_server
+        from pyvista.trame.jupyter import elegantly_launch
 
-        # Returns a future that finalizes when server is ready - should be awaited
-        return launch_server(pyvista.global_theme.trame.jupyter_server_name)
-    # Return an awaitable future to prevent errors when accidentally awaiting
-    # other backends
-    future = asyncio.Future()  # type: ignore
-    future.set_result(True)
-    return future
+        return elegantly_launch()

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1326,7 +1326,7 @@ class DefaultTheme(_ThemeConfig):
         # Grab system flag for auto-closing
         self._auto_close = os.environ.get('PYVISTA_AUTO_CLOSE', '').lower() != 'false'
 
-        self._jupyter_backend = os.environ.get('PYVISTA_JUPYTER_BACKEND', 'server')
+        self._jupyter_backend = os.environ.get('PYVISTA_JUPYTER_BACKEND', 'trame')
         self._trame = _TrameConfig()
 
         self._multi_rendering_splitting_position = None

--- a/pyvista/trame/jupyter.py
+++ b/pyvista/trame/jupyter.py
@@ -57,8 +57,10 @@ class TrameJupyterServerDownError(RuntimeError):
         super().__init__(JUPYTER_SERVER_DOWN_MESSAGE)
 
 
-def launch_server(server):
+def launch_server(server=None):
     """Launch a trame server."""
+    if server is None:
+        server = pyvista.global_theme.trame.jupyter_server_name
     if isinstance(server, str):
         server = get_server(server)
 
@@ -205,7 +207,11 @@ def elegantly_launch(server):
         import nest_asyncio
     except ImportError:
         raise ImportError(
-            'Please install `nest_asyncio` to automagically launch the trame server without await.'
+            """Please install `nest_asyncio` to automagically launch the trame server without await. Or, to avoid `nest_asynctio` run:
+
+    from pyvista.trame.jupyter import launch_server
+    await launch_server()
+"""
         )
 
     async def launch_it():

--- a/pyvista/trame/jupyter.py
+++ b/pyvista/trame/jupyter.py
@@ -162,7 +162,9 @@ def show_trame(
     else:
         server = get_server(name=name)
     if name is None and not server.running:
-        raise TrameJupyterServerDownError()
+        elegantly_launch(server)
+        if not server.running:
+            raise TrameJupyterServerDownError()
     elif not server.running:
         raise TrameServerDownError(name)
 
@@ -185,7 +187,7 @@ def show_trame(
     )
 
 
-def elegantly_launch():
+def elegantly_launch(server):
     """Elegantly launch the Trame server without await.
 
     This provides a mechanism to launch the Trame Jupyter backend in
@@ -207,7 +209,7 @@ def elegantly_launch():
         )
 
     async def launch_it():
-        await launch_server(pyvista.global_theme.trame.jupyter_server_name)
+        await launch_server(server)
 
     # Basically monkey patches asyncio to support this
     nest_asyncio.apply()

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,11 +12,11 @@ ipyvtklink<0.4.0
 ipywidgets<9.0.0
 matplotlib<3.7.0
 meshio<5.4.0
+nest_asyncio<1.5.7
 numpydoc==1.5.0
 panel<0.15.0
 param<1.13.0
 pytest<7.3.0
-pytest-asyncio<0.21.0
 pytest-cov<4.1.0
 pytest-memprof<0.3.0
 pytest-xdist<3.2.0

--- a/tests/jupyter/test_trame.py
+++ b/tests/jupyter/test_trame.py
@@ -37,18 +37,16 @@ def test_set_jupyter_backend_trame():
 
 @skip_no_trame
 @skip_no_plotting
-@pytest.mark.asyncio
-async def test_trame_server_launch():
-    await pv.set_jupyter_backend('trame')
+def test_trame_server_launch():
+    pv.set_jupyter_backend('trame')
     server = get_server(name=pv.global_theme.trame.jupyter_server_name)
     assert server.running
 
 
 @skip_no_trame
 @skip_no_plotting
-@pytest.mark.asyncio
-async def test_trame():
-    await pv.set_jupyter_backend('trame')
+def test_trame():
+    pv.set_jupyter_backend('trame')
     server = get_server(name=pv.global_theme.trame.jupyter_server_name)
     assert server.running
 
@@ -106,9 +104,8 @@ async def test_trame():
 
 @skip_no_trame
 @skip_no_plotting
-@pytest.mark.asyncio
-async def test_trame_jupyter_modes():
-    await pv.set_jupyter_backend('trame')
+def test_trame_jupyter_modes():
+    pv.set_jupyter_backend('trame')
 
     pl = pv.Plotter(notebook=True)
     pl.add_mesh(pv.Cone())


### PR DESCRIPTION
This is based on #3385 and must merge into `feat/trame`.

The new trame-based Jupyter backend was requiring end-users to `await` the `set_jupyter_backend()` call. @akaszynski and I feel strongly that this introduces too much user overhead and inconvenience by preventing the use of an environment variable to automatically set the Jupyter backend to use trame.

These changes leverage [nest_asyncio](https://github.com/erdewit/nest_asyncio) which patches the standard lib `asyncio` package. This may have unintended consequences for some uses cases,so I've tried to make it opt-in for when `show_trame` is called or the backend is explicitly set the use Trame. I advise strongly to make sure PyVista's Jupyter backend is not set to use Trame when not in a Jupyter environment.

To be transparent, monkey patching (which is what I think `nest_asyncio` is doing) scares the 💩  out of me, and we should really avoid this... This PR makes it so this only happens when explicitly trying to use the Jupyter backend and is easily opt-out-able by using the old await-able API:

```py
import pyvista as pv
from pyvista.trame.jupyter import launch_server

await launch_server()
```