### PR TITLE
Add fine grain execution control for pyvista-plot directive

### DIFF
--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -55,8 +55,8 @@ The ``pyvista-plot`` directive supports the following options:
         directives for which the ``:context:`` option was specified.  This only
         applies to inline code plot directives, not those run from files.
 
-    nofigs : bool, default None
-        If specified, the code block will be run, but no figures will be
+    nofigs : None
+        When setting this flag, the code block will be run but no figures will be
         inserted.  This is usually useful with the ``:context:`` option.
 
     caption : str
@@ -64,10 +64,11 @@ The ``pyvista-plot`` directive supports the following options:
         figure. This overwrites the caption given in the content, when the plot
         is generated from a file.
 
-    force_static : bool, default None
-        If specified, static images will be used instead of an interactive scene.
+    force_static : None
+        When setting this flag, static images will be used instead of an
+        interactive scene.
 
-    skip : bool
+    skip : bool, default: True
         Whether to skip execution of this directive. If no argument is provided
         i.e., ``:skip:``, then it defaults to ``:skip: true``.  Default
         behaviour is controlled by the ``plot_skip`` boolean variable in
@@ -87,7 +88,7 @@ include *alt*, *height*, *width*, *scale*, *align*.
 **Configuration options**
 The plot directive has the following configuration options:
 
-    plot_include_source : bool
+    plot_include_source : bool, default: True
         Default value for the ``include-source`` directive option.
         Default is ``True``.
 
@@ -96,7 +97,7 @@ The plot directive has the following configuration options:
         to.  If ``None`` or unset, file names are relative to the
         directory where the file containing the directive is.
 
-    plot_html_show_formats : bool
+    plot_html_show_formats : bool, default: True
         Whether to show links to the files in HTML. Default ``True``.
 
     plot_template : str
@@ -108,11 +109,12 @@ The plot directive has the following configuration options:
     plot_cleanup : str
         Python code to be run after every plot directive block.
 
-    plot_skip : bool, default False
+    plot_skip : bool, default: False
         Default value for the ``skip`` directive option.
 
-    plot_skip_optional : bool, default False
+    plot_skip_optional : bool, default: False
         Whether to skip execution of ``optional`` directives.
+
 These options can be set by defining global variables of the same name in
 :file:`conf.py`.
 

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -55,7 +55,7 @@ The ``pyvista-plot`` directive supports the following options:
         directives for which the ``:context:`` option was specified.  This only
         applies to inline code plot directives, not those run from files.
 
-    nofigs : None
+    nofigs : bool, default None
         If specified, the code block will be run, but no figures will be
         inserted.  This is usually useful with the ``:context:`` option.
 

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -111,10 +111,8 @@ The plot directive has the following configuration options:
     plot_skip : bool, default False
         Default value for the ``skip`` directive option.
 
-    plot_skip_optional : bool
-        Whether to skip execution of ``optional`` directives.  Default is
-        ``False``.
-
+    plot_skip_optional : bool, default False
+        Whether to skip execution of ``optional`` directives.
 These options can be set by defining global variables of the same name in
 :file:`conf.py`.
 

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -108,9 +108,8 @@ The plot directive has the following configuration options:
     plot_cleanup : str
         Python code to be run after every plot directive block.
 
-    plot_skip : bool
-        Default value for the ``skip`` directive option.  Default is
-        ``False``.
+    plot_skip : bool, default False
+        Default value for the ``skip`` directive option.
 
     plot_skip_optional : bool
         Whether to skip execution of ``optional`` directives.  Default is

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -64,7 +64,7 @@ The ``pyvista-plot`` directive supports the following options:
         figure. This overwrites the caption given in the content, when the plot
         is generated from a file.
 
-    force_static : None
+    force_static : bool, default None
         If specified, static images will be used instead of an interactive scene.
 
     skip : bool

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -496,7 +496,7 @@ def run(arguments, content, options, state_machine, state, lineno):
     options.setdefault('include-source', config.plot_include_source)
     options.setdefault('skip', config.plot_skip)
 
-    skip = options["skip"] or (optional and config.plot_skip_optional)
+    skip = options['skip'] or (optional and config.plot_skip_optional)
 
     keep_context = 'context' in options
     _ = None if not keep_context else options['context']

--- a/tests/test_tinypages.py
+++ b/tests/test_tinypages.py
@@ -18,12 +18,30 @@ pytest.importorskip('sphinx')
 if not system_supports_plotting():
     pytestmark = pytest.mark.skip(reason='Requires system to support plotting')
 
+ENVIRONMENT_HOOKS = ["PLOT_SKIP", "PLOT_SKIP_OPTIONAL"]
+
+
 
 @pytest.mark.skipif(os.name == 'nt', reason='path issues on Azure Windows CI')
-def test_tinypages(tmpdir):
-    tmp_path = Path(tmpdir)
-    html_dir = tmp_path / 'html'
-    doctree_dir = tmp_path / 'doctrees'
+@pytest.mark.parametrize("ename", ENVIRONMENT_HOOKS)
+@pytest.mark.parametrize("evalue", [False, True])
+def test_tinypages(tmp_path, ename, evalue):
+    # sanitise the environment namespace
+    for hook in ENVIRONMENT_HOOKS:
+        os.environ.pop(hook, None)
+
+    # configure the plot-directive environment variable hook for conf.py
+    os.environ[ename] = str(evalue)
+
+    skip = False if ename != "PLOT_SKIP" else evalue
+    skip_optional = False if ename != "PLOT_SKIP_OPTIONAL" else evalue
+    expected = not skip
+    expected_optional = False if skip else not skip_optional
+
+    tmp_dir = tmp_path / f"{ename}_{evalue}"
+    tmp_dir.mkdir()
+    html_dir = tmp_dir / 'html'
+    doctree_dir = tmp_dir / 'doctrees'
     # Build the pages with warnings turned into errors
     cmd = [
         sys.executable,
@@ -58,34 +76,45 @@ def test_tinypages(tmpdir):
         return html_dir / f'some_plots-{plt}_{num:02d}_{subnum:02d}.{extension}'
 
     # verify directives generating a figure generated figures
-    assert plot_file(1, 0, 0).exists()
-    assert plot_file(2, 0, 0).exists()
-    assert plot_file(4, 0, 0).exists()
-    assert plot_file(8, 0, 0, 'png').exists()
-    assert plot_file(9, 0, 0, 'png').exists()
-    assert plot_file(9, 1, 0, 'png').exists()
+    assert plot_file(1, 0, 0).exists() == expected
+    assert plot_file(2, 0, 0).exists() == expected
+    assert plot_file(4, 0, 0).exists() == expected
+    assert plot_file(8, 0, 0, 'png').exists() == expected
+    assert plot_file(9, 0, 0, 'png').exists() == expected
+    assert plot_file(9, 1, 0, 'png').exists() == expected
 
     # test skip directive
     assert not plot_file(10, 0, 0).exists()
 
     # verify external file generated figure
     cone_file = html_dir / 'plot_cone_00_00.png'
-    assert cone_file.exists()
+    assert cone_file.exists() == expected
 
     html_contents = (html_dir / 'some_plots.html').read_bytes()
-    assert b'# Only a comment' in html_contents
+    assert (b'# Only a comment' in html_contents)
 
     # check if figure caption made it into html file
-    assert b'This is the caption for plot 8.' in html_contents
+    assert (b'This is the caption for plot 8.' in html_contents) == expected
 
     # check if figure caption using :caption: made it into html file
-    assert b'Plot 10 uses the caption option.' in html_contents
+    assert (b'Plot 8 uses the caption option.' in html_contents) == expected
 
     # check that the multi-image caption is applied twice
-    assert html_contents.count(b'This caption applies to both plots.') == 2
+    assert (html_contents.count(b'This caption applies to both plots.') == 2) == expected
 
     assert b'you should not be reading this right now' not in html_contents
-    assert b'should be printed: include-source with no args' in html_contents
+    assert (b'should be printed: include-source with no args' in html_contents)
 
     # check that caption with tabs works
-    assert html_contents.count(b'Plot __ uses the caption option with tabbed UI.') == 1
+    assert (html_contents.count(b'Plot 15 uses the caption option with tabbed UI.') == 1) == expected
+
+    # check that no skip always exists
+    assert b'Plot 16 will never be skipped' in html_contents
+    assert plot_file(16, 0, 0).exists()
+
+    # check that enforced skip caption doesn't exist
+    assert b'This plot will always be skipped with no caption' not in html_contents
+
+    # check conditional execution
+    assert (b'This plot may be skipped with no caption' in html_contents) == expected_optional
+    assert plot_file(18, 0, 0).exists() == expected_optional

--- a/tests/test_tinypages.py
+++ b/tests/test_tinypages.py
@@ -18,13 +18,12 @@ pytest.importorskip('sphinx')
 if not system_supports_plotting():
     pytestmark = pytest.mark.skip(reason='Requires system to support plotting')
 
-ENVIRONMENT_HOOKS = ["PLOT_SKIP", "PLOT_SKIP_OPTIONAL"]
-
+ENVIRONMENT_HOOKS = ['PLOT_SKIP', 'PLOT_SKIP_OPTIONAL']
 
 
 @pytest.mark.skipif(os.name == 'nt', reason='path issues on Azure Windows CI')
-@pytest.mark.parametrize("ename", ENVIRONMENT_HOOKS)
-@pytest.mark.parametrize("evalue", [False, True])
+@pytest.mark.parametrize('ename', ENVIRONMENT_HOOKS)
+@pytest.mark.parametrize('evalue', [False, True])
 def test_tinypages(tmp_path, ename, evalue):
     # sanitise the environment namespace
     for hook in ENVIRONMENT_HOOKS:
@@ -33,12 +32,12 @@ def test_tinypages(tmp_path, ename, evalue):
     # configure the plot-directive environment variable hook for conf.py
     os.environ[ename] = str(evalue)
 
-    skip = False if ename != "PLOT_SKIP" else evalue
-    skip_optional = False if ename != "PLOT_SKIP_OPTIONAL" else evalue
+    skip = False if ename != 'PLOT_SKIP' else evalue
+    skip_optional = False if ename != 'PLOT_SKIP_OPTIONAL' else evalue
     expected = not skip
     expected_optional = False if skip else not skip_optional
 
-    tmp_dir = tmp_path / f"{ename}_{evalue}"
+    tmp_dir = tmp_path / f'{ename}_{evalue}'
     tmp_dir.mkdir()
     html_dir = tmp_dir / 'html'
     doctree_dir = tmp_dir / 'doctrees'
@@ -91,7 +90,7 @@ def test_tinypages(tmp_path, ename, evalue):
     assert cone_file.exists() == expected
 
     html_contents = (html_dir / 'some_plots.html').read_bytes()
-    assert (b'# Only a comment' in html_contents)
+    assert b'# Only a comment' in html_contents
 
     # check if figure caption made it into html file
     assert (b'This is the caption for plot 8.' in html_contents) == expected
@@ -103,10 +102,12 @@ def test_tinypages(tmp_path, ename, evalue):
     assert (html_contents.count(b'This caption applies to both plots.') == 2) == expected
 
     assert b'you should not be reading this right now' not in html_contents
-    assert (b'should be printed: include-source with no args' in html_contents)
+    assert b'should be printed: include-source with no args' in html_contents
 
     # check that caption with tabs works
-    assert (html_contents.count(b'Plot 15 uses the caption option with tabbed UI.') == 1) == expected
+    assert (
+        html_contents.count(b'Plot 15 uses the caption option with tabbed UI.') == 1
+    ) == expected
 
     # check that no skip always exists
     assert b'Plot 16 will never be skipped' in html_contents

--- a/tests/tinypages/conf.py
+++ b/tests/tinypages/conf.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import os
 from pathlib import Path
 import re
 import sys
@@ -54,6 +55,12 @@ __s_p_t('document')
 del __s_p_t
 """
 plot_cleanup = plot_setup
+
+if value := os.environ.get("PLOT_SKIP"):
+    plot_skip = value.lower() == "true"
+
+if value := os.environ.get("PLOT_SKIP_OPTIONAL"):
+    plot_skip_optional = value.lower() == "true"
 
 
 def _str_examples(self):

--- a/tests/tinypages/conf.py
+++ b/tests/tinypages/conf.py
@@ -56,11 +56,11 @@ del __s_p_t
 """
 plot_cleanup = plot_setup
 
-if value := os.environ.get("PLOT_SKIP"):
-    plot_skip = value.lower() == "true"
+if value := os.environ.get('PLOT_SKIP'):
+    plot_skip = value.lower() == 'true'
 
-if value := os.environ.get("PLOT_SKIP_OPTIONAL"):
-    plot_skip_optional = value.lower() == "true"
+if value := os.environ.get('PLOT_SKIP_OPTIONAL'):
+    plot_skip_optional = value.lower() == 'true'
 
 
 def _str_examples(self):

--- a/tests/tinypages/some_plots.rst
+++ b/tests/tinypages/some_plots.rst
@@ -2,7 +2,7 @@
 Some Plots
 ##########
 
-Plot 1 does not use doctest syntax
+**Plot 1** Does not use doctest syntax:
 
 .. pyvista-plot::
 
@@ -10,7 +10,7 @@ Plot 1 does not use doctest syntax
     pyvista.Sphere().plot()
 
 
-Plot 2 uses doctest syntax:
+**Plot 2** Uses doctest syntax:
 
 .. pyvista-plot::
     :format: doctest
@@ -19,7 +19,7 @@ Plot 2 uses doctest syntax:
     >>> pyvista.Cube().plot()
 
 
-Plot 3 shows that a new block with context does not see the variable defined
+**Plot 3** Shows that a new block with context does not see the variable defined
 in the no-context block:
 
 .. pyvista-plot::
@@ -28,7 +28,7 @@ in the no-context block:
     assert 'a' not in globals()
 
 
-Plot 4 defines ``a`` in a context block:
+**Plot 4** Defines ``a`` in a context block:
 
 .. pyvista-plot::
     :context:
@@ -38,7 +38,7 @@ Plot 4 defines ``a`` in a context block:
     pyvista.Plane().plot()
 
 
-Plot 5 shows that a block with context sees the new variable. It also uses
+**Plot 5** Shows that a block with context sees the new variable. It also uses
 ``:nofigs:``:
 
 .. pyvista-plot::
@@ -48,14 +48,14 @@ Plot 5 shows that a block with context sees the new variable. It also uses
     assert a == 10
 
 
-Plot 6 shows that a non-context block still doesn't have ``a``:
+**Plot 6** Shows that a non-context block still doesn't have ``a``:
 
 .. pyvista-plot::
 
     assert 'a' not in globals()
 
 
-Plot 7 uses ``include-source``:
+**Plot 7** Uses ``include-source``:
 
 .. pyvista-plot::
     :include-source: True
@@ -63,7 +63,7 @@ Plot 7 uses ``include-source``:
     # Only a comment
 
 
-Plot _ uses an external file with the plot commands and a caption:
+Plot _ Uses an external file with the plot commands and a caption:
 
 .. pyvista-plot:: plot_cone.py
    :force_static:
@@ -71,31 +71,30 @@ Plot _ uses an external file with the plot commands and a caption:
    This is the caption for plot 8.
 
 
-Plot _ uses a specific function in a file with plot commands:
+Plot _ Uses a specific function in a file with plot commands:
 
 .. pyvista-plot:: plot_polygon.py plot_poly
 
 
-Plot 8 gets a caption specified by the :caption: option:
+**Plot 8** Gets a caption specified by the ``:caption:`` option:
 
 .. pyvista-plot::
    :force_static:
-   :caption: Plot 10 uses the caption option.
+   :caption: Plot 8 uses the caption option.
 
    import pyvista
    pyvista.Disc().plot()
 
 
-
-Plot __ uses an external file with the plot commands and a caption
-using the :caption: option:
+Plot __ Uses an external file with the plot commands and a caption
+using the ``:caption:`` option:
 
 .. pyvista-plot:: plot_cone.py
    :force_static:
-   :caption: This is the caption for plot 11.
+   :caption: This is the caption for plot_cone.py
 
 
-Plot 9 shows that the default template correctly prints the multi-image
+**Plot 9** Shows that the default template correctly prints the multi-image
 scenario:
 
 .. pyvista-plot::
@@ -108,29 +107,32 @@ scenario:
    pyvista.Text3D('world').plot()
 
 
-Plot 10 uses the skip directive and should not generate a plot.
+**Plot 10** Uses the skip directive and should not generate a plot:
 
 .. pyvista-plot::
 
    import pyvista
    pyvista.Sphere().plot()  # doctest:+SKIP
 
-Plot 11 uses ``include-source`` False:
+
+**Plot 11** Uses ``:include-source: False``:
 
 .. pyvista-plot::
     :include-source: False
 
     # you should not be reading this right now
 
-Plot 12 uses ``include-source`` with no args:
+
+**Plot 12** Uses ``:include-source:`` with no args:
 
 .. pyvista-plot::
     :include-source:
 
     # should be printed: include-source with no args
 
-Plot 13 should create two plots and be able to plot while skipping
-lines, even in two sections.
+
+**Plot 13** Should create two plots and be able to plot while skipping
+lines, even in two sections:
 
 .. pyvista-plot::
 
@@ -141,7 +143,8 @@ lines, even in two sections.
     >>> pyvista.Sphere().plot(color='red',
     ...                       cpos='xy')
 
-Forces a static image instead of an interactive scene:
+
+**Plot 14** Forces two static images instead of interactive scenes:
 
 .. pyvista-plot::
    :force_static:
@@ -153,10 +156,42 @@ Forces a static image instead of an interactive scene:
    >>> pyvista.Sphere().plot(color='red',
    ...                       cpos='xy')
 
-Plot __ uses caption with tabbed UI.
+
+**Plot 15** Uses caption with tabbed UI:
 
 .. pyvista-plot::
-   :caption: Plot __ uses the caption option with tabbed UI.
+   :caption: Plot 15 uses the caption option with tabbed UI.
 
    import pyvista
    pyvista.Disc().plot()
+
+
+**Plot 16** Should never be skipped, using the ``:skip: no`` option:
+
+.. pyvista-plot::
+   :skip: no
+   :caption: Plot 16 will never be skipped
+
+   import pyvista
+   pyvista.Cube().plot()
+
+
+This plot will always be skipped, using the ``:skip: yes`` option,
+but the source will always be included but with no caption:
+
+.. pyvista-plot::
+   :skip: yes
+   :caption: This plot will always be skipped with no caption
+
+   # should be printed: skip is enforced
+
+
+**Plot 18** Conditional plot execution using ``:optional:`` option,
+but the source will always be included with a conditional caption:
+
+.. pyvista-plot::
+   :optional:
+   :caption: This plot may be skipped with no caption
+
+   import pyvista
+   pyvista.Cube().plot()


### PR DESCRIPTION
### Overview

This pull-request adds some fine grain options to control the execution of the `pyvista-plot` directive.

#### Motivation

Building documentation can be expensive, particularly if it's image rich, which is pretty much the accepted norm here. However, sometimes as a developer there is a need for a slicker workflow experience when changing the documentation i.e., change the docs, build the docs, review the rendered docs ... typically this can involve several rinse'n repeat iterations, but the major bottleneck is always the documentation build time.

I'm proposing a couple of minor changes that will hopefully give developers the ability to improve the turnaround of their documentation changes by rendering only images of their choosing, which may be none, all or some.

#### Implementation

##### Directive Options

The `pyvista-plot` directive has the following **new** options:

- `:skip:` which has an optional boolean argument i.e., `yes`, `1`, `true`, `no`, `0`, `false`. If no argument is provided, then it is assumed to be enabled e.g., `:skip:` is equivalent to `:skip: yes`. The purpose of this option is to override the behaviour of the `plot_skip` configuration variable, and enforce the execution of the directive or not
- `:optional:` which is a flag (no argument). The purpose of this option is to mark a directive for conditional execution, which is controlled by the state of the `plot_skip_optional` configuration variable.

##### Configuration Variables (`conf.py`)

The `pyvista-plot` directive has the following **new** configuration variables:

- `plot_skip` is a boolean. Default is `False`. This variable is used to seed the value of any directive that doesn't explicitly specify a `:skip:` option
- `plot_skip_optional` is a boolean. Default is `False`. This variable is used to control whether any directive marked with an `:optional:` flag is executed or not


#### Workflow

Note that, given the default values of the **new** `conf.py` configuration variables there is no change in the existing behaviour of the `pyvista-plot` directive.

Here are some example workflows that are now easily possible:

- disable all `pyvista-plot` directives with `plot_skip = True` in the `conf.py`
- disable all `pyvista-plot` directives with `plot_skip = True` apart from one (or more) marked with `:skip: no`
- execute all `pyvista-plot` directives with `plot_skip = False` and `plot_skip_optional = False` (default behaviour)
- execute all `pyvista-plot` directives with `plot_skip = False` apart from one (or more) marked with `:optional:` because `plot_skip_optional = True`

Note that, skipped `pyvista-plot` directives will still have their code blocks rendered but with no image and no caption.


