### PR TITLE
Ignore dependabot and pre-commit-ci PR for release

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         labels: maintenance
     - uses: actions-ecosystem/action-add-labels@v1
-      if: startsWith(github.event.pull_request.head.ref, 'junk') || startsWith(github.event.pull_request.head.ref, 'dependabot') || startsWith(github.event.pull_request.head.ref, 'pre-commit-ci-update-config')
+      if: startsWith(github.event.pull_request.head.ref, 'junk') || github.actor == 'dependabot[bot]' || github.actor == 'github-actions[bot]' ||  github.actor == 'pre-commit-ci[bot]'
       with:
         labels: ignore-for-release
     - uses: actions-ecosystem/action-add-labels@v1

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         labels: maintenance
     - uses: actions-ecosystem/action-add-labels@v1
-      if: startsWith(github.event.pull_request.head.ref, 'junk')
+      if: startsWith(github.event.pull_request.head.ref, 'junk') || startsWith(github.event.pull_request.head.ref, 'dependabot') || startsWith(github.event.pull_request.head.ref, 'pre-commit-ci-update-config')
       with:
         labels: ignore-for-release
     - uses: actions-ecosystem/action-add-labels@v1


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
PR of @dependabot and @pre-commit-ci is noisy to read [v0.43.0 release note](https://github.com/pyvista/pyvista/releases/tag/v0.43.0). Let's add [ignore-for-release](https://github.com/pyvista/pyvista/labels/ignore-for-release) to them and remove it from the release note.
<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None