### PR TITLE
Remove deprecated update_coordinates method

### DIFF
--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -5017,58 +5017,6 @@ class BasePlotter(PickingHelper, WidgetHelper):
         if render:
             self.render()
 
-    @_deprecate_positional_args(allowed=['points'])
-    def update_coordinates(
-        self,
-        points: MatrixLike[float] | VectorLike[float],
-        mesh: _vtk.vtkPolyData | _vtk.vtkUnstructuredGrid | None = None,
-        render: bool | None = True,  # noqa: FBT001, FBT002
-    ) -> None:
-        """Update the points of an object in the plotter.
-
-        .. deprecated:: 0.43.0
-            This method is deprecated and will be removed in a future version of
-            PyVista. It is functionally equivalent to directly modifying the
-            points of a mesh in-place.
-
-            .. code-block:: python
-
-                # Modify the points in place
-                mesh.points = points
-                # Explicitly call render if needed
-                plotter.render()
-
-        Parameters
-        ----------
-        points : np.ndarray
-            Points to replace existing points.
-
-        mesh : vtk.PolyData | vtk.UnstructuredGrid, optional
-            Object that has already been added to the Plotter.  If ``None``, uses
-            last added mesh.
-
-        render : bool, default: True
-            Force a render when True.
-
-        """
-        # Deprecated on 0.43.0, estimated removal on v0.46.0
-        warnings.warn(
-            'This method is deprecated and will be removed in a future version of '
-            'PyVista. Directly modify the points of a mesh in-place instead.',
-            PyVistaDeprecationWarning,
-        )
-        if mesh is None:
-            mesh = self.mesh  # type: ignore[assignment]
-
-        mesh.points = points  # type: ignore[union-attr]
-
-        # only render when the plotter has already been shown
-        if render is None:
-            render = not self._first_time
-
-        if render:
-            self.render()
-
     def _clear_ren_win(self) -> None:
         """Clear the render window."""
         # Not using `render_window` property here to enforce clean up

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -18,7 +18,6 @@ import vtk
 
 import pyvista as pv
 from pyvista.core.errors import MissingDataError
-from pyvista.core.errors import PyVistaDeprecationWarning
 from pyvista.plotting import _plotting
 from pyvista.plotting.errors import RenderWindowUnavailable
 
@@ -815,26 +814,6 @@ def test_plotter_zoom_camera():
 def test_plotter_reset_key_events():
     pl = pv.Plotter()
     pl.reset_key_events()
-
-
-def test_plotter_update_coordinates(sphere):
-    pl = pv.Plotter()
-    pl.add_mesh(sphere)
-
-    def _test_update_coordinates():
-        pl.update_coordinates(sphere.points * 2.0)
-        if pv._version.version_info[:2] > (0, 46):
-            msg = 'Convert error this method'
-            raise RuntimeError(msg)
-        if pv._version.version_info[:2] > (0, 47):
-            msg = 'Remove this method'
-            raise RuntimeError(msg)
-
-    with pytest.warns(
-        PyVistaDeprecationWarning,
-        match='This method is deprecated and will be removed in a future version',
-    ):
-        _test_update_coordinates()
 
 
 @pytest.mark.usefixtures('global_variables_reset')


### PR DESCRIPTION
## Summary
- Removes the deprecated `update_coordinates` method from the Plotter class
- Removes associated test for the deprecated method
- Removes unused `PyVistaDeprecationWarning` import from test file

## Background
The `update_coordinates` method was deprecated in v0.43.0 with a note that it would be removed in a future version. The method was functionally equivalent to directly modifying the points of a mesh in-place:

```python
# Instead of:
plotter.update_coordinates(points)

# Users should:
mesh.points = points
plotter.render()  # if needed
```

## Test plan
- [x] Pre-commit hooks pass
- [x] CI tests should pass (no functionality is being changed, only deprecated code removed)

🤖 Generated with [Claude Code](https://claude.ai/code)