### PR TITLE
Release 0.38

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  USE_CACHE: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.cache == 'true') || (github.event_name == 'pull_request') || (github.event_name == 'push') }}
+  USE_CACHE: ${{ ( (github.event_name == 'workflow_dispatch' && github.event.inputs.cache == 'true') || (github.event_name == 'pull_request') || (github.event_name == 'push') ) && !startsWith(github.ref, 'refs/heads/release/') }}
 
 jobs:
   doc:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  USE_CACHE: ${{ ( (github.event_name == 'workflow_dispatch' && github.event.inputs.cache == 'true') || (github.event_name == 'pull_request') || (github.event_name == 'push') ) && !startsWith(github.ref, 'refs/heads/release/') }}
+  USE_CACHE: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.cache == 'true') || (github.event_name == 'pull_request') || (github.event_name == 'push') }}
 
 jobs:
   doc:
@@ -62,14 +62,14 @@ jobs:
 
       - name: Cache Sphinx-Gallery Examples
         uses: actions/cache@v3
-        if: env.USE_CACHE == 'true'
+        if: env.USE_CACHE == 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/v')
         with:
           path: doc/examples/
           key: doc-examples-${{ hashFiles('pyvista/_version.py') }}
 
       - name: Cache example data
         uses: actions/cache@v3
-        if: env.USE_CACHE == 'true'
+        if: env.USE_CACHE == 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/v')
         with:
           path: ${{ env.PYVISTA_EXAMPLE_DATA_PATH }}
           key: example-data-1-${{ hashFiles('pyvista/_version.py') }}

--- a/examples/99-advanced/sphere_eversion.py
+++ b/examples/99-advanced/sphere_eversion.py
@@ -4,30 +4,20 @@
 Turning the sphere inside out
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are several videos online talking about how a sphere can
-be turned inside out in a continuous fashion, for instance in
-`this YouTube video <https://www.youtube.com/watch?v=OI-To1eUtuU>`_.
-Thanks to |the paper| (also available
-`on arXiv <https://arxiv.org/abs/1711.10466>`_), we can plot this
-so-called eversion of a sphere (turning it inside out without
-pinching or tearing the surface, in other words by preserving its
-topology).
+There are several videos online talking about how a sphere can be turned inside
+out in a continuous fashion, for instance in `this YouTube video
+<https://www.youtube.com/watch?v=OI-To1eUtuU>`_.  Thanks to `the paper
+<https://doi.org/10.1016/j.difgeo.2019.02.004>`_ (also available `on arXiv
+<https://arxiv.org/abs/1711.10466>`_), we can plot this so-called eversion of a
+sphere (turning it inside out without pinching or tearing the surface, in other
+words by preserving its topology).
 
-The mathematics involved can seem a bit, well, involved. What
-matters is the overall process visible in the animation: first
-the sphere is corrugated and stretched out a bit to allow some
-legroom for the smooth transformation, then the lobes are twisted
-around through each other, and the process is reversed in order
-to unfold the sphere. It's not obvious that the transformation
-is truly smooth; this was proved in the paper by Bednorz and
-Bednorz!
-
-.. |the paper| raw:: html
-
-   <!-- this hack is necessary to have boldface in a hyperlink -->
-   <a href=https://doi.org/10.1016/j.difgeo.2019.02.004>an excellent
-   paper by Adam Bednorz and Witold Bednorz, Differential Geometry
-   and its Applications <b>64</b>, 59 (2019)</a>
+The mathematics involved can seem a bit, well, involved. What matters is the
+overall process visible in the animation: first the sphere is corrugated and
+stretched out a bit to allow some legroom for the smooth transformation, then
+the lobes are twisted around through each other, and the process is reversed in
+order to unfold the sphere. It's not obvious that the transformation is truly
+smooth; this was proved in the paper by Bednorz and Bednorz!
 
 """
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/99-advanced/sphere_eversion.py
+++ b/examples/99-advanced/sphere_eversion.py
@@ -6,11 +6,12 @@ Turning the sphere inside out
 
 There are several videos online talking about how a sphere can be turned inside
 out in a continuous fashion, for instance in `this YouTube video
-<https://www.youtube.com/watch?v=OI-To1eUtuU>`_.  Thanks to `the paper
-<https://doi.org/10.1016/j.difgeo.2019.02.004>`_ (also available `on arXiv
-<https://arxiv.org/abs/1711.10466>`_), we can plot this so-called eversion of a
-sphere (turning it inside out without pinching or tearing the surface, in other
-words by preserving its topology).
+<https://www.youtube.com/watch?v=OI-To1eUtuU>`_.  Thanks to `an excellent paper
+by Adam Bednorz and Witold Bednorz, Differential and its Applications 64, 59
+(2019) <https://doi.org/10.1016/j.difgeo.2019.02.004>`_ (also available `on
+arXiv <https://arxiv.org/abs/1711.10466>`_), we can plot this so-called
+eversion of a sphere (turning it inside out without pinching or tearing the
+surface, in other words by preserving its topology).
 
 The mathematics involved can seem a bit, well, involved. What matters is the
 overall process visible in the animation: first the sphere is corrugated and

--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -15,7 +15,7 @@ Denotes the first release candidate.
 
 """
 # major, minor, patch
-version_info = 0, 38, 'dev0'
+version_info = 0, 39, 'dev0'
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3562,7 +3562,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         Requires a 3D data type like :class:`numpy.ndarray`,
         :class:`pyvista.UniformGrid`, :class:`pyvista.RectilinearGrid`,
-         or :class:`pyvista.UnstructuredGrid`.
+        or :class:`pyvista.UnstructuredGrid`.
 
         Parameters
         ----------

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -239,6 +239,8 @@ class Renderer(_vtk.vtkOpenGLRenderer):
     @property
     def camera_set(self) -> bool:
         """Get or set whether this camera has been configured."""
+        if self.camera is None:
+            return False
         return self.camera.is_set
 
     @camera_set.setter

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -239,7 +239,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
     @property
     def camera_set(self) -> bool:
         """Get or set whether this camera has been configured."""
-        if self.camera is None:
+        if self.camera is None:  # pragma: no cover
             return False
         return self.camera.is_set
 
@@ -3025,9 +3025,9 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             del self.edl_pass
         if hasattr(self, '_box_object'):
             self.remove_bounding_box(render=render)
-        if self._shadow_pass is not None:
+        if hasattr(self, '_shadow_pass') and self._shadow_pass is not None:
             self.disable_shadows()
-        if self.__charts is not None:
+        if hasattr(self, '__charts') and self.__charts is not None:
             self.__charts.deep_clean()
             self.__charts = None
 

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -3027,9 +3027,12 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             self.remove_bounding_box(render=render)
         if hasattr(self, '_shadow_pass') and self._shadow_pass is not None:
             self.disable_shadows()
-        if hasattr(self, '__charts') and self.__charts is not None:
-            self.__charts.deep_clean()
-            self.__charts = None
+        try:
+            if self.__charts is not None:
+                self.__charts.deep_clean()
+                self.__charts = None
+        except AttributeError:  # pragma: no cover
+            pass
 
         self._render_passes.deep_clean()
         self.remove_floors(render=render)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -74,6 +74,15 @@ def test_reset_camera():
     plotter.reset_camera(bounds=(-1, 1, -1, 1, -1, 1))
 
 
+def test_camera_is_set():
+    plotter = pyvista.Plotter()
+    assert not plotter.camera_set
+    assert not plotter.renderer.camera_set
+
+    renderer = pyvista.Renderer(plotter)
+    assert not renderer.camera_set
+
+
 def test_layer():
     plotter = pyvista.Plotter()
     plotter.renderer.layer = 1


### PR DESCRIPTION
### Release 0.38.0

- [x] Bump main to `0.39.dev0` (this PR)
- [ ] Keep this branch (`release/0.38`) and update the version to `0.38.0`. And commit the change to this branch.
- [ ] Tag `v0.38.0` and push the tag.
- [ ] Verify [docs](https://docs.pyvista.org/) and [PyPI](https://pypi.org/project/pyvista/) have updated.
- [ ] Update the [conda-forge feedstock](https://github.com/conda-forge/pyvista-feedstock).

---

### Release Notes Preview

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Breaking Changes
* Remove progressbar from pooch fetch and downloads API by @adeak in https://github.com/pyvista/pyvista/pull/3693
* Don't raise on missing iren key events to clear by default by @adeak in https://github.com/pyvista/pyvista/pull/3648
* Fix Circle to remove singular edge by @GlennWSo in https://github.com/pyvista/pyvista/pull/3710
* Fix two other closed geometric objects. by @dcbr in https://github.com/pyvista/pyvista/pull/3723
* Deprecate and remove PlotterITK by @banesullivan in https://github.com/pyvista/pyvista/pull/3737
* Improve and correct vtkThreshold usage by @banesullivan in https://github.com/pyvista/pyvista/pull/3750
* Define type alias for length-6 tuple of numbers for mesh bounds, rename color_like type by @adeak in https://github.com/pyvista/pyvista/pull/3777
### New Features
* Expose BandedPolyDataContourFilter by @akaszynski in https://github.com/pyvista/pyvista/pull/3606
* Add use_scalar_weights argument by @tkoyama010 in https://github.com/pyvista/pyvista/pull/3189
* Add BohemianDome parameters by @tkoyama010 in https://github.com/pyvista/pyvista/pull/3677
* Add classmethod to read pvcc paraview by @beroda in https://github.com/pyvista/pyvista/pull/3662
* Wrapping vtkCell by @beroda in https://github.com/pyvista/pyvista/pull/3715
* Add color cyclers for `add_mesh(..., color=True)` by @banesullivan in https://github.com/pyvista/pyvista/pull/3739
* Adds volume wrapper by @AlejandroFernandezLuces in https://github.com/pyvista/pyvista/pull/3675
* Redraw ChartMPL on Plotter render by @dcbr in https://github.com/pyvista/pyvista/pull/3731
* Add vtkAlgorithm support to `add_mesh` for pipelining by @banesullivan in https://github.com/pyvista/pyvista/pull/3318
* Add volume clipper by @akaszynski in https://github.com/pyvista/pyvista/pull/3834
* Add a `recompute_normals` parameter to `PolyData.save` by @lverret in https://github.com/pyvista/pyvista/pull/3845
* add in rgba volume plotting by @akaszynski in https://github.com/pyvista/pyvista/pull/3830
* Improve Charts compatibility with older and upcoming VTK versions. by @dcbr in https://github.com/pyvista/pyvista/pull/2868
* Support Actor-based picking by @banesullivan in https://github.com/pyvista/pyvista/pull/3863
* Track Actor names better and improve add_actor by @banesullivan in https://github.com/pyvista/pyvista/pull/3864
* Trame support and new Jupyter backend by @banesullivan in https://github.com/pyvista/pyvista/pull/3385
* Scaled screenshots by @banesullivan in https://github.com/pyvista/pyvista/pull/3897
* Support vtkLegendScaleActor with add_legend_scale by @banesullivan in https://github.com/pyvista/pyvista/pull/3716
* Use plotter window_size for trame viewer if set by @banesullivan in https://github.com/pyvista/pyvista/pull/3909
* Support axes customization by @AlejandroFernandezLuces in https://github.com/pyvista/pyvista/pull/3656
* Add hydrogen orbitals example by @akaszynski in https://github.com/pyvista/pyvista/pull/3825
* Custom themes and more theme options by @banesullivan in https://github.com/pyvista/pyvista/pull/3870
* Fix and improve chart interaction by @dcbr in https://github.com/pyvista/pyvista/pull/3756
* UnstructuredGrid volume rendering by @akaszynski in https://github.com/pyvista/pyvista/pull/3930
### Bug fixes or behavior changes
* change default points_gaussian representation by @akaszynski in https://github.com/pyvista/pyvista/pull/3559
* Do not set scalars as active when adding by @banesullivan in https://github.com/pyvista/pyvista/pull/3535
* add version check for mpl by @akaszynski in https://github.com/pyvista/pyvista/pull/3583
* UnicodeDecodeError by @beroda in https://github.com/pyvista/pyvista/pull/3577
* Hotfix: resolve broken deprecated methods by @banesullivan in https://github.com/pyvista/pyvista/pull/3601
* Universalize `cast_to_pointset` and add `cast_to_poly_points` by @banesullivan in https://github.com/pyvista/pyvista/pull/3243
* Fix nan_opacity issues and above/below annotations by @banesullivan in https://github.com/pyvista/pyvista/pull/3556
* Fix the number error of segment in add_lines by @tkoyama010 in https://github.com/pyvista/pyvista/pull/3687
* Fix interactive updates by @dcbr in https://github.com/pyvista/pyvista/pull/3617
* handle verts in pythreejs by @akaszynski in https://github.com/pyvista/pyvista/pull/3102
* Re-reset key events in Plotter.__init__() by @adeak in https://github.com/pyvista/pyvista/pull/3622
* Fix builds by @akaszynski in https://github.com/pyvista/pyvista/pull/3740
* Resolves return_img for Plotter.show() by @beroda in https://github.com/pyvista/pyvista/pull/3761
* Fix link_views() default camera position by @banesullivan in https://github.com/pyvista/pyvista/pull/3743
* Ensure bounds properties are immutable by @banesullivan in https://github.com/pyvista/pyvista/pull/3747
* Fix PVD reader, allow no part by @beroda in https://github.com/pyvista/pyvista/pull/3760
* Fix dataobject repr by @akaszynski in https://github.com/pyvista/pyvista/pull/3786
* Improve `add_volume` and support RectilinearGrid by @akaszynski in https://github.com/pyvista/pyvista/pull/3794
* Fix doc build encoding issue by @dcbr in https://github.com/pyvista/pyvista/pull/3814
* Fix mypy bug on python 3.11 by @akaszynski in https://github.com/pyvista/pyvista/pull/3837
* Skip MathText test for VTK and Matplotlib version incompatibilities by @akaszynski in https://github.com/pyvista/pyvista/pull/3838
* Fix issues with `contour_banded()` and improve examples by @banesullivan in https://github.com/pyvista/pyvista/pull/3842
* Fix inplace filters usage of copy_from by @banesullivan in https://github.com/pyvista/pyvista/pull/3865
* Use `interaction_event` instead of `event_type` in two examples. by @dcbr in https://github.com/pyvista/pyvista/pull/3878
* Fix show vertices for algorithms by @banesullivan in https://github.com/pyvista/pyvista/pull/3890
* Fix a few issues with Plotter.show by @banesullivan in https://github.com/pyvista/pyvista/pull/3889
* fix add_silhouette docstring by @akaszynski in https://github.com/pyvista/pyvista/pull/3912
* Use 3d text actors by default by @akaszynski in https://github.com/pyvista/pyvista/pull/3910
* [HOTFIX] Verify int64 support with trame by @banesullivan in https://github.com/pyvista/pyvista/pull/3924
* Ignore BLK100 for flake8-black by @akaszynski in https://github.com/pyvista/pyvista/pull/3928
* [HOTFIX] Track is_set on Camera rather than Renderer by @banesullivan in https://github.com/pyvista/pyvista/pull/3927
* Add intersection edge case test by @akaszynski in https://github.com/pyvista/pyvista/pull/3929
### Documentation
* Update install dependencies in installation docs by @adeak in https://github.com/pyvista/pyvista/pull/3543
* Add a badge for the supported Python version. by @MaxJPRey in https://github.com/pyvista/pyvista/pull/3552
* minor contributing fix by @akaszynski in https://github.com/pyvista/pyvista/pull/3561
* Add geovista to external examples by @akaszynski in https://github.com/pyvista/pyvista/pull/3558
* Add blog post of IvanNik17 by @tkoyama010 in https://github.com/pyvista/pyvista/pull/3553
* Clarify that interpolate only maps point data to point data by @adeak in https://github.com/pyvista/pyvista/pull/3621
* Move google_analytics_id to analytics in pydata-sphinx-theme by @tkoyama010 in https://github.com/pyvista/pyvista/pull/3634
* Python 3 style using pyupgrade by @mwtoews in https://github.com/pyvista/pyvista/pull/3638
* Add support to modulate the tube filter's radius in absolute units by @jmargeta in https://github.com/pyvista/pyvista/pull/3649
* Change unresolved BasePlotter intersphinx refs to Plotter by @adeak in https://github.com/pyvista/pyvista/pull/3642
* 🎉 HAPPY NEW YEAR 2023 🎉 by @tkoyama010 in https://github.com/pyvista/pyvista/pull/3765
* Add `show_vertices` for vertex rendering by @banesullivan in https://github.com/pyvista/pyvista/pull/3745
* Fix doc builds for main branch by @beroda in https://github.com/pyvista/pyvista/pull/3792
* Fix documentation build main by @beroda in https://github.com/pyvista/pyvista/pull/3799
* Add volume mapper choice notes by @banesullivan in https://github.com/pyvista/pyvista/pull/3824
* Quick fix for docstring of add_volume_clip_plane by @akaszynski in https://github.com/pyvista/pyvista/pull/3846
* Add a Magpylib example to external gallery by @tkoyama010 in https://github.com/pyvista/pyvista/pull/3848
* HOTFIX: `render_window` docstring notes by @banesullivan in https://github.com/pyvista/pyvista/pull/3885
* Fix a small typo by @tkoyama010 in https://github.com/pyvista/pyvista/pull/3917
* Ignore inherited members and attributes and switch to the full doc build by @akaszynski in https://github.com/pyvista/pyvista/pull/3919
* Force redeploy of docs by @banesullivan in https://github.com/pyvista/pyvista/pull/3933
* Document BasePlotter by @banesullivan in https://github.com/pyvista/pyvista/pull/3934
### Maintenance
* Add requirements-txt-fixer to .pre-commit-config.yaml by @tkoyama010 in https://github.com/pyvista/pyvista/pull/3541
* fix startsWith by @akaszynski in https://github.com/pyvista/pyvista/pull/3542
* Migrate config files into pyproject.toml by @banesullivan in https://github.com/pyvista/pyvista/pull/3328
* Finalize v0.37 deprecations by @banesullivan in https://github.com/pyvista/pyvista/pull/3602
* Standardize warnings by @banesullivan in https://github.com/pyvista/pyvista/pull/3232
* Move project metadata to pyproject.toml; avoid calling setup.py by @mwtoews in https://github.com/pyvista/pyvista/pull/3619
* Rename downlad_download to download by @tkoyama010 in https://github.com/pyvista/pyvista/pull/3631
* Remove legacy numpy aliases removed in 1.24.0 by @adeak in https://github.com/pyvista/pyvista/pull/3659
* Adapt project to pytest-pyvista plugin by @AlejandroFernandezLuces in https://github.com/pyvista/pyvista/pull/3579
* Fix the docstring of composite.py by @tkoyama010 in https://github.com/pyvista/pyvista/pull/3694
* Fix the docstring of the parametric object. by @tkoyama010 in https://github.com/pyvista/pyvista/pull/3678
* Add pytest-pyvista to Report by @banesullivan in https://github.com/pyvista/pyvista/pull/3713
* Fix a test of KochanekSpline. by @tkoyama010 in https://github.com/pyvista/pyvista/pull/3657
* Fix the docstring of camera.py by @tkoyama010 in https://github.com/pyvista/pyvista/pull/3688
* Fix the docstring of demos.py by @tkoyama010 in https://github.com/pyvista/pyvista/pull/3683
* [HOTFIX] VTK 9.0.3  + NumPy<1.24 CI by @banesullivan in https://github.com/pyvista/pyvista/pull/3729
* [hotfix] Use latest VTK version for conda tests by @banesullivan in https://github.com/pyvista/pyvista/pull/3736
* Bump pytest-pyvista and fix image regression testing by @banesullivan in https://github.com/pyvista/pyvista/pull/3748
* Use --fail_extra_image_cache on CI by @banesullivan in https://github.com/pyvista/pyvista/pull/3776
* [HOTFIX] Fix docs for copy_meta_from by @banesullivan in https://github.com/pyvista/pyvista/pull/3788
* Add LaTeX symbol test by @banesullivan in https://github.com/pyvista/pyvista/pull/3781
* Allow building full docs in PR, opt-in by @MatthewFlamm in https://github.com/pyvista/pyvista/pull/3800
* pydocstyle using tomli by @beroda in https://github.com/pyvista/pyvista/pull/3803
* Test MathText for conda CI by @banesullivan in https://github.com/pyvista/pyvista/pull/3795
* Improve silhouette decimate parameter check by @banesullivan in https://github.com/pyvista/pyvista/pull/3817
* Update VTK for docs build and limit core requirements by @dcbr in https://github.com/pyvista/pyvista/pull/3822
* Fix the docstring of the charts.py by @tkoyama010 in https://github.com/pyvista/pyvista/pull/3682
* Make above/below color labels consistent by @banesullivan in https://github.com/pyvista/pyvista/pull/3891
* Disable conda CI by @banesullivan in https://github.com/pyvista/pyvista/pull/3906
* Improve add_silhouette with kwargs and remove default decimation by @banesullivan in https://github.com/pyvista/pyvista/pull/3901
* Deprecate non-Trame Jupyter backends by @banesullivan in https://github.com/pyvista/pyvista/pull/3902
* Add BaseVTKReader for custom Reader; Use for PVDReader by @MatthewFlamm in https://github.com/pyvista/pyvista/pull/3894

## New Contributors
* @MaxJPRey made their first contribution in https://github.com/pyvista/pyvista/pull/3552
* @beroda made their first contribution in https://github.com/pyvista/pyvista/pull/3577
* @mwtoews made their first contribution in https://github.com/pyvista/pyvista/pull/3619
* @GlennWSo made their first contribution in https://github.com/pyvista/pyvista/pull/3710
* @lverret made their first contribution in https://github.com/pyvista/pyvista/pull/3845

**Full Changelog**: https://github.com/pyvista/pyvista/compare/v0.37.0...v0.38.0
