### PR TITLE
Disable automatic rebasing of dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
     labels:
       - "maintenance"
       - "dependencies"
+    rebase-strategy: "disabled"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -35,6 +36,7 @@ updates:
     labels:
       - "maintenance"
       - "dependencies"
+    rebase-strategy: "disabled"
 
   - package-ecosystem: "devcontainers"
     directory: "/"
@@ -44,3 +46,4 @@ updates:
     labels:
       - "maintenance"
       - "dependencies"
+    rebase-strategy: "disabled"


### PR DESCRIPTION
Related to https://github.com/pyvista/pyvista/pull/7670

Dependabot aggressively rebases all open PRs by default, and will needlessly push commits to all PRs so that they're all up to date. This is a huge resource hog and is not necessary since we use pivista-bot to manage a merge queue and only merge PRs one at a time.