### PR TITLE
Remove deprecated download_frog_tissue function

### DIFF
--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -2261,62 +2261,6 @@ _dataset_frog = _MultiFileDownloadableDatasetLoader(_frog_files_func)
 
 
 @_deprecate_positional_args
-def download_frog_tissue(load=True):  # noqa: FBT002
-    """Download frog tissue dataset.
-
-    This dataset contains tissue segmentation labels for the frog dataset.
-
-    .. deprecated:: 0.44.0
-
-        This example does not load correctly on some systems and has been deprecated.
-        Use :func:`~pyvista.examples.examples.load_frog_tissues` instead.
-
-    Parameters
-    ----------
-    load : bool, default: True
-        Load the dataset after downloading it when ``True``.  Set this
-        to ``False`` and only the filename will be returned.
-
-    Returns
-    -------
-    pyvista.ImageData | str
-        DataSet or filename depending on ``load``.
-
-    .. seealso::
-
-        :ref:`Frog Tissue Dataset <frog_tissue_dataset>`
-            See this dataset in the Dataset Gallery for more info.
-
-        :ref:`Frog Dataset <frog_dataset>`
-
-        :ref:`medical_dataset_gallery`
-            Browse other medical datasets.
-
-    """
-    # Deprecated on v0.44.0, estimated removal on v0.47.0
-    warnings.warn(
-        'This example is deprecated and will be removed in v0.47.0. '
-        'Use `load_frog_tissues` instead.',
-        PyVistaDeprecationWarning,
-    )
-    if pyvista._version.version_info >= (0, 47):
-        msg = 'Remove this deprecated function'
-        raise RuntimeError(msg)
-
-    return _download_dataset(_dataset_frog_tissue, load=load)
-
-
-def _frog_tissue_files_func():
-    # Multiple files needed for read, but only one gets loaded
-    frog_tissue_zraw = _DownloadableFile('froggy/frogtissue.zraw')
-    frog_tissue_mhd = _SingleFileDownloadableDatasetLoader('froggy/frogtissue.mhd')
-    return frog_tissue_mhd, frog_tissue_zraw
-
-
-_dataset_frog_tissue = _MultiFileDownloadableDatasetLoader(_frog_tissue_files_func)
-
-
-@_deprecate_positional_args
 def download_chest(load=True):  # noqa: FBT002
     """Download chest dataset.
 

--- a/tests/examples/test_download_files.py
+++ b/tests/examples/test_download_files.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-import re
 import warnings
 
 import numpy as np
@@ -1106,22 +1105,6 @@ def test_download_head2():
 
     biplane = examples.download_head_2()
     assert isinstance(biplane, pv.ImageData)
-
-
-def test_download_frog_tissue():
-    match = re.escape(
-        'This example is deprecated and will be removed in v0.47.0. '
-        'Use `load_frog_tissues` instead.'
-    )
-    with pytest.warns(pv.PyVistaDeprecationWarning, match=match):
-        filename = examples.download_frog_tissue(load=False)
-    assert (p := Path(filename)).is_file()
-    assert p.suffix == '.mhd'
-
-    with pytest.warns(pv.PyVistaDeprecationWarning, match=match):
-        frog = examples.download_frog_tissue()
-
-    assert isinstance(frog, pv.ImageData)
 
 
 def test_download_great_white_shark():


### PR DESCRIPTION
## Summary
- Remove `download_frog_tissue` function that was deprecated in v0.44.0 and scheduled for removal in v0.47.0
- Remove associated helper functions and dataset loaders (`_frog_tissue_files_func`, `_dataset_frog_tissue`)
- Remove test case `test_download_frog_tissue` from test suite

## Background
This function was deprecated because it does not load correctly on some systems. Users should use `load_frog_tissues` instead.

## Test plan
- [x] Verify no remaining references to `download_frog_tissue` in the codebase
- [x] Ensure all tests pass after removal
- [x] Confirm pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)