### PR TITLE
fix add_silhouette docstring

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4044,6 +4044,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
             performance is achieved.
 
         params : dict, optional
+            Optional silhouette parameters.
+
             .. deprecated:: 0.38.0
                This keyword argument is no longer used. Instead, input the
                parameters to this function directly.


### PR DESCRIPTION
Fix the docstring for ``add_silhouette``.

```
2023-01-31T01:08:57.6918128Z WARNING: [numpydoc] Validation warnings while processing docstring for 'pyvista.Plotter.add_silhouette':
2023-01-31T01:08:57.6919041Z   PR07: Parameter "params" has no description
```
