### PR TITLE
Fix: CylinderSource orientation

### DIFF
--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -498,10 +498,7 @@ class CylinderSource(_vtk.vtkCylinderSource):
             Cylinder surface.
         """
         self.Update()
-        output = wrap(self.GetOutput())
-        output.rotate_z(-90, inplace=True)
-        translate(output, self.center, self.direction)
-        return output
+        return wrap(self.GetOutput())
 
 
 @no_new_attr

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -3331,7 +3331,17 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 raise TypeError(
                     f'Object type ({type(mesh)}) not supported for plotting in PyVista.'
                 )
-        if isinstance(mesh, pyvista.PointSet):
+        if isinstance(mesh, pyvista.PolyData):
+            mesh_points = mesh.points.copy()
+            angle = np.radians(90.0)
+            rotation_matrix = np.array([
+                [np.cos(angle), -np.sin(angle), 0],
+                [np.sin(angle), np.cos(angle), 0],
+                [0, 0, 1]
+            ])
+            rotated_points = np.dot(mesh_points, rotation_matrix)
+            mesh.points = rotated_points
+        elif isinstance(mesh, pyvista.PointSet):
             # cast to PointSet to PolyData
             if algo is not None:
                 algo = pointset_to_polydata_algorithm(algo)


### PR DESCRIPTION
### Overview

| cyl_source.output.plot() | pl.add_mesh(cyl_source) |
| -------------------------  | --------------------------  |
| ![image](https://github.com/pyvista/pyvista/assets/70969910/b1b7d804-541c-4467-9b11-5e3fe4478d48)  | ![image](https://github.com/pyvista/pyvista/assets/70969910/7e0533c5-7181-45d6-bea1-ce30daa021b8)  |

Resolves: #4956 


### Details

- Bug: Getting different result for `cyl_source = pv.CylinderSource()`, in these two cases `cyl_source.output.plot()` and `pl.add_mesh(cyl_source)`

However the current solution messes up the orientation of `ConeSource()` and `MultipleLinesSource`
| cone_source.output.plot() | pl.add_mesh(cone_source) |
| -------------------------  | --------------------------  |
| ![image](https://github.com/pyvista/pyvista/assets/70969910/aa2a0efe-30f9-46f4-8189-25d37bf19734) | ![image](https://github.com/pyvista/pyvista/assets/70969910/35f4db14-fee2-4674-8de4-f919c3c72428) |
