### PR TITLE
Use `itertools.product` to avoid nested loops in `renderers.py`

### DIFF
--- a/pyvista/plotting/renderers.py
+++ b/pyvista/plotting/renderers.py
@@ -1,6 +1,6 @@
 """Organize Renderers for ``pyvista.Plotter``."""
 import collections
-import itertools
+from itertools import product
 from weakref import proxy
 
 import numpy as np
@@ -180,7 +180,7 @@ class Renderers:
                     # and bottom right corner from the given rows and cols
                     norm_group = [np.min(rows), np.min(cols), np.max(rows), np.max(cols)]
                     # Check for overlap with already defined groups:
-                    for i, j in itertools.product(
+                    for i, j in product(
                         range(norm_group[0], norm_group[2] + 1),
                         range(norm_group[1], norm_group[3] + 1),
                     ):
@@ -192,7 +192,7 @@ class Renderers:
                         (self.groups, np.array([norm_group], dtype=int)), axis=0
                     )
             # Create subplot renderers
-            for row, col in itertools.product(range(shape[0]), range(shape[1])):
+            for row, col in product(range(shape[0]), range(shape[1])):
                 group = self.loc_to_group((row, col))
                 nb_rows = None
                 nb_cols = None

--- a/pyvista/trame/ui/base_viewer.py
+++ b/pyvista/trame/ui/base_viewer.py
@@ -6,6 +6,7 @@ This base class does not define a `ui` method, but its derived classes do.
 See `pyvista.trame.ui.vuetify2` and ``pyvista.trame.ui.vuetify3` for its derived classes.
 """
 import io
+import itertools
 
 from trame.app import get_server
 from trame.widgets import html
@@ -149,10 +150,9 @@ class BaseViewer:
 
         """
         value = kwargs[self.EDGES]
-        for renderer in self.plotter.renderers:
-            for _, actor in renderer.actors.items():
-                if isinstance(actor, pyvista.Actor):
-                    actor.prop.show_edges = value
+        for renderer, _, actor in itertools.product(self.plotter.renderers, renderer.actors.items()):
+            if isinstance(actor, pyvista.Actor):
+                actor.prop.show_edges = value
         self.update()
 
     def on_grid_visiblity_change(self, **kwargs):

--- a/pyvista/trame/ui/base_viewer.py
+++ b/pyvista/trame/ui/base_viewer.py
@@ -6,7 +6,6 @@ This base class does not define a `ui` method, but its derived classes do.
 See `pyvista.trame.ui.vuetify2` and ``pyvista.trame.ui.vuetify3` for its derived classes.
 """
 import io
-import itertools
 
 from trame.app import get_server
 from trame.widgets import html
@@ -150,9 +149,10 @@ class BaseViewer:
 
         """
         value = kwargs[self.EDGES]
-        for renderer, _, actor in itertools.product(self.plotter.renderers, renderer.actors.items()):
-            if isinstance(actor, pyvista.Actor):
-                actor.prop.show_edges = value
+        for renderer in self.plotter.renderers:
+            for _, actor in renderer.actors.items():
+                if isinstance(actor, pyvista.Actor):
+                    actor.prop.show_edges = value
         self.update()
 
     def on_grid_visiblity_change(self, **kwargs):


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Use `itertools.product` to avoid nested loops.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- Ref https://github.com/pyvista/pyvista/pull/4965#discussion_r1339483871_ .
