### PR TITLE
Remove image cache dir CLI since already available in geovista pyproject

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -133,8 +133,7 @@ setenv =
     XDG_DATA_HOME = {temp_dir}{/}.data # for cartopy url downloads
     GEOVISTA_POOCH_MUTE = true
 
-    _GEOVISTA_ARGS = {env:GEOVISTA_HOME}{/}tests \
-        --rootdir={env:GEOVISTA_HOME} \
+    _GEOVISTA_ARGS = {env:GEOVISTA_HOME}{/}tests --rootdir={env:GEOVISTA_HOME}
 
     _MNE_ARGS = {env:MNE_HOME}{/}mne{/}viz{/}_brain \
         {env:MNE_HOME}{/}mne{/}viz{/}tests{/}test_3d.py \


### PR DESCRIPTION
### Overview

Try removing the image cache CLI in geovista integration tests.

Follow-up from https://github.com/pyvista/pyvista/pull/8024#issuecomment-3409450087