### PR TITLE
Bump `trame-pyvista` to 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ docs = [
   'sphinxcontrib-websupport==2.0.0',
   'sphinxext-opengraph==0.13.0',
   'sympy==1.14.0',
-  'trame-pyvista==0.1.2',
+  'trame-pyvista==0.1.3',
   'trimesh==4.12.2',
   'vtk-xref==0.1.2',
   { include-group = 'pinned' },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ docs = [
   'sphinxcontrib-websupport==2.0.0',
   'sphinxext-opengraph==0.13.0',
   'sympy==1.14.0',
-  'trame-pyvista==0.1.1',
+  'trame-pyvista==0.1.2',
   'trimesh==4.12.2',
   'vtk-xref==0.1.2',
   { include-group = 'pinned' },


### PR DESCRIPTION
Needed to support VTK 9.7 since older `trame-vtk` has deprecated `vtkCellArray.GetData()` calls which are removed in 9.7