### PR TITLE
Refactor Trame widget - Vue 2 and Vue 3 versions

### DIFF
--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -49,7 +49,7 @@ def _validate_jupyter_backend(backend):
     return backend
 
 
-def set_jupyter_backend(backend):
+def set_jupyter_backend(backend, name=None, **kwargs):
     """Set the plotting backend for a jupyter notebook.
 
     Parameters
@@ -83,6 +83,10 @@ def set_jupyter_backend(backend):
           instead display using dedicated VTK render windows.  This
           will generate nothing on headless servers even with a
           virtual framebuffer.
+    name : str, optional
+        The unique name identifier for the server.
+    **kwargs : dict, optional
+        Any additional keyword arguments to pass to the server launch.
 
     Examples
     --------
@@ -105,4 +109,6 @@ def set_jupyter_backend(backend):
         # Launch the trame server
         from pyvista.trame.jupyter import elegantly_launch
 
-        elegantly_launch(pyvista.global_theme.trame.jupyter_server_name)
+        if not name:
+            name = pyvista.global_theme.trame.jupyter_server_name
+        elegantly_launch(name, **kwargs)

--- a/pyvista/trame/__init__.py
+++ b/pyvista/trame/__init__.py
@@ -4,7 +4,7 @@ import logging
 logging.getLogger('trame.app').disabled = True
 
 from pyvista.trame.jupyter import elegantly_launch, launch_server, show_trame
-from pyvista.trame.ui import get_or_create_viewer, plotter_ui
+from pyvista.trame.ui import get_viewer, plotter_ui
 from pyvista.trame.views import PyVistaLocalView, PyVistaRemoteLocalView, PyVistaRemoteView
 
 # __all__ only left for mypy --strict to work when pyvista is a dependency

--- a/pyvista/trame/__init__.py
+++ b/pyvista/trame/__init__.py
@@ -10,7 +10,7 @@ from pyvista.trame.views import PyVistaLocalView, PyVistaRemoteLocalView, PyVist
 # __all__ only left for mypy --strict to work when pyvista is a dependency
 __all__ = [
     'elegantly_launch',
-    'get_or_create_viewer',
+    'get_viewer',
     'launch_server',
     'plotter_ui',
     'show_trame',

--- a/pyvista/trame/jupyter.py
+++ b/pyvista/trame/jupyter.py
@@ -5,7 +5,12 @@ import os
 import warnings
 
 from trame.ui.vuetify import VAppLayout
-from trame.widgets import html as html_widgets, vtk as vtk_widgets, vuetify as vuetify_widgets
+from trame.widgets import (
+    html as html_widgets,
+    vtk as vtk_widgets,
+    vuetify as vuetify2_widgets,
+    vuetify3 as vuetify3_widgets,
+)
 
 try:
     from ipywidgets.widgets import HTML
@@ -85,7 +90,7 @@ class Widget(HTML):  # numpydoc ignore=PR01
         return self._src
 
 
-def launch_server(server=None, port=None, host=None):
+def launch_server(server=None, port=None, host=None, **kwargs):
     """Launch a trame server for use with Jupyter.
 
     Parameters
@@ -105,6 +110,8 @@ def launch_server(server=None, port=None, host=None):
     host : str, optional
         The host name to bind the server to on launch. Server will bind to
         ``127.0.0.1`` by default unless user sets the environment variable ``TRAME_DEFAULT_HOST``.
+    **kwargs : dict, optional
+        Any additional keyword arguments to pass to ``pyvista.trame.views.get_server``.
 
     Returns
     -------
@@ -116,7 +123,7 @@ def launch_server(server=None, port=None, host=None):
     if server is None:
         server = pyvista.global_theme.trame.jupyter_server_name
     if isinstance(server, str):
-        server = get_server(server)
+        server = get_server(server, **kwargs)
     if port is None:
         port = pyvista.global_theme.trame.jupyter_server_port
     if host is None:
@@ -126,7 +133,11 @@ def launch_server(server=None, port=None, host=None):
     # Must enable all used modules
     html_widgets.initialize(server)
     vtk_widgets.initialize(server)
-    vuetify_widgets.initialize(server)
+
+    if server.client_type == 'vue2':
+        vuetify2_widgets.initialize(server)
+    else:
+        vuetify3_widgets.initialize(server)
 
     def on_ready(**_):  # numpydoc ignore=GL08
         logger.debug(f'Server ready: {server}')

--- a/pyvista/trame/jupyter.py
+++ b/pyvista/trame/jupyter.py
@@ -19,7 +19,7 @@ except ImportError:
 
 
 import pyvista
-from pyvista.trame.ui import UI_TITLE, get_or_create_viewer
+from pyvista.trame.ui import UI_TITLE, get_viewer
 from pyvista.trame.views import CLOSED_PLOTTER_ERROR, get_server
 
 SERVER_DOWN_MESSAGE = """Trame server has not launched.
@@ -189,7 +189,7 @@ def initialize(
     state = server.state
     state.trame__title = UI_TITLE
 
-    viewer = get_or_create_viewer(plotter, suppress_rendering=mode == 'client')
+    viewer = get_viewer(plotter, suppress_rendering=mode == 'client')
 
     with VAppLayout(server, template_name=plotter._id_name):
         viewer.ui(

--- a/pyvista/trame/ui/__init__.py
+++ b/pyvista/trame/ui/__init__.py
@@ -97,7 +97,7 @@ def plotter_ui(
         Trame view interface for pyvista.
 
     """
-    viewer = get_or_create_viewer(
+    viewer = get_viewer(
         plotter, server=kwargs.get('server'), suppress_rendering=mode == 'client'
     )
     return viewer.ui(

--- a/pyvista/trame/ui/__init__.py
+++ b/pyvista/trame/ui/__init__.py
@@ -18,8 +18,8 @@ _VIEWERS: Dict[str, BaseViewer] = {}
 UI_TITLE = 'PyVista'
 
 
-def get_or_create_viewer(plotter, server=None, suppress_rendering=False):
-    """Get or create a Viewer instance for a given Plotter.
+def get_viewer(plotter, server=None, suppress_rendering=False):
+    """Get a Viewer instance for a given Plotter.
 
     There should be only one Viewer instance per plotter. A Viewer
     can have multiple UI views though.

--- a/pyvista/trame/ui/__init__.py
+++ b/pyvista/trame/ui/__init__.py
@@ -13,6 +13,7 @@ from trame.app import get_server
 from .base_viewer import BaseViewer
 from .vuetify2 import Viewer as Vue2Viewer
 from .vuetify3 import Viewer as Vue3Viewer
+import warnings
 
 _VIEWERS: Dict[str, BaseViewer] = {}
 UI_TITLE = 'PyVista'

--- a/pyvista/trame/ui/__init__.py
+++ b/pyvista/trame/ui/__init__.py
@@ -7,13 +7,13 @@ environments and provides a starting point for custom user-built
 applications.
 """
 from typing import Dict
+import warnings
 
 from trame.app import get_server
 
 from .base_viewer import BaseViewer
 from .vuetify2 import Viewer as Vue2Viewer
 from .vuetify3 import Viewer as Vue3Viewer
-import warnings
 
 _VIEWERS: Dict[str, BaseViewer] = {}
 UI_TITLE = 'PyVista'
@@ -46,7 +46,10 @@ def get_viewer(plotter, server=None, suppress_rendering=False):
         viewer = _VIEWERS[plotter._id_name]
         if suppress_rendering != plotter.suppress_rendering:
             plotter.suppress_rendering = suppress_rendering
-            warnings.warn("Suppress rendering on the plotter is changed to " + str(suppress_rendering), UserWarning)
+            warnings.warn(
+                "Suppress rendering on the plotter is changed to " + str(suppress_rendering),
+                UserWarning,
+            )
         return viewer
 
     if not server:
@@ -98,9 +101,7 @@ def plotter_ui(
         Trame view interface for pyvista.
 
     """
-    viewer = get_viewer(
-        plotter, server=kwargs.get('server'), suppress_rendering=mode == 'client'
-    )
+    viewer = get_viewer(plotter, server=kwargs.get('server'), suppress_rendering=mode == 'client')
     return viewer.ui(
         mode=mode,
         default_server_rendering=default_server_rendering,

--- a/pyvista/trame/ui/__init__.py
+++ b/pyvista/trame/ui/__init__.py
@@ -46,7 +46,7 @@ def get_viewer(plotter, server=None, suppress_rendering=False):
         viewer = _VIEWERS[plotter._id_name]
         if suppress_rendering != plotter.suppress_rendering:
             plotter.suppress_rendering = suppress_rendering
-            # TODO: warn user?
+            warnings.warn("Suppress rendering on the plotter is changed to " + str(suppress_rendering), UserWarning)
         return viewer
 
     if not server:

--- a/pyvista/trame/ui/__init__.py
+++ b/pyvista/trame/ui/__init__.py
@@ -1,0 +1,100 @@
+# flake8: noqa: D102,D103,D107
+"""PyVista Trame User Interface.
+
+This module builds a base UI for manipulating a PyVista Plotter.
+The UI generated here is the default for rendering in Jupyter
+environments and provides a starting point for custom user-built
+applications.
+"""
+from typing import Dict
+
+from trame.app import get_server
+
+from .base_viewer import BaseViewer
+from .vuetify2 import Viewer as Vue2Viewer
+from .vuetify3 import Viewer as Vue3Viewer
+
+_VIEWERS: Dict[str, BaseViewer] = {}
+UI_TITLE = 'PyVista'
+
+
+def get_or_create_viewer(plotter, suppress_rendering=False):
+    """Get or create a Viewer instance for a given Plotter.
+
+    There should be only one Viewer instance per plotter. A Viewer
+    can have multiple UI views though.
+
+    Parameters
+    ----------
+    plotter : pyvista.Plotter
+        Plotter to return or create the viewer instance for.
+
+    suppress_rendering : bool, default: False
+        Suppress rendering on the plotter.
+
+    Returns
+    -------
+    pyvista.trame.ui.Viewer
+        Trame viewer.
+
+    """
+    if plotter._id_name in _VIEWERS:
+        viewer = _VIEWERS[plotter._id_name]
+        if suppress_rendering != plotter.suppress_rendering:
+            plotter.suppress_rendering = suppress_rendering
+            # TODO: warn user?
+        return viewer
+
+    CLIENT_TYPE = get_server().client_type
+    if CLIENT_TYPE == 'vue2':
+        return Vue2Viewer(plotter, suppress_rendering=suppress_rendering)
+    else:
+        return Vue3Viewer(plotter, suppress_rendering=suppress_rendering)
+
+
+def plotter_ui(
+    plotter, mode=None, default_server_rendering=True, collapse_menu=False, add_menu=True, **kwargs
+):
+    """Create a UI view for the given Plotter.
+
+    Parameters
+    ----------
+    plotter : pyvista.Plotter
+        Plotter to create the UI for.
+
+    mode : str, default: 'trame'
+        The UI view mode. Options are:
+
+        * ``'trame'``: Uses a view that can switch between client and server
+          rendering modes.
+        * ``'server'``: Uses a view that is purely server rendering.
+        * ``'client'``: Uses a view that is purely client rendering (generally
+          safe without a virtual frame buffer)
+
+    default_server_rendering : bool, default: True
+        Whether to use server-side or client-side rendering on-start when
+        using the ``'trame'`` mode.
+
+    collapse_menu : bool, default: False
+        Collapse the UI menu (camera controls, etc.) on start.
+
+    add_menu : bool, default: True
+        Add a UI controls VCard to the VContainer.
+
+    **kwargs : dict, optional
+        Additional keyword arguments are passed to the viewer being created.
+
+    Returns
+    -------
+    PyVistaRemoteLocalView, PyVistaRemoteView, or PyVistaLocalView
+        Trame view interface for pyvista.
+
+    """
+    viewer = get_or_create_viewer(plotter, suppress_rendering=mode == 'client')
+    return viewer.ui(
+        mode=mode,
+        default_server_rendering=default_server_rendering,
+        collapse_menu=collapse_menu,
+        add_menu=add_menu,
+        **kwargs,
+    )

--- a/pyvista/trame/ui/__init__.py
+++ b/pyvista/trame/ui/__init__.py
@@ -93,7 +93,7 @@ def plotter_ui(
 
     Returns
     -------
-    PyVistaRemoteLocalView, PyVistaRemoteView, or PyVistaLocalView
+    PyVistaRemoteLocalView | PyVistaRemoteView | PyVistaLocalView
         Trame view interface for pyvista.
 
     """

--- a/pyvista/trame/ui/__init__.py
+++ b/pyvista/trame/ui/__init__.py
@@ -45,11 +45,11 @@ def get_or_create_viewer(plotter, suppress_rendering=False):
             # TODO: warn user?
         return viewer
 
-    CLIENT_TYPE = get_server().client_type
-    if CLIENT_TYPE == 'vue2':
-        return Vue2Viewer(plotter, suppress_rendering=suppress_rendering)
+    server = get_server()
+    if server.client_type == 'vue2':
+        return Vue2Viewer(plotter, suppress_rendering=suppress_rendering, server=server)
     else:
-        return Vue3Viewer(plotter, suppress_rendering=suppress_rendering)
+        return Vue3Viewer(plotter, suppress_rendering=suppress_rendering, server=server)
 
 
 def plotter_ui(

--- a/pyvista/trame/ui/base_viewer.py
+++ b/pyvista/trame/ui/base_viewer.py
@@ -7,6 +7,7 @@ See `pyvista.trame.ui.vuetify2` and ``pyvista.trame.ui.vuetify3` for its derived
 """
 import io
 
+from trame.app import get_server
 from trame.widgets import html
 
 import pyvista
@@ -19,14 +20,19 @@ class BaseViewer:
     ----------
     plotter : pyvista.Plotter
         Target Plotter instance to view.
+    server : trame.Server, optional
+        Current Server for Trame Application.
     suppress_rendering : bool, default=False
         Whether to suppress rendering on the Plotter.
     """
 
-    def __init__(self, plotter, suppress_rendering=False):
+    def __init__(self, plotter, server=None, suppress_rendering=False):
         """Initialize Viewer."""
         self._html_views = set()
 
+        if server is None:
+            server = get_server()
+        self.server = server
         self.plotter = plotter
         self.plotter.suppress_rendering = suppress_rendering
 

--- a/pyvista/trame/ui/base_viewer.py
+++ b/pyvista/trame/ui/base_viewer.py
@@ -200,9 +200,15 @@ class BaseViewer:
             else:
                 renderer.hide_axes()
         for view in self._html_views:
-            view.set_widgets(
-                [ren.axes_widget for ren in self.plotter.renderers if hasattr(ren, 'axes_widget')]
-            )
+            if view.set_widgets:
+                # VtkRemoteView does not have set_widgets function, but VtkRemoteLocalView and VtkLocalView do.
+                view.set_widgets(
+                    [
+                        ren.axes_widget
+                        for ren in self.plotter.renderers
+                        if hasattr(ren, 'axes_widget')
+                    ]
+                )
         self.update()
 
     def on_rendering_mode_change(self, **kwargs):

--- a/pyvista/trame/ui/base_viewer.py
+++ b/pyvista/trame/ui/base_viewer.py
@@ -1,0 +1,243 @@
+# flake8: noqa: D102,D103,D107
+"""PyVista Trame Base Viewer class.
+
+This base class defines methods to manipulate a PyVista Plotter.
+This base class does not define a `ui` method, but its derived classes do.
+See `pyvista.trame.ui.vuetify2` and ``pyvista.trame.ui.vuetify3` for its derived classes.
+"""
+import io
+
+from trame.widgets import html
+
+import pyvista
+
+
+class BaseViewer:
+    """Internal wrapper to sync trame view with Plotter.
+
+    Parameters
+    ----------
+    plotter : pyvista.Plotter
+        Target Plotter instance to view.
+    suppress_rendering : bool, default=False
+        Whether to suppress rendering on the Plotter.
+    """
+
+    def __init__(self, plotter, suppress_rendering=False):
+        """Initialize Viewer."""
+        self._html_views = set()
+
+        self.plotter = plotter
+        self.plotter.suppress_rendering = suppress_rendering
+
+        # State variable names
+        self.SHOW_UI = f'{plotter._id_name}_show_ui'
+        self.GRID = f'{plotter._id_name}_grid_visibility'
+        self.OUTLINE = f'{plotter._id_name}_outline_visibility'
+        self.EDGES = f'{plotter._id_name}_edge_visibility'
+        self.AXIS = f'{plotter._id_name}_axis_visiblity'
+        self.SERVER_RENDERING = f'{plotter._id_name}_use_server_rendering'
+        self.VALID_UI_MODES = [
+            'trame',
+            'client',
+            'server',
+        ]
+
+    @property
+    def views(self):  # numpydoc ignore=RT01
+        """Get a set of all associate trame views for this viewer."""
+        return self._html_views
+
+    def update(self, **kwargs):
+        """Update all associated views.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
+        for view in self._html_views:
+            view.update()
+
+    def push_camera(self, **kwargs):
+        """Push camera to all associated views.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
+        for view in self._html_views:
+            view.push_camera()
+
+    def reset_camera(self, **kwargs):
+        """Reset camera for all associated views.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
+        for view in self._html_views:
+            view.reset_camera()
+
+    def update_image(self, **kwargs):
+        """Update image for all associated views.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
+        for view in self._html_views:
+            view.update_image()
+
+    def update_camera(self, **kwargs):
+        """Update image and camera for all associated views.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
+        for view in self._html_views:
+            view.update_camera()
+
+    def view_isometric(self):
+        """View isometric."""
+        self.plotter.view_isometric(render=False)
+        self.update_camera()
+
+    def view_yz(self):
+        """View YZ plane."""
+        self.plotter.view_yz(render=False)
+        self.update_camera()
+
+    def view_xz(self):
+        """View XZ plane."""
+        self.plotter.view_xz(render=False)
+        self.update_camera()
+
+    def view_xy(self):
+        """View XY plane."""
+        self.plotter.view_xy(render=False)
+        self.update_camera()
+
+    def on_edge_visiblity_change(self, **kwargs):
+        """Toggle edge visibility for all actors.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
+        value = kwargs[self.EDGES]
+        for renderer in self.plotter.renderers:
+            for _, actor in renderer.actors.items():
+                if isinstance(actor, pyvista.Actor):
+                    actor.prop.show_edges = value
+        self.update()
+
+    def on_grid_visiblity_change(self, **kwargs):
+        """Handle axes grid visibility.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
+        value = kwargs[self.GRID]
+        for renderer in self.plotter.renderers:
+            if value:
+                renderer.show_grid()
+            else:
+                renderer.remove_bounds_axes()
+        self.update()
+
+    def on_outline_visiblity_change(self, **kwargs):
+        """Handle outline visibility.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
+        value = kwargs[self.OUTLINE]
+        for renderer in self.plotter.renderers:
+            if value:
+                renderer.add_bounding_box(reset_camera=False)
+            else:
+                renderer.remove_bounding_box()
+        self.update()
+
+    def on_axis_visiblity_change(self, **kwargs):
+        """Handle outline visibility.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
+        value = kwargs[self.AXIS]
+        for renderer in self.plotter.renderers:
+            if value:
+                renderer.show_axes()
+            else:
+                renderer.hide_axes()
+        for view in self._html_views:
+            view.set_widgets(
+                [ren.axes_widget for ren in self.plotter.renderers if hasattr(ren, 'axes_widget')]
+            )
+        self.update()
+
+    def on_rendering_mode_change(self, **kwargs):
+        """Handle any configurations when the render mode changes between client and server.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Unused keyword arguments.
+
+        """
+        if not kwargs[self.SERVER_RENDERING]:
+            self.update_camera()
+
+    @property
+    def actors(self):  # numpydoc ignore=RT01
+        """Get dataset actors."""
+        return {k: v for k, v in self.plotter.actors.items() if isinstance(v, pyvista.Actor)}
+
+    def screenshot(self):
+        """Take screenshot and add attachament.
+
+        Returns
+        -------
+        memoryview
+            Screenshot as a ``memoryview``.
+
+        """
+        self.plotter.render()
+        self.update()  # makes sure the plotter and views are in sync
+        buffer = io.BytesIO()
+        self.plotter.screenshot(filename=buffer)
+        buffer.seek(0)
+        return memoryview(buffer.read())
+
+    def export(self):  # numpydoc ignore=RT01
+        """Export the scene as a zip file."""
+        for view in self._html_views:
+            return memoryview(view.export_html())
+        raise TypeError('This viewer cannot be exported.')
+
+    def ui(self):
+        """Implement in derived classes."""
+        raise NotImplementedError()

--- a/pyvista/trame/ui/vuetify2.py
+++ b/pyvista/trame/ui/vuetify2.py
@@ -216,8 +216,7 @@ class Viewer(BaseViewer):
             default_server_rendering = mode == 'server'
 
         with vuetify.VContainer(
-            fluid=True,
-            classes='pa-0 fill-height',
+            fluid=True, classes='pa-0 fill-height', trame_server=self.server
         ) as container:
             server = container.server
             # Initialize state variables

--- a/pyvista/trame/ui/vuetify2.py
+++ b/pyvista/trame/ui/vuetify2.py
@@ -180,7 +180,7 @@ class Viewer(BaseViewer):
 
         default_server_rendering : bool, default: True
             Whether to use server-side or client-side rendering on-start when
-              using the ``'trame'`` mode.
+            using the ``'trame'`` mode.
 
         collapse_menu : bool, default: False
             Collapse the UI menu (camera controls, etc.) on start.

--- a/pyvista/trame/ui/vuetify2.py
+++ b/pyvista/trame/ui/vuetify2.py
@@ -52,14 +52,14 @@ class Viewer(BaseViewer):
             The UI view mode. Options are:
 
             * ``'trame'``: Uses a view that can switch between client and server
-            rendering modes.
+              rendering modes.
             * ``'server'``: Uses a view that is purely server rendering.
             * ``'client'``: Uses a view that is purely client rendering (generally
-            safe without a virtual frame buffer)
+              safe without a virtual frame buffer)
 
         default_server_rendering : bool, default: True
             Whether to use server-side or client-side rendering on-start when
-            using the ``'trame'`` mode.
+              using the ``'trame'`` mode.
 
         v_show : bool, optional
             Conditionally show the viewer controls.
@@ -182,14 +182,14 @@ class Viewer(BaseViewer):
             The UI view mode. Options are:
 
             * ``'trame'``: Uses a view that can switch between client and server
-            rendering modes.
+              rendering modes.
             * ``'server'``: Uses a view that is purely server rendering.
             * ``'client'``: Uses a view that is purely client rendering (generally
-            safe without a virtual frame buffer)
+              safe without a virtual frame buffer)
 
         default_server_rendering : bool, default: True
             Whether to use server-side or client-side rendering on-start when
-            using the ``'trame'`` mode.
+              using the ``'trame'`` mode.
 
         collapse_menu : bool, default: False
             Collapse the UI menu (camera controls, etc.) on start.

--- a/pyvista/trame/ui/vuetify2.py
+++ b/pyvista/trame/ui/vuetify2.py
@@ -1,27 +1,15 @@
 # flake8: noqa: D102,D103,D107
-"""PyVista Trame User Interface.
+"""PyVista Trame Viewer class for a Vue 2 client.
 
-This module builds a base UI for manipulating a PyVista Plotter.
-The UI generated here is the default for rendering in Jupyter
-environments and provides a starting point for custom user-built
-applications.
+This class, derived from `pyvista.trame.ui.base_viewer`,
+is intended for use with a trame application where the client type is "vue2".
+Therefore, the `ui` method implemented by this class utilizes the API of Vuetify 2.
 """
-import io
+from trame.widgets import html, vuetify as vuetify
 
-from trame.widgets import html, vuetify
-
-import pyvista
 from pyvista.trame.views import PyVistaLocalView, PyVistaRemoteLocalView, PyVistaRemoteView
 
-UI_TITLE = 'PyVista'
-
-VALID_UI_MODES = [
-    'trame',
-    'client',
-    'server',
-]
-
-_VIEWERS = {}
+from .base_viewer import BaseViewer
 
 
 def button(click, icon, tooltip):  # numpydoc ignore=PR01
@@ -49,221 +37,11 @@ def checkbox(model, icons, tooltip):  # numpydoc ignore=PR01
         html.Span(tooltip)
 
 
-class Viewer:
-    """Internal wrapper to sync trame view with Plotter."""
+class Viewer(BaseViewer):
+    """Viewer implementation compatible with Vue 2 Trame Applications."""
 
-    def __init__(self, plotter, suppress_rendering=False):
-        """Initialize Viewer."""
-        if plotter._id_name in _VIEWERS:
-            raise RuntimeError('A viewer instance already exists for this Plotter.')
-        _VIEWERS[plotter._id_name] = self
-        self._html_views = set()
-
-        self.plotter = plotter
-        self.plotter.suppress_rendering = suppress_rendering
-
-        # State variable names
-        self.SHOW_UI = f'{plotter._id_name}_show_ui'
-        self.GRID = f'{plotter._id_name}_grid_visibility'
-        self.OUTLINE = f'{plotter._id_name}_outline_visibility'
-        self.EDGES = f'{plotter._id_name}_edge_visibility'
-        self.AXIS = f'{plotter._id_name}_axis_visiblity'
-        self.SERVER_RENDERING = f'{plotter._id_name}_use_server_rendering'
-
-    @property
-    def views(self):  # numpydoc ignore=RT01
-        """Get a set of all associate trame views for this viewer."""
-        return self._html_views
-
-    def update(self, **kwargs):
-        """Update all associated views.
-
-        Parameters
-        ----------
-        **kwargs : dict, optional
-            Unused keyword arguments.
-
-        """
-        for view in self._html_views:
-            view.update()
-
-    def push_camera(self, **kwargs):
-        """Push camera to all associated views.
-
-        Parameters
-        ----------
-        **kwargs : dict, optional
-            Unused keyword arguments.
-
-        """
-        for view in self._html_views:
-            view.push_camera()
-
-    def reset_camera(self, **kwargs):
-        """Reset camera for all associated views.
-
-        Parameters
-        ----------
-        **kwargs : dict, optional
-            Unused keyword arguments.
-
-        """
-        for view in self._html_views:
-            view.reset_camera()
-
-    def update_image(self, **kwargs):
-        """Update image for all associated views.
-
-        Parameters
-        ----------
-        **kwargs : dict, optional
-            Unused keyword arguments.
-
-        """
-        for view in self._html_views:
-            view.update_image()
-
-    def update_camera(self, **kwargs):
-        """Update image and camera for all associated views.
-
-        Parameters
-        ----------
-        **kwargs : dict, optional
-            Unused keyword arguments.
-
-        """
-        for view in self._html_views:
-            view.update_camera()
-
-    def view_isometric(self):
-        """View isometric."""
-        self.plotter.view_isometric(render=False)
-        self.update_camera()
-
-    def view_yz(self):
-        """View YZ plane."""
-        self.plotter.view_yz(render=False)
-        self.update_camera()
-
-    def view_xz(self):
-        """View XZ plane."""
-        self.plotter.view_xz(render=False)
-        self.update_camera()
-
-    def view_xy(self):
-        """View XY plane."""
-        self.plotter.view_xy(render=False)
-        self.update_camera()
-
-    def on_edge_visiblity_change(self, **kwargs):
-        """Toggle edge visibility for all actors.
-
-        Parameters
-        ----------
-        **kwargs : dict, optional
-            Unused keyword arguments.
-
-        """
-        value = kwargs[self.EDGES]
-        for renderer in self.plotter.renderers:
-            for _, actor in renderer.actors.items():
-                if isinstance(actor, pyvista.Actor):
-                    actor.prop.show_edges = value
-        self.update()
-
-    def on_grid_visiblity_change(self, **kwargs):
-        """Handle axes grid visibility.
-
-        Parameters
-        ----------
-        **kwargs : dict, optional
-            Unused keyword arguments.
-
-        """
-        value = kwargs[self.GRID]
-        for renderer in self.plotter.renderers:
-            if value:
-                renderer.show_grid()
-            else:
-                renderer.remove_bounds_axes()
-        self.update()
-
-    def on_outline_visiblity_change(self, **kwargs):
-        """Handle outline visibility.
-
-        Parameters
-        ----------
-        **kwargs : dict, optional
-            Unused keyword arguments.
-
-        """
-        value = kwargs[self.OUTLINE]
-        for renderer in self.plotter.renderers:
-            if value:
-                renderer.add_bounding_box(reset_camera=False)
-            else:
-                renderer.remove_bounding_box()
-        self.update()
-
-    def on_axis_visiblity_change(self, **kwargs):
-        """Handle outline visibility.
-
-        Parameters
-        ----------
-        **kwargs : dict, optional
-            Unused keyword arguments.
-
-        """
-        value = kwargs[self.AXIS]
-        for renderer in self.plotter.renderers:
-            if value:
-                renderer.show_axes()
-            else:
-                renderer.hide_axes()
-        for view in self._html_views:
-            view.set_widgets(
-                [ren.axes_widget for ren in self.plotter.renderers if hasattr(ren, 'axes_widget')]
-            )
-        self.update()
-
-    def on_rendering_mode_change(self, **kwargs):
-        """Handle any configurations when the render mode changes between client and server.
-
-        Parameters
-        ----------
-        **kwargs : dict, optional
-            Unused keyword arguments.
-
-        """
-        if not kwargs[self.SERVER_RENDERING]:
-            self.update_camera()
-
-    @property
-    def actors(self):  # numpydoc ignore=RT01
-        """Get dataset actors."""
-        return {k: v for k, v in self.plotter.actors.items() if isinstance(v, pyvista.Actor)}
-
-    def screenshot(self):
-        """Take screenshot and add attachament.
-
-        Returns
-        -------
-        memoryview
-            Screenshot as a ``memoryview``.
-
-        """
-        self.plotter.render()
-        self.update()  # makes sure the plotter and views are in sync
-        buffer = io.BytesIO()
-        self.plotter.screenshot(filename=buffer)
-        buffer.seek(0)
-        return memoryview(buffer.read())
-
-    def export(self):
-        """Export the scene as a zip file."""
-        for view in self._html_views:
-            return memoryview(view.export_html())
-        raise TypeError('This viewer cannot be exported.')
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def ui_controls(self, mode=None, default_server_rendering=True, v_show=None):
         """Create a VRow for the UI controls.
@@ -274,10 +52,10 @@ class Viewer:
             The UI view mode. Options are:
 
             * ``'trame'``: Uses a view that can switch between client and server
-              rendering modes.
+            rendering modes.
             * ``'server'``: Uses a view that is purely server rendering.
             * ``'client'``: Uses a view that is purely client rendering (generally
-              safe without a virtual frame buffer)
+            safe without a virtual frame buffer)
 
         default_server_rendering : bool, default: True
             Whether to use server-side or client-side rendering on-start when
@@ -289,8 +67,10 @@ class Viewer:
         """
         if mode is None:
             mode = self.plotter._theme.trame.default_mode
-        if mode not in VALID_UI_MODES:
-            raise ValueError(f'`{mode}` is not a valid mode choice. Use one of: {VALID_UI_MODES}')
+        if mode not in self.VALID_UI_MODES:
+            raise ValueError(
+                f'`{mode}` is not a valid mode choice. Use one of: {self.VALID_UI_MODES}'
+            )
         if mode != 'trame':
             default_server_rendering = mode == 'server'
 
@@ -402,10 +182,10 @@ class Viewer:
             The UI view mode. Options are:
 
             * ``'trame'``: Uses a view that can switch between client and server
-              rendering modes.
+            rendering modes.
             * ``'server'``: Uses a view that is purely server rendering.
             * ``'client'``: Uses a view that is purely client rendering (generally
-              safe without a virtual frame buffer)
+            safe without a virtual frame buffer)
 
         default_server_rendering : bool, default: True
             Whether to use server-side or client-side rendering on-start when
@@ -428,8 +208,10 @@ class Viewer:
         """
         if mode is None:
             mode = self.plotter._theme.trame.default_mode
-        if mode not in VALID_UI_MODES:
-            raise ValueError(f'`{mode}` is not a valid mode choice. Use one of: {VALID_UI_MODES}')
+        if mode not in self.VALID_UI_MODES:
+            raise ValueError(
+                f'`{mode}` is not a valid mode choice. Use one of: {self.VALID_UI_MODES}'
+            )
         if mode != 'trame':
             default_server_rendering = mode == 'server'
 
@@ -453,7 +235,7 @@ class Viewer:
                     style='position: absolute; top: 20px; left: 20px; z-index: 1; height: 36px;',
                     classes=(f"{{ 'rounded-circle': !{self.SHOW_UI} }}",),
                 ):
-                    with vuetify.VRow(classes='pa-0 ma-0') as row:
+                    with vuetify.VRow(classes='pa-0 ma-0'):
                         button(
                             click=f'{self.SHOW_UI}=!{self.SHOW_UI}',
                             icon='mdi-dots-vertical',
@@ -482,80 +264,3 @@ class Viewer:
             self._html_views.add(view)
 
         return view
-
-
-def get_or_create_viewer(plotter, suppress_rendering=False):
-    """Get or create a Viewer instance for a given Plotter.
-
-    There should be only one Viewer instance per plotter. A Viewer
-    can have multiple UI views though.
-
-    Parameters
-    ----------
-    plotter : pyvista.Plotter
-        Plotter to return or create the viewer instance for.
-
-    suppress_rendering : bool, default: False
-        Suppress rendering on the plotter.
-
-    Returns
-    -------
-    pyvista.trame.ui.Viewer
-        Trame viewer.
-
-    """
-    if plotter._id_name in _VIEWERS:
-        viewer = _VIEWERS[plotter._id_name]
-        if suppress_rendering != plotter.suppress_rendering:
-            plotter.suppress_rendering = suppress_rendering
-            # TODO: warn user?
-        return viewer
-    return Viewer(plotter, suppress_rendering=suppress_rendering)
-
-
-def plotter_ui(
-    plotter, mode=None, default_server_rendering=True, collapse_menu=False, add_menu=True, **kwargs
-):
-    """Create a UI view for the given Plotter.
-
-    Parameters
-    ----------
-    plotter : pyvista.Plotter
-        Plotter to create the UI for.
-
-    mode : str, default: 'trame'
-        The UI view mode. Options are:
-
-        * ``'trame'``: Uses a view that can switch between client and server
-          rendering modes.
-        * ``'server'``: Uses a view that is purely server rendering.
-        * ``'client'``: Uses a view that is purely client rendering (generally
-          safe without a virtual frame buffer)
-
-    default_server_rendering : bool, default: True
-        Whether to use server-side or client-side rendering on-start when
-        using the ``'trame'`` mode.
-
-    collapse_menu : bool, default: False
-        Collapse the UI menu (camera controls, etc.) on start.
-
-    add_menu : bool, default: True
-        Add a UI controls VCard to the VContainer.
-
-    **kwargs : dict, optional
-        Additional keyword arguments are passed to the viewer being created.
-
-    Returns
-    -------
-    PyVistaRemoteLocalView, PyVistaRemoteView, or PyVistaLocalView
-        Trame view interface for pyvista.
-
-    """
-    viewer = get_or_create_viewer(plotter, suppress_rendering=mode == 'client')
-    return viewer.ui(
-        mode=mode,
-        default_server_rendering=default_server_rendering,
-        collapse_menu=collapse_menu,
-        add_menu=add_menu,
-        **kwargs,
-    )

--- a/pyvista/trame/ui/vuetify2.py
+++ b/pyvista/trame/ui/vuetify2.py
@@ -65,15 +65,6 @@ class Viewer(BaseViewer):
             Conditionally show the viewer controls.
 
         """
-        if mode is None:
-            mode = self.plotter._theme.trame.default_mode
-        if mode not in self.VALID_UI_MODES:
-            raise ValueError(
-                f'`{mode}` is not a valid mode choice. Use one of: {self.VALID_UI_MODES}'
-            )
-        if mode != 'trame':
-            default_server_rendering = mode == 'server'
-
         with vuetify.VRow(
             v_show=v_show,
             classes='pa-0 ma-0 align-center',
@@ -216,7 +207,9 @@ class Viewer(BaseViewer):
             default_server_rendering = mode == 'server'
 
         with vuetify.VContainer(
-            fluid=True, classes='pa-0 fill-height', trame_server=self.server
+            fluid=True,
+            classes='pa-0 fill-height',
+            trame_server=self.server,
         ) as container:
             server = container.server
             # Initialize state variables

--- a/pyvista/trame/ui/vuetify3.py
+++ b/pyvista/trame/ui/vuetify3.py
@@ -58,14 +58,14 @@ class Viewer(BaseViewer):
             The UI view mode. Options are:
 
             * ``'trame'``: Uses a view that can switch between client and server
-            rendering modes.
+              rendering modes.
             * ``'server'``: Uses a view that is purely server rendering.
             * ``'client'``: Uses a view that is purely client rendering (generally
-            safe without a virtual frame buffer)
+              safe without a virtual frame buffer)
 
         default_server_rendering : bool, default: True
             Whether to use server-side or client-side rendering on-start when
-            using the ``'trame'`` mode.
+              using the ``'trame'`` mode.
 
         v_show : bool, optional
             Conditionally show the viewer controls.
@@ -190,14 +190,14 @@ class Viewer(BaseViewer):
             The UI view mode. Options are:
 
             * ``'trame'``: Uses a view that can switch between client and server
-            rendering modes.
+              rendering modes.
             * ``'server'``: Uses a view that is purely server rendering.
             * ``'client'``: Uses a view that is purely client rendering (generally
-            safe without a virtual frame buffer)
+              safe without a virtual frame buffer)
 
         default_server_rendering : bool, default: True
             Whether to use server-side or client-side rendering on-start when
-            using the ``'trame'`` mode.
+              using the ``'trame'`` mode.
 
         collapse_menu : bool, default: False
             Collapse the UI menu (camera controls, etc.) on start.

--- a/pyvista/trame/ui/vuetify3.py
+++ b/pyvista/trame/ui/vuetify3.py
@@ -71,15 +71,6 @@ class Viewer(BaseViewer):
             Conditionally show the viewer controls.
 
         """
-        if mode is None:
-            mode = self.plotter._theme.trame.default_mode
-        if mode not in self.VALID_UI_MODES:
-            raise ValueError(
-                f'`{mode}` is not a valid mode choice. Use one of: {self.VALID_UI_MODES}'
-            )
-        if mode != 'trame':
-            default_server_rendering = mode == 'server'
-
         with vuetify.VRow(
             v_show=v_show,
             classes='pa-0 ma-0 align-center fill-height',
@@ -226,6 +217,7 @@ class Viewer(BaseViewer):
         with vuetify.VContainer(
             fluid=True,
             classes='pa-0 fill-height',
+            trame_server=self.server,
         ) as container:
             server = container.server
             # Initialize state variables

--- a/pyvista/trame/ui/vuetify3.py
+++ b/pyvista/trame/ui/vuetify3.py
@@ -1,0 +1,276 @@
+# flake8: noqa: D102,D103,D107
+"""PyVista Trame Viewer class for a Vue 3 client.
+
+This class, derived from `pyvista.trame.ui.base_viewer`,
+is intended for use with a trame application where the client type is "vue3".
+Therefore, the `ui` method implemented by this class utilizes the API of Vuetify 3.
+"""
+from trame.widgets import html, vuetify3 as vuetify
+
+from pyvista.trame.views import PyVistaLocalView, PyVistaRemoteLocalView, PyVistaRemoteView
+
+from .base_viewer import BaseViewer
+
+
+def button(click, icon, tooltip):  # numpydoc ignore=PR01
+    """Create a vuetify button."""
+    with vuetify.VTooltip(location='bottom'):
+        with vuetify.Template(v_slot_activator='{ props }'):
+            with vuetify.VBtn(
+                icon=True,
+                v_bind='props',
+                variant='text',
+                size='small',
+                click=click,
+            ):
+                vuetify.VIcon(icon)
+        html.Span(tooltip)
+
+
+def checkbox(model, icons, tooltip):  # numpydoc ignore=PR01
+    """Create a vuetify checkbox."""
+    with vuetify.VTooltip(location='bottom'):
+        with vuetify.Template(v_slot_activator='{ props }'):
+            with html.Div(v_bind='props'):
+                vuetify.VCheckbox(
+                    v_model=model,
+                    true_icon=icons[0],
+                    false_icon=icons[1],
+                    density='compact',
+                    hide_details=True,
+                    classes='ma-1 py-1',
+                )
+        html.Span(tooltip)
+
+
+class Viewer(BaseViewer):
+    """Viewer implementation compatible with Vue 3 Trame Applications."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def ui_controls(self, mode=None, default_server_rendering=True, v_show=None):
+        """Create a VRow for the UI controls.
+
+        Parameters
+        ----------
+        mode : str, default: 'trame'
+            The UI view mode. Options are:
+
+            * ``'trame'``: Uses a view that can switch between client and server
+            rendering modes.
+            * ``'server'``: Uses a view that is purely server rendering.
+            * ``'client'``: Uses a view that is purely client rendering (generally
+            safe without a virtual frame buffer)
+
+        default_server_rendering : bool, default: True
+            Whether to use server-side or client-side rendering on-start when
+            using the ``'trame'`` mode.
+
+        v_show : bool, optional
+            Conditionally show the viewer controls.
+
+        """
+        if mode is None:
+            mode = self.plotter._theme.trame.default_mode
+        if mode not in self.VALID_UI_MODES:
+            raise ValueError(
+                f'`{mode}` is not a valid mode choice. Use one of: {self.VALID_UI_MODES}'
+            )
+        if mode != 'trame':
+            default_server_rendering = mode == 'server'
+
+        with vuetify.VRow(
+            v_show=v_show,
+            classes='pa-0 ma-0 align-center fill-height',
+            style="flex-wrap: nowrap",
+        ) as row:
+            server = row.server
+            # Listen to state changes
+            server.state.change(self.EDGES)(self.on_edge_visiblity_change)
+            server.state.change(self.GRID)(self.on_grid_visiblity_change)
+            server.state.change(self.OUTLINE)(self.on_outline_visiblity_change)
+            server.state.change(self.AXIS)(self.on_axis_visiblity_change)
+            server.state.change(self.SERVER_RENDERING)(self.on_rendering_mode_change)
+            vuetify.VDivider(vertical=True, classes='mr-1')
+            button(
+                click=self.reset_camera,
+                icon='mdi-arrow-expand-all',
+                tooltip='Reset Camera',
+            )
+            vuetify.VDivider(vertical=True, classes='mx-1')
+            button(
+                click=self.view_isometric,
+                icon='mdi-axis-arrow',
+                tooltip='Perspective view',
+            )
+            button(
+                click=self.view_yz,
+                icon='mdi-axis-x-arrow',
+                tooltip='Reset Camera X',
+            )
+            button(
+                click=self.view_xz,
+                icon='mdi-axis-y-arrow',
+                tooltip='Reset Camera Y',
+            )
+            button(
+                click=self.view_xy,
+                icon='mdi-axis-z-arrow',
+                tooltip='Reset Camera Z',
+            )
+            vuetify.VDivider(vertical=True, classes='mx-1')
+            checkbox(
+                model=(self.EDGES, False),
+                icons=('mdi-grid', 'mdi-grid-off'),
+                tooltip=f"Toggle edge visibility ({{{{ {self.EDGES} ? 'on' : 'off' }}}})",
+            )
+            checkbox(
+                model=(self.OUTLINE, False),
+                icons=('mdi-cube', 'mdi-cube-off'),
+                tooltip=f"Toggle bounding box ({{{{ {self.OUTLINE} ? 'on' : 'off' }}}})",
+            )
+            checkbox(
+                model=(self.GRID, False),
+                icons=('mdi-ruler-square', 'mdi-ruler-square'),
+                tooltip=f"Toggle ruler ({{{{ {self.GRID} ? 'on' : 'off' }}}})",
+            )
+            checkbox(
+                model=(self.AXIS, False),
+                icons=('mdi-axis-arrow-info', 'mdi-axis-arrow-info'),
+                tooltip=f"Toggle axis ({{{{ {self.AXIS} ? 'on' : 'off' }}}})",
+            )
+            # Server rendering options
+            if mode == 'trame':
+                vuetify.VDivider(vertical=True, classes='mx-1')
+                checkbox(
+                    model=(self.SERVER_RENDERING, default_server_rendering),
+                    icons=('mdi-dns', 'mdi-open-in-app'),
+                    tooltip=f"Toggle rendering mode ({{{{ {self.SERVER_RENDERING} ? 'remote' : 'local' }}}})",
+                )
+            with vuetify.VRow(
+                v_show=(self.SERVER_RENDERING, default_server_rendering),
+                classes='pa-0 ma-0 align-center fill-height',
+                style="flex-wrap: nowrap",
+            ):
+
+                def attach_screenshot():
+                    return server.protocol.addAttachment(self.screenshot())
+
+                button(
+                    # Must use single-quote string for JS here
+                    click=f"utils.download('screenshot.png', trigger('{server.trigger_name(attach_screenshot)}'), 'image/png')",
+                    icon='mdi-file-png-box',
+                    tooltip='Save screenshot',
+                )
+
+            def attach_export():
+                return server.protocol.addAttachment(self.export())
+
+            button(
+                # Must use single-quote string for JS here
+                click=f"utils.download('scene-export.html', trigger('{server.trigger_name(attach_export)}'), 'application/octet-stream')",
+                icon='mdi-download',
+                tooltip='Export scene as HTML',
+            )
+
+    def ui(
+        self,
+        mode=None,
+        default_server_rendering=True,
+        collapse_menu=False,
+        add_menu=True,
+        **kwargs,
+    ):
+        """Generate VContainer for PyVista Plotter.
+
+        Parameters
+        ----------
+        mode : str, default: 'trame'
+            The UI view mode. Options are:
+
+            * ``'trame'``: Uses a view that can switch between client and server
+            rendering modes.
+            * ``'server'``: Uses a view that is purely server rendering.
+            * ``'client'``: Uses a view that is purely client rendering (generally
+            safe without a virtual frame buffer)
+
+        default_server_rendering : bool, default: True
+            Whether to use server-side or client-side rendering on-start when
+            using the ``'trame'`` mode.
+
+        collapse_menu : bool, default: False
+            Collapse the UI menu (camera controls, etc.) on start.
+
+        add_menu : bool, default: True
+            Add a UI controls VCard to the VContainer.
+
+        **kwargs : dict, optional
+            Additional keyword arguments are passed to the view being created.
+
+        Returns
+        -------
+        PyVistaRemoteLocalView, PyVistaRemoteView, or PyVistaLocalView
+            Trame view interface for pyvista.
+
+        """
+        if mode is None:
+            mode = self.plotter._theme.trame.default_mode
+        if mode not in self.VALID_UI_MODES:
+            raise ValueError(
+                f'`{mode}` is not a valid mode choice. Use one of: {self.VALID_UI_MODES}'
+            )
+        if mode != 'trame':
+            default_server_rendering = mode == 'server'
+
+        with vuetify.VContainer(
+            fluid=True,
+            classes='pa-0 fill-height',
+        ) as container:
+            server = container.server
+            # Initialize state variables
+            server.state[self.EDGES] = False
+            server.state[self.GRID] = self.plotter.renderer.cube_axes_actor is not None
+            server.state[self.OUTLINE] = hasattr(self.plotter.renderer, '_box_object')
+            server.state[self.AXIS] = (
+                hasattr(self.plotter.renderer, 'axes_widget')
+                and self.plotter.renderer.axes_widget.GetEnabled()
+            )
+            server.state[self.SERVER_RENDERING] = default_server_rendering
+            if add_menu:
+                server.state[self.SHOW_UI] = not collapse_menu
+                with vuetify.VCard(
+                    style='position: absolute; top: 20px; left: 20px; z-index: 1; height: 36px;',
+                    classes=(f"{{ 'rounded-circle': !{self.SHOW_UI} }}",),
+                ):
+                    with vuetify.VRow(
+                        classes='pa-0 ma-0 align-center fill-height', style="flex-wrap: nowrap"
+                    ):
+                        button(
+                            click=f'{self.SHOW_UI}=!{self.SHOW_UI}',
+                            icon='mdi-dots-vertical',
+                            tooltip=f"{{{{ {self.SHOW_UI} ? 'Hide' : 'Show' }}}} menu",
+                        )
+                        self.ui_controls(
+                            mode=mode,
+                            default_server_rendering=default_server_rendering,
+                            v_show=(f'{self.SHOW_UI}',),
+                        )
+            if mode == 'trame':
+                view = PyVistaRemoteLocalView(
+                    self.plotter,
+                    mode=(
+                        # Must use single-quote string for JS here
+                        f"{self.SERVER_RENDERING} ? 'remote' : 'local'",
+                        'remote' if default_server_rendering else 'local',
+                    ),
+                    **kwargs,
+                )
+            elif mode == 'server':
+                view = PyVistaRemoteView(self.plotter, **kwargs)
+            elif mode == 'client':
+                view = PyVistaLocalView(self.plotter, **kwargs)
+
+            self._html_views.add(view)
+
+        return view

--- a/pyvista/trame/views.py
+++ b/pyvista/trame/views.py
@@ -65,10 +65,14 @@ class _BasePyVistaView:
         content = io.StringIO()
         if isinstance(self, PyVistaLocalView):
             data = self.export(format="zip")
+            if data is None:
+                raise ValueError('No data to write.')
             write_html(data, content)
             content.seek(0)
         elif isinstance(self, PyVistaRemoteLocalView):
             data = self.export_geometry(format="zip")
+            if data is None:
+                raise ValueError('No data to write.')
             write_html(data, content)
             content.seek(0)
         else:

--- a/pyvista/trame/views.py
+++ b/pyvista/trame/views.py
@@ -26,7 +26,8 @@ def get_server(*args, **kwargs):  # numpydoc ignore=RT01
         Trame server.
     """
     server = trame_get_server(*args, **kwargs)
-    server.client_type = 'vue2'
+    if 'client_type' in kwargs:
+        server.client_type = kwargs['client_type']
     return server
 
 

--- a/tests/plotting/jupyter/test_trame.py
+++ b/tests/plotting/jupyter/test_trame.py
@@ -43,9 +43,11 @@ def test_trame_server_launch():
     assert server.running
 
 
-def test_trame():
+@pytest.mark.parametrize('client_type', ['vue2', 'vue3'])
+def test_trame(client_type):
     pv.set_jupyter_backend('trame')
     server = get_server(name=pv.global_theme.trame.jupyter_server_name)
+    server.client_type = client_type
     assert server.running
 
     pl = pv.Plotter(notebook=True)

--- a/tests/plotting/jupyter/test_trame.py
+++ b/tests/plotting/jupyter/test_trame.py
@@ -45,9 +45,10 @@ def test_trame_server_launch():
 
 @pytest.mark.parametrize('client_type', ['vue2', 'vue3'])
 def test_trame(client_type):
-    pv.set_jupyter_backend('trame')
-    server = get_server(name=pv.global_theme.trame.jupyter_server_name)
-    server.client_type = client_type
+    # give different names for servers so different instances are created
+    name = f'{pv.global_theme.trame.jupyter_server_name}-{client_type}'
+    pv.set_jupyter_backend('trame', name=name, client_type=client_type)
+    server = get_server(name=name)
     assert server.running
 
     pl = pv.Plotter(notebook=True)

--- a/tests/plotting/jupyter/test_trame.py
+++ b/tests/plotting/jupyter/test_trame.py
@@ -12,7 +12,7 @@ try:
     from trame.app import get_server
 
     from pyvista.trame.jupyter import Widget
-    from pyvista.trame.ui import base_viewer, get_or_create_viewer, plotter_ui
+    from pyvista.trame.ui import base_viewer, get_viewer, plotter_ui
     from pyvista.trame.views import (
         PyVistaLocalView,
         PyVistaRemoteLocalView,

--- a/tests/plotting/jupyter/test_trame.py
+++ b/tests/plotting/jupyter/test_trame.py
@@ -12,8 +12,13 @@ try:
     from trame.app import get_server
 
     from pyvista.trame.jupyter import Widget
-    from pyvista.trame.ui import get_or_create_viewer
-    from pyvista.trame.views import PyVistaLocalView, PyVistaRemoteLocalView, PyVistaRemoteView
+    from pyvista.trame.ui import get_or_create_viewer, plotter_ui
+    from pyvista.trame.views import (
+        PyVistaLocalView,
+        PyVistaRemoteLocalView,
+        PyVistaRemoteView,
+        _BasePyVistaView,
+    )
 except:  # noqa: E722
     has_trame = False
 
@@ -41,6 +46,20 @@ def test_trame_server_launch():
     pv.set_jupyter_backend('trame')
     server = get_server(name=pv.global_theme.trame.jupyter_server_name)
     assert server.running
+
+
+@pytest.mark.parametrize('client_type', ['vue2', 'vue3'])
+@pytest.mark.parametrize('mode', ['trame', 'client', 'server'])
+def test_trame_plotter_ui(client_type, mode):
+    # give different names for servers so different instances are created
+    name = f'{pv.global_theme.trame.jupyter_server_name}-{client_type}'
+    pv.set_jupyter_backend('trame', name=name, client_type=client_type)
+    server = get_server(name=name)
+    assert server.running
+
+    pl = pv.Plotter(notebook=True)
+    ui = plotter_ui(pl, mode=mode, server=server)
+    assert isinstance(ui, _BasePyVistaView)
 
 
 @pytest.mark.parametrize('client_type', ['vue2', 'vue3'])

--- a/tests/plotting/jupyter/test_trame.py
+++ b/tests/plotting/jupyter/test_trame.py
@@ -97,7 +97,7 @@ def test_trame(client_type):
     else:
         assert 'http://' in widget.src
 
-    viewer = get_or_create_viewer(pl)
+    viewer = get_viewer(pl)
 
     for cp in ['xy', 'xz', 'yz', 'isometric']:
         exec(f'viewer.view_{cp}()')

--- a/tests/plotting/jupyter/test_trame.py
+++ b/tests/plotting/jupyter/test_trame.py
@@ -12,7 +12,7 @@ try:
     from trame.app import get_server
 
     from pyvista.trame.jupyter import Widget
-    from pyvista.trame.ui import get_or_create_viewer, plotter_ui
+    from pyvista.trame.ui import base_viewer, get_or_create_viewer, plotter_ui
     from pyvista.trame.views import (
         PyVistaLocalView,
         PyVistaRemoteLocalView,
@@ -48,9 +48,15 @@ def test_trame_server_launch():
     assert server.running
 
 
+def test_base_viewer_ui():
+    pl = pv.Plotter(notebook=True)
+    viewer = base_viewer.BaseViewer(pl)
+    with pytest.raises(NotImplementedError):
+        viewer.ui()
+
+
 @pytest.mark.parametrize('client_type', ['vue2', 'vue3'])
-@pytest.mark.parametrize('mode', ['trame', 'client', 'server'])
-def test_trame_plotter_ui(client_type, mode):
+def test_trame_plotter_ui(client_type):
     # give different names for servers so different instances are created
     name = f'{pv.global_theme.trame.jupyter_server_name}-{client_type}'
     pv.set_jupyter_backend('trame', name=name, client_type=client_type)
@@ -58,7 +64,18 @@ def test_trame_plotter_ui(client_type, mode):
     assert server.running
 
     pl = pv.Plotter(notebook=True)
-    ui = plotter_ui(pl, mode=mode, server=server)
+
+    for mode in ['trame', 'client', 'server']:
+        ui = plotter_ui(pl, mode=mode, server=server)
+        assert isinstance(ui, _BasePyVistaView)
+
+    # Test invalid mode
+    mode = 'invalid'
+    with pytest.raises(ValueError, match=f"`{mode}` is not a valid mode choice. Use one of: (.*)"):
+        ui = plotter_ui(pl, mode=mode, server=server)
+
+    # Test when mode and server are None
+    ui = plotter_ui(pl)
     assert isinstance(ui, _BasePyVistaView)
 
 
@@ -123,6 +140,15 @@ def test_trame(client_type):
     viewer.on_rendering_mode_change(**server.state.to_dict())
 
     assert viewer.actors == pl.actors
+
+    # Test update methods
+    viewer.update_image()
+    viewer.reset_camera()
+    viewer.push_camera()
+    assert len(viewer.views) == 1
+
+    with pytest.raises(ValueError, match="No data to write"):
+        viewer.export()
 
     assert isinstance(viewer.screenshot(), memoryview)
 


### PR DESCRIPTION
### Overview

This PR is intended to make the Trame widget compatible with both Vue 2 and Vue 3 client types within a Trame application. Resolves #4776. 
This PR refactors `pyvista/trame/ui.py` into several new files: 

- `trame/pyvista/ui/__init__.py`
- `trame/pyvista/ui/base_viewer.py`
- `trame/pyvista/ui/vuetify2.py`
- `trame/pyvista/ui/vuetify3.py`

### Details
Previously, `ui.py` defined a class `Viewer` and several top-level functions and variables. The following changes were made:

- Most top-level functions and variables were moved to `ui/__init__.py`. 
- Two top-level functions, `button` and `checkbox` required different implementations for the Vuetify 2 and Vuetify 3 API, so these were moved to `ui/vuetify2.py` and `ui/vuetify3.py`, respective to the implementations.
- The `Viewer` class was renamed to `BaseViewer` and moved to `ui/base_viewer.py`. Two class methods, `ui_controls` and `ui`, required different implementations for Vuetify 2 and Vuetify 3. The `ui` method for `BaseViewer` now raises a `NotImplementedError` and the `ui_controls` method was only ever referenced within the `ui` method, so it was removed entirely from `BaseViewer`
- Two new `Viewer` classes were written in `ui/vuetify2.py` and `ui/vuetify3.py`, both derived from the `BaseViewer` class. Both derived classes implement the `ui` and `ui_controls` methods, using the Vuetify 2 and Vuetify 3 APIs respectively.
- The top-level function `get_or_create_viewer` (used within the top-level function `plotter_ui`) now has an extra bit of logic to determine which implementation of `Viewer` to use in the case of new viewer creation. See below code. 

```
CLIENT_TYPE = get_server().client_type
if CLIENT_TYPE == 'vue2':
    return Vue2Viewer(plotter, suppress_rendering=suppress_rendering)
else:
    return Vue3Viewer(plotter, suppress_rendering=suppress_rendering)
```

This solves the problem I mentioned in the linked issue about needing to set the Trame server's client type before the import of `plotter_ui` within the Trame application. Now the client type is not fetched until the `plotter_ui` function calls `get_or_create_viewer`. This PR does not change the API for using the `plotter_ui` function.
