### PR TITLE
Add PointSet guards

### DIFF
--- a/pyvista/core/errors.py
+++ b/pyvista/core/errors.py
@@ -46,3 +46,13 @@ class VTKVersionError(RuntimeError):
     ):
         """Empty init."""
         RuntimeError.__init__(self, message)
+
+
+class PointSetNotSupported(NotImplementedError):
+    """Requested filter or property is not supported by the PointSet class."""
+
+    def __init__(
+        self, message='Slice and other dimension reducing filters are not supported on PointSets'
+    ):
+        """Empty init."""
+        NotImplementedError.__init__(self, message)

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -19,7 +19,7 @@ from .._typing import BoundsLike
 from ..utilities.fileio import get_ext
 from .celltype import CellType
 from .dataset import DataSet
-from .errors import DeprecationError, VTKVersionError
+from .errors import DeprecationError, PointSetNotSupported, VTKVersionError
 from .filters import PolyDataFilters, StructuredGridFilters, UnstructuredGridFilters, _get_output
 
 DEFAULT_INPLACE_WARNING = (
@@ -322,6 +322,117 @@ class PointSet(_vtk.vtkPointSet, _PointSet):
         pdata = self.cast_to_polydata(deep=False)
         kwargs.setdefault('style', 'points')
         return pdata.plot(*args, **kwargs)
+
+    @wraps(PolyDataFilters.threshold)
+    def threshold(self, *args, **kwargs):
+        """Cast to PolyData and threshold.
+
+        Need this because cell-wise operations fail for PointSets.
+        """
+        return self.cast_to_polydata(False).threshold(*args, **kwargs).cast_to_pointset()
+
+    @wraps(PolyDataFilters.threshold_percent)
+    def threshold_percent(self, *args, **kwargs):
+        """Cast to PolyData and threshold.
+
+        Need this because cell-wise operations fail for PointSets.
+        """
+        return self.cast_to_polydata(False).threshold_percent(*args, **kwargs).cast_to_pointset()
+
+    @wraps(PolyDataFilters.explode)
+    def explode(self, *args, **kwargs):
+        """Cast to PolyData and explode.
+
+        The explode filter relies on cells.
+
+        """
+        return self.cast_to_polydata(False).explode(*args, **kwargs).cast_to_pointset()
+
+    @property
+    def area(self) -> float:
+        """Return 0.0 since a PointSet has no area."""
+        return 0.0
+
+    @property
+    def volume(self) -> float:
+        """Return 0.0 since a PointSet has no volume."""
+        return 0.0
+
+    def contour(self, *args, **kwargs):
+        """Raise dimension reducing operations are not supported."""
+        raise PointSetNotSupported(
+            'Contour and other dimension reducing filters are not supported on PointSets'
+        )
+
+    def cell_data_to_point_data(self, *args, **kwargs):
+        """Raise PointSets do not have cells."""
+        raise PointSetNotSupported('PointSets contain no cells or cell data.')
+
+    def point_data_to_cell_data(self, *args, **kwargs):
+        """Raise PointSets do not have cells."""
+        raise PointSetNotSupported('PointSets contain no cells or cell data.')
+
+    def triangulate(self, *args, **kwargs):
+        """Raise cell operations are not supported."""
+        raise PointSetNotSupported('Cell operations are not supported. PointSets contain no cells.')
+
+    def decimate_boundary(self, *args, **kwargs):
+        """Raise cell operations are not supported."""
+        raise PointSetNotSupported('Cell operations are not supported. PointSets contain no cells.')
+
+    def find_cells_along_line(self, *args, **kwargs):
+        """Raise cell operations are not supported."""
+        raise PointSetNotSupported('Cell operations are not supported. PointSets contain no cells.')
+
+    def tessellate(self, *args, **kwargs):
+        """Raise cell operations are not supported."""
+        raise PointSetNotSupported('Cell operations are not supported. PointSets contain no cells.')
+
+    def slice(self, *args, **kwargs):
+        """Raise dimension reducing operations are not supported."""
+        raise PointSetNotSupported(
+            'Slice and other dimension reducing filters are not supported on PointSets'
+        )
+
+    def slice_along_axis(self, *args, **kwargs):
+        """Raise dimension reducing operations are not supported."""
+        raise PointSetNotSupported(
+            'Slice and other dimension reducing filters are not supported on PointSets'
+        )
+
+    def slice_along_line(self, *args, **kwargs):
+        """Raise dimension reducing operations are not supported."""
+        raise PointSetNotSupported(
+            'Slice and other dimension reducing filters are not supported on PointSets'
+        )
+
+    def slice_implicit(self, *args, **kwargs):
+        """Raise dimension reducing operations are not supported."""
+        raise PointSetNotSupported(
+            'Slice and other dimension reducing filters are not supported on PointSets'
+        )
+
+    def slice_orthogonal(self, *args, **kwargs):
+        """Raise dimension reducing operations are not supported."""
+        raise PointSetNotSupported(
+            'Slice and other dimension reducing filters are not supported on PointSets'
+        )
+
+    def shrink(self, *args, **kwargs):
+        """Raise cell operations are not supported."""
+        raise PointSetNotSupported('Cell operations are not supported. PointSets contain no cells.')
+
+    def separate_cells(self, *args, **kwargs):
+        """Raise cell operations are not supported."""
+        raise PointSetNotSupported('Cell operations are not supported. PointSets contain no cells.')
+
+    def remove_cells(self, *args, **kwargs):
+        """Raise cell operations are not supported."""
+        raise PointSetNotSupported('Cell operations are not supported. PointSets contain no cells.')
+
+    def point_is_inside_cell(self, *args, **kwargs):
+        """Raise cell operations are not supported."""
+        raise PointSetNotSupported('Cell operations are not supported. PointSets contain no cells.')
 
 
 class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -348,6 +348,11 @@ class PointSet(_vtk.vtkPointSet, _PointSet):
         """
         return self.cast_to_polydata(False).explode(*args, **kwargs).cast_to_pointset()
 
+    @wraps(PolyDataFilters.delaunay_3d)
+    def delaunay_3d(self, *args, **kwargs):
+        """Cast to PolyData and run delaunay_3d."""
+        return self.cast_to_polydata(False).delaunay_3d(*args, **kwargs)
+
     @property
     def area(self) -> float:
         """Return 0.0 since a PointSet has no area."""
@@ -391,31 +396,31 @@ class PointSet(_vtk.vtkPointSet, _PointSet):
     def slice(self, *args, **kwargs):
         """Raise dimension reducing operations are not supported."""
         raise PointSetNotSupported(
-            'Slice and other dimension reducing filters are not supported on PointSets'
+            'Slice and other dimension reducing filters are not supported on PointSets.'
         )
 
     def slice_along_axis(self, *args, **kwargs):
         """Raise dimension reducing operations are not supported."""
         raise PointSetNotSupported(
-            'Slice and other dimension reducing filters are not supported on PointSets'
+            'Slice and other dimension reducing filters are not supported on PointSets.'
         )
 
     def slice_along_line(self, *args, **kwargs):
         """Raise dimension reducing operations are not supported."""
         raise PointSetNotSupported(
-            'Slice and other dimension reducing filters are not supported on PointSets'
+            'Slice and other dimension reducing filters are not supported on PointSets.'
         )
 
     def slice_implicit(self, *args, **kwargs):
         """Raise dimension reducing operations are not supported."""
         raise PointSetNotSupported(
-            'Slice and other dimension reducing filters are not supported on PointSets'
+            'Slice and other dimension reducing filters are not supported on PointSets.'
         )
 
     def slice_orthogonal(self, *args, **kwargs):
         """Raise dimension reducing operations are not supported."""
         raise PointSetNotSupported(
-            'Slice and other dimension reducing filters are not supported on PointSets'
+            'Slice and other dimension reducing filters are not supported on PointSets.'
         )
 
     def shrink(self, *args, **kwargs):

--- a/tests/test_pointset.py
+++ b/tests/test_pointset.py
@@ -225,6 +225,20 @@ def test_threshold_percent(pointset):
     assert out.n_points == pointset.n_points // 2
 
 
+def test_explode(pointset):
+    out = pointset.explode(1)
+    assert isinstance(out, pyvista.PointSet)
+    ori_xlen = pointset.bounds[1] - pointset.bounds[0]
+    new_xlen = out.bounds[1] - out.bounds[0]
+    assert np.isclose(2 * ori_xlen, new_xlen)
+
+
+def test_delaunay_3d(pointset):
+    out = pointset.delaunay_3d()
+    assert isinstance(out, pyvista.UnstructuredGrid)
+    assert out.n_cells > 10
+
+
 def raise_unsupported(pointset):  # PointSetNotSupported
     with pytest.raises(PointSetNotSupported):
         pointset.contour()

--- a/tests/test_pointset.py
+++ b/tests/test_pointset.py
@@ -5,6 +5,7 @@ import pytest
 import vtk
 
 import pyvista
+from pyvista.core.errors import PointSetNotSupported
 
 # skip all tests if concrete pointset unavailable
 pytestmark = pytest.mark.skipif(
@@ -208,6 +209,70 @@ def test_flip_normal():
             ],
         ),
     )
+
+
+def test_threshold(pointset):
+    pointset['scalars'] = range(pointset.n_points)
+    out = pointset.threshold(pointset.n_points // 2)
+    assert isinstance(out, pyvista.PointSet)
+    assert out.n_points == pointset.n_points // 2
+
+
+def test_threshold_percent(pointset):
+    pointset['scalars'] = range(pointset.n_points)
+    out = pointset.threshold_percent(50)
+    assert isinstance(out, pyvista.PointSet)
+    assert out.n_points == pointset.n_points // 2
+
+
+def raise_unsupported(pointset):  # PointSetNotSupported
+    with pytest.raises(PointSetNotSupported):
+        pointset.contour()
+
+    with pytest.raises(PointSetNotSupported):
+        pointset.cell_data_to_point_data()
+
+    with pytest.raises(PointSetNotSupported):
+        pointset.point_data_to_cell_data()
+
+    with pytest.raises(PointSetNotSupported):
+        pointset.triangulate()
+
+    with pytest.raises(PointSetNotSupported):
+        pointset.decimate_boundary()
+
+    with pytest.raises(PointSetNotSupported):
+        pointset.find_cells_along_line()
+
+    with pytest.raises(PointSetNotSupported):
+        pointset.tessellate()
+
+    with pytest.raises(PointSetNotSupported):
+        pointset.slice()
+
+    with pytest.raises(PointSetNotSupported):
+        pointset.slice_along_axis()
+
+    with pytest.raises(PointSetNotSupported):
+        pointset.slice_along_line()
+
+    with pytest.raises(PointSetNotSupported):
+        pointset.slice_implicit()
+
+    with pytest.raises(PointSetNotSupported):
+        pointset.slice_orthogonal()
+
+    with pytest.raises(PointSetNotSupported):
+        pointset.shrink()
+
+    with pytest.raises(PointSetNotSupported):
+        pointset.separate_cells()
+
+    with pytest.raises(PointSetNotSupported):
+        pointset.remove_cells()
+
+    with pytest.raises(PointSetNotSupported):
+        pointset.point_is_inside_cell()
 
 
 def test_rotate_x():


### PR DESCRIPTION
Resolve #3815 by addressing the following for `pyvista.PointSet`s:
1. Raising `PointSetNotSupported` for some cell-wise operations and casting to PolyData for others.
2. Raising `PointSetNotSupported` for all dimension reducing operations like contouring and slicing.
