### PR TITLE
Remove unused notes of XdmfReader class about time

### DIFF
--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -2435,10 +2435,6 @@ class GIFReader(BaseReader):
 class XdmfReader(BaseReader, PointCellDataSelection, TimeReader):
     """XdmfReader for .xdmf files.
 
-    Notes
-    -----
-    We currently can't inspect the time values for this reader.
-
     Parameters
     ----------
     path : str


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
We don't need notes about time value in `XdmfReader` so we defined the time value in #5332.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None
