### PR TITLE
Catch runtime errors in doc image testing

### DIFF
--- a/tests/doc/tst_doc_images.py
+++ b/tests/doc/tst_doc_images.py
@@ -185,37 +185,35 @@ def _test_both_images_exist(filename, docs_image_path, cached_image_path):
 
 
 def _test_compare_images(test_name, docs_image_path, cached_image_path):
-    docs_image = pv.read(docs_image_path)
-    cached_image = pv.read(cached_image_path)
-
-    # Check if test should fail or warn
     try:
+        docs_image = pv.read(docs_image_path)
+        cached_image = pv.read(cached_image_path)
+
+        # Check if test should fail or warn
         error = pv.compare_images(docs_image, cached_image)
-    except RuntimeError as e:
-        fail_msg = repr(e)
-        warn_msg = None
-    else:
         fail_msg = _check_compare_fail(test_name, error)
         warn_msg = _check_compare_warn(test_name, error)
-
-    if fail_msg:
-        # Check if test case is flaky test
-        if test_name in FLAKY_TEST_CASES:
-            # Compare build image to other known valid versions
-            success_path = _is_false_positive(test_name, docs_image)
-            if success_path:
-                # Convert failure into a warning
-                warn_msg = fail_msg + (
-                    '\nTHIS IS A FLAKY TEST. It initially failed (as above) but passed when '
-                    f'compared to:\n\t{success_path}'
-                )
-                fail_msg = None
-            else:
-                # Test still fails
-                fail_msg += (
-                    '\nTHIS IS A FLAKY TEST. It initially failed (as above) and failed again for '
-                    f'all images in \n\t{Path(FLAKY_IMAGE_DIR, test_name)!s}.'
-                )
+        if fail_msg:
+            # Check if test case is flaky test
+            if test_name in FLAKY_TEST_CASES:
+                # Compare build image to other known valid versions
+                success_path = _is_false_positive(test_name, docs_image)
+                if success_path:
+                    # Convert failure into a warning
+                    warn_msg = fail_msg + (
+                        '\nTHIS IS A FLAKY TEST. It initially failed (as above) but passed when '
+                        f'compared to:\n\t{success_path}'
+                    )
+                    fail_msg = None
+                else:
+                    # Test still fails
+                    fail_msg += (
+                        '\nTHIS IS A FLAKY TEST. It initially failed (as above) and failed again for '
+                        f'all images in \n\t{Path(FLAKY_IMAGE_DIR, test_name)!s}.'
+                    )
+    except RuntimeError as e:
+        warn_msg = None
+        fail_msg = repr(e)
     return warn_msg, fail_msg
 
 

--- a/tests/doc/tst_doc_images.py
+++ b/tests/doc/tst_doc_images.py
@@ -145,7 +145,11 @@ def test_docs(test_case: _TestCaseTuple):
         _save_failed_test_image(fail_source)
         pytest.fail(fail_msg)
 
-    warn_msg, fail_msg = _test_compare_images(*test_case)
+    try:
+        warn_msg, fail_msg = _test_compare_images(*test_case)
+    except RuntimeError as e:
+        fail_msg = repr(e)
+
     if fail_msg:
         _save_failed_test_image(test_case.docs_image_path)
         _save_failed_test_image(test_case.cached_image_path)

--- a/tests/doc/tst_doc_images.py
+++ b/tests/doc/tst_doc_images.py
@@ -140,12 +140,12 @@ def _save_failed_test_image(source_path):
 
 
 def test_docs(test_case: _TestCaseTuple):
-    fail_msg, fail_source = _test_both_images_exist(*test_case)
-    if fail_msg:
-        _save_failed_test_image(fail_source)
-        pytest.fail(fail_msg)
-
     try:
+        fail_msg, fail_source = _test_both_images_exist(*test_case)
+        if fail_msg:
+            _save_failed_test_image(fail_source)
+            pytest.fail(fail_msg)
+
         warn_msg, fail_msg = _test_compare_images(*test_case)
     except RuntimeError as e:
         fail_msg = repr(e)


### PR DESCRIPTION
### Overview

Catch runtime errors when comparing images so that the failed test images artifact is populated. This should make resolving this error more easily:
https://github.com/pyvista/pyvista/actions/runs/10815577469/job/30004788411#step:14:207
