### PR TITLE
Return a context manager with pv.enable_smp_tools()

### DIFF
--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -221,15 +221,35 @@ def has_module(module_name: str) -> bool:
     return module_spec is not None
 
 
+class _SMPToolsContext:
+    """Context manager that restores VTK SMP backend state on exit."""
+
+    def __init__(self, original_backend: str, original_threads: int) -> None:
+        self._original_backend = original_backend
+        self._original_threads = original_threads
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        _vtk.vtkSMPTools.SetBackend(self._original_backend)
+        _vtk.vtkSMPTools.Initialize(self._original_threads)
+
+
 def enable_smp_tools(
     backend: _SMPBackendOptions = 'stdthread',
     n_threads: int | None = None,
-) -> None:
+) -> _SMPToolsContext:
     """Enable a VTK SMP backend for filters that support shared-memory parallelism.
 
     VTK's Python wheels currently default to the sequential SMP backend. This
     helper switches to a parallel backend and optionally configures the maximum
     number of threads used by VTK filters that rely on :vtk:`vtkSMPTools`.
+
+    The backend is applied immediately, so calling this function by itself
+    enables the chosen backend for the rest of the process. The return value is
+    also a context manager, so using it with a ``with`` statement will restore
+    the previous backend and thread count on exit.
 
     Parameters
     ----------
@@ -248,6 +268,13 @@ def enable_smp_tools(
         default maximum thread count and honors the ``VTK_SMP_MAX_THREADS``
         environment variable when it is set.
 
+    Returns
+    -------
+    _SMPToolsContext
+        A context manager that restores the previous SMP backend and thread
+        count when exited. The return value may be discarded when the change
+        should apply for the remainder of the process.
+
     Raises
     ------
     TypeError
@@ -262,7 +289,8 @@ def enable_smp_tools(
 
     Examples
     --------
-    Enable the wheel-supported ``stdthread`` backend.
+    Enable the wheel-supported ``stdthread`` backend for the rest of the
+    process.
 
     >>> import pyvista as pv
     >>> pv.enable_smp_tools()  # doctest:+SKIP
@@ -273,6 +301,12 @@ def enable_smp_tools(
     >>> pv.enable_smp_tools(n_threads=8)  # doctest:+SKIP
     >>> grid = examples.download_fea_bracket()  # doctest:+SKIP
     >>> _ = grid.contour(5, scalars='Equivalent Stress')  # doctest:+SKIP
+
+    Scope the backend change to a ``with`` block. The previous backend and
+    thread count are restored on exit, even if an exception is raised.
+
+    >>> with pv.enable_smp_tools(n_threads=8):  # doctest:+SKIP
+    ...     _ = grid.contour(5, scalars='Equivalent Stress')
 
     """
     if not isinstance(backend, str):
@@ -315,6 +349,8 @@ def enable_smp_tools(
         _vtk.vtkSMPTools.Initialize()
     else:
         _vtk.vtkSMPTools.Initialize(n_threads_)
+
+    return _SMPToolsContext(original_backend, original_threads)
 
 
 def try_callback(func, *args) -> None:  # noqa: ANN001

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -2694,6 +2694,56 @@ def test_enable_smp_tools_unsupported_vtk_build(monkeypatch: pytest.MonkeyPatch)
         pv.enable_smp_tools()
 
 
+@pytest.mark.skipif(
+    not HAS_RUNTIME_SMP_BACKEND_SELECTION,
+    reason='Requires runtime SMP backend selection support in VTK.',
+)
+def test_enable_smp_tools_context_manager_restores_state(reset_smp_tools):  # noqa: ARG001
+    _vtk.vtkSMPTools.SetBackend('Sequential')
+    _vtk.vtkSMPTools.Initialize(1)
+
+    with pv.enable_smp_tools(n_threads=2):
+        assert _vtk.vtkSMPTools.GetBackend() == 'STDThread'
+        assert _vtk.vtkSMPTools.GetEstimatedNumberOfThreads() == 2
+
+    assert _vtk.vtkSMPTools.GetBackend() == 'Sequential'
+    assert _vtk.vtkSMPTools.GetEstimatedNumberOfThreads() == 1
+
+
+@pytest.mark.skipif(
+    not HAS_RUNTIME_SMP_BACKEND_SELECTION,
+    reason='Requires runtime SMP backend selection support in VTK.',
+)
+def test_enable_smp_tools_context_manager_restores_on_exception(reset_smp_tools):  # noqa: ARG001
+    _vtk.vtkSMPTools.SetBackend('Sequential')
+    _vtk.vtkSMPTools.Initialize(1)
+
+    msg = 'boom'
+    with pytest.raises(RuntimeError, match=msg), pv.enable_smp_tools(n_threads=2):
+        raise RuntimeError(msg)
+
+    assert _vtk.vtkSMPTools.GetBackend() == 'Sequential'
+    assert _vtk.vtkSMPTools.GetEstimatedNumberOfThreads() == 1
+
+
+@pytest.mark.skipif(
+    not HAS_RUNTIME_SMP_BACKEND_SELECTION,
+    reason='Requires runtime SMP backend selection support in VTK.',
+)
+def test_enable_smp_tools_context_manager_nested(reset_smp_tools):  # noqa: ARG001
+    _vtk.vtkSMPTools.SetBackend('Sequential')
+    _vtk.vtkSMPTools.Initialize(1)
+
+    with pv.enable_smp_tools(n_threads=2):
+        assert _vtk.vtkSMPTools.GetEstimatedNumberOfThreads() == 2
+        with pv.enable_smp_tools(n_threads=4):
+            assert _vtk.vtkSMPTools.GetEstimatedNumberOfThreads() == 4
+        assert _vtk.vtkSMPTools.GetEstimatedNumberOfThreads() == 2
+
+    assert _vtk.vtkSMPTools.GetBackend() == 'Sequential'
+    assert _vtk.vtkSMPTools.GetEstimatedNumberOfThreads() == 1
+
+
 def test_enable_smp_tools_restores_state_on_unavailable_backend(
     monkeypatch: pytest.MonkeyPatch,
 ):


### PR DESCRIPTION
- `pv.enable_smp_tools()` now returns a context manager that restores the previous VTK SMP backend and thread count on exit, so `with pv.enable_smp_tools(n_threads=8):` cleanly scopes the change to a block.
- Plain calls keep their existing behavior: the backend is applied immediately and the returned value can be discarded when the change should apply for the remainder of the process.
- Restoration runs even when the `with` block raises, and nested `with` blocks unwind in LIFO order.
- Added three tests covering normal exit, exception propagation, and nested usage.
- Updated the docstring with a `with`-block example.


```py
mesh = ...
with pv.enable_smp_tools(n_threads=8):
    mesh.contour(method='flying_edges')
```