### PR TITLE
Fix links to VTK documentation in docstrings

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -69,7 +69,7 @@ class DataSetFilters(DataObjectFilters):
         """Align a dataset to another.
 
         Uses the iterative closest point algorithm to align the points of the
-        two meshes. See the VTK class `:vtk:`vtkIterativeClosestPointTransform`.
+        two meshes. See the VTK class :vtk:`vtkIterativeClosestPointTransform`.
 
         Parameters
         ----------

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -3935,7 +3935,7 @@ class PolyDataFilters(DataSetFilters):
         Due to the nature of the :vtk:`vtkCollisionDetectionFilter`,
         repeated uses of this method will be slower that using the
         :vtk:`vtkCollisionDetectionFilter` directly. The first
-        update of the filter creates two instances of `:vtk:`vtkOBBTree`,
+        update of the filter creates two instances of :vtk:`vtkOBBTree`,
         which can be subsequently updated by modifying the transform or
         matrix of the input meshes.
 

--- a/pyvista/plotting/axes_actor.py
+++ b/pyvista/plotting/axes_actor.py
@@ -20,7 +20,7 @@ class AxesActor(_vtk.DisableVtkSnakeCase, _vtk.vtkAxesActor):
     Hybrid 2D/3D actor used to represent 3D axes in a scene. The user
     can define the geometry to use for the shaft or the tip, and the
     user can set the text for the three axes. To see full customization
-    options, refer to `:vtk:`vtkAxesActor`.
+    options, refer to :vtk:`vtkAxesActor`.
 
     See Also
     --------

--- a/pyvista/plotting/cube_axes_actor.py
+++ b/pyvista/plotting/cube_axes_actor.py
@@ -53,7 +53,7 @@ class CubeAxesActor(_vtk.DisableVtkSnakeCase, _vtk.vtkCubeAxesActor):
 
     This class is created to wrap :vtk:`vtkCubeAxesActor`, which is used to draw axes
     and labels for the input data bounds. This wrapping aims to provide a
-    user-friendly interface to use `:vtk:`vtkCubeAxesActor`.
+    user-friendly interface to use :vtk:`vtkCubeAxesActor`.
 
     Parameters
     ----------

--- a/pyvista/plotting/texture.py
+++ b/pyvista/plotting/texture.py
@@ -405,7 +405,7 @@ class Texture(DataObject, _vtk.vtkTexture):
         return Texture(self.to_image().copy())  # type: ignore[abstract]
 
     def to_skybox(self):
-        """Return the texture as a ``:vtk:`vtkSkybox``` if cube mapping is enabled.
+        """Return the texture as a :vtk:`vtkSkybox` if cube mapping is enabled.
 
         Returns
         -------


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
I found some broken link of vtk-xref.
```bash
$ grep -n -R -s '`:vtk:' .
./pyvista/core/filters/data_set.py:72:        two meshes. See the VTK class `:vtk:`vtkIterativeClosestPointTransform`.
./pyvista/core/filters/poly_data.py:3938:        update of the filter creates two instances of `:vtk:`vtkOBBTree`,
./pyvista/plotting/cube_axes_actor.py:56:    user-friendly interface to use `:vtk:`vtkCubeAxesActor`.
./pyvista/plotting/axes_actor.py:23:    options, refer to `:vtk:`vtkAxesActor`.
./pyvista/plotting/texture.py:408:        """Return the texture as a ``:vtk:`vtkSkybox``` if cube mapping is enabled.
./doc/source/extras/vtk_role.rst:11:This extension adds the ``:vtk:`` role to allow writing, for example,
./doc/source/extras/vtk_role.rst:12:``:vtk:`vtkImageData``` inside docstrings to link directly to the ``vtkImageData``
./doc/source/extras/vtk_role.rst:16:for adding the ``:vtk:`` role to your project.
```

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- Follow up of #7529 .