### PR TITLE
Fix even more broken links in documentation

### DIFF
--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -1678,9 +1678,9 @@ class PolyDataFilters(DataSetFilters):
 
         See Also
         --------
-        point_normals
+        pyvista.PolyData.point_normals
             Returns the array of point normals.
-        cell_normals
+        pyvista.PolyData.cell_normals
             Returns the array of cell normals.
 
         Examples

--- a/pyvista/core/utilities/geometric_objects.py
+++ b/pyvista/core/utilities/geometric_objects.py
@@ -66,14 +66,14 @@ def Capsule(
     """Create the surface of a capsule.
 
     .. warning::
-       :func:`pyvista.Capsule` function rotates the :class:`pyvista.CapsuleSource` 's :class:`pyvista.PolyData` in its own way.
-       It rotates the :attr:`pyvista.CapsuleSource.output` 90 degrees in z-axis, translates and
+       :func:`pyvista.Capsule` function rotates the capsule :class:`pyvista.PolyData`
+       in its own way. It rotates the output 90 degrees in z-axis, translates and
        orients the mesh to a new ``center`` and ``direction``.
 
     .. note::
-       A class:`pyvista.CylinderSource` is used to generate the capsule mesh. For vtk versions
-       below 9.3, a class:`pyvista.CapsuleSource` is used instead. The mesh geometries are similar but
-       not identical.
+       A class:`pyvista.CylinderSource` is used to generate the capsule mesh. For vtk
+       versions below 9.3, a separate ``pyvista.CapsuleSource`` class is used instead.
+       The mesh geometries are similar but not identical.
 
     .. versionadded:: 0.44.0
 

--- a/pyvista/core/utilities/parametric_objects.py
+++ b/pyvista/core/utilities/parametric_objects.py
@@ -99,8 +99,8 @@ def KochanekSpline(
     continuity : sequence[float], default: [0.0, 0.0, 0.0]
         Changes the sharpness in change between tangents.
 
-    n_points : int, default: points.shape[0]
-        Number of points on the spline.
+    n_points : int, optional
+        Number of points on the spline. Defaults to ``points.shape[0]``.
 
     Returns
     -------

--- a/pyvista/plotting/affine_widget.py
+++ b/pyvista/plotting/affine_widget.py
@@ -143,7 +143,7 @@ class AffineWidget3D:
     Notes
     -----
     After interacting with the actor, the transform will be stored within
-    :attr:`pyvista.Actor.user_matrix` but will not be applied to the
+    :attr:`pyvista.Prop3D.user_matrix` but will not be applied to the
     dataset. Use this matrix in conjunction with
     :func:`pyvista.DataSetFilters.transform` to transform the dataset.
 

--- a/pyvista/plotting/axes_assembly.py
+++ b/pyvista/plotting/axes_assembly.py
@@ -342,7 +342,7 @@ class AxesAssembly(_XYZAssembly):
 
     origin : VectorLike[float], default: (0.0, 0.0, 0.0)
         Origin of the axes. This is the point about which all rotations take place. The
-        rotations are defined by the :attr:`orientation`.
+        rotations are defined by the :attr:`~pyvista.Prop3D.orientation`.
 
     scale : VectorLike[float], default: (1.0, 1.0, 1.0)
         Scaling factor applied to the axes.
@@ -1007,7 +1007,7 @@ class AxesAssemblySymmetric(AxesAssembly):
 
     origin : VectorLike[float], default: (0.0, 0.0, 0.0)
         Origin of the axes. This is the point about which all rotations take place. The
-        rotations are defined by the :attr:`orientation`.
+        rotations are defined by the :attr:`~pyvista.Prop3D.orientation`.
 
     scale : VectorLike[float], default: (1.0, 1.0, 1.0)
         Scaling factor applied to the axes.
@@ -1341,13 +1341,13 @@ class PlanesAssembly(_XYZAssembly):
 
     label_offset : float | VectorLike[float], optional
         Vertical offset of the text labels. The offset is proportional to
-        the :attr:`length` of the assembly. Positive values move the labels away
+        the :attr:`~pyvista.Prop3D.length` of the assembly. Positive values move the labels away
         from the center; negative values move them towards it.
 
     label_size : int, default: 50
         Size of the text labels. If :attr:`label_mode` is ``'2D'``, this is the
         font size. If :attr:`label_mode` is ``'3D'``, the labels are scaled
-        proportional to the :attr:`length` of the assembly.
+        proportional to the :attr:`~pyvista.Prop3D.length` of the assembly.
 
     label_mode : '2D' | '3D', default: '2D'
         Mode to use for text labels. In 2D mode, the label actors are always visible
@@ -1379,7 +1379,7 @@ class PlanesAssembly(_XYZAssembly):
 
     origin : VectorLike[float], default: (0.0, 0.0, 0.0)
         Origin of the assembly. This is the point about which all rotations take place.
-        The rotations are defined by the :attr:`orientation`.
+        The rotations are defined by the :attr:`~pyvista.Prop3D.orientation`.
 
     scale : VectorLike[float], default: (1.0, 1.0, 1.0)
         Scaling factor applied to the assembly.
@@ -1813,7 +1813,7 @@ class PlanesAssembly(_XYZAssembly):
     def label_offset(self) -> float:  # numpydoc ignore=RT01
         """Vertical offset of the text labels.
 
-        The offset is proportional to the :attr:`length` of the assembly. Positive
+        The offset is proportional to the :attr:`~pyvista.Prop3D.length` of the assembly. Positive
         values move the labels away from the center; negative values move them
         towards it.
         """

--- a/pyvista/plotting/text.py
+++ b/pyvista/plotting/text.py
@@ -250,10 +250,10 @@ class Label(_Prop3DMixin, Text):
     :class:`~pyvista.Actor`.
 
     In addition, this class supports an additional :attr:`relative_position` attribute.
-    In general, it is recommended to simply use :attr:`position` when positioning a
+    In general, it is recommended to simply use :attr:`~pyvista.Prop3D.position` when positioning a
     :class:`Label` by itself. However, if the position of the label depends on the
-    positioning of another actor, both :attr:`position` and :attr:`relative_position`
-    may be used together. In these cases, the :attr:`position` of the label and actor
+    positioning of another actor, both :attr:`~pyvista.Prop3D.position` and :attr:`relative_position`
+    may be used together. In these cases, the :attr:`~pyvista.Prop3D.position` of the label and actor
     should be kept in-sync. See the examples below.
 
     Parameters
@@ -265,7 +265,7 @@ class Label(_Prop3DMixin, Text):
         Position of the text in XYZ coordinates.
 
     relative_position : VectorLike[float]
-        Position of the text in XYZ coordinates relative to its :attr:`position`.
+        Position of the text in XYZ coordinates relative to its :attr:`~pyvista.Prop3D.position`.
 
     size : int
         Size of the text label.
@@ -386,7 +386,7 @@ class Label(_Prop3DMixin, Text):
         """Position of the label in xyz space.
 
         This is the "true" position of the label. Internally this is loosely
-        equal to :attr:`position` + :attr:`relative_position`.
+        equal to :attr:`~pyvista.Prop3D.position` + :attr:`relative_position`.
         """
         return self.GetPositionCoordinate().GetValue()
 
@@ -412,7 +412,7 @@ class Label(_Prop3DMixin, Text):
 
     @property
     def relative_position(self) -> tuple[float, float, float]:  # numpydoc ignore=RT01
-        """Position of the label relative to its :attr:`position`."""
+        """Position of the label relative to its :attr:`~pyvista.Prop3D.position`."""
         return tuple(self._relative_position.tolist())
 
     @relative_position.setter

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -54,7 +54,6 @@ from .tools import parse_font_family
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Callable
 
-    from pyvista.core._typing_core import Number
     from pyvista.core._typing_core import VectorLike
 
     from ._typing import ColorLike
@@ -1469,7 +1468,7 @@ class _TrameConfig(_ThemeConfig):
         self._default_mode = 'trame'
 
     @property
-    def interactive_ratio(self) -> Number:  # numpydoc ignore=RT01
+    def interactive_ratio(self) -> float:  # numpydoc ignore=RT01
         """Return or set the interactive ratio for PyVista Trame views.
 
         Examples
@@ -1481,11 +1480,11 @@ class _TrameConfig(_ThemeConfig):
         return self._interactive_ratio
 
     @interactive_ratio.setter
-    def interactive_ratio(self, interactive_ratio: Number):
+    def interactive_ratio(self, interactive_ratio: float):
         self._interactive_ratio = interactive_ratio  # type: ignore[assignment]
 
     @property
-    def still_ratio(self) -> Number:  # numpydoc ignore=RT01
+    def still_ratio(self) -> float:  # numpydoc ignore=RT01
         """Return or set the still ratio for PyVista Trame views.
 
         Examples
@@ -1497,7 +1496,7 @@ class _TrameConfig(_ThemeConfig):
         return self._still_ratio
 
     @still_ratio.setter
-    def still_ratio(self, still_ratio: Number):
+    def still_ratio(self, still_ratio: float):
         self._still_ratio = still_ratio  # type: ignore[assignment]
 
     @property

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -2469,13 +2469,13 @@ class WidgetHelper:
 
         Returns
         -------
-        pyvista.widgets.AffineWidget3D
+        pyvista.AffineWidget3D
             The affine widget.
 
         Notes
         -----
         After interacting with the actor, the transform will be stored within
-        :attr:`pyvista.Actor.user_matrix` but will not be applied to the
+        :attr:`pyvista.Prop3D.user_matrix` but will not be applied to the
         dataset. Use this matrix in conjunction with
         :func:`pyvista.DataSetFilters.transform` to transform the dataset.
 


### PR DESCRIPTION
### Overview

Similar to #6896, #6897.

<details>

``` yaml

2024-11-21T19:28:52.6320266Z /home/runner/work/pyvista/pyvista/pyvista/core/filters/poly_data.py:docstring of pyvista.core.filters.poly_data.PolyDataFilters.compute_normals:92: WARNING: py:obj reference target not found: point_normals [ref.obj]
2024-11-21T19:28:52.6324127Z /home/runner/work/pyvista/pyvista/pyvista/core/filters/poly_data.py:docstring of pyvista.core.filters.poly_data.PolyDataFilters.compute_normals:94: WARNING: py:obj reference target not found: cell_normals [ref.obj]
2024-11-21T19:28:52.6612840Z /home/runner/work/pyvista/pyvista/pyvista/plotting/axes_assembly.py:docstring of pyvista.plotting.axes_assembly.AxesAssembly:53: WARNING: py:attr reference target not found: orientation [ref.attr]
2024-11-21T19:28:52.6627866Z /home/runner/work/pyvista/pyvista/pyvista/plotting/axes_assembly.py:docstring of pyvista.plotting.axes_assembly.AxesAssemblySymmetric:64: WARNING: py:attr reference target not found: orientation [ref.attr]
2024-11-21T19:28:52.6632747Z /home/runner/work/pyvista/pyvista/pyvista/plotting/text.py:docstring of pyvista.plotting.text.Label:9: WARNING: py:attr reference target not found: position [ref.attr]
2024-11-21T19:28:52.6634298Z /home/runner/work/pyvista/pyvista/pyvista/plotting/text.py:docstring of pyvista.plotting.text.Label:9: WARNING: py:attr reference target not found: position [ref.attr]
2024-11-21T19:28:52.6635824Z /home/runner/work/pyvista/pyvista/pyvista/plotting/text.py:docstring of pyvista.plotting.text.Label:9: WARNING: py:attr reference target not found: position [ref.attr]
2024-11-21T19:28:52.6637361Z /home/runner/work/pyvista/pyvista/pyvista/plotting/text.py:docstring of pyvista.plotting.text.Label:25: WARNING: py:attr reference target not found: position [ref.attr]
2024-11-21T19:28:52.6638941Z /home/runner/work/pyvista/pyvista/doc/source/api/plotting/_autosummary/pyvista.Label.rst:202:<autosummary>:1: WARNING: py:attr reference target not found: position [ref.attr]
2024-11-21T19:28:52.6640850Z /home/runner/work/pyvista/pyvista/pyvista/plotting/text.py:docstring of pyvista.Label.relative_position:2: WARNING: py:attr reference target not found: position [ref.attr]
2024-11-21T19:28:52.6658779Z /home/runner/work/pyvista/pyvista/pyvista/plotting/axes_assembly.py:docstring of pyvista.plotting.axes_assembly.PlanesAssembly:56: WARNING: py:attr reference target not found: length [ref.attr]
2024-11-21T19:28:52.6660522Z /home/runner/work/pyvista/pyvista/pyvista/plotting/axes_assembly.py:docstring of pyvista.plotting.axes_assembly.PlanesAssembly:61: WARNING: py:attr reference target not found: length [ref.attr]
2024-11-21T19:28:52.6662283Z /home/runner/work/pyvista/pyvista/pyvista/plotting/axes_assembly.py:docstring of pyvista.plotting.axes_assembly.PlanesAssembly:94: WARNING: py:attr reference target not found: orientation [ref.attr]
2024-11-21T19:28:52.6664022Z /home/runner/work/pyvista/pyvista/pyvista/plotting/axes_assembly.py:docstring of pyvista.PlanesAssembly.label_offset:4: WARNING: py:attr reference target not found: length [ref.attr]
2024-11-21T19:28:52.6753591Z /home/runner/work/pyvista/pyvista/pyvista/plotting/widgets.py:docstring of pyvista.plotting.widgets.WidgetHelper.add_affine_transform_widget:62: WARNING: py:attr reference target not found: pyvista.Actor.user_matrix [ref.attr]
2024-11-21T19:28:52.6749464Z /home/runner/work/pyvista/pyvista/pyvista/plotting/affine_widget.py:docstring of pyvista.plotting.affine_widget.AffineWidget3D:61: WARNING: py:attr reference target not found: pyvista.Actor.user_matrix [ref.attr]
2024-11-21T19:28:52.6668021Z /home/runner/work/pyvista/pyvista/pyvista/plotting/widgets.py:docstring of pyvista.plotting.widgets.WidgetHelper.add_affine_transform_widget:62: WARNING: py:attr reference target not found: pyvista.Actor.user_matrix [ref.attr]
2024-11-21T19:28:52.6745850Z /home/runner/work/pyvista/pyvista/pyvista/plotting/themes.py:docstring of pyvista.plotting.themes._TrameConfig.interactive_ratio:1: WARNING: py:class reference target not found: Number [ref.class]
2024-11-21T19:28:52.6747615Z /home/runner/work/pyvista/pyvista/pyvista/plotting/themes.py:docstring of pyvista.plotting.themes._TrameConfig.still_ratio:1: WARNING: py:class reference target not found: Number [ref.class]
2024-11-21T19:28:52.6787007Z /home/runner/work/pyvista/pyvista/pyvista/core/utilities/geometric_objects.py:docstring of pyvista.core.utilities.geometric_objects.Capsule:5: WARNING: py:class reference target not found: pyvista.CapsuleSource [ref.class]
2024-11-21T19:28:52.6789094Z /home/runner/work/pyvista/pyvista/pyvista/core/utilities/geometric_objects.py:docstring of pyvista.core.utilities.geometric_objects.Capsule:5: WARNING: py:attr reference target not found: pyvista.CapsuleSource.output [ref.attr]
2024-11-21T19:28:52.6795387Z /home/runner/work/pyvista/pyvista/pyvista/core/utilities/parametric_objects.py:docstring of pyvista.core.utilities.parametric_objects.KochanekSpline:20: WARNING: py:obj reference target not found: points.shape [ref.obj]
2024-11-21T19:28:52.6665914Z /home/runner/work/pyvista/pyvista/pyvista/plotting/widgets.py:docstring of pyvista.plotting.widgets.WidgetHelper.add_affine_transform_widget:50: WARNING: py:obj reference target not found: pyvista.widgets.AffineWidget3D [ref.obj]

```
