### PR TITLE
Remove trame from `all` in pyproject.toml, as it is no longer a variable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 dynamic = ['version']
 
 [project.optional-dependencies]
-all = ['pyvista[colormaps,io,jupyter,trame]']
+all = ['pyvista[colormaps,io,jupyter]']
 colormaps = [
     'cmocean',
     'colorcet',


### PR DESCRIPTION
Remove `trame` as optional-dependency class, as it is no longer there, and only part of `jupyter` deps.
