### PR TITLE
Do not inherit from `vtkVectorText` for `Text3DSource`

### DIFF
--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -16,7 +16,6 @@ from typing import cast
 from typing import get_args
 
 import numpy as np
-from vtkmodules.vtkRenderingFreeType import vtkVectorText
 
 import pyvista as pv
 from pyvista._deprecate_positional_args import _deprecate_positional_args
@@ -894,12 +893,16 @@ class MultipleLinesSource(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkLineSour
         return wrap(self.GetOutput())
 
 
-class Text3DSource(_NoNewAttrMixin, DisableVtkSnakeCase, vtkVectorText):
+class Text3DSource(_NoNewAttrMixin):
     """3D text from a string.
 
     Generate 3D text from a string with a specified width, height or depth.
 
     .. versionadded:: 0.43
+
+    .. versionchanged:: 0.48
+
+        This class no longer inherits from :vtk:`vtkVectorText`, and uses composition instead.
 
     Parameters
     ----------
@@ -947,8 +950,12 @@ class Text3DSource(_NoNewAttrMixin, DisableVtkSnakeCase, vtkVectorText):
         process_empty_string: bool = True,  # noqa: FBT001, FBT002
     ) -> None:
         """Initialize source."""
+        # Lazily import to defer importing from rendering module
+        from vtkmodules.vtkRenderingFreeType import vtkVectorText  # noqa: PLC0415
+
         super().__init__()
 
+        self._source = vtkVectorText()
         self._output = pv.PolyData()
 
         # Set params
@@ -975,11 +982,11 @@ class Text3DSource(_NoNewAttrMixin, DisableVtkSnakeCase, vtkVectorText):
     @property
     def string(self: Text3DSource) -> str:  # numpydoc ignore=RT01
         """Return or set the text string."""
-        return self.GetText()
+        return self._source.GetText()
 
     @string.setter
     def string(self: Text3DSource, string: str | None) -> None:
-        self.SetText('' if string is None else string)
+        self._source.SetText('' if string is None else string)
 
     @property
     def process_empty_string(self: Text3DSource) -> bool:  # numpydoc ignore=RT01
@@ -1075,13 +1082,13 @@ class Text3DSource(_NoNewAttrMixin, DisableVtkSnakeCase, vtkVectorText):
             is_2d = self.depth == 0 or (self.depth is None and self.height == 0)
             if is_empty_string or is_2d:
                 # Do not apply filters
-                self.Update()
-                out = self.GetOutput()
+                self._source.Update()
+                out = self._source.GetOutput()
             else:
                 # 3D case, apply filters
                 # Create output filters to make text 3D
                 extrude = _vtk.vtkLinearExtrusionFilter()
-                extrude.SetInputConnection(self.GetOutputPort())
+                extrude.SetInputConnection(self._source.GetOutputPort())
                 extrude.SetExtrusionTypeToNormalExtrusion()
                 extrude.SetVector(0, 0, 1)
 


### PR DESCRIPTION
### Overview

As part of https://github.com/pyvista/pyvista/pull/8602 I discovered that  `vtkmodules.vtkRenderingCore` and `vtkmodules.vtkRenderingFreeType` are both imported by `import pyvista`. But, we should not import from rendering modules for initial init. The cause is the import for `Text3DSource`, which inherits from `vtkVectorText`, a rendering class.

Removing `vtkVectorText` from initial import shaves off _several_ seconds, e.g. `import pyvista` is now 3-4 seconds faster.

This PR uses composition instead of inheritance to defer the import to `Text3DSource` initialization. The `vtkAlgorithm` inheritance of this source was never really used anyway, so nothing is really broken by the loss of inheritance.

No test is added here, but if #8602 is accepted, _that_ test can be updated, and these two lines can be removed:
https://github.com/pyvista/pyvista/blob/a41dbdfd163764cc044f773a263ae555482dd47a/tests/test_init.py#L52-L53