### PR TITLE
Enable invalidating caches for documentation build with label from PR

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  USE_CACHE: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.cache == 'true') || (github.event_name == 'pull_request') || (github.event_name == 'push') }}
+  USE_CACHE: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.cache == 'true') || (github.event_name == 'pull_request' && ! contains(github.event.pull_request.labels.*.name, 'no-gallery-cache')) || (github.event_name == 'push') }}
   DOCUMENTATION_CNAME: "docs.pyvista.org"
   PYDEVD_DISABLE_FILE_VALIDATION: "1"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  USE_CACHE: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.cache == 'true') || (github.event_name == 'pull_request' && ! contains(github.event.pull_request.labels.*.name, 'no-gallery-cache')) || (github.event_name == 'push') }}
+  USE_CACHE: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.cache == 'true') || (github.event_name == 'pull_request') || (github.event_name == 'push') }}
   DOCUMENTATION_CNAME: "docs.pyvista.org"
   PYDEVD_DISABLE_FILE_VALIDATION: "1"
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Cache Sphinx-Gallery Examples
         uses: actions/cache@v4
-        if: env.USE_CACHE == 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/v')
+        if: env.USE_CACHE == 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/v') && (! github.event_name == 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'no-gallery-cache'))
         with:
           path: doc/source/examples/
           key: doc-examples-${{ hashFiles('pyvista/_version.py') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,14 +74,14 @@ jobs:
 
       - name: Cache example data
         uses: actions/cache@v4
-        if: env.USE_CACHE == 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/v')
+        if: env.USE_CACHE == 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/v')  && (! github.event_name == 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'no-example-data-cache'))
         with:
           path: ${{ env.PYVISTA_EXAMPLE_DATA_PATH }}
           key: example-data-1-${{ hashFiles('pyvista/_version.py') }}
 
       - name: Cache Sphinx build directory
         uses: actions/cache@v3
-        if: env.USE_CACHE == 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/v')
+        if: env.USE_CACHE == 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/v')  && (! github.event_name == 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'no-sphinx-build-cache'))
         with:
           path: doc/_build/
           key: doc-examples-${{ hashFiles('pyvista/_version.py') }}

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -875,6 +875,20 @@ is successful.
    `Notes Regarding Image Regression Testing`_ for testing methods which should
    be considered first.
 
+Controlling Cache for CI Documentation Build
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To reduce build times of the documentation for PRs, cached sphinx gallery, example data, and sphinx build directories
+are used in the CI on GitHub.  In some cases, the caching action can cause problems for a specific
+PR.  To invalidate a cache for a specific PR, one of the following labels can be applied to the PR.
+
+- ``no-example-data-cache``
+- ``no-gallery-cache``
+- ``no-sphinx-build-cache``
+
+The PR either needs a new commit, e.g. updating the branch from ``main``, or to be closed/re-opened to
+rerun the CI with the labels applied.
+
 
 Contributing to the Documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
### Overview

See discussion in https://github.com/pyvista/pyvista/pull/6380#issuecomment-2228812354.  Sometimes we need to invalidate the cache on a case by case basis.  With image regression testing for documentation, this has become even more important.
