### PR TITLE
Avoid redundant CellArray legacy export during validation

### DIFF
--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -709,8 +709,7 @@ class CellArray(
         vtk_idarr = numpy_to_idarr(cells, deep=False, return_ind=False)
         self.ImportLegacyFormat(vtk_idarr)
 
-        self.ExportLegacyFormat(idarr := _vtk.vtkIdTypeArray())
-        imported_size = _vtk.vtk_to_numpy(idarr).size
+        imported_size = self.GetNumberOfCells() + self.GetNumberOfConnectivityIds()
 
         # https://github.com/pyvista/pyvista/pull/5404
         if imported_size != cells.size:


### PR DESCRIPTION
### Overview

Resolves #8460.

This removes a redundant conversion in `CellArray.cells`. After importing a legacy-format cell array, we only need to check that VTK consumed the expected number of entries. We can get that size directly from the imported cell metadata instead of exporting the whole array back to legacy format just to count it.

### Details

- Use `GetNumberOfCells() + GetNumberOfConnectivityIds()` for the size check.
- Avoid an extra legacy-format export when building large `CellArray` objects.