### PR TITLE
Fix typo in parameter documentation for filename in save_graphic

### DIFF
--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -6203,7 +6203,7 @@ class BasePlotter(_BoundsSizeMixin, PickingHelper, WidgetHelper):
 
         Parameters
         ----------
-        filename : str | Path 
+        filename : str | Path
             Path to save the graphic file to.
 
         title : str, default: "PyVista Export"


### PR DESCRIPTION
Redo of #8061 targeting the right branch. Also add `Path` to the filename type since we clearly support that in the method.