### PR TITLE
Deprecate pass_cell_data

### DIFF
--- a/pyvista/core/filters/rectilinear_grid.py
+++ b/pyvista/core/filters/rectilinear_grid.py
@@ -2,14 +2,12 @@
 
 import collections
 from typing import Sequence, Union
-import warnings
 
 import numpy as np
 
 from pyvista.core import _vtk_core as _vtk
-from pyvista.core.errors import PyVistaDeprecationWarning
 from pyvista.core.filters import _get_output, _update_alg
-from pyvista.core.utilities.misc import abstract_class, assert_empty_kwargs
+from pyvista.core.utilities.misc import abstract_class
 
 
 @abstract_class
@@ -24,7 +22,6 @@ class RectilinearGridFilters:
         pass_cell_ids: bool = True,
         pass_data: bool = True,
         progress_bar: bool = False,
-        **kwargs,
     ):
         """Create a tetrahedral mesh structured grid.
 
@@ -60,9 +57,6 @@ class RectilinearGridFilters:
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
 
-        **kwargs : dict, optional
-            Deprecated keyword argument ``pass_cell_data``.
-
         Returns
         -------
         pyvista.UnstructuredGrid
@@ -95,15 +89,6 @@ class RectilinearGridFilters:
         >>> tet_grid.explode(factor=0.5).plot(show_edges=True)
 
         """
-        # Note remove this section when deprecation is done
-        pass_cell_data = kwargs.pop("pass_cell_data", None)
-        assert_empty_kwargs(**kwargs)
-        if pass_cell_data is not None:
-            warnings.warn(
-                "pass_cell_data is a deprecated option, use pass_data", PyVistaDeprecationWarning
-            )
-            pass_data = pass_cell_data
-
         alg = _vtk.vtkRectilinearGridToTetrahedra()
         alg.SetRememberVoxelId(pass_cell_ids or pass_data)
         if mixed is not False:

--- a/pyvista/core/filters/rectilinear_grid.py
+++ b/pyvista/core/filters/rectilinear_grid.py
@@ -14,7 +14,6 @@ from pyvista.core.utilities.misc import abstract_class
 class RectilinearGridFilters:
     """An internal class to manage filters/algorithms for rectilinear grid datasets."""
 
-    # Note remove kwargs when removing deprecation for pass_cell_data
     def to_tetrahedra(
         self,
         tetra_per_cell: int = 5,

--- a/tests/core/test_rectilinear_grid_filters.py
+++ b/tests/core/test_rectilinear_grid_filters.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 import pyvista as pv
-from pyvista.core.errors import PyVistaDeprecationWarning
 
 
 @pytest.fixture
@@ -74,11 +73,6 @@ def test_to_tetrahedral_pass_cell_data(tiny_rectilinear):
 
     # automatically added
     assert 'vtkOriginalCellIds' in tet_grid.cell_data
-
-    with pytest.warns(PyVistaDeprecationWarning):
-        tiny_rectilinear.to_tetrahedra(pass_cell_data=True)
-        if pv._version.version_info >= (0, 43, 0):
-            raise RuntimeError('Remove this deprecated kwarg')
 
     # Test point data active
     tiny_rectilinear.set_active_scalars("point_data")


### PR DESCRIPTION
This deprecation is holding up the release. Remove the unused `pass_cell_data` kwarg from `to_tetrahedra`.
