### PR TITLE
Fix block splitter syntax to # %% in sphinx-gallery

### DIFF
--- a/examples/00-load/create_parametric_geometric_objects.py
+++ b/examples/00-load/create_parametric_geometric_objects.py
@@ -18,14 +18,14 @@ import pyvista as pv
 # This example demonstrates how to plot parametric objects using pyvista
 #
 # Supertoroid
-# +++++++++++
+
 
 supertoroid = pv.ParametricSuperToroid(n1=0.5)
 supertoroid.plot(color='lightblue', smooth_shading=True)
 
 # %%
 # Parametric Ellipsoid
-# ++++++++++++++++++++
+
 
 # Ellipsoid with a long x axis
 ellipsoid = pv.ParametricEllipsoid(10, 5, 5)
@@ -34,7 +34,7 @@ ellipsoid.plot(color='lightblue')
 
 # %%
 # Partial Parametric Ellipsoid
-# ++++++++++++++++++++++++++++
+
 
 # cool plotting direction
 cpos = [
@@ -51,14 +51,14 @@ part_ellipsoid.plot(color='lightblue', smooth_shading=True, cpos=cpos)
 
 # %%
 # Pseudosphere
-# ++++++++++++
+
 
 pseudosphere = pv.ParametricPseudosphere()
 pseudosphere.plot(color='lightblue', smooth_shading=True)
 
 # %%
 # Bohemian Dome
-# +++++++++++++
+
 
 
 bohemiandome = pv.ParametricBohemianDome()
@@ -66,91 +66,91 @@ bohemiandome.plot(color='lightblue')
 
 # %%
 # Bour
-# ++++
+
 
 bour = pv.ParametricBour()
 bour.plot(color='lightblue')
 
 # %%
 # Boy's Surface
-# +++++++++++++
+
 
 boy = pv.ParametricBoy()
 boy.plot(color='lightblue')
 
 # %%
 # Catalan Minimal
-# +++++++++++++++
+
 
 catalanminimal = pv.ParametricCatalanMinimal()
 catalanminimal.plot(color='lightblue')
 
 # %%
 # Conic Spiral
-# ++++++++++++
+
 
 conicspiral = pv.ParametricConicSpiral()
 conicspiral.plot(color='lightblue')
 
 # %%
 # Cross Cap
-# +++++++++
+
 
 crosscap = pv.ParametricCrossCap()
 crosscap.plot(color='lightblue')
 
 # %%
 # Dini
-# ++++
+
 
 dini = pv.ParametricDini()
 dini.plot(color='lightblue')
 
 # %%
 # Enneper
-# +++++++
+
 
 enneper = pv.ParametricEnneper()
 enneper.plot(cpos='yz')
 
 # %%
 # Figure-8 Klein
-# ++++++++++++++
+
 
 figure8klein = pv.ParametricFigure8Klein()
 figure8klein.plot()
 
 # %%
 # Henneberg
-# +++++++++
+
 
 henneberg = pv.ParametricHenneberg()
 henneberg.plot(color='lightblue')
 
 # %%
 # Klein
-# +++++
+
 
 klein = pv.ParametricKlein()
 klein.plot(color='lightblue')
 
 # %%
 # Kuen
-# ++++
+
 
 kuen = pv.ParametricKuen()
 kuen.plot(color='lightblue')
 
 # %%
 # Mobius
-# ++++++
+
 
 mobius = pv.ParametricMobius()
 mobius.plot(color='lightblue')
 
 # %%
 # Plucker Conoid
-# ++++++++++++++
+
 
 pluckerconoid = pv.ParametricPluckerConoid()
 pluckerconoid.plot(color='lightblue')
@@ -158,35 +158,35 @@ pluckerconoid.plot(color='lightblue')
 
 # %%
 # Random Hills
-# ++++++++++++
+
 
 randomhills = pv.ParametricRandomHills()
 randomhills.plot(color='lightblue')
 
 # %%
 # Roman
-# +++++
+
 
 roman = pv.ParametricRoman()
 roman.plot(color='lightblue')
 
 # %%
 # Super Ellipsoid
-# +++++++++++++++
+
 
 superellipsoid = pv.ParametricSuperEllipsoid(n1=0.1, n2=2)
 superellipsoid.plot(color='lightblue')
 
 # %%
 # Torus
-# +++++
+
 
 torus = pv.ParametricTorus()
 torus.plot(color='lightblue')
 
 # %%
 # Circular Arc
-# ++++++++++++
+
 
 pointa = [-1, 0, 0]
 pointb = [0, 1, 0]
@@ -204,7 +204,7 @@ pl.show()
 
 # %%
 # Extruded Half Arc
-# +++++++++++++++++
+
 
 pointa = [-1, 0, 0]
 pointb = [1, 0, 0]

--- a/examples/00-load/create_spline.py
+++ b/examples/00-load/create_spline.py
@@ -113,7 +113,7 @@ tube.plot(scalars='theta', smooth_shading=True)
 
 # %%
 # Ribbons
-# +++++++
+
 #
 # Ayy of the lines from the examples above can be used to create ribbons.
 # Take a look at the :func:`pyvista.PolyDataFilters.ribbon` filter.

--- a/examples/00-load/create_structured_surface.py
+++ b/examples/00-load/create_structured_surface.py
@@ -18,7 +18,6 @@ from pyvista import examples
 
 # %%
 # From NumPy Meshgrid
-# +++++++++++++++++++
 #
 # Create a simple meshgrid using NumPy. Note the usage of ij indexing.
 
@@ -50,7 +49,6 @@ grid.points
 
 # %%
 # From XYZ Points
-# +++++++++++++++
 #
 # Quite often, you might be given a set of coordinates (XYZ points) in a simple
 # tabular format where there exists some structure such that grid could be
@@ -134,7 +132,6 @@ mesh.plot(show_edges=True, show_grid=True, cpos='xy')
 
 # %%
 # Extending a 2D StructuredGrid to 3D
-# +++++++++++++++++++++++++++++++++++
 #
 # A 2D :class:`pyvista.StructuredGrid` mesh can be extended into a 3D mesh.
 # This is highly applicable when wanting to create a terrain following mesh

--- a/examples/00-load/create_tri_surface.py
+++ b/examples/00-load/create_tri_surface.py
@@ -20,7 +20,7 @@ rng = np.random.default_rng(seed=0)
 
 # %%
 # Simple Triangulations
-# +++++++++++++++++++++
+
 #
 # First, create some points for the surface.
 
@@ -54,7 +54,7 @@ surf.plot(show_edges=True)
 
 # %%
 # Masked Triangulations
-# +++++++++++++++++++++
+
 #
 
 x = np.arange(10, dtype=float)

--- a/examples/01-filter/boolean_operations.py
+++ b/examples/01-filter/boolean_operations.py
@@ -53,7 +53,7 @@ sphere_b = pv.Sphere(center=(0.5, 0, 0))
 
 # %%
 # Boolean Union
-# +++++++++++++
+
 #
 # Perform a boolean union of ``A`` and ``B`` using the
 # :func:`pyvista.PolyDataFilters.boolean_union` filter.
@@ -75,7 +75,7 @@ pl.show()
 
 # %%
 # Boolean Difference
-# ++++++++++++++++++
+
 #
 # Perform a boolean difference of ``A`` and ``B`` using the
 # :func:`pyvista.PolyDataFilters.boolean_difference` filter or the
@@ -97,7 +97,7 @@ pl.show()
 
 # %%
 # Boolean Intersection
-# ++++++++++++++++++++
+
 #
 # Perform a boolean intersection of ``A`` and ``B`` using the
 # :func:`pyvista.PolyDataFilters.boolean_intersection` filter.

--- a/examples/01-filter/clip_with_plane_box.py
+++ b/examples/01-filter/clip_with_plane_box.py
@@ -19,7 +19,7 @@ PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True
 
 # %%
 # Clip with Plane
-# +++++++++++++++
+
 #
 # Clip any dataset by a user defined plane using the
 # :func:`pyvista.DataObjectFilters.clip` filter
@@ -36,7 +36,7 @@ p.show()
 
 # %%
 # Clip with Bounds
-# ++++++++++++++++
+
 #
 # Clip any dataset by a set of XYZ bounds using the
 # :func:`pyvista.DataObjectFilters.clip_box` filter.
@@ -54,7 +54,7 @@ p.show()
 
 # %%
 # Clip with Rotated Box
-# +++++++++++++++++++++
+
 #
 # Clip any dataset by an arbitrarily rotated solid box using the
 # :func:`pyvista.DataObjectFilters.clip_box` filter.
@@ -85,7 +85,7 @@ p.show()
 
 # %%
 # Crinkled Clipping
-# +++++++++++++++++
+
 # Crinkled clipping is useful if you don't want the clip filter to truly clip
 # cells on the boundary, but want to preserve the input cell structure and to
 # pass the entire cell on through the boundary.

--- a/examples/01-filter/contouring.py
+++ b/examples/01-filter/contouring.py
@@ -19,7 +19,7 @@ from pyvista import examples
 
 # %%
 # Iso-Lines
-# +++++++++
+
 #
 # Let's extract 1D iso-lines of a scalar field from a 2D surface mesh.
 mesh = examples.load_random_hills()
@@ -34,7 +34,7 @@ pl.show()
 
 # %%
 # Iso-Surfaces
-# ++++++++++++
+
 #
 # Let's extract 2D iso-surfaces of a scalar field from a 3D mesh.
 mesh = examples.download_embryo()
@@ -54,7 +54,7 @@ pl.show()
 
 # %%
 # Banded Contours
-# +++++++++++++++
+
 # Create banded contours for surface meshes using :func:`~pyvista.PolyDataFilters.contour_banded`.
 mesh = examples.load_random_hills()
 
@@ -80,7 +80,7 @@ pl.show()
 
 # %%
 # Contours from a label map
-# +++++++++++++++++++++++++
+
 #
 # Create labeled surfaces from 3D label maps (e.f. multi-label image segmentation)
 # using :func:`~pyvista.ImageDataFilters.contour_labels`.

--- a/examples/01-filter/distance_between_surfaces.py
+++ b/examples/01-filter/distance_between_surfaces.py
@@ -64,7 +64,7 @@ p.show()
 
 # %%
 # Ray Tracing Distance
-# ++++++++++++++++++++
+
 #
 # Compute normals of lower surface at vertex points
 h0n = h0.compute_normals(point_normals=True, cell_normals=False, auto_orient_normals=True)
@@ -97,7 +97,7 @@ p.show()
 
 # %%
 # Nearest Neighbor Distance
-# +++++++++++++++++++++++++
+
 #
 # You could also use a KDTree to compare the distance between each vertex point
 # of the
@@ -120,7 +120,7 @@ p.show()
 
 # %%
 # Using PyVista Filter
-# ++++++++++++++++++++
+
 #
 # The :func:`pyvista.DataSet.find_closest_cell` filter returns the spatial
 # points inside the cells of the top surface that are closest to the vertex

--- a/examples/01-filter/glyph.py
+++ b/examples/01-filter/glyph.py
@@ -72,7 +72,7 @@ p.show()
 
 # %%
 # Subset of Glyphs
-# ++++++++++++++++
+
 #
 # Sometimes you might not want glyphs for every node in the input dataset. In
 # this case, you can choose to build glyphs for a subset of the input dataset

--- a/examples/01-filter/interpolate.py
+++ b/examples/01-filter/interpolate.py
@@ -20,7 +20,7 @@ from pyvista import examples
 
 # %%
 # Simple Surface Interpolation
-# ++++++++++++++++++++++++++++
+
 # Resample the points' arrays onto a surface
 
 # Download sample data
@@ -46,7 +46,7 @@ p.show()
 
 # %%
 # Complex Interpolation
-# +++++++++++++++++++++
+
 # In this example, we will in interpolate sparse points in 3D space into a
 # volume. These data are from temperature probes in the subsurface and the goal
 # is to create an approximate 3D model of the temperature field in the

--- a/examples/01-filter/interpolate_sample.py
+++ b/examples/01-filter/interpolate_sample.py
@@ -32,7 +32,7 @@ import pyvista as pv
 
 # %%
 # Interpolating from point cloud
-# ++++++++++++++++++++++++++++++
+
 # A point cloud is a collection of points that have no connectivity in
 # the mesh, i.e. the mesh contains no cells or the cells are 0D
 # (vertex or polyvertex). The filter :func:`pyvista.DataSetFilters.interpolate`
@@ -117,7 +117,7 @@ pl.show()
 
 # %%
 # Sampling from a mesh with connectivity
-# ++++++++++++++++++++++++++++++++++++++
+
 # This example is in many ways the opposite of the prior one.
 # A mesh with cell connectivity that spans 2 dimensions is
 # sampled at discrete points using :func:`pyvista.DataObjectFilters.sample`.

--- a/examples/01-filter/resampling.py
+++ b/examples/01-filter/resampling.py
@@ -23,7 +23,7 @@ from pyvista import examples
 
 # %%
 # Simple Resample
-# +++++++++++++++
+
 # Query a grid's points onto a sphere
 mesh = pv.Sphere(center=(4.5, 4.5, 4.5), radius=4.5)
 data_to_probe = examples.load_uniform()
@@ -45,7 +45,7 @@ result.plot(scalars=name, clim=data_to_probe.get_data_range(name))
 
 # %%
 # Complex Resample
-# ++++++++++++++++
+
 # Take a volume of data and create a grid of lower resolution to resample on
 data_to_probe = examples.download_embryo()
 mesh = pv.create_grid(data_to_probe, dimensions=(75, 75, 75))

--- a/examples/01-filter/rotate.py
+++ b/examples/01-filter/rotate.py
@@ -22,7 +22,7 @@ from pyvista import examples
 
 # %%
 # Define camera and axes
-# ++++++++++++++++++++++
+
 #
 # Define camera and axes. Setting axes origin to ``(3.0, 3.0, 3.0)``.
 
@@ -38,7 +38,7 @@ axes.origin = (3.0, 3.0, 3.0)
 
 # %%
 # Original Mesh
-# +++++++++++++
+
 #
 # Plot original mesh. Add axes actor to Plotter.
 
@@ -53,7 +53,7 @@ p.show()
 
 # %%
 # Rotation about the x axis
-# +++++++++++++++++++++++++
+
 #
 # Plot the mesh rotated about the x axis every 60 degrees.
 # Add the axes actor to the Plotter and set the axes origin to the point of rotation.
@@ -72,7 +72,7 @@ p.show()
 
 # %%
 # Rotation about the y axis
-# +++++++++++++++++++++++++
+
 #
 # Plot the mesh rotated about the y axis every 60 degrees.
 # Add the axes actor to the Plotter and set the axes origin to the point of rotation.
@@ -91,7 +91,7 @@ p.show()
 
 # %%
 # Rotation about the z axis
-# +++++++++++++++++++++++++
+
 #
 # Plot the mesh rotated about the z axis every 60 degrees.
 # Add axes actor to the Plotter and set the axes origin to the point of rotation.
@@ -110,7 +110,7 @@ p.show()
 
 # %%
 # Rotation about a custom vector
-# ++++++++++++++++++++++++++++++
+
 #
 # Plot the mesh rotated about a custom vector every 60 degrees.
 # Add the axes actor to the Plotter and set axes origin to the point of rotation.

--- a/examples/01-filter/slice.py
+++ b/examples/01-filter/slice.py
@@ -71,7 +71,7 @@ slices.plot(cmap=cmap)
 
 # %%
 # Slice Along Line
-# ++++++++++++++++
+
 #
 # We can also slice a dataset along a :func:`pyvista.Spline` or
 # :func:`pyvista.Line` using the :func:`pyvista.DataObjectFilters.slice_along_line` filter.
@@ -113,7 +113,7 @@ p.show(cpos=[1, -1, 1])
 
 # %%
 # Multiple Slices in Vector Direction
-# +++++++++++++++++++++++++++++++++++
+
 #
 # Slice a mesh along a vector direction perpendicularly.
 
@@ -148,7 +148,7 @@ p.show()
 
 # %%
 # Slice At Different Bearings
-# +++++++++++++++++++++++++++
+
 #
 # From `pyvista-support#23 <https://github.com/pyvista/pyvista-support/issues/23>`_
 #

--- a/examples/01-filter/streamlines.py
+++ b/examples/01-filter/streamlines.py
@@ -22,7 +22,7 @@ from pyvista import examples
 
 # %%
 # Carotid
-# +++++++
+
 # Download a sample dataset containing a vector field that can be integrated.
 
 mesh = examples.download_carotid()
@@ -56,7 +56,7 @@ p.show()
 
 # %%
 # Blood Vessels
-# +++++++++++++
+
 # Here is another example of blood flow:
 
 mesh = examples.download_blood_vessels().cell_data_to_point_data()
@@ -115,7 +115,7 @@ p.show()
 
 # %%
 # Kitchen
-# +++++++
+
 #
 kpos = [(-6.68, 11.9, 11.6), (3.5, 2.5, 1.26), (0.45, -0.4, 0.8)]
 
@@ -136,7 +136,7 @@ p.show()
 
 # %%
 # Custom 3D Vector Field
-# ++++++++++++++++++++++
+
 #
 
 nx = 20

--- a/examples/01-filter/using_filters.py
+++ b/examples/01-filter/using_filters.py
@@ -88,7 +88,7 @@ p.show()
 
 # %%
 # Filter Pipeline
-# +++++++++++++++
+
 #
 # In VTK, filters are often used in a pipeline where each algorithm passes its
 # output to the next filtering algorithm. In PyVista, we can mimic the

--- a/examples/01-filter/volumetric_analysis.py
+++ b/examples/01-filter/volumetric_analysis.py
@@ -98,7 +98,7 @@ largest.plot(show_grid=True, cpos=[-2, 5, 3])
 # .. _split_vol:
 #
 # Splitting Volumes
-# +++++++++++++++++
+
 #
 # What if instead, we wanted to split all the different connected bodies /
 # volumes in a dataset like the one above? We could use the
@@ -127,7 +127,7 @@ bodies.plot(show_grid=True, multi_colors=True, cpos=[-2, 5, 3])
 # -----
 #
 # A Real Dataset
-# ++++++++++++++
+
 #
 # Here is a realistic training dataset of fluvial channels in the subsurface.
 # This will threshold the channels from the dataset then separate each

--- a/examples/02-plot/colormap.py
+++ b/examples/02-plot/colormap.py
@@ -32,7 +32,7 @@ from pyvista import examples
 
 # %%
 # Custom Made Colormaps
-# +++++++++++++++++++++
+
 #
 # To get started using a custom colormap, download some data with scalar values to
 # plot.
@@ -93,7 +93,7 @@ mesh.plot(scalars=scalars, cmap=['black', 'blue', 'yellow', 'grey', 'red'])
 
 # %%
 # Matplotlib vs. Colorcet
-# +++++++++++++++++++++++
+
 #
 # Let's compare Colorcet's perceptually uniform "fire" colormap to Matplotlib's
 # "hot" colormap much like the example on the `first page of Colorcet's docs`_.

--- a/examples/02-plot/edl.py
+++ b/examples/02-plot/edl.py
@@ -27,7 +27,7 @@ PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True
 
 # %%
 # Statue
-# +++++++++++
+
 #
 # Eye-Dome Lighting can dramatically improve depth perception when plotting
 # incredibly sophisticated meshes like the creative commons Queen Nefertiti
@@ -58,7 +58,7 @@ p.show()
 
 # %%
 # Point Cloud
-# +++++++++++
+
 #
 # When plotting a simple point cloud, it can be difficult to perceive depth.
 # Take this Lidar point cloud for example:

--- a/examples/02-plot/element_picking.py
+++ b/examples/02-plot/element_picking.py
@@ -26,7 +26,7 @@ from pyvista.plotting.opts import ElementType
 
 # %%
 # Pick Face on Voxel Cell
-# +++++++++++++++++++++++
+
 #
 mesh = pv.Wavelet()
 
@@ -53,7 +53,7 @@ except AttributeError:
 
 # %%
 # Pick an Edge of a Cell
-# ++++++++++++++++++++++
+
 #
 sphere = pv.Sphere()
 

--- a/examples/02-plot/legend.py
+++ b/examples/02-plot/legend.py
@@ -21,7 +21,7 @@ PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True
 
 # %%
 # Default legend for glyphs
-# +++++++++++++++++++++++++
+
 #
 # The method :func:`~pyvista.Plotter.add_legend` is able to retrieve and use
 # the glyphs for each plot.
@@ -52,7 +52,7 @@ pl.show()
 
 # %%
 # Using custom legends
-# ++++++++++++++++++++
+
 #
 # You can use specific labels with :func:`~pyvista.Plotter.add_legend`
 #
@@ -80,7 +80,7 @@ pl.show()
 
 # %%
 # Using custom legend and glyphs
-# ++++++++++++++++++++++++++++++
+
 #
 # You can use specific labels or glyphs even if they have been specified before.
 #

--- a/examples/02-plot/mesh_picking.py
+++ b/examples/02-plot/mesh_picking.py
@@ -14,7 +14,7 @@ import pyvista as pv
 
 # %%
 # Pick either a cube or a sphere using "p"
-# ++++++++++++++++++++++++++++++++++++++++
+
 #
 
 sphere = pv.Sphere(center=(1, 0, 0))
@@ -29,7 +29,7 @@ pl.show()
 
 # %%
 # Deform the mesh after picking
-# +++++++++++++++++++++++++++++
+
 # Pick to trigger a callback that "shrinks" the mesh each time it's selected.
 
 
@@ -48,7 +48,7 @@ pl.show()
 
 # %%
 # Pick based on Actors
-# ++++++++++++++++++++
+
 # Return the picked actor to the callback
 
 pl = pv.Plotter()

--- a/examples/02-plot/opacity.py
+++ b/examples/02-plot/opacity.py
@@ -21,7 +21,7 @@ mesh = image.warp_by_scalar()
 
 # %%
 # Global Value
-# ++++++++++++
+
 #
 # You can also apply a global opacity value to the mesh by passing a single
 # float between 0 and 1 which would enable you to see objects behind the mesh:
@@ -41,7 +41,7 @@ p.show()
 
 # %%
 # Transfer Functions
-# ++++++++++++++++++
+
 #
 # It's possible to apply an opacity mapping to any scalar array plotted. You
 # can specify either a single static value to make the mesh transparent on all
@@ -130,7 +130,7 @@ p.show()
 
 # %%
 # Opacity by Array
-# ++++++++++++++++
+
 #
 # You can also use a scalar array associated with the mesh to give each cell
 # its own opacity/transparency value derived from a scalar field. For example,

--- a/examples/02-plot/plot_over_circular_arc.py
+++ b/examples/02-plot/plot_over_circular_arc.py
@@ -22,7 +22,7 @@ PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True
 
 # %%
 # Volumetric Mesh
-# +++++++++++++++
+
 #
 # Add the height scalars to a uniform 3D mesh.
 mesh = examples.load_uniform()

--- a/examples/02-plot/plot_over_line.py
+++ b/examples/02-plot/plot_over_line.py
@@ -21,7 +21,7 @@ PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True
 
 # %%
 # Volumetric Mesh
-# +++++++++++++++
+
 #
 # First a 3D mesh example to demonstrate
 mesh = examples.download_kitchen()
@@ -45,7 +45,7 @@ mesh.plot_over_line(a, b, resolution=100)
 
 # %%
 # Flat Surface
-# ++++++++++++
+
 #
 # We could also plot the values of a mesh that lies on a flat surface
 mesh = examples.download_st_helens()

--- a/examples/02-plot/point_labels.py
+++ b/examples/02-plot/point_labels.py
@@ -23,7 +23,7 @@ from pyvista import examples
 
 # %%
 # Label String Array
-# ++++++++++++++++++
+
 #
 # This example will label the nodes of a mesh with a given array of string
 # labels for each of the nodes.
@@ -49,7 +49,7 @@ plotter.show()
 
 # %%
 # Label Node Locations
-# ++++++++++++++++++++
+
 #
 # This example will label the nodes of a mesh with their coordinate locations
 
@@ -74,7 +74,7 @@ plotter.show()
 
 # %%
 # Label Scalar Values
-# +++++++++++++++++++
+
 #
 # This example will label each point with their scalar values
 

--- a/examples/02-plot/point_picking.py
+++ b/examples/02-plot/point_picking.py
@@ -20,7 +20,7 @@ PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True
 
 # %%
 # Pick points on a sphere
-# +++++++++++++++++++++++
+
 #
 sphere = pv.Sphere()
 
@@ -31,7 +31,7 @@ p.show()
 
 # %%
 # Ignore the 3D window
-# ++++++++++++++++++++
+
 #
 # In the above example, both points on the mesh and points in the 3d window can be
 # selected. It is possible instead pick only points on the mesh.
@@ -44,7 +44,7 @@ p.show()
 
 # %%
 # Modify which actors are pickable
-# ++++++++++++++++++++++++++++++++
+
 #
 # After enabling point picking, we can modify which actors are pickable.
 sphere = pv.Sphere()
@@ -61,7 +61,7 @@ p.show()
 
 # %%
 # Pick using the left-mouse button
-# ++++++++++++++++++++++++++++++++
+
 #
 sphere = pv.Sphere()
 

--- a/examples/02-plot/texture.py
+++ b/examples/02-plot/texture.py
@@ -68,7 +68,7 @@ curvsurf.plot(texture=tex)
 
 # %%
 # Textures from Files
-# +++++++++++++++++++
+
 #
 # What about loading your own texture from an image? This is often most easily
 # done using the :func:`pyvista.read_texture` function - simply pass an image
@@ -82,7 +82,7 @@ curvsurf.plot(texture=tex)
 
 # %%
 # NumPy Arrays as Textures
-# ++++++++++++++++++++++++
+
 #
 # Want to use a programmatically built image? :class:`pyvista.ImageData`
 # objects can be converted to textures using :func:`pyvista.image_to_texture`
@@ -109,7 +109,7 @@ curvsurf.plot(texture=tex)
 
 # %%
 # Create a GIF Movie with updating textures
-# +++++++++++++++++++++++++++++++++++++++++
+
 # Generate a moving gif from an active plotter with updating textures.
 
 mesh = curvsurf.extract_surface()
@@ -148,7 +148,7 @@ plotter.close()
 
 # %%
 # Textures with Transparency
-# ++++++++++++++++++++++++++
+
 #
 # Textures can also specify per-pixel opacity values. The image must
 # contain a 4th channel specifying the opacity value from 0 [transparent] to
@@ -168,7 +168,7 @@ curvsurf.plot(texture=rgba, show_grid=True)
 
 # %%
 # Repeating Textures
-# ++++++++++++++++++
+
 #
 # What if you have a single texture that you'd like to repeat across a mesh?
 # Simply define the texture coordinates for all nodes explicitly.
@@ -203,7 +203,7 @@ curvsurf.plot(texture=tex, cpos='xy')
 
 # %%
 # Spherical Texture Coordinates
-# +++++++++++++++++++++++++++++
+
 # We have a built in convienance method for mapping textures to spherical
 # coordinate systems much like the planar mapping demoed above.
 mesh = pv.Sphere()

--- a/examples/02-plot/volume_rendering.py
+++ b/examples/02-plot/volume_rendering.py
@@ -31,7 +31,7 @@ vol
 
 # %%
 # Simple Volume Render
-# ++++++++++++++++++++
+
 #
 
 # A nice camera position
@@ -42,7 +42,7 @@ vol.plot(volume=True, cmap='bone', cpos=cpos)
 
 # %%
 # Opacity Mappings
-# ++++++++++++++++
+
 #
 # Or use the :func:`pyvista.Plotter.add_volume` method like below.
 # Note that here we use a non-default opacity mapping to a sigmoid:
@@ -76,7 +76,7 @@ pl.show()
 
 # %%
 # Cool Volume Examples
-# ++++++++++++++++++++
+
 #
 # Here are a few more cool volume rendering examples.
 
@@ -128,7 +128,7 @@ pl.show()
 
 # %%
 # Extracting a VOI
-# ++++++++++++++++
+
 #
 # Use the :func:`pyvista.ImageDataFilters.extract_subset` filter to extract
 # a volume of interest/subset volume to volume render. This is ideal when
@@ -186,7 +186,7 @@ pl.show()
 # .. _volume_with_mask_example:
 #
 # Volume With Segmentation Mask
-# +++++++++++++++++++++++++++++
+
 # Visualize a medical image with a corresponding binary segmentation mask.
 #
 # For this example, we use :func:`~pyvista.examples.downloads.download_whole_body_ct_male`

--- a/examples/03-widgets/checkbox_widget.py
+++ b/examples/03-widgets/checkbox_widget.py
@@ -22,7 +22,7 @@ import pyvista as pv
 
 # %%
 # Single Checkbox
-# +++++++++++++++
+
 
 mesh = pv.Sphere()
 
@@ -39,7 +39,7 @@ p.show()
 
 # %%
 # Multiple Checkboxes
-# +++++++++++++++++++
+
 #
 # In this example, we will add many meshes to a scene with unique colors and
 # create corresponding checkboxes for those meshes of the same color to toggle

--- a/examples/03-widgets/slider_bar_widget.py
+++ b/examples/03-widgets/slider_bar_widget.py
@@ -45,7 +45,7 @@ p.threshold_meshes
 
 # %%
 # Custom Callback
-# +++++++++++++++
+
 #
 # Or you could leverage a custom callback function that takes a single value
 # from the slider as its argument to do something like control the resolution

--- a/examples/03-widgets/sphere_widget.py
+++ b/examples/03-widgets/sphere_widget.py
@@ -28,7 +28,7 @@ PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True
 
 # %%
 # Example A
-# +++++++++
+
 #
 # Use a single sphere widget
 
@@ -68,7 +68,7 @@ p.show()
 
 # %%
 # Example B
-# +++++++++
+
 #
 # Use several sphere widgets at once
 
@@ -108,7 +108,7 @@ p.show()
 
 # %%
 # Example C
-# +++++++++
+
 #
 # This one is the coolest - use four sphere widgets to update perturbations on
 # a surface and interpolate between them with some boundary conditions

--- a/examples/99-advanced/extending_pyvista.py
+++ b/examples/99-advanced/extending_pyvista.py
@@ -46,7 +46,7 @@ class FooData(pyvista.PolyData):  # noqa: D101
 
 # %%
 # Directly Managing Types
-# +++++++++++++++++++++++
+
 #
 # Now a ``foo_sphere`` object is created of type ``FooData``.
 # The index of the point and location of the point of interest can be obtained
@@ -90,7 +90,7 @@ print(f'Location of maximum point: {foo_sphere.points[foo_sphere.max_point, :]}'
 
 # %%
 # Automatically Managing Types
-# ++++++++++++++++++++++++++++
+
 #
 # The default :class:`pyvista.DataSet` type can be set using ``pyvista._wrappers``.
 # In general, it is best to use this method when it is expected to primarily

--- a/examples/99-advanced/plotting_algorithms.py
+++ b/examples/99-advanced/plotting_algorithms.py
@@ -82,7 +82,7 @@ p.show()
 
 # %%
 # Filter Pipeline
-# +++++++++++++++
+
 # We can do this with any :vtk:`vtkAlgorithm` subclass for dynamically generating
 # or filtering data. Here is an example of executing a pipeline of VTK filters
 # together.


### PR DESCRIPTION
## Summary
This PR removes old-style section underlines (# +++) from example files to align with sphinx-gallery documentation recommendations for code cell separators.

## Details
- Removed the # +++ style section underlines while keeping section titles
- The # %% block separators remain intact
- This follows the same pattern as #6378
- 34 files were updated

## Why this change?
The sphinx-gallery documentation recommends using # %% as a consistent syntax for code cell separators across multiple development environments (VS Code, Jupytext, Spyder, etc.).

## Related
- #6378 - Original PR that established this pattern