### PR TITLE
Fix duplicate Ruff's target-version and project.requires-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -296,7 +296,6 @@ exclude = [
 ]
 line-length = 100
 indent-width = 4
-target-version = 'py38'
 
 [tool.ruff.lint]
 external = ["E131", "D102", "D105"]


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
We have both Ruff's target-version and project.requires-python. We only need the latter.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- https://learn.scientific-python.org/development/guides/style/#RF002