### PR TITLE
Remove deprecated active_t_coords property

### DIFF
--- a/doc/source/user-guide/data_model.rst
+++ b/doc/source/user-guide/data_model.rst
@@ -677,7 +677,7 @@ Vectors, Texture Coords, and Normals Attributes
 Both cell and point data can also store the following "special" attributes in addition to :attr:`active_scalars <pyvista.DataSet.active_scalars>`:
 
 * :attr:`active_normals <pyvista.DataSet.active_normals>`
-* :attr:`active_t_coords <pyvista.DataSet.active_t_coords>`
+* :attr:`active_texture_coordinates <pyvista.DataSet.active_texture_coordinates>`
 * :attr:`active_vectors <pyvista.DataSet.active_vectors>`
 
 
@@ -694,8 +694,8 @@ it will be computed.
 
 Active Texture Coordinates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-The :attr:`active_t_coords
-<pyvista.DataSet.active_t_coords>` array is used for
+The :attr:`active_texture_coordinates
+<pyvista.DataSet.active_texture_coordinates>` array is used for
 rendering textures. See :ref:`texture_example` for examples using
 this array.
 

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -641,40 +641,6 @@ class DataSet(DataSetFilters, DataObject):
             self.cell_data.set_array(scale, scale_name)
         return self.glyph(orient=vectors_name, scale=scale_name)
 
-    @property
-    def active_t_coords(self: Self) -> pyvista_ndarray | None:
-        """Return the active texture coordinates on the points.
-
-        Returns
-        -------
-        Optional[pyvista_ndarray]
-            Active texture coordinates on the points.
-
-        """
-        warnings.warn(
-            'Use of `DataSet.active_t_coords` is deprecated. '
-            'Use `DataSet.active_texture_coordinates` instead.',
-            PyVistaDeprecationWarning,
-        )
-        return self.active_texture_coordinates
-
-    @active_t_coords.setter
-    def active_t_coords(self: Self, t_coords: NumpyArray[float]) -> None:
-        """Set the active texture coordinates on the points.
-
-        Parameters
-        ----------
-        t_coords : np.ndarray
-            Active texture coordinates on the points.
-
-        """
-        warnings.warn(
-            'Use of `DataSet.active_t_coords` is deprecated. '
-            'Use `DataSet.active_texture_coordinates` instead.',
-            PyVistaDeprecationWarning,
-        )
-        self.active_texture_coordinates = t_coords
-
     def set_active_scalars(
         self: Self,
         name: str | None,

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -7,7 +7,6 @@ import copy as copylib
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import TypeVar
-import warnings
 
 import numpy as np
 import numpy.typing as npt
@@ -15,7 +14,6 @@ import numpy.typing as npt
 from pyvista._deprecate_positional_args import _deprecate_positional_args
 
 from . import _vtk_core as _vtk
-from .errors import PyVistaDeprecationWarning
 from .pyvista_ndarray import pyvista_ndarray
 from .utilities.arrays import FieldAssociation
 from .utilities.arrays import convert_array
@@ -405,86 +403,6 @@ class DataSetAttributes(_vtk.VTKObjectWrapper):
         if self.association == FieldAssociation.CELL:
             return self.dataset.GetNumberOfCells()
         return None
-
-    @property
-    def active_t_coords(self: Self) -> pyvista_ndarray | None:
-        """Return the active texture coordinates array.
-
-        .. deprecated:: 0.43.0
-            Use :func:`DataSetAttributes.active_texture_coordinates` instead.
-
-        Returns
-        -------
-        pyvista.pyvista_ndarray
-            Array of the active texture coordinates.
-
-        """
-        warnings.warn(
-            'Use of `DataSetAttributes.active_t_coords` is deprecated. '
-            'Use `DataSetAttributes.active_texture_coordinates` instead.',
-            PyVistaDeprecationWarning,
-        )
-        return self.active_texture_coordinates
-
-    @active_t_coords.setter
-    def active_t_coords(self: Self, t_coords: NumpyArray[float]) -> None:
-        """Set the active texture coordinates array.
-
-        .. deprecated:: 0.43.0
-            Use :func:`DataSetAttributes.active_texture_coordinates` instead.
-
-        Parameters
-        ----------
-        t_coords : np.ndarray
-            Array of the active texture coordinates.
-
-        """
-        warnings.warn(
-            'Use of `DataSetAttributes.active_t_coords` is deprecated. '
-            'Use `DataSetAttributes.active_texture_coordinates` instead.',
-            PyVistaDeprecationWarning,
-        )
-        self.active_texture_coordinates = t_coords
-
-    @property
-    def active_t_coords_name(self: Self) -> str | None:
-        """Return the name of the active texture coordinates array.
-
-        .. deprecated:: 0.43.0
-            Use :func:`DataSetAttributes.active_texture_coordinates_name` instead.
-
-        Returns
-        -------
-        Optional[str]
-            Name of the active texture coordinates array.
-
-        """
-        warnings.warn(
-            'Use of `DataSetAttributes.active_t_coords_name` is deprecated. '
-            'Use `DataSetAttributes.active_texture_coordinates_name` instead.',
-            PyVistaDeprecationWarning,
-        )
-        return self.active_texture_coordinates_name
-
-    @active_t_coords_name.setter
-    def active_t_coords_name(self: Self, name: str) -> None:
-        """Set the name of the active texture coordinates array.
-
-        .. deprecated:: 0.43.0
-            Use :func:`DataSetAttributes.active_texture_coordinates_name` instead.
-
-        Parameters
-        ----------
-        name : str
-            Name of the active texture coordinates array.
-
-        """
-        warnings.warn(
-            'Use of `DataSetAttributes.active_t_coords_name` is deprecated. '
-            'Use `DataSetAttributes.active_texture_coordinates_name` instead.',
-            PyVistaDeprecationWarning,
-        )
-        self.active_texture_coordinates_name = name
 
     def get_array(self: Self, key: str | int) -> pyvista_ndarray:
         """Get an array in this object.

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1539,19 +1539,6 @@ def mesh():
     return examples.load_globe()
 
 
-def test_active_t_coords_deprecated(mesh):
-    with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
-        t_coords = mesh.active_t_coords
-    if pv._version.version_info[:2] > (0, 46):
-        msg = 'Remove this deprecated property'
-        raise RuntimeError(msg)
-    with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
-        mesh.active_t_coords = t_coords
-    if pv._version.version_info[:2] > (0, 46):
-        msg = 'Remove this deprecated property'
-        raise RuntimeError(msg)
-
-
 def test_active_array_info_deprecated():
     match = 'ActiveArrayInfo is deprecated. Use ActiveArrayInfoTuple instead.'
     with pytest.warns(PyVistaDeprecationWarning, match=match):

--- a/tests/core/test_datasetattributes.py
+++ b/tests/core/test_datasetattributes.py
@@ -17,7 +17,6 @@ import numpy as np
 import pytest
 
 import pyvista as pv
-from pyvista.core.errors import PyVistaDeprecationWarning
 from pyvista.core.utilities.arrays import FieldAssociation
 from pyvista.core.utilities.arrays import convert_array
 
@@ -691,34 +690,6 @@ def test_complex(plane, dtype_str):
     assert plane.point_data[name].dtype == dtype
     plane.point_data[name] = plane.point_data[name].real
     assert np.issubdtype(plane.point_data[name].dtype, real_type)
-
-
-def test_active_t_coords_deprecated():
-    mesh = pv.Cube()
-    with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
-        t_coords = mesh.point_data.active_t_coords
-    if pv._version.version_info[:2] > (0, 46):
-        msg = 'Remove this deprecated property'
-        raise RuntimeError(msg)
-    with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
-        mesh.point_data.active_t_coords = t_coords
-    if pv._version.version_info[:2] > (0, 46):
-        msg = 'Remove this deprecated property'
-        raise RuntimeError(msg)
-
-
-def test_active_t_coords_name_deprecated():
-    mesh = pv.Cube()
-    with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
-        name = mesh.point_data.active_t_coords_name
-    if pv._version.version_info[:2] > (0, 46):
-        msg = 'Remove this deprecated property'
-        raise RuntimeError(msg)
-    with pytest.warns(PyVistaDeprecationWarning, match='texture_coordinates'):
-        mesh.point_data.active_t_coords_name = name
-    if pv._version.version_info[:2] > (0, 46):
-        msg = 'Remove this deprecated property'
-        raise RuntimeError(msg)
 
 
 @pytest.mark.parametrize('copy', [True, False])


### PR DESCRIPTION
## Summary
- Remove deprecated `active_t_coords` property and setter from `DataSet` class
- Remove deprecated `active_t_coords` and `active_t_coords_name` properties from `DataSetAttributes` class  
- Remove associated deprecation tests and update documentation references

## Test plan
- [x] Verify all references to `active_t_coords` have been removed
- [x] Run pre-commit hooks and ensure all checks pass
- [x] Run test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)