### PR TITLE
Update Camera class representation to be friendly

### DIFF
--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -55,10 +55,6 @@ class Camera(_vtk.vtkCamera):
         else:
             self._renderer = None
 
-    def __repr__(self):
-        """Print a repr specifying the id of the camera and its camera type."""
-        return f'<{self.__class__.__name__} at {hex(id(self))}>'
-
     def __eq__(self, other):
         """Compare whether the relevant attributes of two cameras are equal."""
         # attributes which are native python types and thus implement __eq__
@@ -85,6 +81,24 @@ class Camera(_vtk.vtkCamera):
             # either but not both are None
             return False
         return not (trans_count == 2 and not np.array_equal(this_trans, that_trans))
+
+    def __repr__(self):
+        """Print a repr specifying the id of the camera and its camera type."""
+        repr_str = f'{self.__class__.__name__} ({hex(id(self))})'
+        repr_str += f'\n  Position:            {self.position}'
+        repr_str += f'\n  Focal Point:         {self.focal_point}'
+        repr_str += f'\n  Parallel Projection: {self.parallel_projection}'
+        repr_str += f'\n  Distance:            {self.distance}'
+        repr_str += f'\n  Thickness:           {self.thickness}'
+        repr_str += f'\n  Parallel Scale:      {self.parallel_scale}'
+        repr_str += f'\n  Clipping Range:      {self.clipping_range}'
+        repr_str += f'\n  View Angle:          {self.view_angle}'
+        repr_str += f'\n  Roll:                {self.roll}'
+        return repr_str
+
+    def __str__(self):
+        """Return the object string representation."""
+        return self.__repr__()
 
     def __del__(self):
         """Delete the camera."""

--- a/tests/plotting/test_camera.py
+++ b/tests/plotting/test_camera.py
@@ -294,3 +294,29 @@ def test_copy():
 
     deep = camera.copy()
     assert deep == camera
+
+
+def test_repr(camera):
+    assert 'Camera' in repr(camera)
+    assert 'Position' in repr(camera)
+    assert 'Focal Point' in repr(camera)
+    assert 'Parallel Projection' in repr(camera)
+    assert 'Distance' in repr(camera)
+    assert 'Thickness' in repr(camera)
+    assert 'Parallel Scale' in repr(camera)
+    assert 'Clipping Range' in repr(camera)
+    assert 'View Angle' in repr(camera)
+    assert 'Roll' in repr(camera)
+
+
+def test_str(camera):
+    assert 'Camera' in str(camera)
+    assert 'Position' in str(camera)
+    assert 'Focal Point' in str(camera)
+    assert 'Parallel Projection' in str(camera)
+    assert 'Distance' in str(camera)
+    assert 'Thickness' in str(camera)
+    assert 'Parallel Scale' in str(camera)
+    assert 'Clipping Range' in str(camera)
+    assert 'View Angle' in str(camera)
+    assert 'Roll' in str(camera)


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Update Camera class representation to be friendly.

#### main

```python
>>> import pyvista as pv
>>> camera = pv.Camera()
>>> camera
<Camera at ...>
```

#### PR

```python
>>> import pyvista as pv
>>> camera = pv.Camera()
>>> camera
Camera (...)
  Position:            (0.0, 0.0, 1.0)
  Focal Point:         (0.0, 0.0, 0.0)
  Parallel Projection: False
  Distance:            1.0
  Thickness:           1000.0
  Parallel Scale:      1.0
  Clipping Range:      (0.01, 1000.01)
  View Angle:          30.0
  Roll:                0.0
```

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None
