### PR TITLE
Replace PR comments with commit statuses for preview deployments

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -246,7 +246,7 @@ jobs:
         run: |
           gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
             -f state=success \
-            -f context="Docs Preview" \
+            -f context="Deploy / Docs Preview" \
             -f description="Documentation preview is ready" \
             -f target_url="$DEPLOY_URL"
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -458,7 +458,7 @@ jobs:
         run: |
           gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
             -f state=success \
-            -f context="Test Image Report" \
+            -f context="Deploy / Test Image Report" \
             -f description="Image comparison report is ready" \
             -f target_url="$DEPLOY_URL"
 


### PR DESCRIPTION
- Replace noisy PR comments for docs preview and test image report Netlify deployments with GitHub commit statuses that appear as labeled entries ("Docs Preview", "Test Image Report") in the PR checks section with clickable "Details" links
- Add distinct `github-deployment-environment` names so each deploy gets its own "View deployment" button in the PR timeline instead of collapsing under a shared name
- Add deployment links to GitHub Actions job summaries for easy access from the Actions run page
- Remove `peter-evans/find-comment` and `peter-evans/create-or-update-comment` dependencies from both workflows