### PR TITLE
Add typing-extensions as dependent library of PyVista

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,5 +27,6 @@ dependencies:
   - trame>=2.5.2
   - trame-vuetify>=2.3.1
   - trame-vtk>=2.5.8
+  - typing-extensions
   - pip:
       - pytest-memprof

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     'pooch',
     'scooby>=0.5.1',
     'vtk',  # keep without version constraints
+    'typing-extensions',
 ]
 dynamic = ['version']
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ numpy<1.27.0
 pillow<10.4.0
 pooch<1.9.0
 scooby>=0.5.1,<0.11.0
+typing-extensions<4.10.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,8 +10,12 @@ imageio-ffmpeg<0.5.0
 ipython<9.0.0
 ipywidgets<9.0.0
 meshio<5.4.0
+mypy<1.9.0
 nest_asyncio<1.6.1
+npt-promote==0.1
 numpydoc==1.7.0
+param<2.1.0
+pyanalyze<=0.12.0
 pydata-sphinx-theme<0.16.0
 pytest<8.3.0
 pytest-cov<5.1.0
@@ -27,3 +31,4 @@ trame>=2.5.2,<3.6.1
 trame-vtk>=2.5.8,<2.8.9
 trame-vuetify>=2.3.1,<2.5.1
 trimesh<4.4.0
+typing-extensions<4.10.0


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Add typing-extensions as dependent library of PyVista.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- Follow up #5571.