### PR TITLE
Replace  `docs` with `typing`  in `dev` dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ docs = [
   'trimesh==4.5.2',
 ]
 
-dev = ['pre-commit', 'pyvista[test,docs]']
+dev = ['pre-commit', 'pyvista[test,typing]']
 
 [project.urls]
 "Bug Tracker" = 'https://github.com/pyvista/pyvista/issues'


### PR DESCRIPTION
### Overview

See https://github.com/pyvista/pyvista/issues/6858#issuecomment-2499629931