### PR TITLE
Add pre-commit hook for gallery example summaries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -109,6 +109,12 @@ repos:
         language: pygrep
         entry: '^\s*(?:>>>|\.\.\.)?\s*import\s+(?:__future__|abc|collections|collections\.abc|dataclasses|enum|http\.server|importlib\.metadata|io|pathlib|types|typing|typing_extensions|unittest\.mock)\s*$'
         types_or: [python, rst, markdown]
+      - id: gallery-docstring-structure
+        name: "Gallery examples need a '.. _label:', a title/underline, and a summary sentence"
+        language: python
+        entry: python hooks/gallery_docstrings.py
+        files: ^examples/.*\.py$
+        types: [python]
       - id: no-lint-suppression-comments
         name: "No lint suppression comments (fix it, or use pyproject.toml per-file-ignores)"
         language: pygrep

--- a/examples/00-load/create_circular_arc.py
+++ b/examples/00-load/create_circular_arc.py
@@ -4,7 +4,11 @@
 Create Circular Arcs
 ~~~~~~~~~~~~~~~~~~~~
 
-Generate arc geometry with :func:`pyvista.CircularArc`.
+Generate circular arc geometry.
+
+Demonstrates usage of:func:`pyvista.CircularArc` and
+:func:`pyvista.CircularArcFromNormal`.
+
 """
 
 import numpy as np

--- a/examples/00-load/create_circular_arc.py
+++ b/examples/00-load/create_circular_arc.py
@@ -4,8 +4,7 @@
 Create Circular Arcs
 ~~~~~~~~~~~~~~~~~~~~
 
-Generate arc geometry with :func:`pyvista.CircularArc` and
-:func:`pyvista.CircularArcFromNormal`.
+Generate arc geometry with :func:`pyvista.CircularArc`.
 """
 
 import numpy as np

--- a/examples/00-load/create_circular_arc.py
+++ b/examples/00-load/create_circular_arc.py
@@ -6,7 +6,7 @@ Create Circular Arcs
 
 Generate circular arc geometry.
 
-Demonstrates usage of:func:`pyvista.CircularArc` and
+Demonstrates usage of :func:`pyvista.CircularArc` and
 :func:`pyvista.CircularArcFromNormal`.
 
 """

--- a/examples/00-load/create_draped_surface.py
+++ b/examples/00-load/create_draped_surface.py
@@ -13,7 +13,8 @@ into how to create a 2.5D sectional mesh from typical data in those use cases.
 For this example, we have an instrument path on the ground surface (the line)
 and a 2D array of the collected image under that line.
 
-Originally posted in `this support issue <https://github.com/pyvista/pyvista-support/issues/135>`_.
+Originally posted in `this support issue
+<https://github.com/pyvista/pyvista-support/issues/135>`_.
 
 Suppose you have some GPR data (or anything that produces a line of data with
 values at depth). With these data, you'll have a 2D image/array of your data

--- a/examples/00-load/create_draped_surface.py
+++ b/examples/00-load/create_draped_surface.py
@@ -13,8 +13,7 @@ into how to create a 2.5D sectional mesh from typical data in those use cases.
 For this example, we have an instrument path on the ground surface (the line)
 and a 2D array of the collected image under that line.
 
-Originally posted in `this support issue
-<https://github.com/pyvista/pyvista-support/issues/135>`_.
+Originally posted in `this support issue <https://github.com/pyvista/pyvista-support/issues/135>`_.
 
 Suppose you have some GPR data (or anything that produces a line of data with
 values at depth). With these data, you'll have a 2D image/array of your data
@@ -32,6 +31,7 @@ have are technically shifted up and we have some NaN filler above the surface
 - its weird and just ignore it. You'll typically have a more uniform looking
 profile in 2D with the coordinates associated to the top of each column in your
 2D array.
+
 """
 
 import matplotlib.pyplot as plt

--- a/examples/00-load/create_explicit_structured_grid.py
+++ b/examples/00-load/create_explicit_structured_grid.py
@@ -5,6 +5,7 @@ Creating an Explicit Structured Grid
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Create an :class:`~pyvista.ExplicitStructuredGrid` from NumPy arrays.
+
 """
 
 import numpy as np

--- a/examples/00-load/create_explicit_structured_grid.py
+++ b/examples/00-load/create_explicit_structured_grid.py
@@ -4,9 +4,7 @@
 Creating an Explicit Structured Grid
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Create an explicit structured grid from NumPy arrays using
-:class:`pyvista.ExplicitStructuredGrid`.
-
+Create an :class:`~pyvista.ExplicitStructuredGrid` from NumPy arrays.
 """
 
 import numpy as np

--- a/examples/00-load/create_geometric_objects.py
+++ b/examples/00-load/create_geometric_objects.py
@@ -5,6 +5,7 @@ Geometric Objects
 ~~~~~~~~~~~~~~~~~
 
 The "Hello, world!" of VTK. Uses objects from :ref:`geometry_api`.
+
 """
 
 import pyvista as pv

--- a/examples/00-load/create_geometric_objects.py
+++ b/examples/00-load/create_geometric_objects.py
@@ -4,7 +4,9 @@
 Geometric Objects
 ~~~~~~~~~~~~~~~~~
 
-The "Hello, world!" of VTK. Uses objects from :ref:`geometry_api`.
+The "Hello, world!" of VTK.
+
+Uses objects from :ref:`geometry_api`.
 
 """
 

--- a/examples/00-load/create_geometric_objects.py
+++ b/examples/00-load/create_geometric_objects.py
@@ -4,8 +4,7 @@
 Geometric Objects
 ~~~~~~~~~~~~~~~~~
 
-The "Hello, world!" of VTK.
-Uses objects from :ref:`geometry_api`.
+The "Hello, world!" of VTK. Uses objects from :ref:`geometry_api`.
 """
 
 import pyvista as pv

--- a/examples/00-load/create_kochanek_spline.py
+++ b/examples/00-load/create_kochanek_spline.py
@@ -7,6 +7,7 @@ Create a Kochanek Spline
 Create a Kochanek spline/polyline from a numpy array of XYZ vertices.
 
 Uses :func:`pyvista.KochanekSpline`.
+
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/00-load/create_kochanek_spline.py
+++ b/examples/00-load/create_kochanek_spline.py
@@ -5,6 +5,7 @@ Create a Kochanek Spline
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Create a Kochanek spline/polyline from a numpy array of XYZ vertices.
+
 Uses :func:`pyvista.KochanekSpline`.
 """
 

--- a/examples/00-load/create_multiple_lines.py
+++ b/examples/00-load/create_multiple_lines.py
@@ -5,6 +5,7 @@ Create Connected Lines from Points
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Build a polyline from ordered points with :func:`pyvista.MultipleLines`.
+
 """
 
 import numpy as np

--- a/examples/00-load/create_parametric_geometric_objects.py
+++ b/examples/00-load/create_parametric_geometric_objects.py
@@ -5,6 +5,7 @@ Parametric Geometric Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Creating parametric objects from :ref:`parametric_api`.
+
 """
 
 import math

--- a/examples/00-load/create_pixel_art.py
+++ b/examples/00-load/create_pixel_art.py
@@ -4,10 +4,10 @@
 Pixel Art of ALIEN MONSTERS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Here we use :func:`pyvista.Box` to make `pixel art <https://en.wikipedia.org/wiki/Pixel_art>`_.
+Use :func:`pyvista.Box` to make `pixel art <https://en.wikipedia.org/wiki/Pixel_art>`_.
+
 Pixel string `source <https://commons.wikimedia.org/wiki/File:Noto_Emoji_Pie_1f47e.svg>`_
 and `license <https://github.com/googlefonts/noto-emoji/blob/main/LICENSE>`_.
-
 """
 
 import pyvista as pv

--- a/examples/00-load/create_pixel_art.py
+++ b/examples/00-load/create_pixel_art.py
@@ -8,6 +8,7 @@ Use :func:`pyvista.Box` to make `pixel art <https://en.wikipedia.org/wiki/Pixel_
 
 Pixel string `source <https://commons.wikimedia.org/wiki/File:Noto_Emoji_Pie_1f47e.svg>`_
 and `license <https://github.com/googlefonts/noto-emoji/blob/main/LICENSE>`_.
+
 """
 
 import pyvista as pv

--- a/examples/00-load/create_platonic_solids.py
+++ b/examples/00-load/create_platonic_solids.py
@@ -5,6 +5,7 @@ Platonic Solids
 ~~~~~~~~~~~~~~~
 
 PyVista wraps the :vtk:`vtkPlatonicSolidSource` filter as :func:`pyvista.PlatonicSolid`.
+
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/00-load/create_platonic_solids.py
+++ b/examples/00-load/create_platonic_solids.py
@@ -4,8 +4,7 @@
 Platonic Solids
 ~~~~~~~~~~~~~~~
 
-PyVista wraps the :vtk:`vtkPlatonicSolidSource` filter as
-:func:`pyvista.PlatonicSolid`.
+PyVista wraps the :vtk:`vtkPlatonicSolidSource` filter as :func:`pyvista.PlatonicSolid`.
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/00-load/create_point_cloud.py
+++ b/examples/00-load/create_point_cloud.py
@@ -4,9 +4,7 @@
 Create Point Cloud
 ~~~~~~~~~~~~~~~~~~
 
-Create a :class:`pyvista.PolyData` object from a point cloud of vertices and
-scalar arrays for those points.
-
+Create a :class:`~pyvista.PolyData` point cloud from vertices and scalar arrays.
 """
 
 import numpy as np

--- a/examples/00-load/create_point_cloud.py
+++ b/examples/00-load/create_point_cloud.py
@@ -5,6 +5,7 @@ Create Point Cloud
 ~~~~~~~~~~~~~~~~~~
 
 Create a :class:`~pyvista.PolyData` point cloud from vertices and scalar arrays.
+
 """
 
 import numpy as np

--- a/examples/00-load/create_pointset.py
+++ b/examples/00-load/create_pointset.py
@@ -8,10 +8,9 @@ A :class:`~pyvista.PointSet` explicitly stores point arrays to represent geometr
 
 This class is useful for improving the performance of filters on point clouds.
 
-This class is useful for improving the performance of filters on point clouds.
-
 This example shows the performance improvement when clipping using the
 :func:`pyvista.DataObjectFilters.clip` filter on a :class:`pyvista.PointSet`.
+
 """
 
 import time

--- a/examples/00-load/create_pointset.py
+++ b/examples/00-load/create_pointset.py
@@ -4,14 +4,14 @@
 Create a PointSet
 ~~~~~~~~~~~~~~~~~
 
-A :class:`pyvista.PointSet` is a concrete class representing a set of points
-that specifies the interface for datasets that explicitly use "point" arrays to
-represent geometry. This class is useful for improving the performance of
-filters on point clouds.
+A :class:`~pyvista.PointSet` explicitly stores point arrays to represent geometry.
+
+This class is useful for improving the performance of filters on point clouds.
+
+This class is useful for improving the performance of filters on point clouds.
 
 This example shows the performance improvement when clipping using the
 :func:`pyvista.DataObjectFilters.clip` filter on a :class:`pyvista.PointSet`.
-
 """
 
 import time

--- a/examples/00-load/create_polydata_strips.py
+++ b/examples/00-load/create_polydata_strips.py
@@ -4,12 +4,10 @@
 Triangle Strips
 ~~~~~~~~~~~~~~~
 
-This example shows how to build a simple :class:`pyvista.PolyData` using
-triangle strips.
+This example shows how to build a simple :class:`pyvista.PolyData` using triangle strips.
 
 Triangle strips are a more efficient way of storing the connectivity of
 adjacent triangles.
-
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/00-load/create_polydata_strips.py
+++ b/examples/00-load/create_polydata_strips.py
@@ -8,6 +8,7 @@ This example shows how to build a simple :class:`pyvista.PolyData` using triangl
 
 Triangle strips are a more efficient way of storing the connectivity of
 adjacent triangles.
+
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/00-load/create_polyhedron.py
+++ b/examples/00-load/create_polyhedron.py
@@ -10,6 +10,7 @@ We will be using VTK types to determine which type of cells we are building. A l
 cell types is given in :class:`pyvista.CellType`.
 
 First, we import the required libraries.
+
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/00-load/create_polyhedron.py
+++ b/examples/00-load/create_polyhedron.py
@@ -4,9 +4,10 @@
 Unstructured Grid with Polyhedra
 --------------------------------
 
-This example shows how to build a simple :class:`pyvista.UnstructuredGrid`
-using polyhedra. We will be using VTK types to determine which type of cells we
-are building. A list of cell types is given in :class:`pyvista.CellType`.
+Build a simple :class:`~pyvista.UnstructuredGrid` using polyhedra.
+
+We will be using VTK types to determine which type of cells we are building. A list of
+cell types is given in :class:`pyvista.CellType`.
 
 First, we import the required libraries.
 """

--- a/examples/00-load/create_spline.py
+++ b/examples/00-load/create_spline.py
@@ -5,6 +5,7 @@ Creating a Spline
 ~~~~~~~~~~~~~~~~~
 
 Create a spline/polyline from a numpy array of XYZ vertices using :func:`pyvista.Spline`.
+
 """
 
 import numpy as np

--- a/examples/00-load/create_spline.py
+++ b/examples/00-load/create_spline.py
@@ -4,8 +4,7 @@
 Creating a Spline
 ~~~~~~~~~~~~~~~~~
 
-Create a spline/polyline from a numpy array of XYZ vertices using
-:func:`pyvista.Spline`.
+Create a spline/polyline from a numpy array of XYZ vertices using :func:`pyvista.Spline`.
 """
 
 import numpy as np

--- a/examples/00-load/create_structured_surface.py
+++ b/examples/00-load/create_structured_surface.py
@@ -5,6 +5,7 @@ Creating a Structured Surface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Create a StructuredGrid surface from NumPy arrays using :class:`pyvista.StructuredGrid`.
+
 """
 
 import numpy as np

--- a/examples/00-load/create_structured_surface.py
+++ b/examples/00-load/create_structured_surface.py
@@ -4,8 +4,7 @@
 Creating a Structured Surface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Create a StructuredGrid surface from NumPy arrays
-using :class:`pyvista.StructuredGrid`.
+Create a StructuredGrid surface from NumPy arrays using :class:`pyvista.StructuredGrid`.
 """
 
 import numpy as np

--- a/examples/00-load/create_text_3d.py
+++ b/examples/00-load/create_text_3d.py
@@ -5,6 +5,7 @@ Create 3D Text
 ~~~~~~~~~~~~~~
 
 Generate extruded text geometry with :func:`pyvista.Text3D`.
+
 """
 
 import pyvista as pv

--- a/examples/00-load/create_tri_surface.py
+++ b/examples/00-load/create_tri_surface.py
@@ -5,6 +5,7 @@ Create Triangulated Surface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Create a surface from a set of points through a Delaunay triangulation.
+
 This example uses :func:`pyvista.PolyDataFilters.delaunay_2d`.
 """
 

--- a/examples/00-load/create_tri_surface.py
+++ b/examples/00-load/create_tri_surface.py
@@ -7,6 +7,7 @@ Create Triangulated Surface
 Create a surface from a set of points through a Delaunay triangulation.
 
 This example uses :func:`pyvista.PolyDataFilters.delaunay_2d`.
+
 """
 
 import numpy as np

--- a/examples/00-load/create_truss.py
+++ b/examples/00-load/create_truss.py
@@ -5,10 +5,8 @@ Plot Truss-like FEA Solution with Cylinders
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Plot connections between points in 3D as cylinders, colored by scalars.
-Lines are created in a :class:`pyvista.PolyData` and then rendered as
-cylinders.
 
-
+Lines are created in a :class:`pyvista.PolyData` and then rendered as cylinders.
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/00-load/create_truss.py
+++ b/examples/00-load/create_truss.py
@@ -6,7 +6,8 @@ Plot Truss-like FEA Solution with Cylinders
 
 Plot connections between points in 3D as cylinders, colored by scalars.
 
-Lines are created in a :class:`pyvista.PolyData` and then rendered as cylinders.
+Lines are created in a :class:`pyvista.PolyData` and then rendered as
+cylinders.
 
 """
 

--- a/examples/00-load/create_truss.py
+++ b/examples/00-load/create_truss.py
@@ -7,6 +7,7 @@ Plot Truss-like FEA Solution with Cylinders
 Plot connections between points in 3D as cylinders, colored by scalars.
 
 Lines are created in a :class:`pyvista.PolyData` and then rendered as cylinders.
+
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/00-load/create_uniform_grid.py
+++ b/examples/00-load/create_uniform_grid.py
@@ -5,8 +5,8 @@ Creating a Uniform Grid
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Create a simple uniform grid from a 3D NumPy array of values.
-This example uses :class:`pyvista.ImageData`.
 
+This example uses :class:`pyvista.ImageData`.
 """
 
 import numpy as np

--- a/examples/00-load/create_uniform_grid.py
+++ b/examples/00-load/create_uniform_grid.py
@@ -7,6 +7,7 @@ Creating a Uniform Grid
 Create a simple uniform grid from a 3D NumPy array of values.
 
 This example uses :class:`pyvista.ImageData`.
+
 """
 
 import numpy as np

--- a/examples/00-load/create_unstructured_surface.py
+++ b/examples/00-load/create_unstructured_surface.py
@@ -5,6 +5,7 @@ Creating an Unstructured Grid
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Create an irregular, unstructured grid from NumPy arrays.
+
 This example uses :class:`pyvista.UnstructuredGrid`.
 """
 

--- a/examples/00-load/create_unstructured_surface.py
+++ b/examples/00-load/create_unstructured_surface.py
@@ -7,6 +7,7 @@ Creating an Unstructured Grid
 Create an irregular, unstructured grid from NumPy arrays.
 
 This example uses :class:`pyvista.UnstructuredGrid`.
+
 """
 
 import numpy as np

--- a/examples/00-load/linear_cells.py
+++ b/examples/00-load/linear_cells.py
@@ -8,13 +8,12 @@ Explains linear VTK cell types and how to create them in PyVista.
 
 This example extends the :ref:`create_unstructured_surface_example` example.
 
-This example extends the :ref:`create_unstructured_surface_example` example.
-
 Linear cells are cells where points only occur at the edges of each
 cell. Non-linear cells contain additional points along the edges of the cell.
 
 For more details regarding what a :class:`pyvista.UnstructuredGrid` is, please
 see :ref:`point_sets_api`.
+
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/00-load/linear_cells.py
+++ b/examples/00-load/linear_cells.py
@@ -4,16 +4,17 @@
 Linear Cells
 ~~~~~~~~~~~~
 
-This example extends the :ref:`create_unstructured_surface_example` example by
-including an explanation of linear VTK cell types and how you can create them in
-PyVista.
+Explains linear VTK cell types and how to create them in PyVista.
+
+This example extends the :ref:`create_unstructured_surface_example` example.
+
+This example extends the :ref:`create_unstructured_surface_example` example.
 
 Linear cells are cells where points only occur at the edges of each
 cell. Non-linear cells contain additional points along the edges of the cell.
 
 For more details regarding what a :class:`pyvista.UnstructuredGrid` is, please
 see :ref:`point_sets_api`.
-
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/00-load/load_gltf.py
+++ b/examples/00-load/load_gltf.py
@@ -6,7 +6,8 @@ Working with glTF Files
 
 Import a glTF file directly into a PyVista plotting scene.
 
-For more details regarding the glTF format, see:
+For more
+details regarding the glTF format, see:
 https://www.khronos.org/gltf/
 
 First, download the examples.  Note that here we're using a high

--- a/examples/00-load/load_gltf.py
+++ b/examples/00-load/load_gltf.py
@@ -3,8 +3,10 @@
 
 Working with glTF Files
 ~~~~~~~~~~~~~~~~~~~~~~~
-Import a glTF file directly into a PyVista plotting scene.  For more
-details regarding the glTF format, see:
+
+Import a glTF file directly into a PyVista plotting scene.
+
+For more details regarding the glTF format, see:
 https://www.khronos.org/gltf/
 
 First, download the examples.  Note that here we're using a high

--- a/examples/00-load/load_vrml.py
+++ b/examples/00-load/load_vrml.py
@@ -3,7 +3,9 @@
 
 Working with VRML Files
 ~~~~~~~~~~~~~~~~~~~~~~~
+
 Import a VRML file directly into a PyVista plotting scene.
+
 For more details regarding the VRML format, see:
 https://en.wikipedia.org/wiki/VRML
 

--- a/examples/00-load/read_dolfin.py
+++ b/examples/00-load/read_dolfin.py
@@ -8,10 +8,9 @@ Read a FEniCS/Dolfin XML mesh using :func:`pyvista.read`.
 
 PyVista leverages `meshio`_ to read many mesh formats not natively supported by VTK.
 
-PyVista leverages `meshio`_ to read many mesh formats not natively supported by VTK.
-
 .. _meshio: https://github.com/nschloe/meshio
 .. _FEniCS/Dolfin: https://fenicsproject.org
+
 """
 
 import pyvista as pv

--- a/examples/00-load/read_dolfin.py
+++ b/examples/00-load/read_dolfin.py
@@ -4,9 +4,11 @@
 Read FEniCS/Dolfin Meshes
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-PyVista leverages `meshio`_ to read many mesh formats not natively supported
-by VTK including the `FEniCS/Dolfin`_ XML format.
-This example uses :func:`pyvista.read`.
+Read a FEniCS/Dolfin XML mesh using :func:`pyvista.read`.
+
+PyVista leverages `meshio`_ to read many mesh formats not natively supported by VTK.
+
+PyVista leverages `meshio`_ to read many mesh formats not natively supported by VTK.
 
 .. _meshio: https://github.com/nschloe/meshio
 .. _FEniCS/Dolfin: https://fenicsproject.org

--- a/examples/00-load/read_parallel.py
+++ b/examples/00-load/read_parallel.py
@@ -7,6 +7,7 @@ Parallel Files
 The VTK library supports parallel file formats.
 
 Reading meshes broken up into several files is natively supported by VTK and PyVista.
+
 """
 
 from pathlib import Path

--- a/examples/00-load/read_parallel.py
+++ b/examples/00-load/read_parallel.py
@@ -6,7 +6,8 @@ Parallel Files
 
 The VTK library supports parallel file formats.
 
-Reading meshes broken up into several files is natively supported by VTK and PyVista.
+Reading meshes broken up into
+several files is natively supported by VTK and PyVista.
 
 """
 

--- a/examples/00-load/read_parallel.py
+++ b/examples/00-load/read_parallel.py
@@ -4,8 +4,9 @@
 Parallel Files
 ~~~~~~~~~~~~~~
 
-The VTK library supports parallel file formats. Reading meshes broken up into
-several files is natively supported by VTK and PyVista.
+The VTK library supports parallel file formats.
+
+Reading meshes broken up into several files is natively supported by VTK and PyVista.
 """
 
 from pathlib import Path

--- a/examples/00-load/reader.py
+++ b/examples/00-load/reader.py
@@ -3,6 +3,8 @@
 
 Load data using a Reader
 ~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use a class based reader to have more control over reading data files.
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/00-load/reader.py
+++ b/examples/00-load/reader.py
@@ -5,6 +5,7 @@ Load data using a Reader
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use a class based reader to have more control over reading data files.
+
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/00-load/terrain_following_mesh.py
+++ b/examples/00-load/terrain_following_mesh.py
@@ -16,6 +16,7 @@ In this example, we demonstrate a simple way to make a 3D grid/mesh that
 follows a given topographic surface. In this example, it is important to note
 that the given digital elevation model (DEM) is structured (gridded and not
 triangulated): this is common for DEMs.
+
 """
 
 import numpy as np

--- a/examples/00-load/wrap_trimesh.py
+++ b/examples/00-load/wrap_trimesh.py
@@ -3,6 +3,9 @@
 
 Wrapping Other Objects
 ~~~~~~~~~~~~~~~~~~~~~~
+
+Wrap other object types using :func:`~pyvista.wrap`.
+
 You can :func:`~pyvista.wrap` several other object types using pyvista including:
 
 - ``numpy`` arrays

--- a/examples/01-filter/boolean_operations.py
+++ b/examples/01-filter/boolean_operations.py
@@ -39,7 +39,6 @@ must be all triangle meshes, which you can check with
    probably has its normals pointing inward. Use
    :func:`pyvista.PolyDataFilters.plot_normals` to visualize the normals.
 
-
 """
 
 # sphinx_gallery_thumbnail_number = 6

--- a/examples/01-filter/clip_closed_surface.py
+++ b/examples/01-filter/clip_closed_surface.py
@@ -4,8 +4,11 @@
 Clip and Cap a Closed Surface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Compare a standard planar clip, which leaves an open boundary, with
-:func:`pyvista.PolyDataFilters.clip_closed_surface`, which seals the cut face.
+Compare a standard planar clip with :func:`~pyvista.PolyDataFilters.clip_closed_surface`.
+
+The standard clip leaves an open boundary; ``clip_closed_surface`` seals the cut face.
+
+The standard clip leaves an open boundary; ``clip_closed_surface`` seals the cut face.
 """
 
 import pyvista as pv

--- a/examples/01-filter/clip_closed_surface.py
+++ b/examples/01-filter/clip_closed_surface.py
@@ -8,7 +8,6 @@ Compare a standard planar clip with :func:`~pyvista.PolyDataFilters.clip_closed_
 
 The standard clip leaves an open boundary; ``clip_closed_surface`` seals the cut face.
 
-The standard clip leaves an open boundary; ``clip_closed_surface`` seals the cut face.
 """
 
 import pyvista as pv

--- a/examples/01-filter/clip_with_plane_box.py
+++ b/examples/01-filter/clip_with_plane_box.py
@@ -5,6 +5,7 @@ Clipping with Planes & Boxes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Clip/cut any dataset using planes or boxes.
+
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/01-filter/clip_with_surface.py
+++ b/examples/01-filter/clip_with_surface.py
@@ -8,13 +8,12 @@ Clip any PyVista dataset by a :class:`~pyvista.PolyData` surface mesh.
 
 Uses the :func:`pyvista.DataSetFilters.clip_surface` filter.
 
-Uses the :func:`pyvista.DataSetFilters.clip_surface` filter.
-
 Note that we first demonstrate how the clipping is performed by computing an
 implicit distance and thresholding the mesh. This thresholding is one approach
 to clip by a surface, and preserve the original geometry of the given mesh,
 but many folks leverage the ``clip_surface`` filter to triangulate/tessellate
 the mesh geometries along the clip.
+
 """
 
 import numpy as np

--- a/examples/01-filter/clip_with_surface.py
+++ b/examples/01-filter/clip_with_surface.py
@@ -4,8 +4,11 @@
 Clipping with a Surface
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Clip any PyVista dataset by a :class:`pyvista.PolyData` surface mesh using
-the :func:`pyvista.DataSetFilters.clip_surface` filter.
+Clip any PyVista dataset by a :class:`~pyvista.PolyData` surface mesh.
+
+Uses the :func:`pyvista.DataSetFilters.clip_surface` filter.
+
+Uses the :func:`pyvista.DataSetFilters.clip_surface` filter.
 
 Note that we first demonstrate how the clipping is performed by computing an
 implicit distance and thresholding the mesh. This thresholding is one approach

--- a/examples/01-filter/collision.py
+++ b/examples/01-filter/collision.py
@@ -3,9 +3,10 @@
 
 Collision
 ~~~~~~~~~
+
 Perform a collision detection between two meshes.
 
-This example use the :meth:`~pyvista.PolyDataFilters.collision`
+This example uses the :meth:`~pyvista.PolyDataFilters.collision`
 filter to detect the faces from one sphere colliding with another
 sphere.
 

--- a/examples/01-filter/collision.py
+++ b/examples/01-filter/collision.py
@@ -24,7 +24,6 @@ sphere.
    repeated collisions.  See the `Collision Detection Example
    <https://examples.vtk.org/site/Python/Visualization/CollisionDetection/>`_
 
-
 """
 
 import numpy as np

--- a/examples/01-filter/compare_threshold_filters.py
+++ b/examples/01-filter/compare_threshold_filters.py
@@ -5,9 +5,11 @@ Compare threshold filters
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Multiple filters exist to exclude or highlight scalar values.
+
 The goal of this example is to compare some of these filters to show how each can be used.
-We will be differentiating them based on the input type they take,
-as well as the output type they produce.
+
+We will be differentiating them based on the input type they take, as well as the output
+type they produce.
 """
 
 import numpy as np

--- a/examples/01-filter/compare_threshold_filters.py
+++ b/examples/01-filter/compare_threshold_filters.py
@@ -10,6 +10,7 @@ The goal of this example is to compare some of these filters to show how each ca
 
 We will be differentiating them based on the input type they take, as well as the output
 type they produce.
+
 """
 
 import numpy as np

--- a/examples/01-filter/compare_threshold_filters.py
+++ b/examples/01-filter/compare_threshold_filters.py
@@ -7,9 +7,8 @@ Compare threshold filters
 Multiple filters exist to exclude or highlight scalar values.
 
 The goal of this example is to compare some of these filters to show how each can be used.
-
-We will be differentiating them based on the input type they take, as well as the output
-type they produce.
+We will be differentiating them based on the input type they take,
+as well as the output type they produce.
 
 """
 

--- a/examples/01-filter/compute_normals.py
+++ b/examples/01-filter/compute_normals.py
@@ -3,6 +3,7 @@
 
 Computing Surface Normals
 ~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Compute normals on a surface.
 
 """

--- a/examples/01-filter/connectivity.py
+++ b/examples/01-filter/connectivity.py
@@ -4,9 +4,7 @@
 Connectivity
 ~~~~~~~~~~~~
 
-This example highlights some applications of the
-:func:`~pyvista.DataSetFilters.connectivity` filter.
-
+Highlight some applications of the :func:`~pyvista.DataSetFilters.connectivity` filter.
 """
 
 # %%

--- a/examples/01-filter/connectivity.py
+++ b/examples/01-filter/connectivity.py
@@ -5,6 +5,7 @@ Connectivity
 ~~~~~~~~~~~~
 
 Highlight some applications of the :func:`~pyvista.DataSetFilters.connectivity` filter.
+
 """
 
 # %%

--- a/examples/01-filter/contouring.py
+++ b/examples/01-filter/contouring.py
@@ -8,6 +8,7 @@ Generate iso-lines or -surfaces for the scalars of a surface or volume.
 
 3D meshes can have 2D iso-surfaces of a scalar field extracted and 2D surface
 meshes can have 1D iso-lines of a scalar field extracted.
+
 """
 
 import numpy as np

--- a/examples/01-filter/convex_hull.py
+++ b/examples/01-filter/convex_hull.py
@@ -5,6 +5,7 @@ Wrap a Point Cloud in a Convex Hull
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Create a convex hull from a point cloud using tetrahedralization and surface extraction.
+
 """
 
 import numpy as np

--- a/examples/01-filter/convex_hull.py
+++ b/examples/01-filter/convex_hull.py
@@ -4,8 +4,7 @@
 Wrap a Point Cloud in a Convex Hull
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Create a convex hull from a point cloud using tetrahedralization and surface
-extraction.
+Create a convex hull from a point cloud using tetrahedralization and surface extraction.
 """
 
 import numpy as np

--- a/examples/01-filter/crop_labeled.py
+++ b/examples/01-filter/crop_labeled.py
@@ -4,9 +4,7 @@
 Crop Labeled ImageData
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Use :meth:`~pyvista.ImageDataFilters.crop` to crop labeled data such as segmented medical
-images.
-
+Use :meth:`~pyvista.ImageDataFilters.crop` to crop labeled medical image data.
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/01-filter/crop_labeled.py
+++ b/examples/01-filter/crop_labeled.py
@@ -5,6 +5,7 @@ Crop Labeled ImageData
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Use :meth:`~pyvista.ImageDataFilters.crop` to crop labeled medical image data.
+
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/01-filter/decimate.py
+++ b/examples/01-filter/decimate.py
@@ -4,7 +4,7 @@
 Decimation
 ~~~~~~~~~~
 
-Decimate a mesh
+Decimate a mesh.
 
 """
 

--- a/examples/01-filter/extract_cells_inside_surface.py
+++ b/examples/01-filter/extract_cells_inside_surface.py
@@ -4,9 +4,11 @@
 Extract Cells Inside Surface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Extract the cells inside or outside a closed surface using
-:meth:`~pyvista.DataSetFilters.select_interior_points`.
+Extract the cells inside or outside a closed surface.
 
+Uses :meth:`~pyvista.DataSetFilters.select_interior_points`.
+
+Uses :meth:`~pyvista.DataSetFilters.select_interior_points`.
 """
 
 # %%

--- a/examples/01-filter/extract_cells_inside_surface.py
+++ b/examples/01-filter/extract_cells_inside_surface.py
@@ -8,7 +8,6 @@ Extract the cells inside or outside a closed surface.
 
 Uses :meth:`~pyvista.DataSetFilters.select_interior_points`.
 
-Uses :meth:`~pyvista.DataSetFilters.select_interior_points`.
 """
 
 # %%

--- a/examples/01-filter/extract_edges.py
+++ b/examples/01-filter/extract_edges.py
@@ -5,6 +5,7 @@ Extract Edges
 ~~~~~~~~~~~~~
 
 Extract edges from a surface.
+
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/01-filter/extract_surface.py
+++ b/examples/01-filter/extract_surface.py
@@ -4,8 +4,7 @@
 Extract Surface
 ---------------
 
-You can extract the surface of nearly any object within ``pyvista``
-using the :meth:`~pyvista.DataObjectFilters.extract_surface` filter.
+Extract nearly any object surface with :meth:`~pyvista.DataObjectFilters.extract_surface`.
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/01-filter/extract_surface.py
+++ b/examples/01-filter/extract_surface.py
@@ -5,6 +5,7 @@ Extract Surface
 ---------------
 
 Extract nearly any object surface with :meth:`~pyvista.DataObjectFilters.extract_surface`.
+
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/01-filter/extrude_rotate.py
+++ b/examples/01-filter/extrude_rotate.py
@@ -4,7 +4,7 @@
 Extrude Rotation
 ~~~~~~~~~~~~~~~~
 
-Sweep polygonal data to create a "skirt" using extrude rotation.
+Sweep polygonal data into a "skirt" using :meth:`~pyvista.PolyDataFilters.extrude_rotate`.
 
 This takes polygonal data as input and generates polygonal data on
 output. The input dataset is swept around the z-axis to create

--- a/examples/01-filter/extrude_rotate.py
+++ b/examples/01-filter/extrude_rotate.py
@@ -4,16 +4,13 @@
 Extrude Rotation
 ~~~~~~~~~~~~~~~~
 
-Sweep polygonal data creating "skirt" from free edges and lines, and
-lines from vertices using the :meth:`~pyvista.PolyDataFilters.extrude_rotate`
-filter.
+Sweep polygonal data to create a "skirt" using extrude rotation.
 
 This takes polygonal data as input and generates polygonal data on
 output. The input dataset is swept around the z-axis to create
 new polygonal primitives. These primitives form a "skirt" or
 swept surface. For example, sweeping a line results in a
 cylindrical shell, and sweeping a circle creates a torus.
-
 """
 
 import numpy as np

--- a/examples/01-filter/extrude_rotate.py
+++ b/examples/01-filter/extrude_rotate.py
@@ -11,6 +11,7 @@ output. The input dataset is swept around the z-axis to create
 new polygonal primitives. These primitives form a "skirt" or
 swept surface. For example, sweeping a line results in a
 cylindrical shell, and sweeping a circle creates a torus.
+
 """
 
 import numpy as np

--- a/examples/01-filter/extrude_rotate.py
+++ b/examples/01-filter/extrude_rotate.py
@@ -3,6 +3,7 @@
 
 Extrude Rotation
 ~~~~~~~~~~~~~~~~
+
 Sweep polygonal data creating "skirt" from free edges and lines, and
 lines from vertices using the :meth:`~pyvista.PolyDataFilters.extrude_rotate`
 filter.

--- a/examples/01-filter/extrude_trim.py
+++ b/examples/01-filter/extrude_trim.py
@@ -3,6 +3,7 @@
 
 Extrude Trim
 ~~~~~~~~~~~~
+
 Extrude a :class:`pyvista.PolyData` with a :func:`pyvista.Plane` using
 :func:`extrude_trim() <pyvista.PolyDataFilters.extrude_trim>`.
 

--- a/examples/01-filter/extrude_trim.py
+++ b/examples/01-filter/extrude_trim.py
@@ -4,9 +4,11 @@
 Extrude Trim
 ~~~~~~~~~~~~
 
-Extrude a :class:`pyvista.PolyData` with a :func:`pyvista.Plane` using
-:func:`extrude_trim() <pyvista.PolyDataFilters.extrude_trim>`.
+Extrude a :class:`~pyvista.PolyData` with a :func:`pyvista.Plane`.
 
+Uses :func:`extrude_trim() <pyvista.PolyDataFilters.extrude_trim>`.
+
+Uses :func:`extrude_trim() <pyvista.PolyDataFilters.extrude_trim>`.
 """
 
 import pyvista as pv

--- a/examples/01-filter/extrude_trim.py
+++ b/examples/01-filter/extrude_trim.py
@@ -8,7 +8,6 @@ Extrude a :class:`~pyvista.PolyData` with a :func:`pyvista.Plane`.
 
 Uses :func:`extrude_trim() <pyvista.PolyDataFilters.extrude_trim>`.
 
-Uses :func:`extrude_trim() <pyvista.PolyDataFilters.extrude_trim>`.
 """
 
 import pyvista as pv

--- a/examples/01-filter/farthest_point_sampling.py
+++ b/examples/01-filter/farthest_point_sampling.py
@@ -4,8 +4,7 @@
 Farthest Point Sampling
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Subsample a point cloud so the kept points stay spaced apart instead of
-clumping in dense regions.
+Subsample a point cloud so the kept points stay spaced apart.
 
 Farthest point sampling (FPS) starts from a random seed and repeatedly picks
 the point that is farthest from the current sample set. Compared to a

--- a/examples/01-filter/fill_holes.py
+++ b/examples/01-filter/fill_holes.py
@@ -5,6 +5,7 @@ Repair a Surface with fill_holes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Seal small openings in a surface with :func:`pyvista.PolyDataFilters.fill_holes`.
+
 """
 
 import numpy as np

--- a/examples/01-filter/fill_holes.py
+++ b/examples/01-filter/fill_holes.py
@@ -4,8 +4,7 @@
 Repair a Surface with fill_holes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Seal small openings in a surface with
-:func:`pyvista.PolyDataFilters.fill_holes`.
+Seal small openings in a surface with :func:`pyvista.PolyDataFilters.fill_holes`.
 """
 
 import numpy as np

--- a/examples/01-filter/geodesic.py
+++ b/examples/01-filter/geodesic.py
@@ -5,6 +5,7 @@ Geodesic Paths
 ~~~~~~~~~~~~~~
 
 Calculates the geodesic path between two vertices using Dijkstra's algorithm.
+
 """
 
 # sphinx_gallery_thumbnail_number = 1

--- a/examples/01-filter/geodesic.py
+++ b/examples/01-filter/geodesic.py
@@ -4,7 +4,7 @@
 Geodesic Paths
 ~~~~~~~~~~~~~~
 
-Calculates the geodesic path between two vertices using Dijkstra's algorithm
+Calculates the geodesic path between two vertices using Dijkstra's algorithm.
 """
 
 # sphinx_gallery_thumbnail_number = 1

--- a/examples/01-filter/glyph.py
+++ b/examples/01-filter/glyph.py
@@ -5,6 +5,7 @@ Plotting Glyphs (Vectors or PolyData)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use vectors in a dataset to plot and orient glyphs/geometric objects.
+
 """
 
 import math

--- a/examples/01-filter/glyph_table.py
+++ b/examples/01-filter/glyph_table.py
@@ -4,8 +4,9 @@
 Table of Glyphs
 ~~~~~~~~~~~~~~~
 
-``vtk`` supports tables of glyphs from which glyphs are looked
-up. This example demonstrates this functionality.
+``vtk`` supports tables of glyphs from which glyphs are looked up.
+
+This example demonstrates this functionality.
 """
 
 import numpy as np

--- a/examples/01-filter/glyph_table.py
+++ b/examples/01-filter/glyph_table.py
@@ -7,6 +7,7 @@ Table of Glyphs
 ``vtk`` supports tables of glyphs from which glyphs are looked up.
 
 This example demonstrates this functionality.
+
 """
 
 import numpy as np

--- a/examples/01-filter/gradients.py
+++ b/examples/01-filter/gradients.py
@@ -11,6 +11,7 @@ The ordering for the output gradient tuple will be
 an input array {u, v, w}.
 
 Showing the :func:`pyvista.DataSetFilters.compute_derivative` filter.
+
 """
 
 import numpy as np

--- a/examples/01-filter/icp_registration.py
+++ b/examples/01-filter/icp_registration.py
@@ -8,7 +8,6 @@ Recover the rigid transform between two surfaces with iterative closest point.
 
 Implemented behind :func:`pyvista.DataSetFilters.align`.
 
-Implemented behind :func:`pyvista.DataSetFilters.align`.
 """
 
 import numpy as np

--- a/examples/01-filter/icp_registration.py
+++ b/examples/01-filter/icp_registration.py
@@ -4,8 +4,11 @@
 Register a Surface with ICP
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Recover the rigid transform between two surfaces with the iterative closest
-point implementation behind :func:`pyvista.DataSetFilters.align`.
+Recover the rigid transform between two surfaces with iterative closest point.
+
+Implemented behind :func:`pyvista.DataSetFilters.align`.
+
+Implemented behind :func:`pyvista.DataSetFilters.align`.
 """
 
 import numpy as np

--- a/examples/01-filter/image_fft.py
+++ b/examples/01-filter/image_fft.py
@@ -4,9 +4,11 @@
 Fast Fourier Transform
 ~~~~~~~~~~~~~~~~~~~~~~
 
-This example shows how to apply a Fast Fourier Transform (FFT) to a
-:class:`pyvista.ImageData` using :func:`pyvista.ImageDataFilters.fft`
-filter.
+Apply a Fast Fourier Transform (FFT) to a :class:`~pyvista.ImageData`.
+
+Uses the :func:`pyvista.ImageDataFilters.fft` filter.
+
+Uses the :func:`pyvista.ImageDataFilters.fft` filter.
 
 Here, we demonstrate FFT usage by denoising an image, effectively removing any
 "high frequency" content by performing a `low pass filter
@@ -14,7 +16,6 @@ Here, we demonstrate FFT usage by denoising an image, effectively removing any
 
 This example was inspired by `Image denoising by FFT
 <https://scipy-lectures.org/intro/scipy/auto_examples/solutions/plot_fft_image_denoise.html>`_.
-
 """
 
 import numpy as np

--- a/examples/01-filter/image_fft.py
+++ b/examples/01-filter/image_fft.py
@@ -8,14 +8,13 @@ Apply a Fast Fourier Transform (FFT) to a :class:`~pyvista.ImageData`.
 
 Uses the :func:`pyvista.ImageDataFilters.fft` filter.
 
-Uses the :func:`pyvista.ImageDataFilters.fft` filter.
-
 Here, we demonstrate FFT usage by denoising an image, effectively removing any
 "high frequency" content by performing a `low pass filter
 <https://en.wikipedia.org/wiki/Low-pass_filter>`_.
 
 This example was inspired by `Image denoising by FFT
 <https://scipy-lectures.org/intro/scipy/auto_examples/solutions/plot_fft_image_denoise.html>`_.
+
 """
 
 import numpy as np

--- a/examples/01-filter/image_fft_perlin_noise.py
+++ b/examples/01-filter/image_fft_perlin_noise.py
@@ -8,13 +8,12 @@ Apply an FFT to a :class:`~pyvista.ImageData` sampled from Perlin noise.
 
 Uses the :func:`pyvista.ImageDataFilters.fft` filter.
 
-Uses the :func:`pyvista.ImageDataFilters.fft` filter.
-
 Here, we demonstrate FFT usage by first generating Perlin noise using
 :func:`pyvista.sample_function() <pyvista.core.utilities.features.sample_function>` to
 sample :func:`pyvista.perlin_noise <pyvista.core.utilities.features.perlin_noise>`,
 and then performing FFT of the sampled noise to show the frequency content of
 that noise.
+
 """
 
 import numpy as np

--- a/examples/01-filter/image_fft_perlin_noise.py
+++ b/examples/01-filter/image_fft_perlin_noise.py
@@ -4,9 +4,11 @@
 Fast Fourier Transform with Perlin Noise
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This example shows how to apply a Fast Fourier Transform (FFT) to a
-:class:`pyvista.ImageData` using :func:`pyvista.ImageDataFilters.fft`
-filter.
+Apply an FFT to a :class:`~pyvista.ImageData` sampled from Perlin noise.
+
+Uses the :func:`pyvista.ImageDataFilters.fft` filter.
+
+Uses the :func:`pyvista.ImageDataFilters.fft` filter.
 
 Here, we demonstrate FFT usage by first generating Perlin noise using
 :func:`pyvista.sample_function() <pyvista.core.utilities.features.sample_function>` to

--- a/examples/01-filter/image_representations.py
+++ b/examples/01-filter/image_representations.py
@@ -3,6 +3,7 @@
 
 Image Data Representations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 This example demonstrates how to use :meth:`~pyvista.ImageDataFilters.points_to_cells`
 and :meth:`~pyvista.ImageDataFilters.cells_to_points` to re-mesh
 :class:`~pyvista.ImageData`.

--- a/examples/01-filter/image_representations.py
+++ b/examples/01-filter/image_representations.py
@@ -9,14 +9,12 @@ Re-mesh :class:`~pyvista.ImageData` between point- and cell-based representation
 Uses :meth:`~pyvista.ImageDataFilters.points_to_cells` and
 :meth:`~pyvista.ImageDataFilters.cells_to_points`.
 
-Uses :meth:`~pyvista.ImageDataFilters.points_to_cells` and
-:meth:`~pyvista.ImageDataFilters.cells_to_points`.
-
 These filters can be used to ensure that image data has an appropriate representation
 when generating plots and/or when using either point- or cell-based filters such as
 :meth:`ImageDataFilters.image_threshold <pyvista.ImageDataFilters.image_threshold>`
 (point-based) and
 :meth:`DataSetFilters.threshold <pyvista.DataSetFilters.threshold>` (cell-based).
+
 """
 
 # %%#

--- a/examples/01-filter/image_representations.py
+++ b/examples/01-filter/image_representations.py
@@ -4,16 +4,19 @@
 Image Data Representations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This example demonstrates how to use :meth:`~pyvista.ImageDataFilters.points_to_cells`
-and :meth:`~pyvista.ImageDataFilters.cells_to_points` to re-mesh
-:class:`~pyvista.ImageData`.
+Re-mesh :class:`~pyvista.ImageData` between point- and cell-based representations.
+
+Uses :meth:`~pyvista.ImageDataFilters.points_to_cells` and
+:meth:`~pyvista.ImageDataFilters.cells_to_points`.
+
+Uses :meth:`~pyvista.ImageDataFilters.points_to_cells` and
+:meth:`~pyvista.ImageDataFilters.cells_to_points`.
 
 These filters can be used to ensure that image data has an appropriate representation
 when generating plots and/or when using either point- or cell-based filters such as
 :meth:`ImageDataFilters.image_threshold <pyvista.ImageDataFilters.image_threshold>`
 (point-based) and
 :meth:`DataSetFilters.threshold <pyvista.DataSetFilters.threshold>` (cell-based).
-
 """
 
 # %%#

--- a/examples/01-filter/integrate_data.py
+++ b/examples/01-filter/integrate_data.py
@@ -5,6 +5,7 @@ Integrate Data
 ~~~~~~~~~~~~~~
 
 Integrate data over a surface using :func:`~pyvista.DataSetFilters.integrate_data`.
+
 """
 
 import pyvista as pv

--- a/examples/01-filter/integrate_data.py
+++ b/examples/01-filter/integrate_data.py
@@ -4,9 +4,7 @@
 Integrate Data
 ~~~~~~~~~~~~~~
 
-Integrate data over a surface using the
-:func:`pyvista.DataSetFilters.integrate_data` filter.
-
+Integrate data over a surface using :func:`~pyvista.DataSetFilters.integrate_data`.
 """
 
 import pyvista as pv

--- a/examples/01-filter/interpolate.py
+++ b/examples/01-filter/interpolate.py
@@ -6,8 +6,8 @@ Detailed Interpolating Points
 
 This example uses :func:`pyvista.DataSetFilters.interpolate`.
 
-:func:`pyvista.DataObjectFilters.sample` is similar, and the two methods are compared in
-:ref:`interpolate_sample_example`.
+:func:`pyvista.DataObjectFilters.sample` is similar, and the two
+methods are compared in :ref:`interpolate_sample_example`.
 
 Interpolate one mesh's point/cell arrays onto another mesh's nodes using a
 Gaussian Kernel.

--- a/examples/01-filter/interpolate.py
+++ b/examples/01-filter/interpolate.py
@@ -11,6 +11,7 @@ This example uses :func:`pyvista.DataSetFilters.interpolate`.
 
 Interpolate one mesh's point/cell arrays onto another mesh's nodes using a
 Gaussian Kernel.
+
 """
 
 # sphinx_gallery_thumbnail_number = 4

--- a/examples/01-filter/interpolate.py
+++ b/examples/01-filter/interpolate.py
@@ -5,8 +5,9 @@ Detailed Interpolating Points
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This example uses :func:`pyvista.DataSetFilters.interpolate`.
-:func:`pyvista.DataObjectFilters.sample` is similar, and the two
-methods are compared in :ref:`interpolate_sample_example`.
+
+:func:`pyvista.DataObjectFilters.sample` is similar, and the two methods are compared in
+:ref:`interpolate_sample_example`.
 
 Interpolate one mesh's point/cell arrays onto another mesh's nodes using a
 Gaussian Kernel.

--- a/examples/01-filter/interpolate_sample.py
+++ b/examples/01-filter/interpolate_sample.py
@@ -20,6 +20,7 @@ Here the two methods are compared and contrasted using a simple example of
 sampling data from a mesh in a rectangular domain. This example demonstrates the
 main differences above. For more complex uses, see :ref:`interpolate_example`
 and :ref:`resampling_example`.
+
 """
 
 # sphinx_gallery_thumbnail_number = 7

--- a/examples/01-filter/interpolate_sample.py
+++ b/examples/01-filter/interpolate_sample.py
@@ -4,12 +4,12 @@
 Compare interpolation/sampling methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are two main methods of interpolating or sampling data from a target mesh
-in PyVista. :func:`pyvista.DataSetFilters.interpolate` uses a distance weighting
-kernel to interpolate point data from nearby points of the target mesh onto
-the desired points.
-:func:`pyvista.DataObjectFilters.sample` interpolates data using the
-interpolation scheme of the enclosing cell from the target mesh.
+Compare two methods for interpolating or sampling data from a target mesh.
+
+:func:`pyvista.DataSetFilters.interpolate` uses a distance weighting kernel to interpolate
+point data from nearby points of the target mesh onto the desired points.
+:func:`pyvista.DataObjectFilters.sample` interpolates data using the interpolation scheme
+of the enclosing cell from the target mesh.
 
 If the target mesh is a point cloud, i.e. there is no connectivity in the cell
 structure, then :func:`pyvista.DataSetFilters.interpolate` is typically
@@ -20,7 +20,6 @@ Here the two methods are compared and contrasted using a simple example of
 sampling data from a mesh in a rectangular domain. This example demonstrates the
 main differences above. For more complex uses, see :ref:`interpolate_example`
 and :ref:`resampling_example`.
-
 """
 
 # sphinx_gallery_thumbnail_number = 7

--- a/examples/01-filter/marching_cubes.py
+++ b/examples/01-filter/marching_cubes.py
@@ -4,13 +4,14 @@
 Marching Cubes
 ~~~~~~~~~~~~~~
 
-Generate a surface from a scalar field using the flying edges and
-marching cubes filters as provided by the :func:`contour
-<pyvista.DataSetFilters.contour>` filter.
+Generate a surface from a scalar field using flying edges or marching cubes.
+
+Provided by the :func:`contour <pyvista.DataSetFilters.contour>` filter.
+
+Provided by the :func:`contour <pyvista.DataSetFilters.contour>` filter.
 
 Special thanks to GitHub user `stla <https://gist.github.com/stla>`_
 for providing examples.
-
 """
 
 import numpy as np

--- a/examples/01-filter/marching_cubes.py
+++ b/examples/01-filter/marching_cubes.py
@@ -8,10 +8,9 @@ Generate a surface from a scalar field using flying edges or marching cubes.
 
 Provided by the :func:`contour <pyvista.DataSetFilters.contour>` filter.
 
-Provided by the :func:`contour <pyvista.DataSetFilters.contour>` filter.
-
 Special thanks to GitHub user `stla <https://gist.github.com/stla>`_
 for providing examples.
+
 """
 
 import numpy as np

--- a/examples/01-filter/perlin_noise_2d.py
+++ b/examples/01-filter/perlin_noise_2d.py
@@ -4,7 +4,7 @@
 Sample Function: Perlin Noise in 2D
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Sample 2D Perlin noise over a region to generate random terrain.
+Sample 2D Perlin noise using :func:`~pyvista.core.utilities.features.sample_function`.
 
 Perlin noise is atype of gradient noise often used by visual effects
 artists to increase the appearance of realism in computer graphics.

--- a/examples/01-filter/perlin_noise_2d.py
+++ b/examples/01-filter/perlin_noise_2d.py
@@ -13,6 +13,7 @@ Source: `Perlin Noise Wikipedia <https://en.wikipedia.org/wiki/Perlin_noise>`_
 The development of Perlin Noise has allowed computer graphics artists
 to better represent the complexity of natural phenomena in visual
 effects for the motion picture industry.
+
 """
 
 import pyvista as pv

--- a/examples/01-filter/perlin_noise_2d.py
+++ b/examples/01-filter/perlin_noise_2d.py
@@ -4,8 +4,7 @@
 Sample Function: Perlin Noise in 2D
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Here we use :func:`pyvista.core.utilities.features.sample_function` to sample
-Perlin noise over a region to generate random terrain.
+Sample 2D Perlin noise over a region to generate random terrain.
 
 Perlin noise is atype of gradient noise often used by visual effects
 artists to increase the appearance of realism in computer graphics.
@@ -14,7 +13,6 @@ Source: `Perlin Noise Wikipedia <https://en.wikipedia.org/wiki/Perlin_noise>`_
 The development of Perlin Noise has allowed computer graphics artists
 to better represent the complexity of natural phenomena in visual
 effects for the motion picture industry.
-
 """
 
 import pyvista as pv

--- a/examples/01-filter/perlin_noise_2d.py
+++ b/examples/01-filter/perlin_noise_2d.py
@@ -3,6 +3,7 @@
 
 Sample Function: Perlin Noise in 2D
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Here we use :func:`pyvista.core.utilities.features.sample_function` to sample
 Perlin noise over a region to generate random terrain.
 

--- a/examples/01-filter/perlin_noise_3d.py
+++ b/examples/01-filter/perlin_noise_3d.py
@@ -3,6 +3,7 @@
 
 Sample Function: Perlin Noise in 3D
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Here we use :func:`pyvista.core.utilities.features.sample_function` to sample
 Perlin noise over a region to generate random terrain.
 

--- a/examples/01-filter/perlin_noise_3d.py
+++ b/examples/01-filter/perlin_noise_3d.py
@@ -4,12 +4,10 @@
 Sample Function: Perlin Noise in 3D
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Here we use :func:`pyvista.core.utilities.features.sample_function` to sample
-Perlin noise over a region to generate random terrain.
+Sample 3D Perlin noise to create a voxelized "cave" mesh.
 
 Video games like Minecraft use Perlin noise to create terrain.  Here,
 we create a voxelized mesh similar to a Minecraft "cave".
-
 """
 
 import pyvista as pv

--- a/examples/01-filter/perlin_noise_3d.py
+++ b/examples/01-filter/perlin_noise_3d.py
@@ -8,6 +8,7 @@ Sample 3D Perlin noise to create a voxelized "cave" mesh.
 
 Video games like Minecraft use Perlin noise to create terrain.  Here,
 we create a voxelized mesh similar to a Minecraft "cave".
+
 """
 
 import pyvista as pv

--- a/examples/01-filter/perlin_noise_3d.py
+++ b/examples/01-filter/perlin_noise_3d.py
@@ -4,7 +4,7 @@
 Sample Function: Perlin Noise in 3D
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Sample 3D Perlin noise to create a voxelized "cave" mesh.
+Sample 3D Perlin noise using :func:`~pyvista.core.utilities.features.sample_function`.
 
 Video games like Minecraft use Perlin noise to create terrain.  Here,
 we create a voxelized mesh similar to a Minecraft "cave".

--- a/examples/01-filter/point_cloud_distance.py
+++ b/examples/01-filter/point_cloud_distance.py
@@ -4,8 +4,11 @@
 Measure Distance Between Point Clouds
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Color a source point cloud by the distance to its nearest neighbors in a target
-cloud using :func:`pyvista.DataSet.find_closest_point`.
+Color a point cloud by its distance to the nearest neighbors in a target cloud.
+
+Uses :func:`pyvista.DataSet.find_closest_point`.
+
+Uses :func:`pyvista.DataSet.find_closest_point`.
 """
 
 import numpy as np

--- a/examples/01-filter/point_cloud_distance.py
+++ b/examples/01-filter/point_cloud_distance.py
@@ -8,7 +8,6 @@ Color a point cloud by its distance to the nearest neighbors in a target cloud.
 
 Uses :func:`pyvista.DataSet.find_closest_point`.
 
-Uses :func:`pyvista.DataSet.find_closest_point`.
 """
 
 import numpy as np

--- a/examples/01-filter/point_cloud_orientation.py
+++ b/examples/01-filter/point_cloud_orientation.py
@@ -8,7 +8,6 @@ Fit a line, plane, and oriented bounding box to a tilted point cloud.
 
 Uses PyVista's principal-axis utilities.
 
-Uses PyVista's principal-axis utilities.
 """
 
 import numpy as np

--- a/examples/01-filter/point_cloud_orientation.py
+++ b/examples/01-filter/point_cloud_orientation.py
@@ -4,8 +4,11 @@
 Analyze the Orientation of a Point Cloud
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Fit a line, plane, and oriented bounding box to a tilted point cloud with
-PyVista's principal-axis utilities.
+Fit a line, plane, and oriented bounding box to a tilted point cloud.
+
+Uses PyVista's principal-axis utilities.
+
+Uses PyVista's principal-axis utilities.
 """
 
 import numpy as np

--- a/examples/01-filter/project_plane.py
+++ b/examples/01-filter/project_plane.py
@@ -9,8 +9,6 @@ Project a :class:`~pyvista.PolyData` surface or pointset to a plane.
 Uses :meth:`~pyvista.PolyDataFilters.project_points_to_plane` with a normal
 and origin.
 
-Uses :meth:`~pyvista.PolyDataFilters.project_points_to_plane` with a normal
-and origin.
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/01-filter/project_plane.py
+++ b/examples/01-filter/project_plane.py
@@ -4,9 +4,13 @@
 Project to a Plane
 ~~~~~~~~~~~~~~~~~~
 
-:class:`pyvista.PolyData` surfaces and pointsets can easily be projected to a
-plane defined by a normal and origin using
-:meth:`~pyvista.PolyDataFilters.project_points_to_plane`.
+Project a :class:`~pyvista.PolyData` surface or pointset to a plane.
+
+Uses :meth:`~pyvista.PolyDataFilters.project_points_to_plane` with a normal
+and origin.
+
+Uses :meth:`~pyvista.PolyDataFilters.project_points_to_plane` with a normal
+and origin.
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/01-filter/ray_trace.py
+++ b/examples/01-filter/ray_trace.py
@@ -4,8 +4,11 @@
 Ray Tracing
 ~~~~~~~~~~~
 
-Single line segment ray tracing for :class:`~pyvista.PolyData` objects
-using :meth:`~pyvista.PolyDataFilters.ray_trace`.
+Single line segment ray tracing for :class:`~pyvista.PolyData` objects.
+
+Uses :meth:`~pyvista.PolyDataFilters.ray_trace`.
+
+Uses :meth:`~pyvista.PolyDataFilters.ray_trace`.
 """
 
 import pyvista as pv

--- a/examples/01-filter/ray_trace.py
+++ b/examples/01-filter/ray_trace.py
@@ -8,7 +8,6 @@ Single line segment ray tracing for :class:`~pyvista.PolyData` objects.
 
 Uses :meth:`~pyvista.PolyDataFilters.ray_trace`.
 
-Uses :meth:`~pyvista.PolyDataFilters.ray_trace`.
 """
 
 import pyvista as pv

--- a/examples/01-filter/reflect.py
+++ b/examples/01-filter/reflect.py
@@ -4,9 +4,7 @@
 Reflect Meshes
 ~~~~~~~~~~~~~~
 
-This example reflects a mesh across a plane using
-:meth:`~pyvista.DataObjectFilters.reflect`.
-
+Reflect a mesh across a plane using :meth:`~pyvista.DataObjectFilters.reflect`.
 """
 
 import pyvista as pv

--- a/examples/01-filter/reflect.py
+++ b/examples/01-filter/reflect.py
@@ -5,6 +5,7 @@ Reflect Meshes
 ~~~~~~~~~~~~~~
 
 Reflect a mesh across a plane using :meth:`~pyvista.DataObjectFilters.reflect`.
+
 """
 
 import pyvista as pv

--- a/examples/01-filter/resampling.py
+++ b/examples/01-filter/resampling.py
@@ -10,6 +10,7 @@ This example uses :func:`pyvista.DataObjectFilters.sample`.
 :ref:`interpolate_sample_example`.
 
 Resample one mesh's point/cell arrays onto another mesh's nodes.
+
 """
 
 # %%

--- a/examples/01-filter/resampling.py
+++ b/examples/01-filter/resampling.py
@@ -5,8 +5,9 @@ Detailed Resampling
 ~~~~~~~~~~~~~~~~~~~
 
 This example uses :func:`pyvista.DataObjectFilters.sample`.
-:func:`pyvista.DataSetFilters.interpolate` is similar, and the two
-methods are compared in :ref:`interpolate_sample_example`.
+
+:func:`pyvista.DataSetFilters.interpolate` is similar, and the two methods are compared in
+:ref:`interpolate_sample_example`.
 
 Resample one mesh's point/cell arrays onto another mesh's nodes.
 """

--- a/examples/01-filter/resampling.py
+++ b/examples/01-filter/resampling.py
@@ -6,8 +6,8 @@ Detailed Resampling
 
 This example uses :func:`pyvista.DataObjectFilters.sample`.
 
-:func:`pyvista.DataSetFilters.interpolate` is similar, and the two methods are compared in
-:ref:`interpolate_sample_example`.
+:func:`pyvista.DataSetFilters.interpolate` is similar, and the two
+methods are compared in :ref:`interpolate_sample_example`.
 
 Resample one mesh's point/cell arrays onto another mesh's nodes.
 

--- a/examples/01-filter/rotate.py
+++ b/examples/01-filter/rotate.py
@@ -13,12 +13,6 @@ In this model, the x axis is from the left to right;
 the y axis is from bottom to top; and the z axis emerges from the
 image. The camera location is the same in all four images.
 
-Uses :meth:`~pyvista.DataObjectFilters.rotate_x`,
-:meth:`~pyvista.DataObjectFilters.rotate_y`, and
-:meth:`~pyvista.DataObjectFilters.rotate_z`.
-In this model, the x axis is from the left to right;
-the y axis is from bottom to top; and the z axis emerges from the
-image. The camera location is the same in all four images.
 """
 
 # sphinx_gallery_thumbnail_number = 3

--- a/examples/01-filter/rotate.py
+++ b/examples/01-filter/rotate.py
@@ -4,14 +4,21 @@
 Rotations
 ~~~~~~~~~
 
-Rotations of a mesh about its axes using
-:meth:`~pyvista.DataObjectFilters.rotate_x`,
+Rotate a mesh about its axes.
+
+Uses :meth:`~pyvista.DataObjectFilters.rotate_x`,
 :meth:`~pyvista.DataObjectFilters.rotate_y`, and
 :meth:`~pyvista.DataObjectFilters.rotate_z`.
 In this model, the x axis is from the left to right;
 the y axis is from bottom to top; and the z axis emerges from the
 image. The camera location is the same in all four images.
 
+Uses :meth:`~pyvista.DataObjectFilters.rotate_x`,
+:meth:`~pyvista.DataObjectFilters.rotate_y`, and
+:meth:`~pyvista.DataObjectFilters.rotate_z`.
+In this model, the x axis is from the left to right;
+the y axis is from bottom to top; and the z axis emerges from the
+image. The camera location is the same in all four images.
 """
 
 # sphinx_gallery_thumbnail_number = 3

--- a/examples/01-filter/slice.py
+++ b/examples/01-filter/slice.py
@@ -5,6 +5,7 @@ Slicing
 ~~~~~~~
 
 Extract thin planar slices from a volume.
+
 """
 
 import matplotlib.pyplot as plt

--- a/examples/01-filter/streamlines.py
+++ b/examples/01-filter/streamlines.py
@@ -5,6 +5,7 @@ Streamlines
 ~~~~~~~~~~~
 
 Integrate a vector field to generate streamlines.
+
 """
 
 # %%

--- a/examples/01-filter/streamlines_2D.py
+++ b/examples/01-filter/streamlines_2D.py
@@ -5,6 +5,7 @@
 ~~~~~~~~~~~~~~
 
 Integrate a vector field to generate streamlines on a 2D surface.
+
 """
 
 # sphinx_gallery_thumbnail_number = 3

--- a/examples/01-filter/subdivide.py
+++ b/examples/01-filter/subdivide.py
@@ -9,6 +9,7 @@ Increase the number of triangles in a single, connected triangular mesh.
 The :func:`pyvista.PolyDataFilters.subdivide` filter utilizes three different
 subdivision algorithms to subdivide a mesh's cells: `butterfly`, `loop`,
 or `linear`.
+
 """
 
 import pyvista as pv

--- a/examples/01-filter/surface_reconstruction.py
+++ b/examples/01-filter/surface_reconstruction.py
@@ -8,7 +8,6 @@ Reconstruct a surface with :func:`~pyvista.PolyDataFilters.reconstruct_surface`.
 
 This tends to perform much better than :func:`pyvista.DataSetFilters.delaunay_3d`.
 
-This tends to perform much better than :func:`pyvista.DataSetFilters.delaunay_3d`.
 """
 
 import pyvista as pv

--- a/examples/01-filter/surface_reconstruction.py
+++ b/examples/01-filter/surface_reconstruction.py
@@ -4,10 +4,11 @@
 Surface Reconstruction
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Surface reconstruction has a dedicated filter in PyVista and is
-handled by :func:`pyvista.PolyDataFilters.reconstruct_surface`. This
-tends to perform much better than :func:`pyvista.DataSetFilters.delaunay_3d`.
+Reconstruct a surface with :func:`~pyvista.PolyDataFilters.reconstruct_surface`.
 
+This tends to perform much better than :func:`pyvista.DataSetFilters.delaunay_3d`.
+
+This tends to perform much better than :func:`pyvista.DataSetFilters.delaunay_3d`.
 """
 
 import pyvista as pv

--- a/examples/01-filter/surface_smoothing.py
+++ b/examples/01-filter/surface_smoothing.py
@@ -4,7 +4,7 @@
 Surface Smoothing
 ~~~~~~~~~~~~~~~~~
 
-Smoothing rough edges of a surface mesh
+Smoothing rough edges of a surface mesh.
 """
 
 # sphinx_gallery_thumbnail_number = 4

--- a/examples/01-filter/surface_smoothing.py
+++ b/examples/01-filter/surface_smoothing.py
@@ -5,6 +5,7 @@ Surface Smoothing
 ~~~~~~~~~~~~~~~~~
 
 Smoothing rough edges of a surface mesh.
+
 """
 
 # sphinx_gallery_thumbnail_number = 4

--- a/examples/01-filter/using_filters.py
+++ b/examples/01-filter/using_filters.py
@@ -5,6 +5,7 @@ Using Common Filters
 ~~~~~~~~~~~~~~~~~~~~
 
 Using common filters like thresholding and clipping.
+
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/01-filter/volumetric_analysis.py
+++ b/examples/01-filter/volumetric_analysis.py
@@ -4,8 +4,7 @@
 Volumetric Analysis
 ~~~~~~~~~~~~~~~~~~~
 
-
-Calculate mass properties such as the volume or area of datasets
+Calculate mass properties such as the volume or area of datasets.
 """
 
 # sphinx_gallery_thumbnail_number = 4

--- a/examples/01-filter/volumetric_analysis.py
+++ b/examples/01-filter/volumetric_analysis.py
@@ -5,6 +5,7 @@ Volumetric Analysis
 ~~~~~~~~~~~~~~~~~~~
 
 Calculate mass properties such as the volume or area of datasets.
+
 """
 
 # sphinx_gallery_thumbnail_number = 4

--- a/examples/01-filter/warp_by_vector.py
+++ b/examples/01-filter/warp_by_vector.py
@@ -4,8 +4,11 @@
 Warping by Vectors
 ~~~~~~~~~~~~~~~~~~
 
-This example applies the :meth:`~pyvista.DataSetFilters.warp_by_vector`
-filter to a sphere mesh that has 3D displacement vectors defined at each node.
+Apply :meth:`~pyvista.DataSetFilters.warp_by_vector` to a sphere mesh.
+
+The sphere has 3D displacement vectors defined at each node.
+
+The sphere has 3D displacement vectors defined at each node.
 """
 
 # %%

--- a/examples/01-filter/warp_by_vector.py
+++ b/examples/01-filter/warp_by_vector.py
@@ -8,7 +8,6 @@ Apply :meth:`~pyvista.DataSetFilters.warp_by_vector` to a sphere mesh.
 
 The sphere has 3D displacement vectors defined at each node.
 
-The sphere has 3D displacement vectors defined at each node.
 """
 
 # %%

--- a/examples/02-plot/anti_aliasing.py
+++ b/examples/02-plot/anti_aliasing.py
@@ -3,6 +3,7 @@
 
 Anti-Aliasing
 ~~~~~~~~~~~~~
+
 Demonstrate anti-aliasing within PyVista.
 
 PyVista supports three types of anti-aliasing:

--- a/examples/02-plot/anti_aliasing.py
+++ b/examples/02-plot/anti_aliasing.py
@@ -30,7 +30,6 @@ balance between efficiency and quality. If you desire additional smoothing, you
 can either increase the number of ``multi_samples`` or use SSAA. Low-end PCs
 should consider FXAA.
 
-
 """
 
 import pyvista as pv

--- a/examples/02-plot/axes_objects.py
+++ b/examples/02-plot/axes_objects.py
@@ -6,8 +6,8 @@ Axes Objects
 
 PyVista has many axes objects which can be used for plotting.
 
-This example highlights many of these objects and shows how to use them with related
-plotting methods.
+This example highlights many of these objects and shows how
+to use them with related plotting methods.
 
 """
 

--- a/examples/02-plot/axes_objects.py
+++ b/examples/02-plot/axes_objects.py
@@ -5,9 +5,9 @@ Axes Objects
 ~~~~~~~~~~~~
 
 PyVista has many axes objects which can be used for plotting.
-This example highlights many of these objects and shows how
-to use them with related plotting methods.
 
+This example highlights many of these objects and shows how to use them with related
+plotting methods.
 """
 
 # sphinx_gallery_thumbnail_number = 7

--- a/examples/02-plot/axes_objects.py
+++ b/examples/02-plot/axes_objects.py
@@ -8,6 +8,7 @@ PyVista has many axes objects which can be used for plotting.
 
 This example highlights many of these objects and shows how to use them with related
 plotting methods.
+
 """
 
 # sphinx_gallery_thumbnail_number = 7

--- a/examples/02-plot/backface_prop.py
+++ b/examples/02-plot/backface_prop.py
@@ -4,9 +4,10 @@
 Setting Backface Properties
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default front and backface rendering uses the same properties. In certain
-situations it can be useful to set different properties for backfaces than
-for frontfaces.
+By default front and backface rendering uses the same properties.
+
+In certain situations it can be useful to set different properties for backfaces than for
+frontfaces.
 
 One straightforward example is when a closed (or close enough) surface has a
 different color on the inside. Note that the notion of "inside" and "outside"

--- a/examples/02-plot/backface_prop.py
+++ b/examples/02-plot/backface_prop.py
@@ -12,6 +12,7 @@ frontfaces.
 One straightforward example is when a closed (or close enough) surface has a
 different color on the inside. Note that the notion of "inside" and "outside"
 depend on the orientation of the surface normals:
+
 """
 
 # sphinx_gallery_thumbnail_number = 1

--- a/examples/02-plot/backface_prop.py
+++ b/examples/02-plot/backface_prop.py
@@ -6,8 +6,9 @@ Setting Backface Properties
 
 By default front and backface rendering uses the same properties.
 
-In certain situations it can be useful to set different properties for backfaces than for
-frontfaces.
+In certain
+situations it can be useful to set different properties for backfaces than
+for frontfaces.
 
 One straightforward example is when a closed (or close enough) surface has a
 different color on the inside. Note that the notion of "inside" and "outside"

--- a/examples/02-plot/blurring.py
+++ b/examples/02-plot/blurring.py
@@ -9,8 +9,6 @@ Blur a plot, or highlight part of it, using depth-of-field style effects.
 Uses :func:`add_blurring <pyvista.Plotter.add_blurring>` or
 :func:`enable_depth_of_field <pyvista.Plotter.enable_depth_of_field>`.
 
-Uses :func:`add_blurring <pyvista.Plotter.add_blurring>` or
-:func:`enable_depth_of_field <pyvista.Plotter.enable_depth_of_field>`.
 """
 
 import pyvista as pv

--- a/examples/02-plot/blurring.py
+++ b/examples/02-plot/blurring.py
@@ -3,6 +3,7 @@
 
 Blurring
 ~~~~~~~~
+
 This example shows how you can use :func:`add_blurring
 <pyvista.Plotter.add_blurring>` to blur a plot, or use
 :func:`enable_depth_of_field <pyvista.Plotter.enable_depth_of_field>`

--- a/examples/02-plot/blurring.py
+++ b/examples/02-plot/blurring.py
@@ -4,11 +4,13 @@
 Blurring
 ~~~~~~~~
 
-This example shows how you can use :func:`add_blurring
-<pyvista.Plotter.add_blurring>` to blur a plot, or use
-:func:`enable_depth_of_field <pyvista.Plotter.enable_depth_of_field>`
-to highlight part of your plot.
+Blur a plot, or highlight part of it, using depth-of-field style effects.
 
+Uses :func:`add_blurring <pyvista.Plotter.add_blurring>` or
+:func:`enable_depth_of_field <pyvista.Plotter.enable_depth_of_field>`.
+
+Uses :func:`add_blurring <pyvista.Plotter.add_blurring>` or
+:func:`enable_depth_of_field <pyvista.Plotter.enable_depth_of_field>`.
 """
 
 import pyvista as pv

--- a/examples/02-plot/bounds.py
+++ b/examples/02-plot/bounds.py
@@ -4,8 +4,8 @@
 Plotting Bounds
 ~~~~~~~~~~~~~~~
 
-This example demonstrates to show bounds within a :class:`pyvista.Plotter`
-using :func:`show_grid() <pyvista.Plotter.show_grid>`
+This example demonstrates how to show bounds within a :class:`pyvista.Plotter`
+using :func:`show_grid() <pyvista.Plotter.show_grid>`.
 
 """
 

--- a/examples/02-plot/bounds.py
+++ b/examples/02-plot/bounds.py
@@ -4,9 +4,7 @@
 Plotting Bounds
 ~~~~~~~~~~~~~~~
 
-This example demonstrates how to show bounds within a :class:`pyvista.Plotter`
-using :func:`show_grid() <pyvista.Plotter.show_grid>`.
-
+Show bounds within a :class:`~pyvista.Plotter` using :func:`~pyvista.Plotter.show_grid`.
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/02-plot/bounds.py
+++ b/examples/02-plot/bounds.py
@@ -5,6 +5,7 @@ Plotting Bounds
 ~~~~~~~~~~~~~~~
 
 Show bounds within a :class:`~pyvista.Plotter` using :func:`~pyvista.Plotter.show_grid`.
+
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/02-plot/chart_basics.py
+++ b/examples/02-plot/chart_basics.py
@@ -8,6 +8,7 @@ This example shows how different types of charts can be added to the scene.
 
 A more complex example, showing how to combine multiple charts as overlays in the same
 renderer, is given in :ref:`chart_overlays_example`.
+
 """
 
 import numpy as np

--- a/examples/02-plot/chart_basics.py
+++ b/examples/02-plot/chart_basics.py
@@ -6,8 +6,8 @@ Chart Basics
 
 This example shows how different types of charts can be added to the scene.
 
-A more complex example, showing how to combine multiple charts as overlays in the same
-renderer, is given in :ref:`chart_overlays_example`.
+A more complex example, showing how to combine multiple charts as overlays
+in the same renderer, is given in :ref:`chart_overlays_example`.
 
 """
 

--- a/examples/02-plot/chart_basics.py
+++ b/examples/02-plot/chart_basics.py
@@ -5,8 +5,9 @@ Chart Basics
 ~~~~~~~~~~~~
 
 This example shows how different types of charts can be added to the scene.
-A more complex example, showing how to combine multiple charts as overlays
-in the same renderer, is given in :ref:`chart_overlays_example`.
+
+A more complex example, showing how to combine multiple charts as overlays in the same
+renderer, is given in :ref:`chart_overlays_example`.
 """
 
 import numpy as np

--- a/examples/02-plot/chart_overlays.py
+++ b/examples/02-plot/chart_overlays.py
@@ -12,6 +12,7 @@ click on top of it. Note that this will disable interaction with the 3D scene. T
 interacting with the chart, perform another double left click. This will either enable
 interaction with another chart (if clicked on top of it) or re-enable interaction with the
 3D scene.
+
 """
 
 import matplotlib.pyplot as plt

--- a/examples/02-plot/chart_overlays.py
+++ b/examples/02-plot/chart_overlays.py
@@ -4,15 +4,14 @@
 Chart Overlays
 ~~~~~~~~~~~~~~
 
-This example shows how you can combine multiple charts as overlays in
-the same renderer. For an overview of the different chart types you
-can use, please refer to :ref:`chart_basics_example`. Interaction with
-a chart can be enabled by a double left click on top of it. Note that this
-will disable interaction with the 3D scene. To stop interacting with
-the chart, perform another double left click. This will either enable
-interaction with another chart (if clicked on top of it) or re-enable
-interaction with the 3D scene.
+This example shows how you can combine multiple charts as overlays in the same renderer.
 
+For an overview of the different chart types you can use, please refer to
+:ref:`chart_basics_example`. Interaction with a chart can be enabled by a double left
+click on top of it. Note that this will disable interaction with the 3D scene. To stop
+interacting with the chart, perform another double left click. This will either enable
+interaction with another chart (if clicked on top of it) or re-enable interaction with the
+3D scene.
 """
 
 import matplotlib.pyplot as plt

--- a/examples/02-plot/chart_overlays.py
+++ b/examples/02-plot/chart_overlays.py
@@ -6,12 +6,13 @@ Chart Overlays
 
 This example shows how you can combine multiple charts as overlays in the same renderer.
 
-For an overview of the different chart types you can use, please refer to
-:ref:`chart_basics_example`. Interaction with a chart can be enabled by a double left
-click on top of it. Note that this will disable interaction with the 3D scene. To stop
-interacting with the chart, perform another double left click. This will either enable
-interaction with another chart (if clicked on top of it) or re-enable interaction with the
-3D scene.
+For an overview of the different chart types you
+can use, please refer to :ref:`chart_basics_example`. Interaction with
+a chart can be enabled by a double left click on top of it. Note that this
+will disable interaction with the 3D scene. To stop interacting with
+the chart, perform another double left click. This will either enable
+interaction with another chart (if clicked on top of it) or re-enable
+interaction with the 3D scene.
 
 """
 

--- a/examples/02-plot/chemistry_molecule.py
+++ b/examples/02-plot/chemistry_molecule.py
@@ -5,6 +5,7 @@ Build a Ball-and-Stick Molecule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Assemble a simple molecule from :func:`~pyvista.Sphere` atoms and cylinder bonds.
+
 """
 
 import numpy as np

--- a/examples/02-plot/chemistry_molecule.py
+++ b/examples/02-plot/chemistry_molecule.py
@@ -4,8 +4,7 @@
 Build a Ball-and-Stick Molecule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Assemble a simple molecule from :func:`pyvista.Sphere` atoms and
-:func:`pyvista.Cylinder` bonds.
+Assemble a simple molecule from :func:`~pyvista.Sphere` atoms and cylinder bonds.
 """
 
 import numpy as np

--- a/examples/02-plot/clear.py
+++ b/examples/02-plot/clear.py
@@ -4,9 +4,7 @@
 Clearing a Mesh or the Entire Plot
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This example demonstrates how to remove elements from a scene using
-:meth:`~pyvista.Plotter.clear`.
-
+Remove elements from a scene using :meth:`~pyvista.Plotter.clear`.
 """
 
 # sphinx_gallery_thumbnail_number = 3

--- a/examples/02-plot/clear.py
+++ b/examples/02-plot/clear.py
@@ -5,6 +5,7 @@ Clearing a Mesh or the Entire Plot
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Remove elements from a scene using :meth:`~pyvista.Plotter.clear`.
+
 """
 
 # sphinx_gallery_thumbnail_number = 3

--- a/examples/02-plot/color_cycler.py
+++ b/examples/02-plot/color_cycler.py
@@ -5,6 +5,7 @@ Color Cycling
 ~~~~~~~~~~~~~
 
 Cycle through colors when sequentially adding meshes to a plotter.
+
 """
 
 # %%

--- a/examples/02-plot/color_lines.py
+++ b/examples/02-plot/color_lines.py
@@ -4,8 +4,7 @@
 Color Several Lines
 ~~~~~~~~~~~~~~~~~~~
 
-Render several :func:`pyvista.MultipleLines` polylines and color them by a
-line-wise scalar value.
+Render several :func:`~pyvista.MultipleLines` polylines colored by a scalar value.
 """
 
 import numpy as np

--- a/examples/02-plot/color_lines.py
+++ b/examples/02-plot/color_lines.py
@@ -5,6 +5,7 @@ Color Several Lines
 ~~~~~~~~~~~~~~~~~~~
 
 Render several :func:`~pyvista.MultipleLines` polylines colored by a scalar value.
+
 """
 
 import numpy as np

--- a/examples/02-plot/colormap.py
+++ b/examples/02-plot/colormap.py
@@ -4,8 +4,11 @@
 Colormap Choices
 ~~~~~~~~~~~~~~~~
 
-Use a Matplotlib, Colorcet, cmocean, or custom colormap when plotting scalar
-values with :func:`pyvista.plot` and :class:`~pyvista.Plotter` methods.
+Use a Matplotlib, Colorcet, cmocean, or custom colormap when plotting scalars.
+
+Works with :func:`pyvista.plot` and :class:`~pyvista.Plotter` methods.
+
+Works with :func:`pyvista.plot` and :class:`~pyvista.Plotter` methods.
 """
 
 from matplotlib.colors import LinearSegmentedColormap

--- a/examples/02-plot/colormap.py
+++ b/examples/02-plot/colormap.py
@@ -8,7 +8,6 @@ Use a Matplotlib, Colorcet, cmocean, or custom colormap when plotting scalars.
 
 Works with :func:`pyvista.plot` and :class:`~pyvista.Plotter` methods.
 
-Works with :func:`pyvista.plot` and :class:`~pyvista.Plotter` methods.
 """
 
 from matplotlib.colors import LinearSegmentedColormap

--- a/examples/02-plot/composite_picking.py
+++ b/examples/02-plot/composite_picking.py
@@ -4,9 +4,11 @@
 Composite Picking
 ~~~~~~~~~~~~~~~~~
 
-Demonstrate how to pick individual blocks of a :class:`pyvista.MultiBlock`
-using :func:`pyvista.Plotter.enable_block_picking`.
+Pick individual blocks of a :class:`~pyvista.MultiBlock`.
 
+Uses :func:`pyvista.Plotter.enable_block_picking`.
+
+Uses :func:`pyvista.Plotter.enable_block_picking`.
 """
 
 import numpy as np

--- a/examples/02-plot/composite_picking.py
+++ b/examples/02-plot/composite_picking.py
@@ -8,7 +8,6 @@ Pick individual blocks of a :class:`~pyvista.MultiBlock`.
 
 Uses :func:`pyvista.Plotter.enable_block_picking`.
 
-Uses :func:`pyvista.Plotter.enable_block_picking`.
 """
 
 import numpy as np

--- a/examples/02-plot/depth_of_field.py
+++ b/examples/02-plot/depth_of_field.py
@@ -5,6 +5,7 @@ Depth of Field Plotting
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Highlight part of a plot using :func:`~pyvista.Plotter.enable_depth_of_field`.
+
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/02-plot/depth_of_field.py
+++ b/examples/02-plot/depth_of_field.py
@@ -4,9 +4,7 @@
 Depth of Field Plotting
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-This example shows how you can use :func:`enable_depth_of_field
-<pyvista.Plotter.enable_depth_of_field>` to highlight part of your plot.
-
+Highlight part of a plot using :func:`~pyvista.Plotter.enable_depth_of_field`.
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/02-plot/depth_peeling.py
+++ b/examples/02-plot/depth_peeling.py
@@ -3,8 +3,10 @@
 
 Depth Peeling
 ~~~~~~~~~~~~~
-Depth peeling is a technique to correctly render translucent geometry.  This is
-not enabled by default in :attr:`pyvista.global_theme
+
+Depth peeling is a technique to correctly render translucent geometry.
+
+This is not enabled by default in :attr:`pyvista.global_theme
 <pyvista.plotting.themes.Theme>` as some operating systems and versions of VTK
 have issues with this routine.
 

--- a/examples/02-plot/depth_peeling.py
+++ b/examples/02-plot/depth_peeling.py
@@ -6,7 +6,8 @@ Depth Peeling
 
 Depth peeling is a technique to correctly render translucent geometry.
 
-This is not enabled by default in :attr:`pyvista.global_theme
+This is
+not enabled by default in :attr:`pyvista.global_theme
 <pyvista.plotting.themes.Theme>` as some operating systems and versions of VTK
 have issues with this routine.
 

--- a/examples/02-plot/distance_along_spline.py
+++ b/examples/02-plot/distance_along_spline.py
@@ -7,6 +7,7 @@ Label based on Distance on Line
 Create a spline and generate labels along the spline based on distance along a spline.
 
 This is an extension of the :ref:`create_spline_example`.
+
 """
 
 import numpy as np

--- a/examples/02-plot/distance_along_spline.py
+++ b/examples/02-plot/distance_along_spline.py
@@ -4,11 +4,9 @@
 Label based on Distance on Line
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Create a spline and generate labels along the spline based on distance along a
-spline.
+Create a spline and generate labels along the spline based on distance along a spline.
 
 This is an extension of the :ref:`create_spline_example`.
-
 """
 
 import numpy as np

--- a/examples/02-plot/distance_measurement.py
+++ b/examples/02-plot/distance_measurement.py
@@ -4,9 +4,7 @@
 Measuring distance
 ~~~~~~~~~~~~~~~~~~
 
-This example demonstrates how to measure distance between two points using
-:func:`add_measurement_widget() <pyvista.Plotter.add_measurement_widget>`.
-
+Measure distance between two points using :func:`~pyvista.Plotter.add_measurement_widget`.
 """
 
 import pyvista as pv

--- a/examples/02-plot/distance_measurement.py
+++ b/examples/02-plot/distance_measurement.py
@@ -5,6 +5,7 @@ Measuring distance
 ~~~~~~~~~~~~~~~~~~
 
 Measure distance between two points using :func:`~pyvista.Plotter.add_measurement_widget`.
+
 """
 
 import pyvista as pv

--- a/examples/02-plot/distance_measurement.py
+++ b/examples/02-plot/distance_measurement.py
@@ -3,7 +3,8 @@
 
 Measuring distance
 ~~~~~~~~~~~~~~~~~~
-This example demonstrates how to measure distance between two points.
+
+This example demonstrates how to measure distance between two points using
 :func:`add_measurement_widget() <pyvista.Plotter.add_measurement_widget>`.
 
 """

--- a/examples/02-plot/edl.py
+++ b/examples/02-plot/edl.py
@@ -10,10 +10,6 @@ It darkens each pixel based on how much nearer its neighbors are in screen
 space, which makes depth ordering readable even on flat-shaded geometry or
 unshaded point clouds. To learn more, see `this blog post`_.
 
-It darkens each pixel based on how much nearer its neighbors are in screen
-space, which makes depth ordering readable even on flat-shaded geometry or
-unshaded point clouds. To learn more, see `this blog post`_.
-
 .. _this blog post: https://www.kitware.com/eye-dome-lighting-a-non-photorealistic-shading-technique/
 
 EDL is most useful when standard Lambertian shading is insufficient, for
@@ -23,6 +19,7 @@ example:
 * Dense or intertwined geometry where overlapping surfaces collapse into a
   visually flat mass.
 * Noisy or raw-scanned meshes with many features at similar depths.
+
 """
 
 # %%

--- a/examples/02-plot/edl.py
+++ b/examples/02-plot/edl.py
@@ -4,8 +4,12 @@
 Eye Dome Lighting
 ~~~~~~~~~~~~~~~~~
 
-Eye-Dome Lighting (EDL) is a non-photorealistic, image-based shading technique
-designed to improve depth perception in scientific visualization images.
+Eye-Dome Lighting (EDL) improves depth perception in scientific visualization.
+
+It darkens each pixel based on how much nearer its neighbors are in screen
+space, which makes depth ordering readable even on flat-shaded geometry or
+unshaded point clouds. To learn more, see `this blog post`_.
+
 It darkens each pixel based on how much nearer its neighbors are in screen
 space, which makes depth ordering readable even on flat-shaded geometry or
 unshaded point clouds. To learn more, see `this blog post`_.
@@ -19,7 +23,6 @@ example:
 * Dense or intertwined geometry where overlapping surfaces collapse into a
   visually flat mass.
 * Noisy or raw-scanned meshes with many features at similar depths.
-
 """
 
 # %%

--- a/examples/02-plot/element_picking.py
+++ b/examples/02-plot/element_picking.py
@@ -17,6 +17,7 @@ The different elements of a mesh are:
 * Point: pick a single point on the mesh
 
 These types are captured in the :class:`pyvista.plotting.opts.ElementType` enum class.
+
 """
 
 # sphinx_gallery_thumbnail_number = 1

--- a/examples/02-plot/element_picking.py
+++ b/examples/02-plot/element_picking.py
@@ -4,8 +4,7 @@
 Picking elements of a mesh
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This example demonstrates how to pick different elements on meshes using
-:func:`enable_element_picking() <pyvista.Plotter.enable_element_picking>`.
+Pick different elements on meshes using :func:`~pyvista.Plotter.enable_element_picking`.
 
 The different elements of a mesh are:
 
@@ -18,7 +17,6 @@ The different elements of a mesh are:
 * Point: pick a single point on the mesh
 
 These types are captured in the :class:`pyvista.plotting.opts.ElementType` enum class.
-
 """
 
 # sphinx_gallery_thumbnail_number = 1

--- a/examples/02-plot/element_picking.py
+++ b/examples/02-plot/element_picking.py
@@ -3,6 +3,7 @@
 
 Picking elements of a mesh
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 This example demonstrates how to pick different elements on meshes using
 :func:`enable_element_picking() <pyvista.Plotter.enable_element_picking>`.
 

--- a/examples/02-plot/flight_paths.py
+++ b/examples/02-plot/flight_paths.py
@@ -4,8 +4,11 @@
 Plot Curved Flight Paths on a Globe
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Connect cities with elevated circular arcs from :func:`pyvista.CircularArc` to
-create a simple route map.
+Connect cities with elevated circular arcs to create a simple route map.
+
+Uses :func:`pyvista.CircularArc`.
+
+Uses :func:`pyvista.CircularArc`.
 """
 
 import numpy as np

--- a/examples/02-plot/flight_paths.py
+++ b/examples/02-plot/flight_paths.py
@@ -8,7 +8,6 @@ Connect cities with elevated circular arcs to create a simple route map.
 
 Uses :func:`pyvista.CircularArc`.
 
-Uses :func:`pyvista.CircularArc`.
 """
 
 import numpy as np

--- a/examples/02-plot/floors.py
+++ b/examples/02-plot/floors.py
@@ -5,6 +5,7 @@ Plot with Floors
 ~~~~~~~~~~~~~~~~
 
 Add a floor/wall at the scene boundary using :func:`~pyvista.Plotter.add_floor`.
+
 """
 
 import pyvista as pv

--- a/examples/02-plot/floors.py
+++ b/examples/02-plot/floors.py
@@ -4,8 +4,7 @@
 Plot with Floors
 ~~~~~~~~~~~~~~~~
 
-Add a floor/wall at the boundary of the rendering scene
-using :func:`~pyvista.Plotter.add_floor`.
+Add a floor/wall at the scene boundary using :func:`~pyvista.Plotter.add_floor`.
 """
 
 import pyvista as pv

--- a/examples/02-plot/ghost_cells.py
+++ b/examples/02-plot/ghost_cells.py
@@ -11,6 +11,7 @@ mesh without creating a new mesh.
 
 Notably, the mesh must be cast to an :class:`pyvista.UnstructuredGrid` type
 for this to work (use the ``cast_to_unstructured_grid`` filter).
+
 """
 
 import numpy as np

--- a/examples/02-plot/gif.py
+++ b/examples/02-plot/gif.py
@@ -3,7 +3,9 @@
 
 Create a GIF Movie
 ~~~~~~~~~~~~~~~~~~
+
 Generate a moving gif from an active plotter.
+
 This example uses :meth:`~pyvista.Plotter.open_gif` and
 :meth:`~pyvista.Plotter.write_frame` to create the gif.
 

--- a/examples/02-plot/graph_network.py
+++ b/examples/02-plot/graph_network.py
@@ -8,7 +8,6 @@ Render a node-edge network with labels and weighted edges.
 
 Uses :func:`pyvista.line_segments_from_points`.
 
-Uses :func:`pyvista.line_segments_from_points`.
 """
 
 import numpy as np

--- a/examples/02-plot/graph_network.py
+++ b/examples/02-plot/graph_network.py
@@ -4,8 +4,11 @@
 Plot a 3D Graph Network
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Render a node-edge network with labels and weighted edges using
-:func:`pyvista.line_segments_from_points`.
+Render a node-edge network with labels and weighted edges.
+
+Uses :func:`pyvista.line_segments_from_points`.
+
+Uses :func:`pyvista.line_segments_from_points`.
 """
 
 import numpy as np

--- a/examples/02-plot/image_depth.py
+++ b/examples/02-plot/image_depth.py
@@ -4,8 +4,13 @@
 Render a depth image
 ~~~~~~~~~~~~~~~~~~~~
 
-Use :meth:`~pyvista.Plotter.get_image_depth` to plot a depth image as viewed from a
-camera overlooking the :func:`~pyvista.examples.examples.load_random_hills` example mesh.
+Plot a depth image as viewed from a camera overlooking an example mesh.
+
+Uses :meth:`~pyvista.Plotter.get_image_depth` with the
+:func:`~pyvista.examples.examples.load_random_hills` example mesh.
+
+Uses :meth:`~pyvista.Plotter.get_image_depth` with the
+:func:`~pyvista.examples.examples.load_random_hills` example mesh.
 """
 
 import matplotlib.pyplot as plt

--- a/examples/02-plot/image_depth.py
+++ b/examples/02-plot/image_depth.py
@@ -9,8 +9,6 @@ Plot a depth image as viewed from a camera overlooking an example mesh.
 Uses :meth:`~pyvista.Plotter.get_image_depth` with the
 :func:`~pyvista.examples.examples.load_random_hills` example mesh.
 
-Uses :meth:`~pyvista.Plotter.get_image_depth` with the
-:func:`~pyvista.examples.examples.load_random_hills` example mesh.
 """
 
 import matplotlib.pyplot as plt

--- a/examples/02-plot/interpolate_before_map.py
+++ b/examples/02-plot/interpolate_before_map.py
@@ -4,17 +4,19 @@
 Interpolate Before Mapping
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The :func:`add_mesh <pyvista.Plotter.add_mesh>` method has an
-``interpolate_before_map`` argument that affects the way scalar data is
-visualized with colors.  The effect of this can vary depending on the
-dataset's topology and the chosen colormap.
+The ``interpolate_before_map`` argument affects how scalar data is colored.
+
+Set via the :func:`add_mesh <pyvista.Plotter.add_mesh>` method. The effect
+can vary depending on the dataset's topology and the chosen colormap.
+
+Set via the :func:`add_mesh <pyvista.Plotter.add_mesh>` method. The effect
+can vary depending on the dataset's topology and the chosen colormap.
 
 This example serves to demo the difference and why we've chosen to enable this
 by default.
 
 For more details, please see `What is InterpolateScalarsBeforeMapping in VTK?
 <https://www.kitware.com/what-is-interpolatescalarsbeforemapping-in-vtk/>`_
-
 """
 
 # sphinx_gallery_thumbnail_number = 4

--- a/examples/02-plot/interpolate_before_map.py
+++ b/examples/02-plot/interpolate_before_map.py
@@ -9,14 +9,12 @@ The ``interpolate_before_map`` argument affects how scalar data is colored.
 Set via the :func:`add_mesh <pyvista.Plotter.add_mesh>` method. The effect
 can vary depending on the dataset's topology and the chosen colormap.
 
-Set via the :func:`add_mesh <pyvista.Plotter.add_mesh>` method. The effect
-can vary depending on the dataset's topology and the chosen colormap.
-
 This example serves to demo the difference and why we've chosen to enable this
 by default.
 
 For more details, please see `What is InterpolateScalarsBeforeMapping in VTK?
 <https://www.kitware.com/what-is-interpolatescalarsbeforemapping-in-vtk/>`_
+
 """
 
 # sphinx_gallery_thumbnail_number = 4

--- a/examples/02-plot/legend.py
+++ b/examples/02-plot/legend.py
@@ -5,6 +5,7 @@ Legends and glyphs
 ~~~~~~~~~~~~~~~~~~
 
 Using custom legends and glyphs within PyVista.
+
 """
 
 import pyvista as pv

--- a/examples/02-plot/lighting_mesh.py
+++ b/examples/02-plot/lighting_mesh.py
@@ -6,8 +6,8 @@ Lighting Properties
 
 Control aspects of the rendered mesh's lighting such as Ambient, Diffuse, and Specular.
 
-These options only work if the ``lighting`` argument to ``add_mesh`` is ``True`` (it's
-``True`` by default).
+These options only work if the ``lighting`` argument to
+``add_mesh`` is ``True`` (it's ``True`` by default).
 
 You can turn off all lighting for the given mesh by passing ``lighting=False``
 to ``add_mesh``.

--- a/examples/02-plot/lighting_mesh.py
+++ b/examples/02-plot/lighting_mesh.py
@@ -4,9 +4,10 @@
 Lighting Properties
 ~~~~~~~~~~~~~~~~~~~
 
-Control aspects of the rendered mesh's lighting such as Ambient, Diffuse,
-and Specular. These options only work if the ``lighting`` argument to
-``add_mesh`` is ``True`` (it's ``True`` by default).
+Control aspects of the rendered mesh's lighting such as Ambient, Diffuse, and Specular.
+
+These options only work if the ``lighting`` argument to ``add_mesh`` is ``True`` (it's
+``True`` by default).
 
 You can turn off all lighting for the given mesh by passing ``lighting=False``
 to ``add_mesh``.

--- a/examples/02-plot/lighting_mesh.py
+++ b/examples/02-plot/lighting_mesh.py
@@ -11,6 +11,7 @@ These options only work if the ``lighting`` argument to ``add_mesh`` is ``True``
 
 You can turn off all lighting for the given mesh by passing ``lighting=False``
 to ``add_mesh``.
+
 """
 
 # sphinx_gallery_thumbnail_number = 4

--- a/examples/02-plot/linked_views.py
+++ b/examples/02-plot/linked_views.py
@@ -10,9 +10,6 @@ Camera movements in one view are synchronized with other views. This is
 particularly useful when comparing different versions or representations of
 the same model.
 
-Camera movements in one view are synchronized with other views. This is
-particularly useful when comparing different versions or representations of
-the same model.
 """
 
 import numpy as np

--- a/examples/02-plot/linked_views.py
+++ b/examples/02-plot/linked_views.py
@@ -4,11 +4,15 @@
 Linked Views in Subplots
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-This example demonstrates how to create linked views in PyVista subplots
-using :func:`~pyvista.Plotter.link_views`, where camera movements
-in one view are synchronized with other views. This is particularly useful when comparing
-different versions or representations of the same model.
+Create linked views in PyVista subplots using :func:`~pyvista.Plotter.link_views`.
 
+Camera movements in one view are synchronized with other views. This is
+particularly useful when comparing different versions or representations of
+the same model.
+
+Camera movements in one view are synchronized with other views. This is
+particularly useful when comparing different versions or representations of
+the same model.
 """
 
 import numpy as np

--- a/examples/02-plot/lookup_table.py
+++ b/examples/02-plot/lookup_table.py
@@ -3,7 +3,8 @@
 
 Lookup Tables
 ~~~~~~~~~~~~~
-Demonstrate the usage of a lookup table within PyVista
+
+Demonstrate the usage of a lookup table within PyVista.
 
 The :class:`pyvista.LookupTable` can be used to have fine-tuned control over
 the mapping between a :class:`pyvista.DataSet`'s scalars and RGBA colors.

--- a/examples/02-plot/lorenz_attractor.py
+++ b/examples/02-plot/lorenz_attractor.py
@@ -8,7 +8,6 @@ Integrate the Lorenz system and render the trajectory as a colored tube.
 
 Built from :func:`pyvista.lines_from_points`.
 
-Built from :func:`pyvista.lines_from_points`.
 """
 
 import numpy as np

--- a/examples/02-plot/lorenz_attractor.py
+++ b/examples/02-plot/lorenz_attractor.py
@@ -4,8 +4,11 @@
 Plot a Lorenz Attractor
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Integrate the Lorenz system and render the trajectory as a colored tube
-built from :func:`pyvista.lines_from_points`.
+Integrate the Lorenz system and render the trajectory as a colored tube.
+
+Built from :func:`pyvista.lines_from_points`.
+
+Built from :func:`pyvista.lines_from_points`.
 """
 
 import numpy as np

--- a/examples/02-plot/maximum_intensity_projection.py
+++ b/examples/02-plot/maximum_intensity_projection.py
@@ -4,10 +4,13 @@
 Maximum Intensity Projection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Maximum Intensity Projection (MIP) is a rendering technique for point
-clouds that reorders vertex depth so points with higher scalar values
-are always rendered in front, regardless of their actual distance from
-the camera.
+Maximum Intensity Projection (MIP) reorders point-cloud depth by scalar value.
+
+Points with higher scalar values are always rendered in front, regardless
+of their actual distance from the camera.
+
+Points with higher scalar values are always rendered in front, regardless
+of their actual distance from the camera.
 
 This is useful for dense point cloud visualization where high-value
 data points would otherwise be hidden behind lower-value points that

--- a/examples/02-plot/maximum_intensity_projection.py
+++ b/examples/02-plot/maximum_intensity_projection.py
@@ -9,9 +9,6 @@ Maximum Intensity Projection (MIP) reorders point-cloud depth by scalar value.
 Points with higher scalar values are always rendered in front, regardless
 of their actual distance from the camera.
 
-Points with higher scalar values are always rendered in front, regardless
-of their actual distance from the camera.
-
 This is useful for dense point cloud visualization where high-value
 data points would otherwise be hidden behind lower-value points that
 happen to be closer to the viewer. The technique was proposed by
@@ -22,6 +19,7 @@ MIP works by replacing the z-coordinate in OpenGL clip space with the
 negated, normalized scalar value via a custom vertex shader. This
 means that depth ordering is driven entirely by scalar magnitude
 rather than spatial position.
+
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/02-plot/mesh_picking.py
+++ b/examples/02-plot/mesh_picking.py
@@ -4,9 +4,7 @@
 Picking Meshes
 ~~~~~~~~~~~~~~
 
-This example demonstrates how to pick meshes using
-:func:`enable_mesh_picking() <pyvista.Plotter.enable_mesh_picking>`.
-
+Pick meshes using :func:`~pyvista.Plotter.enable_mesh_picking`.
 """
 
 import pyvista as pv

--- a/examples/02-plot/mesh_picking.py
+++ b/examples/02-plot/mesh_picking.py
@@ -5,6 +5,7 @@ Picking Meshes
 ~~~~~~~~~~~~~~
 
 Pick meshes using :func:`~pyvista.Plotter.enable_mesh_picking`.
+
 """
 
 import pyvista as pv

--- a/examples/02-plot/mesh_picking.py
+++ b/examples/02-plot/mesh_picking.py
@@ -3,6 +3,7 @@
 
 Picking Meshes
 ~~~~~~~~~~~~~~
+
 This example demonstrates how to pick meshes using
 :func:`enable_mesh_picking() <pyvista.Plotter.enable_mesh_picking>`.
 

--- a/examples/02-plot/movie.py
+++ b/examples/02-plot/movie.py
@@ -5,13 +5,13 @@ Create a MP4 Movie
 ~~~~~~~~~~~~~~~~~~
 
 Create an animated MP4 movie of a rendering scene.
+
 This example uses :meth:`~pyvista.Plotter.open_movie` and
 :meth:`~pyvista.Plotter.write_frame` to create the movie.
 
 .. Note::
     This movie will appear static since MP4 movies will not be
     rendered on a sphinx gallery example.
-
 """
 
 import numpy as np

--- a/examples/02-plot/movie.py
+++ b/examples/02-plot/movie.py
@@ -12,6 +12,7 @@ This example uses :meth:`~pyvista.Plotter.open_movie` and
 .. Note::
     This movie will appear static since MP4 movies will not be
     rendered on a sphinx gallery example.
+
 """
 
 import numpy as np

--- a/examples/02-plot/movie_glyphs.py
+++ b/examples/02-plot/movie_glyphs.py
@@ -9,8 +9,6 @@ Create an animated GIF by generating glyphs from a scalar field.
 Uses :func:`glyph() <pyvista.DataSetFilters.glyph>` with
 :func:`pyvista.Sphere`.
 
-Uses :func:`glyph() <pyvista.DataSetFilters.glyph>` with
-:func:`pyvista.Sphere`.
 """
 
 # sphinx_gallery_thumbnail_number = 1

--- a/examples/02-plot/movie_glyphs.py
+++ b/examples/02-plot/movie_glyphs.py
@@ -4,9 +4,13 @@
 Save a Movie Using Glyphs
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Create an animated GIF by generating glyphs using :func:`glyph()
-<pyvista.DataSetFilters.glyph>` using :func:`pyvista.Sphere`.
+Create an animated GIF by generating glyphs from a scalar field.
 
+Uses :func:`glyph() <pyvista.DataSetFilters.glyph>` with
+:func:`pyvista.Sphere`.
+
+Uses :func:`glyph() <pyvista.DataSetFilters.glyph>` with
+:func:`pyvista.Sphere`.
 """
 
 # sphinx_gallery_thumbnail_number = 1

--- a/examples/02-plot/moving_cmap.py
+++ b/examples/02-plot/moving_cmap.py
@@ -3,8 +3,9 @@
 
 Create a GIF Movie of a Static Object with a Moving Colormap
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Generate a gif movie of a Hopf torus with a moving colormap,
-by updating the scalars.
+
+Generate a gif movie of a Hopf torus with a moving colormap, by updating the scalars.
+
 This example uses :meth:`~pyvista.Plotter.open_gif` and
 :meth:`~pyvista.Plotter.write_frame` to create the gif.
 

--- a/examples/02-plot/moving_isovalue.py
+++ b/examples/02-plot/moving_isovalue.py
@@ -10,9 +10,6 @@ Uses :func:`~pyvista.examples.downloads.download_brain` and
 :meth:`~pyvista.Plotter.open_gif`/:meth:`~pyvista.Plotter.write_frame` to
 create the animation.
 
-Uses :func:`~pyvista.examples.downloads.download_brain` and
-:meth:`~pyvista.Plotter.open_gif`/:meth:`~pyvista.Plotter.write_frame` to
-create the animation.
 """
 
 import numpy as np

--- a/examples/02-plot/moving_isovalue.py
+++ b/examples/02-plot/moving_isovalue.py
@@ -4,11 +4,15 @@
 Moving Isovalue
 ~~~~~~~~~~~~~~~
 
-Make an animation of an isovalue through a volumetric dataset
-such as :func:`~pyvista.examples.downloads.download_brain`.
-This example uses :meth:`~pyvista.Plotter.open_gif` and
-:meth:`~pyvista.Plotter.write_frame` to create the animation.
+Animate an isovalue moving through a volumetric dataset.
 
+Uses :func:`~pyvista.examples.downloads.download_brain` and
+:meth:`~pyvista.Plotter.open_gif`/:meth:`~pyvista.Plotter.write_frame` to
+create the animation.
+
+Uses :func:`~pyvista.examples.downloads.download_brain` and
+:meth:`~pyvista.Plotter.open_gif`/:meth:`~pyvista.Plotter.write_frame` to
+create the animation.
 """
 
 import numpy as np

--- a/examples/02-plot/multi_window.py
+++ b/examples/02-plot/multi_window.py
@@ -4,8 +4,7 @@
 Multi-Window Plot
 ~~~~~~~~~~~~~~~~~
 
-
-Subplotting: having multiple scenes in a single window
+Subplotting: having multiple scenes in a single window.
 """
 
 import pyvista as pv

--- a/examples/02-plot/multi_window.py
+++ b/examples/02-plot/multi_window.py
@@ -5,6 +5,7 @@ Multi-Window Plot
 ~~~~~~~~~~~~~~~~~
 
 Subplotting: having multiple scenes in a single window.
+
 """
 
 import pyvista as pv

--- a/examples/02-plot/opacity.py
+++ b/examples/02-plot/opacity.py
@@ -8,7 +8,6 @@ Plot a mesh's scalar array with an opacity transfer function or mapping.
 
 Uses :class:`~pyvista.opacity_transfer_function`.
 
-Uses :class:`~pyvista.opacity_transfer_function`.
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/02-plot/opacity.py
+++ b/examples/02-plot/opacity.py
@@ -4,8 +4,11 @@
 Plot with Opacity
 ~~~~~~~~~~~~~~~~~
 
-Plot a mesh's scalar array with an :class:`~pyvista.opacity_transfer_function`
-or opacity mapping based on a scalar array.
+Plot a mesh's scalar array with an opacity transfer function or mapping.
+
+Uses :class:`~pyvista.opacity_transfer_function`.
+
+Uses :class:`~pyvista.opacity_transfer_function`.
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/02-plot/pbr.py
+++ b/examples/02-plot/pbr.py
@@ -4,9 +4,11 @@
 Physically Based Rendering
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-VTK 9 introduced Physically Based Rendering (PBR) and we have exposed
-that functionality in PyVista. Read the `blog about PBR
-<https://www.kitware.com/vtk-pbr/>`_ for more details.
+VTK 9 introduced Physically Based Rendering (PBR), exposed in PyVista.
+
+Read the `blog about PBR <https://www.kitware.com/vtk-pbr/>`_ for more details.
+
+Read the `blog about PBR <https://www.kitware.com/vtk-pbr/>`_ for more details.
 
 PBR is only supported for :class:`pyvista.PolyData` and can be
 triggered via the ``pbr`` keyword argument of ``add_mesh``. Also use
@@ -14,7 +16,6 @@ the ``metallic`` and ``roughness`` arguments for further control.
 
 Let's show off this functionality by rendering a high quality mesh of
 a statue as though it were metallic.
-
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/02-plot/pbr.py
+++ b/examples/02-plot/pbr.py
@@ -8,14 +8,13 @@ VTK 9 introduced Physically Based Rendering (PBR), exposed in PyVista.
 
 Read the `blog about PBR <https://www.kitware.com/vtk-pbr/>`_ for more details.
 
-Read the `blog about PBR <https://www.kitware.com/vtk-pbr/>`_ for more details.
-
 PBR is only supported for :class:`pyvista.PolyData` and can be
 triggered via the ``pbr`` keyword argument of ``add_mesh``. Also use
 the ``metallic`` and ``roughness`` arguments for further control.
 
 Let's show off this functionality by rendering a high quality mesh of
 a statue as though it were metallic.
+
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/02-plot/plot_over_circular_arc.py
+++ b/examples/02-plot/plot_over_circular_arc.py
@@ -4,9 +4,11 @@
 Plot Scalars Over a Circular Arc
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Interpolate the scalars of a dataset over a circular arc
-using :meth:`~pyvista.DataSetFilters.plot_over_circular_arc_normal`.
+Interpolate the scalars of a dataset over a circular arc.
 
+Uses :meth:`~pyvista.DataSetFilters.plot_over_circular_arc_normal`.
+
+Uses :meth:`~pyvista.DataSetFilters.plot_over_circular_arc_normal`.
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/02-plot/plot_over_circular_arc.py
+++ b/examples/02-plot/plot_over_circular_arc.py
@@ -8,7 +8,6 @@ Interpolate the scalars of a dataset over a circular arc.
 
 Uses :meth:`~pyvista.DataSetFilters.plot_over_circular_arc_normal`.
 
-Uses :meth:`~pyvista.DataSetFilters.plot_over_circular_arc_normal`.
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/02-plot/plot_over_line.py
+++ b/examples/02-plot/plot_over_line.py
@@ -4,8 +4,11 @@
 Plot Over Line
 ~~~~~~~~~~~~~~
 
-Plot the values of a dataset over a line through that dataset
-using the :meth:`~pyvista.DataSetFilters.plot_over_line` filter.
+Plot the values of a dataset over a line through that dataset.
+
+Uses the :meth:`~pyvista.DataSetFilters.plot_over_line` filter.
+
+Uses the :meth:`~pyvista.DataSetFilters.plot_over_line` filter.
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/02-plot/plot_over_line.py
+++ b/examples/02-plot/plot_over_line.py
@@ -8,7 +8,6 @@ Plot the values of a dataset over a line through that dataset.
 
 Uses the :meth:`~pyvista.DataSetFilters.plot_over_line` filter.
 
-Uses the :meth:`~pyvista.DataSetFilters.plot_over_line` filter.
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/02-plot/point_cell_scalars.py
+++ b/examples/02-plot/point_cell_scalars.py
@@ -5,6 +5,7 @@ Point Cell Scalars
 ~~~~~~~~~~~~~~~~~~
 
 This example demonstrates how to add point scalars for each individual cell to a dataset.
+
 """
 
 import numpy as np

--- a/examples/02-plot/point_cell_scalars.py
+++ b/examples/02-plot/point_cell_scalars.py
@@ -4,10 +4,7 @@
 Point Cell Scalars
 ~~~~~~~~~~~~~~~~~~
 
-This example demonstrates how to add point scalars for each individual cell to
-a dataset.
-
-
+This example demonstrates how to add point scalars for each individual cell to a dataset.
 """
 
 import numpy as np

--- a/examples/02-plot/point_cloud_neighbors.py
+++ b/examples/02-plot/point_cloud_neighbors.py
@@ -4,8 +4,7 @@
 Highlight Nearest Neighbors in a Point Cloud
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :func:`pyvista.DataSet.find_closest_point` to inspect local neighborhoods in
-a point cloud.
+Use :func:`~pyvista.DataSet.find_closest_point` to inspect point-cloud neighborhoods.
 """
 
 import numpy as np

--- a/examples/02-plot/point_cloud_neighbors.py
+++ b/examples/02-plot/point_cloud_neighbors.py
@@ -5,6 +5,7 @@ Highlight Nearest Neighbors in a Point Cloud
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use :func:`~pyvista.DataSet.find_closest_point` to inspect point-cloud neighborhoods.
+
 """
 
 import numpy as np

--- a/examples/02-plot/point_clouds.py
+++ b/examples/02-plot/point_clouds.py
@@ -5,6 +5,7 @@ Plotting Point Clouds
 ~~~~~~~~~~~~~~~~~~~~~
 
 Plot point clouds using PyVista's ``'points'`` and ``'points_gaussian'`` styles.
+
 """
 
 import numpy as np

--- a/examples/02-plot/point_clouds.py
+++ b/examples/02-plot/point_clouds.py
@@ -3,6 +3,7 @@
 
 Plotting Point Clouds
 ~~~~~~~~~~~~~~~~~~~~~
+
 This example shows you how to plot point clouds using PyVista using both the
 ``'points'`` and ``'points_gaussian'`` styles.
 

--- a/examples/02-plot/point_clouds.py
+++ b/examples/02-plot/point_clouds.py
@@ -4,9 +4,7 @@
 Plotting Point Clouds
 ~~~~~~~~~~~~~~~~~~~~~
 
-This example shows you how to plot point clouds using PyVista using both the
-``'points'`` and ``'points_gaussian'`` styles.
-
+Plot point clouds using PyVista's ``'points'`` and ``'points_gaussian'`` styles.
 """
 
 import numpy as np

--- a/examples/02-plot/point_labels.py
+++ b/examples/02-plot/point_labels.py
@@ -5,6 +5,7 @@ Label Points
 ~~~~~~~~~~~~
 
 Use string arrays in a point set to label points.
+
 """
 
 import numpy as np

--- a/examples/02-plot/point_labels.py
+++ b/examples/02-plot/point_labels.py
@@ -4,7 +4,7 @@
 Label Points
 ~~~~~~~~~~~~
 
-Use string arrays in a point set to label points
+Use string arrays in a point set to label points.
 """
 
 import numpy as np

--- a/examples/02-plot/point_picking.py
+++ b/examples/02-plot/point_picking.py
@@ -4,9 +4,7 @@
 Picking points on a mesh
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-This example demonstrates how to pick points on meshes using
-:func:`enable_point_picking() <pyvista.Plotter.enable_point_picking>`.
-
+Pick points on a mesh using :func:`~pyvista.Plotter.enable_point_picking`.
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/02-plot/point_picking.py
+++ b/examples/02-plot/point_picking.py
@@ -3,6 +3,7 @@
 
 Picking points on a mesh
 ~~~~~~~~~~~~~~~~~~~~~~~~
+
 This example demonstrates how to pick points on meshes using
 :func:`enable_point_picking() <pyvista.Plotter.enable_point_picking>`.
 

--- a/examples/02-plot/point_picking.py
+++ b/examples/02-plot/point_picking.py
@@ -5,6 +5,7 @@ Picking points on a mesh
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Pick points on a mesh using :func:`~pyvista.Plotter.enable_point_picking`.
+
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/02-plot/point_sprites.py
+++ b/examples/02-plot/point_sprites.py
@@ -4,9 +4,10 @@
 Point Sprite Shapes
 ~~~~~~~~~~~~~~~~~~~
 
-By default, VTK renders points as squares. PyVista provides several
-built-in point sprite shapes that replace the default square with a
-custom shape via a GLSL fragment shader.
+By default, VTK renders points as squares.
+
+PyVista provides several built-in point sprite shapes that replace the default square with
+a custom shape via a GLSL fragment shader.
 
 The ``point_shape`` parameter can be passed directly to
 :func:`pyvista.Plotter.add_mesh` or set globally via

--- a/examples/02-plot/point_sprites.py
+++ b/examples/02-plot/point_sprites.py
@@ -12,6 +12,7 @@ a custom shape via a GLSL fragment shader.
 The ``point_shape`` parameter can be passed directly to
 :func:`pyvista.Plotter.add_mesh` or set globally via
 :attr:`pyvista.global_theme.point_shape <pyvista.plotting.themes.Theme.point_shape>`.
+
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/02-plot/point_sprites.py
+++ b/examples/02-plot/point_sprites.py
@@ -6,8 +6,9 @@ Point Sprite Shapes
 
 By default, VTK renders points as squares.
 
-PyVista provides several built-in point sprite shapes that replace the default square with
-a custom shape via a GLSL fragment shader.
+PyVista provides several
+built-in point sprite shapes that replace the default square with a
+custom shape via a GLSL fragment shader.
 
 The ``point_shape`` parameter can be passed directly to
 :func:`pyvista.Plotter.add_mesh` or set globally via

--- a/examples/02-plot/points_gaussian_scale.py
+++ b/examples/02-plot/points_gaussian_scale.py
@@ -4,9 +4,11 @@
 Scaled Gaussian Points
 ----------------------
 
-This example demonstrates how to plot spheres using the ``'points_gaussian'``
-style with :func:`~pyvista.Plotter.add_mesh` and scale them by a dynamic radius.
+Plot spheres using the ``'points_gaussian'`` style, scaled by a dynamic radius.
 
+Uses :func:`~pyvista.Plotter.add_mesh`.
+
+Uses :func:`~pyvista.Plotter.add_mesh`.
 """
 
 import numpy as np

--- a/examples/02-plot/points_gaussian_scale.py
+++ b/examples/02-plot/points_gaussian_scale.py
@@ -8,7 +8,6 @@ Plot spheres using the ``'points_gaussian'`` style, scaled by a dynamic radius.
 
 Uses :func:`~pyvista.Plotter.add_mesh`.
 
-Uses :func:`~pyvista.Plotter.add_mesh`.
 """
 
 import numpy as np

--- a/examples/02-plot/points_gaussian_scale.py
+++ b/examples/02-plot/points_gaussian_scale.py
@@ -3,6 +3,7 @@
 
 Scaled Gaussian Points
 ----------------------
+
 This example demonstrates how to plot spheres using the ``'points_gaussian'``
 style with :func:`~pyvista.Plotter.add_mesh` and scale them by a dynamic radius.
 

--- a/examples/02-plot/scalar_bar.py
+++ b/examples/02-plot/scalar_bar.py
@@ -8,7 +8,6 @@ Walk through the different capabilities of scalar bars.
 
 Shows how a user can customize scalar bars.
 
-Shows how a user can customize scalar bars.
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/02-plot/scalar_bar.py
+++ b/examples/02-plot/scalar_bar.py
@@ -4,9 +4,11 @@
 Customize Scalar Bars
 ~~~~~~~~~~~~~~~~~~~~~
 
-Walk through of all the different capabilities of scalar bars and
-how a user can customize scalar bars.
+Walk through the different capabilities of scalar bars.
 
+Shows how a user can customize scalar bars.
+
+Shows how a user can customize scalar bars.
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/02-plot/screenshot.py
+++ b/examples/02-plot/screenshot.py
@@ -5,6 +5,7 @@ Saving Screenshots
 ~~~~~~~~~~~~~~~~~~
 
 Save a screenshot of a plot without creating an interactive window.
+
 """
 
 import matplotlib.pyplot as plt

--- a/examples/02-plot/screenshot.py
+++ b/examples/02-plot/screenshot.py
@@ -3,6 +3,8 @@
 
 Saving Screenshots
 ~~~~~~~~~~~~~~~~~~
+
+Save a screenshot of a plot without creating an interactive window.
 """
 
 import matplotlib.pyplot as plt

--- a/examples/02-plot/shading.py
+++ b/examples/02-plot/shading.py
@@ -5,6 +5,7 @@ Types of Shading
 ~~~~~~~~~~~~~~~~
 
 Comparison of default, flat shading vs. smooth shading.
+
 """
 
 # sphinx_gallery_thumbnail_number = 4

--- a/examples/02-plot/sharing_scalar_bars.py
+++ b/examples/02-plot/sharing_scalar_bars.py
@@ -8,7 +8,6 @@ Share scalar bars among plotted arrays, or use a unique bar for each.
 
 Uses :meth:`~pyvista.Plotter.subplot` and ``show``.
 
-Uses :meth:`~pyvista.Plotter.subplot` and ``show``.
 """
 
 # sphinx_gallery_thumbnail_number = 3

--- a/examples/02-plot/sharing_scalar_bars.py
+++ b/examples/02-plot/sharing_scalar_bars.py
@@ -4,9 +4,11 @@
 Sharing Scalar Bars
 ~~~~~~~~~~~~~~~~~~~~~
 
-Use :meth:`~pyvista.Plotter.subplot` and show to share scalar bars
-among plotted arrays or use a unique scalar bar for each plotted array.
+Share scalar bars among plotted arrays, or use a unique bar for each.
 
+Uses :meth:`~pyvista.Plotter.subplot` and ``show``.
+
+Uses :meth:`~pyvista.Plotter.subplot` and ``show``.
 """
 
 # sphinx_gallery_thumbnail_number = 3

--- a/examples/02-plot/show_edges.py
+++ b/examples/02-plot/show_edges.py
@@ -4,9 +4,11 @@
 Show Edges
 ~~~~~~~~~~
 
-Show the edges of all geometries within a mesh using the
-:attr:`~pyvista.Property.show_edges` property.
+Show the edges of all geometries within a mesh.
 
+Uses the :attr:`~pyvista.Property.show_edges` property.
+
+Uses the :attr:`~pyvista.Property.show_edges` property.
 """
 
 # %%

--- a/examples/02-plot/show_edges.py
+++ b/examples/02-plot/show_edges.py
@@ -8,7 +8,6 @@ Show the edges of all geometries within a mesh.
 
 Uses the :attr:`~pyvista.Property.show_edges` property.
 
-Uses the :attr:`~pyvista.Property.show_edges` property.
 """
 
 # %%

--- a/examples/02-plot/silhouette.py
+++ b/examples/02-plot/silhouette.py
@@ -8,6 +8,7 @@ Extract an outline (silhouette) of a polygonal mesh's edges.
 
 The silhouette may be created using the `silhouette` keyword with
 :meth:`~pyvista.Plotter.add_mesh`, or by using `~pyvista.Plotter.add_silhouette` directly.
+
 """
 
 import pyvista as pv

--- a/examples/02-plot/silhouette.py
+++ b/examples/02-plot/silhouette.py
@@ -4,12 +4,10 @@
 Silhouette Highlight
 ~~~~~~~~~~~~~~~~~~~~
 
-Extract a subset of the edges of a polygonal mesh to generate an outline
-(silhouette) of a mesh.
-The silhouette may be created using the `silhouette` keyword with
-:meth:`~pyvista.Plotter.add_mesh`, or by using
-`~pyvista.Plotter.add_silhouette` directly.
+Extract an outline (silhouette) of a polygonal mesh's edges.
 
+The silhouette may be created using the `silhouette` keyword with
+:meth:`~pyvista.Plotter.add_mesh`, or by using `~pyvista.Plotter.add_silhouette` directly.
 """
 
 import pyvista as pv

--- a/examples/02-plot/slice_orthogonal.py
+++ b/examples/02-plot/slice_orthogonal.py
@@ -8,6 +8,7 @@ View three orthogonal slices from a mesh.
 
 Use the :func:`pyvista.DataObjectFilters.slice_orthogonal` filter to create these
 slices simultaneously.
+
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/02-plot/spherical.py
+++ b/examples/02-plot/spherical.py
@@ -8,7 +8,6 @@ Generate and visualize meshes from longitude-latitude coordinate data.
 
 Uses :func:`~pyvista.grid_from_sph_coords`.
 
-Uses :func:`~pyvista.grid_from_sph_coords`.
 """
 
 import numpy as np

--- a/examples/02-plot/spherical.py
+++ b/examples/02-plot/spherical.py
@@ -4,8 +4,11 @@
 Plot data in spherical coordinates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Generate and visualize meshes from data in longitude-latitude coordinates
-using :func:`~pyvista.grid_from_sph_coords`.
+Generate and visualize meshes from longitude-latitude coordinate data.
+
+Uses :func:`~pyvista.grid_from_sph_coords`.
+
+Uses :func:`~pyvista.grid_from_sph_coords`.
 """
 
 import numpy as np

--- a/examples/02-plot/surface_point_picking.py
+++ b/examples/02-plot/surface_point_picking.py
@@ -7,6 +7,7 @@ Picking a Point on the Surface of a Mesh
 Pick meshes using :func:`~pyvista.Plotter.enable_surface_point_picking`.
 
 This allows you to pick points on the surface of a mesh.
+
 """
 
 import pyvista as pv

--- a/examples/02-plot/surface_point_picking.py
+++ b/examples/02-plot/surface_point_picking.py
@@ -3,6 +3,7 @@
 
 Picking a Point on the Surface of a Mesh
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 This example demonstrates how to pick meshes using
 :func:`enable_surface_point_picking() <pyvista.Plotter.enable_surface_point_picking>`.
 

--- a/examples/02-plot/surface_point_picking.py
+++ b/examples/02-plot/surface_point_picking.py
@@ -4,11 +4,9 @@
 Picking a Point on the Surface of a Mesh
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This example demonstrates how to pick meshes using
-:func:`enable_surface_point_picking() <pyvista.Plotter.enable_surface_point_picking>`.
+Pick meshes using :func:`~pyvista.Plotter.enable_surface_point_picking`.
 
 This allows you to pick points on the surface of a mesh.
-
 """
 
 import pyvista as pv

--- a/examples/02-plot/texture.py
+++ b/examples/02-plot/texture.py
@@ -5,6 +5,7 @@ Applying Textures
 ~~~~~~~~~~~~~~~~~
 
 Plot a mesh with an image projected onto it as a texture.
+
 """
 
 from matplotlib.pyplot import get_cmap

--- a/examples/02-plot/themes.py
+++ b/examples/02-plot/themes.py
@@ -4,10 +4,11 @@
 Control Global and Local Plotting Themes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-PyVista allows you to set global and local plotting themes to easily
-set default plotting parameters. This example shows how to use the
-:ref:`theme_api` and :func:`~pyvista.set_plot_theme` function.
+Set global and local plotting themes to easily set default plot parameters.
 
+Shows how to use the :ref:`theme_api` and :func:`~pyvista.set_plot_theme` function.
+
+Shows how to use the :ref:`theme_api` and :func:`~pyvista.set_plot_theme` function.
 """
 
 import pyvista as pv

--- a/examples/02-plot/themes.py
+++ b/examples/02-plot/themes.py
@@ -8,7 +8,6 @@ Set global and local plotting themes to easily set default plot parameters.
 
 Shows how to use the :ref:`theme_api` and :func:`~pyvista.set_plot_theme` function.
 
-Shows how to use the :ref:`theme_api` and :func:`~pyvista.set_plot_theme` function.
 """
 
 import pyvista as pv

--- a/examples/02-plot/topo_map.py
+++ b/examples/02-plot/topo_map.py
@@ -4,10 +4,11 @@
 Topographic Map
 ~~~~~~~~~~~~~~~
 
-This is very similar to the :ref:`texture_example` example except it is
-focused on plotting aerial imagery from a GeoTIFF on top of some topography
-mesh.
+Plot aerial imagery from a GeoTIFF on top of a topography mesh.
 
+Similar to the :ref:`texture_example` example.
+
+Similar to the :ref:`texture_example` example.
 """
 
 # sphinx_gallery_thumbnail_number = 4

--- a/examples/02-plot/topo_map.py
+++ b/examples/02-plot/topo_map.py
@@ -8,7 +8,6 @@ Plot aerial imagery from a GeoTIFF on top of a topography mesh.
 
 Similar to the :ref:`texture_example` example.
 
-Similar to the :ref:`texture_example` example.
 """
 
 # sphinx_gallery_thumbnail_number = 4

--- a/examples/02-plot/vector_component.py
+++ b/examples/02-plot/vector_component.py
@@ -8,6 +8,7 @@ Plot a single component of a vector as a scalar array.
 
 We can plot individual components of multi-component arrays with the
 ``component`` argument  of the :meth:`~pyvista.Plotter.add_mesh` method.
+
 """
 
 import pyvista as pv

--- a/examples/02-plot/vertices.py
+++ b/examples/02-plot/vertices.py
@@ -5,6 +5,7 @@ Visible Vertices
 ~~~~~~~~~~~~~~~~
 
 Display vertices on a mesh in the same fashion as edge visibility.
+
 """
 
 # sphinx_gallery_thumbnail_number = 3

--- a/examples/02-plot/volume_rendering.py
+++ b/examples/02-plot/volume_rendering.py
@@ -4,8 +4,7 @@
 Volume Rendering
 ~~~~~~~~~~~~~~~~
 
-Volume render uniform mesh types like :class:`pyvista.ImageData` or 3D
-NumPy arrays.
+Volume render uniform mesh types like :class:`pyvista.ImageData` or 3D NumPy arrays.
 
 This also explores how to extract a volume of interest (VOI) from a
 :class:`pyvista.ImageData` using the

--- a/examples/02-plot/volume_rendering.py
+++ b/examples/02-plot/volume_rendering.py
@@ -9,6 +9,7 @@ Volume render uniform mesh types like :class:`pyvista.ImageData` or 3D NumPy arr
 This also explores how to extract a volume of interest (VOI) from a
 :class:`pyvista.ImageData` using the
 :func:`pyvista.ImageDataFilters.extract_subset` filter.
+
 """
 
 # sphinx_gallery_thumbnail_number = 3

--- a/examples/03-widgets/animation.py
+++ b/examples/03-widgets/animation.py
@@ -11,6 +11,7 @@ scene.
 
 Inspired by `VTK Animation Examples
 <https://examples.vtk.org/site/Python/Utilities/Animation/>`_.
+
 """
 
 import pyvista as pv

--- a/examples/03-widgets/animation.py
+++ b/examples/03-widgets/animation.py
@@ -5,10 +5,12 @@ Animation
 ~~~~~~~~~
 
 This example demonstrates how to create a simple animation.
-A timer is used with :meth:`~pyvista.Plotter.add_timer_event`
-to move a sphere across a scene.
 
-Inspired by `VTK Animation Examples <https://examples.vtk.org/site/Python/Utilities/Animation/>`_.
+A timer is used with :meth:`~pyvista.Plotter.add_timer_event` to move a sphere across a
+scene.
+
+Inspired by `VTK Animation Examples
+<https://examples.vtk.org/site/Python/Utilities/Animation/>`_.
 """
 
 import pyvista as pv

--- a/examples/03-widgets/animation.py
+++ b/examples/03-widgets/animation.py
@@ -6,11 +6,10 @@ Animation
 
 This example demonstrates how to create a simple animation.
 
-A timer is used with :meth:`~pyvista.Plotter.add_timer_event` to move a sphere across a
-scene.
+A timer is used with :meth:`~pyvista.Plotter.add_timer_event`
+to move a sphere across a scene.
 
-Inspired by `VTK Animation Examples
-<https://examples.vtk.org/site/Python/Utilities/Animation/>`_.
+Inspired by `VTK Animation Examples <https://examples.vtk.org/site/Python/Utilities/Animation/>`_.
 
 """
 

--- a/examples/03-widgets/box_widget.py
+++ b/examples/03-widgets/box_widget.py
@@ -4,18 +4,24 @@
 Box Widget
 ~~~~~~~~~~
 
-The box widget can be enabled and disabled by the
-:func:`pyvista.Plotter.add_box_widget` and
-:func:`pyvista.Plotter.clear_box_widgets` methods respectively.
-When enabling the box widget, you must provide a custom callback function
-otherwise the box would appear and do nothing - the callback functions are
-what allow us to leverage the widget to perform a task like clipping/cropping.
+Enable and disable the box widget to clip or crop a mesh interactively.
+
+Uses :func:`pyvista.Plotter.add_box_widget` and
+:func:`pyvista.Plotter.clear_box_widgets`. When enabling the box widget,
+you must provide a custom callback function otherwise the box would appear
+and do nothing - the callback functions are what allow us to leverage the
+widget to perform a task like clipping/cropping.
+
+Uses :func:`pyvista.Plotter.add_box_widget` and
+:func:`pyvista.Plotter.clear_box_widgets`. When enabling the box widget,
+you must provide a custom callback function otherwise the box would appear
+and do nothing - the callback functions are what allow us to leverage the
+widget to perform a task like clipping/cropping.
 
 Considering that using a box to clip/crop a mesh is one of the most common use
 cases, we have included a helper method that will allow you to add a mesh to a
 scene with a box widget that controls its extent, the
 :func:`pyvista.Plotter.add_mesh_clip_box` method.
-
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/03-widgets/box_widget.py
+++ b/examples/03-widgets/box_widget.py
@@ -12,16 +12,11 @@ you must provide a custom callback function otherwise the box would appear
 and do nothing - the callback functions are what allow us to leverage the
 widget to perform a task like clipping/cropping.
 
-Uses :func:`pyvista.Plotter.add_box_widget` and
-:func:`pyvista.Plotter.clear_box_widgets`. When enabling the box widget,
-you must provide a custom callback function otherwise the box would appear
-and do nothing - the callback functions are what allow us to leverage the
-widget to perform a task like clipping/cropping.
-
 Considering that using a box to clip/crop a mesh is one of the most common use
 cases, we have included a helper method that will allow you to add a mesh to a
 scene with a box widget that controls its extent, the
 :func:`pyvista.Plotter.add_mesh_clip_box` method.
+
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/03-widgets/clip_volume_widget.py
+++ b/examples/03-widgets/clip_volume_widget.py
@@ -4,13 +4,19 @@
 Clip Volume Widget
 ------------------
 
+Clip a structured dataset with the volume clip plane widget.
+
 If you have a structured dataset like a :class:`pyvista.ImageData` or
 :class:`pyvista.RectilinearGrid`, you can clip it using the
-:func:`pyvista.Plotter.add_volume_clip_plane` widget to better see the internal
-structure of the dataset.
+:func:`pyvista.Plotter.add_volume_clip_plane` widget to better see the
+internal structure of the dataset.
+
+If you have a structured dataset like a :class:`pyvista.ImageData` or
+:class:`pyvista.RectilinearGrid`, you can clip it using the
+:func:`pyvista.Plotter.add_volume_clip_plane` widget to better see the
+internal structure of the dataset.
 
 .. image:: ../../images/gifs/volume-clip-plane-widget.gif
-
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/03-widgets/clip_volume_widget.py
+++ b/examples/03-widgets/clip_volume_widget.py
@@ -11,12 +11,8 @@ If you have a structured dataset like a :class:`pyvista.ImageData` or
 :func:`pyvista.Plotter.add_volume_clip_plane` widget to better see the
 internal structure of the dataset.
 
-If you have a structured dataset like a :class:`pyvista.ImageData` or
-:class:`pyvista.RectilinearGrid`, you can clip it using the
-:func:`pyvista.Plotter.add_volume_clip_plane` widget to better see the
-internal structure of the dataset.
-
 .. image:: ../../images/gifs/volume-clip-plane-widget.gif
+
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/03-widgets/clip_volume_widget.py
+++ b/examples/03-widgets/clip_volume_widget.py
@@ -3,6 +3,7 @@
 
 Clip Volume Widget
 ------------------
+
 If you have a structured dataset like a :class:`pyvista.ImageData` or
 :class:`pyvista.RectilinearGrid`, you can clip it using the
 :func:`pyvista.Plotter.add_volume_clip_plane` widget to better see the internal

--- a/examples/03-widgets/line_widget.py
+++ b/examples/03-widgets/line_widget.py
@@ -11,14 +11,10 @@ Uses :func:`pyvista.Plotter.add_line_widget` and
 have any helper methods to utilize this widget, so it is necessary to pass
 a custom callback method.
 
-Uses :func:`pyvista.Plotter.add_line_widget` and
-:func:`pyvista.Plotter.clear_line_widgets`. Unfortunately, PyVista does not
-have any helper methods to utilize this widget, so it is necessary to pass
-a custom callback method.
-
 One particularly fun example is to use the line widget to create a source for
 the :func:`pyvista.DataSetFilters.streamlines` filter. Again note the use of
 the ``name`` argument in ``add_mesh``.
+
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/03-widgets/line_widget.py
+++ b/examples/03-widgets/line_widget.py
@@ -4,11 +4,17 @@
 Line Widget
 ~~~~~~~~~~~
 
-The line widget can be enabled and disabled by the
-:func:`pyvista.Plotter.add_line_widget` and
-:func:`pyvista.Plotter.clear_line_widgets` methods respectively.
-Unfortunately, PyVista does not have any helper methods to utilize this
-widget, so it is necessary to pass a custom callback method.
+Enable and disable the line widget with a custom callback method.
+
+Uses :func:`pyvista.Plotter.add_line_widget` and
+:func:`pyvista.Plotter.clear_line_widgets`. Unfortunately, PyVista does not
+have any helper methods to utilize this widget, so it is necessary to pass
+a custom callback method.
+
+Uses :func:`pyvista.Plotter.add_line_widget` and
+:func:`pyvista.Plotter.clear_line_widgets`. Unfortunately, PyVista does not
+have any helper methods to utilize this widget, so it is necessary to pass
+a custom callback method.
 
 One particularly fun example is to use the line widget to create a source for
 the :func:`pyvista.DataSetFilters.streamlines` filter. Again note the use of

--- a/examples/03-widgets/multi_slider_widget.py
+++ b/examples/03-widgets/multi_slider_widget.py
@@ -4,13 +4,17 @@
 Multiple Slider Widgets
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :func:`~pyvista.Plotter.add_slider_widget` and a class-based callback
-to track multiple slider widgets for updating a single mesh.
+Track multiple slider widgets updating a single mesh.
+
+Uses :func:`~pyvista.Plotter.add_slider_widget` with a class-based
+callback.
+
+Uses :func:`~pyvista.Plotter.add_slider_widget` with a class-based
+callback.
 
 In this example we simply change a few parameters for the
 :func:`pyvista.Sphere` method, but this could easily be applied to any
 mesh-generating/altering code.
-
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/03-widgets/multi_slider_widget.py
+++ b/examples/03-widgets/multi_slider_widget.py
@@ -9,12 +9,10 @@ Track multiple slider widgets updating a single mesh.
 Uses :func:`~pyvista.Plotter.add_slider_widget` with a class-based
 callback.
 
-Uses :func:`~pyvista.Plotter.add_slider_widget` with a class-based
-callback.
-
 In this example we simply change a few parameters for the
 :func:`pyvista.Sphere` method, but this could easily be applied to any
 mesh-generating/altering code.
+
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/03-widgets/plane_widget.py
+++ b/examples/03-widgets/plane_widget.py
@@ -4,12 +4,19 @@
 Plane Widget
 ~~~~~~~~~~~~
 
-The plane widget can be enabled and disabled by the
-:func:`pyvista.Plotter.add_plane_widget` and
-:func:`pyvista.Plotter.clear_plane_widgets` methods respectively.
-As with all widgets, you must provide a custom callback method to utilize that
-plane. Considering that planes are most commonly used for clipping and slicing
-meshes, we have included two helper methods for doing those tasks.
+Enable and disable the plane widget to clip or slice a mesh.
+
+Uses :func:`pyvista.Plotter.add_plane_widget` and
+:func:`pyvista.Plotter.clear_plane_widgets`. As with all widgets, you must
+provide a custom callback method to utilize that plane. Considering that
+planes are most commonly used for clipping and slicing meshes, we have
+included two helper methods for doing those tasks.
+
+Uses :func:`pyvista.Plotter.add_plane_widget` and
+:func:`pyvista.Plotter.clear_plane_widgets`. As with all widgets, you must
+provide a custom callback method to utilize that plane. Considering that
+planes are most commonly used for clipping and slicing meshes, we have
+included two helper methods for doing those tasks.
 
 Let's use a plane to clip a mesh:
 """

--- a/examples/03-widgets/plane_widget.py
+++ b/examples/03-widgets/plane_widget.py
@@ -12,13 +12,8 @@ provide a custom callback method to utilize that plane. Considering that
 planes are most commonly used for clipping and slicing meshes, we have
 included two helper methods for doing those tasks.
 
-Uses :func:`pyvista.Plotter.add_plane_widget` and
-:func:`pyvista.Plotter.clear_plane_widgets`. As with all widgets, you must
-provide a custom callback method to utilize that plane. Considering that
-planes are most commonly used for clipping and slicing meshes, we have
-included two helper methods for doing those tasks.
-
 Let's use a plane to clip a mesh:
+
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/03-widgets/slider_bar_widget.py
+++ b/examples/03-widgets/slider_bar_widget.py
@@ -4,11 +4,17 @@
 Slider Bar Widget
 ~~~~~~~~~~~~~~~~~
 
-The slider widget can be enabled and disabled by the
-:func:`pyvista.Plotter.add_slider_widget` and
-:func:`pyvista.Plotter.clear_slider_widgets` methods respectively.
-This is one of the most versatile widgets as it can control a value that can
-be used for just about anything.
+Enable and disable the slider widget to control an arbitrary value.
+
+Uses :func:`pyvista.Plotter.add_slider_widget` and
+:func:`pyvista.Plotter.clear_slider_widgets`. This is one of the most
+versatile widgets as it can control a value that can be used for just
+about anything.
+
+Uses :func:`pyvista.Plotter.add_slider_widget` and
+:func:`pyvista.Plotter.clear_slider_widgets`. This is one of the most
+versatile widgets as it can control a value that can be used for just
+about anything.
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/03-widgets/slider_bar_widget.py
+++ b/examples/03-widgets/slider_bar_widget.py
@@ -11,10 +11,6 @@ Uses :func:`pyvista.Plotter.add_slider_widget` and
 versatile widgets as it can control a value that can be used for just
 about anything.
 
-Uses :func:`pyvista.Plotter.add_slider_widget` and
-:func:`pyvista.Plotter.clear_slider_widgets`. This is one of the most
-versatile widgets as it can control a value that can be used for just
-about anything.
 """
 
 # sphinx_gallery_start_ignore

--- a/examples/03-widgets/sphere_widget.py
+++ b/examples/03-widgets/sphere_widget.py
@@ -11,16 +11,12 @@ Uses :func:`pyvista.Plotter.add_sphere_widget` and
 widget as it can control vertex location that can be used to control or
 update the location of just about anything.
 
-Uses :func:`pyvista.Plotter.add_sphere_widget` and
-:func:`pyvista.Plotter.clear_sphere_widgets`. This is a very versatile
-widget as it can control vertex location that can be used to control or
-update the location of just about anything.
-
 We don't have any convenient helper methods that utilize this widget out of
 the box, but we have added a lot of ways to use this widget so that you can
 easily add several widgets to a scene.
 
 Let's look at a few use cases that all update a surface mesh.
+
 """
 
 # sphinx_gallery_thumbnail_number = 3

--- a/examples/03-widgets/sphere_widget.py
+++ b/examples/03-widgets/sphere_widget.py
@@ -4,11 +4,17 @@
 Sphere Widget
 ~~~~~~~~~~~~~
 
-The sphere widget can be enabled and disabled by the
-:func:`pyvista.Plotter.add_sphere_widget` and
-:func:`pyvista.Plotter.clear_sphere_widgets` methods respectively.
-This is a very versatile widget as it can control vertex location that can
-be used to control or update the location of just about anything.
+Enable and disable the sphere widget to control a vertex location.
+
+Uses :func:`pyvista.Plotter.add_sphere_widget` and
+:func:`pyvista.Plotter.clear_sphere_widgets`. This is a very versatile
+widget as it can control vertex location that can be used to control or
+update the location of just about anything.
+
+Uses :func:`pyvista.Plotter.add_sphere_widget` and
+:func:`pyvista.Plotter.clear_sphere_widgets`. This is a very versatile
+widget as it can control vertex location that can be used to control or
+update the location of just about anything.
 
 We don't have any convenient helper methods that utilize this widget out of
 the box, but we have added a lot of ways to use this widget so that you can

--- a/examples/03-widgets/spline_widget.py
+++ b/examples/03-widgets/spline_widget.py
@@ -11,15 +11,11 @@ Uses :func:`pyvista.Plotter.add_spline_widget` and
 interactively create a poly line (spline) through a scene and use that
 spline.
 
-Uses :func:`pyvista.Plotter.add_spline_widget` and
-:func:`pyvista.Plotter.clear_spline_widgets`. This widget allows users to
-interactively create a poly line (spline) through a scene and use that
-spline.
-
 A common task with splines is to slice a volumetric dataset using an irregular
 path. To do this, we have added a convenient helper method which leverages the
 :func:`pyvista.DataObjectFilters.slice_along_line` filter named
 :func:`pyvista.Plotter.add_mesh_slice_spline`.
+
 """
 
 import numpy as np

--- a/examples/03-widgets/spline_widget.py
+++ b/examples/03-widgets/spline_widget.py
@@ -4,12 +4,17 @@
 Spline Widget
 ~~~~~~~~~~~~~
 
+Enable and disable the spline widget to interactively create a poly line.
 
-A spline widget can be enabled and disabled by the
-:func:`pyvista.Plotter.add_spline_widget` and
-:func:`pyvista.Plotter.clear_spline_widgets` methods respectively.
-This widget allows users to interactively create a poly line (spline) through
-a scene and use that spline.
+Uses :func:`pyvista.Plotter.add_spline_widget` and
+:func:`pyvista.Plotter.clear_spline_widgets`. This widget allows users to
+interactively create a poly line (spline) through a scene and use that
+spline.
+
+Uses :func:`pyvista.Plotter.add_spline_widget` and
+:func:`pyvista.Plotter.clear_spline_widgets`. This widget allows users to
+interactively create a poly line (spline) through a scene and use that
+spline.
 
 A common task with splines is to slice a volumetric dataset using an irregular
 path. To do this, we have added a convenient helper method which leverages the

--- a/examples/04-lights/attenuation.py
+++ b/examples/04-lights/attenuation.py
@@ -23,6 +23,7 @@ quadratic attenuation produces a beam that is shorter in range than that produce
 by linear attenuation.
 
 Three spotlights with three different attenuation profiles each:
+
 """
 
 # sphinx_gallery_thumbnail_number = 3

--- a/examples/04-lights/beam_shape.py
+++ b/examples/04-lights/beam_shape.py
@@ -11,12 +11,8 @@ which the only geometric customization option is the choice of beam
 direction defined by the light's position and focal point. Positional
 lights, however, have more options for beam customization.
 
-The default directional lights are infinitely distant point sources, for
-which the only geometric customization option is the choice of beam
-direction defined by the light's position and focal point. Positional
-lights, however, have more options for beam customization.
-
 Consider two hemispheres:
+
 """
 
 # sphinx_gallery_thumbnail_number = 5

--- a/examples/04-lights/beam_shape.py
+++ b/examples/04-lights/beam_shape.py
@@ -4,10 +4,17 @@
 Beam Shape
 ~~~~~~~~~~
 
-The default directional lights are infinitely distant point sources, for which
-the only geometric customization option is the choice of beam direction defined
-by the light's position and focal point. Positional lights, however, have more
-options for beam customization.
+Compare beam customization options for directional and positional lights.
+
+The default directional lights are infinitely distant point sources, for
+which the only geometric customization option is the choice of beam
+direction defined by the light's position and focal point. Positional
+lights, however, have more options for beam customization.
+
+The default directional lights are infinitely distant point sources, for
+which the only geometric customization option is the choice of beam
+direction defined by the light's position and focal point. Positional
+lights, however, have more options for beam customization.
 
 Consider two hemispheres:
 """

--- a/examples/04-lights/light_actors.py
+++ b/examples/04-lights/light_actors.py
@@ -4,10 +4,15 @@
 Light Actors
 ~~~~~~~~~~~~
 
-Positional lights in PyVista have customizable beam shapes, see the
-:ref:`beam_shape_example` example. Spotlights are special in
-the sense that they are unidirectional lights with a finite position,
-so they can be visualized using a cone.
+Visualize the customizable beam shapes of positional lights.
+
+See the :ref:`beam_shape_example` example. Spotlights are special in the
+sense that they are unidirectional lights with a finite position, so they
+can be visualized using a cone.
+
+See the :ref:`beam_shape_example` example. Spotlights are special in the
+sense that they are unidirectional lights with a finite position, so they
+can be visualized using a cone.
 
 This is exactly the purpose of a :vtk:`vtkLightActor`, the
 functionality of which can be enabled for spotlights:

--- a/examples/04-lights/light_actors.py
+++ b/examples/04-lights/light_actors.py
@@ -10,12 +10,9 @@ See the :ref:`beam_shape_example` example. Spotlights are special in the
 sense that they are unidirectional lights with a finite position, so they
 can be visualized using a cone.
 
-See the :ref:`beam_shape_example` example. Spotlights are special in the
-sense that they are unidirectional lights with a finite position, so they
-can be visualized using a cone.
-
 This is exactly the purpose of a :vtk:`vtkLightActor`, the
 functionality of which can be enabled for spotlights:
+
 """
 
 # sphinx_gallery_thumbnail_number = 1

--- a/examples/04-lights/light_types.py
+++ b/examples/04-lights/light_types.py
@@ -4,6 +4,8 @@
 Light Types
 ~~~~~~~~~~~
 
+Demonstrate PyVista's three types of lights.
+
 Lights come in three types:
 
   * headlights, the axis of which always coincides with the view of the camera,

--- a/examples/04-lights/plotter_lighting.py
+++ b/examples/04-lights/plotter_lighting.py
@@ -4,6 +4,8 @@
 Plotter Lighting Systems
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
+Compare the :class:`pyvista.Plotter` class's three default lighting systems.
+
 The :class:`pyvista.Plotter` class comes with three options for the default
 lighting system:
 

--- a/examples/04-lights/plotter_lighting.py
+++ b/examples/04-lights/plotter_lighting.py
@@ -23,6 +23,7 @@ Light kit
 The default ``lighting='light kit'`` option recreates a lighting setup that
 corresponds to a :vtk:`vtkLightKit`. We can check what type of lights this
 lighting comprises:
+
 """
 
 # sphinx_gallery_thumbnail_number = 3

--- a/examples/04-lights/shadows.py
+++ b/examples/04-lights/shadows.py
@@ -4,8 +4,11 @@
 Shadows
 ~~~~~~~
 
-Demonstrate the usage of lights and shadows in PyVista with :class:`~pyvista.Light`
-objects and the :meth:`~pyvista.Plotter.enable_shadows` plotting method.
+Demonstrate the usage of lights and shadows in PyVista.
+
+Uses :class:`~pyvista.Light` objects and :meth:`~pyvista.Plotter.enable_shadows`.
+
+Uses :class:`~pyvista.Light` objects and :meth:`~pyvista.Plotter.enable_shadows`.
 """
 
 import numpy as np

--- a/examples/04-lights/shadows.py
+++ b/examples/04-lights/shadows.py
@@ -8,7 +8,6 @@ Demonstrate the usage of lights and shadows in PyVista.
 
 Uses :class:`~pyvista.Light` objects and :meth:`~pyvista.Plotter.enable_shadows`.
 
-Uses :class:`~pyvista.Light` objects and :meth:`~pyvista.Plotter.enable_shadows`.
 """
 
 import numpy as np

--- a/examples/98-common/dataframe_export.py
+++ b/examples/98-common/dataframe_export.py
@@ -12,15 +12,10 @@ Uses :attr:`point_data <pyvista.DataSet.point_data>` or
 analytics, export, or interactive exploration in IDEs like Positron's
 Data Explorer, JupyterLab, or VS Code's data viewer.
 
-Uses :attr:`point_data <pyvista.DataSet.point_data>` or
-:attr:`cell_data <pyvista.DataSet.cell_data>` and converts to a
-:class:`pandas.DataFrame` or :class:`pyarrow.Table` for downstream
-analytics, export, or interactive exploration in IDEs like Positron's
-Data Explorer, JupyterLab, or VS Code's data viewer.
-
 This example uses a classic CFD-style workflow: a scalar field and a vector
 field attached to a mesh, then filtered / aggregated / exported using
 pandas idioms.
+
 """
 
 import numpy as np

--- a/examples/98-common/dataframe_export.py
+++ b/examples/98-common/dataframe_export.py
@@ -4,16 +4,23 @@
 Export Mesh Data to a DataFrame
 -------------------------------
 
-Convert a mesh's :attr:`point_data <pyvista.DataSet.point_data>` or
-:attr:`cell_data <pyvista.DataSet.cell_data>` to a :class:`pandas.DataFrame`
-or :class:`pyarrow.Table` for downstream analytics, export, or interactive
-exploration in IDEs like Positron's Data Explorer, JupyterLab, or VS Code's
-data viewer.
+Convert a mesh's point or cell data to a pandas or PyArrow table.
+
+Uses :attr:`point_data <pyvista.DataSet.point_data>` or
+:attr:`cell_data <pyvista.DataSet.cell_data>` and converts to a
+:class:`pandas.DataFrame` or :class:`pyarrow.Table` for downstream
+analytics, export, or interactive exploration in IDEs like Positron's
+Data Explorer, JupyterLab, or VS Code's data viewer.
+
+Uses :attr:`point_data <pyvista.DataSet.point_data>` or
+:attr:`cell_data <pyvista.DataSet.cell_data>` and converts to a
+:class:`pandas.DataFrame` or :class:`pyarrow.Table` for downstream
+analytics, export, or interactive exploration in IDEs like Positron's
+Data Explorer, JupyterLab, or VS Code's data viewer.
 
 This example uses a classic CFD-style workflow: a scalar field and a vector
 field attached to a mesh, then filtered / aggregated / exported using
 pandas idioms.
-
 """
 
 import numpy as np

--- a/examples/98-common/project_points_tessellate.py
+++ b/examples/98-common/project_points_tessellate.py
@@ -4,13 +4,11 @@
 Project points to a plane and Tessellate
 ----------------------------------------
 
-Using pyvista and numpy, generate a 3D point cloud, project it to a plane, and
-tessellate it.
+Generate a 3D point cloud, project it to a plane, and tessellate it.
 
 This demonstrates how to use
 :class:`pyvista.UnstructuredGridFilters.delaunay_2d` and a simple numpy
 function that projects points to a plane.
-
 """
 
 import numpy as np

--- a/examples/98-common/project_points_tessellate.py
+++ b/examples/98-common/project_points_tessellate.py
@@ -9,6 +9,7 @@ Generate a 3D point cloud, project it to a plane, and tessellate it.
 This demonstrates how to use
 :class:`pyvista.UnstructuredGridFilters.delaunay_2d` and a simple numpy
 function that projects points to a plane.
+
 """
 
 import numpy as np

--- a/examples/99-advanced/add_example.py
+++ b/examples/99-advanced/add_example.py
@@ -9,9 +9,6 @@ Add a new PyVista Sphinx Gallery example using this file as a template.
 See `Sphinx Gallery <https://sphinx-gallery.github.io/>`_ for background
 on the format.
 
-See `Sphinx Gallery <https://sphinx-gallery.github.io/>`_ for background
-on the format.
-
 Each example should have a reference anchor in the form:
 
 ``.. _<example_name>_example:``
@@ -71,6 +68,7 @@ typically set up your imports.
         # \sphinx_gallery_end_ignore (remove the \)
         ...
         pl.show()  # this will be static plot
+
 """
 
 

--- a/examples/99-advanced/add_example.py
+++ b/examples/99-advanced/add_example.py
@@ -4,9 +4,13 @@ r"""
 Adding a New Gallery Example
 ----------------------------
 
-This example demonstrates how to add a new PyVista `Sphinx Gallery
-<https://sphinx-gallery.github.io/>`_ example as well as being a template that
-can be used in their creation.
+Add a new PyVista Sphinx Gallery example using this file as a template.
+
+See `Sphinx Gallery <https://sphinx-gallery.github.io/>`_ for background
+on the format.
+
+See `Sphinx Gallery <https://sphinx-gallery.github.io/>`_ for background
+on the format.
 
 Each example should have a reference anchor in the form:
 
@@ -67,7 +71,6 @@ typically set up your imports.
         # \sphinx_gallery_end_ignore (remove the \)
         ...
         pl.show()  # this will be static plot
-
 """
 
 

--- a/examples/99-advanced/add_example.py
+++ b/examples/99-advanced/add_example.py
@@ -3,6 +3,7 @@ r"""
 
 Adding a New Gallery Example
 ----------------------------
+
 This example demonstrates how to add a new PyVista `Sphinx Gallery
 <https://sphinx-gallery.github.io/>`_ example as well as being a template that
 can be used in their creation.

--- a/examples/99-advanced/anatomical_groups.py
+++ b/examples/99-advanced/anatomical_groups.py
@@ -3,6 +3,7 @@
 
 Visualize Anatomical Groups
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 This example visualizes different anatomical groups using the segmentation
 labels available from the downloadable datasets
 :func:`~pyvista.examples.downloads.download_whole_body_ct_female` and

--- a/examples/99-advanced/anatomical_groups.py
+++ b/examples/99-advanced/anatomical_groups.py
@@ -10,14 +10,11 @@ Uses the downloadable datasets
 :func:`~pyvista.examples.downloads.download_whole_body_ct_female` and
 :func:`~pyvista.examples.downloads.download_whole_body_ct_male`.
 
-Uses the downloadable datasets
-:func:`~pyvista.examples.downloads.download_whole_body_ct_female` and
-:func:`~pyvista.examples.downloads.download_whole_body_ct_male`.
-
 These datasets include labels for 117 anatomical structures. In this example,
 the labels are grouped by filtering the list of labels and coloring the
 labels with the recommended RGB values used by the 3DSlicer
 `TotalSegmentator Extension <https://github.com/lassoan/SlicerTotalSegmentator>`_.
+
 """
 
 import pyvista as pv

--- a/examples/99-advanced/anatomical_groups.py
+++ b/examples/99-advanced/anatomical_groups.py
@@ -4,8 +4,13 @@
 Visualize Anatomical Groups
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This example visualizes different anatomical groups using the segmentation
-labels available from the downloadable datasets
+Visualize anatomical groups from whole-body CT segmentation labels.
+
+Uses the downloadable datasets
+:func:`~pyvista.examples.downloads.download_whole_body_ct_female` and
+:func:`~pyvista.examples.downloads.download_whole_body_ct_male`.
+
+Uses the downloadable datasets
 :func:`~pyvista.examples.downloads.download_whole_body_ct_female` and
 :func:`~pyvista.examples.downloads.download_whole_body_ct_male`.
 

--- a/examples/99-advanced/antarctica.py
+++ b/examples/99-advanced/antarctica.py
@@ -4,16 +4,20 @@
 Compare Field Across Mesh Regions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Here is some velocity data from a glacier modelling simulation that is compared
-across nodes in the simulation. We have simplified the mesh to have the
-simulation node value already on the mesh.
+Plot glacier velocity data from a modelling simulation.
 
-This was originally posted to `pyvista/pyvista-support#83 <https://github.com/pyvista/pyvista-support/issues/83>`_.
+This is compared across nodes in the simulation. We have simplified the
+mesh to have the simulation node value already on the mesh.
+
+This is compared across nodes in the simulation. We have simplified the
+mesh to have the simulation node value already on the mesh.
+
+This was originally posted to `pyvista/pyvista-support#83
+<https://github.com/pyvista/pyvista-support/issues/83>`_.
 
 The modeling results are courtesy of `Urruty Benoit <https://github.com/BenoitURRUTY>`_
 and  are from the `Elmer/Ice <https://elmerice.elmerfem.org>`_ simulation
 software.
-
 """
 
 import numpy as np

--- a/examples/99-advanced/antarctica.py
+++ b/examples/99-advanced/antarctica.py
@@ -9,15 +9,13 @@ Plot glacier velocity data from a modelling simulation.
 This is compared across nodes in the simulation. We have simplified the
 mesh to have the simulation node value already on the mesh.
 
-This is compared across nodes in the simulation. We have simplified the
-mesh to have the simulation node value already on the mesh.
-
 This was originally posted to `pyvista/pyvista-support#83
 <https://github.com/pyvista/pyvista-support/issues/83>`_.
 
 The modeling results are courtesy of `Urruty Benoit <https://github.com/BenoitURRUTY>`_
 and  are from the `Elmer/Ice <https://elmerice.elmerfem.org>`_ simulation
 software.
+
 """
 
 import numpy as np

--- a/examples/99-advanced/atomic_orbitals.py
+++ b/examples/99-advanced/atomic_orbitals.py
@@ -3,6 +3,7 @@
 
 Plot Atomic Orbitals
 --------------------
+
 Visualize the wave functions (orbitals) of the hydrogen atom.
 
 """

--- a/examples/99-advanced/customize_trame_toolbar.py
+++ b/examples/99-advanced/customize_trame_toolbar.py
@@ -8,6 +8,7 @@ Bring more of the power of trame to the jupyter view.
 
 This example shows how to add custom tools using the `jupyter_kwargs` option with
 :meth:`~pyvista.Plotter.show`.
+
 """
 
 import asyncio

--- a/examples/99-advanced/customize_trame_toolbar.py
+++ b/examples/99-advanced/customize_trame_toolbar.py
@@ -5,8 +5,9 @@ Customize Trame toolbar
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Bring more of the power of trame to the jupyter view.
-This example shows how to add custom tools using the
-`jupyter_kwargs` option with :meth:`~pyvista.Plotter.show`.
+
+This example shows how to add custom tools using the `jupyter_kwargs` option with
+:meth:`~pyvista.Plotter.show`.
 """
 
 import asyncio

--- a/examples/99-advanced/customize_trame_toolbar.py
+++ b/examples/99-advanced/customize_trame_toolbar.py
@@ -6,8 +6,8 @@ Customize Trame toolbar
 
 Bring more of the power of trame to the jupyter view.
 
-This example shows how to add custom tools using the `jupyter_kwargs` option with
-:meth:`~pyvista.Plotter.show`.
+This example shows how to add custom tools using the
+`jupyter_kwargs` option with :meth:`~pyvista.Plotter.show`.
 
 """
 

--- a/examples/99-advanced/extending_pyvista.py
+++ b/examples/99-advanced/extending_pyvista.py
@@ -6,8 +6,8 @@ Extending PyVista
 
 A :class:`pyvista.DataSet`, such as :class:`pyvista.PolyData`, can be extended by users.
 
-For example, if the user wants to keep track of the location of the maximum point in the
-(1, 0, 1) direction on the mesh.
+For example, if the user wants to keep track of the location of the
+maximum point in the (1, 0, 1) direction on the mesh.
 
 There are two methods by which users can handle subclassing.  One is directly managing
 the types objects.  This may require checking types during filter

--- a/examples/99-advanced/extending_pyvista.py
+++ b/examples/99-advanced/extending_pyvista.py
@@ -20,6 +20,7 @@ classes are nearly always used for particular types of DataSets.
     This is for advanced usage only.  Automatic managing of types
     will not work in all situations, in particular when a builtin dataset is directly
     instantiated.  See examples below.
+
 """
 
 import numpy as np

--- a/examples/99-advanced/extending_pyvista.py
+++ b/examples/99-advanced/extending_pyvista.py
@@ -4,9 +4,10 @@
 Extending PyVista
 ~~~~~~~~~~~~~~~~~
 
-A :class:`pyvista.DataSet`, such as :class:`pyvista.PolyData`, can be extended
-by users.  For example, if the user wants to keep track of the location of the
-maximum point in the (1, 0, 1) direction on the mesh.
+A :class:`pyvista.DataSet`, such as :class:`pyvista.PolyData`, can be extended by users.
+
+For example, if the user wants to keep track of the location of the maximum point in the
+(1, 0, 1) direction on the mesh.
 
 There are two methods by which users can handle subclassing.  One is directly managing
 the types objects.  This may require checking types during filter
@@ -19,7 +20,6 @@ classes are nearly always used for particular types of DataSets.
     This is for advanced usage only.  Automatic managing of types
     will not work in all situations, in particular when a builtin dataset is directly
     instantiated.  See examples below.
-
 """
 
 import numpy as np

--- a/examples/99-advanced/fea_hertzian_contact_pressure.py
+++ b/examples/99-advanced/fea_hertzian_contact_pressure.py
@@ -3,6 +3,7 @@
 
 Visualize Hertzian Contact Stress
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 The following example demonstrates how to use PyVista to visualize
 Hertzian contact stress between a cylinder and a flat plate.
 

--- a/examples/99-advanced/fea_hertzian_contact_pressure.py
+++ b/examples/99-advanced/fea_hertzian_contact_pressure.py
@@ -17,6 +17,7 @@ Hertz, a German physicist who first described the phenomenon in the late
 1800s. Hertzian contact stress is an important concept in materials science,
 engineering, and other fields where the behavior of materials under stress is a
 critical consideration.
+
 """
 
 import matplotlib.pyplot as plt

--- a/examples/99-advanced/fea_hertzian_contact_pressure.py
+++ b/examples/99-advanced/fea_hertzian_contact_pressure.py
@@ -4,8 +4,7 @@
 Visualize Hertzian Contact Stress
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following example demonstrates how to use PyVista to visualize
-Hertzian contact stress between a cylinder and a flat plate.
+Visualize Hertzian contact stress between a cylinder and a flat plate.
 
 This example loads a dataset, constructs a line to represent the point of
 contact between the cylinder and the block, and samples the stress along that
@@ -18,7 +17,6 @@ Hertz, a German physicist who first described the phenomenon in the late
 1800s. Hertzian contact stress is an important concept in materials science,
 engineering, and other fields where the behavior of materials under stress is a
 critical consideration.
-
 """
 
 import matplotlib.pyplot as plt

--- a/examples/99-advanced/gyroid.py
+++ b/examples/99-advanced/gyroid.py
@@ -9,8 +9,6 @@ Contour an implicit gyroid field into a periodic surface.
 Uses a field stored on :class:`pyvista.ImageData` with
 :func:`pyvista.DataSetFilters.contour`.
 
-Uses a field stored on :class:`pyvista.ImageData` with
-:func:`pyvista.DataSetFilters.contour`.
 """
 
 import numpy as np

--- a/examples/99-advanced/gyroid.py
+++ b/examples/99-advanced/gyroid.py
@@ -4,8 +4,13 @@
 Plot a Gyroid Surface
 ---------------------
 
-Contour an implicit gyroid field stored on :class:`pyvista.ImageData` into a
-periodic surface with :func:`pyvista.DataSetFilters.contour`.
+Contour an implicit gyroid field into a periodic surface.
+
+Uses a field stored on :class:`pyvista.ImageData` with
+:func:`pyvista.DataSetFilters.contour`.
+
+Uses a field stored on :class:`pyvista.ImageData` with
+:func:`pyvista.DataSetFilters.contour`.
 """
 
 import numpy as np

--- a/examples/99-advanced/magnetic_fields.py
+++ b/examples/99-advanced/magnetic_fields.py
@@ -14,6 +14,7 @@ This dataset was created from the `Coil Field Lines
 <https://magpylib.readthedocs.io/en/stable/_pages/user_guide/examples/examples_app_coils.html>`_
 example from the awesome `magpylib <https://github.com/magpylib/magpylib>`_
 library.
+
 """
 
 # sphinx_gallery_thumbnail_number = 3

--- a/examples/99-advanced/magnetic_fields.py
+++ b/examples/99-advanced/magnetic_fields.py
@@ -4,8 +4,7 @@
 Plot a Magnetic Field
 ---------------------
 
-The following example demonstrates how PyVista can be used to plot a magnetic
-field.
+The following example demonstrates how PyVista can be used to plot a magnetic field.
 
 This example relies on :func:`~pyvista.DataSetFilters.streamlines_from_source` to
 generate streamlines and :func:`add_volume() <pyvista.Plotter.add_volume>` to plot
@@ -15,7 +14,6 @@ This dataset was created from the `Coil Field Lines
 <https://magpylib.readthedocs.io/en/stable/_pages/user_guide/examples/examples_app_coils.html>`_
 example from the awesome `magpylib <https://github.com/magpylib/magpylib>`_
 library.
-
 """
 
 # sphinx_gallery_thumbnail_number = 3

--- a/examples/99-advanced/mesh_validation.py
+++ b/examples/99-advanced/mesh_validation.py
@@ -3,6 +3,7 @@
 
 Mesh Validation
 ~~~~~~~~~~~~~~~
+
 This example explores different cases where a mesh may not be considered valid as defined
 by the :meth:`~pyvista.DataObjectFilters.validate_mesh` method.
 

--- a/examples/99-advanced/mesh_validation.py
+++ b/examples/99-advanced/mesh_validation.py
@@ -8,7 +8,6 @@ Explore different cases where a mesh may not be considered valid.
 
 As defined by the :meth:`~pyvista.DataObjectFilters.validate_mesh` method.
 
-As defined by the :meth:`~pyvista.DataObjectFilters.validate_mesh` method.
 """
 
 # sphinx_gallery_thumbnail_number = 5

--- a/examples/99-advanced/mesh_validation.py
+++ b/examples/99-advanced/mesh_validation.py
@@ -4,9 +4,11 @@
 Mesh Validation
 ~~~~~~~~~~~~~~~
 
-This example explores different cases where a mesh may not be considered valid as defined
-by the :meth:`~pyvista.DataObjectFilters.validate_mesh` method.
+Explore different cases where a mesh may not be considered valid.
 
+As defined by the :meth:`~pyvista.DataObjectFilters.validate_mesh` method.
+
+As defined by the :meth:`~pyvista.DataObjectFilters.validate_mesh` method.
 """
 
 # sphinx_gallery_thumbnail_number = 5

--- a/examples/99-advanced/openfoam.py
+++ b/examples/99-advanced/openfoam.py
@@ -5,6 +5,7 @@ Plot OpenFOAM data
 ~~~~~~~~~~~~~~~~~~
 
 Read and plot data from a lid-driven cavity flow simulation.
+
 """
 
 import pyvista as pv

--- a/examples/99-advanced/openfoam.py
+++ b/examples/99-advanced/openfoam.py
@@ -3,6 +3,8 @@
 
 Plot OpenFOAM data
 ~~~~~~~~~~~~~~~~~~
+
+Read and plot data from a lid-driven cavity flow simulation.
 """
 
 import pyvista as pv

--- a/examples/99-advanced/openfoam_cooling.py
+++ b/examples/99-advanced/openfoam_cooling.py
@@ -11,14 +11,10 @@ generated from the `Thermal Management Tutorial: CHT Analysis of an
 Electronics Box
 <https://www.simscale.com/docs/tutorials/thermal-management-cht-analysis-electronics-box/>`_.
 
-From the `SimScale Project Library <https://www.simscale.com/projects/>`_,
-generated from the `Thermal Management Tutorial: CHT Analysis of an
-Electronics Box
-<https://www.simscale.com/docs/tutorials/thermal-management-cht-analysis-electronics-box/>`_.
-
 This example dataset was read using the :class:`pyvista.POpenFOAMReader` and
 post processed according to this `README.md
 <https://github.com/pyvista/data/blob/master/Data/fvm/cooling_electronics/README.md>`_.
+
 """
 
 import numpy as np

--- a/examples/99-advanced/openfoam_cooling.py
+++ b/examples/99-advanced/openfoam_cooling.py
@@ -4,16 +4,21 @@
 Electronics Cooling CFD
 -----------------------
 
-Plot an electronics cooling CFD example from OpenFoam hosted on the public
-SimScale examples at `SimScale Project Library
-<https://www.simscale.com/projects/>`_ and generated from the `Thermal
-Management Tutorial: CHT Analysis of an Electronics Box
+Plot an electronics cooling CFD example hosted on SimScale.
+
+From the `SimScale Project Library <https://www.simscale.com/projects/>`_,
+generated from the `Thermal Management Tutorial: CHT Analysis of an
+Electronics Box
+<https://www.simscale.com/docs/tutorials/thermal-management-cht-analysis-electronics-box/>`_.
+
+From the `SimScale Project Library <https://www.simscale.com/projects/>`_,
+generated from the `Thermal Management Tutorial: CHT Analysis of an
+Electronics Box
 <https://www.simscale.com/docs/tutorials/thermal-management-cht-analysis-electronics-box/>`_.
 
 This example dataset was read using the :class:`pyvista.POpenFOAMReader` and
 post processed according to this `README.md
 <https://github.com/pyvista/data/blob/master/Data/fvm/cooling_electronics/README.md>`_.
-
 """
 
 import numpy as np

--- a/examples/99-advanced/openfoam_cooling.py
+++ b/examples/99-advanced/openfoam_cooling.py
@@ -3,6 +3,7 @@
 
 Electronics Cooling CFD
 -----------------------
+
 Plot an electronics cooling CFD example from OpenFoam hosted on the public
 SimScale examples at `SimScale Project Library
 <https://www.simscale.com/projects/>`_ and generated from the `Thermal

--- a/examples/99-advanced/openfoam_tubes.py
+++ b/examples/99-advanced/openfoam_tubes.py
@@ -4,12 +4,14 @@
 Plot CFD Data
 -------------
 
-Plot a CFD example from OpenFoam hosted on the public SimScale examples at
-`SimScale Project Library <https://www.simscale.com/projects/>`_.
+Plot a CFD example hosted on the public SimScale examples.
+
+From `SimScale Project Library <https://www.simscale.com/projects/>`_.
+
+From `SimScale Project Library <https://www.simscale.com/projects/>`_.
 
 This example dataset was read using the :class:`pyvista.POpenFOAMReader`. See
 :ref:`openfoam_example` for a full example using this reader.
-
 """
 
 import numpy as np

--- a/examples/99-advanced/openfoam_tubes.py
+++ b/examples/99-advanced/openfoam_tubes.py
@@ -3,6 +3,7 @@
 
 Plot CFD Data
 -------------
+
 Plot a CFD example from OpenFoam hosted on the public SimScale examples at
 `SimScale Project Library <https://www.simscale.com/projects/>`_.
 

--- a/examples/99-advanced/openfoam_tubes.py
+++ b/examples/99-advanced/openfoam_tubes.py
@@ -8,10 +8,9 @@ Plot a CFD example hosted on the public SimScale examples.
 
 From `SimScale Project Library <https://www.simscale.com/projects/>`_.
 
-From `SimScale Project Library <https://www.simscale.com/projects/>`_.
-
 This example dataset was read using the :class:`pyvista.POpenFOAMReader`. See
 :ref:`openfoam_example` for a full example using this reader.
+
 """
 
 import numpy as np

--- a/examples/99-advanced/planets.py
+++ b/examples/99-advanced/planets.py
@@ -17,6 +17,7 @@ This example is inspired by `planet3D-MATLAB
 
    Please take a look at libraries like `astropy <https://www.astropy.org/>`_
    if you wish to use Python for astronomical calculations.
+
 """
 
 import pyvista as pv

--- a/examples/99-advanced/planets.py
+++ b/examples/99-advanced/planets.py
@@ -4,8 +4,7 @@
 3D Earth and Celestial Bodies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Plot the solar system in PyVista using datasets from the
-:mod:`~pyvista.examples.planets` module.
+Plot the solar system using datasets from :mod:`~pyvista.examples.planets`.
 
 This example is inspired by `planet3D-MATLAB
 <https://github.com/tamaskis/planet3D-MATLAB>`_.
@@ -18,7 +17,6 @@ This example is inspired by `planet3D-MATLAB
 
    Please take a look at libraries like `astropy <https://www.astropy.org/>`_
    if you wish to use Python for astronomical calculations.
-
 """
 
 import pyvista as pv

--- a/examples/99-advanced/plotting_algorithms.py
+++ b/examples/99-advanced/plotting_algorithms.py
@@ -22,6 +22,7 @@ pipeline when adding data to the scene through methods like
 
 This example will walk through using a few :vtk:`vtkAlgorithm` filters directly
 and passing them to PyVista for dynamic visualization.
+
 """
 
 import pyvista as pv

--- a/examples/99-advanced/pump_bracket.py
+++ b/examples/99-advanced/pump_bracket.py
@@ -8,8 +8,6 @@ Visualize the modal analysis of a pump bracket.
 
 Based on point arrays representing mode shapes for different modes of vibration.
 
-Based on point arrays representing mode shapes for different modes of vibration.
-
 **Background**
 Modal analysis is the study of the dynamic properties of mechanical structures
 in the frequency domain. It is a common technique in structural dynamics,
@@ -21,6 +19,7 @@ force, it responds at all its natural frequencies with each mode shape being
 independent of the others. In this example, we will visualize the mode shapes
 to get an understanding of how the pump bracket responds to different modes of
 vibration.
+
 """
 
 import numpy as np

--- a/examples/99-advanced/pump_bracket.py
+++ b/examples/99-advanced/pump_bracket.py
@@ -3,6 +3,7 @@
 
 Visualize Modal Analysis of a Pump Bracket
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 The following example demonstrates how to use PyVista to visualize the modal
 analysis of a pump bracket based on point arrays representing mode shapes for
 different modes of vibration.

--- a/examples/99-advanced/pump_bracket.py
+++ b/examples/99-advanced/pump_bracket.py
@@ -4,9 +4,11 @@
 Visualize Modal Analysis of a Pump Bracket
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following example demonstrates how to use PyVista to visualize the modal
-analysis of a pump bracket based on point arrays representing mode shapes for
-different modes of vibration.
+Visualize the modal analysis of a pump bracket.
+
+Based on point arrays representing mode shapes for different modes of vibration.
+
+Based on point arrays representing mode shapes for different modes of vibration.
 
 **Background**
 Modal analysis is the study of the dynamic properties of mechanical structures
@@ -19,7 +21,6 @@ force, it responds at all its natural frequencies with each mode shape being
 independent of the others. In this example, we will visualize the mode shapes
 to get an understanding of how the pump bracket responds to different modes of
 vibration.
-
 """
 
 import numpy as np

--- a/examples/99-advanced/ray_trace_moeller.py
+++ b/examples/99-advanced/ray_trace_moeller.py
@@ -4,8 +4,11 @@
 Visualize the Moeller-Trumbore Algorithm
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This example demonstrates the Moeller-Trumbore intersection algorithm
-using :class:`~pyvista.PolyData`.
+Demonstrate the Moeller-Trumbore ray/triangle intersection algorithm.
+
+Uses :class:`~pyvista.PolyData`.
+
+Uses :class:`~pyvista.PolyData`.
 
 For additional details, please reference the following:
 

--- a/examples/99-advanced/ray_trace_moeller.py
+++ b/examples/99-advanced/ray_trace_moeller.py
@@ -8,14 +8,13 @@ Demonstrate the Moeller-Trumbore ray/triangle intersection algorithm.
 
 Uses :class:`~pyvista.PolyData`.
 
-Uses :class:`~pyvista.PolyData`.
-
 For additional details, please reference the following:
 
 - `Moeller-Trumbore intersection algorithm <https://en.wikipedia.org/wiki/M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm>`_
 - `Fast Minimum Storage Ray Triangle Intersectio <https://cadxfem.org/inf/Fast%20MinimumStorage%20RayTriangle%20Intersection.pdf>`_
 
 First, define the ray triangle intersection method.
+
 """
 
 import numpy as np

--- a/examples/99-advanced/sphere_eversion.py
+++ b/examples/99-advanced/sphere_eversion.py
@@ -15,21 +15,13 @@ available `on arXiv <https://arxiv.org/abs/1711.10466>`_), we can plot this
 so-called eversion of a sphere (turning it inside out without pinching or
 tearing the surface, in other words by preserving its topology).
 
-There are several videos online talking about how a sphere can be turned
-inside out in a continuous fashion, for instance in `this YouTube video
-<https://www.youtube.com/watch?v=OI-To1eUtuU>`_. Thanks to `an excellent
-paper by Adam Bednorz and Witold Bednorz, Differential and its Applications
-64, 59 (2019) <https://doi.org/10.1016/j.difgeo.2019.02.004>`_ (also
-available `on arXiv <https://arxiv.org/abs/1711.10466>`_), we can plot this
-so-called eversion of a sphere (turning it inside out without pinching or
-tearing the surface, in other words by preserving its topology).
-
 The mathematics involved can seem a bit, well, involved. What matters is the
 overall process visible in the animation: first the sphere is corrugated and
 stretched out a bit to allow some legroom for the smooth transformation, then
 the lobes are twisted around through each other, and the process is reversed in
 order to unfold the sphere. It's not obvious that the transformation is truly
 smooth; this was proved in the paper by Bednorz and Bednorz.
+
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/99-advanced/sphere_eversion.py
+++ b/examples/99-advanced/sphere_eversion.py
@@ -4,14 +4,25 @@
 Turning the sphere inside out
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are several videos online talking about how a sphere can be turned inside
-out in a continuous fashion, for instance in `this YouTube video
-<https://www.youtube.com/watch?v=OI-To1eUtuU>`_.  Thanks to `an excellent paper
-by Adam Bednorz and Witold Bednorz, Differential and its Applications 64, 59
-(2019) <https://doi.org/10.1016/j.difgeo.2019.02.004>`_ (also available `on
-arXiv <https://arxiv.org/abs/1711.10466>`_), we can plot this so-called
-eversion of a sphere (turning it inside out without pinching or tearing the
-surface, in other words by preserving its topology).
+Plot the eversion of a sphere: turning it inside out without tearing it.
+
+There are several videos online talking about how a sphere can be turned
+inside out in a continuous fashion, for instance in `this YouTube video
+<https://www.youtube.com/watch?v=OI-To1eUtuU>`_. Thanks to `an excellent
+paper by Adam Bednorz and Witold Bednorz, Differential and its Applications
+64, 59 (2019) <https://doi.org/10.1016/j.difgeo.2019.02.004>`_ (also
+available `on arXiv <https://arxiv.org/abs/1711.10466>`_), we can plot this
+so-called eversion of a sphere (turning it inside out without pinching or
+tearing the surface, in other words by preserving its topology).
+
+There are several videos online talking about how a sphere can be turned
+inside out in a continuous fashion, for instance in `this YouTube video
+<https://www.youtube.com/watch?v=OI-To1eUtuU>`_. Thanks to `an excellent
+paper by Adam Bednorz and Witold Bednorz, Differential and its Applications
+64, 59 (2019) <https://doi.org/10.1016/j.difgeo.2019.02.004>`_ (also
+available `on arXiv <https://arxiv.org/abs/1711.10466>`_), we can plot this
+so-called eversion of a sphere (turning it inside out without pinching or
+tearing the surface, in other words by preserving its topology).
 
 The mathematics involved can seem a bit, well, involved. What matters is the
 overall process visible in the animation: first the sphere is corrugated and
@@ -19,7 +30,6 @@ stretched out a bit to allow some legroom for the smooth transformation, then
 the lobes are twisted around through each other, and the process is reversed in
 order to unfold the sphere. It's not obvious that the transformation is truly
 smooth; this was proved in the paper by Bednorz and Bednorz.
-
 """
 
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/99-advanced/warp_by_vector_eigenmodes.py
+++ b/examples/99-advanced/warp_by_vector_eigenmodes.py
@@ -4,14 +4,21 @@
 Display Eigenmodes of Vibration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This example applies the :func:`warp_by_vector
-<pyvista.DataSetFilters.warp_by_vector>` filter to a cube whose eigenmodes have
-been computed using the Ritz method, as outlined in Visscher, William M.,
-Albert Migliori, Thomas M. Bell, et Robert A. Reinert. "On the normal modes of
-free vibration of inhomogeneous and anisotropic elastic objects". The Journal
-of the Acoustical Society of America 90, n.4 (October 1991): 2154-62.
+Apply :func:`~pyvista.DataSetFilters.warp_by_vector` to a cube eigenmode.
+
+The eigenmodes have been computed using the Ritz method, as outlined in
+Visscher, William M., Albert Migliori, Thomas M. Bell, et Robert A.
+Reinert. "On the normal modes of free vibration of inhomogeneous and
+anisotropic elastic objects". The Journal of the Acoustical Society of
+America 90, n.4 (October 1991): 2154-62.
 https://asa.scitation.org/doi/10.1121/1.401643.
 
+The eigenmodes have been computed using the Ritz method, as outlined in
+Visscher, William M., Albert Migliori, Thomas M. Bell, et Robert A.
+Reinert. "On the normal modes of free vibration of inhomogeneous and
+anisotropic elastic objects". The Journal of the Acoustical Society of
+America 90, n.4 (October 1991): 2154-62.
+https://asa.scitation.org/doi/10.1121/1.401643.
 """
 
 # %%

--- a/examples/99-advanced/warp_by_vector_eigenmodes.py
+++ b/examples/99-advanced/warp_by_vector_eigenmodes.py
@@ -13,12 +13,6 @@ anisotropic elastic objects". The Journal of the Acoustical Society of
 America 90, n.4 (October 1991): 2154-62.
 https://asa.scitation.org/doi/10.1121/1.401643.
 
-The eigenmodes have been computed using the Ritz method, as outlined in
-Visscher, William M., Albert Migliori, Thomas M. Bell, et Robert A.
-Reinert. "On the normal modes of free vibration of inhomogeneous and
-anisotropic elastic objects". The Journal of the Acoustical Society of
-America 90, n.4 (October 1991): 2154-62.
-https://asa.scitation.org/doi/10.1121/1.401643.
 """
 
 # %%

--- a/hooks/gallery_docstrings.py
+++ b/hooks/gallery_docstrings.py
@@ -4,8 +4,8 @@ Ruff's D400/D415 (first line ends in punctuation) can't be enabled for
 ``examples/`` because Sphinx-Gallery requires the docstring to start with a
 ``.. _label:`` target followed by a title/underline pair, which those rules
 would force us to break. This hook instead enforces the shape directly: a
-ref label, a title with a matching underline, and a one-sentence summary
-paragraph (ending in punctuation) right after the title.
+ref label, a title with a matching underline, and a summary right after the
+title that fits on a single line and ends in punctuation, mirroring D400.
 """
 
 from __future__ import annotations
@@ -34,8 +34,10 @@ def _title_error(paragraph: str) -> str | None:
 
 
 def _summary_error(paragraph: str) -> str | None:
-    """Check that the summary paragraph is a sentence ending in punctuation."""
-    summary = ' '.join(paragraph.strip().split())
+    """Check that the summary paragraph is a single line ending in punctuation."""
+    summary = paragraph.strip('\n')
+    if '\n' in summary:
+        return f'summary must fit on a single line, not wrap: {summary!r}'
     if summary.startswith('.. '):
         return 'summary paragraph is a directive, not a summary sentence'
     return (

--- a/hooks/gallery_docstrings.py
+++ b/hooks/gallery_docstrings.py
@@ -1,11 +1,15 @@
 """Enforce Sphinx-Gallery example docstring structure.
 
-Ruff's D400/D415 (first line ends in punctuation) can't be enabled for
-``examples/`` because Sphinx-Gallery requires the docstring to start with a
-``.. _label:`` target followed by a title/underline pair, which those rules
-would force us to break. This hook instead enforces the shape directly: a
-ref label, a title with a matching underline, and a summary right after the
-title that fits on a single line and ends in punctuation, mirroring D400.
+This hook emulates ruff's D400/D415 rules and applies them to Sphinx Gallery
+examples. D400/D415 cannot be used directly here because Sphinx-Gallery
+requires the docstring to start with a ``.. _label:`` target followed by a
+title/underline pair, which those rules would fail on. This hook applies
+the same single-line, ends-in-punctuation check to the summary right after
+the title, rather than to the docstring's first line.
+
+A valid docstring here has a ref label, a title with a matching underline, and that
+summary.
+
 """
 
 from __future__ import annotations

--- a/hooks/gallery_docstrings.py
+++ b/hooks/gallery_docstrings.py
@@ -1,0 +1,75 @@
+"""Enforce Sphinx-Gallery example docstring structure.
+
+Ruff's D400/D415 (first line ends in punctuation) can't be enabled for
+``examples/`` because Sphinx-Gallery requires the docstring to start with a
+``.. _label:`` target followed by a title/underline pair, which those rules
+would force us to break. This hook instead enforces the shape directly: a
+ref label, a title with a matching underline, and a one-sentence summary
+paragraph (ending in punctuation) right after the title.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import sys
+
+UNDERLINE_CHARS = set('~-=^"#*+.')
+
+
+def _title_error(paragraph: str) -> str | None:
+    """Check that the title paragraph is a title line plus a matching underline."""
+    title_lines = paragraph.strip('\n').split('\n')
+    if len(title_lines) != 2:
+        return 'summary must be its own paragraph, separated from the title by a blank line'
+    title, underline = title_lines
+    underline_ok = (
+        len(set(underline)) == 1
+        and underline[0] in UNDERLINE_CHARS
+        and len(underline) >= len(title)
+    )
+    return (
+        None if underline_ok else f'title underline {underline!r} does not match title {title!r}'
+    )
+
+
+def _summary_error(paragraph: str) -> str | None:
+    """Check that the summary paragraph is a sentence ending in punctuation."""
+    summary = ' '.join(paragraph.strip().split())
+    if summary.startswith('.. '):
+        return 'summary paragraph is a directive, not a summary sentence'
+    return (
+        None
+        if summary and summary[-1] in '.?!'
+        else f'summary line does not end in punctuation: {summary!r}'
+    )
+
+
+def find_docstring_error(source: str) -> str | None:
+    """Return a description of the first docstring structure violation, if any."""
+    doc = ast.get_docstring(ast.parse(source), clean=False)
+    if doc is None:
+        return 'module is missing a docstring'
+
+    paragraphs = doc.strip('\n').split('\n\n')
+    if not paragraphs[0].lstrip().startswith('.. _'):
+        return 'docstring must start with a ``.. _label:`` target'
+    if len(paragraphs) < 3:
+        return 'docstring is missing a title or a summary paragraph after it'
+
+    return _title_error(paragraphs[1]) or _summary_error(paragraphs[2])
+
+
+def main(argv: list[str]) -> int:
+    """Check each file in argv, printing and counting violations."""
+    exit_code = 0
+    for filename in argv:
+        error = find_docstring_error(Path(filename).read_text(encoding='utf-8'))
+        if error is not None:
+            print(f'{filename}: {error}')  # noqa: T201
+            exit_code = 1
+    return exit_code
+
+
+if __name__ == '__main__':
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/doc/doc_build/test_opengraph.py
+++ b/tests/doc/doc_build/test_opengraph.py
@@ -64,7 +64,7 @@ OPENGRAPH_PAGES = (
         id='gallery',
         # A gallery example selecting its image with ``sphinx_gallery_thumbnail_number``
         path='examples/00-load/create_circular_arc.html',
-        description='Generate arc geometry with pyvista.CircularArc()',
+        description='Generate circular arc geometry.',
         image_number=2,
     ),
     OpenGraphPage(


### PR DESCRIPTION
### Overview

All of PyVista's docstrings _except_ for the Sphinx Gallery examples are linted with ruff D400 and D415 to ensure there is always an initial one-line summary describing the content. 

But, ruff's D400/D415 (first docstring line must end in punctuation) can't be enabled for `examples/` because Sphinx-Gallery requires the docstring to start with a `.. _label:` target followed by a title/underline pair. This PR adds a local pre-commit hook to enforce the intended structure directly instead: a ref label, a title with a matching underline, and a one-line summary sentence right after it, ending in punctuation.

Every example whose summary didn't already match that shape is fixed.

Changes drafted by Claude Sonnet 5 but fully understood by me.

### Details

- `hooks/gallery_docstrings.py`: new structure check, wired into `.pre-commit-config.yaml`
- 191 example docstrings adjusted to have a proper one-line summary paragraph
