### PR TITLE
Change development status to stable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = '>=3.8'
 keywords = ['vtk', 'numpy', 'plotting', 'mesh']
 license = {text = 'MIT'}
 classifiers = [
-    'Development Status :: 4 - Beta',
+    'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Science/Research',
     'Topic :: Scientific/Engineering :: Information Analysis',
     'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Resolve #3975 by changing our "Development Status" to "Production/Stable".

Knowing how PyVista is being used ([~1.6k connections](https://github.com/pyvista/pyvista/network/dependents)!), I'm happy to take this a little closer to a v1.0 release.

Considering there are likely more changes to be made with the API (and it will probably never stop), I'm fine with delaying it past the end of this year. However, I also think we have enough API coverage as-is to call what we have as a 1.0.

It's for everyone to decide when, but I'm happy either way and regardless, I think we're "stable enough." right now.