### PR TITLE
 Allow users to specify Trame Jupyter Mode in environment variable

### DIFF
--- a/doc/source/user-guide/jupyter/trame.rst
+++ b/doc/source/user-guide/jupyter/trame.rst
@@ -150,6 +150,51 @@ setting the following flag to ``True`` or ``False``:
   <pyvista.plotting.themes._TrameConfig.jupyter_extension_enabled>`
 
 
+Setting Remote Jupyter Host with an Environment Variable
+########################################################
+You can set the Remote Jupyter Host manually with the flags discussed above,
+but these need to be set every time the Jupyter kernel restarts. In some environments,
+it may be more efficient to configure the Remote Jupyter Host with an environment variable.
+If set, the value for `PYVISTA_TRAME_JUPYTER_MODE` will determine the values of
+these two flags:
+
+* :py:attr:`pyvista.global_theme.trame.server_proxy_enabled
+  <pyvista.plotting.themes._TrameConfig.server_proxy_enabled>`
+* :py:attr:`pyvista.global_theme.trame.jupyter_extension_enabled
+  <pyvista.plotting.themes._TrameConfig.jupyter_extension_enabled>`
+
+If set, the accepted values for `PYVISTA_TRAME_JUPYTER_MODE` include "extension", "proxy", and "native".
+The following table shows how each accepted value will affect the two flags, as well as any precondition
+that must be true for the value to be applicable. To meet these prerequisites,
+review the sections above for installation instructions.
+
+.. list-table::
+   :header-rows: 1
+
+   * - `PYVISTA_TRAME_JUPYTER_MODE`
+     - Description
+     - Condition
+     - `server_proxy_enabled`
+     - `jupyter_extension_enabled`
+
+   * - "extension"
+     - Use Trame Jupyter Extension
+     - Extension must be available
+     - False
+     - True
+
+   * - "proxy"
+     - Use Jupyter Server Proxy
+     - Proxy must be available
+     - True
+     - False
+
+   * - "native"
+     - Do not use Extension nor Proxy
+     - None
+     - False
+     - False
+
 Other Considerations
 ++++++++++++++++++++
 It may be worth using GPU acceleration, see :ref:`gpu_off_screen`.

--- a/doc/source/user-guide/jupyter/trame.rst
+++ b/doc/source/user-guide/jupyter/trame.rst
@@ -163,7 +163,7 @@ these two flags:
 * :py:attr:`pyvista.global_theme.trame.jupyter_extension_enabled
   <pyvista.plotting.themes._TrameConfig.jupyter_extension_enabled>`
 
-If set, the accepted values for `PYVISTA_TRAME_JUPYTER_MODE` include "extension", "proxy", and "native".
+If set, the accepted values for `PYVISTA_TRAME_JUPYTER_MODE` include ``'extension'``, ``'proxy'``, and ``'native'``.
 The following table shows how each accepted value will affect the two flags, as well as any precondition
 that must be true for the value to be applicable. To meet these prerequisites,
 review the sections above for installation instructions.

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -1396,6 +1396,20 @@ class _TrameConfig(_ThemeConfig):
         self._jupyter_extension_enabled = (
             self._jupyter_extension_available and not self._server_proxy_enabled
         )
+        # if set, jupyter_mode overwrites defaults
+        if "PYVISTA_TRAME_JUPYTER_MODE" in os.environ:
+            jupyter_mode = os.environ.get("PYVISTA_TRAME_JUPYTER_MODE")
+
+            if jupyter_mode == "extension" and self._jupyter_extension_available:
+                self._server_proxy_enabled = False
+                self._jupyter_extension_enabled = True
+
+            if jupyter_mode == "proxy" and self._server_proxy_enabled:
+                self._jupyter_extension_enabled = False
+
+            if jupyter_mode == "native":
+                self._jupyter_extension_enabled = False
+                self._server_proxy_enabled = False
         self._default_mode = 'trame'
 
     @property

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -1397,19 +1397,15 @@ class _TrameConfig(_ThemeConfig):
             self._jupyter_extension_available and not self._server_proxy_enabled
         )
         # if set, jupyter_mode overwrites defaults
-        if "PYVISTA_TRAME_JUPYTER_MODE" in os.environ:
-            jupyter_mode = os.environ.get("PYVISTA_TRAME_JUPYTER_MODE")
-
-            if jupyter_mode == "extension" and self._jupyter_extension_available:
-                self._server_proxy_enabled = False
-                self._jupyter_extension_enabled = True
-
-            if jupyter_mode == "proxy" and self._server_proxy_enabled:
-                self._jupyter_extension_enabled = False
-
-            if jupyter_mode == "native":
-                self._jupyter_extension_enabled = False
-                self._server_proxy_enabled = False
+        jupyter_mode = os.environ.get("PYVISTA_TRAME_JUPYTER_MODE")
+        if jupyter_mode == "extension" and self._jupyter_extension_available:  # pragma: no cover
+            self._server_proxy_enabled = False
+            self._jupyter_extension_enabled = True
+        elif jupyter_mode == "proxy" and self._server_proxy_enabled:  # pragma: no cover
+            self._jupyter_extension_enabled = False
+        elif jupyter_mode == "native":  # pragma: no cover
+            self._jupyter_extension_enabled = False
+            self._server_proxy_enabled = False
         self._default_mode = 'trame'
 
     @property


### PR DESCRIPTION
### Overview

In environments such as Binder builds, it would be helpful to be able to specify whether to use the `trame_jupyter_extension` with an environment variable. This would reduce the need to reset the configuration manually every time the kernel starts. With these changes, a user may specify `PYVISTA_TRAME_JUPYTER_MODE` in the environment to override the default behavior. If set, accepted values include "extension", "proxy", and "native".

See https://mybinder.org/v2/gh/pyvista/pyvista-xarray/fix-binder?labpath=examples. This Binder build needs to have the `trame_jupyter_extension` enabled. Without it, the plotter iFrames show 404 errors.

### Details

This PR involves one change: the addition of a logic block in the constructor for `pyvista/plotting/themes/_TrameConfig`. If `PYVISTA_TRAME_JUPYTER_MODE` is set, the value will determine how to override the values for `self._server_proxy_enabled` and `self._jupyter_extension_enabled`. If not set, the default values for these are used.

The following table shows how each accepted value affects these attributes, as well as the precondition that must be true for the override to occur.

| PYVISTA_TRAME_JUPYTER_MODE | condition | server_proxy_enabled| jupyter_extension_enabled |
|-----|-----|-----------|------|
|"extension"|extension must be available|False|True|
|"proxy"|proxy must be available|True|False|
|"native"|None|False|False|

