### PR TITLE
Inform users about installing `pyvista-zstd` when reading/saving `.pv` files

### DIFF
--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from collections import UserDict
 from collections import defaultdict
+import importlib.util
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -291,6 +292,13 @@ class DataObject(_NoNewAttrMixin, DisableVtkSnakeCase, vtkPyVistaOverride):
                 f'Must be one of: '
                 f'{list(writer_exts) + list(PICKLE_EXT) + _list_custom_writer_exts()}'
             )
+            if file_ext == '.pv' and not importlib.util.find_spec(
+                'pyvista-zstd'
+            ):  # pragma: no cover
+                msg += (
+                    ".\nThe '.pv' extension is supported by the `pyvista-zstd` package. "
+                    'It can be installed with `pyvista[io]`.'
+                )
             raise ValueError(msg)
 
     def _store_metadata(self: Self) -> None:

--- a/pyvista/core/utilities/fileio.py
+++ b/pyvista/core/utilities/fileio.py
@@ -358,19 +358,17 @@ def read(  # noqa: PLR0911, PLR0917
     try:
         reader = pv.get_reader(filename, force_ext)
     except ValueError:
+        msg = f'This file was not able to be automatically read by pyvista.\n  {str(filename)!r}'
         # if using force_ext, we are explicitly only using vtk readers
         if force_ext is not None:
-            msg = 'This file was not able to be automatically read by pyvista.'
             raise OSError(msg)
         try:
             from meshio._exceptions import ReadError  # noqa: PLC0415
         except ImportError:
-            msg = 'This file was not able to be automatically read by pyvista.'
             raise OSError(msg)
         try:
             return read_meshio(filename)
         except ReadError:
-            msg = 'This file was not able to be automatically read by pyvista.'
             if ext == '.pv':  # pragma: no cover
                 msg += (
                     "\nThe '.pv' extension is supported by the `pyvista-zstd` package. "

--- a/pyvista/core/utilities/fileio.py
+++ b/pyvista/core/utilities/fileio.py
@@ -371,6 +371,11 @@ def read(  # noqa: PLR0911, PLR0917
             return read_meshio(filename)
         except ReadError:
             msg = 'This file was not able to be automatically read by pyvista.'
+            if ext == '.pv':  # pragma: no cover
+                msg += (
+                    "\nThe '.pv' extension is supported by the `pyvista-zstd` package. "
+                    'It can be installed with `pyvista[io]`.'
+                )
             raise OSError(msg)
     else:
         observer = Observer()


### PR DESCRIPTION
### Overview
This is the current user experience trying to save `.pv` files without installing `pyvista-zstd`:

``` py
import pyvista as pv
pv.read('sphere.vtk').save('sphere.pv')
```
```
ValueError: Invalid file extension '.pv' for data type <class 'pyvista.core.pointset.PolyData'>.
Must be one of: ['.ply', '.vtp', '.stl', '.vtk', '.geo', '.obj', '.iv', '.vtkhdf', '.pkl', '.pickle']
```

This PR lets users know it's supported with additional installation

```
ValueError: Invalid file extension '.pv' for data type <class 'pyvista.core.pointset.PolyData'>.
Must be one of: ['.ply', '.vtp', '.stl', '.vtk', '.geo', '.obj', '.iv', '.vtkhdf', '.pkl', '.pickle'].
The '.pv' extension is supported by the `pyvista-zstd` package. It can be installed with `pyvista[io]`.
```

Similarly, trying to read back the saved `.pv` file without `pyvista-zstd` installed:

``` py
import pyvista as pv
pv.read('sphere.pv')
```
```
OSError: This file was not able to be automatically read by pyvista.
```

With this PRL
```
OSError: This file was not able to be automatically read by pyvista.
The '.pv' extension is supported by the `pyvista-zstd` package. It can be installed with `pyvista[io]`.
```