### PR TITLE
Require disclosing AI use in pull requests

### DIFF
--- a/.claude/skills/pyvista-pr/SKILL.md
+++ b/.claude/skills/pyvista-pr/SKILL.md
@@ -93,13 +93,17 @@ verification matters, it fits in a clause.
 
 ## Disclosing AI assistance
 
-The `Generative AI` section of `CONTRIBUTING.rst` adopts the Python Developer's Guide
-[policy on AI tools](https://devguide.python.org/getting-started/ai-tools/): disclosure in
-the pull request description is appreciated and not required, and the person opening the
-pull request owns everything in it. When disclosing, use one inline clause naming what the tool did and confirming the
-author understood it, in the form merged descriptions already use:
+The `Generative AI` section of `CONTRIBUTING.rst` requires disclosure, unlike the Python
+Developer's Guide [policy on AI tools](https://devguide.python.org/getting-started/ai-tools/)
+it otherwise follows: a pull request you helped write says so in its description. Use one
+inline clause naming what the tool did and confirming the author understood it, in the form
+merged descriptions already use:
 
 > Changes drafted by Claude Opus 5 but fully understood by me
+
+The second half of that clause is the author's statement, not yours. Put it in the draft so
+the sentence is complete, and say plainly that it is theirs to confirm, reword, or drop —
+you cannot attest that someone else reviewed the change.
 
 No banner, no badge, no separate heading, no generated-with footer. Put it in the
 description rather than only in a commit trailer, because the description is what a
@@ -107,16 +111,20 @@ reviewer reads first.
 
 ## Before opening
 
-1. Draft the title and body.
-2. If the body is longer than the diff deserves and carries no screenshots, cut rather
+1. Check the branch name against `Branch Naming Conventions` in `CONTRIBUTING.rst`, and
+   that the prefix is not itself a branch on the remote (`git ls-remote --heads origin
+refs/heads/doc`) -- pushing `doc/x` to a fork that has a `doc` branch is rejected with
+   `directory file conflict`.
+2. Draft the title and body.
+3. If the body is longer than the diff deserves and carries no screenshots, cut rather
    than restructure.
-3. Confirm every paragraph is a single unbroken line.
-4. Strip anything that reads as generated: section scaffolding, bold labels, hedged
+4. Confirm every paragraph is a single unbroken line.
+5. Strip anything that reads as generated: section scaffolding, bold labels, hedged
    summary sentences, rule-of-three lists.
-5. Add `Resolves #NNNN` when the change fully closes an issue.
-6. Confirm the local gates pass. Continuous integration runs on `pull_request`, so a red
+6. Add `Resolves #NNNN` when the change fully closes an issue.
+7. Confirm the local gates pass. Continuous integration runs on `pull_request`, so a red
    pull request costs the whole matrix.
-7. Open as a draft unless the change is ready for review.
+8. Open as a draft unless the change is ready for review.
 
 ## Example
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,8 @@
 
 <!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->
 
+<!-- If an AI tool wrote any part of this pull request, including this description, say so here in your own words. -->
+
 ### Details
 
 - < feature1 or bug1 description >

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,9 @@ baseline the run collected.
 
 ## Disclosing agent use
 
-`CONTRIBUTING.rst` follows the Python Developer's Guide: disclosure in the pull request
-description is appreciated and not required, and whoever opens the pull request is
-responsible for its content and for what each push costs the project.
+`CONTRIBUTING.rst` requires it: when you write any part of a pull request, its
+description has to say so. Draft that clause along with the rest of the description, and
+hand it to the author to confirm or reword — it is their statement that they reviewed the
+change and can explain it, so never write it as though you were them and never assert on
+their behalf that they understood it. Whoever opens the pull request is responsible for
+its content and for what each push costs the project.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -138,9 +138,16 @@ original author to relicense the code.
 Generative AI
 -------------
 
-We follow the Python Developer's Guide on `AI tools <https://devguide.python.org/getting-started/ai-tools/>`_.
+We follow the Python Developer's Guide on `AI tools <https://devguide.python.org/getting-started/ai-tools/>`_,
+with one difference: disclosure is required here, where the guide only appreciates it.
 The resulting contribution is the responsibility of the contributor, and we value good code,
 concise accurate documentation, and avoiding unneeded code churn.
+
+If an AI tool wrote any part of a pull request -- code, tests, documentation, or the
+description itself -- say so in the description. Write that sentence yourself: it states
+that you reviewed the change and can explain it, which no tool can attest to on your
+behalf. One clause naming the tool and what it did is enough, in the form merged
+descriptions already use, e.g. ``Changes drafted by Claude Opus 5 but fully understood by me``.
 
 That responsibility covers what the contribution costs us to review and to test.
 If you work with a coding agent, point it at ``AGENTS.md`` in the repository root,
@@ -682,6 +689,12 @@ changes any given branch is introducing before looking at the code.
 -  ``testing/``: improvements or changes to testing
 -  ``release/``: releases (see below)
 -  ``breaking-change/``: Changes that break backward compatibility
+
+A prefix is unusable on a remote that already has a branch named exactly that, since
+Git cannot store a ref as both a file and a directory: pushing ``doc/my-change`` to a
+fork that still has an old ``doc`` branch is rejected with ``directory file conflict``.
+Check the remote you push to with ``git ls-remote --heads origin refs/heads/doc``, then
+either use another prefix or delete the stale branch.
 
 Testing
 ^^^^^^^


### PR DESCRIPTION
The Python Developer's Guide we otherwise follow only appreciates disclosure. Per the discussion in #8925, require it here instead, and say what one looks like: a clause naming the tool and what it did.

The agent instructions get the other half. Reading "appreciated and not required", an agent left the disclosure off #8925 altogether; the pull request skill now has it draft the clause, and has it hand the "understood by me" half to the author to confirm or reword, since no tool can attest that someone else reviewed a change.

Drafted by Claude Opus 5 and reviewed by me.