### PR TITLE
Validate cached active tensors info against VTK state

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -278,6 +278,26 @@ class DataSet(DataSetFilters, DataObject):
             Active tensor's field and name: [field, name].
 
         """
+        field, name = self._active_tensors_info
+
+        # verify this field is still valid
+        if name is not None:
+            if field is FieldAssociation.POINT:
+                if self.point_data.active_tensors_name != name:
+                    name = None
+            if field is FieldAssociation.CELL:
+                if self.cell_data.active_tensors_name != name:
+                    name = None
+
+        if name is None:
+            # check for the active tensors in point or cell arrays
+            self._active_tensors_info = ActiveArrayInfoTuple(field, None)
+            for attr in [self.point_data, self.cell_data]:
+                name = attr.active_tensors_name
+                if name is not None:
+                    self._active_tensors_info = ActiveArrayInfoTuple(attr.association, name)
+                    break
+
         return self._active_tensors_info
 
     @property

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -1586,6 +1586,62 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
         self._raise_no_normals()
         self.SetActiveNormals(name)
 
+    @property
+    def active_tensors_name(self: Self) -> str | None:
+        """Return the name of the active tensors array.
+
+        Returns
+        -------
+        Optional[str]
+            Name of the active tensors array.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> import pyvista as pv
+        >>> mesh = pv.Sphere()
+        >>> mesh.point_data['my-tensors'] = np.zeros((mesh.n_points, 9))
+        >>> mesh.point_data.active_tensors_name = 'my-tensors'
+        >>> mesh.point_data.active_tensors_name
+        'my-tensors'
+
+        """
+        self._raise_no_tensors()
+        if self.GetTensors() is not None:
+            return str(self.GetTensors().GetName())
+        return None
+
+    @active_tensors_name.setter
+    def active_tensors_name(self: Self, name: str | None) -> None:
+        """Set the name of the active tensors array.
+
+        Parameters
+        ----------
+        name : str
+            Name of the active tensors array.
+
+        """
+        # permit setting no active
+        if name is None:
+            self.SetActiveTensors(None)
+            return
+        self._raise_no_tensors()
+        if name not in self:
+            msg = f'DataSetAttribute does not contain "{name}"'
+            raise KeyError(msg)
+        # VTK accepts 9-component (full) and 6-component (symmetric) tensor
+        # arrays; let it reject anything else
+        if self.SetActiveTensors(name) < 0:
+            n_comp = self.GetArray(name).GetNumberOfComponents()
+            msg = f'{name} needs 9 or 6 components, has ({n_comp})'
+            raise ValueError(msg)
+
+    def _raise_no_tensors(self: Self) -> None:
+        """Raise AttributeError when attempting access tensors for field data."""
+        if self.association == FieldAssociation.NONE:
+            msg = 'FieldData does not have active tensors.'
+            raise AttributeError(msg)
+
     def _raise_no_normals(self: Self) -> None:
         """Raise AttributeError when attempting access normals for field data."""
         if self.association == FieldAssociation.NONE:

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -580,6 +580,22 @@ def test_set_active_tensors(hexbeam):
     active_component_consistency_check(hexbeam, 'tensors', 'point')
 
 
+def test_active_tensors_name_not_stale(hexbeam):
+    """Removing or renaming the active tensors array updates the reported name (#8749)."""
+    tensor_arr = np.arange(hexbeam.n_points * 9).reshape([hexbeam.n_points, 9])
+    hexbeam.point_data['tensor_arr'] = tensor_arr
+    hexbeam.active_tensors_name = 'tensor_arr'
+
+    hexbeam.point_data.remove('tensor_arr')
+    assert hexbeam.active_tensors_name is None
+    assert hexbeam.active_tensors is None
+
+    hexbeam.point_data['tensor_arr'] = tensor_arr
+    hexbeam.active_tensors_name = 'tensor_arr'
+    hexbeam.rename_array('tensor_arr', 'renamed_arr')
+    assert hexbeam.active_tensors_name == 'renamed_arr'
+
+
 def test_set_texture_coordinates(hexbeam):
     with pytest.raises(TypeError):
         hexbeam.active_texture_coordinates = [1, 2, 3]

--- a/tests/core/test_datasetattributes.py
+++ b/tests/core/test_datasetattributes.py
@@ -678,6 +678,31 @@ def test_active_vectors_name_setter():
         mesh.point_data.active_vectors_name = 'my-scalars'
 
 
+def test_active_tensors_name_setter():
+    mesh = pv.Plane(i_resolution=1, j_resolution=1)
+    mesh.point_data.set_array(range(4), 'my-scalars')
+    mesh.point_data['tensors9'] = np.zeros((4, 9))
+    mesh.point_data['tensors6'] = np.zeros((4, 6))
+
+    mesh.point_data.active_tensors_name = 'tensors9'
+    assert mesh.point_data.active_tensors_name == 'tensors9'
+    # VTK also accepts 6-component (symmetric) tensors
+    mesh.point_data.active_tensors_name = 'tensors6'
+    assert mesh.point_data.active_tensors_name == 'tensors6'
+
+    mesh.point_data.active_tensors_name = None
+    assert mesh.point_data.active_tensors_name is None
+
+    with pytest.raises(KeyError, match='does not contain'):
+        mesh.point_data.active_tensors_name = 'not a valid key'
+
+    with pytest.raises(ValueError, match='needs 9 or 6 components'):
+        mesh.point_data.active_tensors_name = 'my-scalars'
+
+    with pytest.raises(AttributeError):
+        _ = mesh.field_data.active_tensors_name
+
+
 def test_active_vectors_eq():
     mesh = pv.Plane(i_resolution=1, j_resolution=1)
     vectors0 = np.random.default_rng().random((4, 3))


### PR DESCRIPTION
Fixes #8749.

`active_tensors_info` returned its cached value unvalidated, so `active_tensors_name` kept reporting an array after it was removed or renamed, while scalars and vectors self-heal in the same scenario. This brings tensors in line with `active_vectors_info`: the getter now verifies the cached name against the attribute-level state and falls back to whatever VTK actually has active.

Doing that needed an attribute-level accessor, so `DataSetAttributes` gains `active_tensors_name` (get/set), mirroring `active_vectors_name`. The setter relies on VTK's `SetActiveTensors` return value rather than a hand-rolled component check since VTK accepts both 9-component and 6-component (symmetric) tensor arrays.

The staleness regression test fails on main; also covers the rename case from #8748's review thread, the 6/9-component setter paths, and the field-data guard.
