### PR TITLE
Fix dataset gallery URLs

### DIFF
--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -35,6 +35,7 @@ from scipy.stats import linregress
 
 import pyvista as pv
 from pyvista import _validation
+from pyvista import examples
 from pyvista.core.celltype import _CELL_TYPE_INFO
 from pyvista.core.celltype import PLACEHOLDER
 from pyvista.core.filters.data_object import _get_cell_quality_measures
@@ -51,6 +52,8 @@ from pyvista.examples._dataset_loader import _DatasetLoader
 from pyvista.examples._dataset_loader import _Downloadable
 from pyvista.examples._dataset_loader import _MultiFilePropsProtocol
 from pyvista.examples._dataset_loader import _SingleFilePropsProtocol
+from pyvista.examples.downloads import _DEFAULT_VTK_DATA_SOURCE
+from pyvista.examples.downloads import _FILE_CACHE
 from pyvista.plotting.colors import _CSS_COLORS
 from pyvista.plotting.colors import _PARAVIEW_COLORS
 from pyvista.plotting.colors import _TABLEAU_COLORS
@@ -2690,9 +2693,13 @@ class DatasetPropsGenerator:
         # Collect url names and links as sequences
         name = loader.source_name
         names = [name] if isinstance(name, str) else name
-        url = loader.source_url_blob
+        url = loader.source_url_raw
         urls = [url] if isinstance(url, str) else url
+        # Ensure urls are not based on local cache
+        if loader._module is examples.downloads and _FILE_CACHE:
+            urls = [url.replace(loader.base_url, _DEFAULT_VTK_DATA_SOURCE) for url in urls]
 
+        urls = examples._dataset_loader._Downloadable._raw_to_blob(urls)
         # Use dict to create an ordered set to make sure links are unique
         url_dict = {url: name for name, url in zip(names, urls, strict=True)}
 

--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -2697,7 +2697,12 @@ class DatasetPropsGenerator:
         urls = [url] if isinstance(url, str) else url
         # Ensure urls are not based on local cache
         if loader._module is examples.downloads and _FILE_CACHE:
-            urls = [url.replace(loader.base_url, _DEFAULT_VTK_DATA_SOURCE) for url in urls]
+            base = loader.base_url
+            bases = [base] if isinstance(base, str) else base
+            urls = [
+                url.replace(base, _DEFAULT_VTK_DATA_SOURCE)
+                for base, url in zip(bases, urls, strict=True)
+            ]
 
         urls = examples._dataset_loader._Downloadable._raw_to_blob(urls)
         # Use dict to create an ordered set to make sure links are unique

--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -35,7 +35,6 @@ from scipy.stats import linregress
 
 import pyvista as pv
 from pyvista import _validation
-from pyvista import examples
 from pyvista.core.celltype import _CELL_TYPE_INFO
 from pyvista.core.celltype import PLACEHOLDER
 from pyvista.core.filters.data_object import _get_cell_quality_measures
@@ -52,8 +51,6 @@ from pyvista.examples._dataset_loader import _DatasetLoader
 from pyvista.examples._dataset_loader import _Downloadable
 from pyvista.examples._dataset_loader import _MultiFilePropsProtocol
 from pyvista.examples._dataset_loader import _SingleFilePropsProtocol
-from pyvista.examples.downloads import _DEFAULT_VTK_DATA_SOURCE
-from pyvista.examples.downloads import _FILE_CACHE
 from pyvista.plotting.colors import _CSS_COLORS
 from pyvista.plotting.colors import _PARAVIEW_COLORS
 from pyvista.plotting.colors import _TABLEAU_COLORS
@@ -2693,18 +2690,9 @@ class DatasetPropsGenerator:
         # Collect url names and links as sequences
         name = loader.source_name
         names = [name] if isinstance(name, str) else name
-        url = loader.source_url_raw
+        url = loader.web_url
         urls = [url] if isinstance(url, str) else url
-        # Ensure urls are not based on local cache
-        if loader._module is examples.downloads and _FILE_CACHE:
-            base = loader.base_url
-            bases = [base] if isinstance(base, str) else base
-            urls = [
-                url.replace(base, _DEFAULT_VTK_DATA_SOURCE)
-                for base, url in zip(bases, urls, strict=True)
-            ]
 
-        urls = examples._dataset_loader._Downloadable._raw_to_blob(urls)
         # Use dict to create an ordered set to make sure links are unique
         url_dict = {url: name for name, url in zip(names, urls, strict=True)}
 
@@ -3226,6 +3214,16 @@ class DownloadsCarousel(DatasetGalleryCarousel):
     def fetch_dataset_names(cls):
         return DatasetCardFetcher.fetch_dataset_names_by_module(pv.examples.downloads)
 
+    @classmethod
+    def generate(cls):
+        super().generate()
+        # Sanity check to ensure proper URLs are generated due to complexity with
+        # using local cached data for downloads
+        with open(cls.path) as f:
+            content = f.read()
+        real_url = 'https://github.com/pyvista/data/blob/master/Data/cow.vtp'
+        assert real_url in content
+
 
 class PlanetsCarousel(DatasetGalleryCarousel):
     """Class to generate a carousel with cards from the planets module."""
@@ -3249,6 +3247,16 @@ class GltfCarousel(DatasetGalleryCarousel):
     @classmethod
     def fetch_dataset_names(cls):
         return DatasetCardFetcher.fetch_dataset_names_by_module(pv.examples.gltf)
+
+    @classmethod
+    def generate(cls):
+        super().generate()
+        # Sanity check to ensure proper URLs are generated due to complexity with
+        # using local cached data for downloads
+        with open(cls.path) as f:
+            content = f.read()
+        real_url = 'https://github.com/KhronosGroup/glTF-Sample-Models/blob/main/2.0/DamagedHelmet/glTF-Embedded/DamagedHelmet.gltf'
+        assert real_url in content
 
 
 class PointSetCarousel(DatasetGalleryCarousel):

--- a/pyvista/examples/_dataset_loader.py
+++ b/pyvista/examples/_dataset_loader.py
@@ -154,33 +154,42 @@ class _Downloadable(Protocol[_FilePropStrType_co]):
         """Return the base url of the download."""
 
     @property
-    def source_url_raw(self) -> _FilePropStrType_co:
-        """Return the raw source of the download.
+    def source_url(self) -> _FilePropStrType_co:
+        """Return the source of the download.
 
-        This is the full URL used to download the data directly.
+        This is the full URL or local cached path used to download the data directly.
         """
+        return self._source_url()
+
+    def _source_url(self, *, web_blob: bool = False):
+        base_url = self.base_url
+        base_url_iter = [base_url] if isinstance(base_url, str) else list(base_url)
+        if web_blob:
+            # Ensure urls are not based on a local cache path
+            from pyvista.examples.downloads import _DEFAULT_VTK_DATA_SOURCE  # noqa: PLC0415
+            from pyvista.examples.downloads import _FILE_CACHE  # noqa: PLC0415
+            from pyvista.examples.downloads import SOURCE  # noqa: PLC0415
+
+            for i, base in enumerate(base_url_iter):
+                new_base = _DEFAULT_VTK_DATA_SOURCE if _FILE_CACHE and (base == SOURCE) else base
+                assert new_base.startswith('http')
+                new_base = new_base.replace('/raw/', '/blob/')
+                assert '/blob/' in new_base
+                base_url_iter[i] = new_base
+
         name = self.source_name
         name_iter = [name] if isinstance(name, str) else name
-        url = self.base_url
-        base_url_iter = [url] if isinstance(url, str) else url
-        url_raw = list(map(os.path.join, base_url_iter, name_iter))
-        return url_raw[0] if isinstance(name, str) else tuple(url_raw)
+        urls = list(map(os.path.join, base_url_iter, name_iter))
+        return urls[0] if isinstance(name, str) else tuple(urls)
 
     @property
-    def source_url_blob(self) -> _FilePropStrType_co:
-        """Return the blob source of the download.
+    def web_url(self) -> _FilePropStrType_co:
+        """Return the web source of the download as blob instead of raw.
 
         This URL is useful for linking to the source webpage for
         a human to open on a browser.
         """
-        # Make single urls iterable and replace 'raw' with 'blob'
-        return _Downloadable._raw_to_blob(self.source_url_raw)
-
-    @staticmethod
-    def _raw_to_blob(url_raw):
-        url_iter = [url_raw] if isinstance(url_raw, str) else url_raw
-        url_blob = [url.replace('/raw/', '/blob/') for url in url_iter]
-        return url_blob[0] if isinstance(url_raw, str) else tuple(url_blob)
+        return self._source_url(web_blob=True)
 
     @property
     @abstractmethod

--- a/pyvista/examples/_dataset_loader.py
+++ b/pyvista/examples/_dataset_loader.py
@@ -174,7 +174,10 @@ class _Downloadable(Protocol[_FilePropStrType_co]):
         a human to open on a browser.
         """
         # Make single urls iterable and replace 'raw' with 'blob'
-        url_raw = self.source_url_raw
+        return _Downloadable._raw_to_blob(self.source_url_raw)
+
+    @staticmethod
+    def _raw_to_blob(url_raw):
         url_iter = [url_raw] if isinstance(url_raw, str) else url_raw
         url_blob = [url.replace('/raw/', '/blob/') for url in url_iter]
         return url_blob[0] if isinstance(url_raw, str) else tuple(url_blob)

--- a/pyvista/examples/gltf.py
+++ b/pyvista/examples/gltf.py
@@ -15,7 +15,7 @@ _GLTF_PATHS: dict[str, str] = {
     'milk_truck': 'CesiumMilkTruck/glTF-Binary/CesiumMilkTruck.glb',
 }
 
-_GLTF_BASE_URL = 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/'
+_GLTF_BASE_URL = 'https://github.com/KhronosGroup/glTF-Sample-Models/raw/main/2.0/'
 
 
 GLTF_FETCHER = pooch.create(  # type: ignore[attr-defined]

--- a/tests/examples/test_dataset_loader.py
+++ b/tests/examples/test_dataset_loader.py
@@ -208,8 +208,8 @@ def test_single_file_loader(file_loader, use_archive):
         assert os.path.isfile(path_download)
         assert os.path.isabs(path_download)
         assert file_loader.path == path_download
-        assert 'https://github.com/pyvista/data/raw/master/Data/' in file_loader.source_url_raw
-        assert 'https://github.com/pyvista/data/blob/master/Data/' in file_loader.source_url_blob
+        assert 'https://github.com/pyvista/data/raw/master/Data/' in file_loader.source_url
+        assert 'https://github.com/pyvista/data/blob/master/Data/' in file_loader.web_url
     else:
         with pytest.raises(AttributeError):
             file_loader.download()
@@ -284,11 +284,11 @@ def test_multi_file_loader(load_func):
     assert all(os.path.isfile(file) for file in path_download)
     assert all(
         'https://github.com/pyvista/data/raw/master/Data/' in url
-        for url in multi_file_loader.source_url_raw
+        for url in multi_file_loader.source_url
     )
     assert all(
         'https://github.com/pyvista/data/blob/master/Data/' in url
-        for url in multi_file_loader.source_url_blob
+        for url in multi_file_loader.web_url
     )
 
     # test load
@@ -345,12 +345,10 @@ def test_dataset_loader_one_file_local(dataset_loader_one_file_local):
     assert loader.unique_dataset_type is pv.PolyData
     assert loader.source_name == 'ant.ply'
     assert (
-        loader.source_url_raw
-        == 'https://github.com/pyvista/pyvista/raw/main/pyvista/examples/ant.ply'
+        loader.source_url == 'https://github.com/pyvista/pyvista/raw/main/pyvista/examples/ant.ply'
     )
     assert (
-        loader.source_url_blob
-        == 'https://github.com/pyvista/pyvista/blob/main/pyvista/examples/ant.ply'
+        loader.web_url == 'https://github.com/pyvista/pyvista/blob/main/pyvista/examples/ant.ply'
     )
     assert loader.unique_cell_types == (pv.CellType.TRIANGLE,)
 
@@ -376,8 +374,8 @@ def test_dataset_loader_one_file(dataset_loader_one_file):
     assert isinstance(loader.dataset_iterable[0], pv.PolyData)
     assert loader.unique_dataset_type is pv.PolyData
     assert loader.source_name == 'cow.vtp'
-    assert loader.source_url_raw == 'https://github.com/pyvista/data/raw/master/Data/cow.vtp'
-    assert loader.source_url_blob == 'https://github.com/pyvista/data/blob/master/Data/cow.vtp'
+    assert loader.source_url == 'https://github.com/pyvista/data/raw/master/Data/cow.vtp'
+    assert loader.web_url == 'https://github.com/pyvista/data/blob/master/Data/cow.vtp'
     assert loader.unique_cell_types == (
         pv.CellType.TRIANGLE,
         pv.CellType.POLYGON,
@@ -415,11 +413,11 @@ def test_dataset_loader_two_files_one_loadable(dataset_loader_two_files_one_load
     assert isinstance(loader.dataset_iterable[0], pv.ImageData)
     assert loader.unique_dataset_type is pv.ImageData
     assert loader.source_name == ('HeadMRVolume.mhd', 'HeadMRVolume.raw')
-    assert loader.source_url_raw == (
+    assert loader.source_url == (
         'https://github.com/pyvista/data/raw/master/Data/HeadMRVolume.mhd',
         'https://github.com/pyvista/data/raw/master/Data/HeadMRVolume.raw',
     )
-    assert loader.source_url_blob == (
+    assert loader.web_url == (
         'https://github.com/pyvista/data/blob/master/Data/HeadMRVolume.mhd',
         'https://github.com/pyvista/data/blob/master/Data/HeadMRVolume.raw',
     )
@@ -461,11 +459,11 @@ def test_dataset_loader_two_files_both_loadable(dataset_loader_two_files_both_lo
     assert isinstance(loader.dataset_iterable[2], pv.ImageData)
     assert loader.unique_dataset_type == (pv.MultiBlock, pv.ImageData)
     assert loader.source_name == ('bolt.slc', 'nut.slc')
-    assert loader.source_url_raw == (
+    assert loader.source_url == (
         'https://github.com/pyvista/data/raw/master/Data/bolt.slc',
         'https://github.com/pyvista/data/raw/master/Data/nut.slc',
     )
-    assert loader.source_url_blob == (
+    assert loader.web_url == (
         'https://github.com/pyvista/data/blob/master/Data/bolt.slc',
         'https://github.com/pyvista/data/blob/master/Data/nut.slc',
     )
@@ -495,11 +493,11 @@ def test_dataset_loader_cubemap(dataset_loader_cubemap):
     assert loader.unique_dataset_type is pv.Texture
     assert loader.source_name == 'cubemap_park/cubemap_park.zip'
     assert (
-        loader.source_url_raw
+        loader.source_url
         == 'https://github.com/pyvista/data/raw/master/Data/cubemap_park/cubemap_park.zip'
     )
     assert (
-        loader.source_url_blob
+        loader.web_url
         == 'https://github.com/pyvista/data/blob/master/Data/cubemap_park/cubemap_park.zip'
     )
 
@@ -527,12 +525,10 @@ def test_dataset_loader_dicom(dataset_loader_dicom):
     assert loader.unique_dataset_type is pv.ImageData
     assert loader.source_name == 'DICOM_Stack/data.zip'
     assert (
-        loader.source_url_raw
-        == 'https://github.com/pyvista/data/raw/master/Data/DICOM_Stack/data.zip'
+        loader.source_url == 'https://github.com/pyvista/data/raw/master/Data/DICOM_Stack/data.zip'
     )
     assert (
-        loader.source_url_blob
-        == 'https://github.com/pyvista/data/blob/master/Data/DICOM_Stack/data.zip'
+        loader.web_url == 'https://github.com/pyvista/data/blob/master/Data/DICOM_Stack/data.zip'
     )
     assert loader.unique_cell_types == (pv.CellType.VOXEL,)
 
@@ -590,13 +586,13 @@ def test_dataset_loader_from_nested_files_and_directory(
         'HeadMRVolume.raw',
         'DICOM_Stack/data.zip',
     )
-    assert loader.source_url_raw == (
+    assert loader.source_url == (
         'https://github.com/pyvista/data/raw/master/Data/cow.vtp',
         'https://github.com/pyvista/data/raw/master/Data/HeadMRVolume.mhd',
         'https://github.com/pyvista/data/raw/master/Data/HeadMRVolume.raw',
         'https://github.com/pyvista/data/raw/master/Data/DICOM_Stack/data.zip',
     )
-    assert loader.source_url_blob == (
+    assert loader.web_url == (
         'https://github.com/pyvista/data/blob/master/Data/cow.vtp',
         'https://github.com/pyvista/data/blob/master/Data/HeadMRVolume.mhd',
         'https://github.com/pyvista/data/blob/master/Data/HeadMRVolume.raw',
@@ -634,10 +630,8 @@ def test_dataset_loader_from_nested_multiblock(dataset_loader_nested_multiblock)
     assert len(loader.dataset_iterable) == 12
     assert loader.unique_dataset_type == (pv.MultiBlock, pv.UnstructuredGrid)
     assert loader.source_name == 'mesh_fs8.exo'
-    assert loader.source_url_raw == 'https://github.com/pyvista/data/raw/master/Data/mesh_fs8.exo'
-    assert (
-        loader.source_url_blob == 'https://github.com/pyvista/data/blob/master/Data/mesh_fs8.exo'
-    )
+    assert loader.source_url == 'https://github.com/pyvista/data/raw/master/Data/mesh_fs8.exo'
+    assert loader.web_url == 'https://github.com/pyvista/data/blob/master/Data/mesh_fs8.exo'
     assert loader.unique_cell_types == (
         pv.CellType.TRIANGLE,
         pv.CellType.QUAD,

--- a/tests/examples/test_downloads.py
+++ b/tests/examples/test_downloads.py
@@ -61,7 +61,7 @@ def _is_valid_url(url):
 def test_dataset_loader_source_url_blob(test_case: DatasetLoaderTestCase):
     try:
         # Skip test if not loadable
-        sources = test_case.dataset_loader[1].source_url_blob
+        sources = test_case.dataset_loader[1].source_url
     except pv.VTKVersionError as e:
         reason = e.args[0]
         pytest.skip(reason)


### PR DESCRIPTION
The `pyvista/data` urls in the Dataset Gallery are currently broken. The link partially includes a local cache base path instead, e.g.:

- https://dev.pyvista.org/home/runner/_work/pyvista/pyvista/pyvista-data/Data/3GQP.pdb

instead of
- https://github.com/pyvista/data/blob/master/Data/3GQP.pdb

And the `gltf` urls use `raw.githubusercontent`, but the dataset loaders assume that the link contain `/raw/` which can be swapped for `/blob/`. But the replacement fails, so the links remain raw, and clicking them downloads the file immediately, whereas we want the link to open a GitHub page. 

This PR fixes both of these.

EDIT: we should include this in a 0.48 patch release