### PR TITLE
Fix specular values in examples

### DIFF
--- a/examples/01-filter/flying_edges.py
+++ b/examples/01-filter/flying_edges.py
@@ -48,7 +48,7 @@ x, y, z = grid.points.T
 values = spider_cage(x, y, z)
 mesh = grid.contour([1], values, method='marching_cubes')
 dist = np.linalg.norm(mesh.points, axis=1)
-mesh.plot(scalars=dist, smooth_shading=True, specular=5, cmap="plasma", show_scalar_bar=False)
+mesh.plot(scalars=dist, smooth_shading=True, specular=1, cmap="plasma", show_scalar_bar=False)
 
 
 ###############################################################################
@@ -90,7 +90,7 @@ x, y, z = grid.points.T
 values = barth_sextic(x, y, z)
 mesh = grid.contour([0], values, method='flying_edges')
 dist = np.linalg.norm(mesh.points, axis=1)
-mesh.plot(scalars=dist, smooth_shading=True, specular=5, cmap="plasma", show_scalar_bar=False)
+mesh.plot(scalars=dist, smooth_shading=True, specular=1, cmap="plasma", show_scalar_bar=False)
 
 
 ###############################################################################
@@ -118,7 +118,7 @@ for angle in np.linspace(0, np.pi, 20, endpoint=False):
         mesh,
         scalars=dist,
         smooth_shading=True,
-        specular=5,
+        specular=1,
         rng=[0.5, 1.5],
         cmap="plasma",
         show_scalar_bar=False,

--- a/examples/01-filter/image-fft-perlin-noise.py
+++ b/examples/01-filter/image-fft-perlin-noise.py
@@ -75,9 +75,9 @@ pl = pv.Plotter(lighting='three lights')
 pl.add_mesh(warped_subset, cmap='blues', show_scalar_bar=False)
 pl.show_bounds(
     axes_ranges=(0, max_freq, 0, max_freq, 0, warped_subset.bounds[-1]),
-    xlabel='X Frequency',
-    ylabel='Y Frequency',
-    zlabel='Amplitude',
+    xtitle='X Frequency',
+    ytitle='Y Frequency',
+    ztitle='Amplitude',
     show_zlabels=False,
     color='k',
     font_size=26,

--- a/examples/02-plot/moving_cmap.py
+++ b/examples/02-plot/moving_cmap.py
@@ -62,7 +62,7 @@ pltr.add_mesh(
     mesh,
     scalars=np.sin(dists),
     smooth_shading=True,
-    specular=10,
+    specular=1,
     cmap="nipy_spectral",
     show_scalar_bar=False,
 )


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
This is an omission of correction in the #4226 changes.

The error occurred when running locally. I think this error should also occur when the document is built, but I would like to know why it did not occur.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

-[ The build of the Japanese page stopped for two weeks because of this error](https://github.com/pyvista/pyvista-docs-dev-ja/actions), so I think it is a CI issue.

