### PR TITLE
Add `None` return annotations to `renderer.py`

### DIFF
--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -5428,7 +5428,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
             if not isinstance(label, str):
                 raise TypeError('Label must be a string')
             addr = actor.GetAddressAsString('')
-            self.renderer._labels[addr] = [lines, label, Color(color)]
+            self.renderer._labels[addr] = (lines, label, Color(color))
 
         # Add to renderer
         self.add_actor(actor, reset_camera=False, name=name, pickable=False)  # type: ignore[arg-type]


### PR DESCRIPTION
### Overview

I ran `python -m autotyping --none-return pyvista/plotting/renderer.py` and then resolved the following 10 type errors:

<details>

``` python
pyvista/plotting/renderer.py: note: In member "__init__" of class "Renderer":
pyvista/plotting/renderer.py:281: error: Need type annotation for "_actors" (hint: "_actors: dict[<type>, <type>] = ...")  [var-annotated]
            self._actors = {}
            ^~~~~~~~~~~~
pyvista/plotting/renderer.py:287: error: Need type annotation for "_labels" (hint: "_labels: dict[<type>, <type>] = ...")  [var-annotated]
            self._labels = {}  # tracks labeled actors
            ^~~~~~~~~~~~
pyvista/plotting/renderer.py:290: error: Need type annotation for "_floors" (hint: "_floors: list[<type>] = ...")  [var-annotated]
            self._floors = []
            ^~~~~~~~~~~~
pyvista/plotting/renderer.py:291: error: Need type annotation for "_floor_kwargs" (hint: "_floor_kwargs: list[<type>] = ...")  [var-annotated]
            self._floor_kwargs = []
            ^~~~~~~~~~~~~~~~~~
pyvista/plotting/renderer.py:293: error: Need type annotation for "_lights" (hint: "_lights: list[<type>] = ...")  [var-annotated]
            self._lights = []
            ^~~~~~~~~~~~
pyvista/plotting/renderer.py:304: error: Need type annotation for "_scalar_bar_slot_lookup" (hint: "_scalar_bar_slot_lookup: dict[<type>, <type>] = ...")  [var-annotated]
            self._scalar_bar_slot_lookup = {}
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
pyvista/plotting/renderer.py: note: In member "_before_render_event" of class "Renderer":
pyvista/plotting/renderer.py:521: error: "None" has no attribute "__iter__" (not iterable)  [attr-defined]
            for chart in self._charts:
                         ^~~~~~~~~~~~
pyvista/plotting/renderer.py: note: In member "remove_chart" of class "Renderer":
pyvista/plotting/renderer.py:783: error: "None" has no attribute "remove_chart"  [attr-defined]
                self._charts.remove_chart(chart_or_index)
                ^~~~~~~~~~~~~~~~~~~~~~~~~
pyvista/plotting/renderer.py: note: In member "remove_floors" of class "Renderer":
pyvista/plotting/renderer.py:2293: error: "None" has no attribute "ReleaseData"  [attr-defined]
                self._floor.ReleaseData()
                ^~~~~~~~~~~~~~~~~~~~~~~
pyvista/plotting/renderer.py: note: In member "deep_clean" of class "Renderer":
pyvista/plotting/renderer.py:3530: error: Incompatible types in assignment (expression has type "None", variable has type "Camera")  [assignment]
            self._camera = None
                           ^~~~
Found 10 errors in 1 file (checked 143 source files)

```

<\details>
