### PR TITLE
Fix Error: Not all objects GCed in `test_affine_widget` function

### DIFF
--- a/tests/plotting/test_widgets.py
+++ b/tests/plotting/test_widgets.py
@@ -583,6 +583,9 @@ def test_affine_widget(sphere):
     assert not widget._circles
     assert not widget._arrows
 
+    interact_calls = []
+    release_calls = []
+
 
 def test_logo_widget(verify_image_cache):
     pl = pv.Plotter()


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Ad reported in #5334, we sometimes have a GC error in `test_affine_widget` function.
I suspect it is because `interact_calls` and `release_calls` is not removed.
I hope this change will reduce errors in the `test_affine_widget` function.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None