### PR TITLE
Revert "Add sshd in `devcontainer.json` to ssh access"

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,7 @@
   "image": "mcr.microsoft.com/devcontainers/python:3.11",
   "features": {
     "ghcr.io/devcontainers/features/desktop-lite:1": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/sshd:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "forwardPorts": [6080],
   "onCreateCommand": "./.devcontainer/oncreatecommand.sh",


### PR DESCRIPTION
Reverts pyvista/pyvista#6024

I am no longer using SSH when working with CodeSpaces and primarily use Web browser instead. To reduce startup time, I would like to revert this change.

