### PR TITLE
Support variable-length cell types in the UnstructuredGrid cells dict

### DIFF
--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -2356,17 +2356,27 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
             return convert_array(arr)
 
     @property
-    def cells_dict(self) -> dict[np.uint8, NumpyArray[int]]:  # numpydoc ignore=RT01
+    def cells_dict(  # numpydoc ignore=RT01
+        self,
+    ) -> dict[np.uint8, NumpyArray[int] | list[NumpyArray[int]]]:
         """Return a dictionary that contains all cells mapped from cell types.
 
         This function returns a :class:`numpy.ndarray` for each cell
-        type in an ordered fashion.  Note that this function only
-        works with element types of fixed sizes.
+        type in an ordered fashion.  For a cell type whose cells all have
+        the same number of points the value is a single ``[N, D]`` array;
+        for a cell type with a data-defined number of points whose cells
+        differ in size (e.g. :attr:`~pyvista.CellType.POLYGON`) the value
+        is instead a list of ``N`` 1D arrays, one per cell.
 
         .. versionchanged:: 0.46
 
             An empty dict ``{}`` is returned instead of ``None`` if
             the input is empty.
+
+        .. versionchanged:: 0.49
+
+            Cell types with a data-defined number of points are now
+            supported (previously this raised a ``ValueError``).
 
         Returns
         -------

--- a/pyvista/core/utilities/cells.py
+++ b/pyvista/core/utilities/cells.py
@@ -16,6 +16,8 @@ from pyvista import _vtk
 from pyvista._deprecate_positional_args import _deprecate_positional_args
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from pyvista import CellType
     from pyvista import UnstructuredGrid
     from pyvista.core._typing_core import ArrayLike
@@ -123,8 +125,120 @@ def numpy_to_idarr(
     return vtk_idarr
 
 
+def _cell_type_n_points(cell_type: CellType) -> int | None:
+    """Return the fixed number of points for a cell type, or ``None`` if data-defined.
+
+    Composite, higher-order, polygonal and polyhedral cells do not have a fixed
+    number of points (:attr:`~pyvista.CellType.n_points` raises for them), so the
+    per-cell point count has to come from the connectivity data instead.
+    """
+    try:
+        n_points = cell_type.n_points
+    except ValueError:
+        return None
+    return n_points if n_points > 0 else None
+
+
+def _check_cell_indices(indices: NumpyArray[int], elem_t: CellType, nr_points: int | None) -> None:
+    """Validate that connectivity indices are non-negative and within the point count."""
+    if np.any(indices < 0):
+        msg = f'Non-valid index (<0) given for cells of type {elem_t}'
+        raise ValueError(msg)
+    if nr_points is not None and np.any(indices >= nr_points):
+        msg = f'Non-valid index (>={nr_points}) given for cells of type {elem_t}'
+        raise ValueError(msg)
+
+
+def _fixed_size_cells(
+    elem_t: CellType,
+    nr_points_per_elem: int,
+    cells_arr: NumpyArray[int],
+    *,
+    nr_points: int | None,
+) -> tuple[NumpyArray[np.uint8], NumpyArray[int]]:
+    """Build the cell-type and connectivity arrays for a fixed-size cell type."""
+    if (
+        not isinstance(cells_arr, np.ndarray)  # type: ignore[redundant-expr]
+        or not np.issubdtype(cells_arr.dtype, np.integer)
+        or cells_arr.ndim not in [1, 2]
+        or (cells_arr.ndim == 1 and cells_arr.size % nr_points_per_elem != 0)
+        or (cells_arr.ndim == 2 and cells_arr.shape[-1] != nr_points_per_elem)
+    ):
+        msg = (
+            f'Expected an np.ndarray of size [N, {nr_points_per_elem}] or '
+            f'[N*{nr_points_per_elem}] with an integral type'
+        )
+        raise ValueError(msg)
+
+    _check_cell_indices(cells_arr, elem_t, nr_points)
+
+    # Ensure array is not flat
+    not_flat = cells_arr.reshape([-1, nr_points_per_elem]) if cells_arr.ndim == 1 else cells_arr
+    nr_elems = not_flat.shape[0]
+    types = np.array([elem_t] * nr_elems, dtype=np.uint8)
+    arr = np.concatenate(
+        [np.ones_like(not_flat[..., :1]) * nr_points_per_elem, not_flat],
+        axis=-1,
+    ).reshape([-1])
+    return types, arr
+
+
+def _variable_size_cells(
+    elem_t: CellType,
+    cells_arr: NumpyArray[int] | Sequence[ArrayLike[int]],
+    *,
+    nr_points: int | None,
+) -> tuple[NumpyArray[np.uint8], NumpyArray[int]]:
+    """Build the cell-type and connectivity arrays for a data-defined cell type.
+
+    The per-cell point count is taken from the data: a 2D ``[N, D]`` array maps to
+    ``N`` cells of ``D`` points each, while a sequence of 1D integer arrays maps to
+    cells of differing sizes (one array per cell).
+    """
+    if elem_t == pv.CellType.POLYHEDRON:
+        msg = (
+            "Cell type 'POLYHEDRON' cannot be created from a cells dict because a "
+            'polyhedron is defined by its faces, not a flat list of point indices. '
+            'Build the UnstructuredGrid from explicit cell and face arrays instead.'
+        )
+        raise ValueError(msg)
+
+    # Uniform case: a 2D [N, D] array is N cells with D points each.
+    if isinstance(cells_arr, np.ndarray):
+        if cells_arr.ndim == 2 and np.issubdtype(cells_arr.dtype, np.integer):
+            _check_cell_indices(cells_arr, elem_t, nr_points)
+            nr_elems, nr_points_per_elem = cells_arr.shape
+            types = np.array([elem_t] * nr_elems, dtype=np.uint8)
+            counts = np.ones_like(cells_arr[..., :1]) * nr_points_per_elem
+            arr = np.concatenate([counts, cells_arr], axis=-1).reshape([-1])
+            return types, arr
+        msg = (
+            f"Cell type '{elem_t.name}' has a data-defined number of points. Pass a "
+            f'2D [N, D] array for cells that all have D points, or a sequence of 1D '
+            f'integer arrays for cells of differing sizes (a flat 1D array is ambiguous).'
+        )
+        raise ValueError(msg)
+
+    # Ragged case: a sequence of per-cell 1D index arrays.
+    per_cell = [np.asarray(cell) for cell in cells_arr]
+    chunks = []
+    for cell in per_cell:
+        if cell.ndim != 1 or not np.issubdtype(cell.dtype, np.integer) or cell.size == 0:
+            msg = (
+                f"Each cell of type '{elem_t.name}' must be a non-empty 1D array of "
+                f'integer point indices.'
+            )
+            raise ValueError(msg)
+        _check_cell_indices(cell, elem_t, nr_points)
+        chunks.append(np.concatenate([[cell.size], cell]).astype(np.int64))
+    types = np.array([elem_t] * len(per_cell), dtype=np.uint8)
+    arr = np.concatenate(chunks) if chunks else np.empty(0, dtype=np.int64)
+    return types, arr
+
+
 def create_mixed_cells(
-    mixed_cell_dict: dict[np.uint8, NumpyArray[int]], nr_points: int | None = None
+    mixed_cell_dict: dict[np.uint8, NumpyArray[int] | Sequence[ArrayLike[int]]],
+    nr_points: int | None = None,
 ) -> tuple[NumpyArray[np.uint8], NumpyArray[int]]:
     """Generate cell arrays for the creation of a pyvista.UnstructuredGrid from a cell dictionary.
 
@@ -135,15 +249,29 @@ def create_mixed_cells(
     [N*D], where N is the number of cells and D is the size of the
     cells for the given type (e.g. 3 for triangles).  Multiple
     vtk_type keys with associated arrays can be present in one
-    dictionary.  This function only accepts cell types of fixed size
-    and not dynamic sized cells like :attr:`~pyvista.CellType.POLYGON`
+    dictionary.
+
+    Cell types whose number of points is not fixed (e.g.
+    :attr:`~pyvista.CellType.POLYGON`, :attr:`~pyvista.CellType.POLY_VERTEX`, and
+    the higher-order :attr:`~pyvista.CellType.LAGRANGE_TRIANGLE` /
+    :attr:`~pyvista.CellType.BEZIER_TRIANGLE` families) are also supported. For
+    such a type, pass either a 2D ``[N, D]`` array (``N`` cells that all have ``D``
+    points) or, when the cells differ in size, a sequence of 1D integer arrays (one
+    array of point indices per cell). :attr:`~pyvista.CellType.POLYHEDRON` is the
+    one exception: it is defined by its faces rather than a flat point list and so
+    cannot be created from a cells dict.
+
+    .. versionchanged:: 0.49
+
+        Cell types with a data-defined number of points are now supported.
 
     Parameters
     ----------
     mixed_cell_dict : dict
         A dictionary that maps VTK-Enum-types (e.g. :attr:`~pyvista.CellType.TRIANGLE`) to
         np.ndarrays of type int.  The ``np.ndarrays`` describe the cell
-        connectivity.
+        connectivity. For cell types with a data-defined number of points, the value
+        may instead be a sequence of 1D integer arrays (one per cell).
     nr_points : int, optional
         Number of points of the grid. Used only to allow additional runtime
         checks for invalid indices.
@@ -159,9 +287,8 @@ def create_mixed_cells(
     Raises
     ------
     ValueError
-        If any of the cell types are not supported, have dynamic sized
-        cells, map to values with wrong size, or cell indices point
-        outside the given number of points.
+        If any of the cell types are not supported, map to values with the
+        wrong size, or cell indices point outside the given number of points.
 
     Examples
     --------
@@ -177,53 +304,31 @@ def create_mixed_cells(
     ...     {vtk.VTK_TRIANGLE: np.array([[0, 1, 2], [3, 4, 5]])}
     ... )
 
-    """
-    mixed_cells = {pv.CellType(k): v for k, v in mixed_cell_dict.items()}  # type: ignore[arg-type]
-    if not all(k.n_points > 0 for k in mixed_cells.keys()):
-        msg = "You requested a cell type with variable length, which can't be used in this method"
-        raise ValueError(msg)
+    Create the cell arrays for two polygons of differing size (a triangle and a
+    quad) by passing a sequence of one index array per cell.
 
+    >>> import pyvista as pv
+    >>> cell_types, cell_arr = create_mixed_cells(
+    ...     {pv.CellType.POLYGON: [np.array([0, 1, 2]), np.array([3, 4, 5, 6])]}
+    ... )
+
+    """
     final_cell_types = []
     final_cell_arr = []
-    for elem_t, cells_arr in mixed_cells.items():
-        nr_points_per_elem = elem_t.n_points
-        if (
-            not isinstance(cells_arr, np.ndarray)  # type: ignore[redundant-expr]
-            or not np.issubdtype(cells_arr.dtype, np.integer)
-            or cells_arr.ndim not in [1, 2]
-            or (cells_arr.ndim == 1 and cells_arr.size % nr_points_per_elem != 0)
-            or (cells_arr.ndim == 2 and cells_arr.shape[-1] != nr_points_per_elem)
-        ):
-            msg = (
-                f'Expected an np.ndarray of size [N, {nr_points_per_elem}] or '
-                f'[N*{nr_points_per_elem}] with an integral type'
+    for key, cells_arr in mixed_cell_dict.items():
+        elem_t = pv.CellType(key)  # type: ignore[arg-type]
+        nr_points_per_elem = _cell_type_n_points(elem_t)
+        if nr_points_per_elem is not None:
+            types, arr = _fixed_size_cells(
+                elem_t,
+                nr_points_per_elem,
+                cells_arr,  # type: ignore[arg-type]
+                nr_points=nr_points,
             )
-            raise ValueError(msg)
-
-        if np.any(cells_arr < 0):
-            msg = f'Non-valid index (<0) given for cells of type {elem_t}'
-            raise ValueError(msg)
-
-        if nr_points is not None and np.any(cells_arr >= nr_points):
-            msg = f'Non-valid index (>={nr_points}) given for cells of type {elem_t}'
-            raise ValueError(msg)
-
-        # Ensure array is not flat
-        cells_arr_not_flat = (
-            cells_arr.reshape([-1, nr_points_per_elem]) if cells_arr.ndim == 1 else cells_arr
-        )
-
-        nr_elems = cells_arr_not_flat.shape[0]
-        final_cell_types.append(np.array([elem_t] * nr_elems, dtype=np.uint8))
-        final_cell_arr.append(
-            np.concatenate(
-                [
-                    np.ones_like(cells_arr_not_flat[..., :1]) * nr_points_per_elem,
-                    cells_arr_not_flat,
-                ],
-                axis=-1,
-            ).reshape([-1]),
-        )
+        else:
+            types, arr = _variable_size_cells(elem_t, cells_arr, nr_points=nr_points)
+        final_cell_types.append(types)
+        final_cell_arr.append(arr)
 
     cell_types_out = np.concatenate(final_cell_types)
     cell_arr_out = np.concatenate(final_cell_arr)
@@ -231,19 +336,29 @@ def create_mixed_cells(
     return cell_types_out, cell_arr_out
 
 
-def get_mixed_cells(vtkobj: UnstructuredGrid) -> dict[np.uint8, NumpyArray[int]]:
+def get_mixed_cells(
+    vtkobj: UnstructuredGrid,
+) -> dict[np.uint8, NumpyArray[int] | list[NumpyArray[int]]]:
     """Create the cells dictionary from the given pyvista.UnstructuredGrid.
 
     This functions creates a cells dictionary (see
-    create_mixed_cells), with a mapping vtk_type -> np.ndarray (int)
-    for fixed size cell types. The returned dictionary will have
-    arrays of size [N, D], where N is the number of cells and D is the
-    size of the cells for the given type (e.g. 3 for triangles).
+    create_mixed_cells), with a mapping vtk_type -> np.ndarray (int).
+    For a cell type whose cells all have the same number of points, the
+    value is an array of size [N, D], where N is the number of cells and
+    D is the size of the cells for the given type (e.g. 3 for triangles).
+    For a cell type with a data-defined number of points whose cells differ
+    in size (e.g. :attr:`~pyvista.CellType.POLYGON`), the value is instead a
+    list of N 1D arrays, one per cell. Both forms round-trip through
+    :func:`create_mixed_cells`.
 
     .. versionchanged:: 0.46
 
         An empty dict ``{}`` is returned instead of ``None`` if the input
         is empty.
+
+    .. versionchanged:: 0.49
+
+        Cell types with a data-defined number of points are now supported.
 
     Parameters
     ----------
@@ -258,9 +373,10 @@ def get_mixed_cells(vtkobj: UnstructuredGrid) -> dict[np.uint8, NumpyArray[int]]
     Raises
     ------
     ValueError
-        If vtkobj is not a pyvista.UnstructuredGrid, any of the
-        present cells are unsupported, or have dynamic cell sizes,
-        like VTK_POLYGON.
+        If vtkobj is not a pyvista.UnstructuredGrid, any of the present
+        cells are unsupported, or any cell is a
+        :attr:`~pyvista.CellType.POLYHEDRON` (which is defined by its faces
+        and cannot be represented as a flat point list).
 
     """
     if not isinstance(vtkobj, pv.UnstructuredGrid):
@@ -271,38 +387,42 @@ def get_mixed_cells(vtkobj: UnstructuredGrid) -> dict[np.uint8, NumpyArray[int]]
     if nr_cells == 0:
         return {}
 
-    return_dict: dict[CellType, NumpyArray[int]] = {}
     cell_types = vtkobj.celltypes
-    cells = vtkobj.cells
+    connectivity = vtkobj.cell_connectivity
+    offset = vtkobj.offset
 
-    distinct_cell_types = vtkobj.distinct_cell_types
+    # Derive the distinct cell types from the live ``celltypes`` array rather than
+    # ``vtkobj.distinct_cell_types`` (which VTK may cache, going stale after a raw
+    # mutation). Building each ``CellType`` here also validates that every present
+    # type is known.
+    distinct_cell_types = [pv.CellType(int(t)) for t in np.unique(cell_types)]
 
-    if not all(k.n_points > 0 for k in distinct_cell_types):
+    if pv.CellType.POLYHEDRON in distinct_cell_types:
         msg = (
-            'You requested a cell-dictionary with a variable length cell, which is not supported '
-            'currently'
+            "Cell type 'POLYHEDRON' cannot be represented in a cells dict because a "
+            'polyhedron is defined by its faces, not a flat list of point indices.'
         )
         raise ValueError(msg)
 
-    cell_sizes = np.zeros_like(cell_types)
+    # Per-cell point counts come from the offset array, so this works uniformly for
+    # both fixed-size and data-defined (variable) cell types.
+    cell_sizes = np.diff(offset)
+    cell_starts = offset[:-1]
+
+    return_dict: dict[np.uint8, NumpyArray[int] | list[NumpyArray[int]]] = {}
     for cell_type in distinct_cell_types:
         mask = cell_types == cell_type
-        cell_sizes[mask] = cell_type.n_points
+        starts = cell_starts[mask]
+        sizes = cell_sizes[mask]
 
-    cell_ends = np.cumsum(cell_sizes + 1)
-    cell_starts = np.concatenate([np.array([0], dtype=cell_ends.dtype), cell_ends[:-1]]) + 1
+        if np.all(sizes == sizes[0]):
+            cell_size = int(sizes[0])
+            cells_inds = starts[..., np.newaxis] + np.arange(cell_size, dtype=starts.dtype)
+            return_dict[np.uint8(cell_type)] = connectivity[cells_inds]
+        else:
+            return_dict[np.uint8(cell_type)] = [
+                connectivity[start : start + size]
+                for start, size in zip(starts, sizes, strict=True)
+            ]
 
-    for cell_type in distinct_cell_types:
-        cell_size = cell_type.n_points
-        mask = cell_types == cell_type
-        current_cell_starts = cell_starts[mask]
-
-        cells_inds = current_cell_starts[..., np.newaxis] + np.arange(cell_size)[
-            np.newaxis
-        ].astype(
-            cell_starts.dtype,
-        )
-
-        return_dict[cell_type] = cells[cells_inds]
-
-    return {np.uint8(k): v for k, v in return_dict.items()}
+    return return_dict

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -282,6 +282,56 @@ def test_init_from_dict(multiple_cell_types, flat_cells):
         pv.UnstructuredGrid(input_cells_dict, points[..., :-1])
 
 
+def test_init_from_dict_variable_length():
+    rng = np.random.default_rng(seed=0)
+
+    # Higher-order Lagrange triangle (TRI10): its point count is data-defined, so a
+    # 2D [N, D] array sets D points per cell. This is the case from issue #8628.
+    points = rng.normal(size=(10, 3))
+    conn = np.arange(10).reshape(1, 10)
+    grid = pv.UnstructuredGrid({CellType.LAGRANGE_TRIANGLE: conn}, points)
+    assert grid.n_cells == 1
+    assert grid.celltypes[0] == CellType.LAGRANGE_TRIANGLE
+    assert grid.get_cell(0).n_points == 10
+    assert np.all(grid.cells_dict[CellType.LAGRANGE_TRIANGLE] == conn)
+
+    # Ragged polygons (a triangle and a pentagon) passed as a sequence of index
+    # arrays of differing length, and the resulting mesh has the expected geometry.
+    square = np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]], dtype=float)
+    grid = pv.UnstructuredGrid({CellType.POLYGON: [np.arange(4)]}, square)
+    assert grid.n_cells == 1
+    assert grid.extract_surface(algorithm='dataset_surface').area == pytest.approx(1.0)
+
+    # A single dict mixing a fixed-size and a variable-size, ragged cell type.
+    points = rng.normal(size=(13, 3))
+    triangle = np.array([[0, 1, 2]])
+    polygons = [np.array([3, 4, 5, 6]), np.array([7, 8, 9, 10, 11, 12])]
+    grid = pv.UnstructuredGrid(
+        {CellType.TRIANGLE: triangle, CellType.POLYGON: polygons},
+        points,
+    )
+    assert grid.n_cells == 3
+    out = grid.cells_dict
+    assert np.all(out[CellType.TRIANGLE] == triangle)
+    assert isinstance(out[CellType.POLYGON], list)
+    assert np.all(out[CellType.POLYGON][0] == polygons[0])
+    assert np.all(out[CellType.POLYGON][1] == polygons[1])
+
+    # POLYHEDRON is defined by faces, not a point list, so it is rejected.
+    with pytest.raises(ValueError, match='POLYHEDRON'):
+        pv.UnstructuredGrid({CellType.POLYHEDRON: [np.arange(4)]}, points)
+
+    # A flat 1D array is ambiguous for a variable-length cell type.
+    with pytest.raises(ValueError, match='data-defined number of points'):
+        pv.UnstructuredGrid({CellType.POLYGON: np.arange(5)}, points)
+
+    # Out-of-range and negative indices are validated for variable-length cells too.
+    with pytest.raises(ValueError, match='Non-valid index'):
+        pv.UnstructuredGrid({CellType.POLYGON: [np.array([0, 1, 99])]}, points)
+    with pytest.raises(ValueError, match='Non-valid index'):
+        pv.UnstructuredGrid({CellType.POLYGON: np.array([[0, 1, -1]])}, points)
+
+
 def test_init_polyhedron():
     polyhedron_nodes = [
         [0.02, 0.0, 0.02],  # 17
@@ -332,19 +382,33 @@ def test_cells_dict_hexbeam_file():
 
 
 def test_cells_dict_variable_length():
+    # A single polygon round-trips through the cells dict (variable-length cell type).
     cells_poly = np.concatenate([[5], np.arange(5)])
     cells_types = np.array([CellType.POLYGON])
     points = np.random.default_rng().normal(size=(5, 3))
     grid = pv.UnstructuredGrid(cells_poly, cells_types, points)
 
-    # Dynamic sizes cell types are currently unsupported
-    with pytest.raises(ValueError):  # noqa: PT011
-        _ = grid.cells_dict
+    assert np.all(grid.cells_dict[CellType.POLYGON] == np.arange(5))
 
     grid.celltypes[:] = 255
     # Unknown cell types
     with pytest.raises(ValueError):  # noqa: PT011
         _ = grid.cells_dict
+
+
+def test_cells_dict_ragged_polygons():
+    # Polygons of differing sizes come back as a list of one index array per cell.
+    triangle = np.array([0, 1, 2])
+    pentagon = np.array([3, 4, 5, 6, 7])
+    cells = np.concatenate([[len(triangle)], triangle, [len(pentagon)], pentagon])
+    cells_types = np.array([CellType.POLYGON, CellType.POLYGON])
+    points = np.random.default_rng().normal(size=(8, 3))
+    grid = pv.UnstructuredGrid(cells, cells_types, points)
+
+    out = grid.cells_dict[CellType.POLYGON]
+    assert isinstance(out, list)
+    assert np.all(out[0] == triangle)
+    assert np.all(out[1] == pentagon)
 
 
 def test_cells_dict_empty_grid():

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -331,6 +331,10 @@ def test_init_from_dict_variable_length():
     with pytest.raises(ValueError, match='Non-valid index'):
         pv.UnstructuredGrid({CellType.POLYGON: np.array([[0, 1, -1]])}, points)
 
+    # Each ragged cell must be a non-empty 1D integer array; an empty cell is rejected.
+    with pytest.raises(ValueError, match='non-empty 1D array'):
+        pv.UnstructuredGrid({CellType.POLYGON: [np.array([], dtype=int)]}, points)
+
 
 def test_init_polyhedron():
     polyhedron_nodes = [
@@ -409,6 +413,20 @@ def test_cells_dict_ragged_polygons():
     assert isinstance(out, list)
     assert np.all(out[0] == triangle)
     assert np.all(out[1] == pentagon)
+
+
+def test_cells_dict_polyhedron_raises():
+    # A polyhedron is defined by its faces, not a flat point list, so reading a grid
+    # that contains one back into a cells dict is rejected (mirrors the init guard).
+    points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+    face_stream = [4, 3, 0, 1, 2, 3, 0, 1, 3, 3, 0, 2, 3, 3, 1, 2, 3]
+    cells = np.array([len(face_stream), *face_stream])
+    cell_types = np.array([CellType.POLYHEDRON])
+    grid = pv.UnstructuredGrid(cells, cell_types, points)
+    assert grid.get_cell(0).type == CellType.POLYHEDRON
+
+    with pytest.raises(ValueError, match='POLYHEDRON'):
+        _ = grid.cells_dict
 
 
 def test_cells_dict_empty_grid():


### PR DESCRIPTION
## Overview

Closes #8629: the `UnstructuredGrid` cells-dict constructor (and the inverse
`cells_dict` / `get_mixed_cells`) only handled cell types with a *fixed* number of
points. Any cell type whose point count is data-defined — `POLYGON`, `POLY_VERTEX`,
`POLY_LINE`, `TRIANGLE_STRIP`, and the higher-order `LAGRANGE_*` / `BEZIER_*`
families — was rejected. This is what blocked building an `UnstructuredGrid` from a
dict for the `LAGRANGE_TRIANGLE` mesh in #8628.

```python
import numpy as np, pyvista as pv

# A 10-node (order-3) Lagrange triangle, as in #8628
pts = np.random.rand(10, 3)
pv.UnstructuredGrid({pv.CellType.LAGRANGE_TRIANGLE: np.arange(10).reshape(1, 10)}, pts)
# main: ValueError: Cannot determine number of points for 'LAGRANGE_TRIANGLE' ...
```

The error even came out of the wrong place: the old guard was
`all(k.n_points > 0 for k in ...)`, but `CellType.n_points` *raises* for these types,
so the constructor surfaced the low-level "Cannot determine number of points" message
instead of a clear, intended one.

## What changed

`create_mixed_cells` now accepts data-defined cell types. The per-cell point count is
taken from the data rather than from `CellType`:

- a **2D `[N, D]`** array → `N` cells that all have `D` points (covers higher-order
  Lagrange/Bezier of a fixed order, and uniform polygons);
- a **sequence of 1D integer arrays** → one array of point indices per cell, for cells
  that differ in size (e.g. a triangle and a pentagon in the same `POLYGON` block).

A flat 1D array is still rejected for these types, because `D` cannot be inferred from
it (this keeps the existing "dynamic sizes cell type" test green). Fixed-size cell
types are untouched and go down exactly the same code path as before.

`get_mixed_cells` (and therefore `UnstructuredGrid.cells_dict`) is made symmetric: it
reads per-cell sizes from the grid's `offset` array, so it works for any cell type. A
type whose cells are all the same size comes back as an `[N, D]` array (unchanged for
fixed types); a type with cells of differing sizes comes back as a list of 1D arrays.
Both forms round-trip back through `create_mixed_cells`. It now also derives the
distinct cell types from the live `celltypes` array rather than VTK's cached
`distinct_cell_types`, which can go stale after the array is mutated in place.

`POLYHEDRON` is intentionally **not** supported by the cells dict in either direction:
a polyhedron is defined by its faces, not a flat list of point indices, so it cannot be
built from (or represented as) one. It now raises a clear, specific error rather than
silently producing an invalid cell.

## Verification

`tests/core/test_grid.py::test_init_from_dict_variable_length` (new) builds and
round-trips:

- a higher-order `LAGRANGE_TRIANGLE` (the #8628 case) — 10 points per cell, recovered
  exactly;
- a single `POLYGON` (a unit square) whose extracted surface has the expected area
  `1.0`, confirming the cell is geometrically valid;
- a dict mixing a fixed-size `TRIANGLE` with ragged `POLYGON`s of size 4 and 6;
- and it asserts the error paths: `POLYHEDRON` rejected, flat-1D rejected, and
  out-of-range / negative indices rejected for variable-length cells too.

`test_cells_dict_variable_length` is updated to assert a polygon now round-trips
through `cells_dict` (it previously asserted the unsupported error), keeping the
unknown-cell-type branch. `test_cells_dict_ragged_polygons` (new) covers the
list-of-arrays return for differing-size cells.

The existing `test_init_from_dict`, `test_cells_dict_*`, and `test_cells_dict_utils`
all pass unchanged; the full `test_grid.py` suite passes. `ruff check` / `ruff format`
and `mypy` on the changed module are clean, and the new docstring example is covered by
`--doctest-modules`.

Closes #8629. Refs #8628.
