### PR TITLE
Add a hook before updating vtkAlgorithms

### DIFF
--- a/pyvista/core/_typing_core.py
+++ b/pyvista/core/_typing_core.py
@@ -1,10 +1,10 @@
 """Type aliases for type hints."""
-from typing import Sequence, Tuple, Union
+from typing import Callable, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
 
-from pyvista.core._vtk_core import vtkMatrix3x3, vtkMatrix4x4, vtkTransform
+from pyvista.core._vtk_core import vtkAlgorithm, vtkMatrix3x3, vtkMatrix4x4, vtkTransform
 
 NumpyNumArray = npt.NDArray[np.number]
 NumpyFltArray = npt.NDArray[np.floating]
@@ -24,3 +24,5 @@ IntMatrix = Union[NumpyIntArray, Sequence[IntVector]]
 FloatMatrix = Union[NumpyFltArray, Sequence[FloatVector]]
 TransformLike = Union[FloatMatrix, vtkMatrix3x3, vtkMatrix4x4, vtkTransform]
 BoundsLike = Tuple[Number, Number, Number, Number, Number, Number]
+
+VTKAlgorithmHook = Optional[Callable[[vtkAlgorithm], None]]

--- a/pyvista/core/filters/__init__.py
+++ b/pyvista/core/filters/__init__.py
@@ -25,12 +25,22 @@ Examples
 # flake8: noqa: F401
 
 import pyvista
+from pyvista.core import _vtk_core as _vtk
+from pyvista.core._typing_core import VTKAlgorithmHook
 from pyvista.core.utilities.helpers import wrap
 from pyvista.core.utilities.observers import ProgressMonitor
 
 
-def _update_alg(alg, progress_bar=False, message=''):
+def _update_alg(
+    alg: _vtk.vtkAlgorithm,
+    progress_bar=False,
+    message='',
+    algo_hook: VTKAlgorithmHook = None,
+):
     """Update an algorithm with or without a progress bar."""
+    if algo_hook is not None:
+        algo_hook(alg)
+
     if progress_bar:
         with ProgressMonitor(alg, message=message):
             alg.Update()
@@ -39,7 +49,12 @@ def _update_alg(alg, progress_bar=False, message=''):
 
 
 def _get_output(
-    algorithm, iport=0, iconnection=0, oport=0, active_scalars=None, active_scalars_field='point'
+    algorithm,
+    iport=0,
+    iconnection=0,
+    oport=0,
+    active_scalars=None,
+    active_scalars_field='point',
 ):
     """Get the algorithm's output and copy input's pyvista meta info."""
     ido = wrap(algorithm.GetInputDataObject(iport, iconnection))

--- a/pyvista/core/filters/__init__.py
+++ b/pyvista/core/filters/__init__.py
@@ -49,12 +49,7 @@ def _update_alg(
 
 
 def _get_output(
-    algorithm,
-    iport=0,
-    iconnection=0,
-    oport=0,
-    active_scalars=None,
-    active_scalars_field='point',
+    algorithm, iport=0, iconnection=0, oport=0, active_scalars=None, active_scalars_field='point'
 ):
     """Get the algorithm's output and copy input's pyvista meta info."""
     ido = wrap(algorithm.GetInputDataObject(iport, iconnection))

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -28,6 +28,8 @@ from pyvista.core.utilities.geometric_objects import NORMALS
 from pyvista.core.utilities.helpers import generate_plane, wrap
 from pyvista.core.utilities.misc import abstract_class, assert_empty_kwargs
 
+from .._typing_core import VTKAlgorithmHook
+
 
 @abstract_class
 class DataSetFilters:
@@ -2099,7 +2101,7 @@ class DataSetFilters:
         _update_alg(alg, progress_bar, 'Computing Cell Sizes')
         return _get_output(alg)
 
-    def cell_centers(self, vertex=True, progress_bar=False):
+    def cell_centers(self, vertex=True, progress_bar=False, algo_hook: VTKAlgorithmHook = None):
         """Generate points at the center of the cells in this dataset.
 
         These points can be used for placing glyphs or vectors.
@@ -2111,6 +2113,10 @@ class DataSetFilters:
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
+
+        algo_hook : VTKAlgorithmHook, optional
+            Hook used to modify the underlying vtkAlgorithm
+            before update.
 
         Returns
         -------
@@ -2140,7 +2146,9 @@ class DataSetFilters:
         alg = _vtk.vtkCellCenters()
         alg.SetInputDataObject(self)
         alg.SetVertexCells(vertex)
-        _update_alg(alg, progress_bar, 'Generating Points at the Center of the Cells')
+        _update_alg(
+            alg, progress_bar, 'Generating Points at the Center of the Cells', algo_hook=algo_hook
+        )
         return _get_output(alg)
 
     def glyph(


### PR DESCRIPTION
### Overview

What's really valuable when it comes to using `pyvista` is that because all objects (`PolyData`, `UnstructuredGrid` ...) inherit from their `vtk` counterparts, they can be directly passed to `vtkAlgorithm`s.
Therefore, if you need to use a `vtkAlgorithm` which is not already wrapped in `pyvista`, you can combine the best of both worlds very easily by using the vtk syntax.

One downside is that the implementations inside the `pyvista` filters API might miss some features of their underlying `vtkAlgorithm`. For example, the algorithm might have more features when changing the vtk version, or some algorithm features have not been considered to be of interest when implementing for the first time the API.

When a users (IMHO it mostly concerns people with some background on vtk) encounters such limitation, an easy workaround is to look at the code inside the `pyvista`'s filters API he wants to use, copy-paste the code instantiating and modifying the `vtkAlgorithm` and set the algorithm input as any `pyvista` object (due to the previously described inheritance).

In order to simplify such scenario, prevent re-inventing the wheel and having boilerplate code, this PR plans to add a `algo_hook` parameter to all filtering methods.
The `algo_hook` value is a callable taking the `vtkAlgorithm` as input in order to modify it on-the-fly before the `Update` is called.
For example, with this PR:

```python
import pyvista as pv
import vtk


def hook(algo: vtk.vtkCellCenters):
    algo.SetCopyArrays(False)


mesh = pv.Sphere()
mesh.cell_data["foo"] = 1
centers = mesh.cell_centers(algo_hook=hook)
"foo" in centers.cell_data
```
```python
False
```

### Notes
Currently, the PR implements such feature for a single filter (`DataSetFilters.cell_centers`) only to show the proof of concept and start to discuss about:
1. whether this feature could be of interest
2. if of interest, the implementation details (name of the parameter, type annotations ...)

Indeed, I counted around a hundred calls to `_update_alg` in the codebase, which means that decisions must be taken beforehand and carefully.