### PR TITLE
Add `auto-approve.yml` to allow review request by bot

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,26 @@
+name: Approve PRs
+on:
+  workflow_dispatch:
+  issue_comment:                                     
+    types: [created, edited]
+
+env:
+  # sintax: ("tkoyama010" "author2")
+  ALLOWED_AUTHORS: ("tkoyama010")
+
+jobs:
+  autoapprove:
+    # This job only runs for pull request comments
+    name: PR comment
+    if: ${{ github.event.issue.pull_request }}
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/auto-approve-action@v3
+        if: |
+          contains(github.event.comment.body, 'LGTM') && contains(env.ALLOWED_AUTHORS, github.event.comment.user.login)
+        with:
+          review-message: ":white_check_mark: Approving this PR because [${{ github.event.comment.user.login }}](https://github.com/${{ github.event.comment.user.login }}) said so in [here](${{ github.event.comment.html_url }}) :grimacing:"
+          pull-request-number: ${{ github.event.issue.number }}
+          github-token: ${{ secrets.PYVISTA_BOT_TOKEN }}


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

I apologize for the burden I have recently placed on other maintainers with my PullRequest reviews. I do not have the authority to merge into main without approval by review and I believe that should continue to be the case. However, if other maintainers are unable to review for an extended period of time, I request that the project allow approval by the bot so that development is not stalled.

This is a proven method used by https://github.com/ansys/pymapdl.

- https://github.com/ansys/pymapdl/blob/main/.github/workflows/approver.yml

By this GitHub Actions, an approved maintainer who makes a comment with "LGTM" and the bot approves it.
Of course, this is a last resort, as I recognize that the best way to improve quality is to have it reviewed by a human maintainer.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- [ ] Test that it works correctly after merging.
