### PR TITLE
Remove outdated reference to .clean() in intro doc

### DIFF
--- a/doc/source/user-guide/what-is-a-mesh.rst
+++ b/doc/source/user-guide/what-is-a-mesh.rst
@@ -226,4 +226,3 @@ Note how this varies from assigning scalars to each point
    pl.subplot(0, 1)
    pl.add_mesh(other_cube, cmap='coolwarm')
    pl.show()
-

--- a/doc/source/user-guide/what-is-a-mesh.rst
+++ b/doc/source/user-guide/what-is-a-mesh.rst
@@ -227,7 +227,3 @@ Note how this varies from assigning scalars to each point
    pl.add_mesh(other_cube, cmap='coolwarm')
    pl.show()
 
-.. note::
-   We use :func:`pyvista.PolyDataFilters.clean` to merge the faces of
-   the cube since, by default, the cube is created with unmerged faces
-   and duplicate points.


### PR DESCRIPTION
### Overview

Reading through the intro, it seemed to me that the reference to .clean() is now outdated.
This PR removes this reference.

Best regards,
Florian