### PR TITLE
Limit I18N Documentation Build to Releases

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -84,8 +84,9 @@ jobs:
             cat "$f"
           done
 
+      # Only build the translations for release builds since they take over 3 hours to build
       - uses: actions/checkout@v6
-        if: startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v')
         with:
           repository: pyvista/pyvista-doc-translations
           path: pyvista-doc-translations
@@ -93,7 +94,7 @@ jobs:
           persist-credentials: false
 
       - name: Build I18N Documentation
-        if: startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           tox run -e docs-build -- mini18n-html
           find doc/_build/mini18n-html -mindepth 1 -maxdepth 1 -type d -exec cp -rf {} doc/_build/html/ \;


### PR DESCRIPTION
## Summary

This PR limits the internationalized (I18N) documentation build to **release tags only**, removing it from the `main` branch CI workflow.

## Motivation

First, I want to acknowledge and thank @tkoyama010 for setting up our documentation translation infrastructure, making PyVista's documentation accessible across languages is genuinely valuable work, and that goal hasn't changed. Translated documentation helps our global community engage with PyVista more effectively, and we should remain committed to supporting it.

That said, the translation build currently adds **over 3 hours** to our documentation CI pipeline, which otherwise completes in ~20 minutes. Running this on every push to `main` places significant strain on our CI resources and slows down the feedback loop for all contributors. Given that translated documentation is most impactful when tied to a stable release (rather than an in-progress development branch), I propose building translations only on release tags as a practical way to keep the translations up to date where they matter most while substantially reducing our day-to-day CI burden.

## Trade-offs

Translations on the development docs (built from `main`) will no longer be available between releases. I believe this is an acceptable trade-off given that:

1. Most users consume documentation tied to a specific release version.
2. The 3+ hour build time creates real pressure on our CI capacity and contributor experience.
3. Translations can drift from the source content on `main` anyway, so release-pinned translations are arguably more reliable.

If the community feels strongly about restoring `main`-branch translation builds in the future, for example, we can and should revisit this decision. I think one solution may be to have a separate repository and CI workflow dedicated to this translation would be the way to go