### PR TITLE
Add `warn_redundant_casts` to mypy config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,6 +73,7 @@ repos:
             --pretty,
             --show-error-context,
             --warn-unused-ignores,
+            --warn-redundant-casts,
             --enable-error-code,
             ignore-without-code,
           ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,7 @@ disallow_any_generics = true
 pretty = true
 show_error_context = true
 warn_unused_ignores = true
+warn_redundant_casts = true
 plugins = ['numpy.typing.mypy_plugin','npt_promote']
 enable_error_code = [
     "ignore-without-code",


### PR DESCRIPTION
### Overview

See https://mypy.readthedocs.io/en/stable/error_code_list2.html#check-that-cast-is-not-redundant-redundant-cast

I ran mypy locally with this option and there are no errors like this currently in the repo. But it may help prevent these cases in the future, e.g. https://github.com/pyvista/pyvista/pull/5571#discussion_r1615272845