### PR TITLE
Fix invalid f-string and make code more readable in anatomical_groups.py

### DIFF
--- a/examples/99-advanced/anatomical_groups.py
+++ b/examples/99-advanced/anatomical_groups.py
@@ -58,8 +58,7 @@ ids_to_colors = dataset.user_dict['ids_to_colors']
 
 print('{')
 for name, (R, G, B) in names_to_colors.items():
-    key = f"'{name}'"
-    print(f'{key:<32}: ({R:>3}, {G:>3}, {B:>3}),')
+    print(f'{repr(name):<32}: ({R:>3}, {G:>3}, {B:>3}),')
 print('}')
 
 # %%

--- a/examples/99-advanced/anatomical_groups.py
+++ b/examples/99-advanced/anatomical_groups.py
@@ -58,7 +58,7 @@ ids_to_colors = dataset.user_dict['ids_to_colors']
 
 print('{')
 for name, (R, G, B) in names_to_colors.items():
-    print(f'{repr(name):<32}: ({R:>3}, {G:>3}, {B:>3}),')
+    print(f'{name!r:<32}: ({R:>3}, {G:>3}, {B:>3}),')
 print('}')
 
 # %%

--- a/examples/99-advanced/anatomical_groups.py
+++ b/examples/99-advanced/anatomical_groups.py
@@ -59,7 +59,7 @@ ids_to_colors = dataset.user_dict['ids_to_colors']
 print('{')
 for name, (R, G, B) in names_to_colors.items():
     key = f"'{name}'"
-    print(f'{key:>32}: ({R:>3}, {G:>3}, {B:>3}),')
+    print(f'{key:<32}: ({R:>3}, {G:>3}, {B:>3}),')
 print('}')
 
 # %%

--- a/examples/99-advanced/anatomical_groups.py
+++ b/examples/99-advanced/anatomical_groups.py
@@ -56,14 +56,11 @@ ids_to_colors = dataset.user_dict['ids_to_colors']
 #     This mapping is specific to the PyVista datasets and is not part of the
 #     TotalSegmentator data.
 
-print(
-    '{\n'
-    + '\n'.join(
-        f'    {"'" + name + "':":<32} ({R:>3}, {G:>3}, {B:>3}),'
-        for name, (R, G, B) in names_to_colors.items()
-    )
-    + '\n}',
-)
+print('{')
+for name, (R, G, B) in names_to_colors.items():
+    key = f"'{name}'"
+    print(f'{key:>32}: ({R:>3}, {G:>3}, {B:>3}),')
+print('}')
 
 # %%
 # Utility Functions


### PR DESCRIPTION
This example is failing any time I run the pre-commit checks locally and I found this code unreadable:

```
debug statements (python)................................................Failed
- hook id: debug-statements
- exit code: 1

examples/99-advanced/anatomical_groups.py - Could not parse ast

        Traceback (most recent call last):
          File "/home/bane/.cache/pre-commit/repogagxs5o5/py_env-python3.11/lib/python3.11/site-packages/pre_commit_hooks/debug_statement_hook.py", line 57, in check_file
            ast_obj = ast.parse(f.read(), filename=filename)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/home/bane/.pyenv/versions/3.11.6/lib/python3.11/ast.py", line 50, in parse
            return compile(source, filename, mode, flags,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "examples/99-advanced/anatomical_groups.py", line 63
            for name, (R, G, B) in names_to_colors.items()
            ^^^
        SyntaxError: f-string: unterminated string
```


This is an attempt to make the code a bit more readable and be a valid f-string for Python 3.11-