### PR TITLE
Make `CameraPosition.__repr__` explicit

### DIFF
--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -258,7 +258,11 @@ class CameraPosition(_NoNewAttrMixin):
 
     def __repr__(self) -> str:
         """List representation method."""
-        return '[{},\n {},\n {}]'.format(*self.to_list())
+        return (
+            f'{CameraPosition.__name__}(position={self._position},\n'
+            f'               focal_point={self._focal_point},\n'
+            f'               viewup={self._viewup})'
+        )
 
     def __getitem__(self, index):
         """Fetch a component by index location like a list."""


### PR DESCRIPTION
### Overview

Originally mentioned here https://github.com/pyvista/pyvista/pull/7788#discussion_r2261087580
This PR makes it obvious that we're dealing with an object with three attributes