### PR TITLE
Add use `TextActor3D` warning when scaling

### DIFF
--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -2404,6 +2404,11 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         >>> pl.show()
 
         """
+        if self.cube_axes_actor is not None:
+            warnings.warn(
+                "Cube axes text uses TextActor3D because `set_scale` is called after `show_bounds`."
+                "If you are not intened to scale text, call `show_bounds` after `set_scale`.",
+            )
         if xscale is None:
             xscale = self.scale[0]
         if yscale is None:

--- a/tests/plotting/test_renderer.py
+++ b/tests/plotting/test_renderer.py
@@ -38,7 +38,7 @@ def test_show_bounds_with_scaling(sphere):
     with pytest.warns():
         actor0 = plotter.show_bounds()
         assert actor0.GetUseTextActor3D()
-    plotter.set_scale(0.5, 0.5, 2)
+        plotter.set_scale(0.5, 0.5, 2)
     actor1 = plotter.show_bounds()
     assert not actor1.GetUseTextActor3D()
 

--- a/tests/plotting/test_renderer.py
+++ b/tests/plotting/test_renderer.py
@@ -35,8 +35,9 @@ def test_show_bounds_axes_ranges():
 def test_show_bounds_with_scaling(sphere):
     plotter = pyvista.Plotter()
     plotter.add_mesh(sphere)
-    actor0 = plotter.show_bounds()
-    assert actor0.GetUseTextActor3D()
+    with pytest.warns():
+        actor0 = plotter.show_bounds()
+        assert actor0.GetUseTextActor3D()
     plotter.set_scale(0.5, 0.5, 2)
     actor1 = plotter.show_bounds()
     assert not actor1.GetUseTextActor3D()


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
resolves #4768 and https://github.com/pyvista/pyvista/discussions/4721

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None
