### PR TITLE
Fix add_composite use within add_mesh

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3216,7 +3216,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 raise TypeError(
                     'Algorithms with `MultiBlock` output type are not supported by `add_mesh` at this time.'
                 )
-            return self.add_composite(
+            actor, _ = self.add_composite(
                 mesh,
                 color=color,
                 style=style,
@@ -3263,6 +3263,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 show_vertices=show_vertices,
                 **kwargs,
             )
+            return actor
         elif copy_mesh and algo is None:
             # A shallow copy of `mesh` is made here so when we set (or add) scalars
             # active, it doesn't modify the original input mesh.


### PR DESCRIPTION
Fixes issue found in https://github.com/pyvista/pyvista/discussions/4218#discussioncomment-5553784

`add_mesh` returns the actor added to the scene. It's internal use of `add_composite` would return an actor and a mapper. These changes fix that return value for `add_mesh`.

IMO, `add_composite` should not return a mapper as that is easily accessible from the actor:

```py
import pyvista as pv

blocks = pv.MultiBlock([pv.Sphere(), pv.Cone()])

pl = pv.Plotter()
actor, _ = pl.add_composite(blocks)
actor.mapper
```

But this would be a breaking API change and should probably come as it's own PR with a bit more intention and focus