### PR TITLE
Convert numpydoc headers into real docutils sections

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -576,6 +576,21 @@ def _str_examples(self):
 SphinxDocString._str_examples = _str_examples
 
 
+# -- headings instead of rubrics for docstring sections -----------------------
+# numpydoc renders section headers (Notes, References, Examples) as
+# `.. rubric::` by default. Rubrics aren't real docutils sections, so they're
+# invisible to the "on this page" navbar, which is built from actual heading
+# structure. Since pyvista generates one dedicated page per function/method/
+# class (see doc/source/_templates/autosummary/*.rst), each page has at most
+# one docstring, so promoting these to real headings doesn't create the
+# duplicate-heading clutter it would on a page combining many docstrings.
+def _str_header(self, name):  # noqa: ARG001
+    return [name, '-' * len(name), '']
+
+
+SphinxDocString._str_header = _str_header
+
+
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,9 +12,12 @@ import sys
 from typing import TYPE_CHECKING
 import warnings
 
+from docutils import nodes
 from docutils.parsers.rst.directives.images import Image
+from sphinx import addnodes
 
 if TYPE_CHECKING:
+    from docutils.nodes import Element
     from sphinx.application import Sphinx
 
 # Otherwise VTK reader issues on some systems, causing sphinx to crash. See also #226.
@@ -591,6 +594,41 @@ def _str_header(self, name):  # noqa: ARG001
 SphinxDocString._str_header = _str_header
 
 
+# Making the sections above real headings isn't enough on its own: autodoc wraps
+# the whole docstring in a `desc` node, and Sphinx's TocTreeCollector explicitly
+# skips any section it finds inside one. Lift them out to page level so they show
+# up in the navbar.
+def _is_nested_desc(node: Element) -> bool:
+    parent = node.parent
+    while parent is not None:
+        if isinstance(parent, addnodes.desc):
+            return True
+        parent = parent.parent
+    return False
+
+
+def hoist_docstring_sections(app: Sphinx, doctree: Element) -> None:  # noqa: ARG001
+    """Move docstring sections out of their ``desc`` node to page level."""
+    for desc in list(doctree.findall(addnodes.desc)):
+        if _is_nested_desc(desc):
+            continue
+        parent = desc.parent
+        if parent is None:
+            continue
+        # Only hoist when this object owns the page, otherwise sections from
+        # several objects would collide at page level.
+        if len([node for node in parent if isinstance(node, addnodes.desc)]) != 1:
+            continue
+        content = next((node for node in desc if isinstance(node, addnodes.desc_content)), None)
+        if content is None:
+            continue
+        sections = [node for node in content if isinstance(node, nodes.section)]
+        index = parent.index(desc)
+        for offset, section in enumerate(sections):
+            content.remove(section)
+            parent.insert(index + 1 + offset, section)
+
+
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -861,6 +899,9 @@ def setup(app: Sphinx) -> None:  # noqa: D103
     app.connect('config-inited', report_parallel_safety)
     app.connect('builder-inited', configure_backend)
     app.connect('html-page-context', pv_html_page_context)
+
+    # priority < 500 so this runs before Sphinx's TocTreeCollector builds the toc
+    app.connect('doctree-read', hoist_docstring_sections, priority=400)
 
     # right before writing, patch the gallery placeholders
     app.connect('doctree-resolved', make_tables.patch_gallery_placeholders)

--- a/tests/doc/tst_doc_build.py
+++ b/tests/doc/tst_doc_build.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 from xml.etree.ElementTree import parse
 
 import pytest
@@ -32,3 +33,79 @@ def test_sphinx_gallery_execution_times(testcase):
             f'Took too long to run: '
             f'Duration {testcase["time"]}s > {SPHINX_GALLERY_EXAMPLE_MAX_TIME}s',
         )
+
+
+# -- docstring sections in the "on this page" navbar --------------------------
+# `conf.py` patches numpydoc to emit real headings instead of rubrics, then
+# hoists those sections out of the autodoc `desc` node so Sphinx's
+# TocTreeCollector can see them. Both halves are needed, and neither fails
+# loudly if it breaks -- the navbar entries just silently disappear.
+
+# Minimum number of API pages expected to gain a docstring-section entry. The
+# real count is in the thousands; this only needs to be high enough that a
+# silent regression can't slip through.
+MIN_PAGES_WITH_HOISTED_SECTIONS = 100
+
+_PAGE_TOC_RE = re.compile(r'<nav class="bd-toc-nav page-toc">(.*?)</nav>', re.DOTALL)
+_HREF_RE = re.compile(r'href="#([^"]+)"')
+
+
+def page_toc_anchors(html: str) -> list[str]:
+    """Return the anchors linked from a page's "on this page" navbar."""
+    match = _PAGE_TOC_RE.search(html)
+    return _HREF_RE.findall(match.group(1)) if match else []
+
+
+def find_api_page(filename: str) -> Path:
+    """Return a generated single-object API page, skipping if docs moved."""
+    page = next(Path(HTML_DIR).rglob(filename), None)
+    if page is None:
+        pytest.skip(f'{filename} not found; the API doc layout may have changed')
+    return page
+
+
+def test_docstring_sections_are_hoisted_into_page_toc():
+    # `PolyData.decimate` has both a Notes and an Examples section.
+    html = find_api_page('pyvista.PolyData.decimate.html').read_text()
+    anchors = page_toc_anchors(html)
+
+    assert 'notes' in anchors
+    assert 'examples' in anchors
+
+
+def test_hoisted_sections_are_not_rubrics():
+    html = find_api_page('pyvista.PolyData.decimate.html').read_text()
+
+    # A rubric would render as <p class="rubric">Examples</p> and never reach
+    # the navbar. Real headings carry an id so they can be linked.
+    assert '<p class="rubric">Examples</p>' not in html
+    assert 'id="examples"' in html
+
+
+def test_multi_object_page_does_not_hoist_sections():
+    # `helpers.rst` documents several objects on one page via `:members:`, so
+    # hoisting is skipped there to avoid colliding sections at page level.
+    page = Path(HTML_DIR) / 'api' / 'core' / 'helpers.html'
+    if not page.is_file():
+        pytest.skip('helpers.html not found; the API doc layout may have changed')
+    anchors = page_toc_anchors(page.read_text())
+
+    assert 'notes' not in anchors
+    assert 'examples' not in anchors
+
+
+def test_page_toc_anchors_resolve():
+    html = find_api_page('pyvista.PolyData.decimate.html').read_text()
+
+    for anchor in page_toc_anchors(html):
+        assert f'id="{anchor}"' in html, f'navbar links to #{anchor} but no such id exists'
+
+
+def test_docstring_sections_hoisted_across_api_pages():
+    pages_with_sections = [
+        path
+        for path in Path(HTML_DIR).rglob('_autosummary/*.html')
+        if {'notes', 'examples'} & set(page_toc_anchors(path.read_text()))
+    ]
+
+    assert len(pages_with_sections) > MIN_PAGES_WITH_HOISTED_SECTIONS

--- a/tests/doc/tst_doc_build.py
+++ b/tests/doc/tst_doc_build.py
@@ -17,12 +17,26 @@ HTML_DIR = str(Path(BUILD_DIR) / 'html')
 SPHINX_GALLERY_CONF_JUNIT = Path('sphinx-gallery') / 'junit-results.xml'
 SPHINX_GALLERY_EXAMPLE_MAX_TIME = 150.0  # Measured in seconds
 XML_FILE = HTML_DIR / SPHINX_GALLERY_CONF_JUNIT
-assert XML_FILE.is_file()
 
 
-xml_root = parse(XML_FILE).getroot()
-test_cases = [dict(case.attrib) for case in xml_root.iterfind('testcase')]
+def load_test_cases() -> list[dict[str, str]]:
+    """Return the sphinx-gallery junit test cases, or none if the docs aren't built.
+
+    Parametrization happens at collection time, so this can't raise on a missing
+    file without failing every test in the module.
+    ``test_sphinx_gallery_junit_results_exist`` reports that instead.
+    """
+    if not XML_FILE.is_file():
+        return []
+    return [dict(case.attrib) for case in parse(XML_FILE).getroot().iterfind('testcase')]
+
+
+test_cases = load_test_cases()
 test_ids = [case['classname'] for case in test_cases]
+
+
+def test_sphinx_gallery_junit_results_exist():
+    assert XML_FILE.is_file(), f'{XML_FILE} not found. Build the documentation first.'
 
 
 @pytest.mark.parametrize('testcase', test_cases, ids=test_ids)
@@ -57,10 +71,16 @@ def page_toc_anchors(html: str) -> list[str]:
 
 
 def find_api_page(filename: str) -> Path:
-    """Return a generated single-object API page, skipping if docs moved."""
+    """Return a generated single-object API page.
+
+    Fails rather than skips when the page is missing: skipping would silently
+    stop testing the feature, and nobody would know to update the test.
+    """
     page = next(Path(HTML_DIR).rglob(filename), None)
-    if page is None:
-        pytest.skip(f'{filename} not found; the API doc layout may have changed')
+    assert page is not None, (
+        f'{filename} not found under {HTML_DIR}. If the API doc layout changed, point '
+        f'this test at another single-object page with Notes and Examples sections.'
+    )
     return page
 
 
@@ -86,8 +106,10 @@ def test_multi_object_page_does_not_hoist_sections():
     # `helpers.rst` documents several objects on one page via `:members:`, so
     # hoisting is skipped there to avoid colliding sections at page level.
     page = Path(HTML_DIR) / 'api' / 'core' / 'helpers.html'
-    if not page.is_file():
-        pytest.skip('helpers.html not found; the API doc layout may have changed')
+    assert page.is_file(), (
+        f'{page} not found. If the API doc layout changed, point this test at another '
+        f'page that documents several objects via `:members:`.'
+    )
     anchors = page_toc_anchors(page.read_text())
 
     assert 'notes' not in anchors
@@ -102,9 +124,15 @@ def test_page_toc_anchors_resolve():
 
 
 def test_docstring_sections_hoisted_across_api_pages():
+    api_pages = list(Path(HTML_DIR).rglob('_autosummary/*.html'))
+    assert api_pages, (
+        f'no generated API pages found under {HTML_DIR}. If autosummary no longer '
+        f'writes to `_autosummary`, update this glob.'
+    )
+
     pages_with_sections = [
         path
-        for path in Path(HTML_DIR).rglob('_autosummary/*.html')
+        for path in api_pages
         if {'notes', 'examples'} & set(page_toc_anchors(path.read_text()))
     ]
 

--- a/tests/doc/tst_doc_build.py
+++ b/tests/doc/tst_doc_build.py
@@ -60,6 +60,9 @@ def test_sphinx_gallery_execution_times(testcase):
 # silent regression can't slip through.
 MIN_PAGES_WITH_HOISTED_SECTIONS = 100
 
+# A generated page for a single object whose docstring has Notes and Examples.
+API_PAGE = 'pyvista.PolyDataFilters.decimate.html'
+
 _PAGE_TOC_RE = re.compile(r'<nav class="bd-toc-nav page-toc">(.*?)</nav>', re.DOTALL)
 _HREF_RE = re.compile(r'href="#([^"]+)"')
 
@@ -85,8 +88,7 @@ def find_api_page(filename: str) -> Path:
 
 
 def test_docstring_sections_are_hoisted_into_page_toc():
-    # `PolyData.decimate` has both a Notes and an Examples section.
-    html = find_api_page('pyvista.PolyData.decimate.html').read_text()
+    html = find_api_page(API_PAGE).read_text()
     anchors = page_toc_anchors(html)
 
     assert 'notes' in anchors
@@ -94,7 +96,7 @@ def test_docstring_sections_are_hoisted_into_page_toc():
 
 
 def test_hoisted_sections_are_not_rubrics():
-    html = find_api_page('pyvista.PolyData.decimate.html').read_text()
+    html = find_api_page(API_PAGE).read_text()
 
     # A rubric would render as <p class="rubric">Examples</p> and never reach
     # the navbar. Real headings carry an id so they can be linked.
@@ -117,7 +119,7 @@ def test_multi_object_page_does_not_hoist_sections():
 
 
 def test_page_toc_anchors_resolve():
-    html = find_api_page('pyvista.PolyData.decimate.html').read_text()
+    html = find_api_page(API_PAGE).read_text()
 
     for anchor in page_toc_anchors(html):
         assert f'id="{anchor}"' in html, f'navbar links to #{anchor} but no such id exists'


### PR DESCRIPTION
### Overview

numpydoc renders section headers (Notes, References, Examples) as `.. rubric::` by default. Rubrics aren't real docutils sections, so they're invisible to the "on this page" navbar, which is built from actual heading structure. This PR changes that, so that these sections _do_ show up in the navbar. Since pyvista generates one dedicated page per function/method/class, each page has at most one docstring, so promoting these to real headings doesn't create the duplicate-heading clutter it would on a page combining many docstrings.

preview:

https://6a6aea08c6d56bb9dd5d6c97--pyvista-dev.netlify.app/api/core/_autosummary/pyvista.polydatafilters.decimate

<img width="2436" height="651" alt="image" src="https://github.com/user-attachments/assets/0e621d37-7207-489c-a6de-592009f0552e" />


This change complements #8840 , since that extension adds download links at the top of "Examples" sections. But for some pages with lots of parameters (e.g. add_mesh), the Examples section is lost somewhere in the middle. With this PR, Examples (and Notes, See Also, etc.) can now be easily navigated to.