### PR TITLE
Add nested tuple and list type annotations to `validation` array-casting functions

### DIFF
--- a/pyvista/core/_typing_core/_aliases.py
+++ b/pyvista/core/_typing_core/_aliases.py
@@ -53,3 +53,6 @@ Has the form (``xmin``, ``xmax``, ``ymin``, ``ymax``, ``zmin``, ``zmax``).
 CellsLike = Union[MatrixLike[int], VectorLike[int]]
 
 CellArrayLike = Union[CellsLike, _vtk.vtkCellArray]
+
+# Undocumented alias - should be expanded in docs
+_ArrayLikeOrScalar = Union[NumberType, ArrayLike[NumberType]]

--- a/pyvista/core/_typing_core/_array_like.py
+++ b/pyvista/core/_typing_core/_array_like.py
@@ -32,14 +32,11 @@ from typing import Union
 import numpy as np
 import numpy.typing as npt
 
-# Define numeric types
-NumberType = TypeVar(
-    'NumberType',
-    bound=Union[np.floating, np.integer, np.bool_, float, int, bool],  # type: ignore[type-arg]
-)
+# Create alias of npt.NDArray bound to numeric types only
+NumberType = TypeVar('NumberType', bool, int, float, np.bool_, np.int_, np.float64, np.uint8)
 NumberType.__doc__ = """Type variable for numeric data types."""
-
 NumpyArray = npt.NDArray[NumberType]
+
 
 _FiniteNestedList = Union[
     List[NumberType],
@@ -47,12 +44,25 @@ _FiniteNestedList = Union[
     List[List[List[NumberType]]],
     List[List[List[List[NumberType]]]],
 ]
-
 _FiniteNestedTuple = Union[
     Tuple[NumberType],
     Tuple[Tuple[NumberType]],
     Tuple[Tuple[Tuple[NumberType]]],
     Tuple[Tuple[Tuple[Tuple[NumberType]]]],
+]
+# Define generic nested sequence
+_T = TypeVar('_T')
+_FiniteNestedSequence = Union[  # Note: scalar types are excluded
+    Sequence[_T],
+    Sequence[Sequence[_T]],
+    Sequence[Sequence[Sequence[_T]]],
+    Sequence[Sequence[Sequence[Sequence[_T]]]],
+]
+
+_ArrayLike = Union[
+    NumpyArray[NumberType],
+    _FiniteNestedSequence[NumberType],
+    _FiniteNestedSequence[NumpyArray[NumberType]],
 ]
 
 _ArrayLike1D = Union[
@@ -74,10 +84,4 @@ _ArrayLike4D = Union[
     NumpyArray[NumberType],
     Sequence[Sequence[Sequence[Sequence[NumberType]]]],
     Sequence[Sequence[Sequence[Sequence[NumpyArray[NumberType]]]]],
-]
-_ArrayLike = Union[
-    _ArrayLike1D[NumberType],
-    _ArrayLike2D[NumberType],
-    _ArrayLike3D[NumberType],
-    _ArrayLike4D[NumberType],
 ]

--- a/pyvista/core/_typing_core/_array_like.py
+++ b/pyvista/core/_typing_core/_array_like.py
@@ -23,31 +23,36 @@ Some key differences include:
 
 from __future__ import annotations
 
+from typing import List
 from typing import Sequence
+from typing import Tuple
 from typing import TypeVar
 from typing import Union
 
 import numpy as np
 import numpy.typing as npt
 
-# Create alias of npt.NDArray bound to numeric types only
-NumberType = TypeVar('NumberType', bool, int, float, np.bool_, np.int_, np.float64, np.uint8)
+# Define numeric types
+NumberType = TypeVar(
+    'NumberType',
+    bound=Union[np.floating, np.integer, np.bool_, float, int, bool],  # type: ignore[type-arg]
+)
 NumberType.__doc__ = """Type variable for numeric data types."""
+
 NumpyArray = npt.NDArray[NumberType]
 
-# Define generic nested sequence
-_T = TypeVar('_T')
-_FiniteNestedSequence = Union[  # Note: scalar types are excluded
-    Sequence[_T],
-    Sequence[Sequence[_T]],
-    Sequence[Sequence[Sequence[_T]]],
-    Sequence[Sequence[Sequence[Sequence[_T]]]],
+_FiniteNestedList = Union[
+    List[NumberType],
+    List[List[NumberType]],
+    List[List[List[NumberType]]],
+    List[List[List[List[NumberType]]]],
 ]
 
-_ArrayLike = Union[
-    NumpyArray[NumberType],
-    _FiniteNestedSequence[NumberType],
-    _FiniteNestedSequence[NumpyArray[NumberType]],
+_FiniteNestedTuple = Union[
+    Tuple[NumberType],
+    Tuple[Tuple[NumberType]],
+    Tuple[Tuple[Tuple[NumberType]]],
+    Tuple[Tuple[Tuple[Tuple[NumberType]]]],
 ]
 
 _ArrayLike1D = Union[
@@ -69,4 +74,10 @@ _ArrayLike4D = Union[
     NumpyArray[NumberType],
     Sequence[Sequence[Sequence[Sequence[NumberType]]]],
     Sequence[Sequence[Sequence[Sequence[NumpyArray[NumberType]]]]],
+]
+_ArrayLike = Union[
+    _ArrayLike1D[NumberType],
+    _ArrayLike2D[NumberType],
+    _ArrayLike3D[NumberType],
+    _ArrayLike4D[NumberType],
 ]

--- a/pyvista/core/_validation/_cast_array.py
+++ b/pyvista/core/_validation/_cast_array.py
@@ -66,7 +66,7 @@ def _cast_to_numpy(
     as_any: bool = True,
     dtype: Optional[npt.DTypeLike] = None,
     copy: bool = False,
-    must_be_real=False,
+    must_be_real: bool = False,
 ) -> NumpyArray[NumberType]:
     """Cast array to a NumPy ndarray.
 

--- a/pyvista/core/_validation/_cast_array.py
+++ b/pyvista/core/_validation/_cast_array.py
@@ -2,15 +2,30 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+from typing import Optional
+from typing import Union
+
 import numpy as np
+import numpy.typing as npt
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pyvista.core._typing_core import ArrayLike
+    from pyvista.core._typing_core import NumpyArray
+    from pyvista.core._typing_core._aliases import _ArrayLikeOrScalar
+    from pyvista.core._typing_core._array_like import NumberType
+    from pyvista.core._typing_core._array_like import _FiniteNestedList
+    from pyvista.core._typing_core._array_like import _FiniteNestedTuple
 
 
-def _cast_to_list(arr):
+def _cast_to_list(
+    arr: _ArrayLikeOrScalar[NumberType],
+) -> Union[NumberType, _FiniteNestedList[NumberType]]:
     """Cast an array to a nested list.
 
     Parameters
     ----------
-    arr : array_like
+    arr : float | ArrayLike[float]
         Array to cast.
 
     Returns
@@ -21,12 +36,14 @@ def _cast_to_list(arr):
     return _cast_to_numpy(arr).tolist()
 
 
-def _cast_to_tuple(arr):
+def _cast_to_tuple(
+    arr: ArrayLike[NumberType],
+) -> Union[NumberType, _FiniteNestedTuple[NumberType]]:
     """Cast an array to a nested tuple.
 
     Parameters
     ----------
-    arr : array_like
+    arr : float | ArrayLike[float]
         Array to cast.
 
     Returns
@@ -42,7 +59,15 @@ def _cast_to_tuple(arr):
     return _to_tuple(arr)
 
 
-def _cast_to_numpy(arr, /, *, as_any=True, dtype=None, copy=False, must_be_real=False):
+def _cast_to_numpy(
+    arr: _ArrayLikeOrScalar[NumberType],
+    /,
+    *,
+    as_any: bool = True,
+    dtype: Optional[npt.DTypeLike] = None,
+    copy: bool = False,
+    must_be_real=False,
+) -> NumpyArray[NumberType]:
     """Cast array to a NumPy ndarray.
 
     Object arrays are not allowed but the dtype is otherwise unchecked by default.
@@ -56,14 +81,14 @@ def _cast_to_numpy(arr, /, *, as_any=True, dtype=None, copy=False, must_be_real=
 
     Parameters
     ----------
-    arr : array_like
+    arr : float | ArrayLike[float]
         Array to cast.
 
     as_any : bool, default: True
         Allow subclasses of ``np.ndarray`` to pass through without
         making a copy.
 
-    dtype : dtype_like, optional
+    dtype : npt.typing.DTypeLike, optional
         The data-type of the returned array.
 
     copy : bool, default: False


### PR DESCRIPTION
### Overview

Follow up from https://github.com/pyvista/pyvista/pull/5571 generally, and https://github.com/pyvista/pyvista/pull/6214 specifically (this PR is part of item 1 defined there).