### PR TITLE
Rename `master_doc` to `root_doc` in Sphinx build configuration file

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,4 +1,4 @@
-# Deploy the PyVista documentation
+# Deploy the PyVista Documentation
 
 Repository [`pyvista-docs`](https://github.com/pyvista/pyvista-docs) is a place where we automatically deploy the PyVista documentation.
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,4 +1,4 @@
-# Deploy the PyVista Documentation
+# Deploy the PyVista documentation
 
 Repository [`pyvista-docs`](https://github.com/pyvista/pyvista-docs) is a place where we automatically deploy the PyVista documentation.
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -256,7 +256,7 @@ autosummary_context = {
 source_suffix = ".rst"
 
 # The main toctree document.
-master_doc = "index"
+root_doc = "index"
 
 
 # General information about the project.
@@ -519,7 +519,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "pyvista.tex", "pyvista Documentation", author, "manual"),
+    (root_doc, "pyvista.tex", "pyvista Documentation", author, "manual"),
 ]
 
 # -- Options for gettext output -------------------------------------------
@@ -531,7 +531,7 @@ gettext_additional_targets = ["raw"]
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "pyvista", "pyvista Documentation", [author], 1)]
+man_pages = [(root_doc, "pyvista", "pyvista Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -541,7 +541,7 @@ man_pages = [(master_doc, "pyvista", "pyvista Documentation", [author], 1)]
 #  dir menu entry, description, category)
 texinfo_documents = [
     (
-        master_doc,
+        root_doc,
         "pyvista",
         "pyvista Documentation",
         author,

--- a/tests/tinypages/conf.py
+++ b/tests/tinypages/conf.py
@@ -15,7 +15,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__)))
 extensions = ['pyvista.ext.plot_directive']
 templates_path = ['_templates']
 source_suffix = '.rst'
-master_doc = 'index'
+root_doc = 'index'
 project = 'tinypages'
 year = datetime.date.today().year
 copyright = f"2021-{year}, PyVista developers"


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Follow-up of #1389 and #1433.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- See https://github.com/sphinx-doc/sphinx/pull/8484 .
