### PR TITLE
Expose underlying `PlaneSource`s for `OrthogonalPlanesSource`

### DIFF
--- a/pyvista/plotting/axes_assembly.py
+++ b/pyvista/plotting/axes_assembly.py
@@ -1483,7 +1483,7 @@ class PlanesAssembly(_XYZAssembly):
         # Init planes from source
         self._geometry_source = OrthogonalPlanesSource(**kwargs)
         self._planes = self._geometry_source.output
-        self._plane_sources = self._geometry_source._plane_sources
+        self._plane_sources = self._geometry_source.sources
 
         for actor, dataset in zip(self._plane_actors, self.planes):
             actor.mapper = pv.DataSetMapper(dataset=dataset)


### PR DESCRIPTION
### Overview

Suggested in https://github.com/pyvista/pyvista/pull/6421#discussion_r1697578036

This is done by modifying the sources when setting/getting properties instead only when `update` is called.
