### PR TITLE
Add `ContourFilter` class to support trame example

### DIFF
--- a/examples_trame/advanced/contour.py
+++ b/examples_trame/advanced/contour.py
@@ -1,7 +1,6 @@
 from trame.app import get_server
 from trame.ui.vuetify import SinglePageLayout
 from trame.widgets import vuetify
-from vtkmodules.vtkFiltersCore import vtkContourFilter
 
 import pyvista as pv
 from pyvista import examples
@@ -28,7 +27,7 @@ ctrl.on_server_ready.add(ctrl.view_update)
 
 volume = examples.download_head_2()
 
-contour = vtkContourFilter()
+contour = pv.ContourFilter()
 contour.SetInputDataObject(volume)
 # contour.SetComputeNormals(True)
 # contour.SetComputeScalars(False)
@@ -60,7 +59,7 @@ actor = pl.add_mesh(contour, cmap="viridis", clim=data_range)
 
 @state.change("contour_value")
 def update_contour(contour_value, **kwargs):
-    contour.SetValue(0, contour_value)
+    contour.isosurfaces = [contour_value]
     ctrl.view_update_image()
 
 

--- a/pyvista/core/__init__.py
+++ b/pyvista/core/__init__.py
@@ -24,6 +24,7 @@ from .errors import (
 )
 from .filters import (
     CompositeFilters,
+    ContourFilter,
     DataSetFilters,
     ImageDataFilters,
     PolyDataFilters,

--- a/pyvista/core/filters/__init__.py
+++ b/pyvista/core/filters/__init__.py
@@ -60,7 +60,7 @@ def _get_output(
 from .composite import CompositeFilters
 
 # Re-export submodules to maintain the same import paths before filters.py was split into submodules
-from .data_set import DataSetFilters
+from .data_set import ContourFilter, DataSetFilters
 from .image_data import ImageDataFilters
 from .poly_data import PolyDataFilters
 from .rectilinear_grid import RectilinearGridFilters
@@ -77,4 +77,5 @@ __all__ = [
     'StructuredGridFilters',
     'ImageDataFilters',
     'UnstructuredGridFilters',
+    'ContourFilter',
 ]

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -31,6 +31,10 @@ from pyvista.core.utilities.helpers import generate_plane, wrap
 from pyvista.core.utilities.misc import abstract_class, assert_empty_kwargs
 
 
+class ContourFilter(_vtk.vtkContourFilter):
+    """Contour filter."""
+
+
 @abstract_class
 class DataSetFilters:
     """A set of common filters that can be applied to any vtkDataSet."""


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
I have recently been very interested in Trame for prototyping applications. The Trame application in the PyVista repository relies on vtk for the filter part of its implementation. I propose to make a class for it in PyVista. Let's have fun pythonic implementing applications together!

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- This proposal also has purpose to discuss if we can add a class for other filters as well.