### PR TITLE
Ignore Sphinx warning about unpickable cache

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -386,6 +386,8 @@ sphinx_gallery_conf = {
     "reset_modules_order": "both",
 }
 
+suppress_warnings = ["config.cache"]
+
 import re
 
 # -- .. pyvista-plot:: directive ----------------------------------------------

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -14,10 +14,10 @@ numpydoc==1.7.0
 osmnx==1.9.2
 pydata-sphinx-theme==0.15.2
 pypandoc==1.13
-pytest-sphinx==0.6.2
+pytest-sphinx==0.6.3
 scipy==1.13.0
-sphinx==7.1.2
-sphinx-autobuild==2024.4.13
+sphinx==7.3.7
+sphinx-autobuild==2024.4.16
 sphinx-copybutton==0.5.2
 sphinx-design==0.5.0
 sphinx-gallery==0.15.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -18,7 +18,7 @@ pytest-cov<5.1.0
 pytest-memprof<0.3.0
 pytest-xdist<3.6.0
 pytest_pyvista==0.1.8
-sphinx<7.2.0
+sphinx<7.4.0
 sphinx-gallery<0.16.0
 sphinx_design<0.6.0
 sympy<1.13.0


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
The sphinx link checking GitHub action is failing in #5971.

This is because of a new sphinx warning. Further discussion of this issue and the steps to address are here: https://github.com/sphinx-doc/sphinx/issues/12300

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- Closes #5971