### PR TITLE
Enforce value range testing for properties

### DIFF
--- a/pyvista/plotting/_property.py
+++ b/pyvista/plotting/_property.py
@@ -74,7 +74,7 @@ class Property(_vtk.vtkProperty):
         The specular lighting coefficient.
 
     specular_power : float, default: :attr:`pyvista.themes._LightingConfig.specular_power`
-        The specular power. Between 0.0 and 128.0.
+        The specular power. Must be between 0.0 and 128.0.
 
     show_edges : bool, default: :attr:`pyvista.themes.DefaultTheme.show_edges`
         Shows the edges.  Does not apply to a wireframe representation.
@@ -547,7 +547,7 @@ class Property(_vtk.vtkProperty):
         Default Default :attr:`pyvista.themes._LightingConfig.specular`.
 
         Specular lighting simulates the bright spot of a light that appears
-        on shiny objects. Must be between 0 and 1
+        on shiny objects. Must be between 0 and 1.
 
         Examples
         --------

--- a/pyvista/plotting/_property.py
+++ b/pyvista/plotting/_property.py
@@ -4,7 +4,7 @@ from typing import Union
 import pyvista as pv
 from pyvista import _vtk
 from pyvista.plotting.opts import InterpolationType
-from pyvista.utilities.misc import no_new_attr
+from pyvista.utilities.misc import _check_range, no_new_attr
 
 from .colors import Color
 
@@ -395,6 +395,7 @@ class Property(_vtk.vtkProperty):
 
     @opacity.setter
     def opacity(self, value: float):
+        _check_range(value, (0, 1), 'opacity')
         self.SetOpacity(value)
 
     @property
@@ -460,10 +461,11 @@ class Property(_vtk.vtkProperty):
     def ambient(self) -> float:
         """Return or set ambient.
 
-        When lighting is enabled, this is the amount of light in
-        the range of 0 to 1 (default 0.0) that reaches the actor
-        when not directed at the light source emitted from the
-        viewer.
+        Default Default :attr:`pyvista.themes._LightingConfig.ambient`.
+
+        When lighting is enabled, this is the amount of light in the range
+        of 0 to 1 that reaches the actor when not directed at the light
+        source emitted from the viewer.
 
         Examples
         --------
@@ -493,17 +495,19 @@ class Property(_vtk.vtkProperty):
 
     @ambient.setter
     def ambient(self, value: float):
+        _check_range(value, (0, 1), 'ambient')
         self.SetAmbient(value)
 
     @property
     def diffuse(self) -> float:
         """Return or set the diffuse lighting coefficient.
 
-        Default 1.0.
+        Default :attr:`pyvista.themes._LightingConfig.diffuse`.
 
-        This is the scattering of light by reflection or transmission. Diffuse
-        reflection results when light strikes an irregular surface such as a
-        frosted window or the surface of a frosted or coated light bulb.
+        This is the scattering of light by reflection or
+        transmission. Diffuse reflection results when light strikes an
+        irregular surface such as a frosted window or the surface of a
+        frosted or coated light bulb. Must be between 0 and 1.
 
         Examples
         --------
@@ -533,16 +537,17 @@ class Property(_vtk.vtkProperty):
 
     @diffuse.setter
     def diffuse(self, value: float):
+        _check_range(value, (0, 1), 'diffuse')
         self.SetDiffuse(value)
 
     @property
     def specular(self) -> float:
         """Return or set specular.
 
-        Default 0.0
+        Default Default :attr:`pyvista.themes._LightingConfig.specular`.
 
-        Specular lighting simulates the bright spot of a light that appears on
-        shiny objects.
+        Specular lighting simulates the bright spot of a light that appears
+        on shiny objects. Must be between 0 and 1
 
         Examples
         --------
@@ -572,13 +577,16 @@ class Property(_vtk.vtkProperty):
 
     @specular.setter
     def specular(self, value: float):
+        _check_range(value, (0, 1), 'specular')
         self.SetSpecular(value)
 
     @property
     def specular_power(self) -> float:
         """Return or set specular power.
 
-        The specular power. Between 0.0 and 128.0. Default 1.0
+        Default :attr:`pyvista.themes._LightingConfig.specular_power`.
+
+        The specular power. Must be between 0.0 and 128.0.
 
         Examples
         --------
@@ -616,14 +624,17 @@ class Property(_vtk.vtkProperty):
 
     @specular_power.setter
     def specular_power(self, value: float):
+        _check_range(value, (0, 128), 'specular_power')
         self.SetSpecularPower(value)
 
     @property
     def metallic(self) -> float:
         """Return or set metallic.
 
+        Default :attr:`pyvista.themes._LightingConfig.metallic`.
+
         This requires that the interpolation be set to ``'Physically based
-        rendering'``
+        rendering'``. Must be between 0 and 1.
 
         Examples
         --------
@@ -657,14 +668,17 @@ class Property(_vtk.vtkProperty):
 
     @metallic.setter
     def metallic(self, value: float):
+        _check_range(value, (0, 1), 'metallic')
         self.SetMetallic(value)
 
     @property
     def roughness(self) -> float:
         """Return or set roughness.
 
+        Default :attr:`pyvista.themes._LightingConfig.roughness`.
+
         This requires that the interpolation be set to ``'Physically based
-        rendering'``
+        rendering'``. Must be between 0 and 1.
 
         Examples
         --------
@@ -699,11 +713,14 @@ class Property(_vtk.vtkProperty):
 
     @roughness.setter
     def roughness(self, value: bool):
+        _check_range(value, (0, 1), 'roughness')
         self.SetRoughness(value)
 
     @property
     def interpolation(self) -> InterpolationType:
         """Return or set the method of shading.
+
+        Defaults to :attr:`pyvista.themes._LightingConfig.interpolation`.
 
         One of the following options.
 
@@ -760,11 +777,13 @@ class Property(_vtk.vtkProperty):
     def render_points_as_spheres(self) -> bool:
         """Return or set rendering points as spheres.
 
+        Defaults to :attr:`pyvista.themes.DefaultTheme.render_points_as_spheres`.
+
         Requires representation style be set to ``'points'``.
 
         Examples
         --------
-        Enable rendering points as spheres
+        Enable rendering points as spheres.
 
         >>> import pyvista as pv
         >>> prop = pv.Property()
@@ -794,6 +813,8 @@ class Property(_vtk.vtkProperty):
     @property
     def render_lines_as_tubes(self) -> bool:
         """Return or set rendering lines as tubes.
+
+        Defaults to :attr:`pyvista.themes.DefaultTheme.render_lines_as_tubes`.
 
         Requires representation style be set to ``'wireframe'``.
 
@@ -830,6 +851,8 @@ class Property(_vtk.vtkProperty):
     def line_width(self) -> float:
         """Return or set the line width.
 
+        Defaults to :attr:`pyvista.themes.DefaultTheme.line_width`.
+
         Examples
         --------
         Change the line width to ``10``.
@@ -861,6 +884,8 @@ class Property(_vtk.vtkProperty):
     @property
     def point_size(self):
         """Return or set the point size.
+
+        Defaults to :attr:`pyvista.themes.DefaultTheme.point_size`.
 
         Examples
         --------
@@ -1095,6 +1120,7 @@ class Property(_vtk.vtkProperty):
             from pyvista.core.errors import VTKVersionError
 
             raise VTKVersionError('Anisotropy requires VTK v9.1.0 or newer.')
+        _check_range(value, (0, 1), 'anisotropy')
         self.SetAnisotropy(value)
 
     def plot(self, **kwargs) -> None:

--- a/pyvista/plotting/composite_mapper.py
+++ b/pyvista/plotting/composite_mapper.py
@@ -11,7 +11,7 @@ import pyvista as pv
 from pyvista import _vtk
 from pyvista.utilities import convert_array, convert_string_array
 
-from ..utilities.misc import vtk_version_info
+from ..utilities.misc import _check_range, vtk_version_info
 from .colors import Color
 from .mapper import _BaseMapper
 
@@ -205,6 +205,7 @@ class BlockAttributes:
             self._attr.Modified()
             return
 
+        _check_range(new_opacity, (0, 1), 'opacity')
         self._attr.SetBlockOpacity(self._block, new_opacity)
 
     @property

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -358,6 +358,11 @@ class _LightingConfig(_ThemeConfig):
     def diffuse(self) -> float:
         """Return or set the diffuse value.
 
+        This is the scattering of light by reflection or
+        transmission. Diffuse reflection results when light strikes an
+        irregular surface such as a frosted window or the surface of a
+        frosted or coated light bulb. Must be between 0 and 1.
+
         Examples
         --------
         Set the global diffuse lighting value to ``0.5``.
@@ -379,7 +384,8 @@ class _LightingConfig(_ThemeConfig):
     def specular(self) -> float:
         """Return or set the specular value.
 
-        Must be between 0 and 1.
+        Specular lighting simulates the bright spot of a light that appears
+        on shiny objects. Must be between 0 and 1.
 
         Examples
         --------
@@ -401,6 +407,8 @@ class _LightingConfig(_ThemeConfig):
     @property
     def specular_power(self) -> float:
         """Return or set the specular power value.
+
+        Must be between 0.0 and 128.0.
 
         Examples
         --------

--- a/pyvista/themes.py
+++ b/pyvista/themes.py
@@ -41,7 +41,7 @@ from .plotting.colors import Color, get_cmap_safe, get_cycler
 from .plotting.opts import InterpolationType
 from .plotting.plotting import Plotter
 from .plotting.tools import parse_font_family
-from .utilities.misc import PyVistaDeprecationWarning
+from .utilities.misc import PyVistaDeprecationWarning, _check_range
 
 
 class _rcParams(dict):  # pragma: no cover
@@ -71,12 +71,6 @@ class _rcParams(dict):  # pragma: no cover
             'rcParams is deprecated.  Please use ``pyvista.global_theme``', DeprecationWarning
         )
         return repr(pyvista.global_theme)
-
-
-def _check_between_zero_and_one(value: float, value_name: str = 'value'):
-    """Check if a value is between zero and one."""
-    if value < 0 or value > 1:
-        raise ValueError(f'{value_name} must be between 0 and 1.')
 
 
 def load_theme(filename):
@@ -288,9 +282,8 @@ class _LightingConfig(_ThemeConfig):
     def metallic(self) -> float:
         """Return or set the metallic value.
 
-        Usually this value is either 0 or 1 for a real material but any
-        value in between is valid. This parameter is only used by PBR
-        interpolation.
+        This requires that the interpolation be set to ``'Physically based
+        rendering'``. Must be between 0 and 1.
 
         Examples
         --------
@@ -307,6 +300,7 @@ class _LightingConfig(_ThemeConfig):
 
     @metallic.setter
     def metallic(self, metallic: float):
+        _check_range(metallic, (0, 1), 'metallic')
         self._metallic = metallic
 
     @property
@@ -332,6 +326,7 @@ class _LightingConfig(_ThemeConfig):
 
     @roughness.setter
     def roughness(self, roughness: float):
+        _check_range(roughness, (0, 1), 'roughness')
         self._roughness = roughness
 
     @property
@@ -356,6 +351,7 @@ class _LightingConfig(_ThemeConfig):
 
     @ambient.setter
     def ambient(self, ambient: float):
+        _check_range(ambient, (0, 1), 'ambient')
         self._ambient = ambient
 
     @property
@@ -376,13 +372,14 @@ class _LightingConfig(_ThemeConfig):
 
     @diffuse.setter
     def diffuse(self, diffuse: float):
+        _check_range(diffuse, (0, 1), 'diffuse')
         self._diffuse = diffuse
 
     @property
     def specular(self) -> float:
         """Return or set the specular value.
 
-        Should be between 0 and 1.
+        Must be between 0 and 1.
 
         Examples
         --------
@@ -398,6 +395,7 @@ class _LightingConfig(_ThemeConfig):
 
     @specular.setter
     def specular(self, specular: float):
+        _check_range(specular, (0, 1), 'specular')
         self._specular = specular
 
     @property
@@ -418,6 +416,7 @@ class _LightingConfig(_ThemeConfig):
 
     @specular_power.setter
     def specular_power(self, specular_power: float):
+        _check_range(specular_power, (0, 128), 'specular_power')
         self._specular_power = specular_power
 
     @property
@@ -603,7 +602,7 @@ class _SilhouetteConfig(_ThemeConfig):
 
     @opacity.setter
     def opacity(self, opacity: float):
-        _check_between_zero_and_one(opacity, 'opacity')
+        _check_range(opacity, (0, 1), 'opacity')
         self._opacity = float(opacity)
 
     @property
@@ -641,7 +640,7 @@ class _SilhouetteConfig(_ThemeConfig):
         if decimate is None:
             self._decimate = None
         else:
-            _check_between_zero_and_one(decimate, 'decimate')
+            _check_range(decimate, (0, 1), 'decimate')
             self._decimate = float(decimate)
 
     def __repr__(self):
@@ -1138,6 +1137,7 @@ class _SliderStyleConfig(_ThemeConfig):
 
     @cap_opacity.setter
     def cap_opacity(self, cap_opacity: float):
+        _check_range(cap_opacity, (0, 1), 'cap_opacity')
         self._cap_opacity = float(cap_opacity)
 
     @property
@@ -1723,7 +1723,7 @@ class DefaultTheme(_ThemeConfig):
 
     @opacity.setter
     def opacity(self, opacity: float):
-        _check_between_zero_and_one(opacity, 'opacity')
+        _check_range(opacity, (0, 1), 'opacity')
         self._opacity = float(opacity)
 
     @property

--- a/pyvista/utilities/misc.py
+++ b/pyvista/utilities/misc.py
@@ -27,6 +27,14 @@ def _set_plot_theme_from_env():
             )
 
 
+def _check_range(value, rng, parm_name):
+    """Check if a parameter is within a range."""
+    if value < rng[0] or value > rng[1]:
+        raise ValueError(
+            f'The value {float(value)} for `{parm_name}` is outside the acceptable range {tuple(rng)}.'
+        )
+
+
 @lru_cache(maxsize=None)
 def has_module(module_name):
     """Return if a module can be imported."""

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -1,11 +1,20 @@
 import pytest
 
 import pyvista as pv
+from pyvista.plotting._property import _check_range
 
 
 @pytest.fixture()
 def prop():
     return pv.Property()
+
+
+def test_check_range():
+    with pytest.raises(ValueError, match="outside the acceptable"):
+        _check_range(-1, (0, 1), 'parm')
+    with pytest.raises(ValueError, match="outside the acceptable"):
+        _check_range(2, (0, 1), 'parm')
+    assert _check_range(0, (0, 1), 'parm') is None
 
 
 def test_property_init():
@@ -31,6 +40,8 @@ def test_property_opacity(prop):
     opacity = 0.5
     prop.opacity = opacity
     assert prop.opacity == opacity
+    with pytest.raises(ValueError):
+        prop.opacity = 2
 
 
 def test_property_show_edges(prop):
@@ -49,30 +60,40 @@ def test_property_ambient(prop):
     value = 0.45
     prop.ambient = value
     assert prop.ambient == value
+    with pytest.raises(ValueError):
+        prop.ambient = -1
 
 
 def test_property_diffuse(prop):
     value = 0.5
     prop.diffuse = value
     assert prop.diffuse == value
+    with pytest.raises(ValueError):
+        prop.diffuse = 2
 
 
 def test_property_specular(prop):
     value = 0.5
     prop.specular = value
     assert prop.specular == value
+    with pytest.raises(ValueError):
+        prop.specular = 2
 
 
 def test_property_specular_power(prop):
     value = 0.5
     prop.specular_power = value
     assert prop.specular_power == value
+    with pytest.raises(ValueError):
+        prop.specular = 200
 
 
 def test_property_metallic(prop):
     value = 0.1
     prop.metallic = value
     assert prop.metallic == value
+    with pytest.raises(ValueError):
+        prop.metallic = -1
 
 
 def test_property_roughness(prop):


### PR DESCRIPTION
Resolves #3871 by adding checks for lighting property values.

Decided to go with updating the docs and also raising errors. Explicit errors rather than implicit clamping is preferred because the code becomes self-documenting.
