### PR TITLE
Use `pv.` namespace instead of bare `from pyvista import`

### DIFF
--- a/examples/00-load/create_unstructured_surface.py
+++ b/examples/00-load/create_unstructured_surface.py
@@ -10,7 +10,6 @@ This example uses :class:`pyvista.UnstructuredGrid`.
 
 import numpy as np
 import pyvista as pv
-from pyvista import CellType
 
 # %%
 # An unstructured grid can be created directly from NumPy arrays.
@@ -24,7 +23,7 @@ from pyvista import CellType
 cells = np.array([8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 9, 10, 11, 12, 13, 14, 15])
 
 # cell type array. Contains the cell type of each cell
-cell_type = np.array([CellType.HEXAHEDRON, CellType.HEXAHEDRON])
+cell_type = np.array([pv.CellType.HEXAHEDRON, pv.CellType.HEXAHEDRON])
 
 # in this example, each cell uses separate points
 cell1 = np.array(
@@ -65,7 +64,7 @@ grid = pv.UnstructuredGrid(cells, cell_type, points)
 # added to the dictionary.
 cells_hex = np.arange(16).reshape([2, 8])
 # = np.array([[0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15]])
-grid = pv.UnstructuredGrid({CellType.HEXAHEDRON: cells_hex}, points)
+grid = pv.UnstructuredGrid({pv.CellType.HEXAHEDRON: cells_hex}, points)
 
 # plot the grid (and suppress the camera position output)
 _ = grid.plot(show_edges=True)
@@ -128,7 +127,7 @@ cells = np.array(
 ).ravel()
 
 # each cell is a HEXAHEDRON
-celltypes = np.full(8, CellType.HEXAHEDRON, dtype=np.uint8)
+celltypes = np.full(8, pv.CellType.HEXAHEDRON, dtype=np.uint8)
 
 
 # %%
@@ -136,9 +135,9 @@ celltypes = np.full(8, CellType.HEXAHEDRON, dtype=np.uint8)
 grid = pv.UnstructuredGrid(cells, celltypes, points)
 
 # Alternate versions:
-grid = pv.UnstructuredGrid({CellType.HEXAHEDRON: cells.reshape([-1, 9])[:, 1:]}, points)
+grid = pv.UnstructuredGrid({pv.CellType.HEXAHEDRON: cells.reshape([-1, 9])[:, 1:]}, points)
 grid = pv.UnstructuredGrid(
-    {CellType.HEXAHEDRON: np.delete(cells, np.arange(0, cells.size, 9))},
+    {pv.CellType.HEXAHEDRON: np.delete(cells, np.arange(0, cells.size, 9))},
     points,
 )
 
@@ -171,7 +170,7 @@ cells = np.array(
     ],
 )
 
-celltypes = np.full(10, fill_value=CellType.TETRA, dtype=np.uint8)
+celltypes = np.full(10, fill_value=pv.CellType.TETRA, dtype=np.uint8)
 
 # These are the 10 points. The number of cells does not need to match the
 # number of points, they just happen to in this example

--- a/examples/00-load/create_unstructured_surface.py
+++ b/examples/00-load/create_unstructured_surface.py
@@ -135,7 +135,9 @@ celltypes = np.full(8, pv.CellType.HEXAHEDRON, dtype=np.uint8)
 grid = pv.UnstructuredGrid(cells, celltypes, points)
 
 # Alternate versions:
-grid = pv.UnstructuredGrid({pv.CellType.HEXAHEDRON: cells.reshape([-1, 9])[:, 1:]}, points)
+grid = pv.UnstructuredGrid(
+    {pv.CellType.HEXAHEDRON: cells.reshape([-1, 9])[:, 1:]}, points
+)
 grid = pv.UnstructuredGrid(
     {pv.CellType.HEXAHEDRON: np.delete(cells, np.arange(0, cells.size, 9))},
     points,

--- a/examples/01-filter/extract_surface.py
+++ b/examples/01-filter/extract_surface.py
@@ -11,7 +11,6 @@ using the :meth:`~pyvista.DataObjectFilters.extract_surface` filter.
 # sphinx_gallery_thumbnail_number = 2
 import numpy as np
 import pyvista as pv
-from pyvista import CellType
 
 # %%
 # Surface extraction of nonlinear cells
@@ -65,7 +64,7 @@ pts = np.vstack((lin_pts, quad_pts))
 # %%
 # Create the grid
 cells = np.hstack((20, np.arange(20))).astype(np.int64, copy=False)
-celltypes = np.array([CellType.QUADRATIC_HEXAHEDRON])
+celltypes = np.array([pv.CellType.QUADRATIC_HEXAHEDRON])
 grid = pv.UnstructuredGrid(cells, celltypes, pts)
 
 # %%
@@ -160,7 +159,7 @@ pl.show()
 
 grid = pv.ImageData(dimensions=(2, 2, 2))
 assert grid.n_cells == 1
-assert grid.distinct_cell_types == {CellType.VOXEL}
+assert grid.distinct_cell_types == {pv.CellType.VOXEL}
 assert grid.max_cell_dimensionality == 3
 
 # %%
@@ -169,12 +168,12 @@ assert grid.max_cell_dimensionality == 3
 
 poly_geometry = grid.extract_surface(algorithm='geometry')
 assert poly_geometry.n_cells == 6
-assert poly_geometry.distinct_cell_types == {CellType.QUAD}
+assert poly_geometry.distinct_cell_types == {pv.CellType.QUAD}
 assert poly_geometry.max_cell_dimensionality == 2
 
 poly_surface = grid.extract_surface(algorithm='dataset_surface')
 assert poly_surface.n_cells == 6
-assert poly_surface.distinct_cell_types == {CellType.QUAD}
+assert poly_surface.distinct_cell_types == {pv.CellType.QUAD}
 assert poly_geometry.max_cell_dimensionality == 2
 
 # %%

--- a/pyvista/core/celltype.py
+++ b/pyvista/core/celltype.py
@@ -894,10 +894,9 @@ class CellType(IntEnum, metaclass=_CellTypeMeta):
     ``CellType``.
 
     >>> import numpy as np
-    >>> from pyvista import CellType
     >>> import pyvista as pv
     >>> cells = np.array([8, 0, 1, 2, 3, 4, 5, 6, 7])
-    >>> cell_type = np.array([CellType.HEXAHEDRON], np.int8)
+    >>> cell_type = np.array([pv.CellType.HEXAHEDRON], np.int8)
     >>> points = np.array(
     ...     [
     ...         [0, 0, 0],

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -2797,12 +2797,13 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
         Examples
         --------
         >>> import numpy as np
-        >>> from pyvista import CellType
         >>> import pyvista as pv
         >>> cell0_ids = [8, 0, 1, 2, 3, 4, 5, 6, 7]
         >>> cell1_ids = [8, 8, 9, 10, 11, 12, 13, 14, 15]
         >>> cells = np.hstack((cell0_ids, cell1_ids))
-        >>> cell_type = np.array([CellType.HEXAHEDRON, CellType.HEXAHEDRON], np.int8)
+        >>> cell_type = np.array(
+        ...     [pv.CellType.HEXAHEDRON, pv.CellType.HEXAHEDRON], np.int8
+        ... )
 
         >>> cell1 = np.array(
         ...     [

--- a/pyvista/core/utilities/accessor_registry.py
+++ b/pyvista/core/utilities/accessor_registry.py
@@ -73,11 +73,11 @@ class DataSetAccessor(Protocol):
     --------
     Declare an accessor that satisfies the protocol.
 
-    >>> from pyvista import DataSetAccessor
+    >>> import pyvista as pv
     >>> class MyAccessor:
     ...     def __init__(self, dataset):
     ...         self._dataset = dataset
-    >>> isinstance(MyAccessor(None), DataSetAccessor)
+    >>> isinstance(MyAccessor(None), pv.DataSetAccessor)
     True
 
     """

--- a/pyvista/plotting/component_registry.py
+++ b/pyvista/plotting/component_registry.py
@@ -88,11 +88,11 @@ class PlotterComponent(Protocol):
     --------
     Declare a component that satisfies the protocol.
 
-    >>> from pyvista import PlotterComponent
+    >>> import pyvista as pv
     >>> class MyComponent:
     ...     def __init__(self, plotter):
     ...         self._plotter = plotter
-    >>> isinstance(MyComponent(None), PlotterComponent)
+    >>> isinstance(MyComponent(None), pv.PlotterComponent)
     True
 
     """

--- a/pyvista/plotting/text.py
+++ b/pyvista/plotting/text.py
@@ -75,8 +75,8 @@ class CornerAnnotation(_NoNewAttrMixin, DisableVtkSnakeCase, _NameMixin, _vtk.vt
     --------
     Create text annotation in four corners.
 
-    >>> from pyvista import CornerAnnotation
-    >>> text = CornerAnnotation(0, 'text')
+    >>> import pyvista as pv
+    >>> text = pv.CornerAnnotation(0, 'text')
     >>> prop = text.prop
 
     """
@@ -206,8 +206,8 @@ class Text(_NoNewAttrMixin, DisableVtkSnakeCase, _NameMixin, _vtk.vtkTextActor):
     --------
     Create a text with text's property.
 
-    >>> from pyvista import Text
-    >>> text = Text()
+    >>> import pyvista as pv
+    >>> text = pv.Text()
     >>> prop = text.prop
 
     """
@@ -523,8 +523,8 @@ class TextProperty(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkTextProperty):
     --------
     Create a text's property.
 
-    >>> from pyvista import TextProperty
-    >>> prop = TextProperty()
+    >>> import pyvista as pv
+    >>> prop = pv.TextProperty()
     >>> prop.opacity = 0.5
     >>> prop.background_color = 'b'
     >>> prop.background_opacity = 0.5


### PR DESCRIPTION
### Overview

An audit of doctests and gallery examples turned up a handful of `from pyvista import X` imports for non-module names, which don't match the house convention of `import pyvista as pv` and the `pv.` namespace. `from pyvista import examples` and similar module imports are unaffected. Fixed `CellType`, `DataSetAccessor`, `PlotterComponent`, `CornerAnnotation`, `Text`, and `TextProperty` in their docstrings and in two gallery scripts under `examples/`.

Changes drafted by Claude Sonnet 5 but fully understood by me.
