### PR TITLE
Make identical accessor re-registration a silent no-op

### DIFF
--- a/pyvista/core/utilities/accessor_registry.py
+++ b/pyvista/core/utilities/accessor_registry.py
@@ -432,6 +432,20 @@ def _attach_accessor(
     """
     accessor_owner = _find_accessor_on_mro(target_cls, name)
     if accessor_owner is not None:
+        existing = accessor_owner.__dict__.get(name)
+        if (
+            accessor_owner is target_cls
+            and isinstance(existing, _CachedAccessor)
+            and existing._accessor_cls is accessor_cls
+        ):
+            # Idempotent re-registration: the exact same accessor class is
+            # already bound directly on this target under this name. This
+            # happens when a module that registers an accessor is imported
+            # twice (e.g. ``pytest --cov`` re-executes it). It is a true
+            # no-op, not a plugin collision, so do not warn or re-bind --
+            # warning here would be fatal for downstream packages running
+            # under ``filterwarnings=error``.
+            return
         # Accessor-vs-accessor collision — warn and replace (pandas style).
         if accessor_owner is target_cls:
             location = target_cls.__qualname__

--- a/tests/core/test_accessor_registry.py
+++ b/tests/core/test_accessor_registry.py
@@ -223,6 +223,33 @@ def test_accessor_vs_accessor_collision_warns_and_replaces():
     assert pv.Sphere().clashing.who() == 'second'
 
 
+def test_re_register_same_class_is_silent_noop(recwarn):
+    """Re-registering the identical accessor class on the same target is a
+    true no-op and must not warn.
+
+    Module re-import (e.g. ``pytest --cov`` re-executing a plugin module)
+    re-runs the registration call with the same class object. Downstream
+    packages run under ``filterwarnings=error``, so a warning here would
+    be fatal and force them into a manual de-dup workaround instead of
+    just decorating their class.
+    """
+
+    class SameAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+        def who(self):
+            return 'same'
+
+    pv.register_dataset_accessor('reimport_noop', pv.PolyData)(SameAccessor)
+    pv.register_dataset_accessor('reimport_noop', pv.PolyData)(SameAccessor)
+
+    assert [w for w in recwarn.list if issubclass(w.category, UserWarning)] == []
+    assert pv.Sphere().reimport_noop.who() == 'same'
+    records = [r for r in pv.registered_accessors() if r.name == 'reimport_noop']
+    assert len(records) == 1
+
+
 def test_inherited_accessor_collision_warns():
     """Registering on a subclass when an ancestor already owns the name warns."""
 


### PR DESCRIPTION
`register_dataset_accessor` warned on every accessor-vs-accessor collision, including re-registering the exact same accessor class on the same target. Module re-import triggers that case: `pytest --cov` and any double-import re-execute a plugin's registration module with the same class object. The warning is spurious there since nothing actually changes.

Downstream packages run under `filterwarnings=error`, so that spurious `UserWarning` is fatal and forces them into a manual de-dup workaround instead of plain decorator usage. This treats exact re-registration (same accessor class already bound directly on the same target under the same name) as a true no-op: return early, no warning, no re-bind. Genuine collisions (different class, or an inherited accessor on an ancestor) still warn and replace as before.