### PR TITLE
Fix filtered warning for vtk-data cache miss

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,7 +221,7 @@ filterwarnings = [
   "ignore:'mode' parameter is deprecated and will be removed in Pillow 13:DeprecationWarning", # matplotlib toolbar icon creation with newer Pillow
   'ignore:.*A NumPy version .* is required for this version of SciPy.*:UserWarning',
   'ignore:.*Given trait value dtype "float64":UserWarning', # bogus numpy ABI warning (see numpy/#432)
-  'ignore:.*PYVISTA_VTK_DATA is not a valid directory.*:UserWarning',
+  'ignore:(?s).*PYVISTA_VTK_DATA is not a valid directory.*:\n.*:UserWarning',
   'ignore:.*The NumPy module was reloaded*:UserWarning', # bogus numpy ABI warning (see numpy/#432)
   'ignore:.*numpy.dtype size changed.*:RuntimeWarning', # bogus numpy ABI warning (see numpy/#432)
   'ignore:.*numpy.ufunc size changed.*:RuntimeWarning', # bogus numpy ABI warning (see numpy/#432)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,9 +219,9 @@ filterwarnings = [
   'error',
 
   "ignore:'mode' parameter is deprecated and will be removed in Pillow 13:DeprecationWarning", # matplotlib toolbar icon creation with newer Pillow
+  'ignore:(?s).*PYVISTA_VTK_DATA is not a valid directory.*:\n.*:UserWarning',
   'ignore:.*A NumPy version .* is required for this version of SciPy.*:UserWarning',
   'ignore:.*Given trait value dtype "float64":UserWarning', # bogus numpy ABI warning (see numpy/#432)
-  'ignore:(?s).*PYVISTA_VTK_DATA is not a valid directory.*:\n.*:UserWarning',
   'ignore:.*The NumPy module was reloaded*:UserWarning', # bogus numpy ABI warning (see numpy/#432)
   'ignore:.*numpy.dtype size changed.*:RuntimeWarning', # bogus numpy ABI warning (see numpy/#432)
   'ignore:.*numpy.ufunc size changed.*:RuntimeWarning', # bogus numpy ABI warning (see numpy/#432)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,7 +219,7 @@ filterwarnings = [
   'error',
 
   "ignore:'mode' parameter is deprecated and will be removed in Pillow 13:DeprecationWarning", # matplotlib toolbar icon creation with newer Pillow
-  'ignore:(?s).*PYVISTA_VTK_DATA is not a valid directory.*:\n.*:UserWarning',
+  'ignore:(?s).*PYVISTA_VTK_DATA is not a valid directory.*:UserWarning',
   'ignore:.*A NumPy version .* is required for this version of SciPy.*:UserWarning',
   'ignore:.*Given trait value dtype "float64":UserWarning', # bogus numpy ABI warning (see numpy/#432)
   'ignore:.*The NumPy module was reloaded*:UserWarning', # bogus numpy ABI warning (see numpy/#432)


### PR DESCRIPTION
### Overview

See https://github.com/pyvista/pyvista/pull/7825#discussion_r2279554416

Need to update the regex to avoid test failure if there is a cache miss for `vtk-data`