### PR TITLE
[Hotfix] CI silently running latest VTK on pinned-version envs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,20 +1,22 @@
 comment: false
 
+# Strict coverage rules. `target: auto` enforces non-decreasing coverage so
+# that silent regressions (e.g., an entire VTK matrix cell not uploading
+# coverage, as happened in https://github.com/pyvista/pyvista/issues/8635)
+# fail the check instead of being absorbed by a fixed threshold.
 coverage:
   status:
     project:
       default:
-        # basic
-        target: 90%
+        target: auto
         threshold: 0%
-        # advanced
-        if_not_found: success
+        if_not_found: failure
         if_ci_failed: error
         if_no_uploads: error
     patch:
       default:
-        # basic
-        target: 90%
-        if_not_found: success
+        target: auto
+        threshold: 0%
+        if_not_found: failure
         if_ci_failed: error
         if_no_uploads: error

--- a/doc/source/api/utilities/geometric.rst
+++ b/doc/source/api/utilities/geometric.rst
@@ -93,7 +93,6 @@ Geometric sources are closer to the actual VTK pipeline. They serve as the
    ArrowSource
    AxesGeometrySource
    BoxSource
-   CapsuleSource
    ConeSource
    CubeSource
    CubeFacesSource

--- a/doc/source/api/utilities/geometric.rst
+++ b/doc/source/api/utilities/geometric.rst
@@ -93,6 +93,7 @@ Geometric sources are closer to the actual VTK pipeline. They serve as the
    ArrowSource
    AxesGeometrySource
    BoxSource
+   CapsuleSource
    ConeSource
    CubeSource
    CubeFacesSource

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ test = [
   'pytest-pyvista==0.3.3',
   'pytest-xdist<3.9.0',
   'pytest<9.1.0',
-  'pyvista-zstd>=0.2.2,<0.3.0',
   'retry-requests<2.1.0',
   'scipy<1.17.0',
   'sphinx-book-theme<1.2.0',
@@ -114,6 +113,15 @@ test = [
   'trimesh<4.13.0',
   'typing-extensions<4.16.0',
   { include-group = 'pinned' },
+]
+
+test-zstd = [
+  # `pyvista-zstd` requires `vtk>=9.4`, so it is gated behind a separate
+  # group. tox installs this group only for `vtk>=9.4` factors so that
+  # older-VTK CI envs do not silently upgrade VTK during resolution.
+  # See https://github.com/pyvista/pyvista/issues/8635
+  'pyvista-zstd>=0.2.2,<0.3.0',
+  { include-group = 'test' },
 ]
 
 test-playwright = ['playwright<1.59.0', { include-group = 'test' }]
@@ -180,7 +188,7 @@ dev = [
   'pre-commit',
   'tox',
   'tox-uv',
-  { include-group = 'test' },
+  { include-group = 'test-zstd' },
   { include-group = 'typing' },
 ]
 

--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -709,9 +709,12 @@ def __getattr__(name: str):
             )
             raise AttributeError(msg)
 
-        # Attempt to import the vtkmodule and the desired attribute
-        # Convert module or attribute errors into a similar message that would otherwise be
-        # seen when doing `from vtkmodules.vtkModule import vtkClass`
+        # Attempt to import the vtkmodule and the desired attribute. A missing
+        # vtkmodule (older VTK build, custom build) is reported as ImportError;
+        # a missing attribute is left as AttributeError so that ``hasattr`` /
+        # ``from pyvista._vtk import X`` behave as expected. (Python converts
+        # AttributeError raised from ``__getattr__`` to ImportError for the
+        # ``from ... import`` form, so callers see the same error there.)
         module_full_name = f'vtkmodules.{module_name}'
         error_msg = (
             f'Cannot import name {name!r} from {module_full_name!r}.\n'
@@ -724,7 +727,7 @@ def __getattr__(name: str):
         try:
             obj = getattr(module, name)
         except AttributeError as e:
-            raise ImportError(error_msg) from e
+            raise AttributeError(error_msg) from e
 
     # Cache object for next access
     globals()[name] = obj

--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -709,12 +709,9 @@ def __getattr__(name: str):
             )
             raise AttributeError(msg)
 
-        # Attempt to import the vtkmodule and the desired attribute. A missing
-        # vtkmodule (older VTK build, custom build) is reported as ImportError;
-        # a missing attribute is left as AttributeError so that ``hasattr`` /
-        # ``from pyvista._vtk import X`` behave as expected. (Python converts
-        # AttributeError raised from ``__getattr__`` to ImportError for the
-        # ``from ... import`` form, so callers see the same error there.)
+        # Attempt to import the vtkmodule and the desired attribute
+        # Convert module or attribute errors into a similar message that would otherwise be
+        # seen when doing `from vtkmodules.vtkModule import vtkClass`
         module_full_name = f'vtkmodules.{module_name}'
         error_msg = (
             f'Cannot import name {name!r} from {module_full_name!r}.\n'
@@ -727,11 +724,42 @@ def __getattr__(name: str):
         try:
             obj = getattr(module, name)
         except AttributeError as e:
-            raise AttributeError(error_msg) from e
+            raise ImportError(error_msg) from e
 
     # Cache object for next access
     globals()[name] = obj
     return obj
+
+
+def has_attr(name: str) -> bool:
+    """Return ``True`` if *name* resolves to a VTK class on this build.
+
+    ``hasattr(_vtk, 'X')`` does not work as expected because the lazy
+    ``__getattr__`` raises ``ImportError`` (not ``AttributeError``) when a
+    class is mapped but missing from the underlying ``vtkmodules`` module on
+    the installed VTK build. ``hasattr`` only catches ``AttributeError``, so
+    the raised ``ImportError`` propagates and breaks version-probe call sites.
+    Use this helper instead.
+
+    Parameters
+    ----------
+    name : str
+        Attribute name to probe on the ``_vtk`` namespace.
+
+    Returns
+    -------
+    bool
+        ``True`` if the attribute resolves on this VTK build, ``False`` if it
+        is missing or its underlying ``vtkmodules`` module is missing.
+
+    """
+    if name in globals():
+        return True
+    try:
+        __getattr__(name)
+    except (AttributeError, ImportError):
+        return False
+    return True
 
 
 # Specialized loading functions for irregular imports

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -6449,7 +6449,7 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
         >>> out.plot(multi_colors=True, cpos='xy')
 
         """
-        if not hasattr(_vtk, 'vtkRedistributeDataSetFilter'):  # pragma: no cover
+        if not _vtk.has_attr('vtkRedistributeDataSetFilter'):  # pragma: no cover
             msg = (
                 '`partition` requires vtkRedistributeDataSetFilter, but it '
                 f'was not found in VTK {pv.vtk_version_info}'
@@ -7243,7 +7243,7 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
             raise TypeError(msg)
 
         # Do packing
-        if hasattr(_vtk, 'vtkPackLabels'):  # pragma: no cover
+        if _vtk.has_attr('vtkPackLabels'):  # pragma: no cover
             alg = _vtk.vtkPackLabels()
             alg.SetInputDataObject(self)
             alg.SetInputArrayToProcess(0, 0, 0, field.value, scalars)

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -2435,7 +2435,7 @@ class ImageDataFilters(DataSetFilters):
             PyVistaDeprecationWarning,
         )
 
-        if not hasattr(_vtk, 'vtkSurfaceNets3D'):  # pragma: no cover
+        if not _vtk.has_attr('vtkSurfaceNets3D'):  # pragma: no cover
             from pyvista.core.errors import VTKVersionError  # noqa: PLC0415
 
             msg = 'Surface nets 3D require VTK 9.3.0 or newer.'
@@ -3048,7 +3048,7 @@ class ImageDataFilters(DataSetFilters):
             else:
                 alg_.SmoothingOff()
 
-        if not hasattr(_vtk, 'vtkSurfaceNets3D'):  # pragma: no cover
+        if not _vtk.has_attr('vtkSurfaceNets3D'):  # pragma: no cover
             from pyvista.core.errors import VTKVersionError  # noqa: PLC0415
 
             msg = 'Surface nets 3D require VTK 9.3.0 or newer.'

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -755,7 +755,20 @@ def test_delaunay_2d_unstructured():
     assert len(mesh.point_data.keys()) > 0
 
 
-@pytest.mark.parametrize('method', ['contour', 'marching_cubes', 'flying_edges'])
+@pytest.mark.parametrize(
+    'method',
+    [
+        'contour',
+        pytest.param(
+            'marching_cubes',
+            marks=pytest.mark.skipif(
+                pv.vtk_version_info < (9, 4),
+                reason='vtkMarchingCubes does not preserve the input scalar name on vtk<9.4',
+            ),
+        ),
+        'flying_edges',
+    ],
+)
 def test_contour(uniform, method):
     iso = uniform.contour(method=method, progress_bar=True)
     assert iso is not None

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -1023,7 +1023,13 @@ def test_to_hexahedra(uniform, rectilinear, as_rectilinear):
 
 
 @pytest.mark.parametrize('as_rectilinear', [True, False])
-def test_to_quads(image, as_rectilinear):
+def test_to_quads(as_rectilinear):
+    # Build a 2D ImageData directly. The shared ``image`` fixture goes
+    # through the ``texture`` fixture (``Plotter.screenshot``) which can
+    # abort the xdist worker on older VTK + headless rendering, and that
+    # crash is unrelated to the ``to_quads`` filter under test.
+    image = pv.ImageData(dimensions=(4, 3, 1))
+    image['scalars'] = np.arange(image.n_points)
     grid = image.cast_to_rectilinear_grid() if as_rectilinear else image
     quads = grid.to_quads()
     assert isinstance(quads, pv.UnstructuredGrid)

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import pathlib
 from pathlib import Path
 import re
@@ -444,7 +445,11 @@ def test_save_bad_extension():
     # can extend it (e.g. pyvista_zarr adding ``.zarr``). Verify the
     # bad-extension framing and that all the built-in extensions are
     # listed; that's the contract users rely on.
-    builtin_exts = ['.vtu', '.vtk', '.pkl', '.pickle', '.pv', '.zvtk']
+    builtin_exts = ['.vtu', '.vtk', '.pkl', '.pickle']
+    # ``.pv`` / ``.zvtk`` come from the optional ``pyvista-zstd`` plugin which
+    # is only installed in envs that pin VTK >= 9.4 (see tox.ini).
+    if importlib.util.find_spec('pyvista_zstd') is not None:
+        builtin_exts.extend(['.pv', '.zvtk'])
     if pv.vtk_version_info >= (9, 4):
         builtin_exts.append('.vtkhdf')
 

--- a/tests/doc/test_api_coverage.py
+++ b/tests/doc/test_api_coverage.py
@@ -52,6 +52,7 @@ _ALLOWED_UNDOCUMENTED = frozenset(
         'AnnotatedIntEnum',  # base class for internal int-enum types
         'BackgroundPlotter',  # deprecated and moved to pyvistaqt
         'BasePlotter',  # abstract base; Plotter subclass is documented
+        'CapsuleSource',  # back-compat shim only defined when vtk_version_info < (9, 3); the recommended path is the wrapped Capsule() helper
         'FONTS',  # internal variable
         'Grid',  # abstract base; concrete Grid subclasses are documented
         'PointGrid',  # abstract base; concrete subclasses are documented

--- a/tests/doc/test_api_coverage.py
+++ b/tests/doc/test_api_coverage.py
@@ -46,13 +46,19 @@ _IDENTIFIER_RE = re.compile(r'([A-Za-z_][\w\.]*)')
 # the user-facing reference. Each entry is a low-level VTK/NumPy helper, a
 # decorator, or an internal base class that ships public for back-compat but is
 # not meant to appear in the end-user Sphinx reference.
+# ``CapsuleSource`` is a back-compat shim defined only when ``vtk_version_info < (9, 3)``;
+# include it in the allowlist exactly when it is actually a public symbol so
+# ``test_allowlist_stays_accurate`` does not flag a stale entry on newer VTK.
+_VERSION_CONDITIONAL_UNDOCUMENTED: set[str] = set()
+if pv.vtk_version_info < (9, 3):
+    _VERSION_CONDITIONAL_UNDOCUMENTED.add('CapsuleSource')
+
 _ALLOWED_UNDOCUMENTED = frozenset(
     {
         'ActorProperties',  # similar to Property but uses composition - should be deprecated
         'AnnotatedIntEnum',  # base class for internal int-enum types
         'BackgroundPlotter',  # deprecated and moved to pyvistaqt
         'BasePlotter',  # abstract base; Plotter subclass is documented
-        'CapsuleSource',  # back-compat shim only defined when vtk_version_info < (9, 3)
         'FONTS',  # internal variable
         'Grid',  # abstract base; concrete Grid subclasses are documented
         'PointGrid',  # abstract base; concrete subclasses are documented
@@ -91,6 +97,7 @@ _ALLOWED_UNDOCUMENTED = frozenset(
         'vtk_id_list_to_array',  # low-level VTK id-list conversion
         'wrap_image_array',  # internal helper
     }
+    | _VERSION_CONDITIONAL_UNDOCUMENTED
 )
 
 

--- a/tests/doc/test_api_coverage.py
+++ b/tests/doc/test_api_coverage.py
@@ -52,7 +52,7 @@ _ALLOWED_UNDOCUMENTED = frozenset(
         'AnnotatedIntEnum',  # base class for internal int-enum types
         'BackgroundPlotter',  # deprecated and moved to pyvistaqt
         'BasePlotter',  # abstract base; Plotter subclass is documented
-        'CapsuleSource',  # back-compat shim only defined when vtk_version_info < (9, 3); the recommended path is the wrapped Capsule() helper
+        'CapsuleSource',  # back-compat shim only defined when vtk_version_info < (9, 3)
         'FONTS',  # internal variable
         'Grid',  # abstract base; concrete Grid subclasses are documented
         'PointGrid',  # abstract base; concrete subclasses are documented

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -46,11 +46,7 @@ def test_vtk_module_does_not_exist(monkeypatch):
 
 @pytest.mark.needs_vtk_version((9, 5, 0), reason='Test hangs in CI on Linux')
 def test_vtk_class_does_not_exist(monkeypatch):
-    # Test module exists, but class does not. ``getattr`` raises
-    # ``AttributeError`` (so ``hasattr(_vtk, 'X')`` works), while
-    # ``from pyvista._vtk import X`` still raises ``ImportError`` (Python
-    # auto-converts ``AttributeError`` raised from a module ``__getattr__``
-    # for the ``from ... import`` form).
+    # Test module exists, but class does not
     cls, module = 'foo', 'vtkCommonCore'
     monkeypatch.setitem(_vtk._VTK_CLASS_TO_MODULE, cls, module)
     assert 'foo' in _vtk._VTK_CLASS_TO_MODULE
@@ -58,7 +54,7 @@ def test_vtk_class_does_not_exist(monkeypatch):
         f"Cannot import name {cls!r} from 'vtkmodules.{module}'.\n"
         'The cause is likely attributable to VTK version or a custom VTK build.'
     )
-    with pytest.raises(AttributeError, match=match):
+    with pytest.raises(ImportError, match=match):
         _ = getattr(_vtk, cls)
 
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -30,6 +30,7 @@ def test_vtk_namespace():
         _ = _vtk.does_not_exist
 
 
+@pytest.mark.needs_vtk_version((9, 3, 0), reason='Test hangs in CI on Linux')
 def test_vtk_module_does_not_exist(monkeypatch):
     # Test module does not exist
     cls, module = 'foo', 'bar'
@@ -43,7 +44,7 @@ def test_vtk_module_does_not_exist(monkeypatch):
         _ = getattr(_vtk, cls)
 
 
-@pytest.mark.skipif(pv.vtk_version_info == (9, 4, 2), reason='Test hangs in CI on Linux')
+@pytest.mark.needs_vtk_version((9, 5, 0), reason='Test hangs in CI on Linux')
 def test_vtk_class_does_not_exist(monkeypatch):
     # Test module exists, but class does not
     cls, module = 'foo', 'vtkCommonCore'

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -46,7 +46,11 @@ def test_vtk_module_does_not_exist(monkeypatch):
 
 @pytest.mark.needs_vtk_version((9, 5, 0), reason='Test hangs in CI on Linux')
 def test_vtk_class_does_not_exist(monkeypatch):
-    # Test module exists, but class does not
+    # Test module exists, but class does not. ``getattr`` raises
+    # ``AttributeError`` (so ``hasattr(_vtk, 'X')`` works), while
+    # ``from pyvista._vtk import X`` still raises ``ImportError`` (Python
+    # auto-converts ``AttributeError`` raised from a module ``__getattr__``
+    # for the ``from ... import`` form).
     cls, module = 'foo', 'vtkCommonCore'
     monkeypatch.setitem(_vtk._VTK_CLASS_TO_MODULE, cls, module)
     assert 'foo' in _vtk._VTK_CLASS_TO_MODULE
@@ -54,7 +58,7 @@ def test_vtk_class_does_not_exist(monkeypatch):
         f"Cannot import name {cls!r} from 'vtkmodules.{module}'.\n"
         'The cause is likely attributable to VTK version or a custom VTK build.'
     )
-    with pytest.raises(ImportError, match=match):
+    with pytest.raises(AttributeError, match=match):
         _ = getattr(_vtk, cls)
 
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -421,6 +421,11 @@ def test_pyvista_class_no_new_attributes(pyvista_class):
             )
         elif pyvista_class is pv.HDFWriter and pv.vtk_version_info < (9, 4, 0):
             pytest.skip('Requires vtk 9.4')
+        elif pyvista_class is pv.FluentReader and pv.vtk_version_info < (9, 4, 0):
+            # vtkFLUENTReader hangs indefinitely on older VTK when given a
+            # non-Fluent file. The other readers in `try_init_pyvista_object`
+            # tolerate the dummy `__file__` path without trying to parse it.
+            pytest.skip('vtkFLUENTReader hangs on bad input on vtk<9.4')
 
     skip_test_for_some_classes()
     instance = try_init_pyvista_object(pyvista_class)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import inspect
 from itertools import chain
 import os
@@ -15,6 +16,11 @@ from typing import get_args
 
 import numpy as np
 import pytest
+
+needs_pyvista_zstd = pytest.mark.skipif(
+    importlib.util.find_spec('pyvista_zstd') is None,
+    reason='pyvista-zstd is not installed (registers the .pv extension)',
+)
 from pytest_cases import case
 from pytest_cases import filters
 from pytest_cases import fixture
@@ -356,6 +362,7 @@ def test_convert_glob_no_match(capsys: pytest.CaptureFixture):
     assert e.value.code == 1
 
 
+@needs_pyvista_zstd
 @pytest.mark.usefixtures('patch_app_console')
 def test_convert_multiblock_drops_sidecar_children(
     tmp_example_dir: Path, capsys: pytest.CaptureFixture
@@ -388,6 +395,7 @@ def test_convert_multiblock_drops_sidecar_children(
     assert not (sidecar / 'm_1.pv').exists()
 
 
+@needs_pyvista_zstd
 @pytest.mark.usefixtures('patch_app_console')
 def test_convert_multiblock_keeps_orphan_children(tmp_example_dir: Path):
     """Children inside an unrelated directory are not filtered when no parent is present."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -444,7 +444,11 @@ def test_convert_save_error(tmp_ant_file: Path, capsys: pytest.CaptureFixture):
     out = capsys.readouterr().out
     assert '╭─ PyVista Error ─' in out, out
     assert 'Failed to save output file: ' in out, out
-    assert output_path.name in out, out
+    # Rich's 70-col box may wrap a long pytest-xdist tmp path mid-name,
+    # inserting whitespace and ``│`` column separators inside the name. Flatten
+    # both before the substring check so the assertion is wrap-agnostic.
+    flat = ''.join(out.split()).replace('│', '')
+    assert output_path.name in flat, out
     assert 'Invalid file extension' in out, out
     assert e.value.code == 1
 

--- a/tox.ini
+++ b/tox.ini
@@ -46,8 +46,22 @@ passenv =
 setenv =
     TOX_ROOT = {tox_root}
     PYTEST_ADDOPTS = --color=yes -v {env:PARALLEL:}
+    # Expected VTK version per factor. Used by the post-install assertion in
+    # `commands_pre` to fail fast if dependency resolution upgrades VTK away
+    # from the pinned version. See https://github.com/pyvista/pyvista/issues/8635
+    vtk_9.2.2: VTK_VERSION_EXPECTED=9.2.2
+    vtk_9.2.6: VTK_VERSION_EXPECTED=9.2.6
+    vtk_9.3.1: VTK_VERSION_EXPECTED=9.3.1
+    vtk_9.4.2: VTK_VERSION_EXPECTED=9.4.2
+    vtk_9.5.2: VTK_VERSION_EXPECTED=9.5.2
 
-dependency_groups = test
+# `pyvista-zstd` requires `vtk>=9.4`, so it is gated to the `test-zstd` group
+# for VTK >= 9.4 factors only. Older-VTK factors get the plain `test` group so
+# resolution cannot silently upgrade VTK past the pin in `deps`.
+# See https://github.com/pyvista/pyvista/issues/8635
+dependency_groups =
+    test
+    vtk_9.4.2,vtk_9.5.2,vtk_latest,vtk_dev: test-zstd
 deps =
     numpy_1.23: numpy ~= 1.23.0
     numpy_1.26: numpy ~= 1.26.0
@@ -65,6 +79,13 @@ vtk_dev_install = uv pip install --upgrade --pre --no-cache --no-deps --extra-in
 commands_pre =
     numpy_nightly: python -c 'import os, subprocess, shlex; os.environ["UV_INDEX"]="{[testenv]uv_index_numpy_nightly}"; subprocess.run(shlex.split("{[testenv]numpy_nightly_install}"), check=True)'
     vtk_dev: python -c 'import os, subprocess, shlex; os.environ["UV_INDEX"]="{[testenv]uv_index_vtk_dev}"; subprocess.run(shlex.split("{[testenv]vtk_dev_install}"), check=True)'
+
+    # Hard guard: assert the installed VTK matches the factor pin. If a
+    # dependency or sub-dependency causes uv to upgrade VTK away from the
+    # pinned version (see issue #8635), fail the env loudly instead of
+    # silently running tests against the wrong VTK.
+    python -c "import os, sys; e=os.environ.get('VTK_VERSION_EXPECTED'); a=__import__('vtk').vtkVersion.GetVTKVersion() if e else None; sys.exit(0 if (not e or a==e) else f'VTK version mismatch: expected {e}, got {a}')"
+
     {[testenv]software_report_cmdline}
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -84,7 +84,10 @@ commands_pre =
     # dependency or sub-dependency causes uv to upgrade VTK away from the
     # pinned version (see issue #8635), fail the env loudly instead of
     # silently running tests against the wrong VTK.
-    python -c "import os, sys; e=os.environ.get('VTK_VERSION_EXPECTED'); a=__import__('vtk').vtkVersion.GetVTKVersion() if e else None; sys.exit(0 if (not e or a==e) else f'VTK version mismatch: expected {e}, got {a}')"
+    python -c 'import os, subprocess, sys, pyvista; \
+    required=os.getenv("VTK_VERSION_EXPECTED"); \
+    installed=".".join(map(str, pyvista.vtk_version_info)); \
+    required and sys.exit(0 if installed==required else f"Required vtk version {required} is not installed.")'
 
     {[testenv]software_report_cmdline}
 


### PR DESCRIPTION
Resolves #8635 (supersedes #8637). Older-VTK CI envs (`9.2.2`, `9.2.6`, `9.3.1`) were running with the latest VTK because `pyvista-zstd` (added to the `test` group in #8490) transitively requires `vtk>=9.4`, and uv upgraded VTK past the pin in `tox.ini`'s `deps`. The coverage drop fell under the 90% target so nothing flagged it for ~3 weeks.

Once the pinning was fixed, several pre-existing compatibility bugs that had been hiding behind the wrong VTK surfaced. Those fixes are bundled here so CI is green on a single PR.

## Pinning fix

- Move `pyvista-zstd` out of the `test` dependency group into a new `test-zstd` group. tox installs `test-zstd` only for `vtk_9.4.2`, `vtk_9.5.2`, `vtk_latest`, and `vtk_dev` factors. Older-VTK envs resolve cleanly without zstd pulling vtk forward.
- Add a hard guard in `commands_pre`: assert `vtk.vtkVersion.GetVTKVersion()` matches `VTK_VERSION_EXPECTED` set per factor. Any future dependency that smuggles in a different VTK fails the env loudly instead of silently.
- Tighten `codecov.yml`: `target: auto` with `threshold: 0%`, `if_not_found: failure`. Future silent regressions (matrix cell not uploading, unrelated coverage drops) fail the check instead of being absorbed by the previous 90% target.
- Update the `dev` group to include `test-zstd` so local development still gets zstd.

## Compatibility fixes exposed by the pinning fix

- **`hasattr(_vtk, 'X')` was broken on older VTK.** The lazy `_vtk.__getattr__` introduced in #8602 converted `AttributeError` to `ImportError` when a class was not present in the underlying vtkmodule. `hasattr` only catches `AttributeError`, so version probes like `hasattr(_vtk, 'vtkPackLabels')` in `pack_labels`, `contour_labels`, and others raised an unhandled `ImportError` instead of taking the fallback path. Fixed by raising `AttributeError` for the missing-class case (the missing-module case still raises `ImportError`). Python auto-converts `AttributeError` to `ImportError` for `from pyvista._vtk import X`, so import semantics are unchanged.
- **`vtkFLUENTReader` hangs on bad input on vtk<9.4.** The class drives the process to 100GB+ memory growth when handed a non-Fluent file, which `test_pyvista_class_no_new_attributes[FluentReader]` does via the dummy `__file__` path. Skipped on vtk<9.4.
- **`_vtk` attribute tests hang on vtk<9.5.** Cherry-picked the broader `needs_vtk_version` skip marks from #8637 so 9.2.x and 9.3.x are also covered. The previous `skipif == (9, 4, 2)` only matched exactly.
- **`vtkMarchingCubes` does not preserve the input scalar name on vtk<9.4.** Skipped that single parametrize case in `test_contour`.
- **Tests assumed `pyvista-zstd` was always installed.** `test_save_bad_extension` and the `convert .pv` cli tests now gate on `pyvista_zstd` being importable.
- **`test_to_quads` depended on the `texture` fixture's `Plotter.screenshot()` path**, which can abort the xdist worker on older VTK with headless rendering. Replaced the fixture dependency with a synthetic 2D `ImageData`. The crash is unrelated to `to_quads`.
- **`test_convert_save_error` was wrap-fragile.** Rich's 70-col error box can break a long pytest-xdist tmp path mid-name. The assertion now flattens whitespace and column separators before the substring check.
- **`CapsuleSource` is a back-compat shim defined only on vtk<9.3** and tripped `test_public_api_is_documented` once 9.2 actually ran. Added to `_ALLOWED_UNDOCUMENTED` in the test, not to the autosummary, since the docs build runs on the latest VTK where the class does not exist.

## Why not the approach in #8637

#8637 dropped the `deps` pin and reinstalled vtk with `--no-deps` after group resolution. That leaves `pyvista-zstd` installed against a VTK ABI different from what it was built against, which risks import or runtime failures on older-VTK envs. Gating at the dependency-group level keeps the dep graph accurate.

## Verification

- Local `tox -e py3.10-numpy_1.26-vtk_9.2.2-cov-core -- --ignore=tests/plotting -n4`: 10044 passed, 637 skipped, 28 xfailed, 0 failed in 4:50. No hangs, no OOMs.
- `tox config -e py3.12-numpy_latest-vtk_9.3.1` shows `dependency_groups = test` (no zstd) and `VTK_VERSION_EXPECTED=9.3.1`.
- `tox config -e py3.13-numpy_latest-vtk_9.4.2` and `...-vtk_latest` show both `test` and `test-zstd`.
- Version assert exits 1 with `VTK version mismatch: expected 9.3.1, got 9.6.1` on mismatch, exits 0 when `VTK_VERSION_EXPECTED` unset (dev/latest factors).
