### PR TITLE
Use environments to manage deployments

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -220,6 +220,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [test, changes]
     if: always() && github.event_name == 'pull_request' && needs.changes.outputs.docs == 'true'
+    environment: ${{ github.event.pull_request.head.repo.fork && 'doc-image-report' || 'doc-image-report-internal' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -295,6 +296,8 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [doc, changes]
     if: (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || needs.changes.outputs.docs == 'true')
+    environment:
+      name: ${{ github.event_name != 'pull_request' && 'docs-main' || (github.event.pull_request.head.repo.fork && 'docs-preview' || 'docs-preview-internal') }}
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -344,6 +347,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: doc
     if: startsWith(github.ref, 'refs/tags/v')
+    environment: docs-release
     steps:
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,6 +1,10 @@
 name: "Pull Request Labeler"
-on:
-  pull_request:
+on: # zizmor: ignore[dangerous-triggers]
+  # Use pull_request_target (not pull_request) so fork PRs can be labeled:
+  # this trigger runs in the base repo context and has access to secrets.
+  # Safe here because no fork code is ever checked out or executed — do not
+  # add a checkout of github.event.pull_request.head.ref to this workflow.
+  pull_request_target:
     types: [opened, reopened]
 
 permissions:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -412,6 +412,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [macOS, Linux, windows, changes]
     if: always() && github.event_name == 'pull_request' && needs.changes.outputs.tests == 'true'
+    environment: ${{ github.event.pull_request.head.repo.fork && 'test-image-report' || 'test-image-report-internal' }}
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

Fixes Netlify deployments for PRs from forks by gating the secret-bearing deploy jobs behind GitHub Actions environments with required reviewers. Fork PRs previously failed because GitHub does not expose repository secrets to workflows triggered by `pull_request` events from forks.

## How it works

Each Netlify deploy job now declares an `environment:`. For jobs that should only require approval on fork PRs (not internal PRs or main/release pushes), a conditional expression on `github.event.pull_request.head.repo.fork` routes the run to either a gated or an ungated environment.

| Job | File | Fork PR → | Internal PR → | Main/tag → |
|---|---|---|---|---|
| `preview` | `docs.yml` | `docs-preview` (gated) | `docs-preview-internal` | `docs-main` |
| `image-report` (docs) | `docs.yml` | `doc-image-report` (gated) | `doc-image-report-internal` | — |
| `image-report` (tests) | `testing-and-deployment.yml` | `test-image-report` (gated) | `test-image-report-internal` | — |
| `deploy` (release) | `docs.yml` | — | — | `docs-release` (gated) |

The split between fork and internal environments is necessary because GitHub environment protection rules apply to every run regardless of trigger — there is no built-in "forks only" toggle. Routing internal PRs through a separate ungated environment keeps the maintainer click cost zero for trusted contributors.

## Required GitHub setup

The following environments must exist in repo settings before merging (already configured):

| Environment | Required reviewers | Branches dropdown | Branch/tag rules |
|---|---|---|---|
| `docs-preview` | `pyvista/maintainers` | No restriction | — |
| `doc-image-report` | `pyvista/maintainers` | No restriction | — |
| `test-image-report` | `pyvista/maintainers` | No restriction | — |
| `docs-preview-internal` | none | No restriction | — |
| `doc-image-report-internal` | none | No restriction | — |
| `test-image-report-internal` | none | No restriction | — |
| `docs-main` | none | Selected branches and tags | branch: `main` |
| `docs-release` | `pyvista/maintainers` | Selected branches and tags | tag: `v*` |

Repo-level `NETLIFY_AUTH_TOKEN` and `NETLIFY_*_SITE_ID` secrets are unchanged and remain available to all environments.

## Also: fix `label.yml` for fork PRs

Noticed this was broken in https://github.com/pyvista/pyvista/pull/8511

The pull request labeler workflow (`.github/workflows/label.yml`) was also failing on fork PRs because it uses `secrets.PYVISTA_BOT_TOKEN` to write labels, and fork PRs don't see secrets under a `pull_request` trigger. Rather than gating it behind an environment approval, the trigger is switched to `pull_request_target`, which runs in the base-repo context and has secret access for fork PRs.

This is safe here because the workflow never checks out or executes any code from the fork, it only calls `actions/labeler` and branch-name-based label actions, both of which just make GitHub API calls. The only fork-controlled input (`head.ref`) is used in `startsWith()` expression conditions, with no shell interpolation path. `actions/labeler`'s own README recommends `pull_request_target` for this exact use case.

Had to add a zizmor suppression (`# zizmor: ignore[dangerous-triggers]`) but left a comment explaining the safety reasoning, so we just need to be sure not to accidentally add a fork-code checkout without noticing.
