### PR TITLE
Add electronics cooling example

### DIFF
--- a/examples/99-advanced/openfoam-cooling.py
+++ b/examples/99-advanced/openfoam-cooling.py
@@ -1,0 +1,173 @@
+""".. _openfoam_cooling_example:
+
+Electronics Cooling CFD
+-----------------------
+Plot an electronics cooling CFD example from OpenFoam hosted on the public
+SimScale examples at `SimScale Project Library
+<https://www.simscale.com/projects/>`_ and generated from the `Thermal
+Management Tutorial: CHT Analysis of an Electronics Box
+<https://www.simscale.com/docs/tutorials/thermal-management-cht-analysis-electronics-box/>`_.
+
+This example dataset was read using the :class:`pyvista.POpenFOAMReader` and
+post processed according to this `README.md
+<https://github.com/pyvista/vtk-data/blob/master/Data/fea/cooling_electronics/README.md>`_.
+
+"""
+
+import numpy as np
+
+import pyvista as pv
+from pyvista import examples
+
+###############################################################################
+# Load the Datasets
+# ~~~~~~~~~~~~~~~~~
+# Download and load the datasets.
+#
+# The ``structure`` dataset consists of a box with several components, being
+# cooled down by a fan, while the ``air`` dataset is the air, containing
+# several scalar arrays including the velocity and temperature of the air.
+
+structure, air = examples.download_electronics_cooling()
+structure, air
+
+
+###############################################################################
+# Plot the Electronics
+# ~~~~~~~~~~~~~~~~~~~~
+# Here we plot the temperature of the electronics using the ``"reds"`` colormap
+# and improve the look of the plot using surface space ambient occlusion with
+# :func:`enable_ssao() <pyvista.Plotter.enable_ssao>`.
+
+pl = pv.Plotter()
+pl.enable_ssao(radius=0.01)
+pl.add_mesh(
+    structure, scalars='T', smooth_shading=True, split_sharp_edges=True, cmap='reds', ambient=0.2
+)
+pl.enable_anti_aliasing('fxaa')  # also try 'ssaa'
+pl.show()
+
+
+###############################################################################
+# Plot Air Velocity
+# ~~~~~~~~~~~~~~~~~
+# Let's plot the velocity of the air.
+#
+# Start by clipping the air dataset with :func:`clip()
+# <pyvista.DataSetFilters.clip>` and plotting it alongside the electronics.
+#
+# As you can see, the air enters from the front of the case (left) and is being
+# pushed out of the "back" of the case via a fan.
+
+# Clip the air in the XY plane
+z_slice = air.clip('z', value=-0.005)
+
+# Plot it
+pl = pv.Plotter()
+pl.enable_ssao(radius=0.01)
+pl.add_mesh(z_slice, scalars='U', lighting=False, scalar_bar_args={'title': 'Velocity'})
+pl.add_mesh(structure, color='w', smooth_shading=True, split_sharp_edges=True)
+pl.camera_position = 'xy'
+pl.camera.roll = 90
+pl.enable_anti_aliasing('fxaa')
+pl.show()
+
+
+###############################################################################
+# Plot Air Velocity
+# ~~~~~~~~~~~~~~~~~
+# Let's also plot the temperature of the air. This time, let's also plot the
+# temperature of the components.
+
+pl = pv.Plotter()
+pl.enable_ssao(radius=0.01)
+pl.add_mesh(
+    z_slice, scalars='T', lighting=False, scalar_bar_args={'title': 'Temperature'}, cmap='reds'
+)
+pl.add_mesh(
+    structure,
+    scalars='T',
+    smooth_shading=True,
+    split_sharp_edges=True,
+    cmap='reds',
+    show_scalar_bar=False,
+)
+pl.camera_position = 'xy'
+pl.camera.roll = 90
+pl.enable_anti_aliasing('fxaa')
+pl.show()
+
+
+###############################################################################
+# Plot Steamlines - Flow Velocity
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Now, let's plot the steamlines of this dataset so we can see how the air is
+# flowing through the case.
+#
+# Generate streamlines using :func:`streamlines() <pyvista.DataSetFilters.streamlines>`.
+
+# Have our streamlines start from the regular openings of the case.
+lines = []
+z_rng = np.linspace(0, 0.03, 5)
+for x in np.linspace(0.045, 0.105, 7, endpoint=True):
+    lines.extend([air.streamlines(start_position=[x, 0.2, z], max_time=2.0) for z in z_rng])
+lines = pv.merge(lines)
+
+# Plot
+pl = pv.Plotter()
+pl.enable_ssao(radius=0.01)
+pl.add_mesh(lines, line_width=2, scalars='T', cmap='reds')
+pl.add_mesh(
+    structure,
+    scalars='T',
+    smooth_shading=True,
+    split_sharp_edges=True,
+    cmap='reds',
+    show_scalar_bar=False,
+)
+pl.camera_position = 'xy'
+pl.camera.roll = 90
+pl.enable_anti_aliasing('fxaa')  # also try 'ssaa'
+pl.show()
+
+
+###############################################################################
+# Volumetric Plot - Visualize High Temperatures
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Show a 3D plot of areas of temperature.
+#
+# For this example, we will first interpolate the results from the
+# :class:`pyvista.UnstructuredGrid` onto a :class:`pyvista.UniformGrid` using
+# :func:`interpolate() <pyvista.DataSetFilters.interpolate>`. This is so we can
+# visualize it using :func:`add_volume() <pyvista.Plotter.add_volume>`
+
+bounds = np.array(air.bounds) * 1.2
+origin = (bounds[0], bounds[2], bounds[4])
+spacing = (0.003, 0.003, 0.003)
+dimensions = (
+    int((bounds[1] - bounds[0]) // spacing[0] + 2),
+    int((bounds[3] - bounds[2]) // spacing[1] + 2),
+    int((bounds[5] - bounds[4]) // spacing[2] + 2),
+)
+grid = pv.UniformGrid(dimensions=dimensions, spacing=spacing, origin=origin)
+grid = grid.interpolate(air, radius=0.005)
+
+
+opac = np.zeros(20)
+opac[1:] = np.geomspace(1e-7, 0.1, 19)
+opac[-5:] = [0.05, 0.1, 0.5, 0.5, 0.5]
+
+pl = pv.Plotter()
+pl.add_mesh(structure, color='w', smooth_shading=True, split_sharp_edges=True)
+vol = pl.add_volume(
+    grid,
+    scalars='T',
+    opacity=opac,
+    cmap='autumn_r',
+    show_scalar_bar=True,
+    scalar_bar_args={'title': 'Temperature'},
+)
+vol.prop.interpolation_type = 'linear'
+pl.enable_anti_aliasing('fxaa')  # also try 'ssaa'
+pl.camera.zoom(2)
+pl.show()

--- a/examples/99-advanced/openfoam-cooling.py
+++ b/examples/99-advanced/openfoam-cooling.py
@@ -104,14 +104,15 @@ pl.show()
 # Now, let's plot the steamlines of this dataset so we can see how the air is
 # flowing through the case.
 #
-# Generate streamlines using :func:`streamlines() <pyvista.DataSetFilters.streamlines>`.
+# Generate streamlines using :func:`streamlines_from_source()
+# <pyvista.DataSetFilters.streamlines_from_source>`.
 
 # Have our streamlines start from the regular openings of the case.
-lines = []
-z_rng = np.linspace(0, 0.03, 5)
+points = []
 for x in np.linspace(0.045, 0.105, 7, endpoint=True):
-    lines.extend([air.streamlines(start_position=[x, 0.2, z], max_time=2.0) for z in z_rng])
-lines = pv.merge(lines)
+    points.extend([x, 0.2, z] for z in np.linspace(0, 0.03, 5))
+points = pv.PointSet(points)
+lines = air.streamlines_from_source(points, max_time=2.0)
 
 # Plot
 pl = pv.Plotter()
@@ -136,22 +137,21 @@ pl.show()
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Show a 3D plot of areas of temperature.
 #
-# For this example, we will first interpolate the results from the
+# For this example, we will first sample the results from the
 # :class:`pyvista.UnstructuredGrid` onto a :class:`pyvista.UniformGrid` using
-# :func:`interpolate() <pyvista.DataSetFilters.interpolate>`. This is so we can
-# visualize it using :func:`add_volume() <pyvista.Plotter.add_volume>`
+# :func:`sample() <pyvista.DataSetFilters.sample>`. This is so we can visualize
+# it using :func:`add_volume() <pyvista.Plotter.add_volume>`
 
 bounds = np.array(air.bounds) * 1.2
 origin = (bounds[0], bounds[2], bounds[4])
-spacing = (0.003, 0.003, 0.003)
+spacing = (0.002, 0.002, 0.002)
 dimensions = (
     int((bounds[1] - bounds[0]) // spacing[0] + 2),
     int((bounds[3] - bounds[2]) // spacing[1] + 2),
     int((bounds[5] - bounds[4]) // spacing[2] + 2),
 )
 grid = pv.UniformGrid(dimensions=dimensions, spacing=spacing, origin=origin)
-grid = grid.interpolate(air, radius=0.005)
-
+grid = grid.sample(air)
 
 opac = np.zeros(20)
 opac[1:] = np.geomspace(1e-7, 0.1, 19)

--- a/examples/99-advanced/openfoam-cooling.py
+++ b/examples/99-advanced/openfoam-cooling.py
@@ -116,7 +116,7 @@ lines = pv.merge(lines)
 # Plot
 pl = pv.Plotter()
 pl.enable_ssao(radius=0.01)
-pl.add_mesh(lines, line_width=2, scalars='T', cmap='reds')
+pl.add_mesh(lines, line_width=2, scalars='T', cmap='reds', scalar_bar_args={'title': 'Temperature'})
 pl.add_mesh(
     structure,
     scalars='T',

--- a/examples/99-advanced/openfoam-cooling.py
+++ b/examples/99-advanced/openfoam-cooling.py
@@ -74,8 +74,8 @@ pl.show()
 
 
 ###############################################################################
-# Plot Air Velocity
-# ~~~~~~~~~~~~~~~~~
+# Plot Air Temperature
+# ~~~~~~~~~~~~~~~~~~~~
 # Let's also plot the temperature of the air. This time, let's also plot the
 # temperature of the components.
 

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -4028,7 +4028,7 @@ def download_electronics_cooling(load=True):  # pragma: no cover
     See :ref:`openfoam_cooling_example` for a full example using this dataset.
 
     """
-    fnames = _download_archive('fea/cooling_electronics/datasets.zip')
+    fnames = _download_archive('fvm/cooling_electronics/datasets.zip')
     if load:
         # return the structure dataset first
         if fnames[1].endswith('structure.vtp'):

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -3930,7 +3930,7 @@ def download_lucy(load=True):  # pragma: no cover
     >>> import pyvista
     >>> dataset = examples.download_lucy()
 
-    Create a light at the "flame"
+    Create a light at the "flame".
 
     >>> flame_light = pyvista.Light(
     ...     color=[0.886, 0.345, 0.133],
@@ -3941,7 +3941,7 @@ def download_lucy(load=True):  # pragma: no cover
     ...     attenuation_values=(0.001, 0.005, 0),
     ... )
 
-    Create a scene light
+    Create a scene light.
 
     >>> scene_light = pyvista.Light(intensity=0.2)
 
@@ -3956,6 +3956,85 @@ def download_lucy(load=True):  # pragma: no cover
 
     """
     return _download_and_read('lucy.ply', load=load)
+
+
+def download_electronics_cooling(load=True):  # pragma: no cover
+    """Download the electronics cooling example datasets.
+
+    Data generated from public SimScale examples at `SimScale Project Library -
+    Turbo <https://www.simscale.com/projects/ayarnoz/turbo/>`_.
+
+    Licensing for this dataset is granted to freely and without restriction
+    reproduce, distribute, publish according to the `SimScale Terms and
+    Conditions <https://www.simscale.com/terms-and-conditions/>`_.
+
+    Parameters
+    ----------
+    load : bool, default: True
+        Load the dataset after downloading it when ``True``.  Set this
+        to ``False`` and only the filename will be returned.
+
+    Returns
+    -------
+    tuple[PolyData, UnstructuredGrid] | list[str]
+        DataSets or filenames depending on ``load``.
+
+    Examples
+    --------
+    Load the datasets
+
+    >>> import pyvista as pv
+    >>> from pyvista import examples
+    >>> structure, air = examples.download_electronics_cooling()
+    >>> structure, air  # doctest:+SKIP
+    (PolyData (0x7fdfe4eb24a0)
+       N Cells:    344270
+       N Points:   187992
+       N Strips:   0
+       X Bounds:   -3.000e-03, 1.530e-01
+       Y Bounds:   -3.000e-03, 2.030e-01
+       Z Bounds:   -9.000e-03, 4.200e-02
+       N Arrays:   5,
+     UnstructuredGrid (0x7fdfde4478e0)
+       N Cells:    1749992
+       N Points:   610176
+       X Bounds:   -1.388e-18, 1.500e-01
+       Y Bounds:   -3.000e-03, 2.030e-01
+       Z Bounds:   -6.000e-03, 4.400e-02
+       N Arrays:   10)
+
+    Plot the air velocity through the electronics.
+
+    >>> z_slice = air.clip('z', value=-0.005)
+    >>> pl = pv.Plotter()
+    >>> pl.enable_ssao(radius=0.01)
+    >>> _ = pl.add_mesh(
+    ...     z_slice,
+    ...     scalars='U',
+    ...     lighting=False,
+    ...     scalar_bar_args={'title': 'Velocity'},
+    ... )
+    >>> _ = pl.add_mesh(
+    ...     structure,
+    ...     color='w',
+    ...     smooth_shading=True,
+    ...     split_sharp_edges=True,
+    ... )
+    >>> pl.camera_position = 'xy'
+    >>> pl.camera.roll = 90
+    >>> pl.enable_anti_aliasing('fxaa')
+    >>> pl.show()
+
+    See :ref:`openfoam_cooling_example` for a full example using this dataset.
+
+    """
+    fnames = _download_archive('fea/cooling_electronics/datasets.zip')
+    if load:
+        # return the structure dataset first
+        if fnames[1].endswith('structure.vtp'):
+            fnames = fnames[::-1]
+        return pyvista.read(fnames[0]), pyvista.read(fnames[1])
+    return fnames
 
 
 def download_can(partial=False, load=True):  # pragma: no cover

--- a/tests/examples/test_download_files.py
+++ b/tests/examples/test_download_files.py
@@ -500,6 +500,16 @@ def test_download_lucy():
     assert isinstance(dataset, pv.PolyData)
 
 
+def test_download_electronics_cooling():
+    filenames = examples.download_electronics_cooling(load=False)
+    for filename in filenames:
+        assert os.path.isfile(filename)
+
+    structure, air = examples.download_electronics_cooling(load=True)
+    assert isinstance(structure, pv.PolyData)
+    assert isinstance(air, pv.UnstructuredGrid)
+
+
 def test_angular_sector():
     filename = examples.download_angular_sector(load=False)
     assert os.path.isfile(filename)


### PR DESCRIPTION
Expose the dataset from: https://github.com/pyvista/vtk-data/pull/29

![velocity](https://user-images.githubusercontent.com/11981631/230143282-26f8b5df-281f-481f-9376-aff65bef57c4.png)

```py
Load the dataset.

>>> import pyvista as pv
>>> from pyvista import examples
>>> structure, air = examples.download_electronics_cooling()

Plot the air velocity through the electronics.

>>> z_slice = air.clip('z', value=-0.005)
>>> pl = pv.Plotter()
>>> pl.enable_ssao(radius=0.01)
>>> _ = pl.add_mesh(z_slice, scalars='U', lighting=False, scalar_bar_args={'title': 'Velocity'})
>>> _ = pl.add_mesh(structure, color='w', smooth_shading=True, split_sharp_edges=True)
>>> pl.camera_position = 'xy'
>>> pl.camera.roll = 90
>>> pl.enable_anti_aliasing('fxaa')
>>> pl.show()
```

More cool screenshots:
![temp](https://user-images.githubusercontent.com/11981631/230143533-cabf8a5f-a6fc-4444-9f70-3db1c2b5f099.png)

![temp2](https://user-images.githubusercontent.com/11981631/230143630-4c8947bd-bef6-43ed-b5dc-457092e41647.png)
