### PR TITLE
Split Preview Documentation in GitHub Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -97,21 +97,6 @@ jobs:
         if: always()
         run: if [ -e doc/errors.txt ]; then cat doc/errors.txt; fi
 
-      - name: Preview HTML documentation
-        uses: nwtgck/actions-netlify@v2.0
-        with:
-          publish-dir: doc/_build/html/
-          production-branch: main
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "Deploy from GitHub Actions"
-          enable-pull-request-comment: true
-          enable-commit-comment: true
-          overwrites-pull-request-comment: true
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        timeout-minutes: 10
-
       - name: Upload HTML documentation
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -1,0 +1,91 @@
+name: Preview Documentation
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  doc:
+    name: Build Documentation
+    runs-on: ubuntu-20.04
+    env:
+      PYVISTA_OFF_SCREEN: 'True'
+      ALLOW_PLOTTING: true
+      SHELLOPTS: 'errexit:pipefail'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements_docs.txt
+
+      - uses: awalsh128/cache-apt-pkgs-action@v1.1.3
+        with:
+          packages: libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime
+          version: 3.0
+
+      - name: Install PyVista and dependencies
+        run: |
+          pip install -e . --no-deps
+          pip install -r requirements_docs.txt
+
+      - name: Install custom OSMesa VTK variant
+        run: |
+          pip uninstall vtk -y
+          aria2c -x5 "https://github.com/pyvista/pyvista-wheels/raw/main/${VTK_OSMESA_WHEEL_NAME}"
+          pip install "$VTK_OSMESA_WHEEL_NAME"
+          rm "$VTK_OSMESA_WHEEL_NAME"
+        env:
+          VTK_OSMESA_WHEEL_NAME: vtk_osmesa-9.2.5-cp311-cp311-linux_x86_64.whl
+
+      - name: PyVista Report
+        run: |
+          python -c "import pyvista;print(pyvista.Report())"
+          echo PYVISTA_EXAMPLE_DATA_PATH=$(python -c "from pyvista import examples; print(examples.USER_DATA_PATH)") >> $GITHUB_ENV
+          pip list
+
+      - name: Cache Sphinx-Gallery Examples
+        uses: actions/cache@v3
+        if: env.USE_CACHE == 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/v')
+        with:
+          path: doc/source/examples/
+          key: doc-examples-${{ hashFiles('pyvista/_version.py') }}
+
+      - name: Cache example data
+        uses: actions/cache@v3
+        if: env.USE_CACHE == 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/v')
+        with:
+          path: ${{ env.PYVISTA_EXAMPLE_DATA_PATH }}
+          key: example-data-1-${{ hashFiles('pyvista/_version.py') }}
+
+      - name: Build Documentation
+        run: make -C doc html
+
+      - name: Copy ads.txt
+        run: cp doc/source/ads.txt doc/_build/html/
+
+      - name: Dump Sphinx Warnings and Errors
+        if: always()
+        run: if [ -e doc/sphinx_warnings.txt ]; then cat doc/sphinx_warnings.txt; fi
+
+      - name: Dump VTK Warnings and Errors
+        if: always()
+        run: if [ -e doc/errors.txt ]; then cat doc/errors.txt; fi
+
+      - name: Preview HTML documentation
+        uses: nwtgck/actions-netlify@v2.0
+        with:
+          publish-dir: doc/_build/html/
+          production-branch: main
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions"
+          enable-pull-request-comment: true
+          enable-commit-comment: true
+          overwrites-pull-request-comment: true
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 10

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -1,6 +1,5 @@
 name: Preview Documentation
 on:
-  push:
   pull_request:
   pull_request_target:
     types: [labeled]

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -1,5 +1,6 @@
 name: Preview Documentation
 on:
+  push:
   pull_request:
   pull_request_target:
     types: [labeled]

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -1,5 +1,6 @@
 name: Preview Documentation
 on:
+  pull_request:
   pull_request_target:
     types: [labeled]
 


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Split Preview Documentation GitHubActions.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- Deploy Netlify in the main is not needed, so the feature is removed.
- Modified to allow preview of documents triggered by labeling.

