### PR TITLE
chore: update pre-commit hooks, zizmor config, ignore uv.lock

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -236,11 +236,11 @@ jobs:
         run: pip install tox-uv
 
       - name: Core Testing (no GL)
-        run: tox run -e ${{env.TOX_FACTOR}}-cov-core # zizmor: ignore[template-injection]
+        run: tox run -e ${{env.TOX_FACTOR}}-cov-core
 
       - name: Plotting Testing (uses GL)
         if: ${{ !cancelled() }}
-        run: xvfb-run tox run -e ${{env.TOX_FACTOR}}-cov-plotting # zizmor: ignore[template-injection]
+        run: xvfb-run tox run -e ${{env.TOX_FACTOR}}-cov-plotting
 
       - name: Upload Images for Failed Tests
         if: always()

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -236,11 +236,15 @@ jobs:
         run: pip install tox-uv
 
       - name: Core Testing (no GL)
-        run: tox run -e ${{env.TOX_FACTOR}}-cov-core
+        env:
+          TOX_ENV: ${{ env.TOX_FACTOR }}-cov-core
+        run: tox run -e "$TOX_ENV"
 
       - name: Plotting Testing (uses GL)
         if: ${{ !cancelled() }}
-        run: xvfb-run tox run -e ${{env.TOX_FACTOR}}-cov-plotting
+        env:
+          TOX_ENV: ${{ env.TOX_FACTOR }}-cov-plotting
+        run: xvfb-run tox run -e "$TOX_ENV"
 
       - name: Upload Images for Failed Tests
         if: always()

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  template-injection:
+    disable: true
+  unpinned-uses:
+    disable: true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,5 +1,6 @@
 rules:
-  template-injection:
-    disable: true
   unpinned-uses:
-    disable: true
+    config:
+      policies:
+        actions/*: ref-pin
+        "*": hash-pin

--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,9 @@ flycheck*
 # PyCharm
 .idea/
 
+# uv environments
+uv.lock
+
 # virtual environments
 venv/
 .venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,14 +81,14 @@ repos:
         exclude: pyvista/_warn_external.py
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.9
+    rev: v0.15.10
     hooks:
       - id: ruff-format
       - id: ruff-check
         args: [--fix, --show-fixes]
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.8.1
+    rev: v3.8.2
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
@@ -101,7 +101,7 @@ repos:
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.13.0-1
+    rev: v3.13.1-1
     hooks:
       - id: shfmt
 
@@ -121,8 +121,7 @@ repos:
           ]
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.19.0
-
+    rev: v1.24.1
     hooks:
       - id: zizmor
 


### PR DESCRIPTION
Update several pre-commit versions.

Add a `.github/zizmor.yml` [configuration file](https://docs.zizmor.sh/configuration/#rulesiddisable) <s>to ignore `template-injection` and `unpinned-uses` rules. The latter rule is new with recent zizmor versions, and would require changing e.g. `actions/checkout@v6` to use a hash instead of `v6` tags. I feel this is an overreach of security paranoia, and I would much prefer to see version tags. Also replace inline `template-injection` comments with a blanket ignore rule, if this is preferred as a default</s>.

Lastly, add uv.lock to .gitignore (I personally use uv for many projects locally, and I see there use tox-uv in use for CI).