### PR TITLE
Fix internal links to core typing

### DIFF
--- a/doc/source/api/core/typing.rst
+++ b/doc/source/api/core/typing.rst
@@ -1,6 +1,5 @@
 Typing
 ======
-.. currentmodule:: pyvista
 
 Type aliases and type variable used by PyVista.
 
@@ -8,11 +7,32 @@ Type aliases and type variable used by PyVista.
 Numeric Array-Like Types
 ------------------------
 
+pyvista.NumberType
+~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: pyvista
+
 .. autotypevar:: NumberType
+
+pyvista.ArrayLike
+~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: pyvista
 
 .. autodata:: ArrayLike
 
+pyvista.MatrixLike
+~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: pyvista
+
 .. autodata:: MatrixLike
+
+
+pyvista.VectorLike
+~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: pyvista
 
 .. autodata:: VectorLike
 
@@ -20,10 +40,30 @@ Numeric Array-Like Types
 VTK Related Types
 -----------------
 
+pyvista.BoundsLike
+~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: pyvista
+
 .. autodata:: BoundsLike
+
+pyvista.CellsLike
+~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: pyvista
 
 .. autodata:: CellsLike
 
+pyvista.CellArrayLike
+~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: pyvista
+
 .. autodata:: CellArrayLike
+
+pyvista.TransformLike
+~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: pyvista
 
 .. autodata:: TransformLike


### PR DESCRIPTION
### Overview

The internal core typing links are currently broken. (See the build errors generated when setting `nitpicky=True` in #6203 for a full list of broken links).

The issue seems to stem from aliases not being documented as `py:class:` (aliases are `py:data:`). See https://github.com/sphinx-doc/sphinx/issues/10974#issuecomment-1315385037

The `pyvista.ColorLike` aliases work, however.  And @dcbr pointed out in https://github.com/pyvista/pyvista/pull/5621#discussion_r1532044361 that this could be because `ColorLike` uses `.. autosummary::`.

It would be preferable not to use autosummary, however, because it creates a separate entry (link and page) for the class. But for aliases I think it would be better if they were all shown in a single flat level, glossary-style.

I found this rst stub generated locally in the pyvista repo:
``` rst
pyvista.ColorLike
=================

.. currentmodule:: pyvista

.. autodata:: ColorLike
```

So, it seems like this is what `autosummary` generates.  This formatting was copied and applied to `typing.rst`. Let's see if it works.