### PR TITLE
Captialize first word in sentence in `text.py`

### DIFF
--- a/pyvista/plotting/text.py
+++ b/pyvista/plotting/text.py
@@ -363,7 +363,7 @@ class TextProperty(_vtk.vtkTextProperty):
         -------
         float
             Background opacity of the text. A single float value that will be applied globally.
-            background opacity of the text and uniformly applied everywhere. Between 0 and 1.
+            Background opacity of the text and uniformly applied everywhere. Between 0 and 1.
 
         """
         return self.GetBackgroundOpacity()


### PR DESCRIPTION
### Overview

Fixed a typo. The first letter of the sentence must be capitalized.

Fix for this [issue](https://github.com/pyvista/pyvista/issues/5075) 




