### PR TITLE
Use vtkEGLRenderWindow for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ env:
   PYDEVD_DISABLE_FILE_VALIDATION: "1"
   PYTEST_ADDOPTS: "--color=yes"
   FORCE_COLOR: "True"
-  VTK_DEFAULT_OPENGL_WINDOW: "vtkOSOpenGLRenderWindow"
+  VTK_DEFAULT_OPENGL_WINDOW: "vtkEGLRenderWindow"
 
 permissions:
   id-token: none


### PR DESCRIPTION
Initial results from with https://github.com/pyvista/pyvista/pull/7848 show that using `vtkEGLRenderWindow` results in correctly rendered depth peeling, resolving #5118.

Instead of using two separate backends (one for GPU self-hosted, one for CPU GitHub-hosted), this PR switches our default backend to EGL on the documentation build workflow.

`vtkOSOpenGLRenderWindow`
![sphx_glr_depth_peeling_001](https://github.com/user-attachments/assets/fab4eb2b-9751-4803-9a86-989ff763dd04)

`vtkEGLRenderWindow`
![sphx_glr_depth_peeling_001](https://github.com/user-attachments/assets/fa82d097-b1a7-4c7c-b195-dff64cd25c1d)


