### PR TITLE
Fix `BoundsTuple.__repr__` with scientific notation

### DIFF
--- a/pyvista/core/_typing_core/_aliases.py
+++ b/pyvista/core/_typing_core/_aliases.py
@@ -84,7 +84,9 @@ class BoundsTuple(NamedTuple):
     def __repr__(self) -> str:
         # Split bounds at decimal and compute padding needed to the left of it
         dot = '.'
-        split_strings = [str(float(val)).split(dot) for val in self]
+        strings = [str(float(val)) for val in self]
+        has_dot = [dot in s for s in strings]
+        split_strings = [s.split(dot) for s in strings]
         pad_left = max(len(parts[0]) for parts in split_strings)
 
         # Iterate through fields and align values at the decimal
@@ -95,8 +97,12 @@ class BoundsTuple(NamedTuple):
         whitespace = (len(name) + 1) * ' '
         for i, items in enumerate(zip(fields, split_strings)):
             field, parts = items
-            left, right = parts
-            aligned = f'{left:>{pad_left}}{dot}{right}'
+            if has_dot[i]:
+                left, right = parts
+                aligned = f'{left:>{pad_left}}{dot}{right}'
+            else:
+                left = parts[0]
+                aligned = f'{left:>{pad_left}}'
             spacing = '' if i == 0 else whitespace
             comma = '' if i == len(fields) - 1 else ','
             lines.append(f'{spacing}{field:<{field_size}} = {aligned}{comma}')

--- a/tests/typing/test_return_type.py
+++ b/tests/typing/test_return_type.py
@@ -153,3 +153,14 @@ def test_center_tuple(class_with_center):
     # Test type annotations
     return_type = get_property_return_type(class_with_center.center)
     assert return_type == 'tuple[float, float, float]'
+
+
+def test_bounds_tuple_repr_scientific_notation():
+    actual = repr(pv.UnstructuredGrid().extract_cells(0).bounds)
+    expected = """BoundsTuple(x_min =  1e+299,
+            x_max = -1e+299,
+            y_min =  1e+299,
+            y_max = -1e+299,
+            z_min =  1e+299,
+            z_max = -1e+299)"""
+    assert actual == expected


### PR DESCRIPTION
### Overview

The current repr for `BoundsTuple` assumes there is a decimal in the stringified float(s), but this is not always the case. E.g. this example shows a mesh where the bounds use scientific notation:
``` py
import pyvista as pv
grid = pv.UnstructuredGrid().extract_cells(0)
repr(grid)
# UnstructuredGrid (0x1112236a0)
#   N Cells:    0
#   N Points:   0
#   X Bounds:   1.000e+299, -1.000e+299
#   Y Bounds:   1.000e+299, -1.000e+299
#   Z Bounds:   1.000e+299, -1.000e+299
#   N Arrays:   0
```

but then trying to show the bounds directly results in an error
``` py
repr(grid.bounds)
```
``` py
  File "/pyvista/core/_typing_core/_aliases.py", line 98, in __repr__
    left, right = parts
    ^^^^^^^^^^^
ValueError: not enough values to unpack (expected 2, got 1)
```

This PR fixes this.