### PR TITLE
Add remove_nan_cells helper filter

### DIFF
--- a/examples/01-filter/using_filters.py
+++ b/examples/01-filter/using_filters.py
@@ -96,13 +96,14 @@ pl.show()
 # filtering pipeline through a chain; attaching each filter to the last filter.
 # In the following example, several filters are chained together:
 #
-# 1. First, and empty ``threshold`` filter to clean out any ``NaN`` values.
+# 1. First, use :func:`~pyvista.DataSetFilters.remove_nan_cells` to drop any
+#    cells whose scalar values are ``NaN``.
 # 2. Use an ``elevation`` filter to generate scalar values corresponding to height.
 # 3. Use the ``clip`` filter to cut the dataset in half.
 # 4. Create three slices along each axial plane using the ``slice_orthogonal`` filter.
 
 # Apply a filtering chain
-result = dataset.threshold().elevation().clip(normal='z').slice_orthogonal()
+result = dataset.remove_nan_cells().elevation().clip(normal='z').slice_orthogonal()
 
 # %%
 # And to view this filtered data, simply call the ``plot`` method

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -1173,6 +1173,9 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
         >>> bool(np.any(np.isnan(cleaned.point_data['values'])))
         False
 
+        See :ref:`using_filters_example` for an end-to-end filter pipeline
+        that begins with this filter.
+
         """
         scalars_ = set_default_active_scalars(self).name if scalars is None else scalars
         arr = get_array(self, scalars_, preference=preference, err=False)

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -833,6 +833,8 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
         --------
         threshold_percent
             Threshold a dataset by a percentage of its scalar range.
+        :meth:`~pyvista.DataSetFilters.remove_nan_cells`
+            Convenience wrapper to remove cells containing NaN values.
         :meth:`~pyvista.DataSetFilters.extract_values`
             Threshold-like filter for extracting specific values and ranges.
         :meth:`~pyvista.ImageDataFilters.image_threshold`
@@ -1084,6 +1086,117 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
             continuous=continuous,
             preference=preference,
             method=method,
+            progress_bar=progress_bar,
+        )
+
+    @_deprecate_positional_args
+    def remove_nan_cells(  # type: ignore[misc]  # noqa: PLR0917
+        self: _DataSetType,
+        scalars: str | None = None,
+        preference: Literal['point', 'cell'] = 'point',
+        component_mode: Literal['component', 'all', 'any'] = 'all',
+        component: int = 0,
+        progress_bar: bool = False,  # noqa: FBT001, FBT002
+    ) -> UnstructuredGrid:
+        """Remove cells whose scalar values are NaN.
+
+        A cell is considered NaN if any of its associated scalar values are
+        NaN. For point data, this means any cell containing a NaN point is
+        dropped; for cell data, cells whose value is NaN are dropped.
+
+        .. versionadded:: 0.48
+
+        .. note::
+            This filter is equivalent to calling
+            :meth:`~pyvista.DataSetFilters.threshold` with ``all_scalars=True``
+            and the default (auto-computed) value range, which uses
+            :func:`numpy.nanmin` and :func:`numpy.nanmax` to exclude NaN
+            values from the bounds. It is provided as a convenience because
+            ``threshold`` defaults to ``preference='cell'`` and
+            ``all_scalars=False``, which does not reliably remove NaN cells
+            from point data.
+
+        Parameters
+        ----------
+        scalars : str, optional
+            Name of scalars to check for NaN values. Defaults to the
+            currently active scalars.
+
+        preference : str, default: 'point'
+            When ``scalars`` is specified, this is the preferred array
+            type to search for in the dataset. Must be either ``'point'``
+            or ``'cell'``.
+
+        component_mode : {'component', 'all', 'any'}, default: 'all'
+            The method to satisfy the criteria for multicomponent scalars.
+            ``'component'`` uses only the single component specified by
+            ``component``. ``'all'`` drops a cell if any component is NaN.
+            ``'any'`` keeps a cell as long as at least one component is
+            finite.
+
+        component : int, default: 0
+            When using ``component_mode='component'``, this sets which
+            component to check for NaN values.
+
+        progress_bar : bool, default: False
+            Display a progress bar to indicate progress.
+
+        Returns
+        -------
+        pyvista.UnstructuredGrid
+            Dataset with NaN cells removed.
+
+        See Also
+        --------
+        threshold
+            Threshold a dataset by value. ``remove_nan_cells`` is a thin
+            wrapper around this filter.
+        :meth:`~pyvista.DataSetFilters.extract_cells`
+            Extract a subset of cells by index.
+        :meth:`~pyvista.DataSetFilters.extract_values`
+            Threshold-like filter for extracting specific values and ranges.
+
+        Examples
+        --------
+        Create a small grid with some NaN point values and remove the
+        affected cells.
+
+        >>> import numpy as np
+        >>> import pyvista as pv
+        >>> grid = pv.ImageData(dimensions=(5, 5, 5))
+        >>> values = np.arange(grid.n_points, dtype=float)
+        >>> values[::7] = np.nan
+        >>> grid.point_data['values'] = values
+        >>> cleaned = grid.remove_nan_cells(scalars='values')
+        >>> cleaned.n_cells < grid.n_cells
+        True
+        >>> bool(np.any(np.isnan(cleaned.point_data['values'])))
+        False
+
+        """
+        scalars_ = set_default_active_scalars(self).name if scalars is None else scalars
+        arr = get_array(self, scalars_, preference=preference, err=False)
+        if arr is None:
+            msg = f'No array {scalars_!r} found to remove NaN cells from.'
+            raise ValueError(msg)
+        # Integer, boolean, and non-numeric arrays cannot contain NaN values.
+        if arr.dtype == bool or not np.issubdtype(arr.dtype, np.floating):
+            return self.cast_to_unstructured_grid()
+        if arr.size == 0 or bool(np.all(np.isnan(arr))):
+            # Entire array is NaN (or empty) — no cells survive. Avoid passing
+            # a (nan, nan) range into VTK's threshold filter.
+            return self.extract_cells(
+                np.array([], dtype=int),
+                pass_cell_ids=False,
+                pass_point_ids=False,
+            )
+        return DataSetFilters.threshold(
+            self,
+            scalars=scalars_,
+            preference=preference,
+            all_scalars=True,
+            component_mode=component_mode,
+            component=component,
             progress_bar=progress_bar,
         )
 

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -392,6 +392,118 @@ def test_threshold_multicomponent():
         mesh.threshold(value=0.5, scalars='data', component_mode='component', component=0.5)
 
 
+def test_remove_nan_cells_point_data():
+    grid = pv.ImageData(dimensions=(5, 5, 5))
+    values = np.arange(grid.n_points, dtype=float)
+    nan_point_mask = np.zeros(grid.n_points, dtype=bool)
+    nan_point_mask[::7] = True
+    values[nan_point_mask] = np.nan
+    grid.point_data['values'] = values
+
+    cleaned = grid.remove_nan_cells(scalars='values')
+    assert isinstance(cleaned, pv.UnstructuredGrid)
+    assert cleaned.n_cells < grid.n_cells
+    assert not np.any(np.isnan(cleaned.point_data['values']))
+
+    # The surviving cells should be exactly the cells with no NaN point.
+    expected_cells = []
+    for cid in range(grid.n_cells):
+        point_ids = grid.get_cell(cid).point_ids
+        if not np.any(nan_point_mask[point_ids]):
+            expected_cells.append(cid)
+    assert cleaned.n_cells == len(expected_cells)
+
+
+def test_remove_nan_cells_cell_data():
+    grid = pv.ImageData(dimensions=(5, 5, 5))
+    cvals = np.arange(grid.n_cells, dtype=float)
+    cvals[::3] = np.nan
+    grid.cell_data['cvals'] = cvals
+
+    cleaned = grid.remove_nan_cells(scalars='cvals', preference='cell')
+    assert isinstance(cleaned, pv.UnstructuredGrid)
+    expected_n = int(np.sum(~np.isnan(cvals)))
+    assert cleaned.n_cells == expected_n
+    assert not np.any(np.isnan(cleaned.cell_data['cvals']))
+
+
+def test_remove_nan_cells_active_scalars_default():
+    grid = pv.ImageData(dimensions=(4, 4, 4))
+    values = np.arange(grid.n_points, dtype=float)
+    values[::5] = np.nan
+    grid.point_data['values'] = values
+    grid.set_active_scalars('values')
+
+    explicit = grid.remove_nan_cells(scalars='values')
+    implicit = grid.remove_nan_cells()
+    assert explicit.n_cells == implicit.n_cells
+
+
+def test_remove_nan_cells_multicomponent():
+    mesh = pv.Plane()
+    data = np.zeros((mesh.n_cells, 3))
+    data[0, 0] = np.nan
+    data[1, :] = np.nan
+    mesh['data'] = data
+
+    # component_mode='all' drops any cell with any NaN component.
+    cleaned_all = mesh.remove_nan_cells(scalars='data', preference='cell', component_mode='all')
+    assert cleaned_all.n_cells == mesh.n_cells - 2
+
+    # component_mode='component' only checks the specified component.
+    cleaned_c0 = mesh.remove_nan_cells(
+        scalars='data', preference='cell', component_mode='component', component=0
+    )
+    assert cleaned_c0.n_cells == mesh.n_cells - 2
+
+    cleaned_c2 = mesh.remove_nan_cells(
+        scalars='data', preference='cell', component_mode='component', component=2
+    )
+    assert cleaned_c2.n_cells == mesh.n_cells - 1
+
+
+def test_remove_nan_cells_all_nan():
+    grid = pv.ImageData(dimensions=(3, 3, 3))
+    grid.point_data['values'] = np.full(grid.n_points, np.nan)
+    cleaned = grid.remove_nan_cells(scalars='values')
+    assert isinstance(cleaned, pv.UnstructuredGrid)
+    assert cleaned.n_cells == 0
+
+
+def test_remove_nan_cells_integer_array():
+    grid = pv.ImageData(dimensions=(3, 3, 3))
+    grid.point_data['ints'] = np.arange(grid.n_points, dtype=np.int32)
+    cleaned = grid.remove_nan_cells(scalars='ints')
+    assert isinstance(cleaned, pv.UnstructuredGrid)
+    assert cleaned.n_cells == grid.n_cells
+
+
+def test_remove_nan_cells_missing_scalar():
+    grid = pv.ImageData(dimensions=(3, 3, 3))
+    grid.point_data['values'] = np.arange(grid.n_points, dtype=float)
+    with pytest.raises(ValueError, match='No array'):
+        grid.remove_nan_cells(scalars='does_not_exist')
+
+
+def test_remove_nan_cells_matches_ptc_threshold_helper():
+    """The new filter should match the user's existing ptc-then-threshold recipe."""
+    grid = pv.ImageData(dimensions=(6, 6, 6))
+    values = np.arange(grid.n_points, dtype=float)
+    values[::11] = np.nan
+    grid.point_data['values'] = values
+    # Tag cells so we can compare surviving cell identities, not just counts.
+    grid.cell_data['cell_ids'] = np.arange(grid.n_cells, dtype=int)
+
+    cleaned = grid.remove_nan_cells(scalars='values')
+
+    # Reference implementation: ptc-then-threshold with the same cell tags.
+    threshed = grid.point_data_to_cell_data().threshold(scalars='values')
+    expected_ids = np.sort(threshed.cell_data['cell_ids'])
+    actual_ids = np.sort(cleaned.cell_data['cell_ids'])
+
+    np.testing.assert_array_equal(actual_ids, expected_ids)
+
+
 def test_threshold_percent(datasets):
     percents = [25, 50, [18.0, 85.0], [19.0, 80.0], 0.70]
     inverts = [False, True, False, True, False]

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -393,16 +393,17 @@ def test_threshold_multicomponent():
 
 
 def test_remove_nan_cells_point_data():
-    grid = pv.ImageData(dimensions=(5, 5, 5))
+    grid = pv.ImageData(dimensions=(7, 7, 7))
     values = np.arange(grid.n_points, dtype=float)
+    # Sparse, explicit NaN points so that some cells survive.
     nan_point_mask = np.zeros(grid.n_points, dtype=bool)
-    nan_point_mask[::7] = True
+    nan_point_mask[[0, 50, 100, 200, 300]] = True
     values[nan_point_mask] = np.nan
     grid.point_data['values'] = values
 
     cleaned = grid.remove_nan_cells(scalars='values')
     assert isinstance(cleaned, pv.UnstructuredGrid)
-    assert cleaned.n_cells < grid.n_cells
+    assert 0 < cleaned.n_cells < grid.n_cells
     assert not np.any(np.isnan(cleaned.point_data['values']))
 
     # The surviving cells should be exactly the cells with no NaN point.
@@ -483,6 +484,64 @@ def test_remove_nan_cells_missing_scalar():
     grid.point_data['values'] = np.arange(grid.n_points, dtype=float)
     with pytest.raises(ValueError, match='No array'):
         grid.remove_nan_cells(scalars='does_not_exist')
+
+
+def test_remove_nan_cells_only_checks_selected_array():
+    """Only the selected scalar array should drive NaN removal.
+
+    A NaN in a different point-data array must not cause a cell to be dropped,
+    and the untouched array must still carry its NaNs in the output. This is
+    the property the user was worried ``all_scalars=True`` might break —
+    ``all_scalars`` refers to "all points of a cell for the one selected
+    input array", not "all arrays in the dataset".
+    """
+    grid = pv.ImageData(dimensions=(7, 7, 7))
+
+    # 'target' has NaNs that we DO want to drive cell removal.
+    target = np.arange(grid.n_points, dtype=float)
+    target_nan_mask = np.zeros(grid.n_points, dtype=bool)
+    target_nan_mask[[0, 50, 100]] = True
+    target[target_nan_mask] = np.nan
+    grid.point_data['target'] = target
+
+    # 'other' has NaNs at entirely different points and must be ignored.
+    other = np.arange(grid.n_points, dtype=float) * 10.0
+    other_nan_mask = np.zeros(grid.n_points, dtype=bool)
+    other_nan_mask[[200, 250, 300]] = True
+    assert not np.any(target_nan_mask & other_nan_mask)
+    other[other_nan_mask] = np.nan
+    grid.point_data['other'] = other
+
+    cleaned = grid.remove_nan_cells(scalars='target')
+
+    # Some cells must survive or the test is vacuous.
+    assert cleaned.n_cells > 0
+
+    # No surviving cell should touch a 'target' NaN point.
+    assert not np.any(np.isnan(cleaned.point_data['target']))
+
+    # 'other' must be carried through with its NaNs intact — remove_nan_cells
+    # must not scrub unrelated arrays.
+    assert 'other' in cleaned.point_data
+    assert np.any(np.isnan(cleaned.point_data['other']))
+
+    # Cell count must match what you would get by checking only 'target'.
+    expected_kept = 0
+    for cid in range(grid.n_cells):
+        point_ids = grid.get_cell(cid).point_ids
+        if not np.any(target_nan_mask[point_ids]):
+            expected_kept += 1
+    assert cleaned.n_cells == expected_kept
+
+    # And the surviving set must be strictly larger than what you'd get if
+    # 'other' also gated removal — proving the two arrays are independent.
+    combined_mask = target_nan_mask | other_nan_mask
+    stricter_kept = 0
+    for cid in range(grid.n_cells):
+        point_ids = grid.get_cell(cid).point_ids
+        if not np.any(combined_mask[point_ids]):
+            stricter_kept += 1
+    assert cleaned.n_cells > stricter_kept
 
 
 def test_remove_nan_cells_matches_ptc_threshold_helper():


### PR DESCRIPTION
## Summary

Adds `DataSetFilters.remove_nan_cells`, a discoverable convenience filter for dropping cells whose scalar values are NaN. Works for both point and cell data via a single call: `mesh.remove_nan_cells(scalars='foo')`.

Previously, you had to call `point_data_to_cell_data().threshold()` pipeline with manual `cell_ids` tracking and `vtkOriginalPointIds` / `vtkOriginalCellIds` cleanup to handle NaN point data. This new filter replaces that recipe with a more robust mechanism.

## Why a new filter instead of extending `threshold`

The underlying machinery already exists as `threshold(scalars=..., preference='point', all_scalars=True)` with the default auto-range produces the same result, because:

- `get_data_range` uses `np.nanmin` / `np.nanmax`, so the bounds exclude NaN.
- With `all_scalars=True`, every point in a cell must satisfy the threshold. NaN comparisons return `False`, so any cell containing a NaN point is dropped. 

1. **Discoverability.** I've pointed people to a bare `threshold()` filter to remove NaNs for years and am always met with suprise. Users searching for "remove NaN" will not think to reach for `threshold()`.
2. **`threshold` already has a lot going on.** Adding an additional argument there that would change semantics (forcing `all_scalars=True`, overriding the `preference='cell'` default) would be a hidden footgun.
3. **Different defaults.** `threshold` defaults to `preference='cell'` and `all_scalars=False` because it's a cell-wise operation over cell data. `remove_nan_cells` defaults to `preference='point'` and `all_scalars=True` because the common NaN-cleanup case is point data.