### PR TITLE
Add RUF100 rule to remove unused noqa directive

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -337,7 +337,7 @@ try:
     import osmnx, fiona  # noqa: F401,E401 isort: skip
 
     has_osmnx = True
-except:  # noqa: E722
+except:
     pass
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,6 +283,7 @@ exclude = [
     'doc/examples',
     'doc/_build',
 ]
+external = ["E131", "D102", "D105"]
 line-length = 100
 indent-width = 4
 target-version = 'py39'
@@ -316,10 +317,14 @@ ignore = [
 fixable = ["ALL"]
 unfixable = []
 extend-select = [
+    "B007",
+    "B010",
     "C4",
+    "F",
     "NPY",
     "PGH004",
     "RSE",
+    "RUF100",
 ]
 
 [tool.ruff.lint.flake8-comprehensions]

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -1110,7 +1110,7 @@ class MultiBlock(
         # Verify array consistency
         dims: Set[int] = set()
         dtypes: Set[np.dtype] = set()
-        for block in self:
+        for _ in self:
             for field, scalars, _ in data_assoc:
                 # only check for the active field association
                 if field != field_asc:

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2265,7 +2265,7 @@ class PolyDataFilters(DataSetFilters):
         try:
             import pyembree  # noqa: F401
             import rtree  # noqa: F401
-            import trimesh  # noqa: F401
+            import trimesh
         except ImportError:
             raise ImportError(
                 "To use multi_ray_trace please install trimesh, rtree and pyembree with:\n"

--- a/pyvista/core/utilities/cell_type_helper.py
+++ b/pyvista/core/utilities/cell_type_helper.py
@@ -2,7 +2,7 @@
 
 try:
     from vtkmodules import vtkCommonDataModel
-except:  # noqa: E722
+except:
     import vtk as vtkCommonDataModel
 
 vtkcell_types = [
@@ -64,5 +64,5 @@ for cell_num_str, cell_str in vtkcell_types:
             cell_num = getattr(vtkCommonDataModel, cell_num_str)
             n_points = getattr(vtkCommonDataModel, cell_str)().GetNumberOfPoints()
             enum_cell_type_nr_points_map[cell_num] = n_points
-        except:  # noqa: E722
+        except:
             pass

--- a/pyvista/core/utilities/cell_type_helper.py
+++ b/pyvista/core/utilities/cell_type_helper.py
@@ -2,7 +2,7 @@
 
 try:
     from vtkmodules import vtkCommonDataModel
-except:
+except:  # pragma: no cover
     import vtk as vtkCommonDataModel
 
 vtkcell_types = [
@@ -64,5 +64,5 @@ for cell_num_str, cell_str in vtkcell_types:
             cell_num = getattr(vtkCommonDataModel, cell_num_str)
             n_points = getattr(vtkCommonDataModel, cell_str)().GetNumberOfPoints()
             enum_cell_type_nr_points_map[cell_num] = n_points
-        except:
+        except:  # pragma: no cover
             pass

--- a/pyvista/core/utilities/fileio.py
+++ b/pyvista/core/utilities/fileio.py
@@ -528,7 +528,7 @@ def save_meshio(filename, mesh, file_format=None, **kwargs):
 
     try:  # for meshio<5.0 compatibility
         from meshio.vtk._vtk import vtk_to_meshio_type
-    except:  # noqa: E722 pragma: no cover
+    except:  # pragma: no cover
         from meshio._vtk_common import vtk_to_meshio_type
 
     # Make sure relative paths will work

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -279,7 +279,7 @@ def no_new_attr(cls):  # numpydoc ignore=RT01
                 f'{self.__class__.__name__}'
             )
 
-    setattr(cls, '__setattr__', __setattr__)
+    cls.__setattr__ = __setattr__
     return cls
 
 

--- a/pyvista/core/utilities/observers.py
+++ b/pyvista/core/utilities/observers.py
@@ -106,7 +106,7 @@ class Observer:
         try:
             kind, path, address, alert = regex.findall(message)[0]
             return kind, path, address, alert
-        except:  # noqa: E722
+        except:
             return '', '', '', message
 
     def log_message(self, kind, alert):

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -161,7 +161,7 @@ class PointPickingElementHandler:
         """
         cell = self.get_cell(picked_point).get_cell(0)
         if cell.n_faces > 1:
-            for i, face in enumerate(cell.faces):
+            for face in cell.faces:
                 contains = face.cast_to_unstructured_grid().find_containing_cell(picked_point)
                 if contains > -1:
                     break
@@ -169,7 +169,7 @@ class PointPickingElementHandler:
                 # this shouldn't happen
                 raise RuntimeError('Trouble aligning point with face.')
             face = face.cast_to_unstructured_grid()
-            face.field_data['vtkOriginalFaceIds'] = np.array([i])
+            face.field_data['vtkOriginalFaceIds'] = np.array([len(cell.faces) - 1])
         else:
             face = cell.cast_to_unstructured_grid()
             face.field_data['vtkOriginalFaceIds'] = np.array([0])

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -706,7 +706,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                                 array.SetName('NORMAL')
                                 renamed_arrays.append(array)
 
-                        except:
+                        except:  # pragma: no cover
                             pass
 
         exporter = vtkGLTFExporter()

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -706,7 +706,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                                 array.SetName('NORMAL')
                                 renamed_arrays.append(array)
 
-                        except:  # noqa: E722
+                        except:
                             pass
 
         exporter = vtkGLTFExporter()

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -691,7 +691,7 @@ def test_set_active_scalars_components(multiblock_poly):
     multiblock_poly.set_active_scalars(None)
     multiblock_poly.set_active_scalars('data')
     for block in multiblock_poly:
-        assert multiblock_poly[0].point_data.active_scalars_name == 'data'
+        assert block.point_data.active_scalars_name == 'data'
 
     data = np.zeros((multiblock_poly[2].n_points, 3))
     multiblock_poly[2].point_data['data'] = data

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1725,12 +1725,12 @@ def test_cell_neighbors_levels(grid: DataSet, i0, n_levels, connections):
         assert set(cell_ids) == set(grid.cell_neighbors(i0, connections=connections))
 
     else:
-        for i, ids in enumerate(cell_ids):
+        for ids in cell_ids:
             assert isinstance(ids, list)
             assert all(isinstance(id, int) for id in ids)
             assert all(0 <= id < grid.n_cells for id in ids)
             assert len(ids) > 0
-        assert i == n_levels - 1
+        assert len(cell_ids) == n_levels
 
 
 @pytest.mark.parametrize("grid", grids, ids=ids)
@@ -1749,12 +1749,12 @@ def test_point_neighbors_levels(grid: DataSet, i0, n_levels):
         assert set(point_ids) == set(grid.point_neighbors(i0))
 
     else:
-        for i, ids in enumerate(point_ids):
+        for ids in point_ids:
             assert isinstance(ids, list)
             assert all(isinstance(id, int) for id in ids)
             assert all(0 <= id < grid.n_points for id in ids)
             assert len(ids) > 0
-        assert i == n_levels - 1
+        assert len(point_ids) == n_levels
 
 
 @pytest.fixture()

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1725,12 +1725,12 @@ def test_cell_neighbors_levels(grid: DataSet, i0, n_levels, connections):
         assert set(cell_ids) == set(grid.cell_neighbors(i0, connections=connections))
 
     else:
+        assert len(list(cell_ids)) == n_levels
         for ids in cell_ids:
             assert isinstance(ids, list)
             assert all(isinstance(id, int) for id in ids)
             assert all(0 <= id < grid.n_cells for id in ids)
             assert len(ids) > 0
-        assert len(list(cell_ids)) == n_levels
 
 
 @pytest.mark.parametrize("grid", grids, ids=ids)
@@ -1749,12 +1749,12 @@ def test_point_neighbors_levels(grid: DataSet, i0, n_levels):
         assert set(point_ids) == set(grid.point_neighbors(i0))
 
     else:
+        assert len(list(point_ids)) == n_levels
         for ids in point_ids:
             assert isinstance(ids, list)
             assert all(isinstance(id, int) for id in ids)
             assert all(0 <= id < grid.n_points for id in ids)
             assert len(ids) > 0
-        assert len(list(point_ids)) == n_levels
 
 
 @pytest.fixture()

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1730,7 +1730,7 @@ def test_cell_neighbors_levels(grid: DataSet, i0, n_levels, connections):
             assert all(isinstance(id, int) for id in ids)
             assert all(0 <= id < grid.n_cells for id in ids)
             assert len(ids) > 0
-        assert len(cell_ids) == n_levels
+        assert len(list(cell_ids)) == n_levels
 
 
 @pytest.mark.parametrize("grid", grids, ids=ids)
@@ -1754,7 +1754,7 @@ def test_point_neighbors_levels(grid: DataSet, i0, n_levels):
             assert all(isinstance(id, int) for id in ids)
             assert all(0 <= id < grid.n_points for id in ids)
             assert len(ids) > 0
-        assert len(point_ids) == n_levels
+        assert len(list(point_ids)) == n_levels
 
 
 @pytest.fixture()

--- a/tests/core/test_geometric_objects.py
+++ b/tests/core/test_geometric_objects.py
@@ -83,7 +83,7 @@ def test_solid_sphere():
     assert np.any(sphere.points)
 
     # make sure cell creation gives positive volume.
-    for i, cell in enumerate(sphere.cell):
+    for cell in sphere.cell:
         assert cell.cast_to_unstructured_grid().volume > 0
     sphere = pv.SolidSphere(radius_resolution=5, theta_resolution=100, phi_resolution=100)
     assert sphere.volume == pytest.approx(4.0 / 3.0 * np.pi * 0.5**3, rel=1e-3)

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -11,7 +11,7 @@ from pyvista.examples.downloads import download_file
 
 HAS_IMAGEIO = True
 try:
-    import imageio  # noqa: F401
+    import imageio
 except ModuleNotFoundError:
     HAS_IMAGEIO = False
 
@@ -513,7 +513,7 @@ def test_pvdreader_no_part_group():
 
     reader.set_active_time_value(1.0)
     assert len(reader.active_datasets) == 2
-    for i, dataset in enumerate(reader.active_datasets):
+    for dataset in reader.active_datasets:
         assert dataset.time == 1.0
         assert dataset.group == ""
         assert dataset.part == 0

--- a/tests/plotting/jupyter/test_static.py
+++ b/tests/plotting/jupyter/test_static.py
@@ -7,7 +7,7 @@ has_ipython = True
 try:
     import IPython  # noqa: F401
     from PIL.Image import Image
-except:  # noqa: E722
+except:
     has_ipython = False
 
 skip_no_ipython = pytest.mark.skipif(not has_ipython, reason="Requires IPython package")

--- a/tests/plotting/jupyter/test_trame.py
+++ b/tests/plotting/jupyter/test_trame.py
@@ -31,7 +31,7 @@ try:
         PyVistaRemoteView,
         _BasePyVistaView,
     )
-except:  # noqa: E722
+except:
     has_trame = False
 
 # skip all tests if VTK<9.1.0

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -49,7 +49,7 @@ try:
             imageio.plugins.ffmpeg.download()
         else:
             raise err
-except:  # noqa: E722
+except:
     ffmpeg_failed = True
 
 
@@ -2982,7 +2982,7 @@ def test_plot_composite_bool(multiblock_poly, verify_image_cache):
     verify_image_cache.windows_skip_image_cache = True
 
     # add in bool data
-    for i, block in enumerate(multiblock_poly):
+    for block in multiblock_poly:
         block['scalars'] = np.zeros(block.n_points, dtype=bool)
         block['scalars'][::2] = 1
 


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Add [RUF100](https://docs.astral.sh/ruff/rules/unused-noqa/) rule to remove unused noqa directives.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- E131 was excluded from the RUF100 check because it is not implemented in RUFF.
- D102 and D105 was excluded from the RUF100 check because it the rule of pydocstyle.
- There are noqa of [B007](https://docs.astral.sh/ruff/rules/unused-loop-control-variable/) and [B010](https://docs.astral.sh/ruff/rules/set-attr-with-constant/) but was not checked by flake8 and ruff. These two rules are useful and newly added.
- [F](https://docs.astral.sh/ruff/rules/#pyflakes-f) was explicitly defined because some Flake8 checks were not done in ruff.
