### PR TITLE
Move check for `sys.meta_path` in `DisableVtkSnakeCase`

### DIFF
--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -625,13 +625,9 @@ class DisableVtkSnakeCase:
     """Base class to raise error if using VTK's `snake_case` API."""
 
     def __getattribute__(self, attr):
-        if vtk_version_info >= (9, 4):
+        # Check sys.meta_path to avoid dynamic imports when Python is shutting down
+        if vtk_version_info >= (9, 4) and sys.meta_path is not None:
             # Raise error if accessing attributes from VTK's pythonic snake_case API
-
-            if sys.meta_path is None:  # pragma: no cover
-                # Python is likely shutting down, so we avoid any dynamic imports
-                # and simply return None
-                return None  # type: ignore[unreachable]
 
             import pyvista as pv
 


### PR DESCRIPTION
### Overview

The fix in #7504 isn't complete since side-effect errors are still being generated when python is shutting down, e.g. https://github.com/pyvista/pyvista/pull/7504#issuecomment-2869215934. This PR allows returning `super().__getattribute__` instead of `None` when `sys.meta_path` is `None`.