### PR TITLE
Temporary upper pin vtk < 9.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   'typing-extensions>=4.10',
   'vtk!=9.4.0',
   'vtk!=9.4.1',
-  'vtk<9.7.0',
+  'vtk<9.6.1', # temporary pinning. Remove before release
   'vtk>=9.2.2',
 ]
 description = 'Easier Pythonic interface to VTK'


### PR DESCRIPTION
### Overview

The explicit structured grid stuff is probably caused by https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12877

there was a known VTK breakage with 9.6 for rendering ghost cells, we added a temp workaround just to support 9.6.0, looks like our workaround and 9.6.1 don’t play nicely. 

IMO this is low impact, I think we can temp pin vtk version in CI for now until we have a proper fix. (I might be able to fix it but not any time soon).

_Originally posted by @user27182 in https://github.com/pyvista/pyvista/pull/8425#discussion_r3010879455_
            