### PR TITLE
Fix more broken links in documentation

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1808,7 +1808,7 @@ class DataSet(DataSetFilters, DataObject):
 
         Parameters
         ----------
-        point : Vector | Matrix
+        point : VectorLike[float] | MatrixLike[float]
             Coordinates of point to query (length 3) or a
             :class:`numpy.ndarray` of ``n`` points with shape ``(n, 3)``.
 
@@ -1938,7 +1938,7 @@ class DataSet(DataSetFilters, DataObject):
 
         Parameters
         ----------
-        point : Vector, Matrix
+        point : VectorLike[float] | MatrixLike[float],
             Coordinates of point to query (length 3) or a
             :class:`numpy.ndarray` of ``n`` points with shape ``(n, 3)``.
 
@@ -2008,10 +2008,10 @@ class DataSet(DataSetFilters, DataObject):
 
         Parameters
         ----------
-        pointa : Vector
+        pointa : VectorLike
             Length 3 coordinate of the start of the line.
 
-        pointb : Vector
+        pointb : VectorLike
             Length 3 coordinate of the end of the line.
 
         tolerance : float, default: 0.0
@@ -2692,7 +2692,7 @@ class DataSet(DataSetFilters, DataObject):
 
         Returns
         -------
-        listint]
+        list[int]
             List of cell IDs using the ind-th point.
 
         Examples

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -897,7 +897,7 @@ class DataSet(DataSetFilters, DataObject):
             name = arr_var
             arr = get_array(self, name, preference=preference, err=True)
         else:
-            arr = arr_var
+            arr = arr_var  # type: ignore[assignment]
 
         # If array has no tuples return a NaN range
         if arr is None:

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5507,7 +5507,7 @@ class DataSetFilters:
 
         Parameters
         ----------
-        values : number | array_like | dict, optional
+        values : float | ArrayLike[float] | dict, optional
             Value(s) to extract. Can be a number, an iterable of numbers, or a dictionary
             with numeric entries. For ``dict`` inputs, either its keys or values may be
             numeric, and the other field must be strings. The numeric field is used as
@@ -7409,7 +7409,7 @@ class DataSetFilters:
 
         Parameters
         ----------
-        vector : Vector
+        vector : VectorLike[float]
             Vector to rotate about.
 
         angle : float
@@ -7549,7 +7549,7 @@ class DataSetFilters:
 
         Parameters
         ----------
-        xyz : Vector
+        xyz : VectorLike[float]
             A vector of three floats.
 
         transform_all_input_vectors : bool, default: False
@@ -7606,7 +7606,7 @@ class DataSetFilters:
 
         Parameters
         ----------
-        xyz : Number | Vector
+        xyz : float | VectorLike[float]
             A vector sequence defining the scale factors along x, y, and z. If
             a scalar, the same uniform scale is used along all three axes.
 

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -1020,7 +1020,7 @@ class ImageDataFilters(DataSetFilters):
         effect, such as plotting images as voxel cells instead of as points.
 
         .. note::
-            Only the input's :attr:`~pyvista.ImageData.dimensions`, and
+            Only the input's :attr:`~pyvista.core.Grid.dimensions`, and
             :attr:`~pyvista.ImageData.origin` are modified by this filter. Other spatial
             properties such as :attr:`~pyvista.ImageData.spacing` and
             :attr:`~pyvista.ImageData.direction_matrix` are not affected.
@@ -1224,7 +1224,7 @@ class ImageDataFilters(DataSetFilters):
         effect, such as plotting images as points instead of as voxel cells.
 
         .. note::
-            Only the input's :attr:`~pyvista.ImageData.dimensions`, and
+            Only the input's :attr:`~pyvista.core.Grid.dimensions`, and
             :attr:`~pyvista.ImageData.origin` are modified by this filter. Other spatial
             properties such as :attr:`~pyvista.ImageData.spacing` and
             :attr:`~pyvista.ImageData.direction_matrix` are not affected.
@@ -1494,7 +1494,7 @@ class ImageDataFilters(DataSetFilters):
 
         Parameters
         ----------
-        pad_value : float | sequence[float] | 'mirror' | 'wrap', default : 0.0
+        pad_value : float | sequence[float] | 'mirror' | 'wrap', default: 0.0
             Padding value(s) given to new points outside the original image extent.
             Specify:
 
@@ -1503,7 +1503,7 @@ class ImageDataFilters(DataSetFilters):
             - ``'wrap'``: New points are filled by wrapping around the padding axis.
             - ``'mirror'``: New points are filled by mirroring the padding axis.
 
-        pad_size : int | sequence[int], default : 1
+        pad_size : int | sequence[int], default: 1
             Number of points to add to the image boundaries. Specify:
 
             - A single value to pad all boundaries equally.

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2451,7 +2451,7 @@ class PolyDataFilters(DataSetFilters):
 
         Parameters
         ----------
-        show_mesh : bool, default: true
+        show_mesh : bool, default: True
             Plot the mesh itself.
 
         mag : float, default: 1.0

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -371,9 +371,9 @@ class Table(DataObject, _vtk.vtkTable):
             # use the first array in the row data
             arr = self.GetRowData().GetArrayName(0)
         if isinstance(arr, str):
-            arr = get_array(self, arr, preference=preference)
+            arr = get_array(self, arr, preference=preference)  # type: ignore[assignment]
         # If array has no tuples return a NaN range
-        if arr is None or arr.size == 0 or not np.issubdtype(arr.dtype, np.number):
+        if arr is None or arr.size == 0 or not np.issubdtype(arr.dtype, np.number):  # type: ignore[attr-defined]
             return (np.nan, np.nan)
         # Use the array range
         return np.nanmin(arr), np.nanmax(arr)

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -197,7 +197,7 @@ class _PointSet(DataSet):
 
         Parameters
         ----------
-        xyz : Vector
+        xyz : VectorLike[float]
             A vector of three floats of cartesian values to translate the mesh with.
 
         transform_all_input_vectors : bool, default: False
@@ -249,7 +249,7 @@ class PointSet(_PointSet, _vtk.vtkPointSet):
 
     Parameters
     ----------
-    var_inp : vtk.vtkPointSet, Matrix, optional
+    var_inp : vtk.vtkPointSet, MatrixLike[float], optional
         Flexible input type.  Can be a ``vtk.vtkPointSet``, in which case
         this PointSet object will be copied if ``deep=True`` and will
         be a shallow copy if ``deep=False``.
@@ -534,7 +534,7 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
         ``None``, then the ``PolyData`` object will be created with
         vertex cells with ``n_verts`` equal to the number of ``points``.
 
-    faces : sequence[int], vtk.vtkCellArray, pv.CellArray, optional
+    faces : sequence[int], vtk.vtkCellArray, pyvista.CellArray, optional
         Polygonal faces of the mesh. Can be either a padded connectivity
         array or an explicit cell array object.
 
@@ -551,7 +551,7 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
     n_faces : int, optional
         Deprecated. Not used.
 
-    lines : sequence[int], vtk.vtkCellArray, pv.CellArray, optional
+    lines : sequence[int], vtk.vtkCellArray, pyvista.CellArray, optional
         Line connectivity. Like ``faces``, this can be either a padded
         connectivity array or an explicit cell array object. The padded
         array format requires padding indicating the number of points in
@@ -562,7 +562,7 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
     n_lines : int, optional
         Deprecated. Not used.
 
-    strips : sequence[int], vtk.vtkCellArray, pv.CellArray, optional
+    strips : sequence[int], vtk.vtkCellArray, pyvista.CellArray, optional
         Triangle strips connectivity.  Triangle strips require an
         initial triangle, and the following points of the strip. Each
         triangle is built with the new point and the two previous
@@ -596,7 +596,7 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
         non-float types, though this may lead to truncation of
         intermediate floats when transforming datasets.
 
-    verts : sequence[int], vtk.vtkCellArray, pv.CellArray, optional
+    verts : sequence[int], vtk.vtkCellArray, pvyvista.CellArray, optional
         The verts connectivity.  Like ``faces``, ``lines``, and
         ``strips`` this can be supplied as either a padded array or an
         explicit cell array object. In the padded array format,
@@ -1146,7 +1146,7 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
 
         Parameters
         ----------
-        points : Matrix
+        points : MatrixLike[float]
             A (n_points, 3) array of points.
 
         faces : Sequence[VectorLike[int]]

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -23,7 +23,7 @@ class pyvista_ndarray(np.ndarray):  # type: ignore[type-arg]  # numpydoc ignore=
 
     Parameters
     ----------
-    array : Array or vtk.vtkAbstractArray
+    array : ArrayLike or vtk.vtkAbstractArray
         Array like.
 
     dataset : pyvista.DataSet

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -19,6 +19,7 @@ from pyvista.core.errors import AmbiguousDataError
 from pyvista.core.errors import MissingDataError
 
 if TYPE_CHECKING:  # pragma: no cover
+    from pyvista import pyvista_ndarray
     from pyvista.core._typing_core import MatrixLike
     from pyvista.core._typing_core import NumpyArray
     from pyvista.core._typing_core import VectorLike
@@ -259,7 +260,7 @@ def convert_array(arr, name=None, deep: bool = False, array_type=None):
     return _vtk.vtk_to_numpy(arr)
 
 
-def get_array(mesh, name, preference='cell', err: bool = False) -> pyvista.ndarray | None:
+def get_array(mesh, name, preference='cell', err: bool = False) -> pyvista_ndarray | None:
     """Search point, cell and field data for an array.
 
     Parameters

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -2203,7 +2203,7 @@ def download_frog_tissue(load=True):  # pragma: no cover
     .. deprecated:: 0.44.0
 
         This example does not load correctly on some systems and has been deprecated.
-        Use :func:`~pyvista.examples.load_frog_tissues` instead.
+        Use :func:`~pyvista.examples.downloads.load_frog_tissues` instead.
 
     Parameters
     ----------

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1092,7 +1092,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         zlabel : str, default: "Z"
             Text used for the z-axis.
 
-        labels_off : bool, default: false
+        labels_off : bool, default: False
             Enable or disable the text labels for the axes.
 
         box : bool, optional
@@ -2160,7 +2160,7 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         offset : float, default: 0.0
             Percentage offset along plane normal.
 
-        pickable : bool, default: false
+        pickable : bool, default: False
             Make this floor actor pickable in the renderer.
 
         store_floor_kwargs : bool, default: True


### PR DESCRIPTION
### Overview

Similar to #6896

<details>

``` yaml


2024-11-21T19:28:52.6132995Z /home/runner/work/pyvista/pyvista/pyvista/core/filters/data_set.py:docstring of pyvista.core.filters.data_set.DataSetFilters.split_values:17: WARNING: py:obj reference target not found: number [ref.obj]
2024-11-21T19:28:52.5877945Z /home/runner/work/pyvista/pyvista/pyvista/core/dataset.py:docstring of pyvista.core.dataset.DataSet.find_cells_along_line:8: WARNING: py:obj reference target not found: Vector [ref.obj]
2024-11-21T19:28:52.5881540Z /home/runner/work/pyvista/pyvista/pyvista/core/dataset.py:docstring of pyvista.core.dataset.DataSet.find_cells_along_line:11: WARNING: py:obj reference target not found: Vector [ref.obj]
2024-11-21T19:28:52.5913891Z /home/runner/work/pyvista/pyvista/pyvista/core/dataset.py:docstring of pyvista.core.dataset.DataSet.find_closest_cell:7: WARNING: py:obj reference target not found: Vector [ref.obj]
2024-11-21T19:28:52.5916915Z /home/runner/work/pyvista/pyvista/pyvista/core/dataset.py:docstring of pyvista.core.dataset.DataSet.find_closest_cell:7: WARNING: py:obj reference target not found: Matrix [ref.obj]
2024-11-21T19:28:52.5929783Z /home/runner/work/pyvista/pyvista/pyvista/core/dataset.py:docstring of pyvista.core.dataset.DataSet.find_containing_cell:7: WARNING: py:obj reference target not found: Vector [ref.obj]
2024-11-21T19:28:52.5932871Z /home/runner/work/pyvista/pyvista/pyvista/core/dataset.py:docstring of pyvista.core.dataset.DataSet.find_containing_cell:7: WARNING: py:obj reference target not found: Matrix [ref.obj]
2024-11-21T19:28:52.5980367Z /home/runner/work/pyvista/pyvista/pyvista/core/dataset.py:docstring of pyvista.core.dataset.DataSet.point_is_inside_cell:11: WARNING: py:obj reference target not found: Matrix [ref.obj]
2024-11-21T19:28:52.5995655Z /home/runner/work/pyvista/pyvista/pyvista/core/dataset.py:docstring of pyvista.core.dataset.DataSet.rotate_vector:11: WARNING: py:obj reference target not found: Vector [ref.obj]
2024-11-21T19:28:52.6021113Z /home/runner/work/pyvista/pyvista/pyvista/core/dataset.py:docstring of pyvista.core.dataset.DataSet.scale:11: WARNING: py:obj reference target not found: Vector [ref.obj]
2024-11-21T19:28:52.6035034Z /home/runner/work/pyvista/pyvista/pyvista/core/dataset.py:docstring of pyvista.core.dataset.DataSet.translate:11: WARNING: py:obj reference target not found: Vector [ref.obj]
2024-11-21T19:28:52.6091778Z /home/runner/work/pyvista/pyvista/pyvista/core/filters/data_set.py:docstring of pyvista.core.filters.data_set.DataSetFilters.extract_values:40: WARNING: py:obj reference target not found: number [ref.obj]
2024-11-21T19:28:52.6265990Z /home/runner/work/pyvista/pyvista/pyvista/core/pointset.py:docstring of pyvista.core.pointset.PointSet:14: WARNING: py:obj reference target not found: Matrix [ref.obj]
2024-11-21T19:28:52.5964167Z /home/runner/work/pyvista/pyvista/pyvista/core/dataset.py:docstring of pyvista.core.dataset.DataSet.point_cell_ids:15: WARNING: py:obj reference target not found: listint [ref.obj]
2024-11-21T19:28:52.6293518Z /home/runner/work/pyvista/pyvista/pyvista/core/pointset.py:docstring of pyvista.core.pointset.PolyData.from_irregular_faces:7: WARNING: py:obj reference target not found: Matrix [ref.obj]  
2024-11-21T19:28:52.6570760Z /home/runner/work/pyvista/pyvista/pyvista/examples/downloads.py:docstring of pyvista.examples.downloads.download_frog_tissue:8: WARNING: py:func reference target not found: pyvista.examples.load_frog_tissues [ref.func]
2024-11-21T19:28:52.6245273Z /home/runner/work/pyvista/pyvista/pyvista/core/filters/image_data.py:docstring of pyvista.core.filters.image_data.ImageDataFilters.pad_image:14: WARNING: py:obj reference target not found: default [ref.obj]
2024-11-21T19:28:52.6248654Z /home/runner/work/pyvista/pyvista/pyvista/core/filters/image_data.py:docstring of pyvista.core.filters.image_data.ImageDataFilters.pad_image:23: WARNING: py:obj reference target not found: default [ref.obj]
2024-11-21T19:28:52.6327622Z /home/runner/work/pyvista/pyvista/pyvista/core/filters/poly_data.py:docstring of pyvista.core.filters.poly_data.PolyDataFilters.plot_normals:7: WARNING: py:obj reference target not found: true [ref.obj]
2024-11-21T19:28:52.6736623Z /home/runner/work/pyvista/pyvista/pyvista/plotting/renderer.py:docstring of pyvista.plotting.renderer.Renderer.add_axes:34: WARNING: py:obj reference target not found: false [ref.obj]
2024-11-21T19:28:52.6740568Z /home/runner/work/pyvista/pyvista/pyvista/plotting/renderer.py:docstring of pyvista.plotting.renderer.Renderer.add_floor:56: WARNING: py:obj reference target not found: false [ref.obj]
2024-11-21T19:28:52.6904669Z /home/runner/work/pyvista/pyvista/pyvista/core/pyvista_ndarray.py:docstring of pyvista.core.pyvista_ndarray.pyvista_ndarray:8: WARNING: py:obj reference target not found: Array [ref.obj]
2024-11-21T19:28:52.6197627Z /home/runner/work/pyvista/pyvista/pyvista/core/filters/image_data.py:docstring of pyvista.core.filters.image_data.ImageDataFilters.cells_to_points:27: WARNING: py:attr reference target not found: pyvista.ImageData.dimensions [ref.attr]
2024-11-21T19:28:52.6255900Z /home/runner/work/pyvista/pyvista/pyvista/core/filters/image_data.py:docstring of pyvista.core.filters.image_data.ImageDataFilters.points_to_cells:29: WARNING: py:attr reference target not found: pyvista.ImageData.dimensions [ref.attr]
2024-11-21T19:28:52.6272305Z /home/runner/work/pyvista/pyvista/pyvista/core/pointset.py:docstring of pyvista.core.pointset.PolyData:35: WARNING: py:obj reference target not found: pv.CellArray [ref.obj]
2024-11-21T19:28:52.6275168Z /home/runner/work/pyvista/pyvista/pyvista/core/pointset.py:docstring of pyvista.core.pointset.PolyData:52: WARNING: py:obj reference target not found: pv.CellArray [ref.obj]
2024-11-21T19:28:52.6278043Z /home/runner/work/pyvista/pyvista/pyvista/core/pointset.py:docstring of pyvista.core.pointset.PolyData:63: WARNING: py:obj reference target not found: pv.CellArray [ref.obj]
2024-11-21T19:28:52.6281055Z /home/runner/work/pyvista/pyvista/pyvista/core/pointset.py:docstring of pyvista.core.pointset.PolyData:97: WARNING: py:obj reference target not found: pv.CellArray [ref.obj]
```