### PR TITLE
Add SMP tools helper

### DIFF
--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -105,10 +105,6 @@ from vtkmodules.vtkCommonCore import vtkTypeUInt32Array as vtkTypeUInt32Array
 from vtkmodules.vtkCommonCore import vtkUnsignedCharArray as vtkUnsignedCharArray
 from vtkmodules.vtkCommonCore import vtkVersion as vtkVersion
 from vtkmodules.vtkCommonCore import vtkWeakReference as vtkWeakReference
-
-with contextlib.suppress(ImportError):
-    from vtkmodules.vtkCommonCore import vtkSMPTools as vtkSMPTools
-
 from vtkmodules.vtkCommonDataModel import VTK_BEZIER_CURVE as VTK_BEZIER_CURVE
 from vtkmodules.vtkCommonDataModel import VTK_BEZIER_HEXAHEDRON as VTK_BEZIER_HEXAHEDRON
 from vtkmodules.vtkCommonDataModel import VTK_BEZIER_PYRAMID as VTK_BEZIER_PYRAMID
@@ -547,3 +543,6 @@ except ImportError:
     from vtkmodules.vtkCommonDataModel import (  # type:ignore[assignment]
         vtkCellTypes as vtkCellTypeUtilities,  # noqa: F401
     )
+
+with contextlib.suppress(ImportError):
+    from vtkmodules.vtkCommonCore import vtkSMPTools as vtkSMPTools

--- a/pyvista/core/_vtk_core.py
+++ b/pyvista/core/_vtk_core.py
@@ -105,6 +105,10 @@ from vtkmodules.vtkCommonCore import vtkTypeUInt32Array as vtkTypeUInt32Array
 from vtkmodules.vtkCommonCore import vtkUnsignedCharArray as vtkUnsignedCharArray
 from vtkmodules.vtkCommonCore import vtkVersion as vtkVersion
 from vtkmodules.vtkCommonCore import vtkWeakReference as vtkWeakReference
+
+with contextlib.suppress(ImportError):
+    from vtkmodules.vtkCommonCore import vtkSMPTools as vtkSMPTools
+
 from vtkmodules.vtkCommonDataModel import VTK_BEZIER_CURVE as VTK_BEZIER_CURVE
 from vtkmodules.vtkCommonDataModel import VTK_BEZIER_HEXAHEDRON as VTK_BEZIER_HEXAHEDRON
 from vtkmodules.vtkCommonDataModel import VTK_BEZIER_PYRAMID as VTK_BEZIER_PYRAMID

--- a/pyvista/core/utilities/__init__.py
+++ b/pyvista/core/utilities/__init__.py
@@ -128,6 +128,7 @@ from .misc import abstract_class as abstract_class
 from .misc import assert_empty_kwargs as assert_empty_kwargs
 from .misc import check_valid_vector as check_valid_vector
 from .misc import conditional_decorator as conditional_decorator
+from .misc import enable_smp_tools as enable_smp_tools
 from .misc import has_module as has_module
 from .misc import set_new_attribute as set_new_attribute
 from .misc import threaded as threaded

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -12,12 +12,14 @@ import sys
 import threading
 import traceback
 from typing import TYPE_CHECKING
+from typing import Literal
 from typing import TypeVar
 
 import numpy as np
 from typing_extensions import Self
 
 from pyvista._warn_external import warn_external
+from pyvista.core import _vtk_core as _vtk
 
 if TYPE_CHECKING:
     from typing import Any
@@ -29,6 +31,14 @@ if TYPE_CHECKING:
     _T = TypeVar('_T')
 
 T = TypeVar('T', bound='AnnotatedIntEnum')
+
+_SMPBackendOptions = Literal['stdthread', 'tbb', 'openmp', 'sequential']
+_SMP_BACKEND_NAMES: dict[str, str] = {
+    'stdthread': 'STDThread',
+    'tbb': 'TBB',
+    'openmp': 'OpenMP',
+    'sequential': 'Sequential',
+}
 
 if sys.version_info >= (3, 11):
     from enum import StrEnum
@@ -209,6 +219,102 @@ def has_module(module_name: str) -> bool:
     """
     module_spec = importlib.util.find_spec(module_name)
     return module_spec is not None
+
+
+def enable_smp_tools(
+    backend: _SMPBackendOptions = 'stdthread',
+    n_threads: int | None = None,
+) -> None:
+    """Enable a VTK SMP backend for filters that support shared-memory parallelism.
+
+    VTK's Python wheels currently default to the sequential SMP backend. This
+    helper switches to a parallel backend and optionally configures the maximum
+    number of threads used by VTK filters that rely on :vtk:`vtkSMPTools`.
+
+    Parameters
+    ----------
+    backend : str, default: 'stdthread'
+        SMP backend to enable. Acceptable values are:
+
+        - ``'stdthread'``: Enable VTK's ``std::thread`` backend. This is the
+          default and is available in the current VTK wheels.
+        - ``'tbb'``: Enable Intel oneTBB when available in the current VTK
+          build.
+        - ``'openmp'``: Enable OpenMP when available in the current VTK build.
+        - ``'sequential'``: Use VTK's sequential backend.
+
+    n_threads : int, optional
+        Maximum number of threads to use. If not provided, VTK resets to its
+        default maximum thread count and honors the ``VTK_SMP_MAX_THREADS``
+        environment variable when it is set.
+
+    Raises
+    ------
+    TypeError
+        If ``backend`` is not a string or if ``n_threads`` is not an integer.
+
+    ValueError
+        If ``backend`` is invalid or if ``n_threads`` is less than ``1``.
+
+    RuntimeError
+        If this VTK build does not support runtime SMP backend selection, or if
+        the requested backend is unavailable.
+
+    Examples
+    --------
+    Enable the wheel-supported ``stdthread`` backend.
+
+    >>> import pyvista as pv
+    >>> pv.enable_smp_tools()  # doctest:+SKIP
+
+    Configure the backend before running a contour filter.
+
+    >>> from pyvista import examples
+    >>> pv.enable_smp_tools(n_threads=8)  # doctest:+SKIP
+    >>> grid = examples.download_fea_bracket()  # doctest:+SKIP
+    >>> _ = grid.contour(5, scalars='Equivalent Stress')  # doctest:+SKIP
+
+    """
+    if not isinstance(backend, str):
+        msg = '`backend` must be a string.'  # type: ignore[unreachable]
+        raise TypeError(msg)
+
+    backend_key = backend.lower()
+    vtk_backend = _SMP_BACKEND_NAMES.get(backend_key)
+    if vtk_backend is None:
+        valid_backends = ', '.join(f'`{name}`' for name in _SMP_BACKEND_NAMES)
+        msg = f'Invalid SMP backend `{backend}`. Valid options are: {valid_backends}.'
+        raise ValueError(msg)
+
+    if n_threads is not None:
+        if isinstance(n_threads, bool) or not isinstance(n_threads, (int, np.integer)):
+            msg = '`n_threads` must be an integer.'
+            raise TypeError(msg)
+        if n_threads < 1:
+            msg = '`n_threads` must be greater than or equal to 1.'
+            raise ValueError(msg)
+        n_threads_ = int(n_threads)
+    else:
+        n_threads_ = None
+
+    if not hasattr(_vtk, 'vtkSMPTools') or not hasattr(_vtk.vtkSMPTools, 'SetBackend'):
+        msg = 'This VTK build does not support runtime SMP backend selection.'
+        raise RuntimeError(msg)
+
+    original_backend = _vtk.vtkSMPTools.GetBackend()
+    original_threads = _vtk.vtkSMPTools.GetEstimatedNumberOfThreads()
+
+    available = _vtk.vtkSMPTools.SetBackend(vtk_backend)
+    if not available:
+        _vtk.vtkSMPTools.SetBackend(original_backend)
+        _vtk.vtkSMPTools.Initialize(original_threads)
+        msg = f'The requested SMP backend `{backend_key}` is not available in this VTK build.'
+        raise RuntimeError(msg)
+
+    if n_threads_ is None:
+        _vtk.vtkSMPTools.Initialize()
+    else:
+        _vtk.vtkSMPTools.Initialize(n_threads_)
 
 
 def try_callback(func, *args) -> None:  # noqa: ANN001

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -15,6 +15,7 @@ import platform
 import re
 import shutil
 import sys
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from typing import Literal
 from typing import TypeVar
@@ -44,6 +45,7 @@ from pyvista.core.utilities import fileio
 from pyvista.core.utilities import fit_line_to_points
 from pyvista.core.utilities import fit_plane_to_points
 from pyvista.core.utilities import line_segments_from_points
+from pyvista.core.utilities import misc
 from pyvista.core.utilities import principal_axes
 from pyvista.core.utilities import transformations
 from pyvista.core.utilities import vector_poly_data
@@ -88,6 +90,22 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 IS_ARM_MAC = platform.system() == 'Darwin' and platform.machine() == 'arm64'
+HAS_RUNTIME_SMP_BACKEND_SELECTION = hasattr(_vtk, 'vtkSMPTools') and hasattr(
+    _vtk.vtkSMPTools, 'SetBackend'
+)
+
+
+@pytest.fixture
+def reset_smp_tools():
+    """Restore VTK's SMP backend state after a test that mutates it."""
+    if not HAS_RUNTIME_SMP_BACKEND_SELECTION:
+        yield
+        return
+    original_backend = _vtk.vtkSMPTools.GetBackend()
+    original_threads = _vtk.vtkSMPTools.GetEstimatedNumberOfThreads()
+    yield
+    _vtk.vtkSMPTools.SetBackend(original_backend)
+    _vtk.vtkSMPTools.Initialize(original_threads)
 
 
 @pytest.fixture
@@ -2618,6 +2636,91 @@ def test_allow_new_attributes():
     assert pv.allow_new_attributes() is True
     set_private()
     set_public()
+
+
+@pytest.mark.skipif(
+    not HAS_RUNTIME_SMP_BACKEND_SELECTION,
+    reason='Requires runtime SMP backend selection support in VTK.',
+)
+def test_enable_smp_tools_default_backend(reset_smp_tools):  # noqa: ARG001
+    _vtk.vtkSMPTools.SetBackend('Sequential')
+    _vtk.vtkSMPTools.Initialize(1)
+
+    pv.enable_smp_tools()
+
+    assert _vtk.vtkSMPTools.GetBackend() == 'STDThread'
+    assert _vtk.vtkSMPTools.GetEstimatedNumberOfThreads() >= 1
+
+
+@pytest.mark.skipif(
+    not HAS_RUNTIME_SMP_BACKEND_SELECTION,
+    reason='Requires runtime SMP backend selection support in VTK.',
+)
+def test_enable_smp_tools_sets_threads(reset_smp_tools):  # noqa: ARG001
+    pv.enable_smp_tools(n_threads=2)
+
+    assert _vtk.vtkSMPTools.GetBackend() == 'STDThread'
+    assert _vtk.vtkSMPTools.GetEstimatedNumberOfThreads() == 2
+
+
+@pytest.mark.parametrize(
+    ('kwargs', 'error_type', 'match'),
+    [
+        ({'backend': 'invalid'}, ValueError, 'Invalid SMP backend'),
+        ({'backend': 1}, TypeError, '`backend` must be a string.'),
+        ({'n_threads': 0}, ValueError, '`n_threads` must be greater than or equal to 1.'),
+        ({'n_threads': 1.5}, TypeError, '`n_threads` must be an integer.'),
+        ({'n_threads': True}, TypeError, '`n_threads` must be an integer.'),
+    ],
+)
+def test_enable_smp_tools_invalid_input(kwargs, error_type, match):
+    with pytest.raises(error_type, match=re.escape(match)):
+        pv.enable_smp_tools(**kwargs)
+
+
+def test_enable_smp_tools_unsupported_vtk_build(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(misc, '_vtk', SimpleNamespace())
+
+    match = 'This VTK build does not support runtime SMP backend selection.'
+    with pytest.raises(RuntimeError, match=re.escape(match)):
+        pv.enable_smp_tools()
+
+
+def test_enable_smp_tools_restores_state_on_unavailable_backend(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    state = {'backend': 'Sequential', 'threads': 3}
+
+    def get_backend() -> str:
+        return state['backend']
+
+    def get_estimated_number_of_threads() -> int:
+        return state['threads']
+
+    def initialize(n_threads: int = 0) -> None:
+        state['threads'] = n_threads or 8
+
+    def set_backend(backend: str) -> bool:
+        if backend == 'TBB':
+            state['backend'] = 'STDThread'
+            return False
+        state['backend'] = backend
+        return True
+
+    fake_smp_tools = SimpleNamespace(
+        GetBackend=get_backend,
+        GetEstimatedNumberOfThreads=get_estimated_number_of_threads,
+        Initialize=initialize,
+        SetBackend=set_backend,
+    )
+    monkeypatch.setattr(misc, '_vtk', SimpleNamespace(vtkSMPTools=fake_smp_tools))
+
+    match = 'The requested SMP backend `tbb` is not available in this VTK build.'
+    with pytest.raises(RuntimeError, match=re.escape(match)):
+        pv.enable_smp_tools('tbb')
+
+    assert get_backend() == 'Sequential'
+    assert get_estimated_number_of_threads() == 3
 
 
 T = TypeVar('T')

--- a/tests/namespace/namespace-top.txt
+++ b/tests/namespace/namespace-top.txt
@@ -233,6 +233,7 @@ create_grid, <function create_grid at 0x1641b3790>
 # cube_axes_actor, <module 'pyvista.plotting.cube_axes_actor' from 'pyvista/pyvista/plotting/cube_axes_actor.py'>
 cubemap, <function cubemap at 0x163f41430>
 cubemap_from_filenames, <function cubemap_from_filenames at 0x163f414c0>
+enable_smp_tools
 # dataobject, <module 'pyvista.core.dataobject' from 'pyvista/pyvista/core/dataobject.py'>
 # dataset, <module 'pyvista.core.dataset' from 'pyvista/pyvista/core/dataset.py'>
 # datasetattributes, <module 'pyvista.core.datasetattributes' from 'pyvista/pyvista/core/datasetattributes.py'>

--- a/tests/namespace/namespace-utilities.txt
+++ b/tests/namespace/namespace-utilities.txt
@@ -135,6 +135,7 @@ convert_string_array, <function convert_string_array at 0x7f72f5e055e0>
 create_grid, <function create_grid at 0x7f72f5d21160>
 cubemap, <function cubemap at 0x7f72f5e07ca0>
 cubemap_from_filenames, <function cubemap_from_filenames at 0x7f72f5e07d30>
+enable_smp_tools
 errors, <module 'pyvista.utilities.errors' from 'pyvista/utilities/errors.py'>
 features, <module 'pyvista.utilities.features' from 'pyvista/utilities/features.py'>
 field_array, <function field_array at 0x7f72f5e058b0>


### PR DESCRIPTION
## Summary

- Adds `pv.enable_smp_tools(backend='stdthread', n_threads=None)` as a public helper that switches VTK's runtime SMP backend and (optionally) sets the max thread count for any PyVista filter that delegates to `vtkSMPTools`.
- No behavior changes for existing code. The helper is opt-in; users who never call it continue to run VTK's default (sequential) backend.
- Validates `backend` against a fixed `Literal['stdthread', 'tbb', 'openmp', 'sequential']` set, validates `n_threads >= 1`, raises a clear `RuntimeError` on VTK builds that lack runtime backend selection, and restores prior state on a failed `SetBackend`.

## Why

VTK's Python wheels default to the sequential SMP backend, so PyVista filters that would otherwise be parallelized via `vtkSMPTools` run single-threaded out of the box. VTK exposes a runtime `vtkSMPTools.SetBackend()` API on recent builds, but most users don't know it exists or how to drive it from Python. This helper surfaces that capability with input validation, safe failure modes, and examples.

Typical usage:

```py
import pyvista as pv
pv.enable_smp_tools()  # STDThread, VTK's default thread count
# or
pv.enable_smp_tools(n_threads=8)
```

## Performance

Benchmarked with the exact filter calls shown below (1 warmup + 7 timed runs, median reported, alternating backend order per trial). Each row shows the best STDThread speedup observed across my Mac and one of my intel linux machines (will run on AMD later). The "Machine" column indicates which one produced the peak number.

| Dataset / call | Sequential (ms) | STDThread (ms) | Speedup | Machine |
| --- | ---: | ---: | ---: | --- |
| `knee_full.contour([40,80,120], method='flying_edges')` | 57.06 | 13.43 | **4.25x** | Mac |
| `fea_bracket.linear_copy().extract_surface(algorithm='geometry')` | 13.16 | 3.78 | **3.48x** | Linux |
| `head.contour([40,80,120], method='flying_edges')` | 3.19 | 1.51 | **2.12x** | Linux |
| `fea_bracket.cell_quality('scaled_jacobian')` | 4.07 | 1.97 | **2.06x** | Linux |
| `channels.contour_labels(smoothing=False)` | 109.44 | 71.42 | 1.53x | Mac (tied) |
| `bunny.compute_normals()` | 23.72 | 17.54 | 1.35x | Linux |
| `dragon.compute_normals()` | 368.26 | 277.71 | 1.33x | Linux |

### Benchmark environments

| Item | Mac | Linux |
| --- | --- | --- |
| OS | macOS 26.3 arm64 | Ubuntu 24.04 x86_64 |
| CPU threads | 10 | 20 |
| Python | 3.13.12 | 3.13.12 |
| VTK wheel | 9.6.0 | 9.6.1 |
| Helper default backend | `STDThread` | `STDThread` |

Neither wheel currently ships `TBB` or `OpenMP`, so those code paths exist in `enable_smp_tools` but weren't validated. A VTK build-from-source with `-DVTK_SMP_IMPLEMENTATION_TYPE=TBB` would be required to benchmark TBB directly.