### PR TITLE
Add PNG repr to plotter

### DIFF
--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -30,7 +30,6 @@ import warnings
 import weakref
 
 import numpy as np
-import PIL.Image
 import scooby
 
 import pyvista as pv
@@ -6633,6 +6632,8 @@ class BasePlotter(_BoundsSizeMixin, PickingHelper, WidgetHelper):
             the plotter has not been rendered.
 
         """
+        import PIL.Image  # noqa: PLC0415
+
         if self.last_image is None:
             return None
         buf = io.BytesIO()

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -30,6 +30,7 @@ import warnings
 import weakref
 
 import numpy as np
+import PIL.Image
 import scooby
 
 import pyvista as pv
@@ -6614,6 +6615,29 @@ class BasePlotter(_BoundsSizeMixin, PickingHelper, WidgetHelper):
             with self.image_scale_context(scale):
                 self._make_render_window_current()
                 return self._save_image(self.image, filename, return_img)
+
+    def _repr_png_(self) -> bytes | None:
+        """Return the last cached screenshot as PNG bytes for IPython display hooks.
+
+        Enables the plotter to render as a static image in IDE plot panes and
+        rich notebook frontends (Positron, VS Code Jupyter, JupyterLab). Uses
+        :attr:`last_image`, which is populated by :meth:`show` or
+        :meth:`screenshot`. Returns ``None`` when no screenshot has been
+        captured yet; this method never triggers a render, so IDE variable
+        inspectors can probe a plotter without side effects.
+
+        Returns
+        -------
+        bytes or None
+            PNG-encoded image of the most recent screenshot, or ``None`` if
+            the plotter has not been rendered.
+
+        """
+        if self.last_image is None:
+            return None
+        buf = io.BytesIO()
+        PIL.Image.fromarray(self.last_image).save(buf, format='PNG')
+        return buf.getvalue()
 
     @wraps(Renderers.set_background)
     def set_background(self, *args, **kwargs) -> None:  # numpydoc ignore=PR01,RT01

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1514,6 +1514,37 @@ def test_screenshot_bytes():
 
 
 @pytest.mark.usefixtures('no_images_to_verify')
+def test_repr_png_before_render():
+    pl = pv.Plotter()
+    pl.add_mesh(pv.Sphere())
+    assert pl._repr_png_() is None
+    assert pl._first_time
+
+
+def test_repr_png_after_show(verify_image_cache):
+    verify_image_cache.skip = True
+    pl = pv.Plotter()
+    pl.add_mesh(pv.Sphere())
+    pl.show()
+    png = pl._repr_png_()
+    assert isinstance(png, bytes)
+    im = Image.open(io.BytesIO(png))
+    assert im.format == 'PNG'
+
+
+def test_repr_png_after_close(verify_image_cache):
+    verify_image_cache.skip = True
+    pl = pv.Plotter()
+    pl.add_mesh(pv.Sphere())
+    pl.show()
+    pl.close()
+    png = pl._repr_png_()
+    assert isinstance(png, bytes)
+    im = Image.open(io.BytesIO(png))
+    assert im.format == 'PNG'
+
+
+@pytest.mark.usefixtures('no_images_to_verify')
 def test_screenshot_rendering(tmpdir):
     pl = pv.Plotter()
     pl.add_mesh(examples.load_airplane(), smooth_shading=True)


### PR DESCRIPTION
Adds a simple fallback PNG repr for the Plotter for data science IDEs and the like that support `_repr_png_`