### PR TITLE
Add class to HTML widget

### DIFF
--- a/pyvista/trame/jupyter.py
+++ b/pyvista/trame/jupyter.py
@@ -74,7 +74,10 @@ class Widget(HTML):  # numpydoc ignore=PR01
         """Initialize."""
         if HTML is object:
             raise ImportError('Please install `ipywidgets`.')
-        value = f"<iframe src='{src}' style='width: {width}; height: {height};'></iframe>"
+        # eventually we could maybe expose this, but for now make sure we're at least
+        # consistent with matplotlib's color (light gray)
+        border = "border: 1px solid rgb(221,221,221);"
+        value = f"<iframe src='{src}' class='pyvista' style='width: {width}; height: {height}; {border}'></iframe>"
         super().__init__(value, **kwargs)
         self._viewer = viewer
         self._src = src


### PR DESCRIPTION
While updating MNE-Python I noticed two things.

1. First, there is always a vertical scrollbar on the `trame` widget even though it's forced to the correct size so it shouldn't need to be there:

   ![Screenshot from 2023-09-05 11-13-31](https://github.com/pyvista/pyvista/assets/2365790/37b7becc-cc38-45b2-8ac1-3edf696d0727)

   I'm not sure how general this problem is, but I'm going to fix it by doing:
   ```
           # viewer
           viewer = self.plotter.show(jupyter_backend="trame", return_viewer=True)
           # Remove scrollbars
           viewer.value = re.sub(
               r" style=[\"'](.+)[\"']></iframe>",
               # value taken from matplotlib's widget
               r" style='\1' scrolling='no'></iframe>",
               viewer.value,
           )
   ```
   So it's a bit of a hack but it works :shrug: If someone sees a better API I'm happy to implement it. Or maybe there should never be scroll bars, or maybe we can detect when they should be there...?

2. There is a border in the `<iframe`, at least by default on Chrome in Linux that looks a bit bad/non-jupyter-ish when removing the scrollbar:

   ![Screenshot from 2023-09-05 11-59-48](https://github.com/pyvista/pyvista/assets/2365790/a63ec9e5-a84e-49f3-8869-4fdc646fc3f3)

   This PR adds a styling consistent with what matplotlib uses, which I think is the principle of least surprise for people:

   ![Screenshot from 2023-09-05 11-58-16](https://github.com/pyvista/pyvista/assets/2365790/627210d3-b01e-43ef-ab2e-2069e076af05)

6. I add a `class="pyvista"` to the `iframe` which should allow people to tweak the style in CSS easily with something like:
   ```
   HTML("""
   <style>
       .widget-html-content iframe.pyvista {
           overflow: hidden !important;
       }
   </style>
   """)
   ```
