### PR TITLE
Ensure tests are not skipped based on `ImportError`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,6 +102,12 @@ repos:
         language: pygrep
         entry: '^\s*(?:>>>|\.\.\.)?\s*import\s+(?:__future__|abc|collections|collections\.abc|dataclasses|enum|http\.server|importlib\.metadata|io|pathlib|types|typing|typing_extensions|unittest\.mock)\s*$'
         types_or: [python, rst, markdown]
+      - id: no-import-error-skip
+        name: "Ensure tests are not skipped based on ImportError."
+        language: pygrep
+        entry: '^\s*(?:>>>|\.\.\.)?.*(?:\bexcept\s*\(?\s*(?:ImportError|ModuleNotFoundError)\b|\bimportorskip\b)'
+        files: ^tests/
+        types: [python]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,7 +116,7 @@ repos:
         files: ^examples/
         types: [python]
       - id: no-import-error-skip
-        name: "Ensure tests are not skipped based on ImportError."
+        name: "Tests must not be skipped based on ImportError"
         language: pygrep
         entry: '^\s*(?:>>>|\.\.\.)?.*(?:\bexcept\s*\(?\s*(?:ImportError|ModuleNotFoundError)\b|\bimportorskip\b|\bsuppress\s*\(\s*(?:ImportError|ModuleNotFoundError)\b)'
         files: ^tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,7 +105,7 @@ repos:
       - id: no-import-error-skip
         name: "Ensure tests are not skipped based on ImportError."
         language: pygrep
-        entry: '^\s*(?:>>>|\.\.\.)?.*(?:\bexcept\s*\(?\s*(?:ImportError|ModuleNotFoundError)\b|\bimportorskip\b)'
+        entry: '^\s*(?:>>>|\.\.\.)?.*(?:\bexcept\s*\(?\s*(?:ImportError|ModuleNotFoundError)\b|\bimportorskip\b|\bsuppress\s*\(\s*(?:ImportError|ModuleNotFoundError)\b)'
         files: ^tests/
         types: [python]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ test = [
   'nest-asyncio2<1.8.0',
   'numpydoc<1.11.0',
   'pandas<=2.4.0',
+  'polars<=1.44',
   'pyarrow<26.0.0',
   'pytest-cases<3.11.0',
   'pytest-cov<7.2.0',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,13 +131,10 @@ def global_variables_reset():
 @pytest.fixture(scope='session', autouse=True)
 def set_mpl():
     """Avoid matplotlib windows popping up."""
-    try:
-        import matplotlib as mpl
-    except ImportError:
-        pass
-    else:
-        mpl.rcdefaults()
-        mpl.use('agg', force=True)
+    import matplotlib as mpl
+
+    mpl.rcdefaults()
+    mpl.use('agg', force=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/core/test_datasetattributes.py
+++ b/tests/core/test_datasetattributes.py
@@ -12,25 +12,15 @@ from hypothesis.strategies import integers
 from hypothesis.strategies import lists
 from hypothesis.strategies import text
 import numpy as np
+import pandas as pd
+import polars as pl
+import pyarrow as pa
 import pytest
 
 import pyvista as pv
 from pyvista import _vtk
 from pyvista.core.utilities.arrays import FieldAssociation
 from pyvista.core.utilities.arrays import convert_array
-
-try:
-    import pandas as pd
-except ImportError:
-    pd = None
-
-try:
-    import pyarrow as pa
-except ImportError:
-    pa = None
-
-skip_no_pandas = pytest.mark.skipif(pd is None, reason='Requires pandas')
-skip_no_pyarrow = pytest.mark.skipif(pa is None, reason='Requires pyarrow')
 
 
 @pytest.fixture
@@ -780,19 +770,16 @@ _NUMERIC_DTYPES = [
 ]
 
 
-@skip_no_pandas
 def test_to_pandas_point_data_row_count(hexbeam):
     df = hexbeam.point_data.to_pandas()
     assert len(df) == hexbeam.n_points
 
 
-@skip_no_pandas
 def test_to_pandas_cell_data_row_count(hexbeam):
     df = hexbeam.cell_data.to_pandas()
     assert len(df) == hexbeam.n_cells
 
 
-@skip_no_pandas
 def test_to_pandas_column_order_matches_keys(hexbeam):
     hexbeam.clear_data()
     hexbeam.point_data['a'] = np.arange(hexbeam.n_points)
@@ -802,7 +789,6 @@ def test_to_pandas_column_order_matches_keys(hexbeam):
     assert list(df.columns) == ['a', 'b', 'c']
 
 
-@skip_no_pandas
 def test_to_pandas_scalar_values_equal(hexbeam):
     hexbeam.clear_data()
     expected = np.arange(hexbeam.n_points, dtype=np.int32)
@@ -811,7 +797,6 @@ def test_to_pandas_scalar_values_equal(hexbeam):
     assert np.array_equal(df['scalars'].to_numpy(), expected)
 
 
-@skip_no_pandas
 def test_to_pandas_vector_expanded_columns(hexbeam):
     hexbeam.clear_data()
     hexbeam.point_data['vec'] = hexbeam.points.astype(np.float32)
@@ -821,7 +806,6 @@ def test_to_pandas_vector_expanded_columns(hexbeam):
         assert np.array_equal(df[f'vec_{i}'].to_numpy(), hexbeam.points[:, i].astype(np.float32))
 
 
-@skip_no_pandas
 def test_to_pandas_two_component_vector(hexbeam):
     hexbeam.clear_data()
     arr = np.column_stack([np.arange(hexbeam.n_points), np.arange(hexbeam.n_points) + 100]).astype(
@@ -834,7 +818,6 @@ def test_to_pandas_two_component_vector(hexbeam):
     assert np.array_equal(df['pair_1'].to_numpy(), arr[:, 1])
 
 
-@skip_no_pandas
 def test_to_pandas_four_component_rgba_preserves_dtype(hexbeam):
     hexbeam.clear_data()
     rgba = np.arange(hexbeam.n_points * 4, dtype=np.uint8).reshape(hexbeam.n_points, 4)
@@ -846,7 +829,6 @@ def test_to_pandas_four_component_rgba_preserves_dtype(hexbeam):
         assert np.array_equal(df[f'rgba_{i}'].to_numpy(), rgba[:, i])
 
 
-@skip_no_pandas
 def test_to_pandas_tensor_flattens_to_nine_columns(hexbeam):
     hexbeam.clear_data()
     tensor = np.arange(hexbeam.n_points * 9, dtype=np.float64).reshape(hexbeam.n_points, 3, 3)
@@ -859,7 +841,6 @@ def test_to_pandas_tensor_flattens_to_nine_columns(hexbeam):
         assert np.array_equal(df[f'tensor_{i}'].to_numpy(), flat[:, i])
 
 
-@skip_no_pandas
 @pytest.mark.parametrize('dtype', _NUMERIC_DTYPES)
 def test_to_pandas_numeric_dtypes_preserved(hexbeam, dtype):
     hexbeam.clear_data()
@@ -870,7 +851,6 @@ def test_to_pandas_numeric_dtypes_preserved(hexbeam, dtype):
     assert np.array_equal(df['col'].to_numpy(), expected)
 
 
-@skip_no_pandas
 def test_to_pandas_bool_preserved(hexbeam):
     hexbeam.clear_data()
     expected = np.arange(hexbeam.n_points) % 2 == 0
@@ -880,7 +860,6 @@ def test_to_pandas_bool_preserved(hexbeam):
     assert np.array_equal(df['flag'].to_numpy(), expected)
 
 
-@skip_no_pandas
 @pytest.mark.parametrize('dtype', [np.complex64, np.complex128])
 def test_to_pandas_complex_preserved_as_single_column(hexbeam, dtype):
     hexbeam.clear_data()
@@ -892,7 +871,6 @@ def test_to_pandas_complex_preserved_as_single_column(hexbeam, dtype):
     assert np.array_equal(df['cplx'].to_numpy(), expected)
 
 
-@skip_no_pandas
 def test_to_pandas_string_column(hexbeam):
     hexbeam.clear_data()
     expected = np.array(['a', 'b'] * ((hexbeam.n_points + 1) // 2))[: hexbeam.n_points]
@@ -902,7 +880,6 @@ def test_to_pandas_string_column(hexbeam):
     assert np.array_equal(df['name'].to_numpy(), expected)
 
 
-@skip_no_pandas
 def test_to_pandas_is_snapshot_not_view(hexbeam):
     hexbeam.clear_data()
     hexbeam.point_data['s'] = np.arange(hexbeam.n_points, dtype=np.float64)
@@ -913,7 +890,6 @@ def test_to_pandas_is_snapshot_not_view(hexbeam):
     assert df.iloc[0, 0] == 999.0
 
 
-@skip_no_pandas
 def test_to_pandas_does_not_share_memory_with_vtk(hexbeam):
     """Pandas consolidates into blocks during construction, which copies."""
     hexbeam.clear_data()
@@ -922,7 +898,6 @@ def test_to_pandas_does_not_share_memory_with_vtk(hexbeam):
     assert not np.shares_memory(hexbeam.point_data['s'], df['s'].to_numpy())
 
 
-@skip_no_pyarrow
 def test_to_arrow_scalar_column_is_zero_copy(hexbeam):
     """1D contiguous numeric columns wrap VTK memory zero-copy."""
     hexbeam.clear_data()
@@ -934,7 +909,6 @@ def test_to_arrow_scalar_column_is_zero_copy(hexbeam):
     )
 
 
-@skip_no_pyarrow
 def test_to_arrow_multi_component_column_is_copied(hexbeam):
     """Expanded multi-component columns are strided slices; pyarrow copies."""
     hexbeam.clear_data()
@@ -946,7 +920,6 @@ def test_to_arrow_multi_component_column_is_copied(hexbeam):
     )
 
 
-@skip_no_pandas
 def test_to_pandas_empty_point_data(hexbeam):
     hexbeam.clear_data()
     df = hexbeam.point_data.to_pandas()
@@ -956,13 +929,11 @@ def test_to_pandas_empty_point_data(hexbeam):
     assert len(df) == 0
 
 
-@skip_no_pandas
 def test_to_pandas_field_data_raises(hexbeam):
     with pytest.raises(ValueError, match=r'field data'):
         hexbeam.field_data.to_pandas()
 
 
-@skip_no_pandas
 def test_to_pandas_column_collision_raises(hexbeam):
     hexbeam.clear_data()
     hexbeam.point_data['vec'] = hexbeam.points.astype(np.float32)
@@ -971,7 +942,6 @@ def test_to_pandas_column_collision_raises(hexbeam):
         hexbeam.point_data.to_pandas()
 
 
-@skip_no_pandas
 @pytest.mark.parametrize('mesh_fixture', ['sphere', 'hexbeam', 'uniform', 'plane'])
 def test_to_pandas_across_dataset_types(request, mesh_fixture):
     mesh = request.getfixturevalue(mesh_fixture)
@@ -985,14 +955,12 @@ def test_to_pandas_across_dataset_types(request, mesh_fixture):
     assert list(df.columns) == ['scalar', 'vec_0', 'vec_1', 'vec_2']
 
 
-@skip_no_pyarrow
 def test_to_arrow_returns_table(hexbeam):
     table = hexbeam.point_data.to_arrow()
     assert isinstance(table, pa.Table)
     assert table.num_rows == hexbeam.n_points
 
 
-@skip_no_pyarrow
 def test_to_arrow_schema_matches_expanded_keys(hexbeam):
     hexbeam.clear_data()
     hexbeam.point_data['s'] = np.arange(hexbeam.n_points, dtype=np.int32)
@@ -1001,7 +969,6 @@ def test_to_arrow_schema_matches_expanded_keys(hexbeam):
     assert table.schema.names == ['s', 'v_0', 'v_1', 'v_2']
 
 
-@skip_no_pyarrow
 @pytest.mark.parametrize('dtype', _NUMERIC_DTYPES)
 def test_to_arrow_numeric_dtypes(hexbeam, dtype):
     hexbeam.clear_data()
@@ -1012,8 +979,6 @@ def test_to_arrow_numeric_dtypes(hexbeam, dtype):
     assert np.array_equal(table.column('col').to_numpy(), expected)
 
 
-@skip_no_pyarrow
-@skip_no_pandas
 def test_to_arrow_and_to_pandas_agree(hexbeam):
     hexbeam.clear_data()
     hexbeam.point_data['s'] = np.arange(hexbeam.n_points, dtype=np.int64)
@@ -1024,13 +989,11 @@ def test_to_arrow_and_to_pandas_agree(hexbeam):
     pd.testing.assert_frame_equal(df_from_arrow, df_direct)
 
 
-@skip_no_pyarrow
 def test_to_arrow_field_data_raises(hexbeam):
     with pytest.raises(ValueError, match=r'field data'):
         hexbeam.field_data.to_arrow()
 
 
-@skip_no_pyarrow
 def test_arrow_c_stream_consumed_by_pyarrow(hexbeam):
     hexbeam.clear_data()
     hexbeam.point_data['s'] = np.arange(hexbeam.n_points, dtype=np.int64)
@@ -1042,7 +1005,6 @@ def test_arrow_c_stream_consumed_by_pyarrow(hexbeam):
     assert table.equals(direct)
 
 
-@skip_no_pyarrow
 def test_arrow_c_stream_returns_pycapsule(hexbeam):
     hexbeam.clear_data()
     hexbeam.point_data['s'] = np.arange(hexbeam.n_points, dtype=np.int32)
@@ -1050,15 +1012,12 @@ def test_arrow_c_stream_returns_pycapsule(hexbeam):
     assert type(capsule).__name__ == 'PyCapsule'
 
 
-@skip_no_pyarrow
 def test_arrow_c_stream_field_data_raises(hexbeam):
     with pytest.raises(ValueError, match=r'field data'):
         hexbeam.field_data.__arrow_c_stream__()
 
 
-@skip_no_pyarrow
 def test_arrow_c_stream_polars_round_trip(hexbeam):
-    pl = pytest.importorskip('polars')
     hexbeam.clear_data()
     hexbeam.point_data['s'] = np.arange(hexbeam.n_points, dtype=np.int64)
     hexbeam.point_data['v'] = hexbeam.points.astype(np.float64)
@@ -1083,7 +1042,6 @@ def test_iter_flat_columns_raises_on_mismatched_leading_dim(hexbeam, mocker):
 # -----------------------------------------------------------------------------
 
 
-@skip_no_pandas
 def test_dataset_to_pandas_defaults_to_point(hexbeam):
     hexbeam.clear_data()
     hexbeam.point_data['p'] = np.arange(hexbeam.n_points, dtype=np.float64)
@@ -1093,7 +1051,6 @@ def test_dataset_to_pandas_defaults_to_point(hexbeam):
     assert len(df) == hexbeam.n_points
 
 
-@skip_no_pandas
 def test_dataset_to_pandas_cell_association(hexbeam):
     hexbeam.clear_data()
     hexbeam.point_data['p'] = np.arange(hexbeam.n_points, dtype=np.float64)
@@ -1114,7 +1071,6 @@ def test_dataset_to_pandas_bogus_association_raises(hexbeam):
         hexbeam.to_pandas('nonsense')  # type: ignore[arg-type]
 
 
-@skip_no_pandas
 def test_dataset_to_pandas_accepts_field_association_enum(hexbeam):
     hexbeam.clear_data()
     hexbeam.point_data['p'] = np.arange(hexbeam.n_points, dtype=np.float64)
@@ -1125,7 +1081,6 @@ def test_dataset_to_pandas_accepts_field_association_enum(hexbeam):
     assert list(df_cell.columns) == ['c']
 
 
-@skip_no_pyarrow
 def test_dataset_to_arrow_accepts_field_association_enum(hexbeam):
     hexbeam.clear_data()
     hexbeam.cell_data['s'] = np.arange(hexbeam.n_cells, dtype=np.int32)
@@ -1138,7 +1093,6 @@ def test_dataset_attributes_for_association_rejects_row(hexbeam):
         hexbeam._attributes_for_association(pv.FieldAssociation.ROW)
 
 
-@skip_no_pyarrow
 def test_dataset_to_arrow_defaults_to_point(hexbeam):
     hexbeam.clear_data()
     hexbeam.point_data['s'] = np.arange(hexbeam.n_points, dtype=np.int32)
@@ -1147,7 +1101,6 @@ def test_dataset_to_arrow_defaults_to_point(hexbeam):
     assert table.schema.names == ['s']
 
 
-@skip_no_pyarrow
 def test_dataset_to_arrow_cell_association(hexbeam):
     hexbeam.clear_data()
     hexbeam.cell_data['s'] = np.arange(hexbeam.n_cells, dtype=np.int32)
@@ -1155,7 +1108,6 @@ def test_dataset_to_arrow_cell_association(hexbeam):
     assert table.num_rows == hexbeam.n_cells
 
 
-@skip_no_pyarrow
 def test_dataset_arrow_c_stream_uses_point_data(hexbeam):
     hexbeam.clear_data()
     hexbeam.point_data['s'] = np.arange(hexbeam.n_points, dtype=np.int64)
@@ -1164,7 +1116,6 @@ def test_dataset_arrow_c_stream_uses_point_data(hexbeam):
     assert table.schema.names == ['s']
 
 
-@skip_no_pyarrow
 def test_dataset_arrow_c_stream_returns_pycapsule(hexbeam):
     hexbeam.clear_data()
     hexbeam.point_data['s'] = np.arange(hexbeam.n_points, dtype=np.int32)
@@ -1177,7 +1128,6 @@ def test_dataset_to_arrow_invalid_association_raises(hexbeam):
         hexbeam.to_arrow('field')
 
 
-@skip_no_pandas
 @pytest.mark.parametrize('mesh_fixture', ['sphere', 'hexbeam', 'uniform', 'plane'])
 def test_dataset_to_pandas_across_dataset_types(request, mesh_fixture):
     mesh = request.getfixturevalue(mesh_fixture)
@@ -1188,7 +1138,6 @@ def test_dataset_to_pandas_across_dataset_types(request, mesh_fixture):
     assert len(mesh.to_pandas('cell')) == mesh.n_cells
 
 
-@skip_no_pandas
 def test_dataset_to_pandas_cell_multi_component(hexbeam):
     hexbeam.clear_data()
     hexbeam.cell_data['vec'] = np.arange(hexbeam.n_cells * 3, dtype=np.float64).reshape(
@@ -1199,7 +1148,6 @@ def test_dataset_to_pandas_cell_multi_component(hexbeam):
     assert len(df) == hexbeam.n_cells
 
 
-@skip_no_pyarrow
 def test_dataset_to_arrow_schema_names_cell(hexbeam):
     hexbeam.clear_data()
     hexbeam.cell_data['s'] = np.arange(hexbeam.n_cells, dtype=np.int32)
@@ -1210,7 +1158,6 @@ def test_dataset_to_arrow_schema_names_cell(hexbeam):
     assert table.schema.names == ['s', 'v_0', 'v_1', 'v_2']
 
 
-@skip_no_pandas
 @pytest.mark.needs_vtk_version(9, 6, 99)  # >= (9, 7, 0)
 def test_to_pandas_matches_vtk_native(hexbeam):
     """PyVista's ``to_pandas`` lines up with VTK's native ``to_pandas``.

--- a/tests/core/test_objects.py
+++ b/tests/core/test_objects.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
+import pandas as pd
+import pyarrow as pa
 import pytest
 
 import pyvista as pv
@@ -13,16 +15,6 @@ from pyvista import examples
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
-
-try:
-    import pandas as pd
-except ImportError:
-    pd = None
-
-try:
-    import pyarrow as pa
-except ImportError:
-    pa = None
 
 
 def test_table_init(tmpdir):
@@ -193,7 +185,6 @@ def test_table_repr():
     assert isinstance(text, str)
 
 
-@pytest.mark.skipif(pd is None, reason='Requires Pandas')
 def test_table_pandas():
     nr, nc = 50, 3
     arrays = np.random.default_rng().random((nr, nc))
@@ -237,7 +228,6 @@ def test_from_dict_raises(mocker: MockerFixture):
         pv.Table(dict(a=m))
 
 
-@pytest.mark.skipif(pa is None, reason='Requires pyarrow')
 def test_table_to_arrow():
     table = pv.Table({'a': np.arange(5, dtype=np.int64), 'b': np.linspace(0, 1, 5)})
     arrow_table = table.to_arrow()
@@ -248,21 +238,18 @@ def test_table_to_arrow():
     assert np.array_equal(arrow_table.column('a').to_numpy(), np.arange(5))
 
 
-@pytest.mark.skipif(pa is None, reason='Requires pyarrow')
 def test_table_arrow_c_stream_round_trip():
     table = pv.Table({'a': np.arange(5, dtype=np.int64), 'b': np.linspace(0, 1, 5)})
     consumed = pa.table(table)
     assert consumed.equals(table.to_arrow())
 
 
-@pytest.mark.skipif(pa is None, reason='Requires pyarrow')
 def test_table_arrow_c_stream_returns_pycapsule():
     table = pv.Table({'a': np.arange(3, dtype=np.int32)})
     capsule = table.__arrow_c_stream__()
     assert type(capsule).__name__ == 'PyCapsule'
 
 
-@pytest.mark.skipif(pa is None, reason='Requires pyarrow')
 def test_table_to_arrow_empty():
     table = pv.Table()
     arrow_table = table.to_arrow()
@@ -270,7 +257,6 @@ def test_table_to_arrow_empty():
     assert arrow_table.num_columns == 0
 
 
-@pytest.mark.skipif(pa is None, reason='Requires pyarrow')
 @pytest.mark.parametrize(
     'dtype',
     [np.int32, np.int64, np.uint8, np.float32, np.float64],
@@ -283,8 +269,6 @@ def test_table_to_arrow_preserves_dtype(dtype):
     assert np.array_equal(arrow_table.column('col').to_numpy(), expected)
 
 
-@pytest.mark.skipif(pa is None, reason='Requires pyarrow')
-@pytest.mark.skipif(pd is None, reason='Requires pandas')
 def test_table_to_arrow_matches_to_pandas():
     arrays = np.random.default_rng(seed=0).random((10, 3))
     table = pv.Table(arrays)

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -9,6 +9,7 @@ from hypothesis import HealthCheck
 from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
+import imageio
 import numpy as np
 import pytest
 
@@ -22,12 +23,6 @@ from pyvista.examples.downloads import download_file
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
-
-HAS_IMAGEIO = True
-try:
-    import imageio
-except ModuleNotFoundError:
-    HAS_IMAGEIO = False
 
 
 def assert_output_type(mesh: pv.DataObject, reader: pv.BaseReader):
@@ -1276,7 +1271,6 @@ def test_xdmf_reader():
         reader.set_active_time_value(1000.0)
 
 
-@pytest.mark.skipif(not HAS_IMAGEIO, reason='Requires imageio')
 def test_try_imageio_imread():
     img = _try_imageio_imread(examples.mapfile)
     assert isinstance(img, (imageio.core.util.Array, np.ndarray))

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-import contextlib
 import inspect
 import itertools
 import json
@@ -86,9 +85,6 @@ from pyvista.core.utilities.writer import _DataFormatMixin
 from pyvista.plotting.prop3d import _orientation_as_rotation_matrix
 from pyvista.plotting.widgets import _parse_interaction_event
 from tests.conftest import NUMPY_VERSION_INFO
-
-with contextlib.suppress(ImportError):
-    import tomllib  # Python 3.11+
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -238,6 +234,8 @@ def test_vtk_version_info_raises(operation):
     reason='Requires Python 3.11+, path issues on macOS',
 )
 def test_min_supported_vtk_version_matches_pyproject():
+    import tomllib
+
     def get_min_vtk_version_from_pyproject():
         # locate pyproject.toml relative to package
         root = Path(
@@ -3330,6 +3328,8 @@ def test_deprecate_positional_args_decorator_not_needed():
     reason='Requires Python 3.11+, path issues on macOS',
 )
 def test_max_positional_args_matches_pyproject():
+    import tomllib
+
     root = Path(
         os.environ.get('TOX_ROOT', Path(pv.__file__).parents[1])
     )  # to make the test work when pyvista is installed via tox

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -630,10 +630,6 @@ def test_check_type():
     check_type(0, int | float)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason='Union type input requires python3.10 or higher',
-)
 def test_check_type_union():
     check_type(0, int | float)
 

--- a/tests/plotting/jupyter/conftest.py
+++ b/tests/plotting/jupyter/conftest.py
@@ -69,10 +69,8 @@ def _trame_array_cache():
     exporting test's arrays would otherwise survive it.
     """
     yield
-    try:
-        from trame_vtk.modules.vtk import HELPERS_PER_SERVER
-    except ImportError:
-        return
+    from trame_vtk.modules.vtk import HELPERS_PER_SERVER
+
     for helper in HELPERS_PER_SERVER.values():
         protocol = helper._root_protocol
         if protocol is None:

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -20,6 +20,7 @@ from typing import TypeVar
 from typing import get_args
 import warnings
 
+import imageio
 import numpy as np
 from PIL import Image
 import pytest
@@ -56,24 +57,6 @@ if TYPE_CHECKING:
 
 # skip all tests if unable to render
 pytestmark = pytest.mark.skip_plotting
-
-
-HAS_IMAGEIO = True
-try:
-    import imageio
-except ModuleNotFoundError:
-    HAS_IMAGEIO = False
-
-try:
-    import imageio_ffmpeg
-
-    imageio_ffmpeg.get_ffmpeg_exe()
-except ImportError:
-    if HAS_IMAGEIO:
-        imageio.plugins.ffmpeg.download()
-    else:
-        raise
-
 
 THIS_PATH = Path(__file__).parent.absolute()
 
@@ -1098,14 +1081,12 @@ def test_add_lines_invalid():
 
 
 @pytest.mark.usefixtures('no_images_to_verify')
-@pytest.mark.skipif(not HAS_IMAGEIO, reason='Requires imageio')
 def test_open_gif_invalid():
     pl = pv.Plotter()
     with pytest.raises(ValueError):  # noqa: PT011
         pl.open_gif('file.abs')
 
 
-@pytest.mark.skipif(not HAS_IMAGEIO, reason='Requires imageio')
 def test_make_movie(sphere, tmpdir, verify_image_cache):
     verify_image_cache.skip = True
 
@@ -1662,7 +1643,6 @@ def test_plot_texture():
 
 
 @pytest.mark.usefixtures('no_images_to_verify')
-@pytest.mark.skipif(not HAS_IMAGEIO, reason='Requires imageio')
 def test_plot_numpy_texture():
     """Text adding a np.ndarray texture to a plot"""
     globe = examples.load_globe()
@@ -1671,7 +1651,6 @@ def test_plot_numpy_texture():
     pl.add_mesh(globe, texture=texture_np)
 
 
-@pytest.mark.skipif(not HAS_IMAGEIO, reason='Requires imageio')
 def test_read_texture_from_numpy():
     """Test adding a texture to a plot"""
     globe = examples.load_globe()
@@ -4134,7 +4113,6 @@ def test_pointset_plot_as_points_vtk():
 
 
 @pytest.mark.usefixtures('no_images_to_verify')
-@pytest.mark.skipif(not HAS_IMAGEIO, reason='Requires imageio')
 def test_write_gif(sphere, tmpdir):
     basename = 'write_gif.gif'
     path = str(tmpdir.join(basename))

--- a/tests/plotting/test_scraper.py
+++ b/tests/plotting/test_scraper.py
@@ -23,7 +23,6 @@ class QApplication:
 
 def test_scraper_with_app(tmpdir, monkeypatch):
     n_win = 2
-    pytest.importorskip('sphinx_gallery')
     monkeypatch.setattr(pv, 'BUILDING_GALLERY', True)
     pv.close_all()
 
@@ -74,7 +73,6 @@ def test_scraper_with_app(tmpdir, monkeypatch):
 @pytest.mark.parametrize('scraper_type', ['static', 'dynamic'])
 @pytest.mark.parametrize('n_win', [1, 2])
 def test_scraper(tmpdir, monkeypatch, n_win, scraper_type):
-    pytest.importorskip('sphinx_gallery')
     monkeypatch.setattr(pv, 'BUILDING_GALLERY', True)
     pv.close_all()
     plotters = [pv.Plotter(off_screen=True) for _ in range(n_win)]
@@ -127,7 +125,6 @@ def test_scraper(tmpdir, monkeypatch, n_win, scraper_type):
 
 
 def test_scraper_raise(tmpdir):
-    pytest.importorskip('sphinx_gallery')
     pv.close_all()
     pl = pv.Plotter(off_screen=True)
     scraper = Scraper()

--- a/tests/plotting/test_tinypages.py
+++ b/tests/plotting/test_tinypages.py
@@ -13,8 +13,6 @@ import pytest
 from pyvista.plotting import system_supports_plotting
 from tests.conftest import flaky_test
 
-pytest.importorskip('sphinx')
-
 # skip all tests if unable to render
 if not system_supports_plotting():
     pytestmark = pytest.mark.skip(reason='Requires system to support plotting')

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -178,7 +178,7 @@ def try_init_pyvista_object(class_):
     kwargs = get_default_class_init_kwargs(class_)
     try:
         instance = class_(**kwargs)
-    except (ImportError, VTKVersionError):
+    except (VTKVersionError, ImportError):
         pytest.skip('VTK Version not supported.')
     except TypeError as e:
         if 'abstract' in repr(e):

--- a/tests/test_import_conventions.py
+++ b/tests/test_import_conventions.py
@@ -17,11 +17,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-# `tomllib` is Python 3.11+, and this project supports 3.10. The convention
-# guard only needs to run on one interpreter to be effective, so skip rather
-# than take on a `tomli` dependency for the oldest supported version.
-tomllib = pytest.importorskip('tomllib', reason='tomllib requires Python 3.11+')
-
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -48,6 +43,10 @@ def _iter_source_files() -> Iterator[Path]:
 
 def _namespace_modules() -> set[str]:
     """Modules ruff requires to be namespace-imported."""
+    if sys.version_info < (3, 11):
+        pytest.skip('tomllib requires Python 3.11+')
+    import tomllib
+
     with (REPO_ROOT / 'pyproject.toml').open('rb') as file:
         config = tomllib.load(file)
     conventions = config['tool']['ruff']['lint']['flake8-import-conventions']

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -10,10 +10,6 @@ from __future__ import annotations
 
 def test_mpl_backend():
     """Check if the backend is correctly set for testing."""
-    # only fail if matplotlib is otherwise available
-    try:
-        import matplotlib as mpl
-    except ImportError:
-        return
+    import matplotlib as mpl
 
     assert mpl.get_backend() == 'agg'


### PR DESCRIPTION
### Overview

Resolves #8392.

Adds a `pygrep` hook to ensure there is no use of
- `except ImportError` or `except ModuleNotFoundError`
- `pytest.importorskip`
- `contextlib.suppress(ImportError)` or `contextlib.suppress(ModuleNotFoundError)`

inside any test modules.