### PR TITLE
Update data_set.py to skip doctest of  `get_data_range`

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -6416,7 +6416,7 @@ class DataSetFilters:
 
         Show range of labels
 
-        >>> image_labels.get_data_range()
+        >>> image_labels.get_data_range()  # doctest:+SKIP
         (0, 29)
 
         Find 'gaps' in the labels
@@ -6433,7 +6433,7 @@ class DataSetFilters:
 
         Show range of packed labels
 
-        >>> packed_labels.get_data_range()
+        >>> packed_labels.get_data_range()  # doctest:+SKIP
         (0, 25)
 
         """


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
The following error occurs about once every two times in CI's doctest.
This is a new feature added in vtk 9.3 and is most likely a bug.
Please let us skip this test temporarily.

```bash
=================================== FAILURES ===================================
______ [doctest] pyvista.core.filters.data_set.DataSetFilters.pack_labels ______
6410 
6411         Load non-contiguous image labels
6412 
6413         >>> from pyvista import examples
6414         >>> import numpy as np
6415         >>> image_labels = examples.download_frog_tissue()
6416 
6417         Show range of labels
6418 
6419         >>> image_labels.get_data_range()
Expected:
    (0, 29)
Got:
    (0, 255)
```

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None