### PR TITLE
Fix Trame Viewers in Jupyter

### DIFF
--- a/pyvista/trame/jupyter.py
+++ b/pyvista/trame/jupyter.py
@@ -189,7 +189,11 @@ def initialize(
     state = server.state
     state.trame__title = UI_TITLE
 
-    viewer = get_viewer(plotter, suppress_rendering=mode == 'client')
+    viewer = get_viewer(
+        plotter,
+        server=server,
+        suppress_rendering=mode == 'client',
+    )
 
     with VAppLayout(server, template_name=plotter._id_name):
         viewer.ui(

--- a/pyvista/trame/ui/base_viewer.py
+++ b/pyvista/trame/ui/base_viewer.py
@@ -48,6 +48,11 @@ class BaseViewer:
             'client',
             'server',
         ]
+        server.state[self.SHOW_UI] = True
+        server.state[self.GRID] = False
+        server.state[self.OUTLINE] = False
+        server.state[self.EDGES] = False
+        server.state[self.AXIS] = False
 
     @property
     def views(self):  # numpydoc ignore=RT01

--- a/tests/plotting/jupyter/test_trame.py
+++ b/tests/plotting/jupyter/test_trame.py
@@ -147,8 +147,7 @@ def test_trame(client_type):
     viewer.push_camera()
     assert len(viewer.views) == 1
 
-    with pytest.raises(ValueError, match="No data to write"):
-        viewer.export()
+    viewer.export()
 
     assert isinstance(viewer.screenshot(), memoryview)
 


### PR DESCRIPTION
### Overview

This PR is intended to address any oversights from #4811.
Related to #4835.

### Changes

- [x]  Initialize UI-related state variables in the constructor of the `BaseViewer` class. This makes calling the `ui` function not mandatory for using the viewer.

