### PR TITLE
Add custom skipif markers in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,7 @@ log_cli_level = "INFO"
 markers = [
   'needs_download: this test downloads data during execution',
   'needs_vtk_version(version): skip test unless VTK version is at least as specified.',
+  'skip_windows(reason="Test fails on windows"): skip test for windows.',
 ]
 minversion = "7"
 testpaths = 'tests'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,7 +224,8 @@ log_cli_level = "INFO"
 markers = [
   'needs_download: this test downloads data during execution',
   'needs_vtk_version(version): skip test unless VTK version is at least as specified.',
-  'skip_windows(reason="Test fails on windows"): skip test for windows.',
+  'skip_mac(reason="Test fails on MacOS"): skip test for MacOS.',
+  'skip_windows(reason="Test fails on Windows"): skip test for windows.',
 ]
 minversion = "7"
 testpaths = 'tests'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,7 @@ log_cli_level = "INFO"
 markers = [
   'needs_download: this test downloads data during execution',
   'needs_vtk_version(version): skip test unless VTK version is at least as specified.',
+  'skip_egl(reason="Test fails when using OSMesa/EGL VTK build"): skip test for OSMesa/EGL.',
   'skip_mac(reason="Test fails on MacOS", machine=None, processor=None): skip test for MacOS and specific architectures if needed',
   'skip_windows(reason="Test fails on Windows"): skip test for windows.',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,7 +224,7 @@ log_cli_level = "INFO"
 markers = [
   'needs_download: this test downloads data during execution',
   'needs_vtk_version(version): skip test unless VTK version is at least as specified.',
-  'skip_mac(reason="Test fails on MacOS"): skip test for MacOS.',
+  'skip_mac(reason="Test fails on MacOS", machine=None, processor=None): skip test for MacOS and specific architectures if needed',
   'skip_windows(reason="Test fails on Windows"): skip test for windows.',
 ]
 minversion = "7"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -318,7 +318,7 @@ def pytest_runtest_setup(item: pytest.Item):
             version_str = '.'.join(map(str, version_needed))
             pytest.skip(f'Test needs VTK {version_str} or newer.')
 
-    if (item_mark := item.get_closest_marker('skip_egl')) and (uses_egl()):
+    if item_mark := item.get_closest_marker('skip_egl'):
         sig = Signature(
             [
                 Parameter(
@@ -331,9 +331,10 @@ def pytest_runtest_setup(item: pytest.Item):
         )
 
         bounds = _check_args_kwargs_marker(item_mark=item_mark, sig=sig)
-        pytest.skip(bounds.arguments[r])
+        if uses_egl():
+            pytest.skip(bounds.arguments[r])
 
-    if (item_mark := item.get_closest_marker('skip_windows')) and (os.name == 'nt'):
+    if item_mark := item.get_closest_marker('skip_windows'):
         sig = Signature(
             [
                 Parameter(
@@ -346,9 +347,10 @@ def pytest_runtest_setup(item: pytest.Item):
         )
 
         bounds = _check_args_kwargs_marker(item_mark=item_mark, sig=sig)
-        pytest.skip(bounds.arguments[r])
+        if os.name == 'nt':
+            pytest.skip(bounds.arguments[r])
 
-    if (item_mark := item.get_closest_marker('skip_mac')) and (platform.system() == 'Darwin'):
+    if item_mark := item.get_closest_marker('skip_mac'):
         sig = Signature(
             [
                 Parameter(
@@ -374,7 +376,7 @@ def pytest_runtest_setup(item: pytest.Item):
 
         bounds = _check_args_kwargs_marker(item_mark=item_mark, sig=sig)
 
-        should_skip = True
+        should_skip = platform.system() == 'Darwin'
         if (proc := bounds.arguments[p]) is not None:
             should_skip &= proc == platform.processor()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from importlib import metadata
 from inspect import Parameter
 from inspect import Signature
 import os
+import platform
 import re
 
 import numpy as np
@@ -322,6 +323,21 @@ def pytest_runtest_setup(item: pytest.Item):
                     r := 'reason',
                     kind=Parameter.POSITIONAL_OR_KEYWORD,
                     default='Test fails on Windows',
+                    annotation=str,
+                )
+            ]
+        )
+
+        bounds = _check_args_kwargs_marker(item_mark=item_mark, sig=sig)
+        pytest.skip(bounds.arguments[r])
+
+    if (item_mark := item.get_closest_marker('skip_mac')) and (platform.system() == 'Darwin'):
+        sig = Signature(
+            [
+                Parameter(
+                    r := 'reason',
+                    kind=Parameter.POSITIONAL_OR_KEYWORD,
+                    default='Test fails on MacOS',
                     annotation=str,
                 )
             ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import functools
 from importlib import metadata
+from inspect import Parameter
+from inspect import Signature
+import os
 import re
 
 import numpy as np
@@ -285,13 +288,25 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
                 item.add_marker(skip_downloads)
 
 
-def pytest_runtest_setup(item):
+def _check_args_kwargs_marker(item_mark: pytest.Mark, sig: Signature):
+    """Test for a given args and kwargs for a mark using its signature"""
+
+    try:
+        bounds = sig.bind(*item_mark.args, **item_mark.kwargs)
+    except TypeError as e:
+        msg = f'Marker {item_mark.name} called with incorrect arguments.\nSignature should be: @pytest.mark.{item_mark.name}{sig}'
+        raise ValueError(msg) from e
+    else:
+        bounds.apply_defaults()
+        return bounds
+
+
+def pytest_runtest_setup(item: pytest.Item):
     """Custom setup to handle skips based on VTK version.
 
-    See pytest.mark.needs_vtk_version in pyproject.toml.
-
+    See custom marks in pyproject.toml.
     """
-    for item_mark in item.iter_markers('needs_vtk_version'):
+    if item_mark := item.get_closest_marker('needs_vtk_version'):
         # this test needs the given VTK version
         # allow both needs_vtk_version(9, 1) and needs_vtk_version((9, 1))
         args = item_mark.args
@@ -299,6 +314,21 @@ def pytest_runtest_setup(item):
         if pyvista.vtk_version_info < version_needed:
             version_str = '.'.join(map(str, version_needed))
             pytest.skip(f'Test needs VTK {version_str} or newer.')
+
+    if (item_mark := item.get_closest_marker('skip_windows')) and (os.name == 'nt'):
+        sig = Signature(
+            [
+                Parameter(
+                    r := 'reason',
+                    kind=Parameter.POSITIONAL_OR_KEYWORD,
+                    default='Test fails on Windows',
+                    annotation=str,
+                )
+            ]
+        )
+
+        bounds = _check_args_kwargs_marker(item_mark=item_mark, sig=sig)
+        pytest.skip(bounds.arguments[r])
 
 
 def pytest_report_header(config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -296,7 +296,7 @@ def _check_args_kwargs_marker(item_mark: pytest.Mark, sig: Signature):
     try:
         bounds = sig.bind(*item_mark.args, **item_mark.kwargs)
     except TypeError as e:
-        msg = f'Marker {item_mark.name} called with incorrect arguments.\nSignature should be: @pytest.mark.{item_mark.name}{sig}'
+        msg = f'Marker `{item_mark.name}` called with incorrect arguments.\nSignature should be: @pytest.mark.{item_mark.name}{sig}'
         raise ValueError(msg) from e
     else:
         bounds.apply_defaults()

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Generator
 import itertools
 import pathlib
-import platform
 import re
 import weakref
 
@@ -20,8 +19,6 @@ from pyvista import RectilinearGrid
 from pyvista import StructuredGrid
 from pyvista import examples as ex
 from pyvista.core.dataobject import USER_DICT_KEY
-
-skip_mac = pytest.mark.skipif(platform.system() == 'Darwin', reason='Flaky Mac tests')
 
 
 def test_multi_block_init_vtk():

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import functools
 import itertools
 from pathlib import Path
-import platform
 import re
 from typing import TYPE_CHECKING
 from typing import Any
@@ -36,7 +35,6 @@ if TYPE_CHECKING:
 
 normals = ['x', 'y', '-z', (1, 1, 1), (3.3, 5.4, 0.8)]
 
-skip_mac = pytest.mark.skipif(platform.system() == 'Darwin', reason='Flaky Mac tests')
 
 HYPOTHESIS_MAX_EXAMPLES = 20
 
@@ -132,7 +130,7 @@ def test_datasetfilters_init():
         pv.core.filters.DataSetFilters()
 
 
-@skip_mac
+@pytest.mark.skip_mac('Flaky Mac test')
 @pytest.mark.parametrize('both', [False, True])
 @pytest.mark.parametrize('invert', [False, True])
 def test_clip_scalar_filter(datasets, both, invert):

--- a/tests/core/test_datasetattributes.py
+++ b/tests/core/test_datasetattributes.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import platform
 import re
 from string import ascii_letters
@@ -23,7 +22,6 @@ from pyvista.core.errors import PyVistaDeprecationWarning
 from pyvista.core.utilities.arrays import FieldAssociation
 from pyvista.core.utilities.arrays import convert_array
 
-skip_windows = pytest.mark.skipif(os.name == 'nt', reason='Test fails on Windows')
 skip_apple_silicon = pytest.mark.skipif(
     platform.system() == 'Darwin' and platform.processor() == 'arm',
     reason='Test fails on Apple Silicon',
@@ -667,7 +665,7 @@ def test_active_texture_coordinates_name(plane):
         plane.field_data.active_texture_coordinates_name = 'arr'
 
 
-@skip_windows  # windows doesn't support np.complex256
+@pytest.mark.skip_windows("windows doesn't support np.complex256")
 @skip_apple_silicon  # same with Apple silicon (M1/M2)
 def test_complex_raises(plane):
     with pytest.raises(ValueError, match='Only numpy.complex64'):

--- a/tests/core/test_datasetattributes.py
+++ b/tests/core/test_datasetattributes.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import platform
 import re
 from string import ascii_letters
 from string import digits
@@ -21,11 +20,6 @@ import pyvista as pv
 from pyvista.core.errors import PyVistaDeprecationWarning
 from pyvista.core.utilities.arrays import FieldAssociation
 from pyvista.core.utilities.arrays import convert_array
-
-skip_apple_silicon = pytest.mark.skipif(
-    platform.system() == 'Darwin' and platform.processor() == 'arm',
-    reason='Test fails on Apple Silicon',
-)
 
 
 @pytest.fixture
@@ -666,7 +660,7 @@ def test_active_texture_coordinates_name(plane):
 
 
 @pytest.mark.skip_windows("windows doesn't support np.complex256")
-@skip_apple_silicon  # same with Apple silicon (M1/M2)
+@pytest.mark.skip_mac('Test fails on Apple silicon (M1/M2)', processor='arm')
 def test_complex_raises(plane):
     with pytest.raises(ValueError, match='Only numpy.complex64'):
         plane.point_data['data'] = np.empty(plane.n_points, dtype=np.complex256)

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 import pickle
 import re
@@ -26,9 +25,6 @@ try:
     import imageio
 except ModuleNotFoundError:
     HAS_IMAGEIO = False
-
-
-skip_windows = pytest.mark.skipif(os.name == 'nt', reason='Test fails on Windows')
 
 
 def test_read_raises():
@@ -568,7 +564,7 @@ def test_pvdreader_no_time_group():
         assert dataset.part == i
 
 
-@skip_windows
+@pytest.mark.skip_windows
 def test_pvdreader_no_part_group():
     filename = examples.download_dual_sphere_animation(load=False)  # download all the files
     # Use a pvd file that has no parts and with timesteps.

--- a/tests/plotting/test_actor.py
+++ b/tests/plotting/test_actor.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import platform
-
 import numpy as np
 import pytest
 import scipy
@@ -13,11 +11,6 @@ from pyvista.plotting.prop3d import Prop3D
 from pyvista.plotting.prop3d import _orientation_as_rotation_matrix
 from pyvista.plotting.prop3d import _Prop3DMixin
 from pyvista.plotting.prop3d import _rotation_matrix_as_orientation
-
-skip_mac = pytest.mark.skipif(
-    platform.system() == 'Darwin',
-    reason='MacOS CI fails when downloading examples',
-)
 
 
 @pytest.fixture
@@ -149,7 +142,7 @@ def test_actor_mblock_copy_shallow(actor_from_multi_block):
     assert actor_copy.mapper.dataset is actor_from_multi_block.mapper.dataset
 
 
-@skip_mac
+@pytest.mark.skip_mac('MacOS CI fails when downloading examples')
 def test_actor_texture(actor):
     texture = examples.download_masonry_texture()
     actor.texture = texture

--- a/tests/plotting/test_charts.py
+++ b/tests/plotting/test_charts.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import itertools
-import platform
 import weakref
 
 import numpy as np
@@ -14,11 +13,6 @@ import pyvista as pv
 from pyvista import examples
 from pyvista.plotting import charts
 from pyvista.plotting.colors import COLOR_SCHEMES
-
-skip_mac = pytest.mark.skipif(
-    platform.system() == 'Darwin',
-    reason='MacOS CI fails when downloading examples',
-)
 
 
 @pytest.fixture(autouse=True)
@@ -181,7 +175,7 @@ def test_wrapping():
     assert pen.GetWidth() == width
 
 
-@skip_mac
+@pytest.mark.skip_mac('MacOS CI fails when downloading examples')
 def test_brush():
     c_red, c_blue = (1.0, 0.0, 0.0, 1.0), (0.0, 0.0, 1.0, 1.0)
     t_masonry = examples.download_masonry_texture()
@@ -1227,7 +1221,7 @@ def test_chart_interaction():
     assert pl.iren._context_style.GetScene() is None
 
 
-@skip_mac
+@pytest.mark.skip_mac('MacOS CI fails when downloading examples')
 def test_get_background_texture(chart_2d):
     t_puppy = examples.download_puppy_texture()
     chart_2d.background_texture = t_puppy

--- a/tests/plotting/test_demos.py
+++ b/tests/plotting/test_demos.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import os
-import platform
-
 import numpy as np
 import pytest
 
@@ -36,12 +33,9 @@ def test_logo_voxel():
     assert grid.n_cells
 
 
-@pytest.mark.skipif(
-    platform.system() == 'Darwin',
-    reason='MacOS testing on Azure fails when downloading',
-)
+@pytest.mark.skip_mac('MacOS testing on Azure fails when downloading')
 @skip_no_plotting
-@pytest.mark.skipif(os.name == 'nt', reason='Test fails on Windows')
+@pytest.mark.skip_windows
 def test_plot_logo():
     # simply should not fail
     demos.plot_logo()

--- a/tests/plotting/test_picking.py
+++ b/tests/plotting/test_picking.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import re
 from typing import TYPE_CHECKING
 
@@ -304,7 +303,7 @@ def test_point_picking(left_clicking):
     pv.vtk_version_info < (9, 2, 0),
     reason='Hardware picker unavailable for VTK<9.2',
 )
-@pytest.mark.skipif(os.name == 'nt', reason='Test fails on Windows')
+@pytest.mark.skip_windows
 @pytest.mark.parametrize('pickable_window', [False, True])
 def test_point_picking_window(pickable_window):
     class Tracker:

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -21,13 +21,12 @@ from pyvista.core.errors import MissingDataError
 from pyvista.core.errors import PyVistaDeprecationWarning
 from pyvista.plotting import _plotting
 from pyvista.plotting.errors import RenderWindowUnavailable
-from pyvista.plotting.utilities.gl_checks import uses_egl
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
-@pytest.mark.skipif(uses_egl(), reason='OSMesa/EGL builds will not fail.')
+@pytest.mark.skip_egl('OSMesa/EGL builds will not fail.')
 def test_plotter_image_before_show():
     plotter = pv.Plotter()
     with pytest.raises(AttributeError, match='not yet been set up'):
@@ -51,7 +50,7 @@ def test_render_lines_as_tubes_show_edges_warning(sphere):
     assert actor.prop.render_lines_as_tubes
 
 
-@pytest.mark.skipif(uses_egl(), reason='OSMesa/EGL builds will not fail.')
+@pytest.mark.skip_egl('OSMesa/EGL builds will not fail.')
 def test_screenshot_fail_suppressed_rendering():
     plotter = pv.Plotter()
     plotter.suppress_rendering = True

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -91,7 +91,6 @@ def using_mesa():
 
 # always set on Windows CI
 # These tests fail with mesa opengl on windows
-skip_windows = pytest.mark.skipif(os.name == 'nt', reason='Test fails on Windows')
 skip_windows_mesa = pytest.mark.skipif(
     using_mesa() and os.name == 'nt',
     reason='Does not display correctly within OSMesa on Windows',
@@ -278,7 +277,7 @@ def test_import_obj_with_texture():
     pl.show(cpos='xy')
 
 
-@skip_windows
+@pytest.mark.skip_windows
 @pytest.mark.skipif(CI_WINDOWS, reason='Windows CI testing segfaults on pbr')
 def test_pbr(sphere, verify_image_cache):
     """Test PBR rendering"""
@@ -310,7 +309,7 @@ def test_pbr(sphere, verify_image_cache):
     pl.show()
 
 
-@skip_windows
+@pytest.mark.skip_windows
 @skip_mac
 def test_set_environment_texture_cubemap(sphere, verify_image_cache):
     """Test set_environment_texture with a cubemap."""
@@ -327,7 +326,7 @@ def test_set_environment_texture_cubemap(sphere, verify_image_cache):
     pl.show()
 
 
-@skip_windows
+@pytest.mark.skip_windows
 @skip_mac
 def test_remove_environment_texture_cubemap(sphere):
     """Test remove_environment_texture with a cubemap."""
@@ -1810,7 +1809,7 @@ def test_subplot_groups_fail():
         pv.Plotter(shape=(4, 4), groups=[(1, [1, 2]), ([0, 3], np.s_[:])])
 
 
-@skip_windows
+@pytest.mark.skip_windows
 def test_link_views(sphere):
     plotter = pv.Plotter(shape=(1, 4))
     plotter.subplot(0, 0)
@@ -1833,7 +1832,7 @@ def test_link_views(sphere):
     plotter.show()
 
 
-@skip_windows
+@pytest.mark.skip_windows
 def test_link_views_camera_set(sphere, verify_image_cache):
     p = pv.Plotter(shape=(1, 2))
     p.add_mesh(pv.Cone())
@@ -1971,7 +1970,7 @@ def test_volume_rendering_rectilinear(uniform):
     plotter.close()
 
 
-@skip_windows
+@pytest.mark.skip_windows
 def test_multiblock_volume_rendering(uniform):
     ds_a = uniform.copy()
     ds_b = uniform.copy()
@@ -2049,7 +2048,7 @@ def test_plot_eye_dome_lighting_enable_disable(airplane):
     p.show()
 
 
-@skip_windows
+@pytest.mark.skip_windows
 def test_opacity_by_array_direct(plane, verify_image_cache):
     # VTK regression 9.0.1 --> 9.1.0
     verify_image_cache.high_variance_test = True
@@ -3088,7 +3087,7 @@ def test_plot_categories_true(sphere):
     pl.show()
 
 
-@skip_windows
+@pytest.mark.skip_windows
 @skip_9_0_X
 def test_depth_of_field():
     pl = pv.Plotter()
@@ -3135,7 +3134,7 @@ def test_ssao_pass_from_helper():
     ugrid.plot(ssao=True)
 
 
-@skip_windows
+@pytest.mark.skip_windows
 def test_many_multi_pass():
     pl = pv.Plotter(lighting=None)
     pl.add_mesh(pv.Sphere(), show_edges=True)
@@ -3193,7 +3192,7 @@ def test_plot_composite_preference_cell(multiblock_poly, verify_image_cache):
     multiblock_poly[:2].plot(preference='cell')
 
 
-@skip_windows  # because of opacity
+@pytest.mark.skip_windows('Test fails on Windows because of opacity')
 def test_plot_composite_poly_scalars_opacity(multiblock_poly, verify_image_cache):
     pl = pv.Plotter()
 
@@ -3399,7 +3398,7 @@ def test_bool_scalars(sphere):
     plotter.show()
 
 
-@skip_windows  # because of pbr
+@pytest.mark.skip_windows('Test fails on Windows because of pbr')
 @skip_9_1_0  # pbr required
 def test_property_pbr(verify_image_cache):
     verify_image_cache.macos_skip_image_cache = True
@@ -3667,7 +3666,7 @@ def test_view_xyz(direction, negative, colorful_tetrahedron):
     pl.show()
 
 
-@skip_windows
+@pytest.mark.skip_windows
 def test_plot_points_gaussian(sphere):
     sphere.plot(
         color='r',
@@ -3678,7 +3677,7 @@ def test_plot_points_gaussian(sphere):
     )
 
 
-@skip_windows
+@pytest.mark.skip_windows
 def test_plot_points_gaussian_scalars(sphere):
     sphere.plot(
         scalars=sphere.points[:, 2],
@@ -3690,7 +3689,7 @@ def test_plot_points_gaussian_scalars(sphere):
     )
 
 
-@skip_windows
+@pytest.mark.skip_windows
 def test_plot_points_gaussian_as_spheres(sphere):
     sphere.plot(
         color='b',
@@ -3702,7 +3701,7 @@ def test_plot_points_gaussian_as_spheres(sphere):
     )
 
 
-@skip_windows
+@pytest.mark.skip_windows
 def test_plot_points_gaussian_scale(sphere):
     sphere['z'] = sphere.points[:, 2] * 0.1
     pl = pv.Plotter()
@@ -3781,7 +3780,7 @@ def test_remove_vertices_actor(sphere):
     pl.show()
 
 
-@skip_windows
+@pytest.mark.skip_windows
 def test_add_point_scalar_labels_fmt():
     mesh = examples.load_uniform().slice()
     p = pv.Plotter()
@@ -4809,7 +4808,7 @@ def test_contour_labels_compare_select_inputs_select_outputs(
     plot.show()
 
 
-@skip_windows  # Windows colors all plane cells red (bug?)
+@pytest.mark.skip_windows('Windows colors all plane cells red (bug?)')
 @pytest.mark.parametrize('normal_sign', ['+', '-'])
 @pytest.mark.parametrize('plane', ['yz', 'zx', 'xy'])
 def test_orthogonal_planes_source_normals(normal_sign, plane):
@@ -4835,7 +4834,7 @@ def test_orthogonal_planes_source_push(distance):
 
 
 # Add skips since Plane's edges differ (e.g. triangles instead of quads)
-@skip_windows
+@pytest.mark.skip_windows
 @skip_9_1_0
 @pytest.mark.parametrize(
     'resolution',
@@ -4848,7 +4847,7 @@ def test_orthogonal_planes_source_resolution(resolution):
 
 
 @skip_9_1_0
-@skip_windows
+@pytest.mark.skip_windows
 @pytest.mark.parametrize(
     ('name', 'value'),
     [

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -89,9 +89,9 @@ def using_mesa():
 
 # always set on Windows CI
 # These tests fail with mesa opengl on windows
-skip_windows_mesa = pytest.mark.skipif(
-    using_mesa() and os.name == 'nt',
-    reason='Does not display correctly within OSMesa on Windows',
+skip_mesa = pytest.mark.skipif(using_mesa(), reason='Does not display correctly within OSMesa')
+skip_windows_mesa = skip_mesa and pytest.mark.skip_windows(
+    'Does not display correctly within OSMesa on Windows'
 )
 skip_9_1_0 = pytest.mark.needs_vtk_version(9, 1, 0)
 skip_9_0_X = pytest.mark.skipif(pv.vtk_version_info < (9, 1), reason='Flaky on 9.0.X')
@@ -105,8 +105,6 @@ skip_lesser_9_3_X = pytest.mark.skipif(
 )
 
 CI_WINDOWS = os.environ.get('CI_WINDOWS', 'false').lower() == 'true'
-
-skip_mesa = pytest.mark.skipif(using_mesa(), reason='Does not display correctly within OSMesa')
 
 
 @pytest.fixture(autouse=True)

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -40,7 +40,6 @@ from pyvista.plotting.plotter import SUPPORTED_FORMATS
 import pyvista.plotting.text
 from pyvista.plotting.texture import numpy_to_texture
 from pyvista.plotting.utilities import algorithms
-from pyvista.plotting.utilities.gl_checks import uses_egl
 from tests.core.test_imagedata_filters import labeled_image  # noqa: F401
 
 if TYPE_CHECKING:
@@ -4023,10 +4022,7 @@ def test_plot_cubemap_alone(cubemap, verify_image_cache):
     cubemap.plot()
 
 
-@pytest.mark.skipif(
-    uses_egl(),
-    reason='Render window will be current with offscreen builds of VTK.',
-)
+@pytest.mark.skip_egl(reason='Render window will be current with offscreen builds of VTK.')
 def test_not_current(verify_image_cache):
     verify_image_cache.skip = True
 

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -108,14 +108,6 @@ skip_lesser_9_3_X = pytest.mark.skipif(
 
 CI_WINDOWS = os.environ.get('CI_WINDOWS', 'false').lower() == 'true'
 
-skip_mac = pytest.mark.skipif(
-    platform.system() == 'Darwin',
-    reason='MacOS CI fails when downloading examples',
-)
-skip_mac_flaky = pytest.mark.skipif(
-    platform.system() == 'Darwin',
-    reason='This is a flaky test on MacOS',
-)
 skip_mesa = pytest.mark.skipif(using_mesa(), reason='Does not display correctly within OSMesa')
 
 
@@ -310,7 +302,7 @@ def test_pbr(sphere, verify_image_cache):
 
 
 @pytest.mark.skip_windows
-@skip_mac
+@pytest.mark.skip_mac('MacOS CI fails when downloading examples')
 def test_set_environment_texture_cubemap(sphere, verify_image_cache):
     """Test set_environment_texture with a cubemap."""
     verify_image_cache.high_variance_test = True
@@ -327,7 +319,7 @@ def test_set_environment_texture_cubemap(sphere, verify_image_cache):
 
 
 @pytest.mark.skip_windows
-@skip_mac
+@pytest.mark.skip_mac('MacOS CI fails when downloading examples')
 def test_remove_environment_texture_cubemap(sphere):
     """Test remove_environment_texture with a cubemap."""
     texture = examples.download_sky_box_cube_map()
@@ -2673,7 +2665,7 @@ def test_collision_plot(verify_image_cache):
     plotter.show()
 
 
-@skip_mac
+@pytest.mark.skip_mac('MacOS CI fails when downloading examples')
 @pytest.mark.needs_vtk_version(9, 2, 0)
 def test_chart_plot():
     """Basic test to verify chart plots correctly"""
@@ -2842,7 +2834,7 @@ def test_plot_normals_smooth_shading(sphere, use_custom_normals, smooth_shading)
     sphere.plot_normals(show_mesh=True, color='red', smooth_shading=smooth_shading)
 
 
-@skip_mac_flaky
+@pytest.mark.skip_mac('This is a flaky test on MacOS')
 def test_splitting_active_cells(cube):
     cube.cell_data['cell_id'] = range(cube.n_cells)
     cube = cube.triangulate().subdivide(1)

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -2018,12 +2018,12 @@ def test_plot_depth_peeling():
     p.show()
 
 
-@pytest.mark.skipif(os.name == 'nt', reason='No testing on windows for EDL')
+@pytest.mark.skip_windows('No testing on windows for EDL')
 def test_plot_eye_dome_lighting_plot(airplane):
     airplane.plot(eye_dome_lighting=True)
 
 
-@pytest.mark.skipif(os.name == 'nt', reason='No testing on windows for EDL')
+@pytest.mark.skip_windows('No testing on windows for EDL')
 def test_plot_eye_dome_lighting_plotter(airplane):
     p = pv.Plotter()
     p.add_mesh(airplane)
@@ -2031,7 +2031,7 @@ def test_plot_eye_dome_lighting_plotter(airplane):
     p.show()
 
 
-@pytest.mark.skipif(os.name == 'nt', reason='No testing on windows for EDL')
+@pytest.mark.skip_windows('No testing on windows for EDL')
 def test_plot_eye_dome_lighting_enable_disable(airplane):
     p = pv.Plotter()
     p.add_mesh(airplane)

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -11,7 +11,6 @@ import io
 import os
 import pathlib
 from pathlib import Path
-import platform
 import re
 import time
 from types import FunctionType
@@ -4933,11 +4932,8 @@ def oblique_cone():
     return pv.examples.download_oblique_cone()
 
 
-is_arm_mac = platform.system() == 'Darwin' and platform.machine() == 'arm64'
-
-
-@pytest.mark.skipif(
-    is_arm_mac, reason='Barely exceeds error threshold (slightly different rendering).'
+@pytest.mark.skip_mac(
+    'Barely exceeds error threshold (slightly different rendering).', machine='arm64'
 )
 @pytest.mark.parametrize('box_style', ['outline', 'face', 'frame'])
 def test_bounding_box(oblique_cone, box_style):

--- a/tests/plotting/test_theme.py
+++ b/tests/plotting/test_theme.py
@@ -16,7 +16,6 @@ import pyvista.plotting
 from pyvista.plotting.themes import DarkTheme
 from pyvista.plotting.themes import Theme
 from pyvista.plotting.themes import _set_plot_theme_from_env
-from pyvista.plotting.utilities.gl_checks import uses_egl
 
 
 @pytest.fixture
@@ -541,7 +540,7 @@ def test_anti_aliasing(default_theme):
         default_theme.anti_aliasing = 42
 
 
-@pytest.mark.skipif(uses_egl(), reason='Requires non-OSMesa/EGL VTK build.')
+@pytest.mark.skip_egl('Requires non-OSMesa/EGL VTK build.')
 def test_anti_aliasing_fxaa(default_theme):
     default_theme.anti_aliasing = 'fxaa'
     assert default_theme.anti_aliasing == 'fxaa'

--- a/tests/plotting/test_tinypages.py
+++ b/tests/plotting/test_tinypages.py
@@ -23,7 +23,7 @@ ENVIRONMENT_HOOKS = ['PLOT_SKIP', 'PLOT_SKIP_OPTIONAL']
 
 
 @flaky_test(exceptions=(AssertionError,))
-@pytest.mark.skipif(os.name == 'nt', reason='path issues on Azure Windows CI')
+@pytest.mark.skip_windows('path issues on Azure Windows CI')
 @pytest.mark.parametrize('ename', ENVIRONMENT_HOOKS)
 @pytest.mark.parametrize('evalue', [False, True])
 def test_tinypages(tmp_path, ename, evalue):

--- a/tests/plotting/test_utilities.py
+++ b/tests/plotting/test_utilities.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import platform
 import re
 from typing import TYPE_CHECKING
 
@@ -16,14 +15,9 @@ from pyvista.plotting.utilities import xvfb
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
-skip_mac = pytest.mark.skipif(
-    platform.system() == 'Darwin',
-    reason='MacOS CI fails when downloading examples',
-)
-
 
 @pytest.mark.skip_windows
-@skip_mac
+@pytest.mark.skip_mac
 def test_start_xvfb():
     with pytest.warns(PyVistaDeprecationWarning):
         pv.start_xvfb()

--- a/tests/plotting/test_utilities.py
+++ b/tests/plotting/test_utilities.py
@@ -16,14 +16,13 @@ from pyvista.plotting.utilities import xvfb
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
-skip_windows = pytest.mark.skipif(os.name == 'nt', reason='Test fails on Windows')
 skip_mac = pytest.mark.skipif(
     platform.system() == 'Darwin',
     reason='MacOS CI fails when downloading examples',
 )
 
 
-@skip_windows
+@pytest.mark.skip_windows
 @skip_mac
 def test_start_xvfb():
     with pytest.warns(PyVistaDeprecationWarning):

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -255,6 +255,12 @@ def test_skip_windows(
     results = pytester.runpytest(p)
 
     results.assert_outcomes(skipped=1, passed=1, errors=1)
+    results.stdout.re_match_lines(
+        [
+            r'.*Marker `skip_windows` called with incorrect arguments\.',
+            r".*Signature should be: @pytest\.mark\.skip_windows\(reason: str = 'Test fails on Windows'\)",
+        ]
+    )
 
     results = results_parser.parse(results=results)
     report = RunResultsReport(results)
@@ -311,6 +317,13 @@ def test_skip_mac(
 
     p = pytester.makepyfile(tests)
     results = pytester.runpytest(p)
+
+    results.stdout.re_match_lines(
+        [
+            r'.*Marker `skip_mac` called with incorrect arguments\.',
+            r'.*Signature should be: @pytest\.mark\.skip_mac\(reason.*processor.*machine.*\)',
+        ]
+    )
 
     skipped = 1
     skipped += 1 if (processor is not None and machine is not None) else 0

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -271,14 +271,6 @@ def test_skip_windows(
 
 
 @pytest.fixture
-def _patch_mac_system(mocker: MockerFixture):
-    import platform
-
-    m = mocker.patch.object(platform, 'system')
-    m.return_value = 'Darwin'
-
-
-@pytest.fixture
 def _patch_uses_egl(mocker: MockerFixture):
     from pyvista.plotting.utilities import gl_checks
 
@@ -339,6 +331,14 @@ def test_skip_egl(
     assert 'test_skipped_message_args' in report.skipped
     assert 'test_skipped_message' in report.skipped
     assert 'test_skipped_wrong' in report.error
+
+
+@pytest.fixture
+def _patch_mac_system(mocker: MockerFixture):
+    import platform
+
+    m = mocker.patch.object(platform, 'system')
+    m.return_value = 'Darwin'
 
 
 @pytest.mark.usefixtures('_patch_mac_system')


### PR DESCRIPTION
### Overview

This PR factorizes `skipif` test markers for OS specific (currently only mac and windows are concerned) and for EGL VTK builds.

More specifically, it enables the following usage:
```python
import pytest

@pytest.mark.skip_windows
@pytest.mark.skip_mac
def test_skipped(): ...

@pytest.mark.skip_windows(reason="foo")
@pytest.mark.skip_mac(reason="foo")
def test_skipped_2(): ...

@pytest.mark.skip_windows("bar")
@pytest.mark.skip_mac("bar")
def test_skipped_3(): ...

@pytest.mark.skip_mac("bar", processor="arm")
def test_skipped_4(): ...

@pytest.mark.skip_mac("bar", machine="arm64")
def test_skipped_5(): ...

@pytest.mark.skip_egl("Not working with EGL")
def test_skipped_6(): ...

skip_windows_egl = pytest.mark.skip_windows and pytest.mark.skip_egl

@skip_windows_egl
def test_skipped_7(): ...

```