### PR TITLE
Move user matrix from `Actor` to `Prop3D`

### DIFF
--- a/pyvista/plotting/actor.py
+++ b/pyvista/plotting/actor.py
@@ -50,7 +50,7 @@ class Actor(Prop3D, _vtk.vtkActor):
       X Bounds                    -4.993E-01, 4.993E-01
       Y Bounds                    -4.965E-01, 4.965E-01
       Z Bounds                    -5.000E-01, 5.000E-01
-      User matrix:                Unset
+      User matrix:                Set
       Has mapper:                 True
     ...
 

--- a/pyvista/plotting/actor.py
+++ b/pyvista/plotting/actor.py
@@ -1,11 +1,8 @@
 """Wrap vtkActor module."""
 
-from typing import Optional, Union
-
-import numpy as np
+from typing import Optional
 
 import pyvista as pv
-from pyvista.core.utilities.arrays import array_from_vtkmatrix, vtkmatrix_from_array
 from pyvista.core.utilities.misc import no_new_attr
 
 from . import _vtk
@@ -341,53 +338,6 @@ class Actor(Prop3D, _vtk.vtkActor):
             attr.append('')
             attr.append(repr(self.mapper))
         return '\n'.join(attr)
-
-    @property
-    def user_matrix(self) -> Optional[np.ndarray]:  # numpydoc ignore=RT01
-        """Return or set the orientation matrix.
-
-        Examples
-        --------
-        Apply a 4x4 translation to a wireframe actor. This 4x4 transformation
-        is effectively translates the actor by one unit in the Z direction,
-        rotates the actor about the Z axis by approximately 45 degrees, and
-        shrinks the actor by a factor of 0.5.
-
-        >>> import numpy as np
-        >>> import pyvista as pv
-        >>> mesh = pv.Cube()
-        >>> pl = pv.Plotter()
-        >>> _ = pl.add_mesh(mesh, color="b")
-        >>> actor = pl.add_mesh(
-        ...     mesh,
-        ...     color="r",
-        ...     style="wireframe",
-        ...     line_width=5,
-        ...     lighting=False,
-        ... )
-        >>> arr = np.array(
-        ...     [
-        ...         [0.707, -0.707, 0, 0],
-        ...         [0.707, 0.707, 0, 0],
-        ...         [0, 0, 1, 1.500001],
-        ...         [0, 0, 0, 2],
-        ...     ]
-        ... )
-        >>> actor.user_matrix = arr
-        >>> pl.show_axes()
-        >>> pl.show()
-
-        """
-        mat = self.GetUserMatrix()
-        if mat is not None:
-            mat = array_from_vtkmatrix(mat)
-        return mat
-
-    @user_matrix.setter
-    def user_matrix(self, value: Union[_vtk.vtkMatrix4x4, np.ndarray]):  # numpydoc ignore=GL08
-        if isinstance(value, np.ndarray):
-            value = vtkmatrix_from_array(value)
-        self.SetUserMatrix(value)
 
     @property
     def backface_prop(self) -> Optional['pv.Property']:  # numpydoc ignore=RT01

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -3478,6 +3478,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         set_algorithm_input(self.mapper, algo or mesh)
 
         actor = Actor(mapper=self.mapper)
+        actor.user_matrix = user_matrix
 
         if texture is not None:
             if isinstance(texture, np.ndarray):

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -2835,6 +2835,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         metallic=None,
         roughness=None,
         render=True,
+        user_matrix=np.eye(4),
         component=None,
         emissive=None,
         copy_mesh=False,
@@ -3121,6 +3122,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         render : bool, default: True
             Force a render when ``True``.
+
+        user_matrix : np.ndarray | vtk.vtkMatrix4x4, default: np.eye(4)
+            Matrix passed to the Actor class before rendering. This affects the
+            actor/rendering only, not the input volume itself. The user matrix is the
+            last transformation applied to the actor before rendering. Defaults to the
+            identity matrix.
 
         component : int, optional
             Set component of vector valued scalars to plot.  Must be
@@ -3671,6 +3678,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         specular=0.2,  # TODO: different default for volumes
         specular_power=10.0,  # TODO: different default for volumes
         render=True,
+        user_matrix=np.eye(4),
         log_scale=False,
         **kwargs,
     ):
@@ -3888,6 +3896,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         render : bool, default: True
             Force a render when True.
+
+        user_matrix : np.ndarray | vtk.vtkMatrix4x4, default: np.eye(4)
+            Matrix passed to the Volume class before rendering. This affects the
+            actor/rendering only, not the input volume itself. The user matrix is the
+            last transformation applied to the actor before rendering. Defaults to the
+            identity matrix.
 
         log_scale : bool, default: False
             Use log scale when mapping data to colors. Scalars less
@@ -4226,6 +4240,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         self.volume = Volume()
         self.volume.mapper = self.mapper
+        self.volume.user_matrix = user_matrix
 
         self.volume.prop = VolumeProperty(
             lookup_table=self.mapper.lookup_table,

--- a/pyvista/plotting/prop3d.py
+++ b/pyvista/plotting/prop3d.py
@@ -1,7 +1,10 @@
 """Prop3D module."""
-from typing import Tuple
+from typing import Tuple, Union
+
+import numpy as np
 
 from pyvista.core._typing_core import BoundsLike, Vector
+from pyvista.core.utilities.arrays import array_from_vtkmatrix, vtkmatrix_from_array
 
 from . import _vtk
 
@@ -241,3 +244,72 @@ class Prop3D(_vtk.vtkProp3D):
         (0.5, 0.5, 1)
         """
         return self.GetCenter()
+
+    @property
+    def user_matrix(self) -> np.ndarray:  # numpydoc ignore=RT01
+        """Return or set the user matrix.
+
+        In addition to the instance variables such as position and orientation, the user
+        can add an additional transformation to the actor.
+
+        This matrix is concatenated with the actor's internal transformation that is
+        implicitly created when the actor is created. This affects the actor/rendering
+        only, not the input data itself.
+
+        The user matrix is the last transformation applied to the actor before
+        rendering.
+
+        Returns
+        -------
+        np.ndarray
+            A 4x4 transformation matrix.
+
+        Examples
+        --------
+        Apply a 4x4 translation to a wireframe actor. This 4x4 transformation
+        effectively translates the actor by one unit in the Z direction,
+        rotates the actor about the Z axis by approximately 45 degrees, and
+        shrinks the actor by a factor of 0.5.
+
+        >>> import numpy as np
+        >>> import pyvista as pv
+        >>> mesh = pv.Cube()
+        >>> pl = pv.Plotter()
+        >>> _ = pl.add_mesh(mesh, color="b")
+        >>> actor = pl.add_mesh(
+        ...     mesh,
+        ...     color="r",
+        ...     style="wireframe",
+        ...     line_width=5,
+        ...     lighting=False,
+        ... )
+        >>> arr = np.array(
+        ...     [
+        ...         [0.707, -0.707, 0, 0],
+        ...         [0.707, 0.707, 0, 0],
+        ...         [0, 0, 1, 1.500001],
+        ...         [0, 0, 0, 2],
+        ...     ]
+        ... )
+        >>> actor.user_matrix = arr
+        >>> pl.show_axes()
+        >>> pl.show()
+
+        """
+        if self.GetUserMatrix() is None:
+            self.SetUserMatrix(vtkmatrix_from_array(np.eye(4)))
+        return array_from_vtkmatrix(self.GetUserMatrix())
+
+    @user_matrix.setter
+    def user_matrix(self, value: Union[_vtk.vtkMatrix4x4, np.ndarray]):  # numpydoc ignore=GL08
+        if isinstance(value, np.ndarray):
+            if value.shape != (4, 4):
+                raise ValueError('User matrix array must be 4x4.')
+            value = vtkmatrix_from_array(value)
+
+        if isinstance(value, _vtk.vtkMatrix4x4):
+            self.SetUserMatrix(value)
+        else:
+            raise TypeError(
+                'Input user matrix must be either:\n' '\tvtk.vtkMatrix4x4\n' '\t4x4 np.ndarray\n'
+            )

--- a/tests/plotting/test_actor.py
+++ b/tests/plotting/test_actor.py
@@ -135,7 +135,7 @@ def test_actor_orientation(actor):
 
 
 def test_actor_unit_matrix(actor):
-    assert actor.user_matrix is None
+    assert np.allclose(actor.user_matrix, np.eye(4))
 
     arr = np.array([[0.707, -0.707, 0, 0], [0.707, 0.707, 0, 0], [0, 0, 1, 1.500001], [0, 0, 0, 2]])
 

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1937,6 +1937,24 @@ def test_user_annotations_scalar_bar_volume(uniform, verify_image_cache):
     p.show()
 
 
+def test_user_matrix_volume(uniform):
+    shear = np.eye(4)
+    shear[0, 1] = 1
+
+    p = pv.Plotter()
+    volume = p.add_volume(uniform, user_matrix=shear)
+    np.testing.assert_almost_equal(volume.user_matrix, shear)
+
+
+def test_user_matrix_mesh(sphere):
+    shear = np.eye(4)
+    shear[0, 1] = 1
+
+    p = pv.Plotter()
+    actor = p.add_mesh(sphere, user_matrix=shear)
+    np.testing.assert_almost_equal(actor.user_matrix, shear)
+
+
 def test_scalar_bar_args_unmodified_add_mesh(sphere):
     sargs = {"vertical": True}
     sargs_copy = sargs.copy()

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1945,6 +1945,12 @@ def test_user_matrix_volume(uniform):
     volume = p.add_volume(uniform, user_matrix=shear)
     np.testing.assert_almost_equal(volume.user_matrix, shear)
 
+    with pytest.raises(ValueError):
+        p.add_volume(uniform, user_matrix=np.eye(5))
+
+    with pytest.raises(TypeError):
+        p.add_volume(uniform, user_matrix='invalid')
+
 
 def test_user_matrix_mesh(sphere):
     shear = np.eye(4)
@@ -1953,6 +1959,12 @@ def test_user_matrix_mesh(sphere):
     p = pv.Plotter()
     actor = p.add_mesh(sphere, user_matrix=shear)
     np.testing.assert_almost_equal(actor.user_matrix, shear)
+
+    with pytest.raises(ValueError):
+        p.add_mesh(sphere, user_matrix=np.eye(5))
+
+    with pytest.raises(TypeError):
+        p.add_mesh(sphere, user_matrix='invalid')
 
 
 def test_scalar_bar_args_unmodified_add_mesh(sphere):


### PR DESCRIPTION
### Overview

- Closes #4928 and #4929

This PR proposes moving the `user_matrix` property from the class `Actor` to the class `Prop3D` (parent of `Actor`) since this property is also useful for the class `Volume` that also inherits from `Prop3D`.

Also proposes a solution for #4929 by adding `user_matrix` argument to `add_mesh` and `add_volume` so the user matrix can be passed to the actor BEFORE adding the actor to the renderer and thus avoiding some visualisation issues.

This is very useful for volume rendering volumes with different affine matrices that can take the data from the voxel space to some other reference space without really resampling the data itself.


### Example code

```python
# Download a volumetric dataset
import pyvista as pv
from pyvista import examples
import numpy as np

# scaling
zoom = np.eye(4)
np.fill_diagonal(zoom[:3,:3], 4)

# translation 
translate = np.eye(4)
translate[:3, 3] = [2, 2, 0]

# rotation
rot = np.eye(4)
rot[1,1] = np.cos(-np.pi/4)
rot[2,2] = np.cos(-np.pi/4)
rot[1,2] = -np.sin(-np.pi/4)
rot[2,1] = np.sin(-np.pi/4)

# shear
shear = np.eye(4)
shear[0, 1] = -1

pl = pv.Plotter()
vol = examples.download_knee_full()

volume = pl.add_volume(vol, user_matrix=translate @ rot @ zoom @ shear, show_scalar_bar=False)
pl.show_grid()

pl.show()
```
![screenshot](https://github.com/pyvista/pyvista/assets/41338087/5e6fbc05-ded6-409f-bdab-0f8a7bd64945)

