### PR TITLE
Set theme as string and add registry

### DIFF
--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -66,8 +66,12 @@ from .texture import image_to_texture as image_to_texture
 from .texture import numpy_to_texture as numpy_to_texture
 from .themes import DocumentTheme as _GlobalTheme
 from .themes import _set_plot_theme_from_env
+from .themes import list_registered_themes as list_registered_themes
 from .themes import load_theme as load_theme
+from .themes import register_theme as register_theme
 from .themes import set_plot_theme as set_plot_theme
+from .themes import unregister_all_themes as unregister_all_themes
+from .themes import unregister_theme as unregister_theme
 from .tools import FONTS as FONTS
 from .tools import check_math_text_support as check_math_text_support
 from .tools import check_matplotlib_vtk_compatibility as check_matplotlib_vtk_compatibility

--- a/pyvista/plotting/_property.py
+++ b/pyvista/plotting/_property.py
@@ -11,6 +11,7 @@ from pyvista.core.utilities.misc import _NoNewAttrMixin
 from . import _vtk
 from .colors import Color
 from .opts import InterpolationType
+from .themes import _get_theme
 
 
 class Property(_NoNewAttrMixin, _vtk.DisableVtkSnakeCase, _vtk.vtkProperty):
@@ -187,13 +188,11 @@ class Property(_NoNewAttrMixin, _vtk.DisableVtkSnakeCase, _vtk.vtkProperty):
         edge_opacity=None,
     ):
         """Initialize this property."""
+        # copy global theme to ensure local property theme is fixed
+        # after creation.
         self._theme = pyvista.themes.Theme()
-        if theme is None:
-            # copy global theme to ensure local property theme is fixed
-            # after creation.
-            self._theme.load_theme(pyvista.global_theme)
-        else:
-            self._theme.load_theme(theme)
+        theme = pyvista.global_theme if theme is None else _get_theme(theme)
+        self._theme.load_theme(theme)
 
         if interpolation is None:
             interpolation = self._theme.lighting_params.interpolation

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -23,6 +23,7 @@ from . import _vtk
 from .colors import Color
 from .colors import get_cmap_safe
 from .lookup_table import LookupTable
+from .themes import _get_theme
 from .tools import normalize
 from .utilities.algorithms import set_algorithm_input
 
@@ -34,13 +35,12 @@ class _BaseMapper(
     """Base Mapper with methods common to other mappers."""
 
     def __init__(self, theme=None, **kwargs) -> None:
+        # copy global theme to ensure local property theme is fixed
+        # after creation.
         self._theme = pyvista.themes.Theme()
-        if theme is None:
-            # copy global theme to ensure local property theme is fixed
-            # after creation.
-            self._theme.load_theme(pyvista.global_theme)
-        else:
-            self._theme.load_theme(theme)
+        theme = pyvista.global_theme if theme is None else _get_theme(theme)
+        self._theme.load_theme(theme)
+
         self.lookup_table = LookupTable()
 
         self.interpolate_before_map = kwargs.get(

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -82,6 +82,7 @@ from .text import Text
 from .text import TextProperty
 from .texture import numpy_to_texture
 from .themes import Theme
+from .themes import _get_theme
 from .themes import _registry_themes
 from .utilities.algorithms import active_scalars_algorithm
 from .utilities.algorithms import algorithm_to_mesh_handler
@@ -302,7 +303,7 @@ class BasePlotter(_BoundsSizeMixin, PickingHelper, WidgetHelper):
         row_weights: Sequence[int] | None = None,
         col_weights: Sequence[int] | None = None,
         lighting: LightingOptions | None = 'light kit',
-        theme: Theme | None = None,
+        theme: Theme | str | None = None,
         image_scale: int | None = None,
         **kwargs,
     ) -> None:
@@ -318,19 +319,11 @@ class BasePlotter(_BoundsSizeMixin, PickingHelper, WidgetHelper):
         self.mwriter: imageio.plugins.ffmpeg.Writer | None = None
         self._gif_filename: Path | None = None
 
+        # copy global theme to ensure local plot theme is fixed
+        # after creation.
         self._theme = Theme()
-        if theme is None:
-            # copy global theme to ensure local plot theme is fixed
-            # after creation.
-            self._theme.load_theme(pyvista.global_theme)
-        else:
-            if not isinstance(theme, Theme):
-                msg = (  # type: ignore[unreachable]
-                    'Expected ``pyvista.plotting.themes.Theme`` for '
-                    f'``theme``, not {type(theme).__name__}.'
-                )
-                raise TypeError(msg)
-            self._theme.load_theme(theme)
+        theme = pyvista.global_theme if theme is None else _get_theme(theme)
+        self._theme.load_theme(theme)
 
         self.image_transparent_background = self._theme.transparent_background
 

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -498,7 +498,7 @@ class BasePlotter(_BoundsSizeMixin, PickingHelper, WidgetHelper):
                 raise ValueError(msg)
 
         if not isinstance(theme, pyvista.plotting.themes.Theme):
-            msg = (  # type: ignore[unreachable]
+            msg = (
                 'Expected a pyvista theme like '
                 '``pyvista.plotting.themes.Theme``, '
                 f'not {type(theme).__name__}.'

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -82,6 +82,7 @@ from .text import Text
 from .text import TextProperty
 from .texture import numpy_to_texture
 from .themes import Theme
+from .themes import _registry_themes
 from .utilities.algorithms import active_scalars_algorithm
 from .utilities.algorithms import algorithm_to_mesh_handler
 from .utilities.algorithms import decimation_algorithm
@@ -459,6 +460,10 @@ class BasePlotter(_BoundsSizeMixin, PickingHelper, WidgetHelper):
     def theme(self) -> Theme:  # numpydoc ignore=RT01
         """Return or set the theme used for this plotter.
 
+        .. versionadded:: 0.47.0
+            A theme can be set via a string from a set of registered
+            values. See example the below.
+
         Returns
         -------
         pyvista.Theme
@@ -475,11 +480,23 @@ class BasePlotter(_BoundsSizeMixin, PickingHelper, WidgetHelper):
         >>> actor = pl.add_mesh(pv.Sphere())
         >>> pl.show()
 
+
+        >>> pl = pv.Plotter()
+        >>> pl.theme = 'dark'
+        >>> actor = pl.add_mesh(pv.Sphere())
+        >>> pl.show()
+
         """
         return self._theme
 
     @theme.setter
-    def theme(self, theme: Theme) -> None:
+    def theme(self, theme: Theme | str) -> None:
+        if isinstance(theme, str):
+            theme = (reg := _registry_themes).get(theme)
+            if theme is None:
+                msg = f'Theme "{theme}" not found. The available themes are:\n{list(reg.keys())}'
+                raise ValueError(msg)
+
         if not isinstance(theme, pyvista.plotting.themes.Theme):
             msg = (  # type: ignore[unreachable]
                 'Expected a pyvista theme like '

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -264,8 +264,14 @@ class BasePlotter(_BoundsSizeMixin, PickingHelper, WidgetHelper):
         * ``'three lights'``: illumination using 3 lights.
         * ``'none'``: no light sources at instantiation.
 
-    theme : pyvista.plotting.themes.Theme, optional
+    theme : pyvista.plotting.themes.Theme | str, optional
         Plot-specific theme.
+
+        .. versionchanged:: 0.47.0
+            A theme can be set via a string from a set of registered
+            values.
+            Run :func:`pyvista.list_registered_themes` to get all available themes
+            and :func:`pyvista.register_theme` to register your custom theme.
 
     image_scale : int, optional
         Scale factor when saving screenshots. Image sizes will be

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -497,8 +497,6 @@ class BasePlotter(_BoundsSizeMixin, PickingHelper, WidgetHelper):
                 msg = f'Theme "{theme}" not found. The available themes are:\n{list(reg.keys())}'
                 raise ValueError(msg)
 
-            theme = theme()
-
         if not isinstance(theme, pyvista.plotting.themes.Theme):
             msg = (  # type: ignore[unreachable]
                 'Expected a pyvista theme like '

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -83,7 +83,6 @@ from .text import TextProperty
 from .texture import numpy_to_texture
 from .themes import Theme
 from .themes import _get_theme
-from .themes import _registry_themes
 from .utilities.algorithms import active_scalars_algorithm
 from .utilities.algorithms import algorithm_to_mesh_handler
 from .utilities.algorithms import decimation_algorithm
@@ -490,20 +489,7 @@ class BasePlotter(_BoundsSizeMixin, PickingHelper, WidgetHelper):
 
     @theme.setter
     def theme(self, theme: Theme | str) -> None:
-        if isinstance(theme, str):
-            theme = (reg := _registry_themes).get(theme)
-            if theme is None:
-                msg = f'Theme "{theme}" not found. The available themes are:\n{list(reg.keys())}'
-                raise ValueError(msg)
-
-        if not isinstance(theme, pyvista.plotting.themes.Theme):
-            msg = (
-                'Expected a pyvista theme like '
-                '``pyvista.plotting.themes.Theme``, '
-                f'not {type(theme).__name__}.'
-            )
-            raise TypeError(msg)
-        self._theme.load_theme(theme)
+        self._theme.load_theme(_get_theme(theme))
 
     @_deprecate_positional_args(allowed=['filename'])
     def import_gltf(self, filename: str | Path, set_camera: bool = True) -> None:  # noqa: FBT001, FBT002

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -497,6 +497,8 @@ class BasePlotter(_BoundsSizeMixin, PickingHelper, WidgetHelper):
                 msg = f'Theme "{theme}" not found. The available themes are:\n{list(reg.keys())}'
                 raise ValueError(msg)
 
+            theme = theme()
+
         if not isinstance(theme, pyvista.plotting.themes.Theme):
             msg = (  # type: ignore[unreachable]
                 'Expected a pyvista theme like '

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -459,7 +459,7 @@ class BasePlotter(_BoundsSizeMixin, PickingHelper, WidgetHelper):
     def theme(self) -> Theme:  # numpydoc ignore=RT01
         """Return or set the theme used for this plotter.
 
-        .. versionadded:: 0.47.0
+        .. versionchanged:: 0.47.0
             A theme can be set via a string from a set of registered
             values. See example the below.
 

--- a/pyvista/plotting/text.py
+++ b/pyvista/plotting/text.py
@@ -19,6 +19,7 @@ from . import _vtk
 from .colors import Color
 from .prop3d import _Prop3DMixin
 from .themes import Theme
+from .themes import _get_theme
 from .tools import FONTS
 
 if TYPE_CHECKING:
@@ -548,12 +549,12 @@ class TextProperty(_NoNewAttrMixin, _vtk.DisableVtkSnakeCase, _vtk.vtkTextProper
     ):
         """Initialize text's property."""
         super().__init__()
-        if theme is None:
-            # copy global theme to ensure local property theme is fixed
-            # after creation.
-            self._theme.load_theme(pyvista.global_theme)
-        else:
-            self._theme.load_theme(theme)
+
+        # copy global theme to ensure local property theme is fixed
+        # after creation.
+        theme = pyvista.global_theme if theme is None else _get_theme(theme)
+        self._theme.load_theme(theme)
+
         self.color = color
         self.font_family = font_family
         if orientation is not None:

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -116,7 +116,7 @@ def set_plot_theme(theme):
     Parameters
     ----------
     theme : str
-        The theme name.  Available predefined theme names include:
+        The theme name. Available predefined theme names include (non-exhaustive):
 
         - ``'dark'``,
         - ``'default'``,
@@ -126,6 +126,9 @@ def set_plot_theme(theme):
         - ``'paraview'``,
         - ``'testing'`` and
         - ``'vtk'``.
+
+        .. versionadded:: 0.47
+            Run :func:`pyvista.list_registered_themes` to get all available themes.
 
     Examples
     --------
@@ -145,6 +148,11 @@ def set_plot_theme(theme):
     Set to the ParaView theme.
 
     >>> pv.set_plot_theme('paraview')
+
+    From ``v0.47.0``, list all available themes:
+
+    >>> pv.list_registered_themes()
+    ['vtk', 'dark', 'paraview', 'default', 'document', 'document_pro', 'document_build', 'testing']
 
     """
     import pyvista  # noqa: PLC0415

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -3381,6 +3381,10 @@ def unregister_all_themes():  # noqa: D103
     _registry_themes.clear()
 
 
+def list_registered_themes():  # noqa: D103
+    return list(_registry_themes.keys())
+
+
 @register_theme('dark')
 class DarkTheme(Theme):
     """Dark mode theme.

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -138,7 +138,7 @@ def set_plot_theme(theme):
         if theme not in (reg := _registry_themes):
             msg = f"Theme {theme} not found in PyVista's native themes."
             raise ValueError(msg)
-        pyvista.global_theme.load_theme(reg[theme]())
+        pyvista.global_theme.load_theme(reg[theme])
     elif isinstance(theme, Theme):
         pyvista.global_theme.load_theme(theme)
     else:
@@ -3302,7 +3302,21 @@ class Theme(_ThemeConfig):
         self._logo_file = path
 
 
-_registry_themes: dict[str, type] = {'vtk': Theme}
+class _ThemesRegistry(dict):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def __getitem__(self, key: str):
+        item = super().__getitem__(key)
+        return item()
+
+    def get(self, key: str):
+        if (value := super().get(key)) is not None:
+            return value()
+        return None
+
+
+_registry_themes: _ThemesRegistry[str, Theme] = _ThemesRegistry(vtk=Theme)
 
 
 def register_theme(theme: str, cls: type | None = None):  # noqa: D103

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -3373,6 +3373,14 @@ def register_theme(  # noqa: D103
     return decorator_register(obj)
 
 
+def unregister_theme(theme: str):  # noqa: D103
+    del _registry_themes[theme]
+
+
+def unregister_all_themes():  # noqa: D103
+    _registry_themes.clear()
+
+
 @register_theme('dark')
 class DarkTheme(Theme):
     """Dark mode theme.

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -68,6 +68,27 @@ if TYPE_CHECKING:
     from ._typing import ColormapOptions
 
 
+def _get_theme(theme: str | Theme):
+    """Helper function to check and get a theme.
+
+    - if string, lookup in registry
+    - if `Theme` instance, return as is
+
+    Otherwise, raise appropriate error.
+    """  # noqa: D401
+    if isinstance(theme, str):
+        return _registry_themes[theme]
+
+    if isinstance(theme, Theme):
+        return theme
+
+    msg = (  # type: ignore[unreachable]
+        'Expected ``pyvista.plotting.themes.Theme`` or `str` for ``theme``, '
+        f'not {type(theme).__name__}.'
+    )
+    raise TypeError(msg)
+
+
 def _set_plot_theme_from_env() -> None:
     """Set plot theme from an environment variable."""
     if (k := 'PYVISTA_PLOT_THEME') in os.environ:

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -3305,7 +3305,7 @@ class Theme(_ThemeConfig):
 _registry_themes: dict[str, Theme] = {'vtk': Theme()}
 
 
-def register_theme(theme: str):  # noqa: D103
+def register_theme(theme: str, cls: type | None = None):  # noqa: D103
     def decorator_register(cls: type):
         if theme in _registry_themes:
             msg = f'Theme with name "{theme}" is already registered.'
@@ -3322,7 +3322,10 @@ def register_theme(theme: str):  # noqa: D103
         _registry_themes[theme] = cls()
         return cls
 
-    return decorator_register
+    if cls is None:
+        return decorator_register
+
+    return decorator_register(cls)
 
 
 @register_theme('dark')

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -3318,13 +3318,13 @@ class _ThemesRegistry(dict):
         item = super().__getitem__(key)
         return item()
 
-    def get(self, key: str):
+    def get(self, key: str, /):
         if (value := super().get(key)) is not None:
             return value()
         return None
 
 
-_registry_themes: _ThemesRegistry[str, Theme] = _ThemesRegistry(vtk=Theme)
+_registry_themes: _ThemesRegistry[str, type[Theme]] = _ThemesRegistry(vtk=Theme)
 
 
 def register_theme(theme: str, cls: type | None = None):  # noqa: D103

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -32,7 +32,6 @@ pyvista.
 
 from __future__ import annotations
 
-from contextlib import contextmanager
 import inspect
 from itertools import chain
 import json
@@ -3327,12 +3326,6 @@ def register_theme(theme: str, cls: type | None = None):  # noqa: D103
         return decorator_register
 
     return decorator_register(cls)
-
-
-@contextmanager
-def register_temp_theme(theme: str, cls: type):  # noqa: D103
-    yield register_theme(theme=theme, cls=cls)
-    _registry_themes.pop(theme)
 
 
 @register_theme('dark')

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -77,7 +77,12 @@ def _get_theme(theme: str | Theme):
     Otherwise, raise appropriate error.
     """  # noqa: D401
     if isinstance(theme, str):
-        return _registry_themes[theme]
+        _theme = (reg := _registry_themes).get(theme)
+        if _theme is None:
+            msg = f'Theme "{_theme}" not found. The available themes are:\n{list(reg.keys())}'
+            raise ValueError(msg)
+
+        return _theme
 
     if isinstance(theme, Theme):
         return theme
@@ -131,13 +136,13 @@ def load_theme(filename):
     return Theme.from_dict(theme_dict)
 
 
-def set_plot_theme(theme):
+def set_plot_theme(theme: str | Theme):
     """Set the plotting parameters to a predefined theme using a string.
 
     Parameters
     ----------
-    theme : str
-        The theme name. Available predefined theme names include (non-exhaustive):
+    theme : str | Theme
+        The theme name of value. Available predefined theme names include (non-exhaustive):
 
         - ``'dark'``,
         - ``'default'``,
@@ -178,18 +183,7 @@ def set_plot_theme(theme):
     """
     import pyvista  # noqa: PLC0415
 
-    if isinstance(theme, str):
-        if theme not in (reg := _registry_themes):
-            msg = f"Theme {theme} not found in PyVista's native themes."
-            raise ValueError(msg)
-        pyvista.global_theme.load_theme(reg[theme])
-    elif isinstance(theme, Theme):
-        pyvista.global_theme.load_theme(theme)
-    else:
-        msg = (
-            f'Expected a ``pyvista.plotting.themes.Theme`` or ``str``, not {type(theme).__name__}'
-        )
-        raise TypeError(msg)
+    pyvista.global_theme.load_theme(_get_theme(theme=theme))
 
 
 # Mostly from https://stackoverflow.com/questions/56579348/how-can-i-force-subclasses-to-have-slots

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -32,6 +32,7 @@ pyvista.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 import inspect
 from itertools import chain
 import json
@@ -3326,6 +3327,12 @@ def register_theme(theme: str, cls: type | None = None):  # noqa: D103
         return decorator_register
 
     return decorator_register(cls)
+
+
+@contextmanager
+def register_temp_theme(theme: str, cls: type):  # noqa: D103
+    yield register_theme(theme=theme, cls=cls)
+    _registry_themes.pop(theme)
 
 
 @register_theme('dark')

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -79,7 +79,7 @@ def _get_theme(theme: str | Theme):
     if isinstance(theme, str):
         _theme = (reg := _registry_themes).get(theme)
         if _theme is None:
-            msg = f'Theme "{_theme}" not found. The available themes are:\n{list(reg.keys())}'
+            msg = f'Theme "{theme}" not found. The available themes are:\n{list(reg.keys())}'
             raise ValueError(msg)
 
         return _theme

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -138,7 +138,7 @@ def set_plot_theme(theme):
         if theme not in (reg := _registry_themes):
             msg = f"Theme {theme} not found in PyVista's native themes."
             raise ValueError(msg)
-        pyvista.global_theme.load_theme(reg[theme])
+        pyvista.global_theme.load_theme(reg[theme]())
     elif isinstance(theme, Theme):
         pyvista.global_theme.load_theme(theme)
     else:
@@ -3302,7 +3302,7 @@ class Theme(_ThemeConfig):
         self._logo_file = path
 
 
-_registry_themes: dict[str, Theme] = {'vtk': Theme()}
+_registry_themes: dict[str, type] = {'vtk': Theme}
 
 
 def register_theme(theme: str, cls: type | None = None):  # noqa: D103
@@ -3319,7 +3319,7 @@ def register_theme(theme: str, cls: type | None = None):  # noqa: D103
             msg = 'The decorated class must be a subclass of "Theme".'
             raise TypeError(msg)
 
-        _registry_themes[theme] = cls()
+        _registry_themes[theme] = cls
         return cls
 
     if cls is None:

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -3341,10 +3341,15 @@ class _ThemesRegistry(dict[str, type[Theme] | Theme]):
 _registry_themes = _ThemesRegistry(vtk=Theme)
 
 
-def register_theme(theme: str, obj: type[Theme] | Theme | None = None):  # noqa: D103
+def register_theme(  # noqa: D103
+    theme: str,
+    obj: type[Theme] | Theme | None = None,
+    *,
+    override: bool = False,
+):
     def decorator_register(obj: type[Theme] | Theme):
-        if theme in _registry_themes:
-            msg = f'Theme with name "{theme}" is already registered.'
+        if theme in _registry_themes and not override:
+            msg = f'Theme with name "{theme}" is already registered. Use `override` to replace the existing value.'  # noqa: E501
             raise ValueError(msg)
 
         if inspect.isclass(obj):

--- a/tests/plotting/test_theme.py
+++ b/tests/plotting/test_theme.py
@@ -284,6 +284,21 @@ def test_themes(theme):
         pv.set_plot_theme('testing')
 
 
+@pytest.fixture
+def reset_registry_themes():
+    reg = pv.plotting.themes._registry_themes.copy()
+    yield
+    pv.plotting.themes._registry_themes = reg
+
+
+@pytest.mark.usefixtures('reset_registry_themes')
+def test_register_theme():
+    @pv.plotting.themes.register_theme('my_theme')
+    class MyTheme(pv.plotting.themes.Theme): ...
+
+    assert 'my_theme' in pv.plotting.themes._registry_themes
+
+
 def test_raises_register_theme():
     match = re.escape('Theme with name "default" is already registered.')
     with pytest.raises(ValueError, match=match):

--- a/tests/plotting/test_theme.py
+++ b/tests/plotting/test_theme.py
@@ -293,19 +293,10 @@ def reset_registry_themes():
 
 @pytest.mark.usefixtures('reset_registry_themes')
 def test_register_theme():
-    @pv.plotting.themes.register_theme(t := 'my_theme')
+    @pv.plotting.themes.register_theme('my_theme')
     class MyTheme(pv.plotting.themes.Theme): ...
 
-    assert t in pv.plotting.themes._registry_themes
-
-
-def test_register_temp_theme():
-    class MyTheme(pv.plotting.themes.Theme): ...
-
-    with pv.plotting.themes.register_temp_theme(t := 'my_theme', MyTheme):
-        assert t in pv.plotting.themes._registry_themes
-
-    assert t not in pv.plotting.themes._registry_themes
+    assert 'my_theme' in pv.plotting.themes._registry_themes
 
 
 def test_raises_register_theme():

--- a/tests/plotting/test_theme.py
+++ b/tests/plotting/test_theme.py
@@ -293,10 +293,19 @@ def reset_registry_themes():
 
 @pytest.mark.usefixtures('reset_registry_themes')
 def test_register_theme():
-    @pv.plotting.themes.register_theme('my_theme')
+    @pv.plotting.themes.register_theme(t := 'my_theme')
     class MyTheme(pv.plotting.themes.Theme): ...
 
-    assert 'my_theme' in pv.plotting.themes._registry_themes
+    assert t in pv.plotting.themes._registry_themes
+
+
+def test_register_temp_theme():
+    class MyTheme(pv.plotting.themes.Theme): ...
+
+    with pv.plotting.themes.register_temp_theme(t := 'my_theme', MyTheme):
+        assert t in pv.plotting.themes._registry_themes
+
+    assert t not in pv.plotting.themes._registry_themes
 
 
 def test_raises_register_theme():

--- a/tests/plotting/test_theme.py
+++ b/tests/plotting/test_theme.py
@@ -368,6 +368,14 @@ def test_unregister_all_themes():
 
 
 @pytest.mark.usefixtures('empty_registry_themes')
+def test_list_registered_themes():
+    pv.plotting.themes.register_theme(k1 := 'default', Theme())
+    pv.plotting.themes.register_theme(k2 := 'foo', Theme)
+
+    assert pv.themes.list_registered_themes() == [k1, k2]
+
+
+@pytest.mark.usefixtures('empty_registry_themes')
 def test_raises_register_theme():
     pv.plotting.themes._registry_themes[(k := 'default')] = Theme()
 

--- a/tests/plotting/test_theme.py
+++ b/tests/plotting/test_theme.py
@@ -277,7 +277,7 @@ def test_colorbar_position_y(default_theme):
 @pytest.mark.parametrize('theme', pv.plotting.themes._registry_themes)
 def test_themes(theme):
     pv.set_plot_theme(theme)
-    assert pv.global_theme == pv.plotting.themes._registry_themes[theme]()
+    assert pv.global_theme == pv.plotting.themes._registry_themes[theme]
 
 
 @pytest.fixture

--- a/tests/plotting/test_theme.py
+++ b/tests/plotting/test_theme.py
@@ -276,12 +276,8 @@ def test_colorbar_position_y(default_theme):
 
 @pytest.mark.parametrize('theme', pv.plotting.themes._registry_themes)
 def test_themes(theme):
-    try:
-        pv.set_plot_theme(theme)
-        assert pv.global_theme == pv.plotting.themes._registry_themes[theme]
-    finally:
-        # always return to testing theme
-        pv.set_plot_theme('testing')
+    pv.set_plot_theme(theme)
+    assert pv.global_theme == pv.plotting.themes._registry_themes[theme]()
 
 
 @pytest.fixture

--- a/tests/plotting/test_theme.py
+++ b/tests/plotting/test_theme.py
@@ -328,12 +328,8 @@ def test_invalid_theme_type_error():
 
 def test_set_theme():
     theme = pv.plotting.themes.DarkTheme()
-    try:
-        pv.set_plot_theme(theme)
-        assert pv.global_theme == theme
-    finally:
-        # always return to testing theme
-        pv.set_plot_theme('testing')
+    pv.set_plot_theme(theme)
+    assert pv.global_theme == theme
 
 
 def test_invalid_load_theme(default_theme):
@@ -670,33 +666,28 @@ def test_user_theme():
     sphere = pv.Sphere()
     lines = sphere.extract_all_edges()
     points = pv.PolyData(sphere.points)
-    try:
-        pv.set_plot_theme(theme)
+    pv.set_plot_theme(theme)
 
-        pl = pv.Plotter()
-        assert pl.background_color == theme.background
-        sactor = pl.add_mesh(sphere)
-        assert sactor.prop.color == theme.color
-        assert sactor.prop.interpolation.value == theme.lighting_params.interpolation
-        assert sactor.prop.ambient == theme.lighting_params.ambient
-        assert sactor.prop.diffuse == theme.lighting_params.diffuse
-        assert sactor.prop.specular == theme.lighting_params.specular
+    pl = pv.Plotter()
+    assert pl.background_color == theme.background
+    sactor = pl.add_mesh(sphere)
+    assert sactor.prop.color == theme.color
+    assert sactor.prop.interpolation.value == theme.lighting_params.interpolation
+    assert sactor.prop.ambient == theme.lighting_params.ambient
+    assert sactor.prop.diffuse == theme.lighting_params.diffuse
+    assert sactor.prop.specular == theme.lighting_params.specular
 
-        lactor = pl.add_mesh(lines)
-        assert lactor.prop.render_lines_as_tubes == theme.render_lines_as_tubes
-        assert lactor.prop.line_width == theme.line_width
+    lactor = pl.add_mesh(lines)
+    assert lactor.prop.render_lines_as_tubes == theme.render_lines_as_tubes
+    assert lactor.prop.line_width == theme.line_width
 
-        pactor = pl.add_mesh(points)
-        assert pactor.prop.point_size == theme.point_size
+    pactor = pl.add_mesh(points)
+    assert pactor.prop.point_size == theme.point_size
 
-        pl = pv.Plotter()
-        sactor = pl.add_mesh(sphere, pbr=True)
-        assert sactor.prop.roughness == theme.lighting_params.roughness
-        assert sactor.prop.metallic == theme.lighting_params.metallic
-
-    finally:
-        # always return to testing theme
-        pv.set_plot_theme('testing')
+    pl = pv.Plotter()
+    sactor = pl.add_mesh(sphere, pbr=True)
+    assert sactor.prop.roughness == theme.lighting_params.roughness
+    assert sactor.prop.metallic == theme.lighting_params.metallic
 
 
 def test_set_plot_theme_from_env(monkeypatch: pytest.MonkeyPatch):

--- a/tests/plotting/test_theme.py
+++ b/tests/plotting/test_theme.py
@@ -344,6 +344,30 @@ def test_register_theme_override():
 
 
 @pytest.mark.usefixtures('empty_registry_themes')
+def test_unregister_theme():
+    pv.plotting.themes.register_theme(k := 'default', Theme())
+    assert k in pv.plotting.themes._registry_themes
+    pv.plotting.themes.unregister_theme(k)
+    assert k not in pv.plotting.themes._registry_themes
+
+
+@pytest.mark.usefixtures('empty_registry_themes')
+def test_unregister_theme_raises():
+    with pytest.raises(KeyError, match=(k := 'default')):
+        pv.plotting.themes.unregister_theme(k)
+
+
+@pytest.mark.usefixtures('empty_registry_themes')
+def test_unregister_all_themes():
+    pv.plotting.themes.register_theme('default', Theme())
+    pv.plotting.themes.register_theme('test', Theme())
+
+    pv.themes.unregister_all_themes()
+
+    assert len(pv.themes._registry_themes) == 0
+
+
+@pytest.mark.usefixtures('empty_registry_themes')
 def test_raises_register_theme():
     pv.plotting.themes._registry_themes[(k := 'default')] = Theme()
 

--- a/tests/plotting/test_theme.py
+++ b/tests/plotting/test_theme.py
@@ -403,9 +403,11 @@ def test_raises_register_theme():
         pv.plotting.themes.register_theme('foo', 1)
 
 
+@pytest.mark.usefixtures('empty_registry_themes')
 def test_invalid_theme():
-    with pytest.raises(ValueError):  # noqa: PT011
-        pv.set_plot_theme('this is not a valid theme')
+    pv.register_theme('valid')
+    with pytest.raises(ValueError, match=(theme := 'invalid')):
+        pv.set_plot_theme(theme)
 
 
 def test_invalid_theme_type_error():

--- a/tests/plotting/test_theme.py
+++ b/tests/plotting/test_theme.py
@@ -328,13 +328,29 @@ def test_theme_registry_new_objects():
 
 
 @pytest.mark.usefixtures('empty_registry_themes')
-def test_raises_register_theme():
-    pv.plotting.themes._registry_themes['default'] = Theme()
+def test_register_theme_override():
+    pv.plotting.themes.register_theme(k := 'default', Theme())
 
-    match = re.escape('Theme with name "default" is already registered.')
+    # Override with instance
+    my_theme = Theme()
+    my_theme.font.size = 100
+    pv.plotting.themes.register_theme(k, my_theme, override=True)
+
+    assert pv.plotting.themes._registry_themes[k] == my_theme
+
+    # Override with class
+    pv.plotting.themes.register_theme(k, DarkTheme, override=True)
+    assert pv.plotting.themes._registry_themes[k] == DarkTheme()
+
+
+@pytest.mark.usefixtures('empty_registry_themes')
+def test_raises_register_theme():
+    pv.plotting.themes._registry_themes[(k := 'default')] = Theme()
+
+    match = re.escape(f'Theme with name "{k}" is already registered.')
     with pytest.raises(ValueError, match=match):
 
-        @pv.plotting.themes.register_theme('default')
+        @pv.plotting.themes.register_theme(k)
         class MyTheme(pv.plotting.themes.Theme):
             pass
 

--- a/tests/plotting/test_theme.py
+++ b/tests/plotting/test_theme.py
@@ -22,7 +22,7 @@ from pyvista.plotting.themes import _ThemesRegistry
 
 @pytest.fixture
 def default_theme():
-    return pv.plotting.themes.Theme()
+    return pv.themes.Theme()
 
 
 @pytest.mark.parametrize('trame', [1, None, object(), True, pv.Sphere()])
@@ -56,7 +56,7 @@ def test_depth_peeling_config(default_theme, parm):
 
 
 def test_depth_peeling_eq(default_theme):
-    my_theme = pv.plotting.themes.Theme()
+    my_theme = pv.themes.Theme()
     my_theme.depth_peeling.enabled = not my_theme.depth_peeling.enabled
     assert my_theme.depth_peeling != default_theme.depth_peeling
     assert my_theme.depth_peeling != 1
@@ -80,14 +80,14 @@ def test_silhouette_config(default_theme, parm):
 
 
 def test_depth_silhouette_eq(default_theme):
-    my_theme = pv.plotting.themes.Theme()
+    my_theme = pv.themes.Theme()
     my_theme.silhouette.opacity = 0.11111
     assert my_theme.silhouette != default_theme.silhouette
     assert my_theme.silhouette != 1
 
 
 def test_depth_silhouette_opacity_outside_clamp():
-    my_theme = pv.plotting.themes.Theme()
+    my_theme = pv.themes.Theme()
     with pytest.raises(ValueError):  # noqa: PT011
         my_theme.silhouette.opacity = 10
     with pytest.raises(ValueError):  # noqa: PT011
@@ -123,7 +123,7 @@ def test_slider_style_config_eq(default_theme):
 
 
 def test_slider_style_eq(default_theme):
-    my_theme = pv.plotting.themes.Theme()
+    my_theme = pv.themes.Theme()
     my_theme.slider_styles.modern.slider_length *= 2
     assert default_theme.slider_styles != my_theme.slider_styles
 
@@ -152,10 +152,10 @@ def test_font():
 
 
 def test_font_eq(default_theme):
-    defa_theme = pv.plotting.themes.Theme()
+    defa_theme = pv.themes.Theme()
     assert defa_theme.font == default_theme.font
 
-    paraview_theme = pv.plotting.themes.ParaViewTheme()
+    paraview_theme = pv.themes.ParaViewTheme()
     assert paraview_theme.font != default_theme.font
     assert paraview_theme.font != 1
 
@@ -186,9 +186,9 @@ def test_font_fmt(default_theme):
 
 
 def test_axes_eq(default_theme):
-    assert default_theme.axes == pv.plotting.themes.Theme().axes
+    assert default_theme.axes == pv.themes.Theme().axes
 
-    theme = pv.plotting.themes.Theme()
+    theme = pv.themes.Theme()
     theme.axes.box = True
     assert default_theme.axes != theme.axes
     assert default_theme.axes != 1
@@ -244,7 +244,7 @@ def test_axes_show(default_theme):
 
 
 def test_colorbar_eq(default_theme):
-    theme = pv.plotting.themes.Theme()
+    theme = pv.themes.Theme()
     assert default_theme.colorbar_horizontal == theme.colorbar_horizontal
 
     assert default_theme.colorbar_horizontal != 1
@@ -275,24 +275,24 @@ def test_colorbar_position_y(default_theme):
     assert default_theme.colorbar_horizontal.position_y == position_y
 
 
-@pytest.mark.parametrize('theme', pv.plotting.themes._registry_themes)
+@pytest.mark.parametrize('theme', pv.themes._registry_themes)
 def test_themes(theme):
     pv.set_plot_theme(theme)
-    assert pv.global_theme == pv.plotting.themes._registry_themes[theme]
+    assert pv.global_theme == pv.themes._registry_themes[theme]
 
 
 @pytest.fixture
 def empty_registry_themes(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(pv.plotting.themes, '_registry_themes', _ThemesRegistry())
+    monkeypatch.setattr(pv.themes, '_registry_themes', _ThemesRegistry())
 
 
 @pytest.mark.usefixtures('empty_registry_themes')
 def test_register_theme_as_type():
-    @pv.plotting.themes.register_theme(k := 'my_theme')
-    class MyTheme(pv.plotting.themes.Theme): ...
+    @pv.themes.register_theme(k := 'my_theme')
+    class MyTheme(pv.themes.Theme): ...
 
-    assert k in pv.plotting.themes._registry_themes
-    assert pv.plotting.themes._registry_themes[k] == MyTheme()
+    assert k in pv.themes._registry_themes
+    assert pv.themes._registry_themes[k] == MyTheme()
 
 
 @pytest.mark.usefixtures('empty_registry_themes')
@@ -300,10 +300,10 @@ def test_register_theme_as_obj():
     my_theme = pv.themes.DocumentTheme()
     my_theme.font.size = 100
 
-    pv.plotting.themes.register_theme(k := 'my_theme', my_theme)
+    pv.themes.register_theme(k := 'my_theme', my_theme)
 
-    assert k in pv.plotting.themes._registry_themes
-    assert pv.plotting.themes._registry_themes[k] == my_theme
+    assert k in pv.themes._registry_themes
+    assert pv.themes._registry_themes[k] == my_theme
 
 
 def test_theme_registry_new_objects():
@@ -329,38 +329,38 @@ def test_theme_registry_new_objects():
 
 @pytest.mark.usefixtures('empty_registry_themes')
 def test_register_theme_override():
-    pv.plotting.themes.register_theme(k := 'default', Theme())
+    pv.themes.register_theme(k := 'default', Theme())
 
     # Override with instance
     my_theme = Theme()
     my_theme.font.size = 100
-    pv.plotting.themes.register_theme(k, my_theme, override=True)
+    pv.themes.register_theme(k, my_theme, override=True)
 
-    assert pv.plotting.themes._registry_themes[k] == my_theme
+    assert pv.themes._registry_themes[k] == my_theme
 
     # Override with class
-    pv.plotting.themes.register_theme(k, DarkTheme, override=True)
-    assert pv.plotting.themes._registry_themes[k] == DarkTheme()
+    pv.themes.register_theme(k, DarkTheme, override=True)
+    assert pv.themes._registry_themes[k] == DarkTheme()
 
 
 @pytest.mark.usefixtures('empty_registry_themes')
 def test_unregister_theme():
-    pv.plotting.themes.register_theme(k := 'default', Theme())
-    assert k in pv.plotting.themes._registry_themes
-    pv.plotting.themes.unregister_theme(k)
-    assert k not in pv.plotting.themes._registry_themes
+    pv.themes.register_theme(k := 'default', Theme())
+    assert k in pv.themes._registry_themes
+    pv.themes.unregister_theme(k)
+    assert k not in pv.themes._registry_themes
 
 
 @pytest.mark.usefixtures('empty_registry_themes')
 def test_unregister_theme_raises():
     with pytest.raises(KeyError, match=(k := 'default')):
-        pv.plotting.themes.unregister_theme(k)
+        pv.themes.unregister_theme(k)
 
 
 @pytest.mark.usefixtures('empty_registry_themes')
 def test_unregister_all_themes():
-    pv.plotting.themes.register_theme('default', Theme())
-    pv.plotting.themes.register_theme('test', Theme())
+    pv.themes.register_theme('default', Theme())
+    pv.themes.register_theme('test', Theme())
 
     pv.themes.unregister_all_themes()
 
@@ -369,38 +369,38 @@ def test_unregister_all_themes():
 
 @pytest.mark.usefixtures('empty_registry_themes')
 def test_list_registered_themes():
-    pv.plotting.themes.register_theme(k1 := 'default', Theme())
-    pv.plotting.themes.register_theme(k2 := 'foo', Theme)
+    pv.themes.register_theme(k1 := 'default', Theme())
+    pv.themes.register_theme(k2 := 'foo', Theme)
 
     assert pv.themes.list_registered_themes() == [k1, k2]
 
 
 @pytest.mark.usefixtures('empty_registry_themes')
 def test_raises_register_theme():
-    pv.plotting.themes._registry_themes[(k := 'default')] = Theme()
+    pv.themes._registry_themes[(k := 'default')] = Theme()
 
     match = re.escape(f'Theme with name "{k}" is already registered.')
     with pytest.raises(ValueError, match=match):
 
-        @pv.plotting.themes.register_theme(k)
-        class MyTheme(pv.plotting.themes.Theme):
+        @pv.themes.register_theme(k)
+        class MyTheme(pv.themes.Theme):
             pass
 
     match = re.escape('The input must be an instance of "Theme", not "<class \'function\'>')
     with pytest.raises(TypeError, match=match):
 
-        @pv.plotting.themes.register_theme('foo')
+        @pv.themes.register_theme('foo')
         def func(): ...
 
     match = re.escape('The decorated class must be a subclass of "Theme".')
     with pytest.raises(TypeError, match=match):
 
-        @pv.plotting.themes.register_theme('foo')
+        @pv.themes.register_theme('foo')
         class MyTheme: ...
 
     match = re.escape('The input must be an instance of "Theme", not "<class \'int\'>')
     with pytest.raises(TypeError, match=match):
-        pv.plotting.themes.register_theme('foo', 1)
+        pv.themes.register_theme('foo', 1)
 
 
 @pytest.mark.usefixtures('empty_registry_themes')
@@ -416,7 +416,7 @@ def test_invalid_theme_type_error():
 
 
 def test_set_theme():
-    theme = pv.plotting.themes.DarkTheme()
+    theme = pv.themes.DarkTheme()
     pv.set_plot_theme(theme)
     assert pv.global_theme == theme
 
@@ -597,10 +597,10 @@ def test_theme_slots(default_theme):
 
 
 def test_theme_eq():
-    defa_theme0 = pv.plotting.themes.Theme()
-    defa_theme1 = pv.plotting.themes.Theme()
+    defa_theme0 = pv.themes.Theme()
+    defa_theme1 = pv.themes.Theme()
     assert defa_theme0 == defa_theme1
-    dark_theme = pv.plotting.themes.DarkTheme()
+    dark_theme = pv.themes.DarkTheme()
     assert defa_theme0 != dark_theme
 
     # for coverage
@@ -609,7 +609,7 @@ def test_theme_eq():
 
 def test_plotter_set_theme():
     # test that the plotter theme is set to the new theme
-    my_theme = pv.plotting.themes.Theme()
+    my_theme = pv.themes.Theme()
     my_theme.color = [1.0, 0.0, 0.0]
     pl = pv.Plotter(theme=my_theme)
     assert pl.theme.color == my_theme.color
@@ -624,7 +624,7 @@ def test_plotter_set_theme():
     pl = pv.Plotter()
     assert pl.theme == pv.global_theme
     pl.theme = 'dark'
-    assert pl.theme == pv.plotting.themes.DarkTheme()
+    assert pl.theme == pv.themes.DarkTheme()
 
 
 @pytest.mark.filterwarnings(
@@ -633,12 +633,12 @@ def test_plotter_set_theme():
 )
 def test_load_theme(tmpdir, default_theme):
     filename = str(tmpdir.mkdir('tmpdir').join('tmp.json'))
-    pv.plotting.themes.DarkTheme().save(filename)
+    pv.themes.DarkTheme().save(filename)
     loaded_theme = pv.load_theme(filename)
-    assert loaded_theme == pv.plotting.themes.DarkTheme()
+    assert loaded_theme == pv.themes.DarkTheme()
 
     default_theme.load_theme(filename)
-    assert default_theme == pv.plotting.themes.DarkTheme()
+    assert default_theme == pv.themes.DarkTheme()
 
 
 @pytest.mark.filterwarnings(
@@ -647,21 +647,21 @@ def test_load_theme(tmpdir, default_theme):
 )
 def test_save_before_close_callback(tmpdir, default_theme):
     filename = str(tmpdir.mkdir('tmpdir').join('tmp.json'))
-    dark_theme = pv.plotting.themes.DarkTheme()
+    dark_theme = pv.themes.DarkTheme()
 
     def fun(plotter):
         pass
 
     dark_theme.before_close_callback = fun
-    assert dark_theme != pv.plotting.themes.DarkTheme()
+    assert dark_theme != pv.themes.DarkTheme()
     dark_theme.save(filename)
 
     # fun is stripped from the theme
     loaded_theme = pv.load_theme(filename)
-    assert loaded_theme == pv.plotting.themes.DarkTheme()
+    assert loaded_theme == pv.themes.DarkTheme()
 
     default_theme.load_theme(filename)
-    assert default_theme == pv.plotting.themes.DarkTheme()
+    assert default_theme == pv.themes.DarkTheme()
 
 
 def test_anti_aliasing(default_theme):
@@ -786,7 +786,7 @@ def test_set_plot_theme_from_env(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_trame_config():
-    trame_config = pv.plotting.themes._TrameConfig()
+    trame_config = pv.themes._TrameConfig()
 
     # Enabling extension when extension is not available should raise exception
     assert not trame_config.jupyter_extension_available


### PR DESCRIPTION
### Overview

Currently, `pv.set_plot_theme` accepts strings as theme but not `Plotter` initialization.
This PR allows setting a theme as a string.

In addition to that, it enables registering custom themes for simpler reuse via a `register_theme` function.

### Usage

```python
import pyvista as pv

from pyvista import themes

# Register from instance
theme = themes.DarkTheme()
theme.edge_color = 'red'
theme.show_edges = True

themes.register_theme('my_theme_1', theme)


# Register from class using decorator
@themes.register_theme('my_theme_2')
class MyTheme(themes.DocumentTheme):  # noqa: D101
    def __init__(self) -> None:
        """Initialize the theme."""
        super().__init__()
        self.background = 'red'
        self.show_edges = True


pl = pv.Plotter(theme='my_theme_1')
pl.theme = theme
pl.add_mesh(pv.Sphere())
pl.show()

pl = pv.Plotter(theme='my_theme_2')
pl.add_mesh(pv.Sphere())
pl.show()

pl = pv.Plotter(theme='paraview')
pl.add_mesh(pv.Sphere())
pl.show()
```
<details>
<summary>Show plots</summary>
<img width="487" height="425" alt="image" src="https://github.com/user-attachments/assets/8bcc6930-a608-48a3-a250-8f14619c081c" />
<img width="495" height="431" alt="image" src="https://github.com/user-attachments/assets/1fd0b979-1e4a-4083-9360-7b5d7117597f" />
<img width="505" height="432" alt="image" src="https://github.com/user-attachments/assets/7d71885f-21ac-4b66-b4ed-60519ae85475" />
</details>