### PR TITLE
Fix enum value format, hoisted See Also ordering, remove See Also duplicates

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -748,20 +748,14 @@ def promote_seealso_admonitions(app: Sphinx, doctree: Element) -> None:  # noqa:
     hoist_docstring_sections below lift it to page level the same way.
 
     A literal ``.. seealso::`` is written wherever the docstring author put it --
-    usually right after the summary, well before References/Examples -- unlike
-    numpydoc's own "See Also", which _DOCSTRING_TEMPLATE above always renders last.
-    Reposition the promoted section to match: directly before "Used In" if present,
-    otherwise at the very end.
+    usually right before References/Examples -- unlike numpydoc's own "See Also",
+    which _DOCSTRING_TEMPLATE above always renders last. Reposition the promoted
+    section to match: directly before "Used In" if present, otherwise at the end.
 
-    "Used In" (sphinx-autocodelink's backreferences section, appended after the whole
-    docstring) is *not* necessarily a sibling of this one: nothing textually closes the
-    docstring's last real heading (usually Examples) before it, so the directive that
-    builds it lands *nested inside* that heading's section instead -- it only reads as
-    a sibling in the rendered page because hoist_docstring_sections below extracts
-    every section it finds, at any depth, up to page level. Search the whole enclosing
-    ``desc_content`` for "Used In", at any depth, and slot directly before it wherever
-    that turns out to be, so hoist_docstring_sections' document-order walk still finds
-    "See Also" first.
+    "Used In" isn't necessarily a sibling: nothing closes off the docstring's last
+    heading before its directive runs, so it lands nested inside that heading's
+    section instead, and only reads as a sibling once hoist_docstring_sections
+    below extracts every section it finds. Search at any depth to still find it.
     """
     for admonition in list(doctree.findall(addnodes.seealso)):
         if not _is_nested_desc(admonition):

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -750,9 +750,18 @@ def promote_seealso_admonitions(app: Sphinx, doctree: Element) -> None:  # noqa:
     A literal ``.. seealso::`` is written wherever the docstring author put it --
     usually right after the summary, well before References/Examples -- unlike
     numpydoc's own "See Also", which _DOCSTRING_TEMPLATE above always renders last.
-    Reposition the promoted section to match: directly before "Used In" (appended
-    after the whole docstring, so it's always the true last section) if present,
+    Reposition the promoted section to match: directly before "Used In" if present,
     otherwise at the very end.
+
+    "Used In" (sphinx-autocodelink's backreferences section, appended after the whole
+    docstring) is *not* necessarily a sibling of this one: nothing textually closes the
+    docstring's last real heading (usually Examples) before it, so the directive that
+    builds it lands *nested inside* that heading's section instead -- it only reads as
+    a sibling in the rendered page because hoist_docstring_sections below extracts
+    every section it finds, at any depth, up to page level. Search the whole enclosing
+    ``desc_content`` for "Used In", at any depth, and slot directly before it wherever
+    that turns out to be, so hoist_docstring_sections' document-order walk still finds
+    "See Also" first.
     """
     for admonition in list(doctree.findall(addnodes.seealso)):
         if not _is_nested_desc(admonition):
@@ -761,18 +770,26 @@ def promote_seealso_admonitions(app: Sphinx, doctree: Element) -> None:  # noqa:
         section += nodes.title(text='See Also')
         section.extend(admonition.children)
         doctree.note_implicit_target(section, section)
-        parent = admonition.parent
+
+        container = admonition.parent
+        while container is not None and not isinstance(container, addnodes.desc_content):
+            container = container.parent
+
         admonition.replace_self(section)
-        parent.remove(section)
-        used_in = next(
-            (
-                sibling
-                for sibling in parent
-                if isinstance(sibling, nodes.section) and sibling[0].astext() == 'Used In'
-            ),
-            None,
+        section.parent.remove(section)
+
+        used_in = (
+            next(
+                (s for s in container.findall(nodes.section) if s[0].astext() == 'Used In'),
+                None,
+            )
+            if container is not None
+            else None
         )
-        parent.insert(parent.index(used_in) if used_in is not None else len(parent), section)
+        if used_in is not None:
+            used_in.parent.insert(used_in.parent.index(used_in), section)
+        else:
+            (container if container is not None else admonition.parent).append(section)
 
 
 def hoist_docstring_sections(app: Sphinx, doctree: Element) -> None:  # noqa: ARG001

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -746,6 +746,13 @@ def promote_seealso_admonitions(app: Sphinx, doctree: Element) -> None:  # noqa:
     this page" navbar -- the same problem fixed above for numpydoc's own "See
     Also" section by not wrapping it in one. Converting it to a section here lets
     hoist_docstring_sections below lift it to page level the same way.
+
+    A literal ``.. seealso::`` is written wherever the docstring author put it --
+    usually right after the summary, well before References/Examples -- unlike
+    numpydoc's own "See Also", which _DOCSTRING_TEMPLATE above always renders last.
+    Reposition the promoted section to match: directly before "Used In" (appended
+    after the whole docstring, so it's always the true last section) if present,
+    otherwise at the very end.
     """
     for admonition in list(doctree.findall(addnodes.seealso)):
         if not _is_nested_desc(admonition):
@@ -754,7 +761,18 @@ def promote_seealso_admonitions(app: Sphinx, doctree: Element) -> None:  # noqa:
         section += nodes.title(text='See Also')
         section.extend(admonition.children)
         doctree.note_implicit_target(section, section)
+        parent = admonition.parent
         admonition.replace_self(section)
+        parent.remove(section)
+        used_in = next(
+            (
+                sibling
+                for sibling in parent
+                if isinstance(sibling, nodes.section) and sibling[0].astext() == 'Used In'
+            ),
+            None,
+        )
+        parent.insert(parent.index(used_in) if used_in is not None else len(parent), section)
 
 
 def hoist_docstring_sections(app: Sphinx, doctree: Element) -> None:  # noqa: ARG001

--- a/pyvista/core/celltype.py
+++ b/pyvista/core/celltype.py
@@ -863,12 +863,6 @@ class CellType(IntEnum, metaclass=_CellTypeMeta):
         :mod:`pyvista.examples.cells`
             Examples creating a mesh comprising a single cell.
 
-        :ref:`linear_cells_example`
-            Detailed example using linear cells.
-
-        :ref:`create_polyhedron_example`
-            Example creating a mesh with :attr:`~pyvista.CellType.POLYHEDRON` cells.
-
         :ref:`create_polydata_strips_example`
             Example creating a mesh with :attr:`~pyvista.CellType.TRIANGLE_STRIP` cells.
 

--- a/pyvista/core/grid.py
+++ b/pyvista/core/grid.py
@@ -665,10 +665,6 @@ class ImageData(Grid, ImageDataFilters, _vtk.vtkImageData):
 
         .. versionadded:: 0.47
 
-    See Also
-    --------
-    :ref:`create_uniform_grid_example`
-
     Examples
     --------
     Create an empty ImageData.

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -3832,10 +3832,6 @@ class StructuredGrid(PointGrid, StructuredGridFilters, _vtk.vtkStructuredGrid):
         Additional keyword arguments passed when reading from a file or loading
         from arrays.
 
-    See Also
-    --------
-    :ref:`create_structured_surface_example`
-
     Examples
     --------
     >>> import pyvista as pv
@@ -4250,10 +4246,6 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
         combination of fields allowed by ``validate_mesh``.
 
         .. versionadded:: 0.47
-
-    See Also
-    --------
-    :ref:`create_explicit_structured_grid_example`
 
     Examples
     --------

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -8791,9 +8791,6 @@ def download_whole_body_ct_female(
 
     .. seealso::
 
-        :ref:`anatomical_groups_example`
-            Additional examples using this dataset.
-
         :ref:`Whole Body Ct Female Dataset <whole_body_ct_female_dataset>`
             See this dataset in the Dataset Gallery for more info.
 

--- a/pyvista/ext/_autoenum.py
+++ b/pyvista/ext/_autoenum.py
@@ -114,7 +114,7 @@ def _is_bitmask_like(cls: type[Enum]) -> bool:
 
 
 def _format_value(value: Any, *, as_hex: bool) -> str:
-    """Format an enum member's value the way it should appear after ``:``."""
+    """Format an enum member's value the way it should appear after ``:value:``."""
     if as_hex:
         return hex(value)
     return repr(value) if isinstance(value, str) else str(value)
@@ -215,13 +215,8 @@ class EnumDocumenter(ClassDocumenter):
 
         for member in cls:
             self.add_line(f'.. py:attribute:: {cls.__name__}.{member.name}', sourcename)
-            # :annotation:, not :value: (renders "= 1") or :type: (renders "1" as a real
-            # annotation, parsed and re-rendered -- silently dropping hex formatting) --
-            # this renders raw, unparsed text, matching the enum's own repr as closely as
-            # Sphinx allows: "VERTEX : 1", not quite "VERTEX: 1" like ``<CellType.VERTEX: 1>``,
-            # since py:attribute always inserts a space before an :annotation:.
             self.add_line(
-                f'   :annotation: : {_format_value(member.value, as_hex=as_hex)}',
+                f'   :value: {_format_value(member.value, as_hex=as_hex)}',
                 sourcename,
             )
             self.add_line('', sourcename)

--- a/pyvista/plotting/axes_actor.py
+++ b/pyvista/plotting/axes_actor.py
@@ -30,9 +30,6 @@ class AxesActor(
     --------
     :class:`~pyvista.AxesAssembly`
 
-    :ref:`axes_objects_example`
-        Example showing different axes objects.
-
     Examples
     --------
     Customize the axis shaft color and shape.

--- a/pyvista/plotting/axes_assembly.py
+++ b/pyvista/plotting/axes_assembly.py
@@ -438,9 +438,6 @@ class AxesAssembly(_XYZAssembly):
     --------
     AxesAssemblySymmetric
 
-    :ref:`axes_objects_example`
-        Example showing different axes objects.
-
     Examples
     --------
     .. pyvista-plot::
@@ -1372,9 +1369,6 @@ class AxesAssemblySymmetric(AxesAssembly):
     See Also
     --------
     AxesAssembly
-
-    :ref:`axes_objects_example`
-        Example showing different axes objects.
 
     Examples
     --------

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -3186,11 +3186,6 @@ class Chart2D(_NoNewAttrMixin, DisableVtkSnakeCase, _Chart, _vtk.vtkChartXY):
     grid : bool, default: True
         Show the background grid in the plot.
 
-    See Also
-    --------
-    :ref:`chart_basics_example`
-    :ref:`chart_overlays_example`
-
     Examples
     --------
     Plot a simple sine wave as a scatter and line plot.
@@ -4624,10 +4619,6 @@ class ChartMPL(_NoNewAttrMixin, DisableVtkSnakeCase, _Chart, _vtk.vtkImageItem):
         Flag indicating whether the chart should be redrawn when
         the plotter is rendered. For static charts, setting this
         to ``False`` can improve performance.
-
-    See Also
-    --------
-    :ref:`chart_overlays_example`
 
     Examples
     --------

--- a/pyvista/plotting/cube_axes_actor.py
+++ b/pyvista/plotting/cube_axes_actor.py
@@ -130,8 +130,6 @@ class CubeAxesActor(
     --------
     :meth:`~pyvista.Plotter.show_bounds`
     :meth:`~pyvista.Plotter.show_grid`
-    :ref:`axes_objects_example`
-        Example showing different axes objects.
 
     Examples
     --------

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -161,10 +161,6 @@ class LookupTable(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkLookupTable):
         range to annotate on the scalar bar and the values are the string
         annotations.
 
-    See Also
-    --------
-    :ref:`lookup_table_example`
-
     Examples
     --------
     Plot the lookup table with the default VTK color map.

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -1560,11 +1560,6 @@ class PickingComponent(_NoNewAttrMixin):
             All remaining keyword arguments are used to control how
             the picked path is interactively displayed.
 
-        See Also
-        --------
-        :ref:`element_picking_example`
-
-
         """
         mode = ElementType.from_any(mode)
         self_ = weakref.ref(self)

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -190,10 +190,6 @@ class RenderWindowInteractor(_NoNewAttrMixin):
             A callable that takes one argument. It will be passed
             `step`, which is the number of times the timer event has occurred.
 
-        See Also
-        --------
-        :ref:`animation_example`
-
         Examples
         --------
         Add a timer to a Plotter to move a sphere across a scene.

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -1199,9 +1199,6 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
         --------
         add_axes
 
-        :ref:`axes_objects_example`
-            Example showing different axes objects.
-
         Examples
         --------
         >>> import pyvista as pv
@@ -1290,9 +1287,6 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
 
         add_north_arrow_widget
             Add north arrow as an orientation widget.
-
-        :ref:`axes_objects_example`
-            Example showing different axes objects.
 
         Examples
         --------
@@ -1408,9 +1402,6 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
 
         add_orientation_widget
             Add any actor as an orientation widget.
-
-        :ref:`axes_objects_example`
-            Example showing different axes objects.
 
         Examples
         --------
@@ -1537,9 +1528,6 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
 
         add_orientation_widget
             Add a custom mesh as an orientation widget.
-
-        :ref:`axes_objects_example`
-            Example showing different axes objects.
 
         Examples
         --------
@@ -1696,9 +1684,6 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
 
         add_orientation_widget
             Add any actor as an orientation widget.
-
-        :ref:`axes_objects_example`
-            Example showing different axes objects.
 
         Examples
         --------
@@ -2014,11 +1999,6 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
         remove_bounds_axes
         update_bounds_axes
 
-        :ref:`axes_objects_example`
-            Example showing different axes objects.
-        :ref:`bounds_example`
-            Additional examples using this method.
-
         Examples
         --------
         >>> import pyvista as pv
@@ -2311,11 +2291,6 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
         show_bounds
         remove_bounds_axes
         update_bounds_axes
-
-        :ref:`axes_objects_example`
-            Example showing different axes objects.
-        :ref:`bounds_example`
-            Additional examples using this method.
 
         Examples
         --------
@@ -3709,10 +3684,6 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
             Controls if occlusion buffer should be blurred before combining it
             with the color buffer.
 
-        See Also
-        --------
-        :ref:`ssao_example`
-
         Examples
         --------
         Generate a :class:`pyvista.UnstructuredGrid` with many tetrahedrons
@@ -4250,10 +4221,6 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
         -------
         :vtk:`vtkLegendBoxActor`
             Actor for the legend.
-
-        See Also
-        --------
-        :ref:`legend_example`
 
         Examples
         --------

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -995,10 +995,6 @@ class WidgetComponent(_NoNewAttrMixin):
         output : :vtk:`vtkPlaneWidget` | :vtk:`vtkImplicitPlaneWidget`
             The VTK plane widget depending on the value of ``implicit``.
 
-        See Also
-        --------
-        :ref:`clip_volume_widget_example`
-
         """
         if isinstance(volume, (pv.ImageData, pv.RectilinearGrid)):
             volume = self._plotter.add_volume(volume, **kwargs)
@@ -1619,10 +1615,6 @@ class WidgetComponent(_NoNewAttrMixin):
         -------
         :vtk:`vtkSliderWidget`
             Slider widget.
-
-        See Also
-        --------
-        :ref:`multi_slider_widget_example`
 
         Examples
         --------
@@ -2370,10 +2362,6 @@ class WidgetComponent(_NoNewAttrMixin):
         :vtk:`vtkDistanceWidget`
             The newly created distance widget.
 
-        See Also
-        --------
-        :ref:`distance_measurement_example`
-
         """
         msg = 'Cannot add a widget to a closed plotter.'
         iren = self._plotter._get_iren_not_none(msg)
@@ -2509,10 +2497,6 @@ class WidgetComponent(_NoNewAttrMixin):
         -------
         :vtk:`vtkSphereWidget`
             The sphere widget.
-
-        See Also
-        --------
-        :ref:`sphere_widget_example`
 
         """
         if color is None:
@@ -3023,9 +3007,6 @@ class WidgetComponent(_NoNewAttrMixin):
 
         :meth:`~pyvista.Plotter.add_box_axes`
             Add an axes box as an orientation widget.
-
-        :ref:`axes_objects_example`
-            Example showing different axes objects.
 
         Examples
         --------

--- a/tests/doc/doc_build/test_gallery_examples.py
+++ b/tests/doc/doc_build/test_gallery_examples.py
@@ -191,14 +191,15 @@ def test_example_anchor(case):
 
 
 # -- no "See Also" entry duplicates an example already in "Used In" -----------
-# numpydoc's own "See Also" section and the raw `.. seealso::` directive both render as
-# the same `.. admonition:: seealso` markup. A hand-written link to a gallery example
+# Both numpydoc's own "See Also" section and a raw `.. seealso::` directive get hoisted
+# to a real ``<section>``/``<h2>See Also`` heading (conf.py's promote_seealso_admonitions),
+# not left as an `.. admonition:: seealso` div. A hand-written link to a gallery example
 # there is only a problem once sphinx-autocodelink's own "Used In" section already shows
 # the same example -- at that point it's pure duplication, and unlike "Used In", it never
 # gets rechecked against what the example actually does. A "See Also" example that "Used
 # In" doesn't (yet) cover is left alone -- that's real information, not redundancy.
 
-_SEE_ALSO_RE = re.compile(r'<div class="admonition seealso">(.*?)</div>', re.DOTALL)
+_SEE_ALSO_RE = re.compile(r'<section[^>]*>\s*<h2>See Also.*?</section>', re.DOTALL)
 _BACKREFS_SECTION_RE = re.compile(
     r'<section class="sphinx-autocodelink-backrefs"[^>]*>.*?</section>', re.DOTALL
 )
@@ -206,8 +207,9 @@ _EXAMPLE_HREF_RE = re.compile(r'href="([^"]*/examples/[^"]*)"')
 
 
 def _example_hrefs(blocks: list[str]) -> set[str]:
-    """Return the basename of every example page linked from `blocks`."""
-    return {Path(href).name for block in blocks for href in _EXAMPLE_HREF_RE.findall(block)}
+    """Return the basename (fragment stripped) of every example page linked from `blocks`."""
+    hrefs = (href for block in blocks for href in _EXAMPLE_HREF_RE.findall(block))
+    return {Path(href.split('#')[0]).name for href in hrefs}
 
 
 def test_see_also_does_not_duplicate_used_in_examples():

--- a/tests/doc/doc_build/test_section_headings.py
+++ b/tests/doc/doc_build/test_section_headings.py
@@ -30,6 +30,11 @@ CLASS_PAGE = 'pyvista.Plotter.html'
 # A page whose docstring instead writes `.. seealso::` directly, in Examples.
 RAW_SEEALSO_PAGE = 'pyvista.examples.downloads.download_bunny.html'
 
+# A page whose raw `.. seealso::` is written well *before* References/Examples --
+# unlike RAW_SEEALSO_PAGE's, which is already last. Catches promote_seealso_admonitions
+# not repositioning the promoted section to match the others' order.
+CELLTYPE_PAGE = 'pyvista.CellType.html'
+
 
 def find_api_page(filename: str) -> Path:
     """Return a generated single-object API page.
@@ -83,6 +88,14 @@ def test_raw_seealso_admonition_is_hoisted_section():
     """Confirm a literal ``.. seealso::`` written in a docstring is promoted too."""
     html = find_api_page(RAW_SEEALSO_PAGE).read_text(encoding='utf-8')
     _assert_see_also_is_hoisted_section(html)
+
+
+def test_raw_seealso_written_before_examples_is_still_reordered_after():
+    """Confirm a ``.. seealso::`` written before References/Examples still ends up after."""
+    html = find_api_page(CELLTYPE_PAGE).read_text(encoding='utf-8')
+    _assert_see_also_is_hoisted_section(html)
+    assert heading_index(html, 'Examples') < heading_index(html, 'See Also')
+    assert heading_index(html, 'See Also') < heading_index(html, 'Used In')
 
 
 def test_methods_is_real_section():


### PR DESCRIPTION
### Overview

- Reverts [4338b8c9](https://github.com/pyvista/pyvista/commit/4338b8c96c9dc38afb196b65af2b04fba34b3f20)'s `:annotation:` for enum member values back to `:value:` -- `NAME : value` reads too much like a dict, `NAME = value` doesn't. 
- Also fixes an ordering bug from [#8895](https://github.com/pyvista/pyvista/pull/8895): `promote_seealso_admonitions` only reordered numpydoc's own `See Also` syntax to render after Examples, not a raw `.. seealso::` written earlier in the docstring (as `CellType`, `PolyDataFilters.append_polydata`, and `PolyDataFilters.merge` all do), which rendered wherever it was originally written instead.
- Also fixes a test bug from #8895, which is supposed to ensure there are no duplicates between "Used In" and "See Also" section. Turns out many pages still had duplicates, so those are also removed

### Details

- `promote_seealso_admonitions` now repositions the promoted section to just before "Used In", matching where numpydoc's own See Also always lands
- added a regression test on `CellType`'s rendered page in `tests/doc/doc_build/test_section_headings.py`

Changes drafted by Claude Sonnet 5 but fully understood by me
