### PR TITLE
Remove `import annotations` to speed up documentation build time

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -78,9 +78,9 @@ jobs:
         with:
           path: ${{ env.PYVISTA_EXAMPLE_DATA_PATH }}
           key: example-data-1-${{ hashFiles('pyvista/_version.py') }}
-          
+
       - name: Remove __future__ imports
-        run: reorder-python-imports --remove-import 'from __future__ import annotations' $(find . -name "*.py")
+        run: reorder-python-imports --remove-import 'from __future__ import annotations' $(find ./examples ./pyvista ./doc -name "*.py")
 
       - name: Build Documentation
         run: make -C doc html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -78,6 +78,9 @@ jobs:
         with:
           path: ${{ env.PYVISTA_EXAMPLE_DATA_PATH }}
           key: example-data-1-${{ hashFiles('pyvista/_version.py') }}
+          
+      - name: Remove __future__ imports
+        run: reorder-python-imports --remove-import 'from __future__ import annotations' $(find . -name "*.py")
 
       - name: Build Documentation
         run: make -C doc html

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -15,6 +15,7 @@ osmnx==1.9.3
 pydata-sphinx-theme==0.15.3
 pypandoc==1.13
 pytest-sphinx==0.6.3
+reorder-python-imports==3.12.0
 scipy==1.13.1
 sphinx==7.3.7
 sphinx-autobuild==2024.4.16


### PR DESCRIPTION
### Overview

The build times seem to be a bit longer after https://github.com/pyvista/pyvista/pull/5712 was merged. I wonder if removing the `from __future__ import annotations` can speed up the build.