### PR TITLE
DOC: document off-screen rendering settings

### DIFF
--- a/doc/source/getting-started/installation.rst
+++ b/doc/source/getting-started/installation.rst
@@ -225,6 +225,24 @@ See other examples and demos:
 .. _Testing: https://github.com/pyvista/pyvista/blob/main/CONTRIBUTING.rst#user-content-testing
 
 
+Off-Screen Rendering
+~~~~~~~~~~~~~~~~~~~~
+
+Set ``PYVISTA_OFF_SCREEN=true`` before importing PyVista to make
+:class:`pyvista.Plotter` use off-screen rendering when its ``off_screen``
+argument is omitted. For a single instance, pass ``off_screen=True`` directly.
+
+``PYVISTA_OFF_SCREEN`` does not select VTK's OpenGL render window. On Linux and
+Windows with VTK 9.4 or later, ``VTK_DEFAULT_OPENGL_WINDOW`` can override VTK's
+runtime selection of a supported render window; see `VTK's OpenGL runtime
+settings <https://docs.vtk.org/en/latest/advanced/runtime_settings.html#opengl>`_.
+
+PyVista does not support ``PYVISTA_VIRTUAL_DISPLAY``. The
+:attr:`pyvista.global_theme.interactive
+<pyvista.plotting.themes.Theme.interactive>` setting controls whether applicable
+widgets are interactive by default; it does not enable off-screen rendering.
+
+
 Running on CI Services
 ~~~~~~~~~~~~~~~~~~~~~~
 Please head over to `pyvista/setup-headless-display-action`_ for details on


### PR DESCRIPTION
### Overview

Document the supported controls for off-screen rendering, distinguish PyVista rendering from VTK's render-window backend selection, and clarify two commonly confused settings.

Resolves #8120.

### Details

- Document `PYVISTA_OFF_SCREEN` and the per-`Plotter` `off_screen=True` override.
- Explain `VTK_DEFAULT_OPENGL_WINDOW` for VTK 9.4+ on Linux and Windows, with the official VTK runtime settings link.
- Clarify that `PYVISTA_VIRTUAL_DISPLAY` is unsupported and `global_theme.interactive` controls widget interaction defaults, not off-screen rendering.
- Validation: `git diff --check`, dependency-free RST/content assertions, and source checks against PyVista commit `82c6b07d621a51412313a8e4a754ee70f14e11ff` all passed.
- Local limitations: `pre-commit`, Vale, tox, Sphinx, and PyVista's full test dependencies were unavailable, so full docs/CI checks were not run locally.
- AI disclosure: This change was prepared with AI assistance and submitted through an automated contribution workflow. The documented behavior and final diff were checked against the pinned PyVista source and official VTK documentation.