### PR TITLE
Fix vtkContextActor rendering after lazy imports

### DIFF
--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 # Magic vtk imports needed to make LaTeX rendering work. See https://discourse.vtk.org/t/how-to-check-if-mathtext-is-supported-without-importing-all-of-vtk/16038
 # isort: off
 import vtkmodules.vtkRenderingFreeType  # noqa: F401, TID251
+import vtkmodules.vtkRenderingContextOpenGL2  # noqa: F401, TID251
 import vtkmodules.vtkRenderingMatplotlib  # noqa: F401, TID251
 # isort: on
 

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -18,7 +18,6 @@ import numpy as np
 import pyvista as pv
 from pyvista import _vtk
 from pyvista._deprecate_positional_args import _deprecate_positional_args
-from pyvista._warn_external import warn_external
 from pyvista.core._vtk_utilities import DisableVtkSnakeCase
 from pyvista.core.utilities.misc import _NoNewAttrMixin
 from pyvista.core.utilities.misc import abstract_class
@@ -1166,14 +1165,6 @@ class _Chart(DocSubs):
     _DOC_SUBS: dict[str, str] | None = None
 
     def __init__(self, size=(1, 1), loc=(0, 0)) -> None:
-        try:
-            # Necessary for displaying charts, otherwise crashes on rendering
-            # Import lazily on init to delay import until it's needed
-            from vtkmodules import vtkRenderingContextOpenGL2  # noqa: F401, PLC0415, TID251
-        except ImportError:
-            msg = 'Unable to import `vtkRenderingContextOpenGL2`. Charts may not render.'
-            warn_external(msg)
-
         super().__init__()
         self._background = _ChartBackground(self)
         self._x_axis = Axis()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -41,6 +41,7 @@ PLOTTING_VTKMODULES = CORE_VTKMODULES | {
     'vtkmodules.vtkPythonContext2D',
     'vtkmodules.vtkRenderingAnnotation',
     'vtkmodules.vtkRenderingContext2D',
+    'vtkmodules.vtkRenderingContextOpenGL2',
     'vtkmodules.vtkRenderingCore',
     'vtkmodules.vtkRenderingFreeType',
     'vtkmodules.vtkRenderingHyperTreeGrid',
@@ -114,6 +115,15 @@ def test_pyvista_oo_flag():
     command = [sys.executable, '-OO', '-c', code]
     result = subprocess.run(command, capture_output=True, text=True, check=False)
     assert result.returncode == 0, f'PyVista failed with -OO flag. stderr: {result.stderr}'
+
+
+def test_plotting_import_loads_context_opengl2():
+    code = (
+        'import pyvista.plotting\n'
+        'import sys\n'
+        "assert 'vtkmodules.vtkRenderingContextOpenGL2' in sys.modules"
+    )
+    assert exec_success(code)
 
 
 def test_plotting_attribute_cached():


### PR DESCRIPTION
### Overview

Resolves #8668.

`vtkRenderingContextOpenGL2` is a side-effect-only VTK module, so the lazy `_vtk.__getattr__` path cannot load it on demand. This moves that import to `pyvista.plotting` startup alongside the existing rendering plugin imports, so direct `vtkContextActor` / `vtkContextScene` use gets the OpenGL2 context backend before rendering.

### Details

- Eagerly import `vtkmodules.vtkRenderingContextOpenGL2` from `pyvista.plotting`.
- Remove the now-redundant chart-only lazy import and warning path.
- Add a subprocess import regression test for the plugin load.

Validated with:

- `python -m pytest tests/test_init.py`
- `python -m pytest tests/plotting/test_charts.py::test_chart_common tests/plotting/test_charts.py::test_chart_2d tests/plotting/test_charts.py::test_charts`
- `python -m ruff check pyvista/plotting/__init__.py pyvista/plotting/charts.py tests/test_init.py`
- `python -m ruff format --check pyvista/plotting/__init__.py pyvista/plotting/charts.py tests/test_init.py`
