### PR TITLE
Add PEP 723 inline script metadata to example files

### DIFF
--- a/examples/00-load/create_draped_surface.py
+++ b/examples/00-load/create_draped_surface.py
@@ -33,6 +33,15 @@ profile in 2D with the coordinates associated to the top of each column in your
 2D array.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "matplotlib",
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import matplotlib.pyplot as plt

--- a/examples/00-load/create_explicit_structured_grid.py
+++ b/examples/00-load/create_explicit_structured_grid.py
@@ -9,6 +9,14 @@ Create an explicit structured grid from NumPy arrays using
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/00-load/create_geometric_objects.py
+++ b/examples/00-load/create_geometric_objects.py
@@ -8,6 +8,13 @@ The "Hello, world!" of VTK.
 Uses objects from :ref:`geometry_api`.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/00-load/create_kochanek_spline.py
+++ b/examples/00-load/create_kochanek_spline.py
@@ -9,6 +9,14 @@ Uses :func:`pyvista.KochanekSpline`.
 """
 
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True

--- a/examples/00-load/create_parametric_geometric_objects.py
+++ b/examples/00-load/create_parametric_geometric_objects.py
@@ -7,6 +7,13 @@ Parametric Geometric Objects
 Creating parametric objects from :ref:`parametric_api`.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 from math import pi

--- a/examples/00-load/create_pixel_art.py
+++ b/examples/00-load/create_pixel_art.py
@@ -10,6 +10,13 @@ and `license <https://github.com/googlefonts/noto-emoji/blob/main/LICENSE>`_.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/00-load/create_platonic_solids.py
+++ b/examples/00-load/create_platonic_solids.py
@@ -9,6 +9,14 @@ PyVista wraps the :vtk:`vtkPlatonicSolidSource` filter as
 """
 
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True

--- a/examples/00-load/create_point_cloud.py
+++ b/examples/00-load/create_point_cloud.py
@@ -9,6 +9,14 @@ scalar arrays for those points.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/00-load/create_pointset.py
+++ b/examples/00-load/create_pointset.py
@@ -14,6 +14,13 @@ This example shows the performance improvement when clipping using the
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import time

--- a/examples/00-load/create_poly.py
+++ b/examples/00-load/create_poly.py
@@ -8,6 +8,14 @@ Creating a :class:`pyvista.PolyData` (surface mesh) from vertices and faces.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/00-load/create_polydata_strips.py
+++ b/examples/00-load/create_polydata_strips.py
@@ -13,6 +13,14 @@ adjacent triangles.
 """
 
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True

--- a/examples/00-load/create_polyhedron.py
+++ b/examples/00-load/create_polyhedron.py
@@ -12,6 +12,13 @@ First, we import the required libraries.
 """
 
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True

--- a/examples/00-load/create_sphere.py
+++ b/examples/00-load/create_sphere.py
@@ -9,6 +9,14 @@ This example shows how to create meshes in different ways.
 """
 
 # sphinx_gallery_thumbnail_number = 5
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/00-load/create_spline.py
+++ b/examples/00-load/create_spline.py
@@ -8,6 +8,14 @@ Create a spline/polyline from a numpy array of XYZ vertices using
 :func:`pyvista.Spline`.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/00-load/create_structured_surface.py
+++ b/examples/00-load/create_structured_surface.py
@@ -8,6 +8,15 @@ Create a StructuredGrid surface from NumPy arrays
 using :class:`pyvista.StructuredGrid`.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "matplotlib",
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/00-load/create_tri_surface.py
+++ b/examples/00-load/create_tri_surface.py
@@ -8,6 +8,14 @@ Create a surface from a set of points through a Delaunay triangulation.
 This example uses :func:`pyvista.PolyDataFilters.delaunay_2d`.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/00-load/create_truss.py
+++ b/examples/00-load/create_truss.py
@@ -12,6 +12,14 @@ cylinders.
 """
 
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True

--- a/examples/00-load/create_uniform_grid.py
+++ b/examples/00-load/create_uniform_grid.py
@@ -9,6 +9,14 @@ This example uses :class:`pyvista.ImageData`.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/00-load/create_unstructured_surface.py
+++ b/examples/00-load/create_unstructured_surface.py
@@ -8,6 +8,14 @@ Create an irregular, unstructured grid from NumPy arrays.
 This example uses :class:`pyvista.UnstructuredGrid`.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/00-load/linear_cells.py
+++ b/examples/00-load/linear_cells.py
@@ -17,6 +17,14 @@ see :ref:`point_sets_api`.
 """
 
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True

--- a/examples/00-load/load_gltf.py
+++ b/examples/00-load/load_gltf.py
@@ -13,6 +13,13 @@ based rendering and VTK v9 supports high dynamic range textures.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista

--- a/examples/00-load/load_vrml.py
+++ b/examples/00-load/load_vrml.py
@@ -9,6 +9,13 @@ https://en.wikipedia.org/wiki/VRML
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista

--- a/examples/00-load/read_dolfin.py
+++ b/examples/00-load/read_dolfin.py
@@ -12,6 +12,13 @@ This example uses :func:`pyvista.read`.
 .. _FEniCS/Dolfin: https://fenicsproject.org
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/00-load/read_file.py
+++ b/examples/00-load/read_file.py
@@ -8,6 +8,13 @@ Read a dataset from a known file type.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 # %%
 # Loading a mesh is trivial - if your data is in one of the many supported
 # file formats, simply use :func:`pyvista.read` to load your spatially

--- a/examples/00-load/read_image.py
+++ b/examples/00-load/read_image.py
@@ -8,6 +8,13 @@ Read and plot image files (JPEG, TIFF, PNG, etc).
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 from pyvista import examples

--- a/examples/00-load/read_parallel.py
+++ b/examples/00-load/read_parallel.py
@@ -8,6 +8,13 @@ The VTK library supports parallel file formats. Reading meshes broken up into
 several files is natively supported by VTK and PyVista.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/examples/00-load/reader.py
+++ b/examples/00-load/reader.py
@@ -6,6 +6,14 @@ Load data using a Reader
 """
 
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True

--- a/examples/00-load/terrain_following_mesh.py
+++ b/examples/00-load/terrain_following_mesh.py
@@ -18,6 +18,14 @@ that the given digital elevation model (DEM) is structured (gridded and not
 triangulated): this is common for DEMs.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/00-load/wrap_trimesh.py
+++ b/examples/00-load/wrap_trimesh.py
@@ -17,6 +17,16 @@ of more than one module.
 """
 
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+#   "trimesh",
+#   "vtk",
+# ]
+# ///
+
 from __future__ import annotations
 
 PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True

--- a/examples/01-filter/boolean_operations.py
+++ b/examples/01-filter/boolean_operations.py
@@ -43,6 +43,13 @@ must be all triangle meshes, which you can check with
 """
 
 # sphinx_gallery_thumbnail_number = 6
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/cell_centers.py
+++ b/examples/01-filter/cell_centers.py
@@ -10,6 +10,13 @@ Here we use :func:`cell_centers <pyvista.DataObjectFilters.cell_centers>`.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/clip_with_plane_box.py
+++ b/examples/01-filter/clip_with_plane_box.py
@@ -8,6 +8,13 @@ Clip/cut any dataset using planes or boxes.
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/clip_with_surface.py
+++ b/examples/01-filter/clip_with_surface.py
@@ -14,6 +14,14 @@ but many folks leverage the ``clip_surface`` filter to triangulate/tessellate
 the mesh geometries along the clip.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/01-filter/collision.py
+++ b/examples/01-filter/collision.py
@@ -26,6 +26,14 @@ sphere.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/01-filter/compute_normals.py
+++ b/examples/01-filter/compute_normals.py
@@ -7,6 +7,14 @@ Compute normals on a surface.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 # sphinx_gallery_start_ignore

--- a/examples/01-filter/connectivity.py
+++ b/examples/01-filter/connectivity.py
@@ -9,6 +9,14 @@ filter.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 # %%
 # Remove Noisy Isosurfaces
 # ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/01-filter/contouring.py
+++ b/examples/01-filter/contouring.py
@@ -10,6 +10,14 @@ Generate iso-lines or -surfaces for the scalars of a surface or volume.
 meshes can have 1D iso-lines of a scalar field extracted.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/01-filter/crop_labeled.py
+++ b/examples/01-filter/crop_labeled.py
@@ -10,6 +10,13 @@ Use :meth:`~pyvista.ImageDataFilters.crop` to crop labeled data such as segmente
 
 # sphinx_gallery_thumbnail_number = 2
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/decimate.py
+++ b/examples/01-filter/decimate.py
@@ -9,6 +9,14 @@ Decimate a mesh
 """
 
 # sphinx_gallery_thumbnail_number = 4
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/01-filter/distance_between_surfaces.py
+++ b/examples/01-filter/distance_between_surfaces.py
@@ -33,6 +33,15 @@ to the top surface, unlike the first two examples.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+#   "scipy",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/01-filter/extract_cells_inside_surface.py
+++ b/examples/01-filter/extract_cells_inside_surface.py
@@ -9,6 +9,13 @@ Extract the cells inside or outside a closed surface using
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 # %%
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/01-filter/extract_edges.py
+++ b/examples/01-filter/extract_edges.py
@@ -8,6 +8,13 @@ Extract edges from a surface.
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/extract_surface.py
+++ b/examples/01-filter/extract_surface.py
@@ -9,6 +9,14 @@ using the :meth:`~pyvista.DataSetFilters.extract_surface` filter.
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/01-filter/extrude_rotate.py
+++ b/examples/01-filter/extrude_rotate.py
@@ -15,6 +15,14 @@ cylindrical shell, and sweeping a circle creates a torus.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/01-filter/extrude_trim.py
+++ b/examples/01-filter/extrude_trim.py
@@ -8,6 +8,13 @@ Extrude a :class:`pyvista.PolyData` with a :func:`pyvista.Plane` using
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/gaussian_smoothing.py
+++ b/examples/01-filter/gaussian_smoothing.py
@@ -16,6 +16,13 @@ See also :func:`pyvista.ImageDataFilters.gaussian_smooth`.
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/geodesic.py
+++ b/examples/01-filter/geodesic.py
@@ -8,6 +8,13 @@ Calculates the geodesic path between two vertices using Dijkstra's algorithm
 """
 
 # sphinx_gallery_thumbnail_number = 1
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/glyph.py
+++ b/examples/01-filter/glyph.py
@@ -7,6 +7,14 @@ Plotting Glyphs (Vectors or PolyData)
 Use vectors in a dataset to plot and orient glyphs/geometric objects.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import math

--- a/examples/01-filter/glyph_table.py
+++ b/examples/01-filter/glyph_table.py
@@ -8,6 +8,14 @@ Table of Glyphs
 up. This example demonstrates this functionality.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/01-filter/gradients.py
+++ b/examples/01-filter/gradients.py
@@ -13,6 +13,14 @@ an input array {u, v, w}.
 Showing the :func:`pyvista.DataSetFilters.compute_derivative` filter.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/01-filter/image_fft.py
+++ b/examples/01-filter/image_fft.py
@@ -17,6 +17,14 @@ This example was inspired by `Image denoising by FFT
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/01-filter/image_fft_perlin_noise.py
+++ b/examples/01-filter/image_fft_perlin_noise.py
@@ -15,6 +15,14 @@ and then performing FFT of the sampled noise to show the frequency content of
 that noise.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/01-filter/image_representations.py
+++ b/examples/01-filter/image_representations.py
@@ -13,6 +13,14 @@ and :meth:`DataSetFilters.threshold <pyvista.DataSetFilters.threshold>` (cell-ba
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 # %%#
 # Representations of 3D Volumes
 # -----------------------------

--- a/examples/01-filter/integrate_data.py
+++ b/examples/01-filter/integrate_data.py
@@ -9,6 +9,13 @@ Integrate data over a surface using the
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista

--- a/examples/01-filter/interpolate.py
+++ b/examples/01-filter/interpolate.py
@@ -13,6 +13,13 @@ Gaussian Kernel.
 """
 
 # sphinx_gallery_thumbnail_number = 4
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/interpolate_sample.py
+++ b/examples/01-filter/interpolate_sample.py
@@ -24,6 +24,14 @@ and :ref:`resampling_example`.
 """
 
 # sphinx_gallery_thumbnail_number = 7
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/01-filter/marching_cubes.py
+++ b/examples/01-filter/marching_cubes.py
@@ -13,6 +13,14 @@ for providing examples.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/01-filter/mesh_quality.py
+++ b/examples/01-filter/mesh_quality.py
@@ -15,6 +15,13 @@ for various cell types:
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/perlin_noise_2d.py
+++ b/examples/01-filter/perlin_noise_2d.py
@@ -16,6 +16,13 @@ effects for the motion picture industry.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/perlin_noise_3d.py
+++ b/examples/01-filter/perlin_noise_3d.py
@@ -11,6 +11,13 @@ we create a voxelized mesh similar to a Minecraft "cave".
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/project_plane.py
+++ b/examples/01-filter/project_plane.py
@@ -10,6 +10,13 @@ plane defined by a normal and origin using
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/ray_trace.py
+++ b/examples/01-filter/ray_trace.py
@@ -8,6 +8,13 @@ Single line segment ray tracing for :class:`~pyvista.PolyData` objects
 using :meth:`~pyvista.PolyDataFilters.ray_trace`.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/reflect.py
+++ b/examples/01-filter/reflect.py
@@ -9,6 +9,13 @@ This example reflects a mesh across a plane using
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista

--- a/examples/01-filter/resampling.py
+++ b/examples/01-filter/resampling.py
@@ -11,6 +11,13 @@ methods are compared in :ref:`interpolate_sample_example`.
 Resample one mesh's point/cell arrays onto another mesh's nodes.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 # %%
 # This example will resample a volumetric mesh's scalar data onto the surface
 # of a sphere contained in that volume.

--- a/examples/01-filter/rotate.py
+++ b/examples/01-filter/rotate.py
@@ -15,6 +15,13 @@ image. The camera location is the same in all four images.
 """
 
 # sphinx_gallery_thumbnail_number = 3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/slice.py
+++ b/examples/01-filter/slice.py
@@ -7,6 +7,15 @@ Slicing
 Extract thin planar slices from a volume.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "matplotlib",
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import matplotlib.pyplot as plt

--- a/examples/01-filter/streamlines.py
+++ b/examples/01-filter/streamlines.py
@@ -7,6 +7,14 @@ Streamlines
 Integrate a vector field to generate streamlines.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 # %%
 # This example generates streamlines of blood velocity. An isosurface of speed
 # provides context. The starting positions for the streamtubes were determined

--- a/examples/01-filter/streamlines_2D.py
+++ b/examples/01-filter/streamlines_2D.py
@@ -9,6 +9,13 @@ Integrate a vector field to generate streamlines on a 2D surface.
 
 # sphinx_gallery_thumbnail_number = 3
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 # %%
 # This example generates streamlines of flow around a cylinder in cross flow.
 from __future__ import annotations

--- a/examples/01-filter/subdivide.py
+++ b/examples/01-filter/subdivide.py
@@ -11,6 +11,13 @@ subdivision algorithms to subdivide a mesh's cells: `butterfly`, `loop`,
 or `linear`.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/surface_reconstruction.py
+++ b/examples/01-filter/surface_reconstruction.py
@@ -10,6 +10,13 @@ tends to perform much better than :func:`pyvista.DataSetFilters.delaunay_3d`.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/surface_smoothing.py
+++ b/examples/01-filter/surface_smoothing.py
@@ -8,6 +8,13 @@ Smoothing rough edges of a surface mesh
 """
 
 # sphinx_gallery_thumbnail_number = 4
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/using_filters.py
+++ b/examples/01-filter/using_filters.py
@@ -8,6 +8,13 @@ Using common filters like thresholding and clipping.
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/01-filter/volumetric_analysis.py
+++ b/examples/01-filter/volumetric_analysis.py
@@ -9,6 +9,14 @@ Calculate mass properties such as the volume or area of datasets
 """
 
 # sphinx_gallery_thumbnail_number = 4
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/01-filter/voxelize.py
+++ b/examples/01-filter/voxelize.py
@@ -11,6 +11,14 @@ bounding :class:`pyvista.PolyData` surface.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/01-filter/warp_by_vector.py
+++ b/examples/01-filter/warp_by_vector.py
@@ -8,6 +8,13 @@ This example applies the :meth:`~pyvista.DataSetFilters.warp_by_vector`
 filter to a sphere mesh that has 3D displacement vectors defined at each node.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 # %%
 # We first compare the unwarped sphere to the warped sphere.
 from __future__ import annotations

--- a/examples/02-plot/anti_aliasing.py
+++ b/examples/02-plot/anti_aliasing.py
@@ -32,6 +32,13 @@ should consider FXAA.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/axes_objects.py
+++ b/examples/02-plot/axes_objects.py
@@ -12,6 +12,13 @@ to use them with related plotting methods.
 
 # sphinx_gallery_thumbnail_number = 7
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/backface_prop.py
+++ b/examples/02-plot/backface_prop.py
@@ -16,6 +16,14 @@ depend on the orientation of the surface normals:
 # sphinx_gallery_thumbnail_number = 1
 
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 # backface properties do not work in interactive
 from __future__ import annotations
 

--- a/examples/02-plot/background_image.py
+++ b/examples/02-plot/background_image.py
@@ -8,6 +8,13 @@ Add a background image with :func:`pyvista.Plotter.add_background_image`.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/blurring.py
+++ b/examples/02-plot/blurring.py
@@ -10,6 +10,13 @@ to highlight part of your plot.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/bounds.py
+++ b/examples/02-plot/bounds.py
@@ -10,6 +10,13 @@ using :func:`show_grid() <pyvista.Plotter.show_grid>`
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/chart_basics.py
+++ b/examples/02-plot/chart_basics.py
@@ -9,6 +9,15 @@ A more complex example, showing how to combine multiple charts as overlays
 in the same renderer, is given in :ref:`chart_overlays_example`.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "matplotlib",
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/02-plot/chart_overlays.py
+++ b/examples/02-plot/chart_overlays.py
@@ -15,6 +15,15 @@ interaction with the 3D scene.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "matplotlib",
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import matplotlib.pyplot as plt

--- a/examples/02-plot/clear.py
+++ b/examples/02-plot/clear.py
@@ -10,6 +10,13 @@ This example demonstrates how to remove elements from a scene using
 """
 
 # sphinx_gallery_thumbnail_number = 3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/color_cycler.py
+++ b/examples/02-plot/color_cycler.py
@@ -7,6 +7,13 @@ Color Cycling
 Cycle through colors when sequentially adding meshes to a plotter.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 # %%
 # Many plotting libraries like Matplotlib cycle through a predefined list of
 # colors to colorize the data being added to the graphic. PyVista supports

--- a/examples/02-plot/colormap.py
+++ b/examples/02-plot/colormap.py
@@ -8,6 +8,15 @@ Use a Matplotlib, Colorcet, cmocean, or custom colormap when plotting scalar
 values with :func:`pyvista.plot` and :class:`~pyvista.Plotter` methods.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "matplotlib",
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 from matplotlib.colors import ListedColormap

--- a/examples/02-plot/composite_picking.py
+++ b/examples/02-plot/composite_picking.py
@@ -9,6 +9,14 @@ using :func:`pyvista.Plotter.enable_block_picking`.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/02-plot/depth_of_field.py
+++ b/examples/02-plot/depth_of_field.py
@@ -9,6 +9,14 @@ This example shows how you can use :func:`enable_depth_of_field
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 # sphinx_gallery_start_ignore

--- a/examples/02-plot/depth_peeling.py
+++ b/examples/02-plot/depth_peeling.py
@@ -14,6 +14,13 @@ provides. See :func:`~pyvista.Plotter.enable_depth_peeling`.
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/distance_along_spline.py
+++ b/examples/02-plot/distance_along_spline.py
@@ -11,6 +11,14 @@ This is an extension of the :ref:`create_spline_example`.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/02-plot/distance_measurement.py
+++ b/examples/02-plot/distance_measurement.py
@@ -8,6 +8,13 @@ This example demonstrates how to measure distance between two points.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/edl.py
+++ b/examples/02-plot/edl.py
@@ -12,6 +12,13 @@ To learn more, please see `this blog post`_.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 # %%
 
 # sphinx_gallery_thumbnail_number = 1

--- a/examples/02-plot/element_picking.py
+++ b/examples/02-plot/element_picking.py
@@ -19,6 +19,13 @@ These types are captured in the :class:`pyvista.plotting.opts.ElementType` enum 
 """
 
 # sphinx_gallery_thumbnail_number = 1
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/floors.py
+++ b/examples/02-plot/floors.py
@@ -8,6 +8,13 @@ Add a floor/wall at the boundary of the rendering scene
 using :func:`~pyvista.Plotter.add_floor`.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/ghost_cells.py
+++ b/examples/02-plot/ghost_cells.py
@@ -13,6 +13,14 @@ Notably, the mesh must be cast to an :class:`pyvista.UnstructuredGrid` type
 for this to work (use the ``cast_to_unstructured_grid`` filter).
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/02-plot/gif.py
+++ b/examples/02-plot/gif.py
@@ -14,6 +14,14 @@ This example uses :meth:`~pyvista.Plotter.open_gif` and
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/02-plot/image_depth.py
+++ b/examples/02-plot/image_depth.py
@@ -8,6 +8,14 @@ Use :meth:`~pyvista.Plotter.get_image_depth` to plot a depth image as viewed fro
 camera overlooking the :func:`~pyvista.examples.examples.load_random_hills` example mesh.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "matplotlib",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import matplotlib.pyplot as plt

--- a/examples/02-plot/interpolate_before_map.py
+++ b/examples/02-plot/interpolate_before_map.py
@@ -18,6 +18,13 @@ For more details, please see `What is InterpolateScalarsBeforeMapping in VTK?
 """
 
 # sphinx_gallery_thumbnail_number = 4
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/legend.py
+++ b/examples/02-plot/legend.py
@@ -7,6 +7,13 @@ Legends and glyphs
 Using custom legends and glyphs within PyVista.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/lighting_mesh.py
+++ b/examples/02-plot/lighting_mesh.py
@@ -13,6 +13,13 @@ to ``add_mesh``.
 """
 
 # sphinx_gallery_thumbnail_number = 4
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/linked_views.py
+++ b/examples/02-plot/linked_views.py
@@ -11,6 +11,14 @@ different versions or representations of the same model.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/02-plot/lookup_table.py
+++ b/examples/02-plot/lookup_table.py
@@ -10,6 +10,13 @@ the mapping between a :class:`pyvista.DataSet`'s scalars and RGBA colors.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/mesh_picking.py
+++ b/examples/02-plot/mesh_picking.py
@@ -8,6 +8,13 @@ This example demonstrates how to pick meshes using
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/movie.py
+++ b/examples/02-plot/movie.py
@@ -14,6 +14,14 @@ This example uses :meth:`~pyvista.Plotter.open_movie` and
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/02-plot/movie_glyphs.py
+++ b/examples/02-plot/movie_glyphs.py
@@ -10,6 +10,14 @@ Create an animated GIF by generating glyphs using :func:`glyph()
 """
 
 # sphinx_gallery_thumbnail_number = 1
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/02-plot/moving_cmap.py
+++ b/examples/02-plot/moving_cmap.py
@@ -10,6 +10,14 @@ This example uses :meth:`~pyvista.Plotter.open_gif` and
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/02-plot/moving_isovalue.py
+++ b/examples/02-plot/moving_isovalue.py
@@ -11,6 +11,14 @@ This example uses :meth:`~pyvista.Plotter.open_gif` and
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/02-plot/multi_window.py
+++ b/examples/02-plot/multi_window.py
@@ -8,6 +8,14 @@ Multi-Window Plot
 Subplotting: having multiple scenes in a single window
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/opacity.py
+++ b/examples/02-plot/opacity.py
@@ -9,6 +9,14 @@ or opacity mapping based on a scalar array.
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "matplotlib",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/orbit.py
+++ b/examples/02-plot/orbit.py
@@ -22,6 +22,13 @@ with ``.show(auto_close=False)``.  You may also have to set
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/pbr.py
+++ b/examples/02-plot/pbr.py
@@ -18,6 +18,13 @@ a statue as though it were metallic.
 """
 
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 # physically based rendering does not seem to work in vtk-js
 from __future__ import annotations
 

--- a/examples/02-plot/plot_over_circular_arc.py
+++ b/examples/02-plot/plot_over_circular_arc.py
@@ -10,6 +10,13 @@ using :meth:`~pyvista.DataSetFilters.plot_over_circular_arc_normal`.
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/plot_over_line.py
+++ b/examples/02-plot/plot_over_line.py
@@ -9,6 +9,13 @@ using the :meth:`~pyvista.DataSetFilters.plot_over_line` filter.
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/point_cell_scalars.py
+++ b/examples/02-plot/point_cell_scalars.py
@@ -10,6 +10,14 @@ a dataset.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/02-plot/point_clouds.py
+++ b/examples/02-plot/point_clouds.py
@@ -8,6 +8,14 @@ This example shows you how to plot point clouds using PyVista using both the
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/02-plot/point_labels.py
+++ b/examples/02-plot/point_labels.py
@@ -7,6 +7,14 @@ Label Points
 Use string arrays in a point set to label points
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/02-plot/point_picking.py
+++ b/examples/02-plot/point_picking.py
@@ -9,6 +9,13 @@ This example demonstrates how to pick points on meshes using
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/points_gaussian_scale.py
+++ b/examples/02-plot/points_gaussian_scale.py
@@ -8,6 +8,14 @@ style with :func:`~pyvista.Plotter.add_mesh` and scale them by a dynamic radius.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/02-plot/scalar_bar.py
+++ b/examples/02-plot/scalar_bar.py
@@ -10,6 +10,13 @@ how a user can customize scalar bars.
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/screenshot.py
+++ b/examples/02-plot/screenshot.py
@@ -5,6 +5,14 @@ Saving Screenshots
 ~~~~~~~~~~~~~~~~~~
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "matplotlib",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import matplotlib.pyplot as plt

--- a/examples/02-plot/shading.py
+++ b/examples/02-plot/shading.py
@@ -8,6 +8,13 @@ Comparison of default, flat shading vs. smooth shading.
 """
 
 # sphinx_gallery_thumbnail_number = 4
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista

--- a/examples/02-plot/sharing_scalar_bars.py
+++ b/examples/02-plot/sharing_scalar_bars.py
@@ -10,6 +10,13 @@ among plotted arrays or use a unique scalar bar for each plotted array.
 """
 
 # sphinx_gallery_thumbnail_number = 3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/show_edges.py
+++ b/examples/02-plot/show_edges.py
@@ -9,6 +9,13 @@ Show the edges of all geometries within a mesh using the
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 # %%
 # Sometimes it can be useful to show all of the edges of a mesh when rendering
 # to communicate aspects of the dataset like resolution.

--- a/examples/02-plot/silhouette.py
+++ b/examples/02-plot/silhouette.py
@@ -12,6 +12,13 @@ The silhouette may be created using the `silhouette` keyword with
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista

--- a/examples/02-plot/slice_orthogonal.py
+++ b/examples/02-plot/slice_orthogonal.py
@@ -11,6 +11,13 @@ slices simultaneously.
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/spherical.py
+++ b/examples/02-plot/spherical.py
@@ -8,6 +8,14 @@ Generate and visualize meshes from data in longitude-latitude coordinates
 using :func:`~pyvista.grid_from_sph_coords`.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/02-plot/ssao.py
+++ b/examples/02-plot/ssao.py
@@ -19,6 +19,13 @@ See `Kitware: Screen-Space Ambient Occlusion
 # sphinx_gallery_thumbnail_number = 3
 
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 # the different options of ssao are more clear in static images
 from __future__ import annotations
 

--- a/examples/02-plot/surface_point_picking.py
+++ b/examples/02-plot/surface_point_picking.py
@@ -10,6 +10,13 @@ This allows you to pick points on the surface of a mesh.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/texture.py
+++ b/examples/02-plot/texture.py
@@ -7,6 +7,15 @@ Applying Textures
 Plot a mesh with an image projected onto it as a texture.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "matplotlib",
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 from matplotlib.pyplot import get_cmap

--- a/examples/02-plot/themes.py
+++ b/examples/02-plot/themes.py
@@ -10,6 +10,13 @@ set default plotting parameters. This example shows how to use the
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/topo_map.py
+++ b/examples/02-plot/topo_map.py
@@ -11,6 +11,14 @@ mesh.
 """
 
 # sphinx_gallery_thumbnail_number = 4
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "matplotlib",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import matplotlib as mpl

--- a/examples/02-plot/vector_component.py
+++ b/examples/02-plot/vector_component.py
@@ -10,6 +10,13 @@ We can plot individual components of multi-component arrays with the
 ``component`` argument  of the :meth:`~pyvista.Plotter.add_mesh` method.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/vertices.py
+++ b/examples/02-plot/vertices.py
@@ -8,6 +8,13 @@ Display vertices on a mesh in the same fashion as edge visibility.
 """
 
 # sphinx_gallery_thumbnail_number = 3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/02-plot/volume_rendering.py
+++ b/examples/02-plot/volume_rendering.py
@@ -13,6 +13,14 @@ This also explores how to extract a volume of interest (VOI) from a
 """
 
 # sphinx_gallery_thumbnail_number = 3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/03-widgets/animation.py
+++ b/examples/03-widgets/animation.py
@@ -11,6 +11,13 @@ to move a sphere across a scene.
 Inspired by `VTK Animation Examples <https://examples.vtk.org/site/Python/Utilities/Animation/>`_.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/03-widgets/box_widget.py
+++ b/examples/03-widgets/box_widget.py
@@ -20,6 +20,13 @@ scene with a box widget that controls its extent, the
 """
 
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 # widgets do not work in interactive examples
 from __future__ import annotations
 

--- a/examples/03-widgets/checkbox_widget.py
+++ b/examples/03-widgets/checkbox_widget.py
@@ -12,6 +12,13 @@ See :func:`pyvista.Plotter.add_checkbox_button_widget` for more details.
 
 # sphinx_gallery_thumbnail_number = 2
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 # widgets do not work in interactive examples
 from __future__ import annotations
 

--- a/examples/03-widgets/clip_volume_widget.py
+++ b/examples/03-widgets/clip_volume_widget.py
@@ -13,6 +13,14 @@ structure of the dataset.
 """
 
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 # widgets do not work in interactive examples
 from __future__ import annotations
 

--- a/examples/03-widgets/line_widget.py
+++ b/examples/03-widgets/line_widget.py
@@ -16,6 +16,14 @@ the ``name`` argument in ``add_mesh``.
 """
 
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 # widgets do not work in interactive examples
 from __future__ import annotations
 

--- a/examples/03-widgets/multi_slider_widget.py
+++ b/examples/03-widgets/multi_slider_widget.py
@@ -14,6 +14,13 @@ mesh-generating/altering code.
 """
 
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 # widgets do not work in interactive examples
 from __future__ import annotations
 

--- a/examples/03-widgets/plane_widget.py
+++ b/examples/03-widgets/plane_widget.py
@@ -15,6 +15,14 @@ Let's use a plane to clip a mesh:
 """
 
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+#   "vtk",
+# ]
+# ///
+
 # widgets do not work in interactive examples
 from __future__ import annotations
 

--- a/examples/03-widgets/slider_bar_widget.py
+++ b/examples/03-widgets/slider_bar_widget.py
@@ -12,6 +12,13 @@ be used for just about anything.
 """
 
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 # widgets do not work in interactive examples
 from __future__ import annotations
 

--- a/examples/03-widgets/sphere_widget.py
+++ b/examples/03-widgets/sphere_widget.py
@@ -20,6 +20,16 @@ Let's look at a few use cases that all update a surface mesh.
 # sphinx_gallery_thumbnail_number = 3
 
 # sphinx_gallery_start_ignore
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "matplotlib",
+#   "numpy",
+#   "pyvista",
+#   "scipy",
+# ]
+# ///
+
 # widgets do not work in interactive examples
 from __future__ import annotations
 

--- a/examples/03-widgets/spline_widget.py
+++ b/examples/03-widgets/spline_widget.py
@@ -17,6 +17,14 @@ path. To do this, we have added a convenient helper method which leverages the
 :func:`pyvista.Plotter.add_mesh_slice_spline`.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/04-lights/attenuation.py
+++ b/examples/04-lights/attenuation.py
@@ -26,6 +26,13 @@ Three spotlights with three different attenuation profiles each:
 """
 
 # sphinx_gallery_thumbnail_number = 3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/04-lights/beam_shape.py
+++ b/examples/04-lights/beam_shape.py
@@ -13,6 +13,13 @@ Consider two hemispheres:
 """
 
 # sphinx_gallery_thumbnail_number = 5
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/04-lights/light_actors.py
+++ b/examples/04-lights/light_actors.py
@@ -14,6 +14,14 @@ functionality of which can be enabled for spotlights:
 """
 
 # sphinx_gallery_thumbnail_number = 1
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/04-lights/light_types.py
+++ b/examples/04-lights/light_types.py
@@ -22,6 +22,13 @@ where you move the camera, the light always emanates from the view point:
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/04-lights/mesh_lighting.py
+++ b/examples/04-lights/mesh_lighting.py
@@ -15,6 +15,13 @@ mesh:
 """
 
 # sphinx_gallery_thumbnail_number = 1
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/04-lights/plotter_lighting.py
+++ b/examples/04-lights/plotter_lighting.py
@@ -24,6 +24,13 @@ lighting comprises:
 """
 
 # sphinx_gallery_thumbnail_number = 3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/04-lights/shadows.py
+++ b/examples/04-lights/shadows.py
@@ -8,6 +8,14 @@ Demonstrate the usage of lights and shadows in PyVista with :class:`~pyvista.Lig
 objects and the :meth:`~pyvista.Plotter.enable_shadows` plotting method.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/98-common/project_points_tessellate.py
+++ b/examples/98-common/project_points_tessellate.py
@@ -13,6 +13,14 @@ function that projects points to a plane.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/99-advanced/add_example.py
+++ b/examples/99-advanced/add_example.py
@@ -66,6 +66,13 @@ typically set up your imports.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/99-advanced/anatomical_groups.py
+++ b/examples/99-advanced/anatomical_groups.py
@@ -14,6 +14,13 @@ labels with the recommended RGB values used by the 3DSlicer
 `TotalSegmentator Extension <https://github.com/lassoan/SlicerTotalSegmentator>`_.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista as pv

--- a/examples/99-advanced/antarctica.py
+++ b/examples/99-advanced/antarctica.py
@@ -16,6 +16,14 @@ software.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/99-advanced/atomic_orbitals.py
+++ b/examples/99-advanced/atomic_orbitals.py
@@ -7,6 +7,14 @@ Visualize the wave functions (orbitals) of the hydrogen atom.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 # %%
 # Import
 # ~~~~~~

--- a/examples/99-advanced/customize_trame_toolbar.py
+++ b/examples/99-advanced/customize_trame_toolbar.py
@@ -9,6 +9,13 @@ This example shows how to add custom tools using the
 `jupyter_kwargs` option with :meth:`~pyvista.Plotter.show`.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import asyncio

--- a/examples/99-advanced/extending_pyvista.py
+++ b/examples/99-advanced/extending_pyvista.py
@@ -22,6 +22,15 @@ classes are nearly always used for particular types of DataSets.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+#   "vtk",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/99-advanced/fea_hertzian_contact_pressure.py
+++ b/examples/99-advanced/fea_hertzian_contact_pressure.py
@@ -20,6 +20,15 @@ critical consideration.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "matplotlib",
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import matplotlib.pyplot as plt

--- a/examples/99-advanced/magnetic_fields.py
+++ b/examples/99-advanced/magnetic_fields.py
@@ -19,6 +19,14 @@ library.
 """
 
 # sphinx_gallery_thumbnail_number = 3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/99-advanced/openfoam.py
+++ b/examples/99-advanced/openfoam.py
@@ -5,6 +5,13 @@ Plot OpenFOAM data
 ~~~~~~~~~~~~~~~~~~
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista

--- a/examples/99-advanced/openfoam_cooling.py
+++ b/examples/99-advanced/openfoam_cooling.py
@@ -15,6 +15,14 @@ post processed according to this `README.md
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/99-advanced/openfoam_tubes.py
+++ b/examples/99-advanced/openfoam_tubes.py
@@ -11,6 +11,14 @@ This example dataset was read using the :class:`pyvista.POpenFOAMReader`. See
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/99-advanced/planets.py
+++ b/examples/99-advanced/planets.py
@@ -21,6 +21,13 @@ This example is inspired by `planet3D-MATLAB
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import pyvista

--- a/examples/99-advanced/plotting_algorithms.py
+++ b/examples/99-advanced/plotting_algorithms.py
@@ -24,6 +24,14 @@ This example will walk through using a few :vtk:`vtkAlgorithm` filters directly
 and passing them to PyVista for dynamic visualization.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+#   "vtk",
+# ]
+# ///
+
 from __future__ import annotations
 
 import vtk

--- a/examples/99-advanced/pump_bracket.py
+++ b/examples/99-advanced/pump_bracket.py
@@ -21,6 +21,14 @@ vibration.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/99-advanced/ray_trace_moeller.py
+++ b/examples/99-advanced/ray_trace_moeller.py
@@ -15,6 +15,14 @@ For additional details, please reference the following:
 First, define the ray triangle intersection method.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/99-advanced/sphere_eversion.py
+++ b/examples/99-advanced/sphere_eversion.py
@@ -23,6 +23,14 @@ smooth; this was proved in the paper by Bednorz and Bednorz.
 """
 
 # sphinx_gallery_thumbnail_number = 2
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+# ]
+# ///
+
 from __future__ import annotations
 
 import numpy as np

--- a/examples/99-advanced/warp_by_vector_eigenmodes.py
+++ b/examples/99-advanced/warp_by_vector_eigenmodes.py
@@ -14,6 +14,15 @@ https://asa.scitation.org/doi/10.1121/1.401643.
 
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "numpy",
+#   "pyvista",
+#   "scipy",
+# ]
+# ///
+
 # %%
 # First, let's solve the eigenvalue problem for a vibrating cube. We use
 # a crude approximation (by choosing a low max polynomial order) to get a fast

--- a/examples_trame/advanced/contour.py
+++ b/examples_trame/advanced/contour.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+#   "trame>=2.5.2",
+# ]
+# ///
+
 from __future__ import annotations
 
 from trame.app import get_server

--- a/examples_trame/advanced/custom_ui.py
+++ b/examples_trame/advanced/custom_ui.py
@@ -4,6 +4,15 @@ This example demonstrates how to use ``plotter_ui`` to add a PyVista
 ``Plotter`` to a UI with scene controls and standard UI features.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "matplotlib",
+#   "pyvista",
+#   "trame>=2.5.2",
+# ]
+# ///
+
 from __future__ import annotations
 
 import matplotlib.pyplot as plt

--- a/examples_trame/basic/PyVistaLocalView.py
+++ b/examples_trame/basic/PyVistaLocalView.py
@@ -4,6 +4,14 @@ This is a full-fledged example on building your own user interface
 with client-side rendering.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+#   "trame>=2.5.2",
+# ]
+# ///
+
 from __future__ import annotations
 
 from trame.app import get_server

--- a/examples_trame/basic/PyVistaRemoteLocalView.py
+++ b/examples_trame/basic/PyVistaRemoteLocalView.py
@@ -4,6 +4,15 @@ This is a full-fledged example on building your own user interface
 with server-side rendering.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "matplotlib",
+#   "pyvista",
+#   "trame>=2.5.2",
+# ]
+# ///
+
 from __future__ import annotations
 
 import matplotlib.pyplot as plt

--- a/examples_trame/basic/PyVistaRemoteView.py
+++ b/examples_trame/basic/PyVistaRemoteView.py
@@ -4,6 +4,15 @@ This is a full-fledged example on building your own user interface
 with server-side rendering.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "matplotlib",
+#   "pyvista",
+#   "trame>=2.5.2",
+# ]
+# ///
+
 from __future__ import annotations
 
 import matplotlib.pyplot as plt

--- a/examples_trame/basic/actor_color.py
+++ b/examples_trame/basic/actor_color.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+#   "trame>=2.5.2",
+# ]
+# ///
+
 from __future__ import annotations
 
 from trame.app import get_server

--- a/examples_trame/basic/algorithm.py
+++ b/examples_trame/basic/algorithm.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+#   "trame>=2.5.2",
+# ]
+# ///
+
 from __future__ import annotations
 
 from trame.app import get_server

--- a/examples_trame/basic/file_viewer.py
+++ b/examples_trame/basic/file_viewer.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+#   "trame>=2.5.2",
+# ]
+# ///
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/examples_trame/basic/mesh_scalars.py
+++ b/examples_trame/basic/mesh_scalars.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+#   "trame>=2.5.2",
+# ]
+# ///
+
 from __future__ import annotations
 
 from trame.app import get_server

--- a/examples_trame/basic/multi_views.py
+++ b/examples_trame/basic/multi_views.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+#   "trame>=2.5.2",
+# ]
+# ///
+
 from __future__ import annotations
 
 from trame.app import get_server

--- a/examples_trame/basic/ui_template.py
+++ b/examples_trame/basic/ui_template.py
@@ -4,6 +4,15 @@ This example demonstrates how to use ``plotter_ui`` to add a PyVista
 ``Plotter`` to a UI with scene controls and standard UI features.
 """
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "matplotlib",
+#   "pyvista",
+#   "trame>=2.5.2",
+# ]
+# ///
+
 from __future__ import annotations
 
 import matplotlib.pyplot as plt

--- a/examples_trame/validation/many_actors.py
+++ b/examples_trame/validation/many_actors.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "pyvista",
+#   "trame>=2.5.2",
+# ]
+# ///
+
 from __future__ import annotations
 
 from trame.app import get_server


### PR DESCRIPTION
## Summary
- Added PEP 723 inline script metadata to all 181 Python files in `examples/` and `examples_trame/` directories
- Each file now includes proper dependency declarations and Python version requirements
- Enables running examples as standalone scripts with PEP 723-compatible tools like `uv`

## Changes Made
- Added metadata blocks with `requires-python = ">=3.9"` matching project requirements  
- Automatically detected and listed third-party dependencies for each script (pyvista, numpy, matplotlib, scipy, trame)
- Placed metadata after docstrings but before imports as per PEP 723 specification
- Excluded standard library imports from dependency lists

## Test plan
- [ ] Verify examples can be run with `uv run <script.py>` 
- [ ] Check that existing functionality is unchanged
- [ ] Confirm metadata format follows PEP 723 specification

🤖 Generated with [Claude Code](https://claude.ai/code)