### PR TITLE
Release v0.46

### DIFF
--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -16,7 +16,7 @@ Denotes the first release candidate.
 # major, minor, patch
 from __future__ import annotations
 
-version_info = 0, 46, 'dev0'
+version_info = 0, 47, 'dev0'
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
## Summary
- Bump version from 0.46.dev0 to 0.47.dev0
- Prepare for v0.46 release

## Release Notes
Release notes will be automatically generated based on merged PRs since the last release.

🤖 Generated with [Claude Code](https://claude.ai/code)