### PR TITLE
Enable `abort_on_example_error` for sphinx gallery

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -461,6 +461,7 @@ has_osmnx = importlib.util.find_spec('fiona') and importlib.util.find_spec('osmn
 
 
 sphinx_gallery_conf = {
+    'abort_on_example_error': True,  # Fail early
     # convert rst to md for ipynb
     'pypandoc': True,
     # path to your examples scripts


### PR DESCRIPTION
### Overview

If there is an error with the sphinx gallery, it's better to fail fast so we can see the error quickly and rectify it. This will help avoid having to wait the full 2hrs for the build, only to see an error that could have been caught in the first 10 minutes.

See https://sphinx-gallery.github.io/stable/configuration.html#abort-build-on-first-fail