### PR TITLE
Add `NameMixin` class to give `name` attribute to actor-like classes

### DIFF
--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -358,7 +358,7 @@ class _NameMixin:
     @property
     def name(self) -> str:  # numpydoc ignore=RT01
         """Get or set the unique name identifier used by PyVista."""
-        if not hasattr(self, '_name') or self._name is None:  # type: ignore[has-type]
+        if not hasattr(self, '_name') or self._name is None:
             address = (
                 self.GetAddressAsString('')
                 if hasattr(self, 'GetAddressAsString')

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -17,6 +17,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     from typing import Any
+    from typing import ClassVar
 
     from .._typing_core import ArrayLike
     from .._typing_core import NumpyArray
@@ -342,9 +343,6 @@ class _classproperty(property):
 
     def __get__(self: property, owner_self: Any, owner_cls: type | None = None) -> Any:
         return self.fget(owner_cls)  # type: ignore[misc]
-
-
-from typing import ClassVar
 
 
 class NameMixin:

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -345,7 +345,7 @@ class _classproperty(property):
         return self.fget(owner_cls)  # type: ignore[misc]
 
 
-class NameMixin:
+class _NameMixin:
     """Add a 'name' property to a class.
 
     .. versionadded:: 0.45

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -364,11 +364,11 @@ class _NameMixin:
                 if hasattr(self, 'GetAddressAsString')
                 else hex(id(self))
             )
-            self._name = f'{type(self).__name__}({address})'
+            return f'{type(self).__name__}({address})'
         return self._name
 
     @name.setter
     def name(self, value: str) -> None:
         if not value:
             raise ValueError('Name must be truthy.')
-        self._name = value
+        self._name = str(value)

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -342,3 +342,35 @@ class _classproperty(property):
 
     def __get__(self: property, owner_self: Any, owner_cls: type | None = None) -> Any:
         return self.fget(owner_cls)  # type: ignore[misc]
+
+
+from typing import ClassVar
+
+
+class NameMixin:
+    """Add a 'name' property to a class.
+
+    .. versionadded:: 0.45
+
+    """
+
+    # In case subclasses use @no_new_attr mixin
+    _new_attr_exceptions: ClassVar[Sequence[str]] = ('_name',)
+
+    @property
+    def name(self) -> str:  # numpydoc ignore=RT01
+        """Get or set the unique name identifier used by PyVista."""
+        if not hasattr(self, '_name') or self._name is None:  # type: ignore[has-type]
+            address = (
+                self.GetAddressAsString('')
+                if hasattr(self, 'GetAddressAsString')
+                else hex(id(self))
+            )
+            self._name = f'{type(self).__name__}({address})'
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        if not value:
+            raise ValueError('Name must be truthy.')
+        self._name = value

--- a/pyvista/plotting/actor.py
+++ b/pyvista/plotting/actor.py
@@ -8,7 +8,7 @@ from typing import ClassVar
 import numpy as np
 
 import pyvista
-from pyvista.core.utilities.misc import NameMixin
+from pyvista.core.utilities.misc import _NameMixin
 from pyvista.core.utilities.misc import no_new_attr
 
 from . import _vtk
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 @no_new_attr
-class Actor(Prop3D, NameMixin, _vtk.vtkActor):
+class Actor(Prop3D, _NameMixin, _vtk.vtkActor):
     """Wrap vtkActor.
 
     This class represents the geometry & properties in a rendered

--- a/pyvista/plotting/actor.py
+++ b/pyvista/plotting/actor.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 import numpy as np
 
 import pyvista
+from pyvista.core.utilities.misc import NameMixin
 from pyvista.core.utilities.misc import no_new_attr
 
 from . import _vtk
@@ -19,7 +20,7 @@ if TYPE_CHECKING:
 
 
 @no_new_attr
-class Actor(Prop3D, _vtk.vtkActor):
+class Actor(Prop3D, NameMixin, _vtk.vtkActor):
     """Wrap vtkActor.
 
     This class represents the geometry & properties in a rendered
@@ -95,19 +96,6 @@ class Actor(Prop3D, _vtk.vtkActor):
         else:
             self.prop = prop
         self._name = name
-
-    @property
-    def name(self) -> str:  # numpydoc ignore=RT01
-        """Get or set the unique name identifier used by PyVista."""
-        if self._name is None:
-            self._name = f'{type(self).__name__}({self.memory_address})'
-        return self._name
-
-    @name.setter
-    def name(self, value: str):
-        if not value:
-            raise ValueError('Name must be truthy.')
-        self._name = value
 
     @property
     def mapper(self) -> _BaseMapper:  # numpydoc ignore=RT01

--- a/pyvista/plotting/axes_assembly.py
+++ b/pyvista/plotting/axes_assembly.py
@@ -21,7 +21,7 @@ from pyvista.core.utilities.geometric_sources import AxesGeometrySource
 from pyvista.core.utilities.geometric_sources import OrthogonalPlanesSource
 from pyvista.core.utilities.geometric_sources import _AxisEnum
 from pyvista.core.utilities.geometric_sources import _PartEnum
-from pyvista.core.utilities.misc import NameMixin
+from pyvista.core.utilities.misc import _NameMixin
 from pyvista.plotting import _vtk
 from pyvista.plotting.actor import Actor
 from pyvista.plotting.colors import Color
@@ -76,7 +76,7 @@ class _XYZTuple(NamedTuple):
     z: Any
 
 
-class _XYZAssembly(_Prop3DMixin, NameMixin, _vtk.vtkPropAssembly):
+class _XYZAssembly(_Prop3DMixin, _NameMixin, _vtk.vtkPropAssembly):
     DEFAULT_LABELS = _XYZTuple('X', 'Y', 'Z')
 
     def __init__(

--- a/pyvista/plotting/axes_assembly.py
+++ b/pyvista/plotting/axes_assembly.py
@@ -21,6 +21,7 @@ from pyvista.core.utilities.geometric_sources import AxesGeometrySource
 from pyvista.core.utilities.geometric_sources import OrthogonalPlanesSource
 from pyvista.core.utilities.geometric_sources import _AxisEnum
 from pyvista.core.utilities.geometric_sources import _PartEnum
+from pyvista.core.utilities.misc import NameMixin
 from pyvista.plotting import _vtk
 from pyvista.plotting.actor import Actor
 from pyvista.plotting.colors import Color
@@ -75,7 +76,7 @@ class _XYZTuple(NamedTuple):
     z: Any
 
 
-class _XYZAssembly(_Prop3DMixin, _vtk.vtkPropAssembly):
+class _XYZAssembly(_Prop3DMixin, NameMixin, _vtk.vtkPropAssembly):
     DEFAULT_LABELS = _XYZTuple('X', 'Y', 'Z')
 
     def __init__(
@@ -99,6 +100,7 @@ class _XYZAssembly(_Prop3DMixin, _vtk.vtkPropAssembly):
         origin: VectorLike[float],
         scale: float | VectorLike[float],
         user_matrix: MatrixLike[float] | None,
+        name: str | None = None,
     ):
         super().__init__()
 
@@ -153,6 +155,8 @@ class _XYZAssembly(_Prop3DMixin, _vtk.vtkPropAssembly):
         self.scale = scale  # type: ignore[assignment]
         self.origin = origin  # type: ignore[assignment]
         self.user_matrix = user_matrix  # type: ignore[assignment]
+
+        self._name = name  # type: ignore[assignment]
 
     @property
     def parts(self):
@@ -352,6 +356,11 @@ class AxesAssembly(_XYZAssembly):
         A 4x4 transformation matrix applied to the axes. Defaults to the identity matrix.
         The user matrix is the last transformation applied to the actor.
 
+    name : str, optional
+        The name of this assembly used when tracking on a plotter.
+
+        .. versionadded:: 0.45
+
     **kwargs
         Keyword arguments passed to :class:`pyvista.AxesGeometrySource`.
 
@@ -448,6 +457,7 @@ class AxesAssembly(_XYZAssembly):
         origin: VectorLike[float] = (0.0, 0.0, 0.0),
         scale: float | VectorLike[float] = (1.0, 1.0, 1.0),
         user_matrix: MatrixLike[float] | None = None,
+        name: str | None = None,
         **kwargs: Unpack[_AxesGeometryKwargs],
     ):
         # Init shaft and tip actors
@@ -475,6 +485,7 @@ class AxesAssembly(_XYZAssembly):
             origin=origin,
             scale=scale,
             user_matrix=user_matrix,
+            name=name,
         )
         self._set_default_label_props()
 
@@ -971,6 +982,11 @@ class AxesAssemblySymmetric(AxesAssembly):
         A 4x4 transformation matrix applied to the axes. Defaults to the identity matrix.
         The user matrix is the last transformation applied to the actor.
 
+    name : str, optional
+        The name of this assembly used when tracking on a plotter.
+
+        .. versionadded:: 0.45
+
     **kwargs
         Keyword arguments passed to :class:`pyvista.AxesGeometrySource`.
 
@@ -1036,6 +1052,7 @@ class AxesAssemblySymmetric(AxesAssembly):
         origin: VectorLike[float] = (0.0, 0.0, 0.0),
         scale: float | VectorLike[float] = (1.0, 1.0, 1.0),
         user_matrix: MatrixLike[float] | None = None,
+        name: str | None = None,
         **kwargs: Unpack[_AxesGeometryKwargs],
     ):
         # Init shaft and tip actors
@@ -1064,6 +1081,7 @@ class AxesAssemblySymmetric(AxesAssembly):
             origin=origin,
             scale=scale,
             user_matrix=user_matrix,
+            name=name,
         )
         self._set_default_label_props()
 
@@ -1343,6 +1361,11 @@ class PlanesAssembly(_XYZAssembly):
         A 4x4 transformation matrix applied to the assembly. Defaults to the identity
         matrix. The user matrix is the last transformation applied to the actor.
 
+    name : str, optional
+        The name of this assembly used when tracking on a plotter.
+
+        .. versionadded:: 0.45
+
     **kwargs
         Keyword arguments passed to :class:`pyvista.OrthogonalPlanesSource`.
 
@@ -1445,6 +1468,7 @@ class PlanesAssembly(_XYZAssembly):
         origin: VectorLike[float] = (0.0, 0.0, 0.0),
         scale: float | VectorLike[float] = (1.0, 1.0, 1.0),
         user_matrix: MatrixLike[float] | None = None,
+        name: str | None = None,
         **kwargs: Unpack[_OrthogonalPlanesKwargs],
     ):
         # Init plane actors
@@ -1485,6 +1509,7 @@ class PlanesAssembly(_XYZAssembly):
             origin=origin,
             scale=scale,
             user_matrix=user_matrix,
+            name=name,
         )
 
         self.opacity = opacity  # type: ignore[assignment]

--- a/pyvista/plotting/text.py
+++ b/pyvista/plotting/text.py
@@ -9,8 +9,8 @@ from typing import TYPE_CHECKING
 import pyvista
 from pyvista.core import _validation
 from pyvista.core._typing_core import BoundsTuple
-from pyvista.core.utilities.misc import NameMixin
 from pyvista.core.utilities.misc import _check_range
+from pyvista.core.utilities.misc import _NameMixin
 from pyvista.core.utilities.misc import no_new_attr
 
 from . import _vtk
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 
 @no_new_attr
-class CornerAnnotation(NameMixin, _vtk.vtkCornerAnnotation):
+class CornerAnnotation(_NameMixin, _vtk.vtkCornerAnnotation):
     """Text annotation in four corners.
 
     This is an annotation object that manages four text actors / mappers to provide annotation in the four corners of a viewport.
@@ -161,7 +161,7 @@ class CornerAnnotation(NameMixin, _vtk.vtkCornerAnnotation):
 
 
 @no_new_attr
-class Text(NameMixin, _vtk.vtkTextActor):
+class Text(_NameMixin, _vtk.vtkTextActor):
     r"""Define text by default theme.
 
     Parameters

--- a/pyvista/plotting/text.py
+++ b/pyvista/plotting/text.py
@@ -286,6 +286,11 @@ class Label(_Prop3DMixin, Text):
     prop : pyvista.TextProperty, optional
         The property of this actor.
 
+    name : str, optional
+        The name of this actor used when tracking on a plotter.
+
+        .. versionadded:: 0.45
+
     See Also
     --------
     pyvista.Plotter.add_point_labels
@@ -384,10 +389,12 @@ class Label(_Prop3DMixin, Text):
         *,
         size: int = 50,
         prop: pyvista.Property | None = None,
+        name: str | None = None,
     ):
         Text.__init__(self, text=text, prop=prop)
         self.GetPositionCoordinate().SetCoordinateSystemToWorld()
         self.SetTextScaleModeToNone()  # Use font size to control size of text
+        self._name = name
 
         _Prop3DMixin.__init__(self)
         self.relative_position = relative_position  # type: ignore[assignment]

--- a/pyvista/plotting/text.py
+++ b/pyvista/plotting/text.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import pyvista
 from pyvista.core import _validation
 from pyvista.core._typing_core import BoundsTuple
+from pyvista.core.utilities.misc import NameMixin
 from pyvista.core.utilities.misc import _check_range
 from pyvista.core.utilities.misc import no_new_attr
 
@@ -28,7 +29,7 @@ if TYPE_CHECKING:
 
 
 @no_new_attr
-class CornerAnnotation(_vtk.vtkCornerAnnotation):
+class CornerAnnotation(NameMixin, _vtk.vtkCornerAnnotation):
     """Text annotation in four corners.
 
     This is an annotation object that manages four text actors / mappers to provide annotation in the four corners of a viewport.
@@ -47,6 +48,11 @@ class CornerAnnotation(_vtk.vtkCornerAnnotation):
     linear_font_scale_factor : float, optional
         Linear font scale factor.
 
+    name : str, optional
+        The name of this actor used when tracking on a plotter.
+
+        .. versionadded:: 0.45
+
     Examples
     --------
     Create text annotation in four corners.
@@ -57,7 +63,7 @@ class CornerAnnotation(_vtk.vtkCornerAnnotation):
 
     """
 
-    def __init__(self, position, text, prop=None, linear_font_scale_factor=None):
+    def __init__(self, position, text, prop=None, linear_font_scale_factor=None, name=None):
         """Initialize a new text annotation descriptor."""
         super().__init__()
         self.set_text(position, text)
@@ -65,6 +71,7 @@ class CornerAnnotation(_vtk.vtkCornerAnnotation):
             self.prop = TextProperty()
         if linear_font_scale_factor is not None:
             self.linear_font_scale_factor = linear_font_scale_factor
+        self._name = name
 
     def get_text(self, position):
         """Get the text to be displayed for each corner.
@@ -154,7 +161,7 @@ class CornerAnnotation(_vtk.vtkCornerAnnotation):
 
 
 @no_new_attr
-class Text(_vtk.vtkTextActor):
+class Text(NameMixin, _vtk.vtkTextActor):
     r"""Define text by default theme.
 
     Parameters
@@ -170,6 +177,11 @@ class Text(_vtk.vtkTextActor):
     prop : pyvista.TextProperty, optional
         The property of this actor.
 
+    name : str, optional
+        The name of this actor used when tracking on a plotter.
+
+        .. versionadded:: 0.45
+
     Examples
     --------
     Create a text with text's property.
@@ -180,7 +192,7 @@ class Text(_vtk.vtkTextActor):
 
     """
 
-    def __init__(self, text=None, position=None, prop=None):
+    def __init__(self, text=None, position=None, prop=None, name=None):
         """Initialize a new text descriptor."""
         super().__init__()
         if text is not None:
@@ -189,6 +201,7 @@ class Text(_vtk.vtkTextActor):
             self.position = position
         if prop is None:
             self.prop = TextProperty()
+        self._name = name
 
     @property
     def input(self):

--- a/pyvista/plotting/text.py
+++ b/pyvista/plotting/text.py
@@ -394,7 +394,7 @@ class Label(_Prop3DMixin, Text):
         Text.__init__(self, text=text, prop=prop)
         self.GetPositionCoordinate().SetCoordinateSystemToWorld()
         self.SetTextScaleModeToNone()  # Use font size to control size of text
-        self._name = name
+        self._name = name  # type: ignore[assignment]
 
         _Prop3DMixin.__init__(self)
         self.relative_position = relative_position  # type: ignore[assignment]

--- a/tests/plotting/test_actor.py
+++ b/tests/plotting/test_actor.py
@@ -250,7 +250,7 @@ def test_actor_center(klass, actor, dummy_actor):
 
 def test_actor_name(actor):
     actor.name = 1
-    assert actor._name == 1
+    assert actor._name == '1'
 
     with pytest.raises(ValueError, match='Name must be truthy'):
         actor.name = None

--- a/tests/plotting/test_axes_assembly.py
+++ b/tests/plotting/test_axes_assembly.py
@@ -337,6 +337,11 @@ def test_axes_assembly_length(axes_assembly):
     assert np.allclose(axes_assembly.length, dataset.length)
 
 
+def test_axes_assembly_name():
+    axes = pv.PlanesAssembly(name='axes')
+    assert axes.name == 'axes'
+
+
 def test_axes_assembly_symmetric(axes_assembly_symmetric):
     assert np.allclose(axes_assembly_symmetric.bounds, (-1.0, 1.0, -1.0, 1.0, -1.0, 1.0))
 
@@ -373,6 +378,11 @@ def test_axes_assembly_symmetric_init_label(test_property):
     kwargs = {test_property: label}
     axes_assembly = pv.AxesAssemblySymmetric(**kwargs)
     assert getattr(axes_assembly, test_property) == label
+
+
+def test_axes_assembly_symmetric_name():
+    axes = pv.PlanesAssembly(name='axes')
+    assert axes.name == 'axes'
 
 
 def test_axes_assembly_set_get_part_prop_all(axes_assembly):
@@ -707,3 +717,8 @@ def test_planes_assembly_camera(planes_assembly):
     camera = pv.Camera()
     planes_assembly.camera = camera
     assert planes_assembly.camera is camera
+
+
+def test_planes_assembly_name():
+    planes = pv.PlanesAssembly(name='planes')
+    assert planes.name == 'planes'

--- a/tests/plotting/test_text.py
+++ b/tests/plotting/test_text.py
@@ -25,6 +25,11 @@ def test_corner_annotation_prop(corner_annotation):
     assert isinstance(prop, pv.TextProperty)
 
 
+def test_corner_annotation_name():
+    corner = pv.CornerAnnotation('top', 'abc', name='corner')
+    assert corner.name == 'corner'
+
+
 @pytest.fixture
 def text():
     return pv.Text()
@@ -46,6 +51,11 @@ def test_text_position(text):
     assert np.all(text.position == position)
 
 
+def test_text_name():
+    text = pv.Text('abc', name='text')
+    assert text.name == 'text'
+
+
 def test_label():
     label = pv.Label('text', (1, 2, 3), size=42, prop=pv.Property())
 
@@ -60,6 +70,11 @@ def test_label():
     assert label.size == 42
     label.size = 99
     assert label.size == 99
+
+
+def test_label_name():
+    label = pv.Label('abc', name='label')
+    assert label.name == 'label'
 
 
 def test_label_prop3d():


### PR DESCRIPTION
### Overview

Part of #7184. Move `name` prop from `Actor` to its own class and add it to `Text`, `CornerAnnotation`, and `XYZAssembly` classes