### PR TITLE
Add `pv.cell_quality_info` to retrieve info about measures used by cell quality filter

### DIFF
--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -19,6 +19,7 @@ from pyvista.core._typing_core._dataset_types import _DataSetType as _DataSetTyp
 from pyvista.core._typing_core._dataset_types import _GridType as _GridType
 from pyvista.core._typing_core._dataset_types import _PointGridType as _PointGridType
 from pyvista.core._typing_core._dataset_types import _PointSetType as _PointSetType
+from pyvista.core._vtk_core import vtk_verbosity as vtk_verbosity
 from pyvista.core._vtk_core import vtk_version_info as vtk_version_info
 from pyvista.core.cell import _get_vtk_id_type
 from pyvista.core.utilities.observers import send_errors_to_logging

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -10,7 +10,9 @@ the entire library.
 from __future__ import annotations
 
 import contextlib
+from typing import Literal
 from typing import NamedTuple
+from typing import get_args
 import warnings
 
 from vtkmodules.vtkCommonCore import vtkVersion as vtkVersion
@@ -584,3 +586,49 @@ def VTKVersionInfo():
 
 
 vtk_version_info = VTKVersionInfo()
+
+_VerbosityLiteral = Literal[
+    'invalid',
+    'off',
+    'error',
+    'warning',
+    'info',
+    'trace',
+    'max',
+    '0',
+    '1',
+    '2',
+    '3',
+    '4',
+    '5',
+    '6',
+    '7',
+    '8',
+    '9',
+]
+
+_VerbosityOptions = get_args(_VerbosityLiteral)
+
+
+class vtk_verbosity(contextlib.ContextDecorator):
+    """Context manager to temporarily set VTK verbosity level."""
+
+    def __init__(self, verbosity: _VerbosityLiteral | vtkLogger.Verbosity):
+        if isinstance(verbosity, (int, str)) and not isinstance(verbosity, vtkLogger.Verbosity):
+            try:
+                verbosity = getattr(vtkLogger, f'VERBOSITY_{str(verbosity).upper()}')
+            except AttributeError:
+                raise ValueError(
+                    f"Invalid verbosity name '{verbosity}', must be one of:\n{_VerbosityOptions}."
+                )
+        self._new_verbosity = verbosity
+
+    def __enter__(self):
+        # Store the current verbosity level
+        self._original_verbosity = vtkLogger.GetCurrentVerbosityCutoff()
+        # Set the new verbosity level
+        vtkLogger.SetStderrVerbosity(self._new_verbosity)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # Restore the original verbosity level
+        vtkLogger.SetStderrVerbosity(self._original_verbosity)

--- a/pyvista/core/celltype.py
+++ b/pyvista/core/celltype.py
@@ -93,6 +93,762 @@ class _CellTypeTuple(NamedTuple):
     faces_override: Literal['variable', 'n/a'] | None = None
 
 
+_CELL_TYPE_INFO = {
+    'EMPTY_CELL': _CellTypeTuple(
+        value=_vtk.VTK_EMPTY_CELL,
+        cell_class=_vtk.vtkEmptyCell,
+        short_doc="""Used as a place-holder during processing.""",
+    ),
+    'VERTEX': _CellTypeTuple(
+        value=_vtk.VTK_VERTEX,
+        cell_class=_vtk.vtkVertex,
+        example='Vertex',
+        short_doc="""
+        Represents a point in 3D space.
+
+        The vertex is a primary zero-dimensional cell. It is defined by a single point.
+        """,
+    ),
+    'POLY_VERTEX': _CellTypeTuple(
+        value=_vtk.VTK_POLY_VERTEX,
+        cell_class=_vtk.vtkPolyVertex,
+        example='PolyVertex',
+        points_override='variable',
+        short_doc="""
+        Represents a set of points in 3D space.
+
+        The polyvertex is a composite zero-dimensional cell. It is defined by an
+        arbitrarily ordered list of points.
+        """,
+    ),
+    'LINE': _CellTypeTuple(
+        value=_vtk.VTK_LINE,
+        cell_class=_vtk.vtkLine,
+        example='Line',
+        short_doc="""
+        Represents a 1D line.
+
+        The line is a primary one-dimensional cell. It is defined by two points.
+        The direction along the line is from the first point to the second point.
+        """,
+    ),
+    'POLY_LINE': _CellTypeTuple(
+        value=_vtk.VTK_POLY_LINE,
+        cell_class=_vtk.vtkPolyLine,
+        example='PolyLine',
+        points_override='variable',
+        short_doc="""
+        Represents a set of 1D lines.
+
+        The polyline is a composite one-dimensional cell consisting of one or more
+        connected lines.
+        """,
+        long_doc="""
+        The polyline is defined by an ordered list of n+1 points, where n is the number
+        of lines in the polyline. Each pair of points ``(i, i+1)`` defines a line.
+        """,
+    ),
+    'TRIANGLE': _CellTypeTuple(
+        value=_vtk.VTK_TRIANGLE,
+        cell_class=_vtk.vtkTriangle,
+        example='Triangle',
+        short_doc="""
+        Represents a 2D triangle.
+
+        The triangle is a primary two-dimensional cell. The triangle is defined by a
+        counter-clockwise ordered list of three points.
+        """,
+        long_doc="""
+        The order of the points specifies the direction of the surface normal using the
+        right-hand rule.
+        """,
+    ),
+    'TRIANGLE_STRIP': _CellTypeTuple(
+        value=_vtk.VTK_TRIANGLE_STRIP,
+        cell_class=_vtk.vtkTriangleStrip,
+        example='TriangleStrip',
+        points_override='variable',
+        edges_override='variable',
+        short_doc="""
+        Represents a 2D triangle strip.
+
+        The triangle strip is a composite two-dimensional cell consisting of one or more
+        triangles. It is a compact representation of triangles connected edge-to-edge.
+        """,
+        long_doc="""
+        The triangle strip is defined by an ordered list of n+2 points, where n is the
+        number of triangles. The ordering of the points is such that each set of three
+        points ``(i,i+1,i+2)`` with ``0≤i≤n`` defines a triangle.
+
+        The connectivity of a triangle strip is three points defining an
+        initial triangle, then for each additional triangle, a single point that,
+        combined with the previous two points, defines the next triangle.
+
+        The points defining the triangle strip need not lie in a plane.
+        """,
+    ),
+    'POLYGON': _CellTypeTuple(
+        value=_vtk.VTK_POLYGON,
+        cell_class=_vtk.vtkPolygon,
+        example='Polygon',
+        points_override='variable',
+        edges_override='variable',
+        short_doc="""
+        Represents a 2D n-sided polygon.
+
+        The polygon is a primary two-dimensional cell. It is defined by an ordered list
+        of three or more points lying in a plane.
+        """,
+        long_doc="""
+        The polygon has n edges, where n is the number of points in the polygon.
+        Define the polygon with n-points ordered in the counter-clockwise direction.
+        Do not repeat the last point.
+
+        The polygon normal is implicitly defined by a counterclockwise ordering of its
+        points using the right-hand rule.
+
+        The polygon may be non-convex, but may not have any internal holes, and cannot
+        self-intersect.
+        """,
+    ),
+    'PIXEL': _CellTypeTuple(
+        value=_vtk.VTK_PIXEL,
+        cell_class=_vtk.vtkPixel,
+        example='Pixel',
+        short_doc="""
+        Represents a 2D orthogonal quadrilateral.
+
+        The pixel is a primary two-dimensional cell defined by an ordered list of four
+        points.
+
+        .. warning::
+            This definition of a pixel differs from the conventional definition which
+            describes a single constant-valued element in an image. The meaning of this
+            term can vary depending on context. See :ref:`image_representations_example`
+            for examples.
+        """,
+        long_doc="""
+        The points are ordered in the direction of increasing axis coordinate, starting
+        with x, then y, then z.
+
+        Unlike a quadrilateral cell, the corners or a pixel are at right angles and
+        aligned along x-y-z coordinate axes. It is used to improve computational
+        performance.
+        """,
+    ),
+    'QUAD': _CellTypeTuple(
+        value=_vtk.VTK_QUAD,
+        cell_class=_vtk.vtkQuad,
+        example='Quadrilateral',
+        short_doc="""
+        Represents a 2D quadrilateral.
+
+        The quadrilateral is a primary two-dimensional cell. It is defined by an ordered
+        list of four points lying in a plane.
+        """,
+        long_doc="""
+        The four points ``(0,1,2,3)`` are ordered counterclockwise around the
+        quadrilateral, defining a surface normal using the right-hand rule.
+
+        The quadrilateral is convex and its edges must not intersect.
+        """,
+    ),
+    'TETRA': _CellTypeTuple(
+        value=_vtk.VTK_TETRA,
+        cell_class=_vtk.vtkTetra,
+        example='Tetrahedron',
+        short_doc="""
+        Represents a 3D tetrahedron.
+
+        The tetrahedron is a primary three-dimensional cell. The tetrahedron is defined
+        by a list of four non-planar points. It has six edges and four triangular faces.
+        """,
+        long_doc="""
+        The tetrahedron is defined by the four points ``(0-3)`` where ``(0,1,2)``
+        is the base of the tetrahedron which, using the right hand rule, forms a
+        triangle whose normal points in the direction of the fourth point.
+        """,
+    ),
+    'VOXEL': _CellTypeTuple(
+        value=_vtk.VTK_VOXEL,
+        cell_class=_vtk.vtkVoxel,
+        example='Voxel',
+        short_doc="""
+        Represents a 3D orthogonal parallelepiped.
+
+        The voxel is a primary three-dimensional cell defined by an ordered list of
+        eight points.
+
+        .. warning::
+            This definition of a voxel differs from the conventional definition which
+            describes a single constant-valued volume element. The meaning of this
+            term can vary depending on context. See :ref:`image_representations_example`
+            for examples.
+        """,
+        long_doc="""
+        The points are ordered in the direction of increasing coordinate value.
+
+        Unlike a hexahedron cell, a voxel has interior angles of 90 degrees, and its
+        sides are parallel to the coordinate axes. It is used to improve computational
+        performance.
+        """,
+    ),
+    'HEXAHEDRON': _CellTypeTuple(
+        value=_vtk.VTK_HEXAHEDRON,
+        cell_class=_vtk.vtkHexahedron,
+        example='Hexahedron',
+        short_doc="""
+        Represents a 3D rectangular hexahedron.
+
+        The hexahedron is a primary three-dimensional cell consisting of six
+        quadrilateral faces, twelve edges, and eight vertices.
+        """,
+        long_doc="""
+        The hexahedron is defined by the eight points ``(0-7)`` where ``(0,1,2,3)``
+        is the base of the hexahedron which, using the right hand rule, forms a
+        quadrilateral whose normal points in the direction of the opposite face
+        ``(4,5,6,7)``.
+
+        The faces and edges must not intersect any other faces and edges, and the
+        hexahedron must be convex.
+        """,
+    ),
+    'WEDGE': _CellTypeTuple(
+        value=_vtk.VTK_WEDGE,
+        cell_class=_vtk.vtkWedge,
+        example='Wedge',
+        short_doc="""
+        Represents a linear 3D wedge.
+
+        The wedge is a primary three-dimensional cell consisting of two triangular
+        and three quadrilateral faces.
+        """,
+        long_doc="""
+        The cell is defined by the six points ``(0-5)`` where ``(0,1,2)`` is the
+        base of the wedge which, using the right hand rule, forms a triangle whose
+        normal points outward (away from the triangular face ``(3,4,5)``).
+
+        The faces and edges must not intersect any other faces and edges, and the wedge
+        must be convex.
+        """,
+    ),
+    'PYRAMID': _CellTypeTuple(
+        value=_vtk.VTK_PYRAMID,
+        cell_class=_vtk.vtkPyramid,
+        example='Pyramid',
+        short_doc="""
+        Represents a 3D pyramid.
+
+        The pyramid is a primary three-dimensional cell consisting of a rectangular base
+        with four triangular faces. It is defined by an ordered list of five points.
+        """,
+        long_doc="""
+        The pyramid is defined by the five points ``(0-4)`` where ``(0,1,2,3)`` is
+        the base of the pyramid which, using the right hand rule, forms a
+        quadrilateral whose normal points in the direction of the pyramid apex at
+        vertex ``(4)``. The parametric location of vertex ``(4)`` is ``[0, 0, 1]``.
+
+        The four points defining the quadrilateral base plane must be convex.
+
+        The fifth apex point must not be co-planar with the base points.
+        """,
+    ),
+    'PENTAGONAL_PRISM': _CellTypeTuple(
+        value=_vtk.VTK_PENTAGONAL_PRISM,
+        cell_class=_vtk.vtkPentagonalPrism,
+        example='PentagonalPrism',
+        short_doc="""
+        Represents a convex 3D prism with a pentagonal base and five quadrilateral faces.
+
+        The pentagonal prism is a primary three-dimensional cell defined by an ordered
+        list of ten points.
+        """,
+        long_doc="""
+        The prism is defined by the ten points ``(0-9)``, where ``(0,1,2,3,4)`` is
+        the base of the prism which, using the right hand rule, forms a pentagon
+        whose normal points is in the direction of the opposite face ``(5,6,7,8,9)``.
+
+        The faces and edges must not intersect any other faces and edges and the
+        pentagon must be convex.
+        """,
+    ),
+    'HEXAGONAL_PRISM': _CellTypeTuple(
+        value=_vtk.VTK_HEXAGONAL_PRISM,
+        cell_class=_vtk.vtkHexagonalPrism,
+        example='HexagonalPrism',
+        short_doc="""
+        Represents a 3D prism with hexagonal base and six quadrilateral faces.
+
+        The hexagonal prism is a primary three-dimensional cell defined by an ordered
+        list of twelve points.
+        """,
+        long_doc="""
+        The prism is defined by the twelve points ``(0-11)`` where ``(0,1,2,3,4,5)``
+        is the base of the prism which, using the right hand rule, forms a hexagon
+        whose normal points is in the direction of the opposite face ``(6,7,8,9,10,11)``.
+
+        The faces and edges must not intersect any other faces and edges and the
+        hexagon must be convex.
+        """,
+    ),
+    ####################################################################################
+    # Quadratic, isoparametric cells
+    'QUADRATIC_EDGE': _CellTypeTuple(
+        value=_vtk.VTK_QUADRATIC_EDGE,
+        cell_class=_vtk.vtkQuadraticEdge,
+        example='QuadraticEdge',
+        short_doc="""
+        Represents a 1D, 3-node, iso-parametric parabolic line.
+
+        The cell includes a mid-edge node.
+        """,
+        long_doc="""
+        The ordering of the three points defining the cell is point ids
+        ``(0,1,2)`` where id ``(2)`` is the mid-edge node.
+        """,
+    ),
+    'QUADRATIC_TRIANGLE': _CellTypeTuple(
+        value=_vtk.VTK_QUADRATIC_TRIANGLE,
+        cell_class=_vtk.vtkQuadraticTriangle,
+        example='QuadraticTriangle',
+        short_doc="""
+        Represents a 2D, 6-node, iso-parametric parabolic triangle.
+
+        The cell includes a mid-edge node for each of the three edges of the cell.
+        """,
+        long_doc="""
+        The ordering of the six points defining the cell is point ids
+        ``(0-2, 3-5)`` where:
+
+        - id ``(3)`` is the mid-edge node between points ``(0,1)``.
+        - id ``(4)`` is the mid-edge node between points ``(1,2)``.
+        - id ``(5)`` is the mid-edge node between points ``(2,0)``.
+
+        """,
+    ),
+    'QUADRATIC_QUAD': _CellTypeTuple(
+        value=_vtk.VTK_QUADRATIC_QUAD,
+        cell_class=_vtk.vtkQuadraticQuad,
+        example='QuadraticQuadrilateral',
+        short_doc="""
+        Represents a 2D, 8-node iso-parametric parabolic quadrilateral element.
+
+        The cell includes a mid-edge node for each of the four edges of the cell.
+        """,
+        long_doc="""
+        The ordering of the eight points defining the cell are point ids
+        ``(0-3, 4-7)`` where:
+
+        - ids ``(0-3)`` define the four corner vertices of the quad.
+        - ids ``(4-7)`` define the mid-edge nodes ``(0,1)``, ``(1,2)``, ``(2,3)``, ``(3,0)``.
+
+        """,
+    ),
+    'QUADRATIC_POLYGON': _CellTypeTuple(
+        value=_vtk.VTK_QUADRATIC_POLYGON,
+        cell_class=_vtk.vtkQuadraticPolygon,
+        example='QuadraticPolygon',
+        points_override='variable',
+        edges_override='variable',
+        short_doc="""
+        Represents a 2D n-sided (2*n nodes) parabolic polygon.
+
+        The polygon cannot have any internal holes, and cannot self-intersect.
+        The cell includes a mid-edge node for each of the n edges of the cell.
+        """,
+        long_doc="""
+        The ordering of the 2*n points defining the cell are point ids
+        ``(0..n-1, n..2*n-1)`` where:
+
+        - ids ``(0..n-1)`` define the corner vertices of the polygon.
+        - ids ``(n..2*n-1)`` define the mid-edge nodes.
+
+        Define the polygon with points ordered in the counter-clockwise direction.
+        Do not repeat the last point.
+        """,
+    ),
+    'QUADRATIC_TETRA': _CellTypeTuple(
+        value=_vtk.VTK_QUADRATIC_TETRA,
+        cell_class=_vtk.vtkQuadraticTetra,
+        example='QuadraticTetrahedron',
+        short_doc="""
+        Represents a 3D, 10-node, iso-parametric parabolic tetrahedron.
+
+        The cell includes a mid-edge node on each of the side edges of the tetrahedron.
+        """,
+        long_doc="""
+        The ordering of the ten points defining the cell is point ids ``(0-3, 4-9)``
+        where:
+
+        - ids ``(0-3)`` are the four tetra vertices.
+        - ids ``(4-9)`` are the mid-edge nodes between ``(0,1)``, ``(1,2)``, ``(2,0)``,
+          ``(0,3)``, ``(1,3)``, and ``(2,3)``.
+
+        """,
+    ),
+    'QUADRATIC_HEXAHEDRON': _CellTypeTuple(
+        value=_vtk.VTK_QUADRATIC_HEXAHEDRON,
+        cell_class=_vtk.vtkQuadraticHexahedron,
+        example='QuadraticHexahedron',
+        short_doc="""
+        Represents a 3D, 20-node iso-parametric parabolic hexahedron.
+
+        The cell includes a mid-edge node.
+        """,
+        long_doc="""
+        The ordering of the twenty points defining the cell is point ids
+        ``(0-7, 8-19)`` where:
+
+        - ids ``(0-7)`` are the eight corner vertices of the cube.
+        - ids ``(8-19)`` are the twelve mid-edge nodes.
+
+        The mid-edge nodes lie on the edges defined by ``(0,1)``, ``(1,2)``, ``(2,3)``,
+        ``(3,0)``, ``(4,5)``, ``(5,6)``, ``(6,7)``, ``(7,4)``, ``(0,4)``, ``(1,5)``,
+        ``(2,6)``, ``(3,7)``.
+        """,
+    ),
+    'QUADRATIC_WEDGE': _CellTypeTuple(
+        value=_vtk.VTK_QUADRATIC_WEDGE,
+        cell_class=_vtk.vtkQuadraticWedge,
+        example='QuadraticWedge',
+        short_doc="""
+        Represents a 3D, 15-node iso-parametric parabolic wedge.
+
+        The cell includes a mid-edge node.
+        """,
+        long_doc="""
+        The ordering of the fifteen points defining the cell is point ids
+        ``(0-5, 6-14)`` where:
+
+        - ids ``(0-5)`` are the six corner vertices of the wedge, defined analogously to
+          the six points in ``WEDGE`` (points ``(0,1,2)`` form the base of the wedge
+          which, using the right hand rule, forms a triangle whose normal points
+          away from the triangular face ``(3,4,5)``).
+        - ids ``(6-14)`` are the nine mid-edge nodes.
+
+        The mid-edge nodes lie on the edges defined by ``(0,1)``, ``(1,2)``, ``(2,0)``,
+        ``(3,4)``, ``(4,5)``, ``(5,3)``, ``(0,3)``, ``(1,4)``, ``(2,5)``.
+        """,
+    ),
+    'QUADRATIC_PYRAMID': _CellTypeTuple(
+        value=_vtk.VTK_QUADRATIC_PYRAMID,
+        cell_class=_vtk.vtkQuadraticPyramid,
+        example='QuadraticPyramid',
+        short_doc="""
+        Represents a 3D, 13-node iso-parametric parabolic pyramid.
+
+        The cell includes a mid-edge node.
+        """,
+        long_doc="""
+        The ordering of the thirteen points defining the cell is point ids
+        ``(0-4, 5-12)`` where:
+
+        - ids ``(0-4)`` are the five corner vertices of the pyramid
+        - ids ``(5-12)`` are the eight mid-edge nodes.
+
+        The mid-edge nodes lie on the edges defined by ``(0,1)``, ``(1,2)``, ``(2,3)``,
+        ``(3,0)``, ``(0,4)``, ``(1,4)``, ``(2,4)``, ``(3,4)``, respectively.
+        The parametric location of vertex ``(4)`` is ``[0, 0, 1]``.
+        """,
+    ),
+    'BIQUADRATIC_QUAD': _CellTypeTuple(
+        value=_vtk.VTK_BIQUADRATIC_QUAD,
+        cell_class=_vtk.vtkBiQuadraticQuad,
+        example='BiQuadraticQuadrilateral',
+        short_doc="""
+        Represents a 2D, 9-node iso-parametric parabolic quadrilateral element with a center-point.
+
+        The cell includes a mid-edge node for each of the four edges of the cell and
+        a center node at the surface.
+        """,
+        long_doc="""
+        The ordering of the eight points defining the cell are point ids
+        ``(0-3, 4-8)`` where:
+
+        - ids ``(0-3)`` define the four corner vertices of the quad.
+        - ids ``(4-7)`` define the mid-edge nodes ``(0,1)``, ``(1,2)``, ``(2,3)``, ``(3,0)``.
+        - id ``(8)`` defines the face center node.
+
+        """,
+    ),
+    'TRIQUADRATIC_HEXAHEDRON': _CellTypeTuple(
+        value=_vtk.VTK_TRIQUADRATIC_HEXAHEDRON,
+        cell_class=_vtk.vtkTriQuadraticHexahedron,
+        example='TriQuadraticHexahedron',
+        short_doc="""
+        Represents a 3D, 27-node iso-parametric triquadratic hexahedron.
+
+        The cell includes 8 edge nodes, 12 mid-edge nodes, 6 mid-face nodes and one
+        mid-volume node.
+        """,
+        long_doc="""
+        The ordering of the 27 points defining the cell is point ids
+        ``(0-7, 8-19, 20-25, 26)`` where:
+
+        - ids ``(0-7)`` are the eight corner vertices of the cube.
+        - ids ``(8-19)`` are the twelve mid-edge nodes.
+        - ids ``(20-25)`` are the six mid-face nodes.
+        - id ``(26)`` is the mid-volume node.
+
+        The mid-edge nodes lie on the edges defined by ``(0,1)``, ``(1,2)``, ``(2,3)``,
+        ``(3,0)``, ``(4,5)``, ``(5,6)``, ``(6,7)``, ``(7,4)``, ``(0,4)``, ``(1,5)``,
+        ``(2,6)``, ``(3,7)``.
+
+        The mid-surface nodes lies on the faces defined by (first edge nodes
+        ids, then mid-edge nodes ids):
+
+        - ``(0,1,5,4; 8,17,12,16)``
+        - ``(1,2,6,5; 9,18,13,17)``
+        - ``(2,3,7,6, 10,19,14,18)``
+        - ``(3,0,4,7; 11,16,15,19)``
+        - ``(0,1,2,3; 8,9,10,11)``
+        - ``(4,5,6,7; 12,13,14,15)``
+
+        The last point lies in the center of the cell ``(0,1,2,3,4,5,6,7)``.
+        """,
+    ),
+    'TRIQUADRATIC_PYRAMID': _CellTypeTuple(
+        value=_vtk.VTK_TRIQUADRATIC_PYRAMID,
+        cell_class=_vtk.vtkTriQuadraticPyramid,
+        example='TriQuadraticPyramid',
+        short_doc="""
+        Represents a second order 3D iso-parametric 19-node pyramid.
+
+        The cell includes 5 corner nodes, 8 mid-edge nodes, 5 mid-face nodes,
+        and 1 volumetric centroid node.
+        """,
+        long_doc="""
+        The ordering of the nineteen points defining the cell is point
+        ids ``(0-4, 5-12, 13-17, 18)``, where:
+
+        - ids ``(0-4)`` are the five corner vertices of the pyramid.
+        - ids ``(5-12)`` are the 8 mid-edge nodes.
+        - ids ``(13-17)`` are the 5 mid-face nodes.
+        - id ``(19)`` is the volumetric centroid node.
+
+        The mid-edge nodes lie on the edges defined by ``(0, 1)``, ``(1, 2)``,
+        ``(2, 3)``, ``(3, 0)``, ``(0, 4)``, ``(1, 4)``, ``(2, 4)``, ``(3, 4)``,
+        respectively.
+
+        The mid-face nodes lie on the faces defined by (first corner nodes ids,
+        then mid-edge node ids):
+
+        - quadrilateral face: ``(0,3,2,1; 8,7,6,5)``
+        - triangle face 1: ``(0,1,4; 5,10,9)``
+        - triangle face 2: ``(1,2,4; 6,11,10)``
+        - triangle face 3: ``(2,3,4; 7,12,11)``
+        - triangle face 5: ``(3,0,4; 8,9,12)``
+
+        The last point lies in the center of the cell ``(0,1,2,3,4)``.
+        The parametric location of vertex ``(4)`` is ``[0.5, 0.5, 1]``.
+        """,
+    ),
+    'QUADRATIC_LINEAR_QUAD': _CellTypeTuple(
+        value=_vtk.VTK_QUADRATIC_LINEAR_QUAD,
+        cell_class=_vtk.vtkQuadraticLinearQuad,
+        example='QuadraticLinearQuadrilateral',
+        short_doc="""
+        Represents a 2D, 6-node iso-parametric quadratic-linear quadrilateral element.
+
+        The cell includes a mid-edge node for two of the four edges.
+        """,
+        long_doc="""
+        The ordering of the six points defining the cell are point ids
+        ``(0-3, 4-5)`` where:
+
+        - ids ``(0-3)`` define the four corner vertices of the quad.
+        - ids ``(4-7)`` define the mid-edge nodes ``(0,1)`` and ``(2,3)``.
+
+        """,
+    ),
+    'QUADRATIC_LINEAR_WEDGE': _CellTypeTuple(
+        value=_vtk.VTK_QUADRATIC_LINEAR_WEDGE,
+        cell_class=_vtk.vtkQuadraticLinearWedge,
+        example='QuadraticLinearWedge',
+        short_doc="""
+        Represents a 3D, 12-node iso-parametric linear quadratic wedge.
+
+        The cell includes mid-edge node in the triangle edges.
+        """,
+        long_doc="""
+        The ordering of the 12 points defining the cell is point ids
+        ``(0-5, 6-12)`` where:
+
+        - ids ``(0-5`` are the six corner vertices of the wedge.
+        - ids ``(6-12)`` are the six mid-edge nodes.
+
+        The mid-edge nodes lie on the edges defined by ``(0,1)``, ``(1,2)``, ``(2,0)``,
+        ``(3,4)``, ``(4,5)``, ``(5,3)``.
+        The edges ``(0,3)``, ``(1,4)``, ``(2,5)`` don't have mid-edge nodes.
+        """,
+    ),
+    'BIQUADRATIC_QUADRATIC_WEDGE': _CellTypeTuple(
+        value=_vtk.VTK_BIQUADRATIC_QUADRATIC_WEDGE,
+        cell_class=_vtk.vtkBiQuadraticQuadraticWedge,
+        example='BiQuadraticQuadraticWedge',
+        short_doc="""
+        Represents a 3D, 18-node iso-parametric bi-quadratic wedge.
+
+        The cell includes a mid-edge node.
+        """,
+        long_doc="""
+        The ordering of the 18 points defining the cell is point ids
+        ``(0-5, 6-15, 16-18)`` where:
+
+        - ids ``(0-5)`` are the six corner vertices of the wedge.
+        - ids ``(6-15)`` are the nine mid-edge nodes.
+        - ids ``(16-18)`` are the three center-face nodes.
+
+        The mid-edge nodes lie on the edges defined by ``(0,1)``, ``(1,2)``, ``(2,0)``,
+        ``(3,4)``, ``(4,5)``, ``(5,3)``, ``(0,3)``, ``(1,4)``, ``(2,5)``.
+
+        The center-face nodes are lie in quads ``16-(0,1,4,3)``, ``17-(1,2,5,4)`` and
+        ``18-(2,0,3,5)``.
+        """,
+    ),
+    'BIQUADRATIC_QUADRATIC_HEXAHEDRON': _CellTypeTuple(
+        value=_vtk.VTK_BIQUADRATIC_QUADRATIC_HEXAHEDRON,
+        cell_class=_vtk.vtkBiQuadraticQuadraticHexahedron,
+        example='BiQuadraticQuadraticHexahedron',
+        short_doc="""
+        Represents a 3D, 24-node iso-parametric biquadratic hexahedron.
+
+        The cell includes mid-edge and center-face nodes.
+        """,
+        long_doc="""
+        The ordering of the 24 points defining the cell is point ids
+        ``(0-7, 8-19, 20-23)`` where:
+
+        - ids ``(0-7)`` are the eight corner vertices of the cube.
+        - ids ``(8-19)`` are the twelve mid-edge nodes.
+        - ids ``(20-23)`` are the center-face nodes.
+
+        The mid-edge nodes lie on the edges defined by ``(0,1)``, ``(1,2)``, ``(2,3)``,
+        ``(3,0)``, ``(4,5)``, ``(5,6)``, ``(6,7)``, ``(7,4)``, ``(0,4)``, ``(1,5)``,
+        ``(2,6)``, ``(3,7)``.
+
+        The center face nodes lie in quads ``22-(0,1,5,4)``, ``21-(1,2,6,5)``,
+        ``23-(2,3,7,6)`` and ``22-(3,0,4,7)``.
+        """,
+    ),
+    'BIQUADRATIC_TRIANGLE': _CellTypeTuple(
+        value=_vtk.VTK_BIQUADRATIC_TRIANGLE,
+        cell_class=_vtk.vtkBiQuadraticTriangle,
+        example='BiQuadraticTriangle',
+        short_doc="""
+        Represents a 2D, 7-node, iso-parametric parabolic triangle.
+
+        The cell includes three mid-edge nodes besides the three triangle vertices
+        and a center node.
+        """,
+        long_doc="""
+        The ordering of the three points defining the cell is point ids
+        ``(0-2, 3-6)`` where:
+
+        - id ``(3)`` is the mid-edge node between points ``(0,1)``.
+        - id ``(4)`` is the mid-edge node between points ``(1,2)``.
+        - id ``(5)`` is the mid-edge node between points ``(2,0)``.
+        - id ``(6)`` is the center node of the cell.
+
+        """,
+    ),
+    ####################################################################################
+    # Cubic, iso-parametric cell
+    'CUBIC_LINE': _CellTypeTuple(
+        value=_vtk.VTK_CUBIC_LINE,
+        cell_class=_vtk.vtkCubicLine,
+        example='CubicLine',
+        short_doc="""
+        Represents a 1D iso-parametric cubic line.
+
+        The cell includes two mid-edge nodes.
+        """,
+        long_doc="""
+        The ordering of the four points defining the cell is point ids ``(0,1,2,3)``
+        where id #2 and #3 are the mid-edge nodes.
+
+        The parametric coordinates lie between -1 and 1.
+        """,
+    ),
+    ####################################################################################
+    # Special class of cells formed by convex group of points
+    'CONVEX_POINT_SET': _CellTypeTuple(
+        value=_vtk.VTK_CONVEX_POINT_SET,
+        cell_class=_vtk.vtkConvexPointSet,
+        points_override='variable',
+    ),
+    ####################################################################################
+    # Polyhedron cell (consisting of polygonal faces)
+    'POLYHEDRON': _CellTypeTuple(
+        value=_vtk.VTK_POLYHEDRON,
+        cell_class=_vtk.vtkPolyhedron,
+        example='Polyhedron',
+        short_doc="""
+        Represents a 3D cell defined by a set of polygonal faces.
+
+        """,
+        long_doc="""
+        Polyhedrons must:
+
+        - be watertight: the faces describing the polyhedron should define
+          an enclosed volume with a clear “inside” and “outside”
+        - have planar faces: all points defining a face should be in the
+          same 2D plane
+        - not be self-intersecting: for example, a face of the polyhedron
+          can't intersect other ones
+        - not contain zero-thickness portions: adjacent faces should not
+          overlap each other even partially
+        - not contain disconnected elements: detached vertice(s), edge(s) or face(s)
+        - be simply connected: vtkPolyhedron must describe a single polyhedron
+        - not contain duplicate elements: each point index and each face
+          description should be unique
+        - not contain “internal” or “external” faces: for each face,
+          one side should be “inside” the cell, the other side “outside”
+
+        """,
+        points_override='variable',
+        edges_override='variable',
+        faces_override='variable',
+    ),
+    ####################################################################################
+    # Higher order cells in parametric form
+    'PARAMETRIC_CURVE': _CellTypeTuple(value=_vtk.VTK_PARAMETRIC_CURVE),
+    'PARAMETRIC_SURFACE': _CellTypeTuple(value=_vtk.VTK_PARAMETRIC_SURFACE),
+    'PARAMETRIC_TRI_SURFACE': _CellTypeTuple(value=_vtk.VTK_PARAMETRIC_TRI_SURFACE),
+    'PARAMETRIC_QUAD_SURFACE': _CellTypeTuple(value=_vtk.VTK_PARAMETRIC_QUAD_SURFACE),
+    'PARAMETRIC_TETRA_REGION': _CellTypeTuple(value=_vtk.VTK_PARAMETRIC_TETRA_REGION),
+    'PARAMETRIC_HEX_REGION': _CellTypeTuple(value=_vtk.VTK_PARAMETRIC_HEX_REGION),
+    ####################################################################################
+    # Higher order cells
+    'HIGHER_ORDER_EDGE': _CellTypeTuple(value=_vtk.VTK_HIGHER_ORDER_EDGE),
+    'HIGHER_ORDER_TRIANGLE': _CellTypeTuple(value=_vtk.VTK_HIGHER_ORDER_TRIANGLE),
+    'HIGHER_ORDER_QUAD': _CellTypeTuple(value=_vtk.VTK_HIGHER_ORDER_QUAD),
+    'HIGHER_ORDER_POLYGON': _CellTypeTuple(value=_vtk.VTK_HIGHER_ORDER_POLYGON),
+    'HIGHER_ORDER_TETRAHEDRON': _CellTypeTuple(value=_vtk.VTK_HIGHER_ORDER_TETRAHEDRON),
+    'HIGHER_ORDER_WEDGE': _CellTypeTuple(value=_vtk.VTK_HIGHER_ORDER_WEDGE),
+    'HIGHER_ORDER_PYRAMID': _CellTypeTuple(value=_vtk.VTK_HIGHER_ORDER_PYRAMID),
+    'HIGHER_ORDER_HEXAHEDRON': _CellTypeTuple(value=_vtk.VTK_HIGHER_ORDER_HEXAHEDRON),
+    ####################################################################################
+    # Arbitrary order Lagrange elements (formulated separated from generic higher order cells)
+    'LAGRANGE_CURVE': _CellTypeTuple(value=_vtk.VTK_LAGRANGE_CURVE),
+    'LAGRANGE_TRIANGLE': _CellTypeTuple(value=_vtk.VTK_LAGRANGE_TRIANGLE),
+    'LAGRANGE_QUADRILATERAL': _CellTypeTuple(value=_vtk.VTK_LAGRANGE_QUADRILATERAL),
+    'LAGRANGE_TETRAHEDRON': _CellTypeTuple(value=_vtk.VTK_LAGRANGE_TETRAHEDRON),
+    'LAGRANGE_HEXAHEDRON': _CellTypeTuple(value=_vtk.VTK_LAGRANGE_HEXAHEDRON),
+    'LAGRANGE_WEDGE': _CellTypeTuple(value=_vtk.VTK_LAGRANGE_WEDGE),
+    'LAGRANGE_PYRAMID': _CellTypeTuple(value=_vtk.VTK_LAGRANGE_PYRAMID),
+    ####################################################################################
+    # Arbitrary order Bezier elements (formulated separated from generic higher order cells)
+    'BEZIER_CURVE': _CellTypeTuple(value=_vtk.VTK_BEZIER_CURVE),
+    'BEZIER_TRIANGLE': _CellTypeTuple(value=_vtk.VTK_BEZIER_TRIANGLE),
+    'BEZIER_QUADRILATERAL': _CellTypeTuple(value=_vtk.VTK_BEZIER_QUADRILATERAL),
+    'BEZIER_TETRAHEDRON': _CellTypeTuple(value=_vtk.VTK_BEZIER_TETRAHEDRON),
+    'BEZIER_HEXAHEDRON': _CellTypeTuple(value=_vtk.VTK_BEZIER_HEXAHEDRON),
+    'BEZIER_WEDGE': _CellTypeTuple(value=_vtk.VTK_BEZIER_WEDGE),
+    'BEZIER_PYRAMID': _CellTypeTuple(value=_vtk.VTK_BEZIER_PYRAMID),
+}
+
+
 class CellType(IntEnum):
     """Define types of cells.
 
@@ -283,763 +1039,92 @@ class CellType(IntEnum):
 
     ####################################################################################
     # Linear cells
-    EMPTY_CELL = _CellTypeTuple(
-        value=_vtk.VTK_EMPTY_CELL,
-        cell_class=_vtk.vtkEmptyCell,
-        short_doc="""Used as a place-holder during processing.""",
-    )
-    VERTEX = _CellTypeTuple(
-        value=_vtk.VTK_VERTEX,
-        cell_class=_vtk.vtkVertex,
-        example='Vertex',
-        short_doc="""
-        Represents a point in 3D space.
+    EMPTY_CELL = _CELL_TYPE_INFO['EMPTY_CELL']
+    VERTEX = _CELL_TYPE_INFO['VERTEX']
+    POLY_VERTEX = _CELL_TYPE_INFO['POLY_VERTEX']
+    LINE = _CELL_TYPE_INFO['LINE']
+    POLY_LINE = _CELL_TYPE_INFO['POLY_LINE']
+    TRIANGLE = _CELL_TYPE_INFO['TRIANGLE']
+    TRIANGLE_STRIP = _CELL_TYPE_INFO['TRIANGLE_STRIP']
+    POLYGON = _CELL_TYPE_INFO['POLYGON']
+    PIXEL = _CELL_TYPE_INFO['PIXEL']
+    QUAD = _CELL_TYPE_INFO['QUAD']
+    TETRA = _CELL_TYPE_INFO['TETRA']
+    VOXEL = _CELL_TYPE_INFO['VOXEL']
+    HEXAHEDRON = _CELL_TYPE_INFO['HEXAHEDRON']
+    WEDGE = _CELL_TYPE_INFO['WEDGE']
+    PYRAMID = _CELL_TYPE_INFO['PYRAMID']
+    PENTAGONAL_PRISM = _CELL_TYPE_INFO['PENTAGONAL_PRISM']
+    HEXAGONAL_PRISM = _CELL_TYPE_INFO['HEXAGONAL_PRISM']
 
-        The vertex is a primary zero-dimensional cell. It is defined by a single point.
-        """,
-    )
-    POLY_VERTEX = _CellTypeTuple(
-        value=_vtk.VTK_POLY_VERTEX,
-        cell_class=_vtk.vtkPolyVertex,
-        example='PolyVertex',
-        points_override='variable',
-        short_doc="""
-        Represents a set of points in 3D space.
-
-        The polyvertex is a composite zero-dimensional cell. It is defined by an
-        arbitrarily ordered list of points.
-        """,
-    )
-    LINE = _CellTypeTuple(
-        value=_vtk.VTK_LINE,
-        cell_class=_vtk.vtkLine,
-        example='Line',
-        short_doc="""
-        Represents a 1D line.
-
-        The line is a primary one-dimensional cell. It is defined by two points.
-        The direction along the line is from the first point to the second point.
-        """,
-    )
-    POLY_LINE = _CellTypeTuple(
-        value=_vtk.VTK_POLY_LINE,
-        cell_class=_vtk.vtkPolyLine,
-        example='PolyLine',
-        points_override='variable',
-        short_doc="""
-        Represents a set of 1D lines.
-
-        The polyline is a composite one-dimensional cell consisting of one or more
-        connected lines.
-        """,
-        long_doc="""
-        The polyline is defined by an ordered list of n+1 points, where n is the number
-        of lines in the polyline. Each pair of points ``(i, i+1)`` defines a line.
-        """,
-    )
-    TRIANGLE = _CellTypeTuple(
-        value=_vtk.VTK_TRIANGLE,
-        cell_class=_vtk.vtkTriangle,
-        example='Triangle',
-        short_doc="""
-        Represents a 2D triangle.
-
-        The triangle is a primary two-dimensional cell. The triangle is defined by a
-        counter-clockwise ordered list of three points.
-        """,
-        long_doc="""
-        The order of the points specifies the direction of the surface normal using the
-        right-hand rule.
-        """,
-    )
-    TRIANGLE_STRIP = _CellTypeTuple(
-        value=_vtk.VTK_TRIANGLE_STRIP,
-        cell_class=_vtk.vtkTriangleStrip,
-        example='TriangleStrip',
-        points_override='variable',
-        edges_override='variable',
-        short_doc="""
-        Represents a 2D triangle strip.
-
-        The triangle strip is a composite two-dimensional cell consisting of one or more
-        triangles. It is a compact representation of triangles connected edge-to-edge.
-        """,
-        long_doc="""
-        The triangle strip is defined by an ordered list of n+2 points, where n is the
-        number of triangles. The ordering of the points is such that each set of three
-        points ``(i,i+1,i+2)`` with ``0≤i≤n`` defines a triangle.
-
-        The connectivity of a triangle strip is three points defining an
-        initial triangle, then for each additional triangle, a single point that,
-        combined with the previous two points, defines the next triangle.
-
-        The points defining the triangle strip need not lie in a plane.
-        """,
-    )
-    POLYGON = _CellTypeTuple(
-        value=_vtk.VTK_POLYGON,
-        cell_class=_vtk.vtkPolygon,
-        example='Polygon',
-        points_override='variable',
-        edges_override='variable',
-        short_doc="""
-        Represents a 2D n-sided polygon.
-
-        The polygon is a primary two-dimensional cell. It is defined by an ordered list
-        of three or more points lying in a plane.
-        """,
-        long_doc="""
-        The polygon has n edges, where n is the number of points in the polygon.
-        Define the polygon with n-points ordered in the counter-clockwise direction.
-        Do not repeat the last point.
-
-        The polygon normal is implicitly defined by a counterclockwise ordering of its
-        points using the right-hand rule.
-
-        The polygon may be non-convex, but may not have any internal holes, and cannot
-        self-intersect.
-        """,
-    )
-    PIXEL = _CellTypeTuple(
-        value=_vtk.VTK_PIXEL,
-        cell_class=_vtk.vtkPixel,
-        example='Pixel',
-        short_doc="""
-        Represents a 2D orthogonal quadrilateral.
-
-        The pixel is a primary two-dimensional cell defined by an ordered list of four
-        points.
-
-        .. warning::
-            This definition of a pixel differs from the conventional definition which
-            describes a single constant-valued element in an image. The meaning of this
-            term can vary depending on context. See :ref:`image_representations_example`
-            for examples.
-        """,
-        long_doc="""
-        The points are ordered in the direction of increasing axis coordinate, starting
-        with x, then y, then z.
-
-        Unlike a quadrilateral cell, the corners or a pixel are at right angles and
-        aligned along x-y-z coordinate axes. It is used to improve computational
-        performance.
-        """,
-    )
-    QUAD = _CellTypeTuple(
-        value=_vtk.VTK_QUAD,
-        cell_class=_vtk.vtkQuad,
-        example='Quadrilateral',
-        short_doc="""
-        Represents a 2D quadrilateral.
-
-        The quadrilateral is a primary two-dimensional cell. It is defined by an ordered
-        list of four points lying in a plane.
-        """,
-        long_doc="""
-        The four points ``(0,1,2,3)`` are ordered counterclockwise around the
-        quadrilateral, defining a surface normal using the right-hand rule.
-
-        The quadrilateral is convex and its edges must not intersect.
-        """,
-    )
-    TETRA = _CellTypeTuple(
-        value=_vtk.VTK_TETRA,
-        cell_class=_vtk.vtkTetra,
-        example='Tetrahedron',
-        short_doc="""
-        Represents a 3D tetrahedron.
-
-        The tetrahedron is a primary three-dimensional cell. The tetrahedron is defined
-        by a list of four non-planar points. It has six edges and four triangular faces.
-        """,
-        long_doc="""
-        The tetrahedron is defined by the four points ``(0-3)`` where ``(0,1,2)``
-        is the base of the tetrahedron which, using the right hand rule, forms a
-        triangle whose normal points in the direction of the fourth point.
-        """,
-    )
-    VOXEL = _CellTypeTuple(
-        value=_vtk.VTK_VOXEL,
-        cell_class=_vtk.vtkVoxel,
-        example='Voxel',
-        short_doc="""
-        Represents a 3D orthogonal parallelepiped.
-
-        The voxel is a primary three-dimensional cell defined by an ordered list of
-        eight points.
-
-        .. warning::
-            This definition of a voxel differs from the conventional definition which
-            describes a single constant-valued volume element. The meaning of this
-            term can vary depending on context. See :ref:`image_representations_example`
-            for examples.
-        """,
-        long_doc="""
-        The points are ordered in the direction of increasing coordinate value.
-
-        Unlike a hexahedron cell, a voxel has interior angles of 90 degrees, and its
-        sides are parallel to the coordinate axes. It is used to improve computational
-        performance.
-        """,
-    )
-    HEXAHEDRON = _CellTypeTuple(
-        value=_vtk.VTK_HEXAHEDRON,
-        cell_class=_vtk.vtkHexahedron,
-        example='Hexahedron',
-        short_doc="""
-        Represents a 3D rectangular hexahedron.
-
-        The hexahedron is a primary three-dimensional cell consisting of six
-        quadrilateral faces, twelve edges, and eight vertices.
-        """,
-        long_doc="""
-        The hexahedron is defined by the eight points ``(0-7)`` where ``(0,1,2,3)``
-        is the base of the hexahedron which, using the right hand rule, forms a
-        quadrilateral whose normal points in the direction of the opposite face
-        ``(4,5,6,7)``.
-
-        The faces and edges must not intersect any other faces and edges, and the
-        hexahedron must be convex.
-        """,
-    )
-    WEDGE = _CellTypeTuple(
-        value=_vtk.VTK_WEDGE,
-        cell_class=_vtk.vtkWedge,
-        example='Wedge',
-        short_doc="""
-        Represents a linear 3D wedge.
-
-        The wedge is a primary three-dimensional cell consisting of two triangular
-        and three quadrilateral faces.
-        """,
-        long_doc="""
-        The cell is defined by the six points ``(0-5)`` where ``(0,1,2)`` is the
-        base of the wedge which, using the right hand rule, forms a triangle whose
-        normal points outward (away from the triangular face ``(3,4,5)``).
-
-        The faces and edges must not intersect any other faces and edges, and the wedge
-        must be convex.
-        """,
-    )
-    PYRAMID = _CellTypeTuple(
-        value=_vtk.VTK_PYRAMID,
-        cell_class=_vtk.vtkPyramid,
-        example='Pyramid',
-        short_doc="""
-        Represents a 3D pyramid.
-
-        The pyramid is a primary three-dimensional cell consisting of a rectangular base
-        with four triangular faces. It is defined by an ordered list of five points.
-        """,
-        long_doc="""
-        The pyramid is defined by the five points ``(0-4)`` where ``(0,1,2,3)`` is
-        the base of the pyramid which, using the right hand rule, forms a
-        quadrilateral whose normal points in the direction of the pyramid apex at
-        vertex ``(4)``. The parametric location of vertex ``(4)`` is ``[0, 0, 1]``.
-
-        The four points defining the quadrilateral base plane must be convex.
-
-        The fifth apex point must not be co-planar with the base points.
-        """,
-    )
-    PENTAGONAL_PRISM = _CellTypeTuple(
-        value=_vtk.VTK_PENTAGONAL_PRISM,
-        cell_class=_vtk.vtkPentagonalPrism,
-        example='PentagonalPrism',
-        short_doc="""
-        Represents a convex 3D prism with a pentagonal base and five quadrilateral faces.
-
-        The pentagonal prism is a primary three-dimensional cell defined by an ordered
-        list of ten points.
-        """,
-        long_doc="""
-        The prism is defined by the ten points ``(0-9)``, where ``(0,1,2,3,4)`` is
-        the base of the prism which, using the right hand rule, forms a pentagon
-        whose normal points is in the direction of the opposite face ``(5,6,7,8,9)``.
-
-        The faces and edges must not intersect any other faces and edges and the
-        pentagon must be convex.
-        """,
-    )
-    HEXAGONAL_PRISM = _CellTypeTuple(
-        value=_vtk.VTK_HEXAGONAL_PRISM,
-        cell_class=_vtk.vtkHexagonalPrism,
-        example='HexagonalPrism',
-        short_doc="""
-        Represents a 3D prism with hexagonal base and six quadrilateral faces.
-
-        The hexagonal prism is a primary three-dimensional cell defined by an ordered
-        list of twelve points.
-        """,
-        long_doc="""
-        The prism is defined by the twelve points ``(0-11)`` where ``(0,1,2,3,4,5)``
-        is the base of the prism which, using the right hand rule, forms a hexagon
-        whose normal points is in the direction of the opposite face ``(6,7,8,9,10,11)``.
-
-        The faces and edges must not intersect any other faces and edges and the
-        hexagon must be convex.
-        """,
-    )
     ####################################################################################
     # Quadratic, isoparametric cells
-    QUADRATIC_EDGE = _CellTypeTuple(
-        value=_vtk.VTK_QUADRATIC_EDGE,
-        cell_class=_vtk.vtkQuadraticEdge,
-        example='QuadraticEdge',
-        short_doc="""
-        Represents a 1D, 3-node, iso-parametric parabolic line.
-
-        The cell includes a mid-edge node.
-        """,
-        long_doc="""
-        The ordering of the three points defining the cell is point ids
-        ``(0,1,2)`` where id ``(2)`` is the mid-edge node.
-        """,
-    )
-    QUADRATIC_TRIANGLE = _CellTypeTuple(
-        value=_vtk.VTK_QUADRATIC_TRIANGLE,
-        cell_class=_vtk.vtkQuadraticTriangle,
-        example='QuadraticTriangle',
-        short_doc="""
-        Represents a 2D, 6-node, iso-parametric parabolic triangle.
-
-        The cell includes a mid-edge node for each of the three edges of the cell.
-        """,
-        long_doc="""
-        The ordering of the six points defining the cell is point ids
-        ``(0-2, 3-5)`` where:
-
-        - id ``(3)`` is the mid-edge node between points ``(0,1)``.
-        - id ``(4)`` is the mid-edge node between points ``(1,2)``.
-        - id ``(5)`` is the mid-edge node between points ``(2,0)``.
-
-        """,
-    )
-    QUADRATIC_QUAD = _CellTypeTuple(
-        value=_vtk.VTK_QUADRATIC_QUAD,
-        cell_class=_vtk.vtkQuadraticQuad,
-        example='QuadraticQuadrilateral',
-        short_doc="""
-        Represents a 2D, 8-node iso-parametric parabolic quadrilateral element.
-
-        The cell includes a mid-edge node for each of the four edges of the cell.
-        """,
-        long_doc="""
-        The ordering of the eight points defining the cell are point ids
-        ``(0-3, 4-7)`` where:
-
-        - ids ``(0-3)`` define the four corner vertices of the quad.
-        - ids ``(4-7)`` define the mid-edge nodes ``(0,1)``, ``(1,2)``, ``(2,3)``, ``(3,0)``.
-
-        """,
-    )
-    QUADRATIC_POLYGON = _CellTypeTuple(
-        value=_vtk.VTK_QUADRATIC_POLYGON,
-        cell_class=_vtk.vtkQuadraticPolygon,
-        example='QuadraticPolygon',
-        points_override='variable',
-        edges_override='variable',
-        short_doc="""
-        Represents a 2D n-sided (2*n nodes) parabolic polygon.
-
-        The polygon cannot have any internal holes, and cannot self-intersect.
-        The cell includes a mid-edge node for each of the n edges of the cell.
-        """,
-        long_doc="""
-        The ordering of the 2*n points defining the cell are point ids
-        ``(0..n-1, n..2*n-1)`` where:
-
-        - ids ``(0..n-1)`` define the corner vertices of the polygon.
-        - ids ``(n..2*n-1)`` define the mid-edge nodes.
-
-        Define the polygon with points ordered in the counter-clockwise direction.
-        Do not repeat the last point.
-        """,
-    )
-    QUADRATIC_TETRA = _CellTypeTuple(
-        value=_vtk.VTK_QUADRATIC_TETRA,
-        cell_class=_vtk.vtkQuadraticTetra,
-        example='QuadraticTetrahedron',
-        short_doc="""
-        Represents a 3D, 10-node, iso-parametric parabolic tetrahedron.
-
-        The cell includes a mid-edge node on each of the side edges of the tetrahedron.
-        """,
-        long_doc="""
-        The ordering of the ten points defining the cell is point ids ``(0-3, 4-9)``
-        where:
-
-        - ids ``(0-3)`` are the four tetra vertices.
-        - ids ``(4-9)`` are the mid-edge nodes between ``(0,1)``, ``(1,2)``, ``(2,0)``,
-          ``(0,3)``, ``(1,3)``, and ``(2,3)``.
-
-        """,
-    )
-    QUADRATIC_HEXAHEDRON = _CellTypeTuple(
-        value=_vtk.VTK_QUADRATIC_HEXAHEDRON,
-        cell_class=_vtk.vtkQuadraticHexahedron,
-        example='QuadraticHexahedron',
-        short_doc="""
-        Represents a 3D, 20-node iso-parametric parabolic hexahedron.
-
-        The cell includes a mid-edge node.
-        """,
-        long_doc="""
-        The ordering of the twenty points defining the cell is point ids
-        ``(0-7, 8-19)`` where:
-
-        - ids ``(0-7)`` are the eight corner vertices of the cube.
-        - ids ``(8-19)`` are the twelve mid-edge nodes.
-
-        The mid-edge nodes lie on the edges defined by ``(0,1)``, ``(1,2)``, ``(2,3)``,
-        ``(3,0)``, ``(4,5)``, ``(5,6)``, ``(6,7)``, ``(7,4)``, ``(0,4)``, ``(1,5)``,
-        ``(2,6)``, ``(3,7)``.
-        """,
-    )
-    QUADRATIC_WEDGE = _CellTypeTuple(
-        value=_vtk.VTK_QUADRATIC_WEDGE,
-        cell_class=_vtk.vtkQuadraticWedge,
-        example='QuadraticWedge',
-        short_doc="""
-        Represents a 3D, 15-node iso-parametric parabolic wedge.
-
-        The cell includes a mid-edge node.
-        """,
-        long_doc="""
-        The ordering of the fifteen points defining the cell is point ids
-        ``(0-5, 6-14)`` where:
-
-        - ids ``(0-5)`` are the six corner vertices of the wedge, defined analogously to
-          the six points in ``WEDGE`` (points ``(0,1,2)`` form the base of the wedge
-          which, using the right hand rule, forms a triangle whose normal points
-          away from the triangular face ``(3,4,5)``).
-        - ids ``(6-14)`` are the nine mid-edge nodes.
-
-        The mid-edge nodes lie on the edges defined by ``(0,1)``, ``(1,2)``, ``(2,0)``,
-        ``(3,4)``, ``(4,5)``, ``(5,3)``, ``(0,3)``, ``(1,4)``, ``(2,5)``.
-        """,
-    )
-    QUADRATIC_PYRAMID = _CellTypeTuple(
-        value=_vtk.VTK_QUADRATIC_PYRAMID,
-        cell_class=_vtk.vtkQuadraticPyramid,
-        example='QuadraticPyramid',
-        short_doc="""
-        Represents a 3D, 13-node iso-parametric parabolic pyramid.
-
-        The cell includes a mid-edge node.
-        """,
-        long_doc="""
-        The ordering of the thirteen points defining the cell is point ids
-        ``(0-4, 5-12)`` where:
-
-        - ids ``(0-4)`` are the five corner vertices of the pyramid
-        - ids ``(5-12)`` are the eight mid-edge nodes.
-
-        The mid-edge nodes lie on the edges defined by ``(0,1)``, ``(1,2)``, ``(2,3)``,
-        ``(3,0)``, ``(0,4)``, ``(1,4)``, ``(2,4)``, ``(3,4)``, respectively.
-        The parametric location of vertex ``(4)`` is ``[0, 0, 1]``.
-        """,
-    )
-    BIQUADRATIC_QUAD = _CellTypeTuple(
-        value=_vtk.VTK_BIQUADRATIC_QUAD,
-        cell_class=_vtk.vtkBiQuadraticQuad,
-        example='BiQuadraticQuadrilateral',
-        short_doc="""
-        Represents a 2D, 9-node iso-parametric parabolic quadrilateral element with a center-point.
-
-        The cell includes a mid-edge node for each of the four edges of the cell and
-        a center node at the surface.
-        """,
-        long_doc="""
-        The ordering of the eight points defining the cell are point ids
-        ``(0-3, 4-8)`` where:
-
-        - ids ``(0-3)`` define the four corner vertices of the quad.
-        - ids ``(4-7)`` define the mid-edge nodes ``(0,1)``, ``(1,2)``, ``(2,3)``, ``(3,0)``.
-        - id ``(8)`` defines the face center node.
-
-        """,
-    )
-    TRIQUADRATIC_HEXAHEDRON = _CellTypeTuple(
-        value=_vtk.VTK_TRIQUADRATIC_HEXAHEDRON,
-        cell_class=_vtk.vtkTriQuadraticHexahedron,
-        example='TriQuadraticHexahedron',
-        short_doc="""
-        Represents a 3D, 27-node iso-parametric triquadratic hexahedron.
-
-        The cell includes 8 edge nodes, 12 mid-edge nodes, 6 mid-face nodes and one
-        mid-volume node.
-        """,
-        long_doc="""
-        The ordering of the 27 points defining the cell is point ids
-        ``(0-7, 8-19, 20-25, 26)`` where:
-
-        - ids ``(0-7)`` are the eight corner vertices of the cube.
-        - ids ``(8-19)`` are the twelve mid-edge nodes.
-        - ids ``(20-25)`` are the six mid-face nodes.
-        - id ``(26)`` is the mid-volume node.
-
-        The mid-edge nodes lie on the edges defined by ``(0,1)``, ``(1,2)``, ``(2,3)``,
-        ``(3,0)``, ``(4,5)``, ``(5,6)``, ``(6,7)``, ``(7,4)``, ``(0,4)``, ``(1,5)``,
-        ``(2,6)``, ``(3,7)``.
-
-        The mid-surface nodes lies on the faces defined by (first edge nodes
-        ids, then mid-edge nodes ids):
-
-        - ``(0,1,5,4; 8,17,12,16)``
-        - ``(1,2,6,5; 9,18,13,17)``
-        - ``(2,3,7,6, 10,19,14,18)``
-        - ``(3,0,4,7; 11,16,15,19)``
-        - ``(0,1,2,3; 8,9,10,11)``
-        - ``(4,5,6,7; 12,13,14,15)``
-
-        The last point lies in the center of the cell ``(0,1,2,3,4,5,6,7)``.
-        """,
-    )
+    QUADRATIC_EDGE = _CELL_TYPE_INFO['QUADRATIC_EDGE']
+    QUADRATIC_TRIANGLE = _CELL_TYPE_INFO['QUADRATIC_TRIANGLE']
+    QUADRATIC_QUAD = _CELL_TYPE_INFO['QUADRATIC_QUAD']
+    QUADRATIC_POLYGON = _CELL_TYPE_INFO['QUADRATIC_POLYGON']
+    QUADRATIC_TETRA = _CELL_TYPE_INFO['QUADRATIC_TETRA']
+    QUADRATIC_HEXAHEDRON = _CELL_TYPE_INFO['QUADRATIC_HEXAHEDRON']
+    QUADRATIC_WEDGE = _CELL_TYPE_INFO['QUADRATIC_WEDGE']
+    QUADRATIC_PYRAMID = _CELL_TYPE_INFO['QUADRATIC_PYRAMID']
+    BIQUADRATIC_QUAD = _CELL_TYPE_INFO['BIQUADRATIC_QUAD']
+    TRIQUADRATIC_HEXAHEDRON = _CELL_TYPE_INFO['TRIQUADRATIC_HEXAHEDRON']
     if hasattr(_vtk, 'VTK_TRIQUADRATIC_PYRAMID'):
-        TRIQUADRATIC_PYRAMID = _CellTypeTuple(
-            value=_vtk.VTK_TRIQUADRATIC_PYRAMID,
-            cell_class=_vtk.vtkTriQuadraticPyramid,
-            example='TriQuadraticPyramid',
-            short_doc="""
-            Represents a second order 3D iso-parametric 19-node pyramid.
-
-            The cell includes 5 corner nodes, 8 mid-edge nodes, 5 mid-face nodes,
-            and 1 volumetric centroid node.
-            """,
-            long_doc="""
-            The ordering of the nineteen points defining the cell is point
-            ids ``(0-4, 5-12, 13-17, 18)``, where:
-
-            - ids ``(0-4)`` are the five corner vertices of the pyramid.
-            - ids ``(5-12)`` are the 8 mid-edge nodes.
-            - ids ``(13-17)`` are the 5 mid-face nodes.
-            - id ``(19)`` is the volumetric centroid node.
-
-            The mid-edge nodes lie on the edges defined by ``(0, 1)``, ``(1, 2)``,
-            ``(2, 3)``, ``(3, 0)``, ``(0, 4)``, ``(1, 4)``, ``(2, 4)``, ``(3, 4)``,
-            respectively.
-
-            The mid-face nodes lie on the faces defined by (first corner nodes ids,
-            then mid-edge node ids):
-
-            - quadrilateral face: ``(0,3,2,1; 8,7,6,5)``
-            - triangle face 1: ``(0,1,4; 5,10,9)``
-            - triangle face 2: ``(1,2,4; 6,11,10)``
-            - triangle face 3: ``(2,3,4; 7,12,11)``
-            - triangle face 5: ``(3,0,4; 8,9,12)``
-
-            The last point lies in the center of the cell ``(0,1,2,3,4)``.
-            The parametric location of vertex ``(4)`` is ``[0.5, 0.5, 1]``.
-            """,
-        )
-    QUADRATIC_LINEAR_QUAD = _CellTypeTuple(
-        value=_vtk.VTK_QUADRATIC_LINEAR_QUAD,
-        cell_class=_vtk.vtkQuadraticLinearQuad,
-        example='QuadraticLinearQuadrilateral',
-        short_doc="""
-        Represents a 2D, 6-node iso-parametric quadratic-linear quadrilateral element.
-
-        The cell includes a mid-edge node for two of the four edges.
-        """,
-        long_doc="""
-        The ordering of the six points defining the cell are point ids
-        ``(0-3, 4-5)`` where:
-
-        - ids ``(0-3)`` define the four corner vertices of the quad.
-        - ids ``(4-7)`` define the mid-edge nodes ``(0,1)`` and ``(2,3)``.
-
-        """,
-    )
-    QUADRATIC_LINEAR_WEDGE = _CellTypeTuple(
-        value=_vtk.VTK_QUADRATIC_LINEAR_WEDGE,
-        cell_class=_vtk.vtkQuadraticLinearWedge,
-        example='QuadraticLinearWedge',
-        short_doc="""
-        Represents a 3D, 12-node iso-parametric linear quadratic wedge.
-
-        The cell includes mid-edge node in the triangle edges.
-        """,
-        long_doc="""
-        The ordering of the 12 points defining the cell is point ids
-        ``(0-5, 6-12)`` where:
-
-        - ids ``(0-5`` are the six corner vertices of the wedge.
-        - ids ``(6-12)`` are the six mid-edge nodes.
-
-        The mid-edge nodes lie on the edges defined by ``(0,1)``, ``(1,2)``, ``(2,0)``,
-        ``(3,4)``, ``(4,5)``, ``(5,3)``.
-        The edges ``(0,3)``, ``(1,4)``, ``(2,5)`` don't have mid-edge nodes.
-        """,
-    )
-    BIQUADRATIC_QUADRATIC_WEDGE = _CellTypeTuple(
-        value=_vtk.VTK_BIQUADRATIC_QUADRATIC_WEDGE,
-        cell_class=_vtk.vtkBiQuadraticQuadraticWedge,
-        example='BiQuadraticQuadraticWedge',
-        short_doc="""
-        Represents a 3D, 18-node iso-parametric bi-quadratic wedge.
-
-        The cell includes a mid-edge node.
-        """,
-        long_doc="""
-        The ordering of the 18 points defining the cell is point ids
-        ``(0-5, 6-15, 16-18)`` where:
-
-        - ids ``(0-5)`` are the six corner vertices of the wedge.
-        - ids ``(6-15)`` are the nine mid-edge nodes.
-        - ids ``(16-18)`` are the three center-face nodes.
-
-        The mid-edge nodes lie on the edges defined by ``(0,1)``, ``(1,2)``, ``(2,0)``,
-        ``(3,4)``, ``(4,5)``, ``(5,3)``, ``(0,3)``, ``(1,4)``, ``(2,5)``.
-
-        The center-face nodes are lie in quads ``16-(0,1,4,3)``, ``17-(1,2,5,4)`` and
-        ``18-(2,0,3,5)``.
-        """,
-    )
-    BIQUADRATIC_QUADRATIC_HEXAHEDRON = _CellTypeTuple(
-        value=_vtk.VTK_BIQUADRATIC_QUADRATIC_HEXAHEDRON,
-        cell_class=_vtk.vtkBiQuadraticQuadraticHexahedron,
-        example='BiQuadraticQuadraticHexahedron',
-        short_doc="""
-        Represents a 3D, 24-node iso-parametric biquadratic hexahedron.
-
-        The cell includes mid-edge and center-face nodes.
-        """,
-        long_doc="""
-        The ordering of the 24 points defining the cell is point ids
-        ``(0-7, 8-19, 20-23)`` where:
-
-        - ids ``(0-7)`` are the eight corner vertices of the cube.
-        - ids ``(8-19)`` are the twelve mid-edge nodes.
-        - ids ``(20-23)`` are the center-face nodes.
-
-        The mid-edge nodes lie on the edges defined by ``(0,1)``, ``(1,2)``, ``(2,3)``,
-        ``(3,0)``, ``(4,5)``, ``(5,6)``, ``(6,7)``, ``(7,4)``, ``(0,4)``, ``(1,5)``,
-        ``(2,6)``, ``(3,7)``.
-
-        The center face nodes lie in quads ``22-(0,1,5,4)``, ``21-(1,2,6,5)``,
-        ``23-(2,3,7,6)`` and ``22-(3,0,4,7)``.
-        """,
-    )
-    BIQUADRATIC_TRIANGLE = _CellTypeTuple(
-        value=_vtk.VTK_BIQUADRATIC_TRIANGLE,
-        cell_class=_vtk.vtkBiQuadraticTriangle,
-        example='BiQuadraticTriangle',
-        short_doc="""
-        Represents a 2D, 7-node, iso-parametric parabolic triangle.
-
-        The cell includes three mid-edge nodes besides the three triangle vertices
-        and a center node.
-        """,
-        long_doc="""
-        The ordering of the three points defining the cell is point ids
-        ``(0-2, 3-6)`` where:
-
-        - id ``(3)`` is the mid-edge node between points ``(0,1)``.
-        - id ``(4)`` is the mid-edge node between points ``(1,2)``.
-        - id ``(5)`` is the mid-edge node between points ``(2,0)``.
-        - id ``(6)`` is the center node of the cell.
-
-        """,
-    )
+        TRIQUADRATIC_PYRAMID = _CELL_TYPE_INFO['TRIQUADRATIC_PYRAMID']
+    QUADRATIC_LINEAR_QUAD = _CELL_TYPE_INFO['QUADRATIC_LINEAR_QUAD']
+    QUADRATIC_LINEAR_WEDGE = _CELL_TYPE_INFO['QUADRATIC_LINEAR_WEDGE']
+    BIQUADRATIC_QUADRATIC_WEDGE = _CELL_TYPE_INFO['BIQUADRATIC_QUADRATIC_WEDGE']
+    BIQUADRATIC_QUADRATIC_HEXAHEDRON = _CELL_TYPE_INFO['BIQUADRATIC_QUADRATIC_HEXAHEDRON']
+    BIQUADRATIC_TRIANGLE = _CELL_TYPE_INFO['BIQUADRATIC_TRIANGLE']
 
     ####################################################################################
     # Cubic, iso-parametric cell
-    CUBIC_LINE = _CellTypeTuple(
-        value=_vtk.VTK_CUBIC_LINE,
-        cell_class=_vtk.vtkCubicLine,
-        example='CubicLine',
-        short_doc="""
-        Represents a 1D iso-parametric cubic line.
-
-        The cell includes two mid-edge nodes.
-        """,
-        long_doc="""
-        The ordering of the four points defining the cell is point ids ``(0,1,2,3)``
-        where id #2 and #3 are the mid-edge nodes.
-
-        The parametric coordinates lie between -1 and 1.
-        """,
-    )
+    CUBIC_LINE = _CELL_TYPE_INFO['CUBIC_LINE']
 
     ####################################################################################
     # Special class of cells formed by convex group of points
-    CONVEX_POINT_SET = _CellTypeTuple(
-        value=_vtk.VTK_CONVEX_POINT_SET,
-        cell_class=_vtk.vtkConvexPointSet,
-        points_override='variable',
-    )
+    CONVEX_POINT_SET = _CELL_TYPE_INFO['CONVEX_POINT_SET']
 
     ####################################################################################
     # Polyhedron cell (consisting of polygonal faces)
-    POLYHEDRON = _CellTypeTuple(
-        value=_vtk.VTK_POLYHEDRON,
-        cell_class=_vtk.vtkPolyhedron,
-        example='Polyhedron',
-        short_doc="""
-        Represents a 3D cell defined by a set of polygonal faces.
-
-        """,
-        long_doc="""
-        Polyhedrons must:
-
-        - be watertight: the faces describing the polyhedron should define
-          an enclosed volume with a clear “inside” and “outside”
-        - have planar faces: all points defining a face should be in the
-          same 2D plane
-        - not be self-intersecting: for example, a face of the polyhedron
-          can't intersect other ones
-        - not contain zero-thickness portions: adjacent faces should not
-          overlap each other even partially
-        - not contain disconnected elements: detached vertice(s), edge(s) or face(s)
-        - be simply connected: vtkPolyhedron must describe a single polyhedron
-        - not contain duplicate elements: each point index and each face
-          description should be unique
-        - not contain “internal” or “external” faces: for each face,
-          one side should be “inside” the cell, the other side “outside”
-
-        """,
-        points_override='variable',
-        edges_override='variable',
-        faces_override='variable',
-    )
+    POLYHEDRON = _CELL_TYPE_INFO['POLYHEDRON']
 
     ####################################################################################
     # Higher order cells in parametric form
-    PARAMETRIC_CURVE = _CellTypeTuple(value=_vtk.VTK_PARAMETRIC_CURVE)
-    PARAMETRIC_SURFACE = _CellTypeTuple(value=_vtk.VTK_PARAMETRIC_SURFACE)
-    PARAMETRIC_TRI_SURFACE = _CellTypeTuple(value=_vtk.VTK_PARAMETRIC_TRI_SURFACE)
-    PARAMETRIC_QUAD_SURFACE = _CellTypeTuple(value=_vtk.VTK_PARAMETRIC_QUAD_SURFACE)
-    PARAMETRIC_TETRA_REGION = _CellTypeTuple(value=_vtk.VTK_PARAMETRIC_TETRA_REGION)
-    PARAMETRIC_HEX_REGION = _CellTypeTuple(value=_vtk.VTK_PARAMETRIC_HEX_REGION)
+    PARAMETRIC_CURVE = _CELL_TYPE_INFO['PARAMETRIC_CURVE']
+    PARAMETRIC_SURFACE = _CELL_TYPE_INFO['PARAMETRIC_SURFACE']
+    PARAMETRIC_TRI_SURFACE = _CELL_TYPE_INFO['PARAMETRIC_TRI_SURFACE']
+    PARAMETRIC_QUAD_SURFACE = _CELL_TYPE_INFO['PARAMETRIC_QUAD_SURFACE']
+    PARAMETRIC_TETRA_REGION = _CELL_TYPE_INFO['PARAMETRIC_TETRA_REGION']
+    PARAMETRIC_HEX_REGION = _CELL_TYPE_INFO['PARAMETRIC_HEX_REGION']
 
     ####################################################################################
     # Higher order cells
-    HIGHER_ORDER_EDGE = _CellTypeTuple(value=_vtk.VTK_HIGHER_ORDER_EDGE)
-    HIGHER_ORDER_TRIANGLE = _CellTypeTuple(value=_vtk.VTK_HIGHER_ORDER_TRIANGLE)
-    HIGHER_ORDER_QUAD = _CellTypeTuple(value=_vtk.VTK_HIGHER_ORDER_QUAD)
-    HIGHER_ORDER_POLYGON = _CellTypeTuple(value=_vtk.VTK_HIGHER_ORDER_POLYGON)
-    HIGHER_ORDER_TETRAHEDRON = _CellTypeTuple(value=_vtk.VTK_HIGHER_ORDER_TETRAHEDRON)
-    HIGHER_ORDER_WEDGE = _CellTypeTuple(value=_vtk.VTK_HIGHER_ORDER_WEDGE)
-    HIGHER_ORDER_PYRAMID = _CellTypeTuple(value=_vtk.VTK_HIGHER_ORDER_PYRAMID)
-    HIGHER_ORDER_HEXAHEDRON = _CellTypeTuple(value=_vtk.VTK_HIGHER_ORDER_HEXAHEDRON)
+    HIGHER_ORDER_EDGE = _CELL_TYPE_INFO['HIGHER_ORDER_EDGE']
+    HIGHER_ORDER_TRIANGLE = _CELL_TYPE_INFO['HIGHER_ORDER_TRIANGLE']
+    HIGHER_ORDER_QUAD = _CELL_TYPE_INFO['HIGHER_ORDER_QUAD']
+    HIGHER_ORDER_POLYGON = _CELL_TYPE_INFO['HIGHER_ORDER_POLYGON']
+    HIGHER_ORDER_TETRAHEDRON = _CELL_TYPE_INFO['HIGHER_ORDER_TETRAHEDRON']
+    HIGHER_ORDER_WEDGE = _CELL_TYPE_INFO['HIGHER_ORDER_WEDGE']
+    HIGHER_ORDER_PYRAMID = _CELL_TYPE_INFO['HIGHER_ORDER_PYRAMID']
+    HIGHER_ORDER_HEXAHEDRON = _CELL_TYPE_INFO['HIGHER_ORDER_HEXAHEDRON']
 
     ####################################################################################
     # Arbitrary order Lagrange elements (formulated separated from generic higher order cells)
-    LAGRANGE_CURVE = _CellTypeTuple(value=_vtk.VTK_LAGRANGE_CURVE)
-    LAGRANGE_TRIANGLE = _CellTypeTuple(value=_vtk.VTK_LAGRANGE_TRIANGLE)
-    LAGRANGE_QUADRILATERAL = _CellTypeTuple(value=_vtk.VTK_LAGRANGE_QUADRILATERAL)
-    LAGRANGE_TETRAHEDRON = _CellTypeTuple(value=_vtk.VTK_LAGRANGE_TETRAHEDRON)
-    LAGRANGE_HEXAHEDRON = _CellTypeTuple(value=_vtk.VTK_LAGRANGE_HEXAHEDRON)
-    LAGRANGE_WEDGE = _CellTypeTuple(value=_vtk.VTK_LAGRANGE_WEDGE)
-    LAGRANGE_PYRAMID = _CellTypeTuple(value=_vtk.VTK_LAGRANGE_PYRAMID)
+    LAGRANGE_CURVE = _CELL_TYPE_INFO['LAGRANGE_CURVE']
+    LAGRANGE_TRIANGLE = _CELL_TYPE_INFO['LAGRANGE_TRIANGLE']
+    LAGRANGE_QUADRILATERAL = _CELL_TYPE_INFO['LAGRANGE_QUADRILATERAL']
+    LAGRANGE_TETRAHEDRON = _CELL_TYPE_INFO['LAGRANGE_TETRAHEDRON']
+    LAGRANGE_HEXAHEDRON = _CELL_TYPE_INFO['LAGRANGE_HEXAHEDRON']
+    LAGRANGE_WEDGE = _CELL_TYPE_INFO['LAGRANGE_WEDGE']
+    LAGRANGE_PYRAMID = _CELL_TYPE_INFO['LAGRANGE_PYRAMID']
 
     ####################################################################################
     # Arbitrary order Bezier elements (formulated separated from generic higher order cells)
-    BEZIER_CURVE = _CellTypeTuple(value=_vtk.VTK_BEZIER_CURVE)
-    BEZIER_TRIANGLE = _CellTypeTuple(value=_vtk.VTK_BEZIER_TRIANGLE)
-    BEZIER_QUADRILATERAL = _CellTypeTuple(value=_vtk.VTK_BEZIER_QUADRILATERAL)
-    BEZIER_TETRAHEDRON = _CellTypeTuple(value=_vtk.VTK_BEZIER_TETRAHEDRON)
-    BEZIER_HEXAHEDRON = _CellTypeTuple(value=_vtk.VTK_BEZIER_HEXAHEDRON)
-    BEZIER_WEDGE = _CellTypeTuple(value=_vtk.VTK_BEZIER_WEDGE)
-    BEZIER_PYRAMID = _CellTypeTuple(value=_vtk.VTK_BEZIER_PYRAMID)
+    BEZIER_CURVE = _CELL_TYPE_INFO['BEZIER_CURVE']
+    BEZIER_TRIANGLE = _CELL_TYPE_INFO['BEZIER_TRIANGLE']
+    BEZIER_QUADRILATERAL = _CELL_TYPE_INFO['BEZIER_QUADRILATERAL']
+    BEZIER_TETRAHEDRON = _CELL_TYPE_INFO['BEZIER_TETRAHEDRON']
+    BEZIER_HEXAHEDRON = _CELL_TYPE_INFO['BEZIER_HEXAHEDRON']
+    BEZIER_WEDGE = _CELL_TYPE_INFO['BEZIER_WEDGE']
+    BEZIER_PYRAMID = _CELL_TYPE_INFO['BEZIER_PYRAMID']

--- a/pyvista/core/utilities/__init__.py
+++ b/pyvista/core/utilities/__init__.py
@@ -113,6 +113,7 @@ from .image_sources import ImageSinusoidSource as ImageSinusoidSource
 with contextlib.suppress(ImportError):
     from .geometric_sources import CapsuleSource as CapsuleSource
 
+from .cell_quality import cell_quality_info as cell_quality_info
 from .helpers import axis_rotation as axis_rotation
 from .helpers import generate_plane as generate_plane
 from .helpers import is_inside_bounds as is_inside_bounds

--- a/pyvista/core/utilities/cell_quality.py
+++ b/pyvista/core/utilities/cell_quality.py
@@ -1,0 +1,141 @@
+"""Information about cell quality measures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from pyvista import CellType
+
+
+@dataclass
+class CellQualityInfo:
+    """Information about a cell's quality measure."""
+
+    cell_type: CellType
+    name: str
+    acceptable_range: tuple[float, float] | None
+    normal_range: tuple[float, float]
+    full_range: tuple[float, float]
+    unit_cell_value: float | None
+
+
+def sqrt(num: float) -> float:  # noqa: D103
+    return num**0.5
+
+
+INF = float('inf')
+TET_ANGLE = (180 / np.pi) * np.arccos(1 / 3)
+R22 = sqrt(2) / 2
+R33 = sqrt(3) / 3
+
+_INFO = [
+    CellQualityInfo(CellType.TRIANGLE, 'area', (0, INF), (0, INF), (0, INF), sqrt(3) / 4),
+    CellQualityInfo(CellType.TRIANGLE, 'aspect_ratio', (1, 1.3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.TRIANGLE, 'aspect_frobenius', (1, 1.3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.TRIANGLE, 'condition', (1, 1.3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.TRIANGLE, 'distortion', (0.5, 1), (0, 1), (-INF, INF), 1),
+    CellQualityInfo(CellType.TRIANGLE, 'edge_ratio', (1, 1.3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.TRIANGLE, 'maximum_angle', (60, 90), (60, 180), (0, 180), 60),
+    CellQualityInfo(CellType.TRIANGLE, 'minimum_angle', (30, 60), (0, 60), (0, 360), 60),
+    CellQualityInfo(
+        CellType.TRIANGLE, 'scaled_jacobian', (0.5, 2 * R33), (-2 * R33, 2 * R33), (-INF, INF), 1
+    ),
+    CellQualityInfo(CellType.TRIANGLE, 'radius_ratio', (1, 3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.TRIANGLE, 'shape', (0.25, 1), (0, 1), (0, 1), None),
+    CellQualityInfo(CellType.TRIANGLE, 'shape_and_size', (0.25, 1), (0, 1), (0, 1), None),
+    CellQualityInfo(CellType.QUAD, 'area', (0, INF), (0, INF), (-INF, INF), 1),
+    CellQualityInfo(CellType.QUAD, 'aspect_ratio', (1, 1.3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.QUAD, 'condition', (1, 4), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.QUAD, 'distortion', (0.5, 1), (0, 1), (-INF, INF), 1),
+    CellQualityInfo(CellType.QUAD, 'edge_ratio', (1, 1.3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.QUAD, 'jacobian', (0, INF), (0, INF), (-INF, INF), 1),
+    CellQualityInfo(CellType.QUAD, 'maximum_aspect_frobenius', (1, 1.3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.QUAD, 'maximum_angle', (90, 135), (90, 360), (0, 360), 90),
+    CellQualityInfo(CellType.QUAD, 'maximum_edge_ratio', (1, 1.3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.QUAD, 'mean_aspect_frobenius', (1, 1.3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.QUAD, 'minimum_angle', (45, 90), (0, 90), (0, 360), 90),
+    CellQualityInfo(CellType.QUAD, 'oddy', (0, 0.5), (0, INF), (0, INF), 0),
+    CellQualityInfo(CellType.QUAD, 'radius_ratio', (1, 1.3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.QUAD, 'relative_size_squared', (0.3, 1), (0, 1), (0, 1), None),
+    CellQualityInfo(CellType.QUAD, 'scaled_jacobian', (0.3, 1), (-1, 1), (-1, 1), 1),
+    CellQualityInfo(CellType.QUAD, 'shape', (0.3, 1), (0, 1), (0, 1), 1),
+    CellQualityInfo(CellType.QUAD, 'shape_and_size', (0.2, 1), (0, 1), (0, 1), None),
+    CellQualityInfo(CellType.QUAD, 'shear', (0.3, 1), (0, 1), (0, 1), 1),
+    CellQualityInfo(CellType.QUAD, 'shear_and_size', (0.2, 1), (0, 1), (0, 1), None),
+    CellQualityInfo(CellType.QUAD, 'skew', (0.5, 1), (0, 1), (0, 1), 1),
+    CellQualityInfo(CellType.QUAD, 'stretch', (0.25, 1), (0, 1), (0, INF), 1),
+    CellQualityInfo(CellType.QUAD, 'taper', (0, 0.7), (0, INF), (0, INF), 0),
+    CellQualityInfo(CellType.QUAD, 'warpage', (0, 0.7), (0, 2), (0, INF), 0),
+    CellQualityInfo(CellType.TETRA, 'edge_ratio', (1, 3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.TETRA, 'aspect_beta', (1, 3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.TETRA, 'aspect_delta', (0.1, INF), (0, INF), (0, INF), 1),
+    CellQualityInfo(CellType.TETRA, 'aspect_frobenius', (1, 1.3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.TETRA, 'aspect_gamma', (1, 3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.TETRA, 'aspect_ratio', (1, 3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.TETRA, 'collapse_ratio', (0.1, INF), (0, INF), (0, INF), sqrt(6) / 3),
+    CellQualityInfo(CellType.TETRA, 'condition', (1, 3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.TETRA, 'distortion', (0.5, 1), (0, 1), (-INF, INF), 0),
+    CellQualityInfo(CellType.TETRA, 'jacobian', (0, INF), (0, INF), (-INF, INF), sqrt(2) / 2),
+    CellQualityInfo(
+        CellType.TETRA,
+        'minimum_dihedral_angle',
+        (40, TET_ANGLE),
+        (0, TET_ANGLE),
+        (0, 360),
+        TET_ANGLE,
+    ),
+    CellQualityInfo(CellType.TETRA, 'radius_ratio', (1, 3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.TETRA, 'relative_size_squared', (0.3, 1), (0, 1), (0, 1), None),
+    CellQualityInfo(CellType.TETRA, 'scaled_jacobian', (0.5, R22), (-R22, R22), (-INF, INF), 1),
+    CellQualityInfo(CellType.TETRA, 'shape', (0.3, 1), (0, 1), (0, 1), 1),
+    CellQualityInfo(CellType.TETRA, 'shape_and_size', (0.2, 1), (0, 1), (0, 1), None),
+    CellQualityInfo(CellType.TETRA, 'volume', (0, INF), (-INF, INF), (-INF, INF), sqrt(2) / 12),
+    CellQualityInfo(CellType.HEXAHEDRON, 'diagonal', (0.65, 1), (0, 1), (1, INF), 1),
+    CellQualityInfo(CellType.HEXAHEDRON, 'dimension', None, (0, INF), (0, INF), 1),
+    CellQualityInfo(CellType.HEXAHEDRON, 'distortion', (0.5, 1), (0, 1), (-INF, INF), 1),
+    CellQualityInfo(CellType.HEXAHEDRON, 'edge_ratio', None, (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.HEXAHEDRON, 'jacobian', (0, INF), (0, INF), (-INF, INF), 1),
+    CellQualityInfo(CellType.HEXAHEDRON, 'maximum_edge_ratio', (1, 1.3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.HEXAHEDRON, 'maximum_aspect_frobenius', (1, 3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.HEXAHEDRON, 'mean_aspect_frobenius', (1, 3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.HEXAHEDRON, 'oddy', (0, 0.5), (0, INF), (0, INF), 0),
+    CellQualityInfo(CellType.HEXAHEDRON, 'relative_size_squared', (0.5, 1), (0, 1), (0, 1), None),
+    CellQualityInfo(CellType.HEXAHEDRON, 'scaled_jacobian', (0.5, 1), (-1, 1), (-1, INF), 1),
+    CellQualityInfo(CellType.HEXAHEDRON, 'shape', (0.3, 1), (0, 1), (0, 1), 1),
+    CellQualityInfo(CellType.HEXAHEDRON, 'shape_and_size', (0.2, 1), (0, 1), (0, 1), None),
+    CellQualityInfo(CellType.HEXAHEDRON, 'shear', (0.3, 1), (0, 1), (0, 1), 1),
+    CellQualityInfo(CellType.HEXAHEDRON, 'shear_and_size', (0.2, 1), (0, 1), (0, 1), None),
+    CellQualityInfo(CellType.HEXAHEDRON, 'skew', (0, 0.5), (0, 1), (0, INF), 0),
+    CellQualityInfo(CellType.HEXAHEDRON, 'stretch', (0.25, 1), (0, 1), (0, INF), 1),
+    CellQualityInfo(CellType.HEXAHEDRON, 'taper', (0, 0.5), (0, INF), (0, INF), 0),
+    CellQualityInfo(CellType.HEXAHEDRON, 'volume', (0, INF), (0, INF), (-INF, INF), 2),
+    CellQualityInfo(CellType.PYRAMID, 'volume', (0, INF), (-INF, INF), (-INF, INF), sqrt(2) / 6),
+    CellQualityInfo(CellType.WEDGE, 'volume', (0, INF), (-INF, INF), (-INF, INF), sqrt(3) / 4),
+]
+
+_INFO_LOOKUP = {}
+for info in _INFO:
+    _INFO_LOOKUP.setdefault(info.cell_type, {})
+    _INFO_LOOKUP[info.cell_type][info.name] = info
+
+
+def cell_quality_info(cell_type: CellType, measure: str) -> CellQualityInfo:
+    """Return information about a cell's quality measure.
+
+    Parameters
+    ----------
+    cell_type : CellType
+        Cell type to get information about.
+
+    measure : str
+        Quality measure to get information about.
+
+    Returns
+    -------
+    CellQualityInfo
+        Dataclass with information about the quality measure for a specific cell type.
+
+    """
+    return _INFO_LOOKUP[cell_type][measure]

--- a/pyvista/core/utilities/cell_quality.py
+++ b/pyvista/core/utilities/cell_quality.py
@@ -3,10 +3,46 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
+from typing import get_args
 
 import numpy as np
 
-from pyvista import CellType
+from pyvista.core import _vtk_core as _vtk
+from pyvista.core.celltype import _CELL_TYPE_INFO
+from pyvista.core.celltype import CellType
+
+_CellQualityLiteral = Literal[
+    'area',
+    'aspect_frobenius',
+    'aspect_gamma',
+    'aspect_ratio',
+    'collapse_ratio',
+    'condition',
+    'diagonal',
+    'dimension',
+    'distortion',
+    'jacobian',
+    'max_angle',
+    'max_aspect_frobenius',
+    'max_edge_ratio',
+    'med_aspect_frobenius',
+    'min_angle',
+    'oddy',
+    'radius_ratio',
+    'relative_size_squared',
+    'scaled_jacobian',
+    'shape',
+    'shape_and_size',
+    'shear',
+    'shear_and_size',
+    'skew',
+    'stretch',
+    'taper',
+    'volume',
+    'warpage',
+]
+_CellQualityOptions = get_args(_CellQualityLiteral)
 
 
 @dataclass
@@ -14,7 +50,7 @@ class CellQualityInfo:
     """Information about a cell's quality measure."""
 
     cell_type: CellType
-    name: str
+    measure: str
     acceptable_range: tuple[float, float] | None
     normal_range: tuple[float, float]
     full_range: tuple[float, float]
@@ -36,9 +72,9 @@ _INFO = [
     CellQualityInfo(CellType.TRIANGLE, 'aspect_frobenius', (1, 1.3), (1, INF), (1, INF), 1),
     CellQualityInfo(CellType.TRIANGLE, 'condition', (1, 1.3), (1, INF), (1, INF), 1),
     CellQualityInfo(CellType.TRIANGLE, 'distortion', (0.5, 1), (0, 1), (-INF, INF), 1),
-    CellQualityInfo(CellType.TRIANGLE, 'edge_ratio', (1, 1.3), (1, INF), (1, INF), 1),
-    CellQualityInfo(CellType.TRIANGLE, 'maximum_angle', (60, 90), (60, 180), (0, 180), 60),
-    CellQualityInfo(CellType.TRIANGLE, 'minimum_angle', (30, 60), (0, 60), (0, 360), 60),
+    # CellQualityInfo(CellType.TRIANGLE, 'edge_ratio', (1, 1.3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.TRIANGLE, 'max_angle', (60, 90), (60, 180), (0, 180), 60),
+    CellQualityInfo(CellType.TRIANGLE, 'min_angle', (30, 60), (0, 60), (0, 360), 60),
     CellQualityInfo(
         CellType.TRIANGLE, 'scaled_jacobian', (0.5, 2 * R33), (-2 * R33, 2 * R33), (-INF, INF), 1
     ),
@@ -49,13 +85,13 @@ _INFO = [
     CellQualityInfo(CellType.QUAD, 'aspect_ratio', (1, 1.3), (1, INF), (1, INF), 1),
     CellQualityInfo(CellType.QUAD, 'condition', (1, 4), (1, INF), (1, INF), 1),
     CellQualityInfo(CellType.QUAD, 'distortion', (0.5, 1), (0, 1), (-INF, INF), 1),
-    CellQualityInfo(CellType.QUAD, 'edge_ratio', (1, 1.3), (1, INF), (1, INF), 1),
+    # CellQualityInfo(CellType.QUAD, 'edge_ratio', (1, 1.3), (1, INF), (1, INF), 1),
     CellQualityInfo(CellType.QUAD, 'jacobian', (0, INF), (0, INF), (-INF, INF), 1),
-    CellQualityInfo(CellType.QUAD, 'maximum_aspect_frobenius', (1, 1.3), (1, INF), (1, INF), 1),
-    CellQualityInfo(CellType.QUAD, 'maximum_angle', (90, 135), (90, 360), (0, 360), 90),
-    CellQualityInfo(CellType.QUAD, 'maximum_edge_ratio', (1, 1.3), (1, INF), (1, INF), 1),
-    CellQualityInfo(CellType.QUAD, 'mean_aspect_frobenius', (1, 1.3), (1, INF), (1, INF), 1),
-    CellQualityInfo(CellType.QUAD, 'minimum_angle', (45, 90), (0, 90), (0, 360), 90),
+    CellQualityInfo(CellType.QUAD, 'max_aspect_frobenius', (1, 1.3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.QUAD, 'max_angle', (90, 135), (90, 360), (0, 360), 90),
+    CellQualityInfo(CellType.QUAD, 'max_edge_ratio', (1, 1.3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.QUAD, 'med_aspect_frobenius', (1, 1.3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.QUAD, 'min_angle', (45, 90), (0, 90), (0, 360), 90),
     CellQualityInfo(CellType.QUAD, 'oddy', (0, 0.5), (0, INF), (0, INF), 0),
     CellQualityInfo(CellType.QUAD, 'radius_ratio', (1, 1.3), (1, INF), (1, INF), 1),
     CellQualityInfo(CellType.QUAD, 'relative_size_squared', (0.3, 1), (0, 1), (0, 1), None),
@@ -68,19 +104,19 @@ _INFO = [
     CellQualityInfo(CellType.QUAD, 'stretch', (0.25, 1), (0, 1), (0, INF), 1),
     CellQualityInfo(CellType.QUAD, 'taper', (0, 0.7), (0, INF), (0, INF), 0),
     CellQualityInfo(CellType.QUAD, 'warpage', (0, 0.7), (0, 2), (0, INF), 0),
-    CellQualityInfo(CellType.TETRA, 'edge_ratio', (1, 3), (1, INF), (1, INF), 1),
-    CellQualityInfo(CellType.TETRA, 'aspect_beta', (1, 3), (1, INF), (1, INF), 1),
-    CellQualityInfo(CellType.TETRA, 'aspect_delta', (0.1, INF), (0, INF), (0, INF), 1),
+    # CellQualityInfo(CellType.TETRA, 'edge_ratio', (1, 3), (1, INF), (1, INF), 1),
+    # CellQualityInfo(CellType.TETRA, 'aspect_beta', (1, 3), (1, INF), (1, INF), 1),
+    # CellQualityInfo(CellType.TETRA, 'aspect_delta', (0.1, INF), (0, INF), (0, INF), 1),
     CellQualityInfo(CellType.TETRA, 'aspect_frobenius', (1, 1.3), (1, INF), (1, INF), 1),
     CellQualityInfo(CellType.TETRA, 'aspect_gamma', (1, 3), (1, INF), (1, INF), 1),
     CellQualityInfo(CellType.TETRA, 'aspect_ratio', (1, 3), (1, INF), (1, INF), 1),
     CellQualityInfo(CellType.TETRA, 'collapse_ratio', (0.1, INF), (0, INF), (0, INF), sqrt(6) / 3),
-    CellQualityInfo(CellType.TETRA, 'condition', (1, 3), (1, INF), (1, INF), 1),
+    # CellQualityInfo(CellType.TETRA, 'condition', (1, 3), (1, INF), (1, INF), 1),
     CellQualityInfo(CellType.TETRA, 'distortion', (0.5, 1), (0, 1), (-INF, INF), 0),
     CellQualityInfo(CellType.TETRA, 'jacobian', (0, INF), (0, INF), (-INF, INF), sqrt(2) / 2),
     CellQualityInfo(
         CellType.TETRA,
-        'minimum_dihedral_angle',
+        'min_angle',
         (40, TET_ANGLE),
         (0, TET_ANGLE),
         (0, 360),
@@ -88,18 +124,18 @@ _INFO = [
     ),
     CellQualityInfo(CellType.TETRA, 'radius_ratio', (1, 3), (1, INF), (1, INF), 1),
     CellQualityInfo(CellType.TETRA, 'relative_size_squared', (0.3, 1), (0, 1), (0, 1), None),
-    CellQualityInfo(CellType.TETRA, 'scaled_jacobian', (0.5, R22), (-R22, R22), (-INF, INF), 1),
+    # CellQualityInfo(CellType.TETRA, 'scaled_jacobian', (0.5, R22), (-R22, R22), (-INF, INF), 1),
     CellQualityInfo(CellType.TETRA, 'shape', (0.3, 1), (0, 1), (0, 1), 1),
     CellQualityInfo(CellType.TETRA, 'shape_and_size', (0.2, 1), (0, 1), (0, 1), None),
     CellQualityInfo(CellType.TETRA, 'volume', (0, INF), (-INF, INF), (-INF, INF), sqrt(2) / 12),
     CellQualityInfo(CellType.HEXAHEDRON, 'diagonal', (0.65, 1), (0, 1), (1, INF), 1),
     CellQualityInfo(CellType.HEXAHEDRON, 'dimension', None, (0, INF), (0, INF), 1),
     CellQualityInfo(CellType.HEXAHEDRON, 'distortion', (0.5, 1), (0, 1), (-INF, INF), 1),
-    CellQualityInfo(CellType.HEXAHEDRON, 'edge_ratio', None, (1, INF), (1, INF), 1),
+    # CellQualityInfo(CellType.HEXAHEDRON, 'edge_ratio', None, (1, INF), (1, INF), 1),
     CellQualityInfo(CellType.HEXAHEDRON, 'jacobian', (0, INF), (0, INF), (-INF, INF), 1),
-    CellQualityInfo(CellType.HEXAHEDRON, 'maximum_edge_ratio', (1, 1.3), (1, INF), (1, INF), 1),
-    CellQualityInfo(CellType.HEXAHEDRON, 'maximum_aspect_frobenius', (1, 3), (1, INF), (1, INF), 1),
-    CellQualityInfo(CellType.HEXAHEDRON, 'mean_aspect_frobenius', (1, 3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.HEXAHEDRON, 'max_edge_ratio', (1, 1.3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.HEXAHEDRON, 'max_aspect_frobenius', (1, 3), (1, INF), (1, INF), 1),
+    CellQualityInfo(CellType.HEXAHEDRON, 'med_aspect_frobenius', (1, 3), (1, INF), (1, INF), 1),
     CellQualityInfo(CellType.HEXAHEDRON, 'oddy', (0, 0.5), (0, INF), (0, INF), 0),
     CellQualityInfo(CellType.HEXAHEDRON, 'relative_size_squared', (0.5, 1), (0, 1), (0, 1), None),
     CellQualityInfo(CellType.HEXAHEDRON, 'scaled_jacobian', (0.5, 1), (-1, 1), (-1, INF), 1),
@@ -116,9 +152,28 @@ _INFO = [
 ]
 
 _INFO_LOOKUP = {}
-for info in _INFO:
-    _INFO_LOOKUP.setdefault(info.cell_type, {})
-    _INFO_LOOKUP[info.cell_type][info.name] = info
+
+
+def _init_lookup(lookup: dict | None) -> None:
+    """Populate info lookup dict."""
+    from pyvista import examples  # Avoid circular import
+
+    for info in _INFO:
+        # Validate info by loading the cell as a mesh and computing its cell quality
+        example_name = _CELL_TYPE_INFO[info.cell_type.name].example
+        cell_mesh = getattr(examples.cells, example_name)()
+        null_value = -1
+        with _vtk.vtk_verbosity('off'):
+            qual = cell_mesh.compute_cell_quality(info.measure, null_value=null_value)
+
+        # Ensure the measure is valid for this cell type
+        assert qual.active_scalars[0] != null_value, (
+            f'Measure {info.measure!r} is not valid for cell type {info.cell_type.name!r}'
+        )
+
+        # Measure is valid, populate dict
+        lookup.setdefault(info.cell_type, {})
+        lookup[info.cell_type][info.measure] = info
 
 
 def cell_quality_info(cell_type: CellType, measure: str) -> CellQualityInfo:
@@ -138,4 +193,6 @@ def cell_quality_info(cell_type: CellType, measure: str) -> CellQualityInfo:
         Dataclass with information about the quality measure for a specific cell type.
 
     """
+    if _INFO_LOOKUP == {}:
+        _init_lookup(_INFO_LOOKUP)
     return _INFO_LOOKUP[cell_type][measure]

--- a/pyvista/core/utilities/cell_quality.py
+++ b/pyvista/core/utilities/cell_quality.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Literal
+from typing import NoReturn
 from typing import get_args
 
 import numpy as np
@@ -193,6 +194,27 @@ def cell_quality_info(cell_type: CellType, measure: str) -> CellQualityInfo:
         Dataclass with information about the quality measure for a specific cell type.
 
     """
+
+    def raise_error(item_: str, valid_options_: list[str]) -> NoReturn:
+        raise ValueError(
+            f'Cell quality info is not available for {item_}. Valid options are:\n{valid_options_}'
+        )
+
     if _INFO_LOOKUP == {}:
         _init_lookup(_INFO_LOOKUP)
-    return _INFO_LOOKUP[cell_type][measure]
+
+    # Lookup measures available for the cell type
+    try:
+        measures = _INFO_LOOKUP[cell_type]
+    except KeyError:
+        item = f'cell type {cell_type.name!r}'
+        valid_options = [typ.name for typ in _INFO_LOOKUP.keys()]
+        raise_error(item, valid_options)
+
+    # Lookup the measure info
+    try:
+        return measures[measure]
+    except KeyError:
+        item = f'{cell_type.name!r} measure {measure!r}'
+        valid_options = list(measures.keys())
+        raise_error(item, valid_options)

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -43,6 +43,7 @@ from pyvista.core.utilities.arrays import parse_field_choice
 from pyvista.core.utilities.arrays import raise_has_duplicates
 from pyvista.core.utilities.arrays import raise_not_matching
 from pyvista.core.utilities.arrays import vtk_id_list_to_array
+from pyvista.core.utilities.cell_quality import CellQualityInfo
 from pyvista.core.utilities.docs import linkcode_resolve
 from pyvista.core.utilities.features import create_grid
 from pyvista.core.utilities.features import sample_function
@@ -1997,3 +1998,28 @@ def test_vtk_verbosity_raises():
     with pytest.raises(ValueError, match=match):
         with pv.vtk_verbosity('str'):
             ...
+
+
+def test_cell_quality_info():
+    cell_type = pv.CellType.TRIANGLE
+    measure = 'area'
+    info = pv.cell_quality_info(cell_type, measure)
+    assert isinstance(info, CellQualityInfo)
+    assert info.cell_type == cell_type
+    assert info.measure == measure
+
+
+def test_cell_quality_info_raises():
+    match = re.escape(
+        "Cell quality info is not available for cell type 'QUADRATIC_EDGE'. Valid options are:\n"
+        "['TRIANGLE', 'QUAD', 'TETRA', 'HEXAHEDRON', 'PYRAMID', 'WEDGE']"
+    )
+    with pytest.raises(ValueError, match=match):
+        pv.cell_quality_info(pv.CellType.QUADRATIC_EDGE, 'area')
+
+    match = re.escape(
+        "Cell quality info is not available for 'TRIANGLE' measure 'volume'. Valid options are:\n"
+        "['area', 'aspect_ratio', 'aspect_frobenius', 'condition', 'distortion', 'max_angle', 'min_angle', 'scaled_jacobian', 'radius_ratio', 'shape', 'shape_and_size']"
+    )
+    with pytest.raises(ValueError, match=match):
+        pv.cell_quality_info(pv.CellType.TRIANGLE, 'volume')

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -23,6 +23,7 @@ import vtk
 
 import pyvista as pv
 from pyvista import examples as ex
+from pyvista.core import _vtk_core as _vtk
 from pyvista.core.utilities import cells
 from pyvista.core.utilities import fileio
 from pyvista.core.utilities import fit_line_to_points
@@ -1979,3 +1980,20 @@ def test_classproperty():
         Foo.prop()
     with pytest.raises(TypeError, match='object is not callable'):
         Foo().prop()
+
+
+# Usage examples:
+@pytest.mark.parametrize('option', [*_vtk._VerbosityOptions, _vtk.vtkLogger.VERBOSITY_OFF])
+def test_vtk_verbosity(option):
+    with pv.vtk_verbosity(option):
+        ...
+
+
+def test_vtk_verbosity_raises():
+    match = re.escape(
+        "Invalid verbosity name 'str', must be one of:\n"
+        "('invalid', 'off', 'error', 'warning', 'info', 'trace', 'max', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9')."
+    )
+    with pytest.raises(ValueError, match=match):
+        with pv.vtk_verbosity('str'):
+            ...


### PR DESCRIPTION
### Overview

The technical reference from #7309 includes information about cell quality measures. For each measure, there is info about the:

- acceptable range
- normal range
- full_range
- reference value for the unit cell

This PR extracts all of this information from https://public.kitware.com/Wiki/images/6/6b/VerdictManual-revA.pdf and stores in it `CellQualityInfo` dataclass objects. The info can then be retrieved using:

``` python
import pyvista as pv
pv.cell_quality_info(pv.CellType.TRIANGLE, 'area')
```
Output:
``` python
CellQualityInfo(
  cell_type=<CellType.TRIANGLE: 5>, 
  measure='area', 
  acceptable_range=(0, inf), 
  normal_range=(0, inf), 
  full_range=(0, inf), 
  unit_cell_value=0.4330127018922193
)
```

For measures where the acceptable range is well defined (e.g. `(0.5, 1.0)`), this will enable users to easily identify and extract "good quality" cells (within the acceptable range) and "bad quality" cells (outside the acceptable range), and also compare cell quality values against a reference unit cell (i.e. compare to `unit_cell_value`)
