### PR TITLE
Do not show edges with render_lines_as_tubes

### DIFF
--- a/pyvista/demos/logo.py
+++ b/pyvista/demos/logo.py
@@ -174,7 +174,6 @@ def plot_logo(
         mesh,
         scalars='scalars',
         style='wireframe',
-        show_edges=True,
         line_width=2,
         cmap='gist_heat',
         backface_culling=True,

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3201,7 +3201,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         if render_lines_as_tubes and show_edges:
             warnings.warn(
-                '`show_edges=True` not supported when `render_lines_as_tubes=True`. Ignoring show_edges',
+                '`show_edges=True` not supported when `render_lines_as_tubes=True`. Ignoring `show_edges`.',
                 UserWarning,
             )
             show_edges = False

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -3199,6 +3199,13 @@ class BasePlotter(PickingHelper, WidgetHelper):
         else:
             self.mapper = DataSetMapper(theme=self.theme)
 
+        if render_lines_as_tubes and show_edges:
+            warnings.warn(
+                '`show_edges=True` not supported when `render_lines_as_tubes=True`. Ignoring show_edges',
+                UserWarning,
+            )
+            show_edges = False
+
         mesh, algo = algorithm_to_mesh_handler(mesh)
 
         # Convert the VTK data object to a pyvista wrapped object if necessary

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -28,6 +28,14 @@ def test_has_render_window_fail():
         pl._make_render_window_current()
 
 
+def test_render_lines_as_tubes_show_edges_warning(sphere):
+    pl = pyvista.Plotter()
+    with pytest.warns(UserWarning, match='not supported'):
+        actor = pl.add_mesh(sphere, render_lines_as_tubes=True, show_edges=True)
+    assert not actor.prop.show_edges
+    assert actor.prop.render_lines_as_tubes
+
+
 def test_screenshot_fail_suppressed_rendering():
     plotter = pyvista.Plotter()
     plotter.suppress_rendering = True


### PR DESCRIPTION
Resolve #4318 by not showing edges and warning when `render_lines_as_tubes=True`.
