### PR TITLE
Remove unnecessary macOS skips in `test_reader.py`

### DIFF
--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-import platform
 
 import numpy as np
 import pytest
@@ -19,10 +18,6 @@ except ModuleNotFoundError:
     HAS_IMAGEIO = False
 
 
-pytestmark = pytest.mark.skipif(
-    platform.system() == 'Darwin',
-    reason='MacOS testing on Azure fails when downloading',
-)
 skip_windows = pytest.mark.skipif(os.name == 'nt', reason='Test fails on Windows')
 
 


### PR DESCRIPTION
### Overview

These tests run fine on macOS but are currently skipped.