### PR TITLE
Pin the console in the CLI compare warning ordering test

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2265,6 +2265,8 @@ def test_compare_too_small_warning_advises_the_command(
     assert 'link=False' not in flattened
 
 
+# Pinned so the panel below is not rendered at a width or style of the environment's choosing
+@pytest.mark.usefixtures('patch_app_console')
 def test_compare_too_small_warning_is_printed_before_the_plot_is_shown(
     tmp_example_dir: Path, capsys: pytest.CaptureFixture, mocker: MockerFixture
 ):
@@ -2283,15 +2285,14 @@ def test_compare_too_small_warning_is_printed_before_the_plot_is_shown(
 
     def fake_show(*args, **kwargs):  # noqa: ARG001
         _, err = capsys.readouterr()
-        # The message is wrapped and padded to the width of the panel it is printed
-        # in, so flatten it the same way it is elsewhere before matching a substring
-        flattened = ' '.join(err.replace('│', ' ').split())
-        printed_before_shown.append('too small to make out' in flattened)
+        # Flatten the wrapping and padding of the panel, as the tests above do
+        printed_before_shown.append(' '.join(err.replace('│', ' ').split()))
 
     mocker.patch.object(pv.Plotter, 'show', fake_show)
     main('compare tiny.vtp huge.vtp --link --off-screen')
 
-    assert printed_before_shown == [True]
+    assert len(printed_before_shown) == 1
+    assert 'too small to make out' in printed_before_shown[0]
 
 
 def test_compare_forwards_other_warnings(tmp_compare_files: list[Path], mocker: MockerFixture):


### PR DESCRIPTION
Fixes a flake in `test_compare_too_small_warning_is_printed_before_the_plot_is_shown`, seen on [Linux Unit Testing (3.10, 9.3.1, latest)](https://github.com/pyvista/pyvista/actions/runs/33336743448/job/99327092369?pr=8996): `assert [False] == [True]`.

- The test was the only one of the compare output tests that did not use `patch_app_console`, so it matched a panel rendered by whatever console the environment handed it.
- At the default width of 80 the wrap falls clear of `too small to make out`; at other widths it falls inside the phrase, and any per-line styling then survives the flattening and breaks the substring match. `test_compare_too_small_warning_advises_the_command`, which asserts the same substring, passed on the same worker moments earlier because its console is pinned.
- Reproduced on py3.10 with `FORCE_COLOR=1 COLUMNS=70` (also 32, 48, 68, 74, 135); all pass with the fixture.
- The captured text is now kept rather than reduced to a bool, so a failure reports what was printed.
