### PR TITLE
Streamline integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -56,7 +56,7 @@ jobs:
           - project: playwright
             timeout: 5 # usually takes ~2
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ matrix.timeout }}
+    timeout-minutes: ${{ matrix.timeout * 2 }}
     defaults:
       run:
         shell: bash -l {0}
@@ -94,6 +94,7 @@ jobs:
       - name: Run tests (${{ matrix.project }})
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
         with:
+          timeout_minutes: ${{ matrix.timeout }}
           max_attempts: 2
           command: tox run -e integration-${{matrix.project}}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -67,7 +67,7 @@ jobs:
           persist-credentials: false
 
       - name: Set test timeout
-        run: echo "retry_test_timeout=$(( ${{ matrix.timeout }} / 2 ))" >> "$GITHUB_ENV"
+        run: echo "retry_test_timeout=$(( ${{ matrix.timeout }} / 2 ))" | tee -a "$GITHUB_OUTPUT"
         id: set_timeout
 
       - uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -60,8 +60,6 @@ jobs:
       run:
         shell: bash -el {0}
     timeout-minutes: ${{ matrix.timeout }}
-    env:
-      MNE_LOGGING_LEVEL: "info"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -el {0}
+        shell: bash -l {0}
     timeout-minutes: ${{ matrix.timeout }}
 
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -56,10 +56,10 @@ jobs:
           - project: playwright
             timeout: 5 # usually takes ~2
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ matrix.timeout }}
     defaults:
       run:
         shell: bash -l {0}
-    timeout-minutes: ${{ matrix.timeout }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -56,7 +56,7 @@ jobs:
           - project: playwright
             timeout: 5 # usually takes ~2
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ matrix.timeout * 2 }}
+    timeout-minutes: ${{ matrix.timeout }}
     defaults:
       run:
         shell: bash -l {0}
@@ -65,6 +65,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+
+      - name: Set test timeout
+        run: echo "retry_test_timeout=$(( ${{ matrix.timeout }} / 2 ))" >> "$GITHUB_ENV"
+        id: set_timeout
 
       - uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0
         with:
@@ -94,7 +98,7 @@ jobs:
       - name: Run tests (${{ matrix.project }})
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
         with:
-          timeout_minutes: ${{ matrix.timeout }}
+          timeout_minutes: ${{ steps.set_timeout.outputs.retry_test_timeout }}
           max_attempts: 2
           command: tox run -e integration-${{matrix.project}}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,11 +44,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: ["mne", "trame", "pyvistaqt", "geovista", "playwright"]
+        include:
+          - project: mne
+            timeout: 20 # usually takes ~10
+          - project: trame
+            timeout: 8 # usually takes ~3
+          - project: pyvistaqt
+            timeout: 5 # usually takes ~2
+          - project: geovista
+            timeout: 10 # usually takes ~5
+          - project: playwright
+            timeout: 5 # usually takes ~2
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -el {0}
+    timeout-minutes: ${{ matrix.timeout }}
     env:
       MNE_LOGGING_LEVEL: "info"
 
@@ -85,7 +96,6 @@ jobs:
       - name: Run tests (${{ matrix.project }})
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
         with:
-          timeout_minutes: 20
           max_attempts: 2
           command: tox run -e integration-${{matrix.project}}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,12 +45,11 @@ jobs:
       fail-fast: false
       matrix:
         project: ["mne", "trame", "pyvistaqt", "geovista", "playwright"]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -el {0}
     env:
-      DISPLAY: ":99.0"
       MNE_LOGGING_LEVEL: "info"
 
     steps:
@@ -61,7 +60,8 @@ jobs:
       - uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0
         with:
           qt: ${{matrix.project == 'pyvistaqt' || matrix.project == 'mne'}}
-          pyvista: ${{matrix.project != 'pyvistaqt' && matrix.project != 'mne'}}
+          pyvista: ${{matrix.project != 'pyvistaqt' && matrix.project != 'mne' && matrix.project != 'geovista'}}
+          wm: false
 
       - uses: actions/setup-python@v6
         with:
@@ -71,7 +71,7 @@ jobs:
 
       - name: Set cache key for mne
         if: ${{ matrix.project == 'mne' }}
-        run: echo MNE_DATA_KEY=$(curl -L https://github.com/mne-tools/mne-testing-data/raw/refs/heads/master/version.txt) >> "$GITHUB_ENV"
+        run: echo MNE_DATA_KEY=$(curl -L https://github.com/mne-tools/mne-testing-data/raw/refs/heads/master/version.txt) | tee -a "$GITHUB_ENV"
 
       - uses: actions/cache@v5
         if: ${{ env.USE_CACHE == 'true' && matrix.project == 'mne' }}
@@ -82,21 +82,13 @@ jobs:
       - name: Install tox-uv
         run: pip install tox-uv
 
-      - name: Run tests (no xvfb)
+      - name: Run tests (${{ matrix.project }})
         if: ${{matrix.project != 'geovista'}}
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
         with:
           timeout_minutes: 30
           max_attempts: 3
           command: tox run -e integration-${{matrix.project}}
-
-      - name: Run tests (geovista)
-        if: ${{matrix.project == 'geovista'}}
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
-        with:
-          timeout_minutes: 30
-          max_attempts: 3
-          command: xvfb-run -a tox run -e integration-${{matrix.project}}
 
   alert-on-failure:
     needs: Integration

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,11 +50,11 @@ jobs:
           - project: trame
             timeout: 8 # usually takes ~3
           - project: pyvistaqt
-            timeout: 5 # usually takes ~2
+            timeout: 6 # usually takes ~2
           - project: geovista
             timeout: 10 # usually takes ~5
           - project: playwright
-            timeout: 5 # usually takes ~2
+            timeout: 6 # usually takes ~2
     runs-on: ubuntu-latest
     timeout-minutes: ${{ matrix.timeout }}
     defaults:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -83,11 +83,10 @@ jobs:
         run: pip install tox-uv
 
       - name: Run tests (${{ matrix.project }})
-        if: ${{matrix.project != 'geovista'}}
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
         with:
-          timeout_minutes: 30
-          max_attempts: 3
+          timeout_minutes: 20
+          max_attempts: 2
           command: tox run -e integration-${{matrix.project}}
 
   alert-on-failure:

--- a/tox.ini
+++ b/tox.ini
@@ -197,8 +197,7 @@ commands_pre =
     # whose cwd is the pyvista tree, so it resolves the installed package
     # rather than the cloned source. Editable keeps the source tree on path.
     mne: uv pip install -e {env:MNE_HOME}[full-pyside6] --project {env:MNE_HOME} --group test_extra
-    mne: bash -c "cd {env:MNE_HOME} && ./tools/get_testing_version.sh"
-    mne: bash -c "cd {env:MNE_HOME} && ./tools/github_actions_download.sh"
+    mne: bash -c "{env:MNE_HOME}/tools/github_actions_download.sh"
     mne: python -c "import pyvista; assert not pyvista.OFF_SCREEN, f'{pyvista.OFF_SCREEN=} should be False'"
 
     # PYVISTAQT SETUP


### PR DESCRIPTION
1. No need to separate xvfb and non-xvfb runs, or setting `DISPLAY`
2. Use `ubuntu-latest` so that the version doesn't need to be manually updated every couple of years (slightly less burden, hopefully)
3. ~~Use `bash -e` so that errors in multi-line commands exit 1 properly~~ EDIT: already in SHELLOPTS :facepalm: 
4. Per-job (rather than for a single step) and per-project timeouts