### PR TITLE
Append 'Like' suffix to core array-like type aliases

### DIFF
--- a/pyvista/core/_typing_core/__init__.py
+++ b/pyvista/core/_typing_core/__init__.py
@@ -1,13 +1,12 @@
 """Type aliases for type hints."""
 
 from ._aliases import (  # noqa: F401
-    Array,
     BoundsLike,
     CellArrayLike,
     CellsLike,
-    Matrix,
+    MatrixLike,
     Number,
     TransformLike,
-    Vector,
+    VectorLike,
 )
-from ._array_like import NumpyArray  # noqa: F401
+from ._array_like import ArrayLike, NumpyArray  # noqa: F401

--- a/pyvista/core/_typing_core/_aliases.py
+++ b/pyvista/core/_typing_core/_aliases.py
@@ -4,17 +4,14 @@ from typing import Tuple, Union
 
 from pyvista.core._vtk_core import vtkCellArray, vtkMatrix3x3, vtkMatrix4x4, vtkTransform
 
-from ._array_like import _ArrayLike1D, _ArrayLike2D, _ArrayLike3D, _ArrayLike4D, _NumType
+from ._array_like import _ArrayLike1D, _ArrayLike2D, _NumType
 
 Number = Union[int, float]
 
-Vector = _ArrayLike1D[_NumType]
-Matrix = _ArrayLike2D[_NumType]
-Array = Union[
-    _ArrayLike1D[_NumType], _ArrayLike2D[_NumType], _ArrayLike3D[_NumType], _ArrayLike4D[_NumType]
-]
+VectorLike = _ArrayLike1D[_NumType]
+MatrixLike = _ArrayLike2D[_NumType]
 
-TransformLike = Union[Matrix[float], vtkMatrix3x3, vtkMatrix4x4, vtkTransform]
+TransformLike = Union[MatrixLike[float], vtkMatrix3x3, vtkMatrix4x4, vtkTransform]
 BoundsLike = Tuple[Number, Number, Number, Number, Number, Number]
-CellsLike = Union[Matrix[int], Vector[int]]
+CellsLike = Union[MatrixLike[int], VectorLike[int]]
 CellArrayLike = Union[CellsLike, vtkCellArray]

--- a/pyvista/core/_typing_core/_array_like.py
+++ b/pyvista/core/_typing_core/_array_like.py
@@ -39,7 +39,7 @@ _FiniteNestedSequence = Union[  # Note: scalar types are excluded
     Sequence[Sequence[Sequence[Sequence[_T]]]],
 ]
 
-_ArrayLike = Union[
+ArrayLike = Union[
     NumpyArray[_NumType],
     _FiniteNestedSequence[_NumType],
     _FiniteNestedSequence[NumpyArray[_NumType]],

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -10,7 +10,7 @@ import numpy as np
 import pyvista
 
 from . import _vtk_core as _vtk
-from ._typing_core import CellsLike, Matrix, NumpyArray, Vector
+from ._typing_core import CellsLike, MatrixLike, NumpyArray, VectorLike
 from .celltype import CellType
 from .dataset import DataObject
 from .errors import CellSizeError, PyVistaDeprecationWarning
@@ -702,7 +702,7 @@ class CellArray(_vtk.vtkCellArray):
         return _get_offset_array(self)
 
     def _set_data(
-        self, offsets: Matrix[int], connectivity: Matrix[int], deep: bool = False
+        self, offsets: MatrixLike[int], connectivity: MatrixLike[int], deep: bool = False
     ) -> None:
         """Set the offsets and connectivity arrays."""
         vtk_offsets = cast(_vtk.vtkIdTypeArray, numpy_to_idarr(offsets, deep=deep))
@@ -717,8 +717,8 @@ class CellArray(_vtk.vtkCellArray):
 
     @staticmethod
     def from_arrays(
-        offsets: Matrix[int],
-        connectivity: Matrix[int],
+        offsets: MatrixLike[int],
+        connectivity: MatrixLike[int],
         deep: bool = False,
     ) -> CellArray:
         """Construct a CellArray from offsets and connectivity arrays.
@@ -762,7 +762,7 @@ class CellArray(_vtk.vtkCellArray):
         return _get_regular_cells(self)
 
     @classmethod
-    def from_regular_cells(cls, cells: Matrix[int], deep: bool = False) -> pyvista.CellArray:
+    def from_regular_cells(cls, cells: MatrixLike[int], deep: bool = False) -> pyvista.CellArray:
         """Construct a ``CellArray`` from a (n_cells, cell_size) array of cell indices.
 
         Parameters
@@ -786,7 +786,7 @@ class CellArray(_vtk.vtkCellArray):
         return cellarr
 
     @classmethod
-    def from_irregular_cells(cls, cells: Sequence[Vector[int]]) -> pyvista.CellArray:
+    def from_irregular_cells(cls, cells: Sequence[VectorLike[int]]) -> pyvista.CellArray:
         """Construct a ``CellArray`` from a (n_cells, cell_size) array of cell indices.
 
         Parameters

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -27,7 +27,7 @@ import numpy as np
 import pyvista
 
 from . import _vtk_core as _vtk
-from ._typing_core import BoundsLike, Matrix, Number, NumpyArray, Vector
+from ._typing_core import BoundsLike, MatrixLike, Number, NumpyArray, VectorLike
 from .dataobject import DataObject
 from .datasetattributes import DataSetAttributes
 from .errors import PyVistaDeprecationWarning, VTKVersionError
@@ -496,12 +496,12 @@ class DataSet(DataSetFilters, DataObject):
         return pyvista_ndarray(_points, dataset=self)
 
     @points.setter
-    def points(self, points: Union[Matrix[float], _vtk.vtkPoints]):  # numpydoc ignore=GL08
+    def points(self, points: Union[MatrixLike[float], _vtk.vtkPoints]):  # numpydoc ignore=GL08
         """Set a reference to the points as a numpy object.
 
         Parameters
         ----------
-        points : Matrix[float] | vtk.vtkPoints
+        points : MatrixLike[float] | vtk.vtkPoints
             Points as a array object.
 
         """
@@ -889,7 +889,7 @@ class DataSet(DataSetFilters, DataObject):
     def rotate_x(
         self,
         angle: float,
-        point: Vector[float] = (0.0, 0.0, 0.0),
+        point: VectorLike[float] = (0.0, 0.0, 0.0),
         transform_all_input_vectors: bool = False,
         inplace: bool = False,
     ):
@@ -947,7 +947,7 @@ class DataSet(DataSetFilters, DataObject):
     def rotate_y(
         self,
         angle: float,
-        point: Vector[float] = (0.0, 0.0, 0.0),
+        point: VectorLike[float] = (0.0, 0.0, 0.0),
         transform_all_input_vectors: bool = False,
         inplace: bool = False,
     ):
@@ -1004,7 +1004,7 @@ class DataSet(DataSetFilters, DataObject):
     def rotate_z(
         self,
         angle: float,
-        point: Vector[float] = (0.0, 0.0, 0.0),
+        point: VectorLike[float] = (0.0, 0.0, 0.0),
         transform_all_input_vectors: bool = False,
         inplace: bool = False,
     ):
@@ -1061,9 +1061,9 @@ class DataSet(DataSetFilters, DataObject):
 
     def rotate_vector(
         self,
-        vector: Vector[float],
+        vector: VectorLike[float],
         angle: float,
-        point: Vector[float] = (0.0, 0.0, 0.0),
+        point: VectorLike[float] = (0.0, 0.0, 0.0),
         transform_all_input_vectors: bool = False,
         inplace: bool = False,
     ):
@@ -1123,7 +1123,10 @@ class DataSet(DataSetFilters, DataObject):
         )
 
     def translate(
-        self, xyz: Vector[float], transform_all_input_vectors: bool = False, inplace: bool = False
+        self,
+        xyz: VectorLike[float],
+        transform_all_input_vectors: bool = False,
+        inplace: bool = False,
     ):
         """Translate the mesh.
 
@@ -1171,7 +1174,7 @@ class DataSet(DataSetFilters, DataObject):
 
     def scale(
         self,
-        xyz: Union[Number, Vector[float]],
+        xyz: Union[Number, VectorLike[float]],
         transform_all_input_vectors: bool = False,
         inplace: bool = False,
     ):
@@ -1229,7 +1232,7 @@ class DataSet(DataSetFilters, DataObject):
 
     def flip_x(
         self,
-        point: Optional[Vector[float]] = None,
+        point: Optional[VectorLike[float]] = None,
         transform_all_input_vectors: bool = False,
         inplace: bool = False,
     ):
@@ -1285,7 +1288,7 @@ class DataSet(DataSetFilters, DataObject):
 
     def flip_y(
         self,
-        point: Optional[Vector[float]] = None,
+        point: Optional[VectorLike[float]] = None,
         transform_all_input_vectors: bool = False,
         inplace: bool = False,
     ):
@@ -1341,7 +1344,7 @@ class DataSet(DataSetFilters, DataObject):
 
     def flip_z(
         self,
-        point: Optional[Vector[float]] = None,
+        point: Optional[VectorLike[float]] = None,
         transform_all_input_vectors: bool = False,
         inplace: bool = False,
     ):
@@ -1397,8 +1400,8 @@ class DataSet(DataSetFilters, DataObject):
 
     def flip_normal(
         self,
-        normal: Vector[float],
-        point: Optional[Vector[float]] = None,
+        normal: VectorLike[float],
+        point: Optional[VectorLike[float]] = None,
         transform_all_input_vectors: bool = False,
         inplace: bool = False,
     ):
@@ -2338,7 +2341,7 @@ class DataSet(DataSetFilters, DataObject):
 
     def find_closest_cell(
         self,
-        point: Union[Vector[float], Matrix[float]],
+        point: Union[VectorLike[float], MatrixLike[float]],
         return_closest_point: bool = False,
     ) -> Union[int, NumpyArray[int], Tuple[Union[int, NumpyArray[int]], NumpyArray[int]]]:
         """Find index of closest cell in this mesh to the given point.
@@ -2470,7 +2473,7 @@ class DataSet(DataSetFilters, DataObject):
         return out_cells
 
     def find_containing_cell(
-        self, point: Union[Vector[float], Matrix[float]]
+        self, point: Union[VectorLike[float], MatrixLike[float]]
     ) -> Union[int, NumpyArray[int]]:
         """Find index of a cell that contains the given point.
 
@@ -2536,8 +2539,8 @@ class DataSet(DataSetFilters, DataObject):
 
     def find_cells_along_line(
         self,
-        pointa: Vector[float],
-        pointb: Vector[float],
+        pointa: VectorLike[float],
+        pointb: VectorLike[float],
         tolerance: float = 0.0,
     ) -> NumpyArray[int]:
         """Find the index of cells whose bounds intersect a line.
@@ -2602,8 +2605,8 @@ class DataSet(DataSetFilters, DataObject):
 
     def find_cells_intersecting_line(
         self,
-        pointa: Vector[float],
-        pointb: Vector[float],
+        pointa: VectorLike[float],
+        pointb: VectorLike[float],
         tolerance: float = 0.0,
     ) -> NumpyArray[int]:
         """Find the index of cells that intersect a line.
@@ -3273,7 +3276,7 @@ class DataSet(DataSetFilters, DataObject):
         return [ids.GetId(i) for i in range(ids.GetNumberOfIds())]
 
     def point_is_inside_cell(
-        self, ind: int, point: Union[Vector[float] | Matrix[float]]
+        self, ind: int, point: Union[VectorLike[float] | MatrixLike[float]]
     ) -> Union[bool, NumpyArray[np.bool_]]:
         """Return whether one or more points are inside a cell.
 

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -6,7 +6,7 @@ import warnings
 import numpy as np
 
 from . import _vtk_core as _vtk
-from ._typing_core import Array, Matrix, NumpyArray
+from ._typing_core import ArrayLike, MatrixLike, NumpyArray
 from .errors import PyVistaDeprecationWarning
 from .pyvista_ndarray import pyvista_ndarray
 from .utilities.arrays import FieldAssociation, convert_array, copy_vtk_array
@@ -218,7 +218,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
             raise TypeError('Only strings are valid keys for DataSetAttributes.')
         return self.get_array(key)
 
-    def __setitem__(self, key: str, value: Array[Any]):  # numpydoc ignore=PR01,RT01
+    def __setitem__(self, key: str, value: ArrayLike[Any]):  # numpydoc ignore=PR01,RT01
         """Implement setting with the ``[]`` operator."""
         if not isinstance(key, str):
             raise TypeError('Only strings are valid keys for DataSetAttributes.')
@@ -517,7 +517,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
             narray = narray.squeeze()
         return narray
 
-    def set_array(self, data: Array[float], name: str, deep_copy=False) -> None:
+    def set_array(self, data: ArrayLike[float], name: str, deep_copy=False) -> None:
         """Add an array to this object.
 
         Use this method when adding arrays to the DataSet.  If
@@ -580,7 +580,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         self.VTKObject.AddArray(vtk_arr)
         self.VTKObject.Modified()
 
-    def set_scalars(self, scalars: Array[float], name='scalars', deep_copy=False):
+    def set_scalars(self, scalars: ArrayLike[float], name='scalars', deep_copy=False):
         """Set the active scalars of the dataset with an array.
 
         In VTK and PyVista, scalars are a quantity that has no
@@ -632,7 +632,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         self.VTKObject.SetScalars(vtk_arr)
         self.VTKObject.Modified()
 
-    def set_vectors(self, vectors: Matrix[float], name: str, deep_copy=False):
+    def set_vectors(self, vectors: MatrixLike[float], name: str, deep_copy=False):
         """Set the active vectors of this data attribute.
 
         Vectors are a quantity that has magnitude and direction, such
@@ -704,7 +704,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         self.VTKObject.Modified()
 
     def _prepare_array(
-        self, data: Array[float], name: str, deep_copy: bool
+        self, data: ArrayLike[float], name: str, deep_copy: bool
     ) -> _vtk.vtkDataArray:  # numpydoc ignore=PR01,RT01
         """Prepare an array to be added to this dataset.
 
@@ -1241,7 +1241,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         return None
 
     @active_normals.setter
-    def active_normals(self, normals: Matrix[float]):  # numpydoc ignore=GL08
+    def active_normals(self, normals: MatrixLike[float]):  # numpydoc ignore=GL08
         """Set the normals.
 
         Parameters

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -14,7 +14,7 @@ import numpy as np
 import pyvista
 
 from . import _vtk_core as _vtk
-from ._typing_core import Array, BoundsLike, CellArrayLike, Matrix, NumpyArray, Vector
+from ._typing_core import ArrayLike, BoundsLike, CellArrayLike, MatrixLike, NumpyArray, VectorLike
 from .cell import (
     CellArray,
     _get_connectivity_array,
@@ -98,12 +98,14 @@ class _PointSet(DataSet):
         DataSet.shallow_copy(self, cast(_vtk.vtkDataObject, to_copy))
         return None
 
-    def remove_cells(self, ind: Union[Vector[bool], Vector[int]], inplace=False) -> '_PointSet':
+    def remove_cells(
+        self, ind: Union[VectorLike[bool], VectorLike[int]], inplace=False
+    ) -> '_PointSet':
         """Remove cells.
 
         Parameters
         ----------
-        ind : BoolVector | IntVector
+        ind : VectorLike[int] | Vector[bool]
             Cell indices to be removed.  The array can also be a
             boolean array of the same size as the number of cells.
 
@@ -174,7 +176,7 @@ class _PointSet(DataSet):
         return self
 
     # todo: `transform_all_input_vectors` is not handled when modifying inplace
-    def translate(self, xyz: Vector[float], transform_all_input_vectors=False, inplace=None):
+    def translate(self, xyz: VectorLike[float], transform_all_input_vectors=False, inplace=None):
         """Translate the mesh.
 
         Parameters
@@ -688,7 +690,7 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
 
     def __init__(
         self,
-        var_inp: Union[_vtk.vtkPolyData, str, Matrix[float], None] = None,
+        var_inp: Union[_vtk.vtkPolyData, str, MatrixLike[float], None] = None,
         faces: Optional[CellArrayLike] = None,
         n_faces: Optional[int] = None,
         lines: Optional[CellArrayLike] = None,
@@ -999,17 +1001,17 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         return _get_regular_cells(self.GetPolys())
 
     @regular_faces.setter
-    def regular_faces(self, faces: Matrix[int]):  # numpydoc ignore=PR01
+    def regular_faces(self, faces: MatrixLike[int]):  # numpydoc ignore=PR01
         """Set the face cells from an (n_faces, face_size) array."""
         self.faces = CellArray.from_regular_cells(faces)
 
     @classmethod
-    def from_regular_faces(cls, points: Matrix[float], faces: Matrix[int], deep=False):
+    def from_regular_faces(cls, points: MatrixLike[float], faces: MatrixLike[int], deep=False):
         """Alternate `pyvista.PolyData` convenience constructor from point and regular face arrays.
 
         Parameters
         ----------
-        points : Matrix[float]
+        points : MatrixLike[float]
             A (n_points, 3) array of points.
 
         faces : Matrix[int]
@@ -1067,12 +1069,12 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         return _get_irregular_cells(self.GetPolys())
 
     @irregular_faces.setter
-    def irregular_faces(self, faces: Sequence[Vector[int]]):  # numpydoc ignore=PR01
+    def irregular_faces(self, faces: Sequence[VectorLike[int]]):  # numpydoc ignore=PR01
         """Set the faces from a sequence of face arrays."""
         self.faces = CellArray.from_irregular_cells(faces)
 
     @classmethod
-    def from_irregular_faces(cls, points: Matrix[float], faces: Sequence[Vector[int]]):
+    def from_irregular_faces(cls, points: MatrixLike[float], faces: Sequence[VectorLike[int]]):
         """Alternate `pyvista.PolyData` convenience constructor from point and ragged face arrays.
 
         Parameters
@@ -1080,7 +1082,7 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         points : Matrix
             A (n_points, 3) array of points.
 
-        faces : Sequence[Vector[int]]
+        faces : Sequence[VectorLike[int]]
             A sequence of face vectors containing point indices.
 
         Returns
@@ -2569,14 +2571,14 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
         self.cell_data.set_array(ghost_cells, _vtk.vtkDataSetAttributes.GhostArrayName())
         return self
 
-    def hide_points(self, ind: Union[Vector[bool], Vector[int]]) -> None:
+    def hide_points(self, ind: Union[VectorLike[bool], VectorLike[int]]) -> None:
         """Hide points without deleting them.
 
         Hides points by setting the ghost_points array to ``HIDDEN_CELL``.
 
         Parameters
         ----------
-        ind : BoolVector | IntVector
+        ind : Vector[bool] | VectorLike[int]
             Vector of point indices to be hidden. The vector can also be a
             boolean array of the same size as the number of points.
 
@@ -2709,16 +2711,16 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         """Return the standard ``str`` representation."""
         return DataSet.__str__(self)
 
-    def _from_arrays(self, dims: Vector[int], corners: Matrix[float]) -> None:
+    def _from_arrays(self, dims: VectorLike[int], corners: MatrixLike[float]) -> None:
         """Create a VTK explicit structured grid from NumPy arrays.
 
         Parameters
         ----------
-        dims : IntVector
+        dims : VectorLike[int]
             A sequence of integers with shape (3,) containing the
             topological dimensions of the grid.
 
-        corners : Matrix
+        corners : MatrixLike[float]
             A sequence of numbers with shape ``(number of corners, 3)``
             containing the coordinates of the corner points.
 
@@ -2847,7 +2849,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         grid = self.cast_to_unstructured_grid()
         grid.save(filename, binary)
 
-    def hide_cells(self, ind: Vector[int], inplace: bool = False) -> 'ExplicitStructuredGrid':
+    def hide_cells(self, ind: VectorLike[int], inplace: bool = False) -> 'ExplicitStructuredGrid':
         """Hide specific cells.
 
         Hides cells by setting the ghost cell array to ``HIDDENCELL``.
@@ -2994,12 +2996,12 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         else:
             return self.bounds
 
-    def cell_id(self, coords: Array[int]) -> Union[int, NumpyArray[int], None]:
+    def cell_id(self, coords: ArrayLike[int]) -> Union[int, NumpyArray[int], None]:
         """Return the cell ID.
 
         Parameters
         ----------
-        coords : IntArray
+        coords : ArrayLike[int]
             Cell structured coordinates.
 
         Returns
@@ -3040,12 +3042,14 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         else:
             return ind
 
-    def cell_coords(self, ind: Union[int, Vector[int]]) -> Union[None, Tuple[int], Matrix[int]]:
+    def cell_coords(
+        self, ind: Union[int, VectorLike[int]]
+    ) -> Union[None, Tuple[int], MatrixLike[int]]:
         """Return the cell structured coordinates.
 
         Parameters
         ----------
-        ind : int | IntVector
+        ind : int | VectorLike[int]
             Cell IDs.
 
         Returns
@@ -3083,12 +3087,12 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
             return coords
         return None
 
-    def neighbors(self, ind: Union[int, Vector[int]], rel: str = 'connectivity') -> List[int]:
+    def neighbors(self, ind: Union[int, VectorLike[int]], rel: str = 'connectivity') -> List[int]:
         """Return the indices of neighboring cells.
 
         Parameters
         ----------
-        ind : int | IntVector
+        ind : int | VectorLike[int]
             Cell IDs.
 
         rel : str, default: "connectivity"

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -105,7 +105,7 @@ class _PointSet(DataSet):
 
         Parameters
         ----------
-        ind : VectorLike[int] | Vector[bool]
+        ind : VectorLike[int] | VectorLike[bool]
             Cell indices to be removed.  The array can also be a
             boolean array of the same size as the number of cells.
 
@@ -1014,7 +1014,7 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         points : MatrixLike[float]
             A (n_points, 3) array of points.
 
-        faces : Matrix[int]
+        faces : MatrixLike[int]
             A (n_faces, face_size) array of face indices. For a triangle mesh, ``face_size = 3``.
 
         deep : bool, default: False
@@ -2578,7 +2578,7 @@ class StructuredGrid(_vtk.vtkStructuredGrid, PointGrid, StructuredGridFilters):
 
         Parameters
         ----------
-        ind : Vector[bool] | VectorLike[int]
+        ind : VectorLike[bool] | VectorLike[int]
             Vector of point indices to be hidden. The vector can also be a
             boolean array of the same size as the number of points.
 

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -6,7 +6,7 @@ from typing import Union
 import numpy as np
 
 from . import _vtk_core as _vtk
-from ._typing_core import Array, NumpyArray
+from ._typing_core import ArrayLike, NumpyArray
 from .utilities.arrays import FieldAssociation, convert_array
 
 
@@ -46,7 +46,7 @@ class pyvista_ndarray(np.ndarray):  # type: ignore[type-arg]  # numpydoc ignore=
 
     def __new__(
         cls,
-        array: Union[Array[float], _vtk.vtkAbstractArray],
+        array: Union[ArrayLike[float], _vtk.vtkAbstractArray],
         dataset=None,
         association=FieldAssociation.NONE,
     ):

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -9,7 +9,7 @@ import numpy as np
 
 import pyvista
 from pyvista.core import _vtk_core as _vtk
-from pyvista.core._typing_core import Matrix, NumpyArray, TransformLike, Vector
+from pyvista.core._typing_core import MatrixLike, NumpyArray, TransformLike, VectorLike
 from pyvista.core.errors import AmbiguousDataError, MissingDataError
 
 
@@ -57,13 +57,13 @@ def parse_field_choice(field):
 
 
 def _coerce_pointslike_arg(
-    points: Union[Matrix[float], Vector[float]], copy: bool = False
+    points: Union[MatrixLike[float], VectorLike[float]], copy: bool = False
 ) -> Tuple[NumpyArray[float], bool]:
     """Check and coerce arg to (n, 3) np.ndarray.
 
     Parameters
     ----------
-    points : Matrix[float] | Vector[float]
+    points : MatrixLike[float] | VectorLike[float]
         Argument to coerce into (n, 3) :class:`numpy.ndarray`.
 
     copy : bool, default: False

--- a/pyvista/core/utilities/cells.py
+++ b/pyvista/core/utilities/cells.py
@@ -8,7 +8,7 @@ import numpy as np
 
 import pyvista
 from pyvista.core import _vtk_core as _vtk
-from pyvista.core._typing_core import Matrix, NumpyArray
+from pyvista.core._typing_core import MatrixLike, NumpyArray
 
 
 def ncells_from_cells(cells: NumpyArray[int]) -> int:
@@ -36,7 +36,7 @@ def ncells_from_cells(cells: NumpyArray[int]) -> int:
 
 
 def numpy_to_idarr(
-    ind: Matrix[int], deep: bool = False, return_ind: bool = False
+    ind: MatrixLike[int], deep: bool = False, return_ind: bool = False
 ) -> Union[Tuple[_vtk.vtkIdTypeArray, NumpyArray[int]], _vtk.vtkIdTypeArray]:
     """Safely convert a numpy array to a vtkIdTypeArray.
 

--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -13,7 +13,7 @@ from vtkmodules.vtkRenderingFreeType import vtkVectorText
 
 import pyvista
 from pyvista.core import _vtk_core as _vtk
-from pyvista.core._typing_core import BoundsLike, Matrix, NumpyArray, Vector
+from pyvista.core._typing_core import BoundsLike, MatrixLike, NumpyArray, VectorLike
 from pyvista.core.utilities.misc import _check_range, _reciprocal, no_new_attr
 
 from .arrays import _coerce_pointslike_arg
@@ -558,12 +558,12 @@ class MultipleLinesSource(_vtk.vtkLineSource):
         return _vtk.vtk_to_numpy(self.GetPoints().GetData())
 
     @points.setter
-    def points(self, points: Union[Matrix[float], Vector[float]]):
+    def points(self, points: Union[MatrixLike[float], VectorLike[float]]):
         """Set the list of points defining a broken line.
 
         Parameters
         ----------
-        points : Vector[float] | Matrix[float]
+        points : VectorLike[float] | MatrixLike[float]
             List of points defining a broken line.
         """
         points, _ = _coerce_pointslike_arg(points)

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -12,7 +12,7 @@ import warnings
 
 import numpy as np
 
-from .._typing_core import Vector
+from .._typing_core import VectorLike
 
 T = TypeVar('T', bound='AnnotatedIntEnum')
 
@@ -52,13 +52,13 @@ def assert_empty_kwargs(**kwargs):
     raise TypeError(message)
 
 
-def check_valid_vector(point: Vector[float], name: str = '') -> None:
+def check_valid_vector(point: VectorLike[float], name: str = '') -> None:
     """
     Check if a vector contains three components.
 
     Parameters
     ----------
-    point : Vector[float]
+    point : VectorLike[float]
         Input vector to check. Must be an iterable with exactly three components.
     name : str, optional
         Name to use in the error messages. If not provided, "Vector" will be used.

--- a/pyvista/plotting/prop3d.py
+++ b/pyvista/plotting/prop3d.py
@@ -4,7 +4,7 @@ from typing import Tuple, Union
 
 import numpy as np
 
-from pyvista.core._typing_core import BoundsLike, NumpyArray, Vector
+from pyvista.core._typing_core import BoundsLike, NumpyArray, VectorLike
 from pyvista.core.utilities.arrays import array_from_vtkmatrix, vtkmatrix_from_array
 
 from . import _vtk
@@ -42,7 +42,7 @@ class Prop3D(_vtk.vtkProp3D):
         return self.GetScale()
 
     @scale.setter
-    def scale(self, value: Vector[float]):  # numpydoc ignore=GL08
+    def scale(self, value: VectorLike[float]):  # numpydoc ignore=GL08
         return self.SetScale(value)
 
     @property
@@ -67,7 +67,7 @@ class Prop3D(_vtk.vtkProp3D):
         return self.GetPosition()
 
     @position.setter
-    def position(self, value: Vector[float]):  # numpydoc ignore=GL08
+    def position(self, value: VectorLike[float]):  # numpydoc ignore=GL08
         self.SetPosition(value)
 
     def rotate_x(self, angle: float):

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -39,7 +39,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import warnings
 
 import pyvista
-from pyvista.core._typing_core import Number, Vector
+from pyvista.core._typing_core import Number, VectorLike
 from pyvista.core.utilities.misc import _check_range
 
 from ._typing import ColorLike
@@ -1551,7 +1551,7 @@ class _CameraConfig(_ThemeConfig):
         self._parallel_scale = 1.0
 
     @property
-    def position(self) -> Vector[float]:  # numpydoc ignore=RT01
+    def position(self) -> VectorLike[float]:  # numpydoc ignore=RT01
         """Return or set the camera position.
 
         Examples
@@ -1565,11 +1565,11 @@ class _CameraConfig(_ThemeConfig):
         return self._position
 
     @position.setter
-    def position(self, position: Vector[float]):  # numpydoc ignore=GL08
+    def position(self, position: VectorLike[float]):  # numpydoc ignore=GL08
         self._position = position
 
     @property
-    def viewup(self) -> Vector[float]:  # numpydoc ignore=RT01
+    def viewup(self) -> VectorLike[float]:  # numpydoc ignore=RT01
         """Return or set the camera viewup.
 
         Examples
@@ -1583,7 +1583,7 @@ class _CameraConfig(_ThemeConfig):
         return self._viewup
 
     @viewup.setter
-    def viewup(self, viewup: Vector[float]):  # numpydoc ignore=GL08
+    def viewup(self, viewup: VectorLike[float]):  # numpydoc ignore=GL08
         self._viewup = viewup
 
     @property


### PR DESCRIPTION
### Overview

Related to #5621. In that, linkable references to the core array-like type aliases are added to the docs. In order to make it seamless and easy when adding these types to docstrings, that PR adds the type aliases to the `pyvista` namespace so that `Sphinx` can implicitly reference the type aliases. This is similar to what is already done with `pyvista.ColorLike`.

However, one potential issue with adding these types to the `pyvista` namespace is that users may access `pyvista.Array` thinking that this creates an actual `Array` object, and not a type alias object.

This PR appends `Like` to address this:
- `Vector` -> `VectorLike`
- `Matrix` -> `MatrixLike`
- `Array` -> `ArrayLike`

In addition, appending `Like` to the types will make `pyvista` more consistent with other scientific libraries such as NumPy and Pandas which also use the term `ArrayLike`. 
However, it may also create ambiguity since our definitions will differ slightly (e.g. PyVista's ArrayLike doesn't include scalars, Numpy's does), see relevant issue https://github.com/pandas-dev/pandas/issues/41807. Perhaps we should also add a `pv` prefix, e.g. `pvArrayLike`? 
