### PR TITLE
Adding the codecov token to use codecov-action v4

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -210,6 +210,8 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         name: "Upload coverage to CodeCov"
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Check package
         run: |


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Adding the Codecov token to use codecov-action v4.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- Tokenless uploading is unsupported from v4 (https://github.com/codecov/codecov-action/releases/tag/v4.0.0).
- Adding the Codecov token (https://docs.codecov.com/docs/adding-the-codecov-token#github-actions)
