### PR TITLE
Make `check_contains` API easier to use and understand

### DIFF
--- a/pyvista/core/_validation/check.py
+++ b/pyvista/core/_validation/check.py
@@ -1036,16 +1036,16 @@ def check_iterable_items(
     )
 
 
-def check_contains(*, item: Any, container: Container[Any], name: str = 'Input') -> None:
+def check_contains(container: Container[Any], /, must_contain: Any, *, name: str = 'Input') -> None:
     """Check if an item is in a container.
 
     Parameters
     ----------
-    item : Any
-        Item to check.
-
     container : Any
-        Container the item is expected to be in.
+        Container to check.
+
+    must_contain : Any
+        Item which must be in the container.
 
     name : str, default: "Input"
         Variable name to use in the error messages if any are raised.
@@ -1053,7 +1053,7 @@ def check_contains(*, item: Any, container: Container[Any], name: str = 'Input')
     Raises
     ------
     ValueError
-        If the string is not in the iterable.
+        If the item is not in the container.
 
     See Also
     --------
@@ -1065,12 +1065,12 @@ def check_contains(*, item: Any, container: Container[Any], name: str = 'Input')
     Check if ``"A"`` is in a list of strings.
 
     >>> from pyvista import _validation
-    >>> _validation.check_contains(item="A", container=["A", "B", "C"])
+    >>> _validation.check_contains(["A", "B", "C"], must_contain="A")
 
     """
-    if item not in container:
+    if must_contain not in container:
         qualifier = 'one of' if isinstance(container, (list, tuple)) else 'in'
-        msg = f"{name} '{item}' is not valid. {name} must be {qualifier}: \n\t{container}"
+        msg = f"{name} '{must_contain}' is not valid. {name} must be {qualifier}: \n\t{container}"
         raise ValueError(msg)
 
 

--- a/pyvista/core/_validation/validate.py
+++ b/pyvista/core/_validation/validate.py
@@ -434,8 +434,8 @@ def validate_axes(
     check_length(axes, exact_length=[1, 2, 3], name=f'{name} arguments')
     if must_have_orientation is not None:
         check_contains(
-            item=must_have_orientation,
-            container=['right', 'left'],
+            ['right', 'left'],
+            must_contain=must_have_orientation,
             name=f'{name} orientation',
         )
     elif must_have_orientation is None and len(axes) == 2:
@@ -542,7 +542,7 @@ def validate_rotation(
 
     """
     check_contains(
-        item=must_have_handedness, container=['right', 'left', None], name='must_have_handedness'
+        ['right', 'left', None], must_contain=must_have_handedness, name='must_have_handedness'
     )
     rotation_matrix = validate_transform3x3(rotation, name=name)
     if not np.allclose(np.linalg.inv(rotation_matrix), rotation_matrix.T):

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -384,7 +384,7 @@ class DataSetFilters:
                 if isinstance(vector, str):
                     vector = vector.lower()
                     valid_strings = list(NORMALS.keys())
-                    _validation.check_contains(item=vector, container=valid_strings, name=name)
+                    _validation.check_contains(valid_strings, must_contain=vector, name=name)
                     vector = NORMALS[vector]
                 vector = _validation.validate_array3(vector, dtype_out=float, name=name)
             return vector
@@ -8483,7 +8483,7 @@ class DataSetFilters:
             return multiblock.combine(merge_points=False).extract_geometry()
 
         # Validate style
-        _validation.check_contains(item=box_style, container=['frame', 'outline', 'face'])
+        _validation.check_contains(['frame', 'outline', 'face'], must_contain=box_style)
 
         # Create box
         source = pyvista.CubeFacesSource(bounds=self.bounds)

--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -3683,8 +3683,8 @@ class AxesGeometrySource:
             return mesh
         else:
             _validation.check_contains(
-                item=geometry,
-                container=AxesGeometrySource.GEOMETRY_TYPES,
+                AxesGeometrySource.GEOMETRY_TYPES,
+                must_contain=geometry,
                 name='Geometry',
             )
             raise NotImplementedError(
@@ -3834,7 +3834,7 @@ class OrthogonalPlanesSource:
     ) -> None:
         def _check_sign(sign_: str) -> None:
             allowed = ['+', '-']
-            _validation.check_contains(item=sign_, container=allowed, name='normal sign')
+            _validation.check_contains(allowed, must_contain=sign_, name='normal sign')
 
         valid_sign: Sequence[str]
         _validation.check_instance(sign, (tuple, list, str), name='normal sign')

--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -457,7 +457,7 @@ class Transform(_vtk.vtkTransform):
     @multiply_mode.setter
     def multiply_mode(self: Transform, multiply_mode: Literal['pre', 'post']) -> None:
         _validation.check_contains(
-            item=multiply_mode, container=['pre', 'post'], name='multiply mode'
+            ['pre', 'post'], must_contain=multiply_mode, name='multiply mode'
         )
         self.pre_multiply() if multiply_mode == 'pre' else self.post_multiply()
 

--- a/pyvista/plotting/axes_assembly.py
+++ b/pyvista/plotting/axes_assembly.py
@@ -1805,7 +1805,9 @@ class PlanesAssembly(_XYZAssembly):
             else _validate_label_sequence(edge, n_labels=3, name='label edge')
         )
         for edge_ in valid_edge:
-            _validation.check_contains(container=['top', 'bottom', 'right', 'left'], item=edge_)
+            _validation.check_contains(
+                ['top', 'bottom', 'right', 'left'], must_contain=edge_, name='label_edge'
+            )
         self._label_edge = tuple(valid_edge)
         self._update_label_positions()
 
@@ -1838,7 +1840,7 @@ class PlanesAssembly(_XYZAssembly):
 
     @label_mode.setter
     def label_mode(self, mode: Literal['2D', '3D']):
-        _validation.check_contains(item=mode, container=['2D', '3D'])
+        _validation.check_contains(['2D', '3D'], must_contain=mode, name='label_mode')
         self._label_mode = mode
         use_2D = mode == '2D'
         for axis in self._axis_actors:

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -878,13 +878,13 @@ def test_check_number():
 
 
 def test_check_contains():
-    check_contains(item='foo', container=['foo', 'bar'])
+    check_contains(['foo', 'bar'], must_contain='foo')
     match = "Input 'foo' is not valid. Input must be one of: \n\t['cat', 'bar']"
     with pytest.raises(ValueError, match=escape(match)):
-        check_contains(item='foo', container=['cat', 'bar'])
+        check_contains(['cat', 'bar'], must_contain='foo')
     match = "_input '5' is not valid. _input must be in: \n\trange(0, 4)"
     with pytest.raises(ValueError, match=escape(match)):
-        check_contains(item=5, container=range(4), name='_input')
+        check_contains(range(4), must_contain=5, name='_input')
 
 
 @pytest.mark.parametrize('name', ['_input', 'Axes'])


### PR DESCRIPTION
### Overview

I find this check particularly confusing to use.  There is ambiguity in the order of operands because typically we do `a in b` in code but when using arguments it's less clear, and the [`operator` module](https://docs.python.org/3/library/operator.html#operator.contains) even reverses the order of the operands.

To address this, `check_contains` currently enforces keyword args only so that `item` and `container` are explicit. I still find this a bit awkward though since it leads to a different order of arguments in code. Every time I see this check I find I have to read it carefulyl and think about whether the arguments are set correctly.

Instead, this PR modifies the API to align it more with the `operator` module, such that the container is the first arg. It also can no longer be used as a keyword, so it _must_ always be the first arg. And the item being checked is renamed to `must_contain` and remains keyword only. Now, when reviewing code, it reads more like "x must contain y" which I think is much more understandable at first glance.

EDIT: This is a breaking change. But the module is private and the documentation states that the API is unstable and subject to change without notice.