### PR TITLE
Remove set_plot_theme from examples

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -359,9 +359,7 @@ sphinx_gallery_conf = {
     # Modules for which function level galleries are created.  In
     "doc_module": "pyvista",
     "image_scrapers": ("pyvista", "matplotlib"),
-    "first_notebook_cell": (
-        "%matplotlib inline\n"
-    ),
+    "first_notebook_cell": ("%matplotlib inline\n"),
     "reset_modules": (reset_pyvista,),
     "reset_modules_order": "both",
 }

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -360,7 +360,7 @@ sphinx_gallery_conf = {
     "doc_module": "pyvista",
     "image_scrapers": ("pyvista", "matplotlib"),
     "first_notebook_cell": (
-        "%matplotlib inline\n" "from pyvista import set_plot_theme\n" "set_plot_theme('document')\n"
+        "%matplotlib inline\n"
     ),
     "reset_modules": (reset_pyvista,),
     "reset_modules_order": "both",

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -359,7 +359,7 @@ sphinx_gallery_conf = {
     # Modules for which function level galleries are created.  In
     "doc_module": "pyvista",
     "image_scrapers": ("pyvista", "matplotlib"),
-    "first_notebook_cell": ("%matplotlib inline"),
+    "first_notebook_cell": "%matplotlib inline",
     "reset_modules": (reset_pyvista,),
     "reset_modules_order": "both",
 }

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -359,7 +359,7 @@ sphinx_gallery_conf = {
     # Modules for which function level galleries are created.  In
     "doc_module": "pyvista",
     "image_scrapers": ("pyvista", "matplotlib"),
-    "first_notebook_cell": ("%matplotlib inline\n"),
+    "first_notebook_cell": ("%matplotlib inline"),
     "reset_modules": (reset_pyvista,),
     "reset_modules_order": "both",
 }


### PR DESCRIPTION
As of #4516, the document theme is the new default. We do not need to set the theme to document in every example