### PR TITLE
Skip `Vale` checks for large diffs (more than 300 files changed)

### DIFF
--- a/.github/workflows/style_docstr.yml
+++ b/.github/workflows/style_docstr.yml
@@ -51,6 +51,7 @@ jobs:
 
   vale:
     name: Vale
+    if: ${{ github.event.pull_request.changed_files < 301 }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Workaround to resolve failed checks associated with `Vale` for #5718. If that PR is approved, then this PR could be merged just before, and then reverted right after #5718 is merged.

The issue is with `reviewdog` specifically, which might be resolved with `reviewdog==0.17.4`. See https://github.com/reviewdog/reviewdog/issues/1696.

The current version of Vale is pinned to 2.9.5, see #5109. This version uses `reviewdog==0.17.0`. I tried unpinning Vale here:
https://github.com/pyvista/pyvista/actions/runs/9217324917/job/25359117083?pr=5718

This updates Vale to 3.4.2 but still uses `reviewdog==0.17.0`, unfortunately, and still fails.

So, this PR disables Vale altogether.
