### PR TITLE
Allow non-real number inputs with `validate_array`

### DIFF
--- a/pyvista/core/_validation/validate.py
+++ b/pyvista/core/_validation/validate.py
@@ -276,11 +276,6 @@ def validate_array(
     # Check type
     if must_be_real:
         check_real(arr_out, name=name)
-    else:
-        try:
-            check_subdtype(arr_out, np.number, name=name)
-        except TypeError as e:
-            raise TypeError(f'{name} must be numeric.') from e
 
     if must_have_dtype is not None:
         check_subdtype(arr_out, must_have_dtype, name=name)

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -539,6 +539,14 @@ def test_validate_array(
         assert array_out is not array_in
 
 
+@pytest.mark.parametrize('array', [(True,), 'abc'])
+def test_validate_array_non_numeric(array):
+    match = 'Array must have real numbers.'
+    with pytest.raises(TypeError, match=match):
+        assert validate_array(array)
+    assert validate_array(array, must_be_real=False)
+
+
 @pytest.mark.parametrize('obj', [0, 0.0, '0'])
 @pytest.mark.parametrize('classinfo', [int, (int, float), [int, float]])
 @pytest.mark.parametrize('allow_subclass', [True, False])


### PR DESCRIPTION
### Overview

Currently only real-valued numeric arrays are supported. But `np.bool` types are considered non-numeric and are therefore not currently supported. This PR removes this restriction. `must_be_real` must be explicitly set to `False` for these types.

This removes the need for a workaround such as this one https://github.com/pyvista/pyvista/pull/6676#discussion_r1786653740