### PR TITLE
Remove `None` from `MultiBlock.keys()` typing

### DIFF
--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from typing import NamedTuple
 import warnings
 
+from vtkmodules.vtkCommonCore import vtkInformation as vtkInformation
 from vtkmodules.vtkCommonCore import vtkVersion as vtkVersion
 from vtkmodules.vtkImagingSources import vtkImageEllipsoidSource as vtkImageEllipsoidSource
 from vtkmodules.vtkImagingSources import vtkImageGaussianSource as vtkImageGaussianSource

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -1499,7 +1499,7 @@ class MultiBlock(
         self.GetMetaData(index).Set(_vtk.vtkCompositeDataSet.NAME(), name)
         self.Modified()
 
-    def get_block_name(self: MultiBlock, index: int) -> str | None:
+    def get_block_name(self: MultiBlock, index: int) -> str:
         """Return the string name of the block at the given index.
 
         Parameters
@@ -1525,12 +1525,11 @@ class MultiBlock(
 
         """
         index = range(self.n_blocks)[index]
-        meta = self.GetMetaData(index)
-        if meta is not None:
-            return meta.Get(_vtk.vtkCompositeDataSet.NAME())
-        return None
+        # Safely cast as vtkInformation since `None` case is caught by IndexError above
+        meta = cast(_vtk.vtkInformation, self.GetMetaData(index))
+        return meta.Get(_vtk.vtkCompositeDataSet.NAME())  # type:ignore[return-value]
 
-    def keys(self: MultiBlock) -> list[str | None]:
+    def keys(self: MultiBlock) -> list[str]:
         """Get all the block names in the dataset.
 
         Returns
@@ -1552,7 +1551,7 @@ class MultiBlock(
         """
         return [self.get_block_name(i) for i in range(self.n_blocks)]
 
-    def _ipython_key_completions_(self: MultiBlock) -> list[str | None]:
+    def _ipython_key_completions_(self: MultiBlock) -> list[str]:
         return self.keys()
 
     def replace(

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -7806,7 +7806,7 @@ class _WholeBodyCTUtilities:  # pragma: no cover
     def add_metadata(dataset: pyvista.MultiBlock, colors_module_path: str):
         # Add color and id mappings to dataset
         segmentations = cast(pyvista.MultiBlock, dataset['segmentations'])
-        label_names = sorted(cast(list[str], segmentations.keys()))
+        label_names = sorted(segmentations.keys())
         names_to_colors = _WholeBodyCTUtilities.import_colors_dict(colors_module_path)
         names_to_ids = {key: i + 1 for i, key in enumerate(label_names)}
         dataset.user_dict['names_to_colors'] = names_to_colors
@@ -7821,7 +7821,7 @@ class _WholeBodyCTUtilities:  # pragma: no cover
         # Initialize array with background values (zeros)
         n_points = cast(pyvista.ImageData, masks[0]).n_points
         label_map_array = np.zeros((n_points,), dtype=np.uint8)
-        label_names = sorted(cast(list[str], masks.keys()))
+        label_names = sorted(masks.keys())
         for i, name in enumerate(label_names):
             mask = cast(pyvista.ImageData, masks[name])
             label_map_array[mask.active_scalars == 1] = i + 1


### PR DESCRIPTION
### Overview

The `MultiBlock` keys are always strings and should hint the type as `list[str]`. But the typing hints `list[str | None]` instead because `get_block_name` returns `str | None`. But the `None` case is only valid here when `GetMetaData` returns `None`, which is only the case when a MultiBlock is empty. However, if it's empty then `get_block_name` raises an `IndexError` before we even call `GetMetaData`, and so the `None` case is not valid and `None` will never be returned.

This PR therefore removes `None` from the return type of `get_block_name` and `keys`.
