### PR TITLE
add flaky test decorator to dataset_loader

### DIFF
--- a/tests/examples/test_downloads.py
+++ b/tests/examples/test_downloads.py
@@ -11,6 +11,7 @@ from retry_requests import retry
 import pyvista as pv
 from pyvista import examples
 from pyvista.examples import downloads
+from tests.conftest import flaky_test
 from tests.examples.test_dataset_loader import DatasetLoaderTestCase
 from tests.examples.test_dataset_loader import _generate_dataset_loader_test_cases_from_module
 from tests.examples.test_dataset_loader import _get_mismatch_fail_msg
@@ -52,6 +53,7 @@ def _is_valid_url(url):
         return True
 
 
+@flaky_test(times=3)  # sometimes fails due to GitHub
 def test_dataset_loader_source_url_blob(test_case: DatasetLoaderTestCase):
     try:
         # Skip test if not loadable

--- a/tests/examples/test_downloads.py
+++ b/tests/examples/test_downloads.py
@@ -53,7 +53,8 @@ def _is_valid_url(url):
         return True
 
 
-@flaky_test(times=3)  # sometimes fails due to GitHub
+# sometimes fails due to GitHub server issues
+@flaky_test(times=3, exceptions=(AssertionError, pytest.fail.Exception))
 def test_dataset_loader_source_url_blob(test_case: DatasetLoaderTestCase):
     try:
         # Skip test if not loadable


### PR DESCRIPTION
### Overview

Just had a failure here:
https://github.com/pyvista/pyvista/actions/runs/16941506418/attempts/1?pr=7813

Seems like we need to allow for retries for `test_dataset_loader_source_url_blob`.

Also, did we consider https://github.com/pytest-dev/pytest-rerunfailures when creating our own? Seems like we could enable a global option with `pytest-rerunfailures`, which might be nice, but it's not necessary.
