### PR TITLE
Increase `max_navbar_depth` in documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -539,7 +539,7 @@ html_theme_options = {
     'use_edit_page_button': True,
     'navigation_with_keys': False,
     'show_navbar_depth': 1,
-    'max_navbar_depth': 3,
+    'max_navbar_depth': 4,
     'icon_links': [
         {
             'name': 'Slack Community',


### PR DESCRIPTION
### Overview

It's helpful to have a way to move up one level in the docs. This feature is sometimes available as a breadcrumb trail, but 
the `sphinx-book-theme` has no breadcrumbs option (see https://github.com/executablebooks/sphinx-book-theme/issues/904).

As an alternative, we can use the left nav bar to move through the site hierarchy. But for some nested API docs, such as for Utilities, this is not available because the nav bar depth is too shallow.
E.g., look at the menu in the bottom left corner:
| From main | This branch |
|-----------|------------|
| <img width="577" height="671" alt="Screenshot main" src="https://github.com/user-attachments/assets/f9c5d060-ab0b-4aeb-9741-cf4e5a7dfe85" /> | <img width="582" height="643" alt="Screenshot branch" src="https://github.com/user-attachments/assets/8337baf1-418e-433d-9fb7-39a86753bc42" /> |


This is particularly useful for classes such as `Transform`, since there's currently no way to link back to the `Transform` class when you're looking at one of the method or attribute pages.