### PR TITLE
Remove test-only `vtkPassArrays` import

### DIFF
--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -397,7 +397,6 @@ _CORE_MODULES: dict[str, tuple[str, ...]] = {
         'vtkGradientFilter',
         'vtkIntersectionPolyDataFilter',
         'vtkOBBTree',
-        'vtkPassArrays',
         'vtkRectilinearGridToPointSet',
         'vtkRectilinearGridToTetrahedra',
         'vtkRemovePolyData',

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -135,12 +135,13 @@ def test_interpolate_raises(strategy):
 
 def test_get_output_restores_field_data(sphere):
     sphere.field_data['data'] = np.arange(3)
-    alg = _vtk.vtkPassArrays()
+    alg = _vtk.vtkTriangleFilter()
     alg.SetInputDataObject(sphere)
-    alg.UseFieldTypesOn()
-    alg.AddFieldType(_vtk.vtkDataObject.FIELD)
     alg.Update()
-    assert alg.GetOutputDataObject(0).GetFieldData().GetNumberOfArrays() == 0
+    vtk_output = alg.GetOutputDataObject(0)
+    vtk_output.GetFieldData().Initialize()
+    assert 'data' in sphere.field_data
+    assert vtk_output.GetFieldData().GetNumberOfArrays() == 0
     output = _get_output(alg)
     assert np.array_equal(output.field_data['data'], np.arange(3))
 


### PR DESCRIPTION
### Overview

`vtkPassArrays` was added in #9043 only to exercise field-data restoration in `_get_output`. Use the already-available `vtkTriangleFilter` and clear its output field data directly, avoiding an otherwise-unused lazy VTK import.

🤖 Generated with [OpenAI Codex](https://openai.com/codex/)
