### PR TITLE
Fix `DataSet` and `DataSetFilters` typing using concrete `DataSet` type aliases

### DIFF
--- a/pyvista/core/_typing_core/_aliases.py
+++ b/pyvista/core/_typing_core/_aliases.py
@@ -7,6 +7,13 @@ from typing import NamedTuple
 from typing import Union
 
 from pyvista.core import _vtk_core as _vtk
+from pyvista.core.grid import ImageData
+from pyvista.core.grid import RectilinearGrid
+from pyvista.core.pointset import ExplicitStructuredGrid
+from pyvista.core.pointset import PointSet
+from pyvista.core.pointset import PolyData
+from pyvista.core.pointset import StructuredGrid
+from pyvista.core.pointset import UnstructuredGrid
 
 from ._array_like import NumberType
 from ._array_like import _ArrayLike
@@ -79,3 +86,17 @@ CellArrayLike = Union[CellsLike, _vtk.vtkCellArray]
 
 # Undocumented alias - should be expanded in docs
 _ArrayLikeOrScalar = Union[NumberType, ArrayLike[NumberType]]
+
+# Concrete subclasses of `_PointSet`. Use this alias wherever a `_PointSet` annotation
+# would otherwise be used.
+_ConcretePointSet = Union[
+    ExplicitStructuredGrid, PointSet, PolyData, StructuredGrid, UnstructuredGrid
+]
+
+# Concrete subclasses of `Grid`. Use this alias wherever a `Grid` annotation
+# would otherwise be used.
+_ConcreteGrid = Union[RectilinearGrid, ImageData]
+
+# Concrete subclasses of `DataSet`. Use this alias wherever a `DataSet` annotation
+# would otherwise be used.
+_ConcreteDataSet = Union[_ConcreteGrid, _ConcretePointSet]

--- a/pyvista/core/_typing_core/_aliases.py
+++ b/pyvista/core/_typing_core/_aliases.py
@@ -3,17 +3,11 @@
 from __future__ import annotations
 
 import contextlib
+from typing import TYPE_CHECKING
 from typing import NamedTuple
 from typing import Union
 
 from pyvista.core import _vtk_core as _vtk
-from pyvista.core.grid import ImageData
-from pyvista.core.grid import RectilinearGrid
-from pyvista.core.pointset import ExplicitStructuredGrid
-from pyvista.core.pointset import PointSet
-from pyvista.core.pointset import PolyData
-from pyvista.core.pointset import StructuredGrid
-from pyvista.core.pointset import UnstructuredGrid
 
 from ._array_like import NumberType
 from ._array_like import _ArrayLike
@@ -22,6 +16,15 @@ from ._array_like import _ArrayLike2D
 
 with contextlib.suppress(ImportError):
     from scipy.spatial.transform import Rotation
+
+if TYPE_CHECKING:
+    from pyvista.core.grid import ImageData
+    from pyvista.core.grid import RectilinearGrid
+    from pyvista.core.pointset import ExplicitStructuredGrid
+    from pyvista.core.pointset import PointSet
+    from pyvista.core.pointset import PolyData
+    from pyvista.core.pointset import StructuredGrid
+    from pyvista.core.pointset import UnstructuredGrid
 
 # NOTE:
 # Type aliases are automatically expanded in the documentation.
@@ -87,16 +90,18 @@ CellArrayLike = Union[CellsLike, _vtk.vtkCellArray]
 # Undocumented alias - should be expanded in docs
 _ArrayLikeOrScalar = Union[NumberType, ArrayLike[NumberType]]
 
-# Concrete subclasses of `_PointSet`. Use this alias wherever a `_PointSet` annotation
-# would otherwise be used.
-_ConcretePointSet = Union[
-    ExplicitStructuredGrid, PointSet, PolyData, StructuredGrid, UnstructuredGrid
-]
 
-# Concrete subclasses of `Grid`. Use this alias wherever a `Grid` annotation
-# would otherwise be used.
-_ConcreteGrid = Union[RectilinearGrid, ImageData]
+if TYPE_CHECKING:
+    # Concrete subclasses of `_PointSet`. Use this alias wherever a `_PointSet` annotation
+    # would otherwise be used.
+    _ConcretePointSet = Union[
+        ExplicitStructuredGrid, PointSet, PolyData, StructuredGrid, UnstructuredGrid
+    ]
 
-# Concrete subclasses of `DataSet`. Use this alias wherever a `DataSet` annotation
-# would otherwise be used.
-_ConcreteDataSet = Union[_ConcreteGrid, _ConcretePointSet]
+    # Concrete subclasses of `Grid`. Use this alias wherever a `Grid` annotation
+    # would otherwise be used.
+    _ConcreteGrid = Union[RectilinearGrid, ImageData]
+
+    # Concrete subclasses of `DataSet`. Use this alias wherever a `DataSet` annotation
+    # would otherwise be used.
+    _ConcreteDataSet = Union[_ConcreteGrid, _ConcretePointSet]

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from ._typing_core import NumpyArray
     from ._typing_core import RotationLike
     from ._typing_core import VectorLike
+    from ._typing_core._aliases import _ConcreteDataSet
 
 # vector array names
 DEFAULT_VECTOR_KEY = '_vectors'
@@ -440,7 +441,7 @@ class DataSet(DataSetFilters, DataObject):
         """
         self.set_active_scalars(name)
 
-    @property
+    @property  # type: ignore[override]
     def points(self) -> pyvista_ndarray:
         """Return a reference to the points as a numpy object.
 
@@ -899,8 +900,8 @@ class DataSet(DataSetFilters, DataObject):
         # Use the array range
         return np.nanmin(arr), np.nanmax(arr)
 
-    def rotate_x(
-        self,
+    def rotate_x(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         angle: float,
         point: VectorLike[float] | None = None,
         transform_all_input_vectors: bool = False,
@@ -957,14 +958,14 @@ class DataSet(DataSetFilters, DataObject):
 
         """
         t = Transform().rotate_x(angle, point=point)
-        return self.transform(  # type: ignore[misc]
+        return self.transform(
             t,
             transform_all_input_vectors=transform_all_input_vectors,
             inplace=inplace,
         )
 
-    def rotate_y(
-        self,
+    def rotate_y(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         angle: float,
         point: VectorLike[float] | None = None,
         transform_all_input_vectors: bool = False,
@@ -1020,14 +1021,14 @@ class DataSet(DataSetFilters, DataObject):
 
         """
         t = Transform().rotate_y(angle, point=point)
-        return self.transform(  # type: ignore[misc]
+        return self.transform(
             t,
             transform_all_input_vectors=transform_all_input_vectors,
             inplace=inplace,
         )
 
-    def rotate_z(
-        self,
+    def rotate_z(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         angle: float,
         point: VectorLike[float] = (0.0, 0.0, 0.0),
         transform_all_input_vectors: bool = False,
@@ -1084,14 +1085,14 @@ class DataSet(DataSetFilters, DataObject):
 
         """
         t = Transform().rotate_z(angle, point=point)
-        return self.transform(  # type: ignore[misc]
+        return self.transform(
             t,
             transform_all_input_vectors=transform_all_input_vectors,
             inplace=inplace,
         )
 
-    def rotate_vector(
-        self,
+    def rotate_vector(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         vector: VectorLike[float],
         angle: float,
         point: VectorLike[float] | None = None,
@@ -1152,14 +1153,14 @@ class DataSet(DataSetFilters, DataObject):
 
         """
         t = Transform().rotate_vector(vector, angle, point=point)
-        return self.transform(  # type: ignore[misc]
+        return self.transform(
             t,
             transform_all_input_vectors=transform_all_input_vectors,
             inplace=inplace,
         )
 
-    def rotate(
-        self,
+    def rotate(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         rotation: RotationLike,
         point: VectorLike[float] | None = None,
         transform_all_input_vectors: bool = False,
@@ -1226,14 +1227,14 @@ class DataSet(DataSetFilters, DataObject):
 
         """
         t = Transform().rotate(rotation, point=point)
-        return self.transform(  # type: ignore[misc]
+        return self.transform(
             t,
             transform_all_input_vectors=transform_all_input_vectors,
             inplace=inplace,
         )
 
-    def translate(
-        self,
+    def translate(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         xyz: VectorLike[float],
         transform_all_input_vectors: bool = False,
         inplace: bool = False,
@@ -1282,14 +1283,14 @@ class DataSet(DataSetFilters, DataObject):
 
         """
         transform = Transform().translate(xyz)
-        return self.transform(  # type: ignore[misc]
+        return self.transform(
             transform,
             transform_all_input_vectors=transform_all_input_vectors,
             inplace=inplace,
         )
 
-    def scale(
-        self,
+    def scale(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         xyz: Number | VectorLike[float],
         transform_all_input_vectors: bool = False,
         inplace: bool = False,
@@ -1347,14 +1348,14 @@ class DataSet(DataSetFilters, DataObject):
 
         """
         transform = Transform().scale(xyz, point=point)
-        return self.transform(  # type: ignore[misc]
+        return self.transform(
             transform,
             transform_all_input_vectors=transform_all_input_vectors,
             inplace=inplace,
         )
 
-    def flip_x(
-        self,
+    def flip_x(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         point: VectorLike[float] | None = None,
         transform_all_input_vectors: bool = False,
         inplace: bool = False,
@@ -1409,14 +1410,14 @@ class DataSet(DataSetFilters, DataObject):
         if point is None:
             point = self.center
         t = Transform().reflect((1, 0, 0), point=point)
-        return self.transform(  # type: ignore[misc]
+        return self.transform(
             t,
             transform_all_input_vectors=transform_all_input_vectors,
             inplace=inplace,
         )
 
-    def flip_y(
-        self,
+    def flip_y(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         point: VectorLike[float] | None = None,
         transform_all_input_vectors: bool = False,
         inplace: bool = False,
@@ -1471,14 +1472,14 @@ class DataSet(DataSetFilters, DataObject):
         if point is None:
             point = self.center
         t = Transform().reflect((0, 1, 0), point=point)
-        return self.transform(  # type: ignore[misc]
+        return self.transform(
             t,
             transform_all_input_vectors=transform_all_input_vectors,
             inplace=inplace,
         )
 
-    def flip_z(
-        self,
+    def flip_z(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         point: VectorLike[float] | None = None,
         transform_all_input_vectors: bool = False,
         inplace: bool = False,
@@ -1533,14 +1534,14 @@ class DataSet(DataSetFilters, DataObject):
         if point is None:
             point = self.center
         t = Transform().reflect((0, 0, 1), point=point)
-        return self.transform(  # type: ignore[misc]
+        return self.transform(
             t,
             transform_all_input_vectors=transform_all_input_vectors,
             inplace=inplace,
         )
 
-    def flip_normal(
-        self,
+    def flip_normal(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         normal: VectorLike[float],
         point: VectorLike[float] | None = None,
         transform_all_input_vectors: bool = False,
@@ -1599,7 +1600,7 @@ class DataSet(DataSetFilters, DataObject):
         if point is None:
             point = self.center
         t = Transform().reflect(normal, point=point)
-        return self.transform(  # type: ignore[misc]
+        return self.transform(
             t,
             transform_all_input_vectors=transform_all_input_vectors,
             inplace=inplace,

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2712,8 +2712,8 @@ class DataSetFilters:
 
         return output
 
-    def connectivity(
-        self,
+    def connectivity(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         extraction_mode: Literal[
             'all',
             'largest',
@@ -2952,11 +2952,11 @@ class DataSetFilters:
             return extracted
 
         # Store active scalars info to restore later if needed
-        active_field, active_name = self.active_scalars_info  # type: ignore[attr-defined]
+        active_field, active_name = self.active_scalars_info
 
         # Set scalars
         if scalar_range is None:
-            input_mesh = self.copy(deep=False)  # type: ignore[attr-defined]
+            input_mesh = self.copy(deep=False)
         else:
             if isinstance(scalar_range, np.ndarray):
                 num_elements = scalar_range.size
@@ -2972,7 +2972,7 @@ class DataSetFilters:
                 )
 
             # Input will be modified, so copy first
-            input_mesh = self.copy()  # type: ignore[attr-defined]
+            input_mesh = self.copy()
             if scalars is None:
                 set_default_active_scalars(input_mesh)
             else:
@@ -3135,7 +3135,7 @@ class DataSetFilters:
 
         if inplace:
             try:
-                self.copy_from(output, deep=False)  # type: ignore[attr-defined]
+                self.copy_from(output, deep=False)
             except:
                 pass
             else:
@@ -5431,8 +5431,8 @@ class DataSetFilters:
         _update_alg(extract_sel, progress_bar, 'Extracting Points')
         return _get_output(extract_sel)
 
-    def split_values(
-        self,
+    def split_values(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         values: None
         | (
             float | VectorLike[float] | MatrixLike[float] | dict[str, float] | dict[float, str]
@@ -5593,8 +5593,8 @@ class DataSetFilters:
             **kwargs,
         )
 
-    def extract_values(
-        self,
+    def extract_values(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         values: None
         | (
             float | VectorLike[float] | MatrixLike[float] | dict[str, float] | dict[float, str]
@@ -6000,8 +6000,8 @@ class DataSetFilters:
             return values_, ranges_
 
         # Return empty mesh if input is empty mesh
-        if self.n_points == 0:  # type: ignore[attr-defined]
-            return self.copy()  # type: ignore[attr-defined]
+        if self.n_points == 0:
+            return self.copy()
 
         array, association = _validate_scalar_array(scalars, preference)
         array, num_components, component_logic = _validate_component_mode(array, component_mode)
@@ -6017,7 +6017,7 @@ class DataSetFilters:
 
         # Set default for include cells
         if include_cells is None:
-            include_cells = self.n_cells > 0  # type: ignore[attr-defined]
+            include_cells = self.n_cells > 0
 
         kwargs = dict(
             array=array,
@@ -7641,8 +7641,8 @@ class DataSetFilters:
                 as_composite=as_composite,
             )
 
-    def _bounding_box(
-        self,
+    def _bounding_box(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         *,
         matrix: NumpyArray[float] | None,
         inverse_matrix: NumpyArray[float] | None,
@@ -7659,7 +7659,7 @@ class DataSetFilters:
         _validation.check_contains(item=box_style, container=['frame', 'outline', 'face'])
 
         # Create box
-        source = pyvista.CubeFacesSource(bounds=self.bounds)  # type: ignore[attr-defined]
+        source = pyvista.CubeFacesSource(bounds=self.bounds)
         if box_style == 'frame':
             source.frame_width = frame_width
         box = source.output
@@ -7699,7 +7699,7 @@ class DataSetFilters:
                 dots = [np.dot(axes, diag) for diag in diagonals]
                 match = diagonals[np.argmax(np.sum(dots, axis=1))]
                 # Choose min bound for positive direction, max bound for negative
-                bnds = self.bounds  # type: ignore[attr-defined]
+                bnds = self.bounds
                 point = np.ones(3)
                 point[0] = bnds.x_min if match[0] == 1 else bnds.x_max
                 point[1] = bnds.y_min if match[1] == 1 else bnds.y_max

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from pyvista.core._typing_core import MatrixLike
     from pyvista.core._typing_core import TransformLike
     from pyvista.core._typing_core import VectorLike
+    from pyvista.core._typing_core._aliases import _ConcreteDataSet
 
 
 @abstract_class
@@ -88,8 +89,8 @@ class DataSetFilters:
             clipped = self.extract_cells(np.unique(clipped.cell_data['cell_ids']))
         return clipped
 
-    def align(
-        self,
+    def align(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         target,
         max_landmarks=100,
         max_mean_distance=1e-5,
@@ -200,8 +201,8 @@ class DataSetFilters:
             return self.transform(matrix, inplace=False), matrix
         return self.transform(matrix, inplace=False)
 
-    def align_xyz(
-        self,
+    def align_xyz(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         *,
         centered: bool = True,
         axis_0_direction: VectorLike[float] | str | None = None,
@@ -433,10 +434,10 @@ class DataSetFilters:
                         axes[1] *= -1
 
         rotation = Transform().rotate(axes)
-        aligned = self.transform(rotation, inplace=False)  # type: ignore[misc]
+        aligned = self.transform(rotation, inplace=False)
         translation = Transform().translate(-np.array(aligned.center))
         if not centered:
-            translation.translate(self.center)  # type: ignore[attr-defined]
+            translation.translate(self.center)
         aligned.transform(translation, inplace=True)
 
         if return_matrix:
@@ -6932,7 +6933,7 @@ class DataSetFilters:
         return _get_output(alg)
 
     def transform(  # type: ignore[misc]
-        self: _vtk.vtkDataSet,
+        self: _ConcreteDataSet,
         trans: TransformLike,
         transform_all_input_vectors=False,
         inplace=True,
@@ -7023,34 +7024,30 @@ class DataSetFilters:
         # so convert input points and relevant vectors to float
         # (creating a new copy would be harmful much more often)
         converted_ints = False
-        if not np.issubdtype(self.points.dtype, np.floating):  # type: ignore[attr-defined]
-            self.points = self.points.astype(np.float32)  # type: ignore[attr-defined]
+        if not np.issubdtype(self.points.dtype, np.floating):
+            self.points = self.points.astype(np.float32)
             converted_ints = True
         if transform_all_input_vectors:
             # all vector-shaped data will be transformed
             point_vectors = [
-                name
-                for name, data in self.point_data.items()  # type: ignore[attr-defined]
-                if data.shape == (self.n_points, 3)  # type: ignore[attr-defined]
+                name for name, data in self.point_data.items() if data.shape == (self.n_points, 3)
             ]
             cell_vectors = [
-                name
-                for name, data in self.cell_data.items()  # type: ignore[attr-defined]
-                if data.shape == (self.n_cells, 3)  # type: ignore[attr-defined]
+                name for name, data in self.cell_data.items() if data.shape == (self.n_cells, 3)
             ]
         else:
             # we'll only transform active vectors and normals
             point_vectors = [
-                self.point_data.active_vectors_name,  # type: ignore[attr-defined]
-                self.point_data.active_normals_name,  # type: ignore[attr-defined]
+                self.point_data.active_vectors_name,  # type: ignore[list-item]
+                self.point_data.active_normals_name,  # type: ignore[list-item]
             ]
             cell_vectors = [
-                self.cell_data.active_vectors_name,  # type: ignore[attr-defined]
-                self.cell_data.active_normals_name,  # type: ignore[attr-defined]
+                self.cell_data.active_vectors_name,  # type: ignore[list-item]
+                self.cell_data.active_normals_name,  # type: ignore[list-item]
             ]
         # dynamically convert each self.point_data[name] etc. to float32
         all_vectors = [point_vectors, cell_vectors]
-        all_dataset_attrs = [self.point_data, self.cell_data]  # type: ignore[attr-defined]
+        all_dataset_attrs = [self.point_data, self.cell_data]
         for vector_names, dataset_attrs in zip(all_vectors, all_dataset_attrs):
             for vector_name in vector_names:
                 if vector_name is None:
@@ -7067,8 +7064,8 @@ class DataSetFilters:
             )
 
         # vtkTransformFilter doesn't respect active scalars.  We need to track this
-        active_point_scalars_name = self.point_data.active_scalars_name  # type: ignore[attr-defined]
-        active_cell_scalars_name = self.cell_data.active_scalars_name  # type: ignore[attr-defined]
+        active_point_scalars_name = self.point_data.active_scalars_name
+        active_cell_scalars_name = self.cell_data.active_scalars_name
 
         # vtkTransformFilter sometimes doesn't transform all vector arrays
         # when there are active point/cell scalars. Use this workaround
@@ -7084,10 +7081,10 @@ class DataSetFilters:
 
         # make the previously active scalars active again
         if active_point_scalars_name is not None:
-            self.point_data.active_scalars_name = active_point_scalars_name  # type: ignore[attr-defined]
+            self.point_data.active_scalars_name = active_point_scalars_name
             res.point_data.active_scalars_name = active_point_scalars_name
         if active_cell_scalars_name is not None:
-            self.cell_data.active_scalars_name = active_cell_scalars_name  # type: ignore[attr-defined]
+            self.cell_data.active_scalars_name = active_cell_scalars_name
             res.cell_data.active_scalars_name = active_cell_scalars_name
 
         self_output = self if inplace else self.__class__()
@@ -7096,9 +7093,9 @@ class DataSetFilters:
         # of the original dataset except for the point arrays.  Here
         # we perform a copy so the two are completely unlinked.
         if inplace:
-            output.copy_from(res, deep=False)  # type: ignore[attr-defined]
+            output.copy_from(res, deep=False)
         else:
-            output.copy_from(res, deep=True)  # type: ignore[attr-defined]
+            output.copy_from(res, deep=True)
         return output
 
     def reflect(
@@ -7295,8 +7292,8 @@ class DataSetFilters:
             return pyvista.merge(list(output), merge_points=False)
         return output
 
-    def oriented_bounding_box(
-        self,
+    def oriented_bounding_box(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         box_style: Literal['frame', 'outline', 'face'] = 'face',
         *,
         axis_0_direction: VectorLike[float] | str | None = None,
@@ -7485,8 +7482,8 @@ class DataSetFilters:
             as_composite=as_composite,
         )
 
-    def bounding_box(
-        self,
+    def bounding_box(  # type: ignore[misc]
+        self: _ConcreteDataSet,
         box_style: Literal['frame', 'outline', 'face'] = 'face',
         *,
         oriented: bool = False,

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -32,6 +32,7 @@ from pyvista.core.utilities.misc import assert_empty_kwargs
 
 if TYPE_CHECKING:  # pragma: no cover
     from pyvista.core._typing_core import VectorLike
+    from pyvista.core.pointset import PolyData
 
 
 @abstract_class
@@ -3899,8 +3900,8 @@ class PolyDataFilters(DataSetFilters):
         _update_alg(alg, progress_bar, 'Generating Protein Ribbons')
         return _get_output(alg)
 
-    def voxelize_binary_mask(
-        self,
+    def voxelize_binary_mask(  # type: ignore[misc]
+        self: PolyData,
         *,
         background_value: int = 0,
         foreground_value: int = 1,
@@ -4216,8 +4217,8 @@ class PolyDataFilters(DataSetFilters):
         >>> plot.show(cpos="yz")
 
         """
-        _validation.check_greater_than(self.n_points, 1, name='n_points')  # type: ignore[attr-defined]
-        _validation.check_greater_than(self.n_cells, 1, name='n_cells')  # type: ignore[attr-defined]
+        _validation.check_greater_than(self.n_points, 1, name='n_points')
+        _validation.check_greater_than(self.n_cells, 1, name='n_cells')
 
         def _preprocess_polydata(poly_in):
             return poly_in.compute_normals().triangulate()
@@ -4237,7 +4238,7 @@ class PolyDataFilters(DataSetFilters):
             _validation.check_instance(reference_volume, pyvista.ImageData, name='reference volume')
             # The image stencil filters do not support orientation, so we apply the
             # inverse direction matrix to "remove" orientation from the polydata
-            poly_ijk = self.transform(reference_volume.direction_matrix.T, inplace=False)  # type: ignore[misc]
+            poly_ijk = self.transform(reference_volume.direction_matrix.T, inplace=False)
             poly_ijk = _preprocess_polydata(poly_ijk)
         else:
             # Compute reference volume geometry
@@ -4273,7 +4274,7 @@ class PolyDataFilters(DataSetFilters):
                             must_be_in_range=[0.0, 1.0],
                         )
                     )
-                    spacing = self.length * mesh_length_fraction  # type: ignore[attr-defined]
+                    spacing = self.length * mesh_length_fraction
                 else:
                     # Estimate spacing from cell length percentile
                     cell_length_percentile = (
@@ -4303,7 +4304,7 @@ class PolyDataFilters(DataSetFilters):
             initial_spacing = _validation.validate_array3(spacing, broadcast=True)
 
             # Get size of poly data for computing dimensions
-            bnds = self.bounds  # type: ignore[attr-defined]
+            bnds = self.bounds
             x_size = bnds.x_max - bnds.x_min
             y_size = bnds.y_max - bnds.y_min
             z_size = bnds.z_max - bnds.z_min
@@ -4324,7 +4325,7 @@ class PolyDataFilters(DataSetFilters):
             # points to be 1/2 spacing width smaller than the polydata bounds
             final_spacing = sizes / np.array(reference_volume.dimensions)
             reference_volume.spacing = final_spacing
-            reference_volume.origin = np.array(self.bounds[::2]) + final_spacing / 2  # type: ignore[attr-defined]
+            reference_volume.origin = np.array(self.bounds[::2]) + final_spacing / 2
 
         # Init output structure. The image stencil filters do not support
         # orientation, so we do not set the direction matrix

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from ._typing_core import MatrixLike
     from ._typing_core import NumpyArray
     from ._typing_core import VectorLike
+    from ._typing_core._aliases import _ConcretePointSet
 
 DEFAULT_INPLACE_WARNING = (
     'You did not specify a value for `inplace` and the default value will '
@@ -190,7 +191,12 @@ class _PointSet(DataSet):
         return self
 
     # todo: `transform_all_input_vectors` is not handled when modifying inplace
-    def translate(self, xyz: VectorLike[float], transform_all_input_vectors=False, inplace=None):
+    def translate(  # type: ignore[misc]
+        self: _ConcretePointSet,
+        xyz: VectorLike[float],
+        transform_all_input_vectors=False,
+        inplace=None,
+    ):
         """Translate the mesh.
 
         Parameters
@@ -227,7 +233,8 @@ class _PointSet(DataSet):
         if inplace:
             self.points += np.asarray(xyz)  # type: ignore[misc]
             return self
-        return super().translate(
+        return DataSet.translate(
+            self,
             xyz,
             transform_all_input_vectors=transform_all_input_vectors,
             inplace=inplace,
@@ -376,7 +383,7 @@ class PointSet(_PointSet, _vtk.vtkPointSet):
         """
         return self.cast_to_polydata(deep=False).cast_to_unstructured_grid()
 
-    @wraps(DataSet.plot)
+    @wraps(DataSet.plot)  # type:ignore[has-type]
     def plot(self, *args, **kwargs):  # numpydoc ignore=RT01
         """Cast to PolyData and plot."""
         pdata = self.cast_to_polydata(deep=False)

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -383,7 +383,7 @@ class PointSet(_PointSet, _vtk.vtkPointSet):
         """
         return self.cast_to_polydata(deep=False).cast_to_unstructured_grid()
 
-    @wraps(DataSet.plot)  # type:ignore[has-type]
+    @wraps(DataSet.plot)
     def plot(self, *args, **kwargs):  # numpydoc ignore=RT01
         """Cast to PolyData and plot."""
         pdata = self.cast_to_polydata(deep=False)

--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from pyvista.core._typing_core import RotationLike
     from pyvista.core._typing_core import TransformLike
     from pyvista.core._typing_core import VectorLike
+    from pyvista.core._typing_core._aliases import _ConcreteDataSet
 
 
 class Transform(_vtk.vtkTransform):
@@ -1471,7 +1472,7 @@ class Transform(_vtk.vtkTransform):
     @overload
     def apply(  # numpydoc ignore: GL08
         self,
-        obj: DataSet,
+        obj: _ConcreteDataSet,
         /,
         *,
         inverse: bool = ...,
@@ -1490,7 +1491,7 @@ class Transform(_vtk.vtkTransform):
     ) -> MultiBlock: ...
     def apply(
         self,
-        obj: VectorLike[float] | MatrixLike[float] | DataSet | MultiBlock,
+        obj: VectorLike[float] | MatrixLike[float] | _ConcreteDataSet | MultiBlock,
         /,
         *,
         inverse: bool = False,
@@ -1579,7 +1580,7 @@ class Transform(_vtk.vtkTransform):
         inplace = not copy
         # Transform dataset
         if isinstance(obj, (DataSet, MultiBlock)):
-            return obj.transform(  # type: ignore[misc]
+            return obj.transform(
                 self.copy().invert() if inverse else self,
                 inplace=inplace,
                 transform_all_input_vectors=transform_all_input_vectors,


### PR DESCRIPTION
### Overview

Datasets in pyvista inherit from filter classes, not the other way around. This leads to type errors when referencing dataset attributes inside the filter implementation (e.g. `self.active_scalars`).

A workaround to this problem is to annotate `self` in `DataSetFilters` with `DataSet` to let `mypy` know more about the actual type being passed to the filter. However, annotating with `DataSet` introduces its own set of type errors since any vtk filter method where `vtkDataSet` is expected will complain  about `DataSet` input types since `DataSet` does not actually inherit from `vtkDataSet`. And we can't simply add `vtkDataSet` as a superclass of `DataSet` due to MRO issues (see #6789).

Therefore, the solution proposed by this PR is to explicitly type `self` using concrete dataset types (`PolyData`, `UnstructuredGrid`, etc.) instead of using the abstract `DataSet` since the concrete types _do_ inherit from `vtkDataSet`. This removes the need to use `# type: ignore[attr-defined]` everywhere in the filters. The only downside is that it requires adding `# type: ignore[misc]` once for the filter since `mypy` is complaining about the mismatch between `self` type (DataSetFilter) and the annotated type (concrete DataSet). But at least this way we only add a single ignore at the top of each filter instead of requiring many ignores in the body.
