### PR TITLE
Bump pytest-pyvista for docs build image report

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1121,7 +1121,7 @@ copies of the images are made as follows:
 #. If the comparison between the two images fails:
 
     - The cache image is copied to ``./_doc_debug_images_failed/errors/from_cache``
-    - The build image is copied to ``./_doc_debug_images_failed/errors/from_build``
+    - The build image is copied to ``./_doc_debug_images_failed/errors/from_test``
 
 #.  If an image is in the cache but missing from the build:
 
@@ -1129,15 +1129,15 @@ copies of the images are made as follows:
 
 #.  If an image is in the build but missing from the cache:
 
-    - The build image is copied to  ``./_doc_debug_images_failed/errors/from_build``
+    - The build image is copied to  ``./_doc_debug_images_failed/errors/from_test``
 
 If a warning is generated instead of an error, images are saved to the
 ``warnings`` sub-directory instead of ``errors``.
 
-To resolve failed tests, any images in ``from_build`` or ``from_cache``
+To resolve failed tests, any images in ``from_test`` or ``from_cache``
 may be copied to or removed from the ``Doc Image Cache``. For example,
 if adding new docstring examples or plots, the test will initially fail,
-and the images in ``from_build`` may be added to the ``Doc Image Cache``.
+and the images in ``from_test`` may be added to the ``Doc Image Cache``.
 Similarly, if removing examples, the images in ``from_cache`` may be removed
 from the ``Doc Image Cache``.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ test = [
   'pytest-cov<7.2.0',
   'pytest-mock<3.16.0',
   'pytest-mypy-plugins<4.1.0',
-  'pytest-pyvista==0.3.2',
+  'pytest-pyvista==0.3.3',
   'pytest-xdist<3.9.0',
   'pytest<9.1.0',
   'retry-requests<2.1.0',
@@ -162,7 +162,7 @@ docs = [
 ]
 
 docs-test = [
-  'pytest-pyvista[vtksz]==0.3.2',
+  'pytest-pyvista[vtksz]==0.3.3',
   'pytest-xdist<3.9.0',
   'trame-vtk==2.11.6',
   { include-group = 'pinned' },


### PR DESCRIPTION
Update pytest-pyvista for https://github.com/pyvista/pytest-pyvista/pull/287 to bring the docs-build image report online