### PR TITLE
Fix integration test regression and expand GC checks

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -112,6 +112,7 @@ jobs:
     permissions:
       issues: write
       actions: read # to look up which matrix jobs failed
+      contents: read # to look up the commit title
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}
@@ -121,6 +122,8 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           RUN_ID: ${{ github.run_id }}
           REF: ${{ github.ref }}
+          SHA: ${{ github.sha }}
+          COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
         run: |
           # Who to @-mention when a given integration breaks; leave empty to not ping anyone
           declare -A maintainers=(
@@ -149,12 +152,17 @@ jobs:
 
           [ -n "$projects" ] || projects="- (could not determine which jobs failed, see the run)"$'\n'
 
+          # Names the PR that landed; no `| head` since SIGPIPE under pipefail kills the step
+          title=$(gh api "repos/{owner}/{repo}/commits/${SHA}" \
+            --jq '.commit.message | split("\n")[0]' || true)
+
           body=$(cat <<EOF
           ### Integration Test Failure
 
           **Date:** $(date -u +%Y-%m-%d)
           **Run:** ${RUN_URL}
           **Ref:** \`${REF}\`
+          **Commit:** [\`${SHA:0:8}\`](${COMMIT_URL})${title:+ — ${title}}
 
           **Failing integrations:**
           ${projects}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -280,6 +280,7 @@ filterwarnings = [
 junit_family = 'legacy'
 log_cli_level = "INFO"
 markers = [
+  'check_gc: Enable the strict core leak check for this test (see tests/core/conftest.py).',
   'expect_check_gc_fail: Expect vtk leak.',
   'needs_download: this test downloads data during execution',
   'needs_playwright: this test uses playwright and must be enabled with the --playwright CLI flag',

--- a/pyvista/core/_vtk_utilities.py
+++ b/pyvista/core/_vtk_utilities.py
@@ -117,6 +117,11 @@ _VTK_SNAKE_CASE_MIN_VERSION_MET = vtk_version_info >= (9, 4)
 # here and reuse it everywhere instead of re-inlining the version comparison.
 _SUPPORTS_FIXED_SIZE_STORAGE = vtk_version_info >= (9, 6, 2)
 
+# Since VTK 9.6, `vtkCellArray.SetData` references the arrays handed to it (their
+# reference count goes 1 -> 2). Before that it does not, so the caller must keep them
+# alive itself -- see `CellArray._set_data`.
+_SETDATA_TAKES_OWNERSHIP = vtk_version_info >= (9, 6)
+
 
 class DisableVtkSnakeCase:
     """Base class to raise error if using VTK's `snake_case` API."""

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -697,8 +697,6 @@ class CellArray(
     ) -> None:
         """Initialize a :vtk:`vtkCellArray`."""
         super().__init__()
-        self.__offsets: _vtk.vtkIdTypeArray | None = None
-        self.__connectivity: _vtk.vtkIdTypeArray | None = None
         if cells is not None:
             self.cells = cells
 
@@ -732,7 +730,6 @@ class CellArray(
                 ' due to invalid connectivity array.'
             )
             raise CellSizeError(msg)
-        self.__offsets = self.__connectivity = None
 
     @property
     def n_cells(self: Self) -> int:
@@ -794,12 +791,8 @@ class CellArray(
         else:
             vtk_offsets = numpy_to_idarr(offsets, deep=deep)
             vtk_connectivity = numpy_to_idarr(connectivity, deep=deep)
+        # Not stashed on self: SetData owns them, and a ghosted __dict__ would outlive us
         self.SetData(vtk_offsets, vtk_connectivity)
-
-        # Because vtkCellArray doesn't take ownership of the arrays, it's possible for them to get
-        # garbage collected. Keep a reference to them for safety
-        self.__offsets = vtk_offsets
-        self.__connectivity = vtk_connectivity
 
     def _set_data_fixed_size(
         self: Self,
@@ -818,12 +811,8 @@ class CellArray(
             self.Use32BitStorage()
         else:
             vtk_connectivity = numpy_to_idarr(connectivity, deep=deep)
+        # Not stashed on self, as in _set_data
         self.SetData(cell_size, vtk_connectivity)
-
-        # Keep the connectivity alive for shallow copies. VTK generates the
-        # offsets implicitly for fixed-size storage.
-        self.__offsets = None
-        self.__connectivity = vtk_connectivity
 
     @staticmethod
     @_deprecate_positional_args(allowed=['offsets', 'connectivity'])

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -10,6 +10,7 @@ import numpy as np
 import pyvista as pv
 from pyvista import _vtk
 from pyvista._deprecate_positional_args import _deprecate_positional_args
+from pyvista.core._vtk_utilities import _SETDATA_TAKES_OWNERSHIP
 from pyvista.core._vtk_utilities import _SUPPORTS_FIXED_SIZE_STORAGE
 from pyvista.core._vtk_utilities import DisableVtkSnakeCase
 from pyvista.core._vtk_utilities import vtkPyVistaOverride
@@ -697,6 +698,8 @@ class CellArray(
     ) -> None:
         """Initialize a :vtk:`vtkCellArray`."""
         super().__init__()
+        self.__offsets: _vtk.vtkIdTypeArray | None = None
+        self.__connectivity: _vtk.vtkIdTypeArray | None = None
         if cells is not None:
             self.cells = cells
 
@@ -730,6 +733,7 @@ class CellArray(
                 ' due to invalid connectivity array.'
             )
             raise CellSizeError(msg)
+        self.__offsets = self.__connectivity = None
 
     @property
     def n_cells(self: Self) -> int:
@@ -791,8 +795,14 @@ class CellArray(
         else:
             vtk_offsets = numpy_to_idarr(offsets, deep=deep)
             vtk_connectivity = numpy_to_idarr(connectivity, deep=deep)
-        # Not stashed on self: SetData owns them, and a ghosted __dict__ would outlive us
         self.SetData(vtk_offsets, vtk_connectivity)
+
+        # Only pre-9.6 VTK needs this: there SetData does not reference the arrays, so
+        # dropping them here frees the buffers out from under us. Newer VTK does own
+        # them, and stashing anyway leaks both via the ghost __dict__ (see #8873).
+        if not _SETDATA_TAKES_OWNERSHIP:
+            self.__offsets = vtk_offsets
+            self.__connectivity = vtk_connectivity
 
     def _set_data_fixed_size(
         self: Self,
@@ -811,7 +821,8 @@ class CellArray(
             self.Use32BitStorage()
         else:
             vtk_connectivity = numpy_to_idarr(connectivity, deep=deep)
-        # Not stashed on self, as in _set_data
+        # No stash needed as in _set_data: fixed-size storage implies VTK >= 9.6.2, which
+        # always owns the array
         self.SetData(cell_size, vtk_connectivity)
 
     @staticmethod

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1392,6 +1392,12 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
         return self.boolean_union(other_mesh)
 
     @property
+    def _offset_array(self) -> NumpyArray[int]:
+        """Return the array used to store cell offsets."""
+        # Unused internally since #8873, but geovista reads it; see tests/core/test_polydata.py
+        return _get_offset_array(self.GetPolys())
+
+    @property
     def _connectivity_array(self) -> NumpyArray[int]:
         """Return the array with the point ids that define the cells' connectivity."""
         return _get_connectivity_array(self.GetPolys())

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,13 +1,12 @@
 """Opt-in leak checking for core tests.
 
-``tests/plotting/conftest.py`` runs a similar check on every plotting test, but sweeps
-VTK's ghost map and re-checks before reporting -- plotter teardown leaves stale ghosts
-behind, and 21 plotting tests rely on that forgiveness. The sweep also forgives a real
-bug: pyvista stashing a VTK object on a wrapper that C++ owns, which then outlives the
-mesh in the ghost ``__dict__``. That is how #8873 shipped a leak the MNE integration
-tests caught but ours did not.
+Same machinery as the plotting conftest (see :mod:`tests.gc_check`), with one
+deliberate difference: no ghost-map sweep before reporting. Plotting needs that
+forgiveness for its own teardown, but it also forgives pyvista stashing a VTK object on
+a wrapper that C++ owns, which then outlives the mesh in the ghost ``__dict__`` -- how
+#8873 shipped a leak the MNE integration tests caught but ours did not.
 
-Modules owning dataset construction opt into the strict (no-sweep) check with::
+Modules owning dataset construction opt in with::
 
     pytestmark = pytest.mark.check_gc
 
@@ -18,30 +17,20 @@ today. Widening the opt-in as those are cleaned up is the point.
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import pytest
-from refleak.testing import Snapshot
-from refleak.testing import gc_collect_once
 
 from pyvista import _vtk
 from pyvista.core._vtk_utilities import _SETDATA_TAKES_OWNERSHIP
-
-_phase_report_key = pytest.StashKey()
-_check_gc_key = pytest.StashKey()
+from tests.gc_check import assert_no_leaks
+from tests.gc_check import stash_phase_report
+from tests.gc_check import take_snapshot
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):  # noqa: ARG001
     """Stash per-phase reports so the leak check can skip on failure."""
     outcome = yield
-    rep = outcome.get_result()
-    item.stash.setdefault(_phase_report_key, {})[rep.when] = rep
-
-
-def _test_passed(item) -> bool:
-    report = item.stash.get(_phase_report_key, {})
-    return 'call' in report and report['call'].outcome == 'passed'
+    stash_phase_report(item, outcome.get_result())
 
 
 @pytest.fixture(autouse=True)
@@ -56,7 +45,7 @@ def check_gc(request):
     ):
         yield
         return
-    node.stash[_check_gc_key] = Snapshot(_vtk.vtkObjectBase, label='VTK')
+    take_snapshot(node, _vtk.vtkObjectBase, 'VTK')
     yield
 
 
@@ -64,19 +53,4 @@ def check_gc(request):
 def pytest_runtest_teardown(item):
     """Ensure every VTK object created during a test is collected by teardown."""
     yield
-    snapshot = item.stash.get(_check_gc_key, None)
-    if snapshot is None:
-        return
-    del item.stash[_check_gc_key]
-
-    if not _test_passed(item):
-        return
-
-    # pytest holds fixture values in item.funcargs until after teardown hooks run, so a
-    # VTK-typed fixture value would always look like a leak. The test passed and its
-    # fixtures are finalized, so release them a moment early.
-    item.funcargs.clear()
-
-    request = SimpleNamespace(node=item)
-    gc_collect_once(request)
-    snapshot.assert_no_new(f'teardown of {item.name}', request=request)
+    assert_no_leaks(item, flush_ghosts=False)

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,0 +1,76 @@
+"""Opt-in leak checking for core tests.
+
+``tests/plotting/conftest.py`` runs a similar check on every plotting test, but sweeps
+VTK's ghost map and re-checks before reporting -- plotter teardown leaves stale ghosts
+behind, and 21 plotting tests rely on that forgiveness. The sweep also forgives a real
+bug: pyvista stashing a VTK object on a wrapper that C++ owns, which then outlives the
+mesh in the ghost ``__dict__``. That is how #8873 shipped a leak the MNE integration
+tests caught but ours did not.
+
+Modules owning dataset construction opt into the strict (no-sweep) check with::
+
+    pytestmark = pytest.mark.check_gc
+
+Opt-in rather than autouse because the check walks the heap twice per test -- 4x the
+runtime over all of ``tests/core`` -- and ~70 core tests hold VTK objects past teardown
+today. Widening the opt-in as those are cleaned up is the point.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from refleak.testing import Snapshot
+from refleak.testing import gc_collect_once
+
+from pyvista import _vtk
+
+_phase_report_key = pytest.StashKey()
+_check_gc_key = pytest.StashKey()
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):  # noqa: ARG001
+    """Stash per-phase reports so the leak check can skip on failure."""
+    outcome = yield
+    rep = outcome.get_result()
+    item.stash.setdefault(_phase_report_key, {})[rep.when] = rep
+
+
+def _test_passed(item) -> bool:
+    report = item.stash.get(_phase_report_key, {})
+    return 'call' in report and report['call'].outcome == 'passed'
+
+
+@pytest.fixture(autouse=True)
+def check_gc(request):
+    """Snapshot live VTK objects so leaks from this test can be detected."""
+    node = request.node
+    if node.get_closest_marker('check_gc') is None or node.get_closest_marker('skip_check_gc'):
+        yield
+        return
+    node.stash[_check_gc_key] = Snapshot(_vtk.vtkObjectBase, label='VTK')
+    yield
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_teardown(item):
+    """Ensure every VTK object created during a test is collected by teardown."""
+    yield
+    snapshot = item.stash.get(_check_gc_key, None)
+    if snapshot is None:
+        return
+    del item.stash[_check_gc_key]
+
+    if not _test_passed(item):
+        return
+
+    # pytest holds fixture values in item.funcargs until after teardown hooks run, so a
+    # VTK-typed fixture value would always look like a leak. The test passed and its
+    # fixtures are finalized, so release them a moment early.
+    item.funcargs.clear()
+
+    request = SimpleNamespace(node=item)
+    gc_collect_once(request)
+    snapshot.assert_no_new(f'teardown of {item.name}', request=request)

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -25,6 +25,7 @@ from refleak.testing import Snapshot
 from refleak.testing import gc_collect_once
 
 from pyvista import _vtk
+from pyvista.core._vtk_utilities import _SETDATA_TAKES_OWNERSHIP
 
 _phase_report_key = pytest.StashKey()
 _check_gc_key = pytest.StashKey()
@@ -47,7 +48,12 @@ def _test_passed(item) -> bool:
 def check_gc(request):
     """Snapshot live VTK objects so leaks from this test can be detected."""
     node = request.node
-    if node.get_closest_marker('check_gc') is None or node.get_closest_marker('skip_check_gc'):
+    if (
+        # On VTK < 9.6 CellArray must hold its own arrays, so this can never pass there
+        not _SETDATA_TAKES_OWNERSHIP
+        or node.get_closest_marker('check_gc') is None
+        or node.get_closest_marker('skip_check_gc')
+    ):
         yield
         return
     node.stash[_check_gc_key] = Snapshot(_vtk.vtkObjectBase, label='VTK')

--- a/tests/core/test_cells.py
+++ b/tests/core/test_cells.py
@@ -12,6 +12,7 @@ import pyvista as pv
 from pyvista import Cell
 from pyvista import CellType
 from pyvista import _vtk
+from pyvista.core._vtk_utilities import _SETDATA_TAKES_OWNERSHIP
 from pyvista.core._vtk_utilities import _SUPPORTS_FIXED_SIZE_STORAGE
 from pyvista.core.celltype import _CELL_TYPE_INFO
 from pyvista.core.celltype import _DEPRECATED_CELL_TYPES
@@ -614,6 +615,10 @@ def test_deep_removed(deep: bool):
         lambda: pv.vector_poly_data(np.zeros((10, 3)), np.ones((10, 3))),
     ],
     ids=['verts', 'faces', 'lines', 'vectors'],
+)
+@pytest.mark.skipif(
+    not _SETDATA_TAKES_OWNERSHIP,
+    reason='VTK < 9.6 requires CellArray to keep the arrays alive itself',
 )
 def test_cell_array_does_not_leak_vtk_arrays(make_mesh):
     # A VTK array stashed on the CellArray outlives the mesh in VTK's ghost __dict__

--- a/tests/core/test_cells.py
+++ b/tests/core/test_cells.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import gc
 import re
 from types import GeneratorType
 
 import numpy as np
 import pytest
+from refleak.testing import Snapshot
 
 import pyvista as pv
 from pyvista import Cell
@@ -23,6 +25,9 @@ from pyvista.examples import load_rectilinear
 from pyvista.examples import load_structured
 from pyvista.examples import load_tetbeam
 from pyvista.examples import load_uniform
+
+# Cell arrays are where a stashed VTK object silently outlives its mesh; see conftest
+pytestmark = pytest.mark.check_gc
 
 grids = [
     load_hexbeam(),
@@ -598,3 +603,41 @@ def test_n_cells_removed():
 def test_deep_removed(deep: bool):
     with pytest.raises(TypeError, match=r'unexpected keyword argument'):
         _ = pv.core.cell.CellArray([3, 0, 1, 2], deep=deep)
+
+
+@pytest.mark.parametrize(
+    'make_mesh',
+    [
+        lambda: pv.PolyData(np.zeros((10, 3))),
+        lambda: pv.PolyData.from_regular_faces(np.zeros((4, 3)), [[0, 1, 2], [1, 2, 3]]),
+        lambda: pv.lines_from_points(np.zeros((10, 3))),
+        lambda: pv.vector_poly_data(np.zeros((10, 3)), np.ones((10, 3))),
+    ],
+    ids=['verts', 'faces', 'lines', 'vectors'],
+)
+def test_cell_array_does_not_leak_vtk_arrays(make_mesh):
+    # A VTK array stashed on the CellArray outlives the mesh in VTK's ghost __dict__
+    snapshot = Snapshot(_vtk.vtkObjectBase, label='VTK')
+    make_mesh()
+    gc.collect()
+    snapshot.assert_no_new(when='after building the mesh')
+
+
+@pytest.mark.parametrize('dtype', [np.int32, pv.ID_TYPE], ids=['int32', 'id_type'])
+def test_cell_array_connectivity_outlives_its_source(dtype):
+    # The counterpart to the leak test: SetData alone must keep the connectivity valid
+    faces = np.arange(120, dtype=dtype).reshape(-1, 3) % 40
+    source = pv.PolyData.from_regular_faces(np.zeros((40, 3)), faces)
+
+    shallow = pv.PolyData()
+    shallow.shallow_copy(source)
+    del source
+    gc.collect()
+    assert np.array_equal(shallow.regular_faces, faces)
+
+    # Same again, but the CellArray wrapper itself dies while C++ still owns it
+    polydata = _vtk.vtkPolyData()
+    polydata.SetPoints(pv.vtk_points(np.zeros((40, 3))))
+    polydata.SetPolys(pv.CellArray.from_regular_cells(faces.copy()))
+    gc.collect()
+    assert np.array_equal(pv.wrap(polydata).regular_faces, faces)

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -1492,3 +1492,9 @@ def test_merge_points(inplace):
     assert output.n_points == 8
     assert isinstance(mesh, pv.PolyData)
     assert (mesh is output) == inplace
+
+
+def test_offset_array():
+    # Private, but geovista reads it, so removing it breaks the integration tests
+    mesh = pv.PolyData.from_regular_faces(np.zeros((4, 3)), [[0, 1, 2], [1, 2, 3]])
+    assert np.array_equal(mesh._offset_array, [0, 3, 6])

--- a/tests/gc_check.py
+++ b/tests/gc_check.py
@@ -1,0 +1,126 @@
+"""Shared leak-check machinery for the ``core`` and ``plotting`` conftests.
+
+Both run the same check -- snapshot the live VTK objects before a test, assert none of
+them outlived it -- so the mechanics live here and each conftest only supplies its
+policy. They differ in exactly two ways:
+
+* what they match: plotting also watches ``BasePlotter``, which is not a VTK object.
+* ``flush_ghosts``: plotting forgives a leak that disappears once VTK's ghost map is
+  swept, because plotter teardown routinely leaves stale ghosts behind. Core does not,
+  and that strictness is the point -- the retry is what let the #8873 leak through.
+
+The check runs from a ``pytest_runtest_teardown`` hookwrapper rather than a fixture
+finalizer: several fixtures are set up before an autouse fixture (``monkeypatch`` via
+other autouse fixtures, the registry save/restore in ``tests/conftest.py``), so their
+finalizers run *after* it -- and anything they still held would be misreported here.
+"""
+
+from __future__ import annotations
+
+import gc
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+from refleak.testing import Snapshot
+from refleak.testing import gc_collect_once
+
+from pyvista import _vtk
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_phase_report_key = pytest.StashKey()
+_check_gc_key = pytest.StashKey()
+
+
+def stash_phase_report(item, report) -> None:
+    """Record a phase report so the check can be skipped when the test failed."""
+    item.stash.setdefault(_phase_report_key, {})[report.when] = report
+
+
+def _test_passed(item) -> bool:
+    report = item.stash.get(_phase_report_key, {})
+    return 'call' in report and report['call'].outcome == 'passed'
+
+
+def _flush_vtk_ghosts() -> None:
+    """Sweep dead entries out of VTK's ghost map.
+
+    When a wrapper with attributes dies while its C++ object is still referenced, VTK
+    "ghosts" the attribute dict so it can be restored should the C++ object resurface in
+    Python. The map is only swept when a new ghost is added, so the dict of a wrapper
+    that died during this test can linger after its C++ object dies -- and anything it
+    holds (e.g. a composite mapper's ``_dataset``) then looks like a leak. Adding one
+    throwaway ghost forces the sweep.
+    """
+    holder = _vtk.vtkPolyData()
+    bait = _vtk.vtkPoints()
+    bait._pyvista_ghost_bait = True
+    holder.SetPoints(bait)
+    # bait's wrapper dies while its C++ object is still held by holder, so it is added to
+    # the ghost map, sweeping out stale ghosts; deleting holder then kills the C++ object,
+    # letting a later sweep remove the bait itself.
+    del bait
+    del holder
+
+
+def take_snapshot(item, match, label: str) -> None:
+    """Record the live matching objects, so only *new* survivors are reported.
+
+    Matching by ``isinstance`` rather than class-name prefix also covers pyvista's own
+    vtk subclasses (``PolyData``, ...) and the pythonic override subclasses VTK >= 9.6
+    instantiates, whose names lack the ``vtk`` prefix. Passing several types as one tuple
+    keeps this to a single pass over the heap. ``Snapshot`` collects before it records
+    ids, so no ``gc.collect()`` is needed here.
+    """
+    item.stash[_check_gc_key] = Snapshot(match, label=label)
+
+
+def assert_no_leaks(
+    item,
+    *,
+    flush_ghosts: bool,
+    before_check: Callable[[], None] | None = None,
+) -> None:
+    """Assert nothing matched by :func:`take_snapshot` outlived the test."""
+    snapshot = item.stash.get(_check_gc_key, None)
+    if snapshot is None:
+        return
+    del item.stash[_check_gc_key]
+
+    if before_check is not None:
+        before_check()
+
+    if not _test_passed(item):
+        return
+
+    # pytest holds every fixture value in item.funcargs until after all teardown hooks
+    # have run (its runner only then sets it to None), so a VTK-typed fixture value
+    # (sphere, texture, ...) would always be flagged as a leak. The test passed and its
+    # fixtures are already finalized, so release them a moment early.
+    item.funcargs.clear()
+
+    when = f'teardown of {item.name}'
+    # gc_collect_once deduplicates on request.node; it only needs .node
+    request = SimpleNamespace(node=item)
+    gc_collect_once(request)
+
+    def _assert_no_new():
+        try:
+            snapshot.assert_no_new(when, request=request)
+        except AssertionError:
+            if not flush_ghosts:
+                raise
+            # A stale VTK ghost is deferred bookkeeping, not a leak: flush the ghost map
+            # and re-check before reporting a failure.
+            _flush_vtk_ghosts()
+            gc.collect()
+            snapshot.assert_no_new(when, request=request)
+
+    if item.get_closest_marker('expect_check_gc_fail'):
+        with pytest.raises(AssertionError, match='Found '):
+            _assert_no_new()
+        return
+
+    _assert_no_new()

--- a/tests/plotting/conftest.py
+++ b/tests/plotting/conftest.py
@@ -4,17 +4,16 @@ memory leaks for all plotting tests
 
 from __future__ import annotations
 
-import gc
 import platform
-from types import SimpleNamespace
 
 import pytest
-from refleak.testing import Snapshot
-from refleak.testing import gc_collect_once
 
 import pyvista as pv
 from pyvista import _vtk
 from pyvista.plotting import system_supports_plotting
+from tests.gc_check import assert_no_leaks
+from tests.gc_check import stash_phase_report
+from tests.gc_check import take_snapshot
 
 # these are set here because we only need them for plotting tests
 pv.OFF_SCREEN = True
@@ -66,76 +65,24 @@ if APPLE_SILICON:
         del pool
 
 
-_phase_report_key = pytest.StashKey()
-
-
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):  # noqa: ARG001
     """Stash per-phase reports so check_gc can skip the leak check on failure."""
     outcome = yield
-    rep = outcome.get_result()
-    item.stash.setdefault(_phase_report_key, {})[rep.when] = rep
-
-
-def _test_passed(item) -> bool:
-    report = item.stash.get(_phase_report_key, {})
-    return 'call' in report and report['call'].outcome == 'passed'
-
-
-def _flush_vtk_ghosts() -> None:
-    """Sweep dead entries out of VTK's ghost map.
-
-    When a wrapper with attributes dies while its C++ object is still
-    referenced, VTK "ghosts" the attribute dict so it can be restored should
-    the C++ object resurface in Python. The map is only swept when a new
-    ghost is added, so the dict of a wrapper that died during this test can
-    linger after its C++ object dies -- and anything it holds (e.g. a
-    composite mapper's ``_dataset``) then looks like a leak. Adding one
-    throwaway ghost forces the sweep.
-    """
-    holder = _vtk.vtkPolyData()
-    bait = _vtk.vtkPoints()
-    bait._pyvista_ghost_bait = True
-    holder.SetPoints(bait)
-    # bait's wrapper dies while its C++ object is still held by holder, so it
-    # is added to the ghost map, sweeping out stale ghosts; deleting holder
-    # then kills the C++ object, letting a later sweep remove the bait itself.
-    del bait
-    del holder
-
-
-_check_gc_key = pytest.StashKey()
+    stash_phase_report(item, outcome.get_result())
 
 
 @pytest.fixture(autouse=True)
 def check_gc(request):
-    """Snapshot live objects so leaks from this test can be detected.
-
-    The check itself runs in the ``pytest_runtest_teardown`` hookwrapper
-    below, not in this fixture's teardown: several fixtures are set up
-    before this one (``monkeypatch`` via other autouse fixtures, the
-    registry save/restore in ``tests/conftest.py::reset_global_state``),
-    so their finalizers run *after* an autouse fixture's teardown -- and
-    anything they still held (a patched-in mock, a test class left in a
-    global registry) would be misreported here as a leak.
-    """
+    """Snapshot live plotters and VTK objects so leaks from this test can be detected."""
     if request.node.get_closest_marker('skip_check_gc'):
         yield
         return
-
-    # A snapshot, so that leftovers of earlier tests that legitimately skip
-    # this check are not blamed on this test. Matching vtkObjectBase by
-    # isinstance rather than by class-name prefix also covers pyvista's own
-    # vtk subclasses (PolyData, ...) and the pythonic override subclasses
-    # VTK >= 9.6 instantiates, whose names lack the 'vtk' prefix.
-    #
-    # BasePlotter is not a vtkObjectBase, so both types are needed; matching
-    # them as a single tuple keeps this to one pass over the heap (which is
-    # walked once per test at setup and once at teardown). Snapshot() collects
-    # before it records ids, so there is no gc.collect() here.
-    request.node.stash[_check_gc_key] = Snapshot(
+    # BasePlotter is not a vtkObjectBase, so both types are needed here
+    take_snapshot(
+        request.node,
         (pv.plotting.plotter.BasePlotter, _vtk.vtkObjectBase),
-        label='VTK/plotter',
+        'VTK/plotter',
     )
     yield
 
@@ -148,46 +95,9 @@ def pytest_runtest_teardown(item):
     (see ``check_gc``, which takes the snapshot this checks against).
     """
     yield
-    snapshot = item.stash.get(_check_gc_key, None)
-    if snapshot is None:
-        return
-    del item.stash[_check_gc_key]
-
-    pv.close_all()
-
-    # Skip GC check if test failed (or was skipped during call)
-    if not _test_passed(item):
-        return
-
-    # pytest holds every fixture value in item.funcargs until after all
-    # teardown hooks have run (its runner only then sets it to None), so a
-    # VTK-typed fixture value (sphere, texture, ...) would always be flagged
-    # as a leak. The test passed and its fixtures are already finalized, so
-    # release them a moment early.
-    item.funcargs.clear()
-
-    when = f'teardown of {item.name}'
-    # gc_collect_once deduplicates on request.node; it only needs .node
-    request = SimpleNamespace(node=item)
-    gc_collect_once(request)
-
-    def _assert_no_new():
-        # No plotter and no VTK object created during a test may survive it.
-        try:
-            snapshot.assert_no_new(when, request=request)
-        except AssertionError:
-            # A stale VTK ghost is deferred bookkeeping, not a leak: flush
-            # the ghost map and re-check before reporting a failure.
-            _flush_vtk_ghosts()
-            gc.collect()
-            snapshot.assert_no_new(when, request=request)
-
-    if item.get_closest_marker('expect_check_gc_fail'):
-        with pytest.raises(AssertionError, match='Found '):
-            _assert_no_new()
-        return
-
-    _assert_no_new()
+    # flush_ghosts: plotter teardown leaves stale ghosts behind, so a leak that a ghost
+    # sweep clears is deferred bookkeeping rather than a real one (unlike tests/core)
+    assert_no_leaks(item, flush_ghosts=True, before_check=pv.close_all)
 
 
 @pytest.fixture

--- a/tests/plotting/test_gc.py
+++ b/tests/plotting/test_gc.py
@@ -43,12 +43,18 @@ def test_leak_pv() -> None:
     # The failure report contains non-ASCII box-drawing characters (refleak's
     # referrer tree), so force UTF-8 on both sides of the pipe -- otherwise
     # the runner's locale (ASCII on CI) breaks the encode or decode step.
+    # PYTHONPATH: the copied conftest imports tests.gc_check, which is not
+    # importable from tmp_path.
     result = subprocess.run(
         ['pytest', '-v', str(test_file)],
         cwd=tmp_path,
         capture_output=True,
         check=False,
-        env={**os.environ, 'PYTHONIOENCODING': 'utf-8'},
+        env={
+            **os.environ,
+            'PYTHONIOENCODING': 'utf-8',
+            'PYTHONPATH': str(Path(__file__).parents[2]),
+        },
         encoding='utf-8',
         errors='replace',
     )


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->

Fixes integration test regressions introduced by #8873 . Changes drafted by Claude Opus 5 and reviewed by me (text all mine unless noted):

1. Restore `PolyData._offset_array` for GeoVista (maybe they shouldn't use a private attr, but 🤷 )
2. Add opt-in refleak testing to core, and use it (TDD: fails on `main`, passes on this PR)
3. Don't store the connectivity on `CellArray`, it creates a ref cycle (what MNE's refleak checks pointed out). The history (investigated with Claude) seems to be that  #4637 stored numpy arrays; #5171 (typehints) changed this to VTK arrays, making it redundant. I added `test_cell_array_connectivity_outlives_its_source` to make sure things work as expected (I think!). The `SetData` already sets the C++ refcount higher so it sticks around on its own as `vtkCellArray` owns a reference, without anything owning it at the Python end.
4. Update alert workflow to name the failing commit, which would have immediately pointed (on first comment at least!) at #8873's merge to `main`

Things are okay in MNE-Python with these changes.
<!-- Be sure to link other PRs or issues that relate to this PR here. -->

Closes #8907
<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

☝️ 

... but I would suggest to try using the `check_gc` elsewhere as well to help diagnose other potential similar problems (not in this PR!). Adding it to the whole `core` tests made them take 3x longer, though, and had a number of errors -- it would take some time to sort out the correct paths there. I can look into it a bit with Claude after this if there's appetite for more `refleak` investigation and PRs.
