### PR TITLE
Measure test code under coverage

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -395,11 +395,30 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: coverage_reports-*
-          path: coverage*.xml
+          path: coverage_reports
 
-      - name: Upload coverage to CodeCov
+      # Each matrix cell contributes one report per side. Sorting them into their own
+      # directories lets each side upload under its own flag.
+      - name: Sort reports by flag
+        run: |
+          mkdir -p flag_package flag_tests
+          find coverage_reports -name 'coverage_package_*.xml' -exec mv {} flag_package/ \;
+          find coverage_reports -name 'coverage_tests_*.xml' -exec mv {} flag_tests/ \;
+          ls flag_package flag_tests
+
+      - name: Upload pyvista coverage to CodeCov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
+          directory: flag_package
+          flags: package
+          fail_ci_if_error: true
+          use_oidc: true
+
+      - name: Upload test coverage to CodeCov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
+        with:
+          directory: flag_tests
+          flags: tests
           fail_ci_if_error: true
           use_oidc: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ test.bat
 # Code coverage results
 htmlcov
 .coverage
+# per-process data files, from run.parallel
+.coverage.*
 *,cover
 
 # Mac

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -959,11 +959,16 @@ if no simple alternative solution has been found.
 Test code is covered too
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-``tests`` is measured alongside ``pyvista``, and Codecov reports the two as separate
-components so a gain on one cannot hide a loss on the other. The target for ``tests`` is
-100%: an uncovered line in a test file is a test that does not run the code it appears to,
-and a partly-covered branch is a case the suite never reaches. Both usually mean a missing
-assertion rather than a missing ``pragma``.
+``tests`` is measured alongside ``pyvista``, and the two are uploaded to Codecov as
+separate reports under the ``package`` and ``tests`` flags, so a gain on one cannot hide a
+loss on the other. ``tests`` is held at 100%: an uncovered line in a test file is a test
+that does not run the code it appears to, and a partly-covered branch is a case the suite
+never reaches. Both usually mean a missing assertion rather than a missing ``pragma``.
+
+Reach for ``# pragma: no cover`` when a branch exists in order to prove it is never taken
+-- a callback asserted never to fire, a fallback for a backend no covered environment runs
+-- and say which in the comment. ``# pragma: no branch`` fits a loop or guard that only
+ever goes one way, such as a retry loop whose last attempt always returns or raises.
 
 Some patterns produce dead test code:
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -956,13 +956,13 @@ for more details.
 However, code coverage exclusion should rarely be used and has to be carefully justified in the PR thread
 if no simple alternative solution has been found.
 
-Test code is covered too
+Test Code Is Covered Too
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``tests`` is measured alongside ``pyvista``, and the two are uploaded to Codecov as
 separate reports under the ``package`` and ``tests`` flags, so a gain on one cannot hide a
 loss on the other. ``tests`` is held at 100%: an uncovered line in a test file is a test
-that does not run the code it appears to, and a partly-covered branch is a case the suite
+that does not run the code it appears to, and a partly covered branch is a case the suite
 never reaches. Both usually mean a missing assertion rather than a missing ``pragma``.
 
 Reach for ``# pragma: no cover`` when a branch exists in order to prove it is never taken

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -917,7 +917,7 @@ such that:
 
         .. code-block:: bash
 
-            pytest --cov pyvista
+            pytest --cov pyvista --cov tests
 
     .. tab-item:: tox
         :sync: tox
@@ -940,7 +940,7 @@ such that:
 
         .. code-block:: bash
 
-            make coverage # pytest -v --cov pyvista
+            make coverage # pytest -v --cov pyvista --cov tests
             make coverage-html # same, with an HTML report at ./htmlcov
 
 When submitting a PR, it is highly recommended that all modifications are thoroughly tested.
@@ -957,7 +957,7 @@ However, code coverage exclusion should rarely be used and has to be carefully j
 if no simple alternative solution has been found.
 
 Test Code Is Covered Too
-~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``tests`` is measured alongside ``pyvista``, and the two are uploaded to Codecov as
 separate reports under the ``package`` and ``tests`` flags, so a gain on one cannot hide a

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -961,9 +961,10 @@ Test Code Is Covered Too
 
 ``tests`` is measured alongside ``pyvista``, and the two are uploaded to Codecov as
 separate reports under the ``package`` and ``tests`` flags, so a gain on one cannot hide a
-loss on the other. ``tests`` is held at 100%: an uncovered line in a test file is a test
-that does not run the code it appears to, and a partly covered branch is a case the suite
-never reaches. Both usually mean a missing assertion rather than a missing ``pragma``.
+loss on the other. New and changed test code must be fully covered, and the total may not
+fall: an uncovered line in a test file is a test that does not run the code it appears to,
+and a partly covered branch is a case the suite never reaches. Both usually mean a missing
+assertion rather than a missing ``pragma``.
 
 Reach for ``# pragma: no cover`` when a branch exists in order to prove it is never taken
 -- a callback asserted never to fire, a fallback for a backend no covered environment runs

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -956,6 +956,31 @@ for more details.
 However, code coverage exclusion should rarely be used and has to be carefully justified in the PR thread
 if no simple alternative solution has been found.
 
+Test code is covered too
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``tests`` is measured alongside ``pyvista``, and Codecov reports the two as separate
+components so a gain on one cannot hide a loss on the other. The target for ``tests`` is
+100%: an uncovered line in a test file is a test that does not run the code it appears to,
+and a partly-covered branch is a case the suite never reaches. Both usually mean a missing
+assertion rather than a missing ``pragma``.
+
+Some patterns produce dead test code:
+
+- A helper class or fixture whose attributes nothing ever reads. Delete the unused member.
+- A stub body written as ``class Stub: ...``. Coverage counts the one-line form as a
+  partial branch, and ``ruff format`` collapses ``...`` onto the ``class`` line, so write
+  ``pass`` or a docstring instead.
+- A class registered or patched but never instantiated, where ``__init__`` only assigns.
+  Drop the ``__init__``, or assert on the instance the test already set up.
+- A branch that only one CI job reaches. Coverage is combined across the matrix, so a
+  ``vtk_version_info`` gate is covered as long as some job takes each side. Only the
+  Linux jobs upload, so a ``sys.platform`` gate for macOS or Windows never is.
+
+Not every file under ``tests`` is measured. The ones run outside a ``-cov`` environment
+(the ``doc_build`` suite, the standalone scripts, the Sphinx projects used as build
+fixtures) are listed under ``report.omit`` in ``pyproject.toml``.
+
 The CI is configured to test multiple vtk versions to ensure sufficient compatibility with vtk.
 If needed, the minimum and/or maximum vtk version needed by a specific test can be controlled with a
 custom pytest marker ``needs_vtk_version``, enabling the following usage (note the inclusive and exclusive signs):

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -976,6 +976,9 @@ Some patterns produce dead test code:
 - A stub body written as ``class Stub: ...``. Coverage counts the one-line form as a
   partial branch, and ``ruff format`` collapses ``...`` onto the ``class`` line, so write
   ``pass`` or a docstring instead.
+- A no-op callback whose body is ``pass`` or a bare ``return``, registered somewhere that
+  never calls it. Give it a docstring instead and delete the statement: a docstring is not
+  an executable line, so nothing is left to go uncovered.
 - A class registered or patched but never instantiated, where ``__init__`` only assigns.
   Drop the ``__init__``, or assert on the instance the test already set up.
 - A branch that only one CI job reaches. Coverage is combined across the matrix, so a

--- a/Makefile
+++ b/Makefile
@@ -17,17 +17,20 @@ CODE_DIRS ?= doc examples examples_trame pyvista tests
 # Files in top level directory
 CODE_FILES ?= *.py *.rst *.md
 
+# Both `pyvista` and `tests` are measured, matching the `-cov` tox environments.
+COV_FLAGS = --cov pyvista --cov tests
+
 coverage:
 	@echo "Running coverage"
-	@pytest -v --cov pyvista
+	@pytest -v $(COV_FLAGS)
 
 coverage-xml:
 	@echo "Reporting XML coverage"
-	@pytest -v --cov pyvista --cov-report xml
+	@pytest -v $(COV_FLAGS) --cov-report xml
 
 coverage-html:
 	@echo "Reporting HTML coverage"
-	@pytest -v --cov pyvista --cov-report html
+	@pytest -v $(COV_FLAGS) --cov-report html
 
 coverage-docs:
 	@echo "Reporting documentation coverage"

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,6 +15,27 @@ coverage:
         if_not_found: failure
         if_ci_failed: error
         if_no_uploads: error
+      # Scoped to the package so a gain under tests/ cannot absorb a loss here.
+      # `if_not_found: success` until main carries flag history to compare against.
+      package:
+        flags:
+          - package
+        target: auto
+        threshold: 0.5%
+        if_not_found: success
+        if_ci_failed: error
+        if_no_uploads: error
+      # A test line that never executes is a test that does not test what it appears
+      # to, so this target is absolute rather than a ratchet. Reach for
+      # `# pragma: no cover` when a branch exists to prove it is never taken.
+      tests:
+        flags:
+          - tests
+        target: 100%
+        threshold: 0%
+        if_not_found: success
+        if_ci_failed: error
+        if_no_uploads: error
     patch:
       default:
         target: auto
@@ -22,30 +43,22 @@ coverage:
         if_not_found: failure
         if_ci_failed: error
         if_no_uploads: error
+      tests:
+        flags:
+          - tests
+        target: 100%
+        threshold: 0%
+        if_not_found: success
+        if_ci_failed: error
+        if_no_uploads: error
 
-# `pyvista` and `tests` are reported in the same upload, so without components a
-# gain on one side hides a loss on the other. Splitting them keeps each honest.
-component_management:
-  individual_components:
-    - component_id: package
-      name: pyvista
+# `pyvista` and `tests` are uploaded as separate reports (see the upload job in
+# .github/workflows/testing-and-deployment.yml), one XML per side per matrix cell.
+flag_management:
+  individual_flags:
+    - name: package
       paths:
-        - pyvista/**
-      # Same rule the project status above applies to the repository as a whole,
-      # scoped to the package so a gain under tests/ cannot absorb a loss here.
-      statuses:
-        - type: project
-          target: auto
-          threshold: 0.5%
-    - component_id: tests
-      name: tests
+        - pyvista/
+    - name: tests
       paths:
-        - tests/**
-      # An uncovered line in a test file is a test that never runs what it looks
-      # like it runs, so the goal here is 100% rather than "don't regress". Until
-      # the tree gets there, `threshold: 0%` ratchets: no PR may add a test line
-      # that never executes.
-      statuses:
-        - type: project
-          target: auto
-          threshold: 0%
+        - tests/

--- a/codecov.yml
+++ b/codecov.yml
@@ -22,3 +22,24 @@ coverage:
         if_not_found: failure
         if_ci_failed: error
         if_no_uploads: error
+
+# `pyvista` and `tests` are reported in the same upload, so without components a
+# gain on one side hides a loss on the other. Splitting them keeps each honest.
+component_management:
+  individual_components:
+    - component_id: package
+      name: pyvista
+      paths:
+        - pyvista/**
+    - component_id: tests
+      name: tests
+      paths:
+        - tests/**
+      # An uncovered line in a test file is a test that never runs what it looks
+      # like it runs, so the goal here is 100% rather than "don't regress". Until
+      # the tree gets there, `threshold: 0%` ratchets: no PR may add a test line
+      # that never executes.
+      statuses:
+        - type: project
+          target: auto
+          threshold: 0%

--- a/codecov.yml
+++ b/codecov.yml
@@ -31,6 +31,12 @@ component_management:
       name: pyvista
       paths:
         - pyvista/**
+      # Same rule the project status above applies to the repository as a whole,
+      # scoped to the package so a gain under tests/ cannot absorb a loss here.
+      statuses:
+        - type: project
+          target: auto
+          threshold: 0.5%
     - component_id: tests
       name: tests
       paths:

--- a/codecov.yml
+++ b/codecov.yml
@@ -26,12 +26,14 @@ coverage:
         if_ci_failed: error
         if_no_uploads: error
       # A test line that never executes is a test that does not test what it appears
-      # to, so this target is absolute rather than a ratchet. Reach for
+      # to, so the goal here is 100% rather than "do not regress". The tree measures
+      # 98.87% today, so this ratchets at `threshold: 0%` and the target rises as the
+      # remainder is cleared; `patch` below already holds new code to 100%. Reach for
       # `# pragma: no cover` when a branch exists to prove it is never taken.
       tests:
         flags:
           - tests
-        target: 100%
+        target: auto
         threshold: 0%
         if_not_found: success
         if_ci_failed: error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,6 +248,18 @@ report.exclude_also = [
 report.omit = [
   '*/pyvista/conftest.py',
   '*/pyvista/plotting/theme.py', # kept for backwards compatibility
+
+  # Under tests/, only files the `-cov` environments actually run are measured.
+  # Everything below runs somewhere else, so coverage would report it as dead.
+  '*/tests/check_doctest_names.py', # tox -e doctest-local
+  '*/tests/doc/doc_build/*', # tox -e docs-test-build
+  '*/tests/doc/vale/check_expected_failures.py', # .github/workflows/style-docstring.yml
+  '*/tests/generate_test_image_report.py', # tox -e image-report
+
+  # Sphinx projects used as build input, copied to a tmpdir and built in a subprocess.
+  '*/tests/doc/tinypages_autoenum/*',
+  '*/tests/plotting/tinypages/*',
+  '*/tests/plotting/tinypages_autocodelink/*',
 ]
 run.branch = true
 run.parallel = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -839,7 +839,7 @@ def pytest_runtest_setup(item: pytest.Item):
         )
 
         bounds = _check_args_kwargs_marker(item_mark=item_mark, sig=sig)
-        if os.name == 'nt':
+        if os.name == 'nt':  # pragma: no cover -- Windows only
             pytest.skip(bounds.arguments[r])
 
     if item_mark := item.get_closest_marker('skip_mac'):
@@ -879,7 +879,8 @@ def pytest_runtest_setup(item: pytest.Item):
             pytest.skip(bounds.arguments[r])
 
     test_downloads = item.config.getoption(flag := '--test_downloads')
-    if item.get_closest_marker('needs_download') and not test_downloads:
+    # Unreached: the core run enables downloads, and no plotting test is marked.
+    if item.get_closest_marker('needs_download') and not test_downloads:  # pragma: no cover
         pytest.skip(f'Downloads not enabled with {flag}')
 
     playwright = item.config.getoption(flag := '--playwright')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,7 @@ if HAS_PLOTTING:
     )
     from pyvista.plotting.theme_registry import _save_registry_state as _save_theme_registry_state
     from pyvista.plotting.utilities.gl_checks import uses_egl
-else:  # core-only VTK backend: rendering modules are absent
+else:  # pragma: no cover — core-only VTK backend, measured by no -cov environment
 
     def _save_component_registry_state():
         return None
@@ -153,7 +153,7 @@ def flaky_test(
 
     @functools.wraps(test_function)
     def wrapper(*args, **kwargs):
-        for i in range(times):
+        for i in range(times):  # pragma: no branch — the last attempt returns or raises
             try:
                 test_function(*args, **kwargs)
             except exceptions as e:
@@ -613,15 +613,14 @@ def pytest_ignore_collect(collection_path, config):  # noqa: ARG001
     (``HAS_PLOTTING is False``); otherwise these modules collect and run
     normally (and carry the ``needs_rendering`` marker).
     """
-    if HAS_PLOTTING:
-        return None
-
-    tests_root = Path(__file__).parent
-    try:
-        rel = Path(str(collection_path)).relative_to(tests_root).as_posix()
-    except ValueError:
-        return None
-    return True if rel in _RENDERING_ONLY_MODULES else None
+    if not HAS_PLOTTING:  # pragma: no cover — measured by no -cov environment
+        tests_root = Path(__file__).parent
+        try:
+            rel = Path(str(collection_path)).relative_to(tests_root).as_posix()
+        except ValueError:
+            return None
+        return True if rel in _RENDERING_ONLY_MODULES else None
+    return None
 
 
 def pytest_collection_modifyitems(config, items):  # noqa: ARG001

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,7 @@ if HAS_PLOTTING:
     )
     from pyvista.plotting.theme_registry import _save_registry_state as _save_theme_registry_state
     from pyvista.plotting.utilities.gl_checks import uses_egl
-else:  # pragma: no cover — core-only VTK backend, measured by no -cov environment
+else:  # pragma: no cover -- core-only VTK backend, measured by no -cov environment
 
     def _save_component_registry_state():
         return None
@@ -153,7 +153,7 @@ def flaky_test(
 
     @functools.wraps(test_function)
     def wrapper(*args, **kwargs):
-        for i in range(times):  # pragma: no branch — the last attempt returns or raises
+        for i in range(times):  # pragma: no branch -- the last attempt returns or raises
             try:
                 test_function(*args, **kwargs)
             except exceptions as e:
@@ -613,7 +613,7 @@ def pytest_ignore_collect(collection_path, config):  # noqa: ARG001
     (``HAS_PLOTTING is False``); otherwise these modules collect and run
     normally (and carry the ``needs_rendering`` marker).
     """
-    if not HAS_PLOTTING:  # pragma: no cover — measured by no -cov environment
+    if not HAS_PLOTTING:  # pragma: no cover -- measured by no -cov environment
         tests_root = Path(__file__).parent
         try:
             rel = Path(str(collection_path)).relative_to(tests_root).as_posix()

--- a/tests/core/test_accessor_registry.py
+++ b/tests/core/test_accessor_registry.py
@@ -505,11 +505,17 @@ def test_non_class_accessor_raises():
 def test_unregister_removes_descriptor():
     @pv.register_dataset_accessor('removable', pv.PolyData)
     class RemovableAccessor:
-        pass
+        def __init__(self, mesh):
+            self._mesh = mesh
 
+    sphere = pv.Sphere()
+    assert sphere.removable._mesh is sphere
     assert 'removable' in pv.PolyData.__dict__
+
     pv.unregister_dataset_accessor('removable', pv.PolyData)
     assert 'removable' not in pv.PolyData.__dict__
+    with pytest.raises(AttributeError):
+        _ = pv.Sphere().removable
 
 
 def test_unregister_restores_overridden_builtin():

--- a/tests/core/test_accessor_registry.py
+++ b/tests/core/test_accessor_registry.py
@@ -161,8 +161,7 @@ def test_del_on_a_slotted_target_raises():
 
     @pv.register_dataset_accessor('slotted_del', SlottedTarget)
     class SlottedAccessor:
-        def __init__(self, obj):
-            self._obj = obj
+        pass
 
     with pytest.raises(AttributeError, match='slotted_del'):
         del SlottedTarget().slotted_del
@@ -235,9 +234,6 @@ def test_class_access_returns_accessor_class():
     class ExposedAccessor:
         """Docstring visible on help(pv.PolyData.exposed)."""
 
-        def __init__(self, mesh):
-            self._mesh = mesh
-
     assert pv.PolyData.exposed is ExposedAccessor
     assert 'Docstring visible' in (pv.PolyData.exposed.__doc__ or '')
 
@@ -245,8 +241,7 @@ def test_class_access_returns_accessor_class():
 def test_accessor_name_appears_in_dir():
     @pv.register_dataset_accessor('discoverable', pv.PolyData)
     class DiscoverableAccessor:
-        def __init__(self, mesh):
-            self._mesh = mesh
+        pass
 
     assert 'discoverable' in dir(pv.PolyData)
     assert 'discoverable' in dir(pv.Sphere())
@@ -353,6 +348,8 @@ def test_accessor_vs_accessor_collision_warns_and_replaces():
         def who(self):
             return 'first'
 
+    assert pv.Sphere().clashing.who() == 'first'
+
     with pytest.warns(UserWarning, match='replaces an existing registered accessor'):
 
         @pv.register_dataset_accessor('clashing', pv.PolyData)
@@ -424,8 +421,7 @@ def test_builtin_shadow_raises_without_override():
 
         @pv.register_dataset_accessor('clip', pv.PolyData)
         class ClipAccessor:
-            def __init__(self, mesh):
-                self._mesh = mesh
+            pass
 
     assert callable(pv.PolyData.clip)
 
@@ -459,8 +455,7 @@ def test_inherited_builtin_shadow_raises():
 
         @pv.register_dataset_accessor('bounds', pv.PolyData)
         class BoundsAccessor:
-            def __init__(self, mesh):
-                self._mesh = mesh
+            pass
 
 
 def test_empty_name_raises():
@@ -510,8 +505,7 @@ def test_non_class_accessor_raises():
 def test_unregister_removes_descriptor():
     @pv.register_dataset_accessor('removable', pv.PolyData)
     class RemovableAccessor:
-        def __init__(self, mesh):
-            self._mesh = mesh
+        pass
 
     assert 'removable' in pv.PolyData.__dict__
     pv.unregister_dataset_accessor('removable', pv.PolyData)
@@ -536,8 +530,10 @@ def test_unregister_restores_overridden_builtin():
             return 'accessor'
 
     assert Target.__dict__['existing_method'] is not original_method
+    assert Target().existing_method() == 'accessor'
     pv.unregister_dataset_accessor('existing_method', Target)
     assert Target.__dict__['existing_method'] is original_method
+    assert Target().existing_method() == 'original'
 
 
 def test_unregister_missing_raises():
@@ -563,8 +559,7 @@ def test_unregister_inherited_accessor_raises():
 def test_unregister_updates_records():
     @pv.register_dataset_accessor('tracked', pv.PolyData)
     class TrackedAccessor:
-        def __init__(self, mesh):
-            self._mesh = mesh
+        pass
 
     names_before = [r.name for r in pv.registered_accessors()]
     assert 'tracked' in names_before
@@ -577,8 +572,7 @@ def test_unregister_updates_records():
 def test_registered_accessors_reports_records():
     @pv.register_dataset_accessor('introspect_me', pv.PolyData)
     class IntrospectMeAccessor:
-        def __init__(self, mesh):
-            self._mesh = mesh
+        pass
 
     records = pv.registered_accessors()
     matches = [r for r in records if r.name == 'introspect_me']
@@ -596,16 +590,14 @@ def test_registered_accessors_returns_tuple():
 def test_re_register_replaces_single_record():
     @pv.register_dataset_accessor('single_record', pv.PolyData)
     class FirstAccessor:
-        def __init__(self, mesh):
-            self._mesh = mesh
+        pass
 
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
 
         @pv.register_dataset_accessor('single_record', pv.PolyData)
         class SecondAccessor:
-            def __init__(self, mesh):
-                self._mesh = mesh
+            pass
 
     records = [r for r in pv.registered_accessors() if r.name == 'single_record']
     assert len(records) == 1
@@ -632,8 +624,7 @@ def test_save_restore_round_trip_populated():
 
     @pv.register_dataset_accessor('post_snapshot', pv.PolyData)
     class PostSnapshotAccessor:
-        def __init__(self, mesh):
-            self._mesh = mesh
+        pass
 
     pv.unregister_dataset_accessor('snapshot_me', pv.PolyData)
 
@@ -653,8 +644,7 @@ def test_save_restore_round_trip_preserves_override():
 
     @pv.register_dataset_accessor('clip', pv.PolyData, override=True)
     class ClipOverride:
-        def __init__(self, mesh):
-            self._mesh = mesh
+        pass
 
     _reg_mod._restore_registry_state(state)
     assert pv.PolyData.clip is original_clip
@@ -666,8 +656,7 @@ def test_fixture_isolation_setup():
 
     @pv.register_dataset_accessor('leaked_accessor', pv.PolyData)
     class LeakedAccessor:
-        def __init__(self, mesh):
-            self._mesh = mesh
+        pass
 
 
 def test_fixture_isolation_teardown():
@@ -1092,7 +1081,7 @@ def test_pending_accessor_appears_in_dir_without_loading(monkeypatch):
     _reset_entry_point_state(monkeypatch, [ep])
     import_calls: list[str] = []
 
-    def _tracking_import(module_path: str):
+    def _tracking_import(module_path: str):  # pragma: no cover — asserted never called
         import_calls.append(module_path)
         return fake_import(module_path)
 
@@ -1115,8 +1104,7 @@ def test_explicit_accessor_appears_in_dir():
 
     @pv.register_dataset_accessor('explicit_dir_demo', pv.PolyData)
     class ExplicitDirDemo:
-        def __init__(self, mesh):
-            self._mesh = mesh
+        pass
 
     try:
         assert 'explicit_dir_demo' in dir(pv.Sphere())
@@ -1160,7 +1148,7 @@ def test_dir_after_pending_accessor_resolved(monkeypatch):
     finally:
         sys.modules.pop(plugin_name, None)
         # Clean up the descriptor that fake_import attached
-        if 'resolved_demo' in pv.PolyData.__dict__:
+        if 'resolved_demo' in pv.PolyData.__dict__:  # pragma: no branch — set by the body
             delattr(pv.PolyData, 'resolved_demo')
 
 

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -379,6 +379,8 @@ def test_pickle_serialize_deserialize(datasets_no_pointset, pickle_format):
     """
     pv.set_pickle_format(pickle_format)
     for dataset in datasets_no_pointset:
+        # These datasets carry no field data of their own.
+        dataset.field_data['pickled_field'] = [1, 2, 3]
         dataset_2 = pickle.loads(pickle.dumps(dataset))
 
         # check python attributes are the same

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -249,7 +249,7 @@ def test_user_dict_removal(data_object_type, method):
             data_object.clear_field_data()
         elif method == 'set_none':
             data_object.user_dict = None
-        else:
+        else:  # pragma: no cover -- parametrize covers every case
             msg = f'Invalid test method {method}.'
             raise RuntimeError(msg)
 

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1655,7 +1655,9 @@ def test_cell_neighbors_levels(grid: DataSet, i0, n_levels, connections):
         assert set(cell_ids) == set(grid.cell_neighbors(i0, connections=connections))
 
     else:
-        assert len(list(cell_ids)) == n_levels
+        # `cell_ids` is a generator, so materialize it before asserting on it twice.
+        cell_ids = list(cell_ids)
+        assert len(cell_ids) == n_levels
         for ids in cell_ids:
             assert isinstance(ids, list)
             assert all(isinstance(id_, int) for id_ in ids)

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -720,7 +720,7 @@ def test_rename_array_doesnt_delete():
     mesh = make_mesh()
     was_deleted = [False]
 
-    def on_delete(*_):
+    def on_delete(*_):  # pragma: no cover -- asserted never invoked
         # Would be easier to throw an exception here but even though the exception gets printed to
         # stderr pytest reports the test passing. See #5246 .
         was_deleted[0] = True

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1681,7 +1681,9 @@ def test_point_neighbors_levels(grid: DataSet, i0, n_levels):
         assert set(point_ids) == set(grid.point_neighbors(i0))
 
     else:
-        assert len(list(point_ids)) == n_levels
+        # `point_ids` is a generator, so materialize it before asserting on it twice.
+        point_ids = list(point_ids)
+        assert len(point_ids) == n_levels
         for ids in point_ids:
             assert isinstance(ids, list)
             assert all(isinstance(id_, int) for id_ in ids)

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -994,24 +994,12 @@ class InterrogateVTKGlyph3D:
         return self.input_data_object.active_vectors_info
 
     @property
-    def scaling(self):
-        return self.alg.GetScaling()
-
-    @property
     def scale_mode(self):
         return self.alg.GetScaleModeAsString()
 
     @property
     def scale_factor(self):
         return self.alg.GetScaleFactor()
-
-    @property
-    def clamping(self):
-        return self.alg.GetClamping()
-
-    @property
-    def vector_mode(self):
-        return self.alg.GetVectorModeAsString()
 
 
 def test_glyph_settings(sphere):

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -3837,7 +3837,7 @@ def test_integrate_data_datasets(datasets):
             assert integrated['Area'] > 0
         elif 'Volume' in integrated.array_names:
             assert integrated['Volume'] > 0
-        else:
+        else:  # pragma: no cover -- parametrize covers every case
             msg = 'Unexpected integration'
             raise ValueError(msg)
 

--- a/tests/core/test_datasetattributes.py
+++ b/tests/core/test_datasetattributes.py
@@ -548,11 +548,7 @@ def test_values_should_be_pyvista_ndarrays(insert_arange_narray):
 
 def test_value_should_exist(insert_arange_narray):
     dsa, sample_array = insert_arange_narray
-    for arr in dsa.values():
-        if np.array_equal(sample_array, arr):
-            return
-    msg = 'Array not in values.'
-    raise AssertionError(msg)
+    assert any(np.array_equal(sample_array, arr) for arr in dsa.values()), 'Array not in values.'
 
 
 def test_active_scalars_setter(hexbeam_point_attributes):

--- a/tests/core/test_frd.py
+++ b/tests/core/test_frd.py
@@ -460,7 +460,7 @@ def test_frd_element_sizes(generic_element_frd):
         assert val > 0.0, (
             f'Element {elem_name} generated non-positive volume ({val}). Bad node ordering!'
         )
-    else:
+    else:  # pragma: no cover -- failure path
         pytest.fail(f'Unhandled cell dimension for element {elem_name} with VTK type {vtk_type}.')
 
 

--- a/tests/core/test_geometric_sources.py
+++ b/tests/core/test_geometric_sources.py
@@ -573,7 +573,7 @@ def test_axes_geometry_source_bounds(axes_geometry_source, part):
         )
         assert np.allclose(actual_bounds, expected_bounds)
 
-    else:
+    else:  # pragma: no cover -- parametrize covers every case
         raise NotImplementedError
 
 

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -1071,6 +1071,8 @@ def test_raise_rectilinear_grid_non_unique():
 
 def test_cast_rectilinear_grid():
     grid = pv.read(examples.rectfile)
+    # The file carries cell data only.
+    grid.point_data['point_values'] = np.arange(grid.n_points)
     structured = grid.cast_to_structured_grid()
     assert isinstance(structured, pv.StructuredGrid)
     assert structured.n_points == grid.n_points

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -407,7 +407,8 @@ def test_vtk_obb_tree_raises():
 
 
 def test_polydata_subclass_del():
-    class PolyDataDerived(pv.PolyData): ...
+    class PolyDataDerived(pv.PolyData):
+        pass
 
     poly = PolyDataDerived()
     del poly

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -117,7 +117,8 @@ def test_extract_base_reader_generic_arg_skips_non_base_reader_generics():
 
     _T = TypeVar('_T')
 
-    class _UnrelatedGeneric(Generic[_T]): ...
+    class _UnrelatedGeneric(Generic[_T]):
+        pass
 
     class _MixedClass(_UnrelatedGeneric[int]):  # Generic, but not a BaseReader
         pass

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -1630,7 +1630,8 @@ def test_no_new_attr_mixin_side_effects():
         @foo.setter
         def foo(self, val): ...
 
-    class Child(Parent): ...
+    class Child(Parent):
+        pass
 
     # Test that setting attributes on lasses does not trigger a call to the getter
     obj = Parent()
@@ -2983,7 +2984,8 @@ def _create_state_manager_subclass(arg1, arg2=None, sub_subclass=False):
 
     if sub_subclass:
 
-        class MyState2(MyState): ...
+        class MyState2(MyState):
+            pass
 
         return MyState2
     return MyState

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -3049,7 +3049,7 @@ def test_cell_quality_info_valid_measures(info):
     # Ensure the computed measure is not null
     null_value = -1
     qual_value = _compute_unit_cell_quality(info, null_value)
-    if np.isclose(qual_value, null_value):
+    if np.isclose(qual_value, null_value):  # pragma: no cover -- failure path
         pytest.fail(
             f'Measure {info.quality_measure!r} is not valid for cell type {info.cell_type.name!r}'
         )

--- a/tests/doc/test_autoenum.py
+++ b/tests/doc/test_autoenum.py
@@ -43,12 +43,12 @@ def test_metaclass_properties_finds_only_metaclass_properties():
     class Meta(type):
         @property
         def computed(cls):
-            return 'value'
+            """Defined on the metaclass."""
 
     class Plain(metaclass=Meta):
         @property
         def instance_only(self):
-            return 'nope'
+            """Defined on the instance, not the metaclass."""
 
     props = autoenum._metaclass_properties(Plain)
     assert set(props) == {'computed'}
@@ -81,12 +81,12 @@ def test_metaclass_properties_first_definition_wins_in_mro():
     class BaseMeta(type):
         @property
         def shared(cls):
-            return 'base'
+            """Defined on the base metaclass."""
 
     class SubMeta(BaseMeta):
         @property
         def shared(self):
-            return 'sub'
+            """Redefined on the subclass metaclass."""
 
     class Widget(metaclass=SubMeta):
         pass
@@ -99,11 +99,11 @@ def test_instance_properties_finds_only_public_properties():
     class Widget:
         @property
         def visible(self):
-            return True
+            """Public, so it is collected."""
 
         @property
         def _hidden(self):
-            return False
+            """Underscored, so it is skipped."""
 
         constant = 1
 
@@ -134,7 +134,6 @@ def test_metaclass_property_descriptions_uses_first_docstring_line(monkeypatch):
 
             More detail that shouldn't appear in the description.
             """
-            return 'value'
 
     class Widget(metaclass=Meta):
         pass
@@ -233,7 +232,7 @@ def test_patch_autosummary_objtype_routes_enums(monkeypatch):
 
 
 def _build_tinypages_autoenum(
-    tmp_path: Path, extra_pages: dict[str, str] | None = None
+    tmp_path: Path, extra_pages: dict[str, str]
 ) -> tuple[subprocess.CompletedProcess, Path]:
     """Build a throwaway copy of tinypages_autoenum; return (process, html build dir).
 
@@ -245,12 +244,11 @@ def _build_tinypages_autoenum(
         TINYPAGES_AUTOENUM_DIR, source_dir, ignore=shutil.ignore_patterns('__pycache__')
     )
 
-    if extra_pages:
-        for filename, content in extra_pages.items():
-            (source_dir / filename).write_text(content, encoding='utf-8')
-        stems = '\n   '.join(Path(filename).stem for filename in extra_pages)
-        with (source_dir / 'index.rst').open('a', encoding='utf-8') as f:
-            f.write(f'\n.. toctree::\n\n   {stems}\n')
+    for filename, content in extra_pages.items():
+        (source_dir / filename).write_text(content, encoding='utf-8')
+    stems = '\n   '.join(Path(filename).stem for filename in extra_pages)
+    with (source_dir / 'index.rst').open('a', encoding='utf-8') as f:
+        f.write(f'\n.. toctree::\n\n   {stems}\n')
 
     build_dir = tmp_path / 'build'
     proc = subprocess.run(

--- a/tests/doc/test_autoenum.py
+++ b/tests/doc/test_autoenum.py
@@ -88,7 +88,8 @@ def test_metaclass_properties_first_definition_wins_in_mro():
         def shared(self):
             return 'sub'
 
-    class Widget(metaclass=SubMeta): ...
+    class Widget(metaclass=SubMeta):
+        pass
 
     props = autoenum._metaclass_properties(Widget)
     assert props['shared'] is SubMeta.__dict__['shared']
@@ -135,7 +136,8 @@ def test_metaclass_property_descriptions_uses_first_docstring_line(monkeypatch):
             """
             return 'value'
 
-    class Widget(metaclass=Meta): ...
+    class Widget(metaclass=Meta):
+        pass
 
     monkeypatch.setattr(autoenum, '_resolve', lambda *_args: Widget)
     descriptions = dict(autoenum.metaclass_property_descriptions('unused', 'unused'))

--- a/tests/examples/test_dataset_loader.py
+++ b/tests/examples/test_dataset_loader.py
@@ -73,7 +73,7 @@ def _generate_dataset_loader_test_cases_from_module(
         elif func.startswith('load_'):
             dataset_name = func.split('load_')[1]
             key = 'dataset_function'
-        else:
+        else:  # pragma: no cover -- parametrize covers every case
             msg = f'Invalid case specified: {(func, dataset_function)}'
             raise RuntimeError(msg)
         test_cases_dict.setdefault(dataset_name, {})

--- a/tests/examples/test_downloads.py
+++ b/tests/examples/test_downloads.py
@@ -38,7 +38,7 @@ def pytest_generate_tests(metafunc):
 
 
 def test_dataset_loader_name_matches_download_name(test_case: DatasetLoaderTestCase):
-    if (msg := _get_mismatch_fail_msg(test_case)) is not None:
+    if (msg := _get_mismatch_fail_msg(test_case)) is not None:  # pragma: no cover -- failure path
         pytest.fail(msg)
 
 
@@ -68,7 +68,7 @@ def test_dataset_loader_source_url_blob(test_case: DatasetLoaderTestCase):
     sources = [sources] if isinstance(sources, str) else sources  # Make iterable
     for url in sources:
         # Check is_file() in case local cache of pyvista/data is used
-        if not (Path(url).is_file() or _is_valid_url(url)):
+        if not (Path(url).is_file() or _is_valid_url(url)):  # pragma: no cover -- failure path
             pytest.fail(f'Invalid blob URL for {test_case.dataset_name}:\n{url}')
 
 

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -22,7 +22,7 @@ def pytest_generate_tests(metafunc):
 
 
 def test_dataset_loader_name_matches_function_name(test_case: DatasetLoaderTestCase):
-    if (msg := _get_mismatch_fail_msg(test_case)) is not None:
+    if (msg := _get_mismatch_fail_msg(test_case)) is not None:  # pragma: no cover -- failure path
         pytest.fail(msg)
 
 

--- a/tests/plotting/test_colors.py
+++ b/tests/plotting/test_colors.py
@@ -341,7 +341,7 @@ def _vtk_named_color_as_hex(name: str) -> str:
     # Get expected hex value from vtkNamedColors
     color3ub = _vtk.vtkNamedColors().GetColor3ub(name)
     int_rgb = (color3ub.GetRed(), color3ub.GetGreen(), color3ub.GetBlue())
-    if int_rgb == (0.0, 0.0, 0.0) and name != 'black':
+    if int_rgb == (0.0, 0.0, 0.0) and name != 'black':  # pragma: no cover -- failure path
         pytest.fail(f"Color '{name}' is not a valid VTK color.")
     return pv.Color(int_rgb).hex_rgb
 
@@ -372,7 +372,7 @@ def test_color_synonyms(color_synonym):
 
 def test_unique_colors():
     duplicates = np.rec.find_duplicate(pv.hex_colors.values())
-    if len(duplicates) > 0:
+    if len(duplicates) > 0:  # pragma: no cover -- failure path
         pytest.fail(f'The following colors have duplicate definitions: {duplicates}.')
 
     assert len(pv.hex_colors) == len(_ALL_ANNOTATED_COLORS)

--- a/tests/plotting/test_component_registry.py
+++ b/tests/plotting/test_component_registry.py
@@ -368,11 +368,17 @@ def test_non_class_component_raises():
 def test_unregister_removes_descriptor():
     @pv.register_plotter_component('removable')
     class RemovableComponent:
-        pass
+        def __init__(self, plotter):
+            self._plotter = plotter
 
+    pl = pv.Plotter()
+    assert pl.removable._plotter is pl
     assert 'removable' in pv.BasePlotter.__dict__
+
     pv.unregister_plotter_component('removable')
     assert 'removable' not in pv.BasePlotter.__dict__
+    with pytest.raises(AttributeError):
+        _ = pv.Plotter().removable
 
 
 def test_unregister_missing_raises():

--- a/tests/plotting/test_component_registry.py
+++ b/tests/plotting/test_component_registry.py
@@ -123,17 +123,13 @@ def test_class_access_returns_component_class():
     class ExposedComponent:
         """Visible on help."""
 
-        def __init__(self, plotter):
-            self._plotter = plotter
-
     assert pv.BasePlotter.exposed is ExposedComponent
 
 
 def test_component_name_appears_in_dir():
     @pv.register_plotter_component('discoverable')
     class DiscoverableComponent:
-        def __init__(self, plotter):
-            self._plotter = plotter
+        pass
 
     assert 'discoverable' in dir(pv.BasePlotter)
     assert 'discoverable' in dir(pv.Plotter())
@@ -172,11 +168,11 @@ def test_close_hook_skipped_for_untouched_components():
 
     @pv.register_plotter_component('lc_untouched')
     class UntouchedComponent:
-        def __init__(self, plotter):
+        def __init__(self, plotter):  # pragma: no cover -- asserted never constructed
             constructions.append('constructed')
             self._plotter = plotter
 
-        def __plotter_close__(self):
+        def __plotter_close__(self):  # pragma: no cover -- asserted never invoked
             constructions.append('closed')
 
     pl = pv.Plotter()
@@ -280,6 +276,8 @@ def test_component_vs_component_collision_warns_and_replaces():
         def who(self):
             return 'first'
 
+    assert pv.Plotter().clashing.who() == 'first'
+
     with pytest.warns(UserWarning, match='replaces an existing registered'):
 
         @pv.register_plotter_component('clashing')
@@ -296,16 +294,14 @@ def test_component_vs_component_collision_warns_and_replaces():
 def test_override_silences_replacement_warning():
     @pv.register_plotter_component('silent_override')
     class FirstComponent:
-        def __init__(self, plotter):
-            self._plotter = plotter
+        pass
 
     with warnings.catch_warnings():
         warnings.simplefilter('error')
 
         @pv.register_plotter_component('silent_override', override=True)
         class SecondComponent:
-            def __init__(self, plotter):
-                self._plotter = plotter
+            pass
 
 
 def test_builtin_shadow_raises_without_override():
@@ -314,8 +310,7 @@ def test_builtin_shadow_raises_without_override():
 
         @pv.register_plotter_component('close')
         class CloseShadow:
-            def __init__(self, plotter):
-                self._plotter = plotter
+            pass
 
 
 def test_builtin_shadow_succeeds_with_override():
@@ -324,8 +319,7 @@ def test_builtin_shadow_succeeds_with_override():
 
     @pv.register_plotter_component('close', override=True)
     class CloseOverride:
-        def __init__(self, plotter):
-            self._plotter = plotter
+        pass
 
     try:
         # Class-level access on a _CachedComponent returns the component class.
@@ -374,8 +368,7 @@ def test_non_class_component_raises():
 def test_unregister_removes_descriptor():
     @pv.register_plotter_component('removable')
     class RemovableComponent:
-        def __init__(self, plotter):
-            self._plotter = plotter
+        pass
 
     assert 'removable' in pv.BasePlotter.__dict__
     pv.unregister_plotter_component('removable')
@@ -402,15 +395,16 @@ def test_unregister_restores_overridden_builtin():
             self._obj = obj
 
     assert Target.__dict__['existing_method'] is not original_method
+    assert isinstance(Target().existing_method, OverrideComponent)
     pv.unregister_plotter_component('existing_method', target_cls=Target)
     assert Target.__dict__['existing_method'] is original_method
+    assert Target().existing_method() == 'original'
 
 
 def test_registered_components_reports_records():
     @pv.register_plotter_component('introspect_me')
     class IntrospectMeComponent:
-        def __init__(self, plotter):
-            self._plotter = plotter
+        pass
 
     matches = [r for r in pv.registered_plotter_components() if r.name == 'introspect_me']
     assert len(matches) == 1
@@ -427,8 +421,7 @@ def test_registered_components_returns_tuple():
 def test_re_register_replaces_single_record():
     @pv.register_plotter_component('single_record')
     class FirstComponent:
-        def __init__(self, plotter):
-            self._plotter = plotter
+        pass
 
     with warnings.catch_warnings():
         # Suppress the intentional collision warning; the test verifies
@@ -437,8 +430,7 @@ def test_re_register_replaces_single_record():
 
         @pv.register_plotter_component('single_record')
         class SecondComponent:
-            def __init__(self, plotter):
-                self._plotter = plotter
+            pass
 
     records = [r for r in pv.registered_plotter_components() if r.name == 'single_record']
     assert len(records) == 1
@@ -455,15 +447,13 @@ def test_save_restore_round_trip_baseline():
 def test_save_restore_round_trip_populated():
     @pv.register_plotter_component('snapshot_me')
     class SnapshotComponent:
-        def __init__(self, plotter):
-            self._plotter = plotter
+        pass
 
     state = _reg_mod._save_registry_state()
 
     @pv.register_plotter_component('post_snapshot')
     class PostSnapshotComponent:
-        def __init__(self, plotter):
-            self._plotter = plotter
+        pass
 
     pv.unregister_plotter_component('snapshot_me')
     _reg_mod._restore_registry_state(state)
@@ -478,8 +468,7 @@ def test_fixture_isolation_setup():
 
     @pv.register_plotter_component('leaked_component')
     class LeakedComponent:
-        def __init__(self, plotter):
-            self._plotter = plotter
+        pass
 
 
 def test_fixture_isolation_teardown():
@@ -704,7 +693,7 @@ def test_pending_component_appears_in_dir_without_loading(monkeypatch):
     _reset_entry_point_state(monkeypatch, [ep])
     import_calls = []
 
-    def _tracking_import(module_path):
+    def _tracking_import(module_path):  # pragma: no cover -- asserted never called
         import_calls.append(module_path)
         return fake_import(module_path)
 
@@ -722,8 +711,7 @@ def test_pending_component_appears_in_dir_without_loading(monkeypatch):
 def test_explicit_component_appears_in_dir():
     @pv.register_plotter_component('explicit_dir_demo')
     class ExplicitDirDemo:
-        def __init__(self, plotter):
-            self._plotter = plotter
+        pass
 
     assert 'explicit_dir_demo' in dir(pv.Plotter())
 
@@ -756,7 +744,7 @@ def test_dir_after_pending_component_resolved(monkeypatch):
         assert 'resolved_demo' in dir(pl)
     finally:
         sys.modules.pop(plugin_name, None)
-        if 'resolved_demo' in pv.BasePlotter.__dict__:
+        if 'resolved_demo' in pv.BasePlotter.__dict__:  # pragma: no branch -- set by the body
             delattr(pv.BasePlotter, 'resolved_demo')
 
 
@@ -849,15 +837,13 @@ def test_inherited_component_replacement_warns():
 
     @pv.register_plotter_component('inherited_demo', target_cls=ParentTarget)
     class FirstComponent:
-        def __init__(self, obj):
-            self._obj = obj
+        pass
 
     with pytest.warns(UserWarning, match='inherited by'):
 
         @pv.register_plotter_component('inherited_demo', target_cls=ChildTarget)
         class SecondComponent:
-            def __init__(self, obj):
-                self._obj = obj
+            pass
 
 
 def test_inherited_shadow_raises_with_inherited_location():
@@ -874,8 +860,9 @@ def test_inherited_shadow_raises_with_inherited_location():
 
         @pv.register_plotter_component('existing_method', target_cls=ChildTarget)
         class ShadowComponent:
-            def __init__(self, obj):
-                self._obj = obj
+            pass
+
+    assert ChildTarget().existing_method() == 'parent'
 
 
 def test_component_descriptor_handles_slots_target():

--- a/tests/plotting/test_plotter.py
+++ b/tests/plotting/test_plotter.py
@@ -1117,7 +1117,7 @@ _MACOS_FIX_CASES = [
 
 @pytest.mark.skipif(sys.platform != 'darwin', reason='macOS-specific test')
 @pytest.mark.parametrize('case', _MACOS_FIX_CASES, ids=lambda c: c.id)
-def test_macos_offscreen_render_window_configured(case):
+def test_macos_offscreen_render_window_configured(case):  # pragma: no cover -- macOS only
     """Test no macOS phantom window is generated for off-screen plotting."""
     appkit_mock = MagicMock()
     appkit_mock.NSApp.return_value = None  # no application running
@@ -1134,7 +1134,7 @@ def test_macos_offscreen_render_window_configured(case):
 
 @pytest.mark.skipif(sys.platform != 'darwin', reason='macOS-specific test')
 @pytest.mark.parametrize('case', _MACOS_FIX_CASES, ids=lambda c: c.id)
-def test_macos_offscreen_keeps_visible_application_in_dock(case):
+def test_macos_offscreen_keeps_visible_application_in_dock(case):  # pragma: no cover -- macOS only
     """Test a host GUI application keeps its Dock icon and menu bar.
 
     The activation policy is process-global, so demoting it for an off-screen

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -967,21 +967,9 @@ def test_plot_no_active_scalars(sphere):
 
     def _test_update_scalars_with_invalid_array():
         pl.update_scalars(np.arange(5))
-        if pv._version.version_info[:2] > (0, 46):
-            msg = 'Convert error this method'
-            raise RuntimeError(msg)
-        if pv._version.version_info[:2] > (0, 47):
-            msg = 'Remove this method'
-            raise RuntimeError(msg)
 
     def _test_update_scalars_with_valid_array():
         pl.update_scalars(np.arange(sphere.n_faces))
-        if pv._version.version_info[:2] > (0, 46):
-            msg = 'Convert error this method'
-            raise RuntimeError(msg)
-        if pv._version.version_info[:2] > (0, 47):
-            msg = 'Remove this method'
-            raise RuntimeError(msg)
 
     with (
         pytest.raises(ValueError, match='Number of scalars'),

--- a/tests/plotting/test_render_window_interactor.py
+++ b/tests/plotting/test_render_window_interactor.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 
 def empty_callback():
-    return
+    """Registered as an observer, never invoked by these tests."""
 
 
 @pytest.mark.parametrize('callback', ['foo', 1, object()])
@@ -84,7 +84,7 @@ def test_observers():
 
     # Callback must not have any  empty arguments.
     def callback(a, b, *, c, d=1.0):
-        pass
+        """Rejected for its signature, so the body never runs."""
 
     with pytest.raises(TypeError):
         pl.add_key_event('w', callback)

--- a/tests/plotting/test_scalar_bars.py
+++ b/tests/plotting/test_scalar_bars.py
@@ -130,7 +130,7 @@ def test_update_title_image(sphere, verify_image_cache):
 def test_too_many_scalar_bars():
     pl = pv.Plotter()
     with pytest.raises(RuntimeError, match='Maximum number of color'):  # noqa: PT012
-        for i in range(100):
+        for i in range(100):  # pragma: no branch -- raises before the loop ends
             mesh = pv.Sphere()
             mesh[str(i)] = range(mesh.n_points)
             pl.add_mesh(mesh)

--- a/tests/plotting/test_scraper.py
+++ b/tests/plotting/test_scraper.py
@@ -85,7 +85,7 @@ def test_scraper(tmpdir, monkeypatch, n_win, scraper_type):
     elif scraper_type == 'dynamic':
         scraper = DynamicScraper()
         assert repr(scraper) == '<DynamicScraper object>'
-    else:
+    else:  # pragma: no cover -- parametrize covers every case
         msg = f'Invalid scraper type: {scraper}'
         raise ValueError(msg)
 

--- a/tests/plotting/test_theme.py
+++ b/tests/plotting/test_theme.py
@@ -587,7 +587,7 @@ def test_save_before_close_callback(tmpdir, default_theme):
     dark_theme = pv.plotting.themes.DarkTheme()
 
     def fun(plotter):
-        pass
+        """Assigned to the theme, never called: the theme is saved, not used."""
 
     dark_theme.before_close_callback = fun
     assert dark_theme != pv.plotting.themes.DarkTheme()

--- a/tests/plotting/test_theme.py
+++ b/tests/plotting/test_theme.py
@@ -545,7 +545,7 @@ def test_plotter_theme_attribute_setter():
     with pytest.raises(pv.core.errors.DeprecationError, match=match):
         pl.theme = my_theme
 
-    if pyvista.version_info >= (0, 50):
+    if pyvista.version_info >= (0, 50):  # pragma: no cover -- fires at the version bump
         pytest.fail('Remove the `theme` setter')
 
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -188,7 +188,7 @@ def try_init_pyvista_object(class_):
     except TypeError as e:
         if 'abstract' in repr(e):
             pytest.skip('Class is abstract.')
-        raise
+        raise  # pragma: no cover -- failure path
     return instance
 
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -332,7 +332,7 @@ def test_vtk_snake_case_api_is_disabled(vtk_subclass):
                 f'the PyVista API'
             )
             assert match in repr(e)  # noqa: PT017
-        else:
+        else:  # pragma: no cover -- failure path
             if DisableVtkSnakeCase not in vtk_subclass.__mro__:
                 msg = (
                     f'The class {vtk_subclass.__name__!r} in {vtk_subclass.__module__!r}\n'
@@ -485,7 +485,7 @@ def test_pyvista_class_no_new_attributes(pyvista_class):
     except AttributeError as e:
         if 'dict' in repr(e):
             pytest.skip('Skip dict classes')
-    else:
+    else:  # pragma: no cover -- failure path
         if not issubclass(pyvista_class, _NoNewAttrMixin):
             msg = (
                 f'The class {pyvista_class.__name__!r} in {pyvista_class.__module__!r}'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1015,7 +1015,7 @@ def test_validate_fields(tmp_ant_file, field, capsys: pytest.CaptureFixture):
     main(f'validate {tmp_ant_file!s} --help')
     out, err = capture_out_err(capsys)
     assert err == ''
-    if f'• {field}:' not in out:
+    if f'• {field}:' not in out:  # pragma: no cover -- failure path
         pytest.fail(f'Field {field} is missing from the validate CLI help documentation.')
 
     # Discard captured output to clean up test output

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -76,10 +76,11 @@ def _load_current_config(
     pytestconfig: pytest.Config,
     pytester: pytest.Pytester,
 ):
-    with (pytestconfig.rootpath / 'pyproject.toml').open('r') as file:
+    # Explicit encoding: the locale default is ASCII on the CI runners.
+    with (pytestconfig.rootpath / 'pyproject.toml').open('r', encoding='utf-8') as file:
         toml = pytester.makepyprojecttoml(file.read())
 
-    with (pytestconfig.rootpath / 'tests/conftest.py').open('r') as file:
+    with (pytestconfig.rootpath / 'tests/conftest.py').open('r', encoding='utf-8') as file:
         conftest = pytester.makeconftest(file.read())
 
     yield

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -11,6 +11,7 @@ from pytest_cases import parametrize
 from pytest_cases import parametrize_with_cases
 
 import pyvista as pv
+from tests.conftest import flaky_test
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -658,3 +659,52 @@ def test_notebook_mode_is_pinned_off():
     ``notebook=True`` themselves.
     """
     assert pv.global_theme.notebook is False
+
+
+def test_flaky_test_retries_until_it_passes(capsys):
+    attempts = []
+
+    @flaky_test
+    def sometimes_fails():
+        attempts.append(None)
+        if len(attempts) < 3:
+            msg = 'not yet'
+            raise AssertionError(msg)
+
+    sometimes_fails()
+    assert len(attempts) == 3
+    assert capsys.readouterr().out.count('retrying...') == 2
+
+
+def test_flaky_test_reraises_after_the_last_attempt(capsys):
+    attempts = []
+
+    @flaky_test(times=2)
+    def always_fails():
+        attempts.append(None)
+        msg = 'nope'
+        raise AssertionError(msg)
+
+    with pytest.raises(AssertionError, match='nope'):
+        always_fails()
+
+    assert len(attempts) == 2
+    out = capsys.readouterr().out.splitlines()
+    assert out[0].endswith('retrying...')
+    assert out[-1] == (
+        'FLAKY TEST FAILED (Attempt 2 of 2) - tests.test_conftest::always_fails - AssertionError'
+    )
+
+
+def test_flaky_test_does_not_retry_an_unlisted_exception():
+    attempts = []
+
+    @flaky_test(exceptions=(ValueError,))
+    def raises_type_error():
+        attempts.append(None)
+        raise TypeError
+
+    with pytest.raises(TypeError):
+        raises_type_error()
+
+    assert len(attempts) == 1

--- a/tests/typing/mypy_plugin/test_plugin.py
+++ b/tests/typing/mypy_plugin/test_plugin.py
@@ -18,7 +18,8 @@ MYPY_CONFIG_FILE_USE_PLUGIN = str(Path(TEST_DIR) / 'mypy_use_plugin.ini')
 @pytest.fixture
 def decorated_single():
     @promote_type(float)
-    class Foo: ...
+    class Foo:
+        pass
 
     return Foo
 
@@ -26,7 +27,8 @@ def decorated_single():
 @pytest.fixture
 def decorated_double():
     @promote_type(float, str)
-    class Foo: ...
+    class Foo:
+        pass
 
     return Foo
 

--- a/tests/typing/test_return_type.py
+++ b/tests/typing/test_return_type.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from enum import Enum
-import inspect
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -76,12 +75,7 @@ def try_init_object(class_, kwargs):
 
 
 def get_property_return_type(prop: property):
-    members = inspect.getmembers(prop)
-    for member in members:  # pragma: no branch -- fget is always present
-        name, func = member
-        if name == 'fget':
-            return func.__annotations__['return']
-    return None
+    return prop.fget.__annotations__['return']
 
 
 def test_bounds_tuple(class_with_bounds):

--- a/tests/typing/test_return_type.py
+++ b/tests/typing/test_return_type.py
@@ -77,7 +77,7 @@ def try_init_object(class_, kwargs):
 
 def get_property_return_type(prop: property):
     members = inspect.getmembers(prop)
-    for member in members:
+    for member in members:  # pragma: no branch -- fget is always present
         name, func = member
         if name == 'fget':
             return func.__annotations__['return']

--- a/tests/typing/test_return_type.py
+++ b/tests/typing/test_return_type.py
@@ -71,7 +71,7 @@ def try_init_object(class_, kwargs):
     except TypeError as e:
         if 'abstract' in repr(e):
             pytest.skip('Class is abstract.')
-        raise
+        raise  # pragma: no cover -- failure path
     return instance
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -78,8 +78,16 @@ commands_pre =
 commands =
     {[testenv]all_testing_cmdline}
 
+# Anchored at {tox_root}: a bare `*/pyvista/*` also matches every test file, because the
+# checkout itself sits in a directory named pyvista (`work/pyvista/pyvista` on CI).
+commands_post =
+    cov: {[testenv]cov_xml_cmdline} --include {tox_root}{/}pyvista{/}* -o coverage_package_{env_name}.xml
+    cov: {[testenv]cov_xml_cmdline} --include {tox_root}{/}tests{/}* -o coverage_tests_{env_name}.xml
+
 # `tests` is measured alongside `pyvista`: an uncovered line in a test file is a test
 # that never runs the code it appears to (see "Test code is covered too" in CONTRIBUTING.rst).
+# The two are reported separately, and `commands_post` splits the run's data into one XML
+# per side so CodeCov receives them under separate flags.
 cov_flags =
     --cov \
     pyvista \
@@ -92,9 +100,9 @@ cov_flags =
     --cov-report \
     term:skip-covered \
     --cov-report \
-    xml:coverage_{env_name}.xml \
-    --cov-report \
     html:coverage_{env_name}
+
+cov_xml_cmdline = coverage xml --rcfile {tox_root}{/}pyproject.toml --data-file {tox_root}{/}.coverage
 
 test_downloads = --test_downloads
 core_flags = --ignore=tests/plotting {[testenv]test_downloads}

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ commands_post =
     cov: {[testenv]cov_xml_cmdline} --include {tox_root}{/}tests{/}* -o coverage_tests_{env_name}.xml
 
 # `tests` is measured alongside `pyvista`: an uncovered line in a test file is a test
-# that never runs the code it appears to (see "Test code is covered too" in CONTRIBUTING.rst).
+# that never runs the code it appears to (see "Test Code Is Covered Too" in CONTRIBUTING.rst).
 # The two are reported separately, and `commands_post` splits the run's data into one XML
 # per side so CodeCov receives them under separate flags.
 cov_flags =

--- a/tox.ini
+++ b/tox.ini
@@ -78,9 +78,13 @@ commands_pre =
 commands =
     {[testenv]all_testing_cmdline}
 
+# `tests` is measured alongside `pyvista`: an uncovered line in a test file is a test
+# that never runs the code it appears to (see "Test code is covered too" in CONTRIBUTING.rst).
 cov_flags =
     --cov \
     pyvista \
+    --cov \
+    tests \
     --cov-config \
     {tox_root}{/}pyproject.toml \
     --cov-context \


### PR DESCRIPTION
### Overview

Coverage only ever measured `pyvista`, so the 74k lines under `tests/` were invisible — and an uncovered line in a test file is a test that doesn't run what it looks like it runs. This measures `tests` too, and uploads it as its own report: `commands_post` splits each run's data into one XML per side, and the upload job sends them under separate `package` and `tests` flags. The `tests` flag targets 100%, since a test branch that never executes has nothing to say.

Getting there is the rest of the work, and CI is the only place it can be checked — only the Linux jobs upload, so a `skip_mac` test looks dead locally and isn't. What's cleared so far: helper members nothing reads, `__init__` bodies on accessor classes no test constructs, and one-line `class X: ...` stubs, which coverage counts as a partial branch and `ruff format` will not let you write any other way. `flaky_test` gained tests for its retry path; the `HAS_PLOTTING` fallback in `tests/conftest.py` is excluded instead, because only a rendering-free backend reaches it and `integration-cvista` measures nothing.

Two tests turned out to assert less than they looked like they did — `test_accessor_vs_accessor_collision_warns_and_replaces` never checked the first accessor was installed before being replaced, and `test_unregister_restores_overridden_builtin` compared descriptor identity without ever calling the method. Separately, `test_plot_no_active_scalars` carried version-bump reminders placed after a call that always raises, so they never fired: `Plotter.update_scalars` was meant to become an error at 0.46 and be removed at 0.47, and we are at 0.49. I removed the dead reminders here and left the deprecation alone.

Expect the `tests` flag to be red until the residual is worked down — that is the point of putting the target in first, and the Codecov report on this run is the list.

Changes drafted by Claude Opus 5 but fully understood by me.
