### PR TITLE
Ensure PEP639 support in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = 'setuptools.build_meta'
-requires = ['setuptools']
+requires = ['setuptools>=77.0.3']
 
 [project]
 authors = [{ name = 'PyVista Developers', email = 'info@pyvista.org' }]
@@ -154,8 +154,9 @@ docs = [
 dev = ['pre-commit', { include-group = 'test' }, { include-group = 'typing' }]
 
 [project.urls]
-'Bug Tracker' = 'https://github.com/pyvista/pyvista/issues'
+'Bug Reports' = 'https://github.com/pyvista/pyvista/issues'
 Documentation = 'https://docs.pyvista.org/'
+Homepage = 'https://github.com/pyvista/pyvista'
 'Source Code' = 'https://github.com/pyvista/pyvista'
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
## Summary
- Update setuptools requirement to `>=77.0.3` to enable PEP639 support
- Replace 'Bug Tracker' with 'Bug Reports' as the well-known label
- Add 'Homepage' URL as recommended by PEP639 and packaging guidelines

## Changes
- Updated `[build-system]` requires to enforce `setuptools>=77.0.3`
- Modified `[project.urls]` to use standard well-known labels per Python packaging guidelines
- Ensures compliance with PEP639 specifications for project metadata

Fixes #7545

🤖 Generated with [Claude Code](https://claude.ai/code)