### PR TITLE
Add `Plotter.meshes`

### DIFF
--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -6885,6 +6885,23 @@ class Plotter(BasePlotter):
 
         return actor
 
+    @property
+    def meshes(self):
+        """Return plotter meshes.
+
+        _extended_summary_
+
+        Returns
+        -------
+        List[Union[pv.PolyData, pv.UnstructuredGrid, pv.UniformGrid]
+            List of mesh objects such as pv.PolyData, pv.UnstructuredGrid, etc.
+        """
+        meshes = []
+        for actor in self.actors.values():
+            if hasattr(actor, 'mapper'):
+                meshes.append(actor.mapper.dataset)
+
+        return meshes
 
 # Tracks created plotters.  This is the end of the module as we need to
 # define ``BasePlotter`` before including it in the type definition.

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -6889,11 +6889,9 @@ class Plotter(BasePlotter):
     def meshes(self):
         """Return plotter meshes.
 
-        _extended_summary_
-
         Returns
         -------
-        List[Union[pv.PolyData, pv.UnstructuredGrid, pv.UniformGrid]
+        List[Union[pyvista.DataSet, PyVista.MultiBlock]]
             List of mesh objects such as pv.PolyData, pv.UnstructuredGrid, etc.
         """
         meshes = []

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -6903,6 +6903,7 @@ class Plotter(BasePlotter):
 
         return meshes
 
+
 # Tracks created plotters.  This is the end of the module as we need to
 # define ``BasePlotter`` before including it in the type definition.
 #

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -392,3 +392,13 @@ def test_plotter_add_volume_clim(uniform: pyvista.ImageData):
     pl = pyvista.Plotter()
     vol = pl.add_volume(uniform, clim=clim_val)
     assert vol.mapper.scalar_range == (-clim_val, clim_val)
+
+
+def test_plotter_meshes(sphere, cube):
+    pl = pyvista.Plotter()
+    pl.add_mesh(sphere)
+    pl.add_mesh(cube)
+
+    assert sphere in pl.meshes
+    assert cube in pl.meshes
+    assert len(pl.meshes) == 2


### PR DESCRIPTION
### Overview

This PR adds the property `meshes` to the `Plotter` object, so you can use it to retrieve the meshes added to the plotter.

I believe this method is more intuitive and natural than using actors.

Resolves #4769 

### Caveats

- I wonder if eventually in the future `Plotter.mesh` should be deprecated for this method, or maybe renamed to `Plotter.last_mesh` which makes more sense IMO.
- I also believe that `Plotter.mesh` should return a mesh results of merging all the added meshes. But this change will be a breaking change, so I'm not proposing in here.
