### PR TITLE
Disallow ruff noqa comments in examples

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,7 +115,6 @@ repos:
         entry: '#\s*(?:noqa|ruff)'
         files: ^examples/
         types: [python]
-        exclude: pyvista/_warn_external.py
 
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: v3.9.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,6 +73,13 @@ repos:
         files: ^context7\.json$
         args: ["--schemafile", ".github/schemas/context7.json"]
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.1
+    hooks:
+      - id: ruff-format
+      - id: ruff-check
+        args: [--fix, --show-fixes]
+
   - repo: local
     hooks:
       - id: warn_external
@@ -102,13 +109,13 @@ repos:
         language: pygrep
         entry: '^\s*(?:>>>|\.\.\.)?\s*import\s+(?:__future__|abc|collections|collections\.abc|dataclasses|enum|http\.server|importlib\.metadata|io|pathlib|types|typing|typing_extensions|unittest\.mock)\s*$'
         types_or: [python, rst, markdown]
-
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.1
-    hooks:
-      - id: ruff-format
-      - id: ruff-check
-        args: [--fix, --show-fixes]
+      - id: no-lint-suppression-comments
+        name: "No lint suppression comments (fix it, or use pyproject.toml per-file-ignores)"
+        language: pygrep
+        entry: '#\s*(?:noqa|ruff)'
+        files: ^examples/
+        types: [python]
+        exclude: pyvista/_warn_external.py
 
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: v3.9.6

--- a/examples/00-load/create_pixel_art.py
+++ b/examples/00-load/create_pixel_art.py
@@ -50,7 +50,7 @@ for line in alien_str.splitlines()[1:]:  # skip first linebreak
 # Define a helper function to add pixel boxes to plotter.
 
 
-def draw_pixels(plotter, pixels, center, color):  # noqa: PLR0917
+def draw_pixels(plotter, *, pixels, center, color):
     bounds = [
         center[0] - 1.0,
         center[0] + 1.0,
@@ -78,15 +78,15 @@ def draw_pixels(plotter, pixels, center, color):  # noqa: PLR0917
 
 # Display MONSTERS
 pl = pv.Plotter()
-pl = draw_pixels(pl, alien, [-22.0, 22.0], 'green')
-pl = draw_pixels(pl, alien, [0.0, 22.0], 'green')
-pl = draw_pixels(pl, alien, [22.0, 22.0], 'green')
-pl = draw_pixels(pl, alien, [-22.0, 0.0], 'blue')
-pl = draw_pixels(pl, alien, [0.0, 0.0], 'blue')
-pl = draw_pixels(pl, alien, [22.0, 0.0], 'blue')
-pl = draw_pixels(pl, alien, [-22.0, -22.0], 'red')
-pl = draw_pixels(pl, alien, [0.0, -22.0], 'red')
-pl = draw_pixels(pl, alien, [22.0, -22.0], 'red')
+pl = draw_pixels(pl, pixels=alien, center=[-22.0, 22.0], color='green')
+pl = draw_pixels(pl, pixels=alien, center=[0.0, 22.0], color='green')
+pl = draw_pixels(pl, pixels=alien, center=[22.0, 22.0], color='green')
+pl = draw_pixels(pl, pixels=alien, center=[-22.0, 0.0], color='blue')
+pl = draw_pixels(pl, pixels=alien, center=[0.0, 0.0], color='blue')
+pl = draw_pixels(pl, pixels=alien, center=[22.0, 0.0], color='blue')
+pl = draw_pixels(pl, pixels=alien, center=[-22.0, -22.0], color='red')
+pl = draw_pixels(pl, pixels=alien, center=[0.0, -22.0], color='red')
+pl = draw_pixels(pl, pixels=alien, center=[22.0, -22.0], color='red')
 
 text = logo.text_3d('ALIEN MONSTERS', depth=10.0)
 text.points *= 4.0

--- a/examples/02-plot/composite_picking.py
+++ b/examples/02-plot/composite_picking.py
@@ -54,7 +54,7 @@ pl = pv.Plotter()
 actor, mapper = pl.add_composite(blocks, color='w', pbr=True, metallic=True)
 
 
-def callback(index, *args):  # noqa: ARG001
+def callback(index, *args):
     """Change a block to red if color is unset, and back to the actor color if set."""
     if mapper.block_attr[index].color is None:
         mapper.block_attr[index].color = 'r'

--- a/examples/02-plot/distance_measurement.py
+++ b/examples/02-plot/distance_measurement.py
@@ -18,7 +18,7 @@ pl.add_mesh(cube)
 pl.add_mesh(cube2)
 
 
-def callback(a, b, distance):  # noqa: ARG001
+def callback(a, b, distance):
     pl.add_text(f'Distance: {distance:.2f}', name='dist')
 
 

--- a/examples/02-plot/volume_rendering.py
+++ b/examples/02-plot/volume_rendering.py
@@ -228,7 +228,7 @@ heart_array = np.full_like(ct_image.active_scalars, -1000)
 # to mask the CT image to only extract the intensities of interest.
 ct_image_array = ct_image.active_scalars
 heart_mask_array = heart_mask.active_scalars
-heart_array[heart_mask_array == True] = ct_image_array[heart_mask_array == True]  # noqa: E712
+heart_array[heart_mask_array == np.True_] = ct_image_array[heart_mask_array == np.True_]
 
 # %%
 # Add the masked array to the CT image as a new set of scalar values.

--- a/examples/03-widgets/multi_slider_widget.py
+++ b/examples/03-widgets/multi_slider_widget.py
@@ -21,7 +21,9 @@ PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True
 import pyvista as pv
 
 
-class MyCustomRoutine:  # noqa: D101
+class MyCustomRoutine:
+    """Stateful callback for updating a mesh from slider parameters."""
+
     def __init__(self, mesh):
         self.output = mesh  # Expected PyVista mesh type
         # default parameters

--- a/examples/99-advanced/customize_trame_toolbar.py
+++ b/examples/99-advanced/customize_trame_toolbar.py
@@ -133,7 +133,7 @@ ctrl.view_update = widget.viewer.update
 
 # trame callbacks
 @state.change('play')
-async def _play(play, **kwargs):  # noqa: ARG001
+async def _play(play, **kwargs):
     while state.play:
         state.resolution += 1
         state.flush()
@@ -143,13 +143,13 @@ async def _play(play, **kwargs):  # noqa: ARG001
 
 
 @state.change('resolution')
-def update_resolution(resolution, **kwargs):  # noqa: ARG001
+def update_resolution(resolution, **kwargs):
     algo.resolution = resolution
     ctrl.view_update()
 
 
 @state.change('visibility')
-def set_visibility(visibility, **kwargs):  # noqa: ARG001
+def set_visibility(visibility, **kwargs):
     toggle = {'Hide': 0, 'Show': 1}
     mesh_actor.visibility = toggle[visibility]
     ctrl.view_update()

--- a/examples/99-advanced/extending_pyvista.py
+++ b/examples/99-advanced/extending_pyvista.py
@@ -34,7 +34,9 @@ pv.set_plot_theme('document')
 # furthest along in the (1, 0, 1) direction.
 
 
-class FooData(pv.PolyData):  # noqa: D101
+class FooData(pv.PolyData):
+    """Example ``PolyData`` subclass with a custom point property."""
+
     @property
     def max_point(self):
         """Returns index of point that is furthest along (1, 0, 1) direction."""

--- a/examples/99-advanced/sphere_eversion.py
+++ b/examples/99-advanced/sphere_eversion.py
@@ -52,7 +52,7 @@ def sphere_to_cylinder(theta, phi):
     return h, phi
 
 
-def cylinder_to_wormhole(*, h, phi, t, p, q):
+def cylinder_to_wormhole(h, phi, t, p, q):
     """
     Map from a cylinder to an open wormhole using Eq. (4).
 
@@ -69,7 +69,7 @@ def cylinder_to_wormhole(*, h, phi, t, p, q):
     return x, y, z
 
 
-def close_wormhole(*, x0, y0, z0, eta, xi, alpha):
+def close_wormhole(x0, y0, z0, eta, xi, alpha):
     """
     Close the wormhole using Eqs. (7)-(8).
 
@@ -107,7 +107,7 @@ def close_wormhole(*, x0, y0, z0, eta, xi, alpha):
     return x2, y2, z2
 
 
-def unfold_sphere(*, theta, phi, t, q, eta, lamda):
+def unfold_sphere(theta, phi, t, q, eta, lamda):
     """
     Unfold the sphere using Eqs. (12), (15), (10).
 
@@ -191,52 +191,52 @@ eta = 1
 theta, phi = np.mgrid[-np.pi / 2 : np.pi / 2 : 200j, -np.pi : np.pi : 400j]
 h, phi = sphere_to_cylinder(theta, phi)
 for lamda in np.linspace(0, 1, n_steps, endpoint=False):
-    x2, y2, z2 = unfold_sphere(theta=theta, phi=phi, t=t, q=q, eta=eta, lamda=lamda)
+    x2, y2, z2 = unfold_sphere(theta, phi, t, q, eta, lamda)
     save_frame(x2, y2, z2)
 
 # inverted wormhole -> unfolded wormhole
-x, y, z = cylinder_to_wormhole(h=h, phi=phi, t=t, p=p, q=q)
+x, y, z = cylinder_to_wormhole(h, phi, t, p, q)
 xis = np.linspace(0, 1, n_steps)
 alphas = np.linspace(0, alpha_final, n_steps)
 etas = np.linspace(1, eta_final, n_steps)
 for xi, alpha, eta in zip(xis, alphas, etas, strict=True):
-    x2, y2, z2 = close_wormhole(x0=x, y0=y, z0=z, eta=eta, xi=xi, alpha=alpha)
+    x2, y2, z2 = close_wormhole(x, y, z, eta, xi, alpha)
     save_frame(x2, y2, z2)
 
 # unfolded wormhole -> closed wormhole
 for q in np.linspace(Q, 0, n_steps):
     p = 1 - abs(q * t)
-    x, y, z = cylinder_to_wormhole(h=h, phi=phi, t=t, p=p, q=q)
-    x2, y2, z2 = close_wormhole(x0=x, y0=y, z0=z, eta=eta, xi=xi, alpha=alpha)
+    x, y, z = cylinder_to_wormhole(h, phi, t, p, q)
+    x2, y2, z2 = close_wormhole(x, y, z, eta, xi, alpha)
     save_frame(x2, y2, z2)
 
 # closed wormhole turned inside out (flip sign of time)
 # unfolded wormhole -> closed wormhole
 for t in np.linspace(-1 / Q, 1 / Q, n_steps):
     p = 1 - abs(q * t)
-    x, y, z = cylinder_to_wormhole(h=h, phi=phi, t=t, p=p, q=q)
-    x2, y2, z2 = close_wormhole(x0=x, y0=y, z0=z, eta=eta, xi=xi, alpha=alpha)
+    x, y, z = cylinder_to_wormhole(h, phi, t, p, q)
+    x2, y2, z2 = close_wormhole(x, y, z, eta, xi, alpha)
     save_frame(x2, y2, z2)
 
 # closed wormhole -> unfolded wormhole
 for q in np.linspace(0, Q, n_steps + 1)[1:]:
     p = 1 - abs(q * t)
-    x, y, z = cylinder_to_wormhole(h=h, phi=phi, t=t, p=p, q=q)
-    x2, y2, z2 = close_wormhole(x0=x, y0=y, z0=z, eta=eta, xi=xi, alpha=alpha)
+    x, y, z = cylinder_to_wormhole(h, phi, t, p, q)
+    x2, y2, z2 = close_wormhole(x, y, z, eta, xi, alpha)
     save_frame(x2, y2, z2)
 
 # unfolded wormhole -> inverted wormhole
-x, y, z = cylinder_to_wormhole(h=h, phi=phi, t=t, p=p, q=q)
+x, y, z = cylinder_to_wormhole(h, phi, t, p, q)
 xis = np.linspace(1, 0, n_steps + 1)[1:]
 alphas = np.linspace(alpha_final, 0, n_steps + 1)[1:]
 etas = np.linspace(eta_final, 1, n_steps + 1)[1:]
 for xi, alpha in zip(xis, alphas, strict=True):
-    x2, y2, z2 = close_wormhole(x0=x, y0=y, z0=z, eta=eta, xi=xi, alpha=alpha)
+    x2, y2, z2 = close_wormhole(x, y, z, eta, xi, alpha)
     save_frame(x2, y2, z2)
 
 # inverted wormhole -> sphere
 for lamda in np.linspace(1, 0, n_steps + 1)[1:]:
-    x2, y2, z2 = unfold_sphere(theta=theta, phi=phi, t=t, q=q, eta=eta, lamda=lamda)
+    x2, y2, z2 = unfold_sphere(theta, phi, t, q, eta, lamda)
     save_frame(x2, y2, z2)
 
 pl.close()
@@ -257,7 +257,7 @@ xi = p = 1
 eta = eta_final
 alpha = alpha_final
 
-x, y, z = cylinder_to_wormhole(h=h, phi=phi, t=t, p=p, q=q)
+x, y, z = cylinder_to_wormhole(h, phi, t, p, q)
 x2, y2, z2 = close_wormhole(x, y, z, eta, xi, alpha)
 
 pl = pv.Plotter(window_size=(512, 512))

--- a/examples/99-advanced/sphere_eversion.py
+++ b/examples/99-advanced/sphere_eversion.py
@@ -52,7 +52,7 @@ def sphere_to_cylinder(theta, phi):
     return h, phi
 
 
-def cylinder_to_wormhole(h, phi, t, p, q):  # noqa: PLR0917
+def cylinder_to_wormhole(*, h, phi, t, p, q):
     """
     Map from a cylinder to an open wormhole using Eq. (4).
 
@@ -69,7 +69,7 @@ def cylinder_to_wormhole(h, phi, t, p, q):  # noqa: PLR0917
     return x, y, z
 
 
-def close_wormhole(x0, y0, z0, eta, xi, alpha):  # noqa: PLR0917
+def close_wormhole(*, x0, y0, z0, eta, xi, alpha):
     """
     Close the wormhole using Eqs. (7)-(8).
 
@@ -107,7 +107,7 @@ def close_wormhole(x0, y0, z0, eta, xi, alpha):  # noqa: PLR0917
     return x2, y2, z2
 
 
-def unfold_sphere(theta, phi, t, q, eta, lamda):  # noqa: PLR0917
+def unfold_sphere(*, theta, phi, t, q, eta, lamda):
     """
     Unfold the sphere using Eqs. (12), (15), (10).
 
@@ -191,52 +191,52 @@ eta = 1
 theta, phi = np.mgrid[-np.pi / 2 : np.pi / 2 : 200j, -np.pi : np.pi : 400j]
 h, phi = sphere_to_cylinder(theta, phi)
 for lamda in np.linspace(0, 1, n_steps, endpoint=False):
-    x2, y2, z2 = unfold_sphere(theta, phi, t, q, eta, lamda)
+    x2, y2, z2 = unfold_sphere(theta=theta, phi=phi, t=t, q=q, eta=eta, lamda=lamda)
     save_frame(x2, y2, z2)
 
 # inverted wormhole -> unfolded wormhole
-x, y, z = cylinder_to_wormhole(h, phi, t, p, q)
+x, y, z = cylinder_to_wormhole(h=h, phi=phi, t=t, p=p, q=q)
 xis = np.linspace(0, 1, n_steps)
 alphas = np.linspace(0, alpha_final, n_steps)
 etas = np.linspace(1, eta_final, n_steps)
 for xi, alpha, eta in zip(xis, alphas, etas, strict=True):
-    x2, y2, z2 = close_wormhole(x, y, z, eta, xi, alpha)
+    x2, y2, z2 = close_wormhole(x0=x, y0=y, z0=z, eta=eta, xi=xi, alpha=alpha)
     save_frame(x2, y2, z2)
 
 # unfolded wormhole -> closed wormhole
 for q in np.linspace(Q, 0, n_steps):
     p = 1 - abs(q * t)
-    x, y, z = cylinder_to_wormhole(h, phi, t, p, q)
-    x2, y2, z2 = close_wormhole(x, y, z, eta, xi, alpha)
+    x, y, z = cylinder_to_wormhole(h=h, phi=phi, t=t, p=p, q=q)
+    x2, y2, z2 = close_wormhole(x0=x, y0=y, z0=z, eta=eta, xi=xi, alpha=alpha)
     save_frame(x2, y2, z2)
 
 # closed wormhole turned inside out (flip sign of time)
 # unfolded wormhole -> closed wormhole
 for t in np.linspace(-1 / Q, 1 / Q, n_steps):
     p = 1 - abs(q * t)
-    x, y, z = cylinder_to_wormhole(h, phi, t, p, q)
-    x2, y2, z2 = close_wormhole(x, y, z, eta, xi, alpha)
+    x, y, z = cylinder_to_wormhole(h=h, phi=phi, t=t, p=p, q=q)
+    x2, y2, z2 = close_wormhole(x0=x, y0=y, z0=z, eta=eta, xi=xi, alpha=alpha)
     save_frame(x2, y2, z2)
 
 # closed wormhole -> unfolded wormhole
 for q in np.linspace(0, Q, n_steps + 1)[1:]:
     p = 1 - abs(q * t)
-    x, y, z = cylinder_to_wormhole(h, phi, t, p, q)
-    x2, y2, z2 = close_wormhole(x, y, z, eta, xi, alpha)
+    x, y, z = cylinder_to_wormhole(h=h, phi=phi, t=t, p=p, q=q)
+    x2, y2, z2 = close_wormhole(x0=x, y0=y, z0=z, eta=eta, xi=xi, alpha=alpha)
     save_frame(x2, y2, z2)
 
 # unfolded wormhole -> inverted wormhole
-x, y, z = cylinder_to_wormhole(h, phi, t, p, q)
+x, y, z = cylinder_to_wormhole(h=h, phi=phi, t=t, p=p, q=q)
 xis = np.linspace(1, 0, n_steps + 1)[1:]
 alphas = np.linspace(alpha_final, 0, n_steps + 1)[1:]
 etas = np.linspace(eta_final, 1, n_steps + 1)[1:]
 for xi, alpha in zip(xis, alphas, strict=True):
-    x2, y2, z2 = close_wormhole(x, y, z, eta, xi, alpha)
+    x2, y2, z2 = close_wormhole(x0=x, y0=y, z0=z, eta=eta, xi=xi, alpha=alpha)
     save_frame(x2, y2, z2)
 
 # inverted wormhole -> sphere
 for lamda in np.linspace(1, 0, n_steps + 1)[1:]:
-    x2, y2, z2 = unfold_sphere(theta, phi, t, q, eta, lamda)
+    x2, y2, z2 = unfold_sphere(theta=theta, phi=phi, t=t, q=q, eta=eta, lamda=lamda)
     save_frame(x2, y2, z2)
 
 pl.close()
@@ -257,7 +257,7 @@ xi = p = 1
 eta = eta_final
 alpha = alpha_final
 
-x, y, z = cylinder_to_wormhole(h, phi, t, p, q)
+x, y, z = cylinder_to_wormhole(h=h, phi=phi, t=t, p=p, q=q)
 x2, y2, z2 = close_wormhole(x, y, z, eta, xi, alpha)
 
 pl = pv.Plotter(window_size=(512, 512))

--- a/examples/99-advanced/warp_by_vector_eigenmodes.py
+++ b/examples/99-advanced/warp_by_vector_eigenmodes.py
@@ -79,7 +79,7 @@ def make_cijkl_E_nu(E=200, nu=0.3):
     return cijkl, cij
 
 
-def get_first_N_above_thresh(*, N, freqs, thresh, decimals=3):
+def get_first_n_above_thresh(*, N, freqs, thresh, decimals=3):
     """Return first N unique frequencies with amplitude>thresh based on first decimals."""
     unique_freqs, unique_indices = np.unique(
         np.round(freqs, decimals=decimals), return_index=True
@@ -120,9 +120,9 @@ def assemble_mass_and_stiffness(*, N, F, geom_params, cijkl):
     for index1, quad1 in enumerate(quadruplets):
         I, p1, q1, r1 = quad1
         for index2, quad2 in enumerate(quadruplets[index1:]):
-            index2 = index2 + index1  # noqa: PLW2901
+            index2_ = index2 + index1
             J, p2, q2, r2 = quad2
-            G[index1, index2] = (
+            G[index1, index2_] = (
                 cijkl[I, 1 - 1, J, 1 - 1]
                 * p1
                 * p2
@@ -160,10 +160,10 @@ def assemble_mass_and_stiffness(*, N, F, geom_params, cijkl):
                 * r2
                 * F(p1 + p2, q1 + q2, r1 + r2 - 2, **geom_params)
             )
-            G[index2, index1] = G[index1, index2]  # since stiffness matrix is symmetric
+            G[index2_, index1] = G[index1, index2_]  # since stiffness matrix is symmetric
             if I == J:
-                E[index1, index2] = F(p1 + p2, q1 + q2, r1 + r2, **geom_params)
-                E[index2, index1] = E[index1, index2]  # since mass matrix is symmetric
+                E[index1, index2_] = F(p1 + p2, q1 + q2, r1 + r2, **geom_params)
+                E[index2_, index1] = E[index1, index2_]  # since mass matrix is symmetric
     return E, G, quadruplets
 
 
@@ -189,15 +189,15 @@ omegas = np.sqrt(np.abs(w) / rho) * 1e5  # convert back to Hz
 freqs = omegas / (2 * np.pi)
 # expected values from (Bernard 2014, pl.14),
 # error depends on polynomial order ``N``
-expected_freqs_kHz = np.array(  # noqa: N816
+expected_freqs_khz = np.array(
     [704.8, 949.0, 965.2, 1096.3, 1128.4, 1182.8, 1338.9, 1360.9]
 )
-computed_freqs_kHz, mode_indices = get_first_N_above_thresh(  # noqa: N816
+computed_freqs_khz, mode_indices = get_first_n_above_thresh(
     N=8, freqs=freqs / 1e3, thresh=1, decimals=1
 )
 print('found the following first unique eigenfrequencies:')
 for ind, (freq1, freq2) in enumerate(
-    zip(computed_freqs_kHz, expected_freqs_kHz, strict=True)
+    zip(computed_freqs_khz, expected_freqs_khz, strict=True)
 ):
     error = np.abs(freq2 - freq1) / freq1 * 100.0
     print(
@@ -270,7 +270,7 @@ for i, j in itertools.product(range(2), range(4)):
     current_index = 4 * i + j
     vector = f'eigenmode_{current_index:02}'
     pl.add_text(
-        f'mode {current_index}, freq. {computed_freqs_kHz[current_index]:.1f} kHz',
+        f'mode {current_index}, freq. {computed_freqs_khz[current_index]:.1f} kHz',
         font_size=10,
     )
     pl.add_mesh(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -571,6 +571,9 @@ pyvista = "pv"
   'T20',
   'TID251',
 ]
+'examples/02-plot/composite_picking.py' = ['ARG001']
+'examples/02-plot/distance_measurement.py' = ['ARG001']
+'examples/99-advanced/customize_trame_toolbar.py' = ['ARG001']
 'examples/99-advanced/warp_by_vector_eigenmodes.py' = ['N802', 'N803']
 'hooks/*' = ['INP001']
 'pyvista/__init__.py' = ['ANN']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -574,6 +574,7 @@ pyvista = "pv"
 'examples/02-plot/composite_picking.py' = ['ARG001']
 'examples/02-plot/distance_measurement.py' = ['ARG001']
 'examples/99-advanced/customize_trame_toolbar.py' = ['ARG001']
+'examples/99-advanced/sphere_eversion.py' = ['PLR0917']
 'examples/99-advanced/warp_by_vector_eigenmodes.py' = ['N802', 'N803']
 'hooks/*' = ['INP001']
 'pyvista/__init__.py' = ['ANN']


### PR DESCRIPTION
### Overview

Using `# noqa` is an internal project thing, and should not be exposed publicly inside of Sphinx Gallery examples. This PR addresses and removes existing `# noqa` usage, and enforces it with a `pygrep` pre-commit hook. The `ruff` hook is also moved _before_ the `pygrep` one so that unused `# noqa` comments are removed before checking for the presence of `# noqa` comments.