### PR TITLE
change np.float_ to np.float64

### DIFF
--- a/pyvista/core/_typing_core/_array_like.py
+++ b/pyvista/core/_typing_core/_array_like.py
@@ -26,7 +26,7 @@ import numpy as np
 import numpy.typing as npt
 
 # Create alias of npt.NDArray bound to numeric types only
-_NumType = TypeVar('_NumType', bool, int, float, np.bool_, np.int_, np.float_, np.uint8)
+_NumType = TypeVar('_NumType', bool, int, float, np.bool_, np.int_, np.float64, np.uint8)
 NumpyArray = npt.NDArray[_NumType]
 
 # Define generic nested sequence

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -663,7 +663,7 @@ class DataSetMapper(_vtk.vtkDataSetMapper, _BaseMapper):
                 scalars = scalars.ravel()
 
         if scalars.dtype == np.bool_:
-            scalars = scalars.astype(np.float_)
+            scalars = scalars.astype(np.float64)
 
         # Set scalars range
         if clim is None:


### PR DESCRIPTION
### Overview

resolves #5472 

Removes deprecated `np.float_` and replaces with `np.float64`

### Details

- I ran `ruff check pyvista --no-fix --preview --select=NPY201` to find the (two) places that needed fixing
