### PR TITLE
fix(voxelize_binary_mask): consider offset and rotation center of reference_volume

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -8069,7 +8069,9 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
             _validation.check_instance(reference_volume, pv.ImageData, name='reference volume')
             # The image stencil filters do not support orientation, so we apply the
             # inverse direction matrix to "remove" orientation from the polydata
-            poly_ijk = surface.transform(reference_volume.direction_matrix.T, inplace=False)
+            poly_ijk = surface.rotate(
+                reference_volume.direction_matrix.T, point=reference_volume.origin, inplace=False
+            )
             poly_ijk = _preprocess_polydata(poly_ijk)
         else:
             # Compute reference volume geometry

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -8133,7 +8133,7 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
         # Init output structure. The image stencil filters do not support
         # orientation, so we do not set the direction matrix
         binary_mask = pv.ImageData()
-        binary_mask.dimensions = reference_volume.dimensions
+        binary_mask.extent = reference_volume.extent
         binary_mask.spacing = reference_volume.spacing
         binary_mask.origin = reference_volume.origin
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -7818,7 +7818,7 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
 
         reference_volume : ImageData, optional
             Volume to use as a reference. The output will have the same ``dimensions``,
-            ``origin``, ``spacing``, and ``direction_matrix`` as the reference.
+            ``origin``, ``spacing``, ``offset``, and ``direction_matrix`` as the reference.
 
         dimensions : VectorLike[int], optional
             Dimensions of the generated mask image. Set this value to control the
@@ -8268,7 +8268,7 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
 
         reference_volume : ImageData, optional
             Volume to use as a reference. The output will have the same ``dimensions``,
-            ``origin``, and ``spacing`` as the reference.
+            ``origin``, ``spacing``, ``offset``, and ``direction_matrix`` as the reference.
 
         dimensions : VectorLike[int], optional
             Dimensions of the generated rectilinear grid. Set this value to control the
@@ -8434,7 +8434,7 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
         ----------
         reference_volume : ImageData, optional
             Volume to use as a reference. The output will have the same ``dimensions``,
-            and ``spacing`` as the reference.
+            ``origin``, ``spacing``, ``offset``, and ``direction_matrix`` as the reference.
 
         dimensions : VectorLike[int], optional
             Dimensions of the voxelized mesh. Set this value to control the

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -4541,6 +4541,7 @@ def oriented_image():
     image = pv.ImageData()
     image.spacing = (1.1, 1.2, 1.3)
     image.dimensions = (10, 11, 12)
+    image.offset = (4, 5, 6)
     image.origin = (3.1, 2.1, 1.1)
     image.direction_matrix = pv.Transform().rotate_vector((4, 5, 6), 30).matrix[:3, :3]
     image['scalars'] = np.ones((image.n_points,))

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -4541,6 +4541,7 @@ def oriented_image():
     image = pv.ImageData()
     image.spacing = (1.1, 1.2, 1.3)
     image.dimensions = (10, 11, 12)
+    image.origin = (3.1, 2.1, 1.1)
     image.direction_matrix = pv.Transform().rotate_vector((4, 5, 6), 30).matrix[:3, :3]
     image['scalars'] = np.ones((image.n_points,))
     return image


### PR DESCRIPTION
### Overview

When voxelize_binary_mask handles an oriented reference_volume, it currently applies the inverse direction matrix to the polydata using a global transform. This is incorrect if the reference_volume has a non-zero origin, as the rotation should be performed relative to the volume's origin.

resolves #8662

### Details

Changed surface.transform(matrix) to surface.rotate(matrix, point=origin). This correctly aligns the polydata by using the volume's origin as the pivot point for rotation.

In tests/core/test_dataset_filters.py, I explicitly set a non-zero origin when setting the oriented_image.
