### PR TITLE
Fix python 3.8 errors in CI by pinning trame-vtk

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -24,6 +24,6 @@ sphinx_design<0.6.0
 sympy<1.13.0
 tqdm<4.67.0
 trame>=2.5.2,<3.6
-trame-vtk>=2.5.8,<2.8.4
+trame-vtk>=2.5.8,<2.8.4 # 2.8.4 break compatibility with Python3.8
 trame-vuetify>=2.3.1,<2.5
 trimesh<4.2.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -24,6 +24,6 @@ sphinx_design<0.6.0
 sympy<1.13.0
 tqdm<4.67.0
 trame>=2.5.2,<3.6
-trame-vtk>=2.5.8,<2.9
+trame-vtk>=2.5.8,<2.8.4
 trame-vuetify>=2.3.1,<2.5
 trimesh<4.2.0


### PR DESCRIPTION
### Overview

trame-vtk recent release broke compatibility with python 3.8

### Details


