### PR TITLE
Filter `pytest` warning for acessing user data path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,7 @@ filterwarnings = [
   'ignore:.*numpy.dtype size changed.*:RuntimeWarning',                                       # bogus numpy ABI warning (see numpy/#432)
   'ignore:.*numpy.ufunc size changed.*:RuntimeWarning',                                       # bogus numpy ABI warning (see numpy/#432)
   'ignore:Passing .{1}N.{1} to ListedColormap is deprecated since:DeprecationWarning',        # https://github.com/matplotlib/cmocean/pull/114
+  'ignore:Unable to access.*Manually specify the PyVista examples cache.*:UserWarning',       # https://github.com/pyvista/pyvista/pull/7009#issuecomment-2599890364
   'ignore:pyvista test generated image dir.* does not yet exist.  Creating dir.:UserWarning',
 
   'always:.*Exceeded image regression warning of .* with an image error of .*:UserWarning',

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -100,7 +100,7 @@ else:
             # Warn, don't raise just in case there's an environment issue.
             warnings.warn(
                 f'Unable to access {USER_DATA_PATH}. Manually specify the PyVista'
-                'examples cache with the PYVISTA_USERDATA_PATH environment variable.',
+                ' examples cache with the PYVISTA_USERDATA_PATH environment variable.',
             )
 
 # Note that our fetcher doesn't have a registry (or we have an empty registry)


### PR DESCRIPTION
### Overview

A warning is emitted unexpectedly for Windows (see https://github.com/pyvista/pyvista/pull/7009#issuecomment-2599890364).
It was not caught in the [original PR](https://github.com/pyvista/pyvista/pull/7009) but now leaks all over the place (see recent PR failures [here](https://github.com/pyvista/pyvista/actions/runs/12847444079/job/35823759196?pr=7101#step:9:28) for example).

This PR is a quick fix to ignore it.