### PR TITLE
Do not initialize `axis_2_direction` for `align_xyz`

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -388,11 +388,11 @@ class DataSetFilters:
 
         axes, std = pyvista.principal_axes(self.points, return_std=True)
 
-        # Set directions to +X,+Y,+Z by default
         if axis_0_direction is None and axis_1_direction is None and axis_2_direction is None:
+            # Set directions of first two axes to +X,+Y by default
+            # Keep third axis as None (direction cannot be set if first two are set)
             axis_0_direction = (1.0, 0.0, 0.0)
             axis_1_direction = (0.0, 1.0, 0.0)
-            axis_2_direction = (0.0, 0.0, 1.0)
         else:
             axis_0_direction = _validate_vector(axis_0_direction, name='axis 0 direction')
             axis_1_direction = _validate_vector(axis_1_direction, name='axis 1 direction')


### PR DESCRIPTION
### Overview

Only two axis directions can be set for `align_xyz`. Setting the third by default has no effect and can result in an unexpected error. This PR fixes this.

Discovered as part of #6517.