### PR TITLE
Mark tinypages parallel test as flaky

### DIFF
--- a/tests/plotting/test_tinypages.py
+++ b/tests/plotting/test_tinypages.py
@@ -133,6 +133,7 @@ def test_tinypages(tmp_path: Path, ename: str, evalue: str):
     assert b'This is a matplotlib plot.' in html_contents
 
 
+@flaky_test(exceptions=(AssertionError,))
 @pytest.mark.skip_windows('path issues, e.g. image file not readable')
 @pytest.mark.skip_check_gc
 def test_parallel(tmp_path: Path) -> None:


### PR DESCRIPTION
### Overview

Resolve #8546 

Turns out the serial tinypages test already has this decorator, so adding this to the parallel test seems appropriate.

https://github.com/pyvista/pyvista/blob/8ae4d3eccf8136782485bea3d64427f6c138a35c/tests/plotting/test_tinypages.py#L25-L30