### PR TITLE
Upload new artifact with images for failed plotting unit test

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -87,6 +87,13 @@ jobs:
         if: always()
         run: pytest -v tests/plotting --fail_extra_image_cache --generated_image_dir debug_images
 
+      - name: Upload Images for Failed Tests
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed_images-${{ github.job }}-${{ join(matrix.* , '-') }}
+          path: failed_image_dir
+
       - name: Upload Generated Images
         if: always()
         uses: actions/upload-artifact@v4
@@ -204,6 +211,13 @@ jobs:
             $PLOTTING_TEST_MODULES_CHARTS \
             $LINUX_PLOTTING_ARGS
 
+      - name: Upload Images for Failed Tests
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed_images-${{ github.job }}-${{ join(matrix.* , '-') }}
+          path: failed_image_dir
+
       - name: Upload Generated Images
         if: always()
         uses: actions/upload-artifact@v4
@@ -305,6 +319,13 @@ jobs:
             $PLOTTING_TEST_MODULES_CHARTS \
             $LINUX_PLOTTING_ARGS
 
+      - name: Upload Images for Failed Tests
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed_images-${{ github.job }}-${{ join(matrix.* , '-') }}
+          path: failed_image_dir
+
       - name: Upload Generated Images
         if: always()
         uses: actions/upload-artifact@v4
@@ -370,6 +391,13 @@ jobs:
       - name: Test Plotting
         if: always()
         run: python -m pytest -v tests/plotting --fail_extra_image_cache --generated_image_dir debug_images
+
+      - name: Upload Images for Failed Tests
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed_images-${{ github.job }}-${{ join(matrix.* , '-') }}
+          path: failed_image_dir
 
       - name: Upload Generated Images
         if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ test = [
   'cmcrameri<1.10.0',
   'cmocean<4.0.4',
   'colorcet<3.2.0',
-  'embreex<2.17.8; sys_platform != "darwin" or platform_machine != "arm64"', # Does not work with arm-based macs
+  'embreex<2.17.8; sys_platform != "darwin" or platform_machine != "arm64"',              # Does not work with arm-based macs
   'hypothesis<6.131.10',
   'imageio-ffmpeg<0.6.0',
   'imageio<2.37.0',
@@ -86,7 +86,7 @@ test = [
   'pyanalyze<=0.13.1',
   'pytest-cov<6.2.0',
   'pytest-mypy-plugins<3.3.0',
-  'pytest-pyvista==0.1.8',
+  'pytest-pyvista @ git+https://github.com/pyvista/pytest-pyvista@feat/failed_image_dir',
   'pytest-xdist<3.7.0',
   'pytest<8.4.0',
   'pytest_cases<3.8.7',


### PR DESCRIPTION
### Overview

Use `failed_image_dir` from https://github.com/pyvista/pytest-pyvista/pull/171 to upload new artifact to more easily review and update images from test failures