### PR TITLE
Mark `test_tinypages` as a flaky test

### DIFF
--- a/tests/test_tinypages.py
+++ b/tests/test_tinypages.py
@@ -12,6 +12,8 @@ import pytest
 
 from pyvista.plotting import system_supports_plotting
 
+from .conftest import flaky_test
+
 pytest.importorskip('sphinx')
 
 # skip all tests if unable to render
@@ -21,6 +23,7 @@ if not system_supports_plotting():
 ENVIRONMENT_HOOKS = ['PLOT_SKIP', 'PLOT_SKIP_OPTIONAL']
 
 
+@flaky_test
 @pytest.mark.skipif(os.name == 'nt', reason='path issues on Azure Windows CI')
 @pytest.mark.parametrize('ename', ENVIRONMENT_HOOKS)
 @pytest.mark.parametrize('evalue', [False, True])


### PR DESCRIPTION
### Overview

This test is a bit of a nuisance lately and keeps failing erroneously, e.g. see https://github.com/pyvista/pyvista/actions/runs/12055204331/job/33615028072?pr=6875
```
FAILED tests/test_tinypages.py::test_tinypages[True-PLOT_SKIP] - AssertionError: sphinx build failed with stdout:
  Running Sphinx v7.4.7
  loading translations [en]... done
  making output directory... done
  Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`.
  [autosummary] generating autosummary for: index.rst, some_autodocs.rst, some_plots.rst
  building [mo]: targets for 0 po files that are out of date
  writing output... 
  building [html]: targets for 3 source files that are out of date
  updating environment: [new config] 3 added, 0 changed, 0 removed
  reading sources... [ 33%] index
  reading sources... [ 67%] some_autodocs
  reading sources... [100%] some_plots
  
  stderr:
  
  
assert -11 == 0
 +  where -11 = <Popen: returncode: -11 args: ['/opt/hostedtoolcache/Python/3.9.20/x64/bin/p...>.returncode
= 1 failed, 2065 passed, 70 skipped, 2 xfailed, 14 warnings in 1023.54s (0:17:03) =
Error: Process completed with exit code 1.
```
