### PR TITLE
Allow multiple cache images for `CubeAxesActor` tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ test = [
   'pyobjc-framework-Cocoa; sys_platform == "darwin"', # see pyvista/pulls/7828
   'pytest-cov<6.3.0',
   'pytest-mypy-plugins<3.3.0',
-  'pytest-pyvista==0.2.0',
+  'pytest-pyvista @ git+https://github.com/pyvista/pytest-pyvista.git@feat/doc',
   'pytest-xdist<3.9.0',
   'pytest<8.5.0',
   'pytest_cases<3.10.0',

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -366,10 +366,6 @@ def test_plot(sphere, tmpdir, verify_image_cache, anti_aliasing):
     verify_image_cache.high_variance_test = True
     verify_image_cache.macos_skip_image_cache = True
     verify_image_cache.windows_skip_image_cache = True
-    # TODO: Change this to (9, 6, 0) when VTK 9.6 is released
-    if pyvista.vtk_version_info < (9, 5, 99):
-        # Axis labels changed substantially in VTK 9.6
-        verify_image_cache.skip = True
 
     tmp_dir = tmpdir.mkdir('tmpdir2')
     filename = str(tmp_dir.join('tmp.png'))
@@ -410,10 +406,6 @@ def test_plot(sphere, tmpdir, verify_image_cache, anti_aliasing):
 
 def test_plot_helper_volume(uniform, verify_image_cache):
     verify_image_cache.windows_skip_image_cache = True
-    # TODO: Change this to (9, 6, 0) when VTK 9.6 is released
-    if pyvista.vtk_version_info < (9, 5, 99):
-        # Axis labels changed substantially in VTK 9.6
-        verify_image_cache.skip = True
 
     uniform.plot(
         volume=True,
@@ -641,23 +633,13 @@ def test_plotter_shape_invalid():
         pv.Plotter(shape={1, 2})
 
 
-def test_plot_bounds_axes_with_no_data(verify_image_cache):
-    # TODO: Change this to (9, 6, 0) when VTK 9.6 is released
-    if pyvista.vtk_version_info < (9, 5, 99):
-        # Axis labels changed substantially in VTK 9.6
-        verify_image_cache.skip = True
-
+def test_plot_bounds_axes_with_no_data():
     plotter = pv.Plotter()
     plotter.show_bounds()
     plotter.show()
 
 
-def test_plot_show_grid(sphere, verify_image_cache):
-    # TODO: Change this to (9, 6, 0) when VTK 9.6 is released
-    if pyvista.vtk_version_info < (9, 5, 99):
-        # Axis labels changed substantially in VTK 9.6
-        verify_image_cache.skip = True
-
+def test_plot_show_grid(sphere):
     plotter = pv.Plotter()
 
     with pytest.raises(ValueError, match='Value of location'):
@@ -811,12 +793,7 @@ def test_plot_show_bounds(sphere):
     plotter.show()
 
 
-def test_plot_label_fmt(sphere, verify_image_cache):
-    # TODO: Change this to (9, 6, 0) when VTK 9.6 is released
-    if pyvista.vtk_version_info < (9, 5, 99):
-        # Axis labels changed substantially in VTK 9.6
-        verify_image_cache.skip = True
-
+def test_plot_label_fmt(sphere):
     plotter = pv.Plotter()
     plotter.add_mesh(sphere)
     # TODO: Change this to (9, 6, 0) when VTK 9.6 is released
@@ -828,11 +805,7 @@ def test_plot_label_fmt(sphere, verify_image_cache):
 @pytest.mark.parametrize('grid', [True, 'both', 'front', 'back'])
 @pytest.mark.parametrize('location', ['all', 'origin', 'outer', 'front', 'back'])
 @pytest.mark.usefixtures('verify_image_cache')
-def test_plot_show_bounds_params(grid, location, verify_image_cache):
-    # TODO: Change this to (9, 6, 0) when VTK 9.6 is released
-    if pyvista.vtk_version_info < (9, 5, 99):
-        # Axis labels changed substantially with VTK 9.6
-        verify_image_cache.skip = True
+def test_plot_show_bounds_params(grid, location):
     plotter = pv.Plotter()
     plotter.add_mesh(pv.Cone())
     plotter.show_bounds(grid=grid, ticks='inside', location=location)
@@ -1737,12 +1710,7 @@ def test_camera(sphere):
     plotter.show()
 
 
-def test_multi_renderers(verify_image_cache):
-    # TODO: Change this to (9, 6, 0) when VTK 9.6 is released
-    if pyvista.vtk_version_info < (9, 5, 99):
-        # Axis labels changed substantially in VTK 9.6
-        verify_image_cache.skip = True
-
+def test_multi_renderers():
     plotter = pv.Plotter(shape=(2, 2))
 
     plotter.subplot(0, 0)
@@ -4942,13 +4910,7 @@ def test_contour_labels_smoothing_constraint(
     labeled_image,  # noqa: F811
     smoothing_distance,
     smoothing_scale,
-    verify_image_cache,
 ):
-    # TODO: Change this to (9, 6, 0) when VTK 9.6 is released
-    if pyvista.vtk_version_info < (9, 5, 99):
-        # Axis labels changed substantially in VTK 9.6
-        verify_image_cache.skip = True
-
     # Scale spacing for visualization
     labeled_image.spacing = (10, 10, 10)
 


### PR DESCRIPTION
### Overview

Use feature from https://github.com/pyvista/pytest-pyvista/pull/211 to store multiple cached images for a single test, and add back CubeAxesActor images for vtk < 9.6 that were removed in #7682 