### PR TITLE
Pin numpy<2.0.0 in GeoVista integration test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -106,7 +106,7 @@ jobs:
           mkdir -p ${CARTOPY_SHARE_DIR}
           python cartopy_feature_download.py physical --output ${CARTOPY_SHARE_DIR} --no-warn
       - name: Pin NumPy version
-        run: pip install numpy<2.0.0
+        run: pip install "numpy<2.0.0"
       - run: pytest
         working-directory: geovista
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -105,6 +105,8 @@ jobs:
           wget --quiet ${CARTOPY_FEATURE}
           mkdir -p ${CARTOPY_SHARE_DIR}
           python cartopy_feature_download.py physical --output ${CARTOPY_SHARE_DIR} --no-warn
+      - name: Pin NumPy version
+        run: pip install numpy<2.0.0
       - run: pytest
         working-directory: geovista
 


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
- Currently, PyVista has not completed support for NumPy v2 (See #6280). Until support is completed, we will limit the version of NumPy used by GeoVista to <2.0.
- The GeoVista side will also need to be modified to support NumPy v2.0, but that should be done after the PyVista side has been modified.
- Even after PyVista's support is complete, it will take a while to make changes on the GeoVista side, so I decided to pin with this CI.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None
