### PR TITLE
Allow computing number of cell vertices in `compute_cell_sizes`

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2071,8 +2071,8 @@ class DataSetFilters:
             Display a progress bar to indicate progress.
 
         vertex_count : bool, default: False
-            Specify whether or not to computer the number of vertices
-            in 0D cells.
+            Specify whether or not to compute the number of vertices
+            of 0D cells.
 
         Returns
         -------

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2071,7 +2071,7 @@ class DataSetFilters:
             Display a progress bar to indicate progress.
 
         vertex_count : bool, default: False
-            Specify whether or not to compute sizes for vertices and 0D cells.
+            Specify whether or not to compute sizes for vertex and polyvertex cells (0D cells).
             The computed value is the number of points in the cell.
 
         Returns

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2051,8 +2051,10 @@ class DataSetFilters:
             self.GetPointData().AddArray(otc)
         return self
 
-    def compute_cell_sizes(self, length=True, area=True, volume=True, progress_bar=False):
-        """Compute sizes for 1D (length), 2D (area) and 3D (volume) cells.
+    def compute_cell_sizes(
+        self, length=True, area=True, volume=True, progress_bar=False, vertex_count=False
+    ):
+        """Compute sizes for 0D (vertex count), 1D (length), 2D (area) and 3D (volume) cells.
 
         Parameters
         ----------
@@ -2068,12 +2070,16 @@ class DataSetFilters:
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
 
+        vertex_count : bool, default: False
+            Specify whether or not to computer the number of vertices
+            in 0D cells.
+
         Returns
         -------
         pyvista.DataSet
-            Dataset with `cell_data` containing the ``"Length"``,
-            ``"Area"``, and ``"Volume"`` arrays if set in the
-            parameters.  Return type matches input.
+            Dataset with `cell_data` containing the ``"VertexCount"``,
+            ``"Length"``, ``"Area"``, and ``"Volume"`` arrays if set
+            in the parameters.  Return type matches input.
 
         Notes
         -----
@@ -2095,7 +2101,7 @@ class DataSetFilters:
         alg.SetComputeArea(area)
         alg.SetComputeVolume(volume)
         alg.SetComputeLength(length)
-        alg.SetComputeVertexCount(False)
+        alg.SetComputeVertexCount(vertex_count)
         _update_alg(alg, progress_bar, 'Computing Cell Sizes')
         return _get_output(alg)
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2071,8 +2071,8 @@ class DataSetFilters:
             Display a progress bar to indicate progress.
 
         vertex_count : bool, default: False
-            Specify whether or not to compute the number of vertices
-            of 0D cells.
+            Specify whether or not to compute sizes for vertices and 0D cells.
+            The computed value is the number of points in the cell.
 
         Returns
         -------

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -741,11 +741,13 @@ def test_texture_map_to_sphere():
 
 def test_compute_cell_sizes(datasets):
     for dataset in datasets:
-        result = dataset.compute_cell_sizes(progress_bar=True)
+        result = dataset.compute_cell_sizes(progress_bar=True, vertex_count=True)
         assert result is not None
         assert isinstance(result, type(dataset))
+        assert 'Length' in result.array_names
         assert 'Area' in result.array_names
         assert 'Volume' in result.array_names
+        assert 'VertexCount' in result.array_names
     # Test the volume property
     grid = pv.ImageData(dimensions=(10, 10, 10))
     volume = float(np.prod(np.array(grid.dimensions) - 1))


### PR DESCRIPTION
### Overview

Add option to include 'VertexCount' in the returned data.


### Details

This is needed for implementing https://github.com/MatthewFlamm/pyransame/issues/29.

I opted to default to `False` for backwards compatibility. It should also be a rare usage.
