### PR TITLE
Enable merge queue for PRs

### DIFF
--- a/.github/workflows/dependency-conflicts.yml
+++ b/.github/workflows/dependency-conflicts.yml
@@ -2,6 +2,7 @@ name: Check Dependency Conflicts
 
 on:
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,7 @@ name: Build Documentation
 
 on: # zizmor: ignore[cache-poisoning]
   pull_request:
+  merge_group:
   workflow_dispatch:
   schedule:
     - cron: "0 0 1 * *" # once a month on main

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,6 +3,7 @@ name: Integration Tests
 # zizmor ignore note: All caching for pushes to main should be disabled with the `USE_CACHE` env var
 on: # zizmor: ignore[cache-poisoning]
   pull_request:
+  merge_group:
   workflow_dispatch:
   schedule:
     - cron: "0 4 * * *"

--- a/.github/workflows/python-syntax.yml
+++ b/.github/workflows/python-syntax.yml
@@ -2,6 +2,7 @@ name: Check Python Syntax
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/style-docstring.yml
+++ b/.github/workflows/style-docstring.yml
@@ -1,7 +1,7 @@
 # check spelling, codestyle
 name: Style and Docstring Check
 
-on: [pull_request, workflow_dispatch]
+on: [pull_request, merge_group, workflow_dispatch]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/vtk-pre-test.yml
+++ b/.github/workflows/vtk-pre-test.yml
@@ -2,6 +2,7 @@ name: VTK Master Testing
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       # To resolve issues on VTK master and test, use this branch name pattern


### PR DESCRIPTION
## Summary

This adds `merge_group` as a CI trigger to all workflows that run on pull requests. This is the CI-side change needed to enable GitHub's merge queue on `main`.

Right now, we require PRs to be up to date with `main` before merging. In practice, this means you come back to an approved PR, click "Update branch," wait for CI to pass again, and then merge. If another PR lands while you're waiting, you get to do it all over again. It's a waste of everyone's time.

### What changes

**CI workflows (this PR):** Added `merge_group` trigger to all workflows that currently run on `pull_request`

`testing-and-deployment.yml` and `type-checking.yml` already had it 🤔 

**Branch protection rules (separate change on `main` settings):**

1. **Enabled** "Require merge queue" on `main`
2. **Disabled** "Require branches to be up to date before merging"

We no longer need the "up to date" requirement because the merge queue handles it. When a PR enters the queue, GitHub creates a temporary branch with the PR's changes on top of the latest `main` and runs all required checks against that. If checks pass, it merges automatically. If they fail, the PR gets ejected from the queue.

### How the new workflow looks

1. PR gets approved and passes checks
2. Click "Merge when ready" to add it to the queue
3. GitHub tests it against the latest `main` automatically
4. It merges without anyone needing to come back