### PR TITLE
Add pytest `tool.pytest.ini_options` configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,10 @@ markers = [
     'needs_download: this test downloads data during execution',
 ]
 image_cache_dir = "tests/plotting/image_cache"
+minversion = "7"
+log_cli_level = "INFO"
+xfail_strict = true
+addopts = ["-ra", "--strict-config", "--strict-markers"]
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
- [PP302](https://learn.scientific-python.org/development/guides/pytest#PP302): Sets a minimum pytest to at least 6
- [PP304](https://learn.scientific-python.org/development/guides/pytest#PP304): Sets the log level in pytest
- [PP305](https://learn.scientific-python.org/development/guides/pytest#PP305): Specifies xfail_strict
- [PP306](https://learn.scientific-python.org/development/guides/pytest#PP306): Specifies strict config
- [PP308](https://learn.scientific-python.org/development/guides/pytest#PP308): Specifies useful pytest summary

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None