### PR TITLE
Cast `center` to list in `project-plane.py`

### DIFF
--- a/examples/01-filter/project-plane.py
+++ b/examples/01-filter/project-plane.py
@@ -17,7 +17,7 @@ poly.plot()
 
 # %%
 # Project that surface to a plane underneath the surface
-origin = poly.center
+origin = list(poly.center)
 origin[-1] -= poly.length / 3.0
 projected = poly.project_points_to_plane(origin=origin)
 


### PR DESCRIPTION
### Overview

Follow-up to #6469. This example got missed, presumably due to caching from the docs. It is now causing failures in other PRs.