### PR TITLE
Limit VTK<9.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   'pooch',
   'scooby>=0.5.1',
   'typing-extensions',
-  'vtk',               # keep without version constraints
+  'vtk<9.4.0',
 ]
 description = 'Easier Pythonic interface to VTK'
 dynamic = ['version']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ pinned = [ # Pinned versions of core dependencies
   'pooch<1.9.0',
   'scooby<0.11.0',
   'typing-extensions<4.13.0',
-  'vtk<9.4.0',
 ]
 
 typing = [


### PR DESCRIPTION
Upper limit of the version of VTK that is supported. We are working on full support for VTK 9.4 and have some base level of support at present but overall VTK 9.4 brought a lot of breaking changes that we still need to resolve.

for #6731

To slow down the reports of this incompatibility, I will cherry pick this commit on to the release branch and issue a patch