### PR TITLE
Fix `copy_vtk_array` with `vtkImplicitArray` inputs

### DIFF
--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -106,10 +106,25 @@ from vtkmodules.vtkCommonComputationalGeometry import (
 )
 from vtkmodules.vtkCommonComputationalGeometry import vtkParametricTorus as vtkParametricTorus
 from vtkmodules.vtkCommonCore import VTK_ARIAL as VTK_ARIAL
+from vtkmodules.vtkCommonCore import VTK_BIT as VTK_BIT
+from vtkmodules.vtkCommonCore import VTK_CHAR as VTK_CHAR
 from vtkmodules.vtkCommonCore import VTK_COURIER as VTK_COURIER
+from vtkmodules.vtkCommonCore import VTK_DOUBLE as VTK_DOUBLE
+from vtkmodules.vtkCommonCore import VTK_FLOAT as VTK_FLOAT
 from vtkmodules.vtkCommonCore import VTK_FONT_FILE as VTK_FONT_FILE
+from vtkmodules.vtkCommonCore import VTK_ID_TYPE as VTK_ID_TYPE
+from vtkmodules.vtkCommonCore import VTK_INT as VTK_INT
+from vtkmodules.vtkCommonCore import VTK_LONG as VTK_LONG
+from vtkmodules.vtkCommonCore import VTK_LONG_LONG as VTK_LONG_LONG
+from vtkmodules.vtkCommonCore import VTK_SHORT as VTK_SHORT
+from vtkmodules.vtkCommonCore import VTK_SIGNED_CHAR as VTK_SIGNED_CHAR
+from vtkmodules.vtkCommonCore import VTK_STRING as VTK_STRING
 from vtkmodules.vtkCommonCore import VTK_TIMES as VTK_TIMES
 from vtkmodules.vtkCommonCore import VTK_UNSIGNED_CHAR as VTK_UNSIGNED_CHAR
+from vtkmodules.vtkCommonCore import VTK_UNSIGNED_INT as VTK_UNSIGNED_INT
+from vtkmodules.vtkCommonCore import VTK_UNSIGNED_LONG as VTK_UNSIGNED_LONG
+from vtkmodules.vtkCommonCore import VTK_UNSIGNED_LONG_LONG as VTK_UNSIGNED_LONG_LONG
+from vtkmodules.vtkCommonCore import VTK_UNSIGNED_SHORT as VTK_UNSIGNED_SHORT
 from vtkmodules.vtkCommonCore import buffer_shared as buffer_shared  # type: ignore[attr-defined]
 from vtkmodules.vtkCommonCore import mutable as mutable
 from vtkmodules.vtkCommonCore import reference as reference
@@ -123,11 +138,15 @@ from vtkmodules.vtkCommonCore import vtkFileOutputWindow as vtkFileOutputWindow
 from vtkmodules.vtkCommonCore import vtkFloatArray as vtkFloatArray
 from vtkmodules.vtkCommonCore import vtkIdList as vtkIdList
 from vtkmodules.vtkCommonCore import vtkIdTypeArray as vtkIdTypeArray
+from vtkmodules.vtkCommonCore import vtkIntArray as vtkIntArray
 from vtkmodules.vtkCommonCore import vtkLogger as vtkLogger
+from vtkmodules.vtkCommonCore import vtkLongArray as vtkLongArray
+from vtkmodules.vtkCommonCore import vtkLongLongArray as vtkLongLongArray
 from vtkmodules.vtkCommonCore import vtkLookupTable as vtkLookupTable
 from vtkmodules.vtkCommonCore import vtkMath as vtkMath
 from vtkmodules.vtkCommonCore import vtkOutputWindow as vtkOutputWindow
 from vtkmodules.vtkCommonCore import vtkPoints as vtkPoints
+from vtkmodules.vtkCommonCore import vtkShortArray as vtkShortArray
 from vtkmodules.vtkCommonCore import vtkSignedCharArray as vtkSignedCharArray
 from vtkmodules.vtkCommonCore import vtkStringArray as vtkStringArray
 from vtkmodules.vtkCommonCore import vtkStringOutputWindow as vtkStringOutputWindow
@@ -135,6 +154,10 @@ from vtkmodules.vtkCommonCore import vtkTypeInt32Array as vtkTypeInt32Array
 from vtkmodules.vtkCommonCore import vtkTypeInt64Array as vtkTypeInt64Array
 from vtkmodules.vtkCommonCore import vtkTypeUInt32Array as vtkTypeUInt32Array
 from vtkmodules.vtkCommonCore import vtkUnsignedCharArray as vtkUnsignedCharArray
+from vtkmodules.vtkCommonCore import vtkUnsignedIntArray as vtkUnsignedIntArray
+from vtkmodules.vtkCommonCore import vtkUnsignedLongArray as vtkUnsignedLongArray
+from vtkmodules.vtkCommonCore import vtkUnsignedLongLongArray as vtkUnsignedLongLongArray
+from vtkmodules.vtkCommonCore import vtkUnsignedShortArray as vtkUnsignedShortArray
 from vtkmodules.vtkCommonCore import vtkWeakReference as vtkWeakReference
 from vtkmodules.vtkCommonDataModel import VTK_BEZIER_CURVE as VTK_BEZIER_CURVE
 from vtkmodules.vtkCommonDataModel import VTK_BEZIER_HEXAHEDRON as VTK_BEZIER_HEXAHEDRON

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -64,8 +64,8 @@ class pyvista_ndarray(np.ndarray):  # type: ignore[type-arg]  # numpydoc ignore=
         association: FieldAssociation = FieldAssociation.NONE,
     ) -> pyvista_ndarray:
         """Allocate the array."""
-        type(array)()
         if isinstance(array, _vtk.vtkAbstractArray):
+            type(array)()
             obj = convert_array(array).view(cls)
             obj.VTKObject = array
         elif isinstance(array, Iterable):

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -64,6 +64,7 @@ class pyvista_ndarray(np.ndarray):  # type: ignore[type-arg]  # numpydoc ignore=
         association: FieldAssociation = FieldAssociation.NONE,
     ) -> pyvista_ndarray:
         """Allocate the array."""
+        type(array)()
         if isinstance(array, _vtk.vtkAbstractArray):
             obj = convert_array(array).view(cls)
             obj.VTKObject = array

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -65,7 +65,6 @@ class pyvista_ndarray(np.ndarray):  # type: ignore[type-arg]  # numpydoc ignore=
     ) -> pyvista_ndarray:
         """Allocate the array."""
         if isinstance(array, _vtk.vtkAbstractArray):
-            type(array)()
             obj = convert_array(array).view(cls)
             obj.VTKObject = array
         elif isinstance(array, Iterable):

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -229,7 +229,7 @@ def copy_vtk_array(array: _vtkArrayType, deep: bool = True) -> _vtkArrayType:  #
         # Init array from the array type instead
         array_type = array.GetArrayType()
         vtk_array_class = VTK_ARRAY_TYPES.get(array_type)
-        if vtk_array_class is None:
+        if vtk_array_class is None:  # pragma: no cover
             msg = f'Unsupported array type code: {array_type}'
             raise ValueError(msg)
         new_array = vtk_array_class()

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -232,7 +232,7 @@ def copy_vtk_array(array: _vtkArrayType, deep: bool = True) -> _vtkArrayType:  #
         if vtk_array_class is None:  # pragma: no cover
             msg = f'Unsupported array type code: {array_type}'
             raise ValueError(msg)
-        new_array = vtk_array_class()
+        new_array = vtk_array_class()  # type: ignore[assignment]
 
     if deep:
         new_array.DeepCopy(array)

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -230,8 +230,8 @@ def copy_vtk_array(array: _vtkArrayType, deep: bool = True) -> _vtkArrayType:  #
         array_type = array.GetArrayType()
         vtk_array_class = VTK_ARRAY_TYPES.get(array_type)
         if vtk_array_class is None:  # pragma: no cover
-            msg = f'Unsupported array type code: {array_type}'
-            raise ValueError(msg)
+            msg = f'Array could not be copied, unsupported array type code: {array_type}'
+            raise TypeError(msg)
         new_array = vtk_array_class()  # type: ignore[assignment]
 
     if deep:

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -33,6 +33,26 @@ if TYPE_CHECKING:
     from pyvista.core._typing_core import VectorLike
     from pyvista.core.dataset import _ActiveArrayExistsInfoTuple
 
+# Mapping from types in `vtkType.h` to the corresponding array class
+VTK_ARRAY_TYPES = {
+    _vtk.VTK_BIT: _vtk.vtkBitArray,
+    _vtk.VTK_CHAR: _vtk.vtkCharArray,
+    _vtk.VTK_SIGNED_CHAR: _vtk.vtkSignedCharArray,
+    _vtk.VTK_UNSIGNED_CHAR: _vtk.vtkUnsignedCharArray,
+    _vtk.VTK_SHORT: _vtk.vtkShortArray,
+    _vtk.VTK_UNSIGNED_SHORT: _vtk.vtkUnsignedShortArray,
+    _vtk.VTK_INT: _vtk.vtkIntArray,
+    _vtk.VTK_UNSIGNED_INT: _vtk.vtkUnsignedIntArray,
+    _vtk.VTK_LONG: _vtk.vtkLongArray,
+    _vtk.VTK_UNSIGNED_LONG: _vtk.vtkUnsignedLongArray,
+    _vtk.VTK_FLOAT: _vtk.vtkFloatArray,
+    _vtk.VTK_DOUBLE: _vtk.vtkDoubleArray,
+    _vtk.VTK_ID_TYPE: _vtk.vtkIdTypeArray,
+    _vtk.VTK_STRING: _vtk.vtkStringArray,
+    _vtk.VTK_LONG_LONG: _vtk.vtkLongLongArray,
+    _vtk.VTK_UNSIGNED_LONG_LONG: _vtk.vtkUnsignedLongLongArray,
+}
+
 
 class FieldAssociation(enum.Enum):
     """Represents which type of vtk field a scalar or vector array is associated with."""
@@ -202,7 +222,18 @@ def copy_vtk_array(array: _vtkArrayType, deep: bool = True) -> _vtkArrayType:  #
         msg = f'Invalid type {type(array)}.'  # type: ignore[unreachable]
         raise TypeError(msg)
 
-    new_array = type(array)()
+    try:
+        new_array = type(array)()
+    except TypeError:
+        # Array appears abstract and is likely implicit
+        # Init array from the array type instead
+        array_type = array.GetArrayType()
+        vtk_array_class = VTK_ARRAY_TYPES.get(array_type)
+        if vtk_array_class is None:
+            msg = f'Unsupported array type code: {array_type}'
+            raise ValueError(msg)
+        new_array = vtk_array_class()
+
     if deep:
         new_array.DeepCopy(array)
     else:

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -940,6 +940,27 @@ def test_copy_vtk_array():
     assert new_value == arr_copy_shallow.GetValue(1)
 
 
+def test_copy_implicit_vtk_array(plane):
+    # Use the connectivity filter to generate an implicit vtkDataArray
+    conn = plane.connectivity()
+    vtk_object = conn['RegionId'].VTKObject
+    if pv.vtk_version_info >= (9, 4):
+        # The VTK array appears to be abstract but is not
+        assert type(vtk_object) is vtk.vtkDataArray
+    else:
+        assert type(vtk_object) is vtk.vtkIdTypeArray
+
+    # `copy_vtk_array` is called with this assignment
+    plane['test'] = conn['RegionId']
+
+    new_vtk_object = plane['test'].VTKObject
+    if pv.vtk_version_info >= (9, 4):
+        # The VTK array type has changed and is now a concrete subclass
+        assert type(new_vtk_object) is vtk.vtkUnsignedIntArray
+    else:
+        assert type(new_vtk_object) is vtk.vtkIdTypeArray
+
+
 def test_cartesian_to_spherical():
     def polar2cart(r, phi, theta):
         return np.vstack(


### PR DESCRIPTION
### Overview

Fix #7655

It is possible for a VTK array to have type `vtkDataArray`, which is normally an abstract class, and yet not actually be abstract. This can happen when an array is dynamically allocated using `vtkImplicitArray`. However, the current copy mechanism assumes that the array type can be instantiated directly, which is not the case for `vtkDataArray` since it is abstract. This PR adds a dict lookup instead to init a new array based on the `GetArrayType` property instead of using the class type itself.