### PR TITLE
Fix import error for deprecated `vtkCompositePolyDataMapper2`

### DIFF
--- a/pyvista/plotting/_vtk_gl.py
+++ b/pyvista/plotting/_vtk_gl.py
@@ -10,6 +10,8 @@ raise an ImportError if the user does not have libGL installed.
 
 from __future__ import annotations
 
+import contextlib
+
 try:
     # Necessary for displaying charts, otherwise crashes on rendering
     from vtkmodules import vtkRenderingContextOpenGL2 as vtkRenderingContextOpenGL2
@@ -18,9 +20,10 @@ except ImportError:  # pragma: no cover
 
 
 from vtkmodules.vtkRenderingOpenGL2 import vtkCameraPass as vtkCameraPass
-from vtkmodules.vtkRenderingOpenGL2 import (
-    vtkCompositePolyDataMapper2 as vtkCompositePolyDataMapper2,
-)
+with contextlib.suppress(ImportError):
+    from vtkmodules.vtkRenderingOpenGL2 import (
+        vtkCompositePolyDataMapper2 as vtkCompositePolyDataMapper2,
+    )
 from vtkmodules.vtkRenderingOpenGL2 import vtkDepthOfFieldPass as vtkDepthOfFieldPass
 from vtkmodules.vtkRenderingOpenGL2 import vtkEDLShading as vtkEDLShading
 from vtkmodules.vtkRenderingOpenGL2 import vtkGaussianBlurPass as vtkGaussianBlurPass

--- a/pyvista/plotting/_vtk_gl.py
+++ b/pyvista/plotting/_vtk_gl.py
@@ -20,6 +20,7 @@ except ImportError:  # pragma: no cover
 
 
 from vtkmodules.vtkRenderingOpenGL2 import vtkCameraPass as vtkCameraPass
+
 with contextlib.suppress(ImportError):
     from vtkmodules.vtkRenderingOpenGL2 import (
         vtkCompositePolyDataMapper2 as vtkCompositePolyDataMapper2,


### PR DESCRIPTION
### Overview

Similar to #7408, fixes failures from #7410