### PR TITLE
Fix VTK error when setting axis visibility

### DIFF
--- a/pyvista/plotting/cube_axes_actor.py
+++ b/pyvista/plotting/cube_axes_actor.py
@@ -573,7 +573,7 @@ class CubeAxesActor(
             else:
                 self.SetAxisLabels(0, self._empty_str)
         else:
-            self.SetXTitle('')
+            self.SetXTitle(' ')
             self.SetAxisLabels(0, self._empty_str)
 
     def _update_y_labels(self):
@@ -591,7 +591,7 @@ class CubeAxesActor(
             else:
                 self.SetAxisLabels(1, self._empty_str)
         else:
-            self.SetYTitle('')
+            self.SetYTitle(' ')
             self.SetAxisLabels(1, self._empty_str)
 
     def _update_z_labels(self):
@@ -609,7 +609,7 @@ class CubeAxesActor(
             else:
                 self.SetAxisLabels(2, self._empty_str)
         else:
-            self.SetZTitle('')
+            self.SetZTitle(' ')
             self.SetAxisLabels(2, self._empty_str)
 
     @property


### PR DESCRIPTION
Running:

```py
import pyvista as pv

pl = pv.Plotter()
pl.add_mesh(pv.Sphere())
pl.show_bounds(show_xaxis=False)
pl.show()
```

Results in:

```
2025-08-09 15:20:07.715 (  19.200s) [    7F6C4BCB5B80]      vtkVectorText.cxx:54     ERR| vtkVectorText (0x562f7b136700): Text is not set!
2025-08-09 15:20:07.715 (  19.200s) [    7F6C4BCB5B80]       vtkExecutive.cxx:729    ERR| vtkCompositeDataPipeline (0x562f78dec8c0): Algorithm vtkVectorText (0x562f7b136700) returned failure for request: vtkInformation (0x562f74e0f500)
  Debug: Off
  Modified Time: 512959
  Reference Count: 1
  Registered Events: (none)
  Request: REQUEST_DATA
  FROM_OUTPUT_PORT: 0
  ALGORITHM_AFTER_FORWARD: 1
  FORWARD_DIRECTION: 0
```

Issue is in `SetXTitle('')`. Apparently VTK doesn't like empty strings. We can keep the same behavior but avoid the VTK error by simply changing it to `SetXTitle(' ')`.
