### PR TITLE
Fix dataset accessor when accessed from class first

### DIFF
--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -30,6 +30,7 @@ from .utilities.fileio import get_ext
 from .utilities.fileio import read
 from .utilities.fileio import save_pickle
 from .utilities.helpers import wrap
+from .utilities.misc import _DataObjectMeta
 from .utilities.misc import _NoNewAttrMixin
 from .utilities.misc import abstract_class
 from .utilities.writer_registry import _get_ext_handler as _get_writer_ext_handler
@@ -71,7 +72,12 @@ def _raise_unexpected_writer_kwargs(
 
 @promote_type(_vtk.vtkDataObject)
 @abstract_class
-class DataObject(_NoNewAttrMixin, DisableVtkSnakeCase, vtkPyVistaOverride):
+class DataObject(
+    _NoNewAttrMixin,
+    DisableVtkSnakeCase,
+    vtkPyVistaOverride,
+    metaclass=_DataObjectMeta,
+):
     """Methods common to all wrapped data objects.
 
     Parameters

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -443,6 +443,21 @@ class _AutoFreezeMeta(type):
         obj._no_new_attributes(cls)
         return obj
 
+    def __getattr__(cls, name: str) -> Any:
+        # Resolve ``pyvista.accessors`` entry-point plugins on class-level
+        # attribute access (e.g. ``pv.PolyData.manifold``). Instance access
+        # is handled by ``DataObject.__getattr__``; without this hook, class
+        # access bypasses lazy loading and raises AttributeError until the
+        # plugin happens to be imported some other way.
+        from pyvista.core.utilities.accessor_registry import (  # noqa: PLC0415
+            _resolve_pending_accessor,
+        )
+
+        if _resolve_pending_accessor(name):
+            return getattr(cls, name)
+        msg = f'type object {cls.__name__!r} has no attribute {name!r}'
+        raise AttributeError(msg)
+
 
 class _AutoFreezeABCMeta(_AutoFreezeMeta, ABCMeta):
     """Metaclass to combine automatic attribute freezing with ABC support."""

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -443,12 +443,21 @@ class _AutoFreezeMeta(type):
         obj._no_new_attributes(cls)
         return obj
 
+
+class _AutoFreezeABCMeta(_AutoFreezeMeta, ABCMeta):
+    """Metaclass to combine automatic attribute freezing with ABC support."""
+
+
+class _DataObjectMeta(_AutoFreezeABCMeta):
+    """Metaclass for ``DataObject`` that resolves accessor entry-points on class access.
+
+    Without this hook, class-level attribute access (e.g. ``pv.PolyData.manifold``)
+    bypasses lazy loading of ``pyvista.accessors`` entry-point plugins and raises
+    ``AttributeError`` until the plugin happens to be imported some other way.
+    Instance access is handled by ``DataObject.__getattr__``.
+    """
+
     def __getattr__(cls, name: str) -> Any:
-        # Resolve ``pyvista.accessors`` entry-point plugins on class-level
-        # attribute access (e.g. ``pv.PolyData.manifold``). Instance access
-        # is handled by ``DataObject.__getattr__``; without this hook, class
-        # access bypasses lazy loading and raises AttributeError until the
-        # plugin happens to be imported some other way.
         from pyvista.core.utilities.accessor_registry import (  # noqa: PLC0415
             _resolve_pending_accessor,
         )
@@ -457,10 +466,6 @@ class _AutoFreezeMeta(type):
             return getattr(cls, name)
         msg = f'type object {cls.__name__!r} has no attribute {name!r}'
         raise AttributeError(msg)
-
-
-class _AutoFreezeABCMeta(_AutoFreezeMeta, ABCMeta):
-    """Metaclass to combine automatic attribute freezing with ABC support."""
 
 
 def _hasattr_static(obj: Any, attr: str) -> bool:

--- a/tests/core/test_accessor_registry.py
+++ b/tests/core/test_accessor_registry.py
@@ -647,6 +647,55 @@ def test_attribute_access_triggers_plugin_load(monkeypatch):
         sys.modules.pop(plugin_name, None)
 
 
+def test_class_level_access_triggers_plugin_load(monkeypatch):
+    """Class-level access (e.g. ``pv.PolyData.<name>``) before any
+    instance access must also trigger the pending plugin import. Without
+    a metaclass ``__getattr__`` hook, class access bypasses the
+    instance-level resolution path and raises ``AttributeError``.
+    """
+    plugin_name = 'fake_ep_plugin_class_access'
+    fake_import = _fake_importer(
+        plugin_name,
+        'import pyvista as pv\n'
+        "@pv.register_dataset_accessor('class_demo', pv.PolyData)\n"
+        'class ClassDemoAccessor:\n'
+        '    def __init__(self, mesh):\n'
+        '        self._mesh = mesh\n',
+    )
+    ep = MagicMock()
+    ep.name = 'class_demo'
+    ep.value = plugin_name
+
+    _reset_entry_point_state(monkeypatch, [ep])
+    monkeypatch.setattr(
+        'pyvista.core.utilities.accessor_registry.import_module',
+        fake_import,
+    )
+
+    try:
+        # Class-level access first — the bug this protects against was
+        # that this raised AttributeError because the metaclass did not
+        # consult the entry-point registry.
+        accessor_cls = pv.PolyData.class_demo
+        assert accessor_cls.__name__ == 'ClassDemoAccessor'
+        # Instance access then returns an instance of that accessor.
+        assert isinstance(pv.Sphere().class_demo, accessor_cls)
+    finally:
+        with contextlib.suppress(ValueError):
+            pv.unregister_dataset_accessor('class_demo', pv.PolyData)
+        sys.modules.pop(plugin_name, None)
+
+
+def test_class_level_access_unknown_attribute_raises(monkeypatch):
+    """Class-level access to a name that is not a pending accessor must
+    still raise ``AttributeError`` rather than silently returning ``None``
+    or hanging on plugin resolution."""
+    _reset_entry_point_state(monkeypatch, [])
+
+    with pytest.raises(AttributeError, match='no attribute'):
+        _ = pv.PolyData.definitely_not_a_real_attribute
+
+
 def test_pending_plugin_only_imported_once(monkeypatch):
     """After a plugin loads, the pending entry is popped. Subsequent
     attribute accesses on the same name go through normal lookup and


### PR DESCRIPTION
Hotfix so that dataset accessors will load if trying to access from class-level first, for example:

```py
import pyvista as pv
mesh = pv.PolyData.manifold.from_manifold(...)
```