### PR TITLE
Remove PY007 from repo-review ignore list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -564,6 +564,5 @@ ignore = [
   'PC111', # ruff is taking care of docstring formatting https://github.com/pyvista/pyvista/pull/6991
   'PC140', # mypy deliberately removed from pre-commit in https://github.com/pyvista/pyvista/pull/6741
   'PY004', # we have a 'doc' folder, not 'docs'
-  'PY007', # tox support
   'RTD', # RTD: the documentation is not hosted by ReadTheDocs
 ]


### PR DESCRIPTION
## Summary
- Remove PY007 (tox support) from repo-review ignore list in pyproject.toml