### PR TITLE
Add `BoundsTuple.__repr__` to align values with decimals

### DIFF
--- a/doc/source/user-guide/simple.rst
+++ b/doc/source/user-guide/simple.rst
@@ -75,7 +75,12 @@ First, check out some common meta-properties:
 
     What are the mesh bounds?
     >>> mesh.bounds
-    BoundsTuple(x_min=139.061, x_max=1654.93, y_min=32.09, y_max=1319.95, z_min-17.74, z_max=282.13)
+    BoundsTuple(x_min =  139.06100463867188
+                x_max = 1654.9300537109375
+                y_min =   32.09429931640625
+                y_max = 1319.949951171875
+                z_min =  -17.741199493408203
+                z_max =  282.1300048828125)
 
     Where is the center of this mesh?
 

--- a/pyvista/core/_typing_core/_aliases.py
+++ b/pyvista/core/_typing_core/_aliases.py
@@ -81,6 +81,26 @@ class BoundsTuple(NamedTuple):
     z_min: float
     z_max: float
 
+    def __repr__(self) -> str:
+        # Split bounds at decimal and compute padding needed to the left of it
+        dot = '.'
+        split_strings = [str(float(val)).split(dot) for val in self]
+        pad_left = max(len(parts[0]) for parts in split_strings)
+
+        # Iterate through fields and align values at the decimal
+        lines = []
+        fields = self._fields
+        field_size = max(len(f) for f in fields)
+        name = self.__class__.__name__
+        whitespace = (len(name) + 1) * ' '
+        for i, items in enumerate(zip(fields, split_strings)):
+            field, parts = items
+            left, right = parts
+            aligned = f'{left:>{pad_left}}{dot}{right}'
+            lines.append(f'{"" if i == 0 else whitespace}{field:<{field_size}} = {aligned}')
+
+        return f'{name}({"\n".join(lines)})'
+
 
 CellsLike = Union[MatrixLike[int], VectorLike[int]]
 

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -513,7 +513,12 @@ class Cell(DataObject, _vtk.vtkGenericCell):
         >>> import pyvista as pv
         >>> mesh = pv.Sphere()
         >>> mesh.get_cell(0).bounds
-        BoundsTuple(x_min=0.0, x_max=0.05405950918793678, y_min=0.0, y_max=0.011239604093134403, z_min=0.49706897139549255, z_max=0.5)
+        BoundsTuple(x_min = 0.0
+                    x_max = 0.05405950918793678
+                    y_min = 0.0
+                    y_max = 0.011239604093134403
+                    z_min = 0.49706897139549255
+                    z_max = 0.5)
 
         """
         return BoundsTuple(*self.GetBounds())

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -1238,7 +1238,12 @@ class MultiBlock(
         ... ]
         >>> blocks = pv.MultiBlock(data)
         >>> blocks.bounds
-        BoundsTuple(x_min=-0.5, x_max=2.5, y_min=-0.5, y_max=2.5, z_min=-0.5, z_max=0.5)
+        BoundsTuple(x_min = -0.5
+                    x_max =  2.5
+                    y_min = -0.5
+                    y_max =  2.5
+                    z_min = -0.5
+                    z_max =  0.5)
 
         """
         # apply reduction of min and max over each block

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1226,7 +1226,12 @@ class DataSet(DataSetFilters, DataObject):
         >>> import pyvista as pv
         >>> cube = pv.Cube()
         >>> cube.bounds
-        BoundsTuple(x_min=-0.5, x_max=0.5, y_min=-0.5, y_max=0.5, z_min=-0.5, z_max=0.5)
+        BoundsTuple(x_min = -0.5
+                    x_max =  0.5
+                    y_min = -0.5
+                    y_max =  0.5
+                    z_min = -0.5
+                    z_max =  0.5)
 
         """
         return BoundsTuple(*self.GetBounds())
@@ -2856,7 +2861,12 @@ class DataSet(DataSetFilters, DataObject):
         >>> from pyvista import examples
         >>> mesh = examples.load_hexbeam()
         >>> mesh.get_cell(0).bounds
-        BoundsTuple(x_min=0.0, x_max=0.5, y_min=0.0, y_max=0.5, z_min=0.0, z_max=0.5)
+        BoundsTuple(x_min = 0.0
+                    x_max = 0.5
+                    y_min = 0.0
+                    y_max = 0.5
+                    z_min = 0.0
+                    z_max = 0.5)
         >>> mesh.point_is_inside_cell(0, [0.2, 0.2, 0.2])
         True
 

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -3208,11 +3208,21 @@ class ImageDataFilters(DataSetFilters):
 
         >>> image_as_cells = image.points_to_cells()
         >>> image_as_cells.bounds
-        BoundsTuple(x_min=-0.5, x_max=2.5, y_min=-0.5, y_max=1.5, z_min=0.0, z_max=0.0)
+        BoundsTuple(x_min = -0.5
+                    x_max =  2.5
+                    y_min = -0.5
+                    y_max =  1.5
+                    z_min =  0.0
+                    z_max =  0.0)
 
         >>> upsampled_as_cells = upsampled.points_to_cells()
         >>> upsampled_as_cells.bounds
-        BoundsTuple(x_min=-0.5, x_max=2.5, y_min=-0.5, y_max=1.5, z_min=0.0, z_max=0.0)
+        BoundsTuple(x_min = -0.5
+                    x_max =  2.5
+                    y_min = -0.5
+                    y_max =  1.5
+                    z_min =  0.0
+                    z_max =  0.0)
 
         Plot the two images together as wireframe to visualize them. The original is in
         red, and the resampled image is in black.
@@ -3292,9 +3302,19 @@ class ImageDataFilters(DataSetFilters):
         bounds are not (and cannot be) extended.
 
         >>> volume.bounds
-        BoundsTuple(x_min=-0.5, x_max=2.5, y_min=-0.5, y_max=1.5, z_min=-0.5, z_max=0.5)
+        BoundsTuple(x_min = -0.5
+                    x_max =  2.5
+                    y_min = -0.5
+                    y_max =  1.5
+                    z_min = -0.5
+                    z_max =  0.5)
         >>> resampled.bounds
-        BoundsTuple(x_min=-0.5, x_max=2.5, y_min=-0.5, y_max=1.5, z_min=-0.5, z_max=0.5)
+        BoundsTuple(x_min = -0.5
+                    x_max =  2.5
+                    y_min = -0.5
+                    y_max =  1.5
+                    z_min = -0.5
+                    z_max =  0.5)
 
         Use a reference image to control the resampling instead. Here we load two
         images with different dimensions:

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -940,7 +940,12 @@ class ImageData(Grid, ImageDataFilters, _vtk.vtkImageData):
         (4, 4, 4)
 
         >>> grid.bounds
-        BoundsTuple(x_min=2.0, x_max=5.0, y_min=2.0, y_max=5.0, z_min=2.0, z_max=5.0)
+        BoundsTuple(x_min = 2.0
+                    x_max = 5.0
+                    y_min = 2.0
+                    y_max = 5.0
+                    z_min = 2.0
+                    z_max = 5.0)
 
         """
         return self.GetExtent()

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -3418,10 +3418,20 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
         >>> grid = examples.load_explicit_structured()
         >>> grid = grid.hide_cells(range(80, 120))
         >>> grid.bounds
-        BoundsTuple(x_min=0.0, x_max=80.0, y_min=0.0, y_max=50.0, z_min=0.0, z_max=6.0)
+        BoundsTuple(x_min =  0.0
+                    x_max = 80.0
+                    y_min =  0.0
+                    y_max = 50.0
+                    z_min =  0.0
+                    z_max =  6.0)
 
         >>> grid.visible_bounds
-        BoundsTuple(x_min=0.0, x_max=80.0, y_min=0.0, y_max=50.0, z_min=0.0, z_max=4.0)
+        BoundsTuple(x_min =  0.0
+                    x_max = 80.0
+                    y_min =  0.0
+                    y_max = 50.0
+                    z_min =  0.0
+                    z_max =  4.0)
 
         """
         name = _vtk.vtkDataSetAttributes.GhostArrayName()

--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -3328,7 +3328,12 @@ class AxesGeometrySource:
         >>> import pyvista as pv
         >>> axes_geometry_source = pv.AxesGeometrySource(symmetric_bounds=True)
         >>> axes_geometry_source.output.bounds
-        BoundsTuple(x_min=-1.0, x_max=1.0, y_min=-1.0, y_max=1.0, z_min=-1.0, z_max=1.0)
+        BoundsTuple(x_min = -1.0
+                    x_max =  1.0
+                    y_min = -1.0
+                    y_max =  1.0
+                    z_min = -1.0
+                    z_max =  1.0)
 
         >>> axes_geometry_source.output.center
         (0.0, 0.0, 0.0)
@@ -3337,7 +3342,12 @@ class AxesGeometrySource:
 
         >>> axes_geometry_source.symmetric_bounds = False
         >>> axes_geometry_source.output.bounds
-        BoundsTuple(x_min=-0.10000000149011612, x_max=1.0, y_min=-0.10000000149011612, y_max=1.0, z_min=-0.10000000149011612, z_max=1.0)
+        BoundsTuple(x_min = -0.1
+                    x_max =  1.0
+                    y_min = -0.1
+                    y_max =  1.0
+                    z_min = -0.1
+                    z_max =  1.0)
 
         >>> axes_geometry_source.output.center
         (0.45, 0.45, 0.45)
@@ -3719,7 +3729,7 @@ class AxesGeometrySource:
             (bnds.x_max - bnds.x_min, bnds.y_max - bnds.y_min, bnds.z_max - bnds.z_min)
         )
         if np.any(axis_length < 1e-8):
-            msg = f'Custom axes part must be 3D. Got bounds: {bnds}.'
+            msg = f'Custom axes part must be 3D. Got bounds:\n{bnds}.'
             raise ValueError(msg)
         part.scale(np.reciprocal(axis_length), inplace=True)
         return part

--- a/pyvista/plotting/actor.py
+++ b/pyvista/plotting/actor.py
@@ -241,11 +241,21 @@ class Actor(Prop3D, _NameMixin, _vtk.vtkActor):
         >>> pl = pv.Plotter()
         >>> actor = pl.add_mesh(mesh)
         >>> pl.bounds
-        BoundsTuple(x_min=139.06100463867188, x_max=1654.9300537109375, y_min=32.09429931640625, y_max=1319.949951171875, z_min=-17.741199493408203, z_max=282.1300048828125)
+        BoundsTuple(x_min =  139.06100463867188
+                    x_max = 1654.9300537109375
+                    y_min =   32.09429931640625
+                    y_max = 1319.949951171875
+                    z_min =  -17.741199493408203
+                    z_max =  282.1300048828125)
 
         >>> actor.visibility = False
         >>> pl.bounds
-        BoundsTuple(x_min=-1.0, x_max=1.0, y_min=-1.0, y_max=1.0, z_min=-1.0, z_max=1.0)
+        BoundsTuple(x_min = -1.0
+                    x_max =  1.0
+                    y_min = -1.0
+                    y_max =  1.0
+                    z_min = -1.0
+                    z_max =  1.0)
 
         """
         return bool(self.GetVisibility())
@@ -276,11 +286,21 @@ class Actor(Prop3D, _NameMixin, _vtk.vtkActor):
         >>> pl = pv.Plotter()
         >>> actor = pl.add_mesh(mesh)
         >>> pl.bounds
-        BoundsTuple(x_min=139.06100463867188, x_max=1654.9300537109375, y_min=32.09429931640625, y_max=1319.949951171875, z_min=-17.741199493408203, z_max=282.1300048828125)
+        BoundsTuple(x_min =  139.06100463867188
+                    x_max = 1654.9300537109375
+                    y_min =   32.09429931640625
+                    y_max = 1319.949951171875
+                    z_min =  -17.741199493408203
+                    z_max =  282.1300048828125)
 
         >>> actor.use_bounds = False
         >>> pl.bounds
-        BoundsTuple(x_min=-1.0, x_max=1.0, y_min=-1.0, y_max=1.0, z_min=-1.0, z_max=1.0)
+        BoundsTuple(x_min = -1.0
+                    x_max =  1.0
+                    y_min = -1.0
+                    y_max =  1.0
+                    z_min = -1.0
+                    z_max =  1.0)
 
         Although the actor's bounds are no longer used, the actor remains visible.
 

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -56,7 +56,12 @@ class _BaseMapper(_vtk.DisableVtkSnakeCase, _vtk.vtkAbstractMapper):
         >>> import pyvista as pv
         >>> mapper = pv.DataSetMapper(dataset=pv.Cube())
         >>> mapper.bounds
-        BoundsTuple(x_min=-0.5, x_max=0.5, y_min=-0.5, y_max=0.5, z_min=-0.5, z_max=0.5)
+        BoundsTuple(x_min = -0.5
+                    x_max =  0.5
+                    y_min = -0.5
+                    y_max =  0.5
+                    z_min = -0.5
+                    z_max =  0.5)
 
         """
         return BoundsTuple(*self.GetBounds())

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -1703,7 +1703,12 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> pl = pv.Plotter()
         >>> _ = pl.add_mesh(pv.Cube())
         >>> pl.bounds
-        BoundsTuple(x_min=-0.5, x_max=0.5, y_min=-0.5, y_max=0.5, z_min=-0.5, z_max=0.5)
+        BoundsTuple(x_min = -0.5
+                    x_max =  0.5
+                    y_min = -0.5
+                    y_max =  0.5
+                    z_min = -0.5
+                    z_max =  0.5)
 
         """
         return self.renderer.bounds

--- a/pyvista/plotting/prop3d.py
+++ b/pyvista/plotting/prop3d.py
@@ -297,7 +297,12 @@ class Prop3D(_vtk.DisableVtkSnakeCase, _vtk.vtkProp3D):
         >>> mesh = pv.Cube(x_length=0.1, y_length=0.2, z_length=0.3)
         >>> actor = pl.add_mesh(mesh)
         >>> actor.bounds
-        BoundsTuple(x_min=-0.05, x_max=0.05, y_min=-0.1, y_max=0.1, z_min=-0.15, z_max=0.15)
+        BoundsTuple(x_min = -0.05
+                    x_max =  0.05
+                    y_min = -0.1
+                    y_max =  0.1
+                    z_min = -0.15
+                    z_max =  0.15)
 
         """
         return BoundsTuple(*self.GetBounds())

--- a/pyvista/plotting/volume.py
+++ b/pyvista/plotting/volume.py
@@ -41,7 +41,12 @@ class Volume(Prop3D, _vtk.vtkVolume):
         >>> pl = pv.Plotter()
         >>> actor = pl.add_volume(vol)
         >>> actor.mapper.bounds
-        BoundsTuple(x_min=0.0, x_max=9.0, y_min=0.0, y_max=9.0, z_min=0.0, z_max=9.0)
+        BoundsTuple(x_min = 0.0
+                    x_max = 9.0
+                    y_min = 0.0
+                    y_max = 9.0
+                    z_min = 0.0
+                    z_max = 9.0)
 
         """
         return self.GetMapper()  # type: ignore[return-value]

--- a/tests/core/test_geometric_sources.py
+++ b/tests/core/test_geometric_sources.py
@@ -640,7 +640,15 @@ def test_axes_geometry_source_custom_part(axes_geometry_source):
     axes_geometry_source.tip_type = pv.ParametricKlein()
     assert axes_geometry_source.tip_type == 'custom'
 
-    match = 'Custom axes part must be 3D. Got bounds: BoundsTuple(x_min=-0.5, x_max=0.5, y_min=-0.5, y_max=0.5, z_min=0.0, z_max=0.0).'
+    match = (
+        'Custom axes part must be 3D. Got bounds:\n'
+        'BoundsTuple(x_min = -0.5\n'
+        '            x_max =  0.5\n'
+        '            y_min = -0.5\n'
+        '            y_max =  0.5\n'
+        '            z_min =  0.0\n'
+        '            z_max =  0.0).'
+    )
     with pytest.raises(ValueError, match=re.escape(match)):
         axes_geometry_source.shaft_type = pv.Plane()
 


### PR DESCRIPTION
### Overview

Sometimes the bounds are very long when there are non-round float values. This can make the docstring very long width-wise. This PR adds a repr method to put each value on its own line and align them with the decimal to make the bounds more legible.