### PR TITLE
bump to v0.47.0

### DIFF
--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -16,7 +16,7 @@ Denotes the first release candidate.
 # major, minor, patch
 from __future__ import annotations
 
-version_info = 0, 48, 'dev0'
+version_info = 0, 47, 0
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
# Release v0.47.0

- [x] Bump `release/0.47` to `0.47.0` (this PR)
- [x] Tag `v0.47.0` and push the tag.
- [x] Verify [docs](https://docs.pyvista.org/) and [PyPI](https://pypi.org/project/pyvista/) have updated.
- [x] Update the [conda-forge feedstock](https://github.com/conda-forge/pyvista-feedstock).
- [x] Generate [release documentation](https://github.com/pyvista/pyvista/releases/tag/v0.47.0)

## Release Notes Draft

---

## What's Changed

### Breaking Changes
* Improve number_time_points property in EnsightReader by @riku-sakamoto in https://github.com/pyvista/pyvista/pull/7804
* Do not always get last image depth by @akaszynski in https://github.com/pyvista/pyvista/pull/7953
* Make `CameraPosition.__repr__` explicit by @user27182 in https://github.com/pyvista/pyvista/pull/7794
* Use 2D labels by default with CubeAxesActor for VTK 9.6 by @user27182 in https://github.com/pyvista/pyvista/pull/8248

### New Features
* Add `Texture.color_mode` and use `'direct'` mode by default by @user27182 in https://github.com/pyvista/pyvista/pull/7757
* Add `pass_point(cell)_ids` to `extract_points(cells)` by @user27182 in https://github.com/pyvista/pyvista/pull/7765
* Add remove_existing_actor parameter to add_mesh by @tkoyama010 in https://github.com/pyvista/pyvista/pull/7809
* Add `point` keyword to `Transform.compose` by @user27182 in https://github.com/pyvista/pyvista/pull/7869
* Add optional downloads info to `Report` by @user27182 in https://github.com/pyvista/pyvista/pull/7927
* Add `border_mode` to `resample` filter by @user27182 in https://github.com/pyvista/pyvista/pull/7964
* Add `bspline` interpolator to `resample` filter by @user27182 in https://github.com/pyvista/pyvista/pull/7965
* Add command line interface with `--version` and `report` options by @user27182 in https://github.com/pyvista/pyvista/pull/7463
* Allow adding mesh to plotter from file by @user27182 in https://github.com/pyvista/pyvista/pull/7976
* Add `plot` command to pyvista CLI by @user27182 in https://github.com/pyvista/pyvista/pull/7970
* Use `cyclopts` as CLI library by @edabor in https://github.com/pyvista/pyvista/pull/7991
* Improve morphological filters for ImageData by @tkoyama010 in https://github.com/pyvista/pyvista/pull/7833
* Use binary filter dynamically with morphological operators by @user27182 in https://github.com/pyvista/pyvista/pull/7996
* Add `convert` CLI command for converting mesh file format by @user27182 in https://github.com/pyvista/pyvista/pull/8005
* Disallow no files for `pyvista plot` CLI by @edabor in https://github.com/pyvista/pyvista/pull/8011
* Add `allow_new_attributes` state manager class by @user27182 in https://github.com/pyvista/pyvista/pull/7864
* Add image `concatenate` filter by @user27182 in https://github.com/pyvista/pyvista/pull/8013
* Add `connectivity` region assignment mode by @edabor in https://github.com/pyvista/pyvista/pull/8029
* Add `background_value` keyword to `concatenate` filter by @user27182 in https://github.com/pyvista/pyvista/pull/8031
* Add `Transform` component properties by @user27182 in https://github.com/pyvista/pyvista/pull/8051
* Add multi-level option to `Box` by @user27182 in https://github.com/pyvista/pyvista/pull/8068
* Add png, jpg, tiff, nifti, bmp, pnm image writers by @user27182 in https://github.com/pyvista/pyvista/pull/8084
* Add writer classes by @user27182 in https://github.com/pyvista/pyvista/pull/8094
* Add `DataObject.cast_to_multiblock` by @user27182 in https://github.com/pyvista/pyvista/pull/8106
* Generalize `dimensionality` property for all datasets by @user27182 in https://github.com/pyvista/pyvista/pull/8121
* Add more arguments to spline by @tletut0ur in https://github.com/pyvista/pyvista/pull/8072
* Enable `VtkErrorCatcher` to catch VTK warnings by @user27182 in https://github.com/pyvista/pyvista/pull/7863
* Add warping spheres example and enable plotting `PartitionedDataSet` by @user27182 in https://github.com/pyvista/pyvista/pull/8111
* Allow using `Plane` with plane-based filters by @user27182 in https://github.com/pyvista/pyvista/pull/8151
* Add `UnstructuredGrid.distinct_cell_types` by @user27182 in https://github.com/pyvista/pyvista/pull/8160
* Enable setting dataset `center` by @user27182 in https://github.com/pyvista/pyvista/pull/8174
* Add `length` option to `resize` filter by @user27182 in https://github.com/pyvista/pyvista/pull/8175
* Add `pv.to_trimesh` and `pv.from_trimesh` functions by @user27182 in https://github.com/pyvista/pyvista/pull/8176
* Add `select_interior_points` filter to replace `select_enclosed_points` by @user27182 in https://github.com/pyvista/pyvista/pull/8181
* Support mesh validation for `MultiBlock` by @user27182 in https://github.com/pyvista/pyvista/pull/8189
* Add min/max cell dimensionality by @user27182 in https://github.com/pyvista/pyvista/pull/8186
* Add generic typing for mesh validation reports by @user27182 in https://github.com/pyvista/pyvista/pull/8203
* Add validate keyword to mesh constructors by @user27182 in https://github.com/pyvista/pyvista/pull/8222
* Add `font_size`, `point_size`, `line_width` and `normals_scale` keywords to `plot_cell` by @user27182 in https://github.com/pyvista/pyvista/pull/8236
* Generalize `distinct_cell_types` for all datasets by @user27182 in https://github.com/pyvista/pyvista/pull/8224
* Enable customizing `AxesAssembly` geometry and add anti-distortion scaling mode by @user27182 in https://github.com/pyvista/pyvista/pull/8274
* Make `AxesAssembly` `anti_distortion` scale mode work with `user_matrix` by @user27182 in https://github.com/pyvista/pyvista/pull/8277
* Add `DataSet.has_nonlinear_cells` property by @user27182 in https://github.com/pyvista/pyvista/pull/8286
* Include cell type info with mesh validation report by @user27182 in https://github.com/pyvista/pyvista/pull/8227

### Bug fixes or behavior changes
* Allow using matplotlib cmap objects with `get_cmap_safe` and global theme by @user27182 in https://github.com/pyvista/pyvista/pull/7787
* Fix camera position typing to allow nested sequence by @user27182 in https://github.com/pyvista/pyvista/pull/7788
* Fix VTK error when setting axis visibility by @akaszynski in https://github.com/pyvista/pyvista/pull/7802
* Fix vtkhdf documentation link by @user27182 in https://github.com/pyvista/pyvista/pull/7805
* Fix ChartMPL scaling and eigenvector example scaling by @akaszynski in https://github.com/pyvista/pyvista/pull/7812
* Fix `clip_box` with `MultiBlock` and  `crinkle` by @user27182 in https://github.com/pyvista/pyvista/pull/7813
* Detect wayland by @akaszynski in https://github.com/pyvista/pyvista/pull/7816
* Fix return type for `clip` and `clip_surface` filters to match input type for `PolyData` and `PointSet` by @user27182 in https://github.com/pyvista/pyvista/pull/7795
* Fix Apple Silicon memory leak on unit testing by @akaszynski in https://github.com/pyvista/pyvista/pull/7830
* Fix `BoundsTuple.__repr__` with scientific notation by @user27182 in https://github.com/pyvista/pyvista/pull/7840
* Fix type hints for `promote_type` decorator by @user27182 in https://github.com/pyvista/pyvista/pull/7839
* Use vtkEGLRenderWindow for docs by @akaszynski in https://github.com/pyvista/pyvista/pull/7861
* Ensure Report can be created without opengl libraries by @akaszynski in https://github.com/pyvista/pyvista/pull/7836
* Remove unused points after using `clip` or `clip_box` by @user27182 in https://github.com/pyvista/pyvista/pull/7789
* Complete double rendering patch by @akaszynski in https://github.com/pyvista/pyvista/pull/7918
* Add pathlib support to compare_images by @akaszynski in https://github.com/pyvista/pyvista/pull/7936
* Make extract_cells and extract_points thread-safe with no side effects by @akaszynski in https://github.com/pyvista/pyvista/pull/7946
* Fix render window class name in Report and reduce report execution time by @user27182 in https://github.com/pyvista/pyvista/pull/7949
* Fixed timer duration only activating on initial start by @DominicBen in https://github.com/pyvista/pyvista/pull/7958
* Check polyhedron_faces when determining equivalency by @akaszynski in https://github.com/pyvista/pyvista/pull/7951
* BUG: Dont set global warning state by @larsoner in https://github.com/pyvista/pyvista/pull/7997
* Fix `get_data_range` for `bool` dtype by @user27182 in https://github.com/pyvista/pyvista/pull/8000
* Fix implicit vtk array copy data type by @user27182 in https://github.com/pyvista/pyvista/pull/8037
* Fix obb tree cache by @user27182 in https://github.com/pyvista/pyvista/pull/8039
* Restrict `trame-server` dependency by @edabor in https://github.com/pyvista/pyvista/pull/8044
* Fix depth image with parallel projection by @user27182 in https://github.com/pyvista/pyvista/pull/8062
* Fix doc building by @edabor in https://github.com/pyvista/pyvista/pull/8082
* Fix cell picking inconsistencies by @edabor in https://github.com/pyvista/pyvista/pull/8065
* Fix LaTeX rendering by @user27182 in https://github.com/pyvista/pyvista/pull/8086
* Fix `dimensionality` of empty `ImageData` by @user27182 in https://github.com/pyvista/pyvista/pull/8126
* Disable scrolling for trame iframe by @banesullivan in https://github.com/pyvista/pyvista/pull/8157
* Fix 2D font scaling with CubeAxesActor for latest VTK by @user27182 in https://github.com/pyvista/pyvista/pull/8167
* Fix face orientations of cell examples by @user27182 in https://github.com/pyvista/pyvista/pull/8169
* Support validating PointSet meshes by @user27182 in https://github.com/pyvista/pyvista/pull/8188
* Validate data array lengths when wrapping vtk meshes by @user27182 in https://github.com/pyvista/pyvista/pull/8201
* Raise `ValueError` when accessing `obbTree` with empty `PolyData` by @user27182 in https://github.com/pyvista/pyvista/pull/8206
* Add optional `validate` keyword to PolyData and UnstructuredGrid constructors by @user27182 in https://github.com/pyvista/pyvista/pull/8216
* Raise OSError for invalid file paths when saving by @riku-sakamoto in https://github.com/pyvista/pyvista/pull/8291

### Documentation
* Drop support for Python 3.9 and VTK 9.0.3 by @tkoyama010 in https://github.com/pyvista/pyvista/pull/7693
* Revert "Drop support for Python 3.9 and VTK 9.0.3" by @banesullivan in https://github.com/pyvista/pyvista/pull/7785
* Use vtk role for GLTF and VRML exporter links by @user27182 in https://github.com/pyvista/pyvista/pull/7807
* Drop support for Python 3.9, VTK 9.0.3, and VTK 9.1 by @tkoyama010 in https://github.com/pyvista/pyvista/pull/7796
* Remove deprecated `download_can` example by @user27182 in https://github.com/pyvista/pyvista/pull/7842
* Update vtk string formatting spec for latest vtk dev wheels (vtk 9.6) by @user27182 in https://github.com/pyvista/pyvista/pull/7876
* DOC: Minor formatting issue by @echedey-ls in https://github.com/pyvista/pyvista/pull/7922
* Fix interactive plots using `np.arange` by @edabor in https://github.com/pyvista/pyvista/pull/7924
* Fix argument mismatch in picking documentation by @edabor in https://github.com/pyvista/pyvista/pull/7969
* Fix see also ref for `close` filter by @user27182 in https://github.com/pyvista/pyvista/pull/8006
* docs: update set_plot_theme docstring by @bjlittle in https://github.com/pyvista/pyvista/pull/8028
* Deprecate setting `theme` attribute to `Plotter` by @edabor in https://github.com/pyvista/pyvista/pull/8032
* Use `CameraPosition` explicitly in docs by @user27182 in https://github.com/pyvista/pyvista/pull/8045
* Fix typo in parameter documentation for filename in save_graphic by @akaszynski in https://github.com/pyvista/pyvista/pull/8063
* Standardize `import pyvista as pv` and `pl = pv.Plotter()` by @user27182 in https://github.com/pyvista/pyvista/pull/8076
* Add vtk class references to reader docs by @user27182 in https://github.com/pyvista/pyvista/pull/8075
* Add unstable banner to dev docs by @user27182 in https://github.com/pyvista/pyvista/pull/8067
* Add Methods and Attributes headings to class docs by @user27182 in https://github.com/pyvista/pyvista/pull/8064
* Increase `max_navbar_depth` in documentation by @user27182 in https://github.com/pyvista/pyvista/pull/8066
* Standardize `Import pyvista as pv` and `pl = pv.Plotter()` by @user27182 in https://github.com/pyvista/pyvista/pull/8080
* Invert dev banner text color by @user27182 in https://github.com/pyvista/pyvista/pull/8083
* Dynamically generate readers table by @user27182 in https://github.com/pyvista/pyvista/pull/8074
* Redirect redundant anchors generated by Sphinx by @user27182 in https://github.com/pyvista/pyvista/pull/8079
* Remove reference and use of vtk-mesa by @banesullivan in https://github.com/pyvista/pyvista/pull/8056
* Fix redirect redundant links for cases with .html in link by @user27182 in https://github.com/pyvista/pyvista/pull/8092
* Improve documentation for supported file formats by @user27182 in https://github.com/pyvista/pyvista/pull/8091
* Fix broken documentation for `ImageData` examples by @edabor in https://github.com/pyvista/pyvista/pull/8107
* Move typing docstrings to `doc` rst files by @user27182 in https://github.com/pyvista/pyvista/pull/8114
* Fix return type in documentation by @edabor in https://github.com/pyvista/pyvista/pull/8081
* Update `omfvista` link by @user27182 in https://github.com/pyvista/pyvista/pull/8149
* Update Professional Support and Sponsorships by @banesullivan in https://github.com/pyvista/pyvista/pull/8150
* Fix empty interactive examples in documentation by @edabor in https://github.com/pyvista/pyvista/pull/8118
* Remove long documentation from `CellType` by @user27182 in https://github.com/pyvista/pyvista/pull/8171
* Filter Sphinx Gallery warnings by @user27182 in https://github.com/pyvista/pyvista/pull/8180
* Include type hints for `okabe_ito` colormap by @user27182 in https://github.com/pyvista/pyvista/pull/8187
* HAPPY NEW YEAR 2026 by @tkoyama010 in https://github.com/pyvista/pyvista/pull/8214
* Expand docs for PolyData verts, lines, faces, strips by @user27182 in https://github.com/pyvista/pyvista/pull/8215
* Add missing references to length keyword in resize filter docs by @user27182 in https://github.com/pyvista/pyvista/pull/8223
* Make labels always visible for ray-trace example by @akaszynski in https://github.com/pyvista/pyvista/pull/8249
* Use `color_labels` for coloring connectivity examples by @user27182 in https://github.com/pyvista/pyvista/pull/8251
* docs: Add Nix package badge to README by @tkoyama010 in https://github.com/pyvista/pyvista/pull/8263
* Add `Text3D` docstring examples by @user27182 in https://github.com/pyvista/pyvista/pull/8270
* Deprecate `extract_geometry` in favor of `extract_surface` by @user27182 in https://github.com/pyvista/pyvista/pull/8259
* Limit Sphinx Gallery examples line length to 90 characters by @user27182 in https://github.com/pyvista/pyvista/pull/8295

### Maintenance
* Add minimum typing-extensions version by @user27182 in https://github.com/pyvista/pyvista/pull/7791
* Use PEP 673 Self type for methods returning self instances by @tkoyama010 in https://github.com/pyvista/pyvista/pull/7799
* Drop deprecated features scheduled for v0.47 by @tkoyama010 in https://github.com/pyvista/pyvista/pull/7797
* Remove `lazy_vtkPOpenFOAMReader` by @user27182 in https://github.com/pyvista/pyvista/pull/7858
* Raise error when comparing `vtk_version_info` with an unsupported VTK version by @user27182 in https://github.com/pyvista/pyvista/pull/7849
* Fix flaky downloads tests by @edabor in https://github.com/pyvista/pyvista/pull/7871
* Replace `doc_image_cache` images with fixed legend symbols by @user27182 in https://github.com/pyvista/pyvista/pull/7874
* Deprecate use_all_points parameter in extract_all_edges by @tkoyama010 in https://github.com/pyvista/pyvista/pull/7933
* Report local VTK data cache usage by @akaszynski in https://github.com/pyvista/pyvista/pull/7926
* Show GPU info in CI reports by @user27182 in https://github.com/pyvista/pyvista/pull/7935
* Fix warn calls without stacklevel keyword argument by @edabor in https://github.com/pyvista/pyvista/pull/7957
* Add missing deps to `Report` and re-order by @user27182 in https://github.com/pyvista/pyvista/pull/7989
* Add annotations to `plot` by @edabor in https://github.com/pyvista/pyvista/pull/7978
* chore: update pre-commit hooks by @pre-commit-ci[bot] in https://github.com/pyvista/pyvista/pull/7992
* Enable anti-aliasing and make lines thicker for `resample` examples by @user27182 in https://github.com/pyvista/pyvista/pull/8002
* Improve styling for the Trame plotter toolbar by @MattTheCuber in https://github.com/pyvista/pyvista/pull/8009
* chore: update ruff pre-commit hook to v0.13.3 by @tkoyama010 in https://github.com/pyvista/pyvista/pull/7994
* Reduce max `vtksz` file size from 50MB to 25MB by @user27182 in https://github.com/pyvista/pyvista/pull/8010
* Update `cyclopts` version to v4 by @edabor in https://github.com/pyvista/pyvista/pull/8018
* Customize CLI help page by @edabor in https://github.com/pyvista/pyvista/pull/8043
* Deprecate `orient_faces` keyword with `contour_labels` by @user27182 in https://github.com/pyvista/pyvista/pull/8038
* Python 3.14: Remove custom docstrings from type aliases by @user27182 in https://github.com/pyvista/pyvista/pull/8102
* Refactor common API for readers/writers and include new `extensions` property by @user27182 in https://github.com/pyvista/pyvista/pull/8098
* Use `nest-asyncio2` by @user27182 in https://github.com/pyvista/pyvista/pull/8109
* Dynamic stacklevel for warnings by @edabor in https://github.com/pyvista/pyvista/pull/8093
* Test vtk dev with python 3.14 by @user27182 in https://github.com/pyvista/pyvista/pull/8096
* Use `uv lock` in CI workflow to check for dependency conflicts by @user27182 in https://github.com/pyvista/pyvista/pull/8148
* Fix regex in dimensionality test for platform-dependent dtype by @user27182 in https://github.com/pyvista/pyvista/pull/8154
* Use `pl = pv.Plotter` in docstrings by @user27182 in https://github.com/pyvista/pyvista/pull/8155
* Raise errors instead of warnings for unsupported transformations by @user27182 in https://github.com/pyvista/pyvista/pull/8178
* Implement `_SeralizedDictArray.__str__` for printing user dict by @user27182 in https://github.com/pyvista/pyvista/pull/8177
* Include `meshio` for type-checking by @user27182 in https://github.com/pyvista/pyvista/pull/8200
* Misc fixes to mesh validation docstring, error messages, and `MultiBlock` compatibility by @user27182 in https://github.com/pyvista/pyvista/pull/8199
* Optimize mesh validation for gridded meshes by @user27182 in https://github.com/pyvista/pyvista/pull/8202
* Do not format messages for valid mesh validation fields by @user27182 in https://github.com/pyvista/pyvista/pull/8212
* Reduce execution time when checking for vtk snake case attributes by @user27182 in https://github.com/pyvista/pyvista/pull/8262
* Raise `ValueError` when saving oriented `ImageData` to `.vtk` file by @user27182 in https://github.com/pyvista/pyvista/pull/8269
* Raise `ValueError` when casting oriented `ImageData` to `RectilinearGrid` by @user27182 in https://github.com/pyvista/pyvista/pull/8268
* Support VTK 9.6 by @user27182 in https://github.com/pyvista/pyvista/pull/8228
* Catch VTK errors when updating algorithms by @user27182 in https://github.com/pyvista/pyvista/pull/8292

## New Contributors
* @pjireland made their first contribution in https://github.com/pyvista/pyvista/pull/7883
* @echedey-ls made their first contribution in https://github.com/pyvista/pyvista/pull/7922
* @DominicBen made their first contribution in https://github.com/pyvista/pyvista/pull/7958
* @tletut0ur made their first contribution in https://github.com/pyvista/pyvista/pull/8072

**Full Changelog**: https://github.com/pyvista/pyvista/compare/v0.46.0...v0.47.0
