### PR TITLE
Rename `xyz` arg names in `slice_index` to `ijk`

### DIFF
--- a/examples/01-filter/slice.py
+++ b/examples/01-filter/slice.py
@@ -190,7 +190,7 @@ p.show()
 # :func:`~pyvista.examples.examples.load_frog_tissues`.
 
 mask = examples.load_frog_tissues()
-sliced = mask.slice_index(z=50)
+sliced = mask.slice_index(k=50)
 colored = sliced.color_labels()
 colored.plot(cpos='xy', zoom='tight', lighting=False)
 
@@ -198,7 +198,7 @@ colored.plot(cpos='xy', zoom='tight', lighting=False)
 # Extract a 3D volume of interest instead and visualize it as a surface mesh. Here we define
 # indices to extract the frog's head.
 
-sliced = mask.slice_index(x=[300, 500], y=[110, 350], z=[0, 100])
+sliced = mask.slice_index(i=[300, 500], j=[110, 350], k=[0, 100])
 surface = sliced.contour_labels()
 colored = surface.color_labels()
 

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -222,9 +222,9 @@ class ImageDataFilters(DataSetFilters):
 
     def slice_index(  # type: ignore[misc]
         self: ImageData,
-        x: int | VectorLike[int] | slice | None = None,
-        y: int | VectorLike[int] | slice | None = None,
-        z: int | VectorLike[int] | slice | None = None,
+        i: int | VectorLike[int] | slice | None = None,
+        j: int | VectorLike[int] | slice | None = None,
+        k: int | VectorLike[int] | slice | None = None,
         *,
         index_mode: Literal['extent', 'dimensions'] = 'dimensions',
         strict_index: bool = False,
@@ -245,9 +245,9 @@ class ImageDataFilters(DataSetFilters):
 
         Parameters
         ----------
-        x, y, z : int | sequence[int], optional
-            Indices to slice along the X, Y, and Z axes, respectively. Specify an integer for
-            a single index, or two integers ``[start, stop)`` for a range of indices.
+        i, j, k : int | VectorLike[int] | slice, optional
+            Indices to slice along the I, J, and K coordinate axes, respectively. Specify an
+            integer for a single index, or two integers ``[start, stop)`` for a range of indices.
 
             .. note::
 
@@ -323,7 +323,7 @@ class ImageDataFilters(DataSetFilters):
 
         Extract a single slice along the z-axis.
 
-        >>> sliced = mesh.slice_index(z=5)
+        >>> sliced = mesh.slice_index(k=5)
         >>> sliced.dimensions
         (10, 10, 1)
 
@@ -335,19 +335,19 @@ class ImageDataFilters(DataSetFilters):
 
         Extract a volume of interest.
 
-        >>> sliced = mesh.slice_index(x=[1, 3], y=[2, 5], z=[5, 10])
+        >>> sliced = mesh.slice_index(i=[1, 3], j=[2, 5], k=[5, 10])
         >>> sliced.dimensions
         (2, 3, 5)
 
         Equivalently:
 
-        >>> sliced2 = mesh[1:3, 2:5, 5:11]
+        >>> sliced2 = mesh[1:3, 2:5, 5:10]
         >>> sliced == sliced2
         True
 
         Use ``None`` to implicitly define the start and/or stop indices.
 
-        >>> sliced = mesh.slice_index(x=[None, 3], y=[2, None], z=None)
+        >>> sliced = mesh.slice_index(i=[None, 3], j=[2, None], k=None)
         >>> sliced.dimensions
         (3, 8, 10)
 
@@ -372,14 +372,14 @@ class ImageDataFilters(DataSetFilters):
                     out[1] = default_stop
             return out
 
-        if x is None and y is None and z is None:
+        if i is None and j is None and k is None:
             msg = 'No indices were provided for slicing.'
             raise TypeError(msg)
 
         lower = (0, 0, 0) if index_mode == 'dimensions' else self.offset
         indices = tuple(
             _set_default_start_and_stop(slc, low, dim)
-            for slc, low, dim in zip((x, y, z), lower, self.dimensions)
+            for slc, low, dim in zip((i, j, k), lower, self.dimensions)
         )
         voi = self._compute_voi_from_index(
             indices, index_mode=index_mode, strict_index=strict_index

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -321,7 +321,7 @@ class ImageDataFilters(DataSetFilters):
         >>> mesh = pv.ImageData(dimensions=(10, 10, 10))
         >>> mesh['data'] = range(mesh.n_points)
 
-        Extract a single slice along the z-axis.
+        Extract a single slice along the k-axis.
 
         >>> sliced = mesh.slice_index(k=5)
         >>> sliced.dimensions

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -704,10 +704,10 @@ class ImageData(Grid, ImageDataFilters, _vtk.vtkImageData):
     ) -> NumpyArray[int]:
         """Compute VOI extents from indexing values."""
         _validation.check_contains(
-            ['extent', 'dimensions'], must_contain=index_mode, name='indexing_range'
+            ['extent', 'dimensions'], must_contain=index_mode, name='index_mode'
         )
         if not (isinstance(indices, tuple) and len(indices) == 3):  # type: ignore[redundant-expr]
-            msg = 'Exactly 3 slices must be specified, one for each xyz-axis.'  # type: ignore[unreachable]
+            msg = 'Exactly 3 slices must be specified, one for each IJK-coordinate axis.'  # type: ignore[unreachable]
             raise IndexError(msg)
 
         dims = self.dimensions

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -1971,12 +1971,12 @@ def test_imagedata_slice_index_integer(
 
     # Slice with integer
     z = 0
-    sliced = appended.slice_index(z=z) if use_slice_index else appended[:, :, z]
+    sliced = appended.slice_index(k=z) if use_slice_index else appended[:, :, z]
     assert sliced == slice0
 
     # Slice with negative integer
     z = -1
-    sliced = appended.slice_index(z=z) if use_slice_index else appended[:, :, z]
+    sliced = appended.slice_index(k=z) if use_slice_index else appended[:, :, z]
     assert sliced == slice1
 
 
@@ -1992,7 +1992,7 @@ def test_imagedata_slice_index_range(
     # Slice with index range equal to dimensions
     lower = 0
     sliced = (
-        appended.slice_index(x=[lower, x_dim], y=[lower, y_dim], z=[lower, z_dim])
+        appended.slice_index(i=[lower, x_dim], j=[lower, y_dim], k=[lower, z_dim])
         if use_slice_index
         else appended[lower:x_dim, lower:y_dim, lower:z_dim]
     )
@@ -2003,7 +2003,7 @@ def test_imagedata_slice_index_range(
     upper_x = x_dim
     upper_z = z_dim
     sliced = (
-        appended.slice_index(x=[None, upper_x], y=[lower, None], z=[lower, upper_z])
+        appended.slice_index(i=[None, upper_x], j=[lower, None], k=[lower, upper_z])
         if use_slice_index
         else appended[:upper_x, lower:, lower:upper_z]
     )
@@ -2024,7 +2024,7 @@ def test_imagedata_slice_index_range_upper_bounds(
     extra = 2
     sliced = (
         appended.slice_index(
-            x=[lower, x_dim + extra], y=[lower, y_dim + extra], z=[lower, z_dim + extra]
+            i=[lower, x_dim + extra], j=[lower, y_dim + extra], k=[lower, z_dim + extra]
         )
         if use_slice_index
         else appended[lower : x_dim + extra, lower : y_dim + extra, lower : z_dim + extra]
@@ -2045,7 +2045,7 @@ def test_imagedata_slice_index_negative_range(
     lower = 0
     upper = -1
     sliced_stop = (
-        appended.slice_index(x=[lower, upper], y=[lower, upper], z=[lower, upper])
+        appended.slice_index(i=[lower, upper], j=[lower, upper], k=[lower, upper])
         if use_slice_index
         else appended[lower:upper, lower:upper, lower:upper]
     )
@@ -2055,7 +2055,7 @@ def test_imagedata_slice_index_negative_range(
     lower = -3
     upper = -1
     sliced_start = (
-        appended.slice_index(x=[lower, upper], y=[lower, upper], z=[lower, upper])
+        appended.slice_index(i=[lower, upper], j=[lower, upper], k=[lower, upper])
         if use_slice_index
         else appended[lower:upper, lower:upper, lower:upper]
     )
@@ -2093,7 +2093,7 @@ def test_slice_index_indexing_range():
 
 
 def test_imagedata_getitem_raises(uniform):
-    match = 'Exactly 3 slices must be specified, one for each xyz-axis.'
+    match = 'Exactly 3 slices must be specified, one for each IJK-coordinate axis.'
     with pytest.raises(IndexError, match=re.escape(match)):
         uniform[0]
 


### PR DESCRIPTION
### Overview

Small follow-up to #7652.
The slicing is done along IJK axes, not XYZ axes, so the arg names should match the coordinate system.

Also fix typo with docstring 
```diff
- mesh[1:3, 2:5, 5:11]
+ mesh[1:3, 2:5, 5:10]
```

And update variable name for validation error messages
```diff
- 'indexing_range'
+ 'index_mode'
```