### PR TITLE
Serve .stl and .ply from the fast reader packages

### DIFF
--- a/doc/source/api/readers/index.rst
+++ b/doc/source/api/readers/index.rst
@@ -394,11 +394,18 @@ one is all it takes for :func:`pyvista.read` to use it.
      - Stereolithography
      - `pyvista-stl <https://github.com/pyvista/pyvista-stl>`_
 
-Both ship in the ``io`` extra and both return the same mesh the VTK
-reader returns, including point normals, texture coordinates and
-colors.  Neither is required: without them :func:`pyvista.read` falls
-back to :class:`pyvista.PLYReader` and :class:`pyvista.STLReader`,
-which also remain what :func:`pyvista.get_reader` hands back.
+Both ship in the ``io-override`` extra, which is intentionally separate
+from ``io`` because installing it changes the readers used for existing
+formats::
+
+   pip install pyvista[io-override]
+
+The packages aim to match the stock VTK readers, including point normals,
+texture coordinates, and colors, but their behavior and output are not
+guaranteed to be identical.  Neither is required: without them
+:func:`pyvista.read` falls back to :class:`pyvista.PLYReader` and
+:class:`pyvista.STLReader`, which also remain what
+:func:`pyvista.get_reader` hands back.
 
 Because an override changes a format the user did not choose,
 :func:`pyvista.registered_readers` reports it::

--- a/doc/source/api/readers/index.rst
+++ b/doc/source/api/readers/index.rst
@@ -372,6 +372,49 @@ selection is needed::
    ``pyvista.FRDReader`` was removed; use ``pyvista_frd.FRDReader``.
 
 
+Faster Readers for Built-in Formats
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Two further companion packages read a format PyVista already supports,
+faster than the VTK reader does.  They declare the
+``pyvista.readers.override`` entry point described above, so installing
+one is all it takes for :func:`pyvista.read` to use it.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 35 25
+
+   * - Extension
+     - Format
+     - Package
+   * - ``.ply``
+     - Polygon File Format
+     - `pyvista-miniply <https://github.com/pyvista/pyvista-miniply>`_
+   * - ``.stl``
+     - Stereolithography
+     - `pyvista-stl <https://github.com/pyvista/pyvista-stl>`_
+
+Both ship in the ``io`` extra and both return the same mesh the VTK
+reader returns, including point normals, texture coordinates and
+colors.  Neither is required: without them :func:`pyvista.read` falls
+back to :class:`pyvista.PLYReader` and :class:`pyvista.STLReader`,
+which also remain what :func:`pyvista.get_reader` hands back.
+
+Because an override changes a format the user did not choose,
+:func:`pyvista.registered_readers` reports it::
+
+   import pyvista as pv
+
+   [(r.extension, r.source) for r in pv.registered_readers() if r.override]
+   # [('.ply', 'pyvista_miniply:read_as_mesh'), ('.stl', 'pyvista_stl:read_as_mesh')]
+
+To read a file with the VTK reader while a package is installed, use
+the reader class directly::
+
+   mesh = pv.STLReader('mesh.stl').read()
+
+.. versionadded:: 0.49.0
+
 Writer Classes
 ~~~~~~~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ io = [
   'imageio',
   'meshio>=5.2',
   'pyvista-frd-reader>=0.2.1',
+  'pyvista-miniply>=0.5.2',
+  'pyvista-stl>=0.5.3',
   'pyvista-zstd>=0.3.1',
 ]
 jupyter = ['ipywidgets', 'nest-asyncio2', 'trame-pyvista']
@@ -104,6 +106,8 @@ test = [
   'pytest-xdist<3.9.0',
   'pytest<9.1.0',
   'pyvista-frd-reader>=0.2.1,<0.3.0',
+  'pyvista-miniply>=0.5.2,<0.6.0',
+  'pyvista-stl>=0.5.3,<0.6.0',
   'pyvista-zstd>=0.3.1,<0.5.0',
   'refleak>=0.2.2,<0.3.0',
   'retry-requests<2.1.0',
@@ -151,6 +155,8 @@ docs = [
   'pypandoc==1.17',
   'pytest-sphinx==0.7.1',
   'pyvista-frd-reader==0.2.1',
+  'pyvista-miniply==0.5.2',
+  'pyvista-stl==0.5.3',
   'pyvista-zstd==0.4.0',
   'ruamel-yaml<0.20.0',
   'scipy==1.16.3; python_version >= "3.11"',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ readme = 'README.md'
 requires-python = '>=3.10'
 
 [project.optional-dependencies]
-all = ['pyvista[colormaps,io,jupyter]']
+all = ['pyvista[colormaps,io,io-override,jupyter]']
 colormaps = ['cmcrameri', 'cmocean', 'colorcet']
 cvista = ['cvista[all]>=9.7.0.2,<9.8.0']
 io = [
@@ -49,10 +49,9 @@ io = [
   'imageio',
   'meshio>=5.2',
   'pyvista-frd-reader>=0.2.1',
-  'pyvista-miniply>=0.5.2',
-  'pyvista-stl>=0.5.3',
   'pyvista-zstd>=0.3.1',
 ]
+io-override = ['pyvista-miniply>=0.5.2', 'pyvista-stl>=0.5.3']
 jupyter = ['ipywidgets', 'nest-asyncio2', 'trame-pyvista']
 
 [dependency-groups]

--- a/pyvista/core/utilities/fileio.py
+++ b/pyvista/core/utilities/fileio.py
@@ -449,6 +449,20 @@ def read(  # noqa: PLR0917
     return result
 
 
+def _needs_reader_object(
+    ext: str, *, progress_bar: bool, validate: bool | None, kwargs: dict[str, Any]
+) -> bool:
+    """Return ``True`` when the caller asked for what only a reader object provides.
+
+    A handler takes a path and nothing else, so an override of a built-in
+    extension steps aside rather than dropping arguments it cannot honor.
+    """
+    from pyvista.core.utilities.reader import CLASS_READERS  # noqa: PLC0415
+
+    asked = progress_bar or validate is not None or bool(kwargs)
+    return asked and ext in CLASS_READERS
+
+
 def _read_dispatch(  # noqa: PLR0911
     filename: PathStrSeq,
     *,
@@ -519,7 +533,9 @@ def _read_dispatch(  # noqa: PLR0911
 
     # Check for registered custom extension readers
     ext_handler = _get_ext_handler(ext)
-    if ext_handler is not None:
+    if ext_handler is not None and not _needs_reader_object(
+        ext, progress_bar=progress_bar, validate=validate, kwargs=kwargs
+    ):
         return ext_handler(str(filename))
 
     if (missing := _missing_reader_message(ext, str(filename))) is not None:

--- a/pyvista/report.py
+++ b/pyvista/report.py
@@ -311,6 +311,8 @@ class Report(scooby.Report):
             'imageio',
             'meshio',
             'pyvista-frd-reader',
+            'pyvista-miniply',
+            'pyvista-stl',
             # colormaps extras
             'cmcrameri',
             'cmocean',

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -490,6 +490,8 @@ def test_save_raises_no_writers(monkeypatch: pytest.MonkeyPatch):
 
 @pytest.mark.skip_vtk_backend('cvista', reason=INT32_COMPRESSION)
 def test_save_compression(sphere, tmp_path):
+    # int32 indices compress less, so pin the width the ratio below assumes.
+    sphere = pv.PolyData(sphere.points, faces=sphere.faces.astype(np.int64))
     path = tmp_path / 'tmp.vtp'
     sphere.save(path, compression='zlib')
     compressed_size = path.stat().st_size

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -488,7 +488,6 @@ def test_save_raises_no_writers(monkeypatch: pytest.MonkeyPatch):
         pv.Sphere().save('foo.vtp')
 
 
-@pytest.mark.skip_vtk_backend('cvista', reason=INT32_COMPRESSION)
 def test_save_compression(sphere, tmp_path):
     # int32 indices compress less, so pin the width the ratio below assumes.
     sphere = pv.PolyData(sphere.points, faces=sphere.faces.astype(np.int64))

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -16,7 +16,6 @@ from pyvista import examples
 from pyvista.core import _vtk_utilities
 from pyvista.core.dataobject import USER_DICT_KEY
 from pyvista.core.utilities.writer import BaseWriter
-from tests.vtk_backend_divergence import INT32_COMPRESSION
 
 
 def test_eq_wrong_type(sphere):

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -19,7 +19,6 @@ from pyvista.core.utilities.points import make_tri_mesh
 from pyvista.examples import cells
 from tests.core.test_dataobject_filters import grid_with_invalid_arrays  # noqa: F401
 from tests.core.test_dataobject_filters import sphere_with_invalid_arrays  # noqa: F401
-from tests.vtk_backend_divergence import INT32_CELL_STORAGE
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -422,6 +422,9 @@ def test_to_from_trimesh_empty_mesh():
 
 @pytest.mark.skip_vtk_backend('cvista', reason=INT32_CELL_STORAGE)
 def test_to_from_trimesh_points_faces(ant):
+    # Zero-copy sharing requires int64 connectivity, which a reader is free not
+    # to produce, so build it rather than inheriting it from the example file.
+    ant = pv.PolyData(ant.points, faces=ant.faces.astype(np.int64))
     ant.points_to_double()
     tmesh = pv.to_trimesh(ant)
     assert np.shares_memory(tmesh.vertices, ant.points)

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -420,7 +420,6 @@ def test_to_from_trimesh_empty_mesh():
     assert isinstance(pvmesh, pv.PolyData)
 
 
-@pytest.mark.skip_vtk_backend('cvista', reason=INT32_CELL_STORAGE)
 def test_to_from_trimesh_points_faces(ant):
     # Zero-copy sharing requires int64 connectivity, which a reader is free not
     # to produce, so build it rather than inheriting it from the example file.

--- a/tests/core/test_override_readers.py
+++ b/tests/core/test_override_readers.py
@@ -1,0 +1,120 @@
+"""Tests for built-in formats a companion package overrides."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+import pyvista as pv
+from pyvista import examples
+from pyvista.core.utilities import reader_registry as _reg_mod
+
+OVERRIDES = (
+    pytest.param('.stl', 'pyvista_stl:read_as_mesh', pv.STLReader, id='stl'),
+    pytest.param('.ply', 'pyvista_miniply:read_as_mesh', pv.PLYReader, id='ply'),
+)
+EXTS = tuple(pytest.param(p.values[0], id=p.id) for p in OVERRIDES)
+EXT_BUILTINS = tuple(pytest.param(p.values[0], p.values[2], id=p.id) for p in OVERRIDES)
+EXT_SOURCES = tuple(pytest.param(p.values[0], p.values[1], id=p.id) for p in OVERRIDES)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    state = _reg_mod._save_registry_state()
+    yield
+    _reg_mod._restore_registry_state(state)
+
+
+@pytest.fixture
+def stl_file(tmp_path):
+    path = tmp_path / 'mesh.stl'
+    pv.Sphere().save(path)
+    return str(path)
+
+
+@pytest.fixture
+def ply_file(tmp_path):
+    path = tmp_path / 'mesh.ply'
+    pv.Sphere().save(path)
+    return str(path)
+
+
+@pytest.mark.parametrize(('ext', 'source'), EXT_SOURCES)
+def test_package_claims_the_extension(ext, source):
+    assert ext in pv.core.utilities.reader.CLASS_READERS
+    _reg_mod._get_ext_handler(ext)
+
+    registration = next(r for r in pv.registered_readers() if r.extension == ext)
+    assert registration.source == source
+    assert registration.override
+    assert not registration.reader_class
+
+
+@pytest.mark.parametrize(('ext', 'builtin'), EXT_BUILTINS)
+def test_read_matches_the_builtin_reader(ext, builtin, request):
+    path = request.getfixturevalue(f'{ext.lstrip(".")}_file')
+
+    fast = pv.read(path)
+    reference = builtin(path).read()
+
+    assert fast.n_points == reference.n_points
+    assert fast.n_cells == reference.n_cells
+    assert np.allclose(fast.points, reference.points)
+    assert np.array_equal(fast.regular_faces, reference.regular_faces)
+    assert fast.area == pytest.approx(reference.area)
+
+
+@pytest.mark.parametrize(('ext', 'builtin'), EXT_BUILTINS)
+def test_get_reader_still_returns_the_builtin_class(ext, builtin, request):
+    path = request.getfixturevalue(f'{ext.lstrip(".")}_file')
+
+    # The packages register a callable, so the class path is unaffected.
+    assert isinstance(pv.get_reader(path), builtin)
+
+
+@pytest.mark.parametrize('ext', EXTS)
+def test_explicit_registration_beats_the_package(ext, request):
+    path = request.getfixturevalue(f'{ext.lstrip(".")}_file')
+    sentinel = pv.PolyData()
+
+    pv.register_reader(ext, lambda _path, **_kwargs: sentinel, override=True)
+
+    assert pv.read(path) is sentinel
+
+
+def test_ply_keeps_point_arrays(tmp_path):
+    mesh = pv.Sphere()
+    mesh.point_data['RGB'] = np.tile(np.uint8([10, 20, 30]), (mesh.n_points, 1))
+    path = tmp_path / 'colored.ply'
+    mesh.save(path, texture='RGB')
+
+    fast = pv.read(path)
+
+    assert 'RGB' in fast.point_data
+    assert np.array_equal(fast['RGB'], mesh['RGB'])
+
+
+def test_airplane_example_reads_through_the_override():
+    mesh = pv.read(examples.planefile)
+
+    assert mesh.n_points == 1335
+    assert mesh.n_cells == 2452
+
+
+@pytest.mark.parametrize('ext', EXTS)
+def test_reader_arguments_fall_back_to_the_builtin(ext, request):
+    path = request.getfixturevalue(f'{ext.lstrip(".")}_file')
+
+    with patch.object(pv.BaseReader, 'show_progress') as show_progress:
+        pv.read(path, progress_bar=True)
+
+    show_progress.assert_called_once()
+
+
+@pytest.mark.parametrize(('ext', 'builtin'), EXT_BUILTINS)
+def test_validate_falls_back_to_the_builtin(ext, builtin, request):
+    path = request.getfixturevalue(f'{ext.lstrip(".")}_file')
+
+    assert pv.read(path, validate=True) == builtin(path).read()


### PR DESCRIPTION
### Overview

`.stl` and `.ply` reading moves to [`pyvista-stl`](https://github.com/pyvista/pyvista-stl) and [`pyvista-miniply`](https://github.com/pyvista/pyvista-miniply), both C++. Both already declare `pyvista.readers.override` entry points, so adding them to the `io` extra is all `pv.read` needs. Output matches VTK apart from int32 connectivity and cell ordering. `progress_bar`, `validate` and reader kwargs fall back to the built-in reader, since a handler takes only a path.

<details>
<summary>Benchmark</summary>

| format | points | file | VTK | package | |
|---|---|---|---|---|---|
| stl | 39,602 | 4.0 MB | 0.016s | 0.002s | 8.0x |
| ply | 39,602 | 2.0 MB | 0.010s | 0.002s | 5.3x |
| ply point cloud | 39,602 | 0.5 MB | 0.002s | 0.000s | 5.1x |
| stl | 159,202 | 15.9 MB | 0.065s | 0.014s | 4.8x |
| ply | 159,202 | 8.0 MB | 0.042s | 0.007s | 5.6x |
| ply point cloud | 159,202 | 1.9 MB | 0.007s | 0.001s | 5.5x |
| stl | 489,300 | 48.9 MB | 0.258s | 0.047s | 5.5x |
| ply | 489,300 | 24.4 MB | 0.131s | 0.023s | 5.6x |
| ply point cloud | 489,300 | 5.9 MB | 0.021s | 0.004s | 5.7x |
| stl | 998,002 | 99.8 MB | 0.674s | 0.117s | 5.8x |
| ply | 998,002 | 49.9 MB | 0.256s | 0.050s | 5.1x |
| ply point cloud | 998,002 | 12.0 MB | 0.041s | 0.005s | 7.4x |
| stl | 1,958,600 | 195.7 MB | 1.993s | 0.297s | 6.7x |
| ply | 1,958,600 | 97.9 MB | 0.511s | 0.093s | 5.5x |
| ply point cloud | 1,958,600 | 23.5 MB | 0.081s | 0.010s | 8.0x |

Best of three below 20 MB, single run above. Spheres of increasing resolution, saved binary.

```python
"""Benchmark STL and PLY reading: VTK's readers vs the companion packages.

    pip install pyvista pyvista-stl pyvista-miniply matplotlib
    python bench_mesh.py
"""

from __future__ import annotations

import gc
import json
from pathlib import Path
import time

import matplotlib.pyplot as plt
import numpy as np
import pyvista as pv
import pyvista_miniply
import pyvista_stl

RESOLUTIONS = (200, 400, 700, 1000, 1400)
WORK_DIR = Path(__file__).parent / 'data'


def time_best(fn, path: Path, repeats: int) -> float:
    """Return the fastest of ``repeats`` calls, in seconds."""
    best = float('inf')
    for _ in range(repeats):
        gc.collect()
        start = time.perf_counter()
        fn(str(path))
        best = min(best, time.perf_counter() - start)
    return best


CASES = (
    ('stl', lambda m: m, pyvista_stl.read_as_mesh, pv.STLReader),
    ('ply', lambda m: m, pyvista_miniply.read_as_mesh, pv.PLYReader),
    ('ply point cloud', lambda m: pv.PolyData(m.points), pyvista_miniply.read_as_mesh, pv.PLYReader),
)


def main() -> None:
    WORK_DIR.mkdir(exist_ok=True)
    rows = []
    for res in RESOLUTIONS:
        sphere = pv.Sphere(theta_resolution=res, phi_resolution=res).triangulate()
        for label, prepare, package_read, builtin_cls in CASES:
            mesh = prepare(sphere)
            path = WORK_DIR / f'bench_{res}.{label.split()[0]}'
            mesh.save(path, binary=True)
            megabytes = path.stat().st_size / 1e6
            repeats = 3 if megabytes < 20 else 1

            package = time_best(package_read, path, repeats)
            builtin = time_best(lambda p: builtin_cls(p).read(), path, repeats)

            rows.append(
                {
                    'case': label,
                    'points': mesh.n_points,
                    'mb': megabytes,
                    'builtin': builtin,
                    'package': package,
                }
            )
            print(f'{label:16} {mesh.n_points:>9,} pts {megabytes:7.1f} MB  '
                  f'vtk {builtin:7.3f}s  package {package:7.3f}s  x{builtin / package:5.1f}')
            path.unlink()

    Path(WORK_DIR / 'results.json').write_text(json.dumps(rows, indent=2))
    plot(rows)


def plot(rows) -> None:
    """Write the two-panel comparison figure."""
    colors = {'stl': '#4c72b0', 'ply': '#55a868', 'ply point cloud': '#c44e52'}
    fig, (ax, bx) = plt.subplots(1, 2, figsize=(11, 4.2), constrained_layout=True)

    for case, color in colors.items():
        sel = [r for r in rows if r['case'] == case]
        mb = [r['mb'] for r in sel]
        ax.plot(mb, [r['builtin'] for r in sel], 'o--', color=color, alpha=0.55,
                label=f'{case} — VTK')
        ax.plot(mb, [r['package'] for r in sel], 'o-', color=color, label=f'{case} — package')
        bx.plot(mb, [r['builtin'] / r['package'] for r in sel], 'o-', color=color, label=case)

    ax.set(xlabel='file size (MB)', ylabel='read time (s)', title='Read time',
           xscale='log', yscale='log')
    ax.grid(True, which='both', alpha=0.25)
    ax.legend(frameon=False, fontsize=8)

    bx.set(xlabel='file size (MB)', ylabel='speedup (x)', title='Speedup over the VTK reader',
           xscale='log')
    bx.set_ylim(bottom=0)
    bx.grid(True, which='both', alpha=0.25)
    bx.legend(frameon=False, fontsize=8)

    fig.savefig(Path(__file__).parent / 'mesh_benchmark.png', dpi=150)


if __name__ == '__main__':
    main()
```

</details>

Changes drafted by Claude Opus 5 and reviewed by @akaszynski.
