### PR TITLE
HOTFIX: HTML repr width

### DIFF
--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -894,7 +894,7 @@ class MultiBlock(
     def _repr_html_(self) -> str:
         """Define a pretty representation for Jupyter notebooks."""
         fmt = ""
-        fmt += "<table>"
+        fmt += "<table style='width: 100%;'>"
         fmt += "<tr><th>Information</th><th>Blocks</th></tr>"
         fmt += "<tr><td>"
         fmt += "\n"

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -209,7 +209,7 @@ class DataObject:
             fmt = ""
             # HTML version
             fmt += "\n"
-            fmt += "<table>\n"
+            fmt += "<table style='width: 100%;'>\n"
             fmt += f"<tr><th>{type(self).__name__}</th><th>Information</th></tr>\n"
             row = "<tr><td>{}</td><td>{}</td></tr>\n"
             # now make a call on the object to get its attributes as a list of len 2 tuples

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1931,7 +1931,7 @@ class DataSet(DataSetFilters, DataObject):
         """
         fmt = ""
         if self.n_arrays > 0:
-            fmt += "<table>"
+            fmt += "<table style='width: 100%;'>"
             fmt += "<tr><th>Header</th><th>Data Arrays</th></tr>"
             fmt += "<tr><td>"
         # Get the header info
@@ -1940,7 +1940,7 @@ class DataSet(DataSetFilters, DataObject):
         if self.n_arrays > 0:
             fmt += "</td><td>"
             fmt += "\n"
-            fmt += "<table>\n"
+            fmt += "<table style='width: 100%;'>\n"
             titles = ["Name", "Field", "Type", "N Comp", "Min", "Max"]
             fmt += "<tr>" + "".join([f"<th>{t}</th>" for t in titles]) + "</tr>\n"
             row = "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>\n"

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -238,7 +238,7 @@ class Table(_vtk.vtkTable, DataObject):
         """
         fmt = ""
         if self.n_arrays > 0:
-            fmt += "<table>"
+            fmt += "<table style='width: 100%;'>"
             fmt += "<tr><th>Header</th><th>Data Arrays</th></tr>"
             fmt += "<tr><td>"
         # Get the header info
@@ -247,7 +247,7 @@ class Table(_vtk.vtkTable, DataObject):
         if self.n_arrays > 0:
             fmt += "</td><td>"
             fmt += "\n"
-            fmt += "<table>\n"
+            fmt += "<table style='width: 100%;'>\n"
             titles = ["Name", "Type", "N Comp", "Min", "Max"]
             fmt += "<tr>" + "".join([f"<th>{t}</th>" for t in titles]) + "</tr>\n"
             row = "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>\n"


### PR DESCRIPTION
The HTML repr is badly messed up. This is a hotfix until we can make it compatible with the `pydata-sphinx-theme`

Before:

<img width="739" alt="Screenshot 2023-06-28 at 10 28 10 PM" src="https://github.com/pyvista/pyvista/assets/22067021/23e31c06-6262-4d8d-8fe9-e1a456fc0404">


After

<img width="857" alt="Screenshot 2023-06-28 at 10 29 08 PM" src="https://github.com/pyvista/pyvista/assets/22067021/a9c17c5f-1a86-431c-a2f1-032e0b183280">

