### PR TITLE
Fix macOS depth peeling probe permanently hiding the window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,22 @@ Reach for a VTK format when another tool has to open the file, and for a chunked
 when the data does not fit in memory. `.pv` is real and supported: do not tell a user it
 is unavailable.
 
+**A capability probe must leave the process as it found it.** `check_depth_peeling()`,
+`supports_open_gl()` and `uses_egl()` answer a question; they do not own the process.
+PyVista is routinely imported into an application it did not start -- a Qt GUI through
+pyvistaqt, a Jupyter kernel, trame -- so any process-global state a probe writes, it writes
+on someone else's behalf. Configure the throwaway render window you created and nothing
+else. The macOS `NSApplication` activation policy is process-global, and demoting it for an
+off-screen probe strips the Dock icon and menu bar from the host application (#8832); so is
+`VTK_DEFAULT_OPENGL_WINDOW`, which also steers VTK's own factory. Where a global genuinely
+has to move, borrow it under a context manager and put it back.
+
+Ask the host rather than inferring it from the environment. `WAYLAND_DISPLAY` says a
+compositor is running, not that this process talks to it, so `QT_QPA_PLATFORM=xcb` makes it
+wrong (#8949); a live `QGuiApplication` knows which platform it connected to. Test the
+embedded case as well as the headless one -- a probe's tests pass just as happily when they
+assert the damage.
+
 **House conventions, most of them machine-enforced.** `import pyvista as pv`, never the
 bare form. The plotter variable is `pl`. Boolean arguments are keyword-only. Error
 messages are assigned to a variable before being raised. Set `pv.OFF_SCREEN = True` once

--- a/pyvista/plotting/tools.py
+++ b/pyvista/plotting/tools.py
@@ -47,26 +47,37 @@ def _prepare_offscreen_macos_render_window(  # pragma: no cover
        ``Accessory`` hides the Dock icon while still allowing the process
        to be activated later; ``Prohibited`` also forbids activation, which
        leaves any later on-screen window stuck behind other applications.
+       An application already running on the ``Regular`` policy is left
+       alone: the activation policy is process-global, so demoting it
+       would strip the Dock icon and menu bar from a host GUI toolkit,
+       such as a Qt application embedding a plotter.
     2. ``SetConnectContextToNSView(False)`` stops this particular render
        window from creating a real NSWindow.
 
     Safe to call unconditionally on any platform or render window type;
     each step no-ops where it doesn't apply (non-macOS, missing PyObjC,
-    non-Cocoa render windows).
+    non-Cocoa render windows, a visible application).
     """
 
     def _suppress_dock_icon():
         if sys.platform != 'darwin':
             return
         try:  # type:ignore[unreachable]
+            from AppKit import NSApp  # noqa: PLC0415
             from AppKit import NSApplication  # noqa: PLC0415
             from AppKit import NSApplicationActivationPolicyAccessory  # noqa: PLC0415
-
-            NSApplication.sharedApplication().setActivationPolicy_(
-                NSApplicationActivationPolicyAccessory,
-            )
+            from AppKit import NSApplicationActivationPolicyRegular  # noqa: PLC0415
         except ImportError:
-            pass
+            return
+
+        # NSApp() reads the shared application without creating one, so a
+        # process that has none still gets its Dock icon suppressed below
+        app = NSApp()
+        if app is not None and app.activationPolicy() == NSApplicationActivationPolicyRegular:
+            return
+        NSApplication.sharedApplication().setActivationPolicy_(
+            NSApplicationActivationPolicyAccessory,
+        )
 
     def _disable_cocoa_nsview_context():
         if hasattr(render_window, 'SetConnectContextToNSView'):

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -1069,11 +1069,15 @@ def _make_fake_render_window():
 
 def _invoke_check_depth_peeling():
     fake_render_window = _make_fake_render_window()
+    # cleared on both sides: a warm cache would skip the call entirely, and the
+    # result computed from the fake window must not outlive this invocation
+    check_depth_peeling.cache_clear()
     with patch(
         'pyvista.plotting.utilities.gl_checks._vtk.vtkRenderWindow',
         return_value=fake_render_window,
     ):
         check_depth_peeling()
+    check_depth_peeling.cache_clear()
     return fake_render_window
 
 
@@ -1116,6 +1120,7 @@ _MACOS_FIX_CASES = [
 def test_macos_offscreen_render_window_configured(case):
     """Test no macOS phantom window is generated for off-screen plotting."""
     appkit_mock = MagicMock()
+    appkit_mock.NSApp.return_value = None  # no application running
     with patch('sys.platform', 'darwin'), patch.dict(sys.modules, {'AppKit': appkit_mock}):
         render_window = case.invoke()
 
@@ -1125,3 +1130,22 @@ def test_macos_offscreen_render_window_configured(case):
     appkit_mock.NSApplication.sharedApplication().setActivationPolicy_.assert_called_once_with(
         appkit_mock.NSApplicationActivationPolicyAccessory,
     )
+
+
+@pytest.mark.skipif(sys.platform != 'darwin', reason='macOS-specific test')
+@pytest.mark.parametrize('case', _MACOS_FIX_CASES, ids=lambda c: c.id)
+def test_macos_offscreen_keeps_visible_application_in_dock(case):
+    """Test a host GUI application keeps its Dock icon and menu bar.
+
+    The activation policy is process-global, so demoting it for an off-screen
+    render window would strip both from a Qt application embedding a plotter.
+    """
+    appkit_mock = MagicMock()
+    appkit_mock.NSApp.return_value.activationPolicy.return_value = (
+        appkit_mock.NSApplicationActivationPolicyRegular
+    )
+    with patch('sys.platform', 'darwin'), patch.dict(sys.modules, {'AppKit': appkit_mock}):
+        render_window = case.invoke()
+
+    assert render_window.GetConnectContextToNSView() is False
+    appkit_mock.NSApplication.sharedApplication().setActivationPolicy_.assert_not_called()


### PR DESCRIPTION
### Overview

`check_depth_peeling()` and `supports_open_gl()` probe by building a throwaway off-screen render window, and since #8832 that also demotes the process activation policy so an unbundled headless process doesn't pick up a Dock icon. The policy is process-global, so it lands on whoever owns the process instead: a Qt application that enables depth peeling loses its Dock icon and menu bar, and worse, the window server stops presenting its window entirely -- Qt never notices, `isVisible()` stays `True` while `isExposed()` flips to `False`, so nothing retries the show and an MNE figure just disappears. #8940 swapped `Prohibited` for `Accessory` and the window still dies: the value was never the problem, writing the policy at all is.

The probe now reads the shared `NSApplication` with `NSApp()`, which doesn't create one, and leaves an application already on `Regular` alone. A headless process has no `NSApplication` at that point, so it's demoted exactly as before. pyvista/pyvistaqt#857 pins this from the other side: its regression test is red on `main` runs and green against this branch.

This is the macOS twin of #8949, so I also added a rule to `AGENTS.md` about capability probes not writing process-global state on behalf of an application they didn't start.

Changes drafted by Claude Opus 5 but fully understood by me.
