### PR TITLE
DOC: preserve newline literals in Text documentation

### DIFF
--- a/pyvista/plotting/text.py
+++ b/pyvista/plotting/text.py
@@ -176,7 +176,7 @@ class Text(_NoNewAttrMixin, DisableVtkSnakeCase, _NameMixin, _vtk.vtkTextActor):
     ----------
     text : str, optional
         Text string to be displayed.
-        "\n" is recognized as a carriage return/linefeed (line separator).
+        ``\n`` is recognized as a carriage return/linefeed (line separator).
         The characters must be in the UTF-8 encoding.
 
     position : Sequence[float], optional
@@ -222,7 +222,7 @@ class Text(_NoNewAttrMixin, DisableVtkSnakeCase, _NameMixin, _vtk.vtkTextActor):
         -------
         str
             Text string to be displayed.
-            "\n" is recognized as a carriage return/linefeed (line separator).
+            ``\n`` is recognized as a carriage return/linefeed (line separator).
             The characters must be in the UTF-8 encoding.
 
         """


### PR DESCRIPTION
### Overview

Render `\n` as an inline code literal in both the `Text` class and `Text.input` property documentation. Raw Python docstrings preserve the backslash in `__doc__`, but reStructuredText still treats it as an escape unless it is marked as literal text.

Closes #7755.

### Validation

- `uvx pre-commit run --files pyvista/plotting/text.py`
- built both docstrings through Sphinx/autodoc and verified the generated HTML contains the literal `\n` in both locations