### PR TITLE
Replace `skip_check_gc` fixture with `skip_check_gc` marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,6 +235,7 @@ log_cli_level = "INFO"
 markers = [
   'needs_download: this test downloads data during execution',
   'needs_vtk_version(at_least, less_than, reason): skip test unless VTK version corresponds to at_least and greater_than values.',
+  'skip_check_gc: Disable the autouse check_gc fixture for this test.',
   'skip_egl(reason="Test fails when using OSMesa/EGL VTK build"): skip test for OSMesa/EGL.',
   'skip_mac(reason="Test fails on MacOS", machine=None, processor=None): skip test for MacOS and specific architectures if needed',
   'skip_windows(reason="Test fails on Windows"): skip test for windows.',

--- a/tests/plotting/conftest.py
+++ b/tests/plotting/conftest.py
@@ -38,29 +38,17 @@ def _is_vtk(obj):
         return False
 
 
-@pytest.fixture
-def skip_check_gc(check_gc):
-    """Skip check_gc fixture."""
-    check_gc.skip = True
-
-
 @pytest.fixture(autouse=True)
-def check_gc():
+def check_gc(request):
     """Ensure that all VTK objects are garbage-collected by Python."""
+    if request.node.get_closest_marker('skip_check_gc'):
+        yield
+        return
+
     gc.collect()
     before = {id(o) for o in gc.get_objects() if _is_vtk(o)}
 
-    class GcHandler:
-        def __init__(self) -> None:
-            # if set to True, will entirely skip checking in this fixture
-            self.skip = False
-
-    gc_handler = GcHandler()
-
-    yield gc_handler
-
-    if gc_handler.skip:
-        return
+    yield
 
     pv.close_all()
 

--- a/tests/plotting/jupyter/test_trame.py
+++ b/tests/plotting/jupyter/test_trame.py
@@ -360,7 +360,7 @@ def test_trame_export_html(tmpdir):
     assert Path(filename).is_file()
 
 
-@pytest.mark.usefixtures('skip_check_gc')
+@pytest.mark.skip_check_gc
 def test_export_single(tmpdir):
     filename = str(tmpdir.mkdir('tmpdir').join('scene-single'))
     data = examples.load_airplane()
@@ -372,7 +372,7 @@ def test_export_single(tmpdir):
     assert Path(f'{filename}').is_file()
 
 
-@pytest.mark.usefixtures('skip_check_gc')
+@pytest.mark.skip_check_gc
 def test_export_multi(tmpdir):
     filename = str(tmpdir.mkdir('tmpdir').join('scene-multi'))
     multi = pv.MultiBlock()
@@ -390,7 +390,7 @@ def test_export_multi(tmpdir):
     assert Path(f'{filename}').is_file()
 
 
-@pytest.mark.usefixtures('skip_check_gc')
+@pytest.mark.skip_check_gc
 def test_export_texture(tmpdir):
     filename = str(tmpdir.mkdir('tmpdir').join('scene-texture'))
     data = examples.load_globe()
@@ -403,7 +403,7 @@ def test_export_texture(tmpdir):
     assert Path(f'{filename}').is_file()
 
 
-@pytest.mark.usefixtures('skip_check_gc')
+@pytest.mark.skip_check_gc
 def test_export_verts(tmpdir):
     filename = str(tmpdir.mkdir('tmpdir').join('scene-verts'))
     data = pv.PolyData(np.random.default_rng().random((100, 3)))
@@ -415,7 +415,7 @@ def test_export_verts(tmpdir):
     assert Path(f'{filename}').is_file()
 
 
-@pytest.mark.usefixtures('skip_check_gc')
+@pytest.mark.skip_check_gc
 def test_export_color(tmpdir):
     filename = str(tmpdir.mkdir('tmpdir').join('scene-color'))
     data = examples.load_airplane()
@@ -427,7 +427,7 @@ def test_export_color(tmpdir):
     assert Path(f'{filename}').is_file()
 
 
-@pytest.mark.usefixtures('skip_check_gc')
+@pytest.mark.skip_check_gc
 def test_embeddable_widget():
     plotter = pv.Plotter(notebook=True)
     plotter.add_mesh(pv.Sphere())

--- a/tests/plotting/mappers/test_volume_mapper.py
+++ b/tests/plotting/mappers/test_volume_mapper.py
@@ -15,12 +15,12 @@ def volume_mapper():
     return actor.mapper
 
 
-@pytest.mark.usefixtures('skip_check_gc')
+@pytest.mark.skip_check_gc
 def test_volume_mapper_dataset(volume_mapper):
     assert isinstance(volume_mapper.dataset, pv.ImageData)
 
 
-@pytest.mark.usefixtures('skip_check_gc')
+@pytest.mark.skip_check_gc
 def test_volume_mapper_blend_mode(volume_mapper):
     assert isinstance(volume_mapper.blend_mode, str)
 

--- a/tests/plotting/test_axes.py
+++ b/tests/plotting/test_axes.py
@@ -11,10 +11,8 @@ from pyvista.plotting import _vtk
 from pyvista.plotting.opts import InterpolationType
 from pyvista.plotting.opts import RepresentationType
 
-
-@pytest.fixture(autouse=True)
-def skip_check_gc(skip_check_gc):
-    """All the tests here fail gc."""
+# A large number of tests here fail gc
+pytestmark = pytest.mark.skip_check_gc
 
 
 @pytest.fixture

--- a/tests/plotting/test_charts.py
+++ b/tests/plotting/test_charts.py
@@ -14,14 +14,10 @@ from pyvista import examples
 from pyvista.plotting import charts
 from pyvista.plotting.colors import COLOR_SCHEMES
 
-
-@pytest.fixture(autouse=True)
-def skip_check_gc(skip_check_gc):
-    """A large number of tests here fail gc."""
-
-
-# skip all tests if VTK<9.2.0
-pytestmark = pytest.mark.needs_vtk_version(9, 2)
+pytestmark = [
+    pytest.mark.needs_vtk_version(9, 2),  # skip all tests if VTK<9.2.0
+    pytest.mark.skip_check_gc,  # A large number of tests here fail gc
+]
 
 
 def vtk_array_to_tuple(arr):

--- a/tests/plotting/test_cube_axes_actor.py
+++ b/tests/plotting/test_cube_axes_actor.py
@@ -7,10 +7,8 @@ import pytest
 
 import pyvista as pv
 
-
-@pytest.fixture(autouse=True)
-def skip_check_gc(skip_check_gc):
-    """A large number of tests here fail gc."""
+# A large number of tests here fail gc
+pytestmark = pytest.mark.skip_check_gc
 
 
 @pytest.fixture

--- a/tests/plotting/test_lookup_table.py
+++ b/tests/plotting/test_lookup_table.py
@@ -226,7 +226,7 @@ def test_table_cmap_list(lut):
     assert lut.n_values == 3
 
 
-@pytest.mark.usefixtures('skip_check_gc')
+@pytest.mark.skip_check_gc
 def test_table_values_update(lut):
     lut.cmap = 'Greens'
     lut.values[:, -1] = np.linspace(0, 255, lut.n_values)
@@ -252,7 +252,7 @@ def test_call(lut):
     assert lut.map_value(0.5) == lut.map_value(0.5)
 
 
-@pytest.mark.usefixtures('skip_check_gc')
+@pytest.mark.skip_check_gc
 def test_custom_opacity(lut):
     values_copy = lut.values.copy()
     lut.apply_opacity('sigmoid')

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1501,7 +1501,7 @@ def _make_rgb_dataset(dtype: str, return_composite: bool, scalars: str):
 
 
 # check_gc fails for polydata (suspected memory leak with pv.merge)
-@pytest.mark.usefixtures('skip_check_gc')
+@pytest.mark.skip_check_gc
 @pytest.mark.parametrize('composite', [True, False], ids=['composite', 'polydata'])
 @pytest.mark.parametrize('dtype', ['float', 'int', 'uint8'])
 def test_plot_rgb(composite, dtype):
@@ -1515,7 +1515,7 @@ def test_plot_rgb(composite, dtype):
 
 
 # check_gc fails for polydata (suspected memory leak with pv.merge)
-@pytest.mark.usefixtures('skip_check_gc')
+@pytest.mark.skip_check_gc
 @pytest.mark.parametrize('scalars', ['_rgb', '_rgba'])
 @pytest.mark.parametrize('composite', [True, False], ids=['composite', 'polydata'])
 def test_plot_rgb_implicit(composite, scalars):
@@ -3638,7 +3638,7 @@ def test_plotter_volume_lookup_table(uniform):
 
 
 @skip_windows_mesa  # due to opacity
-@pytest.mark.usefixtures('skip_check_gc')
+@pytest.mark.skip_check_gc
 def test_plotter_volume_lookup_table_reactive(uniform):
     """Ensure that changes to the underlying lookup table are reflected by the volume property."""
     uniform.set_active_scalars('Spatial Point Data')
@@ -4937,7 +4937,7 @@ def test_orthogonal_planes_source_normals(normal_sign, plane):
     plane.plot_normals(mag=0.8, color='white', lighting=False, show_edges=True)
 
 
-@pytest.mark.usefixtures('skip_check_gc')  # gc fails, suspected memory leak with merge
+@pytest.mark.skip_check_gc  # gc fails, suspected memory leak with merge
 @pytest.mark.parametrize('distance', [(1, 1, 1), (-1, -1, -1)], ids=['+', '-'])
 def test_orthogonal_planes_source_push(distance):
     source = pv.OrthogonalPlanesSource()

--- a/tests/plotting/test_plotting_utilities.py
+++ b/tests/plotting/test_plotting_utilities.py
@@ -48,14 +48,14 @@ def test_ray_trace_plot():
 
 
 @pytest.mark.skip_plotting
-@pytest.mark.usefixtures('skip_check_gc')
+@pytest.mark.skip_check_gc
 def test_plot_curvature():
     sphere = pv.Sphere(0.5, theta_resolution=10, phi_resolution=10)
     sphere.plot_curvature(off_screen=True)
 
 
 @pytest.mark.skip_plotting
-@pytest.mark.usefixtures('skip_check_gc')
+@pytest.mark.skip_check_gc
 def test_plot_curvature_pointset():
     grid = examples.load_structured()
     grid.plot_curvature(off_screen=True)

--- a/tests/plotting/test_volume_property.py
+++ b/tests/plotting/test_volume_property.py
@@ -19,7 +19,7 @@ def test_apply_lookup_table_raises(vol_prop: VolumeProperty, lut):
         vol_prop.apply_lookup_table(lut)
 
 
-@pytest.mark.usefixtures('skip_check_gc')
+@pytest.mark.skip_check_gc
 def test_volume_lookup_table(vol_prop):
     assert vol_prop._lookup_table is None
     vol_prop.reapply_lookup_table()


### PR DESCRIPTION
### Overview

In https://github.com/pyvista/pyvista/pull/7607#issuecomment-2965580101 it was found that `skip_check_gc` only skips checking gc during teardown, and does not skip gc during test setup.

This PR fixes this by using a marker instead of a fixture.