### PR TITLE
added font_file property to add_point_labels

### DIFF
--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -5448,6 +5448,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
         font_size=None,
         text_color=None,
         font_family=None,
+        font_file=None,
         shadow=False,
         show_points=True,
         point_color=None,
@@ -5501,7 +5502,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         font_family : str, optional
             Font family.  Must be either ``'courier'``, ``'times'``,
-            or ``'arial``.
+            or ``'arial``. This is ignored if the `font_file` is set.
+
+        font_file : str, default: None
+            The absolute file path to a local file containing a freetype
+            readable font.
 
         shadow : bool, default: False
             Adds a black shadow to the text.
@@ -5706,6 +5711,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             bold=bold,
             font_size=font_size,
             font_family=font_family,
+            font_file=font_file,
             color=text_color,
             shadow=shadow,
             justification_horizontal=justification_horizontal,


### PR DESCRIPTION
### Overview

added the option to specify the font_file for the function add_point_labels

This is a similar change to:
https://github.com/pyvista/pyvista/pull/4639
which was done for the add_text function

gives a workaround (but maybe does not fully resolve the issue) for this:
https://github.com/pyvista/pyvista/issues/6705

