### PR TITLE
fix(core): flag cells with coincident points in validate_mesh

### DIFF
--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -1780,9 +1780,7 @@ class DataObjectFilters:
                 # indexing so the gather never raises on out-of-range ids.
                 group_valid = np.all(valid_conn[entry_ids], axis=1)
                 pts = ugrid.points[np.clip(pids, 0, n_points - 1)]
-                # Ignore errors caused by non-finite points
-                with np.errstate(over='ignore'):
-                    diff = pts[:, :, np.newaxis, :] - pts[:, np.newaxis, :, :]
+                diff = pts[:, :, np.newaxis, :] - pts[:, np.newaxis, :, :]
                 dist_sq = np.einsum('mijk,mijk->mij', diff, diff)
                 iu = np.triu_indices(size, k=1)
                 any_coincident = np.any(dist_sq[:, iu[0], iu[1]] <= tol * tol, axis=1)

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -1771,12 +1771,8 @@ class DataObjectFilters:
             coincident = np.zeros(n_cells, dtype=bool)
             n_cell_points = np.diff(offset)
             valid_conn = (conn >= 0) & (conn < n_points)
-            poly_vertex = ugrid.celltypes == pv.CellType.POLY_VERTEX
             for size in np.unique(n_cell_points[n_cell_points >= 2]):
-                # Skip POLY_VERTEX since these cannot have collapsed edges
-                cells = np.nonzero((n_cell_points == size) & ~poly_vertex)[0]
-                if cells.size == 0:
-                    continue
+                cells = np.nonzero(n_cell_points == size)[0]
                 # Gather this group's point ids as an (m, size) block via CSR offsets
                 entry_ids = offset[cells, np.newaxis] + np.arange(size)[np.newaxis, :]
                 pids = conn[entry_ids]

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -1767,10 +1767,10 @@ class DataObjectFilters:
             # check: a cell is coincident if any two of its points are within tol. This
             # applies to all cell types (also OR-ing the bit into already-caught cases).
             coincident = np.zeros(n_cells, dtype=bool)
-            sizes = np.diff(offset)
+            n_cell_points = np.diff(offset)
             valid_conn = (conn >= 0) & (conn < n_points)
-            for size in np.unique(sizes[sizes >= 2]):
-                cells = np.nonzero(sizes == size)[0]
+            for size in np.unique(n_cell_points[n_cell_points >= 2]):
+                cells = np.nonzero(n_cell_points == size)[0]
                 # Gather this group's point ids as an (m, size) block via CSR offsets
                 entry_ids = offset[cells, np.newaxis] + np.arange(size)[np.newaxis, :]
                 pids = conn[entry_ids]

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -1771,8 +1771,12 @@ class DataObjectFilters:
             coincident = np.zeros(n_cells, dtype=bool)
             n_cell_points = np.diff(offset)
             valid_conn = (conn >= 0) & (conn < n_points)
+            poly_vertex = ugrid.celltypes == pv.CellType.POLY_VERTEX
             for size in np.unique(n_cell_points[n_cell_points >= 2]):
-                cells = np.nonzero(n_cell_points == size)[0]
+                # Skip POLY_VERTEX since these cannot have collapsed edges
+                cells = np.nonzero((n_cell_points == size) & ~poly_vertex)[0]
+                if cells.size == 0:
+                    continue
                 # Gather this group's point ids as an (m, size) block via CSR offsets
                 entry_ids = offset[cells, np.newaxis] + np.arange(size)[np.newaxis, :]
                 pids = conn[entry_ids]

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -1766,16 +1766,11 @@ class DataObjectFilters:
 
             # VTK's face-based vtkCellValidator never flags 2D cells,
             # so a collapsed edge (two coincident points) is missed. Add a PyVista-side
-            # check: a cell is coincident if any two of its points are within a dtype-aware
-            # RELATIVE tolerance (the tolerance absorbs floating-point representation error,
-            # which scales with magnitude). A pair (i, j) is coincident iff
-            # ``dist**2 <= rtol**2 * max(||p_i||**2, ||p_j||**2)``. This applies to all cell
-            # types (also OR-ing the bit into already-caught cases).
+            # check: a cell is coincident if any two of its points are within tol. This
+            # applies to all cell types (also OR-ing the bit into already-caught cases).
             coincident = np.zeros(n_cells, dtype=bool)
             n_cell_points = np.diff(offset)
             valid_conn = (conn >= 0) & (conn < n_points)
-            # Relative tolerance from the mesh's own points dtype (mirrors ``size_tol``).
-            rtol: float = np.finfo(mesh.points.dtype).eps
             for size in np.unique(n_cell_points[n_cell_points >= 2]):
                 cells = np.nonzero(n_cell_points == size)[0]
                 # Gather this group's point ids as an (m, size) block via CSR offsets
@@ -1784,17 +1779,13 @@ class DataObjectFilters:
                 # Skip cells with invalid connectivity (handled below); clamp for safe
                 # indexing so the gather never raises on out-of-range ids.
                 group_valid = np.all(valid_conn[entry_ids], axis=1)
-                # Compute in float64 so squaring extreme coords cannot overflow (non-finite
-                # points stay non-finite, so their comparisons remain False -> never flagged).
-                pts = ugrid.points[np.clip(pids, 0, n_points - 1)].astype(np.float64, copy=False)
-                diff = pts[:, :, np.newaxis, :] - pts[:, np.newaxis, :, :]
+                pts = ugrid.points[np.clip(pids, 0, n_points - 1)]
+                # Ignore errors caused by non-finite points
+                with np.errstate(over='ignore'):
+                    diff = pts[:, :, np.newaxis, :] - pts[:, np.newaxis, :, :]
                 dist_sq = np.einsum('mijk,mijk->mij', diff, diff)
-                # Per-point squared distance-from-origin, shape (m, size).
-                sq_norm = np.einsum('mik,mik->mi', pts, pts)
                 iu = np.triu_indices(size, k=1)
-                pair_dist_sq = dist_sq[:, iu[0], iu[1]]
-                max_sq_norm = np.maximum(sq_norm[:, iu[0]], sq_norm[:, iu[1]])
-                any_coincident = np.any(pair_dist_sq <= rtol * rtol * max_sq_norm, axis=1)
+                any_coincident = np.any(dist_sq[:, iu[0], iu[1]] <= tol * tol, axis=1)
                 coincident[cells] = any_coincident & group_valid
             state[coincident] |= CellStatus.COINCIDENT_POINTS
 

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -1749,9 +1749,11 @@ class DataObjectFilters:
             # ZERO_SIZE
             state[np.abs(size) <= size_tol] |= CellStatus.ZERO_SIZE
 
-            # INVALID_POINT_REFERENCES
-            if hasattr(mesh, 'dimensions'):
-                return  # Cell connectivity is explicitly defined and cannot be invalid
+            # COINCIDENT_POINTS
+            # Skip remaining checks for datasets where cell connectivity cannot be invalid
+            # Do not skip types StructuredGrid where coincident points are possible
+            if isinstance(mesh, pv.Grid):
+                return
 
             ugrid = (
                 mesh if isinstance(mesh, pv.UnstructuredGrid) else mesh.cast_to_unstructured_grid()
@@ -1762,7 +1764,7 @@ class DataObjectFilters:
             n_cells = ugrid.n_cells
             n_points = ugrid.n_points
 
-            # COINCIDENT_POINTS: VTK's face-based vtkCellValidator never flags 2D cells,
+            # VTK's face-based vtkCellValidator never flags 2D cells,
             # so a collapsed edge (two coincident points) is missed. Add a PyVista-side
             # check: a cell is coincident if any two of its points are within tol. This
             # applies to all cell types (also OR-ing the bit into already-caught cases).
@@ -1785,10 +1787,15 @@ class DataObjectFilters:
                 coincident[cells] = any_coincident & group_valid
             state[coincident] |= CellStatus.COINCIDENT_POINTS
 
+            # INVALID_POINT_REFERENCES
             invalid_conn = ~valid_conn
             if not np.any(invalid_conn):
                 return
+
+            # Map invalid connectivity indices to cell IDs
             invalid_conn_ids = np.nonzero(invalid_conn)[0]
+
+            # Build per-cell boolean mask
             cell_ids = np.searchsorted(offset, invalid_conn_ids, side='right') - 1
             is_invalid = np.zeros(n_cells, dtype=bool)
             is_invalid[cell_ids] = True

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -1766,11 +1766,16 @@ class DataObjectFilters:
 
             # VTK's face-based vtkCellValidator never flags 2D cells,
             # so a collapsed edge (two coincident points) is missed. Add a PyVista-side
-            # check: a cell is coincident if any two of its points are within tol. This
-            # applies to all cell types (also OR-ing the bit into already-caught cases).
+            # check: a cell is coincident if any two of its points are within a dtype-aware
+            # RELATIVE tolerance (the tolerance absorbs floating-point representation error,
+            # which scales with magnitude). A pair (i, j) is coincident iff
+            # ``dist**2 <= rtol**2 * max(||p_i||**2, ||p_j||**2)``. This applies to all cell
+            # types (also OR-ing the bit into already-caught cases).
             coincident = np.zeros(n_cells, dtype=bool)
             n_cell_points = np.diff(offset)
             valid_conn = (conn >= 0) & (conn < n_points)
+            # Relative tolerance from the mesh's own points dtype (mirrors ``size_tol``).
+            rtol: float = np.finfo(mesh.points.dtype).eps
             for size in np.unique(n_cell_points[n_cell_points >= 2]):
                 cells = np.nonzero(n_cell_points == size)[0]
                 # Gather this group's point ids as an (m, size) block via CSR offsets
@@ -1779,13 +1784,17 @@ class DataObjectFilters:
                 # Skip cells with invalid connectivity (handled below); clamp for safe
                 # indexing so the gather never raises on out-of-range ids.
                 group_valid = np.all(valid_conn[entry_ids], axis=1)
-                pts = ugrid.points[np.clip(pids, 0, n_points - 1)]
-                # Ignore errors caused by non-finite points
-                with np.errstate(over='ignore'):
-                    diff = pts[:, :, np.newaxis, :] - pts[:, np.newaxis, :, :]
+                # Compute in float64 so squaring extreme coords cannot overflow (non-finite
+                # points stay non-finite, so their comparisons remain False -> never flagged).
+                pts = ugrid.points[np.clip(pids, 0, n_points - 1)].astype(np.float64, copy=False)
+                diff = pts[:, :, np.newaxis, :] - pts[:, np.newaxis, :, :]
                 dist_sq = np.einsum('mijk,mijk->mij', diff, diff)
+                # Per-point squared distance-from-origin, shape (m, size).
+                sq_norm = np.einsum('mik,mik->mi', pts, pts)
                 iu = np.triu_indices(size, k=1)
-                any_coincident = np.any(dist_sq[:, iu[0], iu[1]] <= tol * tol, axis=1)
+                pair_dist_sq = dist_sq[:, iu[0], iu[1]]
+                max_sq_norm = np.maximum(sq_norm[:, iu[0]], sq_norm[:, iu[1]])
+                any_coincident = np.any(pair_dist_sq <= rtol * rtol * max_sq_norm, axis=1)
                 coincident[cells] = any_coincident & group_valid
             state[coincident] |= CellStatus.COINCIDENT_POINTS
 

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -1780,7 +1780,9 @@ class DataObjectFilters:
                 # indexing so the gather never raises on out-of-range ids.
                 group_valid = np.all(valid_conn[entry_ids], axis=1)
                 pts = ugrid.points[np.clip(pids, 0, n_points - 1)]
-                diff = pts[:, :, np.newaxis, :] - pts[:, np.newaxis, :, :]
+                # Ignore errors caused by non-finite points
+                with np.errstate(over='ignore'):
+                    diff = pts[:, :, np.newaxis, :] - pts[:, np.newaxis, :, :]
                 dist_sq = np.einsum('mijk,mijk->mij', diff, diff)
                 iu = np.triu_indices(size, k=1)
                 any_coincident = np.any(dist_sq[:, iu[0], iu[1]] <= tol * tol, axis=1)
@@ -1794,9 +1796,9 @@ class DataObjectFilters:
 
             # Map invalid connectivity indices to cell IDs
             invalid_conn_ids = np.nonzero(invalid_conn)[0]
+            cell_ids = np.searchsorted(offset, invalid_conn_ids, side='right') - 1
 
             # Build per-cell boolean mask
-            cell_ids = np.searchsorted(offset, invalid_conn_ids, side='right') - 1
             is_invalid = np.zeros(n_cells, dtype=bool)
             is_invalid[cell_ids] = True
             state[is_invalid] |= CellStatus.INVALID_POINT_REFERENCES

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -1757,18 +1757,40 @@ class DataObjectFilters:
                 mesh if isinstance(mesh, pv.UnstructuredGrid) else mesh.cast_to_unstructured_grid()
             )
 
-            # Find invalid connectivity entries
             conn = ugrid.cell_connectivity
+            offset = ugrid.offset
             n_cells = ugrid.n_cells
-            invalid_conn = (conn < 0) | (conn >= ugrid.n_points)
+            n_points = ugrid.n_points
+
+            # COINCIDENT_POINTS: VTK's face-based vtkCellValidator never flags 2D cells,
+            # so a collapsed edge (two coincident points) is missed. Add a PyVista-side
+            # check: a cell is coincident if any two of its points are within tol. This
+            # applies to all cell types (also OR-ing the bit into already-caught cases).
+            coincident = np.zeros(n_cells, dtype=bool)
+            sizes = np.diff(offset)
+            valid_conn = (conn >= 0) & (conn < n_points)
+            for size in np.unique(sizes[sizes >= 2]):
+                cells = np.nonzero(sizes == size)[0]
+                # Gather this group's point ids as an (m, size) block via CSR offsets
+                entry_ids = offset[cells, np.newaxis] + np.arange(size)[np.newaxis, :]
+                pids = conn[entry_ids]
+                # Skip cells with invalid connectivity (handled below); clamp for safe
+                # indexing so the gather never raises on out-of-range ids.
+                group_valid = np.all(valid_conn[entry_ids], axis=1)
+                pts = ugrid.points[np.clip(pids, 0, n_points - 1)]
+                diff = pts[:, :, np.newaxis, :] - pts[:, np.newaxis, :, :]
+                dist_sq = np.einsum('mijk,mijk->mij', diff, diff)
+                iu = np.triu_indices(size, k=1)
+                any_coincident = np.any(dist_sq[:, iu[0], iu[1]] <= tol * tol, axis=1)
+                coincident[cells] = any_coincident & group_valid
+            state[coincident] |= CellStatus.COINCIDENT_POINTS
+
+            # INVALID_POINT_REFERENCES: map out-of-range connectivity entries to cells
+            invalid_conn = ~valid_conn
             if not np.any(invalid_conn):
                 return
-
-            # Map invalid connectivity indices to cell IDs
             invalid_conn_ids = np.nonzero(invalid_conn)[0]
-            cell_ids = np.searchsorted(ugrid.offset, invalid_conn_ids, side='right') - 1
-
-            # Build per-cell boolean mask
+            cell_ids = np.searchsorted(offset, invalid_conn_ids, side='right') - 1
             is_invalid = np.zeros(n_cells, dtype=bool)
             is_invalid[cell_ids] = True
             state[is_invalid] |= CellStatus.INVALID_POINT_REFERENCES

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -1785,7 +1785,6 @@ class DataObjectFilters:
                 coincident[cells] = any_coincident & group_valid
             state[coincident] |= CellStatus.COINCIDENT_POINTS
 
-            # INVALID_POINT_REFERENCES: map out-of-range connectivity entries to cells
             invalid_conn = ~valid_conn
             if not np.any(invalid_conn):
                 return

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -2537,18 +2537,31 @@ def test_validate_mesh_coincident_points(make_mesh):
     mesh.points[1] = mesh.points[0]
 
     report = mesh.validate_mesh()
-    assert report.is_valid is False
-    assert 'coincident_points' in report.invalid_fields
+    if mesh.distinct_cell_types == {pv.CellType.POLY_VERTEX}:
+        # Special case: POLY_VERTEX with coincident points is valid
+        # The points are redundant, yes, but they do not represent a collapsed edge
+        assert report.is_valid
+    else:
+        assert report.is_valid is False
+        assert 'coincident_points' in report.invalid_fields
 
-    state = mesh.cell_validator()['validity_state']
-    assert state[0] & pv.CellStatus.COINCIDENT_POINTS
+        state = mesh.cell_validator()['validity_state']
+        assert state[0] & pv.CellStatus.COINCIDENT_POINTS
 
 
-def test_validate_mesh_coincident_points_non_finite():
-    """Test that no overflow warning is emitted by NumPy"""
+def test_validate_mesh_poly_vertex_non_finite_false_positive():
     mesh = examples.download_particles()
+    assert mesh.distinct_cell_types == {pv.CellType.POLY_VERTEX}
+
+    # Points have values smaller than the default tolerance, which can trigger a false positive
+    assert np.any(mesh.points < np.finfo(np.float32).eps)
+
+    # Mesh has NaN points, which can trigger an overflow RuntimeWarning
     assert not np.isfinite(mesh.points).all()
-    mesh.validate_mesh()
+
+    # Test no overflow RuntimeWarning, no false positive for coincident points.
+    report = mesh.validate_mesh()
+    assert report.invalid_fields == ('non_finite_points',)
 
 
 @pytest.fixture

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -2429,8 +2429,6 @@ def test_cell_validator_invalid_tetra(
         if name in (
             pv.CellStatus.WRONG_NUMBER_OF_POINTS.name.lower(),
             pv.CellStatus.ZERO_SIZE.name.lower(),
-            # Coincident-point fix: the missing-point tetra (cell 0) has two
-            # coincident points, so COINCIDENT_POINTS is now flagged on cell 0.
             pv.CellStatus.COINCIDENT_POINTS.name.lower(),
         ):
             expected_cell_ids = [0]
@@ -2468,8 +2466,6 @@ def test_validate_mesh_degenerate_cells():
     invalid_mesh = pv.Line((0.0, 0.0, 0.0), (0.0, 0.0, 0.0))
     for mesh in [invalid_mesh, append_mixed_cells(invalid_mesh)]:
         state = mesh.cell_validator()['validity_state']
-        # Coincident-point fix: a zero-length line also has coincident points, so
-        # both bits are now set (previously only ZERO_SIZE).
         assert state[0] & pv.CellStatus.ZERO_SIZE
         assert state[0] & pv.CellStatus.COINCIDENT_POINTS
     match = 'Mesh has 1 LINE cell with zero length. Invalid cell id: [0]'
@@ -2482,8 +2478,6 @@ def test_validate_mesh_degenerate_cells():
     invalid_mesh = pv.PolyData(points, faces=[3, 0, 1, 2])
     for mesh in [invalid_mesh, append_mixed_cells(invalid_mesh)]:
         state = mesh.cell_validator()['validity_state']
-        # Coincident-point fix: this degenerate triangle has two coincident points,
-        # so both bits are now set (previously only ZERO_SIZE).
         assert state[0] & pv.CellStatus.ZERO_SIZE
         assert state[0] & pv.CellStatus.COINCIDENT_POINTS
     match = 'Mesh has 1 TRIANGLE cell with zero area. Invalid cell id: [0]'
@@ -2531,8 +2525,7 @@ def test_validate_mesh_coincident_points_2d_cells(make_mesh):
     # cells, and PyVista's supplementary checks only added zero_size / negative_size
     # / invalid_point_references. A collapsed 2D cell keeps positive area, so
     # zero_size does not rescue it. The fix adds a PyVista-side coincident-point
-    # check that sets CellStatus.COINCIDENT_POINTS for any cell with two coincident
-    # points, making 'coincident_points' the sole invalid field for these cells.
+    # check that sets CellStatus.COINCIDENT_POINTS for any cell with two coincident points.
     mesh = make_mesh()
 
     # Negative case: the pristine cell is valid -- the check must not false-positive.

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -2516,16 +2516,21 @@ def test_validate_mesh_degenerate_cells():
 
 @pytest.mark.parametrize(
     'make_mesh',
-    [examples.cells.Quadrilateral, examples.cells.Polygon],
-    ids=['quad', 'polygon'],
+    [
+        examples.cells.PolyVertex,
+        examples.cells.PolyLine,
+        examples.cells.Line,
+        examples.cells.Quadrilateral,
+        examples.cells.Polygon,
+        examples.cells.Hexahedron,
+    ],
+    ids=['poly_vertex', 'poly_line', 'line', 'quad', 'polygon', 'hexahedron'],
 )
-def test_validate_mesh_coincident_points_2d_cells(make_mesh):
-    # Regression: a 2D cell (quad, polygon) with a collapsed edge (two coincident
-    # points) was reported VALID. VTK's face-based vtkCellValidator never flags 2D
-    # cells, and PyVista's supplementary checks only added zero_size / negative_size
-    # / invalid_point_references. A collapsed 2D cell keeps positive area, so
-    # zero_size does not rescue it. The fix adds a PyVista-side coincident-point
-    # check that sets CellStatus.COINCIDENT_POINTS for any cell with two coincident points.
+def test_validate_mesh_coincident_points(make_mesh):
+    # Regression (#8711): a cell with a collapsed edge (two coincident points) was
+    # reported valid. VTK's face-based vtkCellValidator does not flag this for many
+    # cell types and PyVista had no fallback. The fix flags any cell with two
+    # coincident points via CellStatus.COINCIDENT_POINTS.
     mesh = make_mesh()
 
     # Negative case: the pristine cell is valid -- the check must not false-positive.
@@ -2537,8 +2542,6 @@ def test_validate_mesh_coincident_points_2d_cells(make_mesh):
     report = mesh.validate_mesh()
     assert report.is_valid is False
     assert 'coincident_points' in report.invalid_fields
-    # Bit choice is COINCIDENT_POINTS only; 2D cells must not report DEGENERATE_FACES.
-    assert report.invalid_fields == ('coincident_points',)
 
     state = mesh.cell_validator()['validity_state']
     assert state[0] & pv.CellStatus.COINCIDENT_POINTS

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -2551,68 +2551,6 @@ def test_validate_mesh_coincident_points_non_finite():
     mesh.validate_mesh()
 
 
-def test_validate_mesh_coincident_points_no_false_positive_tiny_magnitude():
-    """Regression: distinct but tiny-magnitude points must not read as coincident.
-
-    ``download_particles`` is a single POLY_VERTEX cell whose finite points are all
-    bit-distinct, yet many are separated by only ~1e-11 -- below the absolute
-    single-precision eps that the coincident check used as a distance threshold. That
-    made every such pair a false positive. The check must instead be dtype-aware and
-    relative to the point magnitudes, so these genuinely distinct points are not flagged.
-
-    The genuine-collapse guarantee (a truly coincident pair is still flagged) is covered by
-    ``test_validate_mesh_coincident_points`` and is deliberately not re-asserted here.
-    """
-    mesh = examples.download_particles()
-
-    # Sanity: the finite points really are all distinct, so there is nothing to flag.
-    finite_points = mesh.points[np.isfinite(mesh.points).all(axis=1)]
-    assert np.unique(finite_points, axis=0).shape[0] == finite_points.shape[0]
-
-    report = mesh.validate_mesh()
-
-    # The false positive being fixed: distinct tiny-magnitude points are NOT coincident.
-    assert 'coincident_points' not in report.invalid_fields
-    # The genuinely-invalid finding (a non-finite point) must still be reported, so this
-    # pins the correct behaviour rather than merely "the mesh is valid".
-    assert 'non_finite_points' in report.invalid_fields
-
-
-def test_validate_mesh_coincident_points_dtype_aware_tolerance_float64_far_from_origin():
-    """Guard: the coincident tolerance must be relative to the points' own dtype eps.
-
-    The correct fix uses a per-pair RELATIVE tolerance
-    ``rtol = np.finfo(mesh.points.dtype).eps`` -- NOT a hardcoded single-precision
-    ``np.finfo(np.float32).eps``. This test guards against a fix that hardcodes the
-    float32 eps as the relative tolerance, which would silently regress float64 meshes:
-    at coordinate magnitude ~5e6, a float32 rtol (~1.19e-7) yields an absolute merge
-    radius of ~0.6 m, wrongly collapsing points that are only a few cm apart, whereas a
-    dtype-correct float64 rtol (~2.2e-16) gives a sub-nanometre radius.
-
-    This is a GREEN GUARD, not a RED driver: it already passes on the current absolute
-    float32-eps threshold (a 5 cm gap far exceeds ~1.19e-7 in absolute terms). It goes RED
-    only if the fix is implemented with a float32-hardcoded relative tolerance.
-    """
-    # A 5 cm x 5 cm float64 QUAD centred ~5e6 from the origin. In float64 the ULP at that
-    # magnitude is ~1e-9, so 5 cm is ~30M ULPs -- the four corners are unambiguously distinct.
-    base = 5.0e6
-    points = np.array(
-        [
-            [base, base, 0.0],
-            [base + 0.05, base, 0.0],
-            [base + 0.05, base + 0.05, 0.0],
-            [base, base + 0.05, 0.0],
-        ],
-        dtype=np.float64,
-    )
-    mesh = pv.PolyData(points, faces=[4, 0, 1, 2, 3])
-    assert mesh.points.dtype == np.float64
-    assert mesh.distinct_cell_types == {pv.CellType.QUAD}
-
-    report = mesh.validate_mesh()
-    assert 'coincident_points' not in report.invalid_fields
-
-
 @pytest.fixture
 def degenerate_structured_grid_quad():
     x = np.array(

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -2551,6 +2551,68 @@ def test_validate_mesh_coincident_points_non_finite():
     mesh.validate_mesh()
 
 
+def test_validate_mesh_coincident_points_no_false_positive_tiny_magnitude():
+    """Regression: distinct but tiny-magnitude points must not read as coincident.
+
+    ``download_particles`` is a single POLY_VERTEX cell whose finite points are all
+    bit-distinct, yet many are separated by only ~1e-11 -- below the absolute
+    single-precision eps that the coincident check used as a distance threshold. That
+    made every such pair a false positive. The check must instead be dtype-aware and
+    relative to the point magnitudes, so these genuinely distinct points are not flagged.
+
+    The genuine-collapse guarantee (a truly coincident pair is still flagged) is covered by
+    ``test_validate_mesh_coincident_points`` and is deliberately not re-asserted here.
+    """
+    mesh = examples.download_particles()
+
+    # Sanity: the finite points really are all distinct, so there is nothing to flag.
+    finite_points = mesh.points[np.isfinite(mesh.points).all(axis=1)]
+    assert np.unique(finite_points, axis=0).shape[0] == finite_points.shape[0]
+
+    report = mesh.validate_mesh()
+
+    # The false positive being fixed: distinct tiny-magnitude points are NOT coincident.
+    assert 'coincident_points' not in report.invalid_fields
+    # The genuinely-invalid finding (a non-finite point) must still be reported, so this
+    # pins the correct behaviour rather than merely "the mesh is valid".
+    assert 'non_finite_points' in report.invalid_fields
+
+
+def test_validate_mesh_coincident_points_dtype_aware_tolerance_float64_far_from_origin():
+    """Guard: the coincident tolerance must be relative to the points' own dtype eps.
+
+    The correct fix uses a per-pair RELATIVE tolerance
+    ``rtol = np.finfo(mesh.points.dtype).eps`` -- NOT a hardcoded single-precision
+    ``np.finfo(np.float32).eps``. This test guards against a fix that hardcodes the
+    float32 eps as the relative tolerance, which would silently regress float64 meshes:
+    at coordinate magnitude ~5e6, a float32 rtol (~1.19e-7) yields an absolute merge
+    radius of ~0.6 m, wrongly collapsing points that are only a few cm apart, whereas a
+    dtype-correct float64 rtol (~2.2e-16) gives a sub-nanometre radius.
+
+    This is a GREEN GUARD, not a RED driver: it already passes on the current absolute
+    float32-eps threshold (a 5 cm gap far exceeds ~1.19e-7 in absolute terms). It goes RED
+    only if the fix is implemented with a float32-hardcoded relative tolerance.
+    """
+    # A 5 cm x 5 cm float64 QUAD centred ~5e6 from the origin. In float64 the ULP at that
+    # magnitude is ~1e-9, so 5 cm is ~30M ULPs -- the four corners are unambiguously distinct.
+    base = 5.0e6
+    points = np.array(
+        [
+            [base, base, 0.0],
+            [base + 0.05, base, 0.0],
+            [base + 0.05, base + 0.05, 0.0],
+            [base, base + 0.05, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    mesh = pv.PolyData(points, faces=[4, 0, 1, 2, 3])
+    assert mesh.points.dtype == np.float64
+    assert mesh.distinct_cell_types == {pv.CellType.QUAD}
+
+    report = mesh.validate_mesh()
+    assert 'coincident_points' not in report.invalid_fields
+
+
 @pytest.fixture
 def degenerate_structured_grid_quad():
     x = np.array(

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -2537,31 +2537,18 @@ def test_validate_mesh_coincident_points(make_mesh):
     mesh.points[1] = mesh.points[0]
 
     report = mesh.validate_mesh()
-    if mesh.distinct_cell_types == {pv.CellType.POLY_VERTEX}:
-        # Special case: POLY_VERTEX with coincident points is valid
-        # The points are redundant, yes, but they do not represent a collapsed edge
-        assert report.is_valid
-    else:
-        assert report.is_valid is False
-        assert 'coincident_points' in report.invalid_fields
+    assert report.is_valid is False
+    assert 'coincident_points' in report.invalid_fields
 
-        state = mesh.cell_validator()['validity_state']
-        assert state[0] & pv.CellStatus.COINCIDENT_POINTS
+    state = mesh.cell_validator()['validity_state']
+    assert state[0] & pv.CellStatus.COINCIDENT_POINTS
 
 
-def test_validate_mesh_poly_vertex_non_finite_false_positive():
+def test_validate_mesh_coincident_points_non_finite():
+    """Test that no overflow warning is emitted by NumPy"""
     mesh = examples.download_particles()
-    assert mesh.distinct_cell_types == {pv.CellType.POLY_VERTEX}
-
-    # Points have values smaller than the default tolerance, which can trigger a false positive
-    assert np.any(mesh.points < np.finfo(np.float32).eps)
-
-    # Mesh has NaN points, which can trigger an overflow RuntimeWarning
     assert not np.isfinite(mesh.points).all()
-
-    # Test no overflow RuntimeWarning, no false positive for coincident points.
-    report = mesh.validate_mesh()
-    assert report.invalid_fields == ('non_finite_points',)
+    mesh.validate_mesh()
 
 
 @pytest.fixture

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -2429,6 +2429,9 @@ def test_cell_validator_invalid_tetra(
         if name in (
             pv.CellStatus.WRONG_NUMBER_OF_POINTS.name.lower(),
             pv.CellStatus.ZERO_SIZE.name.lower(),
+            # Coincident-point fix: the missing-point tetra (cell 0) has two
+            # coincident points, so COINCIDENT_POINTS is now flagged on cell 0.
+            pv.CellStatus.COINCIDENT_POINTS.name.lower(),
         ):
             expected_cell_ids = [0]
             assert single_mesh[name].tolist() == expected_cell_ids
@@ -2465,7 +2468,10 @@ def test_validate_mesh_degenerate_cells():
     invalid_mesh = pv.Line((0.0, 0.0, 0.0), (0.0, 0.0, 0.0))
     for mesh in [invalid_mesh, append_mixed_cells(invalid_mesh)]:
         state = mesh.cell_validator()['validity_state']
-        assert state[0] == pv.CellStatus.ZERO_SIZE
+        # Coincident-point fix: a zero-length line also has coincident points, so
+        # both bits are now set (previously only ZERO_SIZE).
+        assert state[0] & pv.CellStatus.ZERO_SIZE
+        assert state[0] & pv.CellStatus.COINCIDENT_POINTS
     match = 'Mesh has 1 LINE cell with zero length. Invalid cell id: [0]'
     for mesh in [invalid_mesh, append_mixed_cells(invalid_mesh)]:
         with pytest.raises(pv.InvalidMeshError, match=re.escape(match)):
@@ -2476,7 +2482,10 @@ def test_validate_mesh_degenerate_cells():
     invalid_mesh = pv.PolyData(points, faces=[3, 0, 1, 2])
     for mesh in [invalid_mesh, append_mixed_cells(invalid_mesh)]:
         state = mesh.cell_validator()['validity_state']
-        assert state[0] == pv.CellStatus.ZERO_SIZE
+        # Coincident-point fix: this degenerate triangle has two coincident points,
+        # so both bits are now set (previously only ZERO_SIZE).
+        assert state[0] & pv.CellStatus.ZERO_SIZE
+        assert state[0] & pv.CellStatus.COINCIDENT_POINTS
     match = 'Mesh has 1 TRIANGLE cell with zero area. Invalid cell id: [0]'
     for mesh in [invalid_mesh, append_mixed_cells(invalid_mesh)]:
         with pytest.raises(pv.InvalidMeshError, match=re.escape(match)):
@@ -2509,6 +2518,37 @@ def test_validate_mesh_degenerate_cells():
         mesh.validate_mesh(size_tolerance=1e-8, action='error')
     with pytest.raises(pv.InvalidMeshError, match=re.escape(match)):
         mesh.cast_to_multiblock().validate_mesh(size_tolerance=1e-8, action='error')
+
+
+@pytest.mark.parametrize(
+    'make_mesh',
+    [examples.cells.Quadrilateral, examples.cells.Polygon],
+    ids=['quad', 'polygon'],
+)
+def test_validate_mesh_coincident_points_2d_cells(make_mesh):
+    # Regression: a 2D cell (quad, polygon) with a collapsed edge (two coincident
+    # points) was reported VALID. VTK's face-based vtkCellValidator never flags 2D
+    # cells, and PyVista's supplementary checks only added zero_size / negative_size
+    # / invalid_point_references. A collapsed 2D cell keeps positive area, so
+    # zero_size does not rescue it. The fix adds a PyVista-side coincident-point
+    # check that sets CellStatus.COINCIDENT_POINTS for any cell with two coincident
+    # points, making 'coincident_points' the sole invalid field for these cells.
+    mesh = make_mesh()
+
+    # Negative case: the pristine cell is valid -- the check must not false-positive.
+    assert mesh.validate_mesh().is_valid
+
+    # Collapse an edge so points[0] and points[1] coincide.
+    mesh.points[1] = mesh.points[0]
+
+    report = mesh.validate_mesh()
+    assert report.is_valid is False
+    assert 'coincident_points' in report.invalid_fields
+    # Bit choice is COINCIDENT_POINTS only; 2D cells must not report DEGENERATE_FACES.
+    assert report.invalid_fields == ('coincident_points',)
+
+    state = mesh.cell_validator()['validity_state']
+    assert state[0] & pv.CellStatus.COINCIDENT_POINTS
 
 
 def test_validate_mesh_invalid_point_references():

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -2515,20 +2515,11 @@ def test_validate_mesh_degenerate_cells():
 
 
 @pytest.mark.parametrize(
-    'make_mesh',
-    [
-        examples.cells.PolyVertex,
-        examples.cells.PolyLine,
-        examples.cells.Line,
-        examples.cells.Quadrilateral,
-        examples.cells.Polygon,
-        examples.cells.Hexahedron,
-    ],
-    ids=['poly_vertex', 'poly_line', 'line', 'quad', 'polygon', 'hexahedron'],
+    'mesh_name', ['PolyVertex', 'PolyLine', 'Line', 'Quadrilateral', 'Polygon', 'Hexahedron']
 )
-def test_validate_mesh_coincident_points(make_mesh):
+def test_validate_mesh_coincident_points(mesh_name):
     """Test that a cell with a collapsed edge (two coincident points) is invalid."""
-    mesh = make_mesh()
+    mesh = getattr(examples.cells, mesh_name)()
 
     # Negative case: the pristine cell is valid -- the check must not false-positive.
     assert mesh.validate_mesh().is_valid

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -2527,10 +2527,7 @@ def test_validate_mesh_degenerate_cells():
     ids=['poly_vertex', 'poly_line', 'line', 'quad', 'polygon', 'hexahedron'],
 )
 def test_validate_mesh_coincident_points(make_mesh):
-    # Regression (#8711): a cell with a collapsed edge (two coincident points) was
-    # reported valid. VTK's face-based vtkCellValidator does not flag this for many
-    # cell types and PyVista had no fallback. The fix flags any cell with two
-    # coincident points via CellStatus.COINCIDENT_POINTS.
+    """Test that a cell with a collapsed edge (two coincident points) is invalid."""
     mesh = make_mesh()
 
     # Negative case: the pristine cell is valid -- the check must not false-positive.
@@ -2545,6 +2542,50 @@ def test_validate_mesh_coincident_points(make_mesh):
 
     state = mesh.cell_validator()['validity_state']
     assert state[0] & pv.CellStatus.COINCIDENT_POINTS
+
+
+@pytest.fixture
+def degenerate_structured_grid_quad():
+    x = np.array(
+        [
+            [0.0, 1.0],
+            [0.0, 1.0],
+        ]
+    )
+    y = np.array(
+        [
+            [0.0, 0.0],
+            [0.0, 0.0],
+        ]
+    )
+    z = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 1.0],
+        ]
+    )
+
+    # Collapse the "south" edge to a single point
+    x[0, :] = 0.0
+    y[0, :] = 0.0
+    z[0, :] = 0.0
+
+    grid = pv.StructuredGrid(x, y, z)
+    assert grid.n_cells == 1
+    assert grid.n_points == 4
+    assert grid.distinct_cell_types == {pv.CellType.QUAD}
+
+    cleaned = grid.extract_surface(algorithm='geometry').clean()
+    assert cleaned.n_cells == 1
+    assert cleaned.n_points == 3
+    assert cleaned.distinct_cell_types == {pv.CellType.TRIANGLE}
+
+    return grid
+
+
+def test_validate_mesh_coincident_points_structured_grid(degenerate_structured_grid_quad):
+    report = degenerate_structured_grid_quad.validate_mesh()
+    assert report.invalid_fields == ('coincident_points',)
 
 
 def test_validate_mesh_invalid_point_references():

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -2544,13 +2544,6 @@ def test_validate_mesh_coincident_points(make_mesh):
     assert state[0] & pv.CellStatus.COINCIDENT_POINTS
 
 
-def test_validate_mesh_coincident_points_non_finite():
-    """Test that no overflow warning is emitted by NumPy"""
-    mesh = examples.download_particles()
-    assert not np.isfinite(mesh.points).all()
-    mesh.validate_mesh()
-
-
 @pytest.fixture
 def degenerate_structured_grid_quad():
     x = np.array(

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -2544,6 +2544,13 @@ def test_validate_mesh_coincident_points(make_mesh):
     assert state[0] & pv.CellStatus.COINCIDENT_POINTS
 
 
+def test_validate_mesh_coincident_points_non_finite():
+    """Test that no overflow warning is emitted by NumPy"""
+    mesh = examples.download_particles()
+    assert not np.isfinite(mesh.points).all()
+    mesh.validate_mesh()
+
+
 @pytest.fixture
 def degenerate_structured_grid_quad():
     x = np.array(


### PR DESCRIPTION
### Overview

`validate_mesh()` reported some cells with a collapsed edge (two coincident points) as **valid** — notably `QUAD` and `HEXAHEDRON`. This adds a PyVista-side coincident-point check so those cells are correctly flagged.

Addresses #8711

### Details

- **Root cause:** PyVista delegated the `coincident_points` / `degenerate_faces`   status bits entirely to VTK's `vtkCellValidator`, which is face-based and never   flags 2D cells (quad, triangle, polygon → raw VTK state `0`). PyVista's own   supplementary checks only added `zero_size` / `negative_size` /  `invalid_point_references`. A collapsed quad keeps **positive area**, so  `zero_size` didn't rescue it either → reported valid. Pyramid/wedge were caught  only incidentally, because their *quad faces* collapse.
- **Fix:** add a PyVista-side coincident-point check in   `set_pyvista_validity_state` (`pyvista/core/filters/data_object.py`) that sets  `CellStatus.COINCIDENT_POINTS` for any cell containing two points within `tol`
  (the same tolerance VTK's validator uses). Vectorized per cell-size group, reusing the existing connectivity/offset/points arrays — no per-cell Python loop. 
- **Effect** (`points[1] = points[0]` collapse):
  - `QUAD` → invalid, `('coincident_points',)` - the reported bug
  - `HEXAHEDRON` → invalid, `('coincident_points', 'non_planar_faces')` - now caught for the right reason, not just incidentally
  - `POLYGON` → invalid, `('coincident_points',)` - same latent bug, also fixed 
  - `LINE` / `TRIANGLE` / `TETRA` → now additionally carry `coincident_points`  alongside `zero_size` (previously `zero_size` only)
  - `PYRAMID` / `WEDGE` → unchanged
  - `ImageData`/`StructuredGrid` (voxels) are excluded by the existing dimensions early-return, so no tiny-cell false positives.
- **Tests:** new `test_validate_mesh_coincident_points_2d_cells` (quad + polygon, incl. a no-false-positive check on the pristine cell); updated the coincident-point assertions in `test_validate_mesh_degenerate_cells` and 
  `test_cell_validator_invalid_tetra` to expect the new bit.
- **Not addressed here:** the saturated `scaled_jacobian` (`1e+30`) for a degenerate hex is a separate cell-quality concern and is out of scope for this validation fix.
