### PR TITLE
Add `autotyping` to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,3 +95,9 @@ repos:
       - id: taplo-format
         # See options: https://taplo.tamasfe.dev/configuration/formatter-options.html
         args: [--option, "reorder_arrays=true", --option, "reorder_keys=true"]
+
+  - repo: https://github.com/JelleZijlstra/autotyping
+    rev: 24.9.0
+    hooks:
+      - id: autotyping
+        args: [--safe]


### PR DESCRIPTION
### Overview

Although we now have `check_untyped_defs` enabled (#6795), `mypy` will nevertheless assume a lot of objects have type `Any` and therefore not report type errors in many cases. To enable `mypy` to detect more type errors, it requires annotations.

This is where `autotyping` is useful, as it will automatically add annotations for the most "obvious" cases, which then In turn allows `mypy` to properly do type-checking on the now-annotated parameters/functions. This should both make life easier for devs (some annotations are now automated) _and_ help catch type errors. It will also enforce a minimum level of (automatic) annotations in new code. 

Only the `--safe` option is enabled, which will only auto-type `None` or scalar return types and builtin magic methods. These are not likely to introduce type-check errors.

