### PR TITLE
Add generic composite filter to apply any filter to `MultiBlock` blocks

### DIFF
--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -183,7 +183,7 @@ class MultiBlock(
         *,
         skip_none: bool = True,
         skip_empty: bool = True,
-        nested_ids: bool = False,
+        nested_ids: bool | None = None,
         prepend_names: bool = False,
         separator: str = '::',
     ) -> (
@@ -226,7 +226,7 @@ class MultiBlock(
         skip_empty : bool, default: True
             Do not include empty meshes in the iterator.
 
-        nested_ids : bool, default: False
+        nested_ids : bool, default: True
             Prepend parent block indices to the child block indices. If ``True``, a
             tuple of indices is returned for each block. If ``False``, a single integer
             index is returned for each block. This option only applies when ``contents``
@@ -315,15 +315,11 @@ class MultiBlock(
           Z Bounds:   -6.351e-01, 3.649e-01
           N Arrays:   6)
 
-        Compute the length of the longest ``MultiBlock`` using ``'ids'``. Here we also
-        allow empty meshes and none blocks so that all blocks are considered.
+        Iterate through ids. The ids are returned as a tuple by default.
 
-        >>> iterator = multi.recursive_iterator(
-        ...     'ids', skip_empty=False, skip_none=False
-        ... )
-        >>> max_n_blocks = max(iterator) + 1
-        >>> max_n_blocks
-        46
+        >>> iterator = multi.recursive_iterator('ids')
+        >>> next(iterator)
+        (0, 0)
 
         Use the iterator to replace all blocks with new blocks. Similar to a previous
         example, we use a filter but this time the operation is not performed in place.
@@ -339,6 +335,7 @@ class MultiBlock(
         _validation.check_contains(
             ['nested_first', 'nested_last', None], must_contain=order, name='order'
         )
+        nested_ids = contents in ['ids', 'all'] if nested_ids is None else nested_ids
         if nested_ids and contents not in ['ids', 'all']:
             raise ValueError('Nested ids option only applies when ids are returned.')
         if prepend_names and contents not in ['names', 'items', 'all']:
@@ -922,17 +919,17 @@ class MultiBlock(
 
     def get(
         self: MultiBlock,
-        index: str,
+        index: int | str,
         default: _TypeMultiBlockLeaf = None,
     ) -> _TypeMultiBlockLeaf:
-        """Get a block by its name.
+        """Get a block by its index or name.
 
         If the name is non-unique then returns the first occurrence.
         Returns ``default`` if name isn't in the dataset.
 
         Parameters
         ----------
-        index : str
+        index : int | str
             Index or name of the dataset within the multiblock.
 
         default : pyvista.DataSet or pyvista.MultiBlock, optional
@@ -942,6 +939,11 @@ class MultiBlock(
         -------
         pyvista.DataSet or pyvista.MultiBlock or None
             Dataset from the given index if it exists.
+
+        See Also
+        --------
+        get_block
+            Get a block and raise an ``IndexError`` if index is not found.
 
         Examples
         --------
@@ -959,13 +961,62 @@ class MultiBlock(
         except KeyError:
             return default
 
-    def set_block_name(self: MultiBlock, index: int, name: str | None) -> None:
+    def get_block(
+        self: MultiBlock,
+        index: int | Sequence[int] | str,
+    ) -> _TypeMultiBlockLeaf:
+        """Get a block by its index or name.
+
+        If the name is non-unique then returns the first occurrence. This
+        method is similar to using ``[]`` for indexing except this method also
+        supports indexing nested blocks.
+
+        .. versionadded:: 0.45
+
+        Parameters
+        ----------
+        index : int | Sequence[int] | str
+            Index or name of the dataset within the multiblock. Specify a sequence of
+            indices to replace a nested block.
+
+        Returns
+        -------
+        pyvista.DataSet or pyvista.MultiBlock or None
+            Dataset from the given index if it exists.
+
+        See Also
+        --------
+        get
+            Get a block and return a default value instead of raising an ``IndexError``.
+
+        Examples
+        --------
+        >>> import pyvista as pv
+        >>> blocks = pv.MultiBlock([pv.PolyData(), pv.ImageData()])
+        >>> nested = pv.MultiBlock([blocks])
+
+        >>> nested.get_block(0)
+        MultiBlock ...
+        >>> nested.get_block((0, 1))
+        ImageData ...
+
+        """
+        if isinstance(index, Sequence) and not isinstance(index, str):
+            parent, final_index = self._navigate_to_parent(index)
+            return parent[final_index]
+        return self[index]
+
+    def set_block_name(self: MultiBlock, index: int | str, name: str | None) -> None:
         """Set a block's string name at the specified index.
 
         Parameters
         ----------
-        index : int
+        index : int | str
             Index or the dataset within the multiblock.
+
+           .. versionadded:: 0.45
+
+                Allow indexing by name.
 
         name : str, optional
             Name to assign to the block at ``index``. If ``None``, no name is
@@ -987,7 +1038,9 @@ class MultiBlock(
         """
         if name is None:
             return
-        index = range(self.n_blocks)[index]
+        index = (
+            self.get_index_by_name(index) if isinstance(index, str) else range(self.n_blocks)[index]
+        )
         self.GetMetaData(index).Set(_vtk.vtkCompositeDataSet.NAME(), name)
         self.Modified()
 
@@ -1047,14 +1100,20 @@ class MultiBlock(
     def _ipython_key_completions_(self: MultiBlock) -> list[str | None]:
         return self.keys()
 
-    def replace(self: MultiBlock, index: int | Sequence[int], dataset: _TypeMultiBlockLeaf) -> None:
+    def replace(
+        self: MultiBlock, index: int | Sequence[int] | str, dataset: _TypeMultiBlockLeaf
+    ) -> None:
         """Replace dataset at index while preserving key name.
 
         Parameters
         ----------
-        index : int | Sequence[int]
-            Index of the block to replace. Specify a sequence of indices to replace
+        index : int | Sequence[int] | str
+            Index or name of the block to replace. Specify a sequence of indices to replace
             a nested block.
+
+            .. versionadded:: 0.45
+
+                Allow indexing nested blocks.
 
         dataset : pyvista.DataSet or pyvista.MultiBlock
             Dataset for replacing the one at index.
@@ -1094,26 +1153,27 @@ class MultiBlock(
         >>> multi[0][42] = surface
 
         """
-        if isinstance(index, Sequence):
-            self._replace_nested(index, dataset)
+        if isinstance(index, Sequence) and not isinstance(index, str):
+            parent, final_index = self._navigate_to_parent(index)
+            parent.replace(final_index, dataset)
             return
-        name = self.get_block_name(index)
+        name = index if isinstance(index, str) else self.get_block_name(index)
         self[index] = dataset
         self.set_block_name(index, name)
         return
 
-    def _replace_nested(self, indices: Sequence[int], block: _TypeMultiBlockLeaf) -> None:
+    def _navigate_to_parent(self, indices: Sequence[int]) -> tuple[MultiBlock, int]:
+        """Navigate to the parent MultiBlock and return (parent, final_index)."""
         _validation.check_length(indices, min_length=1, name='index')
         # Navigate through the indices except the last one
         target: _TypeMultiBlockLeaf = self
-        for ind in indices[:-1:]:
+        for ind in indices[:-1]:
             if target is None or isinstance(target, pyvista.DataSet):
                 raise IndexError(f'Invalid indices {indices}.')
             target = target[ind]
         if not isinstance(target, MultiBlock):
             raise IndexError(f'Invalid indices {indices}.')
-        # Replace the block
-        target.replace(indices[-1], block)
+        return target, indices[-1]
 
     @overload
     def __setitem__(

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -132,20 +132,18 @@ class CompositeFilters:
         ``MultiBlock`` above is heterogeneous and contains some blocks which are not
         :class:`~pyvista.ImageData`.
 
-        >>> multi.generic_filter('resample', 0.5)
-        Traceback (most recent call last):
-        ...
-        RuntimeError: ...
+        >>> multi.generic_filter('resample', 0.5)  # doctest:+SKIP
+        RuntimeError: The filter 'resample' could not be applied to the block at index 1 with name 'Block-01' and type PolyData.
 
         Use a custom function instead to apply the generic filter conditionally. Here we
         filter the image blocks but simply pass-through a copy of any other blocks.
 
-        >>> def conditional_resample(dataset):
+        >>> def conditional_resample(dataset, *args, **kwargs):
         ...     if isinstance(dataset, pv.ImageData):
-        ...         return dataset.resample(0.5)
+        ...         return dataset.resample(*args, **kwargs)
         ...     return dataset.copy()
 
-        >>> filtered = multi.generic_filter(conditional_resample)
+        >>> filtered = multi.generic_filter(conditional_resample, 0.5)
 
         """
 

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -16,11 +16,12 @@ from pyvista.core.utilities.helpers import wrap
 from pyvista.core.utilities.misc import abstract_class
 
 if TYPE_CHECKING:
-    from typing import Any
     from typing import Callable
 
+    from pyvista import DataSet
     from pyvista import MultiBlock
     from pyvista.core._typing_core import TransformLike
+    from pyvista.core.composite import _TypeMultiBlockLeaf
 
 
 @abstract_class
@@ -29,7 +30,8 @@ class CompositeFilters:
 
     def generic_filter(  # type:ignore[misc]
         self: MultiBlock,
-        function: str | Callable[..., Any],
+        function: str | Callable[[MultiBlock | DataSet, ...], _TypeMultiBlockLeaf],
+        /,
         *args,
         **kwargs,
     ) -> MultiBlock:
@@ -39,6 +41,7 @@ class CompositeFilters:
         this :class:`~pyvista.MultiBlock`.
 
         .. note::
+
             The filter is not applied to any ``None`` blocks. These are simply skipped
             and passed through to the output.
 
@@ -71,6 +74,7 @@ class CompositeFilters:
 
         >>> import pyvista as pv
         >>> from pyvista import examples
+        >>> import numpy as np
         >>> volume = examples.load_uniform()
         >>> poly = examples.load_ant()
         >>> unstructured = examples.load_tetbeam()
@@ -97,8 +101,6 @@ class CompositeFilters:
         independently to have bounds between ``-0.5`` and ``0.5``.
 
         >>> def normalize_bounds(dataset):
-        ...     import numpy as np
-        ...
         ...     dataset = dataset.translate(-np.array(dataset.center))
         ...     bounds = dataset.bounds
         ...     x_scale = 1 / (bounds.x_max - bounds.x_min)

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -105,7 +105,7 @@ class CompositeFilters:
                     nested = ' '
                 else:
                     nested = ' nested '
-                    index = ids_
+                    index = ''.join([f'[{id_}]' for id_ in ids_])
                 msg = f"The filter '{func_name}' could not be applied to the{nested}block at index {index} with name '{name_}' and type {obj_name}."
                 raise RuntimeError(msg) from e
             return output_

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -79,7 +79,7 @@ class CompositeFilters:
         >>> type(multi[0]), type(multi[1]), type(multi[2])
         (<class 'pyvista.core.grid.ImageData'>, <class 'pyvista.core.pointset.PolyData'>, <class 'pyvista.core.pointset.UnstructuredGrid'>)
 
-        Use the generic filter to apply :meth:`~pyvista.DataSetFilters.cast_to_unstructured_grid`
+        Use the generic filter to apply :meth:`~pyvista.DataSet.cast_to_unstructured_grid`
         to all blocks.
 
         >>> filtered = multi.generic_filter('cast_to_unstructured_grid')
@@ -93,7 +93,7 @@ class CompositeFilters:
         >>> filtered = multi.generic_filter('partition', 4, as_composite=True)
 
         Any function can be used as long as it returns a :class:`~pyvista.DataSet` or
-        :class:`~pyvista.MutliBlock.`. For example, we can normalize each block
+        :class:`~pyvista.MultiBlock.`. For example, we can normalize each block
         independently to have bounds between ``-0.5`` and ``0.5``.
 
         >>> def normalize_bounds(dataset):

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -26,8 +26,8 @@ if TYPE_CHECKING:
 class CompositeFilters:
     """An internal class to manage filters/algorithms for composite datasets."""
 
-    def _generic_filter(
-        self,
+    def _generic_filter(  # type:ignore[misc]
+        self: MultiBlock,
         function: str | Callable[..., Any],
         args: tuple[Any, ...] | None = None,
         kwargs: dict[str, Any] | None = None,
@@ -100,12 +100,12 @@ class CompositeFilters:
 
         def apply_filter(block_):
             func = getattr(block_, function) if isinstance(function, str) else function
-            return func(**kwargs) if args is None else func(*args, **kwargs)
+            return func(**kwargs_) if args is None else func(*args, **kwargs_)
 
-        kwargs = kwargs if kwargs else {}
+        kwargs_ = kwargs if kwargs else {}
 
         # Apply filter in-place
-        inplace = kwargs.get('inplace')
+        inplace = kwargs_.get('inplace')
         if inplace:
             iterator = self.recursive_iterator('blocks', skip_none=skip_none, skip_empty=skip_empty)
             for block in iterator:
@@ -118,10 +118,10 @@ class CompositeFilters:
         iterator = output.recursive_iterator(
             'all', skip_none=skip_none, skip_empty=False, nested_ids=True
         )
-        for ids, _, block in iterator:
+        for ids, _, block in iterator:  # type: ignore[misc, attr-defined]
             # Only copy the block if skip empty
-            copy_block = block is not None and skip_empty and block.n_points == 0
-            new_block = block.copy() if copy_block else apply_filter(block)
+            copy_block = block is not None and skip_empty and block.n_points == 0  # type: ignore[union-attr]
+            new_block = block.copy() if copy_block else apply_filter(block)  # type: ignore[union-attr]
             output.replace(ids, new_block)
         return output
 
@@ -325,8 +325,8 @@ class CompositeFilters:
         _update_alg(alg, progress_bar, 'Computing Normals')
         return _get_output(alg)
 
-    def transform(
-        self,
+    def transform(  # type:ignore[misc]
+        self: MultiBlock,
         trans: TransformLike,
         transform_all_input_vectors: bool = False,
         inplace: bool | None = None,

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -92,9 +92,7 @@ class CompositeFilters:
 
         Apply the :meth:`~pyvista.DataSetFilters.explode` filter to all blocks.
 
-        >>> filtered = multi._generic_filter(
-        ...     'explode', kwargs=dict(explode_factor=0.5)
-        ... )
+        >>> filtered = multi._generic_filter('explode', kwargs=dict(factor=0.5))
 
         """
 

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 class CompositeFilters:
     """An internal class to manage filters/algorithms for composite datasets."""
 
-    def _generic_filter(  # type:ignore[misc]
+    def generic_filter(  # type:ignore[misc]
         self: MultiBlock,
         function: str | Callable[..., Any],
         *args,
@@ -82,7 +82,7 @@ class CompositeFilters:
         Use the generic filter to apply :meth:`~pyvista.DataSetFilters.cast_to_unstructured_grid`
         to all blocks.
 
-        >>> filtered = multi._generic_filter('cast_to_unstructured_grid')
+        >>> filtered = multi.generic_filter('cast_to_unstructured_grid')
 
         >>> type(filtered[0]), type(filtered[1]), type(filtered[2])
         (<class 'pyvista.core.pointset.UnstructuredGrid'>, <class 'pyvista.core.pointset.UnstructuredGrid'>, <class 'pyvista.core.pointset.UnstructuredGrid'>)
@@ -90,7 +90,7 @@ class CompositeFilters:
         Use the :meth:`~pyvista.DataSetFilters.partition` filter on all blocks.
         Any arguments can be specified as though the filter is being used directly.
 
-        >>> filtered = multi._generic_filter('partition', 4, as_composite=True)
+        >>> filtered = multi.generic_filter('partition', 4, as_composite=True)
 
         Any function can be used as long as it returns a :class:`pyvista.DataSet`.
         For example, we can normalize each block independently to have bounds between
@@ -106,7 +106,7 @@ class CompositeFilters:
         ...     z_scale = 1 / (bounds.z_max - bounds.z_min)
         ...     return dataset.scale((x_scale, y_scale, z_scale))
 
-        >>> multi._generic_filter(normalize_bounds)
+        >>> multi.generic_filter(normalize_bounds)
         >>> multi
         MultiBlock (...)
           N Blocks:   3
@@ -417,7 +417,7 @@ class CompositeFilters:
 
         inplace = check_inplace(cls=type(self), inplace=inplace)
 
-        return self._generic_filter(
+        return self.generic_filter(
             'transform',
             pyvista.Transform(trans),
             transform_all_input_vectors=transform_all_input_vectors,

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -118,13 +118,34 @@ class CompositeFilters:
         ...     z_scale = 1 / (bounds.z_max - bounds.z_min)
         ...     return dataset.scale((x_scale, y_scale, z_scale))
 
-        >>> multi = multi.generic_filter(normalize_bounds)
-        >>> multi
+        >>> filtered = multi.generic_filter(normalize_bounds)
+        >>> filtered
         MultiBlock (...)
           N Blocks:   3
           X Bounds:   -5.000e-01, 5.000e-01
           Y Bounds:   -5.000e-01, 5.000e-01
           Z Bounds:   -5.000e-01, 5.000e-01
+
+        The generic filter will fail if the filter can only be applied to some blocks
+        but not others. For example, it is not possible to use the
+        :meth:`~pyvista.ImageDataFilter.resample` filter generically since the
+        ``MultiBlock`` above is heterogeneous and contains some blocks which are not
+        :class:`~pyvista.ImageData`.
+
+        >>> multi.generic_filter('resample', 0.5)
+        Traceback (most recent call last):
+        ...
+        RuntimeError: ...
+
+        Use a custom function instead to apply the generic filter conditionally. Here we
+        filter the image blocks but simply pass-through a copy of any other blocks.
+
+        >>> def conditional_resample(dataset):
+        ...     if isinstance(dataset, pv.ImageData):
+        ...         return dataset.resample(0.5)
+        ...     return dataset.copy()
+
+        >>> filtered = multi.generic_filter(conditional_resample)
 
         """
 

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -31,7 +31,7 @@ class CompositeFilters:
 
     def generic_filter(  # type:ignore[misc]
         self: MultiBlock,
-        function: str | Callable[[DataSet, *tuple[Any, ...]], _TypeMultiBlockLeaf],
+        function: str | Callable[..., _TypeMultiBlockLeaf],
         /,
         *args,
         **kwargs,
@@ -107,7 +107,7 @@ class CompositeFilters:
         >>> filtered = multi.generic_filter('partition', 4, as_composite=True)
 
         Any function can be used as long as it returns a :class:`~pyvista.DataSet` or
-        :class:`~pyvista.MultiBlock.`. For example, we can normalize each block
+        :class:`~pyvista.MultiBlock`. For example, we can normalize each block
         independently to have bounds between ``-0.5`` and ``0.5``.
 
         >>> def normalize_bounds(dataset):

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -31,7 +31,7 @@ class CompositeFilters:
 
     def generic_filter(  # type:ignore[misc]
         self: MultiBlock,
-        function: str | Callable[[MultiBlock | DataSet, *tuple[Any, ...]], _TypeMultiBlockLeaf],
+        function: str | Callable[[DataSet, *tuple[Any, ...]], _TypeMultiBlockLeaf],
         /,
         *args,
         **kwargs,
@@ -56,7 +56,9 @@ class CompositeFilters:
         Parameters
         ----------
         function : Callable | str
-            Callable function or name of the method to apply to each block.
+            Callable function or name of the method to apply to each block. The function
+            should accept a :class:`~pyvista.DataSet` as input and return either a
+            :class:`~pyvista.DataSet` or :class:`~pyvista.MultiBlock` as output.
 
         *args : Any, optional
             Arguments to use with the specified ``function``.
@@ -68,6 +70,13 @@ class CompositeFilters:
         -------
         MultiBlock
             Filtered dataset.
+
+        Raises
+        ------
+        RuntimeError
+            Raised if the filter cannot be applied to any block for any reason. This
+            overrides ``TypeError``, ``ValueError``, ``AttributeError`` errors when
+            filtering.
 
         Examples
         --------
@@ -102,7 +111,9 @@ class CompositeFilters:
         independently to have bounds between ``-0.5`` and ``0.5``.
 
         >>> def normalize_bounds(dataset):
+        ...     # Center the dataset
         ...     dataset = dataset.translate(-np.array(dataset.center))
+        ...     # Scale the dataset
         ...     bounds = dataset.bounds
         ...     x_scale = 1 / (bounds.x_max - bounds.x_min)
         ...     y_scale = 1 / (bounds.y_max - bounds.y_min)

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -128,7 +128,7 @@ class CompositeFilters:
 
         The generic filter will fail if the filter can only be applied to some blocks
         but not others. For example, it is not possible to use the
-        :meth:`~pyvista.ImageDataFilter.resample` filter generically since the
+        :meth:`~pyvista.ImageDataFilters.resample` filter generically since the
         ``MultiBlock`` above is heterogeneous and contains some blocks which are not
         :class:`~pyvista.ImageData`.
 

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -16,10 +16,8 @@ from pyvista.core.utilities.helpers import wrap
 from pyvista.core.utilities.misc import abstract_class
 
 if TYPE_CHECKING:
-    from typing import Any
     from typing import Callable
 
-    from pyvista import DataSet
     from pyvista import MultiBlock
     from pyvista.core._typing_core import TransformLike
     from pyvista.core.composite import _TypeMultiBlockLeaf

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -153,7 +153,7 @@ class CompositeFilters:
         # Create a copy and replace all the blocks
         output = pyvista.MultiBlock()
         output.shallow_copy(self, recursive=True)
-        for ids, name, block in get_iterator(output):  # type: ignore[misc, attr-defined]
+        for ids, name, block in get_iterator(output):
             output.replace(ids, apply_filter(ids, name, block))
         return output
 

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -16,6 +16,7 @@ from pyvista.core.utilities.helpers import wrap
 from pyvista.core.utilities.misc import abstract_class
 
 if TYPE_CHECKING:
+    from typing import Any
     from typing import Callable
 
     from pyvista import DataSet
@@ -30,7 +31,7 @@ class CompositeFilters:
 
     def generic_filter(  # type:ignore[misc]
         self: MultiBlock,
-        function: str | Callable[[MultiBlock | DataSet, ...], _TypeMultiBlockLeaf],
+        function: str | Callable[[MultiBlock | DataSet, *tuple[Any, ...]], _TypeMultiBlockLeaf],
         /,
         *args,
         **kwargs,
@@ -359,8 +360,8 @@ class CompositeFilters:
         _update_alg(alg, progress_bar, 'Computing Normals')
         return _get_output(alg)
 
-    def transform(  # type:ignore[misc]
-        self: MultiBlock,
+    def transform(
+        self,
         trans: TransformLike,
         transform_all_input_vectors: bool = False,
         inplace: bool | None = None,

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -419,10 +419,15 @@ class CompositeFilters:
 
         inplace = check_inplace(cls=type(self), inplace=inplace)
 
-        return self.generic_filter(
-            'transform',
-            pyvista.Transform(trans),
-            transform_all_input_vectors=transform_all_input_vectors,
-            inplace=inplace,
-            progress_bar=progress_bar,
-        )
+        trans = pyvista.Transform(trans)
+        output = self if inplace else self.copy()  # type: ignore[attr-defined]
+        for name in self.keys():  # type: ignore[attr-defined]
+            block = output[name]  # type: ignore[index]
+            if block is not None:
+                block.transform(
+                    trans,
+                    transform_all_input_vectors=transform_all_input_vectors,
+                    inplace=True,
+                    progress_bar=progress_bar,
+                )
+        return output

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -92,9 +92,9 @@ class CompositeFilters:
 
         >>> filtered = multi.generic_filter('partition', 4, as_composite=True)
 
-        Any function can be used as long as it returns a :class:`pyvista.DataSet`.
-        For example, we can normalize each block independently to have bounds between
-        ``-1.0`` and ``1.0``.
+        Any function can be used as long as it returns a :class:`~pyvista.DataSet` or
+        :class:`~pyvista.MutliBlock.`. For example, we can normalize each block
+        independently to have bounds between ``-0.5`` and ``0.5``.
 
         >>> def normalize_bounds(dataset):
         ...     import numpy as np
@@ -106,7 +106,7 @@ class CompositeFilters:
         ...     z_scale = 1 / (bounds.z_max - bounds.z_min)
         ...     return dataset.scale((x_scale, y_scale, z_scale))
 
-        >>> multi.generic_filter(normalize_bounds)
+        >>> multi = multi.generic_filter(normalize_bounds)
         >>> multi
         MultiBlock (...)
           N Blocks:   3

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -1149,27 +1149,46 @@ def test_flatten_copy(multiblock_all, copy):
     assert shares_memory == (not copy)
 
 
-def test_generic_filter(multiblock_all_with_nested_and_none):
+@pytest.mark.parametrize(
+    'function', [lambda x: x.cast_to_unstructured_grid(), 'cast_to_unstructured_grid']
+)
+def test_generic_filter(multiblock_all_with_nested_and_none, function):
+    # Include empty mesh
+    empty_mesh = pv.PolyData()
+    multiblock_all_with_nested_and_none.append(empty_mesh)
+
+    output = multiblock_all_with_nested_and_none.generic_filter(function)
+    flat_outputs = output.flatten()
+    # Make sure no `None` blocks were removed
+    assert None in flat_outputs
+    # Check output
+    for block in flat_outputs:
+        assert isinstance(block, pv.UnstructuredGrid) or block is None
+
+
+@pytest.mark.parametrize('inplace', [True, False])
+def test_generic_filter_inplace(multiblock_all_with_nested_and_none, inplace):
     # Include empty mesh
     empty_mesh = pv.PolyData()
     multiblock_all_with_nested_and_none.append(empty_mesh)
     flat_inputs = multiblock_all_with_nested_and_none.flatten()
-
-    output = multiblock_all_with_nested_and_none.generic_filter('cast_to_unstructured_grid')
-
+    output = multiblock_all_with_nested_and_none.generic_filter(
+        'extract_largest', inplace, progress_bar=True
+    )
     flat_outputs = output.flatten()
-    assert None in flat_outputs
 
     assert flat_inputs.n_blocks == flat_outputs.n_blocks
-    for block in flat_outputs:
-        assert isinstance(block, pv.UnstructuredGrid) or block is None
+    for block_in, block_out in zip(flat_inputs, flat_outputs):
+        assert block_in is not block_out or block_out is None
 
+
+def test_generic_filter_raises(multiblock_all_with_nested_and_none):
     match = "The filter 'resample' could not be applied to the block at index 1 with name 'Block-01' and type RectilinearGrid."
     with pytest.raises(RuntimeError, match=match):
         multiblock_all_with_nested_and_none.generic_filter(
             'resample',
         )
-
+    # Test error message with nested index
     multi = pv.MultiBlock([multiblock_all_with_nested_and_none])
     match = "The filter 'resample' could not be applied to the nested block at index [0][1] with name 'Block-01' and type RectilinearGrid."
     with pytest.raises(RuntimeError, match=re.escape(match)):

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -515,6 +515,7 @@ def test_transform_filter(ant, sphere, airplane, tetbeam, inplace):
     assert (output is multi) == inplace
     for block_in, block_out in zip(multi, output):
         assert (block_in is block_out) == inplace or (block_in is None)
+        assert type(block_in) is type(block_out)
     assert np.allclose(bounds_before + NUMBER, bounds_after)
     assert n_blocks_before == n_blocks_after
     assert keys_before == keys_after

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -230,6 +230,51 @@ def test_slicing_multiple_in_setitem(sphere):
     assert len(multi) == 9
 
 
+def test_replace_nested():
+    image = pv.ImageData()
+    poly = pv.PolyData()
+    grid = pv.UnstructuredGrid()
+    nested = pv.MultiBlock(dict(image=image, poly=poly))
+    multi = pv.MultiBlock(dict(grid=grid))
+    nested.insert(1, multi, 'multi')
+
+    assert nested[0] is image
+    assert nested[1][0] is grid
+    assert nested[2] is poly
+    expected_keys = ['image', 'multi', 'poly']
+    expected_flat_keys = ['image', 'grid', 'poly']
+    assert nested.keys() == expected_keys
+    assert nested.flatten().keys() == expected_flat_keys
+
+    nested.replace((0,), None)
+    assert nested[0] is None
+    assert nested[1][0] is grid
+    assert nested[2] is poly
+    assert nested.keys() == expected_keys
+    assert nested.flatten().keys() == expected_flat_keys
+
+    nested.replace((1, 0), None)
+    assert nested[0] is None
+    assert nested[1][0] is None
+    assert nested[2] is poly
+    assert nested.keys() == expected_keys
+    assert nested.flatten().keys() == expected_flat_keys
+
+    nested.replace((2,), None)
+    assert nested[0] is None
+    assert nested[1][0] is None
+    assert nested[2] is None
+    assert nested.keys() == expected_keys
+    assert nested.flatten().keys() == expected_flat_keys
+
+    match = re.escape('Invalid indices (0, 0, 0).')
+    with pytest.raises(IndexError, match=match):
+        nested.replace((0, 0, 0), None)
+    match = re.escape('Invalid indices (0, 0).')
+    with pytest.raises(IndexError, match=match):
+        nested.replace((0, 0), None)
+
+
 def test_reverse(sphere):
     multi = MultiBlock({f'{i}': sphere for i in range(3)})
     multi.append(pv.Cube(), 'cube')
@@ -928,11 +973,23 @@ def test_recursive_iterator(multiblock_all_with_nested_and_none):
 
 
 def test_recursive_iterator_contents(multiblock_all_with_nested_and_none):
-    iterator = multiblock_all_with_nested_and_none.recursive_iterator(contents='names')
+    iterator = multiblock_all_with_nested_and_none.recursive_iterator('ids')
+    assert all(isinstance(item, int) for item in iterator)
+
+    iterator = multiblock_all_with_nested_and_none.recursive_iterator('names')
     assert all(isinstance(item, str) for item in iterator)
 
-    iterator = multiblock_all_with_nested_and_none.recursive_iterator(contents='items')
+    iterator = multiblock_all_with_nested_and_none.recursive_iterator('blocks')
+    assert all(isinstance(item, pv.DataSet) for item in iterator)
+
+    iterator = multiblock_all_with_nested_and_none.recursive_iterator('items')
     for name, block in iterator:
+        assert isinstance(name, str)
+        assert isinstance(block, pv.DataSet) or block is None
+
+    iterator = multiblock_all_with_nested_and_none.recursive_iterator('all')
+    for id_, name, block in iterator:
+        assert isinstance(id_, int)
         assert isinstance(name, str)
         assert isinstance(block, pv.DataSet) or block is None
 
@@ -945,7 +1002,7 @@ def test_recursive_iterator_prepend_names(separator, prepend_names):
     expected_names = [name.replace('::', separator) for name in expected_names]
 
     iterator = nested.recursive_iterator(
-        prepend_names=prepend_names, separator=separator, contents='names', skip_none=False
+        'names', prepend_names=prepend_names, separator=separator, skip_none=False
     )
     names = list(iterator)
     assert names == expected_names
@@ -956,41 +1013,106 @@ def test_recursive_iterator_prepend_names(separator, prepend_names):
     assert flattened.keys() == expected_names
 
 
+@pytest.mark.parametrize('nested_ids', [True, False])
+def test_recursive_iterator_ids(nested_ids):
+    nested = MultiBlock(dict(a=MultiBlock(dict(b=MultiBlock(dict(c=None)), d=None)), e=None))
+    expected_ids = [(0, 0, 0), (0, 1), (1,)] if nested_ids else [0, 1, 1]
+
+    iterator = nested.recursive_iterator('ids', nested_ids=nested_ids, skip_none=False)
+    ids = list(iterator)
+    assert ids == expected_ids
+
+
+def test_recursive_iterator_raises():
+    multi = pv.MultiBlock()
+
+    match = 'Nested ids option only applies when ids are returned.'
+    with pytest.raises(ValueError, match=match):
+        multi.recursive_iterator('names', nested_ids=True)
+    with pytest.raises(ValueError, match=match):
+        multi.recursive_iterator('items', nested_ids=True)
+
+    match = 'Prepend names option only applies when names are returned.'
+    with pytest.raises(ValueError, match=match):
+        multi.recursive_iterator('ids', prepend_names=True)
+    with pytest.raises(ValueError, match=match):
+        multi.recursive_iterator('blocks', prepend_names=True)
+
+
 def test_recursive_iterator_order():
-    nested = pv.MultiBlock(dict(image=pv.ImageData(), poly=pv.PolyData()))
-    multi = pv.MultiBlock(dict(grid=pv.UnstructuredGrid()))
+    # Generated nested MultiBlock dataset with three DataSet nodes
+    image = pv.ImageData()
+    poly = pv.PolyData()
+    grid = pv.UnstructuredGrid()
+    nested = pv.MultiBlock(dict(image=image, poly=poly))
+    multi = pv.MultiBlock(dict(grid=grid))
     nested.insert(1, multi)
     assert isinstance(nested[0], pv.ImageData)
     assert isinstance(nested[1], pv.MultiBlock)
     assert isinstance(nested[1][0], pv.UnstructuredGrid)
     assert isinstance(nested[2], pv.PolyData)
 
+    common_kwargs = dict(skip_empty=False, nested_ids=True, contents='all')
+
+    iterator = nested.recursive_iterator(order=None, **common_kwargs)
+    ids0, names0, block0 = next(iterator)
+    ids1, names1, block1 = next(iterator)
+    ids2, names2, block2 = next(iterator)
+
+    # Ids should refer to original datasets in input
+    assert ids0 == (0,)
+    assert ids1 == (1, 0)
+    assert ids2 == (2,)
+    assert nested[ids0[0]] is image
+    assert nested[ids1[0]][ids1[1]] is grid
+    assert nested[ids2[0]] is poly
     # Expect nested dataset in center
-    iterator = list(nested.recursive_iterator('items', order=None, skip_empty=False))
-    assert iterator[0][0] == 'image'
-    assert iterator[1][0] == 'grid'
-    assert iterator[2][0] == 'poly'
-    assert isinstance(iterator[0][1], pv.ImageData)
-    assert isinstance(iterator[1][1], pv.UnstructuredGrid)
-    assert isinstance(iterator[2][1], pv.PolyData)
+    assert names0 == 'image'
+    assert names1 == 'grid'
+    assert names2 == 'poly'
+    assert isinstance(block0, pv.ImageData)
+    assert isinstance(block1, pv.UnstructuredGrid)
+    assert isinstance(block2, pv.PolyData)
 
+    iterator = nested.recursive_iterator(order='nested_last', **common_kwargs)
+    ids0, names0, block0 = next(iterator)
+    ids1, names1, block1 = next(iterator)
+    ids2, names2, block2 = next(iterator)
+
+    # Ids should refer to original datasets in input
+    assert ids0 == (0,)
+    assert ids1 == (2,)
+    assert ids2 == (1, 0)
+    assert nested[ids0[0]] is image
+    assert nested[ids1[0]] is poly
+    assert nested[ids2[0]][ids2[1]] is grid
     # Expect nested dataset last
-    iterator = list(nested.recursive_iterator('items', order='nested_last', skip_empty=False))
-    assert iterator[0][0] == 'image'
-    assert iterator[1][0] == 'poly'
-    assert iterator[2][0] == 'grid'
-    assert isinstance(iterator[0][1], pv.ImageData)
-    assert isinstance(iterator[1][1], pv.PolyData)
-    assert isinstance(iterator[2][1], pv.UnstructuredGrid)
+    assert names0 == 'image'
+    assert names1 == 'poly'
+    assert names2 == 'grid'
+    assert isinstance(block0, pv.ImageData)
+    assert isinstance(block1, pv.PolyData)
+    assert isinstance(block2, pv.UnstructuredGrid)
 
+    iterator = nested.recursive_iterator(order='nested_first', **common_kwargs)
+    ids0, names0, block0 = next(iterator)
+    ids1, names1, block1 = next(iterator)
+    ids2, names2, block2 = next(iterator)
+
+    # Ids should refer to original datasets in input
+    assert ids0 == (1, 0)
+    assert ids1 == (0,)
+    assert ids2 == (2,)
+    assert nested[ids0[0]][ids0[1]] is grid
+    assert nested[ids1[0]] is image
+    assert nested[ids2[0]] is poly
     # Expect nested dataset first
-    iterator = list(nested.recursive_iterator('items', order='nested_first', skip_empty=False))
-    assert iterator[0][0] == 'grid'
-    assert iterator[1][0] == 'image'
-    assert iterator[2][0] == 'poly'
-    assert isinstance(iterator[0][1], pv.UnstructuredGrid)
-    assert isinstance(iterator[1][1], pv.ImageData)
-    assert isinstance(iterator[2][1], pv.PolyData)
+    assert names0 == 'grid'
+    assert names1 == 'image'
+    assert names2 == 'poly'
+    assert isinstance(block0, pv.UnstructuredGrid)
+    assert isinstance(block1, pv.ImageData)
+    assert isinstance(block2, pv.PolyData)
 
 
 def test_flatten(multiblock_all_with_nested_and_none):

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -1155,7 +1155,7 @@ def test_generic_filter(multiblock_all_with_nested_and_none):
     multiblock_all_with_nested_and_none.append(empty_mesh)
     flat_inputs = multiblock_all_with_nested_and_none.flatten()
 
-    output = multiblock_all_with_nested_and_none._generic_filter('cast_to_unstructured_grid')
+    output = multiblock_all_with_nested_and_none.generic_filter('cast_to_unstructured_grid')
 
     flat_outputs = output.flatten()
     assert None in flat_outputs
@@ -1166,13 +1166,13 @@ def test_generic_filter(multiblock_all_with_nested_and_none):
 
     match = "The filter 'resample' could not be applied to the block at index 1 with name 'Block-01' and type RectilinearGrid."
     with pytest.raises(RuntimeError, match=match):
-        multiblock_all_with_nested_and_none._generic_filter(
+        multiblock_all_with_nested_and_none.generic_filter(
             'resample',
         )
 
     multi = pv.MultiBlock([multiblock_all_with_nested_and_none])
     match = "The filter 'resample' could not be applied to the nested block at index [0][1] with name 'Block-01' and type RectilinearGrid."
     with pytest.raises(RuntimeError, match=re.escape(match)):
-        multi._generic_filter(
+        multi.generic_filter(
             'resample',
         )

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -1147,3 +1147,25 @@ def test_flatten_copy(multiblock_all, copy):
     data_after = multi_out.field_data['foo']
     shares_memory = np.shares_memory(data_after, data_before)
     assert shares_memory == (not copy)
+
+
+def test_generic_filter(multiblock_all_with_nested_and_none):
+    # Include empty mesh
+    empty_mesh = pv.PolyData()
+    multiblock_all_with_nested_and_none.append(empty_mesh)
+    flat_inputs = multiblock_all_with_nested_and_none.flatten()
+
+    output = multiblock_all_with_nested_and_none._generic_filter('cast_to_unstructured_grid')
+
+    flat_outputs = output.flatten()
+    assert None in flat_outputs
+
+    assert flat_inputs.n_blocks == flat_outputs.n_blocks
+    for block in flat_outputs:
+        assert isinstance(block, pv.UnstructuredGrid) or block is None
+
+    match = "The filter 'resample' could not be applied to the block at index 1 with name 'Block-01' and type RectilinearGrid."
+    with pytest.raises(RuntimeError, match=match):
+        multiblock_all_with_nested_and_none._generic_filter(
+            'resample',
+        )

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -1169,3 +1169,10 @@ def test_generic_filter(multiblock_all_with_nested_and_none):
         multiblock_all_with_nested_and_none._generic_filter(
             'resample',
         )
+
+    multi = pv.MultiBlock([multiblock_all_with_nested_and_none])
+    match = "The filter 'resample' could not be applied to the nested block at index [0][1] with name 'Block-01' and type RectilinearGrid."
+    with pytest.raises(RuntimeError, match=re.escape(match)):
+        multi._generic_filter(
+            'resample',
+        )

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -1064,31 +1064,19 @@ def test_recursive_iterator_raises():
     ],
 )
 def test_recursive_iterator_order(nested_fixture, order, expected_ids, expected_names):
-    nested = nested_fixture
-    image = nested_fixture['image']
-    poly = nested_fixture['poly']
-    grid = nested_fixture['multi']['grid']
+    # Store instances of each mesh for testing iterator blocks
+    expected_meshes = dict(
+        image=nested_fixture['image'],
+        poly=nested_fixture['poly'],
+        grid=nested_fixture['multi']['grid'],
+    )
+
     common_kwargs = dict(skip_empty=False, nested_ids=True, contents='all')
-
-    iterator = nested.recursive_iterator(order=order, **common_kwargs)
-    ids0, names0, block0 = next(iterator)
-    ids1, names1, block1 = next(iterator)
-    ids2, names2, block2 = next(iterator)
-
-    # Test ids
-    assert ids0 == expected_ids[0]
-    assert ids1 == expected_ids[1]
-    assert ids2 == expected_ids[2]
-
-    # Test names
-    assert names0 == expected_names[0]
-    assert names1 == expected_names[1]
-    assert names2 == expected_names[2]
-
-    # Test blocks
-    assert nested.get_block(ids0) is locals()[names0]
-    assert nested.get_block(ids1) is locals()[names1]
-    assert nested.get_block(ids2) is locals()[names2]
+    iterator = nested_fixture.recursive_iterator(order=order, **common_kwargs)
+    for i, (ids, name, block) in enumerate(iterator):
+        assert ids == expected_ids[i]
+        assert name == expected_names[i]
+        assert block is expected_meshes[name]
 
 
 def test_flatten(multiblock_all_with_nested_and_none):


### PR DESCRIPTION
### Overview

Use the new `MultiBlock.recursive_iterator` to apply filters generically.

~The filter is currently private as the API may change. E.g. there are some options specific to `CompositeFilters` such as `nested` which would be good to include, but this may require updates to the iterator or a new helper method.~
This filter is public.

Note: this PR depends on #7200  and #7202 