### PR TITLE
Skip `@overload` test coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,8 +199,7 @@ omit = [
   'pyvista/plotting/theme.py', # kept for backwards compatibility
 ]
 [tool.coverage.report]
-exclude_also = ['if TYPE_CHECKING:']
-
+exclude_also = ['^\s*@overload\s*def .*\(.*$', '^\s*if TYPE_CHECKING:']
 
 [tool.pytest.ini_options]
 addopts = ['--strict-config', '--strict-markers', '-ra']


### PR DESCRIPTION
### Overview

Fix false positives from partial branches from typing overloads. See https://github.com/pyvista/pyvista/pull/7104#issuecomment-2707251680

This fix was tested in #7279 and resolves the overload coverage issues experienced there.