### PR TITLE
Add `.vtkhdf` as an extension of `pyvista.HDFReader`

### DIFF
--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -27,7 +27,7 @@ from .misc import abstract_class
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Callable
 
-HDF_HELP = 'https://kitware.github.io/vtk-examples/site/VTKFileFormats/#hdf-file-formats'
+HDF_HELP = 'https://docs.vtk.org/en/latest/design_documents/VTKFileFormats.html#vtkhdf-file-format'
 
 
 def _lazy_vtk_instantiation(module_name, class_name):

--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -151,6 +151,8 @@ def get_reader(filename, force_ext=None):
     +----------------+---------------------------------------------+
     | ``.vtk``       | :class:`pyvista.VTKDataSetReader`           |
     +----------------+---------------------------------------------+
+    | ``.vtkhdf``    | :class:`pyvista.HDFReader`                  |
+    +----------------+---------------------------------------------+
     | ``.vtm``       | :class:`pyvista.XMLMultiBlockDataReader`    |
     +----------------+---------------------------------------------+
     | ``.vtmb``      | :class:`pyvista.XMLMultiBlockDataReader`    |
@@ -2883,6 +2885,7 @@ CLASS_READERS = {
     '.vrt': ProStarReader,
     '.vti': XMLImageDataReader,
     '.vtk': VTKDataSetReader,
+    '.vtkhdf': HDFReader,
     '.vtm': XMLMultiBlockDataReader,
     '.vtmb': XMLMultiBlockDataReader,
     '.vtp': XMLPolyDataReader,


### PR DESCRIPTION
### Overview

Hi, I downloaded [ParaViewTestingDataFiles-v5.13.1.tar.xz](https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v5.13&type=data&os=Sources&downloadFile=ParaViewTestingDataFiles-v5.13.1.tar.xz) to test `Testing/Data/vtkHDF/pdc_multi.vtkhdf`.

The first issue I encountered was:
```python
>>> m = pv.get_reader('ParaView-v5.13.1/Testing/Data/vtkHDF/pdc_multi.vtkhdf')
# [...]
ValueError: `pyvista.get_reader` does not support a file with the .vtkhdf extension
```

This PR fixes that. Also the docs moved to I updated the link.

BTW I only added `.vtkhdf` and not `.hdf`, the docs state:

> The VTKHDF format generally uses the .vtkhdf extension. The .hdf extension is also supported but is not preferred.

---

Then I got errors about `Unknown data set type: PartitionedDataSetCollection`, but I guess I need to wait for VTK 9.4 and the followup to #5833