### PR TITLE
Release v0.48

### DIFF
--- a/pyvista/_version.py
+++ b/pyvista/_version.py
@@ -16,7 +16,7 @@ Denotes the first release candidate.
 # major, minor, patch
 from __future__ import annotations
 
-version_info = 0, 48, 'dev0'
+version_info = 0, 49, 'dev0'
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -583,12 +583,6 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
     :attr:`~pyvista.CellType.VERTEX` to create a point cloud where :attr:`n_verts` equals
     :attr:`~pyvista.DataSet.n_points`.
 
-    .. deprecated:: 0.44.0
-       The parameters ``n_faces``, ``n_lines``, ``n_strips``, and
-       ``n_verts`` are deprecated and no longer used. They were
-       previously used to speed up the construction of the corresponding
-       cell arrays but no longer provide any benefit.
-
     Parameters
     ----------
     var_inp : :vtk:`vtkPolyData`, str, sequence, optional
@@ -616,9 +610,6 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
         represented as ``[3, 10, 11, 12, 4, 20, 21, 22, 23]``.  This
         lets you have an arbitrary number of points per face.
 
-    n_faces : int, optional
-        Deprecated. Not used.
-
     lines : CellArrayLike, optional
         Connectivity of :attr:`lines`. Like ``faces``, this can be either a padded
         connectivity array or an explicit cell array object. The padded
@@ -626,9 +617,6 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
         a line segment.  For example, the two line segments ``[0, 1]``
         and ``[1, 2, 3, 4]`` will be represented as
         ``[2, 0, 1, 4, 1, 2, 3, 4]``.
-
-    n_lines : int, optional
-        Deprecated. Not used.
 
     strips : CellArrayLike optional
         Connectivity of triangle :attr:`strips`. Triangle strips require an
@@ -643,9 +631,6 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
         point indices ``[0, 1, 2, 3, 6, 7, 4, 5, 0, 1]`` requires
         padding of ``10`` and should be input as
         ``[10, 0, 1, 2, 3, 6, 7, 4, 5, 0, 1]``.
-
-    n_strips : int, optional
-        Deprecated. Not used.
 
     deep : bool, optional
         Whether to copy the inputs, or to create a mesh from them
@@ -672,9 +657,6 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
         example, ``[1, 0, 1, 1, 1, 2]`` indicates three vertex cells
         each with one point, and ``[2, 0, 1, 2, 2, 3]`` indicates two
         polyvertex cells each with two points.
-
-    n_verts : int, optional
-        Deprecated. Not used.
 
     validate : bool | MeshValidationFields | sequence[MeshValidationFields], default: False
         Validate the mesh using :meth:`~pyvista.DataObjectFilters.validate_mesh` after
@@ -808,16 +790,12 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
         self,
         var_inp: _vtk.vtkPolyData | str | Path | MatrixLike[float] | None = None,
         faces: CellArrayLike | None = None,
-        n_faces: int | None = None,
         lines: CellArrayLike | None = None,
-        n_lines: int | None = None,
         strips: CellArrayLike | None = None,
-        n_strips: int | None = None,
         deep: bool = False,  # noqa: FBT001, FBT002
         force_ext: str | None = None,
         force_float: bool = True,  # noqa: FBT001, FBT002
         verts: CellArrayLike | None = None,
-        n_verts: int | None = None,
         *,
         validate: bool | _NestedMeshValidationFields = False,
     ) -> None:
@@ -830,7 +808,7 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
             return
 
         # filename
-        opt_kwarg = ['faces', 'n_faces', 'lines', 'n_lines']
+        opt_kwarg = ['faces', 'lines']
         if isinstance(var_inp, (str, Path)):
             for kwarg in opt_kwarg:
                 if local_parms[kwarg]:
@@ -895,17 +873,6 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
 
         if validate:
             self._validate_mesh(validate)
-
-        # deprecated 0.44.0, convert to error in 0.47.0, remove 0.48.0
-        for k, v in (  # type: ignore[assignment]
-            ('n_verts', n_verts),
-            ('n_strips', n_strips),
-            ('n_faces', n_faces),
-            ('n_lines', n_lines),
-        ):
-            if v is not None:
-                msg = f'PolyData constructor parameter `{k}` is deprecated and no longer used.'
-                raise TypeError(msg)
 
     def _post_file_load_processing(self) -> None:
         """Execute after loading a PolyData from file."""

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -1462,20 +1462,6 @@ def test_irregular_faces_mutable():
     _assert_irregular_faces_equal(mesh.irregular_faces, expected)
 
 
-@pytest.mark.parametrize('cells', ['faces', 'lines', 'strips', 'verts'])
-def test_n_faces_etc_deprecated(cells: str):
-    n_cells = 'n_' + cells
-    kwargs = {cells: [3, 0, 1, 2], n_cells: 1}  # e.g. specify faces and n_faces
-    with pytest.raises(
-        TypeError,
-        match=f'PolyData constructor parameter `{n_cells}` is deprecated and no longer used',
-    ):
-        _ = pv.PolyData(np.zeros((3, 3)), **kwargs)
-    if pv._version.version_info[:2] > (0, 48):
-        msg = f'Remove `PolyData` `{n_cells} constructor kwarg'
-        raise RuntimeError(msg)
-
-
 @pytest.mark.parametrize('inplace', [True, False])
 def test_merge_points(inplace):
     mesh = pv.Cylinder(resolution=4)


### PR DESCRIPTION
# Release v0.48.0

- [x] Bump dev version on main to `0.49.dev0` (this PR)
- [x] Tag `v0.48.0` and push the tag.
- [x]  Verify published on [PyPI](https://pypi.org/project/pyvista/) (deployment workflow requires approval)
- [x] Verify [docs](https://docs.pyvista.org/) have been updated
- [x] Update the [conda-forge feedstock](https://github.com/conda-forge/pyvista-feedstock).
- [x] Generate [release documentation](https://github.com/pyvista/pyvista/releases/tag/v0.48.0)

closes #8492

## Release Notes Draft

# PyVista 0.48: Built to Extend

PyVista 0.48 is a community release focused on extensibility. Third-party packages can now plug directly into PyVista without monkey-patching or forks. New registries cover readers, writers, themes, plotter components, dataset accessors, interactor styles, and notebook backends, all wired through standard Python entry points. If you maintain a downstream project that wraps PyVista, start here.

## Highlights

**Plugin registries.** `pv.read()` is now backed by a [pluggable reader registry](https://github.com/pyvista/pyvista/pull/8437), with a matching [writer registry](https://github.com/pyvista/pyvista/pull/8490) that adopts the new `pyvista-zstd` package as the first external writer. [Themes](https://github.com/pyvista/pyvista/pull/8568), [interactor styles](https://github.com/pyvista/pyvista/pull/8446), [notebook backends](https://github.com/pyvista/pyvista/pull/8389), [dataset accessors](https://github.com/pyvista/pyvista/pull/8594), and [plotter components](https://github.com/pyvista/pyvista/pull/8604) follow the same pattern. The plotter component work migrates `ScalarBars`, picking, and widgets onto the new architecture so downstream packages can swap in replacements.

**Bug fixes.** Shared meshes across subplots no longer mutate each other's [active scalars](https://github.com/pyvista/pyvista/pull/8472). Smooth shading is [ported to a proper VTK algorithm](https://github.com/pyvista/pyvista/pull/8498) so it composes with the rest of a pipeline. macOS users get a [fix for the zombie off-screen window](https://github.com/pyvista/pyvista/pull/8423). `pyvista_ndarray` no longer [leaks a vtkWeakReference](https://github.com/pyvista/pyvista/pull/8534) through `point_data.__setitem__`. Colormap resolution is now [deterministic](https://github.com/pyvista/pyvista/pull/8593), preferring matplotlib over third-party shadows.

**New rendering and I/O.** [Stereo rendering](https://github.com/pyvista/pyvista/pull/6743), [custom point sprites and max-intensity projection](https://github.com/pyvista/pyvista/pull/8459), [environment texture rotation with a background toggle](https://github.com/pyvista/pyvista/pull/8601), a [CalculiX `.frd` reader](https://github.com/pyvista/pyvista/pull/8255), [`force_opaque` plotting](https://github.com/pyvista/pyvista/pull/8408), and [DataFrame and Apache Arrow export](https://github.com/pyvista/pyvista/pull/8587) for mesh data.

**Notebook and CLI.** A [modernized HTML repr](https://github.com/pyvista/pyvista/pull/8443) and a [PNG repr for plotters](https://github.com/pyvista/pyvista/pull/8583) for cleaner Jupyter output. The CLI gains a [`validate` command](https://github.com/pyvista/pyvista/pull/8344) with [colorized reports](https://github.com/pyvista/pyvista/pull/8358) and [glob support for bulk file conversions](https://github.com/pyvista/pyvista/pull/8578).

**Performance.** [Array and filter optimizations](https://github.com/pyvista/pyvista/pull/8554), [`wrap()` overhead reductions](https://github.com/pyvista/pyvista/pull/8493), [VTK SMP tools helpers](https://github.com/pyvista/pyvista/pull/8487), and a [`remove_nan_cells`](https://github.com/pyvista/pyvista/pull/8504) helper.

**Mesh validation and cell types.** Expanded `validate_mesh` and `cell_validator`, new `CellType` properties, a `dimension_map`, Bezier and Lagrange examples, and `to_hexahedra` / `to_quads` for `ImageData` and `RectilinearGrid`.

Eight new contributors landed PRs this cycle. Thanks to @jcapriot, @Zetarcos, @3rav, @bryzgin, @saschabuehrle, @kuriankattukaren-dev, @T4mmi, and @Maxwell-Rosen for jumping in.

Full changelog: https://github.com/pyvista/pyvista/compare/v0.47.0...v0.48.0


<!-- Release notes generated using configuration in .github/release.yml at release/0.48 -->

## What's Changed
### Breaking Changes
* Use delimited color names by @user27182 in https://github.com/pyvista/pyvista/pull/8350
* Make mesh validation report body show error message by default by @user27182 in https://github.com/pyvista/pyvista/pull/8354
* Fix colormap determinism: prefer matplotlib over third-party shadows by @banesullivan in https://github.com/pyvista/pyvista/pull/8593
### New Features
* Augment `cell_validator` with additional checks by @user27182 in https://github.com/pyvista/pyvista/pull/8318
* Add `exclude_fields` option to `validate_mesh` by @user27182 in https://github.com/pyvista/pyvista/pull/8327
* Update paraview named colors by @user27182 in https://github.com/pyvista/pyvista/pull/8347
* Add `validate` command to PyVista CLI by @user27182 in https://github.com/pyvista/pyvista/pull/8344
* Add `report_body` keyword to `validate_mesh` by @user27182 in https://github.com/pyvista/pyvista/pull/8353
* Add type annotations for literal named colors by @user27182 in https://github.com/pyvista/pyvista/pull/8349
* Add `--report` option to `validate` CLI command by @user27182 in https://github.com/pyvista/pyvista/pull/8355
* Format and color output text from `validate` CLI by @user27182 in https://github.com/pyvista/pyvista/pull/8358
* Allow excluding fields from a subset of mesh validation fields by @user27182 in https://github.com/pyvista/pyvista/pull/8364
* Add `DataSet.bounding_sphere` property by @user27182 in https://github.com/pyvista/pyvista/pull/8385
* Add the ability to read CalculiX .frd files by @3rav in https://github.com/pyvista/pyvista/pull/8255
* Support registration of custom notebook backends by @banesullivan in https://github.com/pyvista/pyvista/pull/8389
* Add `CellType` properties by @user27182 in https://github.com/pyvista/pyvista/pull/8393
* Add `ConvexPointSet` cell type example by @user27182 in https://github.com/pyvista/pyvista/pull/8400
* Add `generate_cell_blocks` to generate mesh with arbitrary cell type(s) by @user27182 in https://github.com/pyvista/pyvista/pull/8404
* Add `force_opaque` argument to plotting methods by @edabor in https://github.com/pyvista/pyvista/pull/8408
* Modernize HTML repr for Jupyter notebooks by @banesullivan in https://github.com/pyvista/pyvista/pull/8443
* Add pluggable reader registry for pv.read() by @banesullivan in https://github.com/pyvista/pyvista/pull/8437
* Add interactor style registry and theme entry by @banesullivan in https://github.com/pyvista/pyvista/pull/8446
* Add `cell_validator` tolerance keywords by @user27182 in https://github.com/pyvista/pyvista/pull/8420
* Actor shader customizations for custom point sprites and max intensity projection by @banesullivan in https://github.com/pyvista/pyvista/pull/8459
* Add SMP tools helper by @banesullivan in https://github.com/pyvista/pyvista/pull/8487
* Add remove_nan_cells helper filter by @banesullivan in https://github.com/pyvista/pyvista/pull/8504
* Return a context manager with pv.enable_smp_tools() by @banesullivan in https://github.com/pyvista/pyvista/pull/8495
* Add writer registry and adopt pyvista-zstd by @banesullivan in https://github.com/pyvista/pyvista/pull/8490
* Add __str__ method to GPUInfo and update related tests by @tkoyama010 in https://github.com/pyvista/pyvista/pull/7420
* Add `CellType.dimension_map` class property by @banesullivan in https://github.com/pyvista/pyvista/pull/8496
* Add PNG repr to plotter by @banesullivan in https://github.com/pyvista/pyvista/pull/8583
* Filter out VTK methods/attributes in __dir__ by @banesullivan in https://github.com/pyvista/pyvista/pull/8584
* Add dataset accessor registry for third-party plugins by @banesullivan in https://github.com/pyvista/pyvista/pull/8594
* Add DataFrame and Arrow export for mesh data  by @banesullivan in https://github.com/pyvista/pyvista/pull/8587
* Add theme registry and entrypoints by @banesullivan in https://github.com/pyvista/pyvista/pull/8568
* Add `merge_points` and `cell_centers` options to `align_xyz` filter by @user27182 in https://github.com/pyvista/pyvista/pull/6542
* Support Stereo Rendering by @banesullivan in https://github.com/pyvista/pyvista/pull/6743
* Support glob patterns in CLI for bulk file conversions by @banesullivan in https://github.com/pyvista/pyvista/pull/8578
* Add rotation and background toggle to set_environment_texture by @banesullivan in https://github.com/pyvista/pyvista/pull/8601
* Add plotter component registry and migrate ScalarBars, picking, and widgets by @banesullivan in https://github.com/pyvista/pyvista/pull/8604
### Bug fixes or behavior changes
* Require VTK 9.5 for distinct cell type check by @akaszynski in https://github.com/pyvista/pyvista/pull/8308
* Improve PointPickingElementHandler.get_point to preserve point data by @tkoyama010 in https://github.com/pyvista/pyvista/pull/8338
* Raise error for bad plane with `texture_map_to_plane` by @user27182 in https://github.com/pyvista/pyvista/pull/8339
* Remove `relpath` from `deprecate_positional_args` decorator by @jcapriot in https://github.com/pyvista/pyvista/pull/8345
* Use `getattr_static` instead of dynamic `getattr` lookup for checking new attributes by @user27182 in https://github.com/pyvista/pyvista/pull/8370
* Fix notch stress dataset by removing invalid and unused points by @user27182 in https://github.com/pyvista/pyvista/pull/8380
* Skip NSWindow for off-screen rendering and solve the zombie window on macOS  by @banesullivan in https://github.com/pyvista/pyvista/pull/8423
* Fix `CellType.vtk_class` for Bezier/Lagrange Triangle/Quadrilateral cell types by @user27182 in https://github.com/pyvista/pyvista/pull/8441
* Fixes for VTK 9.6.1 by @user27182 in https://github.com/pyvista/pyvista/pull/8440
* Add ability to update scalar bar title by @banesullivan in https://github.com/pyvista/pyvista/pull/8456
* Add line check to triangulate_contours by @akaszynski in https://github.com/pyvista/pyvista/pull/8469
* Fix shared mesh active scalars mutation in subplots by @banesullivan in https://github.com/pyvista/pyvista/pull/8472
* Fix issues with point shader and surface rendering by @banesullivan in https://github.com/pyvista/pyvista/pull/8500
* Fix `:force_static:` being silently ignored in docstring Examples by @banesullivan in https://github.com/pyvista/pyvista/pull/8505
* Bump pytest-pyvista for docs build image report by @banesullivan in https://github.com/pyvista/pyvista/pull/8503
* Fix bug with reference cycle by @larsoner in https://github.com/pyvista/pyvista/pull/8515
* Fix vtk-remote-view.set_widgets is missing Error by @ConnorNoddin in https://github.com/pyvista/pyvista/pull/7431
* Fix pyvista_ndarray from leaking a vtkWeakReference through point_data.__setitem__ by @banesullivan in https://github.com/pyvista/pyvista/pull/8534
* Remove timing assertion from test_contour_labels_strict_external by @banesullivan in https://github.com/pyvista/pyvista/pull/8536
* Port smooth shading to a VTK algorithm and add general-purpose algorithm utilities by @banesullivan in https://github.com/pyvista/pyvista/pull/8498
* Guard process_events() against X/EGL interactor mismatch by @banesullivan in https://github.com/pyvista/pyvista/pull/8542
* Array and filter optimizations by @banesullivan in https://github.com/pyvista/pyvista/pull/8554
* Make labels always visible for data model and point_neighbors_levels examples by @user27182 in https://github.com/pyvista/pyvista/pull/8551
* Expose `factor` parameter to the `add_mesh_slice` API by @Maxwell-Rosen in https://github.com/pyvista/pyvista/pull/8590
* Global config and address wrap() overhead by @banesullivan in https://github.com/pyvista/pyvista/pull/8493
* [hotfix] fix Jedi tab-completion crashes on DataSet types by @banesullivan in https://github.com/pyvista/pyvista/pull/8592
* Use linear interpolation with anti-aliasing when resampling environment texture by @user27182 in https://github.com/pyvista/pyvista/pull/7760
* Add `to_hexahedra` and `to_quads` methods for `ImageData` and `RectilinearGrid` by @user27182 in https://github.com/pyvista/pyvista/pull/8230
### Documentation
* Add Generative AI guidelines by @tkoyama010 in https://github.com/pyvista/pyvista/pull/8319
* Remove assertions from `mesh_validation` example by @user27182 in https://github.com/pyvista/pyvista/pull/8328
* Document `MeshValidationFields` type annotations for mesh validation by @user27182 in https://github.com/pyvista/pyvista/pull/8333
* Fix reference to `download_bird` in `resample` filter by @user27182 in https://github.com/pyvista/pyvista/pull/8348
* Update Contributor Covenant Code of Conduct to version 3.0 by @tkoyama010 in https://github.com/pyvista/pyvista/pull/8387
* Add missing Lagrange and Bezier cell examples by @user27182 in https://github.com/pyvista/pyvista/pull/8386
* docs: add examples to Axis.pen and Axis.grid_pen by @bryzgin in https://github.com/pyvista/pyvista/pull/8390
* Fix bullets formatting in `FRDReader` docs by @user27182 in https://github.com/pyvista/pyvista/pull/8394
* Remove redundant generation of PolyDataIOTable in docs build by @user27182 in https://github.com/pyvista/pyvista/pull/8399
* Make `CellType` badges link to new attributes by @user27182 in https://github.com/pyvista/pyvista/pull/8401
* DOC: Add CalculiX cgx custom colormap example to colormap.py by @3rav in https://github.com/pyvista/pyvista/pull/8402
* Fix plotter variable name in trame example by @user27182 in https://github.com/pyvista/pyvista/pull/8416
* Revert static rendering in documentation by @edabor in https://github.com/pyvista/pyvista/pull/8431
* Configure icon links to PyPI to the right of bar by @tkoyama010 in https://github.com/pyvista/pyvista/pull/6201
* Modernize Docker build with a single multi-stage Dockerfile by @banesullivan in https://github.com/pyvista/pyvista/pull/8524
* Forbid using `pltr` as `Plotter` variable name by @user27182 in https://github.com/pyvista/pyvista/pull/8539
* Remove future annotations from examples gallery by @banesullivan in https://github.com/pyvista/pyvista/pull/8538
* Rename pyvista/data repository by @banesullivan in https://github.com/pyvista/pyvista/pull/8573
* Document dataset licenses; add CC0 bust replacements for Nefertiti by @banesullivan in https://github.com/pyvista/pyvista/pull/8574
* Document licensing and attribution for `download_dicom_stack` by @banesullivan in https://github.com/pyvista/pyvista/pull/8572
* Increase docs coverage by @banesullivan in https://github.com/pyvista/pyvista/pull/8589
* Publish development wheels alongside the docs site by @banesullivan in https://github.com/pyvista/pyvista/pull/8599
* Automated PR: Update Local Intersphinx by @pyvista-bot-ci[bot] in https://github.com/pyvista/pyvista/pull/8612
* Remove broken link to pyivsta-wheels by @banesullivan in https://github.com/pyvista/pyvista/pull/8611
* Add documentation coverage for `plotting` module by @user27182 in https://github.com/pyvista/pyvista/pull/8619
* v0.48 deprecations by @banesullivan in https://github.com/pyvista/pyvista/pull/8617
* Add gallery examples for common PyVista APIs by @banesullivan in https://github.com/pyvista/pyvista/pull/8513
### Maintenance
* Add docstring test for windows and older python by @user27182 in https://github.com/pyvista/pyvista/pull/8307
* Add Python 3.14 classifier to pyproject.toml by @user27182 in https://github.com/pyvista/pyvista/pull/8316
* Do not load `download_biplane` in docstring on Windows by @user27182 in https://github.com/pyvista/pyvista/pull/8320
* Exclude `trame-vtk` 2.10.3 from deps by @edabor in https://github.com/pyvista/pyvista/pull/8322
* Sort `cell_validator` and `validate_mesh` fields alphabetically by @user27182 in https://github.com/pyvista/pyvista/pull/8324
* Upper pin `trame-vtk` by @edabor in https://github.com/pyvista/pyvista/pull/8325
* Update `trame-vtk` pin comment by @user27182 in https://github.com/pyvista/pyvista/pull/8331
* Add connectivity cmap test by @user27182 in https://github.com/pyvista/pyvista/pull/8356
* Bump the all-else group with 5 updates by @dependabot[bot] in https://github.com/pyvista/pyvista/pull/8363
* Update pytest-mypy-plugins requirement from <3.3.0 to <3.4.0 in the pytest group by @dependabot[bot] in https://github.com/pyvista/pyvista/pull/8361
* Bump the gha group with 3 updates by @dependabot[bot] in https://github.com/pyvista/pyvista/pull/8362
* Remove VTK error catcher from HDF reader by @user27182 in https://github.com/pyvista/pyvista/pull/8365
* Use a separate bullet for MultiBlock mesh nodes with mesh validation by @user27182 in https://github.com/pyvista/pyvista/pull/8366
* Bump lycheeverse/lychee-action from 2.7.0 to 2.8.0 in the gha group by @dependabot[bot] in https://github.com/pyvista/pyvista/pull/8374
* Use `vtkExtractCells` internally with `extract_cells` by @user27182 in https://github.com/pyvista/pyvista/pull/8371
* chore: update pre-commit hooks by @pre-commit-ci[bot] in https://github.com/pyvista/pyvista/pull/8375
* maint: upgrade ruff from v0.15.0 to v0.15.4 by @tkoyama010 in https://github.com/pyvista/pyvista/pull/8376
* Include named colormap type hints for `color_labels` filters by @user27182 in https://github.com/pyvista/pyvista/pull/8396
* Bump the gha group with 7 updates by @dependabot[bot] in https://github.com/pyvista/pyvista/pull/8411
* Bump the all-else group with 4 updates by @dependabot[bot] in https://github.com/pyvista/pyvista/pull/8412
* Bump the pytest group with 2 updates by @dependabot[bot] in https://github.com/pyvista/pyvista/pull/8410
* Bump the trame group with 2 updates by @dependabot[bot] in https://github.com/pyvista/pyvista/pull/8360
* Bump trame-vtk to 2.11.6 by @user27182 in https://github.com/pyvista/pyvista/pull/8417
* Pin VTK 9.5.2 job and limit VTK 9.6.1 by @banesullivan in https://github.com/pyvista/pyvista/pull/8429
* Bump pypandoc from 1.16.2 to 1.17 in the sphinx group by @dependabot[bot] in https://github.com/pyvista/pyvista/pull/8432
* Bump the all-else group with 2 updates by @dependabot[bot] in https://github.com/pyvista/pyvista/pull/8435
* Update pytest-cov requirement from <7.1.0 to <7.2.0 in the pytest group by @dependabot[bot] in https://github.com/pyvista/pyvista/pull/8433
* Bump nick-fields/retry from 3.0.2 to 4.0.0 in the gha group by @dependabot[bot] in https://github.com/pyvista/pyvista/pull/8434
* Initialize `ren_win = None` in `BasePlotter` by @user27182 in https://github.com/pyvista/pyvista/pull/8418
* Enable merge queue for PRs by @banesullivan in https://github.com/pyvista/pyvista/pull/8452
* Limit I18N Documentation Build to Releases by @banesullivan in https://github.com/pyvista/pyvista/pull/8454
* Remove GitHub stars from README by @banesullivan in https://github.com/pyvista/pyvista/pull/8457
* Regression image test report on CI by @banesullivan in https://github.com/pyvista/pyvista/pull/8451
* Remove select jobs from the merge queue by @banesullivan in https://github.com/pyvista/pyvista/pull/8458
* Skip docs build for unrelated changes by @banesullivan in https://github.com/pyvista/pyvista/pull/8455
* Raise error when getting regular faces but faces are irregular by @user27182 in https://github.com/pyvista/pyvista/pull/8463
* Replace PR comments with commit statuses for preview deployments by @banesullivan in https://github.com/pyvista/pyvista/pull/8465
* Fix CI skip conditions to work with required status checks by @banesullivan in https://github.com/pyvista/pyvista/pull/8466
* Lint rule: disallow bare vtk imports by @banesullivan in https://github.com/pyvista/pyvista/pull/8468
* chore: update pre-commit hooks by @pre-commit-ci[bot] in https://github.com/pyvista/pyvista/pull/8453
* Fix CI failures against NumPy nightly wheel by @banesullivan in https://github.com/pyvista/pyvista/pull/8470
* Add image regression report for doc tests by @banesullivan in https://github.com/pyvista/pyvista/pull/8476
* Reduce noise in image regression warnings by @banesullivan in https://github.com/pyvista/pyvista/pull/8471
* Move integration tests to cron job that raises an issue by @banesullivan in https://github.com/pyvista/pyvista/pull/8478
* Auto-detect Jupyter notebook backend instead of defaulting to trame by @banesullivan in https://github.com/pyvista/pyvista/pull/8481
* Configure Codecov to wait for all CI jobs by @banesullivan in https://github.com/pyvista/pyvista/pull/8482
* Fixes for latest VTK dev wheels (VTK 9.7) by @user27182 in https://github.com/pyvista/pyvista/pull/8405
* Use environments to manage deployments by @banesullivan in https://github.com/pyvista/pyvista/pull/8512
* Isolate netlify deployments to unblock forked PRs by @banesullivan in https://github.com/pyvista/pyvista/pull/8516
* Remove CI skips by @banesullivan in https://github.com/pyvista/pyvista/pull/8519
* chore: update pre-commit hooks, zizmor config, ignore uv.lock by @mwtoews in https://github.com/pyvista/pyvista/pull/8511
* Delete .github/workflows/auto-approve.yml by @banesullivan in https://github.com/pyvista/pyvista/pull/8518
* Add additional regression image for sphx_glr_openfoam_cooling_001_vtksz by @banesullivan in https://github.com/pyvista/pyvista/pull/8526
* Route VTK-dev coverage through central upload job by @banesullivan in https://github.com/pyvista/pyvista/pull/8514
* Update pyvista-zstd version constraints by @banesullivan in https://github.com/pyvista/pyvista/pull/8530
* Add explicit Linux CI job for Python 3.14 + latest stable VTK by @banesullivan in https://github.com/pyvista/pyvista/pull/8533
* Fix some testing failures that are hardware/env specific by @banesullivan in https://github.com/pyvista/pyvista/pull/8531
* Ignore numpy nightly warnings by @banesullivan in https://github.com/pyvista/pyvista/pull/8544
* Replace naming convention tests with pre-commit hooks and ruff rules by @banesullivan in https://github.com/pyvista/pyvista/pull/8543
* Update contributing for documentation image testing by @edabor in https://github.com/pyvista/pyvista/pull/8555
* Mark tinypages parallel test as flaky by @user27182 in https://github.com/pyvista/pyvista/pull/8559
* Inform users about installing `pyvista-zstd` when reading/saving `.pv` files by @user27182 in https://github.com/pyvista/pyvista/pull/8548
* Streamline local developer workflow by @banesullivan in https://github.com/pyvista/pyvista/pull/8502
* Remove update-pr-branch workflow in favor of merge queue by @tkoyama010 in https://github.com/pyvista/pyvista/pull/8563
* Update tox and CI base python to 3.14 by @user27182 in https://github.com/pyvista/pyvista/pull/8314
* Fix pyvistaqt and geovista integration tests by @banesullivan in https://github.com/pyvista/pyvista/pull/8570
* Disable codecov comments by @banesullivan in https://github.com/pyvista/pyvista/pull/8575
* Fix codecov status by @banesullivan in https://github.com/pyvista/pyvista/pull/8569
* Add browser interactivity test for interactive plots by @user27182 in https://github.com/pyvista/pyvista/pull/8444
* Fix docs preview deploy and align image report deploys by @banesullivan in https://github.com/pyvista/pyvista/pull/8591
* Align plugin registries and defer plugin imports until needed by @banesullivan in https://github.com/pyvista/pyvista/pull/8595
* Use `image_threshold` internally by `select_values` to improve performance by @user27182 in https://github.com/pyvista/pyvista/pull/7714
* Remove deprecated NumPy dtype warning from config by @user27182 in https://github.com/pyvista/pyvista/pull/8598
* Do not inherit from `vtkVectorText` for `Text3DSource` by @user27182 in https://github.com/pyvista/pyvista/pull/8605
* Bump the sphinx group with 2 updates by @dependabot[bot] in https://github.com/pyvista/pyvista/pull/8614
* Bump the gha group with 6 updates by @dependabot[bot] in https://github.com/pyvista/pyvista/pull/8615
* Add flaky test image for point labels with box test by @user27182 in https://github.com/pyvista/pyvista/pull/8618
* Bump `mypy` to 1.20.2 by @user27182 in https://github.com/pyvista/pyvista/pull/8620
* Bump trame-vtk from 2.11.7 to 2.11.8 in the trame group by @dependabot[bot] in https://github.com/pyvista/pyvista/pull/8613
* Bump the all-else group with 8 updates by @dependabot[bot] in https://github.com/pyvista/pyvista/pull/8616
* Cache lazily-loaded `pyvista` attributes for faster repeated access by @user27182 in https://github.com/pyvista/pyvista/pull/8607
* Lazily import all VTK classes in a common `pyvista._vtk.py` module by @user27182 in https://github.com/pyvista/pyvista/pull/8602

## New Contributors
* @jcapriot made their first contribution in https://github.com/pyvista/pyvista/pull/8345
* @Zetarcos made their first contribution in https://github.com/pyvista/pyvista/pull/8384
* @3rav made their first contribution in https://github.com/pyvista/pyvista/pull/8255
* @bryzgin made their first contribution in https://github.com/pyvista/pyvista/pull/8390
* @saschabuehrle made their first contribution in https://github.com/pyvista/pyvista/pull/8413
* @kuriankattukaren-dev made their first contribution in https://github.com/pyvista/pyvista/pull/8116
* @T4mmi made their first contribution in https://github.com/pyvista/pyvista/pull/8388
* @Maxwell-Rosen made their first contribution in https://github.com/pyvista/pyvista/pull/8590
* @pyvista-bot-ci[bot] made their first contribution in https://github.com/pyvista/pyvista/pull/8612

**Full Changelog**: https://github.com/pyvista/pyvista/compare/v0.47.0...v0.48.0