### PR TITLE
Do not fail fast for macOS unit testing

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: macos-12
     name: Mac OS Unit Testing
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.9", "3.11"]
 


### PR DESCRIPTION
### Overview

Currently, if one macOS job fails, all other macOS jobs are cancelled. This PR makes it so that other jobs will continue to run. This is consistent with the Linux and Windows testing, which also use `fail-fast: false`