### PR TITLE
Use trusted publishing for release `0.46.5`

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -167,6 +167,13 @@ jobs:
           - python-version: "3.13"
             vtk-version: "latest"
             numpy-version: "nightly"
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyvista
+    permissions:
+      id-token: write # this permission is mandatory for trusted publishing
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -271,13 +278,8 @@ jobs:
           twine check --strict dist/*
 
       - name: Upload to PyPi
-        if: matrix.python-version == '3.9' && startsWith(github.ref, 'refs/tags/v')
-        run: |
-          twine upload --skip-existing dist/pyvista*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-          TWINE_REPOSITORY_URL: "https://upload.pypi.org/legacy/"
+        if: matrix.python-version == '3.13' && startsWith(github.ref, 'refs/tags/v')
+        uses: pypa/gh-action-pypi-publish@ab69e431e9c9f48a3310be0a56527c679f56e04d
 
   VTK-dev:
     # For PRs, only run this job if the 'vtk-dev-testing' label is applied


### PR DESCRIPTION
### Overview

Similar to #8007 , but for the `release/0.46` branch to address PyPI upload failure https://github.com/pyvista/pyvista/pull/8241#issuecomment-3752068711