### PR TITLE
Use dependency groups instead of extras for installing dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ jupyter = [
   'trame>=2.5.2',
 ]
 
+[dependency-groups]
 pinned = [ # Pinned versions of core dependencies
   'matplotlib<3.10.2',
   'numpy<2.2.0',
@@ -64,8 +65,8 @@ typing = [
   'mypy<1.14.0',
   'npt-promote==0.2',
   'numpy>=2.0.0',
-  'pyvista[pinned]',
   'trimesh<4.6.0',
+  { include-group = 'pinned' },
 ]
 
 test = [
@@ -89,7 +90,6 @@ test = [
   'pytest<8.4.0',
   'pytest_cases<3.8.7',
   'pytest_mock<3.15.0',
-  'pyvista[pinned]',
   'scipy<1.14.2',
   'sphinx-book-theme<1.2.0',
   'sphinx-gallery<0.19.0',
@@ -102,6 +102,7 @@ test = [
   'trame>=2.5.2,<3.7.1',
   'trimesh<4.6.0',
   'typing-extensions<4.14.0',
+  { include-group = 'pinned' },
 ]
 
 docs = [
@@ -122,7 +123,6 @@ docs = [
   'pypandoc==1.15',
   'pytest-pyvista==0.1.8',
   'pytest-sphinx==0.6.3',
-  'pyvista[pinned]',
   'scipy==1.15.2',
   'sphinx-autobuild==2024.10.3',
   'sphinx-book-theme==1.1.4',
@@ -142,9 +142,10 @@ docs = [
   'trame-vuetify==3.0.0',
   'trame==3.8.2',
   'trimesh==4.6.6',
+  { include-group = 'pinned' },
 ]
 
-dev = ['pre-commit', 'pyvista[test,typing]']
+dev = ['pre-commit', { include-group = 'test' }, { include-group = 'typing' }]
 
 [project.urls]
 'Bug Tracker' = 'https://github.com/pyvista/pyvista/issues'


### PR DESCRIPTION
### Overview

Pip now supports dependency groups, see:
https://ichard26.github.io/blog/2025/04/whats-new-in-pip-25.1/#dependency-groups-pep-735

This PR moves the `dev`, `test`, `typing`, and `docs` extras from `[project.optional-dependencies]` into `[dependency-groups]`.