### PR TITLE
Add concrete `is_empty` and `get_data_range` methods for `PartitionedDataSet`

### DIFF
--- a/pyvista/core/partitioned.py
+++ b/pyvista/core/partitioned.py
@@ -83,7 +83,7 @@ class PartitionedDataSet(DataObject, MutableSequence, _vtk.vtkPartitionedDataSet
     def __getitem__(self, index):
         """Get a partition by its index."""
         if isinstance(index, slice):
-            return PartitionedDataSet([self[i] for i in range(self.n_partitions)[index]])  # type: ignore[abstract]
+            return PartitionedDataSet([self[i] for i in range(self.n_partitions)[index]])
         else:
             if index < -self.n_partitions or index >= self.n_partitions:
                 msg = f'index ({index}) out of range for this dataset.'

--- a/pyvista/core/partitioned.py
+++ b/pyvista/core/partitioned.py
@@ -17,7 +17,10 @@ from .utilities.helpers import wrap
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from typing_extensions import Self
+
     from .dataset import DataSet
+    from .utilities.arrays import FieldAssociation
 
 
 class PartitionedDataSet(DataObject, MutableSequence, _vtk.vtkPartitionedDataSet):  # type: ignore[type-arg]
@@ -244,6 +247,26 @@ class PartitionedDataSet(DataObject, MutableSequence, _vtk.vtkPartitionedDataSet
         self.SetNumberOfPartitions(n)
         self.Modified()
 
+    @property
+    def is_empty(self) -> bool:  # numpydoc ignore=RT01
+        """Return ``True`` if there are no blocks.
+
+        .. versionadded:: 0.46
+
+        Examples
+        --------
+        >>> import pyvista as pv
+        >>> mesh = pv.MultiBlock()
+        >>> mesh.is_empty
+        True
+
+        >>> mesh.append(pv.Sphere())
+        >>> mesh.is_empty
+        False
+
+        """
+        return self.n_partitions == 0
+
     def append(self, dataset) -> None:
         """Add a data set to the next partition index.
 
@@ -256,3 +279,9 @@ class PartitionedDataSet(DataObject, MutableSequence, _vtk.vtkPartitionedDataSet
         index = self.n_partitions
         self.n_partitions += 1
         self[index] = dataset
+
+    def get_data_range(  # numpydoc ignore=RT01
+        self: Self, name: str | None, preference: FieldAssociation | str
+    ) -> tuple[float, float]:  # pragma: no cover
+        """Get the non-NaN min and max of a named array."""
+        return DataObject.get_data_range(self, name=name, preference=preference)

--- a/pyvista/core/partitioned.py
+++ b/pyvista/core/partitioned.py
@@ -249,7 +249,7 @@ class PartitionedDataSet(DataObject, MutableSequence, _vtk.vtkPartitionedDataSet
 
     @property
     def is_empty(self) -> bool:  # numpydoc ignore=RT01
-        """Return ``True`` if there are no blocks.
+        """Return ``True`` if there are no partitions.
 
         .. versionadded:: 0.46
 

--- a/pyvista/core/partitioned.py
+++ b/pyvista/core/partitioned.py
@@ -256,7 +256,7 @@ class PartitionedDataSet(DataObject, MutableSequence, _vtk.vtkPartitionedDataSet
         Examples
         --------
         >>> import pyvista as pv
-        >>> mesh = pv.MultiBlock()
+        >>> mesh = pv.PartitionedDataSet()
         >>> mesh.is_empty
         True
 

--- a/tests/core/test_partitioned.py
+++ b/tests/core/test_partitioned.py
@@ -112,3 +112,8 @@ def test_partitioned_dataset_repr(ant, sphere, uniform, airplane):
     assert partitions._repr_html_() is not None
     assert repr(partitions) is not None
     assert str(partitions) is not None
+
+
+def test_partitioned_is_empty(sphere):
+    assert PartitionedDataSet().is_empty
+    assert not PartitionedDataSet([sphere]).is_empty


### PR DESCRIPTION
### Overview

When type-checking with `PartitionedDataSet`, `mypy` complains about abstract methods `is_empty` and `get_data_range`.

This PR only adds proper implementation for `is_empty`, `get_data_range` just calls super.