### PR TITLE
Use `cyclopts` as CLI library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
   'Topic :: Scientific/Engineering :: Information Analysis',
 ]
 dependencies = [
-  'cyclopts>3.24.0',
+  'cyclopts>=3.24.0',
   'matplotlib>=3.0.1',
   'numpy>=1.21.0',
   'pillow',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   'Topic :: Scientific/Engineering :: Information Analysis',
 ]
 dependencies = [
+  'cyclopts>3.24.0',
   'matplotlib>=3.0.1',
   'numpy>=1.21.0',
   'pillow',

--- a/pyvista/__main__.py
+++ b/pyvista/__main__.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-from typing import Any
+from functools import wraps
 from typing import get_type_hints
 import warnings
 
@@ -13,29 +12,24 @@ import pyvista
 from pyvista import Report
 from pyvista.core.errors import PyVistaDeprecationWarning
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
-
 # Assign annotations to be able to use the Report class using
 # cyclopts when __future__ annotations are enabled. See https://github.com/BrianPugh/cyclopts/issues/570
 Report.__init__.__annotations__ = get_type_hints(Report.__init__)
 
 
-COMMANDS: dict[str, Callable[..., Any]] = {
-    'report': Report,
-}
-
 # help format needs to be `plaintext` due to unsupported `versionadded` sphinx directive in rich.
 # Change to `rst` when cyclopts v4 is out. See https://github.com/BrianPugh/cyclopts/issues/568
 app = App(
+    name=pyvista.__name__,
     help_format='plaintext',
     version=f'{pyvista.__name__} {pyvista.__version__}',
 )
 
 
-for name, func in COMMANDS.items():
-    app.command(func, name=name)
+@app.command
+@wraps(Report)
+def report(*args, **kwargs):  # noqa: ANN201, D103
+    return Report(*args, **kwargs)
 
 
 def main(argv: list[str] | str | None = None) -> None:

--- a/pyvista/__main__.py
+++ b/pyvista/__main__.py
@@ -35,7 +35,6 @@ app = App(
 
 
 for name, func in COMMANDS.items():
-    # print(Report.__init__.__annotations__)
     app.command(func, name=name)
 
 

--- a/pyvista/__main__.py
+++ b/pyvista/__main__.py
@@ -30,7 +30,7 @@ COMMANDS: dict[str, Callable[..., Any]] = {
 # Change to `rst` when cyclopts v4 is out. See https://github.com/BrianPugh/cyclopts/issues/568
 app = App(
     help_format='plaintext',
-    version=f"f'{pyvista.__name__} {pyvista.__version__}'",
+    version=f'{pyvista.__name__} {pyvista.__version__}',
 )
 
 

--- a/pyvista/report.py
+++ b/pyvista/report.py
@@ -190,7 +190,9 @@ class Report(scooby.Report):
 
         .. code-block:: shell
 
-            pyvista report [key=value] ...
+            pyvista report --sort ...
+
+        Run `pyvista report --help` for more details on available parameters.
 
 
     Parameters

--- a/pyvista/report.py
+++ b/pyvista/report.py
@@ -180,6 +180,7 @@ class GPUInfo:
         return content
 
 
+@_deprecate_positional_args
 class Report(scooby.Report):
     """Generate a PyVista software environment report.
 
@@ -256,7 +257,6 @@ class Report(scooby.Report):
 
     """
 
-    @_deprecate_positional_args
     def __init__(  # noqa: PLR0917
         self,
         additional=None,

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -570,6 +570,11 @@ def test_report():
     assert 'User Data Path' not in report.__repr__()
 
 
+def test_report_warnings():
+    with pytest.warns(pv.PyVistaDeprecationWarning):
+        pv.Report('vtk', 4, 90, True)
+
+
 def test_report_downloads():
     report = pv.Report(downloads=True)
     repr_ = repr(report)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,14 +48,22 @@ def _run_pyvista(argv: list[str] | None = None, *, as_script: bool = False):
     )
 
 
-@pytest.mark.parametrize('args', [None, []])
-def test_no_input(args):
-    result = _run_pyvista(args)
-    assert result.returncode == 1
-    stdout = result.stdout
-    assert stdout.startswith('usage: pyvista [-h] [--version] {report} ...')
-    assert 'positional arguments:' in stdout
-    assert 'options:' in stdout
+@pytest.mark.parametrize('args', [[], ''])
+def test_no_input(args, capsys: pytest.CaptureFixture, console: Console):
+    app(args, console=console)
+
+    expected = textwrap.dedent(
+        """\
+        Usage: pyvista COMMAND
+
+        ╭─ Commands ─────────────────────────────────────────────────────────╮
+        │ report     Generate a PyVista software environment report.         │
+        │ --help -h  Display this message and exit.                          │
+        │ --version  Display application version.                            │
+        ╰────────────────────────────────────────────────────────────────────╯
+        """
+    )
+    assert expected == capsys.readouterr().out
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason='Different output format on older python')
@@ -115,40 +123,14 @@ def test_report(cli_kwargs, py_kwargs):
 def test_report_help(capsys: pytest.CaptureFixture, console: Console):
     app('report --help', console=console)
 
-    assert (
-        textwrap.dedent(
-            """
-            ╭─ Parameters ───────────────────────────────────────────────────────╮
-            │ ADDITIONAL --additional  List of packages or package names to add  │
-            │                          to output information.                    │
-            │ NCOL --ncol              Number of package-columns in html table;  │
-            │                          only has effect if                        │
-            │                          ``mode='HTML'`` or ``mode='html'``.       │
-            │                          [default: 3]                              │
-            │ TEXT-WIDTH --text-width  The text width for non-HTML display       │
-            │                          modes. [default: 80]                      │
-            │ SORT --sort --no-sort    Alphabetically sort the packages.         │
-            │                          [default: False]                          │
-            │ GPU --gpu --no-gpu       Gather information about the GPU.         │
-            │                          Defaults to ``True`` but if               │
-            │                          experiencing rendering issues, pass       │
-            │                          ``False`` to safely generate a            │
-            │                          report. [default: True]                   │
-            │ DOWNLOADS --downloads    Gather information about downloads. If    │
-            │   --no-downloads         ``True``, includes:                       │
-            │                          - The local user data path (where         │
-            │                          downloads are saved)                      │
-            │                          - The VTK Data source (where files are    │
-            │                          downloaded from)                          │
-            │                          - Whether local file caching is enabled   │
-            │                          for the VTK Data source                   │
-            │                                                                    │
-            │                          .. versionadded:: 0.47 [default: False]   │
-            ╰────────────────────────────────────────────────────────────────────╯
-        """
-        )
-        in capsys.readouterr().out
+    expected = textwrap.dedent(
+        """\
+            Usage: pyvista report [ARGS] [OPTIONS]
+
+            Generate a PyVista software environment report.
+       """
     )
+    assert expected in capsys.readouterr().out
 
 
 def test_version(capsys: pytest.CaptureFixture):

--- a/tox.ini
+++ b/tox.ini
@@ -89,7 +89,7 @@ all_testing_cmdline =
     !cov-!plotting-!core: pytest {[testenv]all_flags}  {posargs}
 
 software_report_cmdline=
-    pyvista report gpu=True downloads=True
+    pyvista report --gpu=True --downloads
 
 # ================= INTEGRATION ENVIRONMENTS =================
 [testenv:integration-{trame,geovista,mne,pyvistaqt}]


### PR DESCRIPTION
### Overview

The [`cyclopts`](https://cyclopts.readthedocs.io/en/latest/index.html) package provides great CLI features out of the box.

Pros:
- get arguments from docstring
- convert CLI using type annotations
- rich terminal output
- flexible

Cons:
- supplementary dependency

See a visual comparison below:

| main                                                                                                                               | This PR                                                                                                                            |
|------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
| <img width="689" height="185" alt="image" src="https://github.com/user-attachments/assets/7d16e0d9-2c28-411a-9b4f-86677f9b44dd" /> | <img width="692" height="143" alt="image" src="https://github.com/user-attachments/assets/a2717659-7071-4650-a82b-6eb8632b6dac" /> |
| <img width="562" height="204" alt="image" src="https://github.com/user-attachments/assets/6faec1e3-9942-4360-895b-eeafc60d7754" /> | <img width="691" height="667" alt="image" src="https://github.com/user-attachments/assets/991158d1-40b6-41ef-8ba4-94111c666cef" /> |
| <img width="655" height="69" alt="image" src="https://github.com/user-attachments/assets/0f123db9-f4cc-4e78-9def-9cd6d4bf573e" />  | <img width="694" height="74" alt="image" src="https://github.com/user-attachments/assets/76eecf9e-d057-40ce-b543-491508a52a47" />  |
| <img width="700" height="258" alt="image" src="https://github.com/user-attachments/assets/8024ace0-8fdc-4f40-86d4-7a1312448822" /> | <img width="696" height="71" alt="image" src="https://github.com/user-attachments/assets/9f530753-2693-4744-8f77-23697d76c07d" />  |








