### PR TITLE
security: refuse pickle from remote URIs in pv.read

### DIFF
--- a/pyvista/core/utilities/fileio.py
+++ b/pyvista/core/utilities/fileio.py
@@ -398,8 +398,16 @@ def _read_dispatch(  # noqa: PLR0911
     # Handle remote URIs before Path coercion
     if isinstance(filename, str) and has_scheme(filename):
         uri_ext = get_ext(urlparse(filename).path)
+        if uri_ext.lower() in PICKLE_EXT:
+            msg = (
+                f'Refusing to load pickle from remote URI {filename!r}. '
+                f'Loading a pickle from an untrusted source allows arbitrary '
+                f'code execution. Download the file manually after verifying '
+                f'its origin, then pass the local path to `pyvista.read_pickle`.'
+            )
+            raise ValueError(msg)
         # If a custom reader is registered for this extension, try it
-        # with the raw URI first — the reader may handle cloud paths
+        # with the raw URI first, the reader may handle cloud paths
         # natively (e.g. zarr stores on S3). If it fails, fall back to
         # downloading the file and retrying with a local path.
         ext_handler = _get_ext_handler(uri_ext)

--- a/tests/core/test_reader_registry.py
+++ b/tests/core/test_reader_registry.py
@@ -271,6 +271,31 @@ def test_uri_downloads_then_reads_builtin_ext(tmp_path):
     assert result.n_points == mesh.n_points
 
 
+@pytest.mark.parametrize(
+    'uri',
+    [
+        'https://example.com/evil.pkl',
+        'http://example.com/evil.pickle',
+        'https://example.com/EVIL.PKL',
+        's3://bucket/evil.pkl',
+    ],
+)
+def test_remote_pickle_uri_refused(uri):
+    """Remote .pkl/.pickle URIs must be refused before download to prevent RCE."""
+    downloaded = False
+
+    def fake_retrieve(*_args, **_kwargs):
+        nonlocal downloaded
+        downloaded = True
+        return '/tmp/should-not-be-used'
+
+    with patch('pooch.retrieve', side_effect=fake_retrieve):
+        with pytest.raises(ValueError, match='Refusing to load pickle from remote URI'):
+            pv.read(uri)
+
+    assert downloaded is False, 'remote pickle must be refused before any download'
+
+
 def test_s3_without_fsspec_raises():
     """s3:// URI without fsspec raises ImportError with install hint."""
     with patch.dict('sys.modules', {'fsspec': None}):


### PR DESCRIPTION
Refuse pickle from remote URIs in `pv.read`

`pv.read('https://example.com/x.pkl')` would pooch-download then `pickle.load` the file. A user pasting a URL does not expect arbitrary code execution. Refuse `.pkl` and `.pickle` URIs in `_read_dispatch` before any download, and point the error at `pyvista.read_pickle` for explicitly trusted local paths.

Local pickle load is unchanged (for now... if were up to me would hard deprecate pkl support 🦹🏻 )