### PR TITLE
Rotate 180 for env texture for vtk>=9.6

### DIFF
--- a/pyvista/plotting/texture.py
+++ b/pyvista/plotting/texture.py
@@ -562,7 +562,8 @@ class Texture(DataObject, _vtk.vtkTexture):
 
         # maintain backwards compatibility with VTK <9.6
         if pv.vtk_version_info >= (9, 6, 0):
-            vmat = pv.vtkmatrix_from_array(pv.Transform().rotate_y(180).rotation_matrix)
+            rotate_y_180 = np.array([[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, -1.0]])
+            vmat = pv.vtkmatrix_from_array(rotate_y_180)
             pl.renderer.SetEnvironmentRotationMatrix(vmat)
 
         pl.add_mesh(

--- a/pyvista/plotting/texture.py
+++ b/pyvista/plotting/texture.py
@@ -559,7 +559,13 @@ class Texture(DataObject, _vtk.vtkTexture):
         pl = pv.Plotter(lighting=lighting)
         pl.add_actor(self.to_skybox())
         pl.set_environment_texture(self, is_srgb=True)
-        pl.add_mesh(pv.Sphere(), pbr=True, roughness=0.5, metallic=1.0)
+
+        # maintain backwards compatibility with VTK <9.6
+        if pv.vtk_version_info >= (9, 6, 0):
+            vmat = pv.vtkmatrix_from_array(pv.Transform().rotate_y(180).as_rotation().as_matrix())
+            pl.renderer.SetEnvironmentRotationMatrix(vmat)
+
+        pl.add_mesh(pv.Sphere(), pbr=True, roughness=0.1, metallic=1.0)
         pl.camera_position = cpos
         pl.camera.zoom(zoom)
         if show_axes:

--- a/pyvista/plotting/texture.py
+++ b/pyvista/plotting/texture.py
@@ -561,8 +561,8 @@ class Texture(DataObject, _vtk.vtkTexture):
         pl.set_environment_texture(self, is_srgb=True)
 
         # maintain backwards compatibility with VTK <9.6
-        if pv.vtk_version_info >= (9, 6, 0):  # pragma: no cover
-            vmat = pv.vtkmatrix_from_array(pv.Transform().rotate_y(180).as_rotation().as_matrix())
+        if pv.vtk_version_info >= (9, 6, 0):
+            vmat = pv.vtkmatrix_from_array(pv.Transform().rotate_y(180).rotation_matrix)
             pl.renderer.SetEnvironmentRotationMatrix(vmat)
 
         pl.add_mesh(

--- a/pyvista/plotting/texture.py
+++ b/pyvista/plotting/texture.py
@@ -561,11 +561,16 @@ class Texture(DataObject, _vtk.vtkTexture):
         pl.set_environment_texture(self, is_srgb=True)
 
         # maintain backwards compatibility with VTK <9.6
-        if pv.vtk_version_info >= (9, 6, 0):
+        if pv.vtk_version_info >= (9, 6, 0):  # pragma: no cover
             vmat = pv.vtkmatrix_from_array(pv.Transform().rotate_y(180).as_rotation().as_matrix())
             pl.renderer.SetEnvironmentRotationMatrix(vmat)
 
-        pl.add_mesh(pv.Sphere(), pbr=True, roughness=0.1, metallic=1.0)
+        pl.add_mesh(
+            pv.Sphere(),
+            pbr=True,
+            roughness=kwargs.pop('roughness', 0.5),
+            metallic=kwargs.pop('metallic', 1.0),
+        )
         pl.camera_position = cpos
         pl.camera.zoom(zoom)
         if show_axes:


### PR DESCRIPTION
This PR addresses the behavior change pointed out in #8228 where the enviornment texture is flipped about the Y axis by 180 degrees in VTK v9.6.

I think the base behavior change by VTK is acceptable, but our plot should flip the view direction of the environment as the sphere reflects the enviornment back, which is not the case anymore on `main` for `vtk==9.6.0rc2`. Turning down the roughness you can see that the default behavior is to directly map the environment onto the skybox:

```py
from pyvista import examples

cube_map = examples.download_sky_box_cube_map()
cube_map.plot(roughness=0.5)
```
<img width="1017" height="763" alt="sc008" src="https://github.com/user-attachments/assets/61a91cc2-f955-4047-a4be-e946cc0526ec" />

This PR reverts this behavior by simply flipping the enviornment rotation about the Y axis which results in:

<img width="1021" height="764" alt="sc006" src="https://github.com/user-attachments/assets/f6c4017b-cf03-4edc-9c93-ef6bd44a6cc8" />
