### PR TITLE
Always test documentation images

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -108,6 +108,7 @@ jobs:
         run: if [ -e doc/errors.txt ]; then cat doc/errors.txt; fi
 
       - name: Test Documentation
+        if: always()
         run: pytest tests/doc/tst_doc_build.py
 
       - name: Upload Images for Failed Tests


### PR DESCRIPTION
Always run the tests as this will enable upload of image build artifacts. This is particularly useful when there build fails due to bad references, in which case the build was otherwise successful and all the images are available for testing anyway 