### PR TITLE
Cache check_depth_peeling result

### DIFF
--- a/pyvista/plotting/utilities/gl_checks.py
+++ b/pyvista/plotting/utilities/gl_checks.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from functools import cache
+
 from pyvista import _vtk
 
 
+@cache
 def check_depth_peeling(number_of_peels=100, occlusion_ratio=0.0):
     """Check if depth peeling is available.
 

--- a/pyvista/plotting/utilities/gl_checks.py
+++ b/pyvista/plotting/utilities/gl_checks.py
@@ -7,6 +7,7 @@ from functools import cache
 from pyvista import _vtk
 
 
+@cache
 def check_depth_peeling(number_of_peels=100, occlusion_ratio=0.0):
     """Check if depth peeling is available.
 
@@ -30,13 +31,6 @@ def check_depth_peeling(number_of_peels=100, occlusion_ratio=0.0):
         settings.
 
     """
-    return _check_depth_peeling(number_of_peels, occlusion_ratio)
-
-
-# Use a cache wrapper so the doc checkers see check_depth_peeling as public
-@cache
-def _check_depth_peeling(number_of_peels, occlusion_ratio):
-    """Check if depth peeling is available."""
     # Try Depth Peeling with a basic scene
     source = _vtk.vtkSphereSource()
     mapper = _vtk.vtkPolyDataMapper()

--- a/pyvista/plotting/utilities/gl_checks.py
+++ b/pyvista/plotting/utilities/gl_checks.py
@@ -7,7 +7,6 @@ from functools import cache
 from pyvista import _vtk
 
 
-@cache
 def check_depth_peeling(number_of_peels=100, occlusion_ratio=0.0):
     """Check if depth peeling is available.
 
@@ -31,6 +30,13 @@ def check_depth_peeling(number_of_peels=100, occlusion_ratio=0.0):
         settings.
 
     """
+    return _check_depth_peeling(number_of_peels, occlusion_ratio)
+
+
+# Use a cache wrapper so the doc checkers see check_depth_peeling as public
+@cache
+def _check_depth_peeling(number_of_peels, occlusion_ratio):
+    """Check if depth peeling is available."""
     # Try Depth Peeling with a basic scene
     source = _vtk.vtkSphereSource()
     mapper = _vtk.vtkPolyDataMapper()

--- a/tests/doc/test_api_coverage.py
+++ b/tests/doc/test_api_coverage.py
@@ -56,6 +56,7 @@ _ALLOWED_UNDOCUMENTED = frozenset(
         'BasePlotter',  # abstract base; Plotter subclass is documented
         'FONTS',  # internal variable
         'Grid',  # abstract base; concrete Grid subclasses are documented
+        'has_module',  # internal helper for testing only - should be moved into conftest.py
         'PointGrid',  # abstract base; concrete subclasses are documented
         'QtDeprecationError',  # deprecated and moved to pyvistaqt
         'QtInteractor',  # deprecated and moved to pyvistaqt
@@ -112,7 +113,8 @@ def _collect_public_symbols() -> set[str]:
         obj = getattr(pv, name, None)
         if obj is None:
             continue
-        if not (inspect.isclass(obj) or inspect.isfunction(obj)):
+        # Use `isroutine` instead of `isfunction` so that we also catch @cache decorated functions
+        if not (inspect.isclass(obj) or inspect.isroutine(obj)):
             continue
         if not _is_pyvista_owned(obj):
             continue


### PR DESCRIPTION
check_depth_peeling probes the driver for depth-peeling support by building an offscreen render window, adding a translucent sphere, and running a full Render(). This costs ~130-150 ms and runs once per Renderer.enable_depth_peeling() call (i.e. once per plotter), yet the answer is a fixed GL-driver capability that cannot change within a process. Memoize it on (number_of_peels, occlusion_ratio) so only the first probe pays the cost; measured ~67 ms/figure saved when repeatedly building translucent scenes.

I'm optimizing MNE-Python a bit and ran into this bottleneck (it slows our tests because we build a lot of figures with depth peeling!).

Developed with Claude Opus 4.8 but I understand and vouch for the 2 lines added here :laughing: 