### PR TITLE
Isolate libGL VTK imports

### DIFF
--- a/pyvista/plotting/_vtk.py
+++ b/pyvista/plotting/_vtk.py
@@ -7,8 +7,6 @@ package, which lets us only have to import from select modules and not
 the entire library.
 
 """
-# flake8: noqa: F401
-
 from vtkmodules.vtkChartsCore import (
     vtkAxis,
     vtkChart,
@@ -61,17 +59,6 @@ from vtkmodules.vtkRenderingContext2D import (
     vtkImageItem,
     vtkPen,
 )
-
-from pyvista.core._vtk_core import *
-
-try:
-    # Necessary for displaying charts, otherwise crashes on rendering
-    import vtkmodules.vtkRenderingContextOpenGL2
-
-    _has_vtkRenderingContextOpenGL2 = True
-except ImportError:  # pragma: no cover
-    _has_vtkRenderingContextOpenGL2 = False
-
 from vtkmodules.vtkRenderingCore import (
     vtkAbstractMapper,
     vtkActor,
@@ -110,31 +97,15 @@ from vtkmodules.vtkRenderingCore import (
 )
 from vtkmodules.vtkRenderingFreeType import vtkMathTextFreeTypeTextRenderer, vtkVectorText
 from vtkmodules.vtkRenderingLabel import vtkLabelPlacementMapper, vtkPointSetToLabelHierarchy
-from vtkmodules.vtkRenderingOpenGL2 import (
-    vtkCameraPass,
-    vtkCompositePolyDataMapper2,
-    vtkDepthOfFieldPass,
-    vtkEDLShading,
-    vtkGaussianBlurPass,
-    vtkOpenGLFXAAPass,
-    vtkOpenGLHardwareSelector,
-    vtkOpenGLRenderer,
-    vtkOpenGLTexture,
-    vtkRenderPassCollection,
-    vtkRenderStepsPass,
-    vtkSequencePass,
-    vtkShadowMapPass,
-    vtkSSAAPass,
-    vtkSSAOPass,
-)
 from vtkmodules.vtkRenderingUI import vtkGenericRenderWindowInteractor
 from vtkmodules.vtkRenderingVolume import (
     vtkFixedPointVolumeRayCastMapper,
     vtkGPUVolumeRayCastMapper,
     vtkUnstructuredGridVolumeRayCastMapper,
 )
-from vtkmodules.vtkRenderingVolumeOpenGL2 import (
-    vtkOpenGLGPUVolumeRayCastMapper,
-    vtkSmartVolumeMapper,
-)
 from vtkmodules.vtkViewsContext2D import vtkContextInteractorStyle
+
+from pyvista.core._vtk_core import *
+
+# flake8: noqa: F401
+from ._vtk_gl import *

--- a/pyvista/plotting/_vtk.py
+++ b/pyvista/plotting/_vtk.py
@@ -7,6 +7,8 @@ package, which lets us only have to import from select modules and not
 the entire library.
 
 """
+# flake8: noqa: F401
+
 from vtkmodules.vtkChartsCore import (
     vtkAxis,
     vtkChart,
@@ -107,5 +109,4 @@ from vtkmodules.vtkViewsContext2D import vtkContextInteractorStyle
 
 from pyvista.core._vtk_core import *
 
-# flake8: noqa: F401
 from ._vtk_gl import *

--- a/pyvista/plotting/_vtk_gl.py
+++ b/pyvista/plotting/_vtk_gl.py
@@ -36,7 +36,6 @@ from vtkmodules.vtkRenderingOpenGL2 import (
     vtkSSAAPass,
     vtkSSAOPass,
 )
-
 from vtkmodules.vtkRenderingVolumeOpenGL2 import (
     vtkOpenGLGPUVolumeRayCastMapper,
     vtkSmartVolumeMapper,

--- a/pyvista/plotting/_vtk_gl.py
+++ b/pyvista/plotting/_vtk_gl.py
@@ -14,9 +14,9 @@ try:
     # Necessary for displaying charts, otherwise crashes on rendering
     import vtkmodules.vtkRenderingContextOpenGL2
 
-    _has_vtkRenderingContextOpenGL2 = True
+    has_vtkRenderingContextOpenGL2 = True
 except ImportError:  # pragma: no cover
-    _has_vtkRenderingContextOpenGL2 = False
+    has_vtkRenderingContextOpenGL2 = False
 
 
 from vtkmodules.vtkRenderingOpenGL2 import (

--- a/pyvista/plotting/_vtk_gl.py
+++ b/pyvista/plotting/_vtk_gl.py
@@ -1,0 +1,43 @@
+"""
+GL-dependent imports from VTK.
+
+These are the modules within VTK requiring libGL that must be loaded
+across pyvista's plotting API. These imports have the potential to
+raise an ImportError if the user does not have libGL installed.
+
+    ImportError: libGL.so.1: cannot open shared object file: No such file or directory
+
+"""
+# flake8: noqa: F401
+
+try:
+    # Necessary for displaying charts, otherwise crashes on rendering
+    import vtkmodules.vtkRenderingContextOpenGL2
+
+    _has_vtkRenderingContextOpenGL2 = True
+except ImportError:  # pragma: no cover
+    _has_vtkRenderingContextOpenGL2 = False
+
+
+from vtkmodules.vtkRenderingOpenGL2 import (
+    vtkCameraPass,
+    vtkCompositePolyDataMapper2,
+    vtkDepthOfFieldPass,
+    vtkEDLShading,
+    vtkGaussianBlurPass,
+    vtkOpenGLFXAAPass,
+    vtkOpenGLHardwareSelector,
+    vtkOpenGLRenderer,
+    vtkOpenGLTexture,
+    vtkRenderPassCollection,
+    vtkRenderStepsPass,
+    vtkSequencePass,
+    vtkShadowMapPass,
+    vtkSSAAPass,
+    vtkSSAOPass,
+)
+
+from vtkmodules.vtkRenderingVolumeOpenGL2 import (
+    vtkOpenGLGPUVolumeRayCastMapper,
+    vtkSmartVolumeMapper,
+)

--- a/pyvista/plotting/_vtk_gl.py
+++ b/pyvista/plotting/_vtk_gl.py
@@ -12,11 +12,9 @@ raise an ImportError if the user does not have libGL installed.
 
 try:
     # Necessary for displaying charts, otherwise crashes on rendering
-    import vtkmodules.vtkRenderingContextOpenGL2
-
-    has_vtkRenderingContextOpenGL2 = True
+    from vtkmodules import vtkRenderingContextOpenGL2
 except ImportError:  # pragma: no cover
-    has_vtkRenderingContextOpenGL2 = False
+    vtkRenderingContextOpenGL2 = None
 
 
 from vtkmodules.vtkRenderingOpenGL2 import (

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -650,7 +650,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         >>> pl.show()
 
         """
-        if not _vtk._has_vtkRenderingContextOpenGL2:  # pragma: no cover
+        if not _vtk.has_vtkRenderingContextOpenGL2:  # pragma: no cover
             from pyvista.core.errors import VTKVersionError
 
             raise VTKVersionError(

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -650,7 +650,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         >>> pl.show()
 
         """
-        if not _vtk.has_vtkRenderingContextOpenGL2:  # pragma: no cover
+        if _vtk.vtkRenderingContextOpenGL2 is None:  # pragma: no cover
             from pyvista.core.errors import VTKVersionError
 
             raise VTKVersionError(


### PR DESCRIPTION
Additional follow-up to #4486 to isolate all `libGL.so` VTK imports to a single module.