### PR TITLE
Adds option to `DataSetFilters.glyph` to orient using vector or normal mode

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2536,6 +2536,7 @@ class DataSetFilters:
             If ``'normal'``, the glyphs are aligned using vtk normal mode.
 
             .. versionadded:: 0.45
+
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2699,14 +2699,14 @@ class DataSetFilters:
             alg.SetColorModeToColorByVector()
         else:
             raise ValueError(f"Invalid color mode '{color_mode}'")
-        
+
         if vector_mode == 'vector':
             alg.SetVectorModeToUseVector()
         elif vector_mode == 'normal':
             alg.SetVectorModeToUseNormal()
         else:
             raise ValueError(f"Invalid vector mode '{vector_mode}'")
-        
+
         if rng is not None:
             alg.SetRange(rng)
         alg.SetOrient(orient)

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2707,7 +2707,7 @@ class DataSetFilters:
         elif vector_mode == 'normal':
             alg.SetVectorModeToUseNormal()
         else:
-            raise ValueError('``vector_mode`` must be ``'vector'`` or ``'normal'``.')
+            raise ValueError(f"Invalid vector mode '{vector_mode}'")
 
         if rng is not None:
             alg.SetRange(rng)

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2466,6 +2466,7 @@ class DataSetFilters:
         clamping=False,
         rng=None,
         color_mode='scale',
+        vector_mode='vector',
         progress_bar=False,
     ):
         """Copy a geometric representation (called a glyph) to the input dataset.
@@ -2529,6 +2530,10 @@ class DataSetFilters:
             If ``'vector'`` , color the glyphs by vector.
 
             .. versionadded:: 0.44
+
+        vector_mode : str, optional, default: ``'vector'``
+            If ``'vector'``, the glyphs are aligned using vtk vector mode.
+            If ``'normal'``, the glyphs are aligned using vtk normal mode.
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
@@ -2694,12 +2699,18 @@ class DataSetFilters:
             alg.SetColorModeToColorByVector()
         else:
             raise ValueError(f"Invalid color mode '{color_mode}'")
-
+        
+        if vector_mode == 'vector':
+            alg.SetVectorModeToUseVector()
+        elif vector_mode == 'normal':
+            alg.SetVectorModeToUseNormal()
+        else:
+            raise ValueError(f"Invalid vector mode '{vector_mode}'")
+        
         if rng is not None:
             alg.SetRange(rng)
         alg.SetOrient(orient)
         alg.SetInputData(source_data)
-        alg.SetVectorModeToUseVector()
         alg.SetScaleFactor(factor)
         alg.SetClamping(clamping)
         _update_alg(alg, progress_bar, 'Computing Glyphs')

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2535,6 +2535,7 @@ class DataSetFilters:
             If ``'vector'``, the glyphs are aligned using vtk vector mode.
             If ``'normal'``, the glyphs are aligned using vtk normal mode.
 
+            .. versionadded:: 0.45
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
 
@@ -2705,7 +2706,7 @@ class DataSetFilters:
         elif vector_mode == 'normal':
             alg.SetVectorModeToUseNormal()
         else:
-            raise ValueError(f"Invalid vector mode '{vector_mode}'")
+            raise ValueError('``vector_mode`` must be ``'vector'`` or ``'normal'``.')
 
         if rng is not None:
             alg.SetRange(rng)


### PR DESCRIPTION
### Overview

Add the ability to choose whether to orient with vector or normal model when using the DataSetFilters.glyph method. Default is vector mode which is consistent with the existing implementation.

resolve #6823

### Details

Similar to recently added color_mode, as a flag allowing the user to specify the vector mode.
