### PR TITLE
Fix `pyvista-plot` splitting at a commented `show`

### DIFF
--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -34,7 +34,8 @@ The source code for the plot may be included in one of two ways:
 .. note::
    A ``# doctest: +SKIP`` statement is not executed, but the rest of its code
    block still runs -- matching doctest -- so also mark any statement that
-   depends on a skipped one.
+   depends on a skipped one. Leaving one unmarked warns, which fails a build
+   run with sphinx's ``-W``.
 
 .. note::
    Animations will not be saved, only the last frame will be shown.
@@ -203,7 +204,7 @@ _logger = sphinx_logging.getLogger(__name__)
 _DOCTEST_SKIP_RE = re.compile(r'doctest:\s*\+SKIP')
 
 #: Matches a ``#`` comment, or, as group 1, a string literal that may contain one.
-_COMMENT_RE = re.compile(r"""('(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*")|[ \t]*\#[^\n]*""")
+_COMMENT_OR_STRING_RE = re.compile(r"""('(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*")|[ \t]*#[^\n]*""")
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -396,7 +397,7 @@ def _contains_pyvista_plot(text) -> bool:
 
 def _strip_comments(code):
     """Remove comments from a line of python code, leaving string literals alone."""
-    return _COMMENT_RE.sub(lambda match: match.group(1) or '', code)
+    return _COMMENT_OR_STRING_RE.sub(lambda match: match.group(1) or '', code)
 
 
 def _split_code_at_show(text):
@@ -642,10 +643,9 @@ def render_figures(
             except PlotError as error:
                 if filtered is None:
                     raise
-                # a failing remainder degrades to a warning; names bound so far stay usable
+                # the piece keeps the names it bound; the error already names the file
                 _logger.warning(
-                    '[pyvista-plot] statements alongside a "# doctest: +SKIP" failed in %s\n%s',
-                    code_path,
+                    '[pyvista-plot] statements alongside a "# doctest: +SKIP" failed.\n%s',
                     error,
                 )
 

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -202,6 +202,9 @@ _logger = sphinx_logging.getLogger(__name__)
 #: Matches a ``# doctest: +SKIP`` marker, any spacing.
 _DOCTEST_SKIP_RE = re.compile(r'doctest:\s*\+SKIP')
 
+#: Matches a ``#`` comment, or, as group 1, a string literal that may contain one.
+_COMMENT_RE = re.compile(r"""('(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*")|[ \t]*\#[^\n]*""")
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -392,8 +395,8 @@ def _contains_pyvista_plot(text) -> bool:
 
 
 def _strip_comments(code):
-    """Remove comments from a line of python code."""
-    return re.sub(r'(?m)^ *#.*\n?', '', code)
+    """Remove comments from a line of python code, leaving string literals alone."""
+    return _COMMENT_RE.sub(lambda match: match.group(1) or '', code)
 
 
 def _split_code_at_show(text):

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -639,13 +639,14 @@ def render_figures(
                     ns=ns,
                     function_name=function_name,
                 )
-            except PlotError:
+            except PlotError as error:
                 if filtered is None:
                     raise
                 # a failing remainder degrades to a log; names bound so far stay usable
                 _logger.info(
-                    '[pyvista-plot] statements alongside a "# doctest: +SKIP" failed in %s',
+                    '[pyvista-plot] statements alongside a "# doctest: +SKIP" failed in %s\n%s',
                     code_path,
+                    error,
                 )
 
             images = []

--- a/pyvista/ext/plot_directive.py
+++ b/pyvista/ext/plot_directive.py
@@ -642,8 +642,8 @@ def render_figures(
             except PlotError as error:
                 if filtered is None:
                     raise
-                # a failing remainder degrades to a log; names bound so far stay usable
-                _logger.info(
+                # a failing remainder degrades to a warning; names bound so far stay usable
+                _logger.warning(
                     '[pyvista-plot] statements alongside a "# doctest: +SKIP" failed in %s\n%s',
                     code_path,
                     error,

--- a/tests/ext/test_ext.py
+++ b/tests/ext/test_ext.py
@@ -206,7 +206,7 @@ def test_render_figures_degrades_when_the_filtered_remainder_raises(tmp_path, ca
     code = ">>> raise RuntimeError('kaboom')\n>>> boom()  # doctest: +SKIP\n"
     results = _render(code, tmp_path)
     assert len(results) == 1
-    assert any('doctest: +SKIP' in r.message for r in caplog.records)
+    assert any('doctest: +SKIP' in r.message and 'kaboom' in r.message for r in caplog.records)
 
 
 def test_render_figures_still_raises_for_a_piece_without_skips(tmp_path):

--- a/tests/ext/test_ext.py
+++ b/tests/ext/test_ext.py
@@ -142,6 +142,18 @@ def test_record_namespace_is_none_when_sphinx_autocodelink_unimportable(monkeypa
     assert plot_directive.record_namespace is not None
 
 
+def test_split_code_at_show_ends_a_piece_at_a_commented_show():
+    code = '>>> pl.show()  # doctest: +SKIP\n>>> pl = pv.Plotter()\n'
+    _, pieces = plot_directive._split_code_at_show(code)
+    assert pieces == ['>>> pl.show()  # doctest: +SKIP', '>>> pl = pv.Plotter()\n']
+
+
+def test_split_code_at_show_keeps_a_hash_inside_a_string():
+    code = ">>> mesh.plot(color='#ff0000')\n>>> a = 1\n"
+    _, pieces = plot_directive._split_code_at_show(code)
+    assert pieces == [">>> mesh.plot(color='#ff0000')", '>>> a = 1\n']
+
+
 DOCTEST_WITH_SKIP = '>>> a = 1\n>>> explode()  # doctest: +SKIP\n>>> b = 2\n'
 
 

--- a/tests/ext/test_ext.py
+++ b/tests/ext/test_ext.py
@@ -200,13 +200,13 @@ def _render(code, tmp_path):
     )
 
 
-def test_render_figures_degrades_when_the_filtered_remainder_raises(tmp_path, caplog):
-    # statements alongside a skip never ran before the filtering existed, so a failure
-    # among them logs instead of failing the build
+def test_render_figures_warns_when_the_filtered_remainder_raises(tmp_path, caplog):
+    # a failure among the statements alongside a skip warns rather than aborting the page
     code = ">>> raise RuntimeError('kaboom')\n>>> boom()  # doctest: +SKIP\n"
     results = _render(code, tmp_path)
     assert len(results) == 1
-    assert any('doctest: +SKIP' in r.message and 'kaboom' in r.message for r in caplog.records)
+    warnings = [record for record in caplog.records if record.levelname == 'WARNING']
+    assert any('doctest: +SKIP' in r.message and 'kaboom' in r.message for r in warnings)
 
 
 def test_render_figures_still_raises_for_a_piece_without_skips(tmp_path):

--- a/tests/ext/test_ext.py
+++ b/tests/ext/test_ext.py
@@ -148,10 +148,17 @@ def test_split_code_at_show_ends_a_piece_at_a_commented_show():
     assert pieces == ['>>> pl.show()  # doctest: +SKIP', '>>> pl = pv.Plotter()\n']
 
 
-def test_split_code_at_show_keeps_a_hash_inside_a_string():
-    code = ">>> mesh.plot(color='#ff0000')\n>>> a = 1\n"
+def test_split_code_at_show_ends_a_piece_at_a_comment_holding_a_quote():
+    code = ">>> pl.show()  # don't rely on this\n>>> pl = pv.Plotter()\n"
     _, pieces = plot_directive._split_code_at_show(code)
-    assert pieces == [">>> mesh.plot(color='#ff0000')", '>>> a = 1\n']
+    assert pieces == [">>> pl.show()  # don't rely on this", '>>> pl = pv.Plotter()\n']
+
+
+@pytest.mark.parametrize('quote', ["'", '"'])
+def test_split_code_at_show_keeps_a_hash_inside_a_string(quote):
+    show = f'>>> mesh.plot(color={quote}#ff0000{quote})'
+    _, pieces = plot_directive._split_code_at_show(f'{show}\n>>> a = 1\n')
+    assert pieces == [show, '>>> a = 1\n']
 
 
 DOCTEST_WITH_SKIP = '>>> a = 1\n>>> explode()  # doctest: +SKIP\n>>> b = 2\n'
@@ -200,8 +207,25 @@ def _render(code, tmp_path):
     )
 
 
+def test_render_figures_runs_the_example_after_a_skipped_show(tmp_path, caplog):
+    # the example after a skipped show binds its own plotter instead of the closed one
+    code = (
+        '>>> import pyvista as pv\n'
+        '>>> pl = pv.Plotter()\n'
+        '>>> pl.show()  # doctest: +SKIP\n'
+        '\n'
+        'Prose between the two examples.\n'
+        '\n'
+        '>>> pl = pv.Plotter()\n'
+        '>>> pl.enable_terrain_style()\n'
+        '>>> pl.show()  # doctest: +SKIP\n'
+    )
+    _render(code, tmp_path)
+    assert not [r for r in caplog.records if 'doctest: +SKIP' in r.message]
+
+
 def test_render_figures_warns_when_the_filtered_remainder_raises(tmp_path, caplog):
-    # a failure among the statements alongside a skip warns rather than aborting the page
+    # a failure among the statements alongside a skip warns instead of raising
     code = ">>> raise RuntimeError('kaboom')\n>>> boom()  # doctest: +SKIP\n"
     results = _render(code, tmp_path)
     assert len(results) == 1


### PR DESCRIPTION
### Overview

The [docs build](https://github.com/pyvista/pyvista/actions/runs/33839878737) reports `[pyvista-plot] statements alongside a "# doctest: +SKIP" failed` for both `enable_terrain_style` pages. `_strip_comments` only dropped whole-line comments, so `>>> pl.show()  # doctest:+SKIP` did not end in `)` and `_split_code_at_show` read it as an unterminated multi-line call — it kept consuming until the next line that did end in `)`, swallowing the following example's `>>> pl = pv.Plotter()` into the previous piece. The rest of that example then ran against the closed plotter from the piece before it.

Seven docstrings split differently now, none of them changing a generated image, since every `show`/`plot` call involved is itself skipped. The message also moves from info to a warning carrying the `PlotError` traceback, so `-W` fails the build on it instead of it passing unnoticed.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
