### PR TITLE
Add `user_dict` property to `DataSet` objects for storing user-specified data

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1916,6 +1916,7 @@ class DataSet(DataSetFilters, DataObject):
         The user dict can be updated like a regular dict.
 
         >>> mesh.user_dict['parts'] = ['head', 'thorax', 'abdomen']
+        >>> mesh.user_dict
         {"name": "ant", "num_legs": 6, "parts": ["head", "thorax", "abdomen"]}
 
         Data in the user dict is stored as field data

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1898,6 +1898,14 @@ class DataSet(DataSetFilters, DataObject):
             values. It should not be used to store frequently accessed array data
             with many entries (a regular field data array should be used instead).
 
+        .. warning::
+
+            Field data is typically passed-through by dataset filters, and therefore
+            the user dict's items can generally be expected to persist and remain
+            unchanged in the output of filtering methods. However, this behavior is
+            not guaranteed, as it's possible that some filters may modify or clear
+            field data. Use with caution.
+
         Returns
         -------
         UserDict

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections import namedtuple
+from collections import UserDict, namedtuple
 import collections.abc
 from copy import deepcopy
 from functools import partial
@@ -37,6 +37,8 @@ from .utilities import transformations
 from .utilities.arrays import (
     FieldAssociation,
     _coerce_pointslike_arg,
+    _JSONValueType,
+    _SerializedDictArray,
     get_array,
     get_array_association,
     raise_not_matching,
@@ -1864,6 +1866,88 @@ class DataSet(DataSetFilters, DataObject):
         """
         sizes = self.compute_cell_sizes(length=False, area=True, volume=False)
         return sizes.cell_data['Area'].sum()
+
+    @property
+    def user_dict(self) -> _SerializedDictArray:
+        """Set or get the user dict.
+
+        The user dict is a user-specified data dictionary. The dictionary
+        is stored as a JSON-serialized string as part of the mesh's field data.
+        Unlike regular field data, which requires values to be stored as an
+        array, the user dict provides a mapping for scalar values.
+
+        Since the user dict is stored as field data, it is automatically saved
+        with the mesh when it is saved in a compatible file format (e.g. ``'.vtk'``).
+        Any saved metadata is automatically de-serialized by PyVista whenever
+        the user dict is accessed again. Since the data is stored as JSON, it
+        may also be easily retrieved or read by other programs.
+
+        Any JSON-serializable values are permitted by the user dict, i.e. values
+        can have type ``dict``, ``list``, ``tuple``, ``str``, ``int``, ``float``,
+        ``bool``, or ``None``.
+
+        .. note::
+
+            The user dict is convenience property and is intended for metadata storage.
+            It has an inefficient dictionary implementation and should only be used to
+            store a small number of infrequently-accessed keys with relatively small
+            values. It should not be used to store frequently accessed array data
+            with many entries (a regular field data array should be used instead).
+
+        Returns
+        -------
+        _SerializedDictArray
+            Serialized dict-like subclass of collections.UserDict.
+
+        """
+        self._config_user_dict()
+        return self._user_dict
+
+    @user_dict.setter
+    def user_dict(
+        self,
+        dict_: Union[dict[str, _JSONValueType], UserDict[str, _JSONValueType]],
+    ):  # numpydoc ignore=GL08
+
+        # Setting None removes the field data array
+        if dict_ is None and '_PYVISTA_USER_DICT' in self.field_data.keys():
+            del self.field_data['_PYVISTA_USER_DICT']
+            return
+
+        self._config_user_dict()
+        if isinstance(dict_, dict):
+            self._user_dict.data = dict_
+        elif isinstance(dict_, UserDict):
+            self._user_dict.data = dict_.data
+        else:
+            raise TypeError(
+                f'User dict can only be set with type {dict} or {UserDict}.\nGot {type(dict_)} instead.',
+            )
+
+    def _config_user_dict(self):
+        """Init serialized dict array and ensure it is added to field_data."""
+        field_name = '_PYVISTA_USER_DICT'
+        field_data = self.field_data
+
+        if not hasattr(self, '_user_dict'):
+            # Init
+            self._user_dict = _SerializedDictArray()
+
+        if field_name in field_data.keys():
+            if isinstance(array := field_data[field_name], pyvista_ndarray):
+                # When loaded from file, field will be cast as pyvista ndarray
+                # Convert to string and initialize new user dict object from it
+                self._user_dict = _SerializedDictArray(''.join(array))
+            else:
+                # Do nothing,
+                return
+
+        # Set field data array directly instead of calling 'set_array'
+        # This skips the call to '_prepare_array' which will otherwise
+        # do all kinds of casting/conversions and mangle this array
+        self._user_dict.SetName(field_name)
+        field_data.VTKObject.AddArray(self._user_dict)
+        field_data.VTKObject.Modified()
 
     def get_array(
         self,

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1888,7 +1888,7 @@ class DataSet(DataSetFilters, DataObject):
 
         .. note::
 
-            The user dict is convenience property and is intended for metadata storage.
+            The user dict is a convenience property and is intended for metadata storage.
             It has an inefficient dictionary implementation and should only be used to
             store a small number of infrequently-accessed keys with relatively small
             values. It should not be used to store frequently accessed array data
@@ -1897,7 +1897,42 @@ class DataSet(DataSetFilters, DataObject):
         Returns
         -------
         _SerializedDictArray
-            Serialized dict-like subclass of collections.UserDict.
+            Serialized dict-like object which is subclassed from collections.UserDict.
+
+        Examples
+        --------
+        Create a mesh
+
+        >>> import pyvista as pv
+        >>> from pyvista import examples
+        >>> mesh = examples.load_ant()
+
+        Store data in the user dict. The contents are serialized as JSON.
+
+        >>> mesh.user_dict = dict(name='ant', num_legs=6)
+        >>> mesh.user_dict
+        {"name": "ant", "num_legs": 6}
+
+        The user dict can be updated like a regular dict.
+
+        >>> mesh.user_dict['parts'] = ['head', 'thorax', 'abdomen']
+        {"name": "ant", "num_legs": 6, "parts": ["head", "thorax", "abdomen"]}
+
+        Data in the user dict is stored as field data
+
+        >>> mesh.field_data
+        pyvista DataSetAttributes
+        Association     : NONE
+        Contains arrays :
+            _PYVISTA_USER_DICT      str        "{"name": "ant",..."
+
+        Since it's field data, the user dict can be saved to file and
+        retrieved later.
+
+        >>> mesh.save('ant.vtk')
+        >>> mesh_read = pv.read('ant.vtk')
+        >>> mesh_read.user_dict
+        {"name": "ant", "num_legs": 6, "parts": ["head", "thorax", "abdomen"]}
 
         """
         self._config_user_dict()

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import copy
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple, Union
 import warnings
 
@@ -1067,7 +1068,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
         """
         for name, array in array_dict.items():
-            self[name] = array.copy()
+            self[name] = array.copy() if hasattr(array, 'copy') else copy.copy(array)
 
     def _raise_index_out_of_bounds(self, index: Any):
         """Raise a KeyError if array index is out of bounds."""

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -51,11 +51,11 @@ class pyvista_ndarray(np.ndarray):  # type: ignore[type-arg]  # numpydoc ignore=
         association=FieldAssociation.NONE,
     ):
         """Allocate the array."""
-        if isinstance(array, Iterable):
-            obj = np.asarray(array).view(cls)
-        elif isinstance(array, _vtk.vtkAbstractArray):
+        if isinstance(array, _vtk.vtkAbstractArray):
             obj = convert_array(array).view(cls)
             obj.VTKObject = array
+        elif isinstance(array, Iterable):
+            obj = np.asarray(array).view(cls)
         else:
             raise TypeError(
                 f'pyvista_ndarray got an invalid type {type(array)}. '

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -833,7 +833,9 @@ _JSONValueType = Union[
 ]
 
 
-class _SerializedDictArray(UserDict[str, _JSONValueType], _vtk.vtkStringArray):
+# TODO: add generic type annotations 'UserDict[str, _JSONValueType]'
+#  once support for Python 3.8 is dropped
+class _SerializedDictArray(UserDict, _vtk.vtkStringArray):  # type: ignore[type-arg]
     """Dict-like object with a JSON-serialized string array representation.
 
     This class behaves just like a regular dict, except its contents

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -5,7 +5,7 @@ import collections.abc
 import enum
 from itertools import product
 import json
-from typing import Optional, Tuple, Type, Union
+from typing import Optional, Tuple, Union
 
 import numpy as np
 
@@ -822,14 +822,14 @@ def _coerce_transformlike_arg(transform_like: TransformLike) -> NumpyArray[float
 
 
 _JSONValueType = Union[
-    Type[dict],  # type: ignore[type-arg]
-    Type[list],  # type: ignore[type-arg]
-    Type[tuple],  # type: ignore[type-arg]
-    Type[str],
-    Type[int],
-    Type[float],
-    Type[bool],
-    Type[None],
+    dict,  # type: ignore[type-arg]
+    list,  # type: ignore[type-arg]
+    tuple,  # type: ignore[type-arg]
+    str,
+    int,
+    float,
+    bool,
+    None,
 ]
 
 

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -256,6 +256,31 @@ def test_user_dict_write_read(ant, tmp_path):
     assert dict_field_repr in field_data_repr
 
 
+def test_user_dict_persists_with_merge_filter(uniform):
+    sphere1 = pv.Sphere()
+    sphere1.user_dict['name'] = 'sphere1'
+
+    sphere2 = pv.Sphere()
+    sphere2.user_dict['name'] = 'sphere2'
+
+    merged = sphere1 + sphere2
+    assert merged.user_dict['name'] == 'sphere2'
+
+
+def test_user_dict_persists_with_threshold_filter(uniform):
+    uniform.user_dict['name'] = 'uniform'
+    uniform = uniform.threshold(0.5)
+    assert uniform.user_dict['name'] == 'uniform'
+
+
+def test_user_dict_persists_with_pack_labels_filter(uniform):
+    image = pv.ImageData(dimensions=(2, 2, 2))
+    image['labels'] = [0, 3, 3, 3, 3, 0, 2, 2]
+    image.user_dict['name'] = 'image'
+    image = image.pack_labels()
+    assert image.user_dict['name'] == 'image'
+
+
 @pytest.mark.parametrize('field', [range(5), np.ones((3, 3))[:, 0]])
 def test_add_field_data(grid, field):
     grid.add_field_data(field, 'foo')

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -256,7 +256,7 @@ def test_user_dict_write_read(ant, tmp_path):
     assert dict_field_repr in field_data_repr
 
 
-def test_user_dict_persists_with_merge_filter(uniform):
+def test_user_dict_persists_with_merge_filter():
     sphere1 = pv.Sphere()
     sphere1.user_dict['name'] = 'sphere1'
 
@@ -273,7 +273,7 @@ def test_user_dict_persists_with_threshold_filter(uniform):
     assert uniform.user_dict['name'] == 'uniform'
 
 
-def test_user_dict_persists_with_pack_labels_filter(uniform):
+def test_user_dict_persists_with_pack_labels_filter():
     image = pv.ImageData(dimensions=(2, 2, 2))
     image['labels'] = [0, 3, 3, 3, 3, 0, 2, 2]
     image.user_dict['name'] = 'image'

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -1,5 +1,6 @@
 """Test pyvista core utilities."""
 
+import json
 import os
 import pathlib
 from pathlib import Path
@@ -18,6 +19,7 @@ from pyvista.core.utilities import cells, fileio, fit_plane_to_points, transform
 from pyvista.core.utilities.arrays import (
     _coerce_pointslike_arg,
     _coerce_transformlike_arg,
+    _SerializedDictArray,
     copy_vtk_array,
     get_array,
     has_duplicates,
@@ -955,3 +957,91 @@ def test_no_new_attr_subclass(no_new_attr_subclass):
     msg = 'Attribute "_eggs" does not exist and cannot be added to type B'
     with pytest.raises(AttributeError, match=msg):
         obj._eggs = 'ham'
+
+
+@pytest.fixture()
+def serial_dict_empty():
+    return _SerializedDictArray()
+
+
+@pytest.fixture()
+def serial_dict_with_foobar():
+    serial_dict = _SerializedDictArray()
+    serial_dict.data = dict(foo='bar')
+    return serial_dict
+
+
+def test_serial_dict_init():
+    # empty init
+    serial_dict = _SerializedDictArray()
+    assert serial_dict == {}
+    assert repr(serial_dict) == '{}'
+
+    # init from dict
+    new_dict = dict(ham='eggs')
+    serial_dict = _SerializedDictArray(new_dict)
+    assert serial_dict['ham'] == 'eggs'
+    assert repr(serial_dict) == '{"ham": "eggs"}'
+
+    # init from UserDict
+    serial_dict = _SerializedDictArray(serial_dict)
+    assert serial_dict['ham'] == 'eggs'
+    assert repr(serial_dict) == '{"ham": "eggs"}'
+
+    # init from JSON string
+    json_dict = json.dumps(new_dict)
+    serial_dict = _SerializedDictArray(json.loads(json_dict))
+    assert serial_dict['ham'] == 'eggs'
+    assert repr(serial_dict) == '{"ham": "eggs"}'
+
+
+def test_serial_dict_as_dict(serial_dict_with_foobar):
+    assert not isinstance(serial_dict_with_foobar, dict)
+    actual_dict = dict(serial_dict_with_foobar)
+    assert isinstance(actual_dict, dict)
+    assert actual_dict == serial_dict_with_foobar.data
+
+
+def test_serial_dict_overrides__setitem__(serial_dict_empty):
+    serial_dict_empty['foo'] = 'bar'
+    assert repr(serial_dict_empty) == '{"foo": "bar"}'
+
+
+def test_serial_dict_overrides__delitem__(serial_dict_with_foobar):
+    del serial_dict_with_foobar['foo']
+    assert repr(serial_dict_with_foobar) == '{}'
+
+
+def test_serial_dict_overrides__setattr__(serial_dict_empty):
+    serial_dict_empty.data = dict(foo='bar')
+    assert repr(serial_dict_empty) == '{"foo": "bar"}'
+
+
+def test_serial_dict_overrides_popitem(serial_dict_with_foobar):
+    serial_dict_with_foobar['ham'] = 'eggs'
+    item = serial_dict_with_foobar.popitem()
+    assert item == ('foo', 'bar')
+    assert repr(serial_dict_with_foobar) == '{"ham": "eggs"}'
+
+
+def test_serial_dict_overrides_pop(serial_dict_with_foobar):
+    item = serial_dict_with_foobar.pop('foo')
+    assert item == 'bar'
+    assert repr(serial_dict_with_foobar) == '{}'
+
+
+def test_serial_dict_overrides_update(serial_dict_empty):
+    serial_dict_empty.update(dict(foo='bar'))
+    assert repr(serial_dict_empty) == '{"foo": "bar"}'
+
+
+def test_serial_dict_overrides_clear(serial_dict_with_foobar):
+    serial_dict_with_foobar.clear()
+    assert repr(serial_dict_with_foobar) == '{}'
+
+
+def test_serial_dict_overrides_setdefault(serial_dict_empty, serial_dict_with_foobar):
+    serial_dict_empty.setdefault('foo', 42)
+    assert repr(serial_dict_empty) == '{"foo": 42}'
+    serial_dict_with_foobar.setdefault('foo', 42)
+    assert repr(serial_dict_with_foobar) == '{"foo": "bar"}'

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -990,7 +990,7 @@ def test_serial_dict_init():
 
     # init from JSON string
     json_dict = json.dumps(new_dict)
-    serial_dict = _SerializedDictArray(json.loads(json_dict))
+    serial_dict = _SerializedDictArray(json_dict)
     assert serial_dict['ham'] == 'eggs'
     assert repr(serial_dict) == '{"ham": "eggs"}'
 


### PR DESCRIPTION
### Overview

This PR adds a new `user_dict` property to enable easily storing/accessing user data in a dict-like fashion. It's intended to:

1. Make it easy to store scalar data alongside a mesh, since using regular field data requires storing data in arrays.
2. Better separate user data from mesh data, since all user data can now be nested in a single field data key instead of requiring a new field data key for every item.

If the mesh is saved in a compatible format (e.g. `.vtk`) and then read again, the JSON dict is automatically de-serialized and processed so that it is useable again as a dict object. This is very useful when batch-processing files, allowing for processing a mesh with a script and adding timestamps, parameters, results, etc. and saving everything to a single `.vtk` file.

### Details

Internally, the user dict is first serialized to JSON and stored as a `vtkStringArray`. The array is then stored as a `_PYVISTA_USER_DICT` field data array.

This PR is loosely related to #5747.