### PR TITLE
Fix vtk-remote-view.set_widgets is missing Error

### DIFF
--- a/pyvista/trame/views.py
+++ b/pyvista/trame/views.py
@@ -162,6 +162,12 @@ class PyVistaRemoteView(VtkRemoteView, _BasePyVistaView):  # type: ignore[misc]
         """Wrap update call."""
         return self.update(*args, **kwargs)
 
+    def _post_initialize(self):
+        super()._post_initialize()
+        self.set_widgets(
+            [ren.axes_widget for ren in self._plotter().renderers if hasattr(ren, 'axes_widget')],
+        )
+
 
 class PyVistaLocalView(VtkLocalView, _BasePyVistaView):  # type: ignore[misc]
     """PyVista wrapping of trame VtkLocalView for in-browser rendering.


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Fixes `vtk-remote-view.set_widgets is missing` from being printed when using PyVistaRemoteView

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

Resolves #6660

See https://github.com/Kitware/trame-router/issues/5#issuecomment-2356478780

See related trame_vtk pull request https://github.com/Kitware/trame-vtk/pull/83

### Details

- < feature1 or bug1 description >
- < feature2 or bug2 description >
