### PR TITLE
integration-mne: install ipykernel and register python3 kernelspec

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -160,6 +160,7 @@ deps =
     mne: sphinx-gallery
     mne: nbformat
     mne: nbclient
+    mne: ipykernel
     mne: imageio
     mne: imageio-ffmpeg
     mne,pyvistaqt: PyQt6-Qt6!=6.6.0,!=6.7.0
@@ -215,6 +216,7 @@ commands_pre =
     mne: bash -c "cd {env:MNE_HOME} && ./tools/get_testing_version.sh"
     mne: bash -c "cd {env:MNE_HOME} && ./tools/github_actions_download.sh"
     mne: python -c "import pyvista; assert not pyvista.OFF_SCREEN, f'{pyvista.OFF_SCREEN=} should be False'"
+    mne: python -m ipykernel install --user --name python3
 
     # PYVISTAQT SETUP
     pyvistaqt: git clone https://github.com/pyvista/pyvistaqt.git {env:PYVISTAQT_HOME} --single-branch


### PR DESCRIPTION
Since #8631 made `trame-pyvista` a hard dependency, the `pinned` group now pulls `trame` into the integration-mne env. MNE's notebook tests stop skipping on missing trame, so they run and fail with `jupyter_client.kernelspec.NoSuchKernel: No such kernel named python3` because that env registers no Jupyter kernel.

Install `ipykernel` in the integration-mne env and register the `python3` kernelspec so the notebook tests can run.
