### PR TITLE
Fix camera position typing to allow nested sequence

### DIFF
--- a/pyvista/demos/demos.py
+++ b/pyvista/demos/demos.py
@@ -270,7 +270,7 @@ def plot_wave(fps=30, frequency=1, wavetime=3, notebook=None):  # noqa: PLR0917
     # Start a plotter object and set the scalars to the Z height
     plotter = pyvista.Plotter(notebook=notebook)
     plotter.add_mesh(mesh, scalars='Height', show_scalar_bar=False, smooth_shading=True)
-    plotter.camera_position = cpos  # type: ignore[assignment]
+    plotter.camera_position = cpos
     plotter.show(
         title='Wave Example',
         window_size=[800, 600],
@@ -432,7 +432,7 @@ def plot_beam(notebook=None):
         rng=[-d.max(), d.max()],
         cmap=cmap,  # type: ignore[arg-type]
     )
-    plotter.camera_position = cpos  # type: ignore[assignment]
+    plotter.camera_position = cpos
     plotter.add_text('Static Beam Example')
     plotter.show()
 

--- a/pyvista/plotting/_typing.py
+++ b/pyvista/plotting/_typing.py
@@ -76,7 +76,10 @@ OpacityOptions = Literal[
 CullingOptions = Literal['front', 'back', 'frontface', 'backface', 'f', 'b']
 StyleOptions = Literal['surface', 'wireframe', 'points', 'points_gaussian']
 LightingOptions = Literal['light kit', 'three lights', 'none']
-CameraOptions = Literal['xy', 'xz', 'yz', 'yx', 'zx', 'zy', 'iso']
+CameraOptions = Union[
+    Literal['xy', 'xz', 'yz', 'yx', 'zx', 'zy', 'iso'],
+    Sequence[Union[list[float], tuple[float, float, float]]],
+]
 
 
 class BackfaceArgs(TypedDict, total=False):


### PR DESCRIPTION
### Overview

Fix incomplete type hints for camera position

This should be backported to v0.46