### PR TITLE
Fix CI failures against NumPy nightly wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,6 +255,7 @@ filterwarnings = [
   'ignore:.*numpy.ufunc size changed.*:RuntimeWarning', # bogus numpy ABI warning (see numpy/#432)
   'ignore:Call to deprecated method GetData:DeprecationWarning', # emitted by trame-vtk
   'ignore:Passing .{1}N.{1} to ListedColormap is deprecated since:DeprecationWarning', # https://github.com/matplotlib/cmocean/pull/114
+  'ignore:Setting the dtype on a NumPy array has been deprecated in NumPy 2.4.', # https://numpy.org/devdocs/release/2.4.0-notes.html - triggered by VTK's C++ code
   'ignore:Setting the shape on a NumPy array has been deprecated in NumPy 2.5.', # https://numpy.org/devdocs/release/2.5.0-notes.html#setting-the-shape-attribute-is-deprecated
   'ignore:The .*interactive_bk.* attribute was deprecated in Matplotlib 3\.9.*:matplotlib.MatplotlibDeprecationWarning', # https://github.com/microsoft/debugpy/issues/1623
   'ignore:pyvista test \w+ image dir.* does not yet exist.  Creating dir.:UserWarning',

--- a/tests/plotting/test_lookup_table.py
+++ b/tests/plotting/test_lookup_table.py
@@ -61,6 +61,7 @@ def test_values(lut):
         lut.n_values = 10
 
 
+@pytest.mark.skip_check_gc
 def test_apply_cmap(lut):
     n_values = 5
     lut.cmap = 'reds'


### PR DESCRIPTION
- Add a pytest warning filter to ignore NumPy 2.4's new `DeprecationWarning` for setting `.dtype` on a NumPy array. VTK performs this operation internally when interfacing with NumPy arrays, and pyvista cannot fix the source.
- Mark `test_apply_cmap` with `@pytest.mark.skip_check_gc` to skip the post-test VTK object garbage collection check. The test creates `lookup_table_ndarray` objects that hold `vtkWeakReference` instances which are not fully collected, causing a spurious GC assertion failure. The sibling tests `test_table_values_update` and `test_custom_opacity` already carry this marker for the same reason.
