### PR TITLE
Raise `TypeError` for `compute_normals` with vertex or line cells

### DIFF
--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -1587,10 +1587,13 @@ class PolyDataFilters(DataSetFilters):
         present, the edges are split and new points generated to
         prevent blurry edges (due to Phong shading).
 
+        An array named ``"Normals"`` is stored with the mesh.
+
         .. warning::
 
            - Normals can only be computed for polygons and triangle strips. Point clouds are not supported.
            - Triangle strips are broken up into triangle polygons. You may want to restrip the triangles.
+           - Previous arrays named ``"Normals"`` will be overwritten.
 
         Parameters
         ----------
@@ -1651,20 +1654,12 @@ class PolyDataFilters(DataSetFilters):
         pyvista.PolyData
             Updated mesh with cell and point normals.
 
-        Notes
-        -----
-        Previous arrays named ``"Normals"`` will be overwritten.
-
-        Normals are computed only for polygons and triangle
-        strips. Normals are not computed for lines or vertices.
-
-        Triangle strips are broken up into triangle polygons. You may
-        want to restrip the triangles.
-
-        It may be easier to run
-        :func:`pyvista.PolyData.point_normals` or
-        :func:`pyvista.PolyData.cell_normals` if you would just
-        like the array of point or cell normals.
+        See Also
+        --------
+        point_normals
+            Returns the array of point normals.
+        cell_normals
+            Returns the array of cell normals.
 
         Examples
         --------

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -1713,8 +1713,11 @@ class PolyDataFilters(DataSetFilters):
                     "Normals cannot be computed for PolyData containing only vertex cells (e.g. point clouds)\n"
                     "and/or line cells. The PolyData cells must be polygons (e.g. triangle cells)."
                 )
-            else:
-                raise RuntimeError('Normals could not be computed.')
+            else:  # pragma: no cover
+                raise RuntimeError(
+                    'Normals could not be computed for unknown reasons.\n'
+                    'Please report the issue at https://github.com/pyvista/pyvista/issues.'
+                )
         if point_normals:
             mesh.GetPointData().SetActiveNormals('Normals')
         if cell_normals:

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1424,7 +1424,10 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         # Recompute normals prior to save.  Corrects a bug were some
         # triangular meshes are not saved correctly
         if ftype in ['.stl', '.ply'] and recompute_normals:
-            self.compute_normals(inplace=True)
+            try:
+                self.compute_normals(inplace=True)
+            except TypeError:
+                pass
 
         # validate texture
         if ftype == '.ply' and texture is not None:

--- a/pyvista/plotting/_plotting.py
+++ b/pyvista/plotting/_plotting.py
@@ -87,19 +87,25 @@ def prepare_smooth_shading(mesh, scalars, texture, split_sharp_edges, feature_an
             indices_array = 'vtkOriginalCellIds'
 
     if split_sharp_edges:
-        mesh = mesh.compute_normals(
-            cell_normals=False,
-            split_vertices=True,
-            feature_angle=feature_angle,
-        )
-        if is_polydata:
-            if has_scalars and use_points:
-                # we must track the original IDs with our own array from compute_normals
-                indices_array = 'pyvistaOriginalPointIds'
+        try:
+            mesh = mesh.compute_normals(
+                cell_normals=False,
+                split_vertices=True,
+                feature_angle=feature_angle,
+            )
+            if is_polydata:
+                if has_scalars and use_points:
+                    # we must track the original IDs with our own array from compute_normals
+                    indices_array = 'pyvistaOriginalPointIds'
+        except TypeError:
+            pass
     else:
         # consider checking if mesh contains active normals
         # if mesh.point_data.active_normals is None:
-        mesh.compute_normals(cell_normals=False, inplace=True)
+        try:
+            mesh.compute_normals(cell_normals=False, inplace=True)
+        except TypeError:
+            pass
 
     if has_scalars and indices_array is not None:
         ind = mesh[indices_array]

--- a/pyvista/plotting/_plotting.py
+++ b/pyvista/plotting/_plotting.py
@@ -86,8 +86,8 @@ def prepare_smooth_shading(mesh, scalars, texture, split_sharp_edges, feature_an
         else:
             indices_array = 'vtkOriginalCellIds'
 
-    if split_sharp_edges:
-        try:
+    try:
+        if split_sharp_edges:
             mesh = mesh.compute_normals(
                 cell_normals=False,
                 split_vertices=True,
@@ -97,15 +97,15 @@ def prepare_smooth_shading(mesh, scalars, texture, split_sharp_edges, feature_an
                 if has_scalars and use_points:
                     # we must track the original IDs with our own array from compute_normals
                     indices_array = 'pyvistaOriginalPointIds'
-        except TypeError:
-            pass
-    else:
-        # consider checking if mesh contains active normals
-        # if mesh.point_data.active_normals is None:
-        try:
+        else:
+            # consider checking if mesh contains active normals
+            # if mesh.point_data.active_normals is None:
             mesh.compute_normals(cell_normals=False, inplace=True)
-        except TypeError:
+    except TypeError as e:
+        if "Normals cannot be computed" in repr(e):
             pass
+        else:
+            raise
 
     if has_scalars and indices_array is not None:
         ind = mesh[indices_array]

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -2703,14 +2703,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         # Compute surface normals if using smooth shading
         if smooth_shading:
-            try:
-                dataset = dataset._compute_normals(
-                    cell_normals=False,
-                    split_vertices=True,
-                    feature_angle=feature_angle,
-                )
-            except TypeError:
-                pass
+            dataset = dataset._compute_normals(
+                cell_normals=False,
+                split_vertices=True,
+                feature_angle=feature_angle,
+            )
 
         self.mapper = CompositePolyDataMapper(
             dataset,

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -2703,11 +2703,14 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         # Compute surface normals if using smooth shading
         if smooth_shading:
-            dataset = dataset._compute_normals(
-                cell_normals=False,
-                split_vertices=True,
-                feature_angle=feature_angle,
-            )
+            try:
+                dataset = dataset._compute_normals(
+                    cell_normals=False,
+                    split_vertices=True,
+                    feature_angle=feature_angle,
+                )
+            except TypeError:
+                pass
 
         self.mapper = CompositePolyDataMapper(
             dataset,

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -1,6 +1,7 @@
 from math import pi
 import os
 import pathlib
+import re
 from typing import Dict, List
 import warnings
 
@@ -701,6 +702,23 @@ def test_compute_normals(sphere):
     cell_normals = sphere_normals.cell_data['Normals']
     assert point_normals.shape[0] == sphere.n_points
     assert cell_normals.shape[0] == sphere.n_cells
+
+
+def test_compute_normals_raises(sphere):
+    msg = (
+        'Normals cannot be computed for PolyData containing only vertex cells (e.g. point clouds)\n'
+        'and/or line cells. The PolyData cells must be polygons (e.g. triangle cells).'
+    )
+
+    point_cloud = pv.PolyData(sphere.points)
+    assert point_cloud.n_verts == point_cloud.n_cells
+    with pytest.raises(TypeError, match=re.escape(msg)):
+        point_cloud.compute_normals()
+
+    lines = pv.MultipleLines()
+    assert lines.n_lines == lines.n_cells
+    with pytest.raises(TypeError, match=re.escape(msg)):
+        lines.compute_normals()
 
 
 def test_compute_normals_inplace(sphere):

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -146,6 +146,17 @@ def test_prepare_smooth_shading_not_poly(hexbeam):
     assert np.allclose(mesh[scalars_name], expected_mesh[scalars_name])
 
 
+@pytest.mark.parametrize('split_sharp_edges', [True, False])
+def test_prepare_smooth_shading_point_cloud(split_sharp_edges):
+    point_cloud = pv.PolyData([0.0, 0.0, 0.0])
+    assert point_cloud.n_verts == point_cloud.n_cells
+    mesh, scalars = _plotting.prepare_smooth_shading(
+        point_cloud, None, True, split_sharp_edges, False, None
+    )
+    assert scalars is None
+    assert "Normals" not in mesh.point_data
+
+
 def test_smooth_shading_shallow_copy(sphere):
     """See also ``test_compute_normals_inplace``."""
     sphere.point_data['numbers'] = np.arange(sphere.n_points)


### PR DESCRIPTION
Fix #4709.

Warnings are also added to the docstring based on the warnings from the VTK docs https://vtk.org/doc/nightly/html/classvtkPolyDataNormals.html#details