### PR TITLE
Update MultiBlock repr to use scientific notation

### DIFF
--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -917,11 +917,11 @@ class MultiBlock(
     def _get_attrs(self):
         """Return the representation methods (internal helper)."""
         attrs = []
-        attrs.append(('N Blocks', self.n_blocks, '{}'))
+        attrs.append(('N Blocks:', self.n_blocks, '{}'))
         bds = self.bounds
-        attrs.append(('X Bounds', (bds[0], bds[1]), '{:.3f}, {:.3f}'))
-        attrs.append(('Y Bounds', (bds[2], bds[3]), '{:.3f}, {:.3f}'))
-        attrs.append(('Z Bounds', (bds[4], bds[5]), '{:.3f}, {:.3f}'))
+        attrs.append(('X Bounds:', (bds[0], bds[1]), '{:.3e}, {:.3e}'))
+        attrs.append(('Y Bounds:', (bds[2], bds[3]), '{:.3e}, {:.3e}'))
+        attrs.append(('Z Bounds:', (bds[4], bds[5]), '{:.3e}, {:.3e}'))
         return attrs
 
     def _repr_html_(self) -> str:
@@ -964,7 +964,7 @@ class MultiBlock(
         # return a string that is Python console friendly
         fmt = f'{type(self).__name__} ({hex(id(self))})\n'
         # now make a call on the object to get its attributes as a list of len 2 tuples
-        max_len = max(len(attr[0]) for attr in self._get_attrs()) + 4
+        max_len = max(len(attr[0]) for attr in self._get_attrs()) + 3
         row = '  {:%ds}{}\n' % max_len
         for attr in self._get_attrs():
             try:

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5814,10 +5814,10 @@ class DataSetFilters:
         ... )
         >>> extracted
         MultiBlock (...)
-          N Blocks    3
-          X Bounds    0.000, 1.000
-          Y Bounds    0.000, 1.000
-          Z Bounds    0.000, 5.000
+          N Blocks:   3
+          X Bounds:   0.000e+00, 1.000e+00
+          Y Bounds:   0.000e+00, 1.000e+00
+          Z Bounds:   0.000e+00, 5.000e+00
         >>> extracted.plot(multi_colors=True)
 
         Extract values from multi-component scalars.

--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -4028,10 +4028,10 @@ class CubeFacesSource(CubeSource):
 
     >>> output
     MultiBlock (...)
-      N Blocks    6
-      X Bounds    -0.500, 0.500
-      Y Bounds    -0.500, 0.500
-      Z Bounds    -0.500, 0.500
+      N Blocks:   6
+      X Bounds:   -5.000e-01, 5.000e-01
+      Y Bounds:   -5.000e-01, 5.000e-01
+      Z Bounds:   -5.000e-01, 5.000e-01
 
     >>> cube_source = pv.CubeSource()
     >>> cube_source.output

--- a/pyvista/plotting/composite_mapper.py
+++ b/pyvista/plotting/composite_mapper.py
@@ -465,10 +465,10 @@ class CompositeAttributes(_vtk.vtkCompositeDataDisplayAttributes):
         >>> actor, mapper = pl.add_composite(dataset)
         >>> mapper.block_attr.get_block(0)
         MultiBlock (...)
-          N Blocks    2
-          X Bounds    -0.500, 0.500
-          Y Bounds    -0.500, 0.500
-          Z Bounds    -0.500, 1.500
+          N Blocks:   2
+          X Bounds:   -5.000e-01, 5.000e-01
+          Y Bounds:   -5.000e-01, 5.000e-01
+          Z Bounds:   -5.000e-01, 1.500e+00
 
         Note this is the same as using ``__getitem__``
 
@@ -582,10 +582,10 @@ class CompositePolyDataMapper(
         >>> actor, mapper = pl.add_composite(dataset)
         >>> mapper.dataset
         MultiBlock (...)
-          N Blocks    2
-          X Bounds    -0.500, 0.500
-          Y Bounds    -0.500, 0.500
-          Z Bounds    -0.500, 1.500
+          N Blocks:   2
+          X Bounds:   -5.000e-01, 5.000e-01
+          Y Bounds:   -5.000e-01, 5.000e-01
+          Z Bounds:   -5.000e-01, 1.500e+00
 
         """
         return self._dataset

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -333,10 +333,10 @@ def test_multi_block_repr_bounds():
     poly_y_bounds = repr(empty_poly).splitlines()[4]
     poly_z_bounds = repr(empty_poly).splitlines()[5]
 
-    empy_multiblock = pv.MultiBlock([empty_poly])
-    multi_x_bounds = repr(empy_multiblock).splitlines()[2]
-    multi_y_bounds = repr(empy_multiblock).splitlines()[3]
-    multi_z_bounds = repr(empy_multiblock).splitlines()[4]
+    empty_multiblock = pv.MultiBlock([empty_poly])
+    multi_x_bounds = repr(empty_multiblock).splitlines()[2]
+    multi_y_bounds = repr(empty_multiblock).splitlines()[3]
+    multi_z_bounds = repr(empty_multiblock).splitlines()[4]
 
     assert multi_x_bounds == poly_x_bounds
     assert multi_y_bounds == poly_y_bounds

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import itertools
 import pathlib
 import platform
+import re
 import weakref
 
 import numpy as np
@@ -314,8 +315,32 @@ def test_multi_block_clean(rectilinear, uniform, ant):
 def test_multi_block_repr(multiblock_all_with_nested_and_none):
     multi = multiblock_all_with_nested_and_none
     assert multi._repr_html_() is not None
-    assert repr(multi) is not None
-    assert str(multi) is not None
+    pattern = (
+        r'MultiBlock \(0x[0-9a-fA-F]+\)'
+        r'\s+N Blocks:\s{3}\d+'
+        r'\s+X Bounds:\s{3}[+-]?\d*\.\d{3}e[+-]\d+,\s+[-+]?\d\.\d+e[+-]\d+'
+        r'\s+Y Bounds:\s{3}[+-]?\d*\.\d{3}e[+-]\d+,\s+[-+]?\d\.\d+e[+-]\d+'
+        r'\s+Z Bounds:\s{3}[+-]?\d*\.\d{3}e[+-]\d+,\s+[-+]?\d\.\d+e[+-]\d+'
+    )
+    match = re.search(pattern, repr(multi))
+    assert repr(multi) == match.string
+    assert str(multi) == match.string
+
+
+def test_multi_block_repr_bounds():
+    empty_poly = pv.PolyData().extract_cells(0)
+    poly_x_bounds = repr(empty_poly).splitlines()[3]
+    poly_y_bounds = repr(empty_poly).splitlines()[4]
+    poly_z_bounds = repr(empty_poly).splitlines()[5]
+
+    empy_multiblock = pv.MultiBlock([empty_poly])
+    multi_x_bounds = repr(empy_multiblock).splitlines()[2]
+    multi_y_bounds = repr(empy_multiblock).splitlines()[3]
+    multi_z_bounds = repr(empy_multiblock).splitlines()[4]
+
+    assert multi_x_bounds == poly_x_bounds
+    assert multi_y_bounds == poly_y_bounds
+    assert multi_z_bounds == poly_z_bounds
 
 
 def test_multi_block_eq(multiblock_all_with_nested_and_none):


### PR DESCRIPTION
### Overview

Fix #6438

Colons are also added to the repr to match the formatting for other datasets (e.g. PolyData)