### PR TITLE
Use title-style capitalization to fix vale warning

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,6 +1,6 @@
-# Repository pyvista-docs
+# Deploy the PyVista Documentation.
 
-A place where we automatically deploy the PyVista documentation.
+Repository [`pyvista-docs`](https://github.com/pyvista/pyvista-docs) is a place where we automatically deploy the PyVista documentation.
 
 This repository is automatically edited by our army of robots on the
 Azure CI service. Changes to the documentation should not be made

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,4 +1,4 @@
-# pyvista-docs
+# Repository pyvista-docs
 
 A place where we automatically deploy the PyVista documentation.
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,4 +1,4 @@
-# Deploy the PyVista Documentation.
+# Deploy the PyVista Documentation
 
 Repository [`pyvista-docs`](https://github.com/pyvista/pyvista-docs) is a place where we automatically deploy the PyVista documentation.
 

--- a/doc/source/getting-started/why.rst
+++ b/doc/source/getting-started/why.rst
@@ -112,7 +112,7 @@ to a description of how to use those methods:
 .. figure:: ../images/gifs/documentation.gif
 
 
-Interfacing with other Libraries
+Interfacing with Other Libraries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PyVista is heavily dependent on `numpy <https://numpy.org/>`_ and uses
 it to represent point, cell, field, and other data from the VTK

--- a/doc/source/getting-started/why.rst
+++ b/doc/source/getting-started/why.rst
@@ -112,7 +112,7 @@ to a description of how to use those methods:
 .. figure:: ../images/gifs/documentation.gif
 
 
-Interfacing With Other Libraries
+Interfacing with other Libraries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PyVista is heavily dependent on `numpy <https://numpy.org/>`_ and uses
 it to represent point, cell, field, and other data from the VTK


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Use title-style capitalization to fix vale warning.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- vale warning of Google.Headings.
