### PR TITLE
Fix geovista integration test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -104,11 +104,7 @@ jobs:
       CARTOPY_SHARE_DIR: ~/.local/share/cartopy
       GEOVISTA_POOCH_MUTE: true
     steps:
-      - uses: awalsh128/cache-apt-pkgs-action@v1.5.0
-        if: env.USE_CACHE == 'true'
-        with:
-          packages: xvfb
-          version: 3.0
+      - uses: pyvista/setup-headless-display-action@main
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -124,8 +120,8 @@ jobs:
       - name: Download cartopy assets
         run: |
           mkdir -p ${CARTOPY_SHARE_DIR}
-          python -m cartopy.feature.download physical --output ${CARTOPY_SHARE_DIR} --no-warn
-      - run: pytest
+          cartopy_feature_download physical --output ${CARTOPY_SHARE_DIR} --no-warn
+      - run: xvfb-run -a pytest
         working-directory: geovista
 
   trame:


### PR DESCRIPTION
### Overview

This pull-request updates how the `geovista` integration test is executed after [geovista PR#1494](https://github.com/bjlittle/geovista/pull/1494) finally introduced the minimum pin `pyvista>=0.45.0` and changed how the headless display is configured.

Essentially `geovista` dropped the use of the `pytest` plugin [pytest-xvfb](https://github.com/The-Compiler/pytest-xvfb) and adopted the pattern of using the `pyvista/setup-headless-display-action` GHA and `xvfb-run` combination, akin to `pyvista`.

Once this is merged, blocked PRs can rebase from `main` to pickup this fix :+1: 