### PR TITLE
Minor front buffer read cleanup

### DIFF
--- a/pyvista/plotting/utilities/regression.py
+++ b/pyvista/plotting/utilities/regression.py
@@ -159,26 +159,22 @@ def image_from_window(  # noqa: PLR0917
     imfilter.SetInput(render_window)
     imfilter.SetScale(scale)
     imfilter.FixBoundaryOn()
-    imfilter.ReadFrontBufferOff()
     imfilter.ShouldRerenderOff()
     if ignore_alpha:
         imfilter.SetInputBufferTypeToRGB()
     else:
         imfilter.SetInputBufferTypeToRGBA()
-    # Read the back buffer: the front buffer is the on-screen one, so it only holds
-    # the scene once the window has been composited -- a screenshot taken before
-    # that comes back as screen garbage.  What is left in the back buffer after a
-    # swap is undefined by the OpenGL spec, so render with swapping off and restore
-    # it afterwards.  This is what VTK's own regression tests and ParaView do:
-    # https://github.com/Kitware/VTK/blob/master/Testing/Rendering/vtkTesting.cxx
-    # https://gitlab.kitware.com/paraview/paraview/-/blob/master/Remoting/Views/vtkSMViewProxy.cxx
-    swap_buffers = render_window.GetSwapBuffers()
-    render_window.SwapBuffersOff()
-    render_window.Render()
-    try:
-        data = run_image_filter(imfilter)
-    finally:
-        render_window.SetSwapBuffers(swap_buffers)
+    # Read the front buffer, and say so once.  This used to be turned off here and then
+    # straight back on a few lines later, so only the second call ever took effect.
+    #
+    # The buffers are not interchangeable when multisampling is on (the default is
+    # ``multi_samples=8``).  A front-buffer read returns VTK's DisplayFramebuffer, which
+    # Frame() has already resolved with a gamma-correct shader; a back-buffer read
+    # returns the raw multisample framebuffer, which vtkOpenGLRenderWindow::ReadPixels
+    # resolves inline with a plain glBlitFramebuffer average.  The two disagree on every
+    # anti-aliased edge pixel, by enough to fail image regression.
+    imfilter.ReadFrontBufferOn()
+    data = run_image_filter(imfilter)
     if off:
         # Critical for Trame and other offscreen tools
         render_window.GetInteractor().EnableRenderOff()

--- a/pyvista/plotting/utilities/regression.py
+++ b/pyvista/plotting/utilities/regression.py
@@ -165,8 +165,20 @@ def image_from_window(  # noqa: PLR0917
         imfilter.SetInputBufferTypeToRGB()
     else:
         imfilter.SetInputBufferTypeToRGBA()
-    imfilter.ReadFrontBufferOn()
-    data = run_image_filter(imfilter)
+    # Read the back buffer: the front buffer is the on-screen one, so it only holds
+    # the scene once the window has been composited -- a screenshot taken before
+    # that comes back as screen garbage.  What is left in the back buffer after a
+    # swap is undefined by the OpenGL spec, so render with swapping off and restore
+    # it afterwards.  This is what VTK's own regression tests and ParaView do:
+    # https://github.com/Kitware/VTK/blob/master/Testing/Rendering/vtkTesting.cxx
+    # https://gitlab.kitware.com/paraview/paraview/-/blob/master/Remoting/Views/vtkSMViewProxy.cxx
+    swap_buffers = render_window.GetSwapBuffers()
+    render_window.SwapBuffersOff()
+    render_window.Render()
+    try:
+        data = run_image_filter(imfilter)
+    finally:
+        render_window.SetSwapBuffers(swap_buffers)
     if off:
         # Critical for Trame and other offscreen tools
         render_window.GetInteractor().EnableRenderOff()

--- a/pyvista/plotting/utilities/regression.py
+++ b/pyvista/plotting/utilities/regression.py
@@ -172,7 +172,8 @@ def image_from_window(  # noqa: PLR0917
     # Frame() has already resolved with a gamma-correct shader; a back-buffer read
     # returns the raw multisample framebuffer, which vtkOpenGLRenderWindow::ReadPixels
     # resolves inline with a plain glBlitFramebuffer average.  The two disagree on every
-    # anti-aliased edge pixel, by enough to fail image regression.
+    # anti-aliased edge pixel, by enough to fail image regression.  Reported upstream at
+    # https://gitlab.kitware.com/vtk/vtk/-/work_items/20138
     imfilter.ReadFrontBufferOn()
     data = run_image_filter(imfilter)
     if off:


### PR DESCRIPTION
Tiny robustness fix... working on trying to make Mayavi work with latest VTK (some collaborators still use it instead of PyVista 😄 ), I was working on doc building image scraping and noticed that Mayavi was pulling from the front buffer for its images. I then looked into what Paraview and VTK do, and they use the back buffer intentionally. Looks like as of #3897 , PyVista also has been using the front buffer (though the calls there and in `main` are a bit confusing and maybe a `ReadFrontBufferOn` was left on unintentionally?):
```
    imfilter.ReadFrontBufferOff()
    imfilter.ShouldRerenderOff()
    if ignore_alpha:
        imfilter.SetInputBufferTypeToRGB()
    else:
        imfilter.SetInputBufferTypeToRGBA()
    imfilter.ReadFrontBufferOn()
```
The read front is turned off, then turned back on. In any case, this PR uses the Paraview (BSD 3-clause) method of 1) `ReadFrontBufferOff` (already up on line 162), 2) turning `SwapBuffersOff`, 3) rendering, then 4) setting `SwapBuffers` back to its old state.

In general, the front-buffer read is not wrong, it is conditional -- it returns the right pixels when the window has actually been painted. But if it's not, you can get stuff like this (generated with MNE + PyVistaQt on PyVista main):

<img width="800" height="800" alt="brain_before" src="https://github.com/user-attachments/assets/eb3bdff6-4183-41f0-9b42-4405dd921251" />

Instead of this (on this PR):

<img width="800" height="800" alt="brain_after" src="https://github.com/user-attachments/assets/f332b2f7-f80a-4c55-b30a-e4cde23bd9a8" />

I expect no image diffs since the buffers agree once painted. So this is really a robustness fix. It does require an extra `render` to fill the back buffer, which seems like an okay price to pay for robustness (and consistency with Paraview/VTK).