### PR TITLE
Better support for explicit structured grids

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -2898,8 +2898,7 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
             raise ValueError("Expected dimensions to be length 3.")
         
         else:
-            nx, ny, nz = dims - 1
-            n_cells = nx * ny * nz
+            n_cells = np.prod([n - 1 for n in dims])
 
         if isinstance(cells, dict):
             celltypes = list(cells)

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -2867,12 +2867,6 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
             ]
         )
         cells = np.arange(8 * ni * nj * nk).reshape((ni * nj * nk, 8))
-        points, pinv = np.unique(
-            points,
-            axis=0,
-            return_inverse=True,
-        )
-        cells = pinv[cells]
         self._from_cells_points(dims, {CellType.HEXAHEDRON: cells}, points)
 
     def _from_cells_points(

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -2875,7 +2875,7 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
         cells: VectorLike[int] | dict[int, MatrixLike[int]],
         points: MatrixLike[float],
     ) -> None:
-        """Create a VTK explicit structured grid from NumPy arrays.
+        """Create a VTK explicit structured grid from cells and points arrays.
 
         Parameters
         ----------
@@ -2883,9 +2883,12 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
             A sequence of integers with shape (3,) containing the
             topological dimensions of the grid.
 
-        corners : MatrixLike[float]
-            A sequence of numbers with shape ``(number of corners, 3)``
-            containing the coordinates of the corner points.
+        cells : VectorLike[int] | dict[int, MatrixLike[int]]
+            Array of cells.  Each cell contains the number of points in the
+            cell and the node numbers of the cell.
+
+        points : MatrixLike[float]
+            Numpy array containing point locations.
 
         """
         if len(dims) != 3:

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -2729,7 +2729,7 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
     Can be initialized by the following:
 
     - Creating an empty grid
-    - From a ``vtk.vtkExplicitStructuredGrid`` or ``vtk.vtkUnstructuredGrid`` object
+    - From a ``vtk.StructuredGrid``, ``vtk.vtkExplicitStructuredGrid`` or ``vtk.vtkUnstructuredGrid`` object
     - From a VTU or VTK file
     - From ``dims`` and ``corners`` arrays
     - From ``dims``, ``cells`` and ``points`` arrays
@@ -2795,7 +2795,7 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
                     self.deep_copy(arg0)
                 else:
                     self.shallow_copy(arg0)
-            elif isinstance(arg0, _vtk.vtkUnstructuredGrid):
+            elif isinstance(arg0, (_vtk.vtkStructuredGrid, _vtk.vtkUnstructuredGrid)):
                 grid = arg0.cast_to_explicit_structured_grid()
                 self.shallow_copy(grid)
             elif isinstance(arg0, (str, Path)):

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -2677,30 +2677,28 @@ class StructuredGrid(PointGrid, StructuredGridFilters, _vtk.vtkStructuredGrid):
         # add but do not make active
         self.point_data.set_array(ghost_points, _vtk.vtkDataSetAttributes.GhostArrayName())  # type: ignore[arg-type]
 
-    def cast_to_explicit_structured_grid(
-        self,
-        order: Optional[Literal["C", "F"]] = None,
-    ) -> ExplicitStructuredGrid:
+    def cast_to_explicit_structured_grid(self) -> ExplicitStructuredGrid:
         """Cast to an explicit structured grid.
-
-        Parameters
-        ----------
-        order : {'C', 'F'}, optional, default: 'F'
-            Specifies whether cells are indexed in row-major (C-style) or column-major (Fortran-style) order.
 
         Returns
         -------
         pyvista.ExplicitStructuredGrid
             An explicit structured grid.
 
+        Raises
+        ------
+        TypeError
+            If the structured grid is not 3D (i.e., any dimension is 1).
+
         """
-        order = order if order else "F"
+        if any(n == 1 for n in self.dimensions):
+            raise TypeError("Only 3D structured grid can be casted to an explicit structured grid.")
 
         ni, nj, nk = self.dimensions
         I, J, K = np.unravel_index(
             np.arange(self.n_cells),
             shape=(ni - 1, nj - 1, nk - 1),
-            order=order,
+            order="F",
         )
 
         grid = self.cast_to_unstructured_grid()


### PR DESCRIPTION
### Overview

Following issue #6432, this PR aims at giving some more love for explicit structured grids, which are mainly used in subsurface modeling (e.g., water resources, oil and gas, CO2 sequestration...).

### Details

- Resolves #6432 by vectorizing the inefficient loop and not removing the duplicate points by default.
- Adds a method ``pyvista.ExplicitStructuredGrid.clean()`` (which is much faster than ``numpy.unique``) as an alternative, leaving duplicate points removal to the discretion of the user.
- Allows instantiation of explicit structured grids from cells and points as expected by VTK (following @MatthewFlamm's suggestion in #6432).
- Adds a method ``pyvista.StructuredGrid.cast_to_explicit_structured_grid()`` which is more likely how people would instantiate such grid. Basically, the whole example in the documentation which is quite difficult to understand can be shortened to:

```python
xi = np.arange(0.0, (ni + 1) * si, si)
yi = np.arange(0.0, (nj + 1) * sj, sj)
zi = np.arange(0.0, (nk + 1) * sk, sk)
grid = pv.StructuredGrid(*np.meshgrid(xi, yi, zi, indexing="ij"))
egrid = pv.ExplicitStructuredGrid(grid)
```

- Adds a reader for *THE* explicit structured grid format GRDECL. Usually, one would generate the ``corners`` array using a package like ``xtgeo`` (which is fast as it's written in C). The reader is slightly slower, but has been vectorized as much as I could, and does not require that huge dependency.