### PR TITLE
Document licensing and attribution for `download_dicom_stack`

### DIFF
--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -2251,6 +2251,14 @@ class DICOMReader(BaseReader):
     >>> dataset = reader.read()
     >>> dataset.plot(volume=True, zoom=3, show_scalar_bar=False)
 
+    .. note::
+
+        The example dataset is the CPTAC-SAR collection from The Cancer
+        Imaging Archive, distributed under CC BY 3.0 and subject to the
+        TCIA Data Usage Policy. See
+        :func:`~pyvista.examples.downloads.download_dicom_stack` for the
+        required attribution and usage terms.
+
     """
 
     _vtk_module_name = 'vtkIOImage'

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -6111,6 +6111,15 @@ def download_dicom_stack(
     Clinical Proteomic Tumor Analysis Consortium Sarcomas (CPTAC-SAR)
     collection.
 
+    The CPTAC-SAR collection is distributed under the `Creative Commons
+    Attribution 3.0 Unported License (CC BY 3.0)
+    <https://creativecommons.org/licenses/by/3.0/>`_. Use of this dataset
+    requires attribution (see the citations below) and is subject to the
+    `TCIA Data Usage Policy
+    <https://www.cancerimagingarchive.net/data-usage-policies-and-restrictions/>`_,
+    which prohibits using the data to identify or contact the individual
+    participants.
+
     Parameters
     ----------
     load : bool, default: True


### PR DESCRIPTION
### Summary

The TCIA CPTAC-SAR DICOM stack exposed via `pyvista.examples.download_dicom_stack` is distributed under CC BY 3.0 and is subject to the TCIA Data Usage Policy. The function's References section already provided the required citations, but the license itself and the no-re-identification obligation were not stated in the API docs. This PR makes those terms explicit at every user-facing call site.

The dataset remains fine for commercial use under CC BY 3.0. This change just makes the terms discoverable from the Python API without users having to follow the data back to the other repository https://github.com/pyvista/vtk-data/blob/master/Data/DICOM_Stack/LICENSE.txt

### Changes

- `pyvista/examples/downloads.py`: add a licensing paragraph to `download_dicom_stack()` naming CC BY 3.0, linking the TCIA Data Usage Policy, and noting the prohibition on re-identifying participants.
- `pyvista/core/utilities/reader.py`: add a note to the `DICOMReader` example (which also downloads this dataset) pointing readers back to `download_dicom_stack` for attribution and usage terms.

These are the only two user-facing call sites. Tests don't require attribution, and the dataset gallery page is auto-generated from the updated docstring, so attribution propagates there automatically. No other occurrences in docs, examples, or tutorials.