### PR TITLE
Add `point_dtype` to `Line` and `LineSource` class

### DIFF
--- a/pyvista/core/utilities/geometric_objects.py
+++ b/pyvista/core/utilities/geometric_objects.py
@@ -981,7 +981,7 @@ def Plane(
     return surf
 
 
-def Line(pointa=(-0.5, 0.0, 0.0), pointb=(0.5, 0.0, 0.0), resolution=1):
+def Line(pointa=(-0.5, 0.0, 0.0), pointb=(0.5, 0.0, 0.0), resolution=1, point_dtype='float32'):
     """Create a line.
 
     Parameters
@@ -994,6 +994,10 @@ def Line(pointa=(-0.5, 0.0, 0.0), pointb=(0.5, 0.0, 0.0), resolution=1):
 
     resolution : int, default: 1
         Number of pieces to divide line into.
+
+    point_dtype : str, default: 'float32'
+        Set the desired output point types. It must be either 'float32' or 'float64'.
+        .. versionadded:: 0.44.0
 
     Returns
     -------
@@ -1009,7 +1013,7 @@ def Line(pointa=(-0.5, 0.0, 0.0), pointb=(0.5, 0.0, 0.0), resolution=1):
     >>> mesh.plot(color='k', line_width=10)
 
     """
-    src = LineSource(pointa, pointb, resolution)
+    src = LineSource(pointa, pointb, resolution, point_dtype=point_dtype)
     line = src.output
     # Compute distance of every point along line
     compute = lambda p0, p1: np.sqrt(np.sum((p1 - p0) ** 2, axis=1))

--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -1292,6 +1292,10 @@ class LineSource(_vtk.vtkLineSource):
     resolution : int, default: 1
         Number of pieces to divide line into.
 
+    point_dtype : str, default: 'float32'
+        Set the desired output point types. It must be either 'float32' or 'float64'.
+        .. versionadded:: 0.44.0
+
     """
 
     def __init__(
@@ -1299,12 +1303,14 @@ class LineSource(_vtk.vtkLineSource):
         pointa=(-0.5, 0.0, 0.0),
         pointb=(0.5, 0.0, 0.0),
         resolution=1,
+        point_dtype='float32',
     ):
         """Initialize source."""
         super().__init__()
         self.pointa = pointa
         self.pointb = pointb
         self.resolution = resolution
+        self.point_dtype = point_dtype
 
     @property
     def pointa(self) -> Sequence[float]:
@@ -1389,6 +1395,46 @@ class LineSource(_vtk.vtkLineSource):
         """
         self.Update()
         return wrap(self.GetOutput())
+
+    @property
+    def point_dtype(self) -> str:
+        """Get the desired output point types.
+
+        Returns
+        -------
+        str
+            Desired output point types.
+            It must be either 'float32' or 'float64'.
+        """
+        precision = self.GetOutputPointsPrecision()
+        point_dtype = {
+            SINGLE_PRECISION: 'float32',
+            DOUBLE_PRECISION: 'float64',
+        }[precision]
+        return point_dtype
+
+    @point_dtype.setter
+    def point_dtype(self, point_dtype: str):
+        """Set the desired output point types.
+
+        Parameters
+        ----------
+        point_dtype : str, default: 'float32'
+            Set the desired output point types.
+            It must be either 'float32' or 'float64'.
+
+        Returns
+        -------
+        point_dtype: str
+            Desired output point types.
+        """
+        if point_dtype not in ['float32', 'float64']:
+            raise ValueError("Point dtype must be either 'float32' or 'float64'")
+        precision = {
+            'float32': SINGLE_PRECISION,
+            'float64': DOUBLE_PRECISION,
+        }[point_dtype]
+        self.SetOutputPointsPrecision(precision)
 
 
 @no_new_attr

--- a/tests/core/test_geometric_objects.py
+++ b/tests/core/test_geometric_objects.py
@@ -364,6 +364,16 @@ def test_line():
         pv.Line(pointa, (10, 1.0))
 
 
+@pytest.mark.parametrize(('point_dtype'), (['float32', 'float64', 'invalid']))
+def test_line_point_dtype(point_dtype):
+    if point_dtype in ['float32', 'float64']:
+        line = pv.Line(point_dtype=point_dtype)
+        assert line.points.dtype == point_dtype
+    else:
+        with pytest.raises(ValueError, match="Point dtype must be either 'float32' or 'float64'"):
+            _ = pv.Line(point_dtype=point_dtype)
+
+
 def test_multiple_lines():
     points = np.array([[0, 0, 0], [1, 1, 0], [2, 2, 2], [3, 3, 0]])
     multiple_lines = pv.MultipleLines(points=points)


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Add `point_dtype` to `Line` and `LineSource` classes.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- See #5502 .