### PR TITLE
ci: move non-GPU Linux jobs off self-hosted runners

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         project: ["mne", "trame", "pyvistaqt", "geovista", "playwright"]
-    runs-on: ubuntu-22.04-self-hosted
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash -l {0}
@@ -59,7 +59,7 @@ jobs:
           persist-credentials: false
 
       - uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0
-        if: ${{matrix.project == 'pyvistaqt' || matrix.project == 'geovista' || matrix.project == 'playwright'}}
+        if: ${{matrix.project == 'pyvistaqt' || matrix.project == 'geovista' || matrix.project == 'playwright' || matrix.project == 'trame'}}
         with:
           qt: ${{matrix.project == 'pyvistaqt'}}
           pyvista: ${{matrix.project != 'pyvistaqt'}}

--- a/.github/workflows/intersphinx-update-pull-request.yml
+++ b/.github/workflows/intersphinx-update-pull-request.yml
@@ -14,7 +14,7 @@ jobs:
     # This job can create issues/PRs/comments, so
     #   only run on the head `pyvista/pyvista` repo
     if: github.repository_owner == 'pyvista'
-    runs-on: ubuntu-22.04-self-hosted
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -72,17 +72,13 @@ jobs:
     with:
       runs-on: "ubuntu-22.04"
 
-  # For self-hosted runners, we need to cache each runner separately
+  # The macOS self-hosted runner needs its own cache (GitHub-hosted runners
+  # share cache-github-hosted across Linux and Windows).
   cache-macOS-self-hosted:
     name: Cache pyvista/data
     uses: ./.github/workflows/cache-pyvista-data.yml
     with:
       runs-on: "macos-15-self-hosted"
-  cache-ubuntu-self-hosted:
-    name: Cache pyvista/data
-    uses: ./.github/workflows/cache-pyvista-data.yml
-    with:
-      runs-on: "ubuntu-22.04-self-hosted"
 
   macOS:
     name: ${{ matrix.name }}
@@ -161,8 +157,8 @@ jobs:
 
   Linux:
     name: Linux Unit Testing (${{ matrix.python-version }}, ${{ matrix.vtk-version }}, ${{ matrix.numpy-version }})
-    runs-on: ${{ matrix.runner-labels }}
-    needs: cache-ubuntu-self-hosted
+    runs-on: ubuntu-22.04
+    needs: cache-github-hosted
     strategy:
       fail-fast: false
 
@@ -173,31 +169,24 @@ jobs:
           - python-version: "3.10"
             vtk-version: "9.2.2"
             numpy-version: "1.26"
-            runner-labels: "ubuntu-22.04-self-hosted"
           - python-version: "3.11"
             vtk-version: "9.2.6"
             numpy-version: "latest"
-            runner-labels: "ubuntu-22.04-self-hosted"
           - python-version: "3.12"
             vtk-version: "9.3.1"
             numpy-version: "latest"
-            runner-labels: "ubuntu-22.04-self-hosted"
           - python-version: "3.13"
             vtk-version: "9.4.2"
             numpy-version: "latest"
-            runner-labels: "ubuntu-22.04-self-hosted"
           - python-version: "3.13"
             vtk-version: "9.5.2"
             numpy-version: "latest"
-            runner-labels: "ubuntu-22.04-self-hosted"
           - python-version: "3.14"
             vtk-version: "latest"
             numpy-version: "latest"
-            runner-labels: "ubuntu-22.04-self-hosted"
           - python-version: "3.14"
             vtk-version: "latest"
             numpy-version: "nightly"
-            runner-labels: "ubuntu-22.04-self-hosted"
 
     env:
       TOX_FACTOR: py${{matrix.python-version}}-numpy_${{matrix.numpy-version}}-vtk_${{matrix.vtk-version}}
@@ -215,14 +204,14 @@ jobs:
 
       - uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05
         with:
-          packages: xvfb
+          packages: xvfb libgl1 libglx-mesa0 libosmesa6
           version: 3.0
 
       - name: Restore pyvista/data cache
         uses: actions/cache/restore@v5
         with:
           path: ${{ env.CACHE_FOLDER_NAME }}
-          key: ${{ needs.cache-ubuntu-self-hosted.outputs.key }}
+          key: ${{ needs.cache-github-hosted.outputs.key }}
           enableCrossOsArchive: true
 
       - name: Install tox-uv
@@ -275,8 +264,8 @@ jobs:
     name: Linux VTK Dev Testing
     permissions:
       contents: read
-    runs-on: ubuntu-22.04-self-hosted
-    needs: cache-ubuntu-self-hosted
+    runs-on: ubuntu-22.04
+    needs: cache-github-hosted
     strategy:
       fail-fast: false
       matrix:
@@ -295,14 +284,14 @@ jobs:
 
       - uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05
         with:
-          packages: xvfb
+          packages: xvfb libgl1 libglx-mesa0 libosmesa6
           version: 3.0
 
       - name: Restore pyvista/data cache
         uses: actions/cache/restore@v5
         with:
           path: ${{ env.CACHE_FOLDER_NAME }}
-          key: ${{ needs.cache-ubuntu-self-hosted.outputs.key }}
+          key: ${{ needs.cache-github-hosted.outputs.key }}
           enableCrossOsArchive: true
 
       - name: Install tox-uv

--- a/tox.ini
+++ b/tox.ini
@@ -160,6 +160,7 @@ deps =
     mne: sphinx-gallery
     mne: nbformat
     mne: nbclient
+    mne: ipykernel
     mne: imageio
     mne: imageio-ffmpeg
     mne,pyvistaqt: PyQt6-Qt6!=6.6.0,!=6.7.0
@@ -209,7 +210,13 @@ commands_pre =
 
     # MNE-PYTHON SETUP
     mne: git clone --depth=1 https://github.com/mne-tools/mne-python.git {env:MNE_HOME} --branch main --single-branch
-    mne: bash -c 'if [ "$GITHUB_ACTIONS" = "true" ]; then {env:MNE_HOME}{/}tools{/}setup_xvfb.sh ; fi'
+    # Guard on the pidfile setup_xvfb.sh creates so a pytest retry does not
+    # re-run the script: a second `Xvfb :99` fails under its `bash -ef`,
+    # which would mask the real test outcome from the first attempt.
+    mne: bash -c 'if [ "$GITHUB_ACTIONS" = "true" ] && [ ! -f /tmp/custom_xvfb_99.pid ]; then {env:MNE_HOME}{/}tools{/}setup_xvfb.sh ; fi'
+    # The notebook viz tests need a Jupyter kernel named "python3"; the
+    # self-hosted runner had one ambiently, GitHub-hosted runners do not.
+    mne: python -m ipykernel install --sys-prefix --name python3 --display-name python3
     mne: uv pip install git+https://github.com/pyvista/pyvistaqt.git
     mne: uv pip install {env:MNE_HOME}
     mne: bash -c "cd {env:MNE_HOME} && ./tools/get_testing_version.sh"


### PR DESCRIPTION
Unit/integration/intersphinx Linux jobs ran on the self-hosted runner pool but use software GL (`xvfb`), so the self-hosted GPU bought them nothing while they competed for limited self-hosted capacity. PR turnaround was dominated by self-hosted queue contention. This moves them to GitHub-hosted `ubuntu-22.04`.

Moved: `testing-and-deployment.yml` `Linux` matrix + `VTK-dev`, `integration-tests.yml` `Integration`, `intersphinx-update-pull-request.yml`. Still self-hosted: the GPU docs build (`docs.yml`), `docstringcheck` (`style-docstring.yml`), and the macOS jobs.

Three changes a label swap alone would miss, each a dependency the self-hosted box supplied ambiently:

- The Linux/VTK-dev jobs relied on the self-hosted box's system OpenGL. Added explicit `libgl1 libglx-mesa0 libosmesa6` so they no longer depend on the runner image's GL.
- `trame` had no headless display of its own and only worked via the self-hosted persistent `Xvfb :99`. Added it to `setup-headless-display-action` (software Mesa + offscreen), matching how `geovista`/`playwright` already run. `mne` stays excluded since it provisions its own `Xvfb :99`.
- The `mne` notebook viz tests need a Jupyter kernel named `python3`, which the self-hosted runner had registered ambiently. Added `ipykernel` and register the kernelspec in the mne tox env. This also subsumes #8678. While tracking it down, the `setup_xvfb.sh` call was masking the real `NoSuchKernel` failure: a pytest retry re-ran the script, whose second `Xvfb :99` aborts under `bash -ef`. Guarded it on the pidfile so retries no longer hide the underlying test outcome.

Cache: `Linux`/`VTK-dev` now share the existing `cache-github-hosted` job; the dead `cache-ubuntu-self-hosted` job is removed.
