### PR TITLE
Remove `relpath` from `deprecate_positional_args` decorator (#8345)

### DIFF
--- a/pyvista/_deprecate_positional_args.py
+++ b/pyvista/_deprecate_positional_args.py
@@ -4,7 +4,6 @@ from functools import wraps
 import inspect
 from inspect import Parameter
 from inspect import Signature
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import TypeVar
@@ -176,9 +175,7 @@ def _deprecate_positional_args(
                 signature_string = f'{signature_string[:-1]}, ...)'
 
             # Get source file and line number
-            file = Path(
-                os.path.relpath(inspect.getfile(f), start=os.getcwd())  # noqa: PTH109  # https://github.com/pyvista/pyvista/pull/7732
-            ).as_posix()
+            file = Path(inspect.getfile(f)).as_posix()
             lineno = inspect.getsourcelines(f)[1]
             location = f'{file}:{lineno}'
 
@@ -226,9 +223,7 @@ def _deprecate_positional_args(
                     def call_site() -> str:
                         # Get location where the function is called
                         frame = inspect.stack()[stack_level]
-                        file = Path(
-                            os.path.relpath(frame.filename, start=os.getcwd())  # noqa: PTH109  # https://github.com/pyvista/pyvista/pull/7732
-                        ).as_posix()
+                        file = Path(frame.filename).as_posix()
                         return f'{file}:{frame.lineno}'
 
                     def warn_positional_args() -> None:


### PR DESCRIPTION
Backport commit from #8345 into the 0.47 release branch