### PR TITLE
Make `pyvista.examples` referenceable in the docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1152,8 +1152,8 @@ datasets in a new `card carousel <https://sphinx-design.readthedocs.io/en/latest
 For example, to add a new ``Instrument`` dataset category to :ref:`dataset_gallery_category`
 featuring two datasets of musical instruments, e.g.
 
-#.  :func:`pyvista.examples.downloads.download_guitar`
-#.  :func:`pyvista.examples.downloads.download_trumpet`
+#.  :func:`pyvista.examples.download_guitar`
+#.  :func:`pyvista.examples.download_trumpet`
 
 complete the following steps:
 

--- a/doc/source/api/examples/index.rst
+++ b/doc/source/api/examples/index.rst
@@ -1,6 +1,9 @@
 Examples
 ========
 
+.. automodule:: pyvista.examples
+   :noindex:
+
 .. currentmodule:: pyvista
 
 PyVista contains a variety of built-in demos and downloadable example


### PR DESCRIPTION
### Overview

The docs do not define `pyvista.examples` such that it's possible to do `pyvista.examples.load_uniform` in code but in the docs this is not recognized. Instead, it's necessary to do `pyvista.examples.examples.load_uniform` for cross-referencing. This PR fixes this by adding this entry explicitly.