### PR TITLE
Fix `pv.Rectangle` for small numbers

### DIFF
--- a/pyvista/core/utilities/geometric_objects.py
+++ b/pyvista/core/utilities/geometric_objects.py
@@ -1907,9 +1907,16 @@ def Rectangle(points=None):
     vec_02 = point_2 - point_0
     vec_12 = point_2 - point_1
 
-    scalar_pdct_01_02 = np.dot(vec_01, vec_02)
-    scalar_pdct_01_12 = np.dot(vec_01, vec_12)
-    scalar_pdct_02_12 = np.dot(vec_02, vec_12)
+    mag_01 = np.linalg.norm(vec_01)
+    mag_02 = np.linalg.norm(vec_02)
+    mag_12 = np.linalg.norm(vec_12)
+
+    if np.isclose(mag_01, 0) or np.isclose(mag_02, 0) or np.isclose(mag_12, 0):
+        raise ValueError("Unable to build a rectangle with less than three different points")
+
+    scalar_pdct_01_02 = np.dot(vec_01, vec_02) / min(mag_01, mag_02) ** 2
+    scalar_pdct_01_12 = np.dot(vec_01, vec_12) / min(mag_01, mag_12) ** 2
+    scalar_pdct_02_12 = np.dot(vec_02, vec_12) / min(mag_02, mag_12) ** 2
 
     null_scalar_products = [
         val
@@ -1918,8 +1925,6 @@ def Rectangle(points=None):
     ]
     if len(null_scalar_products) == 0:
         raise ValueError("The three points should defined orthogonal vectors")
-    if len(null_scalar_products) > 1:
-        raise ValueError("Unable to build a rectangle with less than three different points")
 
     points = np.array([point_0, point_1, point_2, point_0])
     if np.isclose(scalar_pdct_01_02, 0):

--- a/tests/core/test_geometric_objects.py
+++ b/tests/core/test_geometric_objects.py
@@ -597,11 +597,20 @@ def test_quadrilateral():
     assert np.allclose(mesh.points, points)
 
 
-def test_rectangle():
-    pointa = [3.0, 1.0, 1.0]
-    pointb = [3.0, 2.0, 1.0]
-    pointc = [1.0, 2.0, 1.0]
-    pointd = [1.0, 1.0, 1.0]
+@pytest.mark.parametrize(
+    "points",
+    [
+        ([3.0, 1.0, 1.0], [3.0, 2.0, 1.0], [1.0, 2.0, 1.0], [1.0, 1.0, 1.0]),
+        (
+            [0.043, 0.0359, 0.0001],
+            [0.044, 0.0359, 0.0001],
+            [0.043, 0.036, 0.0001],
+            [0.044, 0.036, 0.0001],
+        ),
+    ],
+)
+def test_rectangle(points):
+    pointa, pointb, pointc, pointd = points
 
     # Do a rotation to be in full 3D space with floating point coordinates
     trans = pv.core.utilities.transformations.axis_angle_rotation([1, 1, 1], 30)


### PR DESCRIPTION
### Overview

closes #5733 .  Allows creating `Rectangle` with small numbers.  I think doing so will create problems with various filters and rendering, but there are probably use cases where it makes sense.


### Details

The solution here scales the dot product of the vectors between the points by the lengths of the vectors to detect orthogonality. This might prevent using very large numbers with only small changes to be used.  In case this is a problem, we could consider providing an option to skip checking and require the user to specify points in a specific order.

