### PR TITLE
Keep the environment texture's sRGB flag when resampling

### DIFF
--- a/pyvista/plotting/renderer.py
+++ b/pyvista/plotting/renderer.py
@@ -3729,9 +3729,10 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
             Texture.
 
         is_srgb : bool, default: False
-            If the texture is in sRGB color space, set the color flag on the
-            texture or set this parameter to ``True``. Textures are assumed
-            to be in linear color space by default.
+            Decode the texture from sRGB to linear color space while computing
+            the image-based lighting. Set :attr:`~pyvista.Texture.srgb` instead
+            to decode the texture everywhere it is sampled, including the
+            background. Enabling both decodes the texture twice.
 
         resample : bool | float, optional
             Resample the environment texture. Set this to a float to set the
@@ -3836,6 +3837,7 @@ class Renderer(_NoNewAttrMixin, _BoundsSizeMixin, DisableVtkSnakeCase, _vtk.vtkO
             texture_copy.mipmap = texture.mipmap
             texture_copy.interpolate = texture.interpolate
             texture_copy.color_mode = texture.color_mode
+            texture_copy.srgb = texture.srgb
 
             # Resample the texture's images
             for i in range(6 if texture_copy.cube_map else 1):

--- a/pyvista/plotting/texture.py
+++ b/pyvista/plotting/texture.py
@@ -240,6 +240,22 @@ class Texture(DataObject, _vtk.vtkTexture):
     def mipmap(self, value: bool):
         self.SetMipmap(value)
 
+    @property
+    def srgb(self) -> bool:  # numpydoc ignore=RT01
+        """Return or set whether the texture is in sRGB color space.
+
+        When enabled, the texture is decoded to linear color space everywhere it
+        is sampled. Textures are assumed to be in linear color space by default.
+
+        .. versionadded:: 0.49
+
+        """
+        return bool(self.GetUseSRGBColorSpace())
+
+    @srgb.setter
+    def srgb(self, value: bool):
+        self.SetUseSRGBColorSpace(value)
+
     def _from_image_data(self, image):
         if not isinstance(image, pv.ImageData):
             image = pv.ImageData(image)

--- a/tests/plotting/test_plotting.py
+++ b/tests/plotting/test_plotting.py
@@ -420,6 +420,37 @@ def test_set_environment_texture_resample_shrinks_irradiance(small_cubemap, no_i
     pl.close()
 
 
+@pytest.mark.parametrize('resample', [False, 0.5])
+def test_set_environment_texture_keeps_srgb(resample, small_cubemap, no_images_to_verify):  # noqa: ARG001
+    """A texture in sRGB color space lights the scene in sRGB, resampled or not."""
+    small_cubemap.srgb = True
+
+    pl = pv.Plotter(lighting=None)
+    pl.set_environment_texture(small_cubemap, resample=resample)
+
+    assert pl.renderer.GetEnvironmentTexture().srgb
+    pl.close()
+
+
+def test_set_environment_texture_resampled_srgb_changes_lighting(verify_image_cache):
+    """A resampled environment texture in sRGB color space casts different light."""
+    verify_image_cache.skip = True
+
+    def render(srgb):
+        texture = examples.load_globe_texture()
+        texture.srgb = srgb
+        pl = pv.Plotter(lighting=None, window_size=(300, 300))
+        pl.set_environment_texture(texture, resample=0.5, show_background=False)
+        pl.add_mesh(pv.Sphere(), pbr=True, metallic=0.5, roughness=0.3)
+        pl.camera_position = 'xy'
+        return pl.show(return_img=True).astype(np.int16)
+
+    linear = render(srgb=False)
+    # Renders of the same scene are identical, so any difference below is the color space
+    assert np.array_equal(render(srgb=False), linear)
+    assert np.abs(render(srgb=True) - linear).mean() > 1.0
+
+
 @pytest.mark.needs_vtk_version(at_least=(9, 6))
 def test_set_environment_texture_rotation(verify_image_cache):
     """Environment texture rotation rotates both background and reflections."""


### PR DESCRIPTION
### Overview

`set_environment_texture` resamples through a partial copy of the texture, and the copy carried every flag but `UseSRGBColorSpace`. A texture in sRGB color space therefore lit the scene as if it were linear as soon as resampling was on.

The `is_srgb` parameter is unaffected and keeps working: `vtkRenderer` discards the argument, but `vtkOpenGLRenderer` overrides the method and turns it into `ConvertToLinear` on the PBR irradiance and prefilter textures, and has since VTK 9.0. It is a different mechanism from the texture's own flag, though — it decodes only while convolving the image-based lighting, where the flag decodes everywhere the texture is sampled, background included, and enabling both decodes twice. The docstring called the two interchangeable, so this rewrites it.

- Adds `Texture.srgb`, since the documentation asks users to set a flag that had no PyVista name.
- No baselines move; nothing in the repository sets the flag except one test.

Worth the `vtk-dev-testing` label — the behaviour depends on the VTK version. Replaces #9088, which was stacked on #9085.

Changes drafted by Claude Opus 5 but fully understood by me (Erik, that clause is yours to confirm, reword or drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)