### PR TITLE
Use blacksmith runners for docs image testing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
     uses: ./.github/workflows/cache-pyvista-data.yml
     with:
       # Runner should match the actual runner used by the build job
-      runs-on: "blacksmith-8vcpu-ubuntu-2204"
+      runs-on: blacksmith-8vcpu-ubuntu-2204
 
   doc:
     name: Build Documentation
@@ -150,7 +150,7 @@ jobs:
 
   test:
     name: Test Documentation
-    runs-on: ubuntu-22.04
+    runs-on: blacksmith-8vcpu-ubuntu-2204
     needs: doc
     if: ${{ !cancelled() }}
     env:


### PR DESCRIPTION
### Overview

The docs build is the current CI bottleneck, taking approx 40 minutes for the whole job: ~25-30 for cache, build, and html upload, and ~10-15 for the tests.

The tests are rendering-heavy for the conversion of vtksz files into screenshots. This PR uses the blacksmith runners for the tests to see if it can speed things up