### PR TITLE
Fast merge PolyData

### DIFF
--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -361,7 +361,13 @@ class PolyDataFilters(DataSetFilters):
         return merged
 
     def merge(
-        self, dataset, merge_points=True, inplace=False, main_has_priority=True, progress_bar=False
+        self,
+        dataset,
+        merge_points=True,
+        tolerance=0.0,
+        inplace=False,
+        main_has_priority=True,
+        progress_bar=False,
     ):
         """Merge this mesh with one or more datasets.
 
@@ -384,6 +390,10 @@ class PolyDataFilters(DataSetFilters):
 
         merge_points : bool, optional
             Merge equivalent points when ``True``.
+
+        tolerance : float, default: 0.0
+            The absolute tolerance to use to find coincident points when
+            ``merge_points=True``.
 
         inplace : bool, default: False
             Updates grid inplace when ``True`` if the input type is a
@@ -428,6 +438,7 @@ class PolyDataFilters(DataSetFilters):
             self,
             dataset,
             merge_points=merge_points,
+            tolerance=tolerance,
             main_has_priority=main_has_priority,
             inplace=False,
             progress_bar=progress_bar,

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -350,14 +350,7 @@ class PolyDataFilters(DataSetFilters):
         so the in-place merge attempt will raise.
 
         """
-        try:
-            merged = self.merge(dataset, inplace=True)
-        except TypeError:
-            raise TypeError(
-                'In-place merge only possible if the other mesh '
-                'is also a PolyData.\nPlease use `mesh + other_mesh` '
-                'instead, which returns a new UnstructuredGrid.'
-            ) from None
+        merged = self.merge(dataset, inplace=True)
         return merged
 
     def merge(


### PR DESCRIPTION
Resolves #3920 by implementing @whophil's suggestion always using `vtkAppendFilter` when merging PolyData and then casting back.

The speedup is noticeable where it counts. Seems that the point merging algorithm grows quadraticly  with `vtkCleanPolyData`.

### 1M points example
```py
>>> import pyvista as pv
>>> sphere_a = pv.Sphere(theta_resolution=1000, phi_resolution=1000)
>>> sphere_b = sphere_a.copy()
>>> timeit sphere_a.merge(sphere_b, merge_points=True)
```

#### `main` branch
```
1.48 s ± 6.07 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
#### This branch
```
473 ms ± 3.39 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

### 4M points example
```py
>>> import pyvista as pv
>>> sphere_a = pv.Sphere(theta_resolution=2000, phi_resolution=2000)
>>> sphere_b = sphere_a.copy()
>>> timeit sphere_a.merge(sphere_b, merge_points=True)
```

#### `main` branch
```
17.4 s ± 29.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

#### This branch
```
1.97 s ± 21.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```