### PR TITLE
Drop `param` installation as `panel` was dropped

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,7 +11,6 @@ ipywidgets<9.0.0
 meshio<5.4.0
 nest_asyncio<1.6.1
 numpydoc==1.6.0
-param<2.1.0
 pydata-sphinx-theme<0.16.0
 pytest<8.1.0
 pytest-cov<4.2.0


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Drop `param` installation as `panel` was dropped.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- See #1478 .
