### PR TITLE
Add `check-docstring-first` and `end-of-file-fixer` in `pre-commit-hooks`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
     exclude: ^(|pyvista/examples/.*\.ply|pyvista/examples/.*\.vtk)
   - id: check-docstring-first
   - id: end-of-file-fixer
-    exclude_types: [vtk]
+    exclude_types: ["vtk"]
   - id: mixed-line-ending
 
 # this validates our github workflow files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
     exclude: ^(|pyvista/examples/.*\.ply|pyvista/examples/.*\.vtk)
   - id: check-docstring-first
   - id: end-of-file-fixer
-    exclude_types: ["vtk"]
+    exclude: ^(|pyvista/examples/.*\.ply|pyvista/examples/.*\.vtk)
   - id: mixed-line-ending
 
 # this validates our github workflow files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,6 +96,7 @@ repos:
     exclude: ^(|pyvista/examples/.*\.ply|pyvista/examples/.*\.vtk)
   - id: check-docstring-first
   - id: end-of-file-fixer
+    exclude_types: [vtk]
 
 # this validates our github workflow files
 - repo: https://github.com/python-jsonschema/check-jsonschema

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,7 @@ repos:
   - id: requirements-txt-fixer
   - id: trailing-whitespace
     exclude: ^(|pyvista/examples/.*\.ply|pyvista/examples/.*\.vtk)
+  - id: check-docstring-first
 
 # this validates our github workflow files
 - repo: https://github.com/python-jsonschema/check-jsonschema

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,6 +95,7 @@ repos:
   - id: trailing-whitespace
     exclude: ^(|pyvista/examples/.*\.ply|pyvista/examples/.*\.vtk)
   - id: check-docstring-first
+  - id: end-of-file-fixer
 
 # this validates our github workflow files
 - repo: https://github.com/python-jsonschema/check-jsonschema

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,6 +97,7 @@ repos:
   - id: check-docstring-first
   - id: end-of-file-fixer
     exclude_types: [vtk]
+  - id: mixed-line-ending
 
 # this validates our github workflow files
 - repo: https://github.com/python-jsonschema/check-jsonschema


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Add `check-docstring-first` and `end-of-file-fixer` in pre-commit-hooks.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None
