### PR TITLE
Make DataSet.cell a generator

### DIFF
--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -46,7 +46,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
 
     >>> import pyvista
     >>> mesh = pyvista.Sphere()
-    >>> cell = mesh.cell[0]
+    >>> cell = mesh.get_cell(0)
     >>> cell  # doctest: +SKIP
     Cell (0x7fa760075a10)
       Type:       <CellType.TRIANGLE: 5>
@@ -63,7 +63,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
 
     >>> from pyvista import examples
     >>> mesh = examples.load_hexbeam()
-    >>> cell = mesh.cell[0]
+    >>> cell = mesh.get_cell(0)
     >>> cell  # doctest: +SKIP
     Cell (0x7fdc71a3c210)
       Type:       <CellType.HEXAHEDRON: 12>
@@ -103,7 +103,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
         --------
         >>> import pyvista
         >>> mesh = pyvista.Sphere()
-        >>> mesh.cell[0].type
+        >>> mesh.get_cell(0).type
         <CellType.TRIANGLE: 5>
         """
         return CellType(self.GetCellType())
@@ -116,7 +116,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
         --------
         >>> import pyvista
         >>> mesh = pyvista.Sphere()
-        >>> mesh.cell[0].is_linear
+        >>> mesh.get_cell(0).is_linear
         True
 
         """
@@ -135,7 +135,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
         --------
         >>> from pyvista import examples
         >>> mesh = examples.load_hexbeam()
-        >>> cell = mesh.cell[0]
+        >>> cell = mesh.get_cell(0)
         >>> cell.plot()
 
         """
@@ -153,7 +153,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
         --------
         >>> from pyvista import examples
         >>> mesh = examples.load_hexbeam()
-        >>> cell = mesh.cell[0]
+        >>> cell = mesh.get_cell(0)
         >>> grid = cell.cast_to_unstructured_grid()
         >>> grid  # doctest: +SKIP
         UnstructuredGrid (0x7f9383619540)
@@ -187,7 +187,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
         --------
         >>> import pyvista
         >>> mesh = pyvista.Sphere()
-        >>> mesh.cell[0].dimension
+        >>> mesh.get_cell(0).dimension
         2
         """
         return self.GetCellDimension()
@@ -200,7 +200,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
         --------
         >>> import pyvista
         >>> mesh = pyvista.Sphere()
-        >>> mesh.cell[0].n_points
+        >>> mesh.get_cell(0).n_points
         3
         """
         return self.GetNumberOfPoints()
@@ -213,7 +213,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
         --------
         >>> from pyvista.examples.cells import Tetrahedron
         >>> mesh = Tetrahedron()
-        >>> mesh.cell[0].n_faces
+        >>> mesh.get_cell(0).n_faces
         4
         """
         return self.GetNumberOfFaces()
@@ -226,7 +226,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
         --------
         >>> import pyvista
         >>> mesh = pyvista.Sphere()
-        >>> mesh.cell[0].n_edges
+        >>> mesh.get_cell(0).n_edges
         3
         """
         return self.GetNumberOfEdges()
@@ -239,7 +239,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
         --------
         >>> import pyvista
         >>> mesh = pyvista.Sphere()
-        >>> mesh.cell[0].point_ids
+        >>> mesh.get_cell(0).point_ids
         [2, 30, 0]
         """
         point_ids = self.GetPointIds()
@@ -253,7 +253,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
         --------
         >>> import pyvista
         >>> mesh = pyvista.Sphere()
-        >>> mesh.cell[0].points
+        >>> mesh.get_cell(0).points
         array([[-5.40595092e-02,  0.00000000e+00, -4.97068971e-01],
                [-5.28781787e-02,  1.12396041e-02, -4.97068971e-01],
                [-5.55111512e-17,  0.00000000e+00, -5.00000000e-01]])
@@ -280,7 +280,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
 
         >>> import pyvista
         >>> mesh = pyvista.Sphere()
-        >>> cell = mesh.cell[0]
+        >>> cell = mesh.get_cell(0)
         >>> edge = cell.get_edge(0)
         >>> edge.point_ids
         [2, 30]
@@ -299,7 +299,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
 
         >>> from pyvista.examples.cells import Hexahedron
         >>> mesh = Hexahedron()
-        >>> cell = mesh.cell[0]
+        >>> cell = mesh.get_cell(0)
         >>> edges = cell.edges
         >>> len(edges)
         12
@@ -313,7 +313,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
 
         >>> from pyvista.examples.cells import Tetrahedron
         >>> mesh = Tetrahedron()
-        >>> cell = mesh.cell[0]
+        >>> cell = mesh.get_cell(0)
         >>> faces = cell.faces
         >>> len(faces)
         4
@@ -340,7 +340,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
 
         >>> from pyvista.examples.cells import Tetrahedron
         >>> mesh = Tetrahedron()
-        >>> cell = mesh.cell[0]
+        >>> cell = mesh.get_cell(0)
         >>> face = cell.get_face(0)
         >>> face.point_ids
         [0, 1, 3]
@@ -363,7 +363,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
         --------
         >>> import pyvista
         >>> mesh = pyvista.Sphere()
-        >>> mesh.cell[0].bounds
+        >>> mesh.get_cell(0).bounds
         (-0.05405950918793678, -5.551115123125783e-17, 0.0, 0.011239604093134403, -0.5, -0.49706897139549255)
         """
         return self.GetBounds()
@@ -414,7 +414,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
 
         >>> from pyvista.examples.cells import Tetrahedron
         >>> mesh = Tetrahedron()
-        >>> cell = mesh.cell[0]
+        >>> cell = mesh.get_cell(0)
         >>> deep_cell = cell.copy(deep=True)
         >>> deep_cell.points[:] = 0
         >>> cell != deep_cell

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2531,7 +2531,8 @@ class DataSet(DataSetFilters, DataObject):
         >>> cell.edges[0].point_ids
         [0, 1]
 
-        For a Tetrahedoren, get the point ids of the last face
+        For a Tetrahedron, get the point ids of the last face
+
         >>> mesh = examples.cells.Tetrahedron()
         >>> cell = mesh.get_cell(0)
         >>> cell.faces[-1].point_ids

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -3,7 +3,7 @@
 import collections.abc
 from copy import deepcopy
 import sys
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, Union, cast
 import warnings
 
 if sys.version_info >= (3, 8):
@@ -2510,17 +2510,33 @@ class DataSet(DataSetFilters, DataObject):
 
         >>> from pyvista import examples
         >>> mesh = examples.load_airplane()
-        >>> mesh.get_cell(0) # doctest:+SKIP
-        GenericCell (0x7f6304e0a730)
-          Type:	CellType.TRIANGLE
-          Linear:	True
-          Dimension:	2
-          N Points:	3
-          N Faces:	0
-          N Edges:	3
-          X Bounds:	8.970e+02, 9.075e+02
-          Y Bounds:	4.876e+01, 5.549e+01
-          Z Bounds:	8.075e+01, 8.366e+01
+        >>> cell = mesh.get_cell(0)
+        >>> cell
+        Cell ...
+
+        Get the point ids of the first cell
+
+        >>> cell.point_ids
+        [0, 1, 2]
+
+        Get the point coordinates of the first cell
+
+        >>> cell.points
+        array([[897., 48.8, 82.3],
+               [907., 48.8, 80.7],
+               [908., 48.8, 83.7]])
+
+        For the first cell, get the points associated with the first edge
+
+        >>> cell.edges[0].point_ids
+        [0, 1]
+
+        For a Tetrahedoren, get the point ids of the last face
+        >>> mesh = examples.cells.Tetrahedron()
+        >>> cell = mesh.get_cell(0)
+        >>> cell.faces[-1]
+        >>> [0, 2, 1]
+
         """
         # must check upper bounds, otherwise segfaults (on Linux, 9.2)
         if index + 1 > self.n_cells:
@@ -2535,85 +2551,31 @@ class DataSet(DataSetFilters, DataObject):
         return cell
 
     @property
-    def cell(self) -> List['pyvista.Cell']:
-        """Return a list of cells.
+    def cell(self) -> Iterator['pyvista.Cell']:
+        """A generator that provides an easy way to loop over all cells.
 
-        Returns
-        -------
-        list[pyvista.Cell]
-            A list of :class:`pyvista.Cell` objects.
+        To access a single cell, use :func:`pyvista.DataSet.get_cell`.
 
-        Warnings
+        Yields
+        ------
+        pyvista.Cell
+
+        See Also
         --------
-        For large meshes, the list can take some time to compute and you might
-        prefer to use the :func:`DataSet.get_cell` method within a for-loop.
+        pyvista.DataSet.get_cell
 
         Examples
         --------
-        Get the last cell of a dataset.
+        Loop over the cells
 
-        >>> from pyvista import examples
-        >>> mesh = examples.load_hexbeam()
-        >>> mesh.cell[-1] # doctest:+SKIP
-        Type: CellType.HEXAHEDRON
-        Linear: True
-        Dimension: 3
-        N Points: 8
-        N Faces: 6
-        N Edges: 12
-        X Bounds: 5.000e-01, 1.000e+00
-        Y Bounds: 5.000e-01, 1.000e+00
-        Z Bounds: 4.500e+00, 5.000e+00
+        >>> import pyvista as pv
+        >>> mesh = pv.UniformGrid(dimensions=(3, 3, 1))   # 9 points, 4 cells
+        >>> for cell in mesh.cell:  # doctest: +SKIP
+            print(cell)
 
-        Get the point ids of the last cell
-
-        >>> mesh.cell[-1].point_ids
-        [98, 62, 53, 80, 17, 13, 12, 15]
-
-        Get the points coordinates of the last cell
-
-        >>> mesh.cell[-1].points
-        array([[0.5, 0.5, 4.5],
-               [1. , 0.5, 4.5],
-               [1. , 1. , 4.5],
-               [0.5, 1. , 4.5],
-               [0.5, 0.5, 5. ],
-               [1. , 0.5, 5. ],
-               [1. , 1. , 5. ],
-               [0.5, 1. , 5. ]])
-
-        Get the point ids of the edges of the last cell.
-        Note that the `edges` attributes returns a generator of
-        `pyvista.Cell` objects.
-
-        >>> for e in mesh.cell[-1].edges:
-        ...     print(e.point_ids)
-        [98, 62]
-        [62, 53]
-        [80, 53]
-        [98, 80]
-        [17, 13]
-        [13, 12]
-        [15, 12]
-        [17, 15]
-        [98, 17]
-        [62, 13]
-        [80, 15]
-        [53, 12]
-
-        Get the point ids of the faces of the last cell.
-
-        >>> from pyvista.examples.cells import Tetrahedron
-        >>> mesh = Tetrahedron()
-        >>> cell = mesh.cell[-1]
-        >>> for face in cell.faces:
-        ...     print(face.point_ids)
-        [0, 1, 3]
-        [1, 2, 3]
-        [2, 0, 3]
-        [0, 2, 1]
         """
-        return [self.get_cell(i) for i in range(self.n_cells)]
+        for i in range(self.n_cells):
+            yield self.get_cell(i)
 
     def cell_n_points(self, ind: int) -> int:
         """Return the number of points in a cell.
@@ -2634,7 +2596,7 @@ class DataSet(DataSetFilters, DataObject):
         """
         # deprecated 0.38.0, convert to error in 0.41.0, remove 0.42.0
         warnings.warn(
-            '`cell_n_points` is deprecated. Use `cell[i].n_points` instead',
+            '`cell_n_points` is deprecated. Use `get_cell(i).n_points` instead',
             PyVistaDeprecationWarning,
         )
         return self.get_cell(ind).n_points
@@ -2659,7 +2621,8 @@ class DataSet(DataSetFilters, DataObject):
         """
         # deprecated 0.38.0, convert to error in 0.41.0, remove 0.42.0
         warnings.warn(
-            '`cell_points` is deprecated. Use `cell[i].points` instead', PyVistaDeprecationWarning
+            '`cell_points` is deprecated. Use `get_cell(i).points` instead',
+            PyVistaDeprecationWarning,
         )
         return self.get_cell(ind).points
 
@@ -2682,7 +2645,8 @@ class DataSet(DataSetFilters, DataObject):
         """
         # deprecated 0.38.0, convert to error in 0.41.0, remove 0.42.0
         warnings.warn(
-            '`cell_bounds` is deprecated. Use `cell[i].bounds` instead', PyVistaDeprecationWarning
+            '`cell_bounds` is deprecated. Use `get_cell(i).bounds` instead',
+            PyVistaDeprecationWarning,
         )
         return self.get_cell(ind).bounds
 
@@ -2705,7 +2669,7 @@ class DataSet(DataSetFilters, DataObject):
         """
         # deprecated 0.38.0, convert to error in 0.41.0, remove 0.42.0
         warnings.warn(
-            '`cell_type` is deprecated. Use `cell[i].type` instead', PyVistaDeprecationWarning
+            '`cell_type` is deprecated. Use `get_cell(i).type` instead', PyVistaDeprecationWarning
         )
         return self.get_cell(ind).type
 
@@ -2728,10 +2692,10 @@ class DataSet(DataSetFilters, DataObject):
         """
         # deprecated 0.38.0, convert to error in 0.41.0, remove 0.42.0
         warnings.warn(
-            '`cell_point_ids` is deprecated. Use `cell[i].point_ids` instead',
+            '`cell_point_ids` is deprecated. Use `get_cell(i).point_ids` instead',
             PyVistaDeprecationWarning,
         )
-        return self.cell[ind].point_ids
+        return self.get_cell(ind).point_ids
 
     def point_is_inside_cell(
         self, ind: int, point: Union[VectorArray, NumericArray]
@@ -2759,7 +2723,7 @@ class DataSet(DataSetFilters, DataObject):
         --------
         >>> from pyvista import examples
         >>> mesh = examples.load_hexbeam()
-        >>> mesh.cell[0].bounds
+        >>> mesh.get_cell(0).bounds
         (0.0, 0.5, 0.0, 0.5, 0.0, 0.5)
         >>> mesh.point_is_inside_cell(0, [0.2, 0.2, 0.2])
         True

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2571,7 +2571,7 @@ class DataSet(DataSetFilters, DataObject):
         >>> import pyvista as pv
         >>> mesh = pv.UniformGrid(dimensions=(3, 3, 1))   # 9 points, 4 cells
         >>> for cell in mesh.cell:  # doctest: +SKIP
-            print(cell)
+        ...     print(cell)
 
         """
         for i in range(self.n_cells):

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2522,9 +2522,9 @@ class DataSet(DataSetFilters, DataObject):
         Get the point coordinates of the first cell
 
         >>> cell.points
-        array([[897., 48.8, 82.3],
-               [907., 48.8, 80.7],
-               [908., 48.8, 83.7]])
+        array([[897.0,  48.8,  82.3],
+               [906.6,  48.8,  80.7],
+               [907.5,  55.5,  83.7]])
 
         For the first cell, get the points associated with the first edge
 
@@ -2534,8 +2534,8 @@ class DataSet(DataSetFilters, DataObject):
         For a Tetrahedoren, get the point ids of the last face
         >>> mesh = examples.cells.Tetrahedron()
         >>> cell = mesh.get_cell(0)
-        >>> cell.faces[-1]
-        >>> [0, 2, 1]
+        >>> cell.faces[-1].point_ids
+        [0, 2, 1]
 
         """
         # must check upper bounds, otherwise segfaults (on Linux, 9.2)

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2556,6 +2556,10 @@ class DataSet(DataSetFilters, DataObject):
 
         To access a single cell, use :func:`pyvista.DataSet.get_cell`.
 
+        .. versionchanged:: 0.39.0
+            Now returns a generator instead of a list.
+            Use ``get_cell(i)`` instead of ``cell[i]``.
+
         Yields
         ------
         pyvista.Cell

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1553,14 +1553,14 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
         .. note::
            This is only available in ``vtk>=9.0.0``.
 
-        See Also
-        --------
-        pyvista.DataSet.get_cell
-
         Returns
         -------
         numpy.ndarray
             Connectivity array.
+
+        See Also
+        --------
+        pyvista.DataSet.get_cell
 
         Examples
         --------

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1480,6 +1480,10 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
     def cells(self) -> np.ndarray:
         """Return a pointer to the cells as a numpy object.
 
+        See Also
+        --------
+        pyvista.DataSet.get_cell
+
         Examples
         --------
         Return the indices of the first two cells from the example hex
@@ -1509,6 +1513,10 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
         dict
             A dictionary mapping containing all cells of this unstructured grid.
             Structure: vtk_enum_type (int) -> cells (:class:`numpy.ndarray`).
+
+        See Also
+        --------
+        pyvista.DataSet.get_cell
 
         Examples
         --------
@@ -1544,6 +1552,10 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
 
         .. note::
            This is only available in ``vtk>=9.0.0``.
+
+        See Also
+        --------
+        pyvista.DataSet.get_cell
 
         Returns
         -------

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -3344,7 +3344,7 @@ def test_add_point_scalar_labels_fmt():
 
 
 def test_plot_individual_cell(hexbeam):
-    hexbeam.cell[0].plot(color='b')
+    hexbeam.get_cell(0).plot(color='b')
 
 
 def test_add_point_scalar_labels_list():

--- a/tests/test_cells.py
+++ b/tests/test_cells.py
@@ -1,3 +1,5 @@
+from types import GeneratorType
+
 import numpy as np
 import pytest
 import vtk
@@ -17,12 +19,12 @@ from pyvista.examples import (
 )
 
 cells = [
-    example_cells.Hexahedron().cell[0],
-    example_cells.Triangle().cell[0],
-    example_cells.Voxel().cell[0],
-    example_cells.Quadrilateral().cell[0],
-    example_cells.Tetrahedron().cell[0],
-    example_cells.Voxel().cell[0],
+    example_cells.Hexahedron().get_cell(0),
+    example_cells.Triangle().get_cell(0),
+    example_cells.Voxel().get_cell(0),
+    example_cells.Quadrilateral().get_cell(0),
+    example_cells.Tetrahedron().get_cell(0),
+    example_cells.Voxel().get_cell(0),
 ]
 grids = [
     load_hexbeam(),
@@ -72,8 +74,7 @@ def test_bad_init():
 
 @pytest.mark.parametrize("grid", grids, ids=ids)
 def test_cell_attribute(grid):
-    assert isinstance(grid.cell, list)
-    assert len(grid.cell) == grid.n_cells
+    assert isinstance(grid.cell, GeneratorType)
     assert all([issubclass(type(cell), Cell) for cell in grid.cell])
 
 
@@ -201,9 +202,9 @@ def test_cell_faces(cell):
 
 @pytest.mark.parametrize("grid", grids, ids=ids)
 def test_cell_bounds(grid):
-    assert isinstance(grid.cell[0].bounds, tuple)
-    assert all(bc >= bg for bc, bg in zip(grid.cell[0].bounds[::2], grid.bounds[::2]))
-    assert all(bc <= bg for bc, bg in zip(grid.cell[0].bounds[1::2], grid.bounds[1::2]))
+    assert isinstance(grid.get_cell(0).bounds, tuple)
+    assert all(bc >= bg for bc, bg in zip(grid.get_cell(0).bounds[::2], grid.bounds[::2]))
+    assert all(bc <= bg for bc, bg in zip(grid.get_cell(0).bounds[1::2], grid.bounds[1::2]))
 
 
 @pytest.mark.parametrize("cell,type_", zip(cells[:5], types[:5]))


### PR DESCRIPTION
### Overview

Make `DataSet.cell` a generator to prevent `mesh.cell[0]` usage.  It is recommended in the docstring to use this for `for cell in mesh.cell:` usage and `mesh.get_cell(0)` for single cell access.

### Breaking Change

`DataSet.cell` no long returns a list and now returns a generator.  Forming a list is a very time intensive operation and it is highly discouraged if only a few cells are needed to access. See #3971.  A generator still allows for the usage of `for cell in mesh.cell:`.  For single cell access, if this form was used `mesh.cell[0]`, now use `mesh.get_cell(0)`.

### Details

Closes #3971.

Tries to ameliorate name clash with `UnstructuredGrid.cells` by putting in a See Also section.  I'm still concerned about this name clash however.  It will be more natural to use `for cell in mesh.cells:`, so I expect a lot of problems here.  Should we add a `cell_array` method to match `vtkCellArray` and then deprecate `cells`?  Once the original meaning of `cells` has been removed, we can move `cell` -> `cells`.  While technically avoiding breaking change, it will probably take years to accomplish and will be confusing in its own right.