### PR TITLE
Update docker.rst

### DIFF
--- a/doc/source/extras/docker.rst
+++ b/doc/source/extras/docker.rst
@@ -42,6 +42,7 @@ Clone PyVista and build it to create your own customized docker image.
 .. code-block:: bash
 
   git clone https://github.com/pyvista/pyvista
+  cd pyvista
   pip install build
   python -m build --sdist
   IMAGE=my-pyvista-jupyterlab


### PR DESCRIPTION
Updated instructions to "Create your own Docker Container with PyVista"

### Overview

Updating the instructions to build a Docker Container. I found the previous instructions out of date with the repository './docker/README.md'. This should address the fix and mean readthedocs is functional again (not requiring a further dive into the repository)


### Details

Previous instruction were failing because no pyvist tarball was being built and couldn't be found, thus the `docker build` failed.