### PR TITLE
Add scalar return type annotation

### DIFF
--- a/pyvista/core/celltype.py
+++ b/pyvista/core/celltype.py
@@ -56,29 +56,29 @@ def _indent_paragraph(string, level):
 _BADGE_COLORS = dict(linear='primary', primary='success', dimension='secondary', geometry='muted')
 
 
-def _generate_linear_badge(is_linear: bool):
+def _generate_linear_badge(is_linear: bool) -> str:
     text = 'Linear' if is_linear else 'Non-linear'
     return f":bdg-{_BADGE_COLORS['linear']}:`{text}`"
 
 
-def _generate_primary_badge(is_primary: bool):
+def _generate_primary_badge(is_primary: bool) -> str:
     text = 'Primary' if is_primary else 'Composite'
     return f":bdg-{_BADGE_COLORS['primary']}:`{text}`"
 
 
-def _generate_dimension_badge(dimension: int):
+def _generate_dimension_badge(dimension: int) -> str:
     return f":bdg-{_BADGE_COLORS['dimension']}:`{dimension}D`"
 
 
-def _generate_points_badge(num_points: int):
+def _generate_points_badge(num_points: int) -> str:
     return f":bdg-{_BADGE_COLORS['geometry']}:`Points: {num_points}`"
 
 
-def _generate_edges_badge(num_edges: int):
+def _generate_edges_badge(num_edges: int) -> str:
     return f":bdg-{_BADGE_COLORS['geometry']}:`Edges: {num_edges}`"
 
 
-def _generate_faces_badge(num_faces: int):
+def _generate_faces_badge(num_faces: int) -> str:
     return f":bdg-{_BADGE_COLORS['geometry']}:`Faces: {num_faces}`"
 
 

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -759,7 +759,7 @@ class MultiBlock(
         if hasattr(dataset, 'memory_address'):
             self._refs.pop(dataset.memory_address, None)  # type: ignore[union-attr]
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         """Equality comparison."""
         if not isinstance(other, MultiBlock):
             return False
@@ -1286,7 +1286,7 @@ class MultiBlock(
 
         return field, scalars_name, dtype
 
-    def _convert_to_real_scalars(self, data_attr: str, scalars_name: str):
+    def _convert_to_real_scalars(self, data_attr: str, scalars_name: str) -> str:
         """Extract the real component of the active scalars of this dataset."""
         for block in self:
             if isinstance(block, MultiBlock):
@@ -1300,7 +1300,7 @@ class MultiBlock(
                     dattr.active_scalars_name = f'{scalars_name}-real'
         return f'{scalars_name}-real'
 
-    def _convert_to_uint8_rgb_scalars(self, data_attr: str, scalars_name: str):
+    def _convert_to_uint8_rgb_scalars(self, data_attr: str, scalars_name: str) -> str:
         """Convert rgb float or int scalars to uint8."""
         for block in self:
             if isinstance(block, MultiBlock):

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:  # pragma: no cover
 T = TypeVar('T', bound='AnnotatedIntEnum')
 
 
-def assert_empty_kwargs(**kwargs):
+def assert_empty_kwargs(**kwargs) -> bool:
     """Assert that all keyword arguments have been used (internal helper).
 
     If any keyword arguments are passed, a ``TypeError`` is raised.
@@ -169,7 +169,7 @@ class AnnotatedIntEnum(int, enum.Enum):
 
 
 @cache
-def has_module(module_name):
+def has_module(module_name) -> bool:
     """Return if a module can be imported.
 
     Parameters

--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -301,7 +301,7 @@ class BaseReader:
         self.path = str(path)
         self._set_defaults_post()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Representation of a Reader object."""
         return f"{self.__class__.__name__}('{self.path}')"
 

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -153,7 +153,7 @@ pyvista.OFF_SCREEN = True
 # -----------------------------------------------------------------------------
 
 
-def _option_boolean(arg):
+def _option_boolean(arg) -> bool:
     if not arg or not arg.strip():
         # no argument given, assume used as a flag
         return True
@@ -246,7 +246,7 @@ def _contains_doctest(text):
     return bool(m)
 
 
-def _contains_pyvista_plot(text):
+def _contains_pyvista_plot(text) -> bool:
     return '.. pyvista-plot::' in text
 
 

--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -55,7 +55,7 @@ class Camera(_vtk.vtkCamera):
         else:
             self._renderer = None
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         """Compare whether the relevant attributes of two cameras are equal."""
         # attributes which are native python types and thus implement __eq__
 

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -1055,7 +1055,7 @@ class Axis(_vtkWrapper, _vtk.vtkAxis):
 
 class _CustomContextItem(_vtk.vtkPythonItem):
     class ItemWrapper:
-        def Initialize(self, item):
+        def Initialize(self, item) -> bool:
             # item is the _CustomContextItem subclass instance
             return True
 
@@ -1068,7 +1068,7 @@ class _CustomContextItem(_vtk.vtkPythonItem):
         # This will also call ItemWrapper.Initialize
         self.SetPythonObject(_CustomContextItem.ItemWrapper())
 
-    def paint(self, painter):
+    def paint(self, painter) -> bool:
         return True
 
 
@@ -1087,7 +1087,7 @@ class _ChartBackground(_CustomContextItem):
         self.ActiveBorderPen = Pen(color=(0.8, 0.8, 0.2))
         self.ActiveBackgroundBrush = Brush(color=(1.0, 1.0, 1.0, 0.4))
 
-    def paint(self, painter):
+    def paint(self, painter) -> bool:
         if self._chart.visible:
             painter.ApplyPen(self.ActiveBorderPen if self._chart._interactive else self.BorderPen)
             painter.ApplyBrush(

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -1013,7 +1013,7 @@ class Color:
         """Support iteration over the float RGBA representation for backward compatibility."""
         return iter(self.float_rgba)
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self) -> str:  # pragma: no cover
         """Human readable representation."""
         kwargs = f'hex={self.hex_rgba!r}, opacity={self.opacity}'
         if self._name is not None:

--- a/pyvista/plotting/lights.py
+++ b/pyvista/plotting/lights.py
@@ -218,11 +218,11 @@ class Light(vtkLight):
         self.actor.SetLight(self)
         self.actor.SetVisibility(show_actor)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Print a repr specifying the id of the light and its light type."""
         return f'<{self.__class__.__name__} ({self.light_type}) at {hex(id(self))}>'
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         """Compare whether the relevant attributes of two lights are equal."""
         # attributes which are native python types and thus implement __eq__
         native_attrs = [

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -336,7 +336,7 @@ class RenderWindowInteractor:
         self.remove_observers(_vtk.vtkCommand.MouseMoveEvent)
 
     @staticmethod
-    def _get_click_event(side):
+    def _get_click_event(side) -> str:
         side = str(side).lower()
         if side in ['right', 'r']:
             return 'RightButtonPressEvent'

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -213,7 +213,7 @@ class CameraPosition:
         """
         return [self._position, self._focal_point, self._viewup]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """List representation method."""
         return '[{},\n {},\n {}]'.format(*self.to_list())
 
@@ -654,7 +654,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         return actor
 
     @property
-    def has_border(self):  # numpydoc ignore=RT01
+    def has_border(self) -> bool:  # numpydoc ignore=RT01
         """Return if the renderer has a border."""
         return self._border_actor is not None
 

--- a/pyvista/plotting/renderers.py
+++ b/pyvista/plotting/renderers.py
@@ -472,7 +472,7 @@ class Renderers:
         return renderer
 
     @property
-    def has_active_background_renderer(self):  # numpydoc ignore=RT01
+    def has_active_background_renderer(self) -> bool:  # numpydoc ignore=RT01
         """Return ``True`` when Renderer has an active background renderer.
 
         Returns

--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -156,7 +156,7 @@ class ScalarBars:
         """Scalar bar items."""
         return self._scalar_bar_actors.items()
 
-    def __contains__(self, key):
+    def __contains__(self, key) -> bool:
         """Check if a title is a valid actors."""
         return key in self._scalar_bar_actors
 

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -195,7 +195,7 @@ class _ThemeConfig(metaclass=_ForceSlots):
                 dict_[key] = value
         return dict_
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if not isinstance(other, _ThemeConfig):
             return False
 

--- a/pyvista/plotting/utilities/algorithms.py
+++ b/pyvista/plotting/utilities/algorithms.py
@@ -135,7 +135,7 @@ class PreserveTypeAlgorithmBase(_vtk.VTKPythonAlgorithmBase):
         return inp
 
     # THIS IS CRUCIAL to preserve data type through filter
-    def RequestDataObject(self, _request, inInfo, outInfo):
+    def RequestDataObject(self, _request, inInfo, outInfo) -> int:
         """Preserve data type.
 
         Parameters
@@ -193,7 +193,7 @@ class ActiveScalarsAlgorithm(PreserveTypeAlgorithmBase):
         self.scalars_name = name
         self.preference = preference
 
-    def RequestData(self, _request, inInfo, outInfo):
+    def RequestData(self, _request, inInfo, outInfo) -> int:
         """Perform algorithm execution.
 
         Parameters
@@ -241,7 +241,7 @@ class PointSetToPolyDataAlgorithm(_vtk.VTKPythonAlgorithmBase):
             outputType='vtkPolyData',
         )
 
-    def RequestData(self, _request, inInfo, outInfo):
+    def RequestData(self, _request, inInfo, outInfo) -> int:
         """Perform algorithm execution.
 
         Parameters
@@ -299,7 +299,7 @@ class AddIDsAlgorithm(PreserveTypeAlgorithmBase):
         self.point_ids = point_ids
         self.cell_ids = cell_ids
 
-    def RequestData(self, _request, inInfo, outInfo):
+    def RequestData(self, _request, inInfo, outInfo) -> int:
         """Perform algorithm execution.
 
         Parameters
@@ -349,7 +349,7 @@ class CrinkleAlgorithm(_vtk.VTKPythonAlgorithmBase):
             outputType='vtkUnstructuredGrid',
         )
 
-    def RequestData(self, _request, inInfo, outInfo):
+    def RequestData(self, _request, inInfo, outInfo) -> int:
         """Perform algorithm execution based on the input data and produce the output.
 
         Parameters

--- a/pyvista/plotting/utilities/sphinx_gallery.py
+++ b/pyvista/plotting/utilities/sphinx_gallery.py
@@ -149,7 +149,7 @@ class Scraper:
 
     """
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return a stable representation of the class instance."""
         return f'<{type(self).__name__} object>'
 
@@ -191,7 +191,7 @@ class DynamicScraper:  # pragma: no cover
 
     """
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return a stable representation of the class instance."""
         return f'<{type(self).__name__} object>'
 


### PR DESCRIPTION
### Overview
I ran `python -m autotyping --scalar-return pyvista` to automatically add scalar return type annotations. There were no type errors to resolve (all changes are automatic).