### PR TITLE
Fix pyvista_ndarray from leaking a vtkWeakReference through point_data.__setitem__

### DIFF
--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -80,11 +80,14 @@ class pyvista_ndarray(_NoNewAttrMixin, np.ndarray):  # numpydoc ignore=PR02  # n
             raise TypeError(msg)
 
         obj.association = association
-        obj.dataset = _vtk.vtkWeakReference()
-        if isinstance(dataset, _vtk.VTKObjectWrapper):
-            obj.dataset.Set(dataset.VTKObject)
+        if dataset is None:
+            obj.dataset = None
         else:
-            obj.dataset.Set(cast('_vtk.vtkDataSet', dataset))
+            obj.dataset = _vtk.vtkWeakReference()
+            if isinstance(dataset, _vtk.VTKObjectWrapper):
+                obj.dataset.Set(dataset.VTKObject)
+            else:
+                obj.dataset.Set(cast('_vtk.vtkDataSet', dataset))
         return obj
 
     def __array_finalize__(self: pyvista_ndarray, obj: npt.NDArray[Any] | None) -> None:

--- a/tests/core/test_pyvista_ndarray.py
+++ b/tests/core/test_pyvista_ndarray.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 import re
 from unittest import mock
 
@@ -7,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import pyvista as pv
 from pyvista import examples
 from pyvista import pyvista_ndarray
 from pyvista import vtk_points
@@ -116,3 +118,20 @@ def test_wrap_pandas(obj_in):
     array = pyvista_ndarray(obj_in)
     df = pd.DataFrame(array)
     assert np.shares_memory(df.values, array)
+
+
+def test_no_dataset_does_not_allocate_weak_reference():
+    # Regression test for https://github.com/pyvista/pyvista/issues/8532
+    arr = pyvista_ndarray([1.0, 2.0, 3.0])
+    assert arr.dataset is None
+
+
+def test_point_data_assignment_does_not_leak_vtk_weak_reference():
+    # Regression test for https://github.com/pyvista/pyvista/issues/8532
+    mesh = pv.Sphere()
+    mesh.point_data['data'] = mesh.points[:, 2].astype(float)
+    del mesh
+    gc.collect()
+
+    leaked = [o for o in gc.get_objects() if isinstance(o, _vtk.vtkWeakReference)]
+    assert leaked == []

--- a/tests/plotting/test_picking.py
+++ b/tests/plotting/test_picking.py
@@ -606,7 +606,6 @@ def test_block_picking(multiblock_poly):
 
 
 @pytest.mark.parametrize('mode', ['mesh', 'cell', 'face', 'edge', 'point'])
-@pytest.mark.skip_check_gc("vtkDataArray not gc'd with 'point' mode on Python 3.14 vtk dev wheels")
 def test_element_picking(mode):
     class Tracker:
         def __init__(self):

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -2104,7 +2104,6 @@ def test_volume_rendering_from_plotter(uniform):
 
 
 @skip_windows_mesa  # due to opacity
-@pytest.mark.skip_check_gc("vtkWeakReference not gc'd on Python 3.14 vtk dev wheels")
 def test_volume_rendering_rectilinear(uniform):
     grid = uniform.cast_to_rectilinear_grid()
 
@@ -3828,7 +3827,7 @@ def test_plotter_lookup_table(sphere, verify_image_cache):
 
 
 @skip_windows_mesa  # due to opacity
-@pytest.mark.skip_check_gc("vtkTypeUInt8Array not gc'd on Python 3.14 vtk dev wheels")
+@pytest.mark.skip_check_gc("vtkTypeUInt8Array not gc'd on Python 3.14")
 def test_plotter_volume_lookup_table(uniform):
     uniform.set_active_scalars('Spatial Point Data')
 


### PR DESCRIPTION
Fixes #8532. `pyvista_ndarray.__new__` was unconditionally allocating a `vtkWeakReference` even when `dataset=None`, which leaked one VTK object per call through the `numpy_to_vtk` reference chain. Python 3.13 cleaned it up at teardown, but 3.14 changed how it finalizes numpy subclasses with `__array_finalize__` and the chain stayed reachable, so `check_gc` started failing.

The fix skips the `vtkWeakReference` allocation when `dataset=None` and sets `obj.dataset = None` directly. `__setitem__` already guarded against `self.dataset is None`, so nothing else had to change.

I ran the repro on Python 3.14.3 with vtk 9.6.1. Without the fix, `mesh.point_data['data'] = mesh.points[:, 2].astype(float)` leaks two `vtkWeakReference` objects after the mesh is deleted. With the fix, zero.

I also took a look at the`skip_check_gc` markers in the test suite for cases this resolves and remove what this seems to fix