### PR TITLE
Fix MNE-Python integration test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -46,14 +46,13 @@ jobs:
       matrix:
         include:
           - project: mne
-            # TODO: Intentionally set low, should set to 30
-            timeout: 4 # usually takes ~10, but the download can add time
+            timeout: 30 # usually takes ~10, but the download can add time
           - project: trame
             timeout: 8 # usually takes ~3
           - project: pyvistaqt
             timeout: 6 # usually takes ~2
           - project: geovista
-            timeout: 10 # usually takes ~5
+            timeout: 12 # usually takes ~5
           - project: playwright
             timeout: 6 # usually takes ~2
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -46,7 +46,8 @@ jobs:
       matrix:
         include:
           - project: mne
-            timeout: 20 # usually takes ~10
+            # TODO: Intentionally set low, should set to 30
+            timeout: 4 # usually takes ~10, but the download can add time
           - project: trame
             timeout: 8 # usually takes ~3
           - project: pyvistaqt

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,7 +47,7 @@ jobs:
         include:
           - project: mne
             # TODO: Intentionally set low, should set to 30
-            timeout: 8 # usually takes ~10, but the download can add time
+            timeout: 4 # usually takes ~10, but the download can add time
           - project: trame
             timeout: 8 # usually takes ~3
           - project: pyvistaqt

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -52,7 +52,7 @@ jobs:
           - project: pyvistaqt
             timeout: 6 # usually takes ~2
           - project: geovista
-            timeout: 12 # usually takes ~5
+            timeout: 16 # usually takes ~5
           - project: playwright
             timeout: 6 # usually takes ~2
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,7 +47,7 @@ jobs:
         include:
           - project: mne
             # TODO: Intentionally set low, should set to 30
-            timeout: 4 # usually takes ~10, but the download can add time
+            timeout: 8 # usually takes ~10, but the download can add time
           - project: trame
             timeout: 8 # usually takes ~3
           - project: pyvistaqt

--- a/tox.ini
+++ b/tox.ini
@@ -180,11 +180,11 @@ platform =
 
 commands_pre =
     # TRAME-PYVISTA SETUP
-    trame: git clone https://github.com/pyvista/trame-pyvista.git {env:TRAME_HOME} --single-branch
+    trame: bash -c "[ -d {env:TRAME_HOME} ] || git clone https://github.com/pyvista/trame-pyvista.git {env:TRAME_HOME} --single-branch"
     trame: uv pip install {env:TRAME_HOME}[test]
 
     # GEOVISTA SETUP
-    geovista: git clone https://github.com/bjlittle/geovista.git {env:GEOVISTA_HOME} --single-branch
+    geovista: bash -c "[ -d {env:GEOVISTA_HOME} ] || git clone https://github.com/bjlittle/geovista.git {env:GEOVISTA_HOME} --single-branch"
     geovista: uv pip install {env:GEOVISTA_HOME}[test,exam,cmap]
     geovista: cartopy_feature_download physical --output {env:XDG_DATA_HOME}{/}cartopy --no-warn
 
@@ -202,7 +202,7 @@ commands_pre =
     mne: python -c "import pyvista; assert not pyvista.OFF_SCREEN, f'{pyvista.OFF_SCREEN=} should be False'"
 
     # PYVISTAQT SETUP
-    pyvistaqt: git clone https://github.com/pyvista/pyvistaqt.git {env:PYVISTAQT_HOME} --single-branch
+    pyvistaqt: bash -c "[ -d {env:PYVISTAQT_HOME} ] || git clone https://github.com/pyvista/pyvistaqt.git {env:PYVISTAQT_HOME} --single-branch"
     pyvistaqt: uv pip install {env:PYVISTAQT_HOME}[test]
 
     # COMMON SETUP (CURRENT PYVISTA VERSION INSTALLATION)

--- a/tox.ini
+++ b/tox.ini
@@ -190,7 +190,7 @@ commands_pre =
 
     # MNE-PYTHON SETUP
     # Only clone if it hasn't been done already
-    mne: bash -c "if [ -d {env:MNE_HOME} ]; then exit 0; fi; git clone --depth=1 https://github.com/mne-tools/mne-python.git {env:MNE_HOME} --branch main --single-branch"
+    mne: bash -c "[ -d {env:MNE_HOME} ] || git clone --depth=1 https://github.com/mne-tools/mne-python.git {env:MNE_HOME} --branch main --single-branch"
     mne: uv pip install git+https://github.com/pyvista/pyvistaqt.git
     # Editable install so MNE's `*/tests` packages stay importable: MNE's
     # hatch build excludes `/mne/**/tests` from the wheel, but the notebook

--- a/tox.ini
+++ b/tox.ini
@@ -189,7 +189,8 @@ commands_pre =
     geovista: cartopy_feature_download physical --output {env:XDG_DATA_HOME}{/}cartopy --no-warn
 
     # MNE-PYTHON SETUP
-    mne: git clone --depth=1 https://github.com/mne-tools/mne-python.git {env:MNE_HOME} --branch main --single-branch
+    # Only clone if it hasn't been done already
+    mne: bash -c "if [ -d {env:MNE_HOME} ]; then exit 0; fi; git clone --depth=1 https://github.com/mne-tools/mne-python.git {env:MNE_HOME} --branch main --single-branch"
     mne: uv pip install git+https://github.com/pyvista/pyvistaqt.git
     # Editable install so MNE's `*/tests` packages stay importable: MNE's
     # hatch build excludes `/mne/**/tests` from the wheel, but the notebook

--- a/toxfile.py
+++ b/toxfile.py
@@ -108,6 +108,8 @@ def _get_freezed_requirements(lines: list[str]) -> Generator[tuple[str, Version]
     Note that the name is normalized per packaging specifications (see https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization).
     """
     for l in lines:
+        if l.startswith('-e '):  # installed in editable mode, e.g., MNE-Python
+            continue
         req = Requirement(l)
         if (m := re.match(r'(.*)==(\S+)', str(req.specifier))) is not None:
             yield _normalize_package_name(req.name), Version(m.group(2))


### PR DESCRIPTION
First version has intentionally short timeout so that I can see if I can fix the requirements handling to deal with a `-e` install first. Once that works, I'll back off the timeout, and we should be good to go.

Closes #8720