### PR TITLE
Avoid download fetcher test side-effects

### DIFF
--- a/tests/examples/test_downloads.py
+++ b/tests/examples/test_downloads.py
@@ -140,27 +140,29 @@ def test_file_copier(tmpdir):
         examples.downloads._file_copier('not a file', output_file, None)
 
 
-def test_local_file_cache():
+def test_local_file_cache(tmp_path: Path):
     """Ensure that pyvista.examples.downloads can work with a local cache."""
     basename = Path(examples.planefile).name
     dirname = str(Path(examples.planefile).parent)
     downloads.FETCHER.registry[basename] = None
+    old_path = downloads.FETCHER.path
 
     try:
         downloads.FETCHER.base_url = dirname + '/'
         downloads.FETCHER.registry[basename] = None
         downloads._FILE_CACHE = True
+        downloads.FETCHER.path = tmp_path
         filename = downloads._download_and_read(basename, load=False)
         assert Path(filename).is_file()
 
         dataset = downloads._download_and_read(basename, load=True)
         assert isinstance(dataset, pv.DataSet)
-        Path(filename).unlink()
 
     finally:
         downloads.FETCHER.base_url = 'https://github.com/pyvista/vtk-data/raw/master/Data/'
         downloads._FILE_CACHE = False
         downloads.FETCHER.registry.pop(basename, None)
+        downloads.FETCHER.path = old_path
 
 
 @pytest.mark.parametrize('endswith', ['', 'Data', 'Data/'])


### PR DESCRIPTION
Edge case, but it's possible for multiple instances of python to be accessing the same cache and deleting the cached file simultaneously (unlikely, but it happened in https://github.com/pyvista/pyvista/pull/7828). It's also bad practice to be modifying files outside temporary directories anyway.