### PR TITLE
Document `PartitionedDataSet` in Dataset Gallery

### DIFF
--- a/pyvista/examples/_dataset_loader.py
+++ b/pyvista/examples/_dataset_loader.py
@@ -260,7 +260,7 @@ class _DatasetLoader:
                 return [obj]
 
         flat = _flat(dataset)
-        if isinstance(dataset, pv.MultiBlock):
+        if isinstance(dataset, (pv.MultiBlock, pv.PartitionedDataSet)):
             flat.insert(0, dataset)
         return tuple(flat)
 


### PR DESCRIPTION
This PR fixes `PartitionedDataSet` missing from the Dataset Gallery filters and the Warping Spheres dataset. Preview:
<img width="1466" height="1256" alt="image" src="https://github.com/user-attachments/assets/a2f8f786-5cf6-48e0-af89-a2ca24c4bea7" />
