### PR TITLE
fix: avoid read-only issues with inplace statement

### DIFF
--- a/pyvista/core/utilities/helpers.py
+++ b/pyvista/core/utilities/helpers.py
@@ -294,7 +294,7 @@ def generate_plane(normal: VectorLike[float], origin: VectorLike[float]):
     plane = _vtk.vtkPlane()
     # NORMAL MUST HAVE MAGNITUDE OF 1
     normal_ = _validation.validate_array3(normal, dtype_out=float)
-    normal_ /= np.linalg.norm(normal_)
+    normal_ = normal_ / np.linalg.norm(normal_)
     plane.SetNormal(*normal_)
     plane.SetOrigin(*origin)
     return plane


### PR DESCRIPTION
### Overview

With https://github.com/pyvista/pyvista/pull/6934, a certain behavior was surfaced... which is the fact that if you pass in a read-only numpy array, this in-place division will no longer work.

https://github.com/pyvista/pyvista/blob/4397139a92bb8cbd59c4dff834a48f8ecf7baf1a/pyvista/core/utilities/helpers.py#L297

I am suggesting to return back to the previous implementation for the ``normal`` building.

### Details

Instead of performing 

https://github.com/pyvista/pyvista/blob/4397139a92bb8cbd59c4dff834a48f8ecf7baf1a/pyvista/core/utilities/helpers.py#L297

We should:

https://github.com/RobPasMue/pyvista/blob/95d78cdfdbce3bdabb39ab4976adb0b449cadd54/pyvista/core/utilities/helpers.py#L297

Reference: https://stackoverflow.com/questions/63832055/why-does-raise-an-error-but-not-x-x-y-with-a-read-only-numpy-array