### PR TITLE
Fix compat with 9.7 and non-matplotlib wheels

### DIFF
--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import contextlib
 
 # Magic vtk imports needed to make LaTeX rendering work. See https://discourse.vtk.org/t/how-to-check-if-mathtext-is-supported-without-importing-all-of-vtk/16038
+# Also, VTK may be built without its Matplotlib module. MathText/LaTeX rendering is then
+# unavailable (`check_math_text_support()` returns False), but plotting otherwise works.
 # isort: off
+
 import vtkmodules.vtkRenderingFreeType  # noqa: F401, TID251
 import vtkmodules.vtkRenderingContextOpenGL2  # noqa: F401, TID251
 
-# VTK may be built without its Matplotlib module. MathText/LaTeX rendering is then
-# unavailable (`check_math_text_support()` returns False), but plotting otherwise works.
 with contextlib.suppress(ImportError):
     import vtkmodules.vtkRenderingMatplotlib  # noqa: F401, TID251
 # isort: on

--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -4,16 +4,17 @@ from __future__ import annotations
 
 import contextlib
 
+# isort: off
+import vtkmodules.vtkRenderingContextOpenGL2  # noqa: F401, TID251
+
 # Magic vtk imports needed to make LaTeX rendering work. See https://discourse.vtk.org/t/how-to-check-if-mathtext-is-supported-without-importing-all-of-vtk/16038
 # Also, VTK may be built without its Matplotlib module. MathText/LaTeX rendering is then
 # unavailable (`check_math_text_support()` returns False), but plotting otherwise works.
-# isort: off
-
 import vtkmodules.vtkRenderingFreeType  # noqa: F401, TID251
-import vtkmodules.vtkRenderingContextOpenGL2  # noqa: F401, TID251
 
 with contextlib.suppress(ImportError):
     import vtkmodules.vtkRenderingMatplotlib  # noqa: F401, TID251
+
 # isort: on
 
 from pyvista import MAX_N_COLOR_BARS as MAX_N_COLOR_BARS

--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import contextlib
+
 # Magic vtk imports needed to make LaTeX rendering work. See https://discourse.vtk.org/t/how-to-check-if-mathtext-is-supported-without-importing-all-of-vtk/16038
 # isort: off
 import vtkmodules.vtkRenderingFreeType  # noqa: F401, TID251
 import vtkmodules.vtkRenderingContextOpenGL2  # noqa: F401, TID251
-import vtkmodules.vtkRenderingMatplotlib  # noqa: F401, TID251
+
+# VTK may be built without its Matplotlib module. MathText/LaTeX rendering is then
+# unavailable (`check_math_text_support()` returns False), but plotting otherwise works.
+with contextlib.suppress(ImportError):
+    import vtkmodules.vtkRenderingMatplotlib  # noqa: F401, TID251
 # isort: on
 
 from pyvista import MAX_N_COLOR_BARS as MAX_N_COLOR_BARS

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,14 +6,40 @@ import sys
 
 import pytest
 
+# These sets are allow-lists, not requirements: a module may be listed but not
+# actually loaded (e.g. on older VTK, or on a VTK built without a given module).
 CORE_VTKMODULES = {
     'vtkmodules.numpy_interface',
+    # VTK >= 9.7 eagerly imports these pure-Python helpers from vtkCommonCore,
+    # vtkCommonDataModel and vtkCommonExecutionModel.
+    'vtkmodules.numpy_interface._vtk_array_mixin',
+    'vtkmodules.numpy_interface.array_overrides',
     'vtkmodules.numpy_interface.dataset_adapter',
+    'vtkmodules.numpy_interface.utils',
+    'vtkmodules.numpy_interface.vtk_affine_array',
+    'vtkmodules.numpy_interface.vtk_aos_array',
+    'vtkmodules.numpy_interface.vtk_composite_array',
+    'vtkmodules.numpy_interface.vtk_constant_array',
+    'vtkmodules.numpy_interface.vtk_implicit_array',
+    'vtkmodules.numpy_interface.vtk_indexed_array',
+    'vtkmodules.numpy_interface.vtk_none_array',
+    'vtkmodules.numpy_interface.vtk_partitioned_array',
+    'vtkmodules.numpy_interface.vtk_soa_array',
+    'vtkmodules.numpy_interface.vtk_strided_array',
+    'vtkmodules.numpy_interface.vtk_structured_point_array',
     'vtkmodules.util',
+    'vtkmodules.util.data_array_selection',
     'vtkmodules.util.data_model',
     'vtkmodules.util.execution_model',
+    'vtkmodules.util.graph',
+    'vtkmodules.util.implicit_functions',
+    'vtkmodules.util.information',
+    'vtkmodules.util.matrix',
     'vtkmodules.util.numpy_support',
     'vtkmodules.util.pickle_support',
+    'vtkmodules.util.selection',
+    'vtkmodules.util.string_array',
+    'vtkmodules.util.variant_array',
     'vtkmodules.util.vtkConstants',
     'vtkmodules.vtkCommonCore',
     'vtkmodules.vtkCommonDataModel',
@@ -45,6 +71,8 @@ PLOTTING_VTKMODULES = CORE_VTKMODULES | {
     'vtkmodules.vtkRenderingCore',
     'vtkmodules.vtkRenderingFreeType',
     'vtkmodules.vtkRenderingHyperTreeGrid',
+    # Pulled in by vtkRenderingContextOpenGL2 on VTK >= 9.7
+    'vtkmodules.vtkRenderingLabel',
     'vtkmodules.vtkRenderingMatplotlib',
     'vtkmodules.vtkRenderingOpenGL2',
     'vtkmodules.vtkRenderingUI',

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,40 +6,14 @@ import sys
 
 import pytest
 
-# These sets are allow-lists, not requirements: a module may be listed but not
-# actually loaded (e.g. on older VTK, or on a VTK built without a given module).
 CORE_VTKMODULES = {
     'vtkmodules.numpy_interface',
-    # VTK >= 9.7 eagerly imports these pure-Python helpers from vtkCommonCore,
-    # vtkCommonDataModel and vtkCommonExecutionModel.
-    'vtkmodules.numpy_interface._vtk_array_mixin',
-    'vtkmodules.numpy_interface.array_overrides',
     'vtkmodules.numpy_interface.dataset_adapter',
-    'vtkmodules.numpy_interface.utils',
-    'vtkmodules.numpy_interface.vtk_affine_array',
-    'vtkmodules.numpy_interface.vtk_aos_array',
-    'vtkmodules.numpy_interface.vtk_composite_array',
-    'vtkmodules.numpy_interface.vtk_constant_array',
-    'vtkmodules.numpy_interface.vtk_implicit_array',
-    'vtkmodules.numpy_interface.vtk_indexed_array',
-    'vtkmodules.numpy_interface.vtk_none_array',
-    'vtkmodules.numpy_interface.vtk_partitioned_array',
-    'vtkmodules.numpy_interface.vtk_soa_array',
-    'vtkmodules.numpy_interface.vtk_strided_array',
-    'vtkmodules.numpy_interface.vtk_structured_point_array',
     'vtkmodules.util',
-    'vtkmodules.util.data_array_selection',
     'vtkmodules.util.data_model',
     'vtkmodules.util.execution_model',
-    'vtkmodules.util.graph',
-    'vtkmodules.util.implicit_functions',
-    'vtkmodules.util.information',
-    'vtkmodules.util.matrix',
     'vtkmodules.util.numpy_support',
     'vtkmodules.util.pickle_support',
-    'vtkmodules.util.selection',
-    'vtkmodules.util.string_array',
-    'vtkmodules.util.variant_array',
     'vtkmodules.util.vtkConstants',
     'vtkmodules.vtkCommonCore',
     'vtkmodules.vtkCommonDataModel',
@@ -71,8 +45,6 @@ PLOTTING_VTKMODULES = CORE_VTKMODULES | {
     'vtkmodules.vtkRenderingCore',
     'vtkmodules.vtkRenderingFreeType',
     'vtkmodules.vtkRenderingHyperTreeGrid',
-    # Pulled in by vtkRenderingContextOpenGL2 on VTK >= 9.7
-    'vtkmodules.vtkRenderingLabel',
     'vtkmodules.vtkRenderingMatplotlib',
     'vtkmodules.vtkRenderingOpenGL2',
     'vtkmodules.vtkRenderingUI',


### PR DESCRIPTION
I locally built a wheel from VTK `master` without matplotlib support. This made PyVista not import. This is easily fixed with a try/except import (via `contextlib.suppress`).

Then running `test_init.py` had some failures with the same wheel, so I cleaned those up too as a future compat move.