### PR TITLE
Bump awalsh128/cache-apt-pkgs-action from 1.1.3 to latest

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,7 @@ jobs:
             requirements.txt
             requirements_docs.txt
 
-      - uses: awalsh128/cache-apt-pkgs-action@v1.1.3
+      - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime
           version: 3.0

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -86,7 +86,7 @@ jobs:
       CARTOPY_SHARE_DIR: ~/.local/share/cartopy
       GEOVISTA_POOCH_MUTE: true
     steps:
-      - uses: awalsh128/cache-apt-pkgs-action@v1.1.3
+      - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libgl1-mesa-glx xvfb
           version: 3.0

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -28,7 +28,7 @@ jobs:
             requirements.txt
             requirements_docs.txt
 
-      - uses: awalsh128/cache-apt-pkgs-action@v1.1.3
+      - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime
           version: 3.0

--- a/.github/workflows/preview_pull_request.yml
+++ b/.github/workflows/preview_pull_request.yml
@@ -40,7 +40,7 @@ jobs:
             requirements.txt
             requirements_docs.txt
 
-      - uses: awalsh128/cache-apt-pkgs-action@v1.1.3
+      - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime
           version: 3.0

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -194,7 +194,7 @@ jobs:
       - name: Core Testing (no GL)
         run: python -m pytest --cov=pyvista -v tests/core tests/examples
 
-      - uses: awalsh128/cache-apt-pkgs-action@v1.1.3
+      - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libgl1-mesa-glx xvfb
           version: 3.0


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Bump awalsh128/cache-apt-pkgs-action from 1.1.3 to latest.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None