### PR TITLE
Move the nightly numpy/matplotlib run to the integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -58,6 +58,9 @@ jobs:
           - project: cvista
             timeout: 80
             runner: ubuntu-22.04
+          - project: numpy-nightly
+            timeout: 80 # runs the whole suite, like cvista
+            runner: ubuntu-22.04
     runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
     timeout-minutes: ${{ matrix.timeout }}
     defaults:
@@ -136,6 +139,7 @@ jobs:
             [geovista]="@bjlittle"
             [playwright]="@user27182"
             [cvista]="@akaszynski"
+            [numpy-nightly]="@user27182"
           )
 
           # The matrix job names are just the project names (see `name:` above)

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -156,9 +156,6 @@ jobs:
           - python-version: "3.14"
             vtk-version: "latest"
             numpy-version: "latest"
-          - python-version: "3.14"
-            vtk-version: "latest"
-            numpy-version: "nightly"
 
     env:
       TOX_FACTOR: py${{matrix.python-version}}-numpy_${{matrix.numpy-version}}-vtk_${{matrix.vtk-version}}

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -188,7 +188,7 @@ can be installed via package managers like ``scoop`` or ``chocolatey``.
     make docs              # build the full documentation via tox (matches CI)
     make docs-test-build   # sanity-check the built documentation via tox (matches CI)
     make docs-test-images  # compare documentation images against cached baselines via tox (matches CI)
-    make integration PROJECT=<name>  # run integration tests for trame/geovista/mne/pyvistaqt/playwright/cvista
+    make integration PROJECT=<name>  # run integration tests for trame/geovista/mne/pyvistaqt/playwright/cvista/numpy-nightly
 
 ``make test``, ``make test-core``, and ``make test-plotting`` all
 invoke tox environments defined in ``tox.ini`` so they run with the
@@ -1050,18 +1050,6 @@ behaviour that differs deliberately. Attach it to the test with a reason naming 
 
 It is not a way to park a real regression. In library code, use :func:`pyvista.vtk_backend` to raise a clear error for a
 build that cannot support a feature.
-
-Testing Against Nightly ``numpy`` and ``matplotlib``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The nightly ``numpy`` and ``matplotlib`` wheels are tested at **integration cadence**—nightly, and on PRs carrying the
-``integration-testing`` label:
-
-.. code-block:: shell
-
-    make integration PROJECT=numpy-nightly
-
-VTK stays at its latest release, and download-backed tests are skipped. A failure on ``main`` or on the nightly schedule
-opens or comments on the shared ``integration-test-failure`` issue.
 
 Garbage Collection Checks
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1051,6 +1051,18 @@ behaviour that differs deliberately. Attach it to the test with a reason naming 
 It is not a way to park a real regression. In library code, use :func:`pyvista.vtk_backend` to raise a clear error for a
 build that cannot support a feature.
 
+Testing Against Nightly ``numpy`` and ``matplotlib``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The nightly ``numpy`` and ``matplotlib`` wheels are tested at **integration cadence**—nightly, and on PRs carrying the
+``integration-testing`` label:
+
+.. code-block:: shell
+
+    make integration PROJECT=numpy-nightly
+
+VTK stays at its latest release, and download-backed tests are skipped. A failure on ``main`` or on the nightly schedule
+opens or comments on the shared ``integration-test-failure`` issue.
+
 Garbage Collection Checks
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 Every test is checked for reference leaks: no plotter or VTK object created by a test

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ env_list =
     py3.12-numpy_latest-vtk_9.5.2
     py3.13-numpy_latest-vtk_9.6.2
     py3.14-numpy_latest-vtk_9.7.0
-    py3.14-numpy_nightly-vtk_latest
     py3.{10-14}
     py3.{10-14}-vtk_dev
 
@@ -177,6 +176,27 @@ commands_pre =
     {[testenv]software_report_cmdline}
 # Split core/plotting the way [testenv]all_testing_cmdline does (how PyVista's CI
 # runs the suite). Skip download-backed tests to keep the nightly job off the network.
+commands =
+    pytest --ignore=tests/plotting -n auto -m "not needs_download" -ra --tb=short --timeout=300 --timeout-method=thread {posargs}
+    pytest tests/plotting -n auto -m "not needs_download" -ra --tb=short --timeout=300 --timeout-method=thread {posargs}
+
+# Nightly numpy and matplotlib run at integration cadence (like integration-cvista).
+# VTK stays at its latest release so a failure points at numpy or matplotlib.
+[testenv:integration-numpy-nightly]
+description = Run the test suite against the nightly numpy and matplotlib wheels
+basepython = py3.14
+dependency_groups = test
+# Not in the `test` group; guards against a single stuck test burning the job budget.
+deps = pytest-timeout
+setenv =
+    # A named env's setenv replaces [testenv]'s, so repeat TOX_ROOT (tests read
+    # pyproject.toml through it).
+    TOX_ROOT = {tox_root}
+commands_pre =
+    python -c 'import os, subprocess; os.environ["UV_INDEX"]="{[testenv]uv_index_numpy_nightly}"; subprocess.run("{[testenv]numpy_nightly_install}".split(), check=True)'
+    {[testenv]software_report_cmdline}
+# Split core/plotting the way [testenv]all_testing_cmdline does (how PyVista's CI
+# runs the suite). Skip download-backed tests to keep the job off the network.
 commands =
     pytest --ignore=tests/plotting -n auto -m "not needs_download" -ra --tb=short --timeout=300 --timeout-method=thread {posargs}
     pytest tests/plotting -n auto -m "not needs_download" -ra --tb=short --timeout=300 --timeout-method=thread {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -178,6 +178,7 @@ setenv =
 commands_pre =
     cvista: python -c 'import os, subprocess; subprocess.run("{[testenv]cvista_install}".split(), check=True)'
     cvista: python -c 'import os, subprocess; subprocess.run("{[testenv]trame_install}".split(), check=True)'
+    # No VTK install: it stays at its latest release so a failure points at numpy or matplotlib.
     nightly: python -c 'import os, subprocess; os.environ["UV_INDEX"]="{[testenv]uv_index_numpy_nightly}"; subprocess.run("{[testenv]numpy_nightly_install}".split(), check=True)'
     {[testenv]software_report_cmdline}
 # Split core/plotting the way [testenv]all_testing_cmdline does (how PyVista's CI

--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,16 @@ numpy_nightly_install = uv pip install --upgrade --pre --no-cache --no-deps --ex
 vtk_dev_install = uv pip install --upgrade --pre --no-cache --no-deps --extra-index-url {[testenv]uv_index_vtk_dev} vtk
 vtk_local_install = uv pip install --upgrade --pre --no-cache --no-deps --no-index --find-links {env:VTK_WHEEL_DIR} vtk
 vtk_latest_install = uv pip install --upgrade --pre --no-deps vtk
+# `cvista[all]`, not bare `cvista`: the bare tier is rendering- and IO-free and cannot
+# run the plotting suite. cvista >=9.7.0.2 ships every reader and writer the suite
+# exercises, including the parallel Exodus reader added in 9.7.0.1.
+cvista_install = uv pip install --upgrade --no-cache cvista[all]>=9.7.0.2,<9.8.0
+# --no-deps so `--upgrade` does not lift PyVista's own pins (their deps come from
+# the `test` group); a matplotlib bump otherwise fails tests/doc/test_tables.py.
+# trame-vtk >=2.11.16 (Kitware/trame-vtk#124) honours VTK_MODULE_NAME; earlier
+# versions serialized stock-VTK objects. trame-pyvista >=0.1.7 relaxes the matching
+# upper-pin (pyvista/trame-pyvista#96).
+trame_install = uv pip install --upgrade --no-cache --no-deps 'trame-vtk>=2.11.16' 'trame-pyvista>=0.1.7'
 
 commands_pre =
     numpy_nightly: python -c 'import os, subprocess; os.environ["UV_INDEX"]="{[testenv]uv_index_numpy_nightly}"; subprocess.run("{[testenv]numpy_nightly_install}".split(), check=True)'
@@ -144,13 +154,17 @@ commands_pre =
 commands =
     python -m pytest -m needs_playwright --playwright {posargs}
 
-# cvista is an alternative VTK backend, so (like integration-playwright) it runs at
-# integration cadence rather than per-PR. See "Testing Against the cvista Backend"
-# in CONTRIBUTING.rst. `cvista[all]`, not bare `cvista`: the bare tier is
-# rendering- and IO-free and cannot run the plotting suite.
-[testenv:integration-cvista]
-description = Run the test suite against the cvista VTK backend
-basepython = py3.13
+# cvista (an alternative VTK backend) and the nightly numpy/matplotlib wheels both run
+# PyVista's own suite against a swapped-out dependency, so (like integration-playwright)
+# they run at integration cadence rather than per-PR. See "Testing Against the cvista
+# Backend" in CONTRIBUTING.rst.
+[testenv:integration-{cvista,numpy-nightly}]
+description =
+    cvista: Run the test suite against the cvista VTK backend
+    nightly: Run the test suite against the nightly numpy and matplotlib wheels
+basepython =
+    cvista: py3.13
+    nightly: py3.14
 dependency_groups = test
 # Not in the `test` group; guards against a single stuck test burning the job budget.
 deps = pytest-timeout
@@ -158,45 +172,16 @@ setenv =
     # A named env's setenv replaces [testenv]'s, so repeat TOX_ROOT (tests read
     # pyproject.toml through it).
     TOX_ROOT = {tox_root}
-    PYVISTA_VTK_BACKEND = cvista
+    cvista: PYVISTA_VTK_BACKEND = cvista
     # trame-vtk resolves its VTK through this; must match so it builds cvista objects.
-    VTK_MODULE_NAME = cvista
-# trame-vtk >=2.11.16 (Kitware/trame-vtk#124) honours VTK_MODULE_NAME; earlier
-# versions serialized stock-VTK objects. trame-pyvista >=0.1.7 relaxes the matching
-# upper-pin (pyvista/trame-pyvista#96). cvista >=9.7.0.2 ships every reader and
-# writer the suite exercises, including the parallel Exodus reader added in 9.7.0.1.
-cvista_install = uv pip install --upgrade --no-cache cvista[all]>=9.7.0.2,<9.8.0
-# --no-deps so `--upgrade` does not lift PyVista's own pins (their deps come from
-# the `test` group); a matplotlib bump otherwise fails tests/doc/test_tables.py.
-trame_install = uv pip install --upgrade --no-cache --no-deps 'trame-vtk>=2.11.16' 'trame-pyvista>=0.1.7'
-
+    cvista: VTK_MODULE_NAME = cvista
 commands_pre =
-    python -c 'import os, subprocess; subprocess.run("{[testenv:integration-cvista]cvista_install}".split(), check=True)'
-    python -c 'import os, subprocess; subprocess.run("{[testenv:integration-cvista]trame_install}".split(), check=True)'
+    cvista: python -c 'import os, subprocess; subprocess.run("{[testenv]cvista_install}".split(), check=True)'
+    cvista: python -c 'import os, subprocess; subprocess.run("{[testenv]trame_install}".split(), check=True)'
+    nightly: python -c 'import os, subprocess; os.environ["UV_INDEX"]="{[testenv]uv_index_numpy_nightly}"; subprocess.run("{[testenv]numpy_nightly_install}".split(), check=True)'
     {[testenv]software_report_cmdline}
 # Split core/plotting the way [testenv]all_testing_cmdline does (how PyVista's CI
-# runs the suite). Skip download-backed tests to keep the nightly job off the network.
-commands =
-    pytest --ignore=tests/plotting -n auto -m "not needs_download" -ra --tb=short --timeout=300 --timeout-method=thread {posargs}
-    pytest tests/plotting -n auto -m "not needs_download" -ra --tb=short --timeout=300 --timeout-method=thread {posargs}
-
-# Nightly numpy and matplotlib run at integration cadence (like integration-cvista).
-# VTK stays at its latest release so a failure points at numpy or matplotlib.
-[testenv:integration-numpy-nightly]
-description = Run the test suite against the nightly numpy and matplotlib wheels
-basepython = py3.14
-dependency_groups = test
-# Not in the `test` group; guards against a single stuck test burning the job budget.
-deps = pytest-timeout
-setenv =
-    # A named env's setenv replaces [testenv]'s, so repeat TOX_ROOT (tests read
-    # pyproject.toml through it).
-    TOX_ROOT = {tox_root}
-commands_pre =
-    python -c 'import os, subprocess; os.environ["UV_INDEX"]="{[testenv]uv_index_numpy_nightly}"; subprocess.run("{[testenv]numpy_nightly_install}".split(), check=True)'
-    {[testenv]software_report_cmdline}
-# Split core/plotting the way [testenv]all_testing_cmdline does (how PyVista's CI
-# runs the suite). Skip download-backed tests to keep the job off the network.
+# runs the suite). Skip download-backed tests to keep these jobs off the network.
 commands =
     pytest --ignore=tests/plotting -n auto -m "not needs_download" -ra --tb=short --timeout=300 --timeout-method=thread {posargs}
     pytest tests/plotting -n auto -m "not needs_download" -ra --tb=short --timeout=300 --timeout-method=thread {posargs}


### PR DESCRIPTION
### Overview

Moves the nightly `numpy`/`matplotlib` run out of `Unit Testing and Deployment` and into `Integration Tests` as `integration-numpy-nightly`, which shares a tox section with `integration-cvista` since both run PyVista's own suite against a swapped-out dependency.

The nightly wheel index returns 503s often enough to fail pull requests and eject merge-queue batches, and a nightly break is never caused by the diff under review. As an integration job it is label-gated off PRs, runs on the 4am schedule and on `main`, gets the existing 2-attempt retry wrapper, and reports failures through `alert-on-failure` instead of blocking CI.

⚠️ **`Linux Unit Testing (3.14, latest, nightly)` no longer exists** — it must come out of the required-checks list, or the merge queue will wait on a check that never reports.

Claude wrote this branch and this description; I reviewed both.

### Details

- Differences from the job it replaces: download-backed tests skipped (`-m "not needs_download"`), VTK at its latest release rather than `--pre`, no coverage upload, and a `timeout: 80` copied from cvista that should be tuned after the first scheduled run.
- `py3.14-numpy_nightly-vtk_latest` is out of the default `env_list`; the `numpy_nightly` factor stays, so `tox run -e py3.11-vtk_9.4.2-numpy_nightly` still works.
- Failures @-mention @user27182 on the shared `integration-test-failure` issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
