### PR TITLE
Install MNE editable in integration tests so its test packages import

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -218,7 +218,12 @@ commands_pre =
     # self-hosted runner had one ambiently, GitHub-hosted runners do not.
     mne: python -m ipykernel install --sys-prefix --name python3 --display-name python3
     mne: uv pip install git+https://github.com/pyvista/pyvistaqt.git
-    mne: uv pip install {env:MNE_HOME}
+    # Editable install so MNE's `*/tests` packages stay importable: MNE's
+    # hatch build excludes `/mne/**/tests` from the wheel, but the notebook
+    # viz tests import `mne.viz.backends.tests` from inside a Jupyter kernel
+    # whose cwd is the pyvista tree, so it resolves the installed package
+    # rather than the cloned source. Editable keeps the source tree on path.
+    mne: uv pip install -e {env:MNE_HOME}
     mne: bash -c "cd {env:MNE_HOME} && ./tools/get_testing_version.sh"
     mne: bash -c "cd {env:MNE_HOME} && ./tools/github_actions_download.sh"
     mne: python -c "import pyvista; assert not pyvista.OFF_SCREEN, f'{pyvista.OFF_SCREEN=} should be False'"


### PR DESCRIPTION
The MNE notebook viz integration test (`test_widget_abstraction_notebook`) began failing on `main` and most branches with `ModuleNotFoundError: No module named 'mne.viz.backends.tests'`. MNE's hatch build excludes `/mne/**/tests` from the wheel, so the installed package has no `tests` subpackages. The notebook test imports `mne.viz.backends.tests` from a Jupyter kernel whose cwd is the pyvista tree, so it resolves the installed package rather than the cloned MNE source. The self-hosted runner masked this with an ambient `python3` kernel; #8683 moved these jobs to GitHub-hosted runners, which bind the kernel to the tox venv site-packages and exposed the gap.

Installing MNE editable keeps the cloned source tree (including its `tests` packages) on the import path regardless of kernel cwd, matching how MNE installs itself for development.

Failing run: https://github.com/pyvista/pyvista/actions/runs/26015704408/job/76465196548

Closes #8675