### PR TITLE
Fix docstring of `DataSet.cell_neighbors_levels`

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -3092,7 +3092,7 @@ class DataSet(DataSetFilters, DataObject):
 
         n_levels : int, default: 1
             Number of levels to search for cell neighbors.
-            When equal to 1, it is equivalent to :func:`pyvista.DataSet.point_neighbors`.
+            When equal to 1, it is equivalent to :func:`pyvista.DataSet.cell_neighbors`.
 
         Returns
         -------


### PR DESCRIPTION
`cell_neighbors_levels` refers to `point_neighbors` when it should be `cell_neighbors`. Probably a copy-paste artifact.