### PR TITLE
Set `Google.Spacing` NO in `.vale.ini`

### DIFF
--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -21,6 +21,7 @@ BasedOnStyles = Vale, Google
 # Ignoring Google-specific rules - Not applicable under some circumstances
 Google.WordList = NO
 Google.Colons = NO
+Google.Spacing = NO
 
 # ignore Jinja placeholders
 TokenIgnores = (?s){(.+?)}

--- a/doc/source/user-guide/data_model.rst
+++ b/doc/source/user-guide/data_model.rst
@@ -98,7 +98,7 @@ floats can describe the shape, so it takes the least amount of memory
 to store.
 
 This is because in |PolyData| or
-|UnstructuredGrid|, points and cells must be explicitly
+|UnstructuredGrid|, points, and cells must be explicitly
 defined. In other data types, such as |ImageData|,
 the cells (and even points) are defined as an emergent property based
 on the dimensionality of the grid.


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
To skip the error like following.
```bash
{"message": "[Google.Spacing] 'a.M' should have one space.", "location": {"path": "doc/source/api/plotting/index.rst", "range": {"start": {"line": 52, "column": 52}}}, "severity": "ERROR"}
```

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None
