### PR TITLE
More convenient PolyData face interface

### DIFF
--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -536,10 +536,7 @@ class CellArray(_vtk.vtkCellArray):
         """Set the offsets and connectivity arrays."""
         offsets = numpy_to_idarr(offsets, deep=deep)
         connectivity = numpy_to_idarr(connectivity, deep=deep)
-        try:
-            self.SetData(offsets, connectivity)
-        except AttributeError:  # pragma: no cover
-            raise VTKVersionError('vtkCellArray.SetData implemented in VTK 9 or newer.')
+        self.SetData(offsets, connectivity)
 
         # Because vtkCellArray doesn't take ownership of the arrays, it's possible for them to get
         # garbage collected. Keep a reference to them for safety
@@ -617,10 +614,7 @@ class CellArray(_vtk.vtkCellArray):
 
 def _get_connectivity_array(cellarr: _vtk.vtkCellArray):
     """Return the array with the point ids that define the cells' connectivity."""
-    try:
-        return _vtk.vtk_to_numpy(cellarr.GetConnectivityArray())
-    except AttributeError:  # pragma: no cover
-        raise VTKVersionError('Connectivity array implemented in VTK 9 or newer.')
+    return _vtk.vtk_to_numpy(cellarr.GetConnectivityArray())
 
 
 def _get_offset_array(cellarr: _vtk.vtkCellArray):

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -6,7 +6,6 @@ from typing import List, Tuple, cast
 import numpy as np
 
 import pyvista
-from pyvista.core.errors import VTKVersionError
 
 from . import _vtk_core as _vtk
 from .celltype import CellType

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -478,6 +478,7 @@ class CellArray(_vtk.vtkCellArray):
     Examples
     --------
     Create a cell array containing two triangles from the traditional interleaved format
+
     >>> from pyvista.core.cell import CellArray
     >>> cellarr = CellArray([3, 0, 1, 2, 3, 3, 4, 5])
 

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -533,7 +533,7 @@ class CellArray(_vtk.vtkCellArray):
 
     @staticmethod
     def from_arrays(offsets, connectivity, deep=False) -> 'CellArray':
-        """Construct a vtkCellArray from offsets and connectivity arrays
+        """Construct a vtkCellArray from offsets and connectivity arrays.
 
         Parameters
         ----------
@@ -555,7 +555,7 @@ class CellArray(_vtk.vtkCellArray):
 
     @property
     def regular_cells(self) -> np.ndarray:
-        """Return an array of shape (n_cells, cell_size) of point indices when all faces have the same size
+        """Return an array of shape (n_cells, cell_size) of point indices when all faces have the same size.
 
         Returns
         -------
@@ -563,7 +563,7 @@ class CellArray(_vtk.vtkCellArray):
             (n_cells, cell_size) Array of face indices
 
         Notes
-        --------
+        -----
         This property does not validate that the cells are all
         actually the same size. If they're not, this property may either
         raise a `ValueError` or silently return an incorrect array.

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -462,6 +462,7 @@ class Cell(_vtk.vtkGenericCell, DataObject):
         return type(self)(self, deep=deep)
 
 
+@_vtk.vtkCellArray.override
 class CellArray(_vtk.vtkCellArray):
     """pyvista wrapping of vtkCellArray.
 

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -541,13 +541,10 @@ class CellArray(_vtk.vtkCellArray):
         except AttributeError:  # pragma: no cover
             raise VTKVersionError('vtkCellArray.SetData implemented in VTK 9 or newer.')
 
-        if not deep:
-            # Because vtkCellArray doesn't take ownership of the arrays, it's possible for them to get
-            # garbage collected. Keep a reference to them for safety
-            self.__offsets = offsets
-            self.__connectivity = connectivity
-        else:
-            self.__offsets = self.__connectivity = None
+        # Because vtkCellArray doesn't take ownership of the arrays, it's possible for them to get
+        # garbage collected. Keep a reference to them for safety
+        self.__offsets = offsets
+        self.__connectivity = connectivity
 
     @staticmethod
     def from_arrays(offsets, connectivity, deep=False) -> CellArray:

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -598,11 +598,10 @@ class CellArray(_vtk.vtkCellArray):
         pyvista.CellArray
         """
         cells = np.asarray(cells, dtype=pyvista.ID_TYPE)
-        connectivity = numpy_to_idarr(cells, deep=deep)
         n_cells, cell_size = cells.shape
-        offsets = numpy_to_idarr(cell_size * np.arange(n_cells + 1, dtype=pyvista.ID_TYPE))
+        offsets = cell_size * np.arange(n_cells + 1, dtype=pyvista.ID_TYPE)
         cellarr = cls()
-        cellarr._set_data(offsets, connectivity, deep=deep)
+        cellarr._set_data(offsets, cells, deep=deep)
         return cellarr
 
 

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -483,6 +483,7 @@ class CellArray(_vtk.vtkCellArray):
     >>> cellarr = CellArray([3, 0, 1, 2, 3, 3, 4, 5])
 
     Create a cell array containing two triangles from separate offsets and connectivity arrays
+
     >>> from pyvista.core.cell import CellArray
     >>> offsets = [0, 3, 6]
     >>> connectivity = [0, 1, 2, 3, 4, 5]

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -570,7 +570,7 @@ class CellArray(_vtk.vtkCellArray):
 
     @classmethod
     def from_regular_cells(cls, cells, deep=True):
-        """Constract a ``CellArray`` from a (n_cells, cell_size) array of cell indices.
+        """Construct a ``CellArray`` from a (n_cells, cell_size) array of cell indices.
 
         Parameters
         ----------
@@ -620,7 +620,6 @@ def _get_offset_array(cellarr: _vtk.vtkCellArray):
 
 def _get_regular_cells(cellarr: _vtk.vtkCellArray) -> np.ndarray:
     """Return an array of shape (n_cells, cell_size) of point indices when all faces have the same size."""
-
     cells = _get_connectivity_array(cellarr)
     if len(cells) == 0:
         return cells

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 from typing import List, Tuple, cast
 
 import numpy as np
-from pyvista.core.errors import VTKVersionError
 
 import pyvista
+from pyvista.core.errors import VTKVersionError
 
 from . import _vtk_core as _vtk
 from .celltype import CellType
@@ -530,7 +530,7 @@ class CellArray(_vtk.vtkCellArray):
         return _get_offset_array(self)
 
     @staticmethod
-    def from_arrays(offsets, connectivity, deep=False) -> 'CellArray':
+    def from_arrays(offsets, connectivity, deep=False) -> CellArray:
         """Construct a vtkCellArray from offsets and connectivity arrays.
 
         Parameters
@@ -590,7 +590,9 @@ class CellArray(_vtk.vtkCellArray):
 
         n_cells, cell_size = cells.shape
         offsets = cell_size * np.arange(n_cells + 1, dtype=pyvista.ID_TYPE)
-        offsets = numpy_to_idarr(offsets, deep=True)  # Since we're creating offsets on the fly here, force deep copy
+        offsets = numpy_to_idarr(
+            offsets, deep=True
+        )  # Since we're creating offsets on the fly here, force deep copy
         cellarr = cls()
         try:
             cellarr.SetData(offsets, connectivity)
@@ -604,6 +606,7 @@ class CellArray(_vtk.vtkCellArray):
 # but then they wouldn't be available on bare vtkCellArrays. In the future,
 # consider using vtkCellArray.override decorator, so they're all automatically
 # returned as CellArrays
+
 
 def _get_connectivity_array(cellarr: _vtk.vtkCellArray):
     """Return the array with the point ids that define the cells' connectivity."""

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -566,9 +566,9 @@ class CellArray(_vtk.vtkCellArray):
         """
         return _get_regular_cells(self)
 
-    @staticmethod
-    def from_regular_cells(cells, deep=True) -> 'CellArray':
-        """Set cells from a (n_cells, cell_size) array
+    @classmethod
+    def from_regular_cells(cls, cells, deep=True):
+        """Constract a ``CellArray`` from a (n_cells, cell_size) array of cell indices.
 
         Parameters
         ----------
@@ -589,7 +589,7 @@ class CellArray(_vtk.vtkCellArray):
         n_cells, cell_size = cells.shape
         offsets = cell_size * np.arange(n_cells + 1, dtype=pyvista.ID_TYPE)
         offsets = numpy_to_idarr(offsets, deep=True)  # Since we're creating offsets on the fly here, force deep copy
-        cellarr = CellArray()
+        cellarr = cls()
         try:
             cellarr.SetData(offsets, connectivity)
         except AttributeError:  # pragma: no cover

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -557,7 +557,6 @@ class CellArray(_vtk.vtkCellArray):
 
         deep : bool, default: False
             Whether to deep copy the array data into the vtk arrays.
-            Default is ``False``.
         """
         cellarr = CellArray()
         cellarr._set_data(offsets, connectivity, deep=deep)
@@ -587,11 +586,10 @@ class CellArray(_vtk.vtkCellArray):
         Parameters
         ----------
         cells : numpy.ndarray or list[list[int]]
-            Cell array of shape (n_cells, cell_size) where all cells have the same size `cell_size`
+            Cell array of shape (n_cells, cell_size) where all cells have the same size `cell_size`.
 
         deep : bool, default: False
-            Whether to deep copy the cell array data into the vtk connectivity array
-            Default is ``True``.
+            Whether to deep copy the cell array data into the vtk connectivity array.
 
         Returns
         -------

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -556,7 +556,7 @@ class CellArray(_vtk.vtkCellArray):
         Returns
         -------
         numpy.ndarray
-            (n_cells, cell_size) Array of face indices
+            Array of face indices of shape (n_cells, cell_size).
 
         Notes
         -----

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -852,7 +852,10 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         >>> import pyvista as pv
         >>> tetra = pv.Tetrahedron()
         >>> tetra.regular_faces
-        array([[0, 1, 2], [1, 3, 2], [0, 2, 3], [0, 3, 1]])
+        array([[0, 1, 2],
+               [1, 3, 2],
+               [0, 2, 3],
+               [0, 3, 1]])
         """
         return self.GetPolys().regular_cells
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -864,8 +864,8 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         """Set the face cells from an (n_faces, face_size) array."""
         self.faces = CellArray.from_regular_cells(faces, deep=True)
 
-    @staticmethod
-    def from_regular_faces(points, faces: Union[np.ndarray, Sequence[Sequence[int]]], deep=True) -> 'PolyData':
+    @classmethod
+    def from_regular_faces(cls, points, faces: Union[np.ndarray, Sequence[Sequence[int]]], deep=True):
         """Alternate `pyvista.PolyData` convenience constructor from point and regular face arrays.
         
         Parameters
@@ -892,7 +892,7 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         >>> faces = [[0, 1, 2], [1, 3, 2], [0, 2, 3], [0, 3, 1]]
         >>> tetra = pv.PolyData.from_regular_faces(points, faces)
         """
-        p = PolyData()
+        p = cls()
         p.points = points
         p.faces = CellArray.from_regular_cells(faces, deep=deep)
         return p

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -13,7 +13,7 @@ import pyvista
 
 from . import _vtk_core as _vtk
 from ._typing_core import BoundsLike
-from .cell import CellArray
+from .cell import CellArray, _get_offset_array, _get_regular_cells, _get_connectivity_array
 from .celltype import CellType
 from .dataset import DataSet
 from .errors import (
@@ -857,7 +857,7 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
                [0, 2, 3],
                [0, 3, 1]])
         """
-        return self.GetPolys().regular_cells
+        return _get_regular_cells(self.GetPolys())
 
     @regular_faces.setter
     def regular_faces(self, faces: Union[List[List[int]], np.ndarray]):
@@ -968,19 +968,14 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         return self.boolean_difference(cutting_mesh)
 
     @property
-    def _polys(self) -> CellArray:
-        # Because CellArray overrides vtkCellArray, this returns the former, not the latter
-        return self.GetPolys()
-
-    @property
     def _offset_array(self):
         """Return the array used to store cell offsets."""
-        return self._polys.offset_array
+        return _get_offset_array(self.GetPolys())
 
     @property
     def _connectivity_array(self):
         """Return the array with the point ids that define the cells' connectivity."""
-        return self._polys.connectivity_array
+        return _get_connectivity_array(self.GetPolys())
 
     @property
     def n_lines(self) -> int:

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -5,7 +5,7 @@ import numbers
 import os
 import pathlib
 from textwrap import dedent
-from typing import Sequence, Tuple, Union, List
+from typing import List, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -13,7 +13,7 @@ import pyvista
 
 from . import _vtk_core as _vtk
 from ._typing_core import BoundsLike
-from .cell import CellArray, _get_offset_array, _get_regular_cells, _get_connectivity_array
+from .cell import CellArray, _get_connectivity_array, _get_offset_array, _get_regular_cells
 from .celltype import CellType
 from .dataset import DataSet
 from .errors import (
@@ -867,14 +867,16 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         self.faces = CellArray.from_regular_cells(faces, deep=True)
 
     @classmethod
-    def from_regular_faces(cls, points, faces: Union[np.ndarray, Sequence[Sequence[int]]], deep=True):
+    def from_regular_faces(
+        cls, points, faces: Union[np.ndarray, Sequence[Sequence[int]]], deep=True
+    ):
         """Alternate `pyvista.PolyData` convenience constructor from point and regular face arrays.
-        
+
         Parameters
         ----------
         points : numpy.ndarray, sequence[sequence[float]]
             A (n_points, 3) array of points.
-            
+
         faces : numpy.ndarray or sequence[sequence[int]]
             A (n_faces, face_size) array of face indices. For a triangle mesh, face_size = 3.
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -849,6 +849,7 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         Examples
         --------
         Get the face array of a tetrahedron as a 4x3 array
+
         >>> import pyvista as pv
         >>> tetra = pv.Tetrahedron()
         >>> tetra.regular_faces

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -5,7 +5,7 @@ import numbers
 import os
 import pathlib
 from textwrap import dedent
-from typing import List, Sequence, Tuple, Union
+from typing import Sequence, Tuple, Union
 
 import numpy as np
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -776,16 +776,16 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         numpy.ndarray
             Array of face connectivity.
 
+        See Also
+        --------
+        pyvista.PolyData.regular_faces
+
         Notes
         -----
         The array returned cannot be modified in place and will raise a
         ``ValueError`` if attempted.
 
         You can, however, set the faces directly. See the example.
-
-        See Also
-        --------
-        pyvista.PolyData.regular_faces
 
         Examples
         --------
@@ -829,10 +829,10 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
 
     @property
     def regular_faces(self) -> np.ndarray:
-        """Return a face array of point indices when all faces have the same size
+        """Return a face array of point indices when all faces have the same size.
 
         Returns
-        -------
+        --------
         numpy.ndarray
             (n_faces, face_size) Array of face indices
 
@@ -858,27 +858,28 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
 
     @regular_faces.setter
     def regular_faces(self, faces: Union[List[List[int]], np.ndarray]):
-        """Set the face cells from an (n_faces, face_size) array"""
+        """Set the face cells from an (n_faces, face_size) array."""
         self.faces = CellArray.from_regular_cells(faces, deep=True)
 
     @staticmethod
-    def from_regular_faces(points, faces: Union[np.ndarray, List[List[int]]], deep=True) -> 'PolyData':
-        """Alternate `pyvista.PolyData` convenience constructor from point and regular face arrays
+    def from_regular_faces(points, faces: Union[np.ndarray, Sequence[Sequence[int]]], deep=True) -> 'PolyData':
+        """Alternate `pyvista.PolyData` convenience constructor from point and regular face arrays.
         
         Parameters
         ----------
-        points: numpy.ndarray or list[list[float]]
-            A (n_points, 3) array of points
+        points : numpy.ndarray, sequence[sequence[float]]
+            A (n_points, 3) array of points.
             
-        faces : numpy.ndarray or list[list[int]]
-            A (n_faces, face_size) array of face indices. For a triangle mesh, face_size = 3
+        faces : numpy.ndarray or sequence[sequence[int]]
+            A (n_faces, face_size) array of face indices. For a triangle mesh, face_size = 3.
 
-        deep : bool
-            Whether to deep copy the faces array into vtkCellArray connectivity data. Default `True`
+        deep : bool, optional
+            Whether to deep copy the faces array into vtkCellArray connectivity data. Default `True`.
 
         Returns
         -------
         pyvista.PolyData
+            The newly constructed mesh.
 
         Examples
         --------

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -864,11 +864,11 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
     @regular_faces.setter
     def regular_faces(self, faces: Union[List[List[int]], np.ndarray]):
         """Set the face cells from an (n_faces, face_size) array."""
-        self.faces = CellArray.from_regular_cells(faces, deep=True)
+        self.faces = CellArray.from_regular_cells(faces)
 
     @classmethod
     def from_regular_faces(
-        cls, points, faces: Union[np.ndarray, Sequence[Sequence[int]]], deep=True
+        cls, points, faces: Union[np.ndarray, Sequence[Sequence[int]]], deep=False
     ):
         """Alternate `pyvista.PolyData` convenience constructor from point and regular face arrays.
 
@@ -880,8 +880,8 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         faces : numpy.ndarray or sequence[sequence[int]]
             A (n_faces, face_size) array of face indices. For a triangle mesh, face_size = 3.
 
-        deep : bool, optional
-            Whether to deep copy the faces array into vtkCellArray connectivity data. Default `True`.
+        deep : bool, optional, default: False
+            Whether to deep copy the faces array into vtkCellArray connectivity data.
 
         Returns
         -------

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -856,6 +856,7 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
                [1, 3, 2],
                [0, 2, 3],
                [0, 3, 1]])
+
         """
         return _get_regular_cells(self.GetPolys())
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -888,6 +888,7 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         Examples
         --------
         Construct a tetrahedron from four triangles
+
         >>> import pyvista as pv
         >>> points = [[1.0, 1, 1], [-1, 1, -1], [1, -1, -1], [-1, -1, 1]]
         >>> faces = [[0, 1, 2], [1, 3, 2], [0, 2, 3], [0, 3, 1]]

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -834,7 +834,7 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         Returns
         -------
         numpy.ndarray
-            (n_faces, face_size) Array of face indices
+            Array of face indices with shape (n_faces, face_size).
 
         See Also
         --------

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -889,17 +889,19 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         return self.boolean_difference(cutting_mesh)
 
     @property
+    def _polys(self) -> CellArray:
+        # Because CellArray overrides vtkCellArray, this returns the former, not the latter
+        return self.GetPolys()
+
+    @property
     def _offset_array(self):
         """Return the array used to store cell offsets."""
-        return _vtk.vtk_to_numpy(self.GetPolys().GetOffsetsArray())
+        return self._polys.offset_array
 
     @property
     def _connectivity_array(self):
-        """Return the array with the point ids that define the cells connectivity."""
-        try:
-            return _vtk.vtk_to_numpy(self.GetPolys().GetConnectivityArray())
-        except AttributeError:  # pragma: no cover
-            raise VTKVersionError('Connectivity array implemented in VTK 9 or newer.')
+        """Return the array with the point ids that define the cells' connectivity."""
+        return self._polys.connectivity_array
 
     @property
     def n_lines(self) -> int:

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -832,7 +832,7 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         """Return a face array of point indices when all faces have the same size.
 
         Returns
-        --------
+        -------
         numpy.ndarray
             (n_faces, face_size) Array of face indices
 
@@ -841,7 +841,7 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         pyvista.PolyData.faces
 
         Notes
-        --------
+        -----
         This property does not validate that the mesh's faces are all
         actually the same size. If they're not, this property may either
         raise a `ValueError` or silently return an incorrect array.

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -862,7 +862,7 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         return _get_regular_cells(self.GetPolys())
 
     @regular_faces.setter
-    def regular_faces(self, faces: Union[List[List[int]], np.ndarray]):
+    def regular_faces(self, faces: Union[np.ndarray, Sequence[Sequence[int]]]):
         """Set the face cells from an (n_faces, face_size) array."""
         self.faces = CellArray.from_regular_cells(faces)
 

--- a/tests/core/test_cells.py
+++ b/tests/core/test_cells.py
@@ -296,18 +296,17 @@ def test_init_cell_array_from_arrays(offsets, connectivity, deep):
 REGULAR_CELL_LIST = [[0, 1, 2], [3, 4, 5]]
 
 
-@pytest.mark.parametrize(
-    'cells',
-    [
-        REGULAR_CELL_LIST,
-        np.array(REGULAR_CELL_LIST, np.int16),
-        np.array(REGULAR_CELL_LIST, np.int32),
-        np.array(REGULAR_CELL_LIST, np.int64),
-        np.array(np.vstack(REGULAR_CELL_LIST), order='F')
-    ],
-)
-@pytest.mark.parametrize('deep', [False, True])
-def test_init_cell_array_from_regular_cells(cells, deep):
+@pytest.mark.parametrize(('deep', 'cells'), [
+    (True, REGULAR_CELL_LIST),
+    (True, np.array(np.vstack(REGULAR_CELL_LIST), order='F')),
+    (False, np.array(REGULAR_CELL_LIST, np.int16)),
+    (True, np.array(REGULAR_CELL_LIST, np.int16)),
+    (False, np.array(REGULAR_CELL_LIST, np.int32)),
+    (True, np.array(REGULAR_CELL_LIST, np.int32)),
+    (False, np.array(REGULAR_CELL_LIST, np.int64)),
+    (True, np.array(REGULAR_CELL_LIST, np.int64)),
+])
+def test_init_cell_array_from_regular_cells(deep, cells):
     cell_array = pyvista.core.cell.CellArray.from_regular_cells(cells, deep=deep)
     assert np.array_equal(np.array(cells), cell_array.regular_cells)
     assert cell_array.n_cells == cell_array.GetNumberOfCells() == len(cells)

--- a/tests/core/test_cells.py
+++ b/tests/core/test_cells.py
@@ -297,19 +297,17 @@ REGULAR_CELL_LIST = [[0, 1, 2], [3, 4, 5]]
 
 
 @pytest.mark.parametrize(
-    ('deep', 'cells'),
+    'cells',
     [
-        (True, REGULAR_CELL_LIST),
-        (True, np.array(np.vstack(REGULAR_CELL_LIST), order='F')),
-        (False, np.array(REGULAR_CELL_LIST, np.int16)),
-        (True, np.array(REGULAR_CELL_LIST, np.int16)),
-        (False, np.array(REGULAR_CELL_LIST, np.int32)),
-        (True, np.array(REGULAR_CELL_LIST, np.int32)),
-        (False, np.array(REGULAR_CELL_LIST, np.int64)),
-        (True, np.array(REGULAR_CELL_LIST, np.int64)),
+        REGULAR_CELL_LIST,
+        np.array(REGULAR_CELL_LIST, np.int16),
+        np.array(REGULAR_CELL_LIST, np.int32),
+        np.array(REGULAR_CELL_LIST, np.int64),
+        np.array(np.vstack(REGULAR_CELL_LIST), order='F'),
     ],
 )
-def test_init_cell_array_from_regular_cells(deep, cells):
+@pytest.mark.parametrize('deep', [False, True])
+def test_init_cell_array_from_regular_cells(cells, deep):
     cell_array = pyvista.core.cell.CellArray.from_regular_cells(cells, deep=deep)
     assert np.array_equal(np.array(cells), cell_array.regular_cells)
     assert cell_array.n_cells == cell_array.GetNumberOfCells() == len(cells)

--- a/tests/core/test_cells.py
+++ b/tests/core/test_cells.py
@@ -315,6 +315,15 @@ def test_init_cell_array_from_regular_cells(deep, cells):
     assert cell_array.n_cells == cell_array.GetNumberOfCells() == len(cells)
 
 
+def test_set_shallow_regular_cells():
+    points = [[1.0, 1, 1], [-1, 1, -1], [1, -1, -1], [-1, -1, 1]]
+    faces = [[0, 1, 2], [1, 3, 2], [0, 2, 3], [0, 3, 1]]
+    meshes = [pyvista.PolyData.from_regular_faces(points, faces, deep=False) for _ in range(2)]
+
+    for m in meshes:
+        assert np.array_equal(m.regular_faces, faces)
+
+
 def test_numpy_to_idarr_bool():
     mask = np.ones(10, np.bool_)
     idarr = numpy_to_idarr(mask)

--- a/tests/core/test_cells.py
+++ b/tests/core/test_cells.py
@@ -263,6 +263,56 @@ def test_init_cell_array(cells, n_cells, deep):
     assert cell_array.n_cells == cell_array.GetNumberOfCells() == NCELLS
 
 
+CONNECTIVITY_LIST = [0, 1, 2, 3, 4, 5]
+OFFSETS_LIST = [0, 3, 6]
+
+
+@pytest.mark.parametrize(
+    'offsets',
+    [
+        OFFSETS_LIST,
+        np.array(OFFSETS_LIST, np.int16),
+        np.array(OFFSETS_LIST, np.int32),
+        np.array(OFFSETS_LIST, np.int64),
+    ],
+)
+@pytest.mark.parametrize(
+    'connectivity',
+    [
+        CONNECTIVITY_LIST,
+        np.array(CONNECTIVITY_LIST, np.int16),
+        np.array(CONNECTIVITY_LIST, np.int32),
+        np.array(CONNECTIVITY_LIST, np.int64),
+    ],
+)
+@pytest.mark.parametrize('deep', [False, True])
+def test_init_cell_array_from_arrays(offsets, connectivity, deep):
+    cell_array = pyvista.core.cell.CellArray.from_arrays(offsets, connectivity, deep=deep)
+    assert np.array_equal(np.array(connectivity), cell_array.connectivity_array)
+    assert np.array_equal(np.array(offsets), cell_array.offset_array)
+    assert cell_array.n_cells == cell_array.GetNumberOfCells() == len(offsets) - 1
+
+
+REGULAR_CELL_LIST = [[0, 1, 2], [3, 4, 5]]
+
+
+@pytest.mark.parametrize(
+    'cells',
+    [
+        REGULAR_CELL_LIST,
+        np.array(REGULAR_CELL_LIST, np.int16),
+        np.array(REGULAR_CELL_LIST, np.int32),
+        np.array(REGULAR_CELL_LIST, np.int64),
+        np.array(np.vstack(REGULAR_CELL_LIST), order='F')
+    ],
+)
+@pytest.mark.parametrize('deep', [False, True])
+def test_init_cell_array_from_regular_cells(cells, deep):
+    cell_array = pyvista.core.cell.CellArray.from_regular_cells(cells, deep=deep)
+    assert np.array_equal(np.array(cells), cell_array.regular_cells)
+    assert cell_array.n_cells == cell_array.GetNumberOfCells() == len(cells)
+
+
 def test_numpy_to_idarr_bool():
     mask = np.ones(10, np.bool_)
     idarr = numpy_to_idarr(mask)

--- a/tests/core/test_cells.py
+++ b/tests/core/test_cells.py
@@ -296,16 +296,19 @@ def test_init_cell_array_from_arrays(offsets, connectivity, deep):
 REGULAR_CELL_LIST = [[0, 1, 2], [3, 4, 5]]
 
 
-@pytest.mark.parametrize(('deep', 'cells'), [
-    (True, REGULAR_CELL_LIST),
-    (True, np.array(np.vstack(REGULAR_CELL_LIST), order='F')),
-    (False, np.array(REGULAR_CELL_LIST, np.int16)),
-    (True, np.array(REGULAR_CELL_LIST, np.int16)),
-    (False, np.array(REGULAR_CELL_LIST, np.int32)),
-    (True, np.array(REGULAR_CELL_LIST, np.int32)),
-    (False, np.array(REGULAR_CELL_LIST, np.int64)),
-    (True, np.array(REGULAR_CELL_LIST, np.int64)),
-])
+@pytest.mark.parametrize(
+    ('deep', 'cells'),
+    [
+        (True, REGULAR_CELL_LIST),
+        (True, np.array(np.vstack(REGULAR_CELL_LIST), order='F')),
+        (False, np.array(REGULAR_CELL_LIST, np.int16)),
+        (True, np.array(REGULAR_CELL_LIST, np.int16)),
+        (False, np.array(REGULAR_CELL_LIST, np.int32)),
+        (True, np.array(REGULAR_CELL_LIST, np.int32)),
+        (False, np.array(REGULAR_CELL_LIST, np.int64)),
+        (True, np.array(REGULAR_CELL_LIST, np.int64)),
+    ],
+)
 def test_init_cell_array_from_regular_cells(deep, cells):
     cell_array = pyvista.core.cell.CellArray.from_regular_cells(cells, deep=deep)
     assert np.array_equal(np.array(cells), cell_array.regular_cells)

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -930,6 +930,13 @@ def test_regular_faces(deep):
     assert np.array_equal(mesh.regular_faces, faces)
 
 
+def test_set_regular_faces():
+    mesh = pyvista.Tetrahedron()
+    flipped_faces = mesh.regular_faces[:, ::-1]
+    mesh.regular_faces = flipped_faces
+    assert np.array_equal(mesh.regular_faces, flipped_faces)
+
+
 def test_empty_regular_faces():
     mesh = pyvista.PolyData()
     assert np.array_equal(mesh.regular_faces, np.array([], dtype=pyvista.ID_TYPE))

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -925,7 +925,9 @@ def test_regular_faces(deep):
     points = np.array([[1.0, 1, 1], [-1, 1, -1], [1, -1, -1], [-1, -1, 1]])
     faces = np.array([[0, 1, 2], [1, 3, 2], [0, 2, 3], [0, 3, 1]])
     mesh = pyvista.PolyData.from_regular_faces(points, faces, deep=deep)
-    expected_faces = np.hstack([np.full((len(faces), 1), 3), faces]).astype(pyvista.ID_TYPE).flatten()
+    expected_faces = (
+        np.hstack([np.full((len(faces), 1), 3), faces]).astype(pyvista.ID_TYPE).flatten()
+    )
     assert np.array_equal(mesh.faces, expected_faces)
     assert np.array_equal(mesh.regular_faces, faces)
 

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -925,7 +925,7 @@ def test_regular_faces(deep):
     points = np.array([[1.0, 1, 1], [-1, 1, -1], [1, -1, -1], [-1, -1, 1]])
     faces = np.array([[0, 1, 2], [1, 3, 2], [0, 2, 3], [0, 3, 1]])
     mesh = pyvista.PolyData.from_regular_faces(points, faces, deep=deep)
-    expected_faces = np.hstack([np.full((len(faces), 1), 3), faces], dtype=pyvista.ID_TYPE).flatten()
+    expected_faces = np.hstack([np.full((len(faces), 1), 3), faces]).astype(pyvista.ID_TYPE).flatten()
     assert np.array_equal(mesh.faces, expected_faces)
     assert np.array_equal(mesh.regular_faces, faces)
 

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 import pyvista
-from pyvista import examples, CellArray
+from pyvista import examples
 from pyvista.core.errors import NotAllTrianglesError
 from pyvista.errors import PyVistaFutureWarning
 

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -915,9 +915,9 @@ def test_geodesic_disconnected(sphere, sphere_shifted):
         combined.geodesic_distance(start_vertex, end_vertex)
 
 
-def test_polydata_polys_is_cell_array():
-    p = pyvista.PolyData()
-    assert isinstance(p.GetPolys(), CellArray)
+def test_tetrahedron_regular_faces():
+    tetra = pyvista.Tetrahedron()
+    assert np.array_equal(tetra.faces.reshape(-1, 4)[:, 1:], tetra.regular_faces)
 
 
 @pytest.mark.parametrize('deep', [False, True])

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -913,3 +913,10 @@ def test_geodesic_disconnected(sphere, sphere_shifted):
 
     with pytest.raises(ValueError, match=match):
         combined.geodesic_distance(start_vertex, end_vertex)
+
+
+def test_polydata_polys_is_cell_array():
+    p = pyvista.PolyData()
+    assert isinstance(p.GetPolys(), CellArray)
+
+


### PR DESCRIPTION
# Introduction
Currently, the structure of `PolyData.faces` parallels the original representation of vtkCellArray, where offsets and connectivity were stored in an interleaved fashion. In [November 2019](https://discourse.vtk.org/t/upcoming-changes-to-vtkcellarray/2066) `vtkCellArray` was changed to store offsets and connectivity seperately. These separate arrays are currently exposed only privately via the PolyData properties `_connectivity_array` and `_offset_array`. 

This PR adds a new settable and mutatable property `PolyData.regular_faces`, which, for meshes where all faces are the same size, returns a `n_faces` x `face_size` array. It also adds an alternate `PolyData` constructor in the form of the static method `PolyData.from_regular_faces(points, faces, deep)`. IME, constructing a mesh from a set of points and triangles is by far the most common `PolyData` construction, and using a separate method is cleaner than extending the already heavily-overloaded default constructor. 

# Justification
## Intuition and ease of use
The interleaved format is (IMHO) non-intuitive, leading to a number of beginner issues (e.g. #1097, #966), as well as line noise where either the faces array is written out explicitly with cell sizes, or a column of cell sizes is prepended to the face array.

E.g. IMO `faces = [[0, 1, 2], [1, 3, 2], [0, 2, 3], [0, 3, 1]]` is much easier to read than either `faces = [3, 0, 1, 2, 3, 1, 3, 2, 3, 0, 2, 3, 3, 0, 3, 1]` or

```python
faces = [[0, 1, 2], [1, 3, 2], [0, 2, 3], [0, 3, 1]]
faces = np.stack([np.full(3, (len(faces), 1)), faces], axis=1)
```
  
## Performance

![perf](https://github.com/pyvista/pyvista/assets/6875882/328c8711-a729-478d-97ae-1e84572391a0)

<details>
  <summary>Code for performance profiling</summary>
  
  ```python
    import timeit
    from collections import defaultdict
    from pyvista import PolyData, Sphere
    from matplotlib import pyplot as plt

    def time_stuff(mesh, fn_factories, n_sub, n_times, n_repeat):
        times = defaultdict(list)
        n_faces = []
        for i in range(n_sub):
            n_faces.append(mesh.n_faces)
            for j, (name, fn_factory) in enumerate(fn_factories.items()):
                fn = fn_factory(mesh)
                t = timeit.Timer(fn).repeat(repeat=n_repeat, number=n_times)
                times[name].append(min(t) / n_times * 1000)
            mesh = mesh.subdivide(1)
        return n_faces, times

    def plot_times(title, mesh, fn_factories, n_sub, n_times, n_repeat):
        n_faces, times = time_stuff(Sphere().triangulate(), fn_factories, n_sub=n_sub, n_repeat=n_repeat, n_times=n_times)
        for name, fn_times in times.items():
            plt.plot(n_faces, fn_times, marker='x', label=name)
            plt.title(title)
            plt.xscale('log')
            plt.yscale('log')
            plt.xlabel('# faces')
            plt.legend()
        return times

    mesh = Sphere().triangulate()

    def write_default_faces(mesh):
        points, faces = mesh.points, mesh.faces.reshape(-1, 4)
        return lambda: PolyData(points, faces=faces)

    def write_regular_faces(mesh):
        points, faces = mesh.points, mesh.regular_faces
        return lambda: PolyData.from_regular_faces(points, faces)

    def read_default_faces(mesh):
        return lambda: mesh.faces

    def read_regular_faces(mesh):
        return lambda: mesh.regular_faces

    n_sub = 5
    n_repeat = 7
    n_times = 1000

    plt.figure(figsize=(10, 5))
    fn_factories=dict(faces=write_default_faces, regular_faces=write_regular_faces)
    ax_read = plt.subplot(1, 2, 1)
    read_times = plot_times("Write", mesh, fn_factories, n_sub, n_times, n_repeat)
    plt.ylabel('Time (ms)')

    plt.subplot(1, 2, 2, sharey=ax_read)
    fn_factories=dict(faces=read_default_faces, regular_faces=read_regular_faces)
    write_times = plot_times("Read", mesh, fn_factories, n_sub, n_times, n_repeat)
  ```
</details>

When setting faces from a regular array there is a mild (at best) performance benefit to constructing the underlying CellArray from the two arrays. Note that I'm comparing here against the condition of setting the original faces as a `n_faces` x `face_size + 1` array. Setting faces as a 1-dimensional array instead is exceptionally slow, as already noted in the [comments](https://github.com/pyvista/pyvista/blob/447a0905217dd53aff2ba38bd9a2624d3aa15ce6/pyvista/core/cell.py#L493), which requires scanning the entire array to determine the number of faces. 

The read time when the face size is known is O(1) since it's just a view into the connectivity array. When the face size is unknown, there are two options: 1) greedily check only the size of the first face, and assume the rest are the same size (also O(1)) or 2) scan the the entire offsets array and validate that the faces are all the same size, which gives approximately no benefit over the status quo. I've gone with option 1 here.

## Mutation
I don't think I've ever felt the need for this, but the new face array can be mutated in place, e.g. `mesh.regular_faces[0, 0] = 9`, whereas `PolyData.faces` is set read-only because this isn't possible.

# Implementation details
Most of the actual work was done on `CellArray`, exposing public properties `connectivity_array` and `offset_array`, as well as new alternate constructors `CellArray.from_arrays(offsets, connectivity, deep)` and `CellArray.from_regular_cells(cells, deep)`, in the hopes this will be useful beyond just PolyData faces. I added the `@tkCellArray.override` decorator to `CellArray` so e.g. `PolyData.GetPolys()` returns a `CellArray` instead of a `vtkCellArray`. This greatly simplified the glue code in `PolyData`, but perhaps the override decorator is too new/experimental to rely on.

# Relevant issues
Closes #2330

# Open questions

## Spelling
`regular_faces` vs `face_array`, etc.

## Extensions 
A similar interface could be added to other cases of equisized cells, particularly `UnstructuredGrid.regular_cells` and `PolyData.regular_lines`, as well as `PolyData.regular_strips`.

If my argument for the intuitiveness holds water, it might also be worth generalizing to the more general case where faces aren't equisized, adding a `PolyData.irregular_faces` property returning `list[list[int]]`.
 
# Potential downsides
While I think this is more intuitive for the majority case of triangle faces, this does introduce some potentional for confusion if users think `faces` and `regular_faces` are disjoint properties, whereas they actually modify/replace the same underlying vtkCellArray. In addition this also introduces the question of which interface the examples should use where both are applicable.