### PR TITLE
Remove `add_volume_clip_plane` unused argument

### DIFF
--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -796,9 +796,7 @@ class WidgetHelper:
         self,
         volume,
         normal='x',
-        invert=False,
         widget_color=None,
-        value=0.0,
         assign_to_axis=None,
         tubing=False,
         origin_translation=True,
@@ -821,15 +819,8 @@ class WidgetHelper:
         normal : str or tuple(float), optional
             The starting normal vector of the plane.
 
-        invert : bool, optional
-            Flag on whether to flip/invert the clip.
-
         widget_color : ColorLike, optional
             Either a string, RGB list, or hex color string.
-
-        value : float, optional
-            Set the clipping value along the normal direction.
-            The default value is 0.0.
 
         assign_to_axis : str or int, optional
             Assign the normal of the plane to be parallel with a given


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
This is the follow-up PR of #5374.
Remove `add_volume_clip_plane` unused argument.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None