### PR TITLE
Require VTK 9.5 for distinct cell type check

### DIFF
--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -2130,7 +2130,7 @@ def test_validate_mesh_error_message(invalid_hexahedron, poly_with_invalid_point
         poly_with_invalid_point.cast_to_multiblock().validate_mesh(action='warn')
 
 
-@pytest.mark.needs_vtk_version((9, 4, 0), reason='Suspected issue with fixtures for older VTK')
+@pytest.mark.needs_vtk_version((9, 5, 0), reason='Suspected issue with fixtures for older VTK')
 def test_validate_mesh_distinct_cell_types(
     single_cell_invalid_point_references,
     mixed_2d_cells_invalid_point_references,


### PR DESCRIPTION
Still seeing occasional failures with `test_validate_mesh_distinct_cell_types`. Require VTK 9.5 for distinct cell type check.