### PR TITLE
Fix uint8 error for numpy2

### DIFF
--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -650,7 +650,7 @@ def test_check_is_greater_than():
 def test_check_is_real():
     check_is_real(1)
     check_is_real(-2.0)
-    check_is_real(np.array(-2.0, dtype="uint8"))
+    check_is_real(np.array(2.0, dtype="uint8"))
     msg = 'Array must have real numbers.'
     with pytest.raises(TypeError, match=msg):
         check_is_real(1 + 1j)


### PR DESCRIPTION
### Overview

To resolve error from #5450

```txt
    def test_check_is_real():
        check_is_real(1)
        check_is_real(-2.0)
>       check_is_real(np.array(-2.0, dtype="uint8"))
E       OverflowError: Python integer -2 out of bounds for uint8
```


