### PR TITLE
Fix redirect redundant links for cases with .html in link

### DIFF
--- a/doc/source/_static/redirect_fragments.js
+++ b/doc/source/_static/redirect_fragments.js
@@ -11,10 +11,12 @@
     return s.toLowerCase().replace(/[._-]/g, "");
   }
 
-  const tail = path.substring(path.lastIndexOf("/") + 1);
+  // Strip trailing .html for comparison and redirect target
+  const cleanPath = path.replace(/\.html$/, "");
+  const tail = cleanPath.substring(cleanPath.lastIndexOf("/") + 1);
 
   if (norm(tail) === norm(frag)) {
-    // Replace URL without reloading the full page twice
-    history.replaceState({}, "", path);
+    // Replace URL without reloading the page
+    history.replaceState({}, "", cleanPath);
   }
 })();


### PR DESCRIPTION
### Overview

https://github.com/pyvista/pyvista/pull/8079 added redirects, e.g.

https://dev.pyvista.org/api/plotting/_autosummary/pyvista.prop3d#pyvista.Prop3D
now redirects to:
https://dev.pyvista.org/api/plotting/_autosummary/pyvista.prop3d

But there are other cases where the link includes `.html`, e.g.:
https://dev.pyvista.org/api/utilities/_autosummary/pyvista.read.html#pyvista.read
which currently does _not_ work with the redirect. 

This PR fixes this so that the redirect works, and should go to:
https://dev.pyvista.org/api/utilities/_autosummary/pyvista.read