### PR TITLE
Move i18n docs build out of the main docs pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -121,25 +121,8 @@ jobs:
             cat "$f"
           done
 
-      # Only build the translations for release builds since they take over 3 hours to build
-      - uses: actions/checkout@v6
-        if: startsWith(github.ref, 'refs/tags/v')
-        with:
-          repository: pyvista/pyvista-doc-translations
-          path: pyvista-doc-translations
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Build I18N Documentation
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          tox run -e docs-build -- mini18n-html
-          find doc/_build/mini18n-html -mindepth 1 -maxdepth 1 -type d -exec cp -rf {} doc/_build/html/ \;
-          rm -rf doc/_build/mini18n-html
-
-      - name: Dump Sphinx Build Warnings and Errors
-        if: always()
-        run: if [ -e doc/sphinx_warnings.txt ]; then cat doc/sphinx_warnings.txt; fi
+      # Translated (i18n) docs are built in a dedicated pipeline in
+      # pyvista/pyvista-doc-translations. See issue #8626.
 
       - name: Upload HTML documentation
         if: ${{ !cancelled() }}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -11,7 +11,6 @@ import sys
 from typing import TYPE_CHECKING
 import warnings
 
-from atsphinx.mini18n import get_template_dir
 from docutils.parsers.rst.directives.images import Image
 
 if TYPE_CHECKING:
@@ -96,7 +95,6 @@ sys.path.append(str(Path('./_ext').resolve()))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'atsphinx.mini18n',
     'enum_tools.autoenum',
     'jupyter_sphinx',
     'notfound.extension',
@@ -384,7 +382,7 @@ intersphinx_timeout = 5
 # class method or attribute and should be used with the production
 # documentation, but local builds and PR commits can get away without this as
 # it takes ~4x as long to generate the documentation.
-templates_path = ['_templates', get_template_dir()]
+templates_path = ['_templates']
 
 # Autosummary configuration
 autosummary_context = {
@@ -770,19 +768,14 @@ ogp_image = 'https://docs.pyvista.org/_static/pyvista_banner_small.png'
 # sphinx-sitemap options ---------------------------------------------------------
 html_baseurl = 'https://docs.pyvista.org/'
 
-# atsphinx.mini18n options ---------------------------------------------------------
 html_sidebars = {
     '**': [
         'navbar-logo.html',
         'icon-links.html',
-        'mini18n/snippets/select-lang.html',
         'search-button-field.html',
         'sbt-sidebar-nav.html',
     ],
 }
-mini18n_default_language = language
-mini18n_support_languages = ['en', 'ja']
-locale_dirs = ['../../pyvista-doc-translations/locale']
 
 
 class PlaceHolderImage(Image):

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -208,14 +208,13 @@ There is a `pyvista translation page`_ for pyvista (main) documentation.
 #. Click ``Request language`` and fill form.
 #. Wait acceptance by transifex pyvista translation maintainers.
 #. (After acceptance) Translate on transifex.
-#. We can host the translated document using `atsphinx-mini18n`_.
-#. Translation is backed up in `pyvista-doc-translations`_.
+#. Translations are stored in `pyvista-doc-translations`_, which also owns the
+   dedicated pipeline that builds and publishes the localized documentation.
 
 Details can be found here: https://help.transifex.com/en/
 
 .. _`pyvista translation page`: https://app.transifex.com/signin/?next=/tkoyama010/pyvista-doc/
 .. _Transifex: https://app.transifex.com/signin/?next=/home/
-.. _atsphinx-mini18n: https://atsphinx.github.io/mini18n/en/
 .. _`pyvista-doc-translations`: https://github.com/pyvista/pyvista-doc-translations
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,6 @@ test-zstd = [
 test-playwright = ['playwright<1.59.0', { include-group = 'test' }]
 
 docs = [
-  'atsphinx-mini18n==0.5.1',
   'cmcrameri==1.9.0',
   'cmocean==4.0.3',
   'colorcet==3.1.0',


### PR DESCRIPTION
The translated docs build was bundled into the core docs CI. On v0.48 it surfaced i18n-only Sphinx warnings that blocked the release docs deploy and forced a manual hotfix to Netlify. The translated build also takes about three hours, which is why it had been gated to release tags only, and that gating is what hid the regression until release time.

Strips the mini18n step (and ``atsphinx-mini18n``) from the core build. The translated build moves to a dedicated pipeline in ``pyvista/pyvista-doc-translations`` (companion PR: pyvista/pyvista-doc-translations#330), which gives it its own release cadence and dedicated maintainer attention.

Resolves #8626

Specifics:
- Drop ``atsphinx.mini18n`` from ``doc/source/conf.py``: extension entry, ``get_template_dir()`` import and use, ``mini18n_*`` settings, the language-selector sidebar entry, and ``locale_dirs``.
- Drop ``atsphinx-mini18n==0.5.1`` from the ``docs`` dependency group.
- Remove the conditional ``pyvista-doc-translations`` checkout and ``mini18n-html`` build steps from ``.github/workflows/docs.yml``.
- Keep ``gettext_additional_targets`` so ``.pot`` extraction still works on demand.
- Update the ``Translating`` section in ``index.rst`` to point at the new owner.

Production deployment of the translated artifact (Netlify subpath under ``docs.pyvista.org/ja/`` vs. dedicated subdomain) still needs to be wired up with the translation maintainers; tracked as a follow-up to the companion PR.