### PR TITLE
Update `user_dict` type annotations for Python > 3.8

### DIFF
--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -572,8 +572,7 @@ class DataObject:
 
     @user_dict.setter
     def user_dict(
-        self,
-        dict_: dict[str, _JSONValueType] | UserDict,  # type: ignore[type-arg]
+        self, dict_: dict[str, _JSONValueType] | UserDict[str, _JSONValueType]
     ):  # numpydoc ignore=GL08
         # Setting None removes the field data array
         if dict_ is None and '_PYVISTA_USER_DICT' in self.field_data.keys():

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -792,9 +792,9 @@ def set_default_active_scalars(mesh: pyvista.DataSet) -> None:
 
 
 _JSONValueType = Union[
-    dict,  # type: ignore[type-arg]
-    list,  # type: ignore[type-arg]
-    tuple,  # type: ignore[type-arg]
+    dict[str, '_JSONValueType'],
+    list['_JSONValueType'],
+    tuple['_JSONValueType'],
     str,
     int,
     float,
@@ -803,8 +803,6 @@ _JSONValueType = Union[
 ]
 
 
-# TODO: add generic type annotations 'UserDict[str, _JSONValueType]'
-#  once support for Python 3.8 is dropped
 class _SerializedDictArray(UserDict, _vtk.vtkStringArray):  # type: ignore[type-arg]
     """Dict-like object with a JSON-serialized string array representation.
 


### PR DESCRIPTION
### Overview

Additional changes for dropping python 3.8 support #6701 
