### PR TITLE
Fix reference to `download_bird` in `resample` filter

### DIFF
--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -4781,7 +4781,7 @@ class ImageDataFilters(DataSetFilters):
 
         Use a reference image to control the resampling instead. Here we load two
         images with different dimensions:
-        :func:`~pyvista.examples.downloads.download_puppy` and
+        :func:`~pyvista.examples.downloads.download_bird` and
         :func:`~pyvista.examples.downloads.download_gourds`.
 
         >>> bird = examples.download_bird()


### PR DESCRIPTION
### Overview

The example used to use `puppy` but uses `bird` now.