### PR TITLE
Use fullname for autosummary

### DIFF
--- a/doc/source/_templates/autosummary/base.rst
+++ b/doc/source/_templates/autosummary/base.rst
@@ -1,4 +1,4 @@
-{{ name | escape | underline}}
+{{ fullname | escape | underline}}
 
 .. currentmodule:: {{ module }}
 


### PR DESCRIPTION
Eliminate duplicate pages within our documentation search by using the ``fullname`` of a class method in the autosummary. For example:

https://docs.pyvista.org/version/dev/search.html?q=clean

## `main` branch
![a](https://user-images.githubusercontent.com/11981631/235522135-deb8a064-b9a9-4da9-b997-75be9c336b10.png)

## This branch
![b](https://user-images.githubusercontent.com/11981631/235522398-8acab62a-2f2d-4a83-a6cb-0c7df96e76d9.png)

(note that displaying the text requires the documentation to be hosted)