### PR TITLE
Ignore NumPy deprecation warning emitted by `vtk_to_numpy` 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,6 +249,7 @@ filterwarnings = [
   'ignore:.*numpy.dtype size changed.*:RuntimeWarning', # bogus numpy ABI warning (see numpy/#432)
   'ignore:.*numpy.ufunc size changed.*:RuntimeWarning', # bogus numpy ABI warning (see numpy/#432)
   'ignore:Passing .{1}N.{1} to ListedColormap is deprecated since:DeprecationWarning', # https://github.com/matplotlib/cmocean/pull/114
+  'ignore:Setting the shape on a NumPy array has been deprecated in NumPy 2.5.', # https://numpy.org/devdocs/release/2.5.0-notes.html#setting-the-shape-attribute-is-deprecated
   'ignore:The .*interactive_bk.* attribute was deprecated in Matplotlib 3\.9.*:matplotlib.MatplotlibDeprecationWarning', # https://github.com/microsoft/debugpy/issues/1623
   'ignore:pyvista test \w+ image dir.* does not yet exist.  Creating dir.:UserWarning',
 


### PR DESCRIPTION
### Overview

This is a warning emitted by  `vtk_to_numpy` which we can't control or fix directly, so let's ignore it.
There is a small risk that doing so will also mask any real warnings emitted by PyVista code that sets array shape directly. I did a quick search for this though and it does not appear there are any such cases.