### PR TITLE
Fix `Text3DSource` garbage collection

### DIFF
--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -898,17 +898,6 @@ class Text3DSource(vtkVectorText):
         """Initialize source."""
         super().__init__()
 
-        # Create output filters to make text 3D
-        extrude = _vtk.vtkLinearExtrusionFilter()
-        extrude.SetInputConnection(self.GetOutputPort())
-        extrude.SetExtrusionTypeToNormalExtrusion()
-        extrude.SetVector(0, 0, 1)
-        self._extrude_filter = extrude
-
-        tri_filter = _vtk.vtkTriangleFilter()
-        tri_filter.SetInputConnection(extrude.GetOutputPort())
-        self._tri_filter = tri_filter
-
         self._output = pyvista.PolyData()
 
         # Set params
@@ -941,11 +930,6 @@ class Text3DSource(vtkVectorText):
                     f'Attribute "{name}" does not exist and cannot be added to type '
                     f'{self.__class__.__name__}',
                 )
-
-    def __del__(self):
-        """Delete filters."""
-        self._tri_filter = None
-        self._extrude_filter = None
 
     @property
     def string(self) -> str:  # numpydoc ignore=RT01
@@ -1044,8 +1028,16 @@ class Text3DSource(vtkVectorText):
                 out = self.GetOutput()
             else:
                 # 3D case, apply filters
-                self._tri_filter.Update()
-                out = self._tri_filter.GetOutput()
+                # Create output filters to make text 3D
+                extrude = _vtk.vtkLinearExtrusionFilter()
+                extrude.SetInputConnection(self.GetOutputPort())
+                extrude.SetExtrusionTypeToNormalExtrusion()
+                extrude.SetVector(0, 0, 1)
+
+                tri_filter = _vtk.vtkTriangleFilter()
+                tri_filter.SetInputConnection(extrude.GetOutputPort())
+                tri_filter.Update()
+                out = tri_filter.GetOutput()
 
             # Modify output object
             self._output.copy_from(out)


### PR DESCRIPTION
### Overview

This class stores references to additional filters in `__init__` for internal use by the class. Turns out that this causes the plotting gc checks to fail when a parent class which stores its own references to `Text3DSource` is used as a pytest fixture (the internal filters are not properly gc'd). This PR fixes this by moving the filters out of init.

No tests are added with this PR to verify that the gc is working. But a separate PR will be created later with a new `Text3DFollower` class (from #6263), and tests for that class will implicitly verify that the gc is working.