### PR TITLE
Update Codecov action version, fix gpg error

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -426,7 +426,7 @@ jobs:
           path: coverage*.xml
 
       - name: Upload coverage to CodeCov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           fail_ci_if_error: true
           use_oidc: true


### PR DESCRIPTION
### Overview

Attempt whether most recent codecov action version fixes the recent issues.