### PR TITLE
Remove unnecessary pytest markers for VTK < 9.2

### DIFF
--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -65,7 +65,6 @@ def test_clip_filter(multiblock_all_with_nested_and_none, return_clipped, crinkl
                 assert isinstance(clip, pv.UnstructuredGrid)
 
 
-@pytest.mark.needs_vtk_version(9, 1, 0)
 @pytest.mark.parametrize('as_composite', [True, False])
 def test_clip_filter_pointset_no_points_removed(pointset, as_composite):
     n_points_in = pointset.n_points
@@ -378,7 +377,6 @@ def test_cell_centers_no_cell_data(cube):
     assert not cube.cell_centers(pass_cell_data=False).cell_data
 
 
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_cell_center_pointset(airplane):
     pointset = airplane.cast_to_pointset()
     result = pointset.cell_centers(progress_bar=True)

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1184,7 +1184,6 @@ def test_active_normals(sphere):
     assert mesh.active_normals.shape[0] == mesh.n_cells
 
 
-@pytest.mark.needs_vtk_version(9, 1, 0, reason='Requires VTK>=9.1.0 for a concrete PointSet class')
 def test_cast_to_pointset(sphere):
     sphere = sphere.elevation()
     pointset = sphere.cast_to_pointset()
@@ -1202,7 +1201,6 @@ def test_cast_to_pointset(sphere):
     assert not np.allclose(sphere.active_scalars, pointset.active_scalars)
 
 
-@pytest.mark.needs_vtk_version(9, 1, 0, reason='Requires VTK>=9.1.0 for a concrete PointSet class')
 def test_cast_to_pointset_implicit(uniform):
     pointset = uniform.cast_to_pointset(pass_cell_data=True)
     assert isinstance(pointset, pv.PointSet)

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -964,7 +964,6 @@ def connected_datasets_single_disconnected_cell(connected_datasets):
 )
 @pytest.mark.parametrize('label_regions', [True, False])
 @pytest.mark.parametrize('scalar_range', [True, False])
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_connectivity_inplace_and_output_type(
     datasets,
     dataset_index,
@@ -1015,7 +1014,6 @@ def test_connectivity_inplace_and_output_type(
     'extraction_mode',
     ['all', 'largest', 'specified', 'cell_seed', 'point_seed', 'closest'],
 )
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_connectivity_label_regions(datasets, dataset_index, extraction_mode):
     # the connectivity filter is known to output incorrectly sized scalars
     # test all modes and datasets for correct scalar size
@@ -1053,7 +1051,6 @@ def test_connectivity_label_regions(datasets, dataset_index, extraction_mode):
     assert conn.active_scalars_info[1] == active_scalars_info[1]
 
 
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_connectivity_raises(
     connected_datasets_single_disconnected_cell,
 ):
@@ -1096,7 +1093,6 @@ def test_connectivity_raises(
     ['all', 'largest', 'specified', 'cell_seed', 'point_seed', 'closest'],
 )
 @pytest.mark.parametrize('association', ['cell', 'point'])
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_connectivity_scalar_range(
     connected_datasets_single_disconnected_cell,
     dataset_index,
@@ -1132,7 +1128,6 @@ def test_connectivity_scalar_range(
     assert len(conn_with_full_range.array_names) == 3
 
 
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_connectivity_all(foot_bones):
     conn = foot_bones.connectivity('all')
     assert conn.n_cells == foot_bones.n_cells
@@ -1174,7 +1169,6 @@ def test_connectivity_all(foot_bones):
     )
 
 
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_connectivity_largest(foot_bones):
     conn = foot_bones.connectivity('largest')
     assert conn.n_cells == 598
@@ -1186,7 +1180,6 @@ def test_connectivity_largest(foot_bones):
     assert counts == [598]
 
 
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_connectivity_specified(foot_bones):
     # test all regions
     all_regions = list(range(26))
@@ -1212,7 +1205,6 @@ def test_connectivity_specified(foot_bones):
 
 
 @pytest.mark.parametrize('dataset_index', list(range(5)))
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_connectivity_specified_returns_empty(connected_datasets, dataset_index):
     dataset = connected_datasets[dataset_index]
     unused_region_id = 1
@@ -1221,7 +1213,6 @@ def test_connectivity_specified_returns_empty(connected_datasets, dataset_index)
     assert conn.n_points == 0
 
 
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_connectivity_point_seed(foot_bones):
     conn = foot_bones.connectivity('point_seed', point_ids=1598)
     assert conn.n_cells == 598
@@ -1236,7 +1227,6 @@ def test_connectivity_point_seed(foot_bones):
     assert np.array_equal(counts, [598, 360])
 
 
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_connectivity_cell_seed(foot_bones):
     conn = foot_bones.connectivity('cell_seed', cell_ids=3122)
     assert conn.n_cells == 598
@@ -1252,7 +1242,6 @@ def test_connectivity_cell_seed(foot_bones):
     assert np.array_equal(counts, [598, 360])
 
 
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_connectivity_closest_point(foot_bones):
     conn = foot_bones.connectivity('closest', closest_point=(-3.5, -0.5, -0.5))
     assert conn.n_cells == 598
@@ -2381,7 +2370,6 @@ component_mode_test_cases = [
     ('values', 'component_mode', 'expected', 'expected_invert'),
     component_mode_test_cases,
 )
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_extract_values_component_mode(
     point_cloud_colors,
     values,
@@ -2419,7 +2407,6 @@ def test_extract_values_component_mode(
         (pv.DataSetFilters.extract_values, dict(values='_unique', split=True)),
     ],
 )
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_extract_values_component_values_split_unique(
     point_cloud_colors_duplicates,
     dataset_filter,

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -607,7 +607,6 @@ def test_openfoamreader_arrays_time():
     assert reader.time_values == [0.0, 0.5, 1.0, 1.5, 2.0, 2.5]
 
 
-@pytest.mark.needs_vtk_version(9, 1, 0, reason='OpenFOAMReader GetTimeValue missing on vtk<9.1.0')
 def test_openfoamreader_active_time():
     reader = get_cavity_reader()
     assert reader.active_time_value == 0.0
@@ -795,7 +794,6 @@ def test_openfoam_case_type():
         reader.case_type = 'wrong_value'
 
 
-@pytest.mark.needs_vtk_version(9, 1)
 def test_read_cgns():
     filename = examples.download_cgns_structured(load=False)
     reader = pv.get_reader(filename)
@@ -969,7 +967,6 @@ def test_avsucd_reader():
     assert all([mesh.n_points, mesh.n_cells])
 
 
-@pytest.mark.needs_vtk_version(9, 1)
 def test_hdf_reader():
     filename = examples.download_can_crushed_hdf(load=False)
     reader = pv.get_reader(filename)

--- a/tests/core/test_unstructured_grid_filters.py
+++ b/tests/core/test_unstructured_grid_filters.py
@@ -79,7 +79,6 @@ def test_clean_grid(hexbeam):
     assert cleaned.n_points == 165
 
 
-@pytest.mark.needs_vtk_version(9, 2)
 @pytest.mark.parametrize('inplace', [True, False])
 @pytest.mark.parametrize('mesh_type', [pv.PolyData, pv.UnstructuredGrid])
 def test_remove_unused_points(mesh_type, inplace):

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -2431,7 +2431,6 @@ def _compute_unit_cell_quality(
 
 
 @parametrize('info', _CELL_QUALITY_INFO, ids=CELL_QUALITY_IDS)
-@pytest.mark.needs_vtk_version(9, 2)
 def test_cell_quality_info_valid_measures(info):
     # Ensure the computed measure is not null
     null_value = -1
@@ -2460,7 +2459,6 @@ def xfail_distortion_returns_one(info):
 
 
 @parametrize('info', _CELL_QUALITY_INFO, ids=CELL_QUALITY_IDS)
-@pytest.mark.needs_vtk_version(9, 2)
 def test_cell_quality_info_unit_cell_value(info):
     """Test that the actual computed measure for a unit cell matches the reported value."""
     xfail_wedge_negative_volume(info)
@@ -2471,7 +2469,6 @@ def test_cell_quality_info_unit_cell_value(info):
 
 
 @parametrize('info', _CELL_QUALITY_INFO, ids=CELL_QUALITY_IDS)
-@pytest.mark.needs_vtk_version(9, 2)
 def test_cell_quality_info_acceptable_range(info):
     """Test that the unit cell value is within the acceptable range."""
     # Some cells / measures have bugs and return invalid values and are expected to fail
@@ -2495,7 +2492,6 @@ def _replace_range_infinity(rng):
 
 
 @parametrize('info', _CELL_QUALITY_INFO, ids=CELL_QUALITY_IDS)
-@pytest.mark.needs_vtk_version(9, 2)
 def test_cell_quality_info_normal_range(info):
     """Test that the normal range is broader than the acceptable range."""
     acceptable_range = _replace_range_infinity(info.acceptable_range)
@@ -2506,7 +2502,6 @@ def test_cell_quality_info_normal_range(info):
 
 
 @parametrize('info', _CELL_QUALITY_INFO, ids=CELL_QUALITY_IDS)
-@pytest.mark.needs_vtk_version(9, 2)
 def test_cell_quality_info_full_range(info):
     """Test that the full range is broader than the normal range."""
     normal_range = _replace_range_infinity(info.normal_range)
@@ -2517,7 +2512,6 @@ def test_cell_quality_info_full_range(info):
 
 
 @parametrize('info', _CELL_QUALITY_INFO, ids=CELL_QUALITY_IDS)
-@pytest.mark.needs_vtk_version(9, 2)
 def test_cell_quality_info_degenerate_cell(info):
     # Some cells / measures have bugs and return invalid values and are expected to fail
     xfail_distortion_returns_one(info)
@@ -2533,7 +2527,6 @@ def test_cell_quality_info_degenerate_cell(info):
     )
 
 
-@pytest.mark.needs_vtk_version(9, 2)
 def test_cell_quality_info_raises():
     match = re.escape(
         "Cell quality info is not available for cell type 'QUADRATIC_EDGE'. Valid options are:\n"

--- a/tests/examples/test_cell_examples.py
+++ b/tests/examples/test_cell_examples.py
@@ -16,7 +16,6 @@ cell_example_functions = [
 ]
 
 
-@pytest.mark.needs_vtk_version(9, 1, 0)
 @parametrize('cell_example', cell_example_functions)
 def test_area_and_volume(cell_example):
     mesh = cell_example()
@@ -241,7 +240,6 @@ def test_triquadratic_hexahedron():
     assert grid.n_points == 27
 
 
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_triquadratic_pyramid():
     grid = cells.TriQuadraticPyramid()
     assert grid.celltypes[0] == CellType.TRIQUADRATIC_PYRAMID

--- a/tests/examples/test_download_files.py
+++ b/tests/examples/test_download_files.py
@@ -1244,7 +1244,6 @@ def test_download_can(partial: bool):
 
 
 @parametrize(partial=[True, False])
-@pytest.mark.needs_vtk_version(9, 2)
 def test_download_can_raises(partial: bool):
     with pytest.raises(pv.VTKVersionError):
         examples.download_can(partial=partial)

--- a/tests/plotting/test_axes.py
+++ b/tests/plotting/test_axes.py
@@ -166,7 +166,6 @@ def test_axes_actor_labels_group(axes_actor):
         axes_actor.labels = ['1', '2']
 
 
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_axes_actor_properties():
     prop = pv.ActorProperties(_vtk.vtkProperty())
 

--- a/tests/plotting/test_picking.py
+++ b/tests/plotting/test_picking.py
@@ -299,7 +299,6 @@ def test_point_picking(left_clicking):
     assert picked
 
 
-@pytest.mark.needs_vtk_version(9, 2, 0, reason='Hardware picker unavailable for VTK<9.2')
 @pytest.mark.skip_windows
 @pytest.mark.parametrize('pickable_window', [False, True])
 def test_point_picking_window(pickable_window):

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -245,7 +245,6 @@ def test_add_point_labels_raises(points):
         pl.add_point_labels(points=points, labels='foo')
 
 
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_add_point_labels_algo_raises(mocker: MockerFixture):
     from pyvista.plotting import plotter
 

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -310,7 +310,6 @@ def test_pbr(sphere, verify_image_cache):
 
 
 @pytest.mark.parametrize('resample', [True, 0.5])
-@pytest.mark.needs_vtk_version(9, 2)
 def test_set_environment_texture_cubemap(resample, verify_image_cache):
     """Test set_environment_texture with a cubemap."""
     # Skip due to large variance
@@ -2782,7 +2781,6 @@ def test_collision_plot(verify_image_cache):
 
 
 @pytest.mark.skip_mac('MacOS CI fails when downloading examples')
-@pytest.mark.needs_vtk_version(9, 2, 0)
 def test_chart_plot():
     """Basic test to verify chart plots correctly"""
     # Chart 1 (bottom left)
@@ -4249,7 +4247,6 @@ def test_plot_texture_flip_y(texture):
     texture.flip_y().plot()
 
 
-@pytest.mark.needs_vtk_version(9, 2, 0)
 @pytest.mark.skipif(CI_WINDOWS, reason='Windows CI testing segfaults on pbr')
 @pytest.mark.needs_vtk_version(less_than=(9, 3), reason='This is broken on VTK 9.3')
 def test_plot_cubemap_alone(cubemap, verify_image_cache):

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -5245,7 +5245,6 @@ def test_plot_wireframe_style():
     sphere.plot(style='wireframe')
 
 
-@pytest.mark.needs_vtk_version(9, 1)
 @pytest.mark.parametrize('as_multiblock', ['as_multiblock', None])
 @pytest.mark.parametrize('return_clipped', ['return_clipped', None])
 def test_clip_multiblock_crinkle(return_clipped, as_multiblock):
@@ -5267,7 +5266,6 @@ def test_clip_multiblock_crinkle(return_clipped, as_multiblock):
     pl.show()
 
 
-@pytest.mark.needs_vtk_version(9, 1)
 @pytest.mark.parametrize('as_multiblock', ['as_multiblock', None])
 def test_clip_box_crinkle(as_multiblock):
     as_multiblock = bool(as_multiblock)

--- a/tests/plotting/test_render_window_interactor.py
+++ b/tests/plotting/test_render_window_interactor.py
@@ -76,7 +76,6 @@ def test_picker_raises(picker, mocker: MockerFixture):
     m.assert_called_once_with(picker)
 
 
-@pytest.mark.needs_vtk_version(9, 1)
 def test_observers():
     pl = pv.Plotter()
 
@@ -326,7 +325,6 @@ def test_add_pick_observer():
     pl.iren.add_pick_observer(empty_callback)
 
 
-@pytest.mark.needs_vtk_version(9, 1)
 @pytest.mark.parametrize('event', ['LeftButtonReleaseEvent', 'RightButtonReleaseEvent'])
 def test_release_button_observers(event):
     class CallBack:

--- a/tests/plotting/test_renderer.py
+++ b/tests/plotting/test_renderer.py
@@ -253,7 +253,6 @@ LEGEND_FACES = {
 
 
 @pytest.mark.usefixtures('verify_image_cache')
-@pytest.mark.needs_vtk_version(9, 1, 0)
 @pytest.mark.parametrize('face', LEGEND_FACES.values(), ids=LEGEND_FACES.keys())
 def test_legend_face(face):
     pl = pv.Plotter()
@@ -282,7 +281,6 @@ def test_legend_from_glyph(sphere, verify_image_cache):
 
 
 @pytest.mark.usefixtures('verify_image_cache')
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_legend_from_multiple_glyph(plane2x2):
     pl = pv.Plotter()
     plane2x2['Normals2'] = -1 * plane2x2['Normals'].copy()
@@ -316,7 +314,6 @@ def test_legend_using_add_legend(plane2x2):
 
 
 @pytest.mark.usefixtures('verify_image_cache')
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_legend_using_add_legend_with_glyph(plane2x2):
     pl = pv.Plotter()
 
@@ -337,7 +334,6 @@ def test_legend_using_add_legend_with_glyph(plane2x2):
 
 
 @pytest.mark.usefixtures('verify_image_cache')
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_legend_using_add_legend_only_labels(plane2x2):
     pl = pv.Plotter()
 
@@ -353,7 +349,6 @@ def test_legend_using_add_legend_only_labels(plane2x2):
 
 
 @pytest.mark.usefixtures('verify_image_cache')
-@pytest.mark.needs_vtk_version(9, 1, 0)
 @pytest.mark.parametrize('use_dict_labels', [True, False], ids=['dict', 'no_dict'])
 def test_legend_using_add_legend_dict(use_dict_labels):
     sphere_label = 'sphere'

--- a/tests/plotting/test_widgets.py
+++ b/tests/plotting/test_widgets.py
@@ -101,7 +101,6 @@ def test_add_mesh_isovalue_raises():
         pl.add_mesh_isovalue(mesh=sp, scalars='foo')
 
 
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_add_mesh_isovalue_pointset_raises():
     pl = pv.Plotter()
     with pytest.raises(
@@ -493,7 +492,6 @@ def test_widget_radio_button_plotter_closed(uniform):
         p.add_radio_button_widget(callback=func, radio_button_group='group')
 
 
-@pytest.mark.needs_vtk_version(9, 1)
 def test_add_camera_orientation_widget():
     p = pv.Plotter()
     p.add_camera_orientation_widget()
@@ -548,7 +546,6 @@ def test_add_volume_clip_plane(uniform):
     pl.close()
 
 
-@pytest.mark.needs_vtk_version(9, 1, 0)
 def test_plot_pointset_widgets(pointset):
     pointset = pointset.elevation()
 
@@ -920,7 +917,6 @@ def test_clear_sphere_widget():
     pl.show(cpos='xy')
 
 
-@pytest.mark.needs_vtk_version(9, 1)
 @pytest.mark.usefixtures('verify_image_cache')
 def test_clear_camera_widget():
     mesh = pv.Cube()

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -104,7 +104,6 @@ def try_init_pyvista_object(class_):
     return instance
 
 
-@pytest.mark.needs_vtk_version(9, 2)
 def get_default_class_init_kwargs(pyvista_class):
     # Define kwargs as required for initializing some classes
     kwargs = {}


### PR DESCRIPTION
### Overview

Depends on #7796 