### PR TITLE
Fix pyvista.DataSetFilters.extract_points documentation does not represent the features of the method

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -4640,7 +4640,7 @@ class DataSetFilters:
 
         >>> import pyvista
         >>> sphere = pyvista.Sphere()
-        >>> extracted = sphere.extract_points(sphere.points[:, 2] > 0)
+        >>> extracted = sphere.extract_points(sphere.points[:, 2] > 0, include_cells=False)
         >>> extracted.clear_data()  # clear for plotting
         >>> extracted.plot()
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -4640,7 +4640,9 @@ class DataSetFilters:
 
         >>> import pyvista
         >>> sphere = pyvista.Sphere()
-        >>> extracted = sphere.extract_points(sphere.points[:, 2] > 0, include_cells=False)
+        >>> extracted = sphere.extract_points(
+        ...     sphere.points[:, 2] > 0, include_cells=False
+        ... )
         >>> extracted.clear_data()  # clear for plotting
         >>> extracted.plot()
 


### PR DESCRIPTION
### Overview
Resolves: #4849. The image from the documentation should be more adequate to the features of the method.

### Details
Switched the `include_cells` parameter from `True` (default) to `False`

### Example
![pyvista-DataSetFilters-extract_points-1_00_00](https://github.com/pyvista/pyvista/assets/69766137/1c7f8ec3-cc1b-41a1-8c4d-9b4da1f29aca)
