### PR TITLE
Use `pytest-xdist` in unit testing

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -35,7 +35,7 @@ env:
   PYVISTA_USERDATA_PATH: ${{ github.workspace }}/vtk-data
   LINUX_PLOTTING_ARGS: >
     -v --cov=pyvista --cov-append --cov-report=xml --cov-branch
-    --fail_extra_image_cache --generated_image_dir debug_images
+    --fail_extra_image_cache --generated_image_dir debug_images -n auto
   PLOTTING_TEST_MODULES_CHARTS: "tests/plotting/test_charts.py"
   PLOTTING_TEST_MODULES_NO_CHARTS: >
     --ignore=tests/core
@@ -125,11 +125,11 @@ jobs:
         run: python -c "import pyvista;print(pyvista.Report(gpu=False));from pyvista import examples;print('User data path:', examples.USER_DATA_PATH)"
 
       - name: Test Core API
-        run: pytest -v --ignore=tests/plotting --test_downloads
+        run: pytest -v --ignore=tests/plotting --test_downloads -n auto
 
       - name: Test Plotting
         if: always()
-        run: pytest -v tests/plotting --fail_extra_image_cache --generated_image_dir debug_images
+        run: pytest -v tests/plotting --fail_extra_image_cache --generated_image_dir debug_images -n auto
 
       - name: Upload Generated Images
         if: always()
@@ -225,7 +225,7 @@ jobs:
           pip install --pre --no-deps -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
 
       - name: Core Testing (no GL)
-        run: python -m pytest --cov=pyvista --cov-branch -v --ignore=tests/plotting --test_downloads
+        run: python -m pytest --cov=pyvista --cov-branch -v --ignore=tests/plotting --test_downloads -n auto
 
       - uses: awalsh128/cache-apt-pkgs-action@v1.5.0
         if: always()
@@ -328,7 +328,7 @@ jobs:
           pip install --upgrade vtk --pre --no-cache --extra-index-url https://wheels.vtk.org
 
       - name: Core Testing (no GL)
-        run: python -m pytest --cov=pyvista --cov-branch -v --ignore=tests/plotting --test_downloads
+        run: python -m pytest --cov=pyvista --cov-branch -v --ignore=tests/plotting --test_downloads -n auto
 
       - uses: awalsh128/cache-apt-pkgs-action@v1.5.0
         if: always()
@@ -409,11 +409,11 @@ jobs:
         run: python -c "import pyvista; print(pyvista.Report(gpu=False)); from pyvista import examples; print('User data path:', examples.USER_DATA_PATH)"
 
       - name: Test Core API
-        run: python -m pytest -v --ignore=tests/plotting --test_downloads
+        run: python -m pytest -v --ignore=tests/plotting --test_downloads -n auto
 
       - name: Test Plotting
         if: always()
-        run: python -m pytest -v tests/plotting --fail_extra_image_cache --generated_image_dir debug_images
+        run: python -m pytest -v tests/plotting --fail_extra_image_cache --generated_image_dir debug_images -n auto
 
       - name: Upload Generated Images
         if: always()


### PR DESCRIPTION
### Overview

`pytest-xdist` is included in the test dependencies, but it's not currently used. This PR enables its use.