### PR TITLE
Raise error when callback has empty arguments in `add_key_event`

### DIFF
--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -105,7 +105,7 @@ class RenderWindowInteractor:
             raise TypeError('callback must be callable.')
         for param in signature(callback).parameters.values():
             if param.default is param.empty:
-                TypeError('`callback` must not have any arguments without default values.')
+                raise TypeError('`callback` must not have any arguments without default values.')
         self._key_press_event_callbacks[key].append(callback)
 
     @staticmethod

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -2,6 +2,7 @@
 import collections.abc
 from contextlib import contextmanager
 from functools import partial
+from inspect import signature
 import logging
 import time
 import warnings
@@ -102,6 +103,8 @@ class RenderWindowInteractor:
         """
         if not callable(callback):
             raise TypeError('callback must be callable.')
+        if len(signature(callback).parameters) > 0:
+            raise TypeError('callback must not have any arguments.')
         self._key_press_event_callbacks[key].append(callback)
 
     @staticmethod

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -103,7 +103,8 @@ class RenderWindowInteractor:
         """
         if not callable(callback):
             raise TypeError('callback must be callable.')
-        if len(signature(callback).parameters) > 0:
+        for param in signature(callback).parameters.values():
+            if (param.default is param.empty):
             raise TypeError('callback must not have any arguments.')
         self._key_press_event_callbacks[key].append(callback)
 

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -105,7 +105,7 @@ class RenderWindowInteractor:
             raise TypeError('callback must be callable.')
         for param in signature(callback).parameters.values():
             if param.default is param.empty:
-                TypeError(f'`callback` must not have any arguments without default values.')
+                TypeError('`callback` must not have any arguments without default values.')
         self._key_press_event_callbacks[key].append(callback)
 
     @staticmethod

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -98,14 +98,14 @@ class RenderWindowInteractor:
             The key to trigger the event.
 
         callback : callable
-            A callable that takes no empty arguments.
+            A callable that takes no arguments (keyword arguments are allowed).
 
         """
         if not callable(callback):
             raise TypeError('callback must be callable.')
         for param in signature(callback).parameters.values():
             if param.default is param.empty:
-                raise TypeError('callback must not have any empty arguments.')
+                TypeError(f'`callback` must not have any arguments without default values.')
         self._key_press_event_callbacks[key].append(callback)
 
     @staticmethod

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -105,7 +105,7 @@ class RenderWindowInteractor:
             raise TypeError('callback must be callable.')
         for param in signature(callback).parameters.values():
             if (param.default is param.empty):
-            raise TypeError('callback must not have any arguments.')
+                raise TypeError('callback must not have any arguments.')
         self._key_press_event_callbacks[key].append(callback)
 
     @staticmethod

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -98,14 +98,14 @@ class RenderWindowInteractor:
             The key to trigger the event.
 
         callback : callable
-            A callable that takes no arguments.
+            A callable that takes no empty arguments.
 
         """
         if not callable(callback):
             raise TypeError('callback must be callable.')
         for param in signature(callback).parameters.values():
-            if (param.default is param.empty):
-                raise TypeError('callback must not have any arguments.')
+            if param.default is param.empty:
+                raise TypeError('callback must not have any empty arguments.')
         self._key_press_event_callbacks[key].append(callback)
 
     @staticmethod

--- a/tests/plotting/test_render_window_interactor.py
+++ b/tests/plotting/test_render_window_interactor.py
@@ -20,6 +20,13 @@ def test_observers():
     with pytest.raises(TypeError):
         pl.add_key_event('w', 1)
 
+    # Callback must takes no arguments.
+    def callback(arguments):
+        return
+
+    with pytest.raises(TypeError):
+        pl.add_key_event('w', callback)
+
     key = 'w'
     pl.add_key_event(key, empty_callback)
     assert key in pl.iren._key_press_event_callbacks

--- a/tests/plotting/test_render_window_interactor.py
+++ b/tests/plotting/test_render_window_interactor.py
@@ -20,7 +20,7 @@ def test_observers():
     with pytest.raises(TypeError):
         pl.add_key_event('w', 1)
 
-    # Callback must takes no arguments.
+    # Callback must not have any arguments.
     def callback(arguments):
         return
 

--- a/tests/plotting/test_render_window_interactor.py
+++ b/tests/plotting/test_render_window_interactor.py
@@ -20,9 +20,9 @@ def test_observers():
     with pytest.raises(TypeError):
         pl.add_key_event('w', 1)
 
-    # Callback must not have any arguments.
-    def callback(arguments):
-        return
+    # Callback must not have any  empty arguments.
+    def callback(a, b, *, c, d=1.0):
+        pass
 
     with pytest.raises(TypeError):
         pl.add_key_event('w', callback)


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
This PR is to save us in #4750. We were too lazy to read the documentation and it took us quite some time to solve the problem.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None
