### PR TITLE
Add find_cells_intersecting_line

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2438,7 +2438,7 @@ class DataSet(DataSetFilters, DataObject):
         pointb : sequence[float]
             Length 3 coordinate of the end of the line.
 
-        tolerance : float, default: False
+        tolerance : float, default: 0.0
             The absolute tolerance to use to find cells along line.
 
         Returns
@@ -2492,7 +2492,7 @@ class DataSet(DataSetFilters, DataObject):
         pointb : sequence[float]
             Length 3 coordinate of the end of the line.
 
-        tolerance : float, default: False
+        tolerance : float, default: 0.0
             The absolute tolerance to use to find cells along line.
 
         Returns

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2527,7 +2527,16 @@ class DataSet(DataSetFilters, DataObject):
         id_list = _vtk.vtkIdList()
         points = _vtk.vtkPoints()
         cell = _vtk.vtkGenericCell()
-        locator.IntersectWithLine(pointa, pointb, tolerance, points, id_list, cell)
+        t = _vtk.mutable(0.0)
+        x = [0.0, 0.0, 0.0]
+        sub_id = _vtk.mutable(0.0)
+        pcoords = [0.0, 0.0, 0.0]
+        if pyvista.vtk_version_info >= (9, 2, 0):
+            locator.IntersectWithLine(pointa, pointb, tolerance, points, id_list, cell)
+        else:
+            locator.IntersectWithLine(
+                (pointa, pointb, tolerance, t, x, pcoords, sub_id, points, id_list, cell)
+            )
         return vtk_id_list_to_array(id_list)
 
     def find_cells_within_bounds(self, bounds: Iterable[float]) -> np.ndarray:

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2535,7 +2535,7 @@ class DataSet(DataSetFilters, DataObject):
             locator.IntersectWithLine(pointa, pointb, tolerance, points, id_list, cell)
         else:
             locator.IntersectWithLine(
-                pointa, pointb, tolerance, t, x, pcoords, sub_id, points, id_list, cell
+                pointa, pointb, tolerance, t, x, pcoords, sub_id, id_list, cell
             )
         return vtk_id_list_to_array(id_list)
 

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2459,7 +2459,7 @@ class DataSet(DataSetFilters, DataObject):
         --------
         >>> import pyvista
         >>> mesh = pyvista.Sphere()
-        >>> mesh.find_cells_along_line([0, 0, 0], [1.0, 0])
+        >>> mesh.find_cells_along_line([0.0, 0, 0], [1.0, 0, 0])
         array([842, 843, 896, 897])
 
         """
@@ -2513,7 +2513,7 @@ class DataSet(DataSetFilters, DataObject):
         --------
         >>> import pyvista
         >>> mesh = pyvista.Sphere()
-        >>> mesh.find_cells_intersecting_line([0, 0, 0], [1.0, 0, 0])
+        >>> mesh.find_cells_intersecting_line([0.0, 0, 0], [1.0, 0, 0])
         array([896])
 
         """

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2424,13 +2424,6 @@ class DataSet(DataSetFilters, DataObject):
 
         Line is defined from ``pointa`` to ``pointb``.
 
-        Warnings
-        --------
-        This method returns cells whose bounds intersect the line.
-        This means that the line may not intersect the cell itself.
-        To obtain cells that intersect the line, use
-        :func:`pyvista.DataSet.find_cells_intersecting_line`.
-
         Parameters
         ----------
         pointa : sequence[float]
@@ -2447,6 +2440,13 @@ class DataSet(DataSetFilters, DataObject):
         numpy.ndarray
             Index or indices of the cell(s) whose bounds intersect
             the line.
+
+        Warnings
+        --------
+        This method returns cells whose bounds intersect the line.
+        This means that the line may not intersect the cell itself.
+        To obtain cells that intersect the line, use
+        :func:`pyvista.DataSet.find_cells_intersecting_line`.
 
         See Also
         --------

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2527,16 +2527,14 @@ class DataSet(DataSetFilters, DataObject):
         id_list = _vtk.vtkIdList()
         points = _vtk.vtkPoints()
         cell = _vtk.vtkGenericCell()
-        t = _vtk.mutable(0.0)
-        x = [0.0, 0.0, 0.0]
-        sub_id = _vtk.mutable(0)
-        pcoords = [0.0, 0.0, 0.0]
+        # t = _vtk.mutable(0.0)
+        # x = [0.0, 0.0, 0.0]
+        # sub_id = _vtk.mutable(0)
+        # pcoords = [0.0, 0.0, 0.0]
         if pyvista.vtk_version_info >= (9, 2, 0):
             locator.IntersectWithLine(pointa, pointb, tolerance, points, id_list, cell)
         else:
-            locator.IntersectWithLine(
-                pointa, pointb, tolerance, t, x, pcoords, sub_id, id_list, cell
-            )
+            locator.IntersectWithLine(pointa, pointb, tolerance, points, id_list)
         return vtk_id_list_to_array(id_list)
 
     def find_cells_within_bounds(self, bounds: Iterable[float]) -> np.ndarray:

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2529,7 +2529,7 @@ class DataSet(DataSetFilters, DataObject):
         cell = _vtk.vtkGenericCell()
         t = _vtk.mutable(0.0)
         x = [0.0, 0.0, 0.0]
-        sub_id = _vtk.mutable(0.0)
+        sub_id = _vtk.mutable(0)
         pcoords = [0.0, 0.0, 0.0]
         if pyvista.vtk_version_info >= (9, 2, 0):
             locator.IntersectWithLine(pointa, pointb, tolerance, points, id_list, cell)

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -25,6 +25,7 @@ import numpy as np
 
 import pyvista
 from pyvista import _vtk
+from pyvista.core.errors import VTKVersionError
 from pyvista.utilities import (
     FieldAssociation,
     abstract_class,
@@ -2482,7 +2483,8 @@ class DataSet(DataSetFilters, DataObject):
     ) -> np.ndarray:
         """Find the index of cells that intersect a line.
 
-        Line is defined from ``pointa`` to ``pointb``.
+        Line is defined from ``pointa`` to ``pointb``.  This
+        method requires vtk version >=9.2.0.
 
         Parameters
         ----------
@@ -2517,6 +2519,9 @@ class DataSet(DataSetFilters, DataObject):
         array([896])
 
         """
+        if pyvista.vtk_version_info < (9, 2, 0):
+            raise VTKVersionError("pyvista.PointSet requires VTK >= 9.2.0")
+
         if np.array(pointa).size != 3:
             raise TypeError("Point A must be a length three tuple of floats.")
         if np.array(pointb).size != 3:
@@ -2527,14 +2532,7 @@ class DataSet(DataSetFilters, DataObject):
         id_list = _vtk.vtkIdList()
         points = _vtk.vtkPoints()
         cell = _vtk.vtkGenericCell()
-        # t = _vtk.mutable(0.0)
-        # x = [0.0, 0.0, 0.0]
-        # sub_id = _vtk.mutable(0)
-        # pcoords = [0.0, 0.0, 0.0]
-        if pyvista.vtk_version_info >= (9, 2, 0):
-            locator.IntersectWithLine(pointa, pointb, tolerance, points, id_list, cell)
-        else:
-            locator.IntersectWithLine(pointa, pointb, tolerance, points, id_list)
+        locator.IntersectWithLine(pointa, pointb, tolerance, points, id_list, cell)
         return vtk_id_list_to_array(id_list)
 
     def find_cells_within_bounds(self, bounds: Iterable[float]) -> np.ndarray:

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2535,7 +2535,7 @@ class DataSet(DataSetFilters, DataObject):
             locator.IntersectWithLine(pointa, pointb, tolerance, points, id_list, cell)
         else:
             locator.IntersectWithLine(
-                (pointa, pointb, tolerance, t, x, pcoords, sub_id, points, id_list, cell)
+                pointa, pointb, tolerance, t, x, pcoords, sub_id, points, id_list, cell
             )
         return vtk_id_list_to_array(id_list)
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -983,6 +983,13 @@ def test_find_cells_intersecting_line():
 
         indices = mesh.find_cells_intersecting_line([0, 0, 0.0], [1.0, 0, 0.0], tolerance=0.01)
         assert len(indices) == 2
+
+        with pytest.raises(TypeError):
+            mesh.find_cells_intersecting_line([0, 0], [1.0, 0, 0.0])
+
+        with pytest.raises(TypeError):
+            mesh.find_cells_intersecting_line([0, 0, 0.0], [1.0, 0])
+
     else:
         with pytest.raises(VTKVersionError):
             mesh = pyvista.Sphere()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -975,6 +975,15 @@ def test_find_cells_along_line():
     assert len(indices) == 2
 
 
+def test_find_cells_intersecting_line():
+    mesh = pyvista.Sphere()
+    indices = mesh.find_cells_intersecting_line([0, 0, 0.0], [1.0, 0, 0.0])
+    assert len(indices) == 1
+
+    indices = mesh.find_cells_intersecting_line([0, 0, 0.0], [1.0, 0, 0.0], tolerance=0.01)
+    assert len(indices) == 2
+
+
 def test_find_cells_within_bounds():
     mesh = pyvista.Cube()
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -976,12 +976,18 @@ def test_find_cells_along_line():
 
 
 def test_find_cells_intersecting_line():
-    mesh = pyvista.Sphere()
-    indices = mesh.find_cells_intersecting_line([0, 0, 0.0], [1.0, 0, 0.0])
-    assert len(indices) == 1
+    if pyvista.vtk_version_info >= (9, 2, 0):
+        mesh = pyvista.Sphere()
+        indices = mesh.find_cells_intersecting_line([0, 0, 0.0], [1.0, 0, 0.0])
+        assert len(indices) == 1
 
-    indices = mesh.find_cells_intersecting_line([0, 0, 0.0], [1.0, 0, 0.0], tolerance=0.01)
-    assert len(indices) == 2
+        indices = mesh.find_cells_intersecting_line([0, 0, 0.0], [1.0, 0, 0.0], tolerance=0.01)
+        assert len(indices) == 2
+    else:
+        with pytest.raises(VTKVersionError):
+            mesh = pyvista.Sphere()
+            indices = mesh.find_cells_intersecting_line([0, 0, 0.0], [1.0, 0, 0.0])
+            assert len(indices) == 1
 
 
 def test_find_cells_within_bounds():


### PR DESCRIPTION
### Overview

Closes #4398.  This PR first fixes the description of `find_cells_along_line` to clarify that it is finding cells whose bounds intersect the line and not the cells themselves.  The PR adds `find_cells_intersecting_line` to find cells that directly intersect the lines.


### Details

I updated the examples to be better.  The original example put the line in the (0, 0, 1) direction which should go through the vertex at the top of the sphere where many many cells converge together.  It is better to use the (1, 0, 0) direction where it should only intersect 1 cell.  The examples now highlight the difference between the methods where `find_cells_along_line` returns multiple cells, whereas `find_cells_intersecting_line` returns only 1 cell.

