### PR TITLE
fix: correct origin calculation in ImageData's extract_subset when rebase_coordinates=True

### DIFF
--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -503,7 +503,7 @@ class ImageDataFilters(DataSetFilters):
         if rebase_coordinates:
             # Adjust for the confusing issue with the extents
             #   see https://gitlab.kitware.com/vtk/vtk/-/issues/17938
-            result.origin = result.bounds[::2]
+            result.origin = result.points[0]
             result.offset = (0, 0, 0)
         return result
 

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -3112,9 +3112,11 @@ def test_extract_subset(uniform, rebase_coordinates):
     offset = (1, 2, 3)
     dict_ = {'foo': 'bar'}
     origin = (1.1, 2.2, 3.3)
+    direction_matrix = pv.Transform().rotate_x(30.0, point=(3.0, 4.0, 5.0)).matrix[:3, :3]
     uniform.user_dict = dict_
     uniform.offset = offset
     uniform.origin = origin
+    uniform.direction_matrix = direction_matrix
 
     new_offset = (2, 4, 6)
     new_dims = 4, 3, 2
@@ -3131,7 +3133,11 @@ def test_extract_subset(uniform, rebase_coordinates):
         # Test that we fix the confusing issue from extents in
         #   https://gitlab.kitware.com/vtk/vtk/-/issues/17938
         assert voi.origin != origin
-        assert voi.origin == voi.bounds[::2]
+        assert np.allclose(voi.origin, voi.points[0])
+        relative_offset = tuple(new_offset[i] - offset[i] for i in range(3))
+        dims = uniform.dimensions
+        start_idx = np.arange(np.prod(dims)).reshape(dims, order='F')[relative_offset]
+        assert np.allclose(voi.points[0], uniform.points[start_idx])
         assert voi.offset != new_offset
         assert voi.offset == (0, 0, 0)
     else:


### PR DESCRIPTION
### Overview

This pull request fixes a coordinate misalignment bug in ImageData.extract_subset that occurs when rebase_coordinates=True on a dataset with a non-identity direction_matrix.

resolves #8659

### Details

The core issue was using result.bounds[::2] to recalculate the new origin. For rotated datasets, the axis-aligned bounding box (AABB) does not correctly represent the world-space location of the first voxel (index 0,0,0). By using result.points[0] instead, the new origin correctly accounts for the dataset's orientation, spacing, and original origin.

Updated test_extract_subset in tests/core/test_dataset_filters.py to include a rotated direction_matrix. Improved assertion logic to verify that the rebased subset's origin matches the expected physical coordinate in the source grid, determined by mapping the relative offset to the original points array.