### PR TITLE
Fix typed marker file for mypy

### DIFF
--- a/pyvista/py.typed
+++ b/pyvista/py.typed
@@ -1,1 +1,1 @@
-partial\n
+partial


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

Currently, `pyvista` package is not treated by mypy as a partial typed package due to literal `\n` in `py.typed` file.

### Details

Please follow related discussions.

- https://discuss.python.org/t/pep-561-clarification-regarding-n/32875
- https://github.com/pyvista/pyvista/pull/2904#discussion_r1314069315
- https://github.com/pyvista/pyvista/pull/2904#discussion_r1318064352

I found this plobrem when I read [PEP561](https://peps.python.org/pep-0561/#partial-stub-packages) and searched codes with `path:**/py.typed (partial OR PARTIAL)` on GitHub.

https://github.com/search?q=path%3A**%2Fpy.typed+%28partial+OR+PARTIAL%29&type=code

There are likely at least 5 repositories that need a fix similar to this PR:

- ~https://github.com/angr/angr/blob/6dc48059e51de67e85642561b0f08aa3515c67fd/angr/py.typed~ https://github.com/angr/angr/pull/4137
- https://github.com/zwimer/delayed_rm/blob/5462af3539568c8711bd3a3bb3deb727acdd58cb/delayed_rm/py.typed
- https://github.com/apluslms/aplus-auth/blob/8050cecd99dd9335adf684a2ec57c068e7a67edd/src/aplus_auth/py.typed
- https://github.com/domdfcoding/webcolors-stubs/blob/8a7c7096772fa94b66a93955adaa73d443b58849/webcolors-stubs/py.typed
- https://github.com/VincentRPS/reqwests/blob/a7b9c847c9ff1ec36cc4cc92adee03458e5819f3/src/reqwests/py.typed