### PR TITLE
Check the validity of padding information when initializing cells of a CellArray

### DIFF
--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -11,6 +11,7 @@ from . import _vtk_core as _vtk
 from ._typing_core import IntMatrix, IntVector, NumpyIntArray
 from .celltype import CellType
 from .dataset import DataObject
+from .errors import CellSizeError
 from .utilities.cells import ncells_from_cells, numpy_to_idarr
 
 
@@ -643,10 +644,12 @@ class CellArray(_vtk.vtkCellArray):
         # read memory outside of the array bounds if the padding is incorrect.
         # See https://github.com/pyvista/pyvista/issues/5217
         if self.cells.size != cells.size:
-            raise ValueError(
-                f"Cells array size ({cells.size}) does not match expected size"
-                f" ({self.cells.size}). This is likely due to an invalid"
-                " connectivity array."
+            raise CellSizeError(
+                message=(
+                    f"Cell array size is invalid. Size ({cells.size}) does not"
+                    f" match expected size ({self.cells.size}). This is likely"
+                    " due to invalid connectivity array."
+                )
             )
 
         self.__offsets = self.__connectivity = None

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -639,10 +639,7 @@ class CellArray(_vtk.vtkCellArray):
 
         self.SetCells(n_cells, vtk_idarr)
 
-        # Check that the size of cells array matches expectation.  Errors here
-        # are likely due to an invalid connectivity array. VTK SetCells can
-        # read memory outside of the array bounds if the padding is incorrect.
-        # See https://github.com/pyvista/pyvista/issues/5217
+        # https://github.com/pyvista/pyvista/pull/5404
         if self.cells.size != cells.size:
             raise CellSizeError(
                 message=(

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -637,6 +637,18 @@ class CellArray(_vtk.vtkCellArray):
                 n_cells = cells.shape[0]
 
         self.SetCells(n_cells, vtk_idarr)
+
+        # Check that the size of cells array matches expectation.  Errors here
+        # are likely due to an invalid connectivity array. VTK SetCells can
+        # read memory outside of the array bounds if the padding is incorrect.
+        # See https://github.com/pyvista/pyvista/issues/5217
+        if self.cells.size != cells.size:
+            raise ValueError(
+                f"Cells array size ({cells.size}) does not match expected size"
+                f" ({self.cells.size}). This is likely due to an invalid"
+                " connectivity array."
+            )
+
         self.__offsets = self.__connectivity = None
         return None
 

--- a/pyvista/core/errors.py
+++ b/pyvista/core/errors.py
@@ -129,6 +129,21 @@ class AmbiguousDataError(ValueError):
         super().__init__(message)
 
 
+class CellSizeError(ValueError):
+    """Exception when a cell array size is invalid.
+
+    Parameters
+    ----------
+    message : str
+        Error message.
+
+    """
+
+    def __init__(self, message="Cell array size is invalid."):
+        """Call the base class constructor with the custom message."""
+        super().__init__(message)
+
+
 class PyVistaPipelineError(RuntimeError):
     """Exception when a VTK pipeline runs into an issue.
 

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -93,7 +93,7 @@ def test_init_bad_input():
         pv.UnstructuredGrid(np.array(1))
 
     with pytest.raises(TypeError, match="must be a numeric type"):
-        pv.UnstructuredGrid(np.array(1), np.array(1), 'woa')
+        pv.UnstructuredGrid(np.array([2, 0, 1]), np.array(1), 'woa')
 
     with pytest.raises(TypeError, match="requires the following arrays"):
         pv.UnstructuredGrid(*range(5))

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -8,7 +8,12 @@ import vtk
 
 import pyvista as pv
 from pyvista import CellType, examples
-from pyvista.core.errors import AmbiguousDataError, MissingDataError, PyVistaDeprecationWarning
+from pyvista.core.errors import (
+    AmbiguousDataError,
+    CellSizeError,
+    MissingDataError,
+    PyVistaDeprecationWarning,
+)
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -95,7 +100,7 @@ def test_init_bad_input():
     with pytest.raises(TypeError, match="must be a numeric type"):
         pv.UnstructuredGrid(np.array([2, 0, 1]), np.array(1), 'woa')
 
-    with pytest.raises(ValueError, match="invalid connectivity array"):
+    with pytest.raises(CellSizeError, match="Cell array size is invalid"):
         rnd_generator = np.random.default_rng()
         points = rnd_generator.random((4, 3))
         celltypes = [pv.CellType.TETRA]

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -95,6 +95,13 @@ def test_init_bad_input():
     with pytest.raises(TypeError, match="must be a numeric type"):
         pv.UnstructuredGrid(np.array([2, 0, 1]), np.array(1), 'woa')
 
+    with pytest.raises(ValueError, match="invalid connectivity array"):
+        rnd_generator = np.random.default_rng()
+        points = rnd_generator.random((4, 3))
+        celltypes = [pv.CellType.TETRA]
+        cells = np.array([5, 0, 1, 2, 3])
+        pv.UnstructuredGrid(cells, celltypes, points)
+
     with pytest.raises(TypeError, match="requires the following arrays"):
         pv.UnstructuredGrid(*range(5))
 

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -174,6 +174,25 @@ def test_invalid_file():
         pv.PolyData(filename)
 
 
+@pytest.mark.parametrize(
+    "arr,value",
+    [
+        ("faces", [3, 1, 2, 3, 3, 0, 1]),
+        ("strips", np.array([5, 4, 3, 2, 0])),
+        ("lines", [4, 0, 1, 2, 2, 3, 4]),
+        ("verts", [1, 0, 1]),
+        ("faces", [[3, 0, 1], [3, 2, 1], [4, 0, 1]]),
+        ("faces", [[2, 0, 1], [2, 2, 1], [1, 0, 1]]),
+    ],
+)
+def test_invalid_connectivity_arrays(arr, value):
+    generator = np.random.default_rng(seed=None)
+    points = generator.random((10, 3))
+    mesh = pv.PolyData(points)
+    with pytest.raises(ValueError, match="invalid connectivity array"):
+        setattr(mesh, arr, value)
+
+
 def test_lines_on_init():
     lines = [2, 0, 1, 3, 2, 3, 4]
     points = np.random.default_rng().random((5, 3))

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -8,7 +8,7 @@ import pytest
 
 import pyvista as pv
 from pyvista import examples
-from pyvista.core.errors import NotAllTrianglesError, PyVistaFutureWarning
+from pyvista.core.errors import CellSizeError, NotAllTrianglesError, PyVistaFutureWarning
 
 radius = 0.5
 
@@ -189,7 +189,7 @@ def test_invalid_connectivity_arrays(arr, value):
     generator = np.random.default_rng(seed=None)
     points = generator.random((10, 3))
     mesh = pv.PolyData(points)
-    with pytest.raises(ValueError, match="invalid connectivity array"):
+    with pytest.raises(CellSizeError, match="Cell array size is invalid"):
         setattr(mesh, arr, value)
 
 


### PR DESCRIPTION
Resolves #5217 (follows #5376 where a suboptimal fix was proposed)

When a `CellArray` is inititialized, the vtk method `SetCells` is called. 

https://github.com/pyvista/pyvista/blob/276b50b1cfff04ab7912a3e4e6acf72d28d1916f/pyvista/core/cell.py#L626-L641

At this point, cells is supposed to be a connectivity array with padding information. However if the padding structure is incorrect, `SetCells` can read outside the memory bounded by the array `cells`, causing possible memory leak.

This PR fixes this issue by adding a check of the expected/actual size of `cells` by comparing size of `cells` and `self.cells`.

Tests were added to ensure that
- initialize a `PolyData` with invalid connectivity arrays for `faces`, `lines`, `strips` or `verts`
- intialize a `UnstructuredGrid` with invalid connectivity arrays for `cells`

leads to ValueError.
