### PR TITLE
Fix `validate` CLI coloring for some celltypes with compound names

### DIFF
--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -779,6 +779,11 @@ class _MeshValidator(Generic[_DataSetOrMultiBlockType]):
         # Highlight cell types in yellow
         # Reverse sort to ensure we replace things like 'QUADRATIC_HEXAHEDRON' before 'QUAD'
         cell_names = sorted(celltype.name for celltype in CellType)[::-1]
+        # Ensure single-word cell types are last so that POLY_VERTEX is replaced before VERTEX
+        for name in cell_names.copy():
+            if '_' not in name:
+                cell_names.remove(name)
+                cell_names.append(name)
         string = _format_style(string, cell_names, 'yellow')
 
         # Highlight mesh types in purple


### PR DESCRIPTION
### Overview

The `VERTEX` string is currently replaced before `POLY_VERTEX`, which results in incorrect coloring:

<img width="1192" height="112" alt="image" src="https://github.com/user-attachments/assets/f71bff35-ccd9-4edc-a0f1-7801d1745dda" />

This PR ensures `POLY_VERTEX` is replaced first.

EDIT: This fix is more general, e.g. it also fixes this issue:
<img width="780" height="40" alt="Screenshot 2026-07-12 at 9 23 16 PM" src="https://github.com/user-attachments/assets/d2d1a09c-b0d2-44c6-8871-f2956378bc6a" />
