### PR TITLE
Configure Codecov to wait for all CI jobs

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -488,6 +488,12 @@ jobs:
     needs: [Linux, changes]
     if: always() && github.event_name == 'pull_request' && needs.changes.outputs.tests == 'true'
     steps:
+      # Needs to checkout only for codecov to match file names
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+
       - name: Download coverage reports
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -256,12 +256,13 @@ jobs:
           name: generated_test_images-${{ github.job }}-${{ join(matrix.* , '-') }}
           path: _generated_test_images
 
-      - name: Upload coverage to CodeCov
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v7
         with:
-          fail_ci_if_error: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          name: coverage_reports-${{ github.job }}-${{ join(matrix.* , '-') }}
+          path: coverage*.xml
+          if-no-files-found: error
 
       - name: Check package
         run: |
@@ -480,6 +481,25 @@ jobs:
         run: |
           echo "### Test Image Report" >> $GITHUB_STEP_SUMMARY
           echo "$DEPLOY_URL" >> $GITHUB_STEP_SUMMARY
+
+  upload-coverage-:
+    name: Upload coverage reports
+    runs-on: ubuntu-22.04
+    needs: [Linux, changes]
+    if: always() && github.event_name == 'pull_request' && needs.changes.outputs.tests == 'true'
+    steps:
+      - name: Download coverage reports
+        uses: actions/download-artifact@v8
+        with:
+          pattern: coverage_reports-*
+          path: coverage*.xml
+
+      - name: Upload coverage to CodeCov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
+        with:
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # Publish to PyPI using trusted publishing
   release:

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,6 +13,11 @@ coverage:
         if_not_found: success
         if_ci_failed: error
         if_no_uploads: error
+        # Wait for all 6 Linux CI jobs to upload coverage before reporting
+        # status. Without this, Codecov reports failure on partial data which
+        # causes the merge queue to dequeue the PR before the final status
+        # flips to success.
+        after_n_builds: 6
     patch:
       default:
         # basic
@@ -20,3 +25,4 @@ coverage:
         if_not_found: success
         if_ci_failed: error
         if_no_uploads: error
+        after_n_builds: 6

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,11 +13,6 @@ coverage:
         if_not_found: success
         if_ci_failed: error
         if_no_uploads: error
-        # Wait for all 6 Linux CI jobs to upload coverage before reporting
-        # status. Without this, Codecov reports failure on partial data which
-        # causes the merge queue to dequeue the PR before the final status
-        # flips to success.
-        after_n_builds: 6
     patch:
       default:
         # basic
@@ -25,4 +20,3 @@ coverage:
         if_not_found: success
         if_ci_failed: error
         if_no_uploads: error
-        after_n_builds: 6


### PR DESCRIPTION
Configure codecove to wait for all Linux tests to complete before reporting the coverage status to prevent false negatives during the merge queue.

Ref https://github.com/pyvista/pyvista/pull/8420#issuecomment-4204165580

Ref https://github.com/pyvista/pyvista/pull/8405#issuecomment-4211668670