### PR TITLE
Use python3.12 for `shfmt` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,6 +114,8 @@ repos:
     rev: v3.13.1-1
     hooks:
       - id: shfmt
+        # Needs 3.12 else we get a wheel build error on macOS
+        language_version: python3.12
 
   - repo: https://github.com/mrtazz/checkmake.git
     rev: 0.2.2


### PR DESCRIPTION
### Overview

Running pre-commit on macOS with python > 3.12 yields the following error, so let's force using 3.12

```
[INFO] Installing environment for https://github.com/scop/pre-commit-shfmt.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/Users/dev/.cache/pre-commit/repouc7rqvdw/py_env-python3.14/bin/python', '-mpip', 'install', '.')
return code: 1
stdout:
    Processing ./.
      Installing build dependencies: started
      Installing build dependencies: finished with status 'done'
      Getting requirements to build wheel: started
      Getting requirements to build wheel: finished with status 'done'
      Installing backend dependencies: started
      Installing backend dependencies: finished with status 'done'
      Preparing metadata (pyproject.toml): started
      Preparing metadata (pyproject.toml): finished with status 'done'
    Building wheels for collected packages: shfmt_py
      Building wheel for shfmt_py (pyproject.toml): started
      Building wheel for shfmt_py (pyproject.toml): finished with status 'error'
    Failed to build shfmt_py
stderr:
      error: subprocess-exited-with-error
      
      × Building wheel for shfmt_py (pyproject.toml) did not run successfully.
      │ exit code: 1
      ╰─> [7 lines of output]
          /private/var/folders/2v/bv4k0q852z7dv3qlx1zwf2h80000gn/T/pip-build-env-ht2s6hkx/overlay/lib/python3.14/site-packages/setuptools/_vendor/wheel/bdist_wheel.py:4: FutureWarning: The 'wheel' package is no longer the canonical location of the 'bdist_wheel' command, and will be removed in a future release. Please update to setuptools v70.1 or later which contains an integrated version of this command.
            warn(
          running bdist_wheel
          running build
          running setuptools_download
          => downloading shfmt...
          error: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1077)>
          [end of output]
      
      note: This error originates from a subprocess, and is likely not a problem with pip.
      ERROR: Failed building wheel for shfmt_py
    error: failed-wheel-build-for-install
    
    × Failed to build installable wheels for some pyproject.toml based projects
    ╰─> shfmt_py
```