### PR TITLE
Fix import error of matplotlib in Windows Unit Testing

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -293,13 +293,12 @@ jobs:
       - name: Install PyVista
         run: pip install . --no-deps
 
+      - name: Install msvc-runtime
+        run: |
+          pip install msvc-runtime
+
       - name: Install test dependencies
         run: pip install vtk -r requirements_test.txt
-
-      - name: Reinstall matplotlib
-        run: |
-          pip uninstall matplotlib
-          pip install matplotlib
 
       - name: Report
         run: python -c "import pyvista; print(pyvista.Report(gpu=False)); from pyvista import examples; print('User data path:', examples.USER_DATA_PATH)"

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -296,6 +296,9 @@ jobs:
       - name: Install test dependencies
         run: pip install vtk -r requirements_test.txt
 
+      - name: Install msvc-runtime
+        run: pip install msvc-runtime
+
       - name: Report
         run: python -c "import pyvista; print(pyvista.Report(gpu=False)); from pyvista import examples; print('User data path:', examples.USER_DATA_PATH)"
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -294,6 +294,7 @@ jobs:
         run: pip install . --no-deps
 
       - name: Install test dependencies
+        # https://github.com/pyvista/pyvista/pull/6458
         run: pip install vtk --only-binary "matplotlib" -r requirements_test.txt
 
       - name: Report

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -296,8 +296,10 @@ jobs:
       - name: Install test dependencies
         run: pip install vtk -r requirements_test.txt
 
-      - name: Install msvc-runtime
-        run: pip install msvc-runtime
+      - name: Reinstall matplotlib
+        run: |
+            pip uninstall matplotlib
+            pip install matplotlib
 
       - name: Report
         run: python -c "import pyvista; print(pyvista.Report(gpu=False)); from pyvista import examples; print('User data path:', examples.USER_DATA_PATH)"

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -294,7 +294,7 @@ jobs:
         run: pip install . --no-deps
 
       - name: Install test dependencies
-        run: pip install vtk--only-binary :all: -r requirements_test.txt
+        run: pip install vtk --only-binary :all: -r requirements_test.txt
 
       - name: Report
         run: python -c "import pyvista; print(pyvista.Report(gpu=False)); from pyvista import examples; print('User data path:', examples.USER_DATA_PATH)"

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -294,9 +294,7 @@ jobs:
         run: pip install . --no-deps
 
       - name: Install test dependencies
-        run: |
-          pip install vtk
-          pip -r --only-binary requirements_test.txt
+        run: pip install vtk -r --only-binary requirements_test.txt
 
       - name: Report
         run: python -c "import pyvista; print(pyvista.Report(gpu=False)); from pyvista import examples; print('User data path:', examples.USER_DATA_PATH)"

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -294,7 +294,7 @@ jobs:
         run: pip install . --no-deps
 
       - name: Install test dependencies
-        run: pip install vtk --only-binary -r requirements_test.txt
+        run: pip install vtk--only-binary :all: -r requirements_test.txt
 
       - name: Report
         run: python -c "import pyvista; print(pyvista.Report(gpu=False)); from pyvista import examples; print('User data path:', examples.USER_DATA_PATH)"

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -294,7 +294,7 @@ jobs:
         run: pip install . --no-deps
 
       - name: Install test dependencies
-        run: pip install vtk -r --only-binary requirements_test.txt
+        run: pip install vtk --only-binary -r requirements_test.txt
 
       - name: Report
         run: python -c "import pyvista; print(pyvista.Report(gpu=False)); from pyvista import examples; print('User data path:', examples.USER_DATA_PATH)"

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -294,7 +294,7 @@ jobs:
         run: pip install . --no-deps
 
       - name: Install test dependencies
-        run: pip install vtk --only-binary :all: -r requirements_test.txt
+        run: pip install vtk --only-binary ":all:" -r requirements_test.txt
 
       - name: Report
         run: python -c "import pyvista; print(pyvista.Report(gpu=False)); from pyvista import examples; print('User data path:', examples.USER_DATA_PATH)"

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -294,8 +294,7 @@ jobs:
         run: pip install . --no-deps
 
       - name: Install test dependencies
-        # https://github.com/pyvista/pyvista/pull/6458
-        run: pip install vtk --only-binary "matplotlib" -r requirements_test.txt
+        run: pip install vtk -r requirements_test.txt
 
       - name: Report
         run: python -c "import pyvista; print(pyvista.Report(gpu=False)); from pyvista import examples; print('User data path:', examples.USER_DATA_PATH)"

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -298,7 +298,9 @@ jobs:
           pip install msvc-runtime
 
       - name: Install test dependencies
-        run: pip install vtk -r requirements_test.txt
+        run: |
+          pip install vtk
+          pip -r --only-binary requirements_test.txt
 
       - name: Report
         run: python -c "import pyvista; print(pyvista.Report(gpu=False)); from pyvista import examples; print('User data path:', examples.USER_DATA_PATH)"

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -294,7 +294,7 @@ jobs:
         run: pip install . --no-deps
 
       - name: Install test dependencies
-        run: pip install vtk --only-binary ":all:" -r requirements_test.txt
+        run: pip install vtk --only-binary "matplotlib" -r requirements_test.txt
 
       - name: Report
         run: python -c "import pyvista; print(pyvista.Report(gpu=False)); from pyvista import examples; print('User data path:', examples.USER_DATA_PATH)"

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -293,10 +293,6 @@ jobs:
       - name: Install PyVista
         run: pip install . --no-deps
 
-      - name: Install msvc-runtime
-        run: |
-          pip install msvc-runtime
-
       - name: Install test dependencies
         run: |
           pip install vtk

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -298,8 +298,8 @@ jobs:
 
       - name: Reinstall matplotlib
         run: |
-            pip uninstall matplotlib
-            pip install matplotlib
+          pip uninstall matplotlib
+          pip install matplotlib
 
       - name: Report
         run: python -c "import pyvista; print(pyvista.Report(gpu=False)); from pyvista import examples; print('User data path:', examples.USER_DATA_PATH)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #  This is to prevent installing `vtk` from PyPI
 #  when using a custom variant like `vtk_osmesa`
 #  which we do in some of our CI jobs.
-matplotlib<3.9.2
+matplotlib<3.9.2 --only-binary "matplotlib"  # https://github.com/pyvista/pyvista/pull/6458
 numpy<2.1.0
 pillow<10.5.0
 pooch<1.9.0


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

Currently, the main branch Windows Unit Testing CI raise the following error.

```bash
Traceback (most recent call last):
  File "D:\a\pyvista\pyvista\pyvista\core\filters\data_set.py", line 13, in <module>
    import matplotlib.pyplot as plt
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\matplotlib\__init__.py", line [15](https://github.com/pyvista/pyvista/actions/runs/10232901666/job/28310593442#step:7:16)9, in <module>
    from . import _api, _version, cbook, _docstring, rcsetup
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\matplotlib\cbook.py", line 32, in <module>
    from matplotlib import _api, _c_internal_utils
ImportError: DLL load failed while importing _c_internal_utils: The specified module could not be found.
```
 Comparing the logs before and after the error, I found that the matplotlib installation changed from a binary to a source build. ~Although I have not been able to determine the reason for the change,~(Edit: See https://github.com/pyvista/pyvista/pull/6458#issuecomment-2267451811) I will prohibit source-built matplotlib installation in Windows CI as an emergency measure so as not to stop development.

The left is the log before the error occurred and the right is the log after the error occurred.
![image](https://github.com/user-attachments/assets/a0366ac5-b7a4-43fc-890c-9142785ad5f6)

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-no-binary