### PR TITLE
Fix test_timer skip conditions

### DIFF
--- a/tests/plotting/test_render_window_interactor.py
+++ b/tests/plotting/test_render_window_interactor.py
@@ -130,7 +130,7 @@ def test_track_click_position():
 
 
 @pytest.mark.skipif(
-    not isinstance(_vtk.vtkRenderWindowInteractor(), (_vtk.vtkWin32RenderWindowInteractor, _vtk.vtkXRenderWindowInteractor)),
+    type(_vtk.vtkRenderWindowInteractor()).__name__ not in ("vtkWin32RenderWindowInteractor", "vtkXRenderWindowInteractor"),
     reason='Other RenderWindowInteractors do not invoke TimerEvents during ProcessEvents.',
 )
 @pytest.mark.needs_vtk_version(

--- a/tests/plotting/test_render_window_interactor.py
+++ b/tests/plotting/test_render_window_interactor.py
@@ -1,6 +1,5 @@
 """Test render window interactor"""
 
-import platform
 import time
 
 import pytest
@@ -131,8 +130,8 @@ def test_track_click_position():
 
 
 @pytest.mark.skipif(
-    platform.system() == 'Darwin',
-    reason='vtkCocoaRenderWindowInteractor (MacOS) does not invoke TimerEvents during ProcessEvents. ',
+    not isinstance(_vtk.vtkRenderWindowInteractor(), (_vtk.vtkWin32RenderWindowInteractor, _vtk.vtkXRenderWindowInteractor)),
+    reason='Other RenderWindowInteractors do not invoke TimerEvents during ProcessEvents.',
 )
 @pytest.mark.needs_vtk_version(
     (9, 2),

--- a/tests/plotting/test_render_window_interactor.py
+++ b/tests/plotting/test_render_window_interactor.py
@@ -130,7 +130,8 @@ def test_track_click_position():
 
 
 @pytest.mark.skipif(
-    type(_vtk.vtkRenderWindowInteractor()).__name__ not in ("vtkWin32RenderWindowInteractor", "vtkXRenderWindowInteractor"),
+    type(_vtk.vtkRenderWindowInteractor()).__name__
+    not in ("vtkWin32RenderWindowInteractor", "vtkXRenderWindowInteractor"),
     reason='Other RenderWindowInteractors do not invoke TimerEvents during ProcessEvents.',
 )
 @pytest.mark.needs_vtk_version(


### PR DESCRIPTION
### Overview

The `test_timer` test is now skipped in environments without a `RenderWindowInteractor` with proper timer handling in the `ProcessEvents` method.
Resolves #4523.
