### PR TITLE
Fix top-level linter settings deprecated in ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -287,12 +287,12 @@ exclude = [
     'doc/examples',
     'doc/_build',
 ]
-external = ["E131", "D102", "D105"]
 line-length = 100
 indent-width = 4
 target-version = 'py39'
 
 [tool.ruff.lint]
+external = ["E131", "D102", "D105"]
 ignore = [
     # whitespace before ':'
     "E203",


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Fix top-level linter settings deprecated in ruff.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None