### PR TITLE
Perform Render after Zoom event in default interactor key events

### DIFF
--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -2058,11 +2058,20 @@ class BasePlotter(PickingHelper, WidgetHelper):
         b_left_down_callback = lambda: self.iren.add_observer(
             'LeftButtonPressEvent', self.left_button_down
         )
+
+        def zoom_in():  # numpydoc ignore=GL08
+            self.camera.Zoom(1.05)
+            self.render()
+
+        def zoom_out():  # numpydoc ignore=GL08
+            self.camera.Zoom(0.95)
+            self.render()
+
         self.add_key_event('b', b_left_down_callback)
         self.add_key_event('v', lambda: self.isometric_view_interactive())
         self.add_key_event('C', lambda: self.enable_cell_picking())
-        self.add_key_event('Up', lambda: self.camera.Zoom(1.05))
-        self.add_key_event('Down', lambda: self.camera.Zoom(0.95))
+        self.add_key_event('Up', lambda: zoom_in())
+        self.add_key_event('Down', lambda: zoom_out())
         self.add_key_event('plus', lambda: self.increment_point_size_and_line_width(1))
         self.add_key_event('minus', lambda: self.increment_point_size_and_line_width(-1))
 

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -2059,19 +2059,27 @@ class BasePlotter(PickingHelper, WidgetHelper):
             'LeftButtonPressEvent', self.left_button_down
         )
 
-        def zoom_in():  # numpydoc ignore=GL08
-            self.camera.zoom(1.05)
+        def zoom(self, value):
+        """Set the zoom of the camera and render.
+
+        Parameters
+        ----------
+        value : float or str
+            Zoom of the camera. If a float, must be greater than 0. Otherwise,
+            if a string, must be ``"tight"``. If tight, the plot will be zoomed
+            such that the actors fill the entire viewport.
+            self.camera.zoom(value)
             self.render()
 
-        def zoom_out():  # numpydoc ignore=GL08
-            self.camera.zoom(0.95)
-            self.render()
+        """
+        self.camera.zoom(value)
+        self.render()
 
         self.add_key_event('b', b_left_down_callback)
         self.add_key_event('v', lambda: self.isometric_view_interactive())
         self.add_key_event('C', lambda: self.enable_cell_picking())
-        self.add_key_event('Up', lambda: zoom_in())
-        self.add_key_event('Down', lambda: zoom_out())
+        self.add_key_event('Up', lambda: self.zoom(1.05))
+        self.add_key_event('Down', lambda: self.zoom(0.95))
         self.add_key_event('plus', lambda: self.increment_point_size_and_line_width(1))
         self.add_key_event('minus', lambda: self.increment_point_size_and_line_width(-1))
 

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -2068,8 +2068,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Zoom of the camera. If a float, must be greater than 0. Otherwise,
             if a string, must be ``"tight"``. If tight, the plot will be zoomed
             such that the actors fill the entire viewport.
-            self.camera.zoom(value)
-            self.render()
 
         """
         self.camera.zoom(value)

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -2072,7 +2072,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         b_left_down_callback = lambda: self.iren.add_observer(
             'LeftButtonPressEvent', self.left_button_down
         )
-
         self.add_key_event('b', b_left_down_callback)
         self.add_key_event('v', lambda: self.isometric_view_interactive())
         self.add_key_event('C', lambda: self.enable_cell_picking())

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -2060,6 +2060,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         """
         self.camera.zoom(value)
         self.render()
+        return
 
     def reset_key_events(self):
         """Reset all of the key press events to their defaults."""

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -2047,19 +2047,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.render()
         return
 
-    def reset_key_events(self):
-        """Reset all of the key press events to their defaults."""
-        if not hasattr(self, 'iren'):
-            return
-
-        self.iren.clear_key_event_callbacks()
-
-        self.add_key_event('q', self._prep_for_close)  # Add no matter what
-        b_left_down_callback = lambda: self.iren.add_observer(
-            'LeftButtonPressEvent', self.left_button_down
-        )
-
-        def zoom(self, value):
+    def zoom(self, value):
         """Set the zoom of the camera and render.
 
         Parameters
@@ -2072,6 +2060,18 @@ class BasePlotter(PickingHelper, WidgetHelper):
         """
         self.camera.zoom(value)
         self.render()
+
+    def reset_key_events(self):
+        """Reset all of the key press events to their defaults."""
+        if not hasattr(self, 'iren'):
+            return
+
+        self.iren.clear_key_event_callbacks()
+
+        self.add_key_event('q', self._prep_for_close)  # Add no matter what
+        b_left_down_callback = lambda: self.iren.add_observer(
+            'LeftButtonPressEvent', self.left_button_down
+        )
 
         self.add_key_event('b', b_left_down_callback)
         self.add_key_event('v', lambda: self.isometric_view_interactive())

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -2060,11 +2060,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         )
 
         def zoom_in():  # numpydoc ignore=GL08
-            self.camera.Zoom(1.05)
+            self.camera.zoom(1.05)
             self.render()
 
         def zoom_out():  # numpydoc ignore=GL08
-            self.camera.Zoom(0.95)
+            self.camera.zoom(0.95)
             self.render()
 
         self.add_key_event('b', b_left_down_callback)

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -2047,8 +2047,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.render()
         return
 
-    def zoom(self, value):
-        """Set the zoom of the camera and render.
+    def zoom_camera(self, value):
+        """Zoom of the camera and render.
 
         Parameters
         ----------
@@ -2076,8 +2076,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.add_key_event('b', b_left_down_callback)
         self.add_key_event('v', lambda: self.isometric_view_interactive())
         self.add_key_event('C', lambda: self.enable_cell_picking())
-        self.add_key_event('Up', lambda: self.zoom(1.05))
-        self.add_key_event('Down', lambda: self.zoom(0.95))
+        self.add_key_event('Up', lambda: self.zoom_camera(1.05))
+        self.add_key_event('Down', lambda: self.zoom_camera(0.95))
         self.add_key_event('plus', lambda: self.increment_point_size_and_line_width(1))
         self.add_key_event('minus', lambda: self.increment_point_size_and_line_width(-1))
 

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -427,10 +427,10 @@ def test_plotter_add_floor_raise_error():
         pl.add_floor(face='invalid')
 
 
-def test_plotter_zoom():
+def test_plotter_zoom_camera():
     pl = pv.Plotter()
-    pl.zoom(1.05)
-    pl.zoom(0.95)
+    pl.zoom_camera(1.05)
+    pl.zoom_camera(0.95)
 
 
 def test_plotter_reset_key_events():

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -428,5 +428,11 @@ def test_plotter_add_floor_raise_error():
 
 
 def test_plotter_reset_key_events():
+    pl = pv.Plotter
+    pl.zoom(1.05)
+    pl.zoom(0.95)
+
+
+def test_plotter_reset_key_events():
     pl = pv.Plotter()
     pl.reset_key_events()

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -427,7 +427,7 @@ def test_plotter_add_floor_raise_error():
         pl.add_floor(face='invalid')
 
 
-def test_plotter_reset_key_events():
+def test_plotter_zoom():
     pl = pv.Plotter()
     pl.zoom(1.05)
     pl.zoom(0.95)

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -428,7 +428,7 @@ def test_plotter_add_floor_raise_error():
 
 
 def test_plotter_reset_key_events():
-    pl = pv.Plotter
+    pl = pv.Plotter()
     pl.zoom(1.05)
     pl.zoom(0.95)
 

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -430,7 +430,6 @@ def test_plotter_add_floor_raise_error():
 def test_plotter_zoom_camera():
     pl = pv.Plotter()
     pl.zoom_camera(1.05)
-    pl.zoom_camera(0.95)
 
 
 def test_plotter_reset_key_events():

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -425,3 +425,7 @@ def test_plotter_add_floor_raise_error():
     pl = pv.Plotter()
     with pytest.raises(NotImplementedError, match='not implemented'):
         pl.add_floor(face='invalid')
+
+def test_plotter_reset_key_events():
+    pl = pv.Plotter()
+    pl.reset_key_events()

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -426,6 +426,7 @@ def test_plotter_add_floor_raise_error():
     with pytest.raises(NotImplementedError, match='not implemented'):
         pl.add_floor(face='invalid')
 
+
 def test_plotter_reset_key_events():
     pl = pv.Plotter()
     pl.reset_key_events()


### PR DESCRIPTION
### Overview
Based on the [documentation](https://docs.pyvista.org/version/stable/api/plotting/plotting.html) the up/down keys should zoom in/out the view however this does not work as expected. You can verify the issue by pressing "up" for any of the examples.

### Details
Previously the default bindings of the up/down keys wouldn't render the scene and thus the zoomed scene is not visible until another event or interaction causes a render.

The missing part is that the keypress should also trigger a render and this is what this pull request does.
