### PR TITLE
Disable vtk's snake case API for all PyVista classes

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -62,6 +62,7 @@ DEFAULT_INPLACE_WARNING = (
 )
 
 
+@abstract_class
 class _PointSet(DataSet):
     """PyVista's equivalent of vtk.vtkPointSet.
 

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -946,7 +946,7 @@ _JSONValueType = Union[
 ]
 
 
-class _SerializedDictArray(UserDict, _vtk.vtkStringArray):  # type: ignore[type-arg]
+class _SerializedDictArray(_vtk.DisableVtkSnakeCase, UserDict, _vtk.vtkStringArray):  # type: ignore[type-arg]
     """Dict-like object with a JSON-serialized string array representation.
 
     This class behaves just like a regular dict, except its contents

--- a/pyvista/plotting/axes_assembly.py
+++ b/pyvista/plotting/axes_assembly.py
@@ -22,6 +22,7 @@ from pyvista.core.utilities.geometric_sources import OrthogonalPlanesSource
 from pyvista.core.utilities.geometric_sources import _AxisEnum
 from pyvista.core.utilities.geometric_sources import _PartEnum
 from pyvista.core.utilities.misc import _NameMixin
+from pyvista.core.utilities.misc import abstract_class
 from pyvista.plotting import _vtk
 from pyvista.plotting.actor import Actor
 from pyvista.plotting.colors import Color
@@ -76,6 +77,7 @@ class _XYZTuple(NamedTuple):
     z: Any
 
 
+@abstract_class
 class _XYZAssembly(_vtk.DisableVtkSnakeCase, _Prop3DMixin, _NameMixin, _vtk.vtkPropAssembly):
     DEFAULT_LABELS = _XYZTuple('X', 'Y', 'Z')
 
@@ -1981,7 +1983,7 @@ class PlanesAssembly(_XYZAssembly):
         self._update_label_positions()
 
 
-class _AxisActor(_vtk.vtkAxisActor):
+class _AxisActor(_vtk.DisableVtkSnakeCase, _vtk.vtkAxisActor):
     def __init__(self):
         super().__init__()
         # Only show the title

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -1841,7 +1841,7 @@ class _Plot(_vtk.DisableVtkSnakeCase, DocSubs):
     @label.setter
     def label(self, val) -> None:
         self._label = '' if val is None else val
-        self.SetLabel(self._label)  # type: ignore[attr-defined]
+        self.SetLabel(self._label)
 
     @property
     @doc_subs
@@ -1866,11 +1866,11 @@ class _Plot(_vtk.DisableVtkSnakeCase, DocSubs):
            >>> chart.show()
 
         """
-        return self.GetVisible()  # type: ignore[attr-defined]
+        return self.GetVisible()
 
     @visible.setter
     def visible(self, val) -> None:
-        self.SetVisible(val)  # type: ignore[attr-defined]
+        self.SetVisible(val)
 
     @doc_subs
     def toggle(self) -> None:
@@ -1913,7 +1913,7 @@ class _MultiCompPlot(_Plot):
         self._color_series = _vtk.vtkColorSeries()
         self._lookup_table = self._color_series.CreateLookupTable(_vtk.vtkColorSeries.CATEGORICAL)
         self._labels = _vtk.vtkStringArray()
-        self.SetLabels(self._labels)  # type: ignore[attr-defined]
+        self.SetLabels(self._labels)
         self.color_scheme = self.DEFAULT_COLOR_SCHEME
 
     @property

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -50,7 +50,7 @@ class _vtkWrapperMeta(type):
         return obj
 
 
-class _vtkWrapper(metaclass=_vtkWrapperMeta):
+class _vtkWrapper(_vtk.DisableVtkSnakeCase, metaclass=_vtkWrapperMeta):
     def __getattribute__(self, item):
         unwrapped_attrs = ['_wrapped', '__class__', '__init__']
         wrapped = super().__getattribute__('_wrapped')
@@ -1075,7 +1075,7 @@ class Axis(_vtkWrapper, _vtk.vtkAxis):
         self.SetCustomTickPositions(locs, labels)
 
 
-class _CustomContextItem(_vtk.vtkPythonItem):
+class _CustomContextItem(_vtk.DisableVtkSnakeCase, _vtk.vtkPythonItem):
     class ItemWrapper:
         def Initialize(self, item) -> bool:
             # item is the _CustomContextItem subclass instance
@@ -1663,7 +1663,7 @@ class _Chart(_vtk.DisableVtkSnakeCase, DocSubs):
         )
 
 
-class _Plot(DocSubs):
+class _Plot(_vtk.DisableVtkSnakeCase, DocSubs):
     """Common pythonic interface for vtkPlot and vtkPlot3D instances."""
 
     # Subclasses should specify following substitutions: 'plot_name', 'chart_init' and 'plot_init'.

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -1663,6 +1663,7 @@ class _Chart(_vtk.DisableVtkSnakeCase, DocSubs):
         )
 
 
+# Subclasses of `_Plot` also inherit from vtk classes, so we disable the vtk snake_case API here
 class _Plot(_vtk.DisableVtkSnakeCase, DocSubs):
     """Common pythonic interface for vtkPlot and vtkPlot3D instances."""
 

--- a/pyvista/plotting/utilities/algorithms.py
+++ b/pyvista/plotting/utilities/algorithms.py
@@ -92,7 +92,7 @@ def set_algorithm_input(alg, inp, port=0):
         alg.SetInputDataObject(port, inp)
 
 
-class PreserveTypeAlgorithmBase(_vtk.VTKPythonAlgorithmBase):
+class PreserveTypeAlgorithmBase(_vtk.DisableVtkSnakeCase, _vtk.VTKPythonAlgorithmBase):
     """Base algorithm to preserve type.
 
     Parameters
@@ -230,7 +230,7 @@ class ActiveScalarsAlgorithm(PreserveTypeAlgorithmBase):
         return 1
 
 
-class PointSetToPolyDataAlgorithm(_vtk.VTKPythonAlgorithmBase):
+class PointSetToPolyDataAlgorithm(_vtk.DisableVtkSnakeCase, _vtk.VTKPythonAlgorithmBase):
     """Algorithm to cast PointSet to PolyData.
 
     This is implemented with :func:`pyvista.PointSet.cast_to_polydata`.
@@ -346,7 +346,7 @@ class AddIDsAlgorithm(PreserveTypeAlgorithmBase):
         return 1
 
 
-class CrinkleAlgorithm(_vtk.VTKPythonAlgorithmBase):
+class CrinkleAlgorithm(_vtk.DisableVtkSnakeCase, _vtk.VTKPythonAlgorithmBase):
     """Algorithm to crinkle cell IDs."""
 
     def __init__(self):

--- a/tests/test_snake_case_api.py
+++ b/tests/test_snake_case_api.py
@@ -130,10 +130,13 @@ def test_vtk_snake_case_api_is_disabled(vtk_subclass):
             match = "The attribute 'global_warning_display' is defined by VTK and is not part of the PyVista API"
             assert match in repr(e)  # noqa: PT017
         else:
-            msg = (
-                f'The class {vtk_subclass.__name__!r} in {vtk_subclass.__module__!r}\n'
-                f'must inherit from {DisableVtkSnakeCase.__name__!r}'
-            )
+            if DisableVtkSnakeCase not in vtk_subclass.__mro__:
+                msg = (
+                    f'The class {vtk_subclass.__name__!r} in {vtk_subclass.__module__!r}\n'
+                    f'must inherit from {DisableVtkSnakeCase.__name__!r} in {DisableVtkSnakeCase.__module__!r}'
+                )
+            else:
+                msg = f'{PyVistaAttributeError.__name__} was NOT raised (but was expected).'
             pytest.fail(msg)
     else:
         assert not hasattr(instance, vtk_attr_snake_case)

--- a/tests/test_snake_case_api.py
+++ b/tests/test_snake_case_api.py
@@ -1,46 +1,70 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import importlib.util
+from pathlib import Path
+import sys
 
 import pytest
 
 import pyvista as pv
+from pyvista.core._vtk_core import DisableVtkSnakeCase
 from pyvista.core.errors import PyVistaAttributeError
 from pyvista.core.errors import VTKVersionError
 
-if TYPE_CHECKING:
-    from types import ModuleType
 
+def get_all_pyvista_classes() -> tuple[tuple[str, ...], tuple[type, ...]]:
+    """Return all classes defined in the pyvista package."""
+    import pyvista as pv
 
-def get_all_classes() -> tuple[tuple[str, ...], tuple[type, ...]]:
-    """Return all classes which inherit from vtk classes."""
-    class_types: list[type] = []
+    class_types: set[type] = set()
 
-    def _append_classes_from_module(module: ModuleType):
-        keys = module.__dict__.keys()
-        for module_item in keys:
-            module_attr = getattr(module, module_item)
-            if not hasattr(module_attr, '__mro__'):
-                continue  # not a class
-            if any(item.__name__.startswith('vtk') for item in module_attr.__mro__):
-                class_types.append(module_attr)
+    # Add pyvista root to sys.path if needed
+    project_root = Path(pv.__file__).resolve().parent.parent
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
 
-    # Get from core and plotting separately since plotting module has a lazy importer
-    _append_classes_from_module(pv.core)
-    _append_classes_from_module(pv.plotting)
+    package_path = Path(pv.__path__[0])  # path to pyvista package
+    all_py_files = [p for p in package_path.rglob('*.py') if p.name != '__init__.py']
+
+    for file_path in all_py_files:
+        try:
+            # Convert path to dotted module name
+            rel_path = file_path.relative_to(project_root)
+            module_name = '.'.join(rel_path.with_suffix('').parts)
+
+            module = importlib.import_module(module_name)
+
+            for name in dir(module):
+                obj = getattr(module, name)
+                if isinstance(obj, type) and getattr(obj, '__module__', '') == module_name:
+                    class_types.add(obj)
+        except Exception as e:
+            print(f'Failed to import {file_path}: {e}')
+
+    sorted_classes = sorted(class_types, key=lambda cls: cls.__name__)
+    return tuple(cls.__name__ for cls in sorted_classes), tuple(sorted_classes)
 
     # Sort and return names and types as separate tuples
-    dict_ = {class_.__name__: class_ for class_ in class_types}
-    sorted_dict = {key: dict_[key] for key in sorted(dict_.keys())}
-    return tuple(sorted_dict.keys()), tuple(sorted_dict.values())
+    sorted_classes = sorted(class_types, key=lambda cls: cls.__name__)
+    return tuple(cls.__name__ for cls in sorted_classes), tuple(sorted_classes)
 
 
 def pytest_generate_tests(metafunc):
     """Generate parametrized tests."""
     if 'vtk_subclass' in metafunc.fixturenames:
-        # Generate a separate test for any class that has bounds
-        class_names, class_types = get_all_classes()
-        metafunc.parametrize('vtk_subclass', class_types, ids=class_names)
+        class_names, class_types = get_all_pyvista_classes()
+
+        def inherits_from_vtk(klass):
+            bases = klass.__mro__[1:]
+            return any(base.__name__.startswith('vtk') for base in bases)
+
+        filtered = {
+            name: cls for name, cls in zip(class_names, class_types) if inherits_from_vtk(cls)
+        }
+        assert filtered
+        names = filtered.keys()
+        types = filtered.values()
+        metafunc.parametrize('vtk_subclass', types, ids=names)
 
 
 def try_init_object(class_, kwargs):
@@ -72,6 +96,28 @@ def test_vtk_snake_case_api_is_disabled(vtk_subclass):
     elif vtk_subclass is pv.CornerAnnotation:
         kwargs['position'] = 'top'
         kwargs['text'] = 'text'
+    elif vtk_subclass is pv.plotting.utilities.algorithms.ActiveScalarsAlgorithm:
+        kwargs['name'] = 'name'
+    elif vtk_subclass is pv.charts.AreaPlot:
+        kwargs['chart'] = pv.charts.Chart2D()
+        kwargs['x'] = (0, 0, 0)
+        kwargs['y1'] = (1, 0, 0)
+    elif vtk_subclass in [pv.charts.BarPlot, pv.charts.LinePlot2D, pv.charts.ScatterPlot2D]:
+        kwargs['chart'] = pv.charts.Chart2D()
+        kwargs['x'] = (0, 0, 0)
+        kwargs['y'] = (1, 0, 0)
+    elif vtk_subclass is pv.charts.StackPlot:
+        kwargs['chart'] = pv.charts.Chart2D()
+        kwargs['x'] = (0, 0, 0)
+        kwargs['ys'] = (1, 0, 0)
+    elif vtk_subclass in [pv.charts.BoxPlot, pv.charts.PiePlot]:
+        kwargs['chart'] = pv.charts.Chart2D()
+        kwargs['data'] = [0, 0, 0]
+    elif vtk_subclass is pv.charts._ChartBackground:
+        kwargs['chart'] = pv.charts.Chart2D()
+    elif vtk_subclass is pv.plotting.background_renderer.BackgroundRenderer:
+        kwargs['parent'] = pv.Plotter()
+        kwargs['image_path'] = pv.examples.logofile
 
     instance = try_init_object(vtk_subclass, kwargs)
     vtk_attr_camel_case = 'GetGlobalWarningDisplay'
@@ -82,8 +128,19 @@ def test_vtk_snake_case_api_is_disabled(vtk_subclass):
 
     if pv.vtk_version_info >= (9, 4):
         # Test getting the snake_case equivalent raises error
-        match = "The attribute 'global_warning_display' is defined by VTK and is not part of the PyVista API"
-        with pytest.raises(PyVistaAttributeError, match=match):
+
+        try:
             getattr(instance, vtk_attr_snake_case)
+        except PyVistaAttributeError as e:
+            # Test passes, we want an error to be raised
+            # Confirm error message is correct
+            match = "The attribute 'global_warning_display' is defined by VTK and is not part of the PyVista API"
+            assert match in repr(e)  # noqa: PT017
+        else:
+            msg = (
+                f'The class {vtk_subclass.__name__!r} in {vtk_subclass.__module__!r}\n'
+                f'must inherit from {DisableVtkSnakeCase.__name__!r}'
+            )
+            pytest.fail(msg)
     else:
         assert not hasattr(instance, vtk_attr_snake_case)

--- a/tests/test_snake_case_api.py
+++ b/tests/test_snake_case_api.py
@@ -13,8 +13,6 @@ from pyvista.core.errors import VTKVersionError
 
 def get_all_pyvista_classes() -> tuple[tuple[str, ...], tuple[type, ...]]:
     """Return all classes defined in the pyvista package."""
-    import pyvista as pv
-
     class_types: set[type] = set()
 
     package_path = Path(pv.__path__[0])  # path to pyvista package

--- a/tests/test_snake_case_api.py
+++ b/tests/test_snake_case_api.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
-import sys
 
 import pytest
 
@@ -18,11 +17,6 @@ def get_all_pyvista_classes() -> tuple[tuple[str, ...], tuple[type, ...]]:
 
     class_types: set[type] = set()
 
-    # Add pyvista root to sys.path if needed
-    project_root = Path(pv.__file__).resolve().parent.parent
-    if str(project_root) not in sys.path:
-        sys.path.insert(0, str(project_root))
-
     package_path = Path(pv.__path__[0])  # path to pyvista package
 
     def find_py_files(path: Path):
@@ -33,7 +27,7 @@ def get_all_pyvista_classes() -> tuple[tuple[str, ...], tuple[type, ...]]:
 
     for file_path in [*core_py_files, *plotting_py_files]:
         # Convert path to dotted module name
-        rel_path = file_path.relative_to(project_root)
+        rel_path = file_path.relative_to(package_path.parent)
         module_name = '.'.join(rel_path.with_suffix('').parts)
 
         module = importlib.import_module(module_name)
@@ -42,9 +36,6 @@ def get_all_pyvista_classes() -> tuple[tuple[str, ...], tuple[type, ...]]:
             obj = getattr(module, name)
             if isinstance(obj, type) and getattr(obj, '__module__', '') == module_name:
                 class_types.add(obj)
-
-    sorted_classes = sorted(class_types, key=lambda cls: cls.__name__)
-    return tuple(cls.__name__ for cls in sorted_classes), tuple(sorted_classes)
 
     # Sort and return names and types as separate tuples
     sorted_classes = sorted(class_types, key=lambda cls: cls.__name__)


### PR DESCRIPTION
### Overview

#7198 aimed to disable vtk's snake case API for all classes, but it was found that the tests from that PR are limited only to imports from `core` and `plotting` modules and therefore some classes were missed (e.g. `plotting.charts`), see https://github.com/pyvista/pyvista/pull/7497#discussion_r2082518718

This PR broadens the tests to include _all_ classes defined in PyVista's `core` and `plotting` modules which inherit from vtk classes.