### PR TITLE
Add examples for widgets methods

### DIFF
--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -662,7 +662,7 @@ class WidgetHelper:
         >>> vol = examples.load_airplane()
         >>> pl = pv.Plotter()
         >>> pl.add_mesh_clip_plane(vol, normal=[0, -1, 0])
-        >>> pl.show(cpos=[-2.1, 0.6 , 1.5])
+        >>> pl.show(cpos=[-2.1, 0.6, 1.5])
         >>> pl.plane_clipped_meshes  # doctest:+SKIP
 
         For a full example see :ref:`plane_widget_example`.

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -661,7 +661,7 @@ class WidgetHelper:
         >>> from pyvista import examples
         >>> vol = examples.load_airplane()
         >>> pl = pv.Plotter()
-        >>> pl.add_mesh_clip_plane(vol, normal=[0, -1, 0])
+        >>> _ = pl.add_mesh_clip_plane(vol, normal=[0, -1, 0])
         >>> pl.show(cpos=[-2.1, 0.6, 1.5])
         >>> pl.plane_clipped_meshes  # doctest:+SKIP
 
@@ -946,8 +946,8 @@ class WidgetHelper:
         >>> from pyvista import examples
         >>> pl = pv.Plotter()
         >>> mesh = examples.load_channels()
-        >>> pl.add_mesh(mesh.outline())
-        >>> pl.add_mesh_slice(mesh, normal=[1, 0, 0.3])
+        >>> _ = pl.add_mesh(mesh.outline())
+        >>> _ = pl.add_mesh_slice(mesh, normal=[1, 0, 0.3])
         >>> pl.show()
 
         For a full example see :ref:`plane_widget_example`.
@@ -1054,8 +1054,8 @@ class WidgetHelper:
         >>> import pyvista as pv
         >>> pl = pv.Plotter()
         >>> mesh = pv.Wavelet()
-        >>> pl.add_mesh(mesh.outline())
-        >>> pl.add_mesh_slice_orthogonal(mesh)
+        >>> _ = pl.add_mesh(mesh.outline())
+        >>> _ = pl.add_mesh_slice_orthogonal(mesh)
         >>> pl.show()
 
         """
@@ -1755,8 +1755,8 @@ class WidgetHelper:
         >>> from pyvista import examples
         >>> pl = pv.Plotter()
         >>> mesh = examples.load_random_hills()
-        >>> pl.add_mesh(mesh, opacity=0.4)
-        >>> pl.add_mesh_isovalue(mesh)
+        >>> _ = pl.add_mesh(mesh, opacity=0.4)
+        >>> _ = pl.add_mesh_isovalue(mesh)
         >>> pl.show()
 
         """

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -156,7 +156,7 @@ class WidgetHelper:
         Examples
         --------
         Shows interactive box which is used to resize and relocate a sphere.
-        
+
         >>> import pyvista as pv
         >>> import numpy as np
         >>> plotter = pv.Plotter()
@@ -469,8 +469,8 @@ class WidgetHelper:
 
         Examples
         --------
-	    Shows an interactive plane moving along x-axis in random-hill example, which is used to mark the max altitude
-		at a particular distance x.
+        Shows an interactive plane moving along x-axis in random-hill example, which is used to mark the max altitude
+        at a particular distance x.
 
         >>> import pyvista as pv
         >>> from pyvista import examples
@@ -1192,9 +1192,9 @@ class WidgetHelper:
         vtk.vtkLineWidget
             Created line widget.
 
-	Examples
-	--------
-	Shows an interactive line widget to move the sliced object like in `add_mesh_slice` function.
+        Examples
+        --------
+        Shows an interactive line widget to move the sliced object like in `add_mesh_slice` function.
 
         >>> import pyvista as pv
         >>> from pyvista import examples

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -653,6 +653,18 @@ class WidgetHelper:
         vtk.vtkActor
             VTK actor of the mesh.
 
+        Examples
+        --------
+        Shows an interactive plane used to clip the mesh and store it.
+
+        >>> import pyvista as pv
+        >>> from pyvista import examples
+        >>> vol = examples.load_airplane()
+        >>> pl = pv.Plotter()
+        >>> pl.add_mesh_clip_plane(vol, normal=[0, -1, 0])
+        >>> pl.show(cpos=[-2.1, 0.6 , 1.5])
+        >>> pl.plane_clipped_meshes  # doctest:+SKIP
+
         """
         from pyvista.core.filters import _get_output  # avoids circular import
 
@@ -924,6 +936,18 @@ class WidgetHelper:
         vtk.vtkActor
             VTK actor of the mesh.
 
+        Examples
+        --------
+        Shows an interactive plane used specifically for slicing.
+
+        >>> import pyvista as pv
+        >>> from pyvista import examples
+        >>> pl = pv.Plotter()
+        >>> mesh = examples.load_channels()
+        >>> pl.add_mesh(mesh.outline())
+        >>> pl.add_mesh_slice(mesh, normal=[1, 0, 0.3])
+        >>> pl.show()
+
         """
         mesh, algo = algorithm_to_mesh_handler(mesh)
 
@@ -1018,6 +1042,17 @@ class WidgetHelper:
         -------
         list
             List of vtk.vtkActor(s).
+
+        Examples
+        --------
+        Shows an interactive plane sliced along each cartesian axis of the mesh.
+
+        >>> import pyvista as pv
+        >>> pl = pv.Plotter()
+        >>> mesh = pv.Wavelet()
+        >>> pl.add_mesh(mesh.outline())
+        >>> pl.add_mesh_slice_orthogonal(mesh)
+        >>> pl.show()
 
         """
         actors = []
@@ -1707,6 +1742,18 @@ class WidgetHelper:
         -------
         vtk.vtkActor
             VTK actor of the mesh.
+
+        Examples
+        --------
+        Shows an interactive slider controlling the altitude of the contours.
+
+        >>> import pyvista as pv
+        >>> from pyvista import examples
+        >>> pl = pv.Plotter()
+        >>> mesh = examples.load_random_hills()
+        >>> pl.add_mesh(mesh, opacity=0.4)
+        >>> pl.add_mesh_isovalue(mesh)
+        >>> pl.show()
 
         """
         mesh, algo = algorithm_to_mesh_handler(mesh)

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -467,6 +467,33 @@ class WidgetHelper:
         vtk.vtkImplicitPlaneWidget or vtk.vtkPlaneWidget
             Plane widget.
 
+        Examples
+        --------
+	    Shows an interactive plane moving along x-axis in random-hill example, which is used to mark the max altitude
+		at a particular distance x.
+
+        >>> import pyvista as pv
+        >>> from pyvista import examples
+        >>> mesh = examples.load_random_hills()
+        >>> pl = pv.Plotter()
+        >>> _ = pl.add_mesh(mesh)
+        >>> def callback(normal, origin):
+        ...     slc = mesh.slice(normal=normal, origin=origin)
+        ...     origin = list(origin)
+        ...     origin[2] = slc.bounds[5]
+        ...     peak_plane = pv.Plane(
+        ...         center=origin,
+        ...         direction=[0, 0, 1],
+        ...         i_size=20,
+        ...         j_size=20,
+        ...     )
+        ...     _ = pl.add_mesh(
+        ...         peak_plane, name="Peak", color='red', opacity=0.4
+        ...     )
+        ...
+        >>> _ = pl.add_plane_widget(callback, normal_rotation=False)
+        >>> pl.show()
+
         """
         interaction_event = _parse_interaction_event(interaction_event)
 

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -153,6 +153,36 @@ class WidgetHelper:
         vtk.vtkBoxWidget
             Box widget.
 
+        Examples
+        --------
+        Shows interactive box which is used to resize and relocate a sphere.
+        
+        >>> import pyvista as pv
+        >>> import numpy as np
+        >>> plotter = pv.Plotter()
+        >>> def simulate(widget):
+        ...     bounds = widget.bounds
+        ...     new_center = np.array(
+        ...         [
+        ...             (bounds[0] + bounds[1]) / 2,
+        ...             (bounds[2] + bounds[3]) / 2,
+        ...             (bounds[4] + bounds[5]) / 2,
+        ...         ]
+        ...     )
+        ...     new_radius = (
+        ...         min(
+        ...             (bounds[1] - bounds[0]) / 2,
+        ...             (bounds[3] - bounds[2]) / 2,
+        ...             (bounds[5] - bounds[4]) / 2,
+        ...         )
+        ...         - 0.3
+        ...     )
+        ...     sphere = pv.Sphere(new_radius, new_center)
+        ...     _ = plotter.add_mesh(sphere, name="Sphere")
+        ...
+        >>> _ = plotter.add_box_widget(callback=simulate)
+        >>> plotter.show()
+
         """
         interaction_event = _parse_interaction_event(interaction_event)
 
@@ -1134,6 +1164,26 @@ class WidgetHelper:
         -------
         vtk.vtkLineWidget
             Created line widget.
+
+		Examples
+		________
+		Shows an interactive line widget to move the sliced object like in `add_mesh_slice` function.
+
+        >>> import pyvista as pv
+        >>> from pyvista import examples
+        >>> import numpy as np
+        >>> model = examples.load_channels()
+        >>> pl = pv.Plotter()
+        >>> _ = pl.add_mesh(model, opacity=0.4)
+        >>> def move_center(pointa, pointb):
+        ...     center = (np.array(pointa) + np.array(pointb)) / 2
+        ...     normal = np.array(pointa) - np.array(pointb)
+        ...     single_slc = model.slice(normal=normal, origin=center)
+        ...
+        ...     _ = pl.add_mesh(single_slc, name="slc")
+        ...
+        >>> _ = pl.add_line_widget(callback=move_center, use_vertices=True)
+        >>> pl.show()
 
         """
         if bounds is None:

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -153,18 +153,6 @@ class WidgetHelper:
         vtk.vtkBoxWidget
             Box widget.
 
-        Examples
-        --------
-        Shows an interactive clip box.
-
-        >>> import pyvista as pv
-        >>> mesh = pv.ParametricConicSpiral()
-        >>> pl = pv.Plotter()
-        >>> _ = pl.add_mesh_clip_box(mesh, color='white')
-        >>> pl.show()
-
-        For a full example see :ref:`box_widget_example`.
-
         """
         interaction_event = _parse_interaction_event(interaction_event)
 
@@ -278,6 +266,18 @@ class WidgetHelper:
         -------
         vtk.vtkActor
             VTK actor of the mesh.
+
+        Examples
+        --------
+        Shows an interactive clip box.
+
+        >>> import pyvista as pv
+        >>> mesh = pv.ParametricConicSpiral()
+        >>> pl = pv.Plotter()
+        >>> _ = pl.add_mesh_clip_box(mesh, color='white')
+        >>> pl.show()
+
+        For a full example see :ref:`box_widget_example`.
 
         """
         from pyvista.core.filters import _get_output  # avoids circular import

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -665,6 +665,8 @@ class WidgetHelper:
         >>> pl.show(cpos=[-2.1, 0.6 , 1.5])
         >>> pl.plane_clipped_meshes  # doctest:+SKIP
 
+        For a full example see :ref:`plane_widget_example`.
+
         """
         from pyvista.core.filters import _get_output  # avoids circular import
 
@@ -947,6 +949,8 @@ class WidgetHelper:
         >>> pl.add_mesh(mesh.outline())
         >>> pl.add_mesh_slice(mesh, normal=[1, 0, 0.3])
         >>> pl.show()
+
+        For a full example see :ref:`plane_widget_example`.
 
         """
         mesh, algo = algorithm_to_mesh_handler(mesh)

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1192,9 +1192,9 @@ class WidgetHelper:
         vtk.vtkLineWidget
             Created line widget.
 
-		Examples
-		________
-		Shows an interactive line widget to move the sliced object like in `add_mesh_slice` function.
+	Examples
+	--------
+	Shows an interactive line widget to move the sliced object like in `add_mesh_slice` function.
 
         >>> import pyvista as pv
         >>> from pyvista import examples

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -155,7 +155,7 @@ class WidgetHelper:
 
         Examples
         --------
-        Shows interactive box which is used to resize and relocate a sphere.
+        Shows an interactive box that is used to resize and relocate a sphere.
 
         >>> import pyvista as pv
         >>> import numpy as np
@@ -469,7 +469,7 @@ class WidgetHelper:
 
         Examples
         --------
-        Shows an interactive plane moving along x-axis in random-hill example, which is used to mark the max altitude
+        Shows an interactive plane moving along the x-axis in the random-hill example, which is used to mark the max altitude
         at a particular distance x.
 
         >>> import pyvista as pv


### PR DESCRIPTION
### Overview

Add minimal but informative, examples for different functions in `widgets.py` as referenced in #1629.

Also fixed an existing mismatch in examples.

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

The examples were added to the following functions in `widgets.py` file:

- `add_mesh_clip_box`
- `add_mesh_clip_plane`
- `add_mesh_clip_isovalue`
- `add_mesh_slice`
- `add_mesh_slice_orthogonal`

The example in function `add_box_widget`, doesn't explicitly use the function, instead uses the `add_mesh_clip_box`, but in my opinion it deserves its own example. So, I have moved the example under `add_box_widget` into `add_mesh_clip_box`.
