### PR TITLE
Fix long description within streamlines from source

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2931,7 +2931,7 @@ class DataSetFilters(DataObjectFilters):
         """Generate streamlines of vectors from the points of a source mesh.
 
         The integration is performed using a specified integrator, by default
-        Runge-Kutta2. This supports integration through any type of dataset.
+        Runge-Kutta45. This supports integration through any type of dataset.
         If the dataset contains 2D cells like polygons or triangles and the
         ``surface_streamlines`` parameter is used, the integration is constrained
         to lie on the surface defined by 2D cells.


### PR DESCRIPTION
Really minor change. The default integrator within [pyvista.datasetfilters.streamlines_from_source](https://docs.pyvista.org/api/core/_autosummary/pyvista.datasetfilters.streamlines_from_source) states that it's using `RUNGE_KUTTA45`, but the long description states `Runge-Kutta2`.

This PR fixes the long description to reflect the actual default within the `integrator_type` parameter.