### PR TITLE
Use single quotes in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,9 +141,9 @@ docs = [
 dev = ['pre-commit', 'pyvista[test,typing]']
 
 [project.urls]
-"Bug Tracker" = 'https://github.com/pyvista/pyvista/issues'
+'Bug Tracker' = 'https://github.com/pyvista/pyvista/issues'
 Documentation = 'https://docs.pyvista.org/'
-"Source Code" = 'https://github.com/pyvista/pyvista'
+'Source Code' = 'https://github.com/pyvista/pyvista'
 
 [tool.setuptools.dynamic]
 version = { attr = 'pyvista._version.__version__' }
@@ -153,7 +153,7 @@ include = ['pyvista', 'pyvista.*']
 
 [tool.setuptools.package-data]
 pyvista = ['py.typed']
-"pyvista.examples" = [
+'pyvista.examples' = [
   '2k_earth_daymap.jpg',
   'airplane.ply',
   'ant.ply',
@@ -184,7 +184,7 @@ source-dir = 'doc'
 upload-dir = 'doc/_build/html'
 
 [tool.codespell]
-ignore-words = "doc/styles/Vocab/pyvista/accept.txt"
+ignore-words = 'doc/styles/Vocab/pyvista/accept.txt'
 quiet-level = 3
 skip = '*.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.vtu,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,doc/_build/*,./doc/images/*,./dist/*,*~,.hypothesis*,./doc/examples/*,*.mypy_cache/*,*cover,./tests/tinypages/_build/*,*/_autosummary/*'
 
@@ -207,7 +207,7 @@ filterwarnings = [
   'ignore::FutureWarning',
   'ignore::PendingDeprecationWarning',
 ]
-image_cache_dir = "tests/plotting/image_cache"
+image_cache_dir = 'tests/plotting/image_cache'
 junit_family = 'legacy'
 markers = [
   'needs_download: this test downloads data during execution',
@@ -218,7 +218,7 @@ testpaths = 'tests'
 [tool.mypy]
 check_untyped_defs = true
 disallow_any_generics = true
-enable_error_code = ["ignore-without-code"]
+enable_error_code = ['ignore-without-code']
 exclude = ['pyvista/ext/']
 extra_checks = true
 ignore_missing_imports = true
@@ -233,31 +233,31 @@ warn_unused_ignores = true
 
 [tool.numpydoc_validation]
 checks = [
-  "all", # all but the following:
+  'all', # all but the following:
   #
-  "ES01", # Not all docstrings need an extend summary.
-  "EX01", # Examples: Will eventually enforce
-  "GL01", # Contradicts numpydoc examples
-  "GL02", # Permit a blank line after the end of our docstring
-  "GL03", # Considering enforcing
-  "GL06", # Found unknown section
-  "GL07", # "Sections are in the wrong order. Correct order is: {correct_sections}",
-  "GL08", # The object does not have a docstring
-  "GL09", # Deprecation warning should precede extended summary (check broken)
-  "PR01", # "Parameters {missing_params} not documented",
-  "PR02", # "Unknown parameters {unknown_params}",
-  "PR03", # "Wrong parameters order. Actual: {actual_params}. Documented: {documented_params}",
-  "PR04", # 'Parameter "{param_name}" has no type',
-  "PR05", # 'Parameter "{param_name}" type should not finish with "."',
-  "PR06", # 'Parameter "{param_name}" type should use "{right_type}" instead of "{wrong_type}"',
-  "PR07", # 'Parameter "{param_name}" has no description',
-  "PR08", # 'Parameter "{param_name}" description should start with a capital letter",
-  "PR09", # 'Parameter "{param_name}" description should finish with "."',
-  "PR10", # 'Parameter "{param_name}" requires a space before the colon separating the parameter name and type",
-  "SA01", # Not all docstrings need a see also
-  "SA04", # See also section does not need descriptions
-  "SS05", # Appears to be broken.
-  "YD01", # Yields: No plan to enforce
+  'ES01', # Not all docstrings need an extend summary.
+  'EX01', # Examples: Will eventually enforce
+  'GL01', # Contradicts numpydoc examples
+  'GL02', # Permit a blank line after the end of our docstring
+  'GL03', # Considering enforcing
+  'GL06', # Found unknown section
+  'GL07', # 'Sections are in the wrong order. Correct order is: {correct_sections}',
+  'GL08', # The object does not have a docstring
+  'GL09', # Deprecation warning should precede extended summary (check broken)
+  'PR01', # 'Parameters {missing_params} not documented',
+  'PR02', # 'Unknown parameters {unknown_params}',
+  'PR03', # 'Wrong parameters order. Actual: {actual_params}. Documented: {documented_params}',
+  'PR04', # 'Parameter "{param_name}" has no type',
+  'PR05', # 'Parameter "{param_name}" type should not finish with "."',
+  'PR06', # 'Parameter "{param_name}" type should use "{right_type}" instead of "{wrong_type}"',
+  'PR07', # 'Parameter "{param_name}" has no description',
+  'PR08', # 'Parameter "{param_name}" description should start with a capital letter",
+  'PR09', # 'Parameter "{param_name}" description should finish with "."',
+  'PR10', # 'Parameter "{param_name}" requires a space before the colon separating the parameter name and type",
+  'SA01', # Not all docstrings need a see also
+  'SA04', # See also section does not need descriptions
+  'SS05', # Appears to be broken.
+  'YD01', # Yields: No plan to enforce
 ]
 exclude = [ # don't report on objects that match any of these regex
   '\.*Reader(\.|$)',        # classes inherit from BaseReader
@@ -274,89 +274,89 @@ line-length = 100
 
 [tool.ruff.format]
 docstring-code-format = false
-quote-style = "single"
+quote-style = 'single'
 
 [tool.ruff.lint]
 extend-select = [
-  "A",
-  "AIR",
-  "ANN",
-  "ASYNC",
-  "ASYNC1",
-  "B",
-  "C4",
-  "COM",
-  "D",
-  "DJ",
-  "DTZ",
-  "E",
-  "F",
-  "FA",
-  "FLY",
-  "I",
-  "ICN",
-  "INT",
-  "ISC",
-  "LOG",
-  "NPY",
-  "PERF",
-  "PGH",
-  "PIE",
-  "PLC",
-  "PLR0402",
-  "PLR1711",
-  "PLR1714",
-  "PLW0127",
-  "PT",
-  "PTH",
-  "PYI",
-  "Q",
-  "RET",
-  "RSE",
-  "RUF",
-  "SIM",
-  "T10",
-  "TCH",
-  "TRY201",
-  "TRY203",
-  "TRY300",
-  "UP",
-  "W",
-  "YTT",
+  'A',
+  'AIR',
+  'ANN',
+  'ASYNC',
+  'ASYNC1',
+  'B',
+  'C4',
+  'COM',
+  'D',
+  'DJ',
+  'DTZ',
+  'E',
+  'F',
+  'FA',
+  'FLY',
+  'I',
+  'ICN',
+  'INT',
+  'ISC',
+  'LOG',
+  'NPY',
+  'PERF',
+  'PGH',
+  'PIE',
+  'PLC',
+  'PLR0402',
+  'PLR1711',
+  'PLR1714',
+  'PLW0127',
+  'PT',
+  'PTH',
+  'PYI',
+  'Q',
+  'RET',
+  'RSE',
+  'RUF',
+  'SIM',
+  'T10',
+  'TCH',
+  'TRY201',
+  'TRY203',
+  'TRY300',
+  'UP',
+  'W',
+  'YTT',
 ]
-external = ["E131"]
-fixable = ["ALL"]
+external = ['E131']
+fixable = ['ALL']
 ignore = [
-  "ANN002",  # Missing annotations for `*args`
-  "ANN003",  # Missing annotations for `*kwargs`
-  "ANN401",  # Disallow `Any`
-  "B028",    # https://github.com/pyvista/pyvista/pull/6030
-  "B904",    # https://github.com/pyvista/pyvista/pull/6022
-  "COM812",  # May cause conflicts when used with the formatter
-  "D105",    # Missing docstring in magic method
-  "D107",    # Missing docstring in `__init__`
-  "D203",    # May conflict with the formatter
-  "D211",    # Incompatible with D203
-  "D213",    # Incompatible with D212
-  "D402",    # First line should not be the function's signature
-  "D416",    # Section name ends in colon
-  "E203",    # whitespace before ':'
-  "E266",    # too many leading '#' for block comment
-  "E402",    # module level import not at top of file
-  "E501",    # line length too long
-  "E722",
-  "E731",    # do not assign a lambda expression, use a def
-  "E741",    # ambiguous variable name
-  "F403",    # 'from module import *' used; unable to detect undefined names
-  "ISC001",  # May cause conflicts when used with the formatter
-  "PERF203", # https://github.com/pyvista/pyvista/pull/6037
-  "Q0",      # Quotes (temporary)
-  "RET505",  # https://github.com/pyvista/pyvista/pull/5911
-  "RET506",  # https://github.com/pyvista/pyvista/pull/5911
-  "RET507",  # https://github.com/pyvista/pyvista/pull/5911
-  "SIM102",  # https://github.com/pyvista/pyvista/pull/5877
-  "SIM117",  # https://github.com/pyvista/pyvista/pull/5888
-  "SIM118",  # https://github.com/pyvista/pyvista/pull/5837
+  'ANN002',  # Missing annotations for `*args`
+  'ANN003',  # Missing annotations for `*kwargs`
+  'ANN401',  # Disallow `Any`
+  'B028',    # https://github.com/pyvista/pyvista/pull/6030
+  'B904',    # https://github.com/pyvista/pyvista/pull/6022
+  'COM812',  # May cause conflicts when used with the formatter
+  'D105',    # Missing docstring in magic method
+  'D107',    # Missing docstring in `__init__`
+  'D203',    # May conflict with the formatter
+  'D211',    # Incompatible with D203
+  'D213',    # Incompatible with D212
+  'D402',    # First line should not be the function's signature
+  'D416',    # Section name ends in colon
+  'E203',    # whitespace before ':'
+  'E266',    # too many leading '#' for block comment
+  'E402',    # module level import not at top of file
+  'E501',    # line length too long
+  'E722',
+  'E731',    # do not assign a lambda expression, use a def
+  'E741',    # ambiguous variable name
+  'F403',    # 'from module import *' used; unable to detect undefined names
+  'ISC001',  # May cause conflicts when used with the formatter
+  'PERF203', # https://github.com/pyvista/pyvista/pull/6037
+  'Q0',      # Quotes (temporary)
+  'RET505',  # https://github.com/pyvista/pyvista/pull/5911
+  'RET506',  # https://github.com/pyvista/pyvista/pull/5911
+  'RET507',  # https://github.com/pyvista/pyvista/pull/5911
+  'SIM102',  # https://github.com/pyvista/pyvista/pull/5877
+  'SIM117',  # https://github.com/pyvista/pyvista/pull/5888
+  'SIM118',  # https://github.com/pyvista/pyvista/pull/5837
 ]
 unfixable = []
 
@@ -364,62 +364,62 @@ unfixable = []
 allow-dict-calls-with-keyword-arguments = true
 
 [tool.ruff.lint.per-file-ignores]
-"__init__.py" = ["F401"]
-"doc/source/make_tables.py" = ["D101", "D102"]
-"examples/*" = ["D102", "D103", "D205", "D212", "D400", "D415", "SIM115"]
-"examples/**" = [
-  "B015", # https://github.com/pyvista/pyvista/pull/6014
-  "B018", # https://github.com/pyvista/pyvista/pull/6019
+'__init__.py' = ['F401']
+'doc/source/make_tables.py' = ['D101', 'D102']
+'examples/*' = ['D102', 'D103', 'D205', 'D212', 'D400', 'D415', 'SIM115']
+'examples/**' = [
+  'B015', # https://github.com/pyvista/pyvista/pull/6014
+  'B018', # https://github.com/pyvista/pyvista/pull/6019
 ]
-"examples_trame/*" = ["D100", "D103"]
-"examples_trame/tests*" = ["D"]
-"pyvista/ext/*" = ["D100", "D101", "D102", "D103"]
-"tests/*" = ["D"]
+'examples_trame/*' = ['D100', 'D103']
+'examples_trame/tests*' = ['D']
+'pyvista/ext/*' = ['D100', 'D101', 'D102', 'D103']
+'tests/*' = ['D']
 
 # ANN ignores for `pyvista/core`
 # TODO: Add annotations to any files listed below and remove it from this list
-"pyvista/core/_validation/_cast_array.py" = ["ANN"]
-"pyvista/core/_validation/validate.py" = ["ANN202"]
-"pyvista/core/_vtk_core.py" = ["ANN"]
-"pyvista/core/errors.py" = ["ANN"]
-"pyvista/core/filters**" = ["ANN"]
-"pyvista/core/objects.py" = ["ANN"]
-"pyvista/core/partitioned.py" = ["ANN"]
-"pyvista/core/pointset.py" = ["ANN"]
-"pyvista/core/utilities/cell.py" = ["ANN"]
-"pyvista/core/utilities/cells.py" = ["ANN"]
-"pyvista/core/utilities/docs.py" = ["ANN"]
-"pyvista/core/utilities/features.py" = ["ANN"]
-"pyvista/core/utilities/helpers.py" = ["ANN"]
-"pyvista/core/utilities/image_sources.py" = ["ANN"]
-"pyvista/core/utilities/observers.py" = ["ANN"]
-"pyvista/core/utilities/reader.py" = ["ANN"]
+'pyvista/core/_validation/_cast_array.py' = ['ANN']
+'pyvista/core/_validation/validate.py' = ['ANN202']
+'pyvista/core/_vtk_core.py' = ['ANN']
+'pyvista/core/errors.py' = ['ANN']
+'pyvista/core/filters**' = ['ANN']
+'pyvista/core/objects.py' = ['ANN']
+'pyvista/core/partitioned.py' = ['ANN']
+'pyvista/core/pointset.py' = ['ANN']
+'pyvista/core/utilities/cell.py' = ['ANN']
+'pyvista/core/utilities/cells.py' = ['ANN']
+'pyvista/core/utilities/docs.py' = ['ANN']
+'pyvista/core/utilities/features.py' = ['ANN']
+'pyvista/core/utilities/helpers.py' = ['ANN']
+'pyvista/core/utilities/image_sources.py' = ['ANN']
+'pyvista/core/utilities/observers.py' = ['ANN']
+'pyvista/core/utilities/reader.py' = ['ANN']
 
 # ANN ignores for `pyvista/plotting`
-"pyvista/plotting*" = ["ANN"]
+'pyvista/plotting*' = ['ANN']
 
 # All other ANN ignores
-"doc*" = ["ANN"]
-"examples*" = ["ANN"]
-"pyvista/__init__.py" = ["ANN"]
-"pyvista/_plot.py" = ["ANN"]
-"pyvista/conftest.py" = ["ANN"]
-"pyvista/demos*" = ["ANN"]
-"pyvista/errors.py" = ["ANN"]
-"pyvista/examples*" = ["ANN"]
-"pyvista/ext*" = ["ANN"]
-"pyvista/jupyter*" = ["ANN"]
-"pyvista/report.py" = ["ANN"]
-"pyvista/trame*" = ["ANN"]
-"pyvista/utilities/__init__.py" = ["ANN"]
-"tests*" = ["ANN"]
+'doc*' = ['ANN']
+'examples*' = ['ANN']
+'pyvista/__init__.py' = ['ANN']
+'pyvista/_plot.py' = ['ANN']
+'pyvista/conftest.py' = ['ANN']
+'pyvista/demos*' = ['ANN']
+'pyvista/errors.py' = ['ANN']
+'pyvista/examples*' = ['ANN']
+'pyvista/ext*' = ['ANN']
+'pyvista/jupyter*' = ['ANN']
+'pyvista/report.py' = ['ANN']
+'pyvista/trame*' = ['ANN']
+'pyvista/utilities/__init__.py' = ['ANN']
+'tests*' = ['ANN']
 
 [tool.ruff.lint.isort]
-combine-as-imports = true # Combines "as" imports on the same line
+combine-as-imports = true # Combines 'as' imports on the same line
 force-single-line = true # https://github.com/pyvista/pyvista/pull/5712
-force-sort-within-sections = true # Sort by name, don't cluster "from" vs "import"
+force-sort-within-sections = true # Sort by name, don't cluster 'from' vs 'import'
 required-imports = [
-  "from __future__ import annotations", # https://github.com/pyvista/pyvista/pull/5712
+  'from __future__ import annotations', # https://github.com/pyvista/pyvista/pull/5712
 ]
 
 [tool.ruff.lint.pyupgrade]


### PR DESCRIPTION
### Overview

We use `ruff` to enforce single quotes in python code. I propose using single quotes in `pyproject.toml` as well.

The changes are all manual. The `toml` formatter we use (`taplo`) doesn't seem to support auto-formatting quotes.