### PR TITLE
Relax dependabot github-actions ecosystem version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,19 +22,20 @@ updates:
     labels:
       - "maintenance"
       - "dependencies"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 2
     groups:
-      artifacts:
+      gha:
         patterns:
-          - "actions/upload-artifact"
-          - "actions/download-artifact"
+          - "*"
     labels:
       - "maintenance"
       - "dependencies"
+
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:


### PR DESCRIPTION
### Overview

This pull-request is a follow-up to #7638, see this [comment](https://github.com/pyvista/pyvista/pull/7638#issuecomment-3008821621).

I'm proposing that we relax the constraint on automated `dependabot` GHA version updates to ensure that we're using modern third-party GHA version SHAs.