### PR TITLE
Add `pv.vtk_verbosity` context manager for suppressing vtk `stderr` output

### DIFF
--- a/doc/source/api/utilities/utilities.rst
+++ b/doc/source/api/utilities/utilities.rst
@@ -126,6 +126,7 @@ Miscellaneous
 
    start_xvfb
    Report
+   vtk_verbosity
 
 PyVista Version Information
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -19,6 +19,7 @@ from pyvista.core._typing_core._dataset_types import _DataSetType as _DataSetTyp
 from pyvista.core._typing_core._dataset_types import _GridType as _GridType
 from pyvista.core._typing_core._dataset_types import _PointGridType as _PointGridType
 from pyvista.core._typing_core._dataset_types import _PointSetType as _PointSetType
+from pyvista.core._vtk_core import vtk_verbosity as vtk_verbosity
 from pyvista.core._vtk_core import vtk_version_info as vtk_version_info
 from pyvista.core.cell import _get_vtk_id_type
 from pyvista.core.utilities.observers import send_errors_to_logging

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -632,7 +632,7 @@ class _VTKVerbosity(contextlib.AbstractContextManager[None]):
 
     >>> mesh = pv.Sphere()
     >>> with pv.vtk_verbosity('off'):
-    ...     mesh.compute_cell_quality('volume')
+    ...     mesh = mesh.compute_cell_quality('volume')
 
     """
 

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -671,7 +671,7 @@ class _VTKVerbosity(contextlib.AbstractContextManager):
         if self._original_verbosity is not None:
             self._verbosity = self._original_verbosity
 
-    def __call__(self, verbosity: _VerbosityOptions):  # type:ignore[override]
+    def __call__(self, verbosity: _VerbosityOptions):
         """Call the context manager."""
         # Set the verbosity permanently
         self._original_verbosity = self._verbosity

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -10,7 +10,7 @@ the entire library.
 from __future__ import annotations
 
 import contextlib
-from typing import Literal
+from typing import TYPE_CHECKING
 from typing import NamedTuple
 import warnings
 
@@ -586,18 +586,21 @@ def VTKVersionInfo():
 
 vtk_version_info = VTKVersionInfo()
 
-_VerbosityOptions = (
-    Literal[
-        'off',
-        'error',
-        'warning',
-        'info',
-        'trace',
-        'max',
-    ]
-    | int
-    | vtkLogger.Verbosity
-)
+if TYPE_CHECKING:
+    from typing import Literal
+
+    _VerbosityOptions = (
+        Literal[
+            'off',
+            'error',
+            'warning',
+            'info',
+            'trace',
+            'max',
+        ]
+        | int
+        | vtkLogger.Verbosity
+    )
 
 
 class _VTKVerbosity(contextlib.AbstractContextManager):

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -595,7 +595,6 @@ if TYPE_CHECKING:
             'error',
             'warning',
             'info',
-            'trace',
             'max',
         ]
         | int
@@ -612,7 +611,7 @@ class _VTKVerbosity(contextlib.AbstractContextManager[None]):
     ----------
     verbosity : int | str | vtkLogger.Verbosity
         Verbosity of the ``vtkLogger`` to set. Accepted values are, ``'off'``, ``'error'``,
-        ``'warning'``, ``'info'``, ``'trace'``, ``'max'`` or an integer between ``[-9, 9]``.
+        ``'warning'``, ``'info'``, ``'max'`` or an integer between ``[-9, 9]``.
 
     Examples
     --------

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -613,6 +613,8 @@ _VerbosityOptions = get_args(_VerbosityLiteral)
 class vtk_verbosity(contextlib.ContextDecorator):
     """Context manager to temporarily set VTK verbosity level.
 
+    .. versionadded:: 0.45
+
     Examples
     --------
     Load a surface mesh with :attr:`~pyvista.CellType.TRIANGLE` cells.

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -603,7 +603,7 @@ if TYPE_CHECKING:
     )
 
 
-class _VTKVerbosity(contextlib.AbstractContextManager):
+class _VTKVerbosity(contextlib.AbstractContextManager[None]):
     """Context manager to set VTK verbosity level.
 
     .. versionadded:: 0.45
@@ -664,6 +664,10 @@ class _VTKVerbosity(contextlib.AbstractContextManager):
     def __init__(self):
         """Initialize context manager."""
         self._original_verbosity = None
+
+    def __enter__(self):
+        """Enter context manager."""
+        return
 
     def __exit__(self, exc_type, exc_value, traceback):
         """Exit context manager."""

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -633,6 +633,11 @@ class _VTKVerbosity(contextlib.AbstractContextManager[None]):
     >>> with pv.vtk_verbosity('off'):
     ...     mesh = mesh.compute_cell_quality('volume')
 
+    The state is restored to its previous value outside the context.
+
+    >>> pv.vtk_verbosity()
+    'max'
+
     """
 
     @staticmethod

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -701,12 +701,17 @@ class _VTKVerbosity(contextlib.AbstractContextManager[None]):
 
     def __enter__(self):
         """Enter context manager."""
-        return
+        if self._original_verbosity is None:
+            raise ValueError(
+                'Verbosity must be set to a value to use it as a context manager.\n'
+                'Call `vtk_verbosity()` with an argument to set its value.'
+            )
 
     def __exit__(self, exc_type, exc_value, traceback):
         """Exit context manager."""
         # Restore the original verbosity level
         self._verbosity = self._original_verbosity
+        self._original_verbosity = None  # Reset
 
     def __call__(self, verbosity: _VerbosityOptions | None = None):
         """Call the context manager."""

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -698,8 +698,7 @@ class _VTKVerbosity(contextlib.AbstractContextManager[None]):
     def __exit__(self, exc_type, exc_value, traceback):
         """Exit context manager."""
         # Restore the original verbosity level
-        if self._original_verbosity is not None:
-            self._verbosity = self._original_verbosity
+        self._verbosity = self._original_verbosity
 
     def __call__(self, verbosity: _VerbosityOptions | None = None):
         """Call the context manager."""

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -663,8 +663,7 @@ class VTKVerbosity(contextlib.ContextDecorator):
 
     def __init__(self):
         """Initialize context manager."""
-        # Store current verbosity state
-        self._original_verbosity = self._verbosity
+        self._original_verbosity = None
 
     def __enter__(self):
         """Enter context manager."""
@@ -673,12 +672,13 @@ class VTKVerbosity(contextlib.ContextDecorator):
     def __exit__(self, exc_type, exc_value, traceback):
         """Exit context manager."""
         # Restore the original verbosity level
-        self._verbosity = self._original_verbosity
+        if self._original_verbosity is not None:
+            self._verbosity = self._original_verbosity
 
     def __call__(self, verbosity: _VerbosityLiteral | vtkLogger.Verbosity):  # type:ignore[override]
         """Call the context manager."""
-        # Set the verbosity permanently.
-        self._original_verbosity = vtkLogger.GetCurrentVerbosityCutoff()
+        # Set the verbosity permanently
+        self._original_verbosity = self._verbosity
         self._verbosity = verbosity
         return self
 

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -647,12 +647,11 @@ class VTKVerbosity(contextlib.ContextDecorator):
             return verbosity
         else:
             try:
-                verbosity = getattr(vtkLogger, f'VERBOSITY_{str(verbosity).upper()}')
+                return getattr(vtkLogger, f'VERBOSITY_{str(verbosity).upper()}')
             except AttributeError:
                 raise ValueError(
                     f"Invalid verbosity name '{verbosity}', must be one of:\n{_VerbosityOptions}."
                 )
-        return verbosity
 
     @property
     def _verbosity(self):
@@ -676,7 +675,7 @@ class VTKVerbosity(contextlib.ContextDecorator):
         # Restore the original verbosity level
         self._verbosity = self._original_verbosity
 
-    def __call__(self, verbosity: _VerbosityLiteral | vtkLogger.Verbosity):
+    def __call__(self, verbosity: _VerbosityLiteral | vtkLogger.Verbosity):  # type:ignore[override]
         """Call the context manager."""
         # Set the verbosity permanently.
         self._original_verbosity = vtkLogger.GetCurrentVerbosityCutoff()

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -600,7 +600,7 @@ _VerbosityOptions = (
 )
 
 
-class VTKVerbosity(contextlib.ContextDecorator):
+class _VTKVerbosity(contextlib.AbstractContextManager):
     """Context manager to set VTK verbosity level.
 
     .. versionadded:: 0.45
@@ -662,10 +662,6 @@ class VTKVerbosity(contextlib.ContextDecorator):
         """Initialize context manager."""
         self._original_verbosity = None
 
-    def __enter__(self):
-        """Enter context manager."""
-        # Do nothing, state was stored previously on init or call
-
     def __exit__(self, exc_type, exc_value, traceback):
         """Exit context manager."""
         # Restore the original verbosity level
@@ -680,4 +676,4 @@ class VTKVerbosity(contextlib.ContextDecorator):
         return self
 
 
-vtk_verbosity = VTKVerbosity()
+vtk_verbosity = _VTKVerbosity()

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -610,8 +610,16 @@ class _VTKVerbosity(contextlib.AbstractContextManager[None]):
     Parameters
     ----------
     verbosity : int | str | vtkLogger.Verbosity
-        Verbosity of the ``vtkLogger`` to set. Accepted values are, ``'off'``, ``'error'``,
-        ``'warning'``, ``'info'``, ``'max'`` or an integer between ``[-9, 9]``.
+        Verbosity of the ``vtkLogger`` to set.
+
+        - ``'off'``: No output.
+        - ``'error'``: Only error messages.
+        - ``'warning'``: Errors and warnings.
+        - ``'info'``: Errors, warnings, and info messages.
+        - ``'max'``: All messages, including debug info.
+
+        Integers between ``[-9, 9]`` or their string representation
+        are also accepted.
 
     Examples
     --------

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -648,11 +648,15 @@ class _VTKVerbosity(contextlib.AbstractContextManager[None]):
             return verbosity
         else:
             try:
-                return getattr(vtkLogger, f'VERBOSITY_{str(verbosity).upper()}')
+                logger_verbosity = getattr(vtkLogger, f'VERBOSITY_{str(verbosity).upper()}')
+                if logger_verbosity == vtkLogger.VERBOSITY_INVALID:
+                    raise AttributeError
+                else:
+                    return logger_verbosity
             except AttributeError:
                 raise ValueError(
                     f"Invalid verbosity name '{verbosity}', must be one of:\n"
-                    f"'off', 'error', 'warning', 'info', 'trace', 'max', or an integer between [-9, 9]."
+                    f"'off', 'error', 'warning', 'info', 'max', or an integer between [-9, 9]."
                 )
 
     @property

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -635,14 +635,16 @@ class vtk_verbosity(contextlib.ContextDecorator):
     """
 
     def __init__(self, verbosity: _VerbosityLiteral | vtkLogger.Verbosity):
-        if isinstance(verbosity, (int, str)) and not isinstance(verbosity, vtkLogger.Verbosity):
+        if isinstance(verbosity, vtkLogger.Verbosity):
+            verbosity_ = verbosity
+        else:
             try:
-                verbosity = getattr(vtkLogger, f'VERBOSITY_{str(verbosity).upper()}')
+                verbosity_ = getattr(vtkLogger, f'VERBOSITY_{str(verbosity).upper()}')
             except AttributeError:
                 raise ValueError(
                     f"Invalid verbosity name '{verbosity}', must be one of:\n{_VerbosityOptions}."
                 )
-        self._new_verbosity = verbosity
+        self._new_verbosity = verbosity_
 
     def __enter__(self):
         # Store the current verbosity level

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -2106,11 +2106,8 @@ class DataObjectFilters:
                     'VTK v9.1 or newer is required.',
                 )
         # Suppress improperly used INFO for debugging messages in vtkExtractEdges
-        verbosity = _vtk.vtkLogger.GetCurrentVerbosityCutoff()
-        _vtk.vtkLogger.SetStderrVerbosity(_vtk.vtkLogger.VERBOSITY_OFF)
-        _update_alg(alg, progress_bar, 'Extracting All Edges')
-        # Restore the original vtkLogger verbosity level
-        _vtk.vtkLogger.SetStderrVerbosity(verbosity)
+        with pyvista.vtk_verbosity('off'):
+            _update_alg(alg, progress_bar, 'Extracting All Edges')
         output = _get_output(alg)
         if clear_data:
             output.clear_data()

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -1008,11 +1008,8 @@ class ImageDataFilters(DataSetFilters):
         else:
             alg.SmoothingOff()
         # Suppress improperly used INFO for debugging messages in vtkSurfaceNets3D
-        verbosity = _vtk.vtkLogger.GetCurrentVerbosityCutoff()
-        _vtk.vtkLogger.SetStderrVerbosity(_vtk.vtkLogger.VERBOSITY_OFF)
-        _update_alg(alg, progress_bar, 'Performing Labeled Surface Extraction')
-        # Restore the original vtkLogger verbosity level
-        _vtk.vtkLogger.SetStderrVerbosity(verbosity)
+        with pyvista.vtk_verbosity('off'):
+            _update_alg(alg, progress_bar, 'Performing Labeled Surface Extraction')
         return wrap(alg.GetOutput())
 
     def contour_labels(  # type: ignore[misc]
@@ -1606,11 +1603,9 @@ class ImageDataFilters(DataSetFilters):
 
         # Get output
         # Suppress improperly used INFO for debugging messages in vtkSurfaceNets3D
-        verbosity = _vtk.vtkLogger.GetCurrentVerbosityCutoff()
-        _vtk.vtkLogger.SetStderrVerbosity(_vtk.vtkLogger.VERBOSITY_OFF)
-        _update_alg(alg, progress_bar, 'Generating label contours')
-        # Restore the original vtkLogger verbosity level
-        _vtk.vtkLogger.SetStderrVerbosity(verbosity)
+        with pyvista.vtk_verbosity('off'):
+            _update_alg(alg, progress_bar, 'Generating label contours')
+
         output: pyvista.PolyData = _get_output(alg)
 
         (  # Clear temp scalars from input

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -2012,7 +2012,6 @@ def reset_verbosity():
     vtk.vtkLogger.SetStderrVerbosity(initial_verbosity)
 
 
-# Usage examples:
 @pytest.mark.parametrize('verbosity', [*_vtk._VerbosityOptions, _vtk.vtkLogger.VERBOSITY_OFF])
 def test_vtk_verbosity_context(verbosity, reset_verbosity):
     initial_verbosity = vtk.vtkLogger.VERBOSITY_4

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -2046,7 +2046,7 @@ def test_vtk_verbosity_set_get(verbosity, modifies_verbosity):
 def test_vtk_verbosity_raises():
     match = re.escape(
         "Invalid verbosity name 'str', must be one of:\n"
-        "'off', 'error', 'warning', 'info', 'trace', 'max', or an integer between [-9, 9]."
+        "'off', 'error', 'warning', 'info', 'max', or an integer between [-9, 9]."
     )
     with pytest.raises(ValueError, match=match):
         with pv.vtk_verbosity('str'):

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -2006,14 +2006,14 @@ def test_classproperty():
 
 
 @pytest.fixture
-def reset_verbosity():
+def modifies_verbosity():
     initial_verbosity = vtk.vtkLogger.GetCurrentVerbosityCutoff()
     yield
     vtk.vtkLogger.SetStderrVerbosity(initial_verbosity)
 
 
 @pytest.mark.parametrize('verbosity', [*_vtk._VerbosityOptions, _vtk.vtkLogger.VERBOSITY_OFF])
-def test_vtk_verbosity_context(verbosity, reset_verbosity):
+def test_vtk_verbosity_context(verbosity, modifies_verbosity):
     initial_verbosity = vtk.vtkLogger.VERBOSITY_4
     _vtk.vtkLogger.SetStderrVerbosity(initial_verbosity)
     with pv.vtk_verbosity(verbosity):
@@ -2022,7 +2022,7 @@ def test_vtk_verbosity_context(verbosity, reset_verbosity):
 
 
 @pytest.mark.parametrize('verbosity', ['off', _vtk.vtkLogger.VERBOSITY_OFF])
-def test_vtk_verbosity_setter(verbosity, reset_verbosity):
+def test_vtk_verbosity_setter(verbosity, modifies_verbosity):
     assert _vtk.vtkLogger.GetCurrentVerbosityCutoff() != _vtk.vtkLogger.VERBOSITY_OFF
     pv.vtk_verbosity(verbosity)
     assert _vtk.vtkLogger.GetCurrentVerbosityCutoff() == _vtk.vtkLogger.VERBOSITY_OFF

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -2012,6 +2012,7 @@ def modifies_verbosity():
     vtk.vtkLogger.SetStderrVerbosity(initial_verbosity)
 
 
+@pytest.mark.usefixtures('modifies_verbosity')
 @pytest.mark.parametrize(
     'verbosity',
     [
@@ -2027,7 +2028,7 @@ def modifies_verbosity():
         _vtk.vtkLogger.VERBOSITY_OFF,
     ],
 )
-def test_vtk_verbosity_context(verbosity, modifies_verbosity):
+def test_vtk_verbosity_context(verbosity):
     initial_verbosity = vtk.vtkLogger.VERBOSITY_4
     _vtk.vtkLogger.SetStderrVerbosity(initial_verbosity)
     with pv.vtk_verbosity(verbosity):
@@ -2035,7 +2036,8 @@ def test_vtk_verbosity_context(verbosity, modifies_verbosity):
     assert _vtk.vtkLogger.GetCurrentVerbosityCutoff() == initial_verbosity
 
 
-def test_vtk_verbosity_no_context(modifies_verbosity):
+@pytest.mark.usefixtures('modifies_verbosity')
+def test_vtk_verbosity_no_context():
     match = re.escape(
         'Verbosity must be set to a value to use it as a context manager.\n'
         'Call `vtk_verbosity()` with an argument to set its value.'
@@ -2054,8 +2056,9 @@ def test_vtk_verbosity_no_context(modifies_verbosity):
             ...
 
 
+@pytest.mark.usefixtures('modifies_verbosity')
 @pytest.mark.parametrize('verbosity', ['off', _vtk.vtkLogger.VERBOSITY_OFF])
-def test_vtk_verbosity_set_get(verbosity, modifies_verbosity):
+def test_vtk_verbosity_set_get(verbosity):
     assert _vtk.vtkLogger.GetCurrentVerbosityCutoff() != _vtk.vtkLogger.VERBOSITY_OFF
     pv.vtk_verbosity(verbosity)
     assert pv.vtk_verbosity() == 'off'

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -2036,9 +2036,10 @@ def test_vtk_verbosity_context(verbosity, modifies_verbosity):
 
 
 @pytest.mark.parametrize('verbosity', ['off', _vtk.vtkLogger.VERBOSITY_OFF])
-def test_vtk_verbosity_setter(verbosity, modifies_verbosity):
+def test_vtk_verbosity_set_get(verbosity, modifies_verbosity):
     assert _vtk.vtkLogger.GetCurrentVerbosityCutoff() != _vtk.vtkLogger.VERBOSITY_OFF
     pv.vtk_verbosity(verbosity)
+    assert pv.vtk_verbosity() == 'off'
     assert _vtk.vtkLogger.GetCurrentVerbosityCutoff() == _vtk.vtkLogger.VERBOSITY_OFF
 
 

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -2008,8 +2008,11 @@ def test_classproperty():
 # Usage examples:
 @pytest.mark.parametrize('option', [*_vtk._VerbosityOptions, _vtk.vtkLogger.VERBOSITY_OFF])
 def test_vtk_verbosity(option):
+    initial_verbosity = vtk.vtkLogger.VERBOSITY_4
+    _vtk.vtkLogger.SetStderrVerbosity(initial_verbosity)
     with pv.vtk_verbosity(option):
         ...
+    assert _vtk.vtkLogger.GetCurrentVerbosityCutoff() == initial_verbosity
 
 
 def test_vtk_verbosity_raises():

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -24,6 +24,7 @@ import vtk
 
 import pyvista as pv
 from pyvista import examples as ex
+from pyvista.core import _vtk_core as _vtk
 from pyvista.core.utilities import cells
 from pyvista.core.utilities import fileio
 from pyvista.core.utilities import fit_line_to_points
@@ -2002,3 +2003,20 @@ def test_classproperty():
         Foo.prop()
     with pytest.raises(TypeError, match='object is not callable'):
         Foo().prop()
+
+
+# Usage examples:
+@pytest.mark.parametrize('option', [*_vtk._VerbosityOptions, _vtk.vtkLogger.VERBOSITY_OFF])
+def test_vtk_verbosity(option):
+    with pv.vtk_verbosity(option):
+        ...
+
+
+def test_vtk_verbosity_raises():
+    match = re.escape(
+        "Invalid verbosity name 'str', must be one of:\n"
+        "('invalid', 'off', 'error', 'warning', 'info', 'trace', 'max', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9')."
+    )
+    with pytest.raises(ValueError, match=match):
+        with pv.vtk_verbosity('str'):
+            ...

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -2012,7 +2012,21 @@ def modifies_verbosity():
     vtk.vtkLogger.SetStderrVerbosity(initial_verbosity)
 
 
-@pytest.mark.parametrize('verbosity', [*_vtk._VerbosityOptions, _vtk.vtkLogger.VERBOSITY_OFF])
+@pytest.mark.parametrize(
+    'verbosity',
+    [
+        'OFF',
+        'off',
+        'error',
+        'warning',
+        'info',
+        'trace',
+        'max',
+        *range(10),
+        '0',
+        _vtk.vtkLogger.VERBOSITY_OFF,
+    ],
+)
 def test_vtk_verbosity_context(verbosity, modifies_verbosity):
     initial_verbosity = vtk.vtkLogger.VERBOSITY_4
     _vtk.vtkLogger.SetStderrVerbosity(initial_verbosity)
@@ -2031,7 +2045,7 @@ def test_vtk_verbosity_setter(verbosity, modifies_verbosity):
 def test_vtk_verbosity_raises():
     match = re.escape(
         "Invalid verbosity name 'str', must be one of:\n"
-        "('invalid', 'off', 'error', 'warning', 'info', 'trace', 'max', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9')."
+        "'off', 'error', 'warning', 'info', 'trace', 'max', or an integer between [-9, 9]."
     )
     with pytest.raises(ValueError, match=match):
         with pv.vtk_verbosity('str'):

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -2005,14 +2005,28 @@ def test_classproperty():
         Foo().prop()
 
 
+@pytest.fixture
+def reset_verbosity():
+    initial_verbosity = vtk.vtkLogger.GetCurrentVerbosityCutoff()
+    yield
+    vtk.vtkLogger.SetStderrVerbosity(initial_verbosity)
+
+
 # Usage examples:
-@pytest.mark.parametrize('option', [*_vtk._VerbosityOptions, _vtk.vtkLogger.VERBOSITY_OFF])
-def test_vtk_verbosity(option):
+@pytest.mark.parametrize('verbosity', [*_vtk._VerbosityOptions, _vtk.vtkLogger.VERBOSITY_OFF])
+def test_vtk_verbosity_context(verbosity, reset_verbosity):
     initial_verbosity = vtk.vtkLogger.VERBOSITY_4
     _vtk.vtkLogger.SetStderrVerbosity(initial_verbosity)
-    with pv.vtk_verbosity(option):
+    with pv.vtk_verbosity(verbosity):
         ...
     assert _vtk.vtkLogger.GetCurrentVerbosityCutoff() == initial_verbosity
+
+
+@pytest.mark.parametrize('verbosity', ['off', _vtk.vtkLogger.VERBOSITY_OFF])
+def test_vtk_verbosity_setter(verbosity, reset_verbosity):
+    assert _vtk.vtkLogger.GetCurrentVerbosityCutoff() != _vtk.vtkLogger.VERBOSITY_OFF
+    pv.vtk_verbosity(verbosity)
+    assert _vtk.vtkLogger.GetCurrentVerbosityCutoff() == _vtk.vtkLogger.VERBOSITY_OFF
 
 
 def test_vtk_verbosity_raises():

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -2043,11 +2043,11 @@ def test_vtk_verbosity_set_get(verbosity, modifies_verbosity):
     assert _vtk.vtkLogger.GetCurrentVerbosityCutoff() == _vtk.vtkLogger.VERBOSITY_OFF
 
 
-def test_vtk_verbosity_raises():
+@pytest.mark.parametrize('value', ['str', -10])
+def test_vtk_verbosity_raises(value):
     match = re.escape(
-        "Invalid verbosity name 'str', must be one of:\n"
-        "'off', 'error', 'warning', 'info', 'max', or an integer between [-9, 9]."
+        "must be one of:\n'off', 'error', 'warning', 'info', 'max', or an integer between [-9, 9]."
     )
     with pytest.raises(ValueError, match=match):
-        with pv.vtk_verbosity('str'):
+        with pv.vtk_verbosity(value):
             ...

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -2035,6 +2035,25 @@ def test_vtk_verbosity_context(verbosity, modifies_verbosity):
     assert _vtk.vtkLogger.GetCurrentVerbosityCutoff() == initial_verbosity
 
 
+def test_vtk_verbosity_no_context(modifies_verbosity):
+    match = re.escape(
+        'Verbosity must be set to a value to use it as a context manager.\n'
+        'Call `vtk_verbosity()` with an argument to set its value.'
+    )
+    with pytest.raises(ValueError, match=match):
+        with pv.vtk_verbosity:
+            ...
+
+    # Use context normally
+    with pv.vtk_verbosity('off'):
+        ...
+
+    # Test again to check reset after use
+    with pytest.raises(ValueError, match=match):
+        with pv.vtk_verbosity:
+            ...
+
+
 @pytest.mark.parametrize('verbosity', ['off', _vtk.vtkLogger.VERBOSITY_OFF])
 def test_vtk_verbosity_set_get(verbosity, modifies_verbosity):
     assert _vtk.vtkLogger.GetCurrentVerbosityCutoff() != _vtk.vtkLogger.VERBOSITY_OFF
@@ -2044,7 +2063,7 @@ def test_vtk_verbosity_set_get(verbosity, modifies_verbosity):
 
 
 @pytest.mark.parametrize('value', ['str', 'invalid'])
-def test_vtk_verbosity_raises(value):
+def test_vtk_verbosity_invalid_input(value):
     match = re.escape(
         "must be one of:\n'off', 'error', 'warning', 'info', 'max', or an integer between [-9, 9]."
     )

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -2043,7 +2043,7 @@ def test_vtk_verbosity_set_get(verbosity, modifies_verbosity):
     assert _vtk.vtkLogger.GetCurrentVerbosityCutoff() == _vtk.vtkLogger.VERBOSITY_OFF
 
 
-@pytest.mark.parametrize('value', ['str', -10])
+@pytest.mark.parametrize('value', ['str', 'invalid'])
 def test_vtk_verbosity_raises(value):
     match = re.escape(
         "must be one of:\n'off', 'error', 'warning', 'info', 'max', or an integer between [-9, 9]."


### PR DESCRIPTION
### Overview

Sometimes it's helpful or necessary to modify stderr output from VTK. This PR adds a context manager to do this easily.

This can used by `extract_edges` and `contour_labels`, and can also be extend to `compute_cell_quality` (e.g. #7311 and #7306)