### PR TITLE
Improve trame server launching

### DIFF
--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1261,19 +1261,25 @@ class _TrameConfig(_ThemeConfig):
         '_interactive_ratio',
         '_still_ratio',
         '_jupyter_server_name',
+        '_jupyter_server_port',
         '_server_proxy_enabled',
         '_server_proxy_prefix',
         '_default_mode',
+        '_enable_vtk_warnings',
     ]
 
     def __init__(self):
         self._interactive_ratio = 1
         self._still_ratio = 1
         self._jupyter_server_name = 'pyvista-jupyter'
+        self._jupyter_server_port = 0
         self._server_proxy_enabled = 'PYVISTA_TRAME_SERVER_PROXY_PREFIX' in os.environ
         # default for ``jupyter-server-proxy``
         self._server_proxy_prefix = os.environ.get('PYVISTA_TRAME_SERVER_PROXY_PREFIX', '/proxy/')
         self._default_mode = 'trame'
+        self._enable_vtk_warnings = (
+            os.environ.get('VTK_ENABLE_SERIALIZER_WARNINGS', 'false').lower() == 'true'
+        )
 
     @property
     def interactive_ratio(self) -> Number:
@@ -1326,6 +1332,15 @@ class _TrameConfig(_ThemeConfig):
         self._jupyter_server_name = name
 
     @property
+    def jupyter_server_port(self) -> int:
+        """Return or set the port for the Trame Jupyter server."""
+        return self._jupyter_server_port
+
+    @jupyter_server_port.setter
+    def jupyter_server_port(self, port: int):
+        self._jupyter_server_port = port
+
+    @property
     def server_proxy_enabled(self) -> bool:
         """Return or set if use of relative URLs is enabled for the Jupyter interface."""
         return self._server_proxy_enabled
@@ -1359,6 +1374,15 @@ class _TrameConfig(_ThemeConfig):
     @default_mode.setter
     def default_mode(self, mode: str):
         self._default_mode = mode
+
+    @property
+    def enable_vtk_warnings(self) -> bool:
+        """Return or set if VTK web serializer warnings are enabled."""
+        return self._enable_vtk_warnings
+
+    @enable_vtk_warnings.setter
+    def enable_vtk_warnings(self, enabled: bool):
+        self._enable_vtk_warnings = bool(enabled)
 
 
 class DefaultTheme(_ThemeConfig):

--- a/pyvista/trame/jupyter.py
+++ b/pyvista/trame/jupyter.py
@@ -331,29 +331,19 @@ def show_trame(
     return Widget(viewer, src, **kwargs)
 
 
-def elegantly_launch(server):
+def elegantly_launch(*args, **kwargs):
     """Elegantly launch the Trame server without await.
 
     This provides a mechanism to launch the Trame Jupyter backend in
     a way that does not require users to await the call.
 
-    Parameters
-    ----------
-    server : str, optional
-        By default this uses :attr:`pyvista.global_theme.trame.jupyter_server_name
-        <pyvista.themes._TrameConfig.jupyter_server_name>`, which by default is
-        set to ``'pyvista-jupyter'``.
-
-        If a server name is given and such server is not available yet, it will
-        be created. Otherwise, the previously created instance will be returned.
-
-        Server will run on to ``127.0.0.1`` unless you set the environment
-        variable ``TRAME_DEFAULT_HOST``.
+    This is a thin wrapper of
+    :func:`launch_server() <pyvista.trame.jupyter.launch_server>`.
 
     Returns
     -------
     trame_server.core.Server
-        Trame server.
+        The launched trame server.
 
     Warnings
     --------
@@ -375,7 +365,7 @@ def elegantly_launch(server):
         )
 
     async def launch_it():
-        await launch_server(server).ready
+        await launch_server(*args, **kwargs).ready
 
     # Basically monkey patches asyncio to support this
     nest_asyncio.apply()


### PR DESCRIPTION
Some minor internal changes to the trame server launch API to make this easier to configure in managed deployment environments

backporting to `release/0.38`