### PR TITLE
Preserve active attribute roles when renaming an array (#8746)

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -816,6 +816,7 @@ class DataSet(DataSetFilters, DataObject):
         arr.VTKObject.SetName(new_name)  # type: ignore[union-attr]
         data[new_name] = arr
 
+        # Restore active attributes
         for attribute_type, prior_name in prior_active.items():
             restored_name = new_name if prior_name == old_name else prior_name
             attribute = data.VTKObject.GetAttribute(attribute_type)

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -785,9 +785,6 @@ class DataSet(DataSetFilters, DataObject):
         """
         field = get_array_association(self, old_name, preference=preference)
 
-        was_active = False
-        if self.active_scalars_name == old_name:
-            was_active = True
         if field == FieldAssociation.POINT:
             data = self.point_data
         elif field == FieldAssociation.CELL:
@@ -798,20 +795,19 @@ class DataSet(DataSetFilters, DataObject):
             msg = f'Array with name {old_name} not found.'
             raise KeyError(msg)
 
-        # An array can also be the active normals, texture coordinates, vectors, etc.
-        # Popping it clears those designations on the vtkDataSetAttributes, so record
-        # them now and restore them after renaming, otherwise the rename silently drops
-        # them (see issue #8746). The active scalars are restored separately below via
-        # `set_active_scalars` so the dataset's cached scalars info stays in sync.
-        active_attributes: list[int] = []
+        # An array can be the active scalars, normals, texture coordinates, vectors,
+        # etc. Popping it clears those designations on the vtkDataSetAttributes, and
+        # re-adding it can promote it to the active scalars even if it was not active
+        # before (``DataSetAttributes.__setitem__`` activates new arrays when there
+        # are no active scalars). Snapshot every attribute role before renaming and
+        # restore the exact same state afterwards
+        # (see https://github.com/pyvista/pyvista/issues/8746).
+        prior_active: dict[int, str | None] = {}
         if field != FieldAssociation.NONE:
             attributes = data.VTKObject
             for attribute_type in range(_vtk.vtkDataSetAttributes.NUM_ATTRIBUTES):
-                if attribute_type == _vtk.vtkDataSetAttributes.SCALARS:
-                    continue
                 attribute = attributes.GetAttribute(attribute_type)
-                if attribute is not None and attribute.GetName() == old_name:
-                    active_attributes.append(attribute_type)
+                prior_active[attribute_type] = None if attribute is None else attribute.GetName()
 
         arr = data.pop(old_name)
         # Update the array's name before reassigning. This prevents taking a copy of the array in
@@ -820,11 +816,12 @@ class DataSet(DataSetFilters, DataObject):
         arr.VTKObject.SetName(new_name)  # type: ignore[union-attr]
         data[new_name] = arr
 
-        for attribute_type in active_attributes:
-            data.VTKObject.SetActiveAttribute(new_name, attribute_type)
-
-        if was_active and field != FieldAssociation.NONE:
-            self.set_active_scalars(new_name, preference=field)
+        for attribute_type, prior_name in prior_active.items():
+            restored_name = new_name if prior_name == old_name else prior_name
+            attribute = data.VTKObject.GetAttribute(attribute_type)
+            current_name = None if attribute is None else attribute.GetName()
+            if current_name != restored_name:
+                data.VTKObject.SetActiveAttribute(restored_name, attribute_type)
 
     @property
     def active_scalars(self: Self) -> pyvista_ndarray | None:

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -798,12 +798,30 @@ class DataSet(DataSetFilters, DataObject):
             msg = f'Array with name {old_name} not found.'
             raise KeyError(msg)
 
+        # An array can also be the active normals, texture coordinates, vectors, etc.
+        # Popping it clears those designations on the vtkDataSetAttributes, so record
+        # them now and restore them after renaming, otherwise the rename silently drops
+        # them (see issue #8746). The active scalars are restored separately below via
+        # `set_active_scalars` so the dataset's cached scalars info stays in sync.
+        active_attributes: list[int] = []
+        if field != FieldAssociation.NONE:
+            attributes = data.VTKObject
+            for attribute_type in range(_vtk.vtkDataSetAttributes.NUM_ATTRIBUTES):
+                if attribute_type == _vtk.vtkDataSetAttributes.SCALARS:
+                    continue
+                attribute = attributes.GetAttribute(attribute_type)
+                if attribute is not None and attribute.GetName() == old_name:
+                    active_attributes.append(attribute_type)
+
         arr = data.pop(old_name)
         # Update the array's name before reassigning. This prevents taking a copy of the array in
         # `DataSetAttributes._prepare_array` which can lead to the array being garbage collected.
         # See issue #5244.
         arr.VTKObject.SetName(new_name)  # type: ignore[union-attr]
         data[new_name] = arr
+
+        for attribute_type in active_attributes:
+            data.VTKObject.SetActiveAttribute(new_name, attribute_type)
 
         if was_active and field != FieldAssociation.NONE:
             self.set_active_scalars(new_name, preference=field)

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -745,7 +745,9 @@ def test_rename_array_preserves_active_attributes():
     point_data.active_scalars_name = None
 
     def active_tensors_name():
-        # There is no attributes-level tensors accessor.
+        # There is no attributes-level tensors accessor, and the dataset-level
+        # `active_tensors_name` reports stale state after a rename (see issue #8749),
+        # so read the actual state from VTK directly.
         tensors = point_data.VTKObject.GetTensors()
         return None if tensors is None else tensors.GetName()
 

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -727,7 +727,8 @@ def test_rename_array_doesnt_delete():
 
 def test_rename_array_preserves_active_attributes():
     # Regression test for issue #8746: renaming an array must not drop its active
-    # normals / texture coordinates / vectors designation, not only active scalars.
+    # normals / texture coordinates / vectors / tensors designation, and must not
+    # promote the renamed array to the active scalars.
     mesh = pv.Sphere()
     n = mesh.n_points
     point_data = mesh.point_data
@@ -737,10 +738,29 @@ def test_rename_array_preserves_active_attributes():
     point_data.active_texture_coordinates_name = 'my_tcoords'
     point_data['my_vectors'] = np.zeros((n, 3))
     point_data.active_vectors_name = 'my_vectors'
+    point_data['my_tensors'] = np.zeros((n, 9))
+    mesh.active_tensors_name = 'my_tensors'
+    # Active normals/tcoords/vectors/tensors but explicitly NO active scalars:
+    # renaming must not add any.
+    point_data.active_scalars_name = None
+
+    def active_tensors_name():
+        # There is no attributes-level tensors accessor.
+        tensors = point_data.VTKObject.GetTensors()
+        return None if tensors is None else tensors.GetName()
+
+    # Sanity check the setup before renaming.
+    assert point_data.active_normals_name == 'my_normals'
+    assert point_data.active_texture_coordinates_name == 'my_tcoords'
+    assert point_data.active_vectors_name == 'my_vectors'
+    assert active_tensors_name() == 'my_tensors'
+    assert point_data.active_scalars_name is None
+    assert mesh.active_scalars_name is None
 
     mesh.rename_array('my_normals', 'renamed_normals', preference='point')
     mesh.rename_array('my_tcoords', 'renamed_tcoords', preference='point')
     mesh.rename_array('my_vectors', 'renamed_vectors', preference='point')
+    mesh.rename_array('my_tensors', 'renamed_tensors', preference='point')
 
     assert point_data.active_normals_name == 'renamed_normals'
     assert point_data.active_normals is not None
@@ -748,6 +768,9 @@ def test_rename_array_preserves_active_attributes():
     assert point_data.active_texture_coordinates is not None
     assert point_data.active_vectors_name == 'renamed_vectors'
     assert point_data.active_vectors is not None
+    assert active_tensors_name() == 'renamed_tensors'
+    assert point_data.active_scalars_name is None
+    assert mesh.active_scalars_name is None
 
 
 def test_change_name_fail(hexbeam):

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -725,6 +725,31 @@ def test_rename_array_doesnt_delete():
     assert (mesh.point_data['renamed'] == 1).all()
 
 
+def test_rename_array_preserves_active_attributes():
+    # Regression test for issue #8746: renaming an array must not drop its active
+    # normals / texture coordinates / vectors designation, not only active scalars.
+    mesh = pv.Sphere()
+    n = mesh.n_points
+    point_data = mesh.point_data
+    point_data['my_normals'] = np.tile([0.0, 0.0, 1.0], (n, 1))
+    point_data.active_normals_name = 'my_normals'
+    point_data['my_tcoords'] = np.zeros((n, 2))
+    point_data.active_texture_coordinates_name = 'my_tcoords'
+    point_data['my_vectors'] = np.zeros((n, 3))
+    point_data.active_vectors_name = 'my_vectors'
+
+    mesh.rename_array('my_normals', 'renamed_normals', preference='point')
+    mesh.rename_array('my_tcoords', 'renamed_tcoords', preference='point')
+    mesh.rename_array('my_vectors', 'renamed_vectors', preference='point')
+
+    assert point_data.active_normals_name == 'renamed_normals'
+    assert point_data.active_normals is not None
+    assert point_data.active_texture_coordinates_name == 'renamed_tcoords'
+    assert point_data.active_texture_coordinates is not None
+    assert point_data.active_vectors_name == 'renamed_vectors'
+    assert point_data.active_vectors is not None
+
+
 def test_change_name_fail(hexbeam):
     with pytest.raises(KeyError):
         hexbeam.rename_array('not a key', '')


### PR DESCRIPTION
### Overview

Resolves #8746. `rename_array` lost the active **normals** and **texture coordinates** (and other non-scalar attribute) designations when renaming an array — only active *scalars* were preserved.

Thanks to @user27182 for the clear repro.

### Details

- `rename_array` renames by popping the array and re-adding it under the new name (kept that way deliberately for #5244). Popping clears the array's active-attribute roles on the underlying `vtkDataSetAttributes`, but only the active *scalars* role was being restored afterwards. So renaming e.g. a textured sphere's unnamed normals/tcoords arrays cleared `active_normals` / `active_texture_coordinates`:

  ```python
  import vtk
  import pyvista as pv

  source = vtk.vtkTexturedSphereSource()
  source.Update()
  output = pv.wrap(source.GetOutput())
  output.rename_array('Unnamed_0', 'Normals')
  assert output.active_normals is None  # was the bug — now preserved
  ```

- Fix: before the pop, record every active-attribute role the array currently holds (normals, texture coordinates, vectors, tensors, …) by scanning `vtkDataSetAttributes` attribute slots; after re-adding, restore them with `SetActiveAttribute`. Active scalars are still restored via `set_active_scalars` so the dataset's cached scalars info (`_active_scalars_info`) stays in sync. Field data (no active attributes) and plain non-active arrays are unaffected.

- Added `test_rename_array_preserves_active_attributes` covering normals, texture coordinates and vectors (red on `main`). Existing `rename_array` tests, full `tests/core/test_dataset.py` (287 passed) and `tests/core/test_datasetattributes.py` (91 passed) pass locally; `ruff` and `mypy` clean on the changed file.
