### PR TITLE
Fix documentation deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -151,7 +151,7 @@ jobs:
         uses: pyansys/actions/doc-deploy-dev@v4
         with:
           token: ${{ secrets.PYVISTA_BOT_TOKEN }}
-          decompress-artifact: true
+          decompress-artifact: false
           repository: 'pyvista/pyvista-docs'
           doc-artifact-name: docs-build
           cname: ${{ env.DOCUMENTATION_CNAME }}
@@ -161,7 +161,7 @@ jobs:
         uses: pyansys/actions/doc-deploy-stable@v4
         with:
           token: ${{ secrets.PYVISTA_BOT_TOKEN }}
-          decompress-artifact: true
+          decompress-artifact: false
           repository: 'pyvista/pyvista-docs'
           doc-artifact-name: docs-build
           cname: ${{ env.DOCUMENTATION_CNAME }}


### PR DESCRIPTION
Turns out we can't decompress the docs.

Caught this on main after merging https://github.com/pyvista/pyvista/pull/4303