### PR TITLE
Fix incompatible version for trimesh

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ typing = [
   'mypy<1.17.0',
   'npt-promote==0.2',
   'numpy>=2.0.0',
-  'trimesh<4.6.0',
+  'trimesh<4.7.0',
   { include-group = 'pinned' },
 ]
 


### PR DESCRIPTION
### Overview

* Update `trimesh` in `typing` dependency. (See #7728 )

### Details

- Set `trimesh<4.7.0` to ensure compatibility with the `docs` dependency.

### Pending Topics

* This is not a fundamental solution. It may be resolved to use `uv` as discussed in  #7728 and #7441
* The `docs` dependency includes `scipy==1.16.0`, which is not compatible with `requires-python = '>=3.9'`. This needs to be addressed to ensure consistent dependency resolution across all groups.
