### PR TITLE
Fix the edit this page link

### DIFF
--- a/doc/source/_templates/edit-this-page.html
+++ b/doc/source/_templates/edit-this-page.html
@@ -1,0 +1,16 @@
+{% if sourcename is defined and theme_use_edit_page_button and page_source_suffix %}
+  {% set src = sourcename.split('.') %}
+  <div class="tocsection editthispage">
+    <a href="{{ fix_edit_link_button(get_edit_provider_and_url()[1]) }}">
+      <i class="fa-solid fa-pencil"></i>
+      {% set provider = get_edit_provider_and_url()[0] %}
+      {% block edit_this_page_text %}
+        {% if provider %}
+          {% trans provider=provider %}Edit on {{ provider }}{% endtrans %}
+        {% else %}
+          {% trans %}Edit{% endtrans %}
+        {% endif %}
+      {% endblock %}
+    </a>
+  </div>
+{% endif %}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -18,7 +18,7 @@ make_tables.make_all_tables()
 
 # -- pyvista configuration ---------------------------------------------------
 import pyvista
-from pyvista.utilities.docs import linkcode_resolve  # noqa: F401
+from pyvista.utilities.docs import linkcode_resolve, pv_html_page_context  # noqa: F401
 
 # Manage errors
 pyvista.set_error_output_file("errors.txt")
@@ -465,12 +465,12 @@ SphinxDocString._str_examples = _str_examples
 import pydata_sphinx_theme  # noqa
 
 html_theme = "pydata_sphinx_theme"
-# html_theme_path = [pydata_sphinx_theme.get_html_theme_path()]
 html_context = {
     "github_user": "pyvista",
     "github_repo": "pyvista",
     "github_version": "main",
-    "doc_path": "doc",
+    "doc_path": "doc/source",
+    "examples_path": "examples",
 }
 html_show_sourcelink = False
 html_copy_source = False
@@ -614,6 +614,7 @@ copybutton_prompt_is_regexp = True
 
 
 def setup(app):
+    app.connect("html-page-context", pv_html_page_context)
     app.add_css_file("copybutton.css")
     app.add_css_file("no_search_highlight.css")
     app.add_css_file("summary.css")

--- a/pyvista/utilities/docs.py
+++ b/pyvista/utilities/docs.py
@@ -5,7 +5,7 @@ import os.path as op
 import sys
 
 
-def linkcode_resolve(domain, info):
+def linkcode_resolve(domain, info, edit=False):
     """Determine the URL corresponding to a Python object.
 
     Parameters
@@ -15,6 +15,9 @@ def linkcode_resolve(domain, info):
 
     info : dict
         With keys "module" and "fullname".
+
+    edit : bool, default=False
+        Jump right to the edit page.
 
     Returns
     -------
@@ -70,7 +73,7 @@ def linkcode_resolve(domain, info):
     except Exception:  # pragma: no cover
         lineno = None
 
-    if lineno:
+    if lineno and not edit:
         linespec = f"#L{lineno}-L{lineno + len(source) - 1}"
     else:
         linespec = ""
@@ -80,4 +83,56 @@ def linkcode_resolve(domain, info):
     else:  # pragma: no cover
         kind = 'release/%s' % ('.'.join(pyvista.__version__.split('.')[:2]))
 
-    return f"http://github.com/pyvista/pyvista/blob/{kind}/pyvista/{fn}{linespec}"
+    blob_or_edit = 'edit' if edit else 'blob'
+
+    return f"http://github.com/pyvista/pyvista/{blob_or_edit}/{kind}/pyvista/{fn}{linespec}"
+
+
+def pv_html_page_context(
+    app, pagename: str, templatename: str, context, doctree
+) -> None:  # pragma: no cover
+    """Add a function that jinja can access for returning an "edit this page" link pointing to `main`.
+
+    This is specific to PyVista to ensure that the "edit this page" link always
+    goes to the right page, specifically for:
+
+    - Gallery examples
+    - Autosummary examples (using _autosummary)
+
+    """
+
+    def fix_edit_link_button(link: str) -> str:
+        """Transform "edit on github" links to the correct url.
+
+        This is specific to PyVista to ensure that the "edit this page" link
+        always goes to the right page, specifically for:
+
+        - Gallery examples
+        - Autosummary examples (using _autosummary)
+
+        Parameters
+        ----------
+        link : str
+            The link to the github edit interface.
+
+        Returns
+        -------
+        str
+            The link to the tip of the main branch for the same file.
+
+        """
+        if pagename.startswith('examples') and 'index' not in pagename:
+            # This is a gallery example.
+
+            # We can get away with directly using the pagename since "examples"
+            # in the pagename is the same as the "examples" directory in the
+            # repo
+            return f"http://github.com/pyvista/pyvista/edit/main/{pagename}.py"
+        elif "_autosummary" in pagename:
+            # This is an API example
+            fullname = pagename.split('_autosummary')[1][1:]
+            return linkcode_resolve('py', {'module': 'pyvista', 'fullname': fullname}, edit=True)
+        else:
+            return link
+
+    context["fix_edit_link_button"] = fix_edit_link_button


### PR DESCRIPTION
Inspired by https://github.com/pyansys/pymapdl/pull/2012, this PR fixes the "Edit this page" button, which is currently overall because of the move from "doc/" to "doc/source".

Moreover, it also provides correct links for our:
- Gallery examples
- Autosummary examples

These were broken even before the documentation move.

---

@germa89 and @jorgepiloto, I suggest that we implement it this way, it's guarenteed to get to the right source file location rather than implementing a search in GitHub.