### PR TITLE
Make imageio an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
 ]
 dependencies = [
-    'imageio',
     'matplotlib>=3.0.1',
     'numpy',
     'pillow',
@@ -38,6 +37,7 @@ dynamic = ['version']
 
 [project.optional-dependencies]
 all = [
+    'imageio',
     'cmocean',
     'colorcet',
     'ipyvtklink',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ all = [
     'imageio',
     'cmocean',
     'colorcet',
-    'imageio',
     'ipyvtklink',
     'ipywidgets',
     'jupyter-server-proxy',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,16 +40,27 @@ all = [
     'imageio',
     'cmocean',
     'colorcet',
+    'imageio',
     'ipyvtklink',
+    'ipywidgets',
+    'jupyter-server-proxy',
     'meshio>=5.2',
+    'nest_asyncio',
     'panel',
     'pythreejs',
+    'trame-client>=2.4.2',
+    'trame-server>=2.8.0',
+    'trame-vtk>=2.4.0',
+    'trame>=2.2.6',
 ]
 colormaps = [
     'cmocean',
     'colorcet',
 ]
-io = ['meshio>=5.2']
+io = [
+    'imageio',
+    'meshio>=5.2'
+]
 jupyter = [
     'ipyvtklink',
     'ipywidgets',

--- a/pyvista/core/texture.py
+++ b/pyvista/core/texture.py
@@ -148,8 +148,8 @@ class Texture(_vtk.vtkTexture, DataObject):
             if image.n_points < 2:
                 raise RuntimeError("Problem reading the image with VTK.")  # pragma: no cover
             self._from_image_data(image)
-        except (KeyError, ValueError):
-            self._from_array(try_imageio_imread(filename))
+        except (KeyError, ValueError, OSError):
+            self._from_array(try_imageio_imread(filename))  # pragma: no cover
 
     def _from_texture(self, texture):
         image = texture.GetInput()

--- a/pyvista/core/texture.py
+++ b/pyvista/core/texture.py
@@ -9,7 +9,7 @@ import numpy as np
 import pyvista as pv
 from pyvista import _vtk
 from pyvista.plotting.opts import AnnotatedIntEnum
-from pyvista.utilities.misc import PyVistaDeprecationWarning, try_imageio_imread
+from pyvista.utilities.misc import PyVistaDeprecationWarning, _try_imageio_imread
 
 from .dataset import DataObject
 
@@ -149,7 +149,7 @@ class Texture(_vtk.vtkTexture, DataObject):
                 raise RuntimeError("Problem reading the image with VTK.")  # pragma: no cover
             self._from_image_data(image)
         except (KeyError, ValueError, OSError):
-            self._from_array(try_imageio_imread(filename))  # pragma: no cover
+            self._from_array(_try_imageio_imread(filename))  # pragma: no cover
 
     def _from_texture(self, texture):
         image = texture.GetInput()

--- a/pyvista/core/texture.py
+++ b/pyvista/core/texture.py
@@ -9,7 +9,7 @@ import numpy as np
 import pyvista as pv
 from pyvista import _vtk
 from pyvista.plotting.opts import AnnotatedIntEnum
-from pyvista.utilities.misc import PyVistaDeprecationWarning
+from pyvista.utilities.misc import PyVistaDeprecationWarning, try_imageio_imread
 
 from .dataset import DataObject
 
@@ -149,9 +149,7 @@ class Texture(_vtk.vtkTexture, DataObject):
                 raise RuntimeError("Problem reading the image with VTK.")  # pragma: no cover
             self._from_image_data(image)
         except (KeyError, ValueError):
-            from imageio import imread
-
-            self._from_array(imread(filename))
+            self._from_array(try_imageio_imread(filename))
 
     def _from_texture(self, texture):
         image = texture.GetInput()

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4848,7 +4848,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             from imageio import get_writer
         except ModuleNotFoundError:  # pragma: no cover
             raise ModuleNotFoundError(
-                'Install imageio to use `open_movie` with:\n\n' '   pip install imageio'
+                'Install imageio to use `open_movie` with:\n\n   pip install imageio'
             ) from None
 
         if isinstance(pyvista.FIGURE_PATH, str) and not os.path.isabs(filename):
@@ -4912,7 +4912,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             from imageio import get_writer
         except ModuleNotFoundError:  # pragma: no cover
             raise ModuleNotFoundError(
-                'Install imageio to use `open_gif` with:\n\n' '   pip install imageio'
+                'Install imageio to use `open_gif` with:\n\n   pip install imageio'
             ) from None
 
         if filename[-3:] != 'gif':

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4811,6 +4811,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def open_movie(self, filename, framerate=24, quality=5, **kwargs):
         """Establish a connection to the ffmpeg writer.
 
+        Requires ``imageio`` to be installed.
+
         Parameters
         ----------
         filename : str
@@ -4850,6 +4852,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
     def open_gif(self, filename, loop=0, fps=10, palettesize=256, subrectangles=False, **kwargs):
         """Open a gif file.
+
+        Requires `imageio` to be installed.
 
         Parameters
         ----------

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4844,7 +4844,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> pl.open_movie('movie.mp4', quality=10)  # doctest:+SKIP
 
         """
-        from imageio import get_writer
+        try:
+            from imageio import get_writer
+        except ModuleNotFoundError:  # pragma: no cover
+            raise ModuleNotFoundError(
+                'Install imageio to use `open_movie` with:\n\n' '   pip install imageio'
+            ) from None
 
         if isinstance(pyvista.FIGURE_PATH, str) and not os.path.isabs(filename):
             filename = os.path.join(pyvista.FIGURE_PATH, filename)
@@ -4853,7 +4858,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def open_gif(self, filename, loop=0, fps=10, palettesize=256, subrectangles=False, **kwargs):
         """Open a gif file.
 
-        Requires `imageio` to be installed.
+        Requires ``imageio`` to be installed.
 
         Parameters
         ----------
@@ -4903,7 +4908,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
         See :ref:`gif_movie_example` for a full example using this method.
 
         """
-        from imageio import get_writer
+        try:
+            from imageio import get_writer
+        except ModuleNotFoundError:  # pragma: no cover
+            raise ModuleNotFoundError(
+                'Install imageio to use `open_gif` with:\n\n' '   pip install imageio'
+            ) from None
 
         if filename[-3:] != 'gif':
             raise ValueError('Unsupported filetype.  Must end in .gif')

--- a/pyvista/utilities/errors.py
+++ b/pyvista/utilities/errors.py
@@ -337,10 +337,11 @@ class Report(scooby.Report):
     def __init__(self, additional=None, ncol=3, text_width=80, sort=False, gpu=True):
         """Generate a :class:`scooby.Report` instance."""
         # Mandatory packages
-        core = ['pyvista', 'vtk', 'numpy', 'matplotlib', 'imageio', 'scooby', 'pooch']
+        core = ['pyvista', 'vtk', 'numpy', 'matplotlib', 'scooby', 'pooch']
 
         # Optional packages.
         optional = [
+            'imageio',
             'pyvistaqt',
             'PyQt5',
             'IPython',

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -232,6 +232,9 @@ def _apply_attrs_to_reader(reader, attrs):
 def read_texture(filename, attrs=None, progress_bar=False):
     """Load a texture from an image file.
 
+    Will attempt to read any file type supported by ``vtk``, however
+    if it fails, it will attempt to use ``imageio`` to read the file.
+
     Parameters
     ----------
     filename : str

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -8,7 +8,7 @@ import numpy as np
 
 import pyvista
 from pyvista import _vtk
-from pyvista.utilities.misc import PyVistaDeprecationWarning, try_imageio_imread
+from pyvista.utilities.misc import PyVistaDeprecationWarning, _try_imageio_imread
 
 
 def _get_ext_force(filename, force_ext=None):
@@ -280,7 +280,7 @@ def read_texture(filename, attrs=None, progress_bar=False):
         # Otherwise, use the imageio reader
         pass
 
-    return pyvista.Texture(try_imageio_imread(filename))  # pragma: no cover
+    return pyvista.Texture(_try_imageio_imread(filename))  # pragma: no cover
 
 
 def read_exodus(

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -280,7 +280,7 @@ def read_texture(filename, attrs=None, progress_bar=False):
         # Otherwise, use the imageio reader
         pass
 
-    return pyvista.Texture(try_imageio_imread(filename))
+    return pyvista.Texture(try_imageio_imread(filename))  # pragma: no cover
 
 
 def read_exodus(

--- a/pyvista/utilities/fileio.py
+++ b/pyvista/utilities/fileio.py
@@ -8,7 +8,7 @@ import numpy as np
 
 import pyvista
 from pyvista import _vtk
-from pyvista.utilities.misc import PyVistaDeprecationWarning
+from pyvista.utilities.misc import PyVistaDeprecationWarning, try_imageio_imread
 
 
 def _get_ext_force(filename, force_ext=None):
@@ -279,9 +279,8 @@ def read_texture(filename, attrs=None, progress_bar=False):
     except (KeyError, ValueError):
         # Otherwise, use the imageio reader
         pass
-    import imageio
 
-    return pyvista.Texture(imageio.imread(filename))
+    return pyvista.Texture(try_imageio_imread(filename))
 
 
 def read_exodus(

--- a/pyvista/utilities/misc.py
+++ b/pyvista/utilities/misc.py
@@ -43,16 +43,16 @@ def try_imageio_imread(filename):
     filename : str
         Name of the file to read using ``imageio``.
 
+    Returns
+    -------
+    imageio.core.util.Array
+        Image read from ``imageio``.
+
     Raises
     ------
     ModuleNotFoundError
         Raised when ``imageio`` is not installed when attempting to read
         ``filename``.
-
-    Returns
-    -------
-    imageio.core.util.Array
-        Image read from ``imageio``.
 
     """
     try:

--- a/pyvista/utilities/misc.py
+++ b/pyvista/utilities/misc.py
@@ -35,6 +35,38 @@ def _check_range(value, rng, parm_name):
         )
 
 
+def try_imageio_imread(filename):
+    """Attempt to read a file using ``imageio.imread``.
+
+    Parameters
+    ----------
+    filename : str
+        Name of the file to read using ``imageio``.
+
+    Raises
+    ------
+    ModuleNotFoundError
+        Raised when ``imageio`` is not installed when attempting to read
+        ``filename``.
+
+    Returns
+    -------
+    imageio.core.util.Array
+        Image read from ``imageio``.
+
+    """
+    try:
+        from imageio import imread
+    except ModuleNotFoundError:  # pragma: no cover
+        raise ModuleNotFoundError(
+            'Problem reading the image with VTK. Install imageio to try to read the '
+            'file using imageio with:\n\n'
+            '   pip install imageio'
+        ) from None
+
+    return imread(filename)
+
+
 @lru_cache(maxsize=None)
 def has_module(module_name):
     """Return if a module can be imported."""

--- a/pyvista/utilities/misc.py
+++ b/pyvista/utilities/misc.py
@@ -35,7 +35,7 @@ def _check_range(value, rng, parm_name):
         )
 
 
-def try_imageio_imread(filename):
+def _try_imageio_imread(filename):
     """Attempt to read a file using ``imageio.imread``.
 
     Parameters

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 #  This is to prevent installing `vtk` from PyPI
 #  when using a custom variant like `vtk_osmesa`
 #  which we do in some of our CI jobs.
-imageio<2.28.0
 matplotlib<3.7.2
 numpy<1.25.0
 pillow<9.6.0

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -2,6 +2,7 @@
 cmocean==3.0.3
 colorcet==3.0.1
 enum-tools==0.9.0.post1
+imageio==2.27.0
 imageio-ffmpeg==0.4.8
 ipygany==0.5.0
 ipyvtklink==0.2.3

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,10 +1,10 @@
 # Note: using < here to reduce breakages
 # These should be automatically kept up to date by dependabot
 -r requirements.txt
-imageio<2.28.0
 cmocean<3.1
 colorcet<3.1.0
 hypothesis<6.72.2
+imageio<2.28.0
 imageio-ffmpeg<0.5.0
 ipygany<0.6.0
 ipython<9.0.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,7 @@
 # Note: using < here to reduce breakages
 # These should be automatically kept up to date by dependabot
 -r requirements.txt
+imageio<2.28.0
 cmocean<3.1
 colorcet<3.1.0
 hypothesis<6.72.2

--- a/tests/utilities/test_misc.py
+++ b/tests/utilities/test_misc.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from pyvista import examples
-from pyvista.utilities.misc import _set_plot_theme_from_env, has_module, try_imageio_imread
+from pyvista.utilities.misc import _set_plot_theme_from_env, _try_imageio_imread, has_module
 
 HAS_IMAGEIO = True
 try:
@@ -28,5 +28,5 @@ def test_has_module():
 
 @pytest.mark.skipif(not HAS_IMAGEIO, reason="Requires imageio")
 def test_try_imageio_imread():
-    img = try_imageio_imread(examples.mapfile)
+    img = _try_imageio_imread(examples.mapfile)
     assert isinstance(img, imageio.core.util.Array)

--- a/tests/utilities/test_misc.py
+++ b/tests/utilities/test_misc.py
@@ -2,7 +2,14 @@ import os
 
 import pytest
 
-from pyvista.utilities.misc import _set_plot_theme_from_env, has_module
+from pyvista import examples
+from pyvista.utilities.misc import _set_plot_theme_from_env, has_module, try_imageio_imread
+
+HAS_IMAGEIO = True
+try:
+    import imageio
+except ModuleNotFoundError:
+    HAS_IMAGEIO = False
 
 
 def test_set_plot_theme_from_env():
@@ -17,3 +24,9 @@ def test_set_plot_theme_from_env():
 def test_has_module():
     assert has_module('pytest')
     assert not has_module('not_a_module')
+
+
+@pytest.mark.skipif(not HAS_IMAGEIO, reason="Requires imageio")
+def test_try_imageio_imread():
+    img = try_imageio_imread(examples.mapfile)
+    assert isinstance(img, imageio.core.util.Array)

--- a/tests/utilities/test_reader.py
+++ b/tests/utilities/test_reader.py
@@ -9,6 +9,13 @@ import pyvista
 from pyvista import examples
 from pyvista.examples.downloads import download_file
 
+HAS_IMAGEIO = True
+try:
+    import imageio  # noqa: F401
+except ModuleNotFoundError:
+    HAS_IMAGEIO = False
+
+
 pytestmark = pytest.mark.skipif(
     platform.system() == 'Darwin', reason='MacOS testing on Azure fails when downloading'
 )
@@ -924,6 +931,7 @@ def test_hdf_reader():
     assert mesh.n_cells == 4800
 
 
+@pytest.mark.skipif(not HAS_IMAGEIO, reason="Requires imageio")
 def test_gif_reader(gif_file):
     reader = pyvista.get_reader(gif_file)
     assert isinstance(reader, pyvista.GIFReader)


### PR DESCRIPTION
### Overview

As discussed in https://github.com/pyvista/pyvista/issues/4302 and https://github.com/conda-forge/pyvista-feedstock/pull/76.


### Bonus

- Discovered that `imageio==2.28.0` doesn't write multiple frames, so let's keep it `<2.28.0` for now. Reported in https://github.com/imageio/imageio/issues/974


