### PR TITLE
Deprecate `main_has_priority` with `merge` filter

### DIFF
--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -428,7 +428,7 @@ class PolyDataFilters(DataSetFilters):
         merge_points: bool = True,
         tolerance=0.0,
         inplace: bool = False,
-        main_has_priority: bool = True,
+        main_has_priority: bool | None = None,
         progress_bar: bool = False,
     ):
         """Merge this mesh with one or more datasets.
@@ -483,6 +483,11 @@ class PolyDataFilters(DataSetFilters):
             When this parameter is ``True`` and ``merge_points=True``,
             the arrays of the merging grids will be overwritten
             by the original main mesh.
+
+            .. deprecated:: 0.45
+
+                This keyword will be removed in a future version. The main mesh
+                always has priority with VTK > 9.4.2.
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.

--- a/pyvista/core/utilities/features.py
+++ b/pyvista/core/utilities/features.py
@@ -568,7 +568,7 @@ def spherical_to_cartesian(r, phi, theta):
 def merge(
     datasets,
     merge_points: bool = True,
-    main_has_priority: bool = True,
+    main_has_priority: bool | None = None,
     progress_bar: bool = False,
 ):
     """Merge several datasets.
@@ -590,6 +590,11 @@ def merge(
     main_has_priority : bool, default: True
         When this parameter is ``True`` and ``merge_points=True``, the arrays
         of the merging grids will be overwritten by the original main mesh.
+
+        .. deprecated:: 0.45
+
+            This keyword will be removed in a future version. The main mesh
+            always has priority with VTK > 9.4.2.
 
     progress_bar : bool, default: False
         Display a progress bar to indicate progress.

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -266,13 +266,15 @@ def test_user_dict_write_read(tmp_path, data_object, ext):
 
 def test_user_dict_persists_with_merge_filter():
     sphere1 = pv.Sphere()
-    sphere1.user_dict['name'] = 'sphere1'
+    name1 = 'sphere1'
+    sphere1.user_dict['name'] = name1
 
     sphere2 = pv.Sphere()
-    sphere2.user_dict['name'] = 'sphere2'
+    name2 = 'sphere2'
+    sphere2.user_dict['name'] = name2
 
     merged = sphere1 + sphere2
-    assert merged.user_dict['name'] == 'sphere2'
+    assert merged.user_dict['name'] == name1
 
 
 def test_user_dict_persists_with_threshold_filter(uniform):

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -2043,7 +2043,7 @@ def labeled_data():
     bounds = np.array((-0.5, 0.5, -0.5, 0.5, -0.5, 0.5))
     small_box = pv.Box(bounds=bounds)
     big_box = pv.Box(bounds=bounds * 2)
-    labeled = (small_box + big_box).extract_geometry().connectivity()
+    labeled = (big_box + small_box).extract_geometry().connectivity()
     assert isinstance(labeled, pv.PolyData)
     assert labeled.array_names == ['RegionId', 'RegionId']
     assert np.allclose(small_box.volume, SMALL_VOLUME)
@@ -2178,9 +2178,8 @@ def test_split_values_extract_values_component(
     # Convert to polydata to test volume
     multiblock = multiblock.as_polydata_blocks()
     assert expected_n_blocks == len(expected_volume)
-    assert all(
-        np.allclose(block.volume, volume) for block, volume in zip(multiblock, expected_volume)
-    )
+    for block, volume in zip(multiblock, expected_volume):
+        assert np.isclose(block.volume, volume)
 
 
 def test_extract_values_split_ranges_values(labeled_data):
@@ -3613,12 +3612,8 @@ def test_merge_points():
     celltypes = [pv.CellType.LINE]
     points = np.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]])
     pdata = pv.UnstructuredGrid(cells, celltypes, points)
-    assert (
-        pdata.merge(pdata, main_has_priority=True, merge_points=True, tolerance=1.0).n_points == 1
-    )
-    assert (
-        pdata.merge(pdata, main_has_priority=True, merge_points=True, tolerance=0.1).n_points == 2
-    )
+    assert pdata.merge(pdata, merge_points=True, tolerance=1.0).n_points == 1
+    assert pdata.merge(pdata, merge_points=True, tolerance=0.1).n_points == 2
 
 
 @pytest.mark.parametrize('inplace', [True, False])

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -468,10 +468,12 @@ def test_merge(hexbeam):
     assert grid.n_points < unmerged.n_points
 
 
+@pytest.mark.skipif(pv.vtk_version_info > (9, 4, 2), reason='Main always has priority.')
 def test_merge_not_main(hexbeam):
     grid = hexbeam.copy()
     grid.points[:, 0] += 1
-    unmerged = grid.merge(hexbeam, inplace=False, merge_points=False, main_has_priority=False)
+    with pytest.warns(pv.PyVistaDeprecationWarning):
+        unmerged = grid.merge(hexbeam, inplace=False, merge_points=False, main_has_priority=False)
 
     grid.merge(hexbeam, inplace=True, merge_points=True)
     assert grid.n_points > hexbeam.n_points

--- a/tests/core/test_pointset.py
+++ b/tests/core/test_pointset.py
@@ -146,7 +146,7 @@ def test_pointset_clip_vtk_bug(sphere):
     alg.SetInputData(pointset)
     alg.Update()
     out = pv.wrap(alg.GetOutput())
-    if pv.vtk_version_info >= (9, 4) and pv.vtk_version_info < (9, 5):
+    if pv.vtk_version_info >= (9, 4) and pv.vtk_version_info < (9, 4, 3):
         # A vtk bug was introduced in 9.4 https://gitlab.kitware.com/vtk/vtk/-/issues/19649
         # Which has been fixed for vtk 9.5: https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12040
         assert out.is_empty

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -852,14 +852,6 @@ def test_merge(sphere, cube, datasets):
     merged = pv.merge(
         [sphere_a, sphere_b],
         merge_points=True,
-        main_has_priority=False,
-    )
-    assert np.allclose(merged['data'], 1)
-
-    merged = pv.merge(
-        [sphere_a, sphere_b],
-        merge_points=True,
-        main_has_priority=True,
     )
     assert np.allclose(merged['data'], 0)
 


### PR DESCRIPTION
### Overview

The behavior of `vtkAppendFilter` has recently changed (from latest vtk pre-release) such that it now effectively sets `main_has_priority` by default. This fixes a bug with `vtkAppendFilter` where the _last_ appended mesh had priority, whereas it makes more sense for the _first_ appended mesh to have priority. See https://gitlab.kitware.com/vtk/vtk/-/issues/19656

IMO, it seems the keyword `main_has_priority` for `merge` was effectively a workaround for this bug, and is more of a fix than a feature. I don't think we need to keep it for use with future vtk versions.