### PR TITLE
Fix crash with `contour_labels` when there is no foreground

### DIFF
--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -1619,7 +1619,7 @@ class ImageDataFilters(DataSetFilters):
 
         alg_input = _get_alg_input(self, scalars)
         active_scalars = cast('pyvista.pyvista_ndarray', alg_input.active_scalars)
-        if active_scalars.mean() == background_value:
+        if np.all(active_scalars == background_value):
             # Empty input, no contour will be generated
             return pyvista.PolyData()
 
@@ -1639,7 +1639,7 @@ class ImageDataFilters(DataSetFilters):
         else:
             _configure_boundaries(
                 alg,
-                array_=active_scalars,
+                array_=cast('pyvista.pyvista_ndarray', alg_input.active_scalars),
                 select_inputs_=select_inputs,
                 select_outputs_=select_outputs,
             )

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -1618,7 +1618,8 @@ class ImageDataFilters(DataSetFilters):
         )
 
         alg_input = _get_alg_input(self, scalars)
-        if alg_input.active_scalars.mean() == background_value:
+        active_scalars = cast('pyvista.pyvista_ndarray', alg_input.active_scalars)
+        if active_scalars.mean() == background_value:
             # Empty input, no contour will be generated
             return pyvista.PolyData()
 
@@ -1638,7 +1639,7 @@ class ImageDataFilters(DataSetFilters):
         else:
             _configure_boundaries(
                 alg,
-                array_=cast('pyvista.pyvista_ndarray', alg_input.active_scalars),
+                array_=active_scalars,
                 select_inputs_=select_inputs,
                 select_outputs_=select_outputs,
             )

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -1618,6 +1618,9 @@ class ImageDataFilters(DataSetFilters):
         )
 
         alg_input = _get_alg_input(self, scalars)
+        if alg_input.active_scalars.mean() == background_value:
+            # Empty input, no contour will be generated
+            return pyvista.PolyData()
 
         # Pad with background values to close surfaces at image boundaries
         alg_input = alg_input.pad_image(background_value) if pad_background else alg_input

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -1619,7 +1619,7 @@ class ImageDataFilters(DataSetFilters):
 
         alg_input = _get_alg_input(self, scalars)
         active_scalars = cast('pyvista.pyvista_ndarray', alg_input.active_scalars)
-        if np.all(active_scalars == background_value):
+        if np.allclose(active_scalars, background_value):
             # Empty input, no contour will be generated
             return pyvista.PolyData()
 

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -6,6 +6,7 @@ import time
 
 import numpy as np
 import pytest
+import vtk
 
 import pyvista as pv
 from pyvista import examples
@@ -412,6 +413,21 @@ def test_contour_labels_raises_vtkversionerror():
     match = 'Surface nets 3D require VTK 9.3.0 or newer.'
     with pytest.raises(pv.VTKVersionError, match=match):
         pv.ImageData().contour_labels()
+
+
+@pytest.mark.needs_vtk_version(9, 3, 0)
+def test_contour_labels_empty_input(frog_tissues):
+    def extract_voi(self, voi):
+        alg = vtk.vtkExtractVOI()
+        alg.SetVOI(voi)
+        alg.SetInputDataObject(self)
+        alg.Update()
+        return pv.wrap(alg.GetOutput())
+
+    voi = extract_voi(frog_tissues, (10, 100, 20, 200, 20, 80))
+    assert voi.active_scalars.mean() == 0
+    surface = voi.contour_labels()
+    assert surface.is_empty
 
 
 @pytest.fixture

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -418,7 +418,7 @@ def test_contour_labels_raises_vtkversionerror():
 def test_contour_labels_empty_input(frog_tissues):
     voi = frog_tissues.extract_subset((10, 100, 20, 200, 20, 80))
     background_value = 0
-    assert np.all(voi.active_scalars == background_value)
+    assert np.allclose(voi.active_scalars, background_value)
     surface = voi.contour_labels(background_value=background_value)
     assert surface.is_empty
 

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -6,7 +6,6 @@ import time
 
 import numpy as np
 import pytest
-import vtk
 
 import pyvista as pv
 from pyvista import examples
@@ -417,14 +416,7 @@ def test_contour_labels_raises_vtkversionerror():
 
 @pytest.mark.needs_vtk_version(9, 3, 0)
 def test_contour_labels_empty_input(frog_tissues):
-    def extract_voi(self, voi):
-        alg = vtk.vtkExtractVOI()
-        alg.SetVOI(voi)
-        alg.SetInputDataObject(self)
-        alg.Update()
-        return pv.wrap(alg.GetOutput())
-
-    voi = extract_voi(frog_tissues, (10, 100, 20, 200, 20, 80))
+    voi = frog_tissues.extract_subset((10, 100, 20, 200, 20, 80))
     assert voi.active_scalars.mean() == 0
     surface = voi.contour_labels()
     assert surface.is_empty

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -417,8 +417,9 @@ def test_contour_labels_raises_vtkversionerror():
 @pytest.mark.needs_vtk_version(9, 3, 0)
 def test_contour_labels_empty_input(frog_tissues):
     voi = frog_tissues.extract_subset((10, 100, 20, 200, 20, 80))
-    assert voi.active_scalars.mean() == 0
-    surface = voi.contour_labels()
+    background_value = 0
+    assert np.all(voi.active_scalars == background_value)
+    surface = voi.contour_labels(background_value=background_value)
     assert surface.is_empty
 
 


### PR DESCRIPTION
### Overview

While working on an example for #7652 I encountered a bug where `contour_labels` crashes python in some cases where there is no foreground to contour.

``` py
from pyvista import examples

mesh = examples.load_frog_tissues()
subset = mesh.extract_subset((10, 100, 20, 200, 20, 80))
surface = subset.contour_labels()
```