### PR TITLE
Optimize auto approval workflow

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -2,24 +2,21 @@ name: Approve PRs
 on:
   workflow_dispatch:
   issue_comment:
-    types: [created, edited]
-
-env:
-  # sintax: ("tkoyama010" "author2")
-  ALLOWED_AUTHORS: ("tkoyama010", "banesullivan", "akaszynski")
+    types: [created]
 
 jobs:
   autoapprove:
-    # This job only runs for pull request comments
+    # This job only runs for pull request comments by approved users on creation
     name: PR comment
-    if: ${{ github.event.issue.pull_request }}
+    if: ${{
+      github.event.issue.pull_request &&
+      contains(("tkoyama010", "banesullivan", "akaszynski"), github.event.comment.user.login) &&
+      contains(github.event.comment.body, '@pyvista-bot LGTM') }}
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: hmarr/auto-approve-action@v3
-        if: |
-          contains(github.event.comment.body, '@pyvista-bot LGTM') && contains(env.ALLOWED_AUTHORS, github.event.comment.user.login)
         with:
           review-message: ":white_check_mark: Approving this PR because [${{ github.event.comment.user.login }}](https://github.com/${{ github.event.comment.user.login }}) said so in [here](${{ github.event.comment.html_url }}) :grimacing:"
           pull-request-number: ${{ github.event.issue.number }}

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -8,16 +8,18 @@ jobs:
   autoapprove:
     # This job only runs for pull request comments by approved users on creation
     name: PR comment
-    if: ${{
-      github.event.issue.pull_request &&
-      contains(("tkoyama010", "banesullivan", "akaszynski"), github.event.comment.user.login) &&
-      contains(github.event.comment.body, '@pyvista-bot LGTM') }}
+    if: github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@pyvista-bot LGTM') && (
+        github.event.comment.user.login == 'banesullivan' ||
+        github.event.comment.user.login == 'tkoyama010' ||
+        github.event.comment.user.login == 'akaszynski'
+      )
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: hmarr/auto-approve-action@v3
         with:
-          review-message: ":white_check_mark: Approving this PR because [${{ github.event.comment.user.login }}](https://github.com/${{ github.event.comment.user.login }}) said so in [here](${{ github.event.comment.html_url }}) :grimacing:"
+          review-message: ":white_check_mark: Approving this PR because [${{ github.event.comment.user.login }}](https://github.com/${{ github.event.comment.user.login }}) said so in [here](${{ github.event.comment.html_url }}) :shipit:"
           pull-request-number: ${{ github.event.issue.number }}
           github-token: ${{ secrets.PYVISTA_BOT_TOKEN }}


### PR DESCRIPTION
I'm not totally sure if this will fix things, but I'm hoping that by moving the condtional from a workflow step to the job level, GitHub Actions will be able to parse whether or not it needs to spin up a runner or not.

At present, this workflow is eating up a ton of our CI bandwidth as it is spinning up a runner for every single PR comment *and* every time a comment is edited.

I went a step further and turned off runs for comment edits.