### PR TITLE
Ignore bad `typing.Union` references in docs build

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -269,6 +269,7 @@ nitpick_ignore_regex = [
     (r'py:.*', 'collections.*'),
     (r'py:.*', '.*PathStrSeq'),
     (r'py:.*', 'ModuleType'),
+    (r'py:.*', 'typing.Union'),
     #
     # NumPy types. TODO: Fix links (intersphinx?)
     (r'py:.*', '.*DTypeLike'),


### PR DESCRIPTION
### Overview

~Fix~ workaround issue mentioned in https://github.com/pyvista/pyvista/pull/8057#issuecomment-3487549350