### PR TITLE
Bump geovista integration test to py313

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -110,7 +110,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - run: git clone https://github.com/bjlittle/geovista.git --single-branch
       - name: Install PyVista
         run: pip install -ve . # pyvista


### PR DESCRIPTION
### Overview

This pull-request bumps the `integration-tests` GHA to use `py313` for the `geovista` tests after support is extended in [geovista PR#1496](https://github.com/bjlittle/geovista/pull/1496) for `py313` coverage.
