### PR TITLE
Add twist filter to `pyvista.filters.data_set` module

### DIFF
--- a/pyvista/core/_validation/check.py
+++ b/pyvista/core/_validation/check.py
@@ -249,13 +249,13 @@ def check_sorted(
     second_item = array[tuple(second_slice)]
 
     if ascending and not strict:
-        is_sorted = np.all(first_item <= second_item)  # type: ignore[operator]
+        is_sorted = np.all(first_item <= second_item)
     elif ascending and strict:
-        is_sorted = np.all(first_item < second_item)  # type: ignore[operator]
+        is_sorted = np.all(first_item < second_item)
     elif not ascending and not strict:
-        is_sorted = np.all(first_item >= second_item)  # type: ignore[operator]
+        is_sorted = np.all(first_item >= second_item)
     else:  # not ascending and strict
-        is_sorted = np.all(first_item > second_item)  # type: ignore[operator]
+        is_sorted = np.all(first_item > second_item)
 
     if not is_sorted:
         # Show the array's elements in error msg if array is small


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
```python
import pyvista as pv
mesh = pv.Tube(
    pointa=(0, 0, 0),
    pointb=(0, 0, 10),
    resolution=10,
    n_sides=5,
)
twisted = mesh.twist(angle=10, axis=(0, 0, 1), point=(0, 0, 0))
plotter = pv.Plotter(shape=(1, 2))
_ = plotter.add_mesh(mesh, show_edges=True)
plotter.subplot(0, 1)
_ = plotter.add_mesh(twisted, show_edges=True)
plotter.link_views()
plotter.show()
```
![image](https://github.com/user-attachments/assets/7a50edaa-43c0-4439-806a-03c1236887e7)

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- Inspired by [pygmsh's twist](https://github.com/nschloe/pygmsh/blob/main/README.md#extrusions).