### PR TITLE
Enable all ruff `S` rules and harden the CI workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,10 @@
 /joss/                                              @pyvista/admin
 /CODE_OF_CONDUCT.md                                 @pyvista/admin
 /CODEOWNERS                                         @pyvista/admin
-/.github/workflows/testing-and-deployment.yml       @pyvista/ci-reviewers
-/.github/workflows/docs.yml                         @pyvista/ci-reviewers
-/.github/workflows/docker-package.yml               @pyvista/ci-reviewers
-/.github/workflows/vtk-pre-test.yml                 @pyvista/ci-reviewers
+/SECURITY.md                                        @pyvista/admin
+/.github/workflows/                                 @pyvista/ci-reviewers
+/.github/actions/                                   @pyvista/ci-reviewers
+/.github/dependabot.yml                             @pyvista/ci-reviewers
+/.github/auto-merge.yml                             @pyvista/ci-reviewers
+/.github/zizmor.yml                                 @pyvista/ci-reviewers
 /tox.ini                                            @pyvista/ci-reviewers

--- a/.github/actions/vtk-master-failure-summary/action.yml
+++ b/.github/actions/vtk-master-failure-summary/action.yml
@@ -8,8 +8,10 @@ runs:
   steps:
     - name: Build failure summary
       shell: bash
+      env:
+        JOB_LABEL: ${{ github.job }} (${{ join(matrix.*, ', ') }})
       run: |
-        echo "${{ github.job }} (${{ join(matrix.*, ', ') }})" > job_label.txt
+        printf '%s\n' "$JOB_LABEL" > job_label.txt
         : > failure_summary.txt
         for log in core-test.log plotting-test.log; do
           [ -s "$log" ] || continue

--- a/.github/workflows/cache-pyvista-data.yml
+++ b/.github/workflows/cache-pyvista-data.yml
@@ -32,7 +32,10 @@ jobs:
           echo "CACHE_FOLDER_NAME=pyvista-data" >> "$GITHUB_ENV"
 
       - name: Get pyvista/data commit
-        run: echo VTK_DATA_COMMIT=$(git ls-remote https://github.com/pyvista/data HEAD | awk '{ print $1}') >> $GITHUB_ENV
+        run: |
+          commit="$(git ls-remote https://github.com/pyvista/data HEAD | awk '{ print $1 }')"
+          [ -n "$commit" ] || { echo "::error::could not resolve pyvista/data HEAD"; exit 1; }
+          echo "VTK_DATA_COMMIT=$commit" >> "$GITHUB_ENV"
 
       - name: Restore pyvista/data cache
         id: restore

--- a/.github/workflows/dependency-conflicts.yml
+++ b/.github/workflows/dependency-conflicts.yml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   uv-lock:
     permissions:

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -19,14 +19,16 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
-permissions:
-  packages: write
+permissions: {}
 
 jobs:
   build-and-publish:
     name: Build ${{ matrix.target }} image
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write # push the image to ghcr.io
     # For pull requests, run on branches named `docker*` or when the
     # `docker` label is applied. Never runs on forked PRs (needs secrets).
     if: github.event_name == 'push' ||

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -89,8 +89,10 @@ jobs:
       # EGL runtime libraries instead of shipping an image that can import
       # pyvista but cannot actually render.
       - name: Smoke test (render + GPUInfo)
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
-          docker run --rm pyvista-ci:${{ matrix.target }} python -c "
+          docker run --rm "pyvista-ci:$TARGET" python -c "
           import numpy as np
           import pyvista as pv
           print(pv.Report())

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,24 +22,21 @@ permissions:
   id-token: none
 
 jobs:
-  # Save PR metadata as an artifact so the separate deploy workflow (triggered
+  # Save the PR number as an artifact so the separate deploy workflow (triggered
   # via workflow_run) can associate the build with its PR — workflow_run events
-  # do not include pull_request data for fork PRs.
+  # do not include pull_request data for fork PRs. Nothing else goes in here:
+  # the deploy workflow takes the head SHA and fork status from its own event.
   pr-info:
     name: Save PR info
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - name: Save PR metadata
+      - name: Save PR number
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
         run: |
           mkdir -p pr-info
           printf '%s' "$PR_NUMBER" > pr-info/pr_number.txt
-          printf '%s' "$HEAD_SHA" > pr-info/head_sha.txt
-          printf '%s' "$IS_FORK" > pr-info/is_fork.txt
       - uses: actions/upload-artifact@v7
         with:
           name: pr-info

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,7 @@ jobs:
 
   cache-pyvista-data:
     name: Cache pyvista/data
-    uses: ./.github/workflows/cache-pyvista-data.yml
+    uses: $/.github/workflows/cache-pyvista-data.yml
     with:
       # Runner should match the actual runner used by the build job
       runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -221,9 +221,13 @@ jobs:
           name: pyvista-notebooks
           path: .
 
+      # Pinned to a commit: cookiecutter runs the template's hooks, and this job
+      # later publishes the result with a write token.
       - name: Make Cookiecutter
+        env:
+          TEMPLATE_REF: 001da281b2e49efe97af86ab628176d47ce23e21
         run: |
-          cookiecutter -f --no-input --config-file ./doc/source/pyvista-binder-config.yml https://github.com/pyvista/cookiecutter-pyvista-binder.git;
+          cookiecutter -f --no-input --checkout "$TEMPLATE_REF" --config-file ./doc/source/pyvista-binder-config.yml https://github.com/pyvista/cookiecutter-pyvista-binder.git
           rm -rf ./pyvista-examples/notebooks/
           cp -r doc/source/examples/ ./pyvista-examples/
           ls -l ./pyvista-examples/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
     # `id-token: none`, which zeroes every other scope.
     permissions:
       actions: read
-    uses: ./.github/workflows/find-tree-build.yml
+    uses: $/.github/workflows/find-tree-build.yml
     with:
       marker-prefix: docs-tree
 
@@ -91,7 +91,7 @@ jobs:
           version: 3.0
 
       - name: Restore pyvista/data cache
-        uses: ./.github/actions/restore-pyvista-data
+        uses: $/.github/actions/restore-pyvista-data
         with:
           key: ${{ needs.cache-pyvista-data.outputs.key }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -92,9 +92,14 @@ jobs:
             3.13
             3.14
 
+      # The key is remote text, so keep it to one line of safe characters before
+      # it goes into GITHUB_ENV, and fail on an HTTP error instead of caching under it.
       - name: Set cache key for mne
         if: ${{ matrix.project == 'mne' }}
-        run: echo MNE_DATA_KEY=$(curl -L https://github.com/mne-tools/mne-testing-data/raw/refs/heads/master/version.txt) | tee -a "$GITHUB_ENV"
+        run: |
+          key="$(curl -fsSL https://github.com/mne-tools/mne-testing-data/raw/refs/heads/master/version.txt | head -n1 | tr -cd '[:alnum:]._-')"
+          [ -n "$key" ] || { echo "::error::mne-testing-data version.txt is empty"; exit 1; }
+          echo "MNE_DATA_KEY=$key" | tee -a "$GITHUB_ENV"
 
       - uses: actions/cache@v6
         if: ${{ env.USE_CACHE == 'true' && matrix.project == 'mne' }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -75,7 +75,9 @@ jobs:
           persist-credentials: false
 
       - name: Set test timeout
-        run: echo "retry_test_timeout=$(( ${{ matrix.timeout }} / 2 ))" | tee -a "$GITHUB_OUTPUT"
+        env:
+          TIMEOUT: ${{ matrix.timeout }}
+        run: echo "retry_test_timeout=$(( TIMEOUT / 2 ))" | tee -a "$GITHUB_OUTPUT"
         id: set_timeout
 
       - uses: pyvista/setup-headless-display-action@b0bf9f57d62d2b3fee9f1c0e0c7e390f05e97a4e

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -7,60 +7,47 @@ on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [opened, reopened]
 
-# Use the built-in GITHUB_TOKEN (pull_request_target runs in base-repo context,
-# so the token has write access to the PR). No PAT or App token needed.
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   triage:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-22.04
+    # Use the built-in GITHUB_TOKEN (pull_request_target runs in base-repo context,
+    # so the token has write access to the PR). No PAT or App token needed.
+    permissions:
+      contents: read # actions/labeler reads .github/labeler.yml from the base branch
+      pull-requests: write
     steps:
       - name: Label based on changed files
         uses: actions/labeler@v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Label based on branch name
-      - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
-        if: startsWith(github.event.pull_request.head.ref, 'doc/') || startsWith(github.event.pull_request.head.ref, 'docs')
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: documentation
-      - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
-        if: startsWith(github.event.pull_request.head.ref, 'docker')
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: docker
-      - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
-        if: startsWith(github.event.pull_request.head.ref, 'maint') || startsWith(github.event.pull_request.head.ref, 'testing') || startsWith(github.event.pull_request.head.ref, 'no-ci') || startsWith(github.event.pull_request.head.ref, 'ci')
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: maintenance
-      - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
-        if: startsWith(github.event.pull_request.head.ref, 'junk')
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: ignore-for-release
-      - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
-        if: startsWith(github.event.pull_request.head.ref, 'feat')
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: enhancement
-      - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
-        if: startsWith(github.event.pull_request.head.ref, 'fix') || startsWith(github.event.pull_request.head.ref, 'patch') || startsWith(github.event.pull_request.head.ref, 'bug')
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: bug
-      - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
-        if: startsWith(github.event.pull_request.head.ref, 'release')
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: release
-      - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
-        if: startsWith(github.event.pull_request.head.ref, 'breaking-change')
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: breaking-change
+      # The branch name is chosen by the PR author, so it reaches the shell only
+      # through an environment variable and is never expanded into the script.
+      - name: Label based on branch name
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          labels=()
+          case "$HEAD_REF" in doc/* | docs*) labels+=(documentation) ;; esac
+          case "$HEAD_REF" in docker*) labels+=(docker) ;; esac
+          case "$HEAD_REF" in maint* | testing* | no-ci* | ci*) labels+=(maintenance) ;; esac
+          case "$HEAD_REF" in junk*) labels+=(ignore-for-release) ;; esac
+          case "$HEAD_REF" in feat*) labels+=(enhancement) ;; esac
+          case "$HEAD_REF" in fix* | patch* | bug*) labels+=(bug) ;; esac
+          case "$HEAD_REF" in release*) labels+=(release) ;; esac
+          case "$HEAD_REF" in breaking-change*) labels+=(breaking-change) ;; esac
+          if [ "${#labels[@]}" -eq 0 ]; then
+            echo "No branch-name label applies to '$HEAD_REF'"
+            exit 0
+          fi
+          args=()
+          for label in "${labels[@]}"; do
+            args+=(-f "labels[]=$label")
+          done
+          gh api --method POST "repos/$REPO/issues/$PR_NUMBER/labels" "${args[@]}"

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -14,6 +14,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 defaults:
   run:
     shell: bash -l {0}
@@ -23,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      contents: read
       issues: write # required to open/comment the linkcheck failure issue
 
     env:

--- a/.github/workflows/netlify-deploy.yml
+++ b/.github/workflows/netlify-deploy.yml
@@ -51,20 +51,28 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 
+      # The artifact was written by the triggering run, which a fork controls, so
+      # only the PR number is read from it, and only if it is a plain integer. The
+      # head SHA and fork status come from the event payload, which a fork cannot
+      # forge; is_fork picks the deployment environment, so it must never come
+      # from the artifact.
       - name: Parse PR info
         id: parse
         env:
-          FALLBACK_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          IS_FORK: ${{ github.event.workflow_run.head_repository.full_name != github.repository }}
         run: |
+          pr_number=""
           if [ -f pr-info/pr_number.txt ]; then
-            echo "pr_number=$(cat pr-info/pr_number.txt)" >> "$GITHUB_OUTPUT"
-            echo "head_sha=$(cat pr-info/head_sha.txt)" >> "$GITHUB_OUTPUT"
-            echo "is_fork=$(cat pr-info/is_fork.txt)" >> "$GITHUB_OUTPUT"
-          else
-            echo "pr_number=" >> "$GITHUB_OUTPUT"
-            echo "head_sha=$FALLBACK_SHA" >> "$GITHUB_OUTPUT"
-            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+            pr_number="$(tr -d '[:space:]' < pr-info/pr_number.txt)"
+            if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+              echo "::error::pr-info artifact holds an invalid PR number"
+              exit 1
+            fi
           fi
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "is_fork=$IS_FORK" >> "$GITHUB_OUTPUT"
 
   preview:
     name: Preview Development Documentation

--- a/.github/workflows/style-docstring.yml
+++ b/.github/workflows/style-docstring.yml
@@ -149,10 +149,13 @@ jobs:
       # headings that must be flagged, and fails if any of them stops being.
       - name: Install Vale
         run: |
-          curl -sSfL https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz \
-            | sudo tar -xz -C /usr/local/bin vale
+          curl -sSfL "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz" -o vale.tar.gz
+          echo "${VALE_SHA256}  vale.tar.gz" | sha256sum --check
+          sudo tar -xz -C /usr/local/bin -f vale.tar.gz vale
         env:
           VALE_VERSION: 3.18.0
+          # From vale_<version>_checksums.txt on the release page; update both together.
+          VALE_SHA256: a6f71a75a12fe689345b754f2412b90367fe33648abb7d200fa19eaadc2dbf6d
 
       - name: "Check Vale still catches known-bad headings"
         run: python3 tests/doc/vale/check_expected_failures.py

--- a/.github/workflows/style-docstring.yml
+++ b/.github/workflows/style-docstring.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   cache-pyvista-data:
     name: Cache pyvista/data
-    uses: ./.github/workflows/cache-pyvista-data.yml
+    uses: $/.github/workflows/cache-pyvista-data.yml
     with:
       # Runner should match the actual runner used by the docstring job
       runs-on: "blacksmith-4vcpu-ubuntu-2204"

--- a/.github/workflows/style-docstring.yml
+++ b/.github/workflows/style-docstring.yml
@@ -23,7 +23,7 @@ jobs:
   # entry serves the Windows job via enableCrossOsArchive on the restore.
   cache-github-hosted:
     name: Cache pyvista/data
-    uses: ./.github/workflows/cache-pyvista-data.yml
+    uses: $/.github/workflows/cache-pyvista-data.yml
     with:
       runs-on: "ubuntu-22.04"
 
@@ -65,7 +65,7 @@ jobs:
           version: 3.0
 
       - name: Restore pyvista/data cache
-        uses: ./.github/actions/restore-pyvista-data
+        uses: $/.github/actions/restore-pyvista-data
         with:
           key: ${{ runner.os == 'Windows' && needs.cache-github-hosted.outputs.key || needs.cache-pyvista-data.outputs.key }}
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -40,24 +40,21 @@ permissions:
   id-token: none
 
 jobs:
-  # Save PR metadata as an artifact so the separate deploy workflow (triggered
+  # Save the PR number as an artifact so the separate deploy workflow (triggered
   # via workflow_run) can associate the build with its PR — workflow_run events
-  # do not include pull_request data for fork PRs.
+  # do not include pull_request data for fork PRs. Nothing else goes in here:
+  # the deploy workflow takes the head SHA and fork status from its own event.
   pr-info:
     name: Save PR info
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - name: Save PR metadata
+      - name: Save PR number
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
         run: |
           mkdir -p pr-info
           printf '%s' "$PR_NUMBER" > pr-info/pr_number.txt
-          printf '%s' "$HEAD_SHA" > pr-info/head_sha.txt
-          printf '%s' "$IS_FORK" > pr-info/is_fork.txt
       - uses: actions/upload-artifact@v7
         with:
           name: pr-info

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -68,7 +68,7 @@ jobs:
   # GitHub runners too, via enableCrossOsArchive on the restore.
   cache-github-hosted:
     name: Cache pyvista/data
-    uses: ./.github/workflows/cache-pyvista-data.yml
+    uses: $/.github/workflows/cache-pyvista-data.yml
     with:
       runs-on: "ubuntu-22.04"
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -110,11 +110,15 @@ jobs:
         run: pip install tox-uv
 
       - name: Core Testing (no GL)
-        run: tox run -e py${{ matrix.python-version }}-core
+        env:
+          TOX_ENV: py${{ matrix.python-version }}-core
+        run: tox run -e "$TOX_ENV"
 
       - name: Plotting Testing (uses GL)
         if: ${{ !cancelled() }}
-        run: tox run -e py${{ matrix.python-version }}-plotting
+        env:
+          TOX_ENV: py${{ matrix.python-version }}-plotting
+        run: tox run -e "$TOX_ENV"
 
       - name: Upload Images for Failed Tests
         if: always()
@@ -267,11 +271,15 @@ jobs:
         run: pip install tox-uv
 
       - name: Core Testing (no GL)
-        run: tox run -e py${{ matrix.python-version }}-cov-core-vtk_dev
+        env:
+          TOX_ENV: py${{ matrix.python-version }}-cov-core-vtk_dev
+        run: tox run -e "$TOX_ENV"
 
       - name: Plotting Testing (uses GL)
         if: ${{ !cancelled() }}
-        run: xvfb-run tox run -e py${{ matrix.python-version }}-cov-plotting-vtk_dev
+        env:
+          TOX_ENV: py${{ matrix.python-version }}-cov-plotting-vtk_dev
+        run: xvfb-run tox run -e "$TOX_ENV"
 
       - name: Upload Images for Failed Tests
         if: always()

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -102,7 +102,7 @@ jobs:
           cache: ${{ env.USE_CACHE == 'true' && 'pip' || '' }}
 
       - name: Restore pyvista/data cache
-        uses: ./.github/actions/restore-pyvista-data
+        uses: $/.github/actions/restore-pyvista-data
         with:
           key: ${{ needs.cache-github-hosted.outputs.key }}
 
@@ -185,7 +185,7 @@ jobs:
           version: 3.0
 
       - name: Restore pyvista/data cache
-        uses: ./.github/actions/restore-pyvista-data
+        uses: $/.github/actions/restore-pyvista-data
         with:
           key: ${{ needs.cache-github-hosted.outputs.key }}
 
@@ -263,7 +263,7 @@ jobs:
           version: 3.0
 
       - name: Restore pyvista/data cache
-        uses: ./.github/actions/restore-pyvista-data
+        uses: $/.github/actions/restore-pyvista-data
         with:
           key: ${{ needs.cache-github-hosted.outputs.key }}
 
@@ -329,7 +329,7 @@ jobs:
           cache: "pip"
 
       - name: Restore pyvista/data cache
-        uses: ./.github/actions/restore-pyvista-data
+        uses: $/.github/actions/restore-pyvista-data
         with:
           key: ${{ needs.cache-github-hosted.outputs.key }}
 

--- a/.github/workflows/type-checking.yml
+++ b/.github/workflows/type-checking.yml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 env:
   TOX_COLORED: "yes"
 

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -23,10 +23,11 @@ jobs:
     outputs:
       run: ${{ steps.check.outputs.run }}
     steps:
+      # For PRs, only run this job if the 'vtk-master-testing' label is applied
       - id: check
-        run:
-          | # For PRs, only run this job if the 'vtk-master-testing' label is applied
-          echo "run=${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'vtk-master-testing') }}" >> "$GITHUB_OUTPUT"
+        env:
+          RUN: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'vtk-master-testing') }}
+        run: echo "run=$RUN" >> "$GITHUB_OUTPUT"
 
   build-vtk:
     needs: check-should-run
@@ -302,8 +303,10 @@ jobs:
 
       - name: Skip if wheel build failed
         if: steps.download-wheel.outcome != 'success'
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
-          echo "No VTK wheel artifact for ${{ runner.os }}/py${{ matrix.python-version }}"
+          echo "No VTK wheel artifact for $RUNNER_OS/py$PYTHON_VERSION"
           exit 1
 
       # ALL STEPS ABOVE SHOULD BE EXACTLY THE SAME FOR EACH OS
@@ -326,11 +329,15 @@ jobs:
 
       # Teed to a file for the failure-summary upload below.
       - name: Core Testing (no GL)
-        run: tox run -e py${{ matrix.python-version }}-core-vtk_local 2>&1 | tee core-test.log
+        env:
+          TOX_ENV: py${{ matrix.python-version }}-core-vtk_local
+        run: tox run -e "$TOX_ENV" 2>&1 | tee core-test.log
 
       - name: Plotting Testing (uses GL)
         if: ${{ !cancelled() }}
-        run: xvfb-run tox run -e py${{ matrix.python-version }}-plotting-vtk_local 2>&1 | tee plotting-test.log
+        env:
+          TOX_ENV: py${{ matrix.python-version }}-plotting-vtk_local
+        run: xvfb-run tox run -e "$TOX_ENV" 2>&1 | tee plotting-test.log
 
       - name: Upload failure summary
         if: failure()
@@ -386,8 +393,10 @@ jobs:
 
       - name: Skip if wheel build failed
         if: steps.download-wheel.outcome != 'success'
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
-          echo "No VTK wheel artifact for ${{ runner.os }}/py${{ matrix.python-version }}"
+          echo "No VTK wheel artifact for $RUNNER_OS/py$PYTHON_VERSION"
           exit 1
 
       # ALL STEPS ABOVE SHOULD BE EXACTLY THE SAME FOR EACH OS
@@ -405,11 +414,15 @@ jobs:
 
       # Teed to a file for the failure-summary upload below.
       - name: Core Testing (no GL)
-        run: tox run -e py${{ matrix.python-version }}-core-vtk_local 2>&1 | tee core-test.log
+        env:
+          TOX_ENV: py${{ matrix.python-version }}-core-vtk_local
+        run: tox run -e "$TOX_ENV" 2>&1 | tee core-test.log
 
       - name: Plotting Testing (uses GL)
         if: ${{ !cancelled() }}
-        run: tox run -e py${{ matrix.python-version }}-plotting-vtk_local 2>&1 | tee plotting-test.log
+        env:
+          TOX_ENV: py${{ matrix.python-version }}-plotting-vtk_local
+        run: tox run -e "$TOX_ENV" 2>&1 | tee plotting-test.log
 
       - name: Upload failure summary
         if: failure()
@@ -465,8 +478,10 @@ jobs:
 
       - name: Skip if wheel build failed
         if: steps.download-wheel.outcome != 'success'
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
-          echo "No VTK wheel artifact for ${{ runner.os }}/py${{ matrix.python-version }}"
+          echo "No VTK wheel artifact for $RUNNER_OS/py$PYTHON_VERSION"
           exit 1
 
       # ALL STEPS ABOVE SHOULD BE EXACTLY THE SAME FOR EACH OS

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -263,7 +263,7 @@ jobs:
     needs: check-should-run
     if: needs.check-should-run.outputs.run == 'true'
     name: Cache pyvista/data
-    uses: ./.github/workflows/cache-pyvista-data.yml
+    uses: $/.github/workflows/cache-pyvista-data.yml
     with:
       runs-on: "ubuntu-22.04"
 
@@ -341,7 +341,7 @@ jobs:
 
       - name: Upload failure summary
         if: failure()
-        uses: ./.github/actions/vtk-master-failure-summary
+        uses: $/.github/actions/vtk-master-failure-summary
 
       - name: Upload Images for Failed Tests
         if: always()
@@ -426,7 +426,7 @@ jobs:
 
       - name: Upload failure summary
         if: failure()
-        uses: ./.github/actions/vtk-master-failure-summary
+        uses: $/.github/actions/vtk-master-failure-summary
 
       - name: Upload Images for Failed Tests
         if: always()
@@ -522,7 +522,7 @@ jobs:
 
       - name: Upload failure summary
         if: failure()
-        uses: ./.github/actions/vtk-master-failure-summary
+        uses: $/.github/actions/vtk-master-failure-summary
 
       - name: Upload Images for Failed Tests
         if: always()

--- a/.github/workflows/vtk-master-wheels.yml
+++ b/.github/workflows/vtk-master-wheels.yml
@@ -316,7 +316,7 @@ jobs:
           version: 3.0
 
       - name: Restore pyvista/data cache
-        uses: ./.github/actions/restore-pyvista-data
+        uses: $/.github/actions/restore-pyvista-data
         with:
           key: ${{ needs.cache-github-hosted.outputs.key }}
 
@@ -399,7 +399,7 @@ jobs:
       # ALL STEPS BELOW SHOULD MIMIC THE UNIT TESTING WORKFLOW EXACTLY
 
       - name: Restore pyvista/data cache
-        uses: ./.github/actions/restore-pyvista-data
+        uses: $/.github/actions/restore-pyvista-data
         with:
           key: ${{ needs.cache-github-hosted.outputs.key }}
 
@@ -482,7 +482,7 @@ jobs:
       # ALL STEPS BELOW SHOULD MIMIC THE UNIT TESTING WORKFLOW EXACTLY
 
       - name: Restore pyvista/data cache
-        uses: ./.github/actions/restore-pyvista-data
+        uses: $/.github/actions/restore-pyvista-data
         with:
           key: ${{ needs.cache-github-hosted.outputs.key }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -175,7 +175,7 @@ repos:
           ]
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.24.1
+    rev: v1.30.0
     hooks:
       - id: zizmor
 

--- a/doc/intersphinx/update.sh
+++ b/doc/intersphinx/update.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 
 # this script updates the intersphinx files here
-# make sure to follow potential redirects
-curl -L https://docs.python.org/3/objects.inv >python-objects.inv
-curl -L https://docs.scipy.org/doc/scipy/objects.inv >scipy-objects.inv
-curl -L https://numpy.org/doc/stable/objects.inv >numpy-objects.inv
-curl -L https://matplotlib.org/stable/objects.inv >matplotlib-objects.inv
-curl -L https://imageio.readthedocs.io/en/stable/objects.inv >imageio-objects.inv
-curl -L https://pandas.pydata.org/pandas-docs/stable/objects.inv >pandas-objects.inv
-curl -L https://arrow.apache.org/docs/objects.inv >pyarrow-objects.inv
-curl -L https://docs.pytest.org/en/stable/objects.inv >pytest-objects.inv
-curl -L https://qt.pyvista.org/objects.inv >pyvistaqt-objects.inv
-curl -L https://validation.pyvista.org/objects.inv >pyvista-validation-objects.inv
-curl -L https://trimesh.org/objects.inv >trimesh-objects.inv
+# make sure to follow potential redirects, and fail on an HTTP error
+# rather than saving the error page as an inventory
+set -euo pipefail
+curl -fsSL https://docs.python.org/3/objects.inv >python-objects.inv
+curl -fsSL https://docs.scipy.org/doc/scipy/objects.inv >scipy-objects.inv
+curl -fsSL https://numpy.org/doc/stable/objects.inv >numpy-objects.inv
+curl -fsSL https://matplotlib.org/stable/objects.inv >matplotlib-objects.inv
+curl -fsSL https://imageio.readthedocs.io/en/stable/objects.inv >imageio-objects.inv
+curl -fsSL https://pandas.pydata.org/pandas-docs/stable/objects.inv >pandas-objects.inv
+curl -fsSL https://arrow.apache.org/docs/objects.inv >pyarrow-objects.inv
+curl -fsSL https://docs.pytest.org/en/stable/objects.inv >pytest-objects.inv
+curl -fsSL https://qt.pyvista.org/objects.inv >pyvistaqt-objects.inv
+curl -fsSL https://validation.pyvista.org/objects.inv >pyvista-validation-objects.inv
+curl -fsSL https://trimesh.org/objects.inv >trimesh-objects.inv

--- a/doc/source/make_tables.py
+++ b/doc/source/make_tables.py
@@ -318,7 +318,7 @@ def _meshio_info_dict():
                 meshio_info[class_name][format_name] = info
 
         # Store writer info next
-        cls = eval('pv.' + class_name)
+        cls = getattr(pv, class_name)
         writer_extensions = _swap_extension_mapping(cls._WRITERS)
         for writer, extensions in writer_extensions:
             # Check if the format was already added from the reader

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -457,7 +457,7 @@ extend-select = [
   'RET',
   'RSE',
   'RUF',
-  'S101',
+  'S',
   'SIM',
   'T10',
   'T20',
@@ -497,6 +497,7 @@ ignore = [
   'RET505', # https://github.com/pyvista/pyvista/pull/5911
   'RET506', # https://github.com/pyvista/pyvista/pull/5911
   'RET507', # https://github.com/pyvista/pyvista/pull/5911
+  'S603', # subprocess calls pass argv lists, never a shell string
   'SIM102', # https://github.com/pyvista/pyvista/pull/5877
   'SIM117', # https://github.com/pyvista/pyvista/pull/5888
   'SIM118', # https://github.com/pyvista/pyvista/pull/5837
@@ -584,6 +585,8 @@ pyvista = "pv"
 '.claude/skills/*/scripts/*.py' = ['INP', 'T20']
 '__init__.py' = ['PLC0414']
 'doc/*' = ['ANN', 'INP', 'PLC0415']
+# git is resolved from PATH like every other developer tool
+'doc/make_dev_wheel.py' = ['S607']
 # A command-line script: it reports what it runs, like `make` does.
 'doc/run_vale.py' = ['T20']
 'doc/source/make_tables.py' = [
@@ -637,12 +640,15 @@ pyvista = "pv"
 'pyvista/core/utilities/cell.py' = ['ANN']
 'pyvista/core/utilities/docs.py' = ['ANN']
 'pyvista/core/utilities/features.py' = ['ANN']
+# `pass_data` selects which data arrays to pass through; it is not a password
+'pyvista/core/utilities/fileio.py' = ['S105']
 'pyvista/core/utilities/geometric_objects.py' = ['N802']
 'pyvista/core/utilities/helpers.py' = ['ANN']
 'pyvista/core/utilities/image_sources.py' = ['ANN']
 'pyvista/core/utilities/observers.py' = ['ANN']
 'pyvista/core/utilities/parametric_objects.py' = ['N802']
-'pyvista/core/utilities/reader.py' = ['ANN', 'N802']
+# ElementTree does not resolve external entities, and .pvd files are trusted input
+'pyvista/core/utilities/reader.py' = ['ANN', 'N802', 'S314']
 'pyvista/demos/*' = ['ANN']
 'pyvista/errors.py' = ['ANN']
 'pyvista/examples/cells.py' = ['N802']
@@ -671,7 +677,8 @@ pyvista = "pv"
 'pyvista/plotting/axes_actor.py' = ['ANN']
 'pyvista/plotting/axes_assembly.py' = ['ANN']
 'pyvista/plotting/background_renderer.py' = ['ANN']
-'pyvista/plotting/camera.py' = ['ANN']
+# ElementTree does not resolve external entities, and .pvcc files are trusted input
+'pyvista/plotting/camera.py' = ['ANN', 'S314']
 'pyvista/plotting/charts.py' = ['ANN']
 'pyvista/plotting/colors.py' = ['ANN']
 'pyvista/plotting/composite_mapper.py' = ['ANN']
@@ -694,7 +701,8 @@ pyvista = "pv"
 'pyvista/plotting/text.py' = ['ANN']
 'pyvista/plotting/texture.py' = ['ANN']
 'pyvista/plotting/themes.py' = ['ANN', 'ICN001']
-'pyvista/plotting/tools.py' = ['ANN']
+# pgrep and xset live in distribution-specific directories
+'pyvista/plotting/tools.py' = ['ANN', 'S607']
 'pyvista/plotting/utilities/*.py' = ['ANN']
 'pyvista/plotting/utilities/algorithms.py' = ['N802', 'N803']
 'pyvista/plotting/volume.py' = ['ANN']
@@ -703,6 +711,16 @@ pyvista = "pv"
 'pyvista/report.py' = ['ANN']
 'pyvista/utilities/*' = ['ANN', 'F401'] # deprecated modules
 'tests/*' = ['ANN', 'D', 'FBT', 'INP', 'PLC0415', 'PLR0917', 'S101', 'T20']
+# These tests exercise the in-memory pickle protocol on objects they built themselves
+'tests/core/test_accessor_registry.py' = ['S301']
+'tests/core/test_dataobject.py' = ['S301']
+# `pass_data` selects which data arrays to pass through; it is not a password
+'tests/core/test_helpers.py' = ['S106']
+'tests/core/test_utilities.py' = ['S301']
+# Parses the junit report sphinx-gallery wrote during the docs build
+'tests/doc/doc_build/test_gallery_examples.py' = ['S314']
+# vale is resolved from PATH like every other developer tool
+'tests/doc/vale/check_expected_failures.py' = ['S607']
 'tests/examples/test_dataset_loader.py' = [
   'PTH102',
   'PTH107',
@@ -714,6 +732,7 @@ pyvista = "pv"
 ]
 # Sphinx-Gallery examples are rendered verbatim, like those under 'examples/'
 'tests/plotting/tinypages/gallery_src/*' = ['I002']
+'tests/security/test_pickle_refused.py' = ['S301']
 
 [tool.ruff.lint.pylint]
 max-positional-args = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -585,8 +585,7 @@ pyvista = "pv"
 '.claude/skills/*/scripts/*.py' = ['INP', 'T20']
 '__init__.py' = ['PLC0414']
 'doc/*' = ['ANN', 'INP', 'PLC0415']
-# git is resolved from PATH like every other developer tool
-'doc/make_dev_wheel.py' = ['S607']
+'doc/make_dev_wheel.py' = ['S607'] # git comes from PATH
 # A command-line script: it reports what it runs, like `make` does.
 'doc/run_vale.py' = ['T20']
 'doc/source/make_tables.py' = [
@@ -640,15 +639,13 @@ pyvista = "pv"
 'pyvista/core/utilities/cell.py' = ['ANN']
 'pyvista/core/utilities/docs.py' = ['ANN']
 'pyvista/core/utilities/features.py' = ['ANN']
-# `pass_data` selects which data arrays to pass through; it is not a password
-'pyvista/core/utilities/fileio.py' = ['S105']
+'pyvista/core/utilities/fileio.py' = ['S105'] # pass_data is not a password
 'pyvista/core/utilities/geometric_objects.py' = ['N802']
 'pyvista/core/utilities/helpers.py' = ['ANN']
 'pyvista/core/utilities/image_sources.py' = ['ANN']
 'pyvista/core/utilities/observers.py' = ['ANN']
 'pyvista/core/utilities/parametric_objects.py' = ['N802']
-# ElementTree does not resolve external entities, and .pvd files are trusted input
-'pyvista/core/utilities/reader.py' = ['ANN', 'N802', 'S314']
+'pyvista/core/utilities/reader.py' = ['ANN', 'N802', 'S314'] # .pvd is trusted
 'pyvista/demos/*' = ['ANN']
 'pyvista/errors.py' = ['ANN']
 'pyvista/examples/cells.py' = ['N802']
@@ -677,8 +674,7 @@ pyvista = "pv"
 'pyvista/plotting/axes_actor.py' = ['ANN']
 'pyvista/plotting/axes_assembly.py' = ['ANN']
 'pyvista/plotting/background_renderer.py' = ['ANN']
-# ElementTree does not resolve external entities, and .pvcc files are trusted input
-'pyvista/plotting/camera.py' = ['ANN', 'S314']
+'pyvista/plotting/camera.py' = ['ANN', 'S314'] # .pvcc is trusted
 'pyvista/plotting/charts.py' = ['ANN']
 'pyvista/plotting/colors.py' = ['ANN']
 'pyvista/plotting/composite_mapper.py' = ['ANN']
@@ -701,8 +697,7 @@ pyvista = "pv"
 'pyvista/plotting/text.py' = ['ANN']
 'pyvista/plotting/texture.py' = ['ANN']
 'pyvista/plotting/themes.py' = ['ANN', 'ICN001']
-# pgrep and xset live in distribution-specific directories
-'pyvista/plotting/tools.py' = ['ANN', 'S607']
+'pyvista/plotting/tools.py' = ['ANN', 'S607'] # pgrep and xset come from PATH
 'pyvista/plotting/utilities/*.py' = ['ANN']
 'pyvista/plotting/utilities/algorithms.py' = ['N802', 'N803']
 'pyvista/plotting/volume.py' = ['ANN']
@@ -711,16 +706,12 @@ pyvista = "pv"
 'pyvista/report.py' = ['ANN']
 'pyvista/utilities/*' = ['ANN', 'F401'] # deprecated modules
 'tests/*' = ['ANN', 'D', 'FBT', 'INP', 'PLC0415', 'PLR0917', 'S101', 'T20']
-# These tests exercise the in-memory pickle protocol on objects they built themselves
-'tests/core/test_accessor_registry.py' = ['S301']
-'tests/core/test_dataobject.py' = ['S301']
-# `pass_data` selects which data arrays to pass through; it is not a password
-'tests/core/test_helpers.py' = ['S106']
-'tests/core/test_utilities.py' = ['S301']
-# Parses the junit report sphinx-gallery wrote during the docs build
-'tests/doc/doc_build/test_gallery_examples.py' = ['S314']
-# vale is resolved from PATH like every other developer tool
-'tests/doc/vale/check_expected_failures.py' = ['S607']
+'tests/core/test_accessor_registry.py' = ['S301'] # unpickles its own objects
+'tests/core/test_dataobject.py' = ['S301'] # unpickles its own objects
+'tests/core/test_helpers.py' = ['S106'] # pass_data is not a password
+'tests/core/test_utilities.py' = ['S301'] # unpickles its own objects
+'tests/doc/doc_build/test_gallery_examples.py' = ['S314'] # gallery junit report
+'tests/doc/vale/check_expected_failures.py' = ['S607'] # vale comes from PATH
 'tests/examples/test_dataset_loader.py' = [
   'PTH102',
   'PTH107',
@@ -732,7 +723,7 @@ pyvista = "pv"
 ]
 # Sphinx-Gallery examples are rendered verbatim, like those under 'examples/'
 'tests/plotting/tinypages/gallery_src/*' = ['I002']
-'tests/security/test_pickle_refused.py' = ['S301']
+'tests/security/test_pickle_refused.py' = ['S301'] # unpickles its own objects
 
 [tool.ruff.lint.pylint]
 max-positional-args = 3

--- a/pyvista/core/utilities/reader_registry.py
+++ b/pyvista/core/utilities/reader_registry.py
@@ -153,13 +153,17 @@ _override_ext_readers: set[str] = set()
 _pending_ext_readers: dict[str, list[EntryPoint]] = {}
 _entry_points_loaded: bool = False
 _temp_files: list[str] = []
+_temp_dirs: list[str] = []
 
 
 def _cleanup_temp_files() -> None:
-    """Remove temporary files created by :func:`_download_uri`."""
+    """Remove temporary files and directories created by :func:`_download_uri`."""
     for path in _temp_files:
         Path(path).unlink(missing_ok=True)
     _temp_files.clear()
+    for path in _temp_dirs:
+        shutil.rmtree(path, ignore_errors=True)
+    _temp_dirs.clear()
 
 
 atexit.register(_cleanup_temp_files)
@@ -253,7 +257,13 @@ def _download_uri(uri: str, ext: str) -> str:
                 f'Install it with: pip install fsspec'
             )
             raise ImportError(msg)
-        result = pooch.retrieve(uri, known_hash=None, fname=f'pyvista_download{suffix}')  # type: ignore[attr-defined]  # pooch doesn't export retrieve in __all__
+        # A fresh directory per call: pooch reuses an existing file of the same name
+        # without checking it came from the same URL.
+        download_dir = tempfile.mkdtemp(prefix='pyvista_download_')
+        _temp_dirs.append(download_dir)
+        result = pooch.retrieve(  # type: ignore[attr-defined]  # pooch doesn't export retrieve in __all__
+            uri, known_hash=None, fname=f'download{suffix}', path=download_dir
+        )
         _temp_files.append(result)
         return result
 

--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 import weakref
 from xml.etree import ElementTree as ET
 
@@ -15,6 +15,9 @@ from pyvista.core._vtk_utilities import DisableVtkSnakeCase
 from pyvista.core.utilities.misc import _NoNewAttrMixin
 
 from .helpers import view_vectors
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class Camera(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkCamera):

--- a/pyvista/plotting/camera.py
+++ b/pyvista/plotting/camera.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 import weakref
-import xml.dom.minidom as md
 from xml.etree import ElementTree as ET
 
 import numpy as np
@@ -246,10 +245,8 @@ class Camera(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkCamera):
                 e.append(tmp)
                 e.append(ET.Element('Domain', dict(name='bool', id=f'0.{name}.bool')))
 
-        xmlstr = ET.tostring(root).decode()
-        newxml = md.parseString(xmlstr)
-        with Path(filename).open('w') as outfile:
-            outfile.write(newxml.toprettyxml(indent='\t', newl='\n'))
+        ET.indent(root, space='\t')
+        ET.ElementTree(root).write(filename, encoding='utf-8', xml_declaration=True)
 
     @property
     def position(self):  # numpydoc ignore=RT01

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1262,8 +1262,7 @@ def test_actual_memory_size(hexbeam):
 
 
 def test_copy_structure(hexbeam):
-    classname = hexbeam.__class__.__name__
-    copy = eval(f'pv.{classname}')()
+    copy = type(hexbeam)()
     copy.copy_structure(hexbeam)
     assert copy.n_cells == hexbeam.n_cells
     assert copy.n_points == hexbeam.n_points
@@ -1284,8 +1283,7 @@ def test_copy_structure_self(datasets):
 
 
 def test_copy_attributes(hexbeam):
-    classname = hexbeam.__class__.__name__
-    copy = eval(f'pv.{classname}')()
+    copy = type(hexbeam)()
     copy.copy_attributes(hexbeam)
     assert copy.n_cells == 0
     assert copy.n_points == 0

--- a/tests/core/test_reader_registry.py
+++ b/tests/core/test_reader_registry.py
@@ -317,22 +317,15 @@ def test_uri_downloads_are_not_reused_across_urls(tmp_path, local_http_server):
         's3://bucket/evil.pkl',
     ],
 )
-def test_remote_pickle_uri_refused(uri, tmp_path):
+def test_remote_pickle_uri_refused(uri):
     """Remote .pkl/.pickle URIs must be refused before download to prevent RCE."""
-    downloaded = False
-
-    def fake_retrieve(*_args, **_kwargs):
-        nonlocal downloaded
-        downloaded = True
-        return str(tmp_path / 'should-not-be-used')
-
-    with patch('pooch.retrieve', side_effect=fake_retrieve):
+    with patch('pooch.retrieve') as retrieve:
         with pytest.raises(
             ValueError, match='pickle is a Python serialization protocol, not a mesh'
         ):
             pv.read(uri)
 
-    assert downloaded is False, 'remote pickle must be refused before any download'
+    retrieve.assert_not_called()
 
 
 def test_s3_without_fsspec_raises():

--- a/tests/core/test_reader_registry.py
+++ b/tests/core/test_reader_registry.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import contextlib
+import functools
+from http.server import SimpleHTTPRequestHandler
+from http.server import ThreadingHTTPServer
 from importlib.metadata import EntryPoint
 import importlib.util
 from io import BytesIO
@@ -10,6 +13,7 @@ from pathlib import Path
 import re
 import subprocess
 import sys
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -270,6 +274,38 @@ def test_uri_downloads_then_reads_builtin_ext(tmp_path):
     dl.assert_called_once()
     assert isinstance(result, pv.PolyData)
     assert result.n_points == mesh.n_points
+
+
+class _QuietHandler(SimpleHTTPRequestHandler):
+    """Static file handler that keeps request logs out of the test output."""
+
+    def log_message(self, *_args):
+        """Drop the log line."""
+
+
+@pytest.fixture
+def local_http_server(tmp_path):
+    """Serve ``tmp_path`` over HTTP on a random localhost port."""
+    handler = functools.partial(_QuietHandler, directory=str(tmp_path))
+    server = ThreadingHTTPServer(('127.0.0.1', 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f'http://127.0.0.1:{server.server_address[1]}'
+    server.shutdown()
+    server.server_close()
+
+
+def test_uri_downloads_are_not_reused_across_urls(tmp_path, local_http_server):
+    """Two remote files sharing an extension must each be downloaded."""
+    pv.Sphere().save(tmp_path / 'first.vtp')
+    pv.Cube().save(tmp_path / 'second.vtp')
+
+    with patch.dict('sys.modules', {'fsspec': None}):
+        first = pv.read(f'{local_http_server}/first.vtp')
+        second = pv.read(f'{local_http_server}/second.vtp')
+
+    assert first.n_points == pv.Sphere().n_points
+    assert second.n_points == pv.Cube().n_points
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_reader_registry.py
+++ b/tests/core/test_reader_registry.py
@@ -281,14 +281,14 @@ def test_uri_downloads_then_reads_builtin_ext(tmp_path):
         's3://bucket/evil.pkl',
     ],
 )
-def test_remote_pickle_uri_refused(uri):
+def test_remote_pickle_uri_refused(uri, tmp_path):
     """Remote .pkl/.pickle URIs must be refused before download to prevent RCE."""
     downloaded = False
 
     def fake_retrieve(*_args, **_kwargs):
         nonlocal downloaded
         downloaded = True
-        return '/tmp/should-not-be-used'
+        return str(tmp_path / 'should-not-be-used')
 
     with patch('pooch.retrieve', side_effect=fake_retrieve):
         with pytest.raises(

--- a/tests/ext/test_ext.py
+++ b/tests/ext/test_ext.py
@@ -91,7 +91,7 @@ class _Builder:
 def test_offline_viewer_paths_use_builder_target_uri(
     tmp_path, monkeypatch, target_uri, expected_viewer_uri
 ):
-    monkeypatch.setattr(viewer_directive, 'HTML_VIEWER_PATH', '/tmp/viewer.html')
+    monkeypatch.setattr(viewer_directive, 'HTML_VIEWER_PATH', str(tmp_path / 'viewer.html'))
     out_dir = tmp_path / '_build' / 'html'
     dest_file = out_dir / '_images' / 'plot_directive' / 'guide' / 'scene.vtksz'
     dest_file.parent.mkdir(parents=True)
@@ -108,7 +108,7 @@ def test_offline_viewer_paths_use_builder_target_uri(
 
 
 def test_offline_viewer_paths_warns_for_asset_outside_images(tmp_path, monkeypatch, caplog):
-    monkeypatch.setattr(viewer_directive, 'HTML_VIEWER_PATH', '/tmp/viewer.html')
+    monkeypatch.setattr(viewer_directive, 'HTML_VIEWER_PATH', str(tmp_path / 'viewer.html'))
     out_dir = tmp_path / '_build' / 'html'
     dest_file = out_dir / 'plot_directive' / 'guide' / 'scene.vtksz'
     dest_file.parent.mkdir(parents=True)

--- a/tests/plotting/test_gc.py
+++ b/tests/plotting/test_gc.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
+import sys
 from typing import Any
 import weakref
 
@@ -86,7 +87,7 @@ def test_leak_pv() -> None:
     # PYTHONPATH: the copied conftest imports tests.gc_check, which is not
     # importable from tmp_path.
     result = subprocess.run(
-        ['pytest', '-v', str(test_file)],
+        [sys.executable, '-m', 'pytest', '-v', str(test_file)],
         cwd=tmp_path,
         capture_output=True,
         check=False,

--- a/tests/plotting/test_renderer.py
+++ b/tests/plotting/test_renderer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import re
 
 from hypothesis import given
@@ -108,10 +109,13 @@ def test_camera_position():
     assert isinstance(cpos, pv.CameraPosition)
 
     # Test str format is a list
-    assert eval(str(cpos)) == cpos.to_list()
+    assert ast.literal_eval(str(cpos)) == cpos.to_list()
 
-    # Test repr format is init-able
-    cpos2 = eval('pv.' + repr(cpos))
+    # Test repr format is a CameraPosition call with literal arguments
+    call = ast.parse(repr(cpos), mode='eval').body
+    assert isinstance(call, ast.Call)
+    assert call.func.id == pv.CameraPosition.__name__
+    cpos2 = pv.CameraPosition(**{kw.arg: ast.literal_eval(kw.value) for kw in call.keywords})
     assert cpos2 == cpos
 
 

--- a/tests/security/test_pickle_refused.py
+++ b/tests/security/test_pickle_refused.py
@@ -57,14 +57,14 @@ def test_dataobject_save_refuses_pickle(sphere, tmp_path, ext):
         's3://attacker-bucket/evil.pkl',
     ],
 )
-def test_remote_pickle_uri_refused_before_download(uri):
+def test_remote_pickle_uri_refused_before_download(uri, tmp_path):
     """Remote ``.pkl`` URIs must refuse before any network call — covers P-1a."""
     downloaded = False
 
     def fake_retrieve(*_args, **_kwargs):
         nonlocal downloaded
         downloaded = True
-        return '/tmp/should-not-be-used'
+        return str(tmp_path / 'should-not-be-used')
 
     with patch('pooch.retrieve', side_effect=fake_retrieve):
         with pytest.raises(ValueError, match=_REFUSAL_MATCH):

--- a/tests/security/test_pickle_refused.py
+++ b/tests/security/test_pickle_refused.py
@@ -57,20 +57,13 @@ def test_dataobject_save_refuses_pickle(sphere, tmp_path, ext):
         's3://attacker-bucket/evil.pkl',
     ],
 )
-def test_remote_pickle_uri_refused_before_download(uri, tmp_path):
+def test_remote_pickle_uri_refused_before_download(uri):
     """Remote ``.pkl`` URIs must refuse before any network call — covers P-1a."""
-    downloaded = False
-
-    def fake_retrieve(*_args, **_kwargs):
-        nonlocal downloaded
-        downloaded = True
-        return str(tmp_path / 'should-not-be-used')
-
-    with patch('pooch.retrieve', side_effect=fake_retrieve):
+    with patch('pooch.retrieve') as retrieve:
         with pytest.raises(ValueError, match=_REFUSAL_MATCH):
             pv.read(uri)
 
-    assert downloaded is False, 'remote pickle URI must refuse before download'
+    retrieve.assert_not_called()
 
 
 def test_force_ext_pickle_refused(tmp_path):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -83,13 +83,13 @@ PLOTTING_VTKMODULES = CORE_VTKMODULES | {
 
 
 def exec_success(code: str):
-    return os.system(f'{sys.executable} -c "{code}"') == 0
+    return subprocess.run([sys.executable, '-c', code], check=False).returncode == 0
 
 
 def _module_is_loaded(module_to_check: str, module_to_import: str = 'pyvista') -> bool:
     """This function checks if the specified module is loaded after calling `import pyvista`
 
-    We use ``os.system`` because we need to test the import of pyvista
+    We use a subprocess because we need to test the import of pyvista
     outside of the pytest unit test framework as pytest loads vtk.
     """
     exe_str = (


### PR DESCRIPTION
### Overview

Security pass over the package, the CLI and CI. Ruff now selects the whole flake8-bandit `S` family; each finding is fixed or carries a one-line per-file ignore saying why it is a false positive. The review turned up two real bugs: `pv.read` of a second http URL with the same extension returned the first download, because pooch reuses a fixed-name cache file when no hash is given, and the Netlify deploy workflow took a PR's fork status and head SHA from an artifact the fork's own run wrote, so a fork could pick the ungated deployment environment.

The rest is one commit per workflow hardening, so any can be dropped: labels are applied through the API instead of a Node 12 action under `pull_request_target`, permissions are granted per job, matrix values reach `run` steps through `env`, and remote inputs are checksummed, sanitized or pinned. Left alone on purpose: the slim Docker image runs as root, example datasets download without hashes, and `USE_CACHE` reads a `workflow_dispatch` input that neither workflow declares.

Changes drafted by Claude Fable 5.1 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5.1)
