### PR TITLE
Add `pass_point(cell)_ids` to `extract_points(cells)`

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -4152,10 +4152,12 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
             plt.show()
 
     @_deprecate_positional_args(allowed=['ind'])
-    def extract_cells(  # type: ignore[misc]
+    def extract_cells(  # type: ignore[misc]  # noqa: PLR0917
         self: _DataSetType,
         ind: int | VectorLike[int],
         invert: bool = False,  # noqa: FBT001, FBT002
+        pass_cell_ids: bool = True,  # noqa: FBT001, FBT002
+        pass_point_ids: bool = True,  # noqa: FBT001, FBT002
         progress_bar: bool = False,  # noqa: FBT001, FBT002
     ):
         """Return a subset of the grid.
@@ -4167,6 +4169,18 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
 
         invert : bool, default: False
             Invert the selection.
+
+        pass_point_ids : bool, default: True
+            Add a point array ``'vtkOriginalPointIds'`` that identifies the original
+            points the extracted points correspond to.
+
+            .. versionadded:: 0.46
+
+        pass_cell_ids : bool, default: True
+            Add a cell array ``'vtkOriginalCellIds'`` that identifies the original cells
+            the extracted cells correspond to.
+
+            .. versionadded:: 0.46
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
@@ -4224,6 +4238,11 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
             ind = subgrid.point_data['vtkOriginalPointIds']
             subgrid.points = self.points[ind]
 
+        # Process output arrays
+        if (name := 'vtkOriginalPointIds') in (data := subgrid.point_data) and not pass_point_ids:
+            del data[name]
+        if (name := 'vtkOriginalCellIds') in (data := subgrid.cell_data) and not pass_cell_ids:
+            del data[name]
         return subgrid
 
     @_deprecate_positional_args(allowed=['ind'])
@@ -4232,6 +4251,8 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
         ind: int | VectorLike[int] | VectorLike[bool],
         adjacent_cells: bool = True,  # noqa: FBT001, FBT002
         include_cells: bool = True,  # noqa: FBT001, FBT002
+        pass_cell_ids: bool = True,  # noqa: FBT001, FBT002
+        pass_point_ids: bool = True,  # noqa: FBT001, FBT002
         progress_bar: bool = False,  # noqa: FBT001, FBT002
     ):
         """Return a subset of the grid (with cells) that contains any of the given point indices.
@@ -4249,6 +4270,18 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
 
         include_cells : bool, default: True
             Specifies if the cells shall be returned or not.
+
+        pass_point_ids : bool, default: True
+            Add a point array ``'vtkOriginalPointIds'`` that identifies the original
+            points the extracted points correspond to.
+
+            .. versionadded:: 0.46
+
+        pass_cell_ids : bool, default: True
+            Add a cell array ``'vtkOriginalCellIds'`` that identifies the original cells
+            the extracted cells correspond to.
+
+            .. versionadded:: 0.46
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
@@ -4301,7 +4334,14 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
         extract_sel.SetInputData(0, self)
         extract_sel.SetInputData(1, selection)
         _update_alg(extract_sel, progress_bar=progress_bar, message='Extracting Points')
-        return _get_output(extract_sel)
+        output = _get_output(extract_sel)
+
+        # Process output arrays
+        if (name := 'vtkOriginalPointIds') in (data := output.point_data) and not pass_point_ids:
+            del data[name]
+        if (name := 'vtkOriginalCellIds') in (data := output.cell_data) and not pass_cell_ids:
+            del data[name]
+        return output
 
     def split_values(  # type: ignore[misc]
         self: _DataSetType,
@@ -5081,19 +5121,17 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
                 id_mask,
                 adjacent_cells=adjacent_cells,
                 include_cells=include_cells,
+                pass_point_ids=pass_point_ids,
+                pass_cell_ids=pass_cell_ids,
                 progress_bar=progress_bar,
             )
         else:
             output = self.extract_cells(
                 id_mask,
+                pass_point_ids=pass_point_ids,
+                pass_cell_ids=pass_cell_ids,
                 progress_bar=progress_bar,
             )
-
-        # Process output arrays
-        if (POINT_IDS := 'vtkOriginalPointIds') in output.point_data and not pass_point_ids:
-            output.point_data.remove(POINT_IDS)
-        if (CELL_IDS := 'vtkOriginalCellIds') in output.cell_data and not pass_cell_ids:
-            output.cell_data.remove(CELL_IDS)
 
         return output
 

--- a/pyvista/core/filters/unstructured_grid.py
+++ b/pyvista/core/filters/unstructured_grid.py
@@ -238,11 +238,7 @@ class UnstructuredGridFilters(DataSetFilters):
         cell_array.InsertNextCell(1)
 
         # Extract all the cells, except for the dummy cell
-        out = out.extract_cells(np.arange(self.n_cells))
-        if (name := 'vtkOriginalPointIds') in (data := out.point_data):
-            del data[name]
-        if (name := 'vtkOriginalCellIds') in (data := out.cell_data):
-            del data[name]
+        out = out.extract_cells(np.arange(self.n_cells), pass_point_ids=False, pass_cell_ids=False)
 
         if inplace:
             self.copy_from(out)


### PR DESCRIPTION
### Overview

The `vtkOriginalPointIds` and  `vtkOriginalCellIds` arrays are used/removed by downstream filters such as `extract_values` and `remove_unused_points`. This PR adds new keywords to `extract_points` and `extract_cells` so that these can be more easily removed at the source.