### PR TITLE
Add `Transform` decomposition properties

### DIFF
--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -1824,7 +1824,7 @@ class Transform(_vtk.vtkTransform):
         Returns
         -------
         numpy.ndarray
-            Translation component ``T`` as a 3-element vector.
+            Translation component as a 3-element vector.
 
         """
         return self.matrix[:3, 3]
@@ -1841,7 +1841,7 @@ class Transform(_vtk.vtkTransform):
         Returns
         -------
         numpy.ndarray
-            Rotation component ``R`` as a 3x3 orthonormal rotation matrix of row vectors.
+            Rotation component as a 3x3 orthonormal rotation matrix of row vectors.
 
         """
         return self.decompose()[1]
@@ -1861,7 +1861,7 @@ class Transform(_vtk.vtkTransform):
         Returns
         -------
         numpy.ndarray
-            Reflection component ``N`` as a NumPy scalar.
+            Reflection component as a NumPy scalar.
 
         """
         return self.decompose()[2]
@@ -1878,7 +1878,7 @@ class Transform(_vtk.vtkTransform):
         Returns
         -------
         numpy.ndarray
-            Scaling component ``S`` as a 3-element vector.
+            Scaling component as a 3-element vector.
 
         """
         return self.decompose()[3]
@@ -1895,7 +1895,7 @@ class Transform(_vtk.vtkTransform):
         Returns
         -------
         numpy.ndarray
-            Shear component ``K`` as a 3x3 matrix with ones on the diagonal and
+            Shear component as a 3x3 matrix with ones on the diagonal and
             shear values in the off-diagonals.
 
         """

--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -1812,6 +1812,95 @@ class Transform(_vtk.vtkTransform):
             homogeneous=homogeneous,
         )
 
+    @property
+    def translation(self: Transform) -> NumpyArray[float]:
+        """Get the translation component of the current transformation :attr:`matrix`.
+
+        .. note::
+
+            Use :meth:`decompose` instead to get `all` components of the transformation
+            or to get the component as a 4x4 matrix.
+
+        Returns
+        -------
+        numpy.ndarray
+            Translation component ``T`` as a 3-element vector.
+
+        """
+        return self.matrix[:3, 3]
+
+    @property
+    def rotation(self: Transform) -> NumpyArray[float]:
+        """Get the rotation component of the current transformation :attr:`matrix`.
+
+        .. note::
+
+            Use :meth:`decompose` instead to get `all` components of the transformation
+            or to get the component as a 4x4 matrix.
+
+        Returns
+        -------
+        numpy.ndarray
+            Rotation component ``R`` as a 3x3 orthonormal rotation matrix of row vectors.
+
+        """
+        return self.decompose()[1]
+
+    @property
+    def reflection(self: Transform) -> NumpyArray[float]:
+        """Get the reflection component of the current transformation :attr:`matrix`.
+
+        The returned value is ``1`` if there are no reflections and ``-1`` if there
+        are reflections.
+
+        .. note::
+
+            Use :meth:`decompose` instead to get `all` components of the transformation
+            or to get the component as a 4x4 matrix.
+
+        Returns
+        -------
+        numpy.ndarray
+            Reflection component ``N`` as a NumPy scalar.
+
+        """
+        return self.decompose()[2]
+
+    @property
+    def scaling(self: Transform) -> NumpyArray[float]:
+        """Get the scaling component of the current transformation :attr:`matrix`.
+
+        .. note::
+
+            Use :meth:`decompose` instead to get `all` components of the transformation
+            or to get the component as a 4x4 matrix.
+
+        Returns
+        -------
+        numpy.ndarray
+            Scaling component ``S`` as a 3-element vector.
+
+        """
+        return self.decompose()[3]
+
+    @property
+    def shearing(self: Transform) -> NumpyArray[float]:
+        """Get the shearing component of the current transformation :attr:`matrix`.
+
+        .. note::
+
+            Use :meth:`decompose` instead to get `all` components of the transformation
+            or to get the component as a 4x4 matrix.
+
+        Returns
+        -------
+        numpy.ndarray
+            Shear component ``K`` as a 3x3 matrix with ones on the diagonal and
+            shear values in the off-diagonals.
+
+        """
+        return self.decompose()[4]
+
     def invert(self: Transform) -> Transform:  # numpydoc ignore: RT01
         """Invert the current transformation.
 

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -1833,6 +1833,20 @@ def test_transform_decompose_dtype(dtype, homogeneous):
     assert np.issubdtype(K.dtype, dtype)
 
 
+def test_transform_decompose_properties():
+    matrix = np.eye(4)
+    matrix[:3, :] = np.arange(12).reshape((3, 4))
+
+    transform = pv.Transform(matrix)
+    T, R, N, S, K = transform.decompose()
+
+    assert np.allclose(T, transform.translation)
+    assert np.allclose(R, transform.rotation)
+    assert np.allclose(N, transform.reflection)
+    assert np.allclose(S, transform.scaling)
+    assert np.allclose(K, transform.shearing)
+
+
 @pytest.mark.parametrize(
     ('event', 'expected'),
     [


### PR DESCRIPTION
### Overview

Add convenience properties for getting individual parts of the transformation. These properties are similar to scipy's API where the new `RigidTransformation` class has `translation` and `rotation` properties. See #7097 .