### PR TITLE
Mark point-label image regression tests as flaky

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,10 @@ faulthandler.enable()
 
 
 def flaky_test(
-    test_function=None, *, times: int = 3, exceptions: tuple[Exception, ...] = (AssertionError,)
+    test_function=None,
+    *,
+    times: int = 3,
+    exceptions: tuple[type[Exception], ...] = (AssertionError,),
 ):
     """Decorator for re-trying flaky tests.
 
@@ -71,10 +74,11 @@ def flaky_test(
     times : int, default: 3
         Number of times to try to test.
 
-    exceptions : tuple[Exception, ...], default: (AssertionError,)
-        Exceptions which will cause the test to be re-tried. By default, tests are only
-        retried for assertion errors. Customize this to retry for other exceptions
-        depending on the cause(s) of the flaky test, e.g. `(ValueError, TypeError)`.
+    exceptions : tuple[type[Exception], ...], default: (AssertionError,)
+        Exception types which will cause the test to be re-tried. By default, tests
+        are only retried for assertion errors. Customize this to retry for other
+        exceptions depending on the cause(s) of the flaky test, e.g.
+        ``(ValueError, TypeError)``.
 
     """
     if test_function is None:

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -24,6 +24,7 @@ import numpy as np
 from PIL import Image
 import pytest
 from pytest_cases import parametrize
+from pytest_pyvista.pytest_pyvista import RegressionError
 
 import pyvista as pv
 from pyvista import demos
@@ -42,6 +43,7 @@ from pyvista.plotting.opts import PointSpriteShape
 from pyvista.plotting.plotter import SUPPORTED_FORMATS
 from pyvista.plotting.texture import numpy_to_texture
 from pyvista.plotting.utilities import algorithms
+from tests.conftest import flaky_test
 from tests.core.test_imagedata_filters import labeled_image  # noqa: F401
 from tests.examples.test_cell_examples import cell_example_functions
 from tests.plotting.conftest import AlgorithmExecutionTracker
@@ -1178,6 +1180,7 @@ def test_isometric_view_interactive(sphere):
     assert plotter_iso.camera_position != cpos_old
 
 
+@flaky_test(exceptions=(RegressionError,))
 def test_add_point_labels():
     pl = pv.Plotter()
 
@@ -1199,6 +1202,7 @@ def test_add_point_labels():
     pl.show()
 
 
+@flaky_test(exceptions=(RegressionError,))
 @pytest.mark.parametrize('always_visible', [False, True])
 def test_add_point_labels_always_visible(always_visible):
     # just make sure it runs without exception
@@ -1211,6 +1215,7 @@ def test_add_point_labels_always_visible(always_visible):
     pl.show()
 
 
+@flaky_test(exceptions=(RegressionError,))
 @pytest.mark.parametrize('shape', [None, 'rect', 'rounded_rect'])
 @pytest.mark.usefixtures('verify_image_cache')
 def test_add_point_labels_shape(shape):
@@ -1219,6 +1224,7 @@ def test_add_point_labels_shape(shape):
     pl.show()
 
 
+@flaky_test(exceptions=(RegressionError,))
 @pytest.mark.parametrize('justification_horizontal', ['left', 'center', 'right'])
 @pytest.mark.parametrize('justification_vertical', ['bottom', 'center', 'top'])
 def test_add_point_labels_justification(justification_horizontal, justification_vertical):
@@ -4145,6 +4151,7 @@ def test_remove_vertices_actor(sphere):
     pl.show()
 
 
+@flaky_test(exceptions=(RegressionError,))
 @pytest.mark.skip_windows
 def test_add_point_scalar_labels_fmt(verify_image_cache):
     # parallel on GitHub hosted sometimes has high image error
@@ -4166,6 +4173,7 @@ def test_plot_individual_cell(hexbeam):
     hexbeam.get_cell(0).plot(color='b')
 
 
+@flaky_test(exceptions=(RegressionError,))
 def test_add_point_scalar_labels_list():
     pl = pv.Plotter()
 
@@ -4228,6 +4236,7 @@ def test_algorithm_add_points():
     pl.show()
 
 
+@flaky_test(exceptions=(RegressionError,))
 def test_algorithm_add_point_labels():
     algo = pv.ConeSource()
     elev = _vtk.vtkElevationFilter()
@@ -5849,6 +5858,7 @@ def test_clip_box_crinkle(as_multiblock):
     pl.show()
 
 
+@flaky_test(exceptions=(RegressionError,))
 def test_box():
     box = pv.Box(level=0)
     box['cell_data'] = np.arange(box.n_cells)


### PR DESCRIPTION
## Summary

`test_box` (and other tests that render point labels) intermittently fail image regression on CI with errors well above the 500-pixel threshold (e.g. 1689 on a recent main run). The label rendering — particularly the gray label-shape backgrounds with numeric text — is sensitive to sub-pixel font positioning and produces nondeterministic frames.

This PR marks the 8 point-label rendering tests in `tests/plotting/test_plotting.py` with `@flaky_test(exceptions=(RegressionError,))` so a transient regression failure is retried up to 3 times before the test is marked as failed:

- `test_add_point_labels`
- `test_add_point_labels_always_visible`
- `test_add_point_labels_shape`
- `test_add_point_labels_justification`
- `test_add_point_scalar_labels_fmt`
- `test_add_point_scalar_labels_list`
- `test_algorithm_add_point_labels`
- `test_box`

Also fixes the `flaky_test` parameter annotation in `tests/conftest.py` from `tuple[Exception, ...]` to `tuple[type[Exception], ...]` — the decorator takes exception classes, not instances.