### PR TITLE
Add recursive shallow copy for `MultiBlock`

### DIFF
--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -1023,13 +1023,18 @@ class MultiBlock(
         newobject.copy_meta_from(self, deep)
         return newobject
 
-    def shallow_copy(self, to_copy: _vtk.vtkMultiBlockDataSet) -> None:  # type: ignore[override]
+    def shallow_copy(self, to_copy: _vtk.vtkMultiBlockDataSet, recursive=False) -> None:  # type: ignore[override]
         """Shallow copy the given multiblock to this multiblock.
 
         Parameters
         ----------
         to_copy : pyvista.MultiBlock or vtk.vtkMultiBlockDataSet
             Data object to perform a shallow copy from.
+
+        recursive : bool, default: False
+            Also shallow-copy any nested :class:`~pyvista.MultiBlock` blocks. By
+            default, only the root :class:`~pyvista.MultiBlock` is shallow-copied and
+            any nested multi-blocks are not shallow-copied.
 
         """
         if pyvista.vtk_version_info >= (9, 3):  # pragma: no cover
@@ -1047,7 +1052,8 @@ class MultiBlock(
                     this_object_.replace(i, block_to_copy)
                     _replace_nested_multiblocks(this_object_[i], block_to_copy)
 
-        _replace_nested_multiblocks(self, to_copy)
+        if not recursive:
+            _replace_nested_multiblocks(self, to_copy)
 
     def deep_copy(self, to_copy: _vtk.vtkMultiBlockDataSet) -> None:  # type: ignore[override]
         """Overwrite this MultiBlock with another MultiBlock as a deep copy.

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -484,6 +484,21 @@ def test_multi_block_copy(deep, multiblock_all_with_nested_and_none):
         assert (multi[i] is multi_copy[i]) != deep or (multi[i] is None)
 
 
+@pytest.mark.parametrize('recursive', [True, False])
+def test_multi_block_shallow_copy(recursive, multiblock_all_with_nested_and_none):
+    multi = multiblock_all_with_nested_and_none
+    multi_copy = MultiBlock()
+    multi_copy.shallow_copy(multi, recursive=recursive)
+    assert multi.n_blocks == multi_copy.n_blocks
+    for i in range(multi_copy.n_blocks):
+        block = multi_copy.GetBlock(i)
+        assert pv.is_pyvista_dataset(block) or block is None
+        if isinstance(multi[i], MultiBlock):
+            assert (multi[i] is multi_copy[i]) != recursive
+        else:
+            assert multi_copy[i] is multi[i]
+
+
 def test_multi_block_negative_index(ant, sphere, uniform, airplane, tetbeam):
     multi = pv.MultiBlock([ant, sphere, uniform, airplane, tetbeam])
     # Now check everything

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -490,8 +490,7 @@ def test_multi_block_shallow_copy(recursive, multiblock_all_with_nested_and_none
     multi_copy = MultiBlock()
     multi_copy.shallow_copy(multi, recursive=recursive)
     assert multi.n_blocks == multi_copy.n_blocks
-    for i in range(multi_copy.n_blocks):
-        block = multi_copy.GetBlock(i)
+    for i, block in enumerate(multi_copy):
         assert pv.is_pyvista_dataset(block) or block is None
         if isinstance(multi[i], MultiBlock):
             assert (multi[i] is multi_copy[i]) != recursive


### PR DESCRIPTION
### Overview

#6590 fixed `MultiBlock.shallow_copy` so that only the root MultiBlock is copied by default. But sometimes it may be desirable to shallow-copy nested `MultiBlock`s recursively (this was the default behaviour prior to #6590). This PR adds the option to use the previous recursive behavior.