### PR TITLE
Fix package name normalization in CI checks

### DIFF
--- a/toxfile.py
+++ b/toxfile.py
@@ -13,6 +13,8 @@ from tox.tox_env.errors import Fail
 from tox_uv._run import UvVenvRunner
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from tox.config.sets import EnvConfigSet
     from tox.session.state import State
     from tox.tox_env.api import ToxEnv
@@ -82,6 +84,22 @@ def tox_on_install(  # noqa: PLR0917
             getattr(package, 'deps', []).append(constraints_file_dep)
 
 
+def _normalize_package_name(name: str) -> str:
+    """Taken from https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization."""
+    return re.sub(r'[-_.]+', '-', name).lower()
+
+
+def _get_freezed_requirements(lines: list[str]) -> Generator[tuple[str, Version], None, None]:
+    """From a freeze output, get the list of installed requirements as (name, version) tuples.
+
+    Note that the name is normalized per packaging specifications (see https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization).
+    """
+    for l in lines:
+        req = Requirement(l)
+        if (m := re.match(r'(.*)==(\S+)', str(req.specifier))) is not None:
+            yield _normalize_package_name(req.name), Version(m.group(2))
+
+
 @impl
 def tox_before_run_commands(tox_env: ToxEnv) -> None:
     """Check that deps declared in the constraints_file (ie. during the `deps` step above)
@@ -103,21 +121,16 @@ def tox_before_run_commands(tox_env: ToxEnv) -> None:
     # Parse installed deps from the freeze output.
     # Relies on the fact the the freeze command outputs lines in the
     # form of `package==version` (eg. `vtk==9.2.2`)
-    installed = out.out.splitlines()
-
-    installed = [(Requirement(r).name, Requirement(r).specifier) for r in installed]
-    installed = [
-        (r[0], Version(m.group(2)))
-        for r in installed
-        if (m := re.match(r'(.*)==(\S+)', str(r[1]))) is not None
-    ]
+    installed = list(_get_freezed_requirements(out.out.splitlines()))
 
     # Check that the installed requirements match the constraints file ones
     for req in requirements:
         # Get the installed requirement matching the current one
-        installed_req = next((r for r in installed if r[0] == req.name), None)
+        name = _normalize_package_name(req.name)
+
+        installed_req = next((r for r in installed if r[0] == name), None)
         if not installed_req:
-            msg = f'The required package {req.name} is not installed in the environment.'
+            msg = f'The required package {name} is not installed in the environment.'
             raise Fail(msg)
 
         # Check that the installed requirement version matches the specifier in
@@ -130,6 +143,6 @@ def tox_before_run_commands(tox_env: ToxEnv) -> None:
             raise Fail(msg)
 
         logging.warning(  # noqa: LOG015
-            f'Installed {req.name} version ({version_installed}) matches the required version'
+            f'Installed {name} version ({version_installed}) matches the required version'
             f' ({req.specifier}).'
         )


### PR DESCRIPTION
### Overview

When checking package înstallation in the `tox` plugin as introduced per #8641 , the requirement name was not normalized, meaning that requirements specified as `PyQt6-Qt6` in the `deps` section were not found when inspecting the freeze output (which normalizes it to `pyqt6-qt6`).

This was found during sheduled integration tests https://github.com/pyvista/pyvista/issues/8657#issuecomment-4427951219

This PR fixes that.

Closes https://github.com/pyvista/pyvista/issues/8657