### PR TITLE
Fix Windows plotting CI name

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -362,7 +362,7 @@ jobs:
           retry_on: timeout
           command: tox run -e py${{ matrix.python-version }}-core
 
-      - name: Core Testing (no GL)
+      - name: Plotting Testing (uses GL)
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
         if: ${{ !cancelled() }}
         with:


### PR DESCRIPTION
### Overview

#7908 accidentally renamed Plotting -> Core. This PR reverts this change.