### PR TITLE
Ignore documentation reference warnings for `collections`

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -283,6 +283,7 @@ nitpick_ignore_regex = [
     (r'py:.*', '.*UserDict'),
     (r'py:.*', 'sys.float_info.max'),
     (r'py:.*', '.*NoneType'),
+    (r'py:.*', 'collections.*'),
     #
     # NumPy types. TODO: Fix links (intersphinx?)
     (r'py:.*', '.*DTypeLike'),


### PR DESCRIPTION
### Overview

Fix failure from #6935 here:
https://github.com/pyvista/pyvista/actions/runs/12200879988/job/34038017411?pr=6935#step:12:19

```/home/runner/work/pyvista/pyvista/pyvista/core/utilities/arrays.py:docstring of pyvista.core.utilities.arrays.convert_array:1: WARNING: py:class reference target not found: collections.abc.Buffer [ref.class]```

This failure is unrelated to that PR. I suspect this error was not caught by #6895  because of documentation caching.