### PR TITLE
Make upload step conditional on tag only

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -413,5 +413,5 @@ jobs:
           python -m build
 
       - name: Upload to PyPi
-        if: matrix.python-version == '3.13' && startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: pypa/gh-action-pypi-publish@03f86fee9ac21f854951f5c6e2a02c2a1324aec7


### PR DESCRIPTION
PyPI upload step failed to run in latest release workflow.

Make upload step conditional on tag only.