### PR TITLE
Make return type from `clip` and `clip_box` filters match the input type

### DIFF
--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -1450,9 +1450,12 @@ class DataObjectFilters:
 
         Returns
         -------
-        pyvista.PolyData | tuple[pyvista.PolyData]
-            Clipped mesh when ``return_clipped=False``,
-            otherwise a tuple containing the unclipped and clipped datasets.
+        DataSet | MultiBlock | tuple[DataSet | MultiBlock, DataSet | MultiBlock]
+            Clipped mesh when ``return_clipped=False`` or a tuple containing the
+            unclipped and clipped meshes. Output mesh type matches input type for
+            :class:`~pyvista.PointSet`, :class:`~pyvista.PolyData`, and
+            :class:`~pyvista.MultiBlock`; otherwise the output type is
+            :class:`~pyvista.UnstructuredGrid`.
 
         Examples
         --------
@@ -1555,8 +1558,18 @@ class DataObjectFilters:
 
         Returns
         -------
-        pyvista.UnstructuredGrid
-            Clipped dataset.
+        DataSet | MultiBlock | tuple[DataSet | MultiBlock, DataSet | MultiBlock]
+            Clipped mesh when ``return_clipped=False`` or a tuple containing the
+            unclipped and clipped meshes. Output mesh type matches input type for
+            :class:`~pyvista.PointSet`, :class:`~pyvista.PolyData`, and
+            :class:`~pyvista.MultiBlock`; otherwise the output type is
+            :class:`~pyvista.UnstructuredGrid`.
+
+            .. versionchanged:: 0.47
+
+                The output type now matches the input type for :class:`~pyvista.PointSet` and
+                :class:`~pyvista.PolyData`. This matches the behavior of :meth:`clip`.
+                Previously, these types would return :class:`~pyvista.UnstructuredGrid`.
 
         Examples
         --------

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -1280,8 +1280,10 @@ class DataObjectFilters:
                 if VTK_CELL_IDS_KEYS in (cell_data := output.cell_data):
                     del cell_data[VTK_CELL_IDS_KEYS]
                 association, name = active_scalars_info_
-                dataset.set_active_scalars(name, preference=association)
-                output.set_active_scalars(name, preference=association)
+                if not dataset.is_empty:
+                    dataset.set_active_scalars(name, preference=association)
+                if not output.is_empty:
+                    output.set_active_scalars(name, preference=association)
                 return output
 
             def extract_crinkle_cells(dataset, a_, b_, _):
@@ -1298,9 +1300,17 @@ class DataObjectFilters:
                     def extract_cells_from_block(  # noqa: PLR0917
                         block_, clipped_a, clipped_b, active_scalars_info_
                     ):
-                        set_a = set(clipped_a.cell_data[CELL_IDS_KEY])
-                        set_b = set(clipped_b.cell_data[CELL_IDS_KEY]) - set_a
-
+                        set_a = (
+                            set(clipped_a.cell_data[CELL_IDS_KEY])
+                            if CELL_IDS_KEY in clipped_a.cell_data.keys()
+                            else set()
+                        )
+                        set_b = (
+                            set(clipped_b.cell_data[CELL_IDS_KEY])
+                            if CELL_IDS_KEY in clipped_b.cell_data.keys()
+                            else set()
+                        )
+                        set_b = set_b - set_a
                         # Need to cast as int dtype explicitly to ensure empty arrays have
                         # the right type required by extract_cells
                         array_a = np.array(list(set_a), dtype=INT_DTYPE)

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -30,7 +30,8 @@ from tests.core.test_dataset_filters import normals
 
 
 @pytest.mark.parametrize('return_clipped', [True, False])
-def test_clip_filter(multiblock_all_with_nested_and_none, return_clipped):
+@pytest.mark.parametrize('crinkle', [True, False])
+def test_clip_filter(multiblock_all_with_nested_and_none, return_clipped, crinkle):
     """This tests the clip filter on all datatypes available filters"""
     # Remove None blocks in the root block but keep the none block in the nested MultiBlock
     multi = multiblock_all_with_nested_and_none
@@ -41,7 +42,9 @@ def test_clip_filter(multiblock_all_with_nested_and_none, return_clipped):
     assert None in multi.recursive_iterator()
 
     for dataset in multi:
-        clips = dataset.clip(normal='x', invert=True, return_clipped=return_clipped)
+        clips = dataset.clip(
+            normal='x', invert=True, return_clipped=return_clipped, crinkle=crinkle
+        )
         assert clips is not None
 
         if return_clipped:

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -62,6 +62,24 @@ def test_clip_filter(multiblock_all_with_nested_and_none, return_clipped):
                 assert isinstance(clip, pv.UnstructuredGrid)
 
 
+@pytest.mark.needs_vtk_version(9, 1, 0)
+@pytest.mark.parametrize('as_composite', [True, False])
+def test_clip_filter_pointset_no_points_removed(pointset, as_composite):
+    n_points_in = pointset.n_points
+    mesh = pv.MultiBlock([pointset]) if as_composite else pointset
+    # Make sure we clip such that none of the points are removed
+    # This ensures output bounds == input bounds which hits a branch where
+    # remove_unused_points may be called
+    bounds = pointset.bounds
+    clipped = mesh.clip(origin=(bounds.x_max + 1, bounds.y_max, bounds.z_max))
+    assert np.allclose(clipped.bounds, bounds)
+
+    pointset_out = clipped[0] if as_composite else clipped
+    assert isinstance(pointset_out, pv.PointSet)
+    n_points_out = pointset_out.n_points
+    assert n_points_in == n_points_out
+
+
 def test_clip_filter_normal(datasets):
     # Test no errors are raised
     for i, dataset in enumerate(datasets):
@@ -123,14 +141,26 @@ def test_transform_raises(sphere):
         sphere.transform(matrix, inplace=False)
 
 
-def test_clip_box(datasets):
-    for dataset in datasets:
-        clp = dataset.clip_box(invert=True, progress_bar=True)
+@pytest.mark.parametrize('crinkle', [True, False])
+def test_clip_box_output_type(multiblock_all_with_nested_and_none, crinkle):
+    multiblock_all_with_nested_and_none.clean()
+    for dataset in multiblock_all_with_nested_and_none:
+        clp = dataset.clip_box(invert=True, progress_bar=True, crinkle=crinkle)
         assert clp is not None
-        assert isinstance(clp, pv.UnstructuredGrid)
+        if isinstance(dataset, pv.PointSet):
+            assert isinstance(clp, pv.PointSet)
+        elif isinstance(dataset, pv.PolyData):
+            assert isinstance(clp, pv.PolyData)
+        elif isinstance(dataset, pv.MultiBlock):
+            assert isinstance(clp, pv.MultiBlock)
+        else:
+            assert isinstance(clp, pv.UnstructuredGrid)
+
         clp2 = dataset.clip_box(merge_points=False)
         assert clp2 is not None
 
+
+def test_clip_box():
     dataset = examples.load_airplane()
     # test length 3 bounds
     result = dataset.clip_box(bounds=(900, 900, 200), invert=False, progress_bar=True)


### PR DESCRIPTION
### Overview

Fix #6098

- Type-cast the output to match the input type
- Fix issues with `crinkle` when there are empty meshes
- Make `clip` and `clip_box` consistent with their output type casting