### PR TITLE
Revert "Cache build html for preview in each pull request"

### DIFF
--- a/.github/workflows/preview_pull_request2.yml
+++ b/.github/workflows/preview_pull_request2.yml
@@ -61,13 +61,6 @@ jobs:
           echo PYVISTA_EXAMPLE_DATA_PATH=$(python -c "from pyvista import examples; print(examples.USER_DATA_PATH)") >> $GITHUB_ENV
           pip list
 
-      - name: Cache build html
-        uses: actions/cache@v4
-        if: env.USE_CACHE == 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/v')
-        with:
-          path: doc/_build/html/
-          key: doc-html-${{ github.event.issue.number }}
-
       - name: Cache Sphinx-Gallery Examples
         uses: actions/cache@v4
         if: env.USE_CACHE == 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/v')
@@ -110,7 +103,3 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN2 }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_DEV_SITE_ID2 }}
         timeout-minutes: 10
-
-      - name: Remove vtksz cache
-        if: env.USE_CACHE == 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/v')
-        run: find doc/_build/html/ -name "*.vtksz" | xargs rm


### PR DESCRIPTION
Reverts pyvista/pyvista#6094
I have confirmed that this change has no effect length of built time because the api-doc will be rebuilt. I will look into making the plot-directive static in PR.