### PR TITLE
Optimize pyvista.DataSetFilters.extract_cells() when invert=True

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5416,8 +5416,9 @@ class DataSetFilters:
         if invert:
             ind_: VectorLike[int]
             _, ind_ = numpy_to_idarr(ind, return_ind=True)  # type: ignore[misc]
-            ind_ = [i for i in range(self.n_cells) if i not in ind_]
-            ids = numpy_to_idarr(ind_)
+            mask = np.ones(self.n_cells, bool)
+            mask[ind_] = False
+            ids = numpy_to_idarr(mask)
         else:
             ids = numpy_to_idarr(ind)
 


### PR DESCRIPTION
### Overview

Fixes #7103 by replacing inefficient ``in`` operator which has O(n) time complexity with a simple mask array.