### PR TITLE
Add catch-all dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
         patterns:
           - "pytest"
           - "pytest-*"
+      all-else:
+        patterns:
+          - "*"
     labels:
       - "maintenance"
       - "dependencies"


### PR DESCRIPTION
We already have several matching groups for the `pip` ecosystem for `dependabot`, but we don't have a catchall and it's leading to this:

<img width="1779" height="555" alt="sc003" src="https://github.com/user-attachments/assets/e542d277-7b1d-4235-93ae-c71b534c0c66" />

This PR adds a `all-else` group which will hopefully match the remainder of the dependencies.

See: [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference)