### PR TITLE
Improve multidimensional scalar shape errors

### DIFF
--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -497,6 +497,19 @@ def raise_not_matching(scalars: npt.NDArray[Any], dataset: DataSet | Table) -> N
         f'must match either the number of points ({dataset.n_points}) '
         f'or the number of cells ({dataset.n_cells}).'
     )
+    if scalars.size == dataset.n_points:
+        matching_association = f'the number of points ({dataset.n_points})'
+    elif scalars.size == dataset.n_cells:
+        matching_association = f'the number of cells ({dataset.n_cells})'
+    else:
+        matching_association = None
+
+    if matching_association is not None:
+        msg += (
+            f' The scalars have shape {scalars.shape}, and their total size '
+            f'({scalars.size}) matches {matching_association}. Consider flattening '
+            "the scalars with `scalars.ravel(order='F')` before assigning them."
+        )
     raise ValueError(msg)
 
 

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -187,6 +187,26 @@ def test_raise_not_matching_raises():
         raise_not_matching(scalars=np.array([0.0]), dataset=pv.Table())
 
 
+@pytest.mark.parametrize(
+    ('shape', 'association'),
+    [
+        ((2, 3, 4), 'points'),
+        ((1, 2, 3), 'cells'),
+    ],
+)
+def test_raise_not_matching_suggests_flattening(shape, association):
+    grid = pv.ImageData(dimensions=(2, 3, 4))
+    scalars = np.zeros(shape)
+
+    with pytest.raises(ValueError, match='Number of scalars') as exc_info:
+        grid['scalars'] = scalars
+
+    message = str(exc_info.value)
+    assert f'shape {shape}' in message
+    assert f'matches the number of {association}' in message
+    assert "scalars.ravel(order='F')" in message
+
+
 def test_vtk_version_info():
     ver = _vtk.vtkVersion()
     assert ver.GetVTKMajorVersion() == pv.vtk_version_info.major


### PR DESCRIPTION
### Overview

Improve the diagnostic for multidimensional scalar arrays whose total size already matches the target mesh.

Resolves #3387.

### Details

- preserve the existing mismatch message while adding the provided shape and total size
- identify whether the total size matches the mesh's points or cells
- suggest `scalars.ravel(order='F')`, which matches VTK's structured-data ordering
- cover both point and cell associations through public dataset assignment

### Testing

- `.venv/bin/python -m pytest tests/core/test_utilities.py -k raise_not_matching -q` (3 passed)
- `.venv/bin/python -m pytest tests/core/test_utilities.py -k 'not sample_function_raises' -q` (840 passed, 16 skipped, 7 xfailed)
- `uvx pre-commit run --files pyvista/core/utilities/arrays.py tests/core/test_utilities.py` (all applicable hooks passed)

The one excluded test is an unchanged macOS/Python 3.13 baseline failure caused by monkeypatching `os.name` to `nt` before VTK lazily imports a module.

### AI assistance

AI tools assisted with issue investigation and drafting. I reviewed the complete diff, reproduced the original behavior, and ran the validation above.
