### PR TITLE
Do not warn unused ignores with `pre-commit` config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,6 @@ repos:
             --disallow-any-generics,
             --pretty,
             --show-error-context,
-            --warn-unused-ignores,
             --warn-redundant-casts,
             --enable-error-code,
             ignore-without-code,


### PR DESCRIPTION
### Overview

Preparation for dropping the `mypy` pre-commit config. See https://github.com/pyvista/pyvista/pull/6741#issuecomment-2439615925

This option is still kept in the project's mypy config in `pyproject.toml` and will continue to be used with the new workflow CI job in #6738 