### PR TITLE
Stop plotter from reopening

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -6514,7 +6514,10 @@ class Plotter(BasePlotter):
                     if os.name == 'nt':  # pragma: no cover
                         self.iren.process_events()
                     self.iren.start()
-                self.iren.initialize()
+
+                if pyvista.vtk_version_info < (9, 2, 3):  # pragma: no cover
+                    self.iren.initialize()
+
             except KeyboardInterrupt:
                 log.debug('KeyboardInterrupt')
                 self.close()


### PR DESCRIPTION
Resolve #4057 by making ``self.iren.initialize()`` conditional on the VTK version.

This will need verification from mulitple OSes before merging. I've only tested it locally on Ubuntu 22.04.
