### PR TITLE
Mark `test_dataset_loader_source_url_blob` as flaky

### DIFF
--- a/tests/examples/test_downloads.py
+++ b/tests/examples/test_downloads.py
@@ -10,6 +10,7 @@ import requests
 import pyvista as pv
 from pyvista import examples
 from pyvista.examples import downloads
+from tests.conftest import flaky_test
 from tests.examples.test_dataset_loader import DatasetLoaderTestCase
 from tests.examples.test_dataset_loader import _generate_dataset_loader_test_cases_from_module
 from tests.examples.test_dataset_loader import _get_mismatch_fail_msg
@@ -38,6 +39,7 @@ def _is_valid_url(url):
         return True
 
 
+@flaky_test
 def test_dataset_loader_source_url_blob(test_case: DatasetLoaderTestCase):
     try:
         # Skip test if not loadable


### PR DESCRIPTION
### Overview

This failure is common:
https://github.com/pyvista/pyvista/actions/runs/12218087918/job/34083120888?pr=6947#step:12:6690
```
FAILED tests/examples/test_downloads.py::test_dataset_loader_source_url_blob[doorman] - AttributeError: type object 'DatasetLoaderTestCase' has no attribute 'dataset_name'
```