### PR TITLE
Fix `get_cell` bounds and casts with active cell scalars

### DIFF
--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1987,7 +1987,9 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
             cell_data = cell_data.cell_data_to_point_data()
             pset.GetCellData().DeepCopy(cell_data.GetPointData())
         pset.GetPointData().DeepCopy(self.GetPointData())
-        pset.active_scalars_name = self.active_scalars_name
+        field, name = self.active_scalars_info
+        if field == FieldAssociation.POINT or pass_cell_data:
+            pset.active_scalars_name = name
         return pset
 
     @overload

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -1925,7 +1925,9 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
         pset.points = self.points.copy()
         out = self.cell_data_to_point_data() if pass_cell_data else self
         pset.GetPointData().DeepCopy(out.GetPointData())
-        pset.active_scalars_name = out.active_scalars_name
+        field, name = out.active_scalars_info
+        if field == FieldAssociation.POINT:
+            pset.active_scalars_name = name
         return pset
 
     @_deprecate_positional_args

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -2649,8 +2649,8 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
         [0, 2, 1]
 
         """
-        # must check upper bounds, otherwise segfaults (on Linux, 9.2)
-        if index + 1 > self.n_cells:
+        # must check bounds, otherwise segfaults (on Linux, 9.2) or returns an empty cell
+        if not 0 <= index < self.n_cells:
             msg = f'Invalid index {index} for a dataset with {self.n_cells} cells.'
             raise IndexError(msg)
 

--- a/tests/core/test_cells.py
+++ b/tests/core/test_cells.py
@@ -179,6 +179,8 @@ def test_cell_get_cell():
     hexbeam = grids[0]
     with pytest.raises(IndexError, match='Invalid index'):
         hexbeam.get_cell(hexbeam.n_cells)
+    with pytest.raises(IndexError, match='Invalid index'):
+        hexbeam.get_cell(-1)
     assert isinstance(hexbeam.get_cell(0), pv.Cell)
 
 

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1360,6 +1360,16 @@ def test_cast_to_pointset(sphere):
     assert not np.allclose(sphere.active_scalars, pointset.active_scalars)
 
 
+def test_cast_to_pointset_cell_scalars(sphere):
+    sphere.cell_data['cell_scalars'] = np.arange(sphere.n_cells)
+    sphere.set_active_scalars('cell_scalars')
+    pointset = sphere.cast_to_pointset()
+    assert isinstance(pointset, pv.PointSet)
+    assert pointset.active_scalars_name is None
+    pointset = sphere.cast_to_pointset(pass_cell_data=True)
+    assert pointset.active_scalars_name == 'cell_scalars'
+
+
 def test_cast_to_pointset_implicit(uniform):
     pointset = uniform.cast_to_pointset(pass_cell_data=True)
     assert isinstance(pointset, pv.PointSet)

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1387,6 +1387,17 @@ def test_cast_to_pointset_implicit(uniform):
         assert not np.allclose(uniform[name], pointset[name])
 
 
+def test_cast_to_poly_points_cell_scalars(sphere):
+    sphere.cell_data['cell_scalars'] = np.arange(sphere.n_cells)
+    sphere.set_active_scalars('cell_scalars')
+    points = sphere.cast_to_poly_points()
+    assert isinstance(points, pv.PolyData)
+    assert points.active_scalars_name is None
+    points = sphere.cast_to_poly_points(pass_cell_data=True)
+    assert points.active_scalars_name == 'cell_scalars'
+    assert points.active_scalars_info.association == pv.FieldAssociation.CELL
+
+
 def test_cast_to_poly_points_implicit(uniform):
     points = uniform.cast_to_poly_points(pass_cell_data=True)
     assert isinstance(points, pv.PolyData)


### PR DESCRIPTION
### Overview

Three small fixes found while profiling the core dataset code, one commit each. Changes drafted by Claude Fable 5.1 but fully understood by me.

- `DataSet.get_cell` only checked the upper bound, so a negative index returned an empty cell instead of raising; it now raises `IndexError`.
- `DataSet.cast_to_pointset` raised `KeyError` when the active scalars were cell data, because the cast only copies point data. The active scalars are now carried over only when they are point data.
- `DataSet.cast_to_poly_points` had the same failure without `pass_cell_data`; the active scalars are carried over when they are point data or the cell data was passed along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
