### PR TITLE
Add tubes CFD example

### DIFF
--- a/examples/99-advanced/openfoam-tubes.py
+++ b/examples/99-advanced/openfoam-tubes.py
@@ -1,58 +1,104 @@
-""".. _cfd_openfoam_example:
+""".. _openfoam_tubes_example:
 
 Plot CFD Data
-~~~~~~~~~~~~~
-Plot a CFD example from OpenFoam.
+-------------
+Plot a CFD example from OpenFoam hosted on the public SimScale examples at
+`SimScale Project Library <https://www.simscale.com/projects/>`_.
 
-See :ref:`openfoam_example` for a full example using :class:`pyvista.POpenFOAMReader`.
+This example dataset was read using the :class:`pyvista.POpenFOAMReader`. See
+:ref:`openfoam_example` for a full example using this reader.
 
 """
 
 import numpy as np
 
 import pyvista as pv
+from pyvista import examples
 
-reader = pv.OpenFOAMReader('./case.foam')
-reader.set_active_time_value(1000)
-mesh = reader.read()
-# mesh[0].slice_along_axis(7, axis='z').plot(scalars='k', preference='point')
+###############################################################################
+# Download and load the example dataset.
 
-# lines, src = mesh[0].streamlines(vectors='U', source_center=(0, 0, 0), source_radius=0.02, return_source=True, max_time=0.5, integration_direction='backward', n_points=50)
-
-# pl = pv.Plotter()
-# pl.add_mesh(lines, render_lines_as_tubes=True, line_width=1, lighting=False, scalars='U')
-# # pl.add_points(src)
-# pl.add_mesh(mesh[1], color='w', opacity=0.05)
-# pl.enable_anti_aliasing()
-# pl.camera_position='xz'
-# pl.show()
+mesh = examples.download_openfoam_tubes()
+mesh
 
 
-bounds = np.array(mesh[1].bounds) * 1.2
-origin = (bounds[0], bounds[2], bounds[4])
+###############################################################################
+# Plot Cross Section
+# ~~~~~~~~~~~~~~~~~~
+# Plot the outline of the dataset along with a cross section of the flow velocity.
 
-sp = 0.004
-spacing = (sp, sp, sp)
+# generate a slice in the XZ plane
+y_slice = mesh.slice('y')
 
-dimensions = (
-    int((bounds[1] - bounds[0]) // sp + 2),
-    int((bounds[3] - bounds[2]) // sp + 2),
-    int((bounds[5] - bounds[4]) // sp + 2),
+pl = pv.Plotter()
+pl.add_mesh(y_slice, scalars='U', lighting=False, scalar_bar_args={'title': 'Flow Velocity'})
+pl.add_mesh(mesh, color='w', opacity=0.25)
+pl.enable_anti_aliasing()
+pl.show()
+
+
+###############################################################################
+# Plot Steamlines - Flow Velocity
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Generate streamlines using :func:`streamlines() <pyvista.DataSetFilters.streamlines>`.
+
+lines, src = mesh.streamlines(
+    vectors='U',
+    source_center=(0, 0, 0),
+    source_radius=0.025,
+    return_source=True,
+    max_time=0.5,
+    integration_direction='backward',
+    n_points=40,
 )
 
-grid = pv.UniformGrid(dimensions=dimensions, spacing=spacing, origin=origin)
-
-flow = mesh[0].copy()
-flow.clear_data()
-# flow['u-norm'] = np.linalg.norm(mesh[0].point_data['U'], axis=1)
-flow['p'] = mesh[0].point_data['nut']
-
-out = grid.interpolate(flow, radius=0.005)
 pl = pv.Plotter()
-vol = pl.add_volume(out, opacity='linear')
-# , opacity=[0, 0, 0.0, 0.0, 0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.4])
-# vol.mapper.blend_mode = 'maximum'
+pl.add_mesh(
+    lines,
+    render_lines_as_tubes=True,
+    line_width=3,
+    lighting=False,
+    scalar_bar_args={'title': 'Flow Velocity'},
+    scalars='U',
+    rng=(0, 212),
+)
+pl.add_mesh(mesh, color='w', opacity=0.25)
+pl.enable_anti_aliasing()
+pl.camera_position = 'xz'
+pl.show()
+
+
+###############################################################################
+# Volumetric Plot - Visualize Turbulent Kinematic Viscosity
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# The turbulent kinematic viscosity of a fluid is a derived quantity used in
+# turbulence modeling to describe the effect of turbulent motion on the
+# momentum transport within the fluid.
+#
+# For this example, we will first interpolate the results from the
+# :class:`pyvista.UnstructuredGrid` onto a :class:`pyvista.UniformGrid` using
+# :func:`interpolate() <pyvista.DataSetFilters.interpolate>`. This is so we can
+# visualize it using :func:`add_volume() <pyvista.Plotter.add_volume>`
+
+bounds = np.array(mesh.bounds) * 1.2
+origin = (bounds[0], bounds[2], bounds[4])
+spacing = (0.003, 0.003, 0.003)
+dimensions = (
+    int((bounds[1] - bounds[0]) // spacing[0] + 2),
+    int((bounds[3] - bounds[2]) // spacing[1] + 2),
+    int((bounds[5] - bounds[4]) // spacing[2] + 2),
+)
+grid = pv.UniformGrid(dimensions=dimensions, spacing=spacing, origin=origin)
+grid = grid.interpolate(mesh, radius=0.005)
+
+pl = pv.Plotter()
+vol = pl.add_volume(
+    grid,
+    scalars='nut',
+    opacity='linear',
+    scalar_bar_args={'title': 'Turbulent Kinematic Viscosity'},
+)
 vol.prop.interpolation_type = 'linear'
-pl.add_mesh(mesh[1], color='w', opacity=0.1)
+pl.add_mesh(mesh, color='w', opacity=0.1)
 pl.camera_position = 'xz'
 pl.show()

--- a/examples/99-advanced/openfoam-tubes.py
+++ b/examples/99-advanced/openfoam-tubes.py
@@ -1,0 +1,58 @@
+""".. _cfd_openfoam_example:
+
+Plot CFD Data
+~~~~~~~~~~~~~
+Plot a CFD example from OpenFoam.
+
+See :ref:`openfoam_example` for a full example using :class:`pyvista.POpenFOAMReader`.
+
+"""
+
+import numpy as np
+
+import pyvista as pv
+
+reader = pv.OpenFOAMReader('./case.foam')
+reader.set_active_time_value(1000)
+mesh = reader.read()
+# mesh[0].slice_along_axis(7, axis='z').plot(scalars='k', preference='point')
+
+# lines, src = mesh[0].streamlines(vectors='U', source_center=(0, 0, 0), source_radius=0.02, return_source=True, max_time=0.5, integration_direction='backward', n_points=50)
+
+# pl = pv.Plotter()
+# pl.add_mesh(lines, render_lines_as_tubes=True, line_width=1, lighting=False, scalars='U')
+# # pl.add_points(src)
+# pl.add_mesh(mesh[1], color='w', opacity=0.05)
+# pl.enable_anti_aliasing()
+# pl.camera_position='xz'
+# pl.show()
+
+
+bounds = np.array(mesh[1].bounds) * 1.2
+origin = (bounds[0], bounds[2], bounds[4])
+
+sp = 0.004
+spacing = (sp, sp, sp)
+
+dimensions = (
+    int((bounds[1] - bounds[0]) // sp + 2),
+    int((bounds[3] - bounds[2]) // sp + 2),
+    int((bounds[5] - bounds[4]) // sp + 2),
+)
+
+grid = pv.UniformGrid(dimensions=dimensions, spacing=spacing, origin=origin)
+
+flow = mesh[0].copy()
+flow.clear_data()
+# flow['u-norm'] = np.linalg.norm(mesh[0].point_data['U'], axis=1)
+flow['p'] = mesh[0].point_data['nut']
+
+out = grid.interpolate(flow, radius=0.005)
+pl = pv.Plotter()
+vol = pl.add_volume(out, opacity='linear')
+# , opacity=[0, 0, 0.0, 0.0, 0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.4])
+# vol.mapper.blend_mode = 'maximum'
+vol.prop.interpolation_type = 'linear'
+pl.add_mesh(mesh[1], color='w', opacity=0.1)
+pl.camera_position = 'xz'
+pl.show()

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -3904,6 +3904,41 @@ def download_cavity(load=True):  # pragma: no cover
     return pyvista.OpenFOAMReader(filename).read()
 
 
+def download_openfoam_tubes(load=True):  # pragma: no cover
+    """Download tubes OpenFOAM example.
+
+    Data generated from public SimScale examples.
+
+    Parameters
+    ----------
+    load : bool, default: True
+        Load the dataset after downloading it when ``True``.  Set this
+        to ``False`` and only the filename will be returned.
+
+    Returns
+    -------
+    pyvista.UnstructuredGrid | str
+        DataSet or filename depending on ``load``.
+
+    Examples
+    --------
+    >>> from pyvista import examples
+    >>> dataset = examples.download_openfoam_tubes()  # doctest:+SKIP
+
+    See :ref:`openfoam_example` for a full example using this dataset.
+
+    """
+    filename = _download_archive(
+        'fea/turbo_incompressible/Turbo-Incompressible_3-Run_1-SOLUTION_FIELDS.zip',
+        target_file='case.foam',
+    )
+    if not load:
+        return filename
+    reader = pyvista.OpenFOAMReader(filename)
+    reader.set_active_time_value(1000)
+    return reader.read()[0]
+
+
 def download_lucy(load=True):  # pragma: no cover
     """Download the lucy angel mesh.
 

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -3907,7 +3907,12 @@ def download_cavity(load=True):  # pragma: no cover
 def download_openfoam_tubes(load=True):  # pragma: no cover
     """Download tubes OpenFOAM example.
 
-    Data generated from public SimScale examples.
+    Data generated from public SimScale examples at `SimScale Project Library -
+    Turbo <https://www.simscale.com/projects/ayarnoz/turbo/>`_.
+
+    Licensing for this dataset is granted to freely and without restriction
+    reproduce, distribute, publish according to the `SimScale Terms and
+    Conditions <https://www.simscale.com/terms-and-conditions/>`_.
 
     Parameters
     ----------
@@ -3922,10 +3927,24 @@ def download_openfoam_tubes(load=True):  # pragma: no cover
 
     Examples
     --------
-    >>> from pyvista import examples
-    >>> dataset = examples.download_openfoam_tubes()  # doctest:+SKIP
+    Plot the outline of the dataset along with a cross section of the flow velocity.
 
-    See :ref:`openfoam_example` for a full example using this dataset.
+    >>> import pyvista as pv
+    >>> from pyvista import examples
+    >>> dataset = examples.download_openfoam_tubes()
+    >>> y_slice = dataset.slice('y')
+    >>> pl = pv.Plotter()
+    >>> _ = pl.add_mesh(
+    ...     y_slice,
+    ...     scalars='U',
+    ...     lighting=False,
+    ...     scalar_bar_args={'title': 'Flow Velocity'},
+    ... )
+    >>> _ = pl.add_mesh(dataset, color='w', opacity=0.25)
+    >>> pl.enable_anti_aliasing()
+    >>> pl.show()
+
+    See :ref:`openfoam_tubes_example` for a full example using this dataset.
 
     """
     filename = _download_archive(

--- a/tests/examples/test_download_files.py
+++ b/tests/examples/test_download_files.py
@@ -492,6 +492,14 @@ def test_download_cavity():
     assert isinstance(dataset, pv.MultiBlock)
 
 
+def test_download_openfoam_tubes():
+    filename = examples.download_openfoam_tubes(load=False)
+    assert os.path.isfile(filename)
+
+    dataset = examples.download_openfoam_tubes(load=True)
+    assert isinstance(dataset, pv.UnstructuredGrid)
+
+
 def test_download_lucy():
     filename = examples.download_lucy(load=False)
     assert os.path.isfile(filename)


### PR DESCRIPTION
There are a ton of awesome projects and datasets at https://www.simscale.com/ and this PR adds one of the examples to our Gallery and downloadable datasets.


```py
>>> import pyvista as pv
>>> from pyvista import examples
>>> dataset = examples.download_openfoam_tubes()
>>> y_slice = dataset.slice('y')
>>> pl = pv.Plotter()
>>> _ = pl.add_mesh(
...     y_slice,
...     scalars='U',
...     lighting=False,
...     scalar_bar_args={'title': 'Flow Velocity'},
... )
>>> _ = pl.add_mesh(dataset, color='w', opacity=0.25)
>>> pl.enable_anti_aliasing()
>>> pl.show()
```

![flow](https://user-images.githubusercontent.com/11981631/229897239-abc3f566-f79c-4278-9e92-41342eb9cd1c.png)
