### PR TITLE
Check garbage collection on all plotting tests, allow specific skipping

### DIFF
--- a/tests/plotting/conftest.py
+++ b/tests/plotting/conftest.py
@@ -36,21 +36,30 @@ def _is_vtk(obj):
 
 
 @pytest.fixture()
+def skip_check_gc(check_gc):
+    """Skip check_gc fixture."""
+    check_gc.skip = True
+
+
+@pytest.fixture(autouse=True)
 def check_gc(request):
     """Ensure that all VTK objects are garbage-collected by Python."""
     gc.collect()
     before = {id(o) for o in gc.get_objects() if _is_vtk(o)}
-    yield
 
-    # Do not check for collection if the test session failed. Tests that fail
-    # also fail to cleanup their resources and this makes reading the unit test
-    # output more difficult.
-    #
-    # This applies to the entire session, so it's going to be the most useful
-    # when debugging tests with `pytest -x`
-    pyvista.close_all()
-    if request.session.testsfailed:
+    class GcHandler:
+        def __init__(self) -> None:
+            # if set to True, will entirely skip checking in this fixture
+            self.skip = False
+
+    gc_handler = GcHandler()
+
+    yield gc_handler
+
+    if gc_handler.skip:
         return
+
+    pyvista.close_all()
 
     gc.collect()
     after = [o for o in gc.get_objects() if _is_vtk(o) and id(o) not in before]

--- a/tests/plotting/conftest.py
+++ b/tests/plotting/conftest.py
@@ -42,7 +42,7 @@ def skip_check_gc(check_gc):
 
 
 @pytest.fixture(autouse=True)
-def check_gc(request):
+def check_gc():
     """Ensure that all VTK objects are garbage-collected by Python."""
     gc.collect()
     before = {id(o) for o in gc.get_objects() if _is_vtk(o)}

--- a/tests/plotting/jupyter/conftest.py
+++ b/tests/plotting/jupyter/conftest.py
@@ -1,0 +1,8 @@
+"""Conftest for jupyter tests."""
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def skip_check_gc(skip_check_gc):
+    """A large number of tests here fail gc."""
+    pass

--- a/tests/plotting/mappers/test_volume_mapper.py
+++ b/tests/plotting/mappers/test_volume_mapper.py
@@ -13,11 +13,11 @@ def volume_mapper():
     return actor.mapper
 
 
-def test_volume_mapper_dataset(volume_mapper):
+def test_volume_mapper_dataset(volume_mapper, skip_check_gc):
     assert isinstance(volume_mapper.dataset, pv.UniformGrid)
 
 
-def test_volume_mapper_blend_mode(volume_mapper):
+def test_volume_mapper_blend_mode(volume_mapper, skip_check_gc):
     assert isinstance(volume_mapper.blend_mode, str)
 
     volume_mapper.blend_mode = vtk.vtkVolumeMapper.COMPOSITE_BLEND

--- a/tests/plotting/test_axes.py
+++ b/tests/plotting/test_axes.py
@@ -3,10 +3,11 @@ import pytest
 
 import pyvista as pv
 
-# @pytest.fixture(autouse=True)
-# def skip_check_gc(skip_check_gc):
-#     """All the tests here fail gc."""
-#     pass
+
+@pytest.fixture(autouse=True)
+def skip_check_gc(skip_check_gc):
+    """All the tests here fail gc."""
+    pass
 
 
 @pytest.fixture()

--- a/tests/plotting/test_axes.py
+++ b/tests/plotting/test_axes.py
@@ -3,6 +3,11 @@ import pytest
 
 import pyvista as pv
 
+# @pytest.fixture(autouse=True)
+# def skip_check_gc(skip_check_gc):
+#     """All the tests here fail gc."""
+#     pass
+
 
 @pytest.fixture()
 def axes():

--- a/tests/plotting/test_charts.py
+++ b/tests/plotting/test_charts.py
@@ -17,6 +17,13 @@ skip_mac = pytest.mark.skipif(
     platform.system() == 'Darwin', reason='MacOS CI fails when downloading examples'
 )
 
+
+@pytest.fixture(autouse=True)
+def skip_check_gc(skip_check_gc):
+    """A large number of tests here fail gc."""
+    pass
+
+
 # skip all tests if VTK<9.2.0
 if pyvista.vtk_version_info < (9, 2):
     pytestmark = pytest.mark.skip

--- a/tests/plotting/test_collection.py
+++ b/tests/plotting/test_collection.py
@@ -3,17 +3,10 @@ import gc
 import weakref
 
 import numpy as np
-import pytest
 import vtk
 
 import pyvista as pv
 from pyvista.core._vtk_core import vtk_to_numpy
-
-
-@pytest.fixture(autouse=True)
-def validate_gc(check_gc):
-    """Autouse garbage collection validation fixture for this module."""
-    pass
 
 
 def test_pyvistandarray_assign(sphere):

--- a/tests/plotting/test_cube_axes_actor.py
+++ b/tests/plotting/test_cube_axes_actor.py
@@ -5,6 +5,12 @@ import pytest
 import pyvista as pv
 
 
+@pytest.fixture(autouse=True)
+def skip_check_gc(skip_check_gc):
+    """A large number of tests here fail gc."""
+    pass
+
+
 @pytest.fixture
 def cube_axes_actor():
     pl = pv.Plotter()

--- a/tests/plotting/test_lookup_table.py
+++ b/tests/plotting/test_lookup_table.py
@@ -196,7 +196,7 @@ def test_table_cmap_list(lut):
     assert lut.n_values == 3
 
 
-def test_table_values_update(lut):
+def test_table_values_update(lut, skip_check_gc):
     lut.cmap = 'Greens'
     lut.values[:, -1] = np.linspace(0, 255, lut.n_values)
     assert lut.values.max() == 255
@@ -221,7 +221,7 @@ def test_call(lut):
     assert lut.map_value(0.5) == lut.map_value(0.5)
 
 
-def test_custom_opacity(lut):
+def test_custom_opacity(lut, skip_check_gc):
     values_copy = lut.values.copy()
     lut.apply_opacity('sigmoid')
     assert not np.array_equiv(lut.values[:, -1], 255)

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -90,12 +90,6 @@ skip_mesa = pytest.mark.skipif(using_mesa(), reason='Does not display correctly 
 
 
 @pytest.fixture(autouse=True)
-def validate_gc(check_gc):
-    """Autouse garbage collection validation fixture for this module."""
-    pass
-
-
-@pytest.fixture(autouse=True)
 def verify_image_cache_wrapper(verify_image_cache):
     return verify_image_cache
 

--- a/tests/plotting/test_plotting_utilities.py
+++ b/tests/plotting/test_plotting_utilities.py
@@ -42,13 +42,13 @@ def test_ray_trace_plot():
 
 
 @pytest.mark.skip_plotting
-def test_plot_curvature():
+def test_plot_curvature(skip_check_gc):
     sphere = pyvista.Sphere(0.5, theta_resolution=10, phi_resolution=10)
     sphere.plot_curvature(off_screen=True)
 
 
 @pytest.mark.skip_plotting
-def test_plot_curvature_pointset():
+def test_plot_curvature_pointset(skip_check_gc):
     grid = examples.load_structured()
     grid.plot_curvature(off_screen=True)
 

--- a/tests/plotting/test_volume_property.py
+++ b/tests/plotting/test_volume_property.py
@@ -9,7 +9,7 @@ def vol_prop():
     return VolumeProperty()
 
 
-def test_volume_lookup_table(vol_prop):
+def test_volume_lookup_table(vol_prop, skip_check_gc):
     lut = pv.LookupTable(cmap='bwr')
     lut.apply_opacity([1.0, 0.0, 0.0, 0.3, 0.0, 0.0, 0.0, 0.3])
     orig = vol_prop.GetRGBTransferFunction()

--- a/tests/plotting/test_widgets.py
+++ b/tests/plotting/test_widgets.py
@@ -8,12 +8,6 @@ import pyvista
 pytestmark = pytest.mark.skip_plotting
 
 
-@pytest.fixture(autouse=True)
-def validate_gc(check_gc):
-    """Autouse garbage collection validation fixture for this module."""
-    pass
-
-
 def test_widget_box(uniform):
     p = pyvista.Plotter()
     func = lambda box: box  # Does nothing


### PR DESCRIPTION
### Overview

After #4500, `check_gc` fixture was only used in three test modules. It would be better to have it check all of the plotting tests, with optional skips.  This PR adds in this functionality by setting `check_gc` to be `autouse=True` in the `tests/plotting/conftest.py` and yielding an object which allows skipping the test.  A new fixture `skip_check_gc` can be used to skip specific tests (or modules) if warranted.

This PR is not aiming to fix any of the gc issues that might be uncovered. But specific uses of `skip_check_gc` will be an easier indication for bug fixing later.


### Details

First, this PR will push the changes that will expose failing tests, then skips will be added.

