### PR TITLE
ci: trim the macOS unit test matrix to two Python versions

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -86,7 +86,7 @@ jobs:
       PARALLEL: "-n auto" # Use all available cores on the selected runner
     strategy:
       fail-fast: false
-      # Keep to 3 entries or fewer: GitHub-hosted macOS runners are a limited shared pool and bottleneck this workflow.
+      # Keep to 2 entries, the oldest and newest Python: GitHub-hosted macOS runners are a limited shared pool and bottleneck this workflow.
       matrix:
         python-version: ["3.10", "3.14"]
     steps:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -86,12 +86,9 @@ jobs:
       PARALLEL: "-n auto" # Use all available cores on the selected runner
     strategy:
       fail-fast: false
-      # Keep this matrix at three entries or fewer. GitHub-hosted macOS runners
-      # are a limited, shared pool and are the bottleneck for the whole
-      # workflow, so test the oldest and newest supported Python plus one in
-      # between rather than every version.
+      # Keep to 3 entries or fewer: GitHub-hosted macOS runners are a limited shared pool and bottleneck this workflow.
       matrix:
-        python-version: ["3.10", "3.11", "3.14"]
+        python-version: ["3.10", "3.14"]
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -86,8 +86,12 @@ jobs:
       PARALLEL: "-n auto" # Use all available cores on the selected runner
     strategy:
       fail-fast: false
+      # Keep this matrix at three entries or fewer. GitHub-hosted macOS runners
+      # are a limited, shared pool and are the bottleneck for the whole
+      # workflow, so test the oldest and newest supported Python plus one in
+      # between rather than every version.
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.14"]
     steps:
       - uses: actions/checkout@v7
         with:

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -925,7 +925,9 @@ cpos_param.extend(pv.plotting.renderer.Renderer.CAMERA_STR_ATTR_MAP)
 
 
 @pytest.mark.parametrize('cpos', cpos_param)
-def test_set_camera_position(cpos, sphere):
+def test_set_camera_position(cpos, sphere, verify_image_cache):
+    # Sphere edges land differently on each macOS run, see pyvista/pyvista#9030
+    verify_image_cache.macos_skip_image_cache = True
     pl = pv.Plotter()
     pl.add_mesh(sphere)
     pl.camera_position = cpos


### PR DESCRIPTION
Cuts the macOS unit test matrix to the oldest and newest Python, with a note capping it at two — those runners are a limited shared pool that gates the workflow.

Also skips the macOS image check for `test_set_camera_position`, which flakes (#9030).