### PR TITLE
Support reading and saving pickled meshes

### DIFF
--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -20,7 +20,9 @@ from .pyvista_ndarray import pyvista_ndarray
 from .utilities.arrays import FieldAssociation
 from .utilities.arrays import _JSONValueType
 from .utilities.arrays import _SerializedDictArray
+from .utilities.fileio import PICKLE_EXT
 from .utilities.fileio import read
+from .utilities.fileio import save_pickle
 from .utilities.fileio import set_vtkwriter_mode
 from .utilities.helpers import wrap
 from .utilities.misc import abstract_class
@@ -139,6 +141,26 @@ class DataObject:
         file size.
 
         """
+
+        def _write_vtk(mesh_):
+            writer = mesh_._WRITERS[file_ext]()
+            set_vtkwriter_mode(vtk_writer=writer, use_binary=binary)
+            writer.SetFileName(str(file_path))
+            writer.SetInputData(mesh_)
+            if file_ext == '.ply' and texture is not None:
+                if isinstance(texture, str):
+                    writer.SetArrayName(texture)  # type: ignore[union-attr]
+                    array_name = texture
+                elif isinstance(texture, np.ndarray):
+                    array_name = '_color_array'
+                    mesh_[array_name] = texture
+                    writer.SetArrayName(array_name)  # type: ignore[union-attr]
+
+                # enable alpha channel if applicable
+                if mesh_[array_name].shape[-1] == 4:  # type: ignore[index]
+                    writer.SetEnableAlpha(True)  # type: ignore[union-attr]
+            writer.Write()
+
         if self._WRITERS is None:
             raise NotImplementedError(
                 f'{self.__class__.__name__} writers are not specified,'
@@ -149,32 +171,20 @@ class DataObject:
         file_path = file_path.expanduser()
         file_path = file_path.resolve()
         file_ext = file_path.suffix
-        if file_ext not in self._WRITERS:
-            raise ValueError(
-                'Invalid file extension for this data type.'
-                f' Must be one of: {self._WRITERS.keys()}',
-            )
 
         # store complex and bitarray types as field data
         self._store_metadata()
 
-        writer = self._WRITERS[file_ext]()
-        set_vtkwriter_mode(vtk_writer=writer, use_binary=binary)
-        writer.SetFileName(str(file_path))
-        writer.SetInputData(self)
-        if file_ext == '.ply' and texture is not None:
-            if isinstance(texture, str):
-                writer.SetArrayName(texture)  # type: ignore[union-attr]
-                array_name = texture
-            elif isinstance(texture, np.ndarray):
-                array_name = '_color_array'
-                self[array_name] = texture
-                writer.SetArrayName(array_name)  # type: ignore[union-attr]
-
-            # enable alpha channel if applicable
-            if self[array_name].shape[-1] == 4:  # type: ignore[index]
-                writer.SetEnableAlpha(True)  # type: ignore[union-attr]
-        writer.Write()
+        writer_ext = self._WRITERS.keys()
+        if file_ext in writer_ext:
+            _write_vtk(self)
+        elif file_ext in PICKLE_EXT:
+            save_pickle(filename, self)
+        else:
+            raise ValueError(
+                'Invalid file extension for this data type.'
+                f' Must be one of: {list(writer_ext) + list(PICKLE_EXT)}',
+            )
 
     def _store_metadata(self) -> None:
         """Store metadata as field data."""

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -10,6 +10,7 @@ import pytest
 
 import pyvista as pv
 from pyvista import examples
+from pyvista.core.utilities.fileio import save_pickle
 
 
 def test_eq_wrong_type(sphere):
@@ -227,13 +228,24 @@ def _modifies_pickle_format():
 
 @pytest.mark.usefixtures('_modifies_pickle_format')
 @pytest.mark.parametrize('pickle_format', ['vtk', 'xml', 'legacy'])
-def test_pickle_serialize_deserialize(datasets, pickle_format):
+@pytest.mark.parametrize('file_ext', ['.pkl', '.pickle', '', None])
+def test_pickle_serialize_deserialize(datasets, pickle_format, file_ext, tmp_path):
     if pickle_format == 'vtk' and pv.vtk_version_info < (9, 3):
         pytest.xfail('VTK version not supported.')
 
     pv.set_pickle_format(pickle_format)
     for dataset in datasets:
-        dataset_2 = pickle.loads(pickle.dumps(dataset))
+        if file_ext is not None:
+            filepath_save = tmp_path / ('data_object' + file_ext)
+            if file_ext == '':
+                save_pickle(filepath_save, dataset)
+                filepath_read = tmp_path / ('data_object' + '.pkl')
+            else:
+                dataset.save(filepath_save)
+                filepath_read = filepath_save
+            dataset_2 = pv.read(filepath_read)
+        else:
+            dataset_2 = pickle.loads(pickle.dumps(dataset))
 
         # check python attributes are the same
         for attr in dataset.__dict__:

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+import pickle
 
 import numpy as np
 import pytest
@@ -1180,3 +1181,26 @@ def test_grdecl_reader(tmp_path):
     include_content_copy[0] = include_content_copy[0].replace('MAPAXES', 'PLACEHOLDER')
     with pytest.warns(UserWarning, match=match):
         _ = read(content, include_content_copy)
+
+
+@pytest.mark.parametrize(
+    ('data_object', 'ext'),
+    [(pv.MultiBlock([examples.load_ant()]), '.pkl'), (examples.load_ant(), '.pickle')],
+)
+@pytest.mark.skipif(pv.vtk_version_info < (9, 3), reason='VTK version not supported.')
+def test_read_write_pickle(tmp_path, data_object, ext, datasets):
+    filepath = tmp_path / ('data_object' + ext)
+    data_object.save(filepath)
+    new_data_object = pv.read(filepath)
+    assert data_object == new_data_object
+
+    # Test raises
+    with open(str(filepath), 'wb') as f:  # noqa: PTH123
+        # Create non-mesh pickle file
+        pickle.dump([1, 2, 3], f)
+    match = (
+        "Pickled object must be an instance of <class 'pyvista.core.dataobject.DataObject'>. "
+        "Got <class 'list'> instead."
+    )
+    with pytest.raises(TypeError, match=match):
+        pv.read(filepath)


### PR DESCRIPTION
### Overview

Allow using `mesh.save()` and `pv.read()` with `.pkl` or `.pickle` extension.