### PR TITLE
Move integration tests to cron job that raises an issue

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -10,6 +10,7 @@
 
 tests:
   # Directories that don't affect unit tests
+  - "!.github/**"
   - "!doc/**"
   - "!joss/**"
   - "!logo/**"
@@ -35,6 +36,7 @@ tests:
 
 docs:
   # Directories that don't affect documentation
+  - "!.github/**"
   - "!tests/**"
   - "!hooks/**"
   - "!joss/**"

--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -1,5 +1,5 @@
 # Shared path filters for CI skip conditions
-# Used by dorny/paths-filter in docs.yml, testing-and-deployment.yml, and integration-tests.yml
+# Used by dorny/paths-filter in docs.yml and testing-and-deployment.yml
 #
 # DENYLIST approach with predicate-quantifier: 'every'
 # A file triggers the filter only if it matches ALL patterns (i.e., is not excluded by any).
@@ -17,31 +17,6 @@ tests:
   - "!docker/**"
   - "!.devcontainer/**"
   # Root files that don't affect unit tests
-  - "!README.rst"
-  - "!CONTRIBUTING.rst"
-  - "!AUTHORS.rst"
-  - "!CODE_OF_CONDUCT.md"
-  - "!SECURITY.md"
-  - "!FUNDING.yml"
-  - "!CITATION.cff"
-  - "!CITATION.rst"
-  - "!LICENSE"
-  - "!codecov.yml"
-  - "!lychee.toml"
-  - "!.pre-commit-config.yaml"
-  - "!.mailmap"
-  - "!.gitignore"
-  - "!.gitattributes"
-
-integration:
-  # Directories that don't affect integration tests
-  - "!doc/**"
-  - "!joss/**"
-  - "!logo/**"
-  - "!assets/**"
-  - "!docker/**"
-  - "!.devcontainer/**"
-  # Root files that don't affect integration tests
   - "!README.rst"
   - "!CONTRIBUTING.rst"
   - "!AUTHORS.rst"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      docs: ${{ steps.filter.outputs.docs }}
+      docs: ${{ steps.filter.outputs.docs == 'true' || steps.self.outputs.changed == 'true' }}
     steps:
       - uses: actions/checkout@v6
         if: github.event_name == 'pull_request'
@@ -38,6 +38,13 @@ jobs:
         with:
           predicate-quantifier: "every"
           filters: .github/path-filters.yml
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        if: github.event_name == 'pull_request'
+        id: self
+        with:
+          filters: |
+            changed:
+              - ".github/workflows/docs.yml"
 
   cache-vtk-data:
     needs: changes

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,12 +5,12 @@ on: # zizmor: ignore[cache-poisoning]
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: "0 4 * * *"
+    - cron: "0 4 * * 1" # Every Monday at 04:00 UTC
   push:
-    tags:
-      - "*"
     branches:
       - main
+      # To resolve integration test issues, use this branch name pattern
+      - "maint/integration*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -35,28 +35,11 @@ permissions:
   id-token: none
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      integration: ${{ steps.filter.outputs.integration }}
-    steps:
-      - uses: actions/checkout@v6
-        if: github.event_name == 'pull_request'
-        with:
-          persist-credentials: false
-          sparse-checkout: .github/path-filters.yml
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        if: github.event_name == 'pull_request'
-        id: filter
-        with:
-          predicate-quantifier: "every"
-          filters: .github/path-filters.yml
-
   Integration:
-    needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.integration == 'true'
+    # For PRs, only run when the 'integration-testing' label is applied
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'integration-testing')
     name: ${{matrix.project}}
     strategy:
       fail-fast: false
@@ -90,14 +73,58 @@ jobs:
 
       - name: Run tests (no xvfb)
         if: ${{matrix.project != 'geovista'}}
-        run: tox run -e integration-${{matrix.project}}
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: tox run -e integration-${{matrix.project}}
 
       - name: Run tests (geovista)
         if: ${{matrix.project == 'geovista'}}
-        run: xvfb-run -a tox run -e integration-${{matrix.project}}
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: xvfb-run -a tox run -e integration-${{matrix.project}}
 
       - uses: actions/cache@v5
         if: ${{ env.USE_CACHE == 'true' && matrix.project == 'mne' }}
         with:
           key: ${{ env.TESTING_VERSION }}
           path: ~/mne_data
+
+  alert-on-failure:
+    needs: Integration
+    if: >-
+      failure() &&
+      (github.event_name == 'schedule' ||
+       (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Report integration test failure
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REF: ${{ github.ref }}
+        run: |
+          body=$(cat <<EOF
+          ### Integration Test Failure
+
+          **Date:** $(date -u +%Y-%m-%d)
+          **Run:** ${RUN_URL}
+          **Ref:** \`${REF}\`
+          EOF
+          )
+
+          # Check for an existing open issue
+          existing=$(gh issue list --label "integration-test-failure" --state open --limit 1 --json number --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "Integration test failure" --label "integration-test-failure" --body "$body"
+          fi

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,7 +5,7 @@ on: # zizmor: ignore[cache-poisoning]
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: "0 4 * * 1" # Every Monday at 04:00 UTC
+    - cron: "0 4 * * *"
   push:
     branches:
       - main

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -43,7 +43,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      tests: ${{ steps.filter.outputs.tests }}
+      tests: ${{ steps.filter.outputs.tests == 'true' || steps.self.outputs.changed == 'true' }}
     steps:
       - uses: actions/checkout@v6
         if: github.event_name == 'pull_request'
@@ -56,6 +56,13 @@ jobs:
         with:
           predicate-quantifier: "every"
           filters: .github/path-filters.yml
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        if: github.event_name == 'pull_request'
+        id: self
+        with:
+          filters: |
+            changed:
+              - ".github/workflows/testing-and-deployment.yml"
 
   # Cache vtk-data for each runner separately
   # Runner labels should match the actual runners used by the different jobs in this file


### PR DESCRIPTION
>[!Note]
>Alex agreed to add another mac runner to the cluster in exchange for this PR. Please approve promptly before he changes his mind.

- Integration tests no longer run on every PR or in the merge queue. They run daily at 04:00 UTC on `main` and on push to `main`.
- PRs can opt-in by adding the `integration-testing` label (same pattern as `vtk-master` and `vtk-dev-testing`). Pushing to a `maint/integration*` branch also triggers them.
- When tests fail on `main` (scheduled or push), an issue is automatically opened with the `integration-test-failure` label. Subsequent failures comment on the existing issue rather than opening duplicates.
- Test steps now retry up to 3 times via `nick-fields/retry` to handle transient network failures when downloading example data.
