### PR TITLE
Fix MultipleLines example

### DIFF
--- a/pyvista/core/utilities/geometric_objects.py
+++ b/pyvista/core/utilities/geometric_objects.py
@@ -504,7 +504,9 @@ def MultipleLines(points=[[-0.5, 0.0, 0.0], [0.5, 0.0, 0.0]]):
     Create a multiple lines between ``(0, 0, 0)``, ``(1, 1, 1)`` and ``(0, 0, 1)``.
 
     >>> import pyvista
-    >>> mesh = pyvista.MultipleLines(points=[[0, 0, 0], [1, 1, 1], [0, 0, 1]])
+    >>> mesh = pyvista.MultipleLines(
+    ...     points=[[0, 0, 0], [1, 1, 1], [0, 0, 1]]
+    ... )
     >>> plotter = pyvista.Plotter()
     >>> actor = plotter.add_mesh(mesh)
     >>> plotter.camera.azimuth = 45

--- a/pyvista/core/utilities/geometric_objects.py
+++ b/pyvista/core/utilities/geometric_objects.py
@@ -508,7 +508,7 @@ def MultipleLines(points=[[-0.5, 0.0, 0.0], [0.5, 0.0, 0.0]]):
     ...     points=[[0, 0, 0], [1, 1, 1], [0, 0, 1]]
     ... )
     >>> plotter = pyvista.Plotter()
-    >>> actor = plotter.add_mesh(mesh)
+    >>> actor = plotter.add_mesh(mesh, color='k', line_width=10)
     >>> plotter.camera.azimuth = 45
     >>> plotter.camera.zoom(0.8)
     >>> plotter.show()

--- a/pyvista/core/utilities/geometric_objects.py
+++ b/pyvista/core/utilities/geometric_objects.py
@@ -504,10 +504,12 @@ def MultipleLines(points=[[-0.5, 0.0, 0.0], [0.5, 0.0, 0.0]]):
     Create a multiple lines between ``(0, 0, 0)``, ``(1, 1, 1)`` and ``(0, 0, 1)``.
 
     >>> import pyvista
-    >>> mesh = pyvista.MultipleLines(
-    ...     points=[[0, 0, 0], [1, 1, 1], [0, 0, 1]]
-    ... )
-    >>> mesh.plot(color='k', line_width=10)
+    >>> mesh = pyvista.MultipleLines(points=[[0, 0, 0], [1, 1, 1], [0, 0, 1]])
+    >>> plotter = pyvista.Plotter()
+    >>> actor = plotter.add_mesh(mesh)
+    >>> plotter.camera.azimuth = 45
+    >>> plotter.camera.zoom(0.8)
+    >>> plotter.show()
     """
     points, _ = _coerce_pointslike_arg(points)
     src = _vtk.vtkLineSource()


### PR DESCRIPTION
### Overview

Fixes  #4388 by using the plotter to rotate the camera.

### Details
Rotates the camera by 45 degrees and zooms out to see both lines.
