### PR TITLE
Use PEP 673 Self type for methods returning self instances

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -186,7 +186,7 @@ class _PointSet(DataSet):
         target.RemoveGhostCells()
         return target
 
-    def points_to_double(self) -> _PointSet:
+    def points_to_double(self) -> Self:
         """Convert the points datatype to double precision.
 
         Returns
@@ -2791,7 +2791,7 @@ class StructuredGrid(PointGrid, StructuredGridFilters, _vtk.vtkStructuredGrid):
         return self.extract_subset(voi, rate, boundary=False)
 
     @_deprecate_positional_args(allowed=['ind'])
-    def hide_cells(self, ind, inplace: bool = False):  # noqa: FBT001, FBT002
+    def hide_cells(self, ind, inplace: bool = False) -> Self:  # noqa: FBT001, FBT002
         """Hide cells without deleting them.
 
         Hides cells by setting the ghost_cells array to ``HIDDEN_CELL``.
@@ -3313,7 +3313,7 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
         grid.save(filename, binary=binary)
 
     @_deprecate_positional_args(allowed=['ind'])
-    def hide_cells(self, ind: VectorLike[int], inplace: bool = False) -> ExplicitStructuredGrid:  # noqa: FBT001, FBT002
+    def hide_cells(self, ind: VectorLike[int], inplace: bool = False) -> Self:  # noqa: FBT001, FBT002
         """Hide specific cells.
 
         Hides cells by setting the ghost cell array to ``HIDDENCELL``.
@@ -3357,7 +3357,7 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
         return grid
 
     @_deprecate_positional_args
-    def show_cells(self, inplace: bool = False) -> ExplicitStructuredGrid:  # noqa: FBT001, FBT002
+    def show_cells(self, inplace: bool = False) -> Self:  # noqa: FBT001, FBT002
         """Show hidden cells.
 
         Shows hidden cells by setting the ghost cell array to ``0``
@@ -3726,7 +3726,7 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
         return sorted(indices)
 
     @_deprecate_positional_args
-    def compute_connectivity(self, inplace: bool = False) -> ExplicitStructuredGrid:  # noqa: FBT001, FBT002
+    def compute_connectivity(self, inplace: bool = False) -> Self:  # noqa: FBT001, FBT002
         """Compute the faces connectivity flags array.
 
         This method checks the faces connectivity of the cells with
@@ -3775,7 +3775,7 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
             return grid
 
     @_deprecate_positional_args
-    def compute_connections(self, inplace: bool = False):  # noqa: FBT001, FBT002
+    def compute_connections(self, inplace: bool = False) -> Self:  # noqa: FBT001, FBT002
         """Compute an array with the number of connected cell faces.
 
         This method calculates the number of topological cell


### PR DESCRIPTION
## Summary
- Improves type annotations by using [PEP 673](https://peps.python.org/pep-0673/) `Self` type for methods that return their own instance
- Provides better type safety and more precise type inference for subclasses
- Uses existing `typing_extensions.Self` import for Python 3.9+ compatibility

## Compatibility
Supports Python 3.9+ using `typing_extensions.Self` as already imported throughout the codebase.