### PR TITLE
Remove `__matmul__` operator from `Transform` class

### DIFF
--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -173,18 +173,6 @@ class Transform(_vtk.vtkTransform):
     >>> transform_pre = pv.Transform().pre_multiply()
     >>> _ = transform_pre.translate(position).scale(scale_factor)
 
-    Alternatively, create the transform using matrix multiplication. Matrix
-    multiplication concatenates the transformations using pre-multiply semantics such
-    that the transformations are applied in order from right to left, i.e. scale first,
-    then translate.
-
-    >>> transform_pre = translation_T @ scaling_T
-    >>> transform_pre.matrix
-    array([[ 2. ,  0. ,  0. , -0.6],
-           [ 0. ,  2. ,  0. , -0.8],
-           [ 0. ,  0. ,  2. ,  2.1],
-           [ 0. ,  0. ,  0. ,  1. ]])
-
     This is equivalent to using matrix multiplication directly on the arrays:
 
     >>> mat_mul = translation_T.matrix @ scaling_T.matrix
@@ -338,21 +326,6 @@ class Transform(_vtk.vtkTransform):
             raise ValueError(
                 f"Unsupported operand value(s) for *: '{type(other).__name__}' and '{self.__class__.__name__}'\n"
                 f'The left-side argument must be a single number or a length-3 vector.'
-            )
-
-    def __matmul__(self: Transform, other: TransformLike) -> Transform:
-        """:meth:`concatenate` this transform using pre-multiply semantics."""
-        try:
-            return self.copy().concatenate(other, multiply_mode='pre')
-        except TypeError:
-            raise TypeError(
-                f"Unsupported operand type(s) for @: '{self.__class__.__name__}' and '{type(other).__name__}'\n"
-                f'The right-side argument must be transform-like.'
-            )
-        except ValueError:
-            raise ValueError(
-                f"Unsupported operand value(s) for @: '{self.__class__.__name__}' and '{type(other).__name__}'\n"
-                f'The right-side argument must be transform-like.'
             )
 
     def copy(self: Transform) -> Transform:

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -1631,23 +1631,6 @@ def test_transform_rmul(scale_factor):
     assert np.array_equal(transform_mul.matrix, transform_scale.matrix)
 
 
-def test_transform_matmul():
-    scale = Transform().scale(SCALE)
-    translate = Transform().translate(VECTOR)
-
-    transform = pv.Transform().pre_multiply().translate(VECTOR).scale(SCALE)
-    transform_matmul = translate @ scale
-    assert np.array_equal(transform_matmul.matrix, transform.matrix)
-
-    # Test multiply mode override to ensure pre-multiply is always used
-    transform_matmul = translate.post_multiply() @ scale.post_multiply()
-    assert np.array_equal(transform_matmul.matrix, transform.matrix)
-
-    # Validate with numpy matmul
-    matrix_numpy = translate.matrix @ scale.matrix
-    assert np.array_equal(transform_matmul.matrix, matrix_numpy)
-
-
 def test_transform_add_raises():
     match = (
         "Unsupported operand value(s) for +: 'Transform' and 'int'\n"
@@ -1710,22 +1693,6 @@ def test_transform_mul_raises():
     )
     with pytest.raises(TypeError, match=re.escape(match)):
         pv.Transform() * {}
-
-
-def test_transform_matmul_raises():
-    match = (
-        "Unsupported operand value(s) for @: 'Transform' and 'tuple'\n"
-        'The right-side argument must be transform-like.'
-    )
-    with pytest.raises(ValueError, match=re.escape(match)):
-        pv.Transform() @ (1, 2, 3, 4)
-
-    match = (
-        "Unsupported operand type(s) for @: 'Transform' and 'dict'\n"
-        'The right-side argument must be transform-like.'
-    )
-    with pytest.raises(TypeError, match=re.escape(match)):
-        pv.Transform() @ {}
 
 
 @pytest.mark.parametrize('multiply_mode', ['pre', 'post'])


### PR DESCRIPTION
### Overview

See #7097. Using `__matmul__` can be confusing and is not consistent with the scipy API for transformations.

cc @darikg 