### PR TITLE
changed docstring for extract_all_edges() argument use_all_points

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1506,9 +1506,9 @@ class DataSetFilters:
         ----------
         use_all_points : bool, default: False
             Indicates whether all of the points of the input mesh should exist
-            in the output. When ``True`` enables point renumbering.  If set to
-            ``True``, then a threaded approach is used which avoids the use of
-            a point locator and is quicker.
+            in the output. When ``True``, point numbering does not change and
+            a threaded approach is used, which avoids the use of a point locator
+            and is quicker.
 
             By default this is set to ``False``, and unused points are omitted
             from the output.


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
This PR corrects a small docstring error on an argument of the method `extract_all_edges`.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->
https://github.com/pyvista/pyvista/commit/9bf77ed5a68853688bdb041b3f663673c792dc8c#r115259241

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

According to VTK source code, [https://gitlab.kitware.com/vtk/vtk/-/blob/master/Filters/Core/vtkExtractEdges.cxx](https://gitlab.kitware.com/vtk/vtk/-/blob/master/Filters/Core/vtkExtractEdges.cxx), lines 432-438 and 332-338, point renumbering does _not_ happen when `use_all_point=True`. The method's docstring has been modified accordingly.