### PR TITLE
Use default matplotlib rcparams during testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ def set_mpl():
     except ImportError:
         pass
     else:
+        matplotlib.rcdefaults()
         matplotlib.use('agg', force=True)
 
 


### PR DESCRIPTION
### Overview

I use a matplotlibrc file for defaults for making better looking figures.  However, this means that I get an image regression failure when running the test suite.  This PR uses the default.





