### PR TITLE
Pass texture coordinates when wrapping Trimesh object

### DIFF
--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -1003,9 +1003,8 @@ def wrap(dataset):
         faces[:, 0] = 3
         polydata = pyvista.PolyData(np.asarray(dataset.vertices), faces)
         # If the Trimesh object has uv, pass them to the PolyData
-        if hasattr(dataset, 'visual'):
-            if hasattr(dataset.visual, 'uv'):
-                polydata.active_t_coords = dataset.visual.uv
+        if hasattr(dataset.visual, 'uv'):
+            polydata.active_t_coords = np.asarray(dataset.visual.uv)
         return polydata
 
     # otherwise, flag tell the user we can't wrap this object

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -1001,7 +1001,12 @@ def wrap(dataset):
         faces = np.empty((n_face, 4), dataset.faces.dtype)
         faces[:, 1:] = dataset.faces
         faces[:, 0] = 3
-        return pyvista.PolyData(np.asarray(dataset.vertices), faces)
+        polydata = pyvista.PolyData(np.asarray(dataset.vertices), faces)
+        # If the Trimesh object has uv, pass them to the PolyData
+        if hasattr(dataset, 'visual'):
+            if hasattr(dataset.visual, 'uv'):
+                polydata.active_t_coords = dataset.visual.uv
+        return polydata
 
     # otherwise, flag tell the user we can't wrap this object
     raise NotImplementedError(f'Unable to wrap ({type(dataset)}) into a pyvista type.')

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -60,6 +60,15 @@ def test_wrap_trimesh():
     assert np.allclose(tmesh.vertices, mesh.points)
     assert np.allclose(tmesh.faces, mesh.faces[1:])
 
+    assert mesh.active_t_coords is None
+
+    uvs = [[0, 0], [0, 1], [1, 0]]
+    tmesh.visual = trimesh.visual.TextureVisuals(uv=uvs)
+    mesh_with_uv = pyvista.wrap(tmesh)
+
+    assert mesh_with_uv.active_t_coords is not None
+    assert np.allclose(mesh_with_uv.active_t_coords, uvs)
+
 
 def test_make_tri_mesh(sphere):
     with pytest.raises(ValueError):


### PR DESCRIPTION
Texture coordinates from `trimesh.Trimesh` are not passed to the `pyvista.PolyData` when using `pyvista.wrap(.)`.

This PR adds two lines of code to check if the `Trimesh` object has uv (if `Trimesh.visual.uv` exists) and pass them as `active_t_coords` of the resulting `PolyData`.