### PR TITLE
Deploy preview document only from command

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -93,21 +93,6 @@ jobs:
         if: always()
         run: if [ -e doc/errors.txt ]; then cat doc/errors.txt; fi
 
-      - name: Preview HTML documentation
-        uses: nwtgck/actions-netlify@v2.1
-        with:
-          publish-dir: doc/_build/html/
-          production-branch: main
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "Deploy from GitHub Actions"
-          enable-pull-request-comment: true
-          enable-commit-comment: true
-          overwrites-pull-request-comment: true
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        timeout-minutes: 10
-
       - name: Upload HTML documentation
         if: always()
         uses: actions/upload-artifact@v3

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -782,12 +782,7 @@ branch.
 Preview the Documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Once you have make a Pull Request from the pyvista organization repository branch.
-This will automatically deploy the Preview Documentation.
-Please check the documentation that is deployed by your Pull Request
-before merging.
-
-Once you have make a Pull Request from the forked repository. You can comment
+Once you have make a Pull Request. You can comment
 `github-actions preview` on a pull request to preview documentation.
 Since this command is only available for
 `@pyvista/developers <https://github.com/orgs/pyvista/teams/developers>`_ ,


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Now we have `github-actions preview` command to deploy preview. So we don't need the deployment of `docs.yml` anymore.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None
