### PR TITLE
Cast `connectivity` output with `extract_values` instead of `vtkRemovePolyData`

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -2340,31 +2340,6 @@ class DataSetFilters(DataObjectFilters):
                 raise ValueError(msg)
             return np.unique(ids)
 
-        def _post_process_extract_values(before_extraction, extracted):
-            # Output is UnstructuredGrid, so apply vtkRemovePolyData
-            # to input to cast the output as PolyData type instead
-            has_cells = extracted.n_cells != 0
-            if isinstance(before_extraction, pv.PolyData):
-                all_ids = set(range(before_extraction.n_cells))
-
-                ids_to_keep = set()
-                if has_cells:
-                    ids_to_keep |= set(extracted['vtkOriginalCellIds'])
-                ids_to_remove = list(all_ids - ids_to_keep)
-                if len(ids_to_remove) != 0:
-                    remove = _vtk.vtkRemovePolyData()
-                    remove.SetInputData(before_extraction)
-                    remove.SetCellIds(numpy_to_idarr(ids_to_remove))
-                    _update_alg(remove, progress_bar=progress_bar, message='Removing Cells.')
-                    extracted = _get_output(remove)
-                    extracted.clean(
-                        point_merging=False,
-                        inplace=True,
-                        progress_bar=progress_bar,
-                    )  # remove unused points
-
-            return extracted
-
         # Store active scalars info to restore later if needed
         active_field, active_name = self.active_scalars_info
 
@@ -2413,12 +2388,14 @@ class DataSetFilters(DataObjectFilters):
                     # Use extract_values to ensure that cells with at least one
                     # point within the range are kept (this is consistent
                     # with how the filter operates for other modes)
-                    extracted = DataSetFilters.extract_values(
+                    input_mesh = DataSetFilters.extract_values(
                         input_mesh,
                         ranges=scalar_range,
+                        pass_point_ids=False,
+                        pass_cell_ids=False,
+                        match_input_type=True,
                         progress_bar=progress_bar,
                     )
-                    input_mesh = _post_process_extract_values(input_mesh, extracted)
 
         alg = _vtk.vtkConnectivityFilter()
         alg.SetInputDataObject(input_mesh)
@@ -2530,12 +2507,14 @@ class DataSetFilters(DataObjectFilters):
         elif extraction_mode == 'specified':
             # All regions were initially extracted, so extract only the
             # specified regions
-            extracted = DataSetFilters.extract_values(
+            output = DataSetFilters.extract_values(
                 output,
                 values=region_ids,
+                pass_point_ids=False,
+                pass_cell_ids=False,
+                match_input_type=True,
                 progress_bar=progress_bar,
             )
-            output = _post_process_extract_values(output, extracted)
 
             if label_regions:
                 # Extracted regions may not be contiguous and zero-based

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -1297,6 +1297,18 @@ def test_connectivity_label_regions(datasets, dataset_index, extraction_mode):
     assert conn.active_scalars_info[1] == active_scalars_info[1]
 
 
+@pytest.mark.parametrize('extraction_mode', ['all', 'specified'])
+@pytest.mark.parametrize('scalar_range', [None, [0.0, 1.0]])
+def test_connectivity_scalar_range_polydata(sphere, extraction_mode, scalar_range):
+    sphere['z'] = sphere.points[:, 2]
+    scalar_range = sphere.get_data_range() if scalar_range is None else scalar_range
+    conn = sphere.connectivity(extraction_mode, region_ids=[0], scalar_range=scalar_range)
+    assert isinstance(conn, pv.PolyData)
+    assert 'vtkOriginalPointIds' not in conn.point_data
+    assert 'vtkOriginalCellIds' not in conn.cell_data
+    assert conn.n_cells == (sphere.n_cells if scalar_range[0] < 0 else 870)
+
+
 def test_connectivity_raises(
     connected_datasets_single_disconnected_cell,
 ):


### PR DESCRIPTION
### Overview

Stacked on #9101. `connectivity` rebuilt `PolyData` from an `extract_values` result with `vtkRemovePolyData` plus `clean`; with `match_input_type=True` the extraction returns `PolyData` itself, so that post-processing goes. The old path also returned an `UnstructuredGrid` for `PolyData` input when the scalar range removed nothing and in `'specified'` mode, which the new test pins.

Changes drafted by Claude Fable 5.1 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5.1)
