### PR TITLE
Bump artifacts action version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -95,12 +95,12 @@ jobs:
 
       - name: Upload HTML documentation
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs-build
           path: doc/_build/html/
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: examples
           path: doc/source/examples/
@@ -110,7 +110,7 @@ jobs:
           mkdir _notebooks
           find doc/source/examples -type f -name '*.ipynb' | cpio -p -d -v _notebooks/
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pyvista-notebooks
           path: _notebooks
@@ -122,7 +122,7 @@ jobs:
   #   if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
   #   steps:
   #     - uses: actions/checkout@v4
-  #     - uses: actions/download-artifact@v3
+  #     - uses: actions/download-artifact@v4
   #       with:
   #         name: docs-build
   #         path: .
@@ -160,7 +160,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pip install cookiecutter
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: pyvista-notebooks
           path: .


### PR DESCRIPTION
### Overview

This PR bypasses dependabot update in an attempt to speed up documentation in the effort for #5352.  v4 of `upload-artifact` and `download-artifact` are reported to be faster, up to 90% improvement in some cases.


### Details

See https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new
