### PR TITLE
Ignore SciPy warning about NumPy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,6 +217,7 @@ doctest_optionflags = 'NUMBER ELLIPSIS'
 filterwarnings = [
   'error',
 
+  'ignore:.*A NumPy version .* is required for this version of SciPy.*:UserWarning',
   'ignore:.*Given trait value dtype "float64":UserWarning',                                                              # bogus numpy ABI warning (see numpy/#432)
   'ignore:.*The NumPy module was reloaded*:UserWarning',                                                                 # bogus numpy ABI warning (see numpy/#432)
   'ignore:.*numpy.dtype size changed.*:RuntimeWarning',                                                                  # bogus numpy ABI warning (see numpy/#432)


### PR DESCRIPTION
### Overview

The nightly NumPy wheels have bumped version to 2.4.0dev0. SciPy is now warning about this, causing CI to fail. This PR ignores this warning.