### PR TITLE
Bump NumPy pin to <2.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ jupyter = [
 [dependency-groups]
 pinned = [ # Pinned versions of core dependencies
   'matplotlib<3.10.2',
-  'numpy<2.3.0',
+  'numpy<2.4.0',
   'pillow<11.3.0',
   'pooch<1.9.0',
   'scooby<0.11.0',

--- a/pyvista/core/_validation/check.py
+++ b/pyvista/core/_validation/check.py
@@ -102,7 +102,7 @@ def check_subdtype(
     if not isinstance(base_dtype, (tuple, list)):
         base_dtype = [base_dtype]
 
-    if not any(np.issubdtype(input_dtype, base) for base in base_dtype):  # type: ignore[arg-type]
+    if not any(np.issubdtype(input_dtype, base) for base in base_dtype):
         # Not a subdtype, so raise error
         msg = f"{name} has incorrect dtype of '{input_dtype.name}'. "
         if len(base_dtype) == 1:
@@ -253,13 +253,13 @@ def check_sorted(
     second_item = array[tuple(second_slice)]
 
     if ascending and not strict:
-        is_sorted = np.all(first_item <= second_item)  # type: ignore[operator]
+        is_sorted = np.all(first_item <= second_item)
     elif ascending and strict:
-        is_sorted = np.all(first_item < second_item)  # type: ignore[operator]
+        is_sorted = np.all(first_item < second_item)
     elif not ascending and not strict:
-        is_sorted = np.all(first_item >= second_item)  # type: ignore[operator]
+        is_sorted = np.all(first_item >= second_item)
     else:  # not ascending and strict
-        is_sorted = np.all(first_item > second_item)  # type: ignore[operator]
+        is_sorted = np.all(first_item > second_item)
 
     if not is_sorted:
         # Show the array's elements in error msg if array is small

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1746,7 +1746,7 @@ class DataSetFilters(DataObjectFilters):
             alg.SetSourceData(geoms[0])
         else:
             for index, subgeom in zip(indices, geoms):
-                alg.SetSourceData(index, subgeom)  # type: ignore[call-overload]
+                alg.SetSourceData(index, subgeom)
             if dataset.active_scalars is not None:
                 if dataset.active_scalars.ndim > 1:
                     alg.SetIndexModeToVector()
@@ -7360,7 +7360,7 @@ class DataSetFilters(DataObjectFilters):
                 keys_ = np.arange(n_colors)
                 values_ = color_rgb_sequence
                 if negative_indexing:
-                    keys_ = np.append(keys_, keys_[::-1] - len(keys_))  # type: ignore[assignment]
+                    keys_ = np.append(keys_, keys_[::-1] - len(keys_))
                     values_.extend(values_[::-1])
                 keys = keys_
                 values = values_

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -3408,7 +3408,7 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
         # This method is required to avoid conflict if a developer extends `ExplicitStructuredGrid`
         # and reimplements `dimensions` to return, for example, the number of cells in the I, J and
         dims = np.reshape(self.GetExtent(), (3, 2))  # K directions.
-        dims = np.diff(dims, axis=1)  # type: ignore[assignment]
+        dims = np.diff(dims, axis=1)
         dims = dims.flatten() + 1  # type: ignore[assignment]
         return int(dims[0]), int(dims[1]), int(dims[2])
 
@@ -3537,7 +3537,7 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
             coords = tuple(coords)
         dims = self._dimensions()
         try:
-            ind = np.ravel_multi_index(coords, np.array(dims) - 1, order='F')  # type: ignore[call-overload]
+            ind = np.ravel_multi_index(coords, np.array(dims) - 1, order='F')
         except ValueError:
             return None
         else:

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from ._typing_core import NumpyArray
 
 
-class pyvista_ndarray(np.ndarray):  # type: ignore[type-arg]  # numpydoc ignore=PR02  # noqa: N801
+class pyvista_ndarray(np.ndarray):  # numpydoc ignore=PR02  # noqa: N801
     """A ndarray which references the owning dataset and the underlying vtk array.
 
     This array can be acted upon just like a :class:`numpy.ndarray`.

--- a/pyvista/core/utilities/features.py
+++ b/pyvista/core/utilities/features.py
@@ -741,7 +741,7 @@ def sample_function(  # noqa: PLR0917
     bounds: Sequence[float] = (-1.0, 1.0, -1.0, 1.0, -1.0, 1.0),
     dim: Sequence[int] = (50, 50, 50),
     compute_normals: bool = False,  # noqa: FBT001, FBT002
-    output_type: np.dtype = np.double,  # type: ignore[assignment, type-arg]
+    output_type: np.dtype = np.double,  # type: ignore[assignment]
     capping: bool = False,  # noqa: FBT001, FBT002
     cap_value: float = sys.float_info.max,
     scalar_arr_name: str = 'scalars',

--- a/pyvista/core/utilities/geometric_objects.py
+++ b/pyvista/core/utilities/geometric_objects.py
@@ -298,7 +298,7 @@ def CylinderStructured(  # noqa: PLR0917
     yy = np.array([Y] * z_resolution).ravel()
     dz = height / (z_resolution - 1)
     zz = np.empty(yy.size)
-    zz = np.full((X.size, z_resolution), dz)  # type:ignore[assignment]
+    zz = np.full((X.size, z_resolution), dz)
     zz *= np.arange(z_resolution)
     zz = zz.ravel(order='f')  # type: ignore[arg-type]
 
@@ -957,10 +957,10 @@ def SolidSphereGeneric(  # noqa: PLR0917
             cells.append(5)
             cells.extend(
                 [
-                    _index(0, iphi, itheta),  # type:ignore[arg-type]
-                    _index(0, iphi, itheta + 1),  # type:ignore[arg-type]
-                    _index(0, iphi + 1, itheta + 1),  # type:ignore[arg-type]
-                    _index(0, iphi + 1, itheta),  # type:ignore[arg-type]
+                    _index(0, iphi, itheta),
+                    _index(0, iphi, itheta + 1),
+                    _index(0, iphi + 1, itheta + 1),
+                    _index(0, iphi + 1, itheta),
                     0,
                 ],
             )
@@ -1011,14 +1011,14 @@ def SolidSphereGeneric(  # noqa: PLR0917
         cells.append(8)
         cells.extend(
             [
-                _index(ir, iphi, itheta),  # type:ignore[arg-type]
-                _index(ir, iphi + 1, itheta),  # type:ignore[arg-type]
-                _index(ir, iphi + 1, itheta + 1),  # type:ignore[arg-type]
-                _index(ir, iphi, itheta + 1),  # type:ignore[arg-type]
-                _index(ir + 1, iphi, itheta),  # type:ignore[arg-type]
-                _index(ir + 1, iphi + 1, itheta),  # type:ignore[arg-type]
-                _index(ir + 1, iphi + 1, itheta + 1),  # type:ignore[arg-type]
-                _index(ir + 1, iphi, itheta + 1),  # type:ignore[arg-type]
+                _index(ir, iphi, itheta),
+                _index(ir, iphi + 1, itheta),
+                _index(ir, iphi + 1, itheta + 1),
+                _index(ir, iphi, itheta + 1),
+                _index(ir + 1, iphi, itheta),
+                _index(ir + 1, iphi + 1, itheta),
+                _index(ir + 1, iphi + 1, itheta + 1),
+                _index(ir + 1, iphi, itheta + 1),
             ],
         )
         celltypes.append(pyvista.CellType.HEXAHEDRON)
@@ -1758,9 +1758,9 @@ def CircularArc(  # noqa: PLR0917
 
     # fix half-arc bug: if a half arc travels directly through the
     # center point, it becomes a line
-    pointb = list(pointb)  # type: ignore[assignment]
-    pointb[0] -= 1e-10  # type: ignore[index]
-    pointb[1] -= 1e-10  # type: ignore[index]
+    pointb = list(pointb)
+    pointb[0] -= 1e-10
+    pointb[1] -= 1e-10
 
     arc = _vtk.vtkArcSource()
     arc.SetPoint1(*pointa)

--- a/pyvista/core/utilities/points.py
+++ b/pyvista/core/utilities/points.py
@@ -192,7 +192,7 @@ def lines_from_points(
     cells[:, 1] = np.arange(0, len(points) - 1, dtype=np.int_)
     cells[:, 2] = np.arange(1, len(points), dtype=np.int_)
     if close:
-        cells = np.append(cells, [[2, len(points) - 1, 0]], axis=0)  # type: ignore[assignment]
+        cells = np.append(cells, [[2, len(points) - 1, 0]], axis=0)
     poly.lines = cells
     return poly
 

--- a/pyvista/core/utilities/transformations.py
+++ b/pyvista/core/utilities/transformations.py
@@ -344,7 +344,7 @@ def apply_transformation_to_points(
 
     # Paged matrix multiplication. For arrays with ndim > 2, matmul assumes
     # that the matrices to be multiplied lie in the last two dimensions.
-    points_2 = (transformation[np.newaxis, :, :] @ points_2.T)[0, :3, :].T  # type: ignore[assignment]
+    points_2 = (transformation[np.newaxis, :, :] @ points_2.T)[0, :3, :].T
 
     # If inplace, set the points
     if inplace:

--- a/pyvista/demos/demos.py
+++ b/pyvista/demos/demos.py
@@ -257,7 +257,7 @@ def plot_wave(fps=30, frequency=1, wavetime=3, notebook=None):  # noqa: PLR0917
     # Make data
     X = np.arange(-10, 10, 0.25)
     Y = np.arange(-10, 10, 0.25)
-    X, Y = np.meshgrid(X, Y)  # type: ignore[assignment]
+    X, Y = np.meshgrid(X, Y)
     R = np.sqrt(X**2 + Y**2)
     Z = np.sin(R)
 

--- a/pyvista/examples/examples.py
+++ b/pyvista/examples/examples.py
@@ -258,7 +258,7 @@ def load_structured():
 def _structured_load_func():
     x = np.arange(-10, 10, 0.25)
     y = np.arange(-10, 10, 0.25)
-    x, y = np.meshgrid(x, y)  # type: ignore[assignment]
+    x, y = np.meshgrid(x, y)
     r = np.sqrt(x**2 + y**2)
     z = np.sin(r)
     return pyvista.StructuredGrid(x, y, z)

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -27,7 +27,7 @@ RAMP_MAP = {0: 'linear', 1: 's-curve', 2: 'sqrt'}
 RAMP_MAP_INV = {k: v for v, k in RAMP_MAP.items()}
 
 
-class lookup_table_ndarray(np.ndarray):  # type: ignore[type-arg] # noqa: N801
+class lookup_table_ndarray(np.ndarray):  # noqa: N801
     """An ndarray which references the owning table and the underlying :vtk:`vtkArray`.
 
     This class is used to ensure that the internal :vtk:`vtkLookupTable` updates when
@@ -789,7 +789,7 @@ class LookupTable(_vtk.DisableVtkSnakeCase, _vtk.vtkLookupTable):
         if flip:
             values = values[::-1]
 
-        self.values = values
+        self.values = values  # type: ignore[assignment]
         self._values_manual = False
 
         # reapply the opacity

--- a/pyvista/plotting/renderers.py
+++ b/pyvista/plotting/renderers.py
@@ -203,7 +203,7 @@ class Renderers:
                         if self.loc_to_group((i, j)) is not None:
                             msg = f'Groups cannot overlap. Overlap found at position {(i, j)}.'
                             raise ValueError(msg)
-                    self.groups = np.concatenate(  # type: ignore[assignment]
+                    self.groups = np.concatenate(
                         (self.groups, np.array([norm_group], dtype=int)),
                         axis=0,
                     )


### PR DESCRIPTION
### Overview

Not sure if dependabot is working properly since https://github.com/pyvista/pyvista/pull/7473... but NumPy can be bumped.