### PR TITLE
Remove unused fixtures in pytest

### DIFF
--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -12,16 +12,6 @@ from pyvista import ImageData, MultiBlock, PolyData, RectilinearGrid, Structured
 skip_mac = pytest.mark.skipif(platform.system() == 'Darwin', reason="Flaky Mac tests")
 
 
-@pytest.fixture()
-def vtk_multi():
-    return vtk.vtkMultiBlockDataSet()
-
-
-@pytest.fixture()
-def pyvista_multi():
-    return pv.MultiBlock
-
-
 def multi_from_datasets(*datasets):
     """Return pyvista multiblock composed of any number of datasets."""
     return MultiBlock(datasets)

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -59,11 +59,6 @@ def composite(datasets):
     return pv.MultiBlock(datasets)
 
 
-@pytest.fixture()
-def grid():
-    return pv.UnstructuredGrid(examples.hexbeamfile)
-
-
 @pytest.fixture(scope='module')
 def uniform_vec():
     nx, ny, nz = 20, 15, 5


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
I found some unused fixtures in pytest, so I checked it using  [pytest-deadfixtures](https://github.com/jllorencetti/pytest-deadfixtures).

```bash
Hey there, I believe the following fixture(s) are not being used:
Fixture name: vtk_multi, location: tests/core/test_composite.py:16 
Fixture name: pyvista_multi, location: tests/core/test_composite.py:21
Fixture name: grid, location: tests/core/test_dataset_filters.py:63
```

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None

