### PR TITLE
Trigger Pull Request Labeler after approved review

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,10 +1,11 @@
 name: "Pull Request Labeler"
 on:
-  pull_request_target:
-    types: [opened, reopened]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   triage:
+    if: github.event.review.state == 'approved'
     runs-on: ubuntu-20.04
     steps:
     - name: Label based on changed files


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Trigger Pull Request Labeler after approved review.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- Remove `pull_request_target` considering risk (See [Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)).
- Follow-up of #5024.


