### PR TITLE
Add `--warn-unused-ignores` to `mypy` config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,7 @@ repos:
     rev: v1.8.0
     hooks:
       - id: mypy
+        args: [--warn-unused-ignores]
         exclude: ^(doc/|tests/|examples/|pyvista/ext/|examples_trame/)
         additional_dependencies:
           [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ image_cache_dir = "tests/plotting/image_cache"
 
 [tool.mypy]
 ignore_missing_imports = true
+warn_unused_ignores = true
 plugins = ['numpy.typing.mypy_plugin','npt_promote']
 
 [tool.numpydoc_validation]

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -1035,7 +1035,7 @@ class MultiBlock(
 
     def set_active_scalars(
         self, name: Optional[str], preference: str = 'cell', allow_missing: bool = False
-    ) -> Tuple[FieldAssociation, np.ndarray]:  # type: ignore
+    ) -> Tuple[FieldAssociation, np.ndarray]:
         """Find the scalars by name and appropriately set it as active.
 
         To deactivate any active scalars, pass ``None`` as the ``name``.

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -395,7 +395,7 @@ class DataSet(DataSetFilters, DataObject):
         self.set_active_vectors(name)
 
     @property  # type: ignore
-    def active_scalars_name(self) -> str:  # type: ignore  # numpydoc ignore=RT01
+    def active_scalars_name(self) -> str:  # numpydoc ignore=RT01
         """Return the name of the active scalars.
 
         Returns
@@ -1221,7 +1221,7 @@ class DataSet(DataSetFilters, DataObject):
             xyz = [xyz] * 3
 
         transform = _vtk.vtkTransform()
-        transform.Scale(xyz)  # type: ignore
+        transform.Scale(xyz)
         return self.transform(
             transform, transform_all_input_vectors=transform_all_input_vectors, inplace=inplace
         )

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -506,12 +506,12 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         """Check if array needs to be represented as a different type."""
         name = narray.VTKObject.GetName()
         if name in self.dataset._association_bitarray_names[self.association.name]:
-            narray = narray.view(np.bool_)  # type: ignore
+            narray = narray.view(np.bool_)
         elif name in self.dataset._association_complex_names[self.association.name]:
             if narray.dtype == np.float32:
-                narray = narray.view(np.complex64)  # type: ignore
+                narray = narray.view(np.complex64)
             if narray.dtype == np.float64:
-                narray = narray.view(np.complex128)  # type: ignore
+                narray = narray.view(np.complex128)
             # remove singleton dimensions to match the behavior of the rest of 1D
             # VTK arrays
             narray = narray.squeeze()

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -410,7 +410,7 @@ class PolyDataFilters(DataSetFilters):
         merged = _get_output(append_filter)
 
         if inplace:
-            self.deep_copy(merged)  # type: ignore
+            self.deep_copy(merged)
             return self
 
         return merged

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -246,7 +246,7 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid, RectilinearGridFilters):
         return np.meshgrid(self.x, self.y, self.z, indexing='ij')
 
     @property  # type: ignore
-    def points(self) -> np.ndarray:  # type: ignore  # numpydoc ignore=RT01
+    def points(self) -> np.ndarray:  # numpydoc ignore=RT01
         """Return a copy of the points as an ``(n, 3)`` numpy array.
 
         Returns
@@ -632,7 +632,7 @@ class ImageData(_vtk.vtkImageData, Grid, ImageDataFilters):
         self.spacing = (spacing[0], spacing[1], spacing[2])
 
     @property  # type: ignore
-    def points(self) -> np.ndarray:  # type: ignore  # numpydoc ignore=RT01
+    def points(self) -> np.ndarray:  # numpydoc ignore=RT01
         """Build a copy of the implicitly defined points as a numpy array.
 
         Returns

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -80,7 +80,7 @@ class _PointSet(DataSet):
         alg.Update()
         return np.array(alg.GetCenter())
 
-    def shallow_copy(self, to_copy: DataSet) -> None:  # type: ignore[override]
+    def shallow_copy(self, to_copy: DataSet) -> None:
         """Create a shallow copy from a different dataset into this one.
 
         This method mutates this dataset and returns ``None``.
@@ -330,7 +330,7 @@ class PointSet(_vtk.vtkPointSet, _PointSet):
                 pdata.point_data[key] = value
         return pdata
 
-    @wraps(DataSet.plot)  # type: ignore
+    @wraps(DataSet.plot)
     def plot(self, *args, **kwargs):
         """Cast to PolyData and plot."""
         pdata = self.cast_to_polydata(deep=False)
@@ -2726,7 +2726,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         shape1 = 2 * shape0
         ncells = np.prod(shape0)
         cells = 8 * np.ones((ncells, 9), dtype=int)
-        points, indices = np.unique(corners, axis=0, return_inverse=True)  # type: ignore
+        points, indices = np.unique(corners, axis=0, return_inverse=True)
         indices = indices.ravel()
         connectivity = np.asarray(
             [[0, 1, 1, 0, 0, 1, 1, 0], [0, 0, 1, 1, 0, 0, 1, 1], [0, 0, 0, 0, 1, 1, 1, 1]]

--- a/pyvista/core/utilities/helpers.py
+++ b/pyvista/core/utilities/helpers.py
@@ -155,7 +155,7 @@ def wrap(
         )
         # If the Trimesh object has uv, pass them to the PolyData
         if hasattr(dataset.visual, 'uv'):
-            polydata.active_texture_coordinates = np.asarray(dataset.visual.uv)  # type: ignore
+            polydata.active_texture_coordinates = np.asarray(dataset.visual.uv)
         return polydata
 
     # otherwise, flag tell the user we can't wrap this object

--- a/pyvista/ext/coverage.py
+++ b/pyvista/ext/coverage.py
@@ -24,7 +24,7 @@ from sphinx.application import Sphinx
 from sphinx.builders import Builder
 from sphinx.locale import __
 from sphinx.util import logging
-from sphinx.util.console import red  # type: ignore
+from sphinx.util.console import red
 from sphinx.util.inspect import safe_getattr
 
 logger = logging.getLogger(__name__)
@@ -112,7 +112,7 @@ class CoverageBuilder(Builder):
 
     def build_c_coverage(self) -> None:
         # Fetch all the info from the header files
-        c_objects = self.env.domaindata['c']['objects']  # type: ignore
+        c_objects = self.env.domaindata['c']['objects']
         for filename in self.c_sourcefiles:
             undoc: Set[Tuple[str, str]] = set()
             with open(filename) as f:
@@ -165,7 +165,7 @@ class CoverageBuilder(Builder):
         return False
 
     def build_py_coverage(self) -> None:
-        objects = self.env.domaindata['py']['objects']  # type: ignore
+        objects = self.env.domaindata['py']['objects']
 
         # objects are sometimes not referenced in the docs as they are
         # in the source.  Here we simply grab the method and class of
@@ -175,7 +175,7 @@ class CoverageBuilder(Builder):
             # only include method and class
             abbr_names.add(method_from_obj(obj_name))
 
-        modules = self.env.domaindata['py']['modules']  # type: ignore
+        modules = self.env.domaindata['py']['modules']
         for mod_name in self.add_modules:
             modules[mod_name] = None
 

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -1185,7 +1185,7 @@ class _Chart(DocSubs):
         l, b, w, h = self._geometry
         return l <= pos[0] <= l + w and b <= pos[1] <= b + h
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def size(self):  # numpydoc ignore=RT01
         """Return or set the chart size in normalized coordinates.
@@ -1215,7 +1215,7 @@ class _Chart(DocSubs):
             raise ValueError(f'Invalid size {val}.')
         self._size = val
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def loc(self):  # numpydoc ignore=RT01
         """Return or set the chart position in normalized coordinates.
@@ -1245,7 +1245,7 @@ class _Chart(DocSubs):
             raise ValueError(f'Invalid loc {val}.')
         self._loc = val
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def border_color(self):  # numpydoc ignore=RT01
         """Return or set the chart's border color.
@@ -1271,7 +1271,7 @@ class _Chart(DocSubs):
     def border_color(self, val):  # numpydoc ignore=GL08
         self._background.BorderPen.color = val
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def border_width(self):  # numpydoc ignore=RT01
         """Return or set the chart's border width.
@@ -1298,7 +1298,7 @@ class _Chart(DocSubs):
         self._background.BorderPen.width = val
         self._background.ActiveBorderPen.width = val
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def border_style(self):  # numpydoc ignore=RT01
         """Return or set the chart's border style.
@@ -1325,7 +1325,7 @@ class _Chart(DocSubs):
         self._background.BorderPen.style = val
         self._background.ActiveBorderPen.style = val
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def active_border_color(self):  # numpydoc ignore=RT01
         """Return or set the chart's border color in interactive mode.
@@ -1356,7 +1356,7 @@ class _Chart(DocSubs):
     def active_border_color(self, val):  # numpydoc ignore=GL08
         self._background.ActiveBorderPen.color = val
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def background_color(self):  # numpydoc ignore=RT01
         """Return or set the chart's background color.
@@ -1380,7 +1380,7 @@ class _Chart(DocSubs):
     def background_color(self, val):  # numpydoc ignore=GL08
         self._background.BackgroundBrush.color = val
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def background_texture(self):  # numpydoc ignore=RT01
         """Return or set the chart's background texture.
@@ -1406,7 +1406,7 @@ class _Chart(DocSubs):
         self._background.BackgroundBrush.texture = val
         self._background.ActiveBackgroundBrush.texture = val
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def active_background_color(self):  # numpydoc ignore=RT01
         """Return or set the chart's background color in interactive mode.
@@ -1435,7 +1435,7 @@ class _Chart(DocSubs):
     def active_background_color(self, val):  # numpydoc ignore=GL08
         self._background.ActiveBackgroundBrush.color = val
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def visible(self):  # numpydoc ignore=RT01
         """Return or set the chart's visibility.
@@ -1486,7 +1486,7 @@ class _Chart(DocSubs):
         """
         self.visible = not self.visible
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def title(self):  # numpydoc ignore=RT01
         """Return or set the chart's title.
@@ -1510,7 +1510,7 @@ class _Chart(DocSubs):
     def title(self, val):  # numpydoc ignore=GL08
         self.SetTitle(val)
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def legend_visible(self):  # numpydoc ignore=RT01
         """Return or set the visibility of the chart's legend.
@@ -1644,7 +1644,7 @@ class _Plot(DocSubs):
         if hasattr(self, "SetBrush"):
             self.SetBrush(self._brush)
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def color(self):  # numpydoc ignore=RT01
         """Return or set the plot's color.
@@ -1672,7 +1672,7 @@ class _Plot(DocSubs):
         self.pen.color = val
         self.brush.color = val
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def pen(self):  # numpydoc ignore=RT01
         """Pen object controlling how lines in this plot are drawn.
@@ -1699,7 +1699,7 @@ class _Plot(DocSubs):
         """
         return self._pen
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def brush(self):  # numpydoc ignore=RT01
         """Brush object controlling how shapes in this plot are filled.
@@ -1726,7 +1726,7 @@ class _Plot(DocSubs):
         """
         return self._brush
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def line_width(self):  # numpydoc ignore=RT01
         """Return or set the line width of all lines drawn in this plot.
@@ -1754,7 +1754,7 @@ class _Plot(DocSubs):
     def line_width(self, val):  # numpydoc ignore=GL08
         self.pen.width = val
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def line_style(self):  # numpydoc ignore=RT01
         """Return or set the line style of all lines drawn in this plot.
@@ -1781,7 +1781,7 @@ class _Plot(DocSubs):
     def line_style(self, val):  # numpydoc ignore=GL08
         self.pen.style = val
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def label(self):  # numpydoc ignore=RT01
         """Return or set the this plot's label, as shown in the chart's legend.
@@ -1807,7 +1807,7 @@ class _Plot(DocSubs):
         self._label = "" if val is None else val
         self.SetLabel(self._label)
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def visible(self):  # numpydoc ignore=RT01
         """Return or set the this plot's visibility.
@@ -1880,7 +1880,7 @@ class _MultiCompPlot(_Plot):
         self.SetLabels(self._labels)
         self.color_scheme = self.DEFAULT_COLOR_SCHEME
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def color_scheme(self):  # numpydoc ignore=RT01
         """Return or set the plot's color scheme.
@@ -1920,7 +1920,7 @@ class _MultiCompPlot(_Plot):
         self._color_series.BuildLookupTable(self._lookup_table, _vtk.vtkColorSeries.CATEGORICAL)
         self.brush.color = self.colors[0]
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def colors(self):  # numpydoc ignore=RT01
         """Return or set the plot's colors.
@@ -1970,7 +1970,7 @@ class _MultiCompPlot(_Plot):
                     "Invalid colors specified, falling back to default color scheme."
                 ) from e
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def color(self):  # numpydoc ignore=RT01
         """Return or set the plot's color.
@@ -2000,7 +2000,7 @@ class _MultiCompPlot(_Plot):
         # (and their internal representations through color series, lookup tables and brushes) stay synchronized.
         self.colors = [val]
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def labels(self):  # numpydoc ignore=RT01
         """Return or set the this plot's labels, as shown in the chart's legend.
@@ -2037,7 +2037,7 @@ class _MultiCompPlot(_Plot):
         except TypeError:
             raise ValueError("Invalid labels specified.")
 
-    @property  # type: ignore
+    @property
     @doc_subs
     def label(self):  # numpydoc ignore=RT01
         """Return or set the this plot's label, as shown in the chart's legend.

--- a/pyvista/plotting/composite_mapper.py
+++ b/pyvista/plotting/composite_mapper.py
@@ -518,7 +518,7 @@ class CompositeAttributes(_vtk.vtkCompositeDataDisplayAttributes):
 class CompositePolyDataMapper(
     _vtk.vtkCompositePolyDataMapper  # type: ignore
     if vtk_version_info >= (9, 3)
-    else _vtk.vtkCompositePolyDataMapper2,  # type: ignore
+    else _vtk.vtkCompositePolyDataMapper2,
     _BaseMapper,
 ):
     """Composite PolyData mapper.

--- a/pyvista/plotting/composite_mapper.py
+++ b/pyvista/plotting/composite_mapper.py
@@ -517,9 +517,11 @@ class CompositeAttributes(_vtk.vtkCompositeDataDisplayAttributes):
 
 
 class CompositePolyDataMapper(
-    _vtk.vtkCompositePolyDataMapper  # type: ignore
-    if vtk_version_info >= (9, 3)
-    else _vtk.vtkCompositePolyDataMapper2,
+    (
+        _vtk.vtkCompositePolyDataMapper  # type: ignore
+        if vtk_version_info >= (9, 3)
+        else _vtk.vtkCompositePolyDataMapper2
+    ),
     _BaseMapper,
 ):
     """Composite PolyData mapper.

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -945,7 +945,7 @@ class LookupTable(_vtk.vtkLookupTable):
         """Return the lookup type."""
         if self.cmap:
             if hasattr(self.cmap, 'name'):
-                return f'{self.cmap.name}'  # type: ignore
+                return f'{self.cmap.name}'
             else:  # pragma: no cover
                 return f'{self.cmap}'
         elif self._values_manual:

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -297,7 +297,7 @@ class _BaseMapper(_vtk.vtkAbstractMapper):
     def scalar_map_mode(self, scalar_mode: Union[str, FieldAssociation]):  # numpydoc ignore=GL08
         if isinstance(scalar_mode, FieldAssociation):
             scalar_mode = scalar_mode.name
-        scalar_mode = scalar_mode.lower()  # type: ignore
+        scalar_mode = scalar_mode.lower()
         if scalar_mode == 'default':
             self.SetScalarModeToDefault()
         elif scalar_mode == 'point':


### PR DESCRIPTION
This config option helps catch `# type: ignore` comments which are no longer used or needed. See [mypy docs](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-warn-unused-ignores).