### PR TITLE
Do not resolve vtk-xref links

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -202,6 +202,9 @@ sphinx_examples_as_code_conf = {
     'gallery_downloads': True,
 }
 
+# Disable checking if vtk links resolve correctly, web checks can be unstable
+vtk_xref_nitpicky = False
+
 # Warn if target links or references cannot be found
 nitpicky = True
 # Except ignore these entries


### PR DESCRIPTION
### Overview

The vtk nightly and 9.7 release doxygen site is down, causing build failures for a bad link. Let’s stop checking links altogether.