### PR TITLE
Return `{}` instead of `None` for empty `cells_dict` and `get_mixed_cells`

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -2229,6 +2229,11 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
         type in an ordered fashion.  Note that this function only
         works with element types of fixed sizes.
 
+        .. versionchanged:: 0.46
+
+            An empty dict ``{}`` is returned instead of ``None`` if
+            the input is empty.
+
         Returns
         -------
         dict

--- a/pyvista/core/utilities/cells.py
+++ b/pyvista/core/utilities/cells.py
@@ -257,7 +257,7 @@ def get_mixed_cells(vtkobj):
     """
     from .cell_type_helper import enum_cell_type_nr_points_map
 
-    return_dict = {}
+    return_dict = {}  # type: ignore[var-annotated]
 
     if not isinstance(vtkobj, pyvista.UnstructuredGrid):
         msg = 'Expected a pyvista object'
@@ -265,7 +265,7 @@ def get_mixed_cells(vtkobj):
 
     nr_cells = vtkobj.n_cells
     if nr_cells == 0:
-        return None
+        return return_dict
 
     cell_types = vtkobj.celltypes
     cells = vtkobj.cells

--- a/pyvista/core/utilities/cells.py
+++ b/pyvista/core/utilities/cells.py
@@ -237,6 +237,11 @@ def get_mixed_cells(vtkobj):
     arrays of size [N, D], where N is the number of cells and D is the
     size of the cells for the given type (e.g. 3 for triangles).
 
+    .. versionchanged:: 0.46
+
+        An empty dict ``{}`` is returned instead of ``None`` if the input
+        is empty.
+
     Parameters
     ----------
     vtkobj : pyvista.UnstructuredGrid

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -345,7 +345,7 @@ def test_cells_dict_variable_length():
 
 def test_cells_dict_empty_grid():
     grid = pv.UnstructuredGrid()
-    assert grid.cells_dict is None
+    assert grid.cells_dict == {}
 
 
 def test_cells_dict_alternating_cells():


### PR DESCRIPTION
### Overview

This change simplifies the typing from #7609, and I think it makes sense that an empty mesh returns an empty dict here.