### PR TITLE
Use updated version of `reviewdog` with `Vale` config

### DIFF
--- a/.github/workflows/style_docstr.yml
+++ b/.github/workflows/style_docstr.yml
@@ -66,5 +66,6 @@ jobs:
           filter_mode: nofilter
           fail_on_error: true
           version: 2.29.5
+          reviewdog_url: https://github.com/reviewdog/reviewdog/releases/download/v0.17.5/reviewdog_0.17.5_Linux_x86_64.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Overview

Use `reviewdog_url` in the Vale workflow to force using an updated version of `reviewdog` (`17.5` instead of `17.0`). 

Without this, we get a `reviewdog` error like this one from #6657 for large diffs https://github.com/pyvista/pyvista/actions/runs/10907071242/job/30269840434?pr=6657#step:3:40