### PR TITLE
Resolve issues with imageio 2.28.1

### DIFF
--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4873,7 +4873,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         fps=10,
         palettesize=256,
         subrectangles=False,
-        duration=None,
         **kwargs,
     ):
         """Open a gif file.

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -4866,7 +4866,16 @@ class BasePlotter(PickingHelper, WidgetHelper):
             filename = os.path.join(pyvista.FIGURE_PATH, filename)
         self.mwriter = get_writer(filename, fps=framerate, quality=quality, **kwargs)
 
-    def open_gif(self, filename, loop=0, fps=10, palettesize=256, subrectangles=False, **kwargs):
+    def open_gif(
+        self,
+        filename,
+        loop=0,
+        fps=10,
+        palettesize=256,
+        subrectangles=False,
+        duration=None,
+        **kwargs,
+    ):
         """Open a gif file.
 
         Requires ``imageio`` to be installed.
@@ -4920,7 +4929,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         """
         try:
-            from imageio import get_writer
+            from imageio import __version__, get_writer
         except ModuleNotFoundError:  # pragma: no cover
             raise ModuleNotFoundError(
                 'Install imageio to use `open_gif` with:\n\n   pip install imageio'
@@ -4931,15 +4940,17 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if isinstance(pyvista.FIGURE_PATH, str) and not os.path.isabs(filename):
             filename = os.path.join(pyvista.FIGURE_PATH, filename)
         self._gif_filename = os.path.abspath(filename)
-        self.mwriter = get_writer(
-            filename,
-            mode='I',
-            loop=loop,
-            fps=fps,
-            palettesize=palettesize,
-            subrectangles=subrectangles,
-            **kwargs,
-        )
+
+        kwargs['mode'] = 'I'
+        kwargs['loop'] = loop
+        kwargs['palettesize'] = palettesize
+        kwargs['subrectangles'] = subrectangles
+        if scooby.meets_version(__version__, '2.28.1'):
+            kwargs['duration'] = 1000 * 1 / fps
+        else:  # pragma: no cover
+            kwargs['fps'] = fps
+
+        self.mwriter = get_writer(filename, **kwargs)
 
     def write_frame(self):
         """Write a single frame to the movie file.

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,7 +4,7 @@
 cmocean<3.1
 colorcet<3.1.0
 hypothesis<6.74.2
-imageio<2.28.0
+imageio<2.29.0
 imageio-ffmpeg<0.5.0
 ipygany<0.6.0
 ipython<9.0.0

--- a/tests/utilities/test_misc.py
+++ b/tests/utilities/test_misc.py
@@ -1,5 +1,6 @@
 import os
 
+import numpy as np
 import pytest
 
 from pyvista import examples
@@ -29,4 +30,4 @@ def test_has_module():
 @pytest.mark.skipif(not HAS_IMAGEIO, reason="Requires imageio")
 def test_try_imageio_imread():
     img = _try_imageio_imread(examples.mapfile)
-    assert isinstance(img, imageio.core.util.Array)
+    assert isinstance(img, (imageio.core.util.Array, np.ndarray))


### PR DESCRIPTION
Resolve #4371 by using the `duration` kwarg used in the latest `imageio==2.28.1`.
