### PR TITLE
Add `CellArray` to documentation

### DIFF
--- a/doc/source/api/core/cells.rst
+++ b/doc/source/api/core/cells.rst
@@ -56,3 +56,4 @@ Class Definition
    :toctree: _autosummary
 
    pyvista.Cell
+   pyvista.CellArray


### PR DESCRIPTION
### Overview

This is missing from the docs, causing internal links to `CellArray` to be broken.