### PR TITLE
Restrict `embree` in test dependencies to intel macs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ test = [
     'pyvista[pinned]',
     'cmocean<4.0.4',
     'colorcet<3.2.0',
-    'embreex<2.17.8',
+    "embreex<2.17.8; sys_platform == 'darwin' and platform_machine == 'x86_64'",
     'hypothesis<6.115.6',
     'imageio<2.37.0',
     'imageio-ffmpeg<0.6.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,8 @@ test = [
     'pyvista[pinned]',
     'cmocean<4.0.4',
     'colorcet<3.2.0',
-    "embreex<2.17.8; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    # Embreex does not work with arm-based macs
+    "embreex<2.17.8; sys_platform != 'darwin' or platform_machine != 'arm64'",
     'hypothesis<6.115.6',
     'imageio<2.37.0',
     'imageio-ffmpeg<0.6.0',


### PR DESCRIPTION
### Overview

`embreex` does not work with newer mac hardware which use ARM processors. This PR makes it so that this package is not installed on this hardware.