### PR TITLE
Upload `mypy` type checking coverage reports to Codecov

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -245,6 +245,9 @@ jobs:
         name: "Upload coverage to CodeCov"
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          flags: pytest
+          name: Pytest Test Coverage
 
       - name: Check package
         run: |

--- a/.github/workflows/type-checking.yml
+++ b/.github/workflows/type-checking.yml
@@ -22,7 +22,7 @@ jobs:
         run: pip install .[typing]
 
       - name: Run Mypy
-        run: mypy --xml-report
+        run: mypy --xml-report .
 
       - name: Software Report
         run: |

--- a/.github/workflows/type-checking.yml
+++ b/.github/workflows/type-checking.yml
@@ -22,10 +22,19 @@ jobs:
         run: pip install .[typing]
 
       - name: Run Mypy
-        run: mypy
+        run: mypy --txt-report mypy-report/
 
       - name: Software Report
         run: |
           python -c "import pyvista; print(pyvista.Report()); from pyvista import examples; print('Examples path:', examples.USER_DATA_PATH)"
           which python
           pip list
+
+      - name: "Upload Mypy coverage to CodeCov"
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: ./mypy-report/index.txt
+          flags: mypy
+          name: Mypy Static Type Coverage

--- a/.github/workflows/type-checking.yml
+++ b/.github/workflows/type-checking.yml
@@ -22,7 +22,7 @@ jobs:
         run: pip install .[typing]
 
       - name: Run Mypy
-        run: mypy --txt-report mypy-report/
+        run: mypy --xml-report
 
       - name: Software Report
         run: |
@@ -30,11 +30,10 @@ jobs:
           which python
           pip list
 
-      - name: "Upload Mypy coverage to CodeCov"
+      - name: "Upload Mypy coverage to Codecov"
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          files: ./mypy-report/index.txt
           flags: mypy
           name: Mypy Static Type Coverage

--- a/.github/workflows/type-checking.yml
+++ b/.github/workflows/type-checking.yml
@@ -22,7 +22,7 @@ jobs:
         run: pip install .[typing]
 
       - name: Run Mypy
-        run: mypy --xml-report .
+        run: mypy --cobertura-xml-report .
 
       - name: Software Report
         run: |

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,21 +2,29 @@ comment:
   layout: "diff, flags"
   behavior: default
 
-coverage:
-  status:
-    project:
-      default:
-        # basic
-        target: 90%
-        threshold: 0%
-        # advanced
-        if_not_found: success
-        if_ci_failed: error
-        if_no_uploads: error
-    patch:
-      default:
-        # basic
-        target: 90%
-        if_not_found: success
-        if_ci_failed: error
-        if_no_uploads: error
+flag_management:
+  default_rules: # the rules that will be followed for any flag added, generally
+    - statuses:
+        - type: project
+          if_not_found: success
+          if_ci_failed: error
+          if_no_uploads: error
+        - type: patch
+          if_not_found: success
+          if_ci_failed: error
+          if_no_uploads: error
+  individual_flags: # exceptions to the default rules above, stated flag by flag
+    - name: pytest
+      statuses:
+        - type: project
+          target: 90%
+          threshold: 0%
+        - type: patch
+          target: 90%
+    - name: mypy
+      statuses:
+        - type: project
+          target: 20%
+          threshold: 0%
+        - type: patch
+          target: 20%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 comment:
-  layout: "diff"
+  layout: "diff, flags"
   behavior: default
 
 coverage:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,13 @@ pinned = [ # Pinned versions of core dependencies
   'vtk<9.4.0',
 ]
 
-typing = ['mypy<1.14.0', 'npt-promote==0.1', 'numpy>=2.0.0', 'pyvista[pinned]']
+typing = [
+  'lxml<5.4.0',
+  'mypy<1.14.0',
+  'npt-promote==0.1',
+  'numpy>=2.0.0',
+  'pyvista[pinned]',
+]
 
 test = [
   'cmocean<4.0.4',


### PR DESCRIPTION
### Overview

Attempt to integrate coverage reports generated by mypy with Codecov. See https://mypy.readthedocs.io/en/stable/config_file.html#report-generation