### PR TITLE
Remove timing assertion from test_contour_labels_strict_external

### DIFF
--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import operator
 import re
-import time
 from typing import get_args
 
 import numpy as np
@@ -16,7 +15,6 @@ from pyvista.core.errors import DeprecationError
 from pyvista.core.errors import PyVistaDeprecationWarning
 from pyvista.core.filters.image_data import _InterpolationOptions
 from tests.conftest import NUMPY_VERSION_INFO
-from tests.conftest import flaky_test
 
 BOUNDARY_LABELS = 'boundary_labels'
 MORPHOLOGICAL_MAX_VAL = 42.0
@@ -419,19 +417,10 @@ def test_contour_labels_cell_data(channels):
     assert voxel_surface_contoured.n_cells == voxel_surface_extracted.n_cells
 
 
-@flaky_test
 @pytest.mark.needs_vtk_version(9, 3, 0)
 def test_contour_labels_strict_external(channels):
-    start = time.perf_counter()
-    with pytest.warns(pv.PyVistaDeprecationWarning):
-        channels.contour_labels('external', orient_faces=False)
-    time_slow = time.perf_counter() - start
-
-    start = time.perf_counter()
     with pytest.warns(pv.PyVistaDeprecationWarning):
         contours = channels.contour_labels('strict_external', orient_faces=False)
-    time_fast = time.perf_counter() - start
-    assert time_fast < time_slow / 1.5
 
     # Test output is simplified correctly
     assert contours.active_scalars.ndim == 1


### PR DESCRIPTION
Fixes #8529. `test_contour_labels_strict_external` was asserting a 1.5x wall-clock speedup between `contour_labels('external')` and `contour_labels('strict_external')` from single-sample `perf_counter` deltas. On shared CI runners that margin is narrower than the noise, so the test flaked in the merge queue. The reported failure was a 1.29x ratio, i.e. `strict_external` was faster, just not by enough to clear the threshold.

The timing assertion was proving a runtime property with the wrong signal. The thing we actually want to guarantee (that `'strict_external'` takes the short path and produces a correctly simplified output) is already covered by the remaining assertions plus the `select_inputs` / `select_outputs` `TypeError` checks below it.

This drops the timing block entirely, removes the now-unused `@flaky_test` decorator, and cleans up the `time` and `flaky_test` imports that were only used by that test.
