### PR TITLE
Ignore flake8 E701 and E702 to fix conflict with black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -22,4 +22,4 @@ ignore =
     # we already check black
     BLK100,
     # let black auto-format statements on one line
-    E704
+    E701, E702, E704


### PR DESCRIPTION
Follow-up from #5592. The same issue is popping up in #5673, causing unresolvable `pre-commit` failures