### PR TITLE
Deprecate offset in UnstructuredGrid

### DIFF
--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -105,9 +105,6 @@ def test_init_bad_input():
     with pytest.raises(TypeError, match="must be a numeric type"):
         pyvista.UnstructuredGrid(np.array(1), np.array(1), 'woa')
 
-    with pytest.raises(TypeError, match="must be sequences"):
-        pyvista.UnstructuredGrid(*range(4))
-
     with pytest.raises(TypeError, match="requires the following arrays"):
         pyvista.UnstructuredGrid(*range(5))
 
@@ -127,20 +124,12 @@ def create_hex_example():
     )
 
     points = np.vstack((cell1, cell2))
-    offset = np.array([0, 9], np.int8)
-
-    return offset, cells, cell_type, points
+    return cells, cell_type, points
 
 
-# Try both with and without an offset array
-@pytest.mark.parametrize('specify_offset', [False, True])
-def test_init_from_arrays(specify_offset):
-    offset, cells, cell_type, points = create_hex_example()
-    if specify_offset:
-        grid = pyvista.UnstructuredGrid(cells, cell_type, points, deep=False)
-    else:
-        with pytest.warns(UserWarning, match="no longer accepts an offset array"):
-            grid = pyvista.UnstructuredGrid(offset, cells, cell_type, points, deep=False)
+def test_init_from_arrays():
+    cells, cell_type, points = create_hex_example()
+    grid = pyvista.UnstructuredGrid(cells, cell_type, points, deep=False)
 
     assert grid.n_cells == 2
     assert np.allclose(cells, grid.cells)
@@ -151,7 +140,7 @@ def test_init_from_arrays(specify_offset):
 @pytest.mark.parametrize('flat_cells', [False, True])
 def test_init_from_dict(multiple_cell_types, flat_cells):
     # Try mixed construction
-    _, vtk_cell_format, cell_type, points = create_hex_example()
+    vtk_cell_format, cell_type, points = create_hex_example()
 
     offsets = np.array([0, 8, 16])
     cells_hex = np.array([[0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15]])


### PR DESCRIPTION
Since we now require VTK >= 9.0, we no longer need backwards compatibility when initializing using the `offset` array.

This PR removes the now unnecessary logic to support the `offset` array.
