### PR TITLE
Fix copy structure with self returning empty mesh

### DIFF
--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -676,7 +676,7 @@ class DataObject:
         >>> target.plot(show_edges=True)
 
         """
-        self.CopyStructure(dataset)
+        self.CopyStructure(dataset) if dataset is not self else None
 
     def copy_attributes(self, dataset: _vtk.vtkDataSet) -> None:
         """Copy the data attributes of the input dataset object.

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1137,6 +1137,17 @@ def test_copy_structure(grid):
     assert len(copy.point_data) == 0
 
 
+def test_copy_structure_self(datasets):
+    for dataset in datasets:
+        copied = dataset.copy()
+        assert copied is not dataset
+
+        # Copy structure from itself
+        copied.copy_structure(copied)
+        assert copied.n_points == dataset.n_points
+        assert copied.n_cells == dataset.n_cells
+
+
 def test_copy_attributes(grid):
     classname = grid.__class__.__name__
     copy = eval(f'pv.{classname}')()


### PR DESCRIPTION
### Overview
Copying `ImageData` structure from itself returns an empty mesh:
``` python
import pyvista as pv
image = pv.ImageData(dimensions=(10, 10, 5))
image.copy_structure(image)
print(image.dimensions)  # (0, 0, 0)
```
This PR fixes this. Discovered as part of #6616 