### PR TITLE
Bump sphinx-autocodelink docs pin to 0.6.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ docs = [
   'ruamel-yaml<0.20.0',
   'scipy==1.16.3; python_version >= "3.11"',
   'sphinx-autobuild==2024.10.3',
-  'sphinx-autocodelink==0.6.2',
+  'sphinx-autocodelink==0.6.3',
   'sphinx-autoopengraph==0.2.1',
   'sphinx-book-theme==1.1.4',
   'sphinx-copybutton==0.5.2',


### PR DESCRIPTION
## What

Bumps the docs dependency group's `sphinx-autocodelink` pin from `0.6.2` to `0.6.3`, now published on PyPI.

0.6.3 fixes [pyvista/sphinx-autocodelink#3](https://github.com/pyvista/sphinx-autocodelink/pull/3): a chained method call with no intermediate variable on a downloader's result -- e.g. `examples.download_lucy().triangulate()`, as seen on [dev.pyvista.org's clip_closed_surface example](https://dev.pyvista.org/examples/01-filter/clip_closed_surface.html) -- failed to link, because `download_lucy`'s `load: bool = True` toggle gives it a union return type (`PolyData | str`) the extension couldn't resolve at all. It now matches the call's actual argument against the function's `@overload`s (via `typing.get_overloads`) to resolve the precise return type, falling back to its previous best-effort guess when that can't be done unambiguously (no overloads, a non-literal argument, or conflicting call sites on the same page).

The test group's `sphinx-autocodelink>=0.6,<0.7` lower bound is left unchanged -- nothing in pyvista's own test suite asserts this specific fix, so pyvista's tests wouldn't fail without the tighter bound.

## Testing

`uv lock --upgrade-package sphinx-autocodelink` resolves cleanly against the published 0.6.3. Pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)