### PR TITLE
Allow reading DICOM stack from directory with `pv.read()`

### DIFF
--- a/pyvista/core/utilities/fileio.py
+++ b/pyvista/core/utilities/fileio.py
@@ -170,7 +170,7 @@ def read(filename, force_ext=None, file_format=None, progress_bar=False):
             multi.append(read(each, file_format=file_format), name)
         return multi
     filename = os.path.abspath(os.path.expanduser(str(filename)))
-    if not os.path.isfile(filename):
+    if not os.path.isfile(filename) and not os.path.isdir(filename):
         raise FileNotFoundError(f'File ({filename}) not found')
 
     # Read file using meshio.read if file_format is present

--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -191,7 +191,7 @@ def get_reader(filename, force_ext=None):
         Reader = CLASS_READERS[ext]
     except KeyError:
         if os.path.isdir(filename):
-            if len(files := os.listdir()) > 0 and all(
+            if len(files := os.listdir(filename)) > 0 and all(
                 pathlib.Path(f).suffix == '.dcm' for f in files
             ):
                 Reader = DICOMReader

--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -190,7 +190,19 @@ def get_reader(filename, force_ext=None):
     try:
         Reader = CLASS_READERS[ext]
     except KeyError:
-        raise ValueError(f"`pyvista.get_reader` does not support a file with the {ext} extension")
+        if os.path.isdir(filename):
+            if len(files := os.listdir()) > 0 and all(
+                pathlib.Path(f).suffix == '.dcm' for f in files
+            ):
+                Reader = DICOMReader
+            else:
+                raise ValueError(
+                    f"`pyvista.get_reader` does not support reading from directory:\n\t{filename}"
+                )
+        else:
+            raise ValueError(
+                f"`pyvista.get_reader` does not support a file with the {ext} extension"
+            )
 
     return Reader(filename)
 

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -32,7 +32,6 @@ import pyvista
 from pyvista.core import _vtk_core as _vtk
 from pyvista.core.errors import PyVistaDeprecationWarning, VTKVersionError
 from pyvista.core.utilities.fileio import get_ext, read, read_texture
-from pyvista.core.utilities.reader import DICOMReader
 
 # disable pooch verbose logging
 POOCH_LOGGER = get_logger()
@@ -4538,8 +4537,7 @@ def download_dicom_stack(load: bool = True) -> Union[pyvista.ImageData, str]:  #
     fnames = _download_archive('DICOM_Stack/data.zip')
     path = os.path.dirname(fnames[0])
     if load:
-        reader = DICOMReader(path)
-        return reader.read()
+        return pyvista.read(path)
     return path
 
 

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -25,7 +25,7 @@ skip_windows = pytest.mark.skipif(os.name == 'nt', reason='Test fails on Windows
 def test_get_reader_fail(tmp_path):
     with pytest.raises(ValueError):  # noqa: PT011
         pv.get_reader("not_a_supported_file.no_data")
-    match= "`pyvista.get_reader` does not support reading from directory:\n\t"
+    match = "`pyvista.get_reader` does not support reading from directory:\n\t"
     with pytest.raises(ValueError, match=match):
         pv.get_reader(str(tmp_path))
 

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -22,9 +22,12 @@ pytestmark = pytest.mark.skipif(
 skip_windows = pytest.mark.skipif(os.name == 'nt', reason='Test fails on Windows')
 
 
-def test_get_reader_fail():
+def test_get_reader_fail(tmp_path):
     with pytest.raises(ValueError):  # noqa: PT011
         pv.get_reader("not_a_supported_file.no_data")
+    msg = "`pyvista.get_reader` does not support reading from directory:\n\t"
+    with pytest.raises(ValueError, match=msg):
+        pv.get_reader(str(tmp_path))
 
 
 def test_reader_invalid_file():
@@ -279,7 +282,7 @@ def test_ensightreader_time_sets():
 def test_dcmreader(tmpdir):
     # Test reading directory (image stack)
     directory = examples.download_dicom_stack(load=False)
-    reader = pv.DICOMReader(directory)  # ``get_reader`` doesn't support directories
+    reader = pv.get_reader(directory)
     assert directory in str(reader)
     assert isinstance(reader, pv.DICOMReader)
     assert reader.path == directory

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -25,8 +25,8 @@ skip_windows = pytest.mark.skipif(os.name == 'nt', reason='Test fails on Windows
 def test_get_reader_fail(tmp_path):
     with pytest.raises(ValueError):  # noqa: PT011
         pv.get_reader("not_a_supported_file.no_data")
-    msg = "`pyvista.get_reader` does not support reading from directory:\n\t"
-    with pytest.raises(ValueError, match=msg):
+    match= "`pyvista.get_reader` does not support reading from directory:\n\t"
+    with pytest.raises(ValueError, match=match):
         pv.get_reader(str(tmp_path))
 
 


### PR DESCRIPTION
Reading a DICOM stack from a directory is not currently allowed:

``` python
import pyvista as pv
from pyvista import examples as ex
directory = ex.download_dicom_stack(load=False)
pv.read(directory)  # OSError: This file was not able to be automatically read by pyvista.
```

This PR fixes this.
