### PR TITLE
Refactor `MultiBlock.transform` to use `generic_filter`

### DIFF
--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -448,15 +448,10 @@ class CompositeFilters:
 
         inplace = check_inplace(cls=type(self), inplace=inplace)
 
-        trans = pyvista.Transform(trans)
-        output = self if inplace else self.copy()  # type: ignore[attr-defined]
-        for name in self.keys():  # type: ignore[attr-defined]
-            block = output[name]  # type: ignore[index]
-            if block is not None:
-                block.transform(
-                    trans,
-                    transform_all_input_vectors=transform_all_input_vectors,
-                    inplace=True,
-                    progress_bar=progress_bar,
-                )
-        return output
+        return self.generic_filter(
+            'transform',
+            trans=trans,
+            transform_all_input_vectors=transform_all_input_vectors,
+            inplace=inplace,
+            progress_bar=progress_bar,
+        )

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -388,8 +388,8 @@ class CompositeFilters:
         _update_alg(alg, progress_bar, 'Computing Normals')
         return _get_output(alg)
 
-    def transform(
-        self,
+    def transform(  # type: ignore[misc]
+        self: MultiBlock,
         trans: TransformLike,
         transform_all_input_vectors: bool = False,
         inplace: bool | None = None,


### PR DESCRIPTION
### Overview

~The transform filter currently uses `__setitem__` instead of `replace` to replace blocks. This means that block names are lost when transforming.~
EDIT: After review I'm not sure this is true as a copy currently is made and blocks are replaced in-place. But I still think it's good to refactor this.

Use the `generic_filter` instead which handles block replacements correctly.
