### PR TITLE
Add ruff formating to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -11,5 +11,9 @@ a26a52d037a265774be0ca06bb141e3346e73ad0
 635052d1bce8615fcc4879f5f200921a4f78aa1a
 
 # ruff formatting
+# https://github.com/pyvista/pyvista/pull/6607
+7c4166477b875d40e4650b102f67a29a40c2d8f2
+# https://github.com/pyvista/pyvista/pull/6632
+7f8ba86bbe07f85380937bc8d7561775e6a1d4d8
 # https://github.com/pyvista/pyvista/pull/6657
 c0396f73936e1772bc86bde7438e10b9ad19547b

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,7 +1,15 @@
 # enforce unified code style with black
+# https://github.com/pyvista/pyvista/pull/2180
 28914fc2236cd5850f536b151d0ef383855d8519
+# https://github.com/pyvista/pyvista/pull/2212
 db0691cfb6b033e55664ffba25deb456a386a48c
 
 # enforce unified code style in our documentation with blackdoc
+# https://github.com/pyvista/pyvista/pull/4119
 a26a52d037a265774be0ca06bb141e3346e73ad0
+# https://github.com/pyvista/pyvista/pull/4129
 635052d1bce8615fcc4879f5f200921a4f78aa1a
+
+# ruff formatting
+# https://github.com/pyvista/pyvista/pull/6657
+c0396f73936e1772bc86bde7438e10b9ad19547b

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -13,7 +13,5 @@ a26a52d037a265774be0ca06bb141e3346e73ad0
 # ruff formatting
 # https://github.com/pyvista/pyvista/pull/6607
 7c4166477b875d40e4650b102f67a29a40c2d8f2
-# https://github.com/pyvista/pyvista/pull/6632
-7f8ba86bbe07f85380937bc8d7561775e6a1d4d8
 # https://github.com/pyvista/pyvista/pull/6657
 c0396f73936e1772bc86bde7438e10b9ad19547b


### PR DESCRIPTION
### Overview

Added commit from #6607, #6632, and #6657 to `.git-blame-ignore-revs`

### Details

Also added PR link to each existing commit listed for easier cross reference.
