### PR TITLE
Do not pollute integration tests with PyVista's test deps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -144,7 +144,7 @@ basepython =
     trame,mne: py3.14
     geovista: py3.13
 dependency_groups =
-    mne: [ ]
+    mne: []
     pyvistaqt: []
     trame: []
     geovista: []

--- a/tox.ini
+++ b/tox.ini
@@ -145,6 +145,9 @@ basepython =
     geovista: py3.13
 dependency_groups =
     mne: []
+    pyvistaqt: []
+    trame: []
+    geovista: []
 deps =
     pyvistaqt: PyQt6-Qt6!=6.6.0,!=6.7.0
     pyvistaqt: PyQt6!=6.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -144,7 +144,7 @@ basepython =
     trame,mne: py3.14
     geovista: py3.13
 dependency_groups =
-    mne: []
+    mne: [ ]
     pyvistaqt: []
     trame: []
     geovista: []


### PR DESCRIPTION
Fix the `pyvistaqt` integration test failures. These are caused by `pyvistaqt` installing `pytest==9.1.1`, which is incompatible with PyVista, which has `pytest<9.1.0`, because `pytest-cases` (used by PyVista only) is broken with `9.1.0` , see https://github.com/smarie/python-pytest-cases/issues/385

But since `pyvistaqt` doesn't use `pytest-cases`, there is no need to install PyVista's test deps, which is otherwise just polluting the environment.