### PR TITLE
Fix test failure for numpy 2.3

### DIFF
--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -1161,7 +1161,7 @@ def test_recursive_iterator_order(nested_fixture, order, expected_ids, expected_
     [('prepend', '//', 'data', 'Block-00//data'), ('preserve', '::', 'data', 'data')],
 )
 def test_move_nested_field_data_to_root(copy, field_data_mode, separator, name_in, name_out):
-    value = [42]
+    value = np.array([42])
     multi = pv.MultiBlock()
     multi.field_data[name_in] = value
     root = pv.MultiBlock([multi])

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -1161,6 +1161,7 @@ def test_recursive_iterator_order(nested_fixture, order, expected_ids, expected_
     [('prepend', '//', 'data', 'Block-00//data'), ('preserve', '::', 'data', 'data')],
 )
 def test_move_nested_field_data_to_root(copy, field_data_mode, separator, name_in, name_out):
+    # https://github.com/pyvista/pyvista/pull/7538
     value = np.array([42])
     multi = pv.MultiBlock()
     multi.field_data[name_in] = value


### PR DESCRIPTION
### Overview

This test is failing for pre-release numpy (2.3.0dev):
https://github.com/pyvista/pyvista/actions/runs/15154194437/job/42643266844?pr=7536#step:12:8557
``` 
FAILED tests/core/test_composite.py::test_move_nested_field_data_to_root[prepend-//-data-Block-00//data-None] - assert False
 +  where False = <function array_equal at 0x7fd6dd963bf0>(pyvista_ndarray([1]), [42])
 +    where <function array_equal at 0x7fd6dd963bf0> = np.array_equal
```

Locally, I do not get `pyvista_ndarray([1]), [42]` as a comparison, but rather `pyvista_ndarray([44636345150720]), [42])`
Which  to me suggests that there's some sort of dangling pointer or invalid reference to the array. This particular test for `move_nested_field_data_to_root` is testing behavior similar to:
``` python
import pyvista as pv
import numpy as np
m1 = pv.MultiBlock()
m2 = pv.MultiBlock([m1])

m1.field_data['data'] = [42]
m2.field_data['data'] = m1.field_data['data']
assert np.array_equal(m1.field_data['data'], m2.field_data['data'])
```
where the nested field data is moved to the root multiblock without copying or removing the nested field data. However, the example above works, so it doesn't quite replicate the internals of `move_nested_field_data_to_root`.

I think this may be related to garbage collection for how array data is stored with `pyvista_ndarray` and/or `VTKArray`... not really sure.

Casting the input as an array "fixes" this, but it's just a workaround for the test, and this could still be a bug waiting to break something in the future....

