### PR TITLE
Do not skip ``None`` or empty blocks by default with `recursive_iterator`

### DIFF
--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -181,8 +181,8 @@ class MultiBlock(
         contents: Literal['ids', 'names', 'blocks', 'items', 'all'] = 'blocks',
         order: Literal['nested_first', 'nested_last'] | None = None,
         *,
-        skip_none: bool = True,
-        skip_empty: bool = True,
+        skip_none: bool = False,
+        skip_empty: bool = False,
         nested_ids: bool | None = None,
         prepend_names: bool = False,
         separator: str = '::',
@@ -220,11 +220,11 @@ class MultiBlock(
             By default, the ``MultiBlock`` is iterated recursively as-is without
             changing the order.
 
-        skip_none : bool, default: True
-            Do not include ``None`` blocks in the iterator.
+        skip_none : bool, default: False
+            If ``True``, do not include ``None`` blocks in the iterator.
 
-        skip_empty : bool, default: True
-            Do not include empty meshes in the iterator.
+        skip_empty : bool, default: False
+            If ``True``, do not include empty meshes in the iterator.
 
         nested_ids : bool, default: True
             Prepend parent block indices to the child block indices. If ``True``, a
@@ -248,7 +248,11 @@ class MultiBlock(
         See Also
         --------
         flatten
+            Uses the iterator internally to flatten a :class:`MultiBlock`.
+        pyvista.CompositeFilters.generic_filter
+            Uses the iterator internally to apply filters to all blocks.
         clean
+            Remove ``None`` and/or empty mesh blocks.
 
         Examples
         --------
@@ -275,8 +279,8 @@ class MultiBlock(
         >>> len(list(iterator))
         59
 
-        By default, ``None`` blocks are excluded and all items are :class:`~pyvista.DataSet`
-        objects. Empty meshes are also excluded by default.
+        Check if all blocks are class:`~pyvista.DataSet` objects. Note that ``None``
+        blocks are included by default, so this may not be ``True`` in all cases.
 
         >>> all(isinstance(item, pv.DataSet) for item in multi.recursive_iterator())
         True
@@ -505,6 +509,7 @@ class MultiBlock(
         See Also
         --------
         recursive_iterator
+        pyvista.CompositeFilters.generic_filter
         clean
 
         Examples

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -41,13 +41,16 @@ class CompositeFilters:
 
         .. note::
 
-            The filter is not applied to any ``None`` blocks. These are simply skipped
-            and passed through to the output.
+            If an ``inplace`` keyword is used, this ``MultiBlock`` is modified
+            in-place along with all blocks.
 
         .. note::
 
-            If an ``inplace`` keyword is used, this ``MultiBlock`` is modified
-            in-place along with all blocks.
+            By default, the specified ``function`` is not applied to any ``None``
+            blocks. These are simply skipped and passed through to the output.
+
+            For advanced use, it is possible to apply the filter to ``None`` blocks
+            by using the undocumented keyword ``_skip_none=False``.
 
         .. versionadded:: 0.45
 
@@ -75,6 +78,12 @@ class CompositeFilters:
             Raised if the filter cannot be applied to any block for any reason. This
             overrides ``TypeError``, ``ValueError``, ``AttributeError`` errors when
             filtering.
+
+        See Also
+        --------
+        pyvista.MultiBlock.flatten
+        pyvista.MultiBlock.recursive_iterator
+        pyvista.MultiBlock.clean
 
         Examples
         --------
@@ -146,6 +155,17 @@ class CompositeFilters:
         >>> filtered = multi.generic_filter(conditional_resample, 0.5)
 
         """
+        # Set default undocumented kwargs. A function is used here to prevent IDEs from
+        # suggesting these keywords to users.
+
+        def get_iterator_kwargs(kwargs_) -> tuple[bool, bool]:
+            # Skip None blocks by default
+            skip_none_: bool = kwargs_.pop('_skip_none', True)
+            # Do not skip empty blocks by default
+            skip_empty_: bool = kwargs_.pop('_skip_empty', False)
+            return skip_none_, skip_empty_
+
+        skip_none, skip_empty = get_iterator_kwargs(kwargs)
 
         def apply_filter(ids_, name_, block_):
             try:
@@ -157,7 +177,6 @@ class CompositeFilters:
                 output_ = func(**kwargs) if len(args) == 0 else func(*args, **kwargs)
             except (AttributeError, ValueError, TypeError, RuntimeError) as e:
                 # Construct a helpful error message
-                func_name = function if isinstance(function, str) else type(function).__name__
                 obj_name = type(block).__name__
                 if len(ids_) == 1:
                     index = ids_[0]
@@ -165,27 +184,33 @@ class CompositeFilters:
                 else:
                     nested = ' nested '
                     index = ''.join([f'[{id_}]' for id_ in ids_])
-                msg = f"The filter '{func_name}' could not be applied to the{nested}block at index {index} with name '{name_}' and type {obj_name}."
+                msg = (
+                    f"The filter '{function}'"
+                    f"\ncould not be applied to the{nested}block at index {index} with name '{name_}' and type {obj_name}."
+                )
                 raise RuntimeError(msg) from e
             return output_
 
-        def get_iterator(multi):
+        def get_iterator(multi, skip_none_, skip_empty_):
             return multi.recursive_iterator(
-                'all', skip_none=True, skip_empty=False, nested_ids=True
+                'all', skip_none=skip_none_, skip_empty=skip_empty_, nested_ids=True
             )
 
         # Apply filter in-place
         inplace = kwargs.get('inplace')
         if inplace:
-            for ids, name, block in get_iterator(self):
+            for ids, name, block in get_iterator(self, skip_none, skip_empty):
                 apply_filter(ids, name, block)
             return self
 
         # Create a copy and replace all the blocks
         output = pyvista.MultiBlock()
         output.shallow_copy(self, recursive=True)
-        for ids, name, block in get_iterator(output):
-            output.replace(ids, apply_filter(ids, name, block))
+        for ids, name, block in get_iterator(output, skip_none, skip_empty):
+            filtered = apply_filter(ids, name, block)
+            # Only replace if necessary
+            if filtered is not block:
+                output.replace(ids, filtered)
         return output
 
     def extract_geometry(self):

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -41,16 +41,13 @@ class CompositeFilters:
 
         .. note::
 
-            If an ``inplace`` keyword is used, this ``MultiBlock`` is modified
-            in-place along with all blocks.
+            The filter is not applied to any ``None`` blocks. These are simply skipped
+            and passed through to the output.
 
         .. note::
 
-            By default, the specified ``function`` is not applied to any ``None``
-            blocks. These are simply skipped and passed through to the output.
-
-            For advanced use, it is possible to apply the filter to ``None`` blocks
-            by using the undocumented keyword ``_skip_none=False``.
+            If an ``inplace`` keyword is used, this ``MultiBlock`` is modified
+            in-place along with all blocks.
 
         .. versionadded:: 0.45
 
@@ -78,12 +75,6 @@ class CompositeFilters:
             Raised if the filter cannot be applied to any block for any reason. This
             overrides ``TypeError``, ``ValueError``, ``AttributeError`` errors when
             filtering.
-
-        See Also
-        --------
-        pyvista.MultiBlock.flatten
-        pyvista.MultiBlock.recursive_iterator
-        pyvista.MultiBlock.clean
 
         Examples
         --------
@@ -155,17 +146,6 @@ class CompositeFilters:
         >>> filtered = multi.generic_filter(conditional_resample, 0.5)
 
         """
-        # Set default undocumented kwargs. A function is used here to prevent IDEs from
-        # suggesting these keywords to users.
-
-        def get_iterator_kwargs(kwargs_) -> tuple[bool, bool]:
-            # Skip None blocks by default
-            skip_none_: bool = kwargs_.pop('_skip_none', True)
-            # Do not skip empty blocks by default
-            skip_empty_: bool = kwargs_.pop('_skip_empty', False)
-            return skip_none_, skip_empty_
-
-        skip_none, skip_empty = get_iterator_kwargs(kwargs)
 
         def apply_filter(ids_, name_, block_):
             try:
@@ -177,6 +157,7 @@ class CompositeFilters:
                 output_ = func(**kwargs) if len(args) == 0 else func(*args, **kwargs)
             except (AttributeError, ValueError, TypeError, RuntimeError) as e:
                 # Construct a helpful error message
+                func_name = function if isinstance(function, str) else type(function).__name__
                 obj_name = type(block).__name__
                 if len(ids_) == 1:
                     index = ids_[0]
@@ -184,33 +165,27 @@ class CompositeFilters:
                 else:
                     nested = ' nested '
                     index = ''.join([f'[{id_}]' for id_ in ids_])
-                msg = (
-                    f"The filter '{function}'"
-                    f"\ncould not be applied to the{nested}block at index {index} with name '{name_}' and type {obj_name}."
-                )
+                msg = f"The filter '{func_name}' could not be applied to the{nested}block at index {index} with name '{name_}' and type {obj_name}."
                 raise RuntimeError(msg) from e
             return output_
 
-        def get_iterator(multi, skip_none_, skip_empty_):
+        def get_iterator(multi):
             return multi.recursive_iterator(
-                'all', skip_none=skip_none_, skip_empty=skip_empty_, nested_ids=True
+                'all', skip_none=True, skip_empty=False, nested_ids=True
             )
 
         # Apply filter in-place
         inplace = kwargs.get('inplace')
         if inplace:
-            for ids, name, block in get_iterator(self, skip_none, skip_empty):
+            for ids, name, block in get_iterator(self):
                 apply_filter(ids, name, block)
             return self
 
         # Create a copy and replace all the blocks
         output = pyvista.MultiBlock()
         output.shallow_copy(self, recursive=True)
-        for ids, name, block in get_iterator(output, skip_none, skip_empty):
-            filtered = apply_filter(ids, name, block)
-            # Only replace if necessary
-            if filtered is not block:
-                output.replace(ids, filtered)
+        for ids, name, block in get_iterator(output):
+            output.replace(ids, apply_filter(ids, name, block))
         return output
 
     def extract_geometry(self):

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -167,16 +167,19 @@ class CompositeFilters:
 
         skip_none, skip_empty = get_iterator_kwargs(kwargs)
 
-        def apply_filter(ids_, name_, block_):
+        def apply_filter(function_, ids_, name_, block_):
             try:
-                func = (
-                    getattr(block_, function)
-                    if isinstance(function, str)
-                    else functools.partial(function, block_)
+                function_ = (
+                    getattr(block_, function_)
+                    if isinstance(function_, str)
+                    else functools.partial(function_, block_)
                 )
-                output_ = func(**kwargs) if len(args) == 0 else func(*args, **kwargs)
+                output_ = function_(**kwargs) if len(args) == 0 else function_(*args, **kwargs)
             except (AttributeError, ValueError, TypeError, RuntimeError) as e:
                 # Construct a helpful error message
+                func_name = (
+                    function_.func if isinstance(function_, functools.partial) else function_
+                )
                 obj_name = type(block).__name__
                 if len(ids_) == 1:
                     index = ids_[0]
@@ -185,7 +188,7 @@ class CompositeFilters:
                     nested = ' nested '
                     index = ''.join([f'[{id_}]' for id_ in ids_])
                 msg = (
-                    f"The filter '{function}'"
+                    f"The filter '{func_name}'"
                     f"\ncould not be applied to the{nested}block at index {index} with name '{name_}' and type {obj_name}."
                 )
                 raise RuntimeError(msg) from e
@@ -200,14 +203,14 @@ class CompositeFilters:
         inplace = kwargs.get('inplace')
         if inplace:
             for ids, name, block in get_iterator(self, skip_none, skip_empty):
-                apply_filter(ids, name, block)
+                apply_filter(function, ids, name, block)
             return self
 
         # Create a copy and replace all the blocks
         output = pyvista.MultiBlock()
         output.shallow_copy(self, recursive=True)
         for ids, name, block in get_iterator(output, skip_none, skip_empty):
-            filtered = apply_filter(ids, name, block)
+            filtered = apply_filter(function, ids, name, block)
             # Only replace if necessary
             if filtered is not block:
                 output.replace(ids, filtered)

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -167,19 +167,17 @@ class CompositeFilters:
 
         skip_none, skip_empty = get_iterator_kwargs(kwargs)
 
-        def apply_filter(function_, ids_, name_, block_):
+        def apply_filter(ids_, name_, block_):
             try:
-                function_ = (
-                    getattr(block_, function_)
-                    if isinstance(function_, str)
-                    else functools.partial(function_, block_)
+                func = (
+                    getattr(block_, function)
+                    if isinstance(function, str)
+                    else functools.partial(function, block_)
                 )
-                output_ = function_(**kwargs) if len(args) == 0 else function_(*args, **kwargs)
+                output_ = func(**kwargs) if len(args) == 0 else func(*args, **kwargs)
             except (AttributeError, ValueError, TypeError, RuntimeError) as e:
                 # Construct a helpful error message
-                func_name = (
-                    function_.func if isinstance(function_, functools.partial) else function_
-                )
+                func_name = function if isinstance(function, str) else type(function).__name__
                 obj_name = type(block).__name__
                 if len(ids_) == 1:
                     index = ids_[0]
@@ -187,10 +185,7 @@ class CompositeFilters:
                 else:
                     nested = ' nested '
                     index = ''.join([f'[{id_}]' for id_ in ids_])
-                msg = (
-                    f"The filter '{func_name}'"
-                    f"\ncould not be applied to the{nested}block at index {index} with name '{name_}' and type {obj_name}."
-                )
+                msg = f"The filter '{func_name}' could not be applied to the{nested}block at index {index} with name '{name_}' and type {obj_name}."
                 raise RuntimeError(msg) from e
             return output_
 
@@ -203,14 +198,14 @@ class CompositeFilters:
         inplace = kwargs.get('inplace')
         if inplace:
             for ids, name, block in get_iterator(self, skip_none, skip_empty):
-                apply_filter(function, ids, name, block)
+                apply_filter(ids, name, block)
             return self
 
         # Create a copy and replace all the blocks
         output = pyvista.MultiBlock()
         output.shallow_copy(self, recursive=True)
         for ids, name, block in get_iterator(output, skip_none, skip_empty):
-            filtered = apply_filter(function, ids, name, block)
+            filtered = apply_filter(ids, name, block)
             # Only replace if necessary
             if filtered is not block:
                 output.replace(ids, filtered)

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -1155,21 +1155,15 @@ def test_generic_filter_inplace(multiblock_all_with_nested_and_none, inplace):
 
 
 def test_generic_filter_raises(multiblock_all_with_nested_and_none):
-    match = "The filter 'resample'\ncould not be applied to the block at index 1 with name 'Block-01' and type RectilinearGrid."
+    match = "The filter 'resample' could not be applied to the block at index 1 with name 'Block-01' and type RectilinearGrid."
     with pytest.raises(RuntimeError, match=match):
         multiblock_all_with_nested_and_none.generic_filter(
             'resample',
         )
     # Test error message with nested index
     multi = pv.MultiBlock([multiblock_all_with_nested_and_none])
-    match = "The filter 'resample'\ncould not be applied to the nested block at index [0][1] with name 'Block-01' and type RectilinearGrid."
+    match = "The filter 'resample' could not be applied to the nested block at index [0][1] with name 'Block-01' and type RectilinearGrid."
     with pytest.raises(RuntimeError, match=re.escape(match)):
         multi.generic_filter(
             'resample',
-        )
-    # Test with function
-    match = "The filter '<function test_generic_filter_raises"
-    with pytest.raises(RuntimeError, match=match):
-        multiblock_all_with_nested_and_none.generic_filter(
-            test_generic_filter_raises,
         )

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -1160,13 +1160,18 @@ def test_generic_filter_raises(multiblock_all_with_nested_and_none):
         multiblock_all_with_nested_and_none.generic_filter(
             'resample',
         )
-    # Test error message with nested index
+    # Test with nested index
     multi = pv.MultiBlock([multiblock_all_with_nested_and_none])
     match = "The filter 'resample'\ncould not be applied to the nested block at index [0][1] with name 'Block-01' and type RectilinearGrid."
     with pytest.raises(RuntimeError, match=re.escape(match)):
         multi.generic_filter(
             'resample',
         )
+    # Test with invalid kwargs
+    multi = pv.MultiBlock([multiblock_all_with_nested_and_none])
+    match = "The filter '<bound method DataSetFilters.align_xyz of ImageData"
+    with pytest.raises(RuntimeError, match=re.escape(match)):
+        multi.generic_filter('align_xyz', foo='bar')
     # Test with function
     match = "The filter '<function test_generic_filter_raises"
     with pytest.raises(RuntimeError, match=match):

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -1155,26 +1155,15 @@ def test_generic_filter_inplace(multiblock_all_with_nested_and_none, inplace):
 
 
 def test_generic_filter_raises(multiblock_all_with_nested_and_none):
-    match = "The filter 'resample'\ncould not be applied to the block at index 1 with name 'Block-01' and type RectilinearGrid."
+    match = "The filter 'resample' could not be applied to the block at index 1 with name 'Block-01' and type RectilinearGrid."
     with pytest.raises(RuntimeError, match=match):
         multiblock_all_with_nested_and_none.generic_filter(
             'resample',
         )
-    # Test with nested index
+    # Test error message with nested index
     multi = pv.MultiBlock([multiblock_all_with_nested_and_none])
-    match = "The filter 'resample'\ncould not be applied to the nested block at index [0][1] with name 'Block-01' and type RectilinearGrid."
+    match = "The filter 'resample' could not be applied to the nested block at index [0][1] with name 'Block-01' and type RectilinearGrid."
     with pytest.raises(RuntimeError, match=re.escape(match)):
         multi.generic_filter(
             'resample',
-        )
-    # Test with invalid kwargs
-    multi = pv.MultiBlock([multiblock_all_with_nested_and_none])
-    match = "The filter '<bound method DataSetFilters.align_xyz of ImageData"
-    with pytest.raises(RuntimeError, match=re.escape(match)):
-        multi.generic_filter('align_xyz', foo='bar')
-    # Test with function
-    match = "The filter '<function test_generic_filter_raises"
-    with pytest.raises(RuntimeError, match=match):
-        multiblock_all_with_nested_and_none.generic_filter(
-            test_generic_filter_raises,
         )

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -1155,15 +1155,21 @@ def test_generic_filter_inplace(multiblock_all_with_nested_and_none, inplace):
 
 
 def test_generic_filter_raises(multiblock_all_with_nested_and_none):
-    match = "The filter 'resample' could not be applied to the block at index 1 with name 'Block-01' and type RectilinearGrid."
+    match = "The filter 'resample'\ncould not be applied to the block at index 1 with name 'Block-01' and type RectilinearGrid."
     with pytest.raises(RuntimeError, match=match):
         multiblock_all_with_nested_and_none.generic_filter(
             'resample',
         )
     # Test error message with nested index
     multi = pv.MultiBlock([multiblock_all_with_nested_and_none])
-    match = "The filter 'resample' could not be applied to the nested block at index [0][1] with name 'Block-01' and type RectilinearGrid."
+    match = "The filter 'resample'\ncould not be applied to the nested block at index [0][1] with name 'Block-01' and type RectilinearGrid."
     with pytest.raises(RuntimeError, match=re.escape(match)):
         multi.generic_filter(
             'resample',
+        )
+    # Test with function
+    match = "The filter '<function test_generic_filter_raises"
+    with pytest.raises(RuntimeError, match=match):
+        multiblock_all_with_nested_and_none.generic_filter(
+            test_generic_filter_raises,
         )

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -966,26 +966,26 @@ def test_recursive_iterator(multiblock_all_with_nested_and_none):
     # include an empty mesh
     multiblock_all_with_nested_and_none.append(pv.PolyData())
 
-    # Test default skips None blocks and empty meshes by default
+    # Test default does not skip None blocks or empty meshes by default
     iterator = multiblock_all_with_nested_and_none.recursive_iterator()
-    assert isinstance(iterator, Generator)
-    iterator_list = list(iterator)
-    assert None not in iterator_list
-    assert all(isinstance(item, pv.DataSet) for item in iterator_list)
-    assert all(item.n_points > 0 for item in iterator_list)
-
-    # Test do not skip None blocks
-    iterator = multiblock_all_with_nested_and_none.recursive_iterator(skip_none=False)
     assert isinstance(iterator, Generator)
     iterator_list = list(iterator)
     assert None in iterator_list
     assert all(isinstance(item, pv.DataSet) or item is None for item in iterator_list)
+    assert any(item.n_points == 0 for item in iterator_list if item is not None)
 
-    # Test do not skip empty blocks
-    iterator = multiblock_all_with_nested_and_none.recursive_iterator(skip_empty=False)
+    # Test skip None blocks
+    iterator = multiblock_all_with_nested_and_none.recursive_iterator(skip_none=True)
     assert isinstance(iterator, Generator)
     iterator_list = list(iterator)
-    assert any(item.n_points == 0 for item in iterator_list)
+    assert None not in iterator_list
+    assert all(isinstance(item, pv.DataSet) for item in iterator_list)
+
+    # Test skip empty blocks
+    iterator = multiblock_all_with_nested_and_none.recursive_iterator(skip_empty=True)
+    assert isinstance(iterator, Generator)
+    iterator_list = list(iterator)
+    assert all(item.n_points > 0 for item in iterator_list if item is not None)
 
 
 def test_recursive_iterator_contents(multiblock_all_with_nested_and_none):
@@ -996,7 +996,7 @@ def test_recursive_iterator_contents(multiblock_all_with_nested_and_none):
     assert all(isinstance(item, str) for item in iterator)
 
     iterator = multiblock_all_with_nested_and_none.recursive_iterator('blocks')
-    assert all(isinstance(item, pv.DataSet) for item in iterator)
+    assert all(isinstance(item, pv.DataSet) or item is None for item in iterator)
 
     iterator = multiblock_all_with_nested_and_none.recursive_iterator('items')
     for name, block in iterator:
@@ -1155,15 +1155,21 @@ def test_generic_filter_inplace(multiblock_all_with_nested_and_none, inplace):
 
 
 def test_generic_filter_raises(multiblock_all_with_nested_and_none):
-    match = "The filter 'resample' could not be applied to the block at index 1 with name 'Block-01' and type RectilinearGrid."
+    match = "The filter 'resample'\ncould not be applied to the block at index 1 with name 'Block-01' and type RectilinearGrid."
     with pytest.raises(RuntimeError, match=match):
         multiblock_all_with_nested_and_none.generic_filter(
             'resample',
         )
     # Test error message with nested index
     multi = pv.MultiBlock([multiblock_all_with_nested_and_none])
-    match = "The filter 'resample' could not be applied to the nested block at index [0][1] with name 'Block-01' and type RectilinearGrid."
+    match = "The filter 'resample'\ncould not be applied to the nested block at index [0][1] with name 'Block-01' and type RectilinearGrid."
     with pytest.raises(RuntimeError, match=re.escape(match)):
         multi.generic_filter(
             'resample',
+        )
+    # Test with function
+    match = "The filter '<function test_generic_filter_raises"
+    with pytest.raises(RuntimeError, match=match):
+        multiblock_all_with_nested_and_none.generic_filter(
+            test_generic_filter_raises,
         )


### PR DESCRIPTION
### Overview

The default to skip ``None`` and ``empty`` blocks can be problematic. Sometimes it's helpful to exclude them but in general cases it's desirable to include all blocks. I think it's best to always include these, and opt-out explicitly.

`generic_filter` is also updated to allow `None` blocks, but these are still skipped by default.
Allowing None blocks here is needed for general cases, e.g. see #7223 and #7220