### PR TITLE
Remove unused vtk references

### DIFF
--- a/doc/source/api/core/pointsets.rst
+++ b/doc/source/api/core/pointsets.rst
@@ -81,12 +81,6 @@ classes inherit all methods from their corresponding VTK :vtk:`vtkPointSet`,
    pyvista.StructuredGrid
    pyvista.ExplicitStructuredGrid
 
-.. _vtkPointSet: https://www.vtk.org/doc/nightly/html/classvtkPointSet.html
-.. _vtkPolyData: https://www.vtk.org/doc/nightly/html/classvtkPolyData.html
-.. _vtkUnstructuredGrid: https://www.vtk.org/doc/nightly/html/classvtkUnstructuredGrid.html
-.. _vtkStructuredGrid: https://www.vtk.org/doc/nightly/html/classvtkStructuredGrid.html
-.. _vtkExplicitStructuredGrid: https://vtk.org/doc/nightly/html/classvtkExplicitStructuredGrid.html
-
 
 PolyData Creation
 -----------------

--- a/doc/source/user-guide/vtk_to_pyvista.rst
+++ b/doc/source/user-guide/vtk_to_pyvista.rst
@@ -337,9 +337,3 @@ the flexibility of PyVista and the raw power of VTK.
 .. note::
    You can use :func:`pyvista.Polygon` for a one line replacement of
    the above VTK code.
-
-
-.. _vtkDataArray: https://vtk.org/doc/nightly/html/classvtkDataArray.html
-.. _vtkPolyData: https://vtk.org/doc/nightly/html/classvtkPolyData.html
-.. _vtkImageData: https://vtk.org/doc/nightly/html/classvtkImageData.html
-.. _vtkpoints: https://vtk.org/doc/nightly/html/classvtkPoints.html


### PR DESCRIPTION
### Overview

These links are left over from https://github.com/pyvista/pyvista/pull/7529 and were replaced by use of the `:vtk:` role.