### PR TITLE
[HOTFIX] Move more plotting VTK imports

### DIFF
--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -37,24 +37,6 @@ from vtkmodules.util.numpy_support import (
     vtk_to_numpy,
 )
 from vtkmodules.util.vtkAlgorithm import VTKPythonAlgorithmBase
-from vtkmodules.vtkChartsCore import (
-    vtkAxis,
-    vtkChart,
-    vtkChartBox,
-    vtkChartPie,
-    vtkChartXY,
-    vtkChartXYZ,
-    vtkPlotArea,
-    vtkPlotBar,
-    vtkPlotBox,
-    vtkPlotLine,
-    vtkPlotLine3D,
-    vtkPlotPie,
-    vtkPlotPoints,
-    vtkPlotPoints3D,
-    vtkPlotStacked,
-    vtkPlotSurface,
-)
 from vtkmodules.vtkCommonComputationalGeometry import (
     vtkKochanekSpline,
     vtkParametricBohemianDome,
@@ -396,20 +378,6 @@ from vtkmodules.vtkImagingCore import (
 from vtkmodules.vtkImagingGeneral import vtkImageGaussianSmooth, vtkImageMedian3D
 from vtkmodules.vtkImagingHybrid import vtkSampleFunction, vtkSurfaceReconstructionFilter
 from vtkmodules.vtkImagingMorphological import vtkImageDilateErode3D
-from vtkmodules.vtkInteractionWidgets import (
-    vtkBoxWidget,
-    vtkButtonWidget,
-    vtkImplicitPlaneWidget,
-    vtkLineWidget,
-    vtkOrientationMarkerWidget,
-    vtkPlaneWidget,
-    vtkScalarBarWidget,
-    vtkSliderRepresentation2D,
-    vtkSliderWidget,
-    vtkSphereWidget,
-    vtkSplineWidget,
-    vtkTexturedButtonRepresentation2D,
-)
 
 try:
     from vtkmodules.vtkPythonContext2D import vtkPythonItem

--- a/pyvista/plotting/_vtk.py
+++ b/pyvista/plotting/_vtk.py
@@ -9,7 +9,39 @@ the entire library.
 """
 # flake8: noqa: F401
 
+from vtkmodules.vtkChartsCore import (
+    vtkAxis,
+    vtkChart,
+    vtkChartBox,
+    vtkChartPie,
+    vtkChartXY,
+    vtkChartXYZ,
+    vtkPlotArea,
+    vtkPlotBar,
+    vtkPlotBox,
+    vtkPlotLine,
+    vtkPlotLine3D,
+    vtkPlotPie,
+    vtkPlotPoints,
+    vtkPlotPoints3D,
+    vtkPlotStacked,
+    vtkPlotSurface,
+)
 from vtkmodules.vtkCommonColor import vtkColorSeries
+from vtkmodules.vtkInteractionWidgets import (
+    vtkBoxWidget,
+    vtkButtonWidget,
+    vtkImplicitPlaneWidget,
+    vtkLineWidget,
+    vtkOrientationMarkerWidget,
+    vtkPlaneWidget,
+    vtkScalarBarWidget,
+    vtkSliderRepresentation2D,
+    vtkSliderWidget,
+    vtkSphereWidget,
+    vtkSplineWidget,
+    vtkTexturedButtonRepresentation2D,
+)
 from vtkmodules.vtkRenderingAnnotation import (
     vtkAnnotatedCubeActor,
     vtkAxesActor,


### PR DESCRIPTION
I noticed some plotting imports slipped by my in my first iteration. I didn't catch these because, interestingly, they did not fail on import when libGL.so was missing

follow up to #4486 