### PR TITLE
Bump pyvista-zstd past the vtkmodules import fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ requires-python = '>=3.10'
 all = ['pyvista[colormaps,io,jupyter]']
 colormaps = ['cmcrameri', 'cmocean', 'colorcet']
 cvista = ['cvista[all]>=9.7.0.2,<9.8.0']
-io = ['fsspec', 'imageio', 'meshio>=5.2', 'pyvista-zstd>=0.2.3']
+io = ['fsspec', 'imageio', 'meshio>=5.2', 'pyvista-zstd>=0.3.1']
 jupyter = ['ipywidgets', 'nest-asyncio2', 'trame-pyvista']
 
 [dependency-groups]
@@ -95,7 +95,7 @@ test = [
   'pytest-pyvista==0.3.3',
   'pytest-xdist<3.9.0',
   'pytest<9.1.0',
-  'pyvista-zstd>=0.2.3,<0.3.0',
+  'pyvista-zstd>=0.3.1,<0.5.0',
   'refleak>=0.2.2,<0.3.0',
   'retry-requests<2.1.0',
   'scipy<1.17.0',
@@ -141,7 +141,7 @@ docs = [
   'pydata-sphinx-theme==0.15.4', # Do not upgrade, see https://github.com/pyvista/pyvista/pull/7095
   'pypandoc==1.17',
   'pytest-sphinx==0.7.1',
-  'pyvista-zstd==0.2.4',
+  'pyvista-zstd==0.4.0',
   'ruamel-yaml<0.20.0',
   'scipy==1.16.3; python_version >= "3.11"',
   'sphinx-autobuild==2024.10.3',


### PR DESCRIPTION
### Summary

Fixes the nightly `cvista` integration failure in #8975.

`test_real_installed_plugin_still_round_trips` (added in #8950) round-trips a
`.pv` file through the real installed plugin and dies with:

```
pyvista_zstd/pyvista_zstd.py:894: in _segments_to_polydata
    pdata.SetPolys(_extract_cell_array(ds_id, POLYS, segments))
E   TypeError: SetPolys argument 1:
```

pyvista-zstd 0.2.4 builds its cell arrays straight off `vtkmodules`:

```python
from vtkmodules.vtkCommonDataModel import vtkCellArray
```

Under `PYVISTA_VTK_BACKEND=cvista` the `PolyData` is a cvista object, so a
stock-VTK cell array is a different C++ type and `SetPolys` rejects it.
pyvista-zstd fixed this in **0.3.1** by importing through `pyvista._vtk`, which
resolves to whichever binding PyVista is running on.

### Why CI kept installing the broken version

The `test` group already pinned the package — but as `>=0.2.3,<0.3.0`. That cap
sits *below* the fix, so the resolver correctly took the newest version it was
allowed (0.2.4), and the job reinstalled the one release that cannot work with
cvista on every run.

### Changes

- `io` extra → `>=0.3.1`, so `pip install pyvista[io,cvista]` cannot resolve a
  combination that fails on the first `.pv` read. This is a user-facing bug, not
  only a CI one.
- `test` group → `>=0.3.1,<0.5.0`
- `docs` group → `==0.4.0`

### Testing

Verified against the real backend rather than by inspection, using
`tox -e integration-cvista` on this machine:

- With 0.2.4 the failure reproduces exactly, same traceback as CI.
- Same env, same commit, A/B on the zstd version across the full non-plotting
  suite: the **only** difference is that test going fail → pass.

```
diff 0.2.4 -> 0.4.0
< FAILED tests/core/test_reader_registry.py::test_real_installed_plugin_still_round_trips
```

The other failures in both columns are this macOS box (GL-less `-plot`
variants, a `WindowsPath` test, multiprocessing) and are identical on both
versions.

`uv.lock` is gitignored here, so there is nothing to regenerate in-tree; I did
confirm the lock resolves (`pyvista-zstd v0.2.4 -> v0.4.0`). 0.4.0 moves
`zstandard` to its `tests` extra, and nothing in this repo imports it.

Closes #8975

### Agent disclosure

Diagnosed and written by a coding agent (Claude Code) at my direction; I have
reviewed it.
