### PR TITLE
Fix unparsed `.. tags::`/`.. note::` in gallery examples

### DIFF
--- a/examples/03-widgets/line_widget.py
+++ b/examples/03-widgets/line_widget.py
@@ -65,5 +65,4 @@ pl.show()
 #
 # .. image:: ../../images/gifs/line-widget-streamlines.gif
 #
-# %%
 # .. tags:: widgets

--- a/examples/03-widgets/slider_bar_widget.py
+++ b/examples/03-widgets/slider_bar_widget.py
@@ -66,5 +66,4 @@ pl.show()
 #
 # .. image:: ../../images/gifs/slider-widget-resolution.gif
 #
-# %%
 # .. tags:: widgets

--- a/examples/03-widgets/sphere_widget.py
+++ b/examples/03-widgets/sphere_widget.py
@@ -176,5 +176,4 @@ pl.show()
 #
 # .. image:: ../../images/gifs/sphere-widget-c.gif
 #
-# %%
 # .. tags:: widgets

--- a/examples/99-advanced/add_example.py
+++ b/examples/99-advanced/add_example.py
@@ -202,7 +202,7 @@ filename
 dataset = examples.download_bunny()
 dataset
 
-
+# %%
 # Making a Pull Request
 # ~~~~~~~~~~~~~~~~~~~~~
 # Once your example is complete and you've verified it builds locally, you can


### PR DESCRIPTION
### Overview

Three widget examples have a trailing \`.. tags::\` cell that sphinx-gallery glues onto the preceding image-only cell as literal text instead of parsing as a directive, and \`add_example.py\`'s final \`.. note::\` sits in a comment block with no \`# %%\` marker before it, so it renders as a Python comment rather than prose. Both leave raw RST visible on the rendered page. Fixed by merging the tags line into its preceding cell and adding the missing \`# %%\` marker; verified against a minimal sphinx-gallery + sphinx-tags reproduction.

Found via an audit of sphinx-examples-as-code's generated downloads, which surfaced the same raw-text leak in the \`.py\`/\`.ipynb\` output.

Changes drafted by Claude Sonnet 5 but fully understood by me.