### PR TITLE
Fix default value in docs for `partition` filter `as_composite` option

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -7171,7 +7171,7 @@ class DataSetFilters:
             This is stored as ``"vtkGlobalCellIds"`` within the ``cell_data``
             of the output dataset(s).
 
-        as_composite : bool, default: False
+        as_composite : bool, default: True
             Return the partitioned dataset as a :class:`pyvista.MultiBlock`.
 
         See Also


### PR DESCRIPTION
### Overview

Function signature says True, doc says False. Change this to True.