### PR TITLE
Add `Renderer` `viewport` setter to control layout

### DIFF
--- a/pyvista/plotting/background_renderer.py
+++ b/pyvista/plotting/background_renderer.py
@@ -40,7 +40,7 @@ class BackgroundRenderer(Renderer):
         self._modified_observer = None
         self._prior_window_size = None
         if view_port is not None:
-            self.SetViewport(view_port)
+            self.viewport = view_port
 
         # create image actor
         image_actor = _vtk.vtkImageActor()

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -3441,6 +3441,9 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         >>> _ = pl.add_mesh(pv.Sphere())
         >>> pl.renderers[0].viewport
         (0.0, 0.0, 0.5, 1.0)
+
+        Change viewport to half size.
+
         >>> pl.renderers[0].viewport = (0.125, 0.25, 0.375, 0.75)
         >>> pl.show()
 

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -3444,6 +3444,10 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         """
         return self.GetViewport()
 
+    @viewport.setter
+    def viewport(self, viewport):  # numpydoc ignore=GL08
+        self.SetViewport(viewport)
+
     @property
     def width(self):  # numpydoc ignore=RT01
         """Width of the renderer."""

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -3438,8 +3438,11 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         >>> import pyvista as pv
         >>> pl = pv.Plotter(shape=(1, 2))
+        >>> _ = pl.add_mesh(pv.Sphere())
         >>> pl.renderers[0].viewport
         (0.0, 0.0, 0.5, 1.0)
+        >>> pl.renderers[0].viewport = (0.125, 0.25, 0.375, 0.75)
+        >>> pl.show()
 
         """
         return self.GetViewport()

--- a/pyvista/plotting/renderers.py
+++ b/pyvista/plotting/renderers.py
@@ -98,16 +98,16 @@ class Renderers:
             for i in rangen:
                 arenderer = Renderer(self._plotter, border, border_color, border_width)
                 if '|' in shape:
-                    arenderer.SetViewport(0, i / n, xsplit, (i + 1) / n)
+                    arenderer.viewport = (0, i / n, xsplit, (i + 1) / n)
                 else:
-                    arenderer.SetViewport(i / n, 0, (i + 1) / n, xsplit)
+                    arenderer.viewport = (i / n, 0, (i + 1) / n, xsplit)
                 self._renderers.append(arenderer)
             for i in rangem:
                 arenderer = Renderer(self._plotter, border, border_color, border_width)
                 if '|' in shape:
-                    arenderer.SetViewport(xsplit, i / m, 1, (i + 1) / m)
+                    arenderer.viewport = (xsplit, i / m, 1, (i + 1) / m)
                 else:
-                    arenderer.SetViewport(i / m, xsplit, (i + 1) / m, 1)
+                    arenderer.viewport = (i / m, xsplit, (i + 1) / m, 1)
                 self._renderers.append(arenderer)
 
             self._shape = (n + m,)
@@ -211,7 +211,7 @@ class Renderers:
                     y0 = row_off[row + nb_rows]
                     x1 = col_off[col + nb_cols]
                     y1 = row_off[row]
-                    renderer.SetViewport(x0, y0, x1, y1)
+                    renderer.viewport = (x0, y0, x1, y1)
                     self._render_idxs[row, col] = len(self)
                     self._renderers.append(renderer)
                 else:
@@ -224,7 +224,7 @@ class Renderers:
 
         # create a shadow renderer that lives on top of all others
         self._shadow_renderer = Renderer(self._plotter, border, border_color, border_width)
-        self._shadow_renderer.SetViewport(0, 0, 1, 1)
+        self._shadow_renderer.viewport = (0, 0, 1, 1)
         self._shadow_renderer.SetDraw(False)
 
     def loc_to_group(self, loc):

--- a/tests/plotting/test_renderer.py
+++ b/tests/plotting/test_renderer.py
@@ -326,3 +326,10 @@ def test_add_legend_background_opacity(sphere):
     pl.add_mesh(sphere, label='sphere')
     actor = pl.add_legend(background_opacity=background_opacity)
     assert actor.GetBackgroundOpacity() == background_opacity
+
+
+def test_viewport():
+    pl = pv.Plotter(shape=(1, 2))
+    assert pl.renderers[0].viewport == (0.0, 0.0, 0.5, 1.0)
+    pl.renderers[0].viewport = (0.125, 0.25, 0.375, 0.75)
+    assert pl.renderers[0].viewport == (0.125, 0.25, 0.375, 0.75)


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Add `Renderer` `viewport` setter to control layout.

```python
>>> import pyvista as pv
>>> pl = pv.Plotter(shape=(1, 2))
>>> _ = pl.add_mesh(pv.Sphere())
>>> pl.renderers[0].viewport = (0.125, 0.25, 0.375, 0.75)
>>> pl.show()
```
![Screenshot_2024-03-15_08-53-39](https://github.com/pyvista/pyvista/assets/7513610/cfa95d96-7364-43ae-8ef8-610affc563b6)

- [x] Switch `SetViewPort` to `viewport` inside pyvista code.
- [x] Add example to docstring.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- Follow up of #5044
