### PR TITLE
Fix FileExistsError race in parallel example downloads

### DIFF
--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -21,6 +21,7 @@ Examples
 
 from __future__ import annotations
 
+import contextlib
 import functools
 import importlib.util
 import logging
@@ -269,6 +270,9 @@ def download_file(filename: str) -> str | list[str]:
 
 def _download_file(filename: str):
     """Download a file using pooch."""
+    # Pre-create the parent dir: pooch's check-then-makedirs races under parallel downloads
+    with contextlib.suppress(OSError):
+        (FETCHER.abspath / filename).parent.mkdir(parents=True, exist_ok=True)
     return FETCHER.fetch(
         filename,
         processor=pooch.Unzip() if filename.endswith('.zip') else None,  # type: ignore[attr-defined]

--- a/tests/examples/test_downloads.py
+++ b/tests/examples/test_downloads.py
@@ -164,6 +164,21 @@ def test_local_file_cache(tmp_path: Path):
         downloads.FETCHER.path = old_path
 
 
+def test_download_file_creates_destination_directory(tmp_path, monkeypatch):
+    """Ensure the destination dir exists before pooch fetches into it (parallel-safe)."""
+    parent_exists = []
+
+    def fake_fetch(filename, **_kwargs):
+        parent_exists.append((tmp_path / 'subdir').is_dir())
+        return str(tmp_path / filename)
+
+    monkeypatch.setattr(downloads.FETCHER, 'path', tmp_path)
+    monkeypatch.setattr(downloads.FETCHER, 'fetch', fake_fetch)
+
+    downloads.download_file('subdir/file.txt')
+    assert parent_exists == [True]
+
+
 @pytest.mark.parametrize('endswith', ['', 'Data', 'Data/'])
 def test_get_vtk_data_path_with_env_var(monkeypatch, endswith, tmp_path):
     path = (tmp_path / 'mypath').as_posix()


### PR DESCRIPTION
Since #8955 parallelized `make_tables.py`, doc builds intermittently fail with `FileExistsError: [Errno 17] File exists: '/home/runner/.cache/pyvista_3/cubemap_space'` ([example failed run](https://github.com/pyvista/pyvista/actions/runs/33256912105/job/99112171913)). The root cause is a TOCTOU race in pooch's `stream_download`, which does `if not fname.parent.exists(): os.makedirs(...)` without `exist_ok=True`: two worker processes fetching different files into the same not-yet-cached subdirectory (here `cubemap_space/4k.zip` and `cubemap_space/16k.zip`) both see the directory missing, and the slower `makedirs` raises. Any cold-cache parallel build can trip this — the gallery has a dozen shared cache subdirectories (`solar_textures/` alone holds 24 files). Pooch fixed the equivalent race for the cache root itself in fatiando/pooch#171, but the per-file subdirectory creation is still unguarded as of pooch 1.9.0 (concurrent fetching is tracked upstream in fatiando/pooch#411).

The fix pre-creates the destination directory in `_download_file()` before delegating to `FETCHER.fetch()`, so pooch's racy check-then-create never fires. Verified with a no-network stress repro using the `_FILE_CACHE` local-copy downloader (8 processes × 30 trials fetching distinct files into the same fresh subdirectory): 29 `FileExistsError` failures on main, 0 with this fix.

- Pre-create the parent directory with `mkdir(parents=True, exist_ok=True)` in `_download_file()`, wrapped in `contextlib.suppress(OSError)` so an unwritable cache still surfaces through pooch's friendlier error path
- Add a regression test asserting the destination directory exists by the time `FETCHER.fetch()` is called

🤖 Generated with [Claude Code](https://claude.com/claude-code)
