### PR TITLE
Fix bug of get_data_range method in Table class.

### DIFF
--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -350,7 +350,7 @@ class Table(_vtk.vtkTable, DataObject):
         if isinstance(arr, str):
             arr = get_array(self, arr, preference=preference)
         # If array has no tuples return a NaN range
-        if arr.size == 0 or not np.issubdtype(arr.dtype, np.number):
+        if arr is None or arr.size == 0 or not np.issubdtype(arr.dtype, np.number):
             return (np.nan, np.nan)
         # Use the array range
         return np.nanmin(arr), np.nanmax(arr)

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -346,11 +346,11 @@ class Table(_vtk.vtkTable, DataObject):
         """
         if arr is None:
             # use the first array in the row data
-            self.GetRowData().GetArrayName(0)
+            arr = self.GetRowData().GetArrayName(0)
         if isinstance(arr, str):
             arr = get_array(self, arr, preference=preference)
         # If array has no tuples return a NaN range
-        if arr is None or arr.size == 0 or not np.issubdtype(arr.dtype, np.number):
+        if arr.size == 0 or not np.issubdtype(arr.dtype, np.number):
             return (np.nan, np.nan)
         # Use the array range
         return np.nanmin(arr), np.nanmax(arr)

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -214,8 +214,8 @@ def test_get_data_range():
     arrays = np.random.rand(nr, nc)
     table = pyvista.Table(arrays)
     nanmin, nanmax = table.get_data_range()
-    assert nanmin == np.nanmin(arrays)
-    assert nanmax == np.nanmax(arrays)
+    assert nanmin == np.nanmin(arrays[:, 0])
+    assert nanmax == np.nanmax(arrays[:, 0])
 
 
 def test_texture():

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -210,7 +210,7 @@ def test_table_iter():
 
 
 def test_get_data_range():
-    nr, nc = 3, 3
+    nr, nc = 50, 3
     arrays = np.random.rand(nr, nc)
     table = pyvista.Table(arrays)
     nanmin, nanmax = table.get_data_range()

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -209,6 +209,15 @@ def test_table_iter():
         assert np.allclose(array, arrays[:, i])
 
 
+def test_get_data_range():
+    nr, nc = 50, 3
+    arrays = np.random.rand(nr, nc)
+    table = pyvista.Table(arrays)
+    nanmin, nanmax = table.get_data_range()
+    assert nanmin == np.nanmin(arrays)
+    assert nanmax == np.nanmax(arrays)
+
+
 def test_texture():
     texture = pyvista.Texture(examples.mapfile)
     assert texture is not None

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -210,7 +210,7 @@ def test_table_iter():
 
 
 def test_get_data_range():
-    nr, nc = 50, 3
+    nr, nc = 3, 3
     arrays = np.random.rand(nr, nc)
     table = pyvista.Table(arrays)
     nanmin, nanmax = table.get_data_range()


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Fix bug of get_data_range method in Table class.

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

##### main
```python
>>> import pyvista as pv
>>> import numpy as np
>>> nr, nc = 50, 3
>>> arrays = np.random.rand(nr, nc)
>>> table = pv.Table(arrays)
>>> table.get_data_range()
(nan, nan)
```

##### PR
```python
>>> import pyvista as pv
>>> import numpy as np
>>> nr, nc = 50, 3
>>> arrays = np.random.rand(nr, nc)
>>> table = pv.Table(arrays)
>>> table.get_data_range()
(0.00127223358750439, 0.9922766866883922)
```

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None
