### PR TITLE
Stop `test_gc_check` flaking on an exact freeze count

### DIFF
--- a/tests/test_gc_check.py
+++ b/tests/test_gc_check.py
@@ -21,6 +21,23 @@ from pyvista import _vtk
 from tests import gc_check
 
 
+@pytest.fixture(autouse=True)
+def _restore_freeze_state():
+    """Leave the collector as we found it, however the test ended.
+
+    These tests drive ``take_snapshot`` and ``assert_no_leaks`` by hand, and the
+    freeze bookkeeping between them is process-wide module state. A test that
+    fails partway leaves a name in ``_frozen_for`` that nothing pops, so the heap
+    stays frozen and every later check in this worker stops freezing and thawing
+    -- degrading quietly rather than failing. The real conftest cannot strand it
+    that way, because it takes the snapshot in setup and asserts in teardown,
+    which pytest always runs.
+    """
+    yield
+    gc_check._frozen_for.clear()
+    gc.unfreeze()
+
+
 class _StubItem:
     """The parts of a pytest item the freeze bookkeeping touches."""
 
@@ -54,7 +71,12 @@ def test_nested_checks_thaw_only_once() -> None:
 
     gc_check.take_snapshot(inner, _vtk.vtkObjectBase, 'VTK')
     gc_check.assert_no_leaks(inner, flush_ghosts=False)
-    assert gc.get_freeze_count() == frozen, 'the inner check thawed the outer freeze'
+    # Still frozen, rather than still exactly ``frozen``. The count drops by one
+    # for every object that was alive at the freeze and dies while it is held,
+    # which is ordinary refcounting; on a 1.1M object heap a drift of one is
+    # routine and is not a thaw. A thaw empties the permanent generation
+    # outright, so it shows up as 0, which this still catches.
+    assert gc.get_freeze_count() > baseline, 'the inner check thawed the outer freeze'
 
     gc_check.assert_no_leaks(outer, flush_ghosts=False)
     # Zero, not back to ``baseline``: thawing is not the inverse of freezing.


### PR DESCRIPTION
### Overview

Resolves #8918.

`gc.get_freeze_count()` drops by one every time an object that was alive at `gc.freeze()` is deallocated, which is ordinary refcounting and not a thaw, so `test_nested_checks_thaw_only_once` comparing it to an exact value flakes. It did on the first main run after #8916, off by one against a 1.1M object heap, i.e. https://github.com/pyvista/pyvista/actions/runs/31966124320/job/95211468071. macOS 3.14 is only where it landed: the same code was green on that job in #8916's own run, and Linux 3.14, Windows 3.14 and macOS 3.10 to 3.13 all passed on the failing run. A thaw empties the permanent generation outright and shows up as 0, so comparing against the pre-freeze baseline still catches one, which I checked by making `thaw` unfreeze unconditionally and watching the test fail.

The other failure in that run was a cascade, and it is the part worth fixing. The assert is on line 57 and the outer thaw on line 59, so a failure strands a name in `_frozen_for`, which never empties again: `take_snapshot` stops freezing and `thaw` stops unfreezing for the rest of the worker, so every later leak check degrades quietly rather than failing. An autouse fixture now restores the state however the test ended. With it, a deliberately aborted test gives 1 failed 1 passed where it gave 2 failed before. `tests/gc_check.py` needs nothing: it already thaws from a `finally`, and the conftest takes the snapshot in setup and asserts in teardown, which pytest always runs.

Changes drafted by Claude Opus 5 but fully understood by me
