### PR TITLE
Remove unnecessary Updates in nek5000Reader and ExodusIIReader

### DIFF
--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -2205,8 +2205,6 @@ class Nek5000Reader(BaseReader, PointCellDataSelection, TimeReader):
         vtkinfo = self.reader.GetExecutive().GetOutputInformation(0)
         vtkinfo.Set(key, time_value)
 
-        self.reader.Update()
-
     def set_active_time_point(self, time_point):
         """Set active time or iteration by index.
 
@@ -3172,7 +3170,6 @@ class ExodusIIReader(BaseReader, PointCellDataSelection, TimeReader):
         """
         self.reader.SetApplyDisplacements(True)
         self.reader.SetDisplacementMagnitude(displacement_magnitude)
-        self.reader.Update()
 
     def disable_displacements(self):
         """Nodal positions are not 'displaced'."""
@@ -3444,7 +3441,6 @@ class ExodusIIReader(BaseReader, PointCellDataSelection, TimeReader):
 
         """
         self.reader.SetTimeStep(time_point)
-        self.reader.Update()
 
 
 class ExodusIIBlockSet:

--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -2144,7 +2144,7 @@ class Nek5000Reader(BaseReader, PointCellDataSelection, TimeReader):
         )
         key = vtkStreaming.TIME_STEPS()
 
-        vtkinfo = self.reader.GetExecutive().GetOutputInformation(0)
+        vtkinfo = self.reader.GetOutputInformation(0)
         return [vtkinfo.Get(key, i) for i in range(self.number_time_points)]
 
     def time_point_value(self, time_point):
@@ -2175,7 +2175,7 @@ class Nek5000Reader(BaseReader, PointCellDataSelection, TimeReader):
             'vtkCommonExecutionModel', 'vtkStreamingDemandDrivenPipeline'
         )
         key = vtkStreaming.UPDATE_TIME_STEP()
-        vtkinfo = self.reader.GetExecutive().GetOutputInformation(0)
+        vtkinfo = self.reader.GetOutputInformation(0)
         return vtkinfo.Get(key)
 
     @property
@@ -2202,7 +2202,7 @@ class Nek5000Reader(BaseReader, PointCellDataSelection, TimeReader):
             'vtkCommonExecutionModel', 'vtkStreamingDemandDrivenPipeline'
         )
         key = vtkStreaming.UPDATE_TIME_STEP()
-        vtkinfo = self.reader.GetExecutive().GetOutputInformation(0)
+        vtkinfo = self.reader.GetOutputInformation(0)
         vtkinfo.Set(key, time_value)
 
     def set_active_time_point(self, time_point):
@@ -3384,7 +3384,7 @@ class ExodusIIReader(BaseReader, PointCellDataSelection, TimeReader):
             'vtkCommonExecutionModel', 'vtkStreamingDemandDrivenPipeline'
         )
         key = vtkStreaming.TIME_STEPS()
-        vtkinfo = self.reader.GetExecutive().GetOutputInformation(0)
+        vtkinfo = self.reader.GetOutputInformation(0)
         return [vtkinfo.Get(key, i) for i in range(self.number_time_points)]
 
     def time_point_value(self, time_point):


### PR DESCRIPTION
### Overview
This PR is a small update to remove some `Update()` calls from the Nek5000Reader and ExodusIIReader. I believe that these are unnecessary and caused some extra overhead particularly in the former where it was called when the time was set, which is done on class initialisation. This meant that if the time was changed before `read()` then `Update() would be called twice when only required once, unless I have misunderstood the purpose of update in reader classes.
