### PR TITLE
Enforce and check deps version in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ test = [
   'pytest-pyvista==0.3.3',
   'pytest-xdist<3.9.0',
   'pytest<9.1.0',
+  'pyvista-zstd>=0.2.2,<0.3.0',
   'retry-requests<2.1.0',
   'scipy<1.17.0',
   'sphinx-book-theme<1.2.0',
@@ -101,15 +102,6 @@ test = [
   'trimesh<4.13.0',
   'typing-extensions<4.16.0',
   { include-group = 'pinned' },
-]
-
-test-zstd = [
-  # `pyvista-zstd` requires `vtk>=9.4`, so it is gated behind a separate
-  # group. tox installs this group only for `vtk>=9.4` factors so that
-  # older-VTK CI envs do not silently upgrade VTK during resolution.
-  # See https://github.com/pyvista/pyvista/issues/8635
-  'pyvista-zstd>=0.2.2,<0.3.0',
-  { include-group = 'test' },
 ]
 
 test-playwright = ['playwright<1.59.0', { include-group = 'test' }]
@@ -173,7 +165,7 @@ dev = [
   'pre-commit',
   'tox',
   'tox-uv',
-  { include-group = 'test-zstd' },
+  { include-group = 'test' },
   { include-group = 'typing' },
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ requires-python = '>=3.10'
 [project.optional-dependencies]
 all = ['pyvista[colormaps,io,jupyter]']
 colormaps = ['cmcrameri', 'cmocean', 'colorcet']
-io = ['fsspec', 'imageio', 'meshio>=5.2', 'pyvista-zstd>=0.2.2']
+io = ['fsspec', 'imageio', 'meshio>=5.2', 'pyvista-zstd>=0.2.3']
 jupyter = ['ipywidgets', 'nest-asyncio2', 'trame-pyvista']
 
 [dependency-groups]
@@ -89,7 +89,7 @@ test = [
   'pytest-pyvista==0.3.3',
   'pytest-xdist<3.9.0',
   'pytest<9.1.0',
-  'pyvista-zstd>=0.2.2,<0.3.0',
+  'pyvista-zstd>=0.2.3,<0.3.0',
   'retry-requests<2.1.0',
   'scipy<1.17.0',
   'sphinx-book-theme<1.2.0',
@@ -130,7 +130,7 @@ docs = [
   'pydata-sphinx-theme==0.15.4', # Do not upgrade, see https://github.com/pyvista/pyvista/pull/7095
   'pypandoc==1.17',
   'pytest-sphinx==0.7.1',
-  'pyvista-zstd==0.2.2',
+  'pyvista-zstd==0.2.3',
   'ruamel-yaml<0.20.0',
   'scipy==1.16.3; python_version >= "3.11"',
   'sphinx-autobuild==2024.10.3',

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -761,8 +761,8 @@ def test_delaunay_2d_unstructured():
         'contour',
         pytest.param(
             'marching_cubes',
-            marks=pytest.mark.skipif(
-                pv.vtk_version_info < (9, 4),
+            marks=pytest.mark.needs_vtk_version(
+                (9, 4),
                 reason='vtkMarchingCubes does not preserve the input scalar name on vtk<9.4',
             ),
         ),

--- a/tox.ini
+++ b/tox.ini
@@ -46,22 +46,8 @@ passenv =
 setenv =
     TOX_ROOT = {tox_root}
     PYTEST_ADDOPTS = --color=yes -v {env:PARALLEL:}
-    # Expected VTK version per factor. Used by the post-install assertion in
-    # `commands_pre` to fail fast if dependency resolution upgrades VTK away
-    # from the pinned version. See https://github.com/pyvista/pyvista/issues/8635
-    vtk_9.2.2: VTK_VERSION_EXPECTED=9.2.2
-    vtk_9.2.6: VTK_VERSION_EXPECTED=9.2.6
-    vtk_9.3.1: VTK_VERSION_EXPECTED=9.3.1
-    vtk_9.4.2: VTK_VERSION_EXPECTED=9.4.2
-    vtk_9.5.2: VTK_VERSION_EXPECTED=9.5.2
 
-# `pyvista-zstd` requires `vtk>=9.4`, so it is gated to the `test-zstd` group
-# for VTK >= 9.4 factors only. Older-VTK factors get the plain `test` group so
-# resolution cannot silently upgrade VTK past the pin in `deps`.
-# See https://github.com/pyvista/pyvista/issues/8635
-dependency_groups =
-    test
-    vtk_9.4.2,vtk_9.5.2,vtk_latest,vtk_dev: test-zstd
+dependency_groups = test
 deps =
     numpy_1.23: numpy ~= 1.23.0
     numpy_1.26: numpy ~= 1.26.0
@@ -79,16 +65,6 @@ vtk_dev_install = uv pip install --upgrade --pre --no-cache --no-deps --extra-in
 commands_pre =
     numpy_nightly: python -c 'import os, subprocess, shlex; os.environ["UV_INDEX"]="{[testenv]uv_index_numpy_nightly}"; subprocess.run(shlex.split("{[testenv]numpy_nightly_install}"), check=True)'
     vtk_dev: python -c 'import os, subprocess, shlex; os.environ["UV_INDEX"]="{[testenv]uv_index_vtk_dev}"; subprocess.run(shlex.split("{[testenv]vtk_dev_install}"), check=True)'
-
-    # Hard guard: assert the installed VTK matches the factor pin. If a
-    # dependency or sub-dependency causes uv to upgrade VTK away from the
-    # pinned version (see issue #8635), fail the env loudly instead of
-    # silently running tests against the wrong VTK.
-    python -c 'import os, subprocess, sys, pyvista; \
-    required=os.getenv("VTK_VERSION_EXPECTED"); \
-    installed=".".join(map(str, pyvista.vtk_version_info)); \
-    required and sys.exit(0 if installed==required else f"Required vtk version {required} is not installed.")'
-
     {[testenv]software_report_cmdline}
 
 commands =

--- a/toxfile.py
+++ b/toxfile.py
@@ -5,6 +5,7 @@ import os
 import re
 from typing import TYPE_CHECKING
 
+from packaging.requirements import Requirement
 from packaging.version import Version
 from tox.execute.api import StdinSource
 from tox.plugin import impl
@@ -18,6 +19,8 @@ if TYPE_CHECKING:
     from tox.tox_env.python.package import WheelPackage
     from tox.tox_env.python.pip.req_file import PythonDeps
     from tox_uv._installer import UvInstaller
+
+CONSTRAINTS_FILE = 'constraints.txt'
 
 
 @impl
@@ -66,52 +69,67 @@ def tox_on_install(  # noqa: PLR0917
 
     Mostly inspired by https://github.com/tox-dev/tox/issues/2386#issuecomment-1396105380
     """  # noqa: D205
-    constraints_file = tox_env.env_dir / 'constraints.txt'
+    global CONSTRAINTS_FILE  # noqa: PLW0603
+    CONSTRAINTS_FILE = tox_env.env_dir / CONSTRAINTS_FILE
 
     if of_type == 'deps' and isinstance(tox_env, UvVenvRunner):
-        constraints_file.write_text('\n'.join(arguments.lines()))
+        CONSTRAINTS_FILE.write_text('\n'.join(arguments.lines()))
 
     if of_type in 'package':
         _arguments: list[WheelPackage] = arguments
-        constraints_file_dep = f'-c {constraints_file}'
+        constraints_file_dep = f'-c {CONSTRAINTS_FILE}'
         for package in _arguments:
             getattr(package, 'deps', []).append(constraints_file_dep)
 
 
 @impl
 def tox_before_run_commands(tox_env: ToxEnv) -> None:
-    """Check vtk deps.
+    """Check that deps declared in the constraints_file (ie. during the `deps` step above)
+    are indeed installed in the environment before running the tests using a freeze command.
+    """  # noqa: D205
+    # Load requirements from the constraints file
+    with CONSTRAINTS_FILE.open() as f:
+        requirements = [Requirement(l) for l in f.read().splitlines()]
 
-    When specifying the vtk version in the env name, check the installed vtk version with
-    a `freeze` command.
-    """
-    reg = re.compile(r'.*vtk_(\d+\.\d+\.\d+).*')
-    if not (m := re.match(reg, tox_env.name)):
-        return
-
-    required = m.group(1)
-
+    # Load installed deps using freeze
     installer: UvInstaller = tox_env.installer
     out = tox_env.execute(
         installer.freeze_cmd(),
         stdin=StdinSource.OFF,
         show=False,
-        run_id='check_vtk_deps',
+        run_id='check_deps',
     )
-    matches = re.findall(r'\nvtk==(\d+\.\d+\.\d+)\n', out.out, re.MULTILINE)
-    if len(matches) != 1:
-        msg = 'Could not find the installed vtk version in the output of `uv pip freeze`'
-        raise Fail(msg)
 
-    installed = matches[0]
+    # Parse installed deps from the freeze output.
+    # Relies on the fact the the freeze command outputs lines in the
+    # form of `package==version` (eg. `vtk==9.2.2`)
+    installed = out.out.splitlines()
 
-    if installed != required:
-        msg = (
-            f'The installed vtk version ({installed}) does not match the required version',
-            f' ({required}).',
+    installed = [(Requirement(r).name, Requirement(r).specifier) for r in installed]
+    installed = [
+        (r[0], Version(m.group(2)))
+        for r in installed
+        if (m := re.match(r'(.*)==(\S+)', str(r[1]))) is not None
+    ]
+
+    # Check that the installed requirements match the constraints file ones
+    for req in requirements:
+        # Get the installed requirement matching the current one
+        installed_req = next((r for r in installed if r[0] == req.name), None)
+        if not installed_req:
+            msg = f'The required package {req.name} is not installed in the environment.'
+            raise Fail(msg)
+
+        # Check that the installed requirement version matches the specifier in
+        # the constraints file
+        if (version_installed := installed_req[1]) not in req.specifier:
+            msg = (
+                f'The installed version of {req.name} ({version_installed}) does not match',
+                f' the required version ({req.specifier}).',
+            )
+            raise Fail(msg)
+
+        logging.warning(  # noqa: LOG015
+            f'Installed {req.name} version ({version_installed}) matches the required version'
+            f' ({req.specifier}).'
         )
-        raise Fail(msg)
-
-    logging.warning(  # noqa: LOG015
-        f'Installed vtk version ({installed}) matches the required version ({required}).'
-    )

--- a/toxfile.py
+++ b/toxfile.py
@@ -1,15 +1,23 @@
 from __future__ import annotations  # noqa: D100
 
+import logging
 import os
 import re
 from typing import TYPE_CHECKING
 
 from packaging.version import Version
+from tox.execute.api import StdinSource
 from tox.plugin import impl
+from tox.tox_env.errors import Fail
+from tox_uv._run import UvVenvRunner
 
 if TYPE_CHECKING:
     from tox.config.sets import EnvConfigSet
     from tox.session.state import State
+    from tox.tox_env.api import ToxEnv
+    from tox.tox_env.python.package import WheelPackage
+    from tox.tox_env.python.pip.req_file import PythonDeps
+    from tox_uv._installer import UvInstaller
 
 
 @impl
@@ -39,3 +47,71 @@ def tox_add_env_config(env_conf: EnvConfigSet, state: State) -> None:  # noqa: A
 
         updated = {'PARALLEL': val}
         env_conf['set_env'].update(updated)
+
+
+@impl
+def tox_on_install(  # noqa: PLR0917
+    tox_env: ToxEnv,
+    arguments: list[WheelPackage] | PythonDeps,
+    section: str,  # noqa: ARG001
+    of_type: str,
+) -> None:
+    """Before installing:
+    * save environment `deps` to a constraints file
+    * apply constraints file during `install_package_deps` step.
+
+    This is needed since dependencies installed in subsequent steps (eg. `dependency-groups`) may
+    override the `deps` ones.
+    See https://github.com/pyvista/pyvista/issues/8635.
+
+    Mostly inspired by https://github.com/tox-dev/tox/issues/2386#issuecomment-1396105380
+    """  # noqa: D205
+    constraints_file = tox_env.env_dir / 'constraints.txt'
+
+    if of_type == 'deps' and isinstance(tox_env, UvVenvRunner):
+        constraints_file.write_text('\n'.join(arguments.lines()))
+
+    if of_type in 'package':
+        _arguments: list[WheelPackage] = arguments
+        constraints_file_dep = f'-c {constraints_file}'
+        for package in _arguments:
+            getattr(package, 'deps', []).append(constraints_file_dep)
+
+
+@impl
+def tox_before_run_commands(tox_env: ToxEnv) -> None:
+    """Check vtk deps.
+
+    When specifying the vtk version in the env name, check the installed vtk version with
+    a `freeze` command.
+    """
+    reg = re.compile(r'.*vtk_(\d+\.\d+\.\d+).*')
+    if not (m := re.match(reg, tox_env.name)):
+        return
+
+    required = m.group(1)
+
+    installer: UvInstaller = tox_env.installer
+    out = tox_env.execute(
+        installer.freeze_cmd(),
+        stdin=StdinSource.OFF,
+        show=False,
+        run_id='check_vtk_deps',
+    )
+    matches = re.findall(r'\nvtk==(\d+\.\d+\.\d+)\n', out.out, re.MULTILINE)
+    if len(matches) != 1:
+        msg = 'Could not find the installed vtk version in the output of `uv pip freeze`'
+        raise Fail(msg)
+
+    installed = matches[0]
+
+    if installed != required:
+        msg = (
+            f'The installed vtk version ({installed}) does not match the required version',
+            f' ({required}).',
+        )
+        raise Fail(msg)
+
+    logging.warning(  # noqa: LOG015
+        f'Installed vtk version ({installed}) matches the required version ({required}).'
+    )


### PR DESCRIPTION
### Overview

https://github.com/pyvista/pyvista/pull/8638 introduced checking the installed `vtk `version inside the `tox.ini` file to prevent silently testing against an unexpected vtk version.

However, IMHO, it resulted in a more complex `tox.ini` configuration with more `vtk_*` factors declaration, but also a more complex dependency-groups handling to deal with `pyvista-zstd` and `vtk` compatibility.

This PR moves the version enforcing and checking logic into the `toxfile.py` plugin, inspired by https://github.com/tox-dev/tox/issues/2386#issuecomment-1396105380

As a bonus 🌟 all declaration in the `deps` section are checked (ie. not only `vtk` but also `numpy` ...).

### Notes on `pyvista-zstd` and `vtk` compatibility
The special `test-zstd` dependency-group has been removed in this PR, meaning that we're testing `pyvista-zstd` with an 'unsupported' `vtk `version for some jobs in the Linux matrix. However, I guess that the `vtk>=9.4` constraint placed in `pyvista-zstd` was only chosen based on 'modern' vtk considerations and not due to features only available after 9.4.
This is further supported by CI jobs before https://github.com/pyvista/pyvista/pull/8638 that successfully passed tests involving `pyvista-zstd` with `vtk<9.4`.
Maybe @banesullivan could clarify the `vtk>=9.4` deps choice for `pyvista-zstd`.