### PR TITLE
Deprecate `main_has_priority` with `merge` filter (with VTK master testing)

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5255,6 +5255,10 @@ class DataSetFilters(DataObjectFilters):
         append_filter.SetMergePoints(merge_points)
         append_filter.SetTolerance(tolerance)
 
+        # For vtk 9.4.2 and earlier, the last appended mesh has priority.
+        # For newer vtk, the first appended mesh has priority. We apply
+        # logic accordingly to ensure the main mesh is appended in the
+        # correct order
         append_main_first = (not main_has_priority) or vtk_greater_942
         if append_main_first:
             append_filter.AddInputData(self)

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5156,7 +5156,7 @@ class DataSetFilters(DataObjectFilters):
             merge_points=True,
             tolerance=tolerance,
             inplace=inplace,
-            main_has_priority=True,
+            main_has_priority=None,
             progress_bar=progress_bar,
         )
 
@@ -5170,7 +5170,7 @@ class DataSetFilters(DataObjectFilters):
         merge_points: bool = True,
         tolerance: float = 0.0,
         inplace: bool = False,
-        main_has_priority: bool = True,
+        main_has_priority: bool | None = None,
         progress_bar: bool = False,
     ):
         """Join one or many other grids to this grid.
@@ -5208,6 +5208,11 @@ class DataSetFilters(DataObjectFilters):
             the arrays of the merging grids will be overwritten
             by the original main mesh.
 
+            .. deprecated:: 0.45
+
+                This keyword will be removed in a future version. The main mesh
+                always has priority with VTK > 9.4.2.
+
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
 
@@ -5234,11 +5239,24 @@ class DataSetFilters(DataObjectFilters):
         >>> merged.plot()
 
         """
+        vtk_greater_942 = _vtk.vtk_version_info > (9, 4, 2)
+        if main_has_priority is not None:
+            msg = (
+                "The keyword 'main_has_priority' is deprecated and should not be used.\n"
+                'The main mesh will always have priority in a future version.'
+            )
+            if main_has_priority is False and vtk_greater_942:
+                msg += '\nIts value cannot be False for vtk>9.4.2.'
+                raise ValueError(msg)
+            else:
+                warnings.warn(msg, pyvista.PyVistaDeprecationWarning)
+
         append_filter = _vtk.vtkAppendFilter()
         append_filter.SetMergePoints(merge_points)
         append_filter.SetTolerance(tolerance)
 
-        if not main_has_priority:
+        append_main_first = (not main_has_priority) or vtk_greater_942
+        if append_main_first:
             append_filter.AddInputData(self)
 
         if isinstance(grid, _vtk.vtkDataSet):
@@ -5248,7 +5266,7 @@ class DataSetFilters(DataObjectFilters):
             for grid in grids:
                 append_filter.AddInputData(grid)
 
-        if main_has_priority:
+        if not append_main_first:
             append_filter.AddInputData(self)
 
         _update_alg(append_filter, progress_bar, 'Merging')

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -428,7 +428,7 @@ class PolyDataFilters(DataSetFilters):
         merge_points: bool = True,
         tolerance=0.0,
         inplace: bool = False,
-        main_has_priority: bool = True,
+        main_has_priority: bool | None = None,
         progress_bar: bool = False,
     ):
         """Merge this mesh with one or more datasets.
@@ -483,6 +483,11 @@ class PolyDataFilters(DataSetFilters):
             When this parameter is ``True`` and ``merge_points=True``,
             the arrays of the merging grids will be overwritten
             by the original main mesh.
+
+            .. deprecated:: 0.45
+
+                This keyword will be removed in a future version. The main mesh
+                always has priority with VTK > 9.4.2.
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.

--- a/pyvista/core/utilities/features.py
+++ b/pyvista/core/utilities/features.py
@@ -568,7 +568,7 @@ def spherical_to_cartesian(r, phi, theta):
 def merge(
     datasets,
     merge_points: bool = True,
-    main_has_priority: bool = True,
+    main_has_priority: bool | None = None,
     progress_bar: bool = False,
 ):
     """Merge several datasets.
@@ -590,6 +590,11 @@ def merge(
     main_has_priority : bool, default: True
         When this parameter is ``True`` and ``merge_points=True``, the arrays
         of the merging grids will be overwritten by the original main mesh.
+
+        .. deprecated:: 0.45
+
+            This keyword will be removed in a future version. The main mesh
+            always has priority with VTK > 9.4.2.
 
     progress_bar : bool, default: False
         Display a progress bar to indicate progress.

--- a/pyvista/plotting/_vtk_gl.py
+++ b/pyvista/plotting/_vtk_gl.py
@@ -10,6 +10,8 @@ raise an ImportError if the user does not have libGL installed.
 
 from __future__ import annotations
 
+import contextlib
+
 try:
     # Necessary for displaying charts, otherwise crashes on rendering
     from vtkmodules import vtkRenderingContextOpenGL2 as vtkRenderingContextOpenGL2
@@ -18,9 +20,12 @@ except ImportError:  # pragma: no cover
 
 
 from vtkmodules.vtkRenderingOpenGL2 import vtkCameraPass as vtkCameraPass
-from vtkmodules.vtkRenderingOpenGL2 import (
-    vtkCompositePolyDataMapper2 as vtkCompositePolyDataMapper2,
-)
+
+with contextlib.suppress(ImportError):
+    # Deprecated in 9.3
+    from vtkmodules.vtkRenderingOpenGL2 import (
+        vtkCompositePolyDataMapper2 as vtkCompositePolyDataMapper2,
+    )
 from vtkmodules.vtkRenderingOpenGL2 import vtkDepthOfFieldPass as vtkDepthOfFieldPass
 from vtkmodules.vtkRenderingOpenGL2 import vtkEDLShading as vtkEDLShading
 from vtkmodules.vtkRenderingOpenGL2 import vtkGaussianBlurPass as vtkGaussianBlurPass

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -273,9 +273,8 @@ def test_user_dict_persists_with_merge_filter():
     name2 = 'sphere2'
     sphere2.user_dict['name'] = name2
 
-    expected = name1 if pv.vtk_version_info > (9, 4, 2) else name2
     merged = sphere1 + sphere2
-    assert merged.user_dict['name'] == expected
+    assert merged.user_dict['name'] == name1
 
 
 def test_user_dict_persists_with_threshold_filter(uniform):

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -266,13 +266,16 @@ def test_user_dict_write_read(tmp_path, data_object, ext):
 
 def test_user_dict_persists_with_merge_filter():
     sphere1 = pv.Sphere()
-    sphere1.user_dict['name'] = 'sphere1'
+    name1 = 'sphere1'
+    sphere1.user_dict['name'] = name1
 
     sphere2 = pv.Sphere()
-    sphere2.user_dict['name'] = 'sphere2'
+    name2 = 'sphere2'
+    sphere2.user_dict['name'] = name2
 
+    expected = name1 if pv.vtk_version_info > (9, 4, 2) else name2
     merged = sphere1 + sphere2
-    assert merged.user_dict['name'] == 'sphere2'
+    assert merged.user_dict['name'] == expected
 
 
 def test_user_dict_persists_with_threshold_filter(uniform):

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -3613,12 +3613,8 @@ def test_merge_points():
     celltypes = [pv.CellType.LINE]
     points = np.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]])
     pdata = pv.UnstructuredGrid(cells, celltypes, points)
-    assert (
-        pdata.merge(pdata, main_has_priority=True, merge_points=True, tolerance=1.0).n_points == 1
-    )
-    assert (
-        pdata.merge(pdata, main_has_priority=True, merge_points=True, tolerance=0.1).n_points == 2
-    )
+    assert pdata.merge(pdata, merge_points=True, tolerance=1.0).n_points == 1
+    assert pdata.merge(pdata, merge_points=True, tolerance=0.1).n_points == 2
 
 
 @pytest.mark.parametrize('inplace', [True, False])

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -2043,7 +2043,7 @@ def labeled_data():
     bounds = np.array((-0.5, 0.5, -0.5, 0.5, -0.5, 0.5))
     small_box = pv.Box(bounds=bounds)
     big_box = pv.Box(bounds=bounds * 2)
-    labeled = (small_box + big_box).extract_geometry().connectivity()
+    labeled = (big_box + small_box).extract_geometry().connectivity()
     assert isinstance(labeled, pv.PolyData)
     assert labeled.array_names == ['RegionId', 'RegionId']
     assert np.allclose(small_box.volume, SMALL_VOLUME)
@@ -2178,9 +2178,8 @@ def test_split_values_extract_values_component(
     # Convert to polydata to test volume
     multiblock = multiblock.as_polydata_blocks()
     assert expected_n_blocks == len(expected_volume)
-    assert all(
-        np.allclose(block.volume, volume) for block, volume in zip(multiblock, expected_volume)
-    )
+    for block, volume in zip(multiblock, expected_volume):
+        assert np.isclose(block.volume, volume)
 
 
 def test_extract_values_split_ranges_values(labeled_data):

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -468,10 +468,12 @@ def test_merge(hexbeam):
     assert grid.n_points < unmerged.n_points
 
 
+@pytest.mark.skipif(pv.vtk_version_info > (9, 4, 2), reason='Main always has priority.')
 def test_merge_not_main(hexbeam):
     grid = hexbeam.copy()
     grid.points[:, 0] += 1
-    unmerged = grid.merge(hexbeam, inplace=False, merge_points=False, main_has_priority=False)
+    with pytest.warns(pv.PyVistaDeprecationWarning):
+        unmerged = grid.merge(hexbeam, inplace=False, merge_points=False, main_has_priority=False)
 
     grid.merge(hexbeam, inplace=True, merge_points=True)
     assert grid.n_points > hexbeam.n_points

--- a/tests/core/test_pointset.py
+++ b/tests/core/test_pointset.py
@@ -146,7 +146,7 @@ def test_pointset_clip_vtk_bug(sphere):
     alg.SetInputData(pointset)
     alg.Update()
     out = pv.wrap(alg.GetOutput())
-    if pv.vtk_version_info >= (9, 4) and pv.vtk_version_info < (9, 5):
+    if pv.vtk_version_info >= (9, 4) and pv.vtk_version_info < (9, 4, 3):
         # A vtk bug was introduced in 9.4 https://gitlab.kitware.com/vtk/vtk/-/issues/19649
         # Which has been fixed for vtk 9.5: https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12040
         assert out.is_empty

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -550,8 +550,11 @@ def test_merge_active_scalars(input_):
     assert merged.active_scalars_name == 'foo'
 
 
-@pytest.mark.parametrize('input_', [examples.load_hexbeam(), pv.Sphere()])
-def test_merge_main_has_priority(input_):
+@pytest.mark.parametrize(
+    'input_', [examples.load_hexbeam(), pv.Plane(i_resolution=1, j_resolution=1)]
+)
+@pytest.mark.parametrize('main_has_priority', [True, False])
+def test_merge_main_has_priority(input_, main_has_priority):
     mesh = input_.copy()
     data_main = np.arange(mesh.n_points, dtype=float)
     mesh.point_data['present_in_both'] = data_main
@@ -571,12 +574,9 @@ def test_merge_main_has_priority(input_):
             for j in (this.points == point).all(-1).nonzero()
         )
 
-    merged = mesh.merge(other, main_has_priority=True)
-    assert matching_point_data(merged, mesh, 'present_in_both')
-    assert merged.active_scalars_name == 'present_in_both'
-
-    merged = mesh.merge(other, main_has_priority=False)
-    assert matching_point_data(merged, other, 'present_in_both')
+    merged = mesh.merge(other, main_has_priority=main_has_priority)
+    expected_to_match = mesh if main_has_priority else other
+    assert matching_point_data(merged, expected_to_match, 'present_in_both')
     assert merged.active_scalars_name == 'present_in_both'
 
 

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -577,21 +577,26 @@ def test_merge_main_has_priority(input_, main_has_priority):
     if pv.vtk_version_info > (9, 4, 2):
         merged = mesh.merge(other)
         expected_to_match = mesh
-        match = (
-            "The keyword 'main_has_priority' is deprecated and should not be used.\n"
-            'The main mesh will always have priority in a future version.'
-        )
-        if main_has_priority:
-            with pytest.warns(pv.PyVistaDeprecationWarning, match=match):
-                mesh.merge(other, main_has_priority=main_has_priority)
-        else:
-            with pytest.raises(ValueError, match=match):
-                mesh.merge(other, main_has_priority=main_has_priority)
     else:
-        merged = mesh.merge(other, main_has_priority=main_has_priority)
+        with pytest.warns(pv.PyVistaDeprecationWarning):
+            merged = mesh.merge(other, main_has_priority=main_has_priority)
         expected_to_match = mesh if main_has_priority else other
     assert matching_point_data(merged, expected_to_match, 'present_in_both')
     assert merged.active_scalars_name == 'present_in_both'
+
+
+@pytest.mark.parametrize('main_has_priority', [True, False])
+def test_merge_main_has_priority_deprecated(sphere, main_has_priority):
+    match = (
+        "The keyword 'main_has_priority' is deprecated and should not be used.\n"
+        'The main mesh will always have priority in a future version.'
+    )
+    if main_has_priority is False and pv.vtk_version_info > (9, 4, 2):
+        with pytest.raises(ValueError, match=match):
+            sphere.merge(sphere, main_has_priority=main_has_priority)
+    else:
+        with pytest.warns(pv.PyVistaDeprecationWarning, match=match):
+            sphere.merge(sphere, main_has_priority=main_has_priority)
 
 
 def test_add(sphere, sphere_shifted):

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -574,8 +574,22 @@ def test_merge_main_has_priority(input_, main_has_priority):
             for j in (this.points == point).all(-1).nonzero()
         )
 
-    merged = mesh.merge(other, main_has_priority=main_has_priority)
-    expected_to_match = mesh if main_has_priority else other
+    if pv.vtk_version_info > (9, 4, 2):
+        merged = mesh.merge(other)
+        expected_to_match = mesh
+        match = (
+            "The keyword 'main_has_priority' is deprecated and should not be used.\n"
+            'The main mesh will always have priority in a future version.'
+        )
+        if main_has_priority:
+            with pytest.warns(pv.PyVistaDeprecationWarning, match=match):
+                mesh.merge(other, main_has_priority=main_has_priority)
+        else:
+            with pytest.raises(ValueError, match=match):
+                mesh.merge(other, main_has_priority=main_has_priority)
+    else:
+        merged = mesh.merge(other, main_has_priority=main_has_priority)
+        expected_to_match = mesh if main_has_priority else other
     assert matching_point_data(merged, expected_to_match, 'present_in_both')
     assert merged.active_scalars_name == 'present_in_both'
 

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -852,14 +852,6 @@ def test_merge(sphere, cube, datasets):
     merged = pv.merge(
         [sphere_a, sphere_b],
         merge_points=True,
-        main_has_priority=False,
-    )
-    assert np.allclose(merged['data'], 1)
-
-    merged = pv.merge(
-        [sphere_a, sphere_b],
-        merge_points=True,
-        main_has_priority=True,
     )
     assert np.allclose(merged['data'], 0)
 


### PR DESCRIPTION
### Overview

Fix `ImportError` for latest vtk pre-related related to deprecated `vtkCompositePolyDataMapper2`.

Follow-up to #7408