### PR TITLE
More numpy 2.0 fixes: ndarray.ptp and np.ComplexWarning

### DIFF
--- a/examples/01-filter/image-fft-perlin-noise.py
+++ b/examples/01-filter/image-fft-perlin-noise.py
@@ -160,7 +160,7 @@ def warp_low_pass_noise(cfreq, scalar_ptp=np.ptp(sampled['scalars'])):
 
     # on the right: scale to fixed warped height
     output_scaled = output.translate((-11, 11, 0), inplace=False)
-    output_scaled['scalars_warp'] = output['scalars'] / np.ptp(output['scalars'].ptp) * scalar_ptp
+    output_scaled['scalars_warp'] = output['scalars'] / np.ptp(output['scalars']) * scalar_ptp
     warped_scaled = output_scaled.warp_by_scalar('scalars_warp')
     warped_scaled.active_scalars_name = 'scalars'
     # push center back to xy plane due to peaks near 0 frequency

--- a/examples/01-filter/image-fft-perlin-noise.py
+++ b/examples/01-filter/image-fft-perlin-noise.py
@@ -150,7 +150,7 @@ pl.show()
 # Animate the variation of the cutoff frequency.
 
 
-def warp_low_pass_noise(cfreq, scalar_ptp=sampled['scalars'].ptp()):
+def warp_low_pass_noise(cfreq, scalar_ptp=np.ptp(sampled['scalars'])):
     """Process the sampled FFT and warp by scalars."""
     output = sampled_fft.low_pass(cfreq, cfreq, cfreq).rfft()
 
@@ -160,7 +160,7 @@ def warp_low_pass_noise(cfreq, scalar_ptp=sampled['scalars'].ptp()):
 
     # on the right: scale to fixed warped height
     output_scaled = output.translate((-11, 11, 0), inplace=False)
-    output_scaled['scalars_warp'] = output['scalars'] / output['scalars'].ptp() * scalar_ptp
+    output_scaled['scalars_warp'] = output['scalars'] / np.ptp(output['scalars'].ptp) * scalar_ptp
     warped_scaled = output_scaled.warp_by_scalar('scalars_warp')
     warped_scaled.active_scalars_name = 'scalars'
     # push center back to xy plane due to peaks near 0 frequency

--- a/examples/01-filter/slicing.py
+++ b/examples/01-filter/slicing.py
@@ -153,7 +153,7 @@ p.show()
 # around a user-chosen location.
 #
 # Create a point to orient slices around
-ranges = np.array(model.bounds).reshape(-1, 2).ptp(axis=1)
+ranges = np.ptp(np.array(model.bounds).reshape(-1, 2), axis=1)
 point = np.array(model.center) - ranges * 0.25
 
 ###############################################################################

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -1058,6 +1058,8 @@ class LookupTable(_vtk.vtkLookupTable):
         """
         opacity_tf = _vtk.vtkPiecewiseFunction()
         for ii, value in enumerate(self.values[:, 3]):
+            if not isinstance(value, np.uint8):
+                raise ValueError("not uint8 here")
             opacity_tf.AddPoint(ii, value / self.n_values)
         return opacity_tf
 

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -1058,8 +1058,6 @@ class LookupTable(_vtk.vtkLookupTable):
         """
         opacity_tf = _vtk.vtkPiecewiseFunction()
         for ii, value in enumerate(self.values[:, 3]):
-            if not isinstance(value, np.uint8):
-                raise ValueError("not uint8 here")
             opacity_tf.AddPoint(ii, value / self.n_values)
         return opacity_tf
 

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1890,7 +1890,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             kwargs = locals()
             kwargs.pop('self')
             self._floor_kwargs.append(kwargs)
-        ranges = np.array(self.bounds).reshape(-1, 2).ptp(axis=1)
+        ranges = np.ptp(np.array(self.bounds).reshape(-1, 2), axis=1)
         ranges += ranges * pad
         center = np.array(self.center)
         if face.lower() in '-z':

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -2673,11 +2673,20 @@ def test_plot_complex_value(plane, verify_image_cache):
     verify_image_cache.windows_skip_image_cache = True
     data = np.arange(plane.n_points, dtype=np.complex128)
     data += np.linspace(0, 1, plane.n_points) * -1j
-    with pytest.warns(np.ComplexWarning):
+
+    # needed to support numpy <1.25
+    # needed to support vtk 9.0.3
+    # check for removal when support for vtk 9.0.3 is removed
+    try:
+        ComplexWarning = np.exceptions.ComplexWarning
+    except:
+        ComplexWarning = np.ComplexWarning
+
+    with pytest.warns(ComplexWarning):
         plane.plot(scalars=data)
 
     pl = pv.Plotter()
-    with pytest.warns(np.ComplexWarning):
+    with pytest.warns(ComplexWarning):
         pl.add_mesh(plane, scalars=data, show_scalar_bar=True)
     pl.show()
 
@@ -2962,8 +2971,16 @@ def test_plot_composite_poly_complex(multiblock_poly):
     # make a multi_multi for better coverage
     multi_multi = pv.MultiBlock([multiblock_poly, multiblock_poly])
 
+    # needed to support numpy <1.25
+    # needed to support vtk 9.0.3
+    # check for removal when support for vtk 9.0.3 is removed
+    try:
+        ComplexWarning = np.exceptions.ComplexWarning
+    except:
+        ComplexWarning = np.ComplexWarning
+
     pl = pv.Plotter()
-    with pytest.warns(np.ComplexWarning, match='Casting complex'):
+    with pytest.warns(ComplexWarning, match='Casting complex'):
         pl.add_composite(multi_multi, scalars='data')
     pl.show()
 


### PR DESCRIPTION
### Overview

More fixes for numpy2.0.  numpy2.0 devdocs and migration guide is either out of date or is missing key information.


### Details

ptp error example:

```txt
>       ranges = np.array(self.bounds).reshape(-1, 2).ptp(axis=1)
E       AttributeError: `ptp` was removed from the ndarray class in NumPy 2.0. Use np.ptp(arr, ...) instead.
```

`ComplexWarning` was put into `np.exceptions` in v2.0, but we also need older numpy support for vtk 9.0.3 which do not have this module.  So we have to do a dance with these warning until we drop support for vtk 9.0.3.
