### PR TITLE
Add dataset accessor registry for third-party plugins

### DIFF
--- a/doc/source/api/core/accessors.rst
+++ b/doc/source/api/core/accessors.rst
@@ -1,0 +1,25 @@
+.. _accessor-api:
+
+Dataset Accessors
+=================
+
+PyVista exposes a pandas/xarray-style accessor mechanism so that
+third-party packages can add namespaced filter methods to dataset
+classes without monkey-patching or subclassing. Once a plugin module
+is imported, its accessor becomes available on every instance of the
+target class as ``dataset.<namespace>.<method>(...)`` and chains
+seamlessly with built-in PyVista filters.
+
+See :ref:`extending-pyvista` for a full guide with a worked example
+and guidance on typing and autocomplete.
+
+.. currentmodule:: pyvista
+
+.. autosummary::
+   :toctree: _autosummary
+
+   register_dataset_accessor
+   unregister_dataset_accessor
+   registered_accessors
+   AccessorRegistration
+   DataSetAccessor

--- a/doc/source/api/core/index.rst
+++ b/doc/source/api/core/index.rst
@@ -69,6 +69,7 @@ PyVista has the following mesh types:
    grids
    composite
    filters
+   accessors
    camera
    lights
    cells

--- a/doc/source/extras/extending_pyvista.rst
+++ b/doc/source/extras/extending_pyvista.rst
@@ -103,22 +103,62 @@ cover :class:`~pyvista.MultiBlock` as well, register against
 :class:`~pyvista.DataObject`.
 
 
-Registration is import-time
----------------------------
+Registration paths
+------------------
 
-Registration is a side effect of importing the plugin module: the
-``@pv.register_dataset_accessor(...)`` decorator runs at import time,
-and that is the entire contract. If a user never imports the plugin,
-nothing is attached.
+PyVista supports two ways to register an accessor. Both use the same
+``@register_dataset_accessor`` decorator — the difference is only
+*when* the decorator runs.
 
-This is deliberately different from the reader/writer registries,
-which use ``importlib.metadata`` entry points for zero-config
-discovery. Accessors are looked up by name (``mesh.meshfix.*``), so
-the user is already reaching for the plugin; requiring ``import
-pymeshfix`` is zero extra cognitive load and buys a lot of
-predictability. If ``mesh.meshfix`` is missing, the answer is always
-"you did not import pymeshfix", never "the entry point failed to
-load".
+**Import-time.** The plugin's module runs the decorator at import
+time, so any user who does ``import plugin`` gets the accessor
+attached. This is the simplest pattern and is ideal for scripts,
+notebooks, and tests:
+
+.. code-block:: python
+
+    # script.py
+    import pyvista as pv
+    import pymeshfix  # noqa: F401 — registers the ``.meshfix`` accessor
+
+    pv.PolyData("broken.ply").meshfix.repair()
+
+**Entry points.** The plugin declares a ``pyvista.accessors`` entry
+point in its ``pyproject.toml`` pointing at its accessor module.
+PyVista discovers the entry points on the first ``import pyvista``
+and imports each module, whose top-level decorators run as a side
+effect. Users never need an explicit ``import plugin``:
+
+.. code-block:: toml
+
+   # pymeshfix/pyproject.toml
+   [project.entry-points."pyvista.accessors"]
+   meshfix = "pymeshfix._accessor"
+
+.. code-block:: python
+
+    # script.py
+    import pyvista as pv
+
+    pv.PolyData(
+        "broken.ply"
+    ).meshfix.repair()  # works with no explicit import
+
+Both paths populate the same registry. A plugin that declares an
+entry point AND imports its accessor module from its ``__init__`` is
+safe (the second import is a no-op against ``sys.modules``).
+
+For production plugins on PyPI, prefer the entry-point path: users
+get zero-config ergonomics, which is the main ergonomic win of the
+accessor pattern. For in-script or in-notebook experimentation, the
+decorator alone is simpler.
+
+The entry point value must be a module path (no ``:ClassName``
+suffix). Put your accessor in a small module like ``_accessor.py``
+that does nothing at import time besides run the decorator — that
+keeps the cost of ``import pyvista`` minimal no matter how many
+plugins are installed. Lazy-import any heavy compute dependencies
+inside the accessor methods, not at module top.
 
 
 Chaining and return types

--- a/doc/source/extras/extending_pyvista.rst
+++ b/doc/source/extras/extending_pyvista.rst
@@ -19,7 +19,7 @@ Why accessors
 
 PyVista inherits the problem every extensible scientific library in
 Python eventually faces: users want to add methods to a core type
-without forking it. Pandas solved this first with
+without forking it. pandas solved this first with
 `registered accessors <https://pandas.pydata.org/docs/development/extending.html#registering-custom-accessors>`_
 and xarray adopted the same pattern, growing an ecosystem of
 downstream plugins such as
@@ -107,7 +107,7 @@ Registration paths
 ------------------
 
 PyVista supports two ways to register an accessor. Both use the same
-``@register_dataset_accessor`` decorator — the difference is only
+``@register_dataset_accessor`` decorator. The difference is only
 *when* the decorator runs.
 
 **Import-time.** The plugin's module runs the decorator at import
@@ -300,12 +300,12 @@ behavior — functional methods that return a new dataset are easier to
 reason about.
 
 
-Subclassing (advanced)
+subclassing (advanced)
 ----------------------
 
-For use cases that genuinely require a custom class — for example,
-adding persistent state that travels with the dataset through filters
-— direct subclassing of :class:`~pyvista.PolyData` or
+For use cases that genuinely require a custom class (for example,
+adding persistent state that travels with the dataset through
+filters), direct subclassing of :class:`~pyvista.PolyData` or
 :class:`~pyvista.UnstructuredGrid` is still supported. See
 :ref:`Extending PyVista Example <extending_pyvista_example>` for the
 subclassing pattern.

--- a/doc/source/extras/extending_pyvista.rst
+++ b/doc/source/extras/extending_pyvista.rst
@@ -213,12 +213,10 @@ Typing and autocomplete
 Because accessors are attached at import time via a decorator, static
 type checkers do not see the new attribute on the target class.
 PyVista exports a :class:`~pyvista.DataSetAccessor` structural
-protocol that plugin authors can use to type-check their own accessor
-classes:
+protocol so plugin authors can have type checkers verify their own
+accessor class conforms to the expected shape:
 
 .. code-block:: python
-
-    from typing import TYPE_CHECKING
 
     import pyvista as pv
 
@@ -230,9 +228,9 @@ classes:
         def repair(self) -> pv.PolyData: ...
 
 
-    if TYPE_CHECKING:
-        # structural confirmation the class satisfies the protocol
-        _check: pv.DataSetAccessor = MeshFixAccessor(pv.PolyData())
+    # mypy / pyright verify that MeshFixAccessor's __init__ signature
+    # is compatible with the DataSetAccessor protocol.
+    _accessor_cls: type[pv.DataSetAccessor] = MeshFixAccessor
 
 To give downstream users autocomplete on ``mesh.meshfix.repair(...)``,
 plugin packages should ship a small ``.pyi`` stub that declares the

--- a/doc/source/extras/extending_pyvista.rst
+++ b/doc/source/extras/extending_pyvista.rst
@@ -125,9 +125,12 @@ notebooks, and tests:
 
 **Entry points.** The plugin declares a ``pyvista.accessors`` entry
 point in its ``pyproject.toml`` pointing at its accessor module.
-PyVista discovers the entry points on the first ``import pyvista``
-and imports each module, whose top-level decorators run as a side
-effect. Users never need an explicit ``import plugin``:
+``import pyvista`` reads the entry-point metadata but does not import
+any plugin module. The plugin module imports on demand: on the first
+``dataset.<name>`` access whose normal attribute lookup misses,
+PyVista resolves the pending entry, imports the module, lets its
+top-level decorator attach the accessor, and completes the lookup.
+Users never need an explicit ``import plugin``:
 
 .. code-block:: toml
 
@@ -148,17 +151,28 @@ Both paths populate the same registry. A plugin that declares an
 entry point AND imports its accessor module from its ``__init__`` is
 safe (the second import is a no-op against ``sys.modules``).
 
+The lazy resolution means installing an accessor plugin does not
+affect ``import pyvista`` performance or stability. A broken plugin
+only surfaces when a user actually accesses its namespace: they get
+a ``UserWarning`` pointing at the specific plugin and an
+``AttributeError`` on the call, and no other code is affected.
+``pv.registered_accessors()`` is the one call that explicitly forces
+discovery of every pending plugin so the returned list reflects the
+full picture.
+
 For production plugins on PyPI, prefer the entry-point path: users
-get zero-config ergonomics, which is the main ergonomic win of the
-accessor pattern. For in-script or in-notebook experimentation, the
+get zero-config discovery without any startup cost on ``import
+pyvista``. For in-script or in-notebook experimentation, the
 decorator alone is simpler.
 
-The entry point value must be a module path (no ``:ClassName``
-suffix). Put your accessor in a small module like ``_accessor.py``
-that does nothing at import time besides run the decorator — that
-keeps the cost of ``import pyvista`` minimal no matter how many
-plugins are installed. Lazy-import any heavy compute dependencies
-inside the accessor methods, not at module top.
+The entry-point key is the accessor namespace (``meshfix`` above),
+and the value must be a module path (no ``:ClassName`` suffix). A
+plugin that registers multiple accessors from one module should
+declare one entry-point line per namespace, all pointing at the same
+module. Put the accessor in a small module like ``_accessor.py``
+that runs the decorator at import time and does nothing else; heavy
+compute dependencies should be lazy-imported inside the accessor
+methods, not at the module top.
 
 
 Chaining and return types

--- a/doc/source/extras/extending_pyvista.rst
+++ b/doc/source/extras/extending_pyvista.rst
@@ -1,5 +1,263 @@
+.. _extending-pyvista:
+
 Extending PyVista
 =================
 
-PyVista ``DataSets`` can be extended for user defined functionality.
-See :ref:`Extending PyVista Example <extending_pyvista_example>`.
+PyVista exposes a pandas/xarray-style accessor mechanism so third-party
+packages can attach custom filter methods to dataset classes without
+monkey-patching or subclassing. This is the recommended way to plug
+domain-specific operations (mesh repair, tetrahedralization, format
+conversion, remote IO) into the fluent filter API.
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Why accessors
+-------------
+
+PyVista inherits the problem every extensible scientific library in
+Python eventually faces: users want to add methods to a core type
+without forking it. Pandas solved this first with
+`registered accessors <https://pandas.pydata.org/docs/development/extending.html#registering-custom-accessors>`_
+and xarray adopted the same pattern, growing an ecosystem of
+downstream plugins such as
+`rioxarray <https://github.com/corteva/rioxarray>`_ and
+`pint-xarray <https://github.com/xarray-contrib/pint-xarray>`_
+that hook in via ``ds.rio.reproject(...)`` and ``ds.pint.quantify()``
+without ever subclassing xarray's core objects.
+
+PyVista's accessor mechanism follows the same contract. A plugin
+registers an accessor class against a target dataset type. When the
+plugin is imported, the accessor becomes available on every instance
+of that type (and its subclasses) under a single namespace.
+
+The advantages over subclassing and monkey-patching:
+
+- **Namespaced**: ``mesh.meshfix.repair(...)`` cannot collide with
+  PyVista built-ins or with a second plugin's methods.
+- **Lazy**: the accessor class is instantiated on first access per
+  instance, so unused plugins cost nothing.
+- **Composable**: accessor methods that return PyVista datasets chain
+  naturally with core filters.
+- **Per-instance caching**: subsequent accesses on the same dataset
+  return the same accessor object, which can hold per-mesh computed
+  state without leaking across instances.
+
+
+Writing an accessor
+-------------------
+
+An accessor class accepts the dataset instance as its single
+``__init__`` argument and exposes any methods that should be callable
+under the namespace.
+
+.. code-block:: python
+
+    # pymeshfix/_pyvista_plugin.py
+    import pyvista as pv
+    from pymeshfix import MeshFix
+
+
+    @pv.register_dataset_accessor("meshfix", pv.PolyData)
+    class MeshFixAccessor:
+        """Accessor exposing pymeshfix on PolyData."""
+
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+        def repair(
+            self,
+            *,
+            verbose=False,
+            joincomp=False,
+            remove_smallest_components=True
+        ):
+            fix = MeshFix(self._mesh)
+            fix.repair(
+                verbose=verbose,
+                joincomp=joincomp,
+                remove_smallest_components=remove_smallest_components,
+            )
+            return fix.mesh
+
+        def has_holes(self):
+            return MeshFix(self._mesh).has_holes()
+
+Once the plugin is imported, every :class:`~pyvista.PolyData` instance
+exposes the ``meshfix`` namespace:
+
+.. code-block:: python
+
+    import pyvista as pv
+    import pymeshfix  # noqa: F401 — registers the .meshfix accessor
+
+    mesh = pv.PolyData("broken.ply")
+    result = mesh.clean().meshfix.repair(verbose=True).decimate(0.5)
+
+The accessor registered against :class:`~pyvista.PolyData` is visible
+only on ``PolyData`` and its subclasses. To expose a method across
+every dataset type, register against :class:`~pyvista.DataSet`. To
+cover :class:`~pyvista.MultiBlock` as well, register against
+:class:`~pyvista.DataObject`.
+
+
+Registration is import-time
+---------------------------
+
+Registration is a side effect of importing the plugin module: the
+``@pv.register_dataset_accessor(...)`` decorator runs at import time,
+and that is the entire contract. If a user never imports the plugin,
+nothing is attached.
+
+This is deliberately different from the reader/writer registries,
+which use ``importlib.metadata`` entry points for zero-config
+discovery. Accessors are looked up by name (``mesh.meshfix.*``), so
+the user is already reaching for the plugin; requiring ``import
+pymeshfix`` is zero extra cognitive load and buys a lot of
+predictability. If ``mesh.meshfix`` is missing, the answer is always
+"you did not import pymeshfix", never "the entry point failed to
+load".
+
+
+Chaining and return types
+-------------------------
+
+Accessor methods can return three kinds of things:
+
+1. **A PyVista dataset** (the common case). Chaining continues
+   seamlessly into core filters and into other plugins' accessors.
+2. **A different PyVista type** (for example, a filter that converts
+   ``PolyData`` to ``UnstructuredGrid``). Chaining continues on the
+   new type; any accessors registered against that type become
+   available.
+3. **A non-dataset value** (for example, a ``bool``). Chaining
+   terminates. Documented as a query method, not a filter.
+
+For consistency with PyVista's core filters, which are overwhelmingly
+functional, plugins should prefer returning a new dataset rather than
+mutating the input in place. The caller then decides whether to
+assign the result back.
+
+
+Collision policy
+----------------
+
+Two collision cases are handled differently:
+
+- **Accessor-vs-accessor** (two plugins register the same name on
+  the same target): emits :class:`UserWarning` and replaces the
+  previous accessor. Matches pandas' behavior so a collision does not
+  hard-break user scripts.
+- **Accessor shadowing a built-in attribute** (a filter method, a
+  property, or any other non-accessor attribute on the target or one
+  of its ancestors): raises :class:`ValueError` unless
+  ``override=True`` is passed. This prevents accidental replacement
+  of core PyVista methods.
+
+.. code-block:: python
+
+    @pv.register_dataset_accessor("clip", pv.PolyData)
+    class MyClipAccessor: ...
+
+
+    # ValueError: Cannot register accessor 'clip' on PolyData:
+    #   shadows built-in attribute on DataSetFilters
+    #   (inherited by PolyData). Pass override=True to force.
+
+
+Typing and autocomplete
+-----------------------
+
+Because accessors are attached at import time via a decorator, static
+type checkers do not see the new attribute on the target class.
+PyVista exports a :class:`~pyvista.DataSetAccessor` structural
+protocol that plugin authors can use to type-check their own accessor
+classes:
+
+.. code-block:: python
+
+    from typing import TYPE_CHECKING
+
+    import pyvista as pv
+
+
+    class MeshFixAccessor:
+        def __init__(self, mesh: pv.PolyData) -> None:
+            self._mesh = mesh
+
+        def repair(self) -> pv.PolyData: ...
+
+
+    if TYPE_CHECKING:
+        # structural confirmation the class satisfies the protocol
+        _check: pv.DataSetAccessor = MeshFixAccessor(pv.PolyData())
+
+To give downstream users autocomplete on ``mesh.meshfix.repair(...)``,
+plugin packages should ship a small ``.pyi`` stub that declares the
+attribute on the target class. For example, ``pymeshfix/__init__.pyi``:
+
+.. code-block:: python
+
+    from pyvista import PolyData
+
+    from pymeshfix._pyvista_plugin import MeshFixAccessor
+
+    # Surface the attribute that the import-time decorator installs at
+    # runtime. Type checkers do not execute decorators, so the stub is
+    # the only signal they see.
+    PolyData.meshfix: MeshFixAccessor  # type: ignore[attr-defined]
+
+This is the same pattern used by ``rioxarray`` and ``pint-xarray`` on
+the xarray side, where the plugin ships stubs that teach editors and
+type checkers about the attribute.
+
+
+Deregistration
+--------------
+
+For tests and interactive sessions, an accessor can be removed with
+:func:`~pyvista.unregister_dataset_accessor`. Any built-in attribute
+that was shadowed via ``override=True`` is restored.
+
+.. code-block:: python
+
+    pv.unregister_dataset_accessor("meshfix", pv.PolyData)
+
+To inspect the current registry, call
+:func:`~pyvista.registered_accessors`, which returns a tuple of
+:class:`~pyvista.AccessorRegistration` records describing each active
+registration.
+
+
+Cache semantics
+---------------
+
+The first access of ``dataset.<name>`` constructs the accessor and
+caches the result in the dataset instance's ``__dict__``. All
+subsequent accesses return the same accessor object, which allows the
+accessor to hold per-mesh computed state without re-running any setup
+work.
+
+If the underlying dataset is mutated in a way the accessor needs to
+observe, evict the cache with ``del dataset.<name>``; the next access
+will rebuild the accessor. Avoid mutating the dataset from inside
+accessor methods unless you explicitly document and test that
+behavior — functional methods that return a new dataset are easier to
+reason about.
+
+
+Subclassing (advanced)
+----------------------
+
+For use cases that genuinely require a custom class — for example,
+adding persistent state that travels with the dataset through filters
+— direct subclassing of :class:`~pyvista.PolyData` or
+:class:`~pyvista.UnstructuredGrid` is still supported. See
+:ref:`Extending PyVista Example <extending_pyvista_example>` for the
+subclassing pattern.
+
+For everything else, prefer accessors. They compose more cleanly,
+cost nothing when unused, and give plugins a clear boundary the
+PyVista core can rely on.

--- a/doc/styles/Vocab/pyvista/accept.txt
+++ b/doc/styles/Vocab/pyvista/accept.txt
@@ -1,5 +1,7 @@
 APIs
 Abaqus
+Accessor
+Accessors
 Ansys
 Attene
 Autosummary
@@ -12,10 +14,12 @@ Colab
 Colormap
 Colormaps
 Comms
+Composable
 Cookiecutter
 Coords
 Cython
 Dependabot
+Deregistration
 Deserializing
 Dev
 Dictionary-like
@@ -84,6 +88,8 @@ Transifex
 URI
 URIs
 VTK
+accessor
+accessors
 autodoc
 autoenum
 autofix
@@ -100,8 +106,11 @@ colormap
 colormaps
 conda
 data's
+dataclass
 dataframes
 dependabot
+deregister
+deregistration
 deserialize
 deserializes
 dev
@@ -148,9 +157,11 @@ numpy
 numpydoc
 omf
 omfvista
+pandas
 parametrizing
 parm
 performant
+pint-xarray
 pixi
 postprocessing
 pre
@@ -169,13 +180,16 @@ relicense
 renderers
 reusability
 revered
+rioxarray
 rst
 rtree
+runtime-checkable
 scipy
 scooby
 setuptools
 sphinx
 stl
+subclassing
 subpackages
 sympy
 tensorflow
@@ -201,5 +215,6 @@ vtk
 wireframe
 worktree
 wslink
+xarray
 xy
 zenodo

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -25,6 +25,15 @@ from pyvista.core._vtk_utilities import VersionInfo
 from pyvista.core._vtk_utilities import vtk_version_info as vtk_version_info
 from pyvista.core.cell import _get_vtk_id_type
 from pyvista.core.filters.data_object import MeshValidationFields as MeshValidationFields
+from pyvista.core.utilities.accessor_registry import AccessorRegistration as AccessorRegistration
+from pyvista.core.utilities.accessor_registry import DataSetAccessor as DataSetAccessor
+from pyvista.core.utilities.accessor_registry import (
+    register_dataset_accessor as register_dataset_accessor,
+)
+from pyvista.core.utilities.accessor_registry import registered_accessors as registered_accessors
+from pyvista.core.utilities.accessor_registry import (
+    unregister_dataset_accessor as unregister_dataset_accessor,
+)
 from pyvista.core.utilities.observers import send_errors_to_logging
 from pyvista.core.utilities.reader_registry import LocalFileRequiredError as LocalFileRequiredError
 from pyvista.core.utilities.reader_registry import has_scheme as has_scheme

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -28,9 +28,6 @@ from pyvista.core.filters.data_object import MeshValidationFields as MeshValidat
 from pyvista.core.utilities.accessor_registry import AccessorRegistration as AccessorRegistration
 from pyvista.core.utilities.accessor_registry import DataSetAccessor as DataSetAccessor
 from pyvista.core.utilities.accessor_registry import (
-    _ensure_entry_points as _ensure_accessor_entry_points,
-)
-from pyvista.core.utilities.accessor_registry import (
     register_dataset_accessor as register_dataset_accessor,
 )
 from pyvista.core.utilities.accessor_registry import registered_accessors as registered_accessors
@@ -80,13 +77,6 @@ ON_SCREENSHOT = os.environ.get('PYVISTA_ON_SCREENSHOT', 'false').lower() == 'tru
 
 # Send VTK messages to the logging module:
 send_errors_to_logging()
-
-# Discover ``pyvista.accessors`` entry points at ``import pyvista`` time.
-# Unlike readers/writers (discovered lazily on first ``read``/``save``),
-# accessors must attach their descriptors to dataset classes before any
-# ``dataset.<namespace>`` access can succeed — so discovery has to be
-# eager.
-_ensure_accessor_entry_points()
 
 # theme to use by default for the plot directive
 PLOT_DIRECTIVE_THEME = None

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -78,6 +78,15 @@ ON_SCREENSHOT = os.environ.get('PYVISTA_ON_SCREENSHOT', 'false').lower() == 'tru
 # Send VTK messages to the logging module:
 send_errors_to_logging()
 
+# Discover ``pyvista.accessors`` entry points so installed plugin
+# packages attach their accessors automatically, matching the
+# zero-config behavior of the reader / writer registries.
+from pyvista.core.utilities.accessor_registry import (
+    _ensure_entry_points as _ensure_accessor_entry_points,
+)
+
+_ensure_accessor_entry_points()
+
 # theme to use by default for the plot directive
 PLOT_DIRECTIVE_THEME = None
 

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -28,6 +28,9 @@ from pyvista.core.filters.data_object import MeshValidationFields as MeshValidat
 from pyvista.core.utilities.accessor_registry import AccessorRegistration as AccessorRegistration
 from pyvista.core.utilities.accessor_registry import DataSetAccessor as DataSetAccessor
 from pyvista.core.utilities.accessor_registry import (
+    _ensure_entry_points as _ensure_accessor_entry_points,
+)
+from pyvista.core.utilities.accessor_registry import (
     register_dataset_accessor as register_dataset_accessor,
 )
 from pyvista.core.utilities.accessor_registry import registered_accessors as registered_accessors
@@ -78,13 +81,11 @@ ON_SCREENSHOT = os.environ.get('PYVISTA_ON_SCREENSHOT', 'false').lower() == 'tru
 # Send VTK messages to the logging module:
 send_errors_to_logging()
 
-# Discover ``pyvista.accessors`` entry points so installed plugin
-# packages attach their accessors automatically, matching the
-# zero-config behavior of the reader / writer registries.
-from pyvista.core.utilities.accessor_registry import (
-    _ensure_entry_points as _ensure_accessor_entry_points,
-)
-
+# Discover ``pyvista.accessors`` entry points at ``import pyvista`` time.
+# Unlike readers/writers (discovered lazily on first ``read``/``save``),
+# accessors must attach their descriptors to dataset classes before any
+# ``dataset.<namespace>`` access can succeed — so discovery has to be
+# eager.
 _ensure_accessor_entry_points()
 
 # theme to use by default for the plot directive

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -101,7 +101,19 @@ class DataObject(_NoNewAttrMixin, DisableVtkSnakeCase, vtkPyVistaOverride):
         self._association_complex_names: defaultdict[Any, Any] = defaultdict(set)
 
     def __getattr__(self: Self, item: str) -> Any:
-        """Get attribute from base class if not found."""
+        """Get attribute from base class if not found.
+
+        Before falling through to the VTK base class, check whether
+        ``item`` matches a pending ``pyvista.accessors`` entry point.
+        A match triggers a one-shot plugin import, after which normal
+        attribute resolution finds the newly-attached accessor
+        descriptor.
+        """
+        # Lazy import to avoid a circular dependency at module load time.
+        from pyvista.core.utilities.accessor_registry import _resolve_pending_accessor
+
+        if _resolve_pending_accessor(item):
+            return object.__getattribute__(self, item)
         return super().__getattribute__(item)
 
     def shallow_copy(self: Self, to_copy: Self | _vtk.vtkDataObject) -> None:

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -213,7 +213,21 @@ class DataSet(DataSetFilters, DataObject):
         self._glyph_geom: Sequence[_vtk.vtkDataSet] | None = None
 
     def __getattr__(self: Self, item: str) -> Any:
-        """Get attribute from base class if not found."""
+        """Get attribute from base class if not found.
+
+        Before falling through to the VTK base class, check whether
+        ``item`` matches a pending ``pyvista.accessors`` entry point.
+        A match triggers a one-shot plugin import, after which normal
+        attribute resolution finds the newly-attached accessor
+        descriptor.
+        """
+        # Lazy import to avoid a circular dependency at module load time.
+        from pyvista.core.utilities.accessor_registry import (  # noqa: PLC0415
+            _resolve_pending_accessor,
+        )
+
+        if _resolve_pending_accessor(item):
+            return object.__getattribute__(self, item)
         return super().__getattribute__(item)
 
     @property

--- a/pyvista/core/utilities/__init__.py
+++ b/pyvista/core/utilities/__init__.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 import contextlib
 
+from .accessor_registry import AccessorRegistration as AccessorRegistration
+from .accessor_registry import DataSetAccessor as DataSetAccessor
+from .accessor_registry import register_dataset_accessor as register_dataset_accessor
+from .accessor_registry import registered_accessors as registered_accessors
+from .accessor_registry import unregister_dataset_accessor as unregister_dataset_accessor
 from .arrays import FieldAssociation as FieldAssociation
 from .arrays import array_from_vtkmatrix as array_from_vtkmatrix
 from .arrays import cell_array as cell_array

--- a/pyvista/core/utilities/accessor_registry.py
+++ b/pyvista/core/utilities/accessor_registry.py
@@ -12,8 +12,11 @@ Two registration paths are supported:
    user that does ``import plugin`` gets the accessor attached.
 2. **Entry points.** A plugin declares a ``pyvista.accessors`` entry
    point in its ``pyproject.toml`` pointing at its accessor module.
-   PyVista discovers and imports the module once on startup, so users
-   get the accessor without a manual ``import``.
+   PyVista reads the entry-point metadata lazily (no plugin module is
+   imported at ``import pyvista`` time). The plugin module imports only
+   when a user first accesses ``dataset.<name>`` on any dataset and the
+   normal attribute lookup misses. That isolates broken or slow plugins
+   from the main ``import pyvista`` path.
 
 See Also
 --------
@@ -121,9 +124,14 @@ class _AccessorRegistryState(TypedDict):
     # Snapshot of each target class's current binding for each registered
     # name so restore can diff against "live" state.
     attached: dict[tuple[type, str], Any]
-    # Whether entry-point discovery has already run. Tests that mock
-    # ``entry_points`` reset this to force re-discovery.
+    # Whether entry-point metadata has already been scanned. Tests that
+    # mock ``entry_points`` reset this to force a re-scan.
     entry_points_loaded: bool
+    # Accessor names declared via entry points that have not yet had
+    # their plugin module imported. Populated by ``_ensure_entry_points``
+    # and consumed by ``_resolve_pending_accessor`` on first attribute
+    # miss.
+    pending: dict[str, str]
 
 
 class _CachedAccessor:
@@ -167,6 +175,7 @@ _MISSING: Any = object()
 _registrations: list[AccessorRegistration] = []
 _prior_values: dict[tuple[type, str], Any] = {}
 _entry_points_loaded: bool = False
+_pending_accessors: dict[str, str] = {}
 
 
 def _save_registry_state() -> _AccessorRegistryState:
@@ -180,6 +189,7 @@ def _save_registry_state() -> _AccessorRegistryState:
         'prior': dict(_prior_values),
         'attached': attached,
         'entry_points_loaded': _entry_points_loaded,
+        'pending': dict(_pending_accessors),
     }
 
 
@@ -226,6 +236,8 @@ def _restore_registry_state(state: _AccessorRegistryState) -> None:
     _prior_values.clear()
     _prior_values.update(state['prior'])
     _entry_points_loaded = state['entry_points_loaded']
+    _pending_accessors.clear()
+    _pending_accessors.update(state['pending'])
 
 
 def _find_accessor_on_mro(target_cls: type, name: str) -> type | None:
@@ -529,11 +541,15 @@ def unregister_dataset_accessor(name: str, target_cls: type) -> None:
 
 
 def _ensure_entry_points() -> None:
-    """Discover ``pyvista.accessors`` entry points once.
+    """Scan ``pyvista.accessors`` entry-point metadata once.
 
-    Each entry point's ``value`` points at a plugin module. Importing
-    the module triggers any ``@register_dataset_accessor`` decorators
-    in that module, attaching the accessor as a side effect.
+    Populates :data:`_pending_accessors` with a mapping of
+    ``name -> module_path`` for every declared entry point. The plugin
+    modules themselves are **not** imported here; the cost of this
+    function is one ``importlib.metadata.entry_points`` call. The
+    plugin import is deferred to :func:`_resolve_pending_accessor`,
+    which runs only when the corresponding accessor is actually
+    accessed on a dataset.
     """
     global _entry_points_loaded  # noqa: PLW0603
     if _entry_points_loaded:
@@ -543,24 +559,58 @@ def _ensure_entry_points() -> None:
     # pyvista recursively does not loop back into this function.
     _entry_points_loaded = True
     for accessor_entry_point in entry_points(group=ACCESSOR_ENTRY_POINT_GROUP):
-        module_path = accessor_entry_point.value
-        try:
-            import_module(module_path)
-        except Exception as exc:  # noqa: BLE001
-            msg = (
-                f'Failed to load {ACCESSOR_ENTRY_POINT_GROUP} entry point '
-                f'"{accessor_entry_point.name}" from {module_path}: {exc}'
-            )
-            warn_external(msg)
+        _pending_accessors[accessor_entry_point.name] = accessor_entry_point.value
+
+
+def _resolve_pending_accessor(name: str) -> bool:
+    """Import the plugin module registered under ``name``, if any.
+
+    Called from :meth:`pyvista.DataObject.__getattr__` when a normal
+    attribute lookup misses. Ensures entry-point metadata has been
+    scanned, pops the pending entry for ``name``, and imports the
+    corresponding plugin module. Importing the module triggers any
+    ``@register_dataset_accessor`` decorators inside it and attaches
+    the accessor as a side effect.
+
+    Returns
+    -------
+    bool
+        ``True`` if a plugin was loaded for ``name`` (and the attribute
+        lookup should be retried). ``False`` if no pending plugin
+        matches ``name``, or if the plugin failed to import.
+
+    Notes
+    -----
+    A plugin that fails to import emits a ``UserWarning`` and is
+    dropped from the pending list, so subsequent lookups of the same
+    name fall straight through without re-triggering the import or
+    re-emitting the warning.
+
+    """
+    _ensure_entry_points()
+    module_path = _pending_accessors.pop(name, None)
+    if module_path is None:
+        return False
+    try:
+        import_module(module_path)
+    except Exception as exc:  # noqa: BLE001
+        msg = (
+            f'Failed to load {ACCESSOR_ENTRY_POINT_GROUP} entry point '
+            f'"{name}" from {module_path}: {exc}'
+        )
+        warn_external(msg)
+        return False
+    return True
 
 
 def registered_accessors() -> tuple[AccessorRegistration, ...]:
     """Return every accessor currently registered.
 
-    Inspects the registry populated by
-    :func:`~pyvista.register_dataset_accessor`. Entry-point plugins
-    are discovered (and their accessor modules imported) on the first
-    call so they appear in the result.
+    Forces discovery of any pending entry-point plugins so the returned
+    list reflects every plugin visible to PyVista, not just the ones
+    that have been touched already via attribute access. A plugin that
+    fails to import emits a ``UserWarning`` and is skipped; the rest
+    still appear in the result.
 
     .. versionadded:: 0.48.0
 
@@ -583,4 +633,6 @@ def registered_accessors() -> tuple[AccessorRegistration, ...]:
 
     """
     _ensure_entry_points()
+    for pending_name in list(_pending_accessors):
+        _resolve_pending_accessor(pending_name)
     return tuple(_registrations)

--- a/pyvista/core/utilities/accessor_registry.py
+++ b/pyvista/core/utilities/accessor_registry.py
@@ -5,6 +5,16 @@ dataset classes. Plugin packages attach a namespaced accessor to a target
 class at import time; the accessor is constructed lazily on first access
 per dataset instance and cached on the instance.
 
+Two registration paths are supported:
+
+1. **Explicit import.** A plugin's module runs the
+   :func:`register_dataset_accessor` decorator at import time, so any
+   user that does ``import plugin`` gets the accessor attached.
+2. **Entry points.** A plugin declares a ``pyvista.accessors`` entry
+   point in its ``pyproject.toml`` pointing at its accessor module.
+   PyVista discovers and imports the module once on startup, so users
+   get the accessor without a manual ``import``.
+
 See Also
 --------
 pyvista.register_dataset_accessor
@@ -16,6 +26,8 @@ pyvista.registered_accessors
 from __future__ import annotations
 
 import contextlib
+from importlib import import_module
+from importlib.metadata import entry_points
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import NamedTuple
@@ -27,6 +39,9 @@ from pyvista._warn_external import warn_external
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+
+ACCESSOR_ENTRY_POINT_GROUP = 'pyvista.accessors'
 
 
 @runtime_checkable
@@ -95,6 +110,9 @@ class _AccessorRegistryState(TypedDict):
     # Snapshot of each target class's current binding for each registered
     # name so restore can diff against "live" state.
     attached: dict[tuple[type, str], Any]
+    # Whether entry-point discovery has already run. Tests that mock
+    # ``entry_points`` reset this to force re-discovery.
+    entry_points_loaded: bool
 
 
 class _CachedAccessor:
@@ -137,6 +155,7 @@ _MISSING: Any = object()
 
 _registrations: list[AccessorRegistration] = []
 _prior_values: dict[tuple[type, str], Any] = {}
+_entry_points_loaded: bool = False
 
 
 def _save_registry_state() -> _AccessorRegistryState:
@@ -149,6 +168,7 @@ def _save_registry_state() -> _AccessorRegistryState:
         'registrations': list(_registrations),
         'prior': dict(_prior_values),
         'attached': attached,
+        'entry_points_loaded': _entry_points_loaded,
     }
 
 
@@ -159,6 +179,7 @@ def _restore_registry_state(state: _AccessorRegistryState) -> None:
     taken and re-attaches any that were removed, putting prior built-in
     attributes back if override had shadowed them.
     """
+    global _entry_points_loaded  # noqa: PLW0603
     current_keys = {(r.target, r.name) for r in _registrations}
     snapshot_keys = {(r.target, r.name) for r in state['registrations']}
 
@@ -193,6 +214,7 @@ def _restore_registry_state(state: _AccessorRegistryState) -> None:
     _registrations.extend(state['registrations'])
     _prior_values.clear()
     _prior_values.update(state['prior'])
+    _entry_points_loaded = state['entry_points_loaded']
 
 
 def _find_accessor_on_mro(target_cls: type, name: str) -> type | None:
@@ -491,11 +513,40 @@ def unregister_dataset_accessor(name: str, target_cls: type) -> None:
     ]
 
 
+def _ensure_entry_points() -> None:
+    """Discover ``pyvista.accessors`` entry points once.
+
+    Each entry point's ``value`` points at a plugin module. Importing
+    the module triggers any ``@register_dataset_accessor`` decorators
+    in that module, attaching the accessor as a side effect.
+    """
+    global _entry_points_loaded  # noqa: PLW0603
+    if _entry_points_loaded:
+        return
+
+    # Flip the flag before iterating so a plugin that happens to import
+    # pyvista recursively does not loop back into this function.
+    _entry_points_loaded = True
+    for accessor_entry_point in entry_points(group=ACCESSOR_ENTRY_POINT_GROUP):
+        module_path = accessor_entry_point.value
+        try:
+            import_module(module_path)
+        except Exception as exc:  # noqa: BLE001
+            msg = (
+                f'Failed to load {ACCESSOR_ENTRY_POINT_GROUP} entry point '
+                f'"{accessor_entry_point.name}" from {module_path}: {exc}'
+            )
+            warn_external(msg)
+            continue
+
+
 def registered_accessors() -> tuple[AccessorRegistration, ...]:
     """Return every accessor currently registered.
 
     Inspects the registry populated by
-    :func:`~pyvista.register_dataset_accessor`.
+    :func:`~pyvista.register_dataset_accessor`. Entry-point plugins
+    are discovered (and their accessor modules imported) on the first
+    call so they appear in the result.
 
     Returns
     -------
@@ -515,4 +566,5 @@ def registered_accessors() -> tuple[AccessorRegistration, ...]:
     >>> pv.unregister_dataset_accessor('demo_listed', pv.PolyData)
 
     """
+    _ensure_entry_points()
     return tuple(_registrations)

--- a/pyvista/core/utilities/accessor_registry.py
+++ b/pyvista/core/utilities/accessor_registry.py
@@ -616,7 +616,7 @@ def registered_accessors() -> tuple[AccessorRegistration, ...]:
 
     Returns
     -------
-    tuple of AccessorRegistration
+    tuple[AccessorRegistration, ...]
         Ordered by registration time. Each record exposes ``name``,
         ``target``, ``accessor``, and ``source``.
 

--- a/pyvista/core/utilities/accessor_registry.py
+++ b/pyvista/core/utilities/accessor_registry.py
@@ -53,6 +53,15 @@ class DataSetAccessor(Protocol):
     available as ``dataset.<namespace>.<method>(...)`` once the class is
     registered with :func:`~pyvista.register_dataset_accessor`.
 
+    This Protocol exists primarily for static type analysis: plugin
+    authors can annotate ``accessor_cls: type[DataSetAccessor]`` (or
+    use it as a return annotation) to have mypy/pyright check that
+    their accessor class conforms. The runtime ``isinstance`` check is
+    intentionally permissive (every class has ``__init__``), so prefer
+    the static-typing use.
+
+    .. versionadded:: 0.48.0
+
     Examples
     --------
     Declare an accessor that satisfies the protocol.
@@ -73,6 +82,8 @@ class AccessorRegistration(NamedTuple):
     """Describe one registered dataset accessor.
 
     Returned by :func:`~pyvista.registered_accessors`.
+
+    .. versionadded:: 0.48.0
 
     Attributes
     ----------
@@ -141,9 +152,9 @@ class _CachedAccessor:
             # ``help(cls.<name>)`` shows the accessor docstring.
             return self._accessor_cls
         accessor_instance = self._accessor_cls(obj)
-        # Skip the cache on slotted or read-only objects and construct
-        # fresh on each access.
-        with contextlib.suppress(AttributeError, TypeError):
+        # Skip the cache on ``__slots__`` targets (no ``__dict__``) and
+        # construct fresh on each access.
+        with contextlib.suppress(AttributeError):
             obj.__dict__[self._name] = accessor_instance
         return accessor_instance
 
@@ -301,6 +312,8 @@ def register_dataset_accessor(
     and its subclasses. The accessor class is instantiated lazily on
     first access and cached on the dataset instance, so subsequent
     accesses return the same accessor object.
+
+    .. versionadded:: 0.48.0
 
     Parameters
     ----------
@@ -462,6 +475,8 @@ def unregister_dataset_accessor(name: str, target_cls: type) -> None:
     any built-in attribute that was shadowed via ``override=True`` when
     the accessor was registered.
 
+    .. versionadded:: 0.48.0
+
     Parameters
     ----------
     name : str
@@ -537,7 +552,6 @@ def _ensure_entry_points() -> None:
                 f'"{accessor_entry_point.name}" from {module_path}: {exc}'
             )
             warn_external(msg)
-            continue
 
 
 def registered_accessors() -> tuple[AccessorRegistration, ...]:
@@ -547,6 +561,8 @@ def registered_accessors() -> tuple[AccessorRegistration, ...]:
     :func:`~pyvista.register_dataset_accessor`. Entry-point plugins
     are discovered (and their accessor modules imported) on the first
     call so they appear in the result.
+
+    .. versionadded:: 0.48.0
 
     Returns
     -------

--- a/pyvista/core/utilities/accessor_registry.py
+++ b/pyvista/core/utilities/accessor_registry.py
@@ -1,0 +1,518 @@
+"""Registry for third-party dataset accessors.
+
+This module implements the pandas/xarray-style accessor pattern for PyVista
+dataset classes. Plugin packages attach a namespaced accessor to a target
+class at import time; the accessor is constructed lazily on first access
+per dataset instance and cached on the instance.
+
+See Also
+--------
+pyvista.register_dataset_accessor
+pyvista.unregister_dataset_accessor
+pyvista.registered_accessors
+
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import NamedTuple
+from typing import Protocol
+from typing import TypedDict
+from typing import runtime_checkable
+
+from pyvista._warn_external import warn_external
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@runtime_checkable
+class DataSetAccessor(Protocol):
+    """Structural protocol for third-party accessor classes.
+
+    An accessor class must accept the dataset instance as its single
+    ``__init__`` argument. Any public methods on the class become
+    available as ``dataset.<namespace>.<method>(...)`` once the class is
+    registered with :func:`~pyvista.register_dataset_accessor`.
+
+    Examples
+    --------
+    Declare an accessor that satisfies the protocol.
+
+    >>> from pyvista import DataSetAccessor
+    >>> class MyAccessor:
+    ...     def __init__(self, dataset):
+    ...         self._dataset = dataset
+    >>> isinstance(MyAccessor(None), DataSetAccessor)
+    True
+
+    """
+
+    def __init__(self, dataset: Any) -> None: ...
+
+
+class AccessorRegistration(NamedTuple):
+    """Describe one registered dataset accessor.
+
+    Returned by :func:`~pyvista.registered_accessors`.
+
+    Attributes
+    ----------
+    name : str
+        The namespace the accessor is attached under (e.g. ``'meshfix'``).
+    target : type
+        The PyVista dataset class (or base class) the accessor is
+        registered against.
+    accessor : type
+        The accessor class itself.
+    source : str
+        Human-readable origin in the form ``'module.qualname'`` — useful
+        for debugging which plugin registered a given accessor.
+
+    """
+
+    name: str
+    target: type
+    accessor: type
+    source: str
+
+
+class _AccessorRegistryState(TypedDict):
+    """Stored registry state used for test isolation.
+
+    Records every ``(target_cls, name)`` the registry has touched along
+    with the value that was present on the class dictionary before the
+    accessor replaced it (sentinel if the attribute did not exist).
+    """
+
+    registrations: list[AccessorRegistration]
+    # Per (target, name), the exact attribute that was in target.__dict__
+    # before registration, or _MISSING if no attribute existed.
+    prior: dict[tuple[type, str], Any]
+    # Snapshot of each target class's current binding for each registered
+    # name so restore can diff against "live" state.
+    attached: dict[tuple[type, str], Any]
+
+
+class _CachedAccessor:
+    """Non-data descriptor implementing the pandas/xarray accessor pattern.
+
+    The first time ``obj.<name>`` is accessed, ``accessor_cls(obj)`` is
+    constructed and stored in ``obj.__dict__[name]``. Subsequent lookups
+    bypass the descriptor and hit ``__dict__`` directly because a
+    non-data descriptor yields to instance ``__dict__``.
+
+    When the target class uses ``__slots__`` and no ``__dict__`` is
+    available, the accessor is constructed fresh on each access — slower
+    but still correct.
+    """
+
+    def __init__(self, name: str, accessor_cls: type) -> None:
+        self._name = name
+        self._accessor_cls = accessor_cls
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return f'<_CachedAccessor name={self._name!r} cls={self._accessor_cls!r}>'
+
+    def __get__(self, obj: Any, objtype: type | None = None) -> Any:
+        if obj is None:
+            # Class-level access returns the accessor class itself so
+            # ``help(cls.<name>)`` shows the accessor docstring.
+            return self._accessor_cls
+        accessor_instance = self._accessor_cls(obj)
+        # Skip the cache on slotted or read-only objects and construct
+        # fresh on each access.
+        with contextlib.suppress(AttributeError, TypeError):
+            obj.__dict__[self._name] = accessor_instance
+        return accessor_instance
+
+
+# ``_MISSING`` marks "attribute did not exist on the target class dict
+# before we touched it" so unregister can tell the difference between
+# "restore nothing" and "restore a prior value of None".
+_MISSING: Any = object()
+
+_registrations: list[AccessorRegistration] = []
+_prior_values: dict[tuple[type, str], Any] = {}
+
+
+def _save_registry_state() -> _AccessorRegistryState:
+    """Snapshot the current registry state for later restoration."""
+    attached: dict[tuple[type, str], Any] = {}
+    for record in _registrations:
+        key = (record.target, record.name)
+        attached[key] = record.target.__dict__.get(record.name, _MISSING)
+    return {
+        'registrations': list(_registrations),
+        'prior': dict(_prior_values),
+        'attached': attached,
+    }
+
+
+def _restore_registry_state(state: _AccessorRegistryState) -> None:
+    """Restore registry state from a snapshot.
+
+    Removes any accessors that have been added since the snapshot was
+    taken and re-attaches any that were removed, putting prior built-in
+    attributes back if override had shadowed them.
+    """
+    current_keys = {(r.target, r.name) for r in _registrations}
+    snapshot_keys = {(r.target, r.name) for r in state['registrations']}
+
+    # Remove anything that was not in the snapshot.
+    for record in _registrations:
+        key = (record.target, record.name)
+        if key in snapshot_keys:
+            continue
+        attr = record.target.__dict__.get(record.name)
+        if isinstance(attr, _CachedAccessor):
+            delattr(record.target, record.name)
+        prior = _prior_values.pop(key, _MISSING)
+        if prior is not _MISSING:
+            setattr(record.target, record.name, prior)
+
+    # Re-add anything that was in the snapshot but has since been
+    # removed, restoring the descriptor binding that was live at
+    # snapshot time.
+    for record in state['registrations']:
+        key = (record.target, record.name)
+        attached_at_snapshot = state['attached'].get(key, _MISSING)
+        if attached_at_snapshot is _MISSING:
+            if record.name in record.target.__dict__:
+                delattr(record.target, record.name)
+        elif (
+            key not in current_keys
+            or record.target.__dict__.get(record.name) is not attached_at_snapshot
+        ):
+            setattr(record.target, record.name, attached_at_snapshot)
+
+    _registrations.clear()
+    _registrations.extend(state['registrations'])
+    _prior_values.clear()
+    _prior_values.update(state['prior'])
+
+
+def _find_accessor_on_mro(target_cls: type, name: str) -> type | None:
+    """Return the class whose ``__dict__`` owns the accessor.
+
+    Walks ``target_cls.__mro__`` and returns the first class whose
+    ``__dict__`` holds a :class:`_CachedAccessor` under ``name``, or
+    ``None`` if none exists.
+    """
+    for klass in target_cls.__mro__:
+        attr = klass.__dict__.get(name)
+        if isinstance(attr, _CachedAccessor):
+            return klass
+    return None
+
+
+def _find_shadow_on_mro(target_cls: type, name: str) -> type | None:
+    """Return the class shadowing ``name`` with a non-accessor attribute.
+
+    Walks ``target_cls.__mro__`` (skipping ``object``) and returns the
+    first class that defines a non-accessor attribute under ``name``, or
+    ``None`` if none exists. Used to detect built-in attribute
+    shadowing.
+    """
+    for klass in target_cls.__mro__:
+        if klass is object:
+            continue
+        if name not in klass.__dict__:
+            continue
+        attr = klass.__dict__[name]
+        if isinstance(attr, _CachedAccessor):
+            return None  # an accessor wins over any further shadow search
+        return klass
+    return None
+
+
+def _validate_name(name: object) -> str:
+    """Normalize and validate an accessor name.
+
+    Accepts ``object`` so the ``isinstance`` check is reachable for
+    callers that bypass static typing (e.g. dynamic plugin loaders or
+    tests that intentionally pass the wrong type).
+    """
+    if not isinstance(name, str):
+        msg = f'Accessor name must be a string, got {type(name).__name__}.'
+        raise TypeError(msg)
+    normalized = name.strip()
+    if not normalized:
+        msg = 'Accessor name must not be empty.'
+        raise ValueError(msg)
+    if normalized.startswith('_'):
+        msg = (
+            f'Accessor name must not start with an underscore, got {name!r}. '
+            'Leading underscores are reserved for PyVista internals.'
+        )
+        raise ValueError(msg)
+    if not normalized.isidentifier():
+        msg = f'Accessor name must be a valid Python identifier, got {name!r}.'
+        raise ValueError(msg)
+    return normalized
+
+
+def _validate_target(target_cls: Any) -> type:
+    """Validate that ``target_cls`` is a class."""
+    if not isinstance(target_cls, type):
+        msg = f'target_cls must be a class, got {type(target_cls).__name__}.'
+        raise TypeError(msg)
+    return target_cls
+
+
+def register_dataset_accessor(
+    name: str,
+    target_cls: type,
+    *,
+    override: bool = False,
+) -> Callable[[type], type]:
+    """Register a custom namespaced accessor on a PyVista dataset class.
+
+    Mirrors the accessor pattern used by
+    `pandas <https://pandas.pydata.org/docs/development/extending.html#registering-custom-accessors>`_
+    and `xarray <https://docs.xarray.dev/en/stable/internals/extending-xarray.html>`_.
+    Once registered, the accessor becomes available as
+    ``dataset.<name>.<method>(...)`` on every instance of ``target_cls``
+    and its subclasses. The accessor class is instantiated lazily on
+    first access and cached on the dataset instance, so subsequent
+    accesses return the same accessor object.
+
+    Parameters
+    ----------
+    name : str
+        The namespace the accessor will be attached under. Must be a
+        valid Python identifier that does not start with an underscore.
+
+    target_cls : type
+        The PyVista dataset class (or base class) to attach the accessor
+        to. Registering against :class:`~pyvista.DataSet` exposes the
+        accessor on every subclass (``PolyData``, ``UnstructuredGrid``,
+        ``ImageData``, and so on). Registering against
+        :class:`~pyvista.DataObject` additionally covers
+        :class:`~pyvista.MultiBlock`.
+
+    override : bool, default: False
+        If ``True``, allow registering a name that shadows an existing
+        built-in attribute on ``target_cls`` (a filter method, property,
+        or any other non-accessor attribute). The prior attribute is
+        restored on :func:`~pyvista.unregister_dataset_accessor`.
+
+    Returns
+    -------
+    callable
+        Decorator that registers the accessor class passed to it and
+        returns that class unchanged.
+
+    Raises
+    ------
+    ValueError
+        If ``name`` is empty, not a valid identifier, starts with ``_``,
+        or shadows a built-in attribute on ``target_cls`` without
+        ``override=True``.
+
+    TypeError
+        If ``target_cls`` is not a class, or ``name`` is not a string.
+
+    Warns
+    -----
+    UserWarning
+        If ``name`` already refers to a registered accessor on
+        ``target_cls`` or any ancestor. Emitting a warning rather than
+        raising matches pandas' behavior and avoids hard-failing when
+        two plugins collide.
+
+    See Also
+    --------
+    pyvista.unregister_dataset_accessor
+    pyvista.registered_accessors
+    pyvista.DataSetAccessor
+
+    Examples
+    --------
+    Register a minimal accessor on :class:`~pyvista.PolyData`.
+
+    >>> import pyvista as pv
+    >>> @pv.register_dataset_accessor('demo', pv.PolyData)
+    ... class DemoAccessor:
+    ...     def __init__(self, mesh):
+    ...         self._mesh = mesh
+    ...
+    ...     def n_points_doubled(self):
+    ...         return self._mesh.n_points * 2
+    >>> sphere = pv.Sphere()
+    >>> sphere.demo.n_points_doubled() == sphere.n_points * 2
+    True
+
+    The accessor is cached per instance. Repeated access returns the
+    same object.
+
+    >>> sphere.demo is sphere.demo
+    True
+
+    Clean up so the namespace is not visible to later doctest examples.
+
+    >>> pv.unregister_dataset_accessor('demo', pv.PolyData)
+
+    """
+    normalized = _validate_name(name)
+    target = _validate_target(target_cls)
+
+    # Accept ``object`` so the runtime guard is reachable when callers
+    # (e.g. dynamic plugin loaders) bypass static typing.
+    def decorator(accessor_cls: object) -> type:
+        if not isinstance(accessor_cls, type):
+            msg = f'Accessor must be a class, got {type(accessor_cls).__name__}.'
+            raise TypeError(msg)
+        _attach_accessor(normalized, target, accessor_cls, override=override)
+        return accessor_cls
+
+    return decorator
+
+
+def _attach_accessor(
+    name: str,
+    target_cls: type,
+    accessor_cls: type,
+    *,
+    override: bool,
+) -> None:
+    """Attach ``accessor_cls`` as a ``_CachedAccessor`` on ``target_cls``.
+
+    Performs collision detection before attaching.
+    """
+    accessor_owner = _find_accessor_on_mro(target_cls, name)
+    if accessor_owner is not None:
+        # Accessor-vs-accessor collision — warn and replace (pandas style).
+        if accessor_owner is target_cls:
+            location = target_cls.__qualname__
+        else:
+            location = f'{accessor_owner.__qualname__} (inherited by {target_cls.__qualname__})'
+        warn_external(
+            f'Registering accessor {name!r} on {target_cls.__qualname__} '
+            f'replaces an existing registered accessor on {location}.',
+        )
+    else:
+        shadow_owner = _find_shadow_on_mro(target_cls, name)
+        if shadow_owner is not None and not override:
+            if shadow_owner is target_cls:
+                location = target_cls.__qualname__
+            else:
+                location = f'{shadow_owner.__qualname__} (inherited by {target_cls.__qualname__})'
+            msg = (
+                f'Cannot register accessor {name!r} on '
+                f'{target_cls.__qualname__}: shadows built-in attribute on '
+                f'{location}. Pass override=True to force.'
+            )
+            raise ValueError(msg)
+
+    # Record the prior attribute value only on first registration for
+    # this (target, name) pair so repeated override+register cycles do
+    # not forget the very first built-in attribute.
+    key = (target_cls, name)
+    if key not in _prior_values:
+        _prior_values[key] = target_cls.__dict__.get(name, _MISSING)
+
+    setattr(target_cls, name, _CachedAccessor(name, accessor_cls))
+
+    source = f'{accessor_cls.__module__}.{accessor_cls.__qualname__}'
+    # Remove any previous registration record for this (target, name) pair
+    # so the registry state never reports duplicates.
+    _registrations[:] = [
+        r for r in _registrations if not (r.target is target_cls and r.name == name)
+    ]
+    _registrations.append(
+        AccessorRegistration(
+            name=name,
+            target=target_cls,
+            accessor=accessor_cls,
+            source=source,
+        ),
+    )
+
+
+def unregister_dataset_accessor(name: str, target_cls: type) -> None:
+    """Remove an accessor previously attached to a target class.
+
+    The inverse of :func:`~pyvista.register_dataset_accessor`. Restores
+    any built-in attribute that was shadowed via ``override=True`` when
+    the accessor was registered.
+
+    Parameters
+    ----------
+    name : str
+        Namespace of the accessor to remove.
+    target_cls : type
+        Target class the accessor was registered against. Only accessors
+        attached directly on ``target_cls`` can be unregistered; an
+        accessor inherited from a parent class must be unregistered on
+        that parent.
+
+    Raises
+    ------
+    ValueError
+        If no accessor named ``name`` is attached directly to
+        ``target_cls``.
+
+    TypeError
+        If ``target_cls`` is not a class, or ``name`` is not a string.
+
+    Examples
+    --------
+    >>> import pyvista as pv
+    >>> @pv.register_dataset_accessor('tmp', pv.PolyData)
+    ... class TmpAccessor:
+    ...     def __init__(self, mesh):
+    ...         self._mesh = mesh
+    >>> pv.unregister_dataset_accessor('tmp', pv.PolyData)
+
+    """
+    normalized = _validate_name(name)
+    target = _validate_target(target_cls)
+
+    attr = target.__dict__.get(normalized)
+    if not isinstance(attr, _CachedAccessor):
+        # ValueError (not TypeError) — the shape of the target is valid,
+        # the caller just did not have an accessor to remove.
+        msg = f'No registered accessor {name!r} attached directly to {target.__qualname__}.'
+        raise ValueError(msg)  # noqa: TRY004
+
+    key = (target, normalized)
+    prior = _prior_values.pop(key, _MISSING)
+    if prior is _MISSING:
+        delattr(target, normalized)
+    else:
+        setattr(target, normalized, prior)
+
+    _registrations[:] = [
+        r for r in _registrations if not (r.target is target and r.name == normalized)
+    ]
+
+
+def registered_accessors() -> tuple[AccessorRegistration, ...]:
+    """Return every accessor currently registered.
+
+    Inspects the registry populated by
+    :func:`~pyvista.register_dataset_accessor`.
+
+    Returns
+    -------
+    tuple of AccessorRegistration
+        Ordered by registration time. Each record exposes ``name``,
+        ``target``, ``accessor``, and ``source``.
+
+    Examples
+    --------
+    >>> import pyvista as pv
+    >>> @pv.register_dataset_accessor('demo_listed', pv.PolyData)
+    ... class DemoListedAccessor:
+    ...     def __init__(self, mesh):
+    ...         self._mesh = mesh
+    >>> [r.name for r in pv.registered_accessors() if r.name == 'demo_listed']
+    ['demo_listed']
+    >>> pv.unregister_dataset_accessor('demo_listed', pv.PolyData)
+
+    """
+    return tuple(_registrations)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,12 @@ import pytest
 import pyvista as pv
 from pyvista import examples
 from pyvista.core._vtk_utilities import VersionInfo
+from pyvista.core.utilities.accessor_registry import (
+    _restore_registry_state as _restore_accessor_registry_state,
+)
+from pyvista.core.utilities.accessor_registry import (
+    _save_registry_state as _save_accessor_registry_state,
+)
 from pyvista.core.utilities.reader_registry import _restore_registry_state
 from pyvista.core.utilities.reader_registry import _save_registry_state
 from pyvista.core.utilities.writer_registry import (
@@ -130,12 +136,14 @@ def reset_global_state():
     style_registry_state = _save_style_registry_state()
     reader_registry_state = _save_registry_state()
     writer_registry_state = _save_writer_registry_state()
+    accessor_registry_state = _save_accessor_registry_state()
 
     yield
 
     _restore_style_registry_state(style_registry_state)
     _restore_registry_state(reader_registry_state)
     _restore_writer_registry_state(writer_registry_state)
+    _restore_accessor_registry_state(accessor_registry_state)
 
     pv.vtk_snake_case('error')
     assert pv.vtk_snake_case() == 'error'

--- a/tests/core/test_accessor_registry.py
+++ b/tests/core/test_accessor_registry.py
@@ -737,11 +737,17 @@ def test_broken_plugin_warns_once_and_isolates(monkeypatch):
             _ = pv.Sphere().broken
 
     # Pending entry was consumed, so a second access is a clean
-    # AttributeError with no retry and no second warning.
-    with warnings.catch_warnings():
-        warnings.simplefilter('error')
+    # AttributeError with no retry and no second "Failed to load"
+    # warning. Capture all warnings and assert specifically that no
+    # accessor-load warning fires; unrelated warnings (e.g. nightly
+    # NumPy / VTK deprecations) are ignored.
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter('always')
         with pytest.raises(AttributeError):
             _ = pv.Sphere().broken
+
+    accessor_warnings = [w for w in captured if 'Failed to load' in str(w.message)]
+    assert accessor_warnings == []
 
     # Unrelated attributes still work.
     assert pv.Sphere().n_points > 0
@@ -848,11 +854,24 @@ def test_registered_accessors_forces_discovery(monkeypatch):
 
 
 def test_no_entry_points_is_silent(monkeypatch):
-    """No installed accessor plugins must be a no-op without warnings."""
+    """No installed accessor plugins must be a no-op without warnings.
+
+    Captures all warnings and asserts none of them came from the
+    accessor registry. Unrelated warnings (e.g. NumPy / VTK nightly
+    deprecations) are ignored so the test stays robust on
+    nightly-dependency CI jobs.
+    """
     _reset_entry_point_state(monkeypatch, [])
-    with warnings.catch_warnings():
-        warnings.simplefilter('error')
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter('always')
         _reg_mod._ensure_entry_points()
         # Attribute access for an unknown name still raises cleanly.
         with pytest.raises(AttributeError):
             _ = pv.Sphere().completely_unknown
+
+    accessor_warnings = [
+        w
+        for w in captured
+        if 'pyvista.accessors' in str(w.message) or 'Failed to load' in str(w.message)
+    ]
+    assert accessor_warnings == []

--- a/tests/core/test_accessor_registry.py
+++ b/tests/core/test_accessor_registry.py
@@ -1,0 +1,550 @@
+"""Tests for the dataset accessor registry."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+import pyvista as pv
+from pyvista.core.utilities import accessor_registry as _reg_mod
+
+
+def test_decorator_registers_accessor():
+    @pv.register_dataset_accessor('demo', pv.PolyData)
+    class DemoAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+        def n_points_doubled(self):
+            return self._mesh.n_points * 2
+
+    sphere = pv.Sphere()
+    assert sphere.demo.n_points_doubled() == sphere.n_points * 2
+
+
+def test_direct_call_registers_accessor():
+    class DemoAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+        def value(self):
+            return 42
+
+    pv.register_dataset_accessor('demo_direct', pv.PolyData)(DemoAccessor)
+    assert pv.Sphere().demo_direct.value() == 42
+
+
+def test_accessor_init_called_once_per_instance():
+    init_calls: list[pv.PolyData] = []
+
+    @pv.register_dataset_accessor('counted', pv.PolyData)
+    class CountedAccessor:
+        def __init__(self, mesh):
+            init_calls.append(mesh)
+            self._mesh = mesh
+
+    sphere = pv.Sphere()
+    _ = sphere.counted
+    _ = sphere.counted
+    _ = sphere.counted
+    assert len(init_calls) == 1
+    assert init_calls[0] is sphere
+
+
+def test_same_cached_accessor_returned_on_repeat_access():
+    @pv.register_dataset_accessor('cached', pv.PolyData)
+    class CachedAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+    sphere = pv.Sphere()
+    first = sphere.cached
+    second = sphere.cached
+    assert first is second
+
+
+def test_del_evicts_cache():
+    """Deleting the instance attribute forces a rebuild."""
+    init_count = 0
+
+    @pv.register_dataset_accessor('evictable', pv.PolyData)
+    class EvictableAccessor:
+        def __init__(self, mesh):
+            nonlocal init_count
+            init_count += 1
+            self._mesh = mesh
+
+    sphere = pv.Sphere()
+    _ = sphere.evictable
+    assert init_count == 1
+    del sphere.evictable
+    _ = sphere.evictable
+    assert init_count == 2
+
+
+def test_class_access_returns_accessor_class():
+    @pv.register_dataset_accessor('exposed', pv.PolyData)
+    class ExposedAccessor:
+        """Docstring visible on help(pv.PolyData.exposed)."""
+
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+    assert pv.PolyData.exposed is ExposedAccessor
+    assert 'Docstring visible' in (pv.PolyData.exposed.__doc__ or '')
+
+
+def test_accessor_name_appears_in_dir():
+    @pv.register_dataset_accessor('discoverable', pv.PolyData)
+    class DiscoverableAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+    assert 'discoverable' in dir(pv.PolyData)
+    assert 'discoverable' in dir(pv.Sphere())
+
+
+@pytest.mark.parametrize(
+    'factory',
+    [
+        pv.Sphere,
+        pv.ImageData,
+        pv.RectilinearGrid,
+        pv.UnstructuredGrid,
+        pv.StructuredGrid,
+    ],
+)
+def test_register_on_dataset_visible_on_all_subclasses(factory):
+    @pv.register_dataset_accessor('ds_level', pv.DataSet)
+    class DataSetLevelAccessor:
+        def __init__(self, dataset):
+            self._dataset = dataset
+
+        def is_alive(self):
+            return self._dataset is not None
+
+    obj = factory()
+    assert obj.ds_level.is_alive() is True
+
+
+def test_register_on_dataobject_visible_on_multiblock():
+    @pv.register_dataset_accessor('obj_level', pv.DataObject)
+    class DataObjectLevelAccessor:
+        def __init__(self, obj):
+            self._obj = obj
+
+        def tag(self):
+            return type(self._obj).__name__
+
+    block = pv.MultiBlock()
+    assert block.obj_level.tag() == 'MultiBlock'
+    assert pv.Sphere().obj_level.tag() == 'PolyData'
+
+
+def test_register_on_polydata_not_visible_on_unstructured():
+    @pv.register_dataset_accessor('poly_only', pv.PolyData)
+    class PolyOnlyAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+    assert hasattr(pv.Sphere(), 'poly_only')
+    assert not hasattr(pv.UnstructuredGrid(), 'poly_only')
+
+
+def test_subclass_accessor_shadows_ancestor_silently_when_different_names():
+    """Registering different names on ancestor and subclass does not collide."""
+
+    @pv.register_dataset_accessor('base_ns', pv.DataSet)
+    class BaseAccessor:
+        def __init__(self, dataset):
+            self._dataset = dataset
+
+        def who(self):
+            return 'base'
+
+    @pv.register_dataset_accessor('sub_ns', pv.PolyData)
+    class SubAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+        def who(self):
+            return 'sub'
+
+    sphere = pv.Sphere()
+    assert sphere.base_ns.who() == 'base'
+    assert sphere.sub_ns.who() == 'sub'
+
+    grid = pv.ImageData()
+    assert grid.base_ns.who() == 'base'
+    assert not hasattr(grid, 'sub_ns')
+
+
+def test_accessor_survives_type_changing_filter_chain():
+    """An accessor on DataSet survives a filter that changes dataset type."""
+
+    @pv.register_dataset_accessor('chain_tag', pv.DataSet)
+    class ChainTagAccessor:
+        def __init__(self, dataset):
+            self._dataset = dataset
+
+        def classname(self):
+            return type(self._dataset).__name__
+
+    sphere = pv.Sphere()
+    grid = sphere.cast_to_unstructured_grid()
+    assert isinstance(grid, pv.UnstructuredGrid)
+    assert grid.chain_tag.classname() == 'UnstructuredGrid'
+
+
+def test_accessor_vs_accessor_collision_warns_and_replaces():
+    @pv.register_dataset_accessor('clashing', pv.PolyData)
+    class FirstAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+        def who(self):
+            return 'first'
+
+    with pytest.warns(UserWarning, match='replaces an existing registered accessor'):
+
+        @pv.register_dataset_accessor('clashing', pv.PolyData)
+        class SecondAccessor:
+            def __init__(self, mesh):
+                self._mesh = mesh
+
+            def who(self):
+                return 'second'
+
+    assert pv.Sphere().clashing.who() == 'second'
+
+
+def test_inherited_accessor_collision_warns():
+    """Registering on a subclass when an ancestor already owns the name warns."""
+
+    @pv.register_dataset_accessor('inherited_clash', pv.DataSet)
+    class AncestorAccessor:
+        def __init__(self, dataset):
+            self._dataset = dataset
+
+        def who(self):
+            return 'ancestor'
+
+    with pytest.warns(UserWarning, match='inherited by PolyData'):
+
+        @pv.register_dataset_accessor('inherited_clash', pv.PolyData)
+        class DescendantAccessor:
+            def __init__(self, mesh):
+                self._mesh = mesh
+
+            def who(self):
+                return 'descendant'
+
+    assert pv.Sphere().inherited_clash.who() == 'descendant'
+    assert pv.ImageData().inherited_clash.who() == 'ancestor'
+
+
+def test_builtin_shadow_raises_without_override():
+    """Shadowing an existing filter method must raise, not warn."""
+    with pytest.raises(ValueError, match='shadows built-in attribute'):
+
+        @pv.register_dataset_accessor('clip', pv.PolyData)
+        class ClipAccessor:
+            def __init__(self, mesh):
+                self._mesh = mesh
+
+    assert callable(pv.PolyData.clip)
+
+
+def test_builtin_shadow_succeeds_with_override():
+    """``override=True`` bypasses the built-in-shadow check."""
+    original_clip = pv.PolyData.clip
+
+    @pv.register_dataset_accessor('clip', pv.PolyData, override=True)
+    class FakeClipAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+        def kind(self):
+            return 'accessor'
+
+    assert pv.Sphere().clip.kind() == 'accessor'
+    # Class-level access on a _CachedAccessor returns the accessor class itself.
+    assert pv.PolyData.clip is FakeClipAccessor
+
+    pv.unregister_dataset_accessor('clip', pv.PolyData)
+    assert pv.PolyData.clip is original_clip
+    # ``clip`` is inherited from DataSetFilters, not re-attached to PolyData.
+    assert 'clip' not in pv.PolyData.__dict__
+
+
+def test_inherited_builtin_shadow_raises():
+    """A property defined on an ancestor should still be shadow-detected."""
+    # ``bounds`` is a property inherited from DataSet.
+    with pytest.raises(ValueError, match='shadows built-in attribute'):
+
+        @pv.register_dataset_accessor('bounds', pv.PolyData)
+        class BoundsAccessor:
+            def __init__(self, mesh):
+                self._mesh = mesh
+
+
+def test_empty_name_raises():
+    with pytest.raises(ValueError, match='must not be empty'):
+        pv.register_dataset_accessor('', pv.PolyData)
+
+
+def test_whitespace_only_name_raises():
+    with pytest.raises(ValueError, match='must not be empty'):
+        pv.register_dataset_accessor('   ', pv.PolyData)
+
+
+def test_non_identifier_name_raises():
+    with pytest.raises(ValueError, match='must be a valid Python identifier'):
+        pv.register_dataset_accessor('my-accessor', pv.PolyData)
+
+
+def test_leading_digit_name_raises():
+    with pytest.raises(ValueError, match='must be a valid Python identifier'):
+        pv.register_dataset_accessor('1foo', pv.PolyData)
+
+
+def test_leading_underscore_name_raises():
+    with pytest.raises(ValueError, match='must not start with an underscore'):
+        pv.register_dataset_accessor('_hidden', pv.PolyData)
+
+
+def test_non_string_name_raises():
+    with pytest.raises(TypeError, match='must be a string'):
+        # Intentional type violation: the runtime guard rejects non-strings.
+        pv.register_dataset_accessor(123, pv.PolyData)  # type: ignore[arg-type]
+
+
+def test_non_class_target_raises():
+    with pytest.raises(TypeError, match='must be a class'):
+        # Intentional type violation: the runtime guard rejects non-classes.
+        pv.register_dataset_accessor('name', 'not_a_class')  # type: ignore[arg-type]
+
+
+def test_non_class_accessor_raises():
+    decorator = pv.register_dataset_accessor('functional', pv.PolyData)
+    with pytest.raises(TypeError, match='Accessor must be a class'):
+        # Intentional type violation: the decorator rejects plain callables.
+        decorator(lambda mesh: mesh)  # type: ignore[arg-type]
+
+
+def test_unregister_removes_descriptor():
+    @pv.register_dataset_accessor('removable', pv.PolyData)
+    class RemovableAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+    assert 'removable' in pv.PolyData.__dict__
+    pv.unregister_dataset_accessor('removable', pv.PolyData)
+    assert 'removable' not in pv.PolyData.__dict__
+
+
+def test_unregister_restores_overridden_builtin():
+    """Overriding an attribute defined directly on the target is reversible."""
+
+    class Target:
+        def existing_method(self):
+            return 'original'
+
+    original_method = Target.__dict__['existing_method']
+
+    @pv.register_dataset_accessor('existing_method', Target, override=True)
+    class OverrideAccessor:
+        def __init__(self, obj):
+            self._obj = obj
+
+        def __call__(self):
+            return 'accessor'
+
+    assert Target.__dict__['existing_method'] is not original_method
+    pv.unregister_dataset_accessor('existing_method', Target)
+    assert Target.__dict__['existing_method'] is original_method
+
+
+def test_unregister_missing_raises():
+    with pytest.raises(ValueError, match='No registered accessor'):
+        pv.unregister_dataset_accessor('never_registered', pv.PolyData)
+
+
+def test_unregister_inherited_accessor_raises():
+    """An accessor inherited from a parent must be unregistered on the parent."""
+
+    @pv.register_dataset_accessor('parent_only', pv.DataSet)
+    class ParentAccessor:
+        def __init__(self, dataset):
+            self._dataset = dataset
+
+    assert hasattr(pv.Sphere(), 'parent_only')
+    with pytest.raises(ValueError, match='No registered accessor'):
+        pv.unregister_dataset_accessor('parent_only', pv.PolyData)
+
+    pv.unregister_dataset_accessor('parent_only', pv.DataSet)
+
+
+def test_unregister_updates_records():
+    @pv.register_dataset_accessor('tracked', pv.PolyData)
+    class TrackedAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+    names_before = [r.name for r in pv.registered_accessors()]
+    assert 'tracked' in names_before
+
+    pv.unregister_dataset_accessor('tracked', pv.PolyData)
+    names_after = [r.name for r in pv.registered_accessors()]
+    assert 'tracked' not in names_after
+
+
+def test_registered_accessors_reports_records():
+    @pv.register_dataset_accessor('introspect_me', pv.PolyData)
+    class IntrospectMeAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+    records = pv.registered_accessors()
+    matches = [r for r in records if r.name == 'introspect_me']
+    assert len(matches) == 1
+    record = matches[0]
+    assert record.target is pv.PolyData
+    assert record.accessor is IntrospectMeAccessor
+    assert record.source.endswith('IntrospectMeAccessor')
+
+
+def test_registered_accessors_returns_tuple():
+    assert isinstance(pv.registered_accessors(), tuple)
+
+
+def test_re_register_replaces_single_record():
+    @pv.register_dataset_accessor('single_record', pv.PolyData)
+    class FirstAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+
+        @pv.register_dataset_accessor('single_record', pv.PolyData)
+        class SecondAccessor:
+            def __init__(self, mesh):
+                self._mesh = mesh
+
+    records = [r for r in pv.registered_accessors() if r.name == 'single_record']
+    assert len(records) == 1
+    assert records[0].accessor is SecondAccessor
+
+
+def test_save_restore_round_trip_empty():
+    state = _reg_mod._save_registry_state()
+    _reg_mod._restore_registry_state(state)
+    assert pv.registered_accessors() == ()
+
+
+def test_save_restore_round_trip_populated():
+    @pv.register_dataset_accessor('snapshot_me', pv.PolyData)
+    class SnapshotAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+    state = _reg_mod._save_registry_state()
+
+    @pv.register_dataset_accessor('post_snapshot', pv.PolyData)
+    class PostSnapshotAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+    pv.unregister_dataset_accessor('snapshot_me', pv.PolyData)
+
+    _reg_mod._restore_registry_state(state)
+
+    names = {r.name for r in pv.registered_accessors()}
+    assert 'snapshot_me' in names
+    assert 'post_snapshot' not in names
+    assert hasattr(pv.Sphere(), 'snapshot_me')
+    assert not hasattr(pv.Sphere(), 'post_snapshot')
+
+
+def test_save_restore_round_trip_preserves_override():
+    """Snapshot, override, then restore — the inherited attribute is visible again."""
+    original_clip = pv.PolyData.clip
+    state = _reg_mod._save_registry_state()
+
+    @pv.register_dataset_accessor('clip', pv.PolyData, override=True)
+    class ClipOverride:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+    _reg_mod._restore_registry_state(state)
+    assert pv.PolyData.clip is original_clip
+    assert 'clip' not in pv.PolyData.__dict__
+
+
+def test_fixture_isolation_setup():
+    """Register an accessor; the conftest fixture must clean it up."""
+
+    @pv.register_dataset_accessor('leaked_accessor', pv.PolyData)
+    class LeakedAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+
+def test_fixture_isolation_teardown():
+    """The accessor from the previous test should not be visible."""
+    assert not hasattr(pv.Sphere(), 'leaked_accessor')
+    assert 'leaked_accessor' not in {r.name for r in pv.registered_accessors()}
+
+
+def test_protocol_matches_valid_accessor():
+    class Good:
+        def __init__(self, dataset):
+            self._dataset = dataset
+
+    assert isinstance(Good(None), pv.DataSetAccessor)
+
+
+def test_slotted_target_falls_back_to_uncached():
+    """A target class without ``__dict__`` still gets a working accessor.
+
+    Without per-instance caching, two accesses return distinct accessor
+    instances.
+    """
+
+    class SlottedTarget:
+        __slots__ = ()
+
+    @pv.register_dataset_accessor('slotted_acc', SlottedTarget)
+    class SlottedAccessor:
+        def __init__(self, obj):
+            self._obj = obj
+
+        def value(self):
+            return 7
+
+    instance = SlottedTarget()
+    assert instance.slotted_acc.value() == 7
+    first = instance.slotted_acc
+    second = instance.slotted_acc
+    assert first is not second
+
+
+def test_chaining_with_core_filters():
+    @pv.register_dataset_accessor('double_points', pv.PolyData)
+    class DoublePointsAccessor:
+        """Toy accessor that returns a translated copy of the mesh."""
+
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+        def translated(self, dx=1.0):
+            out = self._mesh.copy()
+            out.translate((dx, 0.0, 0.0), inplace=True)
+            return out
+
+    original = pv.Sphere()
+    result = original.clean().double_points.translated(dx=2.0).decimate(0.5)
+    assert isinstance(result, pv.PolyData)
+    assert result.n_points <= original.n_points

--- a/tests/core/test_accessor_registry.py
+++ b/tests/core/test_accessor_registry.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import contextlib
 import sys
 import types
 from unittest.mock import MagicMock
-from unittest.mock import patch
 import warnings
 
 import pytest
@@ -581,10 +581,41 @@ def _fake_importer(name: str, body: str):
     return _import
 
 
-def test_entry_point_triggers_decorator_registration():
-    """An entry point value pointing at a module should import it and
-    the decorator inside runs as a side effect."""
-    plugin_name = 'fake_entry_point_plugin_a'
+def _reset_entry_point_state(monkeypatch, eps: list):
+    """Reset registry discovery state and install a fake
+    ``entry_points`` return value."""
+    monkeypatch.setattr(_reg_mod, '_entry_points_loaded', False)
+    _reg_mod._pending_accessors.clear()
+    monkeypatch.setattr(
+        'pyvista.core.utilities.accessor_registry.entry_points',
+        lambda **_: eps,
+    )
+
+
+def test_ensure_entry_points_does_not_import_plugin_modules(monkeypatch):
+    """``_ensure_entry_points`` reads metadata only and never imports
+    a plugin module. A user that does ``import pyvista`` must not pay
+    any plugin-side import cost up front."""
+    ep = MagicMock()
+    ep.name = 'metadata_only'
+    ep.value = 'metadata_only_module'
+
+    _reset_entry_point_state(monkeypatch, [ep])
+    import_calls: list[str] = []
+    monkeypatch.setattr(
+        'pyvista.core.utilities.accessor_registry.import_module',
+        lambda path: import_calls.append(path) or None,
+    )
+
+    _reg_mod._ensure_entry_points()
+    assert import_calls == []
+    assert _reg_mod._pending_accessors == {'metadata_only': 'metadata_only_module'}
+
+
+def test_attribute_access_triggers_plugin_load(monkeypatch):
+    """First ``mesh.<name>`` access resolves the pending plugin, runs
+    the decorator via import, and returns the accessor."""
+    plugin_name = 'fake_ep_plugin_trigger'
     fake_import = _fake_importer(
         plugin_name,
         'import pyvista as pv\n'
@@ -595,154 +626,233 @@ def test_entry_point_triggers_decorator_registration():
         '    def value(self):\n'
         '        return 42\n',
     )
-
     ep = MagicMock()
-    ep.name = 'ep_demo_plugin'
+    ep.name = 'ep_demo'
     ep.value = plugin_name
 
-    _reg_mod._entry_points_loaded = False
-    with (
-        patch(
-            'pyvista.core.utilities.accessor_registry.entry_points',
-            return_value=[ep],
-        ),
-        patch(
-            'pyvista.core.utilities.accessor_registry.import_module',
-            side_effect=fake_import,
-        ),
-    ):
-        _reg_mod._ensure_entry_points()
+    _reset_entry_point_state(monkeypatch, [ep])
+    monkeypatch.setattr(
+        'pyvista.core.utilities.accessor_registry.import_module',
+        fake_import,
+    )
 
     try:
+        # First access triggers the import.
+        assert pv.Sphere().ep_demo.value() == 42
+        # Second access hits the cached accessor without re-triggering.
         assert pv.Sphere().ep_demo.value() == 42
     finally:
-        pv.unregister_dataset_accessor('ep_demo', pv.PolyData)
+        with contextlib.suppress(ValueError):
+            pv.unregister_dataset_accessor('ep_demo', pv.PolyData)
         sys.modules.pop(plugin_name, None)
 
 
-def test_entry_point_discovery_is_cached():
-    """A second discovery pass must not re-import the plugin modules."""
+def test_pending_plugin_only_imported_once(monkeypatch):
+    """After a plugin loads, the pending entry is popped. Subsequent
+    attribute accesses on the same name go through normal lookup and
+    never re-import the module."""
+    plugin_name = 'fake_ep_plugin_one_shot'
+    import_count = 0
+
+    def _counting_import(path):
+        nonlocal import_count
+        import_count += 1
+        module = types.ModuleType(path)
+        sys.modules[path] = module
+        # Module attaches an accessor as a side effect of import.
+        exec(  # noqa: S102
+            'import pyvista as pv\n'
+            "@pv.register_dataset_accessor('one_shot', pv.PolyData)\n"
+            'class OneShotAccessor:\n'
+            '    def __init__(self, mesh):\n'
+            '        self._mesh = mesh\n',
+            module.__dict__,
+        )
+        return module
+
     ep = MagicMock()
-    ep.name = 'cached_ep_plugin'
-    ep.value = 'cached_ep_plugin_module'
+    ep.name = 'one_shot'
+    ep.value = plugin_name
 
-    _reg_mod._entry_points_loaded = False
-    with (
-        patch(
-            'pyvista.core.utilities.accessor_registry.entry_points',
-            return_value=[ep],
-        ),
-        patch(
-            'pyvista.core.utilities.accessor_registry.import_module',
-        ) as mock_import,
-    ):
-        _reg_mod._ensure_entry_points()
-        _reg_mod._ensure_entry_points()
-        mock_import.assert_called_once_with('cached_ep_plugin_module')
+    _reset_entry_point_state(monkeypatch, [ep])
+    monkeypatch.setattr(
+        'pyvista.core.utilities.accessor_registry.import_module',
+        _counting_import,
+    )
+
+    try:
+        for _ in range(5):
+            _ = pv.Sphere().one_shot
+        assert import_count == 1
+    finally:
+        with contextlib.suppress(ValueError):
+            pv.unregister_dataset_accessor('one_shot', pv.PolyData)
+        sys.modules.pop(plugin_name, None)
 
 
-def test_entry_point_load_failure_warns():
+def test_entry_point_metadata_scanned_once(monkeypatch):
+    """The metadata scan itself runs once per process and is gated by
+    ``_entry_points_loaded``."""
     ep = MagicMock()
-    ep.name = 'broken_plugin'
+    ep.name = 'scan_once'
+    ep.value = 'scan_once_module'
+    scan_count = 0
+
+    def _counting_entry_points(**_):
+        nonlocal scan_count
+        scan_count += 1
+        return [ep]
+
+    monkeypatch.setattr(_reg_mod, '_entry_points_loaded', False)
+    _reg_mod._pending_accessors.clear()
+    monkeypatch.setattr(
+        'pyvista.core.utilities.accessor_registry.entry_points',
+        _counting_entry_points,
+    )
+
+    _reg_mod._ensure_entry_points()
+    _reg_mod._ensure_entry_points()
+    _reg_mod._ensure_entry_points()
+    assert scan_count == 1
+
+
+def test_broken_plugin_warns_once_and_isolates(monkeypatch):
+    """A plugin that fails to import emits one ``UserWarning`` per
+    access attempt, does not crash pyvista, and does not affect
+    lookups of unrelated names."""
+    ep = MagicMock()
+    ep.name = 'broken'
     ep.value = 'broken_plugin_module'
 
-    _reg_mod._entry_points_loaded = False
-    with (
-        patch(
-            'pyvista.core.utilities.accessor_registry.entry_points',
-            return_value=[ep],
-        ),
-        patch(
-            'pyvista.core.utilities.accessor_registry.import_module',
-            side_effect=ImportError('missing dependency'),
-        ),
-        pytest.warns(UserWarning, match='Failed to load'),
-    ):
-        _reg_mod._ensure_entry_points()
+    _reset_entry_point_state(monkeypatch, [ep])
+    monkeypatch.setattr(
+        'pyvista.core.utilities.accessor_registry.import_module',
+        MagicMock(side_effect=ImportError('missing dep')),
+    )
 
-    # A broken plugin must not block future calls or block pyvista usage.
-    assert pv.Sphere() is not None
+    # First access: warn and raise AttributeError because there is no
+    # accessor named 'broken' after the failed import.
+    with pytest.warns(UserWarning, match='Failed to load'):
+        with pytest.raises(AttributeError):
+            _ = pv.Sphere().broken
+
+    # Pending entry was consumed, so a second access is a clean
+    # AttributeError with no retry and no second warning.
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        with pytest.raises(AttributeError):
+            _ = pv.Sphere().broken
+
+    # Unrelated attributes still work.
+    assert pv.Sphere().n_points > 0
 
 
-def test_entry_point_and_decorator_collision_warns():
-    """If a decorator has already registered a name, an entry-point
-    module that tries to register the same name gets the standard
-    accessor-vs-accessor collision warning and wins (pandas semantics)."""
+def test_import_pyvista_does_not_import_plugin_modules(monkeypatch):
+    """Regression guard: ``_ensure_entry_points`` is not invoked
+    eagerly from ``pyvista/__init__.py``."""
+    # Simulate a "fresh" pyvista state and then merely access the
+    # registry-adjacent surface without touching any dataset attribute.
+    monkeypatch.setattr(_reg_mod, '_entry_points_loaded', False)
+    _reg_mod._pending_accessors.clear()
+    ep = MagicMock()
+    ep.name = 'should_not_load'
+    ep.value = 'should_not_load_module'
+    monkeypatch.setattr(
+        'pyvista.core.utilities.accessor_registry.entry_points',
+        lambda **_: [ep],
+    )
+    import_mock = MagicMock()
+    monkeypatch.setattr(
+        'pyvista.core.utilities.accessor_registry.import_module',
+        import_mock,
+    )
 
-    @pv.register_dataset_accessor('ep_collide', pv.PolyData)
-    class FirstAccessor:
+    # Constructing datasets and accessing built-in attributes must not
+    # trigger the pending import. Only a lookup on the specific pending
+    # name does.
+    sphere = pv.Sphere()
+    _ = sphere.n_points
+    _ = sphere.bounds
+    _ = hasattr(sphere, 'definitely_not_a_plugin_name')
+
+    import_mock.assert_not_called()
+
+
+def test_decorator_wins_over_pending_entry_point(monkeypatch):
+    """A decorator that has already attached an accessor preempts
+    the pending entry-point plugin: the attribute lookup hits the
+    decorator-installed descriptor, never misses, and the plugin
+    module is never imported.
+
+    This is a direct consequence of lazy discovery: entry points are
+    only resolved on attribute-lookup misses. A decorator-registered
+    accessor is a hit, so the pending plugin stays pending.
+    """
+
+    @pv.register_dataset_accessor('ep_preempted', pv.PolyData)
+    class DecoratorAccessor:
         def __init__(self, mesh):
             self._mesh = mesh
 
         def who(self):
             return 'decorator'
 
-    plugin_name = 'fake_entry_point_plugin_collide'
+    ep = MagicMock()
+    ep.name = 'ep_preempted'
+    ep.value = 'fake_preempted_plugin_module'
+
+    _reset_entry_point_state(monkeypatch, [ep])
+    import_mock = MagicMock()
+    monkeypatch.setattr(
+        'pyvista.core.utilities.accessor_registry.import_module',
+        import_mock,
+    )
+
+    try:
+        assert pv.Sphere().ep_preempted.who() == 'decorator'
+        import_mock.assert_not_called()
+    finally:
+        with contextlib.suppress(ValueError):
+            pv.unregister_dataset_accessor('ep_preempted', pv.PolyData)
+
+
+def test_registered_accessors_forces_discovery(monkeypatch):
+    """``registered_accessors()`` is the one caller that explicitly
+    asks for the full picture, so it loads every pending plugin."""
+    plugin_name = 'fake_ep_plugin_forced'
     fake_import = _fake_importer(
         plugin_name,
         'import pyvista as pv\n'
-        "@pv.register_dataset_accessor('ep_collide', pv.PolyData)\n"
-        'class EpCollideAccessor:\n'
+        "@pv.register_dataset_accessor('forced', pv.PolyData)\n"
+        'class ForcedAccessor:\n'
         '    def __init__(self, mesh):\n'
-        '        self._mesh = mesh\n'
-        '    def who(self):\n'
-        "        return 'entry_point'\n",
+        '        self._mesh = mesh\n',
     )
-
     ep = MagicMock()
-    ep.name = 'ep_collide_plugin'
+    ep.name = 'forced'
     ep.value = plugin_name
 
-    _reg_mod._entry_points_loaded = False
-    with (
-        patch(
-            'pyvista.core.utilities.accessor_registry.entry_points',
-            return_value=[ep],
-        ),
-        patch(
-            'pyvista.core.utilities.accessor_registry.import_module',
-            side_effect=fake_import,
-        ),
-        pytest.warns(UserWarning, match='replaces an existing registered accessor'),
-    ):
-        _reg_mod._ensure_entry_points()
+    _reset_entry_point_state(monkeypatch, [ep])
+    monkeypatch.setattr(
+        'pyvista.core.utilities.accessor_registry.import_module',
+        fake_import,
+    )
 
     try:
-        assert pv.Sphere().ep_collide.who() == 'entry_point'
+        names = {r.name for r in pv.registered_accessors()}
+        assert 'forced' in names
     finally:
-        pv.unregister_dataset_accessor('ep_collide', pv.PolyData)
+        with contextlib.suppress(ValueError):
+            pv.unregister_dataset_accessor('forced', pv.PolyData)
         sys.modules.pop(plugin_name, None)
 
 
-def test_registered_accessors_triggers_entry_point_discovery():
-    """Calling registered_accessors() must run entry-point discovery."""
-    ep = MagicMock()
-    ep.name = 'trigger_check'
-    ep.value = 'trigger_check_module'
-
-    _reg_mod._entry_points_loaded = False
-    with (
-        patch(
-            'pyvista.core.utilities.accessor_registry.entry_points',
-            return_value=[ep],
-        ),
-        patch(
-            'pyvista.core.utilities.accessor_registry.import_module',
-        ) as mock_import,
-    ):
-        pv.registered_accessors()
-        mock_import.assert_called_once_with('trigger_check_module')
-
-
-def test_no_entry_points_is_silent():
+def test_no_entry_points_is_silent(monkeypatch):
     """No installed accessor plugins must be a no-op without warnings."""
-    _reg_mod._entry_points_loaded = False
-    with (
-        patch(
-            'pyvista.core.utilities.accessor_registry.entry_points',
-            return_value=[],
-        ),
-        warnings.catch_warnings(),
-    ):
+    _reset_entry_point_state(monkeypatch, [])
+    with warnings.catch_warnings():
         warnings.simplefilter('error')
         _reg_mod._ensure_entry_points()
+        # Attribute access for an unknown name still raises cleanly.
+        with pytest.raises(AttributeError):
+            _ = pv.Sphere().completely_unknown

--- a/tests/core/test_accessor_registry.py
+++ b/tests/core/test_accessor_registry.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import sys
+import types
+from unittest.mock import MagicMock
+from unittest.mock import patch
 import warnings
 
 import pytest
@@ -438,10 +442,14 @@ def test_re_register_replaces_single_record():
     assert records[0].accessor is SecondAccessor
 
 
-def test_save_restore_round_trip_empty():
+def test_save_restore_round_trip_baseline():
+    """Save then restore with no mutations in between leaves the
+    registry untouched, whether the baseline is empty or populated by
+    entry-point discovery."""
+    before = pv.registered_accessors()
     state = _reg_mod._save_registry_state()
     _reg_mod._restore_registry_state(state)
-    assert pv.registered_accessors() == ()
+    assert pv.registered_accessors() == before
 
 
 def test_save_restore_round_trip_populated():
@@ -548,3 +556,193 @@ def test_chaining_with_core_filters():
     result = original.clean().double_points.translated(dx=2.0).decimate(0.5)
     assert isinstance(result, pv.PolyData)
     assert result.n_points <= original.n_points
+
+
+def _fake_importer(name: str, body: str):
+    """Return an ``import_module``-compatible callable that executes
+    ``body`` when asked to import ``name``.
+
+    The module body is compiled up front so syntax errors fail the test
+    immediately, but execution (and any decorator side effects) is
+    deferred to the moment ``_ensure_entry_points`` actually imports
+    the module — inside whatever ``pytest.warns`` / ``catch_warnings``
+    context the test wraps around it.
+    """
+    compiled = compile(body, f'<fake {name}>', 'exec')
+
+    def _import(module_path: str) -> types.ModuleType:
+        assert module_path == name
+        module = types.ModuleType(name)
+        module.__file__ = f'<fake {name}>'
+        sys.modules[name] = module
+        exec(compiled, module.__dict__)  # noqa: S102
+        return module
+
+    return _import
+
+
+def test_entry_point_triggers_decorator_registration():
+    """An entry point value pointing at a module should import it and
+    the decorator inside runs as a side effect."""
+    plugin_name = 'fake_entry_point_plugin_a'
+    fake_import = _fake_importer(
+        plugin_name,
+        'import pyvista as pv\n'
+        "@pv.register_dataset_accessor('ep_demo', pv.PolyData)\n"
+        'class EpDemoAccessor:\n'
+        '    def __init__(self, mesh):\n'
+        '        self._mesh = mesh\n'
+        '    def value(self):\n'
+        '        return 42\n',
+    )
+
+    ep = MagicMock()
+    ep.name = 'ep_demo_plugin'
+    ep.value = plugin_name
+
+    _reg_mod._entry_points_loaded = False
+    with (
+        patch(
+            'pyvista.core.utilities.accessor_registry.entry_points',
+            return_value=[ep],
+        ),
+        patch(
+            'pyvista.core.utilities.accessor_registry.import_module',
+            side_effect=fake_import,
+        ),
+    ):
+        _reg_mod._ensure_entry_points()
+
+    try:
+        assert pv.Sphere().ep_demo.value() == 42
+    finally:
+        pv.unregister_dataset_accessor('ep_demo', pv.PolyData)
+        sys.modules.pop(plugin_name, None)
+
+
+def test_entry_point_discovery_is_cached():
+    """A second discovery pass must not re-import the plugin modules."""
+    ep = MagicMock()
+    ep.name = 'cached_ep_plugin'
+    ep.value = 'cached_ep_plugin_module'
+
+    _reg_mod._entry_points_loaded = False
+    with (
+        patch(
+            'pyvista.core.utilities.accessor_registry.entry_points',
+            return_value=[ep],
+        ),
+        patch(
+            'pyvista.core.utilities.accessor_registry.import_module',
+        ) as mock_import,
+    ):
+        _reg_mod._ensure_entry_points()
+        _reg_mod._ensure_entry_points()
+        mock_import.assert_called_once_with('cached_ep_plugin_module')
+
+
+def test_entry_point_load_failure_warns():
+    ep = MagicMock()
+    ep.name = 'broken_plugin'
+    ep.value = 'broken_plugin_module'
+
+    _reg_mod._entry_points_loaded = False
+    with (
+        patch(
+            'pyvista.core.utilities.accessor_registry.entry_points',
+            return_value=[ep],
+        ),
+        patch(
+            'pyvista.core.utilities.accessor_registry.import_module',
+            side_effect=ImportError('missing dependency'),
+        ),
+        pytest.warns(UserWarning, match='Failed to load'),
+    ):
+        _reg_mod._ensure_entry_points()
+
+    # A broken plugin must not block future calls or block pyvista usage.
+    assert pv.Sphere() is not None
+
+
+def test_entry_point_and_decorator_collision_warns():
+    """If a decorator has already registered a name, an entry-point
+    module that tries to register the same name gets the standard
+    accessor-vs-accessor collision warning and wins (pandas semantics)."""
+
+    @pv.register_dataset_accessor('ep_collide', pv.PolyData)
+    class FirstAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+        def who(self):
+            return 'decorator'
+
+    plugin_name = 'fake_entry_point_plugin_collide'
+    fake_import = _fake_importer(
+        plugin_name,
+        'import pyvista as pv\n'
+        "@pv.register_dataset_accessor('ep_collide', pv.PolyData)\n"
+        'class EpCollideAccessor:\n'
+        '    def __init__(self, mesh):\n'
+        '        self._mesh = mesh\n'
+        '    def who(self):\n'
+        "        return 'entry_point'\n",
+    )
+
+    ep = MagicMock()
+    ep.name = 'ep_collide_plugin'
+    ep.value = plugin_name
+
+    _reg_mod._entry_points_loaded = False
+    with (
+        patch(
+            'pyvista.core.utilities.accessor_registry.entry_points',
+            return_value=[ep],
+        ),
+        patch(
+            'pyvista.core.utilities.accessor_registry.import_module',
+            side_effect=fake_import,
+        ),
+        pytest.warns(UserWarning, match='replaces an existing registered accessor'),
+    ):
+        _reg_mod._ensure_entry_points()
+
+    try:
+        assert pv.Sphere().ep_collide.who() == 'entry_point'
+    finally:
+        pv.unregister_dataset_accessor('ep_collide', pv.PolyData)
+        sys.modules.pop(plugin_name, None)
+
+
+def test_registered_accessors_triggers_entry_point_discovery():
+    """Calling registered_accessors() must run entry-point discovery."""
+    ep = MagicMock()
+    ep.name = 'trigger_check'
+    ep.value = 'trigger_check_module'
+
+    _reg_mod._entry_points_loaded = False
+    with (
+        patch(
+            'pyvista.core.utilities.accessor_registry.entry_points',
+            return_value=[ep],
+        ),
+        patch(
+            'pyvista.core.utilities.accessor_registry.import_module',
+        ) as mock_import,
+    ):
+        pv.registered_accessors()
+        mock_import.assert_called_once_with('trigger_check_module')
+
+
+def test_no_entry_points_is_silent():
+    """No installed accessor plugins must be a no-op without warnings."""
+    _reg_mod._entry_points_loaded = False
+    with (
+        patch(
+            'pyvista.core.utilities.accessor_registry.entry_points',
+            return_value=[],
+        ),
+        warnings.catch_warnings(),
+    ):
+        warnings.simplefilter('error')
+        _reg_mod._ensure_entry_points()

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -283,6 +283,7 @@ def test_pyvista_class_no_new_attributes(pyvista_class):
             vtkPyVistaOverride,
             VTKObjectWrapperCheckSnakeCase,
             pv.VtkErrorCatcher,
+            pv.DataSetAccessor,
         ):
             assert not issubclass(pyvista_class, _NoNewAttrMixin)
             pytest.skip('Specialized class with no real risk of new attributes being added.')


### PR DESCRIPTION
## Summary

Introduces a pandas/xarray-style accessor mechanism so third-party packages can attach namespaced filter methods to PyVista dataset classes without monkey-patching or subclassing. Resolves #8523.

Targets plugins like pymeshfix, tetgen, pytetwild, pyvista-tui, and pyvista-xarray that want to expose operations under their own namespace, e.g. `mesh.meshfix.repair()` or `mesh.tui.plot()`. Chaining with core filters continues working because accessor methods return PyVista datasets.

- Two registration paths: a `@pv.register_dataset_accessor(name, target_cls)` decorator for in-script use, and a `pyvista.accessors` entry-point group for zero-config discovery when plugins are installed.
- MRO-aware dispatch: registering against `pv.DataSet` exposes the accessor on every subclass; registering against `pv.DataObject` additionally covers `MultiBlock`.
- Hybrid collision policy: accessor-vs-accessor emits `UserWarning` and replaces (pandas behavior); shadowing a built-in attribute raises unless `override=True`.
- Per-instance lazy construction and caching via a non-data descriptor (matches pandas/xarray `_CachedAccessor` exactly).

## Details

### Public API

Lives in `pyvista.core.utilities.accessor_registry` and is re-exported at top level:

- `pv.register_dataset_accessor(name, target_cls, *, override=False)` — decorator; attaches the class as a `_CachedAccessor` descriptor on `target_cls` and returns the class unchanged.
- `pv.unregister_dataset_accessor(name, target_cls)` — removes the descriptor; restores any built-in attribute that was shadowed via `override=True`.
- `pv.registered_accessors()` — returns a tuple of `AccessorRegistration` records for inspection. Triggers entry-point discovery on first call.
- `pv.AccessorRegistration` — `NamedTuple(name, target, accessor, source)`.
- `pv.DataSetAccessor` — `@runtime_checkable Protocol` for structural typing of accessor classes.

### Two registration paths

The decorator is the primary API and runs at import time:

```python
@pv.register_dataset_accessor("meshfix", pv.PolyData)
class MeshFixAccessor:
    def __init__(self, mesh):
        self._mesh = mesh
    def repair(self, **kwargs):
        ...
```

Plugins shipping on PyPI declare a `pyvista.accessors` entry point so users get the accessor without an explicit import:

```toml
[project.entry-points."pyvista.accessors"]
meshfix = "pymeshfix._accessor"
```

PyVista runs `_ensure_entry_points()` at the end of `pyvista/__init__.py`, importing each registered module so its top-level decorator fires as a side effect. Discovery is cached after the first pass; load failures emit `UserWarning` and do not block any other plugin or pyvista itself. Both paths populate the same registry; a plugin that does both is safe because the second import is a no-op against `sys.modules`.

### Caching

The descriptor is non-data: once the accessor is constructed for a dataset instance, it is cached in `instance.__dict__` and subsequent lookups bypass the descriptor. For `__slots__`-only targets, the cache write is silently skipped and the accessor is constructed fresh on each access.

### Collision detection

Walks `target_cls.__mro__` and distinguishes accessor descriptors from any other attribute. Accessor-vs-accessor collision warns and replaces the previous registration. Shadowing a built-in filter method or property raises `ValueError` unless `override=True`, in which case `unregister_dataset_accessor` exactly reverses the shadow.

### Test isolation

`_save_registry_state()` / `_restore_registry_state()` hook into the `reset_global_state` fixture in `tests/conftest.py` alongside the reader / writer / style registries. The round-trip preserves registrations, prior-value restoration state, and the entry-point-loaded flag.

### Documentation

- New API page at `doc/source/api/core/accessors.rst` covering all five public symbols.
- Rewritten `doc/source/extras/extending_pyvista.rst` covering why accessors, writing one, both registration paths, chaining and return types, collision policy, typing via `DataSetAccessor` + `.pyi` pattern, deregistration, cache semantics, and a note pointing at the subclassing example for genuinely stateful use cases.

### Testing

Covers happy path, MRO dispatch across every concrete dataset type, type-changing filter chains, hybrid collision policy, validation (empty / non-identifier / leading-underscore / non-string / non-class targets), unregister, introspection, state save/restore, fixture isolation between tests, Protocol runtime-check, `__slots__` fallback, and an end-to-end chain `clean().double_points.translated(...).decimate(...)` spanning core filters and a registered accessor. Six tests exercise the entry-point path with mocked `importlib.metadata.entry_points`, including load failures and decorator-vs-entry-point collisions.

### Verified against downstream plugins

Wired the pattern in `pyvista-tui` (`.tui` on `DataObject`), `tetgen` (`.tetgen` on `PolyData`), and `pytetwild` (`.tetwild` on `PolyData`). End-to-end with pyvista-tui editable-installed against this branch: `import pyvista as pv; pv.Sphere().tui.plot()` works with no explicit `import pyvista_tui`. Downstream PRs adding the entry-point declarations and accessor modules will follow.

<img width="593" height="456" alt="Screenshot 2026-04-24 at 6 56 16 PM" src="https://github.com/user-attachments/assets/8aa7dc9b-32c0-4380-9080-74fbaae305b2" />


### Tradeoff

Two registration paths is one more than pandas and xarray ship, and does add a small surface to the extending guide. In return, users installing a plugin get the accessor with no import ceremony (a missive UX improvement in my opinion)

## References

- Issue: #8523
- pandas registered accessors: https://pandas.pydata.org/docs/development/extending.html#registering-custom-accessors
- xarray extending: https://docs.xarray.dev/en/stable/internals/extending-xarray.html
