### PR TITLE
Add `pygrep-hooks` rule which raise now error now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -360,7 +360,7 @@ extend-select = [
     "LOG",
     "NPY",
     "PERF401",
-    "PGH004",
+    "PGH",
     "PIE",
     "PLC",
     "PLR0402",


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Add `pygrep-hooks` rule which raise now error now.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- See https://github.com/pre-commit/pygrep-hooks
