### PR TITLE
Fix RST backtick formatting errors in docstrings

### DIFF
--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -136,7 +136,7 @@ for ext, reader in CLASS_READERS.items():
 
 
 def _aligned_dedent(txt):
-    """Variant of `textwrap.dedent`.
+    """Variant of ``textwrap.dedent``.
 
     Helper method to dedent the provided text up to the special alignment character ``'|'``.
     """
@@ -1894,7 +1894,7 @@ def _max_width(lines: list[str]) -> int:
 
 
 def _repeat_string(string: str, num_repeat: int) -> str:
-    """Repeat `string` `num_repeat` times."""
+    """Repeat ``string`` ``num_repeat`` times."""
     return ''.join([string] * num_repeat)
 
 
@@ -2509,7 +2509,7 @@ class DatasetCard:
     def _generate_field_block(fields: list[tuple[str, str | None]], indent_level: int = 0):
         """Generate a grid for each field and combine them into an indented multi-line rst block.
 
-        Any fields with a `None` value are completely excluded from the block.
+        Any fields with a ``None`` value are completely excluded from the block.
         """
         field_grids = list(itertools.starmap(DatasetCard._generate_field_grid, fields))
         block = '\n'.join([grid for grid in field_grids if grid])
@@ -2773,7 +2773,7 @@ class DatasetPropsGenerator:
 
     @staticmethod
     def generate_celltype_field(loader: _DatasetLoader):
-        """Format cell type(s) as badges linking to their `pyvista.CellType` member."""
+        """Format cell type(s) as badges linking to their ``pyvista.CellType`` member."""
         cell_types = loader.unique_cell_types
         if not cell_types:
             return '``N/A (no cells)``'

--- a/examples/00-load/reader.py
+++ b/examples/00-load/reader.py
@@ -48,7 +48,7 @@ print(f'All arrays: {mesh.array_names}')
 
 # %%
 # Using :func:`pyvista.get_reader` enables more fine-grained control of reading data
-# files. Reading in a ``.vtp``` file uses the :class:`pyvista.XMLPolyDataReader`.
+# files. Reading in a ``.vtp`` file uses the :class:`pyvista.XMLPolyDataReader`.
 
 reader = pv.get_reader(temp_file.name)
 reader

--- a/examples/01-filter/subdivide.py
+++ b/examples/01-filter/subdivide.py
@@ -7,8 +7,8 @@ Subdivide Cells
 Increase the number of triangles in a single, connected triangular mesh.
 
 The :func:`pyvista.PolyDataFilters.subdivide` filter utilizes three different
-subdivision algorithms to subdivide a mesh's cells: `butterfly`, `loop`,
-or `linear`.
+subdivision algorithms to subdivide a mesh's cells: ``'butterfly'``, ``'loop'``,
+or ``'linear'``.
 
 """
 

--- a/examples/02-plot/silhouette.py
+++ b/examples/02-plot/silhouette.py
@@ -6,7 +6,7 @@ Silhouette Highlight
 
 Extract an outline (silhouette) of a polygonal mesh's edges.
 
-The silhouette may be created using the `silhouette` keyword with
+The silhouette may be created using the ``silhouette`` keyword with
 :meth:`~pyvista.Plotter.add_mesh`, or by using `~pyvista.Plotter.add_silhouette` directly.
 
 """

--- a/examples/99-advanced/customize_trame_toolbar.py
+++ b/examples/99-advanced/customize_trame_toolbar.py
@@ -7,7 +7,7 @@ Customize Trame toolbar
 Bring more of the power of trame to the jupyter view.
 
 This example shows how to add custom tools using the
-`jupyter_kwargs` option with :meth:`~pyvista.Plotter.show`.
+``jupyter_kwargs`` option with :meth:`~pyvista.Plotter.show`.
 
 """
 

--- a/hooks/warnings.py
+++ b/hooks/warnings.py
@@ -1,7 +1,7 @@
 """Enforce warnings style.
 
-Python script to enforce using the custom `warn_external` function instead of
-plain `warnings.warn`, to allow for dynamic stacklevel value.
+Python script to enforce using the custom ``warn_external`` function instead of
+plain ``warnings.warn``, to allow for dynamic stacklevel value.
 """
 
 from __future__ import annotations

--- a/pyvista/_cli/compare.py
+++ b/pyvista/_cli/compare.py
@@ -134,7 +134,7 @@ def _converter_border(
 def _resolve_border(
     border: list[_CompareBorderOptions] | None,
 ) -> bool | Literal['interior', 'exterior'] | None:
-    """Turn 0-or-1 raw CLI tokens into the value `plot_compare`'s own `border` expects."""
+    """Turn 0-or-1 raw CLI tokens into what :func:`pyvista.plot_compare`'s ``border`` expects."""
     if border is None:
         return None
     if not border:
@@ -163,7 +163,7 @@ def _showwarning_with_advice(fallback: Callable[..., None]) -> Callable[..., Non
     """Return a ``showwarning`` which prints a warning as it is raised, with advice.
 
     A warning is otherwise not seen until the interactive window this command opens is
-    closed, since `plot_compare` raises every one of them well before it shows the
+    closed, since :func:`pyvista.plot_compare` raises every one of them well before it shows the
     window, but nothing is printed until the window closes and this call returns.
     """
 

--- a/pyvista/_cli/report.py
+++ b/pyvista/_cli/report.py
@@ -1,4 +1,4 @@
-"""```pyvista report``` CLI."""
+"""``pyvista report`` CLI."""
 
 from __future__ import annotations
 

--- a/pyvista/_cli/report.py
+++ b/pyvista/_cli/report.py
@@ -1,4 +1,4 @@
-"""`pyvista report` CLI."""
+"""```pyvista report``` CLI."""
 
 from __future__ import annotations
 

--- a/pyvista/_cli/validate.py
+++ b/pyvista/_cli/validate.py
@@ -1,4 +1,4 @@
-"""```pyvista report``` CLI."""
+"""``pyvista validate`` CLI."""
 
 from __future__ import annotations
 

--- a/pyvista/_cli/validate.py
+++ b/pyvista/_cli/validate.py
@@ -1,4 +1,4 @@
-"""`pyvista report` CLI."""
+"""```pyvista report``` CLI."""
 
 from __future__ import annotations
 

--- a/pyvista/_plot.py
+++ b/pyvista/_plot.py
@@ -37,9 +37,9 @@ if TYPE_CHECKING:
 def _add_axes_widget(
     renderers: Iterable[Renderer], *, show_axes: bool | None, theme: Theme
 ) -> None:
-    """Add the axes orientation widget to each of the renderers, as `pyvista.plot` does.
+    """Add the axes orientation widget to each of the renderers, as :func:`pyvista.plot` does.
 
-    `show_axes` defaults to the theme, which also decides whether the widget drawn is
+    ``show_axes`` defaults to the theme, which also decides whether the widget drawn is
     box axes or the plain orientation widget.
     """
     if show_axes is None:
@@ -50,12 +50,12 @@ def _add_axes_widget(
 
 
 def _set_background(pl: Plotter, background: ColorLike | None) -> None:
-    """Set the background `pyvista.plot` and `pyvista.plot_compare` take.
+    """Set the background :func:`pyvista.plot` and :func:`pyvista.plot_compare` take.
 
-    A color is set as the background of every renderer at once, since `set_background`
+    A color is set as the background of every renderer at once, since ``set_background``
     is a property of the whole collection of them rather than of any one. A path to an
     image file is shown as a background image instead, behind every subplot alike for
-    the same reason, since `set_background` only takes a color and raises otherwise.
+    the same reason, since ``set_background`` only takes a color and raises otherwise.
     """
     try:
         pl.set_background(background)  # type: ignore[arg-type]
@@ -78,12 +78,12 @@ def _apply_render_options(
     parallel_projection: bool,
     ssao: bool,
 ) -> None:
-    """Apply the rendering options `pyvista.plot` takes, in the terms it takes them.
+    """Apply the rendering options :func:`pyvista.plot` takes, in the terms it takes them.
 
-    `anti_aliasing` is a property of the render window, so it is applied once to the
-    plotter. `eye_dome_lighting`, `parallel_projection` and `ssao` are each a
-    renderer's own, so they are applied to every one of `renderers`; a plot with a
-    single renderer gives `[pl.renderer]`.
+    ``anti_aliasing`` is a property of the render window, so it is applied once to the
+    plotter. ``eye_dome_lighting``, ``parallel_projection`` and ``ssao`` are each a
+    renderer's own, so they are applied to every one of ``renderers``; a plot with a
+    single renderer gives ``[pl.renderer]``.
     """
     if anti_aliasing is None:
         pass

--- a/pyvista/_warn_external.py
+++ b/pyvista/_warn_external.py
@@ -8,7 +8,7 @@ import warnings
 
 
 def warn_external(message: str, category: type[Warning] | None = None) -> None:
-    """`warnings.warn` wrapper that sets *stacklevel* to "outside PyVista".
+    """``warnings.warn`` wrapper that sets *stacklevel* to "outside PyVista".
 
     Taken and modified from Matplotlib
     https://github.com/matplotlib/matplotlib/blob/db83efff4d7d3849f8bffbd1f6cdfc43d74c9aea/lib/matplotlib/_api/__init__.py#L395

--- a/pyvista/core/_typing_core/_array_like.py
+++ b/pyvista/core/_typing_core/_array_like.py
@@ -11,7 +11,7 @@ Some key differences include:
   Here, finite sequences are used instead.
 
 - The npt._array_like definitions use a generic _SupportsArray protocol.
-  Here, we use `ndarray` directly.
+  Here, we use ``ndarray`` directly.
 
 - The npt._array_like definitions include scalar types (e.g. float, int).
   Here they are excluded (i.e. scalars are not considered to be arrays).

--- a/pyvista/core/_validation/check.py
+++ b/pyvista/core/_validation/check.py
@@ -327,7 +327,7 @@ def check_integer(
         Number or array to check.
 
     strict : bool, default: False
-        If ``True``, the array's data must be a subtype of `int` or
+        If ``True``, the array's data must be a subtype of ``int`` or
         ``np.integer``. Otherwise, floats are allowed but must be
         whole numbers.
 

--- a/pyvista/core/_validation/validate.py
+++ b/pyvista/core/_validation/validate.py
@@ -1270,12 +1270,12 @@ def _validate_color_sequence(
 ) -> tuple[Color, ...]:
     """Validate a color sequence.
 
-    If `n_colors` is specified, the output will have `n` colors. For single-color
-    inputs, the color is copied and a sequence of `n` identical colors is returned.
+    If ``n_colors`` is specified, the output will have ``n`` colors. For single-color
+    inputs, the color is copied and a sequence of ``n`` identical colors is returned.
     For inputs with multiple colors, the number of colors in the input must
-    match `n_colors`.
+    match ``n_colors``.
 
-    If `n_colors` is None, no broadcasting or length-checking is performed.
+    If ``n_colors`` is None, no broadcasting or length-checking is performed.
     """
     from pyvista.plotting.colors import Color  # noqa: PLC0415
 

--- a/pyvista/core/_vtk_utilities.py
+++ b/pyvista/core/_vtk_utilities.py
@@ -130,7 +130,7 @@ _SUPPORTS_POLYHEDRON_FACE_CELL_ARRAYS = vtk_version_info >= (9, 4)
 
 
 class DisableVtkSnakeCase:
-    """Base class to raise error if using VTK's `snake_case` API."""
+    """Base class to raise error if using VTK's ``snake_case`` API."""
 
     @staticmethod
     def check_attribute(target, attr):

--- a/pyvista/core/cell.py
+++ b/pyvista/core/cell.py
@@ -978,7 +978,7 @@ class CellArray(
         Parameters
         ----------
         offsets : MatrixLike[int]
-            Offsets array of length `n_cells + 1`.
+            Offsets array of length ``n_cells + 1``.
 
         connectivity : MatrixLike[int]
             Connectivity array.
@@ -1009,7 +1009,7 @@ class CellArray(
         -----
         This property does not validate that the cells are all
         actually the same size. If they're not, this property may either
-        raise a `ValueError` or silently return an incorrect array.
+        raise a ``ValueError`` or silently return an incorrect array.
 
         """
         return _get_regular_cells(self)
@@ -1032,7 +1032,7 @@ class CellArray(
         Parameters
         ----------
         cells : numpy.ndarray or list[list[int]]
-            Cell array of shape (n_cells, cell_size) where all cells have the same `cell_size`.
+            Cell array of shape (n_cells, cell_size) where all cells have the same ``cell_size``.
 
         deep : bool, default: False
             Whether to deep copy the cell array data into the vtk connectivity array.

--- a/pyvista/core/celltype.py
+++ b/pyvista/core/celltype.py
@@ -961,19 +961,19 @@ class CellType(IntEnum, metaclass=_CellTypeMeta):
             the cell.
 
         _variable_points: bool, optional
-            Override the value shown for this cell type's `Points` badge. May be
+            Override the value shown for this cell type's ``Points`` badge. May be
             useful for composite cells (e.g. POLY_LINE or POLY_VERTEX) where a value
             of ``0`` may otherwise be shown. By default, the value from ``vtk_class``
             is used.
 
         _variable_edges: bool, optional
-            Override the value shown for this cell type's `Edges` badge. May be
+            Override the value shown for this cell type's ``Edges`` badge. May be
             useful for composite cells (e.g. POLY_LINE or POLY_VERTEX) where a value
             of ``0`` may otherwise be shown. By default, the value from ``vtk_class``
             is used.
 
         _variable_faces: bool, optional
-            Override the value shown for this cell type's `Faces` badge. May be
+            Override the value shown for this cell type's ``Faces`` badge. May be
             useful for composite cells (e.g. POLY_LINE or POLY_VERTEX) where a value
             of ``0`` may otherwise be shown. By default, the value from ``vtk_class``
             is used.

--- a/pyvista/core/celltype.py
+++ b/pyvista/core/celltype.py
@@ -709,7 +709,7 @@ class _CellTypeMeta(EnumMeta):
         Returns
         -------
         dict
-            Dictionary with cell dimensions ``0``, ``1``, ``2,``, ``3`` as keys, and frozen sets as
+            Dictionary with cell dimensions ``0``, ``1``, ``2``, ``3`` as keys, and frozen sets as
             values with the respective :class:`CellType` members.
 
         See Also

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -757,7 +757,7 @@ class MultiBlock(
         """Move or copy field data from all nested :class:`MultiBlock` blocks.
 
         Any nested :class:`MultiBlock` blocks will have its :attr:`~pyvista.DataObject.field_data`
-        contents moved to the root block, (i.e. `this` ``MultiBock``). By default, this
+        contents moved to the root block, (i.e. `this` ``MultiBlock``). By default, this
         data will be cleared from the nested block(s) but a copy may be made instead.
 
         If any nested :class:`MultiBlock` blocks define a :attr:`~pyvista.DataObject.user_dict`,

--- a/pyvista/core/composite.py
+++ b/pyvista/core/composite.py
@@ -190,7 +190,7 @@ class MultiBlock(
                 raise TypeError(msg)
 
         elif len(args) > 1:
-            msg = 'Invalid number of arguments:\n``pyvista.MultiBlock``supports 0 or 1 arguments.'
+            msg = 'Invalid number of arguments:\n``pyvista.MultiBlock`` supports 0 or 1 arguments.'
             raise ValueError(msg)
 
         # Upon creation make sure all nested structures are wrapped

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -909,7 +909,7 @@ class DataObject(
     def _serialize_pyvista_pickle_format(self: Self) -> dict[str, Any]:
         """Support pickle by serializing the VTK object data.
 
-        The format of the serialized VTK object data depends on `pyvista.PICKLE_FORMAT`
+        The format of the serialized VTK object data depends on ``pyvista.PICKLE_FORMAT``
         (case-insensitive).
         - If ``'xml'``, the data is serialized as an XML-formatted string.
         - If ``'legacy'``, the data is serialized to bytes in VTK's binary format.

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -105,7 +105,7 @@ class _ActiveArrayExistsInfoTuple(NamedTuple):
     """Active array info tuple for arrays that exist.
 
     This named tuple is similar to ActiveArrayInfoTuple except the
-    `name` attribute cannot be `None`.
+    ``name`` attribute cannot be ``None``.
     """
 
     association: FieldAssociation

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -4501,7 +4501,7 @@ class DataObjectFilters:
         Returns
         -------
         output : DataSet | MultiBlock
-            Dataset with `cell_data` containing the ``"VertexCount"``,
+            Dataset with ``cell_data`` containing the ``"VertexCount"``,
             ``"Length"``, ``"Area"``, and ``"Volume"`` arrays if set
             in the parameters.  Return type matches input.
 
@@ -4923,11 +4923,11 @@ class DataObjectFilters:
     ):
         """Resample array data from a passed mesh onto this mesh.
 
-        For `mesh1.sample(mesh2)`, the arrays from `mesh2` are sampled onto
-        the points of `mesh1`.  This function interpolates within an
+        For ``mesh1.sample(mesh2)``, the arrays from ``mesh2`` are sampled onto
+        the points of ``mesh1``.  This function interpolates within an
         enclosing cell.  This contrasts with
         :func:`pyvista.DataSetFilters.interpolate` that uses a distance
-        weighting for nearby points.  If there is cell topology, `sample` is
+        weighting for nearby points.  If there is cell topology, ``sample`` is
         usually preferred.
 
         The point data 'vtkValidPointMask' stores whether the point could be sampled

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -3687,7 +3687,7 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
         """Generate evenly spaced streamlines on a 2D dataset.
 
         This filter only supports datasets that lie on the xy plane, i.e. ``z=0``.
-        Particular care must be used to choose a `separating_distance`
+        Particular care must be used to choose a ``separating_distance``
         that do not result in too much memory being utilized.  The
         default unit is cell length.
 
@@ -7737,7 +7737,7 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
         .. note::
             This filter does not discard internal surfaces, due, for instance, to
             intersecting meshes. Instead, the intersection will be considered as
-            background which may produce unexpected results. See `Examples`.
+            background which may produce unexpected results. See Examples.
 
         Parameters
         ----------
@@ -8552,7 +8552,7 @@ def _swap_axes(vectors, values):
     axis is +Y, second is +X, and third is +Z. This function will swap the first two
     axes so that the order is XYZ instead of YXZ.
 
-    This function is intended to be used by `align_xyz` and is only exposed as a
+    This function is intended to be used by ``align_xyz`` and is only exposed as a
     module-level function for testing purposes.
     """
 

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -3748,7 +3748,7 @@ class ImageDataFilters(DataSetFilters):
     ) -> tuple[ImageData, NDArray[int], NDArray[int]]:
         """Find and label connected regions in a :class:`~pyvista.ImageData`.
 
-        Only points whose `scalar` value is within the `scalar_range` are considered for
+        Only points whose ``scalar`` value is within the ``scalar_range`` are considered for
         connectivity. A 4-connectivity is used for 2D images or a 6-connectivity for 3D
         images. This filter operates on point-based data. If cell-based data are provided,
         they are re-meshed to a point-based representation using

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -3134,7 +3134,7 @@ class PolyDataFilters(DataSetFilters):
             are consistent with this implicit definition, consider also using
             :meth:`~pyvista.PolyDataFilters.flip_faces` or re-computing normals with
             :meth:`~pyvista.PolyDataFilters.compute_normals` and enabling the
-            `flip_normals` option.
+            ``flip_normals`` option.
 
         .. versionadded:: 0.45
 

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -785,7 +785,7 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
 
     Construct a mesh reusing the ``faces`` ``pv.CellArray`` from another
     mesh. The VTK methods ``GetPolys``, ``GetLines``, ``GetStrips``, and
-    ``GetVerts`` return the underlying ``CellArray``s for the ``faces``,
+    ``GetVerts`` return the underlying ``CellArray`` objects for the ``faces``,
     ``lines``, ``strips``, and ``verts`` properties respectively.
     Reusing cell arrays like this can be a performance optimization for
     large meshes because it avoids allocating new arrays.

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -1193,7 +1193,7 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
         faces: MatrixLike[int],
         deep: bool = False,  # noqa: FBT001, FBT002
     ):
-        """Alternate `pyvista.PolyData` convenience constructor from point and regular face arrays.
+        """Alternate :class:`pyvista.PolyData` constructor from points and regular face arrays.
 
         Parameters
         ----------
@@ -1266,7 +1266,7 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
 
     @classmethod
     def from_irregular_faces(cls, points: MatrixLike[float], faces: Sequence[VectorLike[int]]):
-        """Alternate `pyvista.PolyData` convenience constructor from point and ragged face arrays.
+        """Alternate :class:`pyvista.PolyData` constructor from points and ragged face arrays.
 
         Parameters
         ----------
@@ -2943,9 +2943,9 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
 
         .. deprecated:: 0.45.0
             This property is deprecated and will be removed in a future release.
-            VTK has deprecated `GetFaces` and `GetFaceLocations` in VTK 9.4 and
+            VTK has deprecated ``GetFaces`` and ``GetFaceLocations`` in VTK 9.4 and
             may be removed in a future release of VTK. Please use
-            `polyhedron_faces` instead.
+            ``polyhedron_faces`` instead.
 
         Returns
         -------
@@ -3002,9 +3002,9 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
 
         .. deprecated:: 0.45.0
             This property is deprecated and will be removed in a future release.
-            VTK has deprecated `GetFaces` and `GetFaceLocations` in VTK 9.4 and
+            VTK has deprecated ``GetFaces`` and ``GetFaceLocations`` in VTK 9.4 and
             may be removed in a future release of VTK. Please use
-            `polyhedron_face_locations` instead.
+            ``polyhedron_face_locations`` instead.
 
         Returns
         -------
@@ -4769,7 +4769,7 @@ class ExplicitStructuredGrid(PointGrid, _vtk.vtkExplicitStructuredGrid):
     def visible_bounds(self) -> BoundsTuple:  # numpydoc ignore=RT01
         """Return the bounding box of the visible cells.
 
-        Different from `bounds`, which returns the bounding box of the
+        Different from ``bounds``, which returns the bounding box of the
         complete grid, this method returns the bounding box of the
         visible cells, where the ghost cell array is not
         ``HIDDENCELL``.

--- a/pyvista/core/utilities/cells.py
+++ b/pyvista/core/utilities/cells.py
@@ -92,7 +92,7 @@ def numpy_to_idarr(
         Converted array as a :vtk:`vtkIdTypeArray`.
     numpy.ndarray
         The input array after it has been cast to the proper dtype. Only
-        returned if `return_ind` is set to ``True``.
+        returned if ``return_ind`` is set to ``True``.
 
     Raises
     ------

--- a/pyvista/core/utilities/docs.py
+++ b/pyvista/core/utilities/docs.py
@@ -32,7 +32,7 @@ def linkcode_resolve(domain: str, info: dict[str, str], edit: bool = False) -> s
 
     Notes
     -----
-    This function is used by the `sphinx.ext.linkcode` extension to create the "[Source]"
+    This function is used by the ``sphinx.ext.linkcode`` extension to create the "[Source]"
     button whose link is edited in this function.
 
     This has been adapted to deal with our "verbose" decorator.

--- a/pyvista/core/utilities/features.py
+++ b/pyvista/core/utilities/features.py
@@ -84,7 +84,7 @@ def voxelize(  # noqa: PLR0917
     fit_bounds : bool, default: False
         If enabled, the end bound of the input mesh is used as the end bound of the
         voxel grid and the density is updated to the closest compatible one. Otherwise,
-        the end bound is excluded. Has no effect if `enclosed` is enabled.
+        the end bound is excluded. Has no effect if ``enclosed`` is enabled.
 
     Returns
     -------
@@ -171,7 +171,7 @@ def _voxelize_legacy(
 ):
     """Voxelize mesh to UnstructuredGrid.
 
-    The public `voxelize` function is deprecated but we need to keep it for
+    The public :func:`~pyvista.voxelize` function is deprecated but we need to keep it for
     generating the PyVista logo.
 
     """
@@ -294,7 +294,7 @@ def voxelize_volume(  # noqa: PLR0917
     fit_bounds : bool, default: False
         If enabled, the end bound of the input mesh is used as the end bound of the
         voxel grid and the density is updated to the closest compatible one. Otherwise,
-        the end bound is excluded. Has no effect if `enclosed` is enabled.
+        the end bound is excluded. Has no effect if ``enclosed`` is enabled.
 
     Returns
     -------

--- a/pyvista/core/utilities/geometric_objects.py
+++ b/pyvista/core/utilities/geometric_objects.py
@@ -59,7 +59,7 @@ def Capsule(  # noqa: PLR0917
        orients the mesh to a new ``center`` and ``direction``.
 
     .. note::
-       A class:`pyvista.CylinderSource` is used to generate the capsule mesh. For vtk
+       A :class:`pyvista.CylinderSource` is used to generate the capsule mesh. For vtk
        versions below 9.3, a separate ``pyvista.CapsuleSource`` class is used instead.
        The mesh geometries are similar but not identical.
 

--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -1610,8 +1610,9 @@ class MultiBlockPlot3DReader(BaseReader['MultiBlock']):
         """When ``True`` (default), intermediate computed quantities will be preserved.
 
         For example, if ``VelocityMagnitude`` is enabled, but not ``Velocity``, the reader still
-        needs to compute ``Velocity``. If `preserve_intermediate_functions` is ``False``, then the
-        output will not have ``Velocity`` array, only the requested ``VelocityMagnitude``.
+        needs to compute ``Velocity``. If ``preserve_intermediate_functions`` is
+        ``False``, then the output will not have ``Velocity`` array, only the requested
+        ``VelocityMagnitude``.
 
         This is useful to avoid using up memory for arrays that are not relevant for the analysis.
         """
@@ -2688,7 +2689,7 @@ class _GRDECLReader(BaseVTKReader):
         """Update information from file."""
 
     def Update(self) -> None:
-        """Read the GRDECL file and store internally to `_data_object`."""
+        """Read the GRDECL file and store internally to ``_data_object``."""
         self._data_object = _read_grdecl(
             self._filename,
             elevation=self._elevation,
@@ -2774,7 +2775,7 @@ class _GIFReader(BaseVTKReader):
         return self._current_frame / self._n_frames
 
     def Update(self) -> None:
-        """Read the GIF and store internally to `_data_object`."""
+        """Read the GIF and store internally to ``_data_object``."""
         from PIL import Image  # noqa: PLC0415
         from PIL import ImageSequence  # noqa: PLC0415
         from PIL import __version__ as pillow_version  # noqa: PLC0415
@@ -2845,7 +2846,7 @@ class _VRMLReader(BaseVTKReader):
     """Simulate a VTK reader for VRML files."""
 
     def Update(self) -> None:
-        """Read the VRML and store internally to `_data_object`."""
+        """Read the VRML and store internally to ``_data_object``."""
         self._data_object = _read_from_plotter(self._filename, 'vrml')
 
     def UpdateInformation(self):
@@ -2892,7 +2893,7 @@ class _ThreeDSReader(BaseVTKReader):
     """Simulate a VTK reader for 3DS files."""
 
     def Update(self) -> None:
-        """Read the 3DS and store internally to `_data_object`."""
+        """Read the 3DS and store internally to ``_data_object``."""
         self._data_object = _read_from_plotter(self._filename, '3ds')
 
     def UpdateInformation(self):

--- a/pyvista/core/utilities/state_manager.py
+++ b/pyvista/core/utilities/state_manager.py
@@ -31,7 +31,7 @@ class _StateManager(AbstractContextManager[None], ABC, Generic[T]):
 
     Subclasses must:
 
-    - Specify a `Literal` as the subclass' type argument. The literal's
+    - Specify a ``Literal`` as the subclass' type argument. The literal's
       arguments must specify all allowable options for the state variable.
     - Define a getter and setter for the state. Input validation is not
       required - the input is automatically validated when setting the state.
@@ -248,8 +248,8 @@ _VtkSnakeCaseOptions = Literal['allow', 'warning', 'error']
 class _vtkSnakeCase(_StateManager[_VtkSnakeCaseOptions]):  # noqa: N801
     """Context manager to control access to VTK's pythonic snake_case API.
 
-    VTK 9.4 introduced pythonic snake_case attributes, e.g. `output_port` instead
-    of `GetOutputPort`. These can easily be confused for PyVista attributes
+    VTK 9.4 introduced pythonic snake_case attributes, e.g. ``output_port`` instead
+    of ``GetOutputPort``. These can easily be confused for PyVista attributes
     which also use a snake_case convention. This class controls access to vtk's
     new interface.
 
@@ -275,7 +275,7 @@ class _vtkSnakeCase(_StateManager[_VtkSnakeCaseOptions]):  # noqa: N801
     >>> pv.vtk_snake_case()
     'error'
 
-    The following will raise an error because the `information` property is defined
+    The following will raise an error because the ``information`` property is defined
     by :vtk:`vtkDataObject` and is not part of PyVista's API.
 
     >>> # pv.PolyData().information

--- a/pyvista/core/utilities/writer.py
+++ b/pyvista/core/utilities/writer.py
@@ -181,7 +181,7 @@ class BaseWriter(_FileIOBase):
         self._written_path = Path(path)
 
     def _execute_before_write(self) -> None:
-        """Execute code before calling `write()`.
+        """Execute code before calling ``write()``.
 
         Subclasses may optionally define this, e.g. to issue warnings.
         """

--- a/pyvista/examples/_dataset_loader.py
+++ b/pyvista/examples/_dataset_loader.py
@@ -360,7 +360,7 @@ class _SingleFileDatasetLoader(_SingleFile, _DatasetLoader):
         as an argument to the loader.
 
     load_func
-        Specify the function used to load the file. Defaults to `None`. This is typically
+        Specify the function used to load the file. Defaults to ``None``. This is typically
         used to specify any processing of the dataset after reading. The load function
         typically will accept a dataset as an input and return a dataset.
 
@@ -791,7 +791,7 @@ def _format_file_size(size: int) -> str:
 
 
 def _get_file_or_folder_ext(path: str):
-    """Wrap the `get_ext` function to handle special cases for directories."""
+    """Wrap the ``get_ext`` function to handle special cases for directories."""
     if os.path.isfile(path):
         return get_ext(path)
     assert os.path.isdir(path), 'Expected a file or folder path.'

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -306,7 +306,7 @@ def _download_archive_file_or_folder(filename: str, target_file: str | None = No
     """Download an archive.
 
     This function is similar to _download_archive, but also allows
-    setting `target_file` as a folder. The target folder path must be
+    setting ``target_file`` as a folder. The target folder path must be
     fully specified relative to the root path of the archive.
 
     Set ``target_file=''`` (empty string) to download the entire

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -528,8 +528,8 @@ def _run_code(*, code, code_path, ns=None, function_name=None):
     """Run a docstring example.
 
     Run the example if it does not contain ``'doctest:+SKIP'``, or a
-    ```pyvista-plot::`` directive.  In the later case, the doctest parser will
-    present the code-block again with the ```pyvista-plot::`` directive
+    ``pyvista-plot::`` directive.  In the later case, the doctest parser will
+    present the code-block again with the ``pyvista-plot::`` directive
     and its options removed.
 
     Import a Python module from a path, and run the function given by
@@ -582,8 +582,8 @@ def render_figures(
     page for a reader to click through to. *state* is the calling directive's own
     ``self.state``, passed through to sphinx-autocodelink for its own categorization.
     """
-    # We skip snippets that contain the ```pyvista-plot::`` directive as part of their code.
-    # The doctest parser will present the code-block once again with the ```pyvista-plot::``
+    # We skip snippets that contain the ``pyvista-plot::`` directive as part of their code.
+    # The doctest parser will present the code-block once again with the ``pyvista-plot::``
     # directive and its options properly parsed.
     if _contains_pyvista_plot(code):
         is_doctest = True

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -80,7 +80,7 @@ The ``pyvista-plot`` directive supports the following options:
         directive is executed is controlled by the ``pyvista_plot_skip_optional``
         boolean variable in :file:`conf.py`.
 
-Additionally, this directive supports all the options of the `image`
+Additionally, this directive supports all the options of the ``image``
 directive, except for *target* (since plot will add its own target).  These
 include *alt*, *height*, *width*, *scale*, *align*.
 

--- a/pyvista/plotting/__init__.py
+++ b/pyvista/plotting/__init__.py
@@ -111,7 +111,7 @@ from .widgets import WidgetComponent as WidgetComponent
 
 
 class QtDeprecationError(Exception):  # numpydoc ignore=PR01
-    """Deprecation Error for features that moved to `pyvistaqt`."""
+    """Deprecation Error for features that moved to ``pyvistaqt``."""
 
     message = """`{}` has moved to pyvistaqt.
     You can install this from PyPI with: `pip install pyvistaqt`

--- a/pyvista/plotting/_property.py
+++ b/pyvista/plotting/_property.py
@@ -122,9 +122,9 @@ class Property(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkProperty):
         between 0 and 1.
 
         .. note::
-            `edge_opacity` uses ``SetEdgeOpacity`` as the underlying method which
+            ``edge_opacity`` uses ``SetEdgeOpacity`` as the underlying method which
             requires VTK version 9.3 or higher. If ``SetEdgeOpacity`` is not
-            available, `edge_opacity` is set to 1.
+            available, ``edge_opacity`` is set to 1.
 
     Examples
     --------
@@ -463,9 +463,9 @@ class Property(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkProperty):
         edge opacity of the mesh and uniformly applied everywhere. Between 0 and 1.
 
         .. note::
-            `edge_opacity` uses ``SetEdgeOpacity`` as the underlying method which
+            ``edge_opacity`` uses ``SetEdgeOpacity`` as the underlying method which
             requires VTK version 9.3 or higher. If ``SetEdgeOpacity`` is not
-            available, `edge_opacity` is set to 1.
+            available, ``edge_opacity`` is set to 1.
 
         Examples
         --------

--- a/pyvista/plotting/axes_assembly.py
+++ b/pyvista/plotting/axes_assembly.py
@@ -2150,7 +2150,7 @@ class PlanesAssembly(_XYZAssembly):
     def label_edge(self) -> tuple[str, str, str]:  # numpydoc ignore=RT01
         """Edge on which to position each plane's label.
 
-        Edge can be ``'top'``,``'bottom'``,``'right'``, or ``'left'``, and can be
+        Edge can be ``'top'``, ``'bottom'``, ``'right'``, or ``'left'``, and can be
         set independently for each plane or to the same edge for all planes.
 
         The edge is relative to each plane's local ``i`` and ``j`` coordinates.

--- a/pyvista/plotting/colors.py
+++ b/pyvista/plotting/colors.py
@@ -2408,7 +2408,7 @@ def color_scheme_to_cycler(scheme):
     Raises
     ------
     ValueError
-        If the provided `scheme` is not a valid color scheme.
+        If the provided ``scheme`` is not a valid color scheme.
 
     """
     if not isinstance(scheme, _vtk.vtkColorSeries):

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -1093,9 +1093,9 @@ class _DataSetMapper(_BaseMapper):
         z-buffer resolution (and hence rendering problems).
 
         If not off, there are two methods to choose from.
-        `polygon_offset` uses graphics systems calls to shift polygons,
+        ``polygon_offset`` uses graphics systems calls to shift polygons,
         lines, and points from each other.
-        `shift_zbuffer` is a legacy method that is used to remap the z-buffer
+        ``shift_zbuffer`` is a legacy method that is used to remap the z-buffer
         to distinguish vertices, lines, and polygons,
         but does not always produce acceptable results.
         You should only use the polygon_offset method (or none) at this point.
@@ -1104,7 +1104,7 @@ class _DataSetMapper(_BaseMapper):
         -------
         str
             Global flag to avoid z-buffer resolution.
-            Must be either `off`, `polygon_offset` or `shift_zbuffer`.
+            Must be either ``off``, ``polygon_offset`` or ``shift_zbuffer``.
 
         Examples
         --------

--- a/pyvista/plotting/plot_compare.py
+++ b/pyvista/plotting/plot_compare.py
@@ -161,11 +161,11 @@ def _fix_clipping_range_on_render(
     """Reset the clipping range to the given bounds before every future render.
 
     Linked renderers share one camera but not one clipping range: an interactor style
-    narrows the range before every render it drives, from `ComputeVisiblePropBounds`
+    narrows the range before every render it drives, from ``ComputeVisiblePropBounds``
     of whichever renderer the interaction is in, which is one subplot's worth of
     bounds where every subplot needs fitting. Undo that here, every time, from the
     same bounds the camera itself was fit to, rather than from an actor standing in
-    for them, which would leave `renderer.bounds` itself, and anything that relies on
+    for them, which would leave ``renderer.bounds`` itself, and anything that relies on
     it, reporting more than what is actually in each subplot.
     """
     # The render window holds this callback for as long as it lives, so hold nothing of

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -3056,9 +3056,9 @@ class BasePlotter(_BoundsSizeMixin):
             between 0 and 1.
 
             .. note::
-                `edge_opacity` uses ``SetEdgeOpacity`` as the underlying method which
+                ``edge_opacity`` uses ``SetEdgeOpacity`` as the underlying method which
                 requires VTK version 9.3 or higher. If ``SetEdgeOpacity`` is not
-                available, `edge_opacity` is set to 1.
+                available, ``edge_opacity`` is set to 1.
 
         force_opaque : bool, default: False
             Whether to force the returned actor to be opaque. Can be useful for web visualization
@@ -3720,9 +3720,9 @@ class BasePlotter(_BoundsSizeMixin):
             between 0 and 1.
 
             .. note::
-                `edge_opacity` uses ``SetEdgeOpacity`` as the underlying method which
+                ``edge_opacity`` uses ``SetEdgeOpacity`` as the underlying method which
                 requires VTK version 9.3 or higher. If ``SetEdgeOpacity`` is not
-                available, `edge_opacity` is set to 1.
+                available, ``edge_opacity`` is set to 1.
 
         remove_existing_actor : bool, optional
             Remove any existing actor in the renderer with the same name before adding
@@ -3829,7 +3829,7 @@ class BasePlotter(_BoundsSizeMixin):
         ...     show_scalar_bar=False,
         ... )
 
-        Plot spheres using `points_gaussian` style and scale them by radius.
+        Plot spheres using ``'points_gaussian'`` style and scale them by radius.
 
         >>> N_SPHERES = 1_000_000
         >>> rng = np.random.default_rng(seed=0)
@@ -5539,7 +5539,7 @@ class BasePlotter(_BoundsSizeMixin):
 
         font : str, default: 'arial'
             Font name may be ``'courier'``, ``'times'``, or ``'arial'``.
-            This is ignored if the `font_file` is set.
+            This is ignored if the ``font_file`` is set.
 
         shadow : bool, default: False
             Adds a black shadow to the text.
@@ -6156,7 +6156,7 @@ class BasePlotter(_BoundsSizeMixin):
 
         font_family : str, optional
             Font family.  Must be either ``'courier'``, ``'times'``,
-            or ``'arial``. This is ignored if the `font_file` is set.
+            or ``'arial'``. This is ignored if the ``font_file`` is set.
 
         font_file : str, default: None
             The absolute file path to a local file containing a freetype

--- a/pyvista/plotting/render_window_interactor.py
+++ b/pyvista/plotting/render_window_interactor.py
@@ -44,7 +44,7 @@ class Timer(_NoNewAttrMixin):
         Maximum number of steps to allow for the timer before destroying it.
 
     callback : callable
-        A callable that takes one argument. It will be passed `step`,
+        A callable that takes one argument. It will be passed ``step``,
         which is the number of times the timer event has occurred.
 
     """
@@ -188,7 +188,7 @@ class RenderWindowInteractor(_NoNewAttrMixin):
 
         callback : callable
             A callable that takes one argument. It will be passed
-            `step`, which is the number of times the timer event has occurred.
+            ``step``, which is the number of times the timer event has occurred.
 
         Examples
         --------

--- a/pyvista/plotting/renderers.py
+++ b/pyvista/plotting/renderers.py
@@ -782,7 +782,7 @@ class Renderers(_NoNewAttrMixin):
         0/1 viewport boundary -- the render window's edge -- where VTK's
         2D rasterizer clips away roughly half of a line's width. They're
         drawn from a separate actor at double the requested width to
-        compensate, so the frame actually renders at `border_width`,
+        compensate, so the frame actually renders at ``border_width``,
         matching any interior seams drawn at the same nominal width.
         Two actors are only needed when both kinds of segment are
         present; either alone still uses one.

--- a/pyvista/plotting/themes.py
+++ b/pyvista/plotting/themes.py
@@ -2003,9 +2003,9 @@ class Theme(_ConfigBase):
         """Return or set the edges opacity.
 
         .. note::
-            `edge_opacity` uses ``SetEdgeOpacity`` as the underlying method which
+            ``edge_opacity`` uses ``SetEdgeOpacity`` as the underlying method which
             requires VTK version 9.3 or higher. If ``SetEdgeOpacity`` is not
-            available, `edge_opacity` is set to 1.
+            available, ``edge_opacity`` is set to 1.
 
         Examples
         --------

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -1344,7 +1344,7 @@ class WidgetComponent(_NoNewAttrMixin):
         Examples
         --------
         Shows an interactive line widget to move the sliced object
-        like in `add_mesh_slice` function.
+        like in ``add_mesh_slice`` function.
 
         >>> import pyvista as pv
         >>> from pyvista import examples

--- a/pyvista/typing/mypy_plugin.py
+++ b/pyvista/typing/mypy_plugin.py
@@ -24,7 +24,7 @@ def promote_type(*types: type[Any]) -> Callable[[T], T]:  # noqa: ARG001
     """Duck-type type-promotion decorator used by the mypy plugin.
 
     Apply this decorator to a class to promote its type statically.
-    This tells `mypy` to treat the decorated class as though it's
+    This tells ``mypy`` to treat the decorated class as though it's
     equivalent to another class.
 
     .. note::
@@ -51,7 +51,7 @@ if importlib.util.find_spec('mypy'):  # pragma: no cover
     from mypy.plugin import Plugin
 
     def _promote_type_callback(ctx: ClassDefContext) -> None:
-        """Apply the `promote_type` decorator.
+        """Apply the ``promote_type`` decorator.
 
         The decorated class is captured and promoted to the type(s) provided
         by the decorator's argument(s).

--- a/tests/core/test_cells.py
+++ b/tests/core/test_cells.py
@@ -993,7 +993,7 @@ requires_polyhedron_face_cell_arrays = pytest.mark.skipif(
 def polyhedron_grid():
     """Return a grid holding one polyhedron and one cell that is not a polyhedron.
 
-    Built from literal arrays rather than by merging two example cells. `merge` appends
+    Built from literal arrays rather than by merging two example cells. ``merge`` appends
     the main mesh last before VTK 9.5 and first from 9.5 on, so a merged grid orders its
     cells and numbers its points differently depending on the VTK in use.
     """

--- a/tests/core/test_dataobject_filters.py
+++ b/tests/core/test_dataobject_filters.py
@@ -764,7 +764,7 @@ def test_sample():
     data_to_probe = examples.load_uniform()
 
     def sample_test(**kwargs):
-        """Test `sample` with kwargs."""
+        """Test ``sample`` with kwargs."""
         result = mesh.sample(data_to_probe, **kwargs)
         name = 'Spatial Point Data'
         assert name in result.array_names

--- a/tests/doc/doc_build/conftest.py
+++ b/tests/doc/doc_build/conftest.py
@@ -14,9 +14,9 @@ _THIS_DIR = Path(__file__).parent
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Auto-apply `needs_doc_build` to every test collected under this directory.
+    """Auto-apply ``needs_doc_build`` to every test collected under this directory.
 
-    `items` covers the whole session, not just this directory, since collection
+    ``items`` covers the whole session, not just this directory, since collection
     hooks aren't scoped to the conftest.py that defines them.
     """
     for item in items:

--- a/tests/doc/doc_build/test_docstring_navbar.py
+++ b/tests/doc/doc_build/test_docstring_navbar.py
@@ -1,7 +1,7 @@
 """Test that docstring sections are hoisted into the "on this page" navbar.
 
-`conf.py` patches numpydoc to emit real headings instead of rubrics, then hoists
-those sections out of the autodoc `desc` node so Sphinx's TocTreeCollector can see
+``conf.py`` patches numpydoc to emit real headings instead of rubrics, then hoists
+those sections out of the autodoc ``desc`` node so Sphinx's TocTreeCollector can see
 them. Both halves are needed, and neither fails loudly if it breaks -- the navbar
 entries just silently disappear.
 """
@@ -65,7 +65,7 @@ def test_hoisted_sections_are_not_rubrics():
 
 
 def test_multi_object_page_does_not_hoist_sections():
-    """Confirm pages documenting several objects via `:members:` skip hoisting."""
+    """Confirm pages documenting several objects via ``:members:`` skip hoisting."""
     # `helpers.rst` documents several objects on one page via `:members:`, so
     # hoisting is skipped there to avoid colliding sections at page level.
     page = Path(BUILD_HTML_DIR) / 'api' / 'core' / 'helpers.html'

--- a/tests/doc/doc_build/test_gallery_examples.py
+++ b/tests/doc/doc_build/test_gallery_examples.py
@@ -207,7 +207,7 @@ _EXAMPLE_HREF_RE = re.compile(r'href="([^"]*/examples/[^"]*)"')
 
 
 def _example_hrefs(blocks: list[str]) -> set[str]:
-    """Return the basename (fragment stripped) of every example page linked from `blocks`."""
+    """Return the basename (fragment stripped) of every example page linked from ``blocks``."""
     hrefs = (href for block in blocks for href in _EXAMPLE_HREF_RE.findall(block))
     return {Path(href.split('#')[0]).name for href in hrefs}
 

--- a/tests/doc/doc_build/test_section_headings.py
+++ b/tests/doc/doc_build/test_section_headings.py
@@ -4,14 +4,14 @@ Three independent mechanisms feed into this, none of which fail loudly if they
 regress -- the section just silently reverts to an unlinkable rubric or
 admonition, or disappears from the "on this page" navbar:
 
-- `_str_header` patches numpydoc to emit real headings (not `.. rubric::`) for
-  sections like Examples, and `hoist_docstring_sections` lifts those out of the
-  `desc` node they're generated inside, to page level.
-- `promote_seealso_admonitions` additionally turns a literal `.. seealso::`
+- ``_str_header`` patches numpydoc to emit real headings (not ``.. rubric::``) for
+  sections like Examples, and ``hoist_docstring_sections`` lifts those out of the
+  ``desc`` node they're generated inside, to page level.
+- ``promote_seealso_admonitions`` additionally turns a literal ``.. seealso::``
   admonition -- written directly in a docstring instead of using numpydoc's own
-  "See Also" syntax, as `pyvista.examples.downloads` does -- into a real section
+  "See Also" syntax, as ``pyvista.examples.downloads`` does -- into a real section
   before the hoist above runs.
-- `doc/source/_templates/autosummary/class.rst` renders "Methods" and
+- ``doc/source/_templates/autosummary/class.rst`` renders "Methods" and
   "Attributes" as real page-level headings directly in the class page template,
   outside the docstring entirely.
 """
@@ -51,13 +51,13 @@ def find_api_page(filename: str) -> Path:
 
 
 def assert_is_real_heading(html: str, name: str) -> None:
-    """Assert `name` renders as a real ``<h2>`` heading, not a rubric."""
+    """Assert ``name`` renders as a real ``<h2>`` heading, not a rubric."""
     assert f'<p class="rubric">{name}</p>' not in html
     assert f'<h2>{name}' in html
 
 
 def heading_index(html: str, name: str) -> int:
-    """Return the position of `name`'s real heading in the page."""
+    """Return the position of ``name``'s real heading in the page."""
     return html.index(f'<h2>{name}')
 
 

--- a/tests/plotting/test_cli.py
+++ b/tests/plotting/test_cli.py
@@ -34,7 +34,7 @@ def test_plot(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """
-    Test a real call to `pv.plot` using CLI and compare images to a Plotter output.
+    Test a real call to :func:`pyvista.plot` using CLI and compare images to a Plotter output.
     """
     monkeypatch.setenv('PYVISTA_PLOT_THEME', 'testing')
 

--- a/tests/plotting/test_cli.py
+++ b/tests/plotting/test_cli.py
@@ -34,7 +34,7 @@ def test_plot(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """
-    Test a real call to :func:`pyvista.plot` using CLI and compare images to a Plotter output.
+    Test a real call to ``pyvista.plot`` using CLI and compare images to a Plotter output.
     """
     monkeypatch.setenv('PYVISTA_PLOT_THEME', 'testing')
 

--- a/tests/plotting/test_picking.py
+++ b/tests/plotting/test_picking.py
@@ -54,7 +54,7 @@ def test_single_cell_picking():
 
 
 def test_picked_cells_attribute():
-    """Test the `picked_cells` attribute when selecting through multiple cells."""
+    """Test the ``picked_cells`` attribute when selecting through multiple cells."""
 
     pl = pv.Plotter()
     pl.add_mesh(pv.Sphere(), pickable=True)

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -1027,7 +1027,7 @@ def test_off_screen_background_thread_rendering():
     """Off-screen plotters must work on background threads.
 
     On macOS, vtkCocoaRenderWindow creates an NSWindow by default which
-    requires the main thread. `SetConnectContextToNSView(False)` creates
+    requires the main thread. ``SetConnectContextToNSView(False)`` creates
     a standalone CGL context instead. On Linux (EGL), background thread
     rendering works out of the box.
     """

--- a/tests/plotting/test_text.py
+++ b/tests/plotting/test_text.py
@@ -287,7 +287,7 @@ def test_add_text_actor_named_position(position):
 
 
 def test_add_text_actor_font_size_matches_add_text():
-    """Test that a font size means the same to this as it does to `add_text`."""
+    """Test that a font size means the same to this as it does to ``add_text``."""
     pl = pv.Plotter()
     drawn = pl.add_text('text', position=(10, 10), font_size=24)
     named = pl._add_text_actor('text', position='upper_left', font_size=24)

--- a/tests/plotting/test_widgets.py
+++ b/tests/plotting/test_widgets.py
@@ -949,7 +949,7 @@ def test_clear_camera3d_widget():
 
 
 class TestEventParser:
-    """Class to regroup tests for widgets that use the  `_parse_interaction_event()` function"""
+    """Class to regroup tests for widgets that use the  ``_parse_interaction_event()`` function"""
 
     @pytest.fixture
     def plotter(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -238,7 +238,7 @@ def test_report_called(
 
 
 class CasesConvert:
-    """CLI argument parsing cases for `convert`."""
+    """CLI argument parsing cases for ``convert``."""
 
     def case_new_ext(self):
         return 'ant.ply new.vtp', 'new.vtp'
@@ -1049,8 +1049,9 @@ _CLI_ONLY_PARAMS = {'skip_unreadable', 'paths', 'static'}
 
 @fixture
 def missing_plot_arguments():
-    """Argument names in the `pv.plot` signature which are intentionally removed from the
-    `pv.cli.plot._plot` function."""
+    """Argument names in the :func:`pyvista.plot` signature which are intentionally
+    removed from the ``pv.cli.plot._plot`` function.
+    """
     return {
         'jupyter_backend',
         'return_viewer',
@@ -1064,7 +1065,7 @@ def missing_plot_arguments():
 
 @fixture
 def default_plot_kwargs(missing_plot_arguments: set[str]) -> dict[str, Any]:
-    """Default arguments of `pv.plot`."""
+    """Default arguments of :func:`pyvista.plot`."""
     params = inspect.signature(pv.plot).parameters
     return {
         p: v.default
@@ -1077,9 +1078,9 @@ def default_plot_kwargs(missing_plot_arguments: set[str]) -> dict[str, Any]:
 
 def test_plot_cli_synced(missing_plot_arguments: set[str]):
     """
-    Since the `pyvista plot` CLI exposes a subset of the original `pv.plot` arguments,
-    any changes made in the signature of `pv.plot` must be synced (or not) in the
-    `pyvista plot` CLI.
+    Since the ``pyvista plot`` CLI exposes a subset of the original :func:`pyvista.plot` arguments,
+    any changes made in the signature of :func:`pyvista.plot` must be synced (or not) in the
+    ``pyvista plot`` CLI.
 
     This test will fail if any:
     - argument names
@@ -1159,8 +1160,8 @@ _CLI_ONLY_COMPARE_PARAMS = {'skip_unreadable', 'paths', 'static', 'outline'}
 
 @fixture
 def missing_compare_arguments():
-    """Argument names in the `pv.plot_compare` signature which are intentionally removed
-    from the `pv.cli.compare._compare` function."""
+    """Argument names in the :func:`pyvista.plot_compare` signature which are intentionally removed
+    from the ``pv.cli.compare._compare`` function."""
     return {
         'jupyter_backend',
         'jupyter_kwargs',
@@ -1177,9 +1178,9 @@ def missing_compare_arguments():
 
 def test_compare_cli_synced(missing_compare_arguments: set[str]):
     """
-    Since the `pyvista compare` CLI exposes a subset of the original `pv.plot_compare`
-    arguments, any changes made in the signature of `pv.plot_compare` must be synced (or
-    not) in the `pyvista compare` CLI.
+    Since the ``pyvista compare`` CLI exposes a subset of the original :func:`pyvista.plot_compare`
+    arguments, any changes made in the signature of :func:`pyvista.plot_compare` must be synced (or
+    not) in the ``pyvista compare`` CLI.
 
     This test will fail if any:
     - argument names
@@ -2098,7 +2099,9 @@ def test_compare_forwards_arguments(
     argument: str,
     expected: Any,
 ):
-    """Test that each argument of the command reaches `plot_compare` as it is spelled there."""
+    """Test that each argument of the command reaches :func:`pyvista.plot_compare` as
+    it is spelled there.
+    """
     names = ' '.join(path.name for path in tmp_compare_files)
     main(shlex.split(f'compare {names} {tokens}'))
 
@@ -2237,7 +2240,7 @@ def test_compare_too_small_warning_advises_the_command(
 ):
     """Test that the advice for a barely visible mesh names the options of this command.
 
-    `plot_compare` suggests its own arguments, which are not the ones a command line
+    :func:`pyvista.plot_compare` suggests its own arguments, which are not the ones a command line
     user has to hand: the outline is drawn by this command rather than given to it.
     """
     for name, mesh in [('tiny', pv.Sphere(radius=0.02)), ('huge', pv.Cone(height=5.0))]:
@@ -2263,10 +2266,10 @@ def test_compare_too_small_warning_is_printed_before_the_plot_is_shown(
 ):
     """Test that the advice is printed before the window opens, not after it closes.
 
-    `plot_compare` raises every one of its warnings well before it shows the window,
+    :func:`pyvista.plot_compare` raises every one of its warnings well before it shows the window,
     but the interactive window blocks until it is closed, and warnings only caught
-    with `warnings.catch_warnings(record=True)` are not printed until whoever caught
-    them chooses to. Printing them only after `show` returns would leave a command
+    with ``warnings.catch_warnings(record=True)`` are not printed until whoever caught
+    them chooses to. Printing them only after ``show`` returns would leave a command
     line user staring at a plot with no idea anything was wrong until they closed it.
     """
     for name, mesh in [('tiny', pv.Sphere(radius=0.02)), ('huge', pv.Cone(height=5.0))]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1049,7 +1049,7 @@ _CLI_ONLY_PARAMS = {'skip_unreadable', 'paths', 'static'}
 
 @fixture
 def missing_plot_arguments():
-    """Argument names in the :func:`pyvista.plot` signature which are intentionally
+    """Argument names in the ``pyvista.plot`` signature which are intentionally
     removed from the ``pv.cli.plot._plot`` function.
     """
     return {
@@ -1065,7 +1065,7 @@ def missing_plot_arguments():
 
 @fixture
 def default_plot_kwargs(missing_plot_arguments: set[str]) -> dict[str, Any]:
-    """Default arguments of :func:`pyvista.plot`."""
+    """Default arguments of ``pyvista.plot``."""
     params = inspect.signature(pv.plot).parameters
     return {
         p: v.default
@@ -1078,8 +1078,8 @@ def default_plot_kwargs(missing_plot_arguments: set[str]) -> dict[str, Any]:
 
 def test_plot_cli_synced(missing_plot_arguments: set[str]):
     """
-    Since the ``pyvista plot`` CLI exposes a subset of the original :func:`pyvista.plot` arguments,
-    any changes made in the signature of :func:`pyvista.plot` must be synced (or not) in the
+    Since the ``pyvista plot`` CLI exposes a subset of the original ``pyvista.plot`` arguments,
+    any changes made in the signature of ``pyvista.plot`` must be synced (or not) in the
     ``pyvista plot`` CLI.
 
     This test will fail if any:
@@ -1160,7 +1160,7 @@ _CLI_ONLY_COMPARE_PARAMS = {'skip_unreadable', 'paths', 'static', 'outline'}
 
 @fixture
 def missing_compare_arguments():
-    """Argument names in the :func:`pyvista.plot_compare` signature which are intentionally removed
+    """Argument names in the ``pyvista.plot_compare`` signature which are intentionally removed
     from the ``pv.cli.compare._compare`` function."""
     return {
         'jupyter_backend',
@@ -1178,8 +1178,8 @@ def missing_compare_arguments():
 
 def test_compare_cli_synced(missing_compare_arguments: set[str]):
     """
-    Since the ``pyvista compare`` CLI exposes a subset of the original :func:`pyvista.plot_compare`
-    arguments, any changes made in the signature of :func:`pyvista.plot_compare` must be synced (or
+    Since the ``pyvista compare`` CLI exposes a subset of the original ``pyvista.plot_compare``
+    arguments, any changes made in the signature of ``pyvista.plot_compare`` must be synced (or
     not) in the ``pyvista compare`` CLI.
 
     This test will fail if any:
@@ -2099,7 +2099,7 @@ def test_compare_forwards_arguments(
     argument: str,
     expected: Any,
 ):
-    """Test that each argument of the command reaches :func:`pyvista.plot_compare` as
+    """Test that each argument of the command reaches ``pyvista.plot_compare`` as
     it is spelled there.
     """
     names = ' '.join(path.name for path in tmp_compare_files)
@@ -2240,7 +2240,7 @@ def test_compare_too_small_warning_advises_the_command(
 ):
     """Test that the advice for a barely visible mesh names the options of this command.
 
-    :func:`pyvista.plot_compare` suggests its own arguments, which are not the ones a command line
+    ``pyvista.plot_compare`` suggests its own arguments, which are not the ones a command line
     user has to hand: the outline is drawn by this command rather than given to it.
     """
     for name, mesh in [('tiny', pv.Sphere(radius=0.02)), ('huge', pv.Cone(height=5.0))]:
@@ -2266,7 +2266,7 @@ def test_compare_too_small_warning_is_printed_before_the_plot_is_shown(
 ):
     """Test that the advice is printed before the window opens, not after it closes.
 
-    :func:`pyvista.plot_compare` raises every one of its warnings well before it shows the window,
+    ``pyvista.plot_compare`` raises every one of its warnings well before it shows the window,
     but the interactive window blocks until it is closed, and warnings only caught
     with ``warnings.catch_warnings(record=True)`` are not printed until whoever caught
     them chooses to. Printing them only after ``show`` returns would leave a command

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -60,7 +60,7 @@ def results_parser(monkeypatch: pytest.MonkeyPatch):
     It enables to get the test name (last part of the test path)
     as well as the status.
 
-    Results can be passed to the `RunResultsReport` class to better interact
+    Results can be passed to the ``RunResultsReport`` class to better interact
     with them.
     """
     monkeypatch.setenv('PYTEST_ADDOPTS', '-v')

--- a/toxfile.py
+++ b/toxfile.py
@@ -75,11 +75,11 @@ def tox_on_install(  # noqa: PLR0917
     of_type: str,
 ) -> None:
     """Before installing:
-    * save environment `deps` to a constraints file
-    * apply constraints file during `install_package_deps` step.
+    * save environment ``deps`` to a constraints file
+    * apply constraints file during ``install_package_deps`` step.
 
     This is needed since dependencies installed in subsequent steps (eg. `dependency-groups`) may
-    override the `deps` ones.
+    override the ``deps`` ones.
     See https://github.com/pyvista/pyvista/issues/8635.
 
     Mostly inspired by https://github.com/tox-dev/tox/issues/2386#issuecomment-1396105380
@@ -117,7 +117,7 @@ def _get_freezed_requirements(lines: list[str]) -> Generator[tuple[str, Version]
 
 @impl
 def tox_before_run_commands(tox_env: ToxEnv) -> None:
-    """Check that deps declared in the constraints_file (ie. during the `deps` step above)
+    """Check that deps declared in the constraints_file (ie. during the ``deps`` step above)
     are indeed installed in the environment before running the tests using a freeze command.
     """  # noqa: D205
     # Load requirements from the constraints file

--- a/toxfile.py
+++ b/toxfile.py
@@ -75,11 +75,11 @@ def tox_on_install(  # noqa: PLR0917
     of_type: str,
 ) -> None:
     """Before installing:
-    * save environment ``deps`` to a constraints file
-    * apply constraints file during ``install_package_deps`` step.
+    * save environment `deps` to a constraints file
+    * apply constraints file during `install_package_deps` step.
 
     This is needed since dependencies installed in subsequent steps (eg. `dependency-groups`) may
-    override the ``deps`` ones.
+    override the `deps` ones.
     See https://github.com/pyvista/pyvista/issues/8635.
 
     Mostly inspired by https://github.com/tox-dev/tox/issues/2386#issuecomment-1396105380
@@ -117,7 +117,7 @@ def _get_freezed_requirements(lines: list[str]) -> Generator[tuple[str, Version]
 
 @impl
 def tox_before_run_commands(tox_env: ToxEnv) -> None:
-    """Check that deps declared in the constraints_file (ie. during the ``deps`` step above)
+    """Check that deps declared in the constraints_file (ie. during the `deps` step above)
     are indeed installed in the environment before running the tests using a freeze command.
     """  # noqa: D205
     # Load requirements from the constraints file


### PR DESCRIPTION
## Summary

Audited docstrings across `pyvista/`, `doc/`, `examples/`, and `tests/` for RST backtick formatting mistakes and fixed them in two passes.

- Punctuation trapped inside a literal (`` ``2,`` `` → `` ``2`` ``), missing spaces between adjacent literals, asymmetric backtick counts, and a couple of small typos found along the way (a missing leading colon on a `:class:` role, an unclosed `` ``'arial` `` pair, `MultiBock` → `MultiBlock`).
- Every single-backtick span left in docstrings was reviewed individually: plain-English emphasis words (`not`, `any`, `before`, ...) were left alone; code identifiers/values were wrapped in proper double backticks; references to public top-level functions (`pyvista.plot`, `pyvista.plot_compare`, `pyvista.voxelize`) were converted to `:func:`/`:class:` cross-refs instead. Backticks inside Python comments (not docstrings) were left untouched.

- `pre-commit run --all-files` (ruff, numpydoc-validation, the `rst-*` hooks, etc.) passes on the changed files.
- No behavior change; docs/docstrings only.