### PR TITLE
Fix names when using `MultiBlock.transform`

### DIFF
--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -270,9 +270,9 @@ class CompositeFilters:
         """
         trans = pyvista.Transform(trans)
         multi = self if inplace else self.copy(deep=False)  # type: ignore[attr-defined]
-        for i, block in enumerate(self):  # type: ignore[var-annotated, arg-type]
-            if block is not None:
-                multi[i] = block.transform(
+        for name in self.keys():  # type: ignore[attr-defined]
+            if self[name] is not None:  # type: ignore[index]
+                multi[name] = multi[name].transform(
                     trans,
                     transform_all_input_vectors=transform_all_input_vectors,
                     inplace=inplace,

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -450,7 +450,7 @@ def test_transform_filter(ant, sphere, airplane, tetbeam, inplace):
     nested = multi_from_datasets(airplane, tetbeam)
     multi.append(nested)
     multi.append(None)
-    for i in enumerate(multi):
+    for i, _ in enumerate(multi):
         multi.set_block_name(i, str(i))
 
     NUMBER = 42

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -450,7 +450,7 @@ def test_transform_filter(ant, sphere, airplane, tetbeam, inplace):
     nested = multi_from_datasets(airplane, tetbeam)
     multi.append(nested)
     multi.append(None)
-    for i in enuerate(multi):
+    for i in enumerate(multi):
         multi.set_block_name(i, str(i))
 
     NUMBER = 42

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -450,11 +450,14 @@ def test_transform_filter(ant, sphere, airplane, tetbeam, inplace):
     nested = multi_from_datasets(airplane, tetbeam)
     multi.append(nested)
     multi.append(None)
+    for i in range(len(multi)):
+        multi.set_block_name(i, str(i))
 
     NUMBER = 42
     transform = pv.Transform().translate(NUMBER, NUMBER, NUMBER)
     bounds_before = np.array(multi.bounds)
     n_blocks_before = multi.n_blocks
+    keys_before = multi.keys()
 
     # Do test
     output = multi.transform(
@@ -462,11 +465,13 @@ def test_transform_filter(ant, sphere, airplane, tetbeam, inplace):
     )
     bounds_after = np.array(output.bounds)
     n_blocks_after = output.n_blocks
+    keys_after = output.keys()
 
     assert (output is multi) == inplace
     assert [(block_in is block_out) == inplace for block_in, block_out in zip(multi, output)]
     assert np.allclose(bounds_before + NUMBER, bounds_after)
     assert n_blocks_before == n_blocks_after
+    assert keys_before == keys_after
 
 
 def test_multi_block_copy(ant, sphere, uniform, airplane, tetbeam):

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -450,7 +450,7 @@ def test_transform_filter(ant, sphere, airplane, tetbeam, inplace):
     nested = multi_from_datasets(airplane, tetbeam)
     multi.append(nested)
     multi.append(None)
-    for i in range(len(multi)):
+    for i in enuerate(multi):
         multi.set_block_name(i, str(i))
 
     NUMBER = 42


### PR DESCRIPTION
### Overview

`transform` for `MultiBlock` uses integer indexing with `enumerate` to update the blocks. It turns out that indexing this way does not preserve the block name, e.g.:
``` python
import pyvista as pv
poly = pv.PolyData()
m = pv.MultiBlock(dict(data=poly)) 

# Block name is 'data'
m.keys() # ['data'] 

# Block name is modified
m[0] = poly
m.keys() # ['Block-00']
```

And so the filter unexpectedly mutates the block names as a result. This PR fixes this by indexing by name instead so that output names (keys) match the input names.