### PR TITLE
Default to matplotlib-base for conda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - vtk
   - scooby>=0.5.1
   - meshio
-  - matplotlib
+  - matplotlib-base
   - imageio>=2.5.0
   - imageio-ffmpeg
   - colorcet


### PR DESCRIPTION
### Overview

Opt to use `matplotlib-base` instead of `matplotlib` in the `environment.yml` for `conda`.

This will potentially resolve with fewer dependencies i.e., `matplotlib` additionally depends on `pyqt` and `tornado`, see [here](https://github.com/conda-forge/matplotlib-feedstock/blob/main/recipe/meta.yaml#L88-L89).