### PR TITLE
Bump flake8-isort to 6.1.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          ["flake8-black==0.3.6", "flake8-isort==6.0.0", "flake8-quotes==3.3.2"]
+          ["flake8-black==0.3.6", "flake8-isort==6.1.1", "flake8-quotes==3.3.2"]
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6

--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -882,7 +882,7 @@ class EnSightReader(BaseReader, PointCellDataSelection, TimeReader):
         if time_set in range(number_time_sets):
             self._active_time_set = time_set
         else:
-            raise IndexError(f"Time set index {time_set} not in {range(0,number_time_sets)}")
+            raise IndexError(f"Time set index {time_set} not in {range(0, number_time_sets)}")
 
 
 # skip pydocstyle D102 check since docstring is taken from TimeReader


### PR DESCRIPTION
Bump flake8-isort to support python 3.12.

The current version of Flake8-isort (6.0.0) is does not support python 3.12 and running pre-commit can result in the following error:
  ```
File "/Users/user/.cache/pre-commit/repoz0bkf8ww/py_env-python3.12/lib/python3.12/site-packages/flake8/plugins/finder.py", line 293, in _load_plugin
    raise FailedToLoadPlugin(plugin.package, e)
flake8.exceptions.FailedToLoadPlugin: Flake8 failed to load plugin "flake8-isort" due to No module named 'pkg_resources'.
```



