### PR TITLE
Validate and clean up pyvista.plotting namespace

### DIFF
--- a/doc/source/api/plotting/index.rst
+++ b/doc/source/api/plotting/index.rst
@@ -71,7 +71,7 @@ in older versions though.
 Widget API
 ----------
 The :class:`pyvista.Plotter` class inherits all of the widget
-methods described by the ``pyvista.plotting.widgets.WidgetHelper``
+methods described by the :class:`pyvista.plotting.widgets.WidgetHelper`
 class. For additional details, see the
 :ref:`widgets` examples.
 
@@ -84,7 +84,7 @@ class. For additional details, see the
 Picking API
 -----------
 The :class:`pyvista.Plotter` class inherits all of the picking
-methods described by the ``pyvista.plotting.picking.PickingHelper``
+methods described by the :class:`pyvista.plotting.picking.PickingHelper`
 class.
 
 .. autosummary::

--- a/doc/source/api/plotting/index.rst
+++ b/doc/source/api/plotting/index.rst
@@ -37,7 +37,7 @@ all plotting functionality in PyVista.
    Plotter
    Property
    Renderer
-   plotting._BaseMapper
+   plotting.mapper._BaseMapper
    plotting.opts.InterpolationType
    plotting.volume.Volume
    plotting.volume_property.VolumeProperty
@@ -70,14 +70,28 @@ in older versions though.
 
 Widget API
 ----------
-The :class:`pyvista.Plotter` class inherits all of the widget methods described
-by the ``pyvista.WidgetHelper`` class. For additional details, see the
+The :class:`pyvista.Plotter` class inherits all of the widget
+methods described by the ``pyvista.plotting.widgets.WidgetHelper``
+class. For additional details, see the
 :ref:`widgets` examples.
 
 .. autosummary::
    :toctree: _autosummary
 
-   WidgetHelper
+   plotting.widgets.WidgetHelper
+
+
+Picking API
+-----------
+The :class:`pyvista.Plotter` class inherits all of the picking
+methods described by the ``pyvista.plotting.picking.PickingHelper``
+class.
+
+.. autosummary::
+   :toctree: _autosummary
+
+   plotting.picking.PickingHelper
+
 
 Convenience Functions
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -189,6 +189,7 @@ numpydoc_validation_exclude = {  # set of regex
     r'\.BasePlotter$',  # Issue with class parameter documentation
     r'\.Plotter$',  # Issue with class parameter documentation
     r'\.WidgetHelper$',
+    r'\.PickingHelper$',
     r'\.from_dict$',
     r'\.to_dict$',
     r'\.__init__$',

--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -6,29 +6,45 @@ from pyvista._plot import plot
 
 from . import _vtk
 from ._property import Property
+from ._typing import Chart, ColorLike
 from .actor import Actor
 from .actor_properties import ActorProperties
 from .axes import Axes
 from .axes_actor import AxesActor
 from .camera import Camera
 from .charts import Chart, Chart2D, ChartBox, ChartMPL, ChartPie
-from .colors import (
-    PARAVIEW_BACKGROUND,
-    Color,
-    ColorLike,
-    color_char_to_word,
-    get_cmap_safe,
-    hexcolors,
-)
+from .colors import PARAVIEW_BACKGROUND, Color, color_char_to_word, get_cmap_safe, hexcolors
 from .composite_mapper import BlockAttributes, CompositeAttributes, CompositePolyDataMapper
 from .cube_axes_actor import CubeAxesActor
+from .errors import InvalidCameraError, RenderWindowUnavailable
 from .export_vtkjs import export_plotter_vtkjs, get_vtkjs_url
 from .helpers import plot_arrows, plot_compare_four
 from .lights import Light
 from .lookup_table import LookupTable
-from .mapper import DataSetMapper, _BaseMapper
-from .plotter import BasePlotter, Plotter, close_all
+from .mapper import (
+    DataSetMapper,
+    FixedPointVolumeRayCastMapper,
+    GPUVolumeRayCastMapper,
+    OpenGLGPUVolumeRayCastMapper,
+    PointGaussianMapper,
+    SmartVolumeMapper,
+    UnstructuredGridVolumeRayCastMapper,
+    _BaseMapper,
+)
+from .picking import PickingHelper
+from .plotter import (
+    _ALL_PLOTTERS,
+    KILL_DISPLAY,
+    SUPPORTED_FORMATS,
+    BasePlotter,
+    Plotter,
+    _warn_xserver,
+    close_all,
+)
+from .render_window_interactor import RenderWindowInteractor
 from .renderer import CameraPosition, Renderer, scale_point
+from .renderers import Renderers
+from .scalar_bars import ScalarBars
 from .texture import Texture, image_to_texture, numpy_to_texture
 from .tools import (
     FONTS,
@@ -36,11 +52,14 @@ from .tools import (
     check_matplotlib_vtk_compatibility,
     create_axes_marker,
     create_axes_orientation_box,
+    normalize,
     opacity_transfer_function,
     parse_font_family,
     system_supports_plotting,
 )
 from .utilities import *
+from .volume import Volume
+from .volume_property import VolumeProperty
 from .widgets import WidgetHelper
 
 

--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -12,7 +12,7 @@ from .actor_properties import ActorProperties
 from .axes import Axes
 from .axes_actor import AxesActor
 from .camera import Camera
-from .charts import Chart, Chart2D, ChartBox, ChartMPL, ChartPie
+from .charts import Chart2D, ChartBox, ChartMPL, ChartPie
 from .colors import PARAVIEW_BACKGROUND, Color, color_char_to_word, get_cmap_safe, hexcolors
 from .composite_mapper import BlockAttributes, CompositeAttributes, CompositePolyDataMapper
 from .cube_axes_actor import CubeAxesActor
@@ -29,22 +29,11 @@ from .mapper import (
     PointGaussianMapper,
     SmartVolumeMapper,
     UnstructuredGridVolumeRayCastMapper,
-    _BaseMapper,
 )
 from .picking import PickingHelper
-from .plotter import (
-    _ALL_PLOTTERS,
-    KILL_DISPLAY,
-    SUPPORTED_FORMATS,
-    BasePlotter,
-    Plotter,
-    _warn_xserver,
-    close_all,
-)
+from .plotter import _ALL_PLOTTERS, BasePlotter, Plotter, close_all
 from .render_window_interactor import RenderWindowInteractor
 from .renderer import CameraPosition, Renderer, scale_point
-from .renderers import Renderers
-from .scalar_bars import ScalarBars
 from .texture import Texture, image_to_texture, numpy_to_texture
 from .tools import (
     FONTS,

--- a/pyvista/plotting/utilities/__init__.py
+++ b/pyvista/plotting/utilities/__init__.py
@@ -16,7 +16,7 @@ from .algorithms import (
     triangulate_algorithm,
 )
 from .cubemap import cubemap, cubemap_from_filenames
-from .gl_checks import check_depth_peeling
+from .gl_checks import check_depth_peeling, uses_egl
 from .regression import (
     compare_images,
     image_from_window,

--- a/tests/namespace/namespace-plotting.txt
+++ b/tests/namespace/namespace-plotting.txt
@@ -7,7 +7,6 @@ DataSetMapper, <class 'pyvista.plotting.mapper.DataSetMapper'>
 FONTS, <enum 'FONTS'>
 FixedPointVolumeRayCastMapper, <class 'pyvista.plotting.mapper.FixedPointVolumeRayCastMapper'>
 GPUVolumeRayCastMapper, <class 'pyvista.plotting.mapper.GPUVolumeRayCastMapper'>
-KILL_DISPLAY, None
 # MissingDataError, <class 'pyvista.errors.MissingDataError'>
 OpenGLGPUVolumeRayCastMapper, <class 'pyvista.plotting.mapper.OpenGLGPUVolumeRayCastMapper'>
 PickingHelper, <class 'pyvista.plotting.picking.PickingHelper'>
@@ -18,9 +17,6 @@ Property, <class 'pyvista.plotting._property.Property'>
 RenderWindowInteractor, <class 'pyvista.plotting.render_window_interactor.RenderWindowInteractor'>
 RenderWindowUnavailable, <class 'pyvista.errors.RenderWindowUnavailable'>
 Renderer, <class 'pyvista.plotting.renderer.Renderer'>
-Renderers, <class 'pyvista.plotting.renderers.Renderers'>
-SUPPORTED_FORMATS, None
-ScalarBars, <class 'pyvista.plotting.scalar_bars.ScalarBars'>
 SmartVolumeMapper, <class 'pyvista.plotting.mapper.SmartVolumeMapper'>
 UnstructuredGridVolumeRayCastMapper, <class 'pyvista.plotting.mapper.UnstructuredGridVolumeRayCastMapper'>
 Volume, <class 'pyvista.plotting.volume.Volume'>
@@ -28,7 +24,6 @@ VolumeProperty, <class 'pyvista.plotting.volume_property.VolumeProperty'>
 WidgetHelper, <class 'pyvista.plotting.widgets.WidgetHelper'>
 _ALL_PLOTTERS, {}
 _vtk, <module 'pyvista._vtk' from 'pyvista/_vtk.py'>
-_warn_xserver, <function _warn_xserver at 0x7f72f5b704c0>
 active_scalars_algorithm, <function active_scalars_algorithm at 0x7f72f5e0a820>
 algorithm_to_mesh_handler, <function algorithm_to_mesh_handler at 0x7f72f5de6160>
 close_all, <function close_all at 0x7f72f5c5d5e0>

--- a/tests/namespace/namespace-plotting.txt
+++ b/tests/namespace/namespace-plotting.txt
@@ -1,0 +1,50 @@
+Actor, <class 'pyvista.plotting.actor.Actor'>
+BasePlotter, <class 'pyvista.plotting.plotting.BasePlotter'>
+Camera, <class 'pyvista.plotting.camera.Camera'>
+Color, <class 'pyvista.plotting.colors.Color'>
+CompositePolyDataMapper, <class 'pyvista.plotting.composite_mapper.CompositePolyDataMapper'>
+DataSetMapper, <class 'pyvista.plotting.mapper.DataSetMapper'>
+FONTS, <enum 'FONTS'>
+FixedPointVolumeRayCastMapper, <class 'pyvista.plotting.mapper.FixedPointVolumeRayCastMapper'>
+GPUVolumeRayCastMapper, <class 'pyvista.plotting.mapper.GPUVolumeRayCastMapper'>
+KILL_DISPLAY, None
+# MissingDataError, <class 'pyvista.errors.MissingDataError'>
+OpenGLGPUVolumeRayCastMapper, <class 'pyvista.plotting.mapper.OpenGLGPUVolumeRayCastMapper'>
+PickingHelper, <class 'pyvista.plotting.picking.PickingHelper'>
+Plotter, <class 'pyvista.plotting.plotting.Plotter'>
+PointGaussianMapper, <class 'pyvista.plotting.mapper.PointGaussianMapper'>
+Property, <class 'pyvista.plotting._property.Property'>
+# PyVistaDeprecationWarning, <class 'pyvista.utilities.misc.PyVistaDeprecationWarning'>
+RenderWindowInteractor, <class 'pyvista.plotting.render_window_interactor.RenderWindowInteractor'>
+RenderWindowUnavailable, <class 'pyvista.errors.RenderWindowUnavailable'>
+Renderer, <class 'pyvista.plotting.renderer.Renderer'>
+Renderers, <class 'pyvista.plotting.renderers.Renderers'>
+SUPPORTED_FORMATS, None
+ScalarBars, <class 'pyvista.plotting.scalar_bars.ScalarBars'>
+SmartVolumeMapper, <class 'pyvista.plotting.mapper.SmartVolumeMapper'>
+UnstructuredGridVolumeRayCastMapper, <class 'pyvista.plotting.mapper.UnstructuredGridVolumeRayCastMapper'>
+Volume, <class 'pyvista.plotting.volume.Volume'>
+VolumeProperty, <class 'pyvista.plotting.volume_property.VolumeProperty'>
+WidgetHelper, <class 'pyvista.plotting.widgets.WidgetHelper'>
+_ALL_PLOTTERS, {}
+_vtk, <module 'pyvista._vtk' from 'pyvista/_vtk.py'>
+_warn_xserver, <function _warn_xserver at 0x7f72f5b704c0>
+active_scalars_algorithm, <function active_scalars_algorithm at 0x7f72f5e0a820>
+algorithm_to_mesh_handler, <function algorithm_to_mesh_handler at 0x7f72f5de6160>
+close_all, <function close_all at 0x7f72f5c5d5e0>
+decimation_algorithm, <function decimation_algorithm at 0x7f72f5e0ac10>
+export_plotter_vtkjs, <function export_plotter_vtkjs at 0x7f72f5c30d30>
+extract_surface_algorithm, <function extract_surface_algorithm at 0x7f72f5e0a790>
+get_cmap_safe, <function get_cmap_safe at 0x7f72f5d01b80>
+image_from_window, <function image_from_window at 0x7f72f5cb4700>
+normalize, <function normalize at 0x7f72f5d1f040>
+numpy_to_texture, <function numpy_to_texture at 0x7f72f5e07280>
+opacity_transfer_function, <function opacity_transfer_function at 0x7f72f5d1f0d0>
+parse_font_family, <function parse_font_family at 0x7f72f5d1f160>
+pointset_to_polydata_algorithm, <function pointset_to_polydata_algorithm at 0x7f72f5e0a8b0>
+# prepare_smooth_shading, <function prepare_smooth_shading at 0x7f72f5bfb670>
+# process_opacity, <function process_opacity at 0x7f72f5bfb700>
+run_image_filter, <function run_image_filter at 0x7f72f5cb4670>
+set_algorithm_input, <function set_algorithm_input at 0x7f72f5e07f70>
+triangulate_algorithm, <function triangulate_algorithm at 0x7f72f5e0ab80>
+uses_egl, <function uses_egl at 0x7f72f5e02790>

--- a/tests/namespace/test_plotting_namespace.py
+++ b/tests/namespace/test_plotting_namespace.py
@@ -1,0 +1,25 @@
+import importlib
+import pathlib
+
+import pytest
+
+from pyvista.core.errors import PyVistaDeprecationWarning
+
+namesapce_data = pathlib.Path(__file__).parent / 'namespace-plotting.txt'
+with open(namesapce_data) as f:
+    namespace = f.read().splitlines()
+    # ignore commented data
+    namespace = [n.split(', ')[0] for n in namespace if not n.startswith('#')]
+
+
+@pytest.mark.parametrize('name', namespace)
+def test_plotting_top_namespace(name):
+    module = importlib.import_module('pyvista.plotting')
+    assert hasattr(module, name)
+
+
+def test_common_plotting_import_paths():
+    # These are `pyvista.plotting.plotting` imports found via search on GitHub
+    # across multiple public repositories
+    with pytest.warns(PyVistaDeprecationWarning):
+        from pyvista.plotting.plotting import _ALL_PLOTTERS, BasePlotter, Plotter  # noqa: F401

--- a/tests/namespace/test_plotting_namespace.py
+++ b/tests/namespace/test_plotting_namespace.py
@@ -5,8 +5,8 @@ import pytest
 
 from pyvista.core.errors import PyVistaDeprecationWarning
 
-namesapce_data = pathlib.Path(__file__).parent / 'namespace-plotting.txt'
-with open(namesapce_data) as f:
+namespace_data = pathlib.Path(__file__).parent / 'namespace-plotting.txt'
+with open(namespace_data) as f:
     namespace = f.read().splitlines()
     # ignore commented data
     namespace = [n.split(', ')[0] for n in namespace if not n.startswith('#')]

--- a/tests/namespace/test_plotting_namespace.py
+++ b/tests/namespace/test_plotting_namespace.py
@@ -22,4 +22,8 @@ def test_common_plotting_import_paths():
     # These are `pyvista.plotting.plotting` imports found via search on GitHub
     # across multiple public repositories
     with pytest.warns(PyVistaDeprecationWarning):
-        from pyvista.plotting.plotting import _ALL_PLOTTERS, BasePlotter, Plotter  # noqa: F401
+        from pyvista.plotting.plotting import _ALL_PLOTTERS  # noqa: F401
+    with pytest.warns(PyVistaDeprecationWarning):
+        from pyvista.plotting.plotting import BasePlotter  # noqa: F401
+    with pytest.warns(PyVistaDeprecationWarning):
+        from pyvista.plotting.plotting import Plotter  # noqa: F401


### PR DESCRIPTION
Follow up to #4486 to validate the changes did not break `from pyvista.plotting import <feature>` imports. I added tests that validate against the namespace in the last release but I did remove things that I did not think were intentionally exposed (which was quite a bit of stuff because of previous `*` imports).