### PR TITLE
Add intersection edge case test

### DIFF
--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -251,7 +251,17 @@ class PolyDataFilters(DataSetFilters):
         See :ref:`boolean_example` for more examples using this filter.
 
         """
-        return self._boolean('intersection', other_mesh, tolerance, progress_bar=progress_bar)
+        bool_inter = self._boolean('intersection', other_mesh, tolerance, progress_bar=progress_bar)
+
+        # check if a polydata is completely contained within another
+        if bool_inter.n_points == 0:
+            inter, s1, s2 = self.intersection(other_mesh)
+            if inter.n_points == 0 and s1.n_points == 0 and s2.n_points == 0:
+                raise RuntimeError(
+                    'Unable to compute boolean intersection when one PolyData is '
+                    'contained within another and no faces intersect.'
+                )
+        return bool_inter
 
     def boolean_difference(self, other_mesh, tolerance=1e-5, progress_bar=False):
         """Perform a boolean difference operation between two meshes.

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -257,9 +257,9 @@ class PolyDataFilters(DataSetFilters):
         if bool_inter.n_points == 0:
             inter, s1, s2 = self.intersection(other_mesh)
             if inter.n_points == 0 and s1.n_points == 0 and s2.n_points == 0:
-                raise RuntimeError(
+                warnings.warn(
                     'Unable to compute boolean intersection when one PolyData is '
-                    'contained within another and no faces intersect.'
+                    'contained within another and no faces intersect.',
                 )
         return bool_inter
 

--- a/tests/filters/test_poly_data.py
+++ b/tests/filters/test_poly_data.py
@@ -43,5 +43,5 @@ def test_boolean_intersect_edge_case():
     a = pv.Cube(x_length=2, y_length=2, z_length=2).triangulate()
     b = pv.Cube().triangulate()  # smaller cube (x_length=1)
 
-    with pytest.raises(RuntimeError, match='contained within another'):
+    with pytest.warns(UserWarning, match='contained within another'):
         a.boolean_intersection(b)

--- a/tests/filters/test_poly_data.py
+++ b/tests/filters/test_poly_data.py
@@ -1,5 +1,6 @@
 import pytest
 
+import pyvista as pv
 from pyvista.errors import MissingDataError
 
 
@@ -36,3 +37,11 @@ def test_contour_banded_points(sphere):
     )
     assert out['data'].min() <= rng[0]
     assert out['data'].max() >= rng[1]
+
+
+def test_boolean_intersect_edge_case():
+    a = pv.Cube(x_length=2, y_length=2, z_length=2).triangulate()
+    b = pv.Cube().triangulate()  # smaller cube (x_length=1)
+
+    with pytest.raises(RuntimeError, match='contained within another'):
+        a.boolean_intersection(b)


### PR DESCRIPTION
Resolve #3840 by providing a helpful message when using `boolean_intersection` when one mesh is completely contained within another.

The intersection filter should work in this case, it's just an edge case that needs to be fixed upstream in VTK.
