### PR TITLE
Auto-retry PyVistaQt integration test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -91,8 +91,11 @@ jobs:
           pyvista: false
       - run: pip install -ve ./pyvistaqt -r ./pyvistaqt/requirements_test.txt "PyQt6-Qt6!=6.6.0,!=6.7.0" "PyQt6!=6.6.0"
       - run: pip install -ve .
-      - run: pytest ./tests
-        working-directory: pyvistaqt
+      - uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          command: pytest ./tests
+          working-directory: pyvistaqt
 
   geovista:
     name: GeoVista

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -94,8 +94,8 @@ jobs:
       - uses: nick-fields/retry@v3
         with:
           max_attempts: 3
+          timeout_minutes: 15
           command: pytest ./tests
-          working-directory: pyvistaqt
 
   geovista:
     name: GeoVista

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -91,6 +91,7 @@ jobs:
           pyvista: false
       - run: pip install -ve ./pyvistaqt -r ./pyvistaqt/requirements_test.txt "PyQt6-Qt6!=6.6.0,!=6.7.0" "PyQt6!=6.6.0"
       - run: pip install -ve .
+      - run: cd pyvistaqt
       - uses: nick-fields/retry@v3
         with:
           max_attempts: 3


### PR DESCRIPTION
### Overview
PyVistaQt integration tests are flaky with vtk 9.4. This PR uses https://github.com/nick-fields/retry to auto-retry the test