### PR TITLE
Fix tubes example

### DIFF
--- a/examples/99-advanced/openfoam-tubes.py
+++ b/examples/99-advanced/openfoam-tubes.py
@@ -18,8 +18,8 @@ from pyvista import examples
 ###############################################################################
 # Download and load the example dataset.
 
-mesh = examples.download_openfoam_tubes()
-mesh
+block = examples.download_openfoam_tubes()
+block
 
 
 ###############################################################################
@@ -27,12 +27,15 @@ mesh
 # ~~~~~~~~~~~~~~~~~~
 # Plot the outline of the dataset along with a cross section of the flow velocity.
 
+# first, get the first block representing the air within the tube.
+air = block[0]
+
 # generate a slice in the XZ plane
-y_slice = mesh.slice('y')
+y_slice = air.slice('y')
 
 pl = pv.Plotter()
 pl.add_mesh(y_slice, scalars='U', lighting=False, scalar_bar_args={'title': 'Flow Velocity'})
-pl.add_mesh(mesh, color='w', opacity=0.25)
+pl.add_mesh(air, color='w', opacity=0.25)
 pl.enable_anti_aliasing()
 pl.show()
 
@@ -40,16 +43,29 @@ pl.show()
 ###############################################################################
 # Plot Steamlines - Flow Velocity
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Generate streamlines using :func:`streamlines() <pyvista.DataSetFilters.streamlines>`.
+# Generate streamlines using :func:`streamlines_from_source()
+# <pyvista.DataSetFilters.streamlines_from_source>`.
 
-lines, src = mesh.streamlines(
+# Let's use the inlet as a source. Let's first plot it.
+inlet = block[1][2]
+pl = pv.Plotter()
+pl.add_mesh(inlet, color='b', label='inlet')
+pl.add_mesh(air, opacity=0.2, color='w', label='air')
+pl.enable_anti_aliasing()
+pl.add_legend(face=None)
+pl.show()
+
+
+###############################################################################
+# Now, actually generate the streamlines. Since the original inlet contains
+# 1000 points, let's reduce this to around 200 points. First, let's remove the
+# points on the outer ring.
+
+pset = pv.PointSet(inlet.points[::5])
+lines = air.streamlines_from_source(
+    pset,
     vectors='U',
-    source_center=(0, 0, 0),
-    source_radius=0.025,
-    return_source=True,
-    max_time=0.5,
-    integration_direction='backward',
-    n_points=40,
+    max_time=1.0,
 )
 
 pl = pv.Plotter()
@@ -62,7 +78,7 @@ pl.add_mesh(
     scalars='U',
     rng=(0, 212),
 )
-pl.add_mesh(mesh, color='w', opacity=0.25)
+pl.add_mesh(air, color='w', opacity=0.25)
 pl.enable_anti_aliasing()
 pl.camera_position = 'xz'
 pl.show()
@@ -75,12 +91,12 @@ pl.show()
 # turbulence modeling to describe the effect of turbulent motion on the
 # momentum transport within the fluid.
 #
-# For this example, we will first interpolate the results from the
+# For this example, we will first sample the results from the
 # :class:`pyvista.UnstructuredGrid` onto a :class:`pyvista.UniformGrid` using
-# :func:`interpolate() <pyvista.DataSetFilters.interpolate>`. This is so we can
-# visualize it using :func:`add_volume() <pyvista.Plotter.add_volume>`
+# :func:`sample() <pyvista.DataSetFilters.sample>`. This is so we can visualize
+# it using :func:`add_volume() <pyvista.Plotter.add_volume>`
 
-bounds = np.array(mesh.bounds) * 1.2
+bounds = np.array(air.bounds) * 1.2
 origin = (bounds[0], bounds[2], bounds[4])
 spacing = (0.003, 0.003, 0.003)
 dimensions = (
@@ -89,7 +105,7 @@ dimensions = (
     int((bounds[5] - bounds[4]) // spacing[2] + 2),
 )
 grid = pv.UniformGrid(dimensions=dimensions, spacing=spacing, origin=origin)
-grid = grid.interpolate(mesh, radius=0.005)
+grid = grid.sample(air)
 
 pl = pv.Plotter()
 vol = pl.add_volume(
@@ -99,6 +115,6 @@ vol = pl.add_volume(
     scalar_bar_args={'title': 'Turbulent Kinematic Viscosity'},
 )
 vol.prop.interpolation_type = 'linear'
-pl.add_mesh(mesh, color='w', opacity=0.1)
+pl.add_mesh(air, color='w', opacity=0.1)
 pl.camera_position = 'xz'
 pl.show()

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -3922,7 +3922,7 @@ def download_openfoam_tubes(load=True):  # pragma: no cover
 
     Returns
     -------
-    pyvista.UnstructuredGrid | str
+    pyvista.MultiBlock | str
         DataSet or filename depending on ``load``.
 
     Examples
@@ -3932,7 +3932,8 @@ def download_openfoam_tubes(load=True):  # pragma: no cover
     >>> import pyvista as pv
     >>> from pyvista import examples
     >>> dataset = examples.download_openfoam_tubes()
-    >>> y_slice = dataset.slice('y')
+    >>> air = dataset[0]
+    >>> y_slice = air.slice('y')
     >>> pl = pv.Plotter()
     >>> _ = pl.add_mesh(
     ...     y_slice,
@@ -3940,7 +3941,7 @@ def download_openfoam_tubes(load=True):  # pragma: no cover
     ...     lighting=False,
     ...     scalar_bar_args={'title': 'Flow Velocity'},
     ... )
-    >>> _ = pl.add_mesh(dataset, color='w', opacity=0.25)
+    >>> _ = pl.add_mesh(air, color='w', opacity=0.25)
     >>> pl.enable_anti_aliasing()
     >>> pl.show()
 
@@ -3948,14 +3949,14 @@ def download_openfoam_tubes(load=True):  # pragma: no cover
 
     """
     filename = _download_archive(
-        'fea/turbo_incompressible/Turbo-Incompressible_3-Run_1-SOLUTION_FIELDS.zip',
+        'fvm/turbo_incompressible/Turbo-Incompressible_3-Run_1-SOLUTION_FIELDS.zip',
         target_file='case.foam',
     )
     if not load:
         return filename
     reader = pyvista.OpenFOAMReader(filename)
     reader.set_active_time_value(1000)
-    return reader.read()[0]
+    return reader.read()
 
 
 def download_lucy(load=True):  # pragma: no cover

--- a/tests/examples/test_download_files.py
+++ b/tests/examples/test_download_files.py
@@ -497,7 +497,7 @@ def test_download_openfoam_tubes():
     assert os.path.isfile(filename)
 
     dataset = examples.download_openfoam_tubes(load=True)
-    assert isinstance(dataset, pv.UnstructuredGrid)
+    assert isinstance(dataset, pv.MultiBlock)
 
 
 def test_download_lucy():


### PR DESCRIPTION
Fix the `Plot CFD Data` example by incorporating the following suggestions from @MatthewFlamm:

- Use the inlet with `streamlines_from_source`.
- Return the entire `MultiBlock`.
- `sample` rather than `interpolate`
