### PR TITLE
Deprecate `read_grdecl`

### DIFF
--- a/pyvista/core/utilities/fileio.py
+++ b/pyvista/core/utilities/fileio.py
@@ -26,6 +26,7 @@ from pyvista import _vtk
 from pyvista._deprecate_positional_args import _deprecate_positional_args
 from pyvista._warn_external import warn_external
 from pyvista.core import _validation
+from pyvista.core.errors import PyVistaDeprecationWarning
 from pyvista.core.utilities.misc import _classproperty
 from pyvista.core.utilities.misc import _NoNewAttrMixin
 
@@ -710,6 +711,23 @@ def read_grdecl(
     {"MAPUNITS": ..., "GRIDUNIT": ..., ...}
 
     """
+    if pv.version_info >= (0, 52):  # pragma: no cover
+        msg = 'Remove this deprecated function private'
+        raise RuntimeError(msg)
+    msg = (
+        '`read_grdecl` is deprecated and will be removed in a future version. '
+        'Use `pyvista.read` or `pyvista.GRDECLReader` instead.'
+    )
+    warn_external(msg, PyVistaDeprecationWarning)
+    return _read_grdecl(filename, elevation=elevation, other_keywords=other_keywords)
+
+
+def _read_grdecl(
+    filename: str | Path,
+    *,
+    elevation: bool = True,
+    other_keywords: Sequence[str] | None = None,
+) -> ExplicitStructuredGrid:
     property_keywords = (
         'ACTNUM',
         'COORD',

--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -34,7 +34,7 @@ from .fileio import _FileIOBase
 from .fileio import _get_ext_force
 from .fileio import _lazy_vtk_import
 from .fileio import _process_filename
-from .fileio import read_grdecl
+from .fileio import _read_grdecl
 from .helpers import wrap
 from .misc import _NoNewAttrMixin
 from .misc import abstract_class
@@ -2737,7 +2737,7 @@ class _GRDECLReader(BaseVTKReader):
 
     def Update(self) -> None:
         """Read the GRDECL file and store internally to `_data_object`."""
-        self._data_object = read_grdecl(
+        self._data_object = _read_grdecl(
             self._filename,
             elevation=self._elevation,
             other_keywords=self._other_keywords,

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -1395,7 +1395,12 @@ def test_grdecl_reader(tmp_path, as_reader):
                 setattr(reader, key, value)
             return reader.read()
         else:
-            return pv.core.utilities.fileio.read_grdecl(filepath, **kwargs)
+            match = (
+                '`read_grdecl` is deprecated and will be removed in a future version. '
+                'Use `pyvista.read` or `pyvista.GRDECLReader` instead.'
+            )
+            with pytest.warns(pv.PyVistaDeprecationWarning, match=match):
+                return pv.core.utilities.fileio.read_grdecl(filepath, **kwargs)
 
     path = Path(__file__).parent.parent / 'example_files'
 


### PR DESCRIPTION
### Overview

Follow-up to #8765 and #8771. Those PRs made it possible to do `pv.read(file.grdecl, elevation=False)` instead of `pv.read_grdecl(file.grdecl, elevation=False)`, so `read_grcecl` can now be deprecated.

FYI @keurfonluu 