### PR TITLE
Add theme registry and entrypoints

### DIFF
--- a/doc/source/api/plotting/conv_func.rst
+++ b/doc/source/api/plotting/conv_func.rst
@@ -11,7 +11,6 @@ routines in PyVista.
    plot
    plot_arrows
    set_plot_theme
-   register_theme
    registered_themes
    ThemeRegistration
    create_axes_orientation_box

--- a/doc/source/api/plotting/conv_func.rst
+++ b/doc/source/api/plotting/conv_func.rst
@@ -13,6 +13,7 @@ routines in PyVista.
    set_plot_theme
    register_theme
    registered_themes
+   ThemeRegistration
    create_axes_orientation_box
    create_axes_marker
    opacity_transfer_function

--- a/doc/source/api/plotting/conv_func.rst
+++ b/doc/source/api/plotting/conv_func.rst
@@ -11,6 +11,8 @@ routines in PyVista.
    plot
    plot_arrows
    set_plot_theme
+   register_theme
+   registered_themes
    create_axes_orientation_box
    create_axes_marker
    opacity_transfer_function

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -148,6 +148,13 @@ def __getattr__(name):
     if 'pyvista.plotting' not in sys.modules:
         import pyvista.plotting  # noqa: F401, PLC0415
 
+        # Apply ``PYVISTA_PLOT_THEME`` now that ``pyvista.plotting`` is fully
+        # loaded. Doing this inside ``pyvista.plotting.__init__`` would invite
+        # re-entrant access to this partially-initialized module when an
+        # entry-point-registered plugin is imported (Python 3.12 evaluates
+        # annotations like ``pv.Plotter`` eagerly at plugin module load).
+        sys.modules['pyvista.plotting']._set_plot_theme_from_env()
+
     try:
         feature = inspect.getattr_static(sys.modules['pyvista.plotting'], name)
     except AttributeError:

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -113,6 +113,13 @@ if TYPE_CHECKING:
     from pyvista.plotting import *
 
 
+# Tracks whether the ``PYVISTA_PLOT_THEME`` environment variable has been
+# applied yet. Applying a plugin theme runs arbitrary plugin code that can
+# call back into ``pyvista`` before this module has finished the caller's
+# original request; the flag keeps the apply single-shot.
+_env_theme_applied: bool = False
+
+
 # Lazily import/access the plotting module
 def __getattr__(name):
     """Fetch an attribute ``name`` from ``globals()`` or the ``pyvista.plotting`` module.
@@ -148,17 +155,23 @@ def __getattr__(name):
     if 'pyvista.plotting' not in sys.modules:
         import pyvista.plotting  # noqa: F401, PLC0415
 
-        # Apply ``PYVISTA_PLOT_THEME`` now that ``pyvista.plotting`` is fully
-        # loaded. Doing this inside ``pyvista.plotting.__init__`` would invite
-        # re-entrant access to this partially-initialized module when an
-        # entry-point-registered plugin is imported (Python 3.12 evaluates
-        # annotations like ``pv.Plotter`` eagerly at plugin module load).
-        sys.modules['pyvista.plotting']._set_plot_theme_from_env()
-
     try:
         feature = inspect.getattr_static(sys.modules['pyvista.plotting'], name)
     except AttributeError:
         msg = f"module 'pyvista' has no attribute '{name}'"
         raise AttributeError(msg) from None
+
+    # Apply ``PYVISTA_PLOT_THEME`` once, now that ``pyvista.plotting`` is fully
+    # loaded and the caller's requested attribute is already resolved. Doing
+    # this inside ``pyvista.plotting.__init__`` invites re-entrant access to a
+    # partially-initialized module when an entry-point-registered plugin is
+    # imported (Python 3.12 evaluates annotations like ``pv.Plotter`` eagerly
+    # at plugin module load). The flag is set before the call to prevent
+    # re-entrant double-application if a plugin's module body accesses
+    # attributes on ``pyvista`` during the theme apply.
+    global _env_theme_applied  # noqa: PLW0603
+    if not _env_theme_applied:
+        _env_theme_applied = True
+        sys.modules['pyvista.plotting']._set_plot_theme_from_env()
 
     return feature

--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -73,7 +73,6 @@ from .theme_registry import registered_themes as registered_themes
 from .themes import DocumentTheme as _GlobalTheme
 from .themes import _set_plot_theme_from_env as _set_plot_theme_from_env
 from .themes import load_theme as load_theme
-from .themes import register_theme as register_theme
 from .themes import set_plot_theme as set_plot_theme
 from .tools import FONTS as FONTS
 from .tools import check_math_text_support as check_math_text_support

--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -71,6 +71,7 @@ from .texture import numpy_to_texture as numpy_to_texture
 from .themes import DocumentTheme as _GlobalTheme
 from .themes import _set_plot_theme_from_env
 from .themes import load_theme as load_theme
+from .themes import register_theme as register_theme
 from .themes import set_plot_theme as set_plot_theme
 from .tools import FONTS as FONTS
 from .tools import check_math_text_support as check_math_text_support

--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -68,6 +68,8 @@ from .text import TextProperty as TextProperty
 from .texture import Texture as Texture
 from .texture import image_to_texture as image_to_texture
 from .texture import numpy_to_texture as numpy_to_texture
+from .theme_registry import ThemeRegistration as ThemeRegistration
+from .theme_registry import registered_themes as registered_themes
 from .themes import DocumentTheme as _GlobalTheme
 from .themes import _set_plot_theme_from_env as _set_plot_theme_from_env
 from .themes import load_theme as load_theme

--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -69,7 +69,7 @@ from .texture import Texture as Texture
 from .texture import image_to_texture as image_to_texture
 from .texture import numpy_to_texture as numpy_to_texture
 from .themes import DocumentTheme as _GlobalTheme
-from .themes import _set_plot_theme_from_env
+from .themes import _set_plot_theme_from_env as _set_plot_theme_from_env
 from .themes import load_theme as load_theme
 from .themes import register_theme as register_theme
 from .themes import set_plot_theme as set_plot_theme
@@ -123,6 +123,3 @@ class QtInteractor:  # numpydoc ignore=PR01
 
 
 global_theme: _GlobalTheme = _GlobalTheme()
-
-# Set preferred plot theme
-_set_plot_theme_from_env()

--- a/pyvista/plotting/theme_registry.py
+++ b/pyvista/plotting/theme_registry.py
@@ -6,6 +6,8 @@ from collections.abc import Mapping
 from importlib import import_module
 from importlib.metadata import entry_points
 from typing import TYPE_CHECKING
+from typing import Literal
+from typing import NamedTuple
 from typing import TypedDict
 
 from pyvista._warn_external import warn_external
@@ -17,11 +19,42 @@ if TYPE_CHECKING:
 THEME_ENTRY_POINT_GROUP = 'pyvista.themes'
 
 
+ThemeRegistrationKind = Literal['subclass', 'instance', 'entry_point', 'alias']
+
+
+class ThemeRegistration(NamedTuple):
+    """Describe how a theme name became registered.
+
+    Returned by :func:`~pyvista.registered_themes`. ``kind`` distinguishes
+    the registration path: a :class:`~pyvista.plotting.themes.Theme`
+    subclass with a class-level ``_default_name`` (``'subclass'``), an
+    instance passed to :func:`~pyvista.register_theme` (``'instance'``),
+    a ``pyvista.themes`` entry point from an installed plugin
+    (``'entry_point'``), or a built-in legacy alias such as ``'default'``
+    or ``'vtk'`` (``'alias'``).
+
+    Attributes
+    ----------
+    name : str
+        The registered (normalized) theme name.
+    kind : str
+        One of ``'subclass'``, ``'instance'``, ``'entry_point'``, ``'alias'``.
+    source : str
+        Human-readable origin (e.g. ``'my_package.theme.MyTheme'``).
+
+    """
+
+    name: str
+    kind: ThemeRegistrationKind
+    source: str
+
+
 class _ThemeRegistryState(TypedDict):
     """Stored registry state used by tests."""
 
     classes: dict[str, type[Theme]]
     classes_sources: dict[str, str]
+    aliases: set[str]
     instances: dict[str, Theme]
     instances_sources: dict[str, str]
     discovered: dict[str, type[Theme] | Theme]
@@ -31,6 +64,7 @@ class _ThemeRegistryState(TypedDict):
 
 _registered_theme_classes: dict[str, type[Theme]] = {}
 _registered_theme_classes_sources: dict[str, str] = {}
+_registered_theme_aliases: set[str] = set()
 _registered_theme_instances: dict[str, Theme] = {}
 _registered_theme_instances_sources: dict[str, str] = {}
 _discovered_entry_point_themes: dict[str, type[Theme] | Theme] = {}
@@ -48,6 +82,7 @@ def _save_registry_state() -> _ThemeRegistryState:
     return {
         'classes': _registered_theme_classes.copy(),
         'classes_sources': _registered_theme_classes_sources.copy(),
+        'aliases': _registered_theme_aliases.copy(),
         'instances': _registered_theme_instances.copy(),
         'instances_sources': _registered_theme_instances_sources.copy(),
         'discovered': _discovered_entry_point_themes.copy(),
@@ -63,6 +98,8 @@ def _restore_registry_state(state: _ThemeRegistryState) -> None:
     _registered_theme_classes.update(state['classes'])
     _registered_theme_classes_sources.clear()
     _registered_theme_classes_sources.update(state['classes_sources'])
+    _registered_theme_aliases.clear()
+    _registered_theme_aliases.update(state['aliases'])
     _registered_theme_instances.clear()
     _registered_theme_instances.update(state['instances'])
     _registered_theme_instances_sources.clear()
@@ -140,7 +177,8 @@ def _register_alias(name: str, cls: type[Theme]) -> None:
     """
     normalized = _normalize_theme_name(name)
     _registered_theme_classes[normalized] = cls
-    _registered_theme_classes_sources[normalized] = f'{cls.__module__}.{cls.__qualname__} (alias)'
+    _registered_theme_classes_sources[normalized] = f'{cls.__module__}.{cls.__qualname__}'
+    _registered_theme_aliases.add(normalized)
 
 
 def _lookup_explicit(normalized: str) -> Theme | None:
@@ -191,6 +229,68 @@ def _available_theme_names() -> tuple[str, ...]:
         | set(_discovered_entry_point_themes)
     )
     return tuple(sorted(names))
+
+
+def registered_themes() -> dict[str, ThemeRegistration]:
+    """Return all registered themes, keyed by name.
+
+    Use this to discover which names can be passed to
+    :func:`~pyvista.set_plot_theme` or the ``PYVISTA_PLOT_THEME``
+    environment variable. Entry-point plugins are loaded on the first
+    call so they appear in the result.
+
+    Returns
+    -------
+    dict[str, ThemeRegistration]
+        Mapping of theme name to a :class:`ThemeRegistration` record
+        describing how the name was registered.
+
+    Examples
+    --------
+    List available theme names.
+
+    >>> import pyvista as pv
+    >>> for name in sorted(pv.registered_themes()):
+    ...     print(name)
+    dark
+    default
+    document
+    document_build
+    document_pro
+    paraview
+    testing
+    vtk
+
+    Inspect how a name became registered.
+
+    >>> pv.registered_themes()['dark'].kind
+    'subclass'
+
+    """
+    _ensure_entry_points()
+    out: dict[str, ThemeRegistration] = {}
+    for name, cls in _registered_theme_classes.items():
+        kind: ThemeRegistrationKind = 'alias' if name in _registered_theme_aliases else 'subclass'
+        source = _registered_theme_classes_sources.get(
+            name, f'{cls.__module__}.{cls.__qualname__}'
+        )
+        out[name] = ThemeRegistration(name=name, kind=kind, source=source)
+    for name in _registered_theme_instances:
+        out[name] = ThemeRegistration(
+            name=name,
+            kind='instance',
+            source=_registered_theme_instances_sources.get(name, '<unknown>'),
+        )
+    for name in _discovered_entry_point_themes:
+        if name in out:
+            # Explicit registrations always win over entry-point providers.
+            continue
+        out[name] = ThemeRegistration(
+            name=name,
+            kind='entry_point',
+            source=_discovered_entry_point_sources.get(name, '<unknown>'),
+        )
+    return dict(sorted(out.items()))
 
 
 def _resolve_dotted_path(spec: str) -> type[Theme]:

--- a/pyvista/plotting/theme_registry.py
+++ b/pyvista/plotting/theme_registry.py
@@ -1,0 +1,295 @@
+"""Registry for named pyvista themes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from importlib import import_module
+from importlib.metadata import entry_points
+from typing import TYPE_CHECKING
+from typing import TypedDict
+
+from pyvista._warn_external import warn_external
+
+if TYPE_CHECKING:
+    from .themes import Theme
+
+
+THEME_ENTRY_POINT_GROUP = 'pyvista.themes'
+
+
+class _ThemeRegistryState(TypedDict):
+    """Stored registry state used by tests."""
+
+    classes: dict[str, type[Theme]]
+    classes_sources: dict[str, str]
+    instances: dict[str, Theme]
+    instances_sources: dict[str, str]
+    discovered: dict[str, type[Theme] | Theme]
+    discovered_sources: dict[str, str]
+    loaded: bool
+
+
+_registered_theme_classes: dict[str, type[Theme]] = {}
+_registered_theme_classes_sources: dict[str, str] = {}
+_registered_theme_instances: dict[str, Theme] = {}
+_registered_theme_instances_sources: dict[str, str] = {}
+_discovered_entry_point_themes: dict[str, type[Theme] | Theme] = {}
+_discovered_entry_point_sources: dict[str, str] = {}
+_entry_points_loaded: bool = False
+
+
+def _normalize_theme_name(name: str) -> str:
+    """Normalize a theme name."""
+    return name.strip().lower()
+
+
+def _save_registry_state() -> _ThemeRegistryState:
+    """Snapshot the current registry state for later restoration."""
+    return {
+        'classes': _registered_theme_classes.copy(),
+        'classes_sources': _registered_theme_classes_sources.copy(),
+        'instances': _registered_theme_instances.copy(),
+        'instances_sources': _registered_theme_instances_sources.copy(),
+        'discovered': _discovered_entry_point_themes.copy(),
+        'discovered_sources': _discovered_entry_point_sources.copy(),
+        'loaded': _entry_points_loaded,
+    }
+
+
+def _restore_registry_state(state: _ThemeRegistryState) -> None:
+    """Restore registry state from a snapshot."""
+    global _entry_points_loaded  # noqa: PLW0603
+    _registered_theme_classes.clear()
+    _registered_theme_classes.update(state['classes'])
+    _registered_theme_classes_sources.clear()
+    _registered_theme_classes_sources.update(state['classes_sources'])
+    _registered_theme_instances.clear()
+    _registered_theme_instances.update(state['instances'])
+    _registered_theme_instances_sources.clear()
+    _registered_theme_instances_sources.update(state['instances_sources'])
+    _discovered_entry_point_themes.clear()
+    _discovered_entry_point_themes.update(state['discovered'])
+    _discovered_entry_point_sources.clear()
+    _discovered_entry_point_sources.update(state['discovered_sources'])
+    _entry_points_loaded = state['loaded']
+
+
+def _describe_existing(name: str) -> str:
+    """Return a human-readable source of the existing registration."""
+    if name in _registered_theme_classes_sources:
+        return _registered_theme_classes_sources[name]
+    if name in _registered_theme_instances_sources:
+        return _registered_theme_instances_sources[name]
+    return '<unknown>'
+
+
+def _register_theme_class(name: str, cls: type[Theme], *, source: str) -> None:
+    """Register a ``Theme`` subclass. Called from ``Theme.__init_subclass__``.
+
+    Collisions warn (do not raise) so that a subclass definition at
+    import time cannot crash the interpreter.
+    """
+    normalized = _normalize_theme_name(name)
+    if not normalized:
+        warn_external(
+            f'Theme class {source} declared an empty ``_default_name``; skipped.',
+        )
+        return
+    if normalized in _registered_theme_classes or normalized in _registered_theme_instances:
+        existing = _describe_existing(normalized)
+        warn_external(
+            f'Theme name "{normalized}" is already registered by {existing}; '
+            f'ignoring duplicate registration from {source}.',
+        )
+        return
+    _registered_theme_classes[normalized] = cls
+    _registered_theme_classes_sources[normalized] = source
+
+
+def _register_theme_instance(name: str, instance: Theme, *, source: str, override: bool) -> None:
+    """Register a pre-configured ``Theme`` instance.
+
+    Collisions raise ``ValueError`` unless ``override=True``. This is
+    called from the public ``register_theme`` function, so loud failure
+    is the right behavior.
+    """
+    normalized = _normalize_theme_name(name)
+    if not normalized:
+        msg = 'Theme name must not be empty.'
+        raise ValueError(msg)
+    if not override and (
+        normalized in _registered_theme_classes or normalized in _registered_theme_instances
+    ):
+        existing = _describe_existing(normalized)
+        msg = (
+            f'Theme name "{normalized}" is already registered by {existing}. '
+            'Pass ``override=True`` to replace it.'
+        )
+        raise ValueError(msg)
+    _registered_theme_classes.pop(normalized, None)
+    _registered_theme_classes_sources.pop(normalized, None)
+    _registered_theme_instances[normalized] = instance
+    _registered_theme_instances_sources[normalized] = source
+
+
+def _register_alias(name: str, cls: type[Theme]) -> None:
+    """Register a built-in name alias (e.g. ``'default' → DocumentTheme``).
+
+    Bypasses collision detection so built-in aliases can coexist with
+    auto-registered subclasses without warning.
+    """
+    normalized = _normalize_theme_name(name)
+    _registered_theme_classes[normalized] = cls
+    _registered_theme_classes_sources[normalized] = f'{cls.__module__}.{cls.__qualname__} (alias)'
+
+
+def _lookup_explicit(normalized: str) -> Theme | None:
+    """Look up a normalized name in the explicit registries.
+
+    Classes are instantiated fresh; instances are returned as-is (the
+    caller uses ``load_theme`` which copies attributes into a target).
+    """
+    cls = _registered_theme_classes.get(normalized)
+    if cls is not None:
+        return cls()
+    return _registered_theme_instances.get(normalized)
+
+
+def _resolve_theme(name: str) -> Theme | None:
+    """Look up a theme by name and return a usable ``Theme`` instance.
+
+    Explicit registrations (subclasses + ``register_theme``) win over
+    entry-point discoveries.
+    """
+    normalized = _normalize_theme_name(name)
+
+    resolved = _lookup_explicit(normalized)
+    if resolved is not None:
+        return resolved
+
+    _ensure_entry_points()
+
+    # Loading an entry point's module may have triggered __init_subclass__
+    # on a Theme subclass, which populates the explicit registry. Re-check
+    # before falling back to the discovered registry.
+    resolved = _lookup_explicit(normalized)
+    if resolved is not None:
+        return resolved
+
+    discovered = _discovered_entry_point_themes.get(normalized)
+    if isinstance(discovered, type):
+        return discovered()
+    return discovered
+
+
+def _available_theme_names() -> tuple[str, ...]:
+    """Return all currently registered theme names."""
+    _ensure_entry_points()
+    names = (
+        set(_registered_theme_classes)
+        | set(_registered_theme_instances)
+        | set(_discovered_entry_point_themes)
+    )
+    return tuple(sorted(names))
+
+
+def _resolve_dotted_path(spec: str) -> type[Theme]:
+    """Resolve a ``'package.module:ClassName'`` spec to a ``Theme`` subclass."""
+    from .themes import Theme  # local import breaks circular dependency  # noqa: PLC0415
+
+    if ':' not in spec:
+        msg = f'Theme spec "{spec}" must use "package.module:ClassName" form.'
+        raise ValueError(msg)
+    module_path, _, class_name = spec.partition(':')
+    if not module_path or not class_name:
+        msg = f'Invalid theme spec "{spec}".'
+        raise ValueError(msg)
+    try:
+        module = import_module(module_path)
+    except ImportError as exc:
+        msg = f'Cannot import "{module_path}" from theme spec "{spec}": {exc}'
+        raise ValueError(msg) from exc
+    cls = getattr(module, class_name, None)
+    if cls is None:
+        msg = f'"{class_name}" not found in module "{module_path}".'
+        raise ValueError(msg)
+    if not (isinstance(cls, type) and issubclass(cls, Theme)):
+        # ValueError (not TypeError) keeps parity with the other dotted-path
+        # failure modes and lets _set_plot_theme_from_env catch it uniformly.
+        msg = f'"{spec}" does not resolve to a pyvista Theme subclass.'
+        raise ValueError(msg)  # noqa: TRY004
+    return cls
+
+
+def _ensure_entry_points() -> None:
+    """Discover ``pyvista.themes`` entry points once."""
+    global _entry_points_loaded  # noqa: PLW0603
+    if _entry_points_loaded:
+        return
+
+    _entry_points_loaded = True
+    for theme_entry_point in entry_points(group=THEME_ENTRY_POINT_GROUP):
+        source = theme_entry_point.value
+        try:
+            loaded = theme_entry_point.load()
+        except Exception as exc:  # noqa: BLE001
+            msg = (
+                f'Failed to load {THEME_ENTRY_POINT_GROUP} entry point '
+                f'"{theme_entry_point.name}" from {source}: {exc}'
+            )
+            warn_external(msg)
+            continue
+
+        if isinstance(loaded, Mapping):
+            for theme_name, theme_obj in loaded.items():
+                if not isinstance(theme_name, str):
+                    warn_external(
+                        f'Ignoring {THEME_ENTRY_POINT_GROUP} entry point from '
+                        f'{source}: theme names must be strings.',
+                    )
+                    continue
+                _register_discovered_theme(theme_name, theme_obj, source=source)
+            continue
+
+        _register_discovered_theme(theme_entry_point.name, loaded, source=source)
+
+
+def _register_discovered_theme(name: str, obj: object, *, source: str) -> None:
+    """Register an entry-point-discovered theme."""
+    from .themes import Theme  # local import breaks circular dependency  # noqa: PLC0415
+
+    normalized = _normalize_theme_name(name)
+    if not normalized:
+        warn_external(
+            f'Ignoring {THEME_ENTRY_POINT_GROUP} entry point from '
+            f'{source}: theme name must not be empty.',
+        )
+        return
+
+    if normalized in _registered_theme_classes or normalized in _registered_theme_instances:
+        # Explicit registration wins silently — user-owned registrations
+        # shouldn't be shouted at just because a plugin also defines it.
+        return
+
+    if normalized in _discovered_entry_point_themes:
+        existing = _discovered_entry_point_sources[normalized]
+        warn_external(
+            f'Multiple {THEME_ENTRY_POINT_GROUP} providers registered for '
+            f'"{normalized}": {existing}, {source}. Using {existing}.',
+        )
+        return
+
+    is_class = isinstance(obj, type) and issubclass(obj, Theme)
+    is_instance = isinstance(obj, Theme)
+    if not (is_class or is_instance):
+        warn_external(
+            f'Ignoring {THEME_ENTRY_POINT_GROUP} entry point "{normalized}" '
+            f'from {source}: value is not a pyvista Theme subclass or instance.',
+        )
+        return
+
+    # ``obj`` was just narrowed to ``type[Theme] | Theme`` by the
+    # ``is_class or is_instance`` check, but mypy can't see through the
+    # boolean union. Safe to assign.
+    _discovered_entry_point_themes[normalized] = obj  # type: ignore[assignment]
+    _discovered_entry_point_sources[normalized] = source

--- a/pyvista/plotting/theme_registry.py
+++ b/pyvista/plotting/theme_registry.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 THEME_ENTRY_POINT_GROUP = 'pyvista.themes'
 
 
-ThemeRegistrationKind = Literal['subclass', 'instance', 'entry_point', 'alias']
+ThemeRegistrationKind = Literal['subclass', 'entry_point', 'alias']
 
 
 class ThemeRegistration(NamedTuple):
@@ -27,9 +27,8 @@ class ThemeRegistration(NamedTuple):
 
     Returned by :func:`~pyvista.registered_themes`. ``kind`` distinguishes
     the registration path: a :class:`~pyvista.plotting.themes.Theme`
-    subclass with a class-level ``_default_name`` (``'subclass'``), an
-    instance passed to :func:`~pyvista.register_theme` (``'instance'``),
-    a ``pyvista.themes`` entry point from an installed plugin
+    subclass with a class-level ``_default_name`` (``'subclass'``), a
+    ``pyvista.themes`` entry point from an installed plugin
     (``'entry_point'``), or a built-in legacy alias such as ``'default'``
     or ``'vtk'`` (``'alias'``).
 
@@ -37,7 +36,7 @@ class ThemeRegistration(NamedTuple):
     ----------
     name : str
         The registered (normalized) theme name.
-    kind : {'subclass', 'instance', 'entry_point', 'alias'}
+    kind : {'subclass', 'entry_point', 'alias'}
         How the name was registered.
     source : str
         Human-readable origin (e.g. ``'my_package.theme.MyTheme'``).
@@ -63,8 +62,6 @@ class _ThemeRegistryState(TypedDict):
     classes: dict[str, type[Theme]]
     classes_sources: dict[str, str]
     aliases: set[str]
-    instances: dict[str, Theme]
-    instances_sources: dict[str, str]
     discovered: dict[str, type[Theme] | Theme]
     discovered_sources: dict[str, str]
     loaded: bool
@@ -73,8 +70,6 @@ class _ThemeRegistryState(TypedDict):
 _registered_theme_classes: dict[str, type[Theme]] = {}
 _registered_theme_classes_sources: dict[str, str] = {}
 _registered_theme_aliases: set[str] = set()
-_registered_theme_instances: dict[str, Theme] = {}
-_registered_theme_instances_sources: dict[str, str] = {}
 _discovered_entry_point_themes: dict[str, type[Theme] | Theme] = {}
 _discovered_entry_point_sources: dict[str, str] = {}
 _entry_points_loaded: bool = False
@@ -91,8 +86,6 @@ def _save_registry_state() -> _ThemeRegistryState:
         'classes': _registered_theme_classes.copy(),
         'classes_sources': _registered_theme_classes_sources.copy(),
         'aliases': _registered_theme_aliases.copy(),
-        'instances': _registered_theme_instances.copy(),
-        'instances_sources': _registered_theme_instances_sources.copy(),
         'discovered': _discovered_entry_point_themes.copy(),
         'discovered_sources': _discovered_entry_point_sources.copy(),
         'loaded': _entry_points_loaded,
@@ -108,24 +101,11 @@ def _restore_registry_state(state: _ThemeRegistryState) -> None:
     _registered_theme_classes_sources.update(state['classes_sources'])
     _registered_theme_aliases.clear()
     _registered_theme_aliases.update(state['aliases'])
-    _registered_theme_instances.clear()
-    _registered_theme_instances.update(state['instances'])
-    _registered_theme_instances_sources.clear()
-    _registered_theme_instances_sources.update(state['instances_sources'])
     _discovered_entry_point_themes.clear()
     _discovered_entry_point_themes.update(state['discovered'])
     _discovered_entry_point_sources.clear()
     _discovered_entry_point_sources.update(state['discovered_sources'])
     _entry_points_loaded = state['loaded']
-
-
-def _describe_existing(name: str) -> str:
-    """Return a human-readable source of the existing registration."""
-    if name in _registered_theme_classes_sources:
-        return _registered_theme_classes_sources[name]
-    if name in _registered_theme_instances_sources:
-        return _registered_theme_instances_sources[name]
-    return '<unknown>'
 
 
 def _register_theme_class(name: str, cls: type[Theme], *, source: str) -> None:
@@ -140,8 +120,8 @@ def _register_theme_class(name: str, cls: type[Theme], *, source: str) -> None:
             f'Theme class {source} declared an empty ``_default_name``; skipped.',
         )
         return
-    if normalized in _registered_theme_classes or normalized in _registered_theme_instances:
-        existing = _describe_existing(normalized)
+    if normalized in _registered_theme_classes:
+        existing = _registered_theme_classes_sources.get(normalized, '<unknown>')
         warn_external(
             f'Theme name "{normalized}" is already registered by {existing}; '
             f'ignoring duplicate registration from {source}.',
@@ -149,32 +129,6 @@ def _register_theme_class(name: str, cls: type[Theme], *, source: str) -> None:
         return
     _registered_theme_classes[normalized] = cls
     _registered_theme_classes_sources[normalized] = source
-
-
-def _register_theme_instance(name: str, instance: Theme, *, source: str, override: bool) -> None:
-    """Register a pre-configured ``Theme`` instance.
-
-    Collisions raise ``ValueError`` unless ``override=True``. This is
-    called from the public ``register_theme`` function, so loud failure
-    is the right behavior.
-    """
-    normalized = _normalize_theme_name(name)
-    if not normalized:
-        msg = 'Theme name must not be empty.'
-        raise ValueError(msg)
-    if not override and (
-        normalized in _registered_theme_classes or normalized in _registered_theme_instances
-    ):
-        existing = _describe_existing(normalized)
-        msg = (
-            f'Theme name "{normalized}" is already registered by {existing}. '
-            'Pass ``override=True`` to replace it.'
-        )
-        raise ValueError(msg)
-    _registered_theme_classes.pop(normalized, None)
-    _registered_theme_classes_sources.pop(normalized, None)
-    _registered_theme_instances[normalized] = instance
-    _registered_theme_instances_sources[normalized] = source
 
 
 def _register_alias(name: str, cls: type[Theme]) -> None:
@@ -190,22 +144,21 @@ def _register_alias(name: str, cls: type[Theme]) -> None:
 
 
 def _lookup_explicit(normalized: str) -> Theme | None:
-    """Look up a normalized name in the explicit registries.
+    """Look up a normalized name in the explicit subclass registry.
 
-    Classes are instantiated fresh; instances are returned as-is (the
-    caller uses ``load_theme`` which copies attributes into a target).
+    Classes are instantiated fresh every call so callers never share a
+    registered instance with the global theme.
     """
     cls = _registered_theme_classes.get(normalized)
     if cls is not None:
         return cls()
-    return _registered_theme_instances.get(normalized)
+    return None
 
 
 def _resolve_theme(name: str) -> Theme | None:
     """Look up a theme by name and return a usable ``Theme`` instance.
 
-    Explicit registrations (subclasses + ``register_theme``) win over
-    entry-point discoveries.
+    Explicit subclass registrations win over entry-point discoveries.
     """
     normalized = _normalize_theme_name(name)
 
@@ -231,11 +184,7 @@ def _resolve_theme(name: str) -> Theme | None:
 def _available_theme_names() -> tuple[str, ...]:
     """Return all currently registered theme names."""
     _ensure_entry_points()
-    names = (
-        set(_registered_theme_classes)
-        | set(_registered_theme_instances)
-        | set(_discovered_entry_point_themes)
-    )
+    names = set(_registered_theme_classes) | set(_discovered_entry_point_themes)
     return tuple(sorted(names))
 
 
@@ -283,12 +232,6 @@ def registered_themes() -> dict[str, ThemeRegistration]:
             name, f'{cls.__module__}.{cls.__qualname__}'
         )
         out[name] = ThemeRegistration(name=name, kind=kind, source=source)
-    for name in _registered_theme_instances:
-        out[name] = ThemeRegistration(
-            name=name,
-            kind='instance',
-            source=_registered_theme_instances_sources.get(name, '<unknown>'),
-        )
     for name in _discovered_entry_point_themes:
         if name in out:
             # Explicit registrations always win over entry-point providers.
@@ -374,7 +317,7 @@ def _register_discovered_theme(name: str, obj: object, *, source: str) -> None:
         )
         return
 
-    if normalized in _registered_theme_classes or normalized in _registered_theme_instances:
+    if normalized in _registered_theme_classes:
         # Explicit registration wins silently — user-owned registrations
         # shouldn't be shouted at just because a plugin also defines it.
         return

--- a/pyvista/plotting/theme_registry.py
+++ b/pyvista/plotting/theme_registry.py
@@ -19,9 +19,6 @@ if TYPE_CHECKING:
 THEME_ENTRY_POINT_GROUP = 'pyvista.themes'
 
 
-ThemeRegistrationKind = Literal['subclass', 'entry_point', 'alias']
-
-
 class ThemeRegistration(NamedTuple):
     """Describe how a theme name became registered.
 
@@ -52,7 +49,7 @@ class ThemeRegistration(NamedTuple):
     """
 
     name: str
-    kind: ThemeRegistrationKind
+    kind: Literal['subclass', 'entry_point', 'alias']
     source: str
 
 
@@ -227,7 +224,9 @@ def registered_themes() -> dict[str, ThemeRegistration]:
     _ensure_entry_points()
     out: dict[str, ThemeRegistration] = {}
     for name, cls in _registered_theme_classes.items():
-        kind: ThemeRegistrationKind = 'alias' if name in _registered_theme_aliases else 'subclass'
+        kind: Literal['subclass', 'alias'] = (
+            'alias' if name in _registered_theme_aliases else 'subclass'
+        )
         source = _registered_theme_classes_sources.get(
             name, f'{cls.__module__}.{cls.__qualname__}'
         )

--- a/pyvista/plotting/theme_registry.py
+++ b/pyvista/plotting/theme_registry.py
@@ -42,6 +42,14 @@ class ThemeRegistration(NamedTuple):
     source : str
         Human-readable origin (e.g. ``'my_package.theme.MyTheme'``).
 
+    Examples
+    --------
+    Inspect how a name became registered.
+
+    >>> import pyvista as pv
+    >>> pv.registered_themes()['dark']
+    ThemeRegistration(name='dark', kind='subclass', source='pyvista.plotting.themes.DarkTheme')
+
     """
 
     name: str
@@ -241,9 +249,9 @@ def registered_themes() -> dict[str, ThemeRegistration]:
 
     Returns
     -------
-    dict[str, ThemeRegistration]
-        Mapping of theme name to a :class:`ThemeRegistration` record
-        describing how the name was registered.
+    dict[str, pyvista.ThemeRegistration]
+        Mapping of theme name to a :class:`~pyvista.ThemeRegistration`
+        record describing how the name was registered.
 
     Examples
     --------

--- a/pyvista/plotting/theme_registry.py
+++ b/pyvista/plotting/theme_registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from importlib import import_module
+from importlib.metadata import EntryPoint
 from importlib.metadata import entry_points
 from typing import TYPE_CHECKING
 from typing import Literal
@@ -11,6 +12,7 @@ from typing import NamedTuple
 from typing import TypedDict
 
 from pyvista._warn_external import warn_external
+from pyvista.core.utilities._registry_helpers import handler_source
 
 if TYPE_CHECKING:
     from .themes import Theme
@@ -43,7 +45,7 @@ class ThemeRegistration(NamedTuple):
     Inspect how a name became registered.
 
     >>> import pyvista as pv
-    >>> pv.registered_themes()['dark']
+    >>> next(r for r in pv.registered_themes() if r.name == 'dark')
     ThemeRegistration(name='dark', kind='subclass', source='pyvista.plotting.themes.DarkTheme')
 
     """
@@ -61,6 +63,7 @@ class _ThemeRegistryState(TypedDict):
     aliases: set[str]
     discovered: dict[str, type[Theme] | Theme]
     discovered_sources: dict[str, str]
+    pending: dict[str, list[EntryPoint]]
     loaded: bool
 
 
@@ -69,6 +72,12 @@ _registered_theme_classes_sources: dict[str, str] = {}
 _registered_theme_aliases: set[str] = set()
 _discovered_entry_point_themes: dict[str, type[Theme] | Theme] = {}
 _discovered_entry_point_sources: dict[str, str] = {}
+# Entry-point metadata, populated by ``_ensure_entry_points``. Maps each
+# theme name to the list of ``EntryPoint`` records that declared it. The
+# plugin module itself is *not* imported until that name is actually
+# requested via :func:`_resolve_theme`, keeping ``set_plot_theme`` calls
+# for built-in themes free of third-party plugin import cost.
+_pending_ep_themes: dict[str, list[EntryPoint]] = {}
 _entry_points_loaded: bool = False
 
 
@@ -85,6 +94,7 @@ def _save_registry_state() -> _ThemeRegistryState:
         'aliases': _registered_theme_aliases.copy(),
         'discovered': _discovered_entry_point_themes.copy(),
         'discovered_sources': _discovered_entry_point_sources.copy(),
+        'pending': {k: list(v) for k, v in _pending_ep_themes.items()},
         'loaded': _entry_points_loaded,
     }
 
@@ -102,6 +112,8 @@ def _restore_registry_state(state: _ThemeRegistryState) -> None:
     _discovered_entry_point_themes.update(state['discovered'])
     _discovered_entry_point_sources.clear()
     _discovered_entry_point_sources.update(state['discovered_sources'])
+    _pending_ep_themes.clear()
+    _pending_ep_themes.update({k: list(v) for k, v in state['pending'].items()})
     _entry_points_loaded = state['loaded']
 
 
@@ -109,7 +121,8 @@ def _register_theme_class(name: str, cls: type[Theme], *, source: str) -> None:
     """Register a ``Theme`` subclass. Called from ``Theme.__init_subclass__``.
 
     Collisions warn (do not raise) so that a subclass definition at
-    import time cannot crash the interpreter.
+    import time cannot crash the interpreter. Last wins, mirroring the
+    behavior of every other PyVista plugin registry.
     """
     normalized = _normalize_theme_name(name)
     if not normalized:
@@ -120,10 +133,9 @@ def _register_theme_class(name: str, cls: type[Theme], *, source: str) -> None:
     if normalized in _registered_theme_classes:
         existing = _registered_theme_classes_sources.get(normalized, '<unknown>')
         warn_external(
-            f'Theme name "{normalized}" is already registered by {existing}; '
-            f'ignoring duplicate registration from {source}.',
+            f'Registering theme "{normalized}" from {source} replaces an '
+            f'existing registration from {existing}.',
         )
-        return
     _registered_theme_classes[normalized] = cls
     _registered_theme_classes_sources[normalized] = source
 
@@ -136,7 +148,7 @@ def _register_alias(name: str, cls: type[Theme]) -> None:
     """
     normalized = _normalize_theme_name(name)
     _registered_theme_classes[normalized] = cls
-    _registered_theme_classes_sources[normalized] = f'{cls.__module__}.{cls.__qualname__}'
+    _registered_theme_classes_sources[normalized] = handler_source(cls)
     _registered_theme_aliases.add(normalized)
 
 
@@ -152,10 +164,20 @@ def _lookup_explicit(normalized: str) -> Theme | None:
     return None
 
 
+def _lookup_discovered(normalized: str) -> Theme | None:
+    """Look up a normalized name in the loaded entry-point registry."""
+    discovered = _discovered_entry_point_themes.get(normalized)
+    if isinstance(discovered, type):
+        return discovered()
+    return discovered
+
+
 def _resolve_theme(name: str) -> Theme | None:
     """Look up a theme by name and return a usable ``Theme`` instance.
 
     Explicit subclass registrations win over entry-point discoveries.
+    Entry-point plugins are imported lazily — only the plugin claiming
+    *name* loads, sibling plugins stay pending.
     """
     normalized = _normalize_theme_name(name)
 
@@ -165,28 +187,51 @@ def _resolve_theme(name: str) -> Theme | None:
 
     _ensure_entry_points()
 
+    # Fast path: load the plugin claiming this exact name.
+    if normalized in _pending_ep_themes:
+        _resolve_pending_theme(normalized)
+
     # Loading an entry point's module may have triggered __init_subclass__
     # on a Theme subclass, which populates the explicit registry. Re-check
     # before falling back to the discovered registry.
     resolved = _lookup_explicit(normalized)
     if resolved is not None:
         return resolved
+    resolved = _lookup_discovered(normalized)
+    if resolved is not None:
+        return resolved
 
-    discovered = _discovered_entry_point_themes.get(normalized)
-    if isinstance(discovered, type):
-        return discovered()
-    return discovered
+    # Final fallback: a Mapping-style entry point may expose names that
+    # differ from its ``ep.name``. The fast path above only matches by
+    # ``ep.name``, so resolve any remaining pending EPs as a last resort.
+    for pending_name in list(_pending_ep_themes):
+        _resolve_pending_theme(pending_name)
+        resolved = _lookup_explicit(normalized)
+        if resolved is not None:
+            return resolved
+        resolved = _lookup_discovered(normalized)
+        if resolved is not None:
+            return resolved
+    return None
 
 
 def _available_theme_names() -> tuple[str, ...]:
-    """Return all currently registered theme names."""
+    """Return all currently registered theme names.
+
+    Pending entry-point names appear in the result without triggering
+    plugin imports — only metadata is consulted.
+    """
     _ensure_entry_points()
-    names = set(_registered_theme_classes) | set(_discovered_entry_point_themes)
+    names = (
+        set(_registered_theme_classes)
+        | set(_discovered_entry_point_themes)
+        | set(_pending_ep_themes)
+    )
     return tuple(sorted(names))
 
 
-def registered_themes() -> dict[str, ThemeRegistration]:
-    """Return all registered themes, keyed by name.
+def registered_themes() -> tuple[ThemeRegistration, ...]:
+    """Return all registered themes.
 
     Use this to discover which names can be passed to
     :func:`~pyvista.set_plot_theme` or the ``PYVISTA_PLOT_THEME``
@@ -195,17 +240,17 @@ def registered_themes() -> dict[str, ThemeRegistration]:
 
     Returns
     -------
-    dict[str, pyvista.ThemeRegistration]
-        Mapping of theme name to a :class:`~pyvista.ThemeRegistration`
-        record describing how the name was registered.
+    tuple[pyvista.ThemeRegistration, ...]
+        One record per registered theme, sorted by name. Each record
+        exposes ``name``, ``kind``, and ``source``.
 
     Examples
     --------
     List available theme names.
 
     >>> import pyvista as pv
-    >>> for name in sorted(pv.registered_themes()):
-    ...     print(name)
+    >>> for record in pv.registered_themes():
+    ...     print(record.name)
     dark
     default
     document
@@ -217,30 +262,36 @@ def registered_themes() -> dict[str, ThemeRegistration]:
 
     Inspect how a name became registered.
 
-    >>> pv.registered_themes()['dark'].kind
+    >>> next(r for r in pv.registered_themes() if r.name == 'dark').kind
     'subclass'
 
     """
     _ensure_entry_points()
-    out: dict[str, ThemeRegistration] = {}
+    # Force every pending plugin to load so the result reflects every
+    # theme visible to PyVista. A plugin that fails to import emits a
+    # ``UserWarning`` and is skipped; the rest still appear.
+    for pending_name in list(_pending_ep_themes):
+        _resolve_pending_theme(pending_name)
+    records: list[ThemeRegistration] = []
     for name, cls in _registered_theme_classes.items():
         kind: Literal['subclass', 'alias'] = (
             'alias' if name in _registered_theme_aliases else 'subclass'
         )
-        source = _registered_theme_classes_sources.get(
-            name, f'{cls.__module__}.{cls.__qualname__}'
-        )
-        out[name] = ThemeRegistration(name=name, kind=kind, source=source)
+        source = _registered_theme_classes_sources.get(name, handler_source(cls))
+        records.append(ThemeRegistration(name=name, kind=kind, source=source))
+    seen = {r.name for r in records}
     for name in _discovered_entry_point_themes:
-        if name in out:
+        if name in seen:
             # Explicit registrations always win over entry-point providers.
             continue
-        out[name] = ThemeRegistration(
-            name=name,
-            kind='entry_point',
-            source=_discovered_entry_point_sources.get(name, '<unknown>'),
+        records.append(
+            ThemeRegistration(
+                name=name,
+                kind='entry_point',
+                source=_discovered_entry_point_sources.get(name, '<unknown>'),
+            )
         )
-    return dict(sorted(out.items()))
+    return tuple(sorted(records, key=lambda r: r.name))
 
 
 def _resolve_dotted_path(spec: str) -> type[Theme]:
@@ -272,36 +323,88 @@ def _resolve_dotted_path(spec: str) -> type[Theme]:
 
 
 def _ensure_entry_points() -> None:
-    """Discover ``pyvista.themes`` entry points once."""
+    """Scan ``pyvista.themes`` entry-point metadata once.
+
+    Populates :data:`_pending_ep_themes` with every name declared by an
+    installed plugin. The plugin modules themselves are **not** imported
+    here; the cost is one ``importlib.metadata.entry_points`` call.
+    Plugin imports are deferred to :func:`_resolve_pending_theme`, which
+    runs only when a theme with that specific name is actually requested.
+    """
     global _entry_points_loaded  # noqa: PLW0603
     if _entry_points_loaded:
         return
-
     _entry_points_loaded = True
-    for theme_entry_point in entry_points(group=THEME_ENTRY_POINT_GROUP):
-        source = theme_entry_point.value
-        try:
-            loaded = theme_entry_point.load()
-        except Exception as exc:  # noqa: BLE001
-            msg = (
-                f'Failed to load {THEME_ENTRY_POINT_GROUP} entry point '
-                f'"{theme_entry_point.name}" from {source}: {exc}'
+
+    for ep in entry_points(group=THEME_ENTRY_POINT_GROUP):
+        normalized = _normalize_theme_name(ep.name)
+        if not normalized:
+            warn_external(
+                f'Ignoring {THEME_ENTRY_POINT_GROUP} entry point from '
+                f'{ep.value}: theme name must not be empty.',
             )
-            warn_external(msg)
             continue
-
-        if isinstance(loaded, Mapping):
-            for theme_name, theme_obj in loaded.items():
-                if not isinstance(theme_name, str):
-                    warn_external(
-                        f'Ignoring {THEME_ENTRY_POINT_GROUP} entry point from '
-                        f'{source}: theme names must be strings.',
-                    )
-                    continue
-                _register_discovered_theme(theme_name, theme_obj, source=source)
+        if normalized in _registered_theme_classes:
+            # Explicit registration wins silently — user-owned registrations
+            # shouldn't be shouted at just because a plugin also defines it.
             continue
+        _pending_ep_themes.setdefault(normalized, []).append(ep)
 
-        _register_discovered_theme(theme_entry_point.name, loaded, source=source)
+
+def _resolve_pending_theme(name: str) -> bool:
+    """Import the plugin claiming *name*, if any.
+
+    Returns
+    -------
+    bool
+        ``True`` if a plugin loaded successfully and contributed at least
+        one registration. ``False`` if no pending plugin matches, or if
+        the plugin failed to import.
+
+    Notes
+    -----
+    A plugin that fails to import emits a ``UserWarning`` and is dropped
+    from the pending list, so subsequent lookups of the same name fall
+    straight through without re-triggering the import or re-emitting the
+    warning.
+
+    """
+    eps = _pending_ep_themes.pop(name, None)
+    if not eps:
+        return False
+    winner = eps[0]
+    source = winner.value
+    try:
+        # ep.load() runs third-party import machinery — it can raise
+        # literally anything. Convert to a warning so one broken plugin
+        # cannot take down every theme lookup.
+        loaded = winner.load()
+    except Exception as exc:  # noqa: BLE001
+        warn_external(
+            f'Failed to load {THEME_ENTRY_POINT_GROUP} entry point '
+            f'"{winner.name}" from {source}: {exc}',
+        )
+        return False
+
+    if isinstance(loaded, Mapping):
+        for theme_name, theme_obj in loaded.items():
+            if not isinstance(theme_name, str):
+                warn_external(
+                    f'Ignoring {THEME_ENTRY_POINT_GROUP} entry point from '
+                    f'{source}: theme names must be strings.',
+                )
+                continue
+            _register_discovered_theme(theme_name, theme_obj, source=source)
+    else:
+        _register_discovered_theme(winner.name, loaded, source=source)
+
+    if len(eps) > 1:
+        providers = ', '.join(ep.value for ep in eps)
+        warn_external(
+            f'Multiple {THEME_ENTRY_POINT_GROUP} providers registered for '
+            f'"{name}": {providers}. Using {source}.',
+        )
+    return name in _registered_theme_classes or name in _discovered_entry_point_themes
 
 
 def _register_discovered_theme(name: str, obj: object, *, source: str) -> None:

--- a/pyvista/plotting/theme_registry.py
+++ b/pyvista/plotting/theme_registry.py
@@ -37,8 +37,8 @@ class ThemeRegistration(NamedTuple):
     ----------
     name : str
         The registered (normalized) theme name.
-    kind : str
-        One of ``'subclass'``, ``'instance'``, ``'entry_point'``, ``'alias'``.
+    kind : {'subclass', 'instance', 'entry_point', 'alias'}
+        How the name was registered.
     source : str
         Human-readable origin (e.g. ``'my_package.theme.MyTheme'``).
 

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -204,6 +204,15 @@ def register_theme(name: str, theme: Any, *, override: bool = False) -> Theme:
     register an already-configured instance (e.g., a mutated copy of
     ``DarkTheme``) under a custom name.
 
+    Notes
+    -----
+    Both this function and subclass-based registration require the
+    defining module to be imported before the name resolves. This is
+    convenient for scripts, notebooks, and testing, but plugin packages
+    that want their themes discovered without a user ``import`` should
+    declare a ``pyvista.themes`` entry point instead — see
+    :class:`~pyvista.plotting.themes.Theme` for details.
+
     Parameters
     ----------
     name : str
@@ -1769,14 +1778,19 @@ class Theme(_ConfigBase):
     ``_default_name`` are not registered, so ad-hoc subclasses remain
     a valid pattern.
 
-    Plugin packages can expose additional themes under the
-    ``pyvista.themes`` entry-point group without requiring users to
-    import the package first:
+    For plugin packages distributing themes, the recommended path is to
+    declare a ``pyvista.themes`` entry point so the theme is discovered
+    without requiring users to import the package first:
 
     .. code-block:: toml
 
         [project.entry-points.'pyvista.themes']
         my_theme = 'my_package.theme:MyTheme'
+
+    Subclass-based auto-registration and :func:`~pyvista.register_theme`
+    require the defining module to be imported before the name resolves.
+    They are primarily useful for scripts, notebooks, testing, and local
+    development; plugin packages should prefer the entry-point path.
 
     Examples
     --------
@@ -1834,7 +1848,6 @@ class Theme(_ConfigBase):
             cls,
             source=f'{cls.__module__}.{cls.__qualname__}',
         )
-
 
     __slots__ = [
         '_above_range_color',

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -186,7 +186,7 @@ def set_plot_theme(theme):
         raise TypeError(msg)
 
 
-def register_theme(name: str, theme: Theme, *, override: bool = False) -> Theme:
+def register_theme(name: str, theme: Any, *, override: bool = False) -> Theme:
     """Register a pre-configured :class:`~pyvista.plotting.themes.Theme` instance.
 
     Once registered, the theme can be activated by name via

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -55,7 +55,6 @@ from .opts import PointSpriteShape
 from .theme_registry import _available_theme_names
 from .theme_registry import _register_alias
 from .theme_registry import _register_theme_class
-from .theme_registry import _register_theme_instance
 from .theme_registry import _resolve_dotted_path
 from .theme_registry import _resolve_theme
 from .tools import parse_font_family
@@ -122,8 +121,8 @@ def set_plot_theme(theme):
         * A registered theme name. Built-in names include ``'dark'``,
           ``'default'``, ``'document'``, ``'document_build'``,
           ``'document_pro'``, ``'paraview'``, ``'testing'``, and
-          ``'vtk'``. Third-party plugins and
-          :func:`~pyvista.register_theme` can add more. Use
+          ``'vtk'``. Third-party plugins can add more via the
+          ``pyvista.themes`` entry-point group. Use
           :func:`~pyvista.registered_themes` to list everything that is
           currently available.
         * A ``"package.module:ClassName"`` dotted path to any importable
@@ -134,9 +133,6 @@ def set_plot_theme(theme):
     --------
     pyvista.registered_themes
         List all registered theme names.
-    pyvista.register_theme
-        Register a pre-configured :class:`Theme` instance under a
-        custom name.
     pyvista.plotting.themes.Theme
         Base class. Subclasses with a class-level ``_default_name`` are
         discoverable by name; see the class docstring for details aimed
@@ -189,88 +185,6 @@ def set_plot_theme(theme):
             f'Expected a ``pyvista.plotting.themes.Theme`` or ``str``, not {type(theme).__name__}'
         )
         raise TypeError(msg)
-
-
-def register_theme(name: str, theme: Any, *, override: bool = False) -> Theme:
-    """Register a pre-configured :class:`~pyvista.plotting.themes.Theme` instance.
-
-    Once registered, the theme can be activated by name via
-    :func:`~pyvista.set_plot_theme` or by setting the
-    ``PYVISTA_PLOT_THEME`` environment variable.
-
-    Subclass-based registration is automatic via
-    ``Theme.__init_subclass__`` when the subclass declares a
-    class-level ``_default_name``. Use this function when you want to
-    register an already-configured instance (e.g., a mutated copy of
-    ``DarkTheme``) under a custom name.
-
-    Notes
-    -----
-    Both this function and subclass-based registration require the
-    defining module to be imported before the name resolves. This is
-    convenient for scripts, notebooks, and testing, but plugin packages
-    that want their themes discovered without a user ``import`` should
-    declare a ``pyvista.themes`` entry point instead — see
-    :class:`~pyvista.plotting.themes.Theme` for details.
-
-    Parameters
-    ----------
-    name : str
-        Name to register the theme under.
-
-    theme : Theme
-        A pre-configured :class:`~pyvista.plotting.themes.Theme` instance.
-
-    override : bool, default: False
-        If ``True``, replace any existing registration with the same name.
-        If ``False`` and the name is already registered, a ``ValueError``
-        is raised.
-
-    Returns
-    -------
-    Theme
-        The registered theme instance.
-
-    Raises
-    ------
-    TypeError
-        If ``theme`` is not a :class:`~pyvista.plotting.themes.Theme`
-        instance.
-
-    ValueError
-        If ``name`` is empty, or if the name is already registered and
-        ``override`` is ``False``.
-
-    Examples
-    --------
-    Register a customized dark theme under a custom name.
-
-    >>> import pyvista as pv
-    >>> from pyvista.plotting.themes import DarkTheme
-    >>> custom = DarkTheme()
-    >>> custom.show_edges = True
-    >>> _ = pv.register_theme('dark_edges', custom)
-    >>> pv.set_plot_theme('dark_edges')
-
-    """
-    if isinstance(theme, type):
-        msg = (
-            f'register_theme expects a Theme instance, got class '
-            f'{theme.__name__}. For Theme subclasses, declare '
-            "'_default_name' as a class attribute and they register "
-            'automatically.'
-        )
-        raise TypeError(msg)
-    if not isinstance(theme, Theme):
-        msg = f'register_theme expects a pyvista Theme instance, got {type(theme).__name__}.'
-        raise TypeError(msg)
-    _register_theme_instance(
-        name,
-        theme,
-        source=f'register_theme({name!r})',
-        override=override,
-    )
-    return theme
 
 
 class _LightingConfig(_ConfigBase):
@@ -1787,10 +1701,10 @@ class Theme(_ConfigBase):
         [project.entry-points.'pyvista.themes']
         my_theme = 'my_package.theme:MyTheme'
 
-    Subclass-based auto-registration and :func:`~pyvista.register_theme`
-    require the defining module to be imported before the name resolves.
-    They are primarily useful for scripts, notebooks, testing, and local
-    development; plugin packages should prefer the entry-point path.
+    Subclass-based auto-registration requires the defining module to be
+    imported before the name resolves, so it is primarily useful for
+    scripts, notebooks, testing, and local development. Plugin packages
+    should prefer the entry-point path.
 
     Examples
     --------

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -112,30 +112,35 @@ def load_theme(filename):
 
 
 def set_plot_theme(theme):
-    """Set the plotting parameters to a predefined theme using a string.
+    """Set plotting parameters to a predefined theme using a string or ``Theme``.
 
     Parameters
     ----------
     theme : str | Theme
-        The theme name or :class:`~pyvista.plotting.themes.Theme` instance.
-        Built-in theme names include:
+        Theme to apply. Accepts any of:
 
-        - ``'dark'``,
-        - ``'default'``,
-        - ``'document'``,
-        - ``'document_build'``,
-        - ``'document_pro'``,
-        - ``'paraview'``,
-        - ``'testing'`` and
-        - ``'vtk'``.
+        * A registered theme name. Built-in names include ``'dark'``,
+          ``'default'``, ``'document'``, ``'document_build'``,
+          ``'document_pro'``, ``'paraview'``, ``'testing'``, and
+          ``'vtk'``. Third-party plugins and
+          :func:`~pyvista.register_theme` can add more. Use
+          :func:`~pyvista.registered_themes` to list everything that is
+          currently available.
+        * A ``"package.module:ClassName"`` dotted path to any importable
+          :class:`~pyvista.plotting.themes.Theme` subclass.
+        * A :class:`~pyvista.plotting.themes.Theme` instance.
 
-        Any :class:`~pyvista.plotting.themes.Theme` subclass that declares
-        a class-level ``_default_name`` is registered automatically and can
-        be referenced by that name. Pre-configured instances can be
-        registered with :func:`~pyvista.register_theme`.
-
-        A theme class from any importable module can also be loaded using a
-        ``"package.module:ClassName"`` string.
+    See Also
+    --------
+    registered_themes
+        List all registered theme names.
+    register_theme
+        Register a pre-configured :class:`~pyvista.plotting.themes.Theme`
+        instance under a custom name.
+    pyvista.plotting.themes.Theme
+        Base class. Subclasses with a class-level ``_default_name`` are
+        discoverable by name; see the class docstring for details aimed
+        at theme authors and plugin packages.
 
     Examples
     --------
@@ -1750,11 +1755,28 @@ class _PlotCellConfig(_ConfigBase):
 class Theme(_ConfigBase):
     """Base VTK theme.
 
+    Notes
+    -----
+    This section is aimed at theme authors and plugin package
+    maintainers; end users calling :func:`set_plot_theme` do not need
+    any of it.
+
     Subclasses that declare a class-level ``_default_name`` are
     automatically registered by that name via
     :meth:`__init_subclass__` and become available through
-    :func:`set_plot_theme` and the ``PYVISTA_PLOT_THEME`` environment
-    variable.
+    :func:`set_plot_theme`, the ``PYVISTA_PLOT_THEME`` environment
+    variable, and :func:`~pyvista.registered_themes`. Subclasses
+    without ``_default_name`` are not registered, so ad-hoc subclasses
+    remain a valid pattern.
+
+    Plugin packages can expose additional themes under the
+    ``pyvista.themes`` entry-point group without requiring users to
+    import the package first:
+
+    .. code-block:: toml
+
+        [project.entry-points.'pyvista.themes']
+        my_theme = 'my_package.theme:MyTheme'
 
     Examples
     --------

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -135,9 +135,9 @@ def set_plot_theme(theme):
     registered_themes
         List all registered theme names.
     register_theme
-        Register a pre-configured :class:`~pyvista.plotting.themes.Theme`
-        instance under a custom name.
-    pyvista.plotting.themes.Theme
+        Register a pre-configured :class:`Theme` instance under a
+        custom name.
+    Theme
         Base class. Subclasses with a class-level ``_default_name`` are
         discoverable by name; see the class docstring for details aimed
         at theme authors and plugin packages.

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -132,12 +132,12 @@ def set_plot_theme(theme):
 
     See Also
     --------
-    registered_themes
+    pyvista.registered_themes
         List all registered theme names.
-    register_theme
+    pyvista.register_theme
         Register a pre-configured :class:`Theme` instance under a
         custom name.
-    Theme
+    pyvista.plotting.themes.Theme
         Base class. Subclasses with a class-level ``_default_name`` are
         discoverable by name; see the class docstring for details aimed
         at theme authors and plugin packages.
@@ -195,14 +195,14 @@ def register_theme(name: str, theme: Any, *, override: bool = False) -> Theme:
     """Register a pre-configured :class:`~pyvista.plotting.themes.Theme` instance.
 
     Once registered, the theme can be activated by name via
-    :func:`set_plot_theme` or by setting the ``PYVISTA_PLOT_THEME``
-    environment variable.
+    :func:`~pyvista.set_plot_theme` or by setting the
+    ``PYVISTA_PLOT_THEME`` environment variable.
 
     Subclass-based registration is automatic via
-    :meth:`Theme.__init_subclass__` when the subclass declares a class-level
-    ``_default_name``. Use this function when you want to register an
-    already-configured instance (e.g., a mutated copy of ``DarkTheme``)
-    under a custom name.
+    ``Theme.__init_subclass__`` when the subclass declares a
+    class-level ``_default_name``. Use this function when you want to
+    register an already-configured instance (e.g., a mutated copy of
+    ``DarkTheme``) under a custom name.
 
     Parameters
     ----------
@@ -1758,16 +1758,16 @@ class Theme(_ConfigBase):
     Notes
     -----
     This section is aimed at theme authors and plugin package
-    maintainers; end users calling :func:`set_plot_theme` do not need
-    any of it.
+    maintainers; end users calling :func:`~pyvista.set_plot_theme` do
+    not need any of it.
 
     Subclasses that declare a class-level ``_default_name`` are
-    automatically registered by that name via
-    :meth:`__init_subclass__` and become available through
-    :func:`set_plot_theme`, the ``PYVISTA_PLOT_THEME`` environment
-    variable, and :func:`~pyvista.registered_themes`. Subclasses
-    without ``_default_name`` are not registered, so ad-hoc subclasses
-    remain a valid pattern.
+    automatically registered by that name via ``__init_subclass__``
+    and become available through :func:`~pyvista.set_plot_theme`, the
+    ``PYVISTA_PLOT_THEME`` environment variable, and
+    :func:`~pyvista.registered_themes`. Subclasses without
+    ``_default_name`` are not registered, so ad-hoc subclasses remain
+    a valid pattern.
 
     Plugin packages can expose additional themes under the
     ``pyvista.themes`` entry-point group without requiring users to

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -38,6 +38,7 @@ import os
 import pathlib
 from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import ClassVar
 
 import pyvista  # noqa: TC001
@@ -51,6 +52,12 @@ from .colors import get_cycler
 from .interactor_style_registry import _validate_interactor_style
 from .opts import InterpolationType
 from .opts import PointSpriteShape
+from .theme_registry import _available_theme_names
+from .theme_registry import _register_alias
+from .theme_registry import _register_theme_class
+from .theme_registry import _register_theme_instance
+from .theme_registry import _resolve_dotted_path
+from .theme_registry import _resolve_theme
 from .tools import parse_font_family
 
 if TYPE_CHECKING:
@@ -65,14 +72,15 @@ if TYPE_CHECKING:
 def _set_plot_theme_from_env() -> None:
     """Set plot theme from an environment variable."""
     if 'PYVISTA_PLOT_THEME' in os.environ:
+        theme = os.environ['PYVISTA_PLOT_THEME']
         try:
-            theme = os.environ['PYVISTA_PLOT_THEME']
-            set_plot_theme(theme.lower())
+            # Dotted paths are case-sensitive; registered names are lowercased.
+            set_plot_theme(theme if ':' in theme else theme.lower())
         except ValueError:
-            allowed = ', '.join([item.name for item in _NATIVE_THEMES])
+            allowed = ', '.join(_available_theme_names())
             warn_external(
                 f'\n\nInvalid PYVISTA_PLOT_THEME environment variable "{theme}". '
-                f'Should be one of the following: {allowed}',
+                f'Should be one of {{ {allowed} }} or "package.module:ClassName".',
             )
 
 
@@ -108,8 +116,9 @@ def set_plot_theme(theme):
 
     Parameters
     ----------
-    theme : str
-        The theme name.  Available predefined theme names include:
+    theme : str | Theme
+        The theme name or :class:`~pyvista.plotting.themes.Theme` instance.
+        Built-in theme names include:
 
         - ``'dark'``,
         - ``'default'``,
@@ -119,6 +128,14 @@ def set_plot_theme(theme):
         - ``'paraview'``,
         - ``'testing'`` and
         - ``'vtk'``.
+
+        Any :class:`~pyvista.plotting.themes.Theme` subclass that declares
+        a class-level ``_default_name`` is registered automatically and can
+        be referenced by that name. Pre-configured instances can be
+        registered with :func:`~pyvista.register_theme`.
+
+        A theme class from any importable module can also be loaded using a
+        ``"package.module:ClassName"`` string.
 
     Examples
     --------
@@ -139,17 +156,27 @@ def set_plot_theme(theme):
 
     >>> pv.set_plot_theme('paraview')
 
+    Load a theme from any importable module using a dotted path.
+
+    >>> pv.set_plot_theme('pyvista.plotting.themes:DarkTheme')
+
     """
     import pyvista  # noqa: PLC0415
 
     if isinstance(theme, str):
-        theme = theme.lower()
-        try:
-            new_theme_type = _NATIVE_THEMES[theme].value
-        except KeyError:
-            msg = f"Theme {theme} not found in PyVista's native themes."
+        if ':' in theme:
+            cls = _resolve_dotted_path(theme)
+            pyvista.global_theme.load_theme(cls())
+            return
+        resolved = _resolve_theme(theme)
+        if resolved is None:
+            allowed = ', '.join(_available_theme_names())
+            msg = (
+                f'Theme "{theme}" not found. Available themes: {allowed}. '
+                'To load from an arbitrary module use "package.module:ClassName".'
+            )
             raise ValueError(msg)
-        pyvista.global_theme.load_theme(new_theme_type())
+        pyvista.global_theme.load_theme(resolved)
     elif isinstance(theme, Theme):
         pyvista.global_theme.load_theme(theme)
     else:
@@ -157,6 +184,79 @@ def set_plot_theme(theme):
             f'Expected a ``pyvista.plotting.themes.Theme`` or ``str``, not {type(theme).__name__}'
         )
         raise TypeError(msg)
+
+
+def register_theme(name: str, theme: Theme, *, override: bool = False) -> Theme:
+    """Register a pre-configured :class:`~pyvista.plotting.themes.Theme` instance.
+
+    Once registered, the theme can be activated by name via
+    :func:`set_plot_theme` or by setting the ``PYVISTA_PLOT_THEME``
+    environment variable.
+
+    Subclass-based registration is automatic via
+    :meth:`Theme.__init_subclass__` when the subclass declares a class-level
+    ``_default_name``. Use this function when you want to register an
+    already-configured instance (e.g., a mutated copy of ``DarkTheme``)
+    under a custom name.
+
+    Parameters
+    ----------
+    name : str
+        Name to register the theme under.
+
+    theme : Theme
+        A pre-configured :class:`~pyvista.plotting.themes.Theme` instance.
+
+    override : bool, default: False
+        If ``True``, replace any existing registration with the same name.
+        If ``False`` and the name is already registered, a ``ValueError``
+        is raised.
+
+    Returns
+    -------
+    Theme
+        The registered theme instance.
+
+    Raises
+    ------
+    TypeError
+        If ``theme`` is not a :class:`~pyvista.plotting.themes.Theme`
+        instance.
+
+    ValueError
+        If ``name`` is empty, or if the name is already registered and
+        ``override`` is ``False``.
+
+    Examples
+    --------
+    Register a customized dark theme under a custom name.
+
+    >>> import pyvista as pv
+    >>> from pyvista.plotting.themes import DarkTheme
+    >>> custom = DarkTheme()
+    >>> custom.show_edges = True
+    >>> _ = pv.register_theme('dark_edges', custom)
+    >>> pv.set_plot_theme('dark_edges')
+
+    """
+    if isinstance(theme, type):
+        msg = (
+            f'register_theme expects a Theme instance, got class '
+            f'{theme.__name__}. For Theme subclasses, declare '
+            "'_default_name' as a class attribute and they register "
+            'automatically.'
+        )
+        raise TypeError(msg)
+    if not isinstance(theme, Theme):
+        msg = f'register_theme expects a pyvista Theme instance, got {type(theme).__name__}.'
+        raise TypeError(msg)
+    _register_theme_instance(
+        name,
+        theme,
+        source=f'register_theme({name!r})',
+        override=override,
+    )
+    return theme
 
 
 class _LightingConfig(_ConfigBase):
@@ -1650,6 +1750,12 @@ class _PlotCellConfig(_ConfigBase):
 class Theme(_ConfigBase):
     """Base VTK theme.
 
+    Subclasses that declare a class-level ``_default_name`` are
+    automatically registered by that name via
+    :meth:`__init_subclass__` and become available through
+    :func:`set_plot_theme` and the ``PYVISTA_PLOT_THEME`` environment
+    variable.
+
     Examples
     --------
     Change the global default background color to white.
@@ -1669,11 +1775,44 @@ class Theme(_ConfigBase):
     >>> my_theme.background = 'white'
     >>> pv.global_theme.load_theme(my_theme)
 
+    Define a custom theme that auto-registers under a name.
+
+    >>> from typing import ClassVar
+    >>> class MyTheme(DocumentTheme):
+    ...     _default_name: ClassVar[str] = 'my_theme'
+    >>> pv.set_plot_theme('my_theme')  # doctest: +SKIP
+
     """
 
     # ``_plot_cell`` is an internal-only sub-config — exclude it from
     # ``to_dict`` output so themes serialize/deserialize round-trip cleanly.
     _TO_DICT_SKIP: ClassVar[frozenset[str]] = frozenset({'plot_cell'})
+
+    _default_name: ClassVar[str | None] = None
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Auto-register ``Theme`` subclasses by ``_default_name``."""
+        super().__init_subclass__(**kwargs)
+        # Read from __dict__ directly so inherited _default_name does not
+        # accidentally re-register a parent theme's name.
+        if '_default_name' not in cls.__dict__:
+            # Subclass does not opt into name-based discovery. Silent skip —
+            # ad-hoc subclasses are a valid pattern.
+            return
+        name = cls.__dict__['_default_name']
+        if not isinstance(name, str) or not name:
+            warn_external(
+                f'Theme subclass {cls.__module__}.{cls.__qualname__} declared '
+                f"an invalid '_default_name' ({name!r}); expected a non-empty "
+                'string. The subclass will not be discoverable by name.',
+            )
+            return
+        _register_theme_class(
+            name,
+            cls,
+            source=f'{cls.__module__}.{cls.__qualname__}',
+        )
+
 
     __slots__ = [
         '_above_range_color',
@@ -1740,7 +1879,7 @@ class Theme(_ConfigBase):
 
     def __init__(self):
         """Initialize the theme."""
-        self._name = 'default'
+        self._name = type(self)._default_name or 'default'
         self._background = Color([0.3, 0.3, 0.3])
         self._full_screen = False
         self._camera = _CameraConfig()
@@ -3354,10 +3493,11 @@ class DarkTheme(Theme):
 
     """
 
+    _default_name: ClassVar[str] = 'dark'
+
     def __init__(self):
         """Initialize the theme."""
         super().__init__()
-        self.name = 'dark'
         self.background = 'black'
         self.cmap = 'viridis'
         self.font.color = 'white'
@@ -3387,10 +3527,11 @@ class ParaViewTheme(Theme):
 
     """
 
+    _default_name: ClassVar[str] = 'paraview'
+
     def __init__(self):
         """Initialize theme."""
         super().__init__()
-        self.name = 'paraview'
         self.background = 'paraview'
         self.cmap = 'coolwarm'
         self.font.family = 'arial'
@@ -3432,10 +3573,11 @@ class DocumentTheme(Theme):
 
     """
 
+    _default_name: ClassVar[str] = 'document'
+
     def __init__(self):
         """Initialize the theme."""
         super().__init__()
-        self.name = 'document'
         self.background = 'white'
         self.cmap = 'viridis'
         self.font.size = 18
@@ -3463,10 +3605,11 @@ class DocumentProTheme(DocumentTheme):
 
     """
 
+    _default_name: ClassVar[str] = 'document_pro'
+
     def __init__(self):
         """Initialize the theme."""
         super().__init__()
-        self.name = 'document_pro'
         self.anti_aliasing = 'ssaa'
         self.color_cycler = get_cycler('default')
         self.render_points_as_spheres = True
@@ -3479,10 +3622,11 @@ class DocumentProTheme(DocumentTheme):
 class _DocumentBuildTheme(DocumentTheme):
     """Theme used for building the documentation."""
 
+    _default_name: ClassVar[str] = 'document_build'
+
     def __init__(self):
         """Initialize the theme."""
         super().__init__()
-        self.name = 'document_build'
         self.window_size = [1024, 768]
         self.font.size = 22
         self.font.label_size = 22
@@ -3511,9 +3655,10 @@ class _TestingTheme(Theme):
 
     """
 
+    _default_name: ClassVar[str] = 'testing'
+
     def __init__(self):
         super().__init__()
-        self.name = 'testing'
         self.multi_samples = 1
         self.window_size = [400, 400]
         self.axes.show = False
@@ -3537,3 +3682,11 @@ class _NATIVE_THEMES(Enum):  # noqa: N801
     default = document
     testing = _TestingTheme
     vtk = Theme
+
+
+# Register legacy name aliases. ``DocumentTheme`` already self-registers as
+# ``'document'`` via ``__init_subclass__``; these aliases preserve the
+# historical ``'default' -> DocumentTheme`` and ``'vtk' -> Theme`` mappings
+# that ``_NATIVE_THEMES`` provided.
+_register_alias('default', DocumentTheme)
+_register_alias('vtk', Theme)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,10 @@ from pyvista.plotting.interactor_style_registry import (
 from pyvista.plotting.interactor_style_registry import (
     _save_registry_state as _save_style_registry_state,
 )
+from pyvista.plotting.theme_registry import (
+    _restore_registry_state as _restore_theme_registry_state,
+)
+from pyvista.plotting.theme_registry import _save_registry_state as _save_theme_registry_state
 from pyvista.plotting.utilities.gl_checks import uses_egl
 
 pv.OFF_SCREEN = True
@@ -137,6 +141,7 @@ def reset_global_state():
     reader_registry_state = _save_registry_state()
     writer_registry_state = _save_writer_registry_state()
     accessor_registry_state = _save_accessor_registry_state()
+    theme_registry_state = _save_theme_registry_state()
 
     yield
 
@@ -144,6 +149,7 @@ def reset_global_state():
     _restore_registry_state(reader_registry_state)
     _restore_writer_registry_state(writer_registry_state)
     _restore_accessor_registry_state(accessor_registry_state)
+    _restore_theme_registry_state(theme_registry_state)
 
     pv.vtk_snake_case('error')
     assert pv.vtk_snake_case() == 'error'

--- a/tests/plotting/test_theme_registry.py
+++ b/tests/plotting/test_theme_registry.py
@@ -1,0 +1,452 @@
+"""Tests for theme registration and discovery."""
+
+from __future__ import annotations
+
+import os
+from typing import ClassVar
+from unittest.mock import MagicMock
+from unittest.mock import patch
+import warnings
+
+import pytest
+
+import pyvista as pv
+from pyvista.plotting import theme_registry as _reg_mod
+from pyvista.plotting.themes import DarkTheme
+from pyvista.plotting.themes import DocumentTheme
+from pyvista.plotting.themes import ParaViewTheme
+from pyvista.plotting.themes import Theme
+from pyvista.plotting.themes import _set_plot_theme_from_env
+
+
+def test_init_subclass_auto_registers():
+    class FooTheme(Theme):
+        _default_name: ClassVar[str] = 'foo_theme'
+
+    assert _reg_mod._resolve_theme('foo_theme') is not None
+    assert 'foo_theme' in _reg_mod._available_theme_names()
+
+    pv.set_plot_theme('foo_theme')
+    assert pv.global_theme.name == 'foo_theme'
+
+
+def test_init_subclass_is_case_insensitive():
+    class CaseTheme(Theme):
+        _default_name: ClassVar[str] = 'MyCase'
+
+    assert _reg_mod._resolve_theme('mycase') is not None
+    assert _reg_mod._resolve_theme('MYCASE') is not None
+
+
+def test_init_subclass_subclass_of_subclass_registers_own_name():
+    class Derived(DocumentTheme):
+        _default_name: ClassVar[str] = 'derived_doc'
+
+    # Derived registers as 'derived_doc', not 'document'
+    assert _reg_mod._resolve_theme('derived_doc') is not None
+    resolved = _reg_mod._resolve_theme('derived_doc')
+    assert isinstance(resolved, Derived)
+
+    # DocumentTheme still resolves to DocumentTheme, not Derived
+    doc = _reg_mod._resolve_theme('document')
+    assert type(doc) is DocumentTheme
+
+
+def test_init_subclass_missing_default_name_is_silent():
+    """Ad-hoc subclasses without ``_default_name`` should register silently."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+
+        class NoName(Theme):
+            pass
+
+    assert 'noname' not in _reg_mod._available_theme_names()
+
+
+def test_init_subclass_empty_default_name_warns():
+    with pytest.warns(UserWarning, match="invalid '_default_name'"):
+
+        class EmptyName(Theme):
+            _default_name: ClassVar[str] = ''
+
+
+def test_init_subclass_whitespace_only_name_warns():
+    with pytest.warns(UserWarning, match='empty ``_default_name``'):
+
+        class WhitespaceName(Theme):
+            _default_name: ClassVar[str] = '   '
+
+
+def test_init_subclass_duplicate_name_warns():
+    class OriginalTheme(Theme):
+        _default_name: ClassVar[str] = 'dup_name'
+
+    with pytest.warns(UserWarning, match='is already registered'):
+
+        class DupTheme(Theme):
+            _default_name: ClassVar[str] = 'dup_name'
+
+    # First registration wins
+    resolved = _reg_mod._resolve_theme('dup_name')
+    assert isinstance(resolved, OriginalTheme)
+
+
+def test_register_theme_instance():
+    custom = DarkTheme()
+    custom.show_edges = True
+
+    returned = pv.register_theme('my_custom', custom)
+    assert returned is custom
+
+    pv.set_plot_theme('my_custom')
+    assert pv.global_theme.show_edges is True
+
+
+def test_register_theme_override():
+    first = DarkTheme()
+    pv.register_theme('replaceable', first)
+
+    replacement = ParaViewTheme()
+    pv.register_theme('replaceable', replacement, override=True)
+
+    resolved = _reg_mod._resolve_theme('replaceable')
+    assert isinstance(resolved, ParaViewTheme)
+
+
+def test_register_theme_collision_raises():
+    instance = DarkTheme()
+    pv.register_theme('collision_name', instance)
+
+    with pytest.raises(ValueError, match='already registered'):
+        pv.register_theme('collision_name', DocumentTheme())
+
+
+def test_register_theme_rejects_class():
+    with pytest.raises(TypeError, match='expects a Theme instance, got class'):
+        pv.register_theme('as_class', DarkTheme)
+
+
+def test_register_theme_rejects_non_theme():
+    with pytest.raises(TypeError, match='expects a pyvista Theme instance'):
+        pv.register_theme('bogus', 'not a theme')
+
+
+def test_register_theme_empty_name_raises():
+    with pytest.raises(ValueError, match='must not be empty'):
+        pv.register_theme('', DarkTheme())
+
+
+def test_register_theme_collides_with_subclass_registration():
+    class PreExisting(Theme):
+        _default_name: ClassVar[str] = 'pre_existing'
+
+    with pytest.raises(ValueError, match='already registered'):
+        pv.register_theme('pre_existing', DarkTheme())
+
+
+def test_dotted_path_resolution():
+    pv.set_plot_theme('pyvista.plotting.themes:DarkTheme')
+    assert pv.global_theme.name == 'dark'
+
+
+def test_dotted_path_wrong_type_raises():
+    with pytest.raises(ValueError, match='does not resolve to a pyvista Theme'):
+        pv.set_plot_theme('pyvista.plotting.themes:Color')
+
+
+def test_dotted_path_missing_module_raises():
+    with pytest.raises(ValueError, match='Cannot import'):
+        pv.set_plot_theme('no_such_module_xyz:Anything')
+
+
+def test_dotted_path_missing_attribute_raises():
+    with pytest.raises(ValueError, match='not found in module'):
+        pv.set_plot_theme('pyvista.plotting.themes:NoSuchTheme')
+
+
+def test_dotted_path_empty_parts_raises():
+    with pytest.raises(ValueError, match='Invalid theme spec'):
+        pv.set_plot_theme(':Bare')
+    with pytest.raises(ValueError, match='Invalid theme spec'):
+        pv.set_plot_theme('module:')
+
+
+def test_unknown_name_raises():
+    with pytest.raises(ValueError, match='not found'):
+        pv.set_plot_theme('definitely_not_a_theme')
+
+
+def test_entry_point_subclass_registered_via_init_subclass_resolves():
+    """An entry-point module whose class self-registers via ``__init_subclass__``
+    must still resolve by name when the registry is otherwise empty."""
+
+    class SelfRegistering(Theme):
+        _default_name: ClassVar[str] = 'self_registering'
+
+    # Clear the explicit registration so we exercise the entry-point path.
+    _reg_mod._registered_theme_classes.pop('self_registering', None)
+    _reg_mod._registered_theme_classes_sources.pop('self_registering', None)
+
+    # Simulate an entry point whose load() re-imports the module and
+    # re-triggers __init_subclass__ on SelfRegistering.
+    def fake_load():
+        _reg_mod._register_theme_class(
+            'self_registering',
+            SelfRegistering,
+            source='fake',
+        )
+        return SelfRegistering
+
+    ep = MagicMock()
+    ep.name = 'self_registering'
+    ep.value = 'pkg:SelfRegistering'
+    ep.load.side_effect = fake_load
+
+    _reg_mod._entry_points_loaded = False
+    with patch(
+        'pyvista.plotting.theme_registry.entry_points',
+        return_value=[ep],
+    ):
+        resolved = _reg_mod._resolve_theme('self_registering')
+
+    assert isinstance(resolved, SelfRegistering)
+
+
+def test_entry_point_class_discovery():
+    class EpTheme(Theme):
+        _default_name: ClassVar[str] = 'ep_registered'
+
+    # Clear explicit registration so discovery path is exercised
+    _reg_mod._registered_theme_classes.pop('ep_registered', None)
+    _reg_mod._registered_theme_classes_sources.pop('ep_registered', None)
+
+    ep = MagicMock()
+    ep.name = 'ep_registered'
+    ep.value = 'pkg:EpTheme'
+    ep.load.return_value = EpTheme
+
+    _reg_mod._entry_points_loaded = False
+    with patch(
+        'pyvista.plotting.theme_registry.entry_points',
+        return_value=[ep],
+    ):
+        resolved = _reg_mod._resolve_theme('ep_registered')
+
+    assert isinstance(resolved, EpTheme)
+
+
+def test_entry_point_instance_discovery():
+    ep_theme_instance = DarkTheme()
+    ep_theme_instance.show_edges = True
+
+    ep = MagicMock()
+    ep.name = 'ep_instance'
+    ep.value = 'pkg:theme_instance'
+    ep.load.return_value = ep_theme_instance
+
+    _reg_mod._entry_points_loaded = False
+    with patch(
+        'pyvista.plotting.theme_registry.entry_points',
+        return_value=[ep],
+    ):
+        resolved = _reg_mod._resolve_theme('ep_instance')
+
+    assert resolved is ep_theme_instance
+
+
+def test_entry_point_mapping_discovery():
+    class MapATheme(Theme):
+        _default_name: ClassVar[str] = 'map_a'
+
+    class MapBTheme(Theme):
+        _default_name: ClassVar[str] = 'map_b'
+
+    # Clear explicit registrations so the entry-point mapping path is used
+    for key in ('map_a', 'map_b'):
+        _reg_mod._registered_theme_classes.pop(key, None)
+        _reg_mod._registered_theme_classes_sources.pop(key, None)
+
+    ep = MagicMock()
+    ep.name = 'bulk'
+    ep.value = 'pkg:THEMES'
+    ep.load.return_value = {'map_a': MapATheme, 'map_b': MapBTheme}
+
+    _reg_mod._entry_points_loaded = False
+    with patch(
+        'pyvista.plotting.theme_registry.entry_points',
+        return_value=[ep],
+    ):
+        assert isinstance(_reg_mod._resolve_theme('map_a'), MapATheme)
+        assert isinstance(_reg_mod._resolve_theme('map_b'), MapBTheme)
+
+
+def test_entry_point_discovery_is_cached():
+    class CachedTheme(Theme):
+        _default_name: ClassVar[str] = 'cached_theme'
+
+    _reg_mod._registered_theme_classes.pop('cached_theme', None)
+    _reg_mod._registered_theme_classes_sources.pop('cached_theme', None)
+
+    ep = MagicMock()
+    ep.name = 'cached_theme'
+    ep.value = 'pkg:CachedTheme'
+    ep.load.return_value = CachedTheme
+
+    _reg_mod._entry_points_loaded = False
+    with patch(
+        'pyvista.plotting.theme_registry.entry_points',
+        return_value=[ep],
+    ):
+        _reg_mod._resolve_theme('cached_theme')
+        ep.load.assert_called_once()
+
+        _reg_mod._resolve_theme('cached_theme')
+        ep.load.assert_called_once()
+
+
+def test_entry_point_explicit_wins_silently():
+    class ExplicitTheme(Theme):
+        _default_name: ClassVar[str] = 'explicit_wins'
+
+    # EntryPointTheme is defined under a distinct name to avoid colliding
+    # with ExplicitTheme during class creation. The entry point below still
+    # advertises it under 'explicit_wins' — the explicit registration should
+    # win.
+    class EntryPointTheme(Theme):
+        _default_name: ClassVar[str] = '__ep_source__'
+
+    ep = MagicMock()
+    ep.name = 'explicit_wins'
+    ep.value = 'pkg:EntryPointTheme'
+    ep.load.return_value = EntryPointTheme
+
+    _reg_mod._entry_points_loaded = False
+    with patch(
+        'pyvista.plotting.theme_registry.entry_points',
+        return_value=[ep],
+    ):
+        resolved = _reg_mod._resolve_theme('explicit_wins')
+
+    assert isinstance(resolved, ExplicitTheme)
+
+
+def test_entry_point_load_failure_warns():
+    ep = MagicMock()
+    ep.name = 'broken_theme'
+    ep.value = 'pkg:broken'
+    ep.load.side_effect = ImportError('missing dependency')
+
+    _reg_mod._entry_points_loaded = False
+    with (
+        patch(
+            'pyvista.plotting.theme_registry.entry_points',
+            return_value=[ep],
+        ),
+        pytest.warns(UserWarning, match='Failed to load'),
+    ):
+        _reg_mod._ensure_entry_points()
+
+
+def test_entry_point_non_theme_warns():
+    ep = MagicMock()
+    ep.name = 'not_theme'
+    ep.value = 'pkg:not_theme'
+    ep.load.return_value = 'not a theme'
+
+    _reg_mod._entry_points_loaded = False
+    with (
+        patch(
+            'pyvista.plotting.theme_registry.entry_points',
+            return_value=[ep],
+        ),
+        pytest.warns(UserWarning, match='not a pyvista Theme'),
+    ):
+        _reg_mod._ensure_entry_points()
+
+
+def test_entry_point_duplicate_provider_warns():
+    # Distinct _default_name so the class itself registers cleanly; the
+    # two entry points below both advertise it under 'dup_theme'.
+    class DupTheme(Theme):
+        _default_name: ClassVar[str] = '__dup_source__'
+
+    _reg_mod._registered_theme_classes.pop('dup_theme', None)
+    _reg_mod._registered_theme_classes_sources.pop('dup_theme', None)
+
+    ep1 = MagicMock()
+    ep1.name = 'dup_theme'
+    ep1.value = 'pkg_a:theme'
+    ep1.load.return_value = DupTheme
+
+    ep2 = MagicMock()
+    ep2.name = 'dup_theme'
+    ep2.value = 'pkg_b:theme'
+    ep2.load.return_value = DupTheme
+
+    _reg_mod._entry_points_loaded = False
+    with (
+        patch(
+            'pyvista.plotting.theme_registry.entry_points',
+            return_value=[ep1, ep2],
+        ),
+        pytest.warns(UserWarning, match='Multiple .* providers'),
+    ):
+        _reg_mod._ensure_entry_points()
+
+
+def test_entry_point_mapping_non_string_key_warns():
+    class MappingTheme(Theme):
+        _default_name: ClassVar[str] = '__mapping_source__'
+
+    ep = MagicMock()
+    ep.name = 'bad_mapping'
+    ep.value = 'pkg:THEMES'
+    ep.load.return_value = {123: MappingTheme}
+
+    _reg_mod._entry_points_loaded = False
+    with (
+        patch(
+            'pyvista.plotting.theme_registry.entry_points',
+            return_value=[ep],
+        ),
+        pytest.warns(UserWarning, match='theme names must be strings'),
+    ):
+        _reg_mod._ensure_entry_points()
+
+
+def test_env_var_registered_name():
+    class EnvTheme(Theme):
+        _default_name: ClassVar[str] = 'env_theme'
+
+    try:
+        os.environ['PYVISTA_PLOT_THEME'] = 'env_theme'
+        _set_plot_theme_from_env()
+    finally:
+        os.environ.pop('PYVISTA_PLOT_THEME', None)
+
+    assert pv.global_theme.name == 'env_theme'
+
+
+def test_env_var_dotted_path_preserves_case():
+    try:
+        os.environ['PYVISTA_PLOT_THEME'] = 'pyvista.plotting.themes:DarkTheme'
+        _set_plot_theme_from_env()
+    finally:
+        os.environ.pop('PYVISTA_PLOT_THEME', None)
+
+    assert pv.global_theme.name == 'dark'
+
+
+def test_env_var_unknown_warns():
+    try:
+        os.environ['PYVISTA_PLOT_THEME'] = 'definitely_bogus'
+        with pytest.warns(UserWarning, match='Invalid PYVISTA_PLOT_THEME'):
+            _set_plot_theme_from_env()
+    finally:
+        os.environ.pop('PYVISTA_PLOT_THEME', None)
+
+
+def test_available_theme_names_includes_builtins():
+    names = _reg_mod._available_theme_names()
+    for name in ('dark', 'document', 'paraview', 'default', 'vtk'):
+        assert name in names

--- a/tests/plotting/test_theme_registry.py
+++ b/tests/plotting/test_theme_registry.py
@@ -24,7 +24,7 @@ def test_init_subclass_auto_registers():
 
     assert _reg_mod._resolve_theme('foo_theme') is not None
     assert 'foo_theme' in _reg_mod._available_theme_names()
-    assert 'foo_theme' in pv.registered_themes()
+    assert any(r.name == 'foo_theme' for r in pv.registered_themes())
 
     pv.set_plot_theme('foo_theme')
     assert pv.global_theme.name == 'foo_theme'
@@ -55,7 +55,7 @@ def test_init_subclass_subclass_of_subclass_registers_own_name():
 def test_init_subclass_missing_default_name_is_not_registered():
     """Ad-hoc subclasses without ``_default_name`` must not be registered."""
     names_before = _reg_mod._available_theme_names()
-    registered_before = dict(pv.registered_themes())
+    registered_before = pv.registered_themes()
 
     with warnings.catch_warnings():
         warnings.simplefilter('error')
@@ -64,11 +64,11 @@ def test_init_subclass_missing_default_name_is_not_registered():
             pass
 
     assert 'noname' not in _reg_mod._available_theme_names()
-    assert 'noname' not in pv.registered_themes()
+    assert all(r.name != 'noname' for r in pv.registered_themes())
     # Creating the subclass must not register it under any other name
     # either — the set of registered themes is unchanged.
     assert _reg_mod._available_theme_names() == names_before
-    assert dict(pv.registered_themes()) == registered_before
+    assert pv.registered_themes() == registered_before
 
 
 def test_init_subclass_empty_default_name_warns():
@@ -85,23 +85,24 @@ def test_init_subclass_whitespace_only_name_warns():
             _default_name: ClassVar[str] = '   '
 
 
-def test_init_subclass_duplicate_name_warns():
+def test_init_subclass_duplicate_name_replaces_existing():
     class OriginalTheme(Theme):
         _default_name: ClassVar[str] = 'dup_name'
 
-    with pytest.warns(UserWarning, match='is already registered'):
+    with pytest.warns(UserWarning, match='replaces an existing registration'):
 
         class DupTheme(Theme):
             _default_name: ClassVar[str] = 'dup_name'
 
-    # First registration wins
+    # Last registration wins, mirroring every other PyVista plugin registry.
     resolved = _reg_mod._resolve_theme('dup_name')
-    assert isinstance(resolved, OriginalTheme)
+    assert isinstance(resolved, DupTheme)
+    assert _reg_mod._registered_theme_classes['dup_name'] is DupTheme
 
 
 def test_set_plot_theme_does_not_mutate_class_registration():
     """Applying a class-backed theme must keep its entry as a subclass."""
-    dark_before = pv.registered_themes()['dark']
+    dark_before = next(r for r in pv.registered_themes() if r.name == 'dark')
     assert dark_before.kind == 'subclass'
 
     pv.set_plot_theme('dark')
@@ -111,7 +112,7 @@ def test_set_plot_theme_does_not_mutate_class_registration():
     # the registry hands out fresh instances from the class on every call.
     pv.global_theme.show_edges = not pv.global_theme.show_edges
 
-    dark_after = pv.registered_themes()['dark']
+    dark_after = next(r for r in pv.registered_themes() if r.name == 'dark')
     assert dark_after == dark_before
     fresh = _reg_mod._resolve_theme('dark')
     assert isinstance(fresh, DarkTheme)
@@ -318,7 +319,7 @@ def test_entry_point_load_failure_warns():
         ),
         pytest.warns(UserWarning, match='Failed to load'),
     ):
-        _reg_mod._ensure_entry_points()
+        _reg_mod._resolve_theme('broken_theme')
 
 
 def test_entry_point_non_theme_warns():
@@ -335,7 +336,7 @@ def test_entry_point_non_theme_warns():
         ),
         pytest.warns(UserWarning, match='not a pyvista Theme'),
     ):
-        _reg_mod._ensure_entry_points()
+        _reg_mod._resolve_theme('not_theme')
 
 
 def test_entry_point_duplicate_provider_warns():
@@ -365,7 +366,7 @@ def test_entry_point_duplicate_provider_warns():
         ),
         pytest.warns(UserWarning, match='Multiple .* providers'),
     ):
-        _reg_mod._ensure_entry_points()
+        _reg_mod._resolve_theme('dup_theme')
 
 
 def test_entry_point_mapping_non_string_key_warns():
@@ -385,7 +386,7 @@ def test_entry_point_mapping_non_string_key_warns():
         ),
         pytest.warns(UserWarning, match='theme names must be strings'),
     ):
-        _reg_mod._ensure_entry_points()
+        _reg_mod._resolve_theme('bad_mapping')
 
 
 def test_env_var_registered_name():
@@ -427,7 +428,7 @@ def test_available_theme_names_includes_builtins():
 
 
 def test_registered_themes_includes_builtins_and_kinds():
-    registered = pv.registered_themes()
+    by_name = {r.name: r for r in pv.registered_themes()}
     expected_classes = {
         'dark': 'DarkTheme',
         'document': 'DocumentTheme',
@@ -435,10 +436,10 @@ def test_registered_themes_includes_builtins_and_kinds():
         'testing': '_TestingTheme',
     }
     for name, class_name in expected_classes.items():
-        assert registered[name].kind == 'subclass'
-        assert registered[name].source.endswith(class_name)
+        assert by_name[name].kind == 'subclass'
+        assert by_name[name].source.endswith(class_name)
     for name in ('default', 'vtk'):
-        assert registered[name].kind == 'alias'
+        assert by_name[name].kind == 'alias'
 
 
 def test_registered_themes_reports_entry_point_source():
@@ -460,11 +461,174 @@ def test_registered_themes_reports_entry_point_source():
     ):
         registered = pv.registered_themes()
 
-    record = registered['ep_listed']
+    record = next(r for r in registered if r.name == 'ep_listed')
     assert record.kind == 'entry_point'
     assert record.source == 'some_plugin.pkg:EpListedTheme'
 
 
+def test_registered_themes_returns_tuple_of_records():
+    result = pv.registered_themes()
+    assert isinstance(result, tuple)
+    assert all(isinstance(r, pv.ThemeRegistration) for r in result)
+    assert all(isinstance(r.name, str) for r in result)
+
+
 def test_registered_themes_is_sorted():
     registered = pv.registered_themes()
-    assert list(registered) == sorted(registered)
+    assert list(registered) == sorted(registered, key=lambda r: r.name)
+
+
+def test_metadata_scan_does_not_load_theme_plugin():
+    """``_ensure_entry_points`` records metadata without importing plugin modules."""
+
+    class ScanTheme(Theme):
+        _default_name: ClassVar[str] = '__scan_source__'
+
+    ep = MagicMock()
+    ep.name = 'scan_only'
+    ep.value = 'pkg:ScanTheme'
+    ep.load.return_value = ScanTheme
+
+    _reg_mod._entry_points_loaded = False
+    with patch(
+        'pyvista.plotting.theme_registry.entry_points',
+        return_value=[ep],
+    ):
+        _reg_mod._ensure_entry_points()
+
+    ep.load.assert_not_called()
+    assert 'scan_only' in _reg_mod._pending_ep_themes
+    assert 'scan_only' in _reg_mod._available_theme_names()
+
+
+def test_lookup_builtin_does_not_load_plugin():
+    """Resolving a built-in name must not import any installed theme plugin.
+
+    ``set_plot_theme('dark')`` and friends are the common case — they
+    must short-circuit before any entry point is touched.
+    """
+
+    class OtherTheme(Theme):
+        _default_name: ClassVar[str] = '__other_source__'
+
+    ep = MagicMock()
+    ep.name = 'other_plugin'
+    ep.value = 'pkg:OtherTheme'
+    ep.load.return_value = OtherTheme
+
+    _reg_mod._entry_points_loaded = False
+    with patch(
+        'pyvista.plotting.theme_registry.entry_points',
+        return_value=[ep],
+    ):
+        resolved = _reg_mod._resolve_theme('dark')
+
+    assert isinstance(resolved, DarkTheme)
+    ep.load.assert_not_called()
+    # 'dark' short-circuits before the EP scan runs, so the EP never
+    # even gets recorded as pending.
+    assert _reg_mod._entry_points_loaded is False
+
+
+def test_lookup_matching_theme_loads_only_its_plugin():
+    """Looking up a name claimed by an EP loads that one plugin only."""
+
+    class WantedTheme(Theme):
+        _default_name: ClassVar[str] = '__wanted_source__'
+
+    class SiblingTheme(Theme):
+        _default_name: ClassVar[str] = '__sibling_source__'
+
+    _reg_mod._registered_theme_classes.pop('wanted', None)
+    _reg_mod._registered_theme_classes.pop('sibling', None)
+
+    ep_wanted = MagicMock()
+    ep_wanted.name = 'wanted'
+    ep_wanted.value = 'pkg_a:WantedTheme'
+    ep_wanted.load.return_value = WantedTheme
+
+    ep_sibling = MagicMock()
+    ep_sibling.name = 'sibling'
+    ep_sibling.value = 'pkg_b:SiblingTheme'
+    ep_sibling.load.return_value = SiblingTheme
+
+    _reg_mod._entry_points_loaded = False
+    with patch(
+        'pyvista.plotting.theme_registry.entry_points',
+        return_value=[ep_wanted, ep_sibling],
+    ):
+        resolved = _reg_mod._resolve_theme('wanted')
+
+    assert isinstance(resolved, WantedTheme)
+    ep_wanted.load.assert_called_once()
+    ep_sibling.load.assert_not_called()
+    assert 'sibling' in _reg_mod._pending_ep_themes
+
+
+def test_registered_themes_forces_full_discovery():
+    """``registered_themes`` resolves every pending plugin so callers see the full list."""
+
+    class AllATheme(Theme):
+        _default_name: ClassVar[str] = '__all_a_source__'
+
+    class AllBTheme(Theme):
+        _default_name: ClassVar[str] = '__all_b_source__'
+
+    _reg_mod._registered_theme_classes.pop('all_a', None)
+    _reg_mod._registered_theme_classes.pop('all_b', None)
+
+    ep_a = MagicMock()
+    ep_a.name = 'all_a'
+    ep_a.value = 'pkg_a:AllATheme'
+    ep_a.load.return_value = AllATheme
+
+    ep_b = MagicMock()
+    ep_b.name = 'all_b'
+    ep_b.value = 'pkg_b:AllBTheme'
+    ep_b.load.return_value = AllBTheme
+
+    _reg_mod._entry_points_loaded = False
+    with patch(
+        'pyvista.plotting.theme_registry.entry_points',
+        return_value=[ep_a, ep_b],
+    ):
+        names = {r.name for r in pv.registered_themes()}
+
+    assert 'all_a' in names
+    assert 'all_b' in names
+    ep_a.load.assert_called_once()
+    ep_b.load.assert_called_once()
+    assert _reg_mod._pending_ep_themes == {}
+
+
+def test_mapping_ep_loads_when_any_of_its_themes_requested():
+    """A Mapping-style EP loads when any of its mapped names is requested,
+    including names that differ from ``ep.name``.
+    """
+
+    class MapXTheme(Theme):
+        _default_name: ClassVar[str] = '__map_x_source__'
+
+    class MapYTheme(Theme):
+        _default_name: ClassVar[str] = '__map_y_source__'
+
+    for key in ('map_x', 'map_y'):
+        _reg_mod._registered_theme_classes.pop(key, None)
+        _reg_mod._registered_theme_classes_sources.pop(key, None)
+
+    ep = MagicMock()
+    ep.name = 'bulk_pack'
+    ep.value = 'pkg:THEMES'
+    ep.load.return_value = {'map_x': MapXTheme, 'map_y': MapYTheme}
+
+    _reg_mod._entry_points_loaded = False
+    with patch(
+        'pyvista.plotting.theme_registry.entry_points',
+        return_value=[ep],
+    ):
+        # Request a name that does NOT match ep.name. Resolution should
+        # still find it via the Mapping fallback.
+        resolved = _reg_mod._resolve_theme('map_y')
+
+    assert isinstance(resolved, MapYTheme)
+    ep.load.assert_called_once()

--- a/tests/plotting/test_theme_registry.py
+++ b/tests/plotting/test_theme_registry.py
@@ -25,6 +25,7 @@ def test_init_subclass_auto_registers():
 
     assert _reg_mod._resolve_theme('foo_theme') is not None
     assert 'foo_theme' in _reg_mod._available_theme_names()
+    assert 'foo_theme' in pv.registered_themes()
 
     pv.set_plot_theme('foo_theme')
     assert pv.global_theme.name == 'foo_theme'
@@ -52,8 +53,11 @@ def test_init_subclass_subclass_of_subclass_registers_own_name():
     assert type(doc) is DocumentTheme
 
 
-def test_init_subclass_missing_default_name_is_silent():
-    """Ad-hoc subclasses without ``_default_name`` should register silently."""
+def test_init_subclass_missing_default_name_is_not_registered():
+    """Ad-hoc subclasses without ``_default_name`` must not be registered."""
+    names_before = _reg_mod._available_theme_names()
+    registered_before = dict(pv.registered_themes())
+
     with warnings.catch_warnings():
         warnings.simplefilter('error')
 
@@ -61,6 +65,11 @@ def test_init_subclass_missing_default_name_is_silent():
             pass
 
     assert 'noname' not in _reg_mod._available_theme_names()
+    assert 'noname' not in pv.registered_themes()
+    # Creating the subclass must not register it under any other name
+    # either — the set of registered themes is unchanged.
+    assert _reg_mod._available_theme_names() == names_before
+    assert dict(pv.registered_themes()) == registered_before
 
 
 def test_init_subclass_empty_default_name_warns():
@@ -100,6 +109,25 @@ def test_register_theme_instance():
 
     pv.set_plot_theme('my_custom')
     assert pv.global_theme.show_edges is True
+
+
+def test_set_plot_theme_does_not_mutate_class_registration():
+    """Applying a class-backed theme must not convert its entry into an instance."""
+    dark_before = pv.registered_themes()['dark']
+    assert dark_before.kind == 'subclass'
+
+    pv.set_plot_theme('dark')
+    assert pv.global_theme.name == 'dark'
+
+    # Mutating the global theme must not leak into the registered theme
+    # (the registry should hand out fresh instances from the class).
+    pv.global_theme.show_edges = not pv.global_theme.show_edges
+
+    dark_after = pv.registered_themes()['dark']
+    assert dark_after == dark_before
+    fresh = _reg_mod._resolve_theme('dark')
+    assert isinstance(fresh, DarkTheme)
+    assert fresh.show_edges is DarkTheme().show_edges
 
 
 def test_register_theme_override():

--- a/tests/plotting/test_theme_registry.py
+++ b/tests/plotting/test_theme_registry.py
@@ -14,7 +14,6 @@ import pyvista as pv
 from pyvista.plotting import theme_registry as _reg_mod
 from pyvista.plotting.themes import DarkTheme
 from pyvista.plotting.themes import DocumentTheme
-from pyvista.plotting.themes import ParaViewTheme
 from pyvista.plotting.themes import Theme
 from pyvista.plotting.themes import _set_plot_theme_from_env
 
@@ -100,27 +99,16 @@ def test_init_subclass_duplicate_name_warns():
     assert isinstance(resolved, OriginalTheme)
 
 
-def test_register_theme_instance():
-    custom = DarkTheme()
-    custom.show_edges = True
-
-    returned = pv.register_theme('my_custom', custom)
-    assert returned is custom
-
-    pv.set_plot_theme('my_custom')
-    assert pv.global_theme.show_edges is True
-
-
 def test_set_plot_theme_does_not_mutate_class_registration():
-    """Applying a class-backed theme must not convert its entry into an instance."""
+    """Applying a class-backed theme must keep its entry as a subclass."""
     dark_before = pv.registered_themes()['dark']
     assert dark_before.kind == 'subclass'
 
     pv.set_plot_theme('dark')
     assert pv.global_theme.name == 'dark'
 
-    # Mutating the global theme must not leak into the registered theme
-    # (the registry should hand out fresh instances from the class).
+    # Mutating the global theme must not leak into the registered theme —
+    # the registry hands out fresh instances from the class on every call.
     pv.global_theme.show_edges = not pv.global_theme.show_edges
 
     dark_after = pv.registered_themes()['dark']
@@ -128,48 +116,6 @@ def test_set_plot_theme_does_not_mutate_class_registration():
     fresh = _reg_mod._resolve_theme('dark')
     assert isinstance(fresh, DarkTheme)
     assert fresh.show_edges is DarkTheme().show_edges
-
-
-def test_register_theme_override():
-    first = DarkTheme()
-    pv.register_theme('replaceable', first)
-
-    replacement = ParaViewTheme()
-    pv.register_theme('replaceable', replacement, override=True)
-
-    resolved = _reg_mod._resolve_theme('replaceable')
-    assert isinstance(resolved, ParaViewTheme)
-
-
-def test_register_theme_collision_raises():
-    instance = DarkTheme()
-    pv.register_theme('collision_name', instance)
-
-    with pytest.raises(ValueError, match='already registered'):
-        pv.register_theme('collision_name', DocumentTheme())
-
-
-def test_register_theme_rejects_class():
-    with pytest.raises(TypeError, match='expects a Theme instance, got class'):
-        pv.register_theme('as_class', DarkTheme)
-
-
-def test_register_theme_rejects_non_theme():
-    with pytest.raises(TypeError, match='expects a pyvista Theme instance'):
-        pv.register_theme('bogus', 'not a theme')
-
-
-def test_register_theme_empty_name_raises():
-    with pytest.raises(ValueError, match='must not be empty'):
-        pv.register_theme('', DarkTheme())
-
-
-def test_register_theme_collides_with_subclass_registration():
-    class PreExisting(Theme):
-        _default_name: ClassVar[str] = 'pre_existing'
-
-    with pytest.raises(ValueError, match='already registered'):
-        pv.register_theme('pre_existing', DarkTheme())
 
 
 def test_dotted_path_resolution():
@@ -493,16 +439,6 @@ def test_registered_themes_includes_builtins_and_kinds():
         assert registered[name].source.endswith(class_name)
     for name in ('default', 'vtk'):
         assert registered[name].kind == 'alias'
-
-
-def test_registered_themes_reports_instance_source():
-    custom = DarkTheme()
-    pv.register_theme('reg_inst_theme', custom)
-
-    record = pv.registered_themes()['reg_inst_theme']
-    assert record.name == 'reg_inst_theme'
-    assert record.kind == 'instance'
-    assert "register_theme('reg_inst_theme')" in record.source
 
 
 def test_registered_themes_reports_entry_point_source():

--- a/tests/plotting/test_theme_registry.py
+++ b/tests/plotting/test_theme_registry.py
@@ -450,3 +450,57 @@ def test_available_theme_names_includes_builtins():
     names = _reg_mod._available_theme_names()
     for name in ('dark', 'document', 'paraview', 'default', 'vtk'):
         assert name in names
+
+
+def test_registered_themes_includes_builtins_and_kinds():
+    registered = pv.registered_themes()
+    expected_classes = {
+        'dark': 'DarkTheme',
+        'document': 'DocumentTheme',
+        'paraview': 'ParaViewTheme',
+        'testing': '_TestingTheme',
+    }
+    for name, class_name in expected_classes.items():
+        assert registered[name].kind == 'subclass'
+        assert registered[name].source.endswith(class_name)
+    for name in ('default', 'vtk'):
+        assert registered[name].kind == 'alias'
+
+
+def test_registered_themes_reports_instance_source():
+    custom = DarkTheme()
+    pv.register_theme('reg_inst_theme', custom)
+
+    record = pv.registered_themes()['reg_inst_theme']
+    assert record.name == 'reg_inst_theme'
+    assert record.kind == 'instance'
+    assert "register_theme('reg_inst_theme')" in record.source
+
+
+def test_registered_themes_reports_entry_point_source():
+    class EpListedTheme(Theme):
+        _default_name: ClassVar[str] = '__ep_listed__'
+
+    _reg_mod._registered_theme_classes.pop('ep_listed', None)
+    _reg_mod._registered_theme_classes_sources.pop('ep_listed', None)
+
+    ep = MagicMock()
+    ep.name = 'ep_listed'
+    ep.value = 'some_plugin.pkg:EpListedTheme'
+    ep.load.return_value = EpListedTheme
+
+    _reg_mod._entry_points_loaded = False
+    with patch(
+        'pyvista.plotting.theme_registry.entry_points',
+        return_value=[ep],
+    ):
+        registered = pv.registered_themes()
+
+    record = registered['ep_listed']
+    assert record.kind == 'entry_point'
+    assert record.source == 'some_plugin.pkg:EpListedTheme'
+
+
+def test_registered_themes_is_sorted():
+    registered = pv.registered_themes()
+    assert list(registered) == sorted(registered)


### PR DESCRIPTION
# Theme registration

Makes `Theme` subclasses and plugin themes discoverable by name. Extends `set_plot_theme()` and `PYVISTA_PLOT_THEME` to accept registered names and `package.module:ClassName` dotted paths, and adds `pv.registered_themes()` for inspection.

Two registration paths, one lookup.

## For subclass authors

Declare a class-level `_default_name` and the theme is registered automatically:

```python
from typing import ClassVar
from pyvista.plotting.themes import DocumentTheme

class MyTheme(DocumentTheme):
    _default_name: ClassVar[str] = 'mine'

pv.set_plot_theme('mine')
```

Ad-hoc `class X(Theme): ...` subclasses without `_default_name` are ignored, so this is opt-in. This path requires the defining module to be imported before the name resolves, so it is useful for scripts, notebooks, testing, and local development.

## For plugin packages

Declare a `pyvista.themes` entry point in `pyproject.toml`:

```toml
[project.entry-points.'pyvista.themes']
my_theme = 'my_package.theme:MyTheme'
```

PyVista discovers it lazily on first lookup. `PYVISTA_PLOT_THEME=my_theme` picks it up on import without requiring the user to import the plugin first. This mirrors the existing `pyvista.interactor_styles`, `pyvista.readers`, and `pyvista.writers` entry-point groups.

## Dotted paths

`PYVISTA_PLOT_THEME=pkg.mod:ClassName` and `pv.set_plot_theme('pkg.mod:ClassName')` both work without the package shipping an entry point.

## Discoverability

`pv.registered_themes()` returns a `tuple[ThemeRegistration, ...]` describing how each name was registered. `ThemeRegistration` is a `NamedTuple(name, kind, source)` with `kind` in `{'subclass', 'entry_point', 'alias'}`:

```python
>>> next(r for r in pv.registered_themes() if r.name == 'dark')
ThemeRegistration(name='dark', kind='subclass', source='pyvista.plotting.themes.DarkTheme')
>>> next(r for r in pv.registered_themes() if r.name == 'default').kind
'alias'
```

## Alignment with #8595

#8595 unified collision, source-attribution, and lazy-loading conventions across PyVista's plugin registries. This PR adopts them for themes:

- Last-wins collision: registering a name that's already taken now warns and replaces, matching the accessor, reader, writer, jupyter-backend, and interactor-style registries.
- `registered_themes()` returns `tuple[ThemeRegistration, ...]` to match `registered_accessors()` / `registered_readers()` / `registered_writers()` / `registered_jupyter_backends()`.
- Source attribution uses the shared `handler_source` helper from `pyvista/core/utilities/_registry_helpers.py`.
- Per-name lazy entry-point loading: `set_plot_theme('document')` no longer imports any installed `pyvista.themes` plugins; only the plugin claiming the requested name (or `registered_themes()`, which forces full discovery) does.

## Context

#8030 (@edabor) added `register_theme` as a combined function and decorator. Earlier revisions of this PR preserved `register_theme()` for pre-configured instances, but @MatthewFlamm pointed out that instance registration requires the same user import as plain subclassing and does not add discoverability beyond what entry points and subclasses already provide. Removing it trims ~230 lines and leaves two clearly differentiated paths.

#5119 (@MatthewFlamm) proposed replacing the subclass API with classmethods and deprecating the `Theme` subclasses. Downstream projects depend on subclassing, so this PR preserves it.

## Backward compatibility

Fully preserved. `_name` stays in `Theme.__slots__`, the `name` property still writes to it, `_NATIVE_THEMES` is unchanged, and `'default'`/`'vtk'` still resolve to `DocumentTheme`/`Theme` via explicit aliases.
