### PR TITLE
Gitpod no doc build and no prebuild

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -21,21 +21,3 @@ tasks:
       pip install --no-cache-dir pre-commit
       pre-commit install --install-hooks
       pip install -e .
-      make -C doc html
-
-github:
-  prebuilds:
-    # enable for the default branch (defaults to true)
-    master: true
-    # enable for all branches in this repo (defaults to false)
-    branches: true
-    # enable for pull requests coming from this repo (defaults to true)
-    pullRequests: true
-    # enable for pull requests coming from forks (defaults to false)
-    pullRequestsFromForks: false
-    # add a check to pull requests (defaults to true)
-    addCheck: false
-    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
-    addComment: false
-    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
-    addBadge: false

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -426,7 +426,7 @@ The workspace has vnc capability through the browser for
 interactive plotting. The workspace also has the ability to view the
 documentation with a live-viewer. Hit the ``Go Live`` button
 and browse to ``doc/_build/html``. The workspace also preloads
- pre-commit environments and installs requirements.
+pre-commit environments and installs requirements.
 
 Unit Testing
 ~~~~~~~~~~~~

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -426,7 +426,7 @@ The workspace has vnc capability through the browser for
 interactive plotting. The workspace also has the ability to view the
 documentation with a live-viewer. Hit the ``Go Live`` button
 and browse to ``doc/_build/html``. The workspace also preloads
- pre-commit environments.
+ pre-commit environments and installs requirements.
 
 Unit Testing
 ~~~~~~~~~~~~

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -416,23 +416,17 @@ suites.
 Using Gitpod Workspace
 ~~~~~~~~~~~~~~~~~~~~~~
 
-A prebuilt gitpod workspace is available for a quick start development
+A gitpod workspace is available for a quick start development
 environment. To start a workspace from the main branch of pyvista, go
 to `<https://gitpod.io/#https://github.com/pyvista/pyvista>`_. See
 `Gitpod Getting Started
 <https://www.gitpod.io/docs/getting-started>`_ for more details.
 
 The workspace has vnc capability through the browser for
-interactive plotting. The workspace also has prebuilt
+interactive plotting. The workspace also has the ability to view the
 documentation with a live-viewer. Hit the ``Go Live`` button
-and browse to ``doc/_build/html``. The workspace is also prebuilt to
-support pre-commit checks.
-
-Workspaces started from the ``pyvista/pyvista`` repository will often
-have prebuilt environments with dependencies installed. Workspaces
-started from forks may not have prebuilt images and will start
-building when starting a new workspace. It is safe to stop, for example
-``Ctrl-C``, the documentation part of the build if unneeded.
+and browse to ``doc/_build/html``. The workspace also preloads
+ pre-commit environments.
 
 Unit Testing
 ~~~~~~~~~~~~


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->
I never set up the project for pre-builds on the Gitpod side and based on some discussion on slack it seems like some more established and larger projects are losing special privelages for free pre-builds. So the prebuild section is removed. 

In addition, making the documentation takes too long without the pre-build.  It is easier for new users of the documentation is opt-in to build.


