### PR TITLE
Pin `black` for `blackdoc`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
       - id: blackdoc
         args: ["--skip-string-normalization"]
         types_or: [rst]
+        additional_dependencies: ["black==25.1.0"]
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1


### PR DESCRIPTION
### Overview

`blackdoc` is broken with the latest version of `black` and must be pinned to work.

See https://github.com/keewis/blackdoc/issues/248