### PR TITLE
Fix `CellType.vtk_class` for Bezier/Lagrange Triangle/Quadrilateral cell types

### DIFF
--- a/pyvista/core/celltype.py
+++ b/pyvista/core/celltype.py
@@ -9,6 +9,7 @@ from typing import NamedTuple
 from typing import cast
 
 from pyvista.core import _vtk_core as _vtk
+from pyvista.core._vtk_utilities import vtk_version_info
 
 _Dimension = Literal[0, 1, 2, 3]
 PLACEHOLDER = 'IMAGE-HASH-PLACEHOLDER'
@@ -772,6 +773,14 @@ class CellType(IntEnum):
         # even though some actually do have a corresponding class. Among other things, skipping
         # abstract types helps avoid the need to work around this VTK bug: https://gitlab.kitware.com/vtk/vtk/-/issues/19988
         _vtk_class_name = _vtk.vtkCellTypeUtilities.GetClassNameFromTypeId(value)
+        if vtk_version_info < (9, 6, 0):
+            # Fix bug with older VTK where higher order Triangle/Quadrilateral are swapped
+            _vtk_class_name = {
+                'vtkBezierTriangle': 'vtkBezierQuadrilateral',
+                'vtkBezierQuadrilateral': 'vtkBezierTriangle',
+                'vtkLagrangeTriangle': 'vtkLagrangeQuadrilateral',
+                'vtkLagrangeQuadrilateral': 'vtkLagrangeTriangle',
+            }.get(_vtk_class_name, _vtk_class_name)
         self._vtk_class = (
             None
             if _vtk_class_name.startswith(('vtkParametric', 'vtkHigherOrder'))  # Abstract

--- a/tests/examples/test_cell_examples.py
+++ b/tests/examples/test_cell_examples.py
@@ -14,16 +14,6 @@ from pyvista.examples import cells
 from pyvista.examples.cells import _NOT_SUPPORTED_CELL_SOURCE
 from pyvista.examples.cells import _NOT_SUPPORTED_PARAMETRIC
 
-# VTK 9.5.2 swaps Bezier/Lagrange Triangle and Quadrilateral cell types
-_VTK_952_SWAPPED_CELLS = frozenset(
-    {
-        'BezierTriangle',
-        'BezierQuadrilateral',
-        'LagrangeTriangle',
-        'LagrangeQuadrilateral',
-    }
-)
-
 # Collect all functions in the cells module that start with a capital letter
 cell_example_functions = [
     func for name, func in inspect.getmembers(cells, inspect.isfunction) if name[0].isupper()
@@ -111,11 +101,8 @@ def test_cell_name(cell_example):
     assert actual == expected
 
 
-@pytest.mark.needs_vtk_version(9, 5, 0, reason='VTK bug for higher-order quads/triangles')
 @parametrize('cell_example', cell_example_functions)
 def test_cell_vtk_class(cell_example):
-    if pv.vtk_version_info == (9, 5, 2) and cell_example.__name__ in _VTK_952_SWAPPED_CELLS:
-        pytest.skip('VTK 9.5.2 bug: Bezier/Lagrange Triangle and Quadrilateral types are swapped')
     cell = cell_example().GetCell(0)
     celltype = CellType(cell.GetCellType())
     assert celltype.vtk_class is type(cell)
@@ -165,11 +152,8 @@ def test_cell_n_points(cell_example):
         assert celltype.n_points == cell.n_points
 
 
-@pytest.mark.needs_vtk_version(9, 5, 0, reason='VTK bug for higher-order quads/triangles')
 @parametrize('cell_example', cell_example_functions)
 def test_cell_n_edges(cell_example):
-    if pv.vtk_version_info == (9, 5, 2) and cell_example.__name__ in _VTK_952_SWAPPED_CELLS:
-        pytest.skip('VTK 9.5.2 bug: Bezier/Lagrange Triangle and Quadrilateral types are swapped')
     cell = next(cell_example().cell)
     celltype = CellType(cell.type)
     if cell_example.__name__ in (


### PR DESCRIPTION
`CellType.vtk_class` tests are currently skipped for older VTK due to a bug with `vtkCellTypes`. This PR removes the skips and adds a proper fix in the `CellType` implementation instead.