### PR TITLE
Fix broken alphabet buttons for the Dataset Gallery docs

### DIFF
--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -1647,9 +1647,7 @@ class AllDatasetsCarousel(DatasetGalleryCarousel):
 
     name = "all_datasets_carousel"
 
-    @property
-    def doc(self):
-        return DatasetCardFetcher.generate_alphabet_index(self.dataset_names)
+    doc = DatasetCardFetcher.generate_alphabet_index(DatasetGalleryCarousel.dataset_names)
 
     @classmethod
     def fetch_dataset_names(cls):

--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -1647,7 +1647,9 @@ class AllDatasetsCarousel(DatasetGalleryCarousel):
 
     name = "all_datasets_carousel"
 
-    doc = DatasetCardFetcher.generate_alphabet_index(DatasetGalleryCarousel.dataset_names)
+    @property
+    def doc(self):
+        return DatasetCardFetcher.generate_alphabet_index(self.dataset_names)
 
     @classmethod
     def fetch_dataset_names(cls):

--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -64,6 +64,18 @@ DATASET_GALLERY_IMAGE_EXT_DICT = {
 }
 
 
+class classproperty(property):
+    """Read-only class property decorator.
+
+    Used as an alternative to chaining @classmethod and @property which is deprecated.
+
+    See https://stackoverflow.com/a/13624858
+    """
+
+    def __get__(self, owner_self, owner_cls):
+        return self.fget(owner_cls)
+
+
 def _aligned_dedent(txt):
     """Custom variant of `textwrap.dedent`.
 
@@ -1647,8 +1659,7 @@ class AllDatasetsCarousel(DatasetGalleryCarousel):
 
     name = "all_datasets_carousel"
 
-    @classmethod  # type: ignore[misc]
-    @property
+    @classproperty
     def doc(cls):
         return DatasetCardFetcher.generate_alphabet_index(cls.dataset_names)
 

--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -1647,9 +1647,10 @@ class AllDatasetsCarousel(DatasetGalleryCarousel):
 
     name = "all_datasets_carousel"
 
+    @classmethod  # type: ignore[misc]
     @property
-    def doc(self):
-        return DatasetCardFetcher.generate_alphabet_index(self.dataset_names)
+    def doc(cls):
+        return DatasetCardFetcher.generate_alphabet_index(cls.dataset_names)
 
     @classmethod
     def fetch_dataset_names(cls):

--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -1358,7 +1358,15 @@ class DatasetCardFetcher:
         # Get mapping of alphabet letters to first dataset name which begins with each letter
         alphabet_dict = {}
         for dataset_name in sorted(dataset_names):
-            alphabet_dict.setdefault(dataset_name[0].upper(), dataset_name)
+            index_character = dataset_name[0].upper()
+            try:
+                int(index_character)
+            except ValueError:
+                pass
+            else:
+                index_character = '#'
+
+            alphabet_dict.setdefault(index_character, dataset_name)
 
         buttons = []
         for letter, dataset_name in alphabet_dict.items():


### PR DESCRIPTION
### Overview

https://github.com/pyvista/pyvista/pull/5872 added alphabet buttons to the Dataset Gallery to easily navigate to datasets by name. See the "A B C D..." buttons at the top of this screenshot:
https://github.com/pyvista/pyvista/pull/5872#pullrequestreview-1995660369

But this is now broken, it's been replaced with `<property object at (...)>`

<img width="411" alt="image" src="https://github.com/user-attachments/assets/5f2d4674-487c-4e94-8b53-47e477c67a7e">

I suspect this was broken by https://github.com/pyvista/pyvista/pull/5922 with this change:
``` diff
-    def doc(cls):
-        return DatasetCardFetcher.generate_alphabet_index(cls.dataset_names)
+    def doc(self):
+        return DatasetCardFetcher.generate_alphabet_index(self.dataset_names)
```

This PR attempts to fix this.
