### PR TITLE
Add `__array__` method to `Transform` for casting to a NumPy array

### DIFF
--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -187,12 +187,7 @@ class Transform(_vtk.vtkTransform):
 
     def __array__(self, dtype=None, copy=None):
         """Cast this transform to a NumPy array."""
-        kwargs = {}
-        if dtype is not None:
-            kwargs['dtype'] = dtype
-        if copy is not None:
-            kwargs['copy'] = copy
-        return self.matrix.astype(**kwargs)
+        return self.matrix.astype(dtype=dtype, copy=copy) if copy is not None else self.matrix.astype(dtype=dtype)
 
     @property
     def multiply_mode(self) -> Literal['pre', 'post']:  # numpydoc ignore=RT01

--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -187,7 +187,12 @@ class Transform(_vtk.vtkTransform):
 
     def __array__(self, dtype=None, copy=None):
         """Cast this transform to a NumPy array."""
-        return self.matrix.astype(dtype=dtype, copy=copy)
+        kwargs = {}
+        if dtype is not None:
+            kwargs['dtype'] = dtype
+        if copy is not None:
+            kwargs['copy'] = copy
+        return self.matrix.astype(**kwargs)
 
     @property
     def multiply_mode(self) -> Literal['pre', 'post']:  # numpydoc ignore=RT01

--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -187,7 +187,11 @@ class Transform(_vtk.vtkTransform):
 
     def __array__(self, dtype=None, copy=None):
         """Cast this transform to a NumPy array."""
-        return self.matrix.astype(dtype=dtype, copy=copy) if copy is not None else self.matrix.astype(dtype=dtype)
+        return (
+            self.matrix.astype(dtype=dtype, copy=copy)
+            if copy is not None
+            else self.matrix.astype(dtype=dtype)
+        )
 
     @property
     def multiply_mode(self) -> Literal['pre', 'post']:  # numpydoc ignore=RT01

--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -185,6 +185,10 @@ class Transform(_vtk.vtkTransform):
         if trans is not None:
             self.matrix = trans  # type: ignore[assignment]
 
+    def __array__(self):
+        """Cast this transform to a NumPy array."""
+        return self.matrix
+
     @property
     def multiply_mode(self) -> Literal['pre', 'post']:  # numpydoc ignore=RT01
         """Set or get the multiplication mode.

--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -185,9 +185,9 @@ class Transform(_vtk.vtkTransform):
         if trans is not None:
             self.matrix = trans  # type: ignore[assignment]
 
-    def __array__(self):
+    def __array__(self, dtype=None, copy=None):
         """Cast this transform to a NumPy array."""
-        return self.matrix
+        return self.matrix.astype(dtype=dtype, copy=copy)
 
     @property
     def multiply_mode(self) -> Literal['pre', 'post']:  # numpydoc ignore=RT01

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -1306,18 +1306,24 @@ def test_transform_chain_methods():
     assert np.array_equal(matrix, eye4)
 
 
-@pytest.mark.parametrize('array_func', [np.array, np.asarray, np.asanyarray])
-def test_transform_asarray(transform, array_func):
+@pytest.mark.parametrize(('copy', 'dtype'), [(True, int), (True, float), (False, float)])
+def test_transform_asarray(transform, dtype, copy):
     # Test a copy is always returned by default
     transform.scale(SCALE)
     matrix = transform.matrix
     assert matrix is not transform.matrix
 
     # Test cast to numpy
-    array = array_func(matrix)
-    if array_func is np.array:
+    array = np.asarray(matrix, dtype=dtype, copy=copy)
+    assert array.dtype == dtype
+    if dtype is int or copy:
         assert array is not matrix
     else:
         assert array is matrix
 
     assert np.array_equal(array, matrix)
+
+
+def test_transform_array_dunder(transform):
+    array = transform.__array__()
+    assert isinstance(array, np.ndarray)

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -1314,7 +1314,13 @@ def test_transform_asarray(transform, dtype, copy):
     assert matrix is not transform.matrix
 
     # Test cast to numpy
-    array = np.asarray(matrix, dtype=dtype, copy=copy)
+    try:
+        array = np.asarray(matrix, dtype=dtype, copy=copy)
+    except TypeError as e:
+        # Will fail for older python 3.8/3.9 on Linux/Windows
+        if "asarray() got an unexpected keyword argument 'copy'" in repr(e):
+            pytest.xfail('Copy not supported')
+
     assert array.dtype == dtype
     if dtype is int or copy:
         assert array is not matrix

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -1304,3 +1304,20 @@ def test_transform_chain_methods():
         .matrix
     )
     assert np.array_equal(matrix, eye4)
+
+
+@pytest.mark.parametrize('array_func', [np.array, np.asarray, np.asanyarray])
+def test_transform_asarray(transform, array_func):
+    # Test a copy is always returned by default
+    transform.scale(SCALE)
+    matrix = transform.matrix
+    assert matrix is not transform.matrix
+
+    # Test cast to numpy
+    array = array_func(matrix)
+    if array_func is np.array:
+        assert array is not matrix
+    else:
+        assert array is matrix
+
+    assert np.array_equal(array, matrix)


### PR DESCRIPTION
### Overview

Make this code valid and return a `Transform`'s `matrix`: 
``` python
np.array(Transform())
```