### PR TITLE
Fix `validate_transform4x4` raising a tuple as its error message

### DIFF
--- a/pyvista/core/_validation/validate.py
+++ b/pyvista/core/_validation/validate.py
@@ -637,16 +637,14 @@ def validate_transform4x4(
                 )
             except TypeError:
                 msg = (
-                    (
-                        'Input transform must be one of:\n'
-                        '\tvtkMatrix4x4\n'
-                        '\tvtkMatrix3x3\n'
-                        '\tvtkTransform\n'
-                        '\t4x4 np.ndarray\n'
-                        '\t3x3 np.ndarray\n'
-                        '\tscipy.spatial.transform.Rotation\n'
-                        f'Got {reprlib.repr(transform)} with type {type(transform)} instead.'
-                    ),
+                    'Input transform must be one of:\n'
+                    '\tvtkMatrix4x4\n'
+                    '\tvtkMatrix3x3\n'
+                    '\tvtkTransform\n'
+                    '\t4x4 np.ndarray\n'
+                    '\t3x3 np.ndarray\n'
+                    '\tscipy.spatial.transform.Rotation\n'
+                    f'Got {reprlib.repr(transform)} with type {type(transform)} instead.'
                 )
                 raise TypeError(msg)
 

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -79,7 +79,17 @@ def test_validate_transform4x4(transform_like):
 def test_validate_transform4x4_raises():
     with pytest.raises(ValueError, match=re.escape('Shape must be one of [(3, 3), (4, 4)].')):
         validate_transform4x4(np.array([1, 2, 3]))
-    with pytest.raises(TypeError, match='Input transform must be one of'):
+    match = (
+        'Input transform must be one of:'
+        '\n\tvtkMatrix4x4'
+        '\n\tvtkMatrix3x3'
+        '\n\tvtkTransform'
+        '\n\t4x4 np.ndarray'
+        '\n\t3x3 np.ndarray'
+        '\n\tscipy.spatial.transform.Rotation'
+        "\nGot 'abc' with type <class 'str'> instead."
+    )
+    with pytest.raises(TypeError, match=re.escape(match)):
         validate_transform4x4('abc')
 
 


### PR DESCRIPTION
`validate_transform4x4` built its error message inside a redundant extra set of parentheses ending in a comma, which made `msg` a 1-tuple rather than a string. The raised `TypeError` therefore rendered as `("Input transform must be one of:\n\tvtkMatrix4x4\n...",)` — the whole message wrapped in tuple syntax with escaped newlines, instead of the intended multi-line text.

The existing test only matched the substring `'Input transform must be one of'`, which is present either way, so it passed against the broken output. It now asserts the full message, mirroring how `test_validate_transform3x3_raises` already checks its sibling.

- Removes the redundant parentheses and trailing comma so `msg` is a plain string
- Tightens `test_validate_transform4x4_raises` to assert the complete message via `re.escape`
- Verified the tightened test fails on the unfixed source and passes with the fix
- No behaviour change beyond the message formatting: the exception type, trigger conditions and message text are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
