### PR TITLE
Copy before unstructured grid clean

### DIFF
--- a/pyvista/core/filters/unstructured_grid.py
+++ b/pyvista/core/filters/unstructured_grid.py
@@ -145,7 +145,7 @@ class UnstructuredGridFilters(DataSetFilters):
             raise VTKVersionError("UnstructuredGrid.clean requires VTK >= 9.2.2") from None
 
         alg = vtkStaticCleanUnstructuredGrid()
-        alg.SetInputDataObject(self)
+        alg.SetInputDataObject(self.copy())
         alg.SetAbsoluteTolerance(True)
         alg.SetTolerance(tolerance)
         alg.SetMergingArray(merging_array_name)

--- a/pyvista/core/filters/unstructured_grid.py
+++ b/pyvista/core/filters/unstructured_grid.py
@@ -145,6 +145,7 @@ class UnstructuredGridFilters(DataSetFilters):
             raise VTKVersionError("UnstructuredGrid.clean requires VTK >= 9.2.2") from None
 
         alg = vtkStaticCleanUnstructuredGrid()
+        # https://github.com/pyvista/pyvista/pull/6337
         alg.SetInputDataObject(self.copy())
         alg.SetAbsoluteTolerance(True)
         alg.SetTolerance(tolerance)

--- a/tests/core/test_unstructured_grid_filters.py
+++ b/tests/core/test_unstructured_grid_filters.py
@@ -52,6 +52,7 @@ def test_clean_points():
 @skip_lesser_9_2_2
 def test_clean_grid(hexbeam):
     hexbeam_shifted = hexbeam.translate([1, 0, 0])
+
     hexbeam.point_data['data'] = np.zeros(hexbeam.n_points)
     hexbeam_shifted.point_data['data'] = np.ones(hexbeam.n_points)
     hexbeam_orig = hexbeam.copy()

--- a/tests/core/test_unstructured_grid_filters.py
+++ b/tests/core/test_unstructured_grid_filters.py
@@ -21,6 +21,7 @@ def test_clean_points():
     points = np.vstack([u_points] * 2)
 
     grid = pv.PolyData(points).cast_to_unstructured_grid()
+    grid_orig = grid.copy()  # ensure grid is not modified in-place
     grid.point_data['data'] = np.hstack((np.zeros(n_unique_points), np.ones(n_unique_points)))
 
     cleaned = grid.clean(produce_merge_map=True)
@@ -28,6 +29,7 @@ def test_clean_points():
     assert cleaned.n_points == n_unique_points
     assert np.allclose(cleaned.point_data['data'], 0.5)
     assert cleaned.point_data['data'].size == n_unique_points
+    assert grid_orig == grid
 
     # verify not averaging works
     cleaned = grid.clean(average_point_data=False)
@@ -43,11 +45,13 @@ def test_clean_points():
     grid = pv.PolyData(points).cast_to_unstructured_grid()
     cleaned = grid.clean(tolerance=1e-5)
     assert cleaned.n_points == points.shape[0]
+    assert grid_orig == grid
 
 
 @skip_lesser_9_2_2
 def test_clean_grid(hexbeam):
     hexbeam_shifted = hexbeam.translate([1, 0, 0])
+    hexbeam_orig = hexbeam.copy()
 
     hexbeam.point_data['data'] = np.zeros(hexbeam.n_points)
     hexbeam_shifted.point_data['data'] = np.ones(hexbeam.n_points)
@@ -55,6 +59,7 @@ def test_clean_grid(hexbeam):
     merged = hexbeam.merge(hexbeam_shifted, merge_points=False)
     cleaned = merged.clean(average_point_data=True, produce_merge_map=False)
     assert 'PointMergeMap' not in cleaned.field_data
+    assert hexbeam_orig == hexbeam
 
     # expect averaging for all merged nodes
     n_merged = merged.n_points - cleaned.n_points

--- a/tests/core/test_unstructured_grid_filters.py
+++ b/tests/core/test_unstructured_grid_filters.py
@@ -21,15 +21,15 @@ def test_clean_points():
     points = np.vstack([u_points] * 2)
 
     grid = pv.PolyData(points).cast_to_unstructured_grid()
-    grid_orig = grid.copy()  # ensure grid is not modified in-place
     grid.point_data['data'] = np.hstack((np.zeros(n_unique_points), np.ones(n_unique_points)))
+    grid_orig = grid.copy()  # ensure grid is not modified in-place
 
     cleaned = grid.clean(produce_merge_map=True)
+    assert grid_orig == grid
     assert cleaned.field_data['PointMergeMap'].size == points.shape[0]
     assert cleaned.n_points == n_unique_points
     assert np.allclose(cleaned.point_data['data'], 0.5)
     assert cleaned.point_data['data'].size == n_unique_points
-    assert grid_orig == grid
 
     # verify not averaging works
     cleaned = grid.clean(average_point_data=False)
@@ -43,6 +43,7 @@ def test_clean_points():
     points = np.vstack((u_points, u_points_shift))
 
     grid = pv.PolyData(points).cast_to_unstructured_grid()
+    grid_orig = grid.copy()
     cleaned = grid.clean(tolerance=1e-5)
     assert cleaned.n_points == points.shape[0]
     assert grid_orig == grid
@@ -51,10 +52,9 @@ def test_clean_points():
 @skip_lesser_9_2_2
 def test_clean_grid(hexbeam):
     hexbeam_shifted = hexbeam.translate([1, 0, 0])
-    hexbeam_orig = hexbeam.copy()
-
     hexbeam.point_data['data'] = np.zeros(hexbeam.n_points)
     hexbeam_shifted.point_data['data'] = np.ones(hexbeam.n_points)
+    hexbeam_orig = hexbeam.copy()
 
     merged = hexbeam.merge(hexbeam_shifted, merge_points=False)
     cleaned = merged.clean(average_point_data=True, produce_merge_map=False)


### PR DESCRIPTION
Resolve #6208 by copying the unstructured grid before cleaning it.

Turns out that ``vtkStaticCleanUnstructuredGrid`` modifies the connectivity of the input grid. From their [documentation](https://vtk.org/doc/nightly/html/classvtkStaticCleanUnstructuredGrid.html#details):

> The filter does not modify the topology of the input dataset, nor change the types of cells. It may however, renumber the cell connectivity id.

Therefore, to avoid side-effects, let's always copy the input grid when cleaning.

### Performance Considerations
Ideally we'd just shallow copy the input ``UnstructuredGrid`` and then deep copy the cells. However, there's an edge case where the input grid has polyhedral cells and we'd have to also code up that edge case. I'm leaning on the side of caution and just copying the entire input grid, especially as the copy operation is unlikely to be the long running operation.
