### PR TITLE
Optimize attribute-access and validation hot paths

### DIFF
--- a/pyvista/core/_validation/_cast_array.py
+++ b/pyvista/core/_validation/_cast_array.py
@@ -128,7 +128,7 @@ def _cast_to_numpy(
     if must_be_real and not issubclass(out.dtype.type, (np.floating, np.integer)):
         msg = f'Array must have real numbers. Got dtype {out.dtype.type}'
         raise TypeError(msg)
-    elif out.dtype.name == 'object':
+    elif out.dtype.kind == 'O':
         msg = f'Object arrays are not supported. Got {arr} when casting to a NumPy array.'
         raise TypeError(msg)
     return out

--- a/pyvista/core/_validation/validate.py
+++ b/pyvista/core/_validation/validate.py
@@ -619,37 +619,37 @@ def validate_transform4x4(
 
     """
     check_string(name, name='Name')
+    if isinstance(transform, _vtk.vtkMatrix4x4):
+        return _array_from_vtkmatrix(transform, shape=(4, 4))
+    if isinstance(transform, _vtk.vtkTransform):
+        return _array_from_vtkmatrix(transform.GetMatrix(), shape=(4, 4))
     try:
-        arr = np.eye(4)  # initialize
-        arr[:3, :3] = validate_transform3x3(transform, must_be_finite=must_be_finite, name=name)
-    except (ValueError, TypeError):
-        if isinstance(transform, _vtk.vtkMatrix4x4):
-            arr = _array_from_vtkmatrix(transform, shape=(4, 4))  # type: ignore[assignment]
-        elif isinstance(transform, _vtk.vtkTransform):
-            arr = _array_from_vtkmatrix(transform.GetMatrix(), shape=(4, 4))  # type: ignore[assignment]
-        else:
-            try:
-                arr = validate_array(
-                    transform,  # type: ignore[arg-type]
-                    must_have_shape=[(3, 3), (4, 4)],
-                    must_be_finite=must_be_finite,
-                    name=name,
-                )
-            except TypeError:
-                msg = (
-                    (
-                        'Input transform must be one of:\n'
-                        '\tvtkMatrix4x4\n'
-                        '\tvtkMatrix3x3\n'
-                        '\tvtkTransform\n'
-                        '\t4x4 np.ndarray\n'
-                        '\t3x3 np.ndarray\n'
-                        '\tscipy.spatial.transform.Rotation\n'
-                        f'Got {reprlib.repr(transform)} with type {type(transform)} instead.'
-                    ),
-                )
-                raise TypeError(msg)
-
+        arr = validate_array(
+            transform,  # type: ignore[arg-type]
+            must_have_shape=[(3, 3), (4, 4)],
+            must_be_finite=must_be_finite,
+            name=name,
+        )
+    except TypeError:
+        # Not array-like; may be a vtkMatrix3x3 or a SciPy Rotation
+        try:
+            arr = validate_transform3x3(transform, must_be_finite=must_be_finite, name=name)
+        except TypeError:
+            msg = (
+                'Input transform must be one of:\n'
+                '\tvtkMatrix4x4\n'
+                '\tvtkMatrix3x3\n'
+                '\tvtkTransform\n'
+                '\t4x4 np.ndarray\n'
+                '\t3x3 np.ndarray\n'
+                '\tscipy.spatial.transform.Rotation\n'
+                f'Got {reprlib.repr(transform)} with type {type(transform)} instead.'
+            )
+            raise TypeError(msg)
+    if arr.shape == (3, 3):
+        arr4 = np.eye(4)
+        arr4[:3, :3] = arr
+        return arr4
     return arr
 
 

--- a/pyvista/core/_vtk_utilities.py
+++ b/pyvista/core/_vtk_utilities.py
@@ -168,27 +168,40 @@ _SETDATA_TAKES_OWNERSHIP = vtk_version_info >= (9, 6)
 _SUPPORTS_POLYHEDRON_FACE_CELL_ARRAYS = vtk_version_info >= (9, 4)
 
 
+# Per-class attribute names verified safe to access in every ``vtk_snake_case`` state.
+_SAFE_ATTRS_BY_CLASS: dict[type, set[str]] = {}
+
+
 class DisableVtkSnakeCase:
     """Base class to raise error if using VTK's ``snake_case`` API."""
 
     @staticmethod
     def check_attribute(target, attr):
-        # Skip check and exit early if possible
-        if (
-            not _VTK_SNAKE_CASE_MIN_VERSION_MET
-            or _VTK_SNAKE_CASE_STATE == 'allow'
-            or not attr
-            or not attr[0].islower()
-            or attr in ('__class__', '__init__')
-        ):
+        """Raise or warn if ``attr`` is a VTK-defined ``snake_case`` name on ``target``."""
+        safe_by_class = _SAFE_ATTRS_BY_CLASS
+        if safe_by_class is None:  # pragma: no cover  # Python is shutting down
+            return  # type: ignore[unreachable]
+        # `target.__class__` and `isinstance` would recurse into `__getattribute__`
+        cls: type = target if issubclass(type(target), type) else type(target)
+        safe = safe_by_class.get(cls)
+        if safe is None:
+            safe = safe_by_class[cls] = set()
+        elif attr in safe:
             return
 
-        # Check if we have a vtk-defined attribute using cached lookup
-        cls = target if isinstance(target, type) else target.__class__
-        if not _is_vtk_attribute_cached(cls, attr):
+        # Names that no state can flag: no snake_case API, or not a VTK lowercase name
+        if (
+            not _VTK_SNAKE_CASE_MIN_VERSION_MET
+            or not attr
+            or not attr[0].islower()
+            or not _is_vtk_attribute_cached(cls, attr)
+        ):
+            safe.add(attr)
             return
 
         # We have a VTK attribute, so raise or warn
+        if _VTK_SNAKE_CASE_STATE == 'allow':
+            return
         if sys.meta_path is not None:  # Avoid dynamic imports when Python is shutting down
             msg = f'The attribute {attr!r} is defined by VTK and is not part of the PyVista API'
             if _VTK_SNAKE_CASE_STATE == 'error':
@@ -200,6 +213,13 @@ class DisableVtkSnakeCase:
         return
 
     def __getattribute__(self, item):
+        """Get an attribute after checking it is part of the PyVista API."""
+        # Hot path: inline the cache lookup so verified-safe names skip the check call
+        try:
+            if item in _SAFE_ATTRS_BY_CLASS[type(self)]:
+                return object.__getattribute__(self, item)
+        except (KeyError, TypeError):  # unseen class, or None during Python shutdown
+            pass
         DisableVtkSnakeCase.check_attribute(self, item)
         return object.__getattribute__(self, item)
 

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -7,7 +7,6 @@ from collections.abc import Sequence
 from enum import Enum
 import functools
 import importlib
-import inspect
 import sys
 import threading
 import traceback
@@ -478,15 +477,6 @@ class _DataObjectMeta(_AutoFreezeABCMeta):
         raise AttributeError(msg)
 
 
-def _hasattr_static(obj: Any, attr: str) -> bool:
-    """Replicate behavior of ``hasattr`` using static lookup."""
-    try:
-        inspect.getattr_static(obj, attr)
-    except AttributeError:
-        return False
-    return True
-
-
 class _NoNewAttrMixin(metaclass=_AutoFreezeABCMeta):
     """``Mixin`` to prevent adding new attributes.
 
@@ -501,6 +491,7 @@ class _NoNewAttrMixin(metaclass=_AutoFreezeABCMeta):
         object.__setattr__(self, '__frozen_by_class', this_class)
 
     def _check_new_attribute(self, key: str) -> None:
+        """Raise if a frozen instance is given a new attribute it does not allow."""
         # Check sys.meta_path to avoid dynamic imports when Python is shutting down
         if sys.meta_path is not None:
             # Get mode for setting new attributes. Read straight out of the module
@@ -521,29 +512,29 @@ class _NoNewAttrMixin(metaclass=_AutoFreezeABCMeta):
                 _ALLOW_NEW_ATTRIBUTES_MODE is True
                 or (key.startswith('_') and _ALLOW_NEW_ATTRIBUTES_MODE == 'private')
             ):
-                # Check if this class froze itself. Any frozen state already set by parent classes,
-                # e.g. by calling super().__init__(), will be ignored. This allows subclasses to
-                # set attributes during init without being affected by a parent class init.
-                frozen = self.__dict__.get('__frozen', False)
-                frozen_by = self.__dict__.get('__frozen_by_class', None)
-                if (
-                    frozen
-                    and frozen_by is type(self)
-                    and not (key in type(self).__dict__ or _hasattr_static(self, key))
-                ):
-                    from pyvista import PyVistaAttributeError  # noqa: PLC0415
+                # Allow attributes that already exist on the instance or anywhere in the MRO
+                cls = type(self)
+                if key in object.__getattribute__(self, '__dict__'):
+                    return
+                for base in cls.__mro__:
+                    if key in base.__dict__:
+                        return
 
-                    msg = (
-                        f'Attribute {key!r} does not exist and cannot be added to class '
-                        f'{self.__class__.__name__!r}\nUse `pyvista.set_new_attribute` '
-                        f'or `pyvista.allow_new_attributes` to set new attributes.\n'
-                        f'Setting new private variables (with `_` prefix) is allowed by default.'
-                    )
-                    raise PyVistaAttributeError(msg)
+                from pyvista import PyVistaAttributeError  # noqa: PLC0415
+
+                msg = (
+                    f'Attribute {key!r} does not exist and cannot be added to class '
+                    f'{cls.__name__!r}\nUse `pyvista.set_new_attribute` '
+                    f'or `pyvista.allow_new_attributes` to set new attributes.\n'
+                    f'Setting new private variables (with `_` prefix) is allowed by default.'
+                )
+                raise PyVistaAttributeError(msg)
 
     def __setattr__(self, key: str, value: Any) -> None:
         """Prevent adding new attributes to classes using "normal" methods."""
-        self._check_new_attribute(key)
+        # Only check instances frozen by their own class, ignoring parent-set state
+        if object.__getattribute__(self, '__dict__').get('__frozen_by_class') is type(self):
+            _NoNewAttrMixin._check_new_attribute(self, key)
         object.__setattr__(self, key, value)
 
 


### PR DESCRIPTION
## Summary

I asked Claude Fable 5 on Ultracode to profile some PyVista hot paths. Profiling shows `DisableVtkSnakeCase.__getattribute__` and `_NoNewAttrMixin.__setattr__` run several times per attribute access/set and dominate cumulative time in attribute-heavy workloads. This PR makes both near-free after a first check, and removes two eager-string-construction costs found along the way in `_validation`. No behavior changes: `vtk_snake_case` states, frozen-attribute errors, and all validation error types/messages are preserved.

- Cache names verified safe in every `vtk_snake_case` state in a per-class set consulted inline in `__getattribute__`; VTK snake_case names are never cached since their outcome is state-dependent.
- Use `type()`/`issubclass` in `check_attribute` instead of `__class__`/`isinstance`, which recursed back into `__getattribute__` on every check.
- `__setattr__` only runs the full new-attribute check for instances frozen by their own class, and the existence check uses an instance-dict + MRO scan instead of `inspect.getattr_static`.
- `validate_transform4x4` validates array-likes directly instead of routing 4x4 input through `validate_transform3x3`, which always failed by raising a `TypeError` whose message eagerly built a numpy array repr, only for the exception to be discarded.
- `_cast_to_numpy` detects object arrays with `dtype.kind` instead of `dtype.name`, which builds the dtype name string through a Python-level property on every cast.

## Benchmarks

Best-of-run with timeit, Python 3.14 / VTK 9.7 (macOS arm64), before vs after:

| Operation | Before | After | Speedup |
|---|---|---|---|
| `n_points` / `n_cells` property | 677 ns | 263 ns | 2.6x |
| `.point_data` | 3.9 us | 2.0 us | 2.0x |
| `point_data['Normals']` | 19.8 us | 12.6 us | 1.6x |
| frozen setattr (`prop.opacity = 0.5`) | 932 ns | 596 ns | 1.6x |
| `.points` get / set | 10.6 / 21.9 us | 8.3 / 15.8 us | ~1.3x |
| `transform()` | 426 us | 267 us | 1.6x |
| `validate_array3` | 2.8 us | 1.7 us | 1.6x |
| `ImageData()` / `PolyData(pts)` / `wrap()` | 33.5 / 48.5 / 23.6 us | 25.8 / 41.5 / 20.7 us | ~1.2x |

🤖 Generated with [Claude Code](https://claude.com/claude-code)