### PR TITLE
Fix xdist collection mismatch from parametrizing over a set

### DIFF
--- a/tests/core/test_cells.py
+++ b/tests/core/test_cells.py
@@ -283,7 +283,7 @@ def test_abstract_celltype_dimension_is_correct(celltype, expected_dim):
     assert celltype.dimension == expected_dim
 
 
-@pytest.mark.parametrize('celltype', _DEPRECATED_CELL_TYPES)
+@pytest.mark.parametrize('celltype', sorted(_DEPRECATED_CELL_TYPES))
 def test_celltype_deprecated(celltype):
     val = _CELL_TYPE_INFO[celltype].value
     match = f'<CellType.{celltype}: {val}> is deprecated and will be removed in a future version.'

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -221,7 +221,7 @@ def test_contour_labels_boundary_style(
 ALL_LABEL_IDS = {0, 2, 5}
 
 
-@pytest.mark.parametrize('background_value', ALL_LABEL_IDS)
+@pytest.mark.parametrize('background_value', sorted(ALL_LABEL_IDS))
 def test_contour_labels_background_value(labeled_image, background_value):
     assert background_value in labeled_image.active_scalars
 


### PR DESCRIPTION
`test_celltype_deprecated` parametrized over `_DEPRECATED_CELL_TYPES`, a set of strings whose iteration order varies with `PYTHONHASHSEED`, so each xdist worker collected a different order and `pytest tests/core -n 4` aborted with `Different tests were collected between gw0 and gw1`.

Sorted at the parametrize site rather than changing the set, since every other use is a membership test; `tests/core -n 4` now passes. The second commit does the same to `ALL_LABEL_IDS`, which is ints and so not a live failure — drop it if unwanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)