### PR TITLE
Expose `DataSet` docs

### DIFF
--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -3,6 +3,7 @@
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
+   :show-inheritance:
 
    {% block methods %}
 

--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -13,7 +13,7 @@
       :toctree:
    {% for item in methods %}
       {% if not item in skipmethods %}
-        {% if name == 'Plotter' or item not in inherited_members %}
+        {% if name == 'Plotter' or item in inherited_members %}
           {{ name }}.{{ item }}
         {% endif %}
       {% endif %}
@@ -28,7 +28,7 @@
    .. autosummary::
       :toctree:
    {% for item in attributes %}
-      {% if name == 'Plotter' or item not in inherited_members %}
+      {% if name == 'Plotter' or item in inherited_members %}
         {% if item.0 != item.upper().0 %}
           {{ name }}.{{ item }}
         {% endif %}

--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -13,7 +13,7 @@
       :toctree:
    {% for item in methods %}
       {% if not item in skipmethods %}
-        {% if name == 'Plotter' or item not in inherited_members %}
+        {% if name in ['Plotter', 'DataSet'] or item not in inherited_members %}
           {{ name }}.{{ item }}
         {% endif %}
       {% endif %}
@@ -28,7 +28,7 @@
    .. autosummary::
       :toctree:
    {% for item in attributes %}
-      {% if name == 'Plotter' or item not in inherited_members %}
+      {% if name in ['Plotter', 'DataSet'] or item not in inherited_members %}
         {% if item.0 != item.upper().0 %}
           {{ name }}.{{ item }}
         {% endif %}

--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -13,7 +13,7 @@
       :toctree:
    {% for item in methods %}
       {% if not item in skipmethods %}
-        {% if name in ['Plotter', 'DataSet'] or item not in inherited_members %}
+        {% if name == 'Plotter' or item not in inherited_members %}
           {{ name }}.{{ item }}
         {% endif %}
       {% endif %}
@@ -28,7 +28,7 @@
    .. autosummary::
       :toctree:
    {% for item in attributes %}
-      {% if name in ['Plotter', 'DataSet'] or item not in inherited_members %}
+      {% if name == 'Plotter' or item not in inherited_members %}
         {% if item.0 != item.upper().0 %}
           {{ name }}.{{ item }}
         {% endif %}

--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -218,6 +218,10 @@ class ColorSchemeTable(DocTable):
     path = f"{CHARTS_TABLE_DIR}/plot_color_schemes.rst"
     header = _aligned_dedent(
         """
+        |..
+        |   Mark as orphan since it's not used explicitly in any toctree
+        |:orphan:
+        |
         |.. list-table:: Color schemes
         |   :widths: 15 50 5 30
         |   :header-rows: 1
@@ -294,6 +298,10 @@ class ColorTable(DocTable):
     path = f"{COLORS_TABLE_DIR}/colors.rst"
     header = _aligned_dedent(
         """
+        |..
+        |   Mark as orphan since it's not used explicitly in any toctree
+        |:orphan:
+        |
         |.. list-table::
         |   :widths: 50 20 30
         |   :header-rows: 1

--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -217,9 +217,8 @@ class ColorSchemeTable(DocTable):
 
     path = f"{CHARTS_TABLE_DIR}/plot_color_schemes.rst"
     header = _aligned_dedent(
+        # Add orphan to suppress sphinx toctree warnings
         """
-        |..
-        |   Mark as orphan since it's not used explicitly in any toctree
         |:orphan:
         |
         |.. list-table:: Color schemes
@@ -297,9 +296,8 @@ class ColorTable(DocTable):
 
     path = f"{COLORS_TABLE_DIR}/colors.rst"
     header = _aligned_dedent(
+        # Add orphan to suppress sphinx toctree warnings
         """
-        |..
-        |   Mark as orphan since it's not used explicitly in any toctree
         |:orphan:
         |
         |.. list-table::

--- a/examples/01-filter/extract-edges.py
+++ b/examples/01-filter/extract-edges.py
@@ -52,7 +52,7 @@ p.show()
 
 
 ###############################################################################
-# We can leverage the :any:`pyvista.PolyData.n_open_edges` property and
+# We can leverage the :attr:`pyvista.PolyData.n_open_edges` property and
 # :func:`pyvista.DataSetFilters.extract_feature_edges` filter to count and
 # extract the open edges on a :class:`pyvista.PolyData` mesh.
 


### PR DESCRIPTION
Possiblly fix #5694 

The method of adding the class to `class.rst` worked previously as part of #5029 to expose the abstract docs of `Prop3D` so it could be referenced for both `Actor` and `AxesActor` child classes.

Let's see what this does for `DataSet`.