### PR TITLE
Prevent numpy nightly job from failing entire workflow

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -163,6 +163,8 @@ jobs:
     name: Linux Unit Testing (${{ matrix.python-version }}, ${{ matrix.vtk-version }}, ${{ matrix.numpy-version }})
     runs-on: ${{ matrix.runner-labels }}
     needs: cache-ubuntu-self-hosted
+    # numpy nightly is allowed to fail without failing the overall workflow
+    continue-on-error: ${{ matrix.numpy-version == 'nightly' }}
     strategy:
       fail-fast: false
 
@@ -225,16 +227,12 @@ jobs:
         run: pip install tox-uv
 
       - name: Core Testing (no GL)
-        # numpy nightly failures are informational only and must not fail the check
-        continue-on-error: ${{ matrix.numpy-version == 'nightly' }}
         env:
           TOX_ENV: ${{ env.TOX_FACTOR }}-cov-core
         run: tox run -e "$TOX_ENV"
 
       - name: Plotting Testing (uses GL)
         if: ${{ !cancelled() }}
-        # numpy nightly failures are informational only and must not fail the check
-        continue-on-error: ${{ matrix.numpy-version == 'nightly' }}
         env:
           TOX_ENV: ${{ env.TOX_FACTOR }}-cov-plotting
         run: xvfb-run tox run -e "$TOX_ENV"

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -163,6 +163,8 @@ jobs:
     name: Linux Unit Testing (${{ matrix.python-version }}, ${{ matrix.vtk-version }}, ${{ matrix.numpy-version }})
     runs-on: ${{ matrix.runner-labels }}
     needs: cache-ubuntu-self-hosted
+    # numpy nightly is allowed to fail without failing the overall workflow
+    continue-on-error: ${{ matrix.numpy-version == 'nightly' }}
     strategy:
       fail-fast: false
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -163,8 +163,6 @@ jobs:
     name: Linux Unit Testing (${{ matrix.python-version }}, ${{ matrix.vtk-version }}, ${{ matrix.numpy-version }})
     runs-on: ${{ matrix.runner-labels }}
     needs: cache-ubuntu-self-hosted
-    # numpy nightly is allowed to fail without failing the overall workflow
-    continue-on-error: ${{ matrix.numpy-version == 'nightly' }}
     strategy:
       fail-fast: false
 
@@ -227,12 +225,16 @@ jobs:
         run: pip install tox-uv
 
       - name: Core Testing (no GL)
+        # numpy nightly failures are informational only and must not fail the check
+        continue-on-error: ${{ matrix.numpy-version == 'nightly' }}
         env:
           TOX_ENV: ${{ env.TOX_FACTOR }}-cov-core
         run: tox run -e "$TOX_ENV"
 
       - name: Plotting Testing (uses GL)
         if: ${{ !cancelled() }}
+        # numpy nightly failures are informational only and must not fail the check
+        continue-on-error: ${{ matrix.numpy-version == 'nightly' }}
         env:
           TOX_ENV: ${{ env.TOX_FACTOR }}-cov-plotting
         run: xvfb-run tox run -e "$TOX_ENV"


### PR DESCRIPTION
The numpy nightly job of the Linux matrix has been failing red on `main` and dragging the overall workflow status down with it. Same with the overall status of PRs.

This adds `continue-on-error: ${{ matrix.numpy-version == 'nightly' }}` to the `Linux` job. The nightly entry still runs and still reports its own status, but a failure no longer fails the parent check or the workflow. Every other matrix entry is unaffected because the expression evaluates to `false` for them.

This will allow for the overall status of the commit to report green while keeping the job as a failure in the full list