### PR TITLE
Make pyvista/kitware team code owners to trame modules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,4 @@
 .github/workflows/docs.yml                          @banesullivan
 .github/workflows/docker-package.yml                @banesullivan
 .github/workflows/vtk-pre-test.yml                  @banesullivan
+/pyvista/trame/                                     @pyvista/kitware


### PR DESCRIPTION
@pyvista/kitware, I recently set up this team to house all our excellent collaborators at Kitware! I'd like to use this group to ping you folks when critical but specifically to automatically assign someone from Kitware as a reviewer anytime the trame-related modules in PyVista are adjusted.

Does this sound good to you all? Feel free to add other sections of the code you'd like to take ownership of!