### PR TITLE
Add Victorian Goblet face illusion example

### DIFF
--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -5554,3 +5554,37 @@ def download_meshio_xdmf(load=True):  # pragma: no cover
     """
     _ = download_file("meshio/out.h5")
     return _download_and_read("meshio/out.xdmf", load=load)
+
+
+def download_victorian_goblet_face_illusion(load=True):  # pragma: no cover
+    """Download Victorian Goblet face illusion.
+
+    This is a replica of a Victorian goblet with an external profile
+    which resembles that of a face.
+
+    Parameters
+    ----------
+    load : bool, default: True
+        Load the dataset after downloading it when ``True``.  Set this
+        to ``False`` and only the filename will be returned.
+
+    Returns
+    -------
+    pyvista.UnstructuredGrid or str
+        DataSet or filename depending on ``load``.
+
+    Examples
+    --------
+    >>> from pyvista import examples
+    >>> import pyvista as pv
+    >>> mesh = examples.download_victorian_goblet_face_illusion()
+    >>> plotter = pv.Plotter(lighting='none')
+    >>> plotter.add_mesh(
+    ...     mesh, edge_color='gray', color='white', show_edges=True
+    ... )
+    >>> plotter.add_floor('-x', color="black")
+    >>> plotter.enable_parallel_projection()
+    >>> plotter.show(cpos="yz")
+
+    """
+    return _download_and_read('Victorian_Goblet_face_illusion/Vase.stl', load=load)

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -5582,7 +5582,7 @@ def download_victorian_goblet_face_illusion(load=True):  # pragma: no cover
     >>> _ = plotter.add_mesh(
     ...     mesh, edge_color='gray', color='white', show_edges=True
     ... )
-    >>> plotter.add_floor('-x', color="black")
+    >>> _ = plotter.add_floor('-x', color="black")
     >>> plotter.enable_parallel_projection()
     >>> plotter.show(cpos="yz")
 

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -5579,7 +5579,7 @@ def download_victorian_goblet_face_illusion(load=True):  # pragma: no cover
     >>> import pyvista as pv
     >>> mesh = examples.download_victorian_goblet_face_illusion()
     >>> plotter = pv.Plotter(lighting='none')
-    >>> plotter.add_mesh(
+    >>> _ = plotter.add_mesh(
     ...     mesh, edge_color='gray', color='white', show_edges=True
     ... )
     >>> plotter.add_floor('-x', color="black")


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
<details><summary>code</summary>

```python
    >>> from pyvista import examples
    >>> import pyvista as pv
    >>> mesh = examples.download_victorian_goblet_face_illusion()
    >>> plotter = pv.Plotter(lighting='none')
    >>> plotter.add_mesh(
    ...     mesh, edge_color='gray', color='white', show_edges=True
    ... )
    >>> plotter.add_floor('-x', color="black")
    >>> plotter.enable_parallel_projection()
    >>> plotter.show(cpos="yz")
```

</details>

<p align="center">
  <img src="https://github.com/pyvista/pyvista/assets/7513610/217267fd-2cc7-4319-ad02-318772fcd3bd" />
</p>


<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

[Victorian Goblet face illusion](https://www.thingiverse.com/thing:1541337)
by [Alzibiff](https://www.thingiverse.com/Alzibiff) is licensed under the [Creative Commons - Attribution](https://creativecommons.org/licenses/by/4.0/) license.