### PR TITLE
Add clear_data option for edge extraction

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1389,7 +1389,7 @@ class DataSetFilters:
         _update_alg(alg, progress_bar, 'Extracting Geometry')
         return _get_output(alg)
 
-    def extract_all_edges(self, use_all_points=False, progress_bar=False):
+    def extract_all_edges(self, use_all_points=False, clear_data=False, progress_bar=False):
         """Extract all the internal/external edges of the dataset as PolyData.
 
         This produces a full wireframe representation of the input dataset.
@@ -1406,6 +1406,10 @@ class DataSetFilters:
             from the output.
 
             This parameter can only be set to ``True`` with ``vtk==9.1.0`` or newer.
+
+        clear_data : bool, default: False
+            Clear any point, cell, or field data. This is useful
+            if wanting to strictly extract the edges.
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
@@ -1444,7 +1448,10 @@ class DataSetFilters:
         _update_alg(alg, progress_bar, 'Extracting All Edges')
         # Reset vtkLogger to default verbosity level
         _vtk.vtkLogger.SetStderrVerbosity(_vtk.vtkLogger.VERBOSITY_INFO)
-        return _get_output(alg)
+        output = _get_output(alg)
+        if clear_data:
+            output.clear_data()
+        return output
 
     def elevation(
         self,
@@ -4541,6 +4548,7 @@ class DataSetFilters:
         non_manifold_edges=True,
         feature_edges=True,
         manifold_edges=True,
+        clear_data=False,
         progress_bar=False,
     ):
         """Extract edges from the surface of the mesh.
@@ -4573,6 +4581,10 @@ class DataSetFilters:
 
         manifold_edges : bool, default: True
             Extract manifold edges.
+
+        clear_data : bool, default: False
+            Clear any point, cell, or field data. This is useful
+            if wanting to strictly extract the edges.
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
@@ -4608,7 +4620,10 @@ class DataSetFilters:
         featureEdges.SetFeatureEdges(feature_edges)
         featureEdges.SetColoring(False)
         _update_alg(featureEdges, progress_bar, 'Extracting Feature Edges')
-        return _get_output(featureEdges)
+        output = _get_output(featureEdges)
+        if clear_data:
+            output.clear_data()
+        return output
 
     def merge(
         self,

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -602,6 +602,14 @@ def test_extract_all_edges(datasets):
         assert edges.n_lines
 
 
+def test_extract_all_edges_no_data():
+    mesh = pyvista.Wavelet()
+    edges = mesh.extract_all_edges(clear_data=True)
+    assert edges is not None
+    assert isinstance(edges, pyvista.PolyData)
+    assert edges.n_arrays == 0
+
+
 def test_wireframe_composite(composite):
     # Now test composite data structures
     output = composite.extract_all_edges(progress_bar=True)

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -507,6 +507,14 @@ def test_extract_feature_edges(sphere):
     assert more_edges.n_points
 
 
+def test_extract_feature_edges_no_data():
+    mesh = pyvista.Wavelet()
+    edges = mesh.extract_feature_edges(90, clear_data=True)
+    assert edges is not None
+    assert isinstance(edges, pyvista.PolyData)
+    assert edges.n_arrays == 0
+
+
 def test_decimate(sphere):
     mesh = sphere.decimate(0.5, progress_bar=True)
     assert mesh.n_points < sphere.n_points


### PR DESCRIPTION
Adds an option to clear data when extracting edges. Been using these APIs to extract mesh boundaries, etc., and found that I often want to clear the data arrays from these edges. Having this option seems widely applicable and since `clear_data()` is an in-place operation, easier to but as an option in the API than have users do it (as they cannot chain the operation)