### PR TITLE
[patch] vtkRedistributeDataSetFilter ImportError

### DIFF
--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -308,7 +308,7 @@ from vtkmodules.vtkFiltersParallel import vtkIntegrateAttributes
 
 try:
     from vtkmodules.vtkFiltersParallelDIY2 import vtkRedistributeDataSetFilter
-except ModuleNotFoundError:  # pragma: no cover
+except ImportError:  # pragma: no cover
     # `vtkmodules.vtkFiltersParallelDIY2` is unavailable in some versions of `vtk` from conda-forge
     pass
 from vtkmodules.vtkFiltersPoints import vtkGaussianKernel, vtkPointInterpolator


### PR DESCRIPTION
This was supposed to have been fixed in #4054... but it looks like #4018 may have incorrectly reverted it 

Resolves #5438

https://github.com/pyvista/pyvista/pull/4018/files#diff-d82c7cce72319a375b24846ad84d5e38b7cf205063148523e289bc0cf8c1c406R315-R319