### PR TITLE
Fail when a VTK version gate can no longer change its result

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,6 +108,19 @@ pv.OFF_SCREEN = True
 
 PYVISTA_ROOT_DIR = Path(__file__).parent.parent
 
+_SKIP_PARTS = frozenset({'build', 'dist', '_build', '__pycache__', '.git'})
+
+
+def source_files(*directories: str) -> list[Path]:
+    """Return every Python file under the given directories of the repository."""
+    return [
+        path
+        for directory in directories
+        for path in sorted((PYVISTA_ROOT_DIR / directory).rglob('*.py'))
+        if _SKIP_PARTS.isdisjoint(path.relative_to(PYVISTA_ROOT_DIR).parts)
+    ]
+
+
 NUMPY_VERSION_INFO = VersionInfo(
     major=int(np.__version__.split('.')[0]),
     minor=int(np.__version__.split('.')[1]),

--- a/tests/test_import_conventions.py
+++ b/tests/test_import_conventions.py
@@ -12,18 +12,13 @@ from __future__ import annotations
 import ast
 import re
 import sys
-from typing import TYPE_CHECKING
 
 import pytest
 
 from tests.conftest import PYVISTA_ROOT_DIR
-
-if TYPE_CHECKING:
-    from collections.abc import Iterator
-    from pathlib import Path
+from tests.conftest import source_files
 
 SOURCE_DIRS = ('pyvista', 'tests', 'doc', 'examples')
-SKIP_PARTS = {'build', 'dist', '_build', '__pycache__', '.git'}
 
 # Aliased imports are an intentional escape hatch, so the modules only ever
 # reached that way are governed by neither list.
@@ -32,14 +27,6 @@ WAIVED = {
     'xml.dom.minidom',  # import xml.dom.minidom as md
     'xml.etree',  # from xml.etree import ElementTree as ET
 }
-
-
-def _iter_source_files() -> Iterator[Path]:
-    for directory in SOURCE_DIRS:
-        for path in sorted((PYVISTA_ROOT_DIR / directory).rglob('*.py')):
-            if not SKIP_PARTS.isdisjoint(path.parts):
-                continue
-            yield path
 
 
 def _namespace_modules() -> set[str]:
@@ -90,7 +77,7 @@ def _documented_member_modules() -> set[str]:
 def _imported_stdlib_modules() -> dict[str, set[str]]:
     """Map each imported stdlib module to the files importing it."""
     found: dict[str, set[str]] = {}
-    for path in _iter_source_files():
+    for path in source_files(*SOURCE_DIRS):
         try:
             tree = ast.parse(path.read_text(encoding='utf-8'))
         except SyntaxError:  # pragma: no cover

--- a/tests/test_vtk_version_gates.py
+++ b/tests/test_vtk_version_gates.py
@@ -10,13 +10,12 @@ import pytest
 
 import pyvista as pv
 from tests.conftest import PYVISTA_ROOT_DIR
+from tests.conftest import source_files
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from pathlib import Path
 
 SOURCE_DIRS = ('pyvista', 'tests')
-SKIP_PARTS = {'build', 'dist', '_build', '__pycache__', '.git'}
 
 _DEAD_AT_BOUND = (ast.Lt, ast.GtE)
 _DEAD_BELOW_BOUND = (ast.LtE, ast.Gt, ast.Eq, ast.NotEq)
@@ -31,14 +30,6 @@ _OPERATORS = {
     ast.Eq: operator.eq,
     ast.NotEq: operator.ne,
 }
-
-
-def _iter_source_files() -> Iterator[Path]:
-    """Yield every Python file in the scanned source directories."""
-    for directory in SOURCE_DIRS:
-        for path in sorted((PYVISTA_ROOT_DIR / directory).rglob('*.py')):
-            if SKIP_PARTS.isdisjoint(path.relative_to(PYVISTA_ROOT_DIR).parts):
-                yield path
 
 
 def _version_bound(node: ast.expr) -> tuple[int, ...] | None:
@@ -95,7 +86,7 @@ def test_no_dead_vtk_version_gates():
     """Every ``vtk_version_info`` comparison must still be able to go both ways."""
     dead = [
         f'{path.relative_to(PYVISTA_ROOT_DIR)}:{lineno}  {source}'
-        for path in _iter_source_files()
+        for path in source_files(*SOURCE_DIRS)
         for lineno, source in _dead_gates(ast.parse(path.read_text(encoding='utf-8')))
     ]
     assert not dead, (
@@ -151,5 +142,5 @@ def test_dead_gate_ignores_other_comparisons(monkeypatch):
 
 def test_source_files_scanned():
     """The scan must actually reach the package and the test suite."""
-    scanned = {path.relative_to(PYVISTA_ROOT_DIR).parts[0] for path in _iter_source_files()}
+    scanned = {path.relative_to(PYVISTA_ROOT_DIR).parts[0] for path in source_files(*SOURCE_DIRS)}
     assert scanned == set(SOURCE_DIRS)

--- a/tests/test_vtk_version_gates.py
+++ b/tests/test_vtk_version_gates.py
@@ -97,15 +97,27 @@ def test_no_dead_vtk_version_gates():
 
 
 _MINIMUM = (9, 5, 0)
-_BOUNDS = [(9, 4, 0), (9, 5, 0), (9, 6, 0), (9, 5), (9,)]
-_SUPPORTED = [(9, 5, 0), (9, 5, 1), (9, 6, 0), (9, 6, 1), (9, 7, 0), (10, 0, 0)]
+_BOUNDS = [(9, 4, 0), (9, 5, 0), (9, 5, 2), (9, 6, 0), (9, 5), (9,)]
+
+
+def _reachable_versions(bound: tuple[int, ...]) -> list[tuple[int, int, int]]:
+    """Return allowed versions on both sides of a bound, including the bound itself."""
+    near = (*bound, 0, 0)[:3]
+    candidates = {
+        _MINIMUM,
+        near,
+        (near[0], near[1], near[2] + 1),
+        (near[0], near[1] + 1, 0),
+        (near[0] + 1, 0, 0),
+    }
+    return sorted(version for version in candidates if version >= _MINIMUM)
 
 
 @pytest.mark.parametrize('bound', _BOUNDS)
 @pytest.mark.parametrize('symbol', ['<', '<=', '>', '>=', '==', '!='])
 @pytest.mark.parametrize('mirrored', [False, True])
 def test_dead_gate_matches_brute_force(monkeypatch, symbol, bound, mirrored):
-    """The classification must agree with evaluating the gate at every supported version."""
+    """The classification must agree with evaluating the gate on either side of the bound."""
     monkeypatch.setattr(pv, '_MIN_SUPPORTED_VTK_VERSION', _MINIMUM)
     gate = (
         f'{bound} {symbol} vtk_version_info' if mirrored else f'vtk_version_info {symbol} {bound}'
@@ -114,7 +126,7 @@ def test_dead_gate_matches_brute_force(monkeypatch, symbol, bound, mirrored):
     operator_ = _OPERATORS[type(node.ops[0])]
     results = {
         operator_(bound, version) if mirrored else operator_(version, bound)
-        for version in _SUPPORTED
+        for version in _reachable_versions(bound)
     }
     expected = [(1, gate)] if len(results) == 1 else []
     assert list(_dead_gates(ast.parse(gate))) == expected
@@ -134,11 +146,13 @@ def test_dead_gate_reports_chained_comparison(monkeypatch, gate):
     assert list(_dead_gates(ast.parse(gate))) == [(1, gate)]
 
 
-def test_dead_gate_ignores_other_comparisons(monkeypatch):
+@pytest.mark.parametrize(
+    'gate', ['version_info < (9, 4, 0)', 'vtk_version_info < other', 'value == (9, 4, 0)']
+)
+def test_dead_gate_ignores_other_comparisons(monkeypatch, gate):
     """Comparisons that do not read ``vtk_version_info`` are left alone."""
     monkeypatch.setattr(pv, '_MIN_SUPPORTED_VTK_VERSION', _MINIMUM)
-    for gate in ('version_info < (9, 4, 0)', 'vtk_version_info < other', 'value == (9, 4, 0)'):
-        assert list(_dead_gates(ast.parse(gate))) == []
+    assert list(_dead_gates(ast.parse(gate))) == []
 
 
 def test_source_files_scanned():

--- a/tests/test_vtk_version_gates.py
+++ b/tests/test_vtk_version_gates.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import ast
+import operator
 from typing import TYPE_CHECKING
+
+import pytest
 
 import pyvista as pv
 from tests.conftest import PYVISTA_ROOT_DIR
@@ -15,19 +18,26 @@ if TYPE_CHECKING:
 SOURCE_DIRS = ('pyvista', 'tests')
 SKIP_PARTS = {'build', 'dist', '_build', '__pycache__', '.git'}
 
-# Constant once the bound is reached.
-_INCLUSIVE_OPS = (ast.Lt, ast.GtE)
-# Constant only strictly below the bound.
-_EXCLUSIVE_OPS = (ast.LtE, ast.Gt, ast.Eq, ast.NotEq)
+_DEAD_AT_BOUND = (ast.Lt, ast.GtE)
+_DEAD_BELOW_BOUND = (ast.LtE, ast.Gt, ast.Eq, ast.NotEq)
 
 _MIRRORED = {ast.Lt: ast.Gt, ast.Gt: ast.Lt, ast.LtE: ast.GtE, ast.GtE: ast.LtE}
+
+_OPERATORS = {
+    ast.Lt: operator.lt,
+    ast.LtE: operator.le,
+    ast.Gt: operator.gt,
+    ast.GtE: operator.ge,
+    ast.Eq: operator.eq,
+    ast.NotEq: operator.ne,
+}
 
 
 def _iter_source_files() -> Iterator[Path]:
     """Yield every Python file in the scanned source directories."""
     for directory in SOURCE_DIRS:
         for path in sorted((PYVISTA_ROOT_DIR / directory).rglob('*.py')):
-            if SKIP_PARTS.isdisjoint(path.parts):
+            if SKIP_PARTS.isdisjoint(path.relative_to(PYVISTA_ROOT_DIR).parts):
                 yield path
 
 
@@ -41,7 +51,7 @@ def _version_bound(node: ast.expr) -> tuple[int, ...] | None:
             for element in node.elts
         )
     ):
-        return tuple(element.value for element in node.elts)  # type: ignore[misc]
+        return tuple(element.value for element in node.elts)
     return None
 
 
@@ -52,27 +62,33 @@ def _reads_vtk_version(node: ast.expr) -> bool:
     return isinstance(node, ast.Attribute) and node.attr == 'vtk_version_info'
 
 
+def _is_constant(operator_: ast.cmpop, bound: tuple[int, ...], minimum: tuple[int, ...]) -> bool:
+    """Return True if the comparison holds the same result for every supported version."""
+    return (isinstance(operator_, _DEAD_AT_BOUND) and bound <= minimum) or (
+        isinstance(operator_, _DEAD_BELOW_BOUND) and bound < minimum
+    )
+
+
 def _dead_gates(tree: ast.Module) -> Iterator[tuple[int, str]]:
     """Yield the line and source of every constant version comparison in a module."""
     minimum = tuple(pv._MIN_SUPPORTED_VTK_VERSION)
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Compare) or len(node.ops) != 1:
+        if not isinstance(node, ast.Compare):
             continue
-        operator = node.ops[0]
-        if _reads_vtk_version(node.left):
-            bound = _version_bound(node.comparators[0])
-        elif _reads_vtk_version(node.comparators[0]):
-            bound = _version_bound(node.left)
-            operator = _MIRRORED.get(type(operator), type(operator))()
-        else:
-            continue
-        if bound is None:
-            continue
-        constant = (isinstance(operator, _INCLUSIVE_OPS) and bound <= minimum) or (
-            isinstance(operator, _EXCLUSIVE_OPS) and bound < minimum
-        )
-        if constant:
-            yield node.lineno, ast.unparse(node)
+        operands = [node.left, *node.comparators]
+        for index, node_op in enumerate(node.ops):
+            left, right = operands[index], operands[index + 1]
+            operator_ = node_op
+            if _reads_vtk_version(left):
+                bound = _version_bound(right)
+            elif _reads_vtk_version(right):
+                bound = _version_bound(left)
+                operator_ = _MIRRORED.get(type(node_op), type(node_op))()
+            else:
+                continue
+            if bound is not None and _is_constant(operator_, bound, minimum):
+                yield node.lineno, ast.unparse(node)
+                break
 
 
 def test_no_dead_vtk_version_gates():
@@ -80,7 +96,7 @@ def test_no_dead_vtk_version_gates():
     dead = [
         f'{path.relative_to(PYVISTA_ROOT_DIR)}:{lineno}  {source}'
         for path in _iter_source_files()
-        for lineno, source in _dead_gates(ast.parse(path.read_text()))
+        for lineno, source in _dead_gates(ast.parse(path.read_text(encoding='utf-8')))
     ]
     assert not dead, (
         f'VTK {pv._MIN_SUPPORTED_VTK_VERSION} is the minimum supported version, so these '
@@ -88,10 +104,52 @@ def test_no_dead_vtk_version_gates():
     )
 
 
-def test_dead_vtk_version_gates_detected(monkeypatch):
-    """Raising the minimum must flag the gates it makes constant."""
-    monkeypatch.setattr(pv, '_MIN_SUPPORTED_VTK_VERSION', (9, 5, 0))
-    source = (
-        'if vtk_version_info >= (9, 5, 0):\n    pass\nif vtk_version_info < (9, 9):\n    pass\n'
+_MINIMUM = (9, 5, 0)
+_BOUNDS = [(9, 4, 0), (9, 5, 0), (9, 6, 0), (9, 5), (9,)]
+_SUPPORTED = [(9, 5, 0), (9, 5, 1), (9, 6, 0), (9, 6, 1), (9, 7, 0), (10, 0, 0)]
+
+
+@pytest.mark.parametrize('bound', _BOUNDS)
+@pytest.mark.parametrize('symbol', ['<', '<=', '>', '>=', '==', '!='])
+@pytest.mark.parametrize('mirrored', [False, True])
+def test_dead_gate_matches_brute_force(monkeypatch, symbol, bound, mirrored):
+    """The classification must agree with evaluating the gate at every supported version."""
+    monkeypatch.setattr(pv, '_MIN_SUPPORTED_VTK_VERSION', _MINIMUM)
+    gate = (
+        f'{bound} {symbol} vtk_version_info' if mirrored else f'vtk_version_info {symbol} {bound}'
     )
-    assert list(_dead_gates(ast.parse(source))) == [(1, 'vtk_version_info >= (9, 5, 0)')]
+    node = ast.parse(gate).body[0].value
+    operator_ = _OPERATORS[type(node.ops[0])]
+    results = {
+        operator_(bound, version) if mirrored else operator_(version, bound)
+        for version in _SUPPORTED
+    }
+    expected = [(1, gate)] if len(results) == 1 else []
+    assert list(_dead_gates(ast.parse(gate))) == expected
+
+
+@pytest.mark.parametrize(
+    'gate',
+    [
+        '(9, 4, 0) <= vtk_version_info < (9, 9)',
+        'lower <= vtk_version_info < (9, 5, 0)',
+    ],
+    ids=['dead_first_half', 'dead_second_half'],
+)
+def test_dead_gate_reports_chained_comparison(monkeypatch, gate):
+    """A chained comparison is reported when either half has gone constant."""
+    monkeypatch.setattr(pv, '_MIN_SUPPORTED_VTK_VERSION', _MINIMUM)
+    assert list(_dead_gates(ast.parse(gate))) == [(1, gate)]
+
+
+def test_dead_gate_ignores_other_comparisons(monkeypatch):
+    """Comparisons that do not read ``vtk_version_info`` are left alone."""
+    monkeypatch.setattr(pv, '_MIN_SUPPORTED_VTK_VERSION', _MINIMUM)
+    for gate in ('version_info < (9, 4, 0)', 'vtk_version_info < other', 'value == (9, 4, 0)'):
+        assert list(_dead_gates(ast.parse(gate))) == []
+
+
+def test_source_files_scanned():
+    """The scan must actually reach the package and the test suite."""
+    scanned = {path.relative_to(PYVISTA_ROOT_DIR).parts[0] for path in _iter_source_files()}
+    assert scanned == set(SOURCE_DIRS)

--- a/tests/test_vtk_version_gates.py
+++ b/tests/test_vtk_version_gates.py
@@ -91,7 +91,8 @@ def test_no_dead_vtk_version_gates():
     ]
     assert not dead, (
         f'VTK {pv._MIN_SUPPORTED_VTK_VERSION} is the minimum supported version, so these '
-        'comparisons are constant and the code they guard is dead:\n  ' + '\n  '.join(dead)
+        'comparisons are constant, so one of the branches they guard is dead:\n  '
+        + '\n  '.join(dead)
     )
 
 

--- a/tests/test_vtk_version_gates.py
+++ b/tests/test_vtk_version_gates.py
@@ -1,0 +1,97 @@
+"""Fail when a ``vtk_version_info`` comparison can no longer change its result."""
+
+from __future__ import annotations
+
+import ast
+from typing import TYPE_CHECKING
+
+import pyvista as pv
+from tests.conftest import PYVISTA_ROOT_DIR
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+SOURCE_DIRS = ('pyvista', 'tests')
+SKIP_PARTS = {'build', 'dist', '_build', '__pycache__', '.git'}
+
+# Constant once the bound is reached.
+_INCLUSIVE_OPS = (ast.Lt, ast.GtE)
+# Constant only strictly below the bound.
+_EXCLUSIVE_OPS = (ast.LtE, ast.Gt, ast.Eq, ast.NotEq)
+
+_MIRRORED = {ast.Lt: ast.Gt, ast.Gt: ast.Lt, ast.LtE: ast.GtE, ast.GtE: ast.LtE}
+
+
+def _iter_source_files() -> Iterator[Path]:
+    """Yield every Python file in the scanned source directories."""
+    for directory in SOURCE_DIRS:
+        for path in sorted((PYVISTA_ROOT_DIR / directory).rglob('*.py')):
+            if SKIP_PARTS.isdisjoint(path.parts):
+                yield path
+
+
+def _version_bound(node: ast.expr) -> tuple[int, ...] | None:
+    """Return the literal version tuple a node represents, if it is one."""
+    if (
+        isinstance(node, ast.Tuple)
+        and node.elts
+        and all(
+            isinstance(element, ast.Constant) and isinstance(element.value, int)
+            for element in node.elts
+        )
+    ):
+        return tuple(element.value for element in node.elts)  # type: ignore[misc]
+    return None
+
+
+def _reads_vtk_version(node: ast.expr) -> bool:
+    """Return True if the node reads ``vtk_version_info``."""
+    if isinstance(node, ast.Name):
+        return node.id == 'vtk_version_info'
+    return isinstance(node, ast.Attribute) and node.attr == 'vtk_version_info'
+
+
+def _dead_gates(tree: ast.Module) -> Iterator[tuple[int, str]]:
+    """Yield the line and source of every constant version comparison in a module."""
+    minimum = tuple(pv._MIN_SUPPORTED_VTK_VERSION)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare) or len(node.ops) != 1:
+            continue
+        operator = node.ops[0]
+        if _reads_vtk_version(node.left):
+            bound = _version_bound(node.comparators[0])
+        elif _reads_vtk_version(node.comparators[0]):
+            bound = _version_bound(node.left)
+            operator = _MIRRORED.get(type(operator), type(operator))()
+        else:
+            continue
+        if bound is None:
+            continue
+        constant = (isinstance(operator, _INCLUSIVE_OPS) and bound <= minimum) or (
+            isinstance(operator, _EXCLUSIVE_OPS) and bound < minimum
+        )
+        if constant:
+            yield node.lineno, ast.unparse(node)
+
+
+def test_no_dead_vtk_version_gates():
+    """Every ``vtk_version_info`` comparison must still be able to go both ways."""
+    dead = [
+        f'{path.relative_to(PYVISTA_ROOT_DIR)}:{lineno}  {source}'
+        for path in _iter_source_files()
+        for lineno, source in _dead_gates(ast.parse(path.read_text()))
+    ]
+    assert not dead, (
+        f'VTK {pv._MIN_SUPPORTED_VTK_VERSION} is the minimum supported version, so these '
+        'comparisons are constant and the code they guard is dead:\n  ' + '\n  '.join(dead)
+    )
+
+
+def test_dead_vtk_version_gates_detected(monkeypatch):
+    """Raising the minimum must flag the gates it makes constant."""
+    monkeypatch.setattr(pv, '_MIN_SUPPORTED_VTK_VERSION', (9, 5, 0))
+    source = (
+        'if vtk_version_info >= (9, 5, 0):\n    pass\nif vtk_version_info < (9, 9):\n    pass\n'
+    )
+    assert list(_dead_gates(ast.parse(source))) == [(1, 'vtk_version_info >= (9, 5, 0)')]

--- a/tests/test_vtk_version_gates.py
+++ b/tests/test_vtk_version_gates.py
@@ -60,8 +60,8 @@ def _is_constant(operator_: ast.cmpop, bound: tuple[int, ...], minimum: tuple[in
     )
 
 
-def _dead_gates(tree: ast.Module) -> Iterator[tuple[int, str]]:
-    """Yield the line and source of every constant version comparison in a module."""
+def _dead_gates(tree: ast.Module) -> Iterator[tuple[int, str, bool]]:
+    """Yield the line, source and fixed result of every constant version comparison."""
     minimum = tuple(pv._MIN_SUPPORTED_VTK_VERSION)
     for node in ast.walk(tree):
         if not isinstance(node, ast.Compare):
@@ -78,20 +78,21 @@ def _dead_gates(tree: ast.Module) -> Iterator[tuple[int, str]]:
             else:
                 continue
             if bound is not None and _is_constant(operator_, bound, minimum):
-                yield node.lineno, ast.unparse(node)
+                constant = _OPERATORS[type(operator_)](minimum, bound)
+                yield node.lineno, ast.unparse(node), constant
                 break
 
 
 def test_no_dead_vtk_version_gates():
     """Every ``vtk_version_info`` comparison must still be able to go both ways."""
     dead = [
-        f'{path.relative_to(PYVISTA_ROOT_DIR)}:{lineno}  {source}'
+        f'{path.relative_to(PYVISTA_ROOT_DIR)}:{lineno}  {source}  (always {constant})'
         for path in source_files(*SOURCE_DIRS)
-        for lineno, source in _dead_gates(ast.parse(path.read_text(encoding='utf-8')))
+        for lineno, source, constant in _dead_gates(ast.parse(path.read_text(encoding='utf-8')))
     ]
     assert not dead, (
-        f'VTK {pv._MIN_SUPPORTED_VTK_VERSION} is the minimum supported version, so these '
-        'comparisons are constant, so one of the branches they guard is dead:\n  '
+        f'VTK {pv._MIN_SUPPORTED_VTK_VERSION} is the minimum supported version. These '
+        'comparisons cannot change their result, so the branch they never take is dead:\n  '
         + '\n  '.join(dead)
     )
 
@@ -128,22 +129,22 @@ def test_dead_gate_matches_brute_force(monkeypatch, symbol, bound, mirrored):
         operator_(bound, version) if mirrored else operator_(version, bound)
         for version in _reachable_versions(bound)
     }
-    expected = [(1, gate)] if len(results) == 1 else []
+    expected = [(1, gate, next(iter(results)))] if len(results) == 1 else []
     assert list(_dead_gates(ast.parse(gate))) == expected
 
 
 @pytest.mark.parametrize(
-    'gate',
+    ('gate', 'constant'),
     [
-        '(9, 4, 0) <= vtk_version_info < (9, 9)',
-        'lower <= vtk_version_info < (9, 5, 0)',
+        ('(9, 4, 0) <= vtk_version_info < (9, 9)', True),
+        ('lower <= vtk_version_info < (9, 5, 0)', False),
     ],
     ids=['dead_first_half', 'dead_second_half'],
 )
-def test_dead_gate_reports_chained_comparison(monkeypatch, gate):
+def test_dead_gate_reports_chained_comparison(monkeypatch, gate, constant):
     """A chained comparison is reported when either half has gone constant."""
     monkeypatch.setattr(pv, '_MIN_SUPPORTED_VTK_VERSION', _MINIMUM)
-    assert list(_dead_gates(ast.parse(gate))) == [(1, gate)]
+    assert list(_dead_gates(ast.parse(gate))) == [(1, gate, constant)]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_vtk_version_gates.py
+++ b/tests/test_vtk_version_gates.py
@@ -1,4 +1,13 @@
-"""Fail when a ``vtk_version_info`` comparison can no longer change its result."""
+"""Fail when a ``vtk_version_info`` comparison can no longer change its result.
+
+``VTKVersionInfo`` raises for an ordering comparison against a version below the
+minimum, and the ``needs_vtk_version`` marker raises for a stale test bound. Both
+report a single site, and only when that line runs.
+
+This is the static equivalent: one pass over the package and the test suite lists
+every stale gate at once, including those no runtime check reaches -- a bound equal
+to the minimum, ``==`` and ``!=``, and lines no test executes.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
`tests/test_vtk_version_gates.py` fails when a `vtk_version_info` comparison can no longer change its result, so raising the VTK minimum lists every gate that has gone constant instead of leaving the dead branches behind.

`VTKVersionInfo` already raises for an ordering comparison against a version below the minimum, and the `needs_vtk_version` marker raises for a stale test bound. Both report a single site, and only when that line runs. This is the static equivalent — one pass over `pyvista/` and `tests/`, reaching what the runtime checks cannot: a bound equal to the minimum, `==` and `!=`, and lines no test executes.

- Each reported gate carries the result it is stuck at, so it is clear whether the guarded code or the `else` is the dead branch.
- A brute-force test evaluates every operator against versions derived from the bound under test, as an independent oracle for the classifier.
- The repo-wide `.py` scan moves to `tests.conftest.source_files`, shared with `tests/test_import_conventions.py`. That module filtered on the absolute path, so a checkout under a directory named `build` or `dist` scanned nothing and passed vacuously.

Clean at the current 9.3.1 minimum. Split out of #9020.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
