### PR TITLE
numpy 2.0 fix for np.unique

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -2637,6 +2637,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         ncells = np.prod(shape0)
         cells = 8 * np.ones((ncells, 9), dtype=int)
         points, indices = np.unique(corners, axis=0, return_inverse=True)  # type: ignore
+        indices = indices.ravel()
         connectivity = np.asarray(
             [[0, 1, 1, 0, 0, 1, 1, 0], [0, 0, 1, 1, 0, 0, 1, 1], [0, 0, 0, 0, 1, 1, 1, 1]]
         )


### PR DESCRIPTION
### Overview

Fixes new numpy 2.0 error due to change in https://github.com/numpy/numpy/pull/25553


### Details

Fixes Error from #5450 : 
```txt
__________________ ERROR collecting tests/core/test_cells.py ___________________
tests/core/test_cells.py:29: in <module>
    load_explicit_structured(),
pyvista/examples/examples.py:394: in load_explicit_structured
    grid = pyvista.ExplicitStructuredGrid(dimensions, corners)
pyvista/core/pointset.py:2608: in __init__
    self._from_arrays(arg0, arg1)
pyvista/core/pointset.py:2647: in _from_arrays
    cells[c, 1:] = indices[cinds]
E   ValueError: could not broadcast input array from shape (8,1) into shape (8,)
_________________ ERROR collecting tests/core/test_dataset.py __________________
tests/core/test_dataset.py:1556: in <module>
    load_explicit_structured(),
pyvista/examples/examples.py:394: in load_explicit_structured
    grid = pyvista.ExplicitStructuredGrid(dimensions, corners)
pyvista/core/pointset.py:2608: in __init__
    self._from_arrays(arg0, arg1)
pyvista/core/pointset.py:2647: in _from_arrays
    cells[c, 1:] = indices[cinds]
E   ValueError: could not broadcast input array from shape (8,1) into shape (8,)
```