### PR TITLE
Add render flag to the `add_actor` call in `BasePlotter.add_point_labels`

### DIFF
--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -5759,11 +5759,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         label_actor = _vtk.vtkActor2D()
         label_actor.SetMapper(label_mapper)
         self.add_actor(
-            label_actor,
+            label_actor,  # type: ignore[arg-type]
             reset_camera=False,
             name=f'{name}-labels',
             pickable=False,
-            render=render,  # type: ignore[arg-type]
+            render=render,
         )
         return label_actor
 

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -5759,8 +5759,8 @@ class BasePlotter(PickingHelper, WidgetHelper):
         label_actor = _vtk.vtkActor2D()
         label_actor.SetMapper(label_mapper)
         self.add_actor(
-            label_actor, reset_camera=False, name=f'{name}-labels', pickable=False, render=render
-        )  # type: ignore[arg-type]
+            label_actor, reset_camera=False, name=f'{name}-labels', pickable=False, render=render  # type: ignore[arg-type]
+        ) 
         return label_actor
 
     def add_point_scalar_labels(

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -5758,7 +5758,7 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         label_actor = _vtk.vtkActor2D()
         label_actor.SetMapper(label_mapper)
-        self.add_actor(label_actor, reset_camera=False, name=f'{name}-labels', pickable=False)  # type: ignore[arg-type]
+        self.add_actor(label_actor, reset_camera=False, name=f'{name}-labels', pickable=False, render=render)  # type: ignore[arg-type]
         return label_actor
 
     def add_point_scalar_labels(

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -5759,8 +5759,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
         label_actor = _vtk.vtkActor2D()
         label_actor.SetMapper(label_mapper)
         self.add_actor(
-            label_actor, reset_camera=False, name=f'{name}-labels', pickable=False, render=render  # type: ignore[arg-type]
-        ) 
+            label_actor,
+            reset_camera=False,
+            name=f'{name}-labels',
+            pickable=False,
+            render=render,  # type: ignore[arg-type]
+        )
         return label_actor
 
     def add_point_scalar_labels(

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -5758,7 +5758,9 @@ class BasePlotter(PickingHelper, WidgetHelper):
 
         label_actor = _vtk.vtkActor2D()
         label_actor.SetMapper(label_mapper)
-        self.add_actor(label_actor, reset_camera=False, name=f'{name}-labels', pickable=False, render=render)  # type: ignore[arg-type]
+        self.add_actor(
+            label_actor, reset_camera=False, name=f'{name}-labels', pickable=False, render=render
+        )  # type: ignore[arg-type]
         return label_actor
 
     def add_point_scalar_labels(


### PR DESCRIPTION
… (#7460)

### Overview

Fix for a bug affecting delayed rendering when adding point labels to a plotter. BasePlotter.add_point_labels wasn't passing down the "render" flag to the "add_actor" label, causing a render.

### Details

Added add_actor(render=render).