### PR TITLE
Add arguments to `needs_vtk_version` custom marker test 

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -535,7 +535,7 @@ if no simple alternative solution has been found.
 
 The CI is configured to test multiple vtk versions to ensure sufficient compatibility with vtk.
 If needed, the minimum and/or maximum vtk version needed by a specific test can be controlled with a
-custom pytest marker ``needs_vtk_version``, enabling the following usage:
+custom pytest marker ``needs_vtk_version``, enabling the following usage (note the inclusive and exclusive signs):
 
 .. code-block:: python
 
@@ -554,7 +554,7 @@ custom pytest marker ``needs_vtk_version``, enabling the following usage:
         """Test is skipped if pv.vtk_version_info >= (9,1)"""
 
 
-    @pytest.mark.needs_vtk_version(greater_than=(8, 2), less_than=(9, 1))
+    @pytest.mark.needs_vtk_version(at_least=(8, 2), less_than=(9, 1))
     def test():
         """Test is skipped if pv.vtk_version_info >= (9,1) or pv.vtk_version_info < (8,2,0)"""
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -549,17 +549,17 @@ custom pytest marker ``needs_vtk_version``, enabling the following usage:
         """Test is skipped if pv.vtk_version_info < (9,1)"""
 
 
-    @pytest.mark.needs_vtk_version(max=(9, 1))
+    @pytest.mark.needs_vtk_version(less_than=(9, 1))
     def test():
         """Test is skipped if pv.vtk_version_info >= (9,1)"""
 
 
-    @pytest.mark.needs_vtk_version(8, 2, max=(9, 1))
+    @pytest.mark.needs_vtk_version(greater_than=(8, 2), less_than=(9, 1))
     def test():
         """Test is skipped if pv.vtk_version_info >= (9,1) or pv.vtk_version_info < (8,2,0)"""
 
 
-    @pytest.mark.needs_vtk_version(max=(9, 1))
+    @pytest.mark.needs_vtk_version(less_than=(9, 1))
     @pytest.mark.needs_vtk_version(8, 2)
     def test():
         """Test is skipped if pv.vtk_version_info >= (9,1) or pv.vtk_version_info < (8,2,0)"""

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -533,6 +533,43 @@ for more details.
 However, code coverage exclusion should rarely be used and has to be carefully justified in the PR thread
 if no simple alternative solution has been found.
 
+The CI is configured to test multiple vtk versions to ensure sufficient compatibility with vtk.
+If needed, the minimum and/or maximum vtk version needed by a specific test can be controlled with a
+custom pytest marker ``needs_vtk_version``, enabling the following usage:
+
+.. code-block:: python
+
+    @pytest.mark.needs_vtk_version(9, 1)
+    def test():
+        """Test is skipped if pv.vtk_version_info < (9,1)"""
+
+
+    @pytest.mark.needs_vtk_version((9, 1))
+    def test():
+        """Test is skipped if pv.vtk_version_info < (9,1)"""
+
+
+    @pytest.mark.needs_vtk_version(max=(9, 1))
+    def test():
+        """Test is skipped if pv.vtk_version_info >= (9,1)"""
+
+
+    @pytest.mark.needs_vtk_version(8, 2, max=(9, 1))
+    def test():
+        """Test is skipped if pv.vtk_version_info >= (9,1) or pv.vtk_version_info < (8,2,0)"""
+
+
+    @pytest.mark.needs_vtk_version(max=(9, 1))
+    @pytest.mark.needs_vtk_version(8, 2)
+    def test():
+        """Test is skipped if pv.vtk_version_info >= (9,1) or pv.vtk_version_info < (8,2,0)"""
+
+
+    @pytest.mark.needs_vtk_version(9, 1, reason='custom reason')
+    def test():
+        """Test is skipped with a custom message"""
+
+
 Docstring Testing
 ~~~~~~~~~~~~~~~~~
 Run all code examples in the docstrings with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,7 +226,7 @@ junit_family = 'legacy'
 log_cli_level = "INFO"
 markers = [
   'needs_download: this test downloads data during execution',
-  'needs_vtk_version(min, max, reason): skip test unless VTK version corresponds to min and max values.',
+  'needs_vtk_version(at_least, less_than, reason): skip test unless VTK version corresponds to at_least and greater_than values.',
   'skip_egl(reason="Test fails when using OSMesa/EGL VTK build"): skip test for OSMesa/EGL.',
   'skip_mac(reason="Test fails on MacOS", machine=None, processor=None): skip test for MacOS and specific architectures if needed',
   'skip_windows(reason="Test fails on Windows"): skip test for windows.',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,7 +226,7 @@ junit_family = 'legacy'
 log_cli_level = "INFO"
 markers = [
   'needs_download: this test downloads data during execution',
-  'needs_vtk_version(version): skip test unless VTK version is at least as specified.',
+  'needs_vtk_version(min, max, reason): skip test unless VTK version corresponds to min and max values.',
   'skip_egl(reason="Test fails when using OSMesa/EGL VTK build"): skip test for OSMesa/EGL.',
   'skip_mac(reason="Test fails on MacOS", machine=None, processor=None): skip test for MacOS and specific architectures if needed',
   'skip_windows(reason="Test fails on Windows"): skip test for windows.',

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -568,6 +568,9 @@ class VersionInfo(NamedTuple):
     minor: int
     micro: int
 
+    def __str__(self):
+        return str((self.major, self.minor, self.micro))
+
 
 def VTKVersionInfo():
     """Return the vtk version as a namedtuple.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -339,21 +339,19 @@ def _get_min_max_vtk_version(
         return val + (0,) * (expected - l)
 
     # Distinguish scenarios from positional arguments
-    if (len(args := bounds.arguments['args']) > 0) and (
-        bounds.arguments['greater_than'] is not None
-    ):
-        msg = f'Cannot specify both *args and `greater_than` keyword argument to `{item_mark.name}` marker.'
+    if (len(args := bounds.arguments['args']) > 0) and (bounds.arguments['at_least'] is not None):
+        msg = f'Cannot specify both *args and `at_least` keyword argument to `{item_mark.name}` marker.'
         raise ValueError(msg)
 
     if len(args) > 0:
         min_version = args[0] if len(args) == 1 and isinstance(args[0], tuple) else args
         return _pad_version(min_version), _pad_version(bounds.arguments['less_than']), bounds
 
-    _min = bounds.arguments['greater_than']
+    _min = bounds.arguments['at_least']
     _max = bounds.arguments['less_than']
 
     if _max is None and _min is None:
-        msg = f'Need to specify either `greater_than` or `less_than` keyword arguments to `{item_mark.name}` marker.'
+        msg = f'Need to specify either `at_least` or `less_than` keyword arguments to `{item_mark.name}` marker.'
         raise ValueError(msg)
 
     return _pad_version(_min), _pad_version(_max), bounds
@@ -375,7 +373,7 @@ def pytest_runtest_setup(item: pytest.Item):
                     annotation=Union[int, tuple[int]],
                 ),
                 Parameter(
-                    'greater_than',
+                    'at_least',
                     kind=Parameter.KEYWORD_ONLY,
                     annotation=Optional[tuple[int]],
                     default=None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import functools
 from importlib import metadata
+from inspect import BoundArguments
 from inspect import Parameter
 from inspect import Signature
 import os
 import platform
 import re
+from typing import Optional
 from typing import Union
 
 import numpy as np
@@ -317,19 +319,80 @@ def _check_args_kwargs_marker(item_mark: pytest.Mark, sig: Signature):
         return bounds
 
 
+def _get_min_max_vtk_version(
+    item_mark: pytest.Mark,
+    sig: Signature,
+) -> tuple[tuple[int] | None, tuple[int] | None, BoundArguments]:
+    bounds = _check_args_kwargs_marker(item_mark=item_mark, sig=sig)
+
+    # Distinguish scenarios from positional arguments
+    if (len(args := bounds.arguments['args']) > 0) and (bounds.arguments['min'] is not None):
+        msg = f'Cannot specify both *args and `min` keyword argument to `{item_mark.name}` marker.'
+        raise ValueError(msg)
+
+    if len(args) > 0:
+        min_version = args[0] if len(args) == 1 and isinstance(args[0], tuple) else args
+        return min_version, bounds.arguments['max'], bounds
+
+    _min = bounds.arguments['min']
+    _max = bounds.arguments['max']
+
+    if _max is None and _min is None:
+        msg = (
+            f'Need to specify either `min` or `max` keyword arguments to `{item_mark.name}` marker.'
+        )
+        raise ValueError(msg)
+
+    return bounds.arguments['min'], bounds.arguments['max'], bounds
+
+
 def pytest_runtest_setup(item: pytest.Item):
     """Custom setup to handle skips based on VTK version.
 
     See custom marks in pyproject.toml.
     """
+
+    # this test needs a given VTK version
     if item_mark := item.get_closest_marker('needs_vtk_version'):
-        # this test needs the given VTK version
-        # allow both needs_vtk_version(9, 1) and needs_vtk_version((9, 1))
-        args = item_mark.args
-        version_needed = args[0] if len(args) == 1 and isinstance(args[0], tuple) else args
-        if pyvista.vtk_version_info < version_needed:
-            version_str = '.'.join(map(str, version_needed))
-            pytest.skip(f'Test needs VTK {version_str} or newer.')
+        sig = Signature(
+            [
+                Parameter(
+                    'args',
+                    kind=Parameter.VAR_POSITIONAL,
+                    annotation=Union[int, tuple[int]],
+                ),
+                Parameter(
+                    'min',
+                    kind=Parameter.KEYWORD_ONLY,
+                    annotation=Optional[tuple[int]],
+                    default=None,
+                ),
+                Parameter(
+                    'max',
+                    kind=Parameter.KEYWORD_ONLY,
+                    default=None,
+                    annotation=Optional[tuple[int]],
+                ),
+            ]
+        )
+        _min, _max, bounds = _get_min_max_vtk_version(item_mark=item_mark, sig=sig)
+        curr_version = pyvista.vtk_version_info
+
+        if _max is None and curr_version < _min:
+            pytest.skip(reason=f'Test needs VTK version > {_min}, current is {curr_version}.')
+
+        if _min is None and curr_version > _max:
+            pytest.skip(reason=f'Test needs VTK version < {_max}, current is {curr_version}.')
+
+        if _min is not None and _max is not None:
+            if _min > _max:
+                msg = 'Cannot specify a minimum version greater than the maximum one.'
+                raise ValueError(msg)
+
+            if curr_version < _min or curr_version > _max:
+                pytest.skip(
+                    reason=f'Test needs {_min} < VTK version < {_max}, current is {curr_version}.'
+                )
 
     if item_mark := item.get_closest_marker('skip_egl'):
         sig = Signature(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -366,7 +366,7 @@ def pytest_runtest_setup(item: pytest.Item):
     """
 
     # this test needs a given VTK version
-    if item_mark := item.get_closest_marker('needs_vtk_version'):
+    for item_mark in item.iter_markers('needs_vtk_version'):
         sig = Signature(
             [
                 Parameter(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -339,24 +339,24 @@ def _get_min_max_vtk_version(
         return val + (0,) * (expected - l)
 
     # Distinguish scenarios from positional arguments
-    if (len(args := bounds.arguments['args']) > 0) and (bounds.arguments['min'] is not None):
-        msg = f'Cannot specify both *args and `min` keyword argument to `{item_mark.name}` marker.'
+    if (len(args := bounds.arguments['args']) > 0) and (
+        bounds.arguments['greater_than'] is not None
+    ):
+        msg = f'Cannot specify both *args and `greater_than` keyword argument to `{item_mark.name}` marker.'
         raise ValueError(msg)
 
     if len(args) > 0:
         min_version = args[0] if len(args) == 1 and isinstance(args[0], tuple) else args
-        return _pad_version(min_version), _pad_version(bounds.arguments['max']), bounds
+        return _pad_version(min_version), _pad_version(bounds.arguments['less_than']), bounds
 
-    _min = bounds.arguments['min']
-    _max = bounds.arguments['max']
+    _min = bounds.arguments['greater_than']
+    _max = bounds.arguments['less_than']
 
     if _max is None and _min is None:
-        msg = (
-            f'Need to specify either `min` or `max` keyword arguments to `{item_mark.name}` marker.'
-        )
+        msg = f'Need to specify either `greater_than` or `less_than` keyword arguments to `{item_mark.name}` marker.'
         raise ValueError(msg)
 
-    return _pad_version(bounds.arguments['min']), _pad_version(bounds.arguments['max']), bounds
+    return _pad_version(_min), _pad_version(_max), bounds
 
 
 def pytest_runtest_setup(item: pytest.Item):
@@ -375,13 +375,13 @@ def pytest_runtest_setup(item: pytest.Item):
                     annotation=Union[int, tuple[int]],
                 ),
                 Parameter(
-                    'min',
+                    'greater_than',
                     kind=Parameter.KEYWORD_ONLY,
                     annotation=Optional[tuple[int]],
                     default=None,
                 ),
                 Parameter(
-                    'max',
+                    'less_than',
                     kind=Parameter.KEYWORD_ONLY,
                     default=None,
                     annotation=Optional[tuple[int]],

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1184,10 +1184,7 @@ def test_active_normals(sphere):
     assert mesh.active_normals.shape[0] == mesh.n_cells
 
 
-@pytest.mark.skipif(
-    pv.vtk_version_info < (9, 1, 0),
-    reason='Requires VTK>=9.1.0 for a concrete PointSet class',
-)
+@pytest.mark.needs_vtk_version(9, 1, 0, reason='Requires VTK>=9.1.0 for a concrete PointSet class')
 def test_cast_to_pointset(sphere):
     sphere = sphere.elevation()
     pointset = sphere.cast_to_pointset()
@@ -1205,10 +1202,7 @@ def test_cast_to_pointset(sphere):
     assert not np.allclose(sphere.active_scalars, pointset.active_scalars)
 
 
-@pytest.mark.skipif(
-    pv.vtk_version_info < (9, 1, 0),
-    reason='Requires VTK>=9.1.0 for a concrete PointSet class',
-)
+@pytest.mark.needs_vtk_version(9, 1, 0, reason='Requires VTK>=9.1.0 for a concrete PointSet class')
 def test_cast_to_pointset_implicit(uniform):
     pointset = uniform.cast_to_pointset(pass_cell_data=True)
     assert isinstance(pointset, pv.PointSet)

--- a/tests/core/test_geometric_sources.py
+++ b/tests/core/test_geometric_sources.py
@@ -24,18 +24,18 @@ def cube_faces_source():
     return pv.CubeFacesSource()
 
 
+@pytest.mark.needs_vtk_version(max=(9, 3))
 def test_capsule_source():
-    if pv.vtk_version_info < (9, 3):
-        algo = pv.CapsuleSource()
-        assert np.array_equal(algo.center, (0.0, 0.0, 0.0))
-        assert np.array_equal(algo.direction, (1.0, 0.0, 0.0))
-        assert algo.radius == 0.5
-        assert algo.cylinder_length == 1.0
-        assert algo.theta_resolution == 30
-        assert algo.phi_resolution == 30
-        direction = np.random.default_rng().random(3)
-        algo.direction = direction
-        assert np.array_equal(algo.direction, direction)
+    algo = pv.CapsuleSource()
+    assert np.array_equal(algo.center, (0.0, 0.0, 0.0))
+    assert np.array_equal(algo.direction, (1.0, 0.0, 0.0))
+    assert algo.radius == 0.5
+    assert algo.cylinder_length == 1.0
+    assert algo.theta_resolution == 30
+    assert algo.phi_resolution == 30
+    direction = np.random.default_rng().random(3)
+    algo.direction = direction
+    assert np.array_equal(algo.direction, direction)
 
 
 def test_cone_source():

--- a/tests/core/test_geometric_sources.py
+++ b/tests/core/test_geometric_sources.py
@@ -24,7 +24,7 @@ def cube_faces_source():
     return pv.CubeFacesSource()
 
 
-@pytest.mark.needs_vtk_version(max=(9, 3))
+@pytest.mark.needs_vtk_version(less_than=(9, 3))
 def test_capsule_source():
     algo = pv.CapsuleSource()
     assert np.array_equal(algo.center, (0.0, 0.0, 0.0))

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -29,9 +29,8 @@ HEXBEAM_CELLS_BOOL = np.ones(40, dtype=bool)  # matches hexbeam.n_cells == 40
 STRUCTGRID_CELLS_BOOL = np.ones(729, dtype=bool)  # struct_grid.n_cells == 729
 STRUCTGRID_POINTS_BOOL = np.ones(1000, dtype=bool)  # struct_grid.n_points == 1000
 
-pointsetmark = pytest.mark.skipif(
-    pv.vtk_version_info < (9, 1, 0),
-    reason='Requires VTK>=9.1.0 for a concrete PointSet class',
+pointsetmark = pytest.mark.needs_vtk_version(
+    9, 1, 0, reason='Requires VTK>=9.1.0 for a concrete PointSet class'
 )
 
 
@@ -1629,9 +1628,8 @@ def test_ExplicitStructuredGrid_raise_init():
         )
 
 
-@pytest.mark.skipif(
-    pv.vtk_version_info < (9, 2, 2),
-    reason='Requires VTK>=9.2.2 for ExplicitStructuredGrid.clean',
+@pytest.mark.needs_vtk_version(
+    9, 2, 2, reason='Requires VTK>=9.2.2 for ExplicitStructuredGrid.clean'
 )
 def test_ExplicitStructuredGrid_clean():
     grid = examples.load_explicit_structured()

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -405,10 +405,7 @@ def test_contour_labels_raises(labeled_image):
         pv.ImageData().contour_labels()
 
 
-@pytest.mark.skipif(
-    pv.vtk_version_info >= (9, 3, 0),
-    reason='Requires VTK<9.3.0',
-)
+@pytest.mark.needs_vtk_version(max=(9, 3, 0))
 def test_contour_labels_raises_vtkversionerror():
     match = 'Surface nets 3D require VTK 9.3.0 or newer.'
     with pytest.raises(pv.VTKVersionError, match=match):

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -405,7 +405,7 @@ def test_contour_labels_raises(labeled_image):
         pv.ImageData().contour_labels()
 
 
-@pytest.mark.needs_vtk_version(max=(9, 3, 0))
+@pytest.mark.needs_vtk_version(less_than=(9, 3, 0))
 def test_contour_labels_raises_vtkversionerror():
     match = 'Surface nets 3D require VTK 9.3.0 or newer.'
     with pytest.raises(pv.VTKVersionError, match=match):

--- a/tests/core/test_pointset.py
+++ b/tests/core/test_pointset.py
@@ -13,9 +13,8 @@ from pyvista.core.errors import PointSetDimensionReductionError
 from pyvista.core.errors import PointSetNotSupported
 
 # skip all tests if concrete pointset unavailable
-pytestmark = pytest.mark.skipif(
-    pv.vtk_version_info < (9, 1, 0),
-    reason='Requires VTK>=9.1.0 for a concrete PointSet class',
+pytestmark = pytest.mark.needs_vtk_version(
+    9, 1, 0, reason='Requires VTK>=9.1.0 for a concrete PointSet class'
 )
 
 

--- a/tests/core/test_polydata_filters.py
+++ b/tests/core/test_polydata_filters.py
@@ -155,9 +155,8 @@ def test_triangulate_contours():
         assert cell.type == pv.CellType.TRIANGLE
 
 
-@pytest.mark.skipif(
-    pv.vtk_version_info < (9, 1, 0),
-    reason='Requires VTK>=9.1.0 for a vtkIOChemistry.vtkCMLMoleculeReader',
+@pytest.mark.needs_vtk_version(
+    9, 1, 0, reason='Requires VTK>=9.1.0 for a vtkIOChemistry.vtkCMLMoleculeReader'
 )
 def test_protein_ribbon():
     tgqp = examples.download_3gqp()

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -598,11 +598,8 @@ def test_openfoamreader_arrays_time():
     assert reader.time_values == [0.0, 0.5, 1.0, 1.5, 2.0, 2.5]
 
 
+@pytest.mark.needs_vtk_version(9, 1, 0, reason='OpenFOAMReader GetTimeValue missing on vtk<9.1.0')
 def test_openfoamreader_active_time():
-    # vtk < 9.1.0 does not support
-    if pv.vtk_version_info < (9, 1, 0):
-        pytest.xfail('OpenFOAMReader GetTimeValue missing on vtk<9.1.0')
-
     reader = get_cavity_reader()
     assert reader.active_time_value == 0.0
     reader.set_active_time_point(1)
@@ -673,8 +670,8 @@ def test_openfoamreader_read_data_time_point():
     assert np.isclose(data.cell_data['U'][:, 1].mean(), 4.525951953837648e-05, 0.0, 1e-10)
 
 
-@pytest.mark.skipif(
-    pv.vtk_version_info > (9, 3),
+@pytest.mark.needs_vtk_version(
+    max=(9, 3),
     reason='polyhedra decomposition was removed after 9.3',
 )
 def test_openfoam_decompose_polyhedra():
@@ -1028,9 +1025,8 @@ def test_try_imageio_imread():
     assert isinstance(img, (imageio.core.util.Array, np.ndarray))
 
 
-@pytest.mark.skipif(
-    pv.vtk_version_info < (9, 1, 0),
-    reason='Requires VTK>=9.1.0 for a concrete PartitionedDataSetWriter class.',
+@pytest.mark.needs_vtk_version(
+    9, 1, 0, reason='Requires VTK>=9.1.0 for a concrete PartitionedDataSetWriter class.'
 )
 def test_xmlpartitioneddatasetreader(tmpdir):
     tmpfile = tmpdir.join('temp.vtpd')
@@ -1046,9 +1042,8 @@ def test_xmlpartitioneddatasetreader(tmpdir):
         assert new_partitions[i].n_cells == partitions[i].n_cells
 
 
-@pytest.mark.skipif(
-    pv.vtk_version_info < (9, 3, 0),
-    reason='Requires VTK>=9.3.0 for a concrete FLUENTCFFReader class.',
+@pytest.mark.needs_vtk_version(
+    9, 3, 0, reason='Requires VTK>=9.3.0 for a concrete FLUENTCFFReader class.'
 )
 def test_fluentcffreader():
     filename = examples.download_room_cff(load=False)
@@ -1072,9 +1067,8 @@ def test_gambitreader():
     assert all([mesh.n_points, mesh.n_cells])
 
 
-@pytest.mark.skipif(
-    pv.vtk_version_info < (9, 1, 0),
-    reason='Requires VTK>=9.1.0 for a concrete GaussianCubeReader class.',
+@pytest.mark.needs_vtk_version(
+    9, 1, 0, reason='Requires VTK>=9.1.0 for a concrete GaussianCubeReader class.'
 )
 def test_gaussian_cubes_reader():
     filename = examples.download_m4_total_density(load=False)
@@ -1108,9 +1102,8 @@ def test_gesignareader():
     assert all([mesh.n_points, mesh.n_cells])
 
 
-@pytest.mark.skipif(
-    pv.vtk_version_info < (9, 1, 0),
-    reason='Requires VTK>=9.1.0 for a concrete GaussianCubeReader class.',
+@pytest.mark.needs_vtk_version(
+    9, 1, 0, reason='Requires VTK>=9.1.0 for a concrete GaussianCubeReader class.'
 )
 def test_pdbreader():
     filename = examples.download_caffeine(load=False)
@@ -1361,7 +1354,7 @@ def test_nek5000_reader():
     ('data_object', 'ext'),
     [(pv.MultiBlock([examples.load_ant()]), '.pkl'), (examples.load_ant(), '.pickle')],
 )
-@pytest.mark.skipif(pv.vtk_version_info < (9, 3), reason='VTK version not supported.')
+@pytest.mark.needs_vtk_version(9, 3, reason='VTK version not supported.')
 def test_read_write_pickle(tmp_path, data_object, ext, datasets):
     filepath = tmp_path / ('data_object' + ext)
     data_object.save(filepath)

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -671,7 +671,7 @@ def test_openfoamreader_read_data_time_point():
 
 
 @pytest.mark.needs_vtk_version(
-    max=(9, 3),
+    less_than=(9, 3),
     reason='polyhedra decomposition was removed after 9.3',
 )
 def test_openfoam_decompose_polyhedra():

--- a/tests/core/test_unstructured_grid_filters.py
+++ b/tests/core/test_unstructured_grid_filters.py
@@ -7,10 +7,7 @@ import pytest
 
 import pyvista as pv
 
-skip_lesser_9_2_2 = pytest.mark.skipif(
-    pv.vtk_version_info <= (9, 2, 2),
-    reason='Requires VTK>=9.2.2',
-)
+skip_lesser_9_2_2 = pytest.mark.needs_vtk_version(9, 2, 2, reason='Requires VTK>=9.2.2')
 
 
 @skip_lesser_9_2_2

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -152,7 +152,6 @@ def test_raise_not_matching_raises():
 
 
 def test_version():
-    assert 'major' in str(pv.vtk_version_info)
     ver = vtk.vtkVersion()
     assert ver.GetVTKMajorVersion() == pv.vtk_version_info.major
     assert ver.GetVTKMinorVersion() == pv.vtk_version_info.minor
@@ -162,6 +161,7 @@ def test_version():
         ver.GetVTKMinorVersion(),
         ver.GetVTKBuildVersion(),
     )
+    assert str(ver_tup) == str(pv.vtk_version_info)
     assert ver_tup == pv.vtk_version_info
     assert pv.vtk_version_info >= (0, 0, 0)
 

--- a/tests/examples/test_download_files.py
+++ b/tests/examples/test_download_files.py
@@ -924,8 +924,8 @@ def test_download_gltf_damaged_helmet():
     pl.import_gltf(filename)
 
 
-@pytest.mark.skipif(
-    pv.vtk_version_info > (9, 1),
+@pytest.mark.needs_vtk_version(
+    max=(9, 1),
     reason='Skip until glTF extension KHR_texture_transform is supported.',
 )
 def test_download_gltf_sheen_chair():

--- a/tests/examples/test_download_files.py
+++ b/tests/examples/test_download_files.py
@@ -925,7 +925,7 @@ def test_download_gltf_damaged_helmet():
 
 
 @pytest.mark.needs_vtk_version(
-    max=(9, 1),
+    less_than=(9, 1),
     reason='Skip until glTF extension KHR_texture_transform is supported.',
 )
 def test_download_gltf_sheen_chair():

--- a/tests/plotting/jupyter/test_trame.py
+++ b/tests/plotting/jupyter/test_trame.py
@@ -35,18 +35,14 @@ try:
 except:
     has_trame = False
 
-# skip all tests if VTK<9.1.0
-if pv.vtk_version_info < (9, 1):
-    pytestmark = pytest.mark.skip
-else:
-    skip_no_trame = pytest.mark.skipif(not has_trame, reason='Requires trame')
-    pytestmark = [
-        skip_no_trame,
-        pytest.mark.skip_plotting,
-        pytest.mark.filterwarnings(
-            r'ignore:It is recommended to use web\.AppKey instances for keys:aiohttp.web_exceptions.NotAppKeyWarning'
-        ),
-    ]
+pytestmark = [
+    pytest.mark.needs_vtk_version(9, 1),
+    pytest.mark.skipif(not has_trame, reason='Requires trame'),
+    pytest.mark.skip_plotting,
+    pytest.mark.filterwarnings(
+        r'ignore:It is recommended to use web\.AppKey instances for keys:aiohttp.web_exceptions.NotAppKeyWarning'
+    ),
+]
 
 
 def test_set_jupyter_backend_trame():

--- a/tests/plotting/test_charts.py
+++ b/tests/plotting/test_charts.py
@@ -21,8 +21,7 @@ def skip_check_gc(skip_check_gc):
 
 
 # skip all tests if VTK<9.2.0
-if pv.vtk_version_info < (9, 2):
-    pytestmark = pytest.mark.skip
+pytestmark = pytest.mark.needs_vtk_version(9, 2)
 
 
 def vtk_array_to_tuple(arr):

--- a/tests/plotting/test_cube_axes_actor.py
+++ b/tests/plotting/test_cube_axes_actor.py
@@ -111,8 +111,8 @@ def test_axis_minor_tick_visibility(cube_axes_actor):
     assert cube_axes_actor.z_axis_minor_tick_visibility is False
 
 
-@pytest.mark.skipif(
-    pv.vtk_version_info >= (9, 3),
+@pytest.mark.needs_vtk_version(
+    max=(9, 3, 0),
     reason='title offset is a tuple of floats from vtk >= 9.3',
 )
 def test_title_offset(cube_axes_actor):

--- a/tests/plotting/test_cube_axes_actor.py
+++ b/tests/plotting/test_cube_axes_actor.py
@@ -112,7 +112,7 @@ def test_axis_minor_tick_visibility(cube_axes_actor):
 
 
 @pytest.mark.needs_vtk_version(
-    max=(9, 3, 0),
+    less_than=(9, 3, 0),
     reason='title offset is a tuple of floats from vtk >= 9.3',
 )
 def test_title_offset(cube_axes_actor):

--- a/tests/plotting/test_picking.py
+++ b/tests/plotting/test_picking.py
@@ -299,10 +299,7 @@ def test_point_picking(left_clicking):
     assert picked
 
 
-@pytest.mark.skipif(
-    pv.vtk_version_info < (9, 2, 0),
-    reason='Hardware picker unavailable for VTK<9.2',
-)
+@pytest.mark.needs_vtk_version(9, 2, 0, reason='Hardware picker unavailable for VTK<9.2')
 @pytest.mark.skip_windows
 @pytest.mark.parametrize('pickable_window', [False, True])
 def test_point_picking_window(pickable_window):

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -847,7 +847,7 @@ def test_legend_font(sphere):
     assert legend.GetEntryTextProperty().GetFontFamily() == vtk.VTK_TIMES
 
 
-@pytest.mark.skipif(pv.vtk_version_info < (9, 3), reason='Functions not implemented before 9.3.X')
+@pytest.mark.needs_vtk_version(9, 3, reason='Functions not implemented before 9.3.X')
 def test_edge_opacity(sphere):
     edge_opacity = np.random.default_rng().random()
     pl = pv.Plotter(sphere)

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -94,14 +94,12 @@ skip_windows_mesa = skip_mesa and pytest.mark.skip_windows(
     'Does not display correctly within OSMesa on Windows'
 )
 skip_9_1_0 = pytest.mark.needs_vtk_version(9, 1, 0)
-skip_9_0_X = pytest.mark.skipif(pv.vtk_version_info < (9, 1), reason='Flaky on 9.0.X')
-skip_lesser_9_0_X = pytest.mark.skipif(
-    pv.vtk_version_info < (9, 1),
-    reason='Functions not implemented before 9.0.X',
+skip_9_0_X = pytest.mark.needs_vtk_version(9, 1, 0, reason='Flaky on 9.0.X')
+skip_lesser_9_0_X = pytest.mark.needs_vtk_version(
+    9, 1, reason='Functions not implemented before 9.0.X'
 )
-skip_lesser_9_3_X = pytest.mark.skipif(
-    pv.vtk_version_info < (9, 3),
-    reason='Functions not implemented before 9.3.X',
+skip_lesser_9_3_X = pytest.mark.needs_vtk_version(
+    9, 3, reason='Functions not implemented before 9.3.X'
 )
 skip_lesser_9_4_X = pytest.mark.skipif(
     pv.vtk_version_info < (9, 4),
@@ -4137,7 +4135,7 @@ def test_plot_texture_flip_y(texture):
 
 @pytest.mark.needs_vtk_version(9, 2, 0)
 @pytest.mark.skipif(CI_WINDOWS, reason='Windows CI testing segfaults on pbr')
-@pytest.mark.skipif(pv.vtk_version_info >= (9, 3), reason='This is broken on VTK 9.3')
+@pytest.mark.needs_vtk_version(max=(9, 3), reason='This is broken on VTK 9.3')
 def test_plot_cubemap_alone(cubemap, verify_image_cache):
     """Test plotting directly from the Texture class."""
     verify_image_cache.high_variance_test = True

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -101,7 +101,7 @@ skip_lesser_9_0_X = pytest.mark.needs_vtk_version(
 skip_lesser_9_3_X = pytest.mark.needs_vtk_version(
     9, 3, reason='Functions not implemented before 9.3.X'
 )
-skip_lesser_9_4_X = pytest.mark.need_vtk_version(
+skip_lesser_9_4_X = pytest.mark.needs_vtk_version(
     9, 4, reason='Functions not implemented before 9.4.X or invalid results prior'
 )
 

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -101,9 +101,8 @@ skip_lesser_9_0_X = pytest.mark.needs_vtk_version(
 skip_lesser_9_3_X = pytest.mark.needs_vtk_version(
     9, 3, reason='Functions not implemented before 9.3.X'
 )
-skip_lesser_9_4_X = pytest.mark.skipif(
-    pv.vtk_version_info < (9, 4),
-    reason='Functions not implemented before 9.4.X or invalid results prior',
+skip_lesser_9_4_X = pytest.mark.need_vtk_version(
+    9, 4, reason='Functions not implemented before 9.4.X or invalid results prior'
 )
 
 CI_WINDOWS = os.environ.get('CI_WINDOWS', 'false').lower() == 'true'

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -4134,7 +4134,7 @@ def test_plot_texture_flip_y(texture):
 
 @pytest.mark.needs_vtk_version(9, 2, 0)
 @pytest.mark.skipif(CI_WINDOWS, reason='Windows CI testing segfaults on pbr')
-@pytest.mark.needs_vtk_version(max=(9, 3), reason='This is broken on VTK 9.3')
+@pytest.mark.needs_vtk_version(less_than=(9, 3), reason='This is broken on VTK 9.3')
 def test_plot_cubemap_alone(cubemap, verify_image_cache):
     """Test plotting directly from the Texture class."""
     verify_image_cache.high_variance_test = True

--- a/tests/plotting/test_property.py
+++ b/tests/plotting/test_property.py
@@ -46,7 +46,7 @@ def test_property_opacity(prop):
         prop.opacity = 2
 
 
-@pytest.mark.skipif(pv.vtk_version_info < (9, 3), reason='Functions not implemented before 9.3.X')
+@pytest.mark.needs_vtk_version(9, 3, reason='Functions not implemented before 9.3.X')
 def test_property_edge_opacity(prop):
     edge_opacity = 0.5
     prop.edge_opacity = edge_opacity

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -193,10 +193,10 @@ class Cases_needs_vtk:
         @pytest.mark.needs_vtk_version((9, 1, 0))
         def test_greater_9_1_tuple_2(): ...
 
-        @pytest.mark.needs_vtk_version(greater_than=(9, 1))
+        @pytest.mark.needs_vtk_version(at_least=(9, 1))
         def test_greater_9_1_kwargs(): ...
 
-        @pytest.mark.needs_vtk_version(greater_than=(9, 2))
+        @pytest.mark.needs_vtk_version(at_least=(9, 2))
         def test_greater_9_2(): ...
         """
 
@@ -255,7 +255,7 @@ class Cases_needs_vtk:
         tests = """
         import pytest
 
-        @pytest.mark.needs_vtk_version(greater_than=(9, 1))
+        @pytest.mark.needs_vtk_version(at_least=(9, 1))
         def test_smaller_9_1_tuple1(): ...
 
         """
@@ -292,7 +292,7 @@ class Cases_needs_vtk:
         tests = """
         import pytest
 
-        @pytest.mark.needs_vtk_version(greater_than=(8, 2), less_than=(9, 1))
+        @pytest.mark.needs_vtk_version(at_least=(8, 2), less_than=(9, 1))
         def test_between(): ...
 
         @pytest.mark.needs_vtk_version((8, 2), less_than=(9, 1))
@@ -338,10 +338,10 @@ class Cases_needs_vtk:
         tests = """
         import pytest
 
-        @pytest.mark.needs_vtk_version(9, 2, 1, greater_than=(8, 1))
+        @pytest.mark.needs_vtk_version(9, 2, 1, at_least=(8, 1))
         def test_1(): ...
 
-        @pytest.mark.needs_vtk_version((9, 2), greater_than=(9, 1))
+        @pytest.mark.needs_vtk_version((9, 2), at_least=(9, 1))
         def test_2(): ...
         """
 

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -5,7 +5,10 @@ import re
 from typing import TYPE_CHECKING
 
 import pytest
+from pytest_cases import case
+from pytest_cases import filters as ft
 from pytest_cases import parametrize
+from pytest_cases import parametrize_with_cases
 
 import pyvista
 
@@ -172,64 +175,205 @@ def test_downloads_mark(
     assert 'test_downloads' in (report.passed if cml else report.skipped)
 
 
-@pytest.mark.parametrize('greater', [True, False])
-def test_needs_vtk_version_tuple(
-    pytester: pytest.Pytester,
-    monkeypatch: pytest.MonkeyPatch,
-    greater: bool,
-):
-    tests = """
-    import pytest
+class Cases_needs_vtk:
+    @case
+    @parametrize(greater=[True, False])
+    def case_min_only(self, greater: bool, monkeypatch: pytest.MonkeyPatch):
+        """Test when using the args, with both tuple and variadic *args and the kwargs"""
 
-    @pytest.mark.needs_vtk_version(9,1)
-    def test_greater_9_1():
-        ...
+        tests = """
+        import pytest
 
-    @pytest.mark.needs_vtk_version((9,1))
-    def test_greater_9_1_tuple():
-        ...
+        @pytest.mark.needs_vtk_version(9, 1)
+        def test_greater_9_1(): ...
 
-    """
+        @pytest.mark.needs_vtk_version((9, 1))
+        def test_greater_9_1_tuple(): ...
 
-    value = (8, 2) if greater else (9, 2)
-    monkeypatch.setattr(pyvista, 'vtk_version_info', value)
+        @pytest.mark.needs_vtk_version((9, 1, 0))
+        def test_greater_9_1_tuple_2(): ...
 
+        @pytest.mark.needs_vtk_version(min=(9, 1))
+        def test_greater_9_1_kwargs(): ...
+
+        @pytest.mark.needs_vtk_version(min=(9, 2))
+        def test_greater_9_2(): ...
+        """
+
+        value = (8, 2, 0) if greater else (9, 2, 0)
+        monkeypatch.setattr(pyvista, 'vtk_version_info', value)
+
+        return tests, dict(passed=0 if greater else 5, skipped=5 if greater else 0)
+
+    @case
+    @parametrize(lower=[True, False])
+    def case_max_only(self, lower: bool, monkeypatch: pytest.MonkeyPatch):
+        """Test when using the max kwargs"""
+
+        tests = """
+        import pytest
+
+        @pytest.mark.needs_vtk_version(max=(9, 1))
+        def test_smaller_9_1(): ...
+
+        @pytest.mark.needs_vtk_version(max=(9,))
+        def test_smaller_9(): ...
+
+        @pytest.mark.needs_vtk_version(max=(9, 1, 2))
+        def test_smaller_9_1_2(): ...
+
+        """
+
+        value = (8, 2, 0) if lower else (9, 2, 0)
+        monkeypatch.setattr(pyvista, 'vtk_version_info', value)
+
+        return tests, dict(passed=3 if lower else 0, skipped=0 if lower else 3)
+
+    @case
+    def case_max_equal(self, monkeypatch: pytest.MonkeyPatch):
+        """Test when the max version equals the current"""
+
+        tests = """
+        import pytest
+
+        @pytest.mark.needs_vtk_version(max=(9, 1))
+        def test_smaller_9_1_tuple1(): ...
+
+        @pytest.mark.needs_vtk_version(max=(9, 1, 0))
+        def test_smaller_9_1_tuple2(): ...
+
+        """
+
+        monkeypatch.setattr(pyvista, 'vtk_version_info', (9, 1, 0))
+
+        return tests, dict(skipped=2)
+
+    @case
+    def case_min_equal(self, monkeypatch: pytest.MonkeyPatch):
+        """Test when the min version equals the current"""
+
+        tests = """
+        import pytest
+
+        @pytest.mark.needs_vtk_version(min=(9, 1))
+        def test_smaller_9_1_tuple1(): ...
+
+        """
+
+        monkeypatch.setattr(pyvista, 'vtk_version_info', (9, 1, 0))
+
+        return tests, dict(passed=1)
+
+    @case
+    @parametrize(between=[True, False])
+    def case_min_max(self, between: bool, monkeypatch: pytest.MonkeyPatch):
+        """Test when using both min and max kwargs"""
+
+        tests = """
+        import pytest
+
+        @pytest.mark.needs_vtk_version(min=(8, 2), max=(9, 1))
+        def test_between(): ...
+
+        @pytest.mark.needs_vtk_version((8, 2), max=(9, 1))
+        def test_between_tuple(): ...
+
+        @pytest.mark.needs_vtk_version(8, 2, max=(9, 1))
+        def test_between_variadic(): ...
+
+        @pytest.mark.needs_vtk_version(8, 2, max=(9, 2))
+        def test_between_variadic_max_equals(): ...
+
+        @pytest.mark.needs_vtk_version(9, max=(9, 2))
+        def test_between_variadic_min_equals(): ...
+
+        """
+
+        value = (9, 0, 0) if between else (9, 2, 0)
+        monkeypatch.setattr(pyvista, 'vtk_version_info', value)
+
+        return tests, dict(passed=5 if between else 0, skipped=0 if between else 5)
+
+    @case(tags='raises')
+    def case_raises_signature(self):
+        """Test when not specifying any version, or using bad signature"""
+
+        tests = """
+        import pytest
+
+        @pytest.mark.needs_vtk_version
+        def test_1(): ...
+
+        @pytest.mark.needs_vtk_version(foo=1)
+        def test_2(): ...
+
+        """
+
+        return tests, dict(errors=2)
+
+    @case(tags='raises')
+    def case_raises_both_args_min_kwargs(self):
+        """Test when specifying both args and min kwargs"""
+
+        tests = """
+        import pytest
+
+        @pytest.mark.needs_vtk_version(9, 2, 1, min=(8, 1))
+        def test_1(): ...
+
+        @pytest.mark.needs_vtk_version((9, 2), min=(9, 1))
+        def test_2(): ...
+        """
+
+        return tests, dict(errors=2)
+
+    @case(tags='raises')
+    def case_min_greater_max(self):
+        """Test when specifying min > max"""
+
+        tests = """
+        import pytest
+
+        @pytest.mark.needs_vtk_version(9, 2, 1, max=(8, 1))
+        def test_1(): ...
+
+        @pytest.mark.needs_vtk_version((9, 2, 1), max=(8, 1))
+        def test_2(): ...
+        """
+
+        return tests, dict(errors=2)
+
+    @case(tags='raises')
+    def case_version_tuple_wrong(self):
+        """Test when specifying a tuple of len > 3"""
+
+        tests = """
+        import pytest
+
+        @pytest.mark.needs_vtk_version(9, 2, 1, 2)
+        def test_1(): ...
+
+        @pytest.mark.needs_vtk_version(max=(8, 1, 0, 1))
+        def test_2(): ...
+        """
+
+        return tests, dict(errors=2)
+
+
+@parametrize_with_cases('tests, outcome', cases=Cases_needs_vtk, filter=~ft.has_tag('raises'))
+def test_needs_vtk_version(tests: str, outcome: dict, pytester: pytest.Pytester):
     p = pytester.makepyfile(tests)
     results = pytester.runpytest(p)
 
-    results.assert_outcomes(
-        passed=0 if greater else 2,
-        skipped=2 if greater else 0,
-    )
+    results.assert_outcomes(**outcome)
 
 
-@pytest.mark.parametrize('version', [(9, 0), (9, 2)])
-def test_needs_vtk_version(
-    pytester: pytest.Pytester,
-    monkeypatch: pytest.MonkeyPatch,
-    version: tuple[int],
-):
-    tests = """
-    import pytest
-
-    @pytest.mark.needs_vtk_version(9,1)
-    def test_greater_9_1():
-        ...
-
-    """
-
-    monkeypatch.setattr(pyvista, 'vtk_version_info', version)
-
+@parametrize_with_cases('tests, outcome', cases=Cases_needs_vtk, has_tag='raises')
+def test_needs_vtk_version_raises(tests: str, outcome: dict, pytester: pytest.Pytester):
     p = pytester.makepyfile(tests)
-    results = pytester.runpytest(p, '-ra')
+    results = pytester.runpytest(p)
 
-    results.assert_outcomes(
-        passed=1 if version == (9, 2) else 0,
-        skipped=0 if version == (9, 2) else 1,
-    )
-
-    if version == (9, 0):
-        results.stdout.re_match_lines([r'SKIPPED.*Test needs VTK 9.1 or newer'])
+    results.assert_outcomes(**outcome)
 
 
 @pytest.mark.skipif(os.name != 'nt', reason='Needs Windows platform to run')

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -193,10 +193,10 @@ class Cases_needs_vtk:
         @pytest.mark.needs_vtk_version((9, 1, 0))
         def test_greater_9_1_tuple_2(): ...
 
-        @pytest.mark.needs_vtk_version(min=(9, 1))
+        @pytest.mark.needs_vtk_version(greater_than=(9, 1))
         def test_greater_9_1_kwargs(): ...
 
-        @pytest.mark.needs_vtk_version(min=(9, 2))
+        @pytest.mark.needs_vtk_version(greater_than=(9, 2))
         def test_greater_9_2(): ...
         """
 
@@ -213,13 +213,13 @@ class Cases_needs_vtk:
         tests = """
         import pytest
 
-        @pytest.mark.needs_vtk_version(max=(9, 1))
+        @pytest.mark.needs_vtk_version(less_than=(9, 1))
         def test_smaller_9_1(): ...
 
-        @pytest.mark.needs_vtk_version(max=(9,))
+        @pytest.mark.needs_vtk_version(less_than=(9,))
         def test_smaller_9(): ...
 
-        @pytest.mark.needs_vtk_version(max=(9, 1, 2))
+        @pytest.mark.needs_vtk_version(less_than=(9, 1, 2))
         def test_smaller_9_1_2(): ...
 
         """
@@ -236,10 +236,10 @@ class Cases_needs_vtk:
         tests = """
         import pytest
 
-        @pytest.mark.needs_vtk_version(max=(9, 1))
+        @pytest.mark.needs_vtk_version(less_than=(9, 1))
         def test_smaller_9_1_tuple1(): ...
 
-        @pytest.mark.needs_vtk_version(max=(9, 1, 0))
+        @pytest.mark.needs_vtk_version(less_than=(9, 1, 0))
         def test_smaller_9_1_tuple2(): ...
 
         """
@@ -255,7 +255,7 @@ class Cases_needs_vtk:
         tests = """
         import pytest
 
-        @pytest.mark.needs_vtk_version(min=(9, 1))
+        @pytest.mark.needs_vtk_version(greater_than=(9, 1))
         def test_smaller_9_1_tuple1(): ...
 
         """
@@ -271,10 +271,10 @@ class Cases_needs_vtk:
         import pytest
 
         @pytest.mark.needs_vtk_version(9, 1)
-        @pytest.mark.needs_vtk_version(max=(9, 3))
+        @pytest.mark.needs_vtk_version(less_than=(9, 3))
         def test_1(): ...
 
-        @pytest.mark.needs_vtk_version(max=(9, 3))
+        @pytest.mark.needs_vtk_version(less_than=(9, 3))
         @pytest.mark.needs_vtk_version(9, 1)
         def test_2(): ...
 
@@ -292,19 +292,19 @@ class Cases_needs_vtk:
         tests = """
         import pytest
 
-        @pytest.mark.needs_vtk_version(min=(8, 2), max=(9, 1))
+        @pytest.mark.needs_vtk_version(greater_than=(8, 2), less_than=(9, 1))
         def test_between(): ...
 
-        @pytest.mark.needs_vtk_version((8, 2), max=(9, 1))
+        @pytest.mark.needs_vtk_version((8, 2), less_than=(9, 1))
         def test_between_tuple(): ...
 
-        @pytest.mark.needs_vtk_version(8, 2, max=(9, 1))
+        @pytest.mark.needs_vtk_version(8, 2, less_than=(9, 1))
         def test_between_variadic(): ...
 
-        @pytest.mark.needs_vtk_version(8, 2, max=(9, 2))
+        @pytest.mark.needs_vtk_version(8, 2, less_than=(9, 2))
         def test_between_variadic_max_equals(): ...
 
-        @pytest.mark.needs_vtk_version(9, max=(9, 2))
+        @pytest.mark.needs_vtk_version(9, less_than=(9, 2))
         def test_between_variadic_min_equals(): ...
 
         """
@@ -338,10 +338,10 @@ class Cases_needs_vtk:
         tests = """
         import pytest
 
-        @pytest.mark.needs_vtk_version(9, 2, 1, min=(8, 1))
+        @pytest.mark.needs_vtk_version(9, 2, 1, greater_than=(8, 1))
         def test_1(): ...
 
-        @pytest.mark.needs_vtk_version((9, 2), min=(9, 1))
+        @pytest.mark.needs_vtk_version((9, 2), greater_than=(9, 1))
         def test_2(): ...
         """
 
@@ -354,10 +354,10 @@ class Cases_needs_vtk:
         tests = """
         import pytest
 
-        @pytest.mark.needs_vtk_version(9, 2, 1, max=(8, 1))
+        @pytest.mark.needs_vtk_version(9, 2, 1, less_than=(8, 1))
         def test_1(): ...
 
-        @pytest.mark.needs_vtk_version((9, 2, 1), max=(8, 1))
+        @pytest.mark.needs_vtk_version((9, 2, 1), less_than=(8, 1))
         def test_2(): ...
         """
 
@@ -373,7 +373,7 @@ class Cases_needs_vtk:
         @pytest.mark.needs_vtk_version(9, 2, 1, 2)
         def test_1(): ...
 
-        @pytest.mark.needs_vtk_version(max=(8, 1, 0, 1))
+        @pytest.mark.needs_vtk_version(less_than=(8, 1, 0, 1))
         def test_2(): ...
         """
 
@@ -389,10 +389,10 @@ class Cases_needs_vtk:
         @pytest.mark.needs_vtk_version(9, 1)
         def test_1(): ...
 
-        @pytest.mark.needs_vtk_version(9, 1, max=(9, 2))
+        @pytest.mark.needs_vtk_version(9, 1, less_than=(9, 2))
         def test_2(): ...
 
-        @pytest.mark.needs_vtk_version(max=(8, 1))
+        @pytest.mark.needs_vtk_version(less_than=(8, 1))
         def test_3(): ...
 
         """


### PR DESCRIPTION
### Overview

This PR adds more control for `needs_vtk_version` marker by adding maximum value, along with custom reason.
Test suite is uniformed accordingly.

See the following examples that highlights the possible behaviors:

```python
@pytest.mark.needs_vtk_version(9, 1)
def test():
    """Test is skipped if pv.vtk_version_info < (9,1)"""


@pytest.mark.needs_vtk_version((9, 1))
def test():
    """Test is skipped if pv.vtk_version_info < (9,1)"""


@pytest.mark.needs_vtk_version(less_than=(9, 1))
def test():
    """Test is skipped if pv.vtk_version_info >= (9,1)"""


@pytest.mark.needs_vtk_version(8, 2, less_than=(9, 1))
def test():
    """Test is skipped if pv.vtk_version_info >= (9,1) or pv.vtk_version_info < (8,2,0)"""

@pytest.mark.needs_vtk_version(less_than=(9, 1))
@pytest.mark.needs_vtk_version(8, 2)
def test():
    """Test is skipped if pv.vtk_version_info >= (9,1) or pv.vtk_version_info < (8,2,0)"""

@pytest.mark.needs_vtk_version(9, 1, reason='custom reason')
def test():
    """Test is skipped with a custom message"""
```
