### PR TITLE
Fix pack_labels numpy fallback dropping the highest contiguous label

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -7209,12 +7209,11 @@ class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
             label_numbers_in, label_sizes = np.unique(arr, return_counts=True)
             if sort:
                 label_numbers_in = label_numbers_in[np.argsort(label_sizes)[::-1]]
-            label_range_in = np.arange(0, np.max(label_numbers_in))
-            label_numbers_out = label_range_in[: len(label_numbers_in)]
+            label_numbers_out = np.arange(len(label_numbers_in))
 
             # Pack/sort array
             packed_array = np.zeros_like(arr)
-            for num_in, num_out in zip(label_numbers_in, label_numbers_out, strict=False):
+            for num_in, num_out in zip(label_numbers_in, label_numbers_out, strict=True):
                 packed_array[arr == num_in] = num_out
 
             result = self if inplace else self.copy(deep=True)

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -4252,6 +4252,24 @@ def test_pack_labels(labeled_image):
     assert 'packed_labels' in packed.array_names
 
 
+def test_pack_labels_numpy_fallback(labeled_image):
+    # Force the numpy fallback path (used when vtkPackLabels is unavailable)
+    # to exercise it regardless of the VTK version under test.
+    with patch.object(_vtk, 'has_attr', return_value=False):
+        packed = labeled_image.pack_labels()
+    assert np.array_equal(packed['packed_labels'], [0, 2, 2, 2, 2, 0, 1, 1])
+
+
+def test_pack_labels_numpy_fallback_contiguous_labels(labeled_image):
+    # Regression test: labels already contiguous from 0 (i.e. max(labels) ==
+    # n_unique - 1) previously caused the last label to be dropped and mapped
+    # to 0 instead of its own value.
+    labeled_image['labels'] = [0, 1, 1, 1, 1, 0, 2, 2]
+    with patch.object(_vtk, 'has_attr', return_value=False):
+        packed = labeled_image.pack_labels()
+    assert np.array_equal(packed['packed_labels'], [0, 1, 1, 1, 1, 0, 2, 2])
+
+
 def test_pack_labels_inplace(uniform):
     assert uniform.pack_labels() is not uniform  # default False
     assert uniform.pack_labels(inplace=False) is not uniform


### PR DESCRIPTION
## Summary

- Fixes a bug in the numpy fallback path of `DataSet.pack_labels()` (used when `vtkPackLabels` is unavailable) where `label_numbers_out` was derived from `np.arange(0, max(label_numbers_in))`, which is one element short of `len(label_numbers_in)` whenever labels are already contiguous from `0`.
- `zip(..., strict=False)` silently truncated the pairing in that case, so the highest label was mapped to `0` instead of its own packed value, colliding with the background label.
- Replaces the calculation with `np.arange(len(label_numbers_in))` and switches to `strict=True` so a future length mismatch fails loudly instead of being silently dropped.
- Adds regression tests that force the numpy fallback path (via monkeypatching `vtkPackLabels` availability) and confirm contiguous labels are packed correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)