### PR TITLE
Dump sphinx execution error logs in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Build Documentation
         run: tox run -e docs-build
 
-      - name: Dump Sphinx Warnings and Errors
+      - name: Dump Sphinx Build Warnings and Errors
         if: always()
         run: if [ -e doc/sphinx_warnings.txt ]; then cat doc/sphinx_warnings.txt; fi
 


### PR DESCRIPTION
### Overview

Try to capture error logs, e.g. ones generated here https://github.com/pyvista/pyvista/pull/7864#issuecomment-3395217636