### PR TITLE
ci: Move VTK-dev coverage to its own Codecov flags

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -372,8 +372,8 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [Linux, VTK-dev]
     # `always()` ensures this still runs when VTK-dev is skipped because the
-    # 'vtk-dev-testing' label is not applied. When VTK-dev does run, its
-    # coverage artifacts get bundled into this single CodeCov upload.
+    # 'vtk-dev-testing' label is not applied. When VTK-dev does run, its reports
+    # upload under their own flags.
     # Run on push/merge_group as well as pull_request so Codecov's
     # main-branch baseline keeps advancing with every merge.
     if: always() && needs.Linux.result == 'success'
@@ -396,13 +396,20 @@ jobs:
           path: coverage_reports
 
       # Each matrix cell contributes one report per side. Sorting them into their own
-      # directories lets each side upload under its own flag.
+      # directories lets each side upload under its own flag. VTK-dev is held apart from
+      # the pinned matrix because it runs only nightly and on labelled pull requests: a
+      # flag whose contents depend on which jobs ran cannot be compared across commits,
+      # and the tests VTK-dev alone executes then read as a coverage loss on any pull
+      # request whose base is a commit the nightly happened to cover. Pull the VTK-dev
+      # reports out first so the globs below match the pinned matrix only.
       - name: Sort reports by flag
         run: |
-          mkdir -p flag_package flag_tests
+          mkdir -p flag_package flag_tests flag_package_vtk_dev flag_tests_vtk_dev
+          find coverage_reports -name 'coverage_package_*vtk_dev.xml' -exec mv {} flag_package_vtk_dev/ \;
+          find coverage_reports -name 'coverage_tests_*vtk_dev.xml' -exec mv {} flag_tests_vtk_dev/ \;
           find coverage_reports -name 'coverage_package_*.xml' -exec mv {} flag_package/ \;
           find coverage_reports -name 'coverage_tests_*.xml' -exec mv {} flag_tests/ \;
-          ls flag_package flag_tests
+          ls flag_package flag_tests flag_package_vtk_dev flag_tests_vtk_dev
 
       - name: Upload pyvista coverage to CodeCov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
@@ -417,6 +424,24 @@ jobs:
         with:
           directory: flag_tests
           flags: tests
+          fail_ci_if_error: true
+          use_oidc: true
+
+      - name: Upload pyvista coverage from VTK dev to CodeCov
+        if: needs.VTK-dev.result == 'success'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
+        with:
+          directory: flag_package_vtk_dev
+          flags: package-vtk-dev
+          fail_ci_if_error: true
+          use_oidc: true
+
+      - name: Upload test coverage from VTK dev to CodeCov
+        if: needs.VTK-dev.result == 'success'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
+        with:
+          directory: flag_tests_vtk_dev
+          flags: tests-vtk-dev
           fail_ci_if_error: true
           use_oidc: true
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -396,12 +396,9 @@ jobs:
           path: coverage_reports
 
       # Each matrix cell contributes one report per side. Sorting them into their own
-      # directories lets each side upload under its own flag. VTK-dev is held apart from
-      # the pinned matrix because it runs only nightly and on labelled pull requests: a
-      # flag whose contents depend on which jobs ran cannot be compared across commits,
-      # and the tests VTK-dev alone executes then read as a coverage loss on any pull
-      # request whose base is a commit the nightly happened to cover. Pull the VTK-dev
-      # reports out first so the globs below match the pinned matrix only.
+      # directories lets each side upload under its own flag. VTK-dev is matched first
+      # and flagged apart, since it runs only nightly and a flag whose set of jobs varies
+      # cannot be compared across commits.
       - name: Sort reports by flag
         run: |
           mkdir -p flag_package flag_tests flag_package_vtk_dev flag_tests_vtk_dev

--- a/codecov.yml
+++ b/codecov.yml
@@ -56,9 +56,6 @@ coverage:
 
 # `pyvista` and `tests` are uploaded as separate reports (see the upload job in
 # .github/workflows/testing-and-deployment.yml), one XML per side per matrix cell.
-# The `package` and `tests` flags carry the pinned Linux matrix and nothing else, so a
-# commit's report for them does not depend on which optional jobs ran. That is what lets
-# the statuses above compare a pull request against `main` at `threshold: 0%`.
 flag_management:
   individual_flags:
     - name: package
@@ -67,11 +64,9 @@ flag_management:
     - name: tests
       paths:
         - tests/
-    # VTK-dev runs nightly and on labelled pull requests only, so these two are absent
-    # from most commits. `carryforward` reuses the last run's report instead of reporting
-    # the lines it alone covers as uncovered -- the VTK >= 9.8 half of tests/plotting/
-    # test_gc.py runs nowhere else. No status is attached to either flag, so a stale
-    # carry-forward can inform the report without ever gating a pull request.
+    # Flagged apart from the two above so the statuses compare a fixed set of jobs.
+    # VTK-dev runs only nightly, so `carryforward` keeps the lines it alone covers from
+    # reading as uncovered; no status is attached, so a stale carry-forward cannot gate.
     - name: package-vtk-dev
       carryforward: true
       paths:

--- a/codecov.yml
+++ b/codecov.yml
@@ -56,11 +56,27 @@ coverage:
 
 # `pyvista` and `tests` are uploaded as separate reports (see the upload job in
 # .github/workflows/testing-and-deployment.yml), one XML per side per matrix cell.
+# The `package` and `tests` flags carry the pinned Linux matrix and nothing else, so a
+# commit's report for them does not depend on which optional jobs ran. That is what lets
+# the statuses above compare a pull request against `main` at `threshold: 0%`.
 flag_management:
   individual_flags:
     - name: package
       paths:
         - pyvista/
     - name: tests
+      paths:
+        - tests/
+    # VTK-dev runs nightly and on labelled pull requests only, so these two are absent
+    # from most commits. `carryforward` reuses the last run's report instead of reporting
+    # the lines it alone covers as uncovered -- the VTK >= 9.8 half of tests/plotting/
+    # test_gc.py runs nowhere else. No status is attached to either flag, so a stale
+    # carry-forward can inform the report without ever gating a pull request.
+    - name: package-vtk-dev
+      carryforward: true
+      paths:
+        - pyvista/
+    - name: tests-vtk-dev
+      carryforward: true
       paths:
         - tests/


### PR DESCRIPTION
### Overview

`codecov/project/tests` keeps failing on pull requests that touch nothing related, most recently #9060 and #9063. Both branch from 00ebcfa, and the only indirect change Codecov reports is `tests/plotting/test_gc.py` at -27.69%.

The `package` and `tests` flags are assembled from whatever coverage artifacts a run produced, and VTK-dev feeds them while running only on the nightly schedule and on branches labelled `vtk-dev-testing`. `test_gc.py` gates two tests on VTK >= 9.8, which no pinned matrix cell provides, so their 18 statements are covered on the one commit a day the nightly lands on and uncovered everywhere else. That is the whole -0.05% that trips `threshold: 0%`. This sends the VTK-dev reports to their own `package-vtk-dev` and `tests-vtk-dev` flags so the gating flags carry the pinned matrix and nothing else.

`carryforward` keeps those 18 lines counted on commits where the job did not run, at the cost of going stale between nightlies, so neither new flag has a status attached. I preferred that to raising the `tests` threshold, which would hide real regressions to absorb a 0.05% artifact, and to running VTK-dev on every pull request. `carryforward` on `tests` itself does nothing here, since that flag is uploaded on every commit and only its contents vary. This branch is based on a932b240, which the nightly did not cover, so the comparison should be clean; a rebase onto a nightly commit would show the drop one last time.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
