### PR TITLE
Auto-detect Jupyter notebook backend instead of defaulting to trame

### DIFF
--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -95,6 +95,31 @@ def _discover_entry_points() -> None:
                 _custom_backends[name] = ep.load()
 
 
+def _resolve_backend() -> str:
+    """Auto-detect the best available Jupyter backend.
+
+    Priority: registered custom backends > trame > static.
+
+    Returns
+    -------
+    str
+        Name of the best available backend.
+
+    """
+    _discover_entry_points()
+    if _custom_backends:
+        return next(iter(_custom_backends))
+
+    try:
+        from pyvista.trame.jupyter import show_trame as show_trame  # noqa: PLC0415
+    except ImportError:
+        pass
+    else:
+        return 'trame'
+
+    return 'static'
+
+
 def _is_jupyter_backend(backend: str) -> TypeIs[JupyterBackendOptions]:
     """Return True if backend is allowed jupyter backend."""
     return backend in ALLOWED_BACKENDS

--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -127,15 +127,17 @@ def _is_jupyter_backend(backend: str) -> TypeIs[JupyterBackendOptions]:
 
 def _validate_jupyter_backend(
     backend: str | None,
-) -> str:
+) -> str | None:
     """Validate that a jupyter backend is valid.
 
-    Returns the normalized name of the backend. Raises if the backend is invalid.
+    Returns the normalized name of the backend, or ``None`` to indicate that
+    the backend should be auto-detected at display time. Raises if the backend
+    is invalid.
 
     """
-    # Must be a string
+    # ``None`` is the auto-detect sentinel; preserve it
     if backend is None:
-        backend = 'none'
+        return None
     backend = backend.lower()
 
     if not importlib.util.find_spec('IPython'):
@@ -203,7 +205,8 @@ def set_jupyter_backend(backend: JupyterBackendOptions | str, name=None, **kwarg
           virtual framebuffer.
 
         Custom backends registered via :func:`~pyvista.register_jupyter_backend`
-        are also accepted.
+        are also accepted. Pass ``None`` to reset to auto-detection at display
+        time.
 
     name : str, optional
         The unique name identifier for the server.
@@ -222,6 +225,10 @@ def set_jupyter_backend(backend: JupyterBackendOptions | str, name=None, **kwarg
 
     Disable all plotting within JupyterLab and display using a
     standard desktop VTK render window.
+
+    >>> pv.set_jupyter_backend('none')  # doctest:+SKIP
+
+    Reset to auto-detect the best available backend.
 
     >>> pv.set_jupyter_backend(None)  # doctest:+SKIP
 

--- a/pyvista/jupyter/notebook.py
+++ b/pyvista/jupyter/notebook.py
@@ -15,7 +15,10 @@ from typing import TYPE_CHECKING
 from typing import cast
 
 from pyvista._warn_external import warn_external
+from pyvista.jupyter import _custom_backends
+from pyvista.jupyter import _discover_entry_points
 from pyvista.jupyter import _get_custom_backend_handler
+from pyvista.jupyter import _resolve_backend
 
 if TYPE_CHECKING:
     import io
@@ -48,10 +51,22 @@ def handle_plotter(
     if screenshot is False:
         screenshot = None
 
-    custom_handler = _get_custom_backend_handler(backend) if backend else None
+    # Auto-detect the best available backend when not specified
+    if backend is None:
+        backend = _resolve_backend()
+        if backend == 'static':
+            warn_external(
+                'Using static image for notebook display.\n'
+                'Install trame for interactive backends:'
+                ' pip install "pyvista[jupyter]"'
+            )
+
+    # Custom backends (registered or from entry points)
+    custom_handler = _get_custom_backend_handler(backend)
     if custom_handler is not None:
         return custom_handler(plotter, screenshot=screenshot, **kwargs)
 
+    # Built-in trame backends
     try:
         if backend in ['server', 'client', 'trame', 'html']:
             from pyvista.trame.jupyter import show_trame  # noqa: PLC0415
@@ -59,8 +74,25 @@ def handle_plotter(
             return show_trame(plotter, mode=backend, **kwargs)
 
     except ImportError as e:
+        # Trame was explicitly requested but not available
+        _discover_entry_points()
+        if _custom_backends:
+            fallback_name, fallback_handler = next(iter(_custom_backends.items()))
+            available = [f'"{b}"' for b in sorted(_custom_backends.keys())]
+            available += ['"static"', '"none"']
+            warn_external(
+                f'Failed to use notebook backend "{backend}": {e}\n\n'
+                f'Using registered backend "{fallback_name}" instead.\n'
+                f'Available backends: {", ".join(available)}'
+            )
+            return fallback_handler(plotter, screenshot=screenshot, **kwargs)
+
         warn_external(
-            f'Failed to use notebook backend: \n\n{e}\n\nFalling back to a static output.'
+            f'Failed to use notebook backend "{backend}": {e}\n\n'
+            'Falling back to a static output.\n'
+            'Available backends: "static", "none"\n'
+            'Install trame for interactive backends:'
+            ' pip install "pyvista[jupyter]"'
         )
 
     return show_static_image(plotter, screenshot)

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -7375,7 +7375,7 @@ class Plotter(_NoNewAttrMixin, BasePlotter):
             if jupyter_backend is None:
                 jupyter_backend = self._theme.jupyter_backend
 
-            if jupyter_backend.lower() != 'none':
+            if jupyter_backend is None or jupyter_backend.lower() != 'none':
                 jupyter_disp = handle_plotter(self, backend=jupyter_backend, **jupyter_kwargs)
 
         self.render()

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -1877,7 +1877,7 @@ class Theme(_ThemeConfig):
         # Grab system flag for auto-closing
         self._auto_close = os.environ.get('PYVISTA_AUTO_CLOSE', '').lower() != 'false'
 
-        self._jupyter_backend: str = os.environ.get('PYVISTA_JUPYTER_BACKEND', 'trame')
+        self._jupyter_backend: str | None = os.environ.get('PYVISTA_JUPYTER_BACKEND')
         self._trame = _TrameConfig()
 
         self._multi_rendering_splitting_position = None
@@ -2103,7 +2103,7 @@ class Theme(_ThemeConfig):
     @property
     def jupyter_backend(
         self,
-    ) -> str:  # numpydoc ignore=RT01
+    ) -> str | None:  # numpydoc ignore=RT01
         """Return or set the jupyter notebook plotting backend.
 
         Jupyter backend to use when plotting.  Must be one of the
@@ -2153,7 +2153,7 @@ class Theme(_ThemeConfig):
         return self._jupyter_backend
 
     @jupyter_backend.setter
-    def jupyter_backend(self, backend: str):
+    def jupyter_backend(self, backend: str | None):
         from pyvista.jupyter import _validate_jupyter_backend  # noqa: PLC0415
 
         self._jupyter_backend = _validate_jupyter_backend(backend)

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -2147,6 +2147,10 @@ class Theme(_ThemeConfig):
         Disable all plotting within JupyterLab and display using a
         standard desktop VTK render window.
 
+        >>> pv.set_jupyter_backend('none')  # doctest:+SKIP
+
+        Reset to auto-detect the best available backend.
+
         >>> pv.set_jupyter_backend(None)  # doctest:+SKIP
 
         """

--- a/tests/plotting/jupyter/test_custom_backends.py
+++ b/tests/plotting/jupyter/test_custom_backends.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import sys
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -11,11 +13,26 @@ import pytest
 import pyvista as pv
 from pyvista.jupyter import _custom_backends
 from pyvista.jupyter import _get_custom_backend_handler
+from pyvista.jupyter import _resolve_backend
 from pyvista.jupyter import _validate_jupyter_backend
 from pyvista.jupyter import register_jupyter_backend
+from pyvista.jupyter.notebook import handle_plotter
 
 has_ipython = bool(importlib.util.find_spec('IPython'))
 skip_no_ipython = pytest.mark.skipif(not has_ipython, reason='Requires IPython package')
+
+
+@contextlib.contextmanager
+def _block_trame_import():
+    """Temporarily make ``from pyvista.trame.jupyter import …`` raise ImportError."""
+    trame_keys = [k for k in sys.modules if k.startswith('pyvista.trame')]
+    saved = {k: sys.modules.pop(k) for k in trame_keys}
+    sentinel = dict.fromkeys(trame_keys) | {'pyvista.trame.jupyter': None}
+    try:
+        with patch.dict(sys.modules, sentinel):
+            yield
+    finally:
+        sys.modules.update(saved)
 
 
 @pytest.fixture(autouse=True)
@@ -74,8 +91,6 @@ def test_set_jupyter_backend_custom():
 
 @skip_no_ipython
 def test_handle_plotter_dispatches_custom():
-    from pyvista.jupyter.notebook import handle_plotter
-
     mock_handler = MagicMock(return_value='widget')
     register_jupyter_backend('mock', mock_handler)
 
@@ -103,3 +118,102 @@ def test_entry_point_discovery():
     ):
         handler = _get_custom_backend_handler('discovered')
         assert handler is _mock_handler
+
+
+@skip_no_ipython
+def test_handle_plotter_falls_back_to_custom_backend_on_trame_import_error():
+    """When trame is unavailable but an entry-point backend is registered, use it."""
+    mock_handler = MagicMock(return_value='ep_widget')
+    register_jupyter_backend('ep_backend', mock_handler)
+
+    plotter = MagicMock()
+
+    with (
+        _block_trame_import(),
+        pytest.warns(UserWarning, match='Using registered backend "ep_backend"'),
+    ):
+        result = handle_plotter(plotter, backend='trame')
+
+    assert result == 'ep_widget'
+    mock_handler.assert_called_once_with(plotter, screenshot=None)
+
+
+@skip_no_ipython
+def test_handle_plotter_static_fallback_lists_available_backends():
+    """When trame is unavailable and no custom backends exist, list available backends."""
+    plotter = MagicMock()
+    plotter.last_image = None
+
+    with (
+        _block_trame_import(),
+        patch(
+            'pyvista.jupyter.notebook.show_static_image',
+            return_value='static_img',
+        ) as mock_static,
+        pytest.warns(UserWarning, match='Available backends: "static", "none"'),
+    ):
+        result = handle_plotter(plotter, backend='trame')
+
+    assert result == 'static_img'
+    mock_static.assert_called_once()
+
+
+@skip_no_ipython
+def test_resolve_backend_prefers_trame_when_no_custom():
+    """When trame is available and no custom backends registered, returns 'trame'."""
+    assert _resolve_backend() == 'trame'
+
+
+@skip_no_ipython
+def test_resolve_backend_prefers_custom_over_trame():
+    """When both trame and a custom backend are available, prefer the custom one."""
+    register_jupyter_backend('mybackend', _mock_handler)
+    assert _resolve_backend() == 'mybackend'
+
+
+@skip_no_ipython
+def test_resolve_backend_prefers_custom_over_static():
+    """When trame is unavailable but a custom backend is registered, prefer it."""
+    register_jupyter_backend('mybackend', _mock_handler)
+    with _block_trame_import():
+        assert _resolve_backend() == 'mybackend'
+
+
+@skip_no_ipython
+def test_resolve_backend_falls_back_to_static():
+    """When nothing else is available, _resolve_backend returns 'static'."""
+    with _block_trame_import():
+        assert _resolve_backend() == 'static'
+
+
+@skip_no_ipython
+def test_handle_plotter_auto_selects_custom_backend():
+    """When backend=None, trame unavailable, registered backend is auto-selected."""
+    mock_handler = MagicMock(return_value='auto_widget')
+    register_jupyter_backend('auto_backend', mock_handler)
+
+    plotter = MagicMock()
+
+    with _block_trame_import():
+        result = handle_plotter(plotter, backend=None)
+
+    assert result == 'auto_widget'
+    mock_handler.assert_called_once_with(plotter, screenshot=None)
+
+
+@skip_no_ipython
+def test_handle_plotter_auto_static_warns_install():
+    """When backend=None and only static is available, warn about installing trame."""
+    plotter = MagicMock()
+
+    with (
+        _block_trame_import(),
+        patch(
+            'pyvista.jupyter.notebook.show_static_image',
+            return_value='static_img',
+        ),
+        pytest.warns(UserWarning, match=r'pip install "pyvista\[jupyter\]"'),
+    ):
+        result = handle_plotter(plotter, backend=None)
+
+    assert result == 'static_img'

--- a/tests/plotting/jupyter/test_static.py
+++ b/tests/plotting/jupyter/test_static.py
@@ -36,10 +36,16 @@ def test_validate_jupyter_backend_raises(mocker: MockerFixture):
         _validate_jupyter_backend('foo')
 
 
-@pytest.mark.parametrize('backend', [None, 'none'])
-def test_set_jupyter_backend_none(backend):
-    pv.set_jupyter_backend(backend)
+def test_set_jupyter_backend_none():
+    pv.set_jupyter_backend('none')
     assert pv.global_theme.jupyter_backend == 'none'
+
+
+def test_set_jupyter_backend_none_resets_to_auto():
+    pv.set_jupyter_backend('static')
+    assert pv.global_theme.jupyter_backend == 'static'
+    pv.set_jupyter_backend(None)
+    assert pv.global_theme.jupyter_backend is None
 
 
 @skip_no_ipython


### PR DESCRIPTION
With the introduction of third-party notebook backend registration in #8389, the hardcoded default of `jupyter_backend='trame'` creates a poor experience. When trame isn't installed but a registered backend *is* available, users see this unhelpful warning and get dumped into static rendering:

```
UserWarning: Failed to use notebook backend:

No module named 'trame'

Falling back to a static output.
```

The registered backend is completely ignored. This defeats the purpose of the registry: third-party packages register backends via entry points so they "just work," but the default still tries trame first, fails, and falls back to static without ever checking what's actually available.

This PR changes the default `jupyter_backend` from `'trame'` to `None`, which triggers auto-detection at display time. `_resolve_backend()` selects the best available backend with priority: registered custom backends > trame > static. When only static is available, the warning now tells users how to install an interactive backend (`pip install "pyvista[jupyter]"`). When trame is explicitly requested but unavailable, the warning lists all available backends and prefers a registered one over static.
