### PR TITLE
Remove `lazy_vtkPOpenFOAMReader`

### DIFF
--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -39,17 +39,6 @@ def _lazy_vtk_instantiation(module_name, class_name):
     return getattr(module, class_name)()
 
 
-def lazy_vtkPOpenFOAMReader():
-    """Lazy import of the :vtk:`vtkPOpenFOAMReader`."""
-    from vtkmodules.vtkIOParallel import vtkPOpenFOAMReader  # noqa: PLC0415
-    from vtkmodules.vtkParallelCore import vtkDummyController  # noqa: PLC0415
-
-    # Workaround waiting for the fix to be upstream (MR 9195 gitlab.kitware.com/vtk/vtk)
-    reader = vtkPOpenFOAMReader()
-    reader.SetController(vtkDummyController())
-    return reader
-
-
 def get_reader(filename, force_ext=None):
     """Get a reader for fine-grained control of reading data files.
 
@@ -1232,9 +1221,8 @@ class POpenFOAMReader(OpenFOAMReader):
     parallel reconstructed data, and decomposed data.
     """
 
-    _class_reader = staticmethod(lazy_vtkPOpenFOAMReader)
-    _vtk_module_name = ''
-    _vtk_class_name = ''
+    _vtk_module_name = 'vtkIOParallel'
+    _vtk_class_name = 'vtkPOpenFOAMReader'
 
     @property
     def case_type(self):


### PR DESCRIPTION
### Overview

Looks like the upstream fix in VTK was committed to the 9.2.0 release (https://gitlab.kitware.com/vtk/vtk/-/commit/aee9f8077651fc8222a8970e74eed5ba85e7412b), so the equivalent PyVista fix can be removed.