### PR TITLE
Show scalar bar if scalar_bar_args are passed

### DIFF
--- a/pyvista/plotting/_plotting.py
+++ b/pyvista/plotting/_plotting.py
@@ -224,6 +224,10 @@ def _common_arg_parser(
     elif culling in ['f', 'frontface']:
         culling = 'front'
 
+    if show_scalar_bar is None:
+        # use theme unless plotting RGB
+        _default = theme.show_scalar_bar or scalar_bar_args is not None
+        show_scalar_bar = False if rgb else _default
     # Avoid mutating input
     if scalar_bar_args is None:
         scalar_bar_args = {'n_colors': n_colors}
@@ -233,9 +237,6 @@ def _common_arg_parser(
     # theme based parameters
     if split_sharp_edges is None:
         split_sharp_edges = theme.split_sharp_edges
-    if show_scalar_bar is None:
-        # use theme unless plotting RGB
-        show_scalar_bar = False if rgb else theme.show_scalar_bar
     feature_angle = kwargs.pop('feature_angle', theme.sharp_edges_feature_angle)
     if render_points_as_spheres is None:
         if style == 'points_gaussian':

--- a/pyvista/plotting/_plotting.py
+++ b/pyvista/plotting/_plotting.py
@@ -226,7 +226,7 @@ def _common_arg_parser(
 
     if show_scalar_bar is None:
         # use theme unless plotting RGB
-        _default = theme.show_scalar_bar or scalar_bar_args is not None
+        _default = theme.show_scalar_bar or scalar_bar_args
         show_scalar_bar = False if rgb else _default
     # Avoid mutating input
     if scalar_bar_args is None:

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3894,7 +3894,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         assert_empty_kwargs(**kwargs)
 
         if show_scalar_bar is None:
-            show_scalar_bar = self._theme.show_scalar_bar or scalar_bar_args is not None
+            show_scalar_bar = self._theme.show_scalar_bar or scalar_bar_args
 
         # Avoid mutating input
         if scalar_bar_args is None:

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3893,6 +3893,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
             )
         assert_empty_kwargs(**kwargs)
 
+        if show_scalar_bar is None:
+            show_scalar_bar = self._theme.show_scalar_bar or scalar_bar_args is not None
+
         # Avoid mutating input
         if scalar_bar_args is None:
             scalar_bar_args = {}
@@ -3903,9 +3906,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
             # Deprecated on ..., estimated removal on v0.40.0
             warnings.warn(USE_SCALAR_BAR_ARGS, PyVistaDeprecationWarning)
             scalar_bar_args.setdefault('title', kwargs.pop('stitle'))
-
-        if show_scalar_bar is None:
-            show_scalar_bar = self._theme.show_scalar_bar
 
         if culling is True:
             culling = 'backface'


### PR DESCRIPTION
I've been wanting tight control of scalar bars lately and found that if you set `show_scalar_bar=False` on the theme and then pass `scalar_bar_args` to `add_mesh()`, the scalar bar is still hidden. IMO, if the user is explicitly passing `scalar_bar_args`, then they probably want to show the scalar bar.

This PR makes this scenario a bit easier.

For example:

```py
import pyvista as pv

pv.global_theme.show_scalar_bar = False

pl = pv.Plotter()
pl.add_mesh(pv.Wavelet(), scalar_bar_args=dict(title='foo'))  # I expect scalar bar to show
pl.show()
```