### PR TITLE
Fix dimension property for abstract cell types with older VTK

### DIFF
--- a/pyvista/core/celltype.py
+++ b/pyvista/core/celltype.py
@@ -14,6 +14,7 @@ from typing import get_args
 
 from pyvista import _vtk
 from pyvista.core._vtk_utilities import vtk_version_info
+from pyvista.core.errors import VTKVersionError
 
 _Dimension = Literal[0, 1, 2, 3]
 PLACEHOLDER = 'IMAGE-HASH-PLACEHOLDER'
@@ -932,7 +933,10 @@ class CellType(IntEnum, metaclass=_CellTypeMeta):
         )
 
         # Set cell type properties using vtkCellTypeUtilities
-        self._dimension = cast('_Dimension', _vtk.vtkCellTypeUtilities.GetDimension(value))
+        if self._vtk_class is None and vtk_version_info < (9, 4, 0):
+            self._dimension = -1  # Dimension is not supported for abstract classes for older VTK
+        else:
+            self._dimension = cast('_Dimension', _vtk.vtkCellTypeUtilities.GetDimension(value))
         self._is_linear = bool(_vtk.vtkCellTypeUtilities.IsLinear(value))
         if value == _vtk.VTK_HEXAGONAL_PRISM:
             # Need to fix https://gitlab.kitware.com/vtk/vtk/-/issues/19988#note_1786788
@@ -1059,6 +1063,9 @@ class CellType(IntEnum, metaclass=_CellTypeMeta):
         3
 
         """
+        if self._dimension == -1 and vtk_version_info < (9, 4, 0):
+            msg = f'dimension for cell type {self.name} requires VTK 9.4 or later'
+            raise VTKVersionError(msg)
         return self._dimension
 
     @property

--- a/pyvista/core/celltype.py
+++ b/pyvista/core/celltype.py
@@ -14,10 +14,34 @@ from typing import get_args
 
 from pyvista import _vtk
 from pyvista.core._vtk_utilities import vtk_version_info
-from pyvista.core.errors import VTKVersionError
 
 _Dimension = Literal[0, 1, 2, 3]
 PLACEHOLDER = 'IMAGE-HASH-PLACEHOLDER'
+
+# Canonical dimensions for abstract / placeholder cell types.
+# ``vtkCellTypeUtilities.GetDimension(value)`` returns ``0`` for these on
+# vtk<9.4 AND emits ``vtkGenericCell ERR| Unsupported cell type: N Setting to
+# vtkEmptyCell`` warnings via the ``vtkEmptyCell`` fallback. Using a hardcoded
+# table avoids the warnings and gives the correct dimension on every VTK
+# build. See https://github.com/pyvista/pyvista/issues/8634
+_ABSTRACT_DIMENSIONS: dict[int, _Dimension] = {
+    _vtk.VTK_PARAMETRIC_CURVE: 1,
+    _vtk.VTK_PARAMETRIC_SURFACE: 2,
+    _vtk.VTK_PARAMETRIC_TRI_SURFACE: 2,
+    _vtk.VTK_PARAMETRIC_QUAD_SURFACE: 2,
+    _vtk.VTK_PARAMETRIC_TETRA_REGION: 3,
+    _vtk.VTK_PARAMETRIC_HEX_REGION: 3,
+    _vtk.VTK_HIGHER_ORDER_EDGE: 1,
+    _vtk.VTK_HIGHER_ORDER_TRIANGLE: 2,
+    _vtk.VTK_HIGHER_ORDER_QUAD: 2,
+    _vtk.VTK_HIGHER_ORDER_POLYGON: 2,
+    _vtk.VTK_HIGHER_ORDER_TETRAHEDRON: 3,
+    _vtk.VTK_HIGHER_ORDER_WEDGE: 3,
+    _vtk.VTK_HIGHER_ORDER_PYRAMID: 3,
+    _vtk.VTK_HIGHER_ORDER_HEXAHEDRON: 3,
+    _vtk.VTK_LAGRANGE_PYRAMID: 3,
+    _vtk.VTK_BEZIER_PYRAMID: 3,
+}
 
 _GRID_TEMPLATE_NO_IMAGE = """
 .. grid:: 1
@@ -932,10 +956,14 @@ class CellType(IntEnum, metaclass=_CellTypeMeta):
             else getattr(_vtk, _vtk_class_name)
         )
 
-        # Set cell type properties using vtkCellTypeUtilities
-        if self._vtk_class is None and vtk_version_info < (9, 4, 0):
-            # Dimension is not supported for abstract classes for older VTK
-            self._dimension = -1  # type: ignore[assignment]
+        # Set cell type properties using vtkCellTypeUtilities. For abstract
+        # types whose value is in ``_ABSTRACT_DIMENSIONS`` we skip the call
+        # entirely (it returns 0 and emits warnings on vtk<9.4 because there
+        # is no concrete cell class). Unknown abstract types (e.g. anything
+        # vtk 9.7+ adds that we have not catalogued) still go through the
+        # utility.
+        if self._vtk_class is None and value in _ABSTRACT_DIMENSIONS:
+            self._dimension = _ABSTRACT_DIMENSIONS[value]
         else:
             self._dimension = cast('_Dimension', _vtk.vtkCellTypeUtilities.GetDimension(value))
         self._is_linear = bool(_vtk.vtkCellTypeUtilities.IsLinear(value))
@@ -1064,9 +1092,6 @@ class CellType(IntEnum, metaclass=_CellTypeMeta):
         3
 
         """
-        if self._dimension == -1 and vtk_version_info < (9, 4, 0):  # type: ignore[comparison-overlap,unreachable]
-            msg = f'dimension for cell type {self.name} requires VTK 9.4 or later'  # type: ignore[unreachable]
-            raise VTKVersionError(msg)
         return self._dimension
 
     @property

--- a/pyvista/core/celltype.py
+++ b/pyvista/core/celltype.py
@@ -934,7 +934,8 @@ class CellType(IntEnum, metaclass=_CellTypeMeta):
 
         # Set cell type properties using vtkCellTypeUtilities
         if self._vtk_class is None and vtk_version_info < (9, 4, 0):
-            self._dimension = -1  # Dimension is not supported for abstract classes for older VTK
+            # Dimension is not supported for abstract classes for older VTK
+            self._dimension = -1  # type: ignore[assignment]
         else:
             self._dimension = cast('_Dimension', _vtk.vtkCellTypeUtilities.GetDimension(value))
         self._is_linear = bool(_vtk.vtkCellTypeUtilities.IsLinear(value))
@@ -1063,8 +1064,8 @@ class CellType(IntEnum, metaclass=_CellTypeMeta):
         3
 
         """
-        if self._dimension == -1 and vtk_version_info < (9, 4, 0):
-            msg = f'dimension for cell type {self.name} requires VTK 9.4 or later'
+        if self._dimension == -1 and vtk_version_info < (9, 4, 0):  # type: ignore[comparison-overlap,unreachable]
+            msg = f'dimension for cell type {self.name} requires VTK 9.4 or later'  # type: ignore[unreachable]
             raise VTKVersionError(msg)
         return self._dimension
 

--- a/tests/core/test_cells.py
+++ b/tests/core/test_cells.py
@@ -230,6 +230,28 @@ def test_celltype_dimension_map_not_mutable():
         mapping[42] = 'foo'
 
 
+def test_abstract_celltype_attributes():
+    celltype = pv.CellType.HIGHER_ORDER_HEXAHEDRON
+
+    if pv.vtk_version_info < (9, 4, 0):
+        match = 'dimension for cell type HIGHER_ORDER_HEXAHEDRON requires VTK 9.4 or later'
+        with pytest.raises(pv.VTKVersionError, match=match):
+            assert celltype.dimension == 3
+
+    else:
+        assert celltype.dimension == 3
+
+    assert not celltype.is_linear
+
+    match = "'HIGHER_ORDER_HEXAHEDRON' without a concrete cell instance."
+    with pytest.raises(ValueError, match=match):
+        _ = celltype.n_points
+    with pytest.raises(ValueError, match=match):
+        _ = celltype.n_edges
+    with pytest.raises(ValueError, match=match):
+        _ = celltype.n_faces
+
+
 @pytest.mark.parametrize(('cell', 'np'), zip(cells, npoints, strict=True), ids=cell_ids)
 def test_cell_n_points(cell, np):
     assert cell.n_points == np

--- a/tests/core/test_cells.py
+++ b/tests/core/test_cells.py
@@ -231,16 +231,11 @@ def test_celltype_dimension_map_not_mutable():
 
 
 def test_abstract_celltype_attributes():
+    # ``HIGHER_ORDER_HEXAHEDRON`` has no concrete vtk class, but its dimension
+    # is well-defined and the same on every supported VTK build. See
+    # https://github.com/pyvista/pyvista/issues/8634
     celltype = pv.CellType.HIGHER_ORDER_HEXAHEDRON
-
-    if pv.vtk_version_info < (9, 4, 0):
-        match = 'dimension for cell type HIGHER_ORDER_HEXAHEDRON requires VTK 9.4 or later'
-        with pytest.raises(pv.VTKVersionError, match=match):
-            assert celltype.dimension == 3
-
-    else:
-        assert celltype.dimension == 3
-
+    assert celltype.dimension == 3
     assert not celltype.is_linear
 
     match = "'HIGHER_ORDER_HEXAHEDRON' without a concrete cell instance."
@@ -250,6 +245,24 @@ def test_abstract_celltype_attributes():
         _ = celltype.n_edges
     with pytest.raises(ValueError, match=match):
         _ = celltype.n_faces
+
+
+@pytest.mark.parametrize(
+    ('celltype', 'expected_dim'),
+    [
+        (pv.CellType.PARAMETRIC_CURVE, 1),
+        (pv.CellType.PARAMETRIC_SURFACE, 2),
+        (pv.CellType.PARAMETRIC_TETRA_REGION, 3),
+        (pv.CellType.HIGHER_ORDER_EDGE, 1),
+        (pv.CellType.HIGHER_ORDER_TRIANGLE, 2),
+        (pv.CellType.HIGHER_ORDER_HEXAHEDRON, 3),
+        (pv.CellType.LAGRANGE_PYRAMID, 3),
+        (pv.CellType.BEZIER_PYRAMID, 3),
+    ],
+)
+def test_abstract_celltype_dimension_is_correct(celltype, expected_dim):
+    """Abstract / placeholder cell types report their canonical dimension."""
+    assert celltype.dimension == expected_dim
 
 
 @pytest.mark.parametrize(('cell', 'np'), zip(cells, npoints, strict=True), ids=cell_ids)

--- a/tox.ini
+++ b/tox.ini
@@ -65,17 +65,11 @@ vtk_dev_install = uv pip install --upgrade --pre --no-cache --no-deps --extra-in
 commands_pre =
     numpy_nightly: python -c 'import os, subprocess, shlex; os.environ["UV_INDEX"]="{[testenv]uv_index_numpy_nightly}"; subprocess.run(shlex.split("{[testenv]numpy_nightly_install}"), check=True)'
     vtk_dev: python -c 'import os, subprocess, shlex; os.environ["UV_INDEX"]="{[testenv]uv_index_vtk_dev}"; subprocess.run(shlex.split("{[testenv]vtk_dev_install}"), check=True)'
-
-    # Install the required VTK version
-    python -c 'import os, subprocess; vtk=os.getenv("VTK_VERSION"); \
-    vtk and subprocess.run(["uv","pip","install","--no-deps",f"vtk=={vtk}"], check=True)'
-
     {[testenv]software_report_cmdline}
 
     # Ensure the correct VTK version is installed
-    python -c 'import os, subprocess, sys, pyvista; \
-    required=os.getenv("VTK_VERSION"); \
-    installed=".".join(map(str, pyvista.vtk_version_info)); \
+    python -c 'import os, subprocess, sys; required=os.getenv("VTK_VERSION"); \
+    import pyvista; installed=pyvista.vtk_version_info; \
     required and sys.exit(0 if installed==required else f"Required vtk version {required} is not installed.")'
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -44,11 +44,6 @@ passenv =
     PIP_TRUSTED_HOST
 
 setenv =
-    vtk_9.2.2: VTK_VERSION=9.2.2
-    vtk_9.2.6: VTK_VERSION=9.2.6
-    vtk_9.3.1: VTK_VERSION=9.3.1
-    vtk_9.4.2: VTK_VERSION=9.4.2
-    vtk_9.5.2: VTK_VERSION=9.5.2
     TOX_ROOT = {tox_root}
     PYTEST_ADDOPTS = --color=yes -v {env:PARALLEL:}
 
@@ -56,6 +51,11 @@ dependency_groups = test
 deps =
     numpy_1.23: numpy ~= 1.23.0
     numpy_1.26: numpy ~= 1.26.0
+    vtk_9.2.2: vtk == 9.2.2
+    vtk_9.2.6: vtk == 9.2.6
+    vtk_9.3.1: vtk == 9.3.1
+    vtk_9.4.2: vtk == 9.4.2
+    vtk_9.5.2: vtk == 9.5.2
 
 uv_index_numpy_nightly = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 uv_index_vtk_dev = https://wheels.vtk.org
@@ -66,11 +66,6 @@ commands_pre =
     numpy_nightly: python -c 'import os, subprocess, shlex; os.environ["UV_INDEX"]="{[testenv]uv_index_numpy_nightly}"; subprocess.run(shlex.split("{[testenv]numpy_nightly_install}"), check=True)'
     vtk_dev: python -c 'import os, subprocess, shlex; os.environ["UV_INDEX"]="{[testenv]uv_index_vtk_dev}"; subprocess.run(shlex.split("{[testenv]vtk_dev_install}"), check=True)'
     {[testenv]software_report_cmdline}
-
-    # Ensure the correct VTK version is installed
-    python -c 'import os, subprocess, sys; required=os.getenv("VTK_VERSION"); \
-    import pyvista; installed=pyvista.vtk_version_info; \
-    sys.exit(0 if installed==required else f"Required vtk version {required} is not installed.")'
 
 commands =
     {[testenv]all_testing_cmdline}

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ commands_pre =
     # Ensure the correct VTK version is installed
     python -c 'import os, subprocess, sys; required=os.getenv("VTK_VERSION"); \
     import pyvista; installed=pyvista.vtk_version_info; \
-    required and sys.exit(0 if installed==required else f"Required vtk version {required} is not installed.")'
+    sys.exit(0 if installed==required else f"Required vtk version {required} is not installed.")'
 
 commands =
     {[testenv]all_testing_cmdline}

--- a/tox.ini
+++ b/tox.ini
@@ -65,11 +65,17 @@ vtk_dev_install = uv pip install --upgrade --pre --no-cache --no-deps --extra-in
 commands_pre =
     numpy_nightly: python -c 'import os, subprocess, shlex; os.environ["UV_INDEX"]="{[testenv]uv_index_numpy_nightly}"; subprocess.run(shlex.split("{[testenv]numpy_nightly_install}"), check=True)'
     vtk_dev: python -c 'import os, subprocess, shlex; os.environ["UV_INDEX"]="{[testenv]uv_index_vtk_dev}"; subprocess.run(shlex.split("{[testenv]vtk_dev_install}"), check=True)'
+
+    # Install the required VTK version
+    python -c 'import os, subprocess; vtk=os.getenv("VTK_VERSION"); \
+    vtk and subprocess.run(["uv","pip","install","--no-deps",f"vtk=={vtk}"], check=True)'
+
     {[testenv]software_report_cmdline}
 
     # Ensure the correct VTK version is installed
-    python -c 'import os, subprocess, sys; required=os.getenv("VTK_VERSION"); \
-    import pyvista; installed=pyvista.vtk_version_info; \
+    python -c 'import os, subprocess, sys, pyvista; \
+    required=os.getenv("VTK_VERSION"); \
+    installed=".".join(map(str, pyvista.vtk_version_info)); \
     required and sys.exit(0 if installed==required else f"Required vtk version {required} is not installed.")'
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ commands_pre =
     # Ensure the correct VTK version is installed
     python -c 'import os, subprocess, sys; required=os.getenv("VTK_VERSION"); \
     import pyvista; installed=pyvista.vtk_version_info; \
-    sys.exit(0 if installed==required else f"Required vtk version {required} is not installed.")'
+    required and sys.exit(0 if installed==required else f"Required vtk version {required} is not installed.")'
 
 commands =
     {[testenv]all_testing_cmdline}

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,11 @@ passenv =
     PIP_TRUSTED_HOST
 
 setenv =
+    vtk_9.2.2: VTK_VERSION=9.2.2
+    vtk_9.2.6: VTK_VERSION=9.2.6
+    vtk_9.3.1: VTK_VERSION=9.3.1
+    vtk_9.4.2: VTK_VERSION=9.4.2
+    vtk_9.5.2: VTK_VERSION=9.5.2
     TOX_ROOT = {tox_root}
     PYTEST_ADDOPTS = --color=yes -v {env:PARALLEL:}
 
@@ -51,11 +56,6 @@ dependency_groups = test
 deps =
     numpy_1.23: numpy ~= 1.23.0
     numpy_1.26: numpy ~= 1.26.0
-    vtk_9.2.2: vtk == 9.2.2
-    vtk_9.2.6: vtk == 9.2.6
-    vtk_9.3.1: vtk == 9.3.1
-    vtk_9.4.2: vtk == 9.4.2
-    vtk_9.5.2: vtk == 9.5.2
 
 uv_index_numpy_nightly = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 uv_index_vtk_dev = https://wheels.vtk.org
@@ -66,6 +66,11 @@ commands_pre =
     numpy_nightly: python -c 'import os, subprocess, shlex; os.environ["UV_INDEX"]="{[testenv]uv_index_numpy_nightly}"; subprocess.run(shlex.split("{[testenv]numpy_nightly_install}"), check=True)'
     vtk_dev: python -c 'import os, subprocess, shlex; os.environ["UV_INDEX"]="{[testenv]uv_index_vtk_dev}"; subprocess.run(shlex.split("{[testenv]vtk_dev_install}"), check=True)'
     {[testenv]software_report_cmdline}
+
+    # Ensure the correct VTK version is installed
+    python -c 'import os, subprocess, sys; required=os.getenv("VTK_VERSION"); \
+    import pyvista; installed=pyvista.vtk_version_info; \
+    sys.exit(0 if installed==required else f"Required vtk version {required} is not installed.")'
 
 commands =
     {[testenv]all_testing_cmdline}


### PR DESCRIPTION
Resolves #8634

`pv.CellType.HIGHER_ORDER_HEXAHEDRON.dimension` returned `0` instead of `3` on vtk<9.4, and `import pyvista` on those builds emitted ~16 lines of `vtkGenericCell ERR| Unsupported cell type: N Setting to vtkEmptyCell`  

This came from `vtkCellTypeUtilities.GetDimension(value)` for cell types that have no concrete vtk class (the abstract `PARAMETRIC_*`, `HIGHER_ORDER_*`, `LAGRANGE_PYRAMID`, `BEZIER_PYRAMID` families). On vtk<9.4 the lookup falls through to `vtkEmptyCell`, which is 0-D and prints the warning.

This PR hardcodes the canonical dimension for the 16 abstract / placeholder cell types in an `_ABSTRACT_DIMENSIONS` table, and skip the `GetDimension` call when the value is in it. Concrete cell types still go through `vtkCellTypeUtilities`.
