### PR TITLE
🚀 Release 0.41

### DIFF
--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -13,7 +13,7 @@ Denotes the first release candidate.
 
 """
 # major, minor, patch
-version_info = 0, 41, 'dev0'
+version_info = 0, 42, 'dev0'
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1032,7 +1032,7 @@ def test_copy_attributes(grid):
 def test_cell_n_points(grid):
     with pytest.warns(PyVistaDeprecationWarning):
         npoints = grid.cell_n_points(0)
-    if pyvista._version.version_info >= (0, 42, 0):
+    if pyvista._version.version_info >= (0, 43):
         raise RuntimeError('Remove this deprecated method')
     assert isinstance(npoints, int)
     assert npoints >= 0
@@ -1041,7 +1041,7 @@ def test_cell_n_points(grid):
 def test_cell_points(grid):
     with pytest.warns(PyVistaDeprecationWarning):
         points = grid.cell_points(0)
-    if pyvista._version.version_info >= (0, 42, 0):
+    if pyvista._version.version_info >= (0, 43):
         raise RuntimeError('Remove this deprecated method')
     assert isinstance(points, np.ndarray)
     assert points.ndim == 2
@@ -1052,7 +1052,7 @@ def test_cell_points(grid):
 def test_cell_point_ids(grid):
     with pytest.warns(PyVistaDeprecationWarning):
         point_ids = grid.cell_point_ids(0)
-    if pyvista._version.version_info >= (0, 42, 0):
+    if pyvista._version.version_info >= (0, 43):
         raise RuntimeError('Remove this deprecated method')
     assert isinstance(point_ids, list)
     with pytest.warns(PyVistaDeprecationWarning):
@@ -1064,7 +1064,7 @@ def test_cell_point_ids(grid):
 def test_cell_bounds(grid):
     with pytest.warns(PyVistaDeprecationWarning):
         bounds = grid.cell_bounds(0)
-    if pyvista._version.version_info >= (0, 42, 0):
+    if pyvista._version.version_info >= (0, 43):
         raise RuntimeError('Remove this deprecated method')
     assert isinstance(bounds, tuple)
     assert len(bounds) == 6
@@ -1073,7 +1073,7 @@ def test_cell_bounds(grid):
 def test_cell_type(grid):
     with pytest.warns(PyVistaDeprecationWarning):
         ctype = grid.cell_type(0)
-    if pyvista._version.version_info >= (0, 42, 0):
+    if pyvista._version.version_info >= (0, 43):
         raise RuntimeError('Remove this deprecated method')
     assert isinstance(ctype, int)
 


### PR DESCRIPTION
I'm issuing a patch release to 0.40.2 prior to this landing. This release is primarily to have a dedicated release for the changes in #4629

Release v0.41.0

- [x] Bump main to `0.42.dev0` (this PR)
- [ ] Keep this branch (`release/0.41`) and update the version to `0.41.0`. And commit the change to this branch.
- [ ] Tag `v0.41.0` and push the tag.
- [ ] Verify [docs](https://docs.pyvista.org/) and [PyPI](https://pypi.org/project/pyvista/) have updated.
- [ ] Update the [conda-forge feedstock](https://github.com/conda-forge/pyvista-feedstock).
- [ ] Generate [release documentation](https://github.com/pyvista/pyvista/releases/tag/v0.41.0)


------


<!-- Release notes generated using configuration in .github/release.yml at release/0.41 -->

## What's Changed
* Isolate plotting API by @banesullivan in https://github.com/pyvista/pyvista/pull/4629

### Breaking Changes
* Texture tracking previously deprecated in https://github.com/pyvista/pyvista/pull/4515 is now removed (fast turnaround)
* Deprecate probe; better explain sample/interpolate by @MatthewFlamm in https://github.com/pyvista/pyvista/pull/4648

### Bug fixes or behavior changes
* Fix issue with last_vtksz when building gallery by @banesullivan in https://github.com/pyvista/pyvista/pull/4621
* HOTFIX: set server_proxy_enabled True if detected in environment by @banesullivan in https://github.com/pyvista/pyvista/pull/4633
* Fix dynamic scraper paths by @banesullivan in https://github.com/pyvista/pyvista/pull/4636

## New Contributors
* @AndCotOli made their first contribution in https://github.com/pyvista/pyvista/pull/4651

**Full Changelog**: https://github.com/pyvista/pyvista/compare/v0.40.2...v0.41.0