### PR TITLE
Use plotter window_size for trame viewer if set

### DIFF
--- a/doc/api/plotting/index.rst
+++ b/doc/api/plotting/index.rst
@@ -12,6 +12,7 @@ Plotting
    plotting
    qt_plotting
    theme
+   trame
 
 .. _matplotlib: https://matplotlib.org/
 

--- a/doc/api/plotting/trame.rst
+++ b/doc/api/plotting/trame.rst
@@ -14,13 +14,9 @@ For the full user guide, see :ref:`trame_jupyter`.
 
 .. autosummary::
    :toctree: _autosummary
-   :no-inherited-members:
 
    launch_server
    show_trame
    elegantly_launch
    get_or_create_viewer
    plotter_ui
-   PyVistaLocalView
-   PyVistaRemoteLocalView
-   PyVistaRemoteView

--- a/doc/api/plotting/trame.rst
+++ b/doc/api/plotting/trame.rst
@@ -15,8 +15,11 @@ For the full user guide, see :ref:`trame_jupyter`.
 .. autosummary::
    :toctree: _autosummary
 
-   jupyter.launch_server
-   jupyter.show_trame
-   jupyter.elegantly_launch
-   ui.get_or_create_viewer
-   ui.plotter_ui
+   launch_server
+   show_trame
+   elegantly_launch
+   get_or_create_viewer
+   plotter_ui
+   PyVistaLocalView
+   PyVistaRemoteLocalView
+   PyVistaRemoteView

--- a/doc/api/plotting/trame.rst
+++ b/doc/api/plotting/trame.rst
@@ -14,6 +14,7 @@ For the full user guide, see :ref:`trame_jupyter`.
 
 .. autosummary::
    :toctree: _autosummary
+   :no-inherited-members:
 
    launch_server
    show_trame

--- a/doc/api/plotting/trame.rst
+++ b/doc/api/plotting/trame.rst
@@ -1,0 +1,22 @@
+.. _trame_api:
+
+Trame
+-----
+The PyVista :mod:`pyvista.trame` module allows users to access the `Trame
+<https://kitware.github.io/trame/index.html>`_ widget from PyVista to create
+web-based 3D visualizations. This allows you to access the VTK pipeline using
+the PyVista API so you can pair PyVista and Trame so that PyVista plotters can
+be used in a web context with both server and client-side rendering.
+
+For the full user guide, see :ref:`trame_jupyter`.
+
+.. currentmodule:: pyvista.trame
+
+.. autosummary::
+   :toctree: _autosummary
+
+   jupyter.launch_server
+   jupyter.show_trame
+   jupyter.elegantly_launch
+   ui.get_or_create_viewer
+   ui.plotter_ui

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -210,6 +210,10 @@ numpydoc_validation_exclude = {  # set of regex
     r'\.Plot3DFunctionEnum$',
     # VTK methods
     r'\.override$',
+    # trame
+    r'\.PyVistaRemoteView(\.|$)',
+    r'\.PyVistaLocalView(\.|$)',
+    r'\.PyVistaRemoteLocalView(\.|$)',
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ colormaps = [
 io = ['meshio>=5.2']
 jupyter = [
     'ipyvtklink',
+    'ipywidgets',
     'jupyter-server-proxy',
     'nest_asyncio',
     'panel',

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -6,7 +6,7 @@ from typing import Optional
 import warnings
 import os
 
-from pyvista import trame
+# Load default theme.  Must be loaded first.
 from pyvista._version import __version__
 from pyvista.plotting import *
 from pyvista.utilities import *

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -6,7 +6,7 @@ from typing import Optional
 import warnings
 import os
 
-# Load default theme.  Must be loaded first.
+from pyvista import trame
 from pyvista._version import __version__
 from pyvista.plotting import *
 from pyvista.utilities import *

--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -83,9 +83,7 @@ def _validate_jupyter_backend(backend):
         try:
             from pyvista.trame.jupyter import show_trame
         except ImportError:  # pragma: no cover
-            raise ImportError(
-                'Please install `trame` (and maybe `jupyter-server-proxy`) to use this feature.'
-            )
+            raise ImportError('Please install `trame` and `ipywidgets` to use this feature.')
 
     if backend == 'none':
         backend = None

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -6251,7 +6251,8 @@ class Plotter(BasePlotter):
         self._window_size_unset = False
         if window_size is None:
             self.window_size = self._theme.window_size
-            self._window_size_unset = True
+            if self.window_size == pyvista.themes.DefaultTheme().window_size:
+                self._window_size_unset = True
         else:
             self.window_size = window_size
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -1591,6 +1591,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def window_size(self, window_size):
         """Set the render window size."""
         self.render_window.SetSize(window_size[0], window_size[1])
+        self._window_size_unset = False
         self.render()
 
     @contextmanager
@@ -6196,12 +6197,6 @@ class Plotter(BasePlotter):
             off_screen = True
         self.off_screen = off_screen
 
-        self._window_size_unset = False
-        if window_size is None:
-            self._window_size_unset = True
-            window_size = self._theme.window_size
-        self.__prior_window_size = window_size
-
         # initialize render window
         self.ren_win = _vtk.vtkRenderWindow()
         self.render_window.SetMultiSamples(0)
@@ -6253,7 +6248,12 @@ class Plotter(BasePlotter):
         self.set_background(self._theme.background)
 
         # Set window size
-        self.window_size = window_size
+        self._window_size_unset = False
+        if window_size is None:
+            self.window_size = self._theme.window_size
+            self._window_size_unset = True
+        else:
+            self.window_size = window_size
 
         # add timer event callback to break out of blocking interactive update call (only needed for VTK<9)
         if not self.iren.can_process_events:
@@ -6350,6 +6350,9 @@ class Plotter(BasePlotter):
 
             This can also be set globally with
             :func:`pyvista.set_jupyter_backend`.
+
+            A dictionary ``jupyter_kwargs`` can also be passed to further
+            configure how the backend displays.
 
         return_viewer : bool, default: False
             Return the jupyterlab viewer, scene, or display object when

--- a/pyvista/trame/jupyter.py
+++ b/pyvista/trame/jupyter.py
@@ -169,6 +169,7 @@ def show_trame(
     server_proxy_enabled=None,
     server_proxy_prefix=None,
     collapse_menu=False,
+    add_menu=True,
     default_server_rendering=True,
     handler=None,
     **kwargs,
@@ -199,6 +200,9 @@ def show_trame(
 
     collapse_menu : bool, default: False
         Collapse the UI menu (camera controls, etc.) on start.
+
+    add_menu : bool, default: True
+            Add a UI controls VCard to the VContainer
 
     default_server_rendering : bool, default: True
         Whether to use server-side or client-side rendering on-start when
@@ -260,6 +264,7 @@ def show_trame(
         mode=mode,
         default_server_rendering=default_server_rendering,
         collapse_menu=collapse_menu,
+        add_menu=add_menu,
     )
 
     # Show as cell result

--- a/pyvista/trame/jupyter.py
+++ b/pyvista/trame/jupyter.py
@@ -80,7 +80,27 @@ class Widget(widgets.HTML):
 
 
 def launch_server(server=None):
-    """Launch a trame server for use with Jupyter."""
+    """Launch a trame server for use with Jupyter.
+
+    Parameters
+    ----------
+    server : str, optional
+        By default this uses :attr:`pyvista.global_theme.trame.jupyter_server_name
+        <pyvista.themes._TrameConfig.jupyter_server_name>`, which by default is
+        set to ``'pyvista-jupyter'``.
+
+        If a server name is given and such server is not available yet, it will
+        be created otherwise the previously created instance will be returned.
+
+        Server will run on to ``127.0.0.1`` unless user sets the environment
+        variable ``TRAME_DEFAULT_HOST``.
+
+    Returns
+    -------
+    trame_server.core.Server
+        Trame server.
+
+    """
     if server is None:
         server = pyvista.global_theme.trame.jupyter_server_name
     if isinstance(server, str):
@@ -176,33 +196,36 @@ def show_trame(
 ):
     """Run and display the trame application in jupyter's event loop.
 
+    Parameters
+    ----------
     plotter : pyvista.BasePlotter
         The PyVista plotter to show.
 
     mode : str, optional
         The UI view mode. This can be set on the global theme. Options are:
-            * ``'trame'``: Uses a view that can switch between client and server
-              rendering modes.
-            * ``'server'``: Uses a view that is purely server rendering.
-            * ``'client'``: Uses a view that is purely client rendering (generally
-              safe without a virtual frame buffer)
+
+        * ``'trame'``: Uses a view that can switch between client and server
+          rendering modes.
+        * ``'server'``: Uses a view that is purely server rendering.
+        * ``'client'``: Uses a view that is purely client rendering (generally
+          safe without a virtual frame buffer)
 
     name : str, optional
-        The name of the trame server on which the UI is defined
+        The name of the trame server on which the UI is defined.
 
     server_proxy_enabled : bool, default: False
         Build a relative URL for use with ``jupyter-server-proxy``.
 
     server_proxy_prefix : str, optional
-        URL prefix when using ``server_proxy_enabled``. This can be set globally in
-        the theme. To ignore, pass ``False``. For use with
+        URL prefix when using ``server_proxy_enabled``. This can be set
+        globally in the theme. To ignore, pass ``False``. For use with
         ``jupyter-server-proxy``, often set to ``proxy/``.
 
     collapse_menu : bool, default: False
         Collapse the UI menu (camera controls, etc.) on start.
 
     add_menu : bool, default: True
-            Add a UI controls VCard to the VContainer
+        Add a UI controls VCard to the VContainer.
 
     default_server_rendering : bool, default: True
         Whether to use server-side or client-side rendering on-start when
@@ -212,7 +235,7 @@ def show_trame(
         Pass a callable that accptes the viewer instance, the string URL,
         and ``**kwargs`` to create custom HTML representations of the output.
 
-        .. code::
+        .. code:: python
 
             import pyvista as pv
             from IPython.display import IFrame
@@ -297,12 +320,30 @@ def elegantly_launch(server):
     This provides a mechanism to launch the Trame Jupyter backend in
     a way that does not require users to await the call.
 
-    .. warning::
-        This uses `nest_asyncio <https://github.com/erdewit/nest_asyncio>`_
-        which patches the standard lib `asyncio` package and may have
-        unintended consequences for some uses cases. We advise strongly to
-        make sure PyVista's Jupyter backend is not set to use Trame when not
-        in a Jupyter environment.
+    Parameters
+    ----------
+    server : str, optional
+        By default this uses :attr:`pyvista.global_theme.trame.jupyter_server_name
+        <pyvista.themes._TrameConfig.jupyter_server_name>`, which by default is
+        set to ``'pyvista-jupyter'``.
+
+        If a server name is given and such server is not available yet, it will
+        be created. Otherwise, the previously created instance will be returned.
+
+        Server will run on to ``127.0.0.1`` unless you set the environment
+        variable ``TRAME_DEFAULT_HOST``.
+
+    Returns
+    -------
+    trame_server.core.Server
+        Trame server.
+
+    Warnings
+    --------
+    This uses `nest_asyncio <https://github.com/erdewit/nest_asyncio>`_ which
+    patches the standard lib `asyncio` package and may have unintended
+    consequences for some uses cases. We advise strongly to make sure PyVista's
+    Jupyter backend is not set to use Trame when not in a Jupyter environment.
 
     """
     try:

--- a/pyvista/trame/ui.py
+++ b/pyvista/trame/ui.py
@@ -477,7 +477,9 @@ def get_or_create_viewer(plotter, suppress_rendering=False):
     return Viewer(plotter, suppress_rendering=suppress_rendering)
 
 
-def plotter_ui(plotter, mode=None, default_server_rendering=True, collapse_menu=False, **kwargs):
+def plotter_ui(
+    plotter, mode=None, default_server_rendering=True, collapse_menu=False, add_menu=True, **kwargs
+):
     """Create a UI view for the given Plotter.
 
     Parameters
@@ -501,6 +503,9 @@ def plotter_ui(plotter, mode=None, default_server_rendering=True, collapse_menu=
     collapse_menu : bool, default: False
         Collapse the UI menu (camera controls, etc.) on start.
 
+    add_menu : bool, default: True
+        Add a UI controls VCard to the VContainer
+
     **kwargs : dict, optional
         Additional keyword arguments are passed to the viewer being created.
 
@@ -515,5 +520,6 @@ def plotter_ui(plotter, mode=None, default_server_rendering=True, collapse_menu=
         mode=mode,
         default_server_rendering=default_server_rendering,
         collapse_menu=collapse_menu,
+        add_menu=add_menu,
         **kwargs,
     )

--- a/pyvista/trame/ui.py
+++ b/pyvista/trame/ui.py
@@ -309,6 +309,12 @@ class Viewer:
             classes='pa-0 fill-height',
         ) as container:
             server = container.server
+            # Initialize state variables
+            server.state[self.EDGES] = False
+            server.state[self.GRID] = False
+            server.state[self.OUTLINE] = False
+            server.state[self.AXIS] = False
+            server.state[self.SERVER_RENDERING] = default_server_rendering
             if add_menu:
                 server.state[self.SHOW_UI] = not collapse_menu
                 with vuetify.VCard(

--- a/pyvista/trame/ui.py
+++ b/pyvista/trame/ui.py
@@ -76,22 +76,50 @@ class Viewer:
         return self._html_views
 
     def update(self, **kwargs):
-        """Update all associated views."""
+        """Update all associated views.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
         for view in self._html_views:
             view.update()
 
     def push_camera(self, **kwargs):
-        """Push camera to all associated views."""
+        """Push camera to all associated views.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
         for view in self._html_views:
             view.push_camera()
 
     def reset_camera(self, **kwargs):
-        """Reset camera for all associated views."""
+        """Reset camera for all associated views.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
         for view in self._html_views:
             view.reset_camera()
 
     def update_image(self, **kwargs):
-        """Update image for all associated views."""
+        """Update image for all associated views.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
         for view in self._html_views:
             if hasattr(view, 'update_image'):
                 view.update_image()
@@ -121,7 +149,14 @@ class Viewer:
         self.update()
 
     def on_edge_visiblity_change(self, **kwargs):
-        """Toggle edge visibility for all actors."""
+        """Toggle edge visibility for all actors.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
         value = kwargs[self.EDGES]
         for _, actor in self.plotter.actors.items():
             if isinstance(actor, pyvista.Actor):
@@ -129,7 +164,14 @@ class Viewer:
         self.update()
 
     def on_grid_visiblity_change(self, **kwargs):
-        """Handle axes grid visibility."""
+        """Handle axes grid visibility.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
         if kwargs[self.GRID]:
             self.plotter.show_grid()
         else:
@@ -137,7 +179,14 @@ class Viewer:
         self.update()
 
     def on_outline_visiblity_change(self, **kwargs):
-        """Handle outline visibility."""
+        """Handle outline visibility.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
         if kwargs[self.OUTLINE]:
             self.plotter.add_bounding_box(reset_camera=False)
         else:
@@ -145,7 +194,14 @@ class Viewer:
         self.update()
 
     def on_axis_visiblity_change(self, **kwargs):
-        """Handle outline visibility."""
+        """Handle outline visibility.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
         if kwargs[self.AXIS]:
             self.plotter.show_axes()
         else:
@@ -153,7 +209,14 @@ class Viewer:
         self.update()
 
     def on_rendering_mode_change(self, **kwargs):
-        """Handle any configurations when the render mode changes between client and server."""
+        """Handle any configurations when the render mode changes between client and server.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
         if not kwargs[self.SERVER_RENDERING]:
             self.push_camera()
             self.update()
@@ -164,7 +227,14 @@ class Viewer:
         return {k: v for k, v in self.plotter.actors.items() if isinstance(v, pyvista.Actor)}
 
     def screenshot(self):
-        """Take screenshot and add attachament."""
+        """Take screenshot and add attachament.
+
+        Returns
+        -------
+        memoryview
+            Screenshot as a ``memoryview``.
+
+        """
         self.plotter.render()
         self.update()  # makes sure the plotter and views are in sync
         buffer = io.BytesIO()
@@ -173,7 +243,27 @@ class Viewer:
         return memoryview(buffer.read())
 
     def ui_controls(self, mode=None, default_server_rendering=True, v_show=None):
-        """Create a VRow for the UI controls."""
+        """Create a VRow for the UI controls.
+
+        Parameters
+        ----------
+        mode : str, default: 'trame'
+            The UI view mode. Options are:
+
+            * ``'trame'``: Uses a view that can switch between client and server
+              rendering modes.
+            * ``'server'``: Uses a view that is purely server rendering.
+            * ``'client'``: Uses a view that is purely client rendering (generally
+              safe without a virtual frame buffer)
+
+        default_server_rendering : bool, default: True
+            Whether to use server-side or client-side rendering on-start when
+            using the ``'trame'`` mode.
+
+        v_show : bool, optional
+            Conditionally show the viewer controls.
+
+        """
         if mode is None:
             mode = self.plotter._theme.trame.default_mode
         if mode not in VALID_UI_MODES:
@@ -277,11 +367,12 @@ class Viewer:
         ----------
         mode : str, default: 'trame'
             The UI view mode. Options are:
-                * ``'trame'``: Uses a view that can switch between client and server
-                rendering modes.
-                * ``'server'``: Uses a view that is purely server rendering.
-                * ``'client'``: Uses a view that is purely client rendering (generally
-                safe without a virtual frame buffer)
+
+            * ``'trame'``: Uses a view that can switch between client and server
+              rendering modes.
+            * ``'server'``: Uses a view that is purely server rendering.
+            * ``'client'``: Uses a view that is purely client rendering (generally
+              safe without a virtual frame buffer)
 
         default_server_rendering : bool, default: True
             Whether to use server-side or client-side rendering on-start when
@@ -293,8 +384,13 @@ class Viewer:
         add_menu : bool, default: True
             Add a UI controls VCard to the VContainer
 
-        **kwargs
-            Addition keyword arguments are passed to the view being created.
+        **kwargs : dict, optional
+            Additional keyword arguments are passed to the view being created.
+
+        Returns
+        -------
+        PyVistaRemoteLocalView, PyVistaRemoteView, or PyVistaLocalView
+            Trame view interface for pyvista.
 
         """
         if mode is None:
@@ -357,6 +453,20 @@ def get_or_create_viewer(plotter, suppress_rendering=False):
 
     There should be only one Viewer instance per plotter. A Viewer
     can have multiple UI views though.
+
+    Parameters
+    ----------
+    plotter : pyvista.Plotter
+        Plotter to return or create the viewer instance for.
+
+    suppress_rendering : bool, default: False
+        Suppress rendering on the plotter.
+
+    Returns
+    -------
+    pyvista.trame.ui.Viewer
+        Trame viewer.
+
     """
     if plotter._id_name in _VIEWERS:
         viewer = _VIEWERS[plotter._id_name]
@@ -368,7 +478,38 @@ def get_or_create_viewer(plotter, suppress_rendering=False):
 
 
 def plotter_ui(plotter, mode=None, default_server_rendering=True, collapse_menu=False, **kwargs):
-    """Create a UI view for the given Plotter."""
+    """Create a UI view for the given Plotter.
+
+    Parameters
+    ----------
+    plotter : pyvista.Plotter
+        Plotter to create the UI for.
+
+    mode : str, default: 'trame'
+        The UI view mode. Options are:
+
+        * ``'trame'``: Uses a view that can switch between client and server
+          rendering modes.
+        * ``'server'``: Uses a view that is purely server rendering.
+        * ``'client'``: Uses a view that is purely client rendering (generally
+          safe without a virtual frame buffer)
+
+    default_server_rendering : bool, default: True
+        Whether to use server-side or client-side rendering on-start when
+        using the ``'trame'`` mode.
+
+    collapse_menu : bool, default: False
+        Collapse the UI menu (camera controls, etc.) on start.
+
+    **kwargs : dict, optional
+        Additional keyword arguments are passed to the viewer being created.
+
+    Returns
+    -------
+    PyVistaRemoteLocalView, PyVistaRemoteView, or PyVistaLocalView
+        Trame view interface for pyvista.
+
+    """
     viewer = get_or_create_viewer(plotter, suppress_rendering=mode == 'client')
     return viewer.ui(
         mode=mode,

--- a/pyvista/trame/ui.py
+++ b/pyvista/trame/ui.py
@@ -382,7 +382,7 @@ class Viewer:
             Collapse the UI menu (camera controls, etc.) on start.
 
         add_menu : bool, default: True
-            Add a UI controls VCard to the VContainer
+            Add a UI controls VCard to the VContainer.
 
         **kwargs : dict, optional
             Additional keyword arguments are passed to the view being created.
@@ -504,7 +504,7 @@ def plotter_ui(
         Collapse the UI menu (camera controls, etc.) on start.
 
     add_menu : bool, default: True
-        Add a UI controls VCard to the VContainer
+        Add a UI controls VCard to the VContainer.
 
     **kwargs : dict, optional
         Additional keyword arguments are passed to the viewer being created.

--- a/pyvista/trame/views.py
+++ b/pyvista/trame/views.py
@@ -19,16 +19,10 @@ class _BasePyVistaView:
 
 
 class PyVistaRemoteView(VtkRemoteView, _BasePyVistaView):
-    """PyVista wrapping of trame VtkRemoteView for server rendering.
+    """PyVista wrapping of trame ``VtkRemoteView`` for server rendering.
 
     This will connect to a PyVista plotter and stream the server-side
     renderings.
-
-    Notes
-    -----
-    * For optimal rendering results, you may want to have the same
-    value for ``interactive_ratio`` and ``still_ratio`` so that
-    the entire rendering is not re-scaled between interaction events.
 
     Parameters
     ----------
@@ -50,6 +44,16 @@ class PyVistaRemoteView(VtkRemoteView, _BasePyVistaView):
     namespace : str, optional
         The namespace for this view component. A default value is
         chosen based on the ``_id_name`` of the plotter.
+
+    **kwargs : dict, optional
+        Any additional keyword arguments to pass to
+        ``trame.widgets.vtk.VtkRemoteView``.
+
+    Notes
+    -----
+    For optimal rendering results, you may want to have the same
+    value for ``interactive_ratio`` and ``still_ratio`` so that
+    the entire rendering is not re-scaled between interaction events.
 
     """
 
@@ -96,6 +100,11 @@ class PyVistaLocalView(VtkLocalView, _BasePyVistaView):
     namespace : str, optional
         The namespace for this view component. A default value is
         chosen based on the ``_id_name`` of the plotter.
+
+    **kwargs : dict, optional
+        Any additional keyword arguments to pass to
+        ``trame.widgets.vtk.VtkLocalView``.
+
     """
 
     def __init__(self, plotter, namespace=None, **kwargs):
@@ -120,7 +129,7 @@ class PyVistaLocalView(VtkLocalView, _BasePyVistaView):
 
 
 class PyVistaRemoteLocalView(VtkRemoteLocalView, _BasePyVistaView):
-    """PyVista wrapping of trame VtkRemoteLocalView.
+    """PyVista wrapping of trame ``VtkRemoteLocalView``.
 
     Dynamically switch between client and server rendering.
 
@@ -145,6 +154,10 @@ class PyVistaRemoteLocalView(VtkRemoteLocalView, _BasePyVistaView):
     namespace : str, optional
         The namespace for this view component. A default value is
         chosen based on the ``_id_name`` of the plotter.
+
+    **kwargs : dict, optional
+        Any additional keyword arguments to pass to
+        ``trame.widgets.vtk.VtkRemoteLocalView``.
 
     """
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -30,5 +30,9 @@ sphinx-notfound-page==0.8.3
 sphinx-toolbox==3.4.0
 sphinxcontrib-asciinema==0.3.5
 sphinxcontrib-websupport==1.2.4
+trame==2.2.6
+trame-client==2.5.1
+trame-server==2.8.1
+trame-vtk==2.0.16
 trimesh==3.18.1
 typed-ast==1.5.4

--- a/tests/jupyter/test_trame.py
+++ b/tests/jupyter/test_trame.py
@@ -55,6 +55,7 @@ def test_trame():
     actor = pl.add_mesh(pv.Cone())
     widget = pl.show(return_viewer=True)
     assert isinstance(widget, Widget)
+    assert 'http://' in widget.src
 
     viewer = get_or_create_viewer(pl)
 

--- a/tests/jupyter/test_trame.py
+++ b/tests/jupyter/test_trame.py
@@ -159,16 +159,29 @@ def test_trame_jupyter_custom_size():
     _ = plotter.add_mesh(pv.Cone())
     widget = plotter.show(jupyter_backend='trame', return_viewer=True)
     html = widget.value
-    assert f"width: {w}px" in html
-    assert f"height: {h}px" in html
+    assert f'width: {w}px' in html
+    assert f'height: {h}px' in html
 
     plotter = pv.Plotter(notebook=True)
     plotter.window_size = (w, h)
     _ = plotter.add_mesh(pv.Cone())
     widget = plotter.show(jupyter_backend='trame', return_viewer=True)
     html = widget.value
-    assert f"width: {w}px" in html
-    assert f"height: {h}px" in html
+    assert f'width: {w}px' in html
+    assert f'height: {h}px' in html
+
+    # Make sure that if size is default theme, it uses 99%/600px
+    previous_size = pv.global_theme.window_size
+    pv.global_theme.window_size = pv.themes.DefaultTheme().window_size
+    try:
+        plotter = pv.Plotter(notebook=True)
+        _ = plotter.add_mesh(pv.Cone())
+        widget = plotter.show(jupyter_backend='trame', return_viewer=True)
+        html = widget.value
+        assert 'width: 99%' in html
+        assert 'height: 600px' in html
+    finally:
+        pv.global_theme.window_size = previous_size
 
 
 @skip_no_trame

--- a/tests/jupyter/test_trame.py
+++ b/tests/jupyter/test_trame.py
@@ -1,3 +1,4 @@
+from IPython.display import IFrame
 import pytest
 
 import pyvista as pv
@@ -147,3 +148,39 @@ def test_trame_views():
     assert PyVistaRemoteLocalView(pl, trame_server=server)
     assert PyVistaRemoteView(pl, trame_server=server)
     assert PyVistaLocalView(pl, trame_server=server)
+
+
+@skip_no_trame
+@skip_no_plotting
+def test_trame_jupyter_custom_size():
+    w, h = 200, 150
+    plotter = pv.Plotter(notebook=True, window_size=(w, h))
+    _ = plotter.add_mesh(pv.Cone())
+    widget = plotter.show(jupyter_backend='trame', return_viewer=True)
+    html = widget.value
+    assert f"width: {w}px" in html
+    assert f"height: {h}px" in html
+
+    plotter = pv.Plotter(notebook=True)
+    plotter.window_size = (w, h)
+    _ = plotter.add_mesh(pv.Cone())
+    widget = plotter.show(jupyter_backend='trame', return_viewer=True)
+    html = widget.value
+    assert f"width: {w}px" in html
+    assert f"height: {h}px" in html
+
+
+@skip_no_trame
+@skip_no_plotting
+def test_trame_jupyter_custom_handler():
+    def handler(viewer, src, **kwargs):
+        return IFrame(src, '75%', '500px')
+
+    plotter = pv.Plotter(notebook=True)
+    _ = plotter.add_mesh(pv.Cone())
+    iframe = plotter.show(
+        jupyter_backend='trame',
+        jupyter_kwargs=dict(handler=handler),
+        return_viewer=True,
+    )
+    assert isinstance(iframe, IFrame)


### PR DESCRIPTION
Resolves #3879

@larsoner, please review

We actually had this same implementation for the `panel` backend checking if `window_size` was ever set and if not, defaulting to something nice for Jupyter.

As a bonus, I added an advanced opt-in mechanism for building your own widget/iframe/whatever by passing a callable that accepts the trame viewer URL

```py
import pyvista as pv

p = pv.Plotter()
p.window_size = 500, 350
p.add_mesh(mesh)
p.show()
```
<img width="819" alt="Screen Shot 2023-01-30 at 5 15 01 PM" src="https://user-images.githubusercontent.com/22067021/215625822-57b5e0ec-3700-4a55-8bf7-3890bf075df9.png">


