### PR TITLE
Mark `test_box_axes` as high variance

### DIFF
--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1306,7 +1306,9 @@ def test_axes():
     plotter.show()
 
 
-def test_box_axes():
+def test_box_axes(verify_image_cache):
+    verify_image_cache.high_variance_test = True
+
     plotter = pv.Plotter()
 
     def _test_add_axes_box():


### PR DESCRIPTION
### Overview

This test is flaky and regularly fails with regression error of 550, e.g. 
https://github.com/pyvista/pyvista/actions/runs/16529582440/job/46751412367?pr=7745#step:15:2052