### PR TITLE
Fix GL capability probes crashing under Wayland if window already instatiated

### DIFF
--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -747,6 +747,7 @@ _OPENGL_MODULES: dict[str, tuple[str, ...]] = {
         'vtkCompositePolyDataMapper2',  # optional (contextlib.suppress)
         'vtkDepthOfFieldPass',
         'vtkEDLShading',
+        'vtkEGLRenderWindow',  # optional (Linux EGL builds)
         'vtkGaussianBlurPass',
         'vtkOpenGLFXAAPass',
         'vtkOpenGLHardwareSelector',
@@ -760,6 +761,7 @@ _OPENGL_MODULES: dict[str, tuple[str, ...]] = {
         'vtkShadowMapPass',
         'vtkSSAAPass',
         'vtkSSAOPass',
+        'vtkXOpenGLRenderWindow',  # optional (Linux X11 builds)
     ),
     'vtkRenderingVolumeOpenGL2': (
         'vtkOpenGLGPUVolumeRayCastMapper',

--- a/pyvista/plotting/utilities/gl_checks.py
+++ b/pyvista/plotting/utilities/gl_checks.py
@@ -2,7 +2,26 @@
 
 from __future__ import annotations
 
+import os
+
 from pyvista import _vtk
+
+
+def _offscreen_probe_render_window():
+    """Create an offscreen render window suitable for GL capability probes.
+
+    Under a Wayland session the process may already be using EGL for OpenGL,
+    for example through a Qt application running on the native ``wayland``
+    platform (pyvista/pyvistaqt#445). Making a GLX context current in such a
+    process aborts it with ``X Error ... BadAccess (X_GLXMakeCurrent)``, so
+    the default (GLX-based) ``vtkXOpenGLRenderWindow`` cannot be used for the
+    probe. The converse mix is harmless: an EGL render window works in a
+    process that already uses GLX. So prefer EGL whenever a Wayland session is
+    detected, and keep the factory default everywhere else.
+    """
+    if os.environ.get('WAYLAND_DISPLAY') and _vtk.has_attr('vtkEGLRenderWindow'):
+        return _vtk.vtkEGLRenderWindow()
+    return _vtk.vtkRenderWindow()
 
 
 def check_depth_peeling(number_of_peels=100, occlusion_ratio=0.0):
@@ -37,7 +56,7 @@ def check_depth_peeling(number_of_peels=100, occlusion_ratio=0.0):
     # requires opacity < 1
     actor.GetProperty().SetOpacity(0.5)
     renderer = _vtk.vtkRenderer()
-    renderWindow = _vtk.vtkRenderWindow()
+    renderWindow = _offscreen_probe_render_window()
     renderWindow.SetOffScreenRendering(True)
     if hasattr(renderWindow, 'SetConnectContextToNSView'):
         renderWindow.SetConnectContextToNSView(False)
@@ -62,5 +81,17 @@ def uses_egl() -> bool:
         otherwise ``False``.
 
     """
+    if os.environ.get('WAYLAND_DISPLAY'):
+        # Instantiating the factory-default render window is not safe here:
+        # constructing (and destroying) the default GLX-based window aborts a
+        # process that already uses EGL, e.g. a Qt application running on the
+        # native ``wayland`` platform (pyvista/pyvistaqt#445). Answer without
+        # instantiation instead: honor an explicit backend override, otherwise
+        # infer from the build -- headless EGL/OSMesa wheels are compiled
+        # without X support.
+        backend = os.environ.get('VTK_DEFAULT_OPENGL_WINDOW')
+        if backend:
+            return 'EGL' in backend or 'OSOpenGL' in backend
+        return not _vtk.has_attr('vtkXOpenGLRenderWindow')
     ren_win_str = str(type(_vtk.vtkRenderWindow()))
     return 'EGL' in ren_win_str or 'OSOpenGL' in ren_win_str

--- a/pyvista/plotting/utilities/gl_checks.py
+++ b/pyvista/plotting/utilities/gl_checks.py
@@ -18,8 +18,17 @@ def _offscreen_probe_render_window():
     probe. The converse mix is harmless: an EGL render window works in a
     process that already uses GLX. So prefer EGL whenever a Wayland session is
     detected, and keep the factory default everywhere else.
+
+    An explicit ``VTK_DEFAULT_OPENGL_WINDOW`` override always wins: the
+    factory honors it, and the user's choice also determines the backend the
+    rest of the process uses, so matching it keeps the probe consistent (and
+    safe) with the actual rendering backend.
     """
-    if os.environ.get('WAYLAND_DISPLAY') and _vtk.has_attr('vtkEGLRenderWindow'):
+    if (
+        not os.environ.get('VTK_DEFAULT_OPENGL_WINDOW')
+        and os.environ.get('WAYLAND_DISPLAY')
+        and _vtk.has_attr('vtkEGLRenderWindow')
+    ):
         return _vtk.vtkEGLRenderWindow()
     return _vtk.vtkRenderWindow()
 

--- a/tests/plotting/test_plotting_utilities.py
+++ b/tests/plotting/test_plotting_utilities.py
@@ -14,6 +14,8 @@ from pyvista import examples
 from pyvista.plotting._plotting import _resolve_scalars_field
 from pyvista.plotting._plotting import reduce_component_scalars
 from pyvista.plotting.helpers import view_vectors
+from pyvista.plotting.utilities.gl_checks import _offscreen_probe_render_window
+from pyvista.plotting.utilities.gl_checks import uses_egl
 from pyvista.report import GPUInfo
 from pyvista.report import _get_render_window_class
 from tests.conftest import PILLOW_VERSION_INFO
@@ -263,3 +265,36 @@ def test_add_mesh_raw_numpy_mismatched_length_raises():
     pl = pv.Plotter()
     with pytest.raises(ValueError, match='Number of scalars'):
         pl.add_mesh(sphere, scalars=np.zeros(42, dtype=np.float32))
+
+
+def test_offscreen_probe_render_window(monkeypatch):
+    """GL probes must not create GLX windows inside a Wayland session.
+
+    Making a GLX context current in a process already using EGL (e.g. Qt on
+    the native wayland platform) aborts the process, so under Wayland the
+    probe window must be EGL-based. See pyvista/pyvistaqt#445.
+    """
+    monkeypatch.delenv('WAYLAND_DISPLAY', raising=False)
+    assert isinstance(_offscreen_probe_render_window(), pv._vtk.vtkRenderWindow)
+
+    monkeypatch.setenv('WAYLAND_DISPLAY', 'wayland-0')
+    if not pv._vtk.has_attr('vtkEGLRenderWindow'):
+        pytest.skip('VTK build lacks vtkEGLRenderWindow')
+    assert isinstance(_offscreen_probe_render_window(), pv._vtk.vtkEGLRenderWindow)
+
+
+def test_uses_egl_wayland(monkeypatch):
+    """uses_egl must not instantiate the factory render window under Wayland.
+
+    Construction (and destruction) of the default GLX window aborts a process
+    already using EGL. See pyvista/pyvistaqt#445.
+    """
+    monkeypatch.setenv('WAYLAND_DISPLAY', 'wayland-0')
+    monkeypatch.delenv('VTK_DEFAULT_OPENGL_WINDOW', raising=False)
+    has_x = pv._vtk.has_attr('vtkXOpenGLRenderWindow')
+    assert uses_egl() is not has_x
+
+    monkeypatch.setenv('VTK_DEFAULT_OPENGL_WINDOW', 'vtkEGLRenderWindow')
+    assert uses_egl() is True
+    monkeypatch.setenv('VTK_DEFAULT_OPENGL_WINDOW', 'vtkXOpenGLRenderWindow')
+    assert uses_egl() is False

--- a/tests/plotting/test_plotting_utilities.py
+++ b/tests/plotting/test_plotting_utilities.py
@@ -275,12 +275,18 @@ def test_offscreen_probe_render_window(monkeypatch):
     probe window must be EGL-based. See pyvista/pyvistaqt#445.
     """
     monkeypatch.delenv('WAYLAND_DISPLAY', raising=False)
-    assert isinstance(_offscreen_probe_render_window(), pv._vtk.vtkRenderWindow)
+    monkeypatch.delenv('VTK_DEFAULT_OPENGL_WINDOW', raising=False)
+    default_cls = type(_offscreen_probe_render_window())
+    assert issubclass(default_cls, pv._vtk.vtkRenderWindow)
 
     monkeypatch.setenv('WAYLAND_DISPLAY', 'wayland-0')
     if not pv._vtk.has_attr('vtkEGLRenderWindow'):
         pytest.skip('VTK build lacks vtkEGLRenderWindow')
     assert isinstance(_offscreen_probe_render_window(), pv._vtk.vtkEGLRenderWindow)
+
+    # an explicit VTK_DEFAULT_OPENGL_WINDOW override wins over the heuristic
+    monkeypatch.setenv('VTK_DEFAULT_OPENGL_WINDOW', default_cls.__name__)
+    assert type(_offscreen_probe_render_window()) is default_cls
 
 
 def test_uses_egl_wayland(monkeypatch):


### PR DESCRIPTION
Found while trying to get PyVistaQt. On Wayland, if you already have a vtkEGLRenderWindow instantiated, pyvista's `check_depth_peeling` will crash:
```
from vtkmodules.vtkRenderingOpenGL2 import vtkEGLRenderWindow
from vtkmodules.vtkRenderingCore import vtkRenderer
ren_win = vtkEGLRenderWindow()
ren_win.AddRenderer(vtkRenderer())
ren_win.Render()  # this process now uses EGL
from pyvista.plotting.utilities import check_depth_peeling
print(check_depth_peeling())
```
gives on `main` for me on Ubuntu 26.04
```
X Error of failed request:  BadAccess (attempt to access private resource denied)
  Major opcode of failed request:  149 (GLX)
  Minor opcode of failed request:  5 (X_GLXMakeCurrent)
  Serial number of failed request:  38
  Current serial number in output stream:  38
```
but on this PR just returns `True`.

Coded with Claude Fable 5, but I understand and vouch for the code. Found while working on pyvista/pyvistaqt#445

Here is Claude's summary:

> Under a Wayland session, a process that already uses EGL for OpenGL (e.g. a Qt application running on the native wayland platform) is aborted with 'X Error ... BadAccess (X_GLXMakeCurrent)' when the GLX-based default vtkXOpenGLRenderWindow is created -- even construction followed by destruction is fatal, since VTK's render window factory initializes and tears down GLX state. The converse mix (an EGL window in a GLX-using process) is harmless.
>
> - uses_egl() has the same failure with an even smaller trigger — after the ren_win.Render() above, plain str(type(vtkRenderWindow())) (its exact implementation) also aborts, because VTK ≥9.7's render-window factory initializes and tears down GLX inside New(). That's why the PR changes both functions.
> - The ordering is what matters: EGL→GLX aborts, while GLX→EGL and either alone are fine (so the EGL probe under WAYLAND_DISPLAY is safe even in processes that already use GLX — e.g. a plain pv.Plotter() user on a Wayland desktop). This is also why the bug never shows in a bare REPL or on X11 CI: nothing brings up EGL first. The real-world hit is a Qt app on the native wayland platform (pyvista/pyvistaqt#445), where Qt's EGL context exists before any pyvista probe runs.
