### PR TITLE
Fix testing warnings in tests/core

### DIFF
--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -3087,10 +3087,10 @@ def test_extract_cells_by_type(tetbeam, hexbeam):
     combined = tetbeam + hexbeam
 
     hex_cells = combined.extract_cells_by_type([pv.CellType.HEXAHEDRON, pv.CellType.BEZIER_PYRAMID])
-    assert np.alltrue(hex_cells.celltypes == pv.CellType.HEXAHEDRON)
+    assert np.all(hex_cells.celltypes == pv.CellType.HEXAHEDRON)
 
     tet_cells = combined.extract_cells_by_type(pv.CellType.TETRA)
-    assert np.alltrue(tet_cells.celltypes == pv.CellType.TETRA)
+    assert np.all(tet_cells.celltypes == pv.CellType.TETRA)
 
     should_be_empty = combined.extract_cells_by_type(pv.CellType.BEZIER_CURVE)
     assert should_be_empty.n_cells == 0

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -36,7 +36,7 @@ def test_wrap_pyvista_ndarray(sphere):
 )
 def test_wrap_pyvista_ndarray_vtk(dtypes):
     np_dtype, vtk_class = dtypes
-    np_array = np.array([[0, 10, 20], [-10, -200, 0], [0.5, 0.667, 0]], dtype=np_dtype)
+    np_array = np.array([[0, 10, 20], [-10, -200, 0], [0.5, 0.667, 0]]).astype(np_dtype)
 
     vtk_array = vtk_class()
     vtk_array.SetNumberOfComponents(3)

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -490,7 +490,8 @@ def test_save(sphere, extension, binary, tmpdir):
 
     if binary:
         if extension == '.vtp':
-            assert 'binary' in open(filename).read(1000)
+            with open(filename) as f:
+                assert 'binary' in f.read(1000)
         else:
             is_binary(filename)
     else:


### PR DESCRIPTION
### Overview

Fixes warnings that arise from running `pytest -Wd tests/core`.  As an aside, we should probably use this in our CI to pick up DeprecationWarnings and address them as needed.

### Details
Before changes (warnings not affected by changes snipped from end of list):

```
tests/core/test_dataset_filters.py::test_extract_cells_by_type
  /usr/local/py-utils/venvs/pytest/lib/python3.11/site-packages/_pytest/python.py:194: DeprecationWarning: `alltrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `all` instead.
    result = testfunction(**testargs)

tests/core/test_helpers.py::test_wrap_pyvista_ndarray_vtk[dtypes4]
  /workspaces/pyvista/tests/core/test_helpers.py:39: DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of -200 to int8 will fail in the future.
  For the old behavior, usually:
      np.array(value).astype(dtype)
  will give the desired result (the cast overflows).
    np_array = np.array([[0, 10, 20], [-10, -200, 0], [0.5, 0.667, 0]], dtype=np_dtype)

tests/core/test_helpers.py::test_wrap_pyvista_ndarray_vtk[dtypes5]
  /workspaces/pyvista/tests/core/test_helpers.py:39: DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of -10 to uint8 will fail in the future.
  For the old behavior, usually:
      np.array(value).astype(dtype)
  will give the desired result (the cast overflows).
    np_array = np.array([[0, 10, 20], [-10, -200, 0], [0.5, 0.667, 0]], dtype=np_dtype)

tests/core/test_helpers.py::test_wrap_pyvista_ndarray_vtk[dtypes5]
  /workspaces/pyvista/tests/core/test_helpers.py:39: DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of -200 to uint8 will fail in the future.
  For the old behavior, usually:
      np.array(value).astype(dtype)
  will give the desired result (the cast overflows).
    np_array = np.array([[0, 10, 20], [-10, -200, 0], [0.5, 0.667, 0]], dtype=np_dtype)

tests/core/test_polydata.py::test_save[.vtp-True]
  /workspaces/pyvista/tests/core/test_polydata.py:493: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/pytest-of-vscode/pytest-0/test_save__vtp_True_0/tmpdir/tmp.vtp' mode='r' encoding='ANSI_X3.4-1968'>
    assert 'binary' in open(filename).read(1000)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

```

There are still these 4 warnings remaining, but they either seem like something we might not want to address (imageio warning) or come from another package (scooby).

```
tests/core/test_reader.py::test_try_imageio_imread
  /workspaces/pyvista/pyvista/core/utilities/fileio.py:744: DeprecationWarning: Starting with ImageIO v3 the behavior of this function will switch to that of iio.v3.imread. To keep the current behavior (and make this warning disappear) use `import imageio.v2 as imageio` or call `imageio.v2.imread` directly.
    return imread(filename)

tests/core/test_utilities.py::test_report
  /home/vscode/.local/lib/python3.11/site-packages/scooby/report.py:424: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import DistributionNotFound, get_distribution

tests/core/test_utilities.py::test_report
  /usr/local/py-utils/shared/lib/python3.11/site-packages/pkg_resources/__init__.py:2871: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('mpl_toolkits')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

tests/core/test_utilities.py::test_report
  /usr/local/py-utils/shared/lib/python3.11/site-packages/pkg_resources/__init__.py:2871: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('sphinxcontrib')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

```


