### PR TITLE
Add a Professional Support section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -270,3 +270,21 @@ BibTex:
       title = {{PyVista}: {3D} plotting and mesh analysis through a streamlined interface for the {Visualization Toolkit} ({VTK})},
       journal = {Journal of Open Source Software}
     }
+
+Professional Support
+====================
+
+While PyVista is an Open Source project with a big community, you might be looking for professional support.
+This section aims to list companies with VTK/PyVista expertise who can help you with your software project.
+
++---------------+-----------------------------------------+
+| Company Name  | Kitware Inc.                            |
++---------------+-----------------------------------------+
+| Description   | Kitware is dedicated to build solutions |
+|               | for our customers based on our          |
+|               | well-established open source platforms. |
++---------------+-----------------------------------------+
+| Expertise     | CMake, VTK, PyVista, ParaView, Trame    |
++---------------+-----------------------------------------+
+| Contact       | https://www.kitware.com/contact/        |
++---------------+-----------------------------------------+

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -286,3 +286,22 @@ Project Index
 *************
 
 * :ref:`genindex`
+
+
+Professional Support
+********************
+
+While PyVista is an Open Source project with a big community, you might be looking for professional support.
+This section aims to list companies with VTK/PyVista expertise who can help you with your software project.
+
++---------------+-----------------------------------------+
+| Company Name  | Kitware Inc.                            |
++---------------+-----------------------------------------+
+| Description   | Kitware is dedicated to build solutions |
+|               | for our customers based on our          |
+|               | well-established open source platforms. |
++---------------+-----------------------------------------+
+| Expertise     | CMake, VTK, PyVista, ParaView, Trame    |
++---------------+-----------------------------------------+
+| Contact       | https://www.kitware.com/contact/        |
++---------------+-----------------------------------------+


### PR DESCRIPTION
### Overview (doc)

This contribution aims to list contact information of companies who could provide support around PyVista.
So far, I've only listed Kitware, but ideally, that list could grow.

Adding a __Professional Support__ section at the bottom of the README and doc landing page. 
