### PR TITLE
Auto-cancel Windows jobs after 60 minutes

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -369,6 +369,7 @@ jobs:
   windows:
     name: Windows Unit Testing
     runs-on: windows-latest
+    timeout-minutes: 60
     needs: cache-vtk-data
     env:
       CI_WINDOWS: true


### PR DESCRIPTION
### Overview

Windows jobs occasionally hang for reasons unknown, and the job will be stuck in limbo until it auto-cancels after a default of 6 hours. Instead, this PR makes it timeout after 1 hr (they usually finish in under 30 minutes).

Might want to consider auto-retry with https://github.com/nick-fields/retry in the future, or somehow fix the hang-up itself if we can figure out the cause.