### PR TITLE
Disable conda CI

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -57,6 +57,7 @@ jobs:
 
   LinuxConda:
     runs-on: ubuntu-20.04
+    if: false
     env:
       CONDA_ALWAYS_YES: 1
       conda_env: pyvista-vtk


### PR DESCRIPTION
Not sure what's going wrong with mamba on the conda CI job, and we don't have the bandwidth to fix it. Temporarily disabling this job to get status checks to be more insightful while on our way to the 0.38 release this week