### PR TITLE
Fix ghost-cells example

### DIFF
--- a/examples/02-plot/ghost-cells.py
+++ b/examples/02-plot/ghost-cells.py
@@ -24,7 +24,7 @@ mesh = vol.cast_to_unstructured_grid()
 ghosts = np.argwhere(mesh["facies"] < 1.0)
 
 # This will act on the mesh inplace to mark those cell indices as ghosts
-mesh.remove_cells(ghosts)
+mesh.remove_cells(ghosts, inplace=True)
 
 ###############################################################################
 # Now we can plot the mesh and those cells will be hidden


### PR DESCRIPTION
### Overview

The `remove_cells` filter probably used to default to `inplace=True`, but the documentation was never updated. See https://docs.pyvista.org/version/stable/examples/02-plot/ghost-cells.html

### Details

#5693 is opened to track whether there should be a better API for Ghosting cells.  Also `remove_cells` filter isn't in the documentation. This is tracked in #5694.
