### PR TITLE
Revert #7538 'Fix test failure for numpy 2.3'

### DIFF
--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -1161,8 +1161,7 @@ def test_recursive_iterator_order(nested_fixture, order, expected_ids, expected_
     [('prepend', '//', 'data', 'Block-00//data'), ('preserve', '::', 'data', 'data')],
 )
 def test_move_nested_field_data_to_root(copy, field_data_mode, separator, name_in, name_out):
-    # https://github.com/pyvista/pyvista/pull/7538
-    value = np.array([42])
+    value = [42]
     multi = pv.MultiBlock()
     multi.field_data[name_in] = value
     root = pv.MultiBlock([multi])


### PR DESCRIPTION
### Overview

This change was originally needed because of a numpy bug https://github.com/numpy/numpy/issues/29038 which has now been resolved.

Will leave as draft until the numpy nightly wheels are updated (and CI passes)