### PR TITLE
Update `macOS` testing strategy to run on latest `arm` architecture

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -21,21 +21,22 @@ env:
 
 jobs:
   macOS:
-    # https://github.com/pyvista/pyvista/pull/5960
-    runs-on: macos-12
     name: Mac OS Unit Testing
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.11"]
+        config:
+          - { os: macos-12, python-version: 3.9 }  # intel processor
+          - { os: macos-latest, python-version: 3.12 }  # arm processor
+    runs-on: ${{ matrix.config.os }}
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.config.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.config.python-version }}
           cache: "pip"
 
       - name: Install PyVista test dependencies

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -1,4 +1,4 @@
-name: Integration Tests
+name: Unit Testing and Deployment
 
 on:
   pull_request:
@@ -20,108 +20,294 @@ env:
   SHELLOPTS: "errexit:pipefail"
 
 jobs:
-  # For now this is just MNE-Python, but others could be added
-  mne:
-    name: MNE-Python
-    runs-on: ubuntu-22.04
-    env:
-      DISPLAY: ":99.0"
-      MNE_LOGGING_LEVEL: "info"
+  macOS:
+    name: Mac OS Unit Testing
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { os: macos-12, python-version: 3.9 } # intel processor
+          - { os: macos-latest, python-version: 3.12 } # arm processor
+    runs-on: ${{ matrix.config.os }}
+
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+
+      - name: Set up Python ${{ matrix.config.python-version }}
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
-      - run: git clone --depth=1 https://github.com/mne-tools/mne-python.git --branch main --single-branch
-      - run: ./mne-python/tools/setup_xvfb.sh
-      - name: Install MNE dependencies
-        run: pip install numpy scipy matplotlib nibabel "PyQt6-Qt6!=6.6.0,!=6.7.0" "PyQt6!=6.6.0" qtpy ipympl pytest pytest-cov pytest-harvest pytest-timeout sphinx-gallery nbformat nbclient imageio imageio-ffmpeg
-      - name: Install PyVista
-        run: pip install -ve . # pyvista
-      - name: Install PyVistaQt main
-        run: pip install -v git+https://github.com/pyvista/pyvistaqt.git
-      - name: Install MNE
-        run: pip install -ve . # mne
-        working-directory: mne-python
-      - name: MNE Info
-        run: mne sys_info -p
-        working-directory: mne-python
-      - run: ./tools/get_testing_version.sh
-        working-directory: mne-python
+          python-version: ${{ matrix.config.python-version }}
+          cache: "pip"
+
+      - name: Install PyVista test dependencies
+        run: pip install .[test]
+
+      - name: Report
+        run: python -c "import pyvista;print(pyvista.Report(gpu=False));from pyvista import examples;print('User data path:', examples.USER_DATA_PATH)"
+
+      - name: Test Core API
+        run: pytest -v --ignore=tests/plotting
+
+      - name: Test Plotting
+        run: pytest -v tests/plotting --fail_extra_image_cache --generated_image_dir debug_images
+
+      - name: Upload Generated Images
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug_images-${{ github.job }}-${{ join(matrix.config.* , '-') }}
+          path: debug_images
+
+  LinuxConda:
+    runs-on: ubuntu-20.04
+    if: false
+    env:
+      CONDA_ALWAYS_YES: 1
+      conda_env: pyvista-vtk
+      DISPLAY: ":99.0"
+      PYVISTA_OFF_SCREEN: True
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up headless display
+        uses: pyvista/setup-headless-display-action@v2
+
+      - name: Cache Conda Packages
+        uses: actions/cache@v4
+        with:
+          path: ~/anaconda3/pkgs
+          key: Conda-${{ runner.os }}-${{ hashFiles('environment.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-conda-
+
       - uses: actions/cache@v4
         with:
-          key: ${{ env.TESTING_VERSION }}
-          path: ~/mne_data
-      - run: ./tools/github_actions_download.sh
-        working-directory: mne-python
-      - run: pytest mne/viz/_brain mne/viz/tests/test_3d.py mne/viz/backends
-        working-directory: mne-python
+          path: ~/.local/share/pyvista/examples
+          key: Examples-1-${{ hashFiles('*') }}
+          restore-keys: |
+            Examples-1-
 
-  pyvistaqt:
-    name: PyVistaQt
-    runs-on: ubuntu-22.04
+      # See: https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community
+      - name: Install mamba
+        run: |
+          source /usr/share/miniconda/etc/profile.d/conda.sh
+          conda config --set channel_priority strict
+          conda update -n base conda
+          conda install -n base conda-libmamba-solver
+
+      - name: "Workaround for mamba-org/mamba#488"
+        run: rm /usr/share/miniconda/pkgs/cache/*.json
+
+      - name: Create Anaconda environment
+        run: |
+          source /usr/share/miniconda/etc/profile.d/conda.sh
+          conda config --add channels conda-forge
+          conda env create --quiet -n ${{ env.conda_env }} --file environment.yml --experimental-solver=libmamba
+          conda activate ${{ env.conda_env }}
+          conda list
+
+      - name: Install PyVista
+        run: |
+          source /usr/share/miniconda/etc/profile.d/conda.sh
+          conda activate ${{ env.conda_env }}
+          pip install -e .
+          which python
+          python -c "import pyvista; print(pyvista.Report(gpu=False))"
+          python -c "from pyvista import examples; print(examples.USER_DATA_PATH)"
+
+      - name: Test Core API
+        run: |
+          source /usr/share/miniconda/etc/profile.d/conda.sh
+          conda activate ${{ env.conda_env }}
+          pip install .[test]
+          pytest -v --ignore=tests/plotting
+
+      - name: Test Core Plotting
+        run: |
+          source /usr/share/miniconda/etc/profile.d/conda.sh
+          conda activate ${{ env.conda_env }}
+          pytest -v tests/plotting --cov-report html --fail_extra_image_cache --generated_image_dir debug_images
+
+      - name: Upload Generated Images
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}
+          path: debug_images
+
+  Linux:
+    name: Linux Unit Testing
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+
+      # see discussion at https://github.com/pyvista/pyvista/issues/2867
+      matrix:
+        include:
+          # numeric numpy versions are ~= conditions, e.g. "1.23" means "numpy~=1.23.0"
+          - python-version: "3.9"
+            vtk-version: "9.0.3" # Requires numpy~=1.23
+            numpy-version: "1.23"
+          - python-version: "3.9"
+            vtk-version: "9.1"
+            numpy-version: "1.26" # Test numpy 1.26
+          - python-version: "3.10"
+            vtk-version: "9.2.2"
+            numpy-version: "latest"
+          - python-version: "3.11"
+            vtk-version: "9.2.6"
+            numpy-version: "latest"
+          - python-version: "3.12"
+            vtk-version: "latest"
+            numpy-version: "latest"
+          - python-version: "3.12"
+            vtk-version: "latest"
+            numpy-version: "nightly"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
-      - run: git clone https://github.com/pyvista/pyvistaqt.git --single-branch
-      - uses: pyvista/setup-headless-display-action@main
-        with:
-          qt: true
-          pyvista: false
-      - run: pip install -ve ./pyvistaqt -r ./pyvistaqt/requirements_test.txt "PyQt6-Qt6!=6.6.0,!=6.7.0" "PyQt6!=6.6.0"
-      - run: pip install -ve .
-      - run: pytest ./tests
-        working-directory: pyvistaqt
+          fetch-depth: 2
 
-  geovista:
-    name: GeoVista
-    runs-on: ubuntu-22.04
-    defaults:
-      run:
-        shell: bash -l {0}
-    env:
-      CARTOPY_SHARE_DIR: ~/.local/share/cartopy
-      GEOVISTA_POOCH_MUTE: true
-    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.local/share/pyvista/examples
+          key: Examples-1-${{ hashFiles('*') }}
+          restore-keys: |
+            Examples-1-
+
+      - name: Build wheel and install pyvista
+        run: |
+          pip install build
+          python -m build --wheel
+          pip install dist/pyvista*.whl
+
+      - name: Set up vtk
+        if: ${{ matrix.vtk-version != 'latest' }}
+        run: pip install vtk==${{ matrix.vtk-version }}
+
+      # Make sure PyVista does not break from non-core dependencies
+      - name: Software Report (Core Dependencies)
+        run: python -c "import pyvista; print(pyvista.Report());"
+
+      - name: Install Testing Requirements
+        run: pip install .[test]
+
+      - name: Set up numpy
+        if: ${{ matrix.numpy-version != 'latest' && matrix.numpy-version != 'nightly' }}
+        run: pip install 'numpy~=${{ matrix.numpy-version }}.0'
+
+      - name: Limit Matplotlib for VTK<9.2.2
+        if: ${{ matrix.vtk-version == '9.1' || matrix.vtk-version == '9.0.3' }}
+        run: pip install 'matplotlib<3.6'
+
+      - name: Install latest numpy 2.0 beta/rc
+        if: ${{ matrix.numpy-version == 'nightly' }}
+        run: |
+          pip uninstall numpy matplotlib -y
+          pip install --pre --no-deps -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib
+          pip install --pre --no-deps -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+
+      - name: Core Testing (no GL)
+        run: python -m pytest --cov=pyvista -v tests/core tests/examples
+
       - uses: awalsh128/cache-apt-pkgs-action@v1.1.3
         with:
           packages: libgl1-mesa-glx xvfb
           version: 3.0
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - run: git clone https://github.com/bjlittle/geovista.git --single-branch
-      - name: Install PyVista
-        run: pip install -ve . # pyvista
-      - name: Install GeoVista
-        run: pip install -ve .[test,exam,cmap] # geovista
-        working-directory: geovista
-      - name: Download cartopy assets
-        run: |
-          mkdir -p ${CARTOPY_SHARE_DIR}
-          python -m cartopy.feature.download physical --output ${CARTOPY_SHARE_DIR} --no-warn
-      - run: pytest
-        working-directory: geovista
 
-  trame:
-    name: Trame
-    runs-on: ubuntu-22.04
-    defaults:
-      run:
-        shell: bash -l {0}
+      - name: Plotting Testing (uses GL)
+        run: xvfb-run -a python -m pytest --cov=pyvista --cov-append --cov-report=xml --fail_extra_image_cache -v --ignore=tests/core --ignore=tests/examples --generated_image_dir debug_images
+
+      - name: Upload Generated Images
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug_images-${{ github.job }}-${{ join(matrix.* , '-') }}
+          path: debug_images
+
+      - name: Software Report
+        if: always()
+        run: |
+          xvfb-run -a python -c "import pyvista; print(pyvista.Report()); from pyvista import examples; print('User data path:', examples.USER_DATA_PATH)"
+          which python
+          pip list
+
+      - uses: codecov/codecov-action@v4
+        name: "Upload coverage to CodeCov"
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Check package
+        run: |
+          pip install build twine
+          python -m build
+          twine check --strict dist/*
+
+      - name: Upload to PyPi
+        if: matrix.python-version == '3.9' && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          twine upload --skip-existing dist/pyvista*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+          TWINE_REPOSITORY_URL: "https://upload.pypi.org/legacy/"
+
+  windows:
+    name: Windows Unit Testing
+    runs-on: windows-latest
+    env:
+      CI_WINDOWS: true
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
-      - name: Install PyVista
-        run: pip install -ve .[test]
-      - name: Install requirements
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+
+      - name: Set up headless display
+        uses: pyvista/setup-headless-display-action@v2
+
+      - name: Install PyVista test dependencies
+        run: pip install .[test]
+
+      - name: Report
+        run: python -c "import pyvista; print(pyvista.Report(gpu=False)); from pyvista import examples; print('User data path:', examples.USER_DATA_PATH)"
+
+      - name: Set example data path as env variable
         run: |
-          pip install -r examples_trame/requirements.txt
-      - name: Run examples
-        working-directory: examples_trame
-        run: pytest -v ./tests
+          chcp 65001 #set code page to utf-8
+          echo ("PYVISTA_EXAMPLE_DATA_PATH=" + $(python -c "import pyvista; from pyvista import examples; print(examples.USER_DATA_PATH)")) >> $env:GITHUB_ENV
+
+      - name: Cache example data
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.PYVISTA_EXAMPLE_DATA_PATH }}
+          key: Examples-1-${{ hashFiles('*') }}
+          restore-keys: |
+            Examples-1-
+
+      - name: Test Core API
+        run: python -m pytest -v --ignore=tests/plotting
+
+      - name: Test Plotting
+        run: python -m pytest -v tests/plotting --fail_extra_image_cache --generated_image_dir debug_images
+
+      - name: Upload Generated Images
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug_images-${{ github.job }}-${{ join(matrix.* , '-') }}
+          path: debug_images

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -55,8 +55,9 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: debug_images-${{ github.job }}-${{ join(matrix.* , '-') }}
+          name: debug_images-${{ github.job }}-${{ join(matrix.config.* , '-') }}
           path: debug_images
+
 
   LinuxConda:
     runs-on: ubuntu-20.04

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -26,8 +26,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: macos-12, python-version: 3.9 }  # intel processor
-          - { os: macos-latest, python-version: 3.12 }  # arm processor
+          - { os: macos-12, python-version: 3.9 } # intel processor
+          - { os: macos-latest, python-version: 3.12 } # arm processor
     runs-on: ${{ matrix.config.os }}
 
     steps:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -26,10 +26,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: macos-12, python-version: 3.9 } # intel processor
-          - { os: macos-13, python-version: 3.10 } # intel processor
-          - { os: macos-14, python-version: 3.11 } # arm processor
-          - { os: macos-latest, python-version: 3.12 } # arm processor
+          - { os: macos-12, python-version: '3.9' } # intel processor
+          - { os: macos-13, python-version: '3.10' } # intel processor
+          - { os: macos-14, python-version: '3.11' } # arm processor
+          - { os: macos-latest, python-version: '3.12' } # arm processor
     runs-on: ${{ matrix.config.os }}
 
     steps:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -27,6 +27,8 @@ jobs:
       matrix:
         config:
           - { os: macos-12, python-version: 3.9 } # intel processor
+          - { os: macos-13, python-version: 3.10 } # intel processor
+          - { os: macos-14, python-version: 3.11 } # arm processor
           - { os: macos-latest, python-version: 3.12 } # arm processor
     runs-on: ${{ matrix.config.os }}
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -26,10 +26,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: macos-12, python-version: '3.9' } # intel processor
-          - { os: macos-13, python-version: '3.10' } # intel processor
-          - { os: macos-14, python-version: '3.11' } # arm processor
-          - { os: macos-latest, python-version: '3.12' } # arm processor
+          - { os: macos-12, python-version: "3.9" } # intel processor
+          - { os: macos-13, python-version: "3.10" } # intel processor
+          - { os: macos-14, python-version: "3.11" } # arm processor
+          - { os: macos-latest, python-version: "3.12" } # arm processor
     runs-on: ${{ matrix.config.os }}
 
     steps:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -1,4 +1,4 @@
-name: Unit Testing and Deployment
+name: Integration Tests
 
 on:
   pull_request:
@@ -20,295 +20,108 @@ env:
   SHELLOPTS: "errexit:pipefail"
 
 jobs:
-  macOS:
-    name: Mac OS Unit Testing
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - { os: macos-12, python-version: 3.9 } # intel processor
-          - { os: macos-latest, python-version: 3.12 } # arm processor
-    runs-on: ${{ matrix.config.os }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.config.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.config.python-version }}
-          cache: "pip"
-
-      - name: Install PyVista test dependencies
-        run: pip install .[test]
-
-      - name: Report
-        run: python -c "import pyvista;print(pyvista.Report(gpu=False));from pyvista import examples;print('User data path:', examples.USER_DATA_PATH)"
-
-      - name: Test Core API
-        run: pytest -v --ignore=tests/plotting
-
-      - name: Test Plotting
-        run: pytest -v tests/plotting --fail_extra_image_cache --generated_image_dir debug_images
-
-      - name: Upload Generated Images
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: debug_images-${{ github.job }}-${{ join(matrix.config.* , '-') }}
-          path: debug_images
-
-
-  LinuxConda:
-    runs-on: ubuntu-20.04
-    if: false
+  # For now this is just MNE-Python, but others could be added
+  mne:
+    name: MNE-Python
+    runs-on: ubuntu-22.04
     env:
-      CONDA_ALWAYS_YES: 1
-      conda_env: pyvista-vtk
       DISPLAY: ":99.0"
-      PYVISTA_OFF_SCREEN: True
-
+      MNE_LOGGING_LEVEL: "info"
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up headless display
-        uses: pyvista/setup-headless-display-action@v2
-
-      - name: Cache Conda Packages
-        uses: actions/cache@v4
+      - uses: actions/setup-python@v5
         with:
-          path: ~/anaconda3/pkgs
-          key: Conda-${{ runner.os }}-${{ hashFiles('environment.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-conda-
-
-      - uses: actions/cache@v4
-        with:
-          path: ~/.local/share/pyvista/examples
-          key: Examples-1-${{ hashFiles('*') }}
-          restore-keys: |
-            Examples-1-
-
-      # See: https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community
-      - name: Install mamba
-        run: |
-          source /usr/share/miniconda/etc/profile.d/conda.sh
-          conda config --set channel_priority strict
-          conda update -n base conda
-          conda install -n base conda-libmamba-solver
-
-      - name: "Workaround for mamba-org/mamba#488"
-        run: rm /usr/share/miniconda/pkgs/cache/*.json
-
-      - name: Create Anaconda environment
-        run: |
-          source /usr/share/miniconda/etc/profile.d/conda.sh
-          conda config --add channels conda-forge
-          conda env create --quiet -n ${{ env.conda_env }} --file environment.yml --experimental-solver=libmamba
-          conda activate ${{ env.conda_env }}
-          conda list
-
+          python-version: "3.12"
+      - run: git clone --depth=1 https://github.com/mne-tools/mne-python.git --branch main --single-branch
+      - run: ./mne-python/tools/setup_xvfb.sh
+      - name: Install MNE dependencies
+        run: pip install numpy scipy matplotlib nibabel "PyQt6-Qt6!=6.6.0,!=6.7.0" "PyQt6!=6.6.0" qtpy ipympl pytest pytest-cov pytest-harvest pytest-timeout sphinx-gallery nbformat nbclient imageio imageio-ffmpeg
       - name: Install PyVista
-        run: |
-          source /usr/share/miniconda/etc/profile.d/conda.sh
-          conda activate ${{ env.conda_env }}
-          pip install -e .
-          which python
-          python -c "import pyvista; print(pyvista.Report(gpu=False))"
-          python -c "from pyvista import examples; print(examples.USER_DATA_PATH)"
-
-      - name: Test Core API
-        run: |
-          source /usr/share/miniconda/etc/profile.d/conda.sh
-          conda activate ${{ env.conda_env }}
-          pip install .[test]
-          pytest -v --ignore=tests/plotting
-
-      - name: Test Core Plotting
-        run: |
-          source /usr/share/miniconda/etc/profile.d/conda.sh
-          conda activate ${{ env.conda_env }}
-          pytest -v tests/plotting --cov-report html --fail_extra_image_cache --generated_image_dir debug_images
-
-      - name: Upload Generated Images
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.job }}
-          path: debug_images
-
-  Linux:
-    name: Linux Unit Testing
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-
-      # see discussion at https://github.com/pyvista/pyvista/issues/2867
-      matrix:
-        include:
-          # numeric numpy versions are ~= conditions, e.g. "1.23" means "numpy~=1.23.0"
-          - python-version: "3.9"
-            vtk-version: "9.0.3" # Requires numpy~=1.23
-            numpy-version: "1.23"
-          - python-version: "3.9"
-            vtk-version: "9.1"
-            numpy-version: "1.26" # Test numpy 1.26
-          - python-version: "3.10"
-            vtk-version: "9.2.2"
-            numpy-version: "latest"
-          - python-version: "3.11"
-            vtk-version: "9.2.6"
-            numpy-version: "latest"
-          - python-version: "3.12"
-            vtk-version: "latest"
-            numpy-version: "latest"
-          - python-version: "3.12"
-            vtk-version: "latest"
-            numpy-version: "nightly"
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-
+        run: pip install -ve . # pyvista
+      - name: Install PyVistaQt main
+        run: pip install -v git+https://github.com/pyvista/pyvistaqt.git
+      - name: Install MNE
+        run: pip install -ve . # mne
+        working-directory: mne-python
+      - name: MNE Info
+        run: mne sys_info -p
+        working-directory: mne-python
+      - run: ./tools/get_testing_version.sh
+        working-directory: mne-python
       - uses: actions/cache@v4
         with:
-          path: ~/.local/share/pyvista/examples
-          key: Examples-1-${{ hashFiles('*') }}
-          restore-keys: |
-            Examples-1-
+          key: ${{ env.TESTING_VERSION }}
+          path: ~/mne_data
+      - run: ./tools/github_actions_download.sh
+        working-directory: mne-python
+      - run: pytest mne/viz/_brain mne/viz/tests/test_3d.py mne/viz/backends
+        working-directory: mne-python
 
-      - name: Build wheel and install pyvista
-        run: |
-          pip install build
-          python -m build --wheel
-          pip install dist/pyvista*.whl
+  pyvistaqt:
+    name: PyVistaQt
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: git clone https://github.com/pyvista/pyvistaqt.git --single-branch
+      - uses: pyvista/setup-headless-display-action@main
+        with:
+          qt: true
+          pyvista: false
+      - run: pip install -ve ./pyvistaqt -r ./pyvistaqt/requirements_test.txt "PyQt6-Qt6!=6.6.0,!=6.7.0" "PyQt6!=6.6.0"
+      - run: pip install -ve .
+      - run: pytest ./tests
+        working-directory: pyvistaqt
 
-      - name: Set up vtk
-        if: ${{ matrix.vtk-version != 'latest' }}
-        run: pip install vtk==${{ matrix.vtk-version }}
-
-      # Make sure PyVista does not break from non-core dependencies
-      - name: Software Report (Core Dependencies)
-        run: python -c "import pyvista; print(pyvista.Report());"
-
-      - name: Install Testing Requirements
-        run: pip install .[test]
-
-      - name: Set up numpy
-        if: ${{ matrix.numpy-version != 'latest' && matrix.numpy-version != 'nightly' }}
-        run: pip install 'numpy~=${{ matrix.numpy-version }}.0'
-
-      - name: Limit Matplotlib for VTK<9.2.2
-        if: ${{ matrix.vtk-version == '9.1' || matrix.vtk-version == '9.0.3' }}
-        run: pip install 'matplotlib<3.6'
-
-      - name: Install latest numpy 2.0 beta/rc
-        if: ${{ matrix.numpy-version == 'nightly' }}
-        run: |
-          pip uninstall numpy matplotlib -y
-          pip install --pre --no-deps -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib
-          pip install --pre --no-deps -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-
-      - name: Core Testing (no GL)
-        run: python -m pytest --cov=pyvista -v tests/core tests/examples
-
+  geovista:
+    name: GeoVista
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash -l {0}
+    env:
+      CARTOPY_SHARE_DIR: ~/.local/share/cartopy
+      GEOVISTA_POOCH_MUTE: true
+    steps:
       - uses: awalsh128/cache-apt-pkgs-action@v1.1.3
         with:
           packages: libgl1-mesa-glx xvfb
           version: 3.0
-
-      - name: Plotting Testing (uses GL)
-        run: xvfb-run -a python -m pytest --cov=pyvista --cov-append --cov-report=xml --fail_extra_image_cache -v --ignore=tests/core --ignore=tests/examples --generated_image_dir debug_images
-
-      - name: Upload Generated Images
-        if: always()
-        uses: actions/upload-artifact@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          name: debug_images-${{ github.job }}-${{ join(matrix.* , '-') }}
-          path: debug_images
-
-      - name: Software Report
-        if: always()
+          python-version: "3.12"
+      - run: git clone https://github.com/bjlittle/geovista.git --single-branch
+      - name: Install PyVista
+        run: pip install -ve . # pyvista
+      - name: Install GeoVista
+        run: pip install -ve .[test,exam,cmap] # geovista
+        working-directory: geovista
+      - name: Download cartopy assets
         run: |
-          xvfb-run -a python -c "import pyvista; print(pyvista.Report()); from pyvista import examples; print('User data path:', examples.USER_DATA_PATH)"
-          which python
-          pip list
+          mkdir -p ${CARTOPY_SHARE_DIR}
+          python -m cartopy.feature.download physical --output ${CARTOPY_SHARE_DIR} --no-warn
+      - run: pytest
+        working-directory: geovista
 
-      - uses: codecov/codecov-action@v4
-        name: "Upload coverage to CodeCov"
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Check package
-        run: |
-          pip install build twine
-          python -m build
-          twine check --strict dist/*
-
-      - name: Upload to PyPi
-        if: matrix.python-version == '3.9' && startsWith(github.ref, 'refs/tags/v')
-        run: |
-          twine upload --skip-existing dist/pyvista*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-          TWINE_REPOSITORY_URL: "https://upload.pypi.org/legacy/"
-
-  windows:
-    name: Windows Unit Testing
-    runs-on: windows-latest
-    env:
-      CI_WINDOWS: true
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+  trame:
+    name: Trame
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-
-      - name: Set up headless display
-        uses: pyvista/setup-headless-display-action@v2
-
-      - name: Install PyVista test dependencies
-        run: pip install .[test]
-
-      - name: Report
-        run: python -c "import pyvista; print(pyvista.Report(gpu=False)); from pyvista import examples; print('User data path:', examples.USER_DATA_PATH)"
-
-      - name: Set example data path as env variable
+          python-version: "3.12"
+      - name: Install PyVista
+        run: pip install -ve .[test]
+      - name: Install requirements
         run: |
-          chcp 65001 #set code page to utf-8
-          echo ("PYVISTA_EXAMPLE_DATA_PATH=" + $(python -c "import pyvista; from pyvista import examples; print(examples.USER_DATA_PATH)")) >> $env:GITHUB_ENV
-
-      - name: Cache example data
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.PYVISTA_EXAMPLE_DATA_PATH }}
-          key: Examples-1-${{ hashFiles('*') }}
-          restore-keys: |
-            Examples-1-
-
-      - name: Test Core API
-        run: python -m pytest -v --ignore=tests/plotting
-
-      - name: Test Plotting
-        run: python -m pytest -v tests/plotting --fail_extra_image_cache --generated_image_dir debug_images
-
-      - name: Upload Generated Images
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: debug_images-${{ github.job }}-${{ join(matrix.* , '-') }}
-          path: debug_images
+          pip install -r examples_trame/requirements.txt
+      - name: Run examples
+        working-directory: examples_trame
+        run: pytest -v ./tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ test = [
     'pyvista[pinned]',
     'cmocean<4.0.4',
     'colorcet<3.2.0',
-    'embreex<2.17.8',
+    "embreex<2.17.8; sys_platform == 'darwin' and platform_machine == 'x86_64'",
     'hypothesis<6.115.6',
     'imageio<2.37.0',
     'imageio-ffmpeg<0.6.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ test = [
     'pyvista[pinned]',
     'cmocean<4.0.4',
     'colorcet<3.2.0',
-    "embreex<2.17.8; sys_platform != 'darwin' or platform_machine != 'x86_64'",
+    "embreex<2.17.8; sys_platform != 'darwin' or platform_machine != 'arm64'",
     'hypothesis<6.115.6',
     'imageio<2.37.0',
     'imageio-ffmpeg<0.6.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ test = [
     'pyvista[pinned]',
     'cmocean<4.0.4',
     'colorcet<3.2.0',
+    # Embreex does not work with arm-based macs
     "embreex<2.17.8; sys_platform != 'darwin' or platform_machine != 'arm64'",
     'hypothesis<6.115.6',
     'imageio<2.37.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ test = [
     'pyvista[pinned]',
     'cmocean<4.0.4',
     'colorcet<3.2.0',
-    "embreex<2.17.8; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "embreex<2.17.8; sys_platform != 'darwin' or platform_machine != 'x86_64'",
     'hypothesis<6.115.6',
     'imageio<2.37.0',
     'imageio-ffmpeg<0.6.0',

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -6,6 +6,7 @@ import json
 import os
 from pathlib import Path
 import pickle
+import platform
 import re
 import shutil
 from unittest import mock
@@ -1007,8 +1008,12 @@ CASE_3 = (  # non-coplanar points
     ],
 )
 
+is_arm_mac = platform.system() == 'Darwin' and platform.machine() == 'arm64'
 
-@pytest.mark.skipif(NUMPY_VERSION_INFO < (1, 26), reason='Different results for some tests.')
+
+@pytest.mark.skipif(
+    NUMPY_VERSION_INFO < (1, 26) or is_arm_mac, reason='Different results for some tests.'
+)
 @pytest.mark.parametrize(
     ('points', 'expected_axes'),
     [CASE_0, CASE_1, CASE_2, CASE_3],

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -4681,6 +4681,12 @@ def oblique_cone():
     return pv.examples.download_oblique_cone()
 
 
+is_arm_mac = platform.system() == 'Darwin' and platform.machine() == 'arm64'
+
+
+@pytest.mark.skipif(
+    is_arm_mac, reason='Barely exceeds error threshold (slightly different rendering).'
+)
 @pytest.mark.parametrize('box_style', ['outline', 'face', 'frame'])
 def test_bounding_box(oblique_cone, box_style):
     pl = pv.Plotter()


### PR DESCRIPTION
### Overview

Add testing with `macos-latest`.

### Details
macOS was pinned to `macos-12` in https://github.com/pyvista/pyvista/pull/5960

However, this means that we are not testing for compatibility with newer macbooks which use ARM processors instead of intel processors. The new architecture breaks compatibility with some of pyvista's optional dependencies, e.g. `embreex`, but this is undetected without testing on the newer architecture.