### PR TITLE
Replace pyvista-bot PAT with GitHub App and adopt Codecov OIDC

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -240,12 +240,25 @@ jobs:
           cp -r doc/source/examples/ ./pyvista-examples/
           ls -l ./pyvista-examples/
 
+      - name: Get app installation token (pyvista-examples)
+        id: app-token
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ vars.PYVISTA_BOT_APP_ID }}
+          private-key: ${{ secrets.PYVISTA_BOT_APP_PRIVATE_KEY }}
+          owner: pyvista
+          # Scope the token to only pyvista-examples — the only repo this
+          # step writes to. The App must be installed on pyvista-examples.
+          repositories: pyvista-examples
+          permission-contents: write
+
       - name: Publish notebooks on release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
         with:
           external_repository: pyvista/pyvista-examples
-          personal_token: ${{ secrets.PYVISTA_BOT_TOKEN }}
+          personal_token: ${{ steps.app-token.outputs.token }}
           publish_dir: pyvista-examples
           publish_branch: master
           exclude_assets: ""

--- a/.github/workflows/intersphinx-update-pull-request.yml
+++ b/.github/workflows/intersphinx-update-pull-request.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   id-token: none
+  contents: read
 
 jobs:
   intersphinx_update:
@@ -22,11 +23,28 @@ jobs:
       - name: Update intersphinx objects
         run: make -C doc update-intersphinx
 
+      - name: Get app installation token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ vars.PYVISTA_BOT_APP_ID }}
+          private-key: ${{ secrets.PYVISTA_BOT_APP_PRIVATE_KEY }}
+          owner: pyvista
+          repositories: pyvista
+          # PR opened by an App installation token triggers CI (unlike PRs
+          # opened with GITHUB_TOKEN), which is the reason this job needs
+          # elevated credentials at all.
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
         with:
-          token: ${{ secrets.PYVISTA_BOT_TOKEN }}
-          author: pyvista-bot <53544751+pyvista-bot@users.noreply.github.com>
+          token: ${{ steps.app-token.outputs.token }}
+          # Omit `author` so peter-evans/create-pull-request uses the App's
+          # bot identity automatically. To pin a specific identity instead,
+          # use: <APP_SLUG>[bot] <<APP_USER_ID>+<APP_SLUG>[bot]@users.noreply.github.com>
+          # where APP_USER_ID is visible in the App's bot profile URL.
           commit-message: "[create-pull-request] update local intersphinx"
           labels: |
             maintenance

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -7,8 +7,11 @@ on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [opened, reopened]
 
+# Use the built-in GITHUB_TOKEN (pull_request_target runs in base-repo context,
+# so the token has write access to the PR). No PAT or App token needed.
 permissions:
-  id-token: none
+  contents: read
+  pull-requests: write
 
 jobs:
   triage:
@@ -18,46 +21,46 @@ jobs:
       - name: Label based on changed files
         uses: actions/labeler@v6
         with:
-          repo-token: "${{ secrets.PYVISTA_BOT_TOKEN }}"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Label based on branch name
       - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
         if: startsWith(github.event.pull_request.head.ref, 'doc/') || startsWith(github.event.pull_request.head.ref, 'docs')
         with:
-          github_token: "${{ secrets.PYVISTA_BOT_TOKEN }}"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: documentation
       - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
         if: startsWith(github.event.pull_request.head.ref, 'docker')
         with:
-          github_token: "${{ secrets.PYVISTA_BOT_TOKEN }}"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: docker
       - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
         if: startsWith(github.event.pull_request.head.ref, 'maint') || startsWith(github.event.pull_request.head.ref, 'testing') || startsWith(github.event.pull_request.head.ref, 'no-ci') || startsWith(github.event.pull_request.head.ref, 'ci')
         with:
-          github_token: "${{ secrets.PYVISTA_BOT_TOKEN }}"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: maintenance
       - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
         if: startsWith(github.event.pull_request.head.ref, 'junk')
         with:
-          github_token: "${{ secrets.PYVISTA_BOT_TOKEN }}"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: ignore-for-release
       - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
         if: startsWith(github.event.pull_request.head.ref, 'feat')
         with:
-          github_token: "${{ secrets.PYVISTA_BOT_TOKEN }}"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: enhancement
       - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
         if: startsWith(github.event.pull_request.head.ref, 'fix') || startsWith(github.event.pull_request.head.ref, 'patch') || startsWith(github.event.pull_request.head.ref, 'bug')
         with:
-          github_token: "${{ secrets.PYVISTA_BOT_TOKEN }}"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: bug
       - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
         if: startsWith(github.event.pull_request.head.ref, 'release')
         with:
-          github_token: "${{ secrets.PYVISTA_BOT_TOKEN }}"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: release
       - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
         if: startsWith(github.event.pull_request.head.ref, 'breaking-change')
         with:
-          github_token: "${{ secrets.PYVISTA_BOT_TOKEN }}"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: breaking-change

--- a/.github/workflows/netlify-deploy.yml
+++ b/.github/workflows/netlify-deploy.yml
@@ -21,9 +21,10 @@ on: # zizmor: ignore[dangerous-triggers]
     workflows: ["Build Documentation", "Unit Testing and Deployment"]
     types: [completed]
 
-# Deploys and commit statuses use PYVISTA_BOT_TOKEN, not GITHUB_TOKEN, so the
-# workflow token only needs read access (plus actions: read to download
-# artifacts from the triggering workflow run).
+# Deploys and commit statuses use a GitHub App installation token (see the
+# per-job "Get app installation token" steps), not GITHUB_TOKEN, so the
+# workflow-level token only needs read access (plus actions: read to
+# download artifacts from the triggering workflow run).
 permissions:
   actions: read
   contents: read
@@ -77,6 +78,19 @@ jobs:
     environment:
       name: ${{ github.event.workflow_run.event == 'push' && 'docs-main' || (needs.setup.outputs.is_fork == 'true' && 'fork-deploys' || 'internal-deploys') }}
     steps:
+      - name: Get app installation token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ vars.PYVISTA_BOT_APP_ID }}
+          private-key: ${{ secrets.PYVISTA_BOT_APP_PRIVATE_KEY }}
+          owner: pyvista
+          repositories: pyvista
+          # nwtgck/actions-netlify creates a GitHub Deployment; the subsequent
+          # step posts a commit status.
+          permission-deployments: write
+          permission-statuses: write
+
       - name: Download docs-build artifact
         uses: actions/download-artifact@v8
         with:
@@ -91,7 +105,7 @@ jobs:
         with:
           publish-dir: .
           production-deploy: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}
-          github-token: ${{ secrets.PYVISTA_BOT_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           deploy-message: "Deploy from GitHub Actions"
           enable-pull-request-comment: false
           enable-commit-comment: false
@@ -106,7 +120,7 @@ jobs:
       - name: Create commit status with preview link
         if: github.event.workflow_run.event == 'pull_request'
         env:
-          GH_TOKEN: ${{ secrets.PYVISTA_BOT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           DEPLOY_URL: ${{ steps.netlify.outputs.deploy-url }}
           HEAD_SHA: ${{ needs.setup.outputs.head_sha }}
           REPO: ${{ github.repository }}
@@ -139,6 +153,17 @@ jobs:
     environment:
       name: ${{ needs.setup.outputs.is_fork == 'true' && 'fork-deploys' || 'internal-deploys' }}
     steps:
+      - name: Get app installation token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ vars.PYVISTA_BOT_APP_ID }}
+          private-key: ${{ secrets.PYVISTA_BOT_APP_PRIVATE_KEY }}
+          owner: pyvista
+          repositories: pyvista
+          permission-deployments: write
+          permission-statuses: write
+
       # Check out base repo (main). Never check out the PR head — the whole
       # point of workflow_run is that fork code is never executed here.
       - uses: actions/checkout@v6
@@ -179,7 +204,7 @@ jobs:
         with:
           publish-dir: _doc_image_report
           production-deploy: false
-          github-token: ${{ secrets.PYVISTA_BOT_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           deploy-message: "Doc image report for PR #${{ needs.setup.outputs.pr_number }}"
           enable-pull-request-comment: false
           enable-commit-comment: false
@@ -194,7 +219,7 @@ jobs:
       - name: Create commit status with report link
         if: steps.report.outputs.has_report == 'true'
         env:
-          GH_TOKEN: ${{ secrets.PYVISTA_BOT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           DEPLOY_URL: ${{ steps.netlify.outputs.deploy-url }}
           HEAD_SHA: ${{ needs.setup.outputs.head_sha }}
           REPO: ${{ github.repository }}
@@ -226,6 +251,17 @@ jobs:
     environment:
       name: ${{ needs.setup.outputs.is_fork == 'true' && 'fork-deploys' || 'internal-deploys' }}
     steps:
+      - name: Get app installation token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ vars.PYVISTA_BOT_APP_ID }}
+          private-key: ${{ secrets.PYVISTA_BOT_APP_PRIVATE_KEY }}
+          owner: pyvista
+          repositories: pyvista
+          permission-deployments: write
+          permission-statuses: write
+
       # Check out base repo (main). Never check out the PR head.
       - uses: actions/checkout@v6
         with:
@@ -265,7 +301,7 @@ jobs:
         with:
           publish-dir: _image_report
           production-deploy: false
-          github-token: ${{ secrets.PYVISTA_BOT_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           deploy-message: "Test image report for PR #${{ needs.setup.outputs.pr_number }}"
           enable-pull-request-comment: false
           enable-commit-comment: false
@@ -280,7 +316,7 @@ jobs:
       - name: Create commit status with report link
         if: steps.report.outputs.has_report == 'true'
         env:
-          GH_TOKEN: ${{ secrets.PYVISTA_BOT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           DEPLOY_URL: ${{ steps.netlify.outputs.deploy-url }}
           HEAD_SHA: ${{ needs.setup.outputs.head_sha }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -416,6 +416,11 @@ jobs:
     # 'vtk-dev-testing' label is not applied. When VTK-dev does run, its
     # coverage artifacts get bundled into this single CodeCov upload.
     if: always() && github.event_name == 'pull_request'
+    permissions:
+      # id-token: write authorizes OIDC token minting so codecov-action can
+      # authenticate to Codecov without a long-lived CODECOV_TOKEN secret.
+      id-token: write
+      contents: read
     steps:
       # Needs to checkout only for codecov to match file names
       - uses: actions/checkout@v6
@@ -433,8 +438,7 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         with:
           fail_ci_if_error: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
 
   # Publish to PyPI using trusted publishing
   release:

--- a/.github/workflows/update-pr-branch.yml
+++ b/.github/workflows/update-pr-branch.yml
@@ -4,17 +4,31 @@ on:
   push:
     branches:
       - "main"
+
+permissions:
+  contents: read
+
 jobs:
   autoupdate:
-    permissions:
-      contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - name: Get app installation token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ vars.PYVISTA_BOT_APP_ID }}
+          private-key: ${{ secrets.PYVISTA_BOT_APP_PRIVATE_KEY }}
+          owner: pyvista
+          repositories: pyvista
+          # adRise/update-pr-branch needs to update the PR branch (merges base
+          # into head) and read PR metadata.
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Automatically update PR
         uses: adRise/update-pr-branch@a51c014567e5be98445551cce9b8f5ad42dd8acf
         with:
-          token: ${{ secrets.PYVISTA_BOT_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           base: "main"
           required_approval_count: 1
           require_passed_checks: false


### PR DESCRIPTION
- Retire `PYVISTA_BOT_TOKEN` across all workflows. Org-wide 2FA enforcement breaks the `pyvista-bot` user account, and App installation tokens are scoped per-workflow, rotated hourly, and not tied to any human user.
- `label.yml` drops the PAT entirely for all 9 labeler calls. `pull_request_target` runs in base-repo context, so the built-in `GITHUB_TOKEN` with `pull-requests: write` is sufficient.
- `update-pr-branch.yml`, `intersphinx-update-pull-request.yml`, `netlify-deploy.yml` (6 uses across preview + two image-report jobs), and `docs.yml` switch to `actions/create-github-app-token`. Each call requests only the repositories and permissions that one job actually needs.
- `docs.yml` mints its cross-repo token scoped to `pyvista/pyvista-examples` with `contents: write`, so the release-tag notebook publish stops needing a cross-repo PAT.
- `testing-and-deployment.yml` switches `codecov-action` to OIDC: adds `id-token: write` on the upload job, sets `use_oidc: true`, removes the `CODECOV_TOKEN` env so the long-lived Codecov secret can also go.
