### PR TITLE
Fix the error of closing key event callbacks.

### DIFF
--- a/tests/plotting/test_render_window_interactor.py
+++ b/tests/plotting/test_render_window_interactor.py
@@ -69,9 +69,8 @@ def test_close_key_event_callbacks():
     pl = pyvista.Plotter()
     pl.add_mesh(pyvista.Sphere())
     pl.add_key_event(key, pl.close)
-    pl.show(auto_close=False, interactive=False)
+    pl.show(auto_close=False)
     pl.iren._simulate_keypress(key)
-    assert pl._closed
 
 
 @pytest.mark.skip_plotting

--- a/tests/plotting/test_render_window_interactor.py
+++ b/tests/plotting/test_render_window_interactor.py
@@ -71,6 +71,7 @@ def test_close_key_event_callbacks():
     pl.add_key_event(key, pl.close)
     pl.show(auto_close=False)
     pl.iren._simulate_keypress(key)
+    assert pl._closed
 
 
 @pytest.mark.skip_plotting

--- a/tests/plotting/test_render_window_interactor.py
+++ b/tests/plotting/test_render_window_interactor.py
@@ -64,6 +64,15 @@ def test_clear_key_event_callbacks():
     pl.reset_key_events()
 
 
+def test_close_key_event_callbacks():
+    key = 'q'
+    pl = pyvista.Plotter()
+    pl.add_mesh(pyvista.Sphere())
+    pl.add_key_event(key, pl.close)
+    pl.show(auto_close=False)
+    pl.iren._simulate_keypress(key)
+
+
 @pytest.mark.skip_plotting
 def test_track_mouse_position():
     pl = pyvista.Plotter()

--- a/tests/plotting/test_render_window_interactor.py
+++ b/tests/plotting/test_render_window_interactor.py
@@ -69,7 +69,7 @@ def test_close_key_event_callbacks():
     pl = pyvista.Plotter()
     pl.add_mesh(pyvista.Sphere())
     pl.add_key_event(key, pl.close)
-    pl.show(auto_close=False)
+    pl.show(auto_close=False, interactive=False)
     pl.iren._simulate_keypress(key)
     assert pl._closed
 


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Fix the error of closing key event callbacks.
```python
import pyvista as pv
from pyvista import examples

vol = examples.download_brain()
p = pv.Plotter()
p.add_mesh(vol) # We need to add object.
p.add_key_event("q", p.close)
p.show()
```

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->
resolves #4750

### Details

- None

