### PR TITLE
Deprecate `ActorProperties` and use `Property` in `AxesActor`

### DIFF
--- a/pyvista/plotting/_property.py
+++ b/pyvista/plotting/_property.py
@@ -1223,6 +1223,82 @@ class Property(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkProperty):
         _check_range(value, (0, 1), 'anisotropy')
         self.SetAnisotropy(value)
 
+    @property
+    def anisotropy_rotation(self) -> float:  # numpydoc ignore=RT01
+        """Return or set the anisotropy rotation coefficient.
+
+        This value controls the rotation of the direction of the anisotropy.
+        This requires that the :attr:`interpolation` be set to
+        ``'Physically based rendering'``.
+
+        For further details see `PBR Journey Part 2 : Anisotropy model with VTK
+        <https://www.kitware.com/pbr-journey-part-2-anisotropy-model-with-vtk/>`_
+
+        Property has range ``[0.0, 1.0]``.
+
+        .. versionadded:: 0.49
+
+        Examples
+        --------
+        Get the default anisotropy rotation.
+
+        >>> import pyvista as pv
+        >>> prop = pv.Property()
+        >>> prop.anisotropy_rotation
+        0.0
+
+        Set the anisotropy rotation.
+
+        >>> prop.anisotropy_rotation = 0.25
+        >>> prop.anisotropy_rotation
+        0.25
+
+        """
+        return self.GetAnisotropyRotation()
+
+    @anisotropy_rotation.setter
+    def anisotropy_rotation(self, value: float):
+        _check_range(value, (0, 1), 'anisotropy_rotation')
+        self.SetAnisotropyRotation(value)
+
+    @property
+    def index_of_refraction(self) -> float:  # numpydoc ignore=RT01
+        """Return or set the index of refraction of the base layer.
+
+        This value controls the amount of light reflected at normal incidence.
+        This requires that the :attr:`interpolation` be set to
+        ``'Physically based rendering'``.
+
+        For further details see `PBR Journey Part 3 : Clear Coat Model with VTK
+        <https://www.kitware.com/pbr-journey-part-3-clear-coat-model-with-vtk/>`_
+
+        Property has range ``[1.0, inf)``.
+
+        .. versionadded:: 0.49
+
+        Examples
+        --------
+        Get the default index of refraction.
+
+        >>> import pyvista as pv
+        >>> prop = pv.Property()
+        >>> prop.index_of_refraction
+        1.5
+
+        Set the index of refraction.
+
+        >>> prop.index_of_refraction = 2.0
+        >>> prop.index_of_refraction
+        2.0
+
+        """
+        return self.GetBaseIOR()
+
+    @index_of_refraction.setter
+    def index_of_refraction(self, value: float):
+        _check_range(value, (1, float('inf')), 'index_of_refraction')
+        self.SetBaseIOR(value)
+
     def plot(self, **kwargs) -> None:
         """Plot this property on the Stanford Bunny.
 

--- a/pyvista/plotting/actor_properties.py
+++ b/pyvista/plotting/actor_properties.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from pyvista._warn_external import warn_external
+from pyvista.core.errors import PyVistaDeprecationWarning
 from pyvista.core.utilities.misc import _NoNewAttrMixin
 
 from .opts import InterpolationType
@@ -18,31 +20,25 @@ class ActorProperties(_NoNewAttrMixin):
 
     Contains the surface properties of the object.
 
+    .. deprecated:: 0.49
+        Use :class:`pyvista.Property` instead. Its
+        :attr:`~pyvista.Property.interpolation` replaces ``interpolation_model``,
+        and ``shading`` has no equivalent.
+
     Parameters
     ----------
     properties : :vtk:`vtkProperty`
         VTK properties of the current object.
 
-    Examples
-    --------
-    Access the properties of the z-axis shaft.
-
-    >>> import pyvista as pv
-
-    >>> axes = pv.Axes()
-    >>> z_axes_prop = axes.axes_actor.z_axis_shaft_properties
-    >>> z_axes_prop.color = (1.0, 1.0, 0.0)
-    >>> z_axes_prop.opacity = 0.5
-    >>> axes.axes_actor.shaft_type = axes.axes_actor.ShaftType.CYLINDER
-
-    >>> pl = pv.Plotter()
-    >>> _ = pl.add_actor(axes.axes_actor)
-    >>> _ = pl.add_mesh(pv.Sphere())
-    >>> pl.show()
-
     """
 
     def __init__(self, properties: _vtk.vtkProperty) -> None:
+        """Initialize the wrapper."""
+        # deprecated 0.49, convert to error in 0.52, remove 0.53
+        warn_external(
+            '`ActorProperties` is deprecated. Use `pyvista.Property` instead.',
+            PyVistaDeprecationWarning,
+        )
         super().__init__()
         self.properties = properties
 

--- a/pyvista/plotting/axes_actor.py
+++ b/pyvista/plotting/axes_actor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from enum import Enum
+from typing import cast
 
 import pyvista as pv
 from pyvista import _vtk
@@ -13,7 +14,7 @@ from pyvista.core.utilities.misc import _BoundsSizeMixin
 from pyvista.core.utilities.misc import _NameMixin
 from pyvista.core.utilities.misc import _NoNewAttrMixin
 
-from .actor_properties import ActorProperties
+from ._property import Property
 
 
 class AxesActor(
@@ -25,6 +26,10 @@ class AxesActor(
     can define the geometry to use for the shaft or the tip, and the
     user can set the text for the three axes. To see full customization
     options, refer to :vtk:`vtkAxesActor`.
+
+    .. versionchanged:: 0.49
+        The shaft and tip properties are :class:`~pyvista.Property` objects
+        instead of ``ActorProperties``, and each can be assigned.
 
     See Also
     --------
@@ -86,6 +91,18 @@ class AxesActor(
     def __init__(self):
         """Initialize actor."""
         super().__init__()
+
+        actors = _vtk.vtkPropCollection()
+        self.GetActors(actors)
+        self._actors = cast(
+            'list[_vtk.vtkActor]',
+            [actors.GetItemAsObject(i) for i in range(actors.GetNumberOfItems())],
+        )
+        for actor in self._actors:
+            # Copy VTK's defaults so wrapping does not change how the axes render
+            prop = Property()
+            prop.DeepCopy(actor.GetProperty())
+            actor.SetProperty(prop)
 
         self.x_axis_shaft_properties.color = pv.global_theme.axes.x_color.float_rgb
         self.x_axis_tip_properties.color = pv.global_theme.axes.x_color.float_rgb
@@ -526,43 +543,55 @@ class AxesActor(
         self.SetZAxisLabelText(label)
 
     @property
-    def x_axis_shaft_properties(self):  # numpydoc ignore=RT01
+    def x_axis_shaft_properties(self) -> Property:  # numpydoc ignore=RT01
         """Return or set the properties of the x-axis shaft."""
-        return ActorProperties(self.GetXAxisShaftProperty())
+        return cast('Property', self.GetXAxisShaftProperty())
+
+    @x_axis_shaft_properties.setter
+    def x_axis_shaft_properties(self, properties: Property):
+        self._actors[0].SetProperty(properties)
 
     @property
-    def y_axis_shaft_properties(self):  # numpydoc ignore=RT01
+    def y_axis_shaft_properties(self) -> Property:  # numpydoc ignore=RT01
         """Return or set the properties of the y-axis shaft."""
-        return ActorProperties(self.GetYAxisShaftProperty())
+        return cast('Property', self.GetYAxisShaftProperty())
+
+    @y_axis_shaft_properties.setter
+    def y_axis_shaft_properties(self, properties: Property):
+        self._actors[1].SetProperty(properties)
 
     @property
-    def z_axis_shaft_properties(self):  # numpydoc ignore=RT01
+    def z_axis_shaft_properties(self) -> Property:  # numpydoc ignore=RT01
         """Return or set the properties of the z-axis shaft."""
-        return ActorProperties(self.GetZAxisShaftProperty())
+        return cast('Property', self.GetZAxisShaftProperty())
+
+    @z_axis_shaft_properties.setter
+    def z_axis_shaft_properties(self, properties: Property):
+        self._actors[2].SetProperty(properties)
 
     @property
-    def x_axis_tip_properties(self):  # numpydoc ignore=RT01
+    def x_axis_tip_properties(self) -> Property:  # numpydoc ignore=RT01
         """Return or set the properties of the x-axis tip."""
-        return ActorProperties(self.GetXAxisTipProperty())
+        return cast('Property', self.GetXAxisTipProperty())
 
     @x_axis_tip_properties.setter
-    def x_axis_tip_properties(self, properties: ActorProperties):
-        self.x_axis_tip_properties = properties
+    def x_axis_tip_properties(self, properties: Property):
+        self._actors[3].SetProperty(properties)
 
     @property
-    def y_axis_tip_properties(self):  # numpydoc ignore=RT01
+    def y_axis_tip_properties(self) -> Property:  # numpydoc ignore=RT01
         """Return or set the properties of the y-axis tip."""
-        return ActorProperties(self.GetYAxisTipProperty())
+        return cast('Property', self.GetYAxisTipProperty())
 
     @y_axis_tip_properties.setter
-    def y_axis_tip_properties(self, properties: ActorProperties):
-        self.y_axis_tip_properties = properties
+    def y_axis_tip_properties(self, properties: Property):
+        self._actors[4].SetProperty(properties)
 
     @property
-    def z_axis_tip_properties(self):  # numpydoc ignore=RT01
+    def z_axis_tip_properties(self) -> Property:  # numpydoc ignore=RT01
         """Return or set the properties of the z-axis tip."""
-        return ActorProperties(self.GetZAxisTipProperty())
+        return cast('Property', self.GetZAxisTipProperty())
 
     @z_axis_tip_properties.setter
-    def z_axis_tip_properties(self, properties: ActorProperties):
-        self.z_axis_tip_properties = properties
+    def z_axis_tip_properties(self, properties: Property):
+        self._actors[5].SetProperty(properties)

--- a/tests/doc/test_api_coverage.py
+++ b/tests/doc/test_api_coverage.py
@@ -49,7 +49,7 @@ _VERSION_CONDITIONAL_UNDOCUMENTED: set[str] = set()
 
 _ALLOWED_UNDOCUMENTED = frozenset(
     {
-        'ActorProperties',  # similar to Property but uses composition - should be deprecated
+        'ActorProperties',  # deprecated in favor of Property
         'AnnotatedIntEnum',  # base class for internal int-enum types
         'BackgroundPlotter',  # deprecated and moved to pyvistaqt
         'BasePlotter',  # abstract base; Plotter subclass is documented

--- a/tests/plotting/test_axes.py
+++ b/tests/plotting/test_axes.py
@@ -163,8 +163,28 @@ def test_axes_actor_labels_group(axes_actor):
         axes_actor.labels = ['1', '2']
 
 
-def test_axes_actor_properties():
-    prop = pv.ActorProperties(_vtk.vtkProperty())
+@pytest.mark.parametrize('axis', ['x', 'y', 'z'])
+@pytest.mark.parametrize('part', ['shaft', 'tip'])
+def test_axes_actor_properties(axes_actor, axis, part):
+    name = f'{axis}_axis_{part}_properties'
+    vtk_getter = getattr(axes_actor, f'Get{axis.upper()}Axis{part.title()}Property')
+
+    prop = getattr(axes_actor, name)
+    assert isinstance(prop, pv.Property)
+    assert vtk_getter() is prop
+    assert prop.color == getattr(pv.global_theme.axes, f'{axis}_color')
+    assert prop.interpolation == InterpolationType.GOURAUD
+
+    new_prop = pv.Property(color='purple')
+    setattr(axes_actor, name, new_prop)
+    assert getattr(axes_actor, name) is new_prop
+    assert vtk_getter() is new_prop
+
+
+def test_actor_properties_deprecated():
+    assert pv.version_info < (0, 52), 'Convert the `ActorProperties` deprecation to an error.'
+    with pytest.warns(pv.PyVistaDeprecationWarning, match='Use `pyvista.Property` instead'):
+        prop = pv.ActorProperties(_vtk.vtkProperty())
 
     prop.color = (1, 1, 1)
     assert prop.color == (1, 1, 1)

--- a/tests/plotting/test_property.py
+++ b/tests/plotting/test_property.py
@@ -238,3 +238,19 @@ def test_property_anisotropy(prop):
     assert isinstance(prop.anisotropy, float)
     prop.anisotropy = value
     assert prop.anisotropy == value
+
+
+def test_property_anisotropy_rotation(prop):
+    assert prop.anisotropy_rotation == 0.0
+    prop.anisotropy_rotation = 0.25
+    assert prop.anisotropy_rotation == 0.25
+    with pytest.raises(ValueError, match='outside the acceptable range'):
+        prop.anisotropy_rotation = 2.0
+
+
+def test_property_index_of_refraction(prop):
+    assert prop.index_of_refraction == 1.5
+    prop.index_of_refraction = 2.0
+    assert prop.index_of_refraction == 2.0
+    with pytest.raises(ValueError, match='outside the acceptable range'):
+        prop.index_of_refraction = 0.5

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import Counter
+import contextlib
 from dataclasses import is_dataclass
 from enum import Enum
 import importlib.util
@@ -181,8 +182,12 @@ def pytest_generate_tests(metafunc):
 def try_init_pyvista_object(class_):
     # Init object but skip if abstract
     kwargs = get_default_class_init_kwargs(class_)
+    ctx = contextlib.nullcontext()
+    if class_ is pv.ActorProperties:
+        ctx = pytest.warns(pv.PyVistaDeprecationWarning)
     try:
-        instance = class_(**kwargs)
+        with ctx:
+            instance = class_(**kwargs)
     except (VTKVersionError, ImportError):
         pytest.skip('VTK Version not supported.')
     except TypeError as e:


### PR DESCRIPTION
### Overview

Supersedes #6192. `ActorProperties` wraps a `vtkProperty` by composition and duplicates most of `Property`, which wraps it by inheritance like the rest of the plotting API. This deprecates `ActorProperties`, makes the six shaft and tip accessors on `AxesActor` return and accept `Property` objects (the tip setters on main recursed into themselves), and adds the two `ActorProperties` attributes that `Property` lacked, `anisotropy_rotation` and `index_of_refraction`.

The axes deep-copy VTK's own defaults into the new properties, so nothing renders differently and no image baselines change. The accessor return type is a deliberate break rather than a warned one: `color` is now a `Color` instead of a 3-tuple, `interpolation_model` is `interpolation`, and `shading` is not carried over because it has no effect in the OpenGL backend. `ActorProperties` never appeared in the rendered API reference.

Changes drafted by Claude Fable 5.1 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5.1)
