### PR TITLE
Add `taplo` pre-commit hook to format and sort `toml` files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,5 +93,5 @@ repos:
     rev: v0.23.1
     hooks:
       - id: toml-sort
-        args: [--in-place]
+        args: [] # Args should be blank. Set args in `pyproject.toml` instead
         types_or: [toml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,9 +89,9 @@ repos:
     hooks:
       - id: shfmt
 
-  - repo: https://github.com/pappasam/toml-sort
-    rev: v0.23.1
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
     hooks:
-      - id: toml-sort
-        args: [] # Args should be blank. Set args in `pyproject.toml` instead
-        types_or: [toml]
+      - id: taplo-format
+        # See options: https://taplo.tamasfe.dev/configuration/formatter-options.html
+        args: [--option, "reorder_arrays=true"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,3 +88,10 @@ repos:
     rev: v3.10.0-1
     hooks:
       - id: shfmt
+
+  - repo: https://github.com/pappasam/toml-sort
+    rev: v0.23.1
+    hooks:
+      - id: toml-sort
+        args: [--in-place]
+        types_or: [toml]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,8 @@ jupyter = [
     'trame-vuetify>=2.3.1',
     'trame>=2.5.2',
 ]
+# Pinned versions of core dependencies
 pinned = [
-    # Pinned versions of core dependencies
     'matplotlib<3.9.3',
     'numpy<2.2.0',
     'pillow<11.1.0',
@@ -204,19 +204,17 @@ quiet-level = 3
 omit = [
     'pyvista/conftest.py',
     'pyvista/ext/coverage.py',
-    # kept for backwards compatibility:
-    'pyvista/plotting/theme.py',
+    'pyvista/plotting/theme.py',  # kept for backwards compatibility
 ]
 
 [tool.pytest.ini_options]
 junit_family = 'legacy'
 filterwarnings = [
     'error::pyvista.PyVistaDeprecationWarning',
-    'ignore:.*Given trait value dtype "float64":UserWarning',
-    # bogus numpy ABI warning (see numpy/#432)
-    'ignore:.*numpy.dtype size changed.*:RuntimeWarning',
-    'ignore:.*numpy.ufunc size changed.*:RuntimeWarning',
-    'ignore:.*The NumPy module was reloaded*:UserWarning',
+    'ignore:.*Given trait value dtype "float64":UserWarning',  # bogus numpy ABI warning (see numpy/#432)
+    'ignore:.*numpy.dtype size changed.*:RuntimeWarning',  # bogus numpy ABI warning (see numpy/#432)
+    'ignore:.*numpy.ufunc size changed.*:RuntimeWarning',  # bogus numpy ABI warning (see numpy/#432)
+    'ignore:.*The NumPy module was reloaded*:UserWarning',  # bogus numpy ABI warning (see numpy/#432)
     'ignore::DeprecationWarning',
     'ignore::FutureWarning',
     'ignore::PendingDeprecationWarning',
@@ -269,14 +267,12 @@ checks = [
     "SS05",  # Appears to be broken.
     "YD01",  # Yields: No plan to enforce
 ]
+# don't report on objects that match any of these regex
 exclude = [
-    # classes inherit from BaseReader
-    '\.*Reader(\.|$)',
-    # don't report on objects that match any of these regex
+    '\.*Reader(\.|$)',  # classes inherit from BaseReader
     '\._.*$',  # Ignore anything that's private (e.g., starts with _)
     '^coverage\..*$',
     '^plot_directive\..*$',
-    # Documentation extensions or utilities
     '^viewer_directive\..*$',
 ]
 
@@ -299,12 +295,9 @@ quote-style = "single"
 [tool.ruff.lint]
 external = ["E131"]
 ignore = [
-    # https://github.com/pyvista/pyvista/pull/6030
-    "B028",
-    # https://github.com/pyvista/pyvista/pull/6022
-    "B904",
-    # The following rules may cause conflicts when used with the formatter
-    "COM812",
+    "B028",  # https://github.com/pyvista/pyvista/pull/6030
+    "B904",  # https://github.com/pyvista/pyvista/pull/6022
+    "COM812",  # May cause conflicts when used with the formatter
     "D105",  # Missing docstring in magic method
     "D107",  # Missing docstring in `__init__`
     "D203",  # May conflict with the formatter
@@ -312,40 +305,23 @@ ignore = [
     "D213",  # Incompatible with D212
     "D402",  # First line should not be the function's signature
     "D416",  # Section name ends in colon
-    # whitespace before ':'
-    "E203",
-    # too many leading '#' for block comment
-    "E266",
-    # module level import not at top of file
-    "E402",
-    # line break before binary operator
-    # "W503",
-    # line length too long
-    "E501",
-    # bare excepts (temporary)
-    # "B001", "E722",
+    "E203",  # whitespace before ':'
+    "E266",  # too many leading '#' for block comment
+    "E402",  # module level import not at top of file
+    "E501",  # line length too long
     "E722",
-    # do not assign a lambda expression, use a def
-    "E731",
-    # ambiguous variable name
-    "E741",
-    # 'from module import *' used; unable to detect undefined names
-    "F403",
-    "ISC001",
-    # https://github.com/pyvista/pyvista/pull/6037
-    "PERF203",
-    # Quotes (temporary)
-    "Q0",
-    # https://github.com/pyvista/pyvista/pull/5911
-    "RET505",
-    "RET506",
-    "RET507",
-    # https://github.com/pyvista/pyvista/pull/5877
-    "SIM102",
-    # https://github.com/pyvista/pyvista/pull/5888
-    "SIM117",
-    # https://github.com/pyvista/pyvista/pull/5837
-    "SIM118",
+    "E731",  # do not assign a lambda expression, use a def
+    "E741",  # ambiguous variable name
+    "F403",  # 'from module import *' used; unable to detect undefined names
+    "ISC001",  # May cause conflicts when used with the formatter
+    "PERF203",  # https://github.com/pyvista/pyvista/pull/6037
+    "Q0",  # Quotes (temporary)
+    "RET505",  # https://github.com/pyvista/pyvista/pull/5911
+    "RET506",  # https://github.com/pyvista/pyvista/pull/5911
+    "RET507",  # https://github.com/pyvista/pyvista/pull/5911
+    "SIM102",  # https://github.com/pyvista/pyvista/pull/5877
+    "SIM117",  # https://github.com/pyvista/pyvista/pull/5888
+    "SIM118",  # https://github.com/pyvista/pyvista/pull/5837
 ]
 fixable = ["ALL"]
 unfixable = []
@@ -401,10 +377,8 @@ allow-dict-calls-with-keyword-arguments = true
 
 [tool.ruff.lint.per-file-ignores]
 "examples/**" = [
-    # https://github.com/pyvista/pyvista/pull/6014
-    "B015",
-    # https://github.com/pyvista/pyvista/pull/6019
-    "B018",
+    "B015",  # https://github.com/pyvista/pyvista/pull/6014
+    "B018",  # https://github.com/pyvista/pyvista/pull/6019
 ]
 "doc/source/make_tables.py" = ["D101", "D102"]
 "examples/*" = ["D102", "D103", "D205", "D212", "D400", "D415", "SIM115"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,147 +5,131 @@ build-backend = 'setuptools.build_meta'
 [project]
 name = 'pyvista'
 description = 'Easier Pythonic interface to VTK'
-authors = [
-    {name = 'PyVista Developers', email = 'info@pyvista.org'},
-]
+authors = [{ name = 'PyVista Developers', email = 'info@pyvista.org' }]
 readme = 'README.rst'
 requires-python = '>=3.9'
 keywords = ['mesh', 'numpy', 'plotting', 'vtk']
-license = {text = 'MIT'}
+license = { text = 'MIT' }
 classifiers = [
-    'Development Status :: 5 - Production/Stable',
-    'Intended Audience :: Science/Research',
-    'License :: OSI Approved :: MIT License',
-    'Operating System :: MacOS',
-    'Operating System :: Microsoft :: Windows',
-    'Operating System :: POSIX',
-    'Programming Language :: Python :: 3.10',
-    'Programming Language :: Python :: 3.11',
-    'Programming Language :: Python :: 3.12',
-    'Programming Language :: Python :: 3.9',
-    'Topic :: Scientific/Engineering :: Information Analysis',
+  'Development Status :: 5 - Production/Stable',
+  'Intended Audience :: Science/Research',
+  'License :: OSI Approved :: MIT License',
+  'Operating System :: MacOS',
+  'Operating System :: Microsoft :: Windows',
+  'Operating System :: POSIX',
+  'Programming Language :: Python :: 3.10',
+  'Programming Language :: Python :: 3.11',
+  'Programming Language :: Python :: 3.12',
+  'Programming Language :: Python :: 3.9',
+  'Topic :: Scientific/Engineering :: Information Analysis',
 ]
 dependencies = [
-    'matplotlib>=3.0.1',
-    'numpy>=1.21.0',  # minimum typing support
-    'pillow',
-    'pooch',
-    'scooby>=0.5.1',
-    'typing-extensions',
-    'vtk',  # keep without version constraints
+  'matplotlib>=3.0.1',
+  'numpy>=1.21.0',     # minimum typing support
+  'pillow',
+  'pooch',
+  'scooby>=0.5.1',
+  'typing-extensions',
+  'vtk',               # keep without version constraints
 ]
 dynamic = ['version']
 
 [project.optional-dependencies]
 all = ['pyvista[colormaps,io,jupyter]']
-colormaps = [
-    'cmocean',
-    'colorcet',
-]
-io = [
-    'imageio',
-    'meshio>=5.2',
-]
+colormaps = ['cmocean', 'colorcet']
+io = ['imageio', 'meshio>=5.2']
 jupyter = [
-    'ipywidgets',
-    'jupyter-server-proxy',
-    'nest_asyncio',
-    'trame-client>=2.12.7',
-    'trame-server>=2.11.7',
-    'trame-vtk>=2.5.8',
-    'trame-vuetify>=2.3.1',
-    'trame>=2.5.2',
+  'ipywidgets',
+  'jupyter-server-proxy',
+  'nest_asyncio',
+  'trame-client>=2.12.7',
+  'trame-server>=2.11.7',
+  'trame-vtk>=2.5.8',
+  'trame-vuetify>=2.3.1',
+  'trame>=2.5.2',
 ]
 # Pinned versions of core dependencies
 pinned = [
-    'matplotlib<3.9.3',
-    'numpy<2.2.0',
-    'pillow<11.1.0',
-    'pooch<1.9.0',
-    'scooby<0.11.0',
-    'typing-extensions<4.13.0',
-    'vtk<9.4.0',
+  'matplotlib<3.9.3',
+  'numpy<2.2.0',
+  'pillow<11.1.0',
+  'pooch<1.9.0',
+  'scooby<0.11.0',
+  'typing-extensions<4.13.0',
+  'vtk<9.4.0',
 ]
-typing = [
-    'mypy<1.14.0',
-    'npt-promote==0.1',
-    'numpy>=2.0.0',
-    'pyvista[pinned]',
-]
+typing = ['mypy<1.14.0', 'npt-promote==0.1', 'numpy>=2.0.0', 'pyvista[pinned]']
 test = [
-    # Embreex does not work with arm-based macs
-    "embreex<2.17.8; sys_platform != 'darwin' or platform_machine != 'arm64'",
-    'cmocean<4.0.4',
-    'colorcet<3.2.0',
-    'hypothesis<6.115.6',
-    'imageio-ffmpeg<0.6.0',
-    'imageio<2.37.0',
-    'ipython<9.0.0',
-    'ipywidgets<9.0.0',
-    'meshio<5.4.0',
-    'nest_asyncio<1.6.1',
-    'numpydoc==1.8.0',
-    'pyanalyze<=0.13.1',
-    'pytest-cov<6.1.0',
-    'pytest-memprof<0.3.0',
-    'pytest-pyvista==0.1.8',
-    'pytest-xdist<3.7.0',
-    'pytest<8.4.0',
-    'pyvista[pinned]',
-    'scipy<1.14.2',
-    'sphinx-book-theme<1.2.0',
-    'sphinx-gallery<0.19.0',
-    'sphinx<8.2.0',
-    'sphinx_design<0.7.0',
-    'sympy<1.14.0',
-    'tqdm<4.67.0',
-    'trame-vtk>=2.5.8,<2.8.12',
-    'trame-vuetify>=2.3.1,<2.7.2',
-    'trame>=2.5.2,<3.7.1',
-    'trimesh<4.6.0',
-    'typing-extensions<4.13.0',
+  # Embreex does not work with arm-based macs
+  "embreex<2.17.8; sys_platform != 'darwin' or platform_machine != 'arm64'",
+  'cmocean<4.0.4',
+  'colorcet<3.2.0',
+  'hypothesis<6.115.6',
+  'imageio-ffmpeg<0.6.0',
+  'imageio<2.37.0',
+  'ipython<9.0.0',
+  'ipywidgets<9.0.0',
+  'meshio<5.4.0',
+  'nest_asyncio<1.6.1',
+  'numpydoc==1.8.0',
+  'pyanalyze<=0.13.1',
+  'pytest-cov<6.1.0',
+  'pytest-memprof<0.3.0',
+  'pytest-pyvista==0.1.8',
+  'pytest-xdist<3.7.0',
+  'pytest<8.4.0',
+  'pyvista[pinned]',
+  'scipy<1.14.2',
+  'sphinx-book-theme<1.2.0',
+  'sphinx-gallery<0.19.0',
+  'sphinx<8.2.0',
+  'sphinx_design<0.7.0',
+  'sympy<1.14.0',
+  'tqdm<4.67.0',
+  'trame-vtk>=2.5.8,<2.8.12',
+  'trame-vuetify>=2.3.1,<2.7.2',
+  'trame>=2.5.2,<3.7.1',
+  'trimesh<4.6.0',
+  'typing-extensions<4.13.0',
 ]
 docs = [
-    'cmocean==4.0.3',
-    'colorcet==3.1.0',
-    'enum-tools==0.12.0',
-    'imageio-ffmpeg==0.5.1',
-    'imageio==2.36.0',
-    'jupyter_sphinx==0.5.3',
-    'jupyterlab==4.2.5',
-    'lxml==5.3.0',
-    'meshio==5.3.5',
-    'mypy-extensions==1.0.0',
-    'mypy==1.13.0',
-    'numpydoc==1.8.0',
-    'osmnx==1.9.4',
-    'pypandoc==1.14',
-    'pytest-sphinx==0.6.3',
-    'pyvista[pinned]',
-    'scipy==1.14.1',
-    'sphinx-autobuild==2024.10.3',
-    'sphinx-book-theme==1.1.3',
-    'sphinx-copybutton==0.5.2',
-    'sphinx-design==0.6.1',
-    'sphinx-gallery==0.18.0',
-    'sphinx-notfound-page==1.0.4',
-    'sphinx-sitemap==2.6.0',
-    'sphinx-tags==0.4.0',
-    'sphinx-toolbox==3.8.1',
-    'sphinx==8.1.3',
-    'sphinxcontrib-asciinema==0.4.2',
-    'sphinxcontrib-websupport==2.0.0',
-    'sphinxext-opengraph==0.9.1',
-    'sympy==1.13.3',
-    'trame-vtk==2.8.11',
-    'trame-vuetify==2.7.1',
-    'trame==3.7.0',
-    'trimesh==4.5.2',
+  'cmocean==4.0.3',
+  'colorcet==3.1.0',
+  'enum-tools==0.12.0',
+  'imageio-ffmpeg==0.5.1',
+  'imageio==2.36.0',
+  'jupyter_sphinx==0.5.3',
+  'jupyterlab==4.2.5',
+  'lxml==5.3.0',
+  'meshio==5.3.5',
+  'mypy-extensions==1.0.0',
+  'mypy==1.13.0',
+  'numpydoc==1.8.0',
+  'osmnx==1.9.4',
+  'pypandoc==1.14',
+  'pytest-sphinx==0.6.3',
+  'pyvista[pinned]',
+  'scipy==1.14.1',
+  'sphinx-autobuild==2024.10.3',
+  'sphinx-book-theme==1.1.3',
+  'sphinx-copybutton==0.5.2',
+  'sphinx-design==0.6.1',
+  'sphinx-gallery==0.18.0',
+  'sphinx-notfound-page==1.0.4',
+  'sphinx-sitemap==2.6.0',
+  'sphinx-tags==0.4.0',
+  'sphinx-toolbox==3.8.1',
+  'sphinx==8.1.3',
+  'sphinxcontrib-asciinema==0.4.2',
+  'sphinxcontrib-websupport==2.0.0',
+  'sphinxext-opengraph==0.9.1',
+  'sympy==1.13.3',
+  'trame-vtk==2.8.11',
+  'trame-vuetify==2.7.1',
+  'trame==3.7.0',
+  'trimesh==4.5.2',
 ]
-dev = [
-    'pre-commit',
-    'pyvista[test,docs]',
-]
+dev = ['pre-commit', 'pyvista[test,docs]']
 
 [project.urls]
 Documentation = 'https://docs.pyvista.org/'
@@ -153,31 +137,26 @@ Documentation = 'https://docs.pyvista.org/'
 "Source Code" = 'https://github.com/pyvista/pyvista'
 
 [tool.setuptools.dynamic]
-version = {attr = 'pyvista._version.__version__'}
+version = { attr = 'pyvista._version.__version__' }
 
 [tool.setuptools.packages.find]
-include = [
-    'pyvista',
-    'pyvista.*',
-]
+include = ['pyvista', 'pyvista.*']
 
 [tool.setuptools.package-data]
-pyvista = [
-    'py.typed',
-]
+pyvista = ['py.typed']
 "pyvista.examples" = [
-    '2k_earth_daymap.jpg',
-    'airplane.ply',
-    'ant.ply',
-    'channels.vti',
-    'frog_tissues.vti',
-    'globe.vtk',
-    'hexbeam.vtk',
-    'nut.ply',
-    'pyvista_logo.png',
-    'rectilinear.vtk',
-    'sphere.ply',
-    'uniform.vtk',
+  '2k_earth_daymap.jpg',
+  'airplane.ply',
+  'ant.ply',
+  'channels.vti',
+  'frog_tissues.vti',
+  'globe.vtk',
+  'hexbeam.vtk',
+  'nut.ply',
+  'pyvista_logo.png',
+  'rectilinear.vtk',
+  'sphere.ply',
+  'uniform.vtk',
 ]
 
 [tool.blackdoc]
@@ -202,28 +181,28 @@ quiet-level = 3
 
 [tool.coverage.run]
 omit = [
-    'pyvista/conftest.py',
-    'pyvista/ext/coverage.py',
-    'pyvista/plotting/theme.py',  # kept for backwards compatibility
+  'pyvista/conftest.py',
+  'pyvista/ext/coverage.py',
+  'pyvista/plotting/theme.py', # kept for backwards compatibility
 ]
 
 [tool.pytest.ini_options]
 junit_family = 'legacy'
 filterwarnings = [
-    'error::pyvista.PyVistaDeprecationWarning',
-    'ignore:.*Given trait value dtype "float64":UserWarning',  # bogus numpy ABI warning (see numpy/#432)
-    'ignore:.*numpy.dtype size changed.*:RuntimeWarning',  # bogus numpy ABI warning (see numpy/#432)
-    'ignore:.*numpy.ufunc size changed.*:RuntimeWarning',  # bogus numpy ABI warning (see numpy/#432)
-    'ignore:.*The NumPy module was reloaded*:UserWarning',  # bogus numpy ABI warning (see numpy/#432)
-    'ignore::DeprecationWarning',
-    'ignore::FutureWarning',
-    'ignore::PendingDeprecationWarning',
+  'error::pyvista.PyVistaDeprecationWarning',
+  'ignore:.*Given trait value dtype "float64":UserWarning', # bogus numpy ABI warning (see numpy/#432)
+  'ignore:.*The NumPy module was reloaded*:UserWarning',    # bogus numpy ABI warning (see numpy/#432)
+  'ignore:.*numpy.dtype size changed.*:RuntimeWarning',     # bogus numpy ABI warning (see numpy/#432)
+  'ignore:.*numpy.ufunc size changed.*:RuntimeWarning',     # bogus numpy ABI warning (see numpy/#432)
+  'ignore::DeprecationWarning',
+  'ignore::FutureWarning',
+  'ignore::PendingDeprecationWarning',
 ]
 doctest_optionflags = 'NUMBER ELLIPSIS'
 testpaths = 'tests'
 markers = [
-    'needs_download: this test downloads data during execution',
-    'needs_vtk_version(version): skip test unless VTK version is at least as specified.',
+  'needs_download: this test downloads data during execution',
+  'needs_vtk_version(version): skip test unless VTK version is at least as specified.',
 ]
 image_cache_dir = "tests/plotting/image_cache"
 
@@ -235,56 +214,47 @@ show_error_context = true
 warn_unused_ignores = true
 warn_redundant_casts = true
 plugins = ['npt_promote', 'numpy.typing.mypy_plugin']
-enable_error_code = [
-    "ignore-without-code",
-]
+enable_error_code = ["ignore-without-code"]
 exclude = ['pyvista/ext/']
 packages = ['pyvista']
 
 [tool.numpydoc_validation]
 checks = [
-    "all",  # all but the following:
-    "ES01",  # Not all docstrings need an extend summary.
-    "EX01",  # Examples: Will eventually enforce
-    "GL01",  # Contradicts numpydoc examples
-    "GL02",  # Permit a blank line after the end of our docstring
-    "GL03",  # Considering enforcing
-    "GL06",  # Found unknown section
-    "GL07",  # "Sections are in the wrong order. Correct order is: {correct_sections}",
-    "GL09",  # Deprecation warning should precede extended summary (check broken)
-    "PR01",  # "Parameters {missing_params} not documented",
-    "PR02",  # "Unknown parameters {unknown_params}",
-    "PR03",  # "Wrong parameters order. Actual: {actual_params}. Documented: {documented_params}",
-    "PR04",  # 'Parameter "{param_name}" has no type',
-    "PR05",  # 'Parameter "{param_name}" type should not finish with "."',
-    "PR06",  # 'Parameter "{param_name}" type should use "{right_type}" instead of "{wrong_type}"',
-    "PR07",  # 'Parameter "{param_name}" has no description',
-    "PR08",  # 'Parameter "{param_name}" description should start with a capital letter",
-    "PR09",  # 'Parameter "{param_name}" description should finish with "."',
-    "PR10",  # 'Parameter "{param_name}" requires a space before the colon separating the parameter name and type",
-    "SA01",  # Not all docstrings need a see also
-    "SA04",  # See also section does not need descriptions
-    "SS05",  # Appears to be broken.
-    "YD01",  # Yields: No plan to enforce
+  "ES01", # Not all docstrings need an extend summary.
+  "EX01", # Examples: Will eventually enforce
+  "GL01", # Contradicts numpydoc examples
+  "GL02", # Permit a blank line after the end of our docstring
+  "GL03", # Considering enforcing
+  "GL06", # Found unknown section
+  "GL07", # "Sections are in the wrong order. Correct order is: {correct_sections}",
+  "GL09", # Deprecation warning should precede extended summary (check broken)
+  "PR01", # "Parameters {missing_params} not documented",
+  "PR02", # "Unknown parameters {unknown_params}",
+  "PR03", # "Wrong parameters order. Actual: {actual_params}. Documented: {documented_params}",
+  "PR04", # 'Parameter "{param_name}" has no type',
+  "PR05", # 'Parameter "{param_name}" type should not finish with "."',
+  "PR06", # 'Parameter "{param_name}" type should use "{right_type}" instead of "{wrong_type}"',
+  "PR07", # 'Parameter "{param_name}" has no description',
+  "PR08", # 'Parameter "{param_name}" description should start with a capital letter",
+  "PR09", # 'Parameter "{param_name}" description should finish with "."',
+  "PR10", # 'Parameter "{param_name}" requires a space before the colon separating the parameter name and type",
+  "SA01", # Not all docstrings need a see also
+  "SA04", # See also section does not need descriptions
+  "SS05", # Appears to be broken.
+  "YD01", # Yields: No plan to enforce
+  "all",  # all but the following:
 ]
 # don't report on objects that match any of these regex
 exclude = [
-    '\.*Reader(\.|$)',  # classes inherit from BaseReader
-    '\._.*$',  # Ignore anything that's private (e.g., starts with _)
-    '^coverage\..*$',
-    '^plot_directive\..*$',
-    '^viewer_directive\..*$',
+  '\.*Reader(\.|$)',        # classes inherit from BaseReader
+  '\._.*$',                 # Ignore anything that's private (e.g., starts with _)
+  '^coverage\..*$',
+  '^plot_directive\..*$',
+  '^viewer_directive\..*$',
 ]
 
 [tool.ruff]
-exclude = [
-    '.git',
-    'build',
-    'dist',
-    'doc/_build',
-    'doc/examples',
-    'pycache__',
-]
+exclude = ['.git', 'build', 'dist', 'doc/_build', 'doc/examples', 'pycache__']
 line-length = 100
 indent-width = 4
 
@@ -295,81 +265,81 @@ quote-style = "single"
 [tool.ruff.lint]
 external = ["E131"]
 ignore = [
-    "B028",  # https://github.com/pyvista/pyvista/pull/6030
-    "B904",  # https://github.com/pyvista/pyvista/pull/6022
-    "COM812",  # May cause conflicts when used with the formatter
-    "D105",  # Missing docstring in magic method
-    "D107",  # Missing docstring in `__init__`
-    "D203",  # May conflict with the formatter
-    "D211",  # Incompatible with D203
-    "D213",  # Incompatible with D212
-    "D402",  # First line should not be the function's signature
-    "D416",  # Section name ends in colon
-    "E203",  # whitespace before ':'
-    "E266",  # too many leading '#' for block comment
-    "E402",  # module level import not at top of file
-    "E501",  # line length too long
-    "E722",
-    "E731",  # do not assign a lambda expression, use a def
-    "E741",  # ambiguous variable name
-    "F403",  # 'from module import *' used; unable to detect undefined names
-    "ISC001",  # May cause conflicts when used with the formatter
-    "PERF203",  # https://github.com/pyvista/pyvista/pull/6037
-    "Q0",  # Quotes (temporary)
-    "RET505",  # https://github.com/pyvista/pyvista/pull/5911
-    "RET506",  # https://github.com/pyvista/pyvista/pull/5911
-    "RET507",  # https://github.com/pyvista/pyvista/pull/5911
-    "SIM102",  # https://github.com/pyvista/pyvista/pull/5877
-    "SIM117",  # https://github.com/pyvista/pyvista/pull/5888
-    "SIM118",  # https://github.com/pyvista/pyvista/pull/5837
+  "B028",    # https://github.com/pyvista/pyvista/pull/6030
+  "B904",    # https://github.com/pyvista/pyvista/pull/6022
+  "COM812",  # May cause conflicts when used with the formatter
+  "D105",    # Missing docstring in magic method
+  "D107",    # Missing docstring in `__init__`
+  "D203",    # May conflict with the formatter
+  "D211",    # Incompatible with D203
+  "D213",    # Incompatible with D212
+  "D402",    # First line should not be the function's signature
+  "D416",    # Section name ends in colon
+  "E203",    # whitespace before ':'
+  "E266",    # too many leading '#' for block comment
+  "E402",    # module level import not at top of file
+  "E501",    # line length too long
+  "E722",
+  "E731",    # do not assign a lambda expression, use a def
+  "E741",    # ambiguous variable name
+  "F403",    # 'from module import *' used; unable to detect undefined names
+  "ISC001",  # May cause conflicts when used with the formatter
+  "PERF203", # https://github.com/pyvista/pyvista/pull/6037
+  "Q0",      # Quotes (temporary)
+  "RET505",  # https://github.com/pyvista/pyvista/pull/5911
+  "RET506",  # https://github.com/pyvista/pyvista/pull/5911
+  "RET507",  # https://github.com/pyvista/pyvista/pull/5911
+  "SIM102",  # https://github.com/pyvista/pyvista/pull/5877
+  "SIM117",  # https://github.com/pyvista/pyvista/pull/5888
+  "SIM118",  # https://github.com/pyvista/pyvista/pull/5837
 ]
 fixable = ["ALL"]
 unfixable = []
 extend-select = [
-    "A",
-    "AIR",
-    "ASYNC",
-    "ASYNC1",
-    "B",
-    "C4",
-    "COM",
-    "D",
-    "DJ",
-    "DTZ",
-    "E",
-    "F",
-    "FA",
-    "FLY",
-    "I",
-    "ICN",
-    "INT",
-    "ISC",
-    "LOG",
-    "NPY",
-    "PERF",
-    "PGH",
-    "PIE",
-    "PLC",
-    "PLR0402",
-    "PLR1711",
-    "PLR1714",
-    "PLW0127",
-    "PT",
-    "PTH",
-    "PYI",
-    "Q",
-    "RET",
-    "RSE",
-    "RUF",
-    "SIM",
-    "T10",
-    "TCH",
-    "TRY201",
-    "TRY203",
-    "TRY300",
-    "UP",
-    "W",
-    "YTT",
+  "A",
+  "AIR",
+  "ASYNC",
+  "ASYNC1",
+  "B",
+  "C4",
+  "COM",
+  "D",
+  "DJ",
+  "DTZ",
+  "E",
+  "F",
+  "FA",
+  "FLY",
+  "I",
+  "ICN",
+  "INT",
+  "ISC",
+  "LOG",
+  "NPY",
+  "PERF",
+  "PGH",
+  "PIE",
+  "PLC",
+  "PLR0402",
+  "PLR1711",
+  "PLR1714",
+  "PLW0127",
+  "PT",
+  "PTH",
+  "PYI",
+  "Q",
+  "RET",
+  "RSE",
+  "RUF",
+  "SIM",
+  "T10",
+  "TCH",
+  "TRY201",
+  "TRY203",
+  "TRY300",
+  "UP",
+  "W",
+  "YTT",
 ]
 
 [tool.ruff.lint.flake8-comprehensions]
@@ -377,8 +347,8 @@ allow-dict-calls-with-keyword-arguments = true
 
 [tool.ruff.lint.per-file-ignores]
 "examples/**" = [
-    "B015",  # https://github.com/pyvista/pyvista/pull/6014
-    "B018",  # https://github.com/pyvista/pyvista/pull/6019
+  "B015", # https://github.com/pyvista/pyvista/pull/6014
+  "B018", # https://github.com/pyvista/pyvista/pull/6019
 ]
 "doc/source/make_tables.py" = ["D101", "D102"]
 "examples/*" = ["D102", "D103", "D205", "D212", "D400", "D415", "SIM115"]
@@ -400,14 +370,3 @@ force-single-line = true
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.
 keep-runtime-typing = true
-
-[tool.tomlsort]
-in_place = true
-# Sorting options:
-no_sort_tables = true
-sort_inline_arrays = true
-ignore_case = true
-# Formatting options:
-spaces_before_inline_comment = 2
-spaces_indent_inline_array = 4
-trailing_comma_inline_array = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,10 @@ typing = [
     'pyvista[pinned]',
 ]
 test = [
+    # Embreex does not work with arm-based macs
+    "embreex<2.17.8; sys_platform != 'darwin' or platform_machine != 'arm64'",
     'cmocean<4.0.4',
     'colorcet<3.2.0',
-    # Embreex does not work with arm-based macs
-    'embreex<2.17.8; sys_platform != "darwin" or platform_machine != "arm64"',
     'hypothesis<6.115.6',
     'imageio-ffmpeg<0.6.0',
     'imageio<2.37.0',
@@ -152,6 +152,34 @@ Documentation = 'https://docs.pyvista.org/'
 "Bug Tracker" = 'https://github.com/pyvista/pyvista/issues'
 "Source Code" = 'https://github.com/pyvista/pyvista'
 
+[tool.setuptools.dynamic]
+version = {attr = 'pyvista._version.__version__'}
+
+[tool.setuptools.packages.find]
+include = [
+    'pyvista',
+    'pyvista.*',
+]
+
+[tool.setuptools.package-data]
+pyvista = [
+    'py.typed',
+]
+"pyvista.examples" = [
+    '2k_earth_daymap.jpg',
+    'airplane.ply',
+    'ant.ply',
+    'channels.vti',
+    'frog_tissues.vti',
+    'globe.vtk',
+    'hexbeam.vtk',
+    'nut.ply',
+    'pyvista_logo.png',
+    'rectilinear.vtk',
+    'sphere.ply',
+    'uniform.vtk',
+]
+
 [tool.blackdoc]
 # From https://numpydoc.readthedocs.io/en/latest/format.html
 # Extended discussion: https://github.com/pyvista/pyvista/pull/4129
@@ -163,6 +191,9 @@ line-length = 75
 source-dir = 'doc'
 build-dir = './doc/_build'
 all_files = 1
+
+[tool.upload_sphinx]
+upload-dir = 'doc/_build/html'
 
 [tool.codespell]
 skip = '*.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.vtu,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,doc/_build/*,./doc/images/*,./dist/*,*~,.hypothesis*,./doc/examples/*,*.mypy_cache/*,*cover,./tests/tinypages/_build/*,*/_autosummary/*'
@@ -176,6 +207,27 @@ omit = [
     # kept for backwards compatibility:
     'pyvista/plotting/theme.py',
 ]
+
+[tool.pytest.ini_options]
+junit_family = 'legacy'
+filterwarnings = [
+    'error::pyvista.PyVistaDeprecationWarning',
+    'ignore:.*Given trait value dtype "float64":UserWarning',
+    # bogus numpy ABI warning (see numpy/#432)
+    'ignore:.*numpy.dtype size changed.*:RuntimeWarning',
+    'ignore:.*numpy.ufunc size changed.*:RuntimeWarning',
+    'ignore:.*The NumPy module was reloaded*:UserWarning',
+    'ignore::DeprecationWarning',
+    'ignore::FutureWarning',
+    'ignore::PendingDeprecationWarning',
+]
+doctest_optionflags = 'NUMBER ELLIPSIS'
+testpaths = 'tests'
+markers = [
+    'needs_download: this test downloads data during execution',
+    'needs_vtk_version(version): skip test unless VTK version is at least as specified.',
+]
+image_cache_dir = "tests/plotting/image_cache"
 
 [tool.mypy]
 ignore_missing_imports = true
@@ -227,27 +279,6 @@ exclude = [
     # Documentation extensions or utilities
     '^viewer_directive\..*$',
 ]
-
-[tool.pytest.ini_options]
-junit_family = 'legacy'
-filterwarnings = [
-    'error::pyvista.PyVistaDeprecationWarning',
-    'ignore:.*Given trait value dtype "float64":UserWarning',
-    # bogus numpy ABI warning (see numpy/#432)
-    'ignore:.*numpy.dtype size changed.*:RuntimeWarning',
-    'ignore:.*numpy.ufunc size changed.*:RuntimeWarning',
-    'ignore:.*The NumPy module was reloaded*:UserWarning',
-    'ignore::DeprecationWarning',
-    'ignore::FutureWarning',
-    'ignore::PendingDeprecationWarning',
-]
-doctest_optionflags = 'NUMBER ELLIPSIS'
-testpaths = 'tests'
-markers = [
-    'needs_download: this test downloads data during execution',
-    'needs_vtk_version(version): skip test unless VTK version is at least as specified.',
-]
-image_cache_dir = "tests/plotting/image_cache"
 
 [tool.ruff]
 exclude = [
@@ -368,16 +399,6 @@ extend-select = [
 [tool.ruff.lint.flake8-comprehensions]
 allow-dict-calls-with-keyword-arguments = true
 
-[tool.ruff.lint.isort]
-# Sort by name, don't cluster "from" vs "import"
-force-sort-within-sections = true
-# Combines "as" imports on the same line
-combine-as-imports = true
-# https://github.com/pyvista/pyvista/pull/5712
-required-imports = ["from __future__ import annotations"]
-# https://github.com/pyvista/pyvista/pull/5712
-force-single-line = true
-
 [tool.ruff.lint.per-file-ignores]
 "examples/**" = [
     # https://github.com/pyvista/pyvista/pull/6014
@@ -392,46 +413,27 @@ force-single-line = true
 "pyvista/ext/*" = ["D100", "D101", "D102", "D103"]
 "tests/*" = ["D"]
 
+[tool.ruff.lint.isort]
+# Sort by name, don't cluster "from" vs "import"
+force-sort-within-sections = true
+# Combines "as" imports on the same line
+combine-as-imports = true
+# https://github.com/pyvista/pyvista/pull/5712
+required-imports = ["from __future__ import annotations"]
+# https://github.com/pyvista/pyvista/pull/5712
+force-single-line = true
+
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.
 keep-runtime-typing = true
 
-[tool.setuptools.dynamic]
-version = {attr = 'pyvista._version.__version__'}
-
-[tool.setuptools.package-data]
-pyvista = [
-    'py.typed',
-]
-"pyvista.examples" = [
-    '2k_earth_daymap.jpg',
-    'airplane.ply',
-    'ant.ply',
-    'channels.vti',
-    'frog_tissues.vti',
-    'globe.vtk',
-    'hexbeam.vtk',
-    'nut.ply',
-    'pyvista_logo.png',
-    'rectilinear.vtk',
-    'sphere.ply',
-    'uniform.vtk',
-]
-
-[tool.setuptools.packages.find]
-include = [
-    'pyvista',
-    'pyvista.*',
-]
-
 [tool.tomlsort]
 in_place = true
-sort_first = ["key2", "pyvista[pinned]"]
+# Sorting options:
+no_sort_tables = true
+sort_inline_arrays = true
+ignore_case = true
+# Formatting options:
 spaces_before_inline_comment = 2
 spaces_indent_inline_array = 4
 trailing_comma_inline_array = true
-sort_inline_arrays = true
-ignore_case = true
-
-[tool.upload_sphinx]
-upload-dir = 'doc/_build/html'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,7 @@ typing = ['mypy<1.14.0', 'npt-promote==0.1', 'numpy>=2.0.0', 'pyvista[pinned]']
 test = [
   'cmocean<4.0.4',
   'colorcet<3.2.0',
-  'pyvista[pinned]',
-  # Embreex does not work with arm-based macs
-  'embreex<2.17.8; sys_platform != "darwin" or platform_machine != "arm64"',
+  'embreex<2.17.8; sys_platform != "darwin" or platform_machine != "arm64"', # Does not work with arm-based macs
   'hypothesis<6.115.6',
   'imageio-ffmpeg<0.6.0',
   'imageio<2.37.0',
@@ -79,6 +77,7 @@ test = [
   'pytest-pyvista==0.1.8',
   'pytest-xdist<3.7.0',
   'pytest<8.4.0',
+  'pyvista[pinned]',
   'scipy<1.14.2',
   'sphinx-book-theme<1.2.0',
   'sphinx-gallery<0.19.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ pinned = [
 typing = ['mypy<1.14.0', 'npt-promote==0.1', 'numpy>=2.0.0', 'pyvista[pinned]']
 test = [
   # Embreex does not work with arm-based macs
-  "embreex<2.17.8; sys_platform != 'darwin' or platform_machine != 'arm64'",
+  'embreex<2.17.8; sys_platform != "darwin" or platform_machine != "arm64"',
   'cmocean<4.0.4',
   'colorcet<3.2.0',
   'hypothesis<6.115.6',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,145 +6,145 @@ build-backend = 'setuptools.build_meta'
 name = 'pyvista'
 description = 'Easier Pythonic interface to VTK'
 authors = [
-  {name = 'PyVista Developers', email = 'info@pyvista.org'}
+    {name = 'PyVista Developers', email = 'info@pyvista.org'},
 ]
 readme = 'README.rst'
 requires-python = '>=3.9'
-keywords = ['vtk', 'numpy', 'plotting', 'mesh']
+keywords = ['mesh', 'numpy', 'plotting', 'vtk']
 license = {text = 'MIT'}
 classifiers = [
-  'Development Status :: 5 - Production/Stable',
-  'Intended Audience :: Science/Research',
-  'Topic :: Scientific/Engineering :: Information Analysis',
-  'License :: OSI Approved :: MIT License',
-  'Operating System :: Microsoft :: Windows',
-  'Operating System :: POSIX',
-  'Operating System :: MacOS',
-  'Programming Language :: Python :: 3.9',
-  'Programming Language :: Python :: 3.10',
-  'Programming Language :: Python :: 3.11',
-  'Programming Language :: Python :: 3.12'
+    'Development Status :: 5 - Production/Stable',
+    'Intended Audience :: Science/Research',
+    'License :: OSI Approved :: MIT License',
+    'Operating System :: MacOS',
+    'Operating System :: Microsoft :: Windows',
+    'Operating System :: POSIX',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.9',
+    'Topic :: Scientific/Engineering :: Information Analysis',
 ]
 dependencies = [
-  'matplotlib>=3.0.1',
-  'numpy>=1.21.0', # minimum typing support
-  'pillow',
-  'pooch',
-  'scooby>=0.5.1',
-  'vtk', # keep without version constraints
-  'typing-extensions'
+    'matplotlib>=3.0.1',
+    'numpy>=1.21.0',  # minimum typing support
+    'pillow',
+    'pooch',
+    'scooby>=0.5.1',
+    'typing-extensions',
+    'vtk',  # keep without version constraints
 ]
 dynamic = ['version']
 
 [project.optional-dependencies]
 all = ['pyvista[colormaps,io,jupyter]']
 colormaps = [
-  'cmocean',
-  'colorcet'
+    'cmocean',
+    'colorcet',
 ]
 io = [
-  'imageio',
-  'meshio>=5.2'
+    'imageio',
+    'meshio>=5.2',
 ]
 jupyter = [
-  'ipywidgets',
-  'jupyter-server-proxy',
-  'nest_asyncio',
-  'trame>=2.5.2',
-  'trame-client>=2.12.7',
-  'trame-server>=2.11.7',
-  'trame-vtk>=2.5.8',
-  'trame-vuetify>=2.3.1'
+    'ipywidgets',
+    'jupyter-server-proxy',
+    'nest_asyncio',
+    'trame-client>=2.12.7',
+    'trame-server>=2.11.7',
+    'trame-vtk>=2.5.8',
+    'trame-vuetify>=2.3.1',
+    'trame>=2.5.2',
 ]
 pinned = [
-  # Pinned versions of core dependencies
-  'matplotlib<3.9.3',
-  'numpy<2.2.0',
-  'pillow<11.1.0',
-  'pooch<1.9.0',
-  'scooby<0.11.0',
-  'vtk<9.4.0',
-  'typing-extensions<4.13.0'
+    # Pinned versions of core dependencies
+    'matplotlib<3.9.3',
+    'numpy<2.2.0',
+    'pillow<11.1.0',
+    'pooch<1.9.0',
+    'scooby<0.11.0',
+    'typing-extensions<4.13.0',
+    'vtk<9.4.0',
 ]
 typing = [
-  'pyvista[pinned]',
-  'numpy>=2.0.0',
-  'mypy<1.14.0',
-  'npt-promote==0.1'
+    'mypy<1.14.0',
+    'npt-promote==0.1',
+    'numpy>=2.0.0',
+    'pyvista[pinned]',
 ]
 test = [
-  'pyvista[pinned]',
-  'cmocean<4.0.4',
-  'colorcet<3.2.0',
-  # Embreex does not work with arm-based macs
-  "embreex<2.17.8; sys_platform != 'darwin' or platform_machine != 'arm64'",
-  'hypothesis<6.115.6',
-  'imageio<2.37.0',
-  'imageio-ffmpeg<0.6.0',
-  'ipython<9.0.0',
-  'ipywidgets<9.0.0',
-  'meshio<5.4.0',
-  'nest_asyncio<1.6.1',
-  'numpydoc==1.8.0',
-  'pyanalyze<=0.13.1',
-  'pytest<8.4.0',
-  'pytest-cov<6.1.0',
-  'pytest-memprof<0.3.0',
-  'pytest-pyvista==0.1.8',
-  'pytest-xdist<3.7.0',
-  'scipy<1.14.2',
-  'sphinx<8.2.0',
-  'sphinx-book-theme<1.2.0',
-  'sphinx-gallery<0.19.0',
-  'sphinx_design<0.7.0',
-  'sympy<1.14.0',
-  'tqdm<4.67.0',
-  'trame>=2.5.2,<3.7.1',
-  'trame-vtk>=2.5.8,<2.8.12',
-  'trame-vuetify>=2.3.1,<2.7.2',
-  'trimesh<4.6.0',
-  'typing-extensions<4.13.0'
+    'cmocean<4.0.4',
+    'colorcet<3.2.0',
+    # Embreex does not work with arm-based macs
+    'embreex<2.17.8; sys_platform != "darwin" or platform_machine != "arm64"',
+    'hypothesis<6.115.6',
+    'imageio-ffmpeg<0.6.0',
+    'imageio<2.37.0',
+    'ipython<9.0.0',
+    'ipywidgets<9.0.0',
+    'meshio<5.4.0',
+    'nest_asyncio<1.6.1',
+    'numpydoc==1.8.0',
+    'pyanalyze<=0.13.1',
+    'pytest-cov<6.1.0',
+    'pytest-memprof<0.3.0',
+    'pytest-pyvista==0.1.8',
+    'pytest-xdist<3.7.0',
+    'pytest<8.4.0',
+    'pyvista[pinned]',
+    'scipy<1.14.2',
+    'sphinx-book-theme<1.2.0',
+    'sphinx-gallery<0.19.0',
+    'sphinx<8.2.0',
+    'sphinx_design<0.7.0',
+    'sympy<1.14.0',
+    'tqdm<4.67.0',
+    'trame-vtk>=2.5.8,<2.8.12',
+    'trame-vuetify>=2.3.1,<2.7.2',
+    'trame>=2.5.2,<3.7.1',
+    'trimesh<4.6.0',
+    'typing-extensions<4.13.0',
 ]
 docs = [
-  'pyvista[pinned]',
-  'cmocean==4.0.3',
-  'colorcet==3.1.0',
-  'enum-tools==0.12.0',
-  'imageio==2.36.0',
-  'imageio-ffmpeg==0.5.1',
-  'jupyter_sphinx==0.5.3',
-  'jupyterlab==4.2.5',
-  'lxml==5.3.0',
-  'meshio==5.3.5',
-  'mypy==1.13.0',
-  'mypy-extensions==1.0.0',
-  'numpydoc==1.8.0',
-  'osmnx==1.9.4',
-  'pypandoc==1.14',
-  'pytest-sphinx==0.6.3',
-  'scipy==1.14.1',
-  'sphinx==8.1.3',
-  'sphinx-autobuild==2024.10.3',
-  'sphinx-book-theme==1.1.3',
-  'sphinx-copybutton==0.5.2',
-  'sphinx-design==0.6.1',
-  'sphinx-gallery==0.18.0',
-  'sphinx-notfound-page==1.0.4',
-  'sphinx-sitemap==2.6.0',
-  'sphinx-tags==0.4.0',
-  'sphinx-toolbox==3.8.1',
-  'sphinxcontrib-asciinema==0.4.2',
-  'sphinxcontrib-websupport==2.0.0',
-  'sphinxext-opengraph==0.9.1',
-  'sympy==1.13.3',
-  'trame==3.7.0',
-  'trame-vtk==2.8.11',
-  'trame-vuetify==2.7.1',
-  'trimesh==4.5.2'
+    'cmocean==4.0.3',
+    'colorcet==3.1.0',
+    'enum-tools==0.12.0',
+    'imageio-ffmpeg==0.5.1',
+    'imageio==2.36.0',
+    'jupyter_sphinx==0.5.3',
+    'jupyterlab==4.2.5',
+    'lxml==5.3.0',
+    'meshio==5.3.5',
+    'mypy-extensions==1.0.0',
+    'mypy==1.13.0',
+    'numpydoc==1.8.0',
+    'osmnx==1.9.4',
+    'pypandoc==1.14',
+    'pytest-sphinx==0.6.3',
+    'pyvista[pinned]',
+    'scipy==1.14.1',
+    'sphinx-autobuild==2024.10.3',
+    'sphinx-book-theme==1.1.3',
+    'sphinx-copybutton==0.5.2',
+    'sphinx-design==0.6.1',
+    'sphinx-gallery==0.18.0',
+    'sphinx-notfound-page==1.0.4',
+    'sphinx-sitemap==2.6.0',
+    'sphinx-tags==0.4.0',
+    'sphinx-toolbox==3.8.1',
+    'sphinx==8.1.3',
+    'sphinxcontrib-asciinema==0.4.2',
+    'sphinxcontrib-websupport==2.0.0',
+    'sphinxext-opengraph==0.9.1',
+    'sympy==1.13.3',
+    'trame-vtk==2.8.11',
+    'trame-vuetify==2.7.1',
+    'trame==3.7.0',
+    'trimesh==4.5.2',
 ]
 dev = [
-  'pyvista[test,docs]',
-  'pre-commit'
+    'pre-commit',
+    'pyvista[test,docs]',
 ]
 
 [project.urls]
@@ -171,10 +171,10 @@ quiet-level = 3
 
 [tool.coverage.run]
 omit = [
-  'pyvista/ext/coverage.py',
-  'pyvista/conftest.py',
-  # kept for backwards compatibility:
-  'pyvista/plotting/theme.py'
+    'pyvista/conftest.py',
+    'pyvista/ext/coverage.py',
+    # kept for backwards compatibility:
+    'pyvista/plotting/theme.py',
 ]
 
 [tool.mypy]
@@ -184,79 +184,79 @@ pretty = true
 show_error_context = true
 warn_unused_ignores = true
 warn_redundant_casts = true
-plugins = ['numpy.typing.mypy_plugin', 'npt_promote']
+plugins = ['npt_promote', 'numpy.typing.mypy_plugin']
 enable_error_code = [
-  "ignore-without-code"
+    "ignore-without-code",
 ]
 exclude = ['pyvista/ext/']
 packages = ['pyvista']
 
 [tool.numpydoc_validation]
 checks = [
-  "all", # all but the following:
-  "GL01", # Contradicts numpydoc examples
-  "GL02", # Permit a blank line after the end of our docstring
-  "GL03", # Considering enforcing
-  "GL06", # Found unknown section
-  "GL07", # "Sections are in the wrong order. Correct order is: {correct_sections}",
-  "GL09", # Deprecation warning should precede extended summary (check broken)
-  "PR01", # "Parameters {missing_params} not documented",
-  "PR02", # "Unknown parameters {unknown_params}",
-  "PR03", # "Wrong parameters order. Actual: {actual_params}. Documented: {documented_params}",
-  "PR04", # 'Parameter "{param_name}" has no type',
-  "PR05", # 'Parameter "{param_name}" type should not finish with "."',
-  "PR06", # 'Parameter "{param_name}" type should use "{right_type}" instead of "{wrong_type}"',
-  "PR07", # 'Parameter "{param_name}" has no description',
-  "PR08", # 'Parameter "{param_name}" description should start with a capital letter",
-  "PR09", # 'Parameter "{param_name}" description should finish with "."',
-  "PR10", # 'Parameter "{param_name}" requires a space before the colon separating the parameter name and type",
-  "SA01", # Not all docstrings need a see also
-  "SA04", # See also section does not need descriptions
-  "SS05", # Appears to be broken.
-  "ES01", # Not all docstrings need an extend summary.
-  "EX01", # Examples: Will eventually enforce
-  "YD01" # Yields: No plan to enforce
+    "all",  # all but the following:
+    "ES01",  # Not all docstrings need an extend summary.
+    "EX01",  # Examples: Will eventually enforce
+    "GL01",  # Contradicts numpydoc examples
+    "GL02",  # Permit a blank line after the end of our docstring
+    "GL03",  # Considering enforcing
+    "GL06",  # Found unknown section
+    "GL07",  # "Sections are in the wrong order. Correct order is: {correct_sections}",
+    "GL09",  # Deprecation warning should precede extended summary (check broken)
+    "PR01",  # "Parameters {missing_params} not documented",
+    "PR02",  # "Unknown parameters {unknown_params}",
+    "PR03",  # "Wrong parameters order. Actual: {actual_params}. Documented: {documented_params}",
+    "PR04",  # 'Parameter "{param_name}" has no type',
+    "PR05",  # 'Parameter "{param_name}" type should not finish with "."',
+    "PR06",  # 'Parameter "{param_name}" type should use "{right_type}" instead of "{wrong_type}"',
+    "PR07",  # 'Parameter "{param_name}" has no description',
+    "PR08",  # 'Parameter "{param_name}" description should start with a capital letter",
+    "PR09",  # 'Parameter "{param_name}" description should finish with "."',
+    "PR10",  # 'Parameter "{param_name}" requires a space before the colon separating the parameter name and type",
+    "SA01",  # Not all docstrings need a see also
+    "SA04",  # See also section does not need descriptions
+    "SS05",  # Appears to be broken.
+    "YD01",  # Yields: No plan to enforce
 ]
 exclude = [
-  # don't report on objects that match any of these regex
-  '\._.*$', # Ignore anything that's private (e.g., starts with _)
-  # classes inherit from BaseReader
-  '\.*Reader(\.|$)',
-  # Documentation extensions or utilities
-  '^viewer_directive\..*$',
-  '^plot_directive\..*$',
-  '^coverage\..*$'
+    # classes inherit from BaseReader
+    '\.*Reader(\.|$)',
+    # don't report on objects that match any of these regex
+    '\._.*$',  # Ignore anything that's private (e.g., starts with _)
+    '^coverage\..*$',
+    '^plot_directive\..*$',
+    # Documentation extensions or utilities
+    '^viewer_directive\..*$',
 ]
 
 [tool.pytest.ini_options]
 junit_family = 'legacy'
 filterwarnings = [
-  'ignore::FutureWarning',
-  'ignore::PendingDeprecationWarning',
-  'ignore::DeprecationWarning',
-  # bogus numpy ABI warning (see numpy/#432)
-  'ignore:.*numpy.dtype size changed.*:RuntimeWarning',
-  'ignore:.*numpy.ufunc size changed.*:RuntimeWarning',
-  'ignore:.*Given trait value dtype "float64":UserWarning',
-  'ignore:.*The NumPy module was reloaded*:UserWarning',
-  'error::pyvista.PyVistaDeprecationWarning'
+    'error::pyvista.PyVistaDeprecationWarning',
+    'ignore:.*Given trait value dtype "float64":UserWarning',
+    # bogus numpy ABI warning (see numpy/#432)
+    'ignore:.*numpy.dtype size changed.*:RuntimeWarning',
+    'ignore:.*numpy.ufunc size changed.*:RuntimeWarning',
+    'ignore:.*The NumPy module was reloaded*:UserWarning',
+    'ignore::DeprecationWarning',
+    'ignore::FutureWarning',
+    'ignore::PendingDeprecationWarning',
 ]
 doctest_optionflags = 'NUMBER ELLIPSIS'
 testpaths = 'tests'
 markers = [
-  'needs_vtk_version(version): skip test unless VTK version is at least as specified.',
-  'needs_download: this test downloads data during execution'
+    'needs_download: this test downloads data during execution',
+    'needs_vtk_version(version): skip test unless VTK version is at least as specified.',
 ]
 image_cache_dir = "tests/plotting/image_cache"
 
 [tool.ruff]
 exclude = [
-  '.git',
-  'pycache__',
-  'build',
-  'dist',
-  'doc/examples',
-  'doc/_build'
+    '.git',
+    'build',
+    'dist',
+    'doc/_build',
+    'doc/examples',
+    'pycache__',
 ]
 line-length = 100
 indent-width = 4
@@ -268,101 +268,101 @@ quote-style = "single"
 [tool.ruff.lint]
 external = ["E131"]
 ignore = [
-  # https://github.com/pyvista/pyvista/pull/6030
-  "B028",
-  # https://github.com/pyvista/pyvista/pull/6022
-  "B904",
-  "D105", # Missing docstring in magic method
-  "D107", # Missing docstring in `__init__`
-  "D203", # May conflict with the formatter
-  "D211", # Incompatible with D203
-  "D213", # Incompatible with D212
-  "D402", # First line should not be the function's signature
-  "D416", # Section name ends in colon
-  # whitespace before ':'
-  "E203",
-  # line break before binary operator
-  # "W503",
-  # line length too long
-  "E501",
-  # do not assign a lambda expression, use a def
-  "E731",
-  # too many leading '#' for block comment
-  "E266",
-  # ambiguous variable name
-  "E741",
-  # module level import not at top of file
-  "E402",
-  # Quotes (temporary)
-  "Q0",
-  # bare excepts (temporary)
-  # "B001", "E722",
-  "E722",
-  # 'from module import *' used; unable to detect undefined names
-  "F403",
-  # https://github.com/pyvista/pyvista/pull/6037
-  "PERF203",
-  # https://github.com/pyvista/pyvista/pull/5877
-  "SIM102",
-  # https://github.com/pyvista/pyvista/pull/5888
-  "SIM117",
-  # https://github.com/pyvista/pyvista/pull/5837
-  "SIM118",
-  # https://github.com/pyvista/pyvista/pull/5911
-  "RET505",
-  "RET506",
-  "RET507",
-  # The following rules may cause conflicts when used with the formatter
-  "COM812",
-  "ISC001"
+    # https://github.com/pyvista/pyvista/pull/6030
+    "B028",
+    # https://github.com/pyvista/pyvista/pull/6022
+    "B904",
+    # The following rules may cause conflicts when used with the formatter
+    "COM812",
+    "D105",  # Missing docstring in magic method
+    "D107",  # Missing docstring in `__init__`
+    "D203",  # May conflict with the formatter
+    "D211",  # Incompatible with D203
+    "D213",  # Incompatible with D212
+    "D402",  # First line should not be the function's signature
+    "D416",  # Section name ends in colon
+    # whitespace before ':'
+    "E203",
+    # too many leading '#' for block comment
+    "E266",
+    # module level import not at top of file
+    "E402",
+    # line break before binary operator
+    # "W503",
+    # line length too long
+    "E501",
+    # bare excepts (temporary)
+    # "B001", "E722",
+    "E722",
+    # do not assign a lambda expression, use a def
+    "E731",
+    # ambiguous variable name
+    "E741",
+    # 'from module import *' used; unable to detect undefined names
+    "F403",
+    "ISC001",
+    # https://github.com/pyvista/pyvista/pull/6037
+    "PERF203",
+    # Quotes (temporary)
+    "Q0",
+    # https://github.com/pyvista/pyvista/pull/5911
+    "RET505",
+    "RET506",
+    "RET507",
+    # https://github.com/pyvista/pyvista/pull/5877
+    "SIM102",
+    # https://github.com/pyvista/pyvista/pull/5888
+    "SIM117",
+    # https://github.com/pyvista/pyvista/pull/5837
+    "SIM118",
 ]
 fixable = ["ALL"]
 unfixable = []
 extend-select = [
-  "A",
-  "AIR",
-  "ASYNC",
-  "ASYNC1",
-  "B",
-  "C4",
-  "COM",
-  "D",
-  "DJ",
-  "DTZ",
-  "E",
-  "F",
-  "FA",
-  "FLY",
-  "I",
-  "ICN",
-  "INT",
-  "ISC",
-  "LOG",
-  "NPY",
-  "PERF",
-  "PGH",
-  "PIE",
-  "PLC",
-  "PLR0402",
-  "PLR1711",
-  "PLR1714",
-  "PLW0127",
-  "PT",
-  "PTH",
-  "PYI",
-  "Q",
-  "RET",
-  "RSE",
-  "RUF",
-  "SIM",
-  "T10",
-  "TCH",
-  "TRY201",
-  "TRY203",
-  "TRY300",
-  "UP",
-  "W",
-  "YTT"
+    "A",
+    "AIR",
+    "ASYNC",
+    "ASYNC1",
+    "B",
+    "C4",
+    "COM",
+    "D",
+    "DJ",
+    "DTZ",
+    "E",
+    "F",
+    "FA",
+    "FLY",
+    "I",
+    "ICN",
+    "INT",
+    "ISC",
+    "LOG",
+    "NPY",
+    "PERF",
+    "PGH",
+    "PIE",
+    "PLC",
+    "PLR0402",
+    "PLR1711",
+    "PLR1714",
+    "PLW0127",
+    "PT",
+    "PTH",
+    "PYI",
+    "Q",
+    "RET",
+    "RSE",
+    "RUF",
+    "SIM",
+    "T10",
+    "TCH",
+    "TRY201",
+    "TRY203",
+    "TRY300",
+    "UP",
+    "W",
+    "YTT",
 ]
 
 [tool.ruff.lint.flake8-comprehensions]
@@ -380,13 +380,13 @@ force-single-line = true
 
 [tool.ruff.lint.per-file-ignores]
 "examples/**" = [
-  # https://github.com/pyvista/pyvista/pull/6014
-  "B015",
-  # https://github.com/pyvista/pyvista/pull/6019
-  "B018"
+    # https://github.com/pyvista/pyvista/pull/6014
+    "B015",
+    # https://github.com/pyvista/pyvista/pull/6019
+    "B018",
 ]
 "doc/source/make_tables.py" = ["D101", "D102"]
-"examples/*" = ["D212", "D102", "D103", "D205", "D400", "D415", "SIM115"]
+"examples/*" = ["D102", "D103", "D205", "D212", "D400", "D415", "SIM115"]
 "examples_trame/*" = ["D100", "D103"]
 "examples_trame/tests*" = ["D"]
 "pyvista/ext/*" = ["D100", "D101", "D102", "D103"]
@@ -401,28 +401,37 @@ version = {attr = 'pyvista._version.__version__'}
 
 [tool.setuptools.package-data]
 pyvista = [
-  'py.typed'
+    'py.typed',
 ]
 "pyvista.examples" = [
-  '2k_earth_daymap.jpg',
-  'airplane.ply',
-  'ant.ply',
-  'channels.vti',
-  'globe.vtk',
-  'hexbeam.vtk',
-  'nut.ply',
-  'pyvista_logo.png',
-  'rectilinear.vtk',
-  'sphere.ply',
-  'uniform.vtk',
-  'frog_tissues.vti'
+    '2k_earth_daymap.jpg',
+    'airplane.ply',
+    'ant.ply',
+    'channels.vti',
+    'frog_tissues.vti',
+    'globe.vtk',
+    'hexbeam.vtk',
+    'nut.ply',
+    'pyvista_logo.png',
+    'rectilinear.vtk',
+    'sphere.ply',
+    'uniform.vtk',
 ]
 
 [tool.setuptools.packages.find]
 include = [
-  'pyvista',
-  'pyvista.*'
+    'pyvista',
+    'pyvista.*',
 ]
+
+[tool.tomlsort]
+in_place = true
+sort_first = ["key2", "pyvista[pinned]"]
+spaces_before_inline_comment = 2
+spaces_indent_inline_array = 4
+trailing_comma_inline_array = true
+sort_inline_arrays = true
+ignore_case = true
 
 [tool.upload_sphinx]
 upload-dir = 'doc/_build/html'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,179 +6,151 @@ build-backend = 'setuptools.build_meta'
 name = 'pyvista'
 description = 'Easier Pythonic interface to VTK'
 authors = [
-    {name = 'PyVista Developers', email = 'info@pyvista.org'},
+  {name = 'PyVista Developers', email = 'info@pyvista.org'}
 ]
 readme = 'README.rst'
 requires-python = '>=3.9'
 keywords = ['vtk', 'numpy', 'plotting', 'mesh']
 license = {text = 'MIT'}
 classifiers = [
-    'Development Status :: 5 - Production/Stable',
-    'Intended Audience :: Science/Research',
-    'Topic :: Scientific/Engineering :: Information Analysis',
-    'License :: OSI Approved :: MIT License',
-    'Operating System :: Microsoft :: Windows',
-    'Operating System :: POSIX',
-    'Operating System :: MacOS',
-    'Programming Language :: Python :: 3.9',
-    'Programming Language :: Python :: 3.10',
-    'Programming Language :: Python :: 3.11',
-    'Programming Language :: Python :: 3.12',
+  'Development Status :: 5 - Production/Stable',
+  'Intended Audience :: Science/Research',
+  'Topic :: Scientific/Engineering :: Information Analysis',
+  'License :: OSI Approved :: MIT License',
+  'Operating System :: Microsoft :: Windows',
+  'Operating System :: POSIX',
+  'Operating System :: MacOS',
+  'Programming Language :: Python :: 3.9',
+  'Programming Language :: Python :: 3.10',
+  'Programming Language :: Python :: 3.11',
+  'Programming Language :: Python :: 3.12'
 ]
 dependencies = [
-    'matplotlib>=3.0.1',
-    'numpy>=1.21.0',  # minimum typing support
-    'pillow',
-    'pooch',
-    'scooby>=0.5.1',
-    'vtk',  # keep without version constraints
-    'typing-extensions',
+  'matplotlib>=3.0.1',
+  'numpy>=1.21.0', # minimum typing support
+  'pillow',
+  'pooch',
+  'scooby>=0.5.1',
+  'vtk', # keep without version constraints
+  'typing-extensions'
 ]
 dynamic = ['version']
 
 [project.optional-dependencies]
 all = ['pyvista[colormaps,io,jupyter]']
 colormaps = [
-    'cmocean',
-    'colorcet',
+  'cmocean',
+  'colorcet'
 ]
 io = [
-    'imageio',
-    'meshio>=5.2'
+  'imageio',
+  'meshio>=5.2'
 ]
 jupyter = [
-    'ipywidgets',
-    'jupyter-server-proxy',
-    'nest_asyncio',
-    'trame>=2.5.2',
-    'trame-client>=2.12.7',
-    'trame-server>=2.11.7',
-    'trame-vtk>=2.5.8',
-    'trame-vuetify>=2.3.1',
+  'ipywidgets',
+  'jupyter-server-proxy',
+  'nest_asyncio',
+  'trame>=2.5.2',
+  'trame-client>=2.12.7',
+  'trame-server>=2.11.7',
+  'trame-vtk>=2.5.8',
+  'trame-vuetify>=2.3.1'
 ]
-
-pinned = [  # Pinned versions of core dependencies
-    'matplotlib<3.9.3',
-    'numpy<2.2.0',
-    'pillow<11.1.0',
-    'pooch<1.9.0',
-    'scooby<0.11.0',
-    'vtk<9.4.0',
-    'typing-extensions<4.13.0',
+pinned = [
+  # Pinned versions of core dependencies
+  'matplotlib<3.9.3',
+  'numpy<2.2.0',
+  'pillow<11.1.0',
+  'pooch<1.9.0',
+  'scooby<0.11.0',
+  'vtk<9.4.0',
+  'typing-extensions<4.13.0'
 ]
-typing= [
-    'pyvista[pinned]',
-    'numpy>=2.0.0',
-    'mypy<1.14.0',
-    'npt-promote==0.1',
+typing = [
+  'pyvista[pinned]',
+  'numpy>=2.0.0',
+  'mypy<1.14.0',
+  'npt-promote==0.1'
 ]
 test = [
-    'pyvista[pinned]',
-    'cmocean<4.0.4',
-    'colorcet<3.2.0',
-    # Embreex does not work with arm-based macs
-    "embreex<2.17.8; sys_platform != 'darwin' or platform_machine != 'arm64'",
-    'hypothesis<6.115.6',
-    'imageio<2.37.0',
-    'imageio-ffmpeg<0.6.0',
-    'ipython<9.0.0',
-    'ipywidgets<9.0.0',
-    'meshio<5.4.0',
-    'nest_asyncio<1.6.1',
-    'numpydoc==1.8.0',
-    'pyanalyze<=0.13.1',
-    'pytest<8.4.0',
-    'pytest-cov<6.1.0',
-    'pytest-memprof<0.3.0',
-    'pytest-pyvista==0.1.8',
-    'pytest-xdist<3.7.0',
-    'scipy<1.14.2',
-    'sphinx<8.2.0',
-    'sphinx-book-theme<1.2.0',
-    'sphinx-gallery<0.19.0',
-    'sphinx_design<0.7.0',
-    'sympy<1.14.0',
-    'tqdm<4.67.0',
-    'trame>=2.5.2,<3.7.1',
-    'trame-vtk>=2.5.8,<2.8.12',
-    'trame-vuetify>=2.3.1,<2.7.2',
-    'trimesh<4.6.0',
-    'typing-extensions<4.13.0',
+  'pyvista[pinned]',
+  'cmocean<4.0.4',
+  'colorcet<3.2.0',
+  # Embreex does not work with arm-based macs
+  "embreex<2.17.8; sys_platform != 'darwin' or platform_machine != 'arm64'",
+  'hypothesis<6.115.6',
+  'imageio<2.37.0',
+  'imageio-ffmpeg<0.6.0',
+  'ipython<9.0.0',
+  'ipywidgets<9.0.0',
+  'meshio<5.4.0',
+  'nest_asyncio<1.6.1',
+  'numpydoc==1.8.0',
+  'pyanalyze<=0.13.1',
+  'pytest<8.4.0',
+  'pytest-cov<6.1.0',
+  'pytest-memprof<0.3.0',
+  'pytest-pyvista==0.1.8',
+  'pytest-xdist<3.7.0',
+  'scipy<1.14.2',
+  'sphinx<8.2.0',
+  'sphinx-book-theme<1.2.0',
+  'sphinx-gallery<0.19.0',
+  'sphinx_design<0.7.0',
+  'sympy<1.14.0',
+  'tqdm<4.67.0',
+  'trame>=2.5.2,<3.7.1',
+  'trame-vtk>=2.5.8,<2.8.12',
+  'trame-vuetify>=2.3.1,<2.7.2',
+  'trimesh<4.6.0',
+  'typing-extensions<4.13.0'
 ]
 docs = [
-    'pyvista[pinned]',
-    'cmocean==4.0.3',
-    'colorcet==3.1.0',
-    'enum-tools==0.12.0',
-    'imageio==2.36.0',
-    'imageio-ffmpeg==0.5.1',
-    'jupyter_sphinx==0.5.3',
-    'jupyterlab==4.2.5',
-    'lxml==5.3.0',
-    'meshio==5.3.5',
-    'mypy==1.13.0',
-    'mypy-extensions==1.0.0',
-    'numpydoc==1.8.0',
-    'osmnx==1.9.4',
-    'pypandoc==1.14',
-    'pytest-sphinx==0.6.3',
-    'scipy==1.14.1',
-    'sphinx==8.1.3',
-    'sphinx-autobuild==2024.10.3',
-    'sphinx-book-theme==1.1.3',
-    'sphinx-copybutton==0.5.2',
-    'sphinx-design==0.6.1',
-    'sphinx-gallery==0.18.0',
-    'sphinx-notfound-page==1.0.4',
-    'sphinx-sitemap==2.6.0',
-    'sphinx-tags==0.4.0',
-    'sphinx-toolbox==3.8.1',
-    'sphinxcontrib-asciinema==0.4.2',
-    'sphinxcontrib-websupport==2.0.0',
-    'sphinxext-opengraph==0.9.1',
-    'sympy==1.13.3',
-    'trame==3.7.0',
-    'trame-vtk==2.8.11',
-    'trame-vuetify==2.7.1',
-    'trimesh==4.5.2',
+  'pyvista[pinned]',
+  'cmocean==4.0.3',
+  'colorcet==3.1.0',
+  'enum-tools==0.12.0',
+  'imageio==2.36.0',
+  'imageio-ffmpeg==0.5.1',
+  'jupyter_sphinx==0.5.3',
+  'jupyterlab==4.2.5',
+  'lxml==5.3.0',
+  'meshio==5.3.5',
+  'mypy==1.13.0',
+  'mypy-extensions==1.0.0',
+  'numpydoc==1.8.0',
+  'osmnx==1.9.4',
+  'pypandoc==1.14',
+  'pytest-sphinx==0.6.3',
+  'scipy==1.14.1',
+  'sphinx==8.1.3',
+  'sphinx-autobuild==2024.10.3',
+  'sphinx-book-theme==1.1.3',
+  'sphinx-copybutton==0.5.2',
+  'sphinx-design==0.6.1',
+  'sphinx-gallery==0.18.0',
+  'sphinx-notfound-page==1.0.4',
+  'sphinx-sitemap==2.6.0',
+  'sphinx-tags==0.4.0',
+  'sphinx-toolbox==3.8.1',
+  'sphinxcontrib-asciinema==0.4.2',
+  'sphinxcontrib-websupport==2.0.0',
+  'sphinxext-opengraph==0.9.1',
+  'sympy==1.13.3',
+  'trame==3.7.0',
+  'trame-vtk==2.8.11',
+  'trame-vuetify==2.7.1',
+  'trimesh==4.5.2'
 ]
 dev = [
-    'pyvista[test,docs]',
-    'pre-commit'
+  'pyvista[test,docs]',
+  'pre-commit'
 ]
 
 [project.urls]
 Documentation = 'https://docs.pyvista.org/'
 "Bug Tracker" = 'https://github.com/pyvista/pyvista/issues'
 "Source Code" = 'https://github.com/pyvista/pyvista'
-
-[tool.setuptools.dynamic]
-version = {attr = 'pyvista._version.__version__'}
-
-[tool.setuptools.packages.find]
-include = [
-    'pyvista',
-    'pyvista.*',
-]
-
-[tool.setuptools.package-data]
-pyvista = [
-    'py.typed',
-]
-"pyvista.examples" = [
-    '2k_earth_daymap.jpg',
-    'airplane.ply',
-    'ant.ply',
-    'channels.vti',
-    'globe.vtk',
-    'hexbeam.vtk',
-    'nut.ply',
-    'pyvista_logo.png',
-    'rectilinear.vtk',
-    'sphere.ply',
-    'uniform.vtk',
-    'frog_tissues.vti',
-]
 
 [tool.blackdoc]
 # From https://numpydoc.readthedocs.io/en/latest/format.html
@@ -189,11 +161,8 @@ line-length = 75
 
 [tool.build_sphinx]
 source-dir = 'doc'
-build-dir  = './doc/_build'
-all_files  = 1
-
-[tool.upload_sphinx]
-upload-dir = 'doc/_build/html'
+build-dir = './doc/_build'
+all_files = 1
 
 [tool.codespell]
 skip = '*.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.vtu,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,doc/_build/*,./doc/images/*,./dist/*,*~,.hypothesis*,./doc/examples/*,*.mypy_cache/*,*cover,./tests/tinypages/_build/*,*/_autosummary/*'
@@ -202,32 +171,11 @@ quiet-level = 3
 
 [tool.coverage.run]
 omit = [
-    'pyvista/ext/coverage.py',
-    'pyvista/conftest.py',
-    # kept for backwards compatibility:
-    'pyvista/plotting/theme.py',
+  'pyvista/ext/coverage.py',
+  'pyvista/conftest.py',
+  # kept for backwards compatibility:
+  'pyvista/plotting/theme.py'
 ]
-
-[tool.pytest.ini_options]
-junit_family='legacy'
-filterwarnings = [
-    'ignore::FutureWarning',
-    'ignore::PendingDeprecationWarning',
-    'ignore::DeprecationWarning',
-    # bogus numpy ABI warning (see numpy/#432)
-    'ignore:.*numpy.dtype size changed.*:RuntimeWarning',
-    'ignore:.*numpy.ufunc size changed.*:RuntimeWarning',
-    'ignore:.*Given trait value dtype "float64":UserWarning',
-    'ignore:.*The NumPy module was reloaded*:UserWarning',
-    'error::pyvista.PyVistaDeprecationWarning'
-]
-doctest_optionflags = 'NUMBER ELLIPSIS'
-testpaths = 'tests'
-markers = [
-    'needs_vtk_version(version): skip test unless VTK version is at least as specified.',
-    'needs_download: this test downloads data during execution',
-]
-image_cache_dir = "tests/plotting/image_cache"
 
 [tool.mypy]
 ignore_missing_imports = true
@@ -236,59 +184,79 @@ pretty = true
 show_error_context = true
 warn_unused_ignores = true
 warn_redundant_casts = true
-plugins = ['numpy.typing.mypy_plugin','npt_promote']
+plugins = ['numpy.typing.mypy_plugin', 'npt_promote']
 enable_error_code = [
-    "ignore-without-code",
+  "ignore-without-code"
 ]
 exclude = ['pyvista/ext/']
 packages = ['pyvista']
 
-
 [tool.numpydoc_validation]
 checks = [
-    "all",  # all but the following:
-    "GL01",  # Contradicts numpydoc examples
-    "GL02",  # Permit a blank line after the end of our docstring
-    "GL03",  # Considering enforcing
-    "GL06",  # Found unknown section
-    "GL07",  # "Sections are in the wrong order. Correct order is: {correct_sections}",
-    "GL09",  # Deprecation warning should precede extended summary (check broken)
-    "PR01",  # "Parameters {missing_params} not documented",
-    "PR02",  # "Unknown parameters {unknown_params}",
-    "PR03",  # "Wrong parameters order. Actual: {actual_params}. Documented: {documented_params}",
-    "PR04",  # 'Parameter "{param_name}" has no type',
-    "PR05",  # 'Parameter "{param_name}" type should not finish with "."',
-    "PR06",  # 'Parameter "{param_name}" type should use "{right_type}" instead of "{wrong_type}"',
-    "PR07",  # 'Parameter "{param_name}" has no description',
-    "PR08",  # 'Parameter "{param_name}" description should start with a capital letter",
-    "PR09",  # 'Parameter "{param_name}" description should finish with "."',
-    "PR10",  # 'Parameter "{param_name}" requires a space before the colon separating the parameter name and type",
-    "SA01",  # Not all docstrings need a see also
-    "SA04",  # See also section does not need descriptions
-    "SS05",  # Appears to be broken.
-    "ES01",  # Not all docstrings need an extend summary.
-    "EX01",  # Examples: Will eventually enforce
-    "YD01",  # Yields: No plan to enforce
+  "all", # all but the following:
+  "GL01", # Contradicts numpydoc examples
+  "GL02", # Permit a blank line after the end of our docstring
+  "GL03", # Considering enforcing
+  "GL06", # Found unknown section
+  "GL07", # "Sections are in the wrong order. Correct order is: {correct_sections}",
+  "GL09", # Deprecation warning should precede extended summary (check broken)
+  "PR01", # "Parameters {missing_params} not documented",
+  "PR02", # "Unknown parameters {unknown_params}",
+  "PR03", # "Wrong parameters order. Actual: {actual_params}. Documented: {documented_params}",
+  "PR04", # 'Parameter "{param_name}" has no type',
+  "PR05", # 'Parameter "{param_name}" type should not finish with "."',
+  "PR06", # 'Parameter "{param_name}" type should use "{right_type}" instead of "{wrong_type}"',
+  "PR07", # 'Parameter "{param_name}" has no description',
+  "PR08", # 'Parameter "{param_name}" description should start with a capital letter",
+  "PR09", # 'Parameter "{param_name}" description should finish with "."',
+  "PR10", # 'Parameter "{param_name}" requires a space before the colon separating the parameter name and type",
+  "SA01", # Not all docstrings need a see also
+  "SA04", # See also section does not need descriptions
+  "SS05", # Appears to be broken.
+  "ES01", # Not all docstrings need an extend summary.
+  "EX01", # Examples: Will eventually enforce
+  "YD01" # Yields: No plan to enforce
+]
+exclude = [
+  # don't report on objects that match any of these regex
+  '\._.*$', # Ignore anything that's private (e.g., starts with _)
+  # classes inherit from BaseReader
+  '\.*Reader(\.|$)',
+  # Documentation extensions or utilities
+  '^viewer_directive\..*$',
+  '^plot_directive\..*$',
+  '^coverage\..*$'
 ]
 
-exclude = [  # don't report on objects that match any of these regex
-    '\._.*$',  # Ignore anything that's private (e.g., starts with _)
-    # classes inherit from BaseReader
-    '\.*Reader(\.|$)',
-    # Documentation extensions or utilities
-    '^viewer_directive\..*$',
-    '^plot_directive\..*$',
-    '^coverage\..*$',
+[tool.pytest.ini_options]
+junit_family = 'legacy'
+filterwarnings = [
+  'ignore::FutureWarning',
+  'ignore::PendingDeprecationWarning',
+  'ignore::DeprecationWarning',
+  # bogus numpy ABI warning (see numpy/#432)
+  'ignore:.*numpy.dtype size changed.*:RuntimeWarning',
+  'ignore:.*numpy.ufunc size changed.*:RuntimeWarning',
+  'ignore:.*Given trait value dtype "float64":UserWarning',
+  'ignore:.*The NumPy module was reloaded*:UserWarning',
+  'error::pyvista.PyVistaDeprecationWarning'
 ]
+doctest_optionflags = 'NUMBER ELLIPSIS'
+testpaths = 'tests'
+markers = [
+  'needs_vtk_version(version): skip test unless VTK version is at least as specified.',
+  'needs_download: this test downloads data during execution'
+]
+image_cache_dir = "tests/plotting/image_cache"
 
 [tool.ruff]
 exclude = [
-    '.git',
-    'pycache__',
-    'build',
-    'dist',
-    'doc/examples',
-    'doc/_build',
+  '.git',
+  'pycache__',
+  'build',
+  'dist',
+  'doc/examples',
+  'doc/_build'
 ]
 line-length = 100
 indent-width = 4
@@ -300,119 +268,105 @@ quote-style = "single"
 [tool.ruff.lint]
 external = ["E131"]
 ignore = [
-    # https://github.com/pyvista/pyvista/pull/6030
-    "B028",
-    # https://github.com/pyvista/pyvista/pull/6022
-    "B904",
-    "D105", # Missing docstring in magic method
-    "D107", # Missing docstring in `__init__`
-    "D203", # May conflict with the formatter
-    "D211", # Incompatible with D203
-    "D213", # Incompatible with D212
-    "D402", # First line should not be the function's signature
-    "D416", # Section name ends in colon
-    # whitespace before ':'
-    "E203",
-    # line break before binary operator
-    # "W503",
-    # line length too long
-    "E501",
-    # do not assign a lambda expression, use a def
-    "E731",
-    # too many leading '#' for block comment
-    "E266",
-    # ambiguous variable name
-    "E741",
-    # module level import not at top of file
-    "E402",
-    # Quotes (temporary)
-    "Q0",
-    # bare excepts (temporary)
-    # "B001", "E722",
-    "E722",
-    # 'from module import *' used; unable to detect undefined names
-    "F403",
-    # https://github.com/pyvista/pyvista/pull/6037
-    "PERF203",
-    # https://github.com/pyvista/pyvista/pull/5877
-    "SIM102",
-    # https://github.com/pyvista/pyvista/pull/5888
-    "SIM117",
-    # https://github.com/pyvista/pyvista/pull/5837
-    "SIM118",
-    # https://github.com/pyvista/pyvista/pull/5911
-    "RET505",
-    "RET506",
-    "RET507",
-    # The following rules may cause conflicts when used with the formatter
-    "COM812",
-    "ISC001",
+  # https://github.com/pyvista/pyvista/pull/6030
+  "B028",
+  # https://github.com/pyvista/pyvista/pull/6022
+  "B904",
+  "D105", # Missing docstring in magic method
+  "D107", # Missing docstring in `__init__`
+  "D203", # May conflict with the formatter
+  "D211", # Incompatible with D203
+  "D213", # Incompatible with D212
+  "D402", # First line should not be the function's signature
+  "D416", # Section name ends in colon
+  # whitespace before ':'
+  "E203",
+  # line break before binary operator
+  # "W503",
+  # line length too long
+  "E501",
+  # do not assign a lambda expression, use a def
+  "E731",
+  # too many leading '#' for block comment
+  "E266",
+  # ambiguous variable name
+  "E741",
+  # module level import not at top of file
+  "E402",
+  # Quotes (temporary)
+  "Q0",
+  # bare excepts (temporary)
+  # "B001", "E722",
+  "E722",
+  # 'from module import *' used; unable to detect undefined names
+  "F403",
+  # https://github.com/pyvista/pyvista/pull/6037
+  "PERF203",
+  # https://github.com/pyvista/pyvista/pull/5877
+  "SIM102",
+  # https://github.com/pyvista/pyvista/pull/5888
+  "SIM117",
+  # https://github.com/pyvista/pyvista/pull/5837
+  "SIM118",
+  # https://github.com/pyvista/pyvista/pull/5911
+  "RET505",
+  "RET506",
+  "RET507",
+  # The following rules may cause conflicts when used with the formatter
+  "COM812",
+  "ISC001"
 ]
 fixable = ["ALL"]
 unfixable = []
 extend-select = [
-    "A",
-    "AIR",
-    "ASYNC",
-    "ASYNC1",
-    "B",
-    "C4",
-    "COM",
-    "D",
-    "DJ",
-    "DTZ",
-    "E",
-    "F",
-    "FA",
-    "FLY",
-    "I",
-    "ICN",
-    "INT",
-    "ISC",
-    "LOG",
-    "NPY",
-    "PERF",
-    "PGH",
-    "PIE",
-    "PLC",
-    "PLR0402",
-    "PLR1711",
-    "PLR1714",
-    "PLW0127",
-    "PT",
-    "PTH",
-    "PYI",
-    "Q",
-    "RET",
-    "RSE",
-    "RUF",
-    "SIM",
-    "T10",
-    "TCH",
-    "TRY201",
-    "TRY203",
-    "TRY300",
-    "UP",
-    "W",
-    "YTT",
+  "A",
+  "AIR",
+  "ASYNC",
+  "ASYNC1",
+  "B",
+  "C4",
+  "COM",
+  "D",
+  "DJ",
+  "DTZ",
+  "E",
+  "F",
+  "FA",
+  "FLY",
+  "I",
+  "ICN",
+  "INT",
+  "ISC",
+  "LOG",
+  "NPY",
+  "PERF",
+  "PGH",
+  "PIE",
+  "PLC",
+  "PLR0402",
+  "PLR1711",
+  "PLR1714",
+  "PLW0127",
+  "PT",
+  "PTH",
+  "PYI",
+  "Q",
+  "RET",
+  "RSE",
+  "RUF",
+  "SIM",
+  "T10",
+  "TCH",
+  "TRY201",
+  "TRY203",
+  "TRY300",
+  "UP",
+  "W",
+  "YTT"
 ]
 
 [tool.ruff.lint.flake8-comprehensions]
 allow-dict-calls-with-keyword-arguments = true
-
-[tool.ruff.lint.per-file-ignores]
-"examples/**" = [
-    # https://github.com/pyvista/pyvista/pull/6014
-    "B015",
-    # https://github.com/pyvista/pyvista/pull/6019
-    "B018",
-]
-"doc/source/make_tables.py" = ["D101","D102"]
-"examples/*" = ["D212","D102","D103","D205","D400","D415", "SIM115"]
-"examples_trame/*" = ["D100","D103"]
-"examples_trame/tests*" = ["D"]
-"pyvista/ext/*" = ["D100", "D101", "D102","D103"]
-"tests/*" = ["D"]
 
 [tool.ruff.lint.isort]
 # Sort by name, don't cluster "from" vs "import"
@@ -424,6 +378,51 @@ required-imports = ["from __future__ import annotations"]
 # https://github.com/pyvista/pyvista/pull/5712
 force-single-line = true
 
+[tool.ruff.lint.per-file-ignores]
+"examples/**" = [
+  # https://github.com/pyvista/pyvista/pull/6014
+  "B015",
+  # https://github.com/pyvista/pyvista/pull/6019
+  "B018"
+]
+"doc/source/make_tables.py" = ["D101", "D102"]
+"examples/*" = ["D212", "D102", "D103", "D205", "D400", "D415", "SIM115"]
+"examples_trame/*" = ["D100", "D103"]
+"examples_trame/tests*" = ["D"]
+"pyvista/ext/*" = ["D100", "D101", "D102", "D103"]
+"tests/*" = ["D"]
+
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.
 keep-runtime-typing = true
+
+[tool.setuptools.dynamic]
+version = {attr = 'pyvista._version.__version__'}
+
+[tool.setuptools.package-data]
+pyvista = [
+  'py.typed'
+]
+"pyvista.examples" = [
+  '2k_earth_daymap.jpg',
+  'airplane.ply',
+  'ant.ply',
+  'channels.vti',
+  'globe.vtk',
+  'hexbeam.vtk',
+  'nut.ply',
+  'pyvista_logo.png',
+  'rectilinear.vtk',
+  'sphere.ply',
+  'uniform.vtk',
+  'frog_tissues.vti'
+]
+
+[tool.setuptools.packages.find]
+include = [
+  'pyvista',
+  'pyvista.*'
+]
+
+[tool.upload_sphinx]
+upload-dir = 'doc/_build/html'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,9 @@ pinned = [
 typing = ['mypy<1.14.0', 'npt-promote==0.1', 'numpy>=2.0.0', 'pyvista[pinned]']
 test = [
   # Embreex does not work with arm-based macs
-  'embreex<2.17.8; sys_platform != "darwin" or platform_machine != "arm64"',
   'cmocean<4.0.4',
   'colorcet<3.2.0',
+  'embreex<2.17.8; sys_platform != "darwin" or platform_machine != "arm64"',
   'hypothesis<6.115.6',
   'imageio-ffmpeg<0.6.0',
   'imageio<2.37.0',


### PR DESCRIPTION
### Overview

`toml` files are not currently formatted or sorted. This enables things like:
https://github.com/pyvista/pyvista/blob/a71e027637a704648af4fbdac9befa425fd503ec/pyproject.toml#L69-L74

Where spaces around `=` are not enforced and where alphabetical sorting is not enforced (we have `n`->`m`->`n` order in the example)

This PR uses ~https://github.com/pappasam/toml-sort~ https://github.com/tamasfe/taplo to fix and enforce the formatting and sorting.