### PR TITLE
Update Dataset Gallery file extension formatting

### DIFF
--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -1141,7 +1141,7 @@ class DatasetPropsGenerator:
         if file_ext:
             file_ext = loader.unique_extension
             file_ext = [file_ext] if isinstance(file_ext, str) else file_ext
-            if len(file_ext) > 6:
+            if len(file_ext) > 10:
                 # Limit number of extensions displayed
                 first = _format_ext(file_ext[:3])
                 last = _format_ext(file_ext[-3:])

--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -8,7 +8,18 @@ from collections.abc import Callable
 from collections.abc import Iterable
 from collections.abc import Iterator
 from dataclasses import dataclass
-from enum import StrEnum
+import sys
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        def __str__(self) -> str:
+            return self.value
+
+
 from enum import auto
 import inspect
 import io
@@ -1122,11 +1133,19 @@ class DatasetPropsGenerator:
     def generate_file_ext(loader: _SingleFilePropsProtocol | _MultiFilePropsProtocol):
         # Format extension as single str with rst backticks
         # Multiple extensions are comma-separated
+        def _format_ext(file_ext_: list[str]):
+            return sep.join(["``" + ext + "``" for ext in file_ext_])
+
+        sep = ",\n"
         file_ext = DatasetPropsGenerator._try_getattr(loader, "unique_extension")
         if file_ext:
             file_ext = loader.unique_extension
             file_ext = [file_ext] if isinstance(file_ext, str) else file_ext
-            return "\n".join(["``'" + ext + "'``" for ext in file_ext])
+            if len(file_ext) > 6:
+                # Limit number of extensions displayed
+                first, last = _format_ext(file_ext[:3]), _format_ext(file_ext[-3:])
+                return first + sep + '...' + sep + last
+            return _format_ext(file_ext)
         return None
 
     @staticmethod

--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -1143,7 +1143,8 @@ class DatasetPropsGenerator:
             file_ext = [file_ext] if isinstance(file_ext, str) else file_ext
             if len(file_ext) > 6:
                 # Limit number of extensions displayed
-                first, last = _format_ext(file_ext[:3]), _format_ext(file_ext[-3:])
+                first = _format_ext(file_ext[:3])
+                last = _format_ext(file_ext[-3:])
                 return first + sep + '...' + sep + last
             return _format_ext(file_ext)
         return None


### PR DESCRIPTION
### Overview

- Add commas between extensions
- Remove the single quotes around each extension
- Limit the number of file extensions displayed to prevent super-long fields like this one from the [headsq dataset](https://dev.pyvista.org/api/examples/dataset_gallery#headsq-dataset):

<img width="332" alt="image" src="https://github.com/user-attachments/assets/12468e6d-4b6c-4748-9199-f9c2fbd770bd">

