### PR TITLE
Use `itertools.product` to avoid nested loops in examples

### DIFF
--- a/examples/01-filter/gradients.py
+++ b/examples/01-filter/gradients.py
@@ -87,12 +87,11 @@ keys = np.array(list(gradients.keys())).reshape(1, 3)
 
 p = pv.Plotter(shape=keys.shape)
 
-for i in range(keys.shape[0]):
-    for j in range(keys.shape[1]):
-        name = keys[i, j]
-        p.subplot(i, j)
-        p.add_mesh(mesh_g.contour(scalars=name), scalars=name, opacity=0.75)
-        p.add_mesh(mesh_g.outline(), color="k")
+for (i, j), name in np.ndenumerate(keys):
+    name = keys[i, j]
+    p.subplot(i, j)
+    p.add_mesh(mesh_g.contour(scalars=name), scalars=name, opacity=0.75)
+    p.add_mesh(mesh_g.outline(), color="k")
 p.link_views()
 p.view_isometric()
 p.show()

--- a/examples/01-filter/gradients.py
+++ b/examples/01-filter/gradients.py
@@ -63,8 +63,7 @@ mesh_g
 keys = np.array(list(gradients.keys())).reshape(3, 3)
 
 p = pv.Plotter(shape=keys.shape)
-for i, j in product(range(keys.shape[0]), range(keys.shape[1])):
-    name = keys[i, j]
+for (i, j), name in np.ndenumerate(keys):
     p.subplot(i, j)
     p.add_mesh(mesh_g.contour(scalars=name), scalars=name, opacity=0.75)
     p.add_mesh(mesh_g.outline(), color="k")

--- a/examples/01-filter/gradients.py
+++ b/examples/01-filter/gradients.py
@@ -12,7 +12,6 @@ an input array {u, v, w}.
 
 Showing the :func:`pyvista.DataSetFilters.compute_derivative` filter.
 """
-from itertools import product
 
 import numpy as np
 

--- a/examples/01-filter/gradients.py
+++ b/examples/01-filter/gradients.py
@@ -12,6 +12,7 @@ an input array {u, v, w}.
 
 Showing the :func:`pyvista.DataSetFilters.compute_derivative` filter.
 """
+from itertools import product
 
 import numpy as np
 
@@ -62,12 +63,11 @@ mesh_g
 keys = np.array(list(gradients.keys())).reshape(3, 3)
 
 p = pv.Plotter(shape=keys.shape)
-for i in range(keys.shape[0]):
-    for j in range(keys.shape[1]):
-        name = keys[i, j]
-        p.subplot(i, j)
-        p.add_mesh(mesh_g.contour(scalars=name), scalars=name, opacity=0.75)
-        p.add_mesh(mesh_g.outline(), color="k")
+for i, j in product(range(keys.shape[0]), range(keys.shape[1])):
+    name = keys[i, j]
+    p.subplot(i, j)
+    p.add_mesh(mesh_g.contour(scalars=name), scalars=name, opacity=0.75)
+    p.add_mesh(mesh_g.outline(), color="k")
 p.link_views()
 p.view_isometric()
 p.show()

--- a/examples/01-filter/warp-by-vector.py
+++ b/examples/01-filter/warp-by-vector.py
@@ -35,7 +35,7 @@ p.show()
 
 warp_factors = [0, 1.5, 3.5, 5.5]
 p = pv.Plotter(shape=(2, 2))
-for i, j in product(range(2), range(2)):
+for i, j in product(range(2), repeat=2):
     idx = 2 * i + j
     p.subplot(i, j)
     p.add_mesh(sphere.warp_by_vector(factor=warp_factors[idx]))

--- a/examples/01-filter/warp-by-vector.py
+++ b/examples/01-filter/warp-by-vector.py
@@ -11,6 +11,8 @@ This example applies the ``warp_by_vector`` filter to a sphere mesh that has
 ###############################################################################
 # We first compare the unwarped sphere to the warped sphere.
 
+from itertools import product
+
 import pyvista as pv
 from pyvista import examples
 
@@ -33,10 +35,9 @@ p.show()
 
 warp_factors = [0, 1.5, 3.5, 5.5]
 p = pv.Plotter(shape=(2, 2))
-for i in range(2):
-    for j in range(2):
-        idx = 2 * i + j
-        p.subplot(i, j)
-        p.add_mesh(sphere.warp_by_vector(factor=warp_factors[idx]))
-        p.add_text(f'factor={warp_factors[idx]}')
+for i, j in product(range(2), range(2)):
+    idx = 2 * i + j
+    p.subplot(i, j)
+    p.add_mesh(sphere.warp_by_vector(factor=warp_factors[idx]))
+    p.add_text(f'factor={warp_factors[idx]}')
 p.show()

--- a/examples/02-plot/pbr.py
+++ b/examples/02-plot/pbr.py
@@ -17,6 +17,8 @@ a statue as though it were metallic.
 
 """
 
+from itertools import product
+
 import pyvista as pv
 from pyvista import examples
 
@@ -53,10 +55,9 @@ colors = ['red', 'teal', 'black', 'orange', 'silver']
 p = pv.Plotter()
 p.set_environment_texture(cubemap)
 
-for i in range(5):
-    for j in range(6):
-        sphere = pv.Sphere(radius=0.5, center=(0.0, 4 - i, j))
-        p.add_mesh(sphere, color=colors[i], pbr=True, metallic=i / 4, roughness=j / 5)
+for i,j in  product(range(5), range(6)):
+    sphere = pv.Sphere(radius=0.5, center=(0.0, 4 - i, j))
+    p.add_mesh(sphere, color=colors[i], pbr=True, metallic=i / 4, roughness=j / 5)
 
 p.view_vector((-1, 0, 0), (0, 1, 0))
 p.show()

--- a/examples/02-plot/pbr.py
+++ b/examples/02-plot/pbr.py
@@ -55,7 +55,7 @@ colors = ['red', 'teal', 'black', 'orange', 'silver']
 p = pv.Plotter()
 p.set_environment_texture(cubemap)
 
-for i,j in  product(range(5), range(6)):
+for i, j in product(range(5), range(6)):
     sphere = pv.Sphere(radius=0.5, center=(0.0, 4 - i, j))
     p.add_mesh(sphere, color=colors[i], pbr=True, metallic=i / 4, roughness=j / 5)
 

--- a/examples/99-advanced/warp-by-vector-eigenmodes.py
+++ b/examples/99-advanced/warp-by-vector-eigenmodes.py
@@ -72,9 +72,9 @@ def make_cijkl_E_nu(E=200, nu=0.3):
     }
 
     cijkl = np.zeros((3, 3, 3, 3))
-    for i, j, k, l in product(range(3), range(3), range(3), range(3)):
-        u = coord_mapping[(i + 1, j + 1)]
-        v = coord_mapping[(k + 1, l + 1)]
+    for i, j, k, l in product(range(3), repeat=4):
+        u = coord_mapping[i + 1, j + 1]
+        v = coord_mapping[k + 1, l + 1]
         cijkl[i, j, k, l] = cij[u - 1, v - 1]
     return cijkl, cij
 

--- a/examples/99-advanced/warp-by-vector-eigenmodes.py
+++ b/examples/99-advanced/warp-by-vector-eigenmodes.py
@@ -18,6 +18,8 @@ https://asa.scitation.org/doi/10.1121/1.401643
 # a crude approximation (by choosing a low max polynomial order) to get a fast
 # computation.
 
+from itertools import product
+
 import numpy as np
 from scipy.linalg import eigh
 
@@ -70,13 +72,10 @@ def make_cijkl_E_nu(E=200, nu=0.3):
     }
 
     cijkl = np.zeros((3, 3, 3, 3))
-    for i in range(3):
-        for j in range(3):
-            for k in range(3):
-                for l in range(3):
-                    u = coord_mapping[(i + 1, j + 1)]
-                    v = coord_mapping[(k + 1, l + 1)]
-                    cijkl[i, j, k, l] = cij[u - 1, v - 1]
+    for i, j, k, l in product(range(3), range(3), range(3), range(3)):
+        u = coord_mapping[(i + 1, j + 1)]
+        v = coord_mapping[(k + 1, l + 1)]
+        cijkl[i, j, k, l] = cij[u - 1, v - 1]
     return cijkl, cij
 
 
@@ -106,9 +105,8 @@ def assemble_mass_and_stiffness(N, F, geom_params, cijkl):
     assert len(triplets) == (N + 1) * (N + 2) * (N + 3) // 6
 
     quadruplets = []
-    for i in range(3):
-        for triplet in triplets:
-            quadruplets.append((i, *triplet))
+    for i, triplet in product(range(3), triplets):
+        quadruplets.append((i, *triplet))
     assert len(quadruplets) == 3 * (N + 1) * (N + 2) * (N + 3) // 6
 
     # assembling the mass and stiffness matrix in a single loop
@@ -234,14 +232,13 @@ pl.show()
 
 
 pl = pv.Plotter(shape=(2, 4))
-for i in range(2):
-    for j in range(4):
-        pl.subplot(i, j)
-        current_index = 4 * i + j
-        vector = f"eigenmode_{current_index:02}"
-        pl.add_text(
-            f"mode {current_index}, freq. {computed_freqs_kHz[current_index]:.1f} kHz",
-            font_size=10,
-        )
-        pl.add_mesh(vol.warp_by_vector(vector, factor=0.03), scalars=vector, show_scalar_bar=False)
+for i, j in product(range(2), range(4)):
+    pl.subplot(i, j)
+    current_index = 4 * i + j
+    vector = f"eigenmode_{current_index:02}"
+    pl.add_text(
+        f"mode {current_index}, freq. {computed_freqs_kHz[current_index]:.1f} kHz",
+        font_size=10,
+    )
+    pl.add_mesh(vol.warp_by_vector(vector, factor=0.03), scalars=vector, show_scalar_bar=False)
 pl.show()


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Use `itertools.product` to avoid nested loops.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- Ref https://github.com/pyvista/pyvista/pull/4965#discussion_r1339483871_ .
