### PR TITLE
Replace type alias `BoundsLike` with named tuple `BoundsTuple`

### DIFF
--- a/doc/source/api/core/typing.rst
+++ b/doc/source/api/core/typing.rst
@@ -41,7 +41,7 @@ VTK Related Types
 -----------------
 
 pyvista.BoundsTuple
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 .. currentmodule:: pyvista
 

--- a/doc/source/api/core/typing.rst
+++ b/doc/source/api/core/typing.rst
@@ -40,12 +40,12 @@ pyvista.VectorLike
 VTK Related Types
 -----------------
 
-pyvista.BoundsLike
+pyvista.BoundsTuple
 ~~~~~~~~~~~~~~~~~~
 
 .. currentmodule:: pyvista
 
-.. autodata:: BoundsLike
+.. autodata:: BoundsTuple
 
 pyvista.CellsLike
 ~~~~~~~~~~~~~~~~~

--- a/doc/source/api/core/typing.rst
+++ b/doc/source/api/core/typing.rst
@@ -45,7 +45,7 @@ pyvista.BoundsTuple
 
 .. currentmodule:: pyvista
 
-.. autodata:: BoundsTuple
+.. autoclass:: BoundsTuple
 
 pyvista.CellsLike
 ~~~~~~~~~~~~~~~~~

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -91,6 +91,7 @@ extensions = [
     "sphinx_tags",
     "sphinx_toolbox.more_autodoc.overloads",
     "sphinx_toolbox.more_autodoc.typevars",
+    "sphinx_toolbox.more_autodoc.autonamedtuple",
 ]
 
 # Configuration of pyvista.ext.coverage

--- a/examples/01-filter/slicing.py
+++ b/examples/01-filter/slicing.py
@@ -91,7 +91,7 @@ def path(y):
     return x, y
 
 
-x, y = path(np.arange(model.bounds[2], model.bounds[3], 15.0))
+x, y = path(np.arange(model.bounds.y_min, model.bounds.y_max, 15.0))
 zo = np.linspace(9.0, 11.0, num=len(y))
 points = np.c_[x, y, zo]
 spline = pv.Spline(points, 15)

--- a/examples/02-plot/bounds.py
+++ b/examples/02-plot/bounds.py
@@ -57,9 +57,10 @@ central_gear = split_gears.pop(1)
 central_gear.translate([0, 60, 60], inplace=True)
 
 # also, grab the size of the central gear
-x_size = central_gear.bounds[1] - central_gear.bounds[0]
-y_size = central_gear.bounds[3] - central_gear.bounds[2]
-z_size = central_gear.bounds[5] - central_gear.bounds[4]
+bnds = central_gear.bounds
+x_size = bnds.x_max - bnds.x_min
+y_size = bnds.y_max - bnds.y_min
+z_size = bnds.z_max - bnds.z_min
 
 plotter = pv.Plotter()
 plotter.add_mesh(split_gears, smooth_shading=True, split_sharp_edges=True)

--- a/examples/02-plot/plot-over-circular-arc.py
+++ b/examples/02-plot/plot-over-circular-arc.py
@@ -28,8 +28,9 @@ mesh['height'] = mesh.points[:, 2]
 # Make two points at the bounds of the mesh and one at the center to
 # construct a circular arc.
 normal = [0, 1, 0]
-polar = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[5]]
-center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
+bnds = mesh.bounds
+polar = [bnds.x_min, bnds.y_min, bnds.z_max]
+center = [bnds.x_min, bnds.y_min, bnds.z_min]
 angle = 90.0
 
 # Preview how this circular arc intersects this mesh

--- a/examples/02-plot/plot-over-line.py
+++ b/examples/02-plot/plot-over-line.py
@@ -26,8 +26,8 @@ PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True
 mesh = examples.download_kitchen()
 
 # Make two points to construct the line between
-a = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
-b = [mesh.bounds[1], mesh.bounds[3], mesh.bounds[5]]
+a = [mesh.bounds.x_min, mesh.bounds.y_min, mesh.bounds.z_min]
+b = [mesh.bounds.x_max, mesh.bounds.y_max, mesh.bounds.z_max]
 
 # Preview how this line intersects this mesh
 line = pv.Line(a, b)
@@ -50,8 +50,8 @@ mesh.plot_over_line(a, b, resolution=100)
 mesh = examples.download_st_helens()
 
 # Make two points to construct the line between
-a = [mesh.center[0], mesh.bounds[2], mesh.bounds[5]]
-b = [mesh.center[0], mesh.bounds[3], mesh.bounds[5]]
+a = [mesh.center[0], mesh.bounds.y_min, mesh.bounds.z_max]
+b = [mesh.center[0], mesh.bounds.y_max, mesh.bounds.z_max]
 
 # Preview how this line intersects this mesh
 line = pv.Line(a, b)

--- a/examples/04-lights/shadows.py
+++ b/examples/04-lights/shadows.py
@@ -50,8 +50,7 @@ rnge = (bnds.x_max - bnds.x_min, bnds.y_max - bnds.y_min, bnds.z_max - bnds.z_mi
 expand = 1.0
 height = rnge[2] * 0.05
 center = np.array(mesh.center)
-center -= [0, 0, mesh.center[2] - bnds.y_max + height / 2]
-
+center -= [0, 0, mesh.center[2] - bnds.z_min + height / 2]
 width = rnge[0] * (1 + expand)
 length = rnge[1] * (1 + expand)
 base_mesh = pyvista.Cube(center, width, length, height)

--- a/examples/04-lights/shadows.py
+++ b/examples/04-lights/shadows.py
@@ -44,13 +44,13 @@ light2 = pyvista.Light(
 )
 
 # Add a thin box below the mesh
-bounds = mesh.bounds
-rnge = (bounds[1] - bounds[0], bounds[3] - bounds[2], bounds[5] - bounds[4])
+bnds = mesh.bounds
+rnge = (bnds.x_max - bnds.x_min, bnds.y_max - bnds.y_min, bnds.z_max - bnds.z_min)
 
 expand = 1.0
 height = rnge[2] * 0.05
 center = np.array(mesh.center)
-center -= [0, 0, mesh.center[2] - bounds[4] + height / 2]
+center -= [0, 0, mesh.center[2] - bnds.y_max + height / 2]
 
 width = rnge[0] * (1 + expand)
 length = rnge[1] * (1 + expand)

--- a/pyvista/core/_typing_core/__init__.py
+++ b/pyvista/core/_typing_core/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from ._aliases import ArrayLike  # noqa: F401
-from ._aliases import BoundsLike  # noqa: F401
+from ._aliases import BoundsTuple  # noqa: F401
 from ._aliases import CellArrayLike  # noqa: F401
 from ._aliases import CellsLike  # noqa: F401
 from ._aliases import MatrixLike  # noqa: F401

--- a/pyvista/core/_typing_core/_aliases.py
+++ b/pyvista/core/_typing_core/_aliases.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import contextlib
-from typing import Tuple
+from typing import NamedTuple
 from typing import Union
 
 from pyvista.core import _vtk_core as _vtk
@@ -58,11 +58,20 @@ TransformLike.__doc__ = """Array or object representing a spatial transformation
 
 Includes 3x3 and 4x4 arrays as well as SciPy Rotation objects."""
 
-BoundsLike = Tuple[Number, Number, Number, Number, Number, Number]
-BoundsLike.__doc__ = """Tuple of six values representing 3D bounds.
 
-Has the form (``xmin``, ``xmax``, ``ymin``, ``ymax``, ``zmin``, ``zmax``).
-"""
+class BoundsTuple(NamedTuple):
+    """Tuple of six values representing 3D bounds.
+
+    Has the form (``x_min``, ``x_max``, ``y_min``, ``y_max``, ``z_min``, ``z_max``).
+    """
+
+    x_min: float
+    x_max: float
+    y_min: float
+    y_max: float
+    z_min: float
+    z_max: float
+
 
 CellsLike = Union[MatrixLike[int], VectorLike[int]]
 

--- a/pyvista/core/_typing_core/_aliases.py
+++ b/pyvista/core/_typing_core/_aliases.py
@@ -62,7 +62,7 @@ Includes 3x3 and 4x4 arrays as well as SciPy Rotation objects."""
 class BoundsTuple(NamedTuple):
     """Tuple of six values representing 3D bounds.
 
-    Has the form (``x_min``, ``x_max``, ``y_min``, ``y_max``, ``z_min``, ``z_max``).
+    Has the form ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
     """
 
     x_min: float

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -493,7 +493,7 @@ class Cell(DataObject, _vtk.vtkGenericCell):
         >>> import pyvista as pv
         >>> mesh = pv.Sphere()
         >>> mesh.get_cell(0).bounds
-        (0.0, 0.05405950918793678, 0.0, 0.011239604093134403, 0.49706897139549255, 0.5)
+        BoundsTuple(x_min=0.0, x_max=0.05405950918793678, y_min=0.0, y_max=0.011239604093134403, z_min=0.49706897139549255, z_max=0.5)
 
         """
         return BoundsTuple(*self.GetBounds())

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -12,6 +12,7 @@ import numpy as np
 import pyvista
 
 from . import _vtk_core as _vtk
+from ._typing_core import BoundsTuple
 from .celltype import CellType
 from .dataset import DataObject
 from .errors import CellSizeError
@@ -479,13 +480,13 @@ class Cell(DataObject, _vtk.vtkGenericCell):
         return Cell(cell, deep=True, cell_type=cell.GetCellType())
 
     @property
-    def bounds(self) -> tuple[float, float, float, float, float, float]:
-        """Get the cell bounds in ``[xmin, xmax, ymin, ymax, zmin, zmax]``.
+    def bounds(self) -> BoundsTuple:
+        """Get the cell bounds in ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
         Returns
         -------
-        tuple[float, float, float, float, float, float]
-            The cell bounds in ``[xmin, xmax, ymin, ymax, zmin, zmax]``.
+        BoundsTuple
+            The cell bounds in ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
         Examples
         --------
@@ -495,7 +496,7 @@ class Cell(DataObject, _vtk.vtkGenericCell):
         (0.0, 0.05405950918793678, 0.0, 0.011239604093134403, 0.49706897139549255, 0.5)
 
         """
-        return self.GetBounds()
+        return BoundsTuple(*self.GetBounds())
 
     @property
     def center(self) -> tuple[float, float, float]:

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -22,9 +22,9 @@ import pyvista
 from pyvista.core import _validation
 
 from . import _vtk_core as _vtk
+from ._typing_core import BoundsTuple
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ._typing_core import BoundsLike
     from ._typing_core import NumpyArray
 from .dataset import DataObject
 from .dataset import DataSet
@@ -172,7 +172,7 @@ class MultiBlock(
                 self.SetBlock(i, wrap(block))
 
     @property
-    def bounds(self) -> BoundsLike:
+    def bounds(self) -> BoundsTuple:
         """Find min/max for bounds across blocks.
 
         Returns
@@ -200,14 +200,14 @@ class MultiBlock(
         all_bounds = [cast(List[float], block.bounds) for block in self if block]
         # edge case where block has no bounds
         if not all_bounds:  # pragma: no cover
-            minima = np.array([0.0, 0.0, 0.0])
-            maxima = np.array([0.0, 0.0, 0.0])
+            minima = (0.0, 0.0, 0.0)
+            maxima = (0.0, 0.0, 0.0)
         else:
             minima = np.minimum.reduce(all_bounds)[::2].tolist()
             maxima = np.maximum.reduce(all_bounds)[1::2].tolist()
 
         # interleave minima and maxima for bounds
-        return (minima[0], maxima[0], minima[1], maxima[1], minima[2], maxima[2])
+        return BoundsTuple(minima[0], maxima[0], minima[1], maxima[1], minima[2], maxima[2])
 
     @property
     def center(self) -> NumpyArray[float]:

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -192,7 +192,7 @@ class MultiBlock(
         ... ]
         >>> blocks = pv.MultiBlock(data)
         >>> blocks.bounds
-        (-0.5, 2.5, -0.5, 2.5, -0.5, 0.5)
+        BoundsTuple(x_min=-0.5, x_max=2.5, y_min=-0.5, y_max=2.5, z_min=-0.5, z_max=0.5)
 
         """
         # apply reduction of min and max over each block

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1747,7 +1747,7 @@ class DataSet(DataSetFilters, DataObject):
         >>> import pyvista as pv
         >>> cube = pv.Cube()
         >>> cube.bounds
-        (-0.5, 0.5, -0.5, 0.5, -0.5, 0.5)
+        BoundsTuple(x_min=-0.5, x_max=0.5, y_min=-0.5, y_max=0.5, z_min=-0.5, z_max=0.5)
 
         """
         return BoundsTuple(*self.GetBounds())
@@ -3349,7 +3349,7 @@ class DataSet(DataSetFilters, DataObject):
         >>> from pyvista import examples
         >>> mesh = examples.load_hexbeam()
         >>> mesh.get_cell(0).bounds
-        (0.0, 0.5, 0.0, 0.5, 0.0, 0.5)
+        BoundsTuple(x_min=0.0, x_max=0.5, y_min=0.0, y_max=0.5, z_min=0.0, z_max=0.5)
         >>> mesh.point_is_inside_cell(0, [0.2, 0.2, 0.2])
         True
 

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -18,11 +18,7 @@ import numpy as np
 import pyvista
 
 from . import _vtk_core as _vtk
-from ._typing_core import BoundsLike
-from ._typing_core import MatrixLike
-from ._typing_core import Number
-from ._typing_core import NumpyArray
-from ._typing_core import VectorLike
+from ._typing_core import BoundsTuple
 from .dataobject import DataObject
 from .datasetattributes import DataSetAttributes
 from .errors import PyVistaDeprecationWarning
@@ -46,6 +42,11 @@ if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Callable
     from collections.abc import Generator
     from collections.abc import Iterator
+
+    from ._typing_core import MatrixLike
+    from ._typing_core import Number
+    from ._typing_core import NumpyArray
+    from ._typing_core import VectorLike
 
 # vector array names
 DEFAULT_VECTOR_KEY = '_vectors'
@@ -1730,14 +1731,14 @@ class DataSet(DataSetFilters, DataObject):
         return self.GetNumberOfCells()
 
     @property
-    def bounds(self) -> BoundsLike:
+    def bounds(self) -> BoundsTuple:
         """Return the bounding box of this dataset.
 
         Returns
         -------
         BoundsLike
             Bounding box of this dataset.
-            The form is: ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+            The form is: ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
         Examples
         --------
@@ -1749,7 +1750,7 @@ class DataSet(DataSetFilters, DataObject):
         (-0.5, 0.5, -0.5, 0.5, -0.5, 0.5)
 
         """
-        return cast(BoundsLike, self.GetBounds())
+        return BoundsTuple(*self.GetBounds())
 
     @property
     def length(self) -> float:
@@ -2706,13 +2707,13 @@ class DataSet(DataSetFilters, DataObject):
         )
         return vtk_id_list_to_array(id_list)
 
-    def find_cells_within_bounds(self, bounds: BoundsLike) -> NumpyArray[int]:
+    def find_cells_within_bounds(self, bounds: BoundsTuple) -> NumpyArray[int]:
         """Find the index of cells in this mesh within bounds.
 
         Parameters
         ----------
         bounds : sequence[float]
-            Bounding box. The form is: ``[xmin, xmax, ymin, ymax, zmin, zmax]``.
+            Bounding box. The form is: ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
         Returns
         -------

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -311,7 +311,7 @@ class DataSetFilters:
         Parameters
         ----------
         bounds : sequence[float], optional
-            Length 6 sequence of floats: ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+            Length 6 sequence of floats: ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
             Length 3 sequence of floats: distances from the min coordinate of
             of the input mesh. Single float value: uniform distance from the
             min coordinate. Length 12 sequence of length 3 sequence of floats:
@@ -1531,7 +1531,7 @@ class DataSetFilters:
         Parameters
         ----------
         extent : sequence[float], optional
-            Specify a ``(xmin, xmax, ymin, ymax, zmin, zmax)`` bounding box to
+            Specify a ``(x_min, x_max, y_min, y_max, z_min, z_max)`` bounding box to
             clip data.
 
         progress_bar : bool, default: False
@@ -1716,10 +1716,10 @@ class DataSetFilters:
         # Fix the projection line:
         if low_point is None:
             low_point = list(self.center)
-            low_point[2] = self.bounds[4]
+            low_point[2] = self.bounds.z_min
         if high_point is None:
             high_point = list(self.center)
-            high_point[2] = self.bounds[5]
+            high_point[2] = self.bounds.z_max
         # Fix scalar_range:
         if scalar_range is None:
             scalar_range = (low_point[2], high_point[2])
@@ -4630,19 +4630,19 @@ class DataSetFilters:
         >>> uniform = examples.load_uniform()
         >>> uniform["height"] = uniform.points[:, 2]
         >>> pointa = [
-        ...     uniform.bounds[1],
-        ...     uniform.bounds[2],
-        ...     uniform.bounds[5],
+        ...     uniform.bounds.x_max,
+        ...     uniform.bounds.y_min,
+        ...     uniform.bounds.z_max,
         ... ]
         >>> pointb = [
-        ...     uniform.bounds[1],
-        ...     uniform.bounds[3],
-        ...     uniform.bounds[4],
+        ...     uniform.bounds.x_max,
+        ...     uniform.bounds.y_max,
+        ...     uniform.bounds.z_min,
         ... ]
         >>> center = [
-        ...     uniform.bounds[1],
-        ...     uniform.bounds[2],
-        ...     uniform.bounds[4],
+        ...     uniform.bounds.x_max,
+        ...     uniform.bounds.y_min,
+        ...     uniform.bounds.z_min,
         ... ]
         >>> sampled_arc = uniform.sample_over_circular_arc(
         ...     pointa, pointb, center
@@ -4721,9 +4721,9 @@ class DataSetFilters:
         >>> normal = [0, 0, 1]
         >>> polar = [0, 9, 0]
         >>> center = [
-        ...     uniform.bounds[1],
-        ...     uniform.bounds[2],
-        ...     uniform.bounds[5],
+        ...     uniform.bounds.x_max,
+        ...     uniform.bounds.y_min,
+        ...     uniform.bounds.z_max,
         ... ]
         >>> arc = uniform.sample_over_circular_arc_normal(
         ...     center, normal=normal, polar=polar
@@ -4821,9 +4821,13 @@ class DataSetFilters:
 
         >>> from pyvista import examples
         >>> mesh = examples.load_uniform()
-        >>> a = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[5]]
-        >>> b = [mesh.bounds[1], mesh.bounds[2], mesh.bounds[4]]
-        >>> center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
+        >>> a = [mesh.bounds.x_min, mesh.bounds.y_min, mesh.bounds.z_max]
+        >>> b = [mesh.bounds.x_max, mesh.bounds.y_min, mesh.bounds.z_min]
+        >>> center = [
+        ...     mesh.bounds.x_min,
+        ...     mesh.bounds.y_min,
+        ...     mesh.bounds.z_min,
+        ... ]
         >>> mesh.plot_over_circular_arc(
         ...     a, b, center, resolution=1000, show=False
         ... )  # doctest:+SKIP
@@ -4955,7 +4959,11 @@ class DataSetFilters:
         >>> normal = normal = [0, 0, 1]
         >>> polar = [0, 9, 0]
         >>> angle = 90
-        >>> center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
+        >>> center = [
+        ...     mesh.bounds.x_min,
+        ...     mesh.bounds.y_min,
+        ...     mesh.bounds.z_min,
+        ... ]
         >>> mesh.plot_over_circular_arc_normal(
         ...     center, polar=polar, angle=angle
         ... )  # doctest:+SKIP

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -210,7 +210,7 @@ class ImageDataFilters(DataSetFilters):
         Parameters
         ----------
         voi : sequence[int]
-            Length 6 iterable of ints: ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+            Length 6 iterable of ints: ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
             These bounds specify the volume of interest in i-j-k min/max
             indices.
 

--- a/pyvista/core/filters/structured_grid.py
+++ b/pyvista/core/filters/structured_grid.py
@@ -31,7 +31,7 @@ class StructuredGridFilters(DataSetFilters):
         Parameters
         ----------
         voi : sequence[int]
-            Length 6 iterable of ints: ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+            Length 6 iterable of ints: ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
             These bounds specify the volume of interest in i-j-k min/max
             indices.
 

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -866,7 +866,7 @@ class ImageData(Grid, ImageDataFilters, _vtk.vtkImageData):
         use default spacing of 1 here, the bounds match the extent exactly.
 
         >>> grid.bounds
-        (2.0, 5.0, 2.0, 5.0, 2.0, 5.0)
+        BoundsTuple(x_min=2.0, x_max=5.0, y_min=2.0, y_max=5.0, z_min=2.0, z_max=5.0)
         >>> grid.dimensions
         (4, 4, 4)
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -3055,10 +3055,10 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
         >>> grid = examples.load_explicit_structured()
         >>> grid = grid.hide_cells(range(80, 120))
         >>> grid.bounds
-        (0.0, 80.0, 0.0, 50.0, 0.0, 6.0)
+        BoundsTuple(x_min=0.0, x_max=80.0, y_min=0.0, y_max=50.0, z_min=0.0, z_max=6.0)
 
         >>> grid.visible_bounds
-        (0.0, 80.0, 0.0, 50.0, 0.0, 4.0)
+        BoundsTuple(x_min=0.0, x_max=80.0, y_min=0.0, y_max=50.0, z_min=0.0, z_max=4.0)
 
         """
         name = _vtk.vtkDataSetAttributes.GhostArrayName()

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -45,7 +45,7 @@ from .utilities.points import vtk_points
 
 if TYPE_CHECKING:  # pragma: no cover
     from ._typing_core import ArrayLike
-    from ._typing_core import BoundsLike
+    from ._typing_core import BoundsTuple
     from ._typing_core import CellArrayLike
     from ._typing_core import MatrixLike
     from ._typing_core import NumpyArray
@@ -3035,7 +3035,7 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
         return self._dimensions()
 
     @property
-    def visible_bounds(self) -> BoundsLike:  # numpydoc ignore=RT01
+    def visible_bounds(self) -> BoundsTuple:  # numpydoc ignore=RT01
         """Return the bounding box of the visible cells.
 
         Different from `bounds`, which returns the bounding box of the

--- a/pyvista/core/utilities/features.py
+++ b/pyvista/core/utilities/features.py
@@ -547,7 +547,7 @@ def sample_function(
     bounds : sequence[float], default: (-1.0, 1.0, -1.0, 1.0, -1.0, 1.0)
         Specify the bounds in the format of:
 
-        - ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+        - ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
     dim : sequence[float], default: (50, 50, 50)
         Dimensions of the data on which to sample in the format of

--- a/pyvista/core/utilities/geometric_objects.py
+++ b/pyvista/core/utilities/geometric_objects.py
@@ -1212,7 +1212,7 @@ def Cube(
 
     bounds : sequence[float], optional
         Specify the bounding box of the cube. If given, all other size
-        arguments are ignored. ``(xMin, xMax, yMin, yMax, zMin, zMax)``.
+        arguments are ignored. ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
     clean : bool, default: True
         Whether to clean the raw points of the mesh, making the cube
@@ -1269,7 +1269,7 @@ def Box(bounds=(-1.0, 1.0, -1.0, 1.0, -1.0, 1.0), level=0, quads=True):
     ----------
     bounds : sequence[float], default: (-1.0, 1.0, -1.0, 1.0, -1.0, 1.0)
         Specify the bounding box of the cube.
-        ``(xMin, xMax, yMin, yMax, zMin, zMax)``.
+        ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
     level : int, default: 0
         Level of subdivision of the faces.

--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -21,6 +21,7 @@ from vtkmodules.vtkRenderingFreeType import vtkVectorText
 import pyvista
 from pyvista.core import _validation
 from pyvista.core import _vtk_core as _vtk
+from pyvista.core._typing_core import BoundsTuple
 from pyvista.core.utilities.arrays import _coerce_pointslike_arg
 from pyvista.core.utilities.helpers import wrap
 from pyvista.core.utilities.misc import _check_range
@@ -30,7 +31,6 @@ from pyvista.core.utilities.misc import no_new_attr
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Sequence
 
-    from pyvista.core._typing_core import BoundsLike
     from pyvista.core._typing_core import MatrixLike
     from pyvista.core._typing_core import NumpyArray
     from pyvista.core._typing_core import VectorLike
@@ -1074,7 +1074,11 @@ class Text3DSource(vtkVectorText):
 
         # Scale mesh
         bnds = out.bounds
-        size_w, size_h, size_d = bnds[1] - bnds[0], bnds[3] - bnds[2], bnds[5] - bnds[4]
+        size_w, size_h, size_d = (
+            bnds.x_max - bnds.x_min,
+            bnds.y_max - bnds.y_min,
+            bnds.z_max - bnds.z_min,
+        )
         scale_w, scale_h, scale_d = _reciprocal((size_w, size_h, size_d))
 
         # Scale width and height first
@@ -1146,7 +1150,7 @@ class CubeSource(_vtk.vtkCubeSource):
 
     bounds : sequence[float], optional
         Specify the bounding box of the cube. If given, all other size
-        arguments are ignored. ``(xMin, xMax, yMin, yMax, zMin, zMax)``.
+        arguments are ignored. ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
     point_dtype : str, default: 'float32'
         Set the desired output point types. It must be either 'float32' or 'float64'.
@@ -1188,17 +1192,18 @@ class CubeSource(_vtk.vtkCubeSource):
         self.point_dtype = point_dtype
 
     @property
-    def bounds(self) -> BoundsLike:  # numpydoc ignore=RT01
+    def bounds(self) -> BoundsTuple:  # numpydoc ignore=RT01
         """Return or set the bounding box of the cube."""
-        return self._bounds
+        bnds = [0] * 6
+        self.GetBounds(bnds)
+        return BoundsTuple(*bnds)
 
     @bounds.setter
-    def bounds(self, bounds: BoundsLike):  # numpydoc ignore=GL08
+    def bounds(self, bounds: VectorLike[float]):  # numpydoc ignore=GL08
         if np.array(bounds).size != 6:
             raise TypeError(
-                'Bounds must be given as length 6 tuple: (xMin, xMax, yMin, yMax, zMin, zMax)',
+                'Bounds must be given as length 6 tuple: (x_min, x_max, y_min, y_max, z_min, z_max)',
             )
-        self._bounds = bounds
         self.SetBounds(bounds)
 
     @property
@@ -2552,7 +2557,7 @@ class BoxSource(_vtk.vtkTessellatedBoxSource):
     ----------
     bounds : sequence[float], default: (-1.0, 1.0, -1.0, 1.0, -1.0, 1.0)
         Specify the bounding box of the cube.
-        ``(xMin, xMax, yMin, yMax, zMin, zMax)``.
+        ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
     level : int, default: 0
         Level of subdivision of the faces.
@@ -2576,17 +2581,19 @@ class BoxSource(_vtk.vtkTessellatedBoxSource):
         self.quads = quads
 
     @property
-    def bounds(self) -> BoundsLike:  # numpydoc ignore=RT01
+    def bounds(self) -> BoundsTuple:  # numpydoc ignore=RT01
         """Return or set the bounding box of the cube."""
         return self._bounds
 
     @bounds.setter
-    def bounds(self, bounds: BoundsLike):  # numpydoc ignore=GL08
+    def bounds(self, bounds: VectorLike[float]):  # numpydoc ignore=GL08
+        bounds_array = np.array(bounds, dtype=float)
         if np.array(bounds).size != 6:
             raise TypeError(
-                'Bounds must be given as length 6 tuple: (xMin, xMax, yMin, yMax, zMin, zMax)',
+                'Bounds must be given as length 6 tuple: (x_min, x_max, y_min, y_max, z_min, z_max)',
             )
-        self._bounds = bounds
+        bounds_tuple = BoundsTuple(*bounds_array.tolist())
+        self._bounds = bounds_tuple
         self.SetBounds(bounds)
 
     @property
@@ -3487,7 +3494,9 @@ class AxesGeometrySource:
 
         # Scale so bounding box edges have length one
         bnds = part.bounds
-        axis_length = np.array((bnds[1] - bnds[0], bnds[3] - bnds[2], bnds[5] - bnds[4]))
+        axis_length = np.array(
+            (bnds.x_max - bnds.x_min, bnds.y_max - bnds.y_min, bnds.z_max - bnds.z_min)
+        )
         if np.any(axis_length < 1e-8):
             raise ValueError(f"Custom axes part must be 3D. Got bounds: {bnds}.")
         part.scale(np.reciprocal(axis_length), inplace=True)
@@ -3515,7 +3524,7 @@ class OrthogonalPlanesSource:
     Parameters
     ----------
     bounds : VectorLike[float], default: (-1.0, 1.0, -1.0, 1.0, -1.0, 1.0)
-        Specify the bounds of the planes in the form: ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+        Specify the bounds of the planes in the form: ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
         The generated planes are centered in these bounds.
 
     resolution : int | VectorLike[int], default: 2
@@ -3605,15 +3614,16 @@ class OrthogonalPlanesSource:
         )
 
     @property
-    def bounds(self) -> BoundsLike:  # numpydoc ignore=RT01
+    def bounds(self) -> BoundsTuple:  # numpydoc ignore=RT01
         """Return or set the bounds of the planes."""
         return self._bounds
 
     @bounds.setter
-    def bounds(self, bounds: BoundsLike):  # numpydoc ignore=GL08
-        self._bounds = _validation.validate_array(
+    def bounds(self, bounds: BoundsTuple):  # numpydoc ignore=GL08
+        bounds_tuple = _validation.validate_array(
             bounds, dtype_out=float, must_have_length=6, to_tuple=True, name='bounds'
         )
+        self._bounds = BoundsTuple(*bounds_tuple)
 
     @property
     def names(self) -> tuple[str, str, str]:  # numpydoc ignore=RT01

--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -2556,7 +2556,7 @@ class BoxSource(_vtk.vtkTessellatedBoxSource):
     Parameters
     ----------
     bounds : sequence[float], default: (-1.0, 1.0, -1.0, 1.0, -1.0, 1.0)
-        Specify the bounding box of the cube.
+        Specify the bounds of the box.
         ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
     level : int, default: 0
@@ -2582,18 +2582,15 @@ class BoxSource(_vtk.vtkTessellatedBoxSource):
 
     @property
     def bounds(self) -> BoundsTuple:  # numpydoc ignore=RT01
-        """Return or set the bounding box of the cube."""
-        return self._bounds
+        """Return or set the bounding box of the box."""
+        return BoundsTuple(*self.GetBounds())
 
     @bounds.setter
     def bounds(self, bounds: VectorLike[float]):  # numpydoc ignore=GL08
-        bounds_array = np.array(bounds, dtype=float)
         if np.array(bounds).size != 6:
             raise TypeError(
                 'Bounds must be given as length 6 tuple: (x_min, x_max, y_min, y_max, z_min, z_max)',
             )
-        bounds_tuple = BoundsTuple(*bounds_array.tolist())
-        self._bounds = bounds_tuple
         self.SetBounds(bounds)
 
     @property

--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -3112,7 +3112,7 @@ class AxesGeometrySource:
         ...     symmetric_bounds=True
         ... )
         >>> axes_geometry_source.output.bounds
-        (-1.0, 1.0, -1.0, 1.0, -1.0, 1.0)
+        BoundsTuple(x_min=-1.0, x_max=1.0, y_min=-1.0, y_max=1.0, z_min=-1.0, z_max=1.0)
 
         >>> axes_geometry_source.output.center
         array([0.0, 0.0, 0.0])
@@ -3121,7 +3121,7 @@ class AxesGeometrySource:
 
         >>> axes_geometry_source.symmetric_bounds = False
         >>> axes_geometry_source.output.bounds
-        (-0.10000000149011612, 1.0, -0.10000000149011612, 1.0, -0.10000000149011612, 1.0)
+        BoundsTuple(x_min=-0.10000000149011612, x_max=1.0, y_min=-0.10000000149011612, y_max=1.0, z_min=-0.10000000149011612, z_max=1.0)
 
         >>> axes_geometry_source.output.center
         array([0.45, 0.45, 0.45])

--- a/pyvista/core/utilities/helpers.py
+++ b/pyvista/core/utilities/helpers.py
@@ -275,7 +275,7 @@ def is_inside_bounds(point, bounds):
         Three item cartesian point (i.e. ``[x, y, z]``).
 
     bounds : sequence[float]
-        Six item bounds in the form of ``(xMin, xMax, yMin, yMax, zMin, zMax)``.
+        Six item bounds in the form of ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
     Returns
     -------

--- a/pyvista/core/utilities/points.py
+++ b/pyvista/core/utilities/points.py
@@ -283,8 +283,8 @@ def fit_plane_to_points(points, return_meta=False):
     projected.transform(rotate_transform)
 
     # Compute size of the plane
-    i_size = projected.bounds[1] - projected.bounds[0]
-    j_size = projected.bounds[3] - projected.bounds[2]
+    i_size = projected.bounds.x_max - projected.bounds.x_min
+    j_size = projected.bounds.y_max - projected.bounds.y_min
 
     # The center of the input data does not necessarily coincide with
     # the center of the plane. The true center of the plane is the

--- a/pyvista/plotting/_typing.py
+++ b/pyvista/plotting/_typing.py
@@ -8,7 +8,7 @@ from typing import Sequence
 from typing import Tuple
 from typing import Union
 
-from pyvista.core._typing_core import BoundsLike  # noqa: F401
+from pyvista.core._typing_core import BoundsTuple  # noqa: F401
 from pyvista.core._typing_core import Number  # noqa: F401
 from pyvista.core._typing_core import NumpyArray
 

--- a/pyvista/plotting/axes_assembly.py
+++ b/pyvista/plotting/axes_assembly.py
@@ -14,7 +14,7 @@ from typing import TypedDict
 import numpy as np
 
 import pyvista as pv
-from pyvista import BoundsLike
+from pyvista import BoundsTuple
 from pyvista.core import _validation
 from pyvista.core.utilities.geometric_sources import AxesGeometrySource
 from pyvista.core.utilities.geometric_sources import OrthogonalPlanesSource
@@ -172,8 +172,8 @@ class _XYZAssembly(_Prop3DMixin, _vtk.vtkPropAssembly):
             ):
                 part.user_matrix = new_matrix
 
-    def _get_bounds(self) -> BoundsLike:  # numpydoc ignore=RT01
-        return self.GetBounds()
+    def _get_bounds(self) -> BoundsTuple:  # numpydoc ignore=RT01
+        return BoundsTuple(*self.GetBounds())
 
     @property
     def show_labels(self) -> bool:  # numpydoc ignore=RT01
@@ -518,9 +518,9 @@ class AxesAssembly(_XYZAssembly):
             f"  Origin:                     {self.origin}",
             f"  Scale:                      {self.scale}",
             f"  User matrix:                {mat_info}",
-            f"  X Bounds                    {bnds[0]:.3E}, {bnds[1]:.3E}",
-            f"  Y Bounds                    {bnds[2]:.3E}, {bnds[3]:.3E}",
-            f"  Z Bounds                    {bnds[4]:.3E}, {bnds[5]:.3E}",
+            f"  X Bounds                    {bnds.x_min:.3E}, {bnds.x_max:.3E}",
+            f"  Y Bounds                    {bnds.y_min:.3E}, {bnds.y_max:.3E}",
+            f"  Z Bounds                    {bnds.z_min:.3E}, {bnds.z_max:.3E}",
         ]
         return '\n'.join(attr)
 
@@ -1565,9 +1565,9 @@ class PlanesAssembly(_XYZAssembly):
             f"  Origin:                     {self.origin}",
             f"  Scale:                      {self.scale}",
             f"  User matrix:                {mat_info}",
-            f"  X Bounds                    {bnds[0]:.3E}, {bnds[1]:.3E}",
-            f"  Y Bounds                    {bnds[2]:.3E}, {bnds[3]:.3E}",
-            f"  Z Bounds                    {bnds[4]:.3E}, {bnds[5]:.3E}",
+            f"  X Bounds                    {bnds.x_min:.3E}, {bnds.x_max:.3E}",
+            f"  Y Bounds                    {bnds.y_min:.3E}, {bnds.y_max:.3E}",
+            f"  Z Bounds                    {bnds.z_min:.3E}, {bnds.z_max:.3E}",
         ]
         return '\n'.join(attr)
 

--- a/pyvista/plotting/cube_axes_actor.py
+++ b/pyvista/plotting/cube_axes_actor.py
@@ -7,12 +7,13 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 import pyvista
+from pyvista.core._typing_core import BoundsTuple
 from pyvista.core.utilities.arrays import convert_string_array
 
 from . import _vtk
 
 if TYPE_CHECKING:  # pragma: no cover
-    from pyvista.core._typing_core import BoundsLike
+    from pyvista.core._typing_core import VectorLike
 
 
 def make_axis_labels(vmin, vmax, n, fmt):
@@ -234,17 +235,18 @@ class CubeAxesActor(_vtk.vtkCubeAxesActor):
             )
 
     @property
-    def bounds(self) -> BoundsLike:  # numpydoc ignore=RT01
+    def bounds(self) -> BoundsTuple:  # numpydoc ignore=RT01
         """Return or set the bounding box."""
-        return self.GetBounds()
+        return BoundsTuple(*self.GetBounds())
 
     @bounds.setter
-    def bounds(self, bounds: BoundsLike):  # numpydoc ignore=GL08
+    def bounds(self, bounds: VectorLike[float]):  # numpydoc ignore=GL08
         self.SetBounds(bounds)
         self._update_labels()
-        self.x_axis_range = float(bounds[0]), float(bounds[1])
-        self.y_axis_range = float(bounds[2]), float(bounds[3])
-        self.z_axis_range = float(bounds[4]), float(bounds[5])
+        bnds = self.bounds
+        self.x_axis_range = bnds.x_min, bnds.x_max
+        self.y_axis_range = bnds.y_min, bnds.y_max
+        self.z_axis_range = bnds.z_min, bnds.z_max
 
     @property
     def x_axis_range(self) -> tuple[float, float]:  # numpydoc ignore=RT01
@@ -564,7 +566,7 @@ class CubeAxesActor(_vtk.vtkCubeAxesActor):
         Parameters
         ----------
         bounds : sequence[float]
-            Bounds in the form of ``[xmin, xmax, ymin, ymax, zmin, zmax]``.
+            Bounds in the form of ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
         """
         self.bounds = bounds

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -56,7 +56,7 @@ class _BaseMapper(_vtk.vtkAbstractMapper):
         >>> import pyvista as pv
         >>> mapper = pv.DataSetMapper(dataset=pv.Cube())
         >>> mapper.bounds
-        (-0.5, 0.5, -0.5, 0.5, -0.5, 0.5)
+        BoundsTuple(x_min=-0.5, x_max=0.5, y_min=-0.5, y_max=0.5, z_min=-0.5, z_max=0.5)
 
         """
         return BoundsTuple(*self.GetBounds())

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING
 from typing import Optional
 from typing import cast
 
 import numpy as np
 
 import pyvista
+from pyvista.core._typing_core import BoundsTuple
 from pyvista.core.utilities.arrays import FieldAssociation
 from pyvista.core.utilities.arrays import convert_array
 from pyvista.core.utilities.arrays import convert_string_array
@@ -24,9 +24,6 @@ from .colors import get_cmap_safe
 from .lookup_table import LookupTable
 from .tools import normalize
 from .utilities.algorithms import set_algorithm_input
-
-if TYPE_CHECKING:  # pragma: no cover
-    from pyvista.core._typing_core import BoundsLike
 
 
 @abstract_class
@@ -51,7 +48,7 @@ class _BaseMapper(_vtk.vtkAbstractMapper):
         )
 
     @property
-    def bounds(self) -> BoundsLike:  # numpydoc ignore=RT01
+    def bounds(self) -> BoundsTuple:  # numpydoc ignore=RT01
         """Return the bounds of this mapper.
 
         Examples
@@ -62,7 +59,7 @@ class _BaseMapper(_vtk.vtkAbstractMapper):
         (-0.5, 0.5, -0.5, 0.5, -0.5, 0.5)
 
         """
-        return self.GetBounds()
+        return BoundsTuple(*self.GetBounds())
 
     def copy(self) -> _BaseMapper:
         """Create a copy of this mapper.

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -1668,7 +1668,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> pl = pv.Plotter()
         >>> _ = pl.add_mesh(pv.Cube())
         >>> pl.bounds
-        (-0.5, 0.5, -0.5, 0.5, -0.5, 0.5)
+        BoundsTuple(x_min=-0.5, x_max=0.5, y_min=-0.5, y_max=0.5, z_min=-0.5, z_max=0.5)
 
         """
         return self.renderer.bounds

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -88,7 +88,7 @@ from .volume_property import VolumeProperty
 from .widgets import WidgetHelper
 
 if TYPE_CHECKING:  # pragma: no cover
-    from pyvista.core._typing_core import BoundsLike
+    from pyvista.core._typing_core import BoundsTuple
     from pyvista.plotting.cube_axes_actor import CubeAxesActor
 
 SUPPORTED_FORMATS = [".png", ".jpeg", ".jpg", ".bmp", ".tif", ".tiff"]
@@ -1654,7 +1654,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         self.renderer.camera.is_set = is_set
 
     @property
-    def bounds(self) -> BoundsLike:  # numpydoc ignore=RT01
+    def bounds(self) -> BoundsTuple:  # numpydoc ignore=RT01
         """Return the bounds of the active renderer.
 
         Returns
@@ -6153,9 +6153,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if viewup is None:
             viewup = self._theme.camera.viewup
         center = np.array(self.center)
-        bnds = np.array(self.bounds)
-        radius = (bnds[1] - bnds[0]) * factor
-        y = (bnds[3] - bnds[2]) * factor
+        bnds = self.bounds
+        radius = (bnds.x_max - bnds.x_min) * factor
+        y = (bnds.y_max - bnds.y_min) * factor
         if y > radius:
             radius = y
         center += np.array(viewup) * shift
@@ -7138,7 +7138,7 @@ class Plotter(BasePlotter):
         bounds : sequence[float], default: (-1.0, 1.0, -1.0, 1.0, -1.0, 1.0)
             Specify the bounds in the format of:
 
-            - ``(xmin, xmax, ymin, ymax, zmin, zmax)``
+            - ``(x_min, x_max, y_min, y_max, z_min, z_max)``
 
         focal_point : sequence[float], default: (0.0, 0.0, 0.0)
             The focal point of the cursor.

--- a/pyvista/plotting/prop3d.py
+++ b/pyvista/plotting/prop3d.py
@@ -284,7 +284,7 @@ class Prop3D(_vtk.vtkProp3D):
     def bounds(self) -> BoundsTuple:  # numpydoc ignore=RT01
         """Return the bounds of the entity.
 
-        Bounds are ``(-X, +X, -Y, +Y, -Z, +Z)``
+        Bounds are ``(x_min, x_max, y_min, y_max, z_min, z_max)``
 
         Examples
         --------
@@ -293,7 +293,7 @@ class Prop3D(_vtk.vtkProp3D):
         >>> mesh = pv.Cube(x_length=0.1, y_length=0.2, z_length=0.3)
         >>> actor = pl.add_mesh(mesh)
         >>> actor.bounds
-        (-0.05, 0.05, -0.1, 0.1, -0.15, 0.15)
+        BoundsTuple(x_min=-0.05, x_max=0.05, y_min=-0.1, y_max=0.1, z_min=-0.15, z_max=0.15)
 
         """
         return BoundsTuple(*self.GetBounds())

--- a/pyvista/plotting/prop3d.py
+++ b/pyvista/plotting/prop3d.py
@@ -571,7 +571,7 @@ class _Prop3DMixin(ABC):
     @wraps(Prop3D.bounds.fget)  # type: ignore[attr-defined]
     def bounds(self) -> BoundsTuple:  # numpydoc ignore=RT01
         """Wrap :class:`pyvista.Prop3D.bounds`."""
-        return self._get_bounds()
+        return BoundsTuple(*self._get_bounds())
 
     @property
     @wraps(Prop3D.center.fget)  # type: ignore[attr-defined]

--- a/pyvista/plotting/prop3d.py
+++ b/pyvista/plotting/prop3d.py
@@ -10,12 +10,12 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from pyvista.core import _validation
+from pyvista.core._typing_core import BoundsTuple
 from pyvista.core.utilities.arrays import array_from_vtkmatrix
 from pyvista.core.utilities.arrays import vtkmatrix_from_array
 from pyvista.plotting import _vtk
 
 if TYPE_CHECKING:  # pragma: no cover
-    from pyvista.core._typing_core import BoundsLike
     from pyvista.core._typing_core import NumpyArray
     from pyvista.core._typing_core import RotationLike
     from pyvista.core._typing_core import TransformLike
@@ -281,7 +281,7 @@ class Prop3D(_vtk.vtkProp3D):
         self.SetOrigin(value)
 
     @property
-    def bounds(self) -> BoundsLike:  # numpydoc ignore=RT01
+    def bounds(self) -> BoundsTuple:  # numpydoc ignore=RT01
         """Return the bounds of the entity.
 
         Bounds are ``(-X, +X, -Y, +Y, -Z, +Z)``
@@ -296,7 +296,7 @@ class Prop3D(_vtk.vtkProp3D):
         (-0.05, 0.05, -0.1, 0.1, -0.15, 0.15)
 
         """
-        return self.GetBounds()
+        return BoundsTuple(*self.GetBounds())
 
     @property
     def center(self) -> tuple[float, float, float]:  # numpydoc ignore=RT01
@@ -564,12 +564,12 @@ class _Prop3DMixin(ABC):
         """Update object after setting Prop3D attributes."""
 
     @abstractmethod
-    def _get_bounds(self) -> BoundsLike:
+    def _get_bounds(self) -> BoundsTuple:
         """Return the object's 3D bounds."""
 
     @property
     @wraps(Prop3D.bounds.fget)  # type: ignore[attr-defined]
-    def bounds(self) -> BoundsLike:  # numpydoc ignore=RT01
+    def bounds(self) -> BoundsTuple:  # numpydoc ignore=RT01
         """Wrap :class:`pyvista.Prop3D.bounds`."""
         return self._get_bounds()
 
@@ -578,11 +578,17 @@ class _Prop3DMixin(ABC):
     def center(self) -> tuple[float, float, float]:  # numpydoc ignore=RT01
         """Wrap :class:`pyvista.Prop3D.center."""
         bnds = self.bounds
-        return (bnds[0] + bnds[1]) / 2, (bnds[2] + bnds[3]) / 2, (bnds[4] + bnds[5]) / 2
+        return (
+            (bnds.x_min + bnds.x_max) / 2,
+            (bnds.y_min + bnds.y_max) / 2,
+            (bnds.z_min + bnds.z_max) / 2,
+        )
 
     @property
     @wraps(Prop3D.length.fget)  # type: ignore[attr-defined]
     def length(self) -> float:  # numpydoc ignore=RT01
         """Wrap :class:`pyvista.Prop3D.length."""
         bnds = self.bounds
-        return np.linalg.norm((bnds[1] - bnds[0], bnds[3] - bnds[2], bnds[5] - bnds[4])).tolist()
+        return np.linalg.norm(
+            (bnds.x_max - bnds.x_min, bnds.y_max - bnds.y_min, bnds.z_max - bnds.z_min)
+        ).tolist()

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -8,7 +8,6 @@ from functools import partial
 from functools import wraps
 from typing import ClassVar
 from typing import Sequence
-from typing import cast
 import warnings
 
 import numpy as np
@@ -16,7 +15,7 @@ import numpy as np
 import pyvista
 from pyvista import MAX_N_COLOR_BARS
 from pyvista import vtk_version_info
-from pyvista.core._typing_core import BoundsLike
+from pyvista.core._typing_core import BoundsTuple
 from pyvista.core.errors import PyVistaDeprecationWarning
 from pyvista.core.utilities.helpers import wrap
 from pyvista.core.utilities.misc import assert_empty_kwargs
@@ -448,7 +447,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         self.camera_set = True
 
     @property
-    def bounds(self) -> BoundsLike:  # numpydoc ignore=RT01
+    def bounds(self) -> BoundsTuple:  # numpydoc ignore=RT01
         """Return the bounds of all actors present in the rendering window."""
         the_bounds = np.array([np.inf, -np.inf, np.inf, -np.inf, np.inf, -np.inf])
 
@@ -476,7 +475,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             the_bounds[the_bounds == np.inf] = -1.0
             the_bounds[the_bounds == -np.inf] = 1.0
 
-        return cast(BoundsLike, tuple(the_bounds.tolist()))
+        return BoundsTuple(*the_bounds.tolist())
 
     @property
     def length(self):  # numpydoc ignore=RT01
@@ -499,10 +498,10 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             Cartesian coordinates of the center.
 
         """
-        bounds = self.bounds
-        x = (bounds[1] + bounds[0]) / 2
-        y = (bounds[3] + bounds[2]) / 2
-        z = (bounds[5] + bounds[4]) / 2
+        bnds = self.bounds
+        x = (bnds.x_max + bnds.x_min) / 2
+        y = (bnds.y_max + bnds.y_min) / 2
+        z = (bnds.z_max + bnds.z_min) / 2
         return x, y, z
 
     @property
@@ -1544,7 +1543,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             to manually display different values. These values must be in the
             form:
 
-            ``[xmin, xmax, ymin, ymax, zmin, zmax]``.
+            ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
         show_xaxis : bool, default: True
             Makes x-axis visible.
@@ -1858,7 +1857,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             # set the axes ranges
             if axes_ranges.shape != (6,):
                 raise ValueError(
-                    '`axes_ranges` must be passed as a [xmin, xmax, ymin, ymax, zmin, zmax] sequence.',
+                    '`axes_ranges` must be passed as a (x_min, x_max, y_min, y_max, z_min, z_max) sequence.',
                 )
 
             cube_axes_actor.x_axis_range = axes_ranges[0], axes_ranges[1]
@@ -2185,32 +2184,32 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         ranges += ranges * pad
         center = np.array(self.center)
         if face.lower() in '-z':
-            center[2] = self.bounds[4] - (ranges[2] * offset)
+            center[2] = self.bounds.z_min - (ranges[2] * offset)
             normal = (0, 0, 1)
             i_size = ranges[0]
             j_size = ranges[1]
         elif face.lower() in '-y':
-            center[1] = self.bounds[2] - (ranges[1] * offset)
+            center[1] = self.bounds.y_min - (ranges[1] * offset)
             normal = (0, 1, 0)
             i_size = ranges[2]
             j_size = ranges[0]
         elif face.lower() in '-x':
-            center[0] = self.bounds[0] - (ranges[0] * offset)
+            center[0] = self.bounds.x_min - (ranges[0] * offset)
             normal = (1, 0, 0)
             i_size = ranges[2]
             j_size = ranges[1]
         elif face.lower() in '+z':
-            center[2] = self.bounds[5] + (ranges[2] * offset)
+            center[2] = self.bounds.z_max + (ranges[2] * offset)
             normal = (0, 0, -1)
             i_size = ranges[0]
             j_size = ranges[1]
         elif face.lower() in '+y':
-            center[1] = self.bounds[3] + (ranges[1] * offset)
+            center[1] = self.bounds.y_max + (ranges[1] * offset)
             normal = (0, -1, 0)
             i_size = ranges[2]
             j_size = ranges[0]
         elif face.lower() in '+x':
-            center[0] = self.bounds[1] + (ranges[0] * offset)
+            center[0] = self.bounds.x_max + (ranges[0] * offset)
             normal = (-1, 0, 0)
             i_size = ranges[2]
             j_size = ranges[1]
@@ -2787,7 +2786,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         bounds : iterable(int), optional
             Automatically set up the camera based on a specified bounding box
-            ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+            ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
         Examples
         --------
@@ -2837,7 +2836,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         bounds : iterable(int), optional
             Automatically set up the camera based on a specified bounding box
-            ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+            ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
         Examples
         --------
@@ -2878,7 +2877,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         bounds : iterable(int), optional
             Automatically set up the camera based on a specified bounding box
-            ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+            ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
         """
         focal_pt = self.center
@@ -2902,7 +2901,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         bounds : iterable(int), optional
             Automatically set up the camera based on a specified bounding box
-            ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+            ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
         Examples
         --------
@@ -2933,7 +2932,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         bounds : iterable(int), optional
             Automatically set up the camera based on a specified bounding box
-            ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+            ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
         Examples
         --------
@@ -2964,7 +2963,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         bounds : iterable(int), optional
             Automatically set up the camera based on a specified bounding box
-            ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+            ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
         Examples
         --------
@@ -2995,7 +2994,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         bounds : iterable(int), optional
             Automatically set up the camera based on a specified bounding box
-            ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+            ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
         Examples
         --------
@@ -3026,7 +3025,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         bounds : iterable(int), optional
             Automatically set up the camera based on a specified bounding box
-            ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+            ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
         Examples
         --------
@@ -3057,7 +3056,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         bounds : iterable(int), optional
             Automatically set up the camera based on a specified bounding box
-            ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+            ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
 
         Examples
         --------
@@ -3962,8 +3961,8 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         Measure x direction of cone and place ruler slightly below.
 
         >>> _ = plotter.add_ruler(
-        ...     pointa=[cone.bounds[0], cone.bounds[2] - 0.1, 0.0],
-        ...     pointb=[cone.bounds[1], cone.bounds[2] - 0.1, 0.0],
+        ...     pointa=[cone.bounds.x_min, cone.bounds.y_min - 0.1, 0.0],
+        ...     pointb=[cone.bounds.x_max, cone.bounds.y_min - 0.1, 0.0],
         ...     title="X Distance",
         ... )
 
@@ -3972,8 +3971,8 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         traveling from ``pointa`` to ``pointb``.
 
         >>> _ = plotter.add_ruler(
-        ...     pointa=[cone.bounds[0] - 0.1, cone.bounds[3], 0.0],
-        ...     pointb=[cone.bounds[0] - 0.1, cone.bounds[2], 0.0],
+        ...     pointa=[cone.bounds.x_min - 0.1, cone.bounds.y_max, 0.0],
+        ...     pointb=[cone.bounds.x_min - 0.1, cone.bounds.y_min, 0.0],
         ...     flip_range=True,
         ...     title="Y Distance",
         ... )

--- a/pyvista/plotting/text.py
+++ b/pyvista/plotting/text.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import pyvista
 from pyvista.core import _validation
+from pyvista.core._typing_core import BoundsTuple
 from pyvista.core.utilities.misc import _check_range
 from pyvista.core.utilities.misc import no_new_attr
 
@@ -416,10 +417,10 @@ class Label(_Prop3DMixin, Text):
         new_position = (matrix4x4 @ vector4)[:3]
         self._label_position = new_position
 
-    def _get_bounds(self):
+    def _get_bounds(self) -> BoundsTuple:
         # Define its 3D position as its bounds
         x, y, z = self._label_position
-        return x, x, y, y, z, z
+        return BoundsTuple(x, x, y, y, z, z)
 
 
 @no_new_attr

--- a/pyvista/plotting/volume.py
+++ b/pyvista/plotting/volume.py
@@ -39,7 +39,7 @@ class Volume(Prop3D, _vtk.vtkVolume):
         >>> pl = pv.Plotter()
         >>> actor = pl.add_volume(vol)
         >>> actor.mapper.bounds
-        (0.0, 9.0, 0.0, 9.0, 0.0, 9.0)
+        BoundsTuple(x_min=0.0, x_max=9.0, y_min=0.0, y_max=9.0, z_min=0.0, z_max=9.0)
         """
         return self.GetMapper()
 

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -497,7 +497,7 @@ class WidgetHelper:
         >>> def callback(normal, origin):
         ...     slc = mesh.slice(normal=normal, origin=origin)
         ...     origin = list(origin)
-        ...     origin[2] = slc.bounds[5]
+        ...     origin[2] = slc.bounds.z_max
         ...     peak_plane = pv.Plane(
         ...         center=origin,
         ...         direction=[0, 0, 1],

--- a/tests/core/test_cells.py
+++ b/tests/core/test_cells.py
@@ -288,9 +288,9 @@ def test_cell_center(grid):
     bounds = grid.get_cell(0).bounds
 
     assert isinstance(center, tuple)
-    assert bounds[0] <= center[0] <= bounds[1]
-    assert bounds[2] <= center[1] <= bounds[3]
-    assert bounds[4] <= center[2] <= bounds[5]
+    assert bounds.x_min <= center[0] <= bounds.x_max
+    assert bounds.y_min <= center[1] <= bounds.y_max
+    assert bounds.z_min <= center[2] <= bounds.z_max
 
 
 def test_cell_center_value():

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1020,23 +1020,23 @@ def test_find_cells_within_bounds():
     mesh = pv.Cube()
 
     bounds = [
-        mesh.bounds[0] * 2.0,
-        mesh.bounds[1] * 2.0,
-        mesh.bounds[2] * 2.0,
-        mesh.bounds[3] * 2.0,
-        mesh.bounds[4] * 2.0,
-        mesh.bounds[5] * 2.0,
+        mesh.bounds.x_min * 2.0,
+        mesh.bounds.x_max * 2.0,
+        mesh.bounds.y_min * 2.0,
+        mesh.bounds.y_max * 2.0,
+        mesh.bounds.z_min * 2.0,
+        mesh.bounds.z_max * 2.0,
     ]
     indices = mesh.find_cells_within_bounds(bounds)
     assert len(indices) == mesh.n_cells
 
     bounds = [
-        mesh.bounds[0] * 0.5,
-        mesh.bounds[1] * 0.5,
-        mesh.bounds[2] * 0.5,
-        mesh.bounds[3] * 0.5,
-        mesh.bounds[4] * 0.5,
-        mesh.bounds[5] * 0.5,
+        mesh.bounds.x_min * 0.5,
+        mesh.bounds.x_max * 0.5,
+        mesh.bounds.y_min * 0.5,
+        mesh.bounds.y_max * 0.5,
+        mesh.bounds.z_min * 0.5,
+        mesh.bounds.z_max * 0.5,
     ]
     indices = mesh.find_cells_within_bounds(bounds)
     assert len(indices) == 0

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -679,7 +679,7 @@ def test_elevation():
     elev = dataset.elevation(progress_bar=True)
     assert 'Elevation' in elev.array_names
     assert elev.active_scalars_name == 'Elevation'
-    assert elev.get_data_range() == (dataset.bounds[4], dataset.bounds[5])
+    assert elev.get_data_range() == (dataset.bounds.z_min, dataset.bounds.z_max)
     # test vector args
     c = list(dataset.center)
     t = list(c)  # cast so it does not point to `c`
@@ -687,7 +687,7 @@ def test_elevation():
     elev = dataset.elevation(low_point=c, high_point=t, progress_bar=True)
     assert 'Elevation' in elev.array_names
     assert elev.active_scalars_name == 'Elevation'
-    assert elev.get_data_range() == (dataset.center[2], dataset.bounds[5])
+    assert elev.get_data_range() == (dataset.center[2], dataset.bounds.z_max)
     # Test not setting active
     elev = dataset.elevation(set_active=False, progress_bar=True)
     assert 'Elevation' in elev.array_names
@@ -725,8 +725,8 @@ def test_texture_map_to_plane():
     # Define the plane explicitly
     bnds = dataset.bounds
     origin = bnds[0::2]
-    point_u = (bnds[1], bnds[2], bnds[4])
-    point_v = (bnds[0], bnds[3], bnds[4])
+    point_u = (bnds.x_max, bnds.y_max, bnds.z_min)
+    point_v = (bnds.x_min, bnds.y_min, bnds.z_min)
     out = dataset.texture_map_to_plane(
         origin=origin,
         point_u=point_u,
@@ -1018,14 +1018,14 @@ def test_glyph_orient_and_scale():
     glyph2 = grid.glyph(geom=geom, orient=False, scale="z_axis")
     glyph3 = grid.glyph(geom=geom, orient="z_axis", scale=False)
     glyph4 = grid.glyph(geom=geom, orient=False, scale=False)
-    assert glyph1.bounds[4] == geom.bounds[0] * scale
-    assert glyph1.bounds[5] == geom.bounds[1] * scale
-    assert glyph2.bounds[0] == geom.bounds[0] * scale
-    assert glyph2.bounds[1] == geom.bounds[1] * scale
-    assert glyph3.bounds[4] == geom.bounds[0]
-    assert glyph3.bounds[5] == geom.bounds[1]
-    assert glyph4.bounds[0] == geom.bounds[0]
-    assert glyph4.bounds[1] == geom.bounds[1]
+    assert glyph1.bounds.z_min == geom.bounds.x_min * scale
+    assert glyph1.bounds.z_max == geom.bounds.x_max * scale
+    assert glyph2.bounds.x_min == geom.bounds.x_min * scale
+    assert glyph2.bounds.x_max == geom.bounds.x_max * scale
+    assert glyph3.bounds.z_min == geom.bounds.x_min
+    assert glyph3.bounds.z_max == geom.bounds.x_max
+    assert glyph4.bounds.x_min == geom.bounds.x_min
+    assert glyph4.bounds.x_max == geom.bounds.x_max
 
 
 @pytest.mark.parametrize('color_mode', ['scale', 'scalar', 'vector'])
@@ -1813,8 +1813,8 @@ def test_plot_over_line(tmpdir):
     filename = str(tmp_dir.join('tmp.png'))
     mesh = examples.load_uniform()
     # Make two points to construct the line between
-    a = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
-    b = [mesh.bounds[1], mesh.bounds[3], mesh.bounds[5]]
+    a = [mesh.bounds.x_min, mesh.bounds.y_min, mesh.bounds.z_min]
+    b = [mesh.bounds.x_max, mesh.bounds.y_max, mesh.bounds.z_max]
     mesh.plot_over_line(a, b, resolution=1000, show=False, progress_bar=True)
     # Test multicomponent
     mesh['foo'] = np.random.default_rng().random((mesh.n_cells, 3))
@@ -1868,11 +1868,11 @@ def test_sample_over_circular_arc():
     uniform = examples.load_uniform()
     uniform[name] = uniform.points[:, 2]
 
-    xmin = uniform.bounds[0]
-    xmax = uniform.bounds[1]
-    ymin = uniform.bounds[2]
-    zmin = uniform.bounds[4]
-    zmax = uniform.bounds[5]
+    xmin = uniform.bounds.x_min
+    xmax = uniform.bounds.x_max
+    ymin = uniform.bounds.y_min
+    zmin = uniform.bounds.z_min
+    zmax = uniform.bounds.z_max
     pointa = [xmin, ymin, zmax]
     pointb = [xmax, ymin, zmin]
     center = [xmin, ymin, zmin]
@@ -1904,11 +1904,11 @@ def test_sample_over_circular_arc_normal():
     uniform = examples.load_uniform()
     uniform[name] = uniform.points[:, 2]
 
-    xmin = uniform.bounds[0]
-    ymin = uniform.bounds[2]
-    ymax = uniform.bounds[3]
-    zmin = uniform.bounds[4]
-    zmax = uniform.bounds[5]
+    xmin = uniform.bounds.x_min
+    ymin = uniform.bounds.y_min
+    ymax = uniform.bounds.y_max
+    zmin = uniform.bounds.z_min
+    zmax = uniform.bounds.z_max
     normal = [xmin, ymax, zmin]
     polar = [xmin, ymin, zmax]
     angle = 90.0 * np.random.default_rng().random()
@@ -1948,9 +1948,9 @@ def test_plot_over_circular_arc(tmpdir):
     filename = str(tmp_dir.join('tmp.png'))
 
     # Make two points and center to construct the circular arc between
-    a = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[5]]
-    b = [mesh.bounds[1], mesh.bounds[2], mesh.bounds[4]]
-    center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
+    a = [mesh.bounds.x_min, mesh.bounds.y_min, mesh.bounds.z_max]
+    b = [mesh.bounds.x_max, mesh.bounds.y_min, mesh.bounds.z_min]
+    center = [mesh.bounds.x_min, mesh.bounds.y_min, mesh.bounds.z_min]
     mesh.plot_over_circular_arc(
         a,
         b,
@@ -1996,10 +1996,10 @@ def test_plot_over_circular_arc_normal(tmpdir):
     filename = str(tmp_dir.join('tmp.png'))
 
     # Make center and normal/polar vector to construct the circular arc between
-    # normal = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[5]]
-    polar = [mesh.bounds[0], mesh.bounds[3], mesh.bounds[4]]
+    # normal = [mesh.bounds.x_min, mesh.bounds.y_min, mesh.bounds.z_max]
+    polar = [mesh.bounds.x_min, mesh.bounds.y_max, mesh.bounds.z_min]
     angle = 90
-    center = [mesh.bounds[0], mesh.bounds[2], mesh.bounds[4]]
+    center = [mesh.bounds.x_min, mesh.bounds.y_min, mesh.bounds.z_min]
     mesh.plot_over_circular_arc_normal(
         center,
         polar=polar,
@@ -2041,7 +2041,7 @@ def test_plot_over_circular_arc_normal(tmpdir):
 def test_slice_along_line():
     model = examples.load_uniform()
     n = 5
-    x = y = z = np.linspace(model.bounds[0], model.bounds[1], num=n)
+    x = y = z = np.linspace(model.bounds.x_min, model.bounds.x_max, num=n)
     points = np.c_[x, y, z]
     spline = pv.Spline(points, n)
     slc = model.slice_along_line(spline, progress_bar=True)
@@ -2049,14 +2049,14 @@ def test_slice_along_line():
     slc = model.slice_along_line(spline, contour=True, progress_bar=True)
     assert slc.n_points > 0
     # Now check a simple line
-    a = [model.bounds[0], model.bounds[2], model.bounds[4]]
-    b = [model.bounds[1], model.bounds[3], model.bounds[5]]
+    a = [model.bounds.x_min, model.bounds.y_min, model.bounds.z_min]
+    b = [model.bounds.x_max, model.bounds.y_max, model.bounds.z_max]
     line = pv.Line(a, b, resolution=10)
     slc = model.slice_along_line(line, progress_bar=True)
     assert slc.n_points > 0
     # Now check a bad input
-    a = [model.bounds[0], model.bounds[2], model.bounds[4]]
-    b = [model.bounds[1], model.bounds[2], model.bounds[5]]
+    a = [model.bounds.x_min, model.bounds.y_min, model.bounds.z_min]
+    b = [model.bounds.x_max, model.bounds.y_min, model.bounds.z_max]
     line2 = pv.Line(a, b, resolution=10)
     line = line2.cast_to_unstructured_grid().merge(line.cast_to_unstructured_grid())
     with pytest.raises(ValueError):  # noqa: PT011
@@ -2752,8 +2752,8 @@ def test_extract_values_raises(grid4x4):
 
 def test_slice_along_line_composite(composite):
     # Now test composite data structures
-    a = [composite.bounds[0], composite.bounds[2], composite.bounds[4]]
-    b = [composite.bounds[1], composite.bounds[3], composite.bounds[5]]
+    a = [composite.bounds.x_min, composite.bounds.y_min, composite.bounds.z_min]
+    b = [composite.bounds.x_max, composite.bounds.y_max, composite.bounds.z_max]
     line = pv.Line(a, b, resolution=10)
     output = composite.slice_along_line(line, progress_bar=True)
     assert output.n_blocks == composite.n_blocks
@@ -3650,20 +3650,20 @@ def test_extrude_rotate():
         progress_bar=True,
         capping=True,
     )
-    zmax = poly.bounds[5]
+    zmax = poly.bounds.z_max
     assert zmax == translation
-    xmax = poly.bounds[1]
-    assert xmax == line.bounds[1] + dradius
+    xmax = poly.bounds.x_max
+    assert xmax == line.bounds.x_max + dradius
 
     poly = line.extrude_rotate(angle=90.0, progress_bar=True, capping=True)
-    xmin = poly.bounds[0]
-    xmax = poly.bounds[1]
-    ymin = poly.bounds[2]
-    ymax = poly.bounds[3]
-    assert xmin == line.bounds[0]
-    assert xmax == line.bounds[1]
-    assert ymin == line.bounds[0]
-    assert ymax == line.bounds[1]
+    xmin = poly.bounds.x_min
+    xmax = poly.bounds.x_max
+    ymin = poly.bounds.y_min
+    ymax = poly.bounds.y_max
+    assert xmin == line.bounds.x_min
+    assert xmax == line.bounds.x_max
+    assert ymin == line.bounds.x_min
+    assert ymax == line.bounds.x_max
 
     rotation_axis = (0, 1, 0)
     if not pv.vtk_version_info >= (9, 1, 0):

--- a/tests/core/test_geometric_objects.py
+++ b/tests/core/test_geometric_objects.py
@@ -536,9 +536,9 @@ def test_text_3d():
 
     bnds = mesh.bounds
     actual_width, actual_height, actual_depth = (
-        bnds[1] - bnds[0],
-        bnds[3] - bnds[2],
-        bnds[5] - bnds[4],
+        bnds.x_max - bnds.x_min,
+        bnds.y_max - bnds.y_min,
+        bnds.z_max - bnds.z_min,
     )
     assert np.isclose(actual_width, 2.0)
     assert np.isclose(actual_height, 3.0)

--- a/tests/core/test_geometric_sources.py
+++ b/tests/core/test_geometric_sources.py
@@ -173,9 +173,9 @@ def test_text3d_source_parameters(string, center, height, width, depth, normal):
     out = src.output
     bnds = out.bounds
     actual_width, actual_height, actual_depth = (
-        bnds[1] - bnds[0],
-        bnds[3] - bnds[2],
-        bnds[5] - bnds[4],
+        bnds.x_max - bnds.x_min,
+        bnds.y_max - bnds.y_min,
+        bnds.z_max - bnds.z_min,
     )
 
     # Compute expected values
@@ -193,7 +193,7 @@ def test_text3d_source_parameters(string, center, height, width, depth, normal):
         src_not_scaled = pv.Text3DSource(string=string, center=center)
         out_not_scaled = src_not_scaled.output
         bnds = out_not_scaled.bounds
-        unscaled_width, unscaled_height = bnds[1] - bnds[0], bnds[3] - bnds[2]
+        unscaled_width, unscaled_height = bnds.x_max - bnds.x_min, bnds.y_max - bnds.y_min
         if width is None and height is not None:
             expected_width = unscaled_width * actual_height / unscaled_height
         elif width is not None and height is None:
@@ -590,7 +590,7 @@ def test_axes_geometry_source_custom_part(axes_geometry_source):
     axes_geometry_source.tip_type = pv.ParametricKlein()
     assert axes_geometry_source.tip_type == 'custom'
 
-    match = 'Custom axes part must be 3D. Got bounds: (-0.5, 0.5, -0.5, 0.5, 0.0, 0.0).'
+    match = 'Custom axes part must be 3D. Got bounds: BoundsTuple(x_min=-0.5, x_max=0.5, y_min=-0.5, y_max=0.5, z_min=0.0, z_max=0.0).'
     with pytest.raises(ValueError, match=re.escape(match)):
         axes_geometry_source.shaft_type = pv.Plane()
 

--- a/tests/core/test_pointset.py
+++ b/tests/core/test_pointset.py
@@ -252,8 +252,8 @@ def test_threshold_percent(pointset):
 def test_explode(pointset):
     out = pointset.explode(1)
     assert isinstance(out, pv.PointSet)
-    ori_xlen = pointset.bounds[1] - pointset.bounds[0]
-    new_xlen = out.bounds[1] - out.bounds[0]
+    ori_xlen = pointset.bounds.x_max - pointset.bounds.x_min
+    new_xlen = out.bounds.x_max - out.bounds.x_min
     assert np.isclose(2 * ori_xlen, new_xlen)
 
 

--- a/tests/plotting/test_actor.py
+++ b/tests/plotting/test_actor.py
@@ -43,7 +43,7 @@ def dummy_actor(actor):
             self._actor.user_matrix = self._transformation_matrix
 
         def _get_bounds(self):
-            return self._actor.GetBounds()
+            return pv.BoundsTuple(*self._actor.GetBounds())
 
     # Sanity checks to make sure fixture is defined properly
     dummy_actor = DummyActor()

--- a/tests/plotting/test_actor.py
+++ b/tests/plotting/test_actor.py
@@ -43,7 +43,7 @@ def dummy_actor(actor):
             self._actor.user_matrix = self._transformation_matrix
 
         def _get_bounds(self):
-            return pv.BoundsTuple(*self._actor.GetBounds())
+            return self._actor.GetBounds()
 
     # Sanity checks to make sure fixture is defined properly
     dummy_actor = DummyActor()

--- a/tests/plotting/test_cube_axes_actor.py
+++ b/tests/plotting/test_cube_axes_actor.py
@@ -46,7 +46,7 @@ def test_labels(cube_axes_actor):
     cube_axes_actor.y_label_format = ''
     assert len(cube_axes_actor.y_labels) == 5
     values = np.array(cube_axes_actor.y_labels, float)
-    expected = np.linspace(cube_axes_actor.bounds[2], cube_axes_actor.bounds[3], 5)
+    expected = np.linspace(cube_axes_actor.bounds.y_min, cube_axes_actor.bounds.y_max, 5)
     assert np.allclose(values, expected)
 
     # standard format

--- a/tests/typing/test_bounds_tuple.py
+++ b/tests/typing/test_bounds_tuple.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import pyvista as pv
+from pyvista.core.errors import VTKVersionError
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -22,11 +23,51 @@ def _get_classes_with_bounds(module: ModuleType) -> list[type]:
 def pytest_generate_tests(metafunc):
     """Generate parametrized tests."""
     if 'class_with_bounds' in metafunc.fixturenames:
-        # Generate a separate test for each class that has bounds
+        # Generate a separate test for any class that has bounds
         core_classes: list[type] = _get_classes_with_bounds(pv.core)
         plotting_classes: list[type] = _get_classes_with_bounds(pv.plotting)
         classes = [*core_classes, *plotting_classes]
         class_names = [class_.__name__ for class_ in classes]
+
+        # List all the classes explicitly
+        expected_names = [
+            'Actor',
+            'AxesAssembly',
+            'AxesAssemblySymmetric',
+            'BasePlotter',
+            'BoxSource',
+            'Cell',
+            'CompositePolyDataMapper',
+            'CubeAxesActor',
+            'CubeSource',
+            'DataSet',
+            'DataSetMapper',
+            'ExplicitStructuredGrid',
+            'FixedPointVolumeRayCastMapper',
+            'GPUVolumeRayCastMapper',
+            'Grid',
+            'ImageData',
+            'Label',
+            'MultiBlock',
+            'OpenGLGPUVolumeRayCastMapper',
+            'OrthogonalPlanesSource',
+            'PlanesAssembly',
+            'Plotter',
+            'PointGaussianMapper',
+            'PointGrid',
+            'PointSet',
+            'PolyData',
+            'Prop3D',
+            'RectilinearGrid',
+            'Renderer',
+            'SmartVolumeMapper',
+            'StructuredGrid',
+            'UnstructuredGrid',
+            'UnstructuredGridVolumeRayCastMapper',
+            'Volume',
+        ]
+        assert sorted(class_names) == sorted(expected_names)
+
         metafunc.parametrize('class_with_bounds', classes, ids=class_names)
 
 
@@ -41,6 +82,8 @@ def test_bounds_tuple(class_with_bounds):
     # Init object but skip if abstract
     try:
         instance = class_with_bounds(**kwargs)
+    except VTKVersionError:
+        pytest.skip('VTK Version not supported.')
     except TypeError as e:
         if 'abstract' in repr(e):
             pytest.skip('Class is abstract.')

--- a/tests/typing/test_bounds_tuple.py
+++ b/tests/typing/test_bounds_tuple.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+import pyvista as pv
+
+
+@pytest.mark.parametrize(
+    ('class_name', 'kwargs'),
+    [
+        ('Plotter', None),  # Also covers Renderer
+        ('MultiBlock', None),
+        ('Actor', None),  # Test Prop3D
+        ('AxesAssembly', None),  # Test Prop3DMixin
+        ('Label', None),
+        ('Cell', None),
+        ('CubeAxesActor', dict(camera=pv.Camera())),
+        ('BoxSource', None),
+        ('CubeSource', None),
+        ('FixedPointVolumeRayCastMapper', None),  # Test _BaseMapper
+        ('PolyData', None),  # Test DataSet
+    ],
+)
+def test_bounds_tuple(class_name, kwargs):
+    kwargs = kwargs if kwargs else {}
+    instance = getattr(pv, class_name)(**kwargs)
+    bounds = instance.bounds
+    assert len(bounds) == 6
+    assert isinstance(bounds, pv.BoundsTuple)
+    assert all(isinstance(bnd, float) for bnd in bounds)


### PR DESCRIPTION
### Overview

Use a named tuple to make accessing bounds more explicit. This makes code easier to read and understand.

This PR also standardizes the bounds representation as `x_min` rather than `xmin` or `xMin`, etc.

The tests are dynamically generated for any class with a `bounds` attribute. This will enforce future classes to also return a `BoundsTuple`.