### PR TITLE
Add support for vtkEnSightWriter

### DIFF
--- a/doc/source/api/readers/index.rst
+++ b/doc/source/api/readers/index.rst
@@ -214,6 +214,7 @@ formats. These are used internally by :meth:`pyvista.DataObject.save`.
    BaseWriter
    BMPWriter
    DataSetWriter
+   EnSightWriter
    HDFWriter
    HoudiniPolyDataWriter
    IVWriter

--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -515,6 +515,7 @@ _CORE_MODULES: dict[str, tuple[str, ...]] = {
         'vtkPDataSetReader',
         'vtkPOpenFOAMReader',
         'vtkPlot3DMetaReader',
+        'vtkEnSightWriter',
     ),
     'vtkIOParallelExodus': ('vtkPExodusIIReader',),
     'vtkIOParallelXML': ('vtkXMLPartitionedDataSetWriter',),

--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -510,12 +510,12 @@ _CORE_MODULES: dict[str, tuple[str, ...]] = {
         'vtkPLYWriter',
     ),
     'vtkIOParallel': (
+        'vtkEnSightWriter',
         'vtkMultiBlockPLOT3DReader',
         'vtkNek5000Reader',
         'vtkPDataSetReader',
         'vtkPOpenFOAMReader',
         'vtkPlot3DMetaReader',
-        'vtkEnSightWriter',
     ),
     'vtkIOParallelExodus': ('vtkPExodusIIReader',),
     'vtkIOParallelXML': ('vtkXMLPartitionedDataSetWriter',),

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -292,8 +292,8 @@ class DataObject(
                     file_ext,
                     target='built-in VTK writer',
                 )
-            if file_ext == '.vtkhdf' and binary is False:
-                msg = '.vtkhdf files can only be written in binary format.'
+            if file_ext in ['.vtkhdf', '.case'] and binary is False:
+                msg = f'{file_ext} files can only be written in binary format.'
                 raise ValueError(msg)
 
             # Save using the writer

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -309,7 +309,7 @@ class DataObject(
 
             writer.write()
 
-            if not writer.formatted_path.exists():
+            if not writer.written_path.exists():
                 msg = f'VTK writer failed to write file: {file_path}'
                 raise OSError(msg)
 

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -309,7 +309,7 @@ class DataObject(
 
             writer.write()
 
-            if not file_path.exists():
+            if not writer.formatted_path.exists():
                 msg = f'VTK writer failed to write file: {file_path}'
                 raise OSError(msg)
 

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -310,7 +310,7 @@ class DataObject(
             writer.write()
 
             if not writer.written_path.exists():
-                msg = f'VTK writer failed to write file: {file_path}'
+                msg = f'VTK writer failed to write file: {writer.written_path}'
                 raise OSError(msg)
 
         elif file_ext in _PICKLE_FILE_EXT:

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -46,6 +46,7 @@ from .utilities.fileio import get_ext
 from .utilities.misc import abstract_class
 from .utilities.points import vtk_points
 from .utilities.writer import BaseWriter
+from .utilities.writer import EnSightWriter
 from .utilities.writer import HDFWriter
 from .utilities.writer import HoudiniPolyDataWriter
 from .utilities.writer import IVWriter
@@ -1963,6 +1964,7 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
     _WRITERS: ClassVar[dict[str, type[BaseWriter]]] = {
         '.vtu': XMLUnstructuredGridWriter,
         '.vtk': UnstructuredGridWriter,
+        '.case': EnSightWriter,
     }
     if vtk_version_info >= (9, 4):
         _WRITERS['.vtkhdf'] = HDFWriter

--- a/pyvista/core/utilities/__init__.py
+++ b/pyvista/core/utilities/__init__.py
@@ -248,6 +248,7 @@ from .transform import Transform as Transform
 from .writer import BaseWriter as BaseWriter
 from .writer import BMPWriter as BMPWriter
 from .writer import DataSetWriter as DataSetWriter
+from .writer import EnSightWriter as EnSightWriter
 from .writer import HDFWriter as HDFWriter
 from .writer import HoudiniPolyDataWriter as HoudiniPolyDataWriter
 from .writer import IVWriter as IVWriter

--- a/pyvista/core/utilities/writer.py
+++ b/pyvista/core/utilities/writer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 import contextlib
+import pathlib
 from typing import TYPE_CHECKING
 from typing import ClassVar
 from typing import Literal
@@ -92,6 +93,7 @@ class BaseWriter(_FileIOBase):
         super().__init__()
         self.path = path
         self.data_object = data_object
+        self.formatted_path = path
 
     @classmethod
     def _get_extension_mappings(cls) -> list[dict[str, type]]:
@@ -140,6 +142,22 @@ class BaseWriter(_FileIOBase):
     def data_object(self, data_object: DataObject) -> None:
         self._data_object = data_object
         self.writer.SetInputData(data_object)
+
+    @property
+    def formatted_path(self) -> pathlib.Path:
+        """Return the formatted path of the written files.
+
+        Returns
+        -------
+        str
+            The formatted path of the written files.
+
+        """
+        return self._formatted_path
+
+    @formatted_path.setter
+    def formatted_path(self, path: str | Path) -> None:
+        self._formatted_path = pathlib.Path(path)
 
     def _execute_before_write(self) -> None:
         """Execute code before calling `write()`.
@@ -454,6 +472,24 @@ class UnstructuredGridWriter(BaseWriter, _DataFormatMixin):
     """
 
     _vtk_class_name = 'vtkUnstructuredGridWriter'
+
+
+class EnSightWriter(BaseWriter):
+    """EnSightWriter for `.case` files.
+
+    Wraps :vtk:`vtkEnSightWriter`.
+
+    .. versionadded:: 0.49.0
+
+    """
+
+    _vtk_class_name = 'vtkEnSightWriter'
+
+    def _execute_before_write(self) -> None:
+        raw_path = pathlib.Path(self.path)
+        process_number = self.writer.GetProcessNumber()  # type: ignore[attr-defined]
+        basename = raw_path.stem
+        self.formatted_path = raw_path.parent / f'{basename}.{process_number}.case'
 
 
 @abstract_class

--- a/pyvista/core/utilities/writer.py
+++ b/pyvista/core/utilities/writer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 import contextlib
-import pathlib
+from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import ClassVar
 from typing import Literal
@@ -130,8 +130,6 @@ class BaseWriter(_FileIOBase):
 
         Notes
         -----
-        :attr:`path`:
-
         This is the path that will be passed to the underlying VTK writer.
         For most writers, this is the actual path of the written file.
         For writers that write multiple files (e.g., EnSightWriter),
@@ -163,10 +161,10 @@ class BaseWriter(_FileIOBase):
     def written_path(self) -> pathlib.Path:
         """Return the formatted path of the written files.
 
+        .. versionadded:: 0.49.0
+
         Notes
         -----
-        :attr:`written_path`:
-
         Unlike :attr:`path`, ``written_path`` is the actual path of the written file.
         For most readers, ``path`` and ``written_path`` are identical. In cases where
         multiple files are written (e.g. :class:`vtkEnSightWriter`), this path corresponds
@@ -182,7 +180,7 @@ class BaseWriter(_FileIOBase):
 
     @written_path.setter
     def written_path(self, path: str | Path) -> None:
-        self._written_path = pathlib.Path(path)
+        self._written_path = Path(path)
 
     def _execute_before_write(self) -> None:
         """Execute code before calling `write()`.
@@ -500,7 +498,7 @@ class UnstructuredGridWriter(BaseWriter, _DataFormatMixin):
 
 
 class EnSightWriter(BaseWriter):
-    """EnSightWriter for `.case` files.
+    """EnSightWriter for ``.case`` files.
 
     Wraps :vtk:`vtkEnSightWriter`.
 
@@ -524,7 +522,7 @@ class EnSightWriter(BaseWriter):
     def path(self) -> str:  # numpydoc ignore=RT01
         """Return or set the filename or directory of the writer."""
         # vtkEnSightWriter has no single FileName concept, only Path/BaseName.
-        path = pathlib.Path(self.writer.GetPath())  # type: ignore[attr-defined]
+        path = Path(self.writer.GetPath())  # type: ignore[attr-defined]
         basename = self.writer.GetBaseName()  # type: ignore[attr-defined]
         return str(path / basename) if basename else str(path)
 
@@ -533,14 +531,14 @@ class EnSightWriter(BaseWriter):
         # Set Path/BaseName directly to avoid vtkEnSightWriter's ComputeNames(),
         # which splits FileName on the last '/' and breaks on Windows backslash
         # paths (falls back to Path="./" and mangles the rest into BaseName).
-        raw_path = pathlib.Path(path)
+        raw_path = Path(path)
         self.writer.SetPath(str(raw_path.parent))  # type: ignore[attr-defined]
         self.writer.SetBaseName(raw_path.stem)  # type: ignore[attr-defined]
 
     def _execute_before_write(self) -> None:
         # ProcessNumber can still change after path is set (e.g. via writer_kwargs),
         # so the final filename must be resolved here, not in the path setter.
-        raw_path = pathlib.Path(self.path)
+        raw_path = Path(self.path)
         process_number = self.writer.GetProcessNumber()  # type: ignore[attr-defined]
         self.written_path = raw_path.parent / f'{raw_path.stem}.{process_number}.case'
 

--- a/pyvista/core/utilities/writer.py
+++ b/pyvista/core/utilities/writer.py
@@ -126,7 +126,19 @@ class BaseWriter(_FileIOBase):
 
     @property
     def path(self) -> str:  # numpydoc ignore=RT01
-        """Return or set the filename or directory of the writer."""
+        """Return or set the filename or directory of the writer.
+
+        This is the path that will be passed to the underlying VTK writer.
+        For most writers, this is the actual path of the written file.
+        For writers that write multiple files (e.g., EnSightWriter),
+        this path can be renamed. See :attr:`written_path` for the actual path of the written file.
+
+        Returns
+        -------
+        str
+            The path of the file to write to.
+
+        """
         return self.writer.GetFileName()  # type: ignore[attr-defined]
 
     @path.setter
@@ -147,10 +159,15 @@ class BaseWriter(_FileIOBase):
     def written_path(self) -> pathlib.Path:
         """Return the formatted path of the written files.
 
+        Unlike :attr:`path`, ``written_path`` is the actual path of the written file.
+        For most readers, ``path`` and ``written_path`` are identical. In cases where
+        multiple files are written (e.g. :class:`vtkEnSightWriter`), this path corresponds
+        to the "main" output file that would be used for reading the mesh again.
+
         Returns
         -------
-        str
-            The formatted path of the written files.
+        pathlib.Path
+            The path of the written file.
 
         """
         return self._written_path
@@ -478,6 +495,11 @@ class EnSightWriter(BaseWriter):
     """EnSightWriter for `.case` files.
 
     Wraps :vtk:`vtkEnSightWriter`.
+
+    .. note::
+        This is a parallel writer that prepends a process number to the ``.case`` extension,
+        e.g. ``<filename>.0.case``. Use :attr:`written_path` to get the saved file after calling
+        :meth:`write`.
 
     .. versionadded:: 0.49.0
 

--- a/pyvista/core/utilities/writer.py
+++ b/pyvista/core/utilities/writer.py
@@ -19,7 +19,6 @@ from pyvista.core.utilities.fileio import _warn_multiblock_nested_field_data
 from pyvista.core.utilities.misc import abstract_class
 
 if TYPE_CHECKING:
-
     from pyvista import DataObject
     from pyvista import NumpyArray
     from pyvista import _vtk
@@ -157,7 +156,7 @@ class BaseWriter(_FileIOBase):
         self.writer.SetInputData(data_object)
 
     @property
-    def written_path(self) -> pathlib.Path:
+    def written_path(self) -> Path:
         """Return the formatted path of the written files.
 
         .. versionadded:: 0.49.0

--- a/pyvista/core/utilities/writer.py
+++ b/pyvista/core/utilities/writer.py
@@ -501,6 +501,11 @@ class EnSightWriter(BaseWriter):
         e.g. ``<filename>.0.case``. Use :attr:`written_path` to get the saved file after calling
         :meth:`write`.
 
+    .. note::
+        This writer saves the mesh as a multi-block dataset.
+        Even if the input mesh is a single block, the output will be a multi-block dataset
+        and the default block name will be ``VTK Part``.
+
     .. versionadded:: 0.49.0
 
     """

--- a/pyvista/core/utilities/writer.py
+++ b/pyvista/core/utilities/writer.py
@@ -535,7 +535,7 @@ class EnSightWriter(BaseWriter):
         # paths (falls back to Path="./" and mangles the rest into BaseName).
         raw_path = pathlib.Path(path)
         self.writer.SetPath(str(raw_path.parent))  # type: ignore[attr-defined]
-        self.writer.SetBaseName(raw_path.name)  # type: ignore[attr-defined]
+        self.writer.SetBaseName(raw_path.stem)  # type: ignore[attr-defined]
 
     def _execute_before_write(self) -> None:
         # ProcessNumber can still change after path is set (e.g. via writer_kwargs),

--- a/pyvista/core/utilities/writer.py
+++ b/pyvista/core/utilities/writer.py
@@ -506,8 +506,8 @@ class EnSightWriter(BaseWriter):
 
     .. note::
         This is a parallel writer that prepends a process number to the ``.case`` extension,
-        e.g. ``<filename>.0.case``. Use :attr:`written_path` to get the saved file after calling
-        :meth:`write`.
+        e.g. ``<filename>.0.case``. Use :attr:`~pyvista.BaseWriter.written_path`
+        to get the saved file after calling :meth:`~pyvista.BaseWriter.write`.
 
     .. note::
         This writer saves the mesh as a multi-block dataset.
@@ -520,11 +520,29 @@ class EnSightWriter(BaseWriter):
 
     _vtk_class_name = 'vtkEnSightWriter'
 
+    @property
+    def path(self) -> str:  # numpydoc ignore=RT01
+        """Return or set the filename or directory of the writer."""
+        # vtkEnSightWriter has no single FileName concept, only Path/BaseName.
+        path = pathlib.Path(self.writer.GetPath())  # type: ignore[attr-defined]
+        basename = self.writer.GetBaseName()  # type: ignore[attr-defined]
+        return str(path / basename) if basename else str(path)
+
+    @path.setter
+    def path(self, path: str | Path) -> None:
+        # Set Path/BaseName directly to avoid vtkEnSightWriter's ComputeNames(),
+        # which splits FileName on the last '/' and breaks on Windows backslash
+        # paths (falls back to Path="./" and mangles the rest into BaseName).
+        raw_path = pathlib.Path(path)
+        self.writer.SetPath(str(raw_path.parent))  # type: ignore[attr-defined]
+        self.writer.SetBaseName(raw_path.name)  # type: ignore[attr-defined]
+
     def _execute_before_write(self) -> None:
+        # ProcessNumber can still change after path is set (e.g. via writer_kwargs),
+        # so the final filename must be resolved here, not in the path setter.
         raw_path = pathlib.Path(self.path)
         process_number = self.writer.GetProcessNumber()  # type: ignore[attr-defined]
-        basename = raw_path.stem
-        self.written_path = raw_path.parent / f'{basename}.{process_number}.case'
+        self.written_path = raw_path.parent / f'{raw_path.stem}.{process_number}.case'
 
 
 @abstract_class

--- a/pyvista/core/utilities/writer.py
+++ b/pyvista/core/utilities/writer.py
@@ -93,7 +93,7 @@ class BaseWriter(_FileIOBase):
         super().__init__()
         self.path = path
         self.data_object = data_object
-        self.formatted_path = path
+        self.written_path = path
 
     @classmethod
     def _get_extension_mappings(cls) -> list[dict[str, type]]:
@@ -144,7 +144,7 @@ class BaseWriter(_FileIOBase):
         self.writer.SetInputData(data_object)
 
     @property
-    def formatted_path(self) -> pathlib.Path:
+    def written_path(self) -> pathlib.Path:
         """Return the formatted path of the written files.
 
         Returns
@@ -153,11 +153,11 @@ class BaseWriter(_FileIOBase):
             The formatted path of the written files.
 
         """
-        return self._formatted_path
+        return self._written_path
 
-    @formatted_path.setter
-    def formatted_path(self, path: str | Path) -> None:
-        self._formatted_path = pathlib.Path(path)
+    @written_path.setter
+    def written_path(self, path: str | Path) -> None:
+        self._written_path = pathlib.Path(path)
 
     def _execute_before_write(self) -> None:
         """Execute code before calling `write()`.
@@ -489,7 +489,7 @@ class EnSightWriter(BaseWriter):
         raw_path = pathlib.Path(self.path)
         process_number = self.writer.GetProcessNumber()  # type: ignore[attr-defined]
         basename = raw_path.stem
-        self.formatted_path = raw_path.parent / f'{basename}.{process_number}.case'
+        self.written_path = raw_path.parent / f'{basename}.{process_number}.case'
 
 
 @abstract_class

--- a/pyvista/core/utilities/writer.py
+++ b/pyvista/core/utilities/writer.py
@@ -128,6 +128,10 @@ class BaseWriter(_FileIOBase):
     def path(self) -> str:  # numpydoc ignore=RT01
         """Return or set the filename or directory of the writer.
 
+        Notes
+        -----
+        :attr:`path`:
+
         This is the path that will be passed to the underlying VTK writer.
         For most writers, this is the actual path of the written file.
         For writers that write multiple files (e.g., EnSightWriter),
@@ -158,6 +162,10 @@ class BaseWriter(_FileIOBase):
     @property
     def written_path(self) -> pathlib.Path:
         """Return the formatted path of the written files.
+
+        Notes
+        -----
+        :attr:`written_path`:
 
         Unlike :attr:`path`, ``written_path`` is the actual path of the written file.
         For most readers, ``path`` and ``written_path`` are identical. In cases where

--- a/pyvista/core/utilities/writer.py
+++ b/pyvista/core/utilities/writer.py
@@ -19,7 +19,6 @@ from pyvista.core.utilities.fileio import _warn_multiblock_nested_field_data
 from pyvista.core.utilities.misc import abstract_class
 
 if TYPE_CHECKING:
-    from pathlib import Path
 
     from pyvista import DataObject
     from pyvista import NumpyArray

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -476,6 +476,10 @@ def test_triangulate_inplace(hexbeam):
 @pytest.mark.parametrize('binary', [True, False])
 @pytest.mark.parametrize('extension', pv.UnstructuredGrid._WRITERS)
 def test_save(extension, binary, tmpdir, hexbeam):
+    if extension == '.case':
+        pytest.skip('Tests for EnSightWriter are prepared in a separate test function.')
+        return
+
     filename = str(tmpdir.mkdir('tmpdir').join(f'tmp.{extension}'))
     if extension == '.vtkhdf' and not binary:
         with pytest.raises(
@@ -491,6 +495,31 @@ def test_save(extension, binary, tmpdir, hexbeam):
     assert grid.points.shape == hexbeam.points.shape
 
     grid = pv.read(filename)
+    assert grid.cells.shape == hexbeam.cells.shape
+    assert grid.points.shape == hexbeam.points.shape
+    assert isinstance(grid, pv.UnstructuredGrid)
+
+
+@pytest.mark.parametrize('binary', [True, False])
+@pytest.mark.parametrize('extension', ['.case'])
+def test_ensight_save(extension, binary, tmpdir, hexbeam):
+    filename = str(tmpdir.mkdir('tmpdir').join(f'tmp{extension}'))
+    if not binary:
+        with pytest.raises(ValueError, match=r'.case files can only be written in binary format'):
+            hexbeam.save(filename, binary=binary)
+        return
+
+    hexbeam.save(filename, binary=binary)
+
+    output_filename = list(pathlib.Path(filename).parent.glob('*.case'))
+    assert len(output_filename) == 1
+    output_filename = str(output_filename[0])
+
+    grid = pv.MultiBlock(output_filename)['VTK Part']
+    assert grid.cells.shape == hexbeam.cells.shape
+    assert grid.points.shape == hexbeam.points.shape
+
+    grid = pv.read(output_filename)['VTK Part']
     assert grid.cells.shape == hexbeam.cells.shape
     assert grid.points.shape == hexbeam.points.shape
     assert isinstance(grid, pv.UnstructuredGrid)

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -512,7 +512,10 @@ def test_ensight_save(extension, binary, tmpdir, hexbeam):
     hexbeam.save(filename, binary=binary)
 
     output_filename = list(pathlib.Path(filename).parent.glob('*.case'))
+    expected_pattern = re.compile(r'^hexbeam\.[0-9]+\.case$')
+
     assert len(output_filename) == 1
+    assert expected_pattern.match(output_filename[0].name)
     output_filename = str(output_filename[0])
 
     grid = pv.MultiBlock(output_filename)['VTK Part']

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -512,7 +512,7 @@ def test_ensight_save(extension, binary, tmpdir, hexbeam):
     hexbeam.save(filename, binary=binary)
 
     output_filename = list(pathlib.Path(filename).parent.glob('*.case'))
-    expected_pattern = re.compile(r'^hexbeam\.[0-9]+\.case$')
+    expected_pattern = re.compile(r'^tmp\.[0-9]+\.case$')
 
     assert len(output_filename) == 1
     assert expected_pattern.match(output_filename[0].name)

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -3332,14 +3332,14 @@ def test_write_path_of_ensight_writer(tmp_path, hexbeam):
 
     path = tmp_path / 'hexbeam.case'
     writer = EnSightWriter(tmp_path / 'hexbeam.case', hexbeam)
-    assert writer.path == str(path)
+    assert writer.path == str(path.parent / path.stem)
     # written_path is initialized same as path,
     # but is updated after write() is called
     assert writer.written_path == path
 
     writer.write()
 
-    assert writer.path == str(path)
+    assert writer.path == str(path.parent / path.stem)
 
     expected_path = path.with_name(path.stem + f'.{writer.writer.GetProcessNumber()}.case')
     assert writer.written_path == expected_path

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -3325,14 +3325,3 @@ def test_try_callback_warns_every_time():
     messages = [w for w in log if 'Encountered issue in callback' in str(w.message)]
     assert len(messages) == n_calls
     assert 'callback failed' in str(messages[0].message)
-
-
-def test_ensight_writer(tmp_path):
-    mesh = pv.UnstructuredGrid(ex.hexbeamfile)
-    mesh.save(tmp_path / 'sample.case')
-
-    # basename is renamed by VTK. (e.g. "sample.0.case")
-    case_path = list(tmp_path.glob('*.case'))
-    assert len(case_path) == 1
-    reloaded = pv.read(case_path[0])
-    assert reloaded['VTK Part'].n_points == mesh.n_points

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -79,7 +79,6 @@ from pyvista.core.utilities.observers import Observer
 from pyvista.core.utilities.observers import ProgressMonitor
 from pyvista.core.utilities.state_manager import _StateManager
 from pyvista.core.utilities.transform import Transform
-from pyvista.core.utilities.writer import EnSightWriter
 from pyvista.core.utilities.writer import _DataFormatMixin
 from pyvista.plotting.prop3d import _orientation_as_rotation_matrix
 from pyvista.plotting.widgets import _parse_interaction_event
@@ -3331,7 +3330,7 @@ def test_try_callback_warns_every_time():
 def test_write_path_of_ensight_writer(tmp_path, hexbeam):
 
     path = tmp_path / 'hexbeam.case'
-    writer = EnSightWriter(tmp_path / 'hexbeam.case', hexbeam)
+    writer = pv.EnSightWriter(tmp_path / 'hexbeam.case', hexbeam)
     assert writer.path == str(path.parent / path.stem)
     # written_path is initialized same as path,
     # but is updated after write() is called

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -79,6 +79,7 @@ from pyvista.core.utilities.observers import Observer
 from pyvista.core.utilities.observers import ProgressMonitor
 from pyvista.core.utilities.state_manager import _StateManager
 from pyvista.core.utilities.transform import Transform
+from pyvista.core.utilities.writer import EnSightWriter
 from pyvista.core.utilities.writer import _DataFormatMixin
 from pyvista.plotting.prop3d import _orientation_as_rotation_matrix
 from pyvista.plotting.widgets import _parse_interaction_event
@@ -3325,3 +3326,20 @@ def test_try_callback_warns_every_time():
     messages = [w for w in log if 'Encountered issue in callback' in str(w.message)]
     assert len(messages) == n_calls
     assert 'callback failed' in str(messages[0].message)
+
+
+def test_write_path_of_ensight_writer(tmp_path, hexbeam):
+
+    path = tmp_path / 'hexbeam.case'
+    writer = EnSightWriter(tmp_path / 'hexbeam.case', hexbeam)
+    assert writer.path == str(path)
+    # written_path is initialized same as path,
+    # but is updated after write() is called
+    assert writer.written_path == path
+
+    writer.write()
+
+    assert writer.path == str(path)
+
+    expected_path = path.with_name(path.stem + f'.{writer.writer.GetProcessNumber()}.case')
+    assert writer.written_path == expected_path

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -3325,3 +3325,14 @@ def test_try_callback_warns_every_time():
     messages = [w for w in log if 'Encountered issue in callback' in str(w.message)]
     assert len(messages) == n_calls
     assert 'callback failed' in str(messages[0].message)
+
+
+def test_ensight_writer(tmp_path):
+    mesh = pv.UnstructuredGrid(ex.hexbeamfile)
+    mesh.save(tmp_path / 'sample.case')
+
+    # basename is renamed by VTK. (e.g. "sample.0.case")
+    case_path = list(tmp_path.glob('*.case'))
+    assert len(case_path) == 1
+    reloaded = pv.read(case_path[0])
+    assert reloaded['VTK Part'].n_points == mesh.n_points

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -285,6 +285,9 @@ def get_default_class_init_kwargs(pyvista_class):
     elif pyvista_class is pv.XMLPartitionedDataSetWriter:
         kwargs['path'] = ''
         kwargs['data_object'] = pv.PartitionedDataSet()
+    elif pyvista_class is pv.EnSightWriter:
+        kwargs['path'] = ''
+        kwargs['data_object'] = pv.UnstructuredGrid()
     elif issubclass(pyvista_class, pv.BaseWriter):
         kwargs['path'] = ''
         kwargs['data_object'] = pv.PolyData()


### PR DESCRIPTION
### Overview

Closes #8847 

### Details

- Add support for writing Ensight files in PyVista.
- Tweak the code to check whether the output file is written successfully since `vtkEnSightWriter` changes the output file name.
  - See: https://gitlab.kitware.com/vtk/vtk/-/blob/master/IO/Parallel/vtkEnSightWriter.cxx#L894-895



