### PR TITLE
Fix module `vtkImageDilateErode3D` not found error

### DIFF
--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -383,7 +383,11 @@ from vtkmodules.vtkImagingCore import (
 )
 from vtkmodules.vtkImagingGeneral import vtkImageGaussianSmooth, vtkImageMedian3D
 from vtkmodules.vtkImagingHybrid import vtkSampleFunction, vtkSurfaceReconstructionFilter
-from vtkmodules.vtkImagingMorphological import vtkImageDilateErode3D
+
+try:
+    from vtkmodules.vtkImagingMorphological import vtkImageDilateErode3D
+except ImportError:  # pragma: no cover
+    pass
 
 try:
     from vtkmodules.vtkPythonContext2D import vtkPythonItem


### PR DESCRIPTION
### Overview

As stated by @banesullivan

> This sounds like an incompatibility with conda-forge's 9.0 VTK build. We need to handle vtkImageDilateErode3D's import with caution. Unfortunately, at this time, our testing matrix for VTK versions only validates the official wheels on PyPI.

We can gracefully handle this error.

Resolves: #4815 


### Details

- Bug: Module `vtkImageDilateErode3D` not found error on remote servers.