### PR TITLE
Use `itertools.product` to avoid nested loops in `arrays.py`

### DIFF
--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -9,6 +9,7 @@ import pyvista as pv
 from pyvista.core import _vtk_core as _vtk
 from pyvista.core._typing_core import NumericArray, VectorArray
 from pyvista.core.errors import AmbiguousDataError, MissingDataError
+from itertools import product
 
 
 class FieldAssociation(enum.Enum):
@@ -610,9 +611,8 @@ def array_from_vtkmatrix(matrix):
             f' got {type(matrix).__name__} instead.'
         )
     array = np.zeros(shape)
-    for i in range(shape[0]):
-        for j in range(shape[1]):
-            array[i, j] = matrix.GetElement(i, j)
+    for i, j in product(range(shape[0]), range(shape[1])):
+        array[i, j] = matrix.GetElement(i, j)
     return array
 
 
@@ -640,9 +640,8 @@ def vtkmatrix_from_array(array):
     else:
         raise ValueError(f'Invalid shape {array.shape}, must be (3, 3) or (4, 4).')
     m, n = array.shape
-    for i in range(m):
-        for j in range(n):
-            matrix.SetElement(i, j, array[i, j])
+    for i, j in product(range(m), range(n)):
+        matrix.SetElement(i, j, array[i, j])
     return matrix
 
 

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -1,6 +1,7 @@
 """Internal array utilities."""
 import collections.abc
 import enum
+from itertools import product
 from typing import Optional, Tuple, Union
 
 import numpy as np
@@ -9,7 +10,6 @@ import pyvista as pv
 from pyvista.core import _vtk_core as _vtk
 from pyvista.core._typing_core import NumericArray, VectorArray
 from pyvista.core.errors import AmbiguousDataError, MissingDataError
-from itertools import product
 
 
 class FieldAssociation(enum.Enum):


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Use `itertools.product` to avoid nested loops.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- Ref https://github.com/pyvista/pyvista/pull/4965#discussion_r1339483871_ .
