### PR TITLE
Refactor `clip` filter tests and add checks for `MultiBlock` inputs

### DIFF
--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -38,7 +38,7 @@ def test_clip_filter(multiblock_all_with_nested_and_none, return_clipped):
     assert None in multi.recursive_iterator()
 
     for dataset in multi:
-        clp = dataset.clip(normal='x', invert=True, return_clipped=return_clipped)
+        clips = dataset.clip(normal='x', invert=True, return_clipped=return_clipped)
         assert clp is not None
 
         if return_clipped:

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -35,6 +35,7 @@ def test_clip_filter(multiblock_all_with_nested_and_none, return_clipped):
         if block is None:
             del multi[i]
     assert None not in multi
+    assert None in multi.recursive_iterator()
 
     for dataset in multi:
         clp = dataset.clip(normal='x', invert=True, return_clipped=return_clipped)

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -49,7 +49,7 @@ def test_clip_filter(multiblock_all_with_nested_and_none, return_clipped):
             # Make dataset iterable
             clp = [clp]
 
-        for clipped in clp:
+        for clip in clips:
             if isinstance(dataset, pv.PolyData):
                 assert isinstance(clipped, pv.PolyData)
             elif isinstance(dataset, pv.MultiBlock):

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -39,24 +39,24 @@ def test_clip_filter(multiblock_all_with_nested_and_none, return_clipped):
 
     for dataset in multi:
         clips = dataset.clip(normal='x', invert=True, return_clipped=return_clipped)
-        assert clp is not None
+        assert clips is not None
 
         if return_clipped:
-            assert isinstance(clp, tuple)
-            assert len(clp) == 2
+            assert isinstance(clips, tuple)
+            assert len(clips) == 2
         else:
-            assert isinstance(clp, pv.DataObject)
+            assert isinstance(clips, pv.DataObject)
             # Make dataset iterable
-            clp = [clp]
+            clips = [clips]
 
         for clip in clips:
             if isinstance(dataset, pv.PolyData):
-                assert isinstance(clipped, pv.PolyData)
+                assert isinstance(clip, pv.PolyData)
             elif isinstance(dataset, pv.MultiBlock):
-                assert isinstance(clipped, pv.MultiBlock)
-                assert clipped.n_blocks == dataset.n_blocks
+                assert isinstance(clip, pv.MultiBlock)
+                assert clip.n_blocks == dataset.n_blocks
             else:
-                assert isinstance(clipped, pv.UnstructuredGrid)
+                assert isinstance(clip, pv.UnstructuredGrid)
 
 
 def test_clip_filter_normal(datasets):


### PR DESCRIPTION
### Overview

Split from #7266

- use a fixture which includes `MultiBlock` inputs
- add instance checks to test `MultiBlock` inputs
- parametrize `return_clipped` so only a single for loop is needed (currently the test uses two separate for-loops, one for each value of `return_clipped`)
- split test for various `normal` inputs into its own test
- define a `'cell_ids'` array explicitly for the crinkle test