### PR TITLE
Add explicit Linux CI job for Python 3.14 + latest stable VTK

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -192,6 +192,10 @@ jobs:
             runner-labels: "ubuntu-22.04-self-hosted"
           - python-version: "3.14"
             vtk-version: "latest"
+            numpy-version: "latest"
+            runner-labels: "ubuntu-22.04-self-hosted"
+          - python-version: "3.14"
+            vtk-version: "latest"
             numpy-version: "nightly"
             runner-labels: "ubuntu-22.04-self-hosted"
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ env_list =
     py3.12-numpy_latest-vtk_9.3.1
     py3.13-numpy_latest-vtk_9.4.2
     py3.13-numpy_latest-vtk_9.5.2
+    py3.14-numpy_latest-vtk_latest
     py3.14-numpy_nightly-vtk_latest
     py3.{10-13}
     py3.{10-14}-vtk_dev


### PR DESCRIPTION
We don't currently have any CI job validating the combination of the latest stable VTK and the latest stable numpy. The only Linux row that touches "latest VTK" pairs it with `numpy=nightly`, which has been failing due to #8484 and is getting ignored. Every other Linux row pins to an older VTK (highest is 9.5.2) with `numpy=latest`. Net result: no row in the matrix actually tells us whether PyVista works against what most of our users are running today, which is stable VTK 9.6 plus stable numpy.

macOS and Windows test Python 3.14 against VTK 9.6 but I think the Linux test suite is more critical

This adds a Linux matrix row for `python=3.14`, `vtk=latest`, `numpy=latest` so we have a dedicated job validating the newest stable releases of both, on the platform with the strictest coverage.