### PR TITLE
Add `ruff` linter config to `pyproject.toml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,3 +105,9 @@ repos:
   rev: 0.27.2
   hooks:
     - id: check-github-workflows
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.1.7
+  hooks:
+    - id: ruff
+      args: [ --fix ]

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,9 @@ PyVista
 .. |pre-commit.ci status| image:: https://results.pre-commit.ci/badge/github/pyvista/pyvista/main.svg
    :target: https://results.pre-commit.ci/latest/github/pyvista/pyvista/main
 
+.. |Ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
+   :target: https://github.com/astral-sh/ruff
+   :alt: Ruff
 
 +----------------------+------------------------+-------------+
 | Deployment           | |pypi|                 | |conda|     |
@@ -79,6 +82,8 @@ PyVista
 | Community            | |slack|                | |discuss|   |
 +----------------------+------------------------+-------------+
 | Formatter            | |black|                | |isort|     |
++----------------------+------------------------+-------------+
+| Linter               | |Ruff|                               |
 +----------------------+------------------------+-------------+
 | Affiliated           | |NumFOCUS Affiliated|                |
 +----------------------+------------------------+-------------+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -271,3 +271,45 @@ exclude = [  # don't report on objects that match any of these regex
     '\.PyVistaRemoteLocalView(\.|$)',
     '\.Texture(\.|$)',  # awaiting Texture refactor
 ]
+
+[tool.ruff]
+exclude = [
+    '.git',
+    'pycache__',
+    'build',
+    'dist',
+    'doc/examples',
+    'doc/_build',
+]
+line-length = 100
+indent-width = 4
+target-version = 'py39'
+
+[tool.ruff.lint]
+ignore = [
+    # whitespace before ':'
+    "E203",
+    # line break before binary operator
+    # "W503",
+    # line length too long
+    "E501",
+    # do not assign a lambda expression, use a def
+    "E731",
+    # too many leading '#' for block comment
+    "E266",
+    # ambiguous variable name
+    "E741",
+    # module level import not at top of file
+    "E402",
+    # Quotes (temporary)
+    "Q0",
+    # bare excepts (temporary)
+    # "B001", "E722",
+    "E722",
+    # we already check black
+    # "BLK100",
+    # 'from module import *' used; unable to detect undefined names
+    "F403",
+]
+fixable = ["ALL"]
+unfixable = []

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -90,7 +90,7 @@ def __getattr__(name):
 
     try:
         feature = inspect.getattr_static(sys.modules['pyvista.plotting'], name)
-    except AttributeError as e:
+    except AttributeError:
         raise AttributeError(f"module 'pyvista' has no attribute '{name}'") from None
 
     return feature

--- a/pyvista/core/input_validation/__init__.py
+++ b/pyvista/core/input_validation/__init__.py
@@ -1,5 +1,5 @@
 """Input validation functions."""
-from .check import (  # noqa: 401
+from .check import (  # noqa: F401
     check_has_length,
     check_has_shape,
     check_is_arraylike,
@@ -24,7 +24,7 @@ from .check import (  # noqa: 401
     check_is_subdtype,
     check_is_type,
 )
-from .validate import (  # noqa: 401
+from .validate import (  # noqa: F401
     validate_array,
     validate_array3,
     validate_arrayN,

--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -220,7 +220,7 @@ class Camera(_vtk.vtkCamera):
             tmp.attrib["index"] = "0"
 
             val = getattr(self, attr)
-            if type(val) is not bool:
+            if not isinstance(val, bool):
                 tmp.attrib["value"] = str(val)
                 e.append(tmp)
             else:

--- a/pyvista/trame/ui/base_viewer.py
+++ b/pyvista/trame/ui/base_viewer.py
@@ -8,7 +8,6 @@ See `pyvista.trame.ui.vuetify2` and ``pyvista.trame.ui.vuetify3` for its derived
 import io
 
 from trame.app import get_server
-from trame.widgets import html
 from trame_client.ui.core import AbstractLayout
 
 import pyvista

--- a/tests/core/test_datasetattributes.py
+++ b/tests/core/test_datasetattributes.py
@@ -454,7 +454,7 @@ def test_length_should_be_0_on_clear(insert_arange_narray):
 def test_keys_should_be_strings(insert_arange_narray):
     dsa, sample_array = insert_arange_narray
     for name in dsa.keys():
-        assert type(name) is str
+        assert isinstance(name, str)
 
 
 def test_key_should_exist(insert_arange_narray):

--- a/tests/core/test_input_validation.py
+++ b/tests/core/test_input_validation.py
@@ -65,7 +65,7 @@ from pyvista.core.utilities.arrays import cast_to_tuple_array, vtkmatrix_from_ar
 )
 def test_validate_transform_as_array4x4(transform_like):
     result = validate_transform4x4(transform_like)
-    assert type(result) is np.ndarray
+    assert isinstance(result, np.ndarray)
     assert np.array_equal(result, np.eye(4))
 
 
@@ -86,7 +86,7 @@ def test_validate_transform_as_array4x4_raises():
 )
 def test_validate_transform_as_array3x3(transform_like):
     result = validate_transform3x3(transform_like)
-    assert type(result) is np.ndarray
+    assert isinstance(result, np.ndarray)
     assert np.array_equal(result, np.eye(3))
 
 
@@ -145,11 +145,11 @@ def test_validate_number():
     validate_number([2.0])
     num = validate_number(1)
     assert num == 1
-    assert type(num) is int
+    assert isinstance(num, int)
 
     num = validate_number(2.0, to_list=False, must_have_shape=(), reshape=False)
     assert num == 2.0
-    assert type(num) is np.ndarray
+    assert isinstance(num, np.ndarray)
     assert num.dtype.type is np.float64
 
     msg = (
@@ -168,7 +168,7 @@ def test_validate_data_range():
     assert rng == [0.0, 2.5]
 
     rng = validate_data_range((-10, -10), to_tuple=False, must_have_shape=2)
-    assert type(rng) is np.ndarray
+    assert isinstance(rng, np.ndarray)
 
     msg = "Data Range [1 0] must be sorted in ascending order."
     with pytest.raises(ValueError, match=escape(msg)):
@@ -504,19 +504,19 @@ def test_validate_array(
     # Check output
     if np.array(array_in).ndim == 0 and (to_tuple or to_list):
         # test scalar input results in scalar output
-        assert type(array_out) is float or type(array_out) is int
+        assert isinstance(array_out, float) or isinstance(array_out, int)
     elif to_tuple:
-        assert type(array_out) is tuple
+        assert isinstance(array_out, tuple)
     elif to_list:
-        assert type(array_out) is list
+        assert isinstance(array_out, list)
     else:
         assert isinstance(array_out, np.ndarray)
         assert array_out.dtype.type is dtype_out
         if as_any:
             if input_type is pyvista_ndarray:
-                assert type(array_out) is pyvista_ndarray
+                assert isinstance(array_out, pyvista_ndarray)
             elif input_type is np.ndarray:
-                assert type(array_out) is np.ndarray
+                assert isinstance(array_out, np.ndarray)
             if (
                 not copy
                 and isinstance(array_in, np.ndarray)
@@ -526,7 +526,7 @@ def test_validate_array(
             else:
                 assert array_out is not array_in
         else:
-            assert type(array_out) is np.ndarray
+            assert isinstance(array_out, np.ndarray)
 
     if copy:
         assert array_out is not array_in
@@ -552,7 +552,7 @@ def test_check_is_instance(obj, classinfo, allow_subclass, name):
                 check_is_instance(obj, classinfo, name=name)
 
     else:
-        if type(classinfo) is tuple:
+        if isinstance(classinfo, tuple):
             if type(obj) in classinfo:
                 check_is_type(obj, classinfo)
             else:

--- a/tests/core/test_input_validation.py
+++ b/tests/core/test_input_validation.py
@@ -65,7 +65,7 @@ from pyvista.core.utilities.arrays import cast_to_tuple_array, vtkmatrix_from_ar
 )
 def test_validate_transform_as_array4x4(transform_like):
     result = validate_transform4x4(transform_like)
-    assert isinstance(result, np.ndarray)
+    assert type(result) is np.ndarray
     assert np.array_equal(result, np.eye(4))
 
 
@@ -86,7 +86,7 @@ def test_validate_transform_as_array4x4_raises():
 )
 def test_validate_transform_as_array3x3(transform_like):
     result = validate_transform3x3(transform_like)
-    assert isinstance(result, np.ndarray)
+    assert type(result) is np.ndarray
     assert np.array_equal(result, np.eye(3))
 
 
@@ -149,7 +149,7 @@ def test_validate_number():
 
     num = validate_number(2.0, to_list=False, must_have_shape=(), reshape=False)
     assert num == 2.0
-    assert isinstance(num, np.ndarray)
+    assert type(num) is np.ndarray
     assert num.dtype.type is np.float64
 
     msg = (
@@ -168,7 +168,7 @@ def test_validate_data_range():
     assert rng == [0.0, 2.5]
 
     rng = validate_data_range((-10, -10), to_tuple=False, must_have_shape=2)
-    assert isinstance(rng, np.ndarray)
+    assert type(rng) is np.ndarray
 
     msg = "Data Range [1 0] must be sorted in ascending order."
     with pytest.raises(ValueError, match=escape(msg)):
@@ -506,7 +506,7 @@ def test_validate_array(
         # test scalar input results in scalar output
         assert isinstance(array_out, float) or isinstance(array_out, int)
     elif to_tuple:
-        assert isinstance(array_out, tuple)
+        assert type(array_out) is tuple
     elif to_list:
         assert isinstance(array_out, list)
     else:
@@ -514,9 +514,9 @@ def test_validate_array(
         assert array_out.dtype.type is dtype_out
         if as_any:
             if input_type is pyvista_ndarray:
-                assert isinstance(array_out, pyvista_ndarray)
+                assert type(array_out) is pyvista_ndarray
             elif input_type is np.ndarray:
-                assert isinstance(array_out, np.ndarray)
+                assert type(array_out) is np.ndarray
             if (
                 not copy
                 and isinstance(array_in, np.ndarray)
@@ -526,7 +526,7 @@ def test_validate_array(
             else:
                 assert array_out is not array_in
         else:
-            assert isinstance(array_out, np.ndarray)
+            assert type(array_out) is np.ndarray
 
     if copy:
         assert array_out is not array_in
@@ -552,7 +552,7 @@ def test_check_is_instance(obj, classinfo, allow_subclass, name):
                 check_is_instance(obj, classinfo, name=name)
 
     else:
-        if isinstance(classinfo, tuple):
+        if type(classinfo) is tuple:
             if type(obj) in classinfo:
                 check_is_type(obj, classinfo)
             else:


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
We previously considered introducing ruff (https://github.com/astral-sh/ruff) and dismissed it (https://github.com/pyvista/pyvista/pull/4115). On the other hand, the `matplotlib` project has introduced ruff (https://github.com/matplotlib/matplotlib/pull/25147) and `numpy` project is also considering using it. ruff has a linter and a formatter, Last time I tried to introduce both of those, I failed. So this time I would like to propose only the linter which has less impact.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None