### PR TITLE
Upgrade typing to support latest `numpy`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ pinned = [ # Pinned versions of core dependencies
 
 typing = [
   'mypy<1.14.0',
-  'npt-promote==0.2',
   'numpy>=2.0.0',
   'trimesh<4.6.0',
   { include-group = 'pinned' },
@@ -251,7 +250,7 @@ extra_checks = true
 ignore_missing_imports = true
 no_implicit_reexport = true
 packages = ['pyvista']
-plugins = ['npt_promote', 'pyvista.typing.mypy_plugin']
+plugins = ['pyvista.typing.mypy_plugin']
 pretty = true
 show_error_context = true
 strict_equality = true

--- a/tests/typing/mypy_plugin/test_plugin.py
+++ b/tests/typing/mypy_plugin/test_plugin.py
@@ -76,7 +76,9 @@ y: DuckType
 def foo(x: {arg_type.__name__}) -> None: ...
 foo(y)
 """
-    mypy_output = _run_mypy_code(code, use_plugin=use_plugin, tmp_path=tmp_path)
+    mypy_output = _run_mypy_code(
+        code, use_plugin=use_plugin, follow_imports=False, tmp_path=tmp_path
+    )
     stdout = str(mypy_output.stdout.decode('utf-8'))
     code = mypy_output.returncode
     if expected_output == '':
@@ -86,7 +88,7 @@ foo(y)
         assert expected_output in stdout
 
 
-def _run_mypy_code(code, use_plugin, tmp_path):
+def _run_mypy_code(code, use_plugin, follow_imports, tmp_path):
     """Call mypy from the project root dir with or without the plugin enabled."""
     # Save code to tmp file
     tmp_file = tmp_path / 'code.py'
@@ -95,9 +97,11 @@ def _run_mypy_code(code, use_plugin, tmp_path):
 
     cwd = Path.cwd()
     try:
-        # Use '--follow-imports=skip' to only analyze the files passed to mypy
-        # otherwise it will analyze the entire pyvista library
-        args = ['mypy', '--show-traceback', '--follow-imports=skip']
+        args = ['mypy', '--show-traceback']
+        if not follow_imports:
+            # Use '--follow-imports=skip' to only analyze the files passed to mypy
+            # otherwise it will analyze the entire pyvista library
+            args.append('--follow-imports=skip')
 
         # Set config file
         config = MYPY_CONFIG_FILE_USE_PLUGIN if use_plugin else MYPY_CONFIG_FILE_NO_PLUGIN
@@ -108,3 +112,53 @@ def _run_mypy_code(code, use_plugin, tmp_path):
         return subprocess.run(args, capture_output=True)
     finally:
         os.chdir(cwd)
+
+
+cases = [
+    dict(  # Test that NDArray[float]
+        use_plugin=False,
+        generic_arg=float,
+        expected_error=[
+            ':3: error: Type argument "float" of "NDArray" must be a subtype of "generic[Any]"'
+        ],
+        expected_note=[
+            ':4: note: Revealed type is "numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[builtins.float]]"'
+        ],
+    ),
+    dict(  # Test that NDArray[float]
+        use_plugin=True,
+        generic_arg=float,
+        expected_error=None,
+        expected_note=[
+            ':4: note: Revealed type is "numpy.ndarray[builtins.tuple[builtins.int, ...], numpy.dtype[builtins.float]]"'
+        ],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ('use_plugin', 'generic_arg', 'expected_error', 'expected_note'),
+    [case.values() for case in cases],
+)
+def test_generic_arraylike(use_plugin, generic_arg, expected_error, expected_note, tmp_path):
+    code = f"""
+from numpy.typing import NDArray
+x: NDArray[{generic_arg.__name__}]
+reveal_type(x)
+"""
+    mypy_output = _run_mypy_code(
+        code, use_plugin=use_plugin, follow_imports=True, tmp_path=tmp_path
+    )
+    stdout = str(mypy_output.stdout.decode('utf-8'))
+    code = mypy_output.returncode
+
+    if expected_error:
+        assert code != 0, f'Mypy returned success status, but an error was expected:\n{stdout}'
+        for error in expected_error:
+            assert error in stdout
+    else:
+        assert code == 0, f'Mypy did not return success status:\n{stdout}'
+
+    if expected_note:
+        for note in expected_note:
+            assert note in stdout


### PR DESCRIPTION
### Overview

Related to https://github.com/pyvista/pyvista/pull/7015

NumPy has recently made a lot of updates to their typing. This revealed some issues with the type promotion from the `npt-promote` plugin, which will need to be modified.

This PR merges the `npt-promote` into PyVista's existing plugin, fixes the type promotion issue with the plugin, and addresses more general typing issues with the latest numpy release.
