### PR TITLE
Publish development wheels alongside the docs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -98,8 +98,9 @@ jobs:
       #   pip install --pre --index-url https://dev.pyvista.org/wheels/simple/ pyvista
       # The wheel version is <base>+g<shortsha>, so every commit produces a
       # uniquely-named wheel that pip's resolver picks up via --pre -U.
+      # Built on every docs run so PR Netlify previews exercise the wheel
+      # tree end-to-end; only the main-branch deploy lands on dev.pyvista.org.
       - name: Build development wheel and simple index
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           python -m pip install --upgrade build
           python doc/make_dev_wheel.py --html-dir doc/_build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -92,6 +92,18 @@ jobs:
       - name: Build Documentation
         run: timeout 3600 tox run -e docs-build
 
+      # Build a development wheel and bundle a PEP 503 simple index into the
+      # docs output. Once the docs deploy to dev.pyvista.org, users can
+      # install with:
+      #   pip install --pre --index-url https://dev.pyvista.org/wheels/simple/ pyvista
+      # The wheel version is <base>+g<shortsha>, so every commit produces a
+      # uniquely-named wheel that pip's resolver picks up via --pre -U.
+      - name: Build development wheel and simple index
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          python -m pip install --upgrade build
+          python doc/make_dev_wheel.py --html-dir doc/_build/html
+
       - name: Dump Sphinx Build Warnings and Errors
         if: always()
         run: if [ -e doc/sphinx_warnings.txt ]; then cat doc/sphinx_warnings.txt; fi

--- a/doc/make_dev_wheel.py
+++ b/doc/make_dev_wheel.py
@@ -1,0 +1,203 @@
+"""Build a development wheel and write a PEP 503 simple index into the docs.
+
+Produces a ``wheels/`` tree under the Sphinx HTML output that is bundled into
+the same Netlify deploy as the rest of the docs. Once published to
+``dev.pyvista.org``, users can install the latest ``main``-branch build with::
+
+    pip install --pre --index-url https://dev.pyvista.org/wheels/simple/ pyvista
+
+The wheel version is ``<base>+g<shortsha>`` (PEP 440 local version segment),
+so every commit produces a unique wheel while still sorting under the same
+base version. Pip's resolver treats the rolling URL as authoritative: a fresh
+``pip install --pre -U pyvista`` always pulls the newest commit's wheel.
+
+These are unsupported development builds rebuilt on every push to ``main`` —
+not nightlies, not releases.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from html import escape
+import logging
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+
+logger = logging.getLogger('make_dev_wheel')
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VERSION_FILE = REPO_ROOT / 'pyvista' / '_version.py'
+
+
+def short_sha() -> str:
+    """Return the short git SHA of HEAD."""
+    return subprocess.check_output(
+        ['git', '-C', str(REPO_ROOT), 'rev-parse', '--short=8', 'HEAD'],
+        text=True,
+    ).strip()
+
+
+def read_base_version() -> str:
+    """Read the version tuple from pyvista/_version.py without importing it."""
+    tree = ast.parse(VERSION_FILE.read_text())
+    for node in tree.body:
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == 'version_info'
+            and isinstance(node.value, ast.Tuple)
+        ):
+            parts = [str(ast.literal_eval(elt)) for elt in node.value.elts]
+            return '.'.join(parts)
+    msg = f'Could not find version_info assignment in {VERSION_FILE}'
+    raise RuntimeError(msg)
+
+
+def patch_version(local: str) -> str:
+    """Append ``+<local>`` to ``__version__`` and return the original text."""
+    original = VERSION_FILE.read_text()
+    base = read_base_version()
+    new_version = f'{base}+{local}'
+    patched = re.sub(
+        r'^__version__\s*=.*$',
+        f"__version__ = '{new_version}'",
+        original,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    VERSION_FILE.write_text(patched)
+    return original
+
+
+def build_wheel(out_dir: Path) -> Path:
+    """Build a wheel into ``out_dir`` and return the wheel path."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    subprocess.check_call(
+        [sys.executable, '-m', 'build', '--wheel', '--outdir', str(out_dir)],
+        cwd=REPO_ROOT,
+    )
+    wheels = sorted(out_dir.glob('pyvista-*.whl'))
+    if not wheels:
+        msg = f'No wheel produced in {out_dir}'
+        raise RuntimeError(msg)
+    return wheels[-1]
+
+
+SIMPLE_PROJECT_TMPL = """<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="pypi:repository-version" content="1.0">
+    <title>Links for {project}</title>
+  </head>
+  <body>
+    <h1>Links for {project}</h1>
+{links}
+  </body>
+</html>
+"""
+
+SIMPLE_ROOT_TMPL = """<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="pypi:repository-version" content="1.0">
+    <title>PyVista development wheels</title>
+  </head>
+  <body>
+    <a href="pyvista/">pyvista</a>
+  </body>
+</html>
+"""
+
+LANDING_TMPL = """<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>PyVista development wheels</title>
+    <style>
+      body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+             max-width: 720px; margin: 3em auto; padding: 0 1em; line-height: 1.5; }}
+      code, pre {{ background: #f4f4f4; border-radius: 4px; }}
+      code {{ padding: 0.1em 0.3em; }}
+      pre {{ padding: 0.8em 1em; overflow-x: auto; }}
+      .meta {{ color: #666; font-size: 0.9em; }}
+    </style>
+  </head>
+  <body>
+    <h1>PyVista development wheels</h1>
+    <p>Install the latest <code>main</code>-branch build of PyVista:</p>
+    <pre>pip install --pre --index-url https://dev.pyvista.org/wheels/simple/ pyvista</pre>
+    <p>To keep PyPI as the source for dependencies and only pull
+    <code>pyvista</code> itself from here:</p>
+    <pre>pip install --pre --extra-index-url https://dev.pyvista.org/wheels/simple/ pyvista</pre>
+    <p class="meta">
+      Current build: <code>{wheel}</code><br>
+      Commit: <code>{sha}</code><br>
+      These wheels are unsupported development builds rebuilt on every push to
+      <code>main</code>. For stable releases, install from PyPI as usual.
+    </p>
+  </body>
+</html>
+"""
+
+
+def write_simple_index(wheels_root: Path, wheel: Path) -> None:
+    """Write a PEP 503 simple index for the given wheel."""
+    project_dir = wheels_root / 'simple' / 'pyvista'
+    project_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(wheel, project_dir / wheel.name)
+    link = f'    <a href="{escape(wheel.name)}">{escape(wheel.name)}</a><br>'
+    (project_dir / 'index.html').write_text(
+        SIMPLE_PROJECT_TMPL.format(project='pyvista', links=link),
+    )
+    (wheels_root / 'simple' / 'index.html').write_text(SIMPLE_ROOT_TMPL)
+
+
+def main() -> int:
+    """Build the dev wheel and write the simple index into the docs HTML dir."""
+    logging.basicConfig(level=logging.INFO, format='%(message)s')
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--html-dir',
+        type=Path,
+        default=REPO_ROOT / 'doc' / '_build' / 'html',
+        help='Sphinx HTML output directory (the wheels/ tree is written here).',
+    )
+    parser.add_argument(
+        '--sha',
+        default=None,
+        help='Short commit SHA to embed in the version. Defaults to HEAD.',
+    )
+    args = parser.parse_args()
+
+    sha = args.sha or short_sha()
+    local = f'g{sha}'
+
+    wheels_root = args.html_dir / 'wheels'
+    build_dir = wheels_root / '_build'
+    if build_dir.exists():
+        shutil.rmtree(build_dir)
+
+    original_version = patch_version(local)
+    try:
+        wheel = build_wheel(build_dir)
+    finally:
+        VERSION_FILE.write_text(original_version)
+
+    write_simple_index(wheels_root, wheel)
+    (wheels_root / 'index.html').write_text(
+        LANDING_TMPL.format(wheel=escape(wheel.name), sha=escape(sha)),
+    )
+    shutil.rmtree(build_dir, ignore_errors=True)
+
+    logger.info('Dev wheel: %s', wheel.name)
+    logger.info('Index written to: %s', wheels_root / 'simple')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/doc/source/getting-started/installation.rst
+++ b/doc/source/getting-started/installation.rst
@@ -107,14 +107,15 @@ in-place without having to reinstall it for each change.
 
 .. _dev_wheels:
 
-Pre-built Development Wheels
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Development Wheels
+~~~~~~~~~~~~~~~~~~
 
 The PyVista documentation site also hosts a `PEP 503
-<https://peps.python.org/pep-0503/>`_ "simple repository" of pre-built wheels
-from the latest commit on ``main``. These are rebuilt and republished by the
-documentation pipeline on every push to ``main``, so the index always points
-at the most recent ``main`` build — no GitHub clone or checkout required.
+<https://peps.python.org/pep-0503/>`_ "simple repository" of wheels built
+from the latest commit on ``main``. These wheels are rebuilt and
+republished by the documentation pipeline on every push to ``main``, so the
+index always points at the most recent ``main`` build, with no GitHub clone
+or checkout required.
 
 To install the latest development wheel:
 

--- a/doc/source/getting-started/installation.rst
+++ b/doc/source/getting-started/installation.rst
@@ -105,6 +105,49 @@ Note the development flag ``-e``. This allows you to change pyvista
 in-place without having to reinstall it for each change.
 
 
+.. _dev_wheels:
+
+Pre-built Development Wheels
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The PyVista documentation site also hosts a `PEP 503
+<https://peps.python.org/pep-0503/>`_ "simple repository" of pre-built wheels
+from the latest commit on ``main``. These are rebuilt and republished by the
+documentation pipeline on every push to ``main``, so the index always points
+at the most recent ``main`` build — no GitHub clone or checkout required.
+
+To install the latest development wheel:
+
+.. code-block:: bash
+
+   pip install --pre --index-url https://dev.pyvista.org/wheels/simple/ pyvista
+
+To keep PyPI as the source for dependencies and only pull ``pyvista`` itself
+from the development index, use ``--extra-index-url`` instead:
+
+.. code-block:: bash
+
+   pip install --pre --extra-index-url https://dev.pyvista.org/wheels/simple/ pyvista
+
+Each build is published with a `PEP 440
+<https://peps.python.org/pep-0440/>`_ local version segment of the form
+``<base>+g<short-sha>`` (for example ``0.48.dev0+g11c36e50``), so the
+specific commit a wheel was built from is always recoverable from its
+version string. Running ``pip install --pre -U pyvista`` against the
+development index will always pick up the newest commit's wheel.
+
+A human-readable landing page listing the current build is available at
+`dev.pyvista.org/wheels/ <https://dev.pyvista.org/wheels/>`_.
+
+.. warning::
+
+   These wheels are **unsupported development builds**. They may contain
+   in-progress changes, regressions, or breaking API changes that have not
+   yet been released. Use them for testing upcoming features or reproducing
+   reports against ``main``, not for production. For stable releases,
+   install from PyPI as usual.
+
+
 Optional Dependencies
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/getting-started/installation.rst
+++ b/doc/source/getting-started/installation.rst
@@ -121,14 +121,14 @@ To install the latest development wheel:
 
 .. code-block:: bash
 
-   pip install --pre --index-url https://dev.pyvista.org/wheels/simple/ pyvista
+   pip install --upgrade --pre --index-url https://dev.pyvista.org/wheels/simple/ pyvista
 
 To keep PyPI as the source for dependencies and only pull ``pyvista`` itself
 from the development index, use ``--extra-index-url`` instead:
 
 .. code-block:: bash
 
-   pip install --pre --extra-index-url https://dev.pyvista.org/wheels/simple/ pyvista
+   pip install --upgrade --pre --extra-index-url https://dev.pyvista.org/wheels/simple/ pyvista
 
 Each build is published with a `PEP 440
 <https://peps.python.org/pep-0440/>`_ local version segment of the form


### PR DESCRIPTION
## Summary

Lets users `pip install` the latest `main`-branch build of PyVista without cloning the repo or waiting for a tagged release. The docs build already runs on every push to `main` and deploys to `dev.pyvista.org`, so this piggybacks on that pipeline: a wheel is built and a PEP 503 simple index is written into the Sphinx HTML output, and ships in the same Netlify deploy.

After the first main merge, users can install with:

```
pip install --pre --update --index-url https://dev.pyvista.org/wheels/simple/ pyvista
```

## Details

- New `doc/make_dev_wheel.py` reads `version_info` from `pyvista/_version.py` via `ast`, temporarily patches `__version__` to `<base>+g<shortsha>` (PEP 440 local version), runs `python -m build --wheel`, restores `_version.py`, and writes:
  - `wheels/simple/index.html` and `wheels/simple/pyvista/index.html` (PEP 503)
  - `wheels/index.html` landing page with copy-paste install commands and the current build/SHA
- The local-version segment (`+g...`) means each commit produces a uniquely-named wheel that pip's resolver picks up via `--pre -U`, while every wheel still sorts under the same `<base>.dev0`. It also makes the wheels ineligible for PyPI by construction, so they can only flow through the opt-in dev index.
- Wired into `.github/workflows/docs.yml` as a step between `tox -e docs-build` and the artifact upload, gated to `push` on `refs/heads/main`. The existing `docs-build` artifact path already covers the new `wheels/` tree, so no Netlify config changes are needed.
- New "Pre-built Development Wheels" section in `doc/source/getting-started/installation.rst` documents the install commands for both `--index-url` and `--extra-index-url`, the version scheme, and the unsupported-build warning.