### PR TITLE
Propagate UI controls to all views

### DIFF
--- a/pyvista/trame/ui.py
+++ b/pyvista/trame/ui.py
@@ -158,9 +158,10 @@ class Viewer:
 
         """
         value = kwargs[self.EDGES]
-        for _, actor in self.plotter.actors.items():
-            if isinstance(actor, pyvista.Actor):
-                actor.prop.show_edges = value
+        for renderer in self.plotter.renderers:
+            for _, actor in renderer.actors.items():
+                if isinstance(actor, pyvista.Actor):
+                    actor.prop.show_edges = value
         self.update()
 
     def on_grid_visiblity_change(self, **kwargs):
@@ -172,10 +173,12 @@ class Viewer:
             Unused keyword arguments.
 
         """
-        if kwargs[self.GRID]:
-            self.plotter.show_grid()
-        else:
-            self.plotter.remove_bounds_axes()
+        value = kwargs[self.GRID]
+        for renderer in self.plotter.renderers:
+            if value:
+                renderer.show_grid()
+            else:
+                renderer.remove_bounds_axes()
         self.update()
 
     def on_outline_visiblity_change(self, **kwargs):
@@ -187,10 +190,12 @@ class Viewer:
             Unused keyword arguments.
 
         """
-        if kwargs[self.OUTLINE]:
-            self.plotter.add_bounding_box(reset_camera=False)
-        else:
-            self.plotter.remove_bounding_box()
+        value = kwargs[self.OUTLINE]
+        for renderer in self.plotter.renderers:
+            if value:
+                renderer.add_bounding_box(reset_camera=False)
+            else:
+                renderer.remove_bounding_box()
         self.update()
 
     def on_axis_visiblity_change(self, **kwargs):
@@ -202,10 +207,12 @@ class Viewer:
             Unused keyword arguments.
 
         """
-        if kwargs[self.AXIS]:
-            self.plotter.show_axes()
-        else:
-            self.plotter.hide_axes()
+        value = kwargs[self.AXIS]
+        for renderer in self.plotter.renderers:
+            if value:
+                renderer.show_axes()
+            else:
+                renderer.hide_axes()
         self.update()
 
     def on_rendering_mode_change(self, **kwargs):


### PR DESCRIPTION
Fixes an issue raised in https://github.com/pyvista/pyvista/discussions/3982 cc @giiyms

The UI controls for the Trame view would only control the current active renderer. I think it makes sense for the controls to propagate to all renderers.


https://user-images.githubusercontent.com/22067021/217609449-084d1855-c51e-4678-a6f2-296a71663ab1.mov

