### PR TITLE
Fix false positive `ModuleNotFoundError` for cmaps common to `matplotlib`,`colorcet`, and `cmocean`

### DIFF
--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -580,7 +580,8 @@ SCHEME_NAMES = {
     for scheme_name, scheme_info in COLOR_SCHEMES.items()
 }
 
-# matches colorcet.cm.keys()
+# Define colormaps that require colorcet
+# matches set(colorcet.cm.keys()) - set(mpl.colormaps)
 _COLORCET_CMAPS = [
     'CET_C1',
     'CET_C10',
@@ -760,8 +761,6 @@ _COLORCET_CMAPS = [
     'circle_mgbm_67_c31_s25_r',
     'colorwheel',
     'colorwheel_r',
-    'coolwarm',
-    'coolwarm_r',
     'cwr',
     'cwr_r',
     'cyclic_bgrmb_35_70_c75',
@@ -884,8 +883,6 @@ _COLORCET_CMAPS = [
     'glasbey_warm_r',
     'gouldian',
     'gouldian_r',
-    'gray',
-    'gray_r',
     'gwv',
     'gwv_r',
     'isolum',
@@ -988,7 +985,6 @@ _COLORCET_CMAPS = [
     'linear_worb_100_25_c53_r',
     'linear_wyor_100_45_c55',
     'linear_wyor_100_45_c55_r',
-    'rainbow',
     'rainbow4',
     'rainbow4_r',
     'rainbow_bgyr_10_90_c83',
@@ -1001,10 +997,10 @@ _COLORCET_CMAPS = [
     'rainbow_bgyrm_35_85_c69_r',
     'rainbow_bgyrm_35_85_c71',
     'rainbow_bgyrm_35_85_c71_r',
-    'rainbow_r',
 ]
 
-# matches cmocean.cm.cmap_d.keys()
+# Define colormaps that require cmocean
+# matches set(cmocean.cm.cmap_d.keys()) - set(mpl.colormaps)
 _CMOCEAN_CMAPS = [
     'algae',
     'algae_i',
@@ -1046,10 +1042,8 @@ _CMOCEAN_CMAPS = [
     'diff_i_r',
     'diff_r',
     'diff_r_i',
-    'gray',
     'gray_i',
     'gray_i_r',
-    'gray_r',
     'gray_r_i',
     'haline',
     'haline_i',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import re
 from typing import Optional
 from typing import Union
 
+import matplotlib as mpl
 import numpy as np
 from numpy.random import default_rng
 import pytest
@@ -26,6 +27,12 @@ NUMPY_VERSION_INFO = VersionInfo(
     major=int(np.__version__.split('.')[0]),
     minor=int(np.__version__.split('.')[1]),
     micro=int(np.__version__.split('.')[2]),
+)
+
+MATPLOTLIB_VERSION_INFO = VersionInfo(
+    major=int(mpl.__version__.split('.')[0]),
+    minor=int(mpl.__version__.split('.')[1]),
+    micro=int(mpl.__version__.split('.')[2]),
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,6 @@ import re
 from typing import Optional
 from typing import Union
 
-import matplotlib as mpl
 import numpy as np
 from numpy.random import default_rng
 import pytest
@@ -27,12 +26,6 @@ NUMPY_VERSION_INFO = VersionInfo(
     major=int(np.__version__.split('.')[0]),
     minor=int(np.__version__.split('.')[1]),
     micro=int(np.__version__.split('.')[2]),
-)
-
-MATPLOTLIB_VERSION_INFO = VersionInfo(
-    major=int(mpl.__version__.split('.')[0]),
-    minor=int(mpl.__version__.split('.')[1]),
-    micro=int(mpl.__version__.split('.')[2]),
 )
 
 

--- a/tests/plotting/test_colors.py
+++ b/tests/plotting/test_colors.py
@@ -254,13 +254,13 @@ def test_unique_colors():
 
 def test_cmaps_colorcet_required():
     # Test that cmaps listed in colors module matches the actual cmaps available
-    actual = set(colorcet.cm.keys()) - set(mpl.colormaps)
+    actual = set(colorcet.cm.keys()) - set(mpl.colormaps._builtin_cmaps)
     expected = set(_COLORCET_CMAPS)
     assert actual == expected
 
 
 def test_cmaps_cmocean_required():
     # Test that cmaps listed in colors module matches the actual cmaps available
-    actual = set(cmocean.cm.cmap_d.keys()) - set(mpl.colormaps)
+    actual = set(cmocean.cm.cmap_d.keys()) - set(mpl.colormaps._builtin_cmaps)
     expected = set(_CMOCEAN_CMAPS)
     assert actual == expected

--- a/tests/plotting/test_colors.py
+++ b/tests/plotting/test_colors.py
@@ -254,13 +254,13 @@ def test_unique_colors():
 
 def test_colorcet_cmaps_allowed():
     # Test that cmaps listed in colors module matches the actual cmaps available
-    actual = set(colorcet.cm.keys())
+    actual = set(colorcet.cm.keys()) - set(mpl.colormaps)
     expected = set(_COLORCET_CMAPS)
     assert actual == expected
 
 
 def test_cmocean_cmaps_allowed():
     # Test that cmaps listed in colors module matches the actual cmaps available
-    actual = set(cmocean.cm.cmap_d.keys())
+    actual = set(cmocean.cm.cmap_d.keys()) - set(mpl.colormaps)
     expected = set(_CMOCEAN_CMAPS)
     assert actual == expected

--- a/tests/plotting/test_colors.py
+++ b/tests/plotting/test_colors.py
@@ -252,14 +252,14 @@ def test_unique_colors():
         pytest.fail(f'The following colors have duplicate definitions: {duplicates}.')
 
 
-def test_colorcet_cmaps_allowed():
+def test_cmaps_colorcet_required():
     # Test that cmaps listed in colors module matches the actual cmaps available
     actual = set(colorcet.cm.keys()) - set(mpl.colormaps)
     expected = set(_COLORCET_CMAPS)
     assert actual == expected
 
 
-def test_cmocean_cmaps_allowed():
+def test_cmaps_cmocean_required():
     # Test that cmaps listed in colors module matches the actual cmaps available
     actual = set(cmocean.cm.cmap_d.keys()) - set(mpl.colormaps)
     expected = set(_CMOCEAN_CMAPS)

--- a/tests/plotting/test_colors.py
+++ b/tests/plotting/test_colors.py
@@ -258,7 +258,7 @@ def reset_matplotlib_cmaps():
     for cmap in list(mpl.colormaps):
         try:
             mpl.colormaps.unregister(cmap)
-        except ValueError:
+        except (ValueError, AttributeError):
             continue
 
 

--- a/tests/plotting/test_colors.py
+++ b/tests/plotting/test_colors.py
@@ -257,7 +257,7 @@ def test_unique_colors():
         pytest.fail(f'The following colors have duplicate definitions: {duplicates}.')
 
 
-@pytest.mark.skipif(MATPLOTLIB_VERSION_INFO < (3, 6))
+@pytest.mark.skipif(MATPLOTLIB_VERSION_INFO < (3, 6), reason='Colormaps API changed.')
 def test_cmaps_colorcet_required():
     # Test that cmaps listed in colors module matches the actual cmaps available
     actual = set(colorcet.cm.keys()) - set(MPL_BUILTIN_CMAPS)

--- a/tests/plotting/test_colors.py
+++ b/tests/plotting/test_colors.py
@@ -19,6 +19,11 @@ from pyvista.plotting.colors import _CMOCEAN_CMAPS
 from pyvista.plotting.colors import _COLORCET_CMAPS
 from pyvista.plotting.colors import color_scheme_to_cycler
 from pyvista.plotting.colors import get_cmap_safe
+from tests.conftest import MATPLOTLIB_VERSION_INFO
+
+# Need to access private var here because non-default cmaps are added
+# to the public `mpl.colormaps` registry
+MPL_BUILTIN_CMAPS = mpl.colormaps._builtin_cmaps
 
 COLORMAPS = ['Greys']
 
@@ -252,15 +257,17 @@ def test_unique_colors():
         pytest.fail(f'The following colors have duplicate definitions: {duplicates}.')
 
 
+@pytest.mark.skipif(MATPLOTLIB_VERSION_INFO < (3, 6))
 def test_cmaps_colorcet_required():
     # Test that cmaps listed in colors module matches the actual cmaps available
-    actual = set(colorcet.cm.keys()) - set(mpl.colormaps._builtin_cmaps)
+    actual = set(colorcet.cm.keys()) - set(MPL_BUILTIN_CMAPS)
     expected = set(_COLORCET_CMAPS)
     assert actual == expected
 
 
+@pytest.mark.skipif(MATPLOTLIB_VERSION_INFO < (3, 6))
 def test_cmaps_cmocean_required():
     # Test that cmaps listed in colors module matches the actual cmaps available
-    actual = set(cmocean.cm.cmap_d.keys()) - set(mpl.colormaps._builtin_cmaps)
+    actual = set(cmocean.cm.cmap_d.keys()) - set(MPL_BUILTIN_CMAPS)
     expected = set(_CMOCEAN_CMAPS)
     assert actual == expected

--- a/tests/plotting/test_colors.py
+++ b/tests/plotting/test_colors.py
@@ -265,7 +265,7 @@ def test_cmaps_colorcet_required():
     assert actual == expected
 
 
-@pytest.mark.skipif(MATPLOTLIB_VERSION_INFO < (3, 6))
+@pytest.mark.skipif(MATPLOTLIB_VERSION_INFO < (3, 6), reason='Colormaps API changed.')
 def test_cmaps_cmocean_required():
     # Test that cmaps listed in colors module matches the actual cmaps available
     actual = set(cmocean.cm.cmap_d.keys()) - set(MPL_BUILTIN_CMAPS)

--- a/tests/plotting/test_colors.py
+++ b/tests/plotting/test_colors.py
@@ -20,10 +20,6 @@ from pyvista.plotting.colors import _COLORCET_CMAPS
 from pyvista.plotting.colors import color_scheme_to_cycler
 from pyvista.plotting.colors import get_cmap_safe
 
-# Need to access private var here because non-default cmaps are added
-# to the public `mpl.colormaps` registry
-MPL_BUILTIN_CMAPS = mpl.colormaps._builtin_cmaps
-
 COLORMAPS = ['Greys']
 
 if importlib.util.find_spec('cmocean'):


### PR DESCRIPTION
### Overview

With #7477, a false positive `ModuleNotFoundError` is raised when plotting cmaps like `rainbow` or `gray` which are common to multiple cmap modules.

E.g. When `colorcet` is not installed, `pv.get_cmap_safe('rainbow')` incorrectly raises an error. This PR fixes this.