### PR TITLE
Implement override mechanics for DataSet subclasses

### DIFF
--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -26,6 +26,12 @@ from pyvista.utilities.sphinx_gallery import _get_sg_image_scraper
 
 from pyvista.utilities.wrappers import _wrappers
 
+# set up overrides once we're done with all the other imports
+from pyvista._overrides import set_up_overrides
+
+set_up_overrides()
+del set_up_overrides  # no longer necessary
+
 global_theme = _GlobalTheme()
 rcParams = _rcParams()  # raises DeprecationError when used
 

--- a/pyvista/_overrides.py
+++ b/pyvista/_overrides.py
@@ -1,0 +1,55 @@
+"""Functionality to override PyVista object creation with other subclasses."""
+from functools import wraps
+
+from pyvista.core import DataSet
+
+
+def set_up_overrides(root=DataSet):
+    """Set up type overriding for all subclasses of a PyVista type.
+
+    Setup entails recursively finding all subclasses of the root
+    type and defining an optional ``type_override`` class
+    attribute on each. __new__ is decorated for each type to
+    return the overriding type if provided.
+
+    Parameters
+    ----------
+    root : type, default: pyvista.DataSet
+        Parent type whose (recursive) subclasses will be set up.
+        Root itself is included.
+    """
+    for cls in OVERRIDABLES:
+        cls.type_override = None
+        old_new = cls.__new__
+
+        @wraps(old_new)
+        def new_new(cls, *args, __old_new=old_new, **kwargs):
+            other_cls = cls.type_override
+            if other_cls is None or other_cls is cls:
+                return __old_new(cls, *args, **kwargs)
+            # non-trivial override is set: return other type
+            instance = other_cls.__new__(other_cls, *args, **kwargs)
+            return instance
+
+        cls.__new__ = new_new
+
+
+def _find_subclasses(root):
+    """Recursively build a set of subclasses for a root type.
+
+    Parameters
+    ----------
+    root : type
+        Root type to find subclasses for.
+
+    Returns
+    -------
+    subclasses : set
+        Set of types containing (recursive) subclasses. Includes
+        the root type.
+    """
+    return {root}.union(*(_find_subclasses(child) for child in root.__subclasses__()))
+
+
+# mainly exposed for ease of resetting:
+OVERRIDABLES = frozenset(_find_subclasses(DataSet))

--- a/pyvista/_overrides.py
+++ b/pyvista/_overrides.py
@@ -32,7 +32,7 @@ def set_up_overrides(root=DataSet):
             instance = other_cls.__new__(other_cls, *args, **kwargs)
             return instance
 
-        new_new.__signature__ = inspect.signature(old_new)
+        new_new.__signature__ = inspect.signature(cls.__init__)
 
         cls.__new__ = new_new
 

--- a/pyvista/_overrides.py
+++ b/pyvista/_overrides.py
@@ -1,5 +1,6 @@
 """Functionality to override PyVista object creation with other subclasses."""
 from functools import wraps
+import inspect
 
 from pyvista.core import DataSet
 
@@ -30,6 +31,8 @@ def set_up_overrides(root=DataSet):
             # non-trivial override is set: return other type
             instance = other_cls.__new__(other_cls, *args, **kwargs)
             return instance
+
+        new_new.__signature__ = inspect.signature(old_new)
 
         cls.__new__ = new_new
 

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -1436,11 +1436,18 @@ def abstract_class(cls_):
     Preventing a class from being instantiated similar to abc.ABCMeta
     but does not require an abstract method.
     """
+    orig_new = cls_.__new__
 
     def __new__(cls, *args, **kwargs):
         if cls is cls_:
             raise TypeError(f'{cls.__name__} is an abstract class and may not be instantiated.')
-        return object.__new__(cls)
+        try:
+            instance = orig_new(cls, *args, **kwargs)
+        except TypeError:
+            # pay for the sins of the parents
+            # (someone probably hard-coded object.__new__() upstream)
+            instance = orig_new(cls)
+        return instance
 
     cls_.__new__ = __new__
     return cls_

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1812,10 +1812,17 @@ def test_point_neighbors_levels(grid: DataSet, i0, n_levels):
 
 def test_type_override(clean_up_type_overrides):
     class NotPolyData(pyvista.PolyData):
-        pass
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.additional_state = 42
 
     poly = pyvista.Sphere()
     assert type(poly) == pyvista.PolyData
+
     pyvista.PolyData.type_override = NotPolyData
     not_poly = pyvista.Sphere()
+    # check correct type
     assert type(not_poly) == NotPolyData
+    # check inherited and additional state
+    assert not_poly == poly
+    assert not_poly.additional_state == 42

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -29,9 +29,17 @@ from pyvista.utilities.misc import PyVistaDeprecationWarning
 HYPOTHESIS_MAX_EXAMPLES = 20
 
 
-@pytest.fixture()
+@pytest.fixture
 def grid():
     return pyvista.UnstructuredGrid(examples.hexbeamfile)
+
+
+@pytest.fixture
+def clean_up_type_overrides():
+    """Reset type overrides on teardown."""
+    yield
+    for cls in pyvista._overrides.OVERRIDABLES:
+        cls.type_override = None
 
 
 def test_invalid_overwrite(grid):
@@ -1800,3 +1808,14 @@ def test_point_neighbors_levels(grid: DataSet, i0, n_levels):
             assert all([0 <= id < grid.n_points for id in ids])
             assert len(ids) > 0
         assert i == n_levels - 1
+
+
+def test_type_override(clean_up_type_overrides):
+    class NotPolyData(pyvista.PolyData):
+        pass
+
+    poly = pyvista.Sphere()
+    assert type(poly) == pyvista.PolyData
+    pyvista.PolyData.type_override = NotPolyData
+    not_poly = pyvista.Sphere()
+    assert type(not_poly) == NotPolyData


### PR DESCRIPTION
[This comment](https://github.com/pyvista/pyvista/pull/4146#issuecomment-1474338302) and its context (including https://github.com/pyvista/pyvista/pull/1584#issuecomment-901340448) got me thinking. We use a bunch of `pv.wrap(poly_data)` calls in `geometric_objects.py` to allow downstream libraries to swap out the wrapping type and replace types that our helper functions.

I started playing with alternatives a bit, and this is a first vague attempt at having more general mechanics for allowing downstream libraries to swap out types of our own (typically with subclasses of the corresponding types). There are some huge questions:
1. Does this even make sense?
2. Is this kind of black magic acceptable? Should we look for alternative implementations?

Some more specific questions:
<ol start="3">
  <li>What API do we actually want for this? Do we want a dedicated helper that overrides types? Or perhaps a mapping that keeps track of all overridden types? Latter would be messy because we'd have to keep the mapping in sync with the class-level overrides, unless we use an immutable mapping.</li>
  <li>Is it OK to consider <code>DataSet</code> subclasses to be overridden? This excludes <code>MultiBlock</code>. Should we hard-code the overridable types instead? That would mean that future new types might fall between the cracks and accidentally become nonoverridable.</li>
  <li>How do we document this? How private should these mechanics be?</li>
</ol>

---

Here's how this PR works as a user:
```py
#import traceback

import pyvista as pv

sphere = pv.Sphere()
print(type(sphere))

class LoudPolyData(pv.PolyData):
    def __init__(self, *args, **kwargs):
        print(f'Hi, my type is {type(self).__name__}')
        #print('traceback:')
        #traceback.print_stack()
        super().__init__(*args, **kwargs)

pv.PolyData.type_override = LoudPolyData

sphere_overridden = pv.Sphere()
print(type(sphere_overridden))
```

This creates a thin `PolyData` subclass that announces its existence when initialised. It overrides `pv.PolyData` with this type and creates a `pv.Sphere()` both before and after. Here's the output:
```
<class 'pyvista.core.pointset.PolyData'>
Hi, my type is LoudPolyData
Hi, my type is LoudPolyData
Hi, my type is LoudPolyData
<class '__main__.LoudPolyData'>
```
The first line comes from the first print in the script, using usual `PolyData`. The next 3 lines come from `pv.Sphere()`, and the last line is our explicit print. I was a bit surprised to see three `LouPolyData` being initialised, but it turns out that `pv.Sphere()` does `pv.wrap()` -> `rotate_y()` -> `translate()`, and while both filters are `inplace=True`, they first create a new `PolyData` then overwrite the original one to become a copy (which is probably [another nail in `inplace`'s coffin](https://github.com/pyvista/pyvista/issues/4158)). If you uncomment the `traceback`-related comments in the script you can trace where these three meshes are being created.

I'm curious to see what you all think. To be clear I'm not attached to any of the current implementation, this is more of an experiment. I'm OK with any outcome, including scrapping the whole idea. Perhaps it might be easier to come up with saner alternatives if we have this as a baseline. All feedback including design nitpicks are very welcome. Cc. @MatthewFlamm.