### PR TITLE
Do not run labeler on dependabot PRs

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -8,6 +8,7 @@ permissions:
 
 jobs:
   triage:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-22.04
     steps:
       - name: Label based on changed files


### PR DESCRIPTION
The labeler is failing due to missing authorization, and this PR disables the labeler as the dependabot PRs already have labels provided.

Background:
https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544