### PR TITLE
Add version.json update in minor release steps

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -847,7 +847,11 @@ created the following will occur:
     feedstock <https://github.com/conda-forge/pyvista-feedstock>`_.
     Merge that pull request.
 
-11. Announce the new release in the PyVista Slack workspace and
+11. Update
+    `version.json <https://github.com/pyvista/pyvista-docs/blob/gh-pages/versions.json>`_
+    to change the stable version to new release.
+
+12. Announce the new release in the PyVista Slack workspace and
     celebrate.
 
 Patch Release Steps

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -848,7 +848,7 @@ created the following will occur:
     Merge that pull request.
 
 11. Check that `version.json <https://github.com/pyvista/pyvista-docs/blob/gh-pages/versions.json>`_
-    is changed from the stable version to the new release automatically by [.github/workflows/docs.yml](.github/workflows/docs.yml).
+    is changed from the stable version to the new release automatically by `.github/workflows/docs.yml <.github/workflows/docs.yml>`_.
 
 12. Announce the new release in the PyVista Slack workspace and
     celebrate.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -847,9 +847,8 @@ created the following will occur:
     feedstock <https://github.com/conda-forge/pyvista-feedstock>`_.
     Merge that pull request.
 
-11. Update
-    `version.json <https://github.com/pyvista/pyvista-docs/blob/gh-pages/versions.json>`_
-    to change the stable version to new release.
+11. Check that `version.json <https://github.com/pyvista/pyvista-docs/blob/gh-pages/versions.json>`_
+    is changed from the stable version to the new release automatically by [.github/workflows/docs.yml](.github/workflows/docs.yml).
 
 12. Announce the new release in the PyVista Slack workspace and
     celebrate.


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
It seems that we need to update [version.json](https://github.com/pyvista/pyvista-docs/blob/gh-pages/versions.json) to update the stable version document.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None
