### PR TITLE
Handle plotter scale for point picking

### DIFF
--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -413,7 +413,9 @@ class PickingInterface:
                         self_()._clear_picking_representations()
                 return
             with self_().iren.poked_subplot():
-                self_()._picked_point = np.array(picker.GetPickPosition())
+                point = np.array(picker.GetPickPosition())
+                point /= self_().scale  # HACK: handle scale
+                self_()._picked_point = point
                 if show_point:
                     _kwargs = kwargs.copy()
                     self_().add_mesh(
@@ -1016,9 +1018,7 @@ class PickingMethods(PickingInterface):
         ----------
         callback : callable, optional
             When input, calls this callable after a selection is made.
-            The ``RectangleSelection`` is the only passed argument
-            containing the viewport coordinates of the selection and the
-            projected frustum.
+            The picked cells is the only passed argument.
 
         show : bool, default: True
             Show the selection interactively.
@@ -1134,9 +1134,7 @@ class PickingMethods(PickingInterface):
         ----------
         callback : callable, optional
             When input, calls this callable after a selection is made.
-            The ``RectangleSelection`` is the only passed argument
-            containing the viewport coordinates of the selection and the
-            projected frustum.
+            The picked cells is the only passed argument.
 
         show : bool, default: True
             Show the selection interactively.


### PR DESCRIPTION
A quick hack to resolve #1335

I notice different results with different pickers. `PickerType.CELL` seems to have the best result for scaled point picking.

This also fixes a docstring

```py
import pyvista as pv
from pyvista import examples
from pyvista.plotting.opts import PickerType

mesh = examples.load_random_hills()

pl = pv.Plotter()
pl.add_mesh(mesh, color='lightblue')
pl.enable_point_picking(picker=PickerType.CELL)
pl.set_scale(zscale=7, xscale=4)
pl.show()
```