### PR TITLE
Dispatch xdist tests singly with `--maxschedchunk=1`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,11 +45,12 @@ passenv =
 
 setenv =
     TOX_ROOT = {tox_root}
-    PYTEST_ADDOPTS = --color=yes -v {env:PARALLEL:}
+    # xdist assigns tests in blocks of a few hundred by default, which lands a run of slow neighbours on one worker.
+    PYTEST_ADDOPTS = --color=yes -v {env:PARALLEL:} --maxschedchunk=1
     # Opting out of the reference leak check (see tests/gc_check.py) goes here rather
     # than in the commands below because those pass their arguments as posargs defaults,
     # which a scoped run replaces wholesale.
-    no_check_gc: PYTEST_ADDOPTS = --color=yes -v {env:PARALLEL:} --no_check_gc
+    no_check_gc: PYTEST_ADDOPTS = --color=yes -v {env:PARALLEL:} --maxschedchunk=1 --no_check_gc
     cov: COVERAGE_CORE = {env:COVERAGE_CORE:ctrace}
 
 dependency_groups = test
@@ -178,8 +179,8 @@ commands_pre =
 # Split core/plotting the way [testenv]all_testing_cmdline does (how PyVista's CI
 # runs the suite). Skip download-backed tests to keep the nightly job off the network.
 commands =
-    pytest --ignore=tests/plotting -n auto -m "not needs_download" -ra --tb=short --timeout=300 --timeout-method=thread {posargs}
-    pytest tests/plotting -n auto -m "not needs_download" -ra --tb=short --timeout=300 --timeout-method=thread {posargs}
+    pytest --ignore=tests/plotting -n auto --maxschedchunk=1 -m "not needs_download" -ra --tb=short --timeout=300 --timeout-method=thread {posargs}
+    pytest tests/plotting -n auto --maxschedchunk=1 -m "not needs_download" -ra --tb=short --timeout=300 --timeout-method=thread {posargs}
 
 # ================= INTEGRATION ENVIRONMENTS =================
 [testenv:integration-{trame,geovista,mne,pyvistaqt}]
@@ -304,7 +305,7 @@ setenv =
     # and the renderer suppresses its OSMesa/EGL anti-aliasing warning only while a
     # gallery is being built (filterwarnings turns that warning into a failure).
     PYVISTA_BUILDING_GALLERY = true
-    PYTEST_ADDOPTS = --color=yes -v {env:PARALLEL:-n auto}
+    PYTEST_ADDOPTS = --color=yes -v {env:PARALLEL:-n auto} --maxschedchunk=1
 commands =
     pytest --doctest-modules --doctest-continue-on-failure {env_site_packages_dir}{/}pyvista {posargs}
 
@@ -381,4 +382,4 @@ commands_pre =
     {[testenv]software_report_cmdline}
     playwright install chromium
 commands =
-    pytest --doc_mode -n auto
+    pytest --doc_mode -n auto --maxschedchunk=1


### PR DESCRIPTION
Adds `--maxschedchunk=1` to every parallel `pytest` invocation, so xdist hands out tests one at a time instead of in large consecutive blocks.

xdist's default `load` scheduler seeds each worker with a block of `len(collection) // workers // 4` consecutive tests — 224 on the macOS plotting job — and commits those assignments before any test has been timed. Tests adjacent in a file therefore travel to the same worker as a unit. Reconstructing the per-test timeline of `MacOS Unit Testing (3.10)` (job 99291720428) from its timestamped `[gwN] PASSED` lines shows the effect: five of the six environment-texture tests land on `gw0`, which is busy 582.0s of a 582.0s span (100% occupancy) while `gw1` and `gw2` idle 136.9s and 171.2s. Total work is 1437.9s across 3 workers, so a perfectly balanced schedule finishes in 479.3s — about 100s of the phase is pure imbalance. Capping the handout defers each assignment until a worker is actually free, which reduces the scheduler to greedy list scheduling and is near-optimal for this workload.

- Simulated makespan for the plotting phase, replaying xdist's scheduler against the real CI durations: 643.7s at the default chunk size versus 480.2s with `--maxschedchunk=1`, against a 479.3s floor.
- Measured locally on `tests/plotting` at `-n 3`: 70.7s median (range 70.1–72.9) by default versus 58.2s (57.8–58.5) with the flag, so the extra dispatches cost nothing.
- Measured locally on the core suite at `-n 3`: 374.0s/580.8s by default versus 251.5s/263.1s with the flag; finer dispatch also removes most of the run-to-run variance that block assignment causes.
- Applied to the base `[testenv]` addopts, which covers every unit-test environment and VTK factor including `vtk_dev` and `vtk_local`, plus the `no_check_gc` variant, `doctest-modules`, `integration-cvista`, and `docs-test-images`.
- The workflows are untouched: they only set `PARALLEL`, and `tox.ini` composes the final `PYTEST_ADDOPTS`, so new jobs inherit the flag automatically.
- The option is registered by pytest-xdist and read only by `LoadScheduling`, so it is inert when `PARALLEL` is empty (as `toxfile.py` sets it for Linux plotting on VTK < 9.4) and when a suite runs without `-n`.

This is a scheduling change only and is a separate axis from #9001 and #9003, which reduce what the individual environment-texture tests cost. Grouping those tests onto one worker was also evaluated and is strictly worse — one worker would have to serialize 626.3s of them, exceeding the current whole-phase wall of 582.0s.

Verification has to happen on CI rather than locally: the tests this targets cost 0.16–0.85s on a GPU Mac versus 58.7–182.0s under CI's Apple Software Renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
