### PR TITLE
Switch to trigger for PR label action

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened]
 
 jobs:


### PR DESCRIPTION
Switch from `pull_request_target` to `pull_request` as the even trigger for the labelling GitHub action.

Using `pull_request_target` puts us in a position where someone could open a malicious PR modifying that action to run any arbitrary code with full access to our GitHub token and other secrets