### PR TITLE
Exclude `trame-vtk` 2.10.3 from deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ jupyter = [
   'nest-asyncio2',
   'trame-client>=2.12.7',
   'trame-server >= 2.11.7, != 3.7.*, != 3.8.0',
-  'trame-vtk>=2.5.8',
+  'trame-vtk>=2.5.8, !=2.10.3', # Exclude 2.10.3 due to https://github.com/Kitware/trame-vtk/issues/101
   'trame-vuetify>=2.3.1',
   'trame>=2.5.2',
 ]


### PR DESCRIPTION
### Overview

Fix https://github.com/pyvista/pyvista/issues/8283