### PR TITLE
Add `MINCImageReader` NetCDF-based img file format

### DIFF
--- a/doc/source/api/readers/index.rst
+++ b/doc/source/api/readers/index.rst
@@ -41,6 +41,7 @@ Reader Classes
     JPEGReader
     MFIXReader
     MetaImageReader
+    MINCImageReader
     MultiBlockPlot3DReader
     NIFTIReader
     NRRDReader

--- a/pyvista/core/utilities/__init__.py
+++ b/pyvista/core/utilities/__init__.py
@@ -188,6 +188,7 @@ from .reader import (
     JPEGReader,
     MetaImageReader,
     MFIXReader,
+    MINCImageReader,
     MultiBlockPlot3DReader,
     NIFTIReader,
     NRRDReader,

--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -2577,6 +2577,26 @@ class GambitReader(BaseReader):
     _vtk_class_name = "vtkGAMBITReader"
 
 
+class MINCImageReader(BaseReader):
+    """MINCImageReader for .mnc files.
+
+    .. versionadded:: 0.44.0
+
+    Examples
+    --------
+    >>> import pyvista as pv
+    >>> from pyvista import examples
+    >>> filename = examples.download_t3_grid_0(load=False)
+    >>> reader = pv.get_reader(filename)
+    >>> mesh = reader.read()
+    >>> mesh.plot()
+
+    """
+
+    _vtk_module_name = "vtkIOMINC"
+    _vtk_class_name = "vtkMINCImageReader"
+
+
 CLASS_READERS = {
     # Standard dataset readers:
     '.bmp': BMPReader,
@@ -2601,6 +2621,7 @@ CLASS_READERS = {
     '.jpg': JPEGReader,
     '.mha': MetaImageReader,
     '.mhd': MetaImageReader,
+    '.mnc': MINCImageReader,
     '.neu': GambitReader,
     '.nhdr': NRRDReader,
     '.nii': NIFTIReader,

--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -2577,6 +2577,94 @@ class GambitReader(BaseReader):
     _vtk_class_name = "vtkGAMBITReader"
 
 
+class GaussianCubeReader(BaseReader):
+    """GaussianCubeReader for .cube files.
+
+    Examples
+    --------
+    >>> import pyvista as pv
+    >>> from pyvista import examples
+
+    >>> filename = examples.download_m4_total_density(load=False)
+    >>> filename.split("/")[-1]  # omit the path
+    'm4_TotalDensity.cube'
+
+    """
+
+    _vtk_module_name = "vtkIOChemistry"
+    _vtk_class_name = "vtkGaussianCubeReader"
+
+    def read(self, grid: bool = True):
+        """Read the file and return the output.
+
+        Parameters
+        ----------
+        grid : bool, default: False
+            Output as a grid if ``True``, otherwise return the polydata.
+        """
+        from pyvista.core.filters import _update_alg  # avoid circular import
+
+        _update_alg(self.reader, progress_bar=self._progress_bar, message=self._progress_msg)
+        data = (
+            wrap(self.reader.GetGridOutput()) if grid else wrap(self.reader.GetOutputDataObject(0))
+        )
+        if data is None:  # pragma: no cover
+            raise RuntimeError("File reader failed to read and/or produced no output.")
+        data._post_file_load_processing()  # type: ignore[union-attr]
+
+        # check for any pyvista metadata
+        data._restore_metadata()  # type: ignore[union-attr]
+        return data
+
+    @property
+    def hb_scale(self) -> float:
+        """Get the scaling factor to compute bonds with hydrogen atoms.
+
+        Returns
+        -------
+        float
+            The scaling factor to compute bonds with hydrogen atoms.
+
+        """
+        return self.reader.GetHBScale()
+
+    @hb_scale.setter
+    def hb_scale(self, hb_scale: float):
+        """Set the scaling factor to compute bonds with hydrogen atoms.
+
+        Parameters
+        ----------
+        hb_scale : float
+            The scaling factor to compute bonds with hydrogen atoms.
+
+        """
+        self.reader.SetHBScale(hb_scale)
+
+    @property
+    def b_scale(self) -> float:
+        """Get the scaling factor to compute bonds between non-hydrogen atoms.
+
+        Returns
+        -------
+        float
+            The scaling factor to compute bonds between non-hydrogen atoms.
+
+        """
+        return self.reader.GetBScale()
+
+    @b_scale.setter
+    def b_scale(self, b_scale: float):
+        """Set the scaling factor to compute bonds between non-hydrogen atoms.
+
+        Parameters
+        ----------
+        b_scale : float
+            The scaling factor to compute bonds between non-hydrogen atoms.
+
+        """
+        self.reader.SetBScale(b_scale)
+
+
 class MINCImageReader(BaseReader):
     """MINCImageReader for .mnc files.
 

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -7750,3 +7750,37 @@ def download_prism(load=True):  # pragma: no cover
 
 
 _dataset_prism = _SingleFileDownloadableDatasetLoader('prism.neu')
+
+
+def download_t3_grid_0(load=True):  # pragma: no cover
+    """Download a T3 grid 0 image.
+
+    .. versionadded:: 0.44.0
+
+    Parameters
+    ----------
+    load : bool, default: True
+        Load the dataset after downloading it when ``True``.  Set this
+        to ``False`` and only the filename will be returned.
+
+    Returns
+    -------
+    pyvista.ImageData | str
+        DataSet or filename depending on ``load``.
+
+    Examples
+    --------
+    >>> from pyvista import examples
+    >>> mesh = examples.download_t3_grid_0()
+    >>> mesh.plot()
+
+    .. seealso::
+
+        :ref:`T3 Grid 0 Dataset <t3_grid_0_dataset>`
+            See this dataset in the Dataset Gallery for more info.
+
+    """
+    return _download_dataset(_dataset_t3_grid_0, load=load)
+
+
+_dataset_t3_grid_0 = _SingleFileDownloadableDatasetLoader('t3_grid_0.mnc')


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Add `MINCImageReader` NetCDF-based img file format.

```python
from pyvista import examples
mesh = examples.download_t3_grid_0()
mesh.plot()
```
![image](https://github.com/pyvista/pyvista/assets/7513610/c0fdf735-2f02-4e74-97b0-1a429987eea5)

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- https://vtk.org/doc/nightly/html/classvtkMINCImageReader.html