### PR TITLE
Use numpy version info for skipping tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from pyvista.core._vtk_core import VersionInfo
 
 pyvista.OFF_SCREEN = True
 
-NumpyVersionInfo = VersionInfo(
+NUMPY_VERSION_INFO = VersionInfo(
     major=int(np.__version__.split('.')[0]),
     minor=int(np.__version__.split('.')[1]),
     micro=int(np.__version__.split('.')[2]),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,15 @@ import pytest
 
 import pyvista
 from pyvista import examples
+from pyvista.core._vtk_core import VersionInfo
 
 pyvista.OFF_SCREEN = True
+
+NumpyVersionInfo = VersionInfo(
+    major=int(np.__version__.split('.')[0]),
+    minor=int(np.__version__.split('.')[1]),
+    micro=int(np.__version__.split('.')[2]),
+)
 
 
 def flaky_test(

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import pickle
 import re
 import shutil
-import sys
 from unittest import mock
 import warnings
 
@@ -42,6 +41,7 @@ from pyvista.core.utilities.observers import Observer
 from pyvista.core.utilities.points import vector_poly_data
 from pyvista.core.utilities.transform import Transform
 from pyvista.plotting.prop3d import _orientation_as_rotation_matrix
+from tests.conftest import NumpyVersionInfo
 
 
 @pytest.fixture
@@ -1008,7 +1008,7 @@ CASE_3 = (  # non-coplanar points
 )
 
 
-@pytest.mark.skipif(sys.version_info < (3, 9), reason='Different results for some tests.')
+@pytest.mark.skipif(NumpyVersionInfo < (1, 26), reason='Different results for some tests.')
 @pytest.mark.parametrize(
     ('points', 'expected_axes'),
     [CASE_0, CASE_1, CASE_2, CASE_3],

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -41,7 +41,7 @@ from pyvista.core.utilities.observers import Observer
 from pyvista.core.utilities.points import vector_poly_data
 from pyvista.core.utilities.transform import Transform
 from pyvista.plotting.prop3d import _orientation_as_rotation_matrix
-from tests.conftest import NumpyVersionInfo
+from tests.conftest import NUMPY_VERSION_INFO
 
 
 @pytest.fixture
@@ -1008,7 +1008,7 @@ CASE_3 = (  # non-coplanar points
 )
 
 
-@pytest.mark.skipif(NumpyVersionInfo < (1, 26), reason='Different results for some tests.')
+@pytest.mark.skipif(NUMPY_VERSION_INFO < (1, 26), reason='Different results for some tests.')
 @pytest.mark.parametrize(
     ('points', 'expected_axes'),
     [CASE_0, CASE_1, CASE_2, CASE_3],

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -53,7 +53,7 @@ from pyvista.core._vtk_core import vtkMatrix3x3
 from pyvista.core._vtk_core import vtkMatrix4x4
 from pyvista.core.utilities.arrays import array_from_vtkmatrix
 from pyvista.core.utilities.arrays import vtkmatrix_from_array
-from tests.conftest import NumpyVersionInfo
+from tests.conftest import NUMPY_VERSION_INFO
 
 
 @pytest.mark.parametrize(
@@ -976,7 +976,7 @@ def test_cast_to_numpy(as_any, copy, dtype):
 
 
 def test_cast_to_numpy_raises():
-    if NumpyVersionInfo < (1, 26):
+    if NUMPY_VERSION_INFO < (1, 26):
         err = TypeError
         match = 'Object arrays are not supported.'
     else:

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -976,7 +976,7 @@ def test_cast_to_numpy(as_any, copy, dtype):
 
 
 def test_cast_to_numpy_raises():
-    if NUMPY_VERSION_INFO < (1, 26):
+    if NUMPY_VERSION_INFO < (1, 26) and sys.platform == 'linux':
         err = TypeError
         match = 'Object arrays are not supported.'
     else:

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -53,6 +53,7 @@ from pyvista.core._vtk_core import vtkMatrix3x3
 from pyvista.core._vtk_core import vtkMatrix4x4
 from pyvista.core.utilities.arrays import array_from_vtkmatrix
 from pyvista.core.utilities.arrays import vtkmatrix_from_array
+from tests.conftest import NumpyVersionInfo
 
 
 @pytest.mark.parametrize(
@@ -975,7 +976,7 @@ def test_cast_to_numpy(as_any, copy, dtype):
 
 
 def test_cast_to_numpy_raises():
-    if sys.version_info < (3, 9) and sys.platform == 'linux':
+    if NumpyVersionInfo < (1, 26):
         err = TypeError
         match = 'Object arrays are not supported.'
     else:


### PR DESCRIPTION
### Overview

Add conditional test skips for numpy version. See https://github.com/pyvista/pyvista/pull/6701#issuecomment-2427118344.