### PR TITLE
Pin `matplotlib==3.8.4` to fix 'get_cmap' import error

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -7,6 +7,7 @@ imageio-ffmpeg==0.4.9
 jupyter_sphinx==0.5.3
 jupyterlab==4.2.1
 lxml==5.2.2
+matplotlib==3.8.4
 meshio==5.3.5
 mypy==1.10.0
 mypy-extensions==1.0.0


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Pin `matplotlib==3.8.4` to fix 'get_cmap' import error.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- See https://github.com/pyvista/pyvista/actions/runs/9309268313/job/25624398477
- https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.9.0.html#removals