### PR TITLE
Add default interaction style to theme

### DIFF
--- a/pyvista/plotting/opts.py
+++ b/pyvista/plotting/opts.py
@@ -83,3 +83,18 @@ class PickerType(AnnotatedIntEnum):
     SCENE = (7, 'Scene')
     VOLUME = (8, 'Volume')
     WORLD = (9, 'World')
+
+
+class InteractionStyle(AnnotatedIntEnum):
+    """Types of pre-defined interaction styles."""
+
+    TRACKBALL = (0, 'Trackball')
+    TRACKBALL_ACTOR = (1, 'Trackball Actor')
+    TWO_D = (2, '2D')
+    JOYSTICK = (3, 'Joystick')
+    JOYSTICK_ACTOR = (4, 'Joystick Actor')
+    IMAGE = (5, 'Image')
+    RUBBERBAND = (6, 'RubberBand')
+    RUBBERBAND_2D = (7, 'RubberBand 2D')
+    TERRAIN = (8, 'Terrain')
+    ZOOM = (9, 'Zoom')

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -91,6 +91,8 @@ if TYPE_CHECKING:
     from pyvista.core._typing_core import BoundsTuple
     from pyvista.plotting.cube_axes_actor import CubeAxesActor
 
+    from .opts import InteractionStyle
+
 SUPPORTED_FORMATS = ['.png', '.jpeg', '.jpg', '.bmp', '.tif', '.tiff']
 
 # EXPERIMENTAL: permit pyvista to kill the render window
@@ -2323,6 +2325,13 @@ class BasePlotter(PickingHelper, WidgetHelper):
     def enable_2d_style(self) -> None:  # numpydoc ignore=PR01,RT01
         """Wrap RenderWindowInteractor.enable_2d_style."""
         self.iren.enable_2d_style()  # type: ignore[has-type]
+
+    @wraps(RenderWindowInteractor.enable_interaction_style)
+    def enable_interaction_style(
+        self, style: InteractionStyle | None = None
+    ) -> None:  # numpydoc ignore=PR01,RT01
+        """Wrap RenderWindowInteractor.enable_interaction_style."""
+        self.iren.enable_interaction_style(style=style)  # type: ignore[has-type]
 
     def enable_stereo_render(self) -> None:
         """Enable anaglyph stereo rendering.
@@ -6723,7 +6732,7 @@ class Plotter(BasePlotter):
         self.iren = RenderWindowInteractor(self, light_follow_camera=False, interactor=interactor)
         self.iren.set_render_window(self.render_window)
         self.reset_key_events()
-        self.enable_trackball_style()  # type: ignore[call-arg] # internally calls update_style()
+        self.enable_interaction_style()
         self.iren.add_observer('KeyPressEvent', self.key_press_event)
 
         # Set camera widget based on theme. This requires that an

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -13,11 +13,13 @@ import weakref
 
 import numpy as np
 
+import pyvista
 from pyvista import vtk_version_info
 from pyvista.core.errors import PyVistaDeprecationWarning
 from pyvista.core.utilities.misc import try_callback
 
 from . import _vtk
+from .opts import InteractionStyle
 from .opts import PickerType
 
 log = logging.getLogger(__name__)
@@ -1138,6 +1140,46 @@ class RenderWindowInteractor:
         self._style = 'RubberBand2D'
         self._style_class = None
         self.update_style()
+
+    def enable_interaction_style(self, style: InteractionStyle | None = None):
+        """Set the interactive style to a pre-defined mode.
+
+        Parameters
+        ----------
+        style : InteractionStyle
+            The pre-defined interaction style.
+
+        """
+        if style is None:
+            if plotter := self._plotter:
+                style = plotter._theme.interaction_style
+            else:
+                style = pyvista.global_theme.interaction_style
+        style = InteractionStyle.from_any(style)
+        match style:
+            case InteractionStyle.TRACKBALL:
+                self.enable_trackball_style()
+            case InteractionStyle.TRACKBALL_ACTOR:
+                self.enable_trackball_actor_style()
+            case InteractionStyle.TWO_D:
+                self.enable_2d_style()
+            case InteractionStyle.JOYSTICK:
+                self.enable_joystick_style()
+            case InteractionStyle.JOYSTICK_ACTOR:
+                self.enable_joystick_actor_style()
+            case InteractionStyle.IMAGE:
+                self.enable_image_style()
+            case InteractionStyle.RUBBERBAND:
+                self.enable_rubber_band_style()
+            case InteractionStyle.RUBBERBAND_2D:
+                self.enable_rubber_band_2d_style()
+            case InteractionStyle.TERRAIN:
+                self.enable_terrain_style()
+            case InteractionStyle.ZOOM:
+                self.enable_zoom_style()
+            case _:
+                msg = f'Unknown interaction style: {style}'
+                raise ValueError(msg)
 
     def _simulate_keypress(self, key):
         """Simulate a keypress."""

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -48,6 +48,7 @@ from pyvista.core.utilities.misc import _check_range
 from .colors import Color
 from .colors import get_cmap_safe
 from .colors import get_cycler
+from .opts import InteractionStyle
 from .opts import InterpolationType
 from .tools import parse_font_family
 
@@ -1743,6 +1744,7 @@ class Theme(_ThemeConfig):
         '_full_screen',
         '_hidden_line_removal',
         '_image_scale',
+        '_interaction_style',
         '_interactive',
         '_interpolate_before_map',
         '_jupyter_backend',
@@ -1857,6 +1859,8 @@ class Theme(_ThemeConfig):
         self._edge_opacity = 1.0
 
         self._logo_file = None
+
+        self._interaction_style = InteractionStyle.TRACKBALL
 
     @property
     def hidden_line_removal(self) -> bool:  # numpydoc ignore=RT01
@@ -3242,6 +3246,38 @@ class Theme(_ThemeConfig):
                 raise FileNotFoundError(msg)
             path = str(logo_file)
         self._logo_file = path
+
+    @property
+    def interaction_style(self) -> InteractionStyle:
+        """Return or set the default interaction style.
+
+        Returns
+        -------
+        InteractionStyle
+            The default interaction style.
+
+        Examples
+        --------
+        Set the default interaction style to ``'trackball'``.
+        >>> import pyvista as pv
+        >>> from pyvista import examples
+        >>> from pyvista.plotting.opts import InteractionStyle
+        >>> pv.global_theme.interaction_style = InteractionStyle.TERRAIN
+
+        Now the default interaction style is set to terrain style.
+
+        >>> mesh = examples.download_st_helens().warp_by_scalar()
+        >>> pl = pv.Plotter()
+        >>> pl.add_mesh(mesh, show_edges=True)
+        >>> pl.show()
+
+        """
+        return self._interaction_style
+
+    @interaction_style.setter
+    def interaction_style(self, interaction_style: InteractionStyle):
+        """Set the default interaction style."""
+        self._interaction_style = InteractionStyle.from_any(interaction_style)
 
 
 class DarkTheme(Theme):


### PR DESCRIPTION
I have a personal preference for using Terrain Style interaction mode anytime I'm plotting with PyVista. So much so, that I have my own subclass of `Plotter` that sets `enable_terrain_style()` by default. I've been wanting for this to be a global theme option for a while and figured I'd implement it as a global theme configuration.

This adds a new enum type for the various interaction styles and a new `enable_interaction_style` to quickly enable a type by name.

I intentionally did not set up a mode for getting the interaction type of the `RenderWindowInteractor` as many of these are custom modifications. I figured this would be just for setting the interaction style to a limited set of pre-defined modes.

I don't really have the time to take this any further such as more tests and I welcome anyone else to contribute directly to this pull request if interested in helping land this