### PR TITLE
Default COVERAGE_CORE to ctrace when unset

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,7 @@ passenv =
 setenv =
     TOX_ROOT = {tox_root}
     PYTEST_ADDOPTS = --color=yes -v {env:PARALLEL:}
+    cov: COVERAGE_CORE = {env:COVERAGE_CORE:ctrace}
 
 dependency_groups = test
 deps =


### PR DESCRIPTION
### Overview

CI is failing for 3.14 latest nightly job, e.g: https://github.com/pyvista/pyvista/actions/runs/30806809664/job/91671872897?pr=8861

this PR fixes that