### PR TITLE
Enable linting for bare except (E722 and BLE001)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -330,6 +330,7 @@ extend-select = [
   'ASYNC',
   'ASYNC1',
   'B',
+  'BLE',
   'C4',
   'COM',
   'D',
@@ -389,7 +390,6 @@ ignore = [
   'D402', # First line should not be the function's signature
   'D416', # Section name ends in colon
   'E402', # module level import not at top of file
-  'E722',
   'E731', # do not assign a lambda expression, use a def
   'E741', # ambiguous variable name
   'F403', # 'from module import *' used; unable to detect undefined names

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -2147,7 +2147,7 @@ class MultiBlock(
         for attr in self._get_attrs():
             try:
                 fmt += row.format(attr[0], attr[2].format(*attr[1]))
-            except:
+            except TypeError:
                 fmt += row.format(attr[0], attr[2].format(attr[1]))
 
         fmt += '</table>\n'
@@ -2177,7 +2177,7 @@ class MultiBlock(
         for attr in self._get_attrs():
             try:
                 fmt += row.format(attr[0], attr[2].format(*attr[1]))
-            except:
+            except TypeError:
                 fmt += row.format(attr[0], attr[2].format(attr[1]))
         return fmt.strip()
 

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -357,7 +357,7 @@ class DataObject(_NoNewAttrMixin, _vtk.DisableVtkSnakeCase, _vtk.vtkPyVistaOverr
             for attr in self._get_attrs():
                 try:
                     fmt += row.format(attr[0], attr[2].format(*attr[1]))
-                except:
+                except TypeError:
                     fmt += row.format(attr[0], attr[2].format(attr[1]))
             if hasattr(self, 'n_arrays'):
                 fmt += row.format('N Arrays', self.n_arrays)
@@ -382,7 +382,7 @@ class DataObject(_NoNewAttrMixin, _vtk.DisableVtkSnakeCase, _vtk.vtkPyVistaOverr
         for attr in self._get_attrs():
             try:
                 fmt += row.format(attr[0] + ':', attr[2].format(*attr[1]))
-            except:
+            except TypeError:
                 fmt += row.format(attr[0] + ':', attr[2].format(attr[1]))
         if hasattr(self, 'n_arrays'):
             fmt += row.format('N Arrays:', self.n_arrays)

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2305,7 +2305,7 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
         if inplace:
             try:
                 self.copy_from(output, deep=False)
-            except:
+            except TypeError:
                 pass
             else:
                 return self

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2926,7 +2926,7 @@ class PolyDataFilters(DataSetFilters):
             for key in self.cell_data:  # type: ignore[attr-defined]
                 try:
                     newmesh.cell_data[key] = self.cell_data[key][fmask]  # type: ignore[attr-defined]
-                except (ValueError, TypeError, KeyError):
+                except (ValueError, TypeError, KeyError):  # pragma: no cover
                     warnings.warn(f'Unable to pass cell key {key} onto reduced mesh')
 
         # Return vtk surface and reverse indexing array

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2920,7 +2920,7 @@ class PolyDataFilters(DataSetFilters):
             for key in self.cell_data:  # type: ignore[attr-defined]
                 try:
                     newmesh.cell_data[key] = self.cell_data[key][fmask]  # type: ignore[attr-defined]
-                except:
+                except (ValueError, TypeError, KeyError):
                     warnings.warn(f'Unable to pass cell key {key} onto reduced mesh')
 
         # Return vtk surface and reverse indexing array

--- a/pyvista/core/partitioned.py
+++ b/pyvista/core/partitioned.py
@@ -152,7 +152,7 @@ class PartitionedDataSet(DataObject, MutableSequence, _vtk.vtkPartitionedDataSet
         for attr in self._get_attrs():
             try:
                 fmt += row.format(attr[0], attr[2].format(*attr[1]))
-            except:
+            except TypeError:
                 fmt += row.format(attr[0], attr[2].format(attr[1]))
         fmt += '</table>\n'
         fmt += '\n'
@@ -177,7 +177,7 @@ class PartitionedDataSet(DataObject, MutableSequence, _vtk.vtkPartitionedDataSet
         for attr in self._get_attrs():
             try:
                 fmt += row.format(attr[0], attr[2].format(*attr[1]))
-            except:
+            except TypeError:
                 fmt += row.format(attr[0], attr[2].format(attr[1]))
         return fmt.strip()
 

--- a/pyvista/core/utilities/cell_type_helper.py
+++ b/pyvista/core/utilities/cell_type_helper.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 try:
     from vtkmodules import vtkCommonDataModel
-except:  # pragma: no cover
+except Exception:  # noqa: BLE001  # pragma: no cover
     import vtk as vtkCommonDataModel  # type: ignore[no-redef]  # noqa: N812
 
 vtkcell_types = [
@@ -66,5 +66,5 @@ for cell_num_str, cell_str in vtkcell_types:
             cell_num = getattr(vtkCommonDataModel, cell_num_str)
             n_points = getattr(vtkCommonDataModel, cell_str)().GetNumberOfPoints()
             enum_cell_type_nr_points_map[cell_num] = n_points
-        except:  # pragma: no cover
+        except Exception:  # noqa: BLE001  # pragma: no cover
             pass

--- a/pyvista/core/utilities/docs.py
+++ b/pyvista/core/utilities/docs.py
@@ -57,7 +57,7 @@ def linkcode_resolve(domain: str, info: dict[str, str], edit: bool = False) -> s
     for part in fullname.split('.'):
         try:
             obj = getattr(obj, part)
-        except Exception:
+        except Exception:  # noqa: BLE001
             return None
 
     # deal with our decorators properly
@@ -69,13 +69,13 @@ def linkcode_resolve(domain: str, info: dict[str, str], edit: bool = False) -> s
         obj = obj.__wrapped__
     try:
         fn = inspect.getsourcefile(obj)
-    except Exception:  # pragma: no cover
+    except Exception:  # noqa: BLE001  # pragma: no cover
         fn = None
 
     if not fn:  # pragma: no cover
         try:
             fn = inspect.getsourcefile(sys.modules[obj.__module__])
-        except Exception:
+        except Exception:  # noqa: BLE001
             return None
         return None
 
@@ -84,7 +84,7 @@ def linkcode_resolve(domain: str, info: dict[str, str], edit: bool = False) -> s
 
     try:
         source, lineno = inspect.getsourcelines(obj)
-    except Exception:  # pragma: no cover
+    except Exception:  # noqa: BLE001 # pragma: no cover
         lineno = None
 
     linespec = f'#L{lineno}-L{lineno + len(source) - 1}' if lineno and not edit else ''

--- a/pyvista/core/utilities/fileio.py
+++ b/pyvista/core/utilities/fileio.py
@@ -1088,7 +1088,7 @@ def to_meshio(mesh: DataSet) -> meshio.Mesh:
     try:  # for meshio<5.0 compatibility
         from meshio.vtk._vtk import vtk_to_meshio_type  # noqa: PLC0415
 
-    except:  # pragma: no cover
+    except (ImportError, AttributeError):  # pragma: no cover
         from meshio._vtk_common import vtk_to_meshio_type  # noqa: PLC0415
 
     # Cast to unstructured grid

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -214,7 +214,7 @@ def try_callback(func, *args) -> None:  # noqa: ANN001
     """
     try:
         func(*args)
-    except Exception:
+    except Exception:  # noqa: BLE001
         etype, exc, tb = sys.exc_info()
         stack = traceback.extract_tb(tb)[1:]
         formatted_exception = 'Encountered issue in callback (most recent call last):\n' + ''.join(

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -214,7 +214,7 @@ def try_callback(func, *args) -> None:  # noqa: ANN001
     """
     try:
         func(*args)
-    except Exception:  # noqa: BLE001
+    except Exception:  # noqa: BLE001  # pragma: no cover
         etype, exc, tb = sys.exc_info()
         stack = traceback.extract_tb(tb)[1:]
         formatted_exception = 'Encountered issue in callback (most recent call last):\n' + ''.join(

--- a/pyvista/core/utilities/observers.py
+++ b/pyvista/core/utilities/observers.py
@@ -131,7 +131,7 @@ class Observer(_NoNewAttrMixin):
         regex = re.compile(r'([A-Z]+):\sIn\s(.+),\sline\s.+\n\w+\s\((.+)\):\s(.+)')
         try:
             kind, path, address, alert = regex.findall(message)[0]
-        except:
+        except Exception:  # noqa: BLE001
             return '', '', '', message
         else:
             return kind, path, address, alert
@@ -158,7 +158,7 @@ class Observer(_NoNewAttrMixin):
                 self.event_history.append(VtkEvent(kind, path, address, alert))
             if self.__log:
                 self.log_message(kind, alert)
-        except Exception:  # pragma: no cover
+        except Exception:  # noqa: BLE001  # pragma: no cover
             try:
                 if len(message) > 120:
                     message = f'{message[:100]!r} ... ({len(message)} characters)'
@@ -169,7 +169,7 @@ class Observer(_NoNewAttrMixin):
                     file=sys.__stdout__,
                 )
                 traceback.print_tb(sys.last_traceback, file=sys.__stderr__)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
 
     def has_event_occurred(self):  # numpydoc ignore=RT01

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -216,7 +216,7 @@ class PlotDirective(Directive):
                 self.state,
                 self.lineno,
             )
-        except Exception as e:  # pragma: no cover
+        except Exception as e:  # noqa: BLE001  # pragma: no cover
             raise self.error(str(e))
 
 

--- a/pyvista/ext/viewer_directive.py
+++ b/pyvista/ext/viewer_directive.py
@@ -76,7 +76,7 @@ class OfflineViewerDirective(Directive):
         if source_file != dest_file:
             try:
                 shutil.copy(source_file, dest_file)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 logger.warning(f'Failed to copy file from {source_file} to {dest_file}: {e}')
 
         # Compute the relative path of the current source to the source directory,

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -1166,6 +1166,6 @@ class LookupTable(_NoNewAttrMixin, _vtk.DisableVtkSnakeCase, _vtk.vtkLookupTable
         else:
             try:
                 return np.array([self.map_value(item) for item in value])
-            except:
+            except (TypeError, ValueError):
                 msg = 'LookupTable __call__ expects a single value or an iterable.'
                 raise TypeError(msg)

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -1051,7 +1051,7 @@ class PickingMethods(PickingInterface):  # numpydoc ignore=PR01
                             reset_camera=_kwargs.pop('reset_camera', False),
                             **_kwargs,
                         )
-                except Exception as e:  # pragma: no cover
+                except Exception as e:  # noqa: BLE001  # pragma: no cover
                     warnings.warn('Unable to show mesh when picking:\n\n%s', str(e))  # type: ignore[call-overload]
 
                 # Reset to the active renderer.

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -878,7 +878,7 @@ class BasePlotter(_BoundsSizeMixin, PickingHelper, WidgetHelper):
                                 try:
                                     dataset = dataset.extract_surface()
                                     mapper.SetInputData(dataset)
-                                except:  # pragma: no cover
+                                except (AttributeError, ValueError, TypeError):  # pragma: no cover
                                     warnings.warn(
                                         'During gLTF export, failed to convert some '
                                         'datasets to PolyData. Exported scene will not have '
@@ -893,7 +893,7 @@ class BasePlotter(_BoundsSizeMixin, PickingHelper, WidgetHelper):
                                 array.SetName('NORMAL')
                                 renamed_arrays.append(array)
 
-                        except:  # pragma: no cover
+                        except Exception:  # noqa: BLE001  # pragma: no cover
                             pass
 
         exporter = vtkGLTFExporter()

--- a/pyvista/report.py
+++ b/pyvista/report.py
@@ -200,12 +200,12 @@ class Report(scooby.Report):
             'nest_asyncio',
         ]
 
-        # Information about the GPU - bare except in case there is a rendering
+        # Information about the GPU - catch all Exception in case there is a rendering
         # bug that the user is trying to report.
         if gpu:
             try:
                 extra_meta = GPUInfo().get_info()
-            except:
+            except Exception:  # noqa: BLE001
                 extra_meta = [
                     ('GPU Details', 'error'),
                 ]

--- a/tests/check_doctest_names.py
+++ b/tests/check_doctest_names.py
@@ -162,7 +162,7 @@ def check_doctests(modules=None, respect_skips=True, verbose=True):
                 continue
             try:
                 exec(example.source, globs)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 if verbose:
                     print(f'FAILED: {dt.name} -- {exc!r}')
                 erroring_code = ''.join([example.source for example in dt.examples[:iline]])

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -167,13 +167,10 @@ def test_point_cell_field_data_empty_array(uniform, attribute, empty_shape, mesh
 
 
 def test_point_cell_data_single_scalar_no_exception_raised():
-    try:
-        m = pv.PolyData([0, 0, 0.0])
-        m.point_data['foo'] = 1
-        m.cell_data['bar'] = 1
-        m['baz'] = 1
-    except Exception as e:
-        pytest.fail(f'Unexpected exception raised: {e}')
+    m = pv.PolyData([0, 0, 0.0])
+    m.point_data['foo'] = 1
+    m.cell_data['bar'] = 1
+    m['baz'] = 1
 
 
 def test_field_data(hexbeam):

--- a/tests/plotting/conftest.py
+++ b/tests/plotting/conftest.py
@@ -34,7 +34,7 @@ def pytest_runtest_setup(item):
 def _is_vtk(obj):
     try:
         return obj.__class__.__name__.startswith('vtk')
-    except AttributeError:  # old Python sometimes no __class__.__name__
+    except (ReferenceError, AttributeError):
         return False
 
 

--- a/tests/plotting/conftest.py
+++ b/tests/plotting/conftest.py
@@ -34,7 +34,7 @@ def pytest_runtest_setup(item):
 def _is_vtk(obj):
     try:
         return obj.__class__.__name__.startswith('vtk')
-    except Exception:  # old Python sometimes no __class__.__name__
+    except AttributeError:  # old Python sometimes no __class__.__name__
         return False
 
 

--- a/tests/plotting/jupyter/test_trame.py
+++ b/tests/plotting/jupyter/test_trame.py
@@ -32,7 +32,7 @@ try:
     from pyvista.trame.views import PyVistaRemoteLocalView
     from pyvista.trame.views import PyVistaRemoteView
     from pyvista.trame.views import _BasePyVistaView
-except:
+except ImportError:
     has_trame = False
 
 pytestmark = [

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -58,19 +58,15 @@ try:
 except ModuleNotFoundError:
     HAS_IMAGEIO = False
 
-ffmpeg_failed = False
 try:
-    try:
-        import imageio_ffmpeg
+    import imageio_ffmpeg
 
-        imageio_ffmpeg.get_ffmpeg_exe()
-    except ImportError:
-        if HAS_IMAGEIO:
-            imageio.plugins.ffmpeg.download()
-        else:
-            raise
-except:
-    ffmpeg_failed = True
+    imageio_ffmpeg.get_ffmpeg_exe()
+except ImportError:
+    if HAS_IMAGEIO:
+        imageio.plugins.ffmpeg.download()
+    else:
+        raise
 
 
 THIS_PATH = pathlib.Path(__file__).parent.absolute()
@@ -982,7 +978,6 @@ def test_open_gif_invalid():
         plotter.open_gif('file.abs')
 
 
-@pytest.mark.skipif(ffmpeg_failed, reason='Requires imageio-ffmpeg')
 @pytest.mark.skipif(not HAS_IMAGEIO, reason='Requires imageio')
 def test_make_movie(sphere, tmpdir, verify_image_cache):
     verify_image_cache.skip = True
@@ -3121,8 +3116,8 @@ def test_plot_complex_value(plane, verify_image_cache):
     # check for removal when support for vtk 9.0.3 is removed
     try:
         ComplexWarning = np.exceptions.ComplexWarning
-    except:
-        ComplexWarning = np.ComplexWarning  # noqa: NPY201
+    except AttributeError:
+        ComplexWarning = np.ComplexWarning
 
     with pytest.warns(ComplexWarning, match='Casting complex'):
         plane.plot(scalars=data)
@@ -3444,8 +3439,8 @@ def test_plot_composite_poly_complex(multiblock_poly):
     # check for removal when support for vtk 9.0.3 is removed
     try:
         ComplexWarning = np.exceptions.ComplexWarning
-    except:
-        ComplexWarning = np.ComplexWarning  # noqa: NPY201
+    except AttributeError:
+        ComplexWarning = np.ComplexWarning
 
     pl = pv.Plotter()
     with pytest.warns(ComplexWarning, match='Casting complex'):
@@ -4724,9 +4719,9 @@ def _has_param(call: Callable, param: str) -> bool:
         kwargs[param] = None
         try:
             call(**kwargs)
-        except BaseException as ex:
+        except TypeError as ex:
             # Param is not valid only if a kwarg TypeError is raised
-            return not ('TypeError' in repr(ex) and 'unexpected keyword argument' in repr(ex))
+            return 'unexpected keyword argument' not in repr(ex)
         else:
             return True
 


### PR DESCRIPTION
### Overview

Using bare except is bad because it also catches keyboard interrupts and system exits. Using `except Exception` is better than a bare except, though it's best not to use this either and to only include minimal exceptions for the expected errors.