### PR TITLE
Checks for use of `Optional` when default is None

### DIFF
--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -1182,7 +1182,7 @@ class DatasetPropsGenerator:
             return None
 
     @staticmethod
-    def _generate_num(num: Optional[float], fmt: Literal['exp', 'spaced'] = None):
+    def _generate_num(num: Optional[float], fmt: Optional[Literal["exp", "spaced"]] = None):
         if num is None:
             return None
         if fmt == 'exp':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -358,6 +358,7 @@ extend-select = [
     "RUF002",
     "RUF005",
     "RUF010",
+    "RUF013",
     "RUF015",
     "RUF100",
     "SIM",


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Checks for the use of `Optional` when the default is None.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- See https://docs.astral.sh/ruff/rules/implicit-optional/.