### PR TITLE
hotfix trame server proxy prefix

### DIFF
--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -1459,7 +1459,7 @@ class _TrameConfig(_ThemeConfig):
         service = os.environ.get('JUPYTERHUB_SERVICE_PREFIX', '')
         prefix = os.environ.get('PYVISTA_TRAME_SERVER_PROXY_PREFIX', '/proxy/')
         if service and not prefix.startswith('http'):  # pragma: no cover
-            self._server_proxy_prefix = str(Path(service) / prefix.lstrip('/'))
+            self._server_proxy_prefix = str(Path(service) / prefix.lstrip('/')).rstrip('/') + '/'
             self._server_proxy_enabled = True
         else:
             self._server_proxy_prefix = prefix


### PR DESCRIPTION
Hotfix to restore handling of `_server_proxy_prefix` to behavior before #7390