### PR TITLE
Move `user_dict` from `DataSet` to `DataObject` to support `MultiBlock`

### DIFF
--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -559,7 +559,7 @@ class DataObject:
     @user_dict.setter
     def user_dict(
         self,
-        dict_: Union[dict[str, _JSONValueType], UserDict],  # type: ignore[type-arg]
+        dict_: Union[Dict[str, _JSONValueType], UserDict],  # type: ignore[type-arg]
     ):  # numpydoc ignore=GL08
 
         # Setting None removes the field data array

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -1,6 +1,7 @@
 """Attributes common to PolyData and Grid Objects."""
 
 from abc import abstractmethod
+from collections import UserDict
 import collections.abc
 from pathlib import Path
 from typing import Any, ClassVar, DefaultDict, Dict, Optional, Type, Union
@@ -12,7 +13,8 @@ import pyvista
 from . import _vtk_core as _vtk
 from ._typing_core import NumpyArray
 from .datasetattributes import DataSetAttributes
-from .utilities.arrays import FieldAssociation
+from .pyvista_ndarray import pyvista_ndarray
+from .utilities.arrays import FieldAssociation, _JSONValueType, _SerializedDictArray
 from .utilities.fileio import read, set_vtkwriter_mode
 from .utilities.helpers import wrap
 from .utilities.misc import abstract_class
@@ -460,6 +462,150 @@ class DataObject:
             raise NotImplementedError(f'`{type(self)}` does not support field data')
 
         self.field_data.clear()
+
+    @property
+    def user_dict(self) -> _SerializedDictArray:
+        """Set or return a user-specified data dictionary.
+
+        The dictionary is stored as a JSON-serialized string as part of the mesh's
+        field data. Unlike regular field data, which requires values to be stored
+        as an array, the user dict provides a mapping for scalar values.
+
+        Since the user dict is stored as field data, it is automatically saved
+        with the mesh when it is saved in a compatible file format (e.g. ``'.vtk'``).
+        Any saved metadata is automatically de-serialized by PyVista whenever
+        the user dict is accessed again. Since the data is stored as JSON, it
+        may also be easily retrieved or read by other programs.
+
+        Any JSON-serializable values are permitted by the user dict, i.e. values
+        can have type ``dict``, ``list``, ``tuple``, ``str``, ``int``, ``float``,
+        ``bool``, or ``None``. Storing NumPy arrays is not directly supported, but
+        these may be cast beforehand to a supported type, e.g. by calling ``tolist()``
+        on the array.
+
+        To completely remove the user dict string from the dataset's field data,
+        set its value to ``None``.
+
+        .. note::
+
+            The user dict is a convenience property and is intended for metadata storage.
+            It has an inefficient dictionary implementation and should only be used to
+            store a small number of infrequently-accessed keys with relatively small
+            values. It should not be used to store frequently accessed array data
+            with many entries (a regular field data array should be used instead).
+
+        .. warning::
+
+            Field data is typically passed-through by dataset filters, and therefore
+            the user dict's items can generally be expected to persist and remain
+            unchanged in the output of filtering methods. However, this behavior is
+            not guaranteed, as it's possible that some filters may modify or clear
+            field data. Use with caution.
+
+        Returns
+        -------
+        UserDict
+            JSON-serialized dict-like object which is subclassed from :py:class:`collections.UserDict`.
+
+        Examples
+        --------
+        Load a mesh.
+
+        >>> import pyvista as pv
+        >>> from pyvista import examples
+        >>> mesh = examples.load_ant()
+
+        Add data to the user dict. The contents are serialized as JSON.
+
+        >>> mesh.user_dict['name'] = 'ant'
+        >>> mesh.user_dict
+        {"name": "ant"}
+
+        Alternatively, set the user dict from an existing dict.
+
+        >>> mesh.user_dict = dict(name='ant')
+
+        The user dict can be updated like a regular dict.
+
+        >>> mesh.user_dict.update(
+        ...     {
+        ...         'num_legs': 6,
+        ...         'body_parts': ['head', 'thorax', 'abdomen'],
+        ...     }
+        ... )
+        >>> mesh.user_dict
+        {"name": "ant", "num_legs": 6, "body_parts": ["head", "thorax", "abdomen"]}
+
+        Data in the user dict is stored as field data.
+
+        >>> mesh.field_data
+        pyvista DataSetAttributes
+        Association     : NONE
+        Contains arrays :
+            _PYVISTA_USER_DICT      str        "{"name": "ant",..."
+
+        Since it's field data, the user dict can be saved to file along with the
+        mesh and retrieved later.
+
+        >>> mesh.save('ant.vtk')
+        >>> mesh_from_file = pv.read('ant.vtk')
+        >>> mesh_from_file.user_dict
+        {"name": "ant", "num_legs": 6, "body_parts": ["head", "thorax", "abdomen"]}
+
+        """
+        self._config_user_dict()
+        return self._user_dict
+
+    @user_dict.setter
+    def user_dict(
+        self,
+        dict_: Union[dict[str, _JSONValueType], UserDict[str, _JSONValueType]],
+    ):  # numpydoc ignore=GL08
+
+        # Setting None removes the field data array
+        if dict_ is None and '_PYVISTA_USER_DICT' in self.field_data.keys():
+            del self.field_data['_PYVISTA_USER_DICT']
+            return
+
+        self._config_user_dict()
+        if isinstance(dict_, dict):
+            self._user_dict.data = dict_
+        elif isinstance(dict_, UserDict):
+            self._user_dict.data = dict_.data
+        else:
+            raise TypeError(
+                f'User dict can only be set with type {dict} or {UserDict}.\nGot {type(dict_)} instead.',
+            )
+
+    def _config_user_dict(self):
+        """Init serialized dict array and ensure it is added to field_data."""
+        field_name = '_PYVISTA_USER_DICT'
+        field_data = self.field_data
+
+        if not hasattr(self, '_user_dict'):
+            # Init
+            self._user_dict = _SerializedDictArray()
+
+        if field_name in field_data.keys():
+            if isinstance(array := field_data[field_name], pyvista_ndarray):
+                # When loaded from file, field will be cast as pyvista ndarray
+                # Convert to string and initialize new user dict object from it
+                self._user_dict = _SerializedDictArray(''.join(array))
+            elif isinstance(array, str) and repr(self._user_dict) != array:
+                # Filters may update the field data block separately, e.g.
+                # when copying field data, so we need to capture the new
+                # string and re-init
+                self._user_dict = _SerializedDictArray(array)
+            else:
+                # User dict is correctly configured, do nothing
+                return
+
+        # Set field data array directly instead of calling 'set_array'
+        # This skips the call to '_prepare_array' which will otherwise
+        # do all kinds of casting/conversions and mangle this array
+        self._user_dict.SetName(field_name)
+        field_data.VTKObject.AddArray(self._user_dict)
+        field_data.VTKObject.Modified()
 
     @property
     def memory_address(self) -> str:  # numpydoc ignore=RT01

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -559,7 +559,7 @@ class DataObject:
     @user_dict.setter
     def user_dict(
         self,
-        dict_: Union[dict[str, _JSONValueType], UserDict[str, Any]],
+        dict_: Union[dict[str, _JSONValueType], UserDict],  # type: ignore[type-arg]
     ):  # numpydoc ignore=GL08
 
         # Setting None removes the field data array

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -559,7 +559,7 @@ class DataObject:
     @user_dict.setter
     def user_dict(
         self,
-        dict_: Union[dict[str, _JSONValueType], UserDict[str, _JSONValueType]],
+        dict_: Union[dict[str, _JSONValueType], UserDict[str, Any]],
     ):  # numpydoc ignore=GL08
 
         # Setting None removes the field data array

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -1,4 +1,8 @@
+from collections import UserDict
+import json
+
 import numpy as np
+import pytest
 
 import pyvista as pv
 from pyvista import examples
@@ -100,3 +104,90 @@ def test_metadata_save(hexbeam, tmpdir):
 
     # metadata should be removed from the field data
     assert not hexbeam_in.field_data
+
+
+def test_user_dict():
+    field_name = '_PYVISTA_USER_DICT'
+    dataset = pv.PolyData()
+    assert field_name not in dataset.field_data.keys()
+
+    dataset.user_dict['abc'] = 123
+    assert field_name in dataset.field_data.keys()
+
+    new_dict = dict(ham='eggs')
+    dataset.user_dict = new_dict
+    assert dataset.user_dict == new_dict
+    assert dataset.field_data[field_name] == json.dumps(new_dict)
+
+    new_dict = UserDict(test='string')
+    dataset.user_dict = new_dict
+    assert dataset.user_dict == new_dict
+    assert dataset.field_data[field_name] == json.dumps(new_dict.data)
+
+    dataset.user_dict = None
+    assert field_name not in dataset.field_data.keys()
+
+    match = (
+        "User dict can only be set with type <class 'dict'> or <class 'collections.UserDict'>."
+        "\nGot <class 'int'> instead."
+    )
+    with pytest.raises(TypeError, match=match):
+        dataset.user_dict = 42
+
+
+@pytest.mark.parametrize('value', [dict(a=0), ['list'], ('tuple', 1), 'string', 0, 1.1, True, None])
+def test_user_dict_values(ant, value):
+    ant.user_dict['key'] = value
+    with pytest.raises(TypeError, match='not JSON serializable'):
+        ant.user_dict['key'] = np.array(value)
+
+    retrieved_value = json.loads(repr(ant.user_dict))['key']
+
+    # Round brackets '()' are saved as square brackets '[]' in JSON
+    expected_value = list(value) if isinstance(value, tuple) else value
+    assert retrieved_value == expected_value
+
+
+def test_user_dict_write_read(ant, tmp_path):
+    # test dict is restored after writing to file
+    dict_data = dict(foo='bar')
+    ant.user_dict = dict_data
+
+    dict_field_repr = repr(ant.user_dict)
+    field_data_repr = repr(ant.field_data)
+    assert dict_field_repr in field_data_repr
+
+    filepath = tmp_path / 'ant.vtp'
+    ant.save(filepath)
+
+    ant_read = pv.PolyData(filepath)
+    assert ant_read.user_dict == dict_data
+
+    dict_field_repr = repr(ant.user_dict)
+    field_data_repr = repr(ant.field_data)
+    assert dict_field_repr in field_data_repr
+
+
+def test_user_dict_persists_with_merge_filter():
+    sphere1 = pv.Sphere()
+    sphere1.user_dict['name'] = 'sphere1'
+
+    sphere2 = pv.Sphere()
+    sphere2.user_dict['name'] = 'sphere2'
+
+    merged = sphere1 + sphere2
+    assert merged.user_dict['name'] == 'sphere2'
+
+
+def test_user_dict_persists_with_threshold_filter(uniform):
+    uniform.user_dict['name'] = 'uniform'
+    uniform = uniform.threshold(0.5)
+    assert uniform.user_dict['name'] == 'uniform'
+
+
+def test_user_dict_persists_with_pack_labels_filter():
+    image = pv.ImageData(dimensions=(2, 2, 2))
+    image['labels'] = [0, 3, 3, 3, 3, 0, 2, 2]
+    image.user_dict['name'] = 'image'
+    image = image.pack_labels()
+    assert image.user_dict['name'] == 'image'

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -148,31 +148,28 @@ def test_user_dict_values(ant, value):
     assert retrieved_value == expected_value
 
 
-@pytest.mark.parametrize('data_object', ['polydata', 'multiblock'])
-def test_user_dict_write_read(ant, tmp_path, data_object):
-    if data_object == 'multiblock':
-        ant = pv.MultiBlock([ant])
-        ext = '.vtm'
-    else:
-        ext = '.vtp'
-
+@pytest.mark.parametrize(
+    ('data_object', 'ext'),
+    [(pv.MultiBlock([examples.load_ant()]), '.vtm'), (examples.load_ant(), '.vtp')],
+)
+def test_user_dict_write_read(tmp_path, data_object, ext):
     # test dict is restored after writing to file
     dict_data = dict(foo='bar')
-    ant.user_dict = dict_data
+    data_object.user_dict = dict_data
 
-    dict_field_repr = repr(ant.user_dict)
-    field_data_repr = repr(ant.field_data)
+    dict_field_repr = repr(data_object.user_dict)
+    field_data_repr = repr(data_object.field_data)
     assert dict_field_repr in field_data_repr
 
-    filepath = tmp_path / ('ant' + ext)
-    ant.save(filepath)
+    filepath = tmp_path / ('data_object' + ext)
+    data_object.save(filepath)
 
-    ant_read = pv.read(filepath)
+    data_object_read = pv.read(filepath)
 
-    assert ant_read.user_dict == dict_data
+    assert data_object_read.user_dict == dict_data
 
-    dict_field_repr = repr(ant.user_dict)
-    field_data_repr = repr(ant.field_data)
+    dict_field_repr = repr(data_object.user_dict)
+    field_data_repr = repr(data_object.field_data)
     assert dict_field_repr in field_data_repr
 
 


### PR DESCRIPTION
Follow-up from #5933. There, `user_dict` was added to `DataSet`. I didn't realize this at the time, but this means that `user_dict` doesn't work with `pv.MultiBlock` objects. This PR fixes this.