### PR TITLE
Extend `wrap()`'s fast validation path to composite datasets

### DIFF
--- a/pyvista/core/utilities/helpers.py
+++ b/pyvista/core/utilities/helpers.py
@@ -96,16 +96,29 @@ def _dataset_array_lengths_match(obj: DataSet) -> bool:
     return ok
 
 
+def _composite_array_lengths_match(obj: MultiBlock | PartitionedDataSet) -> bool:
+    """Recursively apply :func:`_dataset_array_lengths_match` to every leaf DataSet."""
+    for i in range(len(obj)):
+        block = obj[i]
+        if block is None:
+            continue
+        if isinstance(block, pv.MultiBlock):
+            if not _composite_array_lengths_match(block):
+                return False
+        elif not _dataset_array_lengths_match(block):
+            return False
+    return True
+
+
 def _warn_if_invalid_data(obj: DataObject) -> None:
     if not hasattr(obj, 'validate_mesh'):
         return
-    # Fast path: for a plain DataSet, a direct Python-side array-length check
-    # avoids the ~600us setup cost of the validate_mesh machinery on the
-    # common valid case. Composite and table types fall through to
-    # validate_mesh so their warning behavior is unchanged. When the fast
-    # path detects a mismatch we still call validate_mesh to produce the
-    # detailed warning message.
+    # Fast path avoiding the slow validate_mesh machinery on the common valid case.
     if isinstance(obj, pv.DataSet) and _dataset_array_lengths_match(obj):
+        return
+    if isinstance(obj, (pv.MultiBlock, pv.PartitionedDataSet)) and _composite_array_lengths_match(
+        obj,
+    ):
         return
     obj.validate_mesh('data', action='warn')
 

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -107,6 +107,62 @@ def test_wrap_honors_global_config(vtk_poly_with_invalid_arrays, monkeypatch):
         pv.wrap(vtk_poly_with_invalid_arrays)
 
 
+@pytest.mark.parametrize(
+    ('vtk_composite_cls', 'set_block'),
+    [
+        (_vtk.vtkMultiBlockDataSet, _vtk.vtkMultiBlockDataSet.SetBlock),
+        (_vtk.vtkPartitionedDataSet, _vtk.vtkPartitionedDataSet.SetPartition),
+    ],
+)
+def test_wrap_composite_valid_data_does_not_warn(sphere, vtk_composite_cls, set_block):
+    # No explicit warnings.catch_warnings needed: the project's pytest config
+    # already turns any unexpected warning into a test failure.
+    vtk_poly = _vtk.vtkPolyData()
+    vtk_poly.ShallowCopy(sphere)
+    vtk_composite = vtk_composite_cls()
+    set_block(vtk_composite, 0, vtk_poly)
+    pv.wrap(vtk_composite)
+
+
+def test_wrap_nested_multiblock_valid_data_does_not_warn(sphere):
+    vtk_poly = _vtk.vtkPolyData()
+    vtk_poly.ShallowCopy(sphere)
+    nested = _vtk.vtkMultiBlockDataSet()
+    nested.SetBlock(0, vtk_poly)
+    outer = _vtk.vtkMultiBlockDataSet()
+    outer.SetBlock(0, nested)
+    pv.wrap(outer)
+
+
+@pytest.mark.parametrize(
+    ('vtk_composite_cls', 'set_block'),
+    [
+        (_vtk.vtkMultiBlockDataSet, _vtk.vtkMultiBlockDataSet.SetBlock),
+        (_vtk.vtkPartitionedDataSet, _vtk.vtkPartitionedDataSet.SetPartition),
+    ],
+)
+def test_wrap_composite_with_invalid_dataset_warns(
+    vtk_poly_with_invalid_arrays,
+    vtk_composite_cls,
+    set_block,
+):
+    # The invalid DataSet is a block directly inside the composite.
+    vtk_composite = vtk_composite_cls()
+    set_block(vtk_composite, 0, vtk_poly_with_invalid_arrays)
+    with pytest.warns(pv.InvalidMeshWarning, match='Invalid array'):
+        pv.wrap(vtk_composite)
+
+
+def test_wrap_nested_multiblock_with_invalid_dataset_warns(vtk_poly_with_invalid_arrays):
+    # The invalid DataSet is inside a nested MultiBlock (PartitionedDataSet can't nest).
+    nested = _vtk.vtkMultiBlockDataSet()
+    nested.SetBlock(0, vtk_poly_with_invalid_arrays)
+    outer = _vtk.vtkMultiBlockDataSet()
+    outer.SetBlock(0, nested)
+    with pytest.warns(pv.InvalidMeshWarning, match='Invalid array'):
+        pv.wrap(outer)
+
+
 def test_wrap_auto_names_unnamed_arrays():
     # The pre-optimization wrap() path validated via keys(), which has the
     # side effect of renaming unnamed arrays to ``Unnamed_<i>``. Filters


### PR DESCRIPTION
Follow-up to #8493: that PR added a fast-path for `wrap` validation, but excluded composites. This PR extends the fast path to include composites.

When running `make_tables.py`, the `load_gears` dataset was found to be a bottleneck, taking approximately 30 seconds to load, mostly due to slow `wrap` validation. With this PR, the dataset now loads in ~1 second.