### PR TITLE
BUG: Fix reference cycle regression

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1737,6 +1737,11 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
         """
         return self.n_open_edges == 0
 
+    def __del__(self) -> None:
+        """Delete the object."""
+        # avoid a reference cycle that can't be resolved with vtkPolyData
+        self._glyph_geom = None
+
 
 @abstract_class
 class PointGrid(_PointSet):


### PR DESCRIPTION
@user27182 this PR fixes a regression from https://github.com/pyvista/pyvista/pull/7716/files#diff-74eba4a52c2594069f09d6ca675e50579aa1cdf7bb4d2955f44a46482ebb395aL1748 . In MNE-Python we run a ton of examples building our docs, garbage collect after each one, and [ensure no `vtk` objects linger](https://app.circleci.com/pipelines/github/mne-tools/mne-python/28164/workflows/d33ebd65-7d1d-4d7b-963a-144c2be17bec/jobs/74694). After #7716 some `vtkPolyData` stuck around:
```
      File "/home/larsoner/python/mne-python/doc/sphinxext/mne_doc_utils.py", line 115, in _assert_no_instances
        raise ExtensionError(str(exc)) from None
    sphinx.errors.ExtensionError: 
    3 vtkPolyData @ mne/conf.py:Resetter.__call__:after:70_fnirs_processing.py:
    list[0]: len=1, 4 referrers: cell / dict['_glyph_geom'] / list[1] / list[743402]
    list[0]: len=1, 4 referrers: cell / dict['_glyph_geom'] / list[1] / list[743406]
    list[0]: len=1, 4 referrers: cell / dict['_glyph_geom'] / list[1] / list[743409]
```
It's fixed by restoring the setting-to-None in `__del__` that was (accidentally perhaps?) removed.