### PR TITLE
Add technical reference to cell quality filter docstring

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5319,9 +5319,11 @@ class DataSetFilters(DataObjectFilters):
         - ``'volume'``
         - ``'warpage'``
 
-        Notes
-        -----
-        There is a `discussion about shape option <https://github.com/pyvista/pyvista/discussions/6143>`_.
+        .. note::
+
+            Refer to the `Verdict Library Reference Manual <https://public.kitware.com/Wiki/images/6/6b/VerdictManual-revA.pdf>`_
+            for low-level technical information about how each metric is computed and
+            its full, normal, and acceptable range of values..
 
         Parameters
         ----------

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5322,8 +5322,9 @@ class DataSetFilters(DataObjectFilters):
         .. note::
 
             Refer to the `Verdict Library Reference Manual <https://public.kitware.com/Wiki/images/6/6b/VerdictManual-revA.pdf>`_
-            for low-level technical information about how each metric is computed and
-            its full, normal, and acceptable range of values..
+            for low-level technical information about how each metric is computed,
+            which :class:`~pyvista.CellType` it applies to as well as the metric's
+            full, normal, and acceptable range of values.
 
         Parameters
         ----------


### PR DESCRIPTION
### Overview

Supersedes #6150. I found a complete technical reference that documents all of these metrics at a low-level.

https://public.kitware.com/Wiki/images/6/6b/VerdictManual-revA.pdf