### PR TITLE
Remove interactive "note"

### DIFF
--- a/doc/source/user-guide/index.rst
+++ b/doc/source/user-guide/index.rst
@@ -45,8 +45,6 @@ identically locally.
     >>> mesh['scalars'] = mesh.points[:, 1]
     >>> mesh.plot(cpos='xy', cmap='plasma')
 
-.. note::
-   This example (and many others) is interactive.
 
 With just a few lines of code we downloaded a sample mesh from the
 web, added scalars to it based on the points of the mesh, and plotted


### PR DESCRIPTION
It's become redundant to say that the example is interactive since there's now an "interactive" tab.