### PR TITLE
Update tox.ini for geovista integration test fix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -135,7 +135,7 @@ setenv =
 
     _GEOVISTA_ARGS = {env:GEOVISTA_HOME}{/}tests \
         --rootdir={env:GEOVISTA_HOME} \
-        --image_cache_dir={env:GEOVISTA_HOME}{/}tests{/}plotting{/}image_cache
+        --image_cache_dir={env:GEOVISTA_HOME}{/}tests{/}plotting{/}unit_image_cache
 
     _MNE_ARGS = {env:MNE_HOME}{/}mne{/}viz{/}_brain \
         {env:MNE_HOME}{/}mne{/}viz{/}tests{/}test_3d.py \


### PR DESCRIPTION
Never quite realised that you guys were now explicitly taking control of the `--image_cache_dir` flag within `pyvista` to run the `geovista` integration tests.

This seems like a very fragile contract as I can now easily break you, as per https://github.com/bjlittle/geovista/pull/1754.

TBH this directory name change should be stable. It only changed as I'm currently teeing-up the use of `--doc_mode` with `pytest-pyvista` within `geovista`.

Note that I configure the image cache directory using the `image_cache_dir` INI option within the `pyproject.toml` of `geovista`, so perhaps your use of it is unnecessary? Dunno ...

Anyways, I've realigned the image cache directory name change here in this pull-request.

Apologies for the fallout 🙄

Ping @user27182 @tkoyama010 
