### PR TITLE
Add `Property.representation` and accept `RepresentationType` in `style`

### DIFF
--- a/pyvista/plotting/_property.py
+++ b/pyvista/plotting/_property.py
@@ -13,6 +13,7 @@ from pyvista.core.utilities.misc import _NoNewAttrMixin
 
 from .colors import Color
 from .opts import InterpolationType
+from .opts import RepresentationType
 
 
 class Property(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkProperty):
@@ -271,6 +272,15 @@ class Property(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkProperty):
         * ``'wireframe'``
         * ``'points'``
 
+        The setter also accepts an integer or a
+        :class:`~pyvista.plotting.opts.RepresentationType` enum member.
+
+        See Also
+        --------
+        representation
+            Equivalent property which returns a
+            :class:`~pyvista.plotting.opts.RepresentationType` enum member.
+
         Examples
         --------
         Get the default style and visualize it.
@@ -297,25 +307,50 @@ class Property(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkProperty):
         return self.GetRepresentationAsString()
 
     @style.setter
-    def style(self, new_style: str):
-        new_style = new_style.lower()
+    def style(self, new_style: str | int | RepresentationType):
+        self.representation = new_style
 
-        if new_style == 'wireframe':
-            self.SetRepresentationToWireframe()
-            if not self._color_set:
-                self.color = self._theme.outline_color  # type: ignore[union-attr] # type: ignore[attr-defined]
-        elif new_style == 'points':
-            self.SetRepresentationToPoints()
-        elif new_style == 'surface':
-            self.SetRepresentationToSurface()
-        else:
-            msg = (
-                f'Invalid style "{new_style}".  Must be one of the following:\n'
-                '\t"surface"\n'
-                '\t"wireframe"\n'
-                '\t"points"\n'
-            )
-            raise ValueError(msg)
+    @property
+    def representation(self) -> RepresentationType:  # numpydoc ignore=RT01
+        """Return or set the visualization representation of the mesh.
+
+        The setter accepts a string (case insensitive), an integer, or a
+        :class:`~pyvista.plotting.opts.RepresentationType` enum member. One of:
+
+        * ``'points'`` / :attr:`~pyvista.plotting.opts.RepresentationType.POINTS`
+        * ``'wireframe'`` / :attr:`~pyvista.plotting.opts.RepresentationType.WIREFRAME`
+        * ``'surface'`` / :attr:`~pyvista.plotting.opts.RepresentationType.SURFACE`
+
+        See Also
+        --------
+        style
+            Equivalent property which returns the representation as a string.
+
+        Examples
+        --------
+        Get the default representation.
+
+        >>> import pyvista as pv
+        >>> prop = pv.Property()
+        >>> prop.representation
+        <RepresentationType.SURFACE: 2>
+
+        Set the representation using the enum.
+
+        >>> from pyvista.plotting.opts import RepresentationType
+        >>> prop.representation = RepresentationType.WIREFRAME
+        >>> prop.representation
+        <RepresentationType.WIREFRAME: 1>
+
+        """
+        return RepresentationType.from_any(self.GetRepresentation())
+
+    @representation.setter
+    def representation(self, value: str | int | RepresentationType):
+        value = RepresentationType.from_any(value)
+        self.SetRepresentation(value.value)
+        if value == RepresentationType.WIREFRAME and not self._color_set:
+            self.color = self._theme.outline_color  # type: ignore[union-attr] # type: ignore[attr-defined]
 
     @property
     def color(self) -> Color:  # numpydoc ignore=RT01

--- a/tests/plotting/test_property.py
+++ b/tests/plotting/test_property.py
@@ -33,6 +33,50 @@ def test_property_style(prop):
     assert prop.style == style
 
 
+def test_property_representation(prop):
+    from pyvista.plotting.opts import RepresentationType
+
+    # default
+    assert prop.representation == RepresentationType.SURFACE
+    assert prop.style == 'Surface'
+
+    # set via enum, string (case insensitive), and int
+    prop.representation = RepresentationType.WIREFRAME
+    assert prop.representation == RepresentationType.WIREFRAME
+    assert prop.style == 'Wireframe'
+
+    prop.representation = 'POINTS'
+    assert prop.representation == RepresentationType.POINTS
+    assert prop.style == 'Points'
+
+    prop.representation = 2
+    assert prop.representation == RepresentationType.SURFACE
+
+    # invalid values raise
+    with pytest.raises(ValueError):  # noqa: PT011
+        prop.representation = 'invalid'
+    with pytest.raises(ValueError):  # noqa: PT011
+        prop.representation = 99
+
+
+def test_property_style_accepts_representation_type(prop):
+    # Regression test for https://github.com/pyvista/pyvista/issues/8168
+    # `style` setter previously only accepted strings.
+    from pyvista.plotting.opts import RepresentationType
+
+    prop.style = RepresentationType.WIREFRAME
+    assert prop.style == 'Wireframe'
+    assert prop.representation == RepresentationType.WIREFRAME
+    # `style` getter still returns a string for backwards compatibility
+    assert isinstance(prop.style, str)
+
+
+def test_property_representation_wireframe_color(prop):
+    # setting wireframe applies the theme outline color when no color is set
+    prop.representation = 'wireframe'
+    assert prop.color == pv.Color(prop._theme.outline_color)
+
+
 def test_property_edge_color(prop):
     prop.edge_color = 'b'
     assert prop.edge_color.float_rgb == (0, 0, 1)


### PR DESCRIPTION
### Overview

`pv.Property.style` only accepted strings, so assigning a `RepresentationType` enum member raised `AttributeError`. This is inconsistent with `Property.interpolation`, which already accepts its `InterpolationType` enum.

Resolves #8168.

```python
import pyvista as pv
from pyvista.plotting.opts import RepresentationType

prop = pv.Property()
prop.style = RepresentationType.WIREFRAME
# before: AttributeError: 'RepresentationType' object has no attribute 'lower'
# after:  works

prop.representation
# before: PyVistaAttributeError: 'representation' is defined by VTK and is not part of the PyVista API
# after:  <RepresentationType.WIREFRAME: 1>
```

### Details

- Added a `Property.representation` property that **returns** a `RepresentationType` member and whose setter **accepts** a string (case insensitive), an int, or a `RepresentationType`, via `RepresentationType.from_any(...)` — mirroring how `interpolation` uses `InterpolationType`.
- `Property.style` now delegates to `representation`. Its setter therefore accepts the same inputs (fixing the reported bug), while its getter still returns a `str` for backwards compatibility.
- The existing behavior of applying the theme outline color when switching to wireframe (and no color is set) is preserved.
- Invalid values continue to raise `ValueError`.

### On deprecating `style`

In the issue, @banesullivan suggested implementing `representation` and **deprecating** `style`. This PR adds `representation` and routes `style` through it, but does **not** deprecate `style` — `style`/`style=` is used widely (including the `Property(style=...)` constructor and `add_mesh(style=...)`), so I left the deprecation out to keep this change focused and non-breaking. Happy to add a deprecation path (and decide its scope) as a follow-up if you'd like.

### Tests

Added `test_property_representation` (get/set via enum, string, int; invalid raises), `test_property_style_accepts_representation_type` (regression for the reported bug; `style` still returns a string), and `test_property_representation_wireframe_color` (outline-color side effect). `tests/plotting/test_property.py` passes (29 tests); ruff, ruff-format, and mypy (on `_property.py`) are clean.
