### PR TITLE
Fix `image_threshold` bug with integer arrays on some systems

### DIFF
--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -422,16 +422,15 @@ class ImageDataFilters(DataSetFilters):
             scalars,
         )  # args: (idx, port, connection, field, name)
         # set the threshold(s) and mode
-        if isinstance(threshold, (np.ndarray, collections.abc.Sequence)):
-            if len(threshold) != 2:
-                raise ValueError(
-                    f'Threshold must be length one for a float value or two for min/max; not ({threshold}).',
-                )
-            alg.ThresholdBetween(threshold[0], threshold[1])
-        elif isinstance(threshold, collections.abc.Iterable):
-            raise TypeError('Threshold must either be a single scalar or a sequence.')
+        threshold_val = np.atleast_1d(threshold).astype(float)
+        if (size := threshold_val.size) not in (1, 2):
+            raise ValueError(
+                f'Threshold must have one or two values, got {size}.',
+            )
+        if size == 2:
+            alg.ThresholdBetween(threshold_val[0], threshold_val[1])
         else:
-            alg.ThresholdByUpper(threshold)
+            alg.ThresholdByUpper(threshold_val[0])
         # set the replacement values / modes
         if in_value is not None:
             alg.SetReplaceIn(True)

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -414,7 +414,7 @@ class ImageDataFilters(DataSetFilters):
         else:
             field = self.get_array_association(scalars, preference=preference)
 
-        # For some systems and/or versions of numpy, integer scalars won't threshold
+        # For some systems and/or Numpy < 2.0, integer scalars won't threshold
         # correctly. Cast to float in these cases.
         has_int_dtype = np.issubdtype(
             array_dtype := self.active_scalars.dtype,

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -416,7 +416,10 @@ class ImageDataFilters(DataSetFilters):
 
         # For some systems and/or versions of numpy, integer scalars won't threshold
         # correctly. Cast to float in these cases.
-        has_int_dtype = np.issubdtype(array_dtype := self.active_scalars.dtype, (int, np.integer))
+        has_int_dtype = np.issubdtype(
+            array_dtype := self.active_scalars.dtype,
+            int,
+        ) and array_dtype != np.dtype(np.uint8)
         cast_dtype = (
             has_int_dtype
             and int(np.__version__.split('.')[0]) < 2
@@ -459,6 +462,7 @@ class ImageDataFilters(DataSetFilters):
         _update_alg(alg, progress_bar, 'Performing Image Thresholding')
         output = _get_output(alg)
         if cast_dtype:
+            self[scalars] = self[scalars].astype(array_dtype)
             output[scalars] = output[scalars].astype(array_dtype)
         return output
 

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -407,13 +407,15 @@ class ImageDataFilters(DataSetFilters):
         >>> ithresh.plot()
 
         """
-        alg = _vtk.vtkImageThreshold()
-        alg.SetInputDataObject(self)
         if scalars is None:
             set_default_active_scalars(self)
             field, scalars = self.active_scalars_info
         else:
             field = self.get_array_association(scalars, preference=preference)
+        array_dtype = self.active_scalars.dtype
+
+        alg = _vtk.vtkImageThreshold()
+        alg.SetInputDataObject(self)
         alg.SetInputArrayToProcess(
             0,
             0,
@@ -422,7 +424,7 @@ class ImageDataFilters(DataSetFilters):
             scalars,
         )  # args: (idx, port, connection, field, name)
         # set the threshold(s) and mode
-        threshold_val = np.atleast_1d(threshold).astype(float)
+        threshold_val = np.atleast_1d(threshold).astype(array_dtype)
         if (size := threshold_val.size) not in (1, 2):
             raise ValueError(
                 f'Threshold must have one or two values, got {size}.',
@@ -434,12 +436,12 @@ class ImageDataFilters(DataSetFilters):
         # set the replacement values / modes
         if in_value is not None:
             alg.SetReplaceIn(True)
-            alg.SetInValue(in_value)
+            alg.SetInValue(np.array(in_value).astype(array_dtype))
         else:
             alg.SetReplaceIn(False)
         if out_value is not None:
             alg.SetReplaceOut(True)
-            alg.SetOutValue(out_value)
+            alg.SetOutValue(np.array(out_value).astype(array_dtype))
         else:
             alg.SetReplaceOut(False)
         # run the algorithm

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -3163,6 +3163,8 @@ def test_image_threshold_dtype(value_dtype, array_dtype):
     actual_array = thresh['Data']
     assert np.array_equal(actual_array, expected_array)
 
+    assert image['Data'].dtype == thresh['Data'].dtype
+
 
 def test_image_threshold_wrong_threshold_length():
     threshold = (10, 10, 10)  # tuple with too many values

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -3141,6 +3141,24 @@ def test_image_threshold_output_type():
     assert isinstance(volume_thresholded, pv.ImageData)
 
 
+@pytest.mark.parametrize('value_dtype', [float, int])
+@pytest.mark.parametrize('array_dtype', [float, int])
+def test_image_threshold_dtype(value_dtype, array_dtype):
+    image = pv.ImageData(dimensions=(2, 2, 2))
+    thresh_value = value_dtype(4)
+    assert type(thresh_value) is value_dtype
+
+    data_array = np.array(range(8), dtype=array_dtype)
+    image['Data'] = data_array
+
+    thresh = image.image_threshold(thresh_value)
+    assert thresh['Data'].dtype == np.dtype(array_dtype)
+
+    expected_array = [0, 0, 0, 0, 1, 1, 1, 1]
+    actual_array = thresh['Data']
+    assert np.array_equal(actual_array, expected_array)
+
+
 def test_image_threshold_wrong_threshold_length():
     threshold = (10, 10, 10)  # tuple with too many values
     volume = examples.load_uniform()

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -3132,13 +3132,18 @@ def test_image_dilate_erode_cell_data_active():
         volume.image_dilate_erode()
 
 
-def test_image_threshold_output_type():
+def test_image_threshold_output_type(uniform):
     threshold = 10  # 'random' value
-    volume = examples.load_uniform()
-    volume_thresholded = volume.image_threshold(threshold)
+    volume_thresholded = uniform.image_threshold(threshold)
     assert isinstance(volume_thresholded, pv.ImageData)
-    volume_thresholded = volume.image_threshold(threshold, scalars='Spatial Point Data')
+    volume_thresholded = uniform.image_threshold(threshold, scalars='Spatial Point Data')
     assert isinstance(volume_thresholded, pv.ImageData)
+
+
+def test_image_threshold_raises(uniform):
+    match = 'Threshold must have one or two values, got 3.'
+    with pytest.raises(ValueError, match=match):
+        uniform.image_threshold([1, 2, 3])
 
 
 @pytest.mark.parametrize('value_dtype', [float, int])

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -3147,7 +3147,7 @@ def test_image_threshold_raises(uniform):
 
 
 @pytest.mark.parametrize('value_dtype', [float, int])
-@pytest.mark.parametrize('array_dtype', [float, int])
+@pytest.mark.parametrize('array_dtype', [float, int, np.uint8])
 def test_image_threshold_dtype(value_dtype, array_dtype):
     image = pv.ImageData(dimensions=(2, 2, 2))
     thresh_value = value_dtype(4)


### PR DESCRIPTION
Fix issue with `image_threshold` unexpectedly returning all zeros for integer scalar arrays. This seems to be build-specific. I am not able to reproduce this locally but the bug shows up in the docs.

See images of the bug here https://github.com/pyvista/pyvista/pull/6071#issuecomment-2118468493