### PR TITLE
Remove example refs already covered by Used In, and check for them

### DIFF
--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -3274,8 +3274,6 @@ class ImageDataFilters(DataSetFilters):
         - The bounds have decreased by half the spacing
         - The output ``N Points`` equals the input ``N Cells``
 
-        See :ref:`image_representations_example` for more examples using this filter.
-
         """
         if scalars is not None:
             field = self.get_array_association(scalars, preference='cell')

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -800,8 +800,6 @@ class PolyData(_PointSet, PolyDataFilters, _vtk.vtkPolyData):
     >>> _ = pl.add_mesh(larger_sphere, color='blue', opacity=0.3, show_edges=True)
     >>> pl.show()
 
-    See :ref:`create_poly_example` for more examples.
-
     """
 
     _WRITERS: ClassVar[dict[str, type[BaseWriter]]] = {
@@ -2662,9 +2660,6 @@ class UnstructuredGrid(PointGrid, UnstructuredGridFilters, _vtk.vtkUnstructuredG
     ... ]
     >>> grid = pv.UnstructuredGrid(cells, celltypes, points)
     >>> grid.plot(show_edges=True)
-
-    See the :ref:`create_unstructured_surface_example` example for more details
-    on creating unstructured grids within PyVista.
 
     """
 

--- a/pyvista/core/utilities/features.py
+++ b/pyvista/core/utilities/features.py
@@ -817,9 +817,6 @@ def sample_function(  # noqa: PLR0917
     >>> surf = pv.sample_function(noise, dim=(200, 200, 1))
     >>> surf.plot()
 
-    See :ref:`perlin_noise_2d_example` and :ref:`perlin_noise_3d_example`
-    for a full example using this function.
-
     """
     # internal import to avoid circular dependency
     from pyvista.core.filters import _update_alg  # noqa: PLC0415

--- a/pyvista/examples/examples.py
+++ b/pyvista/examples/examples.py
@@ -632,9 +632,6 @@ def load_hydrogen_orbital(n: int = 1, l: int = 0, m: int = 0, zoom_fac: float = 
     >>> grid = examples.load_hydrogen_orbital(3, 2, -2)
     >>> grid.plot(volume=True, opacity=[1, 0, 1], cmap='magma')
 
-    See :ref:`atomic_orbitals_example` for additional examples using
-    this function.
-
     .. seealso::
 
         :ref:`Hydrogen Orbital Dataset <hydrogen_orbital_dataset>`

--- a/pyvista/plotting/picking.py
+++ b/pyvista/plotting/picking.py
@@ -585,8 +585,6 @@ class PickingComponent(_NoNewAttrMixin):
         >>> _ = pl.add_mesh(pv.Cube(), pickable=False)
         >>> pl.enable_point_picking(show_message='Pick a point')
 
-        See :ref:`point_picking_example` for a full example using this method.
-
 
         """
         self._validate_picker_not_in_use()
@@ -883,8 +881,6 @@ class PickingComponent(_NoNewAttrMixin):
         >>> _ = pl.add_mesh(cube)
         >>> _ = pl.enable_surface_point_picking()
 
-        See :ref:`surface_point_picking_example` for a full example using this method.
-
 
         """
         picker = PickerType.from_any(picker)
@@ -1040,8 +1036,6 @@ class PickingComponent(_NoNewAttrMixin):
         >>> _ = pl.add_mesh(mesh)
         >>> _ = pl.add_mesh(cube)
         >>> _ = pl.enable_mesh_picking()
-
-        See :ref:`mesh_picking_example` for a full example using this method.
 
 
         """

--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -655,8 +655,6 @@ class BasePlotter(_BoundsSizeMixin):
         >>> pl.camera.zoom(1.8)  # doctest:+SKIP
         >>> pl.show()  # doctest:+SKIP
 
-        See :ref:`load_gltf_example` for a full example using this method.
-
         """
         filename = Path(filename).expanduser().resolve()
         if not filename.is_file():
@@ -693,8 +691,6 @@ class BasePlotter(_BoundsSizeMixin):
         >>> pl = pv.Plotter()  # doctest:+SKIP
         >>> pl.import_vrml(sextant_file)  # doctest:+SKIP
         >>> pl.show()  # doctest:+SKIP
-
-        See :ref:`load_vrml_example` for a full example using this method.
 
         """
         filename = Path(filename).expanduser().resolve()
@@ -1447,9 +1443,6 @@ class BasePlotter(_BoundsSizeMixin):
         >>> _ = pl.add_mesh(pv.Sphere(), show_edges=True)
         >>> pl.show()
 
-        See :ref:`anti_aliasing_example` for a full example demonstrating
-        VTK's anti-aliasing approaches.
-
         """
         # apply MSAA to entire render window
         if aa_type == 'msaa':
@@ -1490,9 +1483,6 @@ class BasePlotter(_BoundsSizeMixin):
         >>> pl.disable_anti_aliasing()
         >>> _ = pl.add_mesh(pv.Sphere(), show_edges=True)
         >>> pl.show()
-
-        See :ref:`anti_aliasing_example` for a full example demonstrating
-        VTK's anti-aliasing approaches.
 
         """
         self.render_window.SetMultiSamples(0)  # type: ignore[union-attr]
@@ -5865,8 +5855,6 @@ class BasePlotter(_BoundsSizeMixin):
         >>> pl = pv.Plotter()
         >>> pl.open_gif('movie.gif', fps=8, palettesize=64)  # doctest:+SKIP
 
-        See :ref:`gif_example` for a full example using this method.
-
         """
         try:
             from imageio import __version__  # noqa: PLC0415
@@ -5904,8 +5892,6 @@ class BasePlotter(_BoundsSizeMixin):
         >>> pl.open_movie(filename)  # doctest:+SKIP
         >>> pl.add_mesh(pv.Sphere())  # doctest:+SKIP
         >>> pl.write_frame()  # doctest:+SKIP
-
-        See :ref:`movie_example` for a full example using this method.
 
         """
         # if off screen, show has not been called and we must render
@@ -6919,8 +6905,6 @@ class BasePlotter(_BoundsSizeMixin):
         ...     factor=2.0, n_points=50, shift=0.0, viewup=viewup
         ... )
 
-        See :ref:`orbit_example` for a full example using this method.
-
         """
         if viewup is None:
             viewup = self._theme.camera.viewup
@@ -7021,8 +7005,6 @@ class BasePlotter(_BoundsSizeMixin):
         ...     factor=2.0, n_points=24, shift=0.0, viewup=viewup
         ... )
         >>> pl.orbit_on_path(orbit, write_frames=True, viewup=viewup, step=0.02)
-
-        See :ref:`orbit_example` for a full example using this method.
 
         """
         if focus is None:

--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -3496,8 +3496,6 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
         >>> pl.add_blurring()
         >>> pl.show()
 
-        See :ref:`blurring_example` for a full example using this method.
-
         """
         self._render_passes.add_blur_pass()
 
@@ -3555,8 +3553,6 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
         ... )
         >>> pl.enable_depth_of_field()
         >>> pl.show()
-
-        See :ref:`depth_of_field_example` for a full example using this method.
 
         """
         self._render_passes.enable_depth_of_field_pass(

--- a/pyvista/plotting/widgets.py
+++ b/pyvista/plotting/widgets.py
@@ -398,8 +398,6 @@ class WidgetComponent(_NoNewAttrMixin):
         >>> _ = pl.add_mesh_clip_box(mesh, color='white')
         >>> pl.show()
 
-        For a full example see :ref:`box_widget_example`.
-
         """
         from pyvista.core.filters import _get_output  # avoids circular import
 
@@ -832,8 +830,6 @@ class WidgetComponent(_NoNewAttrMixin):
         >>> pl.show(cpos=[-2.1, 0.6, 1.5])
         >>> pl.widgets.plane_clipped_meshes  # doctest:+SKIP
 
-        For a full example see :ref:`plane_widget_example`.
-
         """
         from pyvista.core.filters import _get_output  # avoids circular import
 
@@ -1146,8 +1142,6 @@ class WidgetComponent(_NoNewAttrMixin):
         >>> _ = pl.add_mesh(mesh.outline())
         >>> _ = pl.add_mesh_slice(mesh, normal=[1, 0, 0.3])
         >>> pl.show()
-
-        For a full example see :ref:`plane_widget_example`.
 
         """
         mesh, algo = algorithm_to_mesh_handler(mesh)
@@ -2722,8 +2716,6 @@ class WidgetComponent(_NoNewAttrMixin):
         ...     actor.SetVisibility(flag)
         >>> _ = pl.add_checkbox_button_widget(toggle_vis, value=True)
         >>> pl.show()
-
-        Download the interactive example at :ref:`checkbox_widget_example`.
 
         """
         msg = 'Cannot add a widget to a closed plotter.'

--- a/tests/doc/doc_build/test_gallery_examples.py
+++ b/tests/doc/doc_build/test_gallery_examples.py
@@ -190,20 +190,20 @@ def test_example_anchor(case):
         raise pytest.fail(msg)
 
 
-# -- no "See Also" entry duplicates an example already in "Used In" -----------
-# Both numpydoc's own "See Also" section and a raw `.. seealso::` directive get hoisted
-# to a real ``<section>``/``<h2>See Also`` heading (conf.py's promote_seealso_admonitions),
-# not left as an `.. admonition:: seealso` div. A hand-written link to a gallery example
-# there is only a problem once sphinx-autocodelink's own "Used In" section already shows
-# the same example -- at that point it's pure duplication, and unlike "Used In", it never
-# gets rechecked against what the example actually does. A "See Also" example that "Used
-# In" doesn't (yet) cover is left alone -- that's real information, not redundancy.
+# -- no hand-written ref duplicates an example already in "Used In" -----------
+# Covers "See Also" entries and the trailing "See X for more examples" pointers that
+# accumulate at the end of "Examples". Only a duplicate of what "Used In" already shows
+# counts: a ref it doesn't cover is real information. Refs inside a parameter description
+# explain that parameter and render outside both sections, so they're out of scope.
 
 _SEE_ALSO_RE = re.compile(r'<section[^>]*>\s*<h2>See Also.*?</section>', re.DOTALL)
+_EXAMPLES_SECTION_RE = re.compile(r'<section[^>]*>\s*<h2>Examples.*?</section>', re.DOTALL)
 _BACKREFS_SECTION_RE = re.compile(
     r'<section class="sphinx-autocodelink-backrefs"[^>]*>.*?</section>', re.DOTALL
 )
 _EXAMPLE_HREF_RE = re.compile(r'href="([^"]*/examples/[^"]*)"')
+#: Auto-linked `pyvista.examples` hrefs inside doctests aren't hand-written pointers.
+_CODE_BLOCK_RE = re.compile(r'<pre[^>]*>.*?</pre>', re.DOTALL)
 
 
 def _example_hrefs(blocks: list[str]) -> set[str]:
@@ -212,21 +212,34 @@ def _example_hrefs(blocks: list[str]) -> set[str]:
     return {Path(href.split('#')[0]).name for href in hrefs}
 
 
-def test_see_also_does_not_duplicate_used_in_examples():
+def _prose_example_hrefs(blocks: list[str]) -> set[str]:
+    """Like :func:`_example_hrefs`, ignoring links inside code blocks."""
+    return _example_hrefs([_CODE_BLOCK_RE.sub('', block) for block in blocks])
+
+
+@pytest.mark.parametrize(
+    ('section', 'pattern', 'hrefs'),
+    [
+        ('See Also', _SEE_ALSO_RE, _example_hrefs),
+        ('Examples', _EXAMPLES_SECTION_RE, _prose_example_hrefs),
+    ],
+    ids=['see-also', 'examples'],
+)
+def test_section_does_not_duplicate_used_in_examples(section, pattern, hrefs):
     pages = sorted(Path(BUILD_HTML_DIR).rglob('*.html'))
     assert pages, f'no built pages found under {BUILD_HTML_DIR}. Build the documentation first.'
 
     failures = {}
     for page in pages:
         html_text = page.read_text(encoding='utf-8')
-        see_also_examples = _example_hrefs(_SEE_ALSO_RE.findall(html_text))
+        section_examples = hrefs(pattern.findall(html_text))
         used_in_examples = _example_hrefs(_BACKREFS_SECTION_RE.findall(html_text))
-        duplicated = see_also_examples & used_in_examples
+        duplicated = section_examples & used_in_examples
         if duplicated:
             failures[page.stem] = duplicated
 
     note = (
-        'Remove the "See Also" entry for each example below -- it duplicates that same '
+        f'Remove the "{section}" reference to each example below -- it duplicates that same '
         'example already listed in the page\'s own "Used In" section:\n'
     )
     assert not failures, note + '\n'.join(


### PR DESCRIPTION
## What

Removes 22 hand-written `See :ref:\`x_example\` for more examples` pointers from docstrings, and extends the existing doc-build check so they don't come back.

These pointers duplicate what sphinx-autocodelink's "Used In" section now lists automatically, and unlike "Used In" they never get rechecked against what the example actually does — the `load_hydrogen_orbital` one is what prompted this.

## What was removed vs. kept

The rule is the one the existing `See Also` check already encodes: **a ref is only redundant once "Used In" shows the same example.** Deliberately kept:

- Refs inside a **parameter description** (`shading_example` on `smooth_shading`, `vector_component_example` on `component`, ...) — they explain that parameter, and render outside the scanned sections.
- **`See Also`** entries — already covered by the sibling check, which passes.
- Refs to an example "Used In" **doesn't** cover — notably `extract_largest`'s `volumetric_analysis_example`, which uses `.connectivity('largest')` and never calls `extract_largest`. That's real information, not redundancy.

## Testing

Validated against a real docs build (`b0c6553`) rather than by inspection:

- The new check flagged exactly 22 pages on that build; all 22 are removed here.
- It caught 2 an initial static sweep missed — `PolyData` and `UnstructuredGrid`, whose refs live in **class** docstrings.
- Confirmed every one of those 22 hrefs came from a removable pointer paragraph (0 from any other markup), so a rebuild passes.
- The `See Also` variant passes on that same build, confirming the 3 `See Also` refs left alone genuinely aren't duplicates.

`make lint` and Vale both clean. The check itself needs CI's docs build to run green end to end, since the build available locally predates this cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)