### PR TITLE
Ensure UnstructuredGrid.cells are read only

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -13,7 +13,7 @@ import numpy as np
 import pyvista
 from pyvista import _vtk
 from pyvista.utilities import abstract_class
-from pyvista.utilities.cells import CellArray, create_mixed_cells, get_mixed_cells
+from pyvista.utilities.cells import CellArray, create_mixed_cells, get_mixed_cells, numpy_to_idarr
 
 from .._typing import BoundsLike
 from ..utilities.fileio import get_ext
@@ -1632,9 +1632,10 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
 
         Notes
         -----
-        This is provided for legacy purposes. Any modifications made here will
-        not affect the underlying data. Use :func:`UnstructuredGrid.cell_connectivity`
-        and :func:`UnstructuredGrid.offset` to modify the underlying cell data.
+        The array returned cannot be modified in place and will raise a
+        ``ValueError`` if attempted.
+
+        You can, however, set the cells directly. See the example.
 
         Examples
         --------
@@ -1644,16 +1645,25 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
 
         >>> import pyvista
         >>> from pyvista import examples
-        >>> hex_beam = pyvista.read(examples.hexbeamfile)
-        >>> hex_beam.cells[:18]  # doctest:+SKIP
-        array([ 8,  0,  2,  8,  7, 27, 36, 90, 81,  8,  2,  1,  4,
-                8, 36, 18, 54, 90])
+        >>> grid = examples.load_hexbeam()
+        >>> grid.cells[:18]
+        array([ 8,  0,  2,  8,  7, 27, 36, 90, 81,  8,  2,  1,  4,  8, 36, 18, 54,
+               90])
+
+        While you cannot change the array inplace, you can overwrite it. For example:
+
+        >>> grid.cells = [8, 0, 1, 2, 3, 4, 5, 6, 7]
 
         """
         # Flag this array as read only to ensure users do not attempt to write to it.
         array = _vtk.vtk_to_numpy(self.GetCells().GetData())
         array.flags['WRITEABLE'] = False
         return array
+
+    @cells.setter
+    def cells(self, cells):
+        vtk_idarr = numpy_to_idarr(cells, deep=False, return_ind=False)
+        self.GetCells().ImportLegacyFormat(vtk_idarr)
 
     @property
     def cells_dict(self) -> dict:

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1576,11 +1576,31 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
 
     @property
     def cells(self) -> np.ndarray:
-        """Return a pointer to the cells as a numpy object.
+        """Return the cell data as a numpy object.
+
+        This is the old style VTK data layout::
+
+           [n0, p0_0, p0_1, ..., p0_n, n1, p1_0, p1_1, ..., p1_n, ...]
+
+        where n0 is the number of points in cell 0, and pX_Y is the Y'th point in cell X.
+
+        For example, a triangle and a line might be represented as:
+
+           [3, 0, 1, 2, 2, 0, 1]
+
+        Where the two individual cells would be ``[3, 0, 1, 2]`` and ``[2, 0, 1]``.
+
+        Notes
+        -----
+        This is provided for legacy purposes. Any modifications made here will
+        not affect the underlying data. Use :func:`DataSet.cell_connectivity`
+        and :func:`pyvista.DataSet.offset` to modify the underlying cell data.
 
         See Also
         --------
         pyvista.DataSet.get_cell
+
+        pyvista.DataSet.cell_connectivity
 
         Examples
         --------
@@ -1596,7 +1616,10 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
                 8, 36, 18, 54, 90])
 
         """
-        return _vtk.vtk_to_numpy(self.GetCells().GetData())
+        # Flag this array as read only to ensure users do not attempt to write to it.
+        array = _vtk.vtk_to_numpy(self.GetCells().GetData())
+        array.flags['WRITEABLE'] = False
+        return array
 
     @property
     def cells_dict(self) -> dict:

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1582,25 +1582,26 @@ class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilt
 
            [n0, p0_0, p0_1, ..., p0_n, n1, p1_0, p1_1, ..., p1_n, ...]
 
-        where n0 is the number of points in cell 0, and pX_Y is the Y'th point in cell X.
+        where ``n0`` is the number of points in cell 0, and ``pX_Y`` is the
+        Y'th point in cell X.
 
-        For example, a triangle and a line might be represented as:
+        For example, a triangle and a line might be represented as::
 
            [3, 0, 1, 2, 2, 0, 1]
 
         Where the two individual cells would be ``[3, 0, 1, 2]`` and ``[2, 0, 1]``.
 
-        Notes
-        -----
-        This is provided for legacy purposes. Any modifications made here will
-        not affect the underlying data. Use :func:`DataSet.cell_connectivity`
-        and :func:`pyvista.DataSet.offset` to modify the underlying cell data.
-
         See Also
         --------
         pyvista.DataSet.get_cell
+        pyvista.UnstructuredGrid.cell_connectivity
+        pyvista.UnstructuredGrid.offset
 
-        pyvista.DataSet.cell_connectivity
+        Notes
+        -----
+        This is provided for legacy purposes. Any modifications made here will
+        not affect the underlying data. Use :func:`UnstructuredGrid.cell_connectivity`
+        and :func:`UnstructuredGrid.offset` to modify the underlying cell data.
 
         Examples
         --------

--- a/pyvista/demos/logo.py
+++ b/pyvista/demos/logo.py
@@ -148,7 +148,7 @@ def plot_logo(
     v_grid_atom = atomize(v_grid)
     v_grid_atom['scalars'] = v_grid_atom.points[:, 0]
     v_grid_atom_surf = v_grid_atom.extract_surface()
-    faces = v_grid_atom_surf.faces.reshape(-1, 5)
+    faces = v_grid_atom_surf.faces.reshape(-1, 5).copy()
     faces[:, 1:] = faces[:, 1:][:, ::-1]
     v_grid_atom_surf.faces = faces
     plotter.add_mesh(

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -146,6 +146,14 @@ def test_init_from_arrays(specify_offset):
     assert np.allclose(cells, grid.cells)
     assert np.allclose(grid.cell_connectivity, np.arange(16))
 
+    # grid.cells is not mutable
+    assert not grid.cells.flags['WRITEABLE']
+
+    # but attribute can be set
+    new_cells = [8, 0, 1, 2, 3, 4, 5, 6, 7]
+    grid.cells = [8, 0, 1, 2, 3, 4, 5, 6, 7]
+    assert np.allclose(grid.cells, new_cells)
+
 
 @pytest.mark.parametrize('multiple_cell_types', [False, True])
 @pytest.mark.parametrize('flat_cells', [False, True])
@@ -178,7 +186,6 @@ def test_init_from_dict(multiple_cell_types, flat_cells):
     assert np.all(grid.offset == offsets)
     assert grid.n_cells == (3 if multiple_cell_types else 2)
     assert np.all(grid.cells == vtk_cell_format)
-    assert not grid.cells.flags['WRITEABLE']
     assert np.allclose(
         grid.cell_connectivity, (np.arange(20) if multiple_cell_types else np.arange(16))
     )

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -178,6 +178,7 @@ def test_init_from_dict(multiple_cell_types, flat_cells):
     assert np.all(grid.offset == offsets)
     assert grid.n_cells == (3 if multiple_cell_types else 2)
     assert np.all(grid.cells == vtk_cell_format)
+    assert not grid.cells.flags['WRITEABLE']
     assert np.allclose(
         grid.cell_connectivity, (np.arange(20) if multiple_cell_types else np.arange(16))
     )

--- a/tests/test_polydata.py
+++ b/tests/test_polydata.py
@@ -82,6 +82,15 @@ def test_init_from_arrays():
     with pytest.warns(Warning):
         mesh = pyvista.PolyData(vertices.astype(np.int32), faces)
 
+    # array must be immutable
+    with pytest.raises(ValueError):
+        mesh.faces[0] += 1
+
+    # attribute is mutable
+    faces = [4, 0, 1, 2, 3]
+    mesh.faces = faces
+    assert np.allclose(faces, mesh.faces)
+
 
 def test_init_from_arrays_with_vert():
     vertices = np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0], [0.5, 0.5, -1], [0, 1.5, 1.5]])


### PR DESCRIPTION
As of vtk v9, [vtkCellArray.GetData](https://vtk.org/doc/nightly/html/classvtkCellArray.html#a2841af7d1aae4c8db8544b2317dc712b) is no longer a pointer to the underlying data:

> The returned array is not the actual internal representation used by vtkCellArray. Modifications to the returned array will not change the vtkCellArray's topology.

This means that any changes ``pyvista.UnstructuredGrid.cells`` will not be reflected in the cell data. For example, even though the cells array was modified, the changes are not propigated back to the VTK data:

```py
>>> from pyvista import examples
>>> grid = examples.load_hexbeam()
>>> grid.cells[:10]
array([ 8,  0,  2,  8,  7, 27, 36, 90, 81,  8])

>>> grid.cells[1] = 10000
>>> grid.cells[:10]
array([ 8,  0,  2,  8,  7, 27, 36, 90, 81,  8])
```

To prevent this, we can simply modify the ``WRITEABLE`` [flags](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.flags.html) to effectively let the user know that the array cannot be written to to change the behavior to:

```py
>>> grid.cells[1] = 10000

ValueError: assignment destination is read-only
```

Resolves #2705.