### PR TITLE
Speed up the test leak check by freezing the heap

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,15 +5,12 @@ import functools
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import requires
 from importlib.metadata import version
+import importlib.util
 import inspect
 import os
 import platform
 import re
 
-from hypothesis import HealthCheck
-from hypothesis import given
-from hypothesis import settings
-from hypothesis import strategies as st
 import numpy as np
 from numpy.random import default_rng
 import PIL
@@ -373,6 +370,15 @@ def pytest_sessionstart():
     Hypothesis stops treating the process as still initializing; before that it warns
     about strategies being evaluated in a plugin.
     """
+    # The docs-test dependency group installs no Hypothesis, and this conftest still has
+    # to import under it, so probe for the package instead of importing it at module scope.
+    if importlib.util.find_spec('hypothesis') is None:
+        return
+
+    from hypothesis import HealthCheck
+    from hypothesis import given
+    from hypothesis import settings
+    from hypothesis import strategies as st
 
     @settings(
         max_examples=1, deadline=None, database=None, suppress_health_check=list(HealthCheck)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,10 @@ import os
 import platform
 import re
 
+from hypothesis import HealthCheck
+from hypothesis import given
+from hypothesis import settings
+from hypothesis import strategies as st
 import numpy as np
 from numpy.random import default_rng
 import PIL
@@ -340,6 +344,38 @@ def texture():
 @pytest.fixture
 def image(texture):
     return texture.to_image()
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_sessionstart():
+    """Register Hypothesis' global PRNG now, while the heap is still thawed.
+
+    The leak check freezes the heap for the whole body of every test it covers (see
+    :mod:`tests.gc_check`), and ``gc.get_referrers()`` does not look in the permanent
+    generation. Hypothesis creates and registers its global PRNG lazily, on the first
+    ``@given`` test in the process, and ``register_random`` sanity-checks that PRNG with
+    ``gc.get_referrers()``. Run inside a frozen body, that comes back empty, so Hypothesis
+    warns that the PRNG looks collectable -- and ``filterwarnings = ['error']`` turns the
+    warning into a failure of whichever test happened to be the first one. Which test that
+    is depends on how xdist shards the run, so it fails a different test every time, or
+    none at all.
+
+    Running one throwaway example here does that registration once, at session start,
+    where nothing is frozen. Deleting this brings the intermittent failures back.
+
+    ``trylast`` so it runs after Hypothesis' own ``pytest_sessionstart``, which is where
+    Hypothesis stops treating the process as still initializing; before that it warns
+    about strategies being evaluated in a plugin.
+    """
+
+    @settings(
+        max_examples=1, deadline=None, database=None, suppress_health_check=list(HealthCheck)
+    )
+    @given(_=st.none())
+    def warm_up_prng(_):
+        pass
+
+    warm_up_prng()
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -356,12 +356,18 @@ def pytest_sessionstart():
     ``@given`` test in the process, and ``register_random`` sanity-checks that PRNG with
     ``gc.get_referrers()``. Run inside a frozen body, that comes back empty, so Hypothesis
     warns that the PRNG looks collectable -- and ``filterwarnings = ['error']`` turns the
-    warning into a failure of whichever test happened to be the first one. Which test that
-    is depends on how xdist shards the run, so it fails a different test every time, or
-    none at all.
+    warning into a failure of that first test.
+
+    Two conditions have to line up for that. On Python 3.14 ``threading.local()``
+    allocates its per-thread dict at construction, so the dict holding the PRNG is built
+    when ``hypothesis.core`` is imported and lands in the permanent generation; through
+    3.13 it is created on first access, inside the frozen window, where it stays visible.
+    And the lazy ``register_random`` only runs under ``derandomize=True``, which comes
+    from Hypothesis' ``ci`` profile, auto-loaded when ``CI`` is set. A local run on 3.13,
+    or without ``CI``, will not reproduce it; xdist only picks which test takes the hit.
 
     Running one throwaway example here does that registration once, at session start,
-    where nothing is frozen. Deleting this brings the intermittent failures back.
+    where nothing is frozen. Deleting this brings the failures back.
 
     ``trylast`` so it runs after Hypothesis' own ``pytest_sessionstart``, which is where
     Hypothesis stops treating the process as still initializing; before that it warns

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -10,9 +10,10 @@ Modules owning dataset construction opt in with::
 
     pytestmark = pytest.mark.check_gc
 
-Opt-in rather than autouse because the check walks the heap twice per test -- 4x the
-runtime over all of ``tests/core`` -- and ~70 core tests hold VTK objects past teardown
-today. Widening the opt-in as those are cleaned up is the point.
+Opt-in rather than autouse only because ~70 core tests hold VTK objects past teardown
+today; widening it as those are cleaned up is the point. Cost is no longer a reason:
+since the check freezes the heap rather than scanning it, running it over all 7,559
+tests here takes less time than running it over 397 of them did.
 """
 
 from __future__ import annotations

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -12,8 +12,8 @@ Modules owning dataset construction opt in with::
 
 Opt-in rather than autouse only because ~70 core tests hold VTK objects past teardown
 today; widening it as those are cleaned up is the point. Cost is no longer a reason:
-since the check freezes the heap rather than scanning it, running it over all 7,559
-tests here takes less time than running it over 397 of them did.
+since the check freezes the heap rather than scanning it, running it over every test
+here takes less time than running it over the 397 it started with did.
 """
 
 from __future__ import annotations

--- a/tests/core/test_gc.py
+++ b/tests/core/test_gc.py
@@ -1,18 +1,19 @@
-"""The core leak check must fail on a real leak.
+"""The core leak check must fail on a leak only it can see.
 
-``tests/plotting/test_gc.py`` does this for the plotting check. Core runs the
-stricter half of the same machinery -- no ghost sweep before reporting, because
-the sweep is what let #8873 through -- and nothing held it to catching anything
-until now.
+``tests/plotting/test_gc.py`` already covers the leaks both checks catch. What
+is left for core is the one its own policy exists for: it does not sweep VTK's
+ghost map before reporting, and that sweep is what let #8873 through. Planted
+under the plotting policy, the leak below does not fail the check at all.
 
-Each test here plants a leak and is marked ``expect_check_gc_fail``, so the
-teardown check is asserted to *fail*. A change that quietly stops detecting one
-of these turns its test red.
+``expect_check_gc_fail`` asserts the teardown check *fails*, so a change that
+quietly stops detecting the leak turns the test red.
+``test_no_leak_when_nothing_is_held`` is what stops that passing on a check
+that simply fails on everything.
+
+The machinery both suites share is tested in ``tests/test_gc_check.py``.
 """
 
 from __future__ import annotations
-
-import gc
 
 import pytest
 
@@ -23,21 +24,6 @@ pytestmark = pytest.mark.check_gc
 
 
 @pytest.mark.expect_check_gc_fail
-def test_leak_self_referencing_vtk_object() -> None:
-    """A VTK object in a cycle with itself."""
-    source = _vtk.vtkSphereSource()
-    source.self_ref = source
-
-
-@pytest.mark.expect_check_gc_fail
-def test_leak_pyvista_wrapper() -> None:
-    """The same, reached through a pyvista wrapper rather than a raw VTK one."""
-    mesh = pv.Sphere()
-    points = mesh.points
-    points.VTKObject._ref = points
-
-
-@pytest.mark.expect_check_gc_fail
 def test_leak_ghosted_attribute_dict() -> None:
     """A VTK object stashed on a wrapper whose C++ object outlives it.
 
@@ -45,7 +31,7 @@ def test_leak_ghosted_attribute_dict() -> None:
     dies while its C++ object is still referenced, so it can restore it if that
     object resurfaces in Python, and anything the dict holds stays alive with
     it. The map is only swept when a new ghost is added, so the entry outlives
-    the mesh -- which is why the core check does not sweep before reporting.
+    the mesh, and a check that sweeps first sees nothing wrong.
     """
     polydata = _vtk.vtkPolyData()
     cells = _vtk.vtkCellArray()
@@ -54,47 +40,7 @@ def test_leak_ghosted_attribute_dict() -> None:
     del cells
 
 
-@pytest.mark.skip_check_gc  # this drives the machinery itself, so it must not be inside it
-def test_leak_at_a_reused_address_is_still_found() -> None:
-    """A leak is found even where it reuses the address of an object that died.
-
-    The check this replaced recorded the ``id()`` of everything alive beforehand
-    and reported what was not in that set, so a leak allocated at a dead
-    object's address was indistinguishable from that dead object and passed
-    silently. It is not a rare corner: CPython reuses the most recently freed
-    block of a size class, so in 200 trials the address was reused 199 times and
-    the leak was missed every one of them. Freezing has no ids to collide.
-    """
-    # Whether the allocator hands back the address it just freed is its own
-    # business, so retry until it does rather than assert that it will. The leak
-    # must be found on every pass; landing on the address is what makes a pass
-    # worth having.
-    for _ in range(20):
-        doomed = _vtk.vtkPoints()
-        address = id(doomed)
-
-        gc.freeze()  # what the check does before a test runs, with doomed alive
-        try:
-            del doomed  # and it dies during the test, freeing its address
-            leaked = _vtk.vtkPoints()
-            reused = id(leaked) == address
-
-            gc.collect()
-            survivors = [obj for obj in gc.get_objects() if isinstance(obj, _vtk.vtkObjectBase)]
-            assert any(obj is leaked for obj in survivors)
-        finally:
-            gc.unfreeze()
-
-        del leaked
-        if reused:
-            break
-
-
 def test_no_leak_when_nothing_is_held() -> None:
-    """The negative control: an ordinary mesh must not trip the check.
-
-    Without this, every test above would still pass if the check simply failed
-    on everything.
-    """
+    """The negative control: an ordinary mesh must not trip the check."""
     mesh = pv.Sphere()
     assert mesh.n_points

--- a/tests/core/test_gc.py
+++ b/tests/core/test_gc.py
@@ -2,13 +2,10 @@
 
 ``tests/plotting/test_gc.py`` already covers the leaks both checks catch. What
 is left for core is the one its own policy exists for: it does not sweep VTK's
-ghost map before reporting, and that sweep is what let #8873 through. Planted
-under the plotting policy, the leak below does not fail the check at all.
+ghost map before reporting, and that sweep is what let #8873 through.
 
 ``expect_check_gc_fail`` asserts the teardown check *fails*, so a change that
 quietly stops detecting the leak turns the test red.
-``test_no_leak_when_nothing_is_held`` is what stops that passing on a check
-that simply fails on everything.
 
 The machinery both suites share is tested in ``tests/test_gc_check.py``.
 """
@@ -19,10 +16,15 @@ import pytest
 
 import pyvista as pv
 from pyvista import _vtk
+from pyvista.core._vtk_utilities import _SETDATA_TAKES_OWNERSHIP
 
 pytestmark = pytest.mark.check_gc
 
 
+@pytest.mark.skipif(
+    not _SETDATA_TAKES_OWNERSHIP,
+    reason='CellArray holds its own arrays on VTK < 9.6, so the check never runs there',
+)
 @pytest.mark.expect_check_gc_fail
 def test_leak_ghosted_attribute_dict() -> None:
     """A VTK object stashed on a wrapper whose C++ object outlives it.
@@ -31,7 +33,8 @@ def test_leak_ghosted_attribute_dict() -> None:
     dies while its C++ object is still referenced, so it can restore it if that
     object resurfaces in Python, and anything the dict holds stays alive with
     it. The map is only swept when a new ghost is added, so the entry outlives
-    the mesh, and a check that sweeps first sees nothing wrong.
+    the mesh. Planted under the plotting policy, which sweeps first, this leak
+    does not fail the check at all.
     """
     polydata = _vtk.vtkPolyData()
     cells = _vtk.vtkCellArray()

--- a/tests/core/test_gc.py
+++ b/tests/core/test_gc.py
@@ -1,0 +1,100 @@
+"""The core leak check must fail on a real leak.
+
+``tests/plotting/test_gc.py`` does this for the plotting check. Core runs the
+stricter half of the same machinery -- no ghost sweep before reporting, because
+the sweep is what let #8873 through -- and nothing held it to catching anything
+until now.
+
+Each test here plants a leak and is marked ``expect_check_gc_fail``, so the
+teardown check is asserted to *fail*. A change that quietly stops detecting one
+of these turns its test red.
+"""
+
+from __future__ import annotations
+
+import gc
+
+import pytest
+
+import pyvista as pv
+from pyvista import _vtk
+
+pytestmark = pytest.mark.check_gc
+
+
+@pytest.mark.expect_check_gc_fail
+def test_leak_self_referencing_vtk_object() -> None:
+    """A VTK object in a cycle with itself."""
+    source = _vtk.vtkSphereSource()
+    source.self_ref = source
+
+
+@pytest.mark.expect_check_gc_fail
+def test_leak_pyvista_wrapper() -> None:
+    """The same, reached through a pyvista wrapper rather than a raw VTK one."""
+    mesh = pv.Sphere()
+    points = mesh.points
+    points.VTKObject._ref = points
+
+
+@pytest.mark.expect_check_gc_fail
+def test_leak_ghosted_attribute_dict() -> None:
+    """A VTK object stashed on a wrapper whose C++ object outlives it.
+
+    This is the shape of #8873. VTK keeps the attribute dict of a wrapper that
+    dies while its C++ object is still referenced, so it can restore it if that
+    object resurfaces in Python, and anything the dict holds stays alive with
+    it. The map is only swept when a new ghost is added, so the entry outlives
+    the mesh -- which is why the core check does not sweep before reporting.
+    """
+    polydata = _vtk.vtkPolyData()
+    cells = _vtk.vtkCellArray()
+    cells.stashed = _vtk.vtkPoints()
+    polydata.SetPolys(cells)  # the C++ object now outlives the wrapper
+    del cells
+
+
+@pytest.mark.skip_check_gc  # this drives the machinery itself, so it must not be inside it
+def test_leak_at_a_reused_address_is_still_found() -> None:
+    """A leak is found even where it reuses the address of an object that died.
+
+    The check this replaced recorded the ``id()`` of everything alive beforehand
+    and reported what was not in that set, so a leak allocated at a dead
+    object's address was indistinguishable from that dead object and passed
+    silently. It is not a rare corner: CPython reuses the most recently freed
+    block of a size class, so in 200 trials the address was reused 199 times and
+    the leak was missed every one of them. Freezing has no ids to collide.
+    """
+    # Whether the allocator hands back the address it just freed is its own
+    # business, so retry until it does rather than assert that it will. The leak
+    # must be found on every pass; landing on the address is what makes a pass
+    # worth having.
+    for _ in range(20):
+        doomed = _vtk.vtkPoints()
+        address = id(doomed)
+
+        gc.freeze()  # what the check does before a test runs, with doomed alive
+        try:
+            del doomed  # and it dies during the test, freeing its address
+            leaked = _vtk.vtkPoints()
+            reused = id(leaked) == address
+
+            gc.collect()
+            survivors = [obj for obj in gc.get_objects() if isinstance(obj, _vtk.vtkObjectBase)]
+            assert any(obj is leaked for obj in survivors)
+        finally:
+            gc.unfreeze()
+
+        del leaked
+        if reused:
+            break
+
+
+def test_no_leak_when_nothing_is_held() -> None:
+    """The negative control: an ordinary mesh must not trip the check.
+
+    Without this, every test above would still pass if the check simply failed
+    on everything.
+    """
+    mesh = pv.Sphere()
+    assert mesh.n_points

--- a/tests/core/test_gc.py
+++ b/tests/core/test_gc.py
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.check_gc
 
 @pytest.mark.skipif(
     not _SETDATA_TAKES_OWNERSHIP,
-    reason='CellArray holds its own arrays on VTK < 9.6, so the check never runs there',
+    reason='the core check is disabled entirely on VTK < 9.6, see tests/core/conftest.py',
 )
 @pytest.mark.expect_check_gc_fail
 def test_leak_ghosted_attribute_dict() -> None:
@@ -35,12 +35,19 @@ def test_leak_ghosted_attribute_dict() -> None:
     it. The map is only swept when a new ghost is added, so the entry outlives
     the mesh. Planted under the plotting policy, which sweeps first, this leak
     does not fail the check at all.
+
+    The ghost goes on a command the mesh holds as an observer rather than on the
+    mesh's own arrays because Kitware/VTK@641b2b68 (vtk/vtk!13226, VTK 9.7)
+    evicts a ghost from a ``DeleteEvent`` observer, which only a ``vtkObject``
+    can carry. A command is a ``vtkObjectBase`` that is not a ``vtkObject``, so
+    its ghost still waits for the sweep.
     """
     polydata = _vtk.vtkPolyData()
-    cells = _vtk.vtkCellArray()
-    cells.stashed = _vtk.vtkPoints()
-    polydata.SetPolys(cells)  # the C++ object now outlives the wrapper
-    del cells
+    # The observer list holds the C++ command, so it outlives the wrapper below.
+    tag = polydata.AddObserver('ModifiedEvent', lambda *_: None)
+    command = polydata.GetCommand(tag)
+    command.stashed = _vtk.vtkPoints()
+    del command
 
 
 def test_no_leak_when_nothing_is_held() -> None:

--- a/tests/gc_check.py
+++ b/tests/gc_check.py
@@ -13,6 +13,17 @@ The check runs from a ``pytest_runtest_teardown`` hookwrapper rather than a fixt
 finalizer: several fixtures are set up before an autouse fixture (``monkeypatch`` via
 other autouse fixtures, the registry save/restore in ``tests/conftest.py``), so their
 finalizers run *after* it -- and anything they still held would be misreported here.
+
+.. warning::
+
+    The heap stays frozen for the whole body of a covered test, so anything running in
+    that body sees a *lying* collector: ``gc.get_referrers()`` reports no referrers for
+    an object that pre-dates the test, and ``gc.get_objects()`` omits it entirely. This
+    is not confined to pyvista's own code -- Hypothesis' ``register_random`` uses
+    ``gc.get_referrers()`` to check that a PRNG handed to it is reachable, and wrongly
+    concluded it was not (hence the warmup in ``tests/conftest.py``). Mark a test that
+    needs a truthful view of the collector with ``@pytest.mark.skip_check_gc``, which
+    costs it leak coverage.
 """
 
 from __future__ import annotations
@@ -75,14 +86,15 @@ def take_snapshot(item, match, label: str) -> None:
     """Put every object alive now out of reach, so only *new* survivors are reported.
 
     ``gc.freeze()`` moves them into the permanent generation, which the collector never
-    walks and ``gc.get_objects()`` never reports. So whatever the check finds afterwards
-    was created by this test, and the snapshot needs no "before" set to subtract -- hence
-    the empty ``objs``, which also means ``Snapshot``'s own ``collect=True`` is ignored
-    and the ``gc.collect()`` it used to run here no longer happens. Recording ids instead
-    meant that collect and a scan of the whole heap here and again at teardown, four
-    passes over ~180k objects that between them cost more than the tests: ``tests/core``
-    now runs the check over every one of its tests in less time than it took to run it
-    over the 397 it covered this way.
+    walks and ``gc.get_objects()`` never reports -- for the test body too, not just for
+    the check, which is the hazard the module docstring warns about. So whatever the
+    check finds afterwards was created by this test, and the snapshot needs no "before"
+    set to subtract -- hence the empty ``objs``, which also means ``Snapshot``'s own
+    ``collect=True`` is ignored and the ``gc.collect()`` it used to run here no longer
+    happens. Recording ids instead meant that collect and a scan of the whole heap here
+    and again at teardown, four passes over ~180k objects that between them cost more
+    than the tests: ``tests/core`` now runs the check over every one of its tests in less
+    time than it took to run it over the 397 it covered this way.
 
     It is also stricter. An id-based snapshot cannot distinguish a new object allocated at
     a dead one's address from that dead one, and silently passes; there are no ids to

--- a/tests/gc_check.py
+++ b/tests/gc_check.py
@@ -5,9 +5,9 @@ of the ones it creates outlive it -- so the mechanics live here and each conftes
 supplies its policy. They differ in exactly two ways:
 
 * what they match: plotting also watches ``BasePlotter``, which is not a VTK object.
-* ``flush_ghosts``: plotting forgives a leak that disappears once VTK's ghost map is
-  swept, because plotter teardown routinely leaves stale ghosts behind. Core does not,
-  and that strictness is the point -- the retry is what let the #8873 leak through.
+* ``flush_ghosts``: plotting sweeps VTK's ghost map before scanning, forgiving a leak
+  that the sweep clears, because plotter teardown routinely leaves stale ghosts behind.
+  Core does not, and that strictness is the point -- the sweep is what hid #8873.
 
 The check runs from a ``pytest_runtest_teardown`` hookwrapper rather than a fixture
 finalizer: several fixtures are set up before an autouse fixture (``monkeypatch`` via
@@ -37,10 +37,6 @@ _check_gc_key = pytest.StashKey()
 # with a copy of the conftest (see tests/plotting/test_conftest.py), so an inner test
 # would otherwise unfreeze the heap out from under the outer one -- which then sees every
 # object in the process as its own. Only the outermost check freezes and thaws.
-#
-# A list rather than a counter so the depth is mutated in place, which a module-level int
-# would need ``global`` for. It holds the name of each nested check, so an unbalanced
-# freeze names the tests involved rather than just failing to add up.
 _frozen_for: list[str] = []
 
 
@@ -81,10 +77,12 @@ def take_snapshot(item, match, label: str) -> None:
     ``gc.freeze()`` moves them into the permanent generation, which the collector never
     walks and ``gc.get_objects()`` never reports. So whatever the check finds afterwards
     was created by this test, and the snapshot needs no "before" set to subtract -- hence
-    the empty ``objs``. Recording ids instead meant a ``gc.collect()`` and a scan of the
-    whole heap here and again at teardown, four passes over ~180k objects that between
-    them cost more than the tests: ``tests/core`` runs the check over every one of its
-    7,559 tests in less time than it took to run it over 397 of them this way.
+    the empty ``objs``, which also means ``Snapshot``'s own ``collect=True`` is ignored
+    and the ``gc.collect()`` it used to run here no longer happens. Recording ids instead
+    meant that collect and a scan of the whole heap here and again at teardown, four
+    passes over ~180k objects that between them cost more than the tests: ``tests/core``
+    now runs the check over every one of its tests in less time than it took to run it
+    over the 397 it covered this way.
 
     It is also stricter. An id-based snapshot cannot distinguish a new object allocated at
     a dead one's address from that dead one, and silently passes; there are no ids to
@@ -95,10 +93,13 @@ def take_snapshot(item, match, label: str) -> None:
     instantiates, whose names lack the ``vtk`` prefix. Passing several types as one tuple
     keeps this to a single pass.
     """
+    # Built before the freeze: a raise from Snapshot would otherwise leave a name in
+    # _frozen_for that nothing pops, and the worker's heap frozen for the rest of the run.
+    snapshot = Snapshot(match, label=label, objs=[])
     if not _frozen_for:
         gc.freeze()
     _frozen_for.append(item.name)
-    item.stash[_check_gc_key] = Snapshot(match, label=label, objs=[])
+    item.stash[_check_gc_key] = snapshot
 
 
 def assert_no_leaks(
@@ -113,18 +114,33 @@ def assert_no_leaks(
         return
     del item.stash[_check_gc_key]
 
-    # Whatever happens below, hand the frozen objects back to the collector. Leaving them
-    # in the permanent generation would exempt them from collection for the rest of the
-    # session, and the next test would see them as its own.
-    try:
-        _assert_no_leaks(item, snapshot, flush_ghosts=flush_ghosts, before_check=before_check)
-    finally:
+    thawed = False
+
+    def thaw() -> None:
+        """Hand the frozen objects back to the collector, at most once.
+
+        Leaving them in the permanent generation would exempt them from collection for
+        the rest of the session, and the next test would see them as its own. The check
+        thaws partway through (see :func:`_assert_no_leaks`); this is also the backstop
+        for the paths that return or raise before getting that far.
+        """
         # Never raise from here: this runs while a leak assertion may be in flight, and
         # an IndexError would replace it with something that explains nothing.
+        nonlocal thawed
+        if thawed:
+            return
+        thawed = True
         if _frozen_for:
             _frozen_for.pop()
         if not _frozen_for:
             gc.unfreeze()
+
+    try:
+        _assert_no_leaks(
+            item, snapshot, flush_ghosts=flush_ghosts, before_check=before_check, thaw=thaw
+        )
+    finally:
+        thaw()
 
 
 def _assert_no_leaks(
@@ -133,8 +149,9 @@ def _assert_no_leaks(
     *,
     flush_ghosts: bool,
     before_check: Callable[[], None] | None,
+    thaw: Callable[[], None],
 ) -> None:
-    """Do the checking, with :func:`assert_no_leaks` owning the unfreeze around it."""
+    """Do the checking, calling ``thaw`` once the survivors have been taken."""
     if before_check is not None:
         before_check()
 
@@ -152,21 +169,23 @@ def _assert_no_leaks(
     request = SimpleNamespace(node=item)
     gc_collect_once(request)
 
-    def _assert_no_new():
-        try:
-            snapshot.assert_no_new(when, request=request)
-        except AssertionError:
-            if not flush_ghosts:
-                raise
-            # A stale VTK ghost is deferred bookkeeping, not a leak: flush the ghost map
-            # and re-check before reporting a failure.
-            _flush_vtk_ghosts()
-            gc.collect()
-            snapshot.assert_no_new(when, request=request)
+    if flush_ghosts:
+        # A stale VTK ghost is deferred bookkeeping, not a leak: sweep the map before
+        # scanning rather than re-checking after a failure, because the survivor list
+        # below holds strong references and nothing can be freed once it is taken.
+        _flush_vtk_ghosts()
+        gc.collect()
+
+    # Take the survivors while the heap is still frozen -- these are exactly the objects
+    # this test created. Thaw before reporting: gc.get_referrers() does not look in the
+    # permanent generation either, so a leak anchored in a container that pre-dates the
+    # test would have no visible referrer, and refleak drops a survivor it cannot explain.
+    objs = gc.get_objects()
+    thaw()
 
     if item.get_closest_marker('expect_check_gc_fail'):
         with pytest.raises(AssertionError, match='Found '):
-            _assert_no_new()
+            snapshot.assert_no_new(when, request=request, objs=objs)
         return
 
-    _assert_no_new()
+    snapshot.assert_no_new(when, request=request, objs=objs)

--- a/tests/gc_check.py
+++ b/tests/gc_check.py
@@ -1,8 +1,8 @@
 """Shared leak-check machinery for the ``core`` and ``plotting`` conftests.
 
-Both run the same check -- snapshot the live VTK objects before a test, assert none of
-them outlived it -- so the mechanics live here and each conftest only supplies its
-policy. They differ in exactly two ways:
+Both run the same check -- put the objects alive before a test out of reach, assert none
+of the ones it creates outlive it -- so the mechanics live here and each conftest only
+supplies its policy. They differ in exactly two ways:
 
 * what they match: plotting also watches ``BasePlotter``, which is not a VTK object.
 * ``flush_ghosts``: plotting forgives a leak that disappears once VTK's ghost map is
@@ -32,6 +32,16 @@ if TYPE_CHECKING:
 
 _phase_report_key = pytest.StashKey()
 _check_gc_key = pytest.StashKey()
+
+# Freezing is process-wide, and ``pytester`` runs a nested session in this same process
+# with a copy of the conftest (see tests/plotting/test_conftest.py), so an inner test
+# would otherwise unfreeze the heap out from under the outer one -- which then sees every
+# object in the process as its own. Only the outermost check freezes and thaws.
+#
+# A list rather than a counter so the depth is mutated in place; rebinding a module-level
+# int needs ``global``. It holds the name of each check currently nested, which is what a
+# failure here would need to report.
+_frozen_for: list[str] = []
 
 
 def stash_phase_report(item, report) -> None:
@@ -66,15 +76,29 @@ def _flush_vtk_ghosts() -> None:
 
 
 def take_snapshot(item, match, label: str) -> None:
-    """Record the live matching objects, so only *new* survivors are reported.
+    """Put every object alive now out of reach, so only *new* survivors are reported.
+
+    ``gc.freeze()`` moves them into the permanent generation, which the collector never
+    walks and ``gc.get_objects()`` never reports. So whatever the check finds afterwards
+    was created by this test, and the snapshot needs no "before" set to subtract -- hence
+    the empty ``objs``. Recording ids instead meant a ``gc.collect()`` and a scan of the
+    whole heap here and again at teardown, four passes over ~180k objects that between
+    them cost more than the tests: ``tests/core`` runs the check over every one of its
+    7,559 tests in less time than it took to run it over 397 of them this way.
+
+    It is also stricter. An id-based snapshot cannot distinguish a new object allocated at
+    a dead one's address from that dead one, and silently passes; there are no ids to
+    reuse here.
 
     Matching by ``isinstance`` rather than class-name prefix also covers pyvista's own
     vtk subclasses (``PolyData``, ...) and the pythonic override subclasses VTK >= 9.6
     instantiates, whose names lack the ``vtk`` prefix. Passing several types as one tuple
-    keeps this to a single pass over the heap. ``Snapshot`` collects before it records
-    ids, so no ``gc.collect()`` is needed here.
+    keeps this to a single pass.
     """
-    item.stash[_check_gc_key] = Snapshot(match, label=label)
+    if not _frozen_for:
+        gc.freeze()
+    _frozen_for.append(item.name)
+    item.stash[_check_gc_key] = Snapshot(match, label=label, objs=[])
 
 
 def assert_no_leaks(
@@ -89,6 +113,25 @@ def assert_no_leaks(
         return
     del item.stash[_check_gc_key]
 
+    # Whatever happens below, hand the frozen objects back to the collector. Leaving them
+    # in the permanent generation would exempt them from collection for the rest of the
+    # session, and the next test would see them as its own.
+    try:
+        _assert_no_leaks(item, snapshot, flush_ghosts=flush_ghosts, before_check=before_check)
+    finally:
+        _frozen_for.pop()
+        if not _frozen_for:
+            gc.unfreeze()
+
+
+def _assert_no_leaks(
+    item,
+    snapshot: Snapshot,
+    *,
+    flush_ghosts: bool,
+    before_check: Callable[[], None] | None,
+) -> None:
+    """Do the checking, with :func:`assert_no_leaks` owning the unfreeze around it."""
     if before_check is not None:
         before_check()
 

--- a/tests/gc_check.py
+++ b/tests/gc_check.py
@@ -38,9 +38,9 @@ _check_gc_key = pytest.StashKey()
 # would otherwise unfreeze the heap out from under the outer one -- which then sees every
 # object in the process as its own. Only the outermost check freezes and thaws.
 #
-# A list rather than a counter so the depth is mutated in place; rebinding a module-level
-# int needs ``global``. It holds the name of each check currently nested, which is what a
-# failure here would need to report.
+# A list rather than a counter so the depth is mutated in place, which a module-level int
+# would need ``global`` for. It holds the name of each nested check, so an unbalanced
+# freeze names the tests involved rather than just failing to add up.
 _frozen_for: list[str] = []
 
 
@@ -119,7 +119,10 @@ def assert_no_leaks(
     try:
         _assert_no_leaks(item, snapshot, flush_ghosts=flush_ghosts, before_check=before_check)
     finally:
-        _frozen_for.pop()
+        # Never raise from here: this runs while a leak assertion may be in flight, and
+        # an IndexError would replace it with something that explains nothing.
+        if _frozen_for:
+            _frozen_for.pop()
         if not _frozen_for:
             gc.unfreeze()
 

--- a/tests/plotting/test_gc.py
+++ b/tests/plotting/test_gc.py
@@ -11,6 +11,23 @@ import pytest
 import pyvista as pv
 from pyvista import _vtk
 
+# Stands in for a module-level registry or cache: older than any test here, so the
+# freeze puts it out of reach along with everything else alive at collection time.
+_REGISTRY: list[_vtk.vtkPolyData] = []
+
+
+@pytest.mark.expect_check_gc_fail
+def test_leak_into_a_container_older_than_the_test() -> None:
+    """A leak whose only referrer pre-dates the test must still be reported.
+
+    ``gc.get_referrers`` skips the permanent generation just as ``gc.get_objects``
+    does, so while the heap is frozen this object looks like it is held by nothing
+    -- and the report drops a survivor it cannot explain. Every registry and cache
+    that outlives a test has this shape, ``_ALL_PLOTTERS`` among them.
+    """
+    _REGISTRY.clear()  # whatever an earlier run of this test left, so it cannot pile up
+    _REGISTRY.append(_vtk.vtkPolyData())
+
 
 @pytest.mark.expect_check_gc_fail
 def test_leak_vtk() -> None:

--- a/tests/test_gc_check.py
+++ b/tests/test_gc_check.py
@@ -13,6 +13,9 @@ The leaks the check has to catch live with the policy that catches them:
 from __future__ import annotations
 
 import gc
+from types import SimpleNamespace
+
+import pytest
 
 from pyvista import _vtk
 from tests import gc_check
@@ -42,16 +45,21 @@ def test_nested_checks_thaw_only_once() -> None:
     # bookkeeping and skip the scan itself, which is what is under test here.
     outer, inner = _StubItem('outer'), _StubItem('inner')
 
-    assert gc.get_freeze_count() == 0
+    # A delta, not an absolute: CPython freezes a few hundred objects of its own
+    # during startup, and other tests in this worker may have frozen more.
+    baseline = gc.get_freeze_count()
     gc_check.take_snapshot(outer, _vtk.vtkObjectBase, 'VTK')
     frozen = gc.get_freeze_count()
-    assert frozen > 0
+    assert frozen > baseline
 
     gc_check.take_snapshot(inner, _vtk.vtkObjectBase, 'VTK')
     gc_check.assert_no_leaks(inner, flush_ghosts=False)
     assert gc.get_freeze_count() == frozen, 'the inner check thawed the outer freeze'
 
     gc_check.assert_no_leaks(outer, flush_ghosts=False)
+    # Zero, not back to ``baseline``: thawing is not the inverse of freezing.
+    # ``gc.unfreeze()`` empties the permanent generation outright, so it also
+    # releases whatever was in it before the outer check froze anything.
     assert gc.get_freeze_count() == 0
 
 
@@ -64,27 +72,27 @@ def test_leak_at_a_reused_address_is_still_found() -> None:
     silently. It is not a rare corner: CPython reuses the most recently freed
     block of a size class, so in 200 trials the address was reused 199 times and
     the leak was missed every one of them. Freezing has no ids to collide.
+
+    This is also the only test here that reaches the reporting code with an
+    assertion in flight, so it is what covers the thaw on that path.
     """
-    # Whether the allocator hands back the address it just freed is its own
-    # business, so retry until it does rather than assert that it will. The leak
-    # must be found on every pass; landing on the address is what makes a pass
-    # worth having.
-    for _ in range(20):
-        doomed = _vtk.vtkPoints()
-        address = id(doomed)
+    item = _StubItem('reused')
+    gc_check.stash_phase_report(item, SimpleNamespace(when='call', outcome='passed'))
 
-        gc.freeze()  # what the check does before a test runs, with doomed alive
-        try:
-            del doomed  # and it dies during the test, freeing its address
-            leaked = _vtk.vtkPoints()
-            reused = id(leaked) == address
+    doomed = _vtk.vtkPoints()
+    address = id(doomed)
 
-            gc.collect()
-            survivors = [obj for obj in gc.get_objects() if isinstance(obj, _vtk.vtkObjectBase)]
-            assert any(obj is leaked for obj in survivors)
-        finally:
-            gc.unfreeze()
+    # Nothing may raise between here and the check: it holds the freeze, and an
+    # escape would leave the worker's heap frozen for every test after this one.
+    gc_check.take_snapshot(item, _vtk.vtkObjectBase, 'VTK')
+    del doomed  # dies during the "test", freeing its address for the leak below
+    leaked = _vtk.vtkPoints()
+    leaked.self_ref = leaked  # a referrer for the report to walk
 
-        del leaked
-        if reused:
-            break
+    with pytest.raises(AssertionError, match='Found 1 new VTK object'):
+        gc_check.assert_no_leaks(item, flush_ghosts=False)
+
+    assert gc.get_freeze_count() == 0, 'the failing check left the heap frozen'
+    assert id(leaked) == address, 'the allocator did not hand the address back'
+    leaked.self_ref = None  # break the cycle, so the leak does not outlive its test
+    del leaked

--- a/tests/test_gc_check.py
+++ b/tests/test_gc_check.py
@@ -1,0 +1,90 @@
+"""Test the leak-check machinery in :mod:`tests.gc_check` itself.
+
+The suites that use it can only exercise it through their own conftest, and each
+of those supplies a different policy. What is checked here is common to both and
+belongs to neither, so it drives ``take_snapshot`` and ``assert_no_leaks``
+directly. Nothing under ``tests/`` at this level runs the check, so these are
+outside the thing they are testing.
+
+The leaks the check has to catch live with the policy that catches them:
+``tests/plotting/test_gc.py`` and ``tests/core/test_gc.py``.
+"""
+
+from __future__ import annotations
+
+import gc
+
+from pyvista import _vtk
+from tests import gc_check
+
+
+class _StubItem:
+    """The parts of a pytest item the freeze bookkeeping touches."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.stash: dict = {}
+        self.funcargs: dict = {}
+
+    def get_closest_marker(self, _name: str) -> None:
+        return None
+
+
+def test_nested_checks_thaw_only_once() -> None:
+    """An inner check must not thaw the heap the outer one froze.
+
+    ``pytester`` runs a nested session in this same process with a copy of the
+    conftest, so the checks nest for real (see tests/plotting/test_conftest.py).
+    Freezing is process-wide, so an inner thaw hands the outer test the whole
+    process to account for, and it reports every VTK object in it as a leak.
+    """
+    # The stubs report no passing call phase, so the checks do their freeze
+    # bookkeeping and skip the scan itself, which is what is under test here.
+    outer, inner = _StubItem('outer'), _StubItem('inner')
+
+    assert gc.get_freeze_count() == 0
+    gc_check.take_snapshot(outer, _vtk.vtkObjectBase, 'VTK')
+    frozen = gc.get_freeze_count()
+    assert frozen > 0
+
+    gc_check.take_snapshot(inner, _vtk.vtkObjectBase, 'VTK')
+    gc_check.assert_no_leaks(inner, flush_ghosts=False)
+    assert gc.get_freeze_count() == frozen, 'the inner check thawed the outer freeze'
+
+    gc_check.assert_no_leaks(outer, flush_ghosts=False)
+    assert gc.get_freeze_count() == 0
+
+
+def test_leak_at_a_reused_address_is_still_found() -> None:
+    """A leak is found even where it reuses the address of an object that died.
+
+    The check this replaced recorded the ``id()`` of everything alive beforehand
+    and reported what was not in that set, so a leak allocated at a dead
+    object's address was indistinguishable from that dead object and passed
+    silently. It is not a rare corner: CPython reuses the most recently freed
+    block of a size class, so in 200 trials the address was reused 199 times and
+    the leak was missed every one of them. Freezing has no ids to collide.
+    """
+    # Whether the allocator hands back the address it just freed is its own
+    # business, so retry until it does rather than assert that it will. The leak
+    # must be found on every pass; landing on the address is what makes a pass
+    # worth having.
+    for _ in range(20):
+        doomed = _vtk.vtkPoints()
+        address = id(doomed)
+
+        gc.freeze()  # what the check does before a test runs, with doomed alive
+        try:
+            del doomed  # and it dies during the test, freeing its address
+            leaked = _vtk.vtkPoints()
+            reused = id(leaked) == address
+
+            gc.collect()
+            survivors = [obj for obj in gc.get_objects() if isinstance(obj, _vtk.vtkObjectBase)]
+            assert any(obj is leaked for obj in survivors)
+        finally:
+            gc.unfreeze()
+
+        del leaked
+        if reused:
+            break


### PR DESCRIPTION
### Overview

The VTK leak check recorded the `id()` of every live object before each test and diffed it afterwards, which cost a `gc.collect()` and two walks of a ~180k-object heap per test. `gc.freeze()` gets the same answer for free: it moves everything already alive into the permanent generation, which the collector never walks and `gc.get_objects()` never reports, so whatever the check finds afterwards is what the test created. `tests/plotting` under `-n 8` goes from 176s to about 70s, and the check's own per-test cost from 60ms to 0.1ms.

Freezing also closes two blind spots. Comparing ids cannot distinguish a new object allocated at a dead one's address from that dead one, and since CPython hands back the most recently freed block of a size class, that miss was reliable rather than rare (199 of 200 trials). Separately, the heap has to be thawed before the survivors are reported, because `gc.get_referrers` skips the permanent generation too and `refleak` discards any survivor whose referrer chain comes back empty. Without that, a leak held only by a module-level registry is found and then silently dropped. Related: #8525.

The tradeoff to weigh: the heap stays frozen for the whole test body, not just the check, so anything introspecting the collector mid-test sees pre-existing objects hidden. Hypothesis' `register_random` does exactly that to verify a PRNG is reachable, which broke every Python 3.14 job until `tests/conftest.py` started registering it once at session start. `tests/gc_check.py` documents the constraint and points at `skip_check_gc` as the escape hatch.

Changes drafted by Claude Opus 5 but fully understood by me.
