### PR TITLE
Add and fix API links in plot examples

### DIFF
--- a/examples/02-plot/anti-aliasing.py
+++ b/examples/02-plot/anti-aliasing.py
@@ -41,8 +41,8 @@ mesh = pv.Icosphere()
 # %%
 # No Anti-Aliasing
 # ~~~~~~~~~~~~~~~~
-# First, let's show a plot without any anti-aliasing.
-
+# First, let's show a plot without any anti-aliasing
+# using :func:`disable_anti_aliasing() <pyvista.Plotter.disable_anti_aliasing>`.
 pl = pv.Plotter()
 pl.add_mesh(mesh, style='wireframe', color='k', line_width=2)
 pl.disable_anti_aliasing()
@@ -71,6 +71,7 @@ pl.show()
 
 # %%
 # You can increase the smoothing by increasing multi_samples
+# using :func:`enable_anti_aliasing() <pyvista.Plotter.enable_anti_aliasing>`.
 
 pl = pv.Plotter()
 pl.add_mesh(mesh, style='wireframe', color='k', line_width=2)

--- a/examples/02-plot/anti-aliasing.py
+++ b/examples/02-plot/anti-aliasing.py
@@ -42,7 +42,7 @@ mesh = pv.Icosphere()
 # No Anti-Aliasing
 # ~~~~~~~~~~~~~~~~
 # First, let's show a plot without any anti-aliasing
-# using :func:`disable_anti_aliasing() <pyvista.Plotter.disable_anti_aliasing>`.
+# using :func:`~pyvista.Plotter.disable_anti_aliasing`.
 pl = pv.Plotter()
 pl.add_mesh(mesh, style='wireframe', color='k', line_width=2)
 pl.disable_anti_aliasing()
@@ -71,7 +71,7 @@ pl.show()
 
 # %%
 # You can increase the smoothing by increasing multi_samples
-# using :func:`enable_anti_aliasing() <pyvista.Plotter.enable_anti_aliasing>`.
+# using :func:`~pyvista.Plotter.enable_anti_aliasing`.
 
 pl = pv.Plotter()
 pl.add_mesh(mesh, style='wireframe', color='k', line_width=2)

--- a/examples/02-plot/chart_basics.py
+++ b/examples/02-plot/chart_basics.py
@@ -47,7 +47,7 @@ chart.show()
 
 # %%
 # You can also easily combine scatter and line plots using the general
-# :func:`plot() <pyvista.Chart2D.plot>` function, specifying both the line and marker
+# :func:`~pyvista.Chart2D.plot` function, specifying both the line and marker
 # style at once.
 
 x = np.arange(11)
@@ -118,7 +118,7 @@ chart.show()
 
 # %%
 # In a similar way, you can stack multiple area plots on top of
-# each other using :func:`stack() <pyvista.Chart2D.stack>`.
+# each other using :func:`~pyvista.Chart2D.stack`.
 
 x = np.arange(0, 11)
 ys = [rng.integers(1, 11, 11) for _ in range(5)]

--- a/examples/02-plot/chart_basics.py
+++ b/examples/02-plot/chart_basics.py
@@ -23,9 +23,9 @@ rng = np.random.default_rng(1)  # Seeded random number generator for consistent 
 
 # %%
 # This example shows how to create a 2D scatter plot from 100 randomly sampled
-# datapoints. By default, the chart automatically rescales its axes such that
-# all plotted data is visible. By right clicking on the chart you can enable
-# zooming and panning of the chart.
+# datapoints using :func:`scatter() <pyvista.Chart2D.scatter>`. By default, the chart automatically
+# rescales its axes such that all plotted data is visible. By right clicking on the chart
+# you can enable zooming and panning of the chart.
 
 x = rng.standard_normal(100)
 y = rng.standard_normal(100)
@@ -35,8 +35,8 @@ chart.show()
 
 # %%
 # To connect datapoints with lines, you can create a 2D line plot as shown in
-# the example below. You can also dynamically 'zoom in' on the plotted data
-# by specifying a custom axis range yourself.
+# the example below using :func:`line() <pyvista.Chart2D.line>`. You can also dynamically
+# 'zoom in' on the plotted data by specifying a custom axis range yourself.
 
 x = np.linspace(0, 10, 1000)
 y = np.sin(x**2)
@@ -47,7 +47,7 @@ chart.show()
 
 # %%
 # You can also easily combine scatter and line plots using the general
-# :func:`pyvista.Chart2D.plot` function, specifying both the line and marker
+# :func:`plot() <pyvista.Chart2D.plot>` function, specifying both the line and marker
 # style at once.
 
 x = np.arange(11)
@@ -58,7 +58,8 @@ chart.plot(x, y, 'x--b')  # Marker style 'x', striped line style '--', blue colo
 chart.show()
 
 # %%
-# The following example shows how to create filled areas between two polylines.
+# The following example shows how to create filled areas between two polylines
+# using :func:`area() <pyvista.Chart2D.area>`.
 
 x = np.linspace(0, 10, 1000)
 y1 = np.cos(x) + np.sin(3 * x)
@@ -71,8 +72,8 @@ chart.title = 'Area plot'  # Set custom chart title
 chart.show()
 
 # %%
-# Bar charts are also supported. Multiple bar plots are placed next to each
-# other.
+# Bar charts are also supported using :func:`bar() <pyvista.Chart2D.bar>`.
+# Multiple bar plots are placed next to each other.
 
 x = np.arange(1, 13)
 y1 = rng.integers(1e2, 1e4, 12)
@@ -116,7 +117,8 @@ chart.grid = False  # Disable the grid lines
 chart.show()
 
 # %%
-# In a similar way, you can stack multiple area plots on top of each other.
+# In a similar way, you can stack multiple area plots on top of
+# each other using :func:`stack() <pyvista.Chart2D.stack>`.
 
 x = np.arange(0, 11)
 ys = [rng.integers(1, 11, 11) for _ in range(5)]
@@ -128,7 +130,7 @@ chart.show()
 # %%
 # Beside the flexible Chart2D used in the previous examples, there are a couple
 # other dedicated charts you can create. The example below shows how a pie
-# chart can be created.
+# chart can be created using :class:`ChartPie <pyvista.ChartPie>`.
 
 data = np.array([8.4, 6.1, 2.7, 2.4, 0.9])
 chart = pv.ChartPie(data)
@@ -136,7 +138,8 @@ chart.plot.labels = [f'slice {i}' for i in range(len(data))]
 chart.show()
 
 # %%
-# To summarize statistics of datasets, you can easily create a boxplot.
+# To summarize statistics of datasets, you can easily create a boxplot
+# using :class:`ChartBox <pyvista.ChartBox>`.
 
 data = [rng.poisson(lam, 20) for lam in range(2, 12, 2)]
 chart = pv.ChartBox(data)

--- a/examples/02-plot/chart_basics.py
+++ b/examples/02-plot/chart_basics.py
@@ -23,7 +23,7 @@ rng = np.random.default_rng(1)  # Seeded random number generator for consistent 
 
 # %%
 # This example shows how to create a 2D scatter plot from 100 randomly sampled
-# datapoints using :func:`scatter() <pyvista.Chart2D.scatter>`. By default, the chart automatically
+# datapoints using :func:`~pyvista.Chart2D.scatter`. By default, the chart automatically
 # rescales its axes such that all plotted data is visible. By right clicking on the chart
 # you can enable zooming and panning of the chart.
 
@@ -35,7 +35,7 @@ chart.show()
 
 # %%
 # To connect datapoints with lines, you can create a 2D line plot as shown in
-# the example below using :func:`line() <pyvista.Chart2D.line>`. You can also dynamically
+# the example below using :func:`~pyvista.Chart2D.line`. You can also dynamically
 # 'zoom in' on the plotted data by specifying a custom axis range yourself.
 
 x = np.linspace(0, 10, 1000)
@@ -59,7 +59,7 @@ chart.show()
 
 # %%
 # The following example shows how to create filled areas between two polylines
-# using :func:`area() <pyvista.Chart2D.area>`.
+# using :func:`~pyvista.Chart2D.area`.
 
 x = np.linspace(0, 10, 1000)
 y1 = np.cos(x) + np.sin(3 * x)
@@ -72,7 +72,7 @@ chart.title = 'Area plot'  # Set custom chart title
 chart.show()
 
 # %%
-# Bar charts are also supported using :func:`bar() <pyvista.Chart2D.bar>`.
+# Bar charts are also supported using :func:`~pyvista.Chart2D.bar`.
 # Multiple bar plots are placed next to each other.
 
 x = np.arange(1, 13)
@@ -130,7 +130,7 @@ chart.show()
 # %%
 # Beside the flexible Chart2D used in the previous examples, there are a couple
 # other dedicated charts you can create. The example below shows how a pie
-# chart can be created using :class:`ChartPie <pyvista.ChartPie>`.
+# chart can be created using :class:`~pyvista.ChartPie`.
 
 data = np.array([8.4, 6.1, 2.7, 2.4, 0.9])
 chart = pv.ChartPie(data)
@@ -139,7 +139,7 @@ chart.show()
 
 # %%
 # To summarize statistics of datasets, you can easily create a boxplot
-# using :class:`ChartBox <pyvista.ChartBox>`.
+# using :class:`~pyvista.ChartBox`.
 
 data = [rng.poisson(lam, 20) for lam in range(2, 12, 2)]
 chart = pv.ChartBox(data)

--- a/examples/02-plot/depth-peeling.py
+++ b/examples/02-plot/depth-peeling.py
@@ -9,7 +9,7 @@ not enabled by default in :attr:`pyvista.global_theme
 have issues with this routine.
 
 For this example, we will showcase the difference that depth peeling
-provides. See :func:`enable_depth_peeling() <pyvista.Plotter.enable_depth_peeling>`.
+provides. See :func:`~pyvista.Plotter.enable_depth_peeling`.
 
 """
 

--- a/examples/02-plot/depth-peeling.py
+++ b/examples/02-plot/depth-peeling.py
@@ -9,7 +9,7 @@ not enabled by default in :attr:`pyvista.global_theme
 have issues with this routine.
 
 For this example, we will showcase the difference that depth peeling
-provides.
+provides. See :func:`enable_depth_peeling() <pyvista.Plotter.enable_depth_peeling>`.
 
 """
 

--- a/examples/02-plot/floors.py
+++ b/examples/02-plot/floors.py
@@ -4,7 +4,8 @@
 Plot with Floors
 ~~~~~~~~~~~~~~~~
 
-Add a floor/wall at the boundary of the rendering scene.
+Add a floor/wall at the boundary of the rendering scene
+using :func:`add_floor() <pyvista.Plotter.add_floor>`.
 """
 
 from __future__ import annotations

--- a/examples/02-plot/floors.py
+++ b/examples/02-plot/floors.py
@@ -5,7 +5,7 @@ Plot with Floors
 ~~~~~~~~~~~~~~~~
 
 Add a floor/wall at the boundary of the rendering scene
-using :func:`add_floor() <pyvista.Plotter.add_floor>`.
+using :func:`~pyvista.Plotter.add_floor`.
 """
 
 from __future__ import annotations

--- a/examples/02-plot/labels.py
+++ b/examples/02-plot/labels.py
@@ -38,7 +38,7 @@ poly['My Labels'] = [f'Label {i}' for i in range(poly.n_points)]
 poly
 
 # %%
-# Now plot the points with labels using :func:`add_point_labels() <pyvista.Plotter.add_point_labels>`.
+# Now plot the points with labels using :func:`~pyvista.Plotter.add_point_labels`.
 
 plotter = pv.Plotter()
 plotter.add_point_labels(poly, 'My Labels', point_size=20, font_size=36)

--- a/examples/02-plot/labels.py
+++ b/examples/02-plot/labels.py
@@ -38,7 +38,7 @@ poly['My Labels'] = [f'Label {i}' for i in range(poly.n_points)]
 poly
 
 # %%
-# Now plot the points with labels:
+# Now plot the points with labels using :func:`add_point_labels() <pyvista.Plotter.add_point_labels>`.
 
 plotter = pv.Plotter()
 plotter.add_point_labels(poly, 'My Labels', point_size=20, font_size=36)

--- a/examples/02-plot/legend.py
+++ b/examples/02-plot/legend.py
@@ -21,7 +21,7 @@ PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True
 # Default legend for glyphs
 # +++++++++++++++++++++++++
 #
-# The method :func:`add_legend() <pyvista.Plotter.add_legend>` is able to retrieve and use
+# The method :func:`~pyvista.Plotter.add_legend` is able to retrieve and use
 # the glyphs for each plot.
 #
 pl = pv.Plotter()
@@ -52,7 +52,7 @@ pl.show()
 # Using custom legends
 # ++++++++++++++++++++
 #
-# You can use specific labels with :func:`add_legend() <pyvista.Plotter.add_legend>`
+# You can use specific labels with :func:`~pyvista.Plotter.add_legend`
 #
 
 pl = pv.Plotter()
@@ -71,7 +71,7 @@ legend = ['New top pressure', 'New lower pressure']
 pl.add_legend(legend)
 
 # In this case, the default values are used, not the ones from the
-# :func:`add_mesh() <pyvista.Plotter.add_mesh>`.
+# :func:`~pyvista.Plotter.add_mesh`.
 
 pl.show()
 

--- a/examples/02-plot/legend.py
+++ b/examples/02-plot/legend.py
@@ -21,7 +21,7 @@ PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True
 # Default legend for glyphs
 # +++++++++++++++++++++++++
 #
-# The method :func:`pyvista.PolyData.add_legend` is able to retrieve and use
+# The method :func:`add_legend() <pyvista.Plotter.add_legend>` is able to retrieve and use
 # the glyphs for each plot.
 #
 pl = pv.Plotter()
@@ -52,7 +52,7 @@ pl.show()
 # Using custom legends
 # ++++++++++++++++++++
 #
-# You can use specific labels with :func:`pyvista.PolyData.add_legend`
+# You can use specific labels with :func:`add_legend() <pyvista.Plotter.add_legend>`
 #
 
 pl = pv.Plotter()
@@ -71,7 +71,7 @@ legend = ['New top pressure', 'New lower pressure']
 pl.add_legend(legend)
 
 # In this case, the default values are used, not the ones from the
-# :func:`pyvista.PolyData.add_mesh`.
+# :func:`add_mesh() <pyvista.Plotter.add_mesh>`.
 
 pl.show()
 

--- a/examples/02-plot/linked.py
+++ b/examples/02-plot/linked.py
@@ -5,7 +5,7 @@ Linked Views in Subplots
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 This example demonstrates how to create linked views in PyVista subplots
-using :func:`link_views() <pyvista.Plotter.link_views>`, where camera movements
+using :func:`~pyvista.Plotter.link_views`, where camera movements
 in one view are synchronized with other views. This is particularly useful when comparing
 different versions or representations of the same model.
 

--- a/examples/02-plot/linked.py
+++ b/examples/02-plot/linked.py
@@ -4,6 +4,11 @@
 Linked Views in Subplots
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
+This example demonstrates how to create linked views in PyVista subplots
+using :func:`link_views() <pyvista.Plotter.link_views>`, where camera movements
+in one view are synchronized with other views. This is particularly useful when comparing
+different versions or representations of the same model.
+
 """
 
 from __future__ import annotations

--- a/examples/02-plot/orbit.py
+++ b/examples/02-plot/orbit.py
@@ -31,7 +31,7 @@ mesh = examples.download_st_helens().warp_by_scalar()
 
 # %%
 # Orbit around the Mt. St Helens dataset using
-# :func:`generate_orbital_path() <pyvista.Plotter.generate_orbital_path>`.
+# :func:`~pyvista.Plotter.generate_orbital_path`.
 
 p = pv.Plotter()
 p.add_mesh(mesh, lighting=False)

--- a/examples/02-plot/orbit.py
+++ b/examples/02-plot/orbit.py
@@ -30,7 +30,8 @@ from pyvista import examples
 mesh = examples.download_st_helens().warp_by_scalar()
 
 # %%
-# Orbit around the Mt. St Helens dataset.
+# Orbit around the Mt. St Helens dataset using
+# :func:`generate_orbital_path() <pyvista.Plotter.generate_orbital_path>`.
 
 p = pv.Plotter()
 p.add_mesh(mesh, lighting=False)

--- a/examples/02-plot/point-clouds.py
+++ b/examples/02-plot/point-clouds.py
@@ -149,7 +149,7 @@ pl.show()
 # Orbit a Point Cloud
 # ~~~~~~~~~~~~~~~~~~~
 # Generate a plot orbiting around a point cloud. Color based on the distance
-# from the center of the cloud.
+# from the center of the cloud using :func:`generate_orbital_path() <pyvista.Plotter.generate_orbital_path>`.
 
 cloud = examples.download_cloud_dark_matter()
 scalars = np.linalg.norm(cloud.points - cloud.center, axis=1)

--- a/examples/02-plot/point-clouds.py
+++ b/examples/02-plot/point-clouds.py
@@ -149,7 +149,7 @@ pl.show()
 # Orbit a Point Cloud
 # ~~~~~~~~~~~~~~~~~~~
 # Generate a plot orbiting around a point cloud. Color based on the distance
-# from the center of the cloud using :func:`generate_orbital_path() <pyvista.Plotter.generate_orbital_path>`.
+# from the center of the cloud using :func:`~pyvista.Plotter.generate_orbital_path`.
 
 cloud = examples.download_cloud_dark_matter()
 scalars = np.linalg.norm(cloud.points - cloud.center, axis=1)

--- a/examples/02-plot/scalar-bars.py
+++ b/examples/02-plot/scalar-bars.py
@@ -23,8 +23,8 @@ PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True
 # %%
 # By default, when plotting a dataset with a scalar array, a scalar bar for that
 # array is added. To turn off this behavior, a user could specify
-# ``show_scalar_bar=False`` when calling ``.add_mesh()``. Let's start with a
-# sample dataset provide via PyVista to demonstrate the default behavior of
+# ``show_scalar_bar=False`` when calling :func:`add_mesh() <pyvista.Plotter.add_mesh>`.
+# Let's start with a sample dataset provide via PyVista to demonstrate the default behavior of
 # scalar bar plotting:
 
 # Load St Helens DEM and warp the topography

--- a/examples/02-plot/scalar-bars.py
+++ b/examples/02-plot/scalar-bars.py
@@ -23,7 +23,7 @@ PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True
 # %%
 # By default, when plotting a dataset with a scalar array, a scalar bar for that
 # array is added. To turn off this behavior, a user could specify
-# ``show_scalar_bar=False`` when calling :func:`add_mesh() <pyvista.Plotter.add_mesh>`.
+# ``show_scalar_bar=False`` when calling :func:`~pyvista.Plotter.add_mesh`.
 # Let's start with a sample dataset provide via PyVista to demonstrate the default behavior of
 # scalar bar plotting:
 

--- a/examples/02-plot/ssao.py
+++ b/examples/02-plot/ssao.py
@@ -46,7 +46,7 @@ pl.show()
 # %%
 # Plot with SSAO
 # ~~~~~~~~~~~~~~
-# Now plot this with SSAO. Note how adjacent cubes affect the lighting of each
+# Now plot this with SSAO using :func:`enable_ssao() <pyvista.Plotter.enable_ssao>`. Note how adjacent cubes affect the lighting of each
 # other to make it look less artificial.
 #
 # With a low ``kernel_size``, the image will be rendered quickly at the expense

--- a/examples/02-plot/ssao.py
+++ b/examples/02-plot/ssao.py
@@ -46,7 +46,7 @@ pl.show()
 # %%
 # Plot with SSAO
 # ~~~~~~~~~~~~~~
-# Now plot this with SSAO using :func:`enable_ssao() <pyvista.Plotter.enable_ssao>`. Note how adjacent cubes affect the lighting of each
+# Now plot this with SSAO using :func:`~pyvista.Plotter.enable_ssao`. Note how adjacent cubes affect the lighting of each
 # other to make it look less artificial.
 #
 # With a low ``kernel_size``, the image will be rendered quickly at the expense


### PR DESCRIPTION
resolve #5111.

1. Added  API links to:
   - Several plot examples in `examples/02-plot/`

2. Fixed incorrect API links:
   - `examples/02-plot/legend.py`

3. Added a short explanation and API link to:
   - `examples/02-plot/linked.py`


