### PR TITLE
Initialize `BasePlotter` variables in init

### DIFF
--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -398,6 +398,8 @@ class BasePlotter(_BoundsSizeMixin):
         self.mwriter: imageio.plugins.ffmpeg.Writer | None = None
         self._gif_filename: Path | None = None
         self.ren_win: _vtk.vtkRenderWindow | None = None
+        # 3D location of the last click registered by ``left_button_down``
+        self.pickpoint: NumpyArray[float] | None = None
 
         self._theme = Theme()
         if theme is None:
@@ -473,6 +475,7 @@ class BasePlotter(_BoundsSizeMixin):
         log.debug('BasePlotter init stop')
 
         self._image_depth_null: NumpyArray[bool] | None = None
+        self._window_size_unset = False
         self.last_image_depth: pv.pyvista_ndarray | None = None
         self.last_image: pv.pyvista_ndarray | None = None
         self.last_vtksz: str | Path | None = None

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -1349,6 +1349,26 @@ def test_left_button_down():
     pl.close()
 
 
+def test_left_button_down_pickpoint(verify_image_cache):
+    verify_image_cache.skip = True
+
+    # an empty plotter is enough to reproduce, no mesh is required
+    pl = pv.Plotter()
+    assert pl.pickpoint is None
+
+    pl.show(auto_close=False)  # must start renderer first
+    width, height = pl.window_size
+
+    # pressing 'b' registers ``left_button_down`` for the next left click
+    pl.iren.interactor.SetKeySym('b')
+    pl.iren.interactor.KeyPressEvent()
+    pl.iren._mouse_left_button_press(width // 2, height // 2)
+
+    assert pl.pickpoint.shape == (1, 3)
+    assert not np.any(np.isnan(pl.pickpoint))
+    pl.close()
+
+
 def test_show_axes():
     pl = pv.Plotter()
     pl.show_axes()


### PR DESCRIPTION
### Overview

Fixes #8859