### PR TITLE
BUG: Give scraper a stable __repr__

### DIFF
--- a/pyvista/plotting/utilities/sphinx_gallery.py
+++ b/pyvista/plotting/utilities/sphinx_gallery.py
@@ -66,6 +66,10 @@ class Scraper:
 
     """
 
+    # Give it a stable __repr__
+    def __repr__(self):
+        return f"<{self.__class__.__name__}"
+
     def __call__(self, block, block_vars, gallery_conf):
         """Save the figures generated after running example code.
 


### PR DESCRIPTION
In MNE-Python I was getting doc rebuilds no matter what, turns out it's due to the PyVista scraper not having a stable `__repr__` build to build, e.g.  [here](https://sphinx-gallery.github.io/stable/advanced.html#example-1-a-matplotlib-style-scraper).