### PR TITLE
Amend `.claude/skills/` for succinct comments/docstrings and taplo-safe TOML

### DIFF
--- a/.claude/skills/pyvista-dev/SKILL.md
+++ b/.claude/skills/pyvista-dev/SKILL.md
@@ -133,6 +133,21 @@ a variable before being raised (`EM`), and boolean arguments are keyword-only
 `namespace-stdlib-imports` is ruff's `banned-from` list (`ICN003`) in `pyproject.toml`,
 which forbids the opposite direction; `Import Conventions` explains why both exist.
 
+## Editing TOML
+
+`taplo-format` runs `reorder_keys=true` and `reorder_arrays=true`, so keys and array
+entries in `pyproject.toml` and other TOML files get sorted. A comment on its own line
+above an entry is attached to that entry and breaks the sort -- `taplo` will not reorder
+past it. Put a comment inline, on the same line as the value it documents, so sorting
+still works. Keep it short for the same reason as everywhere else: less is more.
+
+A comment line is legitimate only when it deliberately splits the array or table into
+independently-sorted sections -- `filterwarnings` in `pyproject.toml` keeps `'error'`
+first with a blank line rather than a comment because pytest applies filters in order, and
+the `pytest-pyvista options` comment splits the `pytest-pyvista` keys from pytest's own so
+each group sorts on its own. Reach for that only when order or grouping is load-bearing,
+not to leave a note.
+
 ## Tests
 
 The heaviest review axis by a wide margin. `CONTRIBUTING.rst` and `context7.json` cover

--- a/.claude/skills/pyvista-dev/SKILL.md
+++ b/.claude/skills/pyvista-dev/SKILL.md
@@ -67,6 +67,11 @@ Every function and class gets a docstring, including small private helpers -- a 
 summary is enough when there is nothing more to say. Only the full numpydoc sections
 (`Parameters`, `Returns`, examples, ...) are reserved for the public API.
 
+`numpydoc: ignore=RT01` (no `Returns` section) is fine for a simple property getter or
+setter, where the summary line already says what comes back. A function whose return
+type or meaning is not obvious from the name and summary needs a real `Returns` section
+instead of the ignore, however small the function is.
+
 Never describe how the change came to be -- no "fix", "bug", "temporary workaround", "now
 we", "previously", or reference to a prior version of the code. Write both as if the
 current diff were the first and only version of the file: they describe the code that

--- a/.claude/skills/pyvista-dev/SKILL.md
+++ b/.claude/skills/pyvista-dev/SKILL.md
@@ -57,6 +57,17 @@ Two assumptions cause most of the rework here, and both are one `grep` from cert
 Where a design question has two defensible answers that lead to different code, ask
 rather than picking one silently and building on it.
 
+## Comments and docstrings
+
+Less is more. A comment earns its place by explaining why, not what; if the code already
+says what, delete the comment. Keep docstrings to what the numpydoc sections require, not
+a narrative.
+
+Never describe how the change came to be -- no "fix", "bug", "temporary workaround", "now
+we", "previously", or reference to a prior version of the code. Write both as if the
+current diff were the first and only version of the file: they describe the code that
+exists on this branch relative to `main`, not the debugging path taken to get there.
+
 ## Size
 
 Merged pull requests here are small: the median adds tens of lines, not hundreds. One

--- a/.claude/skills/pyvista-dev/SKILL.md
+++ b/.claude/skills/pyvista-dev/SKILL.md
@@ -63,6 +63,10 @@ Less is more. A comment earns its place by explaining why, not what; if the code
 says what, delete the comment. Keep docstrings to what the numpydoc sections require, not
 a narrative.
 
+Every function and class gets a docstring, including small private helpers -- a one-line
+summary is enough when there is nothing more to say. Only the full numpydoc sections
+(`Parameters`, `Returns`, examples, ...) are reserved for the public API.
+
 Never describe how the change came to be -- no "fix", "bug", "temporary workaround", "now
 we", "previously", or reference to a prior version of the code. Write both as if the
 current diff were the first and only version of the file: they describe the code that

--- a/.claude/skills/pyvista-dev/SKILL.md
+++ b/.claude/skills/pyvista-dev/SKILL.md
@@ -67,7 +67,7 @@ Every function and class gets a docstring, including small private helpers -- a 
 summary is enough when there is nothing more to say. Only the full numpydoc sections
 (`Parameters`, `Returns`, examples, ...) are reserved for the public API.
 
-`numpydoc: ignore=RT01` (no `Returns` section) is fine for a simple property getter or
+`numpydoc ignore=RT01` (no `Returns` section) is fine for a simple property getter or
 setter, where the summary line already says what comes back. A function whose return
 type or meaning is not obvious from the name and summary needs a real `Returns` section
 instead of the ignore, however small the function is.

--- a/.claude/skills/pyvista-review/SKILL.md
+++ b/.claude/skills/pyvista-review/SKILL.md
@@ -55,7 +55,7 @@ reader will not follow either.
 | Documentation | Directives, examples, and pages that actually render              |
 | Naming        | Does the name say what the thing is, without being long?          |
 | Consistency   | Does it match the surrounding module?                             |
-| Comments      | Do they explain why, rather than what?                            |
+| Comments      | Do they explain why, rather than what? Less is more               |
 | Style         | Automated. Prefix anything left over with `nit:`.                 |
 
 Tests and complexity lead because they are what this repository sends back most often.
@@ -91,6 +91,14 @@ new or changed, with the right version.
 **Reuse.** Constants, `Literal` aliases, capability probes, and test guards should be
 defined once and imported. A re-derived version check where a shared constant exists is a
 certain comment.
+
+**Comments and docstrings that narrate the PR instead of describing the code.** Less is
+more: challenge anything that could be deleted without losing information. Anything that
+reads as a debugging note or a description of a fix -- "temporary", "workaround", "now
+we", "previously", a reference to what the code used to do -- is a finding. Judge each
+comment and docstring against the full diff relative to `main`, not against the commit
+that introduced it: it should describe the code as it stands, not the story of how it got
+there.
 
 **Deprecation discipline.** Nothing pre-existing is removed or silently changed, private
 helpers included. Watch for a name being changed for the second time; a rename followed


### PR DESCRIPTION
### Overview

Comments and docstrings here tend to accumulate debugging narration ("temporary fix", "previously") instead of describing the code as it stands, and standalone comment lines in TOML silently break taplo's key/array sorting. This amends pyvista-dev and pyvista-review to call out both: keep comments and docstrings succinct and free of PR history, review them against the diff as a whole rather than the commit that introduced them, and put TOML comments inline rather than on their own line unless they're deliberately splitting an array or table into independently-sorted sections.

Changes drafted by Claude Sonnet 5 but fully understood by me