### PR TITLE
Bump vtk-osmesa from 9.3.0 to 9.3.2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install custom OSMesa VTK variant
         run: |
           pip uninstall vtk -y
-          pip install vtk-osmesa==9.3.0 --index-url https://gitlab.kitware.com/api/v4/projects/13/packages/pypi/simple
+          pip install vtk-osmesa==9.3.2 --index-url https://gitlab.kitware.com/api/v4/projects/13/packages/pypi/simple
 
       - name: PyVista Report
         run: |


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Bump vtk-osmesa from 9.3.0 to 9.3.2.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None