### PR TITLE
Enable autofix_prs in pre-commit.ci configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.ci/
 ci:
   autoupdate_commit_msg: "chore: update pre-commit hooks"
-  autofix_prs: false
+  autofix_prs: true
   autoupdate_schedule: monthly
 
 repos:


### PR DESCRIPTION
## Summary
- Enable `autofix_prs: true` in `.pre-commit-config.yaml` to allow pre-commit.ci to automatically fix formatting and linting issues in pull requests

## Why this change is needed
Currently, `autofix_prs` is set to `false`, which means pre-commit.ci only reports issues but doesn't automatically fix them. This creates additional manual work for contributors who need to address formatting issues after submitting PRs.

## Benefits
- **Improved developer experience**: Contributors don't need to manually fix trivial formatting issues
- **Faster review process**: Eliminates style-related review comments, allowing reviewers to focus on logic and functionality
- **Consistent code style**: Ensures all contributions automatically conform to the project's formatting standards
- **Reduced friction**: New contributors can have their PRs automatically cleaned up without additional setup

## How it works
When enabled, pre-commit.ci will:
1. Run all configured pre-commit hooks on incoming PRs
2. Automatically create commits to fix any formatting/linting issues
3. Push the fixes directly to the PR branch
4. Allow the PR to proceed with clean, properly formatted code

This is a common practice in many open-source projects and helps maintain code quality while reducing contributor friction.

🤖 Generated with [Claude Code](https://claude.ai/code)