### PR TITLE
Remove comment about mypy support for decorated properties

### DIFF
--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -130,9 +130,7 @@ def doc_subs(member):  # numpydoc ignore=PR01,RT01
     Still, only methods can be marked for doc substitution (as for
     properties the docstring seems to be overwritten when specifying
     setters or deleters), hence this decorator should be applied
-    before the property decorator. And 'type: ignore' comments are
-    necessary because mypy cannot handle decorated properties (see
-    https://github.com/python/mypy/issues/1362)
+    before the property decorator.
     """
     # Ensure we are operating on a method
     if not callable(member):  # pragma: no cover


### PR DESCRIPTION
### Overview

#5589 removed `# type: ignore` from the charts module, since mypy supports decorated properties now. The comment saying that those are necessary, can now be removed.
