### PR TITLE
Parallelize the docstringcheck CI job

### DIFF
--- a/.github/workflows/style_docstr.yml
+++ b/.github/workflows/style_docstr.yml
@@ -13,6 +13,13 @@ env:
 jobs:
   docstringcheck:
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - make-target: "doctest-modules-core"
+          - make-target: "doctest-modules-plotting"
+          - make-target: "doctest-modules-local-namespace"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,20 +42,19 @@ jobs:
         run: |
           pip install -e .[test]
 
-      - name: Setup headless display
-        uses: pyvista/setup-headless-display-action@v2
+      - uses: awalsh128/cache-apt-pkgs-action@v1.4.3
+        with:
+          packages: xvfb
+          version: 3.0
 
       - name: Software Report
         run: |
-          python -c "import pyvista; print(pyvista.Report()); from pyvista import examples; print('Examples path:', examples.USER_DATA_PATH)"
+          xvfb-run -a python -c "import pyvista; print(pyvista.Report()); from pyvista import examples; print('Examples path:', examples.USER_DATA_PATH)"
           which python
           pip list
 
-      - name: Test Package Docstrings
-        run: make doctest-modules
-
-      - name: Test Package Docstrings with Local Namespace
-        run: make doctest-modules-local-namespace
+      - name: Test Docstrings
+        run: xvfb-run -a make ${{ matrix.make-target }}
 
   vale:
     name: Vale

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,15 @@ CODE_FILES ?= *.py *.rst *.md
 doctest-modules: export PYVISTA_OFF_SCREEN = True
 doctest-modules-local-namespace: export PYVISTA_OFF_SCREEN = True
 
-doctest-modules:
-	@echo "Running module doctesting"
-	pytest -v --doctest-modules pyvista
+doctest-modules-core:
+	@echo "Running core doctests"
+	pytest -v --doctest-modules pyvista/ --ignore=pyvista/plotting
+
+doctest-modules-plotting:
+	@echo "Running plotting doctests"
+	pytest -v --doctest-modules pyvista/plotting
+
+doctest-modules: doctest-modules-core doctest-modules-plotting
 
 doctest-modules-local-namespace:
 	@echo "Running module doctesting using docstring local namespace"


### PR DESCRIPTION
This is an attempt to deal with https://github.com/pyvista/pyvista/pull/7216#issuecomment-2708007457 where the docstrings CI job has ballooned to ~55 minutes after upgrading the OS.

This PR:

1. Switches to using `xvfb-run` instead of the `setup-headless-display` action
2. Parallelizes the core, plotting, and namespace docstrings checks into separate jobs