### PR TITLE
Fix small typos of docstring in `plotting`

### DIFF
--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -748,16 +748,16 @@ class DataSetMapper(_vtk.vtkDataSetMapper, _BaseMapper):
 
     @property
     def resolve(self) -> str:
-        """Set or return global flag to avoid z-buffer resolution.
+        "Set or return the global flag to avoid z-buffer resolution.
 
-        A global flag that controls whether coincident topology
+        A global flag that controls whether the coincident topology
         (e.g., a line on top of a polygon) is shifted to avoid
         z-buffer resolution (and hence rendering problems).
 
         If not off, there are two methods to choose from.
         `polygon_offset` uses graphics systems calls to shift polygons,
-        lines and points from each other.
-        `shift_zbuffer` is a legacy method that used to remap the z-buffer
+        lines, and points from each other.
+        `shift_zbuffer` is a legacy method that is used to remap the z-buffer
         to distinguish vertices, lines, and polygons,
         but does not always produce acceptable results.
         You should only use the polygon_offset method (or none) at this point.

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -748,7 +748,7 @@ class DataSetMapper(_vtk.vtkDataSetMapper, _BaseMapper):
 
     @property
     def resolve(self) -> str:
-        "Set or return the global flag to avoid z-buffer resolution.
+        """Set or return the global flag to avoid z-buffer resolution.
 
         A global flag that controls whether the coincident topology
         (e.g., a line on top of a polygon) is shifted to avoid

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1083,7 +1083,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             See :func:`pyvista.create_axes_orientation_box` for details.
 
             .. deprecated:: 0.43.0
-                The is deprecated. Use `add_box_axes` method instead.",
+                The is deprecated. Use `add_box_axes` method instead.
 
         box_args : dict, optional
             Parameters for the orientation box widget when


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Fix small typos of docstring in renderer.py.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None
