### PR TITLE
Fix an invalid `if` key causing warnings during workflow execution

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -59,8 +59,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.config.python-version }}
-          if: env.USE_CACHE == 'true'
-          cache: "pip"
+          cache: ${{ env.USE_CACHE == 'true' && 'pip' || '' }}
 
       - name: Install PyVista test dependencies
         run: |


### PR DESCRIPTION
### Overview

This PR attempts to resolve warnings in GitHub workflow runs that are getting thrown because the `if` key is invalid in the location it's being used [[recent example](https://github.com/pyvista/pyvista/actions/runs/15077885943)]:

> ![image](https://github.com/user-attachments/assets/31b69167-8b27-47cd-afc2-b327fec56360)

The strategy used here is an attempt to use a ternary operator to set the caching to "pip" if `USE_CACHE` is set to "true".

However, I'm not sure what the behavior of `actions/setup-python` will be if the `cache` key is set to an empty string when caching is disabled. I assume it will disable caching but this will need to run to be sure.