### PR TITLE
Add comment for necessary noqa PTH109

### DIFF
--- a/pyvista/_deprecate_positional_args.py
+++ b/pyvista/_deprecate_positional_args.py
@@ -174,7 +174,7 @@ def _deprecate_positional_args(
 
             # Get source file and line number
             file = Path(
-                os.path.relpath(inspect.getfile(f), start=os.getcwd()) # noqa: PTH109  # https://github.com/pyvista/pyvista/pull/7732
+                os.path.relpath(inspect.getfile(f), start=os.getcwd())  # noqa: PTH109  # https://github.com/pyvista/pyvista/pull/7732
             ).as_posix()
             lineno = inspect.getsourcelines(f)[1]
             location = f'{file}:{lineno}'
@@ -224,7 +224,7 @@ def _deprecate_positional_args(
                         # Get location where the function is called
                         frame = inspect.stack()[stack_level]
                         file = Path(
-                            os.path.relpath(frame.filename, start=os.getcwd()) # noqa: PTH109  # https://github.com/pyvista/pyvista/pull/7732
+                            os.path.relpath(frame.filename, start=os.getcwd())  # noqa: PTH109  # https://github.com/pyvista/pyvista/pull/7732
                         ).as_posix()
                         return f'{file}:{frame.lineno}'
 

--- a/pyvista/_deprecate_positional_args.py
+++ b/pyvista/_deprecate_positional_args.py
@@ -172,7 +172,7 @@ def _deprecate_positional_args(
                 signature_string = f'{signature_string[:-1]}, ...)'
 
             # Get source file and line number
-            file = Path(inspect.getfile(f)).relative_to(Path.cwd()).as_posix()
+            file = Path(os.path.relpath(inspect.getfile(f), start=os.getcwd())).as_posix()  # noqa: PTH109 # https://github.com/pyvista/pyvista/pull/7732
             lineno = inspect.getsourcelines(f)[1]
             location = f'{file}:{lineno}'
 

--- a/pyvista/_deprecate_positional_args.py
+++ b/pyvista/_deprecate_positional_args.py
@@ -4,6 +4,7 @@ from functools import wraps
 import inspect
 from inspect import Parameter
 from inspect import Signature
+import os
 from pathlib import Path
 from typing import Callable
 from typing import TypeVar

--- a/pyvista/_deprecate_positional_args.py
+++ b/pyvista/_deprecate_positional_args.py
@@ -220,7 +220,7 @@ def _deprecate_positional_args(
                     def call_site() -> str:
                         # Get location where the function is called
                         frame = inspect.stack()[stack_level]
-                        file = Path(frame.filename).relative_to(Path.cwd()).as_posix()
+                        file = Path(os.path.relpath(frame.filename, start=os.getcwd())).as_posix()  # noqa: PTH109 # https://github.com/pyvista/pyvista/pull/7732
                         return f'{file}:{frame.lineno}'
 
                     def warn_positional_args() -> None:

--- a/pyvista/_deprecate_positional_args.py
+++ b/pyvista/_deprecate_positional_args.py
@@ -174,8 +174,8 @@ def _deprecate_positional_args(
 
             # Get source file and line number
             file = Path(
-                os.path.relpath(inspect.getfile(f), start=os.getcwd())
-            ).as_posix()  # https://github.com/pyvista/pyvista/pull/7732
+                os.path.relpath(inspect.getfile(f), start=os.getcwd()) # noqa: PTH109  # https://github.com/pyvista/pyvista/pull/7732
+            ).as_posix()
             lineno = inspect.getsourcelines(f)[1]
             location = f'{file}:{lineno}'
 
@@ -224,8 +224,8 @@ def _deprecate_positional_args(
                         # Get location where the function is called
                         frame = inspect.stack()[stack_level]
                         file = Path(
-                            os.path.relpath(frame.filename, start=os.getcwd())
-                        ).as_posix()  # https://github.com/pyvista/pyvista/pull/7732
+                            os.path.relpath(frame.filename, start=os.getcwd()) # noqa: PTH109  # https://github.com/pyvista/pyvista/pull/7732
+                        ).as_posix()
                         return f'{file}:{frame.lineno}'
 
                     def warn_positional_args() -> None:

--- a/pyvista/_deprecate_positional_args.py
+++ b/pyvista/_deprecate_positional_args.py
@@ -172,7 +172,9 @@ def _deprecate_positional_args(
                 signature_string = f'{signature_string[:-1]}, ...)'
 
             # Get source file and line number
-            file = Path(os.path.relpath(inspect.getfile(f), start=os.getcwd())).as_posix()  # noqa: PTH109 # https://github.com/pyvista/pyvista/pull/7732
+            file = Path(
+                os.path.relpath(inspect.getfile(f), start=os.getcwd())
+            ).as_posix()  # https://github.com/pyvista/pyvista/pull/7732
             lineno = inspect.getsourcelines(f)[1]
             location = f'{file}:{lineno}'
 
@@ -220,7 +222,9 @@ def _deprecate_positional_args(
                     def call_site() -> str:
                         # Get location where the function is called
                         frame = inspect.stack()[stack_level]
-                        file = Path(os.path.relpath(frame.filename, start=os.getcwd())).as_posix()  # noqa: PTH109 # https://github.com/pyvista/pyvista/pull/7732
+                        file = Path(
+                            os.path.relpath(frame.filename, start=os.getcwd())
+                        ).as_posix()  # https://github.com/pyvista/pyvista/pull/7732
                         return f'{file}:{frame.lineno}'
 
                     def warn_positional_args() -> None:

--- a/pyvista/_deprecate_positional_args.py
+++ b/pyvista/_deprecate_positional_args.py
@@ -4,7 +4,6 @@ from functools import wraps
 import inspect
 from inspect import Parameter
 from inspect import Signature
-import os
 from pathlib import Path
 from typing import Callable
 from typing import TypeVar

--- a/pyvista/_deprecate_positional_args.py
+++ b/pyvista/_deprecate_positional_args.py
@@ -221,7 +221,7 @@ def _deprecate_positional_args(
                     def call_site() -> str:
                         # Get location where the function is called
                         frame = inspect.stack()[stack_level]
-                        file = Path(os.path.relpath(frame.filename, start=Path.cwd())).as_posix()
+                        file = Path(frame.filename).relative_to(Path.cwd()).as_posix()
                         return f'{file}:{frame.lineno}'
 
                     def warn_positional_args() -> None:

--- a/pyvista/_deprecate_positional_args.py
+++ b/pyvista/_deprecate_positional_args.py
@@ -173,7 +173,7 @@ def _deprecate_positional_args(
                 signature_string = f'{signature_string[:-1]}, ...)'
 
             # Get source file and line number
-            file = Path(os.path.relpath(inspect.getfile(f), start=os.getcwd())).as_posix()  # noqa: PTH109
+            file = Path(os.path.relpath(inspect.getfile(f), start=Path.cwd())).as_posix()
             lineno = inspect.getsourcelines(f)[1]
             location = f'{file}:{lineno}'
 
@@ -221,7 +221,7 @@ def _deprecate_positional_args(
                     def call_site() -> str:
                         # Get location where the function is called
                         frame = inspect.stack()[stack_level]
-                        file = Path(os.path.relpath(frame.filename, start=os.getcwd())).as_posix()  # noqa: PTH109
+                        file = Path(os.path.relpath(frame.filename, start=Path.cwd())).as_posix()
                         return f'{file}:{frame.lineno}'
 
                     def warn_positional_args() -> None:

--- a/pyvista/_deprecate_positional_args.py
+++ b/pyvista/_deprecate_positional_args.py
@@ -173,7 +173,7 @@ def _deprecate_positional_args(
                 signature_string = f'{signature_string[:-1]}, ...)'
 
             # Get source file and line number
-            file = Path(os.path.relpath(inspect.getfile(f), start=Path.cwd())).as_posix()
+            file = Path(inspect.getfile(f)).relative_to(Path.cwd()).as_posix()
             lineno = inspect.getsourcelines(f)[1]
             location = f'{file}:{lineno}'
 


### PR DESCRIPTION
## Summary
- ~Removed unnecessary `noqa PTH109` comments from `_deprecate_positional_args.py`~
- ~Fixed PTH109 violations by replacing `os.getcwd()` with `Path.cwd()`~

## Test plan
- [x] Ran ruff check to verify PTH109 violations are resolved
- [x] Confirmed pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)