### PR TITLE
Include commits and failure mode in VTK master failure messages 

### DIFF
--- a/.github/actions/vtk-master-failure-summary/action.yml
+++ b/.github/actions/vtk-master-failure-summary/action.yml
@@ -1,9 +1,8 @@
 name: Upload VTK master failure summary
 description: >-
   Extract a short failure summary from core-test.log/plotting-test.log and upload it as a
-  failure-summary-* artifact, for the VTK master workflow's failure report (used since that
-  report can't fetch job logs directly: the GitHub Actions job-logs API needs repo *admin*
-  rights, which the default GITHUB_TOKEN can never have).
+  failure-summary-* artifact for the VTK master workflow's failure report. Used because the
+  job-logs API needs repo admin rights, which GITHUB_TOKEN never has.
 runs:
   using: composite
   steps:
@@ -12,14 +11,6 @@ runs:
       run: |
         echo "${{ github.job }} (${{ join(matrix.*, ', ') }})" > job_label.txt
         : > failure_summary.txt
-        # tox/pytest force-colorize (TOX_COLORED=yes) even when piped to `tee`; strip the ANSI
-        # escapes first (before the SKIPPED/XFAIL filter below, since a colored line doesn't
-        # literally start with "XFAIL"/"SKIPPED" -- it starts with the escape sequence) so the
-        # summary reads cleanly inside a markdown code block. Drop SKIPPED/XFAIL lines from the
-        # short summary (pyproject.toml's `-ra` addopt puts them there too, alongside
-        # FAILED/ERROR) -- expected, not diagnostic of the failure. Truncate by bytes from the
-        # end (to keep the actually-relevant tail of the log), but if that truncated, drop its
-        # first line too: a byte cut can land mid-line/mid-word.
         for log in core-test.log plotting-test.log; do
           [ -s "$log" ] || continue
           start_line="$(grep -n -m1 -E '=+ short test summary info =+' "$log" | head -n1 | cut -d: -f1 || true)"
@@ -28,13 +19,14 @@ runs:
           else
             segment="$(cat "$log")"
           fi
+          # Strip ANSI color codes (TOX_COLORED=yes forces them even under tee).
           segment="$(printf '%s' "$segment" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')"
           if [ -n "$start_line" ]; then
-            # grep -v exits 1 if every line matched (nothing left, e.g. a summary with no
-            # FAILED/ERROR entries); that's a legitimate empty result here, not an error.
+            # Drop SKIPPED/XFAIL entries (pytest's -ra addopt includes them here too).
             segment="$(printf '%s' "$segment" | grep -Ev '^(SKIPPED|XFAIL) ' || true)"
           fi
           size="$(printf '%s' "$segment" | wc -c | tr -d ' ')"
+          # Truncate from the end, dropping a possibly-partial first line.
           if [ "$size" -gt 4000 ]; then
             printf '%s' "$segment" | tail -c 4000 | tail -n +2 >> failure_summary.txt
           else

--- a/.github/actions/vtk-master-failure-summary/action.yml
+++ b/.github/actions/vtk-master-failure-summary/action.yml
@@ -1,0 +1,52 @@
+name: Upload VTK master failure summary
+description: >-
+  Extract a short failure summary from core-test.log/plotting-test.log and upload it as a
+  failure-summary-* artifact, for the VTK master workflow's failure report (used since that
+  report can't fetch job logs directly: the GitHub Actions job-logs API needs repo *admin*
+  rights, which the default GITHUB_TOKEN can never have).
+runs:
+  using: composite
+  steps:
+    - name: Build failure summary
+      shell: bash
+      run: |
+        echo "${{ github.job }} (${{ join(matrix.*, ', ') }})" > job_label.txt
+        : > failure_summary.txt
+        # tox/pytest force-colorize (TOX_COLORED=yes) even when piped to `tee`; strip the ANSI
+        # escapes first (before the SKIPPED/XFAIL filter below, since a colored line doesn't
+        # literally start with "XFAIL"/"SKIPPED" -- it starts with the escape sequence) so the
+        # summary reads cleanly inside a markdown code block. Drop SKIPPED/XFAIL lines from the
+        # short summary (pyproject.toml's `-ra` addopt puts them there too, alongside
+        # FAILED/ERROR) -- expected, not diagnostic of the failure. Truncate by bytes from the
+        # end (to keep the actually-relevant tail of the log), but if that truncated, drop its
+        # first line too: a byte cut can land mid-line/mid-word.
+        for log in core-test.log plotting-test.log; do
+          [ -s "$log" ] || continue
+          start_line="$(grep -n -m1 -E '=+ short test summary info =+' "$log" | head -n1 | cut -d: -f1 || true)"
+          if [ -n "$start_line" ]; then
+            segment="$(tail -n "+${start_line}" "$log")"
+          else
+            segment="$(cat "$log")"
+          fi
+          segment="$(printf '%s' "$segment" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')"
+          if [ -n "$start_line" ]; then
+            # grep -v exits 1 if every line matched (nothing left, e.g. a summary with no
+            # FAILED/ERROR entries); that's a legitimate empty result here, not an error.
+            segment="$(printf '%s' "$segment" | grep -Ev '^(SKIPPED|XFAIL) ' || true)"
+          fi
+          size="$(printf '%s' "$segment" | wc -c | tr -d ' ')"
+          if [ "$size" -gt 4000 ]; then
+            printf '%s' "$segment" | tail -c 4000 | tail -n +2 >> failure_summary.txt
+          else
+            printf '%s' "$segment" >> failure_summary.txt
+          fi
+          echo >> failure_summary.txt
+        done
+
+    - name: Upload failure summary artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: failure-summary-${{ github.job }}-${{ join(matrix.* , '-') }}
+        path: |
+          failure_summary.txt
+          job_label.txt

--- a/.github/actions/vtk-master-failure-summary/action.yml
+++ b/.github/actions/vtk-master-failure-summary/action.yml
@@ -22,9 +22,11 @@ runs:
           # Strip ANSI color codes (TOX_COLORED=yes forces them even under tee).
           segment="$(printf '%s' "$segment" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')"
           if [ -n "$start_line" ]; then
-            # Drop SKIPPED/XFAIL entries (pytest's -ra addopt includes them here too).
-            segment="$(printf '%s' "$segment" | grep -Ev '^(SKIPPED|XFAIL) ' || true)"
+            # Keep only FAILED/ERROR lines: counts and SKIPPED/XFAIL vary run to run even for
+            # the identical set of failing tests, which broke repeat-detection.
+            segment="$(printf '%s' "$segment" | grep -E '^(FAILED|ERROR) ' || true)"
           fi
+          [ -n "$segment" ] || continue
           size="$(printf '%s' "$segment" | wc -c | tr -d ' ')"
           # Truncate from the end, dropping a possibly-partial first line.
           if [ "$size" -gt 4000 ]; then

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -342,10 +342,14 @@ jobs:
         run: |
           echo "${{ github.job }} (${{ join(matrix.*, ', ') }})" > job_label.txt
           : > failure_summary.txt
-          # tox/pytest force-colorize (TOX_COLORED=yes) even when piped to `tee`; strip the
-          # ANSI escapes so the summary reads cleanly inside a markdown code block. Truncate
-          # by bytes from the end (to keep the actually-relevant tail of the log), but if that
-          # truncated, drop its first line too: a byte cut can land mid-line/mid-word.
+          # tox/pytest force-colorize (TOX_COLORED=yes) even when piped to `tee`; strip the ANSI
+          # escapes first (before the SKIPPED/XFAIL filter below, since a colored line doesn't
+          # literally start with "XFAIL"/"SKIPPED" -- it starts with the escape sequence) so the
+          # summary reads cleanly inside a markdown code block. Drop SKIPPED/XFAIL lines from the
+          # short summary (pyproject.toml's `-ra` addopt puts them there too, alongside
+          # FAILED/ERROR) -- expected, not diagnostic of the failure. Truncate by bytes from the
+          # end (to keep the actually-relevant tail of the log), but if that truncated, drop its
+          # first line too: a byte cut can land mid-line/mid-word.
           for log in core-test.log plotting-test.log; do
             [ -s "$log" ] || continue
             start_line="$(grep -n -m1 -E '=+ short test summary info =+' "$log" | head -n1 | cut -d: -f1 || true)"
@@ -355,6 +359,11 @@ jobs:
               segment="$(cat "$log")"
             fi
             segment="$(printf '%s' "$segment" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')"
+            if [ -n "$start_line" ]; then
+              # grep -v exits 1 if every line matched (nothing left, e.g. a summary with no
+              # FAILED/ERROR entries); that's a legitimate empty result here, not an error.
+              segment="$(printf '%s' "$segment" | grep -Ev '^(SKIPPED|XFAIL) ' || true)"
+            fi
             size="$(printf '%s' "$segment" | wc -c | tr -d ' ')"
             if [ "$size" -gt 4000 ]; then
               printf '%s' "$segment" | tail -c 4000 | tail -n +2 >> failure_summary.txt
@@ -455,10 +464,14 @@ jobs:
         run: |
           echo "${{ github.job }} (${{ join(matrix.*, ', ') }})" > job_label.txt
           : > failure_summary.txt
-          # tox/pytest force-colorize (TOX_COLORED=yes) even when piped to `tee`; strip the
-          # ANSI escapes so the summary reads cleanly inside a markdown code block. Truncate
-          # by bytes from the end (to keep the actually-relevant tail of the log), but if that
-          # truncated, drop its first line too: a byte cut can land mid-line/mid-word.
+          # tox/pytest force-colorize (TOX_COLORED=yes) even when piped to `tee`; strip the ANSI
+          # escapes first (before the SKIPPED/XFAIL filter below, since a colored line doesn't
+          # literally start with "XFAIL"/"SKIPPED" -- it starts with the escape sequence) so the
+          # summary reads cleanly inside a markdown code block. Drop SKIPPED/XFAIL lines from the
+          # short summary (pyproject.toml's `-ra` addopt puts them there too, alongside
+          # FAILED/ERROR) -- expected, not diagnostic of the failure. Truncate by bytes from the
+          # end (to keep the actually-relevant tail of the log), but if that truncated, drop its
+          # first line too: a byte cut can land mid-line/mid-word.
           for log in core-test.log plotting-test.log; do
             [ -s "$log" ] || continue
             start_line="$(grep -n -m1 -E '=+ short test summary info =+' "$log" | head -n1 | cut -d: -f1 || true)"
@@ -468,6 +481,11 @@ jobs:
               segment="$(cat "$log")"
             fi
             segment="$(printf '%s' "$segment" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')"
+            if [ -n "$start_line" ]; then
+              # grep -v exits 1 if every line matched (nothing left, e.g. a summary with no
+              # FAILED/ERROR entries); that's a legitimate empty result here, not an error.
+              segment="$(printf '%s' "$segment" | grep -Ev '^(SKIPPED|XFAIL) ' || true)"
+            fi
             size="$(printf '%s' "$segment" | wc -c | tr -d ' ')"
             if [ "$size" -gt 4000 ]; then
               printf '%s' "$segment" | tail -c 4000 | tail -n +2 >> failure_summary.txt
@@ -583,10 +601,14 @@ jobs:
         run: |
           echo "${{ github.job }} (${{ join(matrix.*, ', ') }})" > job_label.txt
           : > failure_summary.txt
-          # tox/pytest force-colorize (TOX_COLORED=yes) even when piped to `tee`; strip the
-          # ANSI escapes so the summary reads cleanly inside a markdown code block. Truncate
-          # by bytes from the end (to keep the actually-relevant tail of the log), but if that
-          # truncated, drop its first line too: a byte cut can land mid-line/mid-word.
+          # tox/pytest force-colorize (TOX_COLORED=yes) even when piped to `tee`; strip the ANSI
+          # escapes first (before the SKIPPED/XFAIL filter below, since a colored line doesn't
+          # literally start with "XFAIL"/"SKIPPED" -- it starts with the escape sequence) so the
+          # summary reads cleanly inside a markdown code block. Drop SKIPPED/XFAIL lines from the
+          # short summary (pyproject.toml's `-ra` addopt puts them there too, alongside
+          # FAILED/ERROR) -- expected, not diagnostic of the failure. Truncate by bytes from the
+          # end (to keep the actually-relevant tail of the log), but if that truncated, drop its
+          # first line too: a byte cut can land mid-line/mid-word.
           for log in core-test.log plotting-test.log; do
             [ -s "$log" ] || continue
             start_line="$(grep -n -m1 -E '=+ short test summary info =+' "$log" | head -n1 | cut -d: -f1 || true)"
@@ -596,6 +618,11 @@ jobs:
               segment="$(cat "$log")"
             fi
             segment="$(printf '%s' "$segment" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')"
+            if [ -n "$start_line" ]; then
+              # grep -v exits 1 if every line matched (nothing left, e.g. a summary with no
+              # FAILED/ERROR entries); that's a legitimate empty result here, not an error.
+              segment="$(printf '%s' "$segment" | grep -Ev '^(SKIPPED|XFAIL) ' || true)"
+            fi
             size="$(printf '%s' "$segment" | wc -c | tr -d ' ')"
             if [ "$size" -gt 4000 ]; then
               printf '%s' "$segment" | tail -c 4000 | tail -n +2 >> failure_summary.txt

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -269,6 +269,16 @@ jobs:
     with:
       runs-on: "ubuntu-22.04"
 
+  # The macOS self-hosted runner needs its own cache (GitHub-hosted runners
+  # share cache-github-hosted across Linux and Windows).
+  cache-macOS-self-hosted:
+    needs: check-should-run
+    if: needs.check-should-run.outputs.run == 'true'
+    name: Cache pyvista/data
+    uses: ./.github/workflows/cache-pyvista-data.yml
+    with:
+      runs-on: "macos-15-self-hosted"
+
   test-linux:
     needs: [check-should-run, build-vtk, cache-github-hosted]
     if: ${{ !cancelled() && needs.check-should-run.outputs.run == 'true' }}
@@ -348,14 +358,15 @@ jobs:
           path: _generated_test_images
 
   test-macOS:
-    needs: [check-should-run, build-vtk, cache-github-hosted]
+    needs: [check-should-run, build-vtk, cache-macOS-self-hosted]
     if: ${{ !cancelled() && needs.check-should-run.outputs.run == 'true' }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
+        # Self-hosted runner configuration
+        runner-labels: ["macos-15-self-hosted"]
         python-version: ["3.14"]
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner-labels }}
 
     env:
       VTK_WHEEL_DIR: ${{ github.workspace }}/vtk-wheel
@@ -366,11 +377,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Python
+      - name: Set up Python ${{ matrix.python-version }}
+        if: runner.environment != 'self-hosted'
         uses: actions/setup-python@v7
+        continue-on-error: true
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
+
+      - name: Set Python PATH and create a virtual env
+        if: runner.environment == 'self-hosted'
+        run: |
+          /opt/homebrew/bin/python${{ matrix.python-version }} -m venv .venv
+          echo "${{ github.workspace }}/.venv/bin" >> $GITHUB_PATH
 
       - name: Download VTK wheel artifact
         id: download-wheel
@@ -393,7 +412,7 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ${{ env.CACHE_FOLDER_NAME }}
-          key: ${{ needs.cache-github-hosted.outputs.key }}
+          key: ${{ needs.cache-macOS-self-hosted.outputs.key }}
           enableCrossOsArchive: true
 
       - name: Install tox-uv
@@ -512,6 +531,7 @@ jobs:
         check-should-run,
         build-vtk,
         cache-github-hosted,
+        cache-macOS-self-hosted,
         test-linux,
         test-macOS,
         test-windows,

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -57,10 +57,7 @@ jobs:
           git checkout "$NIGHTLY_SHA"
           echo "VTK_NIGHTLY_SHA=$NIGHTLY_SHA" >> "$GITHUB_ENV"
 
-          # Record every commit since the *previous* nightly date-stamp, grouped by merge
-          # topic (VTK merges each topic branch as a single first-parent merge commit, so
-          # the second parent of each merge is that topic's own commit history), so a
-          # failure report can point at exactly what landed on VTK master in between.
+          # Commits since the previous nightly date-stamp, grouped by merge topic.
           PREV_NIGHTLY_SHA="$(git log --grep='^VTK Nightly Date Stamp$' --skip=1 -n 1 --format=%H)"
           BASE_URL="https://gitlab.kitware.com/vtk/vtk/-/commit"
           {
@@ -326,10 +323,7 @@ jobs:
       - name: Install tox-uv
         run: pip install tox-uv
 
-      # Output is also teed to a file (deviating from the unit testing workflow, which
-      # doesn't need this) so a failure can be summarized and uploaded as an artifact below:
-      # the GitHub Actions job-logs API needs repo *admin* rights, which the default
-      # GITHUB_TOKEN this workflow's alert-on-failure job uses can never have.
+      # Teed to a file for the failure-summary upload below.
       - name: Core Testing (no GL)
         run: tox run -e py${{ matrix.python-version }}-core-vtk_local 2>&1 | tee core-test.log
 
@@ -407,10 +401,7 @@ jobs:
       - name: Install tox-uv
         run: pip install tox-uv
 
-      # Output is also teed to a file (deviating from the unit testing workflow, which
-      # doesn't need this) so a failure can be summarized and uploaded as an artifact below:
-      # the GitHub Actions job-logs API needs repo *admin* rights, which the default
-      # GITHUB_TOKEN this workflow's alert-on-failure job uses can never have.
+      # Teed to a file for the failure-summary upload below.
       - name: Core Testing (no GL)
         run: tox run -e py${{ matrix.python-version }}-core-vtk_local 2>&1 | tee core-test.log
 
@@ -491,9 +482,7 @@ jobs:
       - name: Install tox-uv
         run: pip install tox-uv
 
-      # `shell: bash` (rather than the action's Windows default, PowerShell) so the `tee`
-      # below behaves the same as on Linux/macOS, including this repo's SHELLOPTS-driven
-      # pipefail; see the comment on the equivalent Linux/macOS steps for why it's teed.
+      # `shell: bash`: this action's Windows default is PowerShell, which `tee` needs to avoid.
       - name: Core Testing (no GL)
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
         with:
@@ -561,9 +550,7 @@ jobs:
           name: vtk-commit-range-Linux
           path: vtk-commit-range
 
-      # Each test job uploads a failure-summary-* artifact (job_label.txt + failure_summary.txt)
-      # only when it fails. This job can't fetch job logs directly via `gh api .../logs`: that
-      # endpoint needs repo *admin* rights, which the default GITHUB_TOKEN can never have.
+      # Populated by each test job's "Upload failure summary" step, if it failed.
       - name: Download failure summaries
         id: download-failure-summaries
         uses: actions/download-artifact@v8
@@ -578,23 +565,17 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           COMMIT_RANGE_OUTCOME: ${{ steps.download-commit-range.outcome }}
         run: |
-          # Individual gh lookups below are best-effort (wrapped in `|| true`); a single
-          # missing issue comment should not abort the whole report. Every
-          # `for x in "${arr[@]}"` below is guarded by a length check first: on bash <4.4,
-          # `"${arr[@]}"` on a *declared-but-empty* array raises an unbound-variable error
-          # under nounset, and an empty array is a real, expected path here.
+          # `for x in "${arr[@]}"` below is guarded by a length check first: bash <4.4 raises
+          # an unbound-variable error under nounset for an empty array otherwise.
           set -uo pipefail
 
-          # Pull this job's failure-hash marker back out of a report's text. No match (e.g.
-          # the previous report predates this marker format) is an expected outcome, not an
-          # error, so it must not raise under the pipefail'd `-e` above.
+          # No failure-hash match (e.g. an older report predates this marker) is expected, not
+          # an error, so it must not raise under `set -e` above.
           extract_hash() {
             printf '%s' "$1" | grep -F "failure-hash:${2}:" | tail -n1 | sed -E 's/.*failure-hash:[^:]+:([0-9a-f]+).*/\1/' || true
           }
 
-          # Drop tox/pytest's own wall-clock-duration wrapper lines, and strip a pytest
-          # summary line's trailing "in <N>s (<H:MM:SS>)", before hashing: two runs hitting
-          # the identical failure otherwise never hash the same, since these change every run.
+          # Strips wall-clock timing so two runs hitting the identical failure hash the same.
           normalize_for_hash() {
             grep -Ev '^\s*(py3\.[0-9]+-[a-z_-]+: (exit|FAIL code)|evaluation failed|congratulations|py3\.[0-9]+-[a-z_-]+: OK)' \
               | sed -E 's/ in [0-9]+\.[0-9]+s \([0-9:]+\)//'
@@ -616,9 +597,7 @@ jobs:
             failed_jobs+=("${name}"$'\t'"${url}")
           done <<< "$failed_jobs_raw"
 
-          # Load whatever failure-summary-* artifacts test jobs uploaded (only jobs that ran
-          # pytest and failed produce one; e.g. a build-vtk failure won't, and that job just
-          # gets a bare bullet below, no nested dropdown).
+          # Only jobs that ran pytest and failed have a failure-summary-* artifact.
           summary_names=()
           summary_texts=()
           if [ -d failure-summaries ]; then
@@ -639,8 +618,7 @@ jobs:
             commit_range_body="(could not determine which VTK commits landed since the previous nightly)"
           fi
 
-          # Fetch the most recently posted report (the last comment, or the issue body if
-          # there are no comments yet) so each job's failure can be checked against it below.
+          # Most recently posted report: the last comment, or the issue body if none yet.
           existing=$(gh issue list --label "vtk-master-wheel-failure" --state open --limit 1 --json number --jq '.[0].number // empty' || true)
           prev_text=""
           prev_url=""
@@ -651,9 +629,6 @@ jobs:
               --jq 'if (.comments | length) > 0 then .comments[-1].url else .url end' 2>/dev/null || true)"
           fi
 
-          # One bullet per failed job, with its failure output (if any) nested directly
-          # underneath as a collapsed dropdown, rather than in a separate section further
-          # down the report.
           jobs_list=""
           if [ "${#failed_jobs[@]}" -eq 0 ]; then
             jobs_list="- (could not determine which jobs failed, see the run)"$'\n'
@@ -685,9 +660,7 @@ jobs:
                 icon="❌"
               fi
 
-              # The HTML comment marker records this job's failure signature so a later run
-              # can detect "same failure as before" without any external state. Every line is
-              # indented 2 spaces to stay nested inside this list item on GitHub.
+              # Indented 2 spaces to stay nested inside this list item on GitHub.
               jobs_list+="  <!-- failure-hash:${name}:${hash} -->"$'\n'
               jobs_list+="  <details>"$'\n'
               jobs_list+="  <summary>${icon} failure output</summary>"$'\n\n'

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -543,8 +543,18 @@ jobs:
           COMMIT_RANGE_OUTCOME: ${{ steps.download-commit-range.outcome }}
         run: |
           # Individual gh/api lookups below are best-effort (wrapped in `|| true`); a single
-          # missing log or issue comment should not abort the whole report.
+          # missing log or issue comment should not abort the whole report. Every
+          # `for row in "${failed_jobs[@]}"` below is guarded by a length check first: on
+          # bash <4.4, `"${arr[@]}"` on a *declared-but-empty* array raises an unbound-variable
+          # error under nounset, and the empty-`failed_jobs` case is a real, expected path here.
           set -uo pipefail
+
+          # Pull this job's failure-hash marker back out of a report's text. No match (e.g.
+          # the previous report predates this marker format) is an expected outcome, not an
+          # error, so it must not raise under the pipefail'd `-e` above.
+          extract_hash() {
+            printf '%s' "$1" | grep -F "failure-hash:${2}:" | tail -n1 | sed -E 's/.*failure-hash:[^:]+:([0-9a-f]+).*/\1/' || true
+          }
 
           # Ensure the dedup label exists (idempotent).
           gh label create vtk-master-wheel-failure \
@@ -554,7 +564,7 @@ jobs:
 
           # The matrix job names include the OS/python-version, e.g. "build-vtk (ubuntu-latest, 3.14)"
           failed_jobs_raw=$(gh run view "$RUN_ID" --json jobs \
-            --jq '.jobs[] | select(.conclusion == "failure") | [.databaseId, .name, .url] | @tsv')
+            --jq '.jobs[] | select(.conclusion == "failure") | [.databaseId, .name, .url] | @tsv' || true)
 
           failed_jobs=()
           while IFS=$'\t' read -r job_id name url; do
@@ -579,7 +589,10 @@ jobs:
               if [ -z "$log" ]; then
                 summary="(could not retrieve the log for this job)"
               else
-                start_line="$(printf '%s\n' "$log" | grep -n -m1 -E '=+ short test summary info =+|^::error::VTK build failed' | head -n1 | cut -d: -f1)"
+                # grep -m1 exits 1 when neither marker is found (a very normal outcome, e.g.
+                # a timeout or infra failure); with pipefail active that would otherwise abort
+                # this whole step under -e, so the miss must be swallowed right here.
+                start_line="$(printf '%s\n' "$log" | grep -n -m1 -E '=+ short test summary info =+|^::error::VTK build failed' | head -n1 | cut -d: -f1 || true)"
                 if [ -n "$start_line" ]; then
                   summary="$(printf '%s\n' "$log" | tail -n "+${start_line}" | tail -c 8000)"
                 else
@@ -609,18 +622,18 @@ jobs:
           # Check for an existing open issue, and compare each failed job's signature
           # against the most recently posted report (the last comment, or the issue body
           # if there are no comments yet).
-          existing=$(gh issue list --label "vtk-master-wheel-failure" --state open --limit 1 --json number --jq '.[0].number // empty')
+          existing=$(gh issue list --label "vtk-master-wheel-failure" --state open --limit 1 --json number --jq '.[0].number // empty' || true)
 
           repeat_note=""
-          if [ -n "$existing" ]; then
+          if [ -n "$existing" ] && [ "${#failed_jobs[@]}" -gt 0 ]; then
             prev_text="$(gh issue view "$existing" --json body,comments \
               --jq 'if (.comments | length) > 0 then .comments[-1].body else .body end' 2>/dev/null || true)"
             prev_url="$(gh issue view "$existing" --json url,comments \
               --jq 'if (.comments | length) > 0 then .comments[-1].url else .url end' 2>/dev/null || true)"
             for row in "${failed_jobs[@]}"; do
               IFS=$'\t' read -r job_id name url <<< "$row"
-              cur_hash="$(printf '%s' "$failure_sections" | grep -F "failure-hash:${name}:" | tail -n1 | sed -E 's/.*failure-hash:[^:]+:([0-9a-f]+).*/\1/')"
-              prev_hash="$(printf '%s' "$prev_text" | grep -F "failure-hash:${name}:" | tail -n1 | sed -E 's/.*failure-hash:[^:]+:([0-9a-f]+).*/\1/')"
+              cur_hash="$(extract_hash "$failure_sections" "$name")"
+              prev_hash="$(extract_hash "$prev_text" "$name")"
               if [ -n "$cur_hash" ] && [ -n "$prev_hash" ] && [ "$cur_hash" = "$prev_hash" ]; then
                 repeat_note+="- \`${name}\`: same failure signature as the [previous report](${prev_url})."$'\n'
               fi

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -606,7 +606,6 @@ jobs:
               [ -f "$summary_file" ] || continue
               name="$(cat "$label_file")"
               summary="$(cat "$summary_file")"
-              [ -n "$summary" ] || summary="(no output captured)"
               summary_names+=("$name")
               summary_texts+=("$summary")
             done < <(find failure-summaries -name job_label.txt | sort)
@@ -657,10 +656,17 @@ jobs:
                 jobs_list+="  ⚠️ Same failure signature as the [previous report](${prev_url})."$'\n'
               fi
 
+              # Counted here rather than trusting pytest's own "N failed" line, which isn't in
+              # $summary any more (and wasn't reliable for repeat-detection either -- see the
+              # FAILED/ERROR-only filtering above).
+              n_failures="$(printf '%s\n' "$summary" | grep -c .)"
+              failure_word="failures"
+              [ "$n_failures" -eq 1 ] && failure_word="failure"
+
               # Indented 2 spaces to stay nested inside this list item on GitHub.
               jobs_list+="  <!-- failure-hash:${name}:${hash} -->"$'\n'
               jobs_list+="  <details>"$'\n'
-              jobs_list+="  <summary>❌ failure output</summary>"$'\n\n'
+              jobs_list+="  <summary>❌ ${n_failures} ${failure_word}</summary>"$'\n\n'
               jobs_list+='  ```text'$'\n'
               jobs_list+="$(printf '%s\n' "$summary" | sed 's/^/  /')"$'\n'
               jobs_list+='  ```'$'\n\n'

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -57,6 +57,29 @@ jobs:
           git checkout "$NIGHTLY_SHA"
           echo "VTK_NIGHTLY_SHA=$NIGHTLY_SHA" >> "$GITHUB_ENV"
 
+          # Record every commit since the *previous* nightly date-stamp so a failure report
+          # can point at exactly what landed on VTK master in between.
+          PREV_NIGHTLY_SHA="$(git log --grep='^VTK Nightly Date Stamp$' --skip=1 -n 1 --format=%H)"
+          {
+            if [ -n "$PREV_NIGHTLY_SHA" ]; then
+              echo "Commits since the previous nightly date-stamp ([\`${PREV_NIGHTLY_SHA:0:8}\`](https://gitlab.kitware.com/vtk/vtk/-/commit/${PREV_NIGHTLY_SHA})):"
+              echo
+              echo "[Compare on GitLab](https://gitlab.kitware.com/vtk/vtk/-/compare/${PREV_NIGHTLY_SHA}...${NIGHTLY_SHA})"
+              echo
+              git log --no-merges --format='- [`%h`](https://gitlab.kitware.com/vtk/vtk/-/commit/%H) %s (%an)' "${PREV_NIGHTLY_SHA}..${NIGHTLY_SHA}"
+            else
+              echo "Could not find a previous nightly date-stamp commit within the last 200 commits;"
+              echo "showing only the pinned commit: [\`${NIGHTLY_SHA:0:8}\`](https://gitlab.kitware.com/vtk/vtk/-/commit/${NIGHTLY_SHA})"
+            fi
+          } > "$GITHUB_WORKSPACE/vtk-commit-range.md"
+
+      - name: Upload VTK commit range
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v7
+        with:
+          name: vtk-commit-range-${{ runner.os }}
+          path: vtk-commit-range.md
+
       - name: Setup Python
         uses: actions/setup-python@v7
         with:
@@ -483,10 +506,19 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}
     steps:
+      - name: Download VTK commit range
+        id: download-commit-range
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: vtk-commit-range-Linux
+          path: vtk-commit-range
+
       - name: Report VTK master wheel failure
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           RUN_ID: ${{ github.run_id }}
+          COMMIT_RANGE_OUTCOME: ${{ steps.download-commit-range.outcome }}
         run: |
           # Ensure the dedup label exists (idempotent).
           gh label create vtk-master-wheel-failure \
@@ -506,6 +538,12 @@ jobs:
 
           [ -n "$jobs_list" ] || jobs_list="- (could not determine which jobs failed, see the run)"$'\n'
 
+          if [ "$COMMIT_RANGE_OUTCOME" = "success" ] && [ -f vtk-commit-range/vtk-commit-range.md ]; then
+            commit_range="$(cat vtk-commit-range/vtk-commit-range.md)"
+          else
+            commit_range="(could not determine which VTK commits landed since the previous nightly)"
+          fi
+
           body=$(cat <<EOF
           ### VTK Master Wheel Failure
 
@@ -514,6 +552,9 @@ jobs:
 
           **Failing jobs:**
           ${jobs_list}
+
+          **VTK commits:**
+          ${commit_range}
           EOF
           )
 

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -689,6 +689,14 @@ jobs:
             printf '%s' "$1" | grep -F "failure-hash:${2}:" | tail -n1 | sed -E 's/.*failure-hash:[^:]+:([0-9a-f]+).*/\1/' || true
           }
 
+          # Drop tox/pytest's own wall-clock-duration wrapper lines, and strip a pytest
+          # summary line's trailing "in <N>s (<H:MM:SS>)", before hashing: two runs hitting
+          # the identical failure otherwise never hash the same, since these change every run.
+          normalize_for_hash() {
+            grep -Ev '^\s*(py3\.[0-9]+-[a-z_-]+: (exit|FAIL code)|evaluation failed|congratulations|py3\.[0-9]+-[a-z_-]+: OK)' \
+              | sed -E 's/ in [0-9]+\.[0-9]+s \([0-9:]+\)//'
+          }
+
           # Ensure the dedup label exists (idempotent).
           gh label create vtk-master-wheel-failure \
             --color cbb230 \
@@ -699,18 +707,17 @@ jobs:
           failed_jobs_raw=$(gh run view "$RUN_ID" --json jobs \
             --jq '.jobs[] | select(.conclusion == "failure") | [.name, .url] | @tsv' || true)
 
-          jobs_list=""
+          failed_jobs=()
           while IFS=$'\t' read -r name url; do
             [ -n "$name" ] || continue
-            jobs_list+="- [\`${name}\`](${url})"$'\n'
+            failed_jobs+=("${name}"$'\t'"${url}")
           done <<< "$failed_jobs_raw"
-          [ -n "$jobs_list" ] || jobs_list="- (could not determine which jobs failed, see the run)"$'\n'
 
-          # Build the per-job failure-output dropdowns from whatever failure-summary-*
-          # artifacts test jobs uploaded (only jobs that ran pytest and failed produce one;
-          # e.g. a build-vtk failure won't, and that's fine).
-          failure_sections=""
-          failed_labels=()
+          # Load whatever failure-summary-* artifacts test jobs uploaded (only jobs that ran
+          # pytest and failed produce one; e.g. a build-vtk failure won't, and that job just
+          # gets a bare bullet below, no nested dropdown).
+          summary_names=()
+          summary_texts=()
           if [ -d failure-summaries ]; then
             while IFS= read -r label_file; do
               summary_file="$(dirname "$label_file")/failure_summary.txt"
@@ -718,16 +725,8 @@ jobs:
               name="$(cat "$label_file")"
               summary="$(cat "$summary_file")"
               [ -n "$summary" ] || summary="(no output captured)"
-              hash="$(printf '%s' "$summary" | sha256sum | cut -d' ' -f1)"
-              failed_labels+=("$name")
-
-              # The HTML comment marker records this job's failure signature so a later run
-              # can detect "same failure as before" without any external state.
-              failure_sections+="<!-- failure-hash:${name}:${hash} -->"$'\n'
-              failure_sections+="<details>"$'\n'
-              failure_sections+="<summary>❌ ${name} — failure output</summary>"$'\n\n'
-              failure_sections+='```text'$'\n'"${summary}"$'\n''```'$'\n'
-              failure_sections+="</details>"$'\n\n'
+              summary_names+=("$name")
+              summary_texts+=("$summary")
             done < <(find failure-summaries -name job_label.txt | sort)
           fi
 
@@ -737,26 +736,64 @@ jobs:
             commit_range_body="(could not determine which VTK commits landed since the previous nightly)"
           fi
 
-          # Check for an existing open issue, and compare each failed job's signature
-          # against the most recently posted report (the last comment, or the issue body
-          # if there are no comments yet).
+          # Fetch the most recently posted report (the last comment, or the issue body if
+          # there are no comments yet) so each job's failure can be checked against it below.
           existing=$(gh issue list --label "vtk-master-wheel-failure" --state open --limit 1 --json number --jq '.[0].number // empty' || true)
-
-          repeat_note=""
-          if [ -n "$existing" ] && [ "${#failed_labels[@]}" -gt 0 ]; then
+          prev_text=""
+          prev_url=""
+          if [ -n "$existing" ]; then
             prev_text="$(gh issue view "$existing" --json body,comments \
               --jq 'if (.comments | length) > 0 then .comments[-1].body else .body end' 2>/dev/null || true)"
             prev_url="$(gh issue view "$existing" --json url,comments \
               --jq 'if (.comments | length) > 0 then .comments[-1].url else .url end' 2>/dev/null || true)"
-            for name in "${failed_labels[@]}"; do
-              cur_hash="$(extract_hash "$failure_sections" "$name")"
-              prev_hash="$(extract_hash "$prev_text" "$name")"
-              if [ -n "$cur_hash" ] && [ -n "$prev_hash" ] && [ "$cur_hash" = "$prev_hash" ]; then
-                repeat_note+="- \`${name}\`: same failure signature as the [previous report](${prev_url})."$'\n'
+          fi
+
+          # One bullet per failed job, with its failure output (if any) nested directly
+          # underneath as a collapsed dropdown, rather than in a separate section further
+          # down the report.
+          jobs_list=""
+          if [ "${#failed_jobs[@]}" -eq 0 ]; then
+            jobs_list="- (could not determine which jobs failed, see the run)"$'\n'
+          else
+            for row in "${failed_jobs[@]}"; do
+              IFS=$'\t' read -r name url <<< "$row"
+
+              summary=""
+              if [ "${#summary_names[@]}" -gt 0 ]; then
+                for i in "${!summary_names[@]}"; do
+                  if [ "${summary_names[$i]}" = "$name" ]; then
+                    summary="${summary_texts[$i]}"
+                    break
+                  fi
+                done
               fi
+
+              jobs_list+="- [\`${name}\`](${url})"$'\n'
+              if [ -z "$summary" ]; then
+                continue
+              fi
+
+              hash="$(printf '%s' "$summary" | normalize_for_hash | sha256sum | cut -d' ' -f1)"
+              prev_hash="$(extract_hash "$prev_text" "$name")"
+              if [ -n "$prev_hash" ] && [ "$prev_hash" = "$hash" ]; then
+                icon="⚠️"
+                jobs_list+="  Same failure signature as the [previous report](${prev_url})."$'\n'
+              else
+                icon="❌"
+              fi
+
+              # The HTML comment marker records this job's failure signature so a later run
+              # can detect "same failure as before" without any external state. Every line is
+              # indented 2 spaces to stay nested inside this list item on GitHub.
+              jobs_list+="  <!-- failure-hash:${name}:${hash} -->"$'\n'
+              jobs_list+="  <details>"$'\n'
+              jobs_list+="  <summary>${icon} failure output</summary>"$'\n\n'
+              jobs_list+='  ```text'$'\n'
+              jobs_list+="$(printf '%s\n' "$summary" | sed 's/^/  /')"$'\n'
+              jobs_list+='  ```'$'\n\n'
+              jobs_list+="  </details>"$'\n'
             done
           fi
-          [ -z "$repeat_note" ] || repeat_note="**Repeat failures:**"$'\n'"${repeat_note}"
 
           body=$(cat <<EOF
           ### VTK Master Wheel Failure
@@ -765,11 +802,9 @@ jobs:
           **Run:** ${RUN_URL}
 
           **Failing jobs:**
-          ${jobs_list}
-          ${repeat_note}
-          ${commit_range_body}
 
-          ${failure_sections}
+          ${jobs_list}
+          ${commit_range_body}
           EOF
           )
 

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -339,48 +339,7 @@ jobs:
 
       - name: Upload failure summary
         if: failure()
-        run: |
-          echo "${{ github.job }} (${{ join(matrix.*, ', ') }})" > job_label.txt
-          : > failure_summary.txt
-          # tox/pytest force-colorize (TOX_COLORED=yes) even when piped to `tee`; strip the ANSI
-          # escapes first (before the SKIPPED/XFAIL filter below, since a colored line doesn't
-          # literally start with "XFAIL"/"SKIPPED" -- it starts with the escape sequence) so the
-          # summary reads cleanly inside a markdown code block. Drop SKIPPED/XFAIL lines from the
-          # short summary (pyproject.toml's `-ra` addopt puts them there too, alongside
-          # FAILED/ERROR) -- expected, not diagnostic of the failure. Truncate by bytes from the
-          # end (to keep the actually-relevant tail of the log), but if that truncated, drop its
-          # first line too: a byte cut can land mid-line/mid-word.
-          for log in core-test.log plotting-test.log; do
-            [ -s "$log" ] || continue
-            start_line="$(grep -n -m1 -E '=+ short test summary info =+' "$log" | head -n1 | cut -d: -f1 || true)"
-            if [ -n "$start_line" ]; then
-              segment="$(tail -n "+${start_line}" "$log")"
-            else
-              segment="$(cat "$log")"
-            fi
-            segment="$(printf '%s' "$segment" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')"
-            if [ -n "$start_line" ]; then
-              # grep -v exits 1 if every line matched (nothing left, e.g. a summary with no
-              # FAILED/ERROR entries); that's a legitimate empty result here, not an error.
-              segment="$(printf '%s' "$segment" | grep -Ev '^(SKIPPED|XFAIL) ' || true)"
-            fi
-            size="$(printf '%s' "$segment" | wc -c | tr -d ' ')"
-            if [ "$size" -gt 4000 ]; then
-              printf '%s' "$segment" | tail -c 4000 | tail -n +2 >> failure_summary.txt
-            else
-              printf '%s' "$segment" >> failure_summary.txt
-            fi
-            echo >> failure_summary.txt
-          done
-
-      - name: Upload failure summary artifact
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: failure-summary-${{ github.job }}-${{ join(matrix.* , '-') }}
-          path: |
-            failure_summary.txt
-            job_label.txt
+        uses: ./.github/actions/vtk-master-failure-summary
 
       - name: Upload Images for Failed Tests
         if: always()
@@ -461,48 +420,7 @@ jobs:
 
       - name: Upload failure summary
         if: failure()
-        run: |
-          echo "${{ github.job }} (${{ join(matrix.*, ', ') }})" > job_label.txt
-          : > failure_summary.txt
-          # tox/pytest force-colorize (TOX_COLORED=yes) even when piped to `tee`; strip the ANSI
-          # escapes first (before the SKIPPED/XFAIL filter below, since a colored line doesn't
-          # literally start with "XFAIL"/"SKIPPED" -- it starts with the escape sequence) so the
-          # summary reads cleanly inside a markdown code block. Drop SKIPPED/XFAIL lines from the
-          # short summary (pyproject.toml's `-ra` addopt puts them there too, alongside
-          # FAILED/ERROR) -- expected, not diagnostic of the failure. Truncate by bytes from the
-          # end (to keep the actually-relevant tail of the log), but if that truncated, drop its
-          # first line too: a byte cut can land mid-line/mid-word.
-          for log in core-test.log plotting-test.log; do
-            [ -s "$log" ] || continue
-            start_line="$(grep -n -m1 -E '=+ short test summary info =+' "$log" | head -n1 | cut -d: -f1 || true)"
-            if [ -n "$start_line" ]; then
-              segment="$(tail -n "+${start_line}" "$log")"
-            else
-              segment="$(cat "$log")"
-            fi
-            segment="$(printf '%s' "$segment" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')"
-            if [ -n "$start_line" ]; then
-              # grep -v exits 1 if every line matched (nothing left, e.g. a summary with no
-              # FAILED/ERROR entries); that's a legitimate empty result here, not an error.
-              segment="$(printf '%s' "$segment" | grep -Ev '^(SKIPPED|XFAIL) ' || true)"
-            fi
-            size="$(printf '%s' "$segment" | wc -c | tr -d ' ')"
-            if [ "$size" -gt 4000 ]; then
-              printf '%s' "$segment" | tail -c 4000 | tail -n +2 >> failure_summary.txt
-            else
-              printf '%s' "$segment" >> failure_summary.txt
-            fi
-            echo >> failure_summary.txt
-          done
-
-      - name: Upload failure summary artifact
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: failure-summary-${{ github.job }}-${{ join(matrix.* , '-') }}
-          path: |
-            failure_summary.txt
-            job_label.txt
+        uses: ./.github/actions/vtk-master-failure-summary
 
       - name: Upload Images for Failed Tests
         if: always()
@@ -597,49 +515,7 @@ jobs:
 
       - name: Upload failure summary
         if: failure()
-        shell: bash
-        run: |
-          echo "${{ github.job }} (${{ join(matrix.*, ', ') }})" > job_label.txt
-          : > failure_summary.txt
-          # tox/pytest force-colorize (TOX_COLORED=yes) even when piped to `tee`; strip the ANSI
-          # escapes first (before the SKIPPED/XFAIL filter below, since a colored line doesn't
-          # literally start with "XFAIL"/"SKIPPED" -- it starts with the escape sequence) so the
-          # summary reads cleanly inside a markdown code block. Drop SKIPPED/XFAIL lines from the
-          # short summary (pyproject.toml's `-ra` addopt puts them there too, alongside
-          # FAILED/ERROR) -- expected, not diagnostic of the failure. Truncate by bytes from the
-          # end (to keep the actually-relevant tail of the log), but if that truncated, drop its
-          # first line too: a byte cut can land mid-line/mid-word.
-          for log in core-test.log plotting-test.log; do
-            [ -s "$log" ] || continue
-            start_line="$(grep -n -m1 -E '=+ short test summary info =+' "$log" | head -n1 | cut -d: -f1 || true)"
-            if [ -n "$start_line" ]; then
-              segment="$(tail -n "+${start_line}" "$log")"
-            else
-              segment="$(cat "$log")"
-            fi
-            segment="$(printf '%s' "$segment" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')"
-            if [ -n "$start_line" ]; then
-              # grep -v exits 1 if every line matched (nothing left, e.g. a summary with no
-              # FAILED/ERROR entries); that's a legitimate empty result here, not an error.
-              segment="$(printf '%s' "$segment" | grep -Ev '^(SKIPPED|XFAIL) ' || true)"
-            fi
-            size="$(printf '%s' "$segment" | wc -c | tr -d ' ')"
-            if [ "$size" -gt 4000 ]; then
-              printf '%s' "$segment" | tail -c 4000 | tail -n +2 >> failure_summary.txt
-            else
-              printf '%s' "$segment" >> failure_summary.txt
-            fi
-            echo >> failure_summary.txt
-          done
-
-      - name: Upload failure summary artifact
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: failure-summary-${{ github.job }}-${{ join(matrix.* , '-') }}
-          path: |
-            failure_summary.txt
-            job_label.txt
+        uses: ./.github/actions/vtk-master-failure-summary
 
       - name: Upload Images for Failed Tests
         if: always()

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -654,16 +654,13 @@ jobs:
               hash="$(printf '%s' "$summary" | normalize_for_hash | sha256sum | cut -d' ' -f1)"
               prev_hash="$(extract_hash "$prev_text" "$name")"
               if [ -n "$prev_hash" ] && [ "$prev_hash" = "$hash" ]; then
-                icon="⚠️"
-                jobs_list+="  Same failure signature as the [previous report](${prev_url})."$'\n'
-              else
-                icon="❌"
+                jobs_list+="  ⚠️ Same failure signature as the [previous report](${prev_url})."$'\n'
               fi
 
               # Indented 2 spaces to stay nested inside this list item on GitHub.
               jobs_list+="  <!-- failure-hash:${name}:${hash} -->"$'\n'
               jobs_list+="  <details>"$'\n'
-              jobs_list+="  <summary>${icon} failure output</summary>"$'\n\n'
+              jobs_list+="  <summary>❌ failure output</summary>"$'\n\n'
               jobs_list+='  ```text'$'\n'
               jobs_list+="$(printf '%s\n' "$summary" | sed 's/^/  /')"$'\n'
               jobs_list+='  ```'$'\n\n'

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -336,12 +336,41 @@ jobs:
       - name: Install tox-uv
         run: pip install tox-uv
 
+      # Output is also teed to a file (deviating from the unit testing workflow, which
+      # doesn't need this) so a failure can be summarized and uploaded as an artifact below:
+      # the GitHub Actions job-logs API needs repo *admin* rights, which the default
+      # GITHUB_TOKEN this workflow's alert-on-failure job uses can never have.
       - name: Core Testing (no GL)
-        run: tox run -e py${{ matrix.python-version }}-core-vtk_local
+        run: tox run -e py${{ matrix.python-version }}-core-vtk_local 2>&1 | tee core-test.log
 
       - name: Plotting Testing (uses GL)
         if: ${{ !cancelled() }}
-        run: xvfb-run tox run -e py${{ matrix.python-version }}-plotting-vtk_local
+        run: xvfb-run tox run -e py${{ matrix.python-version }}-plotting-vtk_local 2>&1 | tee plotting-test.log
+
+      - name: Upload failure summary
+        if: failure()
+        run: |
+          echo "${{ github.job }} (${{ join(matrix.*, ', ') }})" > job_label.txt
+          : > failure_summary.txt
+          for log in core-test.log plotting-test.log; do
+            [ -s "$log" ] || continue
+            start_line="$(grep -n -m1 -E '=+ short test summary info =+' "$log" | head -n1 | cut -d: -f1 || true)"
+            if [ -n "$start_line" ]; then
+              tail -n "+${start_line}" "$log" | tail -c 4000 >> failure_summary.txt
+            else
+              tail -c 4000 "$log" >> failure_summary.txt
+            fi
+            echo >> failure_summary.txt
+          done
+
+      - name: Upload failure summary artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: failure-summary-${{ github.job }}-${{ join(matrix.* , '-') }}
+          path: |
+            failure_summary.txt
+            job_label.txt
 
       - name: Upload Images for Failed Tests
         if: always()
@@ -418,12 +447,41 @@ jobs:
       - name: Install tox-uv
         run: pip install tox-uv
 
+      # Output is also teed to a file (deviating from the unit testing workflow, which
+      # doesn't need this) so a failure can be summarized and uploaded as an artifact below:
+      # the GitHub Actions job-logs API needs repo *admin* rights, which the default
+      # GITHUB_TOKEN this workflow's alert-on-failure job uses can never have.
       - name: Core Testing (no GL)
-        run: tox run -e py${{ matrix.python-version }}-core-vtk_local
+        run: tox run -e py${{ matrix.python-version }}-core-vtk_local 2>&1 | tee core-test.log
 
       - name: Plotting Testing (uses GL)
         if: ${{ !cancelled() }}
-        run: tox run -e py${{ matrix.python-version }}-plotting-vtk_local
+        run: tox run -e py${{ matrix.python-version }}-plotting-vtk_local 2>&1 | tee plotting-test.log
+
+      - name: Upload failure summary
+        if: failure()
+        run: |
+          echo "${{ github.job }} (${{ join(matrix.*, ', ') }})" > job_label.txt
+          : > failure_summary.txt
+          for log in core-test.log plotting-test.log; do
+            [ -s "$log" ] || continue
+            start_line="$(grep -n -m1 -E '=+ short test summary info =+' "$log" | head -n1 | cut -d: -f1 || true)"
+            if [ -n "$start_line" ]; then
+              tail -n "+${start_line}" "$log" | tail -c 4000 >> failure_summary.txt
+            else
+              tail -c 4000 "$log" >> failure_summary.txt
+            fi
+            echo >> failure_summary.txt
+          done
+
+      - name: Upload failure summary artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: failure-summary-${{ github.job }}-${{ join(matrix.* , '-') }}
+          path: |
+            failure_summary.txt
+            job_label.txt
 
       - name: Upload Images for Failed Tests
         if: always()
@@ -494,13 +552,17 @@ jobs:
       - name: Install tox-uv
         run: pip install tox-uv
 
+      # `shell: bash` (rather than the action's Windows default, PowerShell) so the `tee`
+      # below behaves the same as on Linux/macOS, including this repo's SHELLOPTS-driven
+      # pipefail; see the comment on the equivalent Linux/macOS steps for why it's teed.
       - name: Core Testing (no GL)
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
         with:
           timeout_minutes: 12
           max_attempts: 3
           retry_on: timeout
-          command: tox run -e py${{ matrix.python-version }}-core-vtk_local
+          shell: bash
+          command: tox run -e py${{ matrix.python-version }}-core-vtk_local 2>&1 | tee core-test.log
 
       - name: Plotting Testing (uses GL)
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
@@ -509,7 +571,34 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           retry_on: timeout
-          command: tox run -e py${{ matrix.python-version }}-plotting-vtk_local
+          shell: bash
+          command: tox run -e py${{ matrix.python-version }}-plotting-vtk_local 2>&1 | tee plotting-test.log
+
+      - name: Upload failure summary
+        if: failure()
+        shell: bash
+        run: |
+          echo "${{ github.job }} (${{ join(matrix.*, ', ') }})" > job_label.txt
+          : > failure_summary.txt
+          for log in core-test.log plotting-test.log; do
+            [ -s "$log" ] || continue
+            start_line="$(grep -n -m1 -E '=+ short test summary info =+' "$log" | head -n1 | cut -d: -f1 || true)"
+            if [ -n "$start_line" ]; then
+              tail -n "+${start_line}" "$log" | tail -c 4000 >> failure_summary.txt
+            else
+              tail -c 4000 "$log" >> failure_summary.txt
+            fi
+            echo >> failure_summary.txt
+          done
+
+      - name: Upload failure summary artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: failure-summary-${{ github.job }}-${{ join(matrix.* , '-') }}
+          path: |
+            failure_summary.txt
+            job_label.txt
 
       - name: Upload Images for Failed Tests
         if: always()
@@ -556,17 +645,28 @@ jobs:
           name: vtk-commit-range-Linux
           path: vtk-commit-range
 
+      # Each test job uploads a failure-summary-* artifact (job_label.txt + failure_summary.txt)
+      # only when it fails. This job can't fetch job logs directly via `gh api .../logs`: that
+      # endpoint needs repo *admin* rights, which the default GITHUB_TOKEN can never have.
+      - name: Download failure summaries
+        id: download-failure-summaries
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: failure-summary-*
+          path: failure-summaries
+
       - name: Report VTK master wheel failure
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           RUN_ID: ${{ github.run_id }}
           COMMIT_RANGE_OUTCOME: ${{ steps.download-commit-range.outcome }}
         run: |
-          # Individual gh/api lookups below are best-effort (wrapped in `|| true`); a single
-          # missing log or issue comment should not abort the whole report. Every
-          # `for row in "${failed_jobs[@]}"` below is guarded by a length check first: on
-          # bash <4.4, `"${arr[@]}"` on a *declared-but-empty* array raises an unbound-variable
-          # error under nounset, and the empty-`failed_jobs` case is a real, expected path here.
+          # Individual gh lookups below are best-effort (wrapped in `|| true`); a single
+          # missing issue comment should not abort the whole report. Every
+          # `for x in "${arr[@]}"` below is guarded by a length check first: on bash <4.4,
+          # `"${arr[@]}"` on a *declared-but-empty* array raises an unbound-variable error
+          # under nounset, and an empty array is a real, expected path here.
           set -uo pipefail
 
           # Pull this job's failure-hash marker back out of a report's text. No match (e.g.
@@ -584,43 +684,29 @@ jobs:
 
           # The matrix job names include the OS/python-version, e.g. "build-vtk (ubuntu-latest, 3.14)"
           failed_jobs_raw=$(gh run view "$RUN_ID" --json jobs \
-            --jq '.jobs[] | select(.conclusion == "failure") | [.databaseId, .name, .url] | @tsv' || true)
-
-          failed_jobs=()
-          while IFS=$'\t' read -r job_id name url; do
-            [ -n "$job_id" ] || continue
-            failed_jobs+=("${job_id}"$'\t'"${name}"$'\t'"${url}")
-          done <<< "$failed_jobs_raw"
+            --jq '.jobs[] | select(.conclusion == "failure") | [.name, .url] | @tsv' || true)
 
           jobs_list=""
+          while IFS=$'\t' read -r name url; do
+            [ -n "$name" ] || continue
+            jobs_list+="- [\`${name}\`](${url})"$'\n'
+          done <<< "$failed_jobs_raw"
+          [ -n "$jobs_list" ] || jobs_list="- (could not determine which jobs failed, see the run)"$'\n'
+
+          # Build the per-job failure-output dropdowns from whatever failure-summary-*
+          # artifacts test jobs uploaded (only jobs that ran pytest and failed produce one;
+          # e.g. a build-vtk failure won't, and that's fine).
           failure_sections=""
-
-          if [ "${#failed_jobs[@]}" -eq 0 ]; then
-            jobs_list="- (could not determine which jobs failed, see the run)"$'\n'
-          else
-            for row in "${failed_jobs[@]}"; do
-              IFS=$'\t' read -r job_id name url <<< "$row"
-              jobs_list+="- [\`${name}\`](${url})"$'\n'
-
-              # Pull the job log and try to isolate a useful failure summary: a pytest
-              # short-summary section, or the marker the Build step prints on a VTK build
-              # failure, falling back to the tail of the log if neither is found.
-              log="$(gh api "repos/${GH_REPO}/actions/jobs/${job_id}/logs" 2>/dev/null || true)"
-              if [ -z "$log" ]; then
-                summary="(could not retrieve the log for this job)"
-              else
-                # grep -m1 exits 1 when neither marker is found (a very normal outcome, e.g.
-                # a timeout or infra failure); with pipefail active that would otherwise abort
-                # this whole step under -e, so the miss must be swallowed right here.
-                start_line="$(printf '%s\n' "$log" | grep -n -m1 -E '=+ short test summary info =+|^::error::VTK build failed' | head -n1 | cut -d: -f1 || true)"
-                if [ -n "$start_line" ]; then
-                  summary="$(printf '%s\n' "$log" | tail -n "+${start_line}" | tail -c 8000)"
-                else
-                  summary="$(printf '%s\n' "$log" | tail -c 8000)"
-                fi
-              fi
-
+          failed_labels=()
+          if [ -d failure-summaries ]; then
+            while IFS= read -r label_file; do
+              summary_file="$(dirname "$label_file")/failure_summary.txt"
+              [ -f "$summary_file" ] || continue
+              name="$(cat "$label_file")"
+              summary="$(cat "$summary_file")"
+              [ -n "$summary" ] || summary="(no output captured)"
               hash="$(printf '%s' "$summary" | sha256sum | cut -d' ' -f1)"
+              failed_labels+=("$name")
 
               # The HTML comment marker records this job's failure signature so a later run
               # can detect "same failure as before" without any external state.
@@ -629,9 +715,8 @@ jobs:
               failure_sections+="<summary>❌ ${name} — failure output</summary>"$'\n\n'
               failure_sections+='```text'$'\n'"${summary}"$'\n''```'$'\n'
               failure_sections+="</details>"$'\n\n'
-            done
+            done < <(find failure-summaries -name job_label.txt | sort)
           fi
-          [ -n "$jobs_list" ] || jobs_list="- (could not determine which jobs failed, see the run)"$'\n'
 
           if [ "$COMMIT_RANGE_OUTCOME" = "success" ] && [ -f vtk-commit-range/vtk-commit-range.md ]; then
             commit_range_body="$(cat vtk-commit-range/vtk-commit-range.md)"
@@ -645,13 +730,12 @@ jobs:
           existing=$(gh issue list --label "vtk-master-wheel-failure" --state open --limit 1 --json number --jq '.[0].number // empty' || true)
 
           repeat_note=""
-          if [ -n "$existing" ] && [ "${#failed_jobs[@]}" -gt 0 ]; then
+          if [ -n "$existing" ] && [ "${#failed_labels[@]}" -gt 0 ]; then
             prev_text="$(gh issue view "$existing" --json body,comments \
               --jq 'if (.comments | length) > 0 then .comments[-1].body else .body end' 2>/dev/null || true)"
             prev_url="$(gh issue view "$existing" --json url,comments \
               --jq 'if (.comments | length) > 0 then .comments[-1].url else .url end' 2>/dev/null || true)"
-            for row in "${failed_jobs[@]}"; do
-              IFS=$'\t' read -r job_id name url <<< "$row"
+            for name in "${failed_labels[@]}"; do
               cur_hash="$(extract_hash "$failure_sections" "$name")"
               prev_hash="$(extract_hash "$prev_text" "$name")"
               if [ -n "$cur_hash" ] && [ -n "$prev_hash" ] && [ "$cur_hash" = "$prev_hash" ]; then

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -57,19 +57,41 @@ jobs:
           git checkout "$NIGHTLY_SHA"
           echo "VTK_NIGHTLY_SHA=$NIGHTLY_SHA" >> "$GITHUB_ENV"
 
-          # Record every commit since the *previous* nightly date-stamp so a failure report
-          # can point at exactly what landed on VTK master in between.
+          # Record every commit since the *previous* nightly date-stamp, grouped by merge
+          # topic (VTK merges each topic branch as a single first-parent merge commit, so
+          # the second parent of each merge is that topic's own commit history), so a
+          # failure report can point at exactly what landed on VTK master in between.
           PREV_NIGHTLY_SHA="$(git log --grep='^VTK Nightly Date Stamp$' --skip=1 -n 1 --format=%H)"
+          BASE_URL="https://gitlab.kitware.com/vtk/vtk/-/commit"
           {
-            if [ -n "$PREV_NIGHTLY_SHA" ]; then
-              echo "Commits since the previous nightly date-stamp ([\`${PREV_NIGHTLY_SHA:0:8}\`](https://gitlab.kitware.com/vtk/vtk/-/commit/${PREV_NIGHTLY_SHA})):"
+            if [ -z "$PREV_NIGHTLY_SHA" ]; then
+              echo "Could not find a previous nightly date-stamp commit within the last 200 commits;"
+              echo "showing only the pinned commit: [\`${NIGHTLY_SHA:0:8}\`](${BASE_URL}/${NIGHTLY_SHA})"
+            else
+              n_commits="$(git rev-list --count "${PREV_NIGHTLY_SHA}..${NIGHTLY_SHA}")"
+              echo "Commits since the previous nightly date-stamp ([\`${PREV_NIGHTLY_SHA:0:8}\`](${BASE_URL}/${PREV_NIGHTLY_SHA})):"
               echo
               echo "[Compare on GitLab](https://gitlab.kitware.com/vtk/vtk/-/compare/${PREV_NIGHTLY_SHA}...${NIGHTLY_SHA})"
               echo
-              git log --no-merges --format='- [`%h`](https://gitlab.kitware.com/vtk/vtk/-/commit/%H) %s (%an)' "${PREV_NIGHTLY_SHA}..${NIGHTLY_SHA}"
-            else
-              echo "Could not find a previous nightly date-stamp commit within the last 200 commits;"
-              echo "showing only the pinned commit: [\`${NIGHTLY_SHA:0:8}\`](https://gitlab.kitware.com/vtk/vtk/-/commit/${NIGHTLY_SHA})"
+              echo "<details>"
+              echo "<summary>${n_commits} commits (grouped by merge topic)</summary>"
+              echo
+              git log --first-parent --reverse --format='%H%x09%h%x09%s%x09%an' \
+                "${PREV_NIGHTLY_SHA}..${NIGHTLY_SHA}" |
+                while IFS=$'\t' read -r full short subject author; do
+                  echo "- [\`${short}\`](${BASE_URL}/${full}) ${subject} (${author})"
+                  read -r -a parents <<<"$(git log -1 --format='%P' "$full")"
+                  if [ "${#parents[@]}" -ge 2 ]; then
+                    # Second parent is the topic branch tip; list what it added over the mainline.
+                    git log --no-merges --reverse --format='%H%x09%h%x09%s%x09%an' \
+                      "${parents[0]}..${parents[1]}" |
+                      while IFS=$'\t' read -r sfull sshort ssubject sauthor; do
+                        echo "  - [\`${sshort}\`](${BASE_URL}/${sfull}) ${ssubject} (${sauthor})"
+                      done
+                  fi
+                done
+              echo
+              echo "</details>"
             fi
           } > "$GITHUB_WORKSPACE/vtk-commit-range.md"
 
@@ -520,6 +542,10 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           COMMIT_RANGE_OUTCOME: ${{ steps.download-commit-range.outcome }}
         run: |
+          # Individual gh/api lookups below are best-effort (wrapped in `|| true`); a single
+          # missing log or issue comment should not abort the whole report.
+          set -uo pipefail
+
           # Ensure the dedup label exists (idempotent).
           gh label create vtk-master-wheel-failure \
             --color cbb230 \
@@ -527,22 +553,80 @@ jobs:
             --force || true
 
           # The matrix job names include the OS/python-version, e.g. "build-vtk (ubuntu-latest, 3.14)"
-          failed=$(gh run view "$RUN_ID" --json jobs \
-            --jq '.jobs[] | select(.conclusion == "failure") | [.name, .url] | @tsv')
+          failed_jobs_raw=$(gh run view "$RUN_ID" --json jobs \
+            --jq '.jobs[] | select(.conclusion == "failure") | [.databaseId, .name, .url] | @tsv')
+
+          failed_jobs=()
+          while IFS=$'\t' read -r job_id name url; do
+            [ -n "$job_id" ] || continue
+            failed_jobs+=("${job_id}"$'\t'"${name}"$'\t'"${url}")
+          done <<< "$failed_jobs_raw"
 
           jobs_list=""
-          while IFS=$'\t' read -r name url; do
-            [ -n "$name" ] || continue
-            jobs_list+="- [\`${name}\`](${url})"$'\n'
-          done <<< "$failed"
+          failure_sections=""
 
+          if [ "${#failed_jobs[@]}" -eq 0 ]; then
+            jobs_list="- (could not determine which jobs failed, see the run)"$'\n'
+          else
+            for row in "${failed_jobs[@]}"; do
+              IFS=$'\t' read -r job_id name url <<< "$row"
+              jobs_list+="- [\`${name}\`](${url})"$'\n'
+
+              # Pull the job log and try to isolate a useful failure summary: a pytest
+              # short-summary section, or the marker the Build step prints on a VTK build
+              # failure, falling back to the tail of the log if neither is found.
+              log="$(gh api "repos/${GH_REPO}/actions/jobs/${job_id}/logs" 2>/dev/null || true)"
+              if [ -z "$log" ]; then
+                summary="(could not retrieve the log for this job)"
+              else
+                start_line="$(printf '%s\n' "$log" | grep -n -m1 -E '=+ short test summary info =+|^::error::VTK build failed' | head -n1 | cut -d: -f1)"
+                if [ -n "$start_line" ]; then
+                  summary="$(printf '%s\n' "$log" | tail -n "+${start_line}" | tail -c 8000)"
+                else
+                  summary="$(printf '%s\n' "$log" | tail -c 8000)"
+                fi
+              fi
+
+              hash="$(printf '%s' "$summary" | sha256sum | cut -d' ' -f1)"
+
+              # The HTML comment marker records this job's failure signature so a later run
+              # can detect "same failure as before" without any external state.
+              failure_sections+="<!-- failure-hash:${name}:${hash} -->"$'\n'
+              failure_sections+="<details>"$'\n'
+              failure_sections+="<summary>❌ ${name} — failure output</summary>"$'\n\n'
+              failure_sections+='```text'$'\n'"${summary}"$'\n''```'$'\n'
+              failure_sections+="</details>"$'\n\n'
+            done
+          fi
           [ -n "$jobs_list" ] || jobs_list="- (could not determine which jobs failed, see the run)"$'\n'
 
           if [ "$COMMIT_RANGE_OUTCOME" = "success" ] && [ -f vtk-commit-range/vtk-commit-range.md ]; then
-            commit_range="$(cat vtk-commit-range/vtk-commit-range.md)"
+            commit_range_body="$(cat vtk-commit-range/vtk-commit-range.md)"
           else
-            commit_range="(could not determine which VTK commits landed since the previous nightly)"
+            commit_range_body="(could not determine which VTK commits landed since the previous nightly)"
           fi
+
+          # Check for an existing open issue, and compare each failed job's signature
+          # against the most recently posted report (the last comment, or the issue body
+          # if there are no comments yet).
+          existing=$(gh issue list --label "vtk-master-wheel-failure" --state open --limit 1 --json number --jq '.[0].number // empty')
+
+          repeat_note=""
+          if [ -n "$existing" ]; then
+            prev_text="$(gh issue view "$existing" --json body,comments \
+              --jq 'if (.comments | length) > 0 then .comments[-1].body else .body end' 2>/dev/null || true)"
+            prev_url="$(gh issue view "$existing" --json url,comments \
+              --jq 'if (.comments | length) > 0 then .comments[-1].url else .url end' 2>/dev/null || true)"
+            for row in "${failed_jobs[@]}"; do
+              IFS=$'\t' read -r job_id name url <<< "$row"
+              cur_hash="$(printf '%s' "$failure_sections" | grep -F "failure-hash:${name}:" | tail -n1 | sed -E 's/.*failure-hash:[^:]+:([0-9a-f]+).*/\1/')"
+              prev_hash="$(printf '%s' "$prev_text" | grep -F "failure-hash:${name}:" | tail -n1 | sed -E 's/.*failure-hash:[^:]+:([0-9a-f]+).*/\1/')"
+              if [ -n "$cur_hash" ] && [ -n "$prev_hash" ] && [ "$cur_hash" = "$prev_hash" ]; then
+                repeat_note+="- \`${name}\`: same failure signature as the [previous report](${prev_url})."$'\n'
+              fi
+            done
+          fi
+          [ -z "$repeat_note" ] || repeat_note="**Repeat failures:**"$'\n'"${repeat_note}"
 
           body=$(cat <<EOF
           ### VTK Master Wheel Failure
@@ -552,14 +636,12 @@ jobs:
 
           **Failing jobs:**
           ${jobs_list}
+          ${repeat_note}
+          ${commit_range_body}
 
-          **VTK commits:**
-          ${commit_range}
+          ${failure_sections}
           EOF
           )
-
-          # Check for an existing open issue
-          existing=$(gh issue list --label "vtk-master-wheel-failure" --state open --limit 1 --json number --jq '.[0].number // empty')
 
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body "$body"

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -269,16 +269,6 @@ jobs:
     with:
       runs-on: "ubuntu-22.04"
 
-  # The macOS self-hosted runner needs its own cache (GitHub-hosted runners
-  # share cache-github-hosted across Linux and Windows).
-  cache-macOS-self-hosted:
-    needs: check-should-run
-    if: needs.check-should-run.outputs.run == 'true'
-    name: Cache pyvista/data
-    uses: ./.github/workflows/cache-pyvista-data.yml
-    with:
-      runs-on: "macos-15-self-hosted"
-
   test-linux:
     needs: [check-should-run, build-vtk, cache-github-hosted]
     if: ${{ !cancelled() && needs.check-should-run.outputs.run == 'true' }}
@@ -352,14 +342,16 @@ jobs:
         run: |
           echo "${{ github.job }} (${{ join(matrix.*, ', ') }})" > job_label.txt
           : > failure_summary.txt
+          # tox/pytest force-colorize (TOX_COLORED=yes) even when piped to `tee`; strip the
+          # ANSI escapes so the summary reads cleanly inside a markdown code block.
           for log in core-test.log plotting-test.log; do
             [ -s "$log" ] || continue
             start_line="$(grep -n -m1 -E '=+ short test summary info =+' "$log" | head -n1 | cut -d: -f1 || true)"
             if [ -n "$start_line" ]; then
-              tail -n "+${start_line}" "$log" | tail -c 4000 >> failure_summary.txt
+              tail -n "+${start_line}" "$log"
             else
-              tail -c 4000 "$log" >> failure_summary.txt
-            fi
+              cat "$log"
+            fi | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g' | tail -c 4000 >> failure_summary.txt
             echo >> failure_summary.txt
           done
 
@@ -387,15 +379,14 @@ jobs:
           path: _generated_test_images
 
   test-macOS:
-    needs: [check-should-run, build-vtk, cache-macOS-self-hosted]
+    needs: [check-should-run, build-vtk, cache-github-hosted]
     if: ${{ !cancelled() && needs.check-should-run.outputs.run == 'true' }}
     strategy:
       fail-fast: false
       matrix:
-        # Self-hosted runner configuration
-        runner-labels: ["macos-15-self-hosted"]
+        os: [macos-latest]
         python-version: ["3.14"]
-    runs-on: ${{ matrix.runner-labels }}
+    runs-on: ${{ matrix.os }}
 
     env:
       VTK_WHEEL_DIR: ${{ github.workspace }}/vtk-wheel
@@ -406,19 +397,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python ${{ matrix.python-version }}
-        if: runner.environment != 'self-hosted'
+      - name: Setup Python
         uses: actions/setup-python@v7
-        continue-on-error: true
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
-
-      - name: Set Python PATH and create a virtual env
-        if: runner.environment == 'self-hosted'
-        run: |
-          /opt/homebrew/bin/python${{ matrix.python-version }} -m venv .venv
-          echo "${{ github.workspace }}/.venv/bin" >> $GITHUB_PATH
 
       - name: Download VTK wheel artifact
         id: download-wheel
@@ -441,7 +424,7 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ${{ env.CACHE_FOLDER_NAME }}
-          key: ${{ needs.cache-macOS-self-hosted.outputs.key }}
+          key: ${{ needs.cache-github-hosted.outputs.key }}
           enableCrossOsArchive: true
 
       - name: Install tox-uv
@@ -463,14 +446,16 @@ jobs:
         run: |
           echo "${{ github.job }} (${{ join(matrix.*, ', ') }})" > job_label.txt
           : > failure_summary.txt
+          # tox/pytest force-colorize (TOX_COLORED=yes) even when piped to `tee`; strip the
+          # ANSI escapes so the summary reads cleanly inside a markdown code block.
           for log in core-test.log plotting-test.log; do
             [ -s "$log" ] || continue
             start_line="$(grep -n -m1 -E '=+ short test summary info =+' "$log" | head -n1 | cut -d: -f1 || true)"
             if [ -n "$start_line" ]; then
-              tail -n "+${start_line}" "$log" | tail -c 4000 >> failure_summary.txt
+              tail -n "+${start_line}" "$log"
             else
-              tail -c 4000 "$log" >> failure_summary.txt
-            fi
+              cat "$log"
+            fi | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g' | tail -c 4000 >> failure_summary.txt
             echo >> failure_summary.txt
           done
 
@@ -580,14 +565,16 @@ jobs:
         run: |
           echo "${{ github.job }} (${{ join(matrix.*, ', ') }})" > job_label.txt
           : > failure_summary.txt
+          # tox/pytest force-colorize (TOX_COLORED=yes) even when piped to `tee`; strip the
+          # ANSI escapes so the summary reads cleanly inside a markdown code block.
           for log in core-test.log plotting-test.log; do
             [ -s "$log" ] || continue
             start_line="$(grep -n -m1 -E '=+ short test summary info =+' "$log" | head -n1 | cut -d: -f1 || true)"
             if [ -n "$start_line" ]; then
-              tail -n "+${start_line}" "$log" | tail -c 4000 >> failure_summary.txt
+              tail -n "+${start_line}" "$log"
             else
-              tail -c 4000 "$log" >> failure_summary.txt
-            fi
+              cat "$log"
+            fi | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g' | tail -c 4000 >> failure_summary.txt
             echo >> failure_summary.txt
           done
 
@@ -620,7 +607,6 @@ jobs:
         check-should-run,
         build-vtk,
         cache-github-hosted,
-        cache-macOS-self-hosted,
         test-linux,
         test-macOS,
         test-windows,

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -343,15 +343,24 @@ jobs:
           echo "${{ github.job }} (${{ join(matrix.*, ', ') }})" > job_label.txt
           : > failure_summary.txt
           # tox/pytest force-colorize (TOX_COLORED=yes) even when piped to `tee`; strip the
-          # ANSI escapes so the summary reads cleanly inside a markdown code block.
+          # ANSI escapes so the summary reads cleanly inside a markdown code block. Truncate
+          # by bytes from the end (to keep the actually-relevant tail of the log), but if that
+          # truncated, drop its first line too: a byte cut can land mid-line/mid-word.
           for log in core-test.log plotting-test.log; do
             [ -s "$log" ] || continue
             start_line="$(grep -n -m1 -E '=+ short test summary info =+' "$log" | head -n1 | cut -d: -f1 || true)"
             if [ -n "$start_line" ]; then
-              tail -n "+${start_line}" "$log"
+              segment="$(tail -n "+${start_line}" "$log")"
             else
-              cat "$log"
-            fi | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g' | tail -c 4000 >> failure_summary.txt
+              segment="$(cat "$log")"
+            fi
+            segment="$(printf '%s' "$segment" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')"
+            size="$(printf '%s' "$segment" | wc -c | tr -d ' ')"
+            if [ "$size" -gt 4000 ]; then
+              printf '%s' "$segment" | tail -c 4000 | tail -n +2 >> failure_summary.txt
+            else
+              printf '%s' "$segment" >> failure_summary.txt
+            fi
             echo >> failure_summary.txt
           done
 
@@ -447,15 +456,24 @@ jobs:
           echo "${{ github.job }} (${{ join(matrix.*, ', ') }})" > job_label.txt
           : > failure_summary.txt
           # tox/pytest force-colorize (TOX_COLORED=yes) even when piped to `tee`; strip the
-          # ANSI escapes so the summary reads cleanly inside a markdown code block.
+          # ANSI escapes so the summary reads cleanly inside a markdown code block. Truncate
+          # by bytes from the end (to keep the actually-relevant tail of the log), but if that
+          # truncated, drop its first line too: a byte cut can land mid-line/mid-word.
           for log in core-test.log plotting-test.log; do
             [ -s "$log" ] || continue
             start_line="$(grep -n -m1 -E '=+ short test summary info =+' "$log" | head -n1 | cut -d: -f1 || true)"
             if [ -n "$start_line" ]; then
-              tail -n "+${start_line}" "$log"
+              segment="$(tail -n "+${start_line}" "$log")"
             else
-              cat "$log"
-            fi | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g' | tail -c 4000 >> failure_summary.txt
+              segment="$(cat "$log")"
+            fi
+            segment="$(printf '%s' "$segment" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')"
+            size="$(printf '%s' "$segment" | wc -c | tr -d ' ')"
+            if [ "$size" -gt 4000 ]; then
+              printf '%s' "$segment" | tail -c 4000 | tail -n +2 >> failure_summary.txt
+            else
+              printf '%s' "$segment" >> failure_summary.txt
+            fi
             echo >> failure_summary.txt
           done
 
@@ -566,15 +584,24 @@ jobs:
           echo "${{ github.job }} (${{ join(matrix.*, ', ') }})" > job_label.txt
           : > failure_summary.txt
           # tox/pytest force-colorize (TOX_COLORED=yes) even when piped to `tee`; strip the
-          # ANSI escapes so the summary reads cleanly inside a markdown code block.
+          # ANSI escapes so the summary reads cleanly inside a markdown code block. Truncate
+          # by bytes from the end (to keep the actually-relevant tail of the log), but if that
+          # truncated, drop its first line too: a byte cut can land mid-line/mid-word.
           for log in core-test.log plotting-test.log; do
             [ -s "$log" ] || continue
             start_line="$(grep -n -m1 -E '=+ short test summary info =+' "$log" | head -n1 | cut -d: -f1 || true)"
             if [ -n "$start_line" ]; then
-              tail -n "+${start_line}" "$log"
+              segment="$(tail -n "+${start_line}" "$log")"
             else
-              cat "$log"
-            fi | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g' | tail -c 4000 >> failure_summary.txt
+              segment="$(cat "$log")"
+            fi
+            segment="$(printf '%s' "$segment" | sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g')"
+            size="$(printf '%s' "$segment" | wc -c | tr -d ' ')"
+            if [ "$size" -gt 4000 ]; then
+              printf '%s' "$segment" | tail -c 4000 | tail -n +2 >> failure_summary.txt
+            else
+              printf '%s' "$segment" >> failure_summary.txt
+            fi
             echo >> failure_summary.txt
           done
 

--- a/check_local_vtk_wheel.py
+++ b/check_local_vtk_wheel.py
@@ -1,14 +1,7 @@
 """Fail unless the installed vtk matches the wheel in VTK_WHEEL_DIR.
 
-Run as a `vtk_local` `commands_pre` step in tox.ini, right after `vtk_local_install`.
-`uv pip install --no-index --find-links ...` can silently keep an already-installed vtk
-instead of the local wheel (e.g. its own version comparison decides the current install
-already "satisfies", or the wheel's platform tag doesn't match the runner) rather than
-erroring, so this checks explicitly.
-
-Deliberately not part of toxfile.py: that module is a tox plugin, imported by tox itself,
-and its top-level imports pull in `tox`/`tox_uv` -- packages installed only in the outer
-tox-runner environment, not inside each per-testenv venv this script actually runs in.
+Standalone rather than part of toxfile.py (a tox plugin -- tox/tox_uv aren't installed
+inside a testenv) so this can run as a `vtk_local` commands_pre step.
 """
 
 from __future__ import annotations

--- a/check_local_vtk_wheel.py
+++ b/check_local_vtk_wheel.py
@@ -1,0 +1,48 @@
+"""Fail unless the installed vtk matches the wheel in VTK_WHEEL_DIR.
+
+Run as a `vtk_local` `commands_pre` step in tox.ini, right after `vtk_local_install`.
+`uv pip install --no-index --find-links ...` can silently keep an already-installed vtk
+instead of the local wheel (e.g. its own version comparison decides the current install
+already "satisfies", or the wheel's platform tag doesn't match the runner) rather than
+erroring, so this checks explicitly.
+
+Deliberately not part of toxfile.py: that module is a tox plugin, imported by tox itself,
+and its top-level imports pull in `tox`/`tox_uv` -- packages installed only in the outer
+tox-runner environment, not inside each per-testenv venv this script actually runs in.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as installed_version
+import os
+from pathlib import Path
+
+from packaging.utils import parse_wheel_filename
+from packaging.version import Version
+
+
+def main() -> None:
+    """Compare the installed vtk version against the wheel in VTK_WHEEL_DIR."""
+    wheel_dir = Path(os.environ['VTK_WHEEL_DIR'])
+    wheels = list(wheel_dir.glob('vtk-*.whl'))
+    if not wheels:
+        msg = f'No VTK wheel found in VTK_WHEEL_DIR ({wheel_dir}).'
+        raise SystemExit(msg)
+
+    _name, expected, _build, _tags = parse_wheel_filename(wheels[0].name)
+    try:
+        installed = Version(installed_version('vtk'))
+    except PackageNotFoundError:
+        installed = None
+
+    if installed != expected:
+        msg = (
+            f'Expected the local VTK wheel ({expected}) to be installed, but found'
+            f' {installed} instead.'
+        )
+        raise SystemExit(msg)
+
+
+if __name__ == '__main__':
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -66,11 +66,17 @@ numpy_nightly_install = uv pip install --upgrade --pre --no-cache --no-deps --ex
 vtk_dev_install = uv pip install --upgrade --pre --no-cache --no-deps --extra-index-url {[testenv]uv_index_vtk_dev} vtk
 vtk_local_install = uv pip install --upgrade --pre --no-cache --no-deps --no-index --find-links {env:VTK_WHEEL_DIR} vtk
 vtk_latest_install = uv pip install --upgrade --pre --no-deps vtk
+# uv/pip may silently keep an already-installed vtk instead of the local wheel (e.g. if it
+# looks newer/compatible by its own comparison, or the wheel's platform tag doesn't match the
+# runner) rather than erroring, so vtk_local_verify checks the installed version actually
+# matches the wheel's own filename and fails the run if it doesn't.
+vtk_local_verify = import glob, os, re; from importlib.metadata import version as _v; _dir = os.environ["VTK_WHEEL_DIR"]; _wheels = glob.glob(os.path.join(_dir, "vtk-*.whl")); assert _wheels, "No VTK wheel found in " + _dir; _expected = re.match(r"vtk-([^-]+)-", os.path.basename(_wheels[0])).group(1); _installed = _v("vtk"); assert _installed == _expected, "Expected local VTK wheel " + _expected + " to be installed, but found " + _installed + " instead"
 
 commands_pre =
     numpy_nightly: python -c 'import os, subprocess; os.environ["UV_INDEX"]="{[testenv]uv_index_numpy_nightly}"; subprocess.run("{[testenv]numpy_nightly_install}".split(), check=True)'
     vtk_dev: python -c 'import os, subprocess; os.environ["UV_INDEX"]="{[testenv]uv_index_vtk_dev}"; subprocess.run("{[testenv]vtk_dev_install}".split(), check=True)'
     vtk_local: python -c 'import os, subprocess; subprocess.run("{[testenv]vtk_local_install}".split(), check=True)'
+    vtk_local: python -c '{[testenv]vtk_local_verify}'
     vtk_latest: python -c "import subprocess; subprocess.run('{[testenv]vtk_latest_install}'.split(), check=True)"
     {[testenv]software_report_cmdline}
 

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,7 @@ commands_pre =
     numpy_nightly: python -c 'import os, subprocess; os.environ["UV_INDEX"]="{[testenv]uv_index_numpy_nightly}"; subprocess.run("{[testenv]numpy_nightly_install}".split(), check=True)'
     vtk_dev: python -c 'import os, subprocess; os.environ["UV_INDEX"]="{[testenv]uv_index_vtk_dev}"; subprocess.run("{[testenv]vtk_dev_install}".split(), check=True)'
     vtk_local: python -c 'import os, subprocess; subprocess.run("{[testenv]vtk_local_install}".split(), check=True)'
+    vtk_local: python {tox_root}/check_local_vtk_wheel.py
     vtk_latest: python -c "import subprocess; subprocess.run('{[testenv]vtk_latest_install}'.split(), check=True)"
     {[testenv]software_report_cmdline}
 

--- a/tox.ini
+++ b/tox.ini
@@ -66,17 +66,11 @@ numpy_nightly_install = uv pip install --upgrade --pre --no-cache --no-deps --ex
 vtk_dev_install = uv pip install --upgrade --pre --no-cache --no-deps --extra-index-url {[testenv]uv_index_vtk_dev} vtk
 vtk_local_install = uv pip install --upgrade --pre --no-cache --no-deps --no-index --find-links {env:VTK_WHEEL_DIR} vtk
 vtk_latest_install = uv pip install --upgrade --pre --no-deps vtk
-# uv/pip may silently keep an already-installed vtk instead of the local wheel (e.g. if it
-# looks newer/compatible by its own comparison, or the wheel's platform tag doesn't match the
-# runner) rather than erroring, so vtk_local_verify checks the installed version actually
-# matches the wheel's own filename and fails the run if it doesn't.
-vtk_local_verify = import glob, os, re; from importlib.metadata import version as _v; _dir = os.environ["VTK_WHEEL_DIR"]; _wheels = glob.glob(os.path.join(_dir, "vtk-*.whl")); assert _wheels, "No VTK wheel found in " + _dir; _expected = re.match(r"vtk-([^-]+)-", os.path.basename(_wheels[0])).group(1); _installed = _v("vtk"); assert _installed == _expected, "Expected local VTK wheel " + _expected + " to be installed, but found " + _installed + " instead"
 
 commands_pre =
     numpy_nightly: python -c 'import os, subprocess; os.environ["UV_INDEX"]="{[testenv]uv_index_numpy_nightly}"; subprocess.run("{[testenv]numpy_nightly_install}".split(), check=True)'
     vtk_dev: python -c 'import os, subprocess; os.environ["UV_INDEX"]="{[testenv]uv_index_vtk_dev}"; subprocess.run("{[testenv]vtk_dev_install}".split(), check=True)'
     vtk_local: python -c 'import os, subprocess; subprocess.run("{[testenv]vtk_local_install}".split(), check=True)'
-    vtk_local: python -c '{[testenv]vtk_local_verify}'
     vtk_latest: python -c "import subprocess; subprocess.run('{[testenv]vtk_latest_install}'.split(), check=True)"
     {[testenv]software_report_cmdline}
 

--- a/toxfile.py
+++ b/toxfile.py
@@ -2,10 +2,12 @@ from __future__ import annotations  # noqa: D100
 
 import logging
 import os
+from pathlib import Path
 import re
 from typing import TYPE_CHECKING
 
 from packaging.requirements import Requirement
+from packaging.utils import parse_wheel_filename
 from packaging.version import Version
 from tox.execute.api import StdinSource
 from tox.plugin import impl
@@ -115,6 +117,33 @@ def _get_freezed_requirements(lines: list[str]) -> Generator[tuple[str, Version]
             yield _normalize_package_name(req.name), Version(m.group(2))
 
 
+def _check_local_vtk_wheel(tox_env: ToxEnv, installed: list[tuple[str, Version]]) -> None:
+    """For a `vtk_local` env, fail if the installed vtk isn't the wheel in VTK_WHEEL_DIR.
+
+    `uv pip install --no-index --find-links ...` can silently keep an already-installed vtk
+    instead of the local wheel (e.g. its own version comparison decides the current install
+    already "satisfies", or the wheel's platform tag doesn't match the runner) rather than
+    erroring, so this needs to be checked explicitly.
+    """
+    if 'vtk_local' not in tox_env.name:
+        return
+
+    wheel_dir = Path(os.environ['VTK_WHEEL_DIR'])
+    wheels = list(wheel_dir.glob('vtk-*.whl'))
+    if not wheels:
+        msg = f'No VTK wheel found in VTK_WHEEL_DIR ({wheel_dir}).'
+        raise Fail(msg)
+
+    _name, expected_version, _build, _tags = parse_wheel_filename(wheels[0].name)
+    installed_version = next((v for n, v in installed if n == 'vtk'), None)
+    if installed_version != expected_version:
+        msg = (
+            f'Expected the local VTK wheel ({expected_version}) to be installed, but found'
+            f' {installed_version} instead.'
+        )
+        raise Fail(msg)
+
+
 @impl
 def tox_before_run_commands(tox_env: ToxEnv) -> None:
     """Check that deps declared in the constraints_file (ie. during the `deps` step above)
@@ -138,6 +167,8 @@ def tox_before_run_commands(tox_env: ToxEnv) -> None:
     # Relies on the fact the the freeze command outputs lines in the
     # form of `package==version` (eg. `vtk==9.4.2`)
     installed = list(_get_freezed_requirements(out.out.splitlines()))
+
+    _check_local_vtk_wheel(tox_env, installed)
 
     # Check that the installed requirements match the constraints file ones
     for req in requirements:

--- a/toxfile.py
+++ b/toxfile.py
@@ -2,12 +2,10 @@ from __future__ import annotations  # noqa: D100
 
 import logging
 import os
-from pathlib import Path
 import re
 from typing import TYPE_CHECKING
 
 from packaging.requirements import Requirement
-from packaging.utils import parse_wheel_filename
 from packaging.version import Version
 from tox.execute.api import StdinSource
 from tox.plugin import impl
@@ -117,33 +115,6 @@ def _get_freezed_requirements(lines: list[str]) -> Generator[tuple[str, Version]
             yield _normalize_package_name(req.name), Version(m.group(2))
 
 
-def _check_local_vtk_wheel(tox_env: ToxEnv, installed: list[tuple[str, Version]]) -> None:
-    """For a `vtk_local` env, fail if the installed vtk isn't the wheel in VTK_WHEEL_DIR.
-
-    `uv pip install --no-index --find-links ...` can silently keep an already-installed vtk
-    instead of the local wheel (e.g. its own version comparison decides the current install
-    already "satisfies", or the wheel's platform tag doesn't match the runner) rather than
-    erroring, so this needs to be checked explicitly.
-    """
-    if 'vtk_local' not in tox_env.name:
-        return
-
-    wheel_dir = Path(os.environ['VTK_WHEEL_DIR'])
-    wheels = list(wheel_dir.glob('vtk-*.whl'))
-    if not wheels:
-        msg = f'No VTK wheel found in VTK_WHEEL_DIR ({wheel_dir}).'
-        raise Fail(msg)
-
-    _name, expected_version, _build, _tags = parse_wheel_filename(wheels[0].name)
-    installed_version = next((v for n, v in installed if n == 'vtk'), None)
-    if installed_version != expected_version:
-        msg = (
-            f'Expected the local VTK wheel ({expected_version}) to be installed, but found'
-            f' {installed_version} instead.'
-        )
-        raise Fail(msg)
-
-
 @impl
 def tox_before_run_commands(tox_env: ToxEnv) -> None:
     """Check that deps declared in the constraints_file (ie. during the `deps` step above)
@@ -167,8 +138,6 @@ def tox_before_run_commands(tox_env: ToxEnv) -> None:
     # Relies on the fact the the freeze command outputs lines in the
     # form of `package==version` (eg. `vtk==9.4.2`)
     installed = list(_get_freezed_requirements(out.out.splitlines()))
-
-    _check_local_vtk_wheel(tox_env, installed)
 
     # Check that the installed requirements match the constraints file ones
     for req in requirements:


### PR DESCRIPTION
### Overview

VTK master failures like the one from #8956 would benefit from explicitly listing all commits since the last date stamp.

This PR adds those links in the failure message. In addition, the failure mode is reported and hashed, so that the _next_ failure can check if the failure mode has changed, and report as such. This should help distinguish noise from the cause of the error in case a failure goes unfixed for extended periods of time. 
