### PR TITLE
Fix undefined variable exception in conditional check for `Rotation` import

### DIFF
--- a/pyvista/core/_typing_core/_aliases.py
+++ b/pyvista/core/_typing_core/_aliases.py
@@ -18,10 +18,10 @@ from ._array_like import _ArrayLike2D
 if TYPE_CHECKING or os.environ.get(
     'PYVISTA_DOCUMENTATION_BULKY_IMPORTS_ALLOWED'
 ):  # pragma: no cover
-    import contextlib
-
-    with contextlib.suppress(ImportError):
+    try:
         from scipy.spatial.transform import Rotation
+    except ImportError:
+        Rotation = None
 else:
     Rotation = None
 


### PR DESCRIPTION
I made a small mistake in #7023 

the conditional check prior to that was `if 'Rotation' in locals()`, which became `if Rotation is not None`, but since the `ImportError` was suppressed, it would be possible to get an undefined variable exception if importing during `TYPE_CHECKING` or a documentation build where `scipy` is not importable