### PR TITLE
Raise error when only one index is given in subplot

### DIFF
--- a/pyvista/plotting/renderers.py
+++ b/pyvista/plotting/renderers.py
@@ -362,6 +362,8 @@ class Renderers:
             self._active_index = index_row
             return
 
+        if index_column is None:
+            raise IndexError(f'Only one index is given for ({self.shape}).')
         if index_row < 0 or index_row >= self.shape[0]:
             raise IndexError(f'Row index is out of range ({self.shape[0]})')
         if index_column < 0 or index_column >= self.shape[1]:

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -547,3 +547,9 @@ def test_add_ruler_scale():
     min_, max_ = ruler.GetRange()
     assert min_ == 0.6
     assert max_ == 0.0
+
+
+def test_subplot_with_one_index():
+    pl = pv.Plotter(shape=(1, 2))
+    with pytest.raises(IndexError, match='Only one index is given'):
+        pl.subplot(0)


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
resolve #6306.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None