### PR TITLE
Invert dev banner text color

### DIFF
--- a/doc/source/_static/announcement.css
+++ b/doc/source/_static/announcement.css
@@ -1,7 +1,7 @@
 /* Override the theme's announcement bar wrapper */
 .bd-header-announcement {
   background-color: var(--pst-color-danger) !important;
-  color: var(--pst-color-text-danger) !important;
+  color: var(--pst-color-background) !important;
 }
 
 /* Inner announcement content */
@@ -14,7 +14,7 @@
   text-align: center;
   padding: 0.5em;
   background-color: var(--pst-color-danger);
-  color: var(--pst-color-text-danger);
+  color: var(--pst-color-background);
 }
 
 /* Button inside the banner */
@@ -22,15 +22,15 @@
   margin-left: 0;
   padding: 0.3em 0.6em;
   background-color: var(--pst-color-info);
-  color: var(--pst-color-text-info) !important;
+  color: var(--pst-color-background) !important;
   text-decoration: none;
   border-radius: 4px;
   white-space: nowrap;
 }
 
-/* Ensure the button text stays black on hover */
+/* Button hover keeps consistent text color */
 .pv-announcement-button:hover {
-  color: var(--pst-color-text-info) !important;
+  color: var(--pst-color-background) !important;
 }
 
 /* Responsive adjustments for small screens */


### PR DESCRIPTION
### Overview

The text on the dev banner has somewhat low contrast, since we have white font on light color (dark theme), or black font on dark color (light theme). This PR inverts the font color so that we have better contrast.

This should now match the font color of the "Hide Search Matches" button.

From main:
<img width="1071" height="175" alt="dev banner dark" src="https://github.com/user-attachments/assets/d87a0fbb-e397-4c49-9976-b678c04a2a3c" />
<img width="1063" height="190" alt="dev banner light" src="https://github.com/user-attachments/assets/75dbba37-890d-4a78-811b-f5debf5402b2" />

This branch:
![image](https://github.com/user-attachments/assets/7bb4ef4e-d021-402f-83cd-96ec3a33bd7d)
![image](https://github.com/user-attachments/assets/74961ecc-c735-4466-8676-25937ad5d335)