### PR TITLE
Change source links to github

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,6 +18,7 @@ make_tables.make_all_tables()
 
 # -- pyvista configuration ---------------------------------------------------
 import pyvista
+from pyvista.utilities.docs import linkcode_resolve  # noqa: F401
 
 # Manage errors
 pyvista.set_error_output_file("errors.txt")
@@ -67,10 +68,10 @@ extensions = [
     "pyvista.ext.plot_directive",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
+    'sphinx.ext.linkcode',
     "sphinx.ext.doctest",
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
-    "sphinx.ext.viewcode",
     "sphinx_copybutton",
     "sphinx_design",
     "sphinx_gallery.gen_gallery",
@@ -432,6 +433,11 @@ html_context = {
     "doc_path": "doc",
 }
 html_show_sourcelink = False
+html_copy_source = False
+
+# If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
+html_show_sphinx = False
+
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -3145,7 +3145,7 @@ def download_cubemap_space_16k():  # pragma: no cover
     https://jaxry.github.io/panorama-to-cubemap/
 
     See `vtk-data/cubemap_space
-    <https://github.com/pyvista/vtk-data/tree/master/cubemap_space>`_ for
+    <https://github.com/pyvista/vtk-data/tree/master/Data/cubemap_space#readme>`_ for
     more details.
 
     Returns

--- a/pyvista/utilities/docs.py
+++ b/pyvista/utilities/docs.py
@@ -60,8 +60,6 @@ def linkcode_resolve(domain, info):
             fn = inspect.getsourcefile(sys.modules[obj.__module__])
         except Exception:
             return None
-
-    if not fn:  # pragma: no cover
         return None
 
     fn = op.relpath(fn, start=op.dirname(pyvista.__file__))

--- a/pyvista/utilities/docs.py
+++ b/pyvista/utilities/docs.py
@@ -1,0 +1,85 @@
+"""Supporting functions for documentation build."""
+import inspect
+import os
+import os.path as op
+import sys
+
+
+def linkcode_resolve(domain, info):
+    """Determine the URL corresponding to a Python object.
+
+    Parameters
+    ----------
+    domain : str
+        Only useful when 'py'.
+
+    info : dict
+        With keys "module" and "fullname".
+
+    Returns
+    -------
+    url : str
+        The code URL.
+
+    Notes
+    -----
+    This has been adapted to deal with our "verbose" decorator.
+
+    Adapted from mne (mne/utils/docs.py), which was adapted from SciPy (doc/source/conf.py).
+    """
+    import pyvista
+
+    if domain != 'py':
+        return None
+
+    modname = info['module']
+    fullname = info['fullname']
+
+    submod = sys.modules.get(modname)
+    if submod is None:
+        return None
+
+    obj = submod
+    for part in fullname.split('.'):
+        try:
+            obj = getattr(obj, part)
+        except Exception:
+            return None
+
+    # deal with our decorators properly
+    while hasattr(obj, 'fget'):
+        obj = obj.fget
+
+    try:
+        fn = inspect.getsourcefile(obj)
+    except Exception:  # pragma: no cover
+        fn = None
+
+    if not fn:  # pragma: no cover
+        try:
+            fn = inspect.getsourcefile(sys.modules[obj.__module__])
+        except Exception:
+            return None
+
+    if not fn:  # pragma: no cover
+        return None
+
+    fn = op.relpath(fn, start=op.dirname(pyvista.__file__))
+    fn = '/'.join(op.normpath(fn).split(os.sep))  # in case on Windows
+
+    try:
+        source, lineno = inspect.getsourcelines(obj)
+    except Exception:  # pragma: no cover
+        lineno = None
+
+    if lineno:
+        linespec = f"#L{lineno}-L{lineno + len(source) - 1}"
+    else:
+        linespec = ""
+
+    if 'dev' in pyvista.__version__:
+        kind = 'main'
+    else:  # pragma: no cover
+        kind = 'release/%s' % ('.'.join(pyvista.__version__.split('.')[:2]))
+
+    return f"http://github.com/pyvista/pyvista/blob/{kind}/pyvista/{fn}{linespec}"

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -25,6 +25,7 @@ from pyvista.utilities import (
     helpers,
     transformations,
 )
+from pyvista.utilities.docs import linkcode_resolve
 from pyvista.utilities.misc import PyVistaDeprecationWarning, has_duplicates, raise_has_duplicates
 
 skip_no_plotting = pytest.mark.skipif(
@@ -861,3 +862,24 @@ def test_set_pickle_format():
 
     with pytest.raises(ValueError):
         pyvista.set_pickle_format('invalid_format')
+
+
+def test_linkcode_resolve():
+    assert linkcode_resolve('not-py', {}) is None
+    link = linkcode_resolve('py', {'module': 'pyvista', 'fullname': 'pyvista.core.DataObject'})
+    assert 'dataobject.py' in link
+    assert '#L' in link
+
+    # badmodule name
+    assert linkcode_resolve('py', {'module': 'doesnotexist', 'fullname': 'foo.bar'}) is None
+
+    assert (
+        linkcode_resolve('py', {'module': 'pyvista', 'fullname': 'pyvista.not.an.object'}) is None
+    )
+
+    # test property
+    link = linkcode_resolve('py', {'module': 'pyvista', 'fullname': 'pyvista.core.DataSet.points'})
+    assert 'dataset.py' in link
+
+    link = linkcode_resolve('py', {'module': 'pyvista', 'fullname': 'pyvista.core'})
+    assert link.endswith('__init__.py')


### PR DESCRIPTION
The ``mne`` libray uses `sphinx.ext.linkcode` rather than ``sphinx.ext.viewcode`` and they link directly to github:
[mne.io.read_raw](https://mne.tools/stable/generated/mne.io.read_raw.html)

This PR implements the same logic and uses a source link to GitHub. It's much cleaner than having source within our documentation, and it has the (minor) added advantage of decreasing the build time and size of our docs.
