### PR TITLE
Simplify "all" optional dependency, add pytest_report_header

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,22 +36,7 @@ dependencies = [
 dynamic = ['version']
 
 [project.optional-dependencies]
-all = [
-    'imageio',
-    'cmocean',
-    'colorcet',
-    'ipyvtklink',
-    'ipywidgets',
-    'jupyter-server-proxy',
-    'meshio>=5.2',
-    'nest_asyncio',
-    'panel',
-    'pythreejs',
-    'trame-client>=2.4.2',
-    'trame-server>=2.8.0',
-    'trame-vtk>=2.4.0',
-    'trame>=2.2.6',
-]
+all = ['pyvista[colormaps,io,jupyter,trame]']
 colormaps = [
     'cmocean',
     'colorcet',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+from importlib import metadata
+import re
+
 # see https://github.com/jupyter-widgets/ipywidgets/issues/3729
 import ipykernel.ipkernel  # noqa: F401
 import numpy as np
@@ -239,3 +242,51 @@ def pytest_runtest_setup(item):
         if pyvista.vtk_version_info < version_needed:
             version_str = '.'.join(map(str, version_needed))
             skip(f'Test needs VTK {version_str} or newer.')
+
+
+def pytest_report_header(config):
+    """Header for pytest to show versions of required and optional packages."""
+
+    required = []
+    extra = {}
+    for item in metadata.requires("pyvista"):
+        pkg_name = re.findall(r"[a-z0-9_\-]+", item, re.IGNORECASE)[0]
+        if pkg_name == "pyvista":
+            continue
+        elif res := re.findall("extra == ['\"](.+)['\"]", item):
+            assert len(res) == 1, item
+            pkg_extra = res[0]
+            if pkg_extra not in extra:
+                extra[pkg_extra] = []
+            extra[pkg_extra].append(pkg_name)
+        else:
+            required.append(pkg_name)
+
+    lines = []
+    items = []
+    for name in required:
+        try:
+            version = metadata.version(name)
+            items.append(f"{name}-{version}")
+        except metadata.PackageNotFoundError:
+            items.append(f"{name} (not found)")
+    lines.append("required packages: " + ", ".join(items))
+
+    not_found = []
+    for pkg_extra in extra.keys():
+        installed = []
+        for name in extra[pkg_extra]:
+            try:
+                version = metadata.version(name)
+                installed.append(f"{name}-{version}")
+            except metadata.PackageNotFoundError:
+                not_found.append(name)
+        if installed:
+            plrl = "s" if len(installed) != 1 else ""
+            comma_lst = ", ".join(installed)
+            lines.append(f"optional {pkg_extra!r} package{plrl}: {comma_lst}")
+    if not_found:
+        plrl = "s" if len(not_found) != 1 else ""
+        comma_lst = ", ".join(not_found)
+        lines.append(f"optional package{plrl} not found: {comma_lst}")
+    return "\n".join(lines)


### PR DESCRIPTION
### Overview

- Simplify the "all" optional dependency in `pyproject.toml` to remove repetitions
- Implement a pytest report header that shows the required and optional packages and their versions. Also a report of what packages are not installed.

### Details

When running pytest, the top of the report might look something like:
```
============================= test session starts =============================
platform win32 -- Python 3.8.10, pytest-7.3.1, pluggy-1.0.0 -- C:\hostedtoolcache\windows\Python\3.8.10\x64\python.exe
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('D:\\a\\pyvista\\pyvista\\.hypothesis\\examples')
required packages: matplotlib-3.7.1, numpy-1.24.3, pillow-9.5.0, pooch-1.7.0, scooby-0.7.2, vtk-9.2.6
optional 'colormaps' packages: cmocean-3.0.3, colorcet-3.0.1
optional 'io' packages: imageio-2.28.1, meshio-5.3.4
optional 'jupyter' packages: ipyvtklink-0.2.3, ipywidgets-7.7.5, nest_asyncio-1.5.6, panel-0.14.4, pythreejs-2.4.2, trame-2.4.0, trame-client-2.7.5, trame-server-2.11.0, trame-vtk-2.4.4
optional 'trame' packages: trame-2.4.0, trame-client-2.7.5, trame-server-2.11.0, trame-vtk-2.4.4
optional package not found: jupyter-server-proxy
rootdir: D:\a\pyvista\pyvista
configfile: pyproject.toml
testpaths: tests
plugins: anyio-3.6.2, hypothesis-6.75.2, cov-4.0.0, memprof-0.2.0, pytest_pyvista-0.1.8, xdist-3.2.1
collecting ... collected [19](https://github.com/pyvista/pyvista/actions/runs/4942108414/jobs/8835357232#step:10:20)58 items
```