### PR TITLE
Pad `voxelize` and `voxelize_volume` to contain input mesh

### DIFF
--- a/pyvista/core/utilities/features.py
+++ b/pyvista/core/utilities/features.py
@@ -25,9 +25,6 @@ def padded_bins(mesh, density):
         density : array_like[float]
             A list of densities along x,y,z directions.
 
-        density (_type_): _description_
-        bounds (_type_, optional): _description_. Defaults to None.
-
     Returns
     -------
     list[np.ndarray]
@@ -37,7 +34,6 @@ def padded_bins(mesh, density):
     -----
     Ensures limits of voxelization are padded to ensure the mesh is fully enclosed.
     """
-
     bounds = np.array(mesh.bounds).reshape(3, 2)
     bin_count = np.ceil((bounds[:, 1] - bounds[:, 0]) / density)
     pad = (bin_count * density - (bounds[:, 1] - bounds[:, 0])) / 2

--- a/pyvista/core/utilities/features.py
+++ b/pyvista/core/utilities/features.py
@@ -42,12 +42,10 @@ def padded_bins(mesh, density):
     bin_count = np.ceil((bounds[:, 1] - bounds[:, 0]) / density)
     pad = (bin_count * density - (bounds[:, 1] - bounds[:, 0])) / 2
 
-    bin_edges = [
+    return [
         np.arange(bounds[i, 0] - pad[i], bounds[i, 1] + pad[i] + density[i] / 2, density[i])
         for i in range(3)
     ]
-
-    return bin_edges
 
 
 def voxelize(mesh, density=None, check_surface=True):


### PR DESCRIPTION
### Overview

Padding added to pyvista voxelisation. 

### Details

Currently pyvista voxelize and voxelize volume do not cover the entire mesh because the np.arange method finds the nearest bin within the range. 

This commit ensures that the bounds of the voxelization completely cover the input mesh.

Example from the docs - https://docs.pyvista.org/api/utilities/_autosummary/pyvista.voxelize_volume.html

The following code generates a voxelization with surface vertices which lie within the input mesh - therefore the input mesh isn't fully covered.
`import numpy as np
from pyvista import examples
mesh = examples.download_cow()

import pyvista as pv
pv.start_xvfb(wait=0.0)

vox = pv.voxelize_volume(mesh, density=0.15)
vox = vox.select_enclosed_points(mesh, tolerance=0.0)
vox.plot(scalars='SelectedPoints', show_edges=True, jupyter_backend='static')`
![image](https://github.com/user-attachments/assets/988d1fc2-cedb-4b37-bc1c-d508ab44a7dc)

The horns, nose and side of the cow extend outside the voxelization. After the change, the mesh is fully contained and the boundaries of the mesh lie within the last voxel at the edges.

![image](https://github.com/user-attachments/assets/388de3d4-8a50-44c4-8812-e95e48cc0a1f)

