### PR TITLE
Add command line interface with `--version` and `report` options

### DIFF
--- a/pyvista/__main__.py
+++ b/pyvista/__main__.py
@@ -1,0 +1,127 @@
+"""PyVista's command-line interface."""
+
+from __future__ import annotations
+
+import argparse
+import inspect
+import re
+
+import pyvista as pv
+
+
+def _parse_numpy_doc(doc: str) -> dict[str, str]:
+    """Parse a NumPy-style docstring to get parameter names and help strings."""
+    help_map: dict[str, str] = {}  # Store parameter name to description mapping
+    if not doc:
+        return help_map
+
+    lines = doc.splitlines()
+    in_params = False  # Flag to indicate whether we are inside the 'Parameters' section
+    current_param = None  # Temporary variable
+
+    # Iterate through lines of the docstring
+    for line in lines:
+        stripped = line.strip()
+
+        # Detect the start of the 'Parameters' section
+        if re.match(r'^Parameters$', stripped):
+            in_params = True
+            continue
+
+        # Skip the underline section of 'Parameters'
+        if in_params and re.match(r'^-{3,}$', stripped):
+            continue
+
+        # Detect a parameter line, e.g., 'param_name : type'
+        if in_params and re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*\s*:', stripped):
+            current_param = stripped.split(':')[0].strip()  # Extract the parameter name
+            help_map[current_param] = ''  # Initialize description storage
+        elif in_params and stripped:
+            # Append description to the current parameter
+            if current_param:
+                help_map[current_param] += ' ' + stripped
+        elif in_params and not stripped:
+            # End of a parameter description
+            current_param = None
+        elif in_params and not current_param:
+            break  # Stop if we've passed the Parameters section
+
+    return {k: v.strip() for k, v in help_map.items()}  # Clean up the whitespace
+
+
+def _add_report_subparser(subparsers):  # noqa: ANN001, ANN202
+    """Add the 'report' subcommand to the argparse parser.
+
+    Arguments are generated dynamically based on the Report class'
+    signature and docstring.
+    """
+    doc_help = _parse_numpy_doc(pv.Report.__doc__)  # type: ignore[arg-type]
+    sig = inspect.signature(
+        pv.Report.__init__
+    )  # Get the function signature of the Report class' __init__ method
+    parser = subparsers.add_parser(
+        'report', help='Show system information via pyvista.Report'
+    )  # Create a parser for the 'report' command
+
+    # Loop through the signature parameters and add them to the argument parser
+    for name, param in sig.parameters.items():
+        if name == 'self':  # Skip the 'self' parameter for instance methods
+            continue
+
+        # Get the default value (if any) and type
+        default = param.default if param.default is not inspect.Parameter.empty else None
+        param_type = type(default) if default is not None else str
+
+        # Get the help text from the docstring (if available)
+        help_text = doc_help.get(name, '')
+        arg_name = (
+            f'--{name.replace("_", "-")}'  # Convert underscores to hyphens for argument names
+        )
+
+        # Handle bool parameters
+        if param_type is bool:
+            parser.add_argument(
+                arg_name,
+                type=lambda x: x.lower()
+                != 'false',  # Convert 'false' to False, anything else to True
+                default=default,
+                help=help_text,
+            )
+        # Handle lists with `nargs` to allow multiple values
+        elif param_type is list:
+            parser.add_argument(arg_name, nargs='+', default=default, help=help_text)
+        else:
+            # General case
+            parser.add_argument(arg_name, type=param_type, default=default, help=help_text)
+
+    return parser
+
+
+def main() -> None:
+    """Entry point for the pyvista CLI."""
+    # Create the main parser
+    parser = argparse.ArgumentParser(description='PyVista CLI')
+    parser.add_argument('--version', action='store_true', help='Show PyVista version and exit')
+
+    # Subparser for different commands
+    subparsers = parser.add_subparsers(dest='command')
+    # Add 'report' subcommand dynamically
+    _add_report_subparser(subparsers)
+
+    args = parser.parse_args()
+
+    # Handle the --version flag
+    if args.version:
+        print(pv.__version__)  # Print PyVista version
+    elif args.command == 'report':
+        # Pass arguments for the 'report' command to the Report class
+        kwargs = vars(args).copy()  # Convert the arguments into a dictionary
+        kwargs.pop('command', None)  # Remove the 'command' key as it's not a parameter for Report
+        kwargs.pop('version', None)  # Remove the 'version' flag
+        print(pv.Report(**kwargs))  # Create a Report instance and print it
+    else:
+        parser.print_help()  # Show help if no valid command is provided
+
+
+if __name__ == '__main__':
+    main()

--- a/pyvista/report.py
+++ b/pyvista/report.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from types import ModuleType
 
 import scooby
 
@@ -158,7 +163,14 @@ class Report(scooby.Report):
 
     """
 
-    def __init__(self, additional=None, ncol=3, text_width=80, sort=False, gpu=True):
+    def __init__(
+        self,
+        additional: Sequence[ModuleType] | Sequence[str] | None = None,
+        ncol: int = 3,
+        text_width: int = 80,
+        sort: bool = False,
+        gpu: bool = True,
+    ):
         """Generate a :class:`scooby.Report` instance."""
         from vtkmodules.vtkRenderingCore import vtkRenderWindow
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,13 +33,15 @@ def test_report(tmp_path, include_args):
         capture_output=True,
         encoding='utf-8',
         cwd=tmp_path,
-        check=True,
     )
     actual = result.stdout.strip()
 
-    if result.returncode != 0:
-        print('STDOUT:\n', actual)
-        print('STDERR:\n', result.stderr)
+    # Helpful error if subprocess failed
+    assert result.returncode == 0, (
+        f'Subprocess failed with exit code {result.returncode}\n'
+        f'STDOUT:\n{result.stdout}\n'
+        f'STDERR:\n{result.stderr}'
+    )
 
     # Remove Date field (time may be off by 1 second)
     expected_no_date = remove_date_field(expected)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+import pytest
+
+import pyvista as pv
+
+
+def remove_date_field(text):
+    """Remove the 'Date:' line from the report output."""
+    text = re.sub(r'^  Date: .*\n', '', text, flags=re.MULTILINE)
+    return text.lstrip()  # remove any leading whitespace/newlines
+
+
+@pytest.mark.parametrize('include_args', [True, False])
+def test_report(tmp_path, include_args):
+    """Test that the CLI call to `pyvista report`  matches `pyvista.Report()` in python."""
+    cli_args = [sys.executable, '-m', 'pyvista', 'report']
+    python_kwargs = {}
+    if include_args:
+        cli_args.extend(
+            ['--gpu=False', '--sort=true', '--additional', 'mypy', 'scipy', '--text-width', '100']
+        )
+        python_kwargs = dict(gpu=False, sort=True, additional=['mypy', 'scipy'])
+
+    expected = str(pv.Report(**python_kwargs))
+
+    result = subprocess.run(
+        cli_args,
+        capture_output=True,
+        encoding='utf-8',
+        cwd=tmp_path,
+        check=True,
+    )
+    actual = result.stdout.strip()
+
+    if result.returncode != 0:
+        print('STDOUT:\n', actual)
+        print('STDERR:\n', result.stderr)
+
+    # Remove Date field (time may be off by 1 second)
+    expected_no_date = remove_date_field(expected)
+    actual_no_date = remove_date_field(actual)
+
+    assert actual_no_date == expected_no_date


### PR DESCRIPTION
### Overview

Enable `python -m pyvista --version` and `python -m pyvista report`.

This is easier than doing `python -c "import pyvista; print(pyvista.Report())"`
The CLI can be extended in future PRs with a `pyvista convert` option (similar to `meshio convert`), and a quick/simple `pyvista plot` option for quickly reading and plotting a file.