### PR TITLE
Fix `point_cell_ids` for VTK 9.5

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2850,7 +2850,7 @@ class DataSet(DataSetFilters, DataObject):
         ids = _vtk.vtkIdList()
         self.GetPointCells(ind, ids)
         out = [ids.GetId(i) for i in range(ids.GetNumberOfIds())]
-        if pyvista.vtk_version_info >= (9, 4, 0):
+        if (9, 4, 0) <= pyvista.vtk_version_info < (9, 5, 0):
             # Need to reverse the order
             return out[::-1]
         return out

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1364,6 +1364,14 @@ def test_point_cell_ids(grid: DataSet, i0):
         assert i0 not in grid.get_cell(c).point_ids
 
 
+def test_point_cell_ids_order():
+    resolution = 10
+    mesh = pv.Sphere(theta_resolution=resolution)
+    expected_ids = list(range(resolution))
+    actual_ids = mesh.point_cell_ids(0)
+    assert actual_ids == expected_ids
+
+
 @pytest.mark.parametrize('grid', grids_cells, ids=ids_cells)
 @pytest.mark.parametrize('i0', i0s)
 def test_cell_point_neighbors_ids(grid: DataSet, i0):


### PR DESCRIPTION
### Overview

We are seeing a docstring test failure with `vtk==9.5.0rc3` (see https://github.com/pyvista/pyvista/actions/runs/15626386561/job/44021349926?pr=7612#step:8:152)

We saw a similar failure as part of #6879... my guess is that this was a bug introduced into 9.4 which has been fixed for 9.5.

Since we only see this failure in the docstring, this PR also adds a proper test.