### PR TITLE
Add `filelock` to MNE test dependencies

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,7 +51,7 @@ jobs:
       - run: git clone --depth=1 https://github.com/mne-tools/mne-python.git --branch main --single-branch
       - run: ./mne-python/tools/setup_xvfb.sh
       - name: Install MNE dependencies
-        run: pip install numpy scipy matplotlib nibabel "PyQt6-Qt6!=6.6.0,!=6.7.0" "PyQt6!=6.6.0" qtpy ipympl pytest pytest-cov pytest-harvest pytest-timeout sphinx-gallery nbformat nbclient imageio imageio-ffmpeg
+        run: pip install numpy scipy matplotlib nibabel "PyQt6-Qt6!=6.6.0,!=6.7.0" "PyQt6!=6.6.0" qtpy ipympl pytest pytest-cov pytest-harvest pytest-timeout sphinx-gallery nbformat nbclient imageio imageio-ffmpeg filelock
       - name: Install PyVista
         run: pip install -ve . # pyvista
       - name: Install PyVistaQt main


### PR DESCRIPTION
### Overview

Tests are failing, `filelock` is now required, see https://github.com/mne-tools/mne-python/pull/13241

@larsoner should we change this to install from extras, e.g. `pip install .[full]`, so that dependencies are always up to date? 