### PR TITLE
Align API for `get_data_range` across classes

### DIFF
--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -30,6 +30,7 @@ from .filters import CompositeFilters
 from .pyvista_ndarray import pyvista_ndarray
 from .utilities.arrays import CellLiteral
 from .utilities.arrays import FieldAssociation
+from .utilities.arrays import FieldLiteral
 from .utilities.arrays import PointLiteral
 from .utilities.arrays import parse_field_choice
 from .utilities.geometric_objects import Box
@@ -740,7 +741,10 @@ class MultiBlock(
         return sum(block.volume for block in self if block)
 
     def get_data_range(  # type: ignore[override]
-        self: MultiBlock, name: str, allow_missing: bool = False
+        self: MultiBlock,
+        name: str,
+        allow_missing: bool = False,
+        preference: PointLiteral | CellLiteral | FieldLiteral = 'cell',
     ) -> tuple[float, float]:
         """Get the min/max of an array given its name across all blocks.
 
@@ -751,6 +755,13 @@ class MultiBlock(
 
         allow_missing : bool, default: False
             Allow a block to be missing the named array.
+
+        preference : str, default: "cell"
+            When scalars is specified, this is the preferred array type
+            to search for in the dataset.  Must be either ``'point'``,
+            ``'cell'``, or ``'field'``.
+
+            .. versionadded:: 0.45
 
         Returns
         -------
@@ -765,7 +776,7 @@ class MultiBlock(
                 continue
             # get the scalars if available - recursive
             try:
-                tmi, tma = data.get_data_range(name)
+                tmi, tma = data.get_data_range(name, preference=preference)
             except KeyError:
                 if allow_missing:
                     continue

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -742,7 +742,7 @@ class MultiBlock(
 
     def get_data_range(  # type: ignore[override]
         self: MultiBlock,
-        name: str,
+        name: str | None,
         allow_missing: bool = False,
         preference: PointLiteral | CellLiteral | FieldLiteral = 'cell',
     ) -> tuple[float, float]:
@@ -750,8 +750,9 @@ class MultiBlock(
 
         Parameters
         ----------
-        name : str
-            Name of the array.
+        name : str, optional
+            The name of the array to get the range. If ``None``, the
+            active scalars are used.
 
         allow_missing : bool, default: False
             Allow a block to be missing the named array.

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -230,7 +230,9 @@ class DataObject:
                     del fdata[key]
 
     @abstractmethod
-    def get_data_range(self: Self) -> tuple[float, float]:  # pragma: no cover
+    def get_data_range(
+        self: Self, name: str | None, preference: FieldAssociation | str
+    ) -> tuple[float, float]:  # pragma: no cover
         """Get the non-NaN min and max of a named array."""
         raise NotImplementedError(
             f'{type(self)} mesh type does not have a `get_data_range` method.',

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -907,7 +907,7 @@ class DataSet(DataSetFilters, DataObject):
             return self.point_data.active_normals
         return self.cell_data.active_normals
 
-    def get_data_range(
+    def get_data_range(  # type: ignore[override]
         self: Self,
         arr_var: str | NumpyArray[float] | None = None,
         preference: PointLiteral | CellLiteral | FieldLiteral = 'cell',

--- a/pyvista/core/objects.py
+++ b/pyvista/core/objects.py
@@ -346,7 +346,7 @@ class Table(DataObject, _vtk.vtkTable):
             "Please use the `to_pandas` method and harness Pandas' wonderful file IO methods.",
         )
 
-    def get_data_range(
+    def get_data_range(  # type: ignore[override]
         self,
         arr: str | None = None,
         preference: FieldLiteral | RowLiteral = 'row',

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -666,13 +666,25 @@ def test_multi_block_save_lines(tmpdir):
 
 
 def test_multi_block_data_range():
-    volume = pv.Wavelet()
+    # Create ambiguous point and cell data
+    volume = pv.ImageData(dimensions=(10, 10, 10))
+    point_data_value = 99
+    cell_data_value = 42
+    volume.point_data['data'] = np.ones((volume.n_points,)) * point_data_value
+    volume.cell_data['data'] = np.ones((volume.n_cells,)) * cell_data_value
+
+    # Create multiblock
     a = volume.slice_along_axis(5, 'x')
     with pytest.raises(KeyError):
         a.get_data_range('foo')
-    mi, ma = a.get_data_range(volume.active_scalars_name)
-    assert mi is not None
-    assert ma is not None
+    mi, ma = a.get_data_range(volume.active_scalars_name, preference='point')
+    assert mi == point_data_value
+    assert ma == point_data_value
+
+    mi, ma = a.get_data_range(volume.active_scalars_name, preference='cell')
+    assert mi == cell_data_value
+    assert ma == cell_data_value
+
     # Test on a nested MultiBlock
     b = volume.slice_along_axis(5, 'y')
     slices = pv.MultiBlock([a, b])

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1003,11 +1003,11 @@ def test_get_data_range(grid):
     assert len(rng) == 2
     assert np.allclose(rng, (1, 302))
 
-    rng = grid.get_data_range('sample_point_scalars')
+    rng = grid.get_data_range('sample_point_scalars', preference='point')
     assert len(rng) == 2
     assert np.allclose(rng, (1, 302))
 
-    rng = grid.get_data_range('sample_cell_scalars')
+    rng = grid.get_data_range('sample_cell_scalars', preference='cell')
     assert len(rng) == 2
     assert np.allclose(rng, (1, 40))
 

--- a/tests/core/test_objects.py
+++ b/tests/core/test_objects.py
@@ -206,10 +206,13 @@ def test_table_iter():
         assert np.allclose(array, arrays[:, i])
 
 
-def test_get_data_range():
+@pytest.mark.parametrize('preference', ['row', None])
+def test_get_data_range_table(preference):
     nr, nc = 50, 3
     arrays = np.random.default_rng().random((nr, nc))
     table = pv.Table(arrays)
-    nanmin, nanmax = table.get_data_range()
+    nanmin, nanmax = (
+        table.get_data_range(preference=preference) if preference else table.get_data_range()
+    )
     assert nanmin == np.nanmin(arrays[:, 0])
     assert nanmax == np.nanmax(arrays[:, 0])


### PR DESCRIPTION
### Overview
Split from #7210.

The  'preference' option is missing from `MultiBlock.get_data_range`.

Not sure if this is a bug (missing kwarg) or feature (new kwarg added) or just maintenance (align API)