### PR TITLE
Add conversion of 3D label maps to labeled meshes with SurfaceNets.

### DIFF
--- a/examples/01-filter/contouring.py
+++ b/examples/01-filter/contouring.py
@@ -74,3 +74,15 @@ pl.add_mesh(edges, line_width=5, render_lines_as_tubes=True, color='k')
 pl.add_mesh(contours, **dargs)
 pl.add_mesh(arrows, **dargs)
 pl.show()
+
+###############################################################################
+# Contours from a label map
+# +++++++++++++++++++++++++
+#
+# Create labeled surfaces from 3D label maps (e.f. multi-label image segmentation)
+# using :func:`contour_labeled() <pyvista.PolyDataFilters.contour_labeled>`.
+# Requires VTK version 9.3
+if pv.vtk_version_info >= (9, 3):
+    label_map = pv.examples.download_frog_tissue()
+    mesh = label_map.contour_labeled()
+    mesh.plot(cmap="glasbey_warm", cpos="yx", show_scalar_bar=False)

--- a/examples/01-filter/contouring.py
+++ b/examples/01-filter/contouring.py
@@ -80,7 +80,7 @@ pl.show()
 # +++++++++++++++++++++++++
 #
 # Create labeled surfaces from 3D label maps (e.f. multi-label image segmentation)
-# using :func:`contour_labeled() <pyvista.PolyDataFilters.contour_labeled>`.
+# using :func:`contour_labeled() <pyvista.ImageDataFilters.contour_labeled>`.
 # Requires VTK version 9.3
 if pv.vtk_version_info >= (9, 3):
     label_map = pv.examples.download_frog_tissue()

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -421,3 +421,9 @@ try:  # Introduced prior to VTK 9.3
     from vtkmodules.vtkRenderingCore import vtkViewport
 except ImportError:  # pragma: no cover
     pass
+
+# 9.3+ imports
+try:
+    from vtkmodules.vtkFiltersCore import vtkSurfaceNets3D
+except ImportError:  # pragma: no cover
+    pass

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -796,7 +796,6 @@ class ImageDataFilters(DataSetFilters):
         This filter requires that the :class:`ImageData` has integer point
         scalars, such as multi-label maps generated from image segmentation.
 
-
         Parameters
         ----------
         n_labels : int, optional

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -842,6 +842,7 @@ class ImageDataFilters(DataSetFilters):
         Examples
         --------
         See :ref:`contouring_example` for a full example using this filter.
+
         """
         if not hasattr(_vtk, 'vtkSurfaceNets3D'):  # pragma: no cover
             from pyvista.core.errors import VTKVersionError

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -847,7 +847,7 @@ class ImageDataFilters(DataSetFilters):
         if not hasattr(_vtk, 'vtkSurfaceNets3D'):  # pragma: no cover
             from pyvista.core.errors import VTKVersionError
 
-            raise VTKVersionError('Surface nets 3D require VTK 9.3.20230807rc0 or newer.')
+            raise VTKVersionError('Surface nets 3D require VTK 9.3.0 or newer.')
 
         alg = _vtk.vtkSurfaceNets3D()
         if scalars is None:

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -841,7 +841,7 @@ class ImageDataFilters(DataSetFilters):
 
         Examples
         --------
-        See :ref:`surface_nets_example` for a full example using this filter.
+        See :ref:`contouring_example` for a full example using this filter.
         """
         if not hasattr(_vtk, 'vtkSurfaceNets3D'):  # pragma: no cover
             from pyvista.core.errors import VTKVersionError

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -852,11 +852,11 @@ class ImageDataFilters(DataSetFilters):
         if scalars is None:
             set_default_active_scalars(self)  # type: ignore
             field, scalars = self.active_scalars_info  # type: ignore
-            if field.value != FieldAssociation.POINT:
+            if field != FieldAssociation.POINT:
                 raise ValueError('If `scalars` not given, active scalars must be point array.')
         else:
             field = self.get_array_association(scalars, preference='point')  # type: ignore
-            if field.value != FieldAssociation.POINT:
+            if field != FieldAssociation.POINT:
                 raise ValueError(
                     f'Can only process point data, given `scalars` are {field.name.lower()} data.'
                 )

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -9,7 +9,7 @@ from pyvista.core import _vtk_core as _vtk
 from pyvista.core.errors import AmbiguousDataError, MissingDataError
 from pyvista.core.filters import _get_output, _update_alg
 from pyvista.core.filters.data_set import DataSetFilters
-from pyvista.core.utilities.arrays import set_default_active_scalars
+from pyvista.core.utilities.arrays import FieldAssociation, set_default_active_scalars
 from pyvista.core.utilities.helpers import wrap
 from pyvista.core.utilities.misc import abstract_class
 
@@ -852,12 +852,14 @@ class ImageDataFilters(DataSetFilters):
         if scalars is None:
             set_default_active_scalars(self)  # type: ignore
             field, scalars = self.active_scalars_info  # type: ignore
-            if field.value == 1:
+            if field.value != FieldAssociation.POINT:
                 raise ValueError('If `scalars` not given, active scalars must be point array.')
         else:
             field = self.get_array_association(scalars, preference='point')  # type: ignore
-            if field.value == 1:
-                raise ValueError('Can only process point data, given `scalars` are cell data.')
+            if field.value != FieldAssociation.POINT:
+                raise ValueError(
+                    f'Can only process point data, given `scalars` are {field.name.lower()} data.'
+                )
         alg.SetInputArrayToProcess(
             0, 0, 0, field.value, scalars
         )  # args: (idx, port, connection, field, name)

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -1,5 +1,6 @@
 """Filters with a class to manage filters/algorithms for uniform grid datasets."""
 import collections.abc
+from typing import Optional
 
 import numpy as np
 
@@ -771,4 +772,115 @@ class ImageDataFilters(DataSetFilters):
         alg.SetInputData(self)
         alg.SetFilteredAxes(axis)
         alg.Update()
+        return wrap(alg.GetOutput())
+
+    def contour_labeled(
+        self,
+        n_labels: Optional[int] = None,
+        smoothing: bool = False,
+        smoothing_num_iterations: int = 50,
+        smoothing_relaxation_factor: float = 0.5,
+        smoothing_constraint_distance: float = 1,
+        output_mesh_type: str = 'quads',
+        output_style: str = 'default',
+        scalars: Optional[str] = None,
+        progress_bar: bool = False,
+    ) -> 'pyvista.PolyData':
+        """Generate labeled contours from 3D label maps.
+
+        SurfaceNets algorithm is used to extract contours preserving sharp
+        boundaries for the selected labels from the label maps.
+        Optionally, the boundaries can be smoothened to reduce the staircase
+        appearance in case of low resolution input label maps.
+
+        This filter requires that the :class:`ImageData` has integer point
+        scalars, such as multi-label maps generated from image segmentation.
+
+
+        Parameters
+        ----------
+        n_labels : int, optional
+            Number of labels to be extracted (all are extracted if None is given).
+
+        smoothing : bool, default: False
+            Apply smoothing to the meshes.
+
+        smoothing_num_iterations : int, default: 50
+            Number of smoothing iterations.
+
+        smoothing_relaxation_factor : float, default: 0.5
+            Relaxation factor of the smoothing.
+
+        smoothing_constraint_distance : float, default: 1
+            Constraint distance of the smoothing.
+
+        output_mesh_type : str, default: 'quads'
+            Mesh type - triangles or quads.
+
+        output_style : str, default: 'default'
+            Output style (default, boundary). "selected" is currently not implemented.
+
+        scalars : str, optional
+            Name of scalars to process. Defaults to currently active scalars.
+
+        progress_bar : bool, default: False
+            Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.PolyData
+            :class:`pyvista.PolyData` Labeled mesh with the segments labeled.
+
+        References
+        ----------
+        Sarah F. Frisken, SurfaceNets for Multi-Label Segmentations with Preservation
+        of Sharp Boundaries, Journal of Computer Graphics Techniques (JCGT), vol. 11,
+        no. 1, 34-54, 2022. Available online http://jcgt.org/published/0011/01/03/
+
+        https://www.kitware.com/really-fast-isocontouring/
+
+        Examples
+        --------
+        See :ref:`surface_nets_example` for a full example using this filter.
+        """
+        if not hasattr(_vtk, 'vtkSurfaceNets3D'):  # pragma: no cover
+            from pyvista.core.errors import VTKVersionError
+
+            raise VTKVersionError('Surface nets 3D require VTK 9.3.20230807rc0 or newer.')
+
+        alg = _vtk.vtkSurfaceNets3D()
+        if scalars is None:
+            set_default_active_scalars(self)  # type: ignore
+            field, scalars = self.active_scalars_info  # type: ignore
+            if field.value == 1:
+                raise ValueError('If `scalars` not given, active scalars must be point array.')
+        else:
+            field = self.get_array_association(scalars, preference='point')  # type: ignore
+            if field.value == 1:
+                raise ValueError('Can only process point data, given `scalars` are cell data.')
+        alg.SetInputArrayToProcess(
+            0, 0, 0, field.value, scalars
+        )  # args: (idx, port, connection, field, name)
+        alg.SetInputData(self)
+        if n_labels is not None:
+            alg.GenerateLabels(n_labels, 1, n_labels)
+        if output_mesh_type == 'quads':
+            alg.SetOutputMeshTypeToQuads()
+        elif output_mesh_type == 'triangles':
+            alg.SetOutputMeshTypeToTriangles()
+        if output_style == 'default':
+            alg.SetOutputStyleToDefault()
+        elif output_style == 'boundary':
+            alg.SetOutputStyleToBoundary()
+        else:
+            alg.SetOutputStyleToSelected()
+            raise NotImplementedError(f'Output style "{output_style}" is not implemented')
+        if smoothing:
+            alg.SmoothingOn()
+            alg.GetSmoother().SetNumberOfIterations(smoothing_num_iterations)
+            alg.GetSmoother().SetRelaxationFactor(smoothing_relaxation_factor)
+            alg.GetSmoother().SetConstraintDistance(smoothing_constraint_distance)
+        else:
+            alg.SmoothingOff()
+        _update_alg(alg, progress_bar, 'Performing High Pass Filter')
         return wrap(alg.GetOutput())

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -877,6 +877,10 @@ class ImageDataFilters(DataSetFilters):
             alg.SetOutputMeshTypeToQuads()
         elif output_mesh_type == 'triangles':
             alg.SetOutputMeshTypeToTriangles()
+        else:
+            raise ValueError(
+                f'Invalid output mesh type "{output_mesh_type}", use "quads" or "triangles"'
+            )
         if output_style == 'default':
             alg.SetOutputStyleToDefault()
         elif output_style == 'boundary':
@@ -884,7 +888,7 @@ class ImageDataFilters(DataSetFilters):
         elif output_style == 'selected':
             raise NotImplementedError(f'Output style "{output_style}" is not implemented')
         else:
-            raise ValueError(f'Invalud output style "{output_style}", use "default" or "boundary"')
+            raise ValueError(f'Invalid output style "{output_style}", use "default" or "boundary"')
         if smoothing:
             alg.SmoothingOn()
             alg.GetSmoother().SetNumberOfIterations(smoothing_num_iterations)

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -7,7 +7,7 @@ from pyvista import examples
 VTK93 = pv.vtk_version_info >= (9, 3)
 
 
-@pytest.mark.skipif(not VTK93, reason="At least VTK 9.3 is required")
+@pytest.mark.skipif(not VTK93, reason='At least VTK 9.3 is required')
 def test_contour_labeled():
     # Load a 3D label map (segmentation of a frog's tissue)
     label_map = examples.download_frog_tissue()
@@ -16,11 +16,11 @@ def test_contour_labeled():
     mesh = label_map.contour_labeled()
 
     assert label_map.point_data.active_scalars.max() == 29
-    assert "BoundaryLabels" in mesh.cell_data
-    assert np.max(mesh["BoundaryLabels"][:, 0]) == 29
+    assert 'BoundaryLabels' in mesh.cell_data
+    assert np.max(mesh['BoundaryLabels'][:, 0]) == 29
 
 
-@pytest.mark.skipif(not VTK93, reason="At least VTK 9.3 is required")
+@pytest.mark.skipif(not VTK93, reason='At least VTK 9.3 is required')
 def test_contour_labeled_with_smoothing():
     # Load a 3D label map (segmentation of a frog's tissue)
     label_map = examples.download_frog_tissue()
@@ -29,11 +29,11 @@ def test_contour_labeled_with_smoothing():
     mesh = label_map.contour_labeled(smoothing=True)
     # this somehow mutates the object... also the n_labels is likely not correct
 
-    assert "BoundaryLabels" in mesh.cell_data
-    assert np.max(mesh["BoundaryLabels"][:, 0]) == 29
+    assert 'BoundaryLabels' in mesh.cell_data
+    assert np.max(mesh['BoundaryLabels'][:, 0]) == 29
 
 
-@pytest.mark.skipif(not VTK93, reason="At least VTK 9.3 is required")
+@pytest.mark.skipif(not VTK93, reason='At least VTK 9.3 is required')
 def test_contour_labeled_with_reduced_labels_count():
     # Load a 3D label map (segmentation of a frog's tissue)
     label_map = examples.download_frog_tissue()
@@ -42,86 +42,86 @@ def test_contour_labeled_with_reduced_labels_count():
     mesh = label_map.contour_labeled(n_labels=2)
     # this somehow mutates the object... also the n_labels is likely not correct
 
-    assert "BoundaryLabels" in mesh.cell_data
-    assert np.max(mesh["BoundaryLabels"][:, 0]) == 2
+    assert 'BoundaryLabels' in mesh.cell_data
+    assert np.max(mesh['BoundaryLabels'][:, 0]) == 2
 
 
-@pytest.mark.skipif(not VTK93, reason="At least VTK 9.3 is required")
+@pytest.mark.skipif(not VTK93, reason='At least VTK 9.3 is required')
 def test_contour_labeled_with_triangle_output_mesh():
     # Load a 3D label map (segmentation of a frog's tissue)
     label_map = examples.download_frog_tissue()
 
     # Extract surface for each label
-    mesh = label_map.contour_labeled(scalars="MetaImage", output_mesh_type="triangles")
+    mesh = label_map.contour_labeled(scalars='MetaImage', output_mesh_type='triangles')
 
-    assert "BoundaryLabels" in mesh.cell_data
-    assert np.max(mesh["BoundaryLabels"][:, 0]) == 29
+    assert 'BoundaryLabels' in mesh.cell_data
+    assert np.max(mesh['BoundaryLabels'][:, 0]) == 29
 
 
-@pytest.mark.skipif(not VTK93, reason="At least VTK 9.3 is required")
+@pytest.mark.skipif(not VTK93, reason='At least VTK 9.3 is required')
 def test_contour_labeled_with_boundary_output_style():
     # Load a 3D label map (segmentation of a frog's tissue)
     label_map = examples.download_frog_tissue()
 
     # Extract surface for each label
-    mesh = label_map.contour_labeled(output_style="boundary")
+    mesh = label_map.contour_labeled(output_style='boundary')
 
-    assert "BoundaryLabels" in mesh.cell_data
-    assert np.max(mesh["BoundaryLabels"][:, 0]) == 29
+    assert 'BoundaryLabels' in mesh.cell_data
+    assert np.max(mesh['BoundaryLabels'][:, 0]) == 29
 
 
-@pytest.mark.skipif(not VTK93, reason="At least VTK 9.3 is required")
+@pytest.mark.skipif(not VTK93, reason='At least VTK 9.3 is required')
 def test_contour_labeled_with_invalid_output_mesh_type():
     # Load a 3D label map (segmentation of a frog's tissue)
     label_map = examples.download_frog_tissue()
 
     # Extract surface for each label
     with pytest.raises(ValueError):
-        label_map.contour_labeled(output_mesh_type="invalid")
+        label_map.contour_labeled(output_mesh_type='invalid')
 
 
-@pytest.mark.skipif(not VTK93, reason="At least VTK 9.3 is required")
+@pytest.mark.skipif(not VTK93, reason='At least VTK 9.3 is required')
 def test_contour_labeled_with_invalid_output_style():
     # Load a 3D label map (segmentation of a frog's tissue)
     label_map = examples.download_frog_tissue()
 
     # Extract surface for each label
     with pytest.raises(NotImplementedError):
-        label_map.contour_labeled(output_style="selected")
+        label_map.contour_labeled(output_style='selected')
 
     with pytest.raises(ValueError):
-        label_map.contour_labeled(output_style="invalid")
+        label_map.contour_labeled(output_style='invalid')
 
 
-@pytest.mark.skipif(not VTK93, reason="At least VTK 9.3 is required")
+@pytest.mark.skipif(not VTK93, reason='At least VTK 9.3 is required')
 def test_contour_labeled_with_scalars():
     # Load a 3D label map (segmentation of a frog's tissue)
     # and create a new array with reduced number of labels
     label_map = examples.download_frog_tissue()
-    label_map["labels"] = label_map["MetaImage"] // 2
+    label_map['labels'] = label_map['MetaImage'] // 2
 
     # Extract surface for each label
-    mesh = label_map.contour_labeled(scalars="labels")
+    mesh = label_map.contour_labeled(scalars='labels')
 
-    assert "BoundaryLabels" in mesh.cell_data
-    assert np.max(mesh["BoundaryLabels"][:, 0]) == 14
+    assert 'BoundaryLabels' in mesh.cell_data
+    assert np.max(mesh['BoundaryLabels'][:, 0]) == 14
 
 
-@pytest.mark.skipif(not VTK93, reason="At least VTK 9.3 is required")
+@pytest.mark.skipif(not VTK93, reason='At least VTK 9.3 is required')
 def test_contour_labeled_with_invalid_scalars():
     # Load a 3D label map (segmentation of a frog's tissue)
     label_map = examples.download_frog_tissue()
 
     # Nonexistent scalar key
     with pytest.raises(KeyError):
-        label_map.contour_labeled(scalars="nonexistent_key")
+        label_map.contour_labeled(scalars='nonexistent_key')
 
     # Using cell data
-    label_map.cell_data["cell_data"] = np.zeros(label_map.n_cells)
-    with pytest.raises(ValueError, match="Can only process point data"):
-        label_map.contour_labeled(scalars="cell_data")
+    label_map.cell_data['cell_data'] = np.zeros(label_map.n_cells)
+    with pytest.raises(ValueError, match='Can only process point data'):
+        label_map.contour_labeled(scalars='cell_data')
 
     # When no scalas are given and active scalars are not point data
-    label_map.set_active_scalars("cell_data", preference="cell")
-    with pytest.raises(ValueError, match="active scalars must be point array"):
+    label_map.set_active_scalars('cell_data', preference='cell')
+    with pytest.raises(ValueError, match='active scalars must be point array'):
         label_map.contour_labeled()

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -71,6 +71,16 @@ def test_contour_labeled_with_boundary_output_style():
 
 
 @pytest.mark.skipif(not VTK93, reason="At least VTK 9.3 is required")
+def test_contour_labeled_with_invalid_output_mesh_type():
+    # Load a 3D label map (segmentation of a frog's tissue)
+    label_map = examples.download_frog_tissue()
+
+    # Extract surface for each label
+    with pytest.raises(ValueError):
+        label_map.contour_labeled(output_mesh_type="invalid")
+
+
+@pytest.mark.skipif(not VTK93, reason="At least VTK 9.3 is required")
 def test_contour_labeled_with_invalid_output_style():
     # Load a 3D label map (segmentation of a frog's tissue)
     label_map = examples.download_frog_tissue()

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -1,17 +1,72 @@
 import numpy as np
+import pytest
 
 import pyvista as pv
 from pyvista import examples
 
+VTK93 = pv.vtk_version_info >= (9, 3)
 
-def test_contour_labeled(sphere):
-    if pv.vtk_version_info >= (9, 3, 0):
-        # Load a 3D label map (segmentation of a frog's tissue)
-        label_map = examples.download_frog_tissue()
 
-        # Extract surface for each label
-        mesh = label_map.contour_labeled()
+@pytest.mark.skipif(not VTK93, reason="At least VTK 9.3 is required")
+def test_contour_labeled():
+    # Load a 3D label map (segmentation of a frog's tissue)
+    label_map = examples.download_frog_tissue()
 
-        assert label_map.point_data.active_scalars.max() == 29
-        assert 'BoundaryLabels' in mesh.cell_data
-        assert np.max(mesh['BoundaryLabels']) == 29
+    # Extract surface for each label
+    mesh = label_map.contour_labeled()
+
+    assert label_map.point_data.active_scalars.max() == 29
+    assert "BoundaryLabels" in mesh.cell_data
+    assert np.max(mesh["BoundaryLabels"][:, 0]) == 29
+
+
+@pytest.mark.skipif(not VTK93, reason="At least VTK 9.3 is required")
+def test_contour_labeled_with_smoothing():
+    # Load a 3D label map (segmentation of a frog's tissue)
+    label_map = examples.download_frog_tissue()
+
+    # Extract surface for each label
+    mesh = label_map.contour_labeled(smoothing=True)
+    # this somehow mutates the object... also the n_labels is likely not correct
+
+    assert "BoundaryLabels" in mesh.cell_data
+    assert np.max(mesh["BoundaryLabels"][:, 0]) == 29
+
+
+@pytest.mark.skipif(not VTK93, reason="At least VTK 9.3 is required")
+def test_contour_labeled_with_reduced_labels_count():
+    # Load a 3D label map (segmentation of a frog's tissue)
+    label_map = examples.download_frog_tissue()
+
+    # Extract surface for each label
+    mesh = label_map.contour_labeled(n_labels=2)
+    # this somehow mutates the object... also the n_labels is likely not correct
+
+    assert "BoundaryLabels" in mesh.cell_data
+    assert np.max(mesh["BoundaryLabels"][:, 0]) == 2
+
+
+@pytest.mark.skipif(not VTK93, reason="At least VTK 9.3 is required")
+def test_contour_labeled_with_triangle_output_mesh():
+    # Load a 3D label map (segmentation of a frog's tissue)
+    label_map = examples.download_frog_tissue()
+
+    # Extract smooth surface for each label
+    mesh = label_map.contour_labeled(scalars="MetaImage")
+
+    assert "BoundaryLabels" in mesh.cell_data
+    assert np.max(mesh["BoundaryLabels"][:, 0]) == 29
+
+
+@pytest.mark.skipif(not VTK93, reason="At least VTK 9.3 is required")
+def test_contour_labeled_with_scalars():
+    # Load a 3D label map (segmentation of a frog's tissue)
+    # and create a new array with reduced number of labels
+    label_map = examples.download_frog_tissue()
+    label_map["labels"] = label_map["MetaImage"] // 2
+
+    # Extract smooth surface for each label
+    mesh = label_map.contour_labeled(scalars="labels")
+
+    assert "BoundaryLabels" in mesh.cell_data
+    assert np.max(mesh["BoundaryLabels"][:, 0]) == 14

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -25,7 +25,7 @@ def test_contour_labeled_with_smoothing():
     # Load a 3D label map (segmentation of a frog's tissue)
     label_map = examples.download_frog_tissue()
 
-    # Extract surface for each label
+    # Extract smooth surface for each label
     mesh = label_map.contour_labeled(smoothing=True)
     # this somehow mutates the object... also the n_labels is likely not correct
 
@@ -51,7 +51,7 @@ def test_contour_labeled_with_triangle_output_mesh():
     # Load a 3D label map (segmentation of a frog's tissue)
     label_map = examples.download_frog_tissue()
 
-    # Extract smooth surface for each label
+    # Extract surface for each label
     mesh = label_map.contour_labeled(scalars="MetaImage")
 
     assert "BoundaryLabels" in mesh.cell_data
@@ -65,7 +65,7 @@ def test_contour_labeled_with_scalars():
     label_map = examples.download_frog_tissue()
     label_map["labels"] = label_map["MetaImage"] // 2
 
-    # Extract smooth surface for each label
+    # Extract surface for each label
     mesh = label_map.contour_labeled(scalars="labels")
 
     assert "BoundaryLabels" in mesh.cell_data

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+import pyvista as pv
+from pyvista import examples
+
+
+def test_contour_labeled(sphere):
+    if pv.vtk_version_info >= (9, 3, 0):
+        # Load a 3D label map (segmentation of a frog's tissue)
+        label_map = examples.download_frog_tissue()
+
+        # Extract surface for each label
+        mesh = label_map.contour_labeled()
+
+        assert label_map.point_data.active_scalars.max() == 29
+        assert 'BoundaryLabels' in mesh.cell_data
+        assert np.max(mesh['BoundaryLabels']) == 29


### PR DESCRIPTION
### Overview
This PR adds support for conversion of 3D label maps to labeled surfaces for colored visualization using vtkSurfaceNets3D algorithm from VTK. This is particularly useful for visualization of anatomical structures in medical images from their labels or the outputs of multi-label segmentation maps.

Resolves https://github.com/pyvista/pyvista/issues/5170

### Details
- added contour_labeled to ImageData -  contours can be extracted with `label_map.contour_labeled()`
- added example into the gallery with the frog tissue labels and a simple test for the number of extracted labels in the output mesh
![image](https://github.com/pyvista/pyvista/assets/1239359/4a8be7c7-7c20-4630-8690-cd826b8c7031)
- Note, vtk 9.3+ must be used which is currently in the pre-release stage on PyPI. Otherwise, the support with throw an exception. The example will, however, not be generated, and the test will be blank.


As mentioned in the issue, another appealing example could be made using the great [Neuroparc project](https://github.com/neurodata/neuroparc). Is it acceptable to make an example with an external dataset?
```python
import pooch
import pyvista as pv
file_name = pooch.retrieve(
    "https://github.com/neurodata/neuroparc/raw/master/atlases/label/Human/Schaefer1000_space-MNI152NLin6_res-1x1x1.nii.gz",
    known_hash="c3efe797aab3b3d9e705645bf29fac4e932c88dbe54ccaeb03982f11e66b3249",
)
label_map = pv.read(file_name)
label_map.contour_labeled(smoothing=True).plot(cmap="glasbey_bw")
```
![image](https://github.com/pyvista/pyvista/assets/1239359/00ce2f52-8297-498e-9a30-83a8add16ed2)

Does the name `contour_labeled` fit well with PyVista, or would you suggest a better one?

Also, I added types to the function, and had to silence these Mypy errors (as in https://github.com/pyvista/pyvista/pull/3837): 
```
pyvista/core/filters/image_data.py:853: error: Argument 1 to "set_default_active_scalars" has incompatible type "ImageDataFilters"; expected "DataSet"  [arg-type]
pyvista/core/filters/image_data.py:854: error: "ImageDataFilters" has no attribute "active_scalars_info"  [attr-defined]
pyvista/core/filters/image_data.py:858: error: "ImageDataFilters" has no attribute "get_array_association"  [attr-defined]
```

More info about the algorithm: Sarah F. Frisken, SurfaceNets for Multi-Label Segmentations with Preservation of Sharp Boundaries, Journal of Computer Graphics Techniques (JCGT), vol. 11, no. 1, 34-54, 2022. Available online http://jcgt.org/published/0011/01/03/