### PR TITLE
Speed up `Color` init and `convert_color_channel`

### DIFF
--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -770,10 +770,9 @@ class Color:
             # From float
             val = int(round(255 * val))
         if (
-            np.issubdtype(np.asarray(val).dtype, np.integer)
-            and np.size(val) == 1
-            and 0 <= val <= 255
-        ):
+            isinstance(val, int)
+            or (np.issubdtype(np.asarray(val).dtype, np.integer) and np.size(val) == 1)
+        ) and 0 <= val <= 255:
             # From integer
             return int(val)
         else:

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -765,15 +765,18 @@ class Color:
         """
         if isinstance(val, str):
             # From hexadecimal value
-            val = int(Color.strip_hex_prefix(val), 16)
-        elif np.issubdtype(np.asarray(val).dtype, np.floating) and np.ndim(val) == 0:
-            # From float
-            val = int(round(255 * val))
-        if (
-            isinstance(val, int)
-            or (np.issubdtype(np.asarray(val).dtype, np.integer) and np.size(val) == 1)
-        ) and 0 <= val <= 255:
-            # From integer
+            return int(Color.strip_hex_prefix(val), 16)
+        elif isinstance(val, float):
+            return int(round(255 * val))
+        elif (isinstance(val, int) and 0 <= val <= 255) or isinstance(val, np.uint8):
+            return val
+        elif np.issubdtype(np.asanyarray(val).dtype, np.floating) and np.ndim(val) == 0:
+            return int(round(255 * val))
+        elif (
+            np.issubdtype(np.asanyarray(val).dtype, np.integer)
+            and np.ndim(val) == 0
+            and 0 <= val <= 255
+        ):
             return int(val)
         else:
             raise ValueError(f'Unsupported color channel value provided: {val}')

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -744,7 +744,7 @@ class Color:
 
     @staticmethod
     def convert_color_channel(
-        val: float | np.floating[Any] | str,
+        val: float | np.floating[Any] | np.integer[Any] | str,
     ) -> int:
         """Convert the given color channel value to the integer representation.
 
@@ -769,8 +769,10 @@ class Color:
         elif isinstance(val, float):
             val = int(round(255 * val))
 
-        if (isinstance(val, int) and 0 <= val <= 255) or isinstance(val, np.uint8):
-            return val
+        if isinstance(val, int) and 0 <= val <= 255:
+            return val  # type: ignore[return-value]
+        elif isinstance(val, np.uint8):
+            return int(val)
         elif np.issubdtype(np.asanyarray(val).dtype, np.floating) and np.ndim(val) == 0:
             return int(round(255 * val))
         elif (

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -763,21 +763,27 @@ class Color:
             ``0`` and ``255``).
 
         """
+        # Check for numpy inputs to avoid unnecessary calls to np.issubdtype
+        arr = None
+        if isinstance(val, (np.ndarray, np.generic)):
+            arr = np.asanyarray(val)
+
+        # Convert non-integers to int
         if isinstance(val, str):
             # From hexadecimal value
             val = int(Color.strip_hex_prefix(val), 16)
-        elif isinstance(val, float):
+        elif isinstance(val, float) or (
+            arr is not None and np.issubdtype(arr.dtype, np.floating) and arr.ndim == 0
+        ):
             val = int(round(255 * val))
 
+        # Check integers
         if isinstance(val, int) and 0 <= val <= 255:
             return val  # type: ignore[return-value]
-        elif isinstance(val, np.uint8):
-            return int(val)
-        elif np.issubdtype(np.asanyarray(val).dtype, np.floating) and np.ndim(val) == 0:
-            return int(round(255 * val))
-        elif (
-            np.issubdtype(np.asanyarray(val).dtype, np.integer)
-            and np.ndim(val) == 0
+        elif isinstance(val, np.uint8) or (
+            arr is not None
+            and np.issubdtype(arr.dtype, np.integer)
+            and arr.ndim == 0
             and 0 <= val <= 255
         ):
             return int(val)

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -765,10 +765,11 @@ class Color:
         """
         if isinstance(val, str):
             # From hexadecimal value
-            return int(Color.strip_hex_prefix(val), 16)
+            val = int(Color.strip_hex_prefix(val), 16)
         elif isinstance(val, float):
-            return int(round(255 * val))
-        elif (isinstance(val, int) and 0 <= val <= 255) or isinstance(val, np.uint8):
+            val = int(round(255 * val))
+
+        if (isinstance(val, int) and 0 <= val <= 255) or isinstance(val, np.uint8):
             return val
         elif np.issubdtype(np.asanyarray(val).dtype, np.floating) and np.ndim(val) == 0:
             return int(round(255 * val))

--- a/tests/plotting/test_colors.py
+++ b/tests/plotting/test_colors.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import colorsys
 import importlib.util
 import itertools
+import re
 
 import matplotlib as mpl
 from matplotlib.colors import CSS4_COLORS
@@ -34,17 +35,6 @@ def test_color():
     i_rgba, f_rgba = (0, 0, 255, 255), (0.0, 0.0, 1.0, 1.0)
     h = '0000ffff'
     i_opacity, f_opacity, h_opacity = 153, 0.6, '99'
-    invalid_colors = (
-        (300, 0, 0),
-        (0, -10, 0),
-        (0, 0, 1.5),
-        (-0.5, 0, 0),
-        (0, 0),
-        '#hh0000',
-        'invalid_name',
-        {'invalid_name': 100},
-    )
-    invalid_opacities = (275, -50, 2.4, -1.2, '#zz')
     i_types = (int, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64)
     f_types = (float, np.float16, np.float32, np.float64)
     h_prefixes = ('', '0x', '#')
@@ -85,13 +75,6 @@ def test_color():
         assert pv.Color(i_rgba, default_opacity=opacity) == i_rgba
     # Check default_color
     assert pv.Color(None, default_color=name) == i_rgba
-    # Check invalid colors and opacities
-    for invalid_color in invalid_colors:
-        with pytest.raises(ValueError):  # noqa: PT011
-            pv.Color(invalid_color)
-    for invalid_opacity in invalid_opacities:
-        with pytest.raises(ValueError):  # noqa: PT011
-            pv.Color('b', invalid_opacity)
     # Check hex and name getters
     assert pv.Color(name).hex_rgba == f'#{h}'
     assert pv.Color(name).hex_rgb == f'#{h[:-2]}'
@@ -113,6 +96,44 @@ def test_color():
         c['invalid_name']  # Invalid string index
     with pytest.raises(IndexError):
         c[4]  # Invalid integer index
+
+
+@pytest.mark.parametrize('opacity', [275, -50, 2.4, -1.2, '#zz'])
+def test_color_invalid_opacity(opacity):
+    match = (
+        'Must be an integer, float or string.  For example:'
+        "\n\t\topacity='1.0'"
+        "\n\t\topacity='255'"
+        "\n\t\topacity='#FF'"
+    )
+    with pytest.raises(ValueError, match=re.escape(match)):
+        pv.Color('b', opacity)
+
+
+@pytest.mark.parametrize(
+    'color',
+    [
+        (300, 0, 0),
+        (0, -10, 0),
+        (0, 0, 1.5),
+        (-0.5, 0, 0),
+        (0, 0),
+        '#hh0000',
+        'invalid_name',
+        {'invalid_name': 100},
+    ],
+)
+def test_color_invalid_color(color):
+    match = (
+        'Must be a string, rgb(a) sequence, or hex color string.  For example:'
+        "\n\t\tcolor='white'"
+        "\n\t\tcolor='w'"
+        '\n\t\tcolor=[1.0, 1.0, 1.0]'
+        '\n\t\tcolor=[255, 255, 255]'
+        "\n\t\tcolor='#FFFFFF'"
+    )
+    with pytest.raises(ValueError, match=re.escape(match)):
+        pv.Color(color)
 
 
 @pytest.mark.parametrize('delimiter', ['-', '_', ' '])

--- a/tests/plotting/test_colors.py
+++ b/tests/plotting/test_colors.py
@@ -116,6 +116,7 @@ def test_color_invalid_opacity(opacity):
         (300, 0, 0),
         (0, -10, 0),
         (0, 0, 1.5),
+        np.array((0, 0, 1.5), dtype=np.float16),
         (-0.5, 0, 0),
         (0, 0),
         '#hh0000',


### PR DESCRIPTION
### Overview

I ran a profiler on `Color`:

``` python
from pyinstrument import Profiler
from pyvista import Color
import numpy as np
profiler = Profiler()
profiler.start()

rng = np.random.default_rng()
rgb_np_float = rng.random((3,))
rgb_np_int = (rgb_np_float * 255).astype('int')
rgb_float = rgb_np_float.tolist()
rgb_int = rgb_np_int.tolist()

for _ in range(100000):
    Color(rgb_np_float)
    Color(rgb_float)
    Color(rgb_np_int)
    Color(rgb_int)

profiler.stop()
print(profiler.output_text(unicode=True, color=True))
```

And got this output, indicating calls to `issubdtype` inside `convert_color_channel` is a bottleneck.
``` python
9.532 <module>  <ipython-input-2-916129c3a292>:1
└─ 9.443 Color.__init__  pyvista/plotting/colors.py:664
   ├─ 7.010 Color._from_rgba  pyvista/plotting/colors.py:782
   │  ├─ 6.633 <genexpr>  pyvista/plotting/colors.py:791
   │  │  ├─ 6.395 convert_color_channel  pyvista/plotting/colors.py:745
   │  │  │  ├─ 2.683 issubdtype  numpy/_core/numerictypes.py:471
```

With this PR, we have more than a 2x overall speedup:
``` python
3.843 <module>  <ipython-input-2-916129c3a292>:1
├─ 3.735 Color.__init__  pyvista/plotting/colors.py:664
│  ├─ 2.543 Color._from_rgba  pyvista/plotting/colors.py:785
│  │  ├─ 2.205 <genexpr>  pyvista/plotting/colors.py:794
│  │  │  ├─ 1.942 convert_color_channel  pyvista/plotting/colors.py:745
│  │  │  │  ├─ 0.785 [self]  pyvista/plotting/colors.py
│  │  │  │  ├─ 0.492 issubdtype  numpy/_core/numerictypes.py:471
```

Some of the color tests are also parameterized for easier debugging
