### PR TITLE
[HOTFIX] Resolve trame import issues

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -179,6 +179,11 @@ jobs:
           packages: libgl1-mesa-glx xvfb python-tk
           version: 3.0
 
+      # Make sure PyVista does not break from non-core dependencies
+      - name: Software Report (Core Dependencies)
+        run: |
+          xvfb-run python -c "import pyvista; print(pyvista.Report());
+
       - name: Install Testing Requirements
         run: pip install -r requirements_test.txt
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -182,7 +182,7 @@ jobs:
       # Make sure PyVista does not break from non-core dependencies
       - name: Software Report (Core Dependencies)
         run: |
-          xvfb-run python -c "import pyvista; print(pyvista.Report());
+          xvfb-run python -c "import pyvista; print(pyvista.Report());"
 
       - name: Install Testing Requirements
         run: pip install -r requirements_test.txt

--- a/doc/api/plotting/trame.rst
+++ b/doc/api/plotting/trame.rst
@@ -2,7 +2,7 @@
 
 Trame
 -----
-The PyVista :mod:`pyvista.trame` module allows users to access the `Trame
+The PyVista ``pyvista.trame`` module allows users to access the `Trame
 <https://kitware.github.io/trame/index.html>`_ widget from PyVista to create
 web-based 3D visualizations. This allows you to access the VTK pipeline using
 the PyVista API so you can pair PyVista and Trame so that PyVista plotters can
@@ -10,13 +10,8 @@ be used in a web context with both server and client-side rendering.
 
 For the full user guide, see :ref:`trame_jupyter`.
 
-.. currentmodule:: pyvista.trame
 
-.. autosummary::
-   :toctree: _autosummary
-
-   launch_server
-   show_trame
-   elegantly_launch
-   get_or_create_viewer
-   plotter_ui
+.. warning::
+   We are having an issue with Sphinx and numpydoc documenting this module
+   because it is not in the top level namespace of the PyVista package.
+   We will fix this later

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -6,7 +6,6 @@ from typing import Optional
 import warnings
 import os
 
-from pyvista import trame
 from pyvista._version import __version__
 from pyvista.plotting import *
 from pyvista.utilities import *

--- a/pyvista/trame/jupyter.py
+++ b/pyvista/trame/jupyter.py
@@ -4,10 +4,15 @@ import logging
 import os
 import warnings
 
-from ipywidgets import widgets
 from trame.app import get_server
 from trame.ui.vuetify import VAppLayout
 from trame.widgets import html as html_widgets, vtk as vtk_widgets, vuetify as vuetify_widgets
+
+try:
+    from ipywidgets.widgets import HTML
+except ImportError:
+    HTML = None
+
 
 import pyvista
 from pyvista.trame.ui import UI_TITLE, get_or_create_viewer
@@ -58,11 +63,13 @@ class TrameJupyterServerDownError(RuntimeError):
         super().__init__(JUPYTER_SERVER_DOWN_MESSAGE)
 
 
-class Widget(widgets.HTML):
+class Widget(HTML):
     """Custom HTML iframe widget for trame viewer."""
 
     def __init__(self, viewer, src, width, height, **kwargs):
         """Initialize."""
+        if HTML is None:
+            raise ImportError('Please install `ipywidgets`.')
         value = f"<iframe src='{src}' style='width: {width}; height: {height};'></iframe>"
         super().__init__(value, **kwargs)
         self._viewer = viewer

--- a/pyvista/trame/jupyter.py
+++ b/pyvista/trame/jupyter.py
@@ -11,7 +11,7 @@ from trame.widgets import html as html_widgets, vtk as vtk_widgets, vuetify as v
 try:
     from ipywidgets.widgets import HTML
 except ImportError:
-    HTML = None
+    HTML = object
 
 
 import pyvista
@@ -68,7 +68,7 @@ class Widget(HTML):
 
     def __init__(self, viewer, src, width, height, **kwargs):
         """Initialize."""
-        if HTML is None:
+        if HTML is object:
             raise ImportError('Please install `ipywidgets`.')
         value = f"<iframe src='{src}' style='width: {width}; height: {height};'></iframe>"
         super().__init__(value, **kwargs)


### PR DESCRIPTION
Close #3942, resolves #3941, resolves #3939

Will backport to `release/0.38`

cc @RobPasMue and @germa89

The trame module is opt-in, yet it was added to the top-level imports due to a numpydoc/autosummary issue in #3909.

This is a hotfix to just leave that API undocumented and fix the import issue. We'll have to look into the documentation issue separately.

Further, I added a CI step to make sure the we verify PyVista does not break on import/plot when only installed with it's core dependencies