### PR TITLE
Add `point_dtype` to `MultipleLines` and `MultipleLinesSource` class

### DIFF
--- a/pyvista/core/utilities/geometric_objects.py
+++ b/pyvista/core/utilities/geometric_objects.py
@@ -1018,13 +1018,17 @@ def Line(pointa=(-0.5, 0.0, 0.0), pointb=(0.5, 0.0, 0.0), resolution=1):
     return line
 
 
-def MultipleLines(points=[[-0.5, 0.0, 0.0], [0.5, 0.0, 0.0]]):
+def MultipleLines(points=[[-0.5, 0.0, 0.0], [0.5, 0.0, 0.0]], point_dtype='float32'):
     """Create multiple lines.
 
     Parameters
     ----------
     points : array_like[float], default: [[-0.5, 0.0, 0.0], [0.5, 0.0, 0.0]]
         List of points defining a broken line.
+
+    point_dtype : str, default: 'float32'
+        Set the desired output point types. It must be either 'float32' or 'float64'.
+        .. versionadded:: 0.44.0
 
     Returns
     -------
@@ -1043,7 +1047,7 @@ def MultipleLines(points=[[-0.5, 0.0, 0.0], [0.5, 0.0, 0.0]]):
     >>> plotter.camera.zoom(0.8)
     >>> plotter.show()
     """
-    return MultipleLinesSource(points=points).output
+    return MultipleLinesSource(points=points, point_dtype=point_dtype).output
 
 
 def Tube(pointa=(-0.5, 0.0, 0.0), pointb=(0.5, 0.0, 0.0), resolution=1, radius=1.0, n_sides=15):

--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -540,14 +540,20 @@ class MultipleLinesSource(_vtk.vtkLineSource):
     ----------
     points : array_like[float], default: [[-0.5, 0.0, 0.0], [0.5, 0.0, 0.0]]
         List of points defining a broken line.
+
+
+    point_dtype : str, default: 'float32'
+        Set the desired output point types. It must be either 'float32' or 'float64'.
+        .. versionadded:: 0.44.0
     """
 
     _new_attr_exceptions = ['points']
 
-    def __init__(self, points=[[-0.5, 0.0, 0.0], [0.5, 0.0, 0.0]]):
+    def __init__(self, points=[[-0.5, 0.0, 0.0], [0.5, 0.0, 0.0]], point_dtype='float32'):
         """Initialize the multiple lines source class."""
         super().__init__()
         self.points = points
+        self.point_dtype = point_dtype
 
     @property
     def points(self) -> NumpyArray[float]:
@@ -585,6 +591,46 @@ class MultipleLinesSource(_vtk.vtkLineSource):
         """
         self.Update()
         return wrap(self.GetOutput())
+
+    @property
+    def point_dtype(self) -> str:
+        """Get the desired output point types.
+
+        Returns
+        -------
+        str
+            Desired output point types.
+            It must be either 'float32' or 'float64'.
+        """
+        precision = self.GetOutputPointsPrecision()
+        point_dtype = {
+            SINGLE_PRECISION: 'float32',
+            DOUBLE_PRECISION: 'float64',
+        }[precision]
+        return point_dtype
+
+    @point_dtype.setter
+    def point_dtype(self, point_dtype: str):
+        """Set the desired output point types.
+
+        Parameters
+        ----------
+        point_dtype : str, default: 'float32'
+            Set the desired output point types.
+            It must be either 'float32' or 'float64'.
+
+        Returns
+        -------
+        point_dtype: str
+            Desired output point types.
+        """
+        if point_dtype not in ['float32', 'float64']:
+            raise ValueError("Point dtype must be either 'float32' or 'float64'")
+        precision = {
+            'float32': SINGLE_PRECISION,
+            'float64': DOUBLE_PRECISION,
+        }[point_dtype]
+        self.SetOutputPointsPrecision(precision)
 
 
 class Text3DSource(vtkVectorText):

--- a/tests/core/test_geometric_objects.py
+++ b/tests/core/test_geometric_objects.py
@@ -380,6 +380,16 @@ def test_multiple_lines():
         pv.MultipleLines(points[0, :])
 
 
+@pytest.mark.parametrize(('point_dtype'), (['float32', 'float64', 'invalid']))
+def test_multiple_lines_point_dtype(point_dtype):
+    if point_dtype in ['float32', 'float64']:
+        multiple_lines = pv.MultipleLines(point_dtype=point_dtype)
+        assert multiple_lines.points.dtype == point_dtype
+    else:
+        with pytest.raises(ValueError, match="Point dtype must be either 'float32' or 'float64'"):
+            _ = pv.MultipleLines(point_dtype=point_dtype)
+
+
 def test_tube():
     pointa = (0, 0, 0)
     pointb = (10, 1.0, 3)


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Add `point_dtype` to `MultipleLines` and `MultipleLinesSource` classes.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- See #5502 .