### PR TITLE
[hotfix] fix Jedi tab-completion crashes on DataSet types

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -63,9 +63,10 @@ if TYPE_CHECKING:
     from ._typing_core import VectorLike
     from ._typing_core import _ArrayLikeOrScalar
 
+    _Dimensionality = Literal[0, 1, 2, 3]
+
 # vector array names
 DEFAULT_VECTOR_KEY = '_vectors'
-_Dimensionality = Literal[0, 1, 2, 3]
 
 
 class ActiveArrayInfoTuple(NamedTuple):

--- a/pyvista/plotting/_typing.py
+++ b/pyvista/plotting/_typing.py
@@ -19,7 +19,6 @@ from pyvista.core._typing_core import NumpyArray
 from pyvista.core._typing_core import VectorLike
 
 from . import _vtk
-from .colors import _ALL_COLORS_LITERAL
 from .renderer import CameraPosition
 
 if TYPE_CHECKING:
@@ -32,6 +31,7 @@ if TYPE_CHECKING:
     from .charts import ChartBox as ChartBox
     from .charts import ChartMPL as ChartMPL
     from .charts import ChartPie as ChartPie
+    from .colors import _ALL_COLORS_LITERAL
     from .colors import _CMCRAMERI_CMAPS_LITERAL
     from .colors import _CMOCEAN_CMAPS_LITERAL
     from .colors import _COLORCET_CMAPS_LITERAL
@@ -64,7 +64,7 @@ ColorLike = Union[
     str,
     'Color',
     _vtk.vtkColor3ub,
-    _ALL_COLORS_LITERAL,
+    '_ALL_COLORS_LITERAL',
 ]
 Chart = Union['Chart2D', 'ChartBox', 'ChartPie', 'ChartMPL']
 FontFamilyOptions = Literal['courier', 'times', 'arial']


### PR DESCRIPTION
Fixes `AttributeError: 'TreeInstance' object has no attribute 'with_generics'` crashes in any Jedi-based tab completion (IPython, ptpython, `jedi-language-server`) — upstream [jedi#1990](https://github.com/davidhalter/jedi/issues/1990), open since Apr 2024.

## The problem

Module-level `Literal[...]` aliases referenced unstringified crash Jedi's `execute_annotation`. PyVista has two of them in the hot path:

- `_ALL_COLORS_LITERAL` — reachable via `ColorLike` in `DataSetFilters` methods.
- `_Dimensionality` — reachable via `DataSet.dimensionality` and friends.

Result: `mesh.<TAB>`, `mesh.contour(<TAB>`, `mesh.threshold(<TAB>`, and most filter methods crash in IPython today.

## Repro

```python
import jedi, pyvista as pv
jedi.Interpreter("mesh.contour(", [{'mesh': pv.Wavelet()}]).complete(1, 13)
# AttributeError: 'TreeInstance' object has no attribute 'with_generics'
```

After this PR: returns 9 kwarg completions, no crash. Verified zero crashes across 1233 checks covering every public method of `Sphere`/`ImageData`/`Wavelet` plus 40 top-level `pv.*` callables.

## The fix

- Move `_ALL_COLORS_LITERAL` under `TYPE_CHECKING` and stringify its reference in `ColorLike`. Matches the existing pattern already used for the four `*_CMAPS_LITERAL` unions in the same file.
- Move `_Dimensionality = Literal[0, 1, 2, 3]` under `TYPE_CHECKING` in `dataset.py`. Only used in annotations.

`from __future__ import annotations` is already active in both files, so Pylance / ty / mypy / Pyright resolve the forward references with no loss of static type info.

## Pattern for future typing changes

Module-level `SomeAlias = Literal[...]` is Jedi-hostile whenever it reaches a `Union` unstringified. Two rules:

1. Annotation-only → put the alias under `if TYPE_CHECKING:`.
2. Needed at runtime (e.g. for `get_args()` introspection) → stringify every reference in any `Union`.

Worth calling out somewhere in contributor docs so new `Literal` additions don't re-break this.