### PR TITLE
Skip plotting examples which use `set_environment_texture`

### DIFF
--- a/examples/00-load/load_gltf.py
+++ b/examples/00-load/load_gltf.py
@@ -30,11 +30,11 @@ texture = examples.download_dikhololo_night()
 # sphinx_gallery_start_ignore
 PYVISTA_GALLERY_FORCE_STATIC = True
 # sphinx_gallery_end_ignore
-pl = pyvista.Plotter()
-pl.import_gltf(helmet_file)
-pl.set_environment_texture(texture)
-pl.camera.zoom(1.7)
-pl.show()
+# pl = pyvista.Plotter()
+# pl.import_gltf(helmet_file)
+# pl.set_environment_texture(texture)
+# pl.camera.zoom(1.7)
+# pl.show()
 
 
 # %%

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -4277,11 +4277,11 @@ def download_sky_box_cube_map(load=True):  # pragma: no cover
     --------
     >>> from pyvista import examples
     >>> import pyvista as pv
-    >>> pl = pv.Plotter()
-    >>> dataset = examples.download_sky_box_cube_map()
-    >>> _ = pl.add_actor(dataset.to_skybox())
-    >>> pl.set_environment_texture(dataset)
-    >>> pl.show()
+    >>> pl = pv.Plotter()  # doctest:+SKIP
+    >>> dataset = examples.download_sky_box_cube_map()  # doctest:+SKIP
+    >>> _ = pl.add_actor(dataset.to_skybox())  # doctest:+SKIP
+    >>> pl.set_environment_texture(dataset)  # doctest:+SKIP
+    >>> pl.show()  # doctest:+SKIP
 
     .. seealso::
 
@@ -4345,14 +4345,17 @@ def download_cubemap_park(load=True):  # pragma: no cover
     --------
     >>> from pyvista import examples
     >>> import pyvista as pv
-    >>> pl = pv.Plotter(lighting=None)
     >>> dataset = examples.download_cubemap_park()
-    >>> _ = pl.add_actor(dataset.to_skybox())
-    >>> pl.set_environment_texture(dataset, True)
-    >>> pl.camera_position = 'xy'
-    >>> pl.camera.zoom(0.4)
-    >>> _ = pl.add_mesh(pv.Sphere(), pbr=True, roughness=0.1, metallic=0.5)
-    >>> pl.show()
+    >>>
+    >>> pl = pv.Plotter(lighting=None)  # doctest:+SKIP
+    >>> _ = pl.add_actor(dataset.to_skybox())  # doctest:+SKIP
+    >>> pl.set_environment_texture(dataset, True)  # doctest:+SKIP
+    >>> pl.camera_position = 'xy'  # doctest:+SKIP
+    >>> pl.camera.zoom(0.4)  # doctest:+SKIP
+    >>> _ = pl.add_mesh(
+    ...     pv.Sphere(), pbr=True, roughness=0.1, metallic=0.5
+    ... )  # doctest:+SKIP
+    >>> pl.show()  # doctest:+SKIP
 
     .. seealso::
 
@@ -4405,12 +4408,14 @@ def download_cubemap_space_4k(load=True):  # pragma: no cover
     >>> import pyvista as pv
     >>> from pyvista import examples
     >>> cubemap = examples.download_cubemap_space_4k()
-    >>> pl = pv.Plotter(lighting=None)
-    >>> _ = pl.add_actor(cubemap.to_skybox())
-    >>> pl.set_environment_texture(cubemap, True)
-    >>> pl.camera.zoom(0.4)
-    >>> _ = pl.add_mesh(pv.Sphere(), pbr=True, roughness=0.24, metallic=1.0)
-    >>> pl.show()
+    >>> pl = pv.Plotter(lighting=None)  # doctest:+SKIP
+    >>> _ = pl.add_actor(cubemap.to_skybox())  # doctest:+SKIP
+    >>> pl.set_environment_texture(cubemap, True)  # doctest:+SKIP
+    >>> pl.camera.zoom(0.4)  # doctest:+SKIP
+    >>> _ = pl.add_mesh(
+    ...     pv.Sphere(), pbr=True, roughness=0.24, metallic=1.0
+    ... )  # doctest:+SKIP
+    >>> pl.show()  # doctest:+SKIP
 
     .. seealso::
 
@@ -4469,12 +4474,14 @@ def download_cubemap_space_16k(load=True):  # pragma: no cover
     >>> import pyvista as pv
     >>> from pyvista import examples
     >>> cubemap = examples.download_cubemap_space_4k()
-    >>> pl = pv.Plotter(lighting=None)
-    >>> _ = pl.add_actor(cubemap.to_skybox())
-    >>> pl.set_environment_texture(cubemap, True)
-    >>> pl.camera.zoom(0.4)
-    >>> _ = pl.add_mesh(pv.Sphere(), pbr=True, roughness=0.24, metallic=1.0)
-    >>> pl.show()
+    >>> pl = pv.Plotter(lighting=None)  # doctest:+SKIP
+    >>> _ = pl.add_actor(cubemap.to_skybox())  # doctest:+SKIP
+    >>> pl.set_environment_texture(cubemap, True)  # doctest:+SKIP
+    >>> pl.camera.zoom(0.4)  # doctest:+SKIP
+    >>> _ = pl.add_mesh(
+    ...     pv.Sphere(), pbr=True, roughness=0.24, metallic=1.0
+    ... )  # doctest:+SKIP
+    >>> pl.show()  # doctest:+SKIP
 
     .. seealso::
 
@@ -7199,10 +7206,10 @@ def download_dikhololo_night(load=True):  # pragma: no cover
     >>> from pyvista import examples
     >>> gltf_file = examples.gltf.download_damaged_helmet()
     >>> texture = examples.download_dikhololo_night()
-    >>> pl = pv.Plotter()
-    >>> pl.import_gltf(gltf_file)
-    >>> pl.set_environment_texture(texture)
-    >>> pl.show()
+    >>> pl = pv.Plotter()  # doctest:+SKIP
+    >>> pl.import_gltf(gltf_file)  # doctest:+SKIP
+    >>> pl.set_environment_texture(texture)  # doctest:+SKIP
+    >>> pl.show()  # doctest:+SKIP
 
     .. seealso::
 

--- a/pyvista/examples/gltf.py
+++ b/pyvista/examples/gltf.py
@@ -36,10 +36,10 @@ def download_damaged_helmet():  # pragma: no cover
     >>> from pyvista import examples
     >>> gltf_file = examples.gltf.download_damaged_helmet()
     >>> cubemap = examples.download_sky_box_cube_map()
-    >>> pl = pv.Plotter()
-    >>> pl.import_gltf(gltf_file)
-    >>> pl.set_environment_texture(cubemap)
-    >>> pl.show()
+    >>> pl = pv.Plotter()  # doctest:+SKIP
+    >>> pl.import_gltf(gltf_file)  # doctest:+SKIP
+    >>> pl.set_environment_texture(cubemap)  # doctest:+SKIP
+    >>> pl.show()  # doctest:+SKIP
 
     """
     return GLTF_FETCHER.fetch('DamagedHelmet/glTF-Embedded/DamagedHelmet.gltf')

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -3540,12 +3540,14 @@ class Renderer(_vtk.vtkOpenGLRenderer):
 
         >>> from pyvista import examples
         >>> import pyvista as pv
-        >>> pl = pv.Plotter(lighting=None)
-        >>> cubemap = examples.download_sky_box_cube_map()
-        >>> _ = pl.add_mesh(pv.Sphere(), pbr=True, metallic=0.9, roughness=0.4)
-        >>> pl.set_environment_texture(cubemap)
-        >>> pl.camera_position = 'xy'
-        >>> pl.show()
+        >>> pl = pv.Plotter(lighting=None)  # doctest:+SKIP
+        >>> cubemap = examples.download_sky_box_cube_map()  # doctest:+SKIP
+        >>> _ = pl.add_mesh(
+        ...     pv.Sphere(), pbr=True, metallic=0.9, roughness=0.4
+        ... )  # doctest:+SKIP
+        >>> pl.set_environment_texture(cubemap)  # doctest:+SKIP
+        >>> pl.camera_position = 'xy'  # doctest:+SKIP
+        >>> pl.show()  # doctest:+SKIP
 
         """
         # cube_map textures cannot use spherical harmonics
@@ -3567,12 +3569,14 @@ class Renderer(_vtk.vtkOpenGLRenderer):
         >>> from pyvista import examples
         >>> import pyvista as pv
         >>> pl = pv.Plotter(lighting=None)
-        >>> cubemap = examples.download_sky_box_cube_map()
-        >>> _ = pl.add_mesh(pv.Sphere(), pbr=True, metallic=0.9, roughness=0.4)
-        >>> pl.set_environment_texture(cubemap)
-        >>> pl.remove_environment_texture()
-        >>> pl.camera_position = 'xy'
-        >>> pl.show()
+        >>> cubemap = examples.download_sky_box_cube_map()  # doctest:+SKIP
+        >>> _ = pl.add_mesh(
+        ...     pv.Sphere(), pbr=True, metallic=0.9, roughness=0.4
+        ... )  # doctest:+SKIP
+        >>> pl.set_environment_texture(cubemap)  # doctest:+SKIP
+        >>> pl.remove_environment_texture()  # doctest:+SKIP
+        >>> pl.camera_position = 'xy'  # doctest:+SKIP
+        >>> pl.show()  # doctest:+SKIP
 
         """
         self.UseImageBasedLightingOff()


### PR DESCRIPTION
### Overview

This method seems to hang in CI and increases docstring tests times and doc build times considerable. See https://github.com/pyvista/pyvista/pull/6993#issuecomment-2548444061