### PR TITLE
Order two-point line segments in `compute_arc_length`

### DIFF
--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -3309,6 +3309,15 @@ class PolyDataFilters(DataSetFilters):
         computed arc length for each of the polylines in the
         input. For all other cell types, the arc length is set to 0.
 
+        The arc length accumulates along each polyline in point order, so the
+        lines must be ordered for the result to grow along the curve. When
+        every line cell of the input is a two-point segment, as produced by
+        :meth:`~pyvista.DataSetFilters.slice`, the segments are assembled into
+        polylines with :meth:`~pyvista.PolyDataFilters.strip` before the arc
+        length is accumulated. The returned mesh keeps the points and cells of
+        the input. Each polyline restarts at 0, so a mesh holding several
+        disconnected loops ends below the sum of its cell lengths.
+
         Parameters
         ----------
         progress_bar : bool, default: False
@@ -3334,16 +3343,31 @@ class PolyDataFilters(DataSetFilters):
         >>> f'Length is {length:.3f}'
         'Length is 0.812'
 
+        A slice through a surface is a set of unordered two-point segments, and
+        the arc length still spans the whole contour.
+
+        >>> contour = sphere.slice(normal='y').compute_arc_length()
+        >>> f'Perimeter is {contour["arc_length"].max():.3f}'
+        'Perimeter is 3.140'
+
         You can also plot the ``arc_length``.
 
         >>> arc = path.compute_arc_length()
         >>> arc.plot(scalars='arc_length')
 
         """
+        segments = self.n_lines > 1 and self.lines.size == 3 * self.n_lines
+
         alg = _vtk.vtkAppendArcLength()
-        alg.SetInputData(self)
+        alg.SetInputData(self.strip(join=True, progress_bar=progress_bar) if segments else self)
         _update_alg(alg, progress_bar=progress_bar, message='Computing the Arc Length')
-        return _get_output(alg)
+        output = _get_output(alg)
+
+        if segments:
+            arc_length = output.point_data['arc_length']
+            output = self.copy()
+            output.point_data.set_array(arc_length, 'arc_length')
+        return output
 
     @_deprecate_positional_args
     def project_points_to_plane(  # type: ignore[misc]  # noqa: PLR0917

--- a/tests/core/test_polydata_filters.py
+++ b/tests/core/test_polydata_filters.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
 import pytest
 
 import pyvista as pv
@@ -171,3 +172,78 @@ def test_ruled_surface():
     )
     ruled = poly.ruled_surface(resolution=(21, 21))
     assert ruled.n_cells
+
+
+def test_compute_arc_length_polyline():
+    spline = pv.Spline(np.column_stack([np.linspace(0, 1, 20), np.zeros(20), np.zeros(20)]), 40)
+    arc = spline.compute_arc_length()
+
+    assert arc.n_cells == spline.n_cells
+    assert arc['arc_length'][0] == 0.0
+    assert arc['arc_length'].max() == pytest.approx(1.0)
+    assert np.all(np.diff(arc['arc_length']) >= 0.0)
+
+
+def test_compute_arc_length_unordered_segments():
+    contour = pv.Sphere().slice(normal='y')
+    perimeter = contour.compute_cell_sizes(length=True, area=False, volume=False)['Length'].sum()
+
+    assert contour.n_lines > 1
+    assert contour.lines.size == 3 * contour.n_lines
+
+    arc = contour.compute_arc_length()
+
+    assert arc['arc_length'].max() == pytest.approx(perimeter)
+    stripped = contour.strip(join=True).compute_arc_length()['arc_length']
+    assert np.allclose(np.sort(arc['arc_length']), np.sort(stripped))
+
+
+def test_compute_arc_length_keeps_input_topology():
+    contour = pv.Sphere().slice(normal='y')
+    perimeter = contour.compute_cell_sizes(length=True, area=False, volume=False)['Length'].sum()
+    contour['data'] = np.arange(contour.n_points, dtype=float)
+    contour.set_active_scalars('data')
+
+    arc = contour.compute_arc_length()
+
+    assert arc['arc_length'].max() == pytest.approx(perimeter)
+    assert arc.n_cells == contour.n_cells
+    assert arc.n_points == contour.n_points
+    assert np.array_equal(arc.lines, contour.lines)
+    assert np.allclose(arc.points, contour.points)
+    assert arc.active_scalars_name == 'data'
+
+
+def test_compute_arc_length_disjoint_segments_are_not_joined():
+    poly = pv.PolyData(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [5.0, 0.0, 0.0], [7.0, 0.0, 0.0]],
+        lines=[[2, 0, 1], [2, 2, 3]],
+    )
+
+    arc = poly.compute_arc_length()
+
+    assert arc['arc_length'].max() == pytest.approx(2.0)
+
+
+def test_compute_arc_length_no_lines():
+    arc = pv.Sphere().compute_arc_length()
+
+    assert arc.n_cells == pv.Sphere().n_cells
+    assert not np.any(arc['arc_length'])
+
+
+def test_compute_arc_length_existing_polylines_are_left_alone():
+    angles = np.linspace(0.0, 2.0 * np.pi, 9)[:-1]
+    left = np.column_stack([np.cos(angles) - 1.0, np.sin(angles), np.zeros(8)])
+    right = np.column_stack([1.0 - np.cos(angles), -np.sin(angles), np.zeros(8)])
+    points = np.vstack([[0.0, 0.0, 0.0], left[1:], right[1:]])
+    figure_eight = pv.PolyData(points, lines=[9, 0, *range(1, 8), 0, 9, 0, *range(8, 15), 0])
+    lengths = figure_eight.compute_cell_sizes(length=True, area=False, volume=False)['Length']
+
+    assert figure_eight.n_lines == 2
+    assert figure_eight.lines.size > 3 * figure_eight.n_lines
+    assert lengths[0] == pytest.approx(lengths[1])
+
+    arc = figure_eight.compute_arc_length()
+
+    assert arc['arc_length'].max() == pytest.approx(lengths[0])


### PR DESCRIPTION
### Overview

`vtkAppendArcLength` accumulates along each cell's own point list, so a mesh whose line cells are all two-point segments — what `slice` produces — gets an `arc_length` that oscillates between 0 and one segment length instead of growing along the curve: `pv.Sphere().slice(normal='y').compute_arc_length()` peaks at 0.054 rather than the 3.140 perimeter. This assembles those segments into polylines with `strip` first and puts the array back on the input's own points and cells, so the returned mesh is unchanged apart from `arc_length`. It is the first of the two directions in https://github.com/pyvista/pyvista/issues/1948#issuecomment-4320647437 and leaves the `strip` cell-data half alone, so it does not resolve that issue.

The gate is `n_lines > 1 and lines.size == 3 * n_lines`, so anything already carrying a polyline takes exactly the old path, as every in-repo caller does. `join=True` rather than the `strip` default because over 116 slices of 13 surfaces it is never worse and is better on 6, and it recovers a chain whose segments arrive shuffled. Cost lands only on the gated path: 0.066 ms → 0.22 ms for a 1194-segment contour here, other paths unmoved. Two of the six tests also pass against a reverted source and against a naive always-strip version; they are pinning the untouched polyline path and keeping genuinely disjoint segments from being chained.

AI disclosure: the code, the tests and this description were drafted by Claude Opus 5 working as a coding agent in this repository.
