### PR TITLE
Fix pyvistaqt and geovista integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -66,7 +66,9 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.14
+          python-version: |
+            3.13
+            3.14
 
       - name: Install tox-uv
         run: pip install tox-uv

--- a/tox.ini
+++ b/tox.ini
@@ -124,7 +124,8 @@ description =
 skip_install = true # added since commands_pre that install the target package might override the current pyvista installation
 basepython =
     pyvistaqt: py3.14
-    trame,mne,geovista: py3.14
+    trame,mne: py3.14
+    geovista: py3.13
 dependency_groups =
     !mne: {[testenv]dependency_groups}
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -197,7 +197,7 @@ commands_pre =
 
     # PYVISTAQT SETUP
     pyvistaqt: git clone https://github.com/pyvista/pyvistaqt.git {env:PYVISTAQT_HOME} --single-branch
-    pyvistaqt: uv pip install {env:PYVISTAQT_HOME} -r {env:PYVISTAQT_HOME}{/}requirements_test.txt
+    pyvistaqt: uv pip install {env:PYVISTAQT_HOME}[test]
 
     # COMMON SETUP (CURRENT PYVISTA VERSION INSTALLATION)
     uv pip install {tox_root} --project {tox_root} --group pinned
@@ -211,9 +211,7 @@ commands_pre =
 
 commands =
     trame: pytest --color=yes -v tests {posargs}
-    geovista: pytest --color=yes -v \
-        -W ignore::pyvista.core.errors.PyVistaDeprecationWarning \
-        {env:_GEOVISTA_ARGS} {posargs}
+    geovista: pytest --color=yes -v -W ignore::pyvista.core.errors.PyVistaDeprecationWarning {env:_GEOVISTA_ARGS} {posargs}
     mne: pytest --color=yes -v {env:_MNE_ARGS} {posargs}
     pyvistaqt: pytest --color=yes -v {env:_PYVISTAQT_ARGS} {posargs}
 


### PR DESCRIPTION
Fix #8565

- Brings integration test workflow up to date with changes in pyvistaqt
- Pins geovista to py3.13 until cartopy releases for py3.14