### PR TITLE
Fix tag syntax error in `anti_aliasing` documentation

### DIFF
--- a/examples/02-plot/anti_aliasing.py
+++ b/examples/02-plot/anti_aliasing.py
@@ -158,6 +158,7 @@ pl.show()
 #     Render time for msaa  : 42.566 ms
 #     Render time for ssaa  : 51.450 ms
 #
+
 #
 # %%
 # .. tags:: plot

--- a/examples/02-plot/anti_aliasing.py
+++ b/examples/02-plot/anti_aliasing.py
@@ -159,6 +159,5 @@ pl.show()
 #     Render time for ssaa  : 51.450 ms
 #
 
-#
 # %%
 # .. tags:: plot


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
<img width="856" alt="スクリーンショット 2025-06-21 8 49 39" src="https://github.com/user-attachments/assets/5e623461-5925-4005-b8e5-398a39aa76c0" />

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None