### PR TITLE
Allow NaN values with data object equality checks

### DIFF
--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -472,7 +472,7 @@ class DataObject(_vtk.DisableVtkSnakeCase, _vtk.vtkPyVistaOverride):
             # Only check equality for attributes defined by PyVista
             # (i.e. ignore any default vtk snake_case attributes)
             if hasattr(self, attr) and not _vtk.is_vtk_attribute(self, attr):
-                if not np.array_equal(getattr(self, attr), getattr(other, attr)):
+                if not np.array_equal(getattr(self, attr), getattr(other, attr), equal_nan=True):
                     return False
 
         # these attrs can be directly compared

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -1329,6 +1329,14 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
     def __eq__(self: Self, other: object) -> bool:
         """Test dict-like equivalency."""
+
+        def array_equal_nan(array1: npt.ArrayLike, array2: npt.ArrayLike) -> bool:
+            return (
+                np.issubdtype(np.asanyarray(array1).dtype, np.floating)
+                and np.issubdtype(np.asanyarray(array2).dtype, np.floating)
+                and np.array_equal(array1, array2, equal_nan=True)
+            )
+
         # here we check if other is the same class or a subclass of self.
         if not isinstance(other, type(self)):
             return False
@@ -1338,7 +1346,7 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
 
         # verify the value of the arrays
         for key, value in other.items():
-            if not np.array_equal(value, self[key]):
+            if not np.array_equal(value, self[key]) and not array_equal_nan(value, self[key]):
                 return False
 
         # check the name of the active attributes

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -1331,6 +1331,8 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         """Test dict-like equivalency."""
 
         def array_equal_nan(array1: npt.ArrayLike, array2: npt.ArrayLike) -> bool:
+            # Check with `equal_nan=True` but only for floats since this fails for strings
+            # See numpy/numpy#16377
             return (
                 np.issubdtype(np.asanyarray(array1).dtype, np.floating)
                 and np.issubdtype(np.asanyarray(array2).dtype, np.floating)

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -109,6 +109,19 @@ def test_unstructured_grid_eq(hexbeam):
     assert hexbeam != copy
 
 
+def test_eq_nan_points():
+    poly = pv.PolyData([np.nan, np.nan, np.nan])
+    poly2 = poly.copy()
+    assert poly == poly2
+
+
+def test_eq_nan_array():
+    poly = pv.PolyData()
+    poly.field_data['data'] = [np.nan]
+    poly2 = poly.copy()
+    assert poly == poly2
+
+
 def test_metadata_save(hexbeam, tmpdir):
     """Test if complex and bool metadata is saved and restored."""
     filename = tmpdir.join('hexbeam.vtk')

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -122,6 +122,13 @@ def test_eq_nan_array():
     assert poly == poly2
 
 
+def test_eq_string_array():
+    poly = pv.PolyData()
+    poly.field_data['data'] = ['abc']
+    poly2 = poly.copy()
+    assert poly == poly2
+
+
 def test_metadata_save(hexbeam, tmpdir):
     """Test if complex and bool metadata is saved and restored."""
     filename = tmpdir.join('hexbeam.vtk')


### PR DESCRIPTION
### Overview

Partial fix for #7634 

The equality check failures from `download_damavand_volcano` and `download_notch_stress` are due to `nan` values in arrays, and the failure from `download_particles` is caused by `nan` values in the points.