### PR TITLE
Fix all `TypeError` expressions in docstring

### DIFF
--- a/pyvista/core/_validation/_cast_array.py
+++ b/pyvista/core/_validation/_cast_array.py
@@ -99,7 +99,7 @@ def _cast_to_numpy(
             * is a subclass of ``np.ndarray`` and ``as_any`` is ``False``.
 
     must_be_real : bool, default: True
-        Raise a TypeError if the array does not have real numbers, i.e.
+        Raise a ``TypeError`` if the array does not have real numbers, i.e.
         its data type is not integer or floating.
 
     Raises

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -1089,7 +1089,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
                 raise KeyError(f'Array index ({index}) out of range [0, {max_index - 1}]')
 
     def _raise_field_data_no_scalars_vectors(self):
-        """Raise a TypeError if FieldData."""
+        """Raise a ``TypeError`` if FieldData."""
         if self.association == FieldAssociation.NONE:
             raise TypeError('FieldData does not have active scalars or vectors.')
 


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Fix all `TypeError` expressions in docstring.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- Follow-up of #6156