### PR TITLE
Make labels always visible for ray-trace example

### DIFF
--- a/examples/99-advanced/ray_trace_moeller.py
+++ b/examples/99-advanced/ray_trace_moeller.py
@@ -124,7 +124,12 @@ if inter:
         style='wireframe',
     )
     pl.add_points(np.array([point]), point_size=20, render_points_as_spheres=True, color='b')
-    pl.add_point_labels(tri, [f'a = {1 - u - v:.3}', f'b = {u:.3}', f'c = {v:.3}'], font_size=40)
+    pl.add_point_labels(
+        tri,
+        [f'a = {1 - u - v:.3}', f'b = {u:.3}', f'c = {v:.3}'],
+        font_size=40,
+        always_visible=True,
+    )
     pl.show_bounds()
     pl.camera_position = 'xy'
     pl.show()


### PR DESCRIPTION
Address hidden label in ray trace example in `vtk==9.6.0rc2` as pointed out in #8228. Changing the view angle slightly does make the label visible, but we shouldn't have to change the camera position to slightly off the `xy` plane.