### PR TITLE
Fix remaining stale reference to FULL_DOC_BUILD

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -599,7 +599,7 @@ You can improve your documentation build time on Linux and Mac OS with:
    make -C doc phtml
 
 This effectively invokes ``SPHINXOPTS=-j`` and can be especially useful for
-multi-core computers when ``FULL_DOC_BUILD=TRUE``
+multi-core computers.
 
 
 


### PR DESCRIPTION
The FULL_DOC_BUILD flag was removed in https://github.com/pyvista/pyvista/pull/3919. There was a stale reference left around in the contributing guide.