### PR TITLE
Remove usage of deprecated `macos-12` runner

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: macos-13, python-version: "3.9" } # intel processor
+          - { os: macos-13, python-version: "3.9" }
           - { os: macos-14, python-version: "3.10" }
           - { os: macos-latest, python-version: "3.11" }
           - { os: macos-latest, python-version: "3.12" }

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -27,9 +27,9 @@ jobs:
       matrix:
         config:
           - { os: macos-13, python-version: "3.9" } # intel processor
-          - { os: macos-14, python-version: "3.10" } # intel processor
-          - { os: macos-latest, python-version: "3.11" } # arm processor
-          - { os: macos-latest, python-version: "3.12" } # arm processor
+          - { os: macos-14, python-version: "3.10" }
+          - { os: macos-latest, python-version: "3.11" }
+          - { os: macos-latest, python-version: "3.12" }
     runs-on: ${{ matrix.config.os }}
 
     steps:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -26,9 +26,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: macos-12, python-version: "3.9" } # intel processor
-          - { os: macos-13, python-version: "3.10" } # intel processor
-          - { os: macos-14, python-version: "3.11" } # arm processor
+          - { os: macos-13, python-version: "3.9" } # intel processor
+          - { os: macos-14, python-version: "3.10" } # intel processor
+          - { os: macos-latest, python-version: "3.11" } # arm processor
           - { os: macos-latest, python-version: "3.12" } # arm processor
     runs-on: ${{ matrix.config.os }}
 


### PR DESCRIPTION
### Overview

Tests using `macos-12` runners are deprecated and are failing temporarily. See https://github.com/actions/runner-images/issues/10721
This PR removes use of this runner.