### PR TITLE
Ignore BLK100 for flake8-black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -19,3 +19,5 @@ ignore =
     Q0,
     # bare excepts (temporary)
     B001, E722
+    # we already check black
+    BLK100


### PR DESCRIPTION
Ignore BLK100 errors coming from `flake8-black`. We already check for compliance with `black`, so this is unnecessary. 

Also see https://github.com/houndci/hound/issues/1769
