### PR TITLE
Fix flaky downloads tests

### DIFF
--- a/tests/examples/test_dataset_loader.py
+++ b/tests/examples/test_dataset_loader.py
@@ -166,18 +166,14 @@ def examples_local_repository_tmp_dir(tmp_path: Path, monkeypatch: pytest.Monkey
     for base in downloadable_basenames:
         FETCHER.registry[base] = None
     FETCHER.base_url = str(repository_path) + '/'
+    (cache_path := tmp_path / 'cache').mkdir()
+    FETCHER.path = cache_path
 
     monkeypatch.setattr(downloads, 'FETCHER', FETCHER)
     monkeypatch.setattr(downloads, '_FILE_CACHE', True)
+    monkeypatch.setattr(downloads, 'USER_DATA_PATH', cache_path)
 
-    # make sure any "downloaded" files (moved from repo -> cache) are cleared
-    cached_paths = [downloads.FETCHER.path / base for base in downloadable_basenames]
-    [file.unlink() for file in cached_paths if os.path.isfile(file)]
-
-    yield repository_path
-
-    # make sure any "downloaded" files (moved from repo -> cache) are cleared afterward
-    [file.unlink() for file in cached_paths if os.path.isfile(file)]
+    return repository_path
 
 
 @pytest.mark.usefixtures('examples_local_repository_tmp_dir')


### PR DESCRIPTION
### Overview

The file loader tests are flaky since they can overlap when removing files from cache common to multiple jobs.
This PR fixes it.

See:
https://github.com/pyvista/pyvista/actions/runs/17185449908/job/48753822425#step:7:7209
https://github.com/pyvista/pyvista/actions/runs/17086020256/job/48450172182#step:8:8925
