### PR TITLE
Document `warp_by_scalar`'s fallback direction without normals

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2730,6 +2730,24 @@ class DataSetFilters(DataObjectFilters):
         pyvista.DataSet
             Warped Dataset.  Return type matches input.
 
+        See Also
+        --------
+        warp_by_vector
+            Warp along a per-point direction instead of a single fixed one.
+
+        Notes
+        -----
+        Points are only moved along their own point normals when the dataset has
+        them. Without point normals, or with ``normal`` given, every point is instead
+        moved along that single fixed direction -- :vtk:`vtkWarpScalar`'s default is
+        ``(0, 0, 1)`` -- rather than radially or otherwise per point. This is easy to
+        miss on a dataset assembled directly from coordinates, such as
+        :func:`~pyvista.grid_from_sph_coords`, where the result looks like a uniform
+        vertical shift instead of the intended radial warp. Use :func:`warp_by_vector`
+        instead when the warp direction should vary per point but the dataset has no
+        normals to warp along, for example using each point's own radial direction as
+        the vector array.
+
         Examples
         --------
         First, plot the un-warped mesh.
@@ -2812,6 +2830,11 @@ class DataSetFilters(DataObjectFilters):
         -------
         pyvista.PolyData
             The warped mesh resulting from the operation.
+
+        See Also
+        --------
+        warp_by_scalar
+            Warp along a single fixed direction using a scalar amount per point.
 
         Examples
         --------

--- a/pyvista/core/utilities/features.py
+++ b/pyvista/core/utilities/features.py
@@ -456,6 +456,15 @@ def grid_from_sph_coords(theta, phi, r):
     pyvista.StructuredGrid
         Structured grid.
 
+    Notes
+    -----
+    The returned grid has no point normals. Warping it with
+    :func:`~pyvista.DataSetFilters.warp_by_scalar` therefore moves every point
+    along a single fixed direction rather than radially outward -- see that
+    filter's notes. For a radial warp, use
+    :func:`~pyvista.DataSetFilters.warp_by_vector` with the (normalized) point
+    coordinates as the vector array instead.
+
     """
     x, y, z = np.meshgrid(np.radians(theta), np.radians(phi), r)
     # Transform grid to cartesian coordinates


### PR DESCRIPTION
### Overview

Resolves #6883. `warp_by_scalar` silently falls back to a single fixed direction -- VTK's `vtkWarpScalar` default of `(0, 0, 1)` -- when the dataset has no point normals, or when `normal` is given, instead of moving each point along its own normal. This is easy to miss on a dataset built directly from coordinates, such as `grid_from_sph_coords`, where the result looks like a uniform vertical shift rather than the intended radial warp, exactly what the issue reported. An earlier attempt at this ([#8966](https://github.com/pyvista/pyvista/pull/8966)) tried fixing it by attaching normals inside `grid_from_sph_coords`, but that function can also produce 3D volumes where normals aren't well-defined, and computing them reliably for an arbitrary dataset isn't generally possible either -- see [the review discussion](https://github.com/pyvista/pyvista/issues/6883#issuecomment-5457582404). So this documents the fallback on `warp_by_scalar` instead, points to `warp_by_vector` as the alternative for a per-point direction, and cross-links both from `grid_from_sph_coords`.

Changes drafted by Claude Sonnet 5 but fully understood by me.
