### PR TITLE
Apply blackdoc to python source

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,6 @@ repos:
   hooks:
   - id: black
 
-- repo: https://github.com/keewis/blackdoc
-  rev: v0.3.8
-  hooks:
-  - id: blackdoc
-    files: '\.py$'
-    exclude: pyvista/plotting/charts.py
-
 - repo: https://github.com/pycqa/isort
   rev: 5.12.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,13 @@ repos:
   hooks:
   - id: black
 
+- repo: https://github.com/keewis/blackdoc
+  rev: v0.3.8
+  hooks:
+  - id: blackdoc
+    files: '\.py$'
+    exclude: pyvista/plotting/charts.py
+
 - repo: https://github.com/pycqa/isort
   rev: 5.12.0
   hooks:

--- a/pyvista/core/celltype.py
+++ b/pyvista/core/celltype.py
@@ -23,14 +23,19 @@ class CellType(IntEnum):
     >>> import pyvista
     >>> cells = np.array([8, 0, 1, 2, 3, 4, 5, 6, 7])
     >>> cell_type = np.array([CellType.HEXAHEDRON], np.int8)
-    >>> points = np.array([[0, 0, 0],
-    ...                    [1, 0, 0],
-    ...                    [1, 1, 0],
-    ...                    [0, 1, 0],
-    ...                    [0, 0, 1],
-    ...                    [1, 0, 1],
-    ...                    [1, 1, 1],
-    ...                    [0, 1, 1]], dtype=np.float32)
+    >>> points = np.array(
+    ...     [
+    ...         [0, 0, 0],
+    ...         [1, 0, 0],
+    ...         [1, 1, 0],
+    ...         [0, 1, 0],
+    ...         [0, 0, 1],
+    ...         [1, 0, 1],
+    ...         [1, 1, 1],
+    ...         [0, 1, 1],
+    ...     ],
+    ...     dtype=np.float32,
+    ... )
     >>> grid = pyvista.UnstructuredGrid(cells, cell_type, points)
     >>> grid  # doctest:+SKIP
     UnstructuredGrid (0x7f5b0a55e1a0)

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -60,8 +60,7 @@ class MultiBlock(
 
     Instantiate from a list of objects.
 
-    >>> data = [pv.Sphere(center=(2, 0, 0)), pv.Cube(center=(0, 2, 0)),
-    ...         pv.Cone()]
+    >>> data = [pv.Sphere(center=(2, 0, 0)), pv.Cube(center=(0, 2, 0)), pv.Cone()]
     >>> blocks = pv.MultiBlock(data)
     >>> blocks.plot()
 
@@ -75,9 +74,11 @@ class MultiBlock(
 
     >>> for name in blocks.keys():
     ...     block = blocks[name]
+    ...
 
     >>> for block in blocks:
     ...     surf = block.extract_surface()  # Do something with each dataset
+    ...
 
     """
 
@@ -543,7 +544,7 @@ class MultiBlock(
         >>> blocks.replace(1, pv.Sphere(center=(10, 10, 10)))
         >>> blocks.keys()
         ['cube', 'sphere']
-        >>> np.allclose(blocks[1].center, [10., 10., 10.])
+        >>> np.allclose(blocks[1].center, [10.0, 10.0, 10.0])
         True
 
         """

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -366,8 +366,7 @@ class DataObject:
         Add field data to a UniformGrid dataset.
 
         >>> mesh = pyvista.UniformGrid(dimensions=(2, 2, 1))
-        >>> mesh.add_field_data(['I could', 'write', 'notes', 'here'],
-        ...                      'my-field-data')
+        >>> mesh.add_field_data(['I could', 'write', 'notes', 'here'], 'my-field-data')
         >>> mesh['my-field-data']
         pyvista_ndarray(['I could', 'write', 'notes', 'here'], dtype='<U7')
 

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -373,7 +373,7 @@ class DataSet(DataSetFilters, DataObject):
 
         You can also update the points in-place:
 
-        >>> cube.points[...] = 2*points
+        >>> cube.points[...] = 2 * points
         >>> cube.points
         pyvista_ndarray([[-1., -1.,  1.],
                          [-1., -1.,  3.],
@@ -2286,8 +2286,7 @@ class DataSet(DataSetFilters, DataObject):
 
         >>> unit_square = pyvista.Rectangle()
         >>> index, closest_point = unit_square.find_closest_cell(
-        ...     [0.25, 0.25, 0.5],
-        ...     return_closest_point=True
+        ...     [0.25, 0.25, 0.5], return_closest_point=True
         ... )
         >>> closest_point
         array([0.25, 0.25, 0.  ])
@@ -2297,8 +2296,7 @@ class DataSet(DataSetFilters, DataObject):
         desired, see :func:`DataSet.find_closest_point`.
 
         >>> index, closest_point = unit_square.find_closest_cell(
-        ...     [1.0, 1.0, 0.5],
-        ...     return_closest_point=True
+        ...     [1.0, 1.0, 0.5], return_closest_point=True
         ... )
         >>> closest_point
         array([1., 1., 0.])
@@ -2368,7 +2366,7 @@ class DataSet(DataSetFilters, DataObject):
         containing the point ``[0.3, 0.3, 0.0]`` is found.
 
         >>> import pyvista
-        >>> mesh = pyvista.UniformGrid(dimensions=[5, 5, 1], spacing=[1/4, 1/4, 0])
+        >>> mesh = pyvista.UniformGrid(dimensions=[5, 5, 1], spacing=[1 / 4, 1 / 4, 0])
         >>> mesh
         UniformGrid...
         >>> mesh.find_containing_cell([0.3, 0.3, 0.0])
@@ -2575,9 +2573,10 @@ class DataSet(DataSetFilters, DataObject):
         Loop over the cells
 
         >>> import pyvista as pv
-        >>> mesh = pv.UniformGrid(dimensions=(3, 3, 1))   # 9 points, 4 cells
+        >>> mesh = pv.UniformGrid(dimensions=(3, 3, 1))  # 9 points, 4 cells
         >>> for cell in mesh.cell:  # doctest: +SKIP
         ...     cell
+        ...
 
         """
         for i in range(self.n_cells):

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -913,7 +913,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         >>> import pyvista
         >>> mesh = pyvista.Cube()
         >>> mesh.clear_data()
-        >>> mesh.cell_data['data0'] = [0]*mesh.n_cells
+        >>> mesh.cell_data['data0'] = [0] * mesh.n_cells
         >>> mesh.cell_data['data1'] = range(mesh.n_cells)
         >>> mesh.cell_data.items()
         [('data0', pyvista_ndarray([0, 0, 0, 0, 0, 0])), ('data1', pyvista_ndarray([0, 1, 2, 3, 4, 5]))]
@@ -934,7 +934,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         >>> import pyvista
         >>> mesh = pyvista.Sphere()
         >>> mesh.clear_data()
-        >>> mesh.point_data['data0'] = [0]*mesh.n_points
+        >>> mesh.point_data['data0'] = [0] * mesh.n_points
         >>> mesh.point_data['data1'] = range(mesh.n_points)
         >>> mesh.point_data.keys()
         ['data0', 'data1']
@@ -966,7 +966,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         >>> import pyvista
         >>> mesh = pyvista.Cube()
         >>> mesh.clear_data()
-        >>> mesh.cell_data['data0'] = [0]*mesh.n_cells
+        >>> mesh.cell_data['data0'] = [0] * mesh.n_cells
         >>> mesh.cell_data['data1'] = range(mesh.n_cells)
         >>> mesh.cell_data.values()
         [pyvista_ndarray([0, 0, 0, 0, 0, 0]), pyvista_ndarray([0, 1, 2, 3, 4, 5])]
@@ -1096,8 +1096,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         >>> import pyvista
         >>> import numpy as np
         >>> mesh = pyvista.Sphere()
-        >>> mesh.point_data.set_vectors(np.random.random((mesh.n_points, 3)),
-        ...                             'my-vectors')
+        >>> mesh.point_data.set_vectors(np.random.random((mesh.n_points, 3)), 'my-vectors')
         >>> mesh.point_data.active_vectors_name
         'my-vectors'
 

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -52,10 +52,9 @@ class CompositeFilters:
         Combine blocks within a multiblock without merging points.
 
         >>> import pyvista
-        >>> block = pyvista.MultiBlock([
-        ...     pyvista.Cube(clean=False),
-        ...     pyvista.Cube(center=(1, 0, 0), clean=False)
-        ... ])
+        >>> block = pyvista.MultiBlock(
+        ...     [pyvista.Cube(clean=False), pyvista.Cube(center=(1, 0, 0), clean=False)]
+        ... )
         >>> merged = block.combine()
         >>> merged.n_points
         48

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -393,7 +393,9 @@ class DataSetFilters:
         >>> import pyvista as pv
         >>> from pyvista import examples
         >>> dataset = examples.load_hexbeam()
-        >>> _below, _above = dataset.clip_scalar(scalars="sample_point_scalars", value=100, both=True)
+        >>> _below, _above = dataset.clip_scalar(
+        ...     scalars="sample_point_scalars", value=100, both=True
+        ... )
 
         Remove the part of the mesh with "sample_point_scalars" below 100.
 
@@ -900,8 +902,7 @@ class DataSetFilters:
 
         >>> pl = pyvista.Plotter()
         >>> _ = pl.add_mesh(hills, smooth_shading=True, style='wireframe')
-        >>> _ = pl.add_mesh(line_slice, line_width=10, render_lines_as_tubes=True,
-        ...                 color='k')
+        >>> _ = pl.add_mesh(line_slice, line_width=10, render_lines_as_tubes=True, color='k')
         >>> _ = pl.add_mesh(arc, line_width=10, color='grey')
         >>> pl.show()
 
@@ -1051,16 +1052,14 @@ class DataSetFilters:
 
         >>> import pyvista
         >>> noise = pyvista.perlin_noise(0.1, (1, 1, 1), (0, 0, 0))
-        >>> grid = pyvista.sample_function(noise, [0, 1.0, -0, 1.0, 0, 1.0],
-        ...                                dim=(20, 20, 20))
+        >>> grid = pyvista.sample_function(noise, [0, 1.0, -0, 1.0, 0, 1.0], dim=(20, 20, 20))
         >>> grid.plot(cmap='gist_earth_r', show_scalar_bar=True, show_edges=False)
 
         Next, apply the threshold.
 
         >>> import pyvista
         >>> noise = pyvista.perlin_noise(0.1, (1, 1, 1), (0, 0, 0))
-        >>> grid = pyvista.sample_function(noise, [0, 1.0, -0, 1.0, 0, 1.0],
-        ...                                dim=(20, 20, 20))
+        >>> grid = pyvista.sample_function(noise, [0, 1.0, -0, 1.0, 0, 1.0], dim=(20, 20, 20))
         >>> threshed = grid.threshold(value=0.02)
         >>> threshed.plot(cmap='gist_earth_r', show_scalar_bar=False, show_edges=True)
 
@@ -1183,8 +1182,7 @@ class DataSetFilters:
 
         >>> import pyvista
         >>> noise = pyvista.perlin_noise(0.1, (2, 2, 2), (0, 0, 0))
-        >>> grid = pyvista.sample_function(noise, [0, 1.0, -0, 1.0, 0, 1.0],
-        ...                                dim=(30, 30, 30))
+        >>> grid = pyvista.sample_function(noise, [0, 1.0, -0, 1.0, 0, 1.0], dim=(30, 30, 30))
         >>> threshed = grid.threshold_percent(0.5)
         >>> threshed.plot(cmap='gist_earth_r', show_scalar_bar=False, show_edges=True)
 
@@ -1601,29 +1599,34 @@ class DataSetFilters:
         >>> a = 0.4
         >>> b = 0.1
         >>> def f(x, y, z):
-        ...     xx = x*x
-        ...     yy = y*y
-        ...     zz = z*z
-        ...     xyz = x*y*z
+        ...     xx = x * x
+        ...     yy = y * y
+        ...     zz = z * z
+        ...     xyz = x * y * z
         ...     xx_yy = xx + yy
-        ...     a_xx = a*xx
-        ...     b_yy = b*yy
+        ...     a_xx = a * xx
+        ...     b_yy = b * yy
         ...     return (
         ...         (xx_yy + 1) * (a_xx + b_yy)
-        ...         + zz * (b * xx + a * yy) - 2 * (a - b) * xyz
+        ...         + zz * (b * xx + a * yy)
+        ...         - 2 * (a - b) * xyz
         ...         - a * b * xx_yy
-        ...     )**2 - 4 * (xx + yy) * (a_xx + b_yy - xyz * (a - b))**2
+        ...     ) ** 2 - 4 * (xx + yy) * (a_xx + b_yy - xyz * (a - b)) ** 2
+        ...
         >>> n = 100
         >>> x_min, y_min, z_min = -1.35, -1.7, -0.65
         >>> grid = pv.UniformGrid(
         ...     dimensions=(n, n, n),
-        ...     spacing=(abs(x_min)/n*2, abs(y_min)/n*2, abs(z_min)/n*2),
+        ...     spacing=(abs(x_min) / n * 2, abs(y_min) / n * 2, abs(z_min) / n * 2),
         ...     origin=(x_min, y_min, z_min),
         ... )
         >>> x, y, z = grid.points.T
         >>> values = f(x, y, z)
         >>> out = grid.contour(
-        ...     1, scalars=values, rng=[0, 0], method='flying_edges',
+        ...     1,
+        ...     scalars=values,
+        ...     rng=[0, 0],
+        ...     method='flying_edges',
         ... )
         >>> out.plot(color='tan', smooth_shading=True)
 
@@ -1943,8 +1946,9 @@ class DataSetFilters:
         >>> centers = mesh.cell_centers()
         >>> pl = pyvista.Plotter()
         >>> actor = pl.add_mesh(mesh, show_edges=True)
-        >>> actor = pl.add_points(centers, render_points_as_spheres=True,
-        ...                       color='red', point_size=20)
+        >>> actor = pl.add_points(
+        ...     centers, render_points_as_spheres=True, color='red', point_size=20
+        ... )
         >>> pl.show()
 
         See :ref:`cell_centers_example` for more examples using this filter.
@@ -2043,8 +2047,7 @@ class DataSetFilters:
         >>> arrows = mesh.glyph(scale="Normals", orient="Normals", tolerance=0.05)
         >>> pl = pyvista.Plotter()
         >>> actor = pl.add_mesh(arrows, color="black")
-        >>> actor = pl.add_mesh(mesh, scalars="Elevation", cmap="terrain",
-        ...                     show_scalar_bar=False)
+        >>> actor = pl.add_mesh(mesh, scalars="Elevation", cmap="terrain", show_scalar_bar=False)
         >>> pl.show()
 
         See :ref:`glyph_example` and :ref:`glyph_table_example` for more
@@ -2813,8 +2816,7 @@ class DataSetFilters:
         >>> sphere = pyvista.Sphere()
         >>> plane = pyvista.Plane()
         >>> selected = plane.select_enclosed_points(sphere)
-        >>> pts = plane.extract_points(selected['SelectedPoints'].view(bool),
-        ...                            adjacent_cells=False)
+        >>> pts = plane.extract_points(selected['SelectedPoints'].view(bool), adjacent_cells=False)
         >>> pl = pyvista.Plotter()
         >>> _ = pl.add_mesh(sphere, style='wireframe')
         >>> _ = pl.add_points(pts, color='r')
@@ -3538,9 +3540,9 @@ class DataSetFilters:
         >>> import pyvista
         >>> from pyvista import examples
         >>> mesh = examples.download_cylinder_crossflow()
-        >>> streams = mesh[0].streamlines_evenly_spaced_2D(start_position=(4, 0.1, 0.),
-        ...                                                separating_distance=3,
-        ...                                                separating_distance_ratio=0.2)
+        >>> streams = mesh[0].streamlines_evenly_spaced_2D(
+        ...     start_position=(4, 0.1, 0.0), separating_distance=3, separating_distance_ratio=0.2
+        ... )
         >>> plotter = pyvista.Plotter()
         >>> _ = plotter.add_mesh(streams.tube(radius=0.02), scalars="vorticity_mag")
         >>> plotter.view_xy()
@@ -3840,7 +3842,9 @@ class DataSetFilters:
         >>> plane = pyvista.Plane()
         >>> plane.clear_data()
         >>> plane = plane.interpolate(pdata, sharpness=3.5)
-        >>> sample = plane.sample_over_multiple_lines([[-0.5, -0.5, 0], [0.5, -0.5, 0], [0.5, 0.5, 0]])
+        >>> sample = plane.sample_over_multiple_lines(
+        ...     [[-0.5, -0.5, 0], [0.5, -0.5, 0], [0.5, 0.5, 0]]
+        ... )
         >>> pl = pyvista.Plotter()
         >>> _ = pl.add_mesh(pdata, render_points_as_spheres=True, point_size=50)
         >>> _ = pl.add_mesh(sample, scalars='values', line_width=10)
@@ -3978,8 +3982,7 @@ class DataSetFilters:
         >>> normal = [0, 0, 1]
         >>> polar = [0, 9, 0]
         >>> center = [uniform.bounds[1], uniform.bounds[2], uniform.bounds[5]]
-        >>> arc = uniform.sample_over_circular_arc_normal(center, normal=normal,
-        ...                                               polar=polar)
+        >>> arc = uniform.sample_over_circular_arc_normal(center, normal=normal, polar=polar)
         >>> pl = pyvista.Plotter()
         >>> _ = pl.add_mesh(uniform, style='wireframe')
         >>> _ = pl.add_mesh(arc, line_width=10)
@@ -5084,10 +5087,9 @@ class DataSetFilters:
         ``vtk.vtkMatrix4x4`` and ``vtk.vtkTransform`` are also
         accepted.
 
-        >>> transform_matrix = np.array([[1, 0, 0, 50],
-        ...                              [0, 1, 0, 100],
-        ...                              [0, 0, 1, 200],
-        ...                              [0, 0, 0, 1]])
+        >>> transform_matrix = np.array(
+        ...     [[1, 0, 0, 50], [0, 1, 0, 100], [0, 0, 1, 200], [0, 0, 0, 1]]
+        ... )
         >>> transformed = mesh.transform(transform_matrix)
         >>> transformed.plot(show_edges=True)
 

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -507,9 +507,7 @@ class PolyDataFilters(DataSetFilters):
         The mesh splitting takes additional time and can be turned
         off for either mesh individually.
 
-        >>> intersection, _, s2_split = s1.intersection(s2,
-        ...                                             split_first=False,
-        ...                                             split_second=True)
+        >>> intersection, _, s2_split = s1.intersection(s2, split_first=False, split_second=True)
 
         """
         intfilter = _vtk.vtkIntersectionPolyDataFilter()
@@ -555,7 +553,7 @@ class PolyDataFilters(DataSetFilters):
         >>> from pyvista import examples
         >>> hills = examples.load_random_hills()
         >>> curv = hills.curvature()
-        >>> curv   # doctest:+SKIP
+        >>> curv  # doctest:+SKIP
         array([0.20587616, 0.06747695, ..., 0.11781171, 0.15988467])
 
         Plot it.
@@ -616,8 +614,7 @@ class PolyDataFilters(DataSetFilters):
 
         >>> from pyvista import examples
         >>> hills = examples.load_random_hills()
-        >>> hills.plot_curvature(curv_type='gaussian', smooth_shading=True,
-        ...                      clim=[0, 1])
+        >>> hills.plot_curvature(curv_type='gaussian', smooth_shading=True, clim=[0, 1])
 
         """
         kwargs.setdefault('scalar_bar_args', {'title': f'{curv_type.capitalize()} Curvature'})
@@ -1734,8 +1731,9 @@ class PolyDataFilters(DataSetFilters):
         >>> import pyvista as pv
         >>> sphere_with_hole = pv.Sphere(end_theta=330)
         >>> sphere = sphere_with_hole.fill_holes(1000)  # doctest:+SKIP
-        >>> edges = sphere.extract_feature_edges(feature_edges=False,
-        ...                                      manifold_edges=False)  # doctest:+SKIP
+        >>> edges = sphere.extract_feature_edges(
+        ...     feature_edges=False, manifold_edges=False
+        ... )  # doctest:+SKIP
         >>> assert edges.n_cells == 0  # doctest:+SKIP
 
         """
@@ -2132,9 +2130,13 @@ class PolyDataFilters(DataSetFilters):
 
         >>> import pyvista as pv  # doctest:+SKIP
         >>> sphere = pv.Sphere()  # doctest:+SKIP
-        >>> points, rays, cells = sphere.multi_ray_trace([[0, 0, 0]]*3, [[1, 0, 0], [0, 1, 0], [0, 0, 1]], first_point=True)  # doctest:+SKIP
-        >>> string = ", ".join([f"({point[0]:.3f}, {point[1]:.3f}, {point[2]:.3f})" for point in points]) # doctest:+SKIP
-        >>> f'Rays intersected at {string}' # doctest:+SKIP
+        >>> points, rays, cells = sphere.multi_ray_trace(
+        ...     [[0, 0, 0]] * 3, [[1, 0, 0], [0, 1, 0], [0, 0, 1]], first_point=True
+        ... )  # doctest:+SKIP
+        >>> string = ", ".join(
+        ...     [f"({point[0]:.3f}, {point[1]:.3f}, {point[2]:.3f})" for point in points]
+        ... )  # doctest:+SKIP
+        >>> f'Rays intersected at {string}'  # doctest:+SKIP
         'Rays intersected at (0.499, 0.000, 0.000), (0.000, 0.497, 0.000), (0.000, 0.000, 0.500)'
 
         """
@@ -2921,25 +2923,30 @@ class PolyDataFilters(DataSetFilters):
         Create a "spring" using the rotational extrusion filter.
 
         >>> import pyvista
-        >>> profile = pyvista.Polygon(center=[1.25, 0.0, 0.0], radius=0.2,
-        ...                           normal=(0, 1, 0), n_sides=30)
-        >>> extruded = profile.extrude_rotate(resolution=360, translation=4.0,
-        ...                                   dradius=0.5, angle=1500.0,
-        ...                                   capping=True)
+        >>> profile = pyvista.Polygon(
+        ...     center=[1.25, 0.0, 0.0], radius=0.2, normal=(0, 1, 0), n_sides=30
+        ... )
+        >>> extruded = profile.extrude_rotate(
+        ...     resolution=360, translation=4.0, dradius=0.5, angle=1500.0, capping=True
+        ... )
         >>> extruded.plot(smooth_shading=True)
 
         Create a "wine glass" using the rotational extrusion filter.
 
         >>> import numpy as np
-        >>> points = np.array([[-0.18, 0, 0],
-        ...                    [-0.18, 0, 0.01],
-        ...                    [-0.18, 0, 0.02],
-        ...                    [-0.01, 0, 0.03],
-        ...                    [-0.01, 0, 0.04],
-        ...                    [-0.02, 0, 0.5],
-        ...                    [-0.05, 0, 0.75],
-        ...                    [-0.1, 0, 0.8],
-        ...                    [-0.2, 0, 1.0]])
+        >>> points = np.array(
+        ...     [
+        ...         [-0.18, 0, 0],
+        ...         [-0.18, 0, 0.01],
+        ...         [-0.18, 0, 0.02],
+        ...         [-0.01, 0, 0.03],
+        ...         [-0.01, 0, 0.04],
+        ...         [-0.02, 0, 0.5],
+        ...         [-0.05, 0, 0.75],
+        ...         [-0.1, 0, 0.8],
+        ...         [-0.2, 0, 1.0],
+        ...     ]
+        ... )
         >>> spline = pyvista.Spline(points, 30)
         >>> extruded = spline.extrude_rotate(resolution=20, capping=False)
         >>> extruded.plot(color='tan')
@@ -3285,17 +3292,14 @@ class PolyDataFilters(DataSetFilters):
         >>> scalars = np.zeros(collision.n_cells, dtype=bool)
         >>> scalars[collision.field_data['ContactCells']] = True
         >>> pl = pyvista.Plotter()
-        >>> _ = pl.add_mesh(collision, scalars=scalars, show_scalar_bar=False,
-        ...                 cmap='bwr')
-        >>> _ = pl.add_mesh(mesh_b, color='tan', line_width=5, opacity=0.7,
-        ...                 show_edges=True)
+        >>> _ = pl.add_mesh(collision, scalars=scalars, show_scalar_bar=False, cmap='bwr')
+        >>> _ = pl.add_mesh(mesh_b, color='tan', line_width=5, opacity=0.7, show_edges=True)
         >>> pl.show()
 
         Alternatively, simply plot the collisions using the default
         ``'collision_rgba'`` array after enabling ``generate_scalars``.
 
-        >>> collision, ncol = mesh_a.collision(mesh_b, cell_tolerance=1,
-        ...                                    generate_scalars=True)
+        >>> collision, ncol = mesh_a.collision(mesh_b, cell_tolerance=1, generate_scalars=True)
         >>> collision.plot()
 
         See :ref:`collision_example` for more examples using this filter.
@@ -3543,10 +3547,10 @@ class PolyDataFilters(DataSetFilters):
         >>> points = pv.wrap(pv.Sphere().points)
         >>> surf = points.reconstruct_surface()
 
-        >>> pl = pv.Plotter(shape=(1,2))
+        >>> pl = pv.Plotter(shape=(1, 2))
         >>> _ = pl.add_mesh(points)
         >>> _ = pl.add_title('Point Cloud of 3D Surface')
-        >>> pl.subplot(0,1)
+        >>> pl.subplot(0, 1)
         >>> _ = pl.add_mesh(surf, color=True, show_edges=True)
         >>> _ = pl.add_title('Reconstructed Surface')
         >>> pl.show()

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -587,8 +587,9 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         mesh and the additional vertices in a single plot.
 
         >>> mesh = pyvista.Plane(i_resolution=3, j_resolution=3)
-        >>> mesh.verts = np.vstack((np.ones(mesh.n_points, dtype=np.int64),
-        ...                         np.arange(mesh.n_points))).T
+        >>> mesh.verts = np.vstack(
+        ...     (np.ones(mesh.n_points, dtype=np.int64), np.arange(mesh.n_points))
+        ... ).T
         >>> mesh.plot(color='tan', render_points_as_spheres=True, point_size=60)
 
         """
@@ -1372,23 +1373,33 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
         >>> cells = np.array([8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 9, 10, 11, 12, 13, 14, 15])
         >>> cell_type = np.array([CellType.HEXAHEDRON, CellType.HEXAHEDRON], np.int8)
 
-        >>> cell1 = np.array([[0, 0, 0],
-        ...                   [1, 0, 0],
-        ...                   [1, 1, 0],
-        ...                   [0, 1, 0],
-        ...                   [0, 0, 1],
-        ...                   [1, 0, 1],
-        ...                   [1, 1, 1],
-        ...                   [0, 1, 1]], dtype=np.float32)
+        >>> cell1 = np.array(
+        ...     [
+        ...         [0, 0, 0],
+        ...         [1, 0, 0],
+        ...         [1, 1, 0],
+        ...         [0, 1, 0],
+        ...         [0, 0, 1],
+        ...         [1, 0, 1],
+        ...         [1, 1, 1],
+        ...         [0, 1, 1],
+        ...     ],
+        ...     dtype=np.float32,
+        ... )
 
-        >>> cell2 = np.array([[0, 0, 2],
-        ...                   [1, 0, 2],
-        ...                   [1, 1, 2],
-        ...                   [0, 1, 2],
-        ...                   [0, 0, 3],
-        ...                   [1, 0, 3],
-        ...                   [1, 1, 3],
-        ...                   [0, 1, 3]], dtype=np.float32)
+        >>> cell2 = np.array(
+        ...     [
+        ...         [0, 0, 2],
+        ...         [1, 0, 2],
+        ...         [1, 1, 2],
+        ...         [0, 1, 2],
+        ...         [0, 0, 3],
+        ...         [1, 0, 3],
+        ...         [1, 1, 3],
+        ...         [0, 1, 3],
+        ...     ],
+        ...     dtype=np.float32,
+        ... )
 
         >>> points = np.vstack((cell1, cell2))
 
@@ -2035,7 +2046,7 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
         >>> z = 0
         >>> x, y, z = np.meshgrid(x, y, z)
         >>> grid = pv.StructuredGrid(x, y, z)
-        >>> grid = grid.hide_cells(range(79*30, 79*50))
+        >>> grid = grid.hide_cells(range(79 * 30, 79 * 50))
         >>> grid.plot(color=True, show_edges=True)
         """
         if not inplace:
@@ -2086,7 +2097,7 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
         >>> z = 0
         >>> x, y, z = np.meshgrid(x, y, z)
         >>> grid = pv.StructuredGrid(x, y, z)
-        >>> grid.hide_points(range(80*30, 80*50))
+        >>> grid.hide_points(range(80 * 30, 80 * 50))
         >>> grid.plot(color=True, show_edges=True)
         """
         if isinstance(ind, np.ndarray):
@@ -2138,11 +2149,12 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
     >>> si, sj, sk = 20, 10, 1
     >>>
     >>> # create raw coordinate grid
-    >>> grid_ijk = np.mgrid[:(ni+1)*si:si, :(nj+1)*sj:sj, :(nk+1)*sk:sk]
+    >>> grid_ijk = np.mgrid[: (ni + 1) * si : si, : (nj + 1) * sj : sj, : (nk + 1) * sk : sk]
     >>>
     >>> # repeat array along each Cartesian axis for connectivity
     >>> for axis in range(1, 4):
     ...     grid_ijk = grid_ijk.repeat(2, axis=axis)
+    ...
     >>>
     >>> # slice off unnecessarily doubled edge coordinates
     >>> grid_ijk = grid_ijk[:, 1:-1, 1:-1, 1:-1]
@@ -2491,10 +2503,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         >>> grid.cell_id((3, 4, 0))  # doctest:+SKIP
         19
 
-        >>> coords = [(3, 4, 0),
-        ...           (3, 2, 1),
-        ...           (1, 0, 2),
-        ...           (2, 3, 2)]
+        >>> coords = [(3, 4, 0), (3, 2, 1), (1, 0, 2), (2, 3, 2)]
         >>> grid.cell_id(coords)  # doctest:+SKIP
         array([19, 31, 41, 54])
 

--- a/pyvista/demos/demos.py
+++ b/pyvista/demos/demos.py
@@ -338,8 +338,9 @@ def plot_ants_plane(notebook=None):
        Add airplane mesh and make the color equal to the Y position.
 
        >>> plane_scalars = airplane.points[:, 1]
-       >>> _ = plotter.add_mesh(airplane, scalars=plane_scalars,
-       ...                      scalar_bar_args={'title': 'Plane Y Location'})
+       >>> _ = plotter.add_mesh(
+       ...     airplane, scalars=plane_scalars, scalar_bar_args={'title': 'Plane Y Location'}
+       ... )
        >>> _ = plotter.add_text('Ants and Plane Example')
        >>> plotter.show()
 

--- a/pyvista/demos/logo.py
+++ b/pyvista/demos/logo.py
@@ -98,8 +98,7 @@ def logo_basic():
     Add scalars and plot the logo.
 
     >>> logo['x_coord'] = logo.points[:, 0]
-    >>> cpos = logo.plot(scalars='x_coord', cmap='Spectral',
-    ...                  smooth_shading=True, cpos='xy')
+    >>> cpos = logo.plot(scalars='x_coord', cmap='Spectral', smooth_shading=True, cpos='xy')
 
     """
     return logo_letters(merge=True).compute_normals(split_vertices=True)

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -621,11 +621,7 @@ def download_head(load=True):  # pragma: no cover
     >>> dataset = examples.download_head()
     >>> pl = pyvista.Plotter()
     >>> _ = pl.add_volume(dataset, cmap="cool", opacity="sigmoid_6")
-    >>> pl.camera_position = [
-    ...     (-228.0, -418.0, -158.0),
-    ...     (94.0, 122.0, 82.0),
-    ...     (-0.2, -0.3, 0.9)
-    ... ]
+    >>> pl.camera_position = [(-228.0, -418.0, -158.0), (94.0, 122.0, 82.0), (-0.2, -0.3, 0.9)]
     >>> pl.show()
 
     See :ref:`volume_rendering_example` for an example using this
@@ -685,13 +681,12 @@ def download_bolt_nut(load=True):  # pragma: no cover
     >>> dataset = examples.download_bolt_nut()
     >>> pl = pyvista.Plotter()
     >>> _ = pl.add_volume(
-    ...         dataset, cmap="coolwarm", opacity="sigmoid_5", show_scalar_bar=False,
+    ...     dataset,
+    ...     cmap="coolwarm",
+    ...     opacity="sigmoid_5",
+    ...     show_scalar_bar=False,
     ... )
-    >>> pl.camera_position = [
-    ...     (194.6, -141.8, 182.0),
-    ...     (34.5, 61.0, 32.5),
-    ...     (-0.229, 0.45, 0.86)
-    ... ]
+    >>> pl.camera_position = [(194.6, -141.8, 182.0), (34.5, 61.0, 32.5), (-0.229, 0.45, 0.86)]
     >>> pl.show()
 
     See :ref:`volume_rendering_example` for an example using this
@@ -860,11 +855,7 @@ def download_knee_full(load=True):  # pragma: no cover
     --------
     >>> from pyvista import examples
     >>> dataset = examples.download_knee_full()
-    >>> cpos = [
-    ...     (-381.74, -46.02, 216.54),
-    ...     (74.8305, 89.2905, 100.0),
-    ...     (0.23, 0.072, 0.97)
-    ... ]
+    >>> cpos = [(-381.74, -46.02, 216.54), (74.8305, 89.2905, 100.0), (0.23, 0.072, 0.97)]
     >>> dataset.plot(volume=True, cmap="bone", cpos=cpos, show_scalar_bar=False)
 
     This dataset is used in the following examples:
@@ -1632,9 +1623,9 @@ def download_frog(load=True):  # pragma: no cover
     --------
     >>> from pyvista import examples
     >>> cpos = [
-    ...     [ 8.4287e+02, -5.7418e+02, -4.4085e+02],
-    ...     [ 2.4950e+02,  2.3450e+02,  1.0125e+02],
-    ...     [-3.2000e-01,  3.5000e-01, -8.8000e-01]
+    ...     [8.4287e02, -5.7418e02, -4.4085e02],
+    ...     [2.4950e02, 2.3450e02, 1.0125e02],
+    ...     [-3.2000e-01, 3.5000e-01, -8.8000e-01],
     ... ]
     >>> dataset = examples.download_frog()
     >>> dataset.plot(volume=True, cpos=cpos)
@@ -2279,11 +2270,7 @@ def download_carotid(load=True):  # pragma: no cover
     Examples
     --------
     >>> from pyvista import examples
-    >>> cpos = [
-    ...     [220.96, -24.38, -69.96],
-    ...     [135.86, 106.55,  17.72],
-    ...     [ -0.25,   0.42,  -0.87]
-    ... ]
+    >>> cpos = [[220.96, -24.38, -69.96], [135.86, 106.55, 17.72], [-0.25, 0.42, -0.87]]
     >>> dataset = examples.download_carotid()
     >>> dataset.plot(volume=True, cpos=cpos)
 
@@ -2320,11 +2307,7 @@ def download_blow(load=True):  # pragma: no cover
     Examples
     --------
     >>> from pyvista import examples
-    >>> cpos = [
-    ...     [71.96, 86.1 , 28.45],
-    ...     [ 3.5 , 12.  ,  1.  ],
-    ...     [-0.18, -0.19,  0.96]
-    ... ]
+    >>> cpos = [[71.96, 86.1, 28.45], [3.5, 12.0, 1.0], [-0.18, -0.19, 0.96]]
     >>> dataset = examples.download_blow()
     >>> dataset.plot(
     ...     scalars='displacement1',
@@ -2356,9 +2339,9 @@ def download_shark(load=True):  # pragma: no cover
     --------
     >>> from pyvista import examples
     >>> cpos = [
-    ...     [-2.3195e+02, -3.3930e+01,  1.2981e+02],
-    ...     [-8.7100e+00,  1.9000e-01, -1.1740e+01],
-    ...     [-1.4000e-01,  9.9000e-01,  2.0000e-02]
+    ...     [-2.3195e02, -3.3930e01, 1.2981e02],
+    ...     [-8.7100e00, 1.9000e-01, -1.1740e01],
+    ...     [-1.4000e-01, 9.9000e-01, 2.0000e-02],
     ... ]
     >>> dataset = examples.download_shark()
     >>> dataset.plot(cpos=cpos, smooth_shading=True)
@@ -2417,11 +2400,7 @@ def download_armadillo(load=True):  # pragma: no cover
     Plot the armadillo dataset. Use a custom camera position.
 
     >>> from pyvista import examples
-    >>> cpos = [
-    ...     (161.5, 82.1, -330.2),
-    ...     (-4.3, 24.5, -1.6),
-    ...     (-0.1, 1, 0.12)
-    ... ]
+    >>> cpos = [(161.5, 82.1, -330.2), (-4.3, 24.5, -1.6), (-0.1, 1, 0.12)]
     >>> dataset = examples.download_armadillo()
     >>> dataset.plot(cpos=cpos)
 
@@ -2455,6 +2434,7 @@ def download_gears(load=True):  # pragma: no cover
     ...     bid = np.empty(body.n_points)
     ...     bid[:] = i
     ...     body.point_data["Body ID"] = bid
+    ...
     >>> bodies.plot(cmap='jet')
     """
     return _download_and_read('gears.stl', load=load)
@@ -2772,11 +2752,7 @@ def download_crater_imagery(load=True):  # pragma: no cover
     Examples
     --------
     >>> from pyvista import examples
-    >>> cpos = [
-    ...     [  66.,  73. , -382.6],
-    ...     [  66.,  73. ,    0. ],
-    ...     [  -0.,  -1. ,    0. ]
-    ... ]
+    >>> cpos = [[66.0, 73.0, -382.6], [66.0, 73.0, 0.0], [-0.0, -1.0, 0.0]]
     >>> dataset = examples.download_crater_imagery()
     >>> dataset.plot(cpos=cpos)
 
@@ -2828,9 +2804,9 @@ def download_damavand_volcano(load=True):  # pragma: no cover
     --------
     >>> from pyvista import examples
     >>> cpos = [
-    ...     [ 4.66316700e+04,  4.32796241e+06, -3.82467050e+05],
-    ...     [ 5.52532740e+05,  3.98017300e+06, -2.47450000e+04],
-    ...     [ 4.10000000e-01, -2.90000000e-01, -8.60000000e-01]
+    ...     [4.66316700e04, 4.32796241e06, -3.82467050e05],
+    ...     [5.52532740e05, 3.98017300e06, -2.47450000e04],
+    ...     [4.10000000e-01, -2.90000000e-01, -8.60000000e-01],
     ... ]
     >>> dataset = examples.download_damavand_volcano()
     >>> dataset.plot(cpos=cpos, cmap="reds", show_scalar_bar=False, volume=True)
@@ -3291,11 +3267,7 @@ def download_woman(load=True):  # pragma: no cover
     --------
     >>> from pyvista import examples
     >>> dataset = examples.download_woman()
-    >>> cpos = [
-    ...     (-2600.0, 1970.6, 1836.9),
-    ...     (48.5, -20.3, 843.9),
-    ...     (0.23, -0.168, 0.958)
-    ... ]
+    >>> cpos = [(-2600.0, 1970.6, 1836.9), (48.5, -20.3, 843.9), (0.23, -0.168, 0.958)]
     >>> dataset.plot(cpos=cpos)
 
     """
@@ -3374,9 +3346,9 @@ def download_urn(load=True):  # pragma: no cover
     --------
     >>> from pyvista import examples
     >>> cpos = [
-    ...     [-7.123e+02,  5.715e+02,  8.601e+02],
-    ...     [ 4.700e+00,  2.705e+02, -1.010e+01],
-    ...     [ 2.000e-01,  1.000e+00, -2.000e-01]
+    ...     [-7.123e02, 5.715e02, 8.601e02],
+    ...     [4.700e00, 2.705e02, -1.010e01],
+    ...     [2.000e-01, 1.000e00, -2.000e-01],
     ... ]
     >>> dataset = examples.download_urn()
     >>> dataset.plot(cpos=cpos)
@@ -3465,13 +3437,10 @@ def download_action_figure(load=True):  # pragma: no cover
     >>> _ = dataset.clean(inplace=True)
     >>> pl = pyvista.Plotter(lighting=None)
     >>> pl.add_light(pyvista.Light((30, 10, 10)))
-    >>> _ = pl.add_mesh(dataset, color='w', smooth_shading=True,
-    ...                 pbr=True, metallic=0.3, roughness=0.5)
-    >>> pl.camera_position = [
-    ...     (32.3, 116.3, 220.6),
-    ...     (-0.05, 3.8, 33.8),
-    ...     (-0.017, 0.86, -0.51)
-    ... ]
+    >>> _ = pl.add_mesh(
+    ...     dataset, color='w', smooth_shading=True, pbr=True, metallic=0.3, roughness=0.5
+    ... )
+    >>> pl.camera_position = [(32.3, 116.3, 220.6), (-0.05, 3.8, 33.8), (-0.017, 0.86, -0.51)]
     >>> pl.show()
 
     """
@@ -3588,11 +3557,7 @@ def download_louis_louvre(load=True):  # pragma: no cover
     >>> pl = pyvista.Plotter(lighting=None)
     >>> _ = pl.add_mesh(dataset, smooth_shading=True)
     >>> pl.add_light(pyvista.Light((10, -10, 10)))
-    >>> pl.camera_position = [
-    ...     [ -6.71, -14.55,  15.17],
-    ...     [  1.44,   2.54,   9.84],
-    ...     [  0.16,   0.22,   0.96]
-    ... ]
+    >>> pl.camera_position = [[-6.71, -14.55, 15.17], [1.44, 2.54, 9.84], [0.16, 0.22, 0.96]]
     >>> pl.show()
 
     See :ref:`pbr_example` for an example using this dataset.
@@ -3654,11 +3619,7 @@ def download_naca(load=True):  # pragma: no cover
     ``"jet"`` color map.
 
     >>> from pyvista import examples
-    >>> cpos = [
-    ...     [-0.22,  0.  ,  2.52],
-    ...     [ 0.43,  0.  ,  0.  ],
-    ...     [ 0.  ,  1.  ,  0.  ]
-    ... ]
+    >>> cpos = [[-0.22, 0.0, 2.52], [0.43, 0.0, 0.0], [0.0, 1.0, 0.0]]
     >>> dataset = examples.download_naca()
     >>> dataset.plot(cpos=cpos, cmap="jet")
 
@@ -3743,6 +3704,7 @@ def download_single_sphere_animation(load=True):  # pragma: no cover
     ...     plotter.write_frame()
     ...     plotter.clear()
     ...     plotter.enable_lightkit()
+    ...
     >>> plotter.close()
 
     """
@@ -3794,6 +3756,7 @@ def download_dual_sphere_animation(load=True):  # pragma: no cover
     ...     plotter.write_frame()
     ...     plotter.clear()
     ...     plotter.enable_lightkit()
+    ...
     >>> plotter.close()
 
     """
@@ -3904,11 +3867,11 @@ def download_lucy(load=True):  # pragma: no cover
 
     >>> flame_light = pyvista.Light(
     ...     color=[0.886, 0.345, 0.133],
-    ...     position=[550,  140, 950],
+    ...     position=[550, 140, 950],
     ...     intensity=1.5,
     ...     positional=True,
     ...     cone_angle=90,
-    ...     attenuation_values=(0.001, 0.005, 0)
+    ...     attenuation_values=(0.001, 0.005, 0),
     ... )
 
     Create a scene light
@@ -4114,7 +4077,11 @@ def download_cgns_multi(load=True):  # pragma: no cover
     >>> ugrid = dataset.combine()
     >>> ugrid = ugrid = ugrid.cell_data_to_point_data()
     >>> ugrid.plot(
-    ...     cmap='bwr', scalars='ViscosityEddy', zoom=4, cpos='xz', show_scalar_bar=False,
+    ...     cmap='bwr',
+    ...     scalars='ViscosityEddy',
+    ...     zoom=4,
+    ...     cpos='xz',
+    ...     show_scalar_bar=False,
     ... )
 
     """
@@ -4355,7 +4322,7 @@ def download_particles_lethe(load=True):  # pragma: no cover
     ...     scalars='Velocity',
     ...     background='w',
     ...     scalar_bar_args={'color': 'k'},
-    ...     cmap='bwr'
+    ...     cmap='bwr',
     ... )
 
     """
@@ -4382,23 +4349,11 @@ def download_gif_simple(load=True):  # pragma: no cover
 
     >>> from pyvista import examples
     >>> grid = examples.download_gif_simple()
-    >>> grid.plot(
-    ...     scalars='frame0',
-    ...     rgb=True,
-    ...     background='w',
-    ...     show_scalar_bar=False,
-    ...     cpos='xy'
-    ... )
+    >>> grid.plot(scalars='frame0', rgb=True, background='w', show_scalar_bar=False, cpos='xy')
 
     Plot the second frame.
 
-    >>> grid.plot(
-    ...     scalars='frame1',
-    ...     rgb=True,
-    ...     background='w',
-    ...     show_scalar_bar=False,
-    ...     cpos='xy'
-    ... )
+    >>> grid.plot(scalars='frame1', rgb=True, background='w', show_scalar_bar=False, cpos='xy')
 
     """
     return _download_and_read('gifs/sample.gif', load=load)
@@ -4691,9 +4646,7 @@ def download_ivan_angel(load=True):  # pragma: no cover
 
     >>> from pyvista import examples
     >>> mesh = examples.download_ivan_angel()
-    >>> cpos = [(-476.14, -393.73, 282.14),
-    ...         (-15.00, 11.25, 44.08),
-    ...         (0.26, 0.24, 0.93)]
+    >>> cpos = [(-476.14, -393.73, 282.14), (-15.00, 11.25, 44.08), (0.26, 0.24, 0.93)]
     >>> mesh.plot(cpos=cpos)
 
     Return the statistics of the dataset.
@@ -4798,9 +4751,7 @@ def download_owl(load=True):  # pragma: no cover
 
     >>> from pyvista import examples
     >>> mesh = examples.download_owl()
-    >>> cpos = [(-315.18, -402.21, 230.71),
-    ...         (6.06, -1.74, 101.48),
-    ...         (0.108, 0.226, 0.968)]
+    >>> cpos = [(-315.18, -402.21, 230.71), (6.06, -1.74, 101.48), (0.108, 0.226, 0.968)]
     >>> mesh.plot(cpos=cpos)
 
     Return the statistics of the dataset.

--- a/pyvista/examples/gltf.py
+++ b/pyvista/examples/gltf.py
@@ -31,7 +31,7 @@ def download_damaged_helmet():  # pragma: no cover
     Examples
     --------
     >>> import pyvista
-    >>> from pyvista import examples    # doctest:+SKIP
+    >>> from pyvista import examples  # doctest:+SKIP
     >>> gltf_file = examples.gltf.download_damaged_helmet()  # doctest:+SKIP
     >>> cubemap = examples.download_sky_box_cube_map()  # doctest:+SKIP
     >>> pl = pyvista.Plotter()  # doctest:+SKIP
@@ -56,7 +56,7 @@ def download_sheen_chair():  # pragma: no cover
     Examples
     --------
     >>> import pyvista
-    >>> from pyvista import examples    # doctest:+SKIP
+    >>> from pyvista import examples  # doctest:+SKIP
     >>> gltf_file = examples.gltf.download_sheen_chair()  # doctest:+SKIP
     >>> cubemap = examples.download_sky_box_cube_map()  # doctest:+SKIP
     >>> pl = pyvista.Plotter()  # doctest:+SKIP
@@ -81,7 +81,7 @@ def download_gearbox():  # pragma: no cover
     Examples
     --------
     >>> import pyvista
-    >>> from pyvista import examples    # doctest:+SKIP
+    >>> from pyvista import examples  # doctest:+SKIP
     >>> gltf_file = examples.gltf.download_gearbox()  # doctest:+SKIP
     >>> pl = pyvista.Plotter()  # doctest:+SKIP
     >>> pl.import_gltf(gltf_file)  # doctest:+SKIP
@@ -104,7 +104,7 @@ def download_avocado():  # pragma: no cover
     Examples
     --------
     >>> import pyvista
-    >>> from pyvista import examples    # doctest:+SKIP
+    >>> from pyvista import examples  # doctest:+SKIP
     >>> gltf_file = examples.gltf.download_avocado()  # doctest:+SKIP
     >>> pl = pyvista.Plotter()  # doctest:+SKIP
     >>> pl.import_gltf(gltf_file)  # doctest:+SKIP
@@ -127,7 +127,7 @@ def download_milk_truck():  # pragma: no cover
     Examples
     --------
     >>> import pyvista
-    >>> from pyvista import examples    # doctest:+SKIP
+    >>> from pyvista import examples  # doctest:+SKIP
     >>> gltf_file = examples.gltf.download_milk_truck()  # doctest:+SKIP
     >>> pl = pyvista.Plotter()  # doctest:+SKIP
     >>> pl.import_gltf(gltf_file)  # doctest:+SKIP

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -223,11 +223,9 @@ def _split_code_at_show(text):
     Includes logic to deal with edge cases like:
 
     >>> import pyvista
-    >>> pyvista.Sphere().plot(color='blue',
-    ...                       cpos='xy')
+    >>> pyvista.Sphere().plot(color='blue', cpos='xy')
 
-    >>> pyvista.Sphere().plot(color='red',
-    ...                       cpos='xy')
+    >>> pyvista.Sphere().plot(color='red', cpos='xy')
 
     """
     parts = []

--- a/pyvista/plotting/_property.py
+++ b/pyvista/plotting/_property.py
@@ -121,7 +121,7 @@ class Property(_vtk.vtkProperty):
     ...     show_edges=True,
     ...     interpolation='Physically based rendering',
     ...     metallic=0.5,
-    ...     roughness=0.1
+    ...     roughness=0.1,
     ... )
 
     Visualize how the property would look when applied to a mesh.
@@ -1112,11 +1112,7 @@ class Property(_vtk.vtkProperty):
         --------
         >>> import pyvista as pv
         >>> prop = pv.Property(
-        ...     show_edges=True,
-        ...     color='brown',
-        ...     edge_color='blue',
-        ...     line_width=4,
-        ...     specular=1.0
+        ...     show_edges=True, color='brown', edge_color='blue', line_width=4, specular=1.0
         ... )
         >>> prop.plot()
 

--- a/pyvista/plotting/actor.py
+++ b/pyvista/plotting/actor.py
@@ -363,12 +363,7 @@ class Actor(Prop3D, _vtk.vtkActor):
         ...     lighting=False,
         ... )
         >>> arr = np.array(
-        ...     [
-        ...         [0.707, -0.707, 0, 0],
-        ...         [0.707, 0.707, 0, 0],
-        ...         [0, 0, 1, 1.500001],
-        ...         [0, 0, 0, 2]
-        ...     ]
+        ...     [[0.707, -0.707, 0, 0], [0.707, 0.707, 0, 0], [0, 0, 1, 1.500001], [0, 0, 0, 2]]
         ... )
         >>> actor.user_matrix = arr
         >>> pl.show_axes()
@@ -414,7 +409,11 @@ class Actor(Prop3D, _vtk.vtkActor):
         >>> actor = pl.add_mesh(mesh, smooth_shading=True)
         >>> actor.backface_prop.color = 'lightblue'
         >>> _ = pl.add_mesh(
-        ...     plane, opacity=0.25, show_edges=True, color='grey', lighting=False,
+        ...     plane,
+        ...     opacity=0.25,
+        ...     show_edges=True,
+        ...     color='grey',
+        ...     lighting=False,
         ... )
         >>> pl.show()
 

--- a/pyvista/plotting/actor_properties.py
+++ b/pyvista/plotting/actor_properties.py
@@ -24,9 +24,9 @@ class ActorProperties:
     >>> axes.axes_actor.shaft_type = axes.axes_actor.ShaftType.CYLINDER
 
     >>> pl = pv.Plotter()
-    >>> pl.add_actor(axes.axes_actor)   # doctest:+SKIP
-    >>> pl.add_mesh(pv.Sphere())   # doctest:+SKIP
-    >>> pl.show()   # doctest:+SKIP
+    >>> pl.add_actor(axes.axes_actor)  # doctest:+SKIP
+    >>> pl.add_mesh(pv.Sphere())  # doctest:+SKIP
+    >>> pl.show()  # doctest:+SKIP
 
     """
 

--- a/pyvista/plotting/axes_actor.py
+++ b/pyvista/plotting/axes_actor.py
@@ -50,7 +50,10 @@ class AxesActor(pv._vtk.vtkAxesActor):
 
     >>> pl = pv.Plotter()
     >>> _ = pl.add_mesh(pv.Cone())
-    >>> _ = pl.add_orientation_widget(axes_actor, viewport=(0, 0, 0.5, 0.5),)
+    >>> _ = pl.add_orientation_widget(
+    ...     axes_actor,
+    ...     viewport=(0, 0, 0.5, 0.5),
+    ... )
     >>> pl.show()  # doctest:+SKIP
 
     """

--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -120,7 +120,7 @@ class Camera(_vtk.vtkCamera):
         --------
         >>> import pyvista as pv
         >>> pl = pv.Plotter()
-        >>> pl.camera = pv.Camera.from_paraview_pvcc("camera.pvcc") # doctest:+SKIP
+        >>> pl.camera = pv.Camera.from_paraview_pvcc("camera.pvcc")  # doctest:+SKIP
         >>> pl.camera.position
         (1.0, 1.0, 1.0)
         """
@@ -308,10 +308,14 @@ class Camera(_vtk.vtkCamera):
                [0., 1., 0., 0.],
                [0., 0., 1., 0.],
                [0., 0., 0., 1.]])
-        >>> pl.camera.model_transform_matrix = np.array([[1., 0., 0., 0.],
-        ...                                              [0., 1., 0., 0.],
-        ...                                              [0., 0., 1., 0.],
-        ...                                              [0., 0., 0., 0.5]])
+        >>> pl.camera.model_transform_matrix = np.array(
+        ...     [
+        ...         [1.0, 0.0, 0.0, 0.0],
+        ...         [0.0, 1.0, 0.0, 0.0],
+        ...         [0.0, 0.0, 1.0, 0.0],
+        ...         [0.0, 0.0, 0.0, 0.5],
+        ...     ]
+        ... )
         >>>
         array([[1., 0., 0., 0.],
                [0., 1., 0., 0.],
@@ -745,17 +749,25 @@ class Camera(_vtk.vtkCamera):
         >>> import pyvista as pv
         >>> import numpy as np
         >>> camera = pv.Camera()
-        >>> camera.model_transform_matrix = np.array([[1., 0., 0., 0.],
-        ...                                           [0., 1., 0., 0.],
-        ...                                           [0., 0., 1., 0.],
-        ...                                           [0., 0., 0., 1.]])
+        >>> camera.model_transform_matrix = np.array(
+        ...     [
+        ...         [1.0, 0.0, 0.0, 0.0],
+        ...         [0.0, 1.0, 0.0, 0.0],
+        ...         [0.0, 0.0, 1.0, 0.0],
+        ...         [0.0, 0.0, 0.0, 1.0],
+        ...     ]
+        ... )
         >>> copied_camera = camera.copy()
         >>> copied_camera == camera
         True
-        >>> camera.model_transform_matrix = np.array([[1., 0., 0., 0.],
-        ...                                           [0., 1., 0., 0.],
-        ...                                           [0., 0., 1., 0.],
-        ...                                           [0., 0., 0., 0.5]])
+        >>> camera.model_transform_matrix = np.array(
+        ...     [
+        ...         [1.0, 0.0, 0.0, 0.0],
+        ...         [0.0, 1.0, 0.0, 0.0],
+        ...         [0.0, 0.0, 1.0, 0.0],
+        ...         [0.0, 0.0, 0.0, 0.5],
+        ...     ]
+        ... )
         >>> copied_camera == camera
         False
         """

--- a/pyvista/plotting/composite_mapper.py
+++ b/pyvista/plotting/composite_mapper.py
@@ -545,7 +545,7 @@ class CompositePolyDataMapper(_vtk.vtkCompositePolyDataMapper2, _BaseMapper):
         >>> dataset = pv.MultiBlock([pv.Cube(), pv.Sphere(center=(0, 0, 1))])
         >>> pl = pv.Plotter()
         >>> actor, mapper = pl.add_composite(dataset)
-        >>> mapper.dataset   # doctest:+SKIP
+        >>> mapper.dataset  # doctest:+SKIP
         MultiBlock (...)
           N Blocks:     2
           X Bounds:     -0.500, 0.500

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -206,7 +206,7 @@ def plot(
     >>> import numpy as np
     >>> grid = pv.UniformGrid(dimensions=(32, 32, 32), spacing=(0.5, 0.5, 0.5))
     >>> grid['data'] = np.linalg.norm(grid.center - grid.points, axis=1)
-    >>> grid['data'] = np.abs(grid['data'] - grid['data'].max())**3
+    >>> grid['data'] = np.abs(grid['data'] - grid['data'].max()) ** 3
     >>> grid.plot(volume=True)
 
     """

--- a/pyvista/plotting/lights.py
+++ b/pyvista/plotting/lights.py
@@ -114,8 +114,9 @@ class Light(vtkLight):
     Create a positional light at (0, 0, 3) with a cone angle of
     30, exponent of 20, and a visible actor.
 
-    >>> light = pv.Light(position=(0, 0, 3), show_actor=True,
-    ...                  positional=True, cone_angle=30, exponent=20)
+    >>> light = pv.Light(
+    ...     position=(0, 0, 3), show_actor=True, positional=True, cone_angle=30, exponent=20
+    ... )
 
     """
 
@@ -1012,8 +1013,7 @@ class Light(vtkLight):
 
         >>> import pyvista as pv
         >>> light = pv.Light()
-        >>> light.transform_matrix = [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0],
-        ...                           [0, 0, 0, 1]]
+        >>> light.transform_matrix = [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
         >>> shallow_copied = light.copy(deep=False)
         >>> shallow_copied == light
         True

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -196,7 +196,10 @@ class _BaseMapper(_vtk.vtkAbstractMapper):
         >>> dataset[1].point_data['data'] = dataset[1].points[:, 2]
         >>> pl = pv.Plotter()
         >>> actor, mapper = pl.add_composite(
-        ...     dataset, show_scalar_bar=False, n_colors=3, cmap='bwr',
+        ...     dataset,
+        ...     show_scalar_bar=False,
+        ...     n_colors=3,
+        ...     cmap='bwr',
         ... )
         >>> mapper.interpolate_before_map = False
         >>> pl.show()
@@ -205,7 +208,10 @@ class _BaseMapper(_vtk.vtkAbstractMapper):
 
         >>> pl = pv.Plotter()
         >>> actor, mapper = pl.add_composite(
-        ...     dataset, show_scalar_bar=False, n_colors=3, cmap='bwr',
+        ...     dataset,
+        ...     show_scalar_bar=False,
+        ...     n_colors=3,
+        ...     cmap='bwr',
         ... )
         >>> mapper.interpolate_before_map = True
         >>> pl.show()

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -1150,9 +1150,11 @@ class PickingHelper:
         >>> actor, mapper = pl.add_composite(multiblock)
         >>> def turn_blue(index, dataset):
         ...     mapper.block_attr[index].color = 'blue'
+        ...
         >>> pl.enable_block_picking(callback=turn_blue, side='left')
         >>> def clear_color(index, dataset):
         ...     mapper.block_attr[index].color = None
+        ...
         >>> pl.enable_block_picking(callback=clear_color, side='right')
         >>> pl.show()
 

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -504,9 +504,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> import pyvista
         >>> from pyvista import examples
         >>> mesh = examples.load_uniform()
-        >>> pl = pyvista.Plotter(shape=(1,2))
+        >>> pl = pyvista.Plotter(shape=(1, 2))
         >>> _ = pl.add_mesh(mesh, scalars='Spatial Point Data', show_edges=True)
-        >>> pl.subplot(0,1)
+        >>> pl.subplot(0, 1)
         >>> _ = pl.add_mesh(mesh, scalars='Spatial Cell Data', show_edges=True)
         >>> pl.export_html('pyvista.html')  # doctest:+SKIP
 
@@ -608,8 +608,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> sphere = pyvista.Sphere(radius=0.02)
         >>> pc = pdata.glyph(scale=False, geom=sphere, orient=False)
         >>> pl = pyvista.Plotter()
-        >>> _ = pl.add_mesh(pc, cmap='reds', smooth_shading=True,
-        ...                 show_scalar_bar=False)
+        >>> _ = pl.add_mesh(pc, cmap='reds', smooth_shading=True, show_scalar_bar=False)
         >>> pl.export_gltf('balls.gltf')  # doctest:+SKIP
         >>> pl.show()
 
@@ -1644,8 +1643,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> _ = pl.add_mesh(pv.Cube())
         >>> with pl.window_size_context((400, 400)):
         ...     pl.screenshot('/tmp/small_screenshot.png')  # doctest:+SKIP
+        ...
         >>> with pl.window_size_context((1000, 1000)):
         ...     pl.screenshot('/tmp/big_screenshot.png')  # doctest:+SKIP
+        ...
 
         """
         # No op if not set
@@ -3080,8 +3081,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> sphere = pv.Sphere()
         >>> sphere['Data'] = sphere.points[:, 2]
         >>> plotter = pv.Plotter()
-        >>> _ = plotter.add_mesh(sphere,
-        ...                      scalar_bar_args={'title': 'Z Position'})
+        >>> _ = plotter.add_mesh(sphere, scalar_bar_args={'title': 'Z Position'})
         >>> plotter.show()
 
         Plot using RGB on a single cell.  Note that since the number of
@@ -3090,17 +3090,15 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         >>> import pyvista as pv
         >>> import numpy as np
-        >>> vertices = np.array([[0, 0, 0], [1, 0, 0], [.5, .667, 0], [0.5, .33, 0.667]])
+        >>> vertices = np.array([[0, 0, 0], [1, 0, 0], [0.5, 0.667, 0], [0.5, 0.33, 0.667]])
         >>> faces = np.hstack([[3, 0, 1, 2], [3, 0, 3, 2], [3, 0, 1, 3], [3, 1, 2, 3]])
         >>> mesh = pv.PolyData(vertices, faces)
-        >>> mesh.cell_data['colors'] = [[255, 255, 255],
-        ...                               [0, 255, 0],
-        ...                               [0, 0, 255],
-        ...                               [255, 0, 0]]
+        >>> mesh.cell_data['colors'] = [[255, 255, 255], [0, 255, 0], [0, 0, 255], [255, 0, 0]]
         >>> plotter = pv.Plotter()
-        >>> _ = plotter.add_mesh(mesh, scalars='colors', lighting=False,
-        ...                      rgb=True, preference='cell')
-        >>> plotter.camera_position='xy'
+        >>> _ = plotter.add_mesh(
+        ...     mesh, scalars='colors', lighting=False, rgb=True, preference='cell'
+        ... )
+        >>> plotter.camera_position = 'xy'
         >>> plotter.show()
 
         Note how this varies from ``preference=='point'``.  This is
@@ -3109,16 +3107,16 @@ class BasePlotter(PickingHelper, WidgetHelper):
         colored.
 
         >>> plotter = pv.Plotter()
-        >>> _ = plotter.add_mesh(mesh, scalars='colors', lighting=False,
-        ...                      rgb=True, preference='point')
-        >>> plotter.camera_position='xy'
+        >>> _ = plotter.add_mesh(
+        ...     mesh, scalars='colors', lighting=False, rgb=True, preference='point'
+        ... )
+        >>> plotter.camera_position = 'xy'
         >>> plotter.show()
 
         Plot a plane with a constant color and vary its opacity by point.
 
         >>> plane = pv.Plane()
-        >>> plane.plot(color='b', opacity=np.linspace(0, 1, plane.n_points),
-        ...            show_edges=True)
+        >>> plane.plot(color='b', opacity=np.linspace(0, 1, plane.n_points), show_edges=True)
 
         Plot the points of a sphere with gaussian smoothing while coloring by z
         position.
@@ -4656,8 +4654,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
         --------
         >>> import pyvista
         >>> pl = pyvista.Plotter()
-        >>> actor = pl.add_text('Sample Text', position='upper_right', color='blue',
-        ...                     shadow=True, font_size=26)
+        >>> actor = pl.add_text(
+        ...     'Sample Text', position='upper_right', color='blue', shadow=True, font_size=26
+        ... )
         >>> pl.show()
 
         """
@@ -5128,14 +5127,19 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> import numpy as np
         >>> import pyvista
         >>> pl = pyvista.Plotter()
-        >>> points = np.array([[0.0, 0.0, 0.0],
-        ...                    [1.0, 1.0, 0.0],
-        ...                    [2.0, 0.0, 0.0]])
+        >>> points = np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 0.0], [2.0, 0.0, 0.0]])
         >>> labels = ['Point A', 'Point B', 'Point C']
-        >>> actor = pl.add_point_labels(points, labels, italic=True, font_size=20,
-        ...                             point_color='red', point_size=20,
-        ...                             render_points_as_spheres=True,
-        ...                             always_visible=True, shadow=True)
+        >>> actor = pl.add_point_labels(
+        ...     points,
+        ...     labels,
+        ...     italic=True,
+        ...     font_size=20,
+        ...     point_color='red',
+        ...     point_size=20,
+        ...     render_points_as_spheres=True,
+        ...     always_visible=True,
+        ...     shadow=True,
+        ... )
         >>> pl.camera_position = 'xy'
         >>> pl.show()
 
@@ -5329,8 +5333,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> import pyvista
         >>> points = np.random.random((10, 3))
         >>> pl = pyvista.Plotter()
-        >>> actor = pl.add_points(points, render_points_as_spheres=True,
-        ...                       point_size=100.0)
+        >>> actor = pl.add_points(points, render_points_as_spheres=True, point_size=100.0)
         >>> pl.show()
 
         Plot using the ``'points_gaussian'`` style
@@ -5638,8 +5641,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> plotter = pyvista.Plotter()
         >>> _ = plotter.add_mesh(pyvista.Sphere())
         >>> viewup = [0, 0, 1]
-        >>> orbit = plotter.generate_orbital_path(factor=2.0, n_points=50,
-        ...                                       shift=0.0, viewup=viewup)
+        >>> orbit = plotter.generate_orbital_path(factor=2.0, n_points=50, shift=0.0, viewup=viewup)
 
         See :ref:`orbiting_example` for a full example using this method.
 
@@ -5723,10 +5725,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> _ = plotter.add_mesh(examples.load_globe(), smooth_shading=True)
         >>> plotter.open_gif(filename)
         >>> viewup = [0, 0, 1]
-        >>> orbit = plotter.generate_orbital_path(factor=2.0, n_points=24,
-        ...                                       shift=0.0, viewup=viewup)
-        >>> plotter.orbit_on_path(orbit, write_frames=True, viewup=viewup,
-        ...                       step=0.02)
+        >>> orbit = plotter.generate_orbital_path(factor=2.0, n_points=24, shift=0.0, viewup=viewup)
+        >>> plotter.orbit_on_path(orbit, write_frames=True, viewup=viewup, step=0.02)
 
         See :ref:`orbiting_example` for a full example using this method.
 
@@ -6420,7 +6420,7 @@ class Plotter(BasePlotter):
 
         >>> pl = pv.Plotter()
         >>> _ = pl.add_mesh(pv.Sphere())
-        >>> pl.show(return_cpos=True)   # doctest:+SKIP
+        >>> pl.show(return_cpos=True)  # doctest:+SKIP
         [(2.223005211686484, -0.3126909484828709, 2.4686209867735065),
         (0.0, 0.0, 0.0),
         (-0.6839951597283509, -0.47207319712073137, 0.5561452310578585)]
@@ -6619,8 +6619,7 @@ class Plotter(BasePlotter):
         >>> import pyvista
         >>> pl = pyvista.Plotter()
         >>> pl.background_color = 'grey'
-        >>> actor = pl.add_title('Plot Title', font='courier', color='k',
-        ...                      font_size=40)
+        >>> actor = pl.add_title('Plot Title', font='courier', color='k', font_size=40)
         >>> pl.show()
 
         """

--- a/pyvista/plotting/prop3d.py
+++ b/pyvista/plotting/prop3d.py
@@ -84,7 +84,11 @@ class Prop3D(_vtk.vtkProp3D):
         >>> pl = pv.Plotter()
         >>> _ = pl.add_mesh(mesh, color='b')
         >>> actor = pl.add_mesh(
-        ...     mesh, color='r', style='wireframe', line_width=5, lighting=False,
+        ...     mesh,
+        ...     color='r',
+        ...     style='wireframe',
+        ...     line_width=5,
+        ...     lighting=False,
         ... )
         >>> actor.rotate_x(45)
         >>> pl.show_axes()
@@ -111,7 +115,11 @@ class Prop3D(_vtk.vtkProp3D):
         >>> pl = pv.Plotter()
         >>> _ = pl.add_mesh(mesh, color='b')
         >>> actor = pl.add_mesh(
-        ...     mesh, color='r', style='wireframe', line_width=5, lighting=False,
+        ...     mesh,
+        ...     color='r',
+        ...     style='wireframe',
+        ...     line_width=5,
+        ...     lighting=False,
         ... )
         >>> actor.rotate_y(45)
         >>> pl.show_axes()
@@ -138,7 +146,11 @@ class Prop3D(_vtk.vtkProp3D):
         >>> pl = pv.Plotter()
         >>> _ = pl.add_mesh(mesh, color='b')
         >>> actor = pl.add_mesh(
-        ...     mesh, color='r', style='wireframe', line_width=5, lighting=False,
+        ...     mesh,
+        ...     color='r',
+        ...     style='wireframe',
+        ...     line_width=5,
+        ...     lighting=False,
         ... )
         >>> actor.rotate_z(45)
         >>> pl.show_axes()
@@ -180,7 +192,11 @@ class Prop3D(_vtk.vtkProp3D):
         >>> pl = pv.Plotter()
         >>> _ = pl.add_mesh(mesh, color='b')
         >>> actor = pl.add_mesh(
-        ...     mesh, color='r', style='wireframe', line_width=5, lighting=False,
+        ...     mesh,
+        ...     color='r',
+        ...     style='wireframe',
+        ...     line_width=5,
+        ...     lighting=False,
         ... )
         >>> actor.position = (0, 0, 1)
         >>> actor.orientation = (45, 0, 0)

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -632,8 +632,7 @@ class RenderWindowInteractor:
         >>> _ = plotter.add_mesh(pv.Cube(center=(1, 0, 0)))
         >>> _ = plotter.add_mesh(pv.Cube(center=(0, 1, 0)))
         >>> plotter.show_axes()
-        >>> plotter.enable_terrain_style(mouse_wheel_zooms=True,
-        ...                              shift_pans=True)
+        >>> plotter.enable_terrain_style(mouse_wheel_zooms=True, shift_pans=True)
         >>> plotter.show()  # doctest:+SKIP
 
         """

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -289,9 +289,9 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         >>> import pyvista as pv
         >>> pl = pv.Plotter()
         >>> pl.renderer.set_color_cycler(['red', 'green', 'blue'])
-        >>> _ = pl.add_mesh(pv.Cone(center=(0, 0, 0)))      # red
-        >>> _ = pl.add_mesh(pv.Cube(center=(1, 0, 0)))      # green
-        >>> _ = pl.add_mesh(pv.Sphere(center=(1, 1, 0)))    # blue
+        >>> _ = pl.add_mesh(pv.Cone(center=(0, 0, 0)))  # red
+        >>> _ = pl.add_mesh(pv.Cube(center=(1, 0, 0)))  # green
+        >>> _ = pl.add_mesh(pv.Sphere(center=(1, 1, 0)))  # blue
         >>> _ = pl.add_mesh(pv.Cylinder(center=(0, 1, 0)))  # red again
         >>> pl.show()
 
@@ -1085,7 +1085,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         ...     shaft_length=0.7,
         ...     tip_length=0.3,
         ...     ambient=0.5,
-        ...     label_size=(0.4, 0.16)
+        ...     label_size=(0.4, 0.16),
         ... )
         >>> pl.show()
 
@@ -2000,7 +2000,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         --------
         >>> import pyvista
         >>> pl = pyvista.Plotter()
-        >>> pl.renderer.lights   # doctest:+SKIP
+        >>> pl.renderer.lights  # doctest:+SKIP
         [<Light (Headlight) at 0x7f1dd8155820>,
          <Light (Camera Light) at 0x7f1dd8155760>,
          <Light (Camera Light) at 0x7f1dd8155340>,
@@ -2722,14 +2722,9 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         >>> pl.background_color = "w"
         >>> for i in range(5):
         ...     mesh = pv.Sphere(center=(-i * 4, 0, 0))
-        ...     color = [0, 255 - i*20, 30 + i*50]
-        ...     _ = pl.add_mesh(
-        ...         mesh,
-        ...         show_edges=False,
-        ...         pbr=True,
-        ...         metallic=1.0,
-        ...         color=color
-        ...     )
+        ...     color = [0, 255 - i * 20, 30 + i * 50]
+        ...     _ = pl.add_mesh(mesh, show_edges=False, pbr=True, metallic=1.0, color=color)
+        ...
         >>> pl.camera.zoom(1.8)
         >>> pl.camera_position = [
         ...     (4.74, 0.959, 0.525),
@@ -3415,7 +3410,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         >>> _ = plotter.add_ruler(
         ...     pointa=[cone.bounds[0], cone.bounds[2] - 0.1, 0.0],
         ...     pointb=[cone.bounds[1], cone.bounds[2] - 0.1, 0.0],
-        ...     title="X Distance"
+        ...     title="X Distance",
         ... )
 
         Measure y direction of cone and place ruler slightly to left.
@@ -3426,7 +3421,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         ...     pointa=[cone.bounds[0] - 0.1, cone.bounds[3], 0.0],
         ...     pointb=[cone.bounds[0] - 0.1, cone.bounds[2], 0.0],
         ...     flip_range=True,
-        ...     title="Y Distance"
+        ...     title="Y Distance",
         ... )
         >>> plotter.enable_parallel_projection()
         >>> plotter.view_xy()

--- a/pyvista/plotting/renderers.py
+++ b/pyvista/plotting/renderers.py
@@ -522,9 +522,9 @@ class Renderers:
         >>> import pyvista as pv
         >>> pl = pv.Plotter()
         >>> pl.set_color_cycler(['red', 'green', 'blue'])
-        >>> _ = pl.add_mesh(pv.Cone(center=(0, 0, 0)))      # red
-        >>> _ = pl.add_mesh(pv.Cube(center=(1, 0, 0)))      # green
-        >>> _ = pl.add_mesh(pv.Sphere(center=(1, 1, 0)))    # blue
+        >>> _ = pl.add_mesh(pv.Cone(center=(0, 0, 0)))  # red
+        >>> _ = pl.add_mesh(pv.Cube(center=(1, 0, 0)))  # green
+        >>> _ = pl.add_mesh(pv.Sphere(center=(1, 1, 0)))  # blue
         >>> _ = pl.add_mesh(pv.Cylinder(center=(0, 1, 0)))  # red again
         >>> pl.show()
 

--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -315,10 +315,15 @@ class ScalarBars:
         >>> sphere['Data'] = sphere.points[:, 2]
         >>> plotter = pv.Plotter()
         >>> _ = plotter.add_mesh(sphere, show_scalar_bar=False)
-        >>> _ = plotter.add_scalar_bar('Data', interactive=True, vertical=False,
-        ...                            title_font_size=35,
-        ...                            label_font_size=30,
-        ...                            outline=True, fmt='%10.5f')
+        >>> _ = plotter.add_scalar_bar(
+        ...     'Data',
+        ...     interactive=True,
+        ...     vertical=False,
+        ...     title_font_size=35,
+        ...     label_font_size=30,
+        ...     outline=True,
+        ...     fmt='%10.5f',
+        ... )
         >>> plotter.show()
 
         """

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -331,12 +331,19 @@ def create_axes_orientation_box(
 
     >>> import pyvista
     >>> actor = pyvista.create_axes_orientation_box(
-    ...    line_width=1, text_scale=0.53,
-    ...    edge_color='black', x_color='k',
-    ...    y_color=None, z_color=None,
-    ...    xlabel='X', ylabel='Y', zlabel='Z',
-    ...    color_box=False,
-    ...    labels_off=False, opacity=1.0)
+    ...     line_width=1,
+    ...     text_scale=0.53,
+    ...     edge_color='black',
+    ...     x_color='k',
+    ...     y_color=None,
+    ...     z_color=None,
+    ...     xlabel='X',
+    ...     ylabel='Y',
+    ...     zlabel='Z',
+    ...     color_box=False,
+    ...     labels_off=False,
+    ...     opacity=1.0,
+    ... )
     >>> pl = pyvista.Plotter()
     >>> _ = pl.add_actor(actor)
     >>> pl.show()
@@ -490,7 +497,7 @@ def opacity_transfer_function(mapping, n_colors, interpolate=True, kind='quadrat
     >>> # Fetch the `sigmoid` mapping between 0 and 255
     >>> tf = pv.opacity_transfer_function("sigmoid", 256)
     >>> # Fetch the `geom_r` mapping between 0 and 1
-    >>> tf = pv.opacity_transfer_function("geom_r", 256).astype(float) / 255.
+    >>> tf = pv.opacity_transfer_function("geom_r", 256).astype(float) / 255.0
     >>> # Interpolate a user defined opacity mapping
     >>> opacity = [0, 0.2, 0.9, 0.6, 0.3]
     >>> tf = pv.opacity_transfer_function(opacity, 256)

--- a/pyvista/plotting/volume.py
+++ b/pyvista/plotting/volume.py
@@ -29,7 +29,7 @@ class Volume(Prop3D, _vtk.vtkVolume):
 
         >>> import pyvista as pv
         >>> vol = pv.UniformGrid(dimensions=(10, 10, 10))
-        >>> vol['scalars'] = 255 - vol.z*25
+        >>> vol['scalars'] = 255 - vol.z * 25
         >>> pl = pv.Plotter()
         >>> actor = pl.add_volume(vol)
         >>> actor.mapper.bounds
@@ -51,7 +51,7 @@ class Volume(Prop3D, _vtk.vtkVolume):
 
         >>> import pyvista as pv
         >>> vol = pv.UniformGrid(dimensions=(10, 10, 10))
-        >>> vol['scalars'] = 255 - vol.z*25
+        >>> vol['scalars'] = 255 - vol.z * 25
         >>> pl = pv.Plotter()
         >>> actor = pl.add_volume(vol)
         >>> actor.prop.GetShade()

--- a/pyvista/plotting/volume_property.py
+++ b/pyvista/plotting/volume_property.py
@@ -64,7 +64,7 @@ class VolumeProperty(_vtk.vtkVolumeProperty):
     >>> noise = pv.perlin_noise(1, (1, 3, 5), (0, 0, 0))
     >>> grid = pv.sample_function(noise, [0, 3.0, -0, 1.0, 0, 1.0], dim=(40, 40, 40))
     >>> grid['scalars'] -= grid['scalars'].min()
-    >>> grid['scalars']*= 255/grid['scalars'].max()
+    >>> grid['scalars'] *= 255 / grid['scalars'].max()
     >>> pl = pv.Plotter()
     >>> actor = pl.add_volume(grid, show_scalar_bar=False)
     >>> lut = pv.LookupTable(cmap='bwr')
@@ -124,7 +124,7 @@ class VolumeProperty(_vtk.vtkVolumeProperty):
         >>> noise = pv.perlin_noise(1, (1, 3, 5), (0, 0, 0))
         >>> grid = pv.sample_function(noise, [0, 3.0, -0, 1.0, 0, 1.0], dim=(40, 40, 40))
         >>> grid['scalars'] -= grid['scalars'].min()
-        >>> grid['scalars']*= 255/grid['scalars'].max()
+        >>> grid['scalars'] *= 255 / grid['scalars'].max()
         >>> pl = pv.Plotter()
         >>> actor = pl.add_volume(grid, show_scalar_bar=False)
         >>> lut = pv.LookupTable(cmap='bwr')
@@ -152,10 +152,10 @@ class VolumeProperty(_vtk.vtkVolumeProperty):
         >>> import numpy as np
         >>> import pyvista as pv
         >>> n = 21
-        >>> c = -(n-1)/2
+        >>> c = -(n - 1) / 2
         >>> vol = pv.UniformGrid(dimensions=(n, n, n), origin=(c, c, c))
         >>> scalars = np.linalg.norm(vol.points, axis=1)
-        >>> scalars *= 255/scalars.max()
+        >>> scalars *= 255 / scalars.max()
         >>> vol['scalars'] = scalars
 
         Demonstrate nearest (default) interpolation.
@@ -165,7 +165,7 @@ class VolumeProperty(_vtk.vtkVolumeProperty):
         ...     vol,
         ...     show_scalar_bar=False,
         ...     opacity=[0.3, 0.0, 0.05, 0.0, 0.0, 0.0, 1.0, 0.0],
-        ...     cmap='plasma'
+        ...     cmap='plasma',
         ... )
         >>> actor.prop.interpolation_type = 'nearest'
         >>> pl.show()
@@ -177,7 +177,7 @@ class VolumeProperty(_vtk.vtkVolumeProperty):
         ...     vol,
         ...     show_scalar_bar=False,
         ...     opacity=[0.3, 0.0, 0.05, 0.0, 0.0, 0.0, 1.0, 0.0],
-        ...     cmap='plasma'
+        ...     cmap='plasma',
         ... )
         >>> actor.prop.interpolation_type = 'linear'
         >>> pl.show()

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1365,6 +1365,7 @@ class WidgetHelper:
         ...     res = int(value)
         ...     sphere = pv.Sphere(phi_resolution=res, theta_resolution=res)
         ...     pl.add_mesh(sphere, name="sphere", show_edges=True)
+        ...
         >>> slider = pl.add_slider_widget(
         ...     create_mesh,
         ...     [5, 100],
@@ -2230,6 +2231,7 @@ class WidgetHelper:
         >>> actor = p.add_mesh(mesh)
         >>> def toggle_vis(flag):
         ...     actor.SetVisibility(flag)
+        ...
         >>> _ = p.add_checkbox_button_widget(toggle_vis, value=True)
         >>> p.show()
 

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -24,7 +24,6 @@ pyvista.
 >>> my_theme.font.size = 20
 >>> my_theme.font.title_size = 40
 >>> my_theme.cmap = 'jet'
-...
 >>> pv.global_theme.load_theme(my_theme)
 >>> pv.global_theme.font.size
 20
@@ -1874,8 +1873,7 @@ class DefaultTheme(_ThemeConfig):
         Set both the position and view of the camera.
 
         >>> import pyvista as pv
-        >>> pv.global_theme.camera = {'position': [1, 1, 1],
-        ...                                'viewup': [0, 0, 1]}
+        >>> pv.global_theme.camera = {'position': [1, 1, 1], 'viewup': [0, 0, 1]}
 
         Set the default position of the camera.
 
@@ -2088,9 +2086,9 @@ class DefaultTheme(_ThemeConfig):
         >>> pv.global_theme.color_cycler = ['red', 'green', 'blue']
 
         >>> pl = pv.Plotter()
-        >>> _ = pl.add_mesh(pv.Cone(center=(0, 0, 0)))      # red
-        >>> _ = pl.add_mesh(pv.Cube(center=(1, 0, 0)))      # green
-        >>> _ = pl.add_mesh(pv.Sphere(center=(1, 1, 0)))    # blue
+        >>> _ = pl.add_mesh(pv.Cone(center=(0, 0, 0)))  # red
+        >>> _ = pl.add_mesh(pv.Cube(center=(1, 0, 0)))  # green
+        >>> _ = pl.add_mesh(pv.Sphere(center=(1, 1, 0)))  # blue
         >>> _ = pl.add_mesh(pv.Cylinder(center=(0, 1, 0)))  # red again
         >>> pl.show()  # doctest: +SKIP
 
@@ -2774,7 +2772,6 @@ class DefaultTheme(_ThemeConfig):
         >>> my_theme.font.size = 20
         >>> my_theme.font.title_size = 40
         >>> my_theme.cmap = 'jet'
-        ...
         >>> pv.global_theme.load_theme(my_theme)
         >>> pv.global_theme.font.size
         20

--- a/pyvista/trame/jupyter.py
+++ b/pyvista/trame/jupyter.py
@@ -259,8 +259,10 @@ def show_trame(
 
             mesh = pv.Wavelet()
 
+
             def handler(viewer, src, **kwargs):
                 return IFrame(src, '75%', '500px')
+
 
             p = pv.Plotter(notebook=True)
             _ = p.add_mesh(mesh)

--- a/pyvista/utilities/cells.py
+++ b/pyvista/utilities/cells.py
@@ -140,7 +140,9 @@ def create_mixed_cells(mixed_cell_dict, nr_points=None):
     >>> import numpy as np
     >>> import vtk
     >>> from pyvista.utilities.cells import create_mixed_cells
-    >>> cell_types, cell_arr = create_mixed_cells({vtk.VTK_TRIANGLE: np.array([[0, 1, 2], [3, 4, 5]])})
+    >>> cell_types, cell_arr = create_mixed_cells(
+    ...     {vtk.VTK_TRIANGLE: np.array([[0, 1, 2], [3, 4, 5]])}
+    ... )
     """
     from .cell_type_helper import enum_cell_type_nr_points_map
 

--- a/pyvista/utilities/common.py
+++ b/pyvista/utilities/common.py
@@ -158,8 +158,7 @@ def sample_function(
 
     >>> import pyvista
     >>> noise = pyvista.perlin_noise(0.1, (1, 1, 1), (0, 0, 0))
-    >>> grid = pyvista.sample_function(noise, [0, 3.0, -0, 1.0, 0, 1.0],
-    ...                                dim=(60, 20, 20))
+    >>> grid = pyvista.sample_function(noise, [0, 3.0, -0, 1.0, 0, 1.0], dim=(60, 20, 20))
     >>> grid.plot(cmap='gist_earth_r', show_scalar_bar=False, show_edges=True)
 
     Sample Perlin noise in 2D and plot it.

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -57,6 +57,7 @@ class VtkErrorCatcher:
     >>> import pyvista
     >>> with pyvista.VtkErrorCatcher() as error_catcher:
     ...     sphere = pyvista.Sphere()
+    ...
     """
 
     def __init__(self, raise_errors=False, send_to_logging=True):

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -99,8 +99,7 @@ def Cylinder(
     --------
     >>> import pyvista
     >>> import numpy as np
-    >>> cylinder = pyvista.Cylinder(center=[1, 2, 3], direction=[1, 1, 1],
-    ...                             radius=1, height=2)
+    >>> cylinder = pyvista.Cylinder(center=[1, 2, 3], direction=[1, 1, 1], radius=1, height=2)
     >>> cylinder.plot(show_edges=True, line_width=5, cpos='xy')
     """
     cylinderSource = _vtk.vtkCylinderSource()
@@ -952,9 +951,15 @@ def Wavelet(
     Examples
     --------
     >>> import pyvista
-    >>> wavelet = pyvista.Wavelet(extent=(0, 50, 0, 50, 0, 10), x_freq=20,
-    ...                           y_freq=10, z_freq=1, x_mag=100, y_mag=100,
-    ...                           z_mag=1000)
+    >>> wavelet = pyvista.Wavelet(
+    ...     extent=(0, 50, 0, 50, 0, 10),
+    ...     x_freq=20,
+    ...     y_freq=10,
+    ...     z_freq=1,
+    ...     x_mag=100,
+    ...     y_mag=100,
+    ...     z_mag=1000,
+    ... )
     >>> wavelet.plot(show_scalar_bar=False)
 
     Extract lower valued cells of the wavelet and create a surface from it.
@@ -1412,9 +1417,9 @@ def Superquadric(
     Examples
     --------
     >>> import pyvista
-    >>> superquadric = pyvista.Superquadric(scale=(3., 1., 0.5),
-    ...                                     phi_roundness=0.1,
-    ...                                     theta_roundness=0.5)
+    >>> superquadric = pyvista.Superquadric(
+    ...     scale=(3.0, 1.0, 0.5), phi_roundness=0.1, theta_roundness=0.5
+    ... )
     >>> superquadric.plot(show_edges=True)
 
     """

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -664,11 +664,22 @@ def make_tri_mesh(points, faces):
 
     >>> import numpy as np
     >>> import pyvista
-    >>> points = np.array([[0, 0, 0], [0.5, 0, 0], [1, 0, 0], [0, 0.5, 0],
-    ...                    [0.5, 0.5, 0], [1, 0.5, 0], [0, 1, 0], [0.5, 1, 0],
-    ...                    [1, 1, 0]])
-    >>> faces = np.array([[0, 1, 4], [4, 7, 6], [2, 5, 4], [4, 5, 8],
-    ...                   [0, 4, 3], [3, 4, 6], [1, 2, 4], [4, 8, 7]])
+    >>> points = np.array(
+    ...     [
+    ...         [0, 0, 0],
+    ...         [0.5, 0, 0],
+    ...         [1, 0, 0],
+    ...         [0, 0.5, 0],
+    ...         [0.5, 0.5, 0],
+    ...         [1, 0.5, 0],
+    ...         [0, 1, 0],
+    ...         [0.5, 1, 0],
+    ...         [1, 1, 0],
+    ...     ]
+    ... )
+    >>> faces = np.array(
+    ...     [[0, 1, 4], [4, 7, 6], [2, 5, 4], [4, 5, 8], [0, 4, 3], [3, 4, 6], [1, 2, 4], [4, 8, 7]]
+    ... )
     >>> tri_mesh = pyvista.make_tri_mesh(points, faces)
     >>> tri_mesh.plot(show_edges=True, line_width=5)
 
@@ -708,11 +719,11 @@ def vector_poly_data(orig, vec):
 
     >>> import pyvista
     >>> import numpy as np
-    >>> x, y = np.meshgrid(np.linspace(-5,5,10),np.linspace(-5,5,10))
+    >>> x, y = np.meshgrid(np.linspace(-5, 5, 10), np.linspace(-5, 5, 10))
     >>> points = np.vstack((x.ravel(), y.ravel(), np.zeros(x.size))).T
-    >>> u = x/np.sqrt(x**2 + y**2)
-    >>> v = y/np.sqrt(x**2 + y**2)
-    >>> vectors = np.vstack((u.ravel()**3, v.ravel()**3, np.zeros(u.size))).T
+    >>> u = x / np.sqrt(x**2 + y**2)
+    >>> v = y / np.sqrt(x**2 + y**2)
+    >>> vectors = np.vstack((u.ravel() ** 3, v.ravel() ** 3, np.zeros(u.size))).T
     >>> pdata = pyvista.vector_poly_data(points, vectors)
     >>> pdata.point_data.keys()
     ['vectors', 'mag']
@@ -1139,8 +1150,7 @@ def fit_plane_to_points(points, return_meta=False):
 
     >>> pl = pyvista.Plotter()
     >>> _ = pl.add_mesh(plane, color='tan', style='wireframe', line_width=4)
-    >>> _ = pl.add_points(cloud, render_points_as_spheres=True,
-    ...                   color='r', point_size=30)
+    >>> _ = pl.add_points(cloud, render_points_as_spheres=True, color='r', point_size=30)
     >>> pl.show()
 
     """

--- a/pyvista/utilities/parametric_objects.py
+++ b/pyvista/utilities/parametric_objects.py
@@ -92,7 +92,7 @@ def KochanekSpline(points, tension=None, bias=None, continuity=None, n_points=No
     >>> import pyvista as pv
     >>> theta = np.linspace(-4 * np.pi, 4 * np.pi, 100)
     >>> z = np.linspace(-2, 2, 100)
-    >>> r = z ** 2 + 1
+    >>> r = z**2 + 1
     >>> x = r * np.sin(theta)
     >>> y = r * np.cos(theta)
     >>> points = np.column_stack((x, y, z))

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -156,7 +156,7 @@ def get_reader(filename, force_ext=None):
     >>> reader  # doctest: +ELLIPSIS
     XMLPolyDataReader('.../Human.vtp')
     >>> mesh = reader.read()
-    >>> mesh # doctest: +ELLIPSIS
+    >>> mesh  # doctest: +ELLIPSIS
     PolyData ...
     >>> mesh.plot(color='tan')
 
@@ -663,8 +663,7 @@ class XMLRectilinearGridReader(BaseReader, PointCellDataSelection):
     >>> reader = pyvista.get_reader(filename)
     >>> mesh = reader.read()
     >>> sliced_mesh = mesh.slice('y')
-    >>> sliced_mesh.plot(scalars='Void Volume Fraction', cpos='xz',
-    ...                  show_scalar_bar=False)
+    >>> sliced_mesh.plot(scalars='Void Volume Fraction', cpos='xz', show_scalar_bar=False)
 
     """
 
@@ -689,8 +688,7 @@ class XMLUnstructuredGridReader(BaseReader, PointCellDataSelection):
     'notch_disp.vtu'
     >>> reader = pyvista.get_reader(filename)
     >>> mesh = reader.read()
-    >>> mesh.plot(scalars="Nodal Displacement", component=0,
-    ...           cpos='xy', show_scalar_bar=False)
+    >>> mesh.plot(scalars="Nodal Displacement", component=0, cpos='xy', show_scalar_bar=False)
 
     """
 
@@ -716,8 +714,7 @@ class XMLPolyDataReader(BaseReader, PointCellDataSelection):
     >>> reader = pyvista.get_reader(filename)
     >>> mesh = reader.read()
     >>> mesh.plot(
-    ...    cpos=((12, 3.5, -4.5), (4.5, 1.6, 0), (0, 1, 0.3)),
-    ...    clim=[0, 100], show_scalar_bar=False
+    ...     cpos=((12, 3.5, -4.5), (4.5, 1.6, 0), (0, 1, 0.3)), clim=[0, 100], show_scalar_bar=False
     ... )
 
     """
@@ -765,8 +762,14 @@ class EnSightReader(BaseReader, PointCellDataSelection, TimeReader):
     'cylinder_Re35.case'
     >>> reader = pyvista.get_reader(filename)
     >>> mesh = reader.read()
-    >>> mesh.plot(scalars="velocity", component=1, clim=[-20, 20],
-    ...           cpos='xy', cmap='RdBu', show_scalar_bar=False)
+    >>> mesh.plot(
+    ...     scalars="velocity",
+    ...     component=1,
+    ...     clim=[-20, 20],
+    ...     cpos='xy',
+    ...     cmap='RdBu',
+    ...     show_scalar_bar=False,
+    ... )
 
     """
 
@@ -1083,7 +1086,7 @@ class OpenFOAMReader(BaseReader, PointCellDataSelection, TimeReader):
         >>> from pyvista import examples
         >>> filename = examples.download_cavity(load=False)
         >>> reader = pyvista.OpenFOAMReader(filename)
-        >>> reader.all_patch_arrays_status  #doctest: +NORMALIZE_WHITESPACE
+        >>> reader.all_patch_arrays_status  # doctest: +NORMALIZE_WHITESPACE
         {'internalMesh': True, 'patch/movingWall': True, 'patch/fixedWalls': True,
          'patch/frontAndBack': True}
 
@@ -1422,10 +1425,12 @@ class MultiBlockPlot3DReader(BaseReader):
         --------
         >>> import pyvista
         >>> from pyvista import examples
-        >>> filename  = examples.download_file('multi-bin.xyz')
+        >>> filename = examples.download_file('multi-bin.xyz')
         >>> reader = pyvista.reader.MultiBlockPlot3DReader(filename)
         >>> reader.add_function(112)  # add a function by its integer value
-        >>> reader.add_function(reader.PRESSURE_COEFFICIENT)  # add a function by enumeration via class variable alias
+        >>> reader.add_function(
+        ...     reader.PRESSURE_COEFFICIENT
+        ... )  # add a function by enumeration via class variable alias
 
         """
         if isinstance(value, enum.Enum):

--- a/pyvista/utilities/transformations.py
+++ b/pyvista/utilities/transformations.py
@@ -66,11 +66,13 @@ def axis_angle_rotation(axis, angle, point=None, deg=True):
 
     Check that the transformation cycles the cube's three corners.
 
-    >>> corners = np.array([
-    ...     [1, 0, 0],
-    ...     [0, 1, 0],
-    ...     [0, 0, 1],
-    ... ])
+    >>> corners = np.array(
+    ...     [
+    ...         [1, 0, 0],
+    ...         [0, 1, 0],
+    ...         [0, 0, 1],
+    ...     ]
+    ... )
     >>> rotated = transformations.apply_transformation_to_points(trans, corners)
     >>> np.allclose(rotated, corners[[1, 2, 0], :])
     True
@@ -166,16 +168,18 @@ def reflection(normal, point=None):
     Check that the reflection transforms corners of a cube among one
     another.
 
-    >>> verts = np.array([
-    ...     [ 1, -1,  1],
-    ...     [-1, -1,  1],
-    ...     [-1, -1, -1],
-    ...     [-1, -1,  1],
-    ...     [ 1,  1,  1],
-    ...     [-1,  1,  1],
-    ...     [-1,  1, -1],
-    ...     [-1,  1,  1],
-    ... ])
+    >>> verts = np.array(
+    ...     [
+    ...         [1, -1, 1],
+    ...         [-1, -1, 1],
+    ...         [-1, -1, -1],
+    ...         [-1, -1, 1],
+    ...         [1, 1, 1],
+    ...         [-1, 1, 1],
+    ...         [-1, 1, -1],
+    ...         [-1, 1, 1],
+    ...     ]
+    ... )
     >>> mirrored = transformations.apply_transformation_to_points(trans, verts)
     >>> np.allclose(mirrored, verts[[np.r_[4:8, 0:4]], :])
     True
@@ -240,7 +244,10 @@ def apply_transformation_to_points(transformation, points, inplace=False):
     >>> points_orig = points.copy()
     >>> scale_factor = 2
     >>> tf = scale_factor * np.eye(4)
-    >>> tf[3, 3,] = 1
+    >>> tf[
+    ...     3,
+    ...     3,
+    ... ] = 1
     >>> pyvista.transformations.apply_transformation_to_points(tf, points, inplace=True)
     >>> assert np.all(np.isclose(points, scale_factor * points_orig))
 

--- a/pyvista/utilities/wrappers.py
+++ b/pyvista/utilities/wrappers.py
@@ -13,6 +13,7 @@ A user-defined Foo class is defined that extends the functionality of
 >>> import pyvista
 >>> class Foo(pyvista.PolyData):
 ...     pass  # Extend PolyData here
+...
 >>> pyvista._wrappers['vtkPolyData'] = Foo
 >>> uniform_grid = pyvista.UniformGrid()
 >>> surface = uniform_grid.extract_surface()


### PR DESCRIPTION
PyVista has adopted [black](https://github.com/psf/black), but we fail to implement this for our documentation or doc strings.

This PR implements [blackdoc](https://github.com/keewis/blackdoc) to reformat all Python code in our docstrings as a `pre-commit`.

Pinging @jorgepiloto because this is really cool and IMO works better than [blacken-docs](https://pypi.org/project/blacken-docs/)
