### PR TITLE
Add .codacy.yml to exclude examples and tests

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,7 @@
+---
+exclude_paths:
+  - "examples/**/*"
+  - "examples_flask/**/*"
+  - "examples_trame/**/*"
+  - "tests/*"
+  - "tests/**/*"


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
![image](https://user-images.githubusercontent.com/7513610/218510330-4df78187-56a8-4da4-bb8b-fce29b2f17d9.png)
The CodeQuality in PyVista's Codacy is B, but this is due to judging the sources in the example and test folders. This PR adds a Codacy configuration file to ignore those folders.

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- [Codacy configuration file](https://docs.codacy.com/repositories-configure/codacy-configuration-file/)

