### PR TITLE
Fix active scalars and pass point data in `to_tetrahedra` for `RectilinearGrid`

### DIFF
--- a/pyvista/core/filters/rectilinear_grid.py
+++ b/pyvista/core/filters/rectilinear_grid.py
@@ -60,6 +60,9 @@ class RectilinearGridFilters:
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
 
+        **kwargs : dict, optional
+            Deprecated keyword argument ``pass_cell_data``.
+
         Returns
         -------
         pyvista.UnstructuredGrid

--- a/pyvista/core/filters/rectilinear_grid.py
+++ b/pyvista/core/filters/rectilinear_grid.py
@@ -2,24 +2,29 @@
 
 import collections
 from typing import Sequence, Union
+import warnings
 
 import numpy as np
 
 from pyvista import _vtk, abstract_class
 from pyvista.core.filters import _get_output, _update_alg
+from pyvista.utilities import assert_empty_kwargs
+from pyvista.utilities.misc import PyVistaDeprecationWarning
 
 
 @abstract_class
 class RectilinearGridFilters:
     """An internal class to manage filters/algorithms for rectilinear grid datasets."""
 
+    # Note remove kwargs when removing deprecation for pass_cell_data
     def to_tetrahedra(
         self,
         tetra_per_cell: int = 5,
         mixed: Union[Sequence[int], bool] = False,
         pass_cell_ids: bool = True,
-        pass_cell_data: bool = True,
+        pass_data: bool = True,
         progress_bar: bool = False,
+        **kwargs,
     ):
         """Create a tetrahedral mesh structured grid.
 
@@ -46,7 +51,7 @@ class RectilinearGridFilters:
             :class:`pyvista.RectilinearGrid`. The name of this array is
             ``'vtkOriginalCellIds'`` within the ``cell_data``.
 
-        pass_cell_data : bool, default: True
+        pass_data : bool, default: True
             Set to ``True`` to make the tetrahedra mesh have the cell data from
             the original :class:`pyvista.RectilinearGrid`.  This uses
             ``pass_cell_ids=True`` internally. If ``True``, ``pass_cell_ids``
@@ -87,8 +92,17 @@ class RectilinearGridFilters:
         >>> tet_grid.explode(factor=0.5).plot(show_edges=True)
 
         """
+        # Note remove this section when deprecation is done
+        pass_cell_data = kwargs.pop("pass_cell_data", None)
+        assert_empty_kwargs(**kwargs)
+        if pass_cell_data is not None:
+            warnings.warn(
+                "pass_cell_data is a deprecated option, use pass_data", PyVistaDeprecationWarning
+            )
+            pass_data = pass_cell_data
+
         alg = _vtk.vtkRectilinearGridToTetrahedra()
-        alg.SetRememberVoxelId(pass_cell_ids or pass_cell_data)
+        alg.SetRememberVoxelId(pass_cell_ids or pass_data)
         if mixed is not False:
             if isinstance(mixed, str):
                 self.cell_data.active_scalars_name = mixed
@@ -117,7 +131,7 @@ class RectilinearGridFilters:
         _update_alg(alg, progress_bar, 'Converting to tetrahedra')
         out = _get_output(alg)
 
-        if pass_cell_data:
+        if pass_data:
             # algorithm stores original cell ids in active scalars
             # this does not preserve active scalars, but we need to
             # keep active scalars until they are renamed
@@ -125,13 +139,16 @@ class RectilinearGridFilters:
                 if name != out.cell_data.active_scalars_name:
                     out[name] = self.cell_data[name][out.cell_data.active_scalars]  # type: ignore
 
+            for name in self.point_data:  # type: ignore
+                out[name] = self.point_data[name]  # type: ignore
+
         if alg.GetRememberVoxelId():
             # original cell_ids are not named and are the active scalars
             out.cell_data.set_array(
                 out.cell_data.pop(out.cell_data.active_scalars_name), 'vtkOriginalCellIds'
             )
 
-        if pass_cell_data:
+        if pass_data:
             # Now reset active scalars in cast the original mesh had data with active scalars
             association, name = self.active_scalars_info  # type: ignore
             out.set_active_scalars(name, preference=association)

--- a/pyvista/core/filters/rectilinear_grid.py
+++ b/pyvista/core/filters/rectilinear_grid.py
@@ -116,8 +116,11 @@ class RectilinearGridFilters:
         alg.SetInputData(self)
         _update_alg(alg, progress_bar, 'Converting to tetrahedra')
         out = _get_output(alg)
+
         if pass_cell_data:
             # algorithm stores original cell ids in active scalars
+            # this does not preserve active scalars, but we need to
+            # keep active scalars until they are renamed
             for name in self.cell_data:  # type: ignore
                 if name != out.cell_data.active_scalars_name:
                     out[name] = self.cell_data[name][out.cell_data.active_scalars]  # type: ignore
@@ -127,5 +130,10 @@ class RectilinearGridFilters:
             out.cell_data.set_array(
                 out.cell_data.pop(out.cell_data.active_scalars_name), 'vtkOriginalCellIds'
             )
+
+        if pass_cell_data:
+            # Now reset active scalars in cast the original mesh had data with active scalars
+            association, name = self.active_scalars_info  # type: ignore
+            out.set_active_scalars(name, preference=association)
 
         return out

--- a/tests/filters/test_rectilinear_grid.py
+++ b/tests/filters/test_rectilinear_grid.py
@@ -57,13 +57,14 @@ def test_to_tetrahedral_pass_cell_ids(tiny_rectilinear):
 
 def test_to_tetrahedral_pass_cell_data(tiny_rectilinear):
     tiny_rectilinear["cell_data"] = np.ones(tiny_rectilinear.n_cells)
-
+    assert tiny_rectilinear.active_scalars_name == "cell_data"
     tet_grid = tiny_rectilinear.to_tetrahedra(pass_cell_ids=False, pass_cell_data=False)
     assert not tet_grid.cell_data
 
     tet_grid = tiny_rectilinear.to_tetrahedra(pass_cell_ids=False, pass_cell_data=True)
     assert tet_grid.cell_data
     assert "cell_data" in tet_grid.cell_data
+    assert tet_grid.active_scalars_name == "cell_data"
 
     # automatically added
     assert 'vtkOriginalCellIds' in tet_grid.cell_data

--- a/tests/filters/test_rectilinear_grid.py
+++ b/tests/filters/test_rectilinear_grid.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import pyvista as pv
+from pyvista.utilities.misc import PyVistaDeprecationWarning
 
 
 @pytest.fixture
@@ -48,23 +49,39 @@ def test_to_tetrahedral_edge_case():
 
 
 def test_to_tetrahedral_pass_cell_ids(tiny_rectilinear):
-    tet_grid = tiny_rectilinear.to_tetrahedra(pass_cell_ids=False, pass_cell_data=False)
+    tet_grid = tiny_rectilinear.to_tetrahedra(pass_cell_ids=False, pass_data=False)
     assert not tet_grid.cell_data
-    tet_grid = tiny_rectilinear.to_tetrahedra(pass_cell_ids=True, pass_cell_data=False)
+    tet_grid = tiny_rectilinear.to_tetrahedra(pass_cell_ids=True, pass_data=False)
     assert 'vtkOriginalCellIds' in tet_grid.cell_data
     assert np.issubdtype(tet_grid.cell_data['vtkOriginalCellIds'].dtype, np.integer)
 
 
 def test_to_tetrahedral_pass_cell_data(tiny_rectilinear):
+    # test that data isn't passed
     tiny_rectilinear["cell_data"] = np.ones(tiny_rectilinear.n_cells)
-    assert tiny_rectilinear.active_scalars_name == "cell_data"
-    tet_grid = tiny_rectilinear.to_tetrahedra(pass_cell_ids=False, pass_cell_data=False)
+    tiny_rectilinear["point_data"] = np.arange(tiny_rectilinear.n_points)
+    tiny_rectilinear.set_active_scalars("cell_data")
+    tet_grid = tiny_rectilinear.to_tetrahedra(pass_cell_ids=False, pass_data=False)
     assert not tet_grid.cell_data
+    assert not tet_grid.point_data
 
-    tet_grid = tiny_rectilinear.to_tetrahedra(pass_cell_ids=False, pass_cell_data=True)
+    # test with cell data
+    tet_grid = tiny_rectilinear.to_tetrahedra(pass_cell_ids=False, pass_data=True)
     assert tet_grid.cell_data
     assert "cell_data" in tet_grid.cell_data
+    assert "point_data" in tet_grid.point_data
     assert tet_grid.active_scalars_name == "cell_data"
 
     # automatically added
     assert 'vtkOriginalCellIds' in tet_grid.cell_data
+
+    with pytest.warns(PyVistaDeprecationWarning):
+        tiny_rectilinear.to_tetrahedra(pass_cell_data=True)
+        if pv._version.version_info >= (0, 43, 0):
+            raise RuntimeError('Remove this deprecated kwarg')
+
+    # Test point data active
+    tiny_rectilinear.set_active_scalars("point_data")
+    assert tiny_rectilinear.active_scalars_name == "point_data"
+    tet_grid = tiny_rectilinear.to_tetrahedra(pass_cell_ids=False, pass_data=True)
+    assert tet_grid.active_scalars_name == "point_data"


### PR DESCRIPTION
### Overview

Closes #4394 by resetting active scalars.


### Details

Additionally this PR finds that point data is also not transferred over even though the number of points is maintained.  I don't think there is a downside to copying over the point data, so this will be added.

