### PR TITLE
Fix resample ignoring output dimensions reduced to a singleton

### DIFF
--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -4491,8 +4491,9 @@ class ImageDataFilters(DataSetFilters):
 
         .. note::
 
-            Singleton dimensions are not resampled by this filter, e.g. 2D images
-            will remain 2D.
+            Singleton input dimensions are not resampled by this filter, e.g. 2D
+            images will remain 2D. An output dimension may be reduced to a singleton,
+            however, e.g. to flatten a 3D volume into a single 2D slice.
 
         .. versionadded:: 0.45
 
@@ -5014,8 +5015,19 @@ class ImageDataFilters(DataSetFilters):
 
         resize_filter = _vtk.vtkImageResize()
         resize_filter.SetInputData(input_image)
-        resize_filter.SetResizeMethodToMagnificationFactors()
-        resize_filter.SetMagnificationFactors(*magnification_factors)
+        # Reducing a non-singleton axis to a single point requires a magnification
+        # factor of zero, but `vtkImageResize` silently ignores zero factors and
+        # leaves the axis unchanged. Set the output dimensions explicitly in that
+        # case so that e.g. flattening a 3D volume to a 2D slice is honored.
+        target_dimensions = np.maximum(np.rint(new_dimensions).astype(int), 1)
+        if np.any((target_dimensions == 1) & ~singleton_dims):
+            # Preserve input singleton dimensions (these are never resampled).
+            target_dimensions[singleton_dims] = old_dimensions[singleton_dims]
+            resize_filter.SetResizeMethodToOutputDimensions()
+            resize_filter.SetOutputDimensions(*(int(d) for d in target_dimensions))
+        else:
+            resize_filter.SetResizeMethodToMagnificationFactors()
+            resize_filter.SetMagnificationFactors(*magnification_factors)
 
         # Set interpolation mode
         interpolator: _vtk.vtkAbstractImageInterpolator

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -1403,6 +1403,30 @@ def test_resample_cell_data(uniform):
     assert np.allclose(uniform.bounds, resampled.bounds)
 
 
+@pytest.mark.parametrize(
+    'dimensions',
+    [(10, 10, 1), (10, 1, 1), (1, 1, 1), (5, 5, 1)],
+)
+def test_resample_dimensions_to_singleton(uniform, dimensions):
+    # Reducing a non-singleton axis to a single point requires a magnification
+    # factor of zero, which vtkImageResize silently ignores. Regression test for
+    # https://github.com/pyvista/pyvista/issues/8022
+    resampled = uniform.resample(dimensions=dimensions)
+    assert np.array_equal(resampled.dimensions, dimensions)
+
+
+def test_resample_dimensions_to_singleton_values():
+    # The collapsed axis is sampled (not ignored): a 3D volume flattened to a
+    # single z-slice must contain the values from that slice.
+    image = pv.ImageData(dimensions=(4, 4, 4))
+    image['v'] = np.arange(image.n_points, dtype=float)
+    resampled = image.resample(dimensions=(4, 4, 1))
+    assert np.array_equal(resampled.dimensions, (4, 4, 1))
+    # Nearest interpolation samples the first (z=0) slice of the volume.
+    first_slice = image['v'].reshape(image.dimensions[::-1])[0].ravel()
+    assert np.array_equal(np.sort(resampled.active_scalars), np.sort(first_slice))
+
+
 def test_resample_inplace(uniform):
     resampled = uniform.resample()
     assert resampled is not uniform


### PR DESCRIPTION
### Overview

Fixes `resample` silently ignoring requested output dimensions when an axis is reduced to a single point.

Resolves #8022.

```python
import pyvista as pv
im = pv.examples.load_uniform()        # dimensions (10, 10, 10)
im.resample(dimensions=(10, 10, 1)).dimensions
# before: (10, 10, 10)  ← request ignored
# after:  (10, 10, 1)   ← honored
```

### Details

- `resample` drives `vtkImageResize` with magnification factors. Reducing a non-singleton axis to one point requires a magnification factor of zero (`(1 - 1) / (N - 1) == 0`), but `vtkImageResize` silently ignores zero factors and leaves the axis at its original size. So requests like `dimensions=(10, 10, 1)` on a `(10, 10, 10)` image returned an unchanged `(10, 10, 10)` image.
- When any output dimension collapses to a singleton, the filter is now driven with explicit output dimensions (`SetResizeMethodToOutputDimensions`) so the request is honored — e.g. flattening a 3D volume into a single 2D slice. The collapsed axis is genuinely sampled (the resulting slice contains the values of the sampled plane), not dropped.
- The magnification-factor path is left untouched for every other case, so existing rounding behavior is preserved (output-dimension rounding differs subtly from `np.rint` for fractional `sample_rate`, so it was deliberately not changed there). Input singleton dimensions continue to pass through unresampled.
- Updated the docstring note to clarify that input singletons are preserved while output dimensions may be reduced to a singleton.

### Tests

Added `test_resample_dimensions_to_singleton` (dimensions are honored for several collapse requests) and `test_resample_dimensions_to_singleton_values` (the collapsed slice contains the sampled plane's values). The full `resample` suite (224 tests) passes.
