### PR TITLE
Require docstrings for "visible" private classes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,14 +112,15 @@ repos:
       - id: gallery-docstring-structure
         name: "Gallery examples need a '.. _label:', a title/underline, and a summary sentence"
         language: python
-        entry: python -P hooks/gallery_docstrings.py
+        entry: python -m hooks.gallery_docstrings
         files: ^examples/.*\.py$
         types: [python]
       - id: private-class-docstrings
         name: "Private classes and modules need docstrings too (ruff D1 skips them)"
         language: python
-        # -P so hooks/warnings.py cannot shadow the stdlib module on the path
-        entry: python -P hooks/private_class_docstrings.py
+        # Run as a module, like warn_external: a script path would put hooks/ on
+        # sys.path, where its warnings.py shadows the stdlib module.
+        entry: python -m hooks.private_class_docstrings
         files: ^pyvista/
         types: [python]
       - id: no-lint-suppression-comments

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,8 +112,15 @@ repos:
       - id: gallery-docstring-structure
         name: "Gallery examples need a '.. _label:', a title/underline, and a summary sentence"
         language: python
-        entry: python hooks/gallery_docstrings.py
+        entry: python -P hooks/gallery_docstrings.py
         files: ^examples/.*\.py$
+        types: [python]
+      - id: private-class-docstrings
+        name: "Private classes and modules need docstrings too (ruff D1 skips them)"
+        language: python
+        # -P so hooks/warnings.py cannot shadow the stdlib module on the path
+        entry: python -P hooks/private_class_docstrings.py
+        files: ^pyvista/
         types: [python]
       - id: no-lint-suppression-comments
         name: "No lint suppression comments (fix it, or use pyproject.toml per-file-ignores)"

--- a/hooks/private_class_docstrings.py
+++ b/hooks/private_class_docstrings.py
@@ -1,0 +1,84 @@
+"""Require docstrings where ruff's D1 rules stop at a private name.
+
+Ruff treats a private class, a private module, and everything inside them as
+private, so neither they nor their public members are checked. This applies the
+D101/D102/D103 standard there.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import sys
+
+
+def _decorator_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    """Return the rightmost name of each decorator on ``node``."""
+    names = []
+    for decorator in node.decorator_list:
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if isinstance(target, ast.Attribute):
+            names.append(target.attr)
+        elif isinstance(target, ast.Name):
+            names.append(target.id)
+    return names
+
+
+def _has_docstring(node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef) -> bool:
+    """Return whether ``node`` starts with a docstring."""
+    return (
+        bool(node.body)
+        and isinstance(node.body[0], ast.Expr)
+        and isinstance(node.body[0].value, ast.Constant)
+        and isinstance(node.body[0].value.value, str)
+    )
+
+
+def _check_file(path: Path) -> list[str]:
+    """Return one error line per undocumented public member of a private class."""
+    errors = []
+
+    def visit(node: ast.AST, *, inside: str | None) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.ClassDef):
+                private = child.name.startswith('_')
+                if (private or inside) and not _has_docstring(child):
+                    why = 'is private' if private else f'is in {inside}'
+                    errors.append(
+                        f'{path}:{child.lineno}: class {child.name!r} {why}, '
+                        f'so it needs a docstring'
+                    )
+                visit(
+                    child, inside=inside or f'private class {child.name!r}' if private else inside
+                )
+            elif isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+                if inside and not child.name.startswith('_'):
+                    decorators = _decorator_names(child)
+                    exempt = {'overload', 'setter', 'deleter'} & set(decorators)
+                    if not exempt and not _has_docstring(child):
+                        errors.append(
+                            f'{path}:{child.lineno}: public {child.name!r} is in {inside}, '
+                            f'so it needs a docstring'
+                        )
+
+    # Ruff skips a private module wholesale, so its public defs are unchecked too
+    private_module = any(part.startswith('_') for part in path.with_suffix('').parts)
+    visit(
+        ast.parse(path.read_text(encoding='utf-8')),
+        inside='a private module' if private_module else None,
+    )
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    """Check every path given on the command line."""
+    all_errors = []
+    for filename in argv:
+        all_errors.extend(_check_file(Path(filename)))
+    for error in all_errors:
+        print(error)  # noqa: T201
+    return 1 if all_errors else 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main(sys.argv[1:]))

--- a/pyvista/_cli/utils.py
+++ b/pyvista/_cli/utils.py
@@ -47,20 +47,64 @@ if TYPE_CHECKING:
 
 
 def default(entry: HelpEntry):  # noqa: ANN202
+    """Return the entry's default value, or ``'-'`` when it has none.
+
+    Parameters
+    ----------
+    entry : HelpEntry
+        Help entry to read.
+
+    Returns
+    -------
+    str
+        Default value, or ``'-'`` when the entry has none.
+
+
+    """
     return d if (d := entry.default) is not None else '-'
 
 
 def names(entry: HelpEntry):  # noqa: ANN202
+    """Return the styled option names, marked when the option is required.
+
+    Parameters
+    ----------
+    entry : HelpEntry
+        Help entry to read.
+
+    Returns
+    -------
+    rich.text.Text
+        Styled option names.
+
+
+    """
     strings = (*entry.names, *entry.shorts)
     names = Text(' '.join(strings), style='cyan')
     return (Text('* ', style='red') + names) if entry.required else names
 
 
 def description(entry: HelpEntry):  # noqa: ANN202
+    """Return the entry's description.
+
+    Parameters
+    ----------
+    entry : HelpEntry
+        Help entry to read.
+
+    Returns
+    -------
+    str
+        Description of the entry.
+
+
+    """
     return entry.description
 
 
 class _PyvistaHelpFormatter(DefaultFormatter):
+    """Help formatter which renders the usage line as plain text."""
+
     def render_usage(self, console: Console, options: ConsoleOptions, usage: str) -> None:  # noqa: ARG002
         """Render the usage line."""
         if usage:  # pragma: no branch
@@ -104,6 +148,18 @@ skip_unreadable = Annotated[
 
 
 def print_error_and_exit(message: str | Group, *, title: str = 'PyVista Error') -> NoReturn:
+    """Print an error panel and exit with a non-zero status.
+
+    Parameters
+    ----------
+    message : str | rich.console.Group
+        Error message to show in the panel.
+
+    title : str, default: "PyVista Error"
+        Title of the panel.
+
+
+    """
     panel = Panel(
         message,
         title=title,

--- a/pyvista/core/_vtk_utilities.py
+++ b/pyvista/core/_vtk_utilities.py
@@ -56,6 +56,8 @@ def _get_vtk_version():
 
 
 class VTKVersionInfo(VersionInfo):
+    """Version info which rejects comparisons against unsupported VTK versions."""
+
     def _check_min_supported(self, other: tuple[int, int, int]) -> None:
         if isinstance(other, tuple) and other < _MIN_SUPPORTED_VTK_VERSION:  # type: ignore[redundant-expr]
             msg = (

--- a/pyvista/core/celltype.py
+++ b/pyvista/core/celltype.py
@@ -141,6 +141,8 @@ def _generate_faces_badge(n_faces: int) -> str:
 
 
 class _CellTypeTuple(NamedTuple):
+    """Value and documentation fields of a :class:`~pyvista.CellType` member."""
+
     value: int
     doc: str = ''
     example: str | None = None

--- a/pyvista/core/config.py
+++ b/pyvista/core/config.py
@@ -89,6 +89,11 @@ class _ConfigBase(metaclass=_ForceSlots):
     their ``__slots__`` and expose each one via a public ``@property`` getter
     / setter pair that reads and writes the underscore slot.
 
+    .. note::
+        This class is a private internal implementation detail. It is documented
+        solely so that its public members, which are inherited by public classes,
+        are visible in the documentation.
+
     """
 
     __slots__: ClassVar[list[str]] = []

--- a/pyvista/core/filters/data_object.py
+++ b/pyvista/core/filters/data_object.py
@@ -69,6 +69,8 @@ if TYPE_CHECKING:
 
 
 class _CellStatusTuple(NamedTuple):
+    """Value and documentation of a cell status flag."""
+
     value: int
     doc: str
 
@@ -169,7 +171,8 @@ class CellStatus(IntEnum):
         return obj
 
 
-class _SENTINEL: ...
+class _SENTINEL:
+    """Sentinel marking an argument the caller did not give."""
 
 
 _ExtractSurfaceOptions = Literal['geometry', 'dataset_surface', None]  # noqa: PYI061
@@ -210,6 +213,29 @@ _OtherFieldGroups = Literal['memory_safe']
 
 
 class _MeshValidator(Generic[_DataSetOrMultiBlockType]):
+    """Run the mesh validation checks and build the report.
+
+    Parameters
+    ----------
+    mesh : DataSet | MultiBlock
+        Mesh to validate.
+
+    validation_fields : str | sequence[str], optional
+        Fields to validate. All supported fields are validated by default.
+
+    exclude_fields : str | sequence[str], optional
+        Fields to leave out of the validation.
+
+    name : str, optional
+        Name to use in the report and error messages.
+
+    **cell_validator_kwargs : dict, optional
+        Keyword arguments passed to
+        :meth:`~pyvista.DataObjectFilters.cell_validator`.
+
+
+    """
+
     _allowed_data_fields = get_args(_DataFields)
     _allowed_point_fields = get_args(_PointFields)
     _allowed_cell_fields = get_args(_CellFields)
@@ -222,6 +248,8 @@ class _MeshValidator(Generic[_DataSetOrMultiBlockType]):
 
     @dataclass
     class _FieldSummary:
+        """One validated field's name, message, and offending values."""
+
         name: str
         message: str | list[str]
         values: Sequence[str | int] | None
@@ -758,6 +786,7 @@ class _MeshValidator(Generic[_DataSetOrMultiBlockType]):
 
     @property
     def validation_report(self) -> _MeshValidationReport[_DataSetOrMultiBlockType]:
+        """Return the mesh validation report."""
         return self._validation_report
 
     @staticmethod
@@ -877,14 +906,18 @@ class _MeshValidationReport(_NoNewAttrMixin, Generic[_DataSetOrMultiBlockType]):
 
     @property
     def name(self) -> str | None:
+        """Return the name of the validated mesh."""
         return self._name  # type: ignore[attr-defined]
 
     @property
     def mesh(self) -> _DataSetOrMultiBlockType:
+        """Return the validated mesh."""
         return self._mesh  # type: ignore[attr-defined]
 
     @property
     def message(self) -> str | None:
+        """Return the formatted validation message, if any."""
+
         def insert_bullet(indent: str, string: str):
             bullet = (
                 _MeshValidator._MESSAGE_BULLET
@@ -5505,6 +5538,8 @@ def _cast_output_to_match_input_type(
 
 
 class _Crinkler:
+    """Extract crinkled cells from the output of a clip."""
+
     CELL_IDS = 'cell_ids'
     INT_DTYPE = np.int64
     ITER_KWARGS: ClassVar = dict(skip_none=True)
@@ -5512,6 +5547,7 @@ class _Crinkler:
     @staticmethod
     def extract_cells(dataset, ids, active_scalars_info_):
         # Extract cells and remove arrays, and restore active scalars
+        """Extract cells by ID and restore the active scalars."""
         output = dataset.extract_cells(ids, pass_cell_ids=False, pass_point_ids=False)
         association, name = active_scalars_info_
         if not dataset.is_empty:
@@ -5522,6 +5558,7 @@ class _Crinkler:
 
     @staticmethod
     def extract_crinkle_cells(dataset, a_, b_, active_scalars_info):  # noqa: PLR0917
+        """Extract crinkled cells from the clip output."""
         if b_ is None:
             # Extract cells when `return_clipped=False`
             def extract_cells_from_block(block_, clipped_a, _, active_scalars_info_):
@@ -5591,6 +5628,7 @@ class _Crinkler:
     @staticmethod
     def add_cell_ids(dataset: DataSet | MultiBlock):
         # Add Cell IDs to all blocks and keep track of scalars to restore later
+        """Add cell ID arrays to all blocks and record the active scalars to restore."""
         active_scalars_info = []
         if isinstance(dataset, pv.MultiBlock):
             blocks: Iterable[DataSet] = dataset.recursive_iterator(

--- a/pyvista/core/pointset.py
+++ b/pyvista/core/pointset.py
@@ -93,6 +93,12 @@ class _PointSetBase(DataSet):
     """PyVista's equivalent of :vtk:`vtkPointSet`.
 
     This holds methods common to PolyData and UnstructuredGrid.
+
+    .. note::
+        This class is a private internal implementation detail. It is documented
+        solely so that its public members, which are inherited by public classes,
+        are visible in the documentation.
+
     """
 
     _WRITERS: ClassVar[dict[str, type[BaseWriter]]] = {

--- a/pyvista/core/utilities/_frd.py
+++ b/pyvista/core/utilities/_frd.py
@@ -124,6 +124,8 @@ class _InvalidElement:
 @dataclass
 class _FRDData:
     # Parsed data
+    """Parsed contents of a CalculiX FRD file."""
+
     nodes: dict[int, list[float]] = field(default_factory=dict)
     elements: list[list[int]] = field(default_factory=list)
     cell_types: list[int] = field(default_factory=list)
@@ -149,6 +151,7 @@ class _FRDParser:
         self._filename = filename
 
     def parse(self) -> _FRDData:
+        """Parse the FRD file into an ``_FRDData`` container."""
         frd_data = _FRDData()
         with Path(self._filename).open(errors='replace') as file_stream:
             lines = _LineTrackingStream(file_stream)

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -1076,23 +1076,63 @@ class _SerializedDictArray(DisableVtkSnakeCase, UserDict, _vtk.vtkStringArray): 
         self._update_string() if key != '_string' else None
 
     def update(self: _SerializedDictArray, *args, **kwargs) -> None:
+        """Update the dictionary and re-serialize.
+
+        Parameters
+        ----------
+        *args : tuple, optional
+            Arguments of :meth:`dict.update`.
+
+        **kwargs : dict, optional
+            Keyword arguments of :meth:`dict.update`.
+
+
+        """
         super().update(*args, **kwargs)
         self._update_string()
 
     def popitem(self: _SerializedDictArray) -> Any:
+        """Pop the last item and re-serialize."""
         item = super().popitem()
         self._update_string()
         return item
 
     def pop(self: _SerializedDictArray, __key: Any) -> Any:  # type: ignore[override]  # noqa: PYI063
+        """Pop an item by key and re-serialize.
+
+        Parameters
+        ----------
+        __key : Any
+            Key to remove.
+
+        Returns
+        -------
+        Any
+            Removed value.
+
+
+        """
         item = super().pop(__key)
         self._update_string()
         return item
 
     def clear(self: _SerializedDictArray) -> None:
+        """Clear the dictionary and re-serialize."""
         super().clear()
         self._update_string()
 
     def setdefault(self: _SerializedDictArray, *args, **kwargs) -> None:
+        """Insert a default value and re-serialize.
+
+        Parameters
+        ----------
+        *args : tuple, optional
+            Arguments of :meth:`dict.setdefault`.
+
+        **kwargs : dict, optional
+            Keyword arguments of :meth:`dict.setdefault`.
+
+
+        """
         super().setdefault(*args, **kwargs)
         self._update_string()

--- a/pyvista/core/utilities/fileio.py
+++ b/pyvista/core/utilities/fileio.py
@@ -76,6 +76,16 @@ _ReadReturnT = TypeVar('_ReadReturnT', bound='DataObject')
 
 
 class _FileIOBase(ABC, _NoNewAttrMixin):
+    """Base class for readers and writers, which are matched to files by extension.
+
+    .. note::
+        This class is a private internal implementation detail. It is documented
+        solely so that its public members, which are inherited by public classes,
+        are visible in the documentation.
+
+
+    """
+
     _vtk_class_name: str = ''
 
     def __repr__(self) -> str:

--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -2995,12 +2995,16 @@ class SuperquadricSource(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkSuperquad
 
 
 class _AxisEnum(IntEnum):
+    """Index of each x-y-z axis."""
+
     x = 0
     y = 1
     z = 2
 
 
 class _PartEnum(IntEnum):
+    """Index of the shaft and tip parts of an axis."""
+
     shaft = 0
     tip = 1
 
@@ -3996,6 +4000,8 @@ class CubeFacesSource(CubeSource):
     """
 
     class _FaceIndex(IntEnum):
+        """Index of each face of a box."""
+
         X_NEG = 0
         X_POS = 1
         Y_NEG = 2

--- a/pyvista/core/utilities/misc.py
+++ b/pyvista/core/utilities/misc.py
@@ -642,6 +642,11 @@ class _NameMixin:
 
     .. versionadded:: 0.45
 
+    .. note::
+        This class is a private internal implementation detail. It is documented
+        solely so that its public members, which are inherited by public classes,
+        are visible in the documentation.
+
     """
 
     @property
@@ -665,6 +670,16 @@ class _NameMixin:
 
 
 class _BoundsSizeMixin:
+    """Add a ``bounds_size`` property to classes which define ``bounds``.
+
+    .. note::
+        This class is a private internal implementation detail. It is documented
+        solely so that its public members, which are inherited by public classes,
+        are visible in the documentation.
+
+
+    """
+
     @property
     def bounds_size(self) -> tuple[float, float, float]:
         """Return the size of each axis of the object's bounding box.

--- a/pyvista/core/utilities/reader.py
+++ b/pyvista/core/utilities/reader.py
@@ -2729,6 +2729,7 @@ class _GRDECLReader(BaseVTKReader):
 
     @property
     def elevation(self) -> bool:
+        """Convert depths to elevations and flip grid along Z axis."""
         return self._elevation
 
     @elevation.setter
@@ -2737,6 +2738,7 @@ class _GRDECLReader(BaseVTKReader):
 
     @property
     def other_keywords(self) -> Sequence[str] | None:
+        """Additional keywords to read."""
         return self._other_keywords
 
     @other_keywords.setter
@@ -2798,6 +2800,7 @@ class _GIFReader(BaseVTKReader):
         """Update Information from file."""
 
     def GetProgress(self):
+        """Return the fraction of frames read so far."""
         return self._current_frame / self._n_frames
 
     def Update(self) -> None:
@@ -3929,6 +3932,7 @@ class _FRDReader(BaseVTKReader):
         self._active_time_point: int = 0
 
     def UpdateInformation(self) -> None:
+        """Parse the FRD file and update time step information."""
         parser = _FRDParser(self._filename)
         self._frd_data = parser.parse()
 

--- a/pyvista/core/utilities/reader_registry.py
+++ b/pyvista/core/utilities/reader_registry.py
@@ -99,6 +99,8 @@ class ReaderRegistration(NamedTuple):
 
 
 class _RegistryState(TypedDict):
+    """Mutable state of the reader registry."""
+
     ext: dict[str, ReaderHandler]
     classes: dict[str, type[BaseReader[Any]]]
     sources: dict[str, str]

--- a/pyvista/core/utilities/writer.py
+++ b/pyvista/core/utilities/writer.py
@@ -29,6 +29,24 @@ _DataFormatOptions = Literal['binary', 'ascii']
 @abstract_class
 class _DataFormatMixin:
     # Different writers use different values to indicate the current format
+    """Add a ``data_format`` property to writers which support ASCII and binary output.
+
+    .. note::
+        This class is a private internal implementation detail. It is documented
+        solely so that its public members, which are inherited by public classes,
+        are visible in the documentation.
+
+    Parameters
+    ----------
+    *args : tuple, optional
+        Positional arguments passed to the parent class.
+
+    **kwargs : dict, optional
+        Keyword arguments passed to the parent class.
+
+
+    """
+
     _ascii0_binary1: ClassVar[dict[int, _DataFormatOptions]] = {0: 'ascii', 1: 'binary'}
     _ascii1_binary2: ClassVar[dict[int, _DataFormatOptions]] = {1: 'ascii', 2: 'binary'}
     _format_mapping: ClassVar[dict[int, _DataFormatOptions]] = _ascii1_binary2
@@ -545,6 +563,24 @@ class EnSightWriter(BaseWriter):
 
 @abstract_class
 class _XMLWriter(BaseWriter, _DataFormatMixin):
+    """Base class for the XML writers, which also support compression.
+
+    .. note::
+        This class is a private internal implementation detail. It is documented
+        solely so that its public members, which are inherited by public classes,
+        are visible in the documentation.
+
+    Parameters
+    ----------
+    *args : tuple, optional
+        Positional arguments passed to the parent class.
+
+    **kwargs : dict, optional
+        Keyword arguments passed to the parent class.
+
+
+    """
+
     _format_mapping = _DataFormatMixin._ascii0_binary1
 
     def __init__(self, *args, **kwargs) -> None:

--- a/pyvista/core/utilities/writer_registry.py
+++ b/pyvista/core/utilities/writer_registry.py
@@ -55,6 +55,8 @@ class WriterRegistration(NamedTuple):
 
 
 class _RegistryState(TypedDict):
+    """Mutable state of the writer registry."""
+
     ext: dict[str, WriterHandler]
     sources: dict[str, str]
     pending: dict[str, list[EntryPoint]]

--- a/pyvista/examples/_dataset_loader.py
+++ b/pyvista/examples/_dataset_loader.py
@@ -89,6 +89,8 @@ def _collapse_str_sequence(values: Sequence[str]) -> str | tuple[str, ...]:
 
 
 class _BaseFilePropsProtocol(Generic[_FilePropStrType_co, _FilePropIntType_co]):
+    """Define the file properties shared by single- and multi-file loaders."""
+
     @property
     @abstractmethod
     def path(self) -> _FilePropStrType_co:
@@ -331,6 +333,7 @@ class _SingleFile(_SingleFilePropsProtocol):
 
     @property
     def path(self) -> str:
+        """Return the path of the file."""
         return self._path
 
     @property
@@ -347,6 +350,7 @@ class _SingleFile(_SingleFilePropsProtocol):
 
     @property
     def total_size(self) -> str:
+        """Return the total size of all files formatted as a string."""
         return self._filesize_format
 
     @property

--- a/pyvista/examples/downloads.py
+++ b/pyvista/examples/downloads.py
@@ -8617,9 +8617,25 @@ def download_whole_body_ct_male(
 
 
 class _WholeBodyCTUtilities:
+    """Helpers for loading the whole body CT datasets."""
+
     @staticmethod
     def import_colors_dict(module_path) -> dict[str, tuple[int, int, int]]:  # noqa: ANN001
         # Import `colors` dict from downloaded `colors.py` module
+        """Import the ``colors`` dict from the downloaded ``colors.py`` module.
+
+        Parameters
+        ----------
+        module_path : str
+            Path of the downloaded ``colors.py`` module.
+
+        Returns
+        -------
+        dict[str, tuple[int, int, int]]
+            Mapping from label names to RGB colors.
+
+
+        """
         module_name = 'colors'
         spec = importlib.util.spec_from_file_location(module_name, module_path)
         if spec is not None:
@@ -8636,6 +8652,18 @@ class _WholeBodyCTUtilities:
     @staticmethod
     def add_metadata(dataset: MultiBlock, colors_module_path: str) -> None:
         # Add color and id mappings to dataset
+        """Add color and id mappings to the dataset's user dict.
+
+        Parameters
+        ----------
+        dataset : pyvista.MultiBlock
+            Dataset to annotate.
+
+        colors_module_path : str
+            Path of the downloaded ``colors.py`` module.
+
+
+        """
         segmentations = cast('pv.MultiBlock', dataset['segmentations'])
         label_names = sorted(segmentations.keys())
         names_to_colors = _WholeBodyCTUtilities.import_colors_dict(colors_module_path)
@@ -8650,6 +8678,20 @@ class _WholeBodyCTUtilities:
     def label_map_from_masks(masks: MultiBlock) -> ImageData:
         # Create label map array from segmentation masks
         # Initialize array with background values (zeros)
+        """Create a label map image from segmentation masks.
+
+        Parameters
+        ----------
+        masks : pyvista.MultiBlock
+            Segmentation masks, one block per label.
+
+        Returns
+        -------
+        pyvista.ImageData
+            Label map image.
+
+
+        """
         n_points = cast('pv.ImageData', masks[0]).n_points
         label_map_array = np.zeros((n_points,), dtype=np.uint8)
         label_names = sorted(masks.keys())
@@ -8665,6 +8707,20 @@ class _WholeBodyCTUtilities:
 
     @staticmethod
     def load_func(files):  # noqa: ANN001, ANN205
+        """Load the dataset and add its label map and metadata.
+
+        Parameters
+        ----------
+        files : sequence
+            Loaders for the dataset file and the colors module.
+
+        Returns
+        -------
+        pyvista.MultiBlock
+            Loaded dataset with label map and metadata.
+
+
+        """
         dataset_file, colors_module = files
         dataset = dataset_file.load()
 
@@ -8678,6 +8734,20 @@ class _WholeBodyCTUtilities:
     @staticmethod
     def files_func(name):  # noqa: ANN001, ANN205
         # Resampled version is saved as a multiblock
+        """Return the file-loading function for the named dataset variant.
+
+        Parameters
+        ----------
+        name : str
+            Name of the dataset variant.
+
+        Returns
+        -------
+        callable
+            Function returning the file loaders.
+
+
+        """
         target_file = f'{name}.vtm' if 'resampled' in name else name
 
         def func():

--- a/pyvista/plotting/_typing.py
+++ b/pyvista/plotting/_typing.py
@@ -111,6 +111,8 @@ CameraPositionOptions = (
 
 
 class BackfaceArgs(TypedDict, total=False):
+    """Keyword arguments accepted by backface property settings."""
+
     theme: Theme
     interpolation: Literal['Physically based rendering', 'pbr', 'Phong', 'Gouraud', 'Flat']
     color: ColorLike
@@ -134,6 +136,8 @@ class BackfaceArgs(TypedDict, total=False):
 
 
 class ScalarBarArgs(TypedDict, total=False):
+    """Keyword arguments accepted by :meth:`~pyvista.Plotter.add_scalar_bar`."""
+
     title: str
     mapper: _vtk.vtkMapper
     n_labels: int
@@ -165,6 +169,8 @@ class ScalarBarArgs(TypedDict, total=False):
 
 
 class SilhouetteArgs(TypedDict, total=False):
+    """Keyword arguments accepted by silhouette settings."""
+
     color: ColorLike
     line_width: float
     opacity: float

--- a/pyvista/plotting/axes_assembly.py
+++ b/pyvista/plotting/axes_assembly.py
@@ -58,6 +58,8 @@ ScaleModeOptions = Literal['default', 'anti_distortion']
 
 
 class _AxesPropTuple(NamedTuple):
+    """A property value for each axis shaft and tip."""
+
     x_shaft: float | str | ColorLike
     y_shaft: float | str | ColorLike
     z_shaft: float | str | ColorLike
@@ -67,12 +69,16 @@ class _AxesPropTuple(NamedTuple):
 
 
 class _OrthogonalPlanesKwargs(TypedDict):
+    """Keyword arguments accepted by the orthogonal planes source."""
+
     bounds: VectorLike[float]
     resolution: int | VectorLike[int]
     normal_sign: Literal['+', '-'] | Sequence[str]
 
 
 class _XYZTuple(NamedTuple):
+    """A value for each of the x, y, and z axes."""
+
     x: Any
     y: Any
     z: Any
@@ -86,6 +92,16 @@ class _XYZAssembly(
     _NameMixin,
     _vtk.vtkPropAssembly,
 ):
+    """Base class for assemblies of x-y-z actors with labels.
+
+    .. note::
+        This class is a private internal implementation detail. It is documented
+        solely so that its public members, which are inherited by public classes,
+        are visible in the documentation.
+
+
+    """
+
     DEFAULT_LABELS = _XYZTuple('X', 'Y', 'Z')
 
     def __init__(
@@ -2384,6 +2400,8 @@ class PlanesAssembly(_XYZAssembly):
 
 
 class _AxisActor(DisableVtkSnakeCase, _vtk.vtkAxisActor):
+    """Axis actor which shows only its title."""
+
     def __init__(self):
         super().__init__()
         # Only show the title
@@ -2421,4 +2439,5 @@ class _AxisActor(DisableVtkSnakeCase, _vtk.vtkAxisActor):
 
     @property
     def prop(self) -> TextProperty:
+        """Return the title text property."""
         return self.GetTitleTextProperty()

--- a/pyvista/plotting/charts.py
+++ b/pyvista/plotting/charts.py
@@ -34,6 +34,8 @@ if TYPE_CHECKING:
 
 # region Some metaclass wrapping magic
 class _vtkWrapperMeta(type):  # noqa: N801
+    """Metaclass which restores the signature of a wrapped VTK class."""
+
     def __init__(cls, clsname, bases, attrs) -> None:
         # Restore the signature of classes inheriting from _vtkWrapper
         # Based on https://stackoverflow.com/questions/49740290/call-from-metaclass-shadows-signature-of-init
@@ -54,6 +56,8 @@ class _vtkWrapperMeta(type):  # noqa: N801
 
 
 class _vtkWrapper(DisableVtkSnakeCase, metaclass=_vtkWrapperMeta):  # noqa: N801
+    """Forward attribute access to a wrapped VTK object."""
+
     def __getattribute__(self, item):
         unwrapped_attrs = ['_wrapped', '__class__', '__init__']
         wrapped = super().__getattribute__('_wrapped')
@@ -1112,13 +1116,48 @@ class Axis(_vtkWrapper, _vtk.vtkAxis):
 
 @abstract_class
 class _CustomContextItem(_vtk.vtkPythonItem):
+    """Context item which paints through a Python subclass."""
+
     class ItemWrapper:
+        """Adapter passed to :vtk:`vtkPythonItem`."""
+
         def Initialize(self, item) -> bool:  # noqa: ARG002, N802
             # item is the _CustomContextItem subclass instance
+            """Initialize the wrapped context item.
+
+            Parameters
+            ----------
+            item : _CustomContextItem
+                Wrapped item.
+
+            Returns
+            -------
+            bool
+                Always ``True``.
+
+
+            """
             return True
 
         def Paint(self, item, painter):  # noqa: N802
             # item is the _CustomContextItem subclass instance
+            """Paint the wrapped context item.
+
+            Parameters
+            ----------
+            item : _CustomContextItem
+                Item to paint.
+
+            painter : :vtk:`vtkContext2D`
+                Painter to draw with.
+
+            Returns
+            -------
+            bool
+                Whether painting succeeded.
+
+
+            """
             return item.paint(painter)
 
     def __init__(self) -> None:
@@ -1127,6 +1166,7 @@ class _CustomContextItem(_vtk.vtkPythonItem):
         self.SetPythonObject(_CustomContextItem.ItemWrapper())
 
     def paint(self, _) -> bool:
+        """Paint the context item."""
         return True
 
 
@@ -1146,6 +1186,20 @@ class _ChartBackground(DisableVtkSnakeCase, _CustomContextItem):
         self.ActiveBackgroundBrush = Brush(color=(1.0, 1.0, 1.0, 0.4))
 
     def paint(self, painter) -> bool:
+        """Paint the chart's background and border.
+
+        Parameters
+        ----------
+        painter : :vtk:`vtkContext2D`
+            Painter to draw with.
+
+        Returns
+        -------
+        bool
+            Always ``True``.
+
+
+        """
         if self._chart.visible:
             painter.ApplyPen(self.ActiveBorderPen if self._chart._interactive else self.BorderPen)
             painter.ApplyBrush(
@@ -1158,7 +1212,14 @@ class _ChartBackground(DisableVtkSnakeCase, _CustomContextItem):
 
 @abstract_class
 class _Chart(DocSubs):
-    """Common interface for ``vtkChart``/``vtkChartBox``/``vtkChartPie``/``ChartMPL``."""
+    """Common interface for ``vtkChart``/``vtkChartBox``/``vtkChartPie``/``ChartMPL``.
+
+    .. note::
+        This class is a private internal implementation detail. It is documented
+        solely so that its public members, which are inherited by public classes,
+        are visible in the documentation.
+
+    """
 
     # Subclasses should specify following substitutions: 'chart_name', 'chart_args', 'chart_init'
     # and 'chart_set_labels'.
@@ -1722,7 +1783,14 @@ class _Chart(DocSubs):
 # Subclasses of `_Plot` also inherit from vtk classes, so we disable the vtk snake_case API here
 @abstract_class
 class _Plot(DocSubs):
-    """Common pythonic interface for :vtk:`vtkPlot` and :vtk:`vtkPlot3D` instances."""
+    """Common pythonic interface for :vtk:`vtkPlot` and :vtk:`vtkPlot3D` instances.
+
+    .. note::
+        This class is a private internal implementation detail. It is documented
+        solely so that its public members, which are inherited by public classes,
+        are visible in the documentation.
+
+    """
 
     # Subclasses should specify following substitutions: 'plot_name', 'chart_init' and 'plot_init'.
     _DOC_SUBS: dict[str, str] | None = None
@@ -1959,6 +2027,12 @@ class _MultiCompPlot(_Plot):
     """Common pythonic interface for :vtk:`vtkPlot` instances with multiple components.
 
     Example subclasses are BoxPlot, PiePlot, BarPlot, and StackPlot.
+
+    .. note::
+        This class is a private internal implementation detail. It is documented
+        solely so that its public members, which are inherited by public classes,
+        are visible in the documentation.
+
     """
 
     DEFAULT_COLOR_SCHEME = 'qual_accent'

--- a/pyvista/plotting/mapper.py
+++ b/pyvista/plotting/mapper.py
@@ -41,7 +41,14 @@ if TYPE_CHECKING:
 
 @abstract_class
 class _BaseMapper(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkAbstractMapper):
-    """Base Mapper with methods common to other mappers."""
+    """Base Mapper with methods common to other mappers.
+
+    .. note::
+        This class is a private internal implementation detail. It is documented
+        solely so that its public members, which are inherited by public classes,
+        are visible in the documentation.
+
+    """
 
     def __init__(self, theme=None, **kwargs) -> None:
         self._theme = pv.themes.Theme()
@@ -399,6 +406,11 @@ class _BaseMapper(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.v
 
 class _BaseDataSetMapper(_BaseMapper):
     """Base wrapper for :vtk:`vtkDataSetMapper`.
+
+    .. note::
+        This class is a private internal implementation detail. It is documented
+        solely so that its public members, which are inherited by public classes,
+        are visible in the documentation.
 
     Parameters
     ----------
@@ -1402,7 +1414,14 @@ class PointGaussianMapper(_BaseDataSetMapper, _vtk.vtkPointGaussianMapper):
 
 @abstract_class
 class _BaseVolumeMapper(_BaseMapper):
-    """Volume mapper class to override methods and attributes for to volume mappers."""
+    """Volume mapper class to override methods and attributes for to volume mappers.
+
+    .. note::
+        This class is a private internal implementation detail. It is documented
+        solely so that its public members, which are inherited by public classes,
+        are visible in the documentation.
+
+    """
 
     def __init__(self, theme=None) -> None:
         """Initialize this class."""

--- a/pyvista/plotting/prop3d.py
+++ b/pyvista/plotting/prop3d.py
@@ -575,6 +575,12 @@ class _Prop3DMixin(_BoundsSizeMixin, ABC):
 
     Derived classes need to implement the ``_post_set_update`` method to define
     their behavior, for example, manually apply a transformation.
+
+    .. note::
+        This class is a private internal implementation detail. It is documented
+        solely so that its public members, which are inherited by public classes,
+        are visible in the documentation.
+
     """
 
     def __init__(self) -> None:

--- a/pyvista/plotting/prop_collection.py
+++ b/pyvista/plotting/prop_collection.py
@@ -82,6 +82,18 @@ class _PropCollection(MutableSequence[_vtk.vtkProp]):
             raise TypeError(msg)
 
     def insert(self, index, value) -> None:
+        """Insert a prop at the given index.
+
+        Parameters
+        ----------
+        index : int
+            Index to insert the prop at.
+
+        value : :vtk:`vtkProp`
+            Prop to insert.
+
+
+        """
         _validation.check_instance(value, _vtk.vtkProp)
         if len(self) == 0:
             self.append(value)
@@ -92,10 +104,20 @@ class _PropCollection(MutableSequence[_vtk.vtkProp]):
         self._prop_collection.InsertItem(index - 1, value)
 
     def append(self, value: _vtk.vtkProp):
+        """Add a prop to the end of the collection.
+
+        Parameters
+        ----------
+        value : :vtk:`vtkProp`
+            Prop to add.
+
+
+        """
         _validation.check_instance(value, _vtk.vtkProp)
         self._prop_collection.AddItem(value)
 
     def keys(self) -> list[str]:
+        """Return the name of each prop in the collection."""
         return [
             prop.name
             if hasattr(prop, 'name')
@@ -104,6 +126,7 @@ class _PropCollection(MutableSequence[_vtk.vtkProp]):
         ]
 
     def items(self) -> Iterable[tuple[str, _vtk.vtkProp]]:
+        """Yield ``(name, prop)`` pairs for the collection."""
         yield from zip(self.keys(), self, strict=True)
 
     def __del__(self):

--- a/tests/doc/test_private_class_notes.py
+++ b/tests/doc/test_private_class_notes.py
@@ -1,0 +1,91 @@
+"""Private classes documented for their inherited public members carry a note.
+
+Since private classes are documented, a reader can land on ``_BoundsSizeMixin``
+with nothing saying why a private name has a page. Any private class whose own
+public members are inherited by a public class has to say so.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+
+import pytest
+
+import pyvista as pv
+
+NOTE = 'private internal implementation detail'
+
+
+def _all_classes():
+    """Return every class defined anywhere in ``pyvista``."""
+    modules = [pv]
+    for info in pkgutil.walk_packages(pv.__path__, f'{pv.__name__}.'):
+        try:
+            modules.append(importlib.import_module(info.name))
+        except Exception:  # noqa: BLE001, S112  # pragma: no cover
+            continue  # a module whose optional dependency is missing
+    return list(
+        {
+            obj
+            for module in modules
+            for _, obj in inspect.getmembers(module, inspect.isclass)
+            if getattr(obj, '__module__', '').startswith(pv.__name__)
+        }
+    )
+
+
+def _own_public_members(cls) -> list[str]:
+    """Return the public members ``cls`` itself defines."""
+    return sorted(
+        name
+        for name, value in vars(cls).items()
+        if not name.startswith('_')
+        and (
+            inspect.isfunction(value)
+            or isinstance(value, (property, staticmethod, classmethod))
+            or type(value).__name__ in ('_classproperty', 'cached_property')
+        )
+    )
+
+
+def _classes_needing_the_note():
+    """Return ``{private class: public subclasses}`` for classes the note applies to."""
+    classes = _all_classes()
+    needed = {}
+    for cls in classes:
+        if not cls.__name__.startswith('_') or not _own_public_members(cls):
+            continue
+        subclasses = sorted(
+            {
+                other.__name__
+                for other in classes
+                if not other.__name__.startswith('_') and other is not cls and cls in other.__mro__
+            }
+        )
+        if subclasses:
+            needed[cls] = subclasses
+    return needed
+
+
+@pytest.fixture(scope='module')
+def needs_note():
+    return _classes_needing_the_note()
+
+
+def test_some_classes_need_the_note(needs_note):
+    """Guard the test above: the set it checks must not silently become empty."""
+    assert len(needs_note) > 10
+
+
+def test_private_classes_exposing_public_members_carry_the_note(needs_note):
+    missing = sorted(
+        f'{cls.__module__}.{cls.__name__} (inherited by {", ".join(subs[:3])})'
+        for cls, subs in needs_note.items()
+        if NOTE not in (cls.__doc__ or '')
+    )
+    assert not missing, (
+        'These private classes expose public members through public subclasses, '
+        'so their docstring must contain a note saying so:\n  ' + '\n  '.join(missing)
+    )

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -78,3 +78,134 @@ def test_warnings_converter(
         """
 
     assert textwrap.dedent(expected) == ''.join(lines)
+
+
+def _run_private_class_hook(
+    source: str,
+    tmp_path: Path,
+    pre_commit_config: dict,
+    request: pytest.FixtureRequest,
+    *,
+    encoding: str = 'utf-8',
+) -> tuple[int, str]:
+    """Write ``source`` to a file and return the hook's exit code and output."""
+    file = tmp_path / 'file.py'
+    file.write_text(textwrap.dedent(source), encoding=encoding)
+
+    local = next(v for v in pre_commit_config['repos'] if v['repo'] == 'local')
+    hook = next(v for v in local['hooks'] if v['id'] == 'private-class-docstrings')
+
+    ret = subprocess.run(
+        [sys.executable, *shlex.split(hook['entry'])[1:], str(file.absolute())],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=request.config.rootpath,
+    )
+    return ret.returncode, ret.stdout
+
+
+def test_private_class_docstrings_reports(
+    tmp_path: Path, pre_commit_config: dict, request: pytest.FixtureRequest
+):
+    code, out = _run_private_class_hook(
+        '''\
+        class _Private:
+            def undocumented(self): ...
+
+            @property
+            def undocumented_property(self): ...
+
+            def _private_method(self): ...
+
+            @documented.setter
+            def documented(self, value): ...
+
+            @overload
+            def stub(self) -> int: ...
+
+            def documented_method(self):
+                """Documented."""
+
+        class Public:
+            def undocumented(self): ...
+        ''',
+        tmp_path,
+        pre_commit_config,
+        request,
+    )
+    assert code == 1
+    # The private class itself, and only its two undocumented public members
+    assert "class '_Private' is private, so it needs a docstring" in out
+    assert "public 'undocumented' is in private class '_Private'" in out
+    assert "public 'undocumented_property' is in private class '_Private'" in out
+    # Exempt: private members, setters, overload stubs, documented members
+    assert '_private_method' not in out
+    assert "'documented'" not in out
+    assert "'stub'" not in out
+    assert "'documented_method'" not in out
+    # Ruff's D102 already covers a public class
+    assert "'Public'" not in out
+
+
+def test_private_class_docstrings_nested_and_clean(
+    tmp_path: Path, pre_commit_config: dict, request: pytest.FixtureRequest
+):
+    code, out = _run_private_class_hook(
+        '''\
+        class _Private:
+            """Documented."""
+
+            class Nested:
+                """Documented."""
+
+                def member(self):
+                    """Documented."""
+
+        class Public:
+            class _AlsoPrivate:
+                """Documented."""
+        ''',
+        tmp_path,
+        pre_commit_config,
+        request,
+    )
+    assert code == 0, out
+    assert out == ''
+
+
+def test_private_class_docstrings_nested_class_needs_docstring(
+    tmp_path: Path, pre_commit_config: dict, request: pytest.FixtureRequest
+):
+    code, out = _run_private_class_hook(
+        '''\
+        class _Private:
+            """Documented."""
+
+            class Nested: ...
+        ''',
+        tmp_path,
+        pre_commit_config,
+        request,
+    )
+    assert code == 1
+    assert "class 'Nested' is in private class '_Private'" in out
+
+
+def test_private_class_docstrings_reads_non_ascii(
+    tmp_path: Path, pre_commit_config: dict, request: pytest.FixtureRequest, monkeypatch
+):
+    """The hook must not depend on the locale's preferred encoding."""
+    monkeypatch.setenv('PYTHONUTF8', '0')
+    monkeypatch.setenv('PYTHONCOERCECLOCALE', '0')
+    monkeypatch.setenv('LC_ALL', 'C')
+    code, out = _run_private_class_hook(
+        '''\
+        class _Private:
+            """Documented — with an em dash."""
+        ''',
+        tmp_path,
+        pre_commit_config,
+        request,
+    )
+    assert code == 0, out


### PR DESCRIPTION
### Overview

Ruff's `D1` rules treat a private class, a private module, and everything inside them as private, so a public method of `_SomeClass` or a public function in `_typing.py` could ship with no docstring and no linter said a word — numpydoc does not cover it either, since `GL08` is off. Now that #8972 documents private classes, those gaps are visible on published pages. This adds a `private-class-docstrings` pre-commit hook applying the `D101`/`D102`/`D103` standard wherever ruff stops at a private name, and the 69 docstrings it reports.

It also gives every private class whose own public members are inherited by a public class a note saying so, since a reader landing on `_BoundsSizeMixin` (34 public subclasses) or `_FileIOBase` (91) otherwise has nothing telling them why a private name has a page. A hook cannot check that — it sees one file at a time and cannot know which public classes inherit a private one — so `tests/doc/test_private_class_notes.py` walks the real MRO across the package instead.

Split out of #8982, which is about numpydoc's parameter and return checks on already-documented members; this one is about docstrings existing at all. Changes drafted by Claude but fully understood by me.

### Details

- Both script-form hooks now run under `python -P`. `hooks/` holds a `warnings.py` that shadows the stdlib module on `sys.path[0]`, and since Python 3.13 `pathlib` imports `warnings` internally, so the hook died on a circular import before reading a file. `gallery_docstrings.py` has the same latent break and is fixed with it; `warn_external` is already safe because `python -m hooks.warnings` leaves the repository root on the path.
- `tests/test_hooks.py` gains five cases covering the decorator exemptions (`@overload`, setters, deleters), nested classes, and the encoding regression above.
- The note test carries a guard asserting the set it checks stays non-empty, so it cannot silently become vacuous.
