### PR TITLE
Add command that preview forked pull request doc

### DIFF
--- a/.github/workflows/preview_pull_request.yml
+++ b/.github/workflows/preview_pull_request.yml
@@ -1,0 +1,105 @@
+name: Preview Pull Request
+on:
+  issue_comment:
+    types:
+      - created
+
+env:
+  USE_CACHE: ${{ (github.event_name == 'issue_comment') }}
+
+jobs:
+  doc:
+    name: Build Documentation
+    if: |
+      github.event_name == 'issue_comment'
+      && github.event.action == 'created'
+      && github.event.issue.pull_request != null
+      && startsWith(github.event.comment.body, 'github-actions preview')
+    runs-on: ubuntu-20.04
+    env:
+      PYVISTA_OFF_SCREEN: 'True'
+      ALLOW_PLOTTING: true
+      SHELLOPTS: 'errexit:pipefail'
+    steps:
+      - uses: sushichop/action-repository-permission@v1
+        with:
+          required-permission: write
+          reaction-permitted: rocket
+          comment-not-permitted: You don't have permission to deploy. Please ask @pyvista/developers to deploy.
+
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements_docs.txt
+
+      - uses: awalsh128/cache-apt-pkgs-action@v1.1.3
+        with:
+          packages: libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime
+          version: 3.0
+
+      - name: Install PyVista and dependencies
+        run: |
+          pip install -e . --no-deps
+          pip install -r requirements_docs.txt
+
+      - name: Install custom OSMesa VTK variant
+        run: |
+          pip uninstall vtk -y
+          pip install vtk-osmesa==9.3.0 --index-url https://gitlab.kitware.com/api/v4/projects/13/packages/pypi/simple
+
+      - name: PyVista Report
+        run: |
+          python -c "import pyvista;print(pyvista.Report())"
+          echo PYVISTA_EXAMPLE_DATA_PATH=$(python -c "from pyvista import examples; print(examples.USER_DATA_PATH)") >> $GITHUB_ENV
+          pip list
+
+      - name: Cache Sphinx-Gallery Examples
+        uses: actions/cache@v3
+        if: env.USE_CACHE == 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/v')
+        with:
+          path: doc/source/examples/
+          key: doc-examples-${{ hashFiles('pyvista/_version.py') }}
+
+      - name: Cache example data
+        uses: actions/cache@v3
+        if: env.USE_CACHE == 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/v')
+        with:
+          path: ${{ env.PYVISTA_EXAMPLE_DATA_PATH }}
+          key: example-data-1-${{ hashFiles('pyvista/_version.py') }}
+
+      - name: Build Documentation
+        run: make -C doc html
+
+      - name: Copy ads.txt
+        run: cp doc/source/ads.txt doc/_build/html/
+
+      - name: Dump Sphinx Warnings and Errors
+        if: always()
+        run: if [ -e doc/sphinx_warnings.txt ]; then cat doc/sphinx_warnings.txt; fi
+
+      - name: Dump VTK Warnings and Errors
+        if: always()
+        run: if [ -e doc/errors.txt ]; then cat doc/errors.txt; fi
+
+      - name: Preview HTML documentation
+        uses: nwtgck/actions-netlify@v2.1
+        with:
+          publish-dir: doc/_build/html/
+          production-deploy: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions"
+          enable-pull-request-comment: true
+          enable-commit-comment: true
+          overwrites-pull-request-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 10


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
We added a GitHub Actions in #4934 a while back that shows a documentation preview of a pull request. And now it is working very well.

However, the forked repository does not allow access to secret variables due to permission issues. So this is only a branch in the repository.

In its current state, for example, #4938, where previewing the document is important for review, a new PR is created to preview the document, as in #5141. However, this is a cumbersome and ridiculous state of affairs. We also have the hassle of creating extra PRs because we did not check the preview of the document, as in #5243.

Therefore, I have made it possible to preview from forked repositories as in #5024 in the past. However, @MatthewFlamm 's excellent insight revealed that there is a security risk.

This proposal is a solution that avoids the above risks. When a PR is sent from a forked repository, the maintainer will verify that it is not a security risk. Then, if it is determined that there is no problem, the following command is executed to preview the document.

```
github-actions preview
```

This is a command inspired by `pre-commit.ci autofix`. Also, the configuration of GitHubActions was inspired by https://github.com/sushichop/action-repository-permission.
<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

I tested this in https://github.com/pyvista/pyvista-tutorial and it works well (https://github.com/pyvista/pyvista-tutorial/pull/197).

![image](https://github.com/pyvista/pyvista/assets/7513610/fa1865c5-19a6-45b2-93fb-724e96858bfa)

