### PR TITLE
Include report with integration tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -183,6 +183,7 @@ commands_pre =
 
     # COMMON SETUP (CURRENT PYVISTA VERSION INSTALLATION)
     uv pip install {tox_root}
+    {[testenv]software_report_cmdline}
 
 commands =
     trame: pytest --color=yes -v tests {posargs}


### PR DESCRIPTION
Include software report. Some key test dependencies might be missing from the report but it should still be helpful.