### PR TITLE
Update contact/support information

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -40,16 +40,20 @@ For general questions about the project, its applications, or about
 software usage, please create a discussion in the
 `Discussions <https://github.com/pyvista/pyvista/discussions>`_
 repository where the community can collectively address your questions.
-You are also welcome to join us on `Slack <http://slack.pyvista.org>`_
-or send one of the developers an email. The project support team can be
-reached at info@pyvista.org
 
-For more technical questions, you are welcome to create an issue on the
-`issues page <https://github.com/pyvista/pyvista/issues>`_ which we
-will address promptly. Through posting on the issues page, your question
-can be addressed by community members with the needed expertise and the
-information gained will remain available on the issues page for other
-users.
+You are also welcome to join us on `Slack <http://slack.pyvista.org>`_,
+but Slack should be reserverd for ad hoc conversations and community engagement
+rather than technical discussions.
+
+For critical, high-level project support and engagement, please email
+info@pyvista.org - but please do not use this email for technical support.
+
+For all technical conversations, you are welcome to create an issue on the
+`Discussions page <https://github.com/pyvista/pyvista/discussions>`_
+which we will address promptly. Through posting on the Discussions page,
+your question can be addressed by community members with the needed
+expertise and the information gained will remain available for other
+users to find.
 
 Reporting Bugs
 --------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -42,7 +42,7 @@ software usage, please create a discussion in the
 repository where the community can collectively address your questions.
 
 You are also welcome to join us on `Slack <http://slack.pyvista.org>`_,
-but Slack should be reserverd for ad hoc conversations and community engagement
+but Slack should be reserved for ad hoc conversations and community engagement
 rather than technical discussions.
 
 For critical, high-level project support and engagement, please email

--- a/README.rst
+++ b/README.rst
@@ -163,12 +163,10 @@ installation and usage details.
 For general questions about the project, its applications, or about software
 usage, please create a discussion in `pyvista/discussions`_
 where the community can collectively address your questions. You are also
-welcome to join us on Slack_ or send one of the developers an email.
-The project support team can be reached at `info@pyvista.org`_.
+welcome to join us on Slack_.
 
 .. _pyvista/discussions: https://github.com/pyvista/pyvista/discussions
 .. _Slack: http://slack.pyvista.org
-.. _info@pyvista.org: mailto:info@pyvista.org
 
 
 Installation

--- a/doc/source/getting-started/index.rst
+++ b/doc/source/getting-started/index.rst
@@ -163,8 +163,7 @@ Support
 For general questions about the project, its applications, or about software
 usage, please create a discussion in `pyvista/discussions`_
 where the community can collectively address your questions. You are also
-welcome to join us on Slack_ or send one of the developers an email.
-The project support team can be reached at `info@pyvista.org`_.
+welcome to join us on Slack_.
 
 .. _pyvista/discussions: https://github.com/pyvista/pyvista/discussions
 .. _Slack: http://slack.pyvista.org


### PR DESCRIPTION
Update the project contact/support info to have everyone engage on GitHub Discussions/Issues. The `info@pyvista.org` email address is not for technical support and only for mission-critical project maintenance and governance issues.