### PR TITLE
Remove SKIP in docstrings

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -69,7 +69,6 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.linkcode",  # This adds the button ``[Source]`` to each Python API site by calling ``linkcode_resolve``
-    "sphinx.ext.doctest",
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",

--- a/pyvista/core/celltype.py
+++ b/pyvista/core/celltype.py
@@ -37,8 +37,8 @@ class CellType(IntEnum):
     ...     dtype=np.float32,
     ... )
     >>> grid = pyvista.UnstructuredGrid(cells, cell_type, points)
-    >>> grid  # doctest:+SKIP
-    UnstructuredGrid (0x7f5b0a55e1a0)
+    >>> grid
+    UnstructuredGrid (...)
       N Cells:    1
       N Points:   8
       X Bounds:   0.000e+00, 1.000e+00

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -929,13 +929,14 @@ class MultiBlock(
         # return a string that is Python console friendly
         fmt = f"{type(self).__name__} ({hex(id(self))})\n"
         # now make a call on the object to get its attributes as a list of len 2 tuples
-        row = "  {}:\t{}\n"
+        max_len = max(len(attr[0]) for attr in self._get_attrs()) + 4
+        row = "  {:%ds}{}\n" % max_len
         for attr in self._get_attrs():
             try:
                 fmt += row.format(attr[0], attr[2].format(*attr[1]))
             except:
                 fmt += row.format(attr[0], attr[2].format(attr[1]))
-        return fmt
+        return fmt.strip()
 
     def __str__(self) -> str:
         """Return the str representation of the multi block."""

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -241,7 +241,7 @@ class DataObject:
                 fmt += row.format(attr[0] + ':', attr[2].format(attr[1]))
         if hasattr(self, 'n_arrays'):
             fmt += row.format('N Arrays:', self.n_arrays)
-        return fmt
+        return fmt.strip()
 
     def _repr_html_(self):  # pragma: no cover
         """Return a pretty representation for Jupyter notebooks.

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1155,14 +1155,14 @@ class DataSetFilters:
         >>> volume[:3] = 1
         >>> vol = pyvista.wrap(volume)
         >>> threshed = vol.threshold(0.1)
-        >>> threshed  # doctest:+SKIP
-        UnstructuredGrid (0x7f00f9983fa0)
-          N Cells:	243
-          N Points:	400
-          X Bounds:	0.000e+00, 3.000e+00
-          Y Bounds:	0.000e+00, 9.000e+00
-          Z Bounds:	0.000e+00, 9.000e+00
-          N Arrays:	1
+        >>> threshed
+        UnstructuredGrid (...)
+          N Cells:    243
+          N Points:   400
+          X Bounds:   0.000e+00, 3.000e+00
+          Y Bounds:   0.000e+00, 9.000e+00
+          Z Bounds:   0.000e+00, 9.000e+00
+          N Arrays:   1
 
         Apply the threshold filter to Perlin noise.  First generate
         the structured grid.
@@ -1476,14 +1476,15 @@ class DataSetFilters:
         >>> import pyvista
         >>> from pyvista import examples
         >>> hex_beam = pyvista.read(examples.hexbeamfile)
-        >>> hex_beam.extract_geometry()  # doctest:+SKIP
-        PolyData (0x7f2f8c132040)
-          N Cells:	88
-          N Points:	90
-          X Bounds:	0.000e+00, 1.000e+00
-          Y Bounds:	0.000e+00, 1.000e+00
-          Z Bounds:	0.000e+00, 5.000e+00
-          N Arrays:	3
+        >>> hex_beam.extract_geometry()
+        PolyData (...)
+          N Cells:    88
+          N Points:   90
+          N Strips:   0
+          X Bounds:   0.000e+00, 1.000e+00
+          Y Bounds:   0.000e+00, 1.000e+00
+          Z Bounds:   0.000e+00, 5.000e+00
+          N Arrays:   3
 
         See :ref:`surface_smoothing_example` for more examples using this filter.
 

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -49,9 +49,12 @@ class PolyDataFilters(DataSetFilters):
         >>> import pyvista
         >>> mesh = pyvista.Cube().triangulate().subdivide(4)
         >>> mask = mesh.edge_mask(45)
+        >>> mesh.plot(scalars=mask)
+
+        Show the array of masked points.
+
         >>> mask  # doctest:+SKIP
         array([ True,  True,  True, ..., False, False, False])
-        >>> mesh.plot(scalars=mask)
 
         """
         poly_data = self
@@ -552,17 +555,17 @@ class PolyDataFilters(DataSetFilters):
 
         Examples
         --------
-        Calculate the mean curvature of the hills example mesh.
+        Calculate the mean curvature of the hills example mesh and plot it.
 
         >>> from pyvista import examples
         >>> hills = examples.load_random_hills()
         >>> curv = hills.curvature()
+        >>> hills.plot(scalars=curv)
+
+        Show the curvature array.
+
         >>> curv  # doctest:+SKIP
         array([0.20587616, 0.06747695, ..., 0.11781171, 0.15988467])
-
-        Plot it.
-
-        >>> hills.plot(scalars=curv)
 
         """
         curv_type = curv_type.lower()

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -2356,7 +2356,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
     >>> dims = np.array([ni, nj, nk]) + 1
     >>> grid = pv.ExplicitStructuredGrid(dims, corners)
     >>> grid = grid.compute_connectivity()
-    >>> grid.plot(show_edges=True)  # doctest:+SKIP
+    >>> grid.plot(show_edges=True)
 
     """
 
@@ -2799,20 +2799,15 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         --------
         >>> import pyvista as pv
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
-        >>> cell = grid.extract_cells(31)  # doctest:+SKIP
-        >>> ind = grid.neighbors(31)  # doctest:+SKIP
-        >>> neighbors = grid.extract_cells(ind)  # doctest:+SKIP
-        >>>
+        >>> grid = examples.load_explicit_structured()
+        >>> cell = grid.extract_cells(31)
+        >>> ind = grid.neighbors(31)
+        >>> neighbors = grid.extract_cells(ind)
         >>> plotter = pv.Plotter()
-        >>> plotter.add_axes()  # doctest:+SKIP
-        >>> plotter.add_mesh(
-        ...     cell, color='r', show_edges=True
-        ... )  # doctest:+SKIP
-        >>> plotter.add_mesh(
-        ...     neighbors, color='w', show_edges=True
-        ... )  # doctest:+SKIP
-        >>> plotter.show()  # doctest:+SKIP
+        >>> _ = plotter.add_axes()
+        >>> _ = plotter.add_mesh(cell, color='r', show_edges=True)
+        >>> _ = plotter.add_mesh(neighbors, color='w', show_edges=True)
+        >>> plotter.show()
 
         """
 
@@ -2938,9 +2933,9 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         --------
         >>> from pyvista import examples
         >>>
-        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
-        >>> grid = grid.compute_connectivity()  # doctest:+SKIP
-        >>> grid.plot(show_edges=True)  # doctest:+SKIP
+        >>> grid = examples.load_explicit_structured()
+        >>> grid = grid.compute_connectivity()
+        >>> grid.plot(show_edges=True)
 
         """
         if inplace:
@@ -2977,9 +2972,9 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         Examples
         --------
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
-        >>> grid = grid.compute_connections()  # doctest:+SKIP
-        >>> grid.plot(show_edges=True)  # doctest:+SKIP
+        >>> grid = examples.load_explicit_structured()
+        >>> grid = grid.compute_connections()
+        >>> grid.plot(show_edges=True)
 
         """
         if inplace:

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -2005,15 +2005,15 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
     >>> zrng = np.arange(-10, 10, 1, dtype=np.float32)
     >>> x, y, z = np.meshgrid(xrng, yrng, zrng, indexing='ij')
     >>> grid = pyvista.StructuredGrid(x, y, z)
-    >>> grid  # doctest:+SKIP
-    StructuredGrid (0x7fb18f2a8580)
-    N Cells:    513
-    N Points:   800
-    X Bounds:   -1.000e+01, 8.000e+00
-    Y Bounds:   -1.000e+01, 5.000e+00
-    Z Bounds:   -1.000e+01, 9.000e+00
-    Dimensions: 10, 4, 20
-    N Arrays:   0
+    >>> grid
+    StructuredGrid (...)
+      N Cells:      513
+      N Points:     800
+      X Bounds:     -1.000e+01, 8.000e+00
+      Y Bounds:     -1.000e+01, 5.000e+00
+      Z Bounds:     -1.000e+01, 9.000e+00
+      Dimensions:   10, 4, 20
+      N Arrays:     0
 
     """
 
@@ -2464,25 +2464,17 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         Examples
         --------
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
-        >>> grid.plot(
-        ...     color='w', show_edges=True, show_bounds=True
-        ... )  # doctest:+SKIP
+        >>> grid = examples.load_explicit_structured()
+        >>> grid.plot(color='w', show_edges=True, show_bounds=True)
 
-        >>> grid = grid.hide_cells(range(80, 120))  # doctest:+SKIP
-        >>> grid.plot(
-        ...     color='w', show_edges=True, show_bounds=True
-        ... )  # doctest:+SKIP
+        >>> grid = grid.hide_cells(range(80, 120))
+        >>> grid.plot(color='w', show_edges=True, show_bounds=True)
 
-        >>> grid = grid.cast_to_unstructured_grid()  # doctest:+SKIP
-        >>> grid.plot(
-        ...     color='w', show_edges=True, show_bounds=True
-        ... )  # doctest:+SKIP
+        >>> grid = grid.cast_to_unstructured_grid()
+        >>> grid.plot(color='w', show_edges=True, show_bounds=True)
 
-        >>> grid = grid.cast_to_explicit_structured_grid()  # doctest:+SKIP
-        >>> grid.plot(
-        ...     color='w', show_edges=True, show_bounds=True
-        ... )  # doctest:+SKIP
+        >>> grid = grid.cast_to_explicit_structured_grid()
+        >>> grid.plot(color='w', show_edges=True, show_bounds=True)
 
         """
         grid = ExplicitStructuredGrid()
@@ -2641,8 +2633,8 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         Examples
         --------
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
-        >>> grid.dimensions  # doctest:+SKIP
+        >>> grid = examples.load_explicit_structured()
+        >>> grid.dimensions
         (5, 6, 7)
 
         """
@@ -2666,13 +2658,13 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         Examples
         --------
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
-        >>> grid = grid.hide_cells(range(80, 120))  # doctest:+SKIP
-        >>> grid.bounds  # doctest:+SKIP
-        [0.0, 80.0, 0.0, 50.0, 0.0, 6.0]
+        >>> grid = examples.load_explicit_structured()
+        >>> grid = grid.hide_cells(range(80, 120))
+        >>> grid.bounds
+        (0.0, 80.0, 0.0, 50.0, 0.0, 6.0)
 
-        >>> grid.visible_bounds  # doctest:+SKIP
-        [0.0, 80.0, 0.0, 50.0, 0.0, 4.0]
+        >>> grid.visible_bounds
+        (0.0, 80.0, 0.0, 50.0, 0.0, 4.0)
 
         """
         name = _vtk.vtkDataSetAttributes.GhostArrayName()
@@ -2703,12 +2695,12 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         Examples
         --------
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
-        >>> grid.cell_id((3, 4, 0))  # doctest:+SKIP
+        >>> grid = examples.load_explicit_structured()
+        >>> grid.cell_id((3, 4, 0))
         19
 
         >>> coords = [(3, 4, 0), (3, 2, 1), (1, 0, 2), (2, 3, 2)]
-        >>> grid.cell_id(coords)  # doctest:+SKIP
+        >>> grid.cell_id(coords)
         array([19, 31, 41, 54])
 
         """
@@ -2750,11 +2742,11 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         Examples
         --------
         >>> from pyvista import examples
-        >>> grid = examples.load_explicit_structured()  # doctest:+SKIP
-        >>> grid.cell_coords(19)  # doctest:+SKIP
+        >>> grid = examples.load_explicit_structured()
+        >>> grid.cell_coords(19)
         (3, 4, 0)
 
-        >>> grid.cell_coords((19, 31, 41, 54))  # doctest:+SKIP
+        >>> grid.cell_coords((19, 31, 41, 54))
         array([[3, 4, 0],
                [3, 2, 1],
                [1, 0, 2],

--- a/pyvista/core/texture.py
+++ b/pyvista/core/texture.py
@@ -52,7 +52,7 @@ class Texture(_vtk.vtkTexture, DataObject):
     >>> os.path.basename(path)
     'masonry.bmp'
     >>> texture = pv.Texture(path)
-    >>> texture  # doctest:+SKIP
+    >>> texture
     Texture (...)
       Components:   3
       Cube Map:     False

--- a/pyvista/core/texture.py
+++ b/pyvista/core/texture.py
@@ -345,7 +345,7 @@ class Texture(_vtk.vtkTexture, DataObject):
         --------
         >>> from pyvista import examples
         >>> texture = examples.download_puppy_texture()
-        >>> texture  # doctest:+SKIP
+        >>> texture
         Texture (...)
           Components:   3
           Cube Map:     False
@@ -636,8 +636,8 @@ class Texture(_vtk.vtkTexture, DataObject):
         >>> from pyvista import examples
         >>> texture = examples.download_masonry_texture()
         >>> bw_texture = texture.to_grayscale()
-        >>> bw_texture  # doctest:+SKIP
-        Texture (0x7f711fc6a740)
+        >>> bw_texture
+        Texture (...)
           Components:   1
           Cube Map:     False
           Dimensions:   256, 256

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -4100,29 +4100,26 @@ def download_electronics_cooling(load=True):  # pragma: no cover
 
     Examples
     --------
-    Load the datasets
+    Load the datasets and plot the air velocity through the electronics.
 
     >>> import pyvista as pv
     >>> from pyvista import examples
     >>> structure, air = examples.download_electronics_cooling()
-    >>> structure, air  # doctest:+SKIP
-    (PolyData (0x7fdfe4eb24a0)
-       N Cells:    344270
-       N Points:   187992
-       N Strips:   0
-       X Bounds:   -3.000e-03, 1.530e-01
-       Y Bounds:   -3.000e-03, 2.030e-01
-       Z Bounds:   -9.000e-03, 4.200e-02
-       N Arrays:   5,
-     UnstructuredGrid (0x7fdfde4478e0)
-       N Cells:    1749992
-       N Points:   610176
-       X Bounds:   -1.388e-18, 1.500e-01
-       Y Bounds:   -3.000e-03, 2.030e-01
-       Z Bounds:   -6.000e-03, 4.400e-02
-       N Arrays:   10)
-
-    Plot the air velocity through the electronics.
+    >>> structure, air
+    (PolyData (...)
+      N Cells:    344270
+      N Points:   187992
+      N Strips:   0
+      X Bounds:   -3.000e-03, 1.530e-01
+      Y Bounds:   -3.000e-03, 2.030e-01
+      Z Bounds:   -9.000e-03, 4.200e-02
+      N Arrays:   4, UnstructuredGrid (...)
+      N Cells:    1749992
+      N Points:   610176
+      X Bounds:   -1.388e-18, 1.500e-01
+      Y Bounds:   -3.000e-03, 2.030e-01
+      Z Bounds:   -6.000e-03, 4.400e-02
+      N Arrays:   10)
 
     >>> z_slice = air.clip('z', value=-0.005)
     >>> pl = pv.Plotter()
@@ -4143,6 +4140,8 @@ def download_electronics_cooling(load=True):  # pragma: no cover
     >>> pl.camera.roll = 90
     >>> pl.enable_anti_aliasing('fxaa')
     >>> pl.show()
+
+    Show the type and bounds of the datasets.
 
     See :ref:`openfoam_cooling_example` for a full example using this dataset.
 

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -4041,8 +4041,8 @@ def download_pump_bracket(load=True):  # pragma: no cover
     >>> import pyvista as pv
     >>> from pyvista import examples
     >>> dataset = examples.download_pump_bracket()
-    >>> dataset  # doctest:+SKIP
-    UnstructuredGrid (0x7f46a9279120)
+    >>> dataset
+    UnstructuredGrid (...)
       N Cells:    124806
       N Points:   250487
       X Bounds:   -5.000e-01, 5.000e-01
@@ -4663,14 +4663,14 @@ def download_cloud_dark_matter(load=True):  # pragma: no cover
     >>> import numpy as np
     >>> from pyvista import examples
     >>> pc = examples.download_cloud_dark_matter()
-    >>> pc  # doctest:+SKIP
-    PointSet (0x7f97f718d460)
-      N Cells:      0
-      N Points:     32314
-      X Bounds:     7.451e+01, 7.892e+01
-      Y Bounds:     1.616e+01, 2.275e+01
-      Z Bounds:     8.900e+01, 9.319e+01
-      N Arrays:     0
+    >>> pc
+    PointSet (...)
+      N Cells:    0
+      N Points:   32314
+      X Bounds:   7.451e+01, 7.892e+01
+      Y Bounds:   1.616e+01, 2.275e+01
+      Z Bounds:   8.900e+01, 9.319e+01
+      N Arrays:   0
 
     Plot the point cloud. Color based on the distance from the center of the
     cloud.
@@ -4717,14 +4717,14 @@ def download_cloud_dark_matter_dense(load=True):  # pragma: no cover
     >>> import numpy as np
     >>> from pyvista import examples
     >>> pc = examples.download_cloud_dark_matter_dense()
-    >>> pc  # doctest:+SKIP
-    PointSet (0x7fd79493a340)
-    N Cells:      0
-    N Points:     2062256
-    X Bounds:     7.462e+01, 7.863e+01
-    Y Bounds:     1.604e+01, 2.244e+01
-    Z Bounds:     8.893e+01, 9.337e+01
-    N Arrays:     0
+    >>> pc
+    PointSet (...)
+      N Cells:    0
+      N Points:   2062256
+      X Bounds:   7.462e+01, 7.863e+01
+      Y Bounds:   1.604e+01, 2.244e+01
+      Z Bounds:   8.893e+01, 9.337e+01
+      N Arrays:   0
 
     Plot the point cloud. Color based on the distance from the center of the
     cloud.
@@ -4793,15 +4793,15 @@ def download_stars_cloud_hyg(load=True):  # pragma: no cover
     ...     zoom=3.0,
     ... )
 
-    >>> stars  # doctest:+SKIP
-    PolyData (0x7fe5851ac0a0)
-      N Cells:      107857
-      N Points:     107857
-      N Strips:     0
-      X Bounds:     -9.755e+02, 9.774e+02
-      Y Bounds:     -9.620e+02, 9.662e+02
-      Z Bounds:     -9.788e+02, 9.702e+02
-      N Arrays:     4
+    >>> stars
+    PolyData (...)
+      N Cells:    107857
+      N Points:   107857
+      N Strips:   0
+      X Bounds:   -9.755e+02, 9.774e+02
+      Y Bounds:   -9.620e+02, 9.662e+02
+      Z Bounds:   -9.788e+02, 9.702e+02
+      N Arrays:   3
 
     See the :ref:`plotting_point_clouds` for more details on how to plot point
     clouds.
@@ -4937,14 +4937,16 @@ def download_black_vase(load=True):  # pragma: no cover
 
     Return the statistics of the dataset.
 
-    >>> mesh  # doctest:+SKIP
-    PolyData (0x7fe489493520)
-      N Cells:      3136652
-      N Points:     1611789
-      X Bounds:     -1.092e+02, 1.533e+02
-      Y Bounds:     -1.200e+02, 1.415e+02
-      Z Bounds:     1.666e+01, 4.077e+02
-      N Arrays:     0
+    >>> mesh
+    PolyData (...)
+      N Cells:    3136652
+      N Points:   1611789
+      N Strips:   0
+      X Bounds:   -1.092e+02, 1.533e+02
+      Y Bounds:   -1.200e+02, 1.415e+02
+      Z Bounds:   1.666e+01, 4.077e+02
+      N Arrays:   0
+
 
     """
     filename = _download_archive(
@@ -4994,14 +4996,15 @@ def download_ivan_angel(load=True):  # pragma: no cover
 
     Return the statistics of the dataset.
 
-    >>> mesh  # doctest:+SKIP
-    PolyData (0x7f6ed1345520)
-      N Cells:      4547716
-      N Points:     2297089
-      X Bounds:     -1.147e+02, 8.468e+01
-      Y Bounds:     -7.103e+01, 9.247e+01
-      Z Bounds:     -1.198e+02, 2.052e+02
-      N Arrays:     0
+    >>> mesh
+    PolyData (...)
+      N Cells:    3580454
+      N Points:   1811531
+      N Strips:   0
+      X Bounds:   -1.147e+02, 8.468e+01
+      Y Bounds:   -6.996e+01, 9.247e+01
+      Z Bounds:   -1.171e+02, 2.052e+02
+      N Arrays:   0
 
     """
     filename = _download_archive(
@@ -5046,14 +5049,15 @@ def download_bird_bath(load=True):  # pragma: no cover
 
     Return the statistics of the dataset.
 
-    >>> mesh  # doctest:+SKIP
-    PolyData (0x7fe8caf2ba00)
-    N Cells:      3507935
-    N Points:     1831383
-    X Bounds:     -1.601e+02, 1.483e+02
-    Y Bounds:     -1.521e+02, 1.547e+02
-    Z Bounds:     -4.241e+00, 1.409e+02
-    N Arrays:     0
+    >>> mesh
+    PolyData (...)
+      N Cells:    3507935
+      N Points:   1831383
+      N Strips:   0
+      X Bounds:   -1.601e+02, 1.483e+02
+      Y Bounds:   -1.521e+02, 1.547e+02
+      Z Bounds:   -4.241e+00, 1.409e+02
+      N Arrays:   0
 
     """
     filename = _download_archive(
@@ -5103,14 +5107,15 @@ def download_owl(load=True):  # pragma: no cover
 
     Return the statistics of the dataset.
 
-    >>> mesh  # doctest:+SKIP
-    PolyData (0x7fe8caeeaee0)
-      N Cells:      2440707
-      N Points:     1221756
-      X Bounds:     -5.834e+01, 7.047e+01
-      Y Bounds:     -7.006e+01, 6.658e+01
-      Z Bounds:     1.676e+00, 2.013e+02
-      N Arrays:     0
+    >>> mesh
+    PolyData (...)
+      N Cells:    2440707
+      N Points:   1221756
+      N Strips:   0
+      X Bounds:   -5.834e+01, 7.047e+01
+      Y Bounds:   -7.006e+01, 6.658e+01
+      Z Bounds:   1.676e+00, 2.013e+02
+      N Arrays:   0
 
     """
     filename = _download_archive(
@@ -5155,14 +5160,15 @@ def download_plastic_vase(load=True):  # pragma: no cover
 
     Return the statistics of the dataset.
 
-    >>> mesh  # doctest:+SKIP
-    PolyData (0x7fe8cadc14c0)
-      N Cells:      3570967
-      N Points:     1796805
-      X Bounds:     -1.364e+02, 1.929e+02
-      Y Bounds:     -1.677e+02, 1.603e+02
-      Z Bounds:     1.209e+02, 4.090e+02
-      N Arrays:     0
+    >>> mesh
+    PolyData (...)
+      N Cells:    3570967
+      N Points:   1796805
+      N Strips:   0
+      X Bounds:   -1.364e+02, 1.929e+02
+      Y Bounds:   -1.677e+02, 1.603e+02
+      Z Bounds:   1.209e+02, 4.090e+02
+      N Arrays:   0
 
     """
     filename = _download_archive(
@@ -5207,14 +5213,15 @@ def download_sea_vase(load=True):  # pragma: no cover
 
     Return the statistics of the dataset.
 
-    >>> mesh  # doctest:+SKIP
-    PolyData (0x7fe8b3862460)
-      N Cells:      3548473
-      N Points:     1810012
-      X Bounds:     -1.666e+02, 1.465e+02
-      Y Bounds:     -1.742e+02, 1.384e+02
-      Z Bounds:     -1.500e+02, 2.992e+02
-      N Arrays:     0
+    >>> mesh
+    PolyData (...)
+      N Cells:    3548473
+      N Points:   1810012
+      N Strips:   0
+      X Bounds:   -1.666e+02, 1.465e+02
+      Y Bounds:   -1.742e+02, 1.384e+02
+      Z Bounds:   -1.500e+02, 2.992e+02
+      N Arrays:   0
 
     """
     filename = _download_archive(
@@ -5285,14 +5292,15 @@ def download_cad_model_case(load=True):  # pragma: no cover
 
     Return the statistics of the dataset.
 
-    >>> mesh  # doctest:+SKIP
-    PolyData (0x7fd08f1faf40)
-      N Cells:      13702
-      N Points:     6801
-      X Bounds:     -6.460e-31, 9.000e+01
-      Y Bounds:     -3.535e-32, 1.480e+02
-      Z Bounds:     -7.287e-13, 2.000e+01
-      N Arrays:     1
+    >>> mesh
+    PolyData (...)
+      N Cells:    15446
+      N Points:   7677
+      N Strips:   0
+      X Bounds:   -6.460e-31, 9.000e+01
+      Y Bounds:   -3.535e-32, 1.480e+02
+      Z Bounds:   0.000e+00, 2.000e+01
+      N Arrays:   2
 
     """
     return _download_and_read('cad/4947746/Vented_Rear_Case_With_Pi_Supports.vtp', load=load)
@@ -5332,8 +5340,8 @@ def download_aero_bracket(load=True):  # pragma: no cover
 
     >>> from pyvista import examples
     >>> dataset = examples.download_aero_bracket()
-    >>> dataset  # doctest:+SKIP
-    UnstructuredGrid (0x7f439aa2cac0)
+    >>> dataset
+    UnstructuredGrid (...)
       N Cells:    117292
       N Points:   187037
       X Bounds:   -6.858e-03, 1.118e-01

--- a/pyvista/examples/gltf.py
+++ b/pyvista/examples/gltf.py
@@ -31,15 +31,13 @@ def download_damaged_helmet():  # pragma: no cover
     Examples
     --------
     >>> import pyvista
-    >>> from pyvista import examples  # doctest:+SKIP
-    >>> gltf_file = (
-    ...     examples.gltf.download_damaged_helmet()
-    ... )  # doctest:+SKIP
-    >>> cubemap = examples.download_sky_box_cube_map()  # doctest:+SKIP
-    >>> pl = pyvista.Plotter()  # doctest:+SKIP
-    >>> pl.import_gltf(gltf_file)  # doctest:+SKIP
-    >>> pl.set_environment_texture(cubemap)  # doctest:+SKIP
-    >>> pl.show()  # doctest:+SKIP
+    >>> from pyvista import examples
+    >>> gltf_file = examples.gltf.download_damaged_helmet()
+    >>> cubemap = examples.download_sky_box_cube_map()
+    >>> pl = pyvista.Plotter()
+    >>> pl.import_gltf(gltf_file)
+    >>> pl.set_environment_texture(cubemap)
+    >>> pl.show()
 
     """
     return GLTF_FETCHER.fetch('DamagedHelmet/glTF-Embedded/DamagedHelmet.gltf')
@@ -58,9 +56,9 @@ def download_sheen_chair():  # pragma: no cover
     Examples
     --------
     >>> import pyvista
-    >>> from pyvista import examples  # doctest:+SKIP
-    >>> gltf_file = examples.gltf.download_sheen_chair()  # doctest:+SKIP
-    >>> cubemap = examples.download_sky_box_cube_map()  # doctest:+SKIP
+    >>> from pyvista import examples
+    >>> gltf_file = examples.gltf.download_sheen_chair()
+    >>> cubemap = examples.download_sky_box_cube_map()
     >>> pl = pyvista.Plotter()  # doctest:+SKIP
     >>> pl.import_gltf(gltf_file)  # doctest:+SKIP
     >>> pl.set_environment_texture(cubemap)  # doctest:+SKIP
@@ -83,11 +81,11 @@ def download_gearbox():  # pragma: no cover
     Examples
     --------
     >>> import pyvista
-    >>> from pyvista import examples  # doctest:+SKIP
-    >>> gltf_file = examples.gltf.download_gearbox()  # doctest:+SKIP
-    >>> pl = pyvista.Plotter()  # doctest:+SKIP
-    >>> pl.import_gltf(gltf_file)  # doctest:+SKIP
-    >>> pl.show()  # doctest:+SKIP
+    >>> from pyvista import examples
+    >>> gltf_file = examples.gltf.download_gearbox()
+    >>> pl = pyvista.Plotter()
+    >>> pl.import_gltf(gltf_file)
+    >>> pl.show()
 
     """
     return GLTF_FETCHER.fetch('GearboxAssy/glTF-Binary/GearboxAssy.glb')
@@ -106,11 +104,11 @@ def download_avocado():  # pragma: no cover
     Examples
     --------
     >>> import pyvista
-    >>> from pyvista import examples  # doctest:+SKIP
-    >>> gltf_file = examples.gltf.download_avocado()  # doctest:+SKIP
-    >>> pl = pyvista.Plotter()  # doctest:+SKIP
-    >>> pl.import_gltf(gltf_file)  # doctest:+SKIP
-    >>> pl.show()  # doctest:+SKIP
+    >>> from pyvista import examples
+    >>> gltf_file = examples.gltf.download_avocado()
+    >>> pl = pyvista.Plotter()
+    >>> pl.import_gltf(gltf_file)
+    >>> pl.show()
 
     """
     return GLTF_FETCHER.fetch('Avocado/glTF-Binary/Avocado.glb')
@@ -129,11 +127,11 @@ def download_milk_truck():  # pragma: no cover
     Examples
     --------
     >>> import pyvista
-    >>> from pyvista import examples  # doctest:+SKIP
-    >>> gltf_file = examples.gltf.download_milk_truck()  # doctest:+SKIP
-    >>> pl = pyvista.Plotter()  # doctest:+SKIP
-    >>> pl.import_gltf(gltf_file)  # doctest:+SKIP
-    >>> pl.show()  # doctest:+SKIP
+    >>> from pyvista import examples
+    >>> gltf_file = examples.gltf.download_milk_truck()
+    >>> pl = pyvista.Plotter()
+    >>> pl.import_gltf(gltf_file)
+    >>> pl.show()
 
     """
     return GLTF_FETCHER.fetch('CesiumMilkTruck/glTF-Binary/CesiumMilkTruck.glb')

--- a/pyvista/plotting/actor.py
+++ b/pyvista/plotting/actor.py
@@ -42,8 +42,8 @@ class Actor(Prop3D, _vtk.vtkActor):
     >>> mesh = pv.Sphere()
     >>> mapper = pv.DataSetMapper(mesh)
     >>> actor = pv.Actor(mapper=mapper)
-    >>> actor  # doctest:+SKIP
-    Actor (0x7f54c4d65ee0)
+    >>> actor
+    Actor (...)
       Center:                     (0.0, 0.0, 0.0)
       Pickable:                   True
       Position:                   (0.0, 0.0, 0.0)
@@ -114,24 +114,23 @@ class Actor(Prop3D, _vtk.vtkActor):
         >>> dataset = pv.Sphere()
         >>> actor = pv.Actor()
         >>> actor.mapper = pv.DataSetMapper(dataset)
-        >>> actor.mapper  # doctest:+SKIP
-        DataSetMapper (0x7f34dcec5040)
+        >>> actor.mapper
+        DataSetMapper (...)
           Scalar visibility:           True
           Scalar range:                (0.0, 1.0)
-          Interpolate before mapping:  False
+          Interpolate before mapping:  True
           Scalar map mode:             default
           Color mode:                  direct
         <BLANKLINE>
         Attached dataset:
-        PolyData (0x7f34dcec5f40)
-          N Cells:  1680
-          N Points: 842
-          N Strips: 0
-          X Bounds: -4.993e-01, 4.993e-01
-          Y Bounds: -4.965e-01, 4.965e-01
-          Z Bounds: -5.000e-01, 5.000e-01
-          N Arrays: 1
-        <BLANKLINE>
+        PolyData (...)
+          N Cells:    1680
+          N Points:   842
+          N Strips:   0
+          X Bounds:   -4.993e-01, 4.993e-01
+          Y Bounds:   -4.965e-01, 4.965e-01
+          Z Bounds:   -5.000e-01, 5.000e-01
+          N Arrays:   1
 
         """
         return self.GetMapper()
@@ -184,8 +183,11 @@ class Actor(Prop3D, _vtk.vtkActor):
         >>> pl = pv.Plotter()
         >>> actor = pl.add_mesh(plane)
         >>> actor.texture = examples.download_masonry_texture()
-        >>> actor.texture  # doctest:+SKIP
-        <Texture(0x378c920) at 0x7f7af577e700>
+        >>> actor.texture
+        Texture (...)
+          Components:   3
+          Cube Map:     False
+          Dimensions:   256, 256
 
         """
         return self.GetTexture()

--- a/pyvista/plotting/actor_properties.py
+++ b/pyvista/plotting/actor_properties.py
@@ -26,9 +26,9 @@ class ActorProperties:
     >>> axes.axes_actor.shaft_type = axes.axes_actor.ShaftType.CYLINDER
 
     >>> pl = pv.Plotter()
-    >>> pl.add_actor(axes.axes_actor)  # doctest:+SKIP
-    >>> pl.add_mesh(pv.Sphere())  # doctest:+SKIP
-    >>> pl.show()  # doctest:+SKIP
+    >>> _ = pl.add_actor(axes.axes_actor)
+    >>> _ = pl.add_mesh(pv.Sphere())
+    >>> pl.show()
 
     """
 

--- a/pyvista/plotting/axes_actor.py
+++ b/pyvista/plotting/axes_actor.py
@@ -29,7 +29,7 @@ class AxesActor(pv._vtk.vtkAxesActor):
     >>> pl = pv.Plotter()
     >>> _ = pl.add_actor(axes.axes_actor)
     >>> _ = pl.add_mesh(pv.Sphere())
-    >>> pl.show()  # doctest:+SKIP
+    >>> pl.show()
 
     Or you can use this as a custom orientation widget with
     :func:`add_orientation_widget() <pyvista.Renderer.add_orientation_widget>`:
@@ -54,7 +54,7 @@ class AxesActor(pv._vtk.vtkAxesActor):
     ...     axes_actor,
     ...     viewport=(0, 0, 0.5, 0.5),
     ... )
-    >>> pl.show()  # doctest:+SKIP
+    >>> pl.show()
 
     """
 

--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -605,7 +605,7 @@ class Camera(_vtk.vtkCamera):
 
         Examples
         --------
-        >>> import pyvista as pv
+        >>> import pyvista
         >>> pl = pyvista.Plotter()
         >>> pl.camera.direction  # doctest:+SKIP
         (-0.5773502691896257, -0.5773502691896257, -0.5773502691896257)

--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -605,10 +605,10 @@ class Camera(_vtk.vtkCamera):
 
         Examples
         --------
-        >>> import pyvista
-        >>> plotter = pyvista.Plotter()
-        >>> plotter.camera.direction  # doctest:+SKIP
-        (0.0, 0.0, -1.0)
+        >>> import pyvista as pv
+        >>> pl = pyvista.Plotter()
+        >>> pl.camera.direction  # doctest:+SKIP
+        (-0.5773502691896257, -0.5773502691896257, -0.5773502691896257)
 
         """
         return self.GetDirectionOfProjection()

--- a/pyvista/plotting/composite_mapper.py
+++ b/pyvista/plotting/composite_mapper.py
@@ -460,21 +460,21 @@ class CompositeAttributes(_vtk.vtkCompositeDataDisplayAttributes):
         ... )
         >>> pl = pv.Plotter()
         >>> actor, mapper = pl.add_composite(dataset)
-        >>> mapper.block_attr.get_block(0)  # doctest:+SKIP
+        >>> mapper.block_attr.get_block(0)
         MultiBlock (...)
-          N Blocks:	2
-          X Bounds:	-0.500, 0.500
-          Y Bounds:	-0.500, 0.500
-          Z Bounds:	-0.500, 1.500
+          N Blocks    2
+          X Bounds    -0.500, 0.500
+          Y Bounds    -0.500, 0.500
+          Z Bounds    -0.500, 1.500
 
         Note this is the same as using ``__getitem__``
 
-        >>> mapper.block_attr[0]  # doctest:+SKIP
-        MultiBlock (...)
-          N Blocks:	2
-          X Bounds:	-0.500, 0.500
-          Y Bounds:	-0.500, 0.500
-          Z Bounds:	-0.500, 1.500
+        >>> mapper.block_attr[0]
+        Composite Block Addr=... Attributes
+        Visible:   None
+        Opacity:   None
+        Color:     None
+        Pickable   None
 
         """
         try:
@@ -569,12 +569,12 @@ class CompositePolyDataMapper(_vtk.vtkCompositePolyDataMapper2, _BaseMapper):
         ... )
         >>> pl = pv.Plotter()
         >>> actor, mapper = pl.add_composite(dataset)
-        >>> mapper.dataset  # doctest:+SKIP
+        >>> mapper.dataset
         MultiBlock (...)
-          N Blocks:     2
-          X Bounds:     -0.500, 0.500
-          Y Bounds:     -0.500, 0.500
-          Z Bounds:     -0.500, 1.500
+          N Blocks    2
+          X Bounds    -0.500, 0.500
+          Y Bounds    -0.500, 0.500
+          Z Bounds    -0.500, 1.500
 
         """
         return self._dataset

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -156,34 +156,33 @@ class LookupTable(_vtk.vtkLookupTable):
 
     >>> import pyvista as pv
     >>> lut = pv.LookupTable()
-    >>> lut  # doctest:+SKIP
-    LookupTable (0x7ff3de60d580)
+    >>> lut
+    LookupTable (...)
       Table Range:                (0.0, 1.0)
       N Values:                   256
       Above Range Color:          None
       Below Range Color:          None
-      NAN Color:                  Color(name='maroon', hex='#800000ff')
+      NAN Color:                  Color(name='maroon', hex='#800000ff', opacity=255)
       Log Scale:                  False
-      Color Map:                  "VTK lookup table"
+      Color Map:                  "PyVista Lookup Table"
         Alpha Range:              (1.0, 1.0)
         Hue Range:                (0.0, 0.66667)
         Saturation Range          (1.0, 1.0)
         Value Range               (1.0, 1.0)
         Ramp                      s-curve
-        Is Opaque                 True
     >>> lut.plot()
 
     Plot the lookup table with the ``'inferno'`` color map.
 
     >>> import pyvista as pv
     >>> lut = pv.LookupTable('inferno', n_values=32)
-    >>> lut  # doctest:+SKIP
-    LookupTable (0x7ff3c053f3a0)
+    >>> lut
+    LookupTable (...)
       Table Range:                (0.0, 1.0)
       N Values:                   32
       Above Range Color:          None
       Below Range Color:          None
-      NAN Color:                  Color(name='maroon', hex='#800000ff')
+      NAN Color:                  Color(name='maroon', hex='#800000ff', opacity=255)
       Log Scale:                  False
       Color Map:                  "inferno"
     >>> lut.plot()
@@ -1030,8 +1029,8 @@ class LookupTable(_vtk.vtkLookupTable):
         >>> import pyvista
         >>> lut = pyvista.LookupTable()
         >>> tf = lut.to_color_tf()
-        >>> tf  # doctest:+SKIP
-        <vtkmodules.vtkRenderingCore.vtkColorTransferFunction(0x339bd40) at 0x7ffabf634700>
+        >>> tf
+        <vtkmodules.vtkRenderingCore.vtkColorTransferFunction(...) at ...>
 
         """
         color_tf = _vtk.vtkColorTransferFunction()
@@ -1053,8 +1052,8 @@ class LookupTable(_vtk.vtkLookupTable):
         >>> import pyvista
         >>> lut = pyvista.LookupTable()
         >>> tf = lut.to_opacity_tf()
-        >>> tf  # doctest:+SKIP
-        <vtkmodules.vtkCommonDataModel.vtkPiecewiseFunction(0x32fa410) at 0x7fe963d6d5e0>
+        >>> tf
+        <vtkmodules.vtkCommonDataModel.vtkPiecewiseFunction(...) at ...>
 
         """
         opacity_tf = _vtk.vtkPiecewiseFunction()

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -130,15 +130,15 @@ class _BaseMapper(_vtk.vtkAbstractMapper):
         >>> actor = pl.add_mesh(
         ...     mesh, scalars=mesh.points[:, 2], cmap='bwr'
         ... )
-        >>> actor.mapper.lookup_table  # doctest:+SKIP
-        LookupTable (0x7ff3be8d8c40)
+        >>> actor.mapper.lookup_table
+        LookupTable (...)
           Table Range:                (-0.5, 0.5)
           N Values:                   256
           Above Range Color:          None
           Below Range Color:          None
-          NAN Color:                  Color(name='darkgray', hex='#a9a9a9ff')
+          NAN Color:                  Color(name='darkgray', hex='#a9a9a9ff', opacity=255)
           Log Scale:                  False
-          Color Map:                  "From values array"
+          Color Map:                  "bwr"
 
         Return the lookup table of a composite dataset mapper.
 
@@ -149,7 +149,7 @@ class _BaseMapper(_vtk.vtkAbstractMapper):
         >>> pl = pv.Plotter()
         >>> actor, mapper = pl.add_composite(dataset)
         >>> mapper.lookup_table  # doctest:+SKIP
-        <vtkmodules.vtkCommonCore.vtkLookupTable(0x2d4c6e0) at 0x7fce74a89fa0>
+        <vtkmodules.vtkCommonCore.vtkLookupTable(...) at ...>
 
         """
         return self.GetLookupTable()

--- a/pyvista/plotting/plotting.py
+++ b/pyvista/plotting/plotting.py
@@ -828,8 +828,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         Select a scalar bar actor based on the title of the bar.
 
-        >>> plotter.scalar_bars['Data']  # doctest:+SKIP
-        (vtkmodules.vtkRenderingAnnotation.vtkScalarBarActor)0x7fcd3567ca00
+        >>> plotter.scalar_bars['Data']
+        <vtkmodules.vtkRenderingAnnotation.vtkScalarBarActor(...) at ...>
 
         """
         return self._scalar_bars
@@ -871,8 +871,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
         --------
         >>> import pyvista
         >>> pl = pyvista.Plotter()
-        >>> pl.renderer  # doctest:+SKIP
-        (Renderer)0x7f916129bfa0
+        >>> pl.renderer
+        <Renderer(...) at ...>
 
         """
         return self.renderers.active_renderer

--- a/pyvista/plotting/prop3d.py
+++ b/pyvista/plotting/prop3d.py
@@ -168,22 +168,6 @@ class Prop3D(_vtk.vtkProp3D):
 
         Examples
         --------
-        Show that the orientation changes with rotation.
-
-        >>> import pyvista as pv
-        >>> mesh = pv.Cube()
-        >>> pl = pv.Plotter()
-        >>> actor = pl.add_mesh(mesh)
-        >>> actor.rotate_x(90)
-        >>> actor.orientation  # doctest:+SKIP
-        (90, 0, 0)
-
-        Set the orientation directly.
-
-        >>> actor.orientation = (0, 45, 45)
-        >>> actor.orientation  # doctest:+SKIP
-        (0, 45, 45)
-
         Reorient just the actor and plot it. Note how the actor is rotated
         about its own axes as defined by its position.
 
@@ -202,6 +186,22 @@ class Prop3D(_vtk.vtkProp3D):
         >>> actor.orientation = (45, 0, 0)
         >>> pl.show_axes()
         >>> pl.show()
+
+        Show that the orientation changes with rotation.
+
+        >>> import pyvista as pv
+        >>> mesh = pv.Cube()
+        >>> pl = pv.Plotter()
+        >>> actor = pl.add_mesh(mesh)
+        >>> actor.rotate_x(90)
+        >>> actor.orientation  # doctest:+SKIP
+        (90, 0, 0)
+
+        Set the orientation directly.
+
+        >>> actor.orientation = (0, 45, 45)
+        >>> actor.orientation  # doctest:+SKIP
+        (0, 45, 45)
 
         """
         return self.GetOrientation()

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -2041,7 +2041,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         >>> import pyvista
         >>> pl = pyvista.Plotter()
         >>> pl.renderer.lights  # doctest:+SKIP
-        [<Light (Headlight) at 0x7f1dd8155820>,
+        [<Light (Headlight) at ...>,
          <Light (Camera Light) at 0x7f1dd8155760>,
          <Light (Camera Light) at 0x7f1dd8155340>,
          <Light (Camera Light) at 0x7f1dd8155460>,

--- a/pyvista/utilities/helpers.py
+++ b/pyvista/utilities/helpers.py
@@ -922,31 +922,15 @@ def wrap(dataset):
     >>> import pyvista
     >>> points = np.random.random((10, 3))
     >>> cloud = pyvista.wrap(points)
-    >>> cloud  # doctest:+SKIP
-    PolyData (0x7fc52db83d70)
-      N Cells:  10
-      N Points: 10
-      X Bounds: 1.123e-01, 7.457e-01
-      Y Bounds: 1.009e-01, 9.877e-01
-      Z Bounds: 2.346e-03, 9.640e-01
-      N Arrays: 0
-
-    Wrap a Trimesh object.
-
-    >>> import trimesh
-    >>> import pyvista
-    >>> points = [[0, 0, 0], [0, 0, 1], [0, 1, 0]]
-    >>> faces = [[0, 1, 2]]
-    >>> tmesh = trimesh.Trimesh(points, faces=faces, process=False)
-    >>> mesh = pyvista.wrap(tmesh)
-    >>> mesh  # doctest:+SKIP
-    PolyData (0x7fc55ff27ad0)
-      N Cells:  1
-      N Points: 3
-      X Bounds: 0.000e+00, 0.000e+00
-      Y Bounds: 0.000e+00, 1.000e+00
-      Z Bounds: 0.000e+00, 1.000e+00
-      N Arrays: 0
+    >>> cloud
+    PolyData (...)
+      N Cells:    10
+      N Points:   10
+      N Strips:   0
+      X Bounds:   ...
+      Y Bounds:   ...
+      Z Bounds:   ...
+      N Arrays:   0
 
     Wrap a VTK object.
 
@@ -962,6 +946,24 @@ def wrap(dataset):
     >>> _ = point.SetPoints(points)
     >>> _ = point.SetVerts(vertices)
     >>> mesh = pyvista.wrap(point)
+    >>> mesh
+    PolyData (...)
+      N Cells:    1
+      N Points:   1
+      N Strips:   0
+      X Bounds:   1.000e+00, 1.000e+00
+      Y Bounds:   2.000e+00, 2.000e+00
+      Z Bounds:   3.000e+00, 3.000e+00
+      N Arrays:   0
+
+    Wrap a Trimesh object.
+
+    >>> import trimesh
+    >>> import pyvista
+    >>> points = [[0, 0, 0], [0, 0, 1], [0, 1, 0]]
+    >>> faces = [[0, 1, 2]]
+    >>> tmesh = trimesh.Trimesh(points, faces=faces, process=False)
+    >>> mesh = pyvista.wrap(tmesh)
     >>> mesh  # doctest:+SKIP
     PolyData (0x7fc55ff27ad0)
       N Cells:  1

--- a/tests/test_texture.py
+++ b/tests/test_texture.py
@@ -108,7 +108,7 @@ def test_texture_repr(texture):
     tex_repr = repr(texture)
     assert 'Components:   3' in tex_repr
     assert 'Cube Map:     False' in tex_repr
-    assert 'Dimensions:   300, 200\n' in tex_repr
+    assert 'Dimensions:   300, 200' in tex_repr
 
 
 def test_interpolate(texture):


### PR DESCRIPTION
Resolves #4405 by removing skips wherever possible in our docstrings. This allows images to be generated, and revealed several incorrect `repr`.

Also removes `"sphinx.ext.doctest"` since we use `pytest doctest-modules`.