### PR TITLE
Fix bug with actor removal rendering

### DIFF
--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -2351,7 +2351,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
                 if k.startswith(f'{name}-'):
                     names.append(k)
             if len(names) > 0:
-                self.remove_actor(names, reset_camera=reset_camera)
+                self.remove_actor(names, reset_camera=reset_camera, render=render)
             try:
                 actor = self._actors[name]
             except KeyError:
@@ -2360,7 +2360,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         if isinstance(actor, collections.abc.Iterable):
             success = False
             for a in actor:
-                rv = self.remove_actor(a, reset_camera=reset_camera)
+                rv = self.remove_actor(a, reset_camera=reset_camera, render=render)
                 if rv or success:
                     success = True
             return success


### PR DESCRIPTION
`render=render` must be passed when string lookup or iterable is used. Noticed this when I removed a few hundred actors... and it rendered after every one, making it take a few seconds rather than being very quick.
