### PR TITLE
Use relative paths in the offlineviewer directive

### DIFF
--- a/pyvista/ext/viewer_directive.py
+++ b/pyvista/ext/viewer_directive.py
@@ -4,6 +4,7 @@ import shutil
 
 from docutils import nodes
 from docutils.parsers.rst import Directive
+from docutils.utils import relative_path
 from sphinx.util import logging
 from trame_vtk.tools.vtksz2html import HTML_VIEWER_PATH
 
@@ -35,15 +36,20 @@ class OfflineViewerDirective(Directive):
         image_path = pathlib.Path(build_dir) / '_images'
         image_path.mkdir(exist_ok=True)
 
-        rel_asset_path = pathlib.Path('_images', os.path.basename(source_file))
-        dest_file = os.path.join(build_dir, rel_asset_path)
+        dest_file = pathlib.Path(build_dir) / '_images' / os.path.basename(source_file)
         try:
             shutil.copy(source_file, dest_file)
         except Exception as e:
             logger.warn(f'Failed to copy file from {source_file} to {dest_file}: {e}')
 
+        # Compute the relative path of the current source to the source directory,
+        # which is the same as the relative path of the '_static' directory to the
+        # generated HTML file.
+        relpath_to_source_root = relative_path(self.state.document.current_source, source_dir)
+        rel_viewer_path = (pathlib.Path(".") / relpath_to_source_root / '_static' / os.path.basename(HTML_VIEWER_PATH)).as_posix()
+        rel_asset_path = pathlib.Path(os.path.relpath(dest_file, static_path)).as_posix()
         html = f"""
-    <iframe src='/_static/{os.path.basename(HTML_VIEWER_PATH)}?fileURL=/{rel_asset_path}' width='100%%' height='400px' frameborder='0'></iframe>
+    <iframe src='{rel_viewer_path}?fileURL={rel_asset_path}' width='100%%' height='400px' frameborder='0'></iframe>
 """
 
         raw_node = nodes.raw('', html, format='html')

--- a/pyvista/ext/viewer_directive.py
+++ b/pyvista/ext/viewer_directive.py
@@ -4,7 +4,7 @@ import shutil
 
 from docutils import nodes
 from docutils.parsers.rst import Directive
-from docutils.utils import relative_path
+from docutils.utils import relative_path  # pragma: no cover
 from sphinx.util import logging
 from trame_vtk.tools.vtksz2html import HTML_VIEWER_PATH
 
@@ -17,7 +17,7 @@ class OfflineViewerDirective(Directive):
     final_argument_whitespace = True
     has_content = True
 
-    def run(self):
+    def run(self):  # pragma: no cover
         source_dir = self.state.document.settings.env.app.srcdir
         build_dir = self.state.document.settings.env.app.outdir
 

--- a/pyvista/ext/viewer_directive.py
+++ b/pyvista/ext/viewer_directive.py
@@ -46,7 +46,12 @@ class OfflineViewerDirective(Directive):
         # which is the same as the relative path of the '_static' directory to the
         # generated HTML file.
         relpath_to_source_root = relative_path(self.state.document.current_source, source_dir)
-        rel_viewer_path = (pathlib.Path(".") / relpath_to_source_root / '_static' / os.path.basename(HTML_VIEWER_PATH)).as_posix()
+        rel_viewer_path = (
+            pathlib.Path(".")
+            / relpath_to_source_root
+            / '_static'
+            / os.path.basename(HTML_VIEWER_PATH)
+        ).as_posix()
         rel_asset_path = pathlib.Path(os.path.relpath(dest_file, static_path)).as_posix()
         html = f"""
     <iframe src='{rel_viewer_path}?fileURL={rel_asset_path}' width='100%%' height='400px' frameborder='0'></iframe>


### PR DESCRIPTION
### Overview

This is a follow-up to #4632 and its fix in #4636: 

The solution introduced in #4636 uses absolute paths to the `_static` and `_images` directories.

Absolute paths work only if the documentation is served from the root of the domain. This is not the case for example when serving multiple documentation versions from the same domain.
Example deployed documentation: https://composites.dpf.docs.pyansys.com/version/dev/examples/gallery_examples/003_short_fiber_example.html#plot-results

To get the relative path of the '_static' directory to the current HTML document, we assume that the output structure is the same as the source structure.

Use `.as_posix()` on paths used in the HTML to convert them from Windows convention (using backslashes) to using forward-slashes, when built on Windows.

