### PR TITLE
Enable `redundant-expr` and `truthy-bool` in MyPy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,9 +159,7 @@ show_error_context = true
 warn_unused_ignores = true
 warn_redundant_casts = true
 plugins = ['numpy.typing.mypy_plugin','npt_promote']
-enable_error_code = [
-    "ignore-without-code",
-]
+enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 
 
 [tool.numpydoc_validation]


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
- [MY105](https://learn.scientific-python.org/development/guides/style#MY105): MyPy enables redundant-expr
- [MY106](https://learn.scientific-python.org/development/guides/style#MY106): MyPy enables truthy-bool

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None