### PR TITLE
Show object name instead of full name in sidebar documentation

### DIFF
--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -1,4 +1,4 @@
-{{ fullname | escape | underline}}
+{{ objname | escape | underline}}
 
 .. currentmodule:: {{ module }}
 


### PR DESCRIPTION
### Overview

The titles in the documentation sidebar are a bit verbose. This can make it difficult to see the class name, e.g. it's a bit hard to see that the current page is for `BiQuadraticQuadraticHexahedron`
<img width="300" height="448" alt="image" src="https://github.com/user-attachments/assets/3e4e6868-b5eb-485e-b01f-fbc482855f80" />
