### PR TITLE
Return the selected points of a `PointSet` from `extract_points`

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -4725,7 +4725,7 @@ class DataSetFilters(DataObjectFilters):
         self: _DataSetType,
         ind: int | VectorLike[int] | VectorLike[bool],
         adjacent_cells: bool = True,  # noqa: FBT001, FBT002
-        include_cells: bool = True,  # noqa: FBT001, FBT002
+        include_cells: bool | None = None,  # noqa: FBT001
         pass_cell_ids: bool = True,  # noqa: FBT001, FBT002
         pass_point_ids: bool = True,  # noqa: FBT001, FBT002
         progress_bar: bool = False,  # noqa: FBT001, FBT002
@@ -4743,8 +4743,10 @@ class DataSetFilters(DataObjectFilters):
             contain exclusively points from the extracted points list.
             Has no effect if ``include_cells`` is ``False``.
 
-        include_cells : bool, default: True
-            Specifies if the cells shall be returned or not.
+        include_cells : bool, default: None
+            Specifies if the cells shall be returned or not. By default, this value is
+            ``True`` if the input has at least one cell and ``False`` otherwise, so
+            :class:`~pyvista.PointSet` input returns the selected points.
 
         pass_point_ids : bool, default: True
             Add a point array ``'vtkOriginalPointIds'`` that identifies the original
@@ -4784,6 +4786,8 @@ class DataSetFilters(DataObjectFilters):
 
         """
         ind = np.array(ind)
+        if include_cells is None:
+            include_cells = self.n_cells > 0
         # Create selection objects
         selectionNode = _vtk.vtkSelectionNode()
         selectionNode.SetFieldType(_vtk.vtkSelectionNode.POINT)

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -2360,6 +2360,18 @@ def test_extract_points_default(extracted_with_adjacent_true):
     assert np.array_equal(sub_surf_adj.cells, expected_surf.cells)
 
 
+def test_extract_points_pointset(pointset):
+    ind = [0, 1]
+    extracted = pointset.extract_points(ind)
+    assert isinstance(extracted, pv.PointSet)
+    assert extracted.n_points == len(ind)
+    assert np.array_equal(extracted.points, pointset.points[ind])
+    assert extracted['vtkOriginalPointIds'].tolist() == ind
+
+    # Cells can still be requested explicitly, but a point set has none
+    assert pointset.extract_points(ind, include_cells=True).n_points == 0
+
+
 def test_extract_cells(sphere):
     ind = 0
     n_cells = 1


### PR DESCRIPTION
### Overview

`extract_points` asks VTK for the cells containing the selected points, and a `PointSet` has none, so `pointset.extract_points([0, 1])` returned an empty `PointSet`. `include_cells` now defaults to whether the input has cells, as `extract_values` already does, so point clouds return the selected points while meshes behave as before.

- Overlaps with the `extract_points` signature edits in #9101; whichever merges second needs a trivial merge.

Changes drafted by Claude Fable 5.1 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5.1)
