### PR TITLE
ci: Pass Codecov defaults when the base has no report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,10 +9,16 @@ comment: false
 coverage:
   status:
     project:
+      # A base report that does not exist yet is not the pull request's fault. A PR
+      # stacked on another PR's branch has nothing to compare against until that
+      # branch's own CI uploads, and never will if it does not; both defaults failed
+      # that way on #9074 while the flagged statuses below, already `success`, passed
+      # on the same commit. `if_no_uploads` and `if_ci_failed` still guard the head,
+      # and a real regression is still caught wherever a base report exists.
       default:
         target: auto
         threshold: 0.5%
-        if_not_found: failure
+        if_not_found: success
         if_ci_failed: error
         if_no_uploads: error
       # Scoped to the package so a gain under tests/ cannot absorb a loss here.
@@ -39,10 +45,11 @@ coverage:
         if_ci_failed: error
         if_no_uploads: error
     patch:
+      # `if_not_found: success` for the reason given on `project.default` above.
       default:
         target: auto
         threshold: 0.5%
-        if_not_found: failure
+        if_not_found: success
         if_ci_failed: error
         if_no_uploads: error
       tests:


### PR DESCRIPTION
### Overview

`codecov/project` and `codecov/patch` set `if_not_found: failure`, so a pull request stacked on another pull request's branch goes red on both until the base branch's own CI uploads a report, and stays red if it never does. #9074 is the case: both defaults failed with "No report found to compare against" while `codecov/project/tests`, `codecov/project/package` and `codecov/patch/tests` passed on the same commit, because those three already set `if_not_found: success`.

This brings the two defaults in line with the other three. `if_not_found` only applies when there is no base report to compare against, so no status that could have caught a regression stops doing so, and `if_no_uploads` and `if_ci_failed` still guard the head side.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
