### PR TITLE
Remove deprecated parameters

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -3377,7 +3377,6 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
         max_steps: int = 2000,
         terminal_speed: float = 1e-12,
         max_error: float = 1e-6,
-        max_time: float | None = None,
         compute_vorticity: bool = True,  # noqa: FBT001, FBT002
         rotation_scale: float = 1.0,
         interpolator_type: Literal['point', 'cell', 'p', 'c'] = 'point',
@@ -3442,13 +3441,6 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
 
         max_error : float, 1e-6
             Maximum error tolerated throughout streamline integration.
-
-        max_time : float, optional
-            Specify the maximum length of a streamline expressed in physical length.
-
-            .. deprecated:: 0.45.0
-               ``max_time`` parameter is deprecated. Use ``max_length`` instead.
-                It will be removed in v0.48. Default for ``max_time`` changed in v0.45.0.
 
         compute_vorticity : bool, default: True
             Vorticity computation at streamline points. Necessary for generating
@@ -3516,19 +3508,6 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
             self.set_active_vectors(vectors)
         elif vectors is None:
             set_default_active_vectors(self)
-
-        if max_time is not None:
-            if max_length is not None:
-                warn_external(
-                    '``max_length`` and ``max_time`` provided. Ignoring deprecated ``max_time``.',
-                    PyVistaDeprecationWarning,
-                )
-            else:
-                warn_external(
-                    '``max_time`` parameter is deprecated.  It will be removed in v0.48',
-                    PyVistaDeprecationWarning,
-                )
-                max_length = max_time
 
         if max_length is None:
             max_length = 4.0 * self.GetLength()

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -847,7 +847,7 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
             return
 
         # filename
-        opt_kwarg = ['faces', 'n_faces', 'lines', 'n_lines']
+        opt_kwarg = ['faces', 'lines']
         if isinstance(var_inp, (str, Path)):
             for kwarg in opt_kwarg:
                 if local_parms[kwarg]:

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -829,16 +829,12 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
         self,
         var_inp: _vtk.vtkPolyData | str | Path | MatrixLike[float] | None = None,
         faces: CellArrayLike | None = None,
-        n_faces: int | None = None,
         lines: CellArrayLike | None = None,
-        n_lines: int | None = None,
         strips: CellArrayLike | None = None,
-        n_strips: int | None = None,
         deep: bool = False,  # noqa: FBT001, FBT002
         force_ext: str | None = None,
         force_float: bool = True,  # noqa: FBT001, FBT002
         verts: CellArrayLike | None = None,
-        n_verts: int | None = None,
         *,
         validate: bool | _MeshValidationOptions = False,
     ) -> None:
@@ -916,17 +912,6 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
 
         if validate:
             self._validate_mesh(validate)
-
-        # deprecated 0.44.0, convert to error in 0.47.0, remove 0.48.0
-        for k, v in (  # type: ignore[assignment]
-            ('n_verts', n_verts),
-            ('n_strips', n_strips),
-            ('n_faces', n_faces),
-            ('n_lines', n_lines),
-        ):
-            if v is not None:
-                msg = f'PolyData constructor parameter `{k}` is deprecated and no longer used.'
-                raise TypeError(msg)
 
     def _post_file_load_processing(self) -> None:
         """Execute after loading a PolyData from file."""


### PR DESCRIPTION
### Overview
Remove:
-  `max_time` from `streamlines_from_source` 
- `n_verts`, `n_lines`, `n_faces`, `n_strips` from `PolyData.__init__` 