### PR TITLE
ci: Stop cron and manual runs cancelling merges

### DIFF
--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -11,7 +11,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Runs started by the schedule or by hand never cancel an in-progress run, so a merge to
+  # `main` always finishes; they queue behind it, and are dropped if another merge arrives.
+  cancel-in-progress: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,9 @@ on: # zizmor: ignore[cache-poisoning]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Runs started by the schedule or by hand never cancel an in-progress run, so a merge to
+  # `main` always finishes; they queue behind it, and are dropped if another merge arrives.
+  cancel-in-progress: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
 
 permissions:
   id-token: none

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,7 +13,9 @@ on: # zizmor: ignore[cache-poisoning]
       - "maint/integration*"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # The nightly run and a push to `main` share a ref, so the event name keeps a merge
+  # from cancelling the nightly and the nightly from cancelling a merge.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,10 +13,10 @@ on: # zizmor: ignore[cache-poisoning]
       - "maint/integration*"
 
 concurrency:
-  # The nightly run and a push to `main` share a ref, so the event name keeps a merge
-  # from cancelling the nightly and the nightly from cancelling a merge.
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Runs started by the schedule or by hand never cancel an in-progress run, so a merge to
+  # `main` always finishes; they queue behind it, and are dropped if another merge arrives.
+  cancel-in-progress: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
 
 env:
   ALLOW_PLOTTING: true

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -5,8 +5,6 @@ on: # zizmor: ignore[cache-poisoning]
   pull_request:
   merge_group:
   workflow_dispatch:
-  schedule:
-    - cron: "0 4 * * *"
   push:
     tags:
       - "*"
@@ -14,7 +12,9 @@ on: # zizmor: ignore[cache-poisoning]
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # A manual run on `main` shares a ref with a push to `main`, so the event name
+  # keeps a merge from cancelling it and it from cancelling a merge.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 env:
@@ -227,9 +227,9 @@ jobs:
           twine check --strict dist/*
 
   VTK-dev:
-    # For PRs, only run this job if the 'vtk-dev-testing' label is applied
+    # Runs on manual dispatch, and on PRs carrying the 'vtk-dev-testing' label
     if: |
-      (github.event_name != 'pull_request' && github.event_name != 'push' && github.event_name != 'merge_group') ||
+      github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'vtk-dev-testing')
     name: Linux VTK Dev Testing
     permissions:
@@ -397,8 +397,8 @@ jobs:
 
       # Each matrix cell contributes one report per side. Sorting them into their own
       # directories lets each side upload under its own flag. VTK-dev is matched first
-      # and flagged apart, since it runs only nightly and a flag whose set of jobs varies
-      # cannot be compared across commits.
+      # and flagged apart, since it runs only on labelled PRs and a flag whose set of
+      # jobs varies cannot be compared across commits.
       - name: Sort reports by flag
         run: |
           mkdir -p flag_package flag_tests flag_package_vtk_dev flag_tests_vtk_dev

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -5,6 +5,8 @@ on: # zizmor: ignore[cache-poisoning]
   pull_request:
   merge_group:
   workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
   push:
     tags:
       - "*"
@@ -12,10 +14,10 @@ on: # zizmor: ignore[cache-poisoning]
       - main
 
 concurrency:
-  # A manual run on `main` shares a ref with a push to `main`, so the event name
-  # keeps a merge from cancelling it and it from cancelling a merge.
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Runs started by the schedule or by hand never cancel an in-progress run, so a merge to
+  # `main` always finishes; they queue behind it, and are dropped if another merge arrives.
+  cancel-in-progress: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
 
 env:
   ALLOW_PLOTTING: true
@@ -397,8 +399,8 @@ jobs:
 
       # Each matrix cell contributes one report per side. Sorting them into their own
       # directories lets each side upload under its own flag. VTK-dev is matched first
-      # and flagged apart, since it runs only on labelled PRs and a flag whose set of
-      # jobs varies cannot be compared across commits.
+      # and flagged apart, since it runs only on demand and a flag whose set of jobs
+      # varies cannot be compared across commits.
       - name: Sort reports by flag
         run: |
           mkdir -p flag_package flag_tests flag_package_vtk_dev flag_tests_vtk_dev

--- a/codecov.yml
+++ b/codecov.yml
@@ -65,8 +65,8 @@ flag_management:
       paths:
         - tests/
     # Flagged apart from the two above so the statuses compare a fixed set of jobs.
-    # VTK-dev runs only nightly, so `carryforward` keeps the lines it alone covers from
-    # reading as uncovered; no status is attached, so a stale carry-forward cannot gate.
+    # VTK-dev runs only on labelled PRs, so `carryforward` keeps the lines it alone covers
+    # from reading as uncovered; no status is attached, so a stale carry-forward cannot gate.
     - name: package-vtk-dev
       carryforward: true
       paths:

--- a/codecov.yml
+++ b/codecov.yml
@@ -65,8 +65,8 @@ flag_management:
       paths:
         - tests/
     # Flagged apart from the two above so the statuses compare a fixed set of jobs.
-    # VTK-dev runs only on labelled PRs, so `carryforward` keeps the lines it alone covers
-    # from reading as uncovered; no status is attached, so a stale carry-forward cannot gate.
+    # VTK-dev runs only on demand, so `carryforward` keeps the lines it alone covers from
+    # reading as uncovered; no status is attached, so a stale carry-forward cannot gate.
     - name: package-vtk-dev
       carryforward: true
       paths:


### PR DESCRIPTION
### Overview

Resolves #9066.

`cancel-in-progress` is evaluated on the incoming run, so an expression is enough to make this one-directional: a run started by a cron or by hand no longer cancels anything and queues behind an in-progress run instead. A merge to `main` still cancels an earlier merge, and a PR push still cancels its own PR runs. A merge landing while a nightly waits drops the nightly, since GitHub replaces a pending run when a newer one arrives, so a busy merge window skips the nightly rather than doubling up on runners.

The same block is in four workflows that run on both a push to `main` and a cron or a manual dispatch, so all four get the same clause. `docker-package.yml` has no cron today, but stating the rule the same way in each keeps a cron added later from quietly reopening this.

`Linux VTK Dev Testing` also comes off the nightly: `vtk-master-wheels.yml` covers the same ground from further ahead, and it is more useful on demand, which is what its label is for. Everything else in the nightly stays.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
