### PR TITLE
Remove `cell_arrays` in documentation

### DIFF
--- a/doc/source/user-guide/simple.rst
+++ b/doc/source/user-guide/simple.rst
@@ -116,7 +116,7 @@ access an array on that dataset, then add some more data:
 
     Assign a new array to the cell data:
 
-    >>> mesh.cell_arrays['foo'] = np.random.rand(mesh.n_cells)
+    >>> mesh.cell_data['foo'] = np.random.rand(mesh.n_cells)
 
     Don't remember if your array is point or cell data? You can
     directly query the mesh object and access the array from the


### PR DESCRIPTION
### Overview

From https://github.com/pyvista/pyvista/discussions/1481#discussioncomment-7577231, I noticed that `cell_arrays` is still used in this one spot.


### Details

Not sure how this still worked in the documentation since `cell_arrays` doesn't exist anymore


