### PR TITLE
Fix `:force_static:` being silently ignored in docstring Examples

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -510,7 +510,7 @@ def _str_examples(self):
         out += self._str_indent(self['Examples'])
         out += ['']
         return out
-    elif re.search(IMPORT_PYVISTA_RE, examples_str) and 'plot-pyvista::' not in examples_str:
+    elif re.search(IMPORT_PYVISTA_RE, examples_str) and 'pyvista-plot::' not in examples_str:
         out = []
         out += self._str_header('Examples')
         out += ['.. pyvista-plot::', '']

--- a/tests/plotting/tinypages/conf.py
+++ b/tests/plotting/tinypages/conf.py
@@ -87,7 +87,7 @@ def _str_examples(self):
         out += self._str_indent(self['Examples'])
         out += ['']
         return out
-    elif re.search(IMPORT_PYVISTA_RE, examples_str) and 'plot-pyvista::' not in examples_str:
+    elif re.search(IMPORT_PYVISTA_RE, examples_str) and 'pyvista-plot::' not in examples_str:
         out = []
         out += self._str_header('Examples')
         out += ['.. pyvista-plot::', '']


### PR DESCRIPTION
`doc/source/conf.py` monkey-patches `numpydoc.docscrape_sphinx.SphinxDocString._str_examples` so that any `Examples` section containing `import pyvista` is automatically wrapped in a `.. pyvista-plot::` directive. The helper guards against double-wrapping by checking whether the directive is already present in the examples block, but the check looks for the wrong string:

https://github.com/pyvista/pyvista/blob/5d35056009ee1faac2b82020d140e843f8d47aaf/doc/source/conf.py#L513

https://github.com/pyvista/pyvista/blob/5d35056009ee1faac2b82020d140e843f8d47aaf/tests/plotting/tinypages/conf.py#L90

The directive is named `pyvista-plot`, not `plot-pyvista`. The substring `plot-pyvista::` never appears in any docstring in the repository, so the guard is **always true** and the monkey-patch **always** adds an outer wrapper even when the docstring already has an explicit `.. pyvista-plot:: :force_static:` of its own.

Every explicit `.. pyvista-plot:: :force_static:` in a numpydoc `Examples` section was silently ignored at documentation build time. The outer auto-wrapper was applied with no options, so plot-directive rendered both a static PNG **and** a vtk.js/trame `.vtksz` interactive preview for the Examples regardless. For example:

https://github.com/pyvista/pyvista/blob/5d35056009ee1faac2b82020d140e843f8d47aaf/doc/source/user-guide/data_model.rst?plain=1#L60-L63

But we have interactive examples on https://dev.pyvista.org/user-guide/what-is-a-mesh

(whether that page should actually be forcing static is a different question)