### PR TITLE
Make the merge(main_has_priority=...) deprecation match what the keyword does

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5902,7 +5902,7 @@ class DataSetFilters(DataObjectFilters):
 
             .. deprecated:: 0.46
 
-                Deprecated with VTK 9.5.0 or later, where the main mesh always has
+                Has no effect with VTK 9.5.0 or later, where the main mesh always has
                 priority and ``False`` raises :class:`ValueError`. With older VTK the
                 keyword still selects which mesh has priority. It will be removed in a
                 future version.

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5895,15 +5895,17 @@ class DataSetFilters(DataObjectFilters):
             Updates grid in-place when ``True`` if the input type is an
             :class:`pyvista.UnstructuredGrid`.
 
-        main_has_priority : bool, default: True
+        main_has_priority : bool, optional
             When this parameter is true and ``merge_points`` is true,
             the arrays of the merging grids will be overwritten
             by the original main mesh.
 
             .. deprecated:: 0.46
 
-                This keyword will be removed in a future version. The main mesh
-                always has priority with VTK 9.5.0 or later.
+                Deprecated with VTK 9.5.0 or later, where the main mesh always has
+                priority and ``False`` raises :class:`ValueError`. With older VTK the
+                keyword still selects which mesh has priority. It will be removed in a
+                future version.
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
@@ -5932,16 +5934,20 @@ class DataSetFilters(DataObjectFilters):
 
         """
         vtk_at_least_95 = vtk_version_info >= (9, 5, 0)
-        # Deprecated on v0.46.0 for vtk>=9.5.0 only; older vtk still needs the keyword.
+        # Deprecated on v0.46.0 for vtk>=9.5.0 only; remove with the vtk<9.5.0 branch below.
         if main_has_priority is not None and vtk_at_least_95:
-            msg = (
-                "The keyword 'main_has_priority' is deprecated and should not be used.\n"
-                'The main mesh will always have priority in a future version, and this keyword '
-                'will be removed.'
-            )
             if main_has_priority is False:
-                msg += '\nIts value cannot be False for vtk>=9.5.0.'
+                msg = (
+                    "'main_has_priority=False' is not supported for vtk>=9.5.0, where the "
+                    'main mesh always has priority. Swap the meshes instead, as in '
+                    '`other.merge(main)`.'
+                )
                 raise ValueError(msg)
+            msg = (
+                "The keyword 'main_has_priority' is deprecated and has no effect for "
+                'vtk>=9.5.0, where the main mesh always has priority. It will be removed '
+                'in a future version.'
+            )
             warn_external(msg, pv.PyVistaDeprecationWarning)
         elif main_has_priority is None and not vtk_at_least_95:
             # Set default for older VTK:

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5902,10 +5902,9 @@ class DataSetFilters(DataObjectFilters):
 
             .. deprecated:: 0.46
 
-                Has no effect with VTK 9.5.0 or later, where the main mesh always has
-                priority and ``False`` raises :class:`ValueError`. With older VTK the
-                keyword still selects which mesh has priority and defaults to ``True``.
-                It will be removed in a future version.
+                Omit this keyword; the main mesh already has priority. ``False`` raises
+                :class:`ValueError` with VTK 9.5.0 or later and still selects the other
+                mesh with older VTK. It will be removed in a future version.
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
@@ -5934,24 +5933,24 @@ class DataSetFilters(DataObjectFilters):
 
         """
         vtk_at_least_95 = vtk_version_info >= (9, 5, 0)
-        # Deprecated on v0.46.0 for vtk>=9.5.0 only; remove with the vtk<9.5.0 branch below.
-        if main_has_priority is not None and vtk_at_least_95:
-            if not main_has_priority:
-                msg = (
-                    f'main_has_priority={main_has_priority!r} is not supported for '
-                    'vtk>=9.5.0, where the main mesh always has priority. Swap the meshes '
-                    'instead, as in `other.merge(main)`.'
-                )
-                raise ValueError(msg)
+        # Deprecated on v0.46.0; remove with the vtk<9.5.0 branch below.
+        if main_has_priority is None:
+            if not vtk_at_least_95:
+                # Set default for older VTK:
+                main_has_priority = True
+        elif main_has_priority:
             msg = (
-                "The keyword 'main_has_priority' is deprecated and has no effect for "
-                'vtk>=9.5.0, where the main mesh always has priority. It will be removed '
-                'in a future version.'
+                "The keyword 'main_has_priority' is deprecated and will be removed in a "
+                'future version. Omit it; the main mesh already has priority.'
             )
             warn_external(msg, pv.PyVistaDeprecationWarning)
-        elif main_has_priority is None and not vtk_at_least_95:
-            # Set default for older VTK:
-            main_has_priority = True
+        elif vtk_at_least_95:
+            msg = (
+                f'main_has_priority={main_has_priority!r} is not supported for '
+                'vtk>=9.5.0, where the main mesh always has priority. Swap the meshes '
+                'instead, as in `other.merge(main)`.'
+            )
+            raise ValueError(msg)
 
         append_filter = _vtk.vtkAppendFilter()
         append_filter.SetMergePoints(merge_points)

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5932,18 +5932,18 @@ class DataSetFilters(DataObjectFilters):
 
         """
         vtk_at_least_95 = vtk_version_info >= (9, 5, 0)
-        if main_has_priority is not None:
+        # Deprecated on v0.46.0 for vtk>=9.5.0 only; older vtk still needs the keyword.
+        if main_has_priority is not None and vtk_at_least_95:
             msg = (
                 "The keyword 'main_has_priority' is deprecated and should not be used.\n"
                 'The main mesh will always have priority in a future version, and this keyword '
                 'will be removed.'
             )
-            if main_has_priority is False and vtk_at_least_95:
+            if main_has_priority is False:
                 msg += '\nIts value cannot be False for vtk>=9.5.0.'
                 raise ValueError(msg)
-            else:
-                warn_external(msg, pv.PyVistaDeprecationWarning)
-        elif not vtk_at_least_95:
+            warn_external(msg, pv.PyVistaDeprecationWarning)
+        elif main_has_priority is None and not vtk_at_least_95:
             # Set default for older VTK:
             main_has_priority = True
 

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5904,8 +5904,8 @@ class DataSetFilters(DataObjectFilters):
 
                 Has no effect with VTK 9.5.0 or later, where the main mesh always has
                 priority and ``False`` raises :class:`ValueError`. With older VTK the
-                keyword still selects which mesh has priority. It will be removed in a
-                future version.
+                keyword still selects which mesh has priority and defaults to ``True``.
+                It will be removed in a future version.
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.
@@ -5938,9 +5938,9 @@ class DataSetFilters(DataObjectFilters):
         if main_has_priority is not None and vtk_at_least_95:
             if not main_has_priority:
                 msg = (
-                    "'main_has_priority=False' is not supported for vtk>=9.5.0, where the "
-                    'main mesh always has priority. Swap the meshes instead, as in '
-                    '`other.merge(main)`.'
+                    f'main_has_priority={main_has_priority!r} is not supported for '
+                    'vtk>=9.5.0, where the main mesh always has priority. Swap the meshes '
+                    'instead, as in `other.merge(main)`.'
                 )
                 raise ValueError(msg)
             msg = (

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -5936,7 +5936,7 @@ class DataSetFilters(DataObjectFilters):
         vtk_at_least_95 = vtk_version_info >= (9, 5, 0)
         # Deprecated on v0.46.0 for vtk>=9.5.0 only; remove with the vtk<9.5.0 branch below.
         if main_has_priority is not None and vtk_at_least_95:
-            if main_has_priority is False:
+            if not main_has_priority:
                 msg = (
                     "'main_has_priority=False' is not supported for vtk>=9.5.0, where the "
                     'main mesh always has priority. Swap the meshes instead, as in '

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -512,10 +512,9 @@ class PolyDataFilters(DataSetFilters):
 
             .. deprecated:: 0.46
 
-                Has no effect with VTK 9.5.0 or later, where the main mesh always has
-                priority and ``False`` raises :class:`ValueError`. With older VTK the
-                keyword still selects which mesh has priority and defaults to ``True``.
-                It will be removed in a future version.
+                Omit this keyword; the main mesh already has priority. ``False`` raises
+                :class:`ValueError` with VTK 9.5.0 or later and still selects the other
+                mesh with older VTK. It will be removed in a future version.
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -512,8 +512,10 @@ class PolyDataFilters(DataSetFilters):
 
             .. deprecated:: 0.46
 
-                This keyword will be removed in a future version. The main mesh
-                always has priority with VTK 9.5.0 or later.
+                Deprecated with VTK 9.5.0 or later, where the main mesh always has
+                priority and ``False`` raises :class:`ValueError`. With older VTK the
+                keyword still selects which mesh has priority. It will be removed in a
+                future version.
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -514,8 +514,8 @@ class PolyDataFilters(DataSetFilters):
 
                 Has no effect with VTK 9.5.0 or later, where the main mesh always has
                 priority and ``False`` raises :class:`ValueError`. With older VTK the
-                keyword still selects which mesh has priority. It will be removed in a
-                future version.
+                keyword still selects which mesh has priority and defaults to ``True``.
+                It will be removed in a future version.
 
         progress_bar : bool, default: False
             Display a progress bar to indicate progress.

--- a/pyvista/core/filters/poly_data.py
+++ b/pyvista/core/filters/poly_data.py
@@ -512,7 +512,7 @@ class PolyDataFilters(DataSetFilters):
 
             .. deprecated:: 0.46
 
-                Deprecated with VTK 9.5.0 or later, where the main mesh always has
+                Has no effect with VTK 9.5.0 or later, where the main mesh always has
                 priority and ``False`` raises :class:`ValueError`. With older VTK the
                 keyword still selects which mesh has priority. It will be removed in a
                 future version.

--- a/pyvista/core/utilities/features.py
+++ b/pyvista/core/utilities/features.py
@@ -623,8 +623,8 @@ def merge(  # noqa: PLR0917
 
             Has no effect with VTK 9.5.0 or later, where the main mesh always has
             priority and ``False`` raises :class:`ValueError`. With older VTK the
-            keyword still selects which mesh has priority. It will be removed in a
-            future version.
+            keyword still selects which mesh has priority and defaults to ``True``.
+            It will be removed in a future version.
 
     progress_bar : bool, default: False
         Display a progress bar to indicate progress.

--- a/pyvista/core/utilities/features.py
+++ b/pyvista/core/utilities/features.py
@@ -615,14 +615,16 @@ def merge(  # noqa: PLR0917
     merge_points : bool, default: True
         Merge equivalent points when ``True``.
 
-    main_has_priority : bool, default: True
+    main_has_priority : bool, optional
         When this parameter is ``True`` and ``merge_points=True``, the arrays
         of the merging grids will be overwritten by the original main mesh.
 
         .. deprecated:: 0.46
 
-            This keyword will be removed in a future version. The main mesh
-            always has priority with VTK 9.5.0 or later.
+            Deprecated with VTK 9.5.0 or later, where the main mesh always has
+            priority and ``False`` raises :class:`ValueError`. With older VTK the
+            keyword still selects which mesh has priority. It will be removed in a
+            future version.
 
     progress_bar : bool, default: False
         Display a progress bar to indicate progress.

--- a/pyvista/core/utilities/features.py
+++ b/pyvista/core/utilities/features.py
@@ -621,7 +621,7 @@ def merge(  # noqa: PLR0917
 
         .. deprecated:: 0.46
 
-            Deprecated with VTK 9.5.0 or later, where the main mesh always has
+            Has no effect with VTK 9.5.0 or later, where the main mesh always has
             priority and ``False`` raises :class:`ValueError`. With older VTK the
             keyword still selects which mesh has priority. It will be removed in a
             future version.

--- a/pyvista/core/utilities/features.py
+++ b/pyvista/core/utilities/features.py
@@ -621,10 +621,9 @@ def merge(  # noqa: PLR0917
 
         .. deprecated:: 0.46
 
-            Has no effect with VTK 9.5.0 or later, where the main mesh always has
-            priority and ``False`` raises :class:`ValueError`. With older VTK the
-            keyword still selects which mesh has priority and defaults to ``True``.
-            It will be removed in a future version.
+            Omit this keyword; the main mesh already has priority. ``False`` raises
+            :class:`ValueError` with VTK 9.5.0 or later and still selects the other
+            mesh with older VTK. It will be removed in a future version.
 
     progress_bar : bool, default: False
         Display a progress bar to indicate progress.

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -683,10 +683,7 @@ def test_merge(hexbeam):
 def test_merge_not_main(hexbeam):
     grid = hexbeam.copy()
     grid.points[:, 0] += 1
-    with pytest.warns(
-        pv.PyVistaDeprecationWarning, match=r"The keyword 'main_has_priority' is deprecated"
-    ):
-        unmerged = grid.merge(hexbeam, inplace=False, merge_points=False, main_has_priority=False)
+    unmerged = grid.merge(hexbeam, inplace=False, merge_points=False, main_has_priority=False)
 
     grid.merge(hexbeam, inplace=True, merge_points=True)
     assert grid.n_points > hexbeam.n_points

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -4,6 +4,7 @@ import math
 from pathlib import Path
 import re
 from unittest.mock import patch
+import warnings
 
 import numpy as np
 import pytest
@@ -655,11 +656,7 @@ def test_merge_main_has_priority(input_, main_has_priority):
         merged = mesh.merge(other)
         expected_to_match = mesh
     else:
-        with pytest.warns(
-            pv.PyVistaDeprecationWarning,
-            match="The keyword 'main_has_priority' is deprecated and should not be used",
-        ):
-            merged = mesh.merge(other, main_has_priority=main_has_priority)
+        merged = mesh.merge(other, main_has_priority=main_has_priority)
         expected_to_match = mesh if main_has_priority else other
     assert matching_point_data(merged, expected_to_match, 'present_in_both')
     assert merged.active_scalars_name == 'present_in_both'
@@ -671,7 +668,12 @@ def test_merge_main_has_priority_deprecated(sphere, main_has_priority):
         "The keyword 'main_has_priority' is deprecated and should not be used.\n"
         'The main mesh will always have priority in a future version.'
     )
-    if main_has_priority is False and pv.vtk_version_info >= (9, 5, 0):
+    if pv.vtk_version_info < (9, 5, 0):
+        # The keyword still selects the winning mesh, so it is not deprecated yet.
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', pv.PyVistaDeprecationWarning)
+            sphere.merge(sphere, main_has_priority=main_has_priority)
+    elif main_has_priority is False:
         with pytest.raises(ValueError, match=match):
             sphere.merge(sphere, main_has_priority=main_has_priority)
     else:
@@ -694,7 +696,9 @@ def test_merge_field_data(mesh, main_has_priority):
         'The main mesh will always have priority in a future version, and this '
         'keyword will be removed.'
     )
-    if main_has_priority is False and pv.vtk_version_info >= (9, 5, 0):
+    if pv.vtk_version_info < (9, 5, 0):
+        merged = mesh.merge(other, main_has_priority=main_has_priority)
+    elif main_has_priority is False:
         match += '\nIts value cannot be False for vtk>=9.5.0.'
         with pytest.raises(ValueError, match=re.escape(match)):
             mesh.merge(other, main_has_priority=main_has_priority)

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -674,12 +674,12 @@ def test_merge_main_has_priority(input_, main_has_priority):
     assert merged.active_scalars_name == 'present_in_both'
 
 
-@pytest.mark.parametrize('main_has_priority', [True, False])
+@pytest.mark.parametrize('main_has_priority', [True, False, 0, np.False_])
 def test_merge_main_has_priority_deprecated(sphere, main_has_priority):
     if pv.vtk_version_info < (9, 5, 0):
         # The keyword still selects the winning mesh, so it is not deprecated yet.
         sphere.merge(sphere, main_has_priority=main_has_priority)
-    elif main_has_priority is False:
+    elif not main_has_priority:
         match = "'main_has_priority=False' is not supported for vtk>=9.5.0"
         with pytest.raises(ValueError, match=match):
             sphere.merge(sphere, main_has_priority=main_has_priority)

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -627,7 +627,10 @@ def test_merge_active_scalars(input_):
     assert merged.active_scalars_name == 'foo'
 
 
-_MERGE_PRIORITY_INPUTS = [examples.load_hexbeam(), pv.Plane(i_resolution=1, j_resolution=1)]
+_MERGE_PRIORITY_INPUTS = [
+    pytest.param(examples.load_hexbeam(), id='hexbeam'),
+    pytest.param(pv.Plane(i_resolution=1, j_resolution=1), id='plane'),
+]
 
 
 def _conflicting_scalars(input_):
@@ -674,7 +677,9 @@ def test_merge_main_has_priority(input_, main_has_priority):
     assert merged.active_scalars_name == 'present_in_both'
 
 
-@pytest.mark.parametrize('main_has_priority', [True, False, 0, np.False_])
+@pytest.mark.parametrize(
+    'main_has_priority', [True, False, 0, pytest.param(np.False_, id='np_False')]
+)
 def test_merge_main_has_priority_deprecated(sphere, main_has_priority):
     if pv.vtk_version_info < (9, 5, 0):
         # The keyword still selects the winning mesh, so it is not deprecated yet.
@@ -701,7 +706,7 @@ def test_merge_field_data(mesh, main_has_priority):
 
     if pv.vtk_version_info < (9, 5, 0):
         merged = mesh.merge(other, main_has_priority=main_has_priority)
-    elif main_has_priority is False:
+    elif not main_has_priority:
         match = re.escape("'main_has_priority=False' is not supported for vtk>=9.5.0")
         with pytest.raises(ValueError, match=match):
             mesh.merge(other, main_has_priority=main_has_priority)

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -685,7 +685,7 @@ def test_merge_main_has_priority_deprecated(sphere, main_has_priority):
         # The keyword still selects the winning mesh, so it is not deprecated yet.
         sphere.merge(sphere, main_has_priority=main_has_priority)
     elif not main_has_priority:
-        match = "'main_has_priority=False' is not supported for vtk>=9.5.0"
+        match = re.escape(f'main_has_priority={main_has_priority!r} is not supported')
         with pytest.raises(ValueError, match=match):
             sphere.merge(sphere, main_has_priority=main_has_priority)
     else:
@@ -707,7 +707,7 @@ def test_merge_field_data(mesh, main_has_priority):
     if pv.vtk_version_info < (9, 5, 0):
         merged = mesh.merge(other, main_has_priority=main_has_priority)
     elif not main_has_priority:
-        match = re.escape("'main_has_priority=False' is not supported for vtk>=9.5.0")
+        match = re.escape(f'main_has_priority={main_has_priority!r} is not supported')
         with pytest.raises(ValueError, match=match):
             mesh.merge(other, main_has_priority=main_has_priority)
         return

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -4,7 +4,6 @@ import math
 from pathlib import Path
 import re
 from unittest.mock import patch
-import warnings
 
 import numpy as np
 import pytest
@@ -664,19 +663,15 @@ def test_merge_main_has_priority(input_, main_has_priority):
 
 @pytest.mark.parametrize('main_has_priority', [True, False])
 def test_merge_main_has_priority_deprecated(sphere, main_has_priority):
-    match = (
-        "The keyword 'main_has_priority' is deprecated and should not be used.\n"
-        'The main mesh will always have priority in a future version.'
-    )
     if pv.vtk_version_info < (9, 5, 0):
         # The keyword still selects the winning mesh, so it is not deprecated yet.
-        with warnings.catch_warnings():
-            warnings.simplefilter('error', pv.PyVistaDeprecationWarning)
-            sphere.merge(sphere, main_has_priority=main_has_priority)
+        sphere.merge(sphere, main_has_priority=main_has_priority)
     elif main_has_priority is False:
+        match = "'main_has_priority=False' is not supported for vtk>=9.5.0"
         with pytest.raises(ValueError, match=match):
             sphere.merge(sphere, main_has_priority=main_has_priority)
     else:
+        match = "The keyword 'main_has_priority' is deprecated and has no effect"
         with pytest.warns(pv.PyVistaDeprecationWarning, match=match):
             sphere.merge(sphere, main_has_priority=main_has_priority)
 
@@ -691,19 +686,15 @@ def test_merge_field_data(mesh, main_has_priority):
     other = mesh.copy()
     other.field_data[key] = data_other
 
-    match = (
-        "The keyword 'main_has_priority' is deprecated and should not be used.\n"
-        'The main mesh will always have priority in a future version, and this '
-        'keyword will be removed.'
-    )
     if pv.vtk_version_info < (9, 5, 0):
         merged = mesh.merge(other, main_has_priority=main_has_priority)
     elif main_has_priority is False:
-        match += '\nIts value cannot be False for vtk>=9.5.0.'
-        with pytest.raises(ValueError, match=re.escape(match)):
+        match = re.escape("'main_has_priority=False' is not supported for vtk>=9.5.0")
+        with pytest.raises(ValueError, match=match):
             mesh.merge(other, main_has_priority=main_has_priority)
         return
     else:
+        match = "The keyword 'main_has_priority' is deprecated and has no effect"
         with pytest.warns(pv.PyVistaDeprecationWarning, match=match):
             merged = mesh.merge(other, main_has_priority=main_has_priority)
 

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -671,7 +671,11 @@ def test_merge_main_has_priority_by_default(input_):
 @pytest.mark.parametrize('main_has_priority', [True, False])
 def test_merge_main_has_priority(input_, main_has_priority):
     mesh, other = _conflicting_scalars(input_)
-    merged = mesh.merge(other, main_has_priority=main_has_priority)
+    if main_has_priority:
+        with pytest.warns(pv.PyVistaDeprecationWarning, match='is deprecated'):
+            merged = mesh.merge(other, main_has_priority=main_has_priority)
+    else:
+        merged = mesh.merge(other, main_has_priority=main_has_priority)
     expected_to_match = mesh if main_has_priority else other
     assert _matching_point_data(merged, expected_to_match, 'present_in_both')
     assert merged.active_scalars_name == 'present_in_both'
@@ -681,17 +685,17 @@ def test_merge_main_has_priority(input_, main_has_priority):
     'main_has_priority', [True, False, 0, pytest.param(np.False_, id='np_False')]
 )
 def test_merge_main_has_priority_deprecated(sphere, main_has_priority):
-    if pv.vtk_version_info < (9, 5, 0):
-        # The keyword still selects the winning mesh, so it is not deprecated yet.
-        sphere.merge(sphere, main_has_priority=main_has_priority)
-    elif not main_has_priority:
+    if main_has_priority:
+        match = "The keyword 'main_has_priority' is deprecated"
+        with pytest.warns(pv.PyVistaDeprecationWarning, match=match):
+            sphere.merge(sphere, main_has_priority=main_has_priority)
+    elif pv.vtk_version_info >= (9, 5, 0):
         match = re.escape(f'main_has_priority={main_has_priority!r} is not supported')
         with pytest.raises(ValueError, match=match):
             sphere.merge(sphere, main_has_priority=main_has_priority)
     else:
-        match = "The keyword 'main_has_priority' is deprecated and has no effect"
-        with pytest.warns(pv.PyVistaDeprecationWarning, match=match):
-            sphere.merge(sphere, main_has_priority=main_has_priority)
+        # The keyword still selects the winning mesh, so it is not deprecated yet.
+        sphere.merge(sphere, main_has_priority=main_has_priority)
 
 
 @pytest.mark.parametrize('main_has_priority', [True, False])
@@ -704,17 +708,17 @@ def test_merge_field_data(mesh, main_has_priority):
     other = mesh.copy()
     other.field_data[key] = data_other
 
-    if pv.vtk_version_info < (9, 5, 0):
-        merged = mesh.merge(other, main_has_priority=main_has_priority)
-    elif not main_has_priority:
+    if main_has_priority:
+        match = "The keyword 'main_has_priority' is deprecated"
+        with pytest.warns(pv.PyVistaDeprecationWarning, match=match):
+            merged = mesh.merge(other, main_has_priority=main_has_priority)
+    elif pv.vtk_version_info >= (9, 5, 0):
         match = re.escape(f'main_has_priority={main_has_priority!r} is not supported')
         with pytest.raises(ValueError, match=match):
             mesh.merge(other, main_has_priority=main_has_priority)
         return
     else:
-        match = "The keyword 'main_has_priority' is deprecated and has no effect"
-        with pytest.warns(pv.PyVistaDeprecationWarning, match=match):
-            merged = mesh.merge(other, main_has_priority=main_has_priority)
+        merged = mesh.merge(other, main_has_priority=main_has_priority)
 
     actual = merged.field_data[key]
     expected = data_main if main_has_priority else data_other

--- a/tests/core/test_polydata.py
+++ b/tests/core/test_polydata.py
@@ -627,37 +627,50 @@ def test_merge_active_scalars(input_):
     assert merged.active_scalars_name == 'foo'
 
 
-@pytest.mark.parametrize(
-    'input_', [examples.load_hexbeam(), pv.Plane(i_resolution=1, j_resolution=1)]
-)
-@pytest.mark.parametrize('main_has_priority', [True, False])
-def test_merge_main_has_priority(input_, main_has_priority):
+_MERGE_PRIORITY_INPUTS = [examples.load_hexbeam(), pv.Plane(i_resolution=1, j_resolution=1)]
+
+
+def _conflicting_scalars(input_):
+    """Return a mesh and a copy whose shared active scalars have the opposite sign."""
     mesh = input_.copy()
     data_main = np.arange(mesh.n_points, dtype=float)
     mesh.point_data['present_in_both'] = data_main
     mesh.set_active_scalars('present_in_both')
 
     other = mesh.copy()
-    data_other = -data_main
-    other.point_data['present_in_both'] = data_other
+    other.point_data['present_in_both'] = -data_main
     other.set_active_scalars('present_in_both')
+    return mesh, other
 
+
+def _matching_point_data(this, that, scalars_name):
+    """Return True if scalars on two meshes only differ by point order."""
     # note: order of points can change after point merging
-    def matching_point_data(this, that, scalars_name):
-        """Return True if scalars on two meshes only differ by point order."""
-        return all(
-            new_val == this.point_data[scalars_name][j]
-            for point, new_val in zip(that.points, that.point_data[scalars_name], strict=True)
-            for j in (this.points == point).all(-1).nonzero()
-        )
+    return all(
+        new_val == this.point_data[scalars_name][j]
+        for point, new_val in zip(that.points, that.point_data[scalars_name], strict=True)
+        for j in (this.points == point).all(-1).nonzero()
+    )
 
-    if pv.vtk_version_info >= (9, 5, 0):
-        merged = mesh.merge(other)
-        expected_to_match = mesh
-    else:
-        merged = mesh.merge(other, main_has_priority=main_has_priority)
-        expected_to_match = mesh if main_has_priority else other
-    assert matching_point_data(merged, expected_to_match, 'present_in_both')
+
+@pytest.mark.parametrize('input_', _MERGE_PRIORITY_INPUTS)
+def test_merge_main_has_priority_by_default(input_):
+    mesh, other = _conflicting_scalars(input_)
+    merged = mesh.merge(other)
+    assert _matching_point_data(merged, mesh, 'present_in_both')
+    assert merged.active_scalars_name == 'present_in_both'
+
+
+@pytest.mark.needs_vtk_version(
+    less_than=(9, 5, 0), reason='Main always has priority for vtk >= 9.5.'
+)
+@pytest.mark.parametrize('input_', _MERGE_PRIORITY_INPUTS)
+@pytest.mark.parametrize('main_has_priority', [True, False])
+def test_merge_main_has_priority(input_, main_has_priority):
+    mesh, other = _conflicting_scalars(input_)
+    merged = mesh.merge(other, main_has_priority=main_has_priority)
+    expected_to_match = mesh if main_has_priority else other
+    assert _matching_point_data(merged, expected_to_match, 'present_in_both')
     assert merged.active_scalars_name == 'present_in_both'
 
 


### PR DESCRIPTION
`merge(main_has_priority=...)` was deprecated in 0.46 but the warning did not match what the keyword does. It fired on every VTK with a message saying the main mesh "will always have priority in a future version", which is already true for vtk>=9.5.0 and not true at all below it, where the keyword still selects the winning mesh.

Passing `True` is exactly equivalent to omitting the keyword on every VTK, so that warning now names its replacement and fires everywhere. `False` is the only case without one: it raises for vtk>=9.5.0, and below that it still selects the other mesh and stays quiet.

- The `ValueError` quotes the value it rejected and names the `other.merge(main)` equivalent. It also rejects any false value, not just the `False` singleton — the guard tested identity while the rest of `merge` tests truthiness, so `np.False_` was silently given main priority.
- The deprecated directive says what to do instead of restating that it is deprecated, and records what omitting the keyword does on older VTK.
- `test_merge_main_has_priority` called `merge` without the keyword for vtk>=9.5.0, so both parametrized ids ran identical code. The default now has its own test on every VTK and the keyword test carries the `needs_vtk_version` marker.

Split out of #9020.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
