### PR TITLE
ci: Stop re-running merge queue work after the merge

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -170,11 +170,6 @@ jobs:
           name: pyvista-notebooks
           path: _notebooks
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: doc-failed-test-images
-          path: _doc_failed_test_images
-
   # Republishes the matched build under this run, so everything downstream —
   # `publish-notebooks` here, the Netlify deploy over in `netlify-deploy.yml` —
   # keeps reading `docs-build` from the run it was triggered by. The dev wheel
@@ -211,17 +206,6 @@ jobs:
           run-id: ${{ needs.resolve.outputs.run-id }}
           github-token: ${{ github.token }}
 
-      # The doc image report deploys from a push to `main`, and reports on a
-      # green build as well as a failing one, so it needs these carried over.
-      # A run that compared no images uploads nothing, hence the tolerance.
-      - uses: actions/download-artifact@v8
-        continue-on-error: true
-        with:
-          name: doc-failed-test-images
-          path: _doc_failed_test_images
-          run-id: ${{ needs.resolve.outputs.run-id }}
-          github-token: ${{ github.token }}
-
       - name: Rebuild development wheel and simple index
         run: |
           rm -rf doc/_build/html/wheels
@@ -237,11 +221,6 @@ jobs:
         with:
           name: pyvista-notebooks
           path: _notebooks
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: doc-failed-test-images
-          path: _doc_failed_test_images
 
   test:
     name: Test Documentation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -190,8 +190,8 @@ jobs:
   # Republishes the matched build under this run, so everything downstream —
   # `publish-notebooks` here, the Netlify deploy over in `netlify-deploy.yml` —
   # keeps reading `docs-build` from the run it was triggered by. The dev wheel
-  # is the one piece that cannot be copied: its version embeds the commit SHA,
-  # so it is rebuilt here against the commit that actually landed.
+  # is rebuilt rather than copied: its version embeds the commit SHA, and two
+  # commits can share a tree.
   reuse:
     name: Reuse Documentation Build
     runs-on: ubuntu-22.04
@@ -242,13 +242,13 @@ jobs:
   test:
     name: Test Documentation
     runs-on: blacksmith-8vcpu-ubuntu-2204
-    needs: doc
-    # The merge queue tests the docs built from the tree that lands on `main`.
-    # Repeating that after the merge only ever reports a failure the queue
-    # would already have blocked, so a branch push skips it and the doc image
-    # report has nothing to publish. Tag builds are tested: they are what
-    # docs.pyvista.org serves.
-    if: ${{ !cancelled() && (github.event_name != 'push' || startsWith(github.ref, 'refs/tags/')) }}
+    needs: [doc, resolve]
+    # The merge queue tests the docs built from the tree that lands on `main`,
+    # so repeating that after the merge only reports a failure the queue would
+    # already have blocked. A push that matched no queue run built its docs
+    # here and is tested, as are tag builds: they are what docs.pyvista.org
+    # serves.
+    if: ${{ !cancelled() && (github.event_name != 'push' || startsWith(github.ref, 'refs/tags/') || needs.resolve.outputs.run-id == '') }}
     env:
       TOX_COLORED: "yes"
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -170,22 +170,10 @@ jobs:
           name: pyvista-notebooks
           path: _notebooks
 
-      # Advertise this build to the push to `main` that follows it out of the
-      # queue. The step `if` carries an implicit `success()`, so a build that
-      # failed any upload above never advertises itself.
-      - name: Record the tree that was built
-        id: tree
-        if: github.event_name == 'merge_group'
-        run: |
-          echo "sha=$(git rev-parse 'HEAD^{tree}')" >> "$GITHUB_OUTPUT"
-          touch tree-marker
-
-      - name: Upload the tree marker
-        if: github.event_name == 'merge_group'
-        uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@v7
         with:
-          name: docs-tree-${{ steps.tree.outputs.sha }}
-          path: tree-marker
+          name: doc-failed-test-images
+          path: _doc_failed_test_images
 
   # Republishes the matched build under this run, so everything downstream —
   # `publish-notebooks` here, the Netlify deploy over in `netlify-deploy.yml` —
@@ -223,6 +211,17 @@ jobs:
           run-id: ${{ needs.resolve.outputs.run-id }}
           github-token: ${{ github.token }}
 
+      # The doc image report deploys from a push to `main`, and reports on a
+      # green build as well as a failing one, so it needs these carried over.
+      # A run that compared no images uploads nothing, hence the tolerance.
+      - uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: doc-failed-test-images
+          path: _doc_failed_test_images
+          run-id: ${{ needs.resolve.outputs.run-id }}
+          github-token: ${{ github.token }}
+
       - name: Rebuild development wheel and simple index
         run: |
           rm -rf doc/_build/html/wheels
@@ -238,6 +237,11 @@ jobs:
         with:
           name: pyvista-notebooks
           path: _notebooks
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: doc-failed-test-images
+          path: _doc_failed_test_images
 
   test:
     name: Test Documentation
@@ -290,6 +294,25 @@ jobs:
         with:
           name: doc-generated-test-images
           path: _doc_generated_test_images
+
+      # Advertise this build to the push to `main` that follows it out of the
+      # queue. Recorded here rather than in `doc` so a marker means the tree was
+      # built and tested, which is what lets the push skip both. The step `if`
+      # carries an implicit `success()`, so a run that failed never advertises
+      # itself.
+      - name: Record the tree that was built
+        id: tree
+        if: github.event_name == 'merge_group'
+        run: |
+          echo "sha=$(git rev-parse 'HEAD^{tree}')" >> "$GITHUB_OUTPUT"
+          touch tree-marker
+
+      - name: Upload the tree marker
+        if: github.event_name == 'merge_group'
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-tree-${{ steps.tree.outputs.sha }}
+          path: tree-marker
 
   # Netlify deploys (preview, image report, release) live in docs-deploy.yml,
   # triggered via workflow_run. Keeping them out of this workflow means fork PR

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -157,7 +157,12 @@ jobs:
     name: Test Documentation
     runs-on: blacksmith-8vcpu-ubuntu-2204
     needs: doc
-    if: ${{ !cancelled() }}
+    # The merge queue tests the docs built from the tree that lands on `main`.
+    # Repeating that after the merge only ever reports a failure the queue
+    # would already have blocked, so a branch push skips it and the doc image
+    # report has nothing to publish. Tag builds are tested: they are what
+    # docs.pyvista.org serves.
+    if: ${{ !cancelled() && (github.event_name != 'push' || startsWith(github.ref, 'refs/tags/')) }}
     env:
       TOX_COLORED: "yes"
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,8 +45,20 @@ jobs:
           name: pr-info
           path: pr-info/
 
+  # A push to `main` comes out of the merge queue, which has already built the
+  # docs from the same tree on the same paid runner. Find that build so the
+  # push can publish it instead of paying for it twice.
+  resolve:
+    name: Find a matching build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/find-tree-build.yml
+    with:
+      marker-prefix: docs-tree
+
   cache-pyvista-data:
     name: Cache pyvista/data
+    needs: resolve
+    if: ${{ !cancelled() && needs.resolve.outputs.run-id == '' }}
     uses: ./.github/workflows/cache-pyvista-data.yml
     with:
       # Runner should match the actual runner used by the build job
@@ -55,7 +67,8 @@ jobs:
   doc:
     name: Build Documentation
     runs-on: blacksmith-8vcpu-ubuntu-2204
-    needs: cache-pyvista-data
+    needs: [cache-pyvista-data, resolve]
+    if: ${{ !cancelled() && needs.cache-pyvista-data.result == 'success' && needs.resolve.outputs.run-id == '' }}
     env:
       TOX_COLORED: "yes"
       PYVISTA_DATA: ${{ github.workspace }}/pyvista-data
@@ -153,6 +166,75 @@ jobs:
           name: pyvista-notebooks
           path: _notebooks
 
+      # Advertise this build to a later run of the same tree — a push to `main`
+      # out of the merge queue. Recorded only once every upload above has
+      # succeeded, and never for a tag, whose sidebar differs.
+      - name: Record the tree that was built
+        id: tree
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          echo "sha=$(git rev-parse 'HEAD^{tree}')" >> "$GITHUB_OUTPUT"
+          touch tree-marker
+
+      - name: Upload the tree marker
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-tree-${{ steps.tree.outputs.sha }}
+          path: tree-marker
+
+  # Republishes the matched build under this run, so everything downstream —
+  # `publish-notebooks` here, the Netlify deploy over in `netlify-deploy.yml` —
+  # keeps reading `docs-build` from the run it was triggered by. The dev wheel
+  # is the one piece that cannot be copied: its version embeds the commit SHA,
+  # so it is rebuilt here against the commit that actually landed.
+  reuse:
+    name: Reuse Documentation Build
+    runs-on: ubuntu-22.04
+    needs: resolve
+    if: ${{ needs.resolve.outputs.run-id != '' }}
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: 3.14
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: docs-build
+          path: doc/_build/html
+          run-id: ${{ needs.resolve.outputs.run-id }}
+          github-token: ${{ github.token }}
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: pyvista-notebooks
+          path: _notebooks
+          run-id: ${{ needs.resolve.outputs.run-id }}
+          github-token: ${{ github.token }}
+
+      - name: Rebuild development wheel and simple index
+        run: |
+          rm -rf doc/_build/html/wheels
+          python -m pip install --upgrade build
+          python doc/make_dev_wheel.py --html-dir doc/_build/html
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: docs-build
+          path: doc/_build/html/
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: pyvista-notebooks
+          path: _notebooks
+
   test:
     name: Test Documentation
     runs-on: blacksmith-8vcpu-ubuntu-2204
@@ -212,8 +294,8 @@ jobs:
   publish-notebooks:
     name: Publish Notebooks for MyBinder
     runs-on: ubuntu-22.04
-    needs: doc
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    needs: [doc, reuse]
+    if: ${{ !cancelled() && (needs.doc.result == 'success' || needs.reuse.result == 'success') && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,6 +51,10 @@ jobs:
   resolve:
     name: Find a matching build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # A called workflow can only narrow the caller's token, and this file sets
+    # `id-token: none`, which zeroes every other scope.
+    permissions:
+      actions: read
     uses: ./.github/workflows/find-tree-build.yml
     with:
       marker-prefix: docs-tree
@@ -166,18 +170,18 @@ jobs:
           name: pyvista-notebooks
           path: _notebooks
 
-      # Advertise this build to a later run of the same tree — a push to `main`
-      # out of the merge queue. Recorded only once every upload above has
-      # succeeded, and never for a tag, whose sidebar differs.
+      # Advertise this build to the push to `main` that follows it out of the
+      # queue. The step `if` carries an implicit `success()`, so a build that
+      # failed any upload above never advertises itself.
       - name: Record the tree that was built
         id: tree
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        if: github.event_name == 'merge_group'
         run: |
           echo "sha=$(git rev-parse 'HEAD^{tree}')" >> "$GITHUB_OUTPUT"
           touch tree-marker
 
       - name: Upload the tree marker
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        if: github.event_name == 'merge_group'
         uses: actions/upload-artifact@v7
         with:
           name: docs-tree-${{ steps.tree.outputs.sha }}

--- a/.github/workflows/find-tree-build.yml
+++ b/.github/workflows/find-tree-build.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   find:
     name: Look up
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
     outputs:
@@ -47,8 +47,12 @@ jobs:
           SHA: ${{ github.sha }}
         run: |
           # A lookup that cannot answer answers "no match", so an API blip
-          # costs a rebuild rather than the whole run.
-          tree=$(gh api "repos/${REPO}/commits/${SHA}" --jq '.commit.tree.sha' || true)
+          # costs a rebuild rather than the whole run. It says so out loud,
+          # because a silent miss and a broken lookup both just rebuild.
+          if ! tree=$(gh api "repos/${REPO}/commits/${SHA}" --jq '.commit.tree.sha'); then
+            echo "::warning::Could not read the tree for ${SHA}; rebuilding."
+            tree=""
+          fi
           run_id=$(gh api "repos/${REPO}/actions/artifacts?name=${PREFIX}-${tree:-none}&per_page=100" \
             --jq '[.artifacts[]
                    | select(.expired == false)

--- a/.github/workflows/find-tree-build.yml
+++ b/.github/workflows/find-tree-build.yml
@@ -1,0 +1,58 @@
+name: Find a matching build
+
+# Finds an earlier run that built the same source tree as this one.
+#
+# A workflow opts in by uploading an artifact named `<marker-prefix>-<tree>`
+# once its expensive jobs have succeeded, where `<tree>` is the git tree SHA of
+# the commit it built. Git tree SHAs are content addresses: an equal SHA means
+# byte-identical sources, down to the workflow files themselves. A push to
+# `main` that comes out of the merge queue therefore matches the queue's own
+# run, and can take that run's artifacts instead of rebuilding them.
+
+on:
+  workflow_call:
+    inputs:
+      marker-prefix:
+        description: Artifact name prefix that completed builds record.
+        required: true
+        type: string
+    outputs:
+      run-id:
+        description: Run that built this tree, or empty when there is none.
+        value: ${{ jobs.find.outputs.run-id }}
+
+permissions:
+  id-token: none
+
+jobs:
+  find:
+    name: Find a matching build
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      run-id: ${{ steps.find.outputs.run-id }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Look for a recorded build of this tree
+        id: find
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREFIX: ${{ inputs.marker-prefix }}
+          REPO: ${{ github.repository }}
+        run: |
+          tree=$(git rev-parse 'HEAD^{tree}')
+          # The artifacts endpoint returns newest first, so the first live
+          # match is the most recent build of this tree.
+          run_id=$(gh api "repos/${REPO}/actions/artifacts?name=${PREFIX}-${tree}&per_page=100" \
+            --jq 'first(.artifacts[] | select(.expired == false) | .workflow_run.id) // empty')
+          echo "run-id=${run_id}" >> "$GITHUB_OUTPUT"
+          if [ -n "${run_id}" ]; then
+            echo "Tree \`${tree}\` was built by run ${run_id}." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Tree \`${tree}\` has no recorded build." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/find-tree-build.yml
+++ b/.github/workflows/find-tree-build.yml
@@ -2,18 +2,23 @@ name: Find a matching build
 
 # Finds an earlier run that built the same source tree as this one.
 #
-# A workflow opts in by uploading an artifact named `<marker-prefix>-<tree>`
-# once its expensive jobs have succeeded, where `<tree>` is the git tree SHA of
-# the commit it built. Git tree SHAs are content addresses: an equal SHA means
+# A merge queue run uploads an artifact named `<marker-prefix>-<tree>` once its
+# expensive jobs have succeeded, where `<tree>` is the git tree SHA of the
+# commit it built. Git tree SHAs are content addresses, so an equal SHA means
 # byte-identical sources, down to the workflow files themselves. A push to
-# `main` that comes out of the merge queue therefore matches the queue's own
-# run, and can take that run's artifacts instead of rebuilding them.
+# `main` therefore matches the queue run that put it there, and can take that
+# run's artifacts instead of rebuilding them.
+#
+# An artifact name is chosen by whoever uploads it, and a pull request from a
+# fork runs in this repository, so the name alone decides nothing. The match is
+# accepted only from a merge queue branch of this repository — a ref namespace
+# GitHub owns and no pull request can write to.
 
 on:
   workflow_call:
     inputs:
       marker-prefix:
-        description: Artifact name prefix that completed builds record.
+        description: Artifact name prefix that merge queue builds record.
         required: true
         type: string
     outputs:
@@ -26,30 +31,30 @@ permissions:
 
 jobs:
   find:
-    name: Find a matching build
+    name: Look up
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: read
     outputs:
       run-id: ${{ steps.find.outputs.run-id }}
     steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
       - name: Look for a recorded build of this tree
         id: find
         env:
           GH_TOKEN: ${{ github.token }}
           PREFIX: ${{ inputs.marker-prefix }}
           REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
         run: |
-          tree=$(git rev-parse 'HEAD^{tree}')
-          # The artifacts endpoint returns newest first, so the first live
-          # match is the most recent build of this tree.
-          run_id=$(gh api "repos/${REPO}/actions/artifacts?name=${PREFIX}-${tree}&per_page=100" \
-            --jq 'first(.artifacts[] | select(.expired == false) | .workflow_run.id) // empty')
+          # A lookup that cannot answer answers "no match", so an API blip
+          # costs a rebuild rather than the whole run.
+          tree=$(gh api "repos/${REPO}/commits/${SHA}" --jq '.commit.tree.sha' || true)
+          run_id=$(gh api "repos/${REPO}/actions/artifacts?name=${PREFIX}-${tree:-none}&per_page=100" \
+            --jq '[.artifacts[]
+                   | select(.expired == false)
+                   | select(.workflow_run.repository_id == .workflow_run.head_repository_id)
+                   | select(.workflow_run.head_branch | startswith("gh-readonly-queue/"))]
+                  | max_by(.created_at) | .workflow_run.id // empty' || true)
           echo "run-id=${run_id}" >> "$GITHUB_OUTPUT"
           if [ -n "${run_id}" ]; then
             echo "Tree \`${tree}\` was built by run ${run_id}." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/netlify-deploy.yml
+++ b/.github/workflows/netlify-deploy.yml
@@ -165,14 +165,17 @@ jobs:
     # Run on both success and failure — the whole point of the image report is
     # to show what failed. Build-stage failures that produced no test artifact
     # are handled gracefully below via continue-on-error and the has_report
-    # check. Also runs on pushes to main so the report site tracks main.
+    # check. The report site tracks `main` through the merge queue run, whose
+    # commit is the one that lands, and which still holds the images after a
+    # merge skips the rebuild.
     if: >-
       (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure') &&
       github.event.workflow_run.name == 'Build Documentation' &&
       (github.event.workflow_run.event == 'pull_request' ||
-       (github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main'))
+       (github.event.workflow_run.event == 'merge_group' &&
+        startsWith(github.event.workflow_run.head_branch, 'gh-readonly-queue/main/')))
     environment:
-      name: ${{ github.event.workflow_run.event == 'push' && 'docs-main' || (needs.setup.outputs.is_fork == 'true' && 'fork-deploys' || 'internal-deploys') }}
+      name: ${{ github.event.workflow_run.event == 'merge_group' && 'docs-main' || (needs.setup.outputs.is_fork == 'true' && 'fork-deploys' || 'internal-deploys') }}
     steps:
       - name: Get app installation token
         id: app-token
@@ -224,9 +227,9 @@ jobs:
         uses: nwtgck/actions-netlify@d22a32a27c918fe470bbc562e984f80ec48c2668
         with:
           publish-dir: _doc_image_report
-          production-deploy: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}
+          production-deploy: ${{ github.event.workflow_run.event == 'merge_group' }}
           github-token: ${{ steps.app-token.outputs.token }}
-          deploy-message: "${{ needs.setup.outputs.pr_number != '' && format('Doc image report for PR #{0}', needs.setup.outputs.pr_number) || format('Doc image report for {0}', github.event.workflow_run.head_branch) }}"
+          deploy-message: "${{ needs.setup.outputs.pr_number != '' && format('Doc image report for PR #{0}', needs.setup.outputs.pr_number) || format('Doc image report for {0}', github.event.workflow_run.head_sha) }}"
           enable-pull-request-comment: false
           enable-commit-comment: false
           enable-commit-status: false
@@ -264,15 +267,17 @@ jobs:
     runs-on: ubuntu-22.04
     needs: setup
     # Run on both success and failure — the whole point of the image report is
-    # to show what failed. Also runs on pushes to main so the report site
-    # tracks main.
+    # to show what failed. The report site tracks `main` through the merge queue
+    # run, whose commit is the one that lands, and which runs the full matrix a
+    # merge no longer repeats.
     if: >-
       (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure') &&
       github.event.workflow_run.name == 'Unit Testing and Deployment' &&
       (github.event.workflow_run.event == 'pull_request' ||
-       (github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main'))
+       (github.event.workflow_run.event == 'merge_group' &&
+        startsWith(github.event.workflow_run.head_branch, 'gh-readonly-queue/main/')))
     environment:
-      name: ${{ github.event.workflow_run.event == 'push' && 'docs-main' || (needs.setup.outputs.is_fork == 'true' && 'fork-deploys' || 'internal-deploys') }}
+      name: ${{ github.event.workflow_run.event == 'merge_group' && 'docs-main' || (needs.setup.outputs.is_fork == 'true' && 'fork-deploys' || 'internal-deploys') }}
     steps:
       - name: Get app installation token
         id: app-token
@@ -323,9 +328,9 @@ jobs:
         uses: nwtgck/actions-netlify@d22a32a27c918fe470bbc562e984f80ec48c2668
         with:
           publish-dir: _image_report
-          production-deploy: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}
+          production-deploy: ${{ github.event.workflow_run.event == 'merge_group' }}
           github-token: ${{ steps.app-token.outputs.token }}
-          deploy-message: "${{ needs.setup.outputs.pr_number != '' && format('Test image report for PR #{0}', needs.setup.outputs.pr_number) || format('Test image report for {0}', github.event.workflow_run.head_branch) }}"
+          deploy-message: "${{ needs.setup.outputs.pr_number != '' && format('Test image report for PR #{0}', needs.setup.outputs.pr_number) || format('Test image report for {0}', github.event.workflow_run.head_sha) }}"
           enable-pull-request-comment: false
           enable-commit-comment: false
           enable-commit-status: false

--- a/.github/workflows/python-syntax.yml
+++ b/.github/workflows/python-syntax.yml
@@ -1,11 +1,10 @@
 name: Check Python Syntax
 
+# The merge queue compiles the tree that lands on `main`, so there is no push
+# trigger here.
 on:
   pull_request:
   merge_group:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -409,7 +409,8 @@ jobs:
       # id-token: write authorizes OIDC token minting so codecov-action can
       # authenticate to Codecov without a long-lived CODECOV_TOKEN secret.
       id-token: write
-      # actions: read authorizes reading the artifacts of the matched run.
+      # actions: read authorizes downloading the coverage reports through the
+      # API, whether they come from this run or from a matched one.
       actions: read
       contents: read
     steps:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -139,6 +139,10 @@ jobs:
 
   Linux:
     name: Linux Unit Testing (${{ matrix.python-version }}, ${{ matrix.vtk-version }}, ${{ matrix.numpy-version }})
+    # Repeated for a tag only, like the other two. The merge queue's own commit
+    # is the one that lands, so the coverage it uploads is already Codecov's
+    # report for `main` and the push has nothing left to add.
+    if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-22.04
     needs: cache-github-hosted
     strategy:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -79,6 +79,10 @@ jobs:
     # Job names are required status checks on main, so they have to keep
     # rendering exactly as `MacOS Unit Testing (3.10)`.
     name: MacOS Unit Testing (${{ matrix.python-version }})
+    # The merge queue runs this suite against the exact tree that lands, and
+    # nothing downstream of a push to `main` consumes its output, so it is only
+    # repeated for a tag, where `release` gates on it.
+    if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/')
     runs-on: macos-latest
     # macOS runner minutes bill at ten times the Linux rate, so a hung job is
     # expensive at the 360-minute default. The suite finishes in ~15.
@@ -300,6 +304,8 @@ jobs:
 
   windows:
     name: Windows Unit Testing
+    # Repeated for a tag only, for the same reason as the macOS suite.
+    if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/')
     runs-on: windows-latest
     timeout-minutes: 80
     needs: cache-github-hosted

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -69,6 +69,10 @@ jobs:
   resolve:
     name: Find a matching build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # A called workflow can only narrow the caller's token, and this file sets
+    # `id-token: none`, which zeroes every other scope.
+    permissions:
+      actions: read
     uses: ./.github/workflows/find-tree-build.yml
     with:
       marker-prefix: unit-tests-tree
@@ -473,19 +477,18 @@ jobs:
           fail_ci_if_error: true
           use_oidc: true
 
-      # Advertise this run's coverage reports to a later run of the same tree —
-      # a push to `main` out of the merge queue. Recorded only when this run
-      # earned the reports itself, so the marker never points at a run that was
-      # reusing someone else's.
+      # Advertise these reports to the push to `main` that follows this run out
+      # of the queue. Recorded only when this run earned them itself, so the
+      # marker never points at a run that was reusing someone else's.
       - name: Record the tree these reports cover
-        if: needs.Linux.result == 'success'
+        if: github.event_name == 'merge_group' && needs.Linux.result == 'success'
         id: tree
         run: |
           echo "sha=$(git rev-parse 'HEAD^{tree}')" >> "$GITHUB_OUTPUT"
           touch tree-marker
 
       - name: Upload the tree marker
-        if: needs.Linux.result == 'success'
+        if: github.event_name == 'merge_group' && needs.Linux.result == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: unit-tests-tree-${{ steps.tree.outputs.sha }}

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -63,20 +63,6 @@ jobs:
           name: pr-info
           path: pr-info/
 
-  # A push to `main` comes out of the merge queue, which has already run the
-  # Linux matrix against the same tree. Its coverage reports are the only
-  # output the push still needs, so look them up rather than earning them again.
-  resolve:
-    name: Find a matching build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    # A called workflow can only narrow the caller's token, and this file sets
-    # `id-token: none`, which zeroes every other scope.
-    permissions:
-      actions: read
-    uses: ./.github/workflows/find-tree-build.yml
-    with:
-      marker-prefix: unit-tests-tree
-
   # Cache pyvista/data for each runner separately
   # Runner labels should match the actual runners used by the different jobs in this file
 
@@ -85,8 +71,6 @@ jobs:
   # GitHub runners too, via enableCrossOsArchive on the restore.
   cache-github-hosted:
     name: Cache pyvista/data
-    needs: resolve
-    if: ${{ !cancelled() && needs.resolve.outputs.run-id == '' }}
     uses: ./.github/workflows/cache-pyvista-data.yml
     with:
       runs-on: "ubuntu-22.04"
@@ -97,9 +81,8 @@ jobs:
     name: MacOS Unit Testing (${{ matrix.python-version }})
     # The merge queue runs this suite against the exact tree that lands, and
     # nothing downstream of a push to `main` consumes its output, so it is only
-    # repeated for a tag, where `release` gates on it. `!cancelled()` is what
-    # keeps a skipped `resolve` from propagating down the `needs` chain.
-    if: ${{ !cancelled() && needs.cache-github-hosted.result == 'success' && (github.event_name != 'push' || startsWith(github.ref, 'refs/tags/')) }}
+    # repeated for a tag, where `release` gates on it.
+    if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/')
     runs-on: macos-latest
     # macOS runner minutes bill at ten times the Linux rate, so a hung job is
     # expensive at the 360-minute default. The suite finishes in ~15.
@@ -156,12 +139,8 @@ jobs:
 
   Linux:
     name: Linux Unit Testing (${{ matrix.python-version }}, ${{ matrix.vtk-version }}, ${{ matrix.numpy-version }})
-    # Skipped when the merge queue already produced coverage for this tree;
-    # `upload-coverage-` then takes the reports from that run. A push that no
-    # queue run matches — an admin merge, say — still runs the matrix.
-    if: ${{ !cancelled() && needs.cache-github-hosted.result == 'success' && needs.resolve.outputs.run-id == '' }}
     runs-on: ubuntu-22.04
-    needs: [cache-github-hosted, resolve]
+    needs: cache-github-hosted
     strategy:
       fail-fast: false
 
@@ -326,7 +305,7 @@ jobs:
   windows:
     name: Windows Unit Testing
     # Repeated for a tag only, for the same reason as the macOS suite.
-    if: ${{ !cancelled() && needs.cache-github-hosted.result == 'success' && (github.event_name != 'push' || startsWith(github.ref, 'refs/tags/')) }}
+    if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/')
     runs-on: windows-latest
     timeout-minutes: 80
     needs: cache-github-hosted
@@ -399,20 +378,17 @@ jobs:
   upload-coverage-:
     name: Upload coverage reports
     runs-on: ubuntu-22.04
-    needs: [Linux, VTK-dev, resolve]
+    needs: [Linux, VTK-dev]
     # `always()` ensures this still runs when VTK-dev is skipped because the
     # 'vtk-dev-testing' label is not applied. When VTK-dev does run, its reports
     # upload under their own flags.
     # Run on push/merge_group as well as pull_request so Codecov's
     # main-branch baseline keeps advancing with every merge.
-    if: always() && (needs.Linux.result == 'success' || needs.resolve.outputs.run-id != '')
+    if: always() && needs.Linux.result == 'success'
     permissions:
       # id-token: write authorizes OIDC token minting so codecov-action can
       # authenticate to Codecov without a long-lived CODECOV_TOKEN secret.
       id-token: write
-      # actions: read authorizes downloading the coverage reports through the
-      # API, whether they come from this run or from a matched one.
-      actions: read
       contents: read
     steps:
       # Needs to checkout only for codecov to match file names
@@ -421,16 +397,11 @@ jobs:
           fetch-depth: 2
           persist-credentials: false
 
-      # A coverage report carries no commit identity of its own, so reports
-      # earned in the merge queue are attributed to whichever commit uploads
-      # them — here, the commit the queue put on `main`.
       - name: Download coverage reports
         uses: actions/download-artifact@v8
         with:
           pattern: coverage_reports-*
           path: coverage_reports
-          run-id: ${{ needs.resolve.outputs.run-id || github.run_id }}
-          github-token: ${{ github.token }}
 
       # Each matrix cell contributes one report per side. Sorting them into their own
       # directories lets each side upload under its own flag. VTK-dev is matched first
@@ -478,23 +449,6 @@ jobs:
           flags: tests-vtk-dev
           fail_ci_if_error: true
           use_oidc: true
-
-      # Advertise these reports to the push to `main` that follows this run out
-      # of the queue. Recorded only when this run earned them itself, so the
-      # marker never points at a run that was reusing someone else's.
-      - name: Record the tree these reports cover
-        if: github.event_name == 'merge_group' && needs.Linux.result == 'success'
-        id: tree
-        run: |
-          echo "sha=$(git rev-parse 'HEAD^{tree}')" >> "$GITHUB_OUTPUT"
-          touch tree-marker
-
-      - name: Upload the tree marker
-        if: github.event_name == 'merge_group' && needs.Linux.result == 'success'
-        uses: actions/upload-artifact@v7
-        with:
-          name: unit-tests-tree-${{ steps.tree.outputs.sha }}
-          path: tree-marker
 
   # Publish to PyPI using trusted publishing
   release:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -97,8 +97,9 @@ jobs:
     name: MacOS Unit Testing (${{ matrix.python-version }})
     # The merge queue runs this suite against the exact tree that lands, and
     # nothing downstream of a push to `main` consumes its output, so it is only
-    # repeated for a tag, where `release` gates on it.
-    if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/')
+    # repeated for a tag, where `release` gates on it. `!cancelled()` is what
+    # keeps a skipped `resolve` from propagating down the `needs` chain.
+    if: ${{ !cancelled() && needs.cache-github-hosted.result == 'success' && (github.event_name != 'push' || startsWith(github.ref, 'refs/tags/')) }}
     runs-on: macos-latest
     # macOS runner minutes bill at ten times the Linux rate, so a hung job is
     # expensive at the 360-minute default. The suite finishes in ~15.
@@ -325,7 +326,7 @@ jobs:
   windows:
     name: Windows Unit Testing
     # Repeated for a tag only, for the same reason as the macOS suite.
-    if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/')
+    if: ${{ !cancelled() && needs.cache-github-hosted.result == 'success' && (github.event_name != 'push' || startsWith(github.ref, 'refs/tags/')) }}
     runs-on: windows-latest
     timeout-minutes: 80
     needs: cache-github-hosted

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -63,6 +63,16 @@ jobs:
           name: pr-info
           path: pr-info/
 
+  # A push to `main` comes out of the merge queue, which has already run the
+  # Linux matrix against the same tree. Its coverage reports are the only
+  # output the push still needs, so look them up rather than earning them again.
+  resolve:
+    name: Find a matching build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/find-tree-build.yml
+    with:
+      marker-prefix: unit-tests-tree
+
   # Cache pyvista/data for each runner separately
   # Runner labels should match the actual runners used by the different jobs in this file
 
@@ -71,6 +81,8 @@ jobs:
   # GitHub runners too, via enableCrossOsArchive on the restore.
   cache-github-hosted:
     name: Cache pyvista/data
+    needs: resolve
+    if: ${{ !cancelled() && needs.resolve.outputs.run-id == '' }}
     uses: ./.github/workflows/cache-pyvista-data.yml
     with:
       runs-on: "ubuntu-22.04"
@@ -139,8 +151,12 @@ jobs:
 
   Linux:
     name: Linux Unit Testing (${{ matrix.python-version }}, ${{ matrix.vtk-version }}, ${{ matrix.numpy-version }})
+    # Skipped when the merge queue already produced coverage for this tree;
+    # `upload-coverage-` then takes the reports from that run. A push that no
+    # queue run matches — an admin merge, say — still runs the matrix.
+    if: ${{ !cancelled() && needs.cache-github-hosted.result == 'success' && needs.resolve.outputs.run-id == '' }}
     runs-on: ubuntu-22.04
-    needs: cache-github-hosted
+    needs: [cache-github-hosted, resolve]
     strategy:
       fail-fast: false
 
@@ -378,17 +394,19 @@ jobs:
   upload-coverage-:
     name: Upload coverage reports
     runs-on: ubuntu-22.04
-    needs: [Linux, VTK-dev]
+    needs: [Linux, VTK-dev, resolve]
     # `always()` ensures this still runs when VTK-dev is skipped because the
     # 'vtk-dev-testing' label is not applied. When VTK-dev does run, its reports
     # upload under their own flags.
     # Run on push/merge_group as well as pull_request so Codecov's
     # main-branch baseline keeps advancing with every merge.
-    if: always() && needs.Linux.result == 'success'
+    if: always() && (needs.Linux.result == 'success' || needs.resolve.outputs.run-id != '')
     permissions:
       # id-token: write authorizes OIDC token minting so codecov-action can
       # authenticate to Codecov without a long-lived CODECOV_TOKEN secret.
       id-token: write
+      # actions: read authorizes reading the artifacts of the matched run.
+      actions: read
       contents: read
     steps:
       # Needs to checkout only for codecov to match file names
@@ -397,11 +415,16 @@ jobs:
           fetch-depth: 2
           persist-credentials: false
 
+      # A coverage report carries no commit identity of its own, so reports
+      # earned in the merge queue are attributed to whichever commit uploads
+      # them — here, the commit the queue put on `main`.
       - name: Download coverage reports
         uses: actions/download-artifact@v8
         with:
           pattern: coverage_reports-*
           path: coverage_reports
+          run-id: ${{ needs.resolve.outputs.run-id || github.run_id }}
+          github-token: ${{ github.token }}
 
       # Each matrix cell contributes one report per side. Sorting them into their own
       # directories lets each side upload under its own flag. VTK-dev is matched first
@@ -449,6 +472,24 @@ jobs:
           flags: tests-vtk-dev
           fail_ci_if_error: true
           use_oidc: true
+
+      # Advertise this run's coverage reports to a later run of the same tree —
+      # a push to `main` out of the merge queue. Recorded only when this run
+      # earned the reports itself, so the marker never points at a run that was
+      # reusing someone else's.
+      - name: Record the tree these reports cover
+        if: needs.Linux.result == 'success'
+        id: tree
+        run: |
+          echo "sha=$(git rev-parse 'HEAD^{tree}')" >> "$GITHUB_OUTPUT"
+          touch tree-marker
+
+      - name: Upload the tree marker
+        if: needs.Linux.result == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: unit-tests-tree-${{ steps.tree.outputs.sha }}
+          path: tree-marker
 
   # Publish to PyPI using trusted publishing
   release:


### PR DESCRIPTION
The merge queue runs every gate against the exact tree that lands, so a push to `main` was re-running work whose answer was already known. What only a merge can do still runs: integration tests, the Docker publish, the dev-docs deploy, MyBinder notebooks, the dev wheel.

`find-tree-build.yml` is the shared piece — a queue build records an artifact named for the git tree it built, and the push that follows finds it. An artifact name is chosen by whoever uploads it, so a match is accepted only from a `gh-readonly-queue/main/` branch of this repository, and a push that matches nothing builds normally.

- `Reuse Documentation Build` republishes the queue's docs rather than rebuilding them, worth about ten minutes of an 8-vCPU Blacksmith runner per merge; the dev wheel is rebuilt, since its version embeds the commit SHA.
- The macOS, Linux and Windows suites and `Check Python Syntax` no longer repeat after a merge, and still run for pull requests, the queue and tags.
- Both image report sites now deploy from the queue run, whose commit is the one that fast-forwards onto `main`, so they publish a few minutes before the merge completes.
- Codecov is unchanged: the queue run already uploads under the commit that lands.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
