### PR TITLE
Generalize `voxelize_binary_mask` as `voxelize` filter

### DIFF
--- a/examples/01-filter/voxelize.py
+++ b/examples/01-filter/voxelize.py
@@ -4,21 +4,142 @@
 Voxelize a Surface Mesh
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Create a voxel model (like legos) of a closed surface or volumetric mesh.
-
-This example also demonstrates how to compute an implicit distance from a
-bounding :class:`pyvista.PolyData` surface.
+Demonstrate various ways to generate a voxelized mesh using the
+:meth:`~pyvista.DataSetFilters.voxelize` filter.
 
 """
 
 from __future__ import annotations
 
+# sphinx_gallery_thumbnail_number = 2
 import numpy as np
 
 import pyvista as pv
-
-# sphinx_gallery_thumbnail_number = 2
 from pyvista import examples
+
+# %%
+# Voxelize as ImageData
+# ---------------------
+# Load a coarse mesh of a bunny.
+poly = examples.download_bunny_coarse()
+
+# Voxelize the surface mesh as a binary image mask.
+# Represent the voxels as points, which is the standard format for 2D/3D images.
+mask = poly.voxelize_('image', 'points')
+
+# The mask is stored as pyvista.ImageData with point data scalars
+# (zeros for background, ones for foreground).
+mask
+
+
+# Visualize the mask and polydata for comparison.
+def mask_and_polydata_plotter(mask, poly):
+    voxel_cells = mask.points_to_cells().threshold(0.5)
+
+    plot = pv.Plotter()
+    plot.add_mesh(voxel_cells, color='blue')
+    plot.add_mesh(poly, color='lime')
+    plot.camera_position = 'xy'
+    return plot
+
+
+plot = mask_and_polydata_plotter(mask, poly)
+plot.show()
+
+# Repeat the previous example with a finer mesh.
+poly = examples.download_bunny()
+mask = poly.voxelize_('image', 'points')
+plot = mask_and_polydata_plotter(mask, poly)
+plot.show()
+
+# Control the spacing manually.
+mask = poly.voxelize_('image', 'points', spacing=(0.01, 0.04, 0.02))
+plot = mask_and_polydata_plotter(mask, poly)
+plot.show()
+
+# The spacing is approximate. Check the mask's actual spacing.
+mask.spacing
+
+# Use rounding_func=np.floor to force all spacing values to be greater.
+mask = poly.voxelize_('image', 'points', spacing=(0.01, 0.04, 0.02), rounding_func=np.floor)
+mask.spacing
+
+# Set the dimensions instead of the spacing.
+mask = poly.voxelize_('image', 'points', dimensions=(10, 20, 30))
+plot = mask_and_polydata_plotter(mask, poly)
+plot.show()
+
+# Create a mask using a reference volume.
+# First generate polydata from an existing mask.
+volume = examples.load_frog_tissues()
+poly = volume.contour_labels()
+
+# Now create the mask from the polydata using the volume as a reference.
+mask = poly.voxelize_('image', 'points', reference_volume=volume)
+plot = mask_and_polydata_plotter(mask, poly)
+plot.show()
+
+# Voxelize as RectilinearGrid
+# ---------------------------
+# Create a voxelized :class:`pyvista.RectilinearGrid` of a nut with voxels
+# represented as cells. By default, the spacing is automatically estimated.
+
+mesh = pv.examples.load_nut()
+vox = mesh.voxelize_('rectilinear', 'cells')
+
+# Plot the mesh together with its volume.
+pl = pv.Plotter()
+pl.add_mesh(mesh=vox, show_edges=True)
+pl.add_mesh(mesh=mesh, show_edges=True, opacity=1)
+pl.show()
+
+# Load a mesh of a cow.
+mesh = examples.download_cow()
+
+# Create an equal density voxel volume and plot the result.
+vox = mesh.voxelize_('rectilinear', 'cells', spacing=0.15)
+cpos = [(15, 3, 15), (0, 0, 0), (0, 0, 0)]
+vox.plot(scalars='mask', show_edges=True, cpos=cpos)
+
+# Slice the voxel volume to view the mask scalars.
+slices = vox.slice_orthogonal()
+slices.plot(scalars='mask', show_edges=True)
+
+# Create a voxel volume from unequal density dimensions and plot the result.
+vox = mesh.voxelize_('rectilinear', 'cells', spacing=(0.15, 0.15, 0.5))
+vox.plot(scalars='mask', show_edges=True, cpos=cpos)
+
+# Slice the unequal density voxel volume to view the mask scalars.
+slices = vox.slice_orthogonal()
+slices.plot(scalars='mask', show_edges=True, cpos=cpos)
+
+# Voxelize as PolyData
+# --------------------
+# Load an ant mesh.
+ant = examples.load_ant()
+
+# Voxelize it as :class:`~pyvista.PolyData` cells. This generates a surface with
+# :attr:`~pyvista.CellType.QUAD` cells that is hollow inside.
+cpos = [(11.6, 57.3, 28.0), (0.65, -0.78, 1.19), (-0.55, 0.43, -0.71)]
+vox = ant.voxelize_('poly', 'cells', spacing=0.5)
+vox.plot(cpos=cpos)
+
+# Voxelize it as a dense point cloud instead.
+vox = ant.voxelize_('poly', 'points', spacing=0.5)
+
+# Plot the point cloud and show the original mesh for context.
+pl = pv.Plotter()
+pl.add_mesh(ant, opacity=0.1)
+pl.add_mesh(vox, color='black', render_points_as_spheres=True)
+pl.camera_position = cpos
+pl.show()
+
+
+# Voxelize as UnstructuredGrid
+# ----------------------------
+
+# This example also demonstrates how to compute an implicit distance from a
+# bounding :class:`pyvista.PolyData` surface.
 
 # Load a surface to voxelize
 surface = examples.download_foot_bones()
@@ -36,7 +157,7 @@ surface.plot(cpos=cpos, opacity=0.75)
 
 # %%
 # Create a voxel model of the bounding surface
-voxels = pv.voxelize(surface, density=surface.length / 200)
+voxels = surface.voxelize()
 
 p = pv.Plotter()
 p.add_mesh(voxels, color=True, show_edges=True, opacity=0.5)
@@ -68,5 +189,52 @@ p = pv.Plotter()
 p.add_mesh(voxels, opacity=0.25, scalars='implicit_distance')
 p.add_mesh(contours, opacity=0.5, scalars='implicit_distance')
 p.show(cpos=cpos)
+
+# %%
+# Effects of Internal Surfaces
+# ----------------------------
+
+# Visualize the effect of internal surfaces.
+mesh = pv.Cylinder() + pv.Cylinder((0, 0.75, 0))
+binary_mask = mesh.voxelize_('image', 'points', dimensions=(1, 100, 50)).points_to_cells()
+plot = pv.Plotter()
+plot.add_mesh(binary_mask)
+plot.add_mesh(mesh.slice(), color='red')
+plot.show(cpos='yz')
+
+# Process intersecting parts of the mesh sequentially.
+cylinder_1 = pv.Cylinder()
+cylinder_2 = pv.Cylinder((0, 0.75, 0))
+
+reference_volume = pv.ImageData(
+    dimensions=(1, 100, 50),
+    spacing=(1, 0.0175, 0.02),
+    origin=(0, -0.5 + 0.0175 / 2, -0.5 + 0.02 / 2),
+)
+
+binary_mask_1 = cylinder_1.voxelize_(
+    'image', 'points', reference_volume=reference_volume
+).points_to_cells()
+binary_mask_2 = cylinder_2.voxelize_(
+    'image', 'points', reference_volume=reference_volume
+).points_to_cells()
+
+binary_mask_1['mask'] = binary_mask_1['mask'] | binary_mask_2['mask']
+
+plot = pv.Plotter()
+plot.add_mesh(binary_mask_1)
+plot.add_mesh(cylinder_1.slice(), color='red')
+plot.add_mesh(cylinder_2.slice(), color='red')
+plot.show(cpos='yz')
+
+# Visualize nested internal surfaces.
+mesh = pv.Tube(radius=2) + pv.Tube(radius=3) + pv.Tube(radius=4)
+binary_mask = mesh.voxelize_('image', 'points', dimensions=(1, 50, 50)).points_to_cells()
+plot = pv.Plotter()
+plot.add_mesh(binary_mask)
+plot.add_mesh(mesh.slice(), color='red')
+plot.show(cpos='yz')
+
+
 # %%
 # .. tags:: filter

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -239,7 +239,7 @@ def test_clip_box(datasets):
 
     # crinkle clip
     surf = pv.Sphere(radius=3)
-    vol = pv.voxelize(surf)
+    vol = surf.voxelize_('unstructured', 'cells')
     cube = pv.Cube().rotate_x(33, inplace=False)
     clp = vol.clip_box(bounds=cube, invert=False, crinkle=True)
     assert clp is not None
@@ -4933,7 +4933,7 @@ def frog_tissues_contour(frog_tissues_image):
 
 @pytest.mark.needs_vtk_version(9, 3, 0)
 def test_voxelize_binary_mask(frog_tissues_image, frog_tissues_contour):
-    mask = frog_tissues_contour.voxelize_binary_mask(
+    mask = frog_tissues_contour._voxelize_as_image_points(
         reference_volume=frog_tissues_image, progress_bar=True
     )
 
@@ -4946,42 +4946,48 @@ def test_voxelize_binary_mask(frog_tissues_image, frog_tissues_contour):
 
 @pytest.mark.needs_vtk_version(9, 3, 0)
 def test_voxelize_binary_mask_no_reference(frog_tissues_image, frog_tissues_contour):
-    mask = frog_tissues_contour.voxelize_binary_mask()
+    mask = frog_tissues_contour._voxelize_as_image_points()
     assert np.allclose(mask.points_to_cells().bounds, frog_tissues_contour.bounds)
 
 
 def test_voxelize_binary_mask_dimensions(sphere):
     dims = (10, 11, 12)
-    mask = sphere.voxelize_binary_mask(dimensions=dims)
+    mask = sphere._voxelize_as_image_points(dimensions=dims)
     assert np.allclose(mask.points_to_cells().bounds, sphere.bounds)
     assert mask.dimensions == dims
 
 
 def test_voxelize_binary_mask_spacing(ant):
     # Test default
-    mask_no_input = ant.voxelize_binary_mask()
+    mask_no_input = ant._voxelize_as_image_points()
     if pv.vtk_version_info < (9, 2):
-        expected_mask = ant.voxelize_binary_mask(spacing=ant.length / 100)
+        expected_mask = ant._voxelize_as_image_points(spacing=ant.length / 100)
     else:
-        expected_mask = ant.voxelize_binary_mask(cell_length_percentile=0.1)
+        expected_mask = ant._voxelize_as_image_points(cell_length_percentile=0.1)
     assert mask_no_input.spacing == expected_mask.spacing
 
     # Test cell length
     if pv.vtk_version_info < (9, 2):
         match = 'Cell length percentile and sample size requires VTK 9.2 or greater.'
         with pytest.raises(TypeError, match=match):
-            ant.voxelize_binary_mask(cell_length_percentile=0.2)
+            ant._voxelize_as_image_points(cell_length_percentile=0.2)
     else:
-        mask_percentile_20 = ant.voxelize_binary_mask(cell_length_percentile=0.2)
-        mask_percentile_50 = ant.voxelize_binary_mask(cell_length_percentile=0.5)
+        mask_percentile_20 = ant._voxelize_as_image_points(cell_length_percentile=0.2)
+        mask_percentile_50 = ant._voxelize_as_image_points(cell_length_percentile=0.5)
         assert np.all(np.array(mask_percentile_20.spacing) < mask_percentile_50.spacing)
 
     # Test mesh length
-    mask_fraction_200 = ant.voxelize_binary_mask(spacing=ant.length / 200)
-    mask_fraction_500 = ant.voxelize_binary_mask(spacing=ant.length / 500)
+    mask_fraction_200 = ant._voxelize_as_image_points(spacing=ant.length / 200)
+    mask_fraction_500 = ant._voxelize_as_image_points(spacing=ant.length / 500)
     assert np.all(np.array(mask_fraction_200.spacing) > mask_fraction_500.spacing)
     # Check spacing matches mesh length. Use atol since spacing is approximate.
     assert np.allclose(mask_fraction_500.spacing, ant.length / 500, atol=1e-3)
+
+    match = 'Spacing and cell length options cannot both be set. Set one or the other.'
+    with pytest.raises(TypeError, match=match):
+        ant._voxelize_as_image_points(spacing=0.1, cell_length_percentile=0.1)
+    with pytest.raises(TypeError, match=match):
+        ant._voxelize_as_image_points(spacing=0.1, cell_length_sample_size=ant.n_cells)
 
 
 # This test is flaky because of random sampling that cannot be controlled.
@@ -4992,14 +4998,14 @@ def test_voxelize_binary_mask_cell_length_sample_size(ant):
     if pv.vtk_version_info < (9, 2):
         match = 'Cell length percentile and sample size requires VTK 9.2 or greater.'
         with pytest.raises(TypeError, match=match):
-            ant.voxelize_binary_mask(cell_length_percentile=0.2)
+            ant._voxelize_as_image_points(cell_length_percentile=0.2)
     else:
-        mask_samples_1 = ant.voxelize_binary_mask(cell_length_sample_size=100)
-        mask_samples_2 = ant.voxelize_binary_mask(cell_length_sample_size=200)
+        mask_samples_1 = ant._voxelize_as_image_points(cell_length_sample_size=100)
+        mask_samples_2 = ant._voxelize_as_image_points(cell_length_sample_size=200)
         assert mask_samples_1.spacing != mask_samples_2.spacing
 
-        mask_samples_1 = ant.voxelize_binary_mask(cell_length_sample_size=ant.n_cells)
-        mask_samples_2 = ant.voxelize_binary_mask(cell_length_sample_size=ant.n_cells)
+        mask_samples_1 = ant._voxelize_as_image_points(cell_length_sample_size=ant.n_cells)
+        mask_samples_2 = ant._voxelize_as_image_points(cell_length_sample_size=ant.n_cells)
         assert mask_samples_1.spacing == mask_samples_2.spacing
 
 
@@ -5009,7 +5015,7 @@ def test_voxelize_binary_mask_cell_length_sample_size(ant):
 )
 def test_voxelize_binary_mask_rounding_func(sphere, rounding_func):
     spacing = np.array((1.1, 1.2, 1.3))
-    mask = sphere.voxelize_binary_mask(spacing=spacing, rounding_func=rounding_func)
+    mask = sphere._voxelize_as_image_points(spacing=spacing, rounding_func=rounding_func)
     assert np.allclose(mask.points_to_cells().bounds, sphere.bounds)
     if rounding_func == np.round:
         assert np.any(mask.spacing > spacing)
@@ -5026,7 +5032,9 @@ def test_voxelize_binary_mask_rounding_func(sphere, rounding_func):
 @pytest.mark.parametrize('foreground', [1, 2.1])
 @pytest.mark.parametrize('background', [-1, 0])
 def test_voxelize_binary_mask_foreground_background(sphere, foreground, background):
-    mask = sphere.voxelize_binary_mask(foreground_value=foreground, background_value=background)
+    mask = sphere._voxelize_as_image_points(
+        foreground_value=foreground, background_value=background
+    )
     unique, counts = np.unique(mask['mask'], return_counts=True)
     assert np.array_equal(unique, [background, foreground])
     # Test we have more foreground than background (not always true, but is true for a sphere mesh)
@@ -5049,13 +5057,13 @@ def test_voxelize_binary_mask_foreground_background(sphere, foreground, backgrou
 def test_voxelize_binary_mask_input(hexbeam):
     # Test unstructured grid works
     assert isinstance(hexbeam, pv.UnstructuredGrid)
-    mask = hexbeam.voxelize_binary_mask()
+    mask = hexbeam._voxelize_as_image_points()
     assert mask.n_points
 
     # Test point cloud does not
     mesh = pv.PolyData(hexbeam.points)
     with pytest.raises(ValueError, match='Input mesh must have faces for voxelization'):
-        mesh.voxelize_binary_mask()
+        mesh._voxelize_as_image_points()
 
 
 @pytest.fixture
@@ -5077,7 +5085,7 @@ def oriented_polydata(oriented_image):
 
 @pytest.mark.needs_vtk_version(9, 3, 0)
 def test_voxelize_binary_mask_orientation(oriented_image, oriented_polydata):
-    mask = oriented_polydata.voxelize_binary_mask(reference_volume=oriented_image)
+    mask = oriented_polydata._voxelize_as_image_points(reference_volume=oriented_image)
     assert mask.bounds == oriented_image.bounds
     mask_as_surface = mask.pad_image().contour_labels(smoothing=False)
     assert mask_as_surface.bounds == oriented_polydata.bounds
@@ -5086,17 +5094,17 @@ def test_voxelize_binary_mask_orientation(oriented_image, oriented_polydata):
 def test_voxelize_binary_mask_raises(sphere):
     match = 'Spacing and dimensions cannot both be set. Set one or the other.'
     with pytest.raises(TypeError, match=match):
-        sphere.voxelize_binary_mask(dimensions=(1, 2, 3), spacing=(4, 5, 6))
+        sphere._voxelize_as_image_points(dimensions=(1, 2, 3), spacing=(4, 5, 6))
 
     match = 'Spacing and cell length options cannot both be set. Set one or the other.'
     with pytest.raises(TypeError, match=match):
-        sphere.voxelize_binary_mask(spacing=(4, 5, 6), cell_length_percentile=0.2)
+        sphere._voxelize_as_image_points(spacing=(4, 5, 6), cell_length_percentile=0.2)
     with pytest.raises(TypeError, match=match):
-        sphere.voxelize_binary_mask(spacing=0.1, cell_length_sample_size=sphere.n_cells)
+        sphere._voxelize_as_image_points(spacing=0.1, cell_length_sample_size=sphere.n_cells)
 
     match = 'Rounding func cannot be set when dimensions is specified. Set one or the other.'
     with pytest.raises(TypeError, match=match):
-        sphere.voxelize_binary_mask(dimensions=(1, 2, 3), rounding_func=np.round)
+        sphere._voxelize_as_image_points(dimensions=(1, 2, 3), rounding_func=np.round)
 
     for parameter in [
         'dimensions',
@@ -5108,4 +5116,88 @@ def test_voxelize_binary_mask_raises(sphere):
         kwargs = {parameter: 0}  # Give parameter any value for test
         match = 'Cannot specify a reference volume with other geometry parameters. `reference_volume` must define the geometry exclusively.'
         with pytest.raises(TypeError, match=match):
-            sphere.voxelize_binary_mask(reference_volume=pv.ImageData(), **kwargs)
+            sphere._voxelize_as_image_points(reference_volume=pv.ImageData(), **kwargs)
+
+
+def test_voxelize_rectilinear(ant):
+    vox = ant.voxelize_('rectilinear', 'cells')
+    assert isinstance(vox, pv.RectilinearGrid)
+
+    # Test dimensions
+    dims = np.array((10, 20, 30))
+    vox = ant.voxelize_('rectilinear', 'cells', dimensions=dims)
+    assert np.array_equal(vox.dimensions, dims)
+
+    # Test spacing by voxelizing as a single cell
+    bnds = ant.bounds
+    size = bnds.x_max - bnds.x_min, bnds.y_max - bnds.y_min, bnds.z_max - bnds.z_min
+    single_cell_dims = np.array((2, 2, 2))
+    vox = ant.voxelize_('rectilinear', 'cells', spacing=size)
+    assert np.allclose(vox.dimensions, single_cell_dims)
+    assert np.allclose(vox.bounds, ant.bounds)
+
+    # Test reference volume - specify both dimensions and spacing
+    reference_volume = pv.ImageData(dimensions=single_cell_dims - 1, spacing=size)
+    vox = ant.voxelize_('rectilinear', 'cells', reference_volume=reference_volume)
+    assert np.allclose(vox.dimensions, single_cell_dims)
+    assert np.allclose(vox.bounds, ant.bounds)
+
+    # Test scalar values
+    foreground = 2
+    background = 3
+    vox = ant.voxelize_(
+        'rectilinear', 'cells', foreground_value=foreground, background_value=background
+    )
+    assert 'mask' in vox.cell_data
+    assert vox.array_names == ['mask']
+    values = np.unique(vox['mask'])
+    assert np.array_equal(values, [foreground, background])
+
+    # Test other keywords
+    if pv.vtk_version_info >= (9, 2):
+        vox = ant.voxelize_('rectilinear', 'cells', cell_length_percentile=0.5)
+        assert vox.n_cells
+        vox = ant.voxelize_('rectilinear', 'cells', cell_length_sample_size=ant.n_cells)
+        assert vox.n_cells
+    assert vox.n_cells
+    vox = ant.voxelize_('rectilinear', 'cells', progress_bar=True)
+    assert vox.n_cells
+    vox = ant.voxelize_('rectilinear', 'cells', spacing=(0.1, 0.2, 0.3), rounding_func=np.ceil)
+    assert vox.n_cells
+
+    # Test invalid input
+    with pytest.raises(TypeError, match='Object arrays are not supported'):
+        ant.voxelize_('rectilinear', 'cells', spacing={0.5, 0.3})
+
+
+def test_voxelize(ant):
+    vox = ant.voxelize_('unstructured', 'cells')
+    assert isinstance(vox, pv.UnstructuredGrid)
+    assert vox.array_names == []
+
+    # Test dimensions
+    dims = np.array((10, 20, 30))
+    vox = pv.Cube().voxelize_('unstructured', 'cells', dimensions=dims)
+    assert np.array_equal(vox.n_points, np.prod(dims))
+
+    # Test spacing by voxelizing as a single cell
+    bnds = ant.bounds
+    size = bnds.x_max - bnds.x_min, bnds.y_max - bnds.y_min, bnds.z_max - bnds.z_min
+    vox = ant.voxelize_('unstructured', 'cells', spacing=size)
+    assert np.allclose(vox.n_cells, 1)
+    assert np.allclose(vox.bounds, ant.bounds)
+
+    # Test other keywords
+    if pv.vtk_version_info >= (9, 2):
+        vox = ant.voxelize_('unstructured', 'cells', cell_length_percentile=0.5)
+        assert vox.n_cells
+        vox = ant.voxelize_('unstructured', 'cells', cell_length_sample_size=ant.n_cells)
+        assert vox.n_cells
+    vox = ant.voxelize_('unstructured', 'cells', progress_bar=True)
+    assert vox.n_cells
+    vox = ant.voxelize_('unstructured', 'cells', spacing=(0.1, 0.2, 0.3), rounding_func=np.ceil)
+    assert vox.n_cells
+
+    # Test invalid input
+    with pytest.raises(TypeError, match='Object arrays are not supported'):
+        ant.voxelize_('unstructured', 'cells', spacing={0.5, 0.3})


### PR DESCRIPTION
### Overview

Split from #7037

Create a new `voxelize` filter and allow specifying any output mesh type or voxel type, e.g.

- `mesh.voxelize_binary_mask()` becomes `mesh.voxelize('image', 'points')`
- `pv.voxelize_volume(mesh)` becomes `mesh.voxelize('rectilinear', 'cells')`
- `pv.voxelize(mesh)` becomes `mesh.voxelize('unstructured', 'cells')`
- Add new options for generating `PolyData` mesh types as well
- Move most examples from all voxelize filters to a dedicated gallery example