### PR TITLE
Fix Plotter bounds when importing VRML file

### DIFF
--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -513,8 +513,18 @@ class BasePlotter(PickingHelper, WidgetHelper):
             importer.SetFileName(str(filename))
         else:
             importer.SetFileName(filename)
-        importer.SetRenderWindow(self.render_window)
+
+        # Import to temporary plotter first
+        temp_plotter = pyvista.Plotter()
+        importer.SetRenderWindow(temp_plotter.render_window)
         importer.Update()
+
+        # Add actors from temp plotter to this plotter
+        # Need to use `add_actor` for the plotter's bounds to update correctly
+        actors = temp_plotter.renderer.GetActors()
+        actors.InitTraversal()
+        for _ in range(actors.GetNumberOfItems()):
+            self.add_actor(actors.GetNextActor(), render=False)
 
     def import_3ds(self, filename) -> None:
         """Import a 3DS file into the plotter.

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -180,6 +180,7 @@ def test_import_vrml():
         pl.import_vrml('not a file')
 
     pl.import_vrml(filename)
+    assert np.array_equal(pl.bounds, (-0.5, 0.5, -0.5, 0.5, -0.5, 0.5))
     pl.show()
 
 


### PR DESCRIPTION
### Overview

The Plotter bounds in PyVista are manually computed from the list of actors that have explicitly been added. This means that any actors added to a renderer by any other means are not "seen" or "known" by the Plotter, and thus the bounds computation will be incorrect.

As a result, using the `import_vrml` method to add actors to a scene does not report the correct bounds. E.g.
``` python
import pyvista as pv
from pyvista import examples
pl = pv.Plotter()
pl.import_vrml(examples.vrml.download_sextant())
pl.bounds  # BoundsTuple(x_min=-1.0, x_max=1.0, y_min=-1.0, y_max=1.0, z_min=-1.0, z_max=1.0)
```

This PR fixes this, e.g. the correct bounds are:
``` python
pl.bounds  # BoundsTuple(x_min=0.48927752354865817, x_max=3.3604576885597908, y_min=-0.8170784576890213, y_max=1.2712147237834017, z_min=-2.109999952837825, z_max=-1.0)
```

This is more of a workaround than an actual fix. In my opinion I think the Plotter's `bounds` computation is problematic and should be updated. See https://github.com/pyvista/pyvista/pull/5182 for a separate issue with the bounds computation.
