### PR TITLE
Fix vtk version in tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,7 @@ deps =
     vtk_9.2.6: vtk == 9.2.6
     vtk_9.3.1: vtk == 9.3.1
     vtk_9.4.2: vtk == 9.4.2
+    vtk_9.5.2: vtk == 9.5.2
 
 uv_index_numpy_nightly = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 uv_index_vtk_dev = https://wheels.vtk.org


### PR DESCRIPTION
### Overview

For tests using `vtk == 9.5.2` , the tox config was not correct and installed the latest version.

See https://github.com/pyvista/pyvista/actions/runs/23730323783/job/69122557239#step:8:55

This PR fixes that
