### PR TITLE
Deprecate use_all_points parameter in extract_all_edges

### DIFF
--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -2049,7 +2049,7 @@ class DataObjectFilters:
     @_deprecate_positional_args
     def extract_all_edges(  # type: ignore[misc]
         self: _DataSetOrMultiBlockType,
-        use_all_points: bool | None = None,
+        use_all_points: bool | None = None,  # noqa: FBT001
         clear_data: bool = False,  # noqa: FBT001, FBT002
         progress_bar: bool = False,  # noqa: FBT001, FBT002
     ):
@@ -2090,10 +2090,6 @@ class DataObjectFilters:
         See :ref:`cell_centers_example` for more examples using this filter.
 
         """
-        import warnings
-
-        from pyvista.core.errors import PyVistaDeprecationWarning
-
         if use_all_points is not None:
             warnings.warn(
                 "Parameter 'use_all_points' is deprecated since VTK < 9.2 is no longer "

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -2097,7 +2097,7 @@ class DataObjectFilters:
         if use_all_points is not None:
             warnings.warn(
                 "Parameter 'use_all_points' is deprecated since VTK < 9.2 is no longer "
-                "supported. This parameter has no effect and is always `True`.",
+                'supported. This parameter has no effect and is always `True`.',
                 PyVistaDeprecationWarning,
                 stacklevel=2,
             )

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -303,7 +303,14 @@ def test_extract_all_edges(datasets):
         assert edges is not None
         assert isinstance(edges, pv.PolyData)
 
-    edges = datasets[0].extract_all_edges(use_all_points=True)
+    # Test that use_all_points parameter raises a deprecation warning
+    with pytest.warns(PyVistaDeprecationWarning, match="use_all_points.*deprecated"):
+        edges = datasets[0].extract_all_edges(use_all_points=True)
+    assert edges.n_lines
+
+    # Test that use_all_points=False also raises a deprecation warning
+    with pytest.warns(PyVistaDeprecationWarning, match="use_all_points.*deprecated"):
+        edges = datasets[0].extract_all_edges(use_all_points=False)
     assert edges.n_lines
 
 

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -304,12 +304,12 @@ def test_extract_all_edges(datasets):
         assert isinstance(edges, pv.PolyData)
 
     # Test that use_all_points parameter raises a deprecation warning
-    with pytest.warns(PyVistaDeprecationWarning, match="use_all_points.*deprecated"):
+    with pytest.warns(PyVistaDeprecationWarning, match='use_all_points.*deprecated'):
         edges = datasets[0].extract_all_edges(use_all_points=True)
     assert edges.n_lines
 
     # Test that use_all_points=False also raises a deprecation warning
-    with pytest.warns(PyVistaDeprecationWarning, match="use_all_points.*deprecated"):
+    with pytest.warns(PyVistaDeprecationWarning, match='use_all_points.*deprecated'):
         edges = datasets[0].extract_all_edges(use_all_points=False)
     assert edges.n_lines
 


### PR DESCRIPTION
## Summary
- Deprecates the `use_all_points` parameter in the `extract_all_edges()` method since VTK < 9.2 is no longer supported
- The parameter has no effect and is always `True` now

## Changes
- Added `PyVistaDeprecationWarning` when `use_all_points` parameter is used
- Updated documentation to indicate the parameter is deprecated
- Modified implementation to always call `SetUseAllPoints(True)` 
- Updated tests to verify the deprecation warning is properly raised

Fixes #7852