### PR TITLE
Drop Python3.8 support which EOL is 2024-10

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -134,8 +134,6 @@ jobs:
       # see discussion at https://github.com/pyvista/pyvista/issues/2867
       matrix:
         include:
-          - python-version: "3.8"
-            vtk-version: "9.0.3" # Requires numpy<1.24
           - python-version: "3.9"
             vtk-version: "9.1"
           - python-version: "3.10"
@@ -236,7 +234,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,7 @@ repos:
     rev: v3.15.0
     hooks:
       - id: pyupgrade
-        args: [--py38-plus, --keep-runtime-typing]
+        args: [--py39-plus, --keep-runtime-typing]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Status badges
   :target: https://github.com/psf/black
   :alt: black
 
-.. |python| image:: https://img.shields.io/badge/python-3.8+-blue.svg
+.. |python| image:: https://img.shields.io/badge/python-3.9+-blue.svg
    :target: https://www.python.org/downloads/
 
 .. |NumFOCUS Affiliated| image:: https://img.shields.io/badge/affiliated-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
@@ -179,7 +179,7 @@ Installation
 ============
 
 PyVista can be installed from `PyPI <https://pypi.org/project/pyvista/>`_
-using ``pip`` on Python >= 3.8::
+using ``pip`` on Python >= 3.9::
 
     pip install pyvista
 

--- a/doc/source/extras/building_vtk.rst
+++ b/doc/source/extras/building_vtk.rst
@@ -203,9 +203,6 @@ To do this, create a ``build_wheels.sh`` with the following contents in the
     # build based on python version from args
     PYTHON_VERSION="$1"
     case $PYTHON_VERSION in
-    3.8)
-      PYBIN="/opt/python/cp38-cp38/bin/python"
-      ;;
     3.9)
       PYBIN="/opt/python/cp39-cp39/bin/python"
       ;;
@@ -281,7 +278,7 @@ the ``quay.io/pypa/manylinux2014_aarch64`` image. Run the following:
 
 .. code-block:: bash
 
-    PYTHON_VERSION=3.8
+    PYTHON_VERSION=3.9
     rm -rf build
     docker run -e \
            --rm -v `pwd`:/io quay.io/pypa/manylinux2014_aarch64 \
@@ -299,9 +296,6 @@ Where ``build_wheels.sh`` is:
     # build based on python version from args
     PYTHON_VERSION="$1"
     case $PYTHON_VERSION in
-    3.8)
-      PYBIN="/opt/python/cp38-cp38/bin/python"
-      ;;
     3.9)
       PYBIN="/opt/python/cp39-cp39/bin/python"
       ;;

--- a/doc/source/getting-started/installation.rst
+++ b/doc/source/getting-started/installation.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-PyVista is supported on Python versions 3.8+.
+PyVista is supported on Python versions 3.9+.
 
 For the best experience, please considering using Anaconda as a virtual
 environment and package manager for Python and following the instructions to

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -271,7 +271,7 @@ Status
 .. |discuss| image:: https://img.shields.io/badge/GitHub-Discussions-green?logo=github
    :target: https://github.com/pyvista/pyvista/discussions
 
-.. |python| image:: https://img.shields.io/badge/python-3.8+-blue.svg
+.. |python| image:: https://img.shields.io/badge/python-3.9+-blue.svg
    :target: https://www.python.org/downloads/
 
 +----------------------+----------------+-------------+

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: pyvista-env
 channels:
   - conda-forge
 dependencies:
-  - python>=3.8
+  - python>=3.9
   - jupyterlab
   - numpy
   - vtk

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name = 'PyVista Developers', email = 'info@pyvista.org'},
 ]
 readme = 'README.rst'
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 keywords = ['vtk', 'numpy', 'plotting', 'mesh']
 license = {text = 'MIT'}
 classifiers = [
@@ -20,7 +20,6 @@ classifiers = [
     'Operating System :: Microsoft :: Windows',
     'Operating System :: POSIX',
     'Operating System :: MacOS',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Several CI errors are currently occurring with Python 3.8 errors. This is unlikely to be of PyVista origin. As Python 3.8 will be EOL this October, it is better to end support than spend time investigating it.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None