### PR TITLE
Fix pickling/deepcopy of datasets with a cached cell locator

### DIFF
--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -871,6 +871,21 @@ class DataObject(
         """
         self.CopyAttributes(dataset)
 
+    def _picklable_dict(self: Self) -> dict[str, Any]:
+        """Return a copy of ``__dict__`` that is safe to pickle.
+
+        Cached helper objects such as the lazily-built cell locator
+        (:attr:`~pyvista.PolyData.obbTree`) are VTK objects that cannot be
+        pickled. They are derived caches that are rebuilt on demand, so they
+        are excluded from the serialized state and simply recomputed after
+        unpickling.
+        """
+        return {
+            key: value
+            for key, value in self.__dict__.items()
+            if not isinstance(value, _vtk.vtkAbstractCellLocator)
+        }
+
     def __getstate__(  # type: ignore[return]  # noqa: RET503
         self: Self,
     ) -> tuple[FunctionType, tuple[dict[str, Any]]] | dict[str, Any]:
@@ -891,7 +906,7 @@ class DataObject(
 
         # Add this object's data to the state dictionary
         state_dict = serialized[1][0]
-        state_dict['_PYVISTA_STATE_DICT'] = self.__dict__.copy()
+        state_dict['_PYVISTA_STATE_DICT'] = self._picklable_dict()
 
         # Unlike the PyVista formats, we do not return a dict. Instead, return
         # the same format returned by the vtk serializer.
@@ -917,7 +932,7 @@ class DataObject(
                 "\nUse `pyvista.PICKLE_FORMAT='vtk'`."
             )
             raise TypeError(msg)
-        state = self.__dict__.copy()
+        state = self._picklable_dict()
 
         if pv.PICKLE_FORMAT.lower() == 'xml':
             # the generic VTK XML writer `vtkXMLDataSetWriter` currently has a bug where it does

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import UserDict
+import copy
 import json
 import multiprocessing
 import pickle
@@ -451,6 +452,29 @@ def test_pickle_user_dict(sphere, pickle_format):
     unpickled = pickle.loads(pickled)
 
     assert unpickled.user_dict == user_dict
+
+
+@pytest.mark.parametrize('pickle_format', ['vtk', 'xml', 'legacy'])
+def test_pickle_with_cached_locator(sphere, pickle_format):
+    """Regression test for #8697.
+
+    A cached cell locator (e.g. the lazily-built ``obbTree``) is an
+    unpicklable VTK object. It must not break pickling or deepcopy of the
+    dataset that caches it; instead it is dropped from the serialized state
+    and rebuilt lazily on demand.
+    """
+    if pickle_format == 'vtk' and pv.vtk_version_info < (9, 3):
+        pytest.xfail('VTK version not supported.')
+
+    pv.set_pickle_format(pickle_format)
+    _ = sphere.obbTree  # build and cache the locator
+    assert 'obbTree' in sphere.__dict__
+
+    for restored in (pickle.loads(pickle.dumps(sphere)), copy.deepcopy(sphere)):
+        assert restored == sphere
+        # the cache is not serialized; it is rebuilt lazily on demand
+        assert 'obbTree' not in restored.__dict__
+        assert restored.obbTree is not sphere.obbTree
 
 
 @pytest.mark.parametrize('pickle_format', ['vtk', 'xml', 'legacy'])


### PR DESCRIPTION
### Overview

`pickle.dumps` and `copy.deepcopy` raise `TypeError: cannot pickle 'vtkOBBTree' object`
for any dataset whose cell locator has been accessed.

Resolves #8697.

### Details

- A cached cell locator (e.g. `PolyData.obbTree`, a `functools.cached_property`)
  is stored in the object's `__dict__`. `DataObject.__getstate__` copied
  `__dict__` wholesale into the pickle state, and `vtkAbstractCellLocator`
  objects cannot be pickled — so accessing `obbTree` and then pickling /
  deep-copying the mesh failed.
- Fix: exclude cached cell-locator objects from the serialized state via a new
  `DataObject._picklable_dict()` helper, used by both the `vtk` and the
  `xml`/`legacy` serialization paths. The locator is a derived cache rebuilt
  lazily on demand, so the unpickled / copied object recomputes it on next
  access.
- Added a regression test (`test_pickle_with_cached_locator`) covering pickle
  and deepcopy across all three pickle formats.

This PR intentionally keeps `obbTree` as-is and only makes serialization
robust — whether to deprecate the public `obbTree` property and make the
locator cache fully internal is a separate API decision.

### Reproduction (before this PR)

```python
import copy
import pyvista as pv
poly = pv.Sphere()
poly.obbTree
copy.deepcopy(poly)   # TypeError: cannot pickle 'vtkOBBTree' object
```

### Verification

- The reproduction above now succeeds; the copied / unpickled mesh equals the
  original, does not carry the cached locator, and rebuilds a working locator on
  next access (confirmed `ray_trace` still works).
- The new test fails on `main` (raises the reported `TypeError` for all three
  pickle formats) and passes with this change.
- `tests/core/test_dataobject.py` passes in full (62 tests); `ruff check` and
  `ruff format --check` are clean on the changed files.
