### PR TITLE
Exclude `tests/core/typing` from flake8 and black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-exclude = .git,__pycache__,build,dist,doc/examples,doc/_build
+exclude = .git,__pycache__,build,dist,doc/examples,doc/_build, tests/core/typing
 ignore =
     # whitespace before ':'
     E203,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
     rev: 24.4.2
     hooks:
       - id: black
+        exclude: tests/core/typing
 
   - repo: https://github.com/keewis/blackdoc
     rev: v0.3.9
@@ -28,6 +29,7 @@ repos:
       - id: flake8
         additional_dependencies:
           ["flake8-black==0.3.6", "flake8-isort==6.1.1", "flake8-quotes==3.3.2"]
+        exclude: tests/core/typing
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
@@ -118,6 +120,7 @@ repos:
     hooks:
       - id: ruff
         args: [--fix]
+        exclude: tests/core/typing
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Exclude `tests/core/typing` from flake8 and black.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- Follow-up of #5571
