### PR TITLE
Add support for custom cyclers to color MultiBlocks

### DIFF
--- a/pyvista/plotting/composite_mapper.py
+++ b/pyvista/plotting/composite_mapper.py
@@ -655,10 +655,20 @@ class CompositePolyDataMapper(_vtk.vtkCompositePolyDataMapper2, _BaseMapper):
     def color_missing_with_nan(self, value: bool):  # numpydoc ignore=GL08
         self.SetColorMissingArraysWithNanColor(value)
 
-    def set_unique_colors(self, color_cyler=True ):
+    def set_unique_colors(self, color_cycler=True):
         """Set each block of the dataset to a unique color.
 
-        This uses ``matplotlib``'s color cycler.
+        This uses ``matplotlib``'s color cycler by default.
+
+        When a custom color cycler, or a sequence of
+        color-like objects, is passed it sets the blocks
+        to the corresponding colors.
+
+        Parameters
+        ----------
+        color_cycler : bool | str | cycler.Cycler | sequence[ColorLike]
+            The sequence of colors to cycle through,
+            if ``True``, uses matplotlib cycler.
 
         Examples
         --------
@@ -679,10 +689,10 @@ class CompositePolyDataMapper(_vtk.vtkCompositePolyDataMapper2, _BaseMapper):
         self.scalar_visibility = False
 
         # color_cycler=True still uses 'matplotlib' cycler
-        if isinstance( color_cycler, bool):
+        if isinstance(color_cycler, bool):
             colors = cycle(matplotlib.rcParams['axes.prop_cycle'])
         else:
-            colors = cycle( get_cycler(color_cycler) )
+            colors = cycle(get_cycler(color_cycler))
 
         for attr in self.block_attr:
             attr.color = next(colors)['color']

--- a/pyvista/plotting/composite_mapper.py
+++ b/pyvista/plotting/composite_mapper.py
@@ -13,7 +13,7 @@ from pyvista.core.utilities.misc import _check_range
 from pyvista.report import vtk_version_info
 
 from . import _vtk
-from .colors import Color
+from .colors import Color, get_cycler
 from .mapper import _BaseMapper
 
 
@@ -655,7 +655,7 @@ class CompositePolyDataMapper(_vtk.vtkCompositePolyDataMapper2, _BaseMapper):
     def color_missing_with_nan(self, value: bool):  # numpydoc ignore=GL08
         self.SetColorMissingArraysWithNanColor(value)
 
-    def set_unique_colors(self):
+    def set_unique_colors(self, color_cyler=True ):
         """Set each block of the dataset to a unique color.
 
         This uses ``matplotlib``'s color cycler.
@@ -677,7 +677,13 @@ class CompositePolyDataMapper(_vtk.vtkCompositePolyDataMapper2, _BaseMapper):
         Color(name='tab:green', hex='#2ca02cff', opacity=255)
         """
         self.scalar_visibility = False
-        colors = cycle(matplotlib.rcParams['axes.prop_cycle'])
+
+        # color_cycler=True still uses 'matplotlib' cycler
+        if isinstance( color_cycler, bool):
+            colors = cycle(matplotlib.rcParams['axes.prop_cycle'])
+        else:
+            colors = cycle( get_cycler(color_cycler) )
+
         for attr in self.block_attr:
             attr.color = next(colors)['color']
 

--- a/pyvista/plotting/composite_mapper.py
+++ b/pyvista/plotting/composite_mapper.py
@@ -4,7 +4,6 @@ import sys
 from typing import Optional
 import weakref
 
-import matplotlib
 import numpy as np
 
 import pyvista

--- a/pyvista/plotting/composite_mapper.py
+++ b/pyvista/plotting/composite_mapper.py
@@ -690,7 +690,7 @@ class CompositePolyDataMapper(_vtk.vtkCompositePolyDataMapper2, _BaseMapper):
 
         # color_cycler=True still uses 'matplotlib' cycler
         if isinstance(color_cycler, bool):
-            colors = cycle(matplotlib.rcParams['axes.prop_cycle'])
+            colors = cycle(get_cycler("matplotlib"))
         else:
             colors = cycle(get_cycler(color_cycler))
 

--- a/pyvista/plotting/composite_mapper.py
+++ b/pyvista/plotting/composite_mapper.py
@@ -688,7 +688,6 @@ class CompositePolyDataMapper(_vtk.vtkCompositePolyDataMapper2, _BaseMapper):
         """
         self.scalar_visibility = False
 
-        # color_cycler=True still uses 'matplotlib' cycler
         if isinstance(color_cycler, bool):
             colors = cycle(get_cycler("matplotlib"))
         else:

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -2991,7 +2991,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             If ``True``, the default 'matplotlib' color cycler is used.
 
             See :func:`set_color_cycler<Plotter.set_color_cycler>` for usage of
-            custom color cyclers.
+            custom color cycles.
 
         name : str, optional
             The name for the added mesh/actor so that it can be easily

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -2432,8 +2432,13 @@ class BasePlotter(PickingHelper, WidgetHelper):
             If ``False``, a scalar bar will not be added to the
             scene. Defaults to ``True`` unless ``rgba=True``.
 
-        multi_colors : bool, default: False
-            Color each block by a solid color using matplotlib's color cycler.
+        multi_colors : bool | str | cycler.Cycler | sequence[ColorLike], default: False
+            Color each block by a solid color using a custom cycler.
+
+            If ``True``, the default 'matplotlib' color cycler is used.
+
+            See :func:`set_color_cycler<Plotter.set_color_cycler>` for usage of
+            custom color cyclers.
 
         name : str, optional
             The name for the added mesh/actor so that it can be easily
@@ -2979,9 +2984,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
             If ``False``, a scalar bar will not be added to the
             scene.
 
-        multi_colors : bool, default: False
+        multi_colors : bool | str | cycler.Cycler | sequence[ColorLike], default: False
             If a :class:`pyvista.MultiBlock` dataset is given this will color
-            each block by a solid color using matplotlib's color cycler.
+            each block by a solid color using a custom cycler.
+
+            If ``True``, the default 'matplotlib' color cycler is used.
+
+            See :func:`set_color_cycler<Plotter.set_color_cycler>` for usage of
+            custom color cyclers.
 
         name : str, optional
             The name for the added mesh/actor so that it can be easily

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -2714,7 +2714,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if color is not None:
             self.mapper.scalar_visibility = False
         elif multi_colors:
-            self.mapper.set_unique_colors()
+            self.mapper.set_unique_colors(multi_colors)
         else:
             if scalars is None:
                 point_name, cell_name = dataset._get_consistent_active_scalars()

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -417,9 +417,9 @@ def test_multi_block_color_cycler():
     # test wrong args
     pl = pv.Plotter()
     with pytest.raises(ValueError):
-        pl.set_color_cycler('foo')
+        pl.set_unique_colors('foo')
     with pytest.raises(TypeError):
-        pl.set_color_cycler(5)
+        pl.set_unique_colors(5)
 
 
 @pytest.mark.parametrize(

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -394,6 +394,35 @@ def test_plotter_meshes(sphere, cube):
     assert len(pl.meshes) == 2
 
 
+def test_multi_block_color_cycler(verify_image_cache):
+    """Test passing a custom color cycler"""
+    verify_image_cache.windows_skip_image_cache = True
+    plotter = pv.Plotter()
+    data = {
+        "sphere1": pv.Sphere(center=(1, 0, 0)),
+        "sphere2": pv.Sphere(center=(2, 0, 0)),
+        "sphere3": pv.Sphere(center=(3, 0, 0)),
+        "sphere4": pv.Sphere(center=(4, 0, 0)),
+    }
+    spheres = pv.MultiBlock(data)
+    actor, mapper = plotter.add_composite(spheres)
+
+    # pass custom cycler
+    mapper.set_unique_colors(['red', 'green', 'blue'])
+
+    assert mapper.block_attr[0].color.name == 'red'
+    assert mapper.block_attr[1].color.name == 'green'
+    assert mapper.block_attr[2].color.name == 'blue'
+    assert mapper.block_attr[3].color.name == 'red'
+
+    # test wrong args
+    pl = pv.Plotter()
+    with pytest.raises(ValueError):
+        pl.set_color_cycler('foo')
+    with pytest.raises(TypeError):
+        pl.set_color_cycler(5)
+
+
 @pytest.mark.parametrize(
     'face, normal',
     [

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -394,9 +394,8 @@ def test_plotter_meshes(sphere, cube):
     assert len(pl.meshes) == 2
 
 
-def test_multi_block_color_cycler(verify_image_cache):
+def test_multi_block_color_cycler():
     """Test passing a custom color cycler"""
-    verify_image_cache.windows_skip_image_cache = True
     plotter = pv.Plotter()
     data = {
         "sphere1": pv.Sphere(center=(1, 0, 0)),

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -415,11 +415,11 @@ def test_multi_block_color_cycler():
     assert mapper.block_attr[3].color.name == 'red'
 
     # test wrong args
-    pl = pv.Plotter()
     with pytest.raises(ValueError):
-        pl.set_unique_colors('foo')
+        mapper.set_unique_colors('foo')
+
     with pytest.raises(TypeError):
-        pl.set_unique_colors(5)
+        mapper.set_unique_colors(5)
 
 
 @pytest.mark.parametrize(

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1220,6 +1220,8 @@ def test_multi_block_plot(verify_image_cache):
     multi.plot(scalars='Random Data')
 
     multi.plot(multi_colors=True)
+    multi.plot(multi_colors=['red', 'green', 'blue'])
+    multi.plot(multi_colors='all')
 
 
 def test_clear(sphere):

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1222,35 +1222,6 @@ def test_multi_block_plot(verify_image_cache):
     multi.plot(multi_colors=True)
 
 
-def test_multi_block_color_cycler(verify_image_cache):
-    """Test passing a custom color cycler"""
-    verify_image_cache.windows_skip_image_cache = True
-    plotter = pv.Plotter()
-    data = {
-        "sphere1": pv.Sphere(center=(1, 0, 0)),
-        "sphere2": pv.Sphere(center=(2, 0, 0)),
-        "sphere3": pv.Sphere(center=(3, 0, 0)),
-        "sphere4": pv.Sphere(center=(4, 0, 0)),
-    }
-    spheres = pv.MultiBlock(data)
-    actor, mapper = plotter.add_composite(spheres)
-
-    # pass custom cycler
-    mapper.set_unique_colors(['red', 'green', 'blue'])
-
-    assert mapper.block_attr[0].color.name == 'red'
-    assert mapper.block_attr[1].color.name == 'green'
-    assert mapper.block_attr[2].color.name == 'blue'
-    assert mapper.block_attr[3].color.name == 'red'
-
-    # test wrong args
-    pl = pv.Plotter()
-    with pytest.raises(ValueError):
-        pl.set_color_cycler('foo')
-    with pytest.raises(TypeError):
-        pl.set_color_cycler(5)
-
-
 def test_clear(sphere):
     plotter = pv.Plotter()
     plotter.add_mesh(sphere)

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1224,6 +1224,35 @@ def test_multi_block_plot(verify_image_cache):
     multi.plot(multi_colors='all')
 
 
+def test_multi_block_color_cycler(verify_image_cache):
+    """Test passing a custom color cycler"""
+    verify_image_cache.windows_skip_image_cache = True
+    plotter = pv.Plotter()
+    data = {
+        "sphere1": pv.Sphere(center=(1, 0, 0)),
+        "sphere2": pv.Sphere(center=(2, 0, 0)),
+        "sphere3": pv.Sphere(center=(3, 0, 0)),
+        "sphere4": pv.Sphere(center=(4, 0, 0)),
+    }
+    spheres = pv.MultiBlock(data)
+    actor, mapper = plotter.add_composite(spheres)
+
+    # pass custom cycler
+    mapper.set_unique_colors(['red', 'green', 'blue'])
+
+    assert mapper.block_attr[0].color.name == 'red'
+    assert mapper.block_attr[1].color.name == 'green'
+    assert mapper.block_attr[2].color.name == 'blue'
+    assert mapper.block_attr[3].color.name == 'red'
+
+    # test wrong args
+    pl = pv.Plotter()
+    with pytest.raises(ValueError):
+        pl.set_color_cycler('foo')
+    with pytest.raises(TypeError):
+        pl.set_color_cycler(5)
+
+
 def test_clear(sphere):
     plotter = pv.Plotter()
     plotter.add_mesh(sphere)

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1220,8 +1220,6 @@ def test_multi_block_plot(verify_image_cache):
     multi.plot(scalars='Random Data')
 
     multi.plot(multi_colors=True)
-    multi.plot(multi_colors=['red', 'green', 'blue'])
-    multi.plot(multi_colors='all')
 
 
 def test_multi_block_color_cycler(verify_image_cache):


### PR DESCRIPTION
### Overview

attempts to fixes #1270

The `Plotter.add_mesh` function has support for `multi_colors`. When a `MultiBlock` variable is passed
through, it uses the default 'matplotlib' cycler to iterate through colors. 

But, instead of using the fixed 'matplotlib' default cycler we can implement a custom cycler using the automatic color cycling 
from #3739.

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- This function doesn't break the previous usage of `multi_colors` parameter, i.e. using a single bool. 
- It introduces the cycler as an optional argument.
- The `add_composite`, function which is calls the `set_unique_colors`, now passes the cycler argument 
with it. 
- This uses the `get_cycler` function found in `colors.py` return a cycler used in `set_unique_colors`.
- Also updates the related docstrings for these functions.

This implementation is lot similar to the [`Plotter.set_color_cycler`](https://docs.pyvista.org/version/stable/api/plotting/_autosummary/pyvista.Plotter.set_color_cycler.html). 

