### PR TITLE
Fix the cvista integration job

### DIFF
--- a/pyvista/ext/_autoinherit.py
+++ b/pyvista/ext/_autoinherit.py
@@ -32,6 +32,8 @@ from sphinx.ext.autosummary import extract_summary
 from sphinx.util import logging
 from sphinx.util.docstrings import prepare_docstring
 
+from pyvista.core._vtk_utilities import _VTK_MODULE_PREFIXES
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from collections.abc import Sequence
@@ -277,7 +279,8 @@ def _is_vtk(cls: type) -> bool:
     # ``vtkmodules`` also holds pure-Python helpers -- ``VTKObjectWrapper`` in
     # ``numpy_interface`` -- that VTK does not document, so the ``:vtk:`` role, which
     # checks every target against vtk.org, cannot resolve them.
-    return cls.__module__.startswith('vtkmodules.vtk')
+    root, _, module = cls.__module__.partition('.')
+    return f'{root}.' in _VTK_MODULE_PREFIXES and module.startswith('vtk')
 
 
 def _vtk_entry_points(cls: type) -> list[type]:

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -16,6 +16,7 @@ from pyvista import examples
 from pyvista.core import _vtk_utilities
 from pyvista.core.dataobject import USER_DICT_KEY
 from pyvista.core.utilities.writer import BaseWriter
+from tests.vtk_backend_divergence import INT32_COMPRESSION
 
 
 def test_eq_wrong_type(sphere):
@@ -488,6 +489,7 @@ def test_save_raises_no_writers(monkeypatch: pytest.MonkeyPatch):
         pv.Sphere().save('foo.vtp')
 
 
+@pytest.mark.skip_vtk_backend('cvista', reason=INT32_COMPRESSION)
 def test_save_compression(sphere, tmp_path):
     # int32 indices compress less, so pin the width the ratio below assumes.
     sphere = pv.PolyData(sphere.points, faces=sphere.faces.astype(np.int64))

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -19,6 +19,7 @@ from pyvista.core.utilities.points import make_tri_mesh
 from pyvista.examples import cells
 from tests.core.test_dataobject_filters import grid_with_invalid_arrays  # noqa: F401
 from tests.core.test_dataobject_filters import sphere_with_invalid_arrays  # noqa: F401
+from tests.vtk_backend_divergence import INT32_CELL_STORAGE
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -419,6 +420,7 @@ def test_to_from_trimesh_empty_mesh():
     assert isinstance(pvmesh, pv.PolyData)
 
 
+@pytest.mark.skip_vtk_backend('cvista', reason=INT32_CELL_STORAGE)
 def test_to_from_trimesh_points_faces(ant):
     # Zero-copy sharing requires int64 connectivity, which a reader is free not
     # to produce, so build it rather than inheriting it from the example file.


### PR DESCRIPTION
The cvista integration job has failed since 2026-09-03 on four tests in the core phase, all introduced from the pyvista side.

- `_is_vtk` in the autoinherit extension only recognised `vtkmodules.vtk*` modules, so cvista's `cvista.vtk*` bases were missing from the inheritance rows; it now uses the backend-aware `_VTK_MODULE_PREFIXES`.
- #9056 replaced the cvista skips on `test_to_from_trimesh_points_faces` and `test_save_compression` with an int64 cast, but cvista stores the legacy cell import as int32 whatever the input dtype, so the skips are restored with their existing reasons.

Resolves #9053

Changes drafted by Claude Fable 5.1 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5.1)
