### PR TITLE
Align plugin registries and defer plugin imports until needed

### DIFF
--- a/doc/source/api/readers/index.rst
+++ b/doc/source/api/readers/index.rst
@@ -92,6 +92,8 @@ Registration can be done programmatically or via Python entry points
 for zero-config discovery at install time.
 
 .. autofunction:: pyvista.register_reader
+.. autofunction:: pyvista.registered_readers
+.. autoclass:: pyvista.ReaderRegistration
 
 **Entry points**
 
@@ -129,6 +131,8 @@ and supports programmatic calls, decorators, and Python entry points
 for zero-config discovery at install time.
 
 .. autofunction:: pyvista.register_writer
+.. autofunction:: pyvista.registered_writers
+.. autoclass:: pyvista.WriterRegistration
 
 **Handler signature**
 

--- a/doc/source/api/utilities/utilities.rst
+++ b/doc/source/api/utilities/utilities.rst
@@ -156,6 +156,8 @@ Miscellaneous
    Observer
    ProgressMonitor
    register_jupyter_backend
+   registered_jupyter_backends
+   JupyterBackendRegistration
    send_errors_to_logging
    set_jupyter_backend
    start_xvfb

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -36,12 +36,18 @@ from pyvista.core.utilities.accessor_registry import (
 )
 from pyvista.core.utilities.observers import send_errors_to_logging
 from pyvista.core.utilities.reader_registry import LocalFileRequiredError as LocalFileRequiredError
+from pyvista.core.utilities.reader_registry import ReaderRegistration as ReaderRegistration
 from pyvista.core.utilities.reader_registry import has_scheme as has_scheme
 from pyvista.core.utilities.reader_registry import register_reader as register_reader
+from pyvista.core.utilities.reader_registry import registered_readers as registered_readers
+from pyvista.core.utilities.writer_registry import WriterRegistration as WriterRegistration
 from pyvista.core.utilities.writer_registry import register_writer as register_writer
+from pyvista.core.utilities.writer_registry import registered_writers as registered_writers
 from pyvista.core.wrappers import _wrappers as _wrappers
 from pyvista.jupyter import JupyterBackendOptions as JupyterBackendOptions
+from pyvista.jupyter import JupyterBackendRegistration as JupyterBackendRegistration
 from pyvista.jupyter import register_jupyter_backend as register_jupyter_backend
+from pyvista.jupyter import registered_jupyter_backends as registered_jupyter_backends
 from pyvista.jupyter import set_jupyter_backend as set_jupyter_backend
 from pyvista.report import GPUInfo as GPUInfo
 from pyvista.report import Report as Report

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -116,6 +116,20 @@ class DataObject(_NoNewAttrMixin, DisableVtkSnakeCase, vtkPyVistaOverride):
             return object.__getattribute__(self, item)
         return super().__getattribute__(item)
 
+    def __dir__(self: Self) -> list[str]:
+        """Include pending accessor names so tab completion surfaces them.
+
+        Plugin-contributed accessors registered via the ``pyvista.accessors``
+        entry-point group are imported lazily on first attribute access.
+        Listing their names alongside the normal attribute set lets IPython
+        / Jupyter / REPL tab completion surface them without paying the
+        plugin import cost ahead of time.
+        """
+        # Lazy import to avoid a circular dependency at module load time.
+        from pyvista.core.utilities.accessor_registry import _pending_accessor_names
+
+        return sorted({*super().__dir__(), *_pending_accessor_names()})
+
     def shallow_copy(self: Self, to_copy: Self | _vtk.vtkDataObject) -> None:
         """Shallow copy the given mesh to this mesh.
 

--- a/pyvista/core/utilities/_registry_helpers.py
+++ b/pyvista/core/utilities/_registry_helpers.py
@@ -1,0 +1,38 @@
+"""Internal helpers shared by PyVista's plugin registries.
+
+The registries (accessor, reader, writer, interactor style, jupyter
+backend) all need to record where each registration came from so a user
+inspecting :func:`~pyvista.registered_readers` and friends can tell
+explicit code apart from entry-point discovery. The helpers here keep
+that source-attribution logic in one place.
+"""
+
+from __future__ import annotations
+
+
+def handler_source(handler: object) -> str:
+    """Return ``module.qualname`` for *handler* when available.
+
+    Used by every plugin registry to attach a human-readable origin
+    string to each explicit registration so that :func:`registered_*`
+    introspection can show where a handler came from.
+
+    Parameters
+    ----------
+    handler : object
+        Any callable or class; typically a function, method, or type
+        object whose ``__module__`` and ``__qualname__`` attributes are
+        meaningful.
+
+    Returns
+    -------
+    str
+        ``f'{handler.__module__}.{handler.__qualname__}'`` when both
+        attributes are present, falling back to ``'<unknown>'`` for the
+        module piece and ``repr(handler)`` for the qualname piece when
+        not.
+
+    """
+    module = getattr(handler, '__module__', None) or '<unknown>'
+    qualname = getattr(handler, '__qualname__', None) or repr(handler)
+    return f'{module}.{qualname}'

--- a/pyvista/core/utilities/accessor_registry.py
+++ b/pyvista/core/utilities/accessor_registry.py
@@ -603,6 +603,19 @@ def _resolve_pending_accessor(name: str) -> bool:
     return True
 
 
+def _pending_accessor_names() -> tuple[str, ...]:
+    """Return every pending accessor name without importing any plugin.
+
+    Used by :meth:`pyvista.DataObject.__dir__` so that IPython /
+    Jupyter / REPL tab completion surfaces accessors contributed by
+    installed plugins even before those plugins have been imported. The
+    plugin module itself is **not** loaded — only the entry-point
+    metadata is consulted.
+    """
+    _ensure_entry_points()
+    return tuple(_pending_accessors)
+
+
 def registered_accessors() -> tuple[AccessorRegistration, ...]:
     """Return every accessor currently registered.
 

--- a/pyvista/core/utilities/reader_registry.py
+++ b/pyvista/core/utilities/reader_registry.py
@@ -10,6 +10,7 @@ import shutil
 import tempfile
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import NamedTuple
 from typing import Protocol
 from typing import TypedDict
 from typing import overload
@@ -17,6 +18,7 @@ from typing import overload
 import pooch
 
 from pyvista._warn_external import warn_external
+from pyvista.core.utilities._registry_helpers import handler_source
 from pyvista.core.utilities.reader import CLASS_READERS
 
 if TYPE_CHECKING:
@@ -31,8 +33,35 @@ if TYPE_CHECKING:
             """Read *path* and return the resulting dataset."""
 
 
+class ReaderRegistration(NamedTuple):
+    """Describe one registered custom reader.
+
+    Returned by :func:`~pyvista.registered_readers`.
+
+    .. versionadded:: 0.48.0
+
+    Attributes
+    ----------
+    extension : str
+        File extension the reader is registered against, including the
+        leading dot (e.g. ``'.myformat'``).
+    handler : callable
+        The reader callable.
+    source : str
+        Human-readable origin in the form ``'module.qualname'`` for
+        explicit registrations or the entry-point ``value`` for
+        plugin-discovered registrations.
+
+    """
+
+    extension: str
+    handler: ReaderHandler
+    source: str
+
+
 class _RegistryState(TypedDict):
     ext: dict[str, ReaderHandler]
+    sources: dict[str, str]
     entry_points_loaded: bool
 
 
@@ -57,6 +86,7 @@ class LocalFileRequiredError(Exception):
 
 
 _custom_ext_readers: dict[str, ReaderHandler] = {}
+_custom_ext_reader_sources: dict[str, str] = {}
 _entry_points_loaded: bool = False
 _temp_files: list[str] = []
 
@@ -75,6 +105,7 @@ def _save_registry_state() -> _RegistryState:
     """Snapshot the current registry state for later restoration."""
     return {
         'ext': _custom_ext_readers.copy(),
+        'sources': _custom_ext_reader_sources.copy(),
         'entry_points_loaded': _entry_points_loaded,
     }
 
@@ -84,6 +115,8 @@ def _restore_registry_state(state: _RegistryState) -> None:
     global _entry_points_loaded  # noqa: PLW0603
     _custom_ext_readers.clear()
     _custom_ext_readers.update(state['ext'])
+    _custom_ext_reader_sources.clear()
+    _custom_ext_reader_sources.update(state['sources'])
     _entry_points_loaded = state['entry_points_loaded']
 
 
@@ -206,9 +239,8 @@ def register_reader(
 
     override : bool, default: False
         If ``True``, allow overriding a built-in VTK reader for this
-        extension.  When ``False`` (the default), registering a handler
-        for an extension that collides with a built-in reader raises
-        :class:`ValueError`.
+        extension and silence the warning that would otherwise fire when
+        replacing an existing custom registration.
 
     Returns
     -------
@@ -222,10 +254,19 @@ def register_reader(
         If ``key`` collides with a built-in VTK reader and *override*
         is ``False``.
 
+    Warns
+    -----
+    UserWarning
+        If ``key`` already refers to a registered custom reader. The new
+        registration replaces the old one (last wins); pass
+        ``override=True`` to silence the warning.
+
     See Also
     --------
     pyvista.register_writer
         Sibling API for registering custom writers.
+    pyvista.registered_readers
+        Introspect every registered reader.
 
     Examples
     --------
@@ -258,6 +299,7 @@ def _register(
     handler: ReaderHandler,
     *,
     override: bool = False,
+    source: str | None = None,
 ) -> None:
     """Register a handler in the extension registry."""
     key = key.lower()
@@ -270,7 +312,14 @@ def _register(
             f'Use override=True to replace it.'
         )
         raise ValueError(msg)
+    if not override and key in _custom_ext_readers:
+        existing_source = _custom_ext_reader_sources.get(key, '<unknown>')
+        warn_external(
+            f'Registering reader for "{key}" replaces an existing custom '
+            f'reader from {existing_source}.',
+        )
     _custom_ext_readers[key] = handler
+    _custom_ext_reader_sources[key] = source if source is not None else handler_source(handler)
 
 
 def _get_ext_handler(ext: str) -> ReaderHandler | None:
@@ -306,12 +355,14 @@ def _ensure_entry_points() -> None:
             # ep.load() runs third-party import machinery — it can raise
             # literally anything. Convert to a warning so one broken plugin
             # cannot take down every pyvista.read call.
-            _custom_ext_readers[key] = winner.load()
+            handler = winner.load()
         except Exception as err:  # noqa: BLE001
             warn_external(
                 f'Failed to load pyvista.readers entry point "{winner.value}" for "{key}": {err}'
             )
             continue
+        _custom_ext_readers[key] = handler
+        _custom_ext_reader_sources[key] = winner.value
         if len(eps) > 1:
             providers = ', '.join(ep.value for ep in eps)
             warn_external(
@@ -328,3 +379,43 @@ def _list_custom_exts() -> list[str]:
     """
     _ensure_entry_points()
     return list(_custom_ext_readers.keys())
+
+
+def registered_readers() -> tuple[ReaderRegistration, ...]:
+    """Return every custom reader currently registered.
+
+    Forces discovery of any pending entry-point plugins so the returned
+    list reflects every reader visible to PyVista. A plugin that fails to
+    import emits a ``UserWarning`` and is skipped; the rest still appear
+    in the result.
+
+    .. versionadded:: 0.48.0
+
+    Returns
+    -------
+    tuple[ReaderRegistration, ...]
+        One record per registered extension. Each record exposes
+        ``extension``, ``handler``, and ``source``.
+
+    Examples
+    --------
+    >>> import pyvista as pv
+    >>> def my_reader(path, **kwargs): ...
+    >>> pv.register_reader('.demo_reader', my_reader)
+    >>> [
+    ...     r.extension
+    ...     for r in pv.registered_readers()
+    ...     if r.extension == '.demo_reader'
+    ... ]
+    ['.demo_reader']
+
+    """
+    _ensure_entry_points()
+    return tuple(
+        ReaderRegistration(
+            extension=ext,
+            handler=handler,
+            source=_custom_ext_reader_sources.get(ext, '<unknown>'),
+        )
+        for ext, handler in _custom_ext_readers.items()
+    )

--- a/pyvista/core/utilities/reader_registry.py
+++ b/pyvista/core/utilities/reader_registry.py
@@ -62,6 +62,7 @@ class ReaderRegistration(NamedTuple):
 class _RegistryState(TypedDict):
     ext: dict[str, ReaderHandler]
     sources: dict[str, str]
+    pending: dict[str, list[EntryPoint]]
     entry_points_loaded: bool
 
 
@@ -87,6 +88,13 @@ class LocalFileRequiredError(Exception):
 
 _custom_ext_readers: dict[str, ReaderHandler] = {}
 _custom_ext_reader_sources: dict[str, str] = {}
+# Entry-point metadata, populated by ``_ensure_entry_points``. Maps each
+# extension to the list of ``EntryPoint`` records that declared it.
+# The plugin module itself is *not* imported until that extension is
+# actually requested via :func:`_get_ext_handler`, keeping
+# ``pv.read``/``pv.save`` calls for built-in formats free of third-party
+# plugin import cost.
+_pending_ext_readers: dict[str, list[EntryPoint]] = {}
 _entry_points_loaded: bool = False
 _temp_files: list[str] = []
 
@@ -106,6 +114,7 @@ def _save_registry_state() -> _RegistryState:
     return {
         'ext': _custom_ext_readers.copy(),
         'sources': _custom_ext_reader_sources.copy(),
+        'pending': {k: list(v) for k, v in _pending_ext_readers.items()},
         'entry_points_loaded': _entry_points_loaded,
     }
 
@@ -117,6 +126,8 @@ def _restore_registry_state(state: _RegistryState) -> None:
     _custom_ext_readers.update(state['ext'])
     _custom_ext_reader_sources.clear()
     _custom_ext_reader_sources.update(state['sources'])
+    _pending_ext_readers.clear()
+    _pending_ext_readers.update({k: list(v) for k, v in state['pending'].items()})
     _entry_points_loaded = state['entry_points_loaded']
 
 
@@ -323,62 +334,95 @@ def _register(
 
 
 def _get_ext_handler(ext: str) -> ReaderHandler | None:
-    """Look up a custom extension handler, discovering entry points lazily."""
+    """Look up a custom extension handler, importing the plugin lazily.
+
+    Built-in extensions never trigger entry-point plugin imports — only
+    extensions that an installed plugin has actually claimed do.
+    """
     handler = _custom_ext_readers.get(ext)
     if handler is not None:
         return handler
     _ensure_entry_points()
+    if ext in _pending_ext_readers:
+        _resolve_pending_reader(ext)
     return _custom_ext_readers.get(ext)
 
 
 def _ensure_entry_points() -> None:
-    """Scan the ``pyvista.readers`` entry-point group and load handlers."""
+    """Scan ``pyvista.readers`` entry-point metadata once.
+
+    Populates :data:`_pending_ext_readers` with every extension declared
+    by an installed plugin. The plugin modules themselves are **not**
+    imported here; the cost is one ``importlib.metadata.entry_points``
+    call. Plugin imports are deferred to :func:`_resolve_pending_reader`,
+    which runs only when a reader for that specific extension is
+    actually requested.
+    """
     global _entry_points_loaded  # noqa: PLW0603
     if _entry_points_loaded:
         return
     _entry_points_loaded = True
 
-    # Group entry points by normalized key so we can detect duplicate
-    # providers *and* guarantee a deterministic winner (the first one).
-    eps_by_key: dict[str, list[EntryPoint]] = {}
     for ep in entry_points(group='pyvista.readers'):
         key = ep.name.lower()
         if not key.startswith('.'):
             key = f'.{key}'
-        eps_by_key.setdefault(key, []).append(ep)
-
-    for key, eps in eps_by_key.items():
         if key in _custom_ext_readers:
             continue
-        winner = eps[0]
-        try:
-            # ep.load() runs third-party import machinery — it can raise
-            # literally anything. Convert to a warning so one broken plugin
-            # cannot take down every pyvista.read call.
-            handler = winner.load()
-        except Exception as err:  # noqa: BLE001
-            warn_external(
-                f'Failed to load pyvista.readers entry point "{winner.value}" for "{key}": {err}'
-            )
-            continue
-        _custom_ext_readers[key] = handler
-        _custom_ext_reader_sources[key] = winner.value
-        if len(eps) > 1:
-            providers = ', '.join(ep.value for ep in eps)
-            warn_external(
-                f'Multiple pyvista.readers entry points registered for '
-                f'"{key}": {providers}. Using {winner.value}.'
-            )
+        _pending_ext_readers.setdefault(key, []).append(ep)
+
+
+def _resolve_pending_reader(ext: str) -> bool:
+    """Import the plugin claiming *ext*, if any.
+
+    Returns
+    -------
+    bool
+        ``True`` if a plugin loaded successfully for ``ext``. ``False``
+        if no pending plugin matches, or if the plugin failed to import.
+
+    Notes
+    -----
+    A plugin that fails to import emits a ``UserWarning`` and is dropped
+    from the pending list, so subsequent lookups of the same extension
+    fall straight through without re-triggering the import or
+    re-emitting the warning.
+
+    """
+    eps = _pending_ext_readers.pop(ext, None)
+    if not eps:
+        return False
+    winner = eps[0]
+    try:
+        # ep.load() runs third-party import machinery — it can raise
+        # literally anything. Convert to a warning so one broken plugin
+        # cannot take down every pyvista.read call.
+        handler = winner.load()
+    except Exception as err:  # noqa: BLE001
+        warn_external(
+            f'Failed to load pyvista.readers entry point "{winner.value}" for "{ext}": {err}'
+        )
+        return False
+    _custom_ext_readers[ext] = handler
+    _custom_ext_reader_sources[ext] = winner.value
+    if len(eps) > 1:
+        providers = ', '.join(ep.value for ep in eps)
+        warn_external(
+            f'Multiple pyvista.readers entry points registered for '
+            f'"{ext}": {providers}. Using {winner.value}.'
+        )
+    return True
 
 
 def _list_custom_exts() -> list[str]:
     """Return the list of extensions with registered custom readers.
 
-    Triggers lazy entry-point discovery so that extensions contributed
-    by installed packages appear in listings of supported formats.
+    Triggers lazy entry-point *metadata* discovery so that extensions
+    contributed by installed packages appear in listings of supported
+    formats. The plugin modules themselves are **not** imported.
     """
     _ensure_entry_points()
-    return list(_custom_ext_readers.keys())
+    return list(_custom_ext_readers.keys() | _pending_ext_readers.keys())
 
 
 def registered_readers() -> tuple[ReaderRegistration, ...]:
@@ -411,6 +455,8 @@ def registered_readers() -> tuple[ReaderRegistration, ...]:
 
     """
     _ensure_entry_points()
+    for ext in list(_pending_ext_readers):
+        _resolve_pending_reader(ext)
     return tuple(
         ReaderRegistration(
             extension=ext,

--- a/pyvista/core/utilities/reader_registry.py
+++ b/pyvista/core/utilities/reader_registry.py
@@ -26,11 +26,12 @@ if TYPE_CHECKING:
 
     from pyvista.core.dataset import DataSet
 
-    class ReaderHandler(Protocol):
-        """Callable that reads *path* and returns a :class:`pyvista.DataSet`."""
 
-        def __call__(self, path: str, /, **kwargs: Any) -> DataSet:
-            """Read *path* and return the resulting dataset."""
+class ReaderHandler(Protocol):
+    """Callable that reads *path* and returns a :class:`pyvista.DataSet`."""
+
+    def __call__(self, path: str, /, **kwargs: Any) -> DataSet:
+        """Read *path* and return the resulting dataset."""
 
 
 class ReaderRegistration(NamedTuple):

--- a/pyvista/core/utilities/writer_registry.py
+++ b/pyvista/core/utilities/writer_registry.py
@@ -56,11 +56,18 @@ class WriterRegistration(NamedTuple):
 class _RegistryState(TypedDict):
     ext: dict[str, WriterHandler]
     sources: dict[str, str]
+    pending: dict[str, list[EntryPoint]]
     entry_points_loaded: bool
 
 
 _custom_ext_writers: dict[str, WriterHandler] = {}
 _custom_ext_writer_sources: dict[str, str] = {}
+# Entry-point metadata, populated by ``_ensure_entry_points``. Maps each
+# extension to the list of ``EntryPoint`` records that declared it.
+# The plugin module itself is *not* imported until that extension is
+# actually requested via :func:`_get_ext_handler`, keeping ``pv.save``
+# calls for built-in formats free of third-party plugin import cost.
+_pending_ext_writers: dict[str, list[EntryPoint]] = {}
 _entry_points_loaded: bool = False
 _builtin_writer_exts: frozenset[str] | None = None
 
@@ -70,6 +77,7 @@ def _save_registry_state() -> _RegistryState:
     return {
         'ext': _custom_ext_writers.copy(),
         'sources': _custom_ext_writer_sources.copy(),
+        'pending': {k: list(v) for k, v in _pending_ext_writers.items()},
         'entry_points_loaded': _entry_points_loaded,
     }
 
@@ -81,6 +89,8 @@ def _restore_registry_state(state: _RegistryState) -> None:
     _custom_ext_writers.update(state['ext'])
     _custom_ext_writer_sources.clear()
     _custom_ext_writer_sources.update(state['sources'])
+    _pending_ext_writers.clear()
+    _pending_ext_writers.update({k: list(v) for k, v in state['pending'].items()})
     _entry_points_loaded = state['entry_points_loaded']
 
 
@@ -259,63 +269,96 @@ def _register(
 
 
 def _get_ext_handler(ext: str) -> WriterHandler | None:
-    """Look up a custom extension handler, discovering entry points lazily."""
+    """Look up a custom extension handler, importing the plugin lazily.
+
+    Built-in extensions never trigger entry-point plugin imports — only
+    extensions that an installed plugin has actually claimed do.
+    """
     handler = _custom_ext_writers.get(ext)
     if handler is not None:
         return handler
     _ensure_entry_points()
+    if ext in _pending_ext_writers:
+        _resolve_pending_writer(ext)
     return _custom_ext_writers.get(ext)
 
 
 def _ensure_entry_points() -> None:
-    """Scan the ``pyvista.writers`` entry-point group and load handlers."""
+    """Scan ``pyvista.writers`` entry-point metadata once.
+
+    Populates :data:`_pending_ext_writers` with every extension declared
+    by an installed plugin. The plugin modules themselves are **not**
+    imported here; the cost is one ``importlib.metadata.entry_points``
+    call. Plugin imports are deferred to :func:`_resolve_pending_writer`,
+    which runs only when a writer for that specific extension is
+    actually requested.
+    """
     global _entry_points_loaded  # noqa: PLW0603
     if _entry_points_loaded:
         return
     _entry_points_loaded = True
 
-    # Group entry points by normalized key so we can detect duplicate
-    # providers *and* guarantee a deterministic winner (the first one).
-    eps_by_key: dict[str, list[EntryPoint]] = {}
     for ep in entry_points(group='pyvista.writers'):
         key = ep.name.lower()
         if not key.startswith('.'):
             key = f'.{key}'
-        eps_by_key.setdefault(key, []).append(ep)
-
-    for key, eps in eps_by_key.items():
         if key in _custom_ext_writers:
             continue
-        winner = eps[0]
-        try:
-            # ep.load() runs third-party import machinery — it can raise
-            # literally anything. Convert to a warning so one broken plugin
-            # cannot take down every pyvista.save call.
-            handler = winner.load()
-        except Exception as err:  # noqa: BLE001
-            warn_external(
-                f'Failed to load pyvista.writers entry point "{winner.value}" for "{key}": {err}'
-            )
-            continue
-        _custom_ext_writers[key] = handler
-        _custom_ext_writer_sources[key] = winner.value
-        if len(eps) > 1:
-            providers = ', '.join(ep.value for ep in eps)
-            warn_external(
-                f'Multiple pyvista.writers entry points registered for '
-                f'"{key}": {providers}. Using {winner.value}.'
-            )
+        _pending_ext_writers.setdefault(key, []).append(ep)
+
+
+def _resolve_pending_writer(ext: str) -> bool:
+    """Import the plugin claiming *ext*, if any.
+
+    Returns
+    -------
+    bool
+        ``True`` if a plugin loaded successfully for ``ext``. ``False``
+        if no pending plugin matches, or if the plugin failed to import.
+
+    Notes
+    -----
+    A plugin that fails to import emits a ``UserWarning`` and is dropped
+    from the pending list, so subsequent lookups of the same extension
+    fall straight through without re-triggering the import or
+    re-emitting the warning.
+
+    """
+    eps = _pending_ext_writers.pop(ext, None)
+    if not eps:
+        return False
+    winner = eps[0]
+    try:
+        # ep.load() runs third-party import machinery — it can raise
+        # literally anything. Convert to a warning so one broken plugin
+        # cannot take down every pyvista.save call.
+        handler = winner.load()
+    except Exception as err:  # noqa: BLE001
+        warn_external(
+            f'Failed to load pyvista.writers entry point "{winner.value}" for "{ext}": {err}'
+        )
+        return False
+    _custom_ext_writers[ext] = handler
+    _custom_ext_writer_sources[ext] = winner.value
+    if len(eps) > 1:
+        providers = ', '.join(ep.value for ep in eps)
+        warn_external(
+            f'Multiple pyvista.writers entry points registered for '
+            f'"{ext}": {providers}. Using {winner.value}.'
+        )
+    return True
 
 
 def _list_custom_exts() -> list[str]:
     """Return the list of extensions with registered custom writers.
 
-    Triggers lazy entry-point discovery so that extensions contributed
-    by installed packages appear in error messages listing supported
-    formats.
+    Triggers lazy entry-point *metadata* discovery so that extensions
+    contributed by installed packages appear in error messages listing
+    supported formats. The plugin modules themselves are **not**
+    imported.
     """
     _ensure_entry_points()
-    return list(_custom_ext_writers.keys())
+    return list(_custom_ext_writers.keys() | _pending_ext_writers.keys())
 
 
 def registered_writers() -> tuple[WriterRegistration, ...]:
@@ -348,6 +391,8 @@ def registered_writers() -> tuple[WriterRegistration, ...]:
 
     """
     _ensure_entry_points()
+    for ext in list(_pending_ext_writers):
+        _resolve_pending_writer(ext)
     return tuple(
         WriterRegistration(
             extension=ext,

--- a/pyvista/core/utilities/writer_registry.py
+++ b/pyvista/core/utilities/writer_registry.py
@@ -20,11 +20,12 @@ if TYPE_CHECKING:
 
     from pyvista.core.dataobject import DataObject
 
-    class WriterHandler(Protocol):
-        """Callable that writes *dataset* to *path*."""
 
-        def __call__(self, dataset: DataObject, path: str, /, **kwargs: Any) -> None:
-            """Write *dataset* to *path*, consuming format-specific *kwargs*."""
+class WriterHandler(Protocol):
+    """Callable that writes *dataset* to *path*."""
+
+    def __call__(self, dataset: DataObject, path: str, /, **kwargs: Any) -> None:
+        """Write *dataset* to *path*, consuming format-specific *kwargs*."""
 
 
 class WriterRegistration(NamedTuple):

--- a/pyvista/core/utilities/writer_registry.py
+++ b/pyvista/core/utilities/writer_registry.py
@@ -6,12 +6,14 @@ from importlib.metadata import EntryPoint
 from importlib.metadata import entry_points
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import NamedTuple
 from typing import Protocol
 from typing import TypedDict
 from typing import overload
 
 import pyvista as pv
 from pyvista._warn_external import warn_external
+from pyvista.core.utilities._registry_helpers import handler_source
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -25,12 +27,40 @@ if TYPE_CHECKING:
             """Write *dataset* to *path*, consuming format-specific *kwargs*."""
 
 
+class WriterRegistration(NamedTuple):
+    """Describe one registered custom writer.
+
+    Returned by :func:`~pyvista.registered_writers`.
+
+    .. versionadded:: 0.48.0
+
+    Attributes
+    ----------
+    extension : str
+        File extension the writer is registered against, including the
+        leading dot (e.g. ``'.myformat'``).
+    handler : callable
+        The writer callable.
+    source : str
+        Human-readable origin in the form ``'module.qualname'`` for
+        explicit registrations or the entry-point ``value`` for
+        plugin-discovered registrations.
+
+    """
+
+    extension: str
+    handler: WriterHandler
+    source: str
+
+
 class _RegistryState(TypedDict):
     ext: dict[str, WriterHandler]
+    sources: dict[str, str]
     entry_points_loaded: bool
 
 
 _custom_ext_writers: dict[str, WriterHandler] = {}
+_custom_ext_writer_sources: dict[str, str] = {}
 _entry_points_loaded: bool = False
 _builtin_writer_exts: frozenset[str] | None = None
 
@@ -39,6 +69,7 @@ def _save_registry_state() -> _RegistryState:
     """Snapshot the current registry state for later restoration."""
     return {
         'ext': _custom_ext_writers.copy(),
+        'sources': _custom_ext_writer_sources.copy(),
         'entry_points_loaded': _entry_points_loaded,
     }
 
@@ -48,6 +79,8 @@ def _restore_registry_state(state: _RegistryState) -> None:
     global _entry_points_loaded  # noqa: PLW0603
     _custom_ext_writers.clear()
     _custom_ext_writers.update(state['ext'])
+    _custom_ext_writer_sources.clear()
+    _custom_ext_writer_sources.update(state['sources'])
     _entry_points_loaded = state['entry_points_loaded']
 
 
@@ -125,9 +158,8 @@ def register_writer(
 
     override : bool, default: False
         If ``True``, allow overriding a built-in PyVista writer for this
-        extension.  When ``False`` (the default), registering a handler
-        for an extension that collides with a built-in writer raises
-        :class:`ValueError`.
+        extension and silence the warning that would otherwise fire when
+        replacing an existing custom registration.
 
     Returns
     -------
@@ -141,10 +173,19 @@ def register_writer(
         If ``key`` collides with a built-in PyVista writer and *override*
         is ``False``.
 
+    Warns
+    -----
+    UserWarning
+        If ``key`` already refers to a registered custom writer. The new
+        registration replaces the old one (last wins); pass
+        ``override=True`` to silence the warning.
+
     See Also
     --------
     pyvista.register_reader
         Sibling API for registering custom readers.
+    pyvista.registered_writers
+        Introspect every registered writer.
 
     Notes
     -----
@@ -194,6 +235,7 @@ def _register(
     handler: WriterHandler,
     *,
     override: bool = False,
+    source: str | None = None,
 ) -> None:
     """Register a handler in the extension registry."""
     key = key.lower()
@@ -206,7 +248,14 @@ def _register(
             f'Use override=True to replace it.'
         )
         raise ValueError(msg)
+    if not override and key in _custom_ext_writers:
+        existing_source = _custom_ext_writer_sources.get(key, '<unknown>')
+        warn_external(
+            f'Registering writer for "{key}" replaces an existing custom '
+            f'writer from {existing_source}.',
+        )
     _custom_ext_writers[key] = handler
+    _custom_ext_writer_sources[key] = source if source is not None else handler_source(handler)
 
 
 def _get_ext_handler(ext: str) -> WriterHandler | None:
@@ -242,12 +291,14 @@ def _ensure_entry_points() -> None:
             # ep.load() runs third-party import machinery — it can raise
             # literally anything. Convert to a warning so one broken plugin
             # cannot take down every pyvista.save call.
-            _custom_ext_writers[key] = winner.load()
+            handler = winner.load()
         except Exception as err:  # noqa: BLE001
             warn_external(
                 f'Failed to load pyvista.writers entry point "{winner.value}" for "{key}": {err}'
             )
             continue
+        _custom_ext_writers[key] = handler
+        _custom_ext_writer_sources[key] = winner.value
         if len(eps) > 1:
             providers = ', '.join(ep.value for ep in eps)
             warn_external(
@@ -265,3 +316,43 @@ def _list_custom_exts() -> list[str]:
     """
     _ensure_entry_points()
     return list(_custom_ext_writers.keys())
+
+
+def registered_writers() -> tuple[WriterRegistration, ...]:
+    """Return every custom writer currently registered.
+
+    Forces discovery of any pending entry-point plugins so the returned
+    list reflects every writer visible to PyVista. A plugin that fails to
+    import emits a ``UserWarning`` and is skipped; the rest still appear
+    in the result.
+
+    .. versionadded:: 0.48.0
+
+    Returns
+    -------
+    tuple[WriterRegistration, ...]
+        One record per registered extension. Each record exposes
+        ``extension``, ``handler``, and ``source``.
+
+    Examples
+    --------
+    >>> import pyvista as pv
+    >>> def my_writer(dataset, path, **kwargs): ...
+    >>> pv.register_writer('.demo_writer', my_writer)
+    >>> [
+    ...     r.extension
+    ...     for r in pv.registered_writers()
+    ...     if r.extension == '.demo_writer'
+    ... ]
+    ['.demo_writer']
+
+    """
+    _ensure_entry_points()
+    return tuple(
+        WriterRegistration(
+            extension=ext,
+            handler=handler,
+            source=_custom_ext_writer_sources.get(ext, '<unknown>'),
+        )
+        for ext, handler in _custom_ext_writers.items()
+    )

--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
-import contextlib
+from importlib.metadata import entry_points
 import importlib.util
 from typing import TYPE_CHECKING
 from typing import Literal
+from typing import NamedTuple
 from typing import get_args
 
 from typing_extensions import TypeIs
 
 import pyvista as pv
+from pyvista._warn_external import warn_external
 from pyvista.core.errors import PyVistaDeprecationWarning as PyVistaDeprecationWarning
+from pyvista.core.utilities._registry_helpers import handler_source
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -19,11 +22,44 @@ if TYPE_CHECKING:
 JupyterBackendOptions = Literal['static', 'client', 'server', 'trame', 'html', 'none']
 ALLOWED_BACKENDS = get_args(JupyterBackendOptions)
 
+JUPYTER_BACKEND_ENTRY_POINT_GROUP = 'pyvista.jupyter_backends'
+
 _custom_backends: dict[str, Callable[..., object]] = {}
+_custom_backend_sources: dict[str, str] = {}
 _entry_points_loaded: bool = False
 
 
-def register_jupyter_backend(name: str, handler: Callable[..., object]) -> None:
+class JupyterBackendRegistration(NamedTuple):
+    """Describe one registered custom Jupyter backend.
+
+    Returned by :func:`~pyvista.registered_jupyter_backends`.
+
+    .. versionadded:: 0.48.0
+
+    Attributes
+    ----------
+    name : str
+        Backend name.
+    handler : callable
+        The backend handler callable.
+    source : str
+        Human-readable origin in the form ``'module.qualname'`` for
+        explicit registrations or the entry-point ``value`` for
+        plugin-discovered registrations.
+
+    """
+
+    name: str
+    handler: Callable[..., object]
+    source: str
+
+
+def register_jupyter_backend(
+    name: str,
+    handler: Callable[..., object],
+    *,
+    override: bool = False,
+) -> None:
     """Register a custom Jupyter backend handler.
 
     .. versionadded:: 0.48.0
@@ -32,15 +68,27 @@ def register_jupyter_backend(name: str, handler: Callable[..., object]) -> None:
     ----------
     name : str
         Name of the backend (e.g. ``'custom'``). Must not collide with
-        a built-in backend name.
+        a built-in backend name unless ``override=True`` is passed.
     handler : callable
         A callable with signature ``handler(plotter, **kwargs)`` that
         returns an IPython-displayable object.
+    override : bool, default: False
+        If ``True``, allow registering a name that collides with a
+        built-in backend. Also silences the warning emitted when
+        replacing an existing custom registration.
 
     Raises
     ------
     ValueError
-        If ``name`` collides with a built-in backend.
+        If ``name`` collides with a built-in backend and ``override``
+        is ``False``.
+
+    Warns
+    -----
+    UserWarning
+        If ``name`` already refers to a registered custom backend. The
+        new registration replaces the old one (last wins); pass
+        ``override=True`` to silence the warning.
 
     Examples
     --------
@@ -50,10 +98,49 @@ def register_jupyter_backend(name: str, handler: Callable[..., object]) -> None:
 
     """
     name = name.lower()
-    if name in ALLOWED_BACKENDS:
-        msg = f'Cannot register custom backend "{name}": collides with built-in backend.'
+    if not override and name in ALLOWED_BACKENDS:
+        msg = (
+            f'Cannot register custom backend "{name}": collides with built-in backend. '
+            'Use override=True to replace it.'
+        )
         raise ValueError(msg)
+    if not override and name in _custom_backends:
+        existing_source = _custom_backend_sources.get(name, '<unknown>')
+        warn_external(
+            f'Registering Jupyter backend "{name}" replaces an existing custom '
+            f'registration from {existing_source}.',
+        )
     _custom_backends[name] = handler
+    _custom_backend_sources[name] = handler_source(handler)
+
+
+def registered_jupyter_backends() -> tuple[JupyterBackendRegistration, ...]:
+    """Return every custom Jupyter backend currently registered.
+
+    Forces discovery of any pending entry-point plugins so the returned
+    list reflects every backend visible to PyVista. A plugin that fails
+    to import emits a ``UserWarning`` and is skipped; the rest still
+    appear in the result.
+
+    .. versionadded:: 0.48.0
+
+    Returns
+    -------
+    tuple[JupyterBackendRegistration, ...]
+        One record per registered backend. Each record exposes
+        ``name``, ``handler``, and ``source``. Built-in backends are
+        not included; only custom registrations.
+
+    """
+    _ensure_entry_points()
+    return tuple(
+        JupyterBackendRegistration(
+            name=name,
+            handler=handler,
+            source=_custom_backend_sources.get(name, '<unknown>'),
+        )
+        for name, handler in _custom_backends.items()
+    )
 
 
 def _get_custom_backend_handler(name: str) -> Callable[..., object] | None:
@@ -75,24 +162,35 @@ def _get_custom_backend_handler(name: str) -> Callable[..., object] | None:
     handler = _custom_backends.get(name)
     if handler is not None:
         return handler
-    _discover_entry_points()
+    _ensure_entry_points()
     return _custom_backends.get(name)
 
 
-def _discover_entry_points() -> None:
-    """Scan ``pyvista.jupyter.backends`` entry point group and load handlers."""
+def _ensure_entry_points() -> None:
+    """Scan ``pyvista.jupyter_backends`` entry point group and load handlers."""
     global _entry_points_loaded  # noqa: PLW0603
     if _entry_points_loaded:
         return
     _entry_points_loaded = True
-    from importlib.metadata import entry_points  # noqa: PLC0415
 
-    eps = entry_points(group='pyvista.jupyter.backends')
+    eps = entry_points(group=JUPYTER_BACKEND_ENTRY_POINT_GROUP)
     for ep in eps:
         name = ep.name.lower()
-        if name not in ALLOWED_BACKENDS and name not in _custom_backends:
-            with contextlib.suppress(Exception):
-                _custom_backends[name] = ep.load()
+        if name in ALLOWED_BACKENDS or name in _custom_backends:
+            continue
+        try:
+            # ep.load() runs third-party import machinery — it can raise
+            # literally anything. Convert to a warning so one broken
+            # plugin cannot take down the Jupyter integration.
+            handler = ep.load()
+        except Exception as err:  # noqa: BLE001
+            warn_external(
+                f'Failed to load {JUPYTER_BACKEND_ENTRY_POINT_GROUP} entry point '
+                f'"{ep.value}" for "{name}": {err}',
+            )
+            continue
+        _custom_backends[name] = handler
+        _custom_backend_sources[name] = ep.value
 
 
 def _resolve_backend() -> str:
@@ -106,7 +204,7 @@ def _resolve_backend() -> str:
         Name of the best available backend.
 
     """
-    _discover_entry_points()
+    _ensure_entry_points()
     if _custom_backends:
         return next(iter(_custom_backends))
 

--- a/pyvista/jupyter/__init__.py
+++ b/pyvista/jupyter/__init__.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+# noqa-reason: ``Callable`` is used in the ``JupyterBackendRegistration``
+# NamedTuple field annotations and must be available at runtime so that
+# ``typing.get_type_hints`` (called by Sphinx autodoc) can resolve them.
+from collections.abc import Callable  # noqa: TC003
 from importlib.metadata import entry_points
 import importlib.util
-from typing import TYPE_CHECKING
 from typing import Literal
 from typing import NamedTuple
 from typing import get_args
@@ -15,9 +18,6 @@ import pyvista as pv
 from pyvista._warn_external import warn_external
 from pyvista.core.errors import PyVistaDeprecationWarning as PyVistaDeprecationWarning
 from pyvista.core.utilities._registry_helpers import handler_source
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 JupyterBackendOptions = Literal['static', 'client', 'server', 'trame', 'html', 'none']
 ALLOWED_BACKENDS = get_args(JupyterBackendOptions)

--- a/pyvista/jupyter/notebook.py
+++ b/pyvista/jupyter/notebook.py
@@ -16,7 +16,7 @@ from typing import cast
 
 from pyvista._warn_external import warn_external
 from pyvista.jupyter import _custom_backends
-from pyvista.jupyter import _discover_entry_points
+from pyvista.jupyter import _ensure_entry_points
 from pyvista.jupyter import _get_custom_backend_handler
 from pyvista.jupyter import _resolve_backend
 
@@ -75,7 +75,7 @@ def handle_plotter(
 
     except ImportError as e:
         # Trame was explicitly requested but not available
-        _discover_entry_points()
+        _ensure_entry_points()
         if _custom_backends:
             fallback_name, fallback_handler = next(iter(_custom_backends.items()))
             available = [f'"{b}"' for b in sorted(_custom_backends.keys())]

--- a/pyvista/plotting/interactor_style_registry.py
+++ b/pyvista/plotting/interactor_style_registry.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from typing import TypedDict
 
 from pyvista._warn_external import warn_external
+from pyvista.core.utilities._registry_helpers import handler_source
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -20,6 +21,7 @@ class _InteractorStyleRegistryState(TypedDict):
     """Stored registry state used by tests."""
 
     custom: dict[str, InteractorStyleHandler]
+    custom_sources: dict[str, str]
     discovered: dict[str, InteractorStyleHandler]
     discovered_sources: dict[str, str]
     loaded: bool
@@ -42,6 +44,7 @@ _BUILTIN_INTERACTOR_STYLE_METHODS = {
 }
 
 _custom_interactor_styles: dict[str, InteractorStyleHandler] = {}
+_custom_interactor_style_sources: dict[str, str] = {}
 _discovered_entry_point_styles: dict[str, InteractorStyleHandler] = {}
 _discovered_entry_point_sources: dict[str, str] = {}
 _entry_points_loaded: bool = False
@@ -56,6 +59,7 @@ def _save_registry_state() -> _InteractorStyleRegistryState:
     """Snapshot the current registry state for later restoration."""
     return {
         'custom': _custom_interactor_styles.copy(),
+        'custom_sources': _custom_interactor_style_sources.copy(),
         'discovered': _discovered_entry_point_styles.copy(),
         'discovered_sources': _discovered_entry_point_sources.copy(),
         'loaded': _entry_points_loaded,
@@ -67,6 +71,8 @@ def _restore_registry_state(state: _InteractorStyleRegistryState) -> None:
     global _entry_points_loaded  # noqa: PLW0603
     _custom_interactor_styles.clear()
     _custom_interactor_styles.update(state['custom'])
+    _custom_interactor_style_sources.clear()
+    _custom_interactor_style_sources.update(state['custom_sources'])
     _discovered_entry_point_styles.clear()
     _discovered_entry_point_styles.update(state['discovered'])
     _discovered_entry_point_sources.clear()
@@ -74,7 +80,12 @@ def _restore_registry_state(state: _InteractorStyleRegistryState) -> None:
     _entry_points_loaded = state['loaded']
 
 
-def register_interactor_style(name: str, handler: InteractorStyleHandler) -> None:
+def register_interactor_style(
+    name: str,
+    handler: InteractorStyleHandler,
+    *,
+    override: bool = False,
+) -> None:
     """Register a custom interactor style.
 
     Parameters
@@ -90,11 +101,23 @@ def register_interactor_style(name: str, handler: InteractorStyleHandler) -> Non
         or any callable with signature ``handler(interactor)`` that
         returns an interactor style instance.
 
+    override : bool, default: False
+        If ``True``, allow registering a name that collides with a
+        built-in interactor style. Also silences the warning emitted
+        when replacing an existing custom registration.
+
     Raises
     ------
     ValueError
-        If ``name`` is empty or collides with a built-in PyVista
-        interactor style.
+        If ``name`` is empty, or collides with a built-in PyVista
+        interactor style and ``override`` is ``False``.
+
+    Warns
+    -----
+    UserWarning
+        If ``name`` already refers to a registered custom interactor
+        style. The new registration replaces the old one (last wins);
+        pass ``override=True`` to silence the warning.
 
     Examples
     --------
@@ -123,14 +146,22 @@ def register_interactor_style(name: str, handler: InteractorStyleHandler) -> Non
     if not normalized_name:
         msg = 'Interactor style name must not be empty.'
         raise ValueError(msg)
-    if normalized_name in _BUILTIN_INTERACTOR_STYLE_METHODS:
+    if not override and normalized_name in _BUILTIN_INTERACTOR_STYLE_METHODS:
         msg = (
             f'Cannot register custom interactor style "{normalized_name}": '
-            'collides with a built-in interactor style.'
+            'collides with a built-in interactor style. '
+            'Use override=True to replace it.'
         )
         raise ValueError(msg)
+    if not override and normalized_name in _custom_interactor_styles:
+        existing_source = _custom_interactor_style_sources.get(normalized_name, '<unknown>')
+        warn_external(
+            f'Registering interactor style "{normalized_name}" replaces an '
+            f'existing custom registration from {existing_source}.',
+        )
 
     _custom_interactor_styles[normalized_name] = handler
+    _custom_interactor_style_sources[normalized_name] = handler_source(handler)
 
 
 def _get_interactor_style_handler(name: str) -> str | InteractorStyleHandler | None:

--- a/tests/core/test_accessor_registry.py
+++ b/tests/core/test_accessor_registry.py
@@ -853,6 +853,98 @@ def test_registered_accessors_forces_discovery(monkeypatch):
         sys.modules.pop(plugin_name, None)
 
 
+def test_pending_accessor_appears_in_dir_without_loading(monkeypatch):
+    """``dir(mesh)`` includes pending entry-point accessor names so
+    IPython / Jupyter / REPL tab completion surfaces them, *without*
+    paying the plugin import cost."""
+    plugin_name = 'fake_ep_plugin_dir'
+    fake_import = _fake_importer(
+        plugin_name,
+        'import pyvista as pv\n'
+        "@pv.register_dataset_accessor('dir_demo', pv.PolyData)\n"
+        'class DirDemoAccessor:\n'
+        '    def __init__(self, mesh):\n'
+        '        self._mesh = mesh\n',
+    )
+    ep = MagicMock()
+    ep.name = 'dir_demo'
+    ep.value = plugin_name
+
+    _reset_entry_point_state(monkeypatch, [ep])
+    import_calls: list[str] = []
+
+    def _tracking_import(module_path: str):
+        import_calls.append(module_path)
+        return fake_import(module_path)
+
+    monkeypatch.setattr(
+        'pyvista.core.utilities.accessor_registry.import_module',
+        _tracking_import,
+    )
+
+    try:
+        listing = dir(pv.Sphere())
+        assert 'dir_demo' in listing
+        assert import_calls == []  # plugin not loaded by dir()
+    finally:
+        sys.modules.pop(plugin_name, None)
+
+
+def test_explicit_accessor_appears_in_dir():
+    """Explicitly-registered accessors appear in ``dir`` for instances
+    of their target class but not for unrelated classes."""
+
+    @pv.register_dataset_accessor('explicit_dir_demo', pv.PolyData)
+    class ExplicitDirDemo:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+    try:
+        assert 'explicit_dir_demo' in dir(pv.Sphere())
+        assert 'explicit_dir_demo' in dir(pv.Cube())  # also PolyData
+        assert 'explicit_dir_demo' not in dir(pv.ImageData())
+    finally:
+        pv.unregister_dataset_accessor('explicit_dir_demo', pv.PolyData)
+
+
+def test_dir_after_pending_accessor_resolved(monkeypatch):
+    """After a pending accessor has been resolved (plugin imported and
+    decorator attached the descriptor), ``dir`` still surfaces it via
+    the normal class-dictionary path — not via the pending fallback."""
+    plugin_name = 'fake_ep_plugin_dir_resolved'
+    fake_import = _fake_importer(
+        plugin_name,
+        'import pyvista as pv\n'
+        "@pv.register_dataset_accessor('resolved_demo', pv.PolyData)\n"
+        'class ResolvedDemoAccessor:\n'
+        '    def __init__(self, mesh):\n'
+        '        self._mesh = mesh\n',
+    )
+    ep = MagicMock()
+    ep.name = 'resolved_demo'
+    ep.value = plugin_name
+
+    _reset_entry_point_state(monkeypatch, [ep])
+    monkeypatch.setattr(
+        'pyvista.core.utilities.accessor_registry.import_module',
+        fake_import,
+    )
+
+    try:
+        sphere = pv.Sphere()
+        # Trigger plugin load
+        _ = sphere.resolved_demo
+        # Pending list is empty now; dir should still include the name
+        # via the class-attached descriptor.
+        assert _reg_mod._pending_accessors == {}
+        assert 'resolved_demo' in dir(sphere)
+    finally:
+        sys.modules.pop(plugin_name, None)
+        # Clean up the descriptor that fake_import attached
+        if 'resolved_demo' in pv.PolyData.__dict__:
+            delattr(pv.PolyData, 'resolved_demo')
+
+
 def test_no_entry_points_is_silent(monkeypatch):
     """No installed accessor plugins must be a no-op without warnings.
 

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -439,18 +439,25 @@ def test_init_bad_filename():
 
 
 def test_save_bad_extension():
-    valid_ext = ['.vtu', '.vtk', '.pkl', '.pickle', '.pv', '.zvtk']
+    # Don't assert on the full list of valid extensions because plugin
+    # packages registered via the ``pyvista.writers`` entry-point group
+    # can extend it (e.g. pyvista_zarr adding ``.zarr``). Verify the
+    # bad-extension framing and that all the built-in extensions are
+    # listed; that's the contract users rely on.
+    builtin_exts = ['.vtu', '.vtk', '.pkl', '.pickle', '.pv', '.zvtk']
     if pv.vtk_version_info >= (9, 4):
-        valid_ext.insert(2, '.vtkhdf')
+        builtin_exts.append('.vtkhdf')
 
-    match = (
-        "Invalid file extension '.abc' for data type <class "
-        "'pyvista.core.pointset.UnstructuredGrid'>.\n"
-        f'Must be one of: {valid_ext}'
-    )
-
-    with pytest.raises(ValueError, match=re.escape(match)):
+    with pytest.raises(ValueError, match='Invalid file extension') as excinfo:
         pv.UnstructuredGrid().save('file.abc')
+
+    message = str(excinfo.value)
+    assert (
+        "Invalid file extension '.abc' for data type "
+        "<class 'pyvista.core.pointset.UnstructuredGrid'>" in message
+    )
+    for ext in builtin_exts:
+        assert f"'{ext}'" in message, f'Built-in extension {ext} missing from error message'
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -1349,7 +1349,7 @@ def default_n_faces():
     pv.PolyData._USE_STRICT_N_FACES = False
 
 
-def test_n_faces():
+def test_n_faces(default_n_faces):  # noqa: ARG001
     if pv._version.version_info[:2] >= (0, 46):
         # At version 0.46, n_faces should raise an error instead of warning
         mesh = pv.PolyData(
@@ -1394,7 +1394,7 @@ def test_n_faces():
         raise RuntimeError(msg)
 
 
-def test_opt_in_n_faces_strict():
+def test_opt_in_n_faces_strict(default_n_faces):  # noqa: ARG001
     pv.PolyData.use_strict_n_faces(True)
     mesh = pv.PolyData(
         [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)],

--- a/tests/core/test_pyvista_ndarray.py
+++ b/tests/core/test_pyvista_ndarray.py
@@ -126,12 +126,37 @@ def test_no_dataset_does_not_allocate_weak_reference():
     assert arr.dataset is None
 
 
+def _count_vtk_weak_references() -> int:
+    """Count live ``vtkWeakReference`` objects, tolerating dead weak refs.
+
+    ``isinstance`` on some weakref-like proxies whose targets have already
+    been collected raises ``ReferenceError``; skip those.
+    """
+    count = 0
+    for obj in gc.get_objects():
+        try:
+            if isinstance(obj, _vtk.vtkWeakReference):
+                count += 1
+        except ReferenceError:
+            continue
+    return count
+
+
 def test_point_data_assignment_does_not_leak_vtk_weak_reference():
     # Regression test for https://github.com/pyvista/pyvista/issues/8532
+    # Compare counts before and after rather than asserting an absolute
+    # zero — other code in the interpreter (other tests, fixtures,
+    # imported plugins) may legitimately hold ``vtkWeakReference``
+    # instances that have nothing to do with this operation.
+    gc.collect()
+    before = _count_vtk_weak_references()
+
     mesh = pv.Sphere()
     mesh.point_data['data'] = mesh.points[:, 2].astype(float)
     del mesh
     gc.collect()
 
-    leaked = [o for o in gc.get_objects() if isinstance(o, _vtk.vtkWeakReference)]
-    assert leaked == []
+    after = _count_vtk_weak_references()
+    assert after <= before, (
+        f'point_data assignment leaked {after - before} vtkWeakReference instance(s)'
+    )

--- a/tests/core/test_reader_registry.py
+++ b/tests/core/test_reader_registry.py
@@ -12,6 +12,7 @@ import sys
 import types
 from unittest.mock import MagicMock
 from unittest.mock import patch
+import warnings
 
 import pytest
 
@@ -53,6 +54,7 @@ def test_module_import_registers_cleanup_handler():
 
     register.assert_called_once_with(module._cleanup_temp_files)
     assert module._custom_ext_readers == {}
+    assert module._custom_ext_reader_sources == {}
     assert module._entry_points_loaded is False
     assert module._temp_files == []
 
@@ -358,3 +360,52 @@ def test_top_level_exports_available_in_fresh_python_process():
         capture_output=True,
         text=True,
     )
+
+
+def test_registered_readers_returns_record_with_source():
+    pv.register_reader('.mything', _mock_reader)
+    records = pv.registered_readers()
+    matches = [r for r in records if r.extension == '.mything']
+    assert len(matches) == 1
+    record = matches[0]
+    assert record.handler is _mock_reader
+    assert record.source.endswith('_mock_reader')
+
+
+def test_registered_readers_includes_entry_point_source():
+    _reg_mod._entry_points_loaded = False
+
+    mock_ep = MagicMock()
+    mock_ep.name = '.discovered_src'
+    mock_ep.value = 'package.module:reader_func'
+    mock_ep.load.return_value = _mock_reader
+
+    with patch('pyvista.core.utilities.reader_registry.entry_points', return_value=[mock_ep]):
+        records = pv.registered_readers()
+
+    matches = [r for r in records if r.extension == '.discovered_src']
+    assert len(matches) == 1
+    assert matches[0].source == 'package.module:reader_func'
+
+
+def test_register_custom_collision_warns_and_replaces():
+    pv.register_reader('.collide', _mock_reader)
+
+    def replacement(_path, **__):
+        return pv.PolyData()
+
+    with pytest.warns(UserWarning, match='replaces an existing custom reader'):
+        pv.register_reader('.collide', replacement)
+    assert _reg_mod._custom_ext_readers['.collide'] is replacement
+
+
+def test_register_custom_collision_override_silent():
+    pv.register_reader('.collide', _mock_reader)
+
+    def replacement(_path, **__):
+        return pv.PolyData()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        pv.register_reader('.collide', replacement, override=True)
+    assert _reg_mod._custom_ext_readers['.collide'] is replacement

--- a/tests/core/test_reader_registry.py
+++ b/tests/core/test_reader_registry.py
@@ -409,3 +409,102 @@ def test_register_custom_collision_override_silent():
         warnings.simplefilter('error')
         pv.register_reader('.collide', replacement, override=True)
     assert _reg_mod._custom_ext_readers['.collide'] is replacement
+
+
+def test_metadata_scan_does_not_load_plugin():
+    """``_ensure_entry_points`` records metadata without importing plugins."""
+    _reg_mod._entry_points_loaded = False
+    _reg_mod._pending_ext_readers.clear()
+
+    mock_ep = MagicMock()
+    mock_ep.name = '.lazy'
+    mock_ep.value = 'lazy_pkg:reader'
+
+    with patch('pyvista.core.utilities.reader_registry.entry_points', return_value=[mock_ep]):
+        _reg_mod._ensure_entry_points()
+
+    mock_ep.load.assert_not_called()
+    assert '.lazy' in _reg_mod._pending_ext_readers
+    assert '.lazy' not in _reg_mod._custom_ext_readers
+
+
+def test_unrelated_extension_does_not_load_plugin():
+    """Looking up an extension *no plugin claims* never imports any plugin."""
+    _reg_mod._entry_points_loaded = False
+    _reg_mod._pending_ext_readers.clear()
+
+    plugin_ep = MagicMock()
+    plugin_ep.name = '.someplugin'
+    plugin_ep.value = 'someplugin:reader'
+
+    with patch('pyvista.core.utilities.reader_registry.entry_points', return_value=[plugin_ep]):
+        # Built-in extensions like ``.vtp`` resolve via the VTK class
+        # readers, never via the entry-point registry. The lookup must
+        # not load any plugin.
+        assert _reg_mod._get_ext_handler('.vtp') is None
+
+    plugin_ep.load.assert_not_called()
+    # Pending plugin extension is still recorded for later resolution
+    assert '.someplugin' in _reg_mod._pending_ext_readers
+
+
+def test_matching_extension_loads_only_its_plugin():
+    """Looking up an extension a plugin claims loads *only* that plugin."""
+    _reg_mod._entry_points_loaded = False
+    _reg_mod._pending_ext_readers.clear()
+
+    wanted = MagicMock()
+    wanted.name = '.wanted'
+    wanted.value = 'wanted_pkg:reader'
+    wanted.load.return_value = _mock_reader
+
+    other = MagicMock()
+    other.name = '.other'
+    other.value = 'other_pkg:reader'
+
+    with patch(
+        'pyvista.core.utilities.reader_registry.entry_points',
+        return_value=[wanted, other],
+    ):
+        handler = _reg_mod._get_ext_handler('.wanted')
+
+    assert handler is _mock_reader
+    wanted.load.assert_called_once()
+    other.load.assert_not_called()
+    # The other plugin remains pending — still discoverable, still not loaded
+    assert '.other' in _reg_mod._pending_ext_readers
+
+
+def test_list_custom_exts_includes_pending_without_loading():
+    """``_list_custom_exts`` reports pending extensions without loading."""
+    _reg_mod._entry_points_loaded = False
+    _reg_mod._pending_ext_readers.clear()
+
+    mock_ep = MagicMock()
+    mock_ep.name = '.discoverable'
+    mock_ep.value = 'discoverable_pkg:reader'
+
+    with patch('pyvista.core.utilities.reader_registry.entry_points', return_value=[mock_ep]):
+        exts = _reg_mod._list_custom_exts()
+
+    assert '.discoverable' in exts
+    mock_ep.load.assert_not_called()
+
+
+def test_registered_readers_forces_full_discovery():
+    """``registered_readers`` resolves every pending plugin so callers see all."""
+    _reg_mod._entry_points_loaded = False
+    _reg_mod._pending_ext_readers.clear()
+
+    mock_ep = MagicMock()
+    mock_ep.name = '.eager'
+    mock_ep.value = 'eager_pkg:reader'
+    mock_ep.load.return_value = _mock_reader
+
+    with patch('pyvista.core.utilities.reader_registry.entry_points', return_value=[mock_ep]):
+        records = pv.registered_readers()
+
+    matches = [r for r in records if r.extension == '.eager']
+    assert len(matches) == 1
+    assert matches[0].handler is _mock_reader
+    mock_ep.load.assert_called_once()

--- a/tests/core/test_writer_registry.py
+++ b/tests/core/test_writer_registry.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
 import subprocess
 import sys
 from unittest.mock import MagicMock
 from unittest.mock import patch
+import warnings
 
 import pytest
 
@@ -31,8 +33,24 @@ def _noop_writer(_dataset, _path):
     """Writer stand-in that returns without touching disk."""
 
 
+def _load_module_copy(module_name: str, module_path: str | Path):
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_initial_module_state():
-    assert _reg_mod._custom_ext_writers == {}
+    # Load a fresh copy of the module so the assertion is immune to
+    # plugins (e.g. pyvista_zarr) that register at import time and
+    # pollute the live module's registry dicts.
+    module = _load_module_copy('writer_registry_test_copy', _reg_mod.__file__)
+    assert module._custom_ext_writers == {}
+    assert module._custom_ext_writer_sources == {}
+    assert module._entry_points_loaded is False
 
 
 def test_register_extension():
@@ -391,3 +409,52 @@ def test_top_level_exports_available_in_fresh_python_process():
         text=True,
         timeout=60,
     )
+
+
+def test_registered_writers_returns_record_with_source():
+    pv.register_writer('.mything', _noop_writer)
+    records = pv.registered_writers()
+    matches = [r for r in records if r.extension == '.mything']
+    assert len(matches) == 1
+    record = matches[0]
+    assert record.handler is _noop_writer
+    assert record.source.endswith('_noop_writer')
+
+
+def test_registered_writers_includes_entry_point_source():
+    _reg_mod._entry_points_loaded = False
+
+    mock_ep = MagicMock()
+    mock_ep.name = '.discovered_src'
+    mock_ep.value = 'package.module:writer_func'
+    mock_ep.load.return_value = _noop_writer
+
+    with patch('pyvista.core.utilities.writer_registry.entry_points', return_value=[mock_ep]):
+        records = pv.registered_writers()
+
+    matches = [r for r in records if r.extension == '.discovered_src']
+    assert len(matches) == 1
+    assert matches[0].source == 'package.module:writer_func'
+
+
+def test_register_custom_collision_warns_and_replaces():
+    pv.register_writer('.collide', _noop_writer)
+
+    def replacement(_ds, _path):
+        return None
+
+    with pytest.warns(UserWarning, match='replaces an existing custom writer'):
+        pv.register_writer('.collide', replacement)
+    assert _reg_mod._custom_ext_writers['.collide'] is replacement
+
+
+def test_register_custom_collision_override_silent():
+    pv.register_writer('.collide', _noop_writer)
+
+    def replacement(_ds, _path):
+        return None
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        pv.register_writer('.collide', replacement, override=True)
+    assert _reg_mod._custom_ext_writers['.collide'] is replacement

--- a/tests/core/test_writer_registry.py
+++ b/tests/core/test_writer_registry.py
@@ -458,3 +458,97 @@ def test_register_custom_collision_override_silent():
         warnings.simplefilter('error')
         pv.register_writer('.collide', replacement, override=True)
     assert _reg_mod._custom_ext_writers['.collide'] is replacement
+
+
+def test_metadata_scan_does_not_load_plugin():
+    """``_ensure_entry_points`` records metadata without importing plugins."""
+    _reg_mod._entry_points_loaded = False
+    _reg_mod._pending_ext_writers.clear()
+
+    mock_ep = MagicMock()
+    mock_ep.name = '.lazy'
+    mock_ep.value = 'lazy_pkg:writer'
+
+    with patch('pyvista.core.utilities.writer_registry.entry_points', return_value=[mock_ep]):
+        _reg_mod._ensure_entry_points()
+
+    mock_ep.load.assert_not_called()
+    assert '.lazy' in _reg_mod._pending_ext_writers
+    assert '.lazy' not in _reg_mod._custom_ext_writers
+
+
+def test_save_builtin_extension_does_not_load_plugin(tmp_path):
+    """Saving to a built-in extension never imports any plugin module."""
+    _reg_mod._entry_points_loaded = False
+    _reg_mod._pending_ext_writers.clear()
+
+    plugin_ep = MagicMock()
+    plugin_ep.name = '.someplugin'
+    plugin_ep.value = 'someplugin:writer'
+
+    with patch('pyvista.core.utilities.writer_registry.entry_points', return_value=[plugin_ep]):
+        pv.Sphere().save(tmp_path / 'out.vtp')
+
+    plugin_ep.load.assert_not_called()
+    assert '.someplugin' in _reg_mod._pending_ext_writers
+
+
+def test_matching_extension_loads_only_its_plugin():
+    """Looking up an extension a plugin claims loads *only* that plugin."""
+    _reg_mod._entry_points_loaded = False
+    _reg_mod._pending_ext_writers.clear()
+
+    wanted = MagicMock()
+    wanted.name = '.wanted'
+    wanted.value = 'wanted_pkg:writer'
+    wanted.load.return_value = _noop_writer
+
+    other = MagicMock()
+    other.name = '.other'
+    other.value = 'other_pkg:writer'
+
+    with patch(
+        'pyvista.core.utilities.writer_registry.entry_points',
+        return_value=[wanted, other],
+    ):
+        handler = _reg_mod._get_ext_handler('.wanted')
+
+    assert handler is _noop_writer
+    wanted.load.assert_called_once()
+    other.load.assert_not_called()
+    assert '.other' in _reg_mod._pending_ext_writers
+
+
+def test_list_custom_exts_includes_pending_without_loading():
+    """``_list_custom_exts`` reports pending extensions without loading."""
+    _reg_mod._entry_points_loaded = False
+    _reg_mod._pending_ext_writers.clear()
+
+    mock_ep = MagicMock()
+    mock_ep.name = '.discoverable'
+    mock_ep.value = 'discoverable_pkg:writer'
+
+    with patch('pyvista.core.utilities.writer_registry.entry_points', return_value=[mock_ep]):
+        exts = _reg_mod._list_custom_exts()
+
+    assert '.discoverable' in exts
+    mock_ep.load.assert_not_called()
+
+
+def test_registered_writers_forces_full_discovery():
+    """``registered_writers`` resolves every pending plugin so callers see all."""
+    _reg_mod._entry_points_loaded = False
+    _reg_mod._pending_ext_writers.clear()
+
+    mock_ep = MagicMock()
+    mock_ep.name = '.eager'
+    mock_ep.value = 'eager_pkg:writer'
+    mock_ep.load.return_value = _noop_writer
+
+    with patch('pyvista.core.utilities.writer_registry.entry_points', return_value=[mock_ep]):
+        records = pv.registered_writers()
+
+    matches = [r for r in records if r.extension == '.eager']
+    assert len(matches) == 1
+    assert matches[0].handler is _noop_writer
+    mock_ep.load.assert_called_once()

--- a/tests/namespace/test_utilities_namespace.py
+++ b/tests/namespace/test_utilities_namespace.py
@@ -18,6 +18,15 @@ with namespace_data.open() as f:
 def test_utilities_namespace(name):
     import pyvista.utilities as utilities  # noqa: PLR0402
 
+    # Force ``pyvista.utilities.__getattr__`` to fire by removing any
+    # attribute Python's import machinery may have cached on the parent
+    # module. Without this, a previous test that did
+    # ``from pyvista.utilities.<submodule> import ...`` leaves
+    # ``utilities.<name>`` populated, so ``hasattr`` resolves directly
+    # without triggering the deprecation warning. That made the test
+    # order-dependent.
+    utilities.__dict__.pop(name, None)
+
     with pytest.warns(PyVistaDeprecationWarning):
         assert hasattr(utilities, name)
 

--- a/tests/plotting/jupyter/test_custom_backends.py
+++ b/tests/plotting/jupyter/test_custom_backends.py
@@ -7,10 +7,13 @@ import importlib.util
 import sys
 from unittest.mock import MagicMock
 from unittest.mock import patch
+import warnings
 
 import pytest
 
 import pyvista as pv
+from pyvista import jupyter as jupyter_mod
+from pyvista.jupyter import _custom_backend_sources
 from pyvista.jupyter import _custom_backends
 from pyvista.jupyter import _get_custom_backend_handler
 from pyvista.jupyter import _resolve_backend
@@ -39,13 +42,22 @@ def _block_trame_import():
 def _clean_custom_backends():
     """Remove any custom backends registered during tests."""
     original = _custom_backends.copy()
+    original_sources = _custom_backend_sources.copy()
+    original_loaded = jupyter_mod._entry_points_loaded
     yield
     _custom_backends.clear()
     _custom_backends.update(original)
+    _custom_backend_sources.clear()
+    _custom_backend_sources.update(original_sources)
+    jupyter_mod._entry_points_loaded = original_loaded
 
 
 def _mock_handler(plotter, **kwargs):
     return {'plotter': plotter, **kwargs}
+
+
+def _replacement_handler(_plotter, **_kwargs):
+    return {'replaced': True}
 
 
 @skip_no_ipython
@@ -66,6 +78,86 @@ def test_register_case_insensitive():
 def test_register_builtin_collision(name):
     with pytest.raises(ValueError, match='collides with built-in backend'):
         register_jupyter_backend(name, _mock_handler)
+
+
+@skip_no_ipython
+def test_register_builtin_override_allowed():
+    register_jupyter_backend('static', _mock_handler, override=True)
+    assert _get_custom_backend_handler('static') is _mock_handler
+
+
+@skip_no_ipython
+def test_register_custom_collision_warns_and_replaces():
+    register_jupyter_backend('mycollide', _mock_handler)
+    with pytest.warns(UserWarning, match='replaces an existing custom registration'):
+        register_jupyter_backend('mycollide', _replacement_handler)
+    assert _get_custom_backend_handler('mycollide') is _replacement_handler
+
+
+@skip_no_ipython
+def test_register_custom_collision_override_silent():
+    register_jupyter_backend('mycollide', _mock_handler)
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        register_jupyter_backend('mycollide', _replacement_handler, override=True)
+    assert _get_custom_backend_handler('mycollide') is _replacement_handler
+
+
+def test_registered_jupyter_backends_returns_record_with_source():
+    register_jupyter_backend('demo_backend', _mock_handler)
+    records = pv.registered_jupyter_backends()
+    matches = [r for r in records if r.name == 'demo_backend']
+    assert len(matches) == 1
+    record = matches[0]
+    assert record.handler is _mock_handler
+    assert record.source.endswith('_mock_handler')
+
+
+def test_registered_jupyter_backends_includes_entry_point_source():
+    jupyter_mod._entry_points_loaded = False
+
+    mock_ep = MagicMock()
+    mock_ep.name = 'discovered_backend'
+    mock_ep.value = 'package.module:backend_func'
+    mock_ep.load.return_value = _mock_handler
+
+    with patch('pyvista.jupyter.entry_points', return_value=[mock_ep]):
+        records = pv.registered_jupyter_backends()
+
+    matches = [r for r in records if r.name == 'discovered_backend']
+    assert len(matches) == 1
+    assert matches[0].source == 'package.module:backend_func'
+
+
+def test_entry_point_load_failure_warns_and_continues():
+    jupyter_mod._entry_points_loaded = False
+
+    broken = MagicMock()
+    broken.name = 'broken_backend'
+    broken.value = 'package:broken'
+    broken.load.side_effect = RuntimeError('broken plugin')
+
+    with (
+        patch('pyvista.jupyter.entry_points', return_value=[broken]),
+        pytest.warns(UserWarning, match='Failed to load pyvista.jupyter_backends entry point'),
+    ):
+        assert _get_custom_backend_handler('broken_backend') is None
+
+
+def test_entry_point_uses_renamed_group():
+    """Confirm the entry-point group name is ``pyvista.jupyter_backends``."""
+    jupyter_mod._entry_points_loaded = False
+
+    captured: dict[str, object] = {}
+
+    def fake_entry_points(*, group):
+        captured['group'] = group
+        return []
+
+    with patch('pyvista.jupyter.entry_points', side_effect=fake_entry_points):
+        jupyter_mod._ensure_entry_points()
+
+    assert captured['group'] == 'pyvista.jupyter_backends'
 
 
 @skip_no_ipython
@@ -113,7 +205,7 @@ def test_entry_point_discovery():
     mock_ep.load.return_value = _mock_handler
 
     with patch(
-        'importlib.metadata.entry_points',
+        'pyvista.jupyter.entry_points',
         return_value=[mock_ep],
     ):
         handler = _get_custom_backend_handler('discovered')

--- a/tests/plotting/test_interactor_style_registry.py
+++ b/tests/plotting/test_interactor_style_registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 from unittest.mock import patch
+import warnings
 
 import pytest
 
@@ -11,6 +12,14 @@ import pyvista as pv
 from pyvista import _vtk
 from pyvista.plotting import interactor_style_registry as _reg_mod
 from pyvista.plotting.interactor_style_registry import _get_interactor_style_handler
+
+
+@pytest.fixture(autouse=True)
+def _clean_interactor_styles():
+    """Restore the interactor style registry around every test."""
+    state = _reg_mod._save_registry_state()
+    yield
+    _reg_mod._restore_registry_state(state)
 
 
 def _mock_style_factory(_interactor):
@@ -31,6 +40,34 @@ def test_register_interactor_style_rejects_empty_name():
 def test_register_interactor_style_rejects_builtin_collision():
     with pytest.raises(ValueError, match='collides with a built-in interactor style'):
         pv.register_interactor_style('terrain_style', _mock_style_factory)
+
+
+def test_register_interactor_style_builtin_override_allowed():
+    pv.register_interactor_style('terrain_style', _mock_style_factory, override=True)
+    assert _get_interactor_style_handler('terrain_style') is _mock_style_factory
+
+
+def test_register_interactor_style_custom_collision_warns_and_replaces():
+    pv.register_interactor_style('mycollide', _mock_style_factory)
+
+    def replacement(_interactor):
+        return _vtk.vtkInteractorStyleTrackballCamera()
+
+    with pytest.warns(UserWarning, match='replaces an existing custom registration'):
+        pv.register_interactor_style('mycollide', replacement)
+    assert _get_interactor_style_handler('mycollide') is replacement
+
+
+def test_register_interactor_style_custom_collision_override_silent():
+    pv.register_interactor_style('mycollide', _mock_style_factory)
+
+    def replacement(_interactor):
+        return _vtk.vtkInteractorStyleTrackballCamera()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        pv.register_interactor_style('mycollide', replacement, override=True)
+    assert _get_interactor_style_handler('mycollide') is replacement
 
 
 def test_available_interactor_style_names_includes_builtins_and_custom():

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -89,7 +89,9 @@ def pytest_generate_tests(metafunc):
         class_map = {
             name: cls
             for name, cls in zip(class_names, class_types, strict=True)
-            if not name.startswith('_') and not issubclass(cls, tuple(SKIP_SUBCLASS))
+            if not name.startswith('_')
+            and not issubclass(cls, tuple(SKIP_SUBCLASS))
+            and not getattr(cls, '_is_protocol', False)
         }
         metafunc.parametrize('pyvista_class', list(class_map.values()), ids=list(class_map.keys()))
 


### PR DESCRIPTION
## Summary

I've pushed quite a few new plugin registries recently: dataset accessors, readers, writers, interactor styles, jupyter backends. As I was implementing these I was figuring out what worked, what didn't and drifted in a few areas: collision behavior, source attribution, naming, and import semantics. 

This PR aligns them and fixes a performance regression where any first call to `pv.save()` or `pv.read()` was eagerly importing every installed plugin in its group, even for built-in formats.

## Details

### Registry consistency

Unified the collision philosophy across all five registries: custom-vs-custom name collisions emit a `UserWarning` via `warn_external` and replace (last wins); custom-vs-builtin collisions raise `ValueError` unless `override=True` is passed; failed entry-point plugin imports warn and skip the plugin without re-raising.

Added source attribution to the reader, writer, interactor style, and jupyter registries (matching the accessor registry). Each registration now records the originating `module.qualname` for explicit calls or the entry-point `value` for plugin-discovered ones. New public introspection: `pv.registered_readers()`, `pv.registered_writers()`, `pv.registered_jupyter_backends()`, each returning a `NamedTuple` with `name` / `extension`, `handler`, and `source`.

Renamed the Jupyter entry-point group from `pyvista.jupyter.backends` to `pyvista.jupyter_backends` to match the `pyvista.<plural>` convention used by the other four registries. Renamed `_discover_entry_points` to `_ensure_entry_points` for the same reason. Failed plugin imports in the Jupyter integration now warn instead of silently suppressing exceptions.

Extracted the four-way-duplicated `_handler_source` helper into `pyvista/core/utilities/_registry_helpers.py`.

### Read/write fast path

The reader and writer registries now defer plugin module imports per-extension. `_ensure_entry_points` scans entry-point metadata only and populates `_pending_ext_readers` / `_pending_ext_writers`. The plugin module is only imported when its specific extension is actually requested via `_get_ext_handler`.

Concrete impact with `pyvista_zstd` installed in the dev environment: first `pv.Sphere().save('foo.vtp')` dropped from 872ms to 19ms because no plugin is loaded for built-in VTK extensions. Plugin paths still work as before: `_get_ext_handler('.pv')` imports `pyvista_zstd` and registers the handler on first request.

`registered_readers()` and `registered_writers()` intentionally force full discovery (the user is asking for the full picture). `_list_custom_exts()` reports pending extensions in error messages without loading them, so dispatch errors still list every supported format.

### Tab completion for accessors

`DataObject.__dir__` now includes pending entry-point accessor names. IPython, Jupyter, and the REPL surface plugin accessors like `pyvista_tui`'s `tui` in tab completion without paying the plugin import cost. Once accessed, the descriptor attaches via the normal class-dict path and continues to appear in `dir`. Static analyzers (pyright, mypy) still need plugin-side `.pyi` stubs for static suggestions, matching how `pandas-stubs` handles its own accessors.

### Test isolation

Several tests were order-dependent because plugin packages installed in the dev environment register at import time. Fixed:

- `test_initial_module_state` in `test_writer_registry.py` now loads a fresh module copy.
- `test_n_faces` and `test_opt_in_n_faces_strict` consume the existing `default_n_faces` fixture so `_USE_STRICT_N_FACES` is reset between runs.
- `test_save_bad_extension` no longer hardcodes the writer extension list, since plugins extend it.
- `test_point_data_assignment_does_not_leak_vtk_weak_reference` compares `vtkWeakReference` counts before and after the operation rather than asserting an absolute zero.
- `test_utilities_namespace` pops cached submodules so each parametrize case forces `__getattr__` to fire the deprecation warning.

Verified clean across 10 different `--randomly-seed` values across the affected test paths.