### PR TITLE
MAINT: Avoid infinite recusion

### DIFF
--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -134,7 +134,7 @@ class Observer:
                 self.event_history.append(VtkEvent(kind, path, address, alert))
             if self.__log:
                 self.log_message(kind, alert)
-        except Exception:
+        except Exception:  # pragma: no cover
             try:
                 if len(message) > 120:
                     message = f'{repr(message[:100])} ... ({len(message)} characters)'

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -141,7 +141,7 @@ class Observer:
                 else:
                     message = repr(message)
                 print(
-                    f'PyViysta error in handling VTK error message:\n{message}',
+                    f'PyVista error in handling VTK error message:\n{message}',
                     file=sys.__stdout__,
                 )
                 traceback.print_tb(sys.last_traceback, file=sys.__stderr__)


### PR DESCRIPTION
One solution to avoid possible infinite recursion in error handling, see https://github.com/pyvista/pyvista/discussions/4098#discussioncomment-5231792 . Using the code there on this PR I get:
```
$ python -ui ~/Desktop/rep.py 
PyViysta error in handling VTK error message:
'WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:r' ... (1295 characters)
PyViysta error in handling VTK error message:
'WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:r' ... (1320 characters)
PyViysta error in handling VTK error message:
'WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:r' ... (1264 characters)
PyViysta error in handling VTK error message:
'WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:r' ... (1280 characters)
PyViysta error in handling VTK error message:
'WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:r' ... (1261 characters)
PyViysta error in handling VTK error message:
'WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:r' ... (1272 characters)
PyViysta error in handling VTK error message:
'WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:r' ... (1260 characters)
PyViysta error in handling VTK error message:
'WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:root:WARNING:r' ... (1261 characters)
>>>
```
Doesn't fix the underlying problem where calling a VTK method messes up `print` and logging, but this should at least be safer. 