### PR TITLE
Update trame-client in requirements_test.txt

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -27,7 +27,7 @@ sphinx-gallery<0.13.0
 sympy<1.12.0
 tqdm<4.66.0
 trame>=2.2.6,<2.4
-trame-client>=2.4.2,<2.8
+trame-client>=2.5.1,<2.8
 trame-server>=2.8.0,<2.10
 trame-vtk>=2.0.17,<2.3
 trimesh<3.21.0


### PR DESCRIPTION
``trame-client`` must be at least `2.5.1` for the test suite to run.
