### PR TITLE
Define convention of pydocstyle explicitly for NumPy-style

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -418,3 +418,6 @@ force-single-line = true
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.
 keep-runtime-typing = true
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Define convention of pydocstyle explicitly for NumPy-style.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- [convention](https://docs.astral.sh/ruff/settings/#lint_pydocstyle_convention)