### PR TITLE
Remove `mesh_length_fraction` from `voxelize_binary_mask`

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -9717,7 +9717,7 @@ class DataSetFilters:
                 # Spacing is specified directly. Make sure other params are not set.
                 if cell_length_percentile is not None or cell_length_sample_size is not None:
                     raise TypeError(
-                        'Spacing and cell length percentile cannot both be set. Set one or the other.'
+                        'Spacing and cell length options cannot both be set. Set one or the other.'
                     )
 
             # Get initial spacing (will be adjusted later)

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -9362,7 +9362,6 @@ class DataSetFilters:
         rounding_func: Callable[[VectorLike[float]], VectorLike[int]] | None = None,
         cell_length_percentile: float | None = None,
         cell_length_sample_size: int | None = None,
-        mesh_length_fraction: float | None = None,
         progress_bar: bool = False,
     ):
         """Voxelize mesh as a binary :class:`~pyvista.ImageData` mask.
@@ -9394,16 +9393,13 @@ class DataSetFilters:
         #. Specify the ``cell_length_percentile``. The spacing is estimated from the
            surface's cells using the specified percentile.
 
-        #. Specify ``mesh_length_fraction``. The spacing is computed as a fraction of
-           the mesh's diagonal length.
-
         Use ``reference_volume`` for full control of the output mask's geometry. For
         all other options, the geometry is implicitly defined such that the generated
         mask fits the bounds of the input surface.
 
         If no inputs are provided, ``cell_length_percentile=0.1`` (10th percentile) is
         used by default to estimate the spacing. On systems with VTK < 9.2, the default
-        spacing is set to ``mesh_length_fraction=1/100``.
+        spacing is set to ``1/100`` of the input mesh's length.
 
         .. versionadded:: 0.45.0
 
@@ -9475,11 +9471,6 @@ class DataSetFilters:
             Number of samples to use for the cumulative distribution function (CDF)
             when using the ``cell_length_percentile`` option. ``100 000`` samples are
             used by default.
-
-        mesh_length_fraction : float, optional
-            Fraction of the surface mesh's length to use for computing the default
-            ``spacing``. Set this to any fractional value (e.g. ``1/100``) to enable
-            this option. This is used as an alternative to using ``cell_length_percentile``.
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
@@ -9678,7 +9669,6 @@ class DataSetFilters:
                 or rounding_func is not None
                 or cell_length_percentile is not None
                 or cell_length_sample_size is not None
-                or mesh_length_fraction is not None
             ):
                 raise TypeError(
                     'Cannot specify a reference volume with other geometry parameters. `reference_volume` must define the geometry exclusively.'
@@ -9698,11 +9688,6 @@ class DataSetFilters:
             poly_ijk = _preprocess_polydata(surface)
 
             if spacing is None:
-                if cell_length_percentile is not None and mesh_length_fraction is not None:
-                    raise TypeError(
-                        'Cell length percentile and mesh length fraction cannot both be set. Set one or the other.'
-                    )
-
                 less_than_vtk92 = pyvista.vtk_version_info < (9, 2)
                 if (
                     cell_length_percentile is not None or cell_length_sample_size is not None
@@ -9711,18 +9696,9 @@ class DataSetFilters:
                         'Cell length percentile and sample size requires VTK 9.2 or greater.'
                     )
 
-                if mesh_length_fraction is not None or less_than_vtk92:
+                if less_than_vtk92:
                     # Compute spacing from mesh length
-                    mesh_length_fraction = (
-                        1 / 100
-                        if mesh_length_fraction is None
-                        else _validation.validate_number(
-                            mesh_length_fraction,
-                            must_have_dtype=float,
-                            must_be_in_range=[0.0, 1.0],
-                        )
-                    )
-                    spacing = surface.length * mesh_length_fraction
+                    spacing = surface.length / 100
                 else:
                     # Estimate spacing from cell length percentile
                     cell_length_percentile = (
@@ -9739,13 +9715,9 @@ class DataSetFilters:
                     )
             else:
                 # Spacing is specified directly. Make sure other params are not set.
-                if cell_length_percentile is not None:
+                if cell_length_percentile is not None or cell_length_sample_size is not None:
                     raise TypeError(
                         'Spacing and cell length percentile cannot both be set. Set one or the other.'
-                    )
-                if mesh_length_fraction is not None:
-                    raise TypeError(
-                        'Spacing and mesh length fraction cannot both be set. Set one or the other.'
                     )
 
             # Get initial spacing (will be adjusted later)

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -4951,11 +4951,11 @@ def test_voxelize_binary_mask_dimensions(sphere):
     assert mask.dimensions == dims
 
 
-def test_voxelize_binary_mask_auto_spacing(ant):
+def test_voxelize_binary_mask_spacing(ant):
     # Test default
     mask_no_input = ant.voxelize_binary_mask()
     if pv.vtk_version_info < (9, 2):
-        expected_mask = ant.voxelize_binary_mask(mesh_length_fraction=1 / 100)
+        expected_mask = ant.voxelize_binary_mask(spacing=ant.length / 100)
     else:
         expected_mask = ant.voxelize_binary_mask(cell_length_percentile=0.1)
     assert mask_no_input.spacing == expected_mask.spacing
@@ -4971,11 +4971,17 @@ def test_voxelize_binary_mask_auto_spacing(ant):
         assert np.all(np.array(mask_percentile_20.spacing) < mask_percentile_50.spacing)
 
     # Test mesh length
-    mask_fraction_200 = ant.voxelize_binary_mask(mesh_length_fraction=1 / 200)
-    mask_fraction_500 = ant.voxelize_binary_mask(mesh_length_fraction=1 / 500)
+    mask_fraction_200 = ant.voxelize_binary_mask(spacing=ant.length / 200)
+    mask_fraction_500 = ant.voxelize_binary_mask(spacing=ant.length / 500)
     assert np.all(np.array(mask_fraction_200.spacing) > mask_fraction_500.spacing)
     # Check spacing matches mesh length. Use atol since spacing is approximate.
     assert np.allclose(mask_fraction_500.spacing, ant.length / 500, atol=1e-3)
+
+    match = 'Spacing and cell length percentile cannot both be set. Set one or the other.'
+    with pytest.raises(TypeError, match=match):
+        ant.voxelize_binary_mask(spacing=0.1, cell_length_percentile=0.1)
+    with pytest.raises(TypeError, match=match):
+        ant.voxelize_binary_mask(spacing=0.1, cell_length_sample_size=ant.n_cells)
 
 
 # This test is flaky because of random sampling that cannot be controlled.

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -4977,12 +4977,6 @@ def test_voxelize_binary_mask_spacing(ant):
     # Check spacing matches mesh length. Use atol since spacing is approximate.
     assert np.allclose(mask_fraction_500.spacing, ant.length / 500, atol=1e-3)
 
-    match = 'Spacing and cell length percentile cannot both be set. Set one or the other.'
-    with pytest.raises(TypeError, match=match):
-        ant.voxelize_binary_mask(spacing=0.1, cell_length_percentile=0.1)
-    with pytest.raises(TypeError, match=match):
-        ant.voxelize_binary_mask(spacing=0.1, cell_length_sample_size=ant.n_cells)
-
 
 # This test is flaky because of random sampling that cannot be controlled.
 # Sometimes the sampling produces the same output.
@@ -5056,3 +5050,56 @@ def test_voxelize_binary_mask_input(hexbeam):
     mesh = pv.PolyData(hexbeam.points)
     with pytest.raises(ValueError, match='Input mesh must have faces for voxelization'):
         mesh.voxelize_binary_mask()
+
+
+@pytest.fixture
+def oriented_image():
+    image = pv.ImageData()
+    image.spacing = (1.1, 1.2, 1.3)
+    image.dimensions = (10, 11, 12)
+    image.direction_matrix = pv.Transform().rotate_vector((4, 5, 6), 30).matrix[:3, :3]
+    image['scalars'] = np.ones((image.n_points,))
+    return image
+
+
+@pytest.fixture
+def oriented_polydata(oriented_image):
+    oriented_poly = oriented_image.pad_image().contour_labels(smoothing=False)
+    assert np.allclose(oriented_poly.bounds, oriented_image.points_to_cells().bounds, atol=0.1)
+    return oriented_poly
+
+
+@pytest.mark.needs_vtk_version(9, 3, 0)
+def test_voxelize_binary_mask_orientation(oriented_image, oriented_polydata):
+    mask = oriented_polydata.voxelize_binary_mask(reference_volume=oriented_image)
+    assert mask.bounds == oriented_image.bounds
+    mask_as_surface = mask.pad_image().contour_labels(smoothing=False)
+    assert mask_as_surface.bounds == oriented_polydata.bounds
+
+
+def test_voxelize_binary_mask_raises(sphere):
+    match = 'Spacing and dimensions cannot both be set. Set one or the other.'
+    with pytest.raises(TypeError, match=match):
+        sphere.voxelize_binary_mask(dimensions=(1, 2, 3), spacing=(4, 5, 6))
+
+    match = 'Spacing and cell length options cannot both be set. Set one or the other.'
+    with pytest.raises(TypeError, match=match):
+        sphere.voxelize_binary_mask(spacing=(4, 5, 6), cell_length_percentile=0.2)
+    with pytest.raises(TypeError, match=match):
+        sphere.voxelize_binary_mask(spacing=0.1, cell_length_sample_size=sphere.n_cells)
+
+    match = 'Rounding func cannot be set when dimensions is specified. Set one or the other.'
+    with pytest.raises(TypeError, match=match):
+        sphere.voxelize_binary_mask(dimensions=(1, 2, 3), rounding_func=np.round)
+
+    for parameter in [
+        'dimensions',
+        'spacing',
+        'rounding_func',
+        'cell_length_percentile',
+        'cell_length_sample_size',
+    ]:
+        kwargs = {parameter: 0}  # Give parameter any value for test
+        match = 'Cannot specify a reference volume with other geometry parameters. `reference_volume` must define the geometry exclusively.'
+        with pytest.raises(TypeError, match=match):
+            sphere.voxelize_binary_mask(reference_volume=pv.ImageData(), **kwargs)

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -124,23 +124,6 @@ def test_check_subdtype():
         check_subdtype(np.array([1 + 1j, 2, 3]), (np.integer, np.floating))
 
 
-@pytest.mark.filterwarnings(
-    'ignore:Converting `np.inexact` or `np.floating` to a dtype is deprecated. The current result is `float64` which is not strictly correct.:DeprecationWarning'
-)
-def test_check_subdtype_changes_type():
-    # test coercing some types (e.g. np.number) can lead to unexpected
-    # failed `np.issubtype` checks due to an implicit change of type
-    int_array = np.array([1, 2, 3])
-    dtype_expected = np.number
-    check_subdtype(int_array, dtype_expected)  # int is subtype of np.number
-
-    dtype_coerced = np.dtype(dtype_expected)
-    assert dtype_coerced.type is np.float64  # np.number is coerced (by NumPy) as a float
-    with pytest.raises(TypeError):
-        # this check will now fail since int is not subtype of float
-        check_subdtype(int_array, dtype_coerced)
-
-
 def test_validate_number():
     validate_number([2.0])
     num = validate_number(1)


### PR DESCRIPTION
### Overview

See https://github.com/pyvista/pyvista/pull/7037#discussion_r1937636156

This filter is not yet released so I don't think we need to deprecate this and can simply remove it.

Note: PolyData filter tests were also moved to DataSet filter tests. These were missed by #7148 