### PR TITLE
Remove `check_subdtype` test of deprecated NumPy behavior

### DIFF
--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -124,23 +124,6 @@ def test_check_subdtype():
         check_subdtype(np.array([1 + 1j, 2, 3]), (np.integer, np.floating))
 
 
-@pytest.mark.filterwarnings(
-    'ignore:Converting `np.inexact` or `np.floating` to a dtype is deprecated. The current result is `float64` which is not strictly correct.:DeprecationWarning'
-)
-def test_check_subdtype_changes_type():
-    # test coercing some types (e.g. np.number) can lead to unexpected
-    # failed `np.issubtype` checks due to an implicit change of type
-    int_array = np.array([1, 2, 3])
-    dtype_expected = np.number
-    check_subdtype(int_array, dtype_expected)  # int is subtype of np.number
-
-    dtype_coerced = np.dtype(dtype_expected)
-    assert dtype_coerced.type is np.float64  # np.number is coerced (by NumPy) as a float
-    with pytest.raises(TypeError):
-        # this check will now fail since int is not subtype of float
-        check_subdtype(int_array, dtype_coerced)
-
-
 def test_validate_number():
     validate_number([2.0])
     num = validate_number(1)


### PR DESCRIPTION
### Overview

This test was originally included because of surprising behavior when using `np.number` with `check_subdtype`. But this usage emits a deprecation warning (so users can know to avoid it) and this deprecation is now an error with NumPy 2.3 and causing CI to fail.

We can simply remove this test.