### PR TITLE
BUG: Dont set global warning state

### DIFF
--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -6,7 +6,6 @@ import os
 import sys
 from typing import TYPE_CHECKING
 from typing import Literal
-import warnings
 
 from pyvista._plot import plot as plot
 from pyvista._version import __version__ as __version__
@@ -46,9 +45,6 @@ if vtk_version_info < _MIN_SUPPORTED_VTK_VERSION:  # pragma: no cover
 
     msg = f'VTK version must be {VersionInfo._format(_MIN_SUPPORTED_VTK_VERSION)} or greater.'
     raise VTKVersionError(msg)
-
-# catch annoying numpy/vtk future warning:
-warnings.simplefilter(action='ignore', category=FutureWarning)
 
 # A simple flag to set when generating the documentation
 OFF_SCREEN = os.environ.get('PYVISTA_OFF_SCREEN', 'false').lower() == 'true'


### PR DESCRIPTION
It seems too invasive to add a global ignore for `FutureWarning`, which according to the docs is meant to be used for:

> Base class for warnings about deprecated features when those warnings are intended for end users of applications that are written in Python.

The removed line won't just temporarily suppress them in the scope of PyVista or its interactions with NumPy -- it'll suppress them for any future calls. For MNE-Python for example when we try to emit a `FutureWarning` for deprecations etc., it'll just be ignored if the user has imported PyVista (which they might have implicitly done by doing any 3D viz in MNE). In other words, this is problematic I think:
```
>>> import warnings
>>> warnings.warn("Something", FutureWarning)
<python-input-1>:1: FutureWarning: Something
>>> import pyvista
>>> warnings.warn("Something else", FutureWarning)
>>> 
```
On this branch, you get the second warning.