### PR TITLE
Import VTK eagerly when building the gallery

### DIFF
--- a/pyvista/_vtk.py
+++ b/pyvista/_vtk.py
@@ -1006,3 +1006,10 @@ _SPECIAL_LOADERS: dict[str, Callable[[], type[Any]]] = {
     'vtkRenderPassCollection': _import_vtkRenderPassCollection,
     'vtkSequencePass': _import_vtkSequencePass,
 }
+
+
+# Handing Python a C++ object from a module that has not been imported binds that class
+# name to a base class for the rest of the process, so a documentation build -- whose
+# examples run in worker processes of their own -- resolves every class up front.
+if os.environ.get('PYVISTA_BUILDING_GALLERY', 'false').lower() == 'true':
+    import_all()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -311,6 +311,20 @@ def test_vtk_import_all_suppressed_ignores_failures(monkeypatch):
     assert calls == ['A', 'SpecialA']
 
 
+@pytest.mark.parametrize(('building_gallery', 'imported'), [('true', True), ('false', False)])
+def test_building_gallery_imports_vtk_eagerly(building_gallery, imported):
+    """A gallery build resolves every mapped VTK class when PyVista is imported."""
+    code = "from pyvista import _vtk; print('vtkOutlineFilter' in vars(_vtk))"
+    result = subprocess.run(
+        [sys.executable, '-c', code],
+        env={**os.environ, 'PYVISTA_BUILDING_GALLERY': building_gallery},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == str(imported)
+
+
 def test_validation_forward_deprecated():
     import pyvista_validation
 


### PR DESCRIPTION
### Overview

Resolves #8653.

Sphinx-Gallery runs every example in a joblib worker process, and those workers never execute `conf.py`, so the `_vtk.import_all()` there only ever covered the main process. That matters because a lazy import is not reversible: when VTK hands Python a C++ object whose module has not been imported, `vtkPythonUtil::GetObjectFromPointer` registers that class name against the nearest imported base class, and the later `PyVTKClass_Add` keeps the existing entry, so `vtkmodules.vtkFiltersModeling.vtkOutlineFilter` *becomes* `vtkPolyDataAlgorithm` for the rest of the process. `vtkImplicitPlaneWidget` owns an internal `vtkOutlineFilter`, which is enough to poison it — [failing job](https://github.com/pyvista/pyvista/actions/runs/33880684483/job/101048443280).

Resolving every mapped class when `PYVISTA_BUILDING_GALLERY` is set closes the window in the workers, which inherit the variable from the build that spawned them.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
