### PR TITLE
linkcheck: post failures to a single issue instead of opening new ones

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -24,7 +24,11 @@ jobs:
     runs-on: "ubuntu-22.04"
 
     permissions:
-      issues: write # required for peter-evans/create-issue-from-file
+      issues: write # required to open/comment the linkcheck failure issue
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
 
     steps:
       - uses: actions/checkout@v6
@@ -32,11 +36,17 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: "Compute weekly cache key"
+        id: cachekey
+        # Rotate the cache weekly so a stale entry cannot pin the job to a
+        # permanent failure even if a transient error is somehow cached.
+        run: echo "key=cache-lychee-$(date -u +%Y-%U)" >> "$GITHUB_OUTPUT"
+
       - name: "Cache Lychee"
         uses: actions/cache@v5
         with:
           path: .lycheecache
-          key: cache-lychee
+          key: ${{ steps.cachekey.outputs.key }}
 
       - name: "Run Lychee"
         id: lychee
@@ -47,13 +57,33 @@ jobs:
 
       - name: "Report Failure"
         if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710
-        with:
-          title: "chore: linkcheck failure"
-          content-filepath: ./lychee/out.md
-          labels: |
-            documentation
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Ensure the dedup label exists (idempotent).
+          gh label create linkcheck-failure \
+            --color cbb230 \
+            --description "Tracks the recurring linkcheck failure" \
+            --force || true
+
+          body=$(cat <<EOF
+          See [the linkcheck run](${RUN_URL}) for the full output.
+
+          $(cat ./lychee/out.md)
+          EOF
+          )
+
+          # Post to the single open issue, like the integration tests do.
+          existing=$(gh issue list --label "linkcheck-failure" --state open --limit 1 --json number --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "chore: linkcheck failure" --label "linkcheck-failure" --body "$body"
+          fi
 
       - name: "Exit Action"
         if: steps.lychee.outputs.exit_code != 0
-        run: exit {{ steps.lychee.outputs.exit_code }}
+        env:
+          LYCHEE_EXIT_CODE: ${{ steps.lychee.outputs.exit_code }}
+        run: exit "$LYCHEE_EXIT_CODE"

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -2,7 +2,6 @@
 #   - https://github.com/actions/cache
 #   - https://github.com/actions/checkout
 #   - https://github.com/lycheeverse/lychee-action
-#   - https://github.com/peter-evans/create-issue-from-file
 
 name: LinkCheck - All files 🔗
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,9 +1,14 @@
 accept = [
   200, # Link is OK
   403, # Skip domains known to return 403 Forbidden to bots
+  418, # Skip domains (e.g. IEEE via doi.org) returning "I'm a teapot" to bots
   429, # Network error: Too Many Requests
 ]
 cache = true
+# Do not persist transient failures. The actions/cache key is static, so a
+# cached error would otherwise be re-served every run and the job never
+# recovers (root cause of the perpetual linkcheck issues).
+cache_exclude_status = ['400..=429', '500..=599']
 exclude = [
   'file:///home/*',
   'http://861c873f6352:8888/*',
@@ -14,5 +19,8 @@ exclude = [
 exclude_all_private = true # exclude 'localhost', '127.0.0.1', etc.
 exclude_path = ['pyvista/core/utilities/docs.py']
 extensions = ['md', 'py', 'rst', 'txt']
+# Retry transient network failures (e.g. flaky *.pyvista.org) before erroring.
+max_retries = 4
+retry_wait_time = 3
 user_agent = 'curl/7.83.1'
 verbose = 'info'


### PR DESCRIPTION
The weekly linkcheck job opened a new issue on every failing run, so duplicates piled up (#8658, #8661, #8679). It now comments on the single open `linkcheck-failure` issue and only creates one when none exists, matching the integration-test workflow.

- The cache key now rotates weekly. The static `cache-lychee` key re-served cached transient errors (e.g. `*.pyvista.org` connection failures) on every run, so the job never recovered on its own.
- `lychee.toml`: transient `4xx`/`5xx` responses are no longer cached, network failures are retried, and `418` is accepted (the sole real error in #8679, from IEEE via doi.org).

Closes #8658
Closes #8661
Closes #8679