### PR TITLE
Add `trimesh` as typing dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,13 @@ pinned = [ # Pinned versions of core dependencies
   'vtk<9.4.0',
 ]
 
-typing = ['mypy<1.14.0', 'npt-promote==0.1', 'numpy>=2.0.0', 'pyvista[pinned]']
+typing = [
+  'mypy<1.14.0',
+  'npt-promote==0.1',
+  'numpy>=2.0.0',
+  'pyvista[pinned]',
+  'trimesh<4.6.0',
+]
 
 test = [
   'cmocean<4.0.4',


### PR DESCRIPTION
### Overview

This can be used by #6840 to properly hint a `Trimesh -> PolyData` mapping with `wrap`.