### PR TITLE
Add a `zero()` filter that centers a dataset at the origin

### DIFF
--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -2431,6 +2431,63 @@ class DataObjectFilters:
             inplace=inplace,
         )
 
+    def zero(  # type: ignore[misc]
+        self: _MeshType_co,
+        *,
+        transform_all_input_vectors: bool = False,
+        inplace: bool = False,
+    ) -> _MeshType_co:
+        """Center the dataset at the origin.
+
+        Translates the dataset so that its bounding box center is at
+        ``(0, 0, 0)``. Equivalent to ``mesh.translate(-np.array(mesh.center))``
+        and works for all dataset types, including those with implicit
+        geometry such as :class:`~pyvista.ImageData` and
+        :class:`~pyvista.RectilinearGrid`.
+
+        .. note::
+            See also the notes at :func:`transform` which is used by this filter
+            under the hood.
+
+        Parameters
+        ----------
+        transform_all_input_vectors : bool, default: False
+            When ``True``, all input vectors are
+            transformed. Otherwise, only the points, normals and
+            active vectors are transformed.
+
+        inplace : bool, default: False
+            Updates mesh in-place.
+
+        Returns
+        -------
+        output : DataSet | MultiBlock
+            Dataset centered at the origin. Return type matches input.
+
+        See Also
+        --------
+        translate
+            Translate the dataset by an arbitrary vector.
+        pyvista.DataSet.center
+            Bounding box center of the dataset (also settable).
+
+        Examples
+        --------
+        Center an off-origin sphere at the origin.
+
+        >>> import pyvista as pv
+        >>> mesh = pv.Sphere(center=(2, 1, 2))
+        >>> centered = mesh.zero()
+        >>> centered.center
+        (0.0, 0.0, 0.0)
+
+        """
+        return self.translate(
+            np.negative(self.center),
+            transform_all_input_vectors=transform_all_input_vectors,
+            inplace=inplace,
+        )
+
     @_deprecate_positional_args(allowed=['xyz'])
     def scale(  # noqa: PLR0917
         self: _MeshType_co,

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -1288,6 +1288,39 @@ def test_translate_should_translate_grid(hexbeam, axis_amounts):
     assert np.allclose(grid_copy.points, grid_points)
 
 
+def test_zero_should_center_dataset_at_origin(hexbeam):
+    offset = np.array([3.0, -2.0, 5.0])
+    moved = hexbeam.translate(offset, inplace=False)
+    assert not np.allclose(moved.center, (0.0, 0.0, 0.0))
+
+    centered = moved.zero()
+    assert np.allclose(centered.center, (0.0, 0.0, 0.0))
+    assert np.allclose(moved.center, hexbeam.center + offset)
+
+    moved.zero(inplace=True)
+    assert np.allclose(moved.center, (0.0, 0.0, 0.0))
+
+
+def test_zero_should_work_for_image_and_rectilinear():
+    image = pv.ImageData(dimensions=(5, 5, 5), origin=(10.0, 20.0, 30.0))
+    centered_image = image.zero()
+    assert np.allclose(centered_image.center, (0.0, 0.0, 0.0))
+
+    rect = pv.RectilinearGrid(
+        np.array([10.0, 11.0, 12.0]),
+        np.array([20.0, 21.0, 22.0]),
+        np.array([30.0, 31.0, 32.0]),
+    )
+    centered_rect = rect.zero()
+    assert np.allclose(centered_rect.center, (0.0, 0.0, 0.0))
+
+
+def test_zero_should_work_for_multiblock():
+    blocks = pv.MultiBlock([pv.Sphere(center=(2, 0, 0)), pv.Cube(center=(0, 2, 0)), pv.Cone()])
+    centered = blocks.zero()
+    assert np.allclose(centered.center, (0.0, 0.0, 0.0))
+
+
 @settings(
     suppress_health_check=[HealthCheck.function_scoped_fixture],
     max_examples=HYPOTHESIS_MAX_EXAMPLES,


### PR DESCRIPTION
- Adds `DataObjectFilters.zero()`, a thin wrapper over `translate(-self.center)` that moves a dataset's bounding-box center to `(0, 0, 0)`.
- Works on every dataset type (PolyData, UnstructuredGrid, StructuredGrid, ImageData, RectilinearGrid, MultiBlock) without relying on `.points`, so implicit-geometry types like ImageData and RectilinearGrid are handled correctly.
- Replaces the common `mesh.points -= mesh.center` idiom, which silently breaks for ImageData and RectilinearGrid.
- Boolean parameters are keyword-only (`*`), and the implementation reuses the existing `transform()` pipeline so behavior matches `translate()` exactly.
