### PR TITLE
Fix `save_meshio` with Numpy v2

### DIFF
--- a/pyvista/core/utilities/fileio.py
+++ b/pyvista/core/utilities/fileio.py
@@ -597,7 +597,10 @@ def save_meshio(filename, mesh, file_format=None, **kwargs):
     vtk_cell_data = mesh.cell_data
     indices = np.insert(np.cumsum([len(c[1]) for c in cells]), 0, 0)
     cell_data = (
-        {k.replace(" ", "_"): [v[i1 : i2] for i1, i2 in zip(indices[:-1], indices[1:])] for k, v in vtk_cell_data.items()}
+        {
+            k.replace(" ", "_"): [v[i1:i2] for i1, i2 in zip(indices[:-1], indices[1:])]
+            for k, v in vtk_cell_data.items()
+        }
         if vtk_cell_data
         else {}
     )

--- a/pyvista/core/utilities/fileio.py
+++ b/pyvista/core/utilities/fileio.py
@@ -597,7 +597,7 @@ def save_meshio(filename, mesh, file_format=None, **kwargs):
     vtk_cell_data = mesh.cell_data
     n_cells = np.cumsum([len(c[1]) for c in cells[:-1]])
     cell_data = (
-        {k.replace(" ", "_"): np.split(v, n_cells) for k, v in vtk_cell_data.items()}
+        {k.replace(" ", "_"): list(np.split(v, n_cells)) for k, v in vtk_cell_data.items()}
         if vtk_cell_data
         else {}
     )

--- a/pyvista/core/utilities/fileio.py
+++ b/pyvista/core/utilities/fileio.py
@@ -595,9 +595,9 @@ def save_meshio(filename, mesh, file_format=None, **kwargs):
 
     # Get cell data
     vtk_cell_data = mesh.cell_data
-    n_cells = np.cumsum([len(c[1]) for c in cells[:-1]])
+    indices = np.insert(np.cumsum([len(c[1]) for c in cells]), 0, 0)
     cell_data = (
-        {k.replace(" ", "_"): list(np.split(v, n_cells)) for k, v in vtk_cell_data.items()}
+        {k.replace(" ", "_"): [v[i1 : i2] for i1, i2 in zip(indices[:-1], indices[1:])] for k, v in vtk_cell_data.items()}
         if vtk_cell_data
         else {}
     )


### PR DESCRIPTION
### Overview

- Fixed: `np.split` returns a tuple of arrays in v2 instead of a list (see discussion #5533).