### PR TITLE
Fix type annotation for `pyvista.core.filters.data_set.contour`

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2044,8 +2044,8 @@ class DataSetFilters:
 
     def contour(  # type: ignore[misc]
         self: ConcreteDataSetType,
-        isosurfaces: int = 10,
-        scalars: str | None = None,
+        isosurfaces: int | Sequence[float] = 10,
+        scalars: str | VectorLike[float] | None = None,
         compute_normals: bool = False,
         compute_gradients: bool = False,
         compute_scalars: bool = True,


### PR DESCRIPTION
### Overview

According to the docstring of [`pyvista.core.filters.data_set.contour`](https://github.com/pyvista/pyvista/blob/main/pyvista/core/filters/data_set.py#L2045-L2073), the argument  `isosurfaces` can take an int or a sequence of floats. However, the type annotation only sais `int`, so adding `Sequence[float]`.
Similarly, the argument `scalars` can take an optional `str` or an `array_like` float, but type annotation only say optional `str`, so adding `VectorLike[float]` here as well.
