### PR TITLE
Add trailing commas to `BoundsTuple` repr

### DIFF
--- a/doc/source/user-guide/simple.rst
+++ b/doc/source/user-guide/simple.rst
@@ -75,11 +75,11 @@ First, check out some common meta-properties:
 
     What are the mesh bounds?
     >>> mesh.bounds
-    BoundsTuple(x_min =  139.06100463867188
-                x_max = 1654.9300537109375
-                y_min =   32.09429931640625
-                y_max = 1319.949951171875
-                z_min =  -17.741199493408203
+    BoundsTuple(x_min =  139.06100463867188,
+                x_max = 1654.9300537109375,
+                y_min =   32.09429931640625,
+                y_max = 1319.949951171875,
+                z_min =  -17.741199493408203,
                 z_max =  282.1300048828125)
 
     Where is the center of this mesh?

--- a/pyvista/core/_typing_core/_aliases.py
+++ b/pyvista/core/_typing_core/_aliases.py
@@ -97,7 +97,9 @@ class BoundsTuple(NamedTuple):
             field, parts = items
             left, right = parts
             aligned = f'{left:>{pad_left}}{dot}{right}'
-            lines.append(f'{"" if i == 0 else whitespace}{field:<{field_size}} = {aligned}')
+            spacing = '' if i == 0 else whitespace
+            comma = '' if i == len(fields) - 1 else ','
+            lines.append(f'{spacing}{field:<{field_size}} = {aligned}{comma}')
 
         joined_lines = '\n'.join(lines)
         return f'{name}({joined_lines})'

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -513,11 +513,11 @@ class Cell(DataObject, _vtk.vtkGenericCell):
         >>> import pyvista as pv
         >>> mesh = pv.Sphere()
         >>> mesh.get_cell(0).bounds
-        BoundsTuple(x_min = 0.0
-                    x_max = 0.05405950918793678
-                    y_min = 0.0
-                    y_max = 0.011239604093134403
-                    z_min = 0.49706897139549255
+        BoundsTuple(x_min = 0.0,
+                    x_max = 0.05405950918793678,
+                    y_min = 0.0,
+                    y_max = 0.011239604093134403,
+                    z_min = 0.49706897139549255,
                     z_max = 0.5)
 
         """

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -1238,11 +1238,11 @@ class MultiBlock(
         ... ]
         >>> blocks = pv.MultiBlock(data)
         >>> blocks.bounds
-        BoundsTuple(x_min = -0.5
-                    x_max =  2.5
-                    y_min = -0.5
-                    y_max =  2.5
-                    z_min = -0.5
+        BoundsTuple(x_min = -0.5,
+                    x_max =  2.5,
+                    y_min = -0.5,
+                    y_max =  2.5,
+                    z_min = -0.5,
                     z_max =  0.5)
 
         """

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1226,11 +1226,11 @@ class DataSet(DataSetFilters, DataObject):
         >>> import pyvista as pv
         >>> cube = pv.Cube()
         >>> cube.bounds
-        BoundsTuple(x_min = -0.5
-                    x_max =  0.5
-                    y_min = -0.5
-                    y_max =  0.5
-                    z_min = -0.5
+        BoundsTuple(x_min = -0.5,
+                    x_max =  0.5,
+                    y_min = -0.5,
+                    y_max =  0.5,
+                    z_min = -0.5,
                     z_max =  0.5)
 
         """
@@ -2861,11 +2861,11 @@ class DataSet(DataSetFilters, DataObject):
         >>> from pyvista import examples
         >>> mesh = examples.load_hexbeam()
         >>> mesh.get_cell(0).bounds
-        BoundsTuple(x_min = 0.0
-                    x_max = 0.5
-                    y_min = 0.0
-                    y_max = 0.5
-                    z_min = 0.0
+        BoundsTuple(x_min = 0.0,
+                    x_max = 0.5,
+                    y_min = 0.0,
+                    y_max = 0.5,
+                    z_min = 0.0,
                     z_max = 0.5)
         >>> mesh.point_is_inside_cell(0, [0.2, 0.2, 0.2])
         True

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -3208,20 +3208,20 @@ class ImageDataFilters(DataSetFilters):
 
         >>> image_as_cells = image.points_to_cells()
         >>> image_as_cells.bounds
-        BoundsTuple(x_min = -0.5
-                    x_max =  2.5
-                    y_min = -0.5
-                    y_max =  1.5
-                    z_min =  0.0
+        BoundsTuple(x_min = -0.5,
+                    x_max =  2.5,
+                    y_min = -0.5,
+                    y_max =  1.5,
+                    z_min =  0.0,
                     z_max =  0.0)
 
         >>> upsampled_as_cells = upsampled.points_to_cells()
         >>> upsampled_as_cells.bounds
-        BoundsTuple(x_min = -0.5
-                    x_max =  2.5
-                    y_min = -0.5
-                    y_max =  1.5
-                    z_min =  0.0
+        BoundsTuple(x_min = -0.5,
+                    x_max =  2.5,
+                    y_min = -0.5,
+                    y_max =  1.5,
+                    z_min =  0.0,
                     z_max =  0.0)
 
         Plot the two images together as wireframe to visualize them. The original is in
@@ -3302,18 +3302,18 @@ class ImageDataFilters(DataSetFilters):
         bounds are not (and cannot be) extended.
 
         >>> volume.bounds
-        BoundsTuple(x_min = -0.5
-                    x_max =  2.5
-                    y_min = -0.5
-                    y_max =  1.5
-                    z_min = -0.5
+        BoundsTuple(x_min = -0.5,
+                    x_max =  2.5,
+                    y_min = -0.5,
+                    y_max =  1.5,
+                    z_min = -0.5,
                     z_max =  0.5)
         >>> resampled.bounds
-        BoundsTuple(x_min = -0.5
-                    x_max =  2.5
-                    y_min = -0.5
-                    y_max =  1.5
-                    z_min = -0.5
+        BoundsTuple(x_min = -0.5,
+                    x_max =  2.5,
+                    y_min = -0.5,
+                    y_max =  1.5,
+                    z_min = -0.5,
                     z_max =  0.5)
 
         Use a reference image to control the resampling instead. Here we load two

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -940,11 +940,11 @@ class ImageData(Grid, ImageDataFilters, _vtk.vtkImageData):
         (4, 4, 4)
 
         >>> grid.bounds
-        BoundsTuple(x_min = 2.0
-                    x_max = 5.0
-                    y_min = 2.0
-                    y_max = 5.0
-                    z_min = 2.0
+        BoundsTuple(x_min = 2.0,
+                    x_max = 5.0,
+                    y_min = 2.0,
+                    y_max = 5.0,
+                    z_min = 2.0,
                     z_max = 5.0)
 
         """

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -3421,19 +3421,19 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
         >>> grid = examples.load_explicit_structured()
         >>> grid = grid.hide_cells(range(80, 120))
         >>> grid.bounds
-        BoundsTuple(x_min =  0.0
-                    x_max = 80.0
-                    y_min =  0.0
-                    y_max = 50.0
-                    z_min =  0.0
+        BoundsTuple(x_min =  0.0,
+                    x_max = 80.0,
+                    y_min =  0.0,
+                    y_max = 50.0,
+                    z_min =  0.0,
                     z_max =  6.0)
 
         >>> grid.visible_bounds
-        BoundsTuple(x_min =  0.0
-                    x_max = 80.0
-                    y_min =  0.0
-                    y_max = 50.0
-                    z_min =  0.0
+        BoundsTuple(x_min =  0.0,
+                    x_max = 80.0,
+                    y_min =  0.0,
+                    y_max = 50.0,
+                    z_min =  0.0,
                     z_max =  4.0)
 
         """

--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -3328,11 +3328,11 @@ class AxesGeometrySource:
         >>> import pyvista as pv
         >>> axes_geometry_source = pv.AxesGeometrySource(symmetric_bounds=True)
         >>> axes_geometry_source.output.bounds
-        BoundsTuple(x_min = -1.0
-                    x_max =  1.0
-                    y_min = -1.0
-                    y_max =  1.0
-                    z_min = -1.0
+        BoundsTuple(x_min = -1.0,
+                    x_max =  1.0,
+                    y_min = -1.0,
+                    y_max =  1.0,
+                    z_min = -1.0,
                     z_max =  1.0)
 
         >>> axes_geometry_source.output.center
@@ -3342,11 +3342,11 @@ class AxesGeometrySource:
 
         >>> axes_geometry_source.symmetric_bounds = False
         >>> axes_geometry_source.output.bounds
-        BoundsTuple(x_min = -0.1
-                    x_max =  1.0
-                    y_min = -0.1
-                    y_max =  1.0
-                    z_min = -0.1
+        BoundsTuple(x_min = -0.1,
+                    x_max =  1.0,
+                    y_min = -0.1,
+                    y_max =  1.0,
+                    z_min = -0.1,
                     z_max =  1.0)
 
         >>> axes_geometry_source.output.center

--- a/pyvista/plotting/actor.py
+++ b/pyvista/plotting/actor.py
@@ -241,20 +241,20 @@ class Actor(Prop3D, _NameMixin, _vtk.vtkActor):
         >>> pl = pv.Plotter()
         >>> actor = pl.add_mesh(mesh)
         >>> pl.bounds
-        BoundsTuple(x_min =  139.06100463867188
-                    x_max = 1654.9300537109375
-                    y_min =   32.09429931640625
-                    y_max = 1319.949951171875
-                    z_min =  -17.741199493408203
+        BoundsTuple(x_min =  139.06100463867188,
+                    x_max = 1654.9300537109375,
+                    y_min =   32.09429931640625,
+                    y_max = 1319.949951171875,
+                    z_min =  -17.741199493408203,
                     z_max =  282.1300048828125)
 
         >>> actor.visibility = False
         >>> pl.bounds
-        BoundsTuple(x_min = -1.0
-                    x_max =  1.0
-                    y_min = -1.0
-                    y_max =  1.0
-                    z_min = -1.0
+        BoundsTuple(x_min = -1.0,
+                    x_max =  1.0,
+                    y_min = -1.0,
+                    y_max =  1.0,
+                    z_min = -1.0,
                     z_max =  1.0)
 
         """
@@ -286,20 +286,20 @@ class Actor(Prop3D, _NameMixin, _vtk.vtkActor):
         >>> pl = pv.Plotter()
         >>> actor = pl.add_mesh(mesh)
         >>> pl.bounds
-        BoundsTuple(x_min =  139.06100463867188
-                    x_max = 1654.9300537109375
-                    y_min =   32.09429931640625
-                    y_max = 1319.949951171875
-                    z_min =  -17.741199493408203
+        BoundsTuple(x_min =  139.06100463867188,
+                    x_max = 1654.9300537109375,
+                    y_min =   32.09429931640625,
+                    y_max = 1319.949951171875,
+                    z_min =  -17.741199493408203,
                     z_max =  282.1300048828125)
 
         >>> actor.use_bounds = False
         >>> pl.bounds
-        BoundsTuple(x_min = -1.0
-                    x_max =  1.0
-                    y_min = -1.0
-                    y_max =  1.0
-                    z_min = -1.0
+        BoundsTuple(x_min = -1.0,
+                    x_max =  1.0,
+                    y_min = -1.0,
+                    y_max =  1.0,
+                    z_min = -1.0,
                     z_max =  1.0)
 
         Although the actor's bounds are no longer used, the actor remains visible.

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -56,11 +56,11 @@ class _BaseMapper(_vtk.DisableVtkSnakeCase, _vtk.vtkAbstractMapper):
         >>> import pyvista as pv
         >>> mapper = pv.DataSetMapper(dataset=pv.Cube())
         >>> mapper.bounds
-        BoundsTuple(x_min = -0.5
-                    x_max =  0.5
-                    y_min = -0.5
-                    y_max =  0.5
-                    z_min = -0.5
+        BoundsTuple(x_min = -0.5,
+                    x_max =  0.5,
+                    y_min = -0.5,
+                    y_max =  0.5,
+                    z_min = -0.5,
                     z_max =  0.5)
 
         """

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -1703,11 +1703,11 @@ class BasePlotter(PickingHelper, WidgetHelper):
         >>> pl = pv.Plotter()
         >>> _ = pl.add_mesh(pv.Cube())
         >>> pl.bounds
-        BoundsTuple(x_min = -0.5
-                    x_max =  0.5
-                    y_min = -0.5
-                    y_max =  0.5
-                    z_min = -0.5
+        BoundsTuple(x_min = -0.5,
+                    x_max =  0.5,
+                    y_min = -0.5,
+                    y_max =  0.5,
+                    z_min = -0.5,
                     z_max =  0.5)
 
         """

--- a/pyvista/plotting/prop3d.py
+++ b/pyvista/plotting/prop3d.py
@@ -297,11 +297,11 @@ class Prop3D(_vtk.DisableVtkSnakeCase, _vtk.vtkProp3D):
         >>> mesh = pv.Cube(x_length=0.1, y_length=0.2, z_length=0.3)
         >>> actor = pl.add_mesh(mesh)
         >>> actor.bounds
-        BoundsTuple(x_min = -0.05
-                    x_max =  0.05
-                    y_min = -0.1
-                    y_max =  0.1
-                    z_min = -0.15
+        BoundsTuple(x_min = -0.05,
+                    x_max =  0.05,
+                    y_min = -0.1,
+                    y_max =  0.1,
+                    z_min = -0.15,
                     z_max =  0.15)
 
         """

--- a/pyvista/plotting/volume.py
+++ b/pyvista/plotting/volume.py
@@ -41,11 +41,11 @@ class Volume(Prop3D, _vtk.vtkVolume):
         >>> pl = pv.Plotter()
         >>> actor = pl.add_volume(vol)
         >>> actor.mapper.bounds
-        BoundsTuple(x_min = 0.0
-                    x_max = 9.0
-                    y_min = 0.0
-                    y_max = 9.0
-                    z_min = 0.0
+        BoundsTuple(x_min = 0.0,
+                    x_max = 9.0,
+                    y_min = 0.0,
+                    y_max = 9.0,
+                    z_min = 0.0,
                     z_max = 9.0)
 
         """

--- a/tests/core/test_geometric_sources.py
+++ b/tests/core/test_geometric_sources.py
@@ -642,11 +642,11 @@ def test_axes_geometry_source_custom_part(axes_geometry_source):
 
     match = (
         'Custom axes part must be 3D. Got bounds:\n'
-        'BoundsTuple(x_min = -0.5\n'
-        '            x_max =  0.5\n'
-        '            y_min = -0.5\n'
-        '            y_max =  0.5\n'
-        '            z_min =  0.0\n'
+        'BoundsTuple(x_min = -0.5,\n'
+        '            x_max =  0.5,\n'
+        '            y_min = -0.5,\n'
+        '            y_max =  0.5,\n'
+        '            z_min =  0.0,\n'
         '            z_max =  0.0).'
     )
     with pytest.raises(ValueError, match=re.escape(match)):


### PR DESCRIPTION
### Overview

Follow-up to #7550 ... I forgot to include the trailing commas with that PR 😅
