### PR TITLE
Pin notebook mode off for the test suite

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -130,7 +130,7 @@ jobs:
             [mne]="@larsoner"
             [trame]="@user27182"
             [pyvistaqt]="@larsoner"
-            [geovista]=""
+            [geovista]="@bjlittle"
             [playwright]="@user27182"
           )
 

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -3663,12 +3663,16 @@ class _TestingTheme(Theme):
     Resampling is also enabled for environment textures since this
     can be very slow without a GPU.
 
+    Notebook mode is pinned off rather than detected, so that a test plots the same
+    way wherever it runs.
+
     """
 
     _default_name: ClassVar[str] = 'testing'
 
     def __init__(self):
         super().__init__()
+        self.notebook = False
         self.multi_samples = 1
         self.window_size = [400, 400]
         self.border_color = 'black'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,6 +149,14 @@ def set_mpl():
 
 @pytest.fixture(autouse=True)
 def reset_global_state():
+    # Pin notebook mode off. Left to its default the plotter asks scooby whether it is
+    # in an ipykernel, so a test that plots renders through the trame jupyter backend on
+    # any machine that answers yes -- which launches the process-lifetime
+    # 'pyvista-jupyter' server, and whichever test does that first is blamed for the
+    # vtkWebApplication it leaves behind (pyvista/pyvista#8929). Tests that want a
+    # notebook pass notebook=True themselves.
+    pv.global_theme.notebook = False
+
     # Default is to allow new 'private' attributes for downstream packages,
     # but for PyVista itself we enforce no new attributes
     pv.allow_new_attributes(False)

--- a/tests/plotting/test_theme.py
+++ b/tests/plotting/test_theme.py
@@ -802,3 +802,13 @@ def test_trame_config_server_proxy_prefix_absolute_url(monkeypatch):
 def test_box_axes(default_theme):
     default_theme.axes.box = True
     _ = pv.Sphere().plot(theme=default_theme)
+
+
+def test_testing_theme_pins_notebook_off():
+    """Detected notebook mode would route a plotting test through the trame backend.
+
+    That launches the process-lifetime ``pyvista-jupyter`` server, and whichever test
+    creates it first is blamed for the ``vtkWebApplication`` it leaves behind
+    (pyvista/pyvista#8929).
+    """
+    assert pv.plotting.themes._TestingTheme().notebook is False

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -645,3 +645,16 @@ def test_skip_mac(
         assert 'test_skipped_platform_machine' in report.skipped
     else:
         assert 'test_skipped_platform_machine' in report.passed
+
+
+def test_notebook_mode_is_pinned_off():
+    """``reset_global_state`` pins notebook mode, rather than leaving it detected.
+
+    Left at its default of ``None``, a plotter asks scooby whether it is running in an
+    ipykernel, so on a machine that answers yes an ordinary plotting test renders through
+    the trame jupyter backend and launches the process-lifetime ``pyvista-jupyter``
+    server. Whichever test does that first is then blamed for the ``vtkWebApplication``
+    it leaves behind (pyvista/pyvista#8929). Tests that want a notebook pass
+    ``notebook=True`` themselves.
+    """
+    assert pv.global_theme.notebook is False


### PR DESCRIPTION
One half of https://github.com/pyvista/pyvista/issues/8929 . I also snuck in adding a maintainer to the integration-test notifier since that was requested (overkill as its own PR I think).

Left at its default of None, a plotter asks scooby whether it is running in an ipykernel, so on a machine that answers yes an ordinary plotting test renders through the trame jupyter backend. That launches the process-lifetime 'pyvista-jupyter' server, and whichever test creates it first is blamed for the vtkWebApplication it leaves behind -- which is what the leak check reported for tests/test_cli.py on the macOS and Windows runners in #8929, now that it covers that file.

Tests that want a notebook pass notebook=True themselves, so pinning it costs nothing and makes plotting deterministic across runners.

Changes drafted by Claude Opus 5 and reviewed/understood by me.