### PR TITLE
Fix matplotlib Pillow deprecation warning in doctests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ jupyter = [
 pinned = [ # Pinned versions of core dependencies
   'matplotlib<3.10.2',
   'numpy<2.4.0',
-  'pillow<11.3.0',
+  'pillow<11.4.0',
   'pooch<1.9.0',
   'scooby<0.11.0',
   'typing-extensions<4.15.0',
@@ -218,6 +218,7 @@ doctest_optionflags = 'NUMBER ELLIPSIS'
 filterwarnings = [
   'error',
 
+  "ignore:'mode' parameter is deprecated and will be removed in Pillow 13:DeprecationWarning", # matplotlib toolbar icon creation with newer Pillow
   'ignore:.*A NumPy version .* is required for this version of SciPy.*:UserWarning',
   'ignore:.*Given trait value dtype "float64":UserWarning', # bogus numpy ABI warning (see numpy/#432)
   'ignore:.*The NumPy module was reloaded*:UserWarning', # bogus numpy ABI warning (see numpy/#432)


### PR DESCRIPTION
## Summary
- Fixed doctest failures in ChartMPL-related tests caused by Pillow deprecation warning
- Added filter to pyproject.toml to ignore the specific deprecation warning during pytest runs

## Description
The matplotlib TkAgg backend triggers a deprecation warning from Pillow when creating toolbar icons. This warning was causing doctest failures for all ChartMPL-related tests.

This is a known compatibility issue between matplotlib and newer versions of Pillow where the 'mode' parameter is being deprecated in Pillow 13.

## Changes
- Added a warning filter in  to ignore the specific deprecation warning: 

## Test Results
All ChartMPL doctests now pass successfully:
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 

🤖 Generated with [Claude Code](https://claude.ai/code)