### PR TITLE
Fix re-enabling shadows after `disable_shadows()`

### DIFF
--- a/pyvista/plotting/render_passes.py
+++ b/pyvista/plotting/render_passes.py
@@ -222,6 +222,7 @@ class RenderPasses(_NoNewAttrMixin):
             return
         self._pass_collection.RemoveItem(self._shadow_map_pass.GetShadowMapBakerPass())
         self._pass_collection.RemoveItem(self._shadow_map_pass)
+        self._shadow_map_pass = None
         self._update_passes()
 
     @_deprecate_positional_args

--- a/tests/plotting/test_render_pass.py
+++ b/tests/plotting/test_render_pass.py
@@ -92,14 +92,26 @@ def test_ssao_raise_no_depth_of_field():
 
 
 def test_shadow_pass():
-    _ren, passes = make_passes()
+    ren, passes = make_passes()
     ren_pass = passes.enable_shadow_pass()
     assert isinstance(ren_pass, _vtk.vtkShadowMapPass)
 
     assert passes._pass_collection.IsItemPresent(ren_pass)
+    assert passes._pass_collection.IsItemPresent(ren_pass.GetShadowMapBakerPass())
+    assert ren.GetPass() is not None
 
     passes.disable_shadow_pass()
     assert not passes._pass_collection.IsItemPresent(ren_pass)
+    assert not passes._pass_collection.IsItemPresent(ren_pass.GetShadowMapBakerPass())
+    assert passes._shadow_map_pass is None
+    assert ren.GetPass() is None
+
+    # enabling again after disabling should add a new pass
+    new_pass = passes.enable_shadow_pass()
+    assert isinstance(new_pass, _vtk.vtkShadowMapPass)
+    assert new_pass is not ren_pass
+    assert passes._pass_collection.IsItemPresent(new_pass)
+    assert passes._pass_collection.IsItemPresent(new_pass.GetShadowMapBakerPass())
 
 
 def test_edl_pass():


### PR DESCRIPTION
### Overview

Part of #8685. `RenderPasses.disable_shadow_pass()` removed the shadow map pass and its baker from the pass collection but never cleared `_shadow_map_pass`, so a later `enable_shadow_pass()` returned early at its already-enabled guard and shadows could not be turned back on after `Plotter.disable_shadows()`. This clears the attribute after the removal and extends `test_shadow_pass` with the disable/enable cycle. The GPU-memory half of #8685, which the closed #8686 bundled with this fix, is left for a separate change.

Changes drafted by Claude Fable 5.1 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
