### PR TITLE
Add bug branch name to bug flag

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         labels: enhancement
     - uses: actions-ecosystem/action-add-labels@v1
-      if: startsWith(github.event.pull_request.head.ref, 'fix') || startsWith(github.event.pull_request.head.ref, 'patch')
+      if: startsWith(github.event.pull_request.head.ref, 'fix') || startsWith(github.event.pull_request.head.ref, 'patch') || startsWith(github.event.pull_request.head.ref, 'bug')
       with:
         labels: bug
     - uses: actions-ecosystem/action-add-labels@v1

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -353,7 +353,7 @@ To streamline development, we have the following requirements for naming
 branches. These requirements help the core developers know what kind of
 changes any given branch is introducing before looking at the code.
 
--  ``fix/``: any bug fixes, patches, or experimental changes that are
+-  ``fix/``, ``patch/`` and ``bug/``: any bug fixes, patches, or experimental changes that are
    minor
 -  ``feat/``: any changes that introduce a new feature or significant
    addition


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
I always name the bug branch names like `bug/***` and the labeler ignores it.
I want to add it as a bug branch name.

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None

