### PR TITLE
Backtick-wrap parameter self-references currently using italics

### DIFF
--- a/doc/source/api/readers/index.rst
+++ b/doc/source/api/readers/index.rst
@@ -141,7 +141,7 @@ for zero-config discovery at install time.
 **Handler signature**
 
 A writer handler is a callable ``handler(dataset, path, **kwargs)``
-that writes *dataset* to *path*.  Any extra keyword arguments passed
+that writes ``dataset`` to ``path``.  Any extra keyword arguments passed
 to :meth:`pyvista.DataObject.save` beyond its documented parameters
 are forwarded verbatim to the handler as ``**kwargs``. Use them to
 expose format-specific options such as compression level, thread

--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -39,7 +39,7 @@ _VTK_ROOT = _resolve_vtk_root()
 
 
 def _resolve_root_is_flat(root: str) -> bool:
-    """Return whether *root* exposes VTK classes directly off its package root.
+    """Return whether ``root`` exposes VTK classes directly off its package root.
 
     A flat backend (for example, cvista >=9.6.2.4) resolves public names lazily off the
     root, so PyVista looks classes up by NAME and stays agnostic to module layout.
@@ -907,7 +907,7 @@ def __getattr__(name: str):
 
 
 def has_attr(name: str) -> bool:
-    """Return ``True`` if *name* resolves to a VTK class on this build.
+    """Return ``True`` if ``name`` resolves to a VTK class on this build.
 
     ``hasattr(_vtk, 'X')`` does not work as expected because the lazy
     ``__getattr__`` raises ``ImportError`` (not ``AttributeError``) when a

--- a/pyvista/core/utilities/_registry_helpers.py
+++ b/pyvista/core/utilities/_registry_helpers.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 
 def handler_source(handler: object) -> str:
-    """Return ``module.qualname`` for *handler* when available.
+    """Return ``module.qualname`` for ``handler`` when available.
 
     Used by every plugin registry to attach a human-readable origin
     string to each explicit registration so that :func:`registered_*`

--- a/pyvista/core/utilities/reader_registry.py
+++ b/pyvista/core/utilities/reader_registry.py
@@ -28,10 +28,10 @@ if TYPE_CHECKING:
 
 
 class ReaderHandler(Protocol):
-    """Callable that reads *path* and returns a :class:`pyvista.DataSet`."""
+    """Callable that reads ``path`` and returns a :class:`pyvista.DataSet`."""
 
     def __call__(self, path: str, /, **kwargs: Any) -> DataSet:
-        """Read *path* and return the resulting dataset."""
+        """Read ``path`` and return the resulting dataset."""
 
 
 class ReaderRegistration(NamedTuple):
@@ -133,7 +133,7 @@ def _restore_registry_state(state: _RegistryState) -> None:
 
 
 def has_scheme(value: str) -> bool:
-    """Return ``True`` if *value* starts with a URI scheme (for example, ``https://``).
+    """Return ``True`` if ``value`` starts with a URI scheme (for example, ``https://``).
 
     Parameters
     ----------
@@ -143,7 +143,7 @@ def has_scheme(value: str) -> bool:
     Returns
     -------
     bool
-        ``True`` if *value* contains a ``://`` scheme prefix before
+        ``True`` if ``value`` contains a ``://`` scheme prefix before
         the first ``/``.
 
     """
@@ -155,7 +155,7 @@ def has_scheme(value: str) -> bool:
 
 
 def _download_uri(uri: str, ext: str) -> str:
-    """Download a remote URI to a temporary file, preserving *ext*.
+    """Download a remote URI to a temporary file, preserving ``ext``.
 
     Uses ``fsspec`` when available (supports ``s3://``, ``gs://``,
     ``az://``, ``http://``, and any other registered filesystem).
@@ -263,7 +263,7 @@ def register_reader(
     Raises
     ------
     ValueError
-        If ``key`` collides with a built-in VTK reader and *override*
+        If ``key`` collides with a built-in VTK reader and ``override``
         is ``False``.
 
     Warns
@@ -374,7 +374,7 @@ def _ensure_entry_points() -> None:
 
 
 def _resolve_pending_reader(ext: str) -> bool:
-    """Import the plugin claiming *ext*, if any.
+    """Import the plugin claiming ``ext``, if any.
 
     Returns
     -------

--- a/pyvista/core/utilities/writer_registry.py
+++ b/pyvista/core/utilities/writer_registry.py
@@ -22,10 +22,10 @@ if TYPE_CHECKING:
 
 
 class WriterHandler(Protocol):
-    """Callable that writes *dataset* to *path*."""
+    """Callable that writes ``dataset`` to ``path``."""
 
     def __call__(self, dataset: DataObject, path: str, /, **kwargs: Any) -> None:
-        """Write *dataset* to *path*, consuming format-specific *``kwargs``*."""
+        """Write ``dataset`` to ``path``, consuming format-specific ``kwargs``."""
 
 
 class WriterRegistration(NamedTuple):
@@ -157,7 +157,7 @@ def register_writer(
 
     handler : callable, optional
         A callable with signature ``handler(dataset, path, **kwargs)`` that
-        writes *dataset* to *path*.  Any extra keyword arguments passed to
+        writes ``dataset`` to ``path``.  Any extra keyword arguments passed to
         :meth:`pyvista.DataObject.save` are forwarded to the handler as
         ``**kwargs``—use them to expose format-specific options such as
         compression level, thread count, or chunking.  Handlers that do
@@ -181,7 +181,7 @@ def register_writer(
     Raises
     ------
     ValueError
-        If ``key`` collides with a built-in PyVista writer and *override*
+        If ``key`` collides with a built-in PyVista writer and ``override``
         is ``False``.
 
     Warns
@@ -309,7 +309,7 @@ def _ensure_entry_points() -> None:
 
 
 def _resolve_pending_writer(ext: str) -> bool:
-    """Import the plugin claiming *ext*, if any.
+    """Import the plugin claiming ``ext``, if any.
 
     Returns
     -------

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -81,8 +81,8 @@ The ``pyvista-plot`` directive supports the following options:
         boolean variable in :file:`conf.py`.
 
 Additionally, this directive supports all the options of the ``image``
-directive, except for *target* (since plot will add its own target).  These
-include *alt*, *height*, *width*, *scale*, *align*.
+directive, except for ``target`` (since plot will add its own target).  These
+include ``alt``, ``height``, ``width``, ``scale``, ``align``.
 
 
 **Open Graph previews**
@@ -577,9 +577,9 @@ def render_figures(
     *``output_base``*. Closed plotters are ignored if they were never
     rendered.
 
-    If *env* is given and *``include_source``* is true, also records the code's identifiers
+    If ``env`` is given and ``include_source`` is true, also records the code's identifiers
     to hyperlink -- skipped when the source isn't shown, since there would be nothing on the
-    page for a reader to click through to. *state* is the calling directive's own
+    page for a reader to click through to. ``state`` is the calling directive's own
     ``self.state``, passed through to sphinx-autocodelink for its own categorization.
     """
     # We skip snippets that contain the ``pyvista-plot::`` directive as part of their code.

--- a/pyvista/plotting/theme_registry.py
+++ b/pyvista/plotting/theme_registry.py
@@ -177,7 +177,7 @@ def _resolve_theme(name: str) -> Theme | None:
 
     Explicit subclass registrations win over entry-point discoveries.
     Entry-point plugins are imported lazily—only the plugin claiming
-    *name* loads, sibling plugins stay pending.
+    ``name`` loads, sibling plugins stay pending.
     """
     normalized = _normalize_theme_name(name)
 
@@ -382,7 +382,7 @@ def _ensure_entry_points() -> None:
 
 
 def _resolve_pending_theme(name: str) -> bool:
-    """Import the plugin claiming *name*, if any.
+    """Import the plugin claiming ``name``, if any.
 
     Returns
     -------

--- a/pyvista/plotting/utilities/algorithms.py
+++ b/pyvista/plotting/utilities/algorithms.py
@@ -787,7 +787,7 @@ def source_algorithm(
     """Create a source algorithm that generates data from a callable.
 
     A source has no input port. It produces data from scratch via
-    *generator*.
+    ``generator``.
 
     Parameters
     ----------


### PR DESCRIPTION
Follow-up to the Vale documentation-style work: an audit of single-asterisk RST emphasis (`*word*`) across `pyvista/`, `examples/`, and `doc/`, converting the clear cases to inline code literals.

- Only converted cases where the emphasized word is a genuine code reference: a function/method parameter self-reference, or a real Sphinx directive option name (`target`, `alt`, `height`, `width`, `scale`, `align`).
- Left prose emphasis untouched (`*not*`, `*before*`, `*after*`, `*only*`, `*except*`, `*and*`, `*must*`, and similar).
- Left a handful of ambiguous noun-phrase cases untouched (`*metadata*`, `*component*`, `*point*`) where the word is not a clear parameter match.
- Also fixed two instances of broken double-markup (italics wrapping an already-backticked span, e.g. `` *``kwargs``* ``) to plain code literals.

Vale and pre-commit both run clean on the changed files.