### PR TITLE
Remove deprecated `numpy.typing.mypy_plugin`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,11 +242,7 @@ extra_checks = true
 ignore_missing_imports = true
 no_implicit_reexport = true
 packages = ['pyvista']
-plugins = [
-  'npt_promote',
-  'numpy.typing.mypy_plugin',
-  'pyvista.typing.mypy_plugin',
-]
+plugins = ['npt_promote', 'pyvista.typing.mypy_plugin']
 pretty = true
 show_error_context = true
 strict_equality = true


### PR DESCRIPTION
### Overview

NumPy 2.3 (not yet released) deprecates their typing plugin, so let's remove it.

https://numpy.org/devdocs/release/2.3.0-notes.html#deprecations