### PR TITLE
Share rendered output between identical plot directives

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -628,6 +628,30 @@ pyvista_plot_cleanup = pyvista_plot_setup
 # Hyperlink identifiers in ``.. pyvista-plot::`` output to their documented targets.
 pyvista_plot_autocodelink = True
 
+
+def pyvista_plot_read_group_key(docname):
+    """Group autosummary pages whose target objects share their doctest lines.
+
+    ``Plotter`` methods that wrap a ``Renderer`` method carry its docstring
+    verbatim, so both pages render identical figures; reading them on the same
+    worker lets the plot directive's figure cache render each figure once.
+    """
+    _, sep, qualname = docname.rpartition('_autosummary/')
+    if not sep or not qualname.startswith('pyvista.'):
+        return None
+    try:
+        obj = pv
+        for attr in qualname.split('.')[1:]:
+            obj = getattr(obj, attr)
+        doc = obj.__doc__ or ''
+    except Exception:  # noqa: BLE001
+        return None
+    doctest_lines = [
+        line.strip() for line in doc.splitlines() if line.lstrip().startswith(('>>>', '...'))
+    ]
+    return '\n'.join(doctest_lines) if doctest_lines else None
+
+
 # Append a "Used In" backreferences section to every autodoc-documented object's own
 # docstring (empty ones get nothing appended, not "No references found.").
 autocodelink_autodoc_backrefs = True

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -141,6 +141,14 @@ The plot directive has the following configuration options:
 
         .. versionadded:: 0.49
 
+    ``pyvista_plot_read_group_key`` : Callable[[str], Any] | None
+        Key function over docnames for parallel reading. Docs whose keys are
+        equal (and not ``None``) are read adjacently, and so by the same
+        worker -- without this, identical directives on pages read
+        concurrently each render instead of sharing one result.
+
+        .. versionadded:: 0.49
+
 These options can be set by defining global variables of the same name in
 :file:`conf.py`.
 
@@ -326,6 +334,7 @@ def setup(app: Sphinx):
     setup.confdir = app.confdir
     app.add_directive('pyvista-plot', PlotDirective)
     app.connect('builder-inited', _clear_figure_cache)
+    app.connect('env-before-read-docs', _group_duplicate_docs)
     if record_namespace is not None:
         app.setup_extension('sphinx_autocodelink')
 
@@ -391,6 +400,7 @@ def setup(app: Sphinx):
     app.add_config_value(name='pyvista_plot_skip', default=False, rebuild='html')
     app.add_config_value(name='pyvista_plot_skip_optional', default=False, rebuild='html')
     app.add_config_value(name='pyvista_plot_autocodelink', default=False, rebuild='html')
+    app.add_config_value(name='pyvista_plot_read_group_key', default=None, rebuild='env')
     return {
         'parallel_read_safe': True,
         'parallel_write_safe': True,
@@ -600,6 +610,41 @@ def _figure_cache_dir(app: Sphinx) -> Path:
 def _clear_figure_cache(app: Sphinx) -> None:
     """Drop the figure cache so no entry outlives the build that rendered it."""
     shutil.rmtree(_figure_cache_dir(app), ignore_errors=True)
+
+
+def _adjacent_by_group(docnames, key):
+    """Return ``docnames`` with every multi-member group made contiguous.
+
+    A group's members move up to its first member's position; every other name
+    keeps its place in the order.
+    """
+    group_of = {name: key(name) for name in docnames}
+    members: dict = {}
+    for name in docnames:
+        if group_of[name] is not None:
+            members.setdefault(group_of[name], []).append(name)
+    grouped = {name for group in members.values() if len(group) > 1 for name in group}
+    ordered = []
+    emitted: set[str] = set()
+    for name in docnames:
+        if name not in grouped:
+            ordered.append(name)
+        elif name not in emitted:
+            group = members[group_of[name]]
+            ordered.extend(group)
+            emitted.update(group)
+    return ordered
+
+
+def _group_duplicate_docs(app: Sphinx, _env, docnames) -> None:
+    """Reorder the reading order so docs sharing a group key are read together.
+
+    A parallel read splits ``docnames`` into contiguous chunks, so adjacent
+    duplicates land in one worker and the figure cache serves the later ones.
+    """
+    key = app.config.pyvista_plot_read_group_key
+    if callable(key) and docnames:
+        docnames[:] = _adjacent_by_group(docnames, key)
 
 
 def _load_cached_figures(cache_entry: Path, *, code, output_dir, output_base):

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -166,12 +166,19 @@ that indexed is incompatible with parallel builds due to race conditions.
     (e.g. the https://github.com/pyvista/sphinx-examples-as-code Sphinx extension)
     to reliably locate this directive's generated code within a page.
 
+Within one build, directives with the same source hash share their rendered
+output: the first one executes and every later one copies its figures instead
+of executing again. ``:context:`` directives always execute.
+
+.. versionadded:: 0.49
+
 """
 
 from __future__ import annotations
 
 import doctest
 import hashlib
+import json
 import os
 from pathlib import Path
 import re
@@ -193,6 +200,33 @@ try:
     from sphinx_autocodelink import record_namespace
 except ImportError:
     record_namespace = None
+
+try:
+    # Record capture/replay for the figure cache (see ``run`` when missing).
+    from sphinx_autocodelink import DEFAULT_DOCSTRING_EXAMPLE_CATEGORY
+    from sphinx_autocodelink import is_inside_autodoc_desc
+    from sphinx_autocodelink import record_namespace_to_disk
+
+    try:
+        from sphinx_autocodelink import capture_records
+
+        _records_from_jsonable = list
+    except ImportError:  # older sphinx-autocodelink keeps the round trip private
+        from sphinx_autocodelink import _from_jsonable
+        from sphinx_autocodelink import _records_for
+        from sphinx_autocodelink import _to_jsonable
+
+        def capture_records(*, source, namespace):
+            """Resolve ``source``'s records as JSON-able dicts."""
+            return [_to_jsonable(record) for record in _records_for(source, namespace)]
+
+        def _records_from_jsonable(entries):
+            """Rebuild record objects for ``record_namespace_to_disk``'s ``extra``."""
+            return [_from_jsonable(entry) for entry in entries]
+except ImportError:
+    _RECORDS_CACHE_OK = False
+else:
+    _RECORDS_CACHE_OK = True
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -291,6 +325,7 @@ def setup(app: Sphinx):
     setup.config = app.config
     setup.confdir = app.confdir
     app.add_directive('pyvista-plot', PlotDirective)
+    app.connect('builder-inited', _clear_figure_cache)
     if record_namespace is not None:
         app.setup_extension('sphinx_autocodelink')
 
@@ -557,6 +592,96 @@ def _run_code(*, code, code_path, ns=None, function_name=None):
     return ns
 
 
+def _figure_cache_dir(app: Sphinx) -> Path:
+    """Return the build-wide directory of results shared between identical directives."""
+    return Path(app.doctreedir).parent / 'pyvista_plot_directive' / '_cache'
+
+
+def _clear_figure_cache(app: Sphinx) -> None:
+    """Drop the figure cache so no entry outlives the build that rendered it."""
+    shutil.rmtree(_figure_cache_dir(app), ignore_errors=True)
+
+
+def _load_cached_figures(cache_entry: Path, *, code, output_dir, output_base):
+    """Copy a cached directive's files in as this directive's output.
+
+    Returns ``(results, records)`` for ``render_figures``, or ``None`` when
+    there is no usable entry and the code has to be executed.
+    """
+    try:
+        manifest = json.loads((cache_entry / 'manifest.json').read_text(encoding='utf-8'))
+        image_names = manifest['images']
+    except (OSError, ValueError, KeyError, TypeError):
+        return None
+    _, code_pieces = _split_code_at_show(code)
+    if len(image_names) != len(code_pieces):
+        return None
+    try:
+        results = []
+        for code_piece, names in zip(code_pieces, image_names, strict=True):
+            images = []
+            for name in names:
+                image_file = ImageFile(output_dir, f'{output_base}_{name}')
+                if image_file.extension == 'vtksz':
+                    # the template pairs every interactive scene with a static .png
+                    png = str(Path(name).with_suffix('.png'))
+                    shutil.copyfile(cache_entry / png, Path(output_dir) / f'{output_base}_{png}')
+                shutil.copyfile(cache_entry / name, image_file.filename)
+                images.append(image_file)
+            results.append((code_piece, images))
+    except OSError:
+        return None
+    return results, manifest.get('records')
+
+
+def _store_cached_figures(cache_entry: Path, *, results, output_base, records) -> None:
+    """Copy this directive's rendered files into the build-wide figure cache.
+
+    Staged in a temporary sibling and renamed into place, so a parallel reader
+    never sees a partial entry and a losing concurrent writer is discarded.
+    """
+    prefix = f'{output_base}_'
+    image_names = []
+    files = []
+    for _, images in results:
+        names = []
+        for img in images:
+            names.append(img.basename.removeprefix(prefix))
+            files.append((img.filename, names[-1]))
+            if img.extension == 'vtksz':
+                png = f'{img.stem}.png'
+                files.append((str(Path(img.dirname) / png), png.removeprefix(prefix)))
+        image_names.append(names)
+
+    staging = cache_entry.parent / f'{cache_entry.name}.{os.getpid()}.tmp'
+    try:
+        staging.mkdir(parents=True, exist_ok=True)
+        for source, name in files:
+            shutil.copyfile(source, staging / name)
+        manifest = {'images': image_names, 'records': records}
+        (staging / 'manifest.json').write_text(json.dumps(manifest), encoding='utf-8')
+        staging.rename(cache_entry)
+    except OSError:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def _replay_cached_records(records, *, docname, state) -> None:
+    """Write cache-captured autocodelink records to the package's on-disk records."""
+    category = (
+        DEFAULT_DOCSTRING_EXAMPLE_CATEGORY
+        if state is not None and is_inside_autodoc_desc(state)
+        else ''
+    )
+    record_namespace_to_disk(
+        directory=Path(setup.app.srcdir) / setup.app.config.autocodelink_records_dir,
+        docname=docname,
+        source='',
+        namespace={},
+        extra=_records_from_jsonable(records),
+        category=category,
+    )
+
+
 def render_figures(
     *,
     code,
@@ -570,6 +695,7 @@ def render_figures(
     env: BuildEnvironment | None = None,
     include_source: bool = True,
     state: RSTState | None = None,
+    cache_entry: Path | None = None,
 ):
     """Run a pyplot script and save the images in *``output_dir``*.
 
@@ -581,7 +707,25 @@ def render_figures(
     to hyperlink -- skipped when the source isn't shown, since there would be nothing on the
     page for a reader to click through to. ``state`` is the calling directive's own
     ``self.state``, passed through to sphinx-autocodelink for its own categorization.
+
+    ``cache_entry`` names this code's slot in the build-wide figure cache: a usable
+    entry is copied instead of executing the code, and a rendered result is stored.
     """
+    if cache_entry is not None:
+        cached = _load_cached_figures(
+            cache_entry, code=code, output_dir=output_dir, output_base=output_base
+        )
+        if cached is not None:
+            results, cached_records = cached
+            if (
+                cached_records
+                and env is not None
+                and config.pyvista_plot_autocodelink
+                and include_source
+            ):
+                _replay_cached_records(cached_records, docname=env.docname, state=state)
+            return results
+
     # We skip snippets that contain the ``pyvista-plot::`` directive as part of their code.
     # The doctest parser will present the code-block once again with the ``pyvista-plot::``
     # directive and its options properly parsed.
@@ -594,6 +738,7 @@ def render_figures(
 
     # Otherwise, we didn't find the files, so build them
     results = []
+    records = None
     ns = plot_context if context else {}
     clean_pieces = []
 
@@ -652,22 +797,26 @@ def render_figures(
 
             results.append((code_piece, images))
 
-        if (
-            env is not None
-            and clean_pieces
-            and config.pyvista_plot_autocodelink
-            and include_source
-        ):
-            record_namespace(
-                env=env,
-                docname=env.docname,
-                source='\n'.join(clean_pieces),
-                namespace=ns,
-                state=state,
-            )
+        if env is not None and clean_pieces and config.pyvista_plot_autocodelink:
+            source = '\n'.join(clean_pieces)
+            if include_source:
+                record_namespace(
+                    env=env,
+                    docname=env.docname,
+                    source=source,
+                    namespace=ns,
+                    state=state,
+                )
+            if cache_entry is not None:
+                records = capture_records(source=source, namespace=ns)
     finally:
         if code_cleanup:
             _run_code(code=code_cleanup, code_path=code_path, ns=ns, function_name=function_name)
+
+    if cache_entry is not None:
+        _store_cached_figures(
+            cache_entry, results=results, output_base=output_base, records=records
+        )
 
     return results
 
@@ -805,6 +954,17 @@ def run(arguments, content, options, state_machine, state, lineno):  # noqa: PLR
         build_dir_link = build_dir
     build_dir_link = Path(build_dir_link).as_posix()
 
+    # directives whose results are not a pure function of their source always execute
+    cache_entry = None
+    if (
+        not keep_context
+        and function_name is None
+        and not _contains_pyvista_plot(code)
+        and (not config.pyvista_plot_autocodelink or _RECORDS_CACHE_OK)
+    ):
+        static_tag = '-static' if force_static else ''
+        cache_entry = _figure_cache_dir(setup.app) / f'{hash_plot_code(code, options)}{static_tag}'
+
     # make figures
     errors = []
     if skip:
@@ -823,6 +983,7 @@ def run(arguments, content, options, state_machine, state, lineno):  # noqa: PLR
                 env=document.settings.env,
                 include_source=options['include-source'],
                 state=state,
+                cache_entry=cache_entry,
             )
         except PlotError as err:  # pragma: no cover
             reporter = state.memo.reporter

--- a/tests/ext/test_ext.py
+++ b/tests/ext/test_ext.py
@@ -245,3 +245,99 @@ def test_setup_enables_gallery_mode(monkeypatch):
 
     assert pv.BUILDING_GALLERY
     assert pv.OFF_SCREEN
+
+
+_TWO_PIECE_CODE = '>>> import pyvista as pv\n>>> pv.Sphere().plot()\n>>> pv.Cube().plot()\n'
+
+
+def _fake_render(output_dir, output_base):
+    """Write the files ``render_figures`` would produce for ``_TWO_PIECE_CODE``."""
+    files = {
+        f'{output_base}_00_00.png': b'static',
+        f'{output_base}_00_00.vtksz': b'interactive',
+        f'{output_base}_01_00.png': b'cube',
+    }
+    for name, content in files.items():
+        (output_dir / name).write_bytes(content)
+    _, pieces = plot_directive._split_code_at_show(_TWO_PIECE_CODE)
+    return [
+        (pieces[0], [plot_directive.ImageFile(str(output_dir), f'{output_base}_00_00.vtksz')]),
+        (pieces[1], [plot_directive.ImageFile(str(output_dir), f'{output_base}_01_00.png')]),
+    ]
+
+
+def test_figure_cache_round_trip(tmp_path):
+    first = tmp_path / 'first'
+    second = tmp_path / 'second'
+    first.mkdir()
+    second.mkdir()
+    entry = tmp_path / 'cache' / 'abc123'
+    records = [{'accessed': 'pv.Sphere', 'candidates': ['pyvista.Sphere'], 'counts_as_use': True}]
+
+    results = _fake_render(first, 'page-abc123')
+    plot_directive._store_cached_figures(
+        entry, results=results, output_base='page-abc123', records=records
+    )
+
+    cached = plot_directive._load_cached_figures(
+        entry, code=_TWO_PIECE_CODE, output_dir=str(second), output_base='other-abc123'
+    )
+    assert cached is not None
+    cached_results, cached_records = cached
+    assert cached_records == records
+    assert [[img.basename for img in images] for _, images in cached_results] == [
+        ['other-abc123_00_00.vtksz'],
+        ['other-abc123_01_00.png'],
+    ]
+    assert [piece for piece, _ in cached_results] == [piece for piece, _ in results]
+    assert (second / 'other-abc123_00_00.vtksz').read_bytes() == b'interactive'
+    # the interactive scene's static companion is carried along
+    assert (second / 'other-abc123_00_00.png').read_bytes() == b'static'
+    assert (second / 'other-abc123_01_00.png').read_bytes() == b'cube'
+
+
+def test_figure_cache_misses(tmp_path):
+    out = tmp_path / 'out'
+    out.mkdir()
+    entry = tmp_path / 'cache' / 'abc123'
+
+    def load(code):
+        return plot_directive._load_cached_figures(
+            entry, code=code, output_dir=str(out), output_base='page'
+        )
+
+    assert load(_TWO_PIECE_CODE) is None  # no entry yet
+
+    results = _fake_render(out, 'page-abc123')
+    plot_directive._store_cached_figures(
+        entry, results=results, output_base='page-abc123', records=None
+    )
+
+    one_piece = '>>> import pyvista as pv\n>>> pv.Sphere().plot()\n'
+    assert load(one_piece) is None  # code splits into a different number of pieces
+
+    (entry / '01_00.png').unlink()
+    assert load(_TWO_PIECE_CODE) is None  # a listed file is missing from the entry
+
+
+def test_figure_cache_store_loses_race(tmp_path):
+    out = tmp_path / 'out'
+    out.mkdir()
+    entry = tmp_path / 'cache' / 'abc123'
+    results = _fake_render(out, 'page-abc123')
+    plot_directive._store_cached_figures(
+        entry, results=results, output_base='page-abc123', records=None
+    )
+    manifest = (entry / 'manifest.json').read_bytes()
+
+    plot_directive._store_cached_figures(
+        entry, results=results, output_base='page-abc123', records=['changed']
+    )
+    assert (entry / 'manifest.json').read_bytes() == manifest
+    assert list(entry.parent.glob('*.tmp')) == []
+
+
+def test_setup_connects_figure_cache_clear():
+    app = _FakeSphinxApp()
+    plot_directive.setup(app)
+    assert plot_directive._clear_figure_cache in app.connected['builder-inited']

--- a/tests/ext/test_ext.py
+++ b/tests/ext/test_ext.py
@@ -341,3 +341,45 @@ def test_setup_connects_figure_cache_clear():
     app = _FakeSphinxApp()
     plot_directive.setup(app)
     assert plot_directive._clear_figure_cache in app.connected['builder-inited']
+
+
+def test_adjacent_by_group_pulls_members_together():
+    docnames = ['a', 'plotter.foo', 'b', 'c', 'renderer.foo', 'd']
+
+    def key(name):
+        return 'foo' if name.endswith('.foo') else None
+
+    ordered = plot_directive._adjacent_by_group(docnames, key)
+
+    assert ordered == ['a', 'plotter.foo', 'renderer.foo', 'b', 'c', 'd']
+
+
+def test_adjacent_by_group_leaves_singletons_and_unkeyed_in_place():
+    docnames = ['a', 'only.foo', 'b']
+
+    def key(name):
+        return 'foo' if name.endswith('.foo') else None
+
+    assert plot_directive._adjacent_by_group(docnames, key) == docnames
+
+
+def test_group_duplicate_docs_reorders_in_place():
+    app = SimpleNamespace(
+        config=SimpleNamespace(
+            pyvista_plot_read_group_key=lambda name: name[-1] if name[-1].isdigit() else None
+        )
+    )
+    docnames = ['x1', 'a', 'y1', 'b']
+
+    plot_directive._group_duplicate_docs(app, None, docnames)
+
+    assert docnames == ['x1', 'y1', 'a', 'b']
+
+
+def test_group_duplicate_docs_without_key_is_a_no_op():
+    app = SimpleNamespace(config=SimpleNamespace(pyvista_plot_read_group_key=None))
+    docnames = ['b', 'a']
+
+    plot_directive._group_duplicate_docs(app, None, docnames)
+
+    assert docnames == ['b', 'a']


### PR DESCRIPTION
### Overview

The docs build renders the same figure on many page pairs: 38 `Plotter` methods wrap a `Renderer` method's docstring verbatim (`set_environment_texture` alone reads at 17.5s + 16.4s in #8985's duration report), and the 4k/16k cubemap pages run identical example code. Within one build, the first `pyvista-plot` directive with a given source hash now renders and stores its figures in a build-wide cache, and every later identical directive copies the result instead of executing again — in a two-page test project the second page's reading time drops from 2.5s to 0.004s. `:context:` directives and named functions run from files always execute, the cache is cleared at builder-inited so no entry outlives the build that rendered it, and entries are staged and renamed into place so parallel readers never see partial results.

A cache hit skips execution, so autocodelink records are captured on the miss and replayed on hits through sphinx-autocodelink's on-disk records flow; pyvista/sphinx-autocodelink#33 makes that round trip public, and until the pin moves past 0.9.0 the directive builds the same helpers from the package internals (and disables caching for autocodelink builds if neither is available, so pages never silently lose their links). Copies are byte-identical, so no doc images change.

Changes drafted by Claude (Fable 5) but fully understood by me.
