### PR TITLE
Add axis-rotation methods to `Transform`

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -932,6 +932,11 @@ class DataSet(DataSetFilters, DataObject):
         pyvista.DataSet
             Rotated dataset.
 
+        See Also
+        --------
+        pyvista.Transform.rotate_x
+            Concatenate a rotation about the x-axis with a transformation.
+
         Examples
         --------
         Rotate a mesh 30 degrees about the x-axis.
@@ -990,6 +995,11 @@ class DataSet(DataSetFilters, DataObject):
         -------
         pyvista.DataSet
             Rotated dataset.
+
+        See Also
+        --------
+        pyvista.Transform.rotate_y
+            Concatenate a rotation about the y-axis with a transformation.
 
         Examples
         --------
@@ -1050,6 +1060,11 @@ class DataSet(DataSetFilters, DataObject):
         -------
         pyvista.DataSet
             Rotated dataset.
+
+        See Also
+        --------
+        pyvista.Transform.rotate_z
+            Concatenate a rotation about the z-axis with a transformation.
 
         Examples
         --------
@@ -1114,6 +1129,11 @@ class DataSet(DataSetFilters, DataObject):
         -------
         pyvista.DataSet
             Rotated dataset.
+
+        See Also
+        --------
+        pyvista.Transform.rotate_vector
+            Concatenate a rotation about a vector with a transformation.
 
         Examples
         --------

--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -480,7 +480,7 @@ class Transform(_vtk.vtkTransform):
         angle : float
             Angle in degrees to rotate about the x-axis.
 
-        multiply_mode : 'pre' | 'post, optional
+        multiply_mode : 'pre' | 'post', optional
             Multiplication mode to use when concatenating the matrix. By default, the
             object's :attr:`multiply_mode` is used, but this can be overridden. Set this
             to ``'pre'`` for pre-multiplication or ``'post'`` for post-multiplication.
@@ -533,7 +533,7 @@ class Transform(_vtk.vtkTransform):
         angle : float
             Angle in degrees to rotate about the y-axis.
 
-        multiply_mode : 'pre' | 'post, optional
+        multiply_mode : 'pre' | 'post', optional
             Multiplication mode to use when concatenating the matrix. By default, the
             object's :attr:`multiply_mode` is used, but this can be overridden. Set this
             to ``'pre'`` for pre-multiplication or ``'post'`` for post-multiplication.
@@ -696,7 +696,7 @@ class Transform(_vtk.vtkTransform):
         transform : TransformLike
             Any transform-like input such as a 3x3 or 4x4 array or matrix.
 
-        multiply_mode : 'pre' | 'post, optional
+        multiply_mode : 'pre' | 'post', optional
             Multiplication mode to use when concatenating the matrix. By default, the
             object's :attr:`multiply_mode` is used, but this can be overridden. Set this
             to ``'pre'`` for pre-multiplication or ``'post'`` for post-multiplication.

--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -9,11 +9,13 @@ from pyvista.core import _validation
 from pyvista.core import _vtk_core as _vtk
 from pyvista.core.utilities.arrays import array_from_vtkmatrix
 from pyvista.core.utilities.arrays import vtkmatrix_from_array
+from pyvista.core.utilities.transformations import axis_angle_rotation
 
 if TYPE_CHECKING:  # pragma: no cover
     from pyvista.core._typing_core import NumpyArray
     from pyvista.core._typing_core import RotationLike
     from pyvista.core._typing_core import TransformLike
+    from pyvista.core._typing_core import VectorLike
 
 
 class Transform(_vtk.vtkTransform):
@@ -276,8 +278,7 @@ class Transform(_vtk.vtkTransform):
         Concatenate a scale matrix.
 
         >>> import pyvista as pv
-        >>> transform = pv.Transform()
-        >>> _ = transform.scale(1, 2, 3)
+        >>> transform = pv.Transform().scale(1, 2, 3)
         >>> transform.matrix
         array([[1., 0., 0., 0.],
                [0., 2., 0., 0.],
@@ -331,8 +332,7 @@ class Transform(_vtk.vtkTransform):
         Concatenate a translation matrix.
 
         >>> import pyvista as pv
-        >>> transform = pv.Transform()
-        >>> _ = transform.translate(1, 2, 3)
+        >>> transform = pv.Transform().translate(1, 2, 3)
         >>> transform.matrix
         array([[1., 0., 0., 1.],
                [0., 1., 0., 2.],
@@ -356,7 +356,7 @@ class Transform(_vtk.vtkTransform):
         return self.concatenate(transform, multiply_mode=multiply_mode)
 
     def rotate(
-        self, rotation: RotationLike, multiply_mode: Literal['pre', 'post'] | None = None
+        self, rotation: RotationLike, *, multiply_mode: Literal['pre', 'post'] | None = None
     ) -> Transform:  # numpydoc ignore=RT01
         """Concatenate a rotation matrix.
 
@@ -383,8 +383,7 @@ class Transform(_vtk.vtkTransform):
 
         >>> import pyvista as pv
         >>> rotation_z_90 = [[0, -1, 0], [1, 0, 0], [0, 0, 1]]
-        >>> transform = pv.Transform()
-        >>> _ = transform.rotate(rotation_z_90)
+        >>> transform = pv.Transform().rotate(rotation_z_90)
         >>> transform.matrix
         array([[ 0., -1.,  0.,  0.],
                [ 1.,  0.,  0.,  0.],
@@ -405,11 +404,206 @@ class Transform(_vtk.vtkTransform):
                [ 0.,  0.,  0.,  1.]])
         """
         valid_rotation = _validation.validate_transform3x3(rotation, name='rotation')
-        self.concatenate(valid_rotation, multiply_mode=multiply_mode)
-        return self
+        return self.concatenate(valid_rotation, multiply_mode=multiply_mode)
+
+    def rotate_x(
+        self, angle: float, *, multiply_mode: Literal['pre', 'post'] | None = None
+    ) -> Transform:  # numpydoc ignore=RT01
+        """Concatenate a rotation about the x-axis.
+
+        Create a matrix for rotation about the x-axis and :meth:`concatenate`
+        it with the current transformation :attr:`matrix` according to pre-multiply or
+        post-multiply semantics.
+
+        Internally, the matrix is stored in the :attr:`matrix_list`.
+
+        Parameters
+        ----------
+        angle : float
+            Angle in degrees to rotate about the x-axis.
+
+        multiply_mode : 'pre' | 'post, optional
+            Multiplication mode to use when concatenating the matrix. By default, the
+            object's :attr:`multiply_mode` is used, but this can be overridden. Set this
+            to ``'pre'`` for pre-multiplication or ``'post'`` for post-multiplication.
+
+        Examples
+        --------
+        Concatenate a rotation about the x-axis.
+
+        >>> import pyvista as pv
+        >>> transform = pv.Transform().rotate_x(90)
+        >>> transform.matrix
+        array([[ 1.,  0.,  0.,  0.],
+               [ 0.,  0., -1.,  0.],
+               [ 0.,  1.,  0.,  0.],
+               [ 0.,  0.,  0.,  1.]])
+
+        Concatenate a second rotation about the x-axis.
+
+        >>> _ = transform.rotate_x(45)
+
+        The result is a matrix that rotates about the x-axis by 135 degrees.
+
+        >>> transform.matrix
+        array([[ 1.        ,  0.        ,  0.        ,  0.        ],
+               [ 0.        , -0.70710678, -0.70710678,  0.        ],
+               [ 0.        ,  0.70710678, -0.70710678,  0.        ],
+               [ 0.        ,  0.        ,  0.        ,  1.        ]])
+        """
+        transform = axis_angle_rotation((1, 0, 0), angle, deg=True)
+        return self.concatenate(transform, multiply_mode=multiply_mode)
+
+    def rotate_y(
+        self, angle: float, *, multiply_mode: Literal['pre', 'post'] | None = None
+    ) -> Transform:  # numpydoc ignore=RT01
+        """Concatenate a rotation about the y-axis.
+
+        Create a matrix for rotation about the y-axis and :meth:`concatenate`
+        it with the current transformation :attr:`matrix` according to pre-multiply or
+        post-multiply semantics.
+
+        Internally, the matrix is stored in the :attr:`matrix_list`.
+
+        Parameters
+        ----------
+        angle : float
+            Angle in degrees to rotate about the y-axis.
+
+        multiply_mode : 'pre' | 'post, optional
+            Multiplication mode to use when concatenating the matrix. By default, the
+            object's :attr:`multiply_mode` is used, but this can be overridden. Set this
+            to ``'pre'`` for pre-multiplication or ``'post'`` for post-multiplication.
+
+        Examples
+        --------
+        Concatenate a rotation about the y-axis.
+
+        >>> import pyvista as pv
+        >>> transform = pv.Transform().rotate_y(90)
+        >>> transform.matrix
+        array([[ 1.,  0.,  0.,  0.],
+               [ 0.,  0., -1.,  0.],
+               [ 0.,  1.,  0.,  0.],
+               [ 0.,  0.,  0.,  1.]])
+
+        Concatenate a second rotation about the y-axis.
+
+        >>> _ = transform.rotate_y(45)
+
+        The result is a matrix that rotates about the y-axis by 135 degrees.
+
+        >>> transform.matrix
+        array([[-0.70710678,  0.        ,  0.70710678,  0.        ],
+               [ 0.        ,  1.        ,  0.        ,  0.        ],
+               [-0.70710678,  0.        , -0.70710678,  0.        ],
+               [ 0.        ,  0.        ,  0.        ,  1.        ]])
+        """
+        transform = axis_angle_rotation((0, 1, 0), angle, deg=True)
+        return self.concatenate(transform, multiply_mode=multiply_mode)
+
+    def rotate_z(
+        self, angle: float, *, multiply_mode: Literal['pre', 'post'] | None = None
+    ) -> Transform:  # numpydoc ignore=RT01
+        """Concatenate a rotation about the z-axis.
+
+        Create a matrix for rotation about the z-axis and :meth:`concatenate`
+        it with the current transformation :attr:`matrix` according to pre-multiply or
+        post-multiply semantics.
+
+        Internally, the matrix is stored in the :attr:`matrix_list`.
+
+        Parameters
+        ----------
+        angle : float
+            Angle in degrees to rotate about the z-axis.
+
+        multiply_mode : 'pre' | 'post', optional
+            Multiplication mode to use when concatenating the matrix. By default, the
+            object's :attr:`multiply_mode` is used, but this can be overridden. Set this
+            to ``'pre'`` for pre-multiplication or ``'post'`` for post-multiplication.
+
+        Examples
+        --------
+        Concatenate a rotation about the z-axis.
+
+        >>> import pyvista as pv
+        >>> transform = pv.Transform().rotate_z(90)
+        >>> transform.matrix
+        array([[ 0., -1.,  0.,  0.],
+               [ 1.,  0.,  0.,  0.],
+               [ 0.,  0.,  1.,  0.],
+               [ 0.,  0.,  0.,  1.]])
+
+        Concatenate a second rotation about the z-axis.
+
+        >>> _ = transform.rotate_z(45)
+
+        The result is a matrix that rotates about the z-axis by 135 degrees.
+
+        >>> transform.matrix
+        array([[-0.70710678, -0.70710678,  0.        ,  0.        ],
+               [ 0.70710678, -0.70710678,  0.        ,  0.        ],
+               [ 0.        ,  0.        ,  1.        ,  0.        ],
+               [ 0.        ,  0.        ,  0.        ,  1.        ]])
+        """
+        transform = axis_angle_rotation((0, 0, 1), angle, deg=True)
+        return self.concatenate(transform, multiply_mode=multiply_mode)
+
+    def rotate_vector(
+        self,
+        vector: VectorLike[float],
+        angle: float,
+        *,
+        multiply_mode: Literal['pre', 'post'] | None = None,
+    ) -> Transform:  # numpydoc ignore=RT01
+        """Concatenate a rotation about a vector.
+
+        Create a matrix for rotation about the vector and :meth:`concatenate`
+        it with the current transformation :attr:`matrix` according to pre-multiply or
+        post-multiply semantics.
+
+        Internally, the matrix is stored in the :attr:`matrix_list`.
+
+        Parameters
+        ----------
+        vector : VectorLike[float]
+            Vector to rotate about.
+
+        angle : float
+            Angle in degrees to rotate about the vector.
+
+        multiply_mode : 'pre' | 'post', optional
+            Multiplication mode to use when concatenating the matrix. By default, the
+            object's :attr:`multiply_mode` is used, but this can be overridden. Set this
+            to ``'pre'`` for pre-multiplication or ``'post'`` for post-multiplication.
+
+        Examples
+        --------
+        Concatenate a rotation of 30 degrees about the ``(1, 1, 1)`` axis.
+
+        >>> import pyvista as pv
+        >>> transform = pv.Transform().rotate_vector((1, 1, 1), 30)
+        >>> transform.matrix
+        array([[ 1.       ,  0.       ,  0.       ,  0.       ],
+               [ 0.       ,  0.8660254, -0.5      ,  0.       ],
+               [ 0.       ,  0.5      ,  0.8660254,  0.       ],
+               [ 0.       ,  0.       ,  0.       ,  1.       ]])
+
+        Concatenate a second rotation of 45 degrees about the ``(1, 2, 3)`` axis.
+
+        >>> _ = transform.rotate_vector((1, 2, 3), 45)
+        >>> transform.matrix
+        array([[ 1.        ,  0.        ,  0.        ,  0.        ],
+               [ 0.        ,  0.25881905, -0.96592583,  0.        ],
+               [ 0.        ,  0.96592583,  0.25881905,  0.        ],
+               [ 0.        ,  0.        ,  0.        ,  1.        ]])
+        """
+        transform = axis_angle_rotation(vector, angle, deg=True)
+        return self.concatenate(transform, multiply_mode=multiply_mode)
 
     def concatenate(
-        self, transform: TransformLike, multiply_mode: Literal['pre', 'post'] | None = None
+        self, transform: TransformLike, *, multiply_mode: Literal['pre', 'post'] | None = None
     ) -> Transform:  # numpydoc ignore=RT01
         """Concatenate a transformation matrix.
 
@@ -424,7 +618,7 @@ class Transform(_vtk.vtkTransform):
         transform : TransformLike
             Any transform-like input such as a 3x3 or 4x4 array or matrix.
 
-        multiply_mode : 'pre' | 'post' | None, optional
+        multiply_mode : 'pre' | 'post, optional
             Multiplication mode to use when concatenating the matrix. By default, the
             object's :attr:`multiply_mode` is used, but this can be overridden. Set this
             to ``'pre'`` for pre-multiplication or ``'post'`` for post-multiplication.
@@ -440,8 +634,7 @@ class Transform(_vtk.vtkTransform):
         ...     [0, 0, 1, 1.5],
         ...     [0, 0, 0, 2],
         ... ]
-        >>> transform = pv.Transform()
-        >>> _ = transform.concatenate(array)
+        >>> transform = pv.Transform().concatenate(array)
         >>> transform.matrix
         array([[ 0.707, -0.707,  0.   ,  0.   ],
                [ 0.707,  0.707,  0.   ,  0.   ],

--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -427,6 +427,11 @@ class Transform(_vtk.vtkTransform):
             object's :attr:`multiply_mode` is used, but this can be overridden. Set this
             to ``'pre'`` for pre-multiplication or ``'post'`` for post-multiplication.
 
+        See Also
+        --------
+        pyvista.DataSet.rotate_x
+            Rotate a mesh about the x-axis.
+
         Examples
         --------
         Concatenate a rotation about the x-axis.
@@ -475,6 +480,11 @@ class Transform(_vtk.vtkTransform):
             object's :attr:`multiply_mode` is used, but this can be overridden. Set this
             to ``'pre'`` for pre-multiplication or ``'post'`` for post-multiplication.
 
+        See Also
+        --------
+        pyvista.DataSet.rotate_y
+            Rotate a mesh about the y-axis.
+
         Examples
         --------
         Concatenate a rotation about the y-axis.
@@ -522,6 +532,11 @@ class Transform(_vtk.vtkTransform):
             Multiplication mode to use when concatenating the matrix. By default, the
             object's :attr:`multiply_mode` is used, but this can be overridden. Set this
             to ``'pre'`` for pre-multiplication or ``'post'`` for post-multiplication.
+
+        See Also
+        --------
+        pyvista.DataSet.rotate_z
+            Rotate a mesh about the z-axis.
 
         Examples
         --------
@@ -577,6 +592,11 @@ class Transform(_vtk.vtkTransform):
             Multiplication mode to use when concatenating the matrix. By default, the
             object's :attr:`multiply_mode` is used, but this can be overridden. Set this
             to ``'pre'`` for pre-multiplication or ``'post'`` for post-multiplication.
+
+        See Also
+        --------
+        pyvista.DataSet.rotate_vector
+            Rotate a mesh about a vector.
 
         Examples
         --------

--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -495,9 +495,9 @@ class Transform(_vtk.vtkTransform):
         >>> import pyvista as pv
         >>> transform = pv.Transform().rotate_y(90)
         >>> transform.matrix
-        array([[ 1.,  0.,  0.,  0.],
-               [ 0.,  0., -1.,  0.],
+        array([[ 0.,  0.,  1.,  0.],
                [ 0.,  1.,  0.,  0.],
+               [-1.,  0.,  0.,  0.],
                [ 0.,  0.,  0.,  1.]])
 
         Concatenate a second rotation about the y-axis.
@@ -608,18 +608,18 @@ class Transform(_vtk.vtkTransform):
         >>> import pyvista as pv
         >>> transform = pv.Transform().rotate_vector((1, 1, 1), 30)
         >>> transform.matrix
-        array([[ 1.       ,  0.       ,  0.       ,  0.       ],
-               [ 0.       ,  0.8660254, -0.5      ,  0.       ],
-               [ 0.       ,  0.5      ,  0.8660254,  0.       ],
-               [ 0.       ,  0.       ,  0.       ,  1.       ]])
+        array([[ 0.9106836 , -0.24401694,  0.33333333,  0.        ],
+               [ 0.33333333,  0.9106836 , -0.24401694,  0.        ],
+               [-0.24401694,  0.33333333,  0.9106836 ,  0.        ],
+               [ 0.        ,  0.        ,  0.        ,  1.        ]])
 
         Concatenate a second rotation of 45 degrees about the ``(1, 2, 3)`` axis.
 
         >>> _ = transform.rotate_vector((1, 2, 3), 45)
         >>> transform.matrix
-        array([[ 1.        ,  0.        ,  0.        ,  0.        ],
-               [ 0.        ,  0.25881905, -0.96592583,  0.        ],
-               [ 0.        ,  0.96592583,  0.25881905,  0.        ],
+        array([[ 0.38042304, -0.50894634,  0.77217351,  0.        ],
+               [ 0.83349512,  0.55045308, -0.04782562,  0.        ],
+               [-0.40070461,  0.66179682,  0.63360933,  0.        ],
                [ 0.        ,  0.        ,  0.        ,  1.        ]])
         """
         transform = axis_angle_rotation(vector, angle, deg=True)

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -1167,6 +1167,50 @@ def test_transform_rotate(transform):
     assert np.array_equal(identity, np.eye(4))
 
 
+ANGLE = 30
+
+
+def test_transform_rotate_x(transform):
+    transform.rotate_x(ANGLE)
+    actual = transform.matrix
+    expected = transformations.axis_angle_rotation((1, 0, 0), ANGLE)
+    assert np.array_equal(actual, expected)
+
+    identity = transform.matrix @ transform.inverse_matrix
+    assert np.array_equal(identity, np.eye(4))
+
+
+def test_transform_rotate_y(transform):
+    transform.rotate_y(ANGLE)
+    actual = transform.matrix
+    expected = transformations.axis_angle_rotation((0, 1, 0), ANGLE)
+    assert np.array_equal(actual, expected)
+
+    identity = transform.matrix @ transform.inverse_matrix
+    assert np.allclose(identity, np.eye(4))
+
+
+def test_transform_rotate_z(transform):
+    transform.rotate_z(ANGLE)
+    actual = transform.matrix
+    expected = transformations.axis_angle_rotation((0, 0, 1), ANGLE)
+    assert np.array_equal(actual, expected)
+
+    identity = transform.matrix @ transform.inverse_matrix
+    assert np.array_equal(identity, np.eye(4))
+
+
+def test_transform_rotate_vector(transform):
+    VECTOR = (1, 2, 3)
+    transform.rotate_vector(VECTOR, ANGLE)
+    actual = transform.matrix
+    expected = transformations.axis_angle_rotation(VECTOR, ANGLE)
+    assert np.array_equal(actual, expected)
+
+    identity = transform.matrix @ transform.inverse_matrix
+    assert np.allclose(identity, np.eye(4))
+
+
 def test_transform_concatenate_vtkmatrix(transform):
     scale_array = np.diag((1, 2, 3, 1))
     vtkmatrix = pv.vtkmatrix_from_array(scale_array)

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -1217,8 +1217,10 @@ def test_transform_rotate_z(transform):
     assert np.allclose(identity, np.eye(4))
 
 
+VECTOR = (1, 2, 3)
+
+
 def test_transform_rotate_vector(transform):
-    VECTOR = (1, 2, 3)
     transform.rotate_vector(VECTOR, ANGLE)
     actual = transform.matrix
     expected = transformations.axis_angle_rotation(VECTOR, ANGLE)

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -1180,7 +1180,7 @@ def test_transform_rotate_x(transform):
     assert np.array_equal(actual, expected)
 
     identity = transform.matrix @ transform.inverse_matrix
-    assert np.array_equal(identity, np.eye(4))
+    assert np.allclose(identity, np.eye(4))
 
 
 def test_transform_rotate_y(transform):
@@ -1200,7 +1200,7 @@ def test_transform_rotate_z(transform):
     assert np.array_equal(actual, expected)
 
     identity = transform.matrix @ transform.inverse_matrix
-    assert np.array_equal(identity, np.eye(4))
+    assert np.allclose(identity, np.eye(4))
 
 
 def test_transform_rotate_vector(transform):


### PR DESCRIPTION
### Overview

Add `rotate_x`, `rotate_y`, `rotate_z`, `rotate_vector` methods.

NOTE: These methods can make use of  the `point` parameter from #6501 