### PR TITLE
Rework `transform_all_input_vectors` as `mode` parameter for `Transform.apply`

### DIFF
--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -1435,30 +1435,30 @@ class Transform(_vtk.vtkTransform):
         self: Transform,
         obj: VectorLike[float] | MatrixLike[float],
         /,
+        mode: Literal['points', 'vectors'] | None = ...,
         *,
         inverse: bool = ...,
         copy: bool = ...,
-        transform_all_input_vectors: bool = ...,
     ) -> NumpyArray[float]: ...
     @overload
     def apply(
         self: Transform,
         obj: ConcreteDataSetType,
         /,
+        mode: Literal['all_vectors'] | None = ...,
         *,
         inverse: bool = ...,
         copy: bool = ...,
-        transform_all_input_vectors: bool = ...,
     ) -> ConcreteDataSetType: ...
     @overload
     def apply(
         self: Transform,
         obj: MultiBlock,
         /,
+        mode: Literal['all_vectors'] | None = ...,
         *,
         inverse: bool = ...,
         copy: bool = ...,
-        transform_all_input_vectors: bool = ...,
     ) -> MultiBlock: ...
     def apply(
         self: Transform,


### PR DESCRIPTION
### Overview

The `transform_all_input_vectors` keyword is dataset-specific, which is not ideal, and `apply` is also missing an option to transform vectors. See https://github.com/pyvista/pyvista/issues/7097#issuecomment-2600913235 for context.

This PR removes `transform_all_input_vectors` and adds `mode` instead. `'points'` mode transforms points, `'vectors'` mode transforms vectors, and `'all_vectors'` enables `transform_all_input_vectors` for datasets.