### PR TITLE
Configure icon links to PyPI to the right of bar

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -495,6 +495,11 @@ html_theme_options = {
             "url": "https://doi.org/10.21105/joss.01450",
             "icon": "fa fa-file-text fa-fw",
         },
+        {
+            "name": "PyPI",
+            "url": "https://pypi.org/project/pyvista",
+            "icon": "fa-custom fa-pypi",
+        },
     ],
     "check_switcher": False,
     "switcher": {


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
See https://pydata-sphinx-theme.readthedocs.io/en/v0.8.1/user_guide/configuring.html#configure-icon-links
<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None
