### PR TITLE
chore: update ruff pre-commit hook to v0.13.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
       - id: check-github-workflows
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.11
+    rev: v0.13.3
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/pyvista/core/utilities/fileio.py
+++ b/pyvista/core/utilities/fileio.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     from pyvista.core.utilities.reader import BaseReader
     from pyvista.plotting.texture import Texture
 
-_CompressionOptions = Literal['zlib', 'lz4', 'lzma', None]
+_CompressionOptions = Literal['zlib', 'lz4', 'lzma'] | None
 PathStrSeq = str | Path | Sequence['PathStrSeq']
 
 if TYPE_CHECKING:

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -1529,7 +1529,7 @@ class Color(_NoNewAttrMixin):
             else:  # pragma: no cover
                 msg = f'Unexpected color type: {type(color)}'
                 raise TypeError(msg)
-            self._name = color_names.get(self.hex_rgb, None)
+            self._name = color_names.get(self.hex_rgb)
         except ValueError as e:
             msg = (
                 '\n'


### PR DESCRIPTION
Update ruff-pre-commit from v0.12.11 to v0.13.3 and fix new linting errors.

Separated from #7992.