### PR TITLE
BUG: Fix bug with check

### DIFF
--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -3,7 +3,7 @@
 from enum import Enum
 import os
 import platform
-from subprocess import PIPE, Popen
+from subprocess import PIPE, Popen, TimeoutExpired
 
 import numpy as np
 
@@ -56,7 +56,10 @@ def _system_supports_plotting():
     if platform.system() == 'Darwin':
         # check if finder available
         proc = Popen(["pgrep", "-qx", "Finder"], stdout=PIPE, stderr=PIPE, encoding="utf8")
-        proc.communicate()
+        try:
+            proc.communicate(timeout=10)
+        except TimeoutExpired:
+            return False
         if proc.returncode == 0:
             return True
 
@@ -66,9 +69,9 @@ def _system_supports_plotting():
     # Linux case
     try:
         proc = Popen(["xset", "-q"], stdout=PIPE, stderr=PIPE, encoding="utf8")
-        proc.communicate()
+        proc.communicate(timeout=10)
         return proc.returncode == 0
-    except OSError:
+    except (OSError, TimeoutExpired):
         return False
 
 


### PR DESCRIPTION
There are actually two bugs with the traceback here I found while debugging recent MNE-Python test timeouts for example setting `DISPLAY=1:1` locally (which is invalid) and then waiting as long as you want until hitting ctrl-C (otherwise it just hangs indefinitely):
```
---------------------------------------------------------------------------
KeyboardInterrupt                         Traceback (most recent call last)
Cell In[1], line 13
---> 13 fig = mne.viz.plot_alignment(
     14     info, trans, subject=subject, dig=True,
     15     meg=['helmet', 'sensors'], subjects_dir=subjects_dir,
     16     surfaces=['head-dense'])

...

File ~/python/mne-python/mne/viz/backends/_pyvista.py:124, in PyVistaFigure._build(self)
--> 124 plotter = self._plotter_class(**self.store)

File ~/anaconda3/envs/nb/lib/python3.10/site-packages/pyvista/plotting/plotting.py:6189, in Plotter.__init__(self, off_screen, notebook, shape, groups, row_weights, col_weights, border, border_color, border_width, window_size, multi_samples, line_smoothing, point_smoothing, polygon_smoothing, splitting_position, title, lighting, theme, image_scale)
   6186 log.debug('Plotter init start')
   6188 # check if a plotting backend is enabled
-> 6189 _warn_xserver()
   6191 def on_timer(iren, event_id):
   6192     """Resume execution after processing interaction events during an interactive update."""

File ~/anaconda3/envs/nb/lib/python3.10/site-packages/pyvista/plotting/plotting.py:132, in _warn_xserver()
    129     return
    131 if not hasattr(_warn_xserver, 'has_support'):
--> 132     _warn_xserver.has_support = pyvista.system_supports_plotting()
    134 if not _warn_xserver.has_support:
    135     # check if a display has been set
    136     if 'DISPLAY' in os.environ:

File ~/anaconda3/envs/nb/lib/python3.10/site-packages/pyvista/plotting/tools.py:86, in system_supports_plotting()
     84 global SUPPORTS_PLOTTING
     85 if SUPPORTS_PLOTTING is None:
---> 86     SUPPORTS_PLOTTING = _system_supports_plotting()
     88 # always use the cached response
     89 return SUPPORTS_PLOTTING

File ~/anaconda3/envs/nb/lib/python3.10/site-packages/pyvista/plotting/tools.py:69, in _system_supports_plotting()
     67 try:
     68     proc = Popen(["xset", "-q"], stdout=PIPE, stderr=PIPE, encoding="utf8")
---> 69     proc.communicate()
     70     return proc.returncode == 0
     71 except OSError:

File ~/anaconda3/envs/nb/lib/python3.10/subprocess.py:1154, in Popen.communicate(self, input, timeout)
   1151     endtime = None
   1153 try:
-> 1154     stdout, stderr = self._communicate(input, endtime, timeout)
   1155 except KeyboardInterrupt:
   1156     # https://bugs.python.org/issue25942
   1157     # See the detailed comment in .wait().
   1158     if timeout is not None:

File ~/anaconda3/envs/nb/lib/python3.10/subprocess.py:2005, in Popen._communicate(self, input, endtime, orig_timeout)
   1998     self._check_timeout(endtime, orig_timeout,
   1999                         stdout, stderr,
   2000                         skip_check_and_raise=True)
   2001     raise RuntimeError(  # Impossible :)
   2002         '_check_timeout(..., skip_check_and_raise=True) '
   2003         'failed to raise TimeoutExpired.')
-> 2005 ready = selector.select(timeout)
   2006 self._check_timeout(endtime, orig_timeout, stdout, stderr)
   2008 # XXX Rewrite these to use non-blocking I/O on the file
   2009 # objects; they are no longer using C stdio!

File ~/anaconda3/envs/nb/lib/python3.10/selectors.py:416, in _PollLikeSelector.select(self, timeout)
    414 ready = []
    415 try:
--> 416     fd_event_list = self._selector.poll(timeout)
    417 except InterruptedError:
    418     return ready

KeyboardInterrupt: 
```

1. When using the notebook backend, having an xserver should not be necessary (vtk-osmesa might be in use!), so this check should be skipped somehow I think.
2. ~~It's a bit ugly that this support check is done on library import (right?). It would be better to have this happen only when instantiating a plotter. Having the decorator return a delayed-check version of the function would be better probably.~~ Deleted since I think I misunderstood when this is called due to dedenting of `nbclient`!
3. Using unprotected `proc.communicate` is dangerous. The default is `None` so it can hang.

This PR only takes care of point (3). Points (1) and (2) will require more work. The timeout here (10s) is probably excessive but it's at least better than infinite, and I'm not sure how short is actually safe.