### PR TITLE
Dedupe single-page and class member search results

### DIFF
--- a/doc/source/_static/search_dedupe.js
+++ b/doc/source/_static/search_dedupe.js
@@ -1,0 +1,53 @@
+// Collapse duplicate search results.
+//
+// Sphinx searches several indices independently (objects, titles, full text) and
+// concatenates the hits, so an API page shows up twice. Searching `add_mesh`
+// lists both
+//
+//   pyvista.Plotter.add_mesh (Python method, in Plotter.add_mesh)
+//       -> pyvista.Plotter.add_mesh.html#pyvista.Plotter.add_mesh
+//   Plotter.add_mesh
+//       -> pyvista.Plotter.add_mesh.html
+//
+// The de-duplication in Sphinx's own `searchtools.js` keys on the anchor and the
+// description, so it never merges the two. Every autosummary stub page hits this
+// because the page documents a single object whose name is also the page title.
+//
+// Drop the whole-page hit whenever the same page is already listed through an
+// anchor, keeping the object hit: it links straight to the definition and says
+// what kind of object it is.
+(function () {
+  if (typeof Search === "undefined" || !Search._performSearch) return;
+
+  // Kinds from `SearchResultKind` in searchtools.js. Object and index hits
+  // point at a specific definition; text and title hits are the page itself.
+  const ANCHOR_KINDS = new Set(["object", "index"]);
+  const PAGE_KINDS = new Set(["text", "title"]);
+
+  // Each result is [docname, title, anchor, descr, score, filename, kind].
+  const DOCNAME = 0;
+  const ANCHOR = 2;
+  const KIND = 6;
+
+  const performSearch = Search._performSearch;
+
+  Search._performSearch = function (...args) {
+    const results = performSearch.apply(this, args);
+
+    const anchored = new Set();
+    for (const result of results) {
+      if (result[ANCHOR] && ANCHOR_KINDS.has(result[KIND]))
+        anchored.add(result[DOCNAME]);
+    }
+    if (!anchored.size) return results;
+
+    return results.filter(
+      (result) =>
+        !(
+          PAGE_KINDS.has(result[KIND]) &&
+          !result[ANCHOR] &&
+          anchored.has(result[DOCNAME])
+        ),
+    );
+  };
+})();

--- a/doc/source/_templates/search.html
+++ b/doc/source/_templates/search.html
@@ -1,10 +1,7 @@
-{%- extends "!search.html" %}
-
-{# `search_dedupe.js` patches `Search._performSearch`, so it has to load after
-   the theme's `searchtools.js` (which defines `Search`) and before the first
-   query runs on `DOMContentLoaded`. Scripts added through `app.add_js_file` are
-   emitted by `super()`, i.e. too early, hence this override. #}
-{% block scripts -%}
-  {{ super() }}
-  <script src="{{ pathto('_static/search_dedupe.js', 1) }}"></script>
+{%- extends "!search.html" %} {# `search_dedupe.js` patches
+`Search._performSearch`, so it has to load after the theme's `searchtools.js`
+(which defines `Search`) and before the first query runs on `DOMContentLoaded`.
+Scripts added through `app.add_js_file` are emitted by `super()`, i.e. too
+early, hence this override. #} {% block scripts -%} {{ super() }}
+<script src="{{ pathto('_static/search_dedupe.js', 1) }}"></script>
 {%- endblock scripts %}

--- a/doc/source/_templates/search.html
+++ b/doc/source/_templates/search.html
@@ -1,0 +1,10 @@
+{%- extends "!search.html" %}
+
+{# `search_dedupe.js` patches `Search._performSearch`, so it has to load after
+   the theme's `searchtools.js` (which defines `Search`) and before the first
+   query runs on `DOMContentLoaded`. Scripts added through `app.add_js_file` are
+   emitted by `super()`, i.e. too early, hence this override. #}
+{% block scripts -%}
+  {{ super() }}
+  <script src="{{ pathto('_static/search_dedupe.js', 1) }}"></script>
+{%- endblock scripts %}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -431,7 +431,29 @@ language = 'en'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints', '_templates*']
+exclude_patterns = [
+    '_build',
+    'Thumbs.db',
+    '.DS_Store',
+    '**.ipynb_checkpoints',
+    '_templates*',
+    # Fragments that only ever get ``.. include::``-ed into another page or into a
+    # docstring. Sphinx exempts included files from the "isn't included in any
+    # toctree" warning but still builds them as standalone documents, which puts 70
+    # title-less pages in the search index, e.g. searching `bunny` returns four
+    # `<no title>` dataset-gallery carousels. Excluding them keeps the text
+    # searchable through the page that includes it.
+    'api/core/cell_quality/*.rst',
+    'api/examples/dataset-gallery/*.rst',
+    'api/plotting/charts/pen_line_styles.rst',
+    'api/plotting/charts/plot_color_schemes.rst',
+    'api/plotting/charts/scatter_marker_styles.rst',
+    'api/readers/readers_table.rst',
+    'api/utilities/color_table/*.rst',
+    'api/utilities/colormap_table/*.rst',
+    'api/utilities/io_table/*.rst',
+    'api/utilities/mesh_io.rst',
+]
 _repo_context7 = Path(__file__).resolve().parents[2] / 'context7.json'
 _docs_context7 = Path(__file__).parent / '_extra' / 'context7.json'
 _context7_data = json.loads(_repo_context7.read_text())


### PR DESCRIPTION
Currently, two search results are generated for every class member: one linking to the class member itself, and the other linking to the standalone page where the member lives, e.g.

- page: pyvista.Plotter.add_mesh.html
- member: pyvista.Plotter.add_mesh.html#pyvista.Plotter.add_mesh

status quo:

https://docs.pyvista.org/search.html?q=add_mesh

<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/7b322d70-d0ad-4926-92ae-4b801ac68902" />

This PR:

https://6a6aee02311d6572ddd4073b--pyvista-dev.netlify.app/search.html?q=add_mesh

<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/3aa2f666-c69c-492a-a5a6-a840337803eb" />
