### PR TITLE
Constant array data typing

### DIFF
--- a/doc/source/user-guide/data_model.rst
+++ b/doc/source/user-guide/data_model.rst
@@ -528,6 +528,14 @@ and the name of the active scalars array can be accessed or set with
    >>> ugrid.cell_data.active_scalars_name = 'my-cell-data'
    >>> ugrid.cell_data
 
+Note that setting a constant value induces that the resulting array
+is reshaped to fit the number of cells such that:
+
+.. jupyter-execute::
+
+   >>> ugrid.cell_data['constant'] = 1
+   >>> ugrid.cell_data['constant']
+
 
 Point Data
 ~~~~~~~~~~
@@ -600,6 +608,14 @@ active scalars array can be accessed or set with
 
    >>> ugrid.point_data.active_scalars_name = 'my-point-data'
    >>> ugrid.point_data
+
+As with cell data, note that setting a constant value induces that the resulting array
+is reshaped to fit the number of points such that:
+
+.. jupyter-execute::
+
+   >>> ugrid.point_data['constant'] = 1
+   >>> ugrid.point_data['constant']
 
 
 Dataset Active Scalars

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1011,6 +1011,7 @@ class DataSet(DataSetFilters, DataObject):
         >>> mesh.clear_data()
         >>> mesh.point_data['my_array'] = np.random.default_rng().random(mesh.n_points)
         >>> mesh.point_data['my_other_array'] = np.arange(mesh.n_points)
+        >>> mesh.point_data['my_other_array2'] = 2.0
         >>> mesh.point_data
         pyvista DataSetAttributes
         Association     : POINT
@@ -1021,11 +1022,15 @@ class DataSet(DataSetFilters, DataObject):
         Contains arrays :
             my_array                float64    (8,)                 SCALARS
             my_other_array          int64      (8,)
+            my_other_array2         float64    (8,)
 
         Access an array from ``point_data``.
 
         >>> mesh.point_data['my_other_array']
         pyvista_ndarray([0, 1, 2, 3, 4, 5, 6, 7])
+
+        >>> mesh.point_data['my_other_array2']
+        pyvista_ndarray([2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0])
 
         Or access it directly from the mesh.
 
@@ -1102,6 +1107,7 @@ class DataSet(DataSetFilters, DataObject):
         >>> mesh.clear_data()
         >>> mesh.cell_data['my_array'] = np.random.default_rng().random(mesh.n_cells)
         >>> mesh.cell_data['my_other_array'] = np.arange(mesh.n_cells)
+        >>> mesh.cell_data['my_other_array2'] = 2.0
         >>> mesh.cell_data
         pyvista DataSetAttributes
         Association     : CELL
@@ -1112,11 +1118,15 @@ class DataSet(DataSetFilters, DataObject):
         Contains arrays :
             my_array                float64    (6,)                 SCALARS
             my_other_array          int64      (6,)
+            my_other_array2         float64    (6,)
 
         Access an array from ``cell_data``.
 
         >>> mesh.cell_data['my_other_array']
         pyvista_ndarray([0, 1, 2, 3, 4, 5])
+
+        >>> mesh.cell_data['my_other_array2']
+        pyvista_ndarray([2.0, 2.0, 2.0, 2.0, 2.0, 2.0])
 
         Or access it directly from the mesh.
 

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 
     from ._typing_core import ArrayLike
     from ._typing_core import MatrixLike
+    from ._typing_core import NumberType
     from ._typing_core import NumpyArray
 
 # from https://vtk.org/doc/nightly/html/vtkDataSetAttributes_8h_source.html
@@ -250,7 +251,9 @@ class DataSetAttributes(
         return self.get_array(key)
 
     def __setitem__(
-        self: Self, key: str, value: ArrayLike[Any]
+        self: Self,
+        key: str,
+        value: ArrayLike[Any] | NumberType,
     ) -> None:  # numpydoc ignore=PR01,RT01
         """Implement setting with the ``[]`` operator."""
         if not isinstance(key, str):
@@ -489,7 +492,12 @@ class DataSetAttributes(
         return narray
 
     @_deprecate_positional_args(allowed=['data', 'name'])
-    def set_array(self: Self, data: ArrayLike[float], name: str, deep_copy: bool = False) -> None:  # noqa: FBT001, FBT002
+    def set_array(
+        self: Self,
+        data: ArrayLike[float] | NumberType,
+        name: str,
+        deep_copy: bool = False,  # noqa: FBT001, FBT002
+    ) -> None:
         """Add an array to this object.
 
         Use this method when adding arrays to the DataSet.  If
@@ -503,8 +511,8 @@ class DataSetAttributes(
 
         Parameters
         ----------
-        data : ArrayLike[float]
-            Array of data.
+        data : ArrayLike[float] | NumberType
+            Array of data or constant value
 
         name : str
             Name to assign to the data.  If this name already exists,
@@ -529,6 +537,12 @@ class DataSetAttributes(
         >>> mesh.point_data.set_array(data, 'my-data')
         >>> mesh.point_data['my-data']
         pyvista_ndarray([0, 1, 2, 3, 4, 5, 6, 7])
+
+        Add a constant point array to a mesh using a single value
+
+        >>> mesh.point_data.set_array(1, 'my-data2')
+        >>> mesh.point_data['my-data2']
+        pyvista_ndarray([1, 1, 1, 1, 1, 1, 1, 1])
 
         Add a cell array to a mesh.
 
@@ -556,7 +570,7 @@ class DataSetAttributes(
     @_deprecate_positional_args(allowed=['scalars', 'name'])
     def set_scalars(
         self: Self,
-        scalars: ArrayLike[float],
+        scalars: ArrayLike[float] | NumberType,
         name: str = 'scalars',
         deep_copy: bool = False,  # noqa: FBT001, FBT002
     ) -> None:
@@ -572,8 +586,8 @@ class DataSetAttributes(
 
         Parameters
         ----------
-        scalars : ArrayLike[float]
-            Array of data.
+        scalars : ArrayLike[float] | NumberType
+            Array of data or constant value.
 
         name : str, default: 'scalars'
             Name to assign the scalars.
@@ -692,7 +706,7 @@ class DataSetAttributes(
     def _prepare_array(
         self: Self,
         *,
-        data: npt.ArrayLike,
+        data: npt.ArrayLike | NumberType,
         name: str,
         deep_copy: bool,
     ) -> _vtk.vtkAbstractArray:  # numpydoc ignore=PR01,RT01


### PR DESCRIPTION
### Overview

This PR fixes a typing issue encountered when setting a constant value as `point_data` or `cell_data`.

<img width="987" height="372" alt="image" src="https://github.com/user-attachments/assets/05a8b12f-496f-4bd3-b836-21efc3894ebd" />
