### PR TITLE
Pin `macos-12` in testing and deployment actions

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   macOS:
-    runs-on: macos-latest
+    runs-on: macos-12
     name: Mac OS Unit Testing
     strategy:
       matrix:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -21,6 +21,7 @@ env:
 
 jobs:
   macOS:
+    # https://github.com/pyvista/pyvista/pull/5960
     runs-on: macos-12
     name: Mac OS Unit Testing
     strategy:


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
The following error is occurring in CI. Let's pin the Mac version to 12 until we drop support of Python 3.9.
```
Error: The version '3.9' with architecture 'arm64' was not found for macOS 14.4.1.
```

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None
