### PR TITLE
Add step to check tag before git push tag

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -842,7 +842,7 @@ created the following will occur:
     mentions where appropriate if a specific contributor is to thank for
     a new feature.
 
-10.  Place your release notes from step 8 in the description for `the new
+10. Place your release notes from step 8 in the description for `the new
     release on
     GitHub <https://github.com/pyvista/pyvista/releases/new>`_.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -827,9 +827,14 @@ created the following will occur:
     .. code:: bash
 
        git tag v$(python -c "import pyvista as pv; print(pv.__version__)")
+
+8.  Please check again that the tag has been created correctly and push the tag.
+
+    .. code:: bash
+
        git push origin --tags
 
-8.  Create a list of all changes for the release. It is often helpful to
+9.  Create a list of all changes for the release. It is often helpful to
     leverage `GitHub’s compare
     feature <https://github.com/pyvista/pyvista/compare>`_ to see the
     differences from the last tag and the ``main`` branch. Be sure to
@@ -837,17 +842,17 @@ created the following will occur:
     mentions where appropriate if a specific contributor is to thank for
     a new feature.
 
-9.  Place your release notes from step 8 in the description for `the new
+10.  Place your release notes from step 8 in the description for `the new
     release on
     GitHub <https://github.com/pyvista/pyvista/releases/new>`_.
 
-10. Go grab a beer/coffee/water and wait for
+11. Go grab a beer/coffee/water and wait for
     `@regro-cf-autotick-bot <https://github.com/regro/cf-scripts>`_
     to open a pull request on the conda-forge `PyVista
     feedstock <https://github.com/conda-forge/pyvista-feedstock>`_.
     Merge that pull request.
 
-11. Announce the new release in the PyVista Slack workspace and
+12. Announce the new release in the PyVista Slack workspace and
     celebrate.
 
 Patch Release Steps


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
I accidentally pushed a tag named **v** today. This was due to an error when I ran the tag creation Python one-liner locally. Now when I copy and run the bash code in the document, it pushes even if the tag creation command is in error. This is very dangerous, so I decided to separate the steps. Let's prepare for the next time human error.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None
