### PR TITLE
Add `python_display_short_literal_types` option to docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -181,6 +181,7 @@ overloads_location = ["bottom"]
 # Helps make annotated signatures more readable.
 maximum_signature_line_length = 88
 
+# Remove term 'Literal' from signature type hints
 python_display_short_literal_types = True
 
 # See https://numpydoc.readthedocs.io/en/latest/install.html

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -181,6 +181,8 @@ overloads_location = ["bottom"]
 # Helps make annotated signatures more readable.
 maximum_signature_line_length = 88
 
+python_display_short_literal_types = True
+
 # See https://numpydoc.readthedocs.io/en/latest/install.html
 numpydoc_use_plots = True
 numpydoc_show_class_members = False


### PR DESCRIPTION
### Overview

Set [python_display_short_literal_types](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-python_display_short_literal_types) to `True`. This makes `Literal` annotations less verbose. This would affect function signatures like [`connectivity`](https://docs.pyvista.org/version/stable/api/core/_autosummary/pyvista.datasetfilters.connectivity#pyvista.DataSetFilters.connectivity) , for example.
