### PR TITLE
Drop support for Python 3.9 and VTK 9.0.3

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -79,7 +79,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: macos-13, python-version: "3.9" }
           - { os: macos-14, python-version: "3.10" }
           - { os: macos-latest, python-version: "3.11" }
           - { os: macos-latest, python-version: "3.12" }
@@ -146,12 +145,6 @@ jobs:
       matrix:
         include:
           # numeric numpy versions are ~= conditions, e.g. "1.23" means "numpy~=1.23.0"
-          - python-version: "3.9"
-            vtk-version: "9.0.3" # Requires numpy~=1.23
-            numpy-version: "1.23"
-          - python-version: "3.9"
-            vtk-version: "9.1"
-            numpy-version: "1.26" # Test numpy 1.26
           - python-version: "3.10"
             vtk-version: "9.2.2"
             numpy-version: "latest"
@@ -210,7 +203,7 @@ jobs:
         run: pip install 'numpy~=${{ matrix.numpy-version }}.0'
 
       - name: Limit Matplotlib for VTK<9.2.2
-        if: ${{ matrix.vtk-version == '9.1' || matrix.vtk-version == '9.0.3' }}
+        if: ${{ matrix.vtk-version == '9.1' }}
         run: pip install 'matplotlib<3.6'
 
       - name: Install latest numpy 2.0 beta/rc
@@ -271,7 +264,7 @@ jobs:
           twine check --strict dist/*
 
       - name: Upload to PyPi
-        if: matrix.python-version == '3.9' && startsWith(github.ref, 'refs/tags/v')
+        if: matrix.python-version == '3.10' && startsWith(github.ref, 'refs/tags/v')
         run: |
           twine upload --skip-existing dist/pyvista*
         env:
@@ -370,7 +363,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ Status badges
   :target: https://github.com/prettier/prettier
   :alt: prettier
 
-.. |python| image:: https://img.shields.io/badge/python-3.9+-blue.svg
+.. |python| image:: https://img.shields.io/badge/python-3.10+-blue.svg
    :target: https://www.python.org/downloads/
 
 .. |NumFOCUS Affiliated| image:: https://img.shields.io/badge/affiliated-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
@@ -188,7 +188,7 @@ Installation
 ============
 
 PyVista can be installed from `PyPI <https://pypi.org/project/pyvista/>`_
-using ``pip`` on Python >= 3.9::
+using ``pip`` on Python >= 3.10::
 
     pip install pyvista
 

--- a/doc/source/getting-started/installation.rst
+++ b/doc/source/getting-started/installation.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-PyVista is supported on Python versions 3.9+.
+PyVista is supported on Python versions 3.10+.
 
 For the best experience, please considering using Anaconda as a virtual
 environment and package manager for Python and following the instructions to
@@ -251,7 +251,7 @@ After logging into the remote server, install Miniconda and related packages:
     wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
     bash miniconda.sh -b -p miniconda
     echo '. $HOME/miniconda/etc/profile.d/conda.sh' >> ~/.bashrc && source ~/.bashrc
-    conda create --name vtk_env python=3.9
+    conda create --name vtk_env python=3.10
     conda activate vtk_env
     conda install nodejs  # required when importing pyvista in Jupyter
     pip install jupyter pyvista trame
@@ -295,7 +295,7 @@ related packages:
     wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
     bash miniconda.sh -b -p miniconda
     echo '. $HOME/miniconda/etc/profile.d/conda.sh' >> ~/.bashrc && source ~/.bashrc
-    conda create --name vtk_env python=3.9
+    conda create --name vtk_env python=3.10
     conda activate vtk_env
     conda install nodejs  # required when importing pyvista in Jupyter
     pip install jupyter pyvista[jupyter] trame

--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -2484,7 +2484,7 @@ class DatasetPropsGenerator:
         urls = [url] if isinstance(url, str) else url
 
         # Use dict to create an ordered set to make sure links are unique
-        url_dict = {url: name for name, url in zip(names, urls)}
+        url_dict = {url: name for name, url in zip(names, urls, strict=False)}
 
         rst_links = [_rst_link(name, url) for url, name in url_dict.items()]
         return '\n'.join(rst_links)

--- a/examples/00-load/create_platonic_solids.py
+++ b/examples/00-load/create_platonic_solids.py
@@ -49,7 +49,8 @@ centers = [
 ]
 
 solids = [
-    pv.PlatonicSolid(kind, radius=0.4, center=center) for kind, center in zip(kinds, centers)
+    pv.PlatonicSolid(kind, radius=0.4, center=center)
+    for kind, center in zip(kinds, centers, strict=False)
 ]
 
 # download and align teapotahedron

--- a/examples/00-load/reader.py
+++ b/examples/00-load/reader.py
@@ -109,7 +109,7 @@ mesh_0 = reader.read()
 reader.set_active_time_value(time_values[1])
 mesh_1 = reader.read()
 
-for block_0, block_1 in zip(mesh_0, mesh_1):
+for block_0, block_1 in zip(mesh_0, mesh_1, strict=False):
     block_1['DENS_DIFF'] = block_1['DENS'] - block_0['DENS']
 
 # %%

--- a/examples/01-filter/gradients.py
+++ b/examples/01-filter/gradients.py
@@ -47,7 +47,7 @@ def gradients_to_dict(arr):
         ['du/dx', 'du/dy', 'du/dz', 'dv/dx', 'dv/dy', 'dv/dz', 'dw/dx', 'dw/dy', 'dw/dz'],
     )
     keys = keys.reshape((3, 3))[:, : arr.shape[1]].ravel()
-    return dict(zip(keys, mesh_g['gradient'].T))
+    return dict(zip(keys, mesh_g['gradient'].T, strict=False))
 
 
 gradients = gradients_to_dict(mesh_g['gradient'])

--- a/examples/02-plot/chart_basics.py
+++ b/examples/02-plot/chart_basics.py
@@ -162,8 +162,11 @@ f, ax = plt.subplots(
 alphas = [0.5 + i for i in range(5)]
 betas = [*reversed(alphas)]
 N = int(1e4)
-data = [rng.beta(alpha, beta, N) for alpha, beta in zip(alphas, betas)]
-labels = [f'$\\alpha={alpha:.1f}\\,;\\,\\beta={beta:.1f}$' for alpha, beta in zip(alphas, betas)]
+data = [rng.beta(alpha, beta, N) for alpha, beta in zip(alphas, betas, strict=False)]
+labels = [
+    f'$\\alpha={alpha:.1f}\\,;\\,\\beta={beta:.1f}$'
+    for alpha, beta in zip(alphas, betas, strict=False)
+]
 ax.violinplot(data)
 ax.set_xticks(np.arange(1, 1 + len(labels)))
 ax.set_xticklabels(labels)

--- a/examples/04-lights/attenuation.py
+++ b/examples/04-lights/attenuation.py
@@ -36,7 +36,7 @@ plotter.add_mesh(billboard, color='white')
 
 all_attenuation_values = [(1, 0, 0), (0, 2, 0), (0, 0, 2)]
 offsets = [-2, 0, 2]
-for attenuation_values, offset in zip(all_attenuation_values, offsets):
+for attenuation_values, offset in zip(all_attenuation_values, offsets, strict=False):
     light = pv.Light(position=(0.1, offset, 2), focal_point=(0.1, offset, 1), color='cyan')
     light.positional = True
     light.cone_angle = 20
@@ -63,7 +63,7 @@ plotter.add_mesh(billboard, color='white')
 
 all_attenuation_values = [(1, 0, 0), (0, 2, 0), (0, 0, 2)]
 offsets = [-2, 0, 2]
-for attenuation_values, offset in zip(all_attenuation_values, offsets):
+for attenuation_values, offset in zip(all_attenuation_values, offsets, strict=False):
     light = pv.Light(position=(0.5, offset, 3), focal_point=(0.5, offset, 1), color='cyan')
     light.positional = True
     light.cone_angle = 20
@@ -86,7 +86,7 @@ plotter = pv.Plotter(lighting='none')
 # loop over three lights with three kinds of attenuation
 all_attenuation_values = [(2, 0, 0), (0, 2, 0), (0, 0, 2)]
 light_offsets = [-6, 0, 6]
-for attenuation_values, light_x in zip(all_attenuation_values, light_offsets):
+for attenuation_values, light_x in zip(all_attenuation_values, light_offsets, strict=False):
     # loop over three perpendicular planes for each light
     for plane_y in [2, 5, 10]:
         screen = pv.Plane(center=(light_x, plane_y, 0), direction=(0, 1, 0), i_size=5, j_size=5)

--- a/examples/04-lights/beam_shape.py
+++ b/examples/04-lights/beam_shape.py
@@ -129,7 +129,7 @@ hemi_template = pv.Sphere().clip()
 centers = [(0, 0, 0), (0, 1.5, 0), (0, 1.5 * 0.5, 1.5 * 3**0.5 / 2)]
 exponents = [1, 0.3, 5]
 
-for center, exponent in zip(centers, exponents):
+for center, exponent in zip(centers, exponents, strict=False):
     hemi = hemi_template.copy()
     hemi.translate(center, inplace=True)
     plotter.add_mesh(hemi, color='cyan', smooth_shading=True)

--- a/examples/99-advanced/sphere_eversion.py
+++ b/examples/99-advanced/sphere_eversion.py
@@ -199,7 +199,7 @@ x, y, z = cylinder_to_wormhole(h, phi, t, p, q)
 xis = np.linspace(0, 1, n_steps)
 alphas = np.linspace(0, alpha_final, n_steps)
 etas = np.linspace(1, eta_final, n_steps)
-for xi, alpha, eta in zip(xis, alphas, etas):
+for xi, alpha, eta in zip(xis, alphas, etas, strict=False):
     x2, y2, z2 = close_wormhole(x, y, z, eta, xi, alpha)
     save_frame(x2, y2, z2)
 
@@ -230,7 +230,7 @@ x, y, z = cylinder_to_wormhole(h, phi, t, p, q)
 xis = np.linspace(1, 0, n_steps + 1)[1:]
 alphas = np.linspace(alpha_final, 0, n_steps + 1)[1:]
 etas = np.linspace(eta_final, 1, n_steps + 1)[1:]
-for xi, alpha in zip(xis, alphas):
+for xi, alpha in zip(xis, alphas, strict=False):
     x2, y2, z2 = close_wormhole(x, y, z, eta, xi, alpha)
     save_frame(x2, y2, z2)
 

--- a/examples/99-advanced/warp_by_vector_eigenmodes.py
+++ b/examples/99-advanced/warp_by_vector_eigenmodes.py
@@ -188,7 +188,7 @@ computed_freqs_kHz, mode_indices = get_first_N_above_thresh(  # noqa: N816
     N=8, freqs=freqs / 1e3, thresh=1, decimals=1
 )
 print('found the following first unique eigenfrequencies:')
-for ind, (freq1, freq2) in enumerate(zip(computed_freqs_kHz, expected_freqs_kHz)):
+for ind, (freq1, freq2) in enumerate(zip(computed_freqs_kHz, expected_freqs_kHz, strict=False)):
     error = np.abs(freq2 - freq1) / freq1 * 100.0
     print(f'freq. {ind + 1:1}: {freq1:8.1f} kHz, expected: {freq2:8.1f} kHz, error: {error:.2f} %')
 
@@ -218,7 +218,7 @@ vol.dimensions = [*grid.dimensions[0:2], nz]
 for i, mode_index in enumerate(mode_indices):
     eigenvector = vr[:, mode_index]
     displacement_points = np.zeros_like(vol.points)
-    for weight, (component, p, q, r) in zip(eigenvector, quadruplets):
+    for weight, (component, p, q, r) in zip(eigenvector, quadruplets, strict=False):
         displacement_points[:, component] += (
             weight * vol.points[:, 0] ** p * vol.points[:, 1] ** q * vol.points[:, 2] ** r
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
   'Programming Language :: Python :: 3.13',
-  'Programming Language :: Python :: 3.9',
   'Topic :: Scientific/Engineering :: Information Analysis',
 ]
 dependencies = [
@@ -27,6 +26,7 @@ dependencies = [
   'vtk!=9.4.0',
   'vtk!=9.4.1',
   'vtk<9.6.0',
+  'vtk>=9.1.0',
 ]
 description = 'Easier Pythonic interface to VTK'
 dynamic = ['version']
@@ -34,7 +34,7 @@ keywords = ['mesh', 'numpy', 'plotting', 'vtk']
 license = 'MIT'
 name = 'pyvista'
 readme = 'README.rst'
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 
 [project.optional-dependencies]
 all = ['pyvista[colormaps,io,jupyter]']

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -36,11 +36,11 @@ if TYPE_CHECKING:
 # get the int type from vtk
 ID_TYPE: type[np.int32 | np.int64] = _get_vtk_id_type()
 
-# determine if using at least vtk 9.0.0
-if vtk_version_info.major < 9:  # pragma: no cover
+# determine if using at least vtk 9.1.0
+if vtk_version_info < (9, 1, 0):  # pragma: no cover
     from pyvista.core.errors import VTKVersionError
 
-    msg = 'VTK version must be 9.0.0 or greater.'
+    msg = 'VTK version must be 9.1.0 or greater.'
     raise VTKVersionError(msg)
 
 # catch annoying numpy/vtk future warning:

--- a/pyvista/_deprecate_positional_args.py
+++ b/pyvista/_deprecate_positional_args.py
@@ -6,13 +6,15 @@ from inspect import Parameter
 from inspect import Signature
 import os
 from pathlib import Path
-from typing import Callable
+from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import overload
 import warnings
 
 from typing_extensions import ParamSpec
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
 from pyvista._version import version_info
 
 _MAX_POSITIONAL_ARGS = 3  # Should match value in pyproject.toml

--- a/pyvista/core/_typing_core/_aliases.py
+++ b/pyvista/core/_typing_core/_aliases.py
@@ -6,7 +6,7 @@ import os
 from typing import TYPE_CHECKING
 from typing import Literal
 from typing import NamedTuple
-from typing import Union
+from typing import TypeAlias
 
 from pyvista.core import _vtk_core as _vtk
 
@@ -34,38 +34,23 @@ else:
 #
 # Long or complex type aliases (e.g. a union of 4 or more base types) should
 # always be added to the dictionary and documented
-Number = Union[int, float]
+Number = int | float
 
-VectorLike = _ArrayLike1D[NumberType]
-VectorLike.__doc__ = """One-dimensional array-like object with numerical values.
+VectorLike: TypeAlias = _ArrayLike1D[NumberType]
 
-Includes sequences and numpy arrays.
-"""
+MatrixLike: TypeAlias = _ArrayLike2D[NumberType]
 
-MatrixLike = _ArrayLike2D[NumberType]
-MatrixLike.__doc__ = """Two-dimensional array-like object with numerical values.
+ArrayLike: TypeAlias = _ArrayLike[NumberType]
 
-Includes singly-nested sequences and numpy arrays.
-"""
+# Create a float-specific matrix type for rotation use
+FloatMatrixLike: TypeAlias = _ArrayLike2D[float]
 
-ArrayLike = _ArrayLike[NumberType]
-ArrayLike.__doc__ = """Any-dimensional array-like object with numerical values.
-
-Includes sequences, nested sequences, and numpy arrays. Scalar values are not included.
-"""
 if Rotation is not None:
-    RotationLike = Union[MatrixLike[float], _vtk.vtkMatrix3x3, Rotation]
+    RotationLike: TypeAlias = FloatMatrixLike | _vtk.vtkMatrix3x3 | Rotation
 else:
-    RotationLike = Union[MatrixLike[float], _vtk.vtkMatrix3x3]  # type: ignore[misc]
-RotationLike.__doc__ = """Array or object representing a spatial rotation.
+    RotationLike: TypeAlias = FloatMatrixLike | _vtk.vtkMatrix3x3  # type: ignore[no-redef,misc]
 
-Includes 3x3 arrays and SciPy Rotation objects.
-"""
-
-TransformLike = Union[RotationLike, _vtk.vtkMatrix4x4, _vtk.vtkTransform]
-TransformLike.__doc__ = """Array or object representing a spatial transformation.
-
-Includes 3x3 and 4x4 arrays as well as SciPy Rotation objects."""
+TransformLike: TypeAlias = RotationLike | _vtk.vtkMatrix4x4 | _vtk.vtkTransform
 
 
 class BoundsTuple(NamedTuple):
@@ -93,7 +78,7 @@ class BoundsTuple(NamedTuple):
         field_size = max(len(f) for f in fields)
         name = self.__class__.__name__
         whitespace = (len(name) + 1) * ' '
-        for i, items in enumerate(zip(fields, split_strings)):
+        for i, items in enumerate(zip(fields, split_strings, strict=False)):
             field, parts = items
             left, right = parts
             aligned = f'{left:>{pad_left}}{dot}{right}'
@@ -105,15 +90,11 @@ class BoundsTuple(NamedTuple):
         return f'{name}({joined_lines})'
 
 
-CellsLike = Union[MatrixLike[int], VectorLike[int]]
+CellsLike: TypeAlias = MatrixLike[int] | VectorLike[int]
 
-CellArrayLike = Union[CellsLike, _vtk.vtkCellArray]
+CellArrayLike: TypeAlias = CellsLike | _vtk.vtkCellArray
 
 # Undocumented alias - should be expanded in docs
-_ArrayLikeOrScalar = Union[NumberType, ArrayLike[NumberType]]
+_ArrayLikeOrScalar: TypeAlias = NumberType | ArrayLike[NumberType]  # noqa: PYI047
 
-InteractionEventType = Union[Literal['end', 'start', 'always'], _vtk.vtkCommand.EventIds]
-InteractionEventType.__doc__ = """Interaction event mostly used for widgets.
-
-Includes both strings such as `end`, 'start' and `always` and `_vtk.vtkCommand.EventIds`.
-"""
+InteractionEventType = Literal['end', 'start', 'always'] | _vtk.vtkCommand.EventIds

--- a/pyvista/core/_typing_core/_array_like.py
+++ b/pyvista/core/_typing_core/_array_like.py
@@ -24,8 +24,8 @@ Some key differences include:
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import TypeAlias
 from typing import TypeVar
-from typing import Union
 
 import numpy as np
 import numpy.typing as npt
@@ -33,7 +33,7 @@ import numpy.typing as npt
 # Define numeric types
 NumberType = TypeVar(
     'NumberType',
-    bound=Union[np.floating, np.integer, np.bool_, float, int, bool],
+    bound=np.floating | np.integer | np.bool_ | float | int | bool,
 )
 NumberType.__doc__ = """Type variable for numeric data types."""
 
@@ -41,47 +41,34 @@ NumberType.__doc__ = """Type variable for numeric data types."""
 # Its definition should be identical to `NumberType`
 _NumberType = TypeVar(  # noqa: PYI018
     '_NumberType',
-    bound=Union[np.floating, np.integer, np.bool_, float, int, bool],
+    bound=np.floating | np.integer | np.bool_ | float | int | bool,
 )
 
-NumpyArray = npt.NDArray[NumberType]
+NumpyArray: TypeAlias = npt.NDArray[NumberType]
 
-_FiniteNestedList = Union[
-    list[NumberType],
-    list[list[NumberType]],
-    list[list[list[NumberType]]],
-    list[list[list[list[NumberType]]]],
-]
-_FiniteNestedTuple = Union[
-    tuple[NumberType],
-    tuple[tuple[NumberType]],
-    tuple[tuple[tuple[NumberType]]],
-    tuple[tuple[tuple[tuple[NumberType]]]],
-]
 
-_ArrayLike1D = Union[
-    NumpyArray[NumberType],
-    Sequence[NumberType],
-    Sequence[NumpyArray[NumberType]],
-]
-_ArrayLike2D = Union[
-    NumpyArray[NumberType],
-    Sequence[Sequence[NumberType]],
-    Sequence[Sequence[NumpyArray[NumberType]]],
-]
-_ArrayLike3D = Union[
-    NumpyArray[NumberType],
-    Sequence[Sequence[Sequence[NumberType]]],
-    Sequence[Sequence[Sequence[NumpyArray[NumberType]]]],
-]
-_ArrayLike4D = Union[
-    NumpyArray[NumberType],
-    Sequence[Sequence[Sequence[Sequence[NumberType]]]],
-    Sequence[Sequence[Sequence[Sequence[NumpyArray[NumberType]]]]],
-]
-_ArrayLike = Union[
-    _ArrayLike1D[NumberType],
-    _ArrayLike2D[NumberType],
-    _ArrayLike3D[NumberType],
-    _ArrayLike4D[NumberType],
-]
+_ArrayLike1D: TypeAlias = (
+    NumpyArray[NumberType] | Sequence[NumberType] | Sequence[NumpyArray[NumberType]]
+)
+_ArrayLike2D: TypeAlias = (
+    NumpyArray[NumberType]
+    | Sequence[Sequence[NumberType]]
+    | Sequence[Sequence[NumpyArray[NumberType]]]
+)
+_ArrayLike3D: TypeAlias = (
+    NumpyArray[NumberType]
+    | Sequence[Sequence[Sequence[NumberType]]]
+    | Sequence[Sequence[Sequence[NumpyArray[NumberType]]]]
+)
+_ArrayLike4D: TypeAlias = (
+    NumpyArray[NumberType]
+    | Sequence[Sequence[Sequence[Sequence[NumberType]]]]
+    | Sequence[Sequence[Sequence[Sequence[NumpyArray[NumberType]]]]]
+)
+
+_ArrayLike: TypeAlias = (  # noqa: PYI047
+    _ArrayLike1D[NumberType]
+    | _ArrayLike2D[NumberType]
+    | _ArrayLike3D[NumberType]
+    | _ArrayLike4D[NumberType]
+)

--- a/pyvista/core/_typing_core/_dataset_types.py
+++ b/pyvista/core/_typing_core/_dataset_types.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from typing import TypeVar
-from typing import Union
 
 from pyvista.core.composite import MultiBlock
 from pyvista.core.dataobject import DataObject
@@ -26,7 +25,7 @@ _PointSetType.__doc__ = """Type variable for PyVista ``PointSet`` classes."""
 _DataSetType = TypeVar('_DataSetType', bound=DataSet)
 _DataSetType.__doc__ = """Type variable for :class:`~pyvista.DataSet` classes."""
 
-_DataSetOrMultiBlockType = TypeVar('_DataSetOrMultiBlockType', bound=Union[DataSet, MultiBlock])
+_DataSetOrMultiBlockType = TypeVar('_DataSetOrMultiBlockType', bound=DataSet | MultiBlock)
 _DataSetOrMultiBlockType.__doc__ = (
     """Type variable for :class:`~pyvista.DataSet` or :class:`~pyvista.MultiBlock` classes."""
 )

--- a/pyvista/core/_validation/_cast_array.py
+++ b/pyvista/core/_validation/_cast_array.py
@@ -3,24 +3,36 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Optional
-from typing import Union
 
 import numpy as np
 import numpy.typing as npt
 
 if TYPE_CHECKING:
+    from typing import TypeAlias
+
     from pyvista.core._typing_core import ArrayLike
     from pyvista.core._typing_core import NumpyArray
     from pyvista.core._typing_core._aliases import _ArrayLikeOrScalar
     from pyvista.core._typing_core._array_like import NumberType
-    from pyvista.core._typing_core._array_like import _FiniteNestedList
-    from pyvista.core._typing_core._array_like import _FiniteNestedTuple
+
+    # Local type aliases for finite nested structures
+    _FiniteNestedList: TypeAlias = (
+        list[NumberType]
+        | list[list[NumberType]]
+        | list[list[list[NumberType]]]
+        | list[list[list[list[NumberType]]]]
+    )
+    _FiniteNestedTuple: TypeAlias = (
+        tuple[NumberType]
+        | tuple[tuple[NumberType]]
+        | tuple[tuple[tuple[NumberType]]]
+        | tuple[tuple[tuple[tuple[NumberType]]]]
+    )
 
 
 def _cast_to_list(
     arr: _ArrayLikeOrScalar[NumberType],
-) -> Union[NumberType, _FiniteNestedList[NumberType]]:
+) -> NumberType | _FiniteNestedList[NumberType]:
     """Cast an array to a nested list.
 
     Parameters
@@ -39,7 +51,7 @@ def _cast_to_list(
 
 def _cast_to_tuple(
     arr: ArrayLike[NumberType],
-) -> Union[NumberType, _FiniteNestedTuple[NumberType]]:
+) -> NumberType | _FiniteNestedTuple[NumberType]:
     """Cast an array to a nested tuple.
 
     Parameters
@@ -66,7 +78,7 @@ def _cast_to_numpy(
     /,
     *,
     as_any: bool = True,
-    dtype: Optional[npt.DTypeLike] = None,
+    dtype: npt.DTypeLike | None = None,
     copy: bool = False,
     must_be_real: bool = False,
 ) -> NumpyArray[NumberType]:
@@ -119,8 +131,6 @@ def _cast_to_numpy(
 
     """
     # needed to support numpy <1.25
-    # needed to support vtk 9.0.3
-    # check for removal when support for vtk 9.0.3 is removed
     try:
         VisibleDeprecationWarning = np.exceptions.VisibleDeprecationWarning
     except AttributeError:

--- a/pyvista/core/_validation/check.py
+++ b/pyvista/core/_validation/check.py
@@ -18,6 +18,7 @@ from collections.abc import Sequence
 from collections.abc import Sized
 from numbers import Number
 import reprlib
+import types
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Union
@@ -38,14 +39,14 @@ if TYPE_CHECKING:
     from pyvista.core._typing_core._array_like import _NumberType
 
 
-_Shape = Union[tuple[()], tuple[int, ...]]
-_ShapeLike = Union[int, _Shape]
+_Shape = tuple[()] | tuple[int, ...]
+_ShapeLike = int | _Shape
 
 
 def check_subdtype(
-    input_obj: Union[npt.DTypeLike, _ArrayLikeOrScalar[NumberType]],
+    input_obj: npt.DTypeLike | _ArrayLikeOrScalar[NumberType],
     /,
-    base_dtype: Union[npt.DTypeLike, tuple[npt.DTypeLike, ...], list[npt.DTypeLike]],
+    base_dtype: npt.DTypeLike | tuple[npt.DTypeLike, ...] | list[npt.DTypeLike],
     *,
     name: str = 'Input',
 ) -> None:
@@ -910,7 +911,8 @@ def check_instance(
         raise TypeError(msg)
 
     # Get class info from generics
-    if get_origin(classinfo) is Union:
+    origin = get_origin(classinfo)
+    if origin is Union or origin is types.UnionType:
         classinfo = get_args(classinfo)
 
     # Count num classes

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -186,7 +186,7 @@ class MultiBlock(
                 self.SetBlock(i, wrap(block))
 
     def _items(self) -> Iterable[tuple[str | None, _TypeMultiBlockLeaf]]:
-        yield from zip(self.keys(), self)
+        yield from zip(self.keys(), self, strict=False)
 
     _OrderLiteral = Literal['nested_first', 'nested_last']
 
@@ -645,7 +645,7 @@ class MultiBlock(
             other_ids = []
             other_names = []
             other_blocks = []
-            for id_, name, block in zip(ids, names, self):
+            for id_, name, block in zip(ids, names, self, strict=False):
                 if isinstance(block, MultiBlock):
                     multi_ids.append(id_)
                     multi_names.append(name)
@@ -664,7 +664,7 @@ class MultiBlock(
                 blocks = [*multi_blocks, *other_blocks]
 
         # Iterate through ids, names, blocks
-        for id_, name, block in zip(ids, names, blocks):
+        for id_, name, block in zip(ids, names, blocks, strict=False):
             if (skip_none and block is None) or (
                 skip_empty and (block is not None and block.is_empty)
             ):
@@ -1588,7 +1588,7 @@ class MultiBlock(
         """
         # Code based on collections.abc
         if isinstance(datasets, MultiBlock):
-            for key, data in zip(datasets.keys(), datasets):
+            for key, data in zip(datasets.keys(), datasets, strict=False):
                 self.append(data, key)
         else:
             for v in datasets:
@@ -1972,7 +1972,9 @@ class MultiBlock(
         if not self.keys() == other.keys():
             return False
 
-        return not any(self_mesh != other_mesh for self_mesh, other_mesh in zip(self, other))
+        return not any(
+            self_mesh != other_mesh for self_mesh, other_mesh in zip(self, other, strict=False)
+        )
 
     __hash__ = None  # type: ignore[assignment]  # https://github.com/pyvista/pyvista/pull/7671
 

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -933,7 +933,7 @@ class DataSetAttributes(
          ('data1', pyvista_ndarray([0, 1, 2, 3, 4, 5]))]
 
         """
-        return list(zip(self.keys(), self.values()))
+        return list(zip(self.keys(), self.values(), strict=False))
 
     def keys(self: Self) -> list[str]:
         """Return the names of the arrays as a list.

--- a/pyvista/core/filters/composite.py
+++ b/pyvista/core/filters/composite.py
@@ -18,7 +18,7 @@ from pyvista.core.utilities.helpers import wrap
 from pyvista.core.utilities.misc import abstract_class
 
 if TYPE_CHECKING:
-    from typing import Callable
+    from collections.abc import Callable
 
     from pyvista import MultiBlock
     from pyvista.core.composite import _TypeMultiBlockLeaf

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -223,7 +223,7 @@ class DataObjectFilters:
         # dynamically convert each self.point_data[name] etc. to float32
         all_vectors = [point_vectors, cell_vectors]
         all_dataset_attrs = [self.point_data, self.cell_data]
-        for vector_names, dataset_attrs in zip(all_vectors, all_dataset_attrs):
+        for vector_names, dataset_attrs in zip(all_vectors, all_dataset_attrs, strict=False):
             for vector_name in vector_names:
                 if vector_name is None:
                     continue
@@ -1324,7 +1324,7 @@ class DataObjectFilters:
                     )
 
                     for (ids, _, block_self), block_a, block_b, scalars_info in zip(
-                        self_iter, a_iter, b_iter, active_scalars_info_
+                        self_iter, a_iter, b_iter, active_scalars_info_, strict=False
                     ):
                         crinkled = extract_cells_from_block(
                             block_self, block_a, block_b, scalars_info

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from collections.abc import Iterable
 from collections.abc import Sequence
 import contextlib
@@ -9,7 +10,6 @@ import functools
 import itertools
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Callable
 from typing import Literal
 from typing import cast
 import warnings
@@ -1749,7 +1749,7 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
             # use a single glyph, ignore indices
             alg.SetSourceData(geoms[0])
         else:
-            for index, subgeom in zip(indices, geoms):
+            for index, subgeom in zip(indices, geoms, strict=False):
                 alg.SetSourceData(index, subgeom)
             if dataset.active_scalars is not None:
                 if dataset.active_scalars.ndim > 1:
@@ -5001,11 +5001,11 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
         multi = pyvista.MultiBlock()
         if values is not None:
             value_names = value_names or [None] * len(values)
-            for name, val in zip(value_names, values):
+            for name, val in zip(value_names, values, strict=False):
                 multi.append(method(values=[val], ranges=None, **kwargs), name)
         if ranges is not None:
             range_names = range_names or [None] * len(ranges)
-            for name, rng in zip(range_names, ranges):
+            for name, rng in zip(range_names, ranges, strict=False):
                 multi.append(method(values=None, ranges=[rng], **kwargs), name)
         return multi
 
@@ -6944,7 +6944,7 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
 
             # Pack/sort array
             packed_array = np.zeros_like(arr)
-            for num_in, num_out in zip(label_numbers_in, label_numbers_out):
+            for num_in, num_out in zip(label_numbers_in, label_numbers_out, strict=False):
                 packed_array[arr == num_in] = num_out
 
             result = self if inplace else self.copy(deep=True)
@@ -7304,7 +7304,7 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
                 cast('list[ColorLike]', list(colors.values()))
             )
             color_rgb_sequence = [getattr(c, color_type) for c in colors_]
-            items = zip(colors.keys(), color_rgb_sequence)
+            items = zip(colors.keys(), color_rgb_sequence, strict=False)
 
         else:
             if array.ndim > 1:
@@ -7379,7 +7379,7 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
                 keys = np.unique(array)
                 values = itertools.cycle(color_rgb_sequence)
 
-            items = zip(keys, values)
+            items = zip(keys, values, strict=False)
 
         colors_out = np.full(
             (len(array), num_components), default_channel_value, dtype=color_dtype

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from collections.abc import Iterable
 import operator
 from typing import TYPE_CHECKING
-from typing import Callable
 from typing import Literal
 from typing import cast
 import warnings
@@ -379,7 +379,7 @@ class ImageDataFilters(DataSetFilters):
         lower = (0, 0, 0) if index_mode == 'dimensions' else self.offset
         indices = tuple(
             _set_default_start_and_stop(slc, low, dim)
-            for slc, low, dim in zip((i, j, k), lower, self.dimensions)
+            for slc, low, dim in zip((i, j, k), lower, self.dimensions, strict=False)
         )
         voi = self._compute_voi_from_index(
             indices, index_mode=index_mode, strict_index=strict_index
@@ -920,7 +920,7 @@ class ImageDataFilters(DataSetFilters):
             padding = _validate_padding(margin_)
             # Do not pad singleton dims
             singleton_dims = np.array(self.dimensions) == 1
-            mask = [x for pair in zip(singleton_dims, singleton_dims) for x in pair]
+            mask = [x for pair in zip(singleton_dims, singleton_dims, strict=False) for x in pair]
             padding[mask] = np.array(self.extent)[mask]
             return _pad_extent(self.extent, -padding)
 

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -2672,7 +2672,9 @@ class PolyDataFilters(DataSetFilters):
                 origin_to_centre_lengths + self.length
             )
 
-            for id_r, origin, second_point in zip(retry_ray_indices, origins_retry, second_points):
+            for id_r, origin, second_point in zip(
+                retry_ray_indices, origins_retry, second_points, strict=False
+            ):
                 locs, indices = self.ray_trace(origin, second_point, first_point=first_point)
                 if locs.any():
                     if first_point:

--- a/pyvista/core/filters/structured_grid.py
+++ b/pyvista/core/filters/structured_grid.py
@@ -123,7 +123,7 @@ class StructuredGridFilters(DataSetFilters):
             raise RuntimeError(msg)
 
         # check dimensions are compatible
-        for i, (dim1, dim2) in enumerate(zip(self.dimensions, other.dimensions)):  # type: ignore[attr-defined]
+        for i, (dim1, dim2) in enumerate(zip(self.dimensions, other.dimensions, strict=False)):  # type: ignore[attr-defined]
             if i == axis:
                 continue
             if dim1 != dim2:

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -763,8 +763,8 @@ class ImageData(Grid, ImageDataFilters, _vtk.vtkImageData):
 
         clipped = pyvista.ImageDataFilters._clip_extent(voi, clip_to=self.extent)
         if strict_index and (
-            any(min_ < clp for min_, clp in zip(voi[::2], clipped[::2]))
-            or any(max_ > clp for max_, clp in zip(voi[1::2], clipped[1::2]))
+            any(min_ < clp for min_, clp in zip(voi[::2], clipped[::2], strict=False))
+            or any(max_ > clp for max_, clp in zip(voi[1::2], clipped[1::2], strict=False))
         ):
             msg = (
                 f'The requested volume of interest {tuple(voi)} '

--- a/pyvista/core/partitioned.py
+++ b/pyvista/core/partitioned.py
@@ -107,7 +107,7 @@ class PartitionedDataSet(DataObject, MutableSequence, _vtk.vtkPartitionedDataSet
     ):
         """Set a partition with a VTK data object."""
         if isinstance(index, slice):
-            for i, d in zip(range(self.n_partitions)[index], data):
+            for i, d in zip(range(self.n_partitions)[index], data, strict=False):
                 self.SetPartition(i, d)
         else:
             if index < -self.n_partitions or index >= self.n_partitions:

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING
 from typing import ClassVar
-from typing import Union
 from typing import cast
 import warnings
 
@@ -56,20 +55,20 @@ if TYPE_CHECKING:
     from ._typing_core import NumpyArray
     from ._typing_core import VectorLike
 
-    _PolyDataWriterAlias = Union[
-        _vtk.vtkPLYWriter,
-        _vtk.vtkXMLPolyDataWriter,
-        _vtk.vtkSTLWriter,
-        _vtk.vtkPolyDataWriter,
-        _vtk.vtkHoudiniPolyDataWriter,
-        _vtk.vtkOBJWriter,
-        _vtk.vtkIVWriter,
-        _vtk.vtkHDFWriter,
-    ]
+    _PolyDataWriterAlias = (
+        _vtk.vtkPLYWriter
+        | _vtk.vtkXMLPolyDataWriter
+        | _vtk.vtkSTLWriter
+        | _vtk.vtkPolyDataWriter
+        | _vtk.vtkHoudiniPolyDataWriter
+        | _vtk.vtkOBJWriter
+        | _vtk.vtkIVWriter
+        | _vtk.vtkHDFWriter
+    )
 
-    _UnstructuredGridWriterAlias = Union[
-        _vtk.vtkXMLUnstructuredGridWriter, _vtk.vtkUnstructuredGridWriter, _vtk.vtkHDFWriter
-    ]
+    _UnstructuredGridWriterAlias = (
+        _vtk.vtkXMLUnstructuredGridWriter | _vtk.vtkUnstructuredGridWriter | _vtk.vtkHDFWriter
+    )
 
 
 DEFAULT_INPLACE_WARNING = (
@@ -2196,7 +2195,9 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
             face_count = 0
 
             for i, n_faces in zip(
-                np.flatnonzero(self.celltypes == pyvista.CellType.POLYHEDRON), face_counts
+                np.flatnonzero(self.celltypes == pyvista.CellType.POLYHEDRON),
+                face_counts,
+                strict=False,
             ):
                 locations[i] = [n_faces, *(np.arange(n_faces) + face_count)]
                 face_count += n_faces

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
 from typing import TypeVar
-from typing import Union
 from typing import cast
 from typing import overload
 
@@ -490,7 +489,7 @@ def get_array_association(  # noqa: PLR0917
         msg = f'Data field ({preference}) not supported.'
         raise ValueError(msg)
 
-    matches = [pref for pref, array in zip(preferences, arrays) if array is not None]
+    matches = [pref for pref, array in zip(preferences, arrays, strict=False) if array is not None]
     # optionally raise if no match
     if not matches:
         if err:
@@ -975,16 +974,16 @@ def set_default_active_scalars(mesh: pyvista.DataSet) -> _ActiveArrayExistsInfoT
     return _ActiveArrayExistsInfoTuple(field, cast('str', name))
 
 
-_JSONValueType = Union[
-    dict[str, '_JSONValueType'],
-    list['_JSONValueType'],
-    tuple['_JSONValueType'],
-    str,
-    int,
-    float,
-    bool,
-    None,
-]
+_JSONValueType = (
+    dict[str, '_JSONValueType']
+    | list['_JSONValueType']
+    | tuple['_JSONValueType']
+    | str
+    | int
+    | float
+    | bool
+    | None
+)
 
 
 class _SerializedDictArray(_vtk.DisableVtkSnakeCase, UserDict, _vtk.vtkStringArray):  # type: ignore[type-arg]

--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -3224,7 +3224,7 @@ class AxesGeometrySource(_NoNewAttrMixin):
         # Init datasets
         names = ['x_shaft', 'y_shaft', 'z_shaft', 'x_tip', 'y_tip', 'z_tip']
         polys = [pyvista.PolyData() for _ in range(len(names))]
-        self._output = pyvista.MultiBlock(dict(zip(names, polys)))
+        self._output = pyvista.MultiBlock(dict(zip(names, polys, strict=False)))
 
         # Store shaft/tip references in separate vars for convenience
         self._shaft_datasets = (polys[0], polys[1], polys[2])
@@ -3824,7 +3824,7 @@ class OrthogonalPlanesSource(_NoNewAttrMixin):
         self._normal_sign = tuple(valid_sign)
 
         # Modify sources
-        for source, axis_vector, sign_ in zip(self.sources, np.eye(3), valid_sign):
+        for source, axis_vector, sign_ in zip(self.sources, np.eye(3), valid_sign, strict=False):
             has_positive_normal = np.dot(source.normal, axis_vector) > 0
             if has_positive_normal and sign_ == '-':
                 source.flip_normal()
@@ -3927,12 +3927,12 @@ class OrthogonalPlanesSource(_NoNewAttrMixin):
             dtype_out=float,
             to_tuple=True,
         )
-        for source, dist in zip(self.sources, valid_distance):
+        for source, dist in zip(self.sources, valid_distance, strict=False):
             source.push(dist)
 
     def update(self: OrthogonalPlanesSource) -> None:
         """Update the output of the source."""
-        for source, plane in zip(self.sources, self._output):
+        for source, plane in zip(self.sources, self._output, strict=False):
             plane.copy_from(source.output)
 
     @property
@@ -4391,7 +4391,7 @@ class CubeFacesSource(CubeSource):
         output = self._output
 
         # Modify each face mesh of the output
-        for index, (name, points) in enumerate(zip(self.names, face_points)):
+        for index, (name, points) in enumerate(zip(self.names, face_points, strict=False)):
             output.set_block_name(index, name)
             face_poly = output[index]
             face_center = np.mean(points, axis=0)

--- a/pyvista/examples/_dataset_loader.py
+++ b/pyvista/examples/_dataset_loader.py
@@ -41,7 +41,6 @@ from typing import Any
 from typing import Generic
 from typing import Protocol
 from typing import TypeVar
-from typing import Union
 from typing import cast
 from typing import final
 from typing import runtime_checkable
@@ -70,13 +69,8 @@ _FilePropIntType_co = TypeVar(
     covariant=True,
 )
 
-DatasetObject = Union[pv.DataSet, pv.Texture, NumpyArray[Any], pv.MultiBlock]
-DatasetType = Union[
-    type[pv.DataSet],
-    type[pv.Texture],
-    type[NumpyArray[Any]],
-    type[pv.MultiBlock],
-]
+DatasetObject = pv.DataSet | pv.Texture | NumpyArray[Any] | pv.MultiBlock
+DatasetType = type[pv.DataSet] | type[pv.Texture] | type[NumpyArray[Any]] | type[pv.MultiBlock]
 
 
 class _BaseFilePropsProtocol(Generic[_FilePropStrType_co, _FilePropIntType_co]):
@@ -709,7 +703,7 @@ def _load_as_multiblock(
             for path in paths
         ]
 
-    for file, name in zip(files, names):
+    for file, name in zip(files, names, strict=False):
         if not isinstance(file, _DatasetLoader):
             continue  # type: ignore[unreachable]
         loaded = file.load()

--- a/pyvista/plotting/_typing.py
+++ b/pyvista/plotting/_typing.py
@@ -46,7 +46,7 @@ ColorLike = Union[
     Sequence[int],
     Sequence[float],
     NumpyArray[float],
-    dict[str, Union[int, float, str]],
+    dict[str, int | float | str],
     str,
     'Color',
     _vtk.vtkColor3ub,

--- a/pyvista/plotting/axes_assembly.py
+++ b/pyvista/plotting/axes_assembly.py
@@ -457,7 +457,7 @@ class AxesAssembly(_XYZAssembly):
         # Init shaft and tip datasets
         self._shaft_and_tip_geometry_source = geometry_source
         shaft_tip_datasets = self._shaft_and_tip_geometry_source.output
-        for actor, dataset in zip(self._shaft_and_tip_actors, shaft_tip_datasets):
+        for actor, dataset in zip(self._shaft_and_tip_actors, shaft_tip_datasets, strict=False):
             actor.mapper = pv.DataSetMapper(dataset=dataset)
 
     def __init__(
@@ -489,7 +489,7 @@ class AxesAssembly(_XYZAssembly):
 
         _XYZAssembly.__init__(
             self,
-            xyz_actors=tuple(zip(self._shaft_actors, self._tip_actors)),  # type: ignore[arg-type]
+            xyz_actors=tuple(zip(self._shaft_actors, self._tip_actors, strict=False)),  # type: ignore[arg-type]
             xyz_label_actors=self._label_actors,
             x_label=x_label,
             y_label=y_label,
@@ -882,7 +882,7 @@ class AxesAssembly(_XYZAssembly):
             raise ValueError(msg)
 
         # Sequence is valid, now set values
-        for actor, val in zip(actors, values):
+        for actor, val in zip(actors, values, strict=False):
             setattr(actor.prop, name, val)
 
     def get_actor_prop(self, name: str):
@@ -964,7 +964,7 @@ class AxesAssembly(_XYZAssembly):
     def _update_label_positions(self):
         labels = self._label_actors
         position_vectors = self._get_offset_label_position_vectors(self.label_position)
-        for label, position in zip(labels, position_vectors):
+        for label, position in zip(labels, position_vectors, strict=False):
             label.relative_position = position
 
 
@@ -1136,8 +1136,10 @@ class AxesAssemblySymmetric(AxesAssembly):
 
         _XYZAssembly.__init__(
             self,
-            xyz_actors=tuple(zip(self._shaft_actors, self._tip_actors)),  # type: ignore[arg-type]
-            xyz_label_actors=tuple(zip(self._label_actors, self._label_actors_symmetric)),  # type: ignore[arg-type]
+            xyz_actors=tuple(zip(self._shaft_actors, self._tip_actors, strict=False)),  # type: ignore[arg-type]
+            xyz_label_actors=tuple(
+                zip(self._label_actors, self._label_actors_symmetric, strict=False)
+            ),  # type: ignore[arg-type]
             x_label=x_label,
             y_label=y_label,
             z_label=z_label,
@@ -1332,7 +1334,7 @@ class AxesAssemblySymmetric(AxesAssembly):
         )
         labels_minus = self._label_actors_symmetric
         vector_position_minus = self._get_offset_label_position_vectors(label_position_minus)
-        for label, position in zip(labels_minus, vector_position_minus):
+        for label, position in zip(labels_minus, vector_position_minus, strict=False):
             label.relative_position = position
 
 
@@ -1558,7 +1560,7 @@ class PlanesAssembly(_XYZAssembly):
         self._planes = self._geometry_source.output
         self._plane_sources = self._geometry_source.sources
 
-        for actor, dataset in zip(self._plane_actors, self.planes):
+        for actor, dataset in zip(self._plane_actors, self.planes, strict=False):
             actor.mapper = pv.DataSetMapper(dataset=dataset)
 
         # Init label actors
@@ -1952,7 +1954,7 @@ class PlanesAssembly(_XYZAssembly):
             opacity, broadcast=True, dtype_out=float, to_tuple=True
         )
         self._opacity = valid_opacity
-        for actor, opacity_ in zip(self._plane_actors, valid_opacity):
+        for actor, opacity_ in zip(self._plane_actors, valid_opacity, strict=False):
             actor.prop.opacity = opacity_
 
     @property

--- a/pyvista/plotting/composite_mapper.py
+++ b/pyvista/plotting/composite_mapper.py
@@ -183,10 +183,6 @@ class BlockAttributes(_NoNewAttrMixin):
 
         If opacity has not been set this will be ``None``.
 
-        Warnings
-        --------
-        VTK 9.0.3 has a bug where changing the opacity to less than 1.0 also
-        changes the edge visibility on the block that is partially transparent.
 
         Examples
         --------
@@ -481,11 +477,7 @@ class CompositeAttributes(
 
         """
         try:
-            if vtk_version_info <= (9, 0, 3):  # pragma: no cover
-                vtk_ref = _vtk.reference(0)  # needed for <=9.0.3
-                block = self.DataObjectFromIndex(index, self._dataset, vtk_ref)  # type: ignore[arg-type]
-            else:
-                block = self.DataObjectFromIndex(index, self._dataset)
+            block = self.DataObjectFromIndex(index, self._dataset)
         except OverflowError:
             msg = f'Invalid block key: {index}'
             raise KeyError(msg) from None

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -963,7 +963,7 @@ class LookupTable(_NoNewAttrMixin, _vtk.DisableVtkSnakeCase, _vtk.vtkLookupTable
 
         vtk_str = self.GetAnnotations()
         values = [str(vtk_str.GetValue(ii)) for ii in range(n_items)]
-        return dict(zip(keys, values))
+        return dict(zip(keys, values, strict=False))
 
     @annotations.setter
     def annotations(self, values: dict[float, str] | None):

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-from typing import Optional
 from typing import cast
 
 import numpy as np
@@ -400,7 +399,7 @@ class _DataSetMapper(_BaseMapper):
     @property
     def dataset(self) -> pyvista.core.dataset.DataSet | None:  # numpydoc ignore=RT01
         """Return or set the dataset assigned to this mapper."""
-        return cast('Optional[pyvista.DataSet]', wrap(_mapper_get_data_set_input(self)))
+        return cast('pyvista.DataSet | None', wrap(_mapper_get_data_set_input(self)))
 
     @dataset.setter
     def dataset(

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -1235,7 +1235,7 @@ class BasePlotter(_BoundsSizeMixin, PickingHelper, WidgetHelper):
         # Inspired from Mayavi's version of Raymond Maple 3-lights illumination
         intensities = [1, 0.6, 0.5]
         all_angles = [(45.0, 45.0), (-30.0, -60.0), (-30.0, 60.0)]
-        for intensity, angles in zip(intensities, all_angles):
+        for intensity, angles in zip(intensities, all_angles, strict=False):
             light = pyvista.Light(light_type='camera light')
             light.intensity = intensity
             light.position = _to_pos(*angles)

--- a/pyvista/plotting/prop_collection.py
+++ b/pyvista/plotting/prop_collection.py
@@ -104,7 +104,7 @@ class _PropCollection(MutableSequence[_vtk.vtkProp]):
         ]
 
     def items(self) -> Iterable[tuple[str, _vtk.vtkProp]]:
-        yield from zip(self.keys(), self)
+        yield from zip(self.keys(), self, strict=False)
 
     def __del__(self):
         self._prop_collection = None  # type: ignore[assignment]

--- a/pyvista/trame/jupyter.py
+++ b/pyvista/trame/jupyter.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 from typing import TYPE_CHECKING
+from typing import Concatenate
 from typing import Literal
 import warnings
 
@@ -13,7 +14,6 @@ from trame.widgets import html as html_widgets
 from trame.widgets import vtk as vtk_widgets
 from trame.widgets import vuetify as vuetify2_widgets
 from trame.widgets import vuetify3 as vuetify3_widgets
-from typing_extensions import Concatenate
 
 try:
     from ipywidgets.widgets import HTML

--- a/pyvista/typing/mypy_plugin.py
+++ b/pyvista/typing/mypy_plugin.py
@@ -8,8 +8,8 @@ import importlib.util
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
     from typing import Any
-    from typing import Callable
 
     from mypy.plugin import ClassDefContext
     from mypy.types import Instance

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,6 @@ from inspect import Signature
 import os
 import platform
 import re
-from typing import Optional
-from typing import Union
 
 import numpy as np
 from numpy.random import default_rng
@@ -363,25 +361,25 @@ def pytest_runtest_setup(item: pytest.Item):
                 Parameter(
                     'args',
                     kind=Parameter.VAR_POSITIONAL,
-                    annotation=Union[int, tuple[int]],
+                    annotation=int | tuple[int],
                 ),
                 Parameter(
                     'at_least',
                     kind=Parameter.KEYWORD_ONLY,
-                    annotation=Optional[tuple[int]],
+                    annotation=tuple[int] | None,
                     default=None,
                 ),
                 Parameter(
                     'less_than',
                     kind=Parameter.KEYWORD_ONLY,
                     default=None,
-                    annotation=Optional[tuple[int]],
+                    annotation=tuple[int] | None,
                 ),
                 Parameter(
                     'reason',
                     kind=Parameter.KEYWORD_ONLY,
                     default=None,
-                    annotation=Optional[str],
+                    annotation=str | None,
                 ),
             ]
         )
@@ -460,13 +458,13 @@ def pytest_runtest_setup(item: pytest.Item):
                     p := 'processor',
                     kind=Parameter.KEYWORD_ONLY,
                     default=None,
-                    annotation=Union[str, None],
+                    annotation=str | None,
                 ),
                 Parameter(
                     m := 'machine',
                     kind=Parameter.KEYWORD_ONLY,
                     default=None,
-                    annotation=Union[str, None],
+                    annotation=str | None,
                 ),
             ]
         )

--- a/tests/core/test_cells.py
+++ b/tests/core/test_cells.py
@@ -174,7 +174,7 @@ def test_cell_type_is_inside_enum(cell):
     assert cell.type in CellType
 
 
-@pytest.mark.parametrize(('cell', 'type_'), zip(cells, types), ids=cell_ids)
+@pytest.mark.parametrize(('cell', 'type_'), zip(cells, types, strict=False), ids=cell_ids)
 def test_cell_type(cell, type_):
     assert cell.type == type_
 
@@ -184,22 +184,22 @@ def test_cell_is_linear(cell):
     assert cell.is_linear
 
 
-@pytest.mark.parametrize(('cell', 'dim'), zip(cells, dims), ids=cell_ids)
+@pytest.mark.parametrize(('cell', 'dim'), zip(cells, dims, strict=False), ids=cell_ids)
 def test_cell_dimension(cell, dim):
     assert cell.dimension == dim
 
 
-@pytest.mark.parametrize(('cell', 'np'), zip(cells, npoints), ids=cell_ids)
+@pytest.mark.parametrize(('cell', 'np'), zip(cells, npoints, strict=False), ids=cell_ids)
 def test_cell_n_points(cell, np):
     assert cell.n_points == np
 
 
-@pytest.mark.parametrize(('cell', 'nf'), zip(cells, nfaces), ids=cell_ids)
+@pytest.mark.parametrize(('cell', 'nf'), zip(cells, nfaces, strict=False), ids=cell_ids)
 def test_cell_n_faces(cell, nf):
     assert cell.n_faces == nf
 
 
-@pytest.mark.parametrize(('cell', 'ne'), zip(cells, nedges), ids=cell_ids)
+@pytest.mark.parametrize(('cell', 'ne'), zip(cells, nedges, strict=False), ids=cell_ids)
 def test_cell_n_edges(cell, ne):
     assert cell.n_edges == ne
 
@@ -278,8 +278,12 @@ def test_cell_faces(cell):
 @pytest.mark.parametrize('grid', grids, ids=ids)
 def test_cell_bounds(grid):
     assert isinstance(grid.get_cell(0).bounds, tuple)
-    assert all(bc >= bg for bc, bg in zip(grid.get_cell(0).bounds[::2], grid.bounds[::2]))
-    assert all(bc <= bg for bc, bg in zip(grid.get_cell(0).bounds[1::2], grid.bounds[1::2]))
+    assert all(
+        bc >= bg for bc, bg in zip(grid.get_cell(0).bounds[::2], grid.bounds[::2], strict=False)
+    )
+    assert all(
+        bc <= bg for bc, bg in zip(grid.get_cell(0).bounds[1::2], grid.bounds[1::2], strict=False)
+    )
 
 
 @pytest.mark.parametrize('grid', grids, ids=ids)
@@ -300,12 +304,12 @@ def test_cell_center_value():
     assert np.allclose(mesh.get_cell(0).center, [0.5, np.sqrt(3) / 6, 0.0], rtol=1e-8, atol=1e-8)
 
 
-@pytest.mark.parametrize(('cell', 'type_'), zip(cells, types), ids=cell_ids)
+@pytest.mark.parametrize(('cell', 'type_'), zip(cells, types, strict=False), ids=cell_ids)
 def test_str(cell, type_):
     assert str(type_) in str(cell)
 
 
-@pytest.mark.parametrize(('cell', 'type_'), zip(cells, types), ids=cell_ids)
+@pytest.mark.parametrize(('cell', 'type_'), zip(cells, types, strict=False), ids=cell_ids)
 def test_repr(cell, type_):
     assert str(type_) in repr(cell)
 

--- a/tests/core/test_composite.py
+++ b/tests/core/test_composite.py
@@ -594,7 +594,7 @@ def test_transform_filter(ant, sphere, airplane, tetbeam, inplace):
     keys_after = output.keys()
 
     assert (output is multi) == inplace
-    for block_in, block_out in zip(multi, output):
+    for block_in, block_out in zip(multi, output, strict=False):
         assert (block_in is block_out) == inplace or (block_in is None)
     assert np.allclose(bounds_before + NUMBER, bounds_after)
     assert n_blocks_before == n_blocks_after
@@ -1058,8 +1058,8 @@ def test_multiblock_partitioned_zip(container):
     # Test `__iter__` and `__next__` inheritance
     list_ = [None, None]
     composite = container(list_)
-    zipped_container = list(zip(composite, composite))
-    zipped_list = list(zip(list_, list_))
+    zipped_container = list(zip(composite, composite, strict=False))
+    zipped_list = list(zip(list_, list_, strict=False))
 
     assert len(zipped_container) == len(zipped_list)
     assert len(zipped_container[0]) == len(zipped_list[0])
@@ -1428,7 +1428,7 @@ def test_flatten_copy(multiblock_all, copy):
 
     multi_out = multiblock_all.flatten(copy=copy)
     assert multi_in is not multi_out
-    for block_in, block_out in zip(multi_in, multi_out):
+    for block_in, block_out in zip(multi_in, multi_out, strict=False):
         assert block_in == block_out
         assert (block_in is block_out) == (not copy)
 
@@ -1471,7 +1471,7 @@ def test_generic_filter_inplace(multiblock_all_with_nested_and_none, inplace):
     flat_output = output.flatten(copy=False, check_duplicate_keys=False)
 
     assert flat_inputs.n_blocks == flat_output.n_blocks
-    for block_in, block_out in zip(flat_inputs, flat_output):
+    for block_in, block_out in zip(flat_inputs, flat_output, strict=False):
         assert ((block_in is block_out) == inplace) or block_out is None
 
     # Test root MultiBlock

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -393,7 +393,7 @@ def test_pickle_multiprocessing(datasets, pickle_format):
     pv.set_pickle_format(pickle_format)
     with multiprocessing.Pool(2) as p:
         res = p.map(n_points, datasets)
-    for r, dataset in zip(res, datasets):
+    for r, dataset in zip(res, datasets, strict=False):
         assert r == dataset.n_points
 
 

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -587,7 +587,7 @@ def test_cell_quality_return_type(multiblock_all_with_nested_and_none):
     iter_in = multiblock_all_with_nested_and_none.recursive_iterator()
     qual = multiblock_all_with_nested_and_none.cell_quality([SHAPE])
     iter_out = qual.recursive_iterator()
-    for block_in, block_out in zip(iter_in, iter_out):
+    for block_in, block_out in zip(iter_in, iter_out, strict=False):
         assert type(block_in) is type(block_out)
 
 

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -163,7 +163,7 @@ def test_clip_scalar_filter(datasets, both, invert):
             assert len(clps) == 1
             expect_les = (invert,)
 
-        for clp, expect_le in zip(clps, expect_les):
+        for clp, expect_le in zip(clps, expect_les, strict=False):
             assert clp is not None
             if isinstance(dataset, pv.PolyData):
                 assert isinstance(clp, pv.PolyData)
@@ -2035,7 +2035,7 @@ def extract_values_values():
         np.array(range(10)),
     ]
 
-    return list(zip(point_values, cell_values))
+    return list(zip(point_values, cell_values, strict=False))
 
 
 @pytest.mark.parametrize('preference', ['point', 'cell'])
@@ -2219,7 +2219,7 @@ def test_split_values_extract_values_component(
     # Convert to polydata to test volume
     multiblock = multiblock.as_polydata_blocks()
     assert expected_n_blocks == len(expected_volume)
-    for block, volume in zip(multiblock, expected_volume):
+    for block, volume in zip(multiblock, expected_volume, strict=False):
         assert np.isclose(block.volume, volume)
 
 
@@ -2415,7 +2415,7 @@ def test_extract_values_component_values_split_unique(
     assert extracted.n_blocks == len(COLORS_LIST)
     assert (
         np.array_equal(block['colors'], [color, color])
-        for block, color in zip(extracted, COLORS_LIST)
+        for block, color in zip(extracted, COLORS_LIST, strict=False)
     )
 
 
@@ -3998,7 +3998,7 @@ def test_color_labels_return_dict(labeled_image, color_type):
     input_keys = list(range(len(input_colors)))
     assert set(expected_keys) < set(input_keys)
 
-    mapping_in = dict(zip(input_keys, input_colors))
+    mapping_in = dict(zip(input_keys, input_colors, strict=False))
     colored_mesh, mapping_out = labeled_image.color_labels(
         mapping_in, return_dict=True, color_type=color_type
     )

--- a/tests/core/test_geometric_objects.py
+++ b/tests/core/test_geometric_objects.py
@@ -776,6 +776,7 @@ def test_ellipse():
         range(5),
         [4, 8, 6, 12, 20],
         [4, 6, 8, 20, 12],
+        strict=False,
     ),
 )
 def test_platonic_solids(kind_str, kind_int, n_vertices, n_faces):

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -493,6 +493,7 @@ def test_points_to_cells(uniform_many_scalars, active_scalars, copy):
     for array_in, array_out in zip(
         point_voxel_image.point_data.keys(),
         cell_voxel_image.cell_data.keys(),
+        strict=False,
     ):
         shares_memory = np.shares_memory(point_voxel_image[array_in], cell_voxel_image[array_out])
         assert not shares_memory if copy else shares_memory
@@ -525,6 +526,7 @@ def test_cells_to_points(uniform_many_scalars, active_scalars, copy):
     for array_in, array_out in zip(
         cell_voxel_image.cell_data.keys(),
         point_voxel_image.point_data.keys(),
+        strict=False,
     ):
         shares_memory = np.shares_memory(cell_voxel_image[array_in], point_voxel_image[array_out])
         assert not shares_memory if copy else shares_memory

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -588,7 +588,7 @@ def test_merge_main_has_priority(input_, main_has_priority):
         """Return True if scalars on two meshes only differ by point order."""
         return all(
             new_val == this.point_data[scalars_name][j]
-            for point, new_val in zip(that.points, that.point_data[scalars_name])
+            for point, new_val in zip(that.points, that.point_data[scalars_name], strict=False)
             for j in (this.points == point).all(-1).nonzero()
         )
 

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -281,7 +281,7 @@ def test_ensightreader_timepoints():
     mesh_3 = reader.read()
 
     # assert all the data is different
-    for m_1, m_3 in zip(mesh_1, mesh_3):
+    for m_1, m_3 in zip(mesh_1, mesh_3, strict=False):
         assert not all(m_1['DENS'] == m_3['DENS'])
 
     reader.set_active_time_point(0)

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -277,7 +277,7 @@ def test_read_force_ext(tmpdir):
     )
 
     dummy_extension = '.dummy'
-    for fname, type_ in zip(fnames, types):
+    for fname, type_ in zip(fnames, types, strict=False):
         path = Path(fname)
         root = str(path.parent / path.stem)
         original_ext = path.suffix

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -624,12 +624,12 @@ def test_check_instance(obj, classinfo, allow_subclass, name):
 
 def test_check_type():
     check_type(0, int, name='abc')
-    check_type(0, Union[int])
+    check_type(0, int)
     with pytest.raises(TypeError):
         check_type('str', int)
     with pytest.raises(TypeError):
         check_type(0, int, name=1)
-    check_type(0, Union[int, float])
+    check_type(0, int | float)
 
 
 @pytest.mark.skipif(
@@ -637,7 +637,7 @@ def test_check_type():
     reason='Union type input requires python3.10 or higher',
 )
 def test_check_type_union():
-    check_type(0, Union[int, float])
+    check_type(0, int | float)
 
 
 def test_check_string():
@@ -807,8 +807,6 @@ def test_check_sorted(shape, axis, ascending, strict):
     arr_strict_ascending = np.arange(num_elements).reshape(shape)
 
     # needed to support numpy <1.25
-    # needed to support vtk 9.0.3
-    # check for removal when support for vtk 9.0.3 is removed
     try:
         AxisError = np.exceptions.AxisError
     except AttributeError:

--- a/tests/doc/test_sphinx_gallery.py
+++ b/tests/doc/test_sphinx_gallery.py
@@ -4,7 +4,6 @@ from collections import Counter
 from pathlib import Path
 import re
 from typing import NamedTuple
-from typing import Optional
 
 import pytest
 
@@ -19,7 +18,7 @@ class _TestCaseTuple(NamedTuple):
     file_path: str
     has_crossref_to_api: bool
     has_crossref_from_api: bool
-    anchor: Optional[str]
+    anchor: str | None
 
 
 def find_files_with_extension(root_dir: str, ext: str) -> list[str]:

--- a/tests/plotting/test_charts.py
+++ b/tests/plotting/test_charts.py
@@ -549,7 +549,7 @@ def test_multicomp_plot_common(plot_f, request):
     plot.color_scheme = cs
     assert plot.color_scheme == cs
     assert plot._color_series.GetColorScheme() == COLOR_SCHEMES[cs]['id']
-    assert all(pc == cs for pc, cs in zip(plot.colors, cs_colors))
+    assert all(pc == cs for pc, cs in zip(plot.colors, cs_colors, strict=False))
     series_colors = [
         pv.Color(plot._color_series.GetColor(i)).float_rgba for i in range(len(cs_colors))
     ]
@@ -563,7 +563,7 @@ def test_multicomp_plot_common(plot_f, request):
     plot.colors = cs
     assert plot.color_scheme == cs
     plot.colors = colors
-    assert all(pc == c for pc, c in zip(plot.colors, colors))
+    assert all(pc == c for pc, c in zip(plot.colors, colors, strict=False))
     series_colors = [
         pv.Color(plot._color_series.GetColor(i)).float_rgba for i in range(len(colors))
     ]
@@ -692,7 +692,7 @@ def test_barplot(chart_2d, bar_plot):
     assert plot._chart == weakref.proxy(chart_2d)
     assert np.allclose(plot.x, x)
     assert np.allclose(plot.y, y)
-    assert all(pc == ci for pc, ci in zip(plot.colors, c))
+    assert all(pc == ci for pc, ci in zip(plot.colors, c, strict=False))
     assert plot.orientation == ori
     assert plot.labels == l
 
@@ -737,7 +737,7 @@ def test_stackplot(chart_2d, stack_plot):
     assert plot._chart == weakref.proxy(chart_2d)
     assert np.allclose(plot.x, x)
     assert np.allclose(plot.ys, ys)
-    assert all(pc == ci for pc, ci in zip(plot.colors, c))
+    assert all(pc == ci for pc, ci in zip(plot.colors, c, strict=False))
     assert plot.labels == l
 
     # Test single comp constructor

--- a/tests/plotting/test_colors.py
+++ b/tests/plotting/test_colors.py
@@ -76,7 +76,7 @@ def test_color():
         assert pv.Color(h_prefix + h) == i_rgba
     # Check dict
     for channels in itertools.product(*pv.Color.CHANNEL_NAMES):
-        dct = dict(zip(channels, i_rgba))
+        dct = dict(zip(channels, i_rgba, strict=False))
         assert pv.Color(dct) == i_rgba
     # Check opacity
     for opacity in (i_opacity, f_opacity, h_opacity):
@@ -101,7 +101,7 @@ def test_color():
     assert pv.Color('#bcbcbcbc').srgb_to_linear() == '#80808080'
     # Check iteration and indexing
     c = pv.Color(i_rgba)
-    assert all(ci == fi for ci, fi in zip(c, f_rgba))
+    assert all(ci == fi for ci, fi in zip(c, f_rgba, strict=False))
     for i, cnames in enumerate(pv.Color.CHANNEL_NAMES):
         assert c[i] == f_rgba[i]
         assert all(c[i] == c[cname] for cname in cnames)
@@ -185,21 +185,21 @@ def pytest_generate_tests(metafunc):
         color_names = list(CSS4_COLORS.keys())
         color_values = list(CSS4_COLORS.values())
 
-        test_cases = zip(color_names, color_values)
+        test_cases = zip(color_names, color_values, strict=False)
         metafunc.parametrize('css4_color', test_cases, ids=color_names)
 
     if 'tab_color' in metafunc.fixturenames:
         color_names = list(TABLEAU_COLORS.keys())
         color_values = list(TABLEAU_COLORS.values())
 
-        test_cases = zip(color_names, color_values)
+        test_cases = zip(color_names, color_values, strict=False)
         metafunc.parametrize('tab_color', test_cases, ids=color_names)
 
     if 'vtk_color' in metafunc.fixturenames:
         color_names = list(pv.plotting.colors._VTK_COLORS.keys())
         color_values = list(pv.plotting.colors._VTK_COLORS.values())
 
-        test_cases = zip(color_names, color_values)
+        test_cases = zip(color_names, color_values, strict=False)
         metafunc.parametrize('vtk_color', test_cases, ids=color_names)
 
     if 'color_synonym' in metafunc.fixturenames:

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -2564,12 +2564,12 @@ def test_index_vs_loc():
     # index_to_loc valid cases
     vals = [0, 2, 4]
     expecteds = [(0, 0), (0, 2), (1, 1)]
-    for val, expected in zip(vals, expecteds):
+    for val, expected in zip(vals, expecteds, strict=False):
         assert tuple(pl.renderers.index_to_loc(val)) == expected
     # loc_to_index valid cases
     vals = [(0, 0), (0, 2), (1, 1)]
     expecteds = [0, 2, 4]
-    for val, expected in zip(vals, expecteds):
+    for val, expected in zip(vals, expecteds, strict=False):
         assert pl.renderers.loc_to_index(val) == expected
         assert pl.renderers.loc_to_index(expected) == expected
 
@@ -2864,9 +2864,10 @@ def test_chart_matplotlib_plot(verify_image_cache):
     alphas = [0.5 + i for i in range(5)]
     betas = [*reversed(alphas)]
     N = int(1e4)
-    data = [rng.beta(alpha, beta, N) for alpha, beta in zip(alphas, betas)]
+    data = [rng.beta(alpha, beta, N) for alpha, beta in zip(alphas, betas, strict=False)]
     labels = [
-        f'$\\alpha={alpha:.1f}\\,;\\,\\beta={beta:.1f}$' for alpha, beta in zip(alphas, betas)
+        f'$\\alpha={alpha:.1f}\\,;\\,\\beta={beta:.1f}$'
+        for alpha, beta in zip(alphas, betas, strict=False)
     ]
     ax.violinplot(data)
     ax.set_xticks(np.arange(1, 1 + len(labels)))
@@ -3112,8 +3113,6 @@ def test_plot_complex_value(plane, verify_image_cache):
     data += np.linspace(0, 1, plane.n_points) * -1j
 
     # needed to support numpy <1.25
-    # needed to support vtk 9.0.3
-    # check for removal when support for vtk 9.0.3 is removed
     try:
         ComplexWarning = np.exceptions.ComplexWarning
     except AttributeError:
@@ -3319,7 +3318,7 @@ def test_plot_composite_preference_cell(multiblock_poly, verify_image_cache):
 
 @pytest.mark.skip_windows('Test fails on Windows because of opacity')
 @skip_lesser_9_4_X
-def test_plot_composite_poly_scalars_opacity(multiblock_poly, verify_image_cache):
+def test_plot_composite_poly_scalars_opacity(multiblock_poly):
     pl = pv.Plotter()
 
     actor, mapper = pl.add_composite(
@@ -3336,9 +3335,6 @@ def test_plot_composite_poly_scalars_opacity(multiblock_poly, verify_image_cache
 
     pl.camera_position = 'xy'
 
-    # 9.0.3 has a bug where VTK changes the edge visibility on blocks that are
-    # also opaque. Don't verify the image of that version.
-    verify_image_cache.skip = pv.vtk_version_info == (9, 0, 3)
     pl.show()
 
 
@@ -3366,12 +3362,9 @@ def test_plot_composite_poly_no_scalars(multiblock_poly):
         lighting=False,
     )
 
-    # Note: set the camera position before making the blocks invisible to be
-    # consistent between 9.0.3 and 9.1+
+    # Note: set the camera position before making the blocks invisible
     #
-    # 9.0.3 still considers invisible blocks when determining camera bounds, so
-    # there will be some empty space where the invisible block is for 9.0.3,
-    # while 9.1.0 ignores invisible blocks when computing camera bounds.
+    # VTK 9.1.0+ ignores invisible blocks when computing camera bounds.
     pl.camera_position = 'xy'
     mapper.block_attr[2].color = 'blue'
     mapper.block_attr[3].visible = False
@@ -3435,8 +3428,6 @@ def test_plot_composite_poly_complex(multiblock_poly):
     multi_multi = pv.MultiBlock([multiblock_poly, multiblock_poly])
 
     # needed to support numpy <1.25
-    # needed to support vtk 9.0.3
-    # check for removal when support for vtk 9.0.3 is removed
     try:
         ComplexWarning = np.exceptions.ComplexWarning
     except AttributeError:
@@ -3655,7 +3646,7 @@ def test_charts_sin():
     chart.show()
 
 
-def test_lookup_table(verify_image_cache):
+def test_lookup_table():
     lut = pv.LookupTable('viridis')
     lut.n_values = 8
     lut.below_range_color = 'black'
@@ -3663,26 +3654,20 @@ def test_lookup_table(verify_image_cache):
     lut.nan_color = 'r'
     lut.nan_opacity = 0.5
 
-    # There are minor variations within 9.0.3 that slightly invalidate the
-    # image cache.
-    verify_image_cache.skip = pv.vtk_version_info == (9, 0, 3)
     lut.plot()
 
 
-def test_lookup_table_nan_hidden(verify_image_cache):
+def test_lookup_table_nan_hidden():
     lut = pv.LookupTable('viridis')
     lut.n_values = 8
     lut.below_range_color = 'black'
     lut.above_range_color = 'grey'
     lut.nan_opacity = 0
 
-    # There are minor variations within 9.0.3 that slightly invalidate the
-    # image cache.
-    verify_image_cache.skip = pv.vtk_version_info == (9, 0, 3)
     lut.plot()
 
 
-def test_lookup_table_above_below_opacity(verify_image_cache):
+def test_lookup_table_above_below_opacity():
     lut = pv.LookupTable('viridis')
     lut.n_values = 8
     lut.below_range_color = 'blue'
@@ -3692,9 +3677,6 @@ def test_lookup_table_above_below_opacity(verify_image_cache):
     lut.nan_color = 'r'
     lut.nan_opacity = 0.5
 
-    # There are minor variations within 9.0.3 that slightly invalidate the
-    # image cache.
-    verify_image_cache.skip = pv.vtk_version_info == (9, 0, 3)
     lut.plot()
 
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -64,7 +64,9 @@ def pytest_generate_tests(metafunc):
                 return any(base.__name__[:3].lower() == 'vtk' for base in bases)
 
             inherits_from_vtk = {
-                name: cls for name, cls in zip(class_names, class_types) if inherits_from_vtk(cls)
+                name: cls
+                for name, cls in zip(class_names, class_types, strict=False)
+                if inherits_from_vtk(cls)
             }
             assert inherits_from_vtk
             return inherits_from_vtk
@@ -84,7 +86,7 @@ def pytest_generate_tests(metafunc):
 
         class_map = {
             name: cls
-            for name, cls in zip(class_names, class_types)
+            for name, cls in zip(class_names, class_types, strict=False)
             if not name.startswith('_') and not issubclass(cls, tuple(SKIP_SUBCLASS))
         }
         metafunc.parametrize('pyvista_class', list(class_map.values()), ids=list(class_map.keys()))


### PR DESCRIPTION
## Summary
This PR reapplies the changes from #7693 which was initially merged but then reverted due to timing concerns for the 0.46 release. Now that we're on 0.47.dev0, we can safely apply these changes.

- Drop support for Python 3.9 (minimum now Python 3.10)
- Drop support for VTK 9.0.3 (minimum now VTK 9.1.0)
- Update CI configuration, documentation, and type annotations accordingly

## Changes
- **Python version**: Remove Python 3.9 from project classifiers and CI test matrix, update minimum to 3.10
- **VTK version**: Drop VTK 9.0.3 support and set minimum to 9.1.0
- **Type annotations**: Clean up compatibility code and update type hints for Python 3.10+
- **Documentation**: Update installation docs to reflect new minimum requirements
- **CI/CD**: Remove Python 3.9 from test matrix and update deployment to use Python 3.10

## References
- Original PR: #7693
- Revert PR: #7785

## Test plan
- [ ] CI tests pass with Python 3.10+ only
- [ ] Documentation builds correctly
- [ ] Type checking passes
- [ ] All examples run successfully