### PR TITLE
Add `get_charts` method to `Renderer`

### DIFF
--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -4742,6 +4742,11 @@ class Charts:
         """Return the weakly dereferenced renderer, maybe None."""
         return self.__renderer()
 
+    @property
+    def charts(self):  # numpydoc ignore=RT01
+        """Return the list of charts in this collection."""
+        return self._charts
+
     def _setup_scene(self):
         """Set up a new context scene and actor for these charts."""
         self._scene = _vtk.vtkContextScene()

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -4742,11 +4742,6 @@ class Charts:
         """Return the weakly dereferenced renderer, maybe None."""
         return self.__renderer()
 
-    @property
-    def charts(self):  # numpydoc ignore=RT01
-        """Return the list of charts in this collection."""
-        return self._charts
-
     def _setup_scene(self):
         """Set up a new context scene and actor for these charts."""
         self._scene = _vtk.vtkContextScene()

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -697,7 +697,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
     @property
     def charts(self):  # numpydoc ignore=RT01
-        """Return a list of all Matplotlib charts in this renderer.
+        """Return a list of all charts in this renderer.
 
         Examples
         --------

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -705,10 +705,10 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
            >>> import pyvista as pv
            >>> chart = pv.Chart2D()
-           >>> chart.line([1, 2, 3], [0, 1, 0])
+           >>> _ = chart.line([1, 2, 3], [0, 1, 0])
            >>> pl = pv.Plotter()
            >>> pl.add_chart(chart)
-           >>> print(chart is pl.renderer.get_charts()[0])
+           >>> chart is pl.renderer.get_charts()[0]
            True
 
         """

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -703,19 +703,12 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         .. pyvista-plot::
            :force_static:
 
-           >>> import matplotlib.pyplot as plt
            >>> import pyvista as pv
-           >>> fig, ax = plt.subplots()
-           >>> _ = ax.plot([1, 2, 3], [4, 5, 6])
-           >>> chart = pv.ChartMPL(fig)
-           >>> pl = pv.Plotter(shape=(1, 2))
-           >>> pl.subplot(0, 0)
-           >>> _ = pl.add_mesh(pv.Sphere())
-           >>> pl.subplot(0, 1)
-           >>> _ = pl.add_chart(chart)
-           >>> ax = pl.renderer.get_charts()[0].figure.axes[0]
-           >>> ax.get_lines()[0].set_ydata([6, 5, 4])
-           >>> pl.show()
+           >>> chart = pv.Chart2D()
+           >>> chart.line([1, 2, 3], [0, 1, 0])
+           >>> pl = pv.Plotter()
+           >>> pl.add_chart(chart)
+           >>> print(chart is pl.renderer.get_charts()[0])  # True
 
         """
         return [*self._charts] if self.has_charts else []

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -703,8 +703,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         --------
         >>> import matplotlib.pyplot as plt
         >>> import pyvista as pv
-        >>> fig, ax = plt.subplots()
-        >>> ax.plot([1, 2, 3], [4, 5, 6])
+        >>> fig, _ = plt.subplots()
         >>> chart = pv.ChartMPL(fig)
         >>> pl = pv.Plotter(shape=(1, 2))
         >>> pl.subplot(0, 0)

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -696,7 +696,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         return self._charts is not None and len(self._charts) > 0
 
     @property
-    def mpl_charts(self):  # numpydoc ignore=RT01
+    def charts(self):  # numpydoc ignore=RT01
         """Return a list of all Matplotlib charts in this renderer.
 
         Examples
@@ -714,12 +714,12 @@ class Renderer(_vtk.vtkOpenGLRenderer):
            >>> _ = pl.add_mesh(pv.Sphere())
            >>> pl.subplot(0, 1)
            >>> _ = pl.add_chart(chart)
-           >>> ax = pl.renderer.mpl_charts[0].figure.axes[0]
+           >>> ax = pl.renderer.charts[0].figure.axes[0]
            >>> ax.get_lines()[0].set_ydata([6, 5, 4])
            >>> pl.show()
 
         """
-        return self._charts.charts
+        return self._charts
 
     @wraps(Charts.set_interaction)
     def set_chart_interaction(self, interactive, toggle=False):  # numpydoc ignore=PR01,RT01

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -701,19 +701,22 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         Examples
         --------
-        >>> import matplotlib.pyplot as plt
-        >>> import pyvista as pv
-        >>> fig, ax = plt.subplots()
-        >>> _ = ax.plot([1, 2, 3], [4, 5, 6])
-        >>> chart = pv.ChartMPL(fig)
-        >>> pl = pv.Plotter(shape=(1, 2))
-        >>> pl.subplot(0, 0)
-        >>> _ = pl.add_mesh(pv.Sphere())
-        >>> pl.subplot(0, 1)
-        >>> _ = pl.add_chart(chart)
-        >>> ax = pl.renderer.mpl_charts[0].figure.axes[0]
-        >>> ax.get_lines()[0].set_ydata([6, 5, 4])
-        >>> pl.show()
+        .. pyvista-plot::
+           :force_static:
+
+           >>> import matplotlib.pyplot as plt
+           >>> import pyvista as pv
+           >>> fig, ax = plt.subplots()
+           >>> _ = ax.plot([1, 2, 3], [4, 5, 6])
+           >>> chart = pv.ChartMPL(fig)
+           >>> pl = pv.Plotter(shape=(1, 2))
+           >>> pl.subplot(0, 0)
+           >>> _ = pl.add_mesh(pv.Sphere())
+           >>> pl.subplot(0, 1)
+           >>> _ = pl.add_chart(chart)
+           >>> ax = pl.renderer.mpl_charts[0].figure.axes[0]
+           >>> ax.get_lines()[0].set_ydata([6, 5, 4])
+           >>> pl.show()
 
         """
         return self._charts.charts

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -718,7 +718,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
            >>> pl.show()
 
         """
-        return self._charts
+        return [*self._charts] if self.has_charts else []
 
     @wraps(Charts.set_interaction)
     def set_chart_interaction(self, interactive, toggle=False):  # numpydoc ignore=PR01,RT01

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -708,7 +708,8 @@ class Renderer(_vtk.vtkOpenGLRenderer):
            >>> chart.line([1, 2, 3], [0, 1, 0])
            >>> pl = pv.Plotter()
            >>> pl.add_chart(chart)
-           >>> print(chart is pl.renderer.get_charts()[0])  # True
+           >>> print(chart is pl.renderer.get_charts()[0])
+           True
 
         """
         return [*self._charts] if self.has_charts else []

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -703,7 +703,8 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         --------
         >>> import matplotlib.pyplot as plt
         >>> import pyvista as pv
-        >>> fig, _ = plt.subplots()
+        >>> fig, ax = plt.subplots()
+        >>> _ = ax.plot([1, 2, 3], [4, 5, 6])
         >>> chart = pv.ChartMPL(fig)
         >>> pl = pv.Plotter(shape=(1, 2))
         >>> pl.subplot(0, 0)

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -695,8 +695,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         """Return whether this renderer has charts."""
         return self._charts is not None and len(self._charts) > 0
 
-    @property
-    def charts(self):  # numpydoc ignore=RT01
+    def get_charts(self):  # numpydoc ignore=RT01
         """Return a list of all charts in this renderer.
 
         Examples
@@ -714,7 +713,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
            >>> _ = pl.add_mesh(pv.Sphere())
            >>> pl.subplot(0, 1)
            >>> _ = pl.add_chart(chart)
-           >>> ax = pl.renderer.charts[0].figure.axes[0]
+           >>> ax = pl.renderer.get_charts()[0].figure.axes[0]
            >>> ax.get_lines()[0].set_ydata([6, 5, 4])
            >>> pl.show()
 

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -697,7 +697,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
     @property
     def mpl_charts(self):  # numpydoc ignore=RT01
-        """Return a list of all matplotlib charts in this renderer.
+        """Return a list of all Matplotlib charts in this renderer.
 
         Examples
         --------

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -695,6 +695,11 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         """Return whether this renderer has charts."""
         return self._charts is not None and len(self._charts) > 0
 
+    @property
+    def mpl_charts(self):  # numpydoc ignore=RT01
+        """Return a list of all matplotlib charts in this renderer."""
+        return self._charts.charts
+
     @wraps(Charts.set_interaction)
     def set_chart_interaction(self, interactive, toggle=False):  # numpydoc ignore=PR01,RT01
         """Wrap ``Charts.set_interaction``."""

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -697,7 +697,25 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
     @property
     def mpl_charts(self):  # numpydoc ignore=RT01
-        """Return a list of all matplotlib charts in this renderer."""
+        """Return a list of all matplotlib charts in this renderer.
+
+        Examples
+        --------
+        >>> import matplotlib.pyplot as plt
+        >>> import pyvista as pv
+        >>> fig, ax = plt.subplots()
+        >>> ax.plot([1, 2, 3], [4, 5, 6])
+        >>> chart = pv.ChartMPL(fig)
+        >>> pl = pv.Plotter(shape=(1, 2))
+        >>> pl.subplot(0, 0)
+        >>> pl.add_mesh(pv.Sphere())
+        >>> pl.subplot(0, 1)
+        >>> pl.add_chart(chart)
+        >>> ax = pl.renderer.mpl_charts[0].figure.axes[0]
+        >>> ax.get_lines()[0].set_ydata([6, 5, 4])
+        >>> pl.show()
+
+        """
         return self._charts.charts
 
     @wraps(Charts.set_interaction)

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -708,9 +708,9 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         >>> chart = pv.ChartMPL(fig)
         >>> pl = pv.Plotter(shape=(1, 2))
         >>> pl.subplot(0, 0)
-        >>> pl.add_mesh(pv.Sphere())
+        >>> _ = pl.add_mesh(pv.Sphere())
         >>> pl.subplot(0, 1)
-        >>> pl.add_chart(chart)
+        >>> _ = pl.add_chart(chart)
         >>> ax = pl.renderer.mpl_charts[0].figure.axes[0]
         >>> ax.get_lines()[0].set_ydata([6, 5, 4])
         >>> pl.show()

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -2494,15 +2494,15 @@ def test_chart_matplotlib_plot(verify_image_cache):
     pl.show()
 
 
-def test_get_charts_property():
+def test_get_charts():
     """Test that the get_charts method is retuning a list of charts"""
-    import matplotlib.pyplot as plt
-
-    fig = plt.figure()
-    chart = pv.ChartMPL(fig)
+    chart = pv.Chart2D()
     pl = pv.Plotter()
     pl.add_chart(chart)
-    assert len(pl.renderer.get_charts()) == 1
+
+    charts = pl.renderer.get_charts()
+    assert len(charts) == 1
+    assert chart is charts[0]
 
 
 def test_add_remove_background(sphere):

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -2494,15 +2494,15 @@ def test_chart_matplotlib_plot(verify_image_cache):
     pl.show()
 
 
-def test_charts_property():
-    """Test that the charts property is retuning a list of charts"""
+def test_get_charts_property():
+    """Test that the get_charts method is retuning a list of charts"""
     import matplotlib.pyplot as plt
 
     fig = plt.figure()
     chart = pv.ChartMPL(fig)
     pl = pv.Plotter()
     pl.add_chart(chart)
-    assert len(pl.renderer.charts) == 1
+    assert len(pl.renderer.get_charts()) == 1
 
 
 def test_add_remove_background(sphere):

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -2494,6 +2494,17 @@ def test_chart_matplotlib_plot(verify_image_cache):
     pl.show()
 
 
+def test_charts_property():
+    """Test that the charts property is retuning a list of charts"""
+    import matplotlib.pyplot as plt
+
+    fig = plt.figure()
+    chart = pv.ChartMPL(fig)
+    pl = pv.Plotter()
+    pl.add_chart(chart)
+    assert len(pl.renderer.charts) == 1
+
+
 def test_add_remove_background(sphere):
     plotter = pv.Plotter(shape=(1, 2))
     plotter.add_mesh(sphere, color='w')

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -2502,7 +2502,7 @@ def test_charts_property():
     chart = pv.ChartMPL(fig)
     pl = pv.Plotter()
     pl.add_chart(chart)
-    assert len(pl.renderer.mpl_charts) == 1
+    assert len(pl.renderer.charts) == 1
 
 
 def test_add_remove_background(sphere):

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -2502,7 +2502,7 @@ def test_charts_property():
     chart = pv.ChartMPL(fig)
     pl = pv.Plotter()
     pl.add_chart(chart)
-    assert len(pl.renderer.charts) == 1
+    assert len(pl.renderer.mpl_charts) == 1
 
 
 def test_add_remove_background(sphere):


### PR DESCRIPTION
### Overview

The aim of this PR is to add properties to `Renderer` and `Charts` classes to be able to access matplotlib plots from the plotter without having to use protected attributes.

- Add `mpl_charts` property to `Renderer`: returns a list of charts. It should probably be renamed but I wanted it to not be too close to `_charts` which is a `Charts` object.
- Add `charts` property to `Charts`: returns `self._charts` but I guess there is a good reason why it is a protected variable.

With this change, the following code:
```python
axes = plotter.renderer._charts._charts[0].figure.axes
```

becomes:

```python
axes = plotter.renderer.mpl_charts[0].figure.axes
```

Example:
```python
import matplotlib.pyplot as plt
import pyvista as pv

fig, ax = plt.subplots()
ax.plot([1, 2, 3], [4, 5, 6])

chart = pv.ChartMPL(fig)

pl = pv.Plotter(shape=(1, 2))

pl.subplot(0, 0)
pl.add_mesh(pv.Sphere())

pl.subplot(0, 1)
pl.add_chart(chart)

ax = pl.renderer.mpl_charts[0].figure.axes[0]
ax.get_lines()[0].set_ydata([6, 5, 4])

pl.show()
``` 

![image](https://github.com/pyvista/pyvista/assets/22714778/4faf694a-9a99-4fdc-877f-f86e405fae03)

