### PR TITLE
Fix JupyterHub service proxy prefix issue

### DIFF
--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -1364,7 +1364,7 @@ class _TrameConfig(_ThemeConfig):
         # default for ``jupyter-server-proxy``
         service = os.environ.get('JUPYTERHUB_SERVICE_PREFIX', '')
         prefix = os.environ.get('PYVISTA_TRAME_SERVER_PROXY_PREFIX', '/proxy/')
-        if service:  # pragma: no cover
+        if service and not prefix.startswith('http'):  # pragma: no cover
             self._server_proxy_prefix = os.path.join(service, prefix.lstrip('/'))
         else:
             self._server_proxy_prefix = prefix


### PR DESCRIPTION
Hotfix for an issue I'm having on a JupyterHub deployment