### PR TITLE
Fix plot output of docstring

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -153,6 +153,9 @@ class DataSetFilters:
         ... )
         >>> pl.show()
 
+        Show that the mean distance between the source and the target is
+        nearly zero.
+
         >>> np.abs(dist).mean()  # doctest:+SKIP
         9.997635192915073e-05
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -129,8 +129,6 @@ class DataSetFilters:
         ...     source.points, return_closest_point=True
         ... )
         >>> dist = np.linalg.norm(source.points - closest_points, axis=1)
-        >>> np.abs(dist).mean()  # doctest:+SKIP
-        9.997635192915073e-05
 
         Visualize the source, transformed, and aligned meshes.
 
@@ -154,6 +152,9 @@ class DataSetFilters:
         ...     },
         ... )
         >>> pl.show()
+
+        >>> np.abs(dist).mean()  # doctest:+SKIP
+        9.997635192915073e-05
 
         """
         icp = _vtk.vtkIterativeClosestPointTransform()


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
The plotting output for the newly added align method was not displayed, so I fixed it.

| Main  | This PR |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/7513610/236158897-c27aff12-76ef-44e7-82e7-29869d2a5599.png)  | ![image](https://user-images.githubusercontent.com/7513610/236158655-a0397dca-d3a7-424e-b9e2-06d3546375c1.png)  |

<!-- Be sure to link other PRs or issues that relate to this PR here. -->
Follow up of #4361

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- It is better to be able to output the plot without changing the docstring, but I could not find the cause. Ideas are welcome.

