### PR TITLE
Remove typed-ast dependency

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -36,4 +36,3 @@ trame-client==2.9.4
 trame-server==2.11.4
 trame-vtk==2.5.4
 trimesh==3.22.3
-typed-ast==1.5.4


### PR DESCRIPTION
### Overview

`typed-ast` is no longer maintained and is end of life.  see https://github.com/python/typed_ast#end-of-life

### Details

Supersedes #4624 

