### PR TITLE
Update license for PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 description = 'Easier Pythonic interface to VTK'
 dynamic = ['version']
 keywords = ['mesh', 'numpy', 'plotting', 'vtk']
-license = { text = 'MIT' }
+license = 'MIT'
 name = 'pyvista'
 readme = 'README.rst'
 requires-python = '>=3.9'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = [{ name = 'PyVista Developers', email = 'info@pyvista.org' }]
 classifiers = [
   'Development Status :: 5 - Production/Stable',
   'Intended Audience :: Science/Research',
-  'License :: OSI Approved :: MIT License',
   'Operating System :: MacOS',
   'Operating System :: Microsoft :: Windows',
   'Operating System :: POSIX',


### PR DESCRIPTION
### Overview

The legacy format is deprecated, let's update it. See:
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license