### PR TITLE
Add `MultiBlock.get_block` and extend `replace` to allow indexing nested blocks

### DIFF
--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -1020,7 +1020,8 @@ class MultiBlock(
 
         >>> multi.replace((0, 42), surface)
 
-        This is equivalent to replacing the block directly with indexing.
+        This is similar to replacing the block directly with indexing but the block
+        name is also preserved.
 
         >>> multi[0][42] = surface
 

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -938,13 +938,17 @@ class MultiBlock(
             return parent[final_index]
         return self[index]
 
-    def set_block_name(self: MultiBlock, index: int, name: str | None) -> None:
+    def set_block_name(self: MultiBlock, index: int | str, name: str | None) -> None:
         """Set a block's string name at the specified index.
 
         Parameters
         ----------
-        index : int
+        index : int | str
             Index or the dataset within the multiblock.
+
+           .. versionadded:: 0.45
+
+                Allow indexing by name.
 
         name : str, optional
             Name to assign to the block at ``index``. If ``None``, no name is
@@ -966,7 +970,9 @@ class MultiBlock(
         """
         if name is None:
             return
-        index = range(self.n_blocks)[index]
+        index = (
+            self.get_index_by_name(index) if isinstance(index, str) else range(self.n_blocks)[index]
+        )
         self.GetMetaData(index).Set(_vtk.vtkCompositeDataSet.NAME(), name)
         self.Modified()
 
@@ -1037,7 +1043,7 @@ class MultiBlock(
             Index or name of the block to replace. Specify a sequence of indices to replace
             a nested block.
 
-            .. versionchanged:: 0.45
+            .. versionadded:: 0.45
 
                 Allow indexing nested blocks.
 
@@ -1083,7 +1089,7 @@ class MultiBlock(
             parent, final_index = self._navigate_to_parent(index)
             parent.replace(final_index, dataset)
             return
-        name = self.get_block_name(index)
+        name = index if isinstance(index, str) else self.get_block_name(index)
         self[index] = dataset
         self.set_block_name(index, name)
         return

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -932,7 +932,7 @@ class MultiBlock(
 
         >>> nested.get_block(0)
         MultiBlock ...
-        >>> blocks.get_block((0, 1))
+        >>> nested.get_block((0, 1))
         ImageData ...
 
         """

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -854,17 +854,17 @@ class MultiBlock(
 
     def get(
         self: MultiBlock,
-        index: str,
+        index: int | str,
         default: _TypeMultiBlockLeaf = None,
     ) -> _TypeMultiBlockLeaf:
-        """Get a block by its name.
+        """Get a block by its index or name.
 
         If the name is non-unique then returns the first occurrence.
         Returns ``default`` if name isn't in the dataset.
 
         Parameters
         ----------
-        index : str
+        index : int | str
             Index or name of the dataset within the multiblock.
 
         default : pyvista.DataSet or pyvista.MultiBlock, optional
@@ -874,6 +874,11 @@ class MultiBlock(
         -------
         pyvista.DataSet or pyvista.MultiBlock or None
             Dataset from the given index if it exists.
+
+        See Also
+        --------
+        get_block
+            Get a block and raise an ``IndexError`` if index is not found.
 
         Examples
         --------
@@ -890,6 +895,48 @@ class MultiBlock(
             return self[index]
         except KeyError:
             return default
+
+    def get_block(
+        self: MultiBlock,
+        index: int | Sequence[int] | str,
+    ) -> _TypeMultiBlockLeaf:
+        """Get a block by its index or name.
+
+        If the name is non-unique then returns the first occurrence.
+
+        .. versionadded:: 0.45
+
+        Parameters
+        ----------
+        index : int | Sequence[int] | str
+            Index or name of the dataset within the multiblock. Specify a sequence of
+            indices to replace a nested block.
+
+        Returns
+        -------
+        pyvista.DataSet or pyvista.MultiBlock or None
+            Dataset from the given index if it exists.
+
+        See Also
+        --------
+        get
+            Get a block and return a default value instead of raising an ``IndexError``.
+
+        Examples
+        --------
+        >>> import pyvista as pv
+        >>> from pyvista import examples
+        >>> data = {'poly': pv.PolyData(), 'img': pv.ImageData()}
+        >>> blocks = pv.MultiBlock(data)
+        >>> blocks.get('poly')
+        PolyData ...
+        >>> blocks.get('cone')
+
+        """
+        if isinstance(index, Sequence) and not isinstance(index, str):
+            parent, final_index = self._navigate_to_parent(index)
+            return parent[final_index]
+        return self[index]
 
     def set_block_name(self: MultiBlock, index: int, name: str | None) -> None:
         """Set a block's string name at the specified index.
@@ -979,14 +1026,20 @@ class MultiBlock(
     def _ipython_key_completions_(self: MultiBlock) -> list[str | None]:
         return self.keys()
 
-    def replace(self: MultiBlock, index: int | Sequence[int], dataset: _TypeMultiBlockLeaf) -> None:
+    def replace(
+        self: MultiBlock, index: int | Sequence[int] | str, dataset: _TypeMultiBlockLeaf
+    ) -> None:
         """Replace dataset at index while preserving key name.
 
         Parameters
         ----------
-        index : int | Sequence[int]
-            Index of the block to replace. Specify a sequence of indices to replace
+        index : int | Sequence[int] | str
+            Index or name of the block to replace. Specify a sequence of indices to replace
             a nested block.
+
+            .. versionchanged:: 0.45
+
+                Allow indexing nested blocks.
 
         dataset : pyvista.DataSet or pyvista.MultiBlock
             Dataset for replacing the one at index.
@@ -1026,26 +1079,27 @@ class MultiBlock(
         >>> multi[0][42] = surface
 
         """
-        if isinstance(index, Sequence):
-            self._replace_nested(index, dataset)
+        if isinstance(index, Sequence) and not isinstance(index, str):
+            parent, final_index = self._navigate_to_parent(index)
+            parent.replace(final_index, dataset)
             return
         name = self.get_block_name(index)
         self[index] = dataset
         self.set_block_name(index, name)
         return
 
-    def _replace_nested(self, indices: Sequence[int], block: _TypeMultiBlockLeaf) -> None:
+    def _navigate_to_parent(self, indices: Sequence[int]) -> tuple[MultiBlock, int]:
+        """Navigate to the parent MultiBlock and return (parent, final_index)."""
         _validation.check_length(indices, min_length=1, name='index')
         # Navigate through the indices except the last one
         target: _TypeMultiBlockLeaf = self
-        for ind in indices[:-1:]:
+        for ind in indices[:-1]:
             if target is None or isinstance(target, pyvista.DataSet):
                 raise IndexError(f'Invalid indices {indices}.')
             target = target[ind]
         if not isinstance(target, MultiBlock):
             raise IndexError(f'Invalid indices {indices}.')
-        # Replace the block
-        target.replace(indices[-1], block)
+        return target, indices[-1]
 
     @overload
     def __setitem__(

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -902,7 +902,9 @@ class MultiBlock(
     ) -> _TypeMultiBlockLeaf:
         """Get a block by its index or name.
 
-        If the name is non-unique then returns the first occurrence.
+        If the name is non-unique then returns the first occurrence. This
+        method is similar to using ``[]`` for indexing except this method also
+        supports indexing nested blocks.
 
         .. versionadded:: 0.45
 
@@ -925,12 +927,13 @@ class MultiBlock(
         Examples
         --------
         >>> import pyvista as pv
-        >>> from pyvista import examples
-        >>> data = {'poly': pv.PolyData(), 'img': pv.ImageData()}
-        >>> blocks = pv.MultiBlock(data)
-        >>> blocks.get('poly')
-        PolyData ...
-        >>> blocks.get('cone')
+        >>> blocks = pv.MultiBlock([pv.PolyData(), pv.ImageData()])
+        >>> nested = pv.MultiBlock([blocks])
+
+        >>> nested.get_block(0)
+        MultiBlock ...
+        >>> blocks.get_block((0, 1))
+        ImageData ...
 
         """
         if isinstance(index, Sequence) and not isinstance(index, str):

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -268,15 +268,6 @@ def test_replace_nested(nested_fixture, replace_indices):
     assert nested.flatten().keys() == expected_flat_keys
 
 
-def test_get_block(nested_fixture):
-    index = (1, 0)
-    name = 'grid'
-    block_by_index = nested_fixture[index[0]].get_block(index[1])
-    block_by_nested_index = nested_fixture.get_block(index)
-    block_by_name = nested_fixture[index[0]].get_block(name)
-    assert block_by_name is block_by_index is block_by_nested_index
-
-
 @pytest.mark.parametrize(
     'invalid_indices',
     [
@@ -289,6 +280,15 @@ def test_replace_nested_invalid_indices(nested_fixture, invalid_indices):
     match = re.escape(invalid_indices[1])
     with pytest.raises(IndexError, match=match):
         nested.replace(invalid_indices[0], None)
+
+
+def test_get_block(nested_fixture):
+    index = (1, 0)
+    name = 'grid'
+    block_by_index = nested_fixture[index[0]].get_block(index[1])
+    block_by_nested_index = nested_fixture.get_block(index)
+    block_by_name = nested_fixture[index[0]].get_block(name)
+    assert block_by_name is block_by_index is block_by_nested_index
 
 
 def test_reverse(sphere):

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -240,34 +240,39 @@ def nested_fixture():
     nested.insert(1, multi, 'multi')
     return nested
 
+
 @pytest.mark.parametrize(
-    "replace_indices",
+    'replace_indices',
     [
         ((0,)),
         ((1, 0),),
         ((2,),),
-    ]
+    ],
 )
 def test_replace_nested(nested_fixture, replace_indices):
     nested = nested_fixture
     expected_keys = ['image', 'multi', 'poly']
     expected_flat_keys = ['image', 'grid', 'poly']
-    
+
     original_values = [nested[0], nested[1][0], nested[2]]
     nested.replace(replace_indices, None)
-    
+
     assert all(
         (nested[idx] is None if idx == replace_indices else nested[idx] is original_values[i])
         for i, idx in enumerate([(0,), (1, 0), (2,)])
     )
-    
+
     assert nested.keys() == expected_keys
     assert nested.flatten().keys() == expected_flat_keys
 
-@pytest.mark.parametrize("invalid_indices", [
-    ((0, 0, 0), 'Invalid indices (0, 0, 0).'),
-    ((0, 0), 'Invalid indices (0, 0).'),
-])
+
+@pytest.mark.parametrize(
+    'invalid_indices',
+    [
+        ((0, 0, 0), 'Invalid indices (0, 0, 0).'),
+        ((0, 0), 'Invalid indices (0, 0).'),
+    ],
+)
 def test_replace_nested_invalid_indices(nested_fixture, invalid_indices):
     nested = nested_fixture
     match = re.escape(invalid_indices[1])

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -174,6 +174,14 @@ def test_multi_block_set_get_ers():
         multi[1, 'foo'] = data
 
 
+def test_set_block_name_by_name(ant):
+    old_name = 'foo'
+    new_name = 'bar'
+    multi = pv.MultiBlock({old_name: ant})
+    multi.set_block_name(old_name, new_name)
+    assert multi.keys() == [new_name]
+
+
 def test_replace():
     spheres = {f'{i}': pv.Sphere(phi_resolution=i + 3) for i in range(10)}
     multi = MultiBlock(spheres)

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -267,12 +267,12 @@ def test_replace_nested():
     assert nested.keys() == expected_keys
     assert nested.flatten().keys() == expected_flat_keys
 
+    match = re.escape('Invalid indices (0, 0, 0).')
+    with pytest.raises(IndexError, match=match):
+        nested.replace((0, 0, 0), None)
     match = re.escape('Invalid indices (0, 0).')
     with pytest.raises(IndexError, match=match):
         nested.replace((0, 0), None)
-    match = re.escape('Invalid indices (1, 0, 0).')
-    with pytest.raises(IndexError, match=match):
-        nested.replace((1, 0, 0), None)
 
 
 def test_reverse(sphere):

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -244,9 +244,9 @@ def nested_fixture():
 @pytest.mark.parametrize(
     'replace_indices',
     [
-        ((0,)),
-        ((1, 0),),
-        ((2,),),
+        (0,),
+        (1, 0),
+        (2,),
     ],
 )
 def test_replace_nested(nested_fixture, replace_indices):
@@ -254,16 +254,19 @@ def test_replace_nested(nested_fixture, replace_indices):
     expected_keys = ['image', 'multi', 'poly']
     expected_flat_keys = ['image', 'grid', 'poly']
 
-    original_values = [nested[0], nested[1][0], nested[2]]
     nested.replace(replace_indices, None)
-
-    assert all(
-        (nested[idx] is None if idx == replace_indices else nested[idx] is original_values[i])
-        for i, idx in enumerate([(0,), (1, 0), (2,)])
-    )
-
+    assert nested.get_block(replace_indices) is None
     assert nested.keys() == expected_keys
     assert nested.flatten().keys() == expected_flat_keys
+
+
+def test_get_block(nested_fixture):
+    index = (1, 0)
+    name = 'grid'
+    block_by_index = nested_fixture[index[0]].get_block(index[1])
+    block_by_nested_index = nested_fixture.get_block(index)
+    block_by_name = nested_fixture[index[0]].get_block(name)
+    assert block_by_name is block_by_index is block_by_nested_index
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -230,6 +230,51 @@ def test_slicing_multiple_in_setitem(sphere):
     assert len(multi) == 9
 
 
+def test_replace_nested():
+    image = pv.ImageData()
+    poly = pv.PolyData()
+    grid = pv.UnstructuredGrid()
+    nested = pv.MultiBlock(dict(image=image, poly=poly))
+    multi = pv.MultiBlock(dict(grid=grid))
+    nested.insert(1, multi, 'multi')
+
+    assert nested[0] is image
+    assert nested[1][0] is grid
+    assert nested[2] is poly
+    expected_keys = ['image', 'multi', 'poly']
+    expected_flat_keys = ['image', 'grid', 'poly']
+    assert nested.keys() == expected_keys
+    assert nested.flatten().keys() == expected_flat_keys
+
+    nested.replace((0,), None)
+    assert nested[0] is None
+    assert nested[1][0] is grid
+    assert nested[2] is poly
+    assert nested.keys() == expected_keys
+    assert nested.flatten().keys() == expected_flat_keys
+
+    nested.replace((1, 0), None)
+    assert nested[0] is None
+    assert nested[1][0] is None
+    assert nested[2] is poly
+    assert nested.keys() == expected_keys
+    assert nested.flatten().keys() == expected_flat_keys
+
+    nested.replace((2,), None)
+    assert nested[0] is None
+    assert nested[1][0] is None
+    assert nested[2] is None
+    assert nested.keys() == expected_keys
+    assert nested.flatten().keys() == expected_flat_keys
+
+    match = re.escape('Invalid indices (0, 0).')
+    with pytest.raises(IndexError, match=match):
+        nested.replace((0, 0), None)
+    match = re.escape('Invalid indices (1, 0, 0).')
+    with pytest.raises(IndexError, match=match):
+        nested.replace((1, 0, 0), None)
+
+
 def test_reverse(sphere):
     multi = MultiBlock({f'{i}': sphere for i in range(3)})
     multi.append(pv.Cube(), 'cube')


### PR DESCRIPTION
### Overview

Split from #7200.

The nested ids returned by `recursive_iterator` can be used with the nested replace features from this PR to replace nested blocks.