### PR TITLE
Fix the name of `cartesian_to_spherical` 's returns

### DIFF
--- a/pyvista/core/utilities/features.py
+++ b/pyvista/core/utilities/features.py
@@ -244,7 +244,7 @@ def cartesian_to_spherical(x, y, z):
     phi = np.arctan2(np.sqrt(xy2), z)  # the polar angle in radian angles
     theta = np.arctan2(y, x)  # the azimuth angle in radian angles
 
-    return r, theta, phi
+    return r, phi, theta
 
 
 def merge(

--- a/pyvista/core/utilities/features.py
+++ b/pyvista/core/utilities/features.py
@@ -222,11 +222,11 @@ def cartesian_to_spherical(x, y, z):
     r : numpy.ndarray
         Radial distance.
 
-    theta : numpy.ndarray
+    phi : numpy.ndarray
         Angle (radians) with respect to the polar axis. Also known
         as polar angle.
 
-    phi : numpy.ndarray
+    theta : numpy.ndarray
         Angle (radians) of rotation from the initial meridian plane.
         Also known as azimuthal angle.
 
@@ -236,13 +236,13 @@ def cartesian_to_spherical(x, y, z):
     >>> import pyvista as pv
     >>> grid = pv.ImageData(dimensions=(3, 3, 3))
     >>> x, y, z = grid.points.T
-    >>> r, theta, phi = pv.cartesian_to_spherical(x, y, z)
+    >>> r, phi, theta = pv.cartesian_to_spherical(x, y, z)
 
     """
     xy2 = x**2 + y**2
     r = np.sqrt(xy2 + z**2)
-    theta = np.arctan2(np.sqrt(xy2), z)  # the polar angle in radian angles
-    phi = np.arctan2(y, x)  # the azimuth angle in radian angles
+    phi = np.arctan2(np.sqrt(xy2), z)  # the polar angle in radian angles
+    theta = np.arctan2(y, x)  # the azimuth angle in radian angles
 
     return r, theta, phi
 

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -747,15 +747,15 @@ def test_copy_vtk_array():
 
 
 def test_cartesian_to_spherical():
-    def polar2cart(r, theta, phi):
+    def polar2cart(r, phi, theta):
         return np.vstack(
-            (r * np.sin(theta) * np.cos(phi), r * np.sin(theta) * np.sin(phi), r * np.cos(theta))
+            (r * np.sin(phi) * np.cos(theta), r * np.sin(phi) * np.sin(theta), r * np.cos(phi))
         ).T
 
     points = np.random.random((1000, 3))
     x, y, z = points.T
-    r, theta, phi = pv.cartesian_to_spherical(x, y, z)
-    assert np.allclose(polar2cart(r, theta, phi), points)
+    r, phi, theta = pv.cartesian_to_spherical(x, y, z)
+    assert np.allclose(polar2cart(r, phi, theta), points)
 
 
 def test_set_pickle_format():


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Fix the name of `cartesian_to_spherical` 's parameters.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- This is the follow-up PR of #5003 .
- Switch `theta` and `phi`. Following https://vtk.org/doc/nightly/html/classvtkSphericalTransform.html#details.

