### PR TITLE
Fix dataset accessors pinning their dataset

### DIFF
--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -21,6 +21,7 @@ from pyvista.typing.mypy_plugin import promote_type
 
 from .datasetattributes import DataSetAttributes
 from .pyvista_ndarray import pyvista_ndarray
+from .utilities.accessor_registry import _clear_accessor_cache
 from .utilities.accessor_registry import _pending_accessor_names
 from .utilities.accessor_registry import _resolve_pending_accessor
 from .utilities.arrays import FieldAssociation
@@ -896,6 +897,8 @@ class DataObject(
         # Any cached vtk objects (e.g. vtkLocator objects) must be removed since
         # these cannot be serialized
         _clear_vtk_objects_from_dict(data_dict)
+        # Nor can a cached accessor's weak reference, and a cache is not worth carrying
+        _clear_accessor_cache(data_dict)
 
         state_dict['_PYVISTA_STATE_DICT'] = data_dict
 
@@ -924,6 +927,7 @@ class DataObject(
             )
             raise TypeError(msg)
         state = self.__dict__.copy()
+        _clear_accessor_cache(state)  # a weak reference cannot be pickled
 
         if pv.PICKLE_FORMAT.lower() == 'xml':
             # the generic VTK XML writer `vtkXMLDataSetWriter` currently has a bug where it does

--- a/pyvista/core/utilities/accessor_registry.py
+++ b/pyvista/core/utilities/accessor_registry.py
@@ -28,8 +28,6 @@ pyvista.registered_accessors
 
 from __future__ import annotations
 
-import contextlib
-
 # ICN003 waived: tests patch this module-level name to intercept plugin
 # imports. Patching `importlib.import_module` instead would apply globally,
 # for every importer, for the duration of the test.
@@ -41,7 +39,9 @@ from typing import NamedTuple
 from typing import Protocol
 from typing import TypedDict
 from typing import runtime_checkable
+import weakref
 
+from pyvista import _vtk
 from pyvista._warn_external import warn_external
 
 if TYPE_CHECKING:
@@ -138,21 +138,58 @@ class _AccessorRegistryState(TypedDict):
     pending: dict[str, str]
 
 
+# Cached-accessor bookkeeping lives in the instance dict under this prefix. It is
+# stripped from the pickled state (see ``pyvista.core.dataobject``): a weak reference
+# cannot be pickled, and a cache is not state worth carrying to another process.
+_ACCESSOR_CACHE_PREFIX = '_pyvista_accessor_'
+
+# The anchor below observes an event nothing invokes -- not VTK, not PyVista. It exists
+# only to hold a reference. ``UserEvent`` is VTK's documented base for ids that VTK
+# itself will never fire; should another library fire this exact id, the anchor is a
+# no-op callable and nothing happens.
+_ACCESSOR_ANCHOR_EVENT = _vtk.vtkCommand.UserEvent + 1701
+
+
+class _AccessorAnchor:
+    """Hold an accessor from its dataset's observer list.
+
+    See :class:`_CachedAccessor` for why the observer list, of all places.
+    """
+
+    __slots__ = ('accessor',)
+
+    def __init__(self, accessor: Any) -> None:
+        self.accessor = accessor
+
+    def __call__(self, *args: Any) -> None:
+        """Do nothing: the event this observes is never invoked."""
+
+
 class _CachedAccessor:
-    """Non-data descriptor implementing the pandas/xarray accessor pattern.
+    """Data descriptor implementing the pandas/xarray accessor pattern.
 
-    The first time ``obj.<name>`` is accessed, ``accessor_cls(obj)`` is
-    constructed and stored in ``obj.__dict__[name]``. Subsequent lookups
-    bypass the descriptor and hit ``__dict__`` directly because a
-    non-data descriptor yields to instance ``__dict__``.
+    The first time ``obj.<name>`` is accessed, ``accessor_cls(obj)`` is constructed
+    and cached for as long as ``obj`` lives, so repeated access returns the same
+    accessor and ``__init__`` runs once per dataset.
 
-    When the target class uses ``__slots__`` and no ``__dict__`` is
-    available, the accessor is constructed fresh on each access — slower
-    but still correct.
+    The cache is deliberately indirect: the instance ``__dict__`` holds a weak
+    reference, and the accessor is kept alive by an observer on ``obj``. Caching it
+    the obvious way, as ``obj.__dict__[name] = accessor``, leaks the dataset outright.
+    An accessor that stores the dataset -- the documented pattern, ``self._mesh =
+    mesh`` -- closes a reference cycle through the instance dict of a VTK object, and
+    VTK's ``tp_traverse`` reports observers but never that dict (nor is there a
+    ``tp_clear``), so the collector cannot see the cycle and neither object is ever
+    freed. The observer list is the one place a VTK object's Python references *are*
+    reported, so a cycle anchored there collects normally.
+
+    When the target uses ``__slots__`` and has no ``__dict__``, or is not a
+    ``vtkObject`` and so has nowhere to anchor, the accessor is constructed fresh on
+    each access -- slower but still correct.
     """
 
     def __init__(self, name: str, accessor_cls: type) -> None:
         self._name = name
+        self._cache_key = _ACCESSOR_CACHE_PREFIX + name
         self._accessor_cls = accessor_cls
 
     def __repr__(self) -> str:  # pragma: no cover - trivial
@@ -163,12 +200,63 @@ class _CachedAccessor:
             # Class-level access returns the accessor class itself so
             # ``help(cls.<name>)`` shows the accessor docstring.
             return self._accessor_cls
-        accessor_instance = self._accessor_cls(obj)
-        # Skip the cache on ``__slots__`` targets (no ``__dict__``) and
-        # construct fresh on each access.
-        with contextlib.suppress(AttributeError):
-            obj.__dict__[self._name] = accessor_instance
-        return accessor_instance
+        obj_dict = getattr(obj, '__dict__', None)
+        if obj_dict is None:
+            return self._accessor_cls(obj)
+        if self._name in obj_dict:
+            # A value assigned over the accessor wins, as it did when this was a
+            # non-data descriptor and the instance dict shadowed it.
+            return obj_dict[self._name]
+        cached = obj_dict.get(self._cache_key)
+        if cached is not None:
+            owner_id, accessor_ref, _tag = cached
+            accessor = accessor_ref()
+            # The id guards against an entry that reached a *copy* of ``obj``: a live
+            # accessor holds its own dataset, so while the weak reference is alive that
+            # dataset cannot have been freed and its id cannot have been reused.
+            if accessor is not None and owner_id == id(obj):
+                return accessor
+        accessor = self._accessor_cls(obj)
+        self._cache(obj, obj_dict, accessor)
+        return accessor
+
+    def _cache(self, obj: Any, obj_dict: dict[str, Any], accessor: Any) -> None:
+        """Anchor the accessor to ``obj`` and record how to find it again."""
+        add_observer = getattr(obj, 'AddObserver', None)
+        if add_observer is None:
+            return  # not a vtkObject: nowhere to anchor it, so do not cache
+        try:
+            accessor_ref = weakref.ref(accessor)
+        except TypeError:
+            return  # accessor class is not weak-referenceable (``__slots__``)
+        tag = add_observer(_ACCESSOR_ANCHOR_EVENT, _AccessorAnchor(accessor))
+        obj_dict[self._cache_key] = (id(obj), accessor_ref, tag)
+
+    def __set__(self, obj: Any, value: Any) -> None:
+        # Defining __delete__ makes this a data descriptor, which takes precedence over
+        # the instance dict, so assignment has to be forwarded there explicitly to keep
+        # shadowing an accessor working as it did.
+        obj.__dict__[self._name] = value
+
+    def __delete__(self, obj: Any) -> None:
+        obj_dict = getattr(obj, '__dict__', None)
+        deleted = False
+        if obj_dict is not None:
+            if obj_dict.pop(self._name, _MISSING) is not _MISSING:
+                deleted = True
+            cached = obj_dict.pop(self._cache_key, None)
+            if cached is not None:
+                obj.RemoveObserver(cached[2])  # drop the anchor, so the accessor dies
+                deleted = True
+        if not deleted:
+            msg = self._name
+            raise AttributeError(msg)
+
+
+def _clear_accessor_cache(dict_: dict[str, Any]) -> None:
+    """Drop cached-accessor bookkeeping from an instance dict."""
+    for key in [key for key in dict_ if key.startswith(_ACCESSOR_CACHE_PREFIX)]:
+        del dict_[key]
 
 
 # ``_MISSING`` marks "attribute did not exist on the target class dict

--- a/tests/core/test_accessor_registry.py
+++ b/tests/core/test_accessor_registry.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import contextlib
+import gc
+import pickle
 import sys
 from types import ModuleType
 from unittest.mock import MagicMock
 import warnings
+import weakref
 
 import pytest
 
@@ -66,6 +69,75 @@ def test_same_cached_accessor_returned_on_repeat_access():
     first = sphere.cached
     second = sphere.cached
     assert first is second
+
+
+def test_cached_accessor_does_not_pin_its_dataset():
+    """The cache must not close an uncollectable cycle through the dataset.
+
+    An accessor holding the dataset is the documented pattern, and caching the
+    accessor in ``dataset.__dict__`` would make that pair immortal: the cycle runs
+    through the instance dict of a VTK object, which VTK's ``tp_traverse`` does not
+    report, so the collector never sees it. Hence the anchor in the observer list
+    (see :class:`~pyvista.core.utilities.accessor_registry._CachedAccessor`).
+    """
+
+    @pv.register_dataset_accessor('pinning', pv.PolyData)
+    class PinningAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+    sphere = pv.Sphere()
+    accessor_ref = weakref.ref(sphere.pinning)
+    assert accessor_ref()._mesh is sphere  # the real dataset, not a proxy
+    sphere_ref = weakref.ref(sphere)
+
+    del sphere
+    gc.collect()
+    assert sphere_ref() is None, 'the accessor cache pinned the dataset'
+    assert accessor_ref() is None
+
+
+def test_cached_accessor_survives_a_pickle_round_trip():
+    """A cached accessor holds a weak reference, which cannot be pickled."""
+
+    @pv.register_dataset_accessor('picklable', pv.PolyData)
+    class PicklableAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+        def n_points(self):
+            return self._mesh.n_points
+
+    sphere = pv.Sphere()
+    assert sphere.picklable.n_points() == sphere.n_points
+
+    restored = pickle.loads(pickle.dumps(sphere))
+    assert restored.n_points == sphere.n_points
+    # and the restored dataset builds its own accessor, bound to itself
+    assert restored.picklable is not sphere.picklable
+    assert restored.picklable._mesh is restored
+
+
+def test_assignment_shadows_the_accessor():
+    """Assigning over an accessor wins, and deleting brings the accessor back."""
+
+    @pv.register_dataset_accessor('shadowed', pv.PolyData)
+    class ShadowedAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+    sphere = pv.Sphere()
+    assert isinstance(sphere.shadowed, ShadowedAccessor)
+
+    sphere.shadowed = 42
+    assert sphere.shadowed == 42
+
+    del sphere.shadowed
+    assert isinstance(sphere.shadowed, ShadowedAccessor)
+
+    del sphere.shadowed
+    with pytest.raises(AttributeError):
+        del sphere.shadowed
 
 
 def test_del_evicts_cache():

--- a/tests/core/test_accessor_registry.py
+++ b/tests/core/test_accessor_registry.py
@@ -97,6 +97,77 @@ def test_cached_accessor_does_not_pin_its_dataset():
     assert accessor_ref() is None
 
 
+def test_accessor_on_a_target_without_an_observer_list_is_not_cached():
+    """A target with a ``__dict__`` but no observer list has nowhere to anchor.
+
+    Caching it in the instance dict is exactly the cycle this indirection exists to
+    avoid, so the accessor is built fresh on each access instead.
+    """
+
+    class PlainTarget:
+        pass
+
+    @pv.register_dataset_accessor('plain_acc', PlainTarget)
+    class PlainAccessor:
+        def __init__(self, obj):
+            self._obj = obj
+
+    instance = PlainTarget()
+    assert instance.plain_acc._obj is instance
+    assert instance.plain_acc is not instance.plain_acc
+
+
+def test_accessor_that_cannot_be_weakly_referenced_is_not_cached():
+    """An accessor with ``__slots__`` and no ``__weakref__`` cannot be cached."""
+
+    @pv.register_dataset_accessor('unreferenceable', pv.PolyData)
+    class UnreferenceableAccessor:
+        __slots__ = ('_mesh',)
+
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+    sphere = pv.Sphere()
+    assert sphere.unreferenceable._mesh is sphere
+    assert sphere.unreferenceable is not sphere.unreferenceable
+
+
+def test_cache_entry_from_another_dataset_is_ignored():
+    """A cache entry that reached a copy of the dataset must not be honored.
+
+    Nothing in PyVista copies an instance dict today -- pickling strips the entry --
+    but honoring one would hand back an accessor bound to a different dataset.
+    """
+
+    @pv.register_dataset_accessor('borrowed', pv.PolyData)
+    class BorrowedAccessor:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+    sphere = pv.Sphere()
+    other = pv.Sphere()
+    accessor = sphere.borrowed
+    other.__dict__.update(sphere.__dict__)
+
+    assert other.borrowed is not accessor
+    assert other.borrowed._mesh is other
+
+
+def test_del_on_a_slotted_target_raises():
+    """A ``__slots__`` target has no per-instance accessor state to delete."""
+
+    class SlottedTarget:
+        __slots__ = ()
+
+    @pv.register_dataset_accessor('slotted_del', SlottedTarget)
+    class SlottedAccessor:
+        def __init__(self, obj):
+            self._obj = obj
+
+    with pytest.raises(AttributeError, match='slotted_del'):
+        del SlottedTarget().slotted_del
+
+
 def test_cached_accessor_survives_a_pickle_round_trip():
     """A cached accessor holds a weak reference, which cannot be pickled."""
 


### PR DESCRIPTION
(I generated the below summary using Claude Opus 5 using the `pyvista-pr` skill. Usually I write these myself or at least reword / adjust, but I'll leave this verbatim as a test of / testament to that skill! Note that the agent said that disclosure was optional, so it didn't add one. I would suggest maybe modifying the skill to have that, and to say that a human should write that part. But that's a separate issue... In any case, I used Opus to draft these changes but reviewed them myself already as well. I've opened https://gitlab.kitware.com/vtk/vtk/-/merge_requests/13603 upstream as well but that won't make it until VTK 10 (or 9.8 if they cut one).)

### Overview

An accessor registered with `register_dataset_accessor` is built once per dataset and cached in `dataset.__dict__`, and the documented accessor stores the dataset it was built for. That closes a reference cycle through the instance dict of a VTK object, which `PyVTKObject_Traverse` never reports (there is no `tp_clear` either), so the collector cannot see it and every `dataset.<accessor>` access pins its dataset for the life of the process:

```python
>>> from vtkmodules.vtkCommonCore import vtkPoints
>>> p = vtkPoints()
>>> p.__dict__['self'] = p
>>> del p
>>> gc.collect()
0
```
The cache now keeps a weak reference in the instance dict and holds the accessor from the dataset's observer list instead, which is the one place a VTK object's Python references are reported, so the cycle collects normally. The API is unchanged: repeated access returns the same accessor, and it still holds the real dataset rather than a proxy.