### PR TITLE
docs: update set_plot_theme docstring

### DIFF
--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -109,9 +109,16 @@ def set_plot_theme(theme):
     Parameters
     ----------
     theme : str
-        The theme name.  Available predefined theme names include ``'dark'``,
-        ``'default'``, ``'document'``, ``'document_build'``,
-        ``'document_pro'``, ``'paraview'``, ``'testing'`` and ``'vtk'``.
+        The theme name.  Available predefined theme names include:
+
+        - ``'dark'``,
+        - ``'default'``,
+        - ``'document'``,
+        - ``'document_build'``,
+        - ``'document_pro'``,
+        - ``'paraview'``,
+        - ``'testing'`` and
+        - ``'vtk'``.
 
     Examples
     --------


### PR DESCRIPTION
### Overview

Update the `pyvista.set_plot_theme` docstring to include the names of **all** available predefined native themes.

i.e., I feed it's kinda handy to both users and developers to know the full list of themes available without having to discover this from reading the underlying code.