### PR TITLE
Make the voxelize cell length sample size test deterministic

### DIFF
--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -29,7 +29,6 @@ from pyvista.core.errors import NotAllTrianglesError
 from pyvista.core.errors import PyVistaDeprecationWarning
 from pyvista.core.filters import _get_output
 from pyvista.core.filters.data_set import _swap_axes
-from tests.conftest import flaky_test
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -4558,18 +4557,37 @@ def test_voxelize_binary_mask_spacing(ant):
         ant.voxelize_binary_mask(spacing=0.1, cell_length_sample_size=ant.n_cells)
 
 
-# This test is flaky because of random sampling that cannot be controlled.
-# Sometimes the sampling produces the same output.
-# https://github.com/pyvista/pyvista/pull/6728
-@flaky_test(times=5)
-def test_voxelize_binary_mask_cell_length_sample_size(ant):
-    mask_samples_1 = ant.voxelize_binary_mask(cell_length_sample_size=100)
-    mask_samples_2 = ant.voxelize_binary_mask(cell_length_sample_size=200)
-    assert mask_samples_1.spacing != mask_samples_2.spacing
+def test_voxelize_binary_mask_cell_length_sample_size(ant, mocker: MockerFixture):
+    from pyvista import _vtk
+    from pyvista.core.filters import data_set
 
-    mask_samples_1 = ant.voxelize_binary_mask(cell_length_sample_size=ant.n_cells)
-    mask_samples_2 = ant.voxelize_binary_mask(cell_length_sample_size=ant.n_cells)
-    assert mask_samples_1.spacing == mask_samples_2.spacing
+    sample_sizes = []
+    update_alg = data_set._update_alg
+
+    def _record_sample_size(alg, **kwargs):
+        if isinstance(alg, _vtk.vtkLengthDistribution):
+            sample_sizes.append(alg.GetSampleSize())
+        return update_alg(alg, **kwargs)
+
+    mocker.patch.object(data_set, '_update_alg', _record_sample_size)
+
+    # Sample size is used when sampling cell lengths
+    ant.voxelize_binary_mask(cell_length_sample_size=100)
+    assert sample_sizes == [100]
+
+    # Default sample size covers all cells
+    sample_sizes.clear()
+    ant.voxelize_binary_mask()
+    assert sample_sizes[0] > ant.n_cells
+
+    # Sampling all cells is not random, so the spacing is reproducible
+    mask_all_cells = ant.voxelize_binary_mask(cell_length_sample_size=ant.n_cells)
+    mask_all_cells_again = ant.voxelize_binary_mask(cell_length_sample_size=ant.n_cells)
+    assert mask_all_cells.spacing == mask_all_cells_again.spacing
+
+    # Sample sizes larger than the number of cells are clamped
+    mask_clamped = ant.voxelize_binary_mask(cell_length_sample_size=ant.n_cells * 10)
+    assert mask_clamped.spacing == mask_all_cells.spacing
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Overview

`test_voxelize_binary_mask_cell_length_sample_size` asserted that two different `cell_length_sample_size` values give different spacings. Nothing guarantees that: `vtkLengthDistribution` samples cells with `vtkReservoirSampler`, seeded from `std::random_device` with no seed API, and the spacing is quantized to integer dimensions. Both sample sizes land on the same value ~16% of the time, which is enough to exhaust the five `@flaky_test` retries. From Windows Unit Testing (3.11) in https://github.com/pyvista/pyvista/actions/runs/33336924160/job/99325759311:

```
>       assert mask_samples_1.spacing != mask_samples_2.spacing
E       assert (0.21782313236573927, 0.21825581927632176, 0.21792208683955205) != (0.21782313236573927, 0.21825581927632176, 0.21792208683955205)

tests\core\test_dataset_filters.py:4568: AssertionError
---------------------------- Captured stdout call -----------------------------
FLAKY TEST FAILED (Attempt 1 of 5) - ... - AssertionError, retrying...
FLAKY TEST FAILED (Attempt 2 of 5) - ... - AssertionError, retrying...
FLAKY TEST FAILED (Attempt 3 of 5) - ... - AssertionError, retrying...
FLAKY TEST FAILED (Attempt 4 of 5) - ... - AssertionError, retrying...
FLAKY TEST FAILED (Attempt 5 of 5) - ... - AssertionError
```

Replaced with assertions that hold by construction: `vtkReservoirSampler` returns the identity sequence when the sample size covers every cell, so any size at or above `n_cells` is deterministic.

### Details

- Check the sample size reaches `vtkLengthDistribution`, and that the default covers every cell.
- Check that sampling all cells gives reproducible spacing, and that larger sizes clamp to it.
- Drop `@flaky_test` here; the `tests/conftest.py` helper stays for the plotting tests.
- Not covered: that a *smaller* sample size changes the result. Any random subsample can coincide with any other, so that cannot be asserted deterministically.

Claude Code investigated the flake and wrote this change and description; I reviewed both.
