### PR TITLE
Remove redundant enum docs

### DIFF
--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -139,11 +139,13 @@ class AnnotatedIntEnum(int, Enum):
 
     annotation: str
 
-    def __new__(cls, value: int, annotation: str) -> Self:
-        """Initialize."""
+    def __new__(cls, value: int, annotation: str, doc: str | None = None) -> Self:
+        """Initialize, optionally attaching a member docstring."""
         obj = int.__new__(cls, value)
         obj._value_ = value
         obj.annotation = annotation
+        if doc is not None:
+            obj.__doc__ = doc
         return obj
 
     @classmethod

--- a/pyvista/plotting/opts.py
+++ b/pyvista/plotting/opts.py
@@ -47,25 +47,12 @@ class PointSpriteShape(str, Enum):
 
 
 class InterpolationType(AnnotatedIntEnum):
-    """Lighting interpolation types.
+    """Lighting interpolation types."""
 
-    Attributes
-    ----------
-    FLAT : (int, str)
-        Flat interpolation type.
-    GOURAUD : (int, str)
-        Gouraud interpolation type.
-    PHONG : (int, str)
-        Phong interpolation type.
-    PBR : (int, str)
-        Physically based rendering interpolation type.
-
-    """
-
-    FLAT = (0, 'Flat')
-    GOURAUD = (1, 'Gouraud')
-    PHONG = (2, 'PHONG')
-    PBR = (3, 'Physically based rendering')
+    FLAT = (0, 'Flat', 'Flat interpolation type.')
+    GOURAUD = (1, 'Gouraud', 'Gouraud interpolation type.')
+    PHONG = (2, 'PHONG', 'Phong interpolation type.')
+    PBR = (3, 'Physically based rendering', 'Physically based rendering interpolation type.')
 
     @classmethod
     def from_str(cls, input_str):

--- a/pyvista/plotting/opts.py
+++ b/pyvista/plotting/opts.py
@@ -47,7 +47,11 @@ class PointSpriteShape(str, Enum):
 
 
 class InterpolationType(AnnotatedIntEnum):
-    """Lighting interpolation types."""
+    """Lighting interpolation types.
+
+    Members accept either their ``int`` value or ``str`` annotation, e.g.
+    ``InterpolationType.from_any('Flat')``.
+    """
 
     FLAT = (0, 'Flat', 'Flat interpolation type.')
     GOURAUD = (1, 'Gouraud', 'Gouraud interpolation type.')
@@ -81,7 +85,11 @@ class InterpolationType(AnnotatedIntEnum):
 
 
 class RepresentationType(AnnotatedIntEnum):
-    """Types of representations the models can have."""
+    """Types of representations the models can have.
+
+    Members accept either their ``int`` value or ``str`` annotation, e.g.
+    ``RepresentationType.from_any('Points')``.
+    """
 
     POINTS = (0, 'Points')
     WIREFRAME = (1, 'Wireframe')
@@ -89,7 +97,11 @@ class RepresentationType(AnnotatedIntEnum):
 
 
 class ElementType(AnnotatedIntEnum):
-    """Types of elemental geometries."""
+    """Types of elemental geometries.
+
+    Members accept either their ``int`` value or ``str`` annotation, e.g.
+    ``ElementType.from_any('Cell')``.
+    """
 
     MESH = (0, 'Mesh')
     CELL = (1, 'Cell')
@@ -99,7 +111,11 @@ class ElementType(AnnotatedIntEnum):
 
 
 class PickerType(AnnotatedIntEnum):
-    """Types of pickers."""
+    """Types of pickers.
+
+    Members accept either their ``int`` value or ``str`` annotation, e.g.
+    ``PickerType.from_any('Volume')``.
+    """
 
     AREA = (0, 'Area')
     CELL = (1, 'Cell')
@@ -114,7 +130,11 @@ class PickerType(AnnotatedIntEnum):
 
 
 class StereoType(AnnotatedIntEnum):
-    """Types of stereo rendering."""
+    """Types of stereo rendering.
+
+    Members accept either their ``int`` value or ``str`` annotation, e.g.
+    ``StereoType.from_any('Anaglyph')``.
+    """
 
     CRYSTAL_EYES = (1, 'Crystal Eyes')
     RED_BLUE = (2, 'Red Blue')

--- a/pyvista/plotting/opts.py
+++ b/pyvista/plotting/opts.py
@@ -13,7 +13,7 @@ class ShaderType(str, Enum):
     .. versionadded:: 0.48
     """
 
-    def __new__(cls, value, doc):
+    def __new__(cls, value, doc=None):
         """Override method to include member documentation."""
         obj = str.__new__(cls, value)
         obj._value_ = value
@@ -31,7 +31,7 @@ class PointSpriteShape(str, Enum):
     .. versionadded:: 0.48
     """
 
-    def __new__(cls, value, doc):
+    def __new__(cls, value, doc=None):
         """Override method to include member documentation."""
         obj = str.__new__(cls, value)
         obj._value_ = value

--- a/pyvista/plotting/opts.py
+++ b/pyvista/plotting/opts.py
@@ -11,51 +11,39 @@ class ShaderType(str, Enum):
     """Shader types for GLSL shader replacements.
 
     .. versionadded:: 0.48
-
-    Attributes
-    ----------
-    VERTEX : str
-        Vertex shader.
-    FRAGMENT : str
-        Fragment shader.
-    GEOMETRY : str
-        Geometry shader.
-
     """
 
-    VERTEX = 'vertex'
-    FRAGMENT = 'fragment'
-    GEOMETRY = 'geometry'
+    def __new__(cls, value, doc):
+        """Override method to include member documentation."""
+        obj = str.__new__(cls, value)
+        obj._value_ = value
+        obj.__doc__ = doc
+        return obj
+
+    VERTEX = 'vertex', 'Vertex shader.'
+    FRAGMENT = 'fragment', 'Fragment shader.'
+    GEOMETRY = 'geometry', 'Geometry shader.'
 
 
 class PointSpriteShape(str, Enum):
     """Point sprite shape options for fragment shader rendering.
 
     .. versionadded:: 0.48
-
-    Attributes
-    ----------
-    CIRCLE : str
-        Circular disc.
-    TRIANGLE : str
-        Upward-pointing triangle.
-    HEXAGON : str
-        Regular hexagon.
-    DIAMOND : str
-        Diamond (rotated square).
-    ASTERISK : str
-        Five-pointed asterisk.
-    STAR : str
-        Five-pointed star.
-
     """
 
-    CIRCLE = 'circle'
-    TRIANGLE = 'triangle'
-    HEXAGON = 'hexagon'
-    DIAMOND = 'diamond'
-    ASTERISK = 'asterisk'
-    STAR = 'star'
+    def __new__(cls, value, doc):
+        """Override method to include member documentation."""
+        obj = str.__new__(cls, value)
+        obj._value_ = value
+        obj.__doc__ = doc
+        return obj
+
+    CIRCLE = 'circle', 'Circular disc.'
+    TRIANGLE = 'triangle', 'Upward-pointing triangle.'
+    HEXAGON = 'hexagon', 'Regular hexagon.'
+    DIAMOND = 'diamond', 'Diamond (rotated square).'
+    ASTERISK = 'asterisk', 'Five-pointed asterisk.'
+    STAR = 'star', 'Five-pointed star.'
 
 
 class InterpolationType(AnnotatedIntEnum):

--- a/pyvista/plotting/texture.py
+++ b/pyvista/plotting/texture.py
@@ -110,6 +110,9 @@ class Texture(DataObject, _vtk.vtkTexture):
         * MIRRORED_REPEAT
         * CLAMP_TO_BORDER
 
+        Members accept either their ``int`` value or ``str`` annotation, e.g.
+        ``WrapType.from_any('Repeat')``.
+
         See :attr:`Texture.wrap` for usage.
 
         """


### PR DESCRIPTION
Some enums have attributes _and_ members listed:
<img width="378" height="626" alt="image" src="https://github.com/user-attachments/assets/1d218b76-0f5b-451e-ae0f-a86e0dec69b8" />

This PR uses `__new__` instead to include member descriptions directly with enum values.