### PR TITLE
Fix function name in error messages for `MultiBlock.generic_filter`

### DIFF
--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -1155,15 +1155,26 @@ def test_generic_filter_inplace(multiblock_all_with_nested_and_none, inplace):
 
 
 def test_generic_filter_raises(multiblock_all_with_nested_and_none):
-    match = "The filter 'resample' could not be applied to the block at index 1 with name 'Block-01' and type RectilinearGrid."
+    match = "The filter 'resample'\ncould not be applied to the block at index 1 with name 'Block-01' and type RectilinearGrid."
     with pytest.raises(RuntimeError, match=match):
         multiblock_all_with_nested_and_none.generic_filter(
             'resample',
         )
-    # Test error message with nested index
+    # Test with nested index
     multi = pv.MultiBlock([multiblock_all_with_nested_and_none])
-    match = "The filter 'resample' could not be applied to the nested block at index [0][1] with name 'Block-01' and type RectilinearGrid."
+    match = "The filter 'resample'\ncould not be applied to the nested block at index [0][1] with name 'Block-01' and type RectilinearGrid."
     with pytest.raises(RuntimeError, match=re.escape(match)):
         multi.generic_filter(
             'resample',
+        )
+    # Test with invalid kwargs
+    multi = pv.MultiBlock([multiblock_all_with_nested_and_none])
+    match = "The filter '<bound method DataSetFilters.align_xyz of ImageData"
+    with pytest.raises(RuntimeError, match=re.escape(match)):
+        multi.generic_filter('align_xyz', foo='bar')
+    # Test with function
+    match = "The filter '<function test_generic_filter_raises"
+    with pytest.raises(RuntimeError, match=match):
+        multiblock_all_with_nested_and_none.generic_filter(
+            test_generic_filter_raises,
         )


### PR DESCRIPTION
### Overview

The error message for `MultiBlock.generic_filter` isn't helpful when a generic function is used since it currently says `'function'` could not be applied instead of using the function's name. This PR fixes this. 