### PR TITLE
Add codecov test analytics

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -158,7 +158,7 @@ jobs:
           pip install --pre --no-deps -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
 
       - name: Core Testing (no GL)
-        run: python -m pytest --cov=pyvista --cov-branch -v --ignore=tests/plotting
+        run: python -m pytest tests/test_init.py --cov=pyvista --cov-branch --cov-report=xml -v --ignore=tests/plotting
 
       - uses: awalsh128/cache-apt-pkgs-action@v1.4.3
         with:
@@ -187,6 +187,7 @@ jobs:
 
       - uses: codecov/codecov-action@v4
         name: "Upload coverage to CodeCov"
+        if: always()
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -158,7 +158,8 @@ jobs:
           pip install --pre --no-deps -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
 
       - name: Core Testing (no GL)
-        run: python -m pytest tests/test_init.py --cov=pyvista --cov-branch --cov-report=xml -v --ignore=tests/plotting --junitxml=junit.xml
+        run: |
+          python -m pytest tests/test_init.py --cov=pyvista --cov-branch --cov-report=xml -v --ignore=tests/plotting --junitxml=junit-${{ join(matrix.* , '-') }}.xml
 
       - uses: awalsh128/cache-apt-pkgs-action@v1.4.3
         with:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -196,6 +196,7 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: ${{ join(matrix.* , '-') }}
 
       - name: Check package
         run: |

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -158,7 +158,7 @@ jobs:
           pip install --pre --no-deps -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
 
       - name: Core Testing (no GL)
-        run: python -m pytest tests/test_init.py --cov=pyvista --cov-branch --cov-report=xml -v --ignore=tests/plotting
+        run: python -m pytest tests/test_init.py --cov=pyvista --cov-branch --cov-report=xml -v --ignore=tests/plotting --junitxml=junit.xml
 
       - uses: awalsh128/cache-apt-pkgs-action@v1.4.3
         with:
@@ -190,6 +190,12 @@ jobs:
         if: always()
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results to Codecov
+        if: always()
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Check package
         run: |

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -193,7 +193,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: always()
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@v1.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: ${{ join(matrix.* , '-') }}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -18,6 +18,20 @@ def _module_is_loaded(module: str) -> bool:
     return os.system(f'{sys.executable} -c "{exe_str}"') != 0
 
 
+def test_failed():
+    pytest.fail('test')
+
+
+@pytest.mark.skipif(os.name == 'nt', reason='Test skipped on Windows')
+def test_failed_windows():
+    pytest.fail('test')
+
+
+@pytest.mark.skipif(sys.version_info >= (3, 11), reason='Test skipped for python version >= 3.11')
+def test_failed_python_version():
+    pytest.fail('test')
+
+
 def test_vtk_not_loaded():
     error_msg = """
     vtk has been directly imported in vtk>=9


### PR DESCRIPTION
### Overview
(redo from https://github.com/pyvista/pyvista/pull/7318 and https://github.com/pyvista/pyvista/pull/7325 since the codecov comment was not updated)

Add codecov new feature to display test results in the codecov PR comment.
See the corresponding documentation [here](https://docs.codecov.com/docs/test-analytics)

It could greatly help to diagnose test failures without needing to inspect testing jobs logs for various os (macOS, Linux, Windows) and python/vtk/numpy versions.