### PR TITLE
Always upload failed images from docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -110,7 +110,7 @@ jobs:
         run: pytest tests/doc/tst_doc_images.py
 
       - name: Upload Images for Failed Tests
-        if: ${{ failure() && hashFiles('_doc_debug_images_failed/**/*.jpg') != '' }}
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: doc-debug-images-failed


### PR DESCRIPTION
### Overview

This PR fixes the logic for uploading images. This logic matches the testing workflow:
https://github.com/pyvista/pyvista/blob/98b6e8117a8c48cae2582b138c6a3e6ab5a14256/.github/workflows/testing-and-deployment.yml#L75-L76

This will make it so that even there are only warnings (no failures), an artifact can still be uploaded. See https://github.com/pyvista/pyvista/pull/7394#issuecomment-2795678736.