### PR TITLE
Fix bug with reference cycle

### DIFF
--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -526,7 +526,7 @@ class _DataSetMapper(_BaseMapper):
             if input_conn is not None:
                 self._active_scalars_algo.SetInputConnection(0, input_conn)
             if self._input_dataset is not None:
-                set_algorithm_input(self, self._input_dataset)
+                set_algorithm_input(self._active_scalars_algo, self._input_dataset)
             self.SetInputConnection(0, self._active_scalars_algo.GetOutputPort())
         else:
             self._active_scalars_algo.scalars_name = name

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 from typing import TYPE_CHECKING
 from typing import cast
+import weakref
 
 import numpy as np
 
@@ -401,15 +402,15 @@ class _DataSetMapper(_BaseMapper):
         """Initialize this class."""
         super().__init__(theme=theme)
         self._active_scalars_algo: ActiveScalarsAlgorithm | None = None
-        self._input_dataset: DataSet | None = None
+        self._input_dataset: weakref.ref[DataSet] | None = None
         if dataset is not None:
             self.dataset = dataset
 
     @property
     def dataset(self) -> DataSet | None:  # numpydoc ignore=RT01
         """Return or set the dataset assigned to this mapper."""
-        if self._input_dataset is not None:
-            return self._input_dataset
+        if self._input_dataset is not None and self._input_dataset() is not None:
+            return self._input_dataset()
         # Fall back to the VTK pipeline input when the mapper was wired up
         # with a vtkAlgorithm rather than a direct DataSet assignment.
         return cast('pv.DataSet | None', wrap(_mapper_get_data_set_input(self)))
@@ -422,7 +423,7 @@ class _DataSetMapper(_BaseMapper):
         if isinstance(obj, (_vtk.vtkAlgorithm, _vtk.vtkAlgorithmOutput)):
             self._input_dataset = None
         else:
-            self._input_dataset = obj
+            self._input_dataset = weakref.ref(obj)
         if self._active_scalars_algo is not None:
             # Reconnect pipeline: new input -> algo -> mapper
             set_algorithm_input(self._active_scalars_algo, obj)
@@ -515,8 +516,8 @@ class _DataSetMapper(_BaseMapper):
             input_conn = self.GetInputConnection(0, 0)
             if input_conn is not None:
                 self._active_scalars_algo.SetInputConnection(0, input_conn)
-            if self._input_dataset is not None:
-                set_algorithm_input(self._active_scalars_algo, self._input_dataset)
+            if self._input_dataset is not None and self._input_dataset() is not None:
+                set_algorithm_input(self._active_scalars_algo, self._input_dataset())
             self.SetInputConnection(0, self._active_scalars_algo.GetOutputPort())
         else:
             self._active_scalars_algo.scalars_name = name
@@ -541,8 +542,8 @@ class _DataSetMapper(_BaseMapper):
             return
         algo = self._active_scalars_algo
         self._active_scalars_algo = None
-        if self._input_dataset is not None:
-            set_algorithm_input(self, self._input_dataset)
+        if self._input_dataset is not None and self._input_dataset() is not None:
+            set_algorithm_input(self, self._input_dataset())
         else:
             in_conn = algo.GetInputConnection(0, 0)
             if in_conn is not None:

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -415,15 +415,6 @@ class _DataSetMapper(_BaseMapper):
         # with a vtkAlgorithm rather than a direct DataSet assignment.
         return cast('pv.DataSet | None', wrap(_mapper_get_data_set_input(self)))
 
-    # Avoid ref cycles by using weakref
-    @property
-    def _input_dataset(self):
-        return None if self._input_dataset_ref is None else self._input_dataset_ref()
-
-    @_input_dataset.setter
-    def _input_dataset(self, dataset: DataSet | None):
-        self._input_dataset_ref = None if dataset is None else weakref.ref(dataset)
-
     @dataset.setter
     def dataset(
         self,
@@ -439,6 +430,15 @@ class _DataSetMapper(_BaseMapper):
             set_algorithm_input(self, self._active_scalars_algo)
         else:
             set_algorithm_input(self, obj)
+
+    # Avoid ref cycles by using weakref
+    @property
+    def _input_dataset(self):
+        return None if self._input_dataset_ref is None else self._input_dataset_ref()
+
+    @_input_dataset.setter
+    def _input_dataset(self, dataset: DataSet | None):
+        self._input_dataset_ref = None if dataset is None else weakref.ref(dataset)
 
     @property
     def array_name(self) -> str:  # numpydoc ignore=RT01

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -402,18 +402,27 @@ class _DataSetMapper(_BaseMapper):
         """Initialize this class."""
         super().__init__(theme=theme)
         self._active_scalars_algo: ActiveScalarsAlgorithm | None = None
-        self._input_dataset: weakref.ref[DataSet] | None = None
+        self._input_dataset_ref: weakref.ref[DataSet] | None = None
         if dataset is not None:
             self.dataset = dataset
 
     @property
     def dataset(self) -> DataSet | None:  # numpydoc ignore=RT01
         """Return or set the dataset assigned to this mapper."""
-        if self._input_dataset is not None and self._input_dataset() is not None:
-            return self._input_dataset()
+        if self._input_dataset is not None:
+            return self._input_dataset
         # Fall back to the VTK pipeline input when the mapper was wired up
         # with a vtkAlgorithm rather than a direct DataSet assignment.
         return cast('pv.DataSet | None', wrap(_mapper_get_data_set_input(self)))
+
+    # Avoid ref cycles by using weakref
+    @property
+    def _input_dataset(self):
+        return None if self._input_dataset_ref is None else self._input_dataset_ref()
+
+    @_input_dataset.setter
+    def _input_dataset(self, dataset: DataSet | None):
+        self._input_dataset_ref = None if dataset is None else weakref.ref(dataset)
 
     @dataset.setter
     def dataset(
@@ -423,7 +432,7 @@ class _DataSetMapper(_BaseMapper):
         if isinstance(obj, (_vtk.vtkAlgorithm, _vtk.vtkAlgorithmOutput)):
             self._input_dataset = None
         else:
-            self._input_dataset = weakref.ref(obj)
+            self._input_dataset = obj
         if self._active_scalars_algo is not None:
             # Reconnect pipeline: new input -> algo -> mapper
             set_algorithm_input(self._active_scalars_algo, obj)
@@ -516,8 +525,8 @@ class _DataSetMapper(_BaseMapper):
             input_conn = self.GetInputConnection(0, 0)
             if input_conn is not None:
                 self._active_scalars_algo.SetInputConnection(0, input_conn)
-            if self._input_dataset is not None and self._input_dataset() is not None:
-                set_algorithm_input(self._active_scalars_algo, self._input_dataset())
+            if self._input_dataset is not None:
+                set_algorithm_input(self, self._input_dataset)
             self.SetInputConnection(0, self._active_scalars_algo.GetOutputPort())
         else:
             self._active_scalars_algo.scalars_name = name
@@ -542,8 +551,8 @@ class _DataSetMapper(_BaseMapper):
             return
         algo = self._active_scalars_algo
         self._active_scalars_algo = None
-        if self._input_dataset is not None and self._input_dataset() is not None:
-            set_algorithm_input(self, self._input_dataset())
+        if self._input_dataset is not None:
+            set_algorithm_input(self, self._input_dataset)
         else:
             in_conn = algo.GetInputConnection(0, 0)
             if in_conn is not None:


### PR DESCRIPTION
In MNE-Python [this CI run](https://app.circleci.com/pipelines/gh/mne-tools/mne-python/31198/workflows/992ba417-0441-4527-8f1b-b3d4651d18bf/jobs/81154) failed. It (1) runs each example, (2) does `gc.collect()` each time, and (3) makes sure there are no lingering `vtk*` objects around and errors if they do:
```
      File "/home/circleci/python_env/lib/python3.12/site-packages/joblib/parallel.py", line 773, in _return_or_raise
        raise self._result
    sphinx.errors.ExtensionError: 
    1 vtkPolyData @ mne/conf.py:Resetter.__call__:after:30_reading_fnirs_data.py:
    dict['_input_dataset'] with len=5 | 3 referrers: dict['r'] / list[1] / list[529835]
```
Based on `git bisect` I isolated it to:

https://github.com/pyvista/pyvista/pull/8472/changes#diff-c7905aa57849d51967437c53e63d699f9e2b68a878e311b113cbae3b6ddec7b3R425 

Changing these to `weakref.ref` fixes the issue for me.

Not sure why this wasn't caught by a test at the VTK end, I see you have `check_gc` mechanisms similar to those of MNE-Python :shrug: 