### PR TITLE
Add devcontainer support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,5 +3,5 @@
   "features": { "ghcr.io/devcontainers/features/desktop-lite:1": {}
   },
   "forwardPorts": [6080],
-  "postStartCommand": "./.devcontainer/postcreatecommand.sh"
+  "postCreateCommand": "./.devcontainer/postcreatecommand.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,6 @@
   "image": "mcr.microsoft.com/devcontainers/python:3.11",
   "features": { "ghcr.io/devcontainers/features/desktop-lite:1": {}
   },
-  "forwardPorts": [6080]
+  "forwardPorts": [6080],
+  "postCreateCommand": "./.devcontainer/postcreatecommand.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,5 +3,5 @@
   "features": { "ghcr.io/devcontainers/features/desktop-lite:1": {}
   },
   "forwardPorts": [6080],
-  "postCreateCommand": "./.devcontainer/postcreatecommand.sh"
+  "postStartCommand": "./.devcontainer/postcreatecommand.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "features": { "ghcr.io/devcontainers/features/desktop-lite:1": {}
+  },
+  "forwardPorts": [6080]
+}

--- a/.devcontainer/postcreatecommand.sh
+++ b/.devcontainer/postcreatecommand.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+python -m pip install -r requirements.txt
+python -m pip install -r requirements_test.py
+
+python -m pip install pre-commit
+pre-commit install
+
+python -m pip install -e .

--- a/.devcontainer/postcreatecommand.sh
+++ b/.devcontainer/postcreatecommand.sh
@@ -4,6 +4,6 @@ python -m pip install -r requirements.txt
 python -m pip install -r requirements_test.py
 
 python -m pip install pre-commit
-pre-commit install
+pre-commit install --install-hooks
 
 python -m pip install -e .

--- a/.devcontainer/postcreatecommand.sh
+++ b/.devcontainer/postcreatecommand.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 python -m pip install -r requirements.txt
-python -m pip install -r requirements_test.py
+python -m pip install -r requirements_test.txt
 
 python -m pip install pre-commit
 pre-commit install --install-hooks


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

This PR adds in devcontainer support.  You should be able to go to my fork at https://github.com/MatthewFlamm/pyvista/tree/maint/codespaces and spin up a codespace container for testing.

### Details

This includes pre-installation of requirements and testing requirements + a desktop-lite feature that allows for in browser vnc interaction

