### PR TITLE
Add pass_cell_data kwarg to cell_centers

### DIFF
--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -2319,7 +2319,10 @@ class DataObjectFilters:
         return _get_output(alg)
 
     def cell_centers(  # type: ignore[misc]
-        self: _DataSetOrMultiBlockType, vertex: bool = True, progress_bar: bool = False
+        self: _DataSetOrMultiBlockType,
+        vertex: bool = True,
+        pass_cell_data: bool = True,
+        progress_bar: bool = False,
     ):
         """Generate points at the center of the cells in this dataset.
 
@@ -2329,6 +2332,9 @@ class DataObjectFilters:
         ----------
         vertex : bool, default: True
             Enable or disable the generation of vertex cells.
+
+        pass_cell_data : bool, default: True
+            If enabled, pass the input cell data through to the output.
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
@@ -2362,6 +2368,7 @@ class DataObjectFilters:
         alg = _vtk.vtkCellCenters()
         alg.SetInputDataObject(input_mesh)
         alg.SetVertexCells(vertex)
+        alg.SetCopyArrays(pass_cell_data)
         _update_alg(alg, progress_bar, 'Generating Points at the Center of the Cells')
         return _get_output(alg)
 

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -328,6 +328,12 @@ def test_cell_centers(datasets):
         assert isinstance(result, pv.PolyData)
 
 
+def test_cell_centers_no_cell_data(cube):
+    # test passing cell data kwarg works
+    assert cube.cell_centers(pass_cell_data=True).cell_data
+    assert not cube.cell_centers(pass_cell_data=False).cell_data
+
+
 @pytest.mark.needs_vtk_version(9, 1, 0)
 def test_cell_center_pointset(airplane):
     pointset = airplane.cast_to_pointset()


### PR DESCRIPTION
Add `pass_cell_data` to `cell_centers` filter. Usage:

# default (current) behavior

```py
>>> import pyvista as pv
>>> cube = pv.Cube()
>>> cube.cell_centers().cell_data
>>> cube.cell_centers().cell_data
pyvista DataSetAttributes
Association     : CELL
Active Scalars  : None
Active Vectors  : None
Active Texture  : None
Active Normals  : None
Contains arrays :
    FaceIndex               int64      (6,)
```

Now, with `pass_cell_data` disabled:

```py
>>> cube.cell_centers(pass_cell_data=False).cell_data
pyvista DataSetAttributes
Association     : CELL
Active Scalars  : None
Active Vectors  : None
Active Texture  : None
Active Normals  : None
Contains arrays : None
```
