### PR TITLE
Move `_BoundsSizeMixin` from `DataSetFilters` to `DataSet`

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -45,6 +45,7 @@ from .utilities.arrays import parse_field_choice
 from .utilities.arrays import raise_not_matching
 from .utilities.arrays import vtk_id_list_to_array
 from .utilities.helpers import is_pyvista_dataset
+from .utilities.misc import _BoundsSizeMixin
 from .utilities.misc import abstract_class
 from .utilities.points import vtk_points
 
@@ -114,7 +115,7 @@ class _ActiveArrayExistsInfoTuple(NamedTuple):
 
 @promote_type(_vtk.vtkDataSet)
 @abstract_class
-class DataSet(DataSetFilters, DataObject):
+class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
     """Methods in common to spatially referenced objects.
 
     Parameters

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -42,7 +42,6 @@ from pyvista.core.utilities.cells import numpy_to_idarr
 from pyvista.core.utilities.helpers import _NORMALS
 from pyvista.core.utilities.helpers import _warn_if_invalid_data
 from pyvista.core.utilities.helpers import wrap
-from pyvista.core.utilities.misc import _BoundsSizeMixin
 from pyvista.core.utilities.misc import abstract_class
 from pyvista.core.utilities.misc import assert_empty_kwargs
 from pyvista.core.utilities.transform import Transform
@@ -69,7 +68,7 @@ _SelectInteriorPointsOptions = Literal['signed_distance', 'cell_locator']
 
 
 @abstract_class
-class DataSetFilters(_BoundsSizeMixin, DataObjectFilters):
+class DataSetFilters(DataObjectFilters):
     """A set of common filters that can be applied to any :vtk:`vtkDataSet`."""
 
     @_deprecate_positional_args(allowed=['target'])


### PR DESCRIPTION
### Overview

`_BoundsSizeMixin` supplies the `bounds_size` property, which describes a dataset rather than a filter, so it moves from `DataSetFilters` to `DataSet` — matching `MultiBlock`, which already mixes it in directly.

This is the source-side counterpart to #9012, which stops `_autoinherit` documenting a non-method on a filter class page. That guard should stay; this removes the reason the member was reachable there at all.

### Details

- `DataSet` gains `_BoundsSizeMixin` as its first base, the MRO position `MultiBlock` uses; `DataSetFilters` drops it and the now-unused import.
- `DataObjectFilters.resize` (#7718) still type-checks: its self type is constrained to `DataSet` and `MultiBlock`, so `bounds_size` never resolved through the filter class.
- `bounds_size` is still documented once under "Shared Base Classes", and is no longer reachable on `DataSetFilters`, `PolyDataFilters`, `ImageDataFilters` or `UnstructuredGridFilters`. No behavior change.

Claude wrote the code change and this description; I reviewed both.
