### PR TITLE
Avoid dynamic imports while Python is shutting down

### DIFF
--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -460,7 +460,7 @@ class _DataObjectMeta(_AutoFreezeABCMeta):
     def __getattr__(cls, name: str) -> Any:
         # Check sys.meta_path to avoid dynamic imports when Python is shutting down
         if sys.meta_path is None:
-            return None
+            return None  # type: ignore[unreachable]
 
         from pyvista.core.utilities.accessor_registry import (  # noqa: PLC0415
             _resolve_pending_accessor,

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -459,15 +459,17 @@ class _DataObjectMeta(_AutoFreezeABCMeta):
 
     def __getattr__(cls, name: str) -> Any:
         # Check sys.meta_path to avoid dynamic imports when Python is shutting down
-        if sys.meta_path is not None:
-            from pyvista.core.utilities.accessor_registry import (  # noqa: PLC0415
-                _resolve_pending_accessor,
-            )
+        if sys.meta_path is None:
+            return None
 
-            if _resolve_pending_accessor(name):
-                return getattr(cls, name)
-            msg = f'type object {cls.__name__!r} has no attribute {name!r}'
-            raise AttributeError(msg)
+        from pyvista.core.utilities.accessor_registry import (  # noqa: PLC0415
+            _resolve_pending_accessor,
+        )
+
+        if _resolve_pending_accessor(name):
+            return getattr(cls, name)
+        msg = f'type object {cls.__name__!r} has no attribute {name!r}'
+        raise AttributeError(msg)
 
 
 def _hasattr_static(obj: Any, attr: str) -> bool:

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -458,14 +458,16 @@ class _DataObjectMeta(_AutoFreezeABCMeta):
     """
 
     def __getattr__(cls, name: str) -> Any:
-        from pyvista.core.utilities.accessor_registry import (  # noqa: PLC0415
-            _resolve_pending_accessor,
-        )
+        # Check sys.meta_path to avoid dynamic imports when Python is shutting down
+        if sys.meta_path is not None:
+            from pyvista.core.utilities.accessor_registry import (  # noqa: PLC0415
+                _resolve_pending_accessor,
+            )
 
-        if _resolve_pending_accessor(name):
-            return getattr(cls, name)
-        msg = f'type object {cls.__name__!r} has no attribute {name!r}'
-        raise AttributeError(msg)
+            if _resolve_pending_accessor(name):
+                return getattr(cls, name)
+            msg = f'type object {cls.__name__!r} has no attribute {name!r}'
+            raise AttributeError(msg)
 
 
 def _hasattr_static(obj: Any, attr: str) -> bool:

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -459,7 +459,7 @@ class _DataObjectMeta(_AutoFreezeABCMeta):
 
     def __getattr__(cls, name: str) -> Any:
         # Check sys.meta_path to avoid dynamic imports when Python is shutting down
-        if sys.meta_path is None:
+        if sys.meta_path is None:  # pragma: no cover
             return None  # type: ignore[unreachable]
 
         from pyvista.core.utilities.accessor_registry import (  # noqa: PLC0415


### PR DESCRIPTION
### Overview

Fix #8760 

Probably should be included in a 0.48 patch release.

FYI @banesullivan 