### PR TITLE
MAINT: Fix bug with VTK dev

### DIFF
--- a/.github/workflows/vtk-pre-test.yml
+++ b/.github/workflows/vtk-pre-test.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up VTK with OSMesa
         run: |
           pip uninstall vtk -y
-          pip install vtk_osmesa --pre --no-cache --extra-index-url https://wheels.vtk.org
+          pip install vtk_osmesa --pre --no-cache --index-url https://wheels.vtk.org
 
       - name: Software Report
         run: |

--- a/.github/workflows/vtk-pre-test.yml
+++ b/.github/workflows/vtk-pre-test.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       # To resolve issues on VTK master and test, use this branch name pattern
+      # or label with "vtk-master" label on the PR
       - "maint/vtk-master*"
   workflow_dispatch:
   schedule:

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -187,6 +187,7 @@ class DataObject:
 
         """
         fdata = self.field_data
+        assert isinstance(fdata, pyvista.DataSetAttributes), self.__class__
         for assoc_name in ('bitarray', 'complex'):
             for assoc_type in ('POINT', 'CELL'):
                 key = f'_PYVISTA_{assoc_name}_{assoc_type}_'.upper()
@@ -787,3 +788,20 @@ class DataObject:
         # copy data
         self.copy_structure(mesh)
         self.copy_attributes(mesh)
+
+
+class _VTKDataObjectShadower:
+    @property
+    def field_data(self) -> DataSetAttributes:  # numpydoc ignore=RT01
+        """Return FieldData as DataSetAttributes.
+
+        Use field data when size of the data you wish to associate
+        with the dataset does not match the number of points or cells
+        of the dataset.
+
+        Returns
+        -------
+        DataSetAttributes
+            FieldData as DataSetAttributes.
+        """
+        return DataObject.field_data.fget(self)

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -28,7 +28,7 @@ import pyvista
 
 from . import _vtk_core as _vtk
 from ._typing_core import BoundsLike, MatrixLike, Number, NumpyArray, VectorLike
-from .dataobject import DataObject
+from .dataobject import DataObject, _VTKDataObjectShadower
 from .datasetattributes import DataSetAttributes
 from .errors import PyVistaDeprecationWarning, VTKVersionError
 from .filters import DataSetFilters, _get_output
@@ -3421,3 +3421,27 @@ class DataSet(DataSetFilters, DataObject):
             Active texture coordinates on the points.
         """
         self.point_data.active_texture_coordinates = texture_coordinates  # type: ignore[assignment]
+
+
+class _VTKDataSetShadower(_VTKDataObjectShadower):
+    @property
+    def point_data(self):
+        """Return point data as DataSetAttributes.
+
+        Returns
+        -------
+        DataSetAttributes
+            Point data as DataSetAttributes.
+        """
+        return DataSet.point_data.fget(self)
+
+    @property
+    def cell_data(self):
+        """Return cell data as DataSetAttributes.
+
+        Returns
+        -------
+        DataSetAttributes
+            Cell data as DataSetAttributes.
+        """
+        return DataSet.cell_data.fget(self)

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -11,7 +11,7 @@ import numpy as np
 import pyvista
 
 from . import _vtk_core as _vtk
-from .dataset import DataSet
+from .dataset import DataSet, _VTKDataSetShadower
 from .filters import ImageDataFilters, RectilinearGridFilters, _get_output
 from .utilities.arrays import convert_array, raise_has_duplicates
 from .utilities.misc import abstract_class
@@ -70,7 +70,7 @@ class Grid(DataSet):
         return attrs
 
 
-class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid, RectilinearGridFilters):
+class RectilinearGrid(_VTKDataSetShadower, _vtk.vtkRectilinearGrid, Grid, RectilinearGridFilters):
     """Dataset with variable spacing in the three coordinate directions.
 
     Can be initialized in several ways:

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -25,7 +25,7 @@ from .cell import (
     _get_regular_cells,
 )
 from .celltype import CellType
-from .dataset import DataSet
+from .dataset import DataSet, _VTKDataSetShadower
 from .errors import (
     CellSizeError,
     PointSetCellOperationError,
@@ -469,7 +469,7 @@ class PointSet(_vtk.vtkPointSet, _PointSet):
         raise PointSetCellOperationError
 
 
-class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
+class PolyData(_VTKDataSetShadower, _vtk.vtkPolyData, _PointSet, PolyDataFilters):
     """Dataset consisting of surface geometry (e.g. vertices, lines, and polygons).
 
     Can be initialized in several ways:
@@ -826,28 +826,6 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
     def __str__(self) -> str:
         """Return the standard str representation."""
         return DataSet.__str__(self)
-
-    @property
-    def point_data(self):
-        """Return point data as DataSetAttributes.
-
-        Returns
-        -------
-        DataSetAttributes
-            Point data as DataSetAttributes.
-        """
-        return super(_PointSet, self).point_data
-
-    @property
-    def cell_data(self):
-        """Return cell data as DataSetAttributes.
-
-        Returns
-        -------
-        DataSetAttributes
-            Cell data as DataSetAttributes.
-        """
-        return super(_PointSet, self).cell_data
 
     @staticmethod
     def _make_vertex_cells(npoints: int) -> NumpyArray[int]:
@@ -1712,7 +1690,7 @@ class PointGrid(_PointSet):
         return trisurf.plot_curvature(curv_type, **kwargs)
 
 
-class UnstructuredGrid(_vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
+class UnstructuredGrid(_VTKDataSetShadower, _vtk.vtkUnstructuredGrid, PointGrid, UnstructuredGridFilters):
     """Dataset used for arbitrary combinations of all possible cell types.
 
     Can be initialized by the following:

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -827,6 +827,28 @@ class PolyData(_vtk.vtkPolyData, _PointSet, PolyDataFilters):
         """Return the standard str representation."""
         return DataSet.__str__(self)
 
+    @property
+    def point_data(self):
+        """Return point data as DataSetAttributes.
+
+        Returns
+        -------
+        DataSetAttributes
+            Point data as DataSetAttributes.
+        """
+        return super(_PointSet, self).point_data
+
+    @property
+    def cell_data(self):
+        """Return cell data as DataSetAttributes.
+
+        Returns
+        -------
+        DataSetAttributes
+            Cell data as DataSetAttributes.
+        """
+        return super(_PointSet, self).cell_data
+
     @staticmethod
     def _make_vertex_cells(npoints: int) -> NumpyArray[int]:
         cells = np.empty((npoints, 2), dtype=pyvista.ID_TYPE)

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -11,6 +11,7 @@ import pytest
 
 import pyvista as pv
 from pyvista import examples
+from pyvista.core.datasetattributes import DataSetAttributes
 from pyvista.core.errors import CellSizeError, NotAllTrianglesError, PyVistaFutureWarning
 
 radius = 0.5
@@ -52,6 +53,8 @@ def test_init():
     mesh = pv.PolyData()
     assert not mesh.n_points
     assert not mesh.n_cells
+    assert isinstance(mesh.point_data, DataSetAttributes)
+    assert isinstance(mesh.cell_data, DataSetAttributes)
 
 
 def test_init_from_pdata(sphere):


### PR DESCRIPTION
This PR should fail with the added test on the vtk `dev` job. This is because when you install that you'll see:
```
(Pdb) p PolyData.point_data
<attribute 'point_data' of 'vtkmodules.vtkCommonDataModel.vtkDataSet' objects>
```
the MRO of PolyData puts vtkPolyData first, and on the `dev` branch of VTK this exists for that class.

Once it fails I'll push what I think might constitute a fix, namely adding a `@property` wrapper for `point_data` and `cell_data` directly in `PolyData` itself which wraps to `PointSet.point_data`.