### PR TITLE
Retire `PyVista.Repetition`'s exceptions list

### DIFF
--- a/.claude/skills/pyvista-docs-style/SKILL.md
+++ b/.claude/skills/pyvista-docs-style/SKILL.md
@@ -27,14 +27,12 @@ from the `.py` itself. The extracted file has the same line numbers as the sourc
 `.vale/pyvista/...` path, swap it back to `examples/...` or `pyvista/...` with a `.py`
 extension, and that is the line to fix.
 
-Vale does still open `.py` files directly, for the rules `doc/.vale.ini`'s `[*.py]`
+Vale does still open `.py` files directly, for whatever `doc/.vale.ini`'s `[*.py]`
 section turns on -- today just `Google.Exclamation`. **An alert reported against a
 `pyvista/...py` path rather than a `.vale/...rst` one came from that scan**, which sees
 the raw file: numpydoc signature lines, `See Also` entries and doctest blocks all reach
 it as ordinary prose, with none of the handling described below. Enabling a prose rule
-there means signing up for that. `PyVista.Repetition` was enabled there once and needed
-an exceptions list of two dozen type names to stay quiet; moving it to the extracted
-`.rst` retired the whole list.
+there means signing up for that.
 
 **Trust a live Vale run over a mental model of what it checks.** This session got this
 wrong twice: once assuming a rule (`Google.Headings`'s exceptions list) was needed by

--- a/.claude/skills/pyvista-docs-style/SKILL.md
+++ b/.claude/skills/pyvista-docs-style/SKILL.md
@@ -21,10 +21,20 @@ finishes by confirming the heading rule still rejects the fixture in
 `tests/doc/vale/headings_invalid.rst`. Do not spell the `vale` invocation out by hand --
 four copies of it had already drifted apart once.
 
-Vale never sees a `.py` file directly. It sees the `.rst` files the extraction script
-generates, with the same line numbers as the source (`doc/extract_rst_from_py_for_vale.py:31:1`)
--- read an alert's `.vale/examples/...` or `.vale/pyvista/...` path, swap it back to
-`examples/...` or `pyvista/...` with a `.py` extension, and that is the line to fix.
+Prose in a `.py` file is checked through the `.rst` the extraction script generates, not
+from the `.py` itself. The extracted file has the same line numbers as the source
+(`doc/extract_rst_from_py_for_vale.py:31:1`) -- read an alert's `.vale/examples/...` or
+`.vale/pyvista/...` path, swap it back to `examples/...` or `pyvista/...` with a `.py`
+extension, and that is the line to fix.
+
+Vale does still open `.py` files directly, for the rules `doc/.vale.ini`'s `[*.py]`
+section turns on -- today just `Google.Exclamation`. **An alert reported against a
+`pyvista/...py` path rather than a `.vale/...rst` one came from that scan**, which sees
+the raw file: numpydoc signature lines, `See Also` entries and doctest blocks all reach
+it as ordinary prose, with none of the handling described below. Enabling a prose rule
+there means signing up for that. `PyVista.Repetition` was enabled there once and needed
+an exceptions list of two dozen type names to stay quiet; moving it to the extracted
+`.rst` retired the whole list.
 
 **Trust a live Vale run over a mental model of what it checks.** This session got this
 wrong twice: once assuming a rule (`Google.Headings`'s exceptions list) was needed by
@@ -35,12 +45,13 @@ the real diff in alert count before deciding a rule change is safe.
 
 ## What the extractor does and does not see
 
-- `Parameters`' `name : type` signature line is blanked before Vale runs; its description
-  is checked like any other prose.
-- `Returns`, `Attributes`, `Raises`, `Yields`, `Warns`, `Methods`, `Other Parameters`,
-  and `Receives` are **not** blanked -- their content is checked as ordinary prose. If a
-  change here starts producing type-name/class-name false positives, that is a sign the
-  described value needs backticks, not that the section needs skipping again.
+- Every numpydoc section shaped `name : type` over an indented description has its
+  signature line blanked before Vale runs; the description is checked like any other
+  prose. That is `Parameters`, `Other Parameters`, `Attributes`, `Methods`, `Returns`,
+  `Yields`, `Raises`, `Warns` and `Receives` -- the `STRUCTURED_SECTIONS` set in
+  `doc/extract_rst_from_py_for_vale.py`, which is the list to read rather than this one.
+  Blanking the signature line is what stops a description restating the type it
+  documents (`pyvista.PolyData` over "PolyData mesh.") from reading as a doubled word.
 - `See Also` **is** fully skipped, deliberately. It is numpydoc's own bare-name
   cross-reference DSL (auto-linked at doc-build time), not prose -- backtick-wrapping a
   `See Also` entry fights that convention instead of fixing anything. Don't add prose
@@ -67,6 +78,12 @@ accept). The two failure modes worth naming directly:
   earlier commit had deliberately removed it and hyphenated the one real usage instead.
   The fix for a Vale.Spelling hit you have not seen before might already have a decided
   answer sitting in the log.
+- **An accepted word is exempt from every rule, not just `Vale.Spelling`.** Vale drops
+  vocabulary terms before any check runs, so a term in `accept.txt` can never be reported
+  by `PyVista.Repetition`, `Google.Latin`, or anything else. `PolyData` sat in that rule's
+  exceptions list for exactly this reason: it was already unreachable, and the entry did
+  nothing. If a rule mysteriously will not fire on a word you expect it to, grep
+  `accept.txt` before assuming the rule is broken.
 - **The file is dual-purpose.** `pyproject.toml`'s `codespell` config also uses it as
   `ignore-words`. A word can be dead to Vale (no prose ever uses it, because it only shows
   up in a raw comment, a test fixture, or a variable name) and still required by

--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -54,14 +54,23 @@ BasedOnStyles =
 [*.py]
 
 # Only check for the following:
-# Vale.Repetition is case-insensitive, which flags numpydoc type lines
-# restated in their description (e.g. "list" then "List of ..."). Use a
-# case-sensitive copy instead.
+# Repetition is checked on the extracted `.rst` instead (see the section
+# below). Vale reads a `.py` file as plain text: numpydoc type lines, `See
+# Also` entries and doctest blocks all reach the rule as prose, and each one
+# restating a type name reads as a doubled word. The extractor blanks or skips
+# all three, so the same rule run over its output needs no exceptions list.
 Vale.Repetition = NO
-PyVista.Repetition = error
+PyVista.Repetition = NO
 Google.Exclamation = YES
 
 [.vale/pyvista/**/*.rst]
 # Same case-sensitivity issue as [*.py] -- these files are docstrings.
+Vale.Repetition = NO
+PyVista.Repetition = error
+
+[**/vale/repetition*.rst]
+# The `PyVista.Repetition` fixture. `repetition.rst` is scanned and must pass;
+# `repetition_invalid.rst` is not, and `check_expected_failures.py` asserts
+# every case in it is still caught.
 Vale.Repetition = NO
 PyVista.Repetition = error

--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -54,11 +54,9 @@ BasedOnStyles =
 [*.py]
 
 # Only check for the following:
-# Repetition is checked on the extracted `.rst` instead (see the section
-# below). Vale reads a `.py` file as plain text: numpydoc type lines, `See
-# Also` entries and doctest blocks all reach the rule as prose, and each one
-# restating a type name reads as a doubled word. The extractor blanks or skips
-# all three, so the same rule run over its output needs no exceptions list.
+# Repetition needs the extracted `.rst` (see below): a raw `.py` reaches the
+# rule as plain text, where numpydoc type lines, `See Also` and doctest blocks
+# all read as prose.
 Vale.Repetition = NO
 PyVista.Repetition = NO
 Google.Exclamation = YES
@@ -69,8 +67,6 @@ Vale.Repetition = NO
 PyVista.Repetition = error
 
 [**/vale/repetition*.rst]
-# The `PyVista.Repetition` fixture. `repetition.rst` is scanned and must pass;
-# `repetition_invalid.rst` is not, and `check_expected_failures.py` asserts
-# every case in it is still caught.
+# The `PyVista.Repetition` fixture; `repetition.rst` explains both halves.
 Vale.Repetition = NO
 PyVista.Repetition = error

--- a/doc/run_vale.py
+++ b/doc/run_vale.py
@@ -24,11 +24,13 @@ import sys
 ROOT = Path(__file__).resolve().parents[1]
 CONFIG = ROOT / 'doc' / '.vale.ini'
 
-# Vale cannot read a .py file, so gallery examples and docstrings are extracted
-# to .rst first; see `doc/extract_rst_from_py_for_vale.py`. The last entry is a
-# fixture of headings that must stay valid -- it lives under `tests` and so has
-# to be named explicitly. Its counterpart, `headings_invalid.rst`, is
-# deliberately absent: those headings must fail.
+# Gallery examples and docstrings are extracted to .rst first, so that Vale
+# sees them with numpydoc structure resolved; see
+# `doc/extract_rst_from_py_for_vale.py`. The last two entries are fixtures that
+# must stay valid -- they live under `tests` and so have to be named
+# explicitly. Their counterparts, `headings_invalid.rst` and
+# `repetition_invalid.rst`, are deliberately absent: those cases must fail, and
+# `tests/doc/vale/check_expected_failures.py` asserts that they still do.
 PATHS = [
     'doc',
     'pyvista',
@@ -37,6 +39,7 @@ PATHS = [
     '.vale/examples',
     '.vale/pyvista',
     'tests/doc/vale/headings.rst',
+    'tests/doc/vale/repetition.rst',
 ]
 
 EXTRACT = [

--- a/doc/run_vale.py
+++ b/doc/run_vale.py
@@ -24,13 +24,11 @@ import sys
 ROOT = Path(__file__).resolve().parents[1]
 CONFIG = ROOT / 'doc' / '.vale.ini'
 
-# Gallery examples and docstrings are extracted to .rst first, so that Vale
-# sees them with numpydoc structure resolved; see
-# `doc/extract_rst_from_py_for_vale.py`. The last two entries are fixtures that
-# must stay valid -- they live under `tests` and so have to be named
-# explicitly. Their counterparts, `headings_invalid.rst` and
-# `repetition_invalid.rst`, are deliberately absent: those cases must fail, and
-# `tests/doc/vale/check_expected_failures.py` asserts that they still do.
+# Gallery examples and docstrings are extracted to .rst first, so Vale sees them
+# with numpydoc structure resolved; see `doc/extract_rst_from_py_for_vale.py`.
+# The last two entries are fixtures that must stay valid, and so have to be
+# named explicitly. Their `_invalid` counterparts are deliberately absent: those
+# cases must fail, which `check_expected_failures.py` asserts.
 PATHS = [
     'doc',
     'pyvista',

--- a/doc/styles/PyVista/Repetition.yml
+++ b/doc/styles/PyVista/Repetition.yml
@@ -1,49 +1,17 @@
-# `exceptions` is a snapshot of false positives found when this rule was
-# added, not a maintained list. Add a new type/module name here if CI flags
-# it as repeated; no need to revisit existing entries unless one starts
-# masking a real doubled word.
+# A case-sensitive copy of `Vale.Repetition`, used where `Vale.Repetition`'s
+# case-insensitivity would flag a numpydoc description restating the type it
+# documents (e.g. `list` then "List of ..."). See `doc/.vale.ini`.
+#
+# `tokens` keeps a dotted identifier (`pyvista.plotting.plotting`,
+# `reader.reader.read()`) as a single token, so its repeated segments do not
+# read as a doubled word. A trailing sentence period is left out of the token,
+# so a doubled word ending a sentence is still caught. This rule needs no
+# exceptions list; `tests/doc/vale/repetition.rst` and its `_invalid`
+# counterpart pin both halves of that behaviour.
 extends: repetition
 message: "'%s' is repeated!"
 level: error
 alpha: true
 ignorecase: false
 tokens:
-  - '[^\s.!?]+'
-exceptions:
-  # numpydoc type lines restated as the first word of their description
-  - Actor
-  - AddIDsAlgorithm
-  - Brush
-  - Camera
-  - Chart
-  - Color
-  - CrinkleAlgorithm
-  - DataFrame
-  - Hexahedra
-  - ImageData
-  - Iterable
-  - Iterator
-  - Light
-  - MultiBlock
-  - Number
-  - Path
-  - Pen
-  - Plotter
-  - PolyData
-  - RectilinearGrid
-  - StructuredGrid
-  - Table
-  - Text
-  - Texture
-  - Theme
-  - Trimesh
-  - UnstructuredGrid
-  - Any
-  # dotted module paths repeating their last segment, e.g. pyvista.examples.examples
-  - examples
-  - plotting
-  # code repeating a real identifier, e.g. reader.reader.read()
-  - reader
-  - dataset
-  # two separate, correctly-labeled comments
-  - triangle
+  - '[^\s!?]*[^\s!?.]'

--- a/doc/styles/PyVista/Repetition.yml
+++ b/doc/styles/PyVista/Repetition.yml
@@ -1,13 +1,10 @@
-# A case-sensitive copy of `Vale.Repetition`, used where `Vale.Repetition`'s
-# case-insensitivity would flag a numpydoc description restating the type it
-# documents (e.g. `list` then "List of ..."). See `doc/.vale.ini`.
+# A case-sensitive copy of `Vale.Repetition`, for numpydoc descriptions that
+# restate the type they document (`list` then "List of ..."). See `doc/.vale.ini`.
 #
-# `tokens` keeps a dotted identifier (`pyvista.plotting.plotting`,
-# `reader.reader.read()`) as a single token, so its repeated segments do not
-# read as a doubled word. A trailing sentence period is left out of the token,
-# so a doubled word ending a sentence is still caught. This rule needs no
-# exceptions list; `tests/doc/vale/repetition.rst` and its `_invalid`
-# counterpart pin both halves of that behaviour.
+# `tokens` holds a dotted identifier together, so `pyvista.plotting.plotting` is
+# one word; a trailing sentence period stays outside it, so a doubled word
+# ending a sentence is still caught. `tests/doc/vale/repetition.rst` and its
+# `_invalid` counterpart pin both halves.
 extends: repetition
 message: "'%s' is repeated!"
 level: error

--- a/tests/doc/vale/check_expected_failures.py
+++ b/tests/doc/vale/check_expected_failures.py
@@ -7,11 +7,8 @@ actually had -- a bare ``a`` in ``Google.Headings``' exceptions list matched
 inside every word containing the letter and silently switched heading checks
 off for most of the documentation.
 
-``PyVista.Repetition`` is the same shape of risk from the other direction: it
-carried an exceptions list of type names purely because it ran over raw ``.py``
-files, where numpydoc type lines and ``See Also`` entries reach it as prose.
-The list is gone, so its ``tokens`` pattern is now the only thing standing
-between a real doubled word and silence.
+``PyVista.Repetition`` has no exceptions list, so its ``tokens`` pattern is the
+only thing standing between a real doubled word and silence.
 
 Run with ``make docstyle``, or directly::
 

--- a/tests/doc/vale/check_expected_failures.py
+++ b/tests/doc/vale/check_expected_failures.py
@@ -1,10 +1,17 @@
-"""Assert that Vale still flags the headings it is supposed to flag.
+"""Assert that Vale still flags what it is supposed to flag.
 
-``tests/doc/vale/headings.rst`` covers the other direction: it sits inside the paths
-Vale scans, so every heading in it has to pass. Nothing there would notice the
-rule going *slack*, which is the failure this repository actually had -- a bare
-``a`` in the exceptions list matched inside every word containing the letter
-and silently switched heading checks off for most of the documentation.
+``headings.rst`` and ``repetition.rst`` cover the other direction: they sit
+inside the paths Vale scans, so everything in them has to pass. Nothing there
+would notice a rule going *slack*, which is the failure this repository
+actually had -- a bare ``a`` in ``Google.Headings``' exceptions list matched
+inside every word containing the letter and silently switched heading checks
+off for most of the documentation.
+
+``PyVista.Repetition`` is the same shape of risk from the other direction: it
+carried an exceptions list of type names purely because it ran over raw ``.py``
+files, where numpydoc type lines and ``See Also`` entries reach it as prose.
+The list is gone, so its ``tokens`` pattern is now the only thing standing
+between a real doubled word and silence.
 
 Run with ``make docstyle``, or directly::
 
@@ -22,9 +29,12 @@ import subprocess
 import sys
 
 ROOT = Path(__file__).resolve().parents[3]
-FIXTURE = Path(__file__).resolve().parent / 'headings_invalid.rst'
+HERE = Path(__file__).resolve().parent
 CONFIG = ROOT / 'doc' / '.vale.ini'
-CHECK = 'Google.Headings'
+HEADINGS_FIXTURE = HERE / 'headings_invalid.rst'
+HEADINGS_CHECK = 'Google.Headings'
+REPETITION_FIXTURE = HERE / 'repetition_invalid.rst'
+REPETITION_CHECK = 'PyVista.Repetition'
 
 
 def headings_in(path: Path) -> list[str]:
@@ -39,39 +49,71 @@ def headings_in(path: Path) -> list[str]:
     ]
 
 
-def flagged_by_vale(path: Path) -> set[str]:
-    """Return the headings in ``path`` that Vale reports for ``CHECK``."""
+def alerts_for(path: Path, check: str) -> list[dict]:
+    """Return the alerts Vale reports in ``path`` for ``check``."""
     out = subprocess.run(
         ['vale', '--config', str(CONFIG), '--output=JSON', str(path)],
         capture_output=True,
         text=True,
         check=False,
     )
-    return {
-        alert['Match']
+    return [
+        alert
         for alerts in json.loads(out.stdout or '{}').values()
         for alert in alerts
-        if alert['Check'] == CHECK
+        if alert['Check'] == check
+    ]
+
+
+def bullets_in(path: Path) -> dict[int, str]:
+    """Return the ``- `` bullet lines in ``path``, keyed by line number."""
+    return {
+        number: line.strip()[2:]
+        for number, line in enumerate(path.read_text().splitlines(), start=1)
+        if line.startswith('- ')
     }
 
 
+def check_headings() -> int:
+    """Report any heading the rule no longer catches."""
+    flagged = {alert['Match'] for alert in alerts_for(HEADINGS_FIXTURE, HEADINGS_CHECK)}
+    expected = headings_in(HEADINGS_FIXTURE)[1:]  # the file's own title has to pass
+    missed = [heading for heading in expected if heading not in flagged]
+    if missed:
+        print(f'{HEADINGS_CHECK} no longer flags these headings:')
+        for heading in missed:
+            print(f'  {heading}')
+        print(f'\nSee {HEADINGS_FIXTURE.relative_to(ROOT)}')
+        return 1
+
+    print(f'{HEADINGS_CHECK}: all {len(expected)} expected failures still caught')
+    return 0
+
+
+def check_repetition() -> int:
+    """Report any doubled word the rule no longer catches."""
+    flagged = {alert['Line'] for alert in alerts_for(REPETITION_FIXTURE, REPETITION_CHECK)}
+    expected = bullets_in(REPETITION_FIXTURE)
+    missed = [text for number, text in expected.items() if number not in flagged]
+    if missed:
+        print(f'{REPETITION_CHECK} no longer flags these:')
+        for text in missed:
+            print(f'  {text}')
+        print(f'\nSee {REPETITION_FIXTURE.relative_to(ROOT)}')
+        return 1
+
+    print(f'{REPETITION_CHECK}: all {len(expected)} expected failures still caught')
+    return 0
+
+
 def main() -> int:
-    """Report any expected failure the rule no longer catches."""
+    """Report any expected failure a rule no longer catches."""
     if shutil.which('vale') is None:
         print('vale is not installed; skipping')
         return 0
 
-    expected = headings_in(FIXTURE)[1:]  # the file's own title has to pass
-    missed = [h for h in expected if h not in flagged_by_vale(FIXTURE)]
-    if missed:
-        print(f'{CHECK} no longer flags these headings:')
-        for heading in missed:
-            print(f'  {heading}')
-        print(f'\nSee {FIXTURE.relative_to(ROOT)}')
-        return 1
-
-    print(f'{CHECK}: all {len(expected)} expected failures still caught')
-    return 0
+    # Both run, so one slack rule does not hide the other's report.
+    return max(check_headings(), check_repetition())
 
 
 if __name__ == '__main__':

--- a/tests/doc/vale/headings.rst
+++ b/tests/doc/vale/headings.rst
@@ -2,9 +2,9 @@ Heading Style Test Cases
 ========================
 
 Every heading in this file must pass ``Google.Headings``. The file is not part
-of the documentation. It is passed to Vale explicitly -- see ``docstyle`` in
-``Makefile`` -- so a change to the rule that breaks one of these cases fails CI
-here rather than somewhere in the real documentation.
+of the documentation. It is passed to Vale explicitly -- see ``PATHS`` in
+``doc/run_vale.py`` -- so a change to the rule that breaks one of these cases
+fails CI here rather than somewhere in the real documentation.
 
 The style is AP title case with one deviation, ``to``. See
 ``doc/styles/Google/Headings.yml`` for the rule and the reasoning.

--- a/tests/doc/vale/headings_invalid.rst
+++ b/tests/doc/vale/headings_invalid.rst
@@ -3,9 +3,8 @@ Every Heading Here Must Fail
 
 This file is the negative half of the ``Google.Headings`` fixture; the positive
 half is ``tests/doc/vale/headings.rst``. It lives outside the paths Vale scans -- see
-the file list in ``Makefile`` under ``docstyle`` -- because a heading in a
-scanned file has to pass, which makes it impossible to assert that the rule
-catches anything. ``check_expected_failures.py``, beside it, runs Vale over this
+``PATHS`` in ``doc/run_vale.py`` -- because a heading in a scanned file has to
+pass, which makes it impossible to assert that the rule catches anything. ``check_expected_failures.py``, beside it, runs Vale over this
 file and fails if any heading below is *not* flagged.
 
 Clip with Plane

--- a/tests/doc/vale/repetition.rst
+++ b/tests/doc/vale/repetition.rst
@@ -1,0 +1,22 @@
+Repetition Test Cases
+=====================
+
+Every line in this file must pass ``PyVista.Repetition``. The file is not part
+of the documentation. It is passed to Vale explicitly -- see ``PATHS`` in
+``doc/run_vale.py`` -- so a change to the rule that starts flagging one of these
+shapes fails CI here rather than somewhere in the real documentation. Its
+negative half is ``tests/doc/vale/repetition_invalid.rst``.
+
+The rule's ``tokens`` pattern decides all of it; see
+``doc/styles/PyVista/Repetition.yml``.
+
+A dotted identifier is one token, so a module path may repeat a segment:
+pyvista.plotting.plotting is a real module and reader.reader.read() is a real
+call.
+
+Punctuation stays attached to the token before it, so an enumeration may repeat
+a word across commas: this includes lists, lists of tuples, tuples, tuples of
+lists and arrays.
+
+Vale segments sentences, so the same word may end one sentence and begin the
+next. Consider a mesh. Mesh cells follow.

--- a/tests/doc/vale/repetition_invalid.rst
+++ b/tests/doc/vale/repetition_invalid.rst
@@ -1,0 +1,17 @@
+Every Case Here Must Fail
+=========================
+
+This file is the negative half of the ``PyVista.Repetition`` fixture; the
+positive half is ``tests/doc/vale/repetition.rst``. It lives outside the paths
+Vale scans -- see ``PATHS`` in ``doc/run_vale.py`` -- because prose in a scanned
+file has to pass, which makes it impossible to assert that the rule catches
+anything. ``check_expected_failures.py``, beside it, runs Vale over this file
+and fails if any bullet below is *not* flagged.
+
+The rule is case-sensitive, so both halves of each doubled word are written
+with the same casing. A word in ``accept.txt`` is exempt from the rule
+altogether, so none of these are vocabulary terms.
+
+- A doubled word mid mid sentence.
+- A doubled word ending a sentence here here.
+- A doubled capitalized name Sphere Sphere in one sentence.


### PR DESCRIPTION
`PyVista.Repetition` carried an exceptions list of two dozen type names, described in the file itself as "a snapshot of false positives found when this rule was added, not a maintained list". It was neither obvious nor discoverable: hitting it means adding a name and moving on, with no sign of why the rule flagged something that is plainly not a doubled word. This removes the list rather than growing it.

The cause is that the rule ran over raw `.py` files. Vale reads those as plain text, so numpydoc signature lines, `See Also` entries and doctest blocks all reach the rule as prose, and a description restating the type it documents (`pyvista.UnstructuredGrid` over "UnstructuredGrid containing the tetrahedral cells.") reads as a doubled word. Emptying the list gives 125 alerts: 124 from the raw `.py` scan, 1 from the extracted `.rst`. The extractor already blanks the signature line, skips `See Also`, and gets doctest blocks skipped for free by Vale's rst parser, so the same rule over its output has none of that noise.

The remaining alert was `pyvista.plotting.plotting`, a dotted module path split into separate tokens because the pattern excluded `.`. Keeping dotted identifiers whole fixes it without weakening anything else.

- Check repetition on the extracted `.rst` (`PyVista.Repetition = NO` under `[*.py]`), where numpydoc structure is already resolved.
- `tokens` becomes `[^\s!?]*[^\s!?.]`: a dotted identifier is one token, a trailing sentence period is not part of the token, and punctuation otherwise stays attached as before.
- Delete the `exceptions` list. `doc/run_vale.py` reports 0 errors across the repository.
- Add `tests/doc/vale/repetition.rst` and `repetition_invalid.rst`, mirroring the `Google.Headings` fixture pair, and extend `check_expected_failures.py` to assert both. Reverting the tokens change makes it fail.
- Correct three claims in the Vale skill that did not match the code: Vale does open `.py` files directly; `Returns` and the other structured sections are blanked like `Parameters`; a word in `accept.txt` is exempt from every rule, not just `Vale.Spelling` (which is why `PolyData` in the exceptions list was already dead).
- Point the headings fixtures at `PATHS` in `doc/run_vale.py` instead of a file list in `Makefile` that no longer exists there.

Behaviour kept, verified by the new fixture: a plain doubled word, a doubled word ending a sentence, and a doubled capitalized name are all still flagged. Behaviour unchanged: an enumeration repeating a word across commas ("lists, lists of tuples, tuples of lists") is still not flagged, as punctuation stays attached to the token before it.

The trade-off, stated plainly: what this gives up is doubled-word checking in plain `#` comments anywhere in `pyvista/` and `examples/`, and in comments and code inside `>>>` doctest blocks. That is prose in a Python context, not documentation prose, and Vale is aimed at user-facing documentation — every reader-facing surface stays covered, docstrings and gallery `# %%` cell text included. The two goals are also in direct conflict: the tokens change alone, with the rule still on raw `.py`, leaves 25 alerts, which is an exceptions list of about 25 names all over again. Not having to maintain that list is worth more than the comment coverage, especially as the coverage has never caught anything — of the 125 alerts with the list emptied, exactly 2 fell in that category (`dataset` from a doctest, `triangle` from two comments) and both were false positives that would have needed exceptions entries of their own.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
