### PR TITLE
Remove GitHub stars from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -263,13 +263,6 @@ their ideas. To learn more about contributing to PyVista, please see the
 .. _Contributing Guide: https://github.com/pyvista/pyvista/blob/main/CONTRIBUTING.rst
 .. _Code of Conduct: https://github.com/pyvista/pyvista/blob/main/CODE_OF_CONDUCT.md
 
-Star History
-============
-
-.. image:: https://api.star-history.com/svg?repos=pyvista/pyvista&type=Date
-   :alt: Star History Chart
-   :target: https://star-history.com/#pyvista/pyvista&Date
-
 Citing PyVista
 ==============
 


### PR DESCRIPTION
Removes the Star History chart section from the README.

The README should help users understand what PyVista is, how to install it, and how to get started. A star history chart doesn't serve any of those goals. It's a vanity metric that doesn't belong in our primary documentation.

GitHub already shows star counts on the repo page for everyone to see. No need to duplicate that in the README with a promotional widget.