### PR TITLE
Allow doc builds over 30 minutes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
         run: pip install tox-uv
 
       - name: Build Documentation
-        run: timeout 1800 tox run -e docs-build
+        run: timeout 3600 tox run -e docs-build
 
       - name: Dump Sphinx Build Warnings and Errors
         if: always()


### PR DESCRIPTION
Current documentation build timeouts when over 1800 seconds (30 minutes). Raise that limit to 60 minutes. Depending on server load, actual time ranges from 20-50 minutes.