### PR TITLE
Resolve warnings of Logger library

### DIFF
--- a/pyvista/ext/viewer_directive.py
+++ b/pyvista/ext/viewer_directive.py
@@ -41,7 +41,7 @@ class OfflineViewerDirective(Directive):
         source_file = str(Path(self.state.document.current_source).parent / self.arguments[0])
         source_file = Path(source_file).absolute().resolve()
         if not Path(source_file).is_file():
-            logger.warn(f'Source file {source_file} does not exist.')
+            logger.warning(f'Source file {source_file} does not exist.')
             return []
 
         # copy viewer HTML to _static
@@ -64,7 +64,7 @@ class OfflineViewerDirective(Directive):
         elif is_path_relative_to(source_file, source_dir):
             dest_partial_path = Path(source_file.parent).relative_to(source_dir)
         else:
-            logger.warn(
+            logger.warning(
                 f'Source file {source_file} is not a subpath of either the build directory of the source directory. Cannot extract base path',
             )
             return []
@@ -76,7 +76,7 @@ class OfflineViewerDirective(Directive):
             try:
                 shutil.copy(source_file, dest_file)
             except Exception as e:
-                logger.warn(f'Failed to copy file from {source_file} to {dest_file}: {e}')
+                logger.warning(f'Failed to copy file from {source_file} to {dest_file}: {e}')
 
         # Compute the relative path of the current source to the source directory,
         # which is the same as the relative path of the '_static' directory to the


### PR DESCRIPTION
# PR Summary
This PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```