### PR TITLE
Fix EGL check for Qt (which could use X)

### DIFF
--- a/pyvista/plotting/utilities/gl_checks.py
+++ b/pyvista/plotting/utilities/gl_checks.py
@@ -4,9 +4,61 @@ from __future__ import annotations
 
 import functools
 import os
+import sys
 
 from pyvista import _vtk
 from pyvista.plotting.tools import _prepare_offscreen_macos_render_window
+
+
+def _qt_platform_name() -> str | None:
+    """Return the platform name of a live Qt application, if there is one.
+
+    Only bindings that are *already imported* are consulted: this must never
+    import Qt, and must never construct an application.
+
+    Returns
+    -------
+    str | None
+        The platform Qt actually connected to, or ``None`` when no Qt
+        application is running in this process.
+
+    """
+    for module_name in ('PySide6.QtGui', 'PyQt6.QtGui', 'PySide2.QtGui', 'PyQt5.QtGui'):
+        # getattr rather than an import, and tolerant of a module that is in
+        # sys.modules but still initializing
+        qgui = getattr(sys.modules.get(module_name), 'QGuiApplication', None)
+        if qgui is None:
+            continue
+        app = qgui.instance()
+        if app is not None:
+            return str(app.platformName())
+    return None
+
+
+def _process_uses_egl() -> bool:
+    """Return whether this process draws through EGL rather than GLX.
+
+    ``WAYLAND_DISPLAY`` only says a Wayland compositor is running, not that
+    *this* process talks to it: ``QT_QPA_PLATFORM=xcb`` runs a Qt application
+    through XWayland inside a Wayland session, and then its OpenGL is GLX. An
+    EGL render window cannot make its context current in such a process, so
+    every render through it logs ``Unable to eglMakeCurrent`` with
+    ``EGL_BAD_ACCESS`` (pyvista/pyvistaqt#445 follow-up).
+
+    A running Qt application is authoritative, since it is the thing that did
+    or did not connect to the compositor. Without one, the session variable is
+    all there is to go on.
+
+    Returns
+    -------
+    bool
+        ``True`` when this process's OpenGL goes through EGL.
+
+    """
+    platform_name = _qt_platform_name()
+    if platform_name is not None:
+        return platform_name.startswith('wayland')
+    return bool(os.environ.get('WAYLAND_DISPLAY'))
 
 
 def _offscreen_probe_render_window():
@@ -28,7 +80,7 @@ def _offscreen_probe_render_window():
     """
     if (
         not os.environ.get('VTK_DEFAULT_OPENGL_WINDOW')
-        and os.environ.get('WAYLAND_DISPLAY')
+        and _process_uses_egl()
         and _vtk.has_attr('vtkEGLRenderWindow')
     ):
         return _vtk.vtkEGLRenderWindow()
@@ -92,7 +144,7 @@ def uses_egl() -> bool:
         otherwise ``False``.
 
     """
-    if os.environ.get('WAYLAND_DISPLAY'):
+    if _process_uses_egl():
         # Instantiating the factory-default render window is not safe here:
         # constructing (and destroying) the default GLX-based window aborts a
         # process that already uses EGL, e.g. a Qt application running on the

--- a/pyvista/plotting/utilities/gl_checks.py
+++ b/pyvista/plotting/utilities/gl_checks.py
@@ -9,6 +9,9 @@ import sys
 from pyvista import _vtk
 from pyvista.plotting.tools import _prepare_offscreen_macos_render_window
 
+# Qt GUI modules that would expose a live QGuiApplication, newest binding first
+_QT_GUI_MODULES = ('PySide6.QtGui', 'PyQt6.QtGui', 'PySide2.QtGui', 'PyQt5.QtGui')
+
 
 def _qt_platform_name() -> str | None:
     """Return the platform name of a live Qt application, if there is one.
@@ -23,7 +26,7 @@ def _qt_platform_name() -> str | None:
         application is running in this process.
 
     """
-    for module_name in ('PySide6.QtGui', 'PyQt6.QtGui', 'PySide2.QtGui', 'PyQt5.QtGui'):
+    for module_name in _QT_GUI_MODULES:
         # getattr rather than an import, and tolerant of a module that is in
         # sys.modules but still initializing
         qgui = getattr(sys.modules.get(module_name), 'QGuiApplication', None)

--- a/tests/plotting/test_plotting_utilities.py
+++ b/tests/plotting/test_plotting_utilities.py
@@ -16,6 +16,7 @@ from pyvista import examples
 from pyvista.plotting._plotting import _resolve_scalars_field
 from pyvista.plotting._plotting import reduce_component_scalars
 from pyvista.plotting.helpers import view_vectors
+from pyvista.plotting.utilities.gl_checks import _QT_GUI_MODULES
 from pyvista.plotting.utilities.gl_checks import _offscreen_probe_render_window
 from pyvista.plotting.utilities.gl_checks import _process_uses_egl
 from pyvista.plotting.utilities.gl_checks import _qt_platform_name
@@ -324,7 +325,7 @@ def _fake_binding(monkeypatch, module_name, platform_name):
     monkeypatch.setitem(sys.modules, module_name, module)
 
 
-@pytest.mark.parametrize('module_name', ['PySide6.QtGui', 'PyQt6.QtGui', 'PyQt5.QtGui'])
+@pytest.mark.parametrize('module_name', _QT_GUI_MODULES)
 def test_qt_platform_name(monkeypatch, module_name):
     """A live Qt application reports the platform it actually connected to."""
     _fake_binding(monkeypatch, module_name, 'xcb')
@@ -333,9 +334,9 @@ def test_qt_platform_name(monkeypatch, module_name):
 
 def test_qt_platform_name_no_application(monkeypatch):
     """An imported binding with no application running answers nothing."""
-    _fake_binding(monkeypatch, 'PySide6.QtGui', None)
-    for name in ('PyQt6.QtGui', 'PySide2.QtGui', 'PyQt5.QtGui'):
+    for name in _QT_GUI_MODULES[1:]:
         monkeypatch.delitem(sys.modules, name, raising=False)
+    _fake_binding(monkeypatch, _QT_GUI_MODULES[0], None)
     assert _qt_platform_name() is None
 
 
@@ -359,10 +360,10 @@ def test_process_uses_egl(monkeypatch, wayland_display, platform_name, expected)
     monkeypatch.delenv('WAYLAND_DISPLAY', raising=False)
     if wayland_display is not None:
         monkeypatch.setenv('WAYLAND_DISPLAY', wayland_display)
-    for name in ('PySide6.QtGui', 'PyQt6.QtGui', 'PySide2.QtGui', 'PyQt5.QtGui'):
+    for name in _QT_GUI_MODULES:
         monkeypatch.delitem(sys.modules, name, raising=False)
     if platform_name is not None:
-        _fake_binding(monkeypatch, 'PySide6.QtGui', platform_name)
+        _fake_binding(monkeypatch, _QT_GUI_MODULES[0], platform_name)
     assert _process_uses_egl() is expected
 
 
@@ -377,8 +378,8 @@ def test_offscreen_probe_follows_qt_platform(monkeypatch):
     if not pv._vtk.has_attr('vtkEGLRenderWindow'):
         pytest.skip('VTK build lacks vtkEGLRenderWindow')
 
-    _fake_binding(monkeypatch, 'PySide6.QtGui', 'xcb')
+    _fake_binding(monkeypatch, _QT_GUI_MODULES[0], 'xcb')
     assert not isinstance(_offscreen_probe_render_window(), pv._vtk.vtkEGLRenderWindow)
 
-    _fake_binding(monkeypatch, 'PySide6.QtGui', 'wayland')
+    _fake_binding(monkeypatch, _QT_GUI_MODULES[0], 'wayland')
     assert isinstance(_offscreen_probe_render_window(), pv._vtk.vtkEGLRenderWindow)

--- a/tests/plotting/test_plotting_utilities.py
+++ b/tests/plotting/test_plotting_utilities.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+import sys
+from types import ModuleType
 from unittest.mock import Mock
 
 import numpy as np
@@ -15,6 +17,8 @@ from pyvista.plotting._plotting import _resolve_scalars_field
 from pyvista.plotting._plotting import reduce_component_scalars
 from pyvista.plotting.helpers import view_vectors
 from pyvista.plotting.utilities.gl_checks import _offscreen_probe_render_window
+from pyvista.plotting.utilities.gl_checks import _process_uses_egl
+from pyvista.plotting.utilities.gl_checks import _qt_platform_name
 from pyvista.plotting.utilities.gl_checks import uses_egl
 from pyvista.report import GPUInfo
 from pyvista.report import _get_render_window_class
@@ -302,3 +306,79 @@ def test_uses_egl_wayland(monkeypatch):
     assert uses_egl() is True
     monkeypatch.setenv('VTK_DEFAULT_OPENGL_WINDOW', 'vtkXOpenGLRenderWindow')
     assert uses_egl() is False
+
+
+class _FakeApp:
+    def __init__(self, platform_name):
+        self._platform_name = platform_name
+
+    def platformName(self):  # noqa: N802
+        return self._platform_name
+
+
+def _fake_binding(monkeypatch, module_name, platform_name):
+    """Install a stand-in Qt binding exposing QGuiApplication.instance()."""
+    module = ModuleType(module_name)
+    app = None if platform_name is None else _FakeApp(platform_name)
+    module.QGuiApplication = type('QGuiApplication', (), {'instance': staticmethod(lambda: app)})
+    monkeypatch.setitem(sys.modules, module_name, module)
+
+
+@pytest.mark.parametrize('module_name', ['PySide6.QtGui', 'PyQt6.QtGui', 'PyQt5.QtGui'])
+def test_qt_platform_name(monkeypatch, module_name):
+    """A live Qt application reports the platform it actually connected to."""
+    _fake_binding(monkeypatch, module_name, 'xcb')
+    assert _qt_platform_name() == 'xcb'
+
+
+def test_qt_platform_name_no_application(monkeypatch):
+    """An imported binding with no application running answers nothing."""
+    _fake_binding(monkeypatch, 'PySide6.QtGui', None)
+    for name in ('PyQt6.QtGui', 'PySide2.QtGui', 'PyQt5.QtGui'):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    assert _qt_platform_name() is None
+
+
+@pytest.mark.parametrize(
+    ('wayland_display', 'platform_name', 'expected'),
+    [
+        # The case this exists for: QT_QPA_PLATFORM=xcb runs Qt through
+        # XWayland inside a Wayland session, so the process's GL is GLX even
+        # though a compositor is running.
+        ('wayland-0', 'xcb', False),
+        ('wayland-0', 'wayland', True),
+        # Without a Qt application there is nothing better than the session.
+        ('wayland-0', None, True),
+        (None, None, False),
+        # A Qt application on X11 with no compositor at all.
+        (None, 'xcb', False),
+    ],
+)
+def test_process_uses_egl(monkeypatch, wayland_display, platform_name, expected):
+    """A running Qt application outranks the session variable."""
+    monkeypatch.delenv('WAYLAND_DISPLAY', raising=False)
+    if wayland_display is not None:
+        monkeypatch.setenv('WAYLAND_DISPLAY', wayland_display)
+    for name in ('PySide6.QtGui', 'PyQt6.QtGui', 'PySide2.QtGui', 'PyQt5.QtGui'):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    if platform_name is not None:
+        _fake_binding(monkeypatch, 'PySide6.QtGui', platform_name)
+    assert _process_uses_egl() is expected
+
+
+def test_offscreen_probe_follows_qt_platform(monkeypatch):
+    """Qt on xcb inside a Wayland session must not get an EGL probe window.
+
+    An EGL render window cannot make its context current in a GLX process, so
+    every probe render logs ``Unable to eglMakeCurrent`` with EGL_BAD_ACCESS.
+    """
+    monkeypatch.setenv('WAYLAND_DISPLAY', 'wayland-0')
+    monkeypatch.delenv('VTK_DEFAULT_OPENGL_WINDOW', raising=False)
+    if not pv._vtk.has_attr('vtkEGLRenderWindow'):
+        pytest.skip('VTK build lacks vtkEGLRenderWindow')
+
+    _fake_binding(monkeypatch, 'PySide6.QtGui', 'xcb')
+    assert not isinstance(_offscreen_probe_render_window(), pv._vtk.vtkEGLRenderWindow)
+
+    _fake_binding(monkeypatch, 'PySide6.QtGui', 'wayland')
+    assert isinstance(_offscreen_probe_render_window(), pv._vtk.vtkEGLRenderWindow)


### PR DESCRIPTION
Companion PR of https://github.com/pyvista/pyvistaqt/pull/856. I have a Wayland display but `QT_QPA_PLATFORM=xcb` set, so when `check_depth_peeling` ran it tried to use EGL and failed (there was no EGL context, there was the XWindow one). This improves the check here to see if a Qt application is in use, and if it's using `xcb`, assume EGL is not in use.

Drafted by Claude Opus 5 but reviewed/understood by me.