### PR TITLE
Fix typing of Plane *_size

### DIFF
--- a/pyvista/core/utilities/geometric_objects.py
+++ b/pyvista/core/utilities/geometric_objects.py
@@ -1033,8 +1033,8 @@ def SolidSphereGeneric(  # noqa: PLR0917
 def Plane(  # noqa: PLR0917
     center: VectorLike[float] = (0.0, 0.0, 0.0),
     direction: VectorLike[float] = (0.0, 0.0, 1.0),
-    i_size: int = 1,
-    j_size: int = 1,
+    i_size: float = 1.0,
+    j_size: float = 1.0,
     i_resolution: int = 10,
     j_resolution: int = 10,
 ) -> PolyData:


### PR DESCRIPTION
### Overview

Closes #7665 

### Details

At least in this module, it seems common to use something like `1.0` or `0.0` rather than `1.` or `0.`.  So I used this here.
