### PR TITLE
Fix broken internal links to other classes, methods, attributes

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -866,7 +866,7 @@ class DataSetFilters:
         ----------
         surface : pyvista.PolyData
             The ``PolyData`` surface mesh to use as a clipping
-            function.  If this input mesh is not a :class`pyvista.PolyData`,
+            function.  If this input mesh is not a :class:`pyvista.PolyData`,
             the external surface will be extracted.
 
         invert : bool, default: True
@@ -3833,7 +3833,7 @@ class DataSetFilters:
         For `mesh1.sample(mesh2)`, the arrays from `mesh2` are sampled onto
         the points of `mesh1`.  This function interpolates within an
         enclosing cell.  This contrasts with
-        :function`pyvista.DataSetFilters.interpolate` that uses a distance
+        :function:`pyvista.DataSetFilters.interpolate` that uses a distance
         weighting for nearby points.  If there is cell topology, `sample` is
         usually preferred.
 
@@ -7773,7 +7773,7 @@ class DataSetFilters:
 
         The type of output dataset is always the same as the input type. Since
         structured types of data (i.e., :class:`pyvista.ImageData`,
-        :class:`pyvista.StructuredGrid`, :class`pyvista.RectilnearGrid`)
+        :class:`pyvista.StructuredGrid`, :class:`pyvista.RectilnearGrid`)
         are all composed of a cell of the same
         type, the output is either empty, or a shallow copy of the input.
         Unstructured data (:class:`pyvista.UnstructuredGrid`,

--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -161,7 +161,7 @@ class Transform(_vtk.vtkTransform):
            [0., 0., 0., 1.]])
 
     Create a similar transform but use pre-multiplication this time. Concatenate the
-    transformations in the same order as before using :meth:`translate` and :meth`scale`.
+    transformations in the same order as before using :meth:`translate` and :meth:`scale`.
 
     >>> transform_pre = pv.Transform().pre_multiply()
     >>> _ = transform_pre.translate(position).scale(scale_factor)

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -136,8 +136,8 @@ class LookupTable(_vtk.vtkLookupTable):
     scalar_range : tuple, optional
         The range of scalars which will be mapped to colors. Values outside of
         this range will be colored according to
-        :attr`LookupTable.below_range_color` and
-        :attr`LookupTable.above_range_color`.
+        :attr:`LookupTable.below_range_color` and
+        :attr:`LookupTable.above_range_color`.
 
     log_scale : bool, optional
         Use a log scale when mapping scalar values.
@@ -404,8 +404,8 @@ class LookupTable(_vtk.vtkLookupTable):
 
         This is the range of scalars which will be mapped to colors. Values
         outside of this range will be colored according to
-        :attr`LookupTable.below_range_color` and
-        :attr`LookupTable.above_range_color`.
+        :attr:`LookupTable.below_range_color` and
+        :attr:`LookupTable.above_range_color`.
 
         Examples
         --------

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -2593,7 +2593,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             Show lines as thick tubes rather than flat lines.  Control
             the width with ``line_width``.
 
-        smooth_shading : bool, default: :attr`pyvista.plotting.themes.Theme.smooth_shading`
+        smooth_shading : bool, default: :attr:`pyvista.plotting.themes.Theme.smooth_shading`
             Enable smooth shading when ``True`` using the Phong shading
             algorithm.  When ``False``, uses flat shading.  Automatically
             enabled when ``pbr=True``.  See :ref:`shading_example`.


### PR DESCRIPTION
### Overview

Add missing colons to fix the links. 

Note: Errors like this can probably be prevented with the `nitpicky` option, see #6203 