### PR TITLE
Fix padding RGB image with non-RGB value

### DIFF
--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -2504,6 +2504,7 @@ class ImageDataFilters(DataSetFilters):
                     f"match the number components ({num_input_components}) in array '{scalars}'."
                 )
                 raise ValueError(msg)
+            val = np.broadcast_to(val, (num_input_components,))
             if num_input_components > 1:
                 pad_multi_component = True
                 data = self.point_data  # type: ignore[attr-defined]

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -832,6 +832,19 @@ def test_pad_image_multi_component(zero_dimensionality_image):
     assert np.all(padded['scalars2'] == new_value * 2)
 
 
+def test_pad_image_multi_component_with_scalar(beach):
+    # Image has rgb scalars
+    first_value = beach.active_scalars[0]
+    assert len(first_value) == 3
+
+    # Test padding with single (non-rgb) value works
+    zero = 0
+    padded = beach.pad_image(zero)
+    new_first_value = padded.active_scalars[0]
+    assert not np.array_equal(new_first_value, first_value)
+    assert np.array_equal(new_first_value, (zero, zero, zero))
+
+
 def test_pad_image_raises(zero_dimensionality_image, uniform, beach):
     match = 'Pad size cannot be negative. Got -1.'
     with pytest.raises(ValueError, match=match):


### PR DESCRIPTION
### Overview

Add fix for bug mentioned here https://github.com/pyvista/pyvista/pull/7645#discussion_r2173792486

To reproduce:
``` python
from pyvista import examples
im = examples.download_beach()
im.pad_image(0)
```
```
  File "pyvista/pyvista/core/filters/image_data.py", line 2561, in _get_padded_output
    alg.SetConstant(val[component])  # type: ignore[attr-defined]
                    ~~~^^^^^^^^^^^
IndexError: index 1 is out of bounds for axis 0 with size 1
```
