### PR TITLE
Make `mypy` output more verbose error message

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,7 @@ repos:
     rev: v1.8.0
     hooks:
       - id: mypy
+        args: [--pretty, --show-error-context]
         exclude: ^(doc/|tests/|examples/|pyvista/ext/|examples_trame/)
         additional_dependencies:
           [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,8 @@ image_cache_dir = "tests/plotting/image_cache"
 
 [tool.mypy]
 ignore_missing_imports = true
+pretty = true
+show_error_context = true
 plugins = ['numpy.typing.mypy_plugin','npt_promote']
 
 [tool.numpydoc_validation]


### PR DESCRIPTION
Errors reported by `mypy` are sometimes terse and unclear. This PR adds two config options [`--pretty`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-pretty) and [`--show-error-context`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-show-error-context) to make the output more verbose and helpful.

E.g., the following error:
```
pyvista/ext/plot_directive.py:316: error: Need type annotation for "plot_context" (hint: "plot_context: Dict[<type>, <type>] = ...")  [var-annotated]
```
becomes:
```
pyvista/ext/plot_directive.py: note: In function "render_figures":
pyvista/ext/plot_directive.py:316: error: Need type annotation for "plot_context" (hint: "plot_context: Dict[<type>, <type>] = ...")  [var-annotated]
    plot_context = {}
    ^~~~~~~~~~~~
```