### PR TITLE
Speed up and simplify `principal_axes` test with many points

### DIFF
--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -1004,19 +1004,15 @@ def test_principal_axes_single_point():
     assert np.allclose(axes, DEFAULT_PRINCIPAL_AXES)
 
 
-def test_principal_axes_vectors_success_with_many_points():
+@pytest.fixture()
+def one_million_points():
+    return np.random.default_rng().random((1_000_000, 3))
+
+
+def test_principal_axes_success_with_many_points(one_million_points):
     # Use large mesh to verify no memory errors are raised
-    res = 1000
-    ellipsoid = pv.ParametricEllipsoid(
-        xradius=3, yradius=2, zradius=1, u_res=res, v_res=res, w_res=res
-    )
-    assert ellipsoid.n_points == 997_004
-
-    axes, std = pv.principal_axes(ellipsoid.points, return_std=True)
-
-    # Check std to verify the computed output is valid
-    # Need large atol due to loss of numerical precision
-    assert np.allclose(std, [1.50074922, 1.00049953, 0.70675449])
+    axes = pv.principal_axes(one_million_points)
+    assert isinstance(axes, np.ndarray)
 
 
 @pytest.fixture()


### PR DESCRIPTION
### Overview

The current test to check that principal axes succeeds with many points is slow and hangs up the testing (have to wait 5~10 seconds for this one test to execute). This is because it generates an ellipsoid for the test. The ellipsoid was initially used to check the correct std output. But, this requires magic numbers for the test, and is redundant since the correct std output is tested elsewhere (and more correctly without magic numbers).

This PR uses a numpy array instead the ellipsoid for the tests. This speeds up the test considerably. In addition, I'd like to add a similar to test for `fit_plane_to_points` as part of #6517 to test that it resolves #6460. The fixture from this PR can be used for that test as well.