### PR TITLE
Add update-pr-branch action to update PR branch

### DIFF
--- a/.github/workflows/update-pr-branch.yml
+++ b/.github/workflows/update-pr-branch.yml
@@ -3,7 +3,7 @@ name: PR update
 on:
   push:
     branches:
-      - 'main'
+      - "main"
 jobs:
   autoupdate:
     runs-on: ubuntu-latest
@@ -12,9 +12,9 @@ jobs:
         uses: adRise/update-pr-branch@v0.7.2
         with:
           token: ${{ secrets.PYVISTA_BOT_TOKEN }}
-          base: 'main'
+          base: "main"
           required_approval_count: 1
           require_passed_checks: false
-          sort: 'created'
-          direction: 'desc'
+          sort: "created"
+          direction: "desc"
           require_auto_merge_enabled: true

--- a/.github/workflows/update-pr-branch.yml
+++ b/.github/workflows/update-pr-branch.yml
@@ -1,0 +1,20 @@
+name: PR update
+
+on:
+  push:
+    branches:
+      - 'main'
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Automatically update PR
+        uses: adRise/update-pr-branch@v0.7.2
+        with:
+          token: ${{ secrets.PYVISTA_BOT_TOKEN }}
+          base: 'main'
+          required_approval_count: 1
+          require_passed_checks: false
+          sort: 'created'
+          direction: 'desc'
+          require_auto_merge_enabled: true


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
The job of the action is to help click "Update branch" button for us. Designed to work with the `auto-merge` and ["Require branches to be up to date before merging"](https://docs.github.com/en/github/administering-a-repository/about-protected-branches#require-status-checks-before-merging) options. It will update the newest open PR that match the below conditions

- The PR has the `auto-merge` option enabled
- The PR has 1 approvals and no changes-requested review
- The PR branch has no conflicts with the base branch
- The PR branch is behind the base branch

![image](https://github.com/pyvista/pyvista/assets/7513610/6e141d66-96fd-4c7e-a5b2-3270d1c6cfb7)

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- [Update PR Branch Action](https://github.com/adRise/update-pr-branch)
