### PR TITLE
Add clean unstructured grid

### DIFF
--- a/pyvista/core/filters/unstructured_grid.py
+++ b/pyvista/core/filters/unstructured_grid.py
@@ -2,6 +2,7 @@
 from functools import wraps
 
 from pyvista import _vtk, abstract_class
+from pyvista.core.errors import VTKVersionError
 from pyvista.core.filters import _get_output, _update_alg
 from pyvista.core.filters.data_set import DataSetFilters
 from pyvista.core.filters.poly_data import PolyDataFilters
@@ -46,4 +47,112 @@ class UnstructuredGridFilters(DataSetFilters):
         alg = _vtk.vtkSubdivideTetra()
         alg.SetInputData(self)
         _update_alg(alg)
+        return _get_output(alg)
+
+    def clean(
+        self,
+        tolerance=0,
+        remove_unused_points=True,
+        produce_merge_map=True,
+        average_point_data=True,
+        merging_array_name=None,
+        progress_bar=False,
+    ):
+        """Merge duplicate points and remove unused points, in an UnstructuredGrid.
+
+        This filter, merging coincident points as defined by a merging
+        tolerance and optionally removes unused points. The filter does not
+        modify the topology of the input dataset, nor change the types of
+        cells. It may however, renumber the cell connectivity ids.
+
+        This filter implements `vtkStaticCleanUnstructuredGrid
+        <https://vtk.org/doc/nightly/html/classvtkStaticCleanUnstructuredGrid.html>`_
+
+        Parameters
+        ----------
+        tolerance : float, default: 0.0
+            The absolute point merging tolerance.
+
+        remove_unused_points : bool, default: True
+            Indicate whether points unused by any cell are removed from the
+            output. Note that when this is off, the filter can successfully
+            process datasets with no cells (and just points). If on in this
+            case, and there are no cells, the output will be empty.
+
+        produce_merge_map : bool, default, False
+            Indicate whether a merge map should be produced on output.
+            The merge map, if requested, maps each input point to its
+            output point id, or provides a value of -1 if the input point
+            is not used in the output. The merge map is associated with
+            the filter's output field data and is named ``"PointMergeMap"``.
+
+        average_point_data : bool, default: True
+            Indicate whether point coordinates and point data of merged points
+            are averaged. When ``True``, the data coordinates and attribute
+            values of all merged points are averaged. When ``False``, the point
+            coordinate and data of the single remaining merged point is
+            retained.
+
+        merging_array_name : str, optional
+            If a ``merging_array_name`` is specified and exists in the
+            ``point_data``, then point merging will switch into a mode where
+            merged points must be both geometrically coincident and have
+            matching point data (i.e., an exact match of position and data -
+            tolerances have no effect).
+
+        progress_bar : bool, default: False
+            Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        UnstructuredGrid
+            Cleaned unstructured grid.
+
+        Examples
+        --------
+        Demonstrate cleaning an UnstructuredGrid and show how it can be used to
+        average the point data across merged points.
+
+        >>> import pyvista as pv
+        >>> from pyvista import examples
+        >>> hexbeam = examples.load_hexbeam()
+        >>> hexbeam_shifted = hexbeam.translate([1, 0, 0])
+        >>> hexbeam.point_data['data'] = [0] * hexbeam.n_points
+        >>> hexbeam_shifted.point_data['data'] = [1] * hexbeam.n_points
+        >>> merged = hexbeam.merge(hexbeam_shifted, merge_points=False)
+        >>> cleaned = merged.clean(average_point_data=True)
+        >>> cleaned  # doctest:+SKIP
+        UnstructuredGrid (0x7f02930257e0)
+          N Cells:    80
+          N Points:   165
+          X Bounds:   0.000e+00, 2.000e+00
+          Y Bounds:   0.000e+00, 1.000e+00
+          Z Bounds:   0.000e+00, 5.000e+00
+          N Arrays:   5
+
+        Show how point averaging using the ``clean`` method with
+        ``average_point_data=True`` results in averaged point data for merged
+        points.
+
+        >>> pl = pv.Plotter(shape=(1, 2))
+        >>> _ = pl.add_mesh(merged, scalars='data', show_scalar_bar=False)
+        >>> pl.subplot(0, 1)
+        >>> _ = pl.add_mesh(cleaned, scalars='data')
+        >>> pl.show()
+
+        """
+        try:
+            from vtkmodules.vtkFiltersCore import vtkStaticCleanUnstructuredGrid
+        except ImportError:  # pragma no cover
+            raise VTKVersionError("UnstructuredGrid.clean requires VTK >= 9.2.2") from None
+
+        alg = vtkStaticCleanUnstructuredGrid()
+        alg.SetInputDataObject(self)
+        alg.SetAbsoluteTolerance(True)
+        alg.SetTolerance(tolerance)
+        alg.SetMergingArray(merging_array_name)
+        alg.SetRemoveUnusedPoints(remove_unused_points)
+        alg.SetProduceMergeMap(produce_merge_map)
+        alg.SetAveragePointData(average_point_data)
+        _update_alg(alg, progress_bar, 'Cleaning Unstructured Grid')
         return _get_output(alg)

--- a/pyvista/core/filters/unstructured_grid.py
+++ b/pyvista/core/filters/unstructured_grid.py
@@ -58,7 +58,7 @@ class UnstructuredGridFilters(DataSetFilters):
         merging_array_name=None,
         progress_bar=False,
     ):
-        """Merge duplicate points and remove unused points, in an UnstructuredGrid.
+        """Merge duplicate points and remove unused points in an UnstructuredGrid.
 
         This filter, merging coincident points as defined by a merging
         tolerance and optionally removes unused points. The filter does not
@@ -79,7 +79,7 @@ class UnstructuredGridFilters(DataSetFilters):
             process datasets with no cells (and just points). If on in this
             case, and there are no cells, the output will be empty.
 
-        produce_merge_map : bool, default, False
+        produce_merge_map : bool, default: False
             Indicate whether a merge map should be produced on output.
             The merge map, if requested, maps each input point to its
             output point id, or provides a value of -1 if the input point
@@ -97,8 +97,7 @@ class UnstructuredGridFilters(DataSetFilters):
             If a ``merging_array_name`` is specified and exists in the
             ``point_data``, then point merging will switch into a mode where
             merged points must be both geometrically coincident and have
-            matching point data (i.e., an exact match of position and data -
-            tolerances have no effect).
+            matching point data. When set, ``tolerance`` has no effect.
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
@@ -121,14 +120,8 @@ class UnstructuredGridFilters(DataSetFilters):
         >>> hexbeam_shifted.point_data['data'] = [1] * hexbeam.n_points
         >>> merged = hexbeam.merge(hexbeam_shifted, merge_points=False)
         >>> cleaned = merged.clean(average_point_data=True)
-        >>> cleaned  # doctest:+SKIP
-        UnstructuredGrid (0x7f02930257e0)
-          N Cells:    80
-          N Points:   165
-          X Bounds:   0.000e+00, 2.000e+00
-          Y Bounds:   0.000e+00, 1.000e+00
-          Z Bounds:   0.000e+00, 5.000e+00
-          N Arrays:   5
+        >>> cleaned.n_points < merged.n_points
+        True
 
         Show how point averaging using the ``clean`` method with
         ``average_point_data=True`` results in averaged point data for merged

--- a/tests/filters/test_unstructured_grid.py
+++ b/tests/filters/test_unstructured_grid.py
@@ -1,10 +1,16 @@
 """Tests for UnstructuredGridFilters."""
 
 import numpy as np
+import pytest
 
 import pyvista as pv
 
+skip_lesser_9_2_2 = pytest.mark.skipif(
+    pv.vtk_version_info <= (9, 2, 2), reason='Requires VTK>=9.2.2'
+)
 
+
+@skip_lesser_9_2_2
 def test_clean_points():
     """Test on a set of points."""
     n_unique_points = 100
@@ -36,6 +42,7 @@ def test_clean_points():
     assert cleaned.n_points == points.shape[0]
 
 
+@skip_lesser_9_2_2
 def test_clean_grid(hexbeam):
     hexbeam_shifted = hexbeam.translate([1, 0, 0])
 

--- a/tests/filters/test_unstructured_grid.py
+++ b/tests/filters/test_unstructured_grid.py
@@ -1,0 +1,66 @@
+"""Tests for UnstructuredGridFilters."""
+
+import numpy as np
+
+import pyvista as pv
+
+
+def test_clean_points():
+    """Test on a set of points."""
+    n_unique_points = 100
+    u_points = np.random.random((n_unique_points, 3))
+    points = np.vstack([u_points] * 2)
+
+    grid = pv.PolyData(points).cast_to_unstructured_grid()
+    grid.point_data['data'] = np.hstack((np.zeros(n_unique_points), np.ones(n_unique_points)))
+
+    cleaned = grid.clean(produce_merge_map=True)
+    assert cleaned.field_data['PointMergeMap'].size == points.shape[0]
+    assert cleaned.n_points == n_unique_points
+    assert np.allclose(cleaned.point_data['data'], 0.5)
+    assert cleaned.point_data['data'].size == n_unique_points
+
+    # verify not averaging works
+    cleaned = grid.clean(average_point_data=False)
+    assert cleaned.n_points == n_unique_points
+    assert not (cleaned.point_data['data'] == 0.5).any()
+
+    # verify tolerance
+    u_points = np.random.random((n_unique_points, 3))
+    u_points_shift = u_points.copy()
+    u_points_shift[:, 2] += 1e-4
+    points = np.vstack((u_points, u_points_shift))
+
+    grid = pv.PolyData(points).cast_to_unstructured_grid()
+    cleaned = grid.clean(tolerance=1e-5)
+    assert cleaned.n_points == points.shape[0]
+
+
+def test_clean_grid(hexbeam):
+    hexbeam_shifted = hexbeam.translate([1, 0, 0])
+
+    hexbeam.point_data['data'] = np.zeros(hexbeam.n_points)
+    hexbeam_shifted.point_data['data'] = np.ones(hexbeam.n_points)
+
+    merged = hexbeam.merge(hexbeam_shifted, merge_points=False)
+    cleaned = merged.clean(average_point_data=True, produce_merge_map=False)
+    assert 'PointMergeMap' not in cleaned.field_data
+
+    # expect averaging for all merged nodes
+    n_merged = merged.n_points - cleaned.n_points
+    assert (cleaned['data'] == 0.5).sum() == n_merged
+
+    cleaned = merged.clean(average_point_data=False)
+    assert not (cleaned['data'] == 0.5).any()
+
+    # test merging_array
+    cleaned = merged.clean(average_point_data=True, merging_array_name='data')
+    assert cleaned.n_points == hexbeam.n_points * 2
+
+    hexbeam.point_data['data_2'] = np.ones(hexbeam.n_points)
+    hexbeam_shifted.point_data['data_2'] = np.ones(hexbeam.n_points)
+    merged = hexbeam.merge(hexbeam_shifted, merge_points=False)
+
+    # test merging_array
+    cleaned = merged.clean(average_point_data=True, merging_array_name='data_2')
+    assert cleaned.n_points == 165


### PR DESCRIPTION
Resolve #4345 by adding ``clean`` for ``UnstructuredGrid``.

Also addresses the issues raised in #4357.

```py
Demonstrate cleaning an UnstructuredGrid and show how it can be used to
average the point data across merged points.

>>> import pyvista as pv
>>> from pyvista import examples
>>> hexbeam = examples.load_hexbeam()
>>> hexbeam_shifted = hexbeam.translate([1, 0, 0])
>>> hexbeam.point_data['data'] = [0]*hexbeam.n_points
>>> hexbeam_shifted.point_data['data'] = [1]*hexbeam.n_points
>>> merged = hexbeam.merge(hexbeam_shifted, merge_points=False)
>>> cleaned = merged.clean(average_point_data=True)
>>> cleaned  # doctest:+SKIP
UnstructuredGrid (0x7f02930257e0)
  N Cells:    80
  N Points:   165
  X Bounds:   0.000e+00, 2.000e+00
  Y Bounds:   0.000e+00, 1.000e+00
  Z Bounds:   0.000e+00, 5.000e+00
  N Arrays:   5

Show how point averaging using the ``clean`` method with
``average_point_data=True`` results in averaged point data for merged
points.

>>> pl = pv.Plotter(shape=(1, 2))
>>> _ = pl.add_mesh(merged, scalars='data', show_scalar_bar=False)
>>> pl.subplot(0, 1)
>>> _ = pl.add_mesh(cleaned, scalars='data')
>>> pl.show()
```
![image](https://user-images.githubusercontent.com/11981631/235514269-5f348b6d-9b9b-42bb-b2f7-d038e9aa472a.png)
