### PR TITLE
Fix missing field data of nested `MultiBlock` when reading/writing to file

### DIFF
--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:  # pragma: no cover
 from .dataset import DataObject
 from .dataset import DataSet
 from .filters import CompositeFilters
+from .grid import ImageData
 from .pyvista_ndarray import pyvista_ndarray
 from .utilities.arrays import FieldAssociation
 from .utilities.geometric_objects import Box
@@ -39,6 +40,8 @@ if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Iterable
 
 _TypeMultiBlockLeaf = Union['MultiBlock', DataSet]
+
+PYVISTA_NESTED_MULTIBLOCK_FIELD_DATA = '_PYVISTA_NESTED_MULTIBLOCK_FIELD_DATA'
 
 
 class MultiBlock(
@@ -1384,3 +1387,49 @@ class MultiBlock(
                 block.clear_all_cell_data()
             elif block is not None:
                 block.clear_cell_data()
+
+    def _store_nested_field_data(self) -> None:
+        """Store field data of nested MultiBlock datasets.
+
+        This method stores the field data of nested MultiBlock datasets in a separate
+        "dummy" placeholder mesh. Use `_restore_nested_field_data` to invert this
+        process.
+
+        This is used as a workaround to read and write nested MultiBlock field data,
+        since there is a VTK issue where this field data is otherwise lost.
+        """
+        for block_name in self.keys():
+            block = self[block_name]
+            if isinstance(block, MultiBlock):
+                block._store_nested_field_data()
+
+            # Store nested field data in an arbitrary placeholder mesh
+            nested_fdata = block.field_data
+            fdata_placeholder = ImageData(dimensions=(1, 1, 1))  # Mesh must not be empty
+            fdata_placeholder.field_data.update(nested_fdata, copy=False)
+            key = f'{PYVISTA_NESTED_MULTIBLOCK_FIELD_DATA}-{block_name}'
+            self[key] = fdata_placeholder
+
+    def _restore_nested_field_data(self) -> None:
+        """Restore field data of nested MultiBlock datasets.
+
+        This method restores the field data of nested MultiBlock datasets that were
+        previously stored in a separate "dummy" placeholder mesh by
+        `_store_nested_field_data`.
+
+        This is used as a workaround to read and write nested MultiBlock field data,
+        since there is a VTK issue where this field data is otherwise lost.
+        """
+        for block_name in self.keys():
+            if PYVISTA_NESTED_MULTIBLOCK_FIELD_DATA in block_name:
+                # Get field data from the placeholder mesh then delete the placeholder
+                fdata_placeholder = self[block_name]
+                nested_fdata = fdata_placeholder.field_data
+                block_name_start = len(PYVISTA_NESTED_MULTIBLOCK_FIELD_DATA) + 1
+                dataset_name = block_name[block_name_start:]
+                block = self[dataset_name]
+                block.field_data.update(nested_fdata, copy=False)
+                del self[block_name]
+
+                # Restore field data recursively
+                block._restore_nested_field_data()

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -139,6 +139,8 @@ class DataObject:
         file size.
 
         """
+        from .composite import MultiBlock  # avoid circular import
+
         if self._WRITERS is None:
             raise NotImplementedError(
                 f'{self.__class__.__name__} writers are not specified,'
@@ -157,6 +159,8 @@ class DataObject:
 
         # store complex and bitarray types as field data
         self._store_metadata()
+        if isinstance(self, MultiBlock):
+            self._store_nested_field_data()
 
         writer = self._WRITERS[file_ext]()
         set_vtkwriter_mode(vtk_writer=writer, use_binary=binary)

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -159,6 +159,8 @@ class DataObject:
 
         # store complex and bitarray types as field data
         self._store_metadata()
+
+        # also store field data of any nested multiblocks
         if isinstance(self, MultiBlock):
             self._store_nested_field_data()
 

--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -827,6 +827,13 @@ class XMLMultiBlockDataReader(BaseReader, PointCellDataSelection):
     _vtk_module_name = 'vtkIOXML'
     _vtk_class_name = 'vtkXMLMultiBlockDataReader'
 
+    @wraps(BaseReader.read)
+    def read(self):
+        """Wrap the base reader to assign nested MultiBlock field data."""
+        multiblock = super().read()
+        multiblock._restore_nested_field_data()
+        return multiblock
+
 
 class EnSightReader(BaseReader, PointCellDataSelection, TimeReader):
     """EnSight Reader for .case files.


### PR DESCRIPTION
### Overview

Fix #6408

The VTK MultiBlock reader/writer has an issue where it does not save the field data of nested MultiBlocks. As a workaround, this PR stores nested MultiBlock field data in a separate "dummy" mesh when saving the dataset, and then restores the field data back to the nested MultiBlock objects when read.