### PR TITLE
Fix shadows not re-enabling after disable_shadows

### DIFF
--- a/pyvista/plotting/render_passes.py
+++ b/pyvista/plotting/render_passes.py
@@ -200,6 +200,9 @@ class RenderPasses(_NoNewAttrMixin):
             return
         self._pass_collection.RemoveItem(self._shadow_map_pass.GetShadowMapBakerPass())
         self._pass_collection.RemoveItem(self._shadow_map_pass)
+        # clear the cached pass (like the other ``disable_*_pass`` methods) so a
+        # subsequent ``enable_shadow_pass`` re-creates it instead of early-returning
+        self._shadow_map_pass = None
         self._update_passes()
 
     @_deprecate_positional_args

--- a/tests/plotting/test_render_pass.py
+++ b/tests/plotting/test_render_pass.py
@@ -98,8 +98,23 @@ def test_shadow_pass():
 
     assert passes._pass_collection.IsItemPresent(ren_pass)
 
+    # enabling again should not add the pass again
+    assert passes.enable_shadow_pass() is None
+
     passes.disable_shadow_pass()
     assert not passes._pass_collection.IsItemPresent(ren_pass)
+    # the cached pass must be cleared so it can be re-enabled (regression #8685)
+    assert passes._shadow_map_pass is None
+
+    # re-enabling after disabling must restore the shadow pass
+    ren_pass = passes.enable_shadow_pass()
+    assert isinstance(ren_pass, _vtk.vtkShadowMapPass)
+    assert passes._pass_collection.IsItemPresent(ren_pass)
+
+    # disabling again should just do nothing
+    passes.disable_shadow_pass()
+    passes.disable_shadow_pass()
+    assert passes._shadow_map_pass is None
 
 
 def test_edl_pass():


### PR DESCRIPTION
### Overview

After `disable_shadows()`, a subsequent `enable_shadows()` does nothing — shadows
stay off.

Resolves #8685 (the shadow re-enable problem; the separate GPU-memory growth noted
in that issue is out of scope here).

### Root cause

In `pyvista/plotting/render_passes.py`, every `disable_*_pass` method clears its
cached pass back to `None` (`disable_ssao_pass`, `disable_ssaa_pass`,
`disable_depth_of_field_pass`, …) — except `disable_shadow_pass`, which removed
the pass from the collection but left `self._shadow_map_pass` set:

```python
def disable_shadow_pass(self):
    if self._shadow_map_pass is None:
        return
    self._pass_collection.RemoveItem(self._shadow_map_pass.GetShadowMapBakerPass())
    self._pass_collection.RemoveItem(self._shadow_map_pass)
    self._update_passes()        # self._shadow_map_pass still not None
```

`enable_shadow_pass` early-returns when `self._shadow_map_pass is not None`, so the
second `enable_shadows()` returned without re-adding the pass.

### Fix

Reset `self._shadow_map_pass = None` on disable (before `_update_passes()`, so the
renderer also resets to default rendering via the `self._shadow_map_pass is None`
branch when no other passes remain).

### Reproduction (before this PR)

```python
import numpy as np, pyvista as pv
pv.OFF_SCREEN = True
pl = pv.Plotter(off_screen=True)
pl.add_mesh(pv.Sphere() + pv.Sphere(radius=0.2, center=(0, 0, 1)))
shot = lambda: np.asarray(pl.screenshot(window_size=(200, 200)), dtype=np.int64)
pl.enable_shadows();  s1 = shot()
pl.disable_shadows(); s2 = shot()
pl.enable_shadows();  s3 = shot()
# before: s3 == s2 (shadows NOT restored);  after: s3 == s1 (restored)
```

### Verification

- Before: `s3` is identical to the shadows-off image `s2`. After: `s3` is identical
  to the shadows-on image `s1` and differs from `s2`.
- Extended `test_shadow_pass` (tests/plotting/test_render_pass.py) to cover the
  disable → re-enable cycle and assert `_shadow_map_pass` is cleared on disable.
  The new assertions fail on `main` and pass with this change.
- `pytest tests/plotting/test_render_pass.py` passes (10 tests); `ruff check` /
  `ruff format --check` clean on the changed files.
