### PR TITLE
Update imports and pyvista namespace in `make_tables.py`

### DIFF
--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -9,30 +9,19 @@ from collections.abc import Iterable
 from collections.abc import Iterator
 from collections.abc import Sequence
 from dataclasses import dataclass
-import re
-import sys
-from typing import NamedTuple
-
-if sys.version_info >= (3, 11):
-    from enum import StrEnum
-else:
-    from enum import Enum
-
-    class StrEnum(str, Enum):
-        def __str__(self) -> str:
-            return self.value
-
-
 from enum import auto
 import inspect
 import io
 import os
 from pathlib import Path
+import re
+import sys
 import textwrap
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
 from typing import Literal
+from typing import NamedTuple
 from typing import final
 from typing import get_args
 
@@ -43,7 +32,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scipy.stats import linregress
 
-import pyvista
 import pyvista as pv
 from pyvista.core.celltype import _CELL_TYPE_INFO
 from pyvista.core.errors import VTKVersionError
@@ -62,6 +50,16 @@ from pyvista.plotting.colors import _PARAVIEW_COLORS
 from pyvista.plotting.colors import _TABLEAU_COLORS
 from pyvista.plotting.colors import _VTK_COLORS
 from pyvista.plotting.colors import _format_color_dict
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        def __str__(self) -> str:
+            return self.value
+
 
 if TYPE_CHECKING:
     from types import FunctionType
@@ -259,7 +257,7 @@ class CellQualityMeasuresTable(DocTable):
 class CellQualityInfoTable(DocTable):
     """Class to generate table for cell quality info."""
 
-    cell_type: pyvista.CellType
+    cell_type: pv.CellType
 
     @property
     @final
@@ -1807,15 +1805,15 @@ class DatasetCard:
 
         # Get `download` function from downloads.py or planets.py
         func_name = 'download_' + dataset_name
-        if hasattr(pyvista.examples.downloads, func_name):
-            func = getattr(pyvista.examples.downloads, func_name)
-        elif hasattr(pyvista.examples.planets, func_name):
-            func = getattr(pyvista.examples.planets, func_name)
+        if hasattr(pv.examples.downloads, func_name):
+            func = getattr(pv.examples.downloads, func_name)
+        elif hasattr(pv.examples.planets, func_name):
+            func = getattr(pv.examples.planets, func_name)
         else:
             # Get `load` function from examples.py
             func_name = 'load_' + dataset_name
-            if hasattr(pyvista.examples.examples, func_name):
-                func = getattr(pyvista.examples.examples, func_name)
+            if hasattr(pv.examples.examples, func_name):
+                func = getattr(pv.examples.examples, func_name)
 
         if func is None:
             msg = f'Dataset function {func_name} does not exist.'
@@ -2328,7 +2326,7 @@ class DatasetCardFetcher:
                 try:
                     if isinstance(dataset_loader, _Downloadable):
                         dataset_loader.download()
-                except pyvista.VTKVersionError:
+                except pv.VTKVersionError:
                     # caused by 'download_can', this error is handled later
                     pass
                 else:
@@ -2713,7 +2711,7 @@ class BuiltinCarousel(DatasetGalleryCarousel):
 
     @classmethod
     def fetch_dataset_names(cls):
-        return DatasetCardFetcher.fetch_dataset_names_by_module(pyvista.examples.examples)
+        return DatasetCardFetcher.fetch_dataset_names_by_module(pv.examples.examples)
 
 
 class DownloadsCarousel(DatasetGalleryCarousel):
@@ -2725,7 +2723,7 @@ class DownloadsCarousel(DatasetGalleryCarousel):
 
     @classmethod
     def fetch_dataset_names(cls):
-        return DatasetCardFetcher.fetch_dataset_names_by_module(pyvista.examples.downloads)
+        return DatasetCardFetcher.fetch_dataset_names_by_module(pv.examples.downloads)
 
 
 class PlanetsCarousel(DatasetGalleryCarousel):
@@ -2737,7 +2735,7 @@ class PlanetsCarousel(DatasetGalleryCarousel):
 
     @classmethod
     def fetch_dataset_names(cls):
-        return DatasetCardFetcher.fetch_dataset_names_by_module(pyvista.examples.planets)
+        return DatasetCardFetcher.fetch_dataset_names_by_module(pv.examples.planets)
 
 
 class PointSetCarousel(DatasetGalleryCarousel):


### PR DESCRIPTION
### Overview

The `StrEnum` definition currently splits the imports into two, causing the import sorting to also be split. This PR moves this definition so all imports are grouped and sorted together. `pyvista` and `pyvista as pv` are also both imported, so this PR removes the `pyvista` import.