### PR TITLE
Disable anti-aliasing on openfoam cooling example

### DIFF
--- a/examples/99-advanced/openfoam-cooling.py
+++ b/examples/99-advanced/openfoam-cooling.py
@@ -168,6 +168,5 @@ vol = pl.add_volume(
     scalar_bar_args={'title': 'Temperature'},
 )
 vol.prop.interpolation_type = 'linear'
-pl.enable_anti_aliasing('fxaa')  # also try 'ssaa'
 pl.camera.zoom(2)
 pl.show()


### PR DESCRIPTION
Disable anti-aliasing on openfoam cooling example to see if this fixes the missing volumetric actor.