### PR TITLE
Fix merging field data with `main_has_priority`

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5314,6 +5314,12 @@ class DataSetFilters(DataObjectFilters):
 
         _update_alg(append_filter, progress_bar, 'Merging')
         merged = _get_output(append_filter)
+
+        # Update field data
+        priority = self if main_has_priority else grid
+        for array in merged.field_data:
+            merged.field_data[array] = priority.field_data[array]
+
         if inplace:
             if type(self) is type(merged):
                 self.deep_copy(merged)

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5316,7 +5316,9 @@ class DataSetFilters(DataObjectFilters):
         merged = _get_output(append_filter)
 
         # Update field data
-        priority = self if main_has_priority else grid
+        priority = (
+            grid if (isinstance(grid, pyvista.DataObject) and not main_has_priority) else self
+        )
         for array in merged.field_data:
             merged.field_data[array] = priority.field_data[array]
 

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -276,7 +276,7 @@ def test_user_dict_persists_with_merge_filter():
     sphere2.user_dict['name'] = 'sphere2'
 
     merged = sphere1 + sphere2
-    assert merged.user_dict['name'] == 'sphere2'
+    assert merged.user_dict['name'] == 'sphere1'
 
 
 def test_user_dict_persists_with_threshold_filter(uniform):

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -587,6 +587,23 @@ def test_merge_main_has_priority(input_, main_has_priority):
     assert merged.active_scalars_name == 'present_in_both'
 
 
+@pytest.mark.parametrize('main_has_priority', [True, False])
+@pytest.mark.parametrize('mesh', [pv.UnstructuredGrid(), pv.PolyData()])
+def test_merge_field_data(mesh, main_has_priority):
+    key = 'data'
+    data_main = [1, 2, 3]
+    data_other = [4, 5, 6]
+    mesh.field_data[key] = data_main
+    other = mesh.copy()
+    other.field_data[key] = data_other
+
+    merged = mesh.merge(other, main_has_priority=main_has_priority)
+
+    actual = merged.field_data[key]
+    expected = data_main if main_has_priority else data_other
+    assert np.array_equal(actual, expected)
+
+
 def test_add(sphere, sphere_shifted):
     merged = sphere + sphere_shifted
     assert isinstance(merged, pv.PolyData)


### PR DESCRIPTION
### Overview

`main_has_priority` ensures that the arrays from the "main" mesh are prioritized. This was not the case for field data arrays. This PR fixes this.