### PR TITLE
Update CODEOWNERS with pyvista/ci-reviewers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 /CODE_OF_CONDUCT.md                                 @pyvista/admin
 /CODEOWNERS                                         @pyvista/admin
 /.github/workflows/auto-approve.yml                 @pyvista/admin
-/.github/workflows/testing-and-deployment.yml       @banesullivan
-/.github/workflows/docs.yml                         @banesullivan
-/.github/workflows/docker-package.yml               @banesullivan
-/.github/workflows/vtk-pre-test.yml                 @banesullivan
+/.github/workflows/testing-and-deployment.yml       @pyvista/ci-reviewers
+/.github/workflows/docs.yml                         @pyvista/ci-reviewers
+/.github/workflows/docker-package.yml               @pyvista/ci-reviewers
+/.github/workflows/vtk-pre-test.yml                 @pyvista/ci-reviewers


### PR DESCRIPTION
Adds a team to manage who can review CI changes so that it is not just me.

I added @akaszynski to @pyvista/ci-reviewers 