### PR TITLE
Reset shared scalar bar mappers only when the range widens

### DIFF
--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -5420,6 +5420,11 @@ class BasePlotter(_BoundsSizeMixin):
                 msg = 'This plotter does not have an active mapper.'
                 raise AttributeError(msg)
             self.mapper.scalar_range = clim
+            self.scalar_bars._resync_titles.update(
+                title
+                for title, mappers in self.scalar_bars._scalar_bar_mappers.items()
+                if self.mapper in mappers
+            )
             return
 
         try:
@@ -5429,6 +5434,7 @@ class BasePlotter(_BoundsSizeMixin):
         except KeyError:
             msg = f'Name ({name!r}) not valid/not found in this plotter.'
             raise ValueError(msg) from None
+        self.scalar_bars._resync_titles.add(name)
 
     def clear_actors(self) -> None:
         """Clear actors from all renderers."""

--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -40,7 +40,7 @@ class ScalarBars(_NoNewAttrMixin):
         """Remove all scalar bars and resets all scalar bar properties."""
         self._scalar_bar_ranges = {}
         self._scalar_bar_mappers = {}
-        self._resync_titles: set[str] = set()
+        self._resync_titles = set()
         self._scalar_bar_actors = {}
         self._scalar_bar_widgets = {}
 

--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -547,14 +547,17 @@ class ScalarBars(_NoNewAttrMixin):
 
         # Check that this data hasn't already been plotted
         if title in list(self._scalar_bar_ranges.keys()):
-            _clim = list(self._scalar_bar_ranges[title])
+            stored = list(self._scalar_bar_ranges[title])
             newrng = mapper.scalar_range
             oldmappers = self._scalar_bar_mappers[title]
-            # get max for range and reset everything
-            _clim[0] = min(newrng[0], _clim[0])
-            _clim[1] = max(newrng[1], _clim[1])
-            for mh in oldmappers:
-                mh.scalar_range = _clim[0], _clim[1]
+            # get max for range
+            _clim = [min(newrng[0], stored[0]), max(newrng[1], stored[1])]
+            # Optimization: the old mappers already hold the stored range from the add that
+            # set it, so they are only reset when this mesh widens it, or once on the second
+            # add since the first mapper was stored without going through its setter
+            if _clim != stored or len(oldmappers) == 1:
+                for mh in oldmappers:
+                    mh.scalar_range = _clim[0], _clim[1]
             mapper.scalar_range = _clim[0], _clim[1]
             self._scalar_bar_mappers[title].append(mapper)
             self._scalar_bar_ranges[title] = _clim

--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -32,6 +32,7 @@ class ScalarBars(_NoNewAttrMixin):
         self._plotter = weakref.proxy(plotter)
         self._scalar_bar_ranges = {}
         self._scalar_bar_mappers = {}
+        self._resync_titles: set[str] = set()
         self._scalar_bar_actors = {}
         self._scalar_bar_widgets = {}
 
@@ -39,6 +40,7 @@ class ScalarBars(_NoNewAttrMixin):
         """Remove all scalar bars and resets all scalar bar properties."""
         self._scalar_bar_ranges = {}
         self._scalar_bar_mappers = {}
+        self._resync_titles: set[str] = set()
         self._scalar_bar_actors = {}
         self._scalar_bar_widgets = {}
 
@@ -550,14 +552,15 @@ class ScalarBars(_NoNewAttrMixin):
             stored = list(self._scalar_bar_ranges[title])
             newrng = mapper.scalar_range
             oldmappers = self._scalar_bar_mappers[title]
-            # get max for range
             _clim = [min(newrng[0], stored[0]), max(newrng[1], stored[1])]
             # Optimization: the old mappers already hold the stored range from the add that
-            # set it, so they are only reset when this mesh widens it, or once on the second
-            # add since the first mapper was stored without going through its setter
-            if _clim != stored or len(oldmappers) == 1:
+            # set it, so they are only reset when this mesh widens it, once on the second add
+            # to pin the first mapper's auto range the way the setter pinned the others', or
+            # after ``update_scalar_bar_range`` moved them away from the stored range
+            if _clim != stored or len(oldmappers) == 1 or title in self._resync_titles:
                 for mh in oldmappers:
                     mh.scalar_range = _clim[0], _clim[1]
+                self._resync_titles.discard(title)
             mapper.scalar_range = _clim[0], _clim[1]
             self._scalar_bar_mappers[title].append(mapper)
             self._scalar_bar_ranges[title] = _clim

--- a/tests/plotting/test_scalar_bars.py
+++ b/tests/plotting/test_scalar_bars.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 
+import numpy as np
 import pytest
 
 import pyvista as pv
@@ -153,3 +154,23 @@ def test_unique_scalar_bars(sphere, unique_bar: bool, shape: tuple[int, int]):
         assert len(key_scalar_bars) == shape[0] * shape[1]
     else:
         assert len(key_scalar_bars) == 1
+
+
+def test_add_scalar_bar_shared_range_resync(sphere):
+    # Mappers sharing a scalar bar keep one common range as meshes are added
+    pl = pv.Plotter()
+    low = sphere.copy()
+    low['data'] = np.linspace(0, 1, low.n_points)
+    mid = sphere.copy()
+    mid['data'] = np.linspace(0.2, 0.8, mid.n_points)
+    high = sphere.copy()
+    high['data'] = np.linspace(0, 5, high.n_points)
+    actors = [pl.add_mesh(mesh, scalars='data') for mesh in (low, mid)]
+    mappers = pl.scalar_bars._scalar_bar_mappers['data']
+    assert [m.scalar_range for m in mappers] == [(0.0, 1.0), (0.0, 1.0)]
+    assert not any(m._use_default_scalar_range for m in mappers)
+    actors.append(pl.add_mesh(high, scalars='data'))
+    assert [m.scalar_range for m in mappers] == [(0.0, 5.0)] * 3
+    assert [m.lookup_table.scalar_range for m in mappers] == [(0.0, 5.0)] * 3
+    assert list(pl.scalar_bars._scalar_bar_ranges['data']) == [0.0, 5.0]
+    pl.close()

--- a/tests/plotting/test_scalar_bars.py
+++ b/tests/plotting/test_scalar_bars.py
@@ -164,13 +164,26 @@ def test_add_scalar_bar_shared_range_resync(sphere):
     mid = sphere.copy()
     mid['data'] = np.linspace(0.2, 0.8, mid.n_points)
     high = sphere.copy()
-    high['data'] = np.linspace(0, 5, high.n_points)
+    high['data'] = np.linspace(-1, 5, high.n_points)
     actors = [pl.add_mesh(mesh, scalars='data') for mesh in (low, mid)]
     mappers = pl.scalar_bars._scalar_bar_mappers['data']
     assert [m.scalar_range for m in mappers] == [(0.0, 1.0), (0.0, 1.0)]
     assert not any(m._use_default_scalar_range for m in mappers)
     actors.append(pl.add_mesh(high, scalars='data'))
-    assert [m.scalar_range for m in mappers] == [(0.0, 5.0)] * 3
-    assert [m.lookup_table.scalar_range for m in mappers] == [(0.0, 5.0)] * 3
-    assert list(pl.scalar_bars._scalar_bar_ranges['data']) == [0.0, 5.0]
+    assert [m.scalar_range for m in mappers] == [(-1.0, 5.0)] * 3
+    assert [m.lookup_table.scalar_range for m in mappers] == [(-1.0, 5.0)] * 3
+    assert list(pl.scalar_bars._scalar_bar_ranges['data']) == [-1.0, 5.0]
+    # A mesh inside the shared range leaves every mapper on it
+    actors.append(pl.add_mesh(mid.copy(), scalars='data'))
+    assert [m.scalar_range for m in mappers] == [(-1.0, 5.0)] * 4
+    assert [m.lookup_table.scalar_range for m in mappers] == [(-1.0, 5.0)] * 4
+    assert list(pl.scalar_bars._scalar_bar_ranges['data']) == [-1.0, 5.0]
+    # A manual range update is undone by the next add, as before
+    pl.update_scalar_bar_range([0, 10], name='data')
+    assert [m.scalar_range for m in mappers] == [(0.0, 10.0)] * 4
+    actors.append(pl.add_mesh(mid.copy(), scalars='data'))
+    assert [m.scalar_range for m in mappers] == [(-1.0, 5.0)] * 5
+    pl.update_scalar_bar_range([0, 10])
+    actors.append(pl.add_mesh(mid.copy(), scalars='data'))
+    assert [m.scalar_range for m in mappers] == [(-1.0, 5.0)] * 6
     pl.close()


### PR DESCRIPTION
### Overview

Part of a performance sweep of the plotting module. Every mesh added under an existing scalar bar title reset the scalar range of every mapper already sharing that bar, even when the combined range had not changed, so a scene of N meshes with one scalar bar cost N² range resets. The old mappers already hold the stored range from the add that set it, so they are now only reset when the new mesh widens it (and once on the second add, since the first mapper is registered without going through its setter). A test pins the shared range and its widening. `update_scalar_bar_range` marks its title so the next add still resets the mappers it changed, as before. The sequences that change are a user setting one shared mapper's range directly between two `add_mesh` calls with an unchanged combined range (the manual value is now kept), and a mapper registered under two scalar bar titles (a non-widening add under one title no longer pulls it back from the other's range).

Measured on this machine with VTK 9.7.0:

| Scene | Before | After |
| --- | ---: | ---: |
| 1000 × `add_mesh(scalars=...)`, one scalar bar, common range | 41.7 s | 3.4 s |
| 300 × `add_mesh(scalars=...)`, one scalar bar, common range | 1.49 s | 0.47 s |
| 1000 × `add_mesh(scalars=...)`, range widening on every add | 43 s | 43 s |
| 1000 × `add_mesh(scalars=...)`, `show_scalar_bar=False` | 3.4 s | 3.4 s |

Changes drafted by Claude (Claude Fable 5.1) but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5.1)
