### PR TITLE
Use refleak's own freeze mode for the leak check

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -925,13 +925,23 @@ The ``vtk-dev-testing`` and ``vtk-master-testing`` labels are independent and ma
 
 Garbage Collection Checks
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Every test under ``tests/plotting`` is automatically checked for reference leaks by
-the autouse ``check_gc`` fixture in ``tests/plotting/conftest.py``: no plotter or VTK
-object created by a test may outlive it. A leaking test fails at teardown with a
-rendered chain of what still holds a reference; see the
+Tests are checked for reference leaks: no plotter or VTK object created by a test may
+outlive it. Every test under ``tests/plotting`` is covered by the autouse ``check_gc``
+fixture in ``tests/plotting/conftest.py``, and modules under ``tests/core`` opt in with
+``pytestmark = pytest.mark.check_gc``. A leaking test fails at teardown with a rendered
+chain of what still holds a reference; see the
 `refleak <https://github.com/mne-tools/refleak>`_ documentation for how to read it.
-The cause is usually a reference cycle, and fixing it (e.g. with :mod:`weakref`) is
-preferred over silencing the check with either of these markers:
+
+The check freezes the heap rather than scanning it, so it costs no measurable time and
+every CI job runs it. ``--no_check_gc`` turns it off for a whole run, for local
+iteration where the report is in the way:
+
+.. code-block:: bash
+
+    tox run -e test-plotting-no_check_gc
+
+The cause of a leak is usually a reference cycle, and fixing it (e.g. with
+:mod:`weakref`) is preferred over silencing the check with either of these markers:
 
 .. code-block:: python
 
@@ -947,6 +957,10 @@ preferred over silencing the check with either of these markers:
     @pytest.mark.expect_check_gc_fail
     def test():
         """This test is expected to leak; fail if it does *not*."""
+
+``expect_check_gc_fail`` outranks ``--no_check_gc``, so the tests that exercise the
+check itself (``tests/core/test_gc.py``, ``tests/plotting/test_gc.py``) cannot pass
+while nothing is running.
 
 Docstring Testing
 ~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ test = [
   'pytest-xdist<3.9.0',
   'pytest<9.1.0',
   'pyvista-zstd>=0.2.3,<0.3.0',
-  'refleak>=0.2.1,<0.3.0',
+  'refleak>=0.2.2,<0.3.0',
   'retry-requests<2.1.0',
   'scipy<1.17.0',
   'sphinx-autoopengraph<0.3',
@@ -281,7 +281,7 @@ junit_family = 'legacy'
 log_cli_level = "INFO"
 markers = [
   'check_gc: Enable the strict core leak check for this test (see tests/core/conftest.py).',
-  'expect_check_gc_fail: Expect vtk leak.',
+  'expect_check_gc_fail: Expect vtk leak. Checked even under --no_check_gc.',
   'needs_download: this test downloads data during execution',
   'needs_playwright: this test uses playwright and must be enabled with the --playwright CLI flag',
   'needs_vtk_version(at_least, less_than, reason): skip test unless VTK version corresponds to at_least and greater_than values.',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -393,6 +393,12 @@ def pytest_sessionstart():
 def pytest_addoption(parser):
     parser.addoption('--test_downloads', action='store_true', default=False)
     parser.addoption(
+        '--no_check_gc',
+        action='store_true',
+        default=False,
+        help='skip the reference leak check, which is otherwise run (see tests/gc_check.py)',
+    )
+    parser.addoption(
         '--playwright',
         action='store_true',
         default=False,

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -23,6 +23,7 @@ import pytest
 from pyvista import _vtk
 from pyvista.core._vtk_utilities import _SETDATA_TAKES_OWNERSHIP
 from tests.gc_check import assert_no_leaks
+from tests.gc_check import check_enabled
 from tests.gc_check import stash_phase_report
 from tests.gc_check import take_snapshot
 
@@ -42,7 +43,7 @@ def check_gc(request):
         # On VTK < 9.6 CellArray must hold its own arrays, so this can never pass there
         not _SETDATA_TAKES_OWNERSHIP
         or node.get_closest_marker('check_gc') is None
-        or node.get_closest_marker('skip_check_gc')
+        or not check_enabled(node)
     ):
         yield
         return

--- a/tests/gc_check.py
+++ b/tests/gc_check.py
@@ -16,21 +16,20 @@ finalizers run *after* it -- and anything they still held would be misreported h
 
 .. warning::
 
-    The heap stays frozen for the whole body of a covered test, so anything running in
-    that body sees a *lying* collector: ``gc.get_referrers()`` reports no referrers for
-    an object that pre-dates the test, and ``gc.get_objects()`` omits it entirely. This
-    is not confined to pyvista's own code -- Hypothesis' ``register_random`` uses
-    ``gc.get_referrers()`` to check that a PRNG handed to it is reachable, and wrongly
-    concluded it was not (hence the warmup in ``tests/conftest.py``). Mark a test that
-    needs a truthful view of the collector with ``@pytest.mark.skip_check_gc``, which
-    costs it leak coverage.
+    ``refleak``'s freeze mode keeps the heap frozen for the whole body of a covered test,
+    so anything running in that body sees a *lying* collector: ``gc.get_referrers()``
+    reports no referrers for an object that pre-dates the test, and ``gc.get_objects()``
+    omits it entirely. This is not confined to pyvista's own code -- Hypothesis'
+    ``register_random`` uses ``gc.get_referrers()`` to check that a PRNG handed to it is
+    reachable, and wrongly concluded it was not (hence the warmup in
+    ``tests/conftest.py``). Mark a test that needs a truthful view of the collector with
+    ``@pytest.mark.skip_check_gc``, which costs it leak coverage.
 """
 
 from __future__ import annotations
 
 import gc
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
 
 import pytest
 from refleak.testing import Snapshot
@@ -38,22 +37,32 @@ from refleak.testing import gc_collect_once
 
 from pyvista import _vtk
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
 _phase_report_key = pytest.StashKey()
 _check_gc_key = pytest.StashKey()
-
-# Freezing is process-wide, and ``pytester`` runs a nested session in this same process
-# with a copy of the conftest (see tests/plotting/test_conftest.py), so an inner test
-# would otherwise unfreeze the heap out from under the outer one -- which then sees every
-# object in the process as its own. Only the outermost check freezes and thaws.
-_frozen_for: list[str] = []
 
 
 def stash_phase_report(item, report) -> None:
     """Record a phase report so the check can be skipped when the test failed."""
     item.stash.setdefault(_phase_report_key, {})[report.when] = report
+
+
+def check_enabled(node) -> bool:
+    """Return whether this test should be checked for leaks.
+
+    The check runs unless the test opts out with ``skip_check_gc`` or the whole run does
+    with ``--no_check_gc``, which exists for local iteration only -- CI never passes it,
+    and since the check freezes the heap rather than scanning it there is nothing to
+    gain by it. ``expect_check_gc_fail`` overrides the flag: a test asserting that the
+    check *fails* would otherwise pass while nothing ran.
+    """
+    if node.get_closest_marker('skip_check_gc'):
+        return False
+    if node.get_closest_marker('expect_check_gc_fail'):
+        return True
+    # A default rather than a hard lookup: a nested in-process session (``pytester``,
+    # see tests/plotting/test_conftest.py) copies this conftest but not
+    # ``tests/conftest.py``, which is what registers the option.
+    return not node.config.getoption('no_check_gc', default=False)
 
 
 def _test_passed(item) -> bool:
@@ -85,16 +94,13 @@ def _flush_vtk_ghosts() -> None:
 def take_snapshot(item, match, label: str) -> None:
     """Put every object alive now out of reach, so only *new* survivors are reported.
 
-    ``gc.freeze()`` moves them into the permanent generation, which the collector never
-    walks and ``gc.get_objects()`` never reports -- for the test body too, not just for
-    the check, which is the hazard the module docstring warns about. So whatever the
-    check finds afterwards was created by this test, and the snapshot needs no "before"
-    set to subtract -- hence the empty ``objs``, which also means ``Snapshot``'s own
-    ``collect=True`` is ignored and the ``gc.collect()`` it used to run here no longer
-    happens. Recording ids instead meant that collect and a scan of the whole heap here
-    and again at teardown, four passes over ~180k objects that between them cost more
-    than the tests: ``tests/core`` now runs the check over every one of its tests in less
-    time than it took to run it over the 397 it covered this way.
+    ``freeze=True`` has ``refleak`` call ``gc.freeze()``, moving them into the permanent
+    generation, which the collector never walks and ``gc.get_objects()`` never reports --
+    for the test body too, not just for the check, which is the hazard the module
+    docstring warns about. So whatever the check finds afterwards was created by this
+    test, and there is no "before" set to record: no collect and no heap scan happen here.
+    Recording ids instead meant a collect and a scan of the whole heap here and again at
+    teardown, four passes over ~180k objects that between them cost more than the tests.
 
     It is also stricter. An id-based snapshot cannot distinguish a new object allocated at
     a dead one's address from that dead one, and silently passes; there are no ids to
@@ -105,68 +111,27 @@ def take_snapshot(item, match, label: str) -> None:
     instantiates, whose names lack the ``vtk`` prefix. Passing several types as one tuple
     keeps this to a single pass.
     """
-    # Built before the freeze: a raise from Snapshot would otherwise leave a name in
-    # _frozen_for that nothing pops, and the worker's heap frozen for the rest of the run.
-    snapshot = Snapshot(match, label=label, objs=[])
-    if not _frozen_for:
-        gc.freeze()
-    _frozen_for.append(item.name)
-    item.stash[_check_gc_key] = snapshot
+    item.stash[_check_gc_key] = Snapshot(match, label=label, freeze=True)
 
 
-def assert_no_leaks(
-    item,
-    *,
-    flush_ghosts: bool,
-    before_check: Callable[[], None] | None = None,
-) -> None:
+def assert_no_leaks(item, *, flush_ghosts: bool) -> None:
     """Assert nothing matched by :func:`take_snapshot` outlived the test."""
     snapshot = item.stash.get(_check_gc_key, None)
     if snapshot is None:
         return
     del item.stash[_check_gc_key]
-
-    thawed = False
-
-    def thaw() -> None:
-        """Hand the frozen objects back to the collector, at most once.
-
-        Leaving them in the permanent generation would exempt them from collection for
-        the rest of the session, and the next test would see them as its own. The check
-        thaws partway through (see :func:`_assert_no_leaks`); this is also the backstop
-        for the paths that return or raise before getting that far.
-        """
-        # Never raise from here: this runs while a leak assertion may be in flight, and
-        # an IndexError would replace it with something that explains nothing.
-        nonlocal thawed
-        if thawed:
-            return
-        thawed = True
-        if _frozen_for:
-            _frozen_for.pop()
-        if not _frozen_for:
-            gc.unfreeze()
-
     try:
-        _assert_no_leaks(
-            item, snapshot, flush_ghosts=flush_ghosts, before_check=before_check, thaw=thaw
-        )
+        _assert_no_leaks(item, snapshot, flush_ghosts=flush_ghosts)
     finally:
-        thaw()
+        # Whatever happened above, hand the frozen objects back to the collector: leaving
+        # them in the permanent generation would exempt them from collection for the rest
+        # of the session, and the next test would see them as its own. A no-op on the
+        # paths that reached the check, which thaws itself.
+        snapshot.thaw()
 
 
-def _assert_no_leaks(
-    item,
-    snapshot: Snapshot,
-    *,
-    flush_ghosts: bool,
-    before_check: Callable[[], None] | None,
-    thaw: Callable[[], None],
-) -> None:
-    """Do the checking, calling ``thaw`` once the survivors have been taken."""
-    if before_check is not None:
-        before_check()
-
+def _assert_no_leaks(item, snapshot: Snapshot, *, flush_ghosts: bool) -> None:
+    """Do the checking, with the heap frozen and the caller holding the thaw."""
     if not _test_passed(item):
         return
 
@@ -183,21 +148,17 @@ def _assert_no_leaks(
 
     if flush_ghosts:
         # A stale VTK ghost is deferred bookkeeping, not a leak: sweep the map before
-        # scanning rather than re-checking after a failure, because the survivor list
-        # below holds strong references and nothing can be freed once it is taken.
+        # ``refleak`` scans rather than re-checking after a failure, because the survivor
+        # list it takes holds strong references and nothing can be freed once it is taken.
         _flush_vtk_ghosts()
         gc.collect()
 
-    # Take the survivors while the heap is still frozen -- these are exactly the objects
-    # this test created. Thaw before reporting: gc.get_referrers() does not look in the
-    # permanent generation either, so a leak anchored in a container that pre-dates the
-    # test would have no visible referrer, and refleak drops a survivor it cannot explain.
-    objs = gc.get_objects()
-    thaw()
-
+    # assert_no_new takes its survivors while the heap is still frozen -- those are
+    # exactly the objects this test created -- and thaws before reporting, on the failing
+    # path too.
     if item.get_closest_marker('expect_check_gc_fail'):
         with pytest.raises(AssertionError, match='Found '):
-            snapshot.assert_no_new(when, request=request, objs=objs)
+            snapshot.assert_no_new(when, request=request)
         return
 
-    snapshot.assert_no_new(when, request=request, objs=objs)
+    snapshot.assert_no_new(when, request=request)

--- a/tests/plotting/conftest.py
+++ b/tests/plotting/conftest.py
@@ -12,6 +12,7 @@ import pyvista as pv
 from pyvista import _vtk
 from pyvista.plotting import system_supports_plotting
 from tests.gc_check import assert_no_leaks
+from tests.gc_check import check_enabled
 from tests.gc_check import stash_phase_report
 from tests.gc_check import take_snapshot
 
@@ -75,7 +76,7 @@ def pytest_runtest_makereport(item, call):  # noqa: ARG001
 @pytest.fixture(autouse=True)
 def check_gc(request):
     """Snapshot live plotters and VTK objects so leaks from this test can be detected."""
-    if request.node.get_closest_marker('skip_check_gc'):
+    if not check_enabled(request.node):
         yield
         return
     # BasePlotter is not a vtkObjectBase, so both types are needed here
@@ -89,15 +90,19 @@ def check_gc(request):
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_teardown(item):
-    """Ensure that all VTK objects created during a test are garbage-collected.
+    """Close every plotter, and check that nothing the test created outlived it.
 
-    A hookwrapper so the check runs after every fixture finalizer has run
-    (see ``check_gc``, which takes the snapshot this checks against).
+    A hookwrapper so both run after every fixture finalizer has run (see ``check_gc``,
+    which takes the snapshot this checks against).
     """
     yield
+    # Unconditional, and before the check rather than from it: a test that leaves a
+    # plotter open leaves a render window open for every test after it, whether or not
+    # this run is checking for leaks.
+    pv.close_all()
     # flush_ghosts: plotter teardown leaves stale ghosts behind, so a leak that a ghost
     # sweep clears is deferred bookkeeping rather than a real one (unlike tests/core)
-    assert_no_leaks(item, flush_ghosts=True, before_check=pv.close_all)
+    assert_no_leaks(item, flush_ghosts=True)
 
 
 @pytest.fixture

--- a/tests/test_gc_check.py
+++ b/tests/test_gc_check.py
@@ -16,6 +16,7 @@ import gc
 from types import SimpleNamespace
 
 import pytest
+from refleak.testing import _core as _refleak_core
 
 from pyvista import _vtk
 from tests import gc_check
@@ -26,15 +27,18 @@ def _restore_freeze_state():
     """Leave the collector as we found it, however the test ended.
 
     These tests drive ``take_snapshot`` and ``assert_no_leaks`` by hand, and the
-    freeze bookkeeping between them is process-wide module state. A test that
-    fails partway leaves a name in ``_frozen_for`` that nothing pops, so the heap
-    stays frozen and every later check in this worker stops freezing and thawing
-    -- degrading quietly rather than failing. The real conftest cannot strand it
-    that way, because it takes the snapshot in setup and asserts in teardown,
-    which pytest always runs.
+    freeze bookkeeping between them is process-wide state inside ``refleak``. A
+    test that fails partway leaves it holding a freeze that nothing releases, so
+    the heap stays frozen and every later check in this worker stops freezing and
+    thawing -- degrading quietly rather than failing. The real conftest cannot
+    strand it that way, because it takes the snapshot in setup and asserts in
+    teardown, which pytest always runs.
     """
     yield
-    gc_check._frozen_for.clear()
+    # refleak counts nested freezes in a module global, and only the outermost thaw
+    # unfreezes; a stranded count would keep every later thaw in this worker from
+    # reaching gc.unfreeze(). Nothing public resets it, hence the reach inside.
+    _refleak_core._freeze_depth = 0
     gc.unfreeze()
 
 
@@ -57,6 +61,8 @@ def test_nested_checks_thaw_only_once() -> None:
     conftest, so the checks nest for real (see tests/plotting/test_conftest.py).
     Freezing is process-wide, so an inner thaw hands the outer test the whole
     process to account for, and it reports every VTK object in it as a leak.
+    ``refleak`` counts the nesting; this is the check that pyvista still gets the
+    behavior it depends on.
     """
     # The stubs report no passing call phase, so the checks do their freeze
     # bookkeeping and skip the scan itself, which is what is under test here.
@@ -118,3 +124,25 @@ def test_leak_at_a_reused_address_is_still_found() -> None:
     assert id(leaked) == address, 'the allocator did not hand the address back'
     leaked.self_ref = None  # break the cycle, so the leak does not outlive its test
     del leaked
+
+
+@pytest.mark.parametrize(
+    ('markers', 'opted_out', 'expected'),
+    [
+        ((), False, True),
+        ((), True, False),
+        (('skip_check_gc',), False, False),
+        # A test asserting that the check fails runs it even when the run opted out.
+        (('expect_check_gc_fail',), True, True),
+        # skip wins: a test that cannot survive a frozen heap cannot survive one
+        # because it also expects the check to fail.
+        (('skip_check_gc', 'expect_check_gc_fail'), False, False),
+    ],
+)
+def test_check_enabled(markers, opted_out, expected) -> None:
+    """Everything is checked but what ``--no_check_gc`` or a marker takes out."""
+    node = SimpleNamespace(
+        config=SimpleNamespace(getoption=lambda _name, default=None: opted_out),  # noqa: ARG005
+        get_closest_marker=lambda name: name if name in markers else None,
+    )
+    assert gc_check.check_enabled(node) is expected

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,10 @@ passenv =
 setenv =
     TOX_ROOT = {tox_root}
     PYTEST_ADDOPTS = --color=yes -v {env:PARALLEL:}
+    # Opting out of the reference leak check (see tests/gc_check.py) goes here rather
+    # than in the commands below because those pass their arguments as posargs defaults,
+    # which a scoped run replaces wholesale.
+    no_check_gc: PYTEST_ADDOPTS = --color=yes -v {env:PARALLEL:} --no_check_gc
     cov: COVERAGE_CORE = {env:COVERAGE_CORE:ctrace}
 
 dependency_groups = test
@@ -116,11 +120,12 @@ software_report_cmdline=
 # invocation as CI. They inherit from [testenv] above and rely on the
 # existing `core` / `plotting` factor logic so filters are maintained
 # in one place.
-[testenv:test{,-core,-plotting}]
+[testenv:test{,-core,-plotting}{,-no_check_gc}]
 description =
     test: Run the full test suite locally (core + plotting, matches CI flags)
     test-core: Run core tests locally (matches CI `tox run -e pyX.Y-core`)
     test-plotting: Run plotting tests locally (matches CI `tox run -e pyX.Y-plotting`)
+    no_check_gc: without the reference leak check
 
 # ================= PLAYWRIGHT TESTING ENVIRONMENT =================
 # This environment is specialized to run PyVista tests that require


### PR DESCRIPTION
@akaszynski this PR adopts refleak 0.2.2 which has the freeze from #8916. Given the freeze speedup, I don't think we need a separate set of tests for GC -- with refleak checking on vs off was ~1-2% of added test time for me. This PR nonetheless adds an opt-out mode in case people want it or we end up needing it.

Once this is in, I'll work toward making it an autouse fixture probably and then fixing bugs it finds (maybe it won't find any! :laughing: )