### PR TITLE
Vectorize LookupTable array mapping

### DIFF
--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -1170,10 +1170,16 @@ class LookupTable(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkLookupTable):
             return self.map_value(value)
 
         try:
-            vtk_values = value if isinstance(value, _vtk.vtkDataArray) else convert_array(value)
-            if not isinstance(vtk_values, _vtk.vtkDataArray):
+            if isinstance(value, _vtk.vtkDataArray):
+                vtk_values = value
+            else:
+                values = np.asarray(value)
+                if values.dtype == np.bool_:
+                    values = values.astype(np.uint8)
+                vtk_values = convert_array(values)
+            if not isinstance(vtk_values, (_vtk.vtkDataArray, _vtk.vtkBitArray)):
                 raise TypeError
-            rgba = convert_array(self.MapScalars(vtk_values, 0, -1))
+            rgba = convert_array(self.MapScalars(vtk_values, 1, -1))
             if not isinstance(rgba, np.ndarray):
                 raise TypeError
         except (TypeError, ValueError) as err:

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -1181,7 +1181,7 @@ class LookupTable(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkLookupTable):
             if not isinstance(vtk_values, _vtk.vtkDataArray):
                 raise TypeError
             # Use VTK_COLOR_MODE_MAP_SCALARS to preserve lookup-table mapping for uint8 arrays.
-            rgba = cast('np.ndarray', convert_array(self.MapScalars(vtk_values, 1, -1)))
+            rgba = convert_array(self.MapScalars(vtk_values, 1, -1))
         except (TypeError, ValueError) as err:
             msg = 'LookupTable __call__ expects a single value or an iterable.'
             raise TypeError(msg) from err

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -1168,9 +1168,16 @@ class LookupTable(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkLookupTable):
         """Implement a Matplotlib colormap-like call."""
         if isinstance(value, (int, float)):
             return self.map_value(value)
-        else:
-            try:
-                return np.array([self.map_value(item) for item in value])
-            except (TypeError, ValueError):
-                msg = 'LookupTable __call__ expects a single value or an iterable.'
-                raise TypeError(msg)
+
+        try:
+            vtk_values = value if isinstance(value, _vtk.vtkDataArray) else convert_array(value)
+            if not isinstance(vtk_values, _vtk.vtkDataArray):
+                raise TypeError
+            rgba = convert_array(self.MapScalars(vtk_values, 0, -1))
+            if not isinstance(rgba, np.ndarray):
+                raise TypeError
+        except (TypeError, ValueError) as err:
+            msg = 'LookupTable __call__ expects a single value or an iterable.'
+            raise TypeError(msg) from err
+
+        return rgba.reshape(-1, 4) / 255.0

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -1170,6 +1170,7 @@ class LookupTable(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkLookupTable):
             return self.map_value(value)
 
         try:
+            vtk_values: _vtk.vtkAbstractArray
             if isinstance(value, _vtk.vtkDataArray):
                 vtk_values = value
             else:
@@ -1177,8 +1178,9 @@ class LookupTable(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkLookupTable):
                 if values.dtype == np.bool_:
                     values = values.astype(np.uint8)
                 vtk_values = convert_array(values)
-            if not isinstance(vtk_values, (_vtk.vtkDataArray, _vtk.vtkBitArray)):
+            if not isinstance(vtk_values, _vtk.vtkDataArray):
                 raise TypeError
+            # Use VTK_COLOR_MODE_MAP_SCALARS to preserve lookup-table mapping for uint8 arrays.
             rgba = convert_array(self.MapScalars(vtk_values, 1, -1))
             if not isinstance(rgba, np.ndarray):
                 raise TypeError

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -1181,9 +1181,7 @@ class LookupTable(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkLookupTable):
             if not isinstance(vtk_values, _vtk.vtkDataArray):
                 raise TypeError
             # Use VTK_COLOR_MODE_MAP_SCALARS to preserve lookup-table mapping for uint8 arrays.
-            rgba = convert_array(self.MapScalars(vtk_values, 1, -1))
-            if not isinstance(rgba, np.ndarray):
-                raise TypeError
+            rgba = cast('np.ndarray', convert_array(self.MapScalars(vtk_values, 1, -1)))
         except (TypeError, ValueError) as err:
             msg = 'LookupTable __call__ expects a single value or an iterable.'
             raise TypeError(msg) from err

--- a/tests/plotting/test_lookup_table.py
+++ b/tests/plotting/test_lookup_table.py
@@ -264,6 +264,15 @@ def test_call_bool_array(lut):
     assert np.allclose(arr, expected)
 
 
+def test_call_vtk_array(lut):
+    values = np.linspace(0, 1, 10)
+    arr = lut(pv.convert_array(values))
+    expected = np.array([lut.map_value(value) for value in values])
+
+    assert arr.shape == (10, 4)
+    assert np.allclose(arr, expected)
+
+
 def test_call_scalar(lut):
     assert lut(0.5) == lut.map_value(0.5)
 

--- a/tests/plotting/test_lookup_table.py
+++ b/tests/plotting/test_lookup_table.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -10,9 +9,6 @@ import pyvista as pv
 from pyvista import Color
 from pyvista import LookupTable
 from pyvista import _vtk
-
-if TYPE_CHECKING:
-    from pytest_mock import MockerFixture
 
 
 @pytest.fixture
@@ -33,17 +29,12 @@ def test_cmap_values_raises():
         LookupTable(cmap='foo', values='bar')
 
 
-def test_call_raises(lut: LookupError, mocker: MockerFixture):
-    from pyvista.plotting import lookup_table
-
-    m = mocker.patch.object(lookup_table, 'np')
-    m.array.side_effect = TypeError
-
+def test_call_raises(lut: LookupTable):
     with pytest.raises(
         TypeError,
         match=re.escape('LookupTable __call__ expects a single value or an iterable.'),
     ):
-        lut('foo')
+        lut(object())
 
 
 def test_values(lut):
@@ -246,11 +237,26 @@ def test_map_value(lut):
 
 def test_call(lut):
     n_values = 10
-    arr = lut(np.linspace(0, 1, n_values))
-    assert isinstance(arr, np.ndarray)
-    assert arr.shape[0] == n_values
+    values = np.linspace(0, 1, n_values)
+    arr = lut(values)
+    expected = np.array([lut.map_value(value) for value in values])
 
-    assert lut.map_value(0.5) == lut.map_value(0.5)
+    assert isinstance(arr, np.ndarray)
+    assert arr.shape == (n_values, 4)
+    assert np.allclose(arr, expected)
+
+
+def test_call_list(lut):
+    values = [0.0, 0.5, 1.0]
+    arr = lut(values)
+    expected = np.array([lut.map_value(value) for value in values])
+
+    assert arr.shape == (3, 4)
+    assert np.allclose(arr, expected)
+
+
+def test_call_scalar(lut):
+    assert lut(0.5) == lut.map_value(0.5)
 
 
 @pytest.mark.skip_check_gc

--- a/tests/plotting/test_lookup_table.py
+++ b/tests/plotting/test_lookup_table.py
@@ -255,6 +255,15 @@ def test_call_list(lut):
     assert np.allclose(arr, expected)
 
 
+def test_call_bool_array(lut):
+    values = np.array([False, True, False, True])
+    arr = lut(values)
+    expected = np.array([lut.map_value(value) for value in values])
+
+    assert arr.shape == (4, 4)
+    assert np.allclose(arr, expected)
+
+
 def test_call_scalar(lut):
     assert lut(0.5) == lut.map_value(0.5)
 


### PR DESCRIPTION
### Overview

Use VTK's bulk `MapScalars` API for array-like inputs to
`LookupTable.__call__` instead of mapping each value one at a time in Python.

This preserves scalar behavior while improving the RGBA array path used by
`Mapper.as_rgba()` and plotting styles such as `points_gaussian`.

Resolves #8770.

### Details

- Keep the scalar `LookupTable.__call__` branch using `map_value()`.
- Replace the array branch's Python loop with `MapScalars()`.
- Convert the VTK unsigned-char RGBA output back to PyVista's existing float
  RGBA format.
- Preserve the existing public `TypeError` for invalid input.
- Add tests for scalar input, list input, NumPy array input, output shape, and
  equivalence with `map_value()`.

### Testing

- `python -m pytest tests/plotting/test_lookup_table.py`
- `python -m pre_commit run --files pyvista/plotting/lookup_table.py tests/plotting/test_lookup_table.py`

Local benchmark on 2,000,000 values:

- vectorized path: ~18 ms
- previous per-value loop: ~7310 ms
- output matched previous mapping behavior at RGBA byte precision