### PR TITLE
Always show warnings raised from try_callback

### DIFF
--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -14,6 +14,7 @@ import traceback
 from typing import TYPE_CHECKING
 from typing import Literal
 from typing import TypeVar
+import warnings
 
 import numpy as np
 from typing_extensions import Self
@@ -373,7 +374,14 @@ def try_callback(func, *args) -> None:  # noqa: ANN001
         formatted_exception = 'Encountered issue in callback (most recent call last):\n' + ''.join(
             traceback.format_list(stack) + traceback.format_exception_only(etype, exc),
         ).rstrip('\n')
-        warn_external(formatted_exception)
+        # Force the warning to always be shown. Otherwise, callbacks bound to
+        # high-frequency events (e.g. ``MouseMoveEvent``) emit an identical
+        # warning at the same call site on every invocation, and Python's
+        # default filter de-duplicates it to a single message per session,
+        # making callback errors appear to be silently swallowed.
+        with warnings.catch_warnings():
+            warnings.simplefilter('always')
+            warn_external(formatted_exception)
 
 
 def threaded(fn):  # noqa: ANN001, ANN201

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -3279,3 +3279,25 @@ def test_ply_writer(sphere, tmp_path):
     assert writer.texture == texture_name
     writer.texture = texture_name
     assert writer.texture == texture_name
+
+
+def test_try_callback_warns_every_time():
+    # A callback bound to a high-frequency event (e.g. ``MouseMoveEvent``)
+    # raises an identical exception at the same call site on every
+    # invocation. ``try_callback`` must surface it every time rather than
+    # letting Python's default filter de-duplicate it to a single message.
+    def failing_callback():
+        msg = 'callback failed'
+        raise RuntimeError(msg)
+
+    n_calls = 3
+    with warnings.catch_warnings(record=True) as log:
+        # Restore the default filter that ``catch_warnings(record=True)``
+        # overrides, so that de-duplication would apply without the fix.
+        warnings.simplefilter('default')
+        for _ in range(n_calls):
+            misc.try_callback(failing_callback)
+
+    messages = [w for w in log if 'Encountered issue in callback' in str(w.message)]
+    assert len(messages) == n_calls
+    assert 'callback failed' in str(messages[0].message)


### PR DESCRIPTION
While looking into https://github.com/pyvista/pyvistaqt/issues/829#issuecomment-4564517812, I noticed that some errors weren't being printed. This seems like a bug, as it can make it much harder to see issues with callbacks. (The issue might happen once very early where it's missed, and during later interactions nothing happens, which is confusing.) 

Running:
```
import pyvista as pv
import pyvistaqt as pvqt
mesh = pv.Sphere()

plotter = pv.Plotter()

def bad_event(name, event):
    raise RuntimeError(f'{name=} {event=}')

plotter.iren.add_observer('MouseMoveEvent', bad_event)
plotter.add_mesh(mesh)
plotter.show()
```
produces a single output on `main` when mousing over but multiple (one per event) on this PR. This is more standard callback-error behavior.

Another option would be to `logger.error` or `logger.warn`.

Diagnosed and drafted PR with Claude Opus 4.8, but I understand all changes.