### PR TITLE
Defer to geovista default warning escalation to error with pytest

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -105,5 +105,5 @@ jobs:
           wget --quiet ${CARTOPY_FEATURE}
           mkdir -p ${CARTOPY_SHARE_DIR}
           python cartopy_feature_download.py physical --output ${CARTOPY_SHARE_DIR} --no-warn
-      - run: pytest -m "not image"
+      - run: pytest
         working-directory: geovista

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -105,5 +105,5 @@ jobs:
           wget --quiet ${CARTOPY_FEATURE}
           mkdir -p ${CARTOPY_SHARE_DIR}
           python cartopy_feature_download.py physical --output ${CARTOPY_SHARE_DIR} --no-warn
-      - run: pytest -W error -W "ignore:numpy.ndarray size changed:RuntimeWarning"
+      - run: pytest -m "not image"
         working-directory: geovista


### PR DESCRIPTION
### Overview

`geovista` now performs full image tests using `pytest-pyvista` of its example scripts (see [#494](https://github.com/bjlittle/geovista/pull/494)).

However, until [Issue #447](https://github.com/bjlittle/geovista/issues/447) is resolved, `geovista` is pinned to `pyvista<0.42.2`.

This pull-requests skips the image tests to prevent `pyvista` from failing during integration tests.

Also, note that `geovista` now forces `pytest` to escalate all `warnings` to `errors` (see [#487](https://github.com/bjlittle/geovista/pull/487/files)) by default, so it's no longer necessary to include the explicit `-W error` option when running the `geovista` integration test.

