### PR TITLE
Add `extra_checks` to `mypy` config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,6 +210,7 @@ ignore_missing_imports = true
 disallow_any_generics = true
 pretty = true
 show_error_context = true
+extra_checks = true
 warn_unused_ignores = true
 warn_redundant_casts = true
 plugins = ['npt_promote', 'numpy.typing.mypy_plugin']


### PR DESCRIPTION
### Overview

Part of https://github.com/pyvista/pyvista/issues/6279.

I originally intended to add `strict_concatenate` but was warned that it's deprecated and to use `extra_checks` instead.

See: https://mypy.readthedocs.io/en/stable/config_file.html#confval-strict_concatenate