### PR TITLE
Skip labeling if the pull request already has labels

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-20.04
+    # Skip the job if the pull request already has any labels
+    if: github.event.pull_request.labels | length == 0
     steps:
       - name: Label based on changed files
         uses: actions/labeler@v5


### PR DESCRIPTION
### Overview

This pull request updates the **Pull Request Labeler** workflow to prevent labeling if any labels are already present on the pull request. This ensures that existing labels are not overridden by the automated labeling process.

### Details

- Added a condition `if: github.event.pull_request.labels | length == 0` to skip the job if labels are already applied.
- Ensured that all comments in the workflow file are written in English for consistency.