### PR TITLE
Add pydocstringformatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,11 @@ repos:
   rev: v1.5.0
   hooks:
     - id: docformatter
-      args: [--in-place --config ./pyproject.toml]
+      args: [
+      "--in-place",
+      "--config",
+      "./pyproject.toml",
+      ]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.1.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,16 +39,11 @@ repos:
     files: ^(pyvista/|other/)
     exclude: ^pyvista/ext/
 
-- repo: https://github.com/PyCQA/docformatter
-  rev: v1.5.0
+- repo: https://github.com/DanielNoord/pydocstringformatter
+  rev: v0.7.3
   hooks:
-    - id: docformatter
-      args: [
-      "--in-place",
-      "--config",
-      "./pyproject.toml",
-      "pyvista",
-      ]
+    - id: pydocstringformatter
+      args: []
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.1.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,7 @@ repos:
       "--in-place",
       "--config",
       "./pyproject.toml",
+      "pyvista",
       ]
 
 - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,11 @@ repos:
   rev: v0.7.3
   hooks:
     - id: pydocstringformatter
-      args: []
+      args: [
+        "--style {numpydoc,pep257}",
+        "--no-strip-whitespace",
+        "--no-capitalize-first-letter",
+      ]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.1.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,12 @@ repos:
     files: ^(pyvista/|other/)
     exclude: ^pyvista/ext/
 
+- repo: https://github.com/PyCQA/docformatter
+  rev: v1.5.0
+  hooks:
+    - id: docformatter
+      args: [--in-place --config ./pyproject.toml]
+
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.1.1
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,5 +163,10 @@ markers = [
 ]
 image_cache_dir = "tests/plotting/image_cache"
 
+[tool.docformatter]
+recursive = true
+wrap-summaries = 0
+blank = true
+
 [tool.mypy]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,11 +163,5 @@ markers = [
 ]
 image_cache_dir = "tests/plotting/image_cache"
 
-[tool.docformatter]
-recursive = true
-wrap-summaries = 0
-wrap-descriptions = 79
-blank = true
-
 [tool.mypy]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,7 @@ image_cache_dir = "tests/plotting/image_cache"
 [tool.docformatter]
 recursive = true
 wrap-summaries = 0
+wrap-descriptions = 79
 blank = true
 
 [tool.mypy]

--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -5,8 +5,6 @@ For example:
 
 version_info = 0, 27, 'dev0'
 
----
-
 When generating pre-release wheels, use '0rcN', for example:
 
 version_info = 0, 28, '0rc1'

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -252,7 +252,9 @@ class DataObject:
         raise NotImplementedError('Called only by the inherited class')
 
     def copy_meta_from(self, *args, **kwargs):  # pragma: no cover
-        """Copy pyvista meta data onto this object from another object. Intended to be overridden by subclasses.
+        """Copy pyvista meta data onto this object from another object.
+
+        Intended to be overridden by subclasses.
 
         Parameters
         ----------

--- a/pyvista/core/filters/uniform_grid.py
+++ b/pyvista/core/filters/uniform_grid.py
@@ -453,9 +453,9 @@ class UniformGridFilters(DataSetFilters):
 
         See Also
         --------
-        rfft: The reverse transform.
-        low_pass: Low-pass filtering of FFT output.
-        high_pass: High-pass filtering of FFT output.
+        rfft : The reverse transform.
+        low_pass : Low-pass filtering of FFT output.
+        high_pass : High-pass filtering of FFT output.
 
         Examples
         --------
@@ -532,9 +532,9 @@ class UniformGridFilters(DataSetFilters):
 
         See Also
         --------
-        fft: The direct transform.
-        low_pass: Low-pass filtering of FFT output.
-        high_pass: High-pass filtering of FFT output.
+        fft : The direct transform.
+        low_pass : Low-pass filtering of FFT output.
+        high_pass : High-pass filtering of FFT output.
 
         Examples
         --------
@@ -624,9 +624,9 @@ class UniformGridFilters(DataSetFilters):
 
         See Also
         --------
-        fft: Direct fast Fourier transform.
-        rfft: Reverse fast Fourier transform.
-        high_pass: High-pass filtering of FFT output.
+        fft : Direct fast Fourier transform.
+        rfft : Reverse fast Fourier transform.
+        high_pass : High-pass filtering of FFT output.
 
         Examples
         --------
@@ -702,9 +702,9 @@ class UniformGridFilters(DataSetFilters):
 
         See Also
         --------
-        fft: Direct fast Fourier transform.
-        rfft: Reverse fast Fourier transform.
-        low_pass: Low-pass filtering of FFT output.
+        fft : Direct fast Fourier transform.
+        rfft : Reverse fast Fourier transform.
+        low_pass : Low-pass filtering of FFT output.
 
         Examples
         --------

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -423,7 +423,10 @@ class Texture(_vtk.vtkTexture, DataObject):
         return image.active_scalars.shape[1]
 
     def flip(self, axis):
-        """Flip this texture inplace along the specified axis. 0 for X and 1 for Y."""
+        """Flip this texture inplace along the specified axis.
+
+        0 for X and 1 for Y.
+        """
         if not 0 <= axis <= 1:
             raise ValueError(f"Axis {axis} out of bounds")
         array = self.to_array()

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1939,7 +1939,6 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
 
     @dimensions.setter
     def dimensions(self, dims):
-        """Set the dataset dimensions. Pass a length three tuple of integers."""
         nx, ny, nz = dims[0], dims[1], dims[2]
         self.SetDimensions(nx, ny, nz)
         self.Modified()

--- a/pyvista/ext/coverage.py
+++ b/pyvista/ext/coverage.py
@@ -61,9 +61,7 @@ def method_from_obj(obj_name):
 
 
 class CoverageBuilder(Builder):
-    """
-    Evaluates coverage of code in the documentation.
-    """
+    """Evaluates coverage of code in the documentation."""
 
     name = 'coverage'
     epilog = __(

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -1,7 +1,6 @@
 """Plot directive module.
 
 A directive for including a PyVista plot in a Sphinx document
-=============================================================
 
 The ``.. pyvista-plot::`` sphinx directive will include an inline
 ``.png`` image.

--- a/pyvista/plotting/actor_properties.py
+++ b/pyvista/plotting/actor_properties.py
@@ -4,7 +4,9 @@ from pyvista.plotting.opts import InterpolationType, RepresentationType
 
 
 class ActorProperties:
-    """Properties wrapper for ``vtkProperty``. Contains the surface properties of the object.
+    """Properties wrapper for ``vtkProperty``.
+
+    Contains the surface properties of the object.
 
     Parameters
     ----------
@@ -90,7 +92,10 @@ class ActorProperties:
 
     @property
     def interpolation_model(self):
-        """Return or set the interpolation model. Can be any of the options in :class:`pyvista.plotting.opts.InterpolationType` enum."""
+        """Return or set the interpolation model.
+
+        Can be any of the options in :class:`pyvista.plotting.opts.InterpolationType` enum.
+        """
         return InterpolationType.from_any(self.properties.GetInterpolation())
 
     @interpolation_model.setter
@@ -126,7 +131,10 @@ class ActorProperties:
 
     @property
     def representation(self) -> RepresentationType:
-        """Return or set the representation of the actor. Can be any of the options in :class:`pyvista.plotting.opts.RepresentationType` enum."""
+        """Return or set the representation of the actor.
+
+        Can be any of the options in :class:`pyvista.plotting.opts.RepresentationType` enum.
+        """
         return RepresentationType.from_any(self.properties.GetRepresentation())
 
     @representation.setter

--- a/pyvista/plotting/axes_actor.py
+++ b/pyvista/plotting/axes_actor.py
@@ -349,7 +349,9 @@ class AxesActor(pv._vtk.vtkAxesActor):
 
     @property
     def shaft_type(self) -> ShaftType:
-        """Return or set the shaft type. Can be either a cylinder(0) or a line(1).
+        """Return or set the shaft type.
+
+        Can be either a cylinder(0) or a line(1).
 
         Examples
         --------
@@ -372,7 +374,9 @@ class AxesActor(pv._vtk.vtkAxesActor):
 
     @property
     def tip_type(self) -> TipType:
-        """Return or set the shaft type. Can be either a cone(0) or a sphere(1).
+        """Return or set the shaft type.
+
+        Can be either a cone(0) or a sphere(1).
 
         Examples
         --------

--- a/pyvista/plotting/helpers.py
+++ b/pyvista/plotting/helpers.py
@@ -329,7 +329,7 @@ def plot_arrows(cent, direction, **kwargs):
 
     See Also
     --------
-    :func:`pyvista.plot`
+    pyvista.plot
 
     Examples
     --------

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -785,7 +785,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     @property
     def scalar_bar(self):
-        """First scalar bar.  Kept for backwards compatibility."""
+        """First scalar bar.
+
+        Kept for backwards compatibility.
+        """
         return list(self.scalar_bars.values())[0]
 
     @property

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -785,10 +785,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     @property
     def scalar_bar(self):
-        """First scalar bar.
-
-        Kept for backwards compatibility.
-        """
+        """First scalar bar (kept for backwards compatibility)."""
         return list(self.scalar_bars.values())[0]
 
     @property

--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -191,7 +191,7 @@ class ScalarBars:
         italic : bool, optional
             Italicises title and bar labels.  Default ``False``.
 
-        bold  : bool, optional
+        bold : bool, optional
             Bolds title and bar labels.  Default ``True``.
 
         title_font_size : float, optional

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1587,9 +1587,7 @@ class DefaultTheme(_ThemeConfig):
         will be interpolated across the topology of the dataset which is
         more accurate.
 
-        See Also
-        --------
-        :ref:`interpolate_before_mapping_example`
+        See also :ref:`interpolate_before_mapping_example`.
 
         Examples
         --------

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -300,7 +300,6 @@ class Report(scooby.Report):
     --------
     >>> import pyvista as pv
     >>> pv.Report()  # doctest:+SKIP
-    ---------------------------------------------------------------------------
       Date: Fri Oct 28 15:54:11 2022 MDT
     <BLANKLINE>
                     OS : Linux
@@ -332,7 +331,6 @@ class Report(scooby.Report):
                 meshio : 5.3.4
             jupyterlab : 3.4.7
              pythreejs : Version unknown
-    ---------------------------------------------------------------------------
 
     """
 

--- a/pyvista/utilities/features.py
+++ b/pyvista/utilities/features.py
@@ -112,11 +112,11 @@ def grid_from_sph_coords(theta, phi, r):
 
     Parameters
     ----------
-    theta: array-like
+    theta : array-like
         Azimuthal angle in degrees ``[0, 360]``.
-    phi: array-like
+    phi : array-like
         Polar (zenith) angle in degrees ``[0, 180]``.
-    r: array-like
+    r : array-like
         Distance (radius) from the point of origin.
 
     Returns

--- a/pyvista/utilities/geometric_objects.py
+++ b/pyvista/utilities/geometric_objects.py
@@ -1372,7 +1372,7 @@ def Superquadric(
     center : Sequence, default: (0.0, 0.0, 0.0)
         Center of the superquadric in ``[x, y, z]``.
 
-    scale :  Sequence, default: (1.0, 1.0, 1.0)
+    scale : Sequence, default: (1.0, 1.0, 1.0)
         Scale factors of the superquadric in ``[x, y, z]``.
 
     size : float, default: 0.5

--- a/pyvista/utilities/reader.py
+++ b/pyvista/utilities/reader.py
@@ -584,7 +584,7 @@ class TimeReader(ABC):
 
         Parameters
         ----------
-        time_point: int
+        time_point : int
             Time point index.
 
         Returns
@@ -621,7 +621,7 @@ class TimeReader(ABC):
 
         Parameters
         ----------
-        time_value: float
+        time_value : float
             Time or iteration value to set as active.
 
         """
@@ -632,7 +632,7 @@ class TimeReader(ABC):
 
         Parameters
         ----------
-        time_point: int
+        time_point : int
             Time or iteration point index for setting active time.
 
         """


### PR DESCRIPTION
In an effort to universally fix wrapping for our docstrings, I came across [pydocstringformatter](https://github.com/DanielNoord/pydocstringformatter). It has the potential to be that solution in the future, but for the time being it's fairly limited.

I still find it quite useful at preventing simple mistakes that would normally take **forever** to show up in the normal documentation build. Since it does basic enforcement of numpydoc standards, let's include this.

I'm on the fence of if we should include or not include this in the blame.
