### PR TITLE
Do not fail unit testing if `vtk-data` cache restore fails

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -105,7 +105,6 @@ jobs:
           path: ${{ env.CACHE_FOLDER_NAME }}
           key: ${{ needs.cache-vtk-data.outputs.key }}
           enableCrossOsArchive: true
-          fail-on-cache-miss: true
 
       - name: Install PyVista test dependencies
         run: |
@@ -186,7 +185,6 @@ jobs:
           path: ${{ env.CACHE_FOLDER_NAME }}
           key: ${{ needs.cache-vtk-data.outputs.key }}
           enableCrossOsArchive: true
-          fail-on-cache-miss: true
 
       - name: Build wheel and install pyvista
         run: |
@@ -313,7 +311,6 @@ jobs:
           path: ${{ env.CACHE_FOLDER_NAME }}
           key: ${{ needs.cache-vtk-data.outputs.key }}
           enableCrossOsArchive: true
-          fail-on-cache-miss: true
 
       - name: Install Testing Requirements
         run: |
@@ -391,7 +388,6 @@ jobs:
           path: ${{ env.CACHE_FOLDER_NAME }}
           key: ${{ needs.cache-vtk-data.outputs.key }}
           enableCrossOsArchive: true
-          fail-on-cache-miss: true
 
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@7d84ae825e6d9297a8e99bdbbae20d1b919a0b19


### PR DESCRIPTION
### Overview

The `vtk-data` cache and restore from #7501 is nice but the action is a bit flaky, and sometimes fails to restore. This currently fails the job, which isn't ideal, but is made worse by the fact that simply retrying the job often doesn't fix the issue. This makes it so that the PR must be closed/reopened to retry the job, or a new commit must be pushed, and _all_ CI must be retried instead of just the one job.

I think it's fine to continue the job without the cache. If the restore fails, the `vtk-data` dir will simply not be created. The downloads module already checks that the USER_DATA_CACHE dir exists, and falls back to using the default dir in this case. So the job should not fail, and simply download directly from the repo as usual.