### PR TITLE
Fix getattr takes a constant attr value as an arg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -340,6 +340,7 @@ fixable = ["ALL"]
 unfixable = []
 extend-select = [
     "B007",
+    "B009",
     "B010",
     "C4",
     "F",

--- a/tests/namespace/test_utilities_namespace.py
+++ b/tests/namespace/test_utilities_namespace.py
@@ -88,4 +88,4 @@ def test_failure_to_find():
         AttributeError,
         match=r'Module `pyvista\.utilities` has been deprecated and we could not automatically find',
     ):
-        getattr(module, 'this_does_not_exist')
+        module.this_does_not_exist


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Checks for uses of `getattr` that take a constant attribute value as an argument (e.g., `getattr(obj, "foo")`).
<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

> [!NOTE]
> https://docs.astral.sh/ruff/rules/get-attr-with-constant/
