### PR TITLE
Fix bugs with GC captured by PyVistaQt

### DIFF
--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -423,10 +423,34 @@ class _DataSetMapper(_BaseMapper):
         # -> _maybe_set_default_scalar_range) see the theme colors before
         # any set_scalars call.
         self.lookup_table.apply_cmap(self._theme.cmap, self.lookup_table.n_values)
-        self._active_scalars_algo: ActiveScalarsAlgorithm | None = None
         self._input_dataset_ref: weakref.ref[DataSet] | None = None
         if dataset is not None:
             self.dataset = dataset
+
+    @property
+    def _active_scalars_algo(self) -> ActiveScalarsAlgorithm | None:
+        """Return the spliced active-scalars algorithm, if any.
+
+        Derived from the mapper's VTK input connection rather than stored on
+        the instance: a ``__dict__`` reference would close an uncollectable
+        Python<->C++ cycle whenever the mapper's Python wrapper dies before
+        its C++ object. VTK's "ghost" mechanism then keeps the old
+        ``__dict__`` (and thus the algorithm's Python object) alive as long
+        as the mapper's C++ object lives, while the algorithm's pipeline
+        consumer references keep that C++ object alive -- and neither
+        Python's nor VTK's garbage collector can traverse the full loop.
+
+        A ``weakref`` (like ``_input_dataset_ref``) is not an option: this
+        dict entry was the *only* strong Python reference to the algorithm
+        (``vtkPythonAlgorithm`` does not keep its Python half alive), so a
+        weak one would die as soon as ``set_active_scalars`` returned even
+        though the C++ algorithm stays spliced in the pipeline. Deriving
+        from the pipeline instead re-wraps on demand; VTK's ghost dict
+        restores the wrapper's class and state on resurrection.
+        """
+        conn = cast('_vtk.vtkAlgorithmOutput | None', self.GetInputConnection(0, 0))
+        producer = conn.GetProducer() if conn is not None else None
+        return producer if isinstance(producer, ActiveScalarsAlgorithm) else None
 
     @property
     def dataset(self) -> DataSet | None:  # numpydoc ignore=RT01
@@ -653,8 +677,9 @@ class _DataSetMapper(_BaseMapper):
 
         """
         source_dataset = self._scalar_source_dataset
-        if self._active_scalars_algo is None:
-            self._active_scalars_algo = ActiveScalarsAlgorithm(name=name, preference=preference)
+        algo = self._active_scalars_algo
+        if algo is None:
+            algo = ActiveScalarsAlgorithm(name=name, preference=preference)
             # Splice the algo between the mapper and its current input.
             # Prefer the existing pipeline connection so upstream
             # modifications propagate on re-render. If no connection exists
@@ -662,13 +687,15 @@ class _DataSetMapper(_BaseMapper):
             # cached dataset input instead of wiring a null VTK connection.
             input_conn = cast('_vtk.vtkAlgorithmOutput | None', self.GetInputConnection(0, 0))
             if input_conn is not None:
-                self._active_scalars_algo.SetInputConnection(0, input_conn)
+                algo.SetInputConnection(0, input_conn)
             elif self._input_dataset is not None:
-                set_algorithm_input(self._active_scalars_algo, self._input_dataset)
-            self.SetInputConnection(0, self._active_scalars_algo.GetOutputPort())
+                set_algorithm_input(algo, self._input_dataset)
+            # The pipeline connection is the only reference kept: see
+            # _active_scalars_algo for why it must not land in __dict__.
+            self.SetInputConnection(0, algo.GetOutputPort())
         else:
-            self._active_scalars_algo.scalars_name = name
-            self._active_scalars_algo.preference = preference
+            algo.scalars_name = name
+            algo.preference = preference
         # Also point the mapper at the array directly. SetInputConnection
         # above clears the VTK-level array name, so this must come last.
         self.SetArrayName(name)
@@ -687,10 +714,9 @@ class _DataSetMapper(_BaseMapper):
         set_active_scalars
 
         """
-        if self._active_scalars_algo is None:
-            return
         algo = self._active_scalars_algo
-        self._active_scalars_algo = None
+        if algo is None:
+            return
         if self._input_dataset is not None:
             set_algorithm_input(self, self._input_dataset)
         else:

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -5332,7 +5332,8 @@ class BasePlotter(_BoundsSizeMixin):
         # tearing anything else down, so it stops touching this plotter's
         # VTK objects once they're cleared.
         if self._orbit_thread is not None:
-            if self._orbit_thread.is_alive():
+            # no branch: whether the thread already finished is timing-dependent
+            if self._orbit_thread.is_alive():  # pragma: no branch
                 # `_orbit_stop_event` is always set alongside `_orbit_thread` in
                 # `orbit_on_path`, so it can't be `None` here.
                 assert self._orbit_stop_event is not None  # noqa: S101
@@ -6826,8 +6827,10 @@ class BasePlotter(_BoundsSizeMixin):
             points_seq = tqdm(points) if progress_bar else points
 
             for point in points_seq:
-                if stop_event is not None and stop_event.is_set():  # pragma: no branch
-                    return
+                if stop_event is not None and stop_event.is_set():
+                    # Cancellation is usually observed in the `wait()` below
+                    # instead, so reaching this exit is timing-dependent.
+                    return  # pragma: no cover
                 tstart = time.time()  # include the render time in the step time
                 self.set_position(point, render=False)
                 self.set_focus(focus, render=False)  # type: ignore[arg-type]
@@ -6841,10 +6844,13 @@ class BasePlotter(_BoundsSizeMixin):
                 if sleep_time > 0 and (
                     hasattr(self, 'off_screen') and not self.off_screen
                 ):  # 'off_screen' attribute is specific to Plotter objects.
-                    if stop_event is not None:  # pragma: no branch
-                        if stop_event.wait(sleep_time):
+                    if stop_event is not None:
+                        # no branch: whether close() interrupts the wait or the
+                        # wait times out first is timing-dependent
+                        if stop_event.wait(sleep_time):  # pragma: no branch
                             return
-                    else:
+                    else:  # pragma: no cover
+                        # needs a non-threaded run with off_screen=False
                         time.sleep(sleep_time)
             if write_frames:  # pragma: no cover
                 self._get_mwriter_not_none().close()

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -6826,7 +6826,7 @@ class BasePlotter(_BoundsSizeMixin):
             points_seq = tqdm(points) if progress_bar else points
 
             for point in points_seq:
-                if stop_event is not None and stop_event.is_set():  # pragma: no cover
+                if stop_event is not None and stop_event.is_set():  # pragma: no branch
                     return
                 tstart = time.time()  # include the render time in the step time
                 self.set_position(point, render=False)
@@ -6841,10 +6841,10 @@ class BasePlotter(_BoundsSizeMixin):
                 if sleep_time > 0 and (
                     hasattr(self, 'off_screen') and not self.off_screen
                 ):  # 'off_screen' attribute is specific to Plotter objects.
-                    if stop_event is not None:  # pragma: no cover
+                    if stop_event is not None:  # pragma: no branch
                         if stop_event.wait(sleep_time):
                             return
-                    else:  # pragma: no cover
+                    else:
                         time.sleep(sleep_time)
             if write_frames:  # pragma: no cover
                 self._get_mwriter_not_none().close()

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -6826,7 +6826,7 @@ class BasePlotter(_BoundsSizeMixin):
             points_seq = tqdm(points) if progress_bar else points
 
             for point in points_seq:
-                if stop_event is not None and stop_event.is_set():
+                if stop_event is not None and stop_event.is_set():  # pragma: no cover
                     return
                 tstart = time.time()  # include the render time in the step time
                 self.set_position(point, render=False)
@@ -6841,12 +6841,12 @@ class BasePlotter(_BoundsSizeMixin):
                 if sleep_time > 0 and (
                     hasattr(self, 'off_screen') and not self.off_screen
                 ):  # 'off_screen' attribute is specific to Plotter objects.
-                    if stop_event is not None:
+                    if stop_event is not None:  # pragma: no cover
                         if stop_event.wait(sleep_time):
                             return
-                    else:
+                    else:  # pragma: no cover
                         time.sleep(sleep_time)
-            if write_frames:
+            if write_frames:  # pragma: no cover
                 self._get_mwriter_not_none().close()
 
         if threaded:

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -5333,6 +5333,9 @@ class BasePlotter(_BoundsSizeMixin):
         # VTK objects once they're cleared.
         if self._orbit_thread is not None:
             if self._orbit_thread.is_alive():
+                # `_orbit_stop_event` is always set alongside `_orbit_thread` in
+                # `orbit_on_path`, so it can't be `None` here.
+                assert self._orbit_stop_event is not None  # noqa: S101
                 self._orbit_stop_event.set()
                 self._orbit_thread.join(timeout=5)
 

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -5331,9 +5331,10 @@ class BasePlotter(_BoundsSizeMixin):
         # Stop any background `orbit_on_path(threaded=True)` thread before
         # tearing anything else down, so it stops touching this plotter's
         # VTK objects once they're cleared.
-        if self._orbit_thread is not None and self._orbit_thread.is_alive():
-            self._orbit_stop_event.set()
-            self._orbit_thread.join(timeout=5)
+        if self._orbit_thread is not None:
+            if self._orbit_thread.is_alive():
+                self._orbit_stop_event.set()
+                self._orbit_thread.join(timeout=5)
 
         # optionally run just prior to exiting the plotter
         if self._before_close_callback is not None:

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -20,6 +20,7 @@ import os
 from pathlib import Path
 import sys
 import textwrap
+from threading import Event
 from threading import Thread
 import time
 from typing import TYPE_CHECKING
@@ -415,6 +416,10 @@ class BasePlotter(_BoundsSizeMixin):
 
         # optional function to be called prior to closing
         self.__before_close_callback = None
+        # background thread (and its cancellation event) started by a threaded
+        # `orbit_on_path()` call, if any; used by `close()` to stop it cleanly
+        self._orbit_thread: Thread | None = None
+        self._orbit_stop_event: Event | None = None
         self.mesh: MultiBlock | DataSet | None = None
         if title is None:
             title = self._theme.title
@@ -5323,6 +5328,13 @@ class BasePlotter(_BoundsSizeMixin):
 
     def close(self) -> None:
         """Close the render window."""
+        # Stop any background `orbit_on_path(threaded=True)` thread before
+        # tearing anything else down, so it stops touching this plotter's
+        # VTK objects once they're cleared.
+        if self._orbit_thread is not None and self._orbit_thread.is_alive():
+            self._orbit_stop_event.set()
+            self._orbit_thread.join(timeout=5)
+
         # optionally run just prior to exiting the plotter
         if self._before_close_callback is not None:
             self._before_close_callback(self)  # type: ignore[arg-type]
@@ -6801,11 +6813,17 @@ class BasePlotter(_BoundsSizeMixin):
                 msg = 'Please install `tqdm` to use ``progress_bar=True``'
                 raise ImportError(msg)
 
+        # Lets a threaded orbit be cancelled from `close()` so the background
+        # thread stops touching this plotter's VTK objects once they're torn down.
+        stop_event = Event() if threaded else None
+
         def orbit() -> None:
             """Define the internal thread for running the orbit."""
             points_seq = tqdm(points) if progress_bar else points
 
             for point in points_seq:
+                if stop_event is not None and stop_event.is_set():
+                    return
                 tstart = time.time()  # include the render time in the step time
                 self.set_position(point, render=False)
                 self.set_focus(focus, render=False)  # type: ignore[arg-type]
@@ -6819,12 +6837,18 @@ class BasePlotter(_BoundsSizeMixin):
                 if sleep_time > 0 and (
                     hasattr(self, 'off_screen') and not self.off_screen
                 ):  # 'off_screen' attribute is specific to Plotter objects.
-                    time.sleep(sleep_time)
+                    if stop_event is not None:
+                        if stop_event.wait(sleep_time):
+                            return
+                    else:
+                        time.sleep(sleep_time)
             if write_frames:
                 self._get_mwriter_not_none().close()
 
         if threaded:
+            self._orbit_stop_event = stop_event
             thread = Thread(target=orbit)
+            self._orbit_thread = thread
             thread.start()
         else:
             orbit()

--- a/pyvista/plotting/render_passes.py
+++ b/pyvista/plotting/render_passes.py
@@ -45,6 +45,7 @@ class RenderPasses(_NoNewAttrMixin):
     def __init__(self, renderer):
         """Initialize render passes."""
         self._renderer_ref = weakref.ref(renderer)
+        self._closed = False
 
         self._passes = {}
         self._fxaa_pass = None
@@ -114,6 +115,23 @@ class RenderPasses(_NoNewAttrMixin):
             return self._renderer_ref()
         return None  # type: ignore[unreachable]
 
+    def _check_closed(self):
+        """Raise if the renderer has already been closed."""
+        if self._closed:
+            msg = 'The renderer has been closed.'
+            raise RuntimeError(msg)
+
+    def close(self):
+        """Delete all render passes and mark them permanently unusable.
+
+        Unlike plain ``deep_clean()``, this is only called once the owning
+        renderer itself is closed, so it also latches ``_closed`` -- any
+        further attempt to enable/disable a pass then raises instead of
+        silently no-op'ing.
+        """
+        self._closed = True
+        self.deep_clean()
+
     def deep_clean(self):
         """Delete all render passes."""
         if self._renderer is not None:
@@ -149,6 +167,7 @@ class RenderPasses(_NoNewAttrMixin):
 
     def disable_edl_pass(self):
         """Disable the EDL pass."""
+        self._check_closed()
         if self._edl_pass is None:
             return
         self._remove_pass(self._edl_pass)
@@ -172,6 +191,7 @@ class RenderPasses(_NoNewAttrMixin):
 
     def remove_blur_pass(self):
         """Remove a single :vtk:`vtkGaussianBlurPass` pass."""
+        self._check_closed()
         if self._blur_passes:
             # order of the blur passes does not matter
             self._remove_pass(self._blur_passes.pop())
@@ -185,6 +205,7 @@ class RenderPasses(_NoNewAttrMixin):
             The enabled shadow pass.
 
         """
+        self._check_closed()
         # shadow pass can be directly added to the base pass collection
         if self._shadow_map_pass is not None:
             return None
@@ -196,6 +217,7 @@ class RenderPasses(_NoNewAttrMixin):
 
     def disable_shadow_pass(self):
         """Disable shadow pass."""
+        self._check_closed()
         if self._shadow_map_pass is None:
             return
         self._pass_collection.RemoveItem(self._shadow_map_pass.GetShadowMapBakerPass())
@@ -232,6 +254,7 @@ class RenderPasses(_NoNewAttrMixin):
 
     def disable_depth_of_field_pass(self):
         """Disable the depth of field pass."""
+        self._check_closed()
         if self._dof_pass is None:
             return
         self._remove_pass(self._dof_pass)
@@ -276,6 +299,7 @@ class RenderPasses(_NoNewAttrMixin):
 
     def disable_ssao_pass(self):
         """Disable the screen space ambient occlusion pass."""
+        self._check_closed()
         if self._ssao_pass is None:
             return
         self._remove_pass(self._ssao_pass)
@@ -298,6 +322,7 @@ class RenderPasses(_NoNewAttrMixin):
 
     def disable_ssaa_pass(self):
         """Disable super-sample anti-aliasing pass."""
+        self._check_closed()
         if self._ssaa_pass is None:
             return
         self._remove_pass(self._ssaa_pass)
@@ -305,9 +330,7 @@ class RenderPasses(_NoNewAttrMixin):
 
     def _update_passes(self):
         """Reassemble pass delegation."""
-        if hasattr(self._renderer, '_closed') and self._renderer._closed:
-            msg = 'The renderer has been closed.'
-            raise RuntimeError(msg)
+        self._check_closed()
 
         current_pass = self._camera_pass
         for class_name in PRE_PASS + POST_PASS:

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -3965,7 +3965,7 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
         self._marker_actor = None
         self._border_actor = None
         self.cube_axes_actor = None
-        self._render_passes.deep_clean()
+        self._render_passes.close()
 
         if self._empty_str is not None:
             self._empty_str.SetReferenceCount(0)

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -3953,9 +3953,19 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
         self.RemoveAllObservers()
         self._remove_axes_widget()
 
+        # Detach all props from the underlying vtkRenderer's actual scene graph.
+        # Just dropping our own Python-side references (below) isn't enough: VTK's
+        # own C++ reference counting keeps a prop (and everything it owns, e.g. the
+        # cube axes actor's axis label arrays) alive as long as it's still attached
+        # here, regardless of whether we still hold a Python attribute pointing to it.
+        self.RemoveAllViewProps()
+
         self._bounding_box = None
         self._box_object = None
         self._marker_actor = None
+        self._border_actor = None
+        self.cube_axes_actor = None
+        self._render_passes.deep_clean()
 
         if self._empty_str is not None:
             self._empty_str.SetReferenceCount(0)

--- a/tests/plotting/mappers/test_mapper.py
+++ b/tests/plotting/mappers/test_mapper.py
@@ -634,7 +634,14 @@ def test_active_scalars_algo_not_leaked_by_ghost_dict():
     # The leak was deallocation-order sensitive: plotter first, actor last.
     del pl, mesh, actor
     gc.collect()
-    leaked = [
-        obj for obj in gc.get_objects() if isinstance(obj, algorithms.ActiveScalarsAlgorithm)
-    ]
+
+    def _is_algo(obj):
+        # The heap can contain dead weakref proxies, whose isinstance check
+        # raises ReferenceError (via ABC __instancecheck__)
+        try:
+            return isinstance(obj, algorithms.ActiveScalarsAlgorithm)
+        except ReferenceError:
+            return False
+
+    leaked = [obj for obj in gc.get_objects() if _is_algo(obj)]
     assert leaked == []

--- a/tests/plotting/mappers/test_mapper.py
+++ b/tests/plotting/mappers/test_mapper.py
@@ -610,3 +610,31 @@ def test_add_mesh_smooth_shading_multi_component_scalars_mapper_output():
 
     pl.close()
     del point_data, mapped, actor, pl
+
+
+def test_active_scalars_algo_not_leaked_by_ghost_dict():
+    """A dead mapper wrapper must not pin its algorithm via VTK's ghost dict.
+
+    When the mapper's Python wrapper is destroyed while its C++ object is
+    still alive (here: the plotter is deleted before the actor), VTK stores
+    the wrapper's ``__dict__`` as a "ghost". If that dict held the
+    active-scalars algorithm, the algorithm's pipeline consumer references
+    would keep the mapper's C++ object (and thus the ghost) alive, closing a
+    Python<->C++ cycle that neither garbage collector can break. See the
+    ``_active_scalars_algo`` property, which exists to prevent exactly this.
+    """
+    import gc
+
+    pl = pv.Plotter(off_screen=True)
+    mesh = pv.Sphere()
+    mesh['data'] = mesh.points[:, 0]
+    actor = pl.add_mesh(mesh, scalars='data')
+    assert actor.mapper._active_scalars_algo is not None
+    pl.close()
+    # The leak was deallocation-order sensitive: plotter first, actor last.
+    del pl, mesh, actor
+    gc.collect()
+    leaked = [
+        obj for obj in gc.get_objects() if isinstance(obj, algorithms.ActiveScalarsAlgorithm)
+    ]
+    assert leaked == []

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -3261,6 +3261,7 @@ def test_orbit_on_path(sphere):
     pl.close()
 
 
+@pytest.mark.usefixtures('no_images_to_verify')
 def test_orbit_on_path_threaded_stopped_on_close(sphere):
     # Regression test: `close()` must stop a threaded `orbit_on_path()` run before
     # returning. Otherwise the orbit thread keeps running afterward, and while it

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -3261,6 +3261,20 @@ def test_orbit_on_path(sphere):
     pl.close()
 
 
+def test_orbit_on_path_threaded_stopped_on_close(sphere):
+    # Regression test: `close()` must stop a threaded `orbit_on_path()` run before
+    # returning. Otherwise the orbit thread keeps running afterward, and while it
+    # runs, its live stack frame keeps VTK objects (e.g. the orbit path's point
+    # array) reachable past `close()` -- previously an intermittent leak
+    # ("only sometimes -- usually macOS").
+    pl = pv.Plotter(off_screen=False)
+    pl.add_mesh(sphere)
+    pl.orbit_on_path(threaded=True, step=0.05)
+    time.sleep(0.02)  # let the thread actually start before closing
+    pl.close()
+    assert not pl._orbit_thread.is_alive()
+
+
 def test_rectlinear_edge_case(verify_image_cache):
     verify_image_cache.windows_skip_image_cache = True
 

--- a/tests/plotting/test_renderer.py
+++ b/tests/plotting/test_renderer.py
@@ -458,6 +458,59 @@ def test_actors_after_close():
     pl.increment_point_size_and_line_width(1)
 
 
+def _add_self_referencing_observer(pl, vtk_obj):
+    """Add an observer whose callback closes over ``pl``.
+
+    VTK's observer/command storage holds the callback (and anything it closes
+    over) in a way that isn't visible to Python's cyclic garbage collector.
+    Without that, plain refcounting already collects an unreferenced ``pl`` --
+    an observer like this is what makes a *missing* ``close()`` cleanup step
+    actually manifest as a real, unreachable leak instead of getting silently
+    swept up anyway.
+    """
+
+    def _cb(*_args):
+        return pl
+
+    vtk_obj.AddObserver('ModifiedEvent', _cb)
+
+
+def test_border_actor_gc_after_close():
+    # Regression test: `Renderer.close()` must clear `_border_actor` (in addition
+    # to `_bounding_box`/`_box_object`/`_marker_actor`, which it already cleared)
+    # so the border actor can be garbage-collected instead of lingering after close.
+    pl = pv.Plotter(border=True)
+    _add_self_referencing_observer(pl, pl.renderer._border_actor)
+    pl.close()
+
+
+def test_render_passes_gc_after_close():
+    # Regression test: `Renderer.close()` must clean up render passes (e.g. the
+    # EDL pass enabled below) the same way `deep_clean()` already does, so their
+    # VTK objects don't linger after close.
+    pl = pv.Plotter()
+    pl.enable_eye_dome_lighting()
+    _add_self_referencing_observer(pl, pl.renderer._render_passes._edl_pass)
+    pl.close()
+
+
+def test_actors_removed_from_scene_on_close():
+    # Regression test: `Renderer.close()` must detach all props from the
+    # underlying vtkRenderer's actual scene graph (e.g. via `RemoveAllViewProps()`),
+    # not just drop pyvista's own Python-side references to them. VTK's own C++
+    # reference counting otherwise keeps a still-attached prop -- and everything
+    # it owns, like the cube axes actor's axis label arrays below -- alive
+    # regardless of whether pyvista still holds a Python attribute pointing to it.
+    pl = pv.Plotter()
+    pl.add_mesh(pv.Sphere())
+    cube_axes_actor = pl.show_bounds()
+    _add_self_referencing_observer(pl, cube_axes_actor)
+
+    assert pl.renderer.GetViewProps().GetNumberOfItems() > 0
+    pl.close()
+    assert pl.renderer.GetViewProps().GetNumberOfItems() == 0
+
+
 def test_background_renderer_resize_after_close():
     # Regression test for #8419: a background renderer can be closed (its `_actors`
     # reset to None) while the parent plotter and its render window are still alive,


### PR DESCRIPTION
Over in PyVistaQt I worked with Claude Sonnet 5.0 to look into the `allow_bad_gc` and `allow_bad_gc_pyside` marks. It found several reference cycles attributable to PyVista.

Most fixes, like calling a `deep_clean` and setting some stuff to `None` seem pretty straightforward.

The biggest unknown (I asked explicitly) afterward was:

> 1. RemoveAllViewProps() in Renderer.close() is the biggest unknown. It's the fix with the widest blast radius — it now runs for every renderer close, not just pyvistaqt's. I never fully pinned down why the cube-axes leak only appeared with menu_bar/toolbar enabled plus a lambda closure created inside a function frame (vs. identical code at module scope) — I found that removing all props from the actual VTK scene graph resolves it empirically, but I don't have a complete causal model of the interaction between VTK's C++ refcounting and Python's cyclic GC that produced it. That means I can't rule out this being one symptom of a broader class of issue rather than the full root cause. I ran pyvista's test_renderer.py/test_plotter.py/test_cube_axes_actor.py (166 tests) and they passed, but not pyvista's full suite (thousands of tests, several requiring test deps I didn't chase down), so some downstream test elsewhere in pyvista could rely on actors still being attached right after close() in a way I haven't seen.

I could push harder and investigate more on that front if `RemoveAllViewProps` is too much. But it does at least get the regression test to pass, and allow `pyvistaqt`'s tests to pass with no `allow_bad_gc*` marks.

This was all done on Linux -- will be interesting to see if other OSes pass, too!