### PR TITLE
Add missing `axes_enabled` method in Plotter class

### DIFF
--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -1327,6 +1327,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         """Wrap ``Renderer.show_axes``."""
         return self.renderer.show_axes(*args, **kwargs)
 
+    @wraps(Renderer.axes_enabled)
+    def axes_enabled(self, *args, **kwargs):  # numpydoc ignore=PR01,RT01
+        """Wrap ``Renderer.axes_enabled``."""
+        return self.renderer.axes_enabled(*args, **kwargs)
+
     @wraps(Renderer.update_bounds_axes)
     def update_bounds_axes(self, *args, **kwargs):  # numpydoc ignore=PR01,RT01
         """Wrap ``Renderer.update_bounds_axes``."""

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -547,3 +547,10 @@ def test_add_ruler_scale():
     min_, max_ = ruler.GetRange()
     assert min_ == 0.6
     assert max_ == 0.0
+
+
+@pytest.mark.parametrize('axes_enabled', [True, False])
+def test_axes_enabled(axes_enabled):
+    plotter = pv.Plotter()
+    plotter.axes_enabled = axes_enabled
+    assert plotter.axes_enabled is axes_enabled


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Found in https://github.com/pyvista/pyvista/pull/6198#discussion_r1626011808.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None