### PR TITLE
Add a Dependabot config to auto-update GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,9 @@ updates:
         patterns:
           - "actions/upload-artifact"
           - "actions/download-artifact"
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - "maintenance"
       - "dependencies"


### PR DESCRIPTION
### Overview

Currently, deprecation warnings are being thrown due to actions using out-of-date Node versions ([recent example](https://github.com/pyvista/pyvista/actions/runs/9555140364)). Rather than submitting a PR to update them manually, this PR configures Dependabot to regularly submit PRs to update GitHub action versions as needed.

If this PR merges, you can expect Dependabot to immediately submit a PR to update actions to newer versions.

### Details

- Add a Dependabot config to auto-update GitHub action versions
