### PR TITLE
Ignore `F401` rule for all `__init__.py` files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -363,6 +363,7 @@ unfixable = []
 allow-dict-calls-with-keyword-arguments = true
 
 [tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
 "doc/source/make_tables.py" = ["D101", "D102"]
 "examples/*" = ["D102", "D103", "D205", "D212", "D400", "D415", "SIM115"]
 "examples/**" = [

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -1,6 +1,5 @@
 """PyVista package for 3D plotting and mesh analysis."""
 
-# ruff: noqa: F401
 from __future__ import annotations
 
 import os

--- a/pyvista/core/__init__.py
+++ b/pyvista/core/__init__.py
@@ -1,6 +1,5 @@
 """Core routines."""
 
-# ruff: noqa: F401
 from __future__ import annotations
 
 from . import _vtk_core

--- a/pyvista/core/_typing_core/__init__.py
+++ b/pyvista/core/_typing_core/__init__.py
@@ -4,22 +4,22 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ._aliases import ArrayLike  # noqa: F401
-from ._aliases import BoundsTuple  # noqa: F401
-from ._aliases import CellArrayLike  # noqa: F401
-from ._aliases import CellsLike  # noqa: F401
-from ._aliases import MatrixLike  # noqa: F401
-from ._aliases import Number  # noqa: F401
-from ._aliases import RotationLike  # noqa: F401
-from ._aliases import TransformLike  # noqa: F401
-from ._aliases import VectorLike  # noqa: F401
-from ._array_like import NumberType  # noqa: F401
-from ._array_like import NumpyArray  # noqa: F401
+from ._aliases import ArrayLike
+from ._aliases import BoundsTuple
+from ._aliases import CellArrayLike
+from ._aliases import CellsLike
+from ._aliases import MatrixLike
+from ._aliases import Number
+from ._aliases import RotationLike
+from ._aliases import TransformLike
+from ._aliases import VectorLike
+from ._array_like import NumberType
+from ._array_like import NumpyArray
 
 if TYPE_CHECKING:  # pragma: no cover
     # Avoid circular imports
-    from ._dataset_types import ConcreteDataObjectType  # noqa: F401
-    from ._dataset_types import ConcreteDataSetType  # noqa: F401
-    from ._dataset_types import ConcreteGridType  # noqa: F401
-    from ._dataset_types import ConcretePointGridType  # noqa: F401
-    from ._dataset_types import ConcretePointSetType  # noqa: F401
+    from ._dataset_types import ConcreteDataObjectType
+    from ._dataset_types import ConcreteDataSetType
+    from ._dataset_types import ConcreteGridType
+    from ._dataset_types import ConcretePointGridType
+    from ._dataset_types import ConcretePointSetType

--- a/pyvista/core/_validation/__init__.py
+++ b/pyvista/core/_validation/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-# ruff: noqa: F401
 from .check import check_contains
 from .check import check_finite
 from .check import check_greater_than

--- a/pyvista/core/filters/__init__.py
+++ b/pyvista/core/filters/__init__.py
@@ -23,7 +23,6 @@ Examples
 
 """
 
-# ruff: noqa: F401
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/pyvista/core/utilities/__init__.py
+++ b/pyvista/core/utilities/__init__.py
@@ -1,6 +1,5 @@
 """Utilities routines."""
 
-# ruff: noqa: F401
 from __future__ import annotations
 
 import contextlib

--- a/pyvista/demos/__init__.py
+++ b/pyvista/demos/__init__.py
@@ -1,6 +1,5 @@
 """PyVista Demos."""
 
-# ruff: noqa: F401
 from __future__ import annotations
 
 from pyvista.demos.demos import glyphs

--- a/pyvista/examples/__init__.py
+++ b/pyvista/examples/__init__.py
@@ -1,6 +1,5 @@
 """Examples module."""
 
-# ruff: noqa: F401
 from __future__ import annotations
 
 from . import download_3ds

--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -1,6 +1,5 @@
 """Jupyter notebook plotting module."""
 
-# ruff: noqa: F401
 from __future__ import annotations
 
 import warnings

--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -1,6 +1,5 @@
 """Plotting routines."""
 
-# ruff: noqa: F401
 from __future__ import annotations
 
 from pyvista import MAX_N_COLOR_BARS

--- a/pyvista/plotting/utilities/__init__.py
+++ b/pyvista/plotting/utilities/__init__.py
@@ -1,6 +1,5 @@
 """Plotting utilities."""
 
-# ruff: noqa: F401
 from __future__ import annotations
 
 from .algorithms import active_scalars_algorithm


### PR DESCRIPTION
### Overview

Move the `unused-import` ruff rule `F401` for all `__init__.py` files