### PR TITLE
Make composite mapper dataset optional

### DIFF
--- a/pyvista/plotting/composite_mapper.py
+++ b/pyvista/plotting/composite_mapper.py
@@ -521,7 +521,7 @@ class CompositePolyDataMapper(_vtk.vtkCompositePolyDataMapper2, _BaseMapper):
 
     Parameters
     ----------
-    dataset : pyvista.MultiBlock
+    dataset : pyvista.MultiBlock, optional
         Multiblock dataset.
 
     theme : pyvista.plotting.themes.Theme, optional
@@ -541,16 +541,14 @@ class CompositePolyDataMapper(_vtk.vtkCompositePolyDataMapper2, _BaseMapper):
     """
 
     def __init__(
-        self, dataset, theme=None, color_missing_with_nan=None, interpolate_before_map=None
+        self, dataset=None, theme=None, color_missing_with_nan=None, interpolate_before_map=None
     ):
         """Initialize this composite mapper."""
         super().__init__(theme=theme)
-        self.SetInputDataObject(dataset)
-
         # this must be added to set the color, opacity, and visibility of
         # individual blocks
         self._attr = CompositeAttributes(self, dataset)
-        self._dataset = dataset
+        self.dataset = dataset
 
         if color_missing_with_nan is not None:
             self.color_missing_with_nan = color_missing_with_nan
@@ -578,6 +576,12 @@ class CompositePolyDataMapper(_vtk.vtkCompositePolyDataMapper2, _BaseMapper):
 
         """
         return self._dataset
+
+    @dataset.setter
+    def dataset(self, obj: 'pv.MultiBlock'):  # numpydoc ignore=GL08
+        self.SetInputDataObject(obj)
+        self._dataset = obj
+        self._attr._dataset = obj
 
     @property
     def block_attr(self) -> CompositeAttributes:  # numpydoc ignore=RT01

--- a/tests/plotting/test_actor.py
+++ b/tests/plotting/test_actor.py
@@ -18,7 +18,7 @@ def actor():
 
 
 @pytest.fixture()
-def actor_from_mblock():
+def actor_from_multi_block():
     return pv.Plotter().add_mesh(pv.MultiBlock([pv.Plane()]))
 
 
@@ -73,12 +73,12 @@ def test_actor_copy_shallow(actor):
     assert actor_copy.mapper is actor.mapper
 
 
-def test_actor_mblock_copy_shallow(actor_from_mblock):
-    actor_copy = actor_from_mblock.copy(deep=False)
-    assert actor_copy is not actor_from_mblock
-    assert actor_copy.prop is actor_from_mblock.prop
-    assert actor_copy.mapper is actor_from_mblock.mapper
-    assert actor_copy.mapper.dataset is actor_from_mblock.mapper.dataset
+def test_actor_mblock_copy_shallow(actor_from_multi_block):
+    actor_copy = actor_from_multi_block.copy(deep=False)
+    assert actor_copy is not actor_from_multi_block
+    assert actor_copy.prop is actor_from_multi_block.prop
+    assert actor_copy.mapper is actor_from_multi_block.mapper
+    assert actor_copy.mapper.dataset is actor_from_multi_block.mapper.dataset
 
 
 @skip_mac

--- a/tests/plotting/test_actor.py
+++ b/tests/plotting/test_actor.py
@@ -18,6 +18,11 @@ def actor():
 
 
 @pytest.fixture()
+def actor_from_mblock():
+    return pv.Plotter().add_mesh(pv.MultiBlock([pv.Plane()]))
+
+
+@pytest.fixture()
 def vol_actor():
     vol = pv.ImageData(dimensions=(10, 10, 10))
     vol['scalars'] = 255 - vol.z * 25
@@ -66,6 +71,14 @@ def test_actor_copy_shallow(actor):
     assert actor_copy is not actor
     assert actor_copy.prop is actor.prop
     assert actor_copy.mapper is actor.mapper
+
+
+def test_actor_mblock_copy_shallow(actor_from_mblock):
+    actor_copy = actor_from_mblock.copy(deep=False)
+    assert actor_copy is not actor_from_mblock
+    assert actor_copy.prop is actor_from_mblock.prop
+    assert actor_copy.mapper is actor_from_mblock.mapper
+    assert actor_copy.mapper.dataset is actor_from_mblock.mapper.dataset
 
 
 @skip_mac


### PR DESCRIPTION
Existing `CompositePolyDataMapper` implementation makes actor copy impossible:

```py
>>> import pyvista as pv
>>> mblock = pv.MultiBlock([pv.Sphere()])
>>> pl = pv.Plotter()
>>> actor, _ = pl.add_composite(mblock)
>>> actor.copy()
...
~/.venv311/lib/python3.11/site-packages/pyvista/plotting/mapper.py in copy(self)
...
TypeError: CompositePolyDataMapper.__init__() missing 1 required positional argument: 'dataset'
```

This PR allows the dataset to be optional to the mapper, which is then added later in `Actor.copy`. Since we don't test copying actors with composite datasets, I added a test as well for good measure even though this doesn't improve coverage.
