### PR TITLE
Add typing overloads to `wrap`

### DIFF
--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -233,6 +233,7 @@ from vtkmodules.vtkCommonDataModel import vtkSelectionNode
 from vtkmodules.vtkCommonDataModel import vtkStaticCellLocator
 from vtkmodules.vtkCommonDataModel import vtkStaticPointLocator
 from vtkmodules.vtkCommonDataModel import vtkStructuredGrid
+from vtkmodules.vtkCommonDataModel import vtkStructuredPoints
 from vtkmodules.vtkCommonDataModel import vtkTable
 from vtkmodules.vtkCommonDataModel import vtkTetra
 from vtkmodules.vtkCommonDataModel import vtkTriangle

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -867,5 +867,5 @@ class DataObject:
         mesh = wrap(reader.GetOutput())  # type: ignore[attr-defined]
 
         # copy data
-        self.copy_structure(mesh)  # type: ignore[arg-type]
-        self.copy_attributes(mesh)  # type: ignore[arg-type]
+        self.copy_structure(mesh)
+        self.copy_attributes(mesh)

--- a/pyvista/core/filters/__init__.py
+++ b/pyvista/core/filters/__init__.py
@@ -52,14 +52,14 @@ def _get_output(
     ido = wrap(algorithm.GetInputDataObject(iport, iconnection))
     data = wrap(algorithm.GetOutputDataObject(oport))
     if not isinstance(data, pyvista.MultiBlock):
-        data.copy_meta_from(ido, deep=True)  # type: ignore[arg-type, union-attr]
-        if not data.field_data and ido.field_data:  # type: ignore[union-attr]
-            data.field_data.update(ido.field_data)  # type: ignore[union-attr]
+        data.copy_meta_from(ido, deep=True)
+        if not data.field_data and ido.field_data:
+            data.field_data.update(ido.field_data)
         if active_scalars is not None:
-            data.set_active_scalars(active_scalars, preference=active_scalars_field)  # type: ignore[union-attr]
+            data.set_active_scalars(active_scalars, preference=active_scalars_field)
     # return a PointSet if input is a pointset
     if isinstance(ido, pyvista.PointSet):
-        return data.cast_to_pointset()  # type: ignore[union-attr]
+        return data.cast_to_pointset()
     return data
 
 

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -983,7 +983,7 @@ class ImageDataFilters(DataSetFilters):
         _update_alg(alg, progress_bar, 'Performing Labeled Surface Extraction')
         # Restore the original vtkLogger verbosity level
         _vtk.vtkLogger.SetStderrVerbosity(verbosity)
-        return cast(pyvista.PolyData, wrap(alg.GetOutput()))
+        return wrap(alg.GetOutput())
 
     def points_to_cells(
         self,

--- a/pyvista/core/utilities/geometric_objects.py
+++ b/pyvista/core/utilities/geometric_objects.py
@@ -138,7 +138,7 @@ def Capsule(
             phi_resolution=resolution,
         )
     output = wrap(algo.output)
-    output.rotate_z(90, inplace=True)  # type: ignore[union-attr]
+    output.rotate_z(90, inplace=True)
     translate(output, center, direction)
     return output
 
@@ -216,7 +216,7 @@ def Cylinder(
         resolution=resolution,
     )
     output = wrap(algo.output)
-    output.rotate_z(90, inplace=True)  # type: ignore[union-attr]
+    output.rotate_z(90, inplace=True)
     translate(output, center, direction)
     return output
 

--- a/pyvista/core/utilities/helpers.py
+++ b/pyvista/core/utilities/helpers.py
@@ -11,7 +11,22 @@ if TYPE_CHECKING:  # pragma: no cover
     from meshio import Mesh
     from trimesh import Trimesh
 
+    from pyvista import DataObject
+    from pyvista import DataSet
+    from pyvista import ExplicitStructuredGrid
+    from pyvista import ImageData
+    from pyvista import MultiBlock
+    from pyvista import PartitionedDataSet
+    from pyvista import PointSet
+    from pyvista import PolyData
+    from pyvista import RectilinearGrid
+    from pyvista import StructuredGrid
+    from pyvista import Table
+    from pyvista import UnstructuredGrid
+    from pyvista import pyvista_ndarray
     from pyvista.core._typing_core import NumpyArray
+
+from typing import overload
 
 import numpy as np
 
@@ -23,9 +38,89 @@ from .fileio import from_meshio
 from .fileio import is_meshio_mesh
 
 
+# Overload types should match the mappings in the `pyvista._wrappers` dict
+# Overloads should be ordered from narrow types (child class) to general types (parent class)
+@overload
+def wrap(  # type: ignore[overload-overlap]  # numpydoc ignore=GL08
+    dataset: _vtk.vtkPolyData,
+) -> PolyData: ...
+@overload
+def wrap(  # type: ignore[overload-overlap]  # numpydoc ignore=GL08
+    dataset: _vtk.vtkStructuredGrid,
+) -> StructuredGrid: ...
+@overload
+def wrap(  # type: ignore[overload-overlap]  # numpydoc ignore=GL08
+    dataset: _vtk.vtkExplicitStructuredGrid,
+) -> ExplicitStructuredGrid: ...
+@overload
+def wrap(  # type: ignore[overload-overlap]  # numpydoc ignore=GL08
+    dataset: _vtk.vtkUnstructuredGrid,
+) -> UnstructuredGrid: ...
+@overload
+def wrap(  # numpydoc ignore=GL08
+    dataset: _vtk.vtkPointSet,
+) -> PointSet: ...
+@overload
+def wrap(  # numpydoc ignore=GL08
+    dataset: _vtk.vtkRectilinearGrid,
+) -> RectilinearGrid: ...
+@overload
+def wrap(  # numpydoc ignore=GL08
+    dataset: _vtk.vtkStructuredPoints,
+) -> ImageData: ...
+@overload
+def wrap(  # numpydoc ignore=GL08
+    dataset: _vtk.vtkImageData,
+) -> ImageData: ...
+@overload
+def wrap(  # numpydoc ignore=GL08
+    dataset: _vtk.vtkMultiBlockDataSet,
+) -> MultiBlock: ...
+@overload
+def wrap(  # numpydoc ignore=GL08
+    dataset: _vtk.vtkTable,
+) -> Table: ...
+@overload
+def wrap(  # numpydoc ignore=GL08
+    dataset: _vtk.vtkPartitionedDataSet,
+) -> PartitionedDataSet: ...
+
+
+# General catch-all cases
+@overload
+def wrap(  # numpydoc ignore=GL08
+    dataset: _vtk.vtkDataSet,
+) -> DataSet: ...
+@overload
+def wrap(  # numpydoc ignore=GL08
+    dataset: _vtk.vtkDataObject,
+) -> DataObject: ...
+
+
+# Misc overloads
+@overload
+def wrap(  # numpydoc ignore=GL08
+    dataset: NumpyArray[float],
+) -> PolyData | ImageData: ...
+@overload
+def wrap(  # numpydoc ignore=GL08
+    dataset: Trimesh,
+) -> PolyData: ...
+@overload
+def wrap(  # numpydoc ignore=GL08
+    dataset: Trimesh | Mesh,
+) -> DataSet: ...
+@overload
+def wrap(  # numpydoc ignore=GL08
+    dataset: _vtk.vtkDataArray,
+) -> pyvista_ndarray: ...
+@overload
+def wrap(  # numpydoc ignore=GL08
+    dataset: None,
+) -> None: ...
 def wrap(
     dataset: NumpyArray[float] | _vtk.vtkDataSet | Trimesh | Mesh | None,
-) -> pyvista.DataSet | pyvista.pyvista_ndarray | None:
+) -> DataObject | pyvista_ndarray | None:
     """Wrap any given VTK data object to its appropriate PyVista data object.
 
     Other formats that are supported include:

--- a/pyvista/core/utilities/parametric_objects.py
+++ b/pyvista/core/utilities/parametric_objects.py
@@ -1438,7 +1438,7 @@ def surface_from_para(
     para_source.Update()
     surf = wrap(para_source.GetOutput())
     if clean:
-        surf = surf.clean(  # type: ignore[union-attr]
+        surf = surf.clean(
             tolerance=1e-7,  # determined experimentally
             absolute=False,
             lines_to_points=False,

--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -413,10 +413,10 @@ class BaseReader:
         data = wrap(self.reader.GetOutputDataObject(0))
         if data is None:  # pragma: no cover
             raise RuntimeError('File reader failed to read and/or produced no output.')
-        data._post_file_load_processing()  # type: ignore[union-attr]
+        data._post_file_load_processing()
 
         # check for any pyvista metadata
-        data._restore_metadata()  # type: ignore[union-attr]
+        data._restore_metadata()
         return data
 
     def _update_information(self):
@@ -2636,10 +2636,10 @@ class GaussianCubeReader(BaseReader):
         )
         if data is None:  # pragma: no cover
             raise RuntimeError('File reader failed to read and/or produced no output.')
-        data._post_file_load_processing()  # type: ignore[union-attr]
+        data._post_file_load_processing()
 
         # check for any pyvista metadata
-        data._restore_metadata()  # type: ignore[union-attr]
+        data._restore_metadata()
         return data
 
     @property

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from functools import partial
 from functools import wraps
-from typing import cast
 import warnings
 import weakref
 
@@ -76,7 +75,7 @@ class RectangleSelection:
         frustum_source.ShowLinesOff()
         frustum_source.SetPlanes(self.frustum)
         frustum_source.Update()
-        return cast(pyvista.PolyData, pyvista.wrap(frustum_source.GetOutput()))
+        return pyvista.wrap(frustum_source.GetOutput())
 
     @property
     def viewport(self) -> tuple[float, float, float, float]:  # numpydoc ignore=RT01
@@ -1146,12 +1145,12 @@ class PickingMethods(PickingInterface):  # numpydoc ignore=PR01
             for actor in renderer.actors.values():
                 if actor.GetMapper() and actor.GetPickable():
                     input_mesh = pyvista.wrap(actor.GetMapper().GetInputAsDataSet())
-                    input_mesh.cell_data['orig_extract_id'] = np.arange(input_mesh.n_cells)  # type: ignore[union-attr]
+                    input_mesh.cell_data['orig_extract_id'] = np.arange(input_mesh.n_cells)
                     extract = _vtk.vtkExtractGeometry()
                     extract.SetInputData(input_mesh)
                     extract.SetImplicitFunction(selection.frustum)
                     extract.Update()
-                    picked.append(pyvista.wrap(extract.GetOutput()))  # type: ignore[arg-type]
+                    picked.append(pyvista.wrap(extract.GetOutput()))
 
             if picked.n_blocks == 0 or picked.combine().n_cells < 1:
                 self_()._picked_cell = None  # type: ignore[union-attr]
@@ -1285,11 +1284,11 @@ class PickingMethods(PickingInterface):  # numpydoc ignore=PR01
                             'Display representations other than `surface` will result in incorrect results.',
                         )
                     smesh = pyvista.wrap(actor.GetMapper().GetInputAsDataSet())
-                    smesh = smesh.copy()  # type: ignore[union-attr]
-                    smesh['original_cell_ids'] = np.arange(smesh.n_cells)  # type: ignore[index, union-attr]
-                    tri_smesh = smesh.extract_surface().triangulate()  # type: ignore[union-attr]
+                    smesh = smesh.copy()
+                    smesh['original_cell_ids'] = np.arange(smesh.n_cells)
+                    tri_smesh = smesh.extract_surface().triangulate()
                     cids_to_get = tri_smesh.extract_cells(cids)['original_cell_ids']
-                    picked.append(smesh.extract_cells(cids_to_get))  # type: ignore[union-attr]
+                    picked.append(smesh.extract_cells(cids_to_get))
 
                 # memory leak issues on vtk==9.0.20210612.dev0
                 # See: https://gitlab.kitware.com/vtk/vtk/-/issues/18239#note_973826
@@ -1855,8 +1854,8 @@ class PickingHelper(PickingMethods):
             if picker.GetDataSet() is None:
                 return
             mesh = pyvista.wrap(picker.GetDataSet())
-            idx = mesh.find_closest_point(picked_point)  # type: ignore[union-attr]
-            point = mesh.points[idx]  # type: ignore[union-attr]
+            idx = mesh.find_closest_point(picked_point)
+            point = mesh.points[idx]
             if self._last_picked_idx is None:
                 self.picked_geodesic = pyvista.PolyData(point)
                 self.picked_geodesic['vtkOriginalPointIds'] = [idx]

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -4263,7 +4263,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
                 block = wrap(volume.GetBlock(idx))
                 if resolution is None:
                     try:
-                        block_resolution = block.GetSpacing()  # type: ignore[union-attr]
+                        block_resolution = block.GetSpacing()
                     except AttributeError:
                         block_resolution = resolution
                 else:

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -2764,7 +2764,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
             and self._box_object is not None
             and self.bounding_box_actor is not None
         ):
-            if not np.allclose(self._box_object.bounds, self.bounds):  # type: ignore[union-attr]
+            if not np.allclose(self._box_object.bounds, self.bounds):
                 color = self.bounding_box_actor.GetProperty().GetColor()
                 self.remove_bounding_box()
                 self.add_bounding_box(color=color)

--- a/pyvista/plotting/utilities/algorithms.py
+++ b/pyvista/plotting/utilities/algorithms.py
@@ -214,9 +214,9 @@ class ActiveScalarsAlgorithm(PreserveTypeAlgorithmBase):
         try:
             inp = wrap(self.GetInputData(inInfo, 0, 0))
             out = self.GetOutputData(outInfo, 0)
-            output = inp.copy()  # type: ignore[union-attr]
-            if output.n_arrays:  # type: ignore[union-attr]
-                output.set_active_scalars(self.scalars_name, preference=self.preference)  # type: ignore[union-attr]
+            output = inp.copy()
+            if output.n_arrays:
+                output.set_active_scalars(self.scalars_name, preference=self.preference)
             out.ShallowCopy(output)
         except Exception:  # pragma: no cover
             traceback.print_exc()
@@ -262,7 +262,7 @@ class PointSetToPolyDataAlgorithm(_vtk.VTKPythonAlgorithmBase):
         try:
             inp = wrap(self.GetInputData(inInfo, 0, 0))
             out = self.GetOutputData(outInfo, 0)
-            output = inp.cast_to_polydata(deep=False)  # type: ignore[union-attr]
+            output = inp.cast_to_polydata(deep=False)
             out.ShallowCopy(output)
         except Exception:  # pragma: no cover
             traceback.print_exc()
@@ -325,13 +325,13 @@ class AddIDsAlgorithm(PreserveTypeAlgorithmBase):
         try:
             inp = wrap(self.GetInputData(inInfo, 0, 0))
             out = self.GetOutputData(outInfo, 0)
-            output = inp.copy()  # type: ignore[union-attr]
+            output = inp.copy()
             if self.point_ids:
-                output.point_data['point_ids'] = np.arange(0, output.n_points, dtype=int)  # type: ignore[union-attr]
+                output.point_data['point_ids'] = np.arange(0, output.n_points, dtype=int)
             if self.cell_ids:
-                output.cell_data['cell_ids'] = np.arange(0, output.n_cells, dtype=int)  # type: ignore[union-attr]
-            if output.active_scalars_name in ['point_ids', 'cell_ids']:  # type: ignore[union-attr]
-                output.active_scalars_name = inp.active_scalars_name  # type: ignore[union-attr]
+                output.cell_data['cell_ids'] = np.arange(0, output.n_cells, dtype=int)
+            if output.active_scalars_name in ['point_ids', 'cell_ids']:
+                output.active_scalars_name = inp.active_scalars_name
             out.ShallowCopy(output)
         except Exception:  # pragma: no cover
             traceback.print_exc()
@@ -371,7 +371,7 @@ class CrinkleAlgorithm(_vtk.VTKPythonAlgorithmBase):
             clipped = wrap(self.GetInputData(inInfo, 0, 0))
             source = wrap(self.GetInputData(inInfo, 1, 0))
             out = self.GetOutputData(outInfo, 0)
-            output = source.extract_cells(np.unique(clipped.cell_data['cell_ids']))  # type: ignore[union-attr]
+            output = source.extract_cells(np.unique(clipped.cell_data['cell_ids']))
             out.ShallowCopy(output)
         except Exception:  # pragma: no cover
             traceback.print_exc()

--- a/pyvista/plotting/utilities/regression.py
+++ b/pyvista/plotting/utilities/regression.py
@@ -70,7 +70,7 @@ def wrap_image_array(arr):
     img = _vtk.vtkImageData()
     img.SetDimensions(arr.shape[1], arr.shape[0], 1)
     wrap_img = pyvista.wrap(img)
-    wrap_img.point_data['PNGImage'] = arr[::-1].reshape(-1, arr.shape[2])  # type: ignore[union-attr]
+    wrap_img.point_data['PNGImage'] = arr[::-1].reshape(-1, arr.shape[2])
     return wrap_img
 
 

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1081,7 +1081,7 @@ class WidgetHelper:
             plane = generate_plane(normal, origin)
             alg.SetCutFunction(plane)  # the cutter to use the plane we made
             alg.Update()  # Perform the Cut
-            plane_sliced_mesh.shallow_copy(alg.GetOutput())  # type: ignore[union-attr]
+            plane_sliced_mesh.shallow_copy(alg.GetOutput())
 
         self.add_plane_widget(
             callback=callback,
@@ -1759,7 +1759,7 @@ class WidgetHelper:
         def callback(value):  # numpydoc ignore=GL08
             _set_threshold_limit(alg, value, method, invert)
             alg.Update()
-            threshold_mesh.shallow_copy(alg.GetOutput())  # type: ignore[union-attr]
+            threshold_mesh.shallow_copy(alg.GetOutput())
 
         self.add_slider_widget(
             callback=callback,
@@ -1918,7 +1918,7 @@ class WidgetHelper:
         def callback(value):  # numpydoc ignore=GL08
             alg.SetValue(0, value)
             alg.Update()
-            isovalue_mesh.shallow_copy(alg.GetOutput())  # type: ignore[union-attr]
+            isovalue_mesh.shallow_copy(alg.GetOutput())
 
         self.add_slider_widget(
             callback=callback,
@@ -2030,7 +2030,7 @@ class WidgetHelper:
             para_source.SetParametricFunction(widget.GetParametricSpline())
             para_source.Update()
             polyline = pyvista.wrap(para_source.GetOutput())
-            ribbon.shallow_copy(polyline.ribbon(normal=(0, 0, 1), angle=90.0))  # type: ignore[union-attr]
+            ribbon.shallow_copy(polyline.ribbon(normal=(0, 0, 1), angle=90.0))
             if callable(callback):
                 if pass_widget:
                     try_callback(callback, polyline, widget)
@@ -2174,7 +2174,7 @@ class WidgetHelper:
             polyplane.SetPolyLine(polyline)
             alg.SetCutFunction(polyplane)  # the cutter to use the poly planes
             alg.Update()  # Perform the Cut
-            spline_sliced_mesh.shallow_copy(alg.GetOutput())  # type: ignore[union-attr]
+            spline_sliced_mesh.shallow_copy(alg.GetOutput())
 
         self.add_spline_widget(
             callback=callback,


### PR DESCRIPTION
### Overview

Add typing overloads for wrapping meshes.

This fixes approx 60 type errors that were ignored.
