### PR TITLE
Deprecate `t_coords` and use `texture_coordinates`

### DIFF
--- a/examples/02-plot/texture.py
+++ b/examples/02-plot/texture.py
@@ -188,9 +188,9 @@ puppy_coords = np.c_[yyc.ravel(), xxc.ravel()]
 # produce 4 repetitions of the same texture on this mesh.
 #
 # Then we must associate those texture coordinates with the mesh through the
-# :attr:`pyvista.DataSet.active_t_coords` property.
+# :attr:`pyvista.DataSet.active_texture_coordinates` property.
 
-curvsurf.active_t_coords = puppy_coords
+curvsurf.active_texture_coordinates = puppy_coords
 
 ###############################################################################
 # Now display all the puppies.
@@ -225,11 +225,11 @@ sphere = pv.Sphere(
 )
 
 # Initialize the texture coordinates array
-sphere.active_t_coords = np.zeros((sphere.points.shape[0], 2))
+sphere.active_texture_coordinates = np.zeros((sphere.points.shape[0], 2))
 
 # Populate by manually calculating
 for i in range(sphere.points.shape[0]):
-    sphere.active_t_coords[i] = [
+    sphere.active_texture_coordinates[i] = [
         0.5 + np.arctan2(-sphere.points[i, 0], sphere.points[i, 1]) / (2 * np.pi),
         0.5 + np.arcsin(sphere.points[i, 2]) / np.pi,
     ]

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -577,21 +577,6 @@ class DataSet(DataSetFilters, DataObject):
         Optional[pyvista_ndarray]
             Active texture coordinates on the points.
 
-        Examples
-        --------
-        Return the active texture coordinates from the globe example.
-
-        >>> from pyvista import examples
-        >>> globe = examples.load_globe()
-        >>> globe.active_t_coords
-        pyvista_ndarray([[0.        , 0.        ],
-                         [0.        , 0.07142857],
-                         [0.        , 0.14285714],
-                         ...,
-                         [1.        , 0.85714286],
-                         [1.        , 0.92857143],
-                         [1.        , 1.        ]])
-
         """
         warnings.warn(
             "Use of `DataSet.active_t_coords` is deprecated. Use `DataSet.active_texture_coordinates` instead.",

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -593,7 +593,11 @@ class DataSet(DataSetFilters, DataObject):
                          [1.        , 1.        ]])
 
         """
-        return self.point_data.active_t_coords
+        warnings.warn(
+            "Use of `DataSet.active_t_coords` is deprecated. Use `DataSet.active_texture_coordinates` instead.",
+            PyVistaDeprecationWarning,
+        )
+        return self.active_texture_coordinates
 
     @active_t_coords.setter
     def active_t_coords(self, t_coords: np.ndarray):  # numpydoc ignore=GL08
@@ -604,7 +608,11 @@ class DataSet(DataSetFilters, DataObject):
         t_coords : np.ndarray
             Active texture coordinates on the points.
         """
-        self.point_data.active_t_coords = t_coords  # type: ignore
+        warnings.warn(
+            "Use of `DataSet.active_t_coords` is deprecated. Use `DataSet.active_texture_coordinates` instead.",
+            PyVistaDeprecationWarning,
+        )
+        self.active_texture_coordinates = t_coords  # type: ignore
 
     def set_active_scalars(self, name: Optional[str], preference='cell'):
         """Find the scalars by name and appropriately sets it as active.

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -569,7 +569,7 @@ class DataSet(DataSetFilters, DataObject):
         return self.glyph(orient=vectors_name, scale=scale_name)
 
     @property
-    def active_t_coords(self) -> Optional[pyvista_ndarray]:  # numpydoc ignore=RT01
+    def active_texture_coordinates(self) -> Optional[pyvista_ndarray]:  # numpydoc ignore=RT01
         """Return the active texture coordinates on the points.
 
         Returns
@@ -583,7 +583,7 @@ class DataSet(DataSetFilters, DataObject):
 
         >>> from pyvista import examples
         >>> globe = examples.load_globe()
-        >>> globe.active_t_coords
+        >>> globe.active_texture_coordinates
         pyvista_ndarray([[0.        , 0.        ],
                          [0.        , 0.07142857],
                          [0.        , 0.14285714],
@@ -593,18 +593,18 @@ class DataSet(DataSetFilters, DataObject):
                          [1.        , 1.        ]])
 
         """
-        return self.point_data.active_t_coords
+        return self.point_data.active_texture_coordinates
 
-    @active_t_coords.setter
-    def active_t_coords(self, t_coords: np.ndarray):  # numpydoc ignore=GL08
+    @active_texture_coordinates.setter
+    def active_texture_coordinates(self, texture_coordinates: np.ndarray):  # numpydoc ignore=GL08
         """Set the active texture coordinates on the points.
 
         Parameters
         ----------
-        t_coords : np.ndarray
+        texture_coordinates : np.ndarray
             Active texture coordinates on the points.
         """
-        self.point_data.active_t_coords = t_coords  # type: ignore
+        self.point_data.active_texture_coordinates = texture_coordinates  # type: ignore
 
     def set_active_scalars(self, name: Optional[str], preference='cell'):
         """Find the scalars by name and appropriately sets it as active.

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -594,8 +594,7 @@ class DataSet(DataSetFilters, DataObject):
 
         """
         warnings.warn(
-            "Use of `DataSet.active_t_coords` is deprecated.",
-            "Use `DataSet.active_texture_coordinates` instead.",
+            "Use of `DataSet.active_t_coords` is deprecated. Use `DataSet.active_texture_coordinates` instead.",
             PyVistaDeprecationWarning,
         )
         return self.active_texture_coordinates
@@ -610,8 +609,7 @@ class DataSet(DataSetFilters, DataObject):
             Active texture coordinates on the points.
         """
         warnings.warn(
-            "Use of `DataSet.active_t_coords` is deprecated.",
-            "Use `DataSet.active_texture_coordinates` instead.",
+            "Use of `DataSet.active_t_coords` is deprecated. Use `DataSet.active_texture_coordinates` instead.",
             PyVistaDeprecationWarning,
         )
         self.active_texture_coordinates = t_coords  # type: ignore

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -594,7 +594,8 @@ class DataSet(DataSetFilters, DataObject):
 
         """
         warnings.warn(
-            "Use of `DataSet.active_t_coords` is deprecated. Use `DataSet.active_texture_coordinates` instead.",
+            "Use of `DataSet.active_t_coords` is deprecated.",
+            "Use `DataSet.active_texture_coordinates` instead.",
             PyVistaDeprecationWarning,
         )
         return self.active_texture_coordinates
@@ -609,7 +610,8 @@ class DataSet(DataSetFilters, DataObject):
             Active texture coordinates on the points.
         """
         warnings.warn(
-            "Use of `DataSet.active_t_coords` is deprecated. Use `DataSet.active_texture_coordinates` instead.",
+            "Use of `DataSet.active_t_coords` is deprecated.",
+            "Use `DataSet.active_texture_coordinates` instead.",
             PyVistaDeprecationWarning,
         )
         self.active_texture_coordinates = t_coords  # type: ignore

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -569,7 +569,7 @@ class DataSet(DataSetFilters, DataObject):
         return self.glyph(orient=vectors_name, scale=scale_name)
 
     @property
-    def active_texture_coordinates(self) -> Optional[pyvista_ndarray]:  # numpydoc ignore=RT01
+    def active_t_coords(self) -> Optional[pyvista_ndarray]:  # numpydoc ignore=RT01
         """Return the active texture coordinates on the points.
 
         Returns
@@ -583,7 +583,7 @@ class DataSet(DataSetFilters, DataObject):
 
         >>> from pyvista import examples
         >>> globe = examples.load_globe()
-        >>> globe.active_texture_coordinates
+        >>> globe.active_t_coords
         pyvista_ndarray([[0.        , 0.        ],
                          [0.        , 0.07142857],
                          [0.        , 0.14285714],
@@ -593,18 +593,18 @@ class DataSet(DataSetFilters, DataObject):
                          [1.        , 1.        ]])
 
         """
-        return self.point_data.active_texture_coordinates
+        return self.point_data.active_t_coords
 
-    @active_texture_coordinates.setter
-    def active_texture_coordinates(self, texture_coordinates: np.ndarray):  # numpydoc ignore=GL08
+    @active_t_coords.setter
+    def active_t_coords(self, t_coords: np.ndarray):  # numpydoc ignore=GL08
         """Set the active texture coordinates on the points.
 
         Parameters
         ----------
-        texture_coordinates : np.ndarray
+        t_coords : np.ndarray
             Active texture coordinates on the points.
         """
-        self.point_data.active_texture_coordinates = texture_coordinates  # type: ignore
+        self.point_data.active_t_coords = t_coords  # type: ignore
 
     def set_active_scalars(self, name: Optional[str], preference='cell'):
         """Find the scalars by name and appropriately sets it as active.
@@ -3295,3 +3295,41 @@ class DataSet(DataSetFilters, DataObject):
         if singular:
             return in_cell[0]
         return in_cell
+
+    @property
+    def active_texture_coordinates(self) -> Optional[pyvista_ndarray]:  # numpydoc ignore=RT01
+        """Return the active texture coordinates on the points.
+
+        Returns
+        -------
+        Optional[pyvista_ndarray]
+            Active texture coordinates on the points.
+
+        Examples
+        --------
+        Return the active texture coordinates from the globe example.
+
+        >>> from pyvista import examples
+        >>> globe = examples.load_globe()
+        >>> globe.active_texture_coordinates
+        pyvista_ndarray([[0.        , 0.        ],
+                         [0.        , 0.07142857],
+                         [0.        , 0.14285714],
+                         ...,
+                         [1.        , 0.85714286],
+                         [1.        , 0.92857143],
+                         [1.        , 1.        ]])
+
+        """
+        return self.point_data.active_texture_coordinates
+
+    @active_texture_coordinates.setter
+    def active_texture_coordinates(self, texture_coordinates: np.ndarray):  # numpydoc ignore=GL08
+        """Set the active texture coordinates on the points.
+
+        Parameters
+        ----------
+        texture_coordinates : np.ndarray
+            Active texture coordinates on the points.
+        """
+        self.point_data.active_texture_coordinates = texture_coordinates  # type: ignore

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -394,8 +394,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
         """
         warnings.warn(
-            "Use of `DataSetAttributes.active_t_coords` is deprecated.",
-            "Use `DataSetAttributes.active_texture_coordinates` instead.",
+            "Use of `DataSetAttributes.active_t_coords` is deprecated. Use `DataSetAttributes.active_texture_coordinates` instead.",
             PyVistaDeprecationWarning,
         )
         return self.active_texture_coordinates
@@ -414,8 +413,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
         """
         warnings.warn(
-            "Use of `DataSetAttributes.active_t_coords` is deprecated."
-            "Use `DataSetAttributes.active_texture_coordinates` instead.",
+            "Use of `DataSetAttributes.active_t_coords` is deprecated. Use `DataSetAttributes.active_texture_coordinates` instead.",
             PyVistaDeprecationWarning,
         )
         self.active_texture_coordinates = t_coords

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -416,13 +416,6 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         Optional[str]
             Name of the active texture coordinates array.
 
-        Examples
-        --------
-        >>> import pyvista as pv
-        >>> mesh = pv.Cube()
-        >>> mesh.point_data.active_t_coords_name
-        'TCoords'
-
         """
         warnings.warn(
             "Use of `DataSetAttributes.active_t_coords_name` is deprecated. Use `DataSetAttributes.active_texture_coordinates_name` instead.",

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -394,7 +394,8 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
         """
         warnings.warn(
-            "Use of `DataSetAttributes.active_t_coords` is deprecated. Use `DataSetAttributes.active_texture_coordinates` instead.",
+            "Use of `DataSetAttributes.active_t_coords` is deprecated.",
+            "Use `DataSetAttributes.active_texture_coordinates` instead.",
             PyVistaDeprecationWarning,
         )
         return self.active_texture_coordinates
@@ -413,7 +414,8 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
         """
         warnings.warn(
-            "Use of `DataSetAttributes.active_t_coords` is deprecated. Use `DataSetAttributes.active_texture_coordinates` instead.",
+            "Use of `DataSetAttributes.active_t_coords` is deprecated."
+            "Use `DataSetAttributes.active_texture_coordinates` instead.",
             PyVistaDeprecationWarning,
         )
         self.active_texture_coordinates = t_coords

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -1,11 +1,12 @@
 """Implements DataSetAttributes, which represents and manipulates datasets."""
-
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
+import warnings
 
 import numpy as np
 
 from . import _vtk_core as _vtk
 from ._typing_core import Number
+from .errors import PyVistaDeprecationWarning
 from .pyvista_ndarray import pyvista_ndarray
 from .utilities.arrays import FieldAssociation, convert_array, copy_vtk_array
 
@@ -391,6 +392,10 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
                          [-1.,  0.]], dtype=float32)
 
         """
+        warnings.warn(
+            "Use of `DataSetAttributes.active_t_coords` is deprecated. Use `DataSetAttributes.active_texture_coordinates` instead.",
+            PyVistaDeprecationWarning,
+        )
         return self.active_texture_coordinates
 
     @active_t_coords.setter
@@ -406,6 +411,10 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
             Array of the active texture coordinates.
 
         """
+        warnings.warn(
+            "Use of `DataSetAttributes.active_t_coords` is deprecated. Use `DataSetAttributes.active_texture_coordinates` instead.",
+            PyVistaDeprecationWarning,
+        )
         self.active_texture_coordinates = t_coords
 
     @property
@@ -428,6 +437,10 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         'TCoords'
 
         """
+        warnings.warn(
+            "Use of `DataSetAttributes.active_t_coords_name` is deprecated. Use `DataSetAttributes.active_texture_coordinates_name` instead.",
+            PyVistaDeprecationWarning,
+        )
         return self.active_texture_coordinates_name
 
     @active_t_coords_name.setter
@@ -443,6 +456,10 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
             Name of the active texture coordinates array.
 
         """
+        warnings.warn(
+            "Use of `DataSetAttributes.active_t_coords_name` is deprecated. Use `DataSetAttributes.active_texture_coordinates_name` instead.",
+            PyVistaDeprecationWarning,
+        )
         self.active_texture_coordinates_name = name
 
     def get_array(self, key: Union[str, int]) -> pyvista_ndarray:

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -378,20 +378,6 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         pyvista.pyvista_ndarray
             Array of the active texture coordinates.
 
-        Examples
-        --------
-        >>> import pyvista as pv
-        >>> mesh = pv.Cube()
-        >>> mesh.point_data.active_t_coords
-        pyvista_ndarray([[ 0.,  0.],
-                         [ 1.,  0.],
-                         [ 1.,  1.],
-                         [ 0.,  1.],
-                         [-0.,  0.],
-                         [-0.,  1.],
-                         [-1.,  1.],
-                         [-1.,  0.]], dtype=float32)
-
         """
         warnings.warn(
             "Use of `DataSetAttributes.active_t_coords` is deprecated. Use `DataSetAttributes.active_texture_coordinates` instead.",

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -365,8 +365,11 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         return None
 
     @property
-    def active_texture_coordinates(self) -> Optional[pyvista_ndarray]:  # numpydoc ignore=RT01
+    def active_t_coords(self) -> Optional[pyvista_ndarray]:  # numpydoc ignore=RT01
         """Return the active texture coordinates array.
+
+        .. deprecated:: 0.43.0
+            Use :func:`DataSetAttributes.active_texture_coordinates` instead.
 
         Returns
         -------
@@ -377,7 +380,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         --------
         >>> import pyvista as pv
         >>> mesh = pv.Cube()
-        >>> mesh.point_data.active_texture_coordinates
+        >>> mesh.point_data.active_t_coords
         pyvista_ndarray([[ 0.,  0.],
                          [ 1.,  0.],
                          [ 1.,  1.],
@@ -388,45 +391,29 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
                          [-1.,  0.]], dtype=float32)
 
         """
-        self._raise_no_texture_coordinates()
-        texture_coordinates = self.GetTCoords()
-        if texture_coordinates is not None:
-            return pyvista_ndarray(
-                texture_coordinates, dataset=self.dataset, association=self.association
-            )
-        return None
+        return self.active_texture_coordinates
 
-    @active_texture_coordinates.setter
-    def active_texture_coordinates(self, texture_coordinates: np.ndarray):  # numpydoc ignore=GL08
+    @active_t_coords.setter
+    def active_t_coords(self, t_coords: np.ndarray):  # numpydoc ignore=GL08
         """Set the active texture coordinates array.
+
+        .. deprecated:: 0.43.0
+            Use :func:`DataSetAttributes.active_texture_coordinates` instead.
 
         Parameters
         ----------
-        texture_coordinates : np.ndarray
+        t_coords : np.ndarray
             Array of the active texture coordinates.
 
         """
-        self._raise_no_texture_coordinates()
-        if not isinstance(texture_coordinates, np.ndarray):
-            raise TypeError('Texture coordinates must be a numpy array')
-        if texture_coordinates.ndim != 2:
-            raise ValueError('Texture coordinates must be a 2-dimensional array')
-        valid_length = self.valid_array_len
-        if texture_coordinates.shape[0] != valid_length:
-            raise ValueError(
-                f'Number of texture coordinates ({texture_coordinates.shape[0]}) must match number of points ({valid_length})'
-            )
-        if texture_coordinates.shape[1] != 2:
-            raise ValueError(
-                f'Texture coordinates must only have 2 components, not ({texture_coordinates.shape[1]})'
-            )
-        vtkarr = _vtk.numpyTovtkDataArray(texture_coordinates, name='Texture Coordinates')
-        self.SetTCoords(vtkarr)
-        self.Modified()
+        self.active_texture_coordinates = t_coords
 
     @property
-    def active_texture_coordinates_name(self) -> Optional[str]:  # numpydoc ignore=RT01
+    def active_t_coords_name(self) -> Optional[str]:  # numpydoc ignore=RT01
         """Return the name of the active texture coordinates array.
+
+        .. deprecated:: 0.43.0
+            Use :func:`DataSetAttributes.active_texture_coordinates_name` instead.
 
         Returns
         -------
@@ -437,18 +424,18 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         --------
         >>> import pyvista as pv
         >>> mesh = pv.Cube()
-        >>> mesh.point_data.active_texture_coordinates_name
+        >>> mesh.point_data.active_t_coords_name
         'TCoords'
 
         """
-        self._raise_no_texture_coordinates()
-        if self.GetTCoords() is not None:
-            return str(self.GetTCoords().GetName())
-        return None
+        return self.active_texture_coordinates_name
 
-    @active_texture_coordinates_name.setter
-    def active_texture_coordinates_name(self, name: str) -> None:  # numpydoc ignore=GL08
+    @active_t_coords_name.setter
+    def active_t_coords_name(self, name: str) -> None:  # numpydoc ignore=GL08
         """Set the name of the active texture coordinates array.
+
+        .. deprecated:: 0.43.0
+            Use :func:`DataSetAttributes.active_texture_coordinates_name` instead.
 
         Parameters
         ----------
@@ -456,15 +443,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
             Name of the active texture coordinates array.
 
         """
-        if name is None:
-            self.SetActiveTCoords(None)
-            return
-
-        self._raise_no_texture_coordinates()
-        dtype = self[name].dtype
-        # only vtkDataArray subclasses can be set as active attributes
-        if np.issubdtype(dtype, np.number) or dtype == bool:
-            self.SetActiveTCoords(name)
+        self.active_texture_coordinates_name = name
 
     def get_array(self, key: Union[str, int]) -> pyvista_ndarray:
         """Get an array in this object.
@@ -1349,3 +1328,105 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         """Raise AttributeError when attempting access texture_coordinates for field data."""
         if self.association == FieldAssociation.NONE:
             raise AttributeError('FieldData does not have active texture coordinates.')
+
+    @property
+    def active_texture_coordinates(self) -> Optional[pyvista_ndarray]:  # numpydoc ignore=RT01
+        """Return the active texture coordinates array.
+
+        Returns
+        -------
+        pyvista.pyvista_ndarray
+            Array of the active texture coordinates.
+
+        Examples
+        --------
+        >>> import pyvista as pv
+        >>> mesh = pv.Cube()
+        >>> mesh.point_data.active_texture_coordinates
+        pyvista_ndarray([[ 0.,  0.],
+                         [ 1.,  0.],
+                         [ 1.,  1.],
+                         [ 0.,  1.],
+                         [-0.,  0.],
+                         [-0.,  1.],
+                         [-1.,  1.],
+                         [-1.,  0.]], dtype=float32)
+
+        """
+        self._raise_no_texture_coordinates()
+        texture_coordinates = self.GetTCoords()
+        if texture_coordinates is not None:
+            return pyvista_ndarray(
+                texture_coordinates, dataset=self.dataset, association=self.association
+            )
+        return None
+
+    @active_texture_coordinates.setter
+    def active_texture_coordinates(self, texture_coordinates: np.ndarray):  # numpydoc ignore=GL08
+        """Set the active texture coordinates array.
+
+        Parameters
+        ----------
+        texture_coordinates : np.ndarray
+            Array of the active texture coordinates.
+
+        """
+        self._raise_no_texture_coordinates()
+        if not isinstance(texture_coordinates, np.ndarray):
+            raise TypeError('Texture coordinates must be a numpy array')
+        if texture_coordinates.ndim != 2:
+            raise ValueError('Texture coordinates must be a 2-dimensional array')
+        valid_length = self.valid_array_len
+        if texture_coordinates.shape[0] != valid_length:
+            raise ValueError(
+                f'Number of texture coordinates ({texture_coordinates.shape[0]}) must match number of points ({valid_length})'
+            )
+        if texture_coordinates.shape[1] != 2:
+            raise ValueError(
+                f'Texture coordinates must only have 2 components, not ({texture_coordinates.shape[1]})'
+            )
+        vtkarr = _vtk.numpyTovtkDataArray(texture_coordinates, name='Texture Coordinates')
+        self.SetTCoords(vtkarr)
+        self.Modified()
+
+    @property
+    def active_texture_coordinates_name(self) -> Optional[str]:  # numpydoc ignore=RT01
+        """Return the name of the active texture coordinates array.
+
+        Returns
+        -------
+        Optional[str]
+            Name of the active texture coordinates array.
+
+        Examples
+        --------
+        >>> import pyvista as pv
+        >>> mesh = pv.Cube()
+        >>> mesh.point_data.active_texture_coordinates_name
+        'TCoords'
+
+        """
+        self._raise_no_texture_coordinates()
+        if self.GetTCoords() is not None:
+            return str(self.GetTCoords().GetName())
+        return None
+
+    @active_texture_coordinates_name.setter
+    def active_texture_coordinates_name(self, name: str) -> None:  # numpydoc ignore=GL08
+        """Set the name of the active texture coordinates array.
+
+        Parameters
+        ----------
+        name : str
+            Name of the active texture coordinates array.
+
+        """
+        if name is None:
+            self.SetActiveTCoords(None)
+            return
+
+        self._raise_no_texture_coordinates()
+        dtype = self[name].dtype
+        # only vtkDataArray subclasses can be set as active attributes
+        if np.issubdtype(dtype, np.number) or dtype == bool:
+            self.SetActiveTCoords(name)

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -1,4 +1,5 @@
 """Implements DataSetAttributes, which represents and manipulates datasets."""
+
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
 import warnings
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1965,11 +1965,11 @@ class DataSetFilters:
         output = _get_output(alg)
         if not inplace:
             return output
-        t_coords = output.GetPointData().GetTCoords()
-        t_coords.SetName(name)
+        texture_coordinates = output.GetPointData().GetTCoords()
+        texture_coordinates.SetName(name)
         otc = self.GetPointData().GetTCoords()
-        self.GetPointData().SetTCoords(t_coords)
-        self.GetPointData().AddArray(t_coords)
+        self.GetPointData().SetTCoords(texture_coordinates)
+        self.GetPointData().AddArray(texture_coordinates)
         # CRITICAL:
         if otc and otc.GetName() != name:
             # Add old ones back at the end if different name
@@ -2039,11 +2039,11 @@ class DataSetFilters:
         output = _get_output(alg)
         if not inplace:
             return output
-        t_coords = output.GetPointData().GetTCoords()
-        t_coords.SetName(name)
+        texture_coordinates = output.GetPointData().GetTCoords()
+        texture_coordinates.SetName(name)
         otc = self.GetPointData().GetTCoords()
-        self.GetPointData().SetTCoords(t_coords)
-        self.GetPointData().AddArray(t_coords)
+        self.GetPointData().SetTCoords(texture_coordinates)
+        self.GetPointData().AddArray(texture_coordinates)
         # CRITICAL:
         if otc and otc.GetName() != name:
             # Add old ones back at the end if different name

--- a/pyvista/core/utilities/helpers.py
+++ b/pyvista/core/utilities/helpers.py
@@ -149,7 +149,7 @@ def wrap(dataset):
         polydata = pyvista.PolyData(np.asarray(dataset.vertices), faces)
         # If the Trimesh object has uv, pass them to the PolyData
         if hasattr(dataset.visual, 'uv'):
-            polydata.active_t_coords = np.asarray(dataset.visual.uv)
+            polydata.active_texture_coordinates = np.asarray(dataset.visual.uv)
         return polydata
 
     # otherwise, flag tell the user we can't wrap this object

--- a/pyvista/examples/planets.py
+++ b/pyvista/examples/planets.py
@@ -36,7 +36,7 @@ def _sphere_with_texture_map(radius=1.0, lat_resolution=50, lon_resolution=100):
     texture_coords = np.empty((sphere.n_points, 2))
     texture_coords[:, 0] = phi.ravel('F') / phi.max()
     texture_coords[:, 1] = theta[::-1, :].ravel('F') / theta.max()
-    sphere.active_t_coords = texture_coords
+    sphere.active_texture_coordinates = texture_coords
     return sphere.extract_surface(pass_pointid=False, pass_cellid=False)
 
 
@@ -397,10 +397,10 @@ def load_saturn_rings(inner=0.25, outer=0.5, c_res=6):  # pragma: no cover
 
     """
     disc = pyvista.Disc(inner=inner, outer=outer, c_res=c_res)
-    disc.active_t_coords = np.zeros((disc.points.shape[0], 2))
+    disc.active_texture_coordinates = np.zeros((disc.points.shape[0], 2))
     radius = np.sqrt(disc.points[:, 0] ** 2 + disc.points[:, 1] ** 2)
-    disc.active_t_coords[:, 0] = radius / np.max(radius)
-    disc.active_t_coords[:, 1] = 0.0
+    disc.active_texture_coordinates[:, 0] = radius / np.max(radius)
+    disc.active_texture_coordinates[:, 1] = 0.0
     return disc
 
 

--- a/pyvista/plotting/actor.py
+++ b/pyvista/plotting/actor.py
@@ -176,7 +176,7 @@ class Actor(Prop3D, _vtk.vtkActor):
         >>> import pyvista as pv
         >>> from pyvista import examples
         >>> plane = pv.Plane()
-        >>> plane.active_t_coords is not None
+        >>> plane.active_texture_coordinates is not None
         True
         >>> pl = pv.Plotter()
         >>> actor = pl.add_mesh(plane)

--- a/pyvista/plotting/texture.py
+++ b/pyvista/plotting/texture.py
@@ -234,7 +234,7 @@ class Texture(_vtk.vtkTexture, DataObject):
         >>> from pyvista import examples
         >>> texture = examples.download_masonry_texture()
         >>> plane = pv.Plane()
-        >>> plane.active_t_coords *= 2
+        >>> plane.active_texture_coordinates *= 2
 
         This is the texture plotted with repeat set to ``False``.
 
@@ -563,7 +563,7 @@ class Texture(_vtk.vtkTexture, DataObject):
         >>> from pyvista import examples
         >>> texture = examples.download_masonry_texture()
         >>> plane = pv.Plane()
-        >>> plane.active_t_coords *= 2
+        >>> plane.active_texture_coordinates *= 2
 
         Let's now set the texture wrap to clamp to edge and visualize it.
 

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -484,8 +484,8 @@ def test_invalid_vector(grid):
         grid["vectors"] = np.empty((3, 3))
 
 
-def test_no_t_coords(grid):
-    assert grid.active_t_coords is None
+def test_no_texture_coordinates(grid):
+    assert grid.active_texture_coordinates is None
 
 
 def test_no_arrows(grid):
@@ -557,18 +557,18 @@ def test_set_active_tensors(grid):
     active_component_consistency_check(grid, "tensors", "point")
 
 
-def test_set_t_coords(grid):
+def test_set_texture_coordinates(grid):
     with pytest.raises(TypeError):
-        grid.active_t_coords = [1, 2, 3]
+        grid.active_texture_coordinates = [1, 2, 3]
 
     with pytest.raises(ValueError):
-        grid.active_t_coords = np.empty(10)
+        grid.active_texture_coordinates = np.empty(10)
 
     with pytest.raises(ValueError):
-        grid.active_t_coords = np.empty((3, 3))
+        grid.active_texture_coordinates = np.empty((3, 3))
 
     with pytest.raises(ValueError):
-        grid.active_t_coords = np.empty((grid.n_points, 1))
+        grid.active_texture_coordinates = np.empty((grid.n_points, 1))
 
 
 def test_set_active_vectors_fail(grid):

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1710,23 +1710,17 @@ def test_point_neighbors_levels(grid: DataSet, i0, n_levels):
         assert i == n_levels - 1
 
 
-def test_active_t_coords_deprecated(grid):
-    with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
-        t_coords = grid.active_t_coords
-        if pv._version.version_info >= (0, 46):
-            raise RuntimeError('Remove this deprecated property')
-    with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
-        grid.active_t_coords = t_coords
-        if pv._version.version_info >= (0, 46):
-            raise RuntimeError('Remove this deprecated property')
+@pytest.fixture()
+def mesh():
+    return examples.load_globe()
 
 
-def test_active_t_coords_name_deprecated(grid):
+def test_active_t_coords_deprecated(mesh):
     with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
-        name = grid.active_t_coords_name
+        t_coords = mesh.active_t_coords
         if pv._version.version_info >= (0, 46):
             raise RuntimeError('Remove this deprecated property')
     with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
-        grid.active_t_coords_name = name
+        mesh.active_t_coords = t_coords
         if pv._version.version_info >= (0, 46):
             raise RuntimeError('Remove this deprecated property')

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1713,12 +1713,20 @@ def test_point_neighbors_levels(grid: DataSet, i0, n_levels):
 def test_active_t_coords_deprecated(grid):
     with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
         t_coords = grid.active_t_coords
+        if pv._version.version_info >= (0, 46):
+            raise RuntimeError('Remove this deprecated property')
     with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
         grid.active_t_coords = t_coords
+        if pv._version.version_info >= (0, 46):
+            raise RuntimeError('Remove this deprecated property')
 
 
 def test_active_t_coords_name_deprecated(grid):
     with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
         name = grid.active_t_coords_name
+        if pv._version.version_info >= (0, 46):
+            raise RuntimeError('Remove this deprecated property')
     with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
         grid.active_t_coords_name = name
+        if pv._version.version_info >= (0, 46):
+            raise RuntimeError('Remove this deprecated property')

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1708,3 +1708,17 @@ def test_point_neighbors_levels(grid: DataSet, i0, n_levels):
             assert all([0 <= id < grid.n_points for id in ids])
             assert len(ids) > 0
         assert i == n_levels - 1
+
+
+def test_active_t_coords_deprecated(grid):
+    with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
+        t_coords = grid.active_t_coords
+    with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
+        grid.active_t_coords = t_coords
+
+
+def test_active_t_coords_name_deprecated(grid):
+    with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
+        name = grid.active_t_coords_name
+    with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
+        grid.active_t_coords_name = name

--- a/tests/core/test_datasetattributes.py
+++ b/tests/core/test_datasetattributes.py
@@ -7,9 +7,11 @@ from hypothesis import HealthCheck, given, settings
 from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import integers, lists, text
 import numpy as np
+import pytest
 from pytest import fixture, mark, raises
 
 import pyvista as pv
+from pyvista.core.errors import PyVistaDeprecationWarning
 from pyvista.core.utilities.arrays import FieldAssociation, convert_array
 
 skip_windows = mark.skipif(os.name == 'nt', reason='Test fails on Windows')
@@ -635,3 +637,19 @@ def test_complex(plane, dtype_str):
     assert plane.point_data[name].dtype == dtype
     plane.point_data[name] = plane.point_data[name].real
     assert np.issubdtype(plane.point_data[name].dtype, real_type)
+
+
+def test_active_t_coords_deprecated():
+    mesh = pv.Cube()
+    with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
+        t_coords = mesh.active_t_coords
+    with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
+        mesh.active_t_coords = t_coords
+
+
+def test_active_t_coords_name_deprecated():
+    mesh = pv.Cube()
+    with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
+        name = mesh.active_t_coords_name
+    with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
+        mesh.active_t_coords_name = name

--- a/tests/core/test_datasetattributes.py
+++ b/tests/core/test_datasetattributes.py
@@ -643,13 +643,21 @@ def test_active_t_coords_deprecated():
     mesh = pv.Cube()
     with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
         t_coords = mesh.active_t_coords
+        if pv._version.version_info >= (0, 46):
+            raise RuntimeError('Remove this deprecated property')
     with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
         mesh.active_t_coords = t_coords
+        if pv._version.version_info >= (0, 46):
+            raise RuntimeError('Remove this deprecated property')
 
 
 def test_active_t_coords_name_deprecated():
     mesh = pv.Cube()
     with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
         name = mesh.active_t_coords_name
+        if pv._version.version_info >= (0, 46):
+            raise RuntimeError('Remove this deprecated property')
     with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
         mesh.active_t_coords_name = name
+        if pv._version.version_info >= (0, 46):
+            raise RuntimeError('Remove this deprecated property')

--- a/tests/core/test_datasetattributes.py
+++ b/tests/core/test_datasetattributes.py
@@ -642,11 +642,11 @@ def test_complex(plane, dtype_str):
 def test_active_t_coords_deprecated():
     mesh = pv.Cube()
     with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
-        t_coords = mesh.active_t_coords
+        t_coords = mesh.point_data.active_t_coords
         if pv._version.version_info >= (0, 46):
             raise RuntimeError('Remove this deprecated property')
     with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
-        mesh.active_t_coords = t_coords
+        mesh.point_data.active_t_coords = t_coords
         if pv._version.version_info >= (0, 46):
             raise RuntimeError('Remove this deprecated property')
 
@@ -654,10 +654,10 @@ def test_active_t_coords_deprecated():
 def test_active_t_coords_name_deprecated():
     mesh = pv.Cube()
     with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
-        name = mesh.active_t_coords_name
+        name = mesh.point_data.active_t_coords_name
         if pv._version.version_info >= (0, 46):
             raise RuntimeError('Remove this deprecated property')
     with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
-        mesh.active_t_coords_name = name
+        mesh.point_data.active_t_coords_name = name
         if pv._version.version_info >= (0, 46):
             raise RuntimeError('Remove this deprecated property')

--- a/tests/core/test_datasetattributes.py
+++ b/tests/core/test_datasetattributes.py
@@ -228,15 +228,15 @@ def test_set_invalid_vectors(hexbeam):
         hexbeam.point_data.set_vectors(not_vectors, 'my-vectors')
 
 
-def test_set_tcoords_name():
+def test_set_texture_coordinates_name():
     mesh = pv.Cube()
-    old_name = mesh.point_data.active_t_coords_name
-    assert mesh.point_data.active_t_coords_name is not None
-    mesh.point_data.active_t_coords_name = None
-    assert mesh.point_data.active_t_coords_name is None
+    old_name = mesh.point_data.active_texture_coordinates_name
+    assert mesh.point_data.active_texture_coordinates_name is not None
+    mesh.point_data.active_texture_coordinates_name = None
+    assert mesh.point_data.active_texture_coordinates_name is None
 
-    mesh.point_data.active_t_coords_name = old_name
-    assert mesh.point_data.active_t_coords_name == old_name
+    mesh.point_data.active_texture_coordinates_name = old_name
+    assert mesh.point_data.active_texture_coordinates_name == old_name
 
 
 def test_set_bitarray(hexbeam):
@@ -597,12 +597,12 @@ def test_active_vectors_eq():
     assert mesh != other_mesh
 
 
-def test_active_t_coords_name(plane):
-    plane.point_data['arr'] = plane.point_data.active_t_coords
-    plane.point_data.active_t_coords_name = 'arr'
+def test_active_texture_coordinates_name(plane):
+    plane.point_data['arr'] = plane.point_data.active_texture_coordinates
+    plane.point_data.active_texture_coordinates_name = 'arr'
 
     with raises(AttributeError):
-        plane.field_data.active_t_coords_name = 'arr'
+        plane.field_data.active_texture_coordinates_name = 'arr'
 
 
 @skip_windows  # windows doesn't support np.complex256

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -59,14 +59,14 @@ def test_wrap_trimesh():
     assert np.allclose(tmesh.vertices, mesh.points)
     assert np.allclose(tmesh.faces, mesh.faces[1:])
 
-    assert mesh.active_t_coords is None
+    assert mesh.active_texture_coordinates is None
 
     uvs = [[0, 0], [0, 1], [1, 0]]
     tmesh.visual = trimesh.visual.TextureVisuals(uv=uvs)
     mesh_with_uv = pv.wrap(tmesh)
 
-    assert mesh_with_uv.active_t_coords is not None
-    assert np.allclose(mesh_with_uv.active_t_coords, uvs)
+    assert mesh_with_uv.active_texture_coordinates is not None
+    assert np.allclose(mesh_with_uv.active_texture_coordinates, uvs)
 
 
 def test_make_tri_mesh(sphere):

--- a/tests/plotting/test_texture.py
+++ b/tests/plotting/test_texture.py
@@ -215,14 +215,14 @@ def test_texture_coordinates():
     faces = np.hstack([[3, 0, 1, 2], [3, 0, 3, 2]]).astype(np.int8)
 
     # Create simple texture coordinates
-    t_coords = np.array([[0, 0], [1, 0], [1, 1], [0, 1]])
+    texture_coordinates = np.array([[0, 0], [1, 0], [1, 1], [0, 1]])
     # Create the poly data
     mesh = pv.PolyData(vertices, faces)
     # Attempt setting the texture coordinates
-    mesh.active_t_coords = t_coords
+    mesh.active_texture_coordinates = texture_coordinates
     # now grab the texture coordinates
-    foo = mesh.active_t_coords
-    assert np.allclose(foo, t_coords)
+    foo = mesh.active_texture_coordinates
+    assert np.allclose(foo, texture_coordinates)
 
 
 def test_multiple_texture_coordinates():
@@ -237,4 +237,4 @@ def test_inplace_no_overwrite_texture_coordinates():
     truth = mesh.texture_map_to_plane(inplace=False)
     mesh.texture_map_to_sphere(inplace=True)
     test = mesh.texture_map_to_plane(inplace=True)
-    assert np.allclose(truth.active_t_coords, test.active_t_coords)
+    assert np.allclose(truth.active_texture_coordinates, test.active_texture_coordinates)


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
I understand that `t_coords` was defined this way to omit the length of the variable name. However, as one user, it is difficult to understand the meaning of this variable.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- [x] Add Deprecate warning.

