### PR TITLE
Run `pre-commit` `mypy` on project directories instead of only modified files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,11 +106,11 @@ repos:
       - id: ruff-format
         exclude: tests/core/typing
 
-#  - repo: https://github.com/pre-commit/mirrors-prettier
-#    rev: v3.1.0
-#    hooks:
-#      - id: prettier
-#        types_or: [yaml, markdown, html, css, scss, javascript, json]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        types_or: [yaml, markdown, html, css, scss, javascript, json]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,9 @@ repos:
             --warn-redundant-casts,
             --enable-error-code,
             ignore-without-code,
+            pyvista,  # Run mypy on entire project directory
           ]
+        pass_filenames: false  # Do not run on individual modified files
         exclude: ^(tests/|examples/|pyvista/ext/|examples_trame/)
         additional_dependencies:
           [
@@ -67,6 +69,7 @@ repos:
             "toml==0.10.2",
             "numpy>=1.21",
             "npt-promote==0.1",
+            "types-docutils",
           ]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -102,11 +105,11 @@ repos:
       - id: ruff-format
         exclude: tests/core/typing
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
-    hooks:
-      - id: prettier
-        types_or: [yaml, markdown, html, css, scss, javascript, json]
+#  - repo: https://github.com/pre-commit/mirrors-prettier
+#    rev: v3.1.0
+#    hooks:
+#      - id: prettier
+#        types_or: [yaml, markdown, html, css, scss, javascript, json]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,8 +50,7 @@ repos:
     rev: v1.10.0
     hooks:
       - id: mypy
-        args:
-          [
+        args: [
             --disallow-any-generics,
             --pretty,
             --show-error-context,
@@ -59,10 +58,10 @@ repos:
             --warn-redundant-casts,
             --enable-error-code,
             ignore-without-code,
-            pyvista,  # Run mypy on pyvista directory
+            pyvista, # Run mypy on pyvista directory
           ]
-        pass_filenames: false  # Do not run on individual modified files
-        always_run: true  # Need this to ensure mypy runs for config-only changes
+        pass_filenames: false # Do not run on individual modified files
+        always_run: true # Need this to ensure mypy runs for config-only changes
         exclude: ^(tests/|examples/|pyvista/ext/|examples_trame/)
         additional_dependencies:
           [

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,9 +59,10 @@ repos:
             --warn-redundant-casts,
             --enable-error-code,
             ignore-without-code,
-            pyvista,  # Run mypy on entire project directory
+            pyvista,  # Run mypy on pyvista directory
           ]
         pass_filenames: false  # Do not run on individual modified files
+        always_run: true  # Need this to ensure mypy runs for config-only changes
         exclude: ^(tests/|examples/|pyvista/ext/|examples_trame/)
         additional_dependencies:
           [

--- a/pyvista/core/_validation/_cast_array.py
+++ b/pyvista/core/_validation/_cast_array.py
@@ -122,7 +122,7 @@ def _cast_to_numpy(
     try:
         VisibleDeprecationWarning = np.exceptions.VisibleDeprecationWarning
     except AttributeError:
-        VisibleDeprecationWarning = np.VisibleDeprecationWarning
+        VisibleDeprecationWarning = np.VisibleDeprecationWarning  # type: ignore[attr-defined]
 
     try:
         out = np.asanyarray(arr, dtype=dtype) if as_any else np.asarray(arr, dtype=dtype)

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -268,7 +268,7 @@ class RectilinearGrid(_vtk.vtkRectilinearGrid, Grid, RectilinearGridFilters):
             List of numpy arrays representing the points of this mesh.
 
         """
-        return np.meshgrid(self.x, self.y, self.z, indexing='ij')
+        return np.meshgrid(self.x, self.y, self.z, indexing='ij')  # type: ignore[return-value]
 
     @property  # type: ignore[explicit-override, override]
     def points(self) -> NumpyArray[float]:

--- a/pyvista/ext/coverage.py
+++ b/pyvista/ext/coverage.py
@@ -39,12 +39,12 @@ logger = logging.getLogger(__name__)
 
 
 # utility
-def write_header(f: IO, text: str, char: str = '-') -> None:
+def write_header(f: IO[Any], text: str, char: str = '-') -> None:
     f.write(text + '\n')
     f.write(char * len(text) + '\n')
 
 
-def compile_regex_list(name: str, exps: str) -> list[Pattern]:
+def compile_regex_list(name: str, exps: str) -> list[Pattern[Any]]:
     lst = []
     for exp in exps:
         try:
@@ -82,14 +82,14 @@ class CoverageBuilder(Builder):
             pattern = path.join(self.srcdir, pattern)  # noqa: PTH118
             self.c_sourcefiles.extend(glob.glob(pattern))  # noqa: PTH207
 
-        self.c_regexes: list[tuple[str, Pattern]] = []
+        self.c_regexes: list[tuple[str, Pattern[Any]]] = []
         for name, exp in self.config.coverage_c_regexes.items():
             try:
                 self.c_regexes.append((name, re.compile(exp)))
             except Exception:
                 logger.warning(__('invalid regex %r in coverage_c_regexes'), exp)
 
-        self.c_ignorexps: dict[str, list[Pattern]] = {}
+        self.c_ignorexps: dict[str, list[Pattern[Any]]] = {}
         for name, exps in self.config.coverage_ignore_c_items.items():
             self.c_ignorexps[name] = compile_regex_list('coverage_ignore_c_items', exps)
         self.mod_ignorexps = compile_regex_list(

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -124,6 +124,7 @@ import pyvista
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Callable
+    from typing import Any
 
 pyvista.BUILDING_GALLERY = True
 pyvista.OFF_SCREEN = True
@@ -161,7 +162,7 @@ class PlotDirective(Directive):
     required_arguments = 0
     optional_arguments = 2
     final_argument_whitespace = False
-    option_spec: ClassVar[dict[str, Callable]] = {
+    option_spec: ClassVar[dict[str, Callable[..., Any]]] = {
         'alt': directives.unchanged,
         'height': directives.length_or_unitless,
         'width': directives.length_or_percentage_or_unitless,
@@ -322,7 +323,7 @@ Exception occurred rendering plot.
 
 # the context of the plot for all directives specified with the
 # :context: option
-plot_context = {}
+plot_context = {}  # type: ignore[var-annotated]
 
 
 class ImageFile:


### PR DESCRIPTION
### Overview

This *should* resolve #5611 and put us one step closer to #6279. See https://github.com/pyvista/pyvista/pull/6268#discussion_r1644972791 for additional context. 

After updating the config locally, `mypy` immediately reported some type errors that should have previously been addressed. This suggests the config is now working as it should.

Some of these errors are currently being resolved by other PRs, e.g. the numpy depreaction warnings and meshgrid return type in https://github.com/pyvista/pyvista/pull/6280, so I've just `# type: ignore`d these for so that CI checks pass. Some `docutils` errors were addressed by adding the type stubs as a dependency.

### Details

By default, pre-commit runs on _modified_ files only by passing the modified file names as command-line arguments. There is an escape-hatch though for this behavior by setting `pass_filenames: false` and specifying paths explicitly via `entry`. See https://github.com/pre-commit/pre-commit/issues/1519.

Any concerns about this being a slow and not recommended way of running this hook are not warranted in my view because `mypy` maintains its own cache, so once the cache is populated it runs quickly between successive calls to `pre-commit` despite running mypy on most of the project files.

EDIT: Corrected the resolved issue
