### PR TITLE
Update `ArrayLike` and `NumberType` definitions in core typing

### DIFF
--- a/pyvista/core/_typing_core/_aliases.py
+++ b/pyvista/core/_typing_core/_aliases.py
@@ -53,3 +53,6 @@ Has the form (``xmin``, ``xmax``, ``ymin``, ``ymax``, ``zmin``, ``zmax``).
 CellsLike = Union[MatrixLike[int], VectorLike[int]]
 
 CellArrayLike = Union[CellsLike, _vtk.vtkCellArray]
+
+# Undocumented alias - should be expanded in docs
+_ArrayLikeOrScalar = Union[NumberType, ArrayLike[NumberType]]

--- a/pyvista/core/_typing_core/_array_like.py
+++ b/pyvista/core/_typing_core/_array_like.py
@@ -23,10 +23,6 @@ Some key differences include:
 
 from __future__ import annotations
 
-import sys
-import typing
-from typing import TYPE_CHECKING
-from typing import Any
 from typing import List
 from typing import Sequence
 from typing import Tuple
@@ -46,36 +42,7 @@ NumberType = TypeVar(
 )
 NumberType.__doc__ = """Type variable for numeric data types."""
 
-# Create a copy of the typevar
-_NumberType = TypeVar(  # noqa: PYI018
-    '_NumberType',
-    bound=Union[np.floating, np.integer, np.bool_, float, int, bool],  # type: ignore[type-arg]
-)
-_PyNumberType = TypeVar('_PyNumberType', float, int, bool)  # noqa: PYI018
-_NpNumberType = TypeVar('_NpNumberType', np.float64, np.int_, np.bool_)  # noqa: PYI018
-
-
-_T = TypeVar('_T')
-if not TYPE_CHECKING and sys.version_info < (3, 9, 0):
-    # TODO: Remove this conditional block once support for Python3.8 is dropped
-
-    # Numpy's type annotations use a customized generic alias type for
-    # python < 3.9.0 (defined in numpy.typing._generic_alias._GenericAlias)
-    # which makes it incompatible with built-in generic alias types, e.g.
-    # Sequence[NDArray[T]]. As a workaround, we define NDArray types using
-    # the private typing._GenericAlias type instead
-    np_dtype = typing._GenericAlias(np.dtype, NumberType)
-    _np_floating = typing._GenericAlias(np.floating, _T)
-    _np_integer = typing._GenericAlias(np.integer, _T)
-    np_dtype_floating = typing._GenericAlias(np.dtype, _np_floating[_T])
-    np_dtype_integer = typing._GenericAlias(np.dtype, _np_integer[_T])
-    NumpyArray = typing._GenericAlias(np.ndarray, (Any, np_dtype[NumberType]))
-else:
-    np_dtype = np.dtype[NumberType]
-    np_dtype_floating = np.dtype[np.floating[Any]]
-    np_dtype_integer = np.dtype[np.integer[Any]]
-    # Create alias of npt.NDArray bound to numeric types only
-    NumpyArray = npt.NDArray[NumberType]
+NumpyArray = npt.NDArray[NumberType]
 
 _FiniteNestedList = Union[
     List[NumberType],

--- a/pyvista/core/_typing_core/_array_like.py
+++ b/pyvista/core/_typing_core/_array_like.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 from typing import List
 from typing import Sequence
 from typing import Tuple
-from typing import Type
 from typing import TypeVar
 from typing import Union
 
@@ -34,8 +33,6 @@ import numpy as np
 import numpy.typing as npt
 
 # Define numeric types
-# TODO: remove # type: ignore once support for Python3.8 is dropped
-_NumberUnion = Union[Type[np.floating], Type[np.integer], Type[np.bool_], Type[float], Type[int], Type[bool]]  # type: ignore[type-arg]
 NumberType = TypeVar(
     'NumberType',
     bound=Union[np.floating, np.integer, np.bool_, float, int, bool],  # type: ignore[type-arg]

--- a/pyvista/core/_typing_core/_array_like.py
+++ b/pyvista/core/_typing_core/_array_like.py
@@ -23,9 +23,7 @@ Some key differences include:
 
 from __future__ import annotations
 
-from typing import List
 from typing import Sequence
-from typing import Tuple
 from typing import TypeVar
 from typing import Union
 
@@ -40,20 +38,6 @@ NumberType = TypeVar(
 NumberType.__doc__ = """Type variable for numeric data types."""
 
 NumpyArray = npt.NDArray[NumberType]
-
-_FiniteNestedList = Union[
-    List[NumberType],
-    List[List[NumberType]],
-    List[List[List[NumberType]]],
-    List[List[List[List[NumberType]]]],
-]
-
-_FiniteNestedTuple = Union[
-    Tuple[NumberType],
-    Tuple[Tuple[NumberType]],
-    Tuple[Tuple[Tuple[NumberType]]],
-    Tuple[Tuple[Tuple[Tuple[NumberType]]]],
-]
 
 _ArrayLike1D = Union[
     NumpyArray[NumberType],


### PR DESCRIPTION
### Overview

Follow up from #5571 generally, and #6214 specifically (this PR is item 1 defined there).

### Details
- Remove `FiniteNestedSequence` (no longer used)
- Redefine `ArrayLike` as a union of 1D, 2D, 3D, and 4D array-like types
- Generalize `NumberType` definition as any python or numpy float, int, or bool type
- Add private `_ArrayLikeOrScalar` alias to make it easier to add typing for inputs where scalars are allowed