### PR TITLE
Remove duplicate colormaps from documentation

### DIFF
--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -967,8 +967,6 @@ _COLORMAP_INFO: list[_ColormapInfo] = [
     _ColormapInfo('cmcrameri', ColormapKind.DIVERGING, 'vanimo'),
     _ColormapInfo('matplotlib', ColormapKind.DIVERGING, 'vanimo'),
     _ColormapInfo('cmcrameri', ColormapKind.DIVERGING, 'managua'),
-    _ColormapInfo('colorcet', ColormapKind.DIVERGING, 'bkr'),
-    _ColormapInfo('colorcet', ColormapKind.DIVERGING, 'bky'),
     _ColormapInfo('matplotlib', ColormapKind.DIVERGING, 'managua'),
     _ColormapInfo('colorcet', ColormapKind.DIVERGING, 'bjy'),
     _ColormapInfo('colorcet', ColormapKind.DIVERGING, 'bwy'),

--- a/tests/doc/test_tables.py
+++ b/tests/doc/test_tables.py
@@ -85,6 +85,7 @@ def test_colormap_table_colorcet_continuous(colorcet_continuous_cmaps):
         if (info.package == 'colorcet') and (info.kind.name != 'CATEGORICAL')
     ]
     assert set(documented_cmaps) == set(colorcet_continuous_cmaps), CMAP_SET_MISMATCH_ERROR_MSG
+    assert sorted(documented_cmaps) == sorted(colorcet_continuous_cmaps), DUPLICATE_CMAP_ERROR_MSG
 
 
 def test_colormap_table_colorcet_categorical(colorcet_categorical_cmaps):
@@ -94,3 +95,4 @@ def test_colormap_table_colorcet_categorical(colorcet_categorical_cmaps):
         if info.package == 'colorcet' and info.kind.name == 'CATEGORICAL'
     ]
     assert set(documented_cmaps) == set(colorcet_categorical_cmaps), CMAP_SET_MISMATCH_ERROR_MSG
+    assert sorted(documented_cmaps) == sorted(colorcet_categorical_cmaps), DUPLICATE_CMAP_ERROR_MSG


### PR DESCRIPTION
### Overview

Similar to #7532. Two duplicate ``colorcet`` cmaps were missed by that PR.