### PR TITLE
Deprecate non-Trame Jupyter backends

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -48,11 +48,6 @@ warnings.filterwarnings(
     category=UserWarning,
     message="Matplotlib is currently using agg, which is a non-GUI backend, so cannot show the figure.",
 )
-warnings.filterwarnings(
-    "ignore",
-    category=Warning,
-    message=r".*backend is deprecated and is planned for future removal.",
-)
 
 # -- General configuration ------------------------------------------------
 numfig = False

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -48,6 +48,11 @@ warnings.filterwarnings(
     category=UserWarning,
     message="Matplotlib is currently using agg, which is a non-GUI backend, so cannot show the figure.",
 )
+warnings.filterwarnings(
+    "ignore",
+    category=Warning,
+    message=r".*backend is deprecated and is planned for future removal.",
+)
 
 # -- General configuration ------------------------------------------------
 numfig = False

--- a/doc/user-guide/jupyter/ipygany.rst
+++ b/doc/user-guide/jupyter/ipygany.rst
@@ -2,10 +2,10 @@
 
 Using ``ipygany`` with PyVista
 ------------------------------
-.. warning::
-   Currently, this backend has inferior support and features than the
-   ``pythreejs``.  If you would like accurate recreations of VTK
-   scenes in three.js, please see :ref:`pythreejs_ref`.
+.. deprecated:: 0.38.0
+   This backend has been deprecated in favor of :ref:`trame_jupyter` - a new
+   framework for building dynamic web applications with Python with great
+   support for VTK.
 
 The `ipygany <https://github.com/QuantStack/ipygany>`_ jupyterlab
 plotting backend is a powerful module that enables pure plotting that

--- a/doc/user-guide/jupyter/ipyvtk_plotting.rst
+++ b/doc/user-guide/jupyter/ipyvtk_plotting.rst
@@ -3,10 +3,10 @@
 Using ``ipyvtklink`` with PyVista
 ---------------------------------
 
-.. warning::
-
-    The ``ipyvtklink`` backend is deprecated in favor of the new
-    ``server`` backend powered by ``trame``. See :ref:`trame_jupyter`.
+.. deprecated:: 0.38.0
+   This backend has been deprecated in favor of :ref:`trame_jupyter` - a new
+   framework for building dynamic web applications with Python with great
+   support for VTK.
 
 ``pyvista`` has the ability to display fully featured plots within a
 JupyterLab environment using ``ipyvtklink``.  This feature works by

--- a/doc/user-guide/jupyter/panel.rst
+++ b/doc/user-guide/jupyter/panel.rst
@@ -2,6 +2,13 @@
 
 Using ``Panel`` with PyVista
 ----------------------------
+
+.. deprecated:: 0.38.0
+   This backend has been deprecated in favor of :ref:`trame_jupyter` - a new
+   framework for building dynamic web applications with Python with great
+   support for VTK.
+
+
 PyVista supports the usage of the `panel
 <https://github.com/holoviz/panel>`_ module as a ``vtk.js`` jupyterlab
 plotting backend that can be utialized as either a standalone VTK

--- a/doc/user-guide/jupyter/pythreejs.rst
+++ b/doc/user-guide/jupyter/pythreejs.rst
@@ -2,6 +2,12 @@
 
 Using ``pythreejs`` with PyVista
 --------------------------------
+
+.. deprecated:: 0.38.0
+   This backend has been deprecated in favor of :ref:`trame_jupyter` - a new
+   framework for building dynamic web applications with Python with great
+   support for VTK.
+
 The `pythreejs <https://github.com/jupyter-widgets/pythreejs>`_
 jupyterlab plotting backend is a powerful library that enables
 web-based visualization leveraging `threejs <https://threejs.org/>`_.

--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -92,11 +92,12 @@ def _validate_jupyter_backend(backend):
         # raises an import error when fail
         from pyvista.jupyter import pv_ipygany
 
-        warnings.warn(
-            '`ipygany` backend is deprecated and is planned for future removal.',
-            PyVistaDeprecationWarning,
-            stacklevel=3,
-        )
+        if not pyvista.BUILDING_GALLERY:
+            warnings.warn(
+                '`ipygany` backend is deprecated and is planned for future removal.',
+                PyVistaDeprecationWarning,
+                stacklevel=3,
+            )
 
     if backend in ['server', 'client', 'trame']:
         try:

--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -56,6 +56,11 @@ def _validate_jupyter_backend(backend):
             import pythreejs
         except ImportError:  # pragma: no cover
             raise ImportError('Please install `pythreejs` to use this feature.')
+        warnings.warn(
+            '`pythreejs` backend is deprecated and is planned for future removal.',
+            PyVistaDeprecationWarning,
+            stacklevel=3,
+        )
 
     if backend == 'ipyvtklink':
         warnings.warn(
@@ -74,10 +79,21 @@ def _validate_jupyter_backend(backend):
         except ImportError:  # pragma: no cover
             raise ImportError('Please install `panel` to use this feature.')
         panel.extension('vtk')
+        warnings.warn(
+            '`panel` backend is deprecated and is planned for future removal.',
+            PyVistaDeprecationWarning,
+            stacklevel=3,
+        )
 
     if backend == 'ipygany':
         # raises an import error when fail
         from pyvista.jupyter import pv_ipygany
+
+        warnings.warn(
+            '`ipygany` backend is deprecated and is planned for future removal.',
+            PyVistaDeprecationWarning,
+            stacklevel=3,
+        )
 
     if backend in ['server', 'client', 'trame']:
         try:

--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -56,18 +56,20 @@ def _validate_jupyter_backend(backend):
             import pythreejs
         except ImportError:  # pragma: no cover
             raise ImportError('Please install `pythreejs` to use this feature.')
-        warnings.warn(
-            '`pythreejs` backend is deprecated and is planned for future removal.',
-            PyVistaDeprecationWarning,
-            stacklevel=3,
-        )
+        if not pyvista.BUILDING_GALLERY:
+            warnings.warn(
+                '`pythreejs` backend is deprecated and is planned for future removal.',
+                PyVistaDeprecationWarning,
+                stacklevel=3,
+            )
 
     if backend == 'ipyvtklink':
-        warnings.warn(
-            '`ipyvtklink` backend is deprecated and has been replaced by the `trame` backend.',
-            PyVistaDeprecationWarning,
-            stacklevel=3,
-        )
+        if not pyvista.BUILDING_GALLERY:
+            warnings.warn(
+                '`ipyvtklink` backend is deprecated and has been replaced by the `trame` backend.',
+                PyVistaDeprecationWarning,
+                stacklevel=3,
+            )
         try:
             import ipyvtklink
         except ImportError:  # pragma: no cover
@@ -79,11 +81,12 @@ def _validate_jupyter_backend(backend):
         except ImportError:  # pragma: no cover
             raise ImportError('Please install `panel` to use this feature.')
         panel.extension('vtk')
-        warnings.warn(
-            '`panel` backend is deprecated and is planned for future removal.',
-            PyVistaDeprecationWarning,
-            stacklevel=3,
-        )
+        if not pyvista.BUILDING_GALLERY:
+            warnings.warn(
+                '`panel` backend is deprecated and is planned for future removal.',
+                PyVistaDeprecationWarning,
+                stacklevel=3,
+            )
 
     if backend == 'ipygany':
         # raises an import error when fail

--- a/tests/jupyter/test_ipygany.py
+++ b/tests/jupyter/test_ipygany.py
@@ -3,6 +3,7 @@ import pytest
 
 import pyvista as pv
 from pyvista import examples
+from pyvista.utilities.misc import PyVistaDeprecationWarning
 
 has_ipygany = True
 try:
@@ -17,9 +18,12 @@ skip_no_ipygany = pytest.mark.skipif(not has_ipygany, reason="Requires ipygany p
 
 @skip_no_ipygany
 def test_set_jupyter_backend_ipygany():
-    pv.global_theme.jupyter_backend = 'ipygany'
-    assert pv.global_theme.jupyter_backend == 'ipygany'
-    pv.global_theme.jupyter_backend = None
+    try:
+        with pytest.warns(PyVistaDeprecationWarning):
+            pv.global_theme.jupyter_backend = 'ipygany'
+        assert pv.global_theme.jupyter_backend == 'ipygany'
+    finally:
+        pv.global_theme.jupyter_backend = None
 
 
 @skip_no_ipygany

--- a/tests/jupyter/test_ipyvtk.py
+++ b/tests/jupyter/test_ipyvtk.py
@@ -22,10 +22,12 @@ skip_no_ipyvtk = pytest.mark.skipif(not has_ipyvtklink, reason="Requires IPython
 
 @skip_no_ipyvtk
 def test_set_jupyter_backend_ipyvtklink():
-    with pytest.warns(PyVistaDeprecationWarning):
-        pv.global_theme.jupyter_backend = 'ipyvtklink'
-    assert pv.global_theme.jupyter_backend == 'ipyvtklink'
-    pv.global_theme.jupyter_backend = None
+    try:
+        with pytest.warns(PyVistaDeprecationWarning):
+            pv.global_theme.jupyter_backend = 'ipyvtklink'
+        assert pv.global_theme.jupyter_backend == 'ipyvtklink'
+    finally:
+        pv.global_theme.jupyter_backend = None
 
 
 @skip_no_ipyvtk

--- a/tests/jupyter/test_panel.py
+++ b/tests/jupyter/test_panel.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 import pyvista as pv
+from pyvista.utilities.misc import PyVistaDeprecationWarning
 
 has_panel = True
 try:
@@ -15,9 +16,12 @@ skip_no_panel = pytest.mark.skipif(not has_panel, reason='Requires panel')
 
 @skip_no_panel
 def test_set_jupyter_backend_panel():
-    pv.set_jupyter_backend('panel')
-    assert pv.global_theme.jupyter_backend == 'panel'
-    pv.set_jupyter_backend(None)
+    try:
+        with pytest.warns(PyVistaDeprecationWarning):
+            pv.set_jupyter_backend('panel')
+        assert pv.global_theme.jupyter_backend == 'panel'
+    finally:
+        pv.set_jupyter_backend(None)
 
 
 @skip_no_panel

--- a/tests/jupyter/test_pythreejs.py
+++ b/tests/jupyter/test_pythreejs.py
@@ -10,11 +10,13 @@ except:  # noqa: E722
 
 import pyvista
 from pyvista.jupyter import pv_pythreejs
+from pyvista.utilities.misc import PyVistaDeprecationWarning
 
 
-def test_set_jupyter_backend_ipygany():
+def test_set_jupyter_backend_threejs():
     try:
-        pyvista.global_theme.jupyter_backend = 'pythreejs'
+        with pytest.warns(PyVistaDeprecationWarning):
+            pyvista.global_theme.jupyter_backend = 'pythreejs'
         assert pyvista.global_theme.jupyter_backend == 'pythreejs'
     finally:
         pyvista.global_theme.jupyter_backend = None

--- a/tests/jupyter/test_trame.py
+++ b/tests/jupyter/test_trame.py
@@ -26,13 +26,15 @@ skip_no_trame = pytest.mark.skipif(not has_trame, reason="Requires trame")
 
 @skip_no_trame
 def test_set_jupyter_backend_trame():
-    pv.global_theme.jupyter_backend = 'trame'
-    assert pv.global_theme.jupyter_backend == 'trame'
-    pv.global_theme.jupyter_backend = 'client'
-    assert pv.global_theme.jupyter_backend == 'client'
-    pv.global_theme.jupyter_backend = 'server'
-    assert pv.global_theme.jupyter_backend == 'server'
-    pv.global_theme.jupyter_backend = None
+    try:
+        pv.global_theme.jupyter_backend = 'trame'
+        assert pv.global_theme.jupyter_backend == 'trame'
+        pv.global_theme.jupyter_backend = 'client'
+        assert pv.global_theme.jupyter_backend == 'client'
+        pv.global_theme.jupyter_backend = 'server'
+        assert pv.global_theme.jupyter_backend == 'server'
+    finally:
+        pv.global_theme.jupyter_backend = None
 
 
 @skip_no_trame


### PR DESCRIPTION
The final step to resolve #3690 -- deprecates all previous notebook backends in favor of the new Trame-based backend.