### PR TITLE
Add StructuredPointsWriter wrapper

### DIFF
--- a/pyvista/core/utilities/__init__.py
+++ b/pyvista/core/utilities/__init__.py
@@ -252,6 +252,7 @@ from .writer import RectilinearGridWriter as RectilinearGridWriter
 from .writer import SimplePointsWriter as SimplePointsWriter
 from .writer import STLWriter as STLWriter
 from .writer import StructuredGridWriter as StructuredGridWriter
+from .writer import StructuredPointsWriter as StructuredPointsWriter
 from .writer import TIFFWriter as TIFFWriter
 from .writer import UnstructuredGridWriter as UnstructuredGridWriter
 from .writer import XMLImageDataWriter as XMLImageDataWriter

--- a/pyvista/core/utilities/writer.py
+++ b/pyvista/core/utilities/writer.py
@@ -446,6 +446,19 @@ class StructuredGridWriter(BaseWriter, _DataFormatMixin):
     _vtk_class_name = 'vtkStructuredGridWriter'
 
 
+class StructuredPointsWriter(BaseWriter, _DataFormatMixin):
+    """StructuredPointsWriter for legacy VTK structured points ``.vtk`` files.
+
+    Wraps :vtk:`vtkStructuredPointsWriter`.
+
+    .. versionadded:: 0.47.0
+
+    """
+
+    _vtk_module_name = 'vtkIOLegacy'
+    _vtk_class_name = 'vtkStructuredPointsWriter'
+
+
 class TIFFWriter(BaseWriter):
     """TIFFWriter for ``.tif`` and ``.tiff`` files.
 

--- a/pyvista/core/utilities/writer.py
+++ b/pyvista/core/utilities/writer.py
@@ -451,7 +451,7 @@ class StructuredPointsWriter(BaseWriter, _DataFormatMixin):
 
     Wraps :vtk:`vtkStructuredPointsWriter`.
 
-    .. versionadded:: 0.47.0
+    .. versionadded:: 0.48.0
 
     """
 

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -3058,7 +3058,7 @@ def test_writer_data_mode_mixin(writer_cls):
 def test_fileio_extensions(cls):
     if cls is pv.HDFWriter and pv.vtk_version_info < (9, 4, 0):
         pytest.xfail('Needs vtk 9.4')
-    if cls in [pv.OpenFOAMReader, pv.MultiBlockPlot3DReader]:
+    if cls in [pv.OpenFOAMReader, pv.MultiBlockPlot3DReader, pv.StructuredPointsWriter]:
         # These classes are not associated with any extensions
         pytest.xfail()
     assert len(cls.extensions) > 0


### PR DESCRIPTION
### Overview

This PR adds a wrapper for `vtkStructuredPointsWriter` to write legacy VTK structured points `.vtk` files.

This complements the existing `StructuredGridWriter` and provides complete support for the legacy VTK file formats.

### Details

- Add `StructuredPointsWriter` class wrapping `vtkStructuredPointsWriter`
- Inherits from `BaseWriter` and `_DataFormatMixin` for binary/ascii format support
- Export in `pyvista.core.utilities` module