### PR TITLE
Bump trame-vtk to 2.11.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,8 @@ jupyter = [
   'nest-asyncio2',
   'trame-client>=2.12.7',
   'trame-server >= 2.11.7, != 3.7.*, != 3.8.0',
-  'trame-vtk != 2.10.3, != 2.11.0, != 2.11.1, != 2.11.2, != 2.11.3, != 2.11.4',
-  'trame-vtk>=2.5.8, <2.11.6', # Pin indefinitely to avoid breakages
+  'trame-vtk != 2.10.3, != 2.11.0, != 2.11.1, != 2.11.2, != 2.11.3, != 2.11.4, != 2.11.5',
+  'trame-vtk>=2.5.8, <2.11.7', # Pin indefinitely to avoid breakages
   'trame-vuetify>=2.3.1',
   'trame>=2.5.2',
 ]
@@ -105,7 +105,7 @@ test = [
   'sphinx<8.3.0',
   'sympy<1.15.0',
   'tqdm<4.68.0',
-  'trame-vtk>=2.5.8,<2.11.6',
+  'trame-vtk>=2.5.8,<2.11.7',
   'trame-vuetify>=2.3.1,<3.3.0',
   'trame>=2.5.2,<3.13.0',
   'trimesh<4.12.0',
@@ -151,7 +151,7 @@ docs = [
   'sphinxcontrib-websupport==2.0.0',
   'sphinxext-opengraph==0.13.0',
   'sympy==1.14.0',
-  'trame-vtk==2.11.5',
+  'trame-vtk==2.11.6',
   'trame-vuetify==3.2.1',
   'trame==3.12.0',
   'trimesh==4.11.3',
@@ -162,7 +162,7 @@ docs = [
 docs-test = [
   'pytest-pyvista[vtksz]==0.3.2',
   'pytest-xdist<3.9.0',
-  'trame-vtk==2.11.5',
+  'trame-vtk==2.11.6',
   { include-group = 'pinned' },
 ]
 


### PR DESCRIPTION
### Overview

Needed to support the new VTK 9.7 array overrides. See
https://gitlab.kitware.com/vtk/vtk/-/work_items/19996#note_1794022

tested with #8405 and confirmed working.