### PR TITLE
Add Marimo notebook support with auto-detection

### DIFF
--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -95,10 +95,27 @@ def _discover_entry_points() -> None:
                 _custom_backends[name] = ep.load()
 
 
+def _is_marimo() -> bool:
+    """Check if running in a Marimo notebook environment.
+
+    Returns
+    -------
+    bool
+        True if running in a Marimo notebook, False otherwise.
+
+    """
+    try:
+        import marimo  # noqa: PLC0415
+
+        return bool(marimo.running_in_notebook())
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def _resolve_backend() -> str:
     """Auto-detect the best available Jupyter backend.
 
-    Priority: registered custom backends > trame > static.
+    Priority: registered custom backends > marimo (html) > trame > static.
 
     Returns
     -------
@@ -113,11 +130,14 @@ def _resolve_backend() -> str:
     try:
         from pyvista.trame.jupyter import show_trame as show_trame  # noqa: PLC0415
     except ImportError:
-        pass
-    else:
-        return 'trame'
+        return 'static'
 
-    return 'static'
+    # In Marimo, use 'html' (VTK.js export) — no server required and works
+    # with Marimo's native _repr_html_() rendering pipeline.
+    if _is_marimo():
+        return 'html'
+
+    return 'trame'
 
 
 def _is_jupyter_backend(backend: str) -> TypeIs[JupyterBackendOptions]:

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -7188,7 +7188,9 @@ class Plotter(_NoNewAttrMixin, BasePlotter):
             if self._theme.notebook is not None:
                 notebook = self._theme.notebook
             else:
-                notebook = scooby.in_ipykernel()
+                from pyvista.jupyter import _is_marimo  # noqa: PLC0415
+
+                notebook = scooby.in_ipykernel() or _is_marimo()
 
         self.notebook = notebook
         if self.notebook or pv.ON_SCREENSHOT:

--- a/pyvista/trame/jupyter.py
+++ b/pyvista/trame/jupyter.py
@@ -147,6 +147,28 @@ class EmbeddableWidget(HTML):  # type: ignore[misc]  # numpydoc ignore=PR01
         self._src = src
 
 
+class PlainHtmlWidget:  # numpydoc ignore=PR01
+    """Lightweight HTML display widget that only requires ``_repr_html_()``.
+
+    Used in environments that support ``_repr_html_()`` but do not have
+    ``ipywidgets`` installed, such as Marimo notebooks.
+    """
+
+    def __init__(self, plotter, width, height, **kwargs):  # noqa: ARG002
+        """Initialize."""
+        scene = plotter.export_html(filename=None)
+        src = scene.getvalue().replace('"', '&quot;')
+        border = 'border: 1px solid rgb(221,221,221);'
+        self._html = (
+            f'<iframe srcdoc="{src}" class="pyvista" style="width: {width}; '
+            f'height: {height}; {border}"></iframe>'
+        )
+
+    def _repr_html_(self) -> str:  # numpydoc ignore=RT01
+        """Return HTML representation."""
+        return self._html
+
+
 def launch_server(server=None, port=None, host=None, wslink_backend=None, **kwargs):
     """Launch a trame server for use with Jupyter.
 
@@ -391,6 +413,8 @@ def show_trame(
     kwargs.setdefault('height', dh)
 
     if mode == 'html':
+        if HTML is object:
+            return PlainHtmlWidget(plotter, **kwargs)
         return EmbeddableWidget(plotter, **kwargs)
 
     if jupyter_extension_enabled is None:

--- a/tests/plotting/jupyter/test_marimo.py
+++ b/tests/plotting/jupyter/test_marimo.py
@@ -1,0 +1,88 @@
+"""Tests for Marimo notebook support."""
+
+from __future__ import annotations
+
+import importlib.util
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from pyvista.jupyter import _is_marimo
+from pyvista.jupyter import _resolve_backend
+
+has_ipython = bool(importlib.util.find_spec('IPython'))
+skip_no_ipython = pytest.mark.skipif(not has_ipython, reason='Requires IPython package')
+
+
+def test_is_marimo_returns_false_outside_marimo():
+    assert _is_marimo() is False
+
+
+def test_is_marimo_returns_false_when_marimo_not_installed():
+    with patch.dict('sys.modules', {'marimo': None}):
+        assert _is_marimo() is False
+
+
+def test_is_marimo_returns_true_when_running_in_notebook():
+    mock_marimo = MagicMock()
+    mock_marimo.running_in_notebook.return_value = True
+    with patch.dict('sys.modules', {'marimo': mock_marimo}):
+        assert _is_marimo() is True
+
+
+def test_is_marimo_returns_false_when_not_in_notebook():
+    mock_marimo = MagicMock()
+    mock_marimo.running_in_notebook.return_value = False
+    with patch.dict('sys.modules', {'marimo': mock_marimo}):
+        assert _is_marimo() is False
+
+
+@skip_no_ipython
+def test_resolve_backend_returns_html_in_marimo():
+    mock_marimo = MagicMock()
+    mock_marimo.running_in_notebook.return_value = True
+    with patch.dict('sys.modules', {'marimo': mock_marimo}):
+        backend = _resolve_backend()
+    assert backend == 'html'
+
+
+@skip_no_ipython
+def test_resolve_backend_returns_trame_outside_marimo():
+    assert _resolve_backend() == 'trame'
+
+
+@skip_no_ipython
+def test_plain_html_widget_repr_html():
+    from pyvista.trame.jupyter import PlainHtmlWidget
+
+    plotter = MagicMock()
+    scene = MagicMock()
+    scene.getvalue.return_value = '<html>test</html>'
+    plotter.export_html.return_value = scene
+
+    widget = PlainHtmlWidget(plotter, width='100%', height='600px')
+    html = widget._repr_html_()
+    assert '<iframe' in html
+    assert 'pyvista' in html
+
+
+@skip_no_ipython
+def test_show_trame_html_mode_uses_plain_widget_without_ipywidgets():
+    from unittest.mock import patch as _patch
+
+    import pyvista.trame.jupyter as trame_mod
+    from pyvista.trame.jupyter import PlainHtmlWidget
+
+    plotter = MagicMock()
+    plotter.render_window = MagicMock()
+    plotter._window_size_unset = True
+
+    scene = MagicMock()
+    scene.getvalue.return_value = '<html/>'
+    plotter.export_html.return_value = scene
+
+    with _patch.object(trame_mod, 'HTML', object):
+        result = trame_mod.show_trame(plotter, mode='html')
+
+    assert isinstance(result, PlainHtmlWidget)


### PR DESCRIPTION
### Overview

Add support for interactive 3D visualization in [Marimo](https://marimo.io/) notebooks.

Marimo uses its own kernel (independent from Jupyter/ipykernel), so PyVista's existing notebook detection via `scooby.in_ipykernel()` returned `False`, preventing `plotter.show()` from rendering anything in Marimo.

related to #7265 (does not resolve)

### Details

- No new backend name is introduced — Marimo is treated as an environment, not a separate backend