### PR TITLE
Validate CubeAxesActor titles are strings to avoid segfault

### DIFF
--- a/pyvista/plotting/cube_axes_actor.py
+++ b/pyvista/plotting/cube_axes_actor.py
@@ -10,6 +10,7 @@ import numpy as np
 import pyvista as pv
 from pyvista import _vtk
 from pyvista._deprecate_positional_args import _deprecate_positional_args
+from pyvista.core import _validation
 from pyvista.core._typing_core import BoundsTuple
 from pyvista.core._vtk_utilities import DisableVtkSnakeCase
 from pyvista.core.utilities.arrays import convert_string_array
@@ -464,6 +465,7 @@ class CubeAxesActor(
 
     @x_title.setter
     def x_title(self, value: str):
+        _validation.check_string(value, name='x_title')
         self._x_title = value
         self._update_x_labels()
 
@@ -474,6 +476,7 @@ class CubeAxesActor(
 
     @y_title.setter
     def y_title(self, value: str):
+        _validation.check_string(value, name='y_title')
         self._y_title = value
         self._update_y_labels()
 
@@ -484,6 +487,7 @@ class CubeAxesActor(
 
     @z_title.setter
     def z_title(self, value: str):
+        _validation.check_string(value, name='z_title')
         self._z_title = value
         self._update_z_labels()
 

--- a/tests/plotting/test_cube_axes_actor.py
+++ b/tests/plotting/test_cube_axes_actor.py
@@ -96,6 +96,12 @@ def test_titles(cube_axes_actor):
     assert cube_axes_actor.z_title == 'z foo'
 
 
+@pytest.mark.parametrize('title', ['x_title', 'y_title', 'z_title'])
+def test_title_must_be_string(cube_axes_actor, title):
+    with pytest.raises(TypeError, match=rf'{title} must be an instance of .*str'):
+        setattr(cube_axes_actor, title, None)
+
+
 def test_axis_minor_tick_visibility(cube_axes_actor):
     assert isinstance(cube_axes_actor.x_axis_minor_tick_visibility, bool)
     cube_axes_actor.x_axis_minor_tick_visibility = False


### PR DESCRIPTION
### Overview

Validate `CubeAxesActor` axis titles before passing them to VTK. Supplying `None` currently leaves an invalid value in the actor and can cause a segmentation fault when the axes are rendered.

Resolves #8824.

### Details

- validate `x_title`, `y_title`, and `z_title` with the existing PyVista string validator
- raise an axis-specific `TypeError` during construction or later property assignment
- cover all three title properties with a parameterized regression test

### Testing

- `python -m pytest tests/plotting/test_cube_axes_actor.py tests/plotting/test_renderer.py -q` (91 passed)
- `python -m pytest tests/test_attributes.py -k CubeAxesActor -q` (3 passed)
- `uvx pre-commit run --files pyvista/plotting/cube_axes_actor.py tests/plotting/test_cube_axes_actor.py` (all applicable hooks passed)

### AI assistance

OpenAI Codex assisted with issue investigation, implementation, testing, and PR drafting. No private data or generated assets are included.