### PR TITLE
Fix missing `from __future__ import annotations`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -347,6 +347,7 @@ extend-select = [
     "C4",
     "COM",
     "F",
+    "FA",
     "FLY",
     "ICN",
     "ISC",

--- a/pyvista/core/_validation/check.py
+++ b/pyvista/core/_validation/check.py
@@ -10,6 +10,8 @@ A ``check`` function typically:
 
 """
 
+from __future__ import annotations
+
 from collections.abc import Iterable, Sequence
 from numbers import Number
 from typing import Tuple, Union, get_args, get_origin

--- a/pyvista/core/_validation/validate.py
+++ b/pyvista/core/_validation/validate.py
@@ -13,13 +13,14 @@ A ``validate`` function typically:
 
 """
 
+from __future__ import annotations
+
 import inspect
 from itertools import product
-from typing import Any, Dict, Literal, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Literal, Tuple, Union
 
 import numpy as np
 
-from pyvista.core._typing_core._array_like import NumpyArray
 from pyvista.core._validation import (
     check_contains,
     check_finite,
@@ -35,6 +36,9 @@ from pyvista.core._validation import (
 )
 from pyvista.core._validation._cast_array import _cast_to_numpy, _cast_to_tuple
 from pyvista.core._vtk_core import vtkMatrix3x3, vtkMatrix4x4, vtkTransform
+
+if TYPE_CHECKING:
+    from pyvista.core._typing_core._array_like import NumpyArray
 
 
 def validate_array(

--- a/pyvista/core/_validation/validate.py
+++ b/pyvista/core/_validation/validate.py
@@ -37,7 +37,7 @@ from pyvista.core._validation import (
 from pyvista.core._validation._cast_array import _cast_to_numpy, _cast_to_tuple
 from pyvista.core._vtk_core import vtkMatrix3x3, vtkMatrix4x4, vtkTransform
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from pyvista.core._typing_core._array_like import NumpyArray
 
 

--- a/pyvista/core/_validation/validate.py
+++ b/pyvista/core/_validation/validate.py
@@ -37,7 +37,7 @@ from pyvista.core._validation import (
 from pyvista.core._validation._cast_array import _cast_to_numpy, _cast_to_tuple
 from pyvista.core._vtk_core import vtkMatrix3x3, vtkMatrix4x4, vtkTransform
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: no cover
     from pyvista.core._typing_core._array_like import NumpyArray
 
 

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -4,6 +4,8 @@ These classes hold many VTK datasets in one object that can be passed
 to VTK algorithms and PyVista filtering/plotting routines.
 """
 
+from __future__ import annotations
+
 import collections.abc
 from itertools import zip_longest
 import pathlib
@@ -379,7 +381,7 @@ class MultiBlock(
         ...  # pragma: no cover
 
     @overload
-    def __getitem__(self, index: slice) -> 'MultiBlock':  # noqa: D105
+    def __getitem__(self, index: slice) -> MultiBlock:  # noqa: D105
         ...  # pragma: no cover
 
     def __getitem__(self, index):
@@ -747,7 +749,7 @@ class MultiBlock(
         if hasattr(dataset, 'memory_address'):
             self._refs.pop(dataset.memory_address, None)  # type: ignore[union-attr]
 
-    def __iter__(self) -> 'MultiBlock':
+    def __iter__(self) -> MultiBlock:
         """Return the iterator across all blocks."""
         self._iter_n = 0
         return self

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -20,7 +20,7 @@ from .utilities.fileio import read, set_vtkwriter_mode
 from .utilities.helpers import wrap
 from .utilities.misc import abstract_class
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: no cover
     from ._typing_core import NumpyArray
 
 # vector array names

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -1,23 +1,27 @@
 """Attributes common to PolyData and Grid Objects."""
 
+from __future__ import annotations
+
 from abc import abstractmethod
 from collections import UserDict
 import collections.abc
 from pathlib import Path
-from typing import Any, ClassVar, DefaultDict, Dict, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, ClassVar, DefaultDict, Dict, Optional, Type, Union
 
 import numpy as np
 
 import pyvista
 
 from . import _vtk_core as _vtk
-from ._typing_core import NumpyArray
 from .datasetattributes import DataSetAttributes
 from .pyvista_ndarray import pyvista_ndarray
 from .utilities.arrays import FieldAssociation, _JSONValueType, _SerializedDictArray
 from .utilities.fileio import read, set_vtkwriter_mode
 from .utilities.helpers import wrap
 from .utilities.misc import abstract_class
+
+if TYPE_CHECKING:
+    from ._typing_core import NumpyArray
 
 # vector array names
 DEFAULT_VECTOR_KEY = '_vectors'

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -20,7 +20,7 @@ from .utilities.fileio import read, set_vtkwriter_mode
 from .utilities.helpers import wrap
 from .utilities.misc import abstract_class
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from ._typing_core import NumpyArray
 
 # vector array names

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1,15 +1,16 @@
 """Filters module with a class of common filters that can be applied to any vtkDataSet."""
 
+from __future__ import annotations
+
 import collections.abc
 import contextlib
-from typing import Literal, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Literal, Optional, Sequence, Union
 import warnings
 
 import matplotlib.pyplot as plt
 import numpy as np
 
 import pyvista
-from pyvista.core._typing_core import NumpyArray
 import pyvista.core._vtk_core as _vtk
 from pyvista.core.errors import (
     AmbiguousDataError,
@@ -30,6 +31,9 @@ from pyvista.core.utilities.cells import numpy_to_idarr
 from pyvista.core.utilities.geometric_objects import NORMALS
 from pyvista.core.utilities.helpers import generate_plane, wrap
 from pyvista.core.utilities.misc import abstract_class, assert_empty_kwargs
+
+if TYPE_CHECKING:
+    from pyvista.core._typing_core import NumpyArray
 
 
 @abstract_class

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -32,7 +32,7 @@ from pyvista.core.utilities.geometric_objects import NORMALS
 from pyvista.core.utilities.helpers import generate_plane, wrap
 from pyvista.core.utilities.misc import abstract_class, assert_empty_kwargs
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from pyvista.core._typing_core import NumpyArray
 
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -32,7 +32,7 @@ from pyvista.core.utilities.geometric_objects import NORMALS
 from pyvista.core.utilities.helpers import generate_plane, wrap
 from pyvista.core.utilities.misc import abstract_class, assert_empty_kwargs
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: no cover
     from pyvista.core._typing_core import NumpyArray
 
 

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -1,5 +1,7 @@
 """Filters with a class to manage filters/algorithms for uniform grid datasets."""
 
+from __future__ import annotations
+
 import collections.abc
 from typing import Literal, Optional, cast
 
@@ -791,7 +793,7 @@ class ImageDataFilters(DataSetFilters):
                 '`numpy.complex128`.',
             )
 
-    def _flip_uniform(self, axis) -> 'pyvista.ImageData':
+    def _flip_uniform(self, axis) -> pyvista.ImageData:
         """Flip the uniform grid along a specified axis and return a uniform grid.
 
         This varies from :func:`DataSet.flip_x` because it returns a ImageData.
@@ -814,7 +816,7 @@ class ImageDataFilters(DataSetFilters):
         output_style: Literal['default', 'boundary'] = 'default',
         scalars: Optional[str] = None,
         progress_bar: bool = False,
-    ) -> 'pyvista.PolyData':
+    ) -> pyvista.PolyData:
         """Generate labeled contours from 3D label maps.
 
         SurfaceNets algorithm is used to extract contours preserving sharp

--- a/pyvista/core/filters/rectilinear_grid.py
+++ b/pyvista/core/filters/rectilinear_grid.py
@@ -1,5 +1,7 @@
 """Filters module with the class to manage filters/algorithms for rectilinear grid datasets."""
 
+from __future__ import annotations
+
 import collections
 from typing import Sequence, Union
 

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -18,7 +18,7 @@ from .filters import ImageDataFilters, RectilinearGridFilters, _get_output
 from .utilities.arrays import convert_array, raise_has_duplicates
 from .utilities.misc import abstract_class, assert_empty_kwargs
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: no cover
     from pyvista.core._typing_core import NumpyArray
 
 

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -1,14 +1,15 @@
 """Sub-classes for vtk.vtkRectilinearGrid and vtk.vtkImageData."""
 
+from __future__ import annotations
+
 from functools import wraps
 import pathlib
-from typing import ClassVar, Dict, List, Sequence, Tuple, Type, Union
+from typing import TYPE_CHECKING, ClassVar, Dict, List, Sequence, Tuple, Type, Union
 import warnings
 
 import numpy as np
 
 import pyvista
-from pyvista.core._typing_core import NumpyArray
 
 from . import _vtk_core as _vtk
 from .dataset import DataSet
@@ -16,6 +17,9 @@ from .errors import PyVistaDeprecationWarning
 from .filters import ImageDataFilters, RectilinearGridFilters, _get_output
 from .utilities.arrays import convert_array, raise_has_duplicates
 from .utilities.misc import abstract_class, assert_empty_kwargs
+
+if TYPE_CHECKING:
+    from pyvista.core._typing_core import NumpyArray
 
 
 @abstract_class
@@ -439,7 +443,7 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid, RectilinearGridFilters):
             "defined and thus cannot be set.",
         )
 
-    def cast_to_structured_grid(self) -> 'pyvista.StructuredGrid':
+    def cast_to_structured_grid(self) -> pyvista.StructuredGrid:
         """Cast this rectilinear grid to a structured grid.
 
         Returns
@@ -837,7 +841,7 @@ class ImageData(_vtk.vtkImageData, Grid, ImageDataFilters):
         attrs.append(("Spacing", self.spacing, fmt))
         return attrs
 
-    def cast_to_structured_grid(self) -> 'pyvista.StructuredGrid':
+    def cast_to_structured_grid(self) -> pyvista.StructuredGrid:
         """Cast this uniform grid to a structured grid.
 
         Returns
@@ -851,7 +855,7 @@ class ImageData(_vtk.vtkImageData, Grid, ImageDataFilters):
         alg.Update()
         return _get_output(alg)
 
-    def cast_to_rectilinear_grid(self) -> 'RectilinearGrid':
+    def cast_to_rectilinear_grid(self) -> RectilinearGrid:
         """Cast this uniform grid to a rectilinear grid.
 
         Returns

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -18,7 +18,7 @@ from .filters import ImageDataFilters, RectilinearGridFilters, _get_output
 from .utilities.arrays import convert_array, raise_has_duplicates
 from .utilities.misc import abstract_class, assert_empty_kwargs
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from pyvista.core._typing_core import NumpyArray
 
 

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -4,6 +4,8 @@ The data objects does not have any sort of spatial reference.
 
 """
 
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import numpy as np

--- a/pyvista/core/partitioned.py
+++ b/pyvista/core/partitioned.py
@@ -1,5 +1,7 @@
 """Contains the PartitionedDataSet class."""
 
+from __future__ import annotations
+
 import collections.abc
 from typing import Iterable, Optional, Union, overload
 
@@ -62,7 +64,7 @@ class PartitionedDataSet(_vtk.vtkPartitionedDataSet, DataObject, collections.abc
         ...  # pragma: no cover
 
     @overload
-    def __getitem__(self, index: slice) -> 'PartitionedDataSet':  # noqa: D105
+    def __getitem__(self, index: slice) -> PartitionedDataSet:  # noqa: D105
         ...  # pragma: no cover
 
     def __getitem__(self, index):
@@ -104,7 +106,7 @@ class PartitionedDataSet(_vtk.vtkPartitionedDataSet, DataObject, collections.abc
         """Remove a partition at the specified index are not supported."""
         raise PartitionedDataSetsNotSupported
 
-    def __iter__(self) -> 'PartitionedDataSet':
+    def __iter__(self) -> PartitionedDataSet:
         """Return the iterator across all partitions."""
         self._iter_n = 0
         return self

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -40,7 +40,7 @@ from .utilities.fileio import get_ext
 from .utilities.misc import abstract_class
 from .utilities.points import vtk_points
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from ._typing_core import (
         ArrayLike,
         BoundsLike,

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1,5 +1,7 @@
 """Sub-classes and wrappers for vtk.vtkPointSet."""
 
+from __future__ import annotations
+
 import collections.abc
 import contextlib
 from functools import wraps
@@ -7,7 +9,7 @@ import numbers
 import pathlib
 from pathlib import Path
 from textwrap import dedent
-from typing import ClassVar, Dict, List, Optional, Sequence, Tuple, Type, Union, cast
+from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, Sequence, Tuple, Type, Union, cast
 import warnings
 
 import numpy as np
@@ -15,7 +17,6 @@ import numpy as np
 import pyvista
 
 from . import _vtk_core as _vtk
-from ._typing_core import ArrayLike, BoundsLike, CellArrayLike, MatrixLike, NumpyArray, VectorLike
 from .cell import (
     CellArray,
     _get_connectivity_array,
@@ -38,6 +39,16 @@ from .utilities.cells import create_mixed_cells, get_mixed_cells, numpy_to_idarr
 from .utilities.fileio import get_ext
 from .utilities.misc import abstract_class
 from .utilities.points import vtk_points
+
+if TYPE_CHECKING:
+    from ._typing_core import (
+        ArrayLike,
+        BoundsLike,
+        CellArrayLike,
+        MatrixLike,
+        NumpyArray,
+        VectorLike,
+    )
 
 DEFAULT_INPLACE_WARNING = (
     'You did not specify a value for `inplace` and the default value will '
@@ -104,7 +115,7 @@ class _PointSet(DataSet):
         self,
         ind: Union[VectorLike[bool], VectorLike[int]],
         inplace=False,
-    ) -> '_PointSet':
+    ) -> _PointSet:
         """Remove cells.
 
         Parameters
@@ -146,7 +157,7 @@ class _PointSet(DataSet):
         target.RemoveGhostCells()
         return target
 
-    def points_to_double(self) -> '_PointSet':
+    def points_to_double(self) -> _PointSet:
         """Convert the points datatype to double precision.
 
         Returns
@@ -1482,7 +1493,7 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         return mprop.GetVolume()
 
     @property
-    def point_normals(self) -> 'pyvista.pyvista_ndarray':  # numpydoc ignore=RT01
+    def point_normals(self) -> pyvista.pyvista_ndarray:  # numpydoc ignore=RT01
         """Return the point normals.
 
         If the point data already contains an array named ``'Normals'``, this
@@ -1517,7 +1528,7 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         return normals
 
     @property
-    def cell_normals(self) -> 'pyvista.pyvista_ndarray':  # numpydoc ignore=RT01
+    def cell_normals(self) -> pyvista.pyvista_ndarray:  # numpydoc ignore=RT01
         """Return the cell normals.
 
         If the cell data already contains an array named ``'Normals'``, this
@@ -1551,7 +1562,7 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         return normals
 
     @property
-    def face_normals(self) -> 'pyvista.pyvista_ndarray':  # numpydoc ignore=RT01
+    def face_normals(self) -> pyvista.pyvista_ndarray:  # numpydoc ignore=RT01
         """Return the cell normals.
 
         Alias to :func:`PolyData.cell_normals`.
@@ -2775,7 +2786,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         self.SetPoints(points)
         self.SetCells(CellArray(cells))
 
-    def cast_to_unstructured_grid(self) -> 'UnstructuredGrid':
+    def cast_to_unstructured_grid(self) -> UnstructuredGrid:
         """Cast to an unstructured grid.
 
         Returns
@@ -2876,7 +2887,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         grid = self.cast_to_unstructured_grid()
         grid.save(filename, binary)
 
-    def hide_cells(self, ind: VectorLike[int], inplace: bool = False) -> 'ExplicitStructuredGrid':
+    def hide_cells(self, ind: VectorLike[int], inplace: bool = False) -> ExplicitStructuredGrid:
         """Hide specific cells.
 
         Hides cells by setting the ghost cell array to ``HIDDENCELL``.
@@ -2919,7 +2930,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
         grid.hide_cells(ind, inplace=True)
         return grid
 
-    def show_cells(self, inplace: bool = False) -> 'ExplicitStructuredGrid':
+    def show_cells(self, inplace: bool = False) -> ExplicitStructuredGrid:
         """Show hidden cells.
 
         Shows hidden cells by setting the ghost cell array to ``0``
@@ -3255,7 +3266,7 @@ class ExplicitStructuredGrid(_vtk.vtkExplicitStructuredGrid, PointGrid):
             indices.update(rel_func(i))
         return sorted(indices)
 
-    def compute_connectivity(self, inplace: bool = False) -> 'ExplicitStructuredGrid':
+    def compute_connectivity(self, inplace: bool = False) -> ExplicitStructuredGrid:
         """Compute the faces connectivity flags array.
 
         This method checks the faces connectivity of the cells with

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -40,7 +40,7 @@ from .utilities.fileio import get_ext
 from .utilities.misc import abstract_class
 from .utilities.points import vtk_points
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: no cover
     from ._typing_core import (
         ArrayLike,
         BoundsLike,

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -10,7 +10,7 @@ import numpy as np
 from . import _vtk_core as _vtk
 from .utilities.arrays import FieldAssociation, convert_array
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from ._typing_core import ArrayLike, NumpyArray
 
 

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -10,7 +10,7 @@ import numpy as np
 from . import _vtk_core as _vtk
 from .utilities.arrays import FieldAssociation, convert_array
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: no cover
     from ._typing_core import ArrayLike, NumpyArray
 
 

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -1,13 +1,17 @@
 """Contains pyvista_ndarray a numpy ndarray type used in pyvista."""
 
+from __future__ import annotations
+
 from collections.abc import Iterable
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
 
 from . import _vtk_core as _vtk
-from ._typing_core import ArrayLike, NumpyArray
 from .utilities.arrays import FieldAssociation, convert_array
+
+if TYPE_CHECKING:
+    from ._typing_core import ArrayLike, NumpyArray
 
 
 class pyvista_ndarray(np.ndarray):  # type: ignore[type-arg]  # numpydoc ignore=PR02

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -15,7 +15,7 @@ import pyvista
 from pyvista.core import _vtk_core as _vtk
 from pyvista.core.errors import AmbiguousDataError, MissingDataError
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from pyvista.core._typing_core import MatrixLike, NumpyArray, TransformLike, VectorLike
 
 

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -1,18 +1,22 @@
 """Internal array utilities."""
 
+from __future__ import annotations
+
 from collections import UserDict
 import collections.abc
 import enum
 from itertools import product
 import json
-from typing import Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 import numpy as np
 
 import pyvista
 from pyvista.core import _vtk_core as _vtk
-from pyvista.core._typing_core import MatrixLike, NumpyArray, TransformLike, VectorLike
 from pyvista.core.errors import AmbiguousDataError, MissingDataError
+
+if TYPE_CHECKING:
+    from pyvista.core._typing_core import MatrixLike, NumpyArray, TransformLike, VectorLike
 
 
 class FieldAssociation(enum.Enum):
@@ -239,7 +243,7 @@ def convert_array(arr, name=None, deep=False, array_type=None):
     return _vtk.vtk_to_numpy(arr)
 
 
-def get_array(mesh, name, preference='cell', err=False) -> Optional['pyvista.ndarray']:
+def get_array(mesh, name, preference='cell', err=False) -> Optional[pyvista.ndarray]:
     """Search point, cell and field data for an array.
 
     Parameters
@@ -678,7 +682,7 @@ def vtkmatrix_from_array(array):
     return matrix
 
 
-def set_default_active_vectors(mesh: 'pyvista.DataSet') -> None:
+def set_default_active_vectors(mesh: pyvista.DataSet) -> None:
     """Set a default vectors array on mesh, if not already set.
 
     If an active vector already exists, no changes are made.
@@ -731,7 +735,7 @@ def set_default_active_vectors(mesh: 'pyvista.DataSet') -> None:
         )
 
 
-def set_default_active_scalars(mesh: 'pyvista.DataSet') -> None:
+def set_default_active_scalars(mesh: pyvista.DataSet) -> None:
     """Set a default scalars array on mesh, if not already set.
 
     If an active scalars already exists, no changes are made.

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -15,7 +15,7 @@ import pyvista
 from pyvista.core import _vtk_core as _vtk
 from pyvista.core.errors import AmbiguousDataError, MissingDataError
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: no cover
     from pyvista.core._typing_core import MatrixLike, NumpyArray, TransformLike, VectorLike
 
 

--- a/pyvista/core/utilities/cell_type_helper.py
+++ b/pyvista/core/utilities/cell_type_helper.py
@@ -1,5 +1,7 @@
 """Helper module to query vtk cell sizes upon importing."""
 
+from __future__ import annotations
+
 try:
     from vtkmodules import vtkCommonDataModel
 except:  # pragma: no cover

--- a/pyvista/core/utilities/cells.py
+++ b/pyvista/core/utilities/cells.py
@@ -11,7 +11,7 @@ import numpy as np
 import pyvista
 from pyvista.core import _vtk_core as _vtk
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from pyvista.core._typing_core import MatrixLike, NumpyArray
 
 

--- a/pyvista/core/utilities/cells.py
+++ b/pyvista/core/utilities/cells.py
@@ -1,14 +1,18 @@
 """PyVista wrapping of vtkCellArray."""
 
+from __future__ import annotations
+
 from collections import deque
 from itertools import count, islice
-from typing import Tuple, Union
+from typing import TYPE_CHECKING, Tuple, Union
 
 import numpy as np
 
 import pyvista
 from pyvista.core import _vtk_core as _vtk
-from pyvista.core._typing_core import MatrixLike, NumpyArray
+
+if TYPE_CHECKING:
+    from pyvista.core._typing_core import MatrixLike, NumpyArray
 
 
 def ncells_from_cells(cells: NumpyArray[int]) -> int:

--- a/pyvista/core/utilities/cells.py
+++ b/pyvista/core/utilities/cells.py
@@ -11,7 +11,7 @@ import numpy as np
 import pyvista
 from pyvista.core import _vtk_core as _vtk
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: no cover
     from pyvista.core._typing_core import MatrixLike, NumpyArray
 
 

--- a/pyvista/core/utilities/docs.py
+++ b/pyvista/core/utilities/docs.py
@@ -1,5 +1,7 @@
 """Supporting functions for documentation build."""
 
+from __future__ import annotations
+
 import inspect
 import os
 import os.path as op

--- a/pyvista/core/utilities/helpers.py
+++ b/pyvista/core/utilities/helpers.py
@@ -1,9 +1,12 @@
 """Core helper utilities."""
 
+from __future__ import annotations
+
 import collections
 from typing import TYPE_CHECKING, Optional, Union, cast
 
 if TYPE_CHECKING:  # pragma: no cover
+    from pyvista.core._typing_core import NumpyArray
     from trimesh import Trimesh
     from meshio import Mesh
 
@@ -11,15 +14,14 @@ import numpy as np
 
 import pyvista
 from pyvista.core import _vtk_core as _vtk
-from pyvista.core._typing_core import NumpyArray
 
 from . import transformations
 from .fileio import from_meshio, is_meshio_mesh
 
 
 def wrap(
-    dataset: Optional[Union[NumpyArray[float], _vtk.vtkDataSet, 'Trimesh', 'Mesh']],
-) -> Optional[Union['pyvista.DataSet', 'pyvista.pyvista_ndarray']]:
+    dataset: Optional[Union[NumpyArray[float], _vtk.vtkDataSet, Trimesh, Mesh]],
+) -> Optional[Union[pyvista.DataSet, pyvista.pyvista_ndarray]]:
     """Wrap any given VTK data object to its appropriate PyVista data object.
 
     Other formats that are supported include:

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -14,7 +14,7 @@ import warnings
 
 import numpy as np
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from .._typing_core import VectorLike
 
 T = TypeVar('T', bound='AnnotatedIntEnum')

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -1,5 +1,7 @@
 """Miscellaneous core utilities."""
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import enum
 from functools import lru_cache
@@ -7,12 +9,13 @@ import importlib
 import sys
 import threading
 import traceback
-from typing import Type, TypeVar, Union
+from typing import TYPE_CHECKING, Type, TypeVar, Union
 import warnings
 
 import numpy as np
 
-from .._typing_core import VectorLike
+if TYPE_CHECKING:
+    from .._typing_core import VectorLike
 
 T = TypeVar('T', bound='AnnotatedIntEnum')
 

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -14,7 +14,7 @@ import warnings
 
 import numpy as np
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: no cover
     from .._typing_core import VectorLike
 
 T = TypeVar('T', bound='AnnotatedIntEnum')

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -19,6 +19,8 @@ Examples
 
 """
 
+from __future__ import annotations
+
 import functools
 import logging
 import os

--- a/pyvista/plotting/_property.py
+++ b/pyvista/plotting/_property.py
@@ -1,5 +1,7 @@
 """This module contains the Property class."""
 
+from __future__ import annotations
+
 from typing import Union
 
 import pyvista
@@ -1230,7 +1232,7 @@ class Property(_vtk.vtkProperty):
         pl.camera_position = 'xy'
         pl.show(before_close_callback=before_close_callback)
 
-    def copy(self) -> 'Property':
+    def copy(self) -> Property:
         """Create a deep copy of this property.
 
         Returns

--- a/pyvista/plotting/axes_actor.py
+++ b/pyvista/plotting/axes_actor.py
@@ -1,5 +1,7 @@
 """Axes actor module."""
 
+from __future__ import annotations
+
 from collections.abc import Iterable
 from enum import Enum
 from typing import Tuple, Union

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -19,7 +19,7 @@ from pyvista import vtk_version_info
 from . import _vtk
 from .colors import COLOR_SCHEMES, SCHEME_NAMES, Color, color_synonyms, hexcolors
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: no cover
     from ._typing import Chart
 
 

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -19,7 +19,7 @@ from pyvista import vtk_version_info
 from . import _vtk
 from .colors import COLOR_SCHEMES, SCHEME_NAMES, Color, color_synonyms, hexcolors
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from ._typing import Chart
 
 

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -1,10 +1,12 @@
 """Module containing pyvista wrappers for the vtk Charts API."""
 
+from __future__ import annotations
+
 from functools import wraps
 import inspect
 import itertools
 import re
-from typing import ClassVar, Dict, Optional, Sequence, Type, Union
+from typing import TYPE_CHECKING, ClassVar, Dict, Optional, Sequence, Type, Union
 import weakref
 
 from matplotlib.backends.backend_agg import FigureCanvasAgg
@@ -15,8 +17,10 @@ import pyvista
 from pyvista import vtk_version_info
 
 from . import _vtk
-from ._typing import Chart
 from .colors import COLOR_SCHEMES, SCHEME_NAMES, Color, color_synonyms, hexcolors
+
+if TYPE_CHECKING:
+    from ._typing import Chart
 
 
 # region Some metaclass wrapping magic

--- a/pyvista/plotting/composite_mapper.py
+++ b/pyvista/plotting/composite_mapper.py
@@ -1,5 +1,7 @@
 """Module containing composite data mapper."""
 
+from __future__ import annotations
+
 from itertools import cycle
 import sys
 from typing import Optional
@@ -567,7 +569,7 @@ class CompositePolyDataMapper(
             self.interpolate_before_map = interpolate_before_map
 
     @property
-    def dataset(self) -> 'pyvista.MultiBlock':  # numpydoc ignore=RT01
+    def dataset(self) -> pyvista.MultiBlock:  # numpydoc ignore=RT01
         """Return the composite dataset assigned to this mapper.
 
         Examples
@@ -589,7 +591,7 @@ class CompositePolyDataMapper(
         return self._dataset
 
     @dataset.setter
-    def dataset(self, obj: 'pyvista.MultiBlock'):  # numpydoc ignore=GL08
+    def dataset(self, obj: pyvista.MultiBlock):  # numpydoc ignore=GL08
         self.SetInputDataObject(obj)
         self._dataset = obj
         self._attr._dataset = obj

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -14,7 +14,7 @@ from . import _vtk
 from .colors import Color, get_cmap_safe
 from .tools import opacity_transfer_function
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from ._typing import ColorLike
 
 RAMP_MAP = {0: 'linear', 1: 's-curve', 2: 'sqrt'}

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -1,6 +1,8 @@
 """Wrap vtkLookupTable."""
 
-from typing import Any, Dict, Optional, Tuple, Union, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union, cast
 
 import numpy as np
 
@@ -9,9 +11,11 @@ from pyvista.core.utilities.arrays import convert_array
 from pyvista.core.utilities.misc import no_new_attr
 
 from . import _vtk
-from ._typing import ColorLike
 from .colors import Color, get_cmap_safe
 from .tools import opacity_transfer_function
+
+if TYPE_CHECKING:
+    from ._typing import ColorLike
 
 RAMP_MAP = {0: 'linear', 1: 's-curve', 2: 'sqrt'}
 RAMP_MAP_INV = {k: v for v, k in RAMP_MAP.items()}

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -14,7 +14,7 @@ from . import _vtk
 from .colors import Color, get_cmap_safe
 from .tools import opacity_transfer_function
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: no cover
     from ._typing import ColorLike
 
 RAMP_MAP = {0: 'linear', 1: 's-curve', 2: 'sqrt'}

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -1,12 +1,13 @@
 """An internal module for wrapping the use of mappers."""
 
+from __future__ import annotations
+
 import sys
-from typing import Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Optional, Tuple, Union, cast
 
 import numpy as np
 
 import pyvista
-from pyvista.core._typing_core import BoundsLike
 from pyvista.core.utilities.arrays import (
     FieldAssociation,
     convert_array,
@@ -21,6 +22,9 @@ from .colors import Color, get_cmap_safe
 from .lookup_table import LookupTable
 from .tools import normalize
 from .utilities.algorithms import set_algorithm_input
+
+if TYPE_CHECKING:
+    from pyvista.core._typing_core import BoundsLike
 
 
 @abstract_class
@@ -58,7 +62,7 @@ class _BaseMapper(_vtk.vtkAbstractMapper):
         """
         return self.GetBounds()
 
-    def copy(self) -> '_BaseMapper':
+    def copy(self) -> _BaseMapper:
         """Create a copy of this mapper.
 
         Returns
@@ -118,7 +122,7 @@ class _BaseMapper(_vtk.vtkAbstractMapper):
         self.SetScalarRange(*clim)
 
     @property
-    def lookup_table(self) -> 'pyvista.LookupTable':  # numpydoc ignore=RT01
+    def lookup_table(self) -> pyvista.LookupTable:  # numpydoc ignore=RT01
         """Return or set the lookup table.
 
         Examples
@@ -389,8 +393,8 @@ class DataSetMapper(_vtk.vtkDataSetMapper, _BaseMapper):
 
     def __init__(
         self,
-        dataset: Optional['pyvista.DataSet'] = None,
-        theme: Optional['pyvista.themes.Theme'] = None,
+        dataset: Optional[pyvista.DataSet] = None,
+        theme: Optional[pyvista.themes.Theme] = None,
     ):
         """Initialize this class."""
         super().__init__(theme=theme)
@@ -398,14 +402,14 @@ class DataSetMapper(_vtk.vtkDataSetMapper, _BaseMapper):
             self.dataset = dataset
 
     @property
-    def dataset(self) -> Optional['pyvista.core.dataset.DataSet']:  # numpydoc ignore=RT01
+    def dataset(self) -> Optional[pyvista.core.dataset.DataSet]:  # numpydoc ignore=RT01
         """Return or set the dataset assigned to this mapper."""
         return cast(Optional[pyvista.DataSet], wrap(self.GetInputAsDataSet()))
 
     @dataset.setter
     def dataset(
         self,
-        obj: Union['pyvista.core.dataset.DataSet', _vtk.vtkAlgorithm, _vtk.vtkAlgorithmOutput],
+        obj: Union[pyvista.core.dataset.DataSet, _vtk.vtkAlgorithm, _vtk.vtkAlgorithmOutput],
     ):  # numpydoc ignore=GL08
         set_algorithm_input(self, obj)
 
@@ -1043,7 +1047,7 @@ class _BaseVolumeMapper(_BaseMapper):
     @dataset.setter
     def dataset(
         self,
-        obj: Union['pyvista.core.dataset.DataSet', _vtk.vtkAlgorithm, _vtk.vtkAlgorithmOutput],
+        obj: Union[pyvista.core.dataset.DataSet, _vtk.vtkAlgorithm, _vtk.vtkAlgorithmOutput],
     ):
         set_algorithm_input(self, obj)
 

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -23,7 +23,7 @@ from .lookup_table import LookupTable
 from .tools import normalize
 from .utilities.algorithms import set_algorithm_input
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from pyvista.core._typing_core import BoundsLike
 
 

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -23,7 +23,7 @@ from .lookup_table import LookupTable
 from .tools import normalize
 from .utilities.algorithms import set_algorithm_input
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: no cover
     from pyvista.core._typing_core import BoundsLike
 
 

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -85,7 +85,7 @@ from .volume import Volume
 from .volume_property import VolumeProperty
 from .widgets import WidgetHelper
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from pyvista.core._typing_core import BoundsLike
 
 SUPPORTED_FORMATS = [".png", ".jpeg", ".jpg", ".bmp", ".tif", ".tiff"]

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -85,7 +85,7 @@ from .volume import Volume
 from .volume_property import VolumeProperty
 from .widgets import WidgetHelper
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: no cover
     from pyvista.core._typing_core import BoundsLike
 
 SUPPORTED_FORMATS = [".png", ".jpeg", ".jpg", ".bmp", ".tif", ".tiff"]

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -1,5 +1,7 @@
 """PyVista plotting module."""
 
+from __future__ import annotations
+
 import collections.abc
 import contextlib
 from contextlib import contextmanager, suppress
@@ -16,7 +18,7 @@ import sys
 import textwrap
 from threading import Thread
 import time
-from typing import Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 import uuid
 import warnings
 import weakref
@@ -26,7 +28,6 @@ import numpy as np
 import scooby
 
 import pyvista
-from pyvista.core._typing_core import BoundsLike
 from pyvista.core.errors import MissingDataError, PyVistaDeprecationWarning
 from pyvista.core.utilities.arrays import (
     FieldAssociation,
@@ -83,6 +84,9 @@ from .utilities.regression import image_from_window, run_image_filter
 from .volume import Volume
 from .volume_property import VolumeProperty
 from .widgets import WidgetHelper
+
+if TYPE_CHECKING:
+    from pyvista.core._typing_core import BoundsLike
 
 SUPPORTED_FORMATS = [".png", ".jpeg", ".jpg", ".bmp", ".tif", ".tiff"]
 

--- a/pyvista/plotting/prop3d.py
+++ b/pyvista/plotting/prop3d.py
@@ -10,7 +10,7 @@ from pyvista.core.utilities.arrays import array_from_vtkmatrix, vtkmatrix_from_a
 
 from . import _vtk
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from pyvista.core._typing_core import BoundsLike, NumpyArray, VectorLike
 
 

--- a/pyvista/plotting/prop3d.py
+++ b/pyvista/plotting/prop3d.py
@@ -10,7 +10,7 @@ from pyvista.core.utilities.arrays import array_from_vtkmatrix, vtkmatrix_from_a
 
 from . import _vtk
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: no cover
     from pyvista.core._typing_core import BoundsLike, NumpyArray, VectorLike
 
 

--- a/pyvista/plotting/prop3d.py
+++ b/pyvista/plotting/prop3d.py
@@ -1,13 +1,17 @@
 """Prop3D module."""
 
-from typing import Tuple, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Tuple, Union
 
 import numpy as np
 
-from pyvista.core._typing_core import BoundsLike, NumpyArray, VectorLike
 from pyvista.core.utilities.arrays import array_from_vtkmatrix, vtkmatrix_from_array
 
 from . import _vtk
+
+if TYPE_CHECKING:
+    from pyvista.core._typing_core import BoundsLike, NumpyArray, VectorLike
 
 
 class Prop3D(_vtk.vtkProp3D):

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -30,23 +30,28 @@ pyvista.
 
 """
 
+from __future__ import annotations
+
 from enum import Enum
 from itertools import chain
 import json
 import os
 import pathlib
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 import warnings
 
 import pyvista  # noqa: TCH001
-from pyvista.core._typing_core import Number, VectorLike
 from pyvista.core.utilities.misc import _check_range
 
-from ._typing import ColorLike
 from .colors import Color, get_cmap_safe, get_cycler
 from .opts import InterpolationType
 from .tools import parse_font_family
+
+if TYPE_CHECKING:
+    from pyvista.core._typing_core import Number, VectorLike
+
+    from ._typing import ColorLike
 
 
 def _set_plot_theme_from_env() -> None:
@@ -2048,7 +2053,7 @@ class Theme(_ThemeConfig):
         return self._jupyter_backend
 
     @jupyter_backend.setter
-    def jupyter_backend(self, backend: 'str'):  # numpydoc ignore=GL08
+    def jupyter_backend(self, backend: str):  # numpydoc ignore=GL08
         from pyvista.jupyter import _validate_jupyter_backend
 
         self._jupyter_backend = _validate_jupyter_backend(backend)
@@ -2885,14 +2890,14 @@ class Theme(_ThemeConfig):
         self._axes = config
 
     @property
-    def before_close_callback(self) -> Callable[['pyvista.Plotter'], None]:  # numpydoc ignore=RT01
+    def before_close_callback(self) -> Callable[[pyvista.Plotter], None]:  # numpydoc ignore=RT01
         """Return the default before_close_callback function for Plotter."""
         return self._before_close_callback
 
     @before_close_callback.setter
     def before_close_callback(
         self,
-        value: Callable[['pyvista.Plotter'], None],
+        value: Callable[[pyvista.Plotter], None],
     ):  # numpydoc ignore=GL08
         self._before_close_callback = value
 
@@ -2991,7 +2996,7 @@ class Theme(_ThemeConfig):
     def name(self, name: str):  # numpydoc ignore=GL08
         self._name = name
 
-    def load_theme(self, theme: Union[str, 'Theme']) -> None:
+    def load_theme(self, theme: Union[str, Theme]) -> None:
         """Overwrite the current theme with a theme.
 
         Parameters

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -48,7 +48,7 @@ from .colors import Color, get_cmap_safe, get_cycler
 from .opts import InterpolationType
 from .tools import parse_font_family
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: no cover
     from pyvista.core._typing_core import Number, VectorLike
 
     from ._typing import ColorLike

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -48,7 +48,7 @@ from .colors import Color, get_cmap_safe, get_cycler
 from .opts import InterpolationType
 from .tools import parse_font_family
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from pyvista.core._typing_core import Number, VectorLike
 
     from ._typing import ColorLike

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -26,7 +26,7 @@ from .utilities.algorithms import (
     set_algorithm_input,
 )
 
-if TYPE_CHECKING: # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from pyvista.core._typing_core._array_like import NumpyArray
 
 

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -26,7 +26,7 @@ from .utilities.algorithms import (
     set_algorithm_input,
 )
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: no cover
     from pyvista.core._typing_core._array_like import NumpyArray
 
 

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1,12 +1,13 @@
 """Module dedicated to widgets."""
 
+from __future__ import annotations
+
 import pathlib
-from typing import Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
 import pyvista
-from pyvista.core._typing_core._array_like import NumpyArray
 from pyvista.core.utilities.arrays import get_array, get_array_association
 from pyvista.core.utilities.geometric_objects import NORMALS
 from pyvista.core.utilities.helpers import generate_plane
@@ -24,6 +25,9 @@ from .utilities.algorithms import (
     pointset_to_polydata_algorithm,
     set_algorithm_input,
 )
+
+if TYPE_CHECKING:
+    from pyvista.core._typing_core._array_like import NumpyArray
 
 
 def _parse_interaction_event(interaction_event):


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Fix missing `from __future__ import annotations`.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- See https://docs.astral.sh/ruff/rules/future-rewritable-type-annotation/