### PR TITLE
Check `sys.meta_path` in `DisableVtkSnakeCase.__getattribute__`

### DIFF
--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -10,7 +10,6 @@ the entire library.
 from __future__ import annotations
 
 import contextlib
-import sys
 from typing import NamedTuple
 import warnings
 
@@ -632,12 +631,15 @@ class DisableVtkSnakeCase:
             # We normally can import pyvista dynamically, but this can't be done in
             # some cases, e.g. when the python interpreter is shutting down,
             # in which case the meta_path is None and we set the state directly
-            if sys.meta_path is not None:
-                import pyvista as pv
+            # if sys.meta_path is not None:
+            #     import pyvista as pv
+            #
+            #     state = pv._VTK_SNAKE_CASE_STATE
+            # else:
+            #     state = 'error'
+            import pyvista as pv
 
-                state = pv._VTK_SNAKE_CASE_STATE
-            else:
-                state = 'error'
+            state = pv._VTK_SNAKE_CASE_STATE
 
             if state != 'allow':
                 if (

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -628,16 +628,14 @@ class DisableVtkSnakeCase:
         if vtk_version_info >= (9, 4):
             # Raise error if accessing attributes from VTK's pythonic snake_case API
 
-            # Get the current value of the snake case state variable
             if sys.meta_path is None:  # pragma: no cover
                 # Python is likely shutting down, so we avoid any dynamic imports
-                # and simply set a default value
-                state = 'error'  # type: ignore[unreachable]
-            else:  # pragma: no branch
-                import pyvista as pv
+                # and simply return None
+                return None
 
-                state = pv._VTK_SNAKE_CASE_STATE
+            import pyvista as pv
 
+            state = pv._VTK_SNAKE_CASE_STATE
             if state != 'allow':
                 if (
                     attr not in ['__class__', '__init__']

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -631,7 +631,7 @@ class DisableVtkSnakeCase:
             if sys.meta_path is None:  # pragma: no cover
                 # Python is likely shutting down, so we avoid any dynamic imports
                 # and simply return None
-                return None
+                return None  # type: ignore[unreachable]
 
             import pyvista as pv
 

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -632,8 +632,8 @@ class DisableVtkSnakeCase:
             if sys.meta_path is None:
                 # Python is likely shutting down, so we avoid any dynamic imports
                 # and simply set a default value
-                state = 'error'
-            else:
+                state = 'error'  # pragma: no cover
+            else:  # pragma: no branch
                 import pyvista as pv
 
                 state = pv._VTK_SNAKE_CASE_STATE

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -10,6 +10,7 @@ the entire library.
 from __future__ import annotations
 
 import contextlib
+import sys
 from typing import NamedTuple
 import warnings
 
@@ -628,18 +629,14 @@ class DisableVtkSnakeCase:
             # Raise error if accessing attributes from VTK's pythonic snake_case API
 
             # Get the current value of the snake case state variable
-            # We normally can import pyvista dynamically, but this can't be done in
-            # some cases, e.g. when the python interpreter is shutting down,
-            # in which case the meta_path is None and we set the state directly
-            # if sys.meta_path is not None:
-            #     import pyvista as pv
-            #
-            #     state = pv._VTK_SNAKE_CASE_STATE
-            # else:
-            #     state = 'error'
-            import pyvista as pv
+            if sys.meta_path is None:
+                # Python is likely shutting down, so we avoid any dynamic imports
+                # and simply set a default value
+                state = 'error'
+            else:
+                import pyvista as pv
 
-            state = pv._VTK_SNAKE_CASE_STATE
+                state = pv._VTK_SNAKE_CASE_STATE
 
             if state != 'allow':
                 if (

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -629,10 +629,10 @@ class DisableVtkSnakeCase:
             # Raise error if accessing attributes from VTK's pythonic snake_case API
 
             # Get the current value of the snake case state variable
-            if sys.meta_path is None:
+            if sys.meta_path is None:  # pragma: no cover
                 # Python is likely shutting down, so we avoid any dynamic imports
                 # and simply set a default value
-                state = 'error'  # pragma: no cover
+                state = 'error'  # type: ignore[unreachable]
             else:  # pragma: no branch
                 import pyvista as pv
 

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -10,6 +10,7 @@ the entire library.
 from __future__ import annotations
 
 import contextlib
+import sys
 from typing import NamedTuple
 import warnings
 
@@ -626,9 +627,18 @@ class DisableVtkSnakeCase:
     def __getattribute__(self, attr):
         if vtk_version_info >= (9, 4):
             # Raise error if accessing attributes from VTK's pythonic snake_case API
-            import pyvista as pv
 
-            state = pv._VTK_SNAKE_CASE_STATE
+            # Get the current value of the snake case state variable
+            # We normally can import pyvista dynamically, but this can't be done in
+            # some cases, e.g. when the python interpreter is shutting down,
+            # in which case the meta_path is None and we set the state directly
+            if sys.meta_path is not None:
+                import pyvista as pv
+
+                state = pv._VTK_SNAKE_CASE_STATE
+            else:
+                state = 'error'
+
             if state != 'allow':
                 if (
                     attr not in ['__class__', '__init__']

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -1370,3 +1370,7 @@ def test_merge_points(inplace):
     assert output.n_points == 8
     assert isinstance(mesh, pv.PolyData)
     assert (mesh is output) == inplace
+
+
+def test_mre():
+    _ = pv.PolyData().x

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -1370,7 +1370,3 @@ def test_merge_points(inplace):
     assert output.n_points == 8
     assert isinstance(mesh, pv.PolyData)
     assert (mesh is output) == inplace
-
-
-def test_mre():
-    _ = pv.PolyData().x


### PR DESCRIPTION
### Overview

Fix #7503
Dynamic imports in dunder methods like `__getattribute__` can cause issues when Python is trying to shut down. This PR fixes this.