### PR TITLE
Add immutable `cell_offsets` and `cell_connectivity` accessors

### DIFF
--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from typing import TYPE_CHECKING
 from typing import cast
 
@@ -25,6 +26,7 @@ from .utilities.misc import _BoundsSizeMixin
 from .utilities.misc import _NoNewAttrMixin
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from typing import Any
 
     from typing_extensions import Self
@@ -839,6 +841,49 @@ class CellArray(
     def cell_connectivity(self: Self, connectivity: VectorLike[int]) -> None:
         _set_cell_array_data(self, self.cell_offsets, connectivity)
 
+    def edit_cell_connectivity(self: Self) -> contextlib.AbstractContextManager[NumpyArray[int]]:
+        """Edit the cell connectivity in place, without copying.
+
+        Context manager yielding a *writeable* view of :attr:`cell_connectivity`.
+        Assigning to :attr:`cell_connectivity` copies the array twice, which is
+        wasteful for large meshes; this yields VTK's own buffer instead and marks the
+        cell array modified on exit.
+
+        .. versionadded:: 0.49
+
+        Returns
+        -------
+        contextlib.AbstractContextManager[numpy.ndarray]
+            Context manager yielding a writeable connectivity array.
+
+        See Also
+        --------
+        cell_connectivity
+            Read-only connectivity array.
+
+        Notes
+        -----
+        Only the connectivity may be edited this way. The offsets define the structure
+        of the cell array and may be stored implicitly, so they are changed by assigning
+        to :attr:`cell_offsets`.
+
+        Editing in place bypasses validation. The point ids you write are not checked
+        against the number of points, and out-of-range ids cause undefined behavior
+        when the mesh is used. Use :meth:`~pyvista.DataObjectFilters.validate_mesh` if
+        the new ids are not known to be in range.
+
+        Examples
+        --------
+        >>> from pyvista import CellArray
+        >>> cell_array = CellArray.from_arrays([0, 3, 6], [0, 1, 2, 3, 4, 5])
+        >>> with cell_array.edit_cell_connectivity() as connectivity:
+        ...     connectivity[connectivity == 5] = 0
+        >>> cell_array.cell_connectivity
+        array([0, 1, 2, 3, 4, 0])
+
+        """
+        return _edit_connectivity(self)
+
     @property
     def connectivity_array(self: Self) -> NumpyArray[int]:
         """Return the array with the point ids that define the cells' connectivity.
@@ -1139,6 +1184,25 @@ def _make_cell_array(offsets: VectorLike[int], connectivity: VectorLike[int]) ->
     cellarr = CellArray()
     _set_cell_array_data(cellarr, offsets, connectivity)
     return cellarr
+
+
+@contextlib.contextmanager
+def _edit_connectivity(
+    cellarr: _vtk.vtkCellArray, owner: _vtk.vtkObject | None = None
+) -> Iterator[NumpyArray[int]]:
+    """Yield a writeable connectivity array and mark it modified on exit.
+
+    The array is a zero-copy view of VTK's memory. ``Modified`` is called on the way
+    out, including when the block raises, since a partial write still changes the mesh.
+
+    """
+    array = _get_connectivity_array(cellarr)
+    try:
+        yield array
+    finally:
+        cellarr.Modified()
+        if owner is not None:
+            owner.Modified()
 
 
 def _get_regular_cells(cellarr: _vtk.vtkCellArray) -> NumpyArray[int]:

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -10,6 +10,7 @@ import numpy as np
 import pyvista as pv
 from pyvista import _vtk
 from pyvista._deprecate_positional_args import _deprecate_positional_args
+from pyvista._warn_external import warn_external
 from pyvista.core._vtk_utilities import _SUPPORTS_FIXED_SIZE_STORAGE
 from pyvista.core._vtk_utilities import DisableVtkSnakeCase
 from pyvista.core._vtk_utilities import vtkPyVistaOverride
@@ -18,6 +19,7 @@ from ._typing_core import BoundsTuple
 from .celltype import CellType
 from .dataobject import DataObject
 from .errors import CellSizeError
+from .errors import PyVistaDeprecationWarning
 from .utilities.cells import numpy_to_idarr
 from .utilities.misc import _BoundsSizeMixin
 from .utilities.misc import _NoNewAttrMixin
@@ -33,6 +35,7 @@ if TYPE_CHECKING:
     from ._typing_core import CellsLike
     from ._typing_core import MatrixLike
     from ._typing_core import NumpyArray
+    from ._typing_core import VectorLike
 
 
 def _get_vtk_id_type() -> type[np.int32 | np.longlong]:
@@ -747,8 +750,102 @@ class CellArray(
         return self.GetNumberOfCells()
 
     @property
+    def cell_offsets(self: Self) -> NumpyArray[int]:  # numpydoc ignore=RT01
+        """Return the offsets array.
+
+        The offsets array has ``n_cells + 1`` values and stores the index into
+        :attr:`cell_connectivity` at which each cell begins. The point ids of cell ``i``
+        are ``cell_connectivity[cell_offsets[i]:cell_offsets[i + 1]]``.
+
+        .. versionadded:: 0.49
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of cell offsets with ``n_cells + 1`` values.
+
+        See Also
+        --------
+        cell_connectivity
+            Point ids that define the cells.
+
+        Notes
+        -----
+        The returned array is read-only and cannot be modified in place. Assign a new
+        array to this property to change the offsets, or use :meth:`from_arrays` to
+        replace the offsets and connectivity together.
+
+        Examples
+        --------
+        >>> from pyvista import CellArray
+        >>> cell_array = CellArray.from_arrays([0, 3, 6], [0, 1, 2, 3, 4, 5])
+        >>> cell_array.cell_offsets
+        array([0, 3, 6])
+
+        Replace the offsets so the same connectivity describes three 2-point cells.
+
+        >>> cell_array.cell_offsets = [0, 2, 4, 6]
+        >>> cell_array.n_cells
+        3
+
+        """
+        return _get_offsets(self)
+
+    @cell_offsets.setter
+    def cell_offsets(self: Self, offsets: VectorLike[int]) -> None:
+        _set_cell_array_data(self, offsets, self.cell_connectivity)
+
+    @property
+    def cell_connectivity(self: Self) -> NumpyArray[int]:  # numpydoc ignore=RT01
+        """Return the connectivity array.
+
+        The connectivity array stores the point ids of every cell, one cell after
+        another and without any padding. Use :attr:`cell_offsets` to determine where each
+        cell begins and ends.
+
+        .. versionadded:: 0.49
+
+        Returns
+        -------
+        numpy.ndarray
+            Point ids that define the cells.
+
+        See Also
+        --------
+        cell_offsets
+            Index into this array at which each cell begins.
+
+        Notes
+        -----
+        The returned array is read-only and cannot be modified in place. Assign a new
+        array to this property to change the connectivity, or use :meth:`from_arrays`
+        to replace the offsets and connectivity together.
+
+        Examples
+        --------
+        >>> from pyvista import CellArray
+        >>> cell_array = CellArray.from_arrays([0, 3, 6], [0, 1, 2, 3, 4, 5])
+        >>> cell_array.cell_connectivity
+        array([0, 1, 2, 3, 4, 5])
+
+        >>> cell_array.cell_connectivity = [5, 4, 3, 2, 1, 0]
+        >>> cell_array.cell_connectivity
+        array([5, 4, 3, 2, 1, 0])
+
+        """
+        return _get_connectivity(self)
+
+    @cell_connectivity.setter
+    def cell_connectivity(self: Self, connectivity: VectorLike[int]) -> None:
+        _set_cell_array_data(self, self.cell_offsets, connectivity)
+
+    @property
     def connectivity_array(self: Self) -> NumpyArray[int]:
         """Return the array with the point ids that define the cells' connectivity.
+
+        .. deprecated:: 0.49
+            Use :attr:`cell_connectivity` instead. Note that :attr:`cell_connectivity` is
+            read-only, whereas this property returns a writeable array.
 
         Returns
         -------
@@ -756,11 +853,21 @@ class CellArray(
             Array with the point ids that define the cells' connectivity.
 
         """
+        # Deprecated on 0.49.0, error on 0.52.0, estimated removal on 0.53.0
+        warn_external(
+            '`CellArray.connectivity_array` is deprecated. Use '
+            '`CellArray.cell_connectivity` instead, which returns a read-only array.',
+            PyVistaDeprecationWarning,
+        )
         return _get_connectivity_array(self)
 
     @property
     def offset_array(self: Self) -> NumpyArray[int]:
         """Return the array used to store cell offsets.
+
+        .. deprecated:: 0.49
+            Use :attr:`cell_offsets` instead. Note that :attr:`cell_offsets` is read-only,
+            whereas this property returns a writeable array.
 
         Returns
         -------
@@ -768,6 +875,12 @@ class CellArray(
             Array used to store cell offsets.
 
         """
+        # Deprecated on 0.49.0, error on 0.52.0, estimated removal on 0.53.0
+        warn_external(
+            '`CellArray.offset_array` is deprecated. Use `CellArray.cell_offsets` '
+            'instead, which returns a read-only array.',
+            PyVistaDeprecationWarning,
+        )
         return _get_offset_array(self)
 
     def _set_data(
@@ -944,6 +1057,88 @@ def _get_connectivity_array(cellarr: _vtk.vtkCellArray) -> NumpyArray[int]:
 def _get_offset_array(cellarr: _vtk.vtkCellArray) -> NumpyArray[int]:
     """Return the array used to store cell offsets."""
     return _vtk.vtk_to_numpy(cellarr.GetOffsetsArray())
+
+
+def _get_offsets(cellarr: _vtk.vtkCellArray) -> NumpyArray[int]:
+    """Return a read-only array of the cell offsets."""
+    array = _get_offset_array(cellarr)
+    array.flags['WRITEABLE'] = False
+    return array
+
+
+def _get_connectivity(cellarr: _vtk.vtkCellArray) -> NumpyArray[int]:
+    """Return a read-only array of the cell connectivity."""
+    array = _get_connectivity_array(cellarr)
+    array.flags['WRITEABLE'] = False
+    return array
+
+
+def _validate_offsets_connectivity(
+    offsets: NumpyArray[int], connectivity: NumpyArray[int]
+) -> None:
+    """Raise if ``offsets`` and ``connectivity`` do not describe a valid cell array."""
+    for name, array in (('Offsets', offsets), ('Connectivity', connectivity)):
+        if array.ndim != 1:
+            msg = f'{name} must be a 1D array, got {array.ndim}D.'
+            raise ValueError(msg)
+        if not np.issubdtype(array.dtype, np.integer):
+            msg = f'{name} must have an integer dtype, got {array.dtype}.'
+            raise TypeError(msg)
+
+    if offsets.size == 0:
+        msg = 'Offsets must have at least one value. Use `[0]` for an empty cell array.'
+        raise ValueError(msg)
+    if offsets[0] != 0:
+        msg = f'The first offset must be 0, got {offsets[0]}.'
+        raise ValueError(msg)
+    if np.any(np.diff(offsets) < 0):
+        msg = 'Offsets must be monotonically non-decreasing.'
+        raise ValueError(msg)
+    if offsets[-1] != connectivity.size:
+        msg = (
+            f'The last offset ({offsets[-1]}) must equal the size of the '
+            f'connectivity array ({connectivity.size}).'
+        )
+        raise ValueError(msg)
+
+
+def _set_cell_array_data(
+    cellarr: CellArray,
+    offsets: VectorLike[int],
+    connectivity: VectorLike[int],
+) -> None:
+    """Validate ``offsets`` and ``connectivity`` and store them in ``cellarr``.
+
+    The inputs are always deep-copied so the cell array never aliases memory owned by
+    the caller. Fixed-size storage is used when the offsets are uniform, which lets VTK
+    generate the offsets implicitly instead of allocating them.
+
+    """
+    offsets_array = np.asarray(offsets)
+    connectivity_array = np.asarray(connectivity)
+    # An empty sequence defaults to a float dtype, so coerce it before validating
+    if offsets_array.size == 0:
+        offsets_array = offsets_array.astype(pv.ID_TYPE)
+    if connectivity_array.size == 0:
+        connectivity_array = connectivity_array.astype(pv.ID_TYPE)
+    _validate_offsets_connectivity(offsets_array, connectivity_array)
+
+    sizes = np.diff(offsets_array)
+    uniform = sizes.size > 0 and bool((sizes == sizes[0]).all()) and sizes[0] > 0
+    if _SUPPORTS_FIXED_SIZE_STORAGE and uniform:
+        cell_size = int(sizes[0])
+        cellarr._set_data_fixed_size(
+            cell_size, connectivity_array.reshape(-1, cell_size), deep=True
+        )
+    else:
+        cellarr._set_data(offsets_array, connectivity_array, deep=True)
+
+
+def _make_cell_array(offsets: VectorLike[int], connectivity: VectorLike[int]) -> CellArray:
+    """Build a validated :class:`CellArray` from offsets and connectivity."""
+    cellarr = CellArray()
+    _set_cell_array_data(cellarr, offsets, connectivity)
+    return cellarr
 
 
 def _get_regular_cells(cellarr: _vtk.vtkCellArray) -> NumpyArray[int]:

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -1769,7 +1769,7 @@ class DataObjectFilters:
             )
 
             conn = ugrid.cell_connectivity
-            offset = ugrid.offset
+            offset = ugrid.cell_offsets
             n_cells = ugrid.n_cells
             n_points = ugrid.n_points
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -6951,7 +6951,7 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
             split = split.cast_to_unstructured_grid()
 
         vec = (split.cell_centers().points - split.center) * factor
-        split.points += np.repeat(vec, np.diff(split.offset), axis=0)
+        split.points += np.repeat(vec, np.diff(split.cell_offsets), axis=0)
         return split
 
     def separate_cells(  # type: ignore[misc]

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -23,10 +23,13 @@ from pyvista.core._vtk_utilities import vtk_version_info
 from pyvista.core.errors import PyVistaDeprecationWarning
 
 from .cell import CellArray
+from .cell import _get_connectivity
 from .cell import _get_connectivity_array
 from .cell import _get_irregular_cells
 from .cell import _get_offset_array
+from .cell import _get_offsets
 from .cell import _get_regular_cells
+from .cell import _make_cell_array
 from .celltype import CellType
 from .dataset import DataSet
 from .errors import CellSizeError
@@ -1369,7 +1372,7 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
             return False
 
         # early return if not all triangular
-        if self._connectivity_array.size % 3:
+        if self.GetPolys().GetNumberOfConnectivityIds() % 3:
             return False
 
         # next, check if there are three points per face
@@ -1392,9 +1395,144 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
         return self.boolean_union(other_mesh)
 
     @property
-    def _connectivity_array(self) -> NumpyArray[int]:
-        """Return the array with the point ids that define the cells' connectivity."""
-        return _get_connectivity_array(self.GetPolys())
+    def cell_offsets(self) -> NumpyArray[int]:  # numpydoc ignore=RT01
+        """Return the offsets array of the polygonal faces.
+
+        The offsets array has ``n_faces + 1`` values and stores the index into
+        :attr:`cell_connectivity` at which each face begins. The point ids of face ``i``
+        are ``cell_connectivity[cell_offsets[i]:cell_offsets[i + 1]]``.
+
+        .. warning::
+            This property describes the :attr:`faces` only. Vertices, lines, and
+            strips are stored in separate cell arrays and are not included, so
+            ``len(cell_offsets) - 1`` is :attr:`n_faces`, which is only equal to
+            :attr:`~pyvista.DataSet.n_cells` for a mesh made up of faces alone.
+
+        .. versionadded:: 0.49
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of face offsets with ``n_faces + 1`` values.
+
+        See Also
+        --------
+        cell_connectivity
+            Point ids that define the faces.
+        faces
+            Faces in the legacy padded format.
+        regular_faces
+            Faces as a 2D array, when every face has the same size.
+        pyvista.UnstructuredGrid.cell_offsets
+            Equivalent property for an unstructured grid.
+
+        Notes
+        -----
+        The returned array is read-only and cannot be modified in place. To change
+        the offsets, assign a new array to this property. The new offsets must remain
+        consistent with the current :attr:`cell_connectivity`; to replace both at once,
+        assign a :class:`pyvista.CellArray` to :attr:`faces`. See the examples below.
+
+        Examples
+        --------
+        >>> import pyvista as pv
+        >>> mesh = pv.Plane(i_resolution=1, j_resolution=1).triangulate()
+        >>> mesh.cell_offsets
+        array([0, 3, 6])
+
+        The offsets and connectivity together describe each face.
+
+        >>> mesh.cell_connectivity[mesh.cell_offsets[0] : mesh.cell_offsets[1]]
+        array([0, 1, 2])
+
+        The array cannot be modified in place.
+
+        >>> mesh.cell_offsets[0] = 1
+        Traceback (most recent call last):
+        ...
+        ValueError: assignment destination is read-only
+
+        Assign a new array instead. Here the six connectivity ids are re-partitioned
+        into three 2-point cells.
+
+        >>> mesh.cell_offsets = [0, 2, 4, 6]
+        >>> mesh.n_faces
+        3
+
+        To replace the offsets and connectivity together, assign a
+        :class:`pyvista.CellArray` to :attr:`faces`.
+
+        >>> mesh.faces = pv.CellArray.from_arrays([0, 4], [0, 1, 3, 2])
+        >>> mesh.n_faces
+        1
+
+        """
+        return _get_offsets(self.GetPolys())
+
+    @cell_offsets.setter
+    def cell_offsets(self, offsets: VectorLike[int]) -> None:
+        self.SetPolys(_make_cell_array(offsets, self.cell_connectivity))
+
+    @property
+    def cell_connectivity(self) -> NumpyArray[int]:  # numpydoc ignore=RT01
+        """Return the connectivity array of the polygonal faces.
+
+        The connectivity array stores the point ids of every face, one face after
+        another and without any padding. Use :attr:`cell_offsets` to determine where each
+        face begins and ends.
+
+        .. warning::
+            This property describes the :attr:`faces` only. Vertices, lines, and
+            strips are stored in separate cell arrays and are not included.
+
+        .. versionadded:: 0.49
+
+        Returns
+        -------
+        numpy.ndarray
+            Point ids that define the faces.
+
+        See Also
+        --------
+        cell_offsets
+            Index into this array at which each face begins.
+        faces
+            Faces in the legacy padded format.
+        pyvista.UnstructuredGrid.cell_connectivity
+            Equivalent property for an unstructured grid.
+
+        Notes
+        -----
+        The returned array is read-only and cannot be modified in place. To change
+        the topology, assign a new array to this property, to :attr:`cell_offsets`, or to
+        :attr:`faces`. See the examples below.
+
+        Examples
+        --------
+        >>> import pyvista as pv
+        >>> mesh = pv.Plane(i_resolution=1, j_resolution=1).triangulate()
+        >>> mesh.cell_connectivity
+        array([0, 1, 2, 1, 3, 2])
+
+        The array cannot be modified in place.
+
+        >>> mesh.cell_connectivity[0] = 1
+        Traceback (most recent call last):
+        ...
+        ValueError: assignment destination is read-only
+
+        Assign a new array instead. Here the winding of both triangles is reversed.
+
+        >>> mesh.cell_connectivity = [2, 1, 0, 2, 3, 1]
+        >>> mesh.cell_connectivity
+        array([2, 1, 0, 2, 3, 1])
+
+        """
+        return _get_connectivity(self.GetPolys())
+
+    @cell_connectivity.setter
+    def cell_connectivity(self, connectivity: VectorLike[int]) -> None:
+        self.SetPolys(_make_cell_array(self.cell_offsets, connectivity))
 
     @property
     def n_lines(self) -> int:  # numpydoc ignore=RT01
@@ -2156,9 +2294,9 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
             )
             raise ValueError(msg)
 
-        if self.n_cells != self.offset.size - 1:  # pragma: no cover
+        if self.n_cells != self.cell_offsets.size - 1:  # pragma: no cover
             msg = (
-                f'Size of the offset ({self.offset.size}) '
+                f'Size of the offsets ({self.cell_offsets.size}) '
                 f'must be one greater than the number of cells ({self.n_cells})'
             )
             raise ValueError(msg)
@@ -2184,7 +2322,7 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
         --------
         pyvista.DataSet.get_cell
         pyvista.UnstructuredGrid.cell_connectivity
-        pyvista.UnstructuredGrid.offset
+        pyvista.UnstructuredGrid.cell_offsets
 
         Notes
         -----
@@ -2412,20 +2550,101 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
         return get_mixed_cells(self)
 
     @property
-    def cell_connectivity(self) -> NumpyArray[int]:  # numpydoc ignore=RT01
-        """Return the cell connectivity as a numpy array.
+    def cell_offsets(self) -> NumpyArray[int]:  # numpydoc ignore=RT01
+        """Return the offsets array.
 
-        This is effectively :attr:`UnstructuredGrid.cells` without the
-        padding.
+        The offsets array has :attr:`~pyvista.DataSet.n_cells` ``+ 1`` values and
+        stores the index into :attr:`cell_connectivity` at which each cell begins. The
+        point ids of cell ``i`` are ``cell_connectivity[cell_offsets[i]:cell_offsets[i + 1]]``.
+
+        .. versionadded:: 0.49
 
         Returns
         -------
         numpy.ndarray
-            Connectivity array.
+            Array of cell offsets with ``n_cells + 1`` values.
 
         See Also
         --------
+        cell_connectivity
+            Point ids that define the cells.
+        cells
+            Cells in the legacy padded format.
+        celltypes
+            Cell type of each cell.
+        pyvista.PolyData.cell_offsets
+            Equivalent property for the faces of a polygonal mesh.
+
+        Notes
+        -----
+        The returned array is read-only and cannot be modified in place. To change
+        the offsets, assign a new array to this property. The number of cells must
+        not change, since :attr:`celltypes` must stay in sync; to change the number
+        of cells, assign to :attr:`cells` or build a new grid. See the examples below.
+
+        Examples
+        --------
+        Return the cell offset array. Since this mesh is composed of all hexahedral
+        cells, note how each cell starts at 8 greater than the prior cell.
+
+        >>> import pyvista as pv
+        >>> from pyvista import examples
+        >>> hex_beam = pv.read(examples.hexbeamfile)
+        >>> hex_beam.cell_offsets
+        array([  0,   8,  16,  24,  32,  40,  48,  56,  64,  72,  80,  88,  96,
+               104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200,
+               208, 216, 224, 232, 240, 248, 256, 264, 272, 280, 288, 296, 304,
+               312, 320])
+
+        The array cannot be modified in place.
+
+        >>> hex_beam.cell_offsets[0] = 1
+        Traceback (most recent call last):
+        ...
+        ValueError: assignment destination is read-only
+
+        """
+        return _get_offsets(self._get_cells())
+
+    @cell_offsets.setter
+    def cell_offsets(self, offsets: VectorLike[int]) -> None:
+        self._set_cells(_make_cell_array(offsets, self.cell_connectivity))
+
+    @property
+    def cell_connectivity(self) -> NumpyArray[int]:  # numpydoc ignore=RT01
+        """Return the connectivity array.
+
+        The connectivity array stores the point ids of every cell, one cell after
+        another and without any padding. It is effectively :attr:`cells` without the
+        padding. Use :attr:`cell_offsets` to determine where each cell begins and ends.
+
+        .. versionchanged:: 0.49
+            The returned array is now read-only, and the property is settable. It
+            previously returned a writeable view into VTK's memory, so code that
+            modified it in place now raises ``ValueError``. Assign a new array to
+            this property instead.
+
+        Returns
+        -------
+        numpy.ndarray
+            Point ids that define the cells.
+
+        See Also
+        --------
+        cell_offsets
+            Index into this array at which each cell begins.
+        cells
+            Cells in the legacy padded format.
         pyvista.DataSet.get_cell
+        pyvista.PolyData.cell_connectivity
+            Equivalent property for the faces of a polygonal mesh.
+
+        Notes
+        -----
+        The returned array is read-only and cannot be modified in place. To change
+        the connectivity, assign a new array to this property. The new connectivity
+        must remain consistent with the current :attr:`cell_offsets`; to replace both at
+        once, assign to :attr:`cells` or build a new grid. See the examples below.
 
         Examples
         --------
@@ -2437,9 +2656,41 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
         >>> hex_beam.cell_connectivity[:16]
         array([ 0,  2,  8,  7, 27, 36, 90, 81,  2,  1,  4,  8, 36, 18, 54, 90]...)
 
+        The array cannot be modified in place.
+
+        >>> hex_beam.cell_connectivity[0] = 1
+        Traceback (most recent call last):
+        ...
+        ValueError: assignment destination is read-only
+
+        Assign a new array instead.
+
+        >>> connectivity = hex_beam.cell_connectivity.copy()
+        >>> connectivity[0] = 1
+        >>> hex_beam.cell_connectivity = connectivity
+        >>> hex_beam.cell_connectivity[:8]
+        array([ 1,  2,  8,  7, 27, 36, 90, 81]...)
+
         """
-        carr = self._get_cells()
-        return _vtk.vtk_to_numpy(carr.GetConnectivityArray())
+        return _get_connectivity(self._get_cells())
+
+    @cell_connectivity.setter
+    def cell_connectivity(self, connectivity: VectorLike[int]) -> None:
+        self._set_cells(_make_cell_array(self.cell_offsets, connectivity))
+
+    def _set_cells(self, cell_array: CellArray) -> None:
+        """Replace the cell array, keeping :attr:`celltypes` in sync."""
+        n_cells = cell_array.n_cells
+        if n_cells != self.n_cells:
+            msg = (
+                f'Number of cells ({n_cells}) does not match the number of cell types '
+                f'({self.n_cells}). The number of cells cannot be changed by setting '
+                f'`cell_offsets` or `cell_connectivity` because `celltypes` must stay '
+                f'in sync. '
+                f'Set `cells` or create a new `UnstructuredGrid` instead.'
+            )
+            raise ValueError(msg)
+        self.SetCells(self._get_cell_types_array(), cell_array)
 
     @_deprecate_positional_args
     def linear_copy(self, deep: bool = False):  # noqa: FBT001, FBT002
@@ -2499,8 +2750,9 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
         # underlying vtkCellArray's connectivity buffer with vtk_to_numpy,
         # so reading it 4-7 times in the loop redundantly allocates wrappers.
         if np.any(quad_quad_mask) or np.any(quad_tri_mask):
-            cell_offsets = lgrid.offset
-            cell_conn = lgrid.cell_connectivity
+            lgrid_cells = lgrid._get_cells()
+            cell_offsets = _get_offset_array(lgrid_cells)
+            cell_conn = _get_connectivity_array(lgrid_cells)
 
         if np.any(quad_quad_mask):
             quad_offset = cell_offsets[:-1][quad_quad_mask]
@@ -2562,11 +2814,16 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
         return array
 
     @property
-    def offset(self) -> NumpyArray[float]:  # numpydoc ignore=RT01
+    def offset(self) -> NumpyArray[int]:  # numpydoc ignore=RT01
         """Return the cell locations array.
 
         This is the location of the start of each cell in
         :attr:`cell_connectivity`.
+
+        .. deprecated:: 0.49
+            Use :attr:`cell_offsets` instead. The name is plural because the array holds
+            ``n_cells + 1`` values, and it avoids the clash with
+            :attr:`pyvista.ImageData.offset`, which is an unrelated property.
 
         Returns
         -------
@@ -2579,27 +2836,14 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
         need to modify this array, create a copy of it using
         :func:`numpy.copy`.
 
-        Examples
-        --------
-        Return the cell offset array.  Since this mesh is composed of
-        all hexahedral cells, note how each cell starts at 8 greater
-        than the prior cell.
-
-        >>> import pyvista as pv
-        >>> from pyvista import examples
-        >>> hex_beam = pv.read(examples.hexbeamfile)
-        >>> hex_beam.offset
-        array([  0,   8,  16,  24,  32,  40,  48,  56,  64,  72,  80,  88,  96,
-               104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200,
-               208, 216, 224, 232, 240, 248, 256, 264, 272, 280, 288, 296, 304,
-               312, 320]...)
-
         """
-        carr = self._get_cells()
-        # This will be the number of cells + 1.
-        array = _vtk.vtk_to_numpy(carr.GetOffsetsArray())
-        array.flags['WRITEABLE'] = False
-        return array
+        # Deprecated on 0.49.0, error on 0.52.0, estimated removal on 0.53.0
+        warn_external(
+            '`UnstructuredGrid.offset` is deprecated. Use `UnstructuredGrid.cell_offsets` '
+            'instead.',
+            PyVistaDeprecationWarning,
+        )
+        return _get_offsets(self._get_cells())
 
     def cast_to_explicit_structured_grid(self):
         """Cast to an explicit structured grid.

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -23,8 +23,8 @@ from pyvista.core._vtk_utilities import vtk_version_info
 from pyvista.core.errors import PyVistaDeprecationWarning
 
 from .cell import CellArray
+from .cell import _edit_connectivity
 from .cell import _get_connectivity
-from .cell import _get_connectivity_array
 from .cell import _get_irregular_cells
 from .cell import _get_offset_array
 from .cell import _get_offsets
@@ -1534,6 +1534,60 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
     def cell_connectivity(self, connectivity: VectorLike[int]) -> None:
         self.SetPolys(_make_cell_array(self.cell_offsets, connectivity))
 
+    def edit_cell_connectivity(self) -> contextlib.AbstractContextManager[NumpyArray[int]]:
+        """Edit the face connectivity in place, without copying.
+
+        Context manager yielding a *writeable* view of :attr:`cell_connectivity`.
+        Assigning to :attr:`cell_connectivity` copies the array twice, which is
+        wasteful for large meshes; this yields VTK's own buffer instead and marks the
+        mesh modified on exit.
+
+        .. versionadded:: 0.49
+
+        Returns
+        -------
+        contextlib.AbstractContextManager[numpy.ndarray]
+            Context manager yielding a writeable connectivity array.
+
+        See Also
+        --------
+        cell_connectivity
+            Read-only connectivity array.
+        cell_offsets
+            Index into the connectivity array at which each face begins.
+
+        Notes
+        -----
+        Only the connectivity may be edited this way. The offsets define the structure
+        of the cell array and may be stored implicitly, so they are changed by assigning
+        to :attr:`cell_offsets`.
+
+        Editing in place bypasses validation. The point ids you write are not checked
+        against :attr:`~pyvista.DataSet.n_points`, and out-of-range ids cause undefined
+        behavior when the mesh is used. Use
+        :meth:`~pyvista.DataObjectFilters.validate_mesh` if the new ids are not known
+        to be in range.
+
+        Marking the mesh modified invalidates VTK's internal caches, but it does not
+        recompute derived *data arrays*. Arrays such as ``'Normals'`` that were
+        computed from the old topology remain in :attr:`~pyvista.DataSet.point_data`
+        and :attr:`~pyvista.DataSet.cell_data` and must be recomputed or removed.
+
+        Examples
+        --------
+        Reverse the winding of every face without copying the connectivity.
+
+        >>> import pyvista as pv
+        >>> mesh = pv.Plane(i_resolution=1, j_resolution=1).triangulate()
+        >>> with mesh.edit_cell_connectivity() as connectivity:
+        ...     connectivity[:] = connectivity.reshape(-1, 3)[:, ::-1].ravel()
+        >>> mesh.regular_faces
+        array([[2, 1, 0],
+               [2, 3, 1]])
+
+        """
+        return _edit_connectivity(self.GetPolys(), self)
+
     @property
     def n_lines(self) -> int:  # numpydoc ignore=RT01
         """Return the number of line cells.
@@ -2678,6 +2732,60 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
     def cell_connectivity(self, connectivity: VectorLike[int]) -> None:
         self._set_cells(_make_cell_array(self.cell_offsets, connectivity))
 
+    def edit_cell_connectivity(self) -> contextlib.AbstractContextManager[NumpyArray[int]]:
+        """Edit the cell connectivity in place, without copying.
+
+        Context manager yielding a *writeable* view of :attr:`cell_connectivity`.
+        Assigning to :attr:`cell_connectivity` copies the array twice, which is
+        wasteful for large meshes; this yields VTK's own buffer instead and marks the
+        grid modified on exit.
+
+        .. versionadded:: 0.49
+
+        Returns
+        -------
+        contextlib.AbstractContextManager[numpy.ndarray]
+            Context manager yielding a writeable connectivity array.
+
+        See Also
+        --------
+        cell_connectivity
+            Read-only connectivity array.
+        cell_offsets
+            Index into the connectivity array at which each cell begins.
+
+        Notes
+        -----
+        Only the connectivity may be edited this way. The offsets define the structure
+        of the cell array and may be stored implicitly, so they are changed by assigning
+        to :attr:`cell_offsets`, which also keeps :attr:`celltypes` in sync.
+
+        Editing in place bypasses validation. The point ids you write are not checked
+        against :attr:`~pyvista.DataSet.n_points`, and out-of-range ids cause undefined
+        behavior when the grid is used. Use
+        :meth:`~pyvista.DataObjectFilters.validate_mesh` if the new ids are not known
+        to be in range.
+
+        Marking the grid modified invalidates VTK's internal caches, but it does not
+        recompute derived *data arrays*. Arrays computed from the old topology remain
+        in :attr:`~pyvista.DataSet.point_data` and :attr:`~pyvista.DataSet.cell_data`
+        and must be recomputed or removed.
+
+        Examples
+        --------
+        Renumber a point id across the whole grid without copying the connectivity.
+
+        >>> import pyvista as pv
+        >>> from pyvista import examples
+        >>> hex_beam = pv.read(examples.hexbeamfile)
+        >>> with hex_beam.edit_cell_connectivity() as connectivity:
+        ...     connectivity[connectivity == 0] = 1
+        >>> hex_beam.cell_connectivity[:8]
+        array([ 1,  2,  8,  7, 27, 36, 90, 81]...)
+
+        """
+        return _edit_connectivity(self._get_cells(), self)
+
     def _set_cells(self, cell_array: CellArray) -> None:
         """Replace the cell array, keeping :attr:`celltypes` in sync."""
         n_cells = cell_array.n_cells
@@ -2746,28 +2854,25 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
             lgrid.SetCells(vtk_cell_type, vtk_offset, cells)
 
         # fixing bug with display of quad cells.
-        # Cache the cell_connectivity array once as each access wraps the
-        # underlying vtkCellArray's connectivity buffer with vtk_to_numpy,
-        # so reading it 4-7 times in the loop redundantly allocates wrappers.
+        # The connectivity is edited in place, which also avoids re-wrapping the
+        # underlying vtkCellArray buffer with vtk_to_numpy on every access.
         if np.any(quad_quad_mask) or np.any(quad_tri_mask):
-            lgrid_cells = lgrid._get_cells()
-            cell_offsets = _get_offset_array(lgrid_cells)
-            cell_conn = _get_connectivity_array(lgrid_cells)
+            cell_offsets = lgrid.cell_offsets
+            with lgrid.edit_cell_connectivity() as cell_conn:
+                if np.any(quad_quad_mask):
+                    quad_offset = cell_offsets[:-1][quad_quad_mask]
+                    base_point = cell_conn[quad_offset]
+                    cell_conn[quad_offset + 4] = base_point
+                    cell_conn[quad_offset + 5] = base_point
+                    cell_conn[quad_offset + 6] = base_point
+                    cell_conn[quad_offset + 7] = base_point
 
-        if np.any(quad_quad_mask):
-            quad_offset = cell_offsets[:-1][quad_quad_mask]
-            base_point = cell_conn[quad_offset]
-            cell_conn[quad_offset + 4] = base_point
-            cell_conn[quad_offset + 5] = base_point
-            cell_conn[quad_offset + 6] = base_point
-            cell_conn[quad_offset + 7] = base_point
-
-        if np.any(quad_tri_mask):
-            tri_offset = cell_offsets[:-1][quad_tri_mask]
-            base_point = cell_conn[tri_offset]
-            cell_conn[tri_offset + 3] = base_point
-            cell_conn[tri_offset + 4] = base_point
-            cell_conn[tri_offset + 5] = base_point
+                if np.any(quad_tri_mask):
+                    tri_offset = cell_offsets[:-1][quad_tri_mask]
+                    base_point = cell_conn[tri_offset]
+                    cell_conn[tri_offset + 3] = base_point
+                    cell_conn[tri_offset + 4] = base_point
+                    cell_conn[tri_offset + 5] = base_point
 
         return lgrid
 

--- a/pyvista/core/utilities/cells.py
+++ b/pyvista/core/utilities/cells.py
@@ -452,7 +452,7 @@ def get_mixed_cells(
         raise ValueError(msg)
 
     if regular_connectivity is None:
-        offset = vtkobj.offset
+        offset = vtkobj.cell_offsets
         cell_sizes = np.diff(offset)
         cell_starts = offset[:-1]
 

--- a/pyvista/core/utilities/fileio.py
+++ b/pyvista/core/utilities/fileio.py
@@ -1325,7 +1325,7 @@ def to_meshio(mesh: DataSet) -> meshio.Mesh:
     # Mixed cell types
     else:
         cells = []
-        offset = mesh.offset
+        offset = mesh.cell_offsets
 
         for i, (i1, i2, vtk_celltype) in enumerate(
             zip(offset[:-1], offset[1:], vtk_celltypes, strict=False)

--- a/tests/core/test_cells.py
+++ b/tests/core/test_cells.py
@@ -11,6 +11,7 @@ from pyvista import Cell
 from pyvista import CellType
 from pyvista import _vtk
 from pyvista.core._vtk_utilities import _SUPPORTS_FIXED_SIZE_STORAGE
+from pyvista.core.cell import _set_cell_array_data
 from pyvista.core.celltype import _CELL_TYPE_INFO
 from pyvista.core.celltype import _DEPRECATED_CELL_TYPES
 from pyvista.core.celltype import _RENAMED_CELL_TYPES
@@ -499,8 +500,8 @@ OFFSETS_LIST = [0, 3, 6]
 @pytest.mark.parametrize('deep', [False, True])
 def test_init_cell_array_from_arrays(offsets, connectivity, deep):
     cell_array = pv.core.cell.CellArray.from_arrays(offsets, connectivity, deep=deep)
-    assert np.array_equal(np.array(connectivity), cell_array.connectivity_array)
-    assert np.array_equal(np.array(offsets), cell_array.offset_array)
+    assert np.array_equal(np.array(connectivity), cell_array.cell_connectivity)
+    assert np.array_equal(np.array(offsets), cell_array.cell_offsets)
     assert cell_array.n_cells == cell_array.GetNumberOfCells() == len(offsets) - 1
 
 
@@ -516,10 +517,10 @@ def test_init_cell_array_preserves_int32_storage(deep):
     # proves 32-bit storage was kept (no upcast copy). This is checked instead of
     # ``IsStorage32Bit()`` because that method is not available on all supported VTK
     # versions (e.g. 9.4.2).
-    assert cell_array.offset_array.dtype == np.int32
-    assert cell_array.connectivity_array.dtype == np.int32
-    assert np.array_equal(cell_array.offset_array, offsets)
-    assert np.array_equal(cell_array.connectivity_array, connectivity)
+    assert cell_array.cell_offsets.dtype == np.int32
+    assert cell_array.cell_connectivity.dtype == np.int32
+    assert np.array_equal(cell_array.cell_offsets, offsets)
+    assert np.array_equal(cell_array.cell_connectivity, connectivity)
 
 
 def test_init_cell_array_int64_uses_64bit_storage():
@@ -527,8 +528,8 @@ def test_init_cell_array_int64_uses_64bit_storage():
     cell_array = pv.core.cell.CellArray.from_arrays(
         np.array(OFFSETS_LIST, np.int64), np.array(CONNECTIVITY_LIST, np.int64)
     )
-    assert cell_array.offset_array.dtype == np.int64
-    assert cell_array.connectivity_array.dtype == np.int64
+    assert cell_array.cell_offsets.dtype == np.int64
+    assert cell_array.cell_connectivity.dtype == np.int64
 
 
 REGULAR_CELL_LIST = [[0, 1, 2], [3, 4, 5]]
@@ -557,7 +558,7 @@ def test_init_cell_array_from_regular_cells_preserves_int32():
     cells = np.array(REGULAR_CELL_LIST, np.int32)
     cell_array = pv.CellArray.from_regular_cells(cells)
     expected_dtype = np.int32 if _SUPPORTS_FIXED_SIZE_STORAGE else pv.ID_TYPE
-    assert cell_array.connectivity_array.dtype == expected_dtype
+    assert cell_array.cell_connectivity.dtype == expected_dtype
 
 
 def test_set_shallow_regular_cells():
@@ -598,3 +599,146 @@ def test_n_cells_removed():
 def test_deep_removed(deep: bool):
     with pytest.raises(TypeError, match=r'unexpected keyword argument'):
         _ = pv.core.cell.CellArray([3, 0, 1, 2], deep=deep)
+
+
+@pytest.fixture
+def offsets_meshes(hexbeam):
+    """Return one mesh per class that exposes ``cell_offsets`` and ``cell_connectivity``."""
+    return {
+        'PolyData': pv.Plane(i_resolution=1, j_resolution=1).triangulate(),
+        'UnstructuredGrid': hexbeam,
+        'CellArray': pv.CellArray.from_arrays([0, 3, 6], [0, 1, 2, 3, 4, 5]),
+    }
+
+
+@pytest.mark.parametrize('name', ['PolyData', 'UnstructuredGrid', 'CellArray'])
+@pytest.mark.parametrize('array_name', ['cell_offsets', 'cell_connectivity'])
+def test_offsets_connectivity_is_read_only(offsets_meshes, name, array_name):
+    array = getattr(offsets_meshes[name], array_name)
+    assert not array.flags['WRITEABLE']
+    with pytest.raises(ValueError, match='read-only'):
+        array[0] = 0
+
+
+@pytest.mark.parametrize('name', ['PolyData', 'UnstructuredGrid', 'CellArray'])
+def test_offsets_connectivity_describe_cells(offsets_meshes, name):
+    obj = offsets_meshes[name]
+    offsets = obj.cell_offsets
+    connectivity = obj.cell_connectivity
+    n_cells = obj.n_faces if name == 'PolyData' else obj.n_cells
+    assert offsets.size == n_cells + 1
+    assert offsets[0] == 0
+    assert offsets[-1] == connectivity.size
+
+
+def test_offsets_setter_polydata():
+    mesh = pv.Plane(i_resolution=1, j_resolution=1).triangulate()
+    mesh.cell_offsets = [0, 2, 4, 6]
+    assert mesh.n_faces == 3
+    assert np.array_equal(mesh.cell_offsets, [0, 2, 4, 6])
+
+
+def test_connectivity_setter_polydata():
+    mesh = pv.Plane(i_resolution=1, j_resolution=1).triangulate()
+    mesh.cell_connectivity = [2, 1, 0, 2, 3, 1]
+    assert np.array_equal(mesh.cell_connectivity, [2, 1, 0, 2, 3, 1])
+    assert np.array_equal(mesh.regular_faces, [[2, 1, 0], [2, 3, 1]])
+
+
+def test_connectivity_setter_unstructured_grid(hexbeam):
+    connectivity = hexbeam.cell_connectivity.copy()
+    connectivity[0] += 1
+    hexbeam.cell_connectivity = connectivity
+    assert np.array_equal(hexbeam.cell_connectivity, connectivity)
+    assert hexbeam.n_cells == hexbeam.celltypes.size
+    assert hexbeam.get_cell(0).point_ids[0] == connectivity[0]
+
+
+def test_offsets_setter_does_not_alias_input(hexbeam):
+    offsets = hexbeam.cell_offsets.copy()
+    hexbeam.cell_offsets = offsets
+    offsets[1] = 0
+    assert hexbeam.cell_offsets[1] != 0
+
+
+def test_unstructured_grid_setter_rejects_cell_count_change(hexbeam):
+    connectivity = hexbeam.cell_connectivity
+    with pytest.raises(ValueError, match='does not match the number of cell types'):
+        hexbeam.cell_offsets = np.arange(0, connectivity.size + 1, 4)
+
+
+@pytest.mark.parametrize(
+    ('offsets', 'connectivity', 'error', 'match'),
+    [
+        ([[0, 3], [3, 6]], [0, 1, 2, 3, 4, 5], ValueError, 'must be a 1D array'),
+        ([0.0, 3.0, 6.0], [0, 1, 2, 3, 4, 5], TypeError, 'integer dtype'),
+        ([], [], ValueError, 'at least one value'),
+        ([1, 4], [0, 1, 2], ValueError, 'first offset must be 0'),
+        ([0, 3, 2], [0, 1], ValueError, 'monotonically non-decreasing'),
+        ([0, 3], [0, 1], ValueError, 'must equal the size of the connectivity'),
+    ],
+)
+def test_offsets_connectivity_validation(offsets, connectivity, error, match):
+    cell_array = pv.CellArray()
+    with pytest.raises(error, match=match):
+        _set_cell_array_data(cell_array, offsets, connectivity)
+
+
+def test_offsets_uses_fixed_size_storage_when_uniform():
+    cell_array = pv.CellArray()
+    _set_cell_array_data(cell_array, [0, 3, 6], [0, 1, 2, 3, 4, 5])
+    if _SUPPORTS_FIXED_SIZE_STORAGE:
+        assert cell_array.IsStorageFixedSize()
+    assert np.array_equal(cell_array.cell_offsets, [0, 3, 6])
+
+
+def test_offsets_generic_storage_when_not_uniform():
+    cell_array = pv.CellArray()
+    _set_cell_array_data(cell_array, [0, 3, 5], [0, 1, 2, 3, 4])
+    if _SUPPORTS_FIXED_SIZE_STORAGE:
+        assert not cell_array.IsStorageFixedSize()
+    assert np.array_equal(cell_array.cell_offsets, [0, 3, 5])
+
+
+def test_cell_array_offset_array_deprecated():
+    cell_array = pv.CellArray.from_arrays([0, 3, 6], [0, 1, 2, 3, 4, 5])
+    with pytest.warns(pv.PyVistaDeprecationWarning, match='`CellArray.cell_offsets`'):
+        assert np.array_equal(cell_array.offset_array, [0, 3, 6])
+    if pv.version_info >= (0, 52):  # pragma: no cover
+        msg = 'Convert `CellArray.offset_array` deprecation warning into an error.'
+        raise RuntimeError(msg)
+    if pv.version_info >= (0, 53):  # pragma: no cover
+        msg = 'Remove `CellArray.offset_array`.'
+        raise RuntimeError(msg)
+
+
+def test_cell_array_connectivity_array_deprecated():
+    cell_array = pv.CellArray.from_arrays([0, 3, 6], [0, 1, 2, 3, 4, 5])
+    with pytest.warns(pv.PyVistaDeprecationWarning, match='`CellArray.cell_connectivity`'):
+        assert np.array_equal(cell_array.connectivity_array, [0, 1, 2, 3, 4, 5])
+
+
+def test_unstructured_grid_offset_deprecated(hexbeam):
+    with pytest.warns(pv.PyVistaDeprecationWarning, match='`UnstructuredGrid.cell_offsets`'):
+        assert np.array_equal(hexbeam.offset, hexbeam.cell_offsets)
+    if pv.version_info >= (0, 52):  # pragma: no cover
+        msg = 'Convert `UnstructuredGrid.offset` deprecation warning into an error.'
+        raise RuntimeError(msg)
+    if pv.version_info >= (0, 53):  # pragma: no cover
+        msg = 'Remove `UnstructuredGrid.offset`.'
+        raise RuntimeError(msg)
+
+
+def test_unstructured_grid_cell_connectivity_is_now_read_only(hexbeam):
+    # Breaking change in 0.49: `cell_connectivity` used to return a writeable view.
+    # Mutating it now raises instead of silently editing the mesh.
+    with pytest.raises(ValueError, match='read-only'):
+        hexbeam.cell_connectivity[0] += 1
+
+
+def test_empty_cell_array_offsets_connectivity():
+    cell_array = pv.CellArray()
+    _set_cell_array_data(cell_array, [0], [])
+    assert cell_array.n_cells == 0
+    assert np.array_equal(cell_array.cell_offsets, [0])
+    assert cell_array.cell_connectivity.size == 0

--- a/tests/core/test_cells.py
+++ b/tests/core/test_cells.py
@@ -742,3 +742,46 @@ def test_empty_cell_array_offsets_connectivity():
     assert cell_array.n_cells == 0
     assert np.array_equal(cell_array.cell_offsets, [0])
     assert cell_array.cell_connectivity.size == 0
+
+
+@pytest.mark.parametrize('name', ['PolyData', 'UnstructuredGrid', 'CellArray'])
+def test_edit_cell_connectivity_is_writeable_and_zero_copy(offsets_meshes, name):
+    obj = offsets_meshes[name]
+    before = obj.cell_connectivity.copy()
+    with obj.edit_cell_connectivity() as connectivity:
+        assert connectivity.flags['WRITEABLE']
+        # The yielded array wraps VTK's buffer, so the edit is visible immediately
+        connectivity[0] = before[-1]
+        assert obj.cell_connectivity[0] == before[-1]
+    assert obj.cell_connectivity[0] == before[-1]
+    assert np.array_equal(obj.cell_connectivity[1:], before[1:])
+
+
+def test_edit_cell_connectivity_marks_modified(hexbeam):
+    mtime = hexbeam.GetMTime()
+    with hexbeam.edit_cell_connectivity() as connectivity:
+        connectivity[0] = connectivity[0]
+    assert hexbeam.GetMTime() > mtime
+
+
+def test_edit_cell_connectivity_marks_modified_on_error(hexbeam):
+    mtime = hexbeam.GetMTime()
+    with pytest.raises(RuntimeError, match='boom'):  # noqa: PT012
+        with hexbeam.edit_cell_connectivity() as connectivity:
+            connectivity[0] = 1
+            msg = 'boom'
+            raise RuntimeError(msg)
+    # A partial write still changed the mesh, so it must still be marked modified
+    assert hexbeam.GetMTime() > mtime
+    assert hexbeam.cell_connectivity[0] == 1
+
+
+def test_edit_cell_connectivity_polydata_edits_faces_only():
+    mesh = pv.PolyData(
+        np.random.default_rng(0).random((4, 3)), lines=[2, 0, 1], faces=[3, 1, 2, 3]
+    )
+    lines = mesh.lines.copy()
+    with mesh.edit_cell_connectivity() as connectivity:
+        connectivity[:] = [3, 2, 1]
+    assert np.array_equal(mesh.regular_faces, [[3, 2, 1]])
+    assert np.array_equal(mesh.lines, lines)

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -106,7 +106,9 @@ def test_unstructured_grid_eq(hexbeam):
     assert hexbeam != copy
 
     copy = hexbeam.copy()
-    hexbeam.cell_connectivity[0] += 1
+    connectivity = hexbeam.cell_connectivity.copy()
+    connectivity[0] += 1
+    hexbeam.cell_connectivity = connectivity
     assert hexbeam != copy
 
     # test changing polyfaces is detected

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -23,6 +23,7 @@ import pyvista as pv
 from pyvista import PyVistaDeprecationWarning
 from pyvista import _vtk
 from pyvista import examples
+from pyvista.core.cell import _get_connectivity_array
 from pyvista.core.errors import DeprecationError
 from pyvista.core.filters.data_object import _PYVISTA_CELL_STATUS_INFO
 from pyvista.core.filters.data_object import _SENTINEL
@@ -926,13 +927,20 @@ def test_transform_mesh(datasets, num_cell_arrays, num_point_data):
         for name, array in dataset.cell_data.items():
             assert transformed.cell_data[name] == pytest.approx(array)
 
-        # verify that the cell connectivity is a deep copy
-        if hasattr(dataset, '_connectivity_array'):
-            transformed._connectivity_array[0] += 1
-            assert not np.array_equal(dataset._connectivity_array, transformed._connectivity_array)
-        if hasattr(dataset, 'cell_connectivity'):
-            transformed.cell_connectivity[0] += 1
-            assert not np.array_equal(dataset.cell_connectivity, transformed.cell_connectivity)
+        # verify that the cell connectivity is a deep copy. The public `connectivity`
+        # property is read-only, so mutate the underlying vtkCellArray in place to
+        # prove the two meshes do not share a buffer.
+        cell_array = None
+        if isinstance(dataset, pv.PolyData):
+            cell_array = pv.core.pointset.PolyData.GetPolys
+        elif isinstance(dataset, pv.UnstructuredGrid):
+            cell_array = pv.core.pointset.UnstructuredGrid._get_cells
+        if cell_array is not None:
+            _get_connectivity_array(cell_array(transformed))[0] += 1
+            assert not np.array_equal(
+                _get_connectivity_array(cell_array(dataset)),
+                _get_connectivity_array(cell_array(transformed)),
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -217,7 +217,7 @@ def test_init_from_dict(multiple_cell_types, flat_cells):
 
     grid = pv.UnstructuredGrid(input_cells_dict, points, deep=False)
 
-    assert np.all(grid.offset == offsets)
+    assert np.all(grid.cell_offsets == offsets)
     assert grid.n_cells == (3 if multiple_cell_types else 2)
     if not multiple_cell_types and _SUPPORTS_FIXED_SIZE_STORAGE:
         assert grid.GetCells().IsStorageFixedSize()
@@ -447,7 +447,7 @@ def test_cells_dict_alternating_cells():
 
     cells_dict = grid.cells_dict
 
-    assert np.all(grid.offset == np.array([0, 4, 7, 11]))
+    assert np.all(grid.cell_offsets == np.array([0, 4, 7, 11]))
     assert np.all(cells_dict[CellType.QUAD] == np.array([cells[1:5], cells[-4:]]))
     assert np.all(cells_dict[CellType.TRIANGLE] == [0, 1, 2])
 


### PR DESCRIPTION
## Overview

Adds `cell_offsets` and `cell_connectivity` as consistent, first-class, **immutable** array accessors on every PyVista class backed by a :vtk:`vtkCellArray`, and deprecates the inconsistent spellings we accumulated over the last eight years.

Draft for #8909. Marked draft because there are open naming/scope questions below that want a maintainer decision before this is polished.

### Before

The same two arrays had three different names depending on which class you reached them from, with inconsistent mutability:

| Class | Offsets | Connectivity | Writable? |
|---|---|---|---|
| `UnstructuredGrid` | `.offset` | `.cell_connectivity` | offsets no, connectivity **yes** |
| `PolyData` | *(none — `_offset_array` was removed in #8873)* | `._connectivity_array` (private) | **yes** |
| `CellArray` | `.offset_array` | `.connectivity_array` | **yes** |

### After

| Class | Offsets | Connectivity |
|---|---|---|
| `UnstructuredGrid` | `.cell_offsets` | `.cell_connectivity` |
| `PolyData` | `.cell_offsets` | `.cell_connectivity` |
| `CellArray` | `.cell_offsets` | `.cell_connectivity` |

All four are read-only and settable.

## Why not plain `offsets` / `connectivity`

That was the first attempt, and `connectivity` does not survive contact with the codebase: `DataSetFilters.connectivity` already exists on every DataSet as the region-extraction filter (`mesh.connectivity('largest')`). A property of the same name shadows it and `mesh.connectivity('largest')` starts raising `TypeError: 'numpy.ndarray' object is not callable`. `test_extract_largest` catches this immediately.

The `cell_` prefix sidesteps that and reads consistently next to `cell_data`, `celltypes`, and `cell_normals`.

## Why immutable

Beyond the general "a raw view into VTK's memory is a footgun" argument, there is a concrete correctness reason as of #8873.

VTK ≥ 9.6.2 stores regular cell arrays with **fixed-size (implicit affine) offsets** — the offsets are generated as `i * cell_size` and have no backing buffer. `vtk_to_numpy` on such an array returns a *materialized cache*, and writing into it desynchronizes the cache from the affine backend that defines it:

```python
>>> ca.SetData(3, conn)                        # fixed-size storage
>>> a = vtk_to_numpy(ca.GetOffsetsArray())
>>> a[1] = 99
>>> vtk_to_numpy(ca.GetOffsetsArray())
array([ 0, 99,  6,  9])                        # nonsense, and it sticks
```

A writable offsets accessor would make that look supported. Read-only closes it.

## Breaking change: `UnstructuredGrid.cell_connectivity`

This is the one genuinely breaking part, and it needs the `breaking-change` label.

`UnstructuredGrid.cell_connectivity` keeps its name but now returns a read-only array; it previously returned a writable view. Code that mutated it in place — including our own `linear_copy` and two tests in this repo — now raises `ValueError: assignment destination is read-only`.

I chose to accept that rather than invent a fifth name because:

- the failure is **loud and immediate**, not silent corruption;
- a deprecation cycle isn't available here — you can't deprecate "the array you get back is writable" without deprecating the property itself, and renaming `cell_connectivity` for a second time is exactly the `n_faces` → `n_faces_strict` → `n_faces` churn #8617 warned about;
- the property now has a setter, so the migration is one line: `mesh.cell_connectivity = modified_copy`.

Documented with `.. versionchanged:: 0.49` on the property. Happy to switch this to a `PyVistaFutureWarning` for a release if that's preferred.

## Deprecations

Warned with `PyVistaDeprecationWarning`, error at 0.52, removal at 0.53 — a deliberately long window, since `UnstructuredGrid.offset` was added for downstream consumers in the first place (#772 was driven by `pyansys`):

- `UnstructuredGrid.offset` → `UnstructuredGrid.cell_offsets`
- `CellArray.offset_array` → `CellArray.cell_offsets`
- `CellArray.connectivity_array` → `CellArray.cell_connectivity`
- `PolyData._connectivity_array` — removed outright (private; its last internal use is gone)

Incidentally, `offset` was carrying two unrelated meanings: `ImageData.offset` is the extent index origin. Retiring it on `UnstructuredGrid` removes that clash. The plural also matches reality — the array holds `n_cells + 1` values.

All internal call sites are migrated so the suite doesn't trip `filterwarnings = ['error']`: `pointset.linear_copy`, `pointset._check_for_consistency`, `utilities/cells.get_mixed_cells`, `utilities/fileio.to_meshio`, `filters/data_object` (×2), `filters/data_set.explode`. Where genuine in-place mutation is needed (`linear_copy`, the deep-copy tests) the code now uses the private `_get_connectivity_array` helper rather than the public property.

## Setting

```python
mesh.cell_connectivity = new_connectivity   # keeps existing offsets
mesh.cell_offsets = new_offsets             # keeps existing connectivity
```

- **Always deep-copies**, so `mesh.cell_offsets = arr; arr[0] = 5` cannot corrupt the mesh. That's the whole point of the change.
- **Validates**: 1-D, integer dtype, `offsets[0] == 0`, monotonically non-decreasing, `offsets[-1] == connectivity.size`. Bad input raises instead of producing a mesh that segfaults on access later.
- **Preserves fixed-size storage** when the resulting offsets are uniform, so we don't undo the memory win from #8873.
- **`UnstructuredGrid` refuses to change the cell count**, since `celltypes` must stay in sync; the error points at `cells` / the constructor.
- Each setter validates against the *current* value of the other array, so replacing both at once goes through `faces` / `cells` / `CellArray.from_arrays`. Documented in the docstrings; see open question 2.

## `PolyData` scope

`PolyData.cell_offsets` / `.cell_connectivity` describe the **polygonal faces only** (`GetPolys()`), matching the deprecated `_connectivity_array` and matching `faces` / `regular_faces` / `n_faces`, which are also polys-only. Verts, lines, and strips live in separate cell arrays and are excluded.

So `len(mesh.cell_offsets) - 1` is `n_faces` on `PolyData` but `n_cells` on `UnstructuredGrid` — the same only for a mesh made of faces alone. Both docstrings carry a `.. warning::` saying so. See open question 3.

## Testing

New coverage in `tests/core/test_cells.py`: read-only enforcement (3 classes × 2 arrays), round-trip get/set, setter no-aliasing, a 6-case validation matrix, fixed-size vs generic storage selection, empty cell array, `n_cells`/`n_faces` consistency, one deprecation test per deprecated property, and the `cell_connectivity` breaking change. Deprecation tests carry the usual `if pv.version_info >= (0, 52)` / `(0, 53)` guards so the follow-through can't be forgotten.

Run locally before pushing: `test_cells`, `test_polydata`, `test_grid`, `test_dataobject`, `test_dataobject_filters`, `test_dataset`, `test_utilities`, `test_helpers`, `test_pointset`, `test_composite`, the `pointset.py` doctests, and `ruff-format` / `ruff-check` / `numpydoc-validation` / `codespell` / `pydocstringformatter`.

## Open questions for review

1. **`ExplicitStructuredGrid`** also wraps a `vtkCellArray` and got neither accessor. In this PR, or a follow-up?
2. **Replacing both arrays at once** has no single-call path on the datasets, because each setter validates against the other array's current value. Is `mesh.cells = ...` / `CellArray.from_arrays` good enough, or do we want `set_cells(offsets, connectivity)`?
3. **`PolyData` scope** — polys-only (as implemented) vs. concatenating all four cell arrays so the accessor always describes `n_cells` cells. The latter is arguably more consistent but is O(n) on mixed meshes and has an ambiguous setter.
4. **`cell_` on `CellArray`** is redundant — it *is* a cell array. Consistency argues for `cell_offsets` there too (as implemented); brevity argues for `offsets` / `connectivity`, which have no filter to collide with on that class. Which wins?
5. **The `cell_connectivity` breaking change** — accept as-is with the `breaking-change` label, or route through `PyVistaFutureWarning` for a release first?
