### PR TITLE
Trame Plotter UI: Menu positioning

### DIFF
--- a/pyvista/trame/ui/vuetify2.py
+++ b/pyvista/trame/ui/vuetify2.py
@@ -284,7 +284,7 @@ class Viewer(BaseViewer):
                 with vuetify.VCard(
                     style='position: absolute; top: 20px; left: 20px; z-index: 1; height: 36px;',
                     classes=(f"{{ 'rounded-circle': !{self.SHOW_UI} }}",),
-                ):
+                ) as self.menu:
                     with vuetify.VRow(classes='pa-0 ma-0'):
                         button(
                             click=f'{self.SHOW_UI}=!{self.SHOW_UI}',
@@ -318,5 +318,6 @@ class Viewer(BaseViewer):
                 view = PyVistaLocalView(self.plotter, **kwargs)
 
             self._html_views.add(view)
+            view.menu = self.menu
 
         return view

--- a/pyvista/trame/ui/vuetify2.py
+++ b/pyvista/trame/ui/vuetify2.py
@@ -266,6 +266,7 @@ class Viewer(BaseViewer):
         with vuetify.VContainer(
             fluid=True,
             classes='pa-0 fill-height',
+            style='position: relative',
             trame_server=self.server,
         ) as container:
             server = container.server

--- a/pyvista/trame/ui/vuetify3.py
+++ b/pyvista/trame/ui/vuetify3.py
@@ -292,7 +292,7 @@ class Viewer(BaseViewer):
                 with vuetify.VCard(
                     style='position: absolute; top: 20px; left: 20px; z-index: 1; height: 36px;',
                     classes=(f"{{ 'rounded-circle': !{self.SHOW_UI} }}",),
-                ):
+                ) as self.menu:
                     with vuetify.VRow(
                         classes='pa-0 ma-0 align-center fill-height', style="flex-wrap: nowrap"
                     ):
@@ -328,5 +328,6 @@ class Viewer(BaseViewer):
                 view = PyVistaLocalView(self.plotter, **kwargs)
 
             self._html_views.add(view)
+            view.menu = self.menu
 
         return view

--- a/pyvista/trame/ui/vuetify3.py
+++ b/pyvista/trame/ui/vuetify3.py
@@ -274,6 +274,7 @@ class Viewer(BaseViewer):
         with vuetify.VContainer(
             fluid=True,
             classes='pa-0 fill-height',
+            style='position: relative',
             trame_server=self.server,
         ) as container:
             server = container.server


### PR DESCRIPTION
### Overview

Resolves #5364 

The plotter menu can be seen in the correct position using Vue 3:
![image](https://github.com/pyvista/pyvista/assets/44912689/c8db3238-461e-435b-abe4-c9a24e70f39b)


### Details

This PR adds styling to the trame plotter container. As the parent to the absolute-positioned menu, the container needs to have relative positioning. The linked issue only identifies the visibility problem in the Vue 3 viewer, but for consistency the change has been made in both the Vue 2 and Vue 3 viewers. 

@landynfrancis also suggests the menu component should be made accessible for further customization. This PR adds an accessor to the viewer and its UI. The following example will print the HTML for the `trame_vuetify.widgets.vuetify3.VCard` component which contains the menu. This object can be customized like any other component inheriting from `trame_client.widgets.core.AbstractElement`.
```
from trame.app import get_server
from trame.ui.vuetify3 import SinglePageLayout
import pyvista as pv
from pyvista.trame.ui import plotter_ui

pv.OFF_SCREEN = True
server = get_server(client_type='vue3')
state, ctrl = server.state, server.controller

mesh = pv.Wavelet()
pl = pv.Plotter()
pl.add_mesh(mesh)

with SinglePageLayout(server) as layout:
    with layout.content:
        ui = plotter_ui(pl)
        print(ui.menu)

server.start()

```
