### PR TITLE
Update `validation` methods

### DIFF
--- a/pyvista/core/_typing_core/_array_like.py
+++ b/pyvista/core/_typing_core/_array_like.py
@@ -31,6 +31,11 @@ import numpy as np
 import numpy.typing as npt
 
 # Define numeric types
+
+_NumberUnion = Union[
+    type[np.floating], type[np.integer], type[np.bool_], type[float], type[int], type[bool]
+]  # type: ignore[type-arg]
+
 NumberType = TypeVar(
     'NumberType',
     bound=Union[np.floating, np.integer, np.bool_, float, int, bool],  # type: ignore[type-arg]
@@ -43,6 +48,9 @@ _NumberType = TypeVar(  # noqa: PYI018
     '_NumberType',
     bound=Union[np.floating, np.integer, np.bool_, float, int, bool],  # type: ignore[type-arg]
 )
+
+_PyNumberType = TypeVar('_PyNumberType', float, int, bool)  # noqa: PYI018
+_NpNumberType = TypeVar('_NpNumberType', np.float64, np.int_, np.bool_)  # noqa: PYI018
 
 NumpyArray = npt.NDArray[NumberType]
 

--- a/pyvista/core/_validation/__init__.py
+++ b/pyvista/core/_validation/__init__.py
@@ -12,6 +12,7 @@ from .check import check_iterable
 from .check import check_iterable_items
 from .check import check_length
 from .check import check_less_than
+from .check import check_ndim
 from .check import check_nonnegative
 from .check import check_number
 from .check import check_range

--- a/pyvista/core/_validation/_cast_array.py
+++ b/pyvista/core/_validation/_cast_array.py
@@ -69,6 +69,7 @@ def _cast_to_numpy(
     dtype: Optional[npt.DTypeLike] = None,
     copy: bool = False,
     must_be_real: bool = False,
+    name: str = 'Array',
 ) -> NumpyArray[NumberType]:
     """Cast array to a NumPy ndarray.
 
@@ -104,6 +105,10 @@ def _cast_to_numpy(
         Raise a ``TypeError`` if the array does not have real numbers, i.e.
         its data type is not integer or floating.
 
+    name : str, default: "Array"
+        Variable name to use in the error messages if any of the
+        _validation checks fail.
+
     Raises
     ------
     ValueError
@@ -135,11 +140,9 @@ def _cast_to_numpy(
             # we requested a copy but didn't end up with one
             out = out.copy()
     except (ValueError, VisibleDeprecationWarning) as e:
-        raise ValueError(f'Input cannot be cast as {np.ndarray}.') from e
-    if must_be_real and not issubclass(out.dtype.type, (np.floating, np.integer)):
-        raise TypeError(f'Array must have real numbers. Got dtype {out.dtype.type}')
+        raise ValueError(f'{name} cannot be cast as {np.ndarray}.') from e
+    if must_be_real is True and not issubclass(out.dtype.type, (np.floating, np.integer)):
+        raise TypeError(f'{name} must have real numbers. Got dtype {out.dtype.type}.')
     elif out.dtype.name == 'object':
-        raise TypeError(
-            f'Object arrays are not supported. Got {arr} when casting to a NumPy array.'
-        )
+        raise TypeError(f'{name} is an object array. Object arrays are not supported.')
     return out

--- a/pyvista/core/_validation/validate.py
+++ b/pyvista/core/_validation/validate.py
@@ -21,67 +21,676 @@ import reprlib
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
+from typing import NamedTuple
+from typing import Optional
+from typing import TypedDict
+from typing import TypeVar
+from typing import Union
+from typing import cast
+from typing import overload
 
 import numpy as np
-from numpy.typing import ArrayLike
 
-from pyvista.core._validation import check_contains
-from pyvista.core._validation import check_finite
-from pyvista.core._validation import check_integer
-from pyvista.core._validation import check_length
-from pyvista.core._validation import check_nonnegative
-from pyvista.core._validation import check_range
-from pyvista.core._validation import check_real
-from pyvista.core._validation import check_shape
-from pyvista.core._validation import check_sorted
-from pyvista.core._validation import check_string
-from pyvista.core._validation import check_subdtype
+try:
+    from typing import Unpack
+except ImportError:
+    from typing_extensions import Unpack
+
+from pyvista.core import _vtk_core as _vtk
+from pyvista.core._typing_core._array_like import _NumberType
+from pyvista.core._typing_core._array_like import _NumberUnion
 from pyvista.core._validation._cast_array import _cast_to_numpy
 from pyvista.core._validation._cast_array import _cast_to_tuple
-from pyvista.core._vtk_core import vtkMatrix3x3
-from pyvista.core._vtk_core import vtkMatrix4x4
-from pyvista.core._vtk_core import vtkTransform
+from pyvista.core._validation.check import check_contains
+from pyvista.core._validation.check import check_finite
+from pyvista.core._validation.check import check_integer
+from pyvista.core._validation.check import check_length
+from pyvista.core._validation.check import check_ndim
+from pyvista.core._validation.check import check_nonnegative
+from pyvista.core._validation.check import check_range
+from pyvista.core._validation.check import check_real
+from pyvista.core._validation.check import check_shape
+from pyvista.core._validation.check import check_sorted
+from pyvista.core._validation.check import check_string
+from pyvista.core._validation.check import check_subdtype
 
 if TYPE_CHECKING:  # pragma: no cover
-    from numpy.typing import ArrayLike
+    from collections.abc import Sequence
 
-    from pyvista.core._typing_core._array_like import NumpyArray
+    from pyvista.core._typing_core import ArrayLike
+    from pyvista.core._typing_core import MatrixLike
+    from pyvista.core._typing_core import NumberType
+    from pyvista.core._typing_core import NumpyArray
+    from pyvista.core._typing_core import TransformLike
+    from pyvista.core._typing_core import VectorLike
+    from pyvista.core._typing_core._aliases import _ArrayLikeOrScalar
+    from pyvista.core._typing_core._array_like import _FiniteNestedList
+    from pyvista.core._typing_core._array_like import _FiniteNestedTuple
+
+
+class _ValidationFlags(NamedTuple):
+    same_shape: bool
+    same_dtype: bool
+    same_type: bool
+    same_object: bool
+
+
+_FloatType = TypeVar('_FloatType', bound=float)  # noqa: PYI018
+_ShapeLike = Union[int, tuple[int, ...], tuple[()]]
+
+_NumpyReturnType = Union[
+    Literal['numpy'],
+    type[np.ndarray],  # type: ignore[type-arg]
+]
+_ListReturnType = Union[
+    Literal['list'],
+    type[list],  # type: ignore[type-arg]
+]
+_TupleReturnType = Union[
+    Literal['tuple'],
+    type[tuple],  # type: ignore[type-arg]
+]
+_ArrayReturnType = Union[_NumpyReturnType, _ListReturnType, _TupleReturnType]
+
+
+class _TypedKwargs(TypedDict, total=False):
+    must_have_shape: Optional[Union[_ShapeLike, list[_ShapeLike]]]
+    must_have_ndim: Optional[int]
+    must_have_dtype: Optional[_NumberUnion]
+    must_have_length: Optional[Union[int, VectorLike[int]]]
+    must_have_min_length: Optional[int]
+    must_have_max_length: Optional[int]
+    must_be_nonnegative: bool
+    must_be_finite: bool
+    must_be_real: bool
+    must_be_integer: bool
+    must_be_sorted: Union[bool, dict[str, Union[bool, int]]]
+    must_be_in_range: Optional[VectorLike[float]]
+    strict_lower_bound: bool
+    strict_upper_bound: bool
+    as_any: bool
+    copy: bool
+    get_flags: bool
+    name: str
+
+
+# Define overloads for validate_array
+# Overloads are listed in a similar order as the runtime isinstance checks performed
+# by the array wrappers, and generally go from most specific to least specific:
+#       scalars -> flat or nested lists and tuples -> numpy arrays -> general array-like
+# See https://mypy.readthedocs.io/en/stable/more_types.html#function-overloading
+#
+# """SCALAR OVERLOADS"""
+# T -> T
+@overload
+def validate_array(  # type: ignore[overload-overlap]  # numpydoc ignore=GL08
+    array: NumberType,
+    /,
+    *,
+    dtype_out: None = None,
+    return_type: Optional[Union[_TupleReturnType, _ListReturnType]] = ...,
+    reshape_to: Optional[tuple[()]] = ...,
+    broadcast_to: Optional[tuple[()]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> NumberType: ...
+
+
+# T1 -> T2
+@overload
+def validate_array(  # type: ignore[overload-overlap]  # numpydoc ignore=GL08
+    array: NumberType,
+    /,
+    *,
+    dtype_out: type[_NumberType],
+    return_type: Optional[Union[_TupleReturnType, _ListReturnType]] = ...,
+    reshape_to: Optional[tuple[()]] = ...,
+    broadcast_to: Optional[tuple[()]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> _NumberType: ...
+
+
+# T -> NDArray[T]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: NumberType,
+    /,
+    *,
+    dtype_out: None = None,
+    return_type: _NumpyReturnType,
+    reshape_to: Optional[tuple[()]] = ...,
+    broadcast_to: Optional[tuple[()]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> NumpyArray[NumberType]: ...
+
+
+# T1 -> NDArray[T2]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: NumberType,
+    /,
+    *,
+    dtype_out: type[_NumberType],
+    return_type: _NumpyReturnType,
+    reshape_to: Optional[tuple[()]] = ...,
+    broadcast_to: Optional[tuple[()]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> NumpyArray[_NumberType]: ...
+
+
+# """LIST OVERLOADS"""
+# list[list[T]] -> list[list[T]]
+@overload
+def validate_array(  # type: ignore[overload-overlap]  # numpydoc ignore=GL08
+    array: list[list[NumberType]],
+    /,
+    *,
+    dtype_out: None = None,
+    return_type: Optional[_ListReturnType] = ...,
+    reshape_to: Optional[tuple[int, int]] = ...,
+    broadcast_to: Optional[tuple[int, int]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> list[list[NumberType]]: ...
+
+
+# list[list[T1]] -> list[list[T2]]
+@overload
+def validate_array(  # type: ignore[overload-overlap]  # numpydoc ignore=GL08
+    array: list[list[NumberType]],
+    /,
+    *,
+    dtype_out: type[_NumberType],
+    return_type: Optional[_ListReturnType] = ...,
+    reshape_to: Optional[tuple[int, int]] = ...,
+    broadcast_to: Optional[tuple[int, int]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> list[list[_NumberType]]: ...
+
+
+# list[list[T]] -> tuple[tuple[T]]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: list[list[NumberType]],
+    /,
+    *,
+    dtype_out: None = None,
+    return_type: _TupleReturnType,
+    reshape_to: Optional[tuple[int, int]] = ...,
+    broadcast_to: Optional[tuple[int, int]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> tuple[tuple[NumberType]]: ...
+
+
+# list[list[T1]] -> tuple[tuple[T2]]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: list[list[NumberType]],
+    /,
+    *,
+    dtype_out: type[_NumberType],
+    return_type: _TupleReturnType,
+    reshape_to: Optional[tuple[int, int]] = ...,
+    broadcast_to: Optional[tuple[int, int]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> tuple[tuple[_NumberType]]: ...
+
+
+# list[T] -> list[T]
+@overload
+def validate_array(  # type: ignore[overload-overlap]  # numpydoc ignore=GL08
+    array: list[NumberType],
+    /,
+    *,
+    dtype_out: None = None,
+    return_type: Optional[_ListReturnType] = ...,
+    reshape_to: Optional[Union[int, tuple[int]]] = ...,
+    broadcast_to: Optional[Union[int, tuple[int]]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> list[NumberType]: ...
+
+
+# list[T1] -> list[T2]
+@overload
+def validate_array(  # type: ignore[overload-overlap]  # numpydoc ignore=GL08
+    array: list[NumberType],
+    /,
+    *,
+    dtype_out: type[_NumberType],
+    return_type: Optional[_ListReturnType] = ...,
+    reshape_to: Optional[Union[int, tuple[int]]] = ...,
+    broadcast_to: Optional[Union[int, tuple[int]]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> list[_NumberType]: ...
+
+
+# list[T] -> tuple[T]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: list[NumberType],
+    /,
+    *,
+    dtype_out: None = None,
+    return_type: _TupleReturnType,
+    reshape_to: Optional[Union[int, tuple[int]]] = ...,
+    broadcast_to: Optional[Union[int, tuple[int]]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> tuple[NumberType]: ...
+
+
+# list[T1] -> tuple[T2]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: list[NumberType],
+    /,
+    *,
+    dtype_out: type[_NumberType],
+    return_type: _TupleReturnType,
+    reshape_to: Optional[Union[int, tuple[int]]] = ...,
+    broadcast_to: Optional[Union[int, tuple[int]]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> tuple[_NumberType]: ...
+
+
+# FiniteNestedlist[T] -> FiniteNestedlist[T]
+@overload
+def validate_array(  # type: ignore[overload-overlap]  # numpydoc ignore=GL08
+    array: _FiniteNestedList[NumberType],
+    /,
+    *,
+    dtype_out: None = None,
+    return_type: Optional[_ListReturnType] = ...,
+    reshape_to: Optional[_ShapeLike] = ...,
+    broadcast_to: Optional[_ShapeLike] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> Union[NumberType, _FiniteNestedList[NumberType]]: ...
+
+
+# FiniteNestedlist[T1] -> FiniteNestedlist[T2]
+@overload
+def validate_array(  # type: ignore[overload-overlap]  # numpydoc ignore=GL08
+    array: _FiniteNestedList[NumberType],
+    /,
+    *,
+    dtype_out: type[_NumberType],
+    return_type: Optional[_ListReturnType] = ...,
+    reshape_to: Optional[_ShapeLike] = ...,
+    broadcast_to: Optional[_ShapeLike] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> Union[_NumberType, _FiniteNestedList[_NumberType]]: ...
+
+
+# """TUPLE OVERLOADS"""
+# tuple[tuple[T]] -> tuple[tuple[T]]
+@overload
+def validate_array(  # type: ignore[overload-overlap]  # numpydoc ignore=GL08
+    array: tuple[tuple[NumberType]],
+    /,
+    *,
+    dtype_out: None = None,
+    return_type: Optional[_TupleReturnType] = ...,
+    reshape_to: Optional[tuple[int, int]] = ...,
+    broadcast_to: Optional[tuple[int, int]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> tuple[tuple[NumberType]]: ...
+
+
+# tuple[tuple[T]] -> list[list[T]]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: tuple[tuple[NumberType]],
+    /,
+    *,
+    dtype_out: None = None,
+    return_type: _ListReturnType,
+    reshape_to: Optional[tuple[int, int]] = ...,
+    broadcast_to: Optional[tuple[int, int]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> list[list[NumberType]]: ...
+
+
+# tuple[tuple[T1]] -> tuple[tuple[T2]]
+@overload
+def validate_array(  # type: ignore[overload-overlap]  # numpydoc ignore=GL08
+    array: tuple[tuple[NumberType]],
+    /,
+    *,
+    dtype_out: type[_NumberType],
+    return_type: Optional[_TupleReturnType] = ...,
+    reshape_to: Optional[tuple[int, int]] = ...,
+    broadcast_to: Optional[tuple[int, int]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> tuple[tuple[_NumberType]]: ...
+
+
+# tuple[tuple[T1]] -> list[list[T2]]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: tuple[tuple[NumberType, ...]],
+    /,
+    *,
+    dtype_out: type[_NumberType],
+    return_type: _ListReturnType,
+    reshape_to: Optional[tuple[int, int]] = ...,
+    broadcast_to: Optional[tuple[int, int]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> list[list[_NumberType]]: ...
+
+
+# tuple[T] -> tuple[T]
+@overload
+def validate_array(  # type: ignore[overload-overlap]  # numpydoc ignore=GL08
+    array: tuple[NumberType, ...],
+    /,
+    *,
+    dtype_out: None = None,
+    return_type: Optional[_TupleReturnType] = ...,
+    reshape_to: Optional[Union[int, tuple[int]]] = ...,
+    broadcast_to: Optional[Union[int, tuple[int]]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> tuple[NumberType]: ...
+
+
+# tuple[T] -> list[T]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: tuple[NumberType],
+    /,
+    *,
+    dtype_out: None = None,
+    return_type: _ListReturnType,
+    reshape_to: Optional[Union[int, tuple[int]]] = ...,
+    broadcast_to: Optional[Union[int, tuple[int]]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> list[NumberType]: ...
+
+
+# tuple[T1] -> tuple[T2]
+@overload
+def validate_array(  # type: ignore[overload-overlap]  # numpydoc ignore=GL08
+    array: tuple[NumberType, ...],
+    /,
+    *,
+    dtype_out: type[_NumberType],
+    return_type: Optional[_TupleReturnType] = ...,
+    reshape_to: Optional[Union[int, tuple[int]]] = ...,
+    broadcast_to: Optional[Union[int, tuple[int]]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> tuple[_NumberType]: ...
+
+
+# tuple[T1] -> list[T2]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: tuple[NumberType, ...],
+    /,
+    *,
+    dtype_out: type[_NumberType],
+    return_type: _ListReturnType,
+    reshape_to: Optional[Union[int, tuple[int]]] = ...,
+    broadcast_to: Optional[Union[int, tuple[int]]] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> list[_NumberType]: ...
+
+
+# FiniteNestedtuple[T] -> FiniteNestedtuple[T]
+@overload
+def validate_array(  # type: ignore[overload-overlap]  # numpydoc ignore=GL08
+    array: _FiniteNestedTuple[NumberType],
+    /,
+    *,
+    dtype_out: None = None,
+    return_type: Optional[_TupleReturnType] = ...,
+    reshape_to: Optional[_ShapeLike] = ...,
+    broadcast_to: Optional[_ShapeLike] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> Union[NumberType, _FiniteNestedTuple[NumberType]]: ...
+
+
+# FiniteNestedtuple[T1] -> FiniteNestedtuple[T2]
+@overload
+def validate_array(  # type: ignore[overload-overlap]  # numpydoc ignore=GL08
+    array: _FiniteNestedTuple[NumberType],
+    /,
+    *,
+    dtype_out: type[_NumberType],
+    return_type: Optional[_TupleReturnType] = ...,
+    reshape_to: Optional[_ShapeLike] = ...,
+    broadcast_to: Optional[_ShapeLike] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> Union[_NumberType, _FiniteNestedTuple[_NumberType]]: ...
+
+
+# """NUMPY OVERLOADS"""
+# NDArray[T] -> NDArray[T]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: NumpyArray[NumberType],
+    /,
+    *,
+    dtype_out: None = None,
+    return_type: Optional[_NumpyReturnType] = ...,
+    reshape_to: Optional[_ShapeLike] = ...,
+    broadcast_to: Optional[_ShapeLike] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> NumpyArray[NumberType]: ...
+
+
+# NDArray[T1] -> NDArray[T2]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: NumpyArray[NumberType],
+    /,
+    *,
+    dtype_out: type[_NumberType],
+    return_type: Optional[_NumpyReturnType] = ...,
+    reshape_to: Optional[_ShapeLike] = ...,
+    broadcast_to: Optional[_ShapeLike] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> NumpyArray[_NumberType]: ...
+
+
+# NDArray[T] -> FiniteNestedlist[T]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: NumpyArray[NumberType],
+    /,
+    *,
+    dtype_out: None = None,
+    return_type: _ListReturnType,
+    reshape_to: Optional[_ShapeLike] = ...,
+    broadcast_to: Optional[_ShapeLike] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> Union[NumberType, _FiniteNestedList[NumberType]]: ...
+
+
+# NDArray[T1] -> FiniteNestedlist[T2]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: NumpyArray[NumberType],
+    /,
+    *,
+    dtype_out: type[_NumberType],
+    return_type: _ListReturnType,
+    reshape_to: Optional[_ShapeLike] = ...,
+    broadcast_to: Optional[_ShapeLike] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> Union[_NumberType, _FiniteNestedList[_NumberType]]: ...
+
+
+# NDArray[T] -> Nestedtuple[T]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: NumpyArray[NumberType],
+    /,
+    *,
+    dtype_out: None = None,
+    return_type: _TupleReturnType,
+    reshape_to: Optional[_ShapeLike] = ...,
+    broadcast_to: Optional[_ShapeLike] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> Union[NumberType, _FiniteNestedTuple[NumberType]]: ...
+
+
+# NDArray[T1] -> FiniteNestedtuple[T2]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: NumpyArray[NumberType],
+    /,
+    *,
+    dtype_out: type[_NumberType],
+    return_type: _TupleReturnType,
+    reshape_to: Optional[_ShapeLike] = ...,
+    broadcast_to: Optional[_ShapeLike] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> Union[_NumberType, _FiniteNestedTuple[_NumberType]]: ...
+
+
+# """ARRAY-LIKE OVERLOADS"""
+# These are general catch-all cases for anything not overloaded explicitly
+# ArrayLike[T] -> FiniteNestedlist[T]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: _ArrayLikeOrScalar[NumberType],
+    /,
+    *,
+    dtype_out: None = None,
+    return_type: _ListReturnType,
+    reshape_to: Optional[_ShapeLike] = ...,
+    broadcast_to: Optional[_ShapeLike] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> Union[NumberType, _FiniteNestedList[NumberType]]: ...
+
+
+# ArrayLike[T1] -> FiniteNestedlist[T2]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: _ArrayLikeOrScalar[NumberType],
+    /,
+    *,
+    dtype_out: type[_NumberType],
+    return_type: _ListReturnType,
+    reshape_to: Optional[_ShapeLike] = ...,
+    broadcast_to: Optional[_ShapeLike] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> Union[_NumberType, _FiniteNestedList[_NumberType]]: ...
+
+
+# ArrayLike[T] -> FiniteNestedtuple[T]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: _ArrayLikeOrScalar[NumberType],
+    /,
+    *,
+    dtype_out: None = None,
+    return_type: _TupleReturnType,
+    reshape_to: Optional[_ShapeLike] = ...,
+    broadcast_to: Optional[_ShapeLike] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> Union[NumberType, _FiniteNestedTuple[NumberType]]: ...
+
+
+# ArrayLike[T1] -> FiniteNestedtuple[T2]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: _ArrayLikeOrScalar[NumberType],
+    /,
+    *,
+    dtype_out: type[_NumberType],
+    return_type: _TupleReturnType,
+    reshape_to: Optional[_ShapeLike] = ...,
+    broadcast_to: Optional[_ShapeLike] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> Union[_NumberType, _FiniteNestedTuple[_NumberType]]: ...
+
+
+# ArrayLike[T] -> NDArray[T]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: _ArrayLikeOrScalar[NumberType],
+    /,
+    *,
+    dtype_out: None = None,
+    return_type: Optional[_NumpyReturnType] = ...,
+    reshape_to: Optional[_ShapeLike] = ...,
+    broadcast_to: Optional[_ShapeLike] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> NumpyArray[NumberType]: ...
+
+
+# ArrayLike[T1] -> NDArray[T2]
+@overload
+def validate_array(  # numpydoc ignore=GL08
+    array: _ArrayLikeOrScalar[NumberType],
+    /,
+    *,
+    dtype_out: type[_NumberType],
+    return_type: Optional[_NumpyReturnType] = ...,
+    reshape_to: Optional[_ShapeLike] = ...,
+    broadcast_to: Optional[_ShapeLike] = ...,
+    **kwargs: Unpack[_TypedKwargs],
+) -> NumpyArray[_NumberType]: ...
 
 
 def validate_array(
-    arr,
+    array: _ArrayLikeOrScalar[NumberType],
     /,
     *,
-    must_have_shape=None,
-    must_have_dtype=None,
-    must_have_length=None,
-    must_have_min_length=None,
-    must_have_max_length=None,
-    must_be_nonnegative=False,
-    must_be_finite=False,
-    must_be_real=True,
-    must_be_integer=False,
-    must_be_sorted=False,
-    must_be_in_range=None,
-    strict_lower_bound=False,
-    strict_upper_bound=False,
-    reshape_to=None,
-    broadcast_to=None,
-    dtype_out=None,
-    as_any=True,
-    copy=False,
+    must_have_shape: Optional[Union[_ShapeLike, list[_ShapeLike]]] = None,
+    must_have_ndim: Optional[Union[int, Sequence[int]]] = None,
+    must_have_dtype: Optional[_NumberUnion] = None,
+    must_have_length: Optional[Union[int, VectorLike[int]]] = None,
+    must_have_min_length: Optional[int] = None,
+    must_have_max_length: Optional[int] = None,
+    must_be_finite: bool = False,
+    must_be_real: bool = True,
+    must_be_integer: bool = False,
+    must_be_nonnegative: bool = False,
+    must_be_sorted: Union[bool, dict[str, Union[bool, int]]] = False,
+    must_be_in_range: Optional[VectorLike[float]] = None,
+    strict_lower_bound: bool = False,
+    strict_upper_bound: bool = False,
+    reshape_to: Optional[_ShapeLike] = None,
+    broadcast_to: Optional[_ShapeLike] = None,
+    dtype_out: Optional[type[_NumberType]] = None,
+    as_any: bool = True,
+    copy: bool = False,
+    get_flags: bool = False,
     to_list=False,
     to_tuple=False,
-    name='Array',
+    name: str = 'Array',
 ):
     """Check and validate a numeric array meets specific requirements.
 
     Validate an array to ensure it is numeric, has a specific shape,
-    data-type, and/or has values that meet specific
-    requirements such as being sorted, integer-like, or finite.
+    data-type, and/or has values that meet specific requirements such as
+    being sorted, having integer values, or is finite. The array can
+    optionally be reshaped or broadcast, and the return type of
+    the array can be explicitly set to standardize its representation.
 
-    The array's output can also be reshaped or broadcast, cast as a
-    nested tuple or list array, or cast to a specific data type.
+    By default, this function is generic and returns an array with the
+    same type and dtype as the input array, i.e. ``Array[T] -> Array[T]``
+    It is specifically designed to return the following array types as-is
+    without copying its data where possible:
+
+    - Scalars: ``T`` -> ``T``
+    - Lists: ``list[T]`` -> ``list[T]``
+    - Nested lists: ``list[list[T]]`` -> ``list[list[T]]``
+    - Tuples: ``tuple[T]`` -> ``tuple[T]``
+    - Nested tuples: ``tuple[tuple[T]]`` -> ``tuple[tuple[T]]``
+    - NumPy arrays: ``NDArray[T]`` -> ``NDArray[T]``
+
+    All other inputs (e.g. ``range`` objects) may first be copied to a
+    NumPy array for processing internally. NumPy protocol arrays (e.g.
+    ``pandas`` arrays) are not copied but are returned as a NumPy array.
+
+    Optionally, use ``return_type`` and/or ``dtype_out`` for non-generic
+    behavior to ensure the output array has a consistent type.
+
+    .. warning::
+
+        This function is primarily designed to work with homogeneous
+        numeric arrays with a regular shape. Any other array-like
+        inputs (e.g. structured arrays, string arrays) are not
+        supported.
 
     See Also
     --------
@@ -94,6 +703,9 @@ def validate_array(
     validate_arrayN
         Specialized function for one-dimensional arrays.
 
+    validate_arrayN_unsigned
+        Specialized function for one-dimensional arrays with unsigned integers.
+
     validate_arrayNx3
         Specialized function for Nx3 dimensional arrays.
 
@@ -102,69 +714,93 @@ def validate_array(
 
     Parameters
     ----------
-    arr : array_like
-        Array to be validated, in any form that can be converted to
+    array : Number | Array
+        Number or array to be validated, in any form that can be converted to
         a :class:`np.ndarray`. This includes lists, lists of tuples, tuples,
         tuples of tuples, tuples of lists and ndarrays.
 
-    must_have_shape : int | tuple[int, ...] | list[int, tuple[int, ...]], optional
-        :func:`Check <pyvista.core.validation.check.check_has_shape>`
+    must_have_shape : ShapeLike | list[ShapeLike], optional
+        :func:`Check <pyvista.core._validation.check.check_shape>`
         if the array has a specific shape. Specify a single shape
-        or a ``list`` of any allowable shapes. If an integer, the array must
+        or a list of any allowable shapes. If an integer, the array must
         be 1-dimensional with that length. Use a value of ``-1`` for any
         dimension where its size is allowed to vary. Use ``()`` to allow
         scalar values (i.e. 0-dimensional). Set to ``None`` if the array
         can have any shape (default).
 
-    must_have_dtype : dtype_like | list[dtype_like, ...], optional
-        :func:`Check <pyvista.core.validation.check.check_subdtype>`
+    must_have_ndim : int | Sequence[int], optional
+        :func:`Check <pyvista.core._validation.check.check_ndim>` if
+        the array has the specified number of dimension(s). Specify a
+        single dimension or a sequence of allowable dimensions. If a
+        sequence, the array must have at least one of the specified
+        number of dimensions.
+
+    must_have_dtype : numpy.typing.DTypeLike | Sequence[numpy.typing.DTypeLike], optional
+        :func:`Check <pyvista.core._validation.check.check_subdtype>`
         if the array's data-type has the given dtype. Specify a
-        :class:`np.dtype` object or dtype-like base class which the
-        array's data must be a subtype of. If a ``list``, the array's data
+        :class:`numpy.dtype` object or dtype-like base class which the
+        array's data must be a subtype of. If a sequence, the array's data
         must be a subtype of at least one of the specified dtypes.
 
-    must_have_length : int | array_like[int, ...], optional
-        :func:`Check <pyvista.core.validation.check.check_has_length>`
+    must_have_length : int | VectorLike[int], optional
+        :func:`Check <pyvista.core._validation.check.check_length>`
         if the array has the given length. If multiple values are given,
         the array's length must match one of the values.
 
         .. note ::
 
             The array's length is determined after reshaping the array
-            (if ``reshape`` is not ``None``) and after broadcasting (if
-            ``broadcast_to`` is not ``None``). Therefore, the values of
-            `length`` should take the array's new shape into
-            consideration if applicable.
+            (if ``reshape_to`` is not ``None``) and after broadcasting (if
+            ``broadcast_to`` is not ``None``). Therefore, the specified length
+            values should take the array's new shape into consideration if
+            applicable.
 
     must_have_min_length : int, optional
-        :func:`Check <pyvista.core.validation.check.check_has_length>`
-        if the array's length is this value or greater.
+        :func:`Check <pyvista.core._validation.check.check_length>`
+        if the array's length is this value or greater. See note in
+        ``must_have_length`` for details.
 
     must_have_max_length : int, optional
-        :func:`Check <pyvista.core.validation.check.check_has_length>`
-        if the array' length is this value or less.
-
-    must_be_nonnegative : bool, default: False
-        :func:`Check <pyvista.core.validation.check.check_nonnegative>`
-        if all elements of the array are nonnegative.
+        :func:`Check <pyvista.core._validation.check.check_length>`
+        if the array' length is this value or less. See note in
+        ``must_have_length`` for details.
 
     must_be_finite : bool, default: False
-        :func:`Check <pyvista.core.validation.check.check_finite>`
+        :func:`Check <pyvista.core._validation.check.check_finite>`
         if all elements of the array are finite, i.e. not ``infinity``
         and not Not a Number (``NaN``).
 
     must_be_real : bool, default: True
-        :func:`Check <pyvista.core.validation.check.check_real>`
+        :func:`Check <pyvista.core._validation.check.check_real>`
         if the array has real numbers, i.e. its data type is integer or
         floating.
 
+        .. warning::
+
+            Setting this parameter to ``False`` can result in unexpected
+            behavior and is not recommended. There is limited support
+            for complex number and/or string arrays.
+
     must_be_integer : bool, default: False
-        :func:`Check <pyvista.core.validation.check.check_integer>`
+        :func:`Check <pyvista.core._validation.check.check_integer>`
         if the array's values are integer-like (i.e. that
         ``np.all(arr, np.floor(arr))``).
 
+        .. note::
+
+            This check does not require the input dtype to be integers,
+            i.e. floats are allowed. Set ``must_have_dtype=int`` if the
+            input is required to be integers or ``dtype_out=int`` to
+            cast the output to integers.
+
+    must_be_nonnegative : bool, default: False
+        :func:`Check <pyvista.core._validation.check.check_nonnegative>`
+        if all elements of the array are nonnegative. Consider also
+        setting ``dtype_out``, e.g. to ensure the output is an unsigned
+        integer type.
+
     must_be_sorted : bool | dict, default: False
-        :func:`Check <pyvista.core.validation.check.check_sorted>`
+        :func:`Check <pyvista.core._validation.check.check_sorted>`
         if the array's values are sorted. If ``True``, the check is
         performed with default parameters:
 
@@ -174,25 +810,26 @@ def validate_array(
 
         To check for descending order, enforce strict ordering, or to check
         along a different axis, use a ``dict`` with keyword arguments that
-        will be passed to ``check_sorted``.
+        will be passed to :func:`Check <pyvista.core._validation.check.check_sorted>`.
 
-    must_be_in_range : array_like[float, float], optional
-        :func:`Check <pyvista.core.validation.check.check_range>`
+    must_be_in_range : VectorLike[float], optional
+        :func:`Check <pyvista.core._validation.check.check_range>`
         if the array's values are all within a specific range. Range
-        must be array-like with two elements specifying the minimum and
+        must be a vector with two elements specifying the minimum and
         maximum data values allowed, respectively. By default, the range
         endpoints are inclusive, i.e. values must be >= minimum and <=
         maximum. Use ``strict_lower_bound`` and/or ``strict_upper_bound``
         to further restrict the allowable range.
 
-        ..note ::
+        .. note::
 
-            Use ``np.inf`` to check for open intervals, e.g.:
+            Use infinity (``np.inf`` or ``float('inf')``) to specify an
+            unlimited bound, e.g.:
 
-            * ``[-np.inf, upper_bound]`` to check if values are less
-              than (or equal to)  ``upper_bound``
-            * ``[lower_bound, np.inf]`` to check if values are greater
-              than (or equal to) ``lower_bound``
+            * ``[-np.inf, upper]`` to check if values are less
+              than (or equal to) ``upper``
+            * ``[lower, np.inf]`` to check if values are greater
+              than (or equal to) ``lower``
 
     strict_lower_bound : bool, default: False
         Enforce a strict lower bound for the range specified by
@@ -205,32 +842,57 @@ def validate_array(
         than the specified maximum.
 
     reshape_to : int | tuple[int, ...], optional
-        Reshape the output array to a new shape with :func:`np.reshape`.
+        Reshape the output array to a new shape with :func:`numpy.reshape`.
         The shape should be compatible with the original shape. If an
         integer, then the result will be a 1-D array of that length. One
-        shape dimension can be -1.
+        shape dimension can be ``-1``.
 
     broadcast_to : int | tuple[int, ...], optional
-        Broadcast the array with :func:`np.broadcast_to` to a
+        Broadcast the array with :func:`numpy.broadcast_to` to a
         read-only view with the specified shape. Broadcasting is done
         after reshaping (if ``reshape_to`` is not ``None``).
 
-    dtype_out : dtype_like, optional
+    dtype_out : numpy.typing.DTypeLike, optional
         Set the data-type of the returned array. By default, the
-        dtype is inferred from the input data.
+        dtype is inferred from the input data. If ``dtype_out`` differs
+        from the array's dtype, a copy of the array is made. The dtype
+        of the array is set after any ``must_be_real`` or ``must_have_dtype``
+        checks are made.
+
+        .. warning::
+
+            Setting this to a NumPy dtype (e.g. ``np.float64``) will implicitly
+            set ``return_type`` to ``numpy``. Set to ``float``, ``int``, or
+            ``bool`` to avoid this behavior.
+
+        .. warning::
+
+            Array validation can fail or result in silent integer overflow
+            if ``dtype_out`` is integral and the input has infinity values.
+            Consider setting ``must_be_finite=True`` for these cases.
+
+    return_type : str | type, optional
+        Control the return type of the array. Must be one of:
+
+        * ``"numpy"`` or ``np.ndarray``
+        * ``"list"`` or ``list``
+        * ``"tuple"`` or ``tuple``
+
+        .. note::
+
+            For scalar inputs, setting the output type to ``list`` or
+            ``tuple`` will return a scalar, and not an actual ``list``
+            or ``tuple`` object.
 
     as_any : bool, default: True
         Allow subclasses of ``np.ndarray`` to pass through without
-        making a copy.
+        making a copy. Has no effect if the input is not a NumPy array.
 
     copy : bool, default: False
-        If ``True``, a copy of the array is returned. A copy is always
-        returned if the array:
-
-        * is a nested sequence
-        * is a subclass of ``np.ndarray`` and ``as_any`` is ``False``.
-
-        A copy may also be made to satisfy ``dtype_out`` requirements.
+        If ``True``, a copy of the array is returned. In some cases, a copy may be
+        returned even if ``copy=False`` (e.g. to convert array type/dtype, reshape,
+        etc.). In cases where the array is immutable (e.g. tuple) the returned array
+        may not be a copy, even if ``copy=True``.
 
     to_list : bool, default: False
         Return the validated array as a ``list`` or nested ``list``. Scalar
@@ -241,19 +903,35 @@ def validate_array(
         Return the validated array as a ``tuple`` or nested ``tuple``. Scalar
         values are always returned as a ``Number``  (i.e. ``int`` or ``float``).
 
+    get_flags : bool, default: False
+        If ``True``, return a ``namedtuple`` of boolean flags with information about
+        how the output may differ from the input. The flags returned are:
+
+        - ``same_shape``:  ``True`` if the validated array has the same shape as the input.
+          Always ``True`` if ``reshape_to`` and ``broadcast_to`` are ``None``.
+
+        - ``same_dtype``: ``True`` if the validated array has the same dtype as the input.
+          Always ``True`` if ``dtype_out`` is ``None``.
+
+        - ``same_type``: ``True`` if the validated array has the same type as the input.
+          Always ``True`` if ``return_type`` is ``None`` and the input array
+          is supported generically (i.e. is scalar, tuple, list, ndarray).
+
+        - ``same_object``: ``True`` if the validated array is the same object as the input.
+          May be ``True`` or ``False`` depending on whether a copy is made.
+          See ``copy`` for details.
+
     name : str, default: "Array"
         Variable name to use in the error messages if any of the
         validation checks fail.
 
     Returns
     -------
-    array_like
-        Validated array. Returned object is:
-
-        * an instance of ``np.ndarray`` (default), or
-        * a nested ``list`` (if ``to_list=True``), or
-        * a nested ``tuple`` (if ``to_tuple=True``), or
-        * a ``Number`` (i.e. ``int`` or ``float``) if the input is a scalar.
+    Number | Array
+        Validated array of the same type and dtype as the input.
+        If ``return_type`` is not ``None``, the returned array has the specified type.
+        If ``dtype_out`` is not ``None``, the returned array has the specified dtype.
+        See function description for more details.
 
     Examples
     --------
@@ -271,28 +949,45 @@ def validate_array(
     ...     must_be_sorted=dict(strict=True),
     ...     must_be_in_range=rng,
     ... )
-    array([ 1,  2,  3,  5,  8, 13])
+    (1, 2, 3, 5, 8, 13)
 
     """
-    arr_out = _cast_to_numpy(arr, as_any=as_any, copy=copy)
+    type_in = type(array) if get_flags else None
+    id_in = id(array) if get_flags else None
 
-    # Check type
+    array_out = _cast_to_numpy(array, as_any=as_any)
+
+    shape_in = array_out.shape if get_flags else None
+    dtype_in = array_out.dtype if get_flags else None
+
+    # Check dtype
     if must_be_real:
-        check_real(arr_out, name=name)
-
+        check_real(array_out, name=name)
     if must_have_dtype is not None:
-        check_subdtype(arr_out, must_have_dtype, name=name)
+        check_subdtype(array_out, base_dtype=must_have_dtype, name=name)
+
+    # Validate dtype_out
+    if (to_list or to_tuple) and np.dtype(dtype_out) not in (
+        np.dtype(float),
+        np.dtype(int),
+        np.dtype(bool),
+    ):
+        raise ValueError(
+            'Invalid `dtype_out` specified. Dtype must be float, int, or bool when \n'
+            '`to_list` or `to_tuple` is enabled.',
+        )
 
     # Check shape
     if must_have_shape is not None:
-        check_shape(arr_out, must_have_shape, name=name)
+        check_shape(array_out, shape=must_have_shape, name=name)
+    if must_have_ndim is not None:
+        check_ndim(array_out, ndim=must_have_ndim, name=name)
 
     # Do reshape _after_ checking shape to prevent unexpected reshaping
-    if reshape_to is not None and arr_out.shape != reshape_to:
-        arr_out = arr_out.reshape(reshape_to)
-
-    if broadcast_to is not None and arr_out.shape != broadcast_to:
-        arr_out = np.broadcast_to(arr_out, broadcast_to, subok=True)
+    if reshape_to is not None and array_out.shape != reshape_to:
+        array_out = array_out.reshape(reshape_to)
+    if broadcast_to is not None and array_out.shape != broadcast_to:
+        array_out = np.broadcast_to(array_out, broadcast_to, subok=True)
 
     # Check length _after_ reshaping otherwise length may be wrong
     if (
@@ -301,7 +996,7 @@ def validate_array(
         or must_have_max_length is not None
     ):
         check_length(
-            arr,
+            array_out,
             exact_length=must_have_length,
             min_length=must_have_min_length,
             max_length=must_have_max_length,
@@ -311,14 +1006,15 @@ def validate_array(
 
     # Check data values
     if must_be_nonnegative:
-        check_nonnegative(arr_out, name=name)
+        check_nonnegative(array_out, name=name)
+    # Check finite before setting dtype since dtype change can fail with inf
     if must_be_finite:
-        check_finite(arr_out, name=name)
+        check_finite(array_out, name=name)
     if must_be_integer:
-        check_integer(arr_out, strict=False, name=name)
+        check_integer(array_out, strict=False, name=name)
     if must_be_in_range is not None:
         check_range(
-            arr_out,
+            array_out,
             must_be_in_range,
             strict_lower=strict_lower_bound,
             strict_upper=strict_upper_bound,
@@ -326,28 +1022,38 @@ def validate_array(
         )
     if must_be_sorted:
         if isinstance(must_be_sorted, dict):
-            check_sorted(arr_out, **must_be_sorted, name=name)
+            check_sorted(array_out, **must_be_sorted, name=name)  # type: ignore[arg-type]
         else:
-            check_sorted(arr_out, name=name)
+            check_sorted(array_out, name=name)
 
-    # Process output
+    # Set dtype
     if dtype_out is not None:
-        # Copy was done earlier, so don't do it again here
-        arr_out = arr_out.astype(dtype_out, copy=False)
+        array_out = array_out.astype(dtype_out, copy=False)
+
+    def _get_flags(_out):
+        return _ValidationFlags(
+            same_shape=_out.shape == shape_in,
+            same_dtype=_out.dtype == np.dtype(dtype_in),
+            same_type=type(_out) is type_in,
+            same_object=id(_out) == id_in,
+        )
+
     if to_tuple:
-        return _cast_to_tuple(arr_out)
+        tuple_out = _cast_to_tuple(array_out)
+        return (tuple_out, _get_flags(array_out)) if get_flags else tuple_out
     if to_list:
-        return arr_out.tolist()
-    return arr_out
+        list_out = array_out.tolist()
+        return (list_out, _get_flags(array_out)) if get_flags else list_out
+    return (array_out, _get_flags(array_out)) if get_flags else array_out
 
 
 def validate_axes(
-    *axes,
-    normalize=True,
-    must_be_orthogonal=True,
-    must_have_orientation='right',
-    name='Axes',
-):
+    *axes: Union[MatrixLike[float], VectorLike[float]],
+    normalize: bool = True,
+    must_be_orthogonal: bool = True,
+    must_have_orientation: Optional[str] = 'right',
+    name: str = 'Axes',
+) -> NumpyArray[float]:
     """Validate 3D axes vectors.
 
     By default, the axes are normalized and checked to ensure they are orthogonal and
@@ -355,9 +1061,9 @@ def validate_axes(
 
     Parameters
     ----------
-    *axes : array_like
-        Axes to be validated. Axes may be specified as a single argument of a 3x3
-        array of row vectors or as separate arguments for each 3-element axis vector.
+    *axes : MatrixLike[float] | VectorLike[float]
+        Axes to be validated. Axes may be specified as a single array of row vectors
+        or as separate arguments for each 3-element axis vector.
         If only two vectors are given and ``must_have_orientation`` is not ``None``,
         the third vector is automatically calculated as the cross-product of the
         two vectors such that the axes have the correct orientation.
@@ -413,44 +1119,68 @@ def validate_axes(
            [ 0.,  0., -1.]])
 
     """
-    # Validate number of args
-    check_length(axes, exact_length=[1, 2, 3], name=f'{name} arguments')
     if must_have_orientation is not None:
         check_contains(
-            item=must_have_orientation,
-            container=['right', 'left'],
+            ['right', 'left'],
+            must_contain=must_have_orientation,
             name=f'{name} orientation',
         )
-    elif must_have_orientation is None and len(axes) == 2:
-        raise ValueError(f'{name} orientation must be specified when only two vectors are given.')
+
+    # Validate number of args
+    num_args = len(axes)
+    if num_args not in (1, 2, 3):
+        raise ValueError(
+            'Incorrect number of axes arguments. Number of arguments must be either:\n'
+            '\tOne arg (a single array with two or three vectors),'
+            '\tTwo args (two vectors), or'
+            '\tThree args (three vectors).',
+        )
 
     # Validate axes array
-    if len(axes) == 1:
-        axes_array = validate_array(axes[0], must_have_shape=(3, 3), name=name)
+    vector2: Optional[NumpyArray[float]] = None
+    if num_args == 1:
+        axes_array = validate_array(
+            axes[0],
+            must_have_shape=[(2, 3), (3, 3)],
+            name=name,
+            dtype_out=np.floating,
+        )
+        vector0 = axes_array[0]
+        vector1 = axes_array[1]
+        if len(axes_array) == 3:
+            vector2 = axes_array[2]
     else:
-        axes_array = np.zeros((3, 3))
-        axes_array[0] = validate_array3(axes[0], name=f'{name} Vector[0]')
-        axes_array[1] = validate_array3(axes[1], name=f'{name} Vector[1]')
-        if len(axes) == 3:
-            axes_array[2] = validate_array3(axes[2], name=f'{name} Vector[2]')
-        else:  # len(axes) == 2
-            if must_have_orientation == 'right':
-                axes_array[2] = np.cross(axes_array[0], axes_array[1])
-            else:
-                axes_array[2] = np.cross(axes_array[1], axes_array[0])
+        vector0 = validate_array3(axes[0], name=f'{name} Vector[0]')
+        vector1 = validate_array3(axes[1], name=f'{name} Vector[1]')
+        if num_args == 3:
+            vector2 = validate_array3(axes[2], name=f'{name} Vector[2]')
+
+    if vector2 is None:
+        if must_have_orientation is None:
+            raise ValueError(
+                f'{name} orientation must be specified when only two vectors are given.',
+            )
+        elif must_have_orientation == 'right':
+            vector2 = np.cross(vector0, vector1)
+        else:
+            vector2 = np.cross(vector1, vector0)
+    axes_array = np.vstack((vector0, vector1, vector2))
     check_finite(axes_array, name=name)
 
-    if np.isclose(np.dot(axes_array[0], axes_array[1]), 1) or np.isclose(
-        np.dot(axes_array[0], axes_array[2]),
-        1,
-    ):
-        raise ValueError(f'{name} cannot be parallel.')
     if np.any(np.all(np.isclose(axes_array, np.zeros(3)), axis=1)):
         raise ValueError(f'{name} cannot be zeros.')
 
-    # Check orthogonality and orientation using cross products
-    # Normalize axes first since norm values are needed for cross product calc
+    # Normalize axes for dot and cross product calcs
     axes_norm = axes_array / np.linalg.norm(axes_array, axis=1).reshape((3, 1))
+
+    # Check non-parallel
+    if np.isclose(np.dot(axes_norm[0], axes_norm[1]), 1) or np.isclose(
+        np.dot(axes_norm[0], axes_norm[2]),
+        1,
+    ):
+        raise ValueError(f'{name} cannot be parallel.')
+
+    # Check orthogonality
     cross_0_1 = np.cross(axes_norm[0], axes_norm[1])
     cross_1_2 = np.cross(axes_norm[1], axes_norm[2])
 
@@ -460,6 +1190,7 @@ def validate_axes(
     ):
         raise ValueError(f'{name} are not orthogonal.')
 
+    # Check orientation
     if must_have_orientation:
         dot = np.dot(cross_0_1, axes_norm[2])
         if must_have_orientation == 'right' and dot < 0:
@@ -467,12 +1198,12 @@ def validate_axes(
         if must_have_orientation == 'left' and dot > 0:
             raise ValueError(f'{name} do not have a left-handed orientation.')
 
-    if normalize:
-        return axes_norm
-    return axes_array
+    return axes_norm if normalize else axes_array
 
 
-def validate_transform4x4(transform, /, *, must_be_finite=True, name='Transform'):
+def validate_transform4x4(
+    transform: TransformLike, /, *, must_be_finite: bool = True, name='Transform'
+) -> NumpyArray[float]:
     """Validate transform-like input as a 4x4 ndarray.
 
     This function supports inputs with a 3x3 or 4x4 shape. If the input is 3x3,
@@ -483,9 +1214,6 @@ def validate_transform4x4(transform, /, *, must_be_finite=True, name='Transform'
     transform : TransformLike
         Transformation matrix as a 3x3 or 4x4 array or vtk matrix, or a
         SciPy ``Rotation`` instance.
-
-        Transformation matrix as a 3x3 or 4x4 array, 3x3 or 4x4 vtkMatrix,
-        or as a vtkTransform.
 
     must_be_finite : bool, default: True
         :func:`Check <pyvista.core.validation.check.check_finite>`
@@ -515,9 +1243,9 @@ def validate_transform4x4(transform, /, *, must_be_finite=True, name='Transform'
         arr = np.eye(4)  # initialize
         arr[:3, :3] = validate_transform3x3(transform, must_be_finite=must_be_finite, name=name)
     except (ValueError, TypeError):
-        if isinstance(transform, vtkMatrix4x4):
+        if isinstance(transform, _vtk.vtkMatrix4x4):
             arr = _array_from_vtkmatrix(transform, shape=(4, 4))
-        elif isinstance(transform, vtkTransform):
+        elif isinstance(transform, _vtk.vtkTransform):
             arr = _array_from_vtkmatrix(transform.GetMatrix(), shape=(4, 4))
         else:
             try:
@@ -538,11 +1266,16 @@ def validate_transform4x4(transform, /, *, must_be_finite=True, name='Transform'
                     '\tscipy.spatial.transform.Rotation\n'
                     f'Got {reprlib.repr(transform)} with type {type(transform)} instead.',
                 )
-
     return arr
 
 
-def validate_transform3x3(transform, /, *, must_be_finite=True, name='Transform'):
+def validate_transform3x3(
+    transform: Union[MatrixLike[float], _vtk.vtkMatrix3x3],
+    /,
+    *,
+    must_be_finite=True,
+    name='Transform',
+) -> NumpyArray[float]:
     """Validate transform-like input as a 3x3 ndarray.
 
     Parameters
@@ -577,11 +1310,11 @@ def validate_transform3x3(transform, /, *, must_be_finite=True, name='Transform'
         Similar function for 4x4 transforms.
 
     validate_array
-        Generic array validation function.
+        Generic array _validation function.
 
     """
     check_string(name, name='Name')
-    if isinstance(transform, vtkMatrix3x3):
+    if isinstance(transform, _vtk.vtkMatrix3x3):
         return _array_from_vtkmatrix(transform, shape=(3, 3))
     else:
         try:
@@ -613,7 +1346,7 @@ def validate_transform3x3(transform, /, *, must_be_finite=True, name='Transform'
 
 
 def _array_from_vtkmatrix(
-    matrix: vtkMatrix3x3 | vtkMatrix4x4,
+    matrix: _vtk.vtkMatrix3x3 | _vtk.vtkMatrix4x4,
     shape: tuple[Literal[3], Literal[3]] | tuple[Literal[4], Literal[4]],
 ) -> NumpyArray[float]:
     """Convert a vtk matrix to an array."""
@@ -623,36 +1356,94 @@ def _array_from_vtkmatrix(
     return array
 
 
-def validate_number(num, /, *, reshape=True, **kwargs):
-    """Validate a real, finite number.
+class _KwargsValidateNumber(TypedDict):
+    reshape: bool
+    must_have_dtype: Optional[_NumberUnion]
+    must_be_finite: bool
+    must_be_real: bool
+    must_be_integer: bool
+    must_be_nonnegative: bool
+    must_be_in_range: Optional[VectorLike[float]]
+    strict_lower_bound: bool
+    strict_upper_bound: bool
+    get_flags: bool
+    name: str
 
-    By default, the number is checked to ensure it:
 
-    * is scalar or is an array which can be reshaped as a scalar
-    * is a real number
-    * is finite
+# Many type ignores needed to make overloads work here but the typing tests should still pass
+@overload
+def validate_number(  # type: ignore[misc]  # numpydoc ignore=GL08
+    num: Union[NumberType, VectorLike[NumberType]],
+    /,
+    *,
+    reshape: bool = ...,
+    dtype_out: None = None,
+    **kwargs: Unpack[_KwargsValidateNumber],
+) -> NumberType: ...
+
+
+@overload
+def validate_number(  # type: ignore[misc]  # numpydoc ignore=GL08
+    num: Union[NumberType, VectorLike[NumberType]],
+    /,
+    *,
+    reshape: bool = ...,
+    dtype_out: type[_NumberType],
+    **kwargs: Unpack[_KwargsValidateNumber],
+) -> _NumberType: ...
+
+
+def validate_number(  # type: ignore[misc]  # numpydoc ignore=PR01,PR02  # noqa: D417
+    num: Union[NumberType, VectorLike[NumberType]],
+    /,
+    *,
+    reshape: bool = True,
+    must_be_finite: bool = True,
+    must_be_real: bool = True,
+    must_have_dtype: Optional[_NumberUnion] = None,
+    must_be_integer: bool = False,
+    must_be_nonnegative: bool = False,
+    must_be_in_range: Optional[VectorLike[float]] = None,
+    strict_lower_bound: bool = False,
+    strict_upper_bound: bool = False,
+    dtype_out: Optional[type[_NumberType]] = None,
+    get_flags: bool = False,
+    name: str = 'Number',
+):
+    """Validate a real number.
+
+    This function is similar to :func:`~validate_array`, but is configured
+    to only allow inputs with one element. The number is checked to be finite
+    by default, and the return type is fixed to always return a ``float``,
+    ``int``, or ``bool`` type.
 
     Parameters
     ----------
-    num : int | float | array_like
+    num : float | VectorLike[float]
         Number to validate.
 
     reshape : bool, default: True
         If ``True``, 1D arrays with 1 element are considered valid input
         and are reshaped to be 0-dimensional.
 
-    **kwargs : dict, optional
-        Additional keyword arguments passed to :func:`~validate_array`.
+    Other Parameters
+    ----------------
+    **kwargs
+        See :func:`~validate_array` for documentation on all other keyword
+        arguments.
 
     Returns
     -------
-    int | float
+    float | int | bool
         Validated number.
 
     See Also
     --------
     validate_array
         Generic array validation function.
+
+    check_number
+        Similar function with fewer options and no return value.
 
     Examples
     --------
@@ -675,36 +1466,76 @@ def validate_number(num, /, *, reshape=True, **kwargs):
     10
 
     """
-    kwargs.setdefault('name', 'Number')
-    kwargs.setdefault('to_list', True)
-    kwargs.setdefault('must_be_finite', True)
+    must_have_shape: Union[_ShapeLike, list[_ShapeLike]]
+    must_have_shape = [(), (1,)] if reshape else ()
 
-    if reshape:
-        shape = [(), (1,)]
-        _set_default_kwarg_mandatory(kwargs, 'reshape_to', ())
-    else:
-        shape = ()
-    _set_default_kwarg_mandatory(kwargs, 'must_have_shape', shape)
+    return validate_array(  # type: ignore[type-var, misc]
+        num,
+        # Override default vales for these params:
+        to_list=True,
+        reshape_to=(),
+        must_have_shape=must_have_shape,
+        # Allow these params to be set by user:
+        dtype_out=dtype_out,  # type: ignore[arg-type]
+        must_have_dtype=must_have_dtype,
+        must_be_nonnegative=must_be_nonnegative,
+        must_be_finite=must_be_finite,
+        must_be_real=must_be_real,
+        must_be_integer=must_be_integer,
+        must_be_in_range=must_be_in_range,
+        strict_lower_bound=strict_lower_bound,
+        strict_upper_bound=strict_upper_bound,
+        get_flags=get_flags,
+        name=name,
+        # These params are irrelevant for this function:
+        must_have_ndim=None,
+        must_be_sorted=False,
+        must_have_length=None,
+        must_have_min_length=None,
+        must_have_max_length=None,
+        broadcast_to=None,
+        as_any=False,
+        copy=False,
+    )
 
-    return validate_array(num, **kwargs)
 
-
-def validate_data_range(rng, /, **kwargs):
+def validate_data_range(  # numpydoc ignore=PR01,PR02  # noqa: D417
+    rng: VectorLike[NumberType],
+    /,
+    *,
+    must_have_dtype: Optional[_NumberUnion] = None,
+    must_be_nonnegative: bool = False,
+    must_be_finite: bool = False,
+    must_be_real: bool = True,
+    must_be_integer: bool = False,
+    must_be_in_range: Optional[VectorLike[float]] = None,
+    strict_lower_bound: bool = False,
+    strict_upper_bound: bool = False,
+    dtype_out: Optional[type[_NumberType]] = None,
+    as_any: bool = True,
+    copy: bool = False,
+    get_flags: bool = False,
+    to_tuple: bool = False,
+    to_list: bool = False,
+    name: str = 'Data Range',
+) -> tuple[_NumberType, _NumberType]:
     """Validate a data range.
 
-    By default, the data range is checked to ensure:
-
-    * it has two values
-    * it has real numbers
-    * the lower bound is not more than the upper bound
+    This function is similar to :func:`~validate_array`, but is configured
+    to only allow inputs with two values and checks that the first value is
+    not greater than the second. The return type is also fixed to always
+    return a tuple.
 
     Parameters
     ----------
-    rng : array_like[float, float]
+    rng : VectorLike[float]
         Range to validate in the form ``(lower_bound, upper_bound)``.
 
-    **kwargs : dict, optional
-        Additional keyword arguments passed to :func:`~validate_array`.
+    Other Parameters
+    ----------------
+    **kwargs
+        See :func:`~validate_array` for documentation on all other keyword
+        arguments.
 
     Returns
     -------
@@ -721,47 +1552,158 @@ def validate_data_range(rng, /, **kwargs):
     Validate a data range.
 
     >>> from pyvista import _validation
-    >>> _validation.validate_data_range([-5, 5])
-    (-5, 5)
+    >>> _validation.validate_data_range([-5, 5.0])
+    (-5, 5.0)
 
-    Add additional constraints if needed.
+    Add additional constraints if needed, e.g. to ensure the output
+    only contains floats.
 
-    >>> _validation.validate_data_range([0, 1.0], must_be_nonnegative=True)
-    (0.0, 1.0)
+    >>> _validation.validate_data_range([-5, 5.0], dtype_out=float)
+    (-5.0, 5.0)
 
     """
-    kwargs.setdefault('name', 'Data Range')
-    _set_default_kwarg_mandatory(kwargs, 'must_have_shape', 2)
-    _set_default_kwarg_mandatory(kwargs, 'must_be_sorted', True)
-    if 'to_list' not in kwargs:
-        kwargs.setdefault('to_tuple', True)
-    return validate_array(rng, **kwargs)
+    return cast(
+        tuple[_NumberType, _NumberType],
+        validate_array(
+            rng,
+            # Override default vales for these params:
+            must_have_shape=2,
+            must_be_sorted=True,
+            # Allow these params to be set by user:
+            dtype_out=dtype_out,
+            must_have_dtype=must_have_dtype,
+            must_be_nonnegative=must_be_nonnegative,
+            must_be_finite=must_be_finite,
+            must_be_real=must_be_real,
+            must_be_integer=must_be_integer,
+            must_be_in_range=must_be_in_range,
+            strict_lower_bound=strict_lower_bound,
+            strict_upper_bound=strict_upper_bound,
+            as_any=as_any,
+            copy=copy,
+            get_flags=get_flags,
+            to_tuple=to_tuple,
+            to_list=to_list,
+            name=name,
+            # These params are irrelevant for this function:
+            must_have_length=None,
+            must_have_min_length=None,
+            must_have_max_length=None,
+            reshape_to=None,
+            broadcast_to=None,
+        ),
+    )
 
 
-def validate_arrayNx3(arr, /, *, reshape=True, **kwargs):
-    """Validate an array is numeric and has shape Nx3.
+class _KwargsValidateArrayNx3(TypedDict, total=False):
+    must_have_dtype: Optional[_NumberUnion]
+    must_have_length: Optional[Union[int, VectorLike[int]]]
+    must_have_min_length: Optional[int]
+    must_have_max_length: Optional[int]
+    must_be_nonnegative: bool
+    must_be_finite: bool
+    must_be_real: bool
+    must_be_integer: bool
+    must_be_sorted: Union[bool, dict[str, Union[bool, int]]]
+    must_be_in_range: Optional[VectorLike[float]]
+    strict_lower_bound: bool
+    strict_upper_bound: bool
+    as_any: bool
+    copy: bool
+    get_flags: bool
+    name: str
 
-    The array is checked to ensure its input values:
 
-    * have shape ``(N, 3)`` or can be reshaped to ``(N, 3)``
-    * are numeric
+@overload
+def validate_arrayNx3(  # numpydoc ignore=GL08
+    array: VectorLike[NumberType],
+    /,
+    *,
+    reshape: Literal[True] = ...,
+    dtype_out: None = None,
+    **kwargs: Unpack[_KwargsValidateArrayNx3],
+) -> NumpyArray[NumberType]: ...
 
-    The returned array is formatted so that its values:
 
-    * have shape ``(N, 3)``.
+@overload
+def validate_arrayNx3(  # numpydoc ignore=GL08
+    array: VectorLike[NumberType],
+    /,
+    *,
+    reshape: Literal[True] = ...,
+    dtype_out: type[_NumberType],
+    **kwargs: Unpack[_KwargsValidateArrayNx3],
+) -> NumpyArray[_NumberType]: ...
+
+
+@overload
+def validate_arrayNx3(  # numpydoc ignore=GL08
+    array: MatrixLike[NumberType],
+    /,
+    *,
+    reshape: bool = ...,
+    dtype_out: None = None,
+    **kwargs: Unpack[_KwargsValidateArrayNx3],
+) -> NumpyArray[NumberType]: ...
+
+
+@overload
+def validate_arrayNx3(  # numpydoc ignore=GL08
+    array: MatrixLike[NumberType],
+    /,
+    *,
+    reshape: bool = ...,
+    dtype_out: type[_NumberType],
+    **kwargs: Unpack[_KwargsValidateArrayNx3],
+) -> NumpyArray[_NumberType]: ...
+
+
+def validate_arrayNx3(  # numpydoc ignore=PR01,PR02  # noqa: D417
+    array: Union[MatrixLike[NumberType], VectorLike[NumberType]],
+    /,
+    *,
+    reshape: bool = True,
+    must_have_dtype: Optional[_NumberUnion] = None,
+    must_have_length: Optional[Union[int, VectorLike[int]]] = None,
+    must_have_min_length: Optional[int] = None,
+    must_have_max_length: Optional[int] = None,
+    must_be_nonnegative: bool = False,
+    must_be_finite: bool = False,
+    must_be_real: bool = True,
+    must_be_integer: bool = False,
+    must_be_sorted: Union[bool, dict[str, Union[bool, int]]] = False,
+    must_be_in_range: Optional[VectorLike[float]] = None,
+    strict_lower_bound: bool = False,
+    strict_upper_bound: bool = False,
+    dtype_out: Optional[type[_NumberType]] = None,
+    as_any: bool = True,
+    copy: bool = False,
+    get_flags: bool = False,
+    to_list: bool = False,
+    to_tuple: bool = False,
+    name: str = 'Array',
+):
+    """Validate a numeric array with N rows and 3 columns.
+
+    This function is similar to :func:`~validate_array`, but is configured
+    to only allow inputs with shape ``(N, 3)`` or which can be reshaped to
+    ``(N, 3)``. The return type is also fixed to always return a NumPy array.
 
     Parameters
     ----------
-    arr : array_like
-        Array to validate.
+    array : VectorLike[float] | MatrixLike[float]
+        1D or 2D array to validate.
 
     reshape : bool, default: True
         If ``True``, 1D arrays with 3 elements are considered valid
         input and are reshaped to ``(1, 3)`` to ensure the output is
         two-dimensional.
 
-    **kwargs : dict, optional
-        Additional keyword arguments passed to :func:`~validate_array`.
+    Other Parameters
+    ----------------
+    **kwargs
+        See :func:`~validate_array` for documentation on all other keyword
+        arguments.
 
     Returns
     -------
@@ -799,32 +1741,163 @@ def validate_arrayNx3(arr, /, *, reshape=True, **kwargs):
            [4, 5, 6]])
 
     """
+    must_have_shape: list[_ShapeLike] = [(-1, 3)]
+    reshape_to: Optional[_ShapeLike] = None
     if reshape:
-        shape = [3, (-1, 3)]
-        _set_default_kwarg_mandatory(kwargs, 'reshape_to', (-1, 3))
-    else:
-        shape = (-1, 3)
-    _set_default_kwarg_mandatory(kwargs, 'must_have_shape', shape)
+        must_have_shape.append((3,))
+        reshape_to = (-1, 3)
 
-    return validate_array(arr, **kwargs)
+    return validate_array(  # type: ignore[call-overload, misc]
+        array,
+        # Override default vales for these params:
+        reshape_to=reshape_to,
+        must_have_shape=must_have_shape,
+        # Allow these params to be set by user:
+        must_have_dtype=must_have_dtype,
+        must_have_length=must_have_length,
+        must_have_min_length=must_have_min_length,
+        must_have_max_length=must_have_max_length,
+        must_be_nonnegative=must_be_nonnegative,
+        must_be_finite=must_be_finite,
+        must_be_real=must_be_real,
+        must_be_integer=must_be_integer,
+        must_be_sorted=must_be_sorted,
+        must_be_in_range=must_be_in_range,
+        strict_lower_bound=strict_lower_bound,
+        strict_upper_bound=strict_upper_bound,
+        dtype_out=dtype_out,
+        as_any=as_any,
+        copy=copy,
+        get_flags=get_flags,
+        to_list=to_list,
+        to_tuple=to_tuple,
+        name=name,
+        # This parameter is not available
+        must_have_ndim=None,
+        broadcast_to=None,
+    )
 
 
-def validate_arrayN(arr, /, *, reshape=True, **kwargs):
-    """Validate a numeric 1D array.
+class _KwargsValidateArrayN(TypedDict, total=False):
+    must_have_dtype: Optional[_NumberUnion]
+    must_have_length: Optional[Union[int, VectorLike[int]]]
+    must_have_min_length: Optional[int]
+    must_have_max_length: Optional[int]
+    must_be_nonnegative: bool
+    must_be_finite: bool
+    must_be_real: bool
+    must_be_integer: bool
+    must_be_sorted: Union[bool, dict[str, Union[bool, int]]]
+    must_be_in_range: Optional[VectorLike[float]]
+    strict_lower_bound: bool
+    strict_upper_bound: bool
+    as_any: bool
+    copy: bool
+    get_flags: bool
+    name: str
 
-    The array is checked to ensure its input values:
 
-    * have shape ``(N,)`` or can be reshaped to ``(N,)``
-    * are numeric
+@overload
+def validate_arrayN(  # numpydoc ignore=GL08
+    array: NumberType,
+    /,
+    *,
+    reshape: Literal[True] = ...,
+    dtype_out: None = None,
+    **kwargs: Unpack[_KwargsValidateArrayN],
+) -> NumpyArray[NumberType]: ...
 
-    The returned array is formatted so that its values:
 
-    * have shape ``(N,)``
+@overload
+def validate_arrayN(  # numpydoc ignore=GL08
+    array: NumberType,
+    /,
+    *,
+    reshape: Literal[True] = ...,
+    dtype_out: type[_NumberType],
+    **kwargs: Unpack[_KwargsValidateArrayN],
+) -> NumpyArray[_NumberType]: ...
+
+
+@overload
+def validate_arrayN(  # numpydoc ignore=GL08
+    array: MatrixLike[NumberType],
+    /,
+    *,
+    reshape: Literal[True] = ...,
+    dtype_out: None = None,
+    **kwargs: Unpack[_KwargsValidateArrayN],
+) -> NumpyArray[NumberType]: ...
+
+
+@overload
+def validate_arrayN(  # numpydoc ignore=GL08
+    array: MatrixLike[NumberType],
+    /,
+    *,
+    reshape: Literal[True] = ...,
+    dtype_out: type[_NumberType],
+    **kwargs: Unpack[_KwargsValidateArrayN],
+) -> NumpyArray[_NumberType]: ...
+
+
+@overload
+def validate_arrayN(  # numpydoc ignore=GL08
+    array: VectorLike[NumberType],
+    /,
+    *,
+    reshape: bool = ...,
+    dtype_out: None = None,
+    **kwargs: Unpack[_KwargsValidateArrayN],
+) -> NumpyArray[NumberType]: ...
+
+
+@overload
+def validate_arrayN(  # numpydoc ignore=GL08
+    array: VectorLike[NumberType],
+    /,
+    *,
+    reshape: bool = ...,
+    dtype_out: type[_NumberType],
+    **kwargs: Unpack[_KwargsValidateArrayN],
+) -> NumpyArray[_NumberType]: ...
+
+
+def validate_arrayN(  # numpydoc ignore=PR01,PR02  # noqa: D417
+    array: Union[NumberType, VectorLike[NumberType], MatrixLike[NumberType]],
+    /,
+    *,
+    reshape: bool = True,
+    must_have_dtype: Optional[_NumberUnion] = None,
+    must_have_length: Optional[Union[int, VectorLike[int]]] = None,
+    must_have_min_length: Optional[int] = None,
+    must_have_max_length: Optional[int] = None,
+    must_be_nonnegative: bool = False,
+    must_be_finite: bool = False,
+    must_be_real: bool = True,
+    must_be_integer: bool = False,
+    must_be_sorted: Union[bool, dict[str, Union[bool, int]]] = False,
+    must_be_in_range: Optional[VectorLike[float]] = None,
+    strict_lower_bound: bool = False,
+    strict_upper_bound: bool = False,
+    dtype_out: Optional[type[_NumberType]] = None,
+    as_any: bool = True,
+    copy: bool = False,
+    get_flags: bool = False,
+    to_list: bool = False,
+    to_tuple: bool = False,
+    name: str = 'Array',
+):
+    """Validate a flat array with N elements.
+
+    This function is similar to :func:`~validate_array`, but is configured
+    to only allow inputs with shape ``(N,)`` or which can be reshaped to
+    ``(N,)``. The return type is also fixed to always return a NumPy array.
 
     Parameters
     ----------
-    arr : array_like[float, ...]
-        Array to validate.
+    array : float | VectorLike[float] | MatrixLike[float]
+        Array-like input to validate.
 
     reshape : bool, default: True
         If ``True``, 0-dimensional scalars are reshaped to ``(1,)`` and 2D
@@ -832,8 +1905,11 @@ def validate_arrayN(arr, /, *, reshape=True, **kwargs):
         output is consistently one-dimensional. Otherwise, all scalar and
         2D inputs are not considered valid.
 
-    **kwargs : dict, optional
-        Additional keyword arguments passed to :func:`~validate_array`.
+    Other Parameters
+    ----------------
+    **kwargs
+        See :func:`~validate_array` for documentation on all other keyword
+        arguments.
 
     Returns
     -------
@@ -873,33 +1949,164 @@ def validate_arrayN(arr, /, *, reshape=True, **kwargs):
     array([1, 2, 3])
 
     """
+    must_have_shape: Union[_ShapeLike, list[_ShapeLike]]
+    reshape_to: Optional[tuple[int]] = None
     if reshape:
-        shape = [(), (-1), (1, -1)]
-        _set_default_kwarg_mandatory(kwargs, 'reshape_to', (-1))
+        must_have_shape = [(), (-1), (1, -1), (-1, 1)]
+        reshape_to = (-1,)
     else:
-        shape = -1
-    _set_default_kwarg_mandatory(kwargs, 'must_have_shape', shape)
-    return validate_array(arr, **kwargs)
+        must_have_shape = (-1,)
+    return validate_array(  # type: ignore[call-overload, misc]
+        array,
+        # Override default vales for these params:
+        reshape_to=reshape_to,
+        must_have_shape=must_have_shape,
+        # Allow these params to be set by user:
+        must_have_dtype=must_have_dtype,
+        must_have_length=must_have_length,
+        must_have_min_length=must_have_min_length,
+        must_have_max_length=must_have_max_length,
+        must_be_nonnegative=must_be_nonnegative,
+        must_be_finite=must_be_finite,
+        must_be_real=must_be_real,
+        must_be_integer=must_be_integer,
+        must_be_sorted=must_be_sorted,
+        must_be_in_range=must_be_in_range,
+        strict_lower_bound=strict_lower_bound,
+        strict_upper_bound=strict_upper_bound,
+        dtype_out=dtype_out,
+        as_any=as_any,
+        copy=copy,
+        get_flags=get_flags,
+        to_list=to_list,
+        to_tuple=to_tuple,
+        name=name,
+        # This parameter is not available
+        must_have_ndim=None,
+        broadcast_to=None,
+    )
 
 
-def validate_arrayN_unsigned(arr, /, *, reshape=True, **kwargs):
-    """Validate a numeric 1D array of non-negative (unsigned) integers.
+class _KwargsValidateArrayNUnsigned(TypedDict, total=False):
+    must_have_dtype: Optional[_NumberUnion]
+    must_have_length: Optional[Union[int, VectorLike[int]]]
+    must_have_min_length: Optional[int]
+    must_have_max_length: Optional[int]
+    must_be_real: bool
+    must_be_sorted: Union[bool, dict[str, Union[bool, int]]]
+    must_be_in_range: Optional[VectorLike[float]]
+    strict_lower_bound: bool
+    strict_upper_bound: bool
+    as_any: bool
+    copy: bool
+    get_flags: bool
+    name: str
 
-    The array is checked to ensure its input values:
 
-    * have shape ``(N,)`` or can be reshaped to ``(N,)``
-    * are integer-like
-    * are non-negative
+_IntegerType = TypeVar('_IntegerType', bound=Union[np.integer, int, np.bool_])  # type: ignore[type-arg]
 
-    The returned array is formatted so that its values:
 
-    * have shape ``(N,)``
-    * have an integer data type
+@overload
+def validate_arrayN_unsigned(  # numpydoc ignore=GL08
+    array: NumberType,
+    /,
+    *,
+    reshape: Literal[True] = ...,
+    dtype_out: int = ...,
+    **kwargs: Unpack[_KwargsValidateArrayNUnsigned],
+) -> NumpyArray[int]: ...
+
+
+@overload
+def validate_arrayN_unsigned(  # numpydoc ignore=GL08
+    array: NumberType,
+    /,
+    *,
+    reshape: Literal[True] = ...,
+    dtype_out: type[_IntegerType],
+    **kwargs: Unpack[_KwargsValidateArrayNUnsigned],
+) -> NumpyArray[_IntegerType]: ...
+
+
+@overload
+def validate_arrayN_unsigned(  # numpydoc ignore=GL08
+    array: MatrixLike[NumberType],
+    /,
+    *,
+    reshape: Literal[True] = ...,
+    dtype_out: int = ...,
+    **kwargs: Unpack[_KwargsValidateArrayNUnsigned],
+) -> NumpyArray[int]: ...
+
+
+@overload
+def validate_arrayN_unsigned(  # numpydoc ignore=GL08
+    array: MatrixLike[NumberType],
+    /,
+    *,
+    reshape: Literal[True] = ...,
+    dtype_out: type[_IntegerType],
+    **kwargs: Unpack[_KwargsValidateArrayNUnsigned],
+) -> NumpyArray[_IntegerType]: ...
+
+
+@overload
+def validate_arrayN_unsigned(  # numpydoc ignore=GL08
+    array: VectorLike[NumberType],
+    /,
+    *,
+    reshape: bool = ...,
+    dtype_out: int = ...,
+    **kwargs: Unpack[_KwargsValidateArrayNUnsigned],
+) -> NumpyArray[int]: ...
+
+
+@overload
+def validate_arrayN_unsigned(  # numpydoc ignore=GL08
+    array: VectorLike[NumberType],
+    /,
+    *,
+    reshape: bool = ...,
+    dtype_out: type[_IntegerType],
+    **kwargs: Unpack[_KwargsValidateArrayNUnsigned],
+) -> NumpyArray[_IntegerType]: ...
+
+
+def validate_arrayN_unsigned(  # type: ignore[misc]  # numpydoc ignore=PR01,PR02  # noqa: D417
+    array: Union[NumberType, VectorLike[NumberType], MatrixLike[NumberType]],
+    /,
+    *,
+    reshape: bool = True,
+    must_have_dtype: Optional[_NumberUnion] = None,
+    must_have_length: Optional[Union[int, VectorLike[int]]] = None,
+    must_have_min_length: Optional[int] = None,
+    must_have_max_length: Optional[int] = None,
+    must_be_real: bool = True,
+    must_be_sorted: Union[bool, dict[str, Union[bool, int]]] = False,
+    must_be_in_range: Optional[VectorLike[float]] = None,
+    strict_lower_bound: bool = False,
+    strict_upper_bound: bool = False,
+    dtype_out: type[Union[_IntegerType]] = int,  # type: ignore[assignment]
+    as_any: bool = True,
+    copy: bool = False,
+    get_flags: bool = False,
+    name: str = 'Array',
+):
+    """Validate a flat array with N non-negative (unsigned) integers.
+
+    This function is similar to :func:`~validate_array`, but is configured
+    to only allow inputs with shape ``(N,)`` or which can be reshaped to
+    ``(N,)``. The return type is fixed to always return a NumPy array with
+     an integer data type, though an integer subtype may be specified
+     (e.g. ``np.unit8``).
+
+    By default, the input is also checked to ensure the values are finite,
+    non-negative, and have integer values.
 
     Parameters
     ----------
-    arr : array_like[float, ...] | array_like[int, ...]
-        Array to validate.
+    array : float | VectorLike[float] | MatrixLike[float]
+        0D, 1D, or 2D array to validate.
 
     reshape : bool, default: True
         If ``True``, 0-dimensional scalars are reshaped to ``(1,)`` and 2D
@@ -907,8 +2114,11 @@ def validate_arrayN_unsigned(arr, /, *, reshape=True, **kwargs):
         output is consistently one-dimensional. Otherwise, all scalar and
         2D inputs are not considered valid.
 
-    **kwargs : dict, optional
-        Additional keyword arguments passed to :func:`~validate_array`.
+    Other Parameters
+    ----------------
+    **kwargs
+        See :func:`~validate_array` for documentation on all other keyword
+        arguments.
 
     Returns
     -------
@@ -918,7 +2128,7 @@ def validate_arrayN_unsigned(arr, /, *, reshape=True, **kwargs):
     See Also
     --------
     validate_arrayN
-        Similar function for numeric one-dimensional arrays.
+        More general function for any numeric one-dimensional array.
 
     validate_array
         Generic array validation function.
@@ -929,13 +2139,13 @@ def validate_arrayN_unsigned(arr, /, *, reshape=True, **kwargs):
 
     >>> import numpy as np
     >>> from pyvista import _validation
-    >>> arr = _validation.validate_arrayN_unsigned((1.0, 2.0, 3.0, 4.0))
-    >>> arr
+    >>> array = _validation.validate_arrayN_unsigned((1.0, 2.0, 3.0, 4.0))
+    >>> array
     array([1, 2, 3, 4])
 
     Verify that the output data type is integral.
 
-    >>> np.issubdtype(arr.dtype, int)
+    >>> np.issubdtype(array.dtype, np.integer)
     True
 
     Scalar 0-dimensional values are automatically reshaped to be 1D.
@@ -957,45 +2167,169 @@ def validate_arrayN_unsigned(arr, /, *, reshape=True, **kwargs):
     array([1, 2, 3])
 
     """
-    # Set default dtype out but allow overriding as long as the dtype
-    # is also integral
-    kwargs.setdefault('dtype_out', int)
-    if kwargs['dtype_out'] is not int:
-        check_subdtype(kwargs['dtype_out'], np.integer)
+    check_subdtype(dtype_out, (np.integer, np.bool_), name='dtype_out')
+    return validate_arrayN(  # type: ignore[misc]
+        array,  # type: ignore[arg-type]
+        reshape=reshape,
+        # Override default vales for these params:
+        must_be_integer=True,
+        must_be_nonnegative=True,
+        must_be_finite=True,
+        # Allow these params to be set by user:
+        must_have_dtype=must_have_dtype,
+        must_have_length=must_have_length,
+        must_have_min_length=must_have_min_length,
+        must_have_max_length=must_have_max_length,
+        must_be_real=must_be_real,
+        must_be_sorted=must_be_sorted,
+        must_be_in_range=must_be_in_range,
+        strict_lower_bound=strict_lower_bound,
+        strict_upper_bound=strict_upper_bound,
+        dtype_out=dtype_out,
+        as_any=as_any,
+        copy=copy,
+        get_flags=get_flags,
+        name=name,
+    )
 
-    _set_default_kwarg_mandatory(kwargs, 'must_be_integer', True)
-    _set_default_kwarg_mandatory(kwargs, 'must_be_nonnegative', True)
 
-    return validate_arrayN(arr, reshape=reshape, **kwargs)
+class _KwargsValidateArray3(TypedDict, total=False):
+    must_have_dtype: Optional[_NumberUnion]
+    must_be_nonnegative: bool
+    must_be_finite: bool
+    must_be_real: bool
+    must_be_integer: bool
+    must_be_sorted: Union[bool, dict[str, Union[bool, int]]]
+    must_be_in_range: Optional[VectorLike[float]]
+    strict_lower_bound: bool
+    strict_upper_bound: bool
+    as_any: bool
+    copy: bool
+    get_flags: bool
+    name: str
 
 
-def validate_array3(arr, /, *, reshape=True, broadcast=False, **kwargs):
-    """Validate a numeric 1D array with 3 elements.
+@overload
+def validate_array3(  # numpydoc ignore=GL08
+    array: NumberType,
+    /,
+    *,
+    reshape: bool = ...,
+    broadcast: Literal[True],
+    dtype_out: None = None,
+    **kwargs: Unpack[_KwargsValidateArray3],
+) -> NumpyArray[NumberType]: ...
 
-    The array is checked to ensure its input values:
 
-    * have shape ``(3,)`` or can be reshaped to ``(3,)``
-    * are numeric and real
+@overload
+def validate_array3(  # numpydoc ignore=GL08
+    array: NumberType,
+    /,
+    *,
+    reshape: bool = ...,
+    broadcast: Literal[True],
+    dtype_out: type[_NumberType],
+    **kwargs: Unpack[_KwargsValidateArray3],
+) -> NumpyArray[_NumberType]: ...
 
-    The returned array is formatted so that it has shape ``(3,)``.
+
+@overload
+def validate_array3(  # numpydoc ignore=GL08
+    array: MatrixLike[NumberType],
+    /,
+    *,
+    reshape: Literal[True] = ...,
+    broadcast: bool = ...,
+    dtype_out: None = None,
+    **kwargs: Unpack[_KwargsValidateArray3],
+) -> NumpyArray[NumberType]: ...
+
+
+@overload
+def validate_array3(  # numpydoc ignore=GL08
+    array: MatrixLike[NumberType],
+    /,
+    *,
+    reshape: Literal[True] = ...,
+    broadcast: bool = ...,
+    dtype_out: type[_NumberType],
+    **kwargs: Unpack[_KwargsValidateArray3],
+) -> NumpyArray[_NumberType]: ...
+
+
+@overload
+def validate_array3(  # numpydoc ignore=GL08
+    array: VectorLike[NumberType],
+    /,
+    *,
+    reshape: bool = ...,
+    broadcast: bool = ...,
+    dtype_out: None = None,
+    **kwargs: Unpack[_KwargsValidateArray3],
+) -> NumpyArray[NumberType]: ...
+
+
+@overload
+def validate_array3(  # numpydoc ignore=GL08
+    array: VectorLike[NumberType],
+    /,
+    *,
+    reshape: bool = ...,
+    broadcast: bool = ...,
+    dtype_out: type[_NumberType],
+    **kwargs: Unpack[_KwargsValidateArray3],
+) -> NumpyArray[_NumberType]: ...
+
+
+def validate_array3(  # numpydoc ignore=PR01,PR02  # noqa: D417
+    array: Union[NumberType, VectorLike[NumberType], MatrixLike[NumberType]],
+    /,
+    *,
+    reshape: bool = True,
+    broadcast: bool = False,
+    must_be_finite: bool = False,
+    must_be_real: bool = True,
+    must_have_dtype: Optional[_NumberUnion] = None,
+    must_be_integer: bool = False,
+    must_be_nonnegative: bool = False,
+    must_be_sorted: Union[bool, dict[str, Union[bool, int]]] = False,
+    must_be_in_range: Optional[VectorLike[float]] = None,
+    strict_lower_bound: bool = False,
+    strict_upper_bound: bool = False,
+    dtype_out: Optional[type[_NumberType]] = None,
+    as_any: bool = True,
+    copy: bool = False,
+    get_flags: bool = False,
+    to_list: bool = False,
+    to_tuple: bool = False,
+    name: str = 'Array',
+):
+    """Validate an array with three numbers.
+
+    This function is similar to :func:`~validate_array`, but is configured
+    to only allow inputs with shape ``(3,)`` or which can be reshaped to
+    ``(3,)``. The return type is also fixed to always return a NumPy array.
 
     Parameters
     ----------
-    arr : array_like[float, float, float]
+    array : float | VectorLike[float] | MatrixLike[float]
         Array to validate.
 
     reshape : bool, default: True
-        If ``True``, 2D vectors with shape ``(1, 3)`` are considered valid
-        input, and are reshaped to ``(3,)`` to ensure the output is
-        consistently one-dimensional.
+        If ``True``, 2D vectors with shape ``(1, 3)`` or ``(3, 1)`` are
+        considered valid input, and are reshaped to ``(3,)`` to ensure
+        the output is consistently one-dimensional.
 
     broadcast : bool, default: False
         If ``True``, scalar values or 1D arrays with a single element
         are considered valid input and the single value is broadcast to
         a length 3 array.
 
-    **kwargs : dict, optional
-        Additional keyword arguments passed to :func:`~validate_array`.
+    Other Parameters
+    ----------------
+    **kwargs
+        See :func:`~validate_array` for documentation on all other keyword
+        arguments.
 
     Returns
     -------
@@ -1038,18 +2372,47 @@ def validate_array3(arr, /, *, reshape=True, broadcast=False, **kwargs):
     array([1, 2, 3])
 
     """
-    shape = [(3,)]
+    must_have_shape: list[_ShapeLike] = [(3,)]
+    reshape_to: Optional[tuple[int]] = None
     if reshape:
-        shape.append((1, 3))
-        shape.append((3, 1))
-        _set_default_kwarg_mandatory(kwargs, 'reshape_to', (-1))
+        must_have_shape.append((1, 3))
+        must_have_shape.append((3, 1))
+        reshape_to = (-1,)
+    broadcast_to: Optional[tuple[int, ...]] = None
     if broadcast:
-        shape.append(())  # allow 0D scalars
-        shape.append((1,))  # 1D 1-element vectors
-        _set_default_kwarg_mandatory(kwargs, 'broadcast_to', (3,))
-    _set_default_kwarg_mandatory(kwargs, 'must_have_shape', shape)
+        must_have_shape.append(())  # allow 0D scalars
+        must_have_shape.append((1,))  # 1D 1-element vectors
+        broadcast_to = (3,)
 
-    return validate_array(arr, **kwargs)
+    return validate_array(  # type: ignore[call-overload, misc]
+        array,
+        # Override default vales for these params:
+        reshape_to=reshape_to,
+        broadcast_to=broadcast_to,
+        must_have_shape=must_have_shape,
+        # Allow these params to be set by user:
+        dtype_out=dtype_out,
+        must_have_dtype=must_have_dtype,
+        must_be_nonnegative=must_be_nonnegative,
+        must_be_finite=must_be_finite,
+        must_be_real=must_be_real,
+        must_be_integer=must_be_integer,
+        must_be_sorted=must_be_sorted,
+        must_be_in_range=must_be_in_range,
+        strict_lower_bound=strict_lower_bound,
+        strict_upper_bound=strict_upper_bound,
+        as_any=as_any,
+        copy=copy,
+        get_flags=get_flags,
+        to_list=to_list,
+        to_tuple=to_tuple,
+        name=name,
+        # These params are irrelevant for this function:
+        must_have_ndim=None,
+        must_have_length=None,
+        must_have_min_length=None,
+        must_have_max_length=None,
+    )
 
 
 def _set_default_kwarg_mandatory(kwargs: dict[str, Any], key: str, default: Any):

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+from collections import namedtuple
+from enum import Enum
+from enum import auto
+import inspect
 import itertools
+from numbers import Real
 from re import escape
 import sys
-from typing import NamedTuple
+from typing import Any
+from typing import Callable
 from typing import Union
 from typing import get_args
 from typing import get_origin
@@ -23,6 +29,7 @@ from pyvista.core._validation import check_iterable
 from pyvista.core._validation import check_iterable_items
 from pyvista.core._validation import check_length
 from pyvista.core._validation import check_less_than
+from pyvista.core._validation import check_ndim
 from pyvista.core._validation import check_nonnegative
 from pyvista.core._validation import check_number
 from pyvista.core._validation import check_range
@@ -111,11 +118,11 @@ def test_check_subdtype():
     check_subdtype(int, np.integer)
     check_subdtype(np.dtype(int), np.integer)
     check_subdtype(np.array([1, 2, 3]), np.integer)
-    check_subdtype(np.array([1.0, 2, 3]), float)
+    check_subdtype([1.0, 2, 3], float)
     check_subdtype(np.array([1.0, 2, 3], dtype='uint8'), 'uint8')
     check_subdtype(np.array([1.0, 2, 3]), ('uint8', float))
     match = "Input has incorrect dtype of 'int32'. The dtype must be a subtype of <class 'float'>."
-    with pytest.raises(TypeError, match=match):
+    with pytest.raises(TypeError, match=escape(match)):
         check_subdtype(np.array([1, 2, 3]).astype('int32'), float)
     match = "Input has incorrect dtype of 'complex128'. The dtype must be a subtype of at least one of \n(<class 'numpy.integer'>, <class 'numpy.floating'>)."
     with pytest.raises(TypeError, match=escape(match)):
@@ -137,44 +144,50 @@ def test_check_subdtype_changes_type():
 
 
 def test_validate_number():
-    validate_number([2.0])
-    num = validate_number(1)
-    assert num == 1
+    num, flags = validate_number(
+        [2.0],
+        reshape=True,
+        must_be_finite=True,
+        must_be_real=True,
+        must_have_dtype=None,
+        must_be_nonnegative=True,
+        must_be_integer=True,
+        must_be_in_range=[0, 3],
+        strict_lower_bound=True,
+        strict_upper_bound=True,
+        dtype_out=int,
+        get_flags=True,
+        name='_number',
+    )
+    assert num == 2
     assert isinstance(num, int)
 
-    num = validate_number(2.0, to_list=False, must_have_shape=(), reshape=False)
-    assert num == 2.0
-    assert type(num) is np.ndarray
-    assert num.dtype.type is np.float64
+    num = validate_number(np.array([3.0]))
+    assert num == 3.0
+    assert isinstance(num, float)
 
-    match = (
-        "Parameter 'must_have_shape' cannot be set for function `validate_number`.\n"
-        'Its value is automatically set to `()`.'
-    )
+    match = 'Number has shape (1,) which is not allowed. Shape must be ().'
     with pytest.raises(ValueError, match=escape(match)):
-        validate_number(1, must_have_shape=2, reshape=False)
+        validate_number([1], reshape=False)
 
 
 def test_validate_data_range():
     rng = validate_data_range([0, 1])
-    assert rng == (0, 1)
+    assert isinstance(rng, np.ndarray)
+    assert np.array_equal(rng, (0, 1))
+    assert rng.dtype == int
 
-    rng = validate_data_range((0, 2.5), to_list=True)
-    assert rng == [0.0, 2.5]
+    rng = validate_data_range((0, 2.5))
+    assert np.array_equal(rng, (0, 2.5))
+    assert rng.dtype == float
 
-    rng = validate_data_range((-10, -10), to_tuple=False, must_have_shape=2)
-    assert type(rng) is np.ndarray
+    rng = validate_data_range((0, 1), dtype_out=float)
+    assert np.array_equal(rng, (0, 1))
+    assert rng.dtype == float
 
     match = 'Data Range with 2 elements must be sorted in ascending order. Got:\n    array([1, 0])'
     with pytest.raises(ValueError, match=escape(match)):
         validate_data_range((1, 0))
-
-    match = (
-        "Parameter 'must_have_shape' cannot be set for function `validate_data_range`.\n"
-        'Its value is automatically set to `2`.'
-    )
-    with pytest.raises(ValueError, match=match):
-        validate_data_range((0, 1), must_have_shape=3)
 
 
 def test_set_default_kwarg_mandatory():
@@ -219,6 +232,21 @@ def test_check_shape():
         check_shape((1, 2, 3), [(), (4, 5)])
 
 
+def test_check_ndim():
+    check_ndim(0, 0)
+    check_ndim(np.array(0), 0)
+    check_ndim((1, 2, 3), range(2))
+    check_ndim([[1, 2, 3]], (0, 2))
+
+    match = 'Input has the incorrect number of dimensions. Got 1, expected 0.'
+    with pytest.raises(ValueError, match=escape(match)):
+        check_ndim((1, 2, 3), 0, name='Input')
+
+    match = 'Array has the incorrect number of dimensions. Got 1, expected one of [4, 5].'
+    with pytest.raises(ValueError, match=escape(match)):
+        check_ndim((1, 2, 3), [4, 5])
+
+
 def test_validate_shape_value():
     match = '`None` is not a valid shape. Use `()` instead.'
     with pytest.raises(TypeError, match=escape(match)):
@@ -257,7 +285,7 @@ def test_validate_shape_value():
 @pytest.mark.parametrize('reshape', [True, False])
 def test_validate_arrayNx3(reshape):
     arr = validate_arrayNx3((1, 2, 3))
-    assert arr.shape == (1, 3)
+    assert np.shape(arr) == (1, 3)
     assert np.array_equal(arr, [[1, 2, 3]])
 
     if not reshape:
@@ -266,15 +294,9 @@ def test_validate_arrayNx3(reshape):
             validate_arrayNx3((1, 2, 3), reshape=False)
 
     arr = validate_arrayNx3([(1, 2, 3), (4, 5, 6)], reshape=reshape)
-    assert arr.shape == (2, 3)
+    assert np.shape(arr) == (2, 3)
 
-    match = (
-        "Parameter 'must_have_shape' cannot be set for function `validate_arrayNx3`.\n"
-        'Its value is automatically set to `[3, (-1, 3)]`.'
-    )
-    with pytest.raises(ValueError, match=escape(match)):
-        validate_arrayNx3((1, 2, 3), must_have_shape=1)
-    match = 'Array has shape () which is not allowed. Shape must be one of [3, (-1, 3)].'
+    match = 'Array has shape () which is not allowed. Shape must be one of [(-1, 3), (3,)].'
     with pytest.raises(ValueError, match=escape(match)):
         validate_arrayNx3(0)
     with pytest.raises(ValueError, match='_input'):
@@ -285,34 +307,31 @@ def test_validate_arrayNx3(reshape):
 def test_validate_arrayN(reshape):
     # test 0D input is reshaped to 1D by default
     arr = validate_arrayN(0)
-    assert arr.shape == (1,)
+    assert np.shape(arr) == (1,)
     assert np.array_equal(arr, [0])
 
     # test 2D input is reshaped to 1D by default
     arr = validate_arrayN([[1, 2, 3]])
-    assert arr.shape == (3,)
+    assert np.shape(arr) == (3,)
+    assert np.array_equal(arr, [1, 2, 3])
+
+    arr = validate_arrayN([[1], [2], [3]])
+    assert np.shape(arr) == (3,)
     assert np.array_equal(arr, [1, 2, 3])
 
     if not reshape:
-        match = 'Array has shape () which is not allowed. Shape must be -1.'
+        match = 'Array has shape () which is not allowed. Shape must be (-1,).'
         with pytest.raises(ValueError, match=escape(match)):
             validate_arrayN(0, reshape=False)
 
-        match = 'Array has shape (1, 3) which is not allowed. Shape must be -1.'
+        match = 'Array has shape (1, 3) which is not allowed. Shape must be (-1,).'
         with pytest.raises(ValueError, match=escape(match)):
             validate_arrayN([[1, 2, 3]], reshape=False)
 
     arr = validate_arrayN((1, 2, 3, 4, 5, 6), reshape=reshape)
-    assert arr.shape == (6,)
+    assert np.shape(arr) == (6,)
 
-    match = (
-        "Parameter 'must_have_shape' cannot be set for function `validate_arrayN`.\n"
-        'Its value is automatically set to `[(), -1, (1, -1)]`.'
-    )
-    with pytest.raises(ValueError, match=escape(match)):
-        validate_arrayN((1, 2, 3), must_have_shape=1)
-
-    match = 'Array has shape (2, 2) which is not allowed. Shape must be one of [(), -1, (1, -1)].'
+    match = 'Array has shape (2, 2) which is not allowed. Shape must be one of [(), -1, (1, -1), (-1, 1)].'
     with pytest.raises(ValueError, match=escape(match)):
         validate_arrayN(((1, 2), (3, 4)))
     with pytest.raises(ValueError, match='_input'):
@@ -323,14 +342,15 @@ def test_validate_arrayN(reshape):
 def test_validate_arrayN_unsigned(reshape):
     # test 0D input is reshaped to 1D by default
     arr = validate_arrayN_unsigned(0.0)
-    assert arr.shape == (1,)
+    assert np.shape(arr) == (1,)
     assert np.array_equal(arr, [0])
-    assert arr.dtype.type is np.int32 or arr.dtype.type is np.int64
+    assert isinstance(arr, np.ndarray)
 
-    arr = validate_arrayN_unsigned(0.0, dtype_out='uint8')
+    arr = validate_arrayN_unsigned(0.0, dtype_out=np.uint8)
     assert arr.dtype.type is np.uint8
 
-    with pytest.raises(ValueError, match='Shape must be -1.'):
+    match = 'Array has shape () which is not allowed. Shape must be (-1,).'
+    with pytest.raises(ValueError, match=escape(match)):
         validate_arrayN_unsigned(0.0, reshape=False)
 
     match = '_input values must all be greater than or equal to 0.'
@@ -340,18 +360,40 @@ def test_validate_arrayN_unsigned(reshape):
 
 @pytest.mark.parametrize('reshape', [True, False])
 def test_validate_array3(reshape):
+    arr, flags = validate_array3(
+        (1, 2, 3),
+        reshape=reshape,
+        broadcast=True,
+        must_have_dtype=int,
+        must_be_finite=True,
+        must_be_real=True,
+        must_be_integer=True,
+        must_be_nonnegative=True,
+        must_be_sorted=True,
+        must_be_in_range=[0, 4],
+        strict_lower_bound=True,
+        strict_upper_bound=True,
+        dtype_out=int,
+        as_any=True,
+        copy=True,
+        get_flags=True,
+        name='_array',
+    )
+    assert np.array_equal(arr, (1, 2, 3))
+    assert isinstance(arr, np.ndarray)
+
     # test 0D input is reshaped to len-3 1D vector with broadcasting enabled
     arr = validate_array3(0, broadcast=True)
-    assert arr.shape == (3,)
+    assert np.shape(arr) == (3,)
     assert np.array_equal(arr, [0, 0, 0])
 
     # test 2D input is reshaped to 1D by default
     arr = validate_array3([[1, 2, 3]])
-    assert arr.shape == (3,)
+    assert np.shape(arr) == (3,)
     assert np.array_equal(arr, [1, 2, 3])
 
     arr = validate_array3([[1], [2], [3]])
-    assert arr.shape == (3,)
+    assert np.shape(arr) == (3,)
     assert np.array_equal(arr, [1, 2, 3])
 
     if not reshape:
@@ -369,14 +411,6 @@ def test_validate_array3(reshape):
         match = 'Shape must be one of [(3,), (1, 3), (3, 1), (), (1,)]'
         with pytest.raises(ValueError, match=escape(match)):
             validate_array3((1, 2, 3, 4, 5, 6), reshape=reshape, broadcast=True)
-
-    # test shape cannot be overridden
-    match = (
-        "Parameter 'must_have_shape' cannot be set for function `validate_array3`.\n"
-        'Its value is automatically set to `[(3,), (1, 3), (3, 1)]`.'
-    )
-    with pytest.raises(ValueError, match=escape(match)):
-        validate_array3((1, 2, 3), must_have_shape=3)
 
 
 def test_check_range():
@@ -400,145 +434,168 @@ def test_check_range():
         check_range((1, 2, 3), [1, 3], strict_lower=True)
 
 
-class Case(NamedTuple):
-    kwarg: dict
-    valid_array: np.ndarray
-    invalid_array: np.ndarray
-    error_type: type
-    error_match: str
-
-
-def numeric_array_test_cases():
-    return (
-        Case(
-            dict(
-                must_be_finite=True,
-                must_be_real=False,
-            ),  # must be real is only added for extra coverage
-            0,
-            np.inf,
-            ValueError,
-            'must have finite values',
-        ),
-        Case(dict(must_be_real=True), 0, 1 + 1j, TypeError, 'must have real numbers'),
-        Case(dict(must_be_integer=True), 0.0, 0.1, ValueError, 'must have integer-like values'),
-        Case(dict(must_be_sorted=True), [0, 1], [1, 0], ValueError, 'must be sorted'),
-        Case(
-            dict(must_be_sorted=dict(ascending=True, strict=False, axis=-1)),
-            [0, 1],
-            [1, 0],
-            ValueError,
-            'must be sorted',
-        ),
+def _generate_ids(name, values):
+    """Generate named test ids using param name and values."""
+    name_iter = [name] * len(values)
+    format_id = lambda name, val: f'{name}={val.__name__ if type(val) is type else val}'.replace(
+        ' ',
+        '',
     )
+    return [format_id(name, val) for name, val in zip(name_iter, values)]
 
 
-@pytest.mark.parametrize('name', ['_array', '_input'])
-@pytest.mark.parametrize('copy', [True, False])
-@pytest.mark.parametrize('as_any', [True, False])
-@pytest.mark.parametrize('to_list', [True, False])
-@pytest.mark.parametrize('to_tuple', [True, False])
-@pytest.mark.parametrize('dtype_out', [np.float32, np.float64])
-@pytest.mark.parametrize('case', numeric_array_test_cases())
-@pytest.mark.parametrize('stack_input', [True, False])
-@pytest.mark.parametrize('input_type', [tuple, list, np.ndarray, pyvista_ndarray])
+def parametrize_with_ids(name, values):
+    """Give meaningful names to parametrized tests."""
+    return pytest.mark.parametrize(name, values, ids=_generate_ids(name, values))
+
+
+@parametrize_with_ids('copy', [True, False])
+@parametrize_with_ids('as_any', [True, False])
+@parametrize_with_ids('to_list', [True, False])
+@parametrize_with_ids('to_tuple', [True, False])
+@parametrize_with_ids('dtype_in', [float, int])
+@parametrize_with_ids('dtype_out', [float, int, np.float32, np.float64])
+@parametrize_with_ids('array', [0, [0, 1], [[0, 1], [0, 1]]])
+@parametrize_with_ids('input_type', [tuple, list, np.ndarray, pyvista_ndarray])
 def test_validate_array(
-    name,
     copy,
     as_any,
     to_list,
     to_tuple,
+    dtype_in,
     dtype_out,
-    case,
-    stack_input,
+    array,
     input_type,
 ):
     # Set up
-    valid_array = np.array(case.valid_array)
-    invalid_array = np.array(case.invalid_array)
+    def _setup_array_type_and_dtype(array_, input_type_, dtype_in_):
+        array_setup = np.array(array_)
+        array_setup = array_setup.astype(dtype_in_)
 
-    # Inputs may be scalar, use stacking to ensure we have test cases
-    # with multidimensional arrays
-    if stack_input:
-        valid_array = np.stack((valid_array, valid_array), axis=0)
-        valid_array = np.stack((valid_array, valid_array), axis=1)
-        invalid_array = np.stack((invalid_array, invalid_array), axis=0)
-        invalid_array = np.stack((invalid_array, invalid_array), axis=1)
+        if input_type_ is tuple:
+            return _cast_to_tuple(array_setup)
+        elif input_type_ is list:
+            return array_setup.tolist()
+        elif input_type_ is np.ndarray:
+            return np.asarray(array_setup)
+        else:  # pyvista_ndarray:
+            return pyvista_ndarray(array_setup)
 
-    if input_type is tuple:
-        valid_array = _cast_to_tuple(valid_array)
-        invalid_array = _cast_to_tuple(invalid_array)
-    elif input_type is list:
-        valid_array = valid_array.tolist()
-        invalid_array = invalid_array.tolist()
-    elif input_type is np.ndarray:
-        valid_array = np.asarray(valid_array)
-        invalid_array = np.asarray(invalid_array)
-    else:  # pyvista_ndarray:
-        valid_array = pyvista_ndarray(valid_array)
-        invalid_array = pyvista_ndarray(invalid_array)
+    array_in = _setup_array_type_and_dtype(array, input_type, dtype_in)
 
-    shape = np.array(valid_array).shape
-    common_kwargs = dict(
-        **case.kwarg,
-        name=name,
+    has_numpy_dtype = issubclass(dtype_out, np.generic)
+    if has_numpy_dtype and (to_list or to_tuple):
+        pytest.skip('NumPy dtype specified with non-numpy return type')
+
+    # These are actual parametrized test keywords
+    test_kwargs = dict(
         copy=copy,
         as_any=as_any,
+        dtype_out=dtype_out,
         to_list=to_list,
         to_tuple=to_tuple,
-        must_have_dtype=np.number,
-        dtype_out=dtype_out,
-        must_have_length=range(np.array(valid_array).size + 1),
-        must_have_min_length=1,
-        must_have_max_length=np.array(valid_array).size,
-        must_have_shape=shape,
-        reshape_to=shape,
-        broadcast_to=shape,
-        must_be_in_range=(np.min(valid_array), np.max(valid_array)),
-        must_be_nonnegative=np.all(np.array(valid_array) > 0),
     )
 
-    # Test raises correct error with invalid input
-    with pytest.raises(case.error_type, match=case.error_match):
-        validate_array(invalid_array, **common_kwargs)
-    # Test error has correct name
-    with pytest.raises(case.error_type, match=name):
-        validate_array(invalid_array, **common_kwargs)
+    # Also include other keywords dynamically based on input array
+    shape = np.array(array_in).shape
+    dynamic_kwargs = dict(
+        must_have_shape=shape,
+        must_have_ndim=np.ndim(array_in),
+        must_have_dtype=np.number,
+        must_have_length=range(np.array(array_in).size + 1),
+        must_have_min_length=1,
+        must_have_max_length=np.array(array_in).size,
+        must_be_sorted=dict(ascending=True),
+        must_be_real=True,
+        must_be_finite=True,
+        reshape_to=shape,
+        broadcast_to=shape,
+        must_be_in_range=(np.min(array_in), np.max(array_in)),
+        must_be_nonnegative=np.all(np.array(array_in) > 0),
+    )
+    common_kwargs = {**test_kwargs, **dynamic_kwargs}
 
-    # Test no error with valid input
-    array_in = valid_array
-    array_out = validate_array(array_in, **common_kwargs)
+    # Do test
+    array_out, flags = validate_array(array_in, **common_kwargs, get_flags=True)
     assert np.array_equal(array_out, array_in)
 
-    # Check output
-    if np.array(array_in).ndim == 0 and (to_tuple or to_list):
-        # test scalar input results in scalar output
-        assert isinstance(array_out, (float, int))
-    elif to_tuple:
-        assert type(array_out) is tuple
-    elif to_list:
-        assert isinstance(array_out, list)
-    else:
-        assert isinstance(array_out, np.ndarray)
-        assert array_out.dtype.type is dtype_out
-        if as_any:
-            if input_type is pyvista_ndarray:
-                assert type(array_out) is pyvista_ndarray
-            elif input_type is np.ndarray:
-                assert type(array_out) is np.ndarray
-            if (
-                not copy
-                and isinstance(array_in, np.ndarray)
-                and np.dtype(dtype_out) is array_in.dtype
-            ):
-                assert array_out is array_in
-            else:
-                assert array_out is not array_in
-        else:
-            assert type(array_out) is np.ndarray
+    # # Check numpy outputs separately from other outputs
+    # expected_numpy_return_type = (
+    #     has_numpy_dtype
+    #     or return_type is np.ndarray
+    #     or (isinstance(array_in, np.ndarray) and return_type is None)
+    # )
+    # expected_other_return_type = return_type in (tuple, list, None)
 
-    if copy:
-        assert array_out is not array_in
+    # if expected_numpy_return_type:
+    #     # Test return type
+    #     assert isinstance(array_out, np.ndarray)
+    #     if as_any and input_type is pyvista_ndarray:
+    #         assert type(array_out) is pyvista_ndarray
+    #     else:
+    #         assert type(array_out) is np.ndarray
+    #
+    #     # Test dtype out
+    #     assert array_out.dtype.type is np.dtype(dtype_out).type
+    #
+    #     # Test copy
+    #     is_same_type = isinstance(array_in, np.ndarray) and type(array_in) is type(array_out)
+    #     is_same_dtype = isinstance(array_in, np.ndarray) and np.dtype(dtype_out) is array_in.dtype
+    #     expect_copy = copy or not is_same_type or not is_same_dtype
+    #     if expect_copy:
+    #         assert array_out is not array_in
+    #     else:
+    #         assert array_out is array_in
+    #
+    # elif expected_other_return_type:
+    #     assert isinstance(array_out, (int, float, tuple, list))
+    #
+    #     ndim = np.array(array_in).ndim
+    #
+    #     if ndim == 0:
+    #         if dtype_out is not None:
+    #             # Test scalars type/dtype
+    #             assert isinstance(array_out, dtype_out)
+    #         else:
+    #             assert isinstance(array_out, dtype_in)
+    #
+    #     elif return_type in (tuple, list):
+    #         # Test sequence type
+    #         assert isinstance(array_out, return_type)
+    #
+    #         # Test sequence dtype
+    #         if ndim == 1:
+    #             assert isinstance(array_out[0], dtype_out)
+    #         elif ndim == 2:
+    #             assert isinstance(array_out[0][0], dtype_out)
+    #         elif ndim == 3:
+    #             assert isinstance(array_out[0][0][0], dtype_out)
+    #         elif ndim == 4:
+    #             assert isinstance(array_out[0][0][0][0], dtype_out)
+    #         else:
+    #             raise RuntimeError('Unexpected test case')
+    #
+    #     # Test copy
+    #     can_be_copied = deepcopy(array_in) is not array_in
+    #     is_same_type = type(array_in) is type(array_out)
+    #     change_dtype = dtype_out is not None and isinstance(array_in, (tuple, list))
+    #     expect_copy = (copy and can_be_copied) or not is_same_type or change_dtype
+    #     if expect_copy:
+    #         assert array_in is not array_out
+    #     else:
+    #         assert array_in is array_out
+    # else:
+    #     raise RuntimeError('Unexpected test case')
+
+    # # Test flags
+    # same_shape = np.shape(array_in) == np.shape(array_out)
+    # same_dtype = np.array(array_in).dtype == np.dtype(dtype_out)
+    # same_object = id(array_in) == id(array_out)
+    # same_type = type(array_in) is type(array_out)
+    # assert flags.same_shape == same_shape
+    # assert flags.same_dtype == same_dtype
+    # assert flags.same_object == same_object
+    # assert flags.same_type == same_type
 
 
 @pytest.mark.parametrize('array', [(True,), 'abc'])
@@ -681,7 +738,7 @@ def test_check_finite():
         check_finite(np.nan, name='_input')
 
 
-def test_check_integer():
+def test_check_integerlike():
     check_integer(1)
     check_integer([2, 3.0])
     match = "Input has incorrect dtype of 'float64'. The dtype must be a subtype of <class 'numpy.integer'>."
@@ -726,6 +783,7 @@ def test_check_length():
     match = '_input must have a length equal to any of: 1. Got length 2 instead.'
     with pytest.raises(ValueError, match=match):
         check_length((1, 2), exact_length=1, name='_input')
+
     match = '_input must have a length equal to any of: [3, 4]. Got length 2 instead.'
     with pytest.raises(ValueError, match=escape(match)):
         check_length((1, 2), exact_length=[3, 4], name='_input')
@@ -754,6 +812,9 @@ def test_check_length():
     with pytest.raises(ValueError, match=escape(match)):
         check_length(((1, 2), (3, 4)), must_be_1d=True)
 
+    with pytest.raises(TypeError, match="object of type 'int' has no len()"):
+        check_length(0, allow_scalar=False)
+
 
 def test_check_nonnegative():
     check_nonnegative(0)
@@ -767,7 +828,8 @@ def test_check_nonnegative():
 @pytest.mark.parametrize('axis', [None, -1, -2, -3, 0, 1, 2, 3])
 @pytest.mark.parametrize('ascending', [True, False])
 @pytest.mark.parametrize('strict', [True, False])
-def test_check_sorted(shape, axis, ascending, strict):
+@pytest.mark.parametrize('as_list', [True, False])
+def test_check_sorted(shape, axis, ascending, strict, as_list):
     def _check_sorted_params(arr):
         check_sorted(arr, axis=axis, strict=strict, ascending=ascending)
 
@@ -803,7 +865,12 @@ def test_check_sorted(shape, axis, ascending, strict):
             _check_sorted_params(arr_strict_ascending)
         return
 
-    if axis is None and arr_ascending.ndim > 1:
+    arr_ascending = arr_ascending.tolist() if as_list else arr_ascending
+    arr_strict_ascending = arr_strict_ascending.tolist() if as_list else arr_strict_ascending
+    arr_descending = arr_descending.tolist() if as_list else arr_descending
+    arr_strict_descending = arr_strict_descending.tolist() if as_list else arr_strict_descending
+
+    if axis is None and not as_list and arr_ascending.ndim > 1:
         # test that axis=None will flatten array and cause it not to be sorted for higher dimension arrays
         with pytest.raises(ValueError):  # noqa: PT011
             _check_sorted_params(arr_ascending)
@@ -836,6 +903,13 @@ def test_check_sorted(shape, axis, ascending, strict):
                 _check_sorted_params(a)
 
 
+def test_check_sorted_error_repr():
+    array = np.zeros(shape=(10, 10))
+    match = 'Array with 100 elements must be sorted in strict ascending order. Got:\n    array([[0., 0... 0., 0., 0.]])'
+    with pytest.raises(ValueError, match=escape(match)):
+        check_sorted(array, ascending=True, strict=True)
+
+
 def test_check_iterable_items():
     check_iterable_items([1, 2, 3], int)
     check_iterable_items(('a', 'b', 'c'), str)
@@ -848,25 +922,59 @@ def test_check_iterable_items():
         check_iterable_items(['abc', 1], str, name='_input')
 
 
-def test_check_number():
-    check_number(1)
-    check_number(1 + 1j)
-    match = "_input must be an instance of <class 'numbers.Number'>. Got <class 'numpy.ndarray'> instead."
+@pytest.mark.parametrize('number', [1, 1.0, True, 1 + 1j])
+@pytest.mark.parametrize('definition', ['builtin', 'numpy'])
+@pytest.mark.parametrize('must_be_real', [True, False])
+def test_check_number(number, definition, must_be_real):
+    if definition == 'numpy':
+        number = np.array([number])[0]
+
+    if isinstance(number, np.bool_) or (not isinstance(number, Real) and must_be_real):
+        # Test bool types always raise an error
+        # Test complex types raise an error when `must_be_real` is True
+        with pytest.raises(TypeError):
+            check_number(number, must_be_real=must_be_real)
+    else:
+        # All other cases should succeed
+        check_number(number, must_be_real=must_be_real)
+
+    if definition == 'numpy':
+        # Test numpy types raise an error when definition is 'builtin'
+        if isinstance(number, float) or (isinstance(number, complex) and not must_be_real):
+            # np.float_ and np.complex_ subclass float and complex, respectively,
+            # so no error is raised
+            check_number(number, must_be_real=must_be_real, definition='builtin')
+        else:
+            with pytest.raises(TypeError):
+                check_number(number, must_be_real=must_be_real, definition='builtin')
+    elif definition == 'builtin':
+        # Test builtin types raise an error when definition is 'numpy'
+        with pytest.raises(TypeError):
+            check_number(number, must_be_real=must_be_real, definition='numpy')
+
+
+def test_check_number_raises():
+    match = (
+        "_input must be an instance of <class 'numbers.Real'>. Got <class 'numpy.ndarray'> instead."
+    )
     with pytest.raises(TypeError, match=match):
         check_number(np.array(0), name='_input')
     match = 'Object must be'
     with pytest.raises(TypeError, match=match):
         check_number(np.array(0))
+    match = 'Object must be'
+    with pytest.raises(TypeError, match=match):
+        check_number(1 + 1j, must_be_real=True)
 
 
 def test_check_contains():
-    check_contains(item='foo', container=['foo', 'bar'])
+    check_contains(['foo', 'bar'], must_contain='foo')
     match = "Input 'foo' is not valid. Input must be one of: \n\t['cat', 'bar']"
     with pytest.raises(ValueError, match=escape(match)):
-        check_contains(item='foo', container=['cat', 'bar'])
+        check_contains(['cat', 'bar'], must_contain='foo')
     match = "_input '5' is not valid. _input must be in: \n\trange(0, 4)"
     with pytest.raises(ValueError, match=escape(match)):
-        check_contains(item=5, container=range(4), name='_input')
+        check_contains(range(4), must_contain=5, name='_input')
 
 
 @pytest.mark.parametrize('name', ['_input', 'Axes'])
@@ -886,10 +994,23 @@ def test_validate_axes(name):
     assert np.array_equal(axes, axes_right)
     axes = validate_axes([1, 0, 0], [[0, 1, 0]], (0, 0, 1))
     assert np.array_equal(axes, axes_right)
+    assert np.issubdtype(axes.dtype, np.floating)
+
+    axes = validate_axes(np.eye(3).astype(int))
+    assert np.array_equal(axes, axes_right)
+    assert np.issubdtype(axes.dtype, np.floating)
+
+    # test with non-identity orthogonal axes
+    from pyvista.core.utilities.transformations import axis_angle_rotation
+
+    axes = axis_angle_rotation(axis=(1, 2, 3), angle=(30))[:3, :3]
+    _ = validate_axes(axes)
 
     # test bad input
     with pytest.raises(ValueError, match=f'{name} cannot be parallel.'):
         validate_axes([[1, 0, 0], [1, 0, 0], [0, 1, 0]], name=name)
+    with pytest.raises(ValueError, match=f'{name} cannot be parallel.'):
+        validate_axes([[1, 2, 3], [2, 4, 6], [0, 1, 0]], name=name)
     with pytest.raises(ValueError, match='Axes cannot be parallel.'):
         validate_axes([[0, 1, 0], [1, 0, 0], [0, 1, 0]])
     with pytest.raises(ValueError, match=f'{name} cannot be zeros.'):
@@ -924,6 +1045,21 @@ def test_validate_axes(name):
         match=f'{name} orientation must be specified when only two vectors are given.',
     ):
         validate_axes([1, 0, 0], [0, 1, 0], must_have_orientation=None, name=name)
+
+    match = 'Axes has shape (3,) which is not allowed. Shape must be one of [(2, 3), (3, 3)].'
+    with pytest.raises(ValueError, match=escape(match)):
+        validate_axes([1, 0, 0])
+
+    match = (
+        'Incorrect number of axes arguments. Number of arguments must be either:\n'
+        '\tOne arg (a single array with two or three vectors),'
+        '\tTwo args (two vectors), or'
+        '\tThree args (three vectors).'
+    )
+    with pytest.raises(ValueError, match=escape(match)):
+        validate_axes()
+    with pytest.raises(ValueError, match=escape(match)):
+        validate_axes(0, 0, 0, 0)
 
 
 @pytest.mark.parametrize('bias_index', [(0, 1), (1, 0), (2, 0)])
@@ -982,7 +1118,7 @@ def test_cast_to_numpy_raises():
         match = 'Object arrays are not supported.'
     else:
         err = ValueError
-        match = "Input cannot be cast as <class 'numpy.ndarray'>."
+        match = "Array cannot be cast as <class 'numpy.ndarray'>."
     with pytest.raises(err, match=match):
         _cast_to_numpy([[1], [2, 3]])
 
@@ -1035,6 +1171,156 @@ def test_array_from_vtkmatrix(cls, shape):
     # Test this matches public function
     expected = array_from_vtkmatrix(mat)
     assert np.array_equal(actual, expected)
+
+
+arraylike_shapes = [
+    (),
+    (0,),
+    (1,),
+    (
+        1,
+        0,
+    ),
+    (1, 1, 0),
+    (1, 1, 1, 0),
+    (
+        1,
+        2,
+    ),
+    (1, 2, 3),
+    (
+        1,
+        2,
+        3,
+        4,
+    ),
+]
+
+ArrayLikePropsTuple = namedtuple(  # noqa: PYI024
+    'ArrayLikePropsTuple',
+    ['array', 'shape', 'dtype', 'ndim', 'size', 'wrapper', 'return_original'],
+)
+
+
+class arraylike_types(Enum):
+    Number = auto()
+    NumpyArraySequence = auto()
+    NumberSequence1D = auto()
+    NumberSequence2D = auto()
+    NumpyArray = auto()
+
+
+ragged_arrays = (
+    [[1, 2, 3], [4, 5], [6, 7, 8, 9]],
+    [np.array([1, 2, 3]), np.array([4, 5]), np.array([6, 7, 8, 9])],
+)
+
+
+@pytest.mark.parametrize('ragged_array', ragged_arrays)
+def test_validate_array_ragged_array(ragged_array):
+    # assert casting directly to numpy array raises error
+    with pytest.raises(ValueError, match='inhomogeneous shape'):
+        np.array(ragged_array)
+
+
+def _get_default_kwargs(call: Callable) -> dict[str, Any]:
+    """Get all args/kwargs and their default value"""
+    params = dict(inspect.signature(call).parameters)
+    # Get default value for positional or keyword args
+    return {
+        key: val.default
+        for key, val in params.items()
+        if val.kind is inspect.Parameter.KEYWORD_ONLY
+    }
+
+
+@pytest.fixture
+def validate_array_kwargs() -> dict[str, Any]:
+    return _get_default_kwargs(validate_array)
+
+
+@pytest.mark.parametrize(
+    'func',
+    [validate_number, validate_array3, validate_arrayNx3, validate_arrayN, validate_data_range],
+)
+def test_validate_array_specialized_kwargs(func, validate_array_kwargs):
+    """Test kwargs for functions which call validate_array
+
+    This test is used to ensure specialized validate_array functions do
+    not modify the values of kwargs which are intended to be passed-through
+    """
+
+    actual_kwargs = _get_default_kwargs(func)
+    expected_kwargs = validate_array_kwargs
+
+    if func is validate_number:
+        # Remove unused kwargs
+        expected_kwargs.pop('must_have_shape')
+        expected_kwargs.pop('must_have_ndim')
+        expected_kwargs.pop('reshape_to')
+        expected_kwargs.pop('broadcast_to')
+        expected_kwargs.pop('to_list')
+        expected_kwargs.pop('to_tuple')
+        expected_kwargs.pop('must_be_sorted')
+        expected_kwargs.pop('must_have_length')
+        expected_kwargs.pop('must_have_max_length')
+        expected_kwargs.pop('must_have_min_length')
+        expected_kwargs.pop('as_any')
+        expected_kwargs.pop('copy')
+
+        # Change default values
+        assert expected_kwargs['must_be_finite'] is not True
+        expected_kwargs['must_be_finite'] = True
+        assert expected_kwargs['name'] != 'Number'
+        expected_kwargs['name'] = 'Number'
+
+        # Remove wrapper-specific kwargs
+        actual_kwargs.pop('reshape')
+
+    elif func is validate_array3:
+        # Remove unused kwargs
+        expected_kwargs.pop('must_have_shape')
+        expected_kwargs.pop('must_have_ndim')
+        expected_kwargs.pop('reshape_to')
+        expected_kwargs.pop('broadcast_to')
+        expected_kwargs.pop('must_have_length')
+        expected_kwargs.pop('must_have_max_length')
+        expected_kwargs.pop('must_have_min_length')
+
+        # Remove wrapper-specific kwargs
+        actual_kwargs.pop('reshape')
+        actual_kwargs.pop('broadcast')
+
+    elif func is validate_data_range:
+        # Remove unused kwargs
+        expected_kwargs.pop('must_have_shape')
+        expected_kwargs.pop('must_have_ndim')
+        expected_kwargs.pop('reshape_to')
+        expected_kwargs.pop('broadcast_to')
+        expected_kwargs.pop('must_have_length')
+        expected_kwargs.pop('must_have_max_length')
+        expected_kwargs.pop('must_have_min_length')
+        expected_kwargs.pop('must_be_sorted')
+
+        assert expected_kwargs['name'] != 'Data Range'
+        expected_kwargs['name'] = 'Data Range'
+
+    elif func is validate_arrayNx3 or validate_arrayN or validate_arrayN_unsigned:
+        # Remove unused kwargs
+        expected_kwargs.pop('must_have_shape')
+        expected_kwargs.pop('must_have_ndim')
+        expected_kwargs.pop('reshape_to')
+        expected_kwargs.pop('broadcast_to')
+
+        # Remove wrapper-specific kwargs
+        actual_kwargs.pop('reshape')
+
+        if func is validate_arrayN_unsigned:
+            expected_kwargs.pop('must_be_finite')
+            expected_kwargs.pop('must_be_integer')
+            expected_kwargs.pop('must_be_nonnegative')
+
+    assert actual_kwargs == expected_kwargs
 
 
 @pytest.mark.parametrize(

--- a/tests/core/typing/test_validation_typing.py
+++ b/tests/core/typing/test_validation_typing.py
@@ -1,0 +1,220 @@
+"""Test static type annotations revealed by Mypy.
+
+This test will automatically analyze all files in the test validation_cases directory.
+To add new test cases, simply add a new .py file with each test case following
+the format:
+
+    reveal_type(arg)  # EXPECTED_TYPE: "<T>"
+
+where `arg` is any argument you want mypy to analyze, and <T> is the expected
+revealed type returned by mypy. Note: the output types from mypy are truncated
+with the module names removed, e.g. `typing.Sequence` -> `Sequence`,
+`builtins.float` -> `float`, etc.
+
+"""
+# flake8: noqa
+
+from collections import namedtuple
+import importlib
+import os
+import re
+import sys
+from typing import Any, List, Sequence, Tuple, Union
+
+from mypy import api as mypy_api
+import numpy as np
+from numpy import bool_, dtype, integer, ndarray
+import pyanalyze
+import pytest
+
+
+from pyvista.core._validation.validate import (
+    validate_array,
+    validate_array3,
+    validate_arrayN,
+    validate_arrayN_unsigned,
+    validate_arrayNx3,
+    validate_number,
+)
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+TYPING_CASES_REL_PATH = 'tests/core/typing/validation_cases'
+TYPING_CASES_PACKAGE = TYPING_CASES_REL_PATH.replace('/', '.')
+TYPING_CASES_ABS_PATH = os.path.join(PROJECT_ROOT, TYPING_CASES_REL_PATH)
+TEST_FILE_NAMES = [f for f in os.listdir(TYPING_CASES_ABS_PATH) if f.endswith('.py')]
+
+_TestCaseTuple = namedtuple('_TestCaseTuple', ['file', 'line_num', 'arg', 'expected', 'revealed'])
+
+
+def _reveal_types():
+    # Call mypy from the project root dir on the typing test case files
+    # Calling from root ensures the config is loaded and imports are found
+    # NOTE: running mypy can be slow, avoid making excessive calls
+    cur = os.getcwd()
+    if importlib.util.find_spec('npt_promote') is None:
+        raise ModuleNotFoundError("Package 'npt-promote' is required for this test.")
+    try:
+        os.chdir(PROJECT_ROOT)
+
+        result = mypy_api.run(['--show-absolute-path', '--package', TYPING_CASES_PACKAGE])
+        assert 'usage: mypy' not in result[1]
+        assert 'Cannot find implementation' not in result[0]
+
+        # Clean up output
+        stdout = str(result[0])
+
+        # group revealed types by (filepath), (line num), and (type)
+        pattern = r'^(.*?):(\d*?):\snote: Revealed type is "([^"]+)"'
+        match = re.findall(pattern, stdout, re.MULTILINE)
+        assert match is not None
+
+        # Make revealed types less verbose
+        for i, group in enumerate(match):
+            filepath, line_num, revealed = group
+            revealed = revealed.replace('Tuple', 'tuple')
+            revealed = revealed.replace('builtins.', '')
+            revealed = revealed.replace('numpy.', '')
+            revealed = revealed.replace('typing.', '')
+            match[i] = (filepath, line_num, revealed)
+        return match
+
+    finally:
+        os.chdir(cur)
+
+
+def _get_expected_types():
+    """Parse all case files and extract expected types."""
+    cases = []
+    pattern = r'^\s.*?reveal_type\((.*?)\)\s*?#\sEXPECTED_TYPE: "([^"]+)"'
+    for file in TEST_FILE_NAMES:
+        with open(os.path.join(TYPING_CASES_ABS_PATH, file)) as f:
+            split_lines = f.read().splitlines()
+        for line_num, line in enumerate(split_lines):
+            if not line.strip().startswith('#'):
+                match = re.search(pattern, line)
+                if match is not None:
+                    arg, expected = match.groups()
+                    cases.append((file, line_num + 1, arg, expected))
+    assert cases is not None
+    return cases
+
+
+def _generate_test_cases():
+    """Generate a list of line-by-line test cases from the typing test directory.
+
+    This function:
+        (1) calls mypy to get the revealed types, and
+        (2) parses the code files to get the `reveal_type(arg)` argument and the
+            expected type.
+
+    The two outputs are then merged to create individual test cases.
+    """
+    test_cases_dict = {}
+
+    def add_to_dict(filepath, line_num: str, key: str, val: str):
+        # Function for stuffing parsed data into a dict.
+        # We use a dict to allow for any entry to be made based on line number alone.
+        # This way, we can defer checking for any errors with the parsed data to test time.
+        nonlocal test_cases_dict
+        filename = os.path.basename(filepath)
+        line_num = int(line_num)
+        try:
+            test_cases_dict[filename]
+        except KeyError:
+            test_cases_dict[filename] = {}
+        try:
+            test_cases_dict[filename][line_num]
+        except KeyError:
+            test_cases_dict[filename][line_num] = {}
+        test_cases_dict[filename][line_num][key] = val
+
+    # run mypy
+    revealed_types: List[Tuple[str, str, str]] = _reveal_types()
+    for filepath, line_num, revealed in revealed_types:
+        add_to_dict(filepath, line_num, 'revealed', revealed)
+
+    # parse code files
+    expected_types: List[Tuple[str, str, str, str]] = _get_expected_types()
+    for filepath, line_num, arg, expected in expected_types:
+        add_to_dict(filepath, line_num, 'arg', arg)
+        add_to_dict(filepath, line_num, 'expected', expected)
+
+    # flatten dict
+    test_cases_list = []
+    for file, lines in test_cases_dict.items():
+        for line_num, content in sorted(lines.items()):
+            arg = content['arg'] if 'arg' in content else None
+            rev = content['revealed'] if 'revealed' in content else None
+            exp = content['expected'] if 'expected' in content else None
+            test_case = _TestCaseTuple(
+                file=file, line_num=line_num, arg=arg, expected=exp, revealed=rev
+            )
+            test_cases_list.append(test_case)
+
+    return test_cases_list
+
+
+def pytest_generate_tests(metafunc):
+    """Generate parametrized tests."""
+    if 'test_case' in metafunc.fixturenames:
+        test_cases = _generate_test_cases()
+        test_cases_runtime = [(*case, 'runtime') for case in test_cases]
+        test_cases_static = [(*case, 'static') for case in test_cases]
+
+        # Interleave cases
+        all_cases = [x for y in zip(test_cases_runtime, test_cases_static) for x in y]
+        all_cases = all_cases[::-1]
+
+        # Name test cases with file line number
+        ids = [f"{file.split('.py')[0]} : line {line} : {static_or_runtime}" for file, line, _, _, _, static_or_runtime in all_cases]
+        metafunc.parametrize('test_case', all_cases, ids=ids)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="Type subscription requires python >= 3.9")
+def test_typing(test_case):
+    file, line_num, arg, expected, revealed, static_or_runtime = test_case
+    # Test set-up
+    assert file in TEST_FILE_NAMES
+    assert isinstance(line_num, int)
+    if arg is None or revealed is None or expected is None:
+        pytest.fail(
+            f"Test setup failed for test case in {file}:{line_num}. Got:\n"
+            f"\targ: {arg}\n"
+            f"\texpected: {expected}\n"
+            f"\trevealed: {revealed}\n"
+        )
+    if static_or_runtime == 'static':
+        # Test statically revealed type from mypy is correct
+        assert f"{arg} -> {revealed}" == f"{arg} -> {expected}"
+    else:
+        # Test that the actual runtime type is compatible with the revealed type
+
+        try:
+            revealed_type = eval(revealed)
+        except Exception as e:
+            pytest.fail(
+                f"Test setup failed for runtime test case in {file}:{line_num}.\n"
+                f"Could not evaluate revealed type:\n "
+                f"\t{revealed}\n"
+                f"An exception was raised:\n{repr(e)}"
+
+            )
+        try:
+            runtime_val = eval(arg)
+        except Exception as e:
+            pytest.fail(
+                f"Test setup failed for runtime test case in {file}:{line_num}.\n"
+                f"Could not evaluate runtime argument:\n "
+                f"\t{arg}\n"
+                f"An exception was raised:\n{repr(e)}"
+
+            )
+        compat_error_msg = pyanalyze.runtime.get_compatibility_error(runtime_val, revealed_type)
+        if compat_error_msg:
+            error_prefix = (f"\nRuntime value:\n"
+                         f"\t{arg} = {runtime_val}\n"
+                         f"is not compatible with statically revealed type:\n"
+                         f"\t{revealed_type}\n\n"
+                            f"Reason:\n")
+
+            pytest.fail(error_prefix + compat_error_msg)

--- a/tests/core/typing/validation_cases/validate_array3.py
+++ b/tests/core/typing/validation_cases/validate_array3.py
@@ -1,0 +1,43 @@
+# flake8: noqa
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from pyvista.core._validation import validate_array3
+
+if TYPE_CHECKING:
+    # scalars
+    reveal_type(validate_array3(1.0, broadcast=True))   # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_array3(1, broadcast=True))     # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_array3(True, broadcast=True))  # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+
+    reveal_type(validate_array3(1.0, broadcast=True, dtype_out=int))     # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_array3(1, broadcast=True, dtype_out=bool))      # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+    # reveal_type(validate_array3(True, broadcast=True, dtype_out=float))  # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+
+    # numpy arrays
+    reveal_type(validate_array3(np.array([1.0, 2.0, 3.0], dtype=float)))     # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_array3(np.array([1, 2, 3], dtype=int)))             # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_array3(np.array([True, False, True], dtype=bool)))  # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+
+    reveal_type(validate_array3(np.array([1.0, 2.0, 3.0]), dtype_out=int))        # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_array3(np.array([1, 2, 3]), dtype_out=bool))             # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+    # reveal_type(validate_array3(np.array([True, False, True]), dtype_out=float))  # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+
+    # 1D inputs
+    reveal_type(validate_array3([1.0, 2.0, 3.0]))      # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_array3([1, 2, 3]))            # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    #reveal_type(validate_array3([True, False, True]))  # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+
+    reveal_type(validate_array3([1.0, 2.0, 3.0], dtype_out=int))        # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_array3([1, 2, 3], dtype_out=bool))             # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+    #reveal_type(validate_array3([True, False, True], dtype_out=float))  # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+
+    # 2D inputs
+    reveal_type(validate_array3([[1.0, 2.0, 3.0]]))      # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_array3([[1, 2, 3]]))            # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_array3([[True, False, True]]))  # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+
+    reveal_type(validate_array3(((1.0, 2.0, 3.0),), dtype_out=int))        # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_array3(((1, 2, 3),), dtype_out=bool))             # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+    # reveal_type(validate_array3(((True, False, True),), dtype_out=float))  # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"

--- a/tests/core/typing/validation_cases/validate_arrayN.py
+++ b/tests/core/typing/validation_cases/validate_arrayN.py
@@ -1,0 +1,43 @@
+# flake8: noqa
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from pyvista.core._validation import validate_arrayN
+
+if TYPE_CHECKING:
+    # scalars
+    reveal_type(validate_arrayN(1.0))   # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_arrayN(1))     # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_arrayN(True))  # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+
+    reveal_type(validate_arrayN(1.0, dtype_out=int))     # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_arrayN(1, dtype_out=bool))      # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+    # reveal_type(validate_arrayN(True, dtype_out=float))  # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+
+    # numpy arrays
+    reveal_type(validate_arrayN(np.array([1.0, 2.0, 3.0], dtype=float)))     # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_arrayN(np.array([1, 2, 3], dtype=int)))             # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_arrayN(np.array([True, False, True], dtype=bool)))  # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+
+    reveal_type(validate_arrayN(np.array([1.0, 2.0, 3.0]), dtype_out=int))        # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_arrayN(np.array([1, 2, 3]), dtype_out=bool))             # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+    # reveal_type(validate_arrayN(np.array([True, False, True]), dtype_out=float))  # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+
+    # 1D inputs
+    reveal_type(validate_arrayN([1.0, 2.0, 3.0]))      # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_arrayN([1, 2, 3]))            # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_arrayN([True, False, True]))  # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+
+    reveal_type(validate_arrayN([1.0, 2.0, 3.0], dtype_out=int))        # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_arrayN([1, 2, 3], dtype_out=bool))             # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+    # reveal_type(validate_arrayN([True, False, True], dtype_out=float))  # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+
+    # 2D inputs
+    reveal_type(validate_arrayN([[1.0, 2.0, 3.0]]))      # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_arrayN([[1, 2, 3]]))            # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_arrayN([[True, False, True]]))  # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+
+    reveal_type(validate_arrayN(((1.0, 2.0, 3.0),), dtype_out=int))        # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_arrayN(((1, 2, 3),), dtype_out=bool))             # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+    # reveal_type(validate_arrayN(((True, False, True),), dtype_out=float))  # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"

--- a/tests/core/typing/validation_cases/validate_arrayN_unsigned.py
+++ b/tests/core/typing/validation_cases/validate_arrayN_unsigned.py
@@ -1,0 +1,42 @@
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from pyvista.core._validation import validate_arrayN_unsigned
+
+if TYPE_CHECKING:
+    # scalars
+    reveal_type(validate_arrayN_unsigned(1.0))   # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_arrayN_unsigned(1))     # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_arrayN_unsigned(True))  # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+
+    reveal_type(validate_arrayN_unsigned(1.0, dtype_out=int))          # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_arrayN_unsigned(1, dtype_out=bool))           # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+    # reveal_type(validate_arrayN_unsigned(True, dtype_out=np.integer))  # EXPECTED_TYPE: "ndarray[Any, dtype[integer[Any]]]"
+
+    # numpy arrays
+    reveal_type(validate_arrayN_unsigned(np.array([1.0, 2.0, 3.0], dtype=float)))     # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_arrayN_unsigned(np.array([1, 2, 3], dtype=int)))             # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_arrayN_unsigned(np.array([True, False, True], dtype=bool)))  # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+
+    reveal_type(validate_arrayN_unsigned(np.array([1.0, 2.0, 3.0]), dtype_out=int))           # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_arrayN_unsigned(np.array([1, 2, 3]), dtype_out=bool))                # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+    # reveal_type(validate_arrayN_unsigned(np.array([True, False, True]), dtype_out=np.bool_))  # EXPECTED_TYPE: "ndarray[Any, dtype[bool_]]"
+
+    # 1D inputs
+    reveal_type(validate_arrayN_unsigned([1.0, 2.0, 3.0]))      # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_arrayN_unsigned([1, 2, 3]))            # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_arrayN_unsigned([True, False, True]))  # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+
+    reveal_type(validate_arrayN_unsigned([1.0, 2.0, 3.0], dtype_out=int))           # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_arrayN_unsigned([1, 2, 3], dtype_out=bool))                # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+    # reveal_type(validate_arrayN_unsigned([True, False, True], dtype_out=np.bool_))  # EXPECTED_TYPE: "ndarray[Any, dtype[bool_]]"
+
+    # 2D inputs
+    reveal_type(validate_arrayN_unsigned([[1.0, 2.0, 3.0]]))      # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_arrayN_unsigned([[1, 2, 3]]))            # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_arrayN_unsigned([[True, False, True]]))  # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+
+    reveal_type(validate_arrayN_unsigned(((1.0, 2.0, 3.0),), dtype_out=int))           # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_arrayN_unsigned(((1, 2, 3),), dtype_out=bool))                # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+    # reveal_type(validate_arrayN_unsigned(((True, False, True),), dtype_out=np.bool_))  # EXPECTED_TYPE: "ndarray[Any, dtype[bool_]]"

--- a/tests/core/typing/validation_cases/validate_arrayNx3.py
+++ b/tests/core/typing/validation_cases/validate_arrayNx3.py
@@ -1,0 +1,34 @@
+# flake8: noqa
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from pyvista.core._validation import validate_arrayNx3
+
+if TYPE_CHECKING:
+    # numpy arrays
+    reveal_type(validate_arrayNx3(np.array([1.0, 2.0, 3.0], dtype=float)))     # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_arrayNx3(np.array([1, 2, 3], dtype=int)))             # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_arrayNx3(np.array([True, False, True], dtype=bool)))  # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+
+    reveal_type(validate_arrayNx3(np.array([1.0, 2.0, 3.0]), dtype_out=int))        # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_arrayNx3(np.array([1, 2, 3]), dtype_out=bool))             # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+    # reveal_type(validate_arrayNx3(np.array([True, False, True]), dtype_out=float))  # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+
+    # 1D inputs
+    reveal_type(validate_arrayNx3([1.0, 2.0, 3.0]))      # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_arrayNx3([1, 2, 3]))            # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_arrayNx3([True, False, True]))  # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+
+    reveal_type(validate_arrayNx3([1.0, 2.0, 3.0], dtype_out=int))        # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_arrayNx3([1, 2, 3], dtype_out=bool))             # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+    # reveal_type(validate_arrayNx3([True, False, True], dtype_out=float))  # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+
+    # 2D inputs
+    reveal_type(validate_arrayNx3([[1.0, 2.0, 3.0]]))      # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_arrayNx3([[1, 2, 3]]))            # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_arrayNx3([[True, False, True]]))  # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+
+    reveal_type(validate_arrayNx3(((1.0, 2.0, 3.0),), dtype_out=int))        # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_arrayNx3(((1, 2, 3),), dtype_out=bool))             # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+    # reveal_type(validate_arrayNx3(((True, False, True),), dtype_out=float))  # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"

--- a/tests/core/typing/validation_cases/validate_array_default.py
+++ b/tests/core/typing/validation_cases/validate_array_default.py
@@ -1,0 +1,45 @@
+# flake8: noqa
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from pyvista.core._validation import validate_array
+
+if TYPE_CHECKING:
+    # scalars
+    reveal_type(validate_array(1.0))   # EXPECTED_TYPE: "float"
+    reveal_type(validate_array(1))     # EXPECTED_TYPE: "int"
+    # reveal_type(validate_array(True))  # EXPECTED_TYPE: "bool"
+
+    # numpy arrays
+    reveal_type(validate_array(np.array((1.0), dtype=float)))  # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_array(np.array((1), dtype=int)))      # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_array(np.array((True), dtype=bool)))  # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+
+    # lists
+    reveal_type(validate_array([1.0]))         # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_array([1]))           # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_array([True]))        # EXPECTED_TYPE: "list[bool]"
+    reveal_type(validate_array([[1.0]]))       # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_array([[1]]))         # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_array([[True]]))      # EXPECTED_TYPE: "list[list[bool]]"
+    reveal_type(validate_array([[[1.0]]]))     # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_array([[[1]]]))       # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_array([[[True]]]))    # EXPECTED_TYPE: "Union[bool, list[bool], list[list[bool]], list[list[list[bool]]], list[list[list[list[bool]]]]]"
+    reveal_type(validate_array([[[[1.0]]]]))   # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_array([[[[1]]]]))     # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_array([[[[True]]]]))  # EXPECTED_TYPE: "Union[bool, list[bool], list[list[bool]], list[list[list[bool]]], list[list[list[list[bool]]]]]"
+
+    # tuples
+    reveal_type(validate_array((1.0,)))            # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_array((1,)))              # EXPECTED_TYPE: "tuple[int]"
+    # reveal_type(validate_array((True,)))           # EXPECTED_TYPE: "tuple[bool]"
+    reveal_type(validate_array(((1.0,),)))         # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_array(((1,),)))           # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_array(((True,),)))        # EXPECTED_TYPE: "tuple[tuple[bool]]"
+    reveal_type(validate_array((((1.0,),),)))      # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_array((((1,),),)))        # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_array((((True,),),)))     # EXPECTED_TYPE: "Union[bool, tuple[bool], tuple[tuple[bool]], tuple[tuple[tuple[bool]]], tuple[tuple[tuple[tuple[bool]]]]]"
+    reveal_type(validate_array(((((1.0,),),),)))   # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_array(((((1,),),),)))     # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    # reveal_type(validate_array(((((True,),),),)))  # EXPECTED_TYPE: "Union[bool, tuple[bool], tuple[tuple[bool]], tuple[tuple[tuple[bool]]], tuple[tuple[tuple[tuple[bool]]]]]"

--- a/tests/core/typing/validation_cases/validate_array_dtype_out.py
+++ b/tests/core/typing/validation_cases/validate_array_dtype_out.py
@@ -1,0 +1,45 @@
+# flake8: noqa
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from pyvista.core._validation import validate_array
+
+if TYPE_CHECKING:
+    # scalars
+    reveal_type(validate_array(1.0, dtype_out=int))     # EXPECTED_TYPE: "int"
+    reveal_type(validate_array(1, dtype_out=bool))      # EXPECTED_TYPE: "bool"
+    reveal_type(validate_array(True, dtype_out=float))  # EXPECTED_TYPE: "float"
+
+    # numpy arrays
+    reveal_type(validate_array(np.array(1.0, dtype=float), dtype_out=int))    # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_array(np.array(1, dtype=int), dtype_out=bool))       # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+    reveal_type(validate_array(np.array(True, dtype=bool), dtype_out=float))  # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+
+    # lists
+    reveal_type(validate_array([1.0], dtype_out=int))           # EXPECTED_TYPE: "list[int]"
+    reveal_type(validate_array([1], dtype_out=bool))            # EXPECTED_TYPE: "list[bool]"
+    reveal_type(validate_array([True], dtype_out=float))        # EXPECTED_TYPE: "list[float]"
+    reveal_type(validate_array([[1.0]], dtype_out=int))         # EXPECTED_TYPE: "list[list[int]]"
+    reveal_type(validate_array([[1]], dtype_out=bool))          # EXPECTED_TYPE: "list[list[bool]]"
+    reveal_type(validate_array([[True]], dtype_out=float))      # EXPECTED_TYPE: "list[list[float]]"
+    reveal_type(validate_array([[[1.0]]], dtype_out=int))       # EXPECTED_TYPE: "Union[int, list[int], list[list[int]], list[list[list[int]]], list[list[list[list[int]]]]]"
+    reveal_type(validate_array([[[1]]], dtype_out=bool))        # EXPECTED_TYPE: "Union[bool, list[bool], list[list[bool]], list[list[list[bool]]], list[list[list[list[bool]]]]]"
+    reveal_type(validate_array([[[True]]], dtype_out=float))    # EXPECTED_TYPE: "Union[float, list[float], list[list[float]], list[list[list[float]]], list[list[list[list[float]]]]]"
+    reveal_type(validate_array([[[[1.0]]]], dtype_out=int))     # EXPECTED_TYPE: "Union[int, list[int], list[list[int]], list[list[list[int]]], list[list[list[list[int]]]]]"
+    reveal_type(validate_array([[[[1]]]], dtype_out=bool))      # EXPECTED_TYPE: "Union[bool, list[bool], list[list[bool]], list[list[list[bool]]], list[list[list[list[bool]]]]]"
+    reveal_type(validate_array([[[[True]]]], dtype_out=float))  # EXPECTED_TYPE: "Union[float, list[float], list[list[float]], list[list[list[float]]], list[list[list[list[float]]]]]"
+
+    # tuples
+    reveal_type(validate_array((1.0,), dtype_out=int))              # EXPECTED_TYPE: "tuple[int]"
+    reveal_type(validate_array((1,), dtype_out=bool))               # EXPECTED_TYPE: "tuple[bool]"
+    reveal_type(validate_array((True,), dtype_out=float))           # EXPECTED_TYPE: "tuple[float]"
+    reveal_type(validate_array(((1.0,),), dtype_out=int))           # EXPECTED_TYPE: "tuple[tuple[int]]"
+    reveal_type(validate_array(((1,),), dtype_out=bool))            # EXPECTED_TYPE: "tuple[tuple[bool]]"
+    reveal_type(validate_array(((True,),), dtype_out=float))        # EXPECTED_TYPE: "tuple[tuple[float]]"
+    reveal_type(validate_array((((1.0,),),), dtype_out=int))        # EXPECTED_TYPE: "Union[int, tuple[int], tuple[tuple[int]], tuple[tuple[tuple[int]]], tuple[tuple[tuple[tuple[int]]]]]"
+    reveal_type(validate_array((((1,),),), dtype_out=bool))         # EXPECTED_TYPE: "Union[bool, tuple[bool], tuple[tuple[bool]], tuple[tuple[tuple[bool]]], tuple[tuple[tuple[tuple[bool]]]]]"
+    reveal_type(validate_array((((True,),),), dtype_out=float))     # EXPECTED_TYPE: "Union[float, tuple[float], tuple[tuple[float]], tuple[tuple[tuple[float]]], tuple[tuple[tuple[tuple[float]]]]]"
+    reveal_type(validate_array(((((1.0,),),),), dtype_out=int))     # EXPECTED_TYPE: "Union[int, tuple[int], tuple[tuple[int]], tuple[tuple[tuple[int]]], tuple[tuple[tuple[tuple[int]]]]]"
+    reveal_type(validate_array(((((1,),),),), dtype_out=bool))      # EXPECTED_TYPE: "Union[bool, tuple[bool], tuple[tuple[bool]], tuple[tuple[tuple[bool]]], tuple[tuple[tuple[tuple[bool]]]]]"
+    reveal_type(validate_array(((((True,),),),), dtype_out=float))  # EXPECTED_TYPE: "Union[float, tuple[float], tuple[tuple[float]], tuple[tuple[tuple[float]]], tuple[tuple[tuple[tuple[float]]]]]"

--- a/tests/core/typing/validation_cases/validate_array_reshape_to.py
+++ b/tests/core/typing/validation_cases/validate_array_reshape_to.py
@@ -1,0 +1,45 @@
+# flake8: noqa
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from pyvista.core._validation import validate_array
+
+if TYPE_CHECKING:
+    # scalars
+    reveal_type(validate_array(1.0, reshape_to=()))        # EXPECTED_TYPE: "float"
+    reveal_type(validate_array(1, reshape_to=(1)))         # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_array(True, reshape_to=((1,1))))  # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+
+    # numpy arrays
+    reveal_type(validate_array(np.array((1.0), dtype=float), reshape_to=()))       # EXPECTED_TYPE: "ndarray[Any, dtype[float]]"
+    reveal_type(validate_array(np.array((1), dtype=int), reshape_to=(1)))          # EXPECTED_TYPE: "ndarray[Any, dtype[int]]"
+    reveal_type(validate_array(np.array((True), dtype=bool), reshape_to=((1,1))))  # EXPECTED_TYPE: "ndarray[Any, dtype[bool]]"
+
+    # lists
+    reveal_type(validate_array([1.0], reshape_to=()))              # EXPECTED_TYPE: "Union[float, list[float], list[list[float]], list[list[list[float]]], list[list[list[list[float]]]]]"
+    reveal_type(validate_array([1], reshape_to=(1)))               # EXPECTED_TYPE: "list[int]"
+    reveal_type(validate_array([True], reshape_to=((1,1))))        # EXPECTED_TYPE: "Union[bool, list[bool], list[list[bool]], list[list[list[bool]]], list[list[list[list[bool]]]]]"
+    reveal_type(validate_array([[1.0]], reshape_to=()))            # EXPECTED_TYPE: "Union[float, list[float], list[list[float]], list[list[list[float]]], list[list[list[list[float]]]]]"
+    reveal_type(validate_array([[1]], reshape_to=(1)))             # EXPECTED_TYPE: "Union[int, list[int], list[list[int]], list[list[list[int]]], list[list[list[list[int]]]]]"
+    reveal_type(validate_array([[True]], reshape_to=((1,1))))      # EXPECTED_TYPE: "list[list[bool]]"
+    reveal_type(validate_array([[[1.0]]], reshape_to=()))          # EXPECTED_TYPE: "Union[float, list[float], list[list[float]], list[list[list[float]]], list[list[list[list[float]]]]]"
+    reveal_type(validate_array([[[1]]], reshape_to=(1)))           # EXPECTED_TYPE: "Union[int, list[int], list[list[int]], list[list[list[int]]], list[list[list[list[int]]]]]"
+    reveal_type(validate_array([[[True]]], reshape_to=((1,1))))    # EXPECTED_TYPE: "Union[bool, list[bool], list[list[bool]], list[list[list[bool]]], list[list[list[list[bool]]]]]"
+    reveal_type(validate_array([[[[1.0]]]], reshape_to=()))        # EXPECTED_TYPE: "Union[float, list[float], list[list[float]], list[list[list[float]]], list[list[list[list[float]]]]]"
+    reveal_type(validate_array([[[[1]]]], reshape_to=(1)))         # EXPECTED_TYPE: "Union[int, list[int], list[list[int]], list[list[list[int]]], list[list[list[list[int]]]]]"
+    reveal_type(validate_array([[[[True]]]], reshape_to=((1,1))))  # EXPECTED_TYPE: "Union[bool, list[bool], list[list[bool]], list[list[list[bool]]], list[list[list[list[bool]]]]]"
+
+    # tuples
+    reveal_type(validate_array((1.0,), reshape_to=()))                 # EXPECTED_TYPE: "Union[float, tuple[float], tuple[tuple[float]], tuple[tuple[tuple[float]]], tuple[tuple[tuple[tuple[float]]]]]"
+    reveal_type(validate_array((1,), reshape_to=(1)))                  # EXPECTED_TYPE: "tuple[int]"
+    reveal_type(validate_array((True,), reshape_to=((1,1))))           # EXPECTED_TYPE: "Union[bool, tuple[bool], tuple[tuple[bool]], tuple[tuple[tuple[bool]]], tuple[tuple[tuple[tuple[bool]]]]]"
+    reveal_type(validate_array(((1.0,),), reshape_to=()))              # EXPECTED_TYPE: "Union[float, tuple[float], tuple[tuple[float]], tuple[tuple[tuple[float]]], tuple[tuple[tuple[tuple[float]]]]]"
+    reveal_type(validate_array(((1,),), reshape_to=(1)))               # EXPECTED_TYPE: "Union[int, tuple[int], tuple[tuple[int]], tuple[tuple[tuple[int]]], tuple[tuple[tuple[tuple[int]]]]]"
+    reveal_type(validate_array(((True,),), reshape_to=((1,1))))        # EXPECTED_TYPE: "tuple[tuple[bool]]"
+    reveal_type(validate_array((((1.0,),),), reshape_to=()))           # EXPECTED_TYPE: "Union[float, tuple[float], tuple[tuple[float]], tuple[tuple[tuple[float]]], tuple[tuple[tuple[tuple[float]]]]]"
+    reveal_type(validate_array((((1,),),), reshape_to=(1)))            # EXPECTED_TYPE: "Union[int, tuple[int], tuple[tuple[int]], tuple[tuple[tuple[int]]], tuple[tuple[tuple[tuple[int]]]]]"
+    reveal_type(validate_array((((True,),),), reshape_to=((1,1))))     # EXPECTED_TYPE: "Union[bool, tuple[bool], tuple[tuple[bool]], tuple[tuple[tuple[bool]]], tuple[tuple[tuple[tuple[bool]]]]]"
+    reveal_type(validate_array(((((1.0,),),),), reshape_to=()))        # EXPECTED_TYPE: "Union[float, tuple[float], tuple[tuple[float]], tuple[tuple[tuple[float]]], tuple[tuple[tuple[tuple[float]]]]]"
+    reveal_type(validate_array(((((1,),),),), reshape_to=(1)))         # EXPECTED_TYPE: "Union[int, tuple[int], tuple[tuple[int]], tuple[tuple[tuple[int]]], tuple[tuple[tuple[tuple[int]]]]]"
+    reveal_type(validate_array(((((True,),),),), reshape_to=((1,1))))  # EXPECTED_TYPE: "Union[bool, tuple[bool], tuple[tuple[bool]], tuple[tuple[tuple[bool]]], tuple[tuple[tuple[tuple[bool]]]]]"

--- a/tests/core/typing/validation_cases/validate_array_to_list.py
+++ b/tests/core/typing/validation_cases/validate_array_to_list.py
@@ -1,0 +1,45 @@
+# flake8: noqa
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from pyvista.core._validation import validate_array
+
+if TYPE_CHECKING:
+    # scalars
+    reveal_type(validate_array(1.0, return_type='list'))   # EXPECTED_TYPE: "float"
+    reveal_type(validate_array(1, return_type='list'))     # EXPECTED_TYPE: "int"
+    reveal_type(validate_array(True, return_type='list'))  # EXPECTED_TYPE: "bool"
+
+    # numpy arrays
+    reveal_type(validate_array(np.array(1.0, dtype=float), return_type='list'))  # EXPECTED_TYPE: "Union[float, list[float], list[list[float]], list[list[list[float]]], list[list[list[list[float]]]]]"
+    reveal_type(validate_array(np.array(1, dtype=int), return_type='list'))      # EXPECTED_TYPE: "Union[int, list[int], list[list[int]], list[list[list[int]]], list[list[list[list[int]]]]]"
+    reveal_type(validate_array(np.array(True, dtype=bool), return_type='list'))  # EXPECTED_TYPE: "Union[bool, list[bool], list[list[bool]], list[list[list[bool]]], list[list[list[list[bool]]]]]"
+
+    # lists
+    reveal_type(validate_array([1.0], return_type='list'))         # EXPECTED_TYPE: "list[float]"
+    reveal_type(validate_array([1], return_type='list'))           # EXPECTED_TYPE: "list[int]"
+    reveal_type(validate_array([True], return_type='list'))        # EXPECTED_TYPE: "list[bool]"
+    reveal_type(validate_array([[1.0]], return_type='list'))       # EXPECTED_TYPE: "list[list[float]]"
+    reveal_type(validate_array([[1]], return_type='list'))         # EXPECTED_TYPE: "list[list[int]]"
+    reveal_type(validate_array([[True]], return_type='list'))      # EXPECTED_TYPE: "list[list[bool]]"
+    reveal_type(validate_array([[[1.0]]], return_type='list'))     # EXPECTED_TYPE: "Union[float, list[float], list[list[float]], list[list[list[float]]], list[list[list[list[float]]]]]"
+    reveal_type(validate_array([[[1]]], return_type='list'))       # EXPECTED_TYPE: "Union[int, list[int], list[list[int]], list[list[list[int]]], list[list[list[list[int]]]]]"
+    reveal_type(validate_array([[[True]]], return_type='list'))    # EXPECTED_TYPE: "Union[bool, list[bool], list[list[bool]], list[list[list[bool]]], list[list[list[list[bool]]]]]"
+    reveal_type(validate_array([[[[1.0]]]], return_type='list'))   # EXPECTED_TYPE: "Union[float, list[float], list[list[float]], list[list[list[float]]], list[list[list[list[float]]]]]"
+    reveal_type(validate_array([[[[1]]]], return_type='list'))     # EXPECTED_TYPE: "Union[int, list[int], list[list[int]], list[list[list[int]]], list[list[list[list[int]]]]]"
+    reveal_type(validate_array([[[[True]]]], return_type='list'))  # EXPECTED_TYPE: "Union[bool, list[bool], list[list[bool]], list[list[list[bool]]], list[list[list[list[bool]]]]]"
+
+    # tuples
+    reveal_type(validate_array((1.0,), return_type='list'))            # EXPECTED_TYPE: "list[float]"
+    reveal_type(validate_array((1,), return_type='list'))              # EXPECTED_TYPE: "list[int]"
+    reveal_type(validate_array((True,), return_type='list'))           # EXPECTED_TYPE: "list[bool]"
+    reveal_type(validate_array(((1.0,),), return_type='list'))         # EXPECTED_TYPE: "list[list[float]]"
+    reveal_type(validate_array(((1,),), return_type='list'))           # EXPECTED_TYPE: "list[list[int]]"
+    reveal_type(validate_array(((True,),), return_type='list'))        # EXPECTED_TYPE: "list[list[bool]]"
+    reveal_type(validate_array((((1.0,),),), return_type='list'))      # EXPECTED_TYPE: "Union[float, list[float], list[list[float]], list[list[list[float]]], list[list[list[list[float]]]]]"
+    reveal_type(validate_array((((1,),),), return_type='list'))        # EXPECTED_TYPE: "Union[int, list[int], list[list[int]], list[list[list[int]]], list[list[list[list[int]]]]]"
+    reveal_type(validate_array((((True,),),), return_type='list'))     # EXPECTED_TYPE: "Union[bool, list[bool], list[list[bool]], list[list[list[bool]]], list[list[list[list[bool]]]]]"
+    reveal_type(validate_array(((((1.0,),),),), return_type='list'))   # EXPECTED_TYPE: "Union[float, list[float], list[list[float]], list[list[list[float]]], list[list[list[list[float]]]]]"
+    reveal_type(validate_array(((((1,),),),), return_type='list'))     # EXPECTED_TYPE: "Union[int, list[int], list[list[int]], list[list[list[int]]], list[list[list[list[int]]]]]"
+    reveal_type(validate_array(((((True,),),),), return_type='list'))  # EXPECTED_TYPE: "Union[bool, list[bool], list[list[bool]], list[list[list[bool]]], list[list[list[list[bool]]]]]"

--- a/tests/core/typing/validation_cases/validate_array_to_list_dtype_out.py
+++ b/tests/core/typing/validation_cases/validate_array_to_list_dtype_out.py
@@ -1,0 +1,45 @@
+# flake8: noqa
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from pyvista.core._validation import validate_array
+
+if TYPE_CHECKING:
+    # scalars
+    reveal_type(validate_array(1.0, return_type='list', dtype_out=int))     # EXPECTED_TYPE: "int"
+    reveal_type(validate_array(1, return_type='list', dtype_out=bool))      # EXPECTED_TYPE: "bool"
+    reveal_type(validate_array(True, return_type='list', dtype_out=float))  # EXPECTED_TYPE: "float"
+
+    # numpy arrays
+    reveal_type(validate_array(np.array(1.0, dtype=float), return_type='list', dtype_out=int))    # EXPECTED_TYPE: "Union[int, list[int], list[list[int]], list[list[list[int]]], list[list[list[list[int]]]]]"
+    reveal_type(validate_array(np.array(1, dtype=int), return_type='list', dtype_out=bool))       # EXPECTED_TYPE: "Union[bool, list[bool], list[list[bool]], list[list[list[bool]]], list[list[list[list[bool]]]]]"
+    reveal_type(validate_array(np.array(True, dtype=bool), return_type='list', dtype_out=float))  # EXPECTED_TYPE: "Union[float, list[float], list[list[float]], list[list[list[float]]], list[list[list[list[float]]]]]"
+
+    # lists
+    reveal_type(validate_array([1.0], return_type='list', dtype_out=int))           # EXPECTED_TYPE: "list[int]"
+    reveal_type(validate_array([1], return_type='list', dtype_out=bool))            # EXPECTED_TYPE: "list[bool]"
+    reveal_type(validate_array([True], return_type='list', dtype_out=float))        # EXPECTED_TYPE: "list[float]"
+    reveal_type(validate_array([[1.0]], return_type='list', dtype_out=int))         # EXPECTED_TYPE: "list[list[int]]"
+    reveal_type(validate_array([[1]], return_type='list', dtype_out=bool))          # EXPECTED_TYPE: "list[list[bool]]"
+    reveal_type(validate_array([[True]], return_type='list', dtype_out=float))      # EXPECTED_TYPE: "list[list[float]]"
+    reveal_type(validate_array([[[1.0]]], return_type='list', dtype_out=int))       # EXPECTED_TYPE: "Union[int, list[int], list[list[int]], list[list[list[int]]], list[list[list[list[int]]]]]"
+    reveal_type(validate_array([[[1]]], return_type='list', dtype_out=bool))        # EXPECTED_TYPE: "Union[bool, list[bool], list[list[bool]], list[list[list[bool]]], list[list[list[list[bool]]]]]"
+    reveal_type(validate_array([[[True]]], return_type='list', dtype_out=float))    # EXPECTED_TYPE: "Union[float, list[float], list[list[float]], list[list[list[float]]], list[list[list[list[float]]]]]"
+    reveal_type(validate_array([[[[1.0]]]], return_type='list', dtype_out=int))     # EXPECTED_TYPE: "Union[int, list[int], list[list[int]], list[list[list[int]]], list[list[list[list[int]]]]]"
+    reveal_type(validate_array([[[[1]]]], return_type='list', dtype_out=bool))      # EXPECTED_TYPE: "Union[bool, list[bool], list[list[bool]], list[list[list[bool]]], list[list[list[list[bool]]]]]"
+    reveal_type(validate_array([[[[True]]]], return_type='list', dtype_out=float))  # EXPECTED_TYPE: "Union[float, list[float], list[list[float]], list[list[list[float]]], list[list[list[list[float]]]]]"
+
+    # tuples
+    reveal_type(validate_array((1.0,), return_type='list', dtype_out=int))              # EXPECTED_TYPE: "list[int]"
+    reveal_type(validate_array((1,), return_type='list', dtype_out=bool))               # EXPECTED_TYPE: "list[bool]"
+    reveal_type(validate_array((True,), return_type='list', dtype_out=float))           # EXPECTED_TYPE: "list[float]"
+    reveal_type(validate_array(((1.0,),), return_type='list', dtype_out=int))           # EXPECTED_TYPE: "list[list[int]]"
+    reveal_type(validate_array(((1,),), return_type='list', dtype_out=bool))            # EXPECTED_TYPE: "list[list[bool]]"
+    reveal_type(validate_array(((True,),), return_type='list', dtype_out=float))        # EXPECTED_TYPE: "list[list[float]]"
+    reveal_type(validate_array((((1.0,),),), return_type='list', dtype_out=int))        # EXPECTED_TYPE: "Union[int, list[int], list[list[int]], list[list[list[int]]], list[list[list[list[int]]]]]"
+    reveal_type(validate_array((((1,),),), return_type='list', dtype_out=bool))         # EXPECTED_TYPE: "Union[bool, list[bool], list[list[bool]], list[list[list[bool]]], list[list[list[list[bool]]]]]"
+    reveal_type(validate_array((((True,),),), return_type='list', dtype_out=float))     # EXPECTED_TYPE: "Union[float, list[float], list[list[float]], list[list[list[float]]], list[list[list[list[float]]]]]"
+    reveal_type(validate_array(((((1.0,),),),), return_type='list', dtype_out=int))     # EXPECTED_TYPE: "Union[int, list[int], list[list[int]], list[list[list[int]]], list[list[list[list[int]]]]]"
+    reveal_type(validate_array(((((1,),),),), return_type='list', dtype_out=bool))      # EXPECTED_TYPE: "Union[bool, list[bool], list[list[bool]], list[list[list[bool]]], list[list[list[list[bool]]]]]"
+    reveal_type(validate_array(((((True,),),),), return_type='list', dtype_out=float))  # EXPECTED_TYPE: "Union[float, list[float], list[list[float]], list[list[list[float]]], list[list[list[list[float]]]]]"

--- a/tests/core/typing/validation_cases/validate_array_to_tuple.py
+++ b/tests/core/typing/validation_cases/validate_array_to_tuple.py
@@ -1,0 +1,45 @@
+# flake8: noqa
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from pyvista.core._validation import validate_array
+
+if TYPE_CHECKING:
+    # scalars
+    reveal_type(validate_array(1.0, return_type='tuple'))   # EXPECTED_TYPE: "float"
+    reveal_type(validate_array(1, return_type='tuple'))     # EXPECTED_TYPE: "int"
+    reveal_type(validate_array(True, return_type='tuple'))  # EXPECTED_TYPE: "bool"
+
+    # numpy arrays
+    reveal_type(validate_array(np.array(1.0, dtype=float), return_type='tuple'))  # EXPECTED_TYPE: "Union[float, tuple[float], tuple[tuple[float]], tuple[tuple[tuple[float]]], tuple[tuple[tuple[tuple[float]]]]]"
+    reveal_type(validate_array(np.array(1, dtype=int), return_type='tuple'))      # EXPECTED_TYPE: "Union[int, tuple[int], tuple[tuple[int]], tuple[tuple[tuple[int]]], tuple[tuple[tuple[tuple[int]]]]]"
+    reveal_type(validate_array(np.array(True, dtype=bool), return_type='tuple'))  # EXPECTED_TYPE: "Union[bool, tuple[bool], tuple[tuple[bool]], tuple[tuple[tuple[bool]]], tuple[tuple[tuple[tuple[bool]]]]]"
+
+    # lists
+    reveal_type(validate_array([1.0], return_type='tuple'))         # EXPECTED_TYPE: "tuple[float]"
+    reveal_type(validate_array([1], return_type='tuple'))           # EXPECTED_TYPE: "tuple[int]"
+    reveal_type(validate_array([True], return_type='tuple'))        # EXPECTED_TYPE: "tuple[bool]"
+    reveal_type(validate_array([[1.0]], return_type='tuple'))       # EXPECTED_TYPE: "tuple[tuple[float]]"
+    reveal_type(validate_array([[1]], return_type='tuple'))         # EXPECTED_TYPE: "tuple[tuple[int]]"
+    reveal_type(validate_array([[True]], return_type='tuple'))      # EXPECTED_TYPE: "tuple[tuple[bool]]"
+    reveal_type(validate_array([[[1.0]]], return_type='tuple'))     # EXPECTED_TYPE: "Union[float, tuple[float], tuple[tuple[float]], tuple[tuple[tuple[float]]], tuple[tuple[tuple[tuple[float]]]]]"
+    reveal_type(validate_array([[[1]]], return_type='tuple'))       # EXPECTED_TYPE: "Union[int, tuple[int], tuple[tuple[int]], tuple[tuple[tuple[int]]], tuple[tuple[tuple[tuple[int]]]]]"
+    reveal_type(validate_array([[[True]]], return_type='tuple'))    # EXPECTED_TYPE: "Union[bool, tuple[bool], tuple[tuple[bool]], tuple[tuple[tuple[bool]]], tuple[tuple[tuple[tuple[bool]]]]]"
+    reveal_type(validate_array([[[[1.0]]]], return_type='tuple'))   # EXPECTED_TYPE: "Union[float, tuple[float], tuple[tuple[float]], tuple[tuple[tuple[float]]], tuple[tuple[tuple[tuple[float]]]]]"
+    reveal_type(validate_array([[[[1]]]], return_type='tuple'))     # EXPECTED_TYPE: "Union[int, tuple[int], tuple[tuple[int]], tuple[tuple[tuple[int]]], tuple[tuple[tuple[tuple[int]]]]]"
+    reveal_type(validate_array([[[[True]]]], return_type='tuple'))  # EXPECTED_TYPE: "Union[bool, tuple[bool], tuple[tuple[bool]], tuple[tuple[tuple[bool]]], tuple[tuple[tuple[tuple[bool]]]]]"
+
+    # tuples
+    reveal_type(validate_array((1.0,), return_type='tuple'))            # EXPECTED_TYPE: "tuple[float]"
+    reveal_type(validate_array((1,), return_type='tuple'))              # EXPECTED_TYPE: "tuple[int]"
+    reveal_type(validate_array((True,), return_type='tuple'))           # EXPECTED_TYPE: "tuple[bool]"
+    reveal_type(validate_array(((1.0,),), return_type='tuple'))         # EXPECTED_TYPE: "tuple[tuple[float]]"
+    reveal_type(validate_array(((1,),), return_type='tuple'))           # EXPECTED_TYPE: "tuple[tuple[int]]"
+    reveal_type(validate_array(((True,),), return_type='tuple'))        # EXPECTED_TYPE: "tuple[tuple[bool]]"
+    reveal_type(validate_array((((1.0,),),), return_type='tuple'))      # EXPECTED_TYPE: "Union[float, tuple[float], tuple[tuple[float]], tuple[tuple[tuple[float]]], tuple[tuple[tuple[tuple[float]]]]]"
+    reveal_type(validate_array((((1,),),), return_type='tuple'))        # EXPECTED_TYPE: "Union[int, tuple[int], tuple[tuple[int]], tuple[tuple[tuple[int]]], tuple[tuple[tuple[tuple[int]]]]]"
+    reveal_type(validate_array((((True,),),), return_type='tuple'))     # EXPECTED_TYPE: "Union[bool, tuple[bool], tuple[tuple[bool]], tuple[tuple[tuple[bool]]], tuple[tuple[tuple[tuple[bool]]]]]"
+    reveal_type(validate_array(((((1.0,),),),), return_type='tuple'))   # EXPECTED_TYPE: "Union[float, tuple[float], tuple[tuple[float]], tuple[tuple[tuple[float]]], tuple[tuple[tuple[tuple[float]]]]]"
+    reveal_type(validate_array(((((1,),),),), return_type='tuple'))     # EXPECTED_TYPE: "Union[int, tuple[int], tuple[tuple[int]], tuple[tuple[tuple[int]]], tuple[tuple[tuple[tuple[int]]]]]"
+    reveal_type(validate_array(((((True,),),),), return_type='tuple'))  # EXPECTED_TYPE: "Union[bool, tuple[bool], tuple[tuple[bool]], tuple[tuple[tuple[bool]]], tuple[tuple[tuple[tuple[bool]]]]]"

--- a/tests/core/typing/validation_cases/validate_array_to_tuple_dtype_out.py
+++ b/tests/core/typing/validation_cases/validate_array_to_tuple_dtype_out.py
@@ -1,0 +1,45 @@
+# flake8: noqa
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from pyvista.core._validation import validate_array
+
+if TYPE_CHECKING:
+    # scalars
+    reveal_type(validate_array(1.0, return_type='tuple', dtype_out=int))     # EXPECTED_TYPE: "int"
+    reveal_type(validate_array(1, return_type='tuple', dtype_out=bool))      # EXPECTED_TYPE: "bool"
+    reveal_type(validate_array(True, return_type='tuple', dtype_out=float))  # EXPECTED_TYPE: "float"
+
+    # numpy arrays
+    reveal_type(validate_array(np.array(1.0, dtype=float), return_type='tuple', dtype_out=int))    # EXPECTED_TYPE: "Union[int, tuple[int], tuple[tuple[int]], tuple[tuple[tuple[int]]], tuple[tuple[tuple[tuple[int]]]]]"
+    reveal_type(validate_array(np.array(1, dtype=int), return_type='tuple', dtype_out=bool))       # EXPECTED_TYPE: "Union[bool, tuple[bool], tuple[tuple[bool]], tuple[tuple[tuple[bool]]], tuple[tuple[tuple[tuple[bool]]]]]"
+    reveal_type(validate_array(np.array(True, dtype=bool), return_type='tuple', dtype_out=float))  # EXPECTED_TYPE: "Union[float, tuple[float], tuple[tuple[float]], tuple[tuple[tuple[float]]], tuple[tuple[tuple[tuple[float]]]]]"
+
+    # lists
+    reveal_type(validate_array([1.0], return_type='tuple', dtype_out=int))           # EXPECTED_TYPE: "tuple[int]"
+    reveal_type(validate_array([1], return_type='tuple', dtype_out=bool))            # EXPECTED_TYPE: "tuple[bool]"
+    reveal_type(validate_array([True], return_type='tuple', dtype_out=float))        # EXPECTED_TYPE: "tuple[float]"
+    reveal_type(validate_array([[1.0]], return_type='tuple', dtype_out=int))         # EXPECTED_TYPE: "tuple[tuple[int]]"
+    reveal_type(validate_array([[1]], return_type='tuple', dtype_out=bool))          # EXPECTED_TYPE: "tuple[tuple[bool]]"
+    reveal_type(validate_array([[True]], return_type='tuple', dtype_out=float))      # EXPECTED_TYPE: "tuple[tuple[float]]"
+    reveal_type(validate_array([[[1.0]]], return_type='tuple', dtype_out=int))       # EXPECTED_TYPE: "Union[int, tuple[int], tuple[tuple[int]], tuple[tuple[tuple[int]]], tuple[tuple[tuple[tuple[int]]]]]"
+    reveal_type(validate_array([[[1]]], return_type='tuple', dtype_out=bool))        # EXPECTED_TYPE: "Union[bool, tuple[bool], tuple[tuple[bool]], tuple[tuple[tuple[bool]]], tuple[tuple[tuple[tuple[bool]]]]]"
+    reveal_type(validate_array([[[True]]], return_type='tuple', dtype_out=float))    # EXPECTED_TYPE: "Union[float, tuple[float], tuple[tuple[float]], tuple[tuple[tuple[float]]], tuple[tuple[tuple[tuple[float]]]]]"
+    reveal_type(validate_array([[[[1.0]]]], return_type='tuple', dtype_out=int))     # EXPECTED_TYPE: "Union[int, tuple[int], tuple[tuple[int]], tuple[tuple[tuple[int]]], tuple[tuple[tuple[tuple[int]]]]]"
+    reveal_type(validate_array([[[[1]]]], return_type='tuple', dtype_out=bool))      # EXPECTED_TYPE: "Union[bool, tuple[bool], tuple[tuple[bool]], tuple[tuple[tuple[bool]]], tuple[tuple[tuple[tuple[bool]]]]]"
+    reveal_type(validate_array([[[[True]]]], return_type='tuple', dtype_out=float))  # EXPECTED_TYPE: "Union[float, tuple[float], tuple[tuple[float]], tuple[tuple[tuple[float]]], tuple[tuple[tuple[tuple[float]]]]]"
+
+    # tuples
+    reveal_type(validate_array((1.0,), return_type='tuple', dtype_out=int))              # EXPECTED_TYPE: "tuple[int]"
+    reveal_type(validate_array((1,), return_type='tuple', dtype_out=bool))               # EXPECTED_TYPE: "tuple[bool]"
+    reveal_type(validate_array((True,), return_type='tuple', dtype_out=float))           # EXPECTED_TYPE: "tuple[float]"
+    reveal_type(validate_array(((1.0,),), return_type='tuple', dtype_out=int))           # EXPECTED_TYPE: "tuple[tuple[int]]"
+    reveal_type(validate_array(((1,),), return_type='tuple', dtype_out=bool))            # EXPECTED_TYPE: "tuple[tuple[bool]]"
+    reveal_type(validate_array(((True,),), return_type='tuple', dtype_out=float))        # EXPECTED_TYPE: "tuple[tuple[float]]"
+    reveal_type(validate_array((((1.0,),),), return_type='tuple', dtype_out=int))        # EXPECTED_TYPE: "Union[int, tuple[int], tuple[tuple[int]], tuple[tuple[tuple[int]]], tuple[tuple[tuple[tuple[int]]]]]"
+    reveal_type(validate_array((((1,),),), return_type='tuple', dtype_out=bool))         # EXPECTED_TYPE: "Union[bool, tuple[bool], tuple[tuple[bool]], tuple[tuple[tuple[bool]]], tuple[tuple[tuple[tuple[bool]]]]]"
+    reveal_type(validate_array((((True,),),), return_type='tuple', dtype_out=float))     # EXPECTED_TYPE: "Union[float, tuple[float], tuple[tuple[float]], tuple[tuple[tuple[float]]], tuple[tuple[tuple[tuple[float]]]]]"
+    reveal_type(validate_array(((((1.0,),),),), return_type='tuple', dtype_out=int))     # EXPECTED_TYPE: "Union[int, tuple[int], tuple[tuple[int]], tuple[tuple[tuple[int]]], tuple[tuple[tuple[tuple[int]]]]]"
+    reveal_type(validate_array(((((1,),),),), return_type='tuple', dtype_out=bool))      # EXPECTED_TYPE: "Union[bool, tuple[bool], tuple[tuple[bool]], tuple[tuple[tuple[bool]]], tuple[tuple[tuple[tuple[bool]]]]]"
+    reveal_type(validate_array(((((True,),),),), return_type='tuple', dtype_out=float))  # EXPECTED_TYPE: "Union[float, tuple[float], tuple[tuple[float]], tuple[tuple[tuple[float]]], tuple[tuple[tuple[tuple[float]]]]]"

--- a/tests/core/typing/validation_cases/validate_number.py
+++ b/tests/core/typing/validation_cases/validate_number.py
@@ -1,0 +1,31 @@
+# flake8: noqa
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from pyvista.core._validation import validate_number
+
+if TYPE_CHECKING:
+    reveal_type(validate_number(1.0))   # EXPECTED_TYPE: "float"
+    reveal_type(validate_number(1))     # EXPECTED_TYPE: "int"
+    # reveal_type(validate_number(True))  # EXPECTED_TYPE: "bool"
+
+    reveal_type(validate_number(np.array(1.0, dtype=float)))  # EXPECTED_TYPE: "float"
+    reveal_type(validate_number(np.array(1, dtype=int)))      # EXPECTED_TYPE: "int"
+    # reveal_type(validate_number(np.array(True, dtype=bool)))  # EXPECTED_TYPE: "bool"
+
+    reveal_type(validate_number([1.0]))   # EXPECTED_TYPE: "float"
+    reveal_type(validate_number(1))       # EXPECTED_TYPE: "int"
+    # reveal_type(validate_number([True]))  # EXPECTED_TYPE: "bool"
+
+    reveal_type(validate_number(1.0, dtype_out=int))     # EXPECTED_TYPE: "int"
+    reveal_type(validate_number(1, dtype_out=bool))      # EXPECTED_TYPE: "bool"
+    # reveal_type(validate_number(True, dtype_out=float))  # EXPECTED_TYPE: "float"
+
+    reveal_type(validate_number(np.array(1.0), dtype_out=int))     # EXPECTED_TYPE: "int"
+    reveal_type(validate_number(np.array(1), dtype_out=bool))      # EXPECTED_TYPE: "bool"
+    # reveal_type(validate_number(np.array(True), dtype_out=float))  # EXPECTED_TYPE: "float"
+
+    reveal_type(validate_number([1.0], dtype_out=int))     # EXPECTED_TYPE: "int"
+    reveal_type(validate_number((1), dtype_out=bool))      # EXPECTED_TYPE: "bool"
+    # reveal_type(validate_number([True], dtype_out=float))  # EXPECTED_TYPE: "float"


### PR DESCRIPTION
### Overview

#5571 has lots of unmerged changes but has become a bit of a mess. I've patched those changes here and merged them with main and will track everything here instead. I've also decided to remove the `ArrayWrapper` class. Everything will return an `ndarray` now by default (i.e. no more generic `T` -> `T` mappings).