### PR TITLE
Add VTK references to `CellType` documentation

### DIFF
--- a/pyvista/core/celltype.py
+++ b/pyvista/core/celltype.py
@@ -1056,7 +1056,7 @@ class CellType(IntEnum):
                     _long_doc += f'\n\n{_indent_paragraph(see_also, level=3)}'
                 _short_doc += '\n\n'
             elif see_also:
-                _short_doc += _indent_paragraph(see_also, level=2)
+                _short_doc += f'\n\n{_indent_paragraph(see_also, level=2)}'
 
             self.__doc__ += (
                 _GRID_TEMPLATE_NO_IMAGE.format(badges, _short_doc, _long_doc)

--- a/pyvista/core/celltype.py
+++ b/pyvista/core/celltype.py
@@ -1036,6 +1036,7 @@ class CellType(IntEnum):
                     level=2,
                 )
 
+                # Add additional references to VTK docs
                 cell_class_ref = f':vtk:`{_cell_class.__name__}`'
                 kind, url = (
                     ('Linear', _VTK_BOOK_LINEAR_CELLS_URL)
@@ -1043,13 +1044,9 @@ class CellType(IntEnum):
                     else ('NonLinear', _VTK_BOOK_NONLINEAR_CELLS_URL)
                 )
                 title = f'VTK Book: {kind} Cells'
-                cell_linear_ref = f'`{title}<{url}>`_'
+                cell_linear_ref = f'`{title} <{url}>`_'
                 see_also = f'See also {cell_class_ref} and {cell_linear_ref}.'
-
-                if _short_doc:
-                    _long_doc += f'\n\n{see_also}'
-                else:
-                    _short_doc = see_also
+                _long_doc += f'\n\n{see_also}'
 
             _short_doc = _indent_paragraph(_short_doc, level=2)
             _long_doc = _indent_paragraph(

--- a/pyvista/core/celltype.py
+++ b/pyvista/core/celltype.py
@@ -54,11 +54,6 @@ _GRID_TEMPLATE_WITH_IMAGE = """
 {}
 """
 
-_VTK_BOOK_LINEAR_CELLS_URL = 'https://book.vtk.org/en/latest/VTKBook/05Chapter5.html#linear-cells'
-_VTK_BOOK_NONLINEAR_CELLS_URL = (
-    'https://book.vtk.org/en/latest/VTKBook/05Chapter5.html#nonlinear-types'
-)
-
 
 def _indent_paragraph(string: str, level: int) -> str:
     indentation = ''.join(['    '] * level)
@@ -1038,14 +1033,7 @@ class CellType(IntEnum):
 
                 # Add additional references to VTK docs
                 cell_class_ref = f':vtk:`{_cell_class.__name__}`'
-                kind, url = (
-                    ('Linear', _VTK_BOOK_LINEAR_CELLS_URL)
-                    if cell.IsLinear()
-                    else ('NonLinear', _VTK_BOOK_NONLINEAR_CELLS_URL)
-                )
-                title = f'VTK Book: {kind} Cells'
-                cell_linear_ref = f'`{title} <{url}>`_'
-                see_also = f'See also {cell_class_ref} and {cell_linear_ref}.'
+                see_also = f'See also {cell_class_ref}.'
                 _long_doc += f'\n\n{see_also}'
 
             _short_doc = _indent_paragraph(_short_doc, level=2)

--- a/pyvista/core/celltype.py
+++ b/pyvista/core/celltype.py
@@ -46,6 +46,11 @@ _GRID_TEMPLATE_WITH_IMAGE = """
 {}{}{}
 """
 
+_VTK_BOOK_LINEAR_CELLS_URL = 'https://book.vtk.org/en/latest/VTKBook/05Chapter5.html#linear-cells'
+_VTK_BOOK_NONLINEAR_CELLS_URL = (
+    'https://book.vtk.org/en/latest/VTKBook/05Chapter5.html#nonlinear-types'
+)
+
 
 def _indent_paragraph(string: str, level: int) -> str:
     indentation = ''.join(['    '] * level)
@@ -877,6 +882,9 @@ class CellType(IntEnum):
 
     .. seealso::
 
+        `VTK Book: Cell Types <https://book.vtk.org/en/latest/VTKBook/05Chapter5.html#cell-types>`
+            VTK reference about cell types.
+
         `vtkCellType.h <https://vtk.org/doc/nightly/html/vtkCellType_8h_source.html>`_
             List of all cell types defined in VTK.
 
@@ -1018,8 +1026,19 @@ class CellType(IntEnum):
                     )
                     + '\n\n'
                 )
+
+                cell_class_ref = f':vtk:`{_cell_class.__name__}`'
+                kind, url = (
+                    ('Linear', _VTK_BOOK_LINEAR_CELLS_URL)
+                    if cell.IsLinear()
+                    else ('NonLinear', _VTK_BOOK_NONLINEAR_CELLS_URL)
+                )
+                title = f'VTK Book: {kind} Cells'
+                cell_linear_ref = f'`{title}<{url}>`'
+                see_also = f'See also {cell_class_ref} and {cell_linear_ref}.'
             else:
                 badges = ''
+                see_also = ''
 
             _short_doc = '' if _short_doc is None else _indent_paragraph(_short_doc, level=2)
 
@@ -1030,8 +1049,14 @@ class CellType(IntEnum):
                     _DROPDOWN_TEMPLATE.format(_indent_paragraph(_long_doc, level=1)), level=2
                 )
             )
+
+            # Add spacing between sections and "see also" section as needed
             if _short_doc and _long_doc:
+                if see_also:
+                    _long_doc += f'\n\n{_indent_paragraph(see_also, level=3)}'
                 _short_doc += '\n\n'
+            elif see_also:
+                _short_doc += _indent_paragraph(see_also, level=2)
 
             self.__doc__ += (
                 _GRID_TEMPLATE_NO_IMAGE.format(badges, _short_doc, _long_doc)

--- a/pyvista/core/celltype.py
+++ b/pyvista/core/celltype.py
@@ -1036,7 +1036,7 @@ class CellType(IntEnum):
                 title = f'VTK Book: {kind} Cells'
                 cell_linear_ref = f'`{title}<{url}>`'
                 see_also = f'See also {cell_class_ref} and {cell_linear_ref}.'
-            else:
+            else:  # pragma: no cover
                 badges = ''
                 see_also = ''
 
@@ -1052,10 +1052,10 @@ class CellType(IntEnum):
 
             # Add spacing between sections and "see also" section as needed
             if _short_doc and _long_doc:
-                if see_also:
+                if see_also:  # pragma: no branch
                     _long_doc += f'\n\n{_indent_paragraph(see_also, level=3)}'
                 _short_doc += '\n\n'
-            elif see_also:
+            elif see_also:  # pragma: no branch
                 _short_doc += f'\n\n{_indent_paragraph(see_also, level=2)}'
 
             self.__doc__ += (


### PR DESCRIPTION
### Overview

Add reference link to the respective `vtkCell` docs for each enum member in the More Info dropdown. A reference to the VTK Book is also added. 

E.g.
![image](https://github.com/user-attachments/assets/aab47ce5-0e3a-4118-af29-88fb498aaca3)