### PR TITLE
ci: move docs and docstring jobs off self-hosted GPU runners

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,11 +48,11 @@ jobs:
     uses: ./.github/workflows/cache-pyvista-data.yml
     with:
       # Runner should match the actual runner used by the build job
-      runs-on: "ubuntu-24.04-self-hosted-gpu"
+      runs-on: "ubuntu-22.04"
 
   doc:
     name: Build Documentation
-    runs-on: ubuntu-24.04-self-hosted-gpu
+    runs-on: ubuntu-22.04
     needs: cache-pyvista-data
     env:
       PARALLEL: "-j2" # Public GitHub runners have 2 real cores
@@ -68,15 +68,9 @@ jobs:
           python-version: 3.14
           cache: "pip"
 
-      - name: Set environment for self-hosted
-        if: runner.environment == 'self-hosted'
-        run: |
-          echo "PARALLEL=-j8" >> $GITHUB_ENV
-
       - uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05
-        if: runner.environment != 'self-hosted'
         with:
-          packages: libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime
+          packages: libosmesa6-dev libgl1-mesa-dev python3-tk pandoc git-restore-mtime xvfb
           version: 3.0
 
       - name: Restore pyvista/data cache
@@ -90,7 +84,7 @@ jobs:
         run: pip install tox-uv
 
       - name: Build Documentation
-        run: timeout 3600 tox run -e docs-build
+        run: timeout 3600 xvfb-run -a tox run -e docs-build
 
       # Build a development wheel and bundle a PEP 503 simple index into the
       # docs output. Once the docs deploy to dev.pyvista.org, users can

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: cache-pyvista-data
     env:
-      PARALLEL: "-j2" # Public GitHub runners have 2 real cores
+      PARALLEL: "-j4" # GitHub-hosted Linux runners have 4 vCPUs
       TOX_COLORED: "yes"
       PYVISTA_VTK_DATA: ${{ github.workspace }}/pyvista-data
     steps:
@@ -84,7 +84,7 @@ jobs:
         run: pip install tox-uv
 
       - name: Build Documentation
-        run: timeout 3600 xvfb-run -a tox run -e docs-build
+        run: timeout 7200 xvfb-run -a tox run -e docs-build
 
       # Build a development wheel and bundle a PEP 503 simple index into the
       # docs output. Once the docs deploy to dev.pyvista.org, users can

--- a/.github/workflows/style-docstring.yml
+++ b/.github/workflows/style-docstring.yml
@@ -16,14 +16,14 @@ jobs:
     uses: ./.github/workflows/cache-pyvista-data.yml
     with:
       # Runner should match the actual runner used by the docstring job
-      runs-on: "ubuntu-24.04-self-hosted-gpu"
+      runs-on: "ubuntu-22.04"
 
   docstringcheck:
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-24.04-self-hosted-gpu
+          - os: ubuntu-22.04
             python-version: "3.14" # Should be the latest version supported
           - os: windows-latest
             python-version: "3.10" # Should be the oldest version supported
@@ -50,6 +50,12 @@ jobs:
         if: runner.os == 'Windows'
         uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0
 
+      - uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05
+        if: runner.os == 'Linux'
+        with:
+          packages: xvfb libgl1 libglx-mesa0 libosmesa6
+          version: 3.0
+
       - name: Restore pyvista/data cache
         uses: actions/cache/restore@v5
         with:
@@ -60,12 +66,17 @@ jobs:
       - name: Install tox-uv
         run: pip install tox-uv
 
-      - name: Test Package Docstrings
+      - name: Test Package Docstrings (Linux)
+        if: runner.os == 'Linux'
+        run: xvfb-run tox run -f doctest
+
+      - name: Test Package Docstrings (Windows)
+        if: runner.os == 'Windows'
         run: tox run -f doctest
 
   vale:
     name: Vale
-    runs-on: ubuntu-22.04 # does not support self-hosted (yet)
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
         with:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -73,6 +73,11 @@ warnings.filterwarnings(
     message='Matplotlib is currently using agg, which is a non-GUI backend, '
     'so cannot show the figure.',
 )
+warnings.filterwarnings(
+    'ignore',
+    category=UserWarning,
+    message='FigureCanvasAgg is non-interactive, and thus cannot be shown',
+)
 
 # Prevent deprecated features from being used in examples
 warnings.filterwarnings(
@@ -454,6 +459,13 @@ def _filter_sphinx_gallery_warnings():
         'ignore',
         message='Call to deprecated method GetData',  # emitted by trame-vtk
         category=DeprecationWarning,
+    )
+    # Matplotlib >=3.10 emits this when plt.show() runs under a non-interactive
+    # backend (the GitHub-hosted runner picks Agg even with xvfb).
+    warnings.filterwarnings(
+        'ignore',
+        message='FigureCanvasAgg is non-interactive, and thus cannot be shown',
+        category=UserWarning,
     )
 
     # Treat all remaining warnings as errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,6 @@ test-playwright = ['playwright<1.59.0', { include-group = 'test' }]
 docs = [
   # vtk 9.6.2 wheels on PyPI ship a broken vtkOutlineFilter (SetGenerateFaces
   # missing); see #8700. Drop this pin once the upstream regression is fixed.
-  'vtk<9.6.2',
   'cmcrameri==1.9.0',
   'cmocean==4.0.3',
   'colorcet==3.1.0',
@@ -154,6 +153,7 @@ docs = [
   'trame-pyvista==0.1.0',
   'trimesh==4.12.0',
   'vtk-xref==0.1.2',
+  'vtk<9.6.2',
   { include-group = 'pinned' },
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,9 @@ test = [
 test-playwright = ['playwright<1.59.0', { include-group = 'test' }]
 
 docs = [
+  # vtk 9.6.2 wheels on PyPI ship a broken vtkOutlineFilter (SetGenerateFaces
+  # missing); see #8700. Drop this pin once the upstream regression is fixed.
+  'vtk<9.6.2',
   'cmcrameri==1.9.0',
   'cmocean==4.0.3',
   'colorcet==3.1.0',


### PR DESCRIPTION
Follow-up to #8683, which moved the Linux unit and integration jobs to GitHub-hosted runners. The remaining non-macOS self-hosted users were the docs build and the Python docstring matrix entry, both pinned to `ubuntu-24.04-self-hosted-gpu`. This shifts them to `ubuntu-22.04` so the self-hosted Linux GPU runner can be retired. macOS jobs continue to use the self-hosted Mac runner.

Both jobs install the same apt packages used for the migrated Linux unit tests (`xvfb`, `libgl1`, `libglx-mesa0`, `libosmesa6`, plus the docs-specific `libosmesa6-dev`, `libgl1-mesa-dev`, `python3-tk`, `pandoc`, `git-restore-mtime`) and run the rendering commands under `xvfb-run`. The `cache-pyvista-data` reusable workflow is repointed at `ubuntu-22.04` so the cache key matches the new runner. The `runner.environment == 'self-hosted'` branches in `docs.yml` and the stale "does not support self-hosted (yet)" comment on the Vale job are removed.

The doc build keeps `PARALLEL=-j2` to match the 2-core GitHub-hosted runner. Expect docs builds to run slower than they did on the GPU runner; if the wall time becomes a problem we can revisit Sphinx parallelism or split the gallery.