### PR TITLE
Remove unused `_new_attr_exceptions` from `Text3DSource`

### DIFF
--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -885,8 +885,6 @@ class Text3DSource(vtkVectorText):
         '_normal',
         '_process_empty_string',
         '_output',
-        '_extrude_filter',
-        '_tri_filter',
         '_modified',
     ]
 


### PR DESCRIPTION
### Overview

Follow-up from #6281, forgot to remove the no-longer-used attributes from `_new_attr_exceptions`.