### PR TITLE
Add the docstring link error to `.git-blame-ignore-revs` file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,5 +6,6 @@ db0691cfb6b033e55664ffba25deb456a386a48c
 a26a52d037a265774be0ca06bb141e3346e73ad0
 635052d1bce8615fcc4879f5f200921a4f78aa1a
 
-# define alias pv when importing pyvista
+# define alias pv when importing pyvista in docstring examples
 545c1d17a4c54ef1b2422a2a13104c35ae40891b
+c4c43dbc2df4735fedd06422ff5f4d25c07c56e8


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Follow-up of #5040 .

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- I am considering whether to add this change to the coding rules.
