### PR TITLE
Deprecate dataset_filters.transform defaulting to inplace=True

### DIFF
--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -227,7 +227,7 @@ class CompositeFilters:
         self,
         trans: TransformLike,
         transform_all_input_vectors: bool = False,
-        inplace: bool = True,
+        inplace: bool = True,  # TODO also needs deprecation warning
         progress_bar: bool = False,
     ):
         """Transform all blocks in this composite dataset.
@@ -272,7 +272,7 @@ class CompositeFilters:
         >>> import pyvista as pv
         >>> mesh = pv.MultiBlock([pv.Sphere(), pv.Plane()])
         >>> transform = pv.Transform().translate(50, 100, 200)
-        >>> transformed = mesh.transform(transform)
+        >>> transformed = mesh.transform(transform, inplace=False)
         >>> transformed.plot(show_edges=True)
 
         """

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -7024,7 +7024,7 @@ class DataSetFilters:
         self: ConcreteDataSetType,
         trans: TransformLike,
         transform_all_input_vectors: bool = False,
-        inplace: bool = True,
+        inplace: bool | None = None,
         progress_bar: bool = False,
     ):
         """Transform this mesh with a 4x4 transform.
@@ -7068,8 +7068,12 @@ class DataSetFilters:
             transformed. Otherwise, only the normals and vectors are
             transformed.  See the warning for more details.
 
-        inplace : bool, default: False
+        inplace : bool, default: True
             When ``True``, modifies the dataset inplace.
+
+            .. deprecated:: 0.45.0
+            `inplace` was previously defaulted to `True`. For API consistency this will be
+            changed to `False`.
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
@@ -7105,10 +7109,20 @@ class DataSetFilters:
         ...         [0, 0, 0, 1],
         ...     ]
         ... )
-        >>> transformed = mesh.transform(transform_matrix)
+        >>> transformed = mesh.transform(transform_matrix, inplace=False)
         >>> transformed.plot(show_edges=True)
 
         """
+        if inplace is None:
+            warnings.warn(
+                """
+The default value of `inplace` for the `dataset.transform` filter will change in the future.
+ Previously it defaulted to `True`, but will change to `False`.
+ Explictly set `inplace` to `True` or `False` to silence this warning. """,
+                PyVistaDeprecationWarning,
+            )
+            inplace = True  # The old default behavior
+
         if inplace and isinstance(self, pyvista.RectilinearGrid):
             raise TypeError(f'Cannot transform a {self.__class__} inplace')
 
@@ -8492,7 +8506,7 @@ class DataSetFilters:
             if box_style == 'outline':
                 face.copy_from(pyvista.lines_from_points(face.points))
             if oriented:
-                face.transform(inverse_matrix)
+                face.transform(inverse_matrix, inplace=True)
 
         # Get output
         alg_output = box if as_composite else _multiblock_to_polydata(box)

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -196,7 +196,7 @@ class _PointSet(DataSet):
         self: ConcretePointSetType,
         xyz: VectorLike[float],
         transform_all_input_vectors: bool = False,
-        inplace=None,
+        inplace=False,
     ):
         """Translate the mesh.
 

--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -84,7 +84,7 @@ def translate(
     trans[:3, 2] = normz
     trans[3, 3] = 1
 
-    surf.transform(trans)
+    surf.transform(trans, inplace=True)
     if not np.allclose(center, [0.0, 0.0, 0.0]):
         surf.points += np.array(center, dtype=surf.points.dtype)
 

--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -211,7 +211,7 @@ class Transform(_vtk.vtkTransform):
     produce different transformations.
 
     >>> mesh_post = pv.Sphere().transform(transform_post)
-    >>> mesh_pre = pv.Cone().transform(transform_pre)
+    >>> mesh_pre = pv.Cone().transform(transform_pre, inplace=False)
     >>> pl = pv.Plotter()
     >>> _ = pl.add_mesh(mesh_post, color='goldenrod')
     >>> _ = pl.add_mesh(mesh_pre, color='teal')
@@ -245,7 +245,7 @@ class Transform(_vtk.vtkTransform):
     Transform the mesh by its inverse to restore it to its original un-scaled state
     and positioning at the origin.
 
-    >>> mesh_pre_inverted = mesh_pre.transform(inverse_matrix)
+    >>> mesh_pre_inverted = mesh_pre.transform(inverse_matrix, inplace=False)
     >>> pl = pv.Plotter()
     >>> _ = pl.add_mesh(mesh_pre_inverted, color='teal')
     >>> _ = pl.add_axes_at_origin()

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -3682,7 +3682,13 @@ def test_transform_imagedata_warns_with_shear(uniform):
         match='The transformation matrix has a shear component which has been removed. \n'
         'Shear is not supported when setting `ImageData` `index_to_physical_matrix`.',
     ):
-        uniform.transform(shear)
+        uniform.transform(shear, inplace=True)
+
+
+def test_transform_filter_inplace_default_warns(cube):
+    expected_msg = 'The default value of `inplace` for the `dataset.transform` filter will change in the future.'
+    with pytest.warns(PyVistaDeprecationWarning, match=expected_msg):
+        _ = cube.transform(np.eye(4))
 
 
 def test_reflect_mesh_about_point(datasets):
@@ -3783,7 +3789,7 @@ def test_transform_should_match_vtk_transformation(rotate_amounts, translate_amo
 
     # Apply transform with pyvista filter
     grid_a = grid.copy()
-    grid_a.transform(trans)
+    grid_a.transform(trans, inplace=True)
 
     # Apply transform with vtk filter
     grid_b = grid.copy()
@@ -3808,7 +3814,7 @@ def test_transform_should_match_vtk_transformation_non_homogeneous(rotate_amount
     trans_rotate_only.Update()
 
     grid_copy = grid.copy()
-    grid_copy.transform(trans_rotate_only)
+    grid_copy.transform(trans_rotate_only, inplace=True)
 
     from pyvista.core.utilities.transformations import apply_transformation_to_points
 
@@ -3819,7 +3825,7 @@ def test_transform_should_match_vtk_transformation_non_homogeneous(rotate_amount
 
 def test_translate_should_not_fail_given_none(grid):
     bounds = grid.bounds
-    grid.transform(None)
+    grid.transform(None, inplace=True)
     assert grid.bounds == bounds
 
 
@@ -3844,7 +3850,7 @@ def test_transform_should_fail_given_wrong_numpy_shape(array, grid):
     assume(array.shape not in [(3, 3), (4, 4)])
     match = 'Shape must be one of [(3, 3), (4, 4)]'
     with pytest.raises(ValueError, match=re.escape(match)):
-        grid.transform(array)
+        grid.transform(array, inplace=True)
 
 
 @pytest.mark.parametrize('axis_amounts', [[1, 1, 1], [0, 0, 0], [-1, -1, -1]])
@@ -4436,7 +4442,7 @@ def test_bounding_box_as_composite(sphere, as_composite, mesh_type):
 def test_oriented_bounding_box():
     rotation = pv.transformations.axis_angle_rotation((1, 2, 3), 30)
     box_mesh = pv.Cube(x_length=1, y_length=2, z_length=3)
-    box_mesh.transform(rotation)
+    box_mesh.transform(rotation, inplace=True)
     obb = box_mesh.oriented_bounding_box()
     assert obb.bounds == box_mesh.bounds
 
@@ -4451,7 +4457,7 @@ def test_bounding_box_return_meta(oriented, as_composite):
 
     # Transform a box manually and get its OBB
     box_mesh = pv.Cube(x_length=1, y_length=2, z_length=3)
-    box_mesh.transform(rotation)
+    box_mesh.transform(rotation, inplace=True)
     obb, point, axes = box_mesh.bounding_box(
         oriented=oriented, return_meta=True, as_composite=as_composite
     )

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -1139,7 +1139,7 @@ def test_imagedata_direction_matrix():
 
     # Test bounds using a transformed reference box
     box = pv.Box(bounds=initial_bounds)
-    box.transform(image.index_to_physical_matrix)
+    box.transform(image.index_to_physical_matrix, inplace=True)
     expected_bounds = box.bounds
     assert np.allclose(image.bounds, expected_bounds)
 


### PR DESCRIPTION
Cf #7027

Draft PR, just curious how much churn a soft-deprecation would be. 

1. Change the actual default of `inplace` to `None`. If called with `inplace=None`, raise a deprecation warning asking the user to explicitly supply a True/False value for `inplace`, but continue on with `inplace=True` so backwards compatibility is maintained.

2. Change the documentation to correctly indicate the default value is actually `True`, but add a deprecation note confirming the default will change in the future to `inplace=False`.

3. Try to find all the places `transform` is called in the codebase and make sure inplace is specified explicitly.

TODO:
- [ ] Didn't run all the tests locally, assume a bunch more will fail
- [ ] `CompositeFilters.transform` also defaults to True, need to add deprecations there too
- [ ] Add required version checks in the tests so the deprecation warning becomes an error, etc

