### PR TITLE
Update `cache-apt-pkgs-action` to `v1.4.2` for Linux Core testing workflow

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -227,7 +227,7 @@ jobs:
       - uses: awalsh128/cache-apt-pkgs-action@v1.4.2
         with:
           packages: libgl1-mesa-glx xvfb
-          version: 3.0
+          version: 4.0
 
       - name: Plotting Testing (uses GL)
         run: xvfb-run -a python -m pytest --cov=pyvista --cov-append --cov-report=xml --fail_extra_image_cache -v --ignore=tests/core --ignore=tests/examples --generated_image_dir debug_images

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Core Testing (no GL)
         run: python -m pytest --cov=pyvista -v tests/core tests/examples
 
-      - uses: awalsh128/cache-apt-pkgs-action@v1.1.3
+      - uses: awalsh128/cache-apt-pkgs-action@v1.4.2
         with:
           packages: libgl1-mesa-glx xvfb
           version: 3.0


### PR DESCRIPTION
### Overview

The linux unit testing workflows are generating this warning, e.g.:
> Linux Unit Testing (3.10, 9.2.2, latest)
> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/cache@v3.

I believe this may be caused by `awalsh128/cache-apt-pkgs-action@v1.1.3`, which uses `actions/cache@v3`:
https://github.com/awalsh128/cache-apt-pkgs-action/blob/d93c95e39c0450c48c3e0c2b2ad2993f33da786a/action.yml#L48

This PR updates this action to the latest version to fix the warning.