### PR TITLE
Revert "Pin numpy<2.0.0 in GeoVista integration test"

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -105,8 +105,6 @@ jobs:
           wget --quiet ${CARTOPY_FEATURE}
           mkdir -p ${CARTOPY_SHARE_DIR}
           python cartopy_feature_download.py physical --output ${CARTOPY_SHARE_DIR} --no-warn
-      - name: Pin NumPy version
-        run: pip install "numpy<2.0.0"
       - run: pytest
         working-directory: geovista
 


### PR DESCRIPTION
Now the `geovista` 0.5.1 is available, which includes the patch fix to resolve the failing `geovista` tests when using `numpy` 2.x, we can now undo #6292 :+1:


