### PR TITLE
Suppress VTK debug messages in contour_labeled and fix extract_all_edges logging level restoration

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1579,11 +1579,12 @@ class DataSetFilters:
                     'This version of VTK does not support `use_all_points=True`. '
                     'VTK v9.1 or newer is required.'
                 )
-        # vtkExtractEdges improperly uses INFO for debugging messages
+        # Suppress improperly used INFO for debugging messages in vtkExtractEdges
+        verbosity = _vtk.vtkLogger.GetCurrentVerbosityCutoff()
         _vtk.vtkLogger.SetStderrVerbosity(_vtk.vtkLogger.VERBOSITY_OFF)
         _update_alg(alg, progress_bar, 'Extracting All Edges')
-        # Reset vtkLogger to default verbosity level
-        _vtk.vtkLogger.SetStderrVerbosity(_vtk.vtkLogger.VERBOSITY_INFO)
+        # Restore the original vtkLogger verbosity level
+        _vtk.vtkLogger.SetStderrVerbosity(verbosity)
         output = _get_output(alg)
         if clear_data:
             output.clear_data()

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -896,5 +896,10 @@ class ImageDataFilters(DataSetFilters):
             alg.GetSmoother().SetConstraintDistance(smoothing_constraint_distance)
         else:
             alg.SmoothingOff()
+        # Suppress improperly used INFO for debugging messages in vtkSurfaceNets3D
+        verbosity = _vtk.vtkLogger.GetCurrentVerbosityCutoff()
+        _vtk.vtkLogger.SetStderrVerbosity(_vtk.vtkLogger.VERBOSITY_OFF)
         _update_alg(alg, progress_bar, 'Performing Labeled Surface Extraction')
+        # Restore the original vtkLogger verbosity level
+        _vtk.vtkLogger.SetStderrVerbosity(verbosity)
         return cast(pyvista.PolyData, wrap(alg.GetOutput()))


### PR DESCRIPTION
### Overview

As reported by @eigenvivek and discussed with @banesullivan, calling `contour_labeled` can result in internal VTK debug messages being printed: https://github.com/pyvista/pyvista/pull/5176#issuecomment-1826372786

This is caused by vtkSurfaceNets3D using INFO logging level for its debug messages.

The same situation is handled in `extract_all_edges` (vtkExtractEdges).
Here, the verbosity level gets restored to the INFO level instead of the value used before the call. This might inadvertently override the verbosity level set elsewhere.

In this PR, update both filters to suppress the debug/info messages during their update call and make sure that the logging levels are restored back to their original values.

### Details

- `contour-labeled`: suppress logging before vtkSurfaceNets3D filter update, restore the logging verbosity level to the original value
- `extract_all_edges`: restore the logging verbosity level to its original value
