### PR TITLE
Add `bool` parameter annotations to `core`

### DIFF
--- a/pyvista/core/_validation/check.py
+++ b/pyvista/core/_validation/check.py
@@ -742,7 +742,7 @@ def check_number(num, /, *, name='Object'):
     check_instance(num, Number, allow_subclass=True, name=name)
 
 
-def check_string(obj, /, *, allow_subclass=True, name='Object'):
+def check_string(obj, /, *, allow_subclass: bool = True, name='Object'):
     """Check if an object is an instance of ``str``.
 
     Parameters
@@ -849,7 +849,7 @@ def check_iterable(obj, /, *, name='Object'):
     check_instance(obj, Iterable, allow_subclass=True, name=name)
 
 
-def check_instance(obj, /, classinfo, *, allow_subclass=True, name='Object'):
+def check_instance(obj, /, classinfo, *, allow_subclass: bool = True, name='Object'):
     """Check if an object is an instance of the given type or types.
 
     Parameters
@@ -975,7 +975,7 @@ def check_iterable_items(
     /,
     item_type,
     *,
-    allow_subclass=True,
+    allow_subclass: bool = True,
     name='Iterable',
 ):
     """Check if an iterable's items all have a specified type.

--- a/pyvista/core/_validation/validate.py
+++ b/pyvista/core/_validation/validate.py
@@ -59,21 +59,21 @@ def validate_array(
     must_have_length=None,
     must_have_min_length=None,
     must_have_max_length=None,
-    must_be_nonnegative=False,
-    must_be_finite=False,
-    must_be_real=True,
-    must_be_integer=False,
-    must_be_sorted=False,
+    must_be_nonnegative: bool = False,
+    must_be_finite: bool = False,
+    must_be_real: bool = True,
+    must_be_integer: bool = False,
+    must_be_sorted: bool = False,
     must_be_in_range=None,
-    strict_lower_bound=False,
-    strict_upper_bound=False,
+    strict_lower_bound: bool = False,
+    strict_upper_bound: bool = False,
     reshape_to=None,
     broadcast_to=None,
     dtype_out=None,
-    as_any=True,
-    copy=False,
-    to_list=False,
-    to_tuple=False,
+    as_any: bool = True,
+    copy: bool = False,
+    to_list: bool = False,
+    to_tuple: bool = False,
     name='Array',
 ):
     """Check and validate a numeric array meets specific requirements.
@@ -354,8 +354,8 @@ def validate_array(
 
 def validate_axes(
     *axes,
-    normalize=True,
-    must_be_orthogonal=True,
+    normalize: bool = True,
+    must_be_orthogonal: bool = True,
     must_have_orientation='right',
     name='Axes',
 ):
@@ -483,7 +483,7 @@ def validate_axes(
     return axes_array
 
 
-def validate_transform4x4(transform, /, *, must_be_finite=True, name='Transform'):
+def validate_transform4x4(transform, /, *, must_be_finite: bool = True, name='Transform'):
     """Validate transform-like input as a 4x4 ndarray.
 
     This function supports inputs with a 3x3 or 4x4 shape. If the input is 3x3,
@@ -553,7 +553,7 @@ def validate_transform4x4(transform, /, *, must_be_finite=True, name='Transform'
     return arr
 
 
-def validate_transform3x3(transform, /, *, must_be_finite=True, name='Transform'):
+def validate_transform3x3(transform, /, *, must_be_finite: bool = True, name='Transform'):
     """Validate transform-like input as a 3x3 ndarray.
 
     Parameters
@@ -634,7 +634,7 @@ def _array_from_vtkmatrix(
     return array
 
 
-def validate_number(num, /, *, reshape=True, **kwargs):
+def validate_number(num, /, *, reshape: bool = True, **kwargs):
     """Validate a real, finite number.
 
     By default, the number is checked to ensure it:
@@ -749,7 +749,7 @@ def validate_data_range(rng, /, **kwargs):
     return validate_array(rng, **kwargs)
 
 
-def validate_arrayNx3(arr, /, *, reshape=True, **kwargs):
+def validate_arrayNx3(arr, /, *, reshape: bool = True, **kwargs):
     """Validate an array is numeric and has shape Nx3.
 
     The array is checked to ensure its input values:
@@ -820,7 +820,7 @@ def validate_arrayNx3(arr, /, *, reshape=True, **kwargs):
     return validate_array(arr, **kwargs)
 
 
-def validate_arrayN(arr, /, *, reshape=True, **kwargs):
+def validate_arrayN(arr, /, *, reshape: bool = True, **kwargs):
     """Validate a numeric 1D array.
 
     The array is checked to ensure its input values:
@@ -893,7 +893,7 @@ def validate_arrayN(arr, /, *, reshape=True, **kwargs):
     return validate_array(arr, **kwargs)
 
 
-def validate_arrayN_unsigned(arr, /, *, reshape=True, **kwargs):
+def validate_arrayN_unsigned(arr, /, *, reshape: bool = True, **kwargs):
     """Validate a numeric 1D array of non-negative (unsigned) integers.
 
     The array is checked to ensure its input values:
@@ -980,7 +980,7 @@ def validate_arrayN_unsigned(arr, /, *, reshape=True, **kwargs):
     return validate_arrayN(arr, reshape=reshape, **kwargs)
 
 
-def validate_array3(arr, /, *, reshape=True, broadcast=False, **kwargs):
+def validate_array3(arr, /, *, reshape: bool = True, broadcast: bool = False, **kwargs):
     """Validate a numeric 1D array with 3 elements.
 
     The array is checked to ensure its input values:

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -103,7 +103,7 @@ class Cell(DataObject, _vtk.vtkGenericCell):
 
     """
 
-    def __init__(self, vtk_cell=None, cell_type=None, deep=False):
+    def __init__(self, vtk_cell=None, cell_type=None, deep: bool = False):
         """Initialize the cell."""
         super().__init__()
         if vtk_cell is not None:
@@ -558,7 +558,7 @@ class Cell(DataObject, _vtk.vtkGenericCell):
         """Return the object string representation."""
         return self.head(display=False, html=False)
 
-    def copy(self, deep=True) -> Cell:
+    def copy(self, deep: bool = True) -> Cell:
         """Return a copy of the cell.
 
         Parameters

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -880,7 +880,7 @@ class MultiBlock(
         for i, name in enumerate(reversed(names)):
             self.set_block_name(i, name)
 
-    def clean(self, empty=True):
+    def clean(self, empty: bool = True):
         """Remove any null blocks in place.
 
         Parameters
@@ -987,7 +987,7 @@ class MultiBlock(
         # This method is here for consistency with the rest of the API and
         # in case we add meta data to this pbject down the road.
 
-    def copy(self, deep=True):
+    def copy(self, deep: bool = True):
         """Return a copy of the multiblock.
 
         Parameters
@@ -1023,7 +1023,7 @@ class MultiBlock(
         newobject.copy_meta_from(self, deep)
         return newobject
 
-    def shallow_copy(self, to_copy: _vtk.vtkMultiBlockDataSet, recursive=False) -> None:  # type: ignore[override]
+    def shallow_copy(self, to_copy: _vtk.vtkMultiBlockDataSet, recursive: bool = False) -> None:  # type: ignore[override]
         """Shallow copy the given multiblock to this multiblock.
 
         Parameters
@@ -1179,7 +1179,7 @@ class MultiBlock(
 
         return field_asc, scalars
 
-    def as_polydata_blocks(self, copy=False):
+    def as_polydata_blocks(self, copy: bool = False):
         """Convert all the datasets within this MultiBlock to :class:`pyvista.PolyData`.
 
         Parameters

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -215,7 +215,7 @@ class DataObject:
         """Return the representation methods (internal helper)."""
         raise NotImplementedError('Called only by the inherited class')
 
-    def head(self, display=True, html=None):
+    def head(self, display: bool = True, html=None):
         """Return the header stats of this dataset.
 
         If in IPython, this will be formatted to HTML. Otherwise
@@ -302,7 +302,7 @@ class DataObject:
         """
         # called only by the inherited class
 
-    def copy(self, deep=True):
+    def copy(self, deep: bool = True):
         """Return a copy of the object.
 
         Parameters

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -547,7 +547,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
         return narray
 
-    def set_array(self, data: ArrayLike[float], name: str, deep_copy=False) -> None:
+    def set_array(self, data: ArrayLike[float], name: str, deep_copy: bool = False) -> None:
         """Add an array to this object.
 
         Use this method when adding arrays to the DataSet.  If
@@ -610,7 +610,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         self.VTKObject.AddArray(vtk_arr)
         self.VTKObject.Modified()
 
-    def set_scalars(self, scalars: ArrayLike[float], name='scalars', deep_copy=False):
+    def set_scalars(self, scalars: ArrayLike[float], name='scalars', deep_copy: bool = False):
         """Set the active scalars of the dataset with an array.
 
         In VTK and PyVista, scalars are a quantity that has no
@@ -662,7 +662,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         self.VTKObject.SetScalars(vtk_arr)
         self.VTKObject.Modified()
 
-    def set_vectors(self, vectors: MatrixLike[float], name: str, deep_copy=False):
+    def set_vectors(self, vectors: MatrixLike[float], name: str, deep_copy: bool = False):
         """Set the active vectors of this data attribute.
 
         Vectors are a quantity that has magnitude and direction, such

--- a/pyvista/core/filters/__init__.py
+++ b/pyvista/core/filters/__init__.py
@@ -31,7 +31,7 @@ from pyvista.core.utilities.helpers import wrap
 from pyvista.core.utilities.observers import ProgressMonitor
 
 
-def _update_alg(alg, progress_bar=False, message=''):
+def _update_alg(alg, progress_bar: bool = False, message=''):
     """Update an algorithm with or without a progress bar."""
     if progress_bar:
         with ProgressMonitor(alg, message=message):

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -40,7 +40,7 @@ class CompositeFilters:
         gf.Update()
         return wrap(gf.GetOutputDataObject(0))
 
-    def combine(self, merge_points=False, tolerance=0.0):
+    def combine(self, merge_points: bool = False, tolerance=0.0):
         """Combine all blocks into a single unstructured grid.
 
         Parameters
@@ -121,7 +121,9 @@ class CompositeFilters:
 
     triangulate = DataSetFilters.triangulate
 
-    def outline(self, generate_faces=False, nested=False, progress_bar=False):
+    def outline(
+        self, generate_faces: bool = False, nested: bool = False, progress_bar: bool = False
+    ):
         """Produce an outline of the full extent for the all blocks in this composite dataset.
 
         Parameters
@@ -150,7 +152,7 @@ class CompositeFilters:
         box = pyvista.Box(bounds=self.bounds)  # type: ignore[attr-defined]
         return box.outline(generate_faces=generate_faces, progress_bar=progress_bar)
 
-    def outline_corners(self, factor=0.2, nested=False, progress_bar=False):
+    def outline_corners(self, factor=0.2, nested: bool = False, progress_bar: bool = False):
         """Produce an outline of the corners for the all blocks in this composite dataset.
 
         Parameters
@@ -178,16 +180,16 @@ class CompositeFilters:
 
     def _compute_normals(
         self,
-        cell_normals=True,
-        point_normals=True,
-        split_vertices=False,
-        flip_normals=False,
-        consistent_normals=True,
-        auto_orient_normals=False,
-        non_manifold_traversal=True,
+        cell_normals: bool = True,
+        point_normals: bool = True,
+        split_vertices: bool = False,
+        flip_normals: bool = False,
+        consistent_normals: bool = True,
+        auto_orient_normals: bool = False,
+        non_manifold_traversal: bool = True,
         feature_angle=30.0,
-        track_vertices=False,
-        progress_bar=False,
+        track_vertices: bool = False,
+        progress_bar: bool = False,
     ):
         """Compute point and/or cell normals for a multi-block dataset."""
         if not self.is_all_polydata:  # type: ignore[attr-defined]
@@ -218,9 +220,9 @@ class CompositeFilters:
     def transform(
         self,
         trans: TransformLike,
-        transform_all_input_vectors=False,
-        inplace=True,
-        progress_bar=False,
+        transform_all_input_vectors: bool = False,
+        inplace: bool = True,
+        progress_bar: bool = False,
     ):
         """Transform all blocks in this composite dataset.
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -49,11 +49,11 @@ class DataSetFilters:
     def _clip_with_function(
         self,
         function,
-        invert=True,
+        invert: bool = True,
         value=0.0,
-        return_clipped=False,
-        progress_bar=False,
-        crinkle=False,
+        return_clipped: bool = False,
+        progress_bar: bool = False,
+        crinkle: bool = False,
     ):
         """Clip using an implicit function (internal helper)."""
         if crinkle:
@@ -94,9 +94,9 @@ class DataSetFilters:
         max_landmarks=100,
         max_mean_distance=1e-5,
         max_iterations=500,
-        check_mean_distance=True,
-        start_by_matching_centroids=True,
-        return_matrix=False,
+        check_mean_distance: bool = True,
+        start_by_matching_centroids: bool = True,
+        return_matrix: bool = False,
     ):
         """Align a dataset to another.
 
@@ -447,12 +447,12 @@ class DataSetFilters:
         self,
         normal='x',
         origin=None,
-        invert=True,
+        invert: bool = True,
         value=0.0,
-        inplace=False,
-        return_clipped=False,
-        progress_bar=False,
-        crinkle=False,
+        inplace: bool = False,
+        return_clipped: bool = False,
+        progress_bar: bool = False,
+        crinkle: bool = False,
     ):
         """Clip a dataset by a plane by specifying the origin and normal.
 
@@ -548,11 +548,11 @@ class DataSetFilters:
     def clip_box(
         self,
         bounds=None,
-        invert=True,
+        invert: bool = True,
         factor=0.35,
-        progress_bar=False,
-        merge_points=True,
-        crinkle=False,
+        progress_bar: bool = False,
+        merge_points: bool = True,
+        crinkle: bool = False,
     ):
         """Clip a dataset by a bounding box defined by the bounds.
 
@@ -659,7 +659,7 @@ class DataSetFilters:
             clipped = self.extract_cells(np.unique(clipped.cell_data['cell_ids']))
         return clipped
 
-    def compute_implicit_distance(self, surface, inplace=False):
+    def compute_implicit_distance(self, surface, inplace: bool = False):
         """Compute the implicit distance from the points to a surface.
 
         This filter will compute the implicit distance from all of the
@@ -750,11 +750,11 @@ class DataSetFilters:
     def clip_scalar(
         self,
         scalars=None,
-        invert=True,
+        invert: bool = True,
         value=0.0,
-        inplace=False,
-        progress_bar=False,
-        both=False,
+        inplace: bool = False,
+        progress_bar: bool = False,
+        both: bool = False,
     ):
         """Clip a dataset by a scalar.
 
@@ -851,11 +851,11 @@ class DataSetFilters:
     def clip_surface(
         self,
         surface,
-        invert=True,
+        invert: bool = True,
         value=0.0,
-        compute_distance=False,
-        progress_bar=False,
-        crinkle=False,
+        compute_distance: bool = False,
+        progress_bar: bool = False,
+        crinkle: bool = False,
     ):
         """Clip any mesh type using a :class:`pyvista.PolyData` surface mesh.
 
@@ -933,9 +933,9 @@ class DataSetFilters:
     def slice_implicit(
         self,
         implicit_function,
-        generate_triangles=False,
-        contour=False,
-        progress_bar=False,
+        generate_triangles: bool = False,
+        contour: bool = False,
+        progress_bar: bool = False,
     ):
         """Slice a dataset by a VTK implicit function.
 
@@ -995,9 +995,9 @@ class DataSetFilters:
         self,
         normal='x',
         origin=None,
-        generate_triangles=False,
-        contour=False,
-        progress_bar=False,
+        generate_triangles: bool = False,
+        contour: bool = False,
+        progress_bar: bool = False,
     ):
         """Slice a dataset by a plane at the specified origin and normal vector orientation.
 
@@ -1065,9 +1065,9 @@ class DataSetFilters:
         x=None,
         y=None,
         z=None,
-        generate_triangles=False,
-        contour=False,
-        progress_bar=False,
+        generate_triangles: bool = False,
+        contour: bool = False,
+        progress_bar: bool = False,
     ):
         """Create three orthogonal slices through the dataset on the three cartesian planes.
 
@@ -1165,11 +1165,11 @@ class DataSetFilters:
         n=5,
         axis='x',
         tolerance=None,
-        generate_triangles=False,
-        contour=False,
+        generate_triangles: bool = False,
+        contour: bool = False,
         bounds=None,
         center=None,
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Create many slices of the input dataset along a specified axis.
 
@@ -1286,7 +1286,13 @@ class DataSetFilters:
             output.append(slc, f'slice{i}')
         return output
 
-    def slice_along_line(self, line, generate_triangles=False, contour=False, progress_bar=False):
+    def slice_along_line(
+        self,
+        line,
+        generate_triangles: bool = False,
+        contour: bool = False,
+        progress_bar: bool = False,
+    ):
         """Slice a dataset using a polyline/spline as the path.
 
         This also works for lines generated with :func:`pyvista.Line`.
@@ -1366,14 +1372,14 @@ class DataSetFilters:
         self,
         value=None,
         scalars=None,
-        invert=False,
-        continuous=False,
+        invert: bool = False,
+        continuous: bool = False,
         preference='cell',
-        all_scalars=False,
+        all_scalars: bool = False,
         component_mode='all',
         component=0,
         method='upper',
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Apply a ``vtkThreshold`` filter to the input dataset.
 
@@ -1570,11 +1576,11 @@ class DataSetFilters:
         self,
         percent=0.50,
         scalars=None,
-        invert=False,
-        continuous=False,
+        invert: bool = False,
+        continuous: bool = False,
         preference='cell',
         method='upper',
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Threshold the dataset by a percentage of its range on the active scalars array.
 
@@ -1700,7 +1706,7 @@ class DataSetFilters:
             progress_bar=progress_bar,
         )
 
-    def outline(self, generate_faces=False, progress_bar=False):
+    def outline(self, generate_faces: bool = False, progress_bar: bool = False):
         """Produce an outline of the full extent for the input dataset.
 
         Parameters
@@ -1740,7 +1746,7 @@ class DataSetFilters:
         _update_alg(alg, progress_bar, 'Producing an outline')
         return wrap(alg.GetOutputDataObject(0))
 
-    def outline_corners(self, factor=0.2, progress_bar=False):
+    def outline_corners(self, factor=0.2, progress_bar: bool = False):
         """Produce an outline of the corners for the input dataset.
 
         Parameters
@@ -1774,7 +1780,7 @@ class DataSetFilters:
         _update_alg(alg, progress_bar, 'Producing an Outline of the Corners')
         return wrap(alg.GetOutputDataObject(0))
 
-    def extract_geometry(self, extent: Sequence[float] | None = None, progress_bar=False):
+    def extract_geometry(self, extent: Sequence[float] | None = None, progress_bar: bool = False):
         """Extract the outer surface of a volume or structured grid dataset.
 
         This will extract all 0D, 1D, and 2D cells producing the
@@ -1825,7 +1831,9 @@ class DataSetFilters:
         _update_alg(alg, progress_bar, 'Extracting Geometry')
         return _get_output(alg)
 
-    def extract_all_edges(self, use_all_points=False, clear_data=False, progress_bar=False):
+    def extract_all_edges(
+        self, use_all_points: bool = False, clear_data: bool = False, progress_bar: bool = False
+    ):
         """Extract all the internal/external edges of the dataset as PolyData.
 
         This produces a full wireframe representation of the input dataset.
@@ -1896,8 +1904,8 @@ class DataSetFilters:
         high_point=None,
         scalar_range=None,
         preference='point',
-        set_active=True,
-        progress_bar=False,
+        set_active: bool = True,
+        progress_bar: bool = False,
     ):
         """Generate scalar values on a dataset.
 
@@ -2004,13 +2012,13 @@ class DataSetFilters:
         self,
         isosurfaces=10,
         scalars=None,
-        compute_normals=False,
-        compute_gradients=False,
-        compute_scalars=True,
+        compute_normals: bool = False,
+        compute_gradients: bool = False,
+        compute_scalars: bool = True,
         rng=None,
         preference='point',
         method='contour',
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Contour an input self by an array.
 
@@ -2195,10 +2203,10 @@ class DataSetFilters:
         origin=None,
         point_u=None,
         point_v=None,
-        inplace=False,
+        inplace: bool = False,
         name='Texture Coordinates',
-        use_bounds=False,
-        progress_bar=False,
+        use_bounds: bool = False,
+        progress_bar: bool = False,
     ):
         """Texture map this dataset to a user defined plane.
 
@@ -2279,10 +2287,10 @@ class DataSetFilters:
     def texture_map_to_sphere(
         self,
         center=None,
-        prevent_seam=True,
-        inplace=False,
+        prevent_seam: bool = True,
+        inplace: bool = False,
         name='Texture Coordinates',
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Texture map this dataset to a user defined sphere.
 
@@ -2352,11 +2360,11 @@ class DataSetFilters:
 
     def compute_cell_sizes(
         self,
-        length=True,
-        area=True,
-        volume=True,
-        progress_bar=False,
-        vertex_count=False,
+        length: bool = True,
+        area: bool = True,
+        volume: bool = True,
+        progress_bar: bool = False,
+        vertex_count: bool = False,
     ):
         """Compute sizes for 0D (vertex count), 1D (length), 2D (area) and 3D (volume) cells.
 
@@ -2409,7 +2417,7 @@ class DataSetFilters:
         _update_alg(alg, progress_bar, 'Computing Cell Sizes')
         return _get_output(alg)
 
-    def cell_centers(self, vertex=True, progress_bar=False):
+    def cell_centers(self, vertex: bool = True, progress_bar: bool = False):
         """Generate points at the center of the cells in this dataset.
 
         These points can be used for placing glyphs or vectors.
@@ -2456,17 +2464,17 @@ class DataSetFilters:
 
     def glyph(
         self,
-        orient=True,
-        scale=True,
+        orient: bool | str = True,
+        scale: bool | str | Sequence[float] = True,
         factor=1.0,
         geom=None,
         indices=None,
         tolerance=None,
-        absolute=False,
-        clamping=False,
+        absolute: bool = False,
+        clamping: bool = False,
         rng=None,
         color_mode='scale',
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Copy a geometric representation (called a glyph) to the input dataset.
 
@@ -2724,13 +2732,13 @@ class DataSetFilters:
         variable_input=None,
         scalar_range=None,
         scalars=None,
-        label_regions=True,
+        label_regions: bool = True,
         region_ids=None,
         point_ids=None,
         cell_ids=None,
         closest_point=None,
-        inplace=False,
-        progress_bar=False,
+        inplace: bool = False,
+        progress_bar: bool = False,
         **kwargs,
     ):
         """Find and label connected regions.
@@ -3141,7 +3149,7 @@ class DataSetFilters:
                 return self
         return output
 
-    def extract_largest(self, inplace=False, progress_bar=False):
+    def extract_largest(self, inplace: bool = False, progress_bar: bool = False):
         """Extract largest connected set in mesh.
 
         Can be used to reduce residues obtained when generating an
@@ -3185,7 +3193,7 @@ class DataSetFilters:
             progress_bar=progress_bar,
         )
 
-    def split_bodies(self, label=False, progress_bar=False):
+    def split_bodies(self, label: bool = False, progress_bar: bool = False):
         """Find, label, and split connected bodies/volumes.
 
         This splits different connected bodies into blocks in a
@@ -3250,8 +3258,8 @@ class DataSetFilters:
         scalars=None,
         factor=1.0,
         normal=None,
-        inplace=False,
-        progress_bar=False,
+        inplace: bool = False,
+        progress_bar: bool = False,
         **kwargs,
     ):
         """Warp the dataset's points by a point data scalars array's values.
@@ -3336,7 +3344,9 @@ class DataSetFilters:
             return self
         return output
 
-    def warp_by_vector(self, vectors=None, factor=1.0, inplace=False, progress_bar=False):
+    def warp_by_vector(
+        self, vectors=None, factor=1.0, inplace: bool = False, progress_bar: bool = False
+    ):
         """Warp the dataset's points by a point data vectors array's values.
 
         This modifies point coordinates by moving points along point
@@ -3412,7 +3422,7 @@ class DataSetFilters:
         else:
             return warped_mesh
 
-    def cell_data_to_point_data(self, pass_cell_data=False, progress_bar=False):
+    def cell_data_to_point_data(self, pass_cell_data: bool = False, progress_bar: bool = False):
         """Transform cell data into point data.
 
         Point data are specified per node and cell data specified
@@ -3473,7 +3483,7 @@ class DataSetFilters:
             active_scalars = self.active_scalars_name
         return _get_output(alg, active_scalars=active_scalars)
 
-    def ctp(self, pass_cell_data=False, progress_bar=False, **kwargs):
+    def ctp(self, pass_cell_data: bool = False, progress_bar: bool = False, **kwargs):
         """Transform cell data into point data.
 
         Point data are specified per node and cell data specified
@@ -3510,9 +3520,9 @@ class DataSetFilters:
 
     def point_data_to_cell_data(
         self,
-        pass_point_data=False,
-        categorical=False,
-        progress_bar=False,
+        pass_point_data: bool = False,
+        categorical: bool = False,
+        progress_bar: bool = False,
     ):
         """Transform point data into cell data.
 
@@ -3587,7 +3597,7 @@ class DataSetFilters:
             active_scalars = self.active_scalars_name
         return _get_output(alg, active_scalars=active_scalars)
 
-    def ptc(self, pass_point_data=False, progress_bar=False, **kwargs):
+    def ptc(self, pass_point_data: bool = False, progress_bar: bool = False, **kwargs):
         """Transform point data into cell data.
 
         Point data are specified per node and cell data specified
@@ -3622,7 +3632,7 @@ class DataSetFilters:
             **kwargs,
         )
 
-    def triangulate(self, inplace=False, progress_bar=False):
+    def triangulate(self, inplace: bool = False, progress_bar: bool = False):
         """Return an all triangle mesh.
 
         More complex polygons will be broken down into triangles.
@@ -3665,7 +3675,7 @@ class DataSetFilters:
             return self
         return mesh
 
-    def delaunay_3d(self, alpha=0.0, tol=0.001, offset=2.5, progress_bar=False):
+    def delaunay_3d(self, alpha=0.0, tol=0.001, offset=2.5, progress_bar: bool = False):
         """Construct a 3D Delaunay triangulation of the mesh.
 
         This filter can be used to generate a 3D tetrahedral mesh from
@@ -3723,9 +3733,9 @@ class DataSetFilters:
         self,
         surface,
         tolerance=0.001,
-        inside_out=False,
-        check_surface=True,
-        progress_bar=False,
+        inside_out: bool = False,
+        check_surface: bool = True,
+        progress_bar: bool = False,
     ):
         """Mark points as to whether they are inside a closed surface.
 
@@ -3820,14 +3830,14 @@ class DataSetFilters:
         self,
         target,
         tolerance=None,
-        pass_cell_data=True,
-        pass_point_data=True,
-        categorical=False,
-        progress_bar=False,
+        pass_cell_data: bool = True,
+        pass_point_data: bool = True,
+        categorical: bool = False,
+        progress_bar: bool = False,
         locator=None,
-        pass_field_data=True,
-        mark_blank=True,
-        snap_to_closest_point=False,
+        pass_field_data: bool = True,
+        mark_blank: bool = True,
+        snap_to_closest_point: bool = False,
     ):
         """Resample array data from a passed mesh onto this mesh.
 
@@ -3973,9 +3983,9 @@ class DataSetFilters:
         strategy='null_value',
         null_value=0.0,
         n_points=None,
-        pass_cell_data=True,
-        pass_point_data=True,
-        progress_bar=False,
+        pass_cell_data: bool = True,
+        pass_point_data: bool = True,
+        progress_bar: bool = False,
     ):
         """Interpolate values onto this mesh from a given dataset.
 
@@ -4117,10 +4127,10 @@ class DataSetFilters:
         source_radius=None,
         n_points=100,
         start_position=None,
-        return_source=False,
+        return_source: bool = False,
         pointa=None,
         pointb=None,
-        progress_bar=False,
+        progress_bar: bool = False,
         **kwargs,
     ):
         """Integrate a vector field to generate streamlines.
@@ -4231,7 +4241,7 @@ class DataSetFilters:
         vectors=None,
         integrator_type=45,
         integration_direction='both',
-        surface_streamlines=False,
+        surface_streamlines: bool = False,
         initial_step_length=0.5,
         step_unit='cl',
         min_step_length=0.01,
@@ -4240,10 +4250,10 @@ class DataSetFilters:
         terminal_speed=1e-12,
         max_error=1e-6,
         max_time=None,
-        compute_vorticity=True,
+        compute_vorticity: bool = True,
         rotation_scale=1.0,
         interpolator_type='point',
-        progress_bar=False,
+        progress_bar: bool = False,
         max_length=None,
     ):
         """Generate streamlines of vectors from the points of a source mesh.
@@ -4451,8 +4461,8 @@ class DataSetFilters:
         closed_loop_maximum_distance=0.5,
         loop_angle=20,
         minimum_number_of_loop_points=4,
-        compute_vorticity=True,
-        progress_bar=False,
+        compute_vorticity: bool = True,
+        progress_bar: bool = False,
     ):
         """Generate evenly spaced streamlines on a 2D dataset.
 
@@ -4614,7 +4624,7 @@ class DataSetFilters:
         _update_alg(alg, progress_bar, 'Generating Evenly Spaced Streamlines on a 2D Dataset')
         return _get_output(alg)
 
-    def decimate_boundary(self, target_reduction=0.5, progress_bar=False):
+    def decimate_boundary(self, target_reduction=0.5, progress_bar: bool = False):
         """Return a decimated version of a triangulation of the boundary.
 
         Only the outer surface of the input dataset will be considered.
@@ -4646,7 +4656,9 @@ class DataSetFilters:
             .decimate(target_reduction)
         )
 
-    def sample_over_line(self, pointa, pointb, resolution=None, tolerance=None, progress_bar=False):
+    def sample_over_line(
+        self, pointa, pointb, resolution=None, tolerance=None, progress_bar: bool = False
+    ):
         """Sample a dataset onto a line.
 
         Parameters
@@ -4713,11 +4725,11 @@ class DataSetFilters:
         title=None,
         ylabel=None,
         figsize=None,
-        figure=True,
-        show=True,
+        figure: bool = True,
+        show: bool = True,
         tolerance=None,
         fname=None,
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Sample a dataset along a high resolution line and plot.
 
@@ -4812,7 +4824,7 @@ class DataSetFilters:
         if show:  # pragma: no cover
             plt.show()
 
-    def sample_over_multiple_lines(self, points, tolerance=None, progress_bar=False):
+    def sample_over_multiple_lines(self, points, tolerance=None, progress_bar: bool = False):
         """Sample a dataset onto a multiple lines.
 
         Parameters
@@ -4870,7 +4882,7 @@ class DataSetFilters:
         center,
         resolution=None,
         tolerance=None,
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Sample a dataset over a circular arc.
 
@@ -4950,7 +4962,7 @@ class DataSetFilters:
         polar=None,
         angle=None,
         tolerance=None,
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Sample a dataset over a circular arc defined by a normal and polar vector and plot it.
 
@@ -5039,11 +5051,11 @@ class DataSetFilters:
         title=None,
         ylabel=None,
         figsize=None,
-        figure=True,
-        show=True,
+        figure: bool = True,
+        show: bool = True,
         tolerance=None,
         fname=None,
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Sample a dataset along a circular arc and plot it.
 
@@ -5168,11 +5180,11 @@ class DataSetFilters:
         title=None,
         ylabel=None,
         figsize=None,
-        figure=True,
-        show=True,
+        figure: bool = True,
+        show: bool = True,
         tolerance=None,
         fname=None,
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Sample a dataset along a resolution circular arc defined by a normal and polar vector and plot it.
 
@@ -5294,7 +5306,7 @@ class DataSetFilters:
         if show:  # pragma: no cover
             plt.show()
 
-    def extract_cells(self, ind, invert=False, progress_bar=False):
+    def extract_cells(self, ind, invert: bool = False, progress_bar: bool = False):
         """Return a subset of the grid.
 
         Parameters
@@ -5360,7 +5372,13 @@ class DataSetFilters:
 
         return subgrid
 
-    def extract_points(self, ind, adjacent_cells=True, include_cells=True, progress_bar=False):
+    def extract_points(
+        self,
+        ind,
+        adjacent_cells: bool = True,
+        include_cells: bool = True,
+        progress_bar: bool = False,
+    ):
         """Return a subset of the grid (with cells) that contains any of the given point indices.
 
         Parameters
@@ -6129,10 +6147,10 @@ class DataSetFilters:
 
     def extract_surface(
         self,
-        pass_pointid=True,
-        pass_cellid=True,
+        pass_pointid: bool = True,
+        pass_cellid: bool = True,
         nonlinear_subdivision=1,
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Extract surface mesh of the grid.
 
@@ -6226,7 +6244,7 @@ class DataSetFilters:
         _update_alg(surf_filter, progress_bar, 'Extracting Surface')
         return _get_output(surf_filter)
 
-    def surface_indices(self, progress_bar=False):
+    def surface_indices(self, progress_bar: bool = False):
         """Return the surface indices of a grid.
 
         Parameters
@@ -6256,12 +6274,12 @@ class DataSetFilters:
     def extract_feature_edges(
         self,
         feature_angle=30.0,
-        boundary_edges=True,
-        non_manifold_edges=True,
-        feature_edges=True,
-        manifold_edges=True,
-        clear_data=False,
-        progress_bar=False,
+        boundary_edges: bool = True,
+        non_manifold_edges: bool = True,
+        feature_edges: bool = True,
+        manifold_edges: bool = True,
+        clear_data: bool = False,
+        progress_bar: bool = False,
     ):
         """Extract edges from the surface of the mesh.
 
@@ -6337,7 +6355,7 @@ class DataSetFilters:
             output.clear_data()
         return output
 
-    def merge_points(self, tolerance=0.0, inplace=False, progress_bar=False):
+    def merge_points(self, tolerance=0.0, inplace: bool = False, progress_bar: bool = False):
         """Merge duplicate points in this mesh.
 
         .. versionadded:: 0.45
@@ -6389,11 +6407,11 @@ class DataSetFilters:
     def merge(
         self,
         grid=None,
-        merge_points=True,
+        merge_points: bool = True,
         tolerance=0.0,
-        inplace=False,
-        main_has_priority=True,
-        progress_bar=False,
+        inplace: bool = False,
+        main_has_priority: bool = True,
+        progress_bar: bool = False,
     ):
         """Join one or many other grids to this grid.
 
@@ -6509,7 +6527,7 @@ class DataSetFilters:
         self,
         quality_measure='scaled_jacobian',
         null_value=-1.0,
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Compute a function of (geometric) quality for each cell of a mesh.
 
@@ -6642,7 +6660,7 @@ class DataSetFilters:
         _update_alg(alg, progress_bar, 'Computing Cell Quality')
         return _get_output(alg)
 
-    def compute_boundary_mesh_quality(self, *, progress_bar=False):
+    def compute_boundary_mesh_quality(self, *, progress_bar: bool = False):
         """Compute metrics on the boundary faces of a mesh.
 
         The metrics that can be computed on the boundary faces of the mesh and are:
@@ -6698,13 +6716,13 @@ class DataSetFilters:
     def compute_derivative(
         self,
         scalars=None,
-        gradient=True,
+        gradient: bool | str = True,
         divergence=None,
         vorticity=None,
         qcriterion=None,
-        faster=False,
+        faster: bool = False,
         preference='point',
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Compute derivative-based quantities of point/cell scalar field.
 
@@ -6818,7 +6836,7 @@ class DataSetFilters:
         _update_alg(alg, progress_bar, 'Computing Derivative')
         return _get_output(alg)
 
-    def shrink(self, shrink_factor=1.0, progress_bar=False):
+    def shrink(self, shrink_factor=1.0, progress_bar: bool = False):
         """Shrink the individual faces of a mesh.
 
         This filter shrinks the individual faces of a mesh rather than
@@ -6867,7 +6885,7 @@ class DataSetFilters:
             return output.extract_surface()
         return output
 
-    def tessellate(self, max_n_subdivide=3, merge_points=True, progress_bar=False):
+    def tessellate(self, max_n_subdivide=3, merge_points: bool = True, progress_bar: bool = False):
         """Tessellate a mesh.
 
         This filter approximates nonlinear FEM-like elements with linear
@@ -6934,9 +6952,9 @@ class DataSetFilters:
     def transform(  # type: ignore[misc]
         self: _vtk.vtkDataSet,
         trans: TransformLike,
-        transform_all_input_vectors=False,
-        inplace=True,
-        progress_bar=False,
+        transform_all_input_vectors: bool = False,
+        inplace: bool = True,
+        progress_bar: bool = False,
     ):
         """Transform this mesh with a 4x4 transform.
 
@@ -7105,9 +7123,9 @@ class DataSetFilters:
         self,
         normal,
         point=None,
-        inplace=False,
-        transform_all_input_vectors=False,
-        progress_bar=False,
+        inplace: bool = False,
+        transform_all_input_vectors: bool = False,
+        progress_bar: bool = False,
     ):
         """Reflect a dataset across a plane.
 
@@ -7158,7 +7176,7 @@ class DataSetFilters:
             progress_bar=progress_bar,
         )
 
-    def integrate_data(self, progress_bar=False):
+    def integrate_data(self, progress_bar: bool = False):
         """Integrate point and cell data.
 
         Area or volume is also provided in point data.
@@ -7207,7 +7225,7 @@ class DataSetFilters:
         _update_alg(alg, progress_bar, 'Integrating Variables')
         return _get_output(alg)
 
-    def partition(self, n_partitions, generate_global_id=False, as_composite=True):
+    def partition(self, n_partitions, generate_global_id: bool = False, as_composite: bool = True):
         """Break down input dataset into a requested number of partitions.
 
         Cells on boundaries are uniquely assigned to each partition without duplication.
@@ -7794,7 +7812,7 @@ class DataSetFilters:
         """
         return self.shrink(1.0)
 
-    def extract_cells_by_type(self, cell_types, progress_bar=False):
+    def extract_cells_by_type(self, cell_types, progress_bar: bool = False):
         """Extract cells of a specified type.
 
         Given an input dataset and a list of cell types, produce an output
@@ -7872,8 +7890,8 @@ class DataSetFilters:
         scalars=None,
         preference='point',
         output_scalars=None,
-        progress_bar=False,
-        inplace=False,
+        progress_bar: bool = False,
+        inplace: bool = False,
     ):
         """Sort labeled data by number of points or cells.
 
@@ -7959,12 +7977,12 @@ class DataSetFilters:
 
     def pack_labels(
         self,
-        sort=False,
+        sort: bool = False,
         scalars=None,
         preference='point',
         output_scalars=None,
-        progress_bar=False,
-        inplace=False,
+        progress_bar: bool = False,
+        inplace: bool = False,
     ):
         """Renumber labeled data such that labels are contiguous.
 

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -37,7 +37,9 @@ if TYPE_CHECKING:  # pragma: no cover
 class ImageDataFilters(DataSetFilters):
     """An internal class to manage filters/algorithms for uniform grid datasets."""
 
-    def gaussian_smooth(self, radius_factor=1.5, std_dev=2.0, scalars=None, progress_bar=False):
+    def gaussian_smooth(
+        self, radius_factor=1.5, std_dev=2.0, scalars=None, progress_bar: bool = False
+    ):
         """Smooth the data with a Gaussian kernel.
 
         Parameters
@@ -121,7 +123,7 @@ class ImageDataFilters(DataSetFilters):
         kernel_size=(3, 3, 3),
         scalars=None,
         preference='point',
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Smooth data using a median filter.
 
@@ -202,7 +204,9 @@ class ImageDataFilters(DataSetFilters):
         _update_alg(alg, progress_bar, 'Performing Median Smoothing')
         return _get_output(alg)
 
-    def extract_subset(self, voi, rate=(1, 1, 1), boundary=False, progress_bar=False):
+    def extract_subset(
+        self, voi, rate=(1, 1, 1), boundary: bool = False, progress_bar: bool = False
+    ):
         """Select piece (e.g., volume of interest).
 
         To use this filter set the VOI ivar which are i-j-k min/max indices
@@ -267,7 +271,7 @@ class ImageDataFilters(DataSetFilters):
         erode_value=0.0,
         kernel_size=(3, 3, 3),
         scalars=None,
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Dilates one value and erodes another.
 
@@ -358,7 +362,7 @@ class ImageDataFilters(DataSetFilters):
         out_value=0.0,
         scalars=None,
         preference='point',
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Apply a threshold to scalar values in a uniform grid.
 
@@ -478,7 +482,7 @@ class ImageDataFilters(DataSetFilters):
             output[scalars] = output[scalars].astype(array_dtype)
         return output
 
-    def fft(self, output_scalars_name=None, progress_bar=False):
+    def fft(self, output_scalars_name=None, progress_bar: bool = False):
         """Apply a fast Fourier transform (FFT) to the active scalars.
 
         The input can be real or complex data, but the output is always
@@ -559,7 +563,7 @@ class ImageDataFilters(DataSetFilters):
         )
         return output
 
-    def rfft(self, output_scalars_name=None, progress_bar=False):
+    def rfft(self, output_scalars_name=None, progress_bar: bool = False):
         """Apply a reverse fast Fourier transform (RFFT) to the active scalars.
 
         The input can be real or complex data, but the output is always
@@ -638,7 +642,7 @@ class ImageDataFilters(DataSetFilters):
         z_cutoff,
         order=1,
         output_scalars_name=None,
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Perform a Butterworth low pass filter in the frequency domain.
 
@@ -718,7 +722,7 @@ class ImageDataFilters(DataSetFilters):
         z_cutoff,
         order=1,
         output_scalars_name=None,
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Perform a Butterworth high pass filter in the frequency domain.
 
@@ -1475,7 +1479,7 @@ class ImageDataFilters(DataSetFilters):
         | Literal[0, 1, 2, 3, '0D', '1D', '2D', '3D', 'preserve'] = 'preserve',
         scalars: str | None = None,
         pad_all_scalars: bool = False,
-        progress_bar=False,
+        progress_bar: bool = False,
         pad_singleton_dims: bool | None = None,
     ) -> pyvista.ImageData:
         """Enlarge an image by padding its boundaries with new points.

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:  # pragma: no cover
 class PolyDataFilters(DataSetFilters):
     """An internal class to manage filters/algorithms for polydata datasets."""
 
-    def edge_mask(self, angle, progress_bar=False):
+    def edge_mask(self, angle, progress_bar: bool = False):
         """Return a mask of the points of a surface mesh that has a surface angle greater than angle.
 
         Parameters
@@ -86,7 +86,7 @@ class PolyDataFilters(DataSetFilters):
 
         return np.isin(poly_data.point_data['point_ind'], orig_id, assume_unique=True)
 
-    def _boolean(self, btype, other_mesh, tolerance, progress_bar=False):
+    def _boolean(self, btype, other_mesh, tolerance, progress_bar: bool = False):
         """Perform boolean operation."""
         if self.n_points == other_mesh.n_points and np.allclose(self.points, other_mesh.points):  # type: ignore[attr-defined]
             raise ValueError(
@@ -114,7 +114,7 @@ class PolyDataFilters(DataSetFilters):
 
         return _get_output(bfilter)
 
-    def boolean_union(self, other_mesh, tolerance=1e-5, progress_bar=False):
+    def boolean_union(self, other_mesh, tolerance=1e-5, progress_bar: bool = False):
         """Perform a boolean union operation on two meshes.
 
         Essentially, boolean union, difference, and intersection are
@@ -190,7 +190,7 @@ class PolyDataFilters(DataSetFilters):
         """
         return self._boolean('union', other_mesh, tolerance, progress_bar=progress_bar)
 
-    def boolean_intersection(self, other_mesh, tolerance=1e-5, progress_bar=False):
+    def boolean_intersection(self, other_mesh, tolerance=1e-5, progress_bar: bool = False):
         """Perform a boolean intersection operation on two meshes.
 
         Essentially, boolean union, difference, and intersection are
@@ -276,7 +276,7 @@ class PolyDataFilters(DataSetFilters):
                 )
         return bool_inter
 
-    def boolean_difference(self, other_mesh, tolerance=1e-5, progress_bar=False):
+    def boolean_difference(self, other_mesh, tolerance=1e-5, progress_bar: bool = False):
         """Perform a boolean difference operation between two meshes.
 
         Essentially, boolean union, difference, and intersection are
@@ -360,8 +360,8 @@ class PolyDataFilters(DataSetFilters):
     def append_polydata(
         self,
         *meshes,
-        inplace=False,
-        progress_bar=False,
+        inplace: bool = False,
+        progress_bar: bool = False,
     ):
         """Append one or more PolyData into this one.
 
@@ -431,11 +431,11 @@ class PolyDataFilters(DataSetFilters):
     def merge(  # type: ignore[override]
         self,
         dataset,
-        merge_points=True,
+        merge_points: bool = True,
         tolerance=0.0,
-        inplace=False,
-        main_has_priority=True,
-        progress_bar=False,
+        inplace: bool = False,
+        main_has_priority: bool = True,
+        progress_bar: bool = False,
     ):
         """Merge this mesh with one or more datasets.
 
@@ -574,7 +574,9 @@ class PolyDataFilters(DataSetFilters):
 
         return merged
 
-    def intersection(self, mesh, split_first=True, split_second=True, progress_bar=False):
+    def intersection(
+        self, mesh, split_first: bool = True, split_second: bool = True, progress_bar: bool = False
+    ):
         """Compute the intersection between two meshes.
 
         .. note::
@@ -652,7 +654,7 @@ class PolyDataFilters(DataSetFilters):
 
         return intersection, first, second
 
-    def curvature(self, curv_type='mean', progress_bar=False):
+    def curvature(self, curv_type='mean', progress_bar: bool = False):
         """Return the pointwise curvature of a mesh.
 
         See :ref:`connectivity_example` for more examples using this
@@ -752,7 +754,7 @@ class PolyDataFilters(DataSetFilters):
         kwargs.setdefault('scalar_bar_args', {'title': f'{curv_type.capitalize()} Curvature'})
         return self.plot(scalars=self.curvature(curv_type), **kwargs)  # type: ignore[attr-defined]
 
-    def triangulate(self, inplace=False, progress_bar=False):
+    def triangulate(self, inplace: bool = False, progress_bar: bool = False):
         """Return an all triangle mesh.
 
         More complex polygons will be broken down into triangles.
@@ -804,10 +806,10 @@ class PolyDataFilters(DataSetFilters):
         convergence=0.0,
         edge_angle=15,
         feature_angle=45,
-        boundary_smoothing=True,
-        feature_smoothing=False,
-        inplace=False,
-        progress_bar=False,
+        boundary_smoothing: bool = True,
+        feature_smoothing: bool = False,
+        inplace: bool = False,
+        progress_bar: bool = False,
     ):
         """Adjust point coordinates using Laplacian smoothing.
 
@@ -895,12 +897,12 @@ class PolyDataFilters(DataSetFilters):
         pass_band=0.1,
         edge_angle=15.0,
         feature_angle=45.0,
-        boundary_smoothing=True,
-        feature_smoothing=False,
-        non_manifold_smoothing=False,
-        normalize_coordinates=False,
-        inplace=False,
-        progress_bar=False,
+        boundary_smoothing: bool = True,
+        feature_smoothing: bool = False,
+        non_manifold_smoothing: bool = False,
+        normalize_coordinates: bool = False,
+        inplace: bool = False,
+        progress_bar: bool = False,
     ):
         """Smooth a PolyData DataSet with Taubin smoothing.
 
@@ -1018,13 +1020,13 @@ class PolyDataFilters(DataSetFilters):
         reduction,
         feature_angle=45.0,
         split_angle=75.0,
-        splitting=True,
-        pre_split_mesh=False,
-        preserve_topology=False,
-        boundary_vertex_deletion=True,
+        splitting: bool = True,
+        pre_split_mesh: bool = False,
+        preserve_topology: bool = False,
+        boundary_vertex_deletion: bool = True,
         max_degree=None,
-        inplace=False,
-        progress_bar=False,
+        inplace: bool = False,
+        progress_bar: bool = False,
     ):
         """Reduce the number of triangles in a triangular mesh.
 
@@ -1137,13 +1139,13 @@ class PolyDataFilters(DataSetFilters):
         self,
         radius=None,
         scalars=None,
-        capping=True,
+        capping: bool = True,
         n_sides=20,
         radius_factor=10.0,
-        absolute=False,
+        absolute: bool = False,
         preference='point',
-        inplace=False,
-        progress_bar=False,
+        inplace: bool = False,
+        progress_bar: bool = False,
     ):
         """Generate a tube around each input line.
 
@@ -1236,7 +1238,9 @@ class PolyDataFilters(DataSetFilters):
             return poly_data
         return mesh
 
-    def subdivide(self, nsub, subfilter='linear', inplace=False, progress_bar=False):
+    def subdivide(
+        self, nsub, subfilter='linear', inplace: bool = False, progress_bar: bool = False
+    ):
         """Increase the number of triangles in a single, connected triangular mesh.
 
         Uses one of the following vtk subdivision filters to subdivide a mesh:
@@ -1343,8 +1347,8 @@ class PolyDataFilters(DataSetFilters):
         max_tri_area=None,
         max_n_tris=None,
         max_n_passes=None,
-        inplace=False,
-        progress_bar=False,
+        inplace: bool = False,
+        progress_bar: bool = False,
     ):
         """Increase the number of triangles in a triangular mesh based on edge and/or area metrics.
 
@@ -1444,20 +1448,20 @@ class PolyDataFilters(DataSetFilters):
     def decimate(
         self,
         target_reduction,
-        volume_preservation=False,
-        attribute_error=False,
-        scalars=True,
-        vectors=True,
-        normals=False,
-        tcoords=True,
-        tensors=True,
+        volume_preservation: bool = False,
+        attribute_error: bool = False,
+        scalars: bool = True,
+        vectors: bool = True,
+        normals: bool = False,
+        tcoords: bool = True,
+        tensors: bool = True,
         scalars_weight=0.1,
         vectors_weight=0.1,
         normals_weight=0.1,
         tcoords_weight=0.1,
         tensors_weight=0.1,
-        inplace=False,
-        progress_bar=False,
+        inplace: bool = False,
+        progress_bar: bool = False,
     ):
         """Reduce the number of triangles in a triangular mesh using ``vtkQuadricDecimation``.
 
@@ -1581,16 +1585,16 @@ class PolyDataFilters(DataSetFilters):
 
     def compute_normals(
         self,
-        cell_normals=True,
-        point_normals=True,
-        split_vertices=False,
-        flip_normals=False,
-        consistent_normals=True,
-        auto_orient_normals=False,
-        non_manifold_traversal=True,
+        cell_normals: bool = True,
+        point_normals: bool = True,
+        split_vertices: bool = False,
+        flip_normals: bool = False,
+        consistent_normals: bool = True,
+        auto_orient_normals: bool = False,
+        non_manifold_traversal: bool = True,
         feature_angle=30.0,
-        inplace=False,
-        progress_bar=False,
+        inplace: bool = False,
+        progress_bar: bool = False,
     ):
         """Compute point and/or cell normals for a mesh.
 
@@ -1753,8 +1757,8 @@ class PolyDataFilters(DataSetFilters):
         normal='x',
         origin=None,
         tolerance=1e-06,
-        inplace=False,
-        progress_bar=False,
+        inplace: bool = False,
+        progress_bar: bool = False,
     ):
         """Clip a closed polydata surface with a plane.
 
@@ -1848,7 +1852,9 @@ class PolyDataFilters(DataSetFilters):
         else:
             return result
 
-    def fill_holes(self, hole_size, inplace=False, progress_bar=False):  # pragma: no cover
+    def fill_holes(
+        self, hole_size, inplace: bool = False, progress_bar: bool = False
+    ):  # pragma: no cover
         """Fill holes in a pyvista.PolyData or vtk.vtkPolyData object.
 
         Holes are identified by locating boundary edges, linking them
@@ -1905,14 +1911,14 @@ class PolyDataFilters(DataSetFilters):
 
     def clean(
         self,
-        point_merging=True,
+        point_merging: bool = True,
         tolerance=None,
-        lines_to_points=True,
-        polys_to_lines=True,
-        strips_to_polys=True,
-        inplace=False,
-        absolute=True,
-        progress_bar=False,
+        lines_to_points: bool = True,
+        polys_to_lines: bool = True,
+        strips_to_polys: bool = True,
+        inplace: bool = False,
+        absolute: bool = True,
+        progress_bar: bool = False,
         **kwargs,
     ):
         """Clean the mesh.
@@ -2010,10 +2016,10 @@ class PolyDataFilters(DataSetFilters):
         self,
         start_vertex,
         end_vertex,
-        inplace=False,
-        keep_order=True,
-        use_scalar_weights=False,
-        progress_bar=False,
+        inplace: bool = False,
+        keep_order: bool = True,
+        use_scalar_weights: bool = False,
+        progress_bar: bool = False,
     ):
         """Calculate the geodesic path between two vertices using Dijkstra's algorithm.
 
@@ -2108,8 +2114,8 @@ class PolyDataFilters(DataSetFilters):
         self,
         start_vertex,
         end_vertex,
-        use_scalar_weights=False,
-        progress_bar=False,
+        use_scalar_weights: bool = False,
+        progress_bar: bool = False,
     ):
         """Calculate the geodesic distance between two vertices using Dijkstra's algorithm.
 
@@ -2156,7 +2162,9 @@ class PolyDataFilters(DataSetFilters):
         del sizes
         return distance
 
-    def ray_trace(self, origin, end_point, first_point=False, plot=False, off_screen=None):
+    def ray_trace(
+        self, origin, end_point, first_point: bool = False, plot: bool = False, off_screen=None
+    ):
         """Perform a single ray trace calculation.
 
         This requires a mesh and a line segment defined by an origin
@@ -2241,8 +2249,8 @@ class PolyDataFilters(DataSetFilters):
         self,
         origins,
         directions,
-        first_point=False,
-        retry=False,
+        first_point: bool = False,
+        retry: bool = False,
     ):  # pragma: no cover
         """Perform multiple ray trace calculations.
 
@@ -2379,7 +2387,9 @@ class PolyDataFilters(DataSetFilters):
 
         return locations, index_ray, index_tri
 
-    def plot_boundaries(self, edge_color='red', line_width=None, progress_bar=False, **kwargs):
+    def plot_boundaries(
+        self, edge_color='red', line_width=None, progress_bar: bool = False, **kwargs
+    ):
         """Plot boundaries of a mesh.
 
         Parameters
@@ -2429,11 +2439,11 @@ class PolyDataFilters(DataSetFilters):
 
     def plot_normals(
         self,
-        show_mesh=True,
+        show_mesh: bool = True,
         mag=1.0,
-        flip=False,
+        flip: bool = False,
         use_every=1,
-        faces=False,
+        faces: bool = False,
         color=None,
         **kwargs,
     ):
@@ -2516,7 +2526,7 @@ class PolyDataFilters(DataSetFilters):
 
         return plotter.show()
 
-    def remove_points(self, remove, mode='any', keep_scalars=True, inplace=False):
+    def remove_points(self, remove, mode='any', keep_scalars: bool = True, inplace: bool = False):
         """Rebuild a mesh by removing points.
 
         Only valid for all-triangle meshes.
@@ -2636,10 +2646,10 @@ class PolyDataFilters(DataSetFilters):
         tol=1e-05,
         alpha=0.0,
         offset=1.0,
-        bound=False,
-        inplace=False,
+        bound: bool = False,
+        inplace: bool = False,
         edge_source=None,
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Apply a 2D Delaunay filter along the best fitting plane.
 
@@ -2739,7 +2749,7 @@ class PolyDataFilters(DataSetFilters):
             return self
         return mesh
 
-    def compute_arc_length(self, progress_bar=False):
+    def compute_arc_length(self, progress_bar: bool = False):
         """Compute the arc length over the length of the probed line.
 
         It adds a new point-data array named ``"arc_length"`` with the
@@ -2782,7 +2792,7 @@ class PolyDataFilters(DataSetFilters):
         _update_alg(alg, progress_bar, 'Computing the Arc Length')
         return _get_output(alg)
 
-    def project_points_to_plane(self, origin=None, normal=(0.0, 0.0, 1.0), inplace=False):
+    def project_points_to_plane(self, origin=None, normal=(0.0, 0.0, 1.0), inplace: bool = False):
         """Project points of this mesh to a plane.
 
         Parameters
@@ -2834,9 +2844,9 @@ class PolyDataFilters(DataSetFilters):
         angle=0.0,
         factor=2.0,
         normal=None,
-        tcoords=False,
+        tcoords: bool = False,
         preference='points',
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Create a ribbon of the lines in this dataset.
 
@@ -2940,7 +2950,7 @@ class PolyDataFilters(DataSetFilters):
         _update_alg(alg, progress_bar, 'Creating a Ribbon')
         return _get_output(alg)
 
-    def extrude(self, vector, capping=None, inplace=False, progress_bar=False):
+    def extrude(self, vector, capping=None, inplace: bool = False, progress_bar: bool = False):
         """Sweep polygonal data creating a "skirt" from free edges.
 
         This will create a line from vertices.
@@ -3032,13 +3042,13 @@ class PolyDataFilters(DataSetFilters):
     def extrude_rotate(
         self,
         resolution=30,
-        inplace=False,
+        inplace: bool = False,
         translation=0.0,
         dradius=0.0,
         angle=360.0,
         capping=None,
         rotation_axis=(0, 0, 1),
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Sweep polygonal data creating "skirt" from free edges and lines, and lines from vertices.
 
@@ -3198,8 +3208,8 @@ class PolyDataFilters(DataSetFilters):
         trim_surface,
         extrusion='boundary_edges',
         capping='intersection',
-        inplace=False,
-        progress_bar=False,
+        inplace: bool = False,
+        progress_bar: bool = False,
     ):
         """Extrude polygonal data trimmed by a surface.
 
@@ -3298,12 +3308,12 @@ class PolyDataFilters(DataSetFilters):
 
     def strip(
         self,
-        join=False,
+        join: bool = False,
         max_length=1000,
-        pass_cell_data=False,
-        pass_cell_ids=False,
-        pass_point_ids=False,
-        progress_bar=False,
+        pass_cell_data: bool = False,
+        pass_cell_ids: bool = False,
+        pass_point_ids: bool = False,
+        progress_bar: bool = False,
     ):
         """Strip poly data cells.
 
@@ -3390,8 +3400,8 @@ class PolyDataFilters(DataSetFilters):
         box_tolerance=0.001,
         cell_tolerance=0.0,
         n_cells_per_node=2,
-        generate_scalars=False,
-        progress_bar=False,
+        generate_scalars: bool = False,
+        progress_bar: bool = False,
     ):
         """Perform collision determination between two polyhedral surfaces.
 
@@ -3559,10 +3569,10 @@ class PolyDataFilters(DataSetFilters):
         scalars=None,
         component=0,
         clip_tolerance=1e-6,
-        generate_contour_edges=True,
+        generate_contour_edges: bool = True,
         scalar_mode='value',
-        clipping=True,
-        progress_bar=False,
+        clipping: bool = True,
+        progress_bar: bool = False,
     ):
         """Generate filled contours.
 
@@ -3723,7 +3733,7 @@ class PolyDataFilters(DataSetFilters):
             return mesh, wrap(alg.GetContourEdgesOutput())
         return mesh
 
-    def reconstruct_surface(self, nbr_sz=None, sample_spacing=None, progress_bar=False):
+    def reconstruct_surface(self, nbr_sz=None, sample_spacing=None, progress_bar: bool = False):
         """Reconstruct a surface from the points in this dataset.
 
         This filter takes a list of points assumed to lie on the
@@ -3800,7 +3810,7 @@ class PolyDataFilters(DataSetFilters):
         _update_alg(mc, progress_bar, 'Reconstructing surface')
         return wrap(mc.GetOutput())
 
-    def triangulate_contours(self, display_errors=False, progress_bar=False):
+    def triangulate_contours(self, display_errors: bool = False, progress_bar: bool = False):
         """Triangulate and fill all 2D contours to create polygons.
 
         .. versionadded:: 0.44.0
@@ -3870,7 +3880,7 @@ class PolyDataFilters(DataSetFilters):
         _update_alg(alg, progress_bar, 'Triangulating Contours')
         return _get_output(alg)
 
-    def protein_ribbon(self, progress_bar=False):
+    def protein_ribbon(self, progress_bar: bool = False):
         """Generate protein ribbon.
 
         Parameters

--- a/pyvista/core/filters/structured_grid.py
+++ b/pyvista/core/filters/structured_grid.py
@@ -15,7 +15,7 @@ from pyvista.core.utilities.misc import abstract_class
 class StructuredGridFilters(DataSetFilters):
     """An internal class to manage filters/algorithms for structured grid datasets."""
 
-    def extract_subset(self, voi, rate=(1, 1, 1), boundary=False):
+    def extract_subset(self, voi, rate=(1, 1, 1), boundary: bool = False):
         """Select piece (e.g., volume of interest).
 
         To use this filter set the VOI ivar which are i-j-k min/max

--- a/pyvista/core/filters/unstructured_grid.py
+++ b/pyvista/core/filters/unstructured_grid.py
@@ -57,11 +57,11 @@ class UnstructuredGridFilters(DataSetFilters):
     def clean(
         self,
         tolerance=0,
-        remove_unused_points=True,
-        produce_merge_map=True,
-        average_point_data=True,
+        remove_unused_points: bool = True,
+        produce_merge_map: bool = True,
+        average_point_data: bool = True,
         merging_array_name=None,
-        progress_bar=False,
+        progress_bar: bool = False,
     ):
         """Merge duplicate points and remove unused points in an UnstructuredGrid.
 

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -171,8 +171,8 @@ class RectilinearGrid(Grid, RectilinearGridFilters, _vtk.vtkRectilinearGrid):
     def __init__(
         self,
         *args,
-        check_duplicates=False,
-        deep=False,
+        check_duplicates: bool = False,
+        deep: bool = False,
         **kwargs,
     ):  # numpydoc ignore=PR01,RT01
         """Initialize the rectilinear grid."""
@@ -583,7 +583,7 @@ class ImageData(Grid, ImageDataFilters, _vtk.vtkImageData):
         dimensions=None,
         spacing=(1.0, 1.0, 1.0),
         origin=(0.0, 0.0, 0.0),
-        deep=False,
+        deep: bool = False,
     ):
         """Initialize the uniform grid."""
         super().__init__()

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -33,7 +33,7 @@ class Table(DataObject, _vtk.vtkTable):
 
     """
 
-    def __init__(self, *args, deep=True, **kwargs):
+    def __init__(self, *args, deep: bool = True, **kwargs):
         """Initialize the table."""
         super().__init__()
         if len(args) == 1:

--- a/pyvista/core/partitioned.py
+++ b/pyvista/core/partitioned.py
@@ -179,7 +179,7 @@ class PartitionedDataSet(_vtk.vtkPartitionedDataSet, DataObject, MutableSequence
     def copy_meta_from(self, ido, deep):  # numpydoc ignore=PR01
         """Copy pyvista meta data onto this object from another object."""
 
-    def copy(self, deep=True):
+    def copy(self, deep: bool = True):
         """Return a copy of the PartitionedDataSet.
 
         Parameters

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -115,7 +115,7 @@ class _PointSet(DataSet):
     def remove_cells(
         self,
         ind: VectorLike[bool] | VectorLike[int],
-        inplace=False,
+        inplace: bool = False,
     ) -> _PointSet:
         """Remove cells.
 
@@ -190,7 +190,9 @@ class _PointSet(DataSet):
         return self
 
     # todo: `transform_all_input_vectors` is not handled when modifying inplace
-    def translate(self, xyz: VectorLike[float], transform_all_input_vectors=False, inplace=None):
+    def translate(
+        self, xyz: VectorLike[float], transform_all_input_vectors: bool = False, inplace=None
+    ):
         """Translate the mesh.
 
         Parameters
@@ -302,7 +304,7 @@ class PointSet(_PointSet, _vtk.vtkPointSet):
             raise VTKVersionError('pyvista.PointSet requires VTK >= 9.1.0')
         return super().__new__(cls, *args, **kwargs)
 
-    def __init__(self, var_inp=None, deep=False, force_float=True):
+    def __init__(self, var_inp=None, deep: bool = False, force_float: bool = True):
         """Initialize the pointset."""
         super().__init__()
 
@@ -324,7 +326,7 @@ class PointSet(_PointSet, _vtk.vtkPointSet):
         """Return the standard str representation."""
         return DataSet.__str__(self)
 
-    def cast_to_polydata(self, deep=True):
+    def cast_to_polydata(self, deep: bool = True):
         """Cast this dataset to polydata.
 
         Parameters
@@ -1068,7 +1070,9 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
         self.faces = CellArray.from_regular_cells(faces)  # type: ignore[assignment]
 
     @classmethod
-    def from_regular_faces(cls, points: MatrixLike[float], faces: MatrixLike[int], deep=False):
+    def from_regular_faces(
+        cls, points: MatrixLike[float], faces: MatrixLike[int], deep: bool = False
+    ):
         """Alternate `pyvista.PolyData` convenience constructor from point and regular face arrays.
 
         Parameters
@@ -1414,7 +1418,7 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
         """
         return self.GetNumberOfPolys()
 
-    def save(self, filename, binary=True, texture=None, recompute_normals=True):
+    def save(self, filename, binary: bool = True, texture=None, recompute_normals: bool = True):
         """Write a surface mesh to disk.
 
         Written file may be an ASCII or binary ply, stl, or vtk mesh
@@ -1813,7 +1817,7 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
         '.vtk': _vtk.vtkUnstructuredGridWriter,
     }
 
-    def __init__(self, *args, deep=False, **kwargs) -> None:
+    def __init__(self, *args, deep: bool = False, **kwargs) -> None:
         """Initialize the unstructured grid."""
         super().__init__()
 
@@ -1868,7 +1872,7 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
         """Return the standard str representation."""
         return DataSet.__str__(self)
 
-    def _from_cells_dict(self, cells_dict, points, deep=True):
+    def _from_cells_dict(self, cells_dict, points, deep: bool = True):
         if points.ndim != 2 or points.shape[-1] != 3:
             raise ValueError('Points array must be a [M, 3] array')
 
@@ -1881,8 +1885,8 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
         cells,
         cell_type,
         points,
-        deep=True,
-        force_float=True,
+        deep: bool = True,
+        force_float: bool = True,
     ):
         """Create VTK unstructured grid from numpy arrays.
 
@@ -2122,7 +2126,7 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
         carr = self.GetCells()
         return _vtk.vtk_to_numpy(carr.GetConnectivityArray())
 
-    def linear_copy(self, deep=False):
+    def linear_copy(self, deep: bool = False):
         """Return a copy of the unstructured grid containing only linear cells.
 
         Converts the following cell types to their linear equivalents.
@@ -2385,7 +2389,7 @@ class StructuredGrid(PointGrid, StructuredGridFilters, _vtk.vtkStructuredGrid):
         dict[str, type[_vtk.vtkStructuredGridWriter | _vtk.vtkXMLStructuredGridWriter]]
     ] = {'.vtk': _vtk.vtkStructuredGridWriter, '.vts': _vtk.vtkXMLStructuredGridWriter}  # type: ignore[assignment]
 
-    def __init__(self, uinput=None, y=None, z=None, *args, deep=False, **kwargs) -> None:
+    def __init__(self, uinput=None, y=None, z=None, *args, deep: bool = False, **kwargs) -> None:
         """Initialize the structured grid."""
         super().__init__()
 
@@ -2428,7 +2432,7 @@ class StructuredGrid(PointGrid, StructuredGridFilters, _vtk.vtkStructuredGrid):
         """Return the standard str representation."""
         return DataSet.__str__(self)
 
-    def _from_arrays(self, x, y, z, force_float=True):
+    def _from_arrays(self, x, y, z, force_float: bool = True):
         """Create VTK structured grid directly from numpy arrays.
 
         Parameters
@@ -2593,7 +2597,7 @@ class StructuredGrid(PointGrid, StructuredGridFilters, _vtk.vtkStructuredGrid):
 
         return self.extract_subset(voi, rate, boundary=False)
 
-    def hide_cells(self, ind, inplace=False):
+    def hide_cells(self, ind, inplace: bool = False):
         """Hide cells without deleting them.
 
         Hides cells by setting the ghost_cells array to ``HIDDEN_CELL``.
@@ -2982,11 +2986,11 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
     def clean(
         self,
         tolerance=0,
-        remove_unused_points=True,
-        produce_merge_map=True,
-        average_point_data=True,
+        remove_unused_points: bool = True,
+        produce_merge_map: bool = True,
+        average_point_data: bool = True,
         merging_array_name=None,
-        progress_bar=False,
+        progress_bar: bool = False,
     ) -> ExplicitStructuredGrid:
         """Merge duplicate points and remove unused points in an ExplicitStructuredGrid.
 
@@ -3551,7 +3555,7 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
             grid.compute_connectivity(inplace=True)
             return grid
 
-    def compute_connections(self, inplace=False):
+    def compute_connections(self, inplace: bool = False):
         """Compute an array with the number of connected cell faces.
 
         This method calculates the number of topological cell

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -762,7 +762,7 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
         n_strips: int | None = None,
         deep: bool = False,
         force_ext: str | None = None,
-        force_float: bool | None = True,
+        force_float: bool = True,
         verts: CellArrayLike | None = None,
         n_verts: int | None = None,
     ) -> None:

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -111,7 +111,7 @@ class pyvista_ndarray(np.ndarray):  # type: ignore[type-arg]  # numpydoc ignore=
         if dataset is not None and dataset.Get():
             dataset.Get().Modified()
 
-    def __array_wrap__(self, out_arr, context=None, return_scalar=False):
+    def __array_wrap__(self, out_arr, context=None, return_scalar: bool = False):
         """Return a numpy scalar if array is 0d.
 
         See https://github.com/numpy/numpy/issues/5819

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -114,7 +114,7 @@ def _coerce_pointslike_arg(
     return points, singular
 
 
-def copy_vtk_array(array, deep=True):
+def copy_vtk_array(array, deep: bool = True):
     """Create a deep or shallow copy of a VTK array.
 
     Parameters
@@ -193,7 +193,7 @@ def raise_has_duplicates(arr):
         raise ValueError('Array contains duplicate values.')
 
 
-def convert_array(arr, name=None, deep=False, array_type=None):
+def convert_array(arr, name=None, deep: bool = False, array_type=None):
     """Convert a NumPy array to a vtkDataArray or vice versa.
 
     Parameters
@@ -249,7 +249,7 @@ def convert_array(arr, name=None, deep=False, array_type=None):
     return _vtk.vtk_to_numpy(arr)
 
 
-def get_array(mesh, name, preference='cell', err=False) -> pyvista.ndarray | None:
+def get_array(mesh, name, preference='cell', err: bool = False) -> pyvista.ndarray | None:
     """Search point, cell and field data for an array.
 
     Parameters
@@ -312,7 +312,7 @@ def get_array(mesh, name, preference='cell', err=False) -> pyvista.ndarray | Non
     return None
 
 
-def get_array_association(mesh, name, preference='cell', err=False) -> FieldAssociation:
+def get_array_association(mesh, name, preference='cell', err: bool = False) -> FieldAssociation:
     """Return the array association.
 
     Parameters

--- a/pyvista/core/utilities/features.py
+++ b/pyvista/core/utilities/features.py
@@ -45,7 +45,9 @@ def _padded_bins(mesh, density):
     ]
 
 
-def voxelize(mesh, density=None, check_surface=True, enclosed=False, fit_bounds=False):
+def voxelize(
+    mesh, density=None, check_surface: bool = True, enclosed: bool = False, fit_bounds: bool = False
+):
     """Voxelize mesh to UnstructuredGrid.
 
     Parameters
@@ -214,7 +216,9 @@ def voxelize(mesh, density=None, check_surface=True, enclosed=False, fit_bounds=
     return ugrid.extract_points(mask)
 
 
-def voxelize_volume(mesh, density=None, check_surface=True, enclosed=False, fit_bounds=False):
+def voxelize_volume(
+    mesh, density=None, check_surface: bool = True, enclosed: bool = False, fit_bounds: bool = False
+):
     """Voxelize mesh to create a RectilinearGrid voxel volume.
 
     Creates a voxel volume that encloses the input mesh and discretizes the cells
@@ -562,9 +566,9 @@ def spherical_to_cartesian(r, phi, theta):
 
 def merge(
     datasets,
-    merge_points=True,
-    main_has_priority=True,
-    progress_bar=False,
+    merge_points: bool = True,
+    main_has_priority: bool = True,
+    progress_bar: bool = False,
 ):
     """Merge several datasets.
 

--- a/pyvista/core/utilities/fileio.py
+++ b/pyvista/core/utilities/fileio.py
@@ -92,7 +92,7 @@ def get_ext(filename):
     return ext
 
 
-def set_vtkwriter_mode(vtk_writer, use_binary=True):
+def set_vtkwriter_mode(vtk_writer, use_binary: bool = True):
     """Set any vtk writer to write as binary or ascii.
 
     Parameters
@@ -126,7 +126,7 @@ def set_vtkwriter_mode(vtk_writer, use_binary=True):
     return vtk_writer
 
 
-def read(filename, force_ext=None, file_format=None, progress_bar=False):
+def read(filename, force_ext=None, file_format=None, progress_bar: bool = False):
     """Read any file type supported by ``vtk`` or ``meshio``.
 
     Automatically determines the correct reader to use then wraps the
@@ -261,7 +261,7 @@ def _apply_attrs_to_reader(reader, attrs):
             attr()
 
 
-def read_texture(filename, progress_bar=False):
+def read_texture(filename, progress_bar: bool = False):
     """Load a texture from an image file.
 
     Will attempt to read any file type supported by ``vtk``, however
@@ -311,11 +311,11 @@ def read_texture(filename, progress_bar=False):
 
 def read_exodus(
     filename,
-    animate_mode_shapes=True,
-    apply_displacements=True,
+    animate_mode_shapes: bool = True,
+    apply_displacements: bool = True,
     displacement_magnitude=1.0,
-    read_point_data=True,
-    read_cell_data=True,
+    read_point_data: bool = True,
+    read_cell_data: bool = True,
     enabled_sidesets=None,
 ):
     """Read an ExodusII file (``'.e'`` or ``'.exo'``).
@@ -402,7 +402,7 @@ def read_exodus(
     return wrap(reader.GetOutput())
 
 
-def read_grdecl(filename, elevation=True, other_keywords=None):
+def read_grdecl(filename, elevation: bool = True, other_keywords=None):
     """Read a GRDECL file (``'.GRDECL'``).
 
     Parameters
@@ -448,7 +448,7 @@ def read_grdecl(filename, elevation=True, other_keywords=None):
         'ZONES',
     )
 
-    def read_keyword(f, split=True, converter=None):
+    def read_keyword(f, split: bool = True, converter=None):
         """Read a keyword.
 
         Parameters

--- a/pyvista/core/utilities/geometric_objects.py
+++ b/pyvista/core/utilities/geometric_objects.py
@@ -149,7 +149,7 @@ def Cylinder(
     radius=0.5,
     height=1.0,
     resolution=100,
-    capping=True,
+    capping: bool = True,
 ):
     """Create the surface of a cylinder.
 
@@ -508,7 +508,7 @@ def SolidSphere(
     phi_resolution=30,
     center=(0.0, 0.0, 0.0),
     direction=(0.0, 0.0, 1.0),
-    radians=False,
+    radians: bool = False,
     tol_radius=1.0e-8,
     tol_angle=None,
 ):
@@ -663,7 +663,7 @@ def SolidSphereGeneric(
     phi=None,
     center=(0.0, 0.0, 0.0),
     direction=(0.0, 0.0, 1.0),
-    radians=False,
+    radians: bool = False,
     tol_radius=1.0e-8,
     tol_angle=None,
 ):
@@ -1181,7 +1181,7 @@ def Cube(
     y_length=1.0,
     z_length=1.0,
     bounds=None,
-    clean=True,
+    clean: bool = True,
     point_dtype='float32',
 ):
     """Create a cube.
@@ -1265,7 +1265,7 @@ def Cube(
     return cube
 
 
-def Box(bounds=(-1.0, 1.0, -1.0, 1.0, -1.0, 1.0), level=0, quads=True):
+def Box(bounds=(-1.0, 1.0, -1.0, 1.0, -1.0, 1.0), level=0, quads: bool = True):
     """Create a box with solid faces for the given bounds.
 
     Parameters
@@ -1303,7 +1303,7 @@ def Cone(
     direction=(1.0, 0.0, 0.0),
     height=1.0,
     radius=None,
-    capping=True,
+    capping: bool = True,
     angle=None,
     resolution=6,
 ):
@@ -1362,7 +1362,9 @@ def Cone(
     return algo.output
 
 
-def Polygon(center=(0.0, 0.0, 0.0), radius=1.0, normal=(0.0, 0.0, 1.0), n_sides=6, fill=True):
+def Polygon(
+    center=(0.0, 0.0, 0.0), radius=1.0, normal=(0.0, 0.0, 1.0), n_sides=6, fill: bool = True
+):
     """Create a polygon.
 
     Parameters
@@ -1623,7 +1625,7 @@ def Wavelet(
     return wrap(wavelet_source.GetOutput())
 
 
-def CircularArc(pointa, pointb, center, resolution=100, negative=False):
+def CircularArc(pointa, pointb, center, resolution=100, negative: bool = False):
     """Create a circular arc defined by two endpoints and a center.
 
     The number of segments composing the polyline is controlled by
@@ -2073,7 +2075,7 @@ def Superquadric(
     phi_roundness=1.0,
     theta_resolution=16,
     phi_resolution=16,
-    toroidal=False,
+    toroidal: bool = False,
     thickness=1 / 3,
 ):
     """Create a superquadric.

--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -349,7 +349,7 @@ class ConeSource(_vtk.vtkConeSource):
         direction=(1.0, 0.0, 0.0),
         height=1.0,
         radius=None,
-        capping=True,
+        capping: bool = True,
         angle=None,
         resolution=6,
     ):
@@ -626,7 +626,7 @@ class CylinderSource(_vtk.vtkCylinderSource):
         direction=(1.0, 0.0, 0.0),
         radius=0.5,
         height=1.0,
-        capping=True,
+        capping: bool = True,
         resolution=100,
     ):
         """Initialize the cylinder source class."""
@@ -949,7 +949,7 @@ class Text3DSource(vtkVectorText):
         height=None,
         center=(0.0, 0.0, 0.0),
         normal=(0.0, 0.0, 1.0),
-        process_empty_string=True,
+        process_empty_string: bool = True,
     ):
         """Initialize source."""
         super().__init__()
@@ -2060,7 +2060,7 @@ class PolygonSource(_vtk.vtkRegularPolygonSource):
         radius=1.0,
         normal=(0.0, 0.0, 1.0),
         n_sides=6,
-        fill=True,
+        fill: bool = True,
     ):
         """Initialize the polygon source class."""
         super().__init__()
@@ -2739,7 +2739,7 @@ class BoxSource(_vtk.vtkTessellatedBoxSource):
         '_bounds',
     ]
 
-    def __init__(self, bounds=(-1.0, 1.0, -1.0, 1.0, -1.0, 1.0), level=0, quads=True):
+    def __init__(self, bounds=(-1.0, 1.0, -1.0, 1.0, -1.0, 1.0), level=0, quads: bool = True):
         """Initialize source."""
         super().__init__()
         self.bounds = bounds
@@ -2875,7 +2875,7 @@ class SuperquadricSource(_vtk.vtkSuperquadricSource):
         phi_roundness=1.0,
         theta_resolution=16,
         phi_resolution=16,
-        toroidal=False,
+        toroidal: bool = False,
         thickness=1 / 3,
     ):
         """Initialize source."""

--- a/pyvista/core/utilities/helpers.py
+++ b/pyvista/core/utilities/helpers.py
@@ -213,7 +213,7 @@ def generate_plane(normal, origin):
     return plane
 
 
-def axis_rotation(points, angle, inplace=False, deg=True, axis='z'):
+def axis_rotation(points, angle, inplace: bool = False, deg: bool = True, axis='z'):
     """Rotate points by angle about an axis.
 
     Parameters

--- a/pyvista/core/utilities/observers.py
+++ b/pyvista/core/utilities/observers.py
@@ -65,7 +65,7 @@ class VtkErrorCatcher:
 
     """
 
-    def __init__(self, raise_errors=False, send_to_logging=True):
+    def __init__(self, raise_errors: bool = False, send_to_logging: bool = True):
         """Initialize context manager."""
         self.raise_errors = raise_errors
         self.send_to_logging = send_to_logging
@@ -102,7 +102,7 @@ class VtkEvent(NamedTuple):
 class Observer:
     """A standard class for observing VTK objects."""
 
-    def __init__(self, event_type='ErrorEvent', log=True, store_history=False):
+    def __init__(self, event_type='ErrorEvent', log: bool = True, store_history: bool = False):
         """Initialize observer."""
         self.__event_occurred = False
         self.__message = None
@@ -113,7 +113,7 @@ class Observer:
         self.__log = log
 
         self.store_history = store_history
-        self.event_history = []
+        self.event_history: list[VtkEvent] = []
 
     @staticmethod
     def parse_message(message):  # numpydoc ignore=RT01
@@ -173,7 +173,7 @@ class Observer:
         self.__event_occurred = False
         return occ
 
-    def get_message(self, etc=False):
+    def get_message(self, etc: bool = False):
         """Get the last set error message.
 
         Returns

--- a/pyvista/core/utilities/parametric_objects.py
+++ b/pyvista/core/utilities/parametric_objects.py
@@ -1332,11 +1332,11 @@ def parametric_keywords(
     max_u=2 * pi,
     min_v=0.0,
     max_v=2 * pi,
-    join_u=False,
-    join_v=False,
-    twist_u=False,
-    twist_v=False,
-    clockwise=True,
+    join_u: bool = False,
+    join_v: bool = False,
+    twist_u: bool = False,
+    twist_v: bool = False,
+    clockwise: bool = True,
 ):
     """Apply keyword arguments to a parametric function.
 
@@ -1394,8 +1394,8 @@ def surface_from_para(
     u_res=100,
     v_res=100,
     w_res=100,
-    clean=False,
-    texture_coordinates=False,
+    clean: bool = False,
+    texture_coordinates: bool = False,
 ):
     """Construct a mesh from a parametric function.
 

--- a/pyvista/core/utilities/points.py
+++ b/pyvista/core/utilities/points.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from pyvista.core._typing_core import VectorLike
 
 
-def vtk_points(points, deep=True, force_float=False):
+def vtk_points(points, deep: bool = True, force_float: bool | None = False):
     """Convert numpy array or array-like to a ``vtkPoints`` object.
 
     Parameters
@@ -148,7 +148,7 @@ def line_segments_from_points(points):
     return poly
 
 
-def lines_from_points(points, close=False):
+def lines_from_points(points, close: bool = False):
     """Make a connected line set given an array of points.
 
     Parameters
@@ -186,7 +186,7 @@ def lines_from_points(points, close=False):
     return poly
 
 
-def fit_plane_to_points(points, return_meta=False, resolution=10, init_normal=None):
+def fit_plane_to_points(points, return_meta: bool = False, resolution=10, init_normal=None):
     """Fit a plane to points using its :func:`principal_axes`.
 
     The plane is automatically sized and oriented to fit the extents of

--- a/pyvista/core/utilities/points.py
+++ b/pyvista/core/utilities/points.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from pyvista.core._typing_core import VectorLike
 
 
-def vtk_points(points, deep: bool = True, force_float: bool | None = False):
+def vtk_points(points, deep: bool = True, force_float: bool = False):
     """Convert numpy array or array-like to a ``vtkPoints`` object.
 
     Parameters

--- a/pyvista/core/utilities/transformations.py
+++ b/pyvista/core/utilities/transformations.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from pyvista.core._typing_core import TransformLike
 
 
-def axis_angle_rotation(axis, angle, point=None, deg=True):
+def axis_angle_rotation(axis, angle, point=None, deg: bool = True):
     r"""Return a 4x4 matrix for rotation about any axis by given angle.
 
     Rotations around an axis that contains the origin can easily be
@@ -247,7 +247,7 @@ def reflection(normal, point=None):
     return augmented
 
 
-def apply_transformation_to_points(transformation, points, inplace=False):
+def apply_transformation_to_points(transformation, points, inplace: bool = False):
     """Apply a given transformation matrix (3x3 or 4x4) to a set of points.
 
     Parameters


### PR DESCRIPTION
### Overview

I ran `python -m autotyping --bool-param pyvista/core` to add `bool` annotations then resolved 9 type errors that were reported:


<details>

``` python

pyvista/core/utilities/observers.py: note: In member "__init__" of class "Observer":
pyvista/core/utilities/observers.py:116: error: Need type annotation for "event_history" (hint: "event_history: list[<type>] = ...")  [var-annotated]
            self.event_history = []
            ^~~~~~~~~~~~~~~~~~
pyvista/core/filters/data_set.py:2608: error: Unused "type: ignore" comment  [unused-ignore]
                dataset.set_active_scalars(scale, preference='cell')  # type: ignore[attr-defined]
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pyvista/core/filters/data_set.py:2630: error: Unused "type: ignore" comment  [unused-ignore]
                if scale and dataset.active_scalars_info.association == FieldAssociation.CELL:  # type: ignore[attr-defined]
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pyvista/core/filters/data_set.py:2634: error: Unused "type: ignore" comment  [unused-ignore]
                dataset.set_active_vectors(orient, preference=prefer)  # type: ignore[attr-defined]
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pyvista/core/filters/data_set.py: note: In member "compute_derivative" of class "DataSetFilters":
pyvista/core/filters/data_set.py:6795: error: Incompatible types in assignment (expression has type "str", variable has type "bool")  [assignment]
                gradient = 'gradient'
                           ^~~~~~~~~~
pyvista/core/filters/data_set.py:6796: error: Argument 1 to "SetResultArrayName" of "vtkGradientFilter" has incompatible type "bool"; expected "str"  [arg-type]
            alg.SetResultArrayName(gradient)
                                   ^~~~~~~~
pyvista/core/dataset.py: note: In member "arrows" of class "DataSet":
pyvista/core/dataset.py:579: error: Argument "orient" to "glyph" of "DataSetFilters" has incompatible type "str"; expected "bool"  [arg-type]
            return self.glyph(orient=vectors_name, scale=scale_name)
                                     ^~~~~~~~~~~~
pyvista/core/dataset.py:579: error: Argument "scale" to "glyph" of "DataSetFilters" has incompatible type "str"; expected "bool"  [arg-type]
            return self.glyph(orient=vectors_name, scale=scale_name)
                                                         ^~~~~~~~~~
pyvista/core/pointset.py: note: In member "__init__" of class "PolyData":
pyvista/core/pointset.py:802: error: Argument "force_float" to "vtk_points" has incompatible type "bool | None"; expected "bool"  [arg-type]
                self.SetPoints(vtk_points(var_inp, deep=deep, force_float=force_float))
                                                                          ^~~~~~~~~~~
Found 9 errors in 4 files (checked 143 source files)
```