### PR TITLE
Specify the version of test library at patch level

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
 # Note: using < here to reduce breakages
 # These should be automatically kept up to date by dependabot
 -r requirements.txt
-cmocean<3.2
+cmocean<3.1.4
 colorcet<3.1.0
 hypothesis<6.97.5
 imageio<2.34.0
@@ -23,7 +23,7 @@ sphinx-gallery<0.16.0
 sphinx_design<0.6.0
 sympy<1.13.0
 tqdm<4.67.0
-trame>=2.5.2,<3.6
-trame-vtk>=2.5.8,<2.9
-trame-vuetify>=2.3.1,<2.5
+trame>=2.5.2,<3.5.3
+trame-vtk>=2.5.8,<2.8.6
+trame-vuetify>=2.3.1,<2.4.3
 trimesh<4.2.0


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Suggestion based on discussion in #5628. I propose to specify the version of the test library at the patch level so that errors due to patch version releases are noticed by updating `dependabot`.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None