### PR TITLE
Fix the mne integration env, forward `pyvista._validation`, and bump to pyvista-validation 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   'pillow',
   'pooch',
   'pyobjc-framework-Cocoa; sys_platform == "darwin"', # see pyvista/pulls/7828, 8423, and 8832
-  'pyvista-validation==0.1.0', # Exact pin: the validation API is still unstable
+  'pyvista-validation==0.1.1', # Exact pin: the validation API is still unstable
   'scooby>=0.5.1',
   'typing-extensions>=4.10',
   'vtk!=9.4.0',

--- a/pyvista/__init__.py
+++ b/pyvista/__init__.py
@@ -118,6 +118,27 @@ _env_theme_applied: bool = False
 
 
 # Lazily import/access the plotting module
+def _get_deprecated_validation():
+    """Forward ``pyvista._validation`` to the ``pyvista_validation`` package with a warning."""
+    import pyvista_validation  # noqa: PLC0415
+
+    from pyvista._warn_external import warn_external  # noqa: PLC0415
+    from pyvista.core.errors import PyVistaDeprecationWarning  # noqa: PLC0415
+
+    msg = (
+        '`pyvista._validation` has moved to the `pyvista_validation` package; '
+        'use `from pyvista_validation import ...` instead.'
+    )
+    warn_external(msg, PyVistaDeprecationWarning)
+    if version_info >= (0, 51):  # pragma: no cover
+        msg = 'Convert this deprecation warning into an error.'
+        raise RuntimeError(msg)
+    if version_info >= (0, 52):  # pragma: no cover
+        msg = 'Remove the _validation forward.'
+        raise RuntimeError(msg)
+    return pyvista_validation
+
+
 def __getattr__(name):
     """Fetch an attribute ``name`` from ``globals()`` or the ``pyvista.plotting`` module.
 
@@ -143,6 +164,9 @@ def __getattr__(name):
 
         # Do not cache since we want to re-issue the deprecation warning
         return _get_deprecated_hexcolors()
+    if name == '_validation':
+        # Not cached either, so the deprecation warning is re-issued on each access
+        return _get_deprecated_validation()
 
     allow = {
         'demos',

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
 import textwrap
@@ -311,3 +312,19 @@ def test_vtk_import_all_suppressed_ignores_failures(monkeypatch):
     _vtk.import_all(suppress_import_errors=True)
 
     assert calls == ['A', 'SpecialA']
+
+
+def test_validation_forward_deprecated():
+    import pyvista_validation
+
+    import pyvista as pv
+
+    msg = (
+        '`pyvista._validation` has moved to the `pyvista_validation` package; '
+        'use `from pyvista_validation import ...` instead.'
+    )
+    with pytest.warns(pv.PyVistaDeprecationWarning, match=re.escape(msg)):
+        assert pv._validation is pyvista_validation
+    with pytest.warns(pv.PyVistaDeprecationWarning, match=re.escape(msg)):
+        from pyvista import _validation
+    assert _validation.validate_array3([1, 2, 3]).shape == (3,)

--- a/tox.ini
+++ b/tox.ini
@@ -272,7 +272,6 @@ commands_pre =
     # rather than the cloned source. Editable keeps the source tree on path.
     mne: uv pip install --upgrade -e {env:MNE_HOME}[full-pyside6] --project {env:MNE_HOME} --group test_extra
     mne: bash -c "{env:MNE_HOME}/tools/github_actions_download.sh"
-    mne: python -c "import pyvista; assert not pyvista.OFF_SCREEN, f'{pyvista.OFF_SCREEN=} should be False'"
 
     # PYVISTAQT SETUP
     pyvistaqt: bash -c "[ -d {env:PYVISTAQT_HOME} ] || git clone https://github.com/pyvista/pyvistaqt.git {env:PYVISTAQT_HOME} --single-branch"
@@ -280,6 +279,9 @@ commands_pre =
 
     # COMMON SETUP (CURRENT PYVISTA VERSION INSTALLATION)
     uv pip install --upgrade {tox_root} --project {tox_root} --group pinned
+    # Runs from tox_root, so this imports the source tree; it has to come after the
+    # install above so the tree's dependencies (e.g. pyvista-validation) are present.
+    mne: python -c "import pyvista; assert not pyvista.OFF_SCREEN, f'{pyvista.OFF_SCREEN=} should be False'"
     {[testenv]software_report_cmdline}
 
     # EXTRA SOFTWARE REPORTS


### PR DESCRIPTION
resolves #9046

Follow-ups to #8979, which moved the validation package out to `pyvista-validation`. Together these turn the post-merge Integration Tests run (https://github.com/pyvista/pyvista/actions/runs/33639370560) green.

**1. Fix the `mne` integration failure.** `integration-mne` runs `python -c "import pyvista; assert not pyvista.OFF_SCREEN"` from `tox_root`, so it imports the source tree rather than an installed package. That import now needs `pyvista-validation`, which the env only installs in the "COMMON SETUP" step — which came *after* the check. Moving the check after the install fixes it, and the check now runs against the fully set-up environment. Verified live on this branch: `mne` green on both the push and PR paths.

**2. Forward `pyvista._validation` with a deprecation warning.** The module was private, but its API page was published in the stable docs (`api/core/_validation.html`), so a hard `AttributeError` on upgrade is worse than the underscore suggests. Accessing `pyvista._validation` (or `from pyvista import _validation`) now returns the `pyvista_validation` package and warns, following the `hexcolors` precedent in `pyvista.__getattr__`: uncached so the warning re-issues, with the usual 0.51/0.52 reminder guards. The deep `pyvista.core._validation` import form was never a supported path and is not forwarded. A GitHub-wide search found exactly one third-party consumer (`camp-lab-tud/permeate`, 0 stars, uses the deep form); nothing in the pyvista ecosystem uses it.

**3. Bump the exact pin to `pyvista-validation==0.1.1`.** The `cvista` failure in that run was a bug in the package itself: its lazy VTK imports were hard-wired to `vtkmodules`, so under `PYVISTA_VTK_BACKEND=cvista` a cvista `vtkMatrix4x4` failed the `isinstance` check in `validate_transform4x4`. `0.1.1` resolves VTK classes through the active backend the same way `pyvista._vtk` does (pyvista/pyvista-validation#14, verified against real cvista 9.7.0). This is the exact-pin workflow doing its job: the package's own CI ran PyVista's core suite against the fix before it was tagged.

The earlier `playwright` failure on this branch was unrelated infrastructure — a 3-minute retry timeout expiring inside `playwright install --with-deps` on a cold runner image, after which `nick-fields/retry` crashed with `kill EPERM` instead of retrying; it passed on the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
