### PR TITLE
Fix cube axes actor title offset for VTK 9.5

### DIFF
--- a/pyvista/plotting/cube_axes_actor.py
+++ b/pyvista/plotting/cube_axes_actor.py
@@ -314,7 +314,7 @@ class CubeAxesActor(_vtk.DisableVtkSnakeCase, _vtk.vtkCubeAxesActor):
     @property
     def title_offset(self) -> float | tuple[float, float]:  # numpydoc ignore=RT01
         """Return or set the distance between title and labels."""
-        if pyvista.vtk_version_info >= (9, 3):
+        if pyvista.vtk_version_info >= (9, 3) and pyvista.vtk_version_info < (9, 5, 0):
             offx, offy = (_vtk.reference(0.0), _vtk.reference(0.0))
             self.GetTitleOffset(offx, offy)  # type: ignore[call-overload]
             return offx, offy  # type: ignore[return-value]

--- a/pyvista/plotting/cube_axes_actor.py
+++ b/pyvista/plotting/cube_axes_actor.py
@@ -314,7 +314,7 @@ class CubeAxesActor(_vtk.DisableVtkSnakeCase, _vtk.vtkCubeAxesActor):
     @property
     def title_offset(self) -> float | tuple[float, float]:  # numpydoc ignore=RT01
         """Return or set the distance between title and labels."""
-        if pyvista.vtk_version_info >= (9, 3) and pyvista.vtk_version_info < (9, 5, 0):
+        if (9, 3, 0) <= pyvista.vtk_version_info < (9, 5, 0):
             offx, offy = (_vtk.reference(0.0), _vtk.reference(0.0))
             self.GetTitleOffset(offx, offy)  # type: ignore[call-overload]
             return offx, offy  # type: ignore[return-value]


### PR DESCRIPTION
### Overview

Fix plotting test failures, e.g. https://github.com/pyvista/pyvista/actions/runs/15561343823/job/43814169584?pr=7426#step:10:595)

``` python
FAILED tests/plotting/test_cube_axes_actor.py::test_title_offset_sequence - TypeError: GetTitleOffset() takes exactly 0 arguments (2 given)
FAILED tests/plotting/test_cube_axes_actor.py::test_title_offset_float - TypeError: GetTitleOffset() takes exactly 0 arguments (2 given)
```