### PR TITLE
Fix error when add_mesh receives ndarray as texture

### DIFF
--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -3441,7 +3441,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         actor = Actor(mapper=self.mapper)
 
-        if texture:
+        if texture is not None:
             if isinstance(texture, np.ndarray):
                 texture = numpy_to_texture(texture)
             if not isinstance(texture, (_vtk.vtkTexture, _vtk.vtkOpenGLTexture)):

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1239,6 +1239,7 @@ def test_plot_texture():
     plotter.show()
 
 
+@pytest.mark.skipif(not HAS_IMAGEIO, reason="Requires imageio")
 def test_plot_numpy_texture():
     """Text adding a np.ndarray texture to a plot"""
     globe = examples.load_globe()

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1239,6 +1239,14 @@ def test_plot_texture():
     plotter.show()
 
 
+def test_plot_numpy_texture():
+    """Text adding a np.ndarray texture to a plot"""
+    globe = examples.load_globe()
+    texture_np = np.asarray(imageio.imread(examples.mapfile))
+    plotter = pyvista.Plotter()
+    plotter.add_mesh(globe, texture=texture_np)
+
+
 @pytest.mark.skipif(not HAS_IMAGEIO, reason="Requires imageio")
 def test_read_texture_from_numpy():
     """Test adding a texture to a plot"""


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
When Plotter.add_mesh(texture=...,) receives a np.ndarray as texture, it throws errors.


### Details

```
  File "/home/yfl/anaconda3/envs/hdr/lib/python3.9/site-packages/pyvista/plotting/plotter.py", line 3444, in add_mesh
    if texture:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

np.ndarray cannot be directly placed in the if-statement.

**Solution:**

I modify the line 3444 in `plotting/plotter.py` from 
```
if texture:
    if isinstance(texture, np.ndarray):
        texture = numpy_to_texture(texture)
    if not isinstance(texture, (_vtk.vtkTexture, _vtk.vtkOpenGLTexture)):
        raise TypeError(f'Invalid texture type ({type(texture)})')
    ...
```
to 
```
if texture is not None:
    if isinstance(texture, np.ndarray):
        texture = numpy_to_texture(texture)
    if not isinstance(texture, (_vtk.vtkTexture, _vtk.vtkOpenGLTexture)):
        raise TypeError(f'Invalid texture type ({type(texture)})')
    ...
```

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->    