### PR TITLE
Remove no-op shadow setting from 2D Perlin noise example

### DIFF
--- a/examples/01-filter/perlin_noise_2d.py
+++ b/examples/01-filter/perlin_noise_2d.py
@@ -72,7 +72,7 @@ pl.show()
 
 
 # %%
-# Show the terrain with custom lighting and shadows
+# Show the terrain with custom lighting
 
 pl = pv.Plotter(lighting=None)
 pl.add_light(
@@ -92,7 +92,6 @@ pl.add_mesh(
     smooth_shading=True,
     clim=clim,
 )
-pl.enable_shadows = True
 pl.show()
 # %%
 # .. tags:: filter


### PR DESCRIPTION
### Overview

`pl.enable_shadows = True` in the 2D Perlin noise example assigns over the `Plotter.enable_shadows` method instead of calling it, so the second figure never had shadows. Calling it would not change the figure either: VTK's shadow map baker skips positional lights with a cone angle of 90° or more, and the render is pixel-identical with the pass on and off. Narrowing the cone leaves the terrain outside the spotlight, since the light points at the origin ten units above the surface. Drop the line and the word "shadows" from the heading instead; the doc baseline is unchanged, and no other assignment to a plotter method exists under `examples/` or `doc/`.

Changes drafted by Claude Fable 5.1 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
