### PR TITLE
Bugfix: Error loading .obj without `uv`

### DIFF
--- a/pyvista/core/utilities/helpers.py
+++ b/pyvista/core/utilities/helpers.py
@@ -243,7 +243,7 @@ def wrap(  # noqa: PLR0911
             faces=dataset.faces,
         )
         # If the Trimesh object has uv, pass them to the PolyData
-        if hasattr(dataset.visual, 'uv'):
+        if hasattr(dataset.visual, 'uv') and dataset.visual.uv is not None:
             polydata.active_texture_coordinates = np.asarray(dataset.visual.uv)
         return polydata
 


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

When loading an .obj without `uv` properties the loader unproperly checks this condition leading to the following error: 
```python-traceback
    mesh = pv.wrap(tm)
  File "/home/username/.local/lib/python3.10/site-packages/pyvista/core/utilities/helpers.py", line 244, in wrap
    polydata.active_texture_coordinates = np.asarray(dataset.visual.uv)
  File "/home/username/.local/lib/python3.10/site-packages/pyvista/core/dataset.py", line 2931, in active_texture_coordinates
    self.point_data.active_texture_coordinates = texture_coordinates  # type: ignore[assignment]
  File "/home/username/.local/lib/python3.10/site-packages/pyvista/core/datasetattributes.py", line 1521, in active_texture_coordinates
    raise ValueError(msg)
ValueError: Texture coordinates must be a 2-dimensional array
```  

### Details

- Check if `dataset.visual.uv is not None` after checking if the attribute exists
- Fixes loading as checked with this [.obj file](https://github.com/bulletphysics/bullet3/blob/master/data/kuka_iiwa/meshes/link_0.obj)
