### PR TITLE
fix: resolve [Source] link for metaclass properties (e.g. CellType.dimension_map)

### DIFF
--- a/pyvista/core/utilities/docs.py
+++ b/pyvista/core/utilities/docs.py
@@ -58,6 +58,12 @@ def linkcode_resolve(domain: str, info: dict[str, str], edit: bool = False) -> s
 
     obj = submod
     for part in fullname.split('.'):
+        # A metaclass property (e.g. CellType.dimension_map) is invoked by a plain
+        # getattr, losing the property itself -- grab it off the metaclass instead.
+        metaclass_prop = getattr(type(obj), part, None) if inspect.isclass(obj) else None
+        if isinstance(metaclass_prop, property):
+            obj = metaclass_prop
+            continue
         try:
             obj = getattr(obj, part)
         except Exception:  # noqa: BLE001

--- a/pyvista/core/utilities/docs.py
+++ b/pyvista/core/utilities/docs.py
@@ -6,6 +6,7 @@ import inspect
 import os
 import os.path as op
 import sys
+from typing import Any
 
 
 def linkcode_resolve(domain: str, info: dict[str, str], edit: bool = False) -> str | None:  # noqa: FBT001, FBT002
@@ -56,7 +57,7 @@ def linkcode_resolve(domain: str, info: dict[str, str], edit: bool = False) -> s
     if submod is None:
         return None
 
-    obj = submod
+    obj: Any = submod
     for part in fullname.split('.'):
         # A metaclass property (e.g. CellType.dimension_map) is invoked by a plain
         # getattr, losing the property itself -- grab it off the metaclass instead.

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -1174,6 +1174,12 @@ def test_linkcode_resolve():
     link = linkcode_resolve('py', {'module': 'pyvista', 'fullname': 'pyvista.core.DataSet.points'})
     assert 'dataset.py' in link
 
+    # test metaclass property (e.g. CellType.dimension_map, defined on the metaclass)
+    link = linkcode_resolve(
+        'py', {'module': 'pyvista', 'fullname': 'pyvista.CellType.dimension_map'}
+    )
+    assert 'celltype.py' in link
+
     # test wrapped function
     link = linkcode_resolve(
         'py',


### PR DESCRIPTION
linkcode_resolve() walked attribute chains with a plain getattr, which invokes a metaclass property instead of returning the property object itself. CellType.dimension_map is defined as a property on CellType's metaclass, so accessing it this way ran the property and handed inspect.getsourcefile() a plain mappingproxy value with no source location -- the [Source] button silently disappeared from its API page instead of erroring.

Fix: check type(obj) for a property before falling back to getattr, grabbing the metaclass property descriptor directly so the existing .fget unwrap handles it the same as a regular property.

- Added a pyvista.CellType.dimension_map case to test_linkcode_resolve, asserting the link now points into celltype.py.

Written with help from Claude Code; I reviewed and understand the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)