### PR TITLE
Ignore `flake8` E704 to fix conflict with `black`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -20,6 +20,6 @@ ignore =
     # bare excepts (temporary)
     B001, E722
     # we already check black
-    BLK100
+    BLK100,
     # let black auto-format statements on one line
     E704

--- a/.flake8
+++ b/.flake8
@@ -21,3 +21,5 @@ ignore =
     B001, E722
     # we already check black
     BLK100
+    # let black auto-format statements on one line
+    E704


### PR DESCRIPTION
Fix #5591.