### PR TITLE
Fix VTK pre-release testing

### DIFF
--- a/.github/workflows/vtk-pre-test.yml
+++ b/.github/workflows/vtk-pre-test.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install nightly VTK
         run: |
-          pip install vtk --pre --no-cache --extra-index-url https://wheels.vtk.org
+          pip install --upgrade vtk --pre --no-cache --extra-index-url https://wheels.vtk.org
 
       - name: Core Testing (no GL)
         run: python -m pytest --cov=pyvista -v tests/core tests/examples


### PR DESCRIPTION
### Overview

This test does not currently install the latest VTK. I suspect this workflow broke when VTK was pinned `<9.4` 