### PR TITLE
Enable shadows by default for `AxesAssembly` labels

### DIFF
--- a/pyvista/plotting/axes_assembly.py
+++ b/pyvista/plotting/axes_assembly.py
@@ -484,6 +484,8 @@ class AxesAssembly(_XYZAssembly):
             prop = label.prop
             prop.bold = True
             prop.italic = True
+            prop.enable_shadow()
+            prop.SetShadowOffset(-1, 1)
 
     def __repr__(self):
         """Representation of the axes assembly."""


### PR DESCRIPTION
### Overview

I am finding the default label color (black) difficult to read against the default z-axis color (blue). See the examples in the [AxesAssembly docs](https://dev.pyvista.org/api/plotting/_autosummary/pyvista.axesassembly#pyvista.AxesAssembly). This PR enables shadows by default to create contrast.
<img width="102" alt="low-contrast" src="https://github.com/user-attachments/assets/0145a169-a672-4c46-bb81-3b97fe77fb66"> <img width="103" alt="shadows" src="https://github.com/user-attachments/assets/5d3d1888-8941-4eb2-b8e9-9d689bd96ea1">
