### PR TITLE
Download vtk-osmesa's wheel with aria2c

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,7 +57,11 @@ jobs:
       - name: Install custom OSMesa VTK variant
         run: |
           pip uninstall vtk -y
-          pip install https://github.com/pyvista/pyvista-wheels/raw/main/vtk_osmesa-9.2.5-cp311-cp311-linux_x86_64.whl
+          aria2c -x5 "https://github.com/pyvista/pyvista-wheels/raw/main/${VTK_OSMESA_WHEEL_NAME}"
+          pip install "$VTK_OSMESA_WHEEL_NAME"
+          rm "$VTK_OSMESA_WHEEL_NAME"
+        env:
+          VTK_OSMESA_WHEEL_NAME: vtk_osmesa-9.2.5-cp311-cp311-linux_x86_64.whl
 
       - name: PyVista Report
         run: |

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -34,8 +34,12 @@ jobs:
           version: 3.0
 
       - name: Install custom OSMesa VTK variant
-        run: pip install https://github.com/pyvista/pyvista-wheels/raw/main/vtk_osmesa-9.2.5-cp39-cp39-linux_x86_64.whl
-
+        run: |
+          aria2c -x5 "https://github.com/pyvista/pyvista-wheels/raw/main/${VTK_OSMESA_WHEEL_NAME}"
+          pip install "$VTK_OSMESA_WHEEL_NAME"
+          rm "$VTK_OSMESA_WHEEL_NAME"
+        env:
+          VTK_OSMESA_WHEEL_NAME: 'vtk_osmesa-9.2.5-cp39-cp39-linux_x86_64.whl'
       - name: Install PyVista
         run: pip install -e . --no-deps
 


### PR DESCRIPTION
### Overview

For stable CI workflow, I suggest the use of pre-download wheel file with `aria2c` before installing instead of direct download with `pip install`.

### Details

- <https://github.com/pyvista/pyvista/actions/runs/6114038971/job/16594752890?pr=4863>

