### PR TITLE
Bump sphinx to v6.1.3

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -20,7 +20,7 @@ pypandoc==1.11
 pytest-sphinx==0.5.0
 pythreejs==2.4.2
 scipy==1.10.1
-Sphinx==5.3.0
+Sphinx==6.1.3
 sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.2
 sphinx-design==0.4.1


### PR DESCRIPTION
We can finally bump Sphinx to >6 now that [sphinx_design](https://pypi.org/project/sphinx_design/) supports it.
