### PR TITLE
Fix str.join calls can be replaced with f-strings

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -436,7 +436,7 @@ def get_version_match(semver):
     if semver.endswith("dev0"):
         return "dev"
     major, minor, _ = semver.split(".")
-    return ".".join([major, minor])
+    return f"{major}.{minor}"
 
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -325,6 +325,7 @@ extend-select = [
     "B010",
     "C4",
     "F",
+    "FLY",
     "NPY",
     "PGH004",
     "RSE",


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Fix str.join calls can be replaced with f-strings.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None