### PR TITLE
Move documentation testing to separate dedicated job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -117,6 +117,7 @@ jobs:
     name: Test Documentation
     runs-on: ubuntu-22.04
     needs: doc
+    if: ${{ !cancelled() }}
     env:
       TOX_COLORED: "yes"
     steps:


### PR DESCRIPTION
Testing is separate from building so should be a separate job. This is also preparation for updates to `pytest-pyvista` which will enable vtksz file testing. This will add several minutes of test time and would otherwise delay the html upload if kept inside the build job