### PR TITLE
Add exclude bot authors instead of adding labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,9 +6,9 @@ changelog:
       - ignore-for-release
     authors:
       - dependabot
+      - github-actions
       - pre-commit-ci
       - pyvista-bot
-      - github-actions
   categories:
     - title: Breaking Changes
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,11 @@ changelog:
   exclude:
     labels:
       - ignore-for-release
+    authors:
+      - dependabot
+      - pre-commit-ci
+      - pyvista-bot
+      - github-actions
   categories:
     - title: Breaking Changes
       labels:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -29,7 +29,7 @@ jobs:
           github_token: "${{ secrets.PYVISTA_BOT_TOKEN }}"
           labels: maintenance
       - uses: actions-ecosystem/action-add-labels@v1
-        if: startsWith(github.event.pull_request.head.ref, 'junk') || github.actor == 'dependabot[bot]' || github.actor == 'github-actions[bot]' ||  github.actor == 'pre-commit-ci[bot]' || github.actor == 'pyvista-bot'
+        if: startsWith(github.event.pull_request.head.ref, 'junk')
         with:
           github_token: "${{ secrets.PYVISTA_BOT_TOKEN }}"
           labels: ignore-for-release


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Add exclude bot authors instead of adding labels.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options
