### PR TITLE
Fix vale error 'Built-in' should use title-style capitalization

### DIFF
--- a/doc/source/api/examples/index.rst
+++ b/doc/source/api/examples/index.rst
@@ -6,7 +6,7 @@ Examples
 PyVista contains a variety of built-in demos and downloadable example
 datasets.
 
-Built-in
+Built-In
 --------
 Several built-in datasets are included and are available for offline use.
 For example, load the built-in :func:`~pyvista.examples.examples.load_random_hills`


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Fix vale error 'Built-in' should use title-style capitalization.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None