### PR TITLE
Add DataSet TypeVar to typing core

### DIFF
--- a/doc/source/api/core/typing.rst
+++ b/doc/source/api/core/typing.rst
@@ -40,19 +40,12 @@ pyvista.VectorLike
 VTK Related Types
 -----------------
 
-pyvista.DataSetType
-~~~~~~~~~~~~~~~~~~~
+pyvista.ConcreteDataSetType
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. currentmodule:: pyvista
 
-.. autotypevar:: DataSetType
-
-pyvista.DataSetMultiBlockType
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. currentmodule:: pyvista
-
-.. autotypevar:: DataSetMultiBlockType
+.. autotypevar:: ConcreteDataSetType
 
 pyvista.BoundsTuple
 ~~~~~~~~~~~~~~~~~~~

--- a/doc/source/api/core/typing.rst
+++ b/doc/source/api/core/typing.rst
@@ -48,7 +48,7 @@ pyvista.DataSetType
 .. autotypevar:: DataSetType
 
 pyvista.DataSetMultiBlockType
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. currentmodule:: pyvista
 

--- a/doc/source/api/core/typing.rst
+++ b/doc/source/api/core/typing.rst
@@ -40,6 +40,20 @@ pyvista.VectorLike
 VTK Related Types
 -----------------
 
+pyvista.DataSetType
+~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: pyvista
+
+.. autotypevar:: DataSetType
+
+pyvista.DataSetMultiBlockType
+~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: pyvista
+
+.. autotypevar:: DataSetMultiBlockType
+
 pyvista.BoundsTuple
 ~~~~~~~~~~~~~~~~~~~
 

--- a/pyvista/core/__init__.py
+++ b/pyvista/core/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from . import _vtk_core
 from ._typing_core import *
+from ._typing_core._dataset_types import DataSetMultiBlockType
+from ._typing_core._dataset_types import DataSetType
 from .cell import Cell
 from .cell import CellArray
 from .celltype import CellType

--- a/pyvista/core/__init__.py
+++ b/pyvista/core/__init__.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 
 from . import _vtk_core
 from ._typing_core import *
-from ._typing_core._dataset_types import DataSetMultiBlockType
-from ._typing_core._dataset_types import DataSetType
+from ._typing_core._dataset_types import ConcreteDataSetType
 from .cell import Cell
 from .cell import CellArray
 from .celltype import CellType

--- a/pyvista/core/_typing_core/__init__.py
+++ b/pyvista/core/_typing_core/__init__.py
@@ -18,4 +18,4 @@ from ._array_like import NumpyArray  # noqa: F401
 
 if TYPE_CHECKING:  # pragma: no cover
     # Avoid circular imports
-    from ._dataset_types import DataSetType  # noqa: F401
+    from ._dataset_types import ConcreteDataSetType  # noqa: F401

--- a/pyvista/core/_typing_core/__init__.py
+++ b/pyvista/core/_typing_core/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from ._aliases import ArrayLike  # noqa: F401
 from ._aliases import BoundsTuple  # noqa: F401
 from ._aliases import CellArrayLike  # noqa: F401
@@ -13,3 +15,7 @@ from ._aliases import TransformLike  # noqa: F401
 from ._aliases import VectorLike  # noqa: F401
 from ._array_like import NumberType  # noqa: F401
 from ._array_like import NumpyArray  # noqa: F401
+
+if TYPE_CHECKING:
+    # Type-checking only otherwise we have circular imports
+    from ._dataset_types import _DataSetType_co  # noqa: F401

--- a/pyvista/core/_typing_core/__init__.py
+++ b/pyvista/core/_typing_core/__init__.py
@@ -16,6 +16,6 @@ from ._aliases import VectorLike  # noqa: F401
 from ._array_like import NumberType  # noqa: F401
 from ._array_like import NumpyArray  # noqa: F401
 
-if TYPE_CHECKING:
-    # Avoid circular imports Type-checking only otherwise we have circular imports
+if TYPE_CHECKING:  # pragma: no cover
+    # Avoid circular imports
     from ._dataset_types import DataSetType  # noqa: F401

--- a/pyvista/core/_typing_core/__init__.py
+++ b/pyvista/core/_typing_core/__init__.py
@@ -17,5 +17,5 @@ from ._array_like import NumberType  # noqa: F401
 from ._array_like import NumpyArray  # noqa: F401
 
 if TYPE_CHECKING:
-    # Type-checking only otherwise we have circular imports
-    from ._dataset_types import _DataSetType_co  # noqa: F401
+    # Avoid circular imports Type-checking only otherwise we have circular imports
+    from ._dataset_types import DataSetType  # noqa: F401

--- a/pyvista/core/_typing_core/_dataset_types.py
+++ b/pyvista/core/_typing_core/_dataset_types.py
@@ -15,8 +15,8 @@ from pyvista.core.pointset import UnstructuredGrid
 
 # Use this typevar wherever a `DataSet` type hint may be used
 # Unlike `DataSet`, the concrete classes here also inherit from `vtkDataSet`
-_DataSetType_co = TypeVar(  # noqa: PYI018
-    '_DataSetType_co',
+DataSetType = TypeVar(
+    'DataSetType',
     ImageData,
     RectilinearGrid,
     ExplicitStructuredGrid,
@@ -24,13 +24,13 @@ _DataSetType_co = TypeVar(  # noqa: PYI018
     PolyData,
     StructuredGrid,
     UnstructuredGrid,
-    covariant=True,
 )
+DataSetType.__doc__ = """Type variable of all concrete :class:`~pyvista.DataSet` classes."""
 
 # Use this typevar wherever a `DataSet | MultiBlock` type hint may be used
 # This should be identical to above, but with `MultiBlock`
-_DataSetOrMultiBlockType_co = TypeVar(  # noqa: PYI018
-    '_DataSetOrMultiBlockType_co',
+DataSetMultiBlockType = TypeVar(
+    'DataSetMultiBlockType',
     ImageData,
     RectilinearGrid,
     ExplicitStructuredGrid,
@@ -39,5 +39,5 @@ _DataSetOrMultiBlockType_co = TypeVar(  # noqa: PYI018
     StructuredGrid,
     UnstructuredGrid,
     MultiBlock,
-    covariant=True,
 )
+DataSetMultiBlockType.__doc__ = """Type variable of :class:`~pyvista.MultiBlock` and all concrete :class:`~pyvista.DataSet` classes."""

--- a/pyvista/core/_typing_core/_dataset_types.py
+++ b/pyvista/core/_typing_core/_dataset_types.py
@@ -1,0 +1,43 @@
+"""PyVista dataset types."""
+
+from __future__ import annotations
+
+from typing import TypeVar
+
+from pyvista.core.composite import MultiBlock
+from pyvista.core.grid import ImageData
+from pyvista.core.grid import RectilinearGrid
+from pyvista.core.pointset import ExplicitStructuredGrid
+from pyvista.core.pointset import PointSet
+from pyvista.core.pointset import PolyData
+from pyvista.core.pointset import StructuredGrid
+from pyvista.core.pointset import UnstructuredGrid
+
+# Use this typevar wherever a `DataSet` type hint may be used
+# Unlike `DataSet`, the concrete classes here also inherit from `vtkDataSet`
+_DataSetType_co = TypeVar(  # noqa: PYI018
+    '_DataSetType_co',
+    ImageData,
+    RectilinearGrid,
+    ExplicitStructuredGrid,
+    PointSet,
+    PolyData,
+    StructuredGrid,
+    UnstructuredGrid,
+    covariant=True,
+)
+
+# Use this typevar wherever a `DataSet | MultiBlock` type hint may be used
+# This should be identical to above, but with `MultiBlock`
+_DataSetOrMultiBlockType_co = TypeVar(  # noqa: PYI018
+    '_DataSetOrMultiBlockType_co',
+    ImageData,
+    RectilinearGrid,
+    ExplicitStructuredGrid,
+    PointSet,
+    PolyData,
+    StructuredGrid,
+    UnstructuredGrid,
+    MultiBlock,
+    covariant=True,
+)

--- a/pyvista/core/_typing_core/_dataset_types.py
+++ b/pyvista/core/_typing_core/_dataset_types.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import TypeVar
 
-from pyvista.core.composite import MultiBlock
 from pyvista.core.grid import ImageData
 from pyvista.core.grid import RectilinearGrid
 from pyvista.core.pointset import ExplicitStructuredGrid
@@ -15,8 +14,8 @@ from pyvista.core.pointset import UnstructuredGrid
 
 # Use this typevar wherever a `DataSet` type hint may be used
 # Unlike `DataSet`, the concrete classes here also inherit from `vtkDataSet`
-DataSetType = TypeVar(
-    'DataSetType',
+ConcreteDataSetType = TypeVar(
+    'ConcreteDataSetType',
     ImageData,
     RectilinearGrid,
     ExplicitStructuredGrid,
@@ -25,19 +24,4 @@ DataSetType = TypeVar(
     StructuredGrid,
     UnstructuredGrid,
 )
-DataSetType.__doc__ = """Type variable of all concrete :class:`~pyvista.DataSet` classes."""
-
-# Use this typevar wherever a `DataSet | MultiBlock` type hint may be used
-# This should be identical to above, but with `MultiBlock`
-DataSetMultiBlockType = TypeVar(
-    'DataSetMultiBlockType',
-    ImageData,
-    RectilinearGrid,
-    ExplicitStructuredGrid,
-    PointSet,
-    PolyData,
-    StructuredGrid,
-    UnstructuredGrid,
-    MultiBlock,
-)
-DataSetMultiBlockType.__doc__ = """Type variable of :class:`~pyvista.MultiBlock` and all concrete :class:`~pyvista.DataSet` classes."""
+ConcreteDataSetType.__doc__ = """Type variable of all concrete :class:`~pyvista.DataSet` classes."""


### PR DESCRIPTION
### Overview

Add new TypeVar for datasets. It can be used in place of a Union (`PolyData | ImageData | ...`) or wherever a `T - > T` mapping is needed. E.g.  in #6853 it's used for overloading `Transform.apply` so that transforming `PolyData` will properly hint that `PolyData` is returned, etc., without needing a separate overload for each dataset subclass. A similar TypeVar is also used in #6840. 

And I think it can also be used to solve the typing issue we have where using `DataSet` as a type hint generates a type error if `vtkDataSet` is expected (since a `DataSet` is not a subclass of `vtkDataSet`), see https://github.com/pyvista/pyvista/pull/6828#discussion_r1854604818. This is solved by specifying all subclasses explicitly in the TypeVar since the subclasses _do_ inherit from `vtkDataSet`.  So, we can simply use `DataSetType_co` instead of `DataSet` as type hint.