### PR TITLE
Update windows doc building command.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -586,7 +586,7 @@ Build the documentation on Windows with:
 
 .. code:: winbatch
 
-   cd doc
+   cd doc/source
    python -msphinx -M html . _build
 
 The generated documentation can be found in the ``doc/_build/html``

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -586,7 +586,8 @@ Build the documentation on Windows with:
 
 .. code:: winbatch
 
-   cd doc/source
+   cd doc
+   python -msphinx -M html source _build
    python -msphinx -M html . _build
 
 The generated documentation can be found in the ``doc/_build/html``


### PR DESCRIPTION
Update the windows command for building the documentation.

### Overview

The location of the `conf.py` file has changed, so the current command for building the documentation in windows is not working. 
