### PR TITLE
Rework `rescale` filter as `resize` filter

### DIFF
--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -810,6 +810,9 @@ class DataObjectFilters:
         pyvista.Transform.scale
             Concatenate a scale matrix with a transformation.
 
+        pyvista.DataSetFilters.resize
+            Resize a mesh.
+
         Examples
         --------
         >>> import pyvista as pv

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1127,6 +1127,13 @@ class DataSetFilters(DataObjectFilters):
         Use ``bounds`` to set the mesh's :attr:`~pyvista.DataSet.bounds` directly or use
         ``size`` and ``center`` to implicitly set the new bounds.
 
+        .. versionadded:: 0.46
+
+        See Also
+        --------
+        :meth:`~pyvista.DataObjectFilters.scale`, :meth:`~pyvista.DataObjectFilters.translate`
+            Scale and/or translate a mesh. Used internally by :meth:`resize`.
+
         Parameters
         ----------
         bounds : VectorLike[float], optional

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1154,30 +1154,53 @@ class DataSetFilters(DataObjectFilters):
 
         Examples
         --------
-        Rescale a sphere to fit within unit bounds [-1, 1] in all dimensions.
+        Load a mesh and show its bounds.
 
         >>> import pyvista as pv
-        >>> sphere = pv.Sphere(radius=5.0)
-        >>> rescaled = sphere.resize(bounds=[-1, 1, -1, 1, -1, 1])
-        >>> rescaled.bounds
-        (-1.0, 1.0, -1.0, 1.0, -1.0, 1.0)
+        >>> mesh = pv.Cube()
+        >>> mesh.bounds
+        BoundsTuple(x_min = -0.5,
+                    x_max =  0.5,
+                    y_min = -0.5,
+                    y_max =  0.5,
+                    z_min = -0.5,
+                    z_max =  0.5)
 
-        Scale a mesh by a factor of 2.0 uniformly.
+        Resize it to fit specific bounds.
+
+        >>> resized = mesh.resize(bounds=[-1, 2, -3, 4, -5, 6])
+        >>> resized.bounds
+        BoundsTuple(x_min = -1.0,
+                    x_max =  2.0,
+                    y_min = -3.0,
+                    y_max =  4.0,
+                    z_min = -5.0,
+                    z_max =  6.0)
+
+        Resize the mesh so its size is ``4.0``.
 
         >>> mesh = pv.Cube()
-        >>> scaled = mesh.resize(size=2.0)
-        >>> scaled.bounds[1] - scaled.bounds[0]  # x extent
-        2.0
+        >>> resized = mesh.resize(size=4.0)
+        >>> resized.bounds
+        BoundsTuple(x_min = -2.0,
+                    x_max =  2.0,
+                    y_min = -2.0,
+                    y_max =  2.0,
+                    z_min = -2.0,
+                    z_max =  2.0)
 
-        Scale with different factors along each axis.
+        Specify a different size for each axis and set the desired center.
 
-        >>> mesh = pv.Cube()
-        >>> scaled = mesh.resize(size=[2.0, 1.0, 0.5])
-
-        Scale about a specific center point.
-
-        >>> mesh = pv.Cube()
-        >>> scaled = mesh.resize(size=2.0, center=[1, 1, 1])
+        >>> resized = mesh.resize(size=[2.0, 1.0, 0.5], center=(1.0, 0.5, 0.25))
+        >>> resized.bounds
+        BoundsTuple(x_min = 0.0,
+                    x_max = 2.0,
+                    y_min = 0.0,
+                    y_max = 1.0,
+                    z_min = 0.0,
+                    z_max = 0.5)
+        >>> resized.center
+        (1.0, 0.5, 0.25)
 
         """
         current_bounds = self.bounds

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -304,11 +304,13 @@ def no_new_attr(cls):  # noqa: ANN001, ANN201 # numpydoc ignore=RT01
     return cls
 
 
-def _reciprocal(x: ArrayLike[float], tol: float = 1e-8) -> NumpyArray[float]:
+def _reciprocal(
+    x: ArrayLike[float], tol: float = 1e-8, default_if_div_by_zero: float = 0.0
+) -> NumpyArray[float]:
     """Compute the element-wise reciprocal and avoid division by zero.
 
     The reciprocal of elements with an absolute value less than a
-    specified tolerance is computed as zero.
+    specified tolerance has the value specified by ``default_if_div_by_zero``.
 
     Parameters
     ----------
@@ -316,6 +318,9 @@ def _reciprocal(x: ArrayLike[float], tol: float = 1e-8) -> NumpyArray[float]:
         Input array.
     tol : float
         Tolerance value. Values smaller than ``tol`` have a reciprocal of zero.
+    default_if_div_by_zero : float
+        Default value given to values less than ``tol``, i.e. the value given if division
+        by zero is detected.
 
     Returns
     -------
@@ -327,7 +332,7 @@ def _reciprocal(x: ArrayLike[float], tol: float = 1e-8) -> NumpyArray[float]:
     x = x if np.issubdtype(x.dtype, np.floating) else x.astype(float)
     zero = np.abs(x) < tol
     x[~zero] = np.reciprocal(x[~zero])
-    x[zero] = 0
+    x[zero] = default_if_div_by_zero
     return x
 
 

--- a/pyvista/core/utilities/transform.py
+++ b/pyvista/core/utilities/transform.py
@@ -537,6 +537,9 @@ class Transform(_vtk.DisableVtkSnakeCase, _vtk.vtkPyVistaOverride, _vtk.vtkTrans
         pyvista.DataObjectFilters.scale
             Scale a mesh.
 
+        pyvista.DataSetFilters.resize
+            Resize a mesh.
+
         Examples
         --------
         Compose a scale matrix.


### PR DESCRIPTION
### Overview

Update #7718 so that users can set the `size` of a mesh directly. (The size property is added in #7092)

Most of the AI slop and redundancy has been removed/reworked.

fix #7718