### PR TITLE
Add `nitpicky` option to doc config to prevent broken links

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -202,7 +202,9 @@ numpydoc_use_plots = True
 numpydoc_show_class_members = False
 numpydoc_xref_param_type = True
 
-# linkcheck ignore entries
+# Warn if target links or references cannot be found
+nitpicky=True
+# Except ignore these entries
 nitpick_ignore_regex = [
     (r'py:.*', '.*ColorLike'),
     (r'py:.*', '.*lookup_table_ndarray'),


### PR DESCRIPTION
### Overview

This config option should help prevent introducing broken links in the docs.

See: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-nitpicky

Currently a bunch of nitpick ignores are already defined here:
https://github.com/pyvista/pyvista/blob/334d852a0c46a598c036f79230d5bbc6db666170/doc/source/conf.py#L206-L225

But these have no effect unless `nitpicky` is set to `True`.