### PR TITLE
Array and filter optimizations

### DIFF
--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -632,11 +632,10 @@ class DataObject(_NoNewAttrMixin, DisableVtkSnakeCase, vtkPyVistaOverride):
 
         .. note::
 
-            The user dict is a convenience property and is intended for metadata storage.
-            It has an inefficient dictionary implementation and should only be used to
-            store a small number of infrequently-accessed keys with relatively small
-            values. It should not be used to store frequently accessed array data
-            with many entries (a regular field data array should be used instead).
+            The user dict is a convenience property intended for metadata storage.
+            Values are JSON-serialized on every mutation, so it is not a substitute
+            for a regular field data array when storing bulk array data with many
+            entries (use a regular field data array for that instead).
 
         .. warning::
 

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -285,7 +285,20 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
         self.remove(key)
 
     def __contains__(self: Self, name: str) -> bool:
-        """Implement the ``in`` operator."""
+        """Implement the ``in`` operator.
+
+        Uses VTK's native ``HasArray`` for an O(1) lookup, avoiding the
+        cost of materialising every array name into a Python list. Falls
+        back to ``self.keys()`` for the empty-name lookup so that
+        ``keys()``'s legacy auto-rename side-effect (renaming any
+        unnamed arrays to ``Unnamed_<i>``) still fires; some plotter
+        codepaths (notably ``set_custom_opacity`` for array-valued
+        ``opacity=`` arguments) inject anonymous arrays and rely on that
+        side-effect to give them a unique, lookup-able name before
+        downstream code activates them.
+        """
+        if name:
+            return bool(self.VTKObject.HasArray(name))
         return name in self.keys()
 
     def __iter__(self: Self) -> Iterator[str]:

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -3416,11 +3416,23 @@ class DataObjectFilters:
             Specify the implicit function to perform the cutting.
 
         generate_triangles : bool, default: False
-            If this is enabled (``False`` by default), the output will
-            be triangles. Otherwise the output will be the intersection
-            polygons. If the cutting function is not a plane, the
-            output will be 3D polygons, which might be nice to look at
-            but hard to compute with downstream.
+            If ``True``, the output will be triangles. Otherwise the
+            output will be the intersection polygons. If the cutting
+            function is not a plane, the output will be 3D polygons,
+            which might be nice to look at but hard to compute with
+            downstream.
+
+            .. note::
+
+               PyVista's default is ``False``, which differs from
+               :vtk:`vtkCutter`'s default of ``True``. The polygon
+               codepath in :vtk:`vtkCutter` is significantly slower than
+               the triangulation path: on a 1.3M-cell UnstructuredGrid
+               the polygon path measures ~89 ms/op vs ~20 ms/op with
+               ``generate_triangles=True`` (~5x slowdown). Pass
+               ``generate_triangles=True`` for the fast path when the
+               output cell shape is not load-bearing for your downstream
+               code.
 
         contour : bool, default: False
             If ``True``, apply a ``contour`` filter after slicing.
@@ -3505,6 +3517,18 @@ class DataObjectFilters:
             be triangles. Otherwise the output will be the intersection
             polygons.
 
+            .. note::
+
+               PyVista's default is ``False``, which differs from
+               :vtk:`vtkCutter`'s default of ``True``. The polygon
+               codepath in :vtk:`vtkCutter` is significantly slower than
+               the triangulation path: on a 1.3M-cell UnstructuredGrid
+               the polygon path measures ~89 ms/op vs ~20 ms/op with
+               ``generate_triangles=True`` (~5x slowdown). Pass
+               ``generate_triangles=True`` for the fast path when the
+               output cell shape is not load-bearing for your downstream
+               code.
+
         contour : bool, default: False
             If ``True``, apply a ``contour`` filter after slicing.
 
@@ -3588,6 +3612,13 @@ class DataObjectFilters:
         generate_triangles : bool, default: False
             When ``True``, the output will be triangles. Otherwise the output
             will be the intersection polygons.
+
+            .. note::
+
+               PyVista's default differs from :vtk:`vtkCutter` (which
+               defaults to ``True``). The polygon path is ~5x slower on
+               UnstructuredGrids. Pass ``generate_triangles=True`` for
+               the fast path. See :meth:`slice_implicit` for details.
 
         contour : bool, default: False
             If ``True``, apply a ``contour`` filter after slicing.
@@ -3706,6 +3737,13 @@ class DataObjectFilters:
         generate_triangles : bool, default: False
             When ``True``, the output will be triangles. Otherwise the output
             will be the intersection polygons.
+
+            .. note::
+
+               PyVista's default differs from :vtk:`vtkCutter` (which
+               defaults to ``True``). The polygon path is ~5x slower on
+               UnstructuredGrids. Pass ``generate_triangles=True`` for
+               the fast path. See :meth:`slice_implicit` for details.
 
         contour : bool, default: False
             If ``True``, apply a ``contour`` filter after slicing.
@@ -3836,6 +3874,13 @@ class DataObjectFilters:
         generate_triangles : bool, default: False
             When ``True``, the output will be triangles. Otherwise the output
             will be the intersection polygons.
+
+            .. note::
+
+               PyVista's default differs from :vtk:`vtkCutter` (which
+               defaults to ``True``). The polygon path is ~5x slower on
+               UnstructuredGrids. Pass ``generate_triangles=True`` for
+               the fast path. See :meth:`slice_implicit` for details.
 
         contour : bool, default: False
             If ``True``, apply a ``contour`` filter after slicing.

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -2547,21 +2547,28 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
             vtk_offset = self.GetCellLocationsArray()
             lgrid.SetCells(vtk_cell_type, vtk_offset, cells)
 
-        # fixing bug with display of quad cells
+        # fixing bug with display of quad cells.
+        # Cache the cell_connectivity array once as each access wraps the
+        # underlying vtkCellArray's connectivity buffer with vtk_to_numpy,
+        # so reading it 4-7 times in the loop redundantly allocates wrappers.
+        if np.any(quad_quad_mask) or np.any(quad_tri_mask):
+            cell_offsets = lgrid.offset
+            cell_conn = lgrid.cell_connectivity
+
         if np.any(quad_quad_mask):
-            quad_offset = lgrid.offset[:-1][quad_quad_mask]
-            base_point = lgrid.cell_connectivity[quad_offset]
-            lgrid.cell_connectivity[quad_offset + 4] = base_point
-            lgrid.cell_connectivity[quad_offset + 5] = base_point
-            lgrid.cell_connectivity[quad_offset + 6] = base_point
-            lgrid.cell_connectivity[quad_offset + 7] = base_point
+            quad_offset = cell_offsets[:-1][quad_quad_mask]
+            base_point = cell_conn[quad_offset]
+            cell_conn[quad_offset + 4] = base_point
+            cell_conn[quad_offset + 5] = base_point
+            cell_conn[quad_offset + 6] = base_point
+            cell_conn[quad_offset + 7] = base_point
 
         if np.any(quad_tri_mask):
-            tri_offset = lgrid.offset[:-1][quad_tri_mask]
-            base_point = lgrid.cell_connectivity[tri_offset]
-            lgrid.cell_connectivity[tri_offset + 3] = base_point
-            lgrid.cell_connectivity[tri_offset + 4] = base_point
-            lgrid.cell_connectivity[tri_offset + 5] = base_point
+            tri_offset = cell_offsets[:-1][quad_tri_mask]
+            base_point = cell_conn[tri_offset]
+            cell_conn[tri_offset + 3] = base_point
+            cell_conn[tri_offset + 4] = base_point
+            cell_conn[tri_offset + 5] = base_point
 
         return lgrid
 

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -728,15 +728,21 @@ def convert_string_array(
             # setting the object name
             _set_string_scalar_object_name(vtkarr)
 
-        # OPTIMIZE ###########
-        for val in arr:
-            vtkarr.InsertNextValue(val)
-        ################################
+        # Pre-allocate the underlying storage instead of growing it via
+        # ``InsertNextValue`` per element. Iterating over ``arr.tolist()``
+        # avoids the per-element ``numpy.str_`` scalar boxing cost that
+        # iterating a numpy string array pays.
+        flat_list = arr.reshape(-1).tolist()
+        vtkarr.SetNumberOfValues(len(flat_list))
+        for i, val in enumerate(flat_list):
+            vtkarr.SetValue(i, val)
         if isinstance(name, str):
             vtkarr.SetName(name)
         return vtkarr
-    # Otherwise it is a vtk array and needs to be converted back to numpy
-    # OPTIMIZE ###############
+    # Otherwise it is a vtk array and needs to be converted back to numpy.
+    # ``np.array(list, dtype='|U')`` auto-sizes the unicode width to the
+    # longest value; passing dtype='|U' to np.empty defaults to width 1
+    # which truncates strings.
     nvalues = arr.GetNumberOfValues()
     arr_out = np.array([arr.GetValue(i) for i in range(nvalues)], dtype='|U')
     try:
@@ -745,7 +751,6 @@ def convert_string_array(
     except AttributeError:
         pass
     return arr_out
-    ########################################
 
 
 def array_from_vtkmatrix(matrix: _vtk.vtkMatrix3x3 | _vtk.vtkMatrix4x4) -> NumpyArray[float]:
@@ -973,14 +978,24 @@ class _SerializedDictArray(DisableVtkSnakeCase, UserDict, _vtk.vtkStringArray): 
     @property
     def _string(self: _SerializedDictArray) -> str:
         """Get the :vtk:`vtkStringArray` string."""
-        return ''.join([self.GetValue(i) for i in range(self.GetNumberOfValues())])
+        # Joining all values handles both the historical char-per-value
+        # format (read from older saved files) and the current
+        # whole-string-as-one-value format below.
+        n = self.GetNumberOfValues()
+        if n == 1:
+            return self.GetValue(0)
+        return ''.join([self.GetValue(i) for i in range(n)])
 
     @_string.setter
     def _string(self: _SerializedDictArray, str_: str) -> None:
         """Set the :vtk:`vtkStringArray` to a specified string."""
-        self.SetNumberOfValues(0)  # Clear string
-        for char in str_:  # Populate string
-            self.InsertNextValue(char)
+        # Store the entire string as a single value rather than one
+        # character per value. This avoids O(len(str_)) Python<->C
+        # crossings and matches how every other VTK string field stores
+        # text. Reading still works for the legacy char-per-value format
+        # because the getter joins all values.
+        self.SetNumberOfValues(1)
+        self.SetValue(0, str_)
 
     def _update_string(self: _SerializedDictArray) -> None:
         """Format dict data as JSON and update the :vtk:`vtkStringArray`."""

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -969,9 +969,9 @@ class _SerializedDictArray(DisableVtkSnakeCase, UserDict, _vtk.vtkStringArray): 
 
     Notes
     -----
-    This class is intended for use as a dict with a small number of keys and
-    relatively small values, e.g. for storing metadata. It should not be
-    used to store frequently accessed array data with hundreds of entries.
+    This class is intended for metadata storage. Values are JSON-serialized
+    on every mutation, so it should not be used in place of a regular field
+    data array when storing bulk array data with many entries.
 
     """
 

--- a/pyvista/core/utilities/cells.py
+++ b/pyvista/core/utilities/cells.py
@@ -116,10 +116,7 @@ def numpy_to_idarr(
     # but skip the ``ravel()`` allocation when the array is already
     # 1D and contiguous (the common case), since ndarray.ravel() of
     # a non-1D shape returns a copy.
-    if ind.ndim == 1:
-        ravelled = ind
-    else:
-        ravelled = ind.ravel()
+    ravelled = ind if ind.ndim == 1 else ind.ravel()
     vtk_idarr = _vtk.numpy_to_vtkIdTypeArray(ravelled, deep=deep)
     if return_ind:
         return vtk_idarr, ind

--- a/pyvista/core/utilities/cells.py
+++ b/pyvista/core/utilities/cells.py
@@ -113,7 +113,14 @@ def numpy_to_idarr(
         ind = np.ascontiguousarray(ind, dtype=pv.ID_TYPE)
 
     # must ravel or segfault when saving MultiBlock
-    vtk_idarr = _vtk.numpy_to_vtkIdTypeArray(ind.ravel(), deep=deep)
+    # but skip the ``ravel()`` allocation when the array is already
+    # 1D and contiguous (the common case), since ndarray.ravel() of
+    # a non-1D shape returns a copy.
+    if ind.ndim == 1:
+        ravelled = ind
+    else:
+        ravelled = ind.ravel()
+    vtk_idarr = _vtk.numpy_to_vtkIdTypeArray(ravelled, deep=deep)
     if return_ind:
         return vtk_idarr, ind
     return vtk_idarr

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -778,6 +778,26 @@ def test_slice_along_line_composite(multiblock_all):
     assert output.n_blocks == multiblock_all.n_blocks
 
 
+def test_slice_generate_triangles_true_emits_only_triangles():
+    grid = examples.load_uniform().cast_to_unstructured_grid()
+    out = grid.slice(normal=(1, 1, 1), generate_triangles=True)
+    ug = out.cast_to_unstructured_grid()
+    assert set(ug.celltypes.tolist()) <= {pv.CellType.TRIANGLE}
+
+
+def test_slice_generate_triangles_false_default_preserves_polygons():
+    """The ``False`` default keeps the historical polygon output for
+    plane-cut UnstructuredGrids (no triangulation forced).
+    """
+    grid = examples.load_uniform().cast_to_unstructured_grid()
+    out = grid.slice(normal=(1, 1, 1))  # default generate_triangles=False
+    ug = out.cast_to_unstructured_grid()
+    # Polygon path produces quads (and maybe other polygons) for hex
+    # cell intersections, not just triangles.
+    types = set(ug.celltypes.tolist())
+    assert pv.CellType.QUAD in types or pv.CellType.POLYGON in types
+
+
 def test_compute_cell_quality():
     mesh = pv.ParametricEllipsoid().triangulate().decimate(0.8)
     match_str = re.escape('This filter is deprecated. Use `cell_quality` instead')

--- a/tests/core/test_datasetattributes.py
+++ b/tests/core/test_datasetattributes.py
@@ -373,7 +373,9 @@ def test_contains_empty_string_preserves_keys_rename_side_effect(hexbeam):
     # The ``''`` lookup must run keys() and rename the anonymous array.
     assert '' not in pd
     last = pd.VTKObject.GetAbstractArray(pd.VTKObject.GetNumberOfArrays() - 1)
-    assert last.GetName() and last.GetName().startswith('Unnamed_')
+    name = last.GetName()
+    assert name
+    assert name.startswith('Unnamed_')
 
 
 def test_set_array_catch(hexbeam):

--- a/tests/core/test_datasetattributes.py
+++ b/tests/core/test_datasetattributes.py
@@ -354,6 +354,28 @@ def test_contains_should_contain_when_added(insert_arange_narray):
     assert 'sample_array' in dsa
 
 
+def test_contains_empty_string_preserves_keys_rename_side_effect(hexbeam):
+    """Empty-name lookup must still trigger ``keys()``'s legacy rename so
+    anonymous arrays injected by codepaths like ``set_custom_opacity`` get
+    a unique ``Unnamed_<i>`` name. Regression for the GIF-writer fallout
+    discovered while implementing the HasArray fast path.
+    """
+    pd = hexbeam.point_data
+    # Inject an anonymous array directly via VTK so it has an empty name.
+    arr = pv.core._vtk_core.vtkFloatArray()
+    arr.SetNumberOfValues(hexbeam.n_points)
+    pd.VTKObject.AddArray(arr)
+    # Name is empty before the lookup.
+    assert pd.VTKObject.GetAbstractArray(pd.VTKObject.GetNumberOfArrays() - 1).GetName() in (
+        None,
+        '',
+    )
+    # The ``''`` lookup must run keys() and rename the anonymous array.
+    assert '' not in pd
+    last = pd.VTKObject.GetAbstractArray(pd.VTKObject.GetNumberOfArrays() - 1)
+    assert last.GetName() and last.GetName().startswith('Unnamed_')
+
+
 def test_set_array_catch(hexbeam):
     data = np.zeros(hexbeam.n_points)
     with pytest.raises(TypeError, match='`name` must be a string'):

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -52,6 +52,7 @@ from pyvista.core.utilities import vector_poly_data
 from pyvista.core.utilities.arrays import _coerce_pointslike_arg
 from pyvista.core.utilities.arrays import _SerializedDictArray
 from pyvista.core.utilities.arrays import convert_array
+from pyvista.core.utilities.arrays import convert_string_array
 from pyvista.core.utilities.arrays import copy_vtk_array
 from pyvista.core.utilities.arrays import get_array
 from pyvista.core.utilities.arrays import get_array_association
@@ -1611,6 +1612,64 @@ def test_serial_dict_init():
     serial_dict = _SerializedDictArray(json_dict)
     assert serial_dict['ham'] == 'eggs'
     assert str(serial_dict) == '{"ham": "eggs"}'
+
+
+def test_convert_string_array_roundtrip():
+    """numpy string array <-> vtkStringArray must round-trip without truncation."""
+    arr = np.array(['alpha', 'beta', 'gamma', 'delta-with-much-more-text'])
+    vtk_arr = convert_string_array(arr)
+    assert vtk_arr.GetNumberOfValues() == arr.size
+    assert vtk_arr.GetValue(0) == 'alpha'
+    assert vtk_arr.GetValue(3) == 'delta-with-much-more-text'
+
+    out = convert_string_array(vtk_arr)
+    assert out.shape == arr.shape
+    # Width must auto-size to longest value, not get truncated to 1 char.
+    assert out[3] == 'delta-with-much-more-text'
+    assert np.array_equal(out, arr)
+
+
+def test_convert_string_array_scalar_string():
+    """A bare Python str round-trips back to a 0-d numpy array of the original."""
+    vtk_arr = convert_string_array('hello')
+    assert vtk_arr.GetNumberOfValues() == 1
+    assert vtk_arr.GetValue(0) == 'hello'
+    out = convert_string_array(vtk_arr)
+    assert out.ndim == 0
+    assert str(out) == 'hello'
+
+
+def test_convert_string_array_rejects_non_ascii():
+    with pytest.raises(ValueError, match='non-ASCII'):
+        convert_string_array(np.array(['hello', 'wörld']))
+
+
+def test_convert_string_array_with_name():
+    vtk_arr = convert_string_array(np.array(['a', 'b']), name='my_array')
+    assert vtk_arr.GetName() == 'my_array'
+
+
+def test_serial_dict_uses_single_value_storage():
+    """The setter stores the JSON string as a single vtkStringArray value
+    instead of one value per character (the historical encoding).
+    """
+    serial = _SerializedDictArray({'foo': 'bar', 'n': 42})
+    # New format: 1 value, not len(json_string).
+    assert serial.GetNumberOfValues() == 1
+    assert serial.GetValue(0) == '{"foo": "bar", "n": 42}'
+
+
+def test_serial_dict_reads_legacy_char_per_value_format():
+    """Files written with the old char-per-value format must still
+    deserialize correctly. The getter joins all values.
+    """
+    legacy = _SerializedDictArray()
+    # Wipe and manually re-encode the JSON char-by-char (the old behavior).
+    legacy.SetNumberOfValues(0)
+    for ch in '{"hello": "world"}':
+        legacy.InsertNextValue(ch)
+    # The getter joins all values so the read still produces the right string.
+    assert legacy._string == '{"hello": "world"}'
 
 
 def test_serial_dict_as_dict(serial_dict_with_foobar):


### PR DESCRIPTION
A few internal code path optimizations that I uncovered while benchmarking one of my projects.

### Speed up string array conversions

Two Python loops in `arrays.py` flagged with `OPTIMIZE` markers were burning per-element Python/C crossings.

- `convert_string_array(numpy -> vtk)`: pre-allocate via `SetNumberOfValues(n)` and iterate `arr.tolist()` to skip `numpy.str_` boxing. ~1.4x.
- `_SerializedDictArray._string` setter: store the JSON string as one value instead of one per character. The getter still joins so legacy char-per-value files keep loading. ~85x on a 50-key dict.

### Speed up has array check

`'name' in mesh.point_data` materialized the full key list before the membership test. Replaced with the VTK object's `HasArray`, with a fallback to `keys()` for an edge case for empty-names still resolves.

~76x on `'a5' in point_data` (20 arrays). This adds up when we look at how commonly `if 'foo' in mesh.point_data` occurs.

### DOC: Add performance note about slice `generate_triangles`

See https://github.com/pyvista/pyvista/issues/8256#issuecomment-4265932183

The slice filters defaults to `generate_triangles=False`, which selects `vtkCutter`'s slow per-cell path. `vtkCutter` defaults to `True`:

```text
slice(generate_triangles=False)   118 ms ± 2.3 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
slice(generate_triangles=True)    31.9 ms ± 264 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

### Code quality

These aren't really performance gains but just code quality things I noticed while benchmarking mesh creation

### `numpy_to_idarr` ravel

`numpy_to_idarr` always called `ind.ravel()`, even for 1D contiguous input where it only allocates view metadata. Skip it in the 1D case as this is widely used in `vtkCellArray` / `PolyData` / `UnstructuredGrid` construction. 

### Reduce redundant wrappers in `linear_copy`

The quad fix-up loop read `lgrid.cell_connectivity` 4-7 times per branch. Each read allocates a fresh numpy view so changed this to cache it to a local variable. Probably has perf gains for smaller meshes