### PR TITLE
Only check if current on windows

### DIFF
--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -6700,7 +6700,7 @@ class Plotter(BasePlotter):
         # render window.
         # Ignore if using a Jupyter display
         _is_current = self.render_window.IsCurrent()
-        if jupyter_disp is None and not _is_current:
+        if jupyter_disp is None and not _is_current and os.name == 'nt':
             self._clear_ren_win()  # The ren_win is deleted
             # proper screenshots cannot be saved if this happens
             if not auto_close:


### PR DESCRIPTION
Resolves #1621 while not causing #4057. However, this fix will likely not fix the issue on Windows.

Since this appears to be a windows only bug and an old one at that, I’d appreciate it if someone could test if we still need to check if current on windows as I’ll be unable to check this for several days.