### PR TITLE
Keep the shape of a two-dimensional string array

### DIFF
--- a/pyvista/_deprecate_positional_args.py
+++ b/pyvista/_deprecate_positional_args.py
@@ -198,6 +198,7 @@ def _deprecate_positional_args(
 
         @functools.wraps(f)
         def inner_f(*args: P.args, **kwargs: P.kwargs) -> T:
+            # Optimization: nothing to check when every positional argument is an allowed one
             if len(args) <= n_free_positional:
                 return f(*args, **kwargs)
             passed_positional_names = param_names[: len(args)]

--- a/pyvista/_deprecate_positional_args.py
+++ b/pyvista/_deprecate_positional_args.py
@@ -188,8 +188,18 @@ def _deprecate_positional_args(
             )
             raise RuntimeError(msg)
 
+        # Leading parameters that may always be passed positionally
+        n_free_positional = 0
+        for name in param_names:
+            if name in ('self', 'cls') or (allowed and name in allowed):
+                n_free_positional += 1
+            else:
+                break
+
         @functools.wraps(f)
         def inner_f(*args: P.args, **kwargs: P.kwargs) -> T:
+            if len(args) <= n_free_positional:
+                return f(*args, **kwargs)
             passed_positional_names = param_names[: len(args)]
 
             # Exclude allowed ones

--- a/pyvista/core/_vtk_utilities.py
+++ b/pyvista/core/_vtk_utilities.py
@@ -163,6 +163,9 @@ _SUPPORTS_FIXED_SIZE_STORAGE = vtk_version_info >= (9, 6, 2)
 # alive itself -- see `CellArray._set_data`.
 _SETDATA_TAKES_OWNERSHIP = vtk_version_info >= (9, 6)
 
+# From VTK 9.4, `vtkMatrix3x3/4x4.GetData` return their elements as a tuple, not a pointer.
+_MATRIX_GET_DATA_RETURNS_ELEMENTS = vtk_version_info >= (9, 4)
+
 # VTK 9.4 keeps the polyhedron faces and face locations in two cell arrays, reachable
 # from `GetPolyhedronFaces` and `GetPolyhedronFaceLocations`. Before that a polyhedron
 # is a single padded face stream with no offsets or connectivity of its own, so the

--- a/pyvista/core/_vtk_utilities.py
+++ b/pyvista/core/_vtk_utilities.py
@@ -309,9 +309,10 @@ class VTKObjectWrapperCheckSnakeCase(_vtk.VTKObjectWrapper):
     """
 
     def __getattr__(self, name: str):
-        """Forward unknown attribute requests to ``VTKArray``'s ``__getattr__``."""
+        """Forward unknown attribute requests to the wrapped VTK object."""
         if self.VTKObject is not None:
             # Check if forwarding snake_case attributes
             DisableVtkSnakeCase.check_attribute(self.VTKObject, name)
             return getattr(self.VTKObject, name)
-        raise AttributeError
+        msg = f'{type(self).__name__!r} object has no attribute {name!r}'
+        raise AttributeError(msg)

--- a/pyvista/core/dataobject.py
+++ b/pyvista/core/dataobject.py
@@ -934,7 +934,9 @@ class DataObject(
             )
             raise TypeError(msg)
         state = self.__dict__.copy()
-        _clear_accessor_cache(state)  # a weak reference cannot be pickled
+        # Cached VTK objects (locators, weak references) and accessors cannot be pickled
+        _clear_vtk_objects_from_dict(state)
+        _clear_accessor_cache(state)
 
         if pv.PICKLE_FORMAT.lower() == 'xml':
             # the generic VTK XML writer `vtkXMLDataSetWriter` currently has a bug where it does

--- a/pyvista/core/dataset.py
+++ b/pyvista/core/dataset.py
@@ -510,15 +510,12 @@ class DataSet(_BoundsSizeMixin, DataSetFilters, DataObject):
                          [ 1., -1.,  3.]], dtype=float32)
 
         """
-        _points = self.GetPoints()
-        try:
-            _points = _points.GetData()
-        except AttributeError:
+        vtkpts = self.GetPoints()
+        if vtkpts is None:
             # create an empty array
             vtkpts = vtk_points(np.empty((0, 3)), deep=False)
             self.SetPoints(vtkpts)
-            _points = self.GetPoints().GetData()
-        return pyvista_ndarray(_points, dataset=self)
+        return pyvista_ndarray(vtkpts.GetData(), dataset=self)
 
     @points.setter
     def points(self: Self, points: MatrixLike[float] | _vtk.vtkPoints) -> None:

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -521,7 +521,7 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
         dataset: DataSet | _vtk.vtkDataSet,
         association: FieldAssociation,
     ) -> pyvista_ndarray:
-        """Return the array viewed as bool or complex, or a scalar field string as ``str``."""
+        """Return the array viewed as ``bool`` or ``complex``, or a scalar string as ``str``."""
         name = vtk_arr.GetName()
         association_name = association.name
         if name in dataset._association_bitarray_names[association_name]:  # type: ignore[union-attr]

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -502,7 +502,7 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
         pyvista_ndarray([0, 1, 2, 3, 4, 5, 6, 7])
 
         """
-        if not isinstance(key, str):
+        if not isinstance(key, str):  # the bounds check only applies to an integer index
             self._raise_index_out_of_bounds(index=key)
         # Optimization: call the VTK object directly rather than through __getattr__ forwarding
         vtk_arr = self.VTKObject.GetAbstractArray(key)
@@ -533,6 +533,7 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
                 narray = narray.view(np.complex128)  # type: ignore[assignment]
             # remove singleton dimensions to match the behavior of the rest of 1D VTK arrays
             return narray.squeeze()  # type: ignore[return-value]
+        # Field data holding a string scalar (np.str_) is returned as the string itself
         if narray.ndim == 0 and association is FieldAssociation.NONE and narray.dtype.kind == 'U':
             return narray.tolist()
         return narray
@@ -771,7 +772,7 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
             array_len = 1 if data.ndim == 0 else data.shape[0]
 
         kind = data.dtype.kind
-        if data.ndim == 0 and kind == 'U':
+        if data.ndim == 0 and kind == 'U':  # np.str_
             pass  # Do not reshape string scalars
         else:
             # Fixup input array length for scalar input
@@ -816,10 +817,10 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
         bitarray_names.discard(name)
         complex_names.discard(name)
 
-        if kind == 'b':
+        if kind == 'b':  # np.bool_
             bitarray_names.add(name)
             data = data.view(np.uint8)
-        elif kind == 'c':
+        elif kind == 'c':  # np.complexfloating
             if data.dtype not in (np.complex64, np.complex128):
                 msg = (
                     'Only numpy.complex64 or numpy.complex128 is supported when '

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -376,8 +376,11 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
         self._raise_field_data_no_scalars_vectors_normals()
         scalars = self.VTKObject.GetScalars()  # Optimization: skip the __getattr__ forwarding
         if scalars is not None:
-            array = pyvista_ndarray(scalars, dataset=self.dataset, association=self.association)
-            return self._patch_type(array)
+            dataset, association = self.dataset, self.association
+            array = pyvista_ndarray(scalars, dataset=dataset, association=association)
+            return self._patch_type(
+                array, vtk_arr=scalars, dataset=dataset, association=association
+            )
         return None
 
     @property
@@ -499,44 +502,39 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
         pyvista_ndarray([0, 1, 2, 3, 4, 5, 6, 7])
 
         """
-        self._raise_index_out_of_bounds(index=key)
-        # Optimization: call the VTK object directly; going through the __getattr__
-        # forwarding costs about as much as the VTK call itself
-        vtk_attributes = self.VTKObject
-        vtk_arr = vtk_attributes.GetArray(key)
+        if not isinstance(key, str):
+            self._raise_index_out_of_bounds(index=key)
+        # Optimization: call the VTK object directly rather than through __getattr__ forwarding
+        vtk_arr = self.VTKObject.GetAbstractArray(key)
         if vtk_arr is None:
-            vtk_arr = vtk_attributes.GetAbstractArray(key)
-            if vtk_arr is None:
-                msg = f'{key}'
-                raise KeyError(msg)
-        narray = pyvista_ndarray(vtk_arr, dataset=self.dataset, association=self.association)
-        return self._patch_type(narray)
+            msg = f'{key}'
+            raise KeyError(msg)
+        dataset, association = self.dataset, self.association
+        narray = pyvista_ndarray(vtk_arr, dataset=dataset, association=association)
+        return self._patch_type(narray, vtk_arr=vtk_arr, dataset=dataset, association=association)
 
-    def _patch_type(self: Self, narray: pyvista_ndarray) -> pyvista_ndarray:
-        """Check if array needs to be represented as a different type."""
-        vtk_arr = getattr(narray, 'VTKObject', None)
-        if isinstance(vtk_arr, _vtk.vtkAbstractArray):
-            name = vtk_arr.GetName()
-            dataset = self.dataset
-            association_name = self.association.name
-            if name in dataset._association_bitarray_names[association_name]:  # type: ignore[union-attr]
-                narray = narray.view(np.bool_)  # type: ignore[assignment]
-            elif name in dataset._association_complex_names[association_name]:  # type: ignore[union-attr]
-                if narray.dtype == np.float32:
-                    narray = narray.view(np.complex64)  # type: ignore[assignment]
-                if narray.dtype == np.float64:
-                    narray = narray.view(np.complex128)  # type: ignore[assignment]
-                # remove singleton dimensions to match the behavior of the rest of 1D
-                # VTK arrays
-                narray = narray.squeeze()  # type: ignore[assignment]
-            elif (
-                narray.ndim == 0
-                and narray.association == FieldAssociation.NONE
-                and np.issubdtype(narray.dtype, np.str_)
-            ):
-                # For field data with a string scalar, return the string
-                # itself instead of a scalar array
-                narray = narray.tolist()
+    def _patch_type(
+        self: Self,
+        narray: pyvista_ndarray,
+        *,
+        vtk_arr: _vtk.vtkAbstractArray,
+        dataset: DataSet | _vtk.vtkDataSet,
+        association: FieldAssociation,
+    ) -> pyvista_ndarray:
+        """Return the array viewed as bool or complex, or a scalar field string as ``str``."""
+        name = vtk_arr.GetName()
+        association_name = association.name
+        if name in dataset._association_bitarray_names[association_name]:  # type: ignore[union-attr]
+            return narray.view(np.bool_)  # type: ignore[return-value]
+        if name in dataset._association_complex_names[association_name]:  # type: ignore[union-attr]
+            if narray.dtype == np.float32:
+                narray = narray.view(np.complex64)  # type: ignore[assignment]
+            if narray.dtype == np.float64:
+                narray = narray.view(np.complex128)  # type: ignore[assignment]
+            # remove singleton dimensions to match the behavior of the rest of 1D VTK arrays
+            return narray.squeeze()  # type: ignore[return-value]
+        if narray.ndim == 0 and association is FieldAssociation.NONE and narray.dtype.kind == 'U':
+            return narray.tolist()
         return narray
 
     @_deprecate_positional_args(allowed=['data', 'name'])
@@ -764,14 +762,16 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
         data = np.asanyarray(data)
 
         association = self.association
-        if association == FieldAssociation.POINT:
-            array_len = self.dataset.GetNumberOfPoints()
-        elif association == FieldAssociation.CELL:
-            array_len = self.dataset.GetNumberOfCells()
+        dataset = self.dataset
+        if association is FieldAssociation.POINT:
+            array_len = dataset.GetNumberOfPoints()
+        elif association is FieldAssociation.CELL:
+            array_len = dataset.GetNumberOfCells()
         else:
             array_len = 1 if data.ndim == 0 else data.shape[0]
 
-        if data.ndim == 0 and np.issubdtype(data.dtype, np.str_):
+        kind = data.dtype.kind
+        if data.ndim == 0 and kind == 'U':
             pass  # Do not reshape string scalars
         else:
             # Fixup input array length for scalar input
@@ -811,15 +811,15 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
                     return vtk_arr
 
         # reset data association (look the name sets up once, they are reused below)
-        bitarray_names = self.dataset._association_bitarray_names[association.name]  # type: ignore[union-attr]
-        complex_names = self.dataset._association_complex_names[association.name]  # type: ignore[union-attr]
+        bitarray_names = dataset._association_bitarray_names[association.name]  # type: ignore[union-attr]
+        complex_names = dataset._association_complex_names[association.name]  # type: ignore[union-attr]
         bitarray_names.discard(name)
         complex_names.discard(name)
 
-        if data.dtype == np.bool_:
+        if kind == 'b':
             bitarray_names.add(name)
             data = data.view(np.uint8)
-        elif np.issubdtype(data.dtype, np.complexfloating):
+        elif kind == 'c':
             if data.dtype not in (np.complex64, np.complex128):
                 msg = (
                     'Only numpy.complex64 or numpy.complex128 is supported when '

--- a/pyvista/core/datasetattributes.py
+++ b/pyvista/core/datasetattributes.py
@@ -771,8 +771,7 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
         else:
             array_len = 1 if data.ndim == 0 else data.shape[0]
 
-        kind = data.dtype.kind
-        if data.ndim == 0 and kind == 'U':  # np.str_
+        if data.ndim == 0 and data.dtype.kind == 'U':  # np.str_
             pass  # Do not reshape string scalars
         else:
             # Fixup input array length for scalar input
@@ -817,6 +816,7 @@ class DataSetAttributes(_NoNewAttrMixin, DisableVtkSnakeCase, VTKObjectWrapperCh
         bitarray_names.discard(name)
         complex_names.discard(name)
 
+        kind = data.dtype.kind
         if kind == 'b':  # np.bool_
             bitarray_names.add(name)
             data = data.view(np.uint8)

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -60,9 +60,10 @@ class pyvista_ndarray(_NoNewAttrMixin, np.ndarray):  # noqa: N801  # numpydoc ig
 
     """
 
-    dataset: _vtk.vtkWeakReference | None
-    association: FieldAssociation
-    VTKObject: _vtk.vtkAbstractArray | None
+    # Metadata of an unassociated array; instances only store what differs
+    dataset: _vtk.vtkWeakReference | None = None
+    association: FieldAssociation = FieldAssociation.NONE
+    VTKObject: _vtk.vtkAbstractArray | None = None
 
     def __new__(  # noqa: PYI034
         cls: type[pyvista_ndarray],
@@ -71,11 +72,10 @@ class pyvista_ndarray(_NoNewAttrMixin, np.ndarray):  # noqa: N801  # numpydoc ig
         association: FieldAssociation = FieldAssociation.NONE,
     ) -> pyvista_ndarray:
         """Allocate the array."""
-        vtk_object = None
+        # Write the instance dict directly; attribute assignment goes through _NoNewAttrMixin
         if isinstance(array, _vtk.vtkAbstractArray):
-            # Optimization: skip the positional-argument checks of the public convert_array
             obj = _vtk_array_to_numpy(array).view(cls)
-            vtk_object = array
+            obj.__dict__['VTKObject'] = array
         elif isinstance(array, Iterable):
             obj = np.asarray(array).view(cls)
         else:
@@ -85,36 +85,38 @@ class pyvista_ndarray(_NoNewAttrMixin, np.ndarray):  # noqa: N801  # numpydoc ig
             )
             raise TypeError(msg)
 
-        dataset_ref = None
         if dataset is not None:
-            dataset_ref = _vtk.vtkWeakReference()
+            reference = _vtk.vtkWeakReference()
             if isinstance(dataset, _vtk.VTKObjectWrapper):
-                dataset_ref.Set(dataset.VTKObject)
+                reference.Set(dataset.VTKObject)
             else:
-                dataset_ref.Set(cast('_vtk.vtkDataSet', dataset))
-        # Optimization: write the instance dict directly, attribute assignment goes through
-        # _NoNewAttrMixin.__setattr__ (the instance is not frozen until __new__ returns)
-        obj.__dict__.update(dataset=dataset_ref, association=association, VTKObject=vtk_object)
+                reference.Set(cast('_vtk.vtkDataSet', dataset))
+            obj.__dict__['dataset'] = reference
+        if association is not FieldAssociation.NONE:
+            obj.__dict__['association'] = association
         return obj
 
     def __array_finalize__(self: pyvista_ndarray, obj: npt.NDArray[Any] | None) -> None:
         """Finalize array (associate with parent metadata)."""
-        # Views and slices stay associated with the dataset and VTK array of their parent.
-        # This runs for every view and ufunc result, so write the instance dict directly.
+        # Views and slices keep their parent's metadata; copies and ufunc results do not
         if isinstance(obj, pyvista_ndarray):
-            if np.shares_memory(self, obj):
+            dataset = obj.dataset
+            vtk_object = obj.VTKObject
+            association = obj.association
+            if (
+                dataset is not None
+                or vtk_object is not None
+                or association is not FieldAssociation.NONE
+            ) and np.may_share_memory(self, obj):
                 self.__dict__.update(
-                    dataset=obj.dataset, association=obj.association, VTKObject=obj.VTKObject
+                    dataset=dataset, association=association, VTKObject=vtk_object
                 )
-                return
-        elif obj is not None and np.shares_memory(self, obj):
+        elif obj is not None and type(obj) is not np.ndarray and np.may_share_memory(self, obj):
             self.__dict__.update(
                 dataset=getattr(obj, 'dataset', None),
                 association=getattr(obj, 'association', FieldAssociation.NONE),
                 VTKObject=getattr(obj, 'VTKObject', None),
             )
-            return
-        self.__dict__.update(dataset=None, association=FieldAssociation.NONE, VTKObject=None)
 
     def __setitem__(self: pyvista_ndarray, key: int | NumpyArray[int], value: Any) -> None:  # type: ignore[override]
         """Implement [] set operator.
@@ -124,13 +126,16 @@ class pyvista_ndarray(_NoNewAttrMixin, np.ndarray):  # noqa: N801  # numpydoc ig
         object.
         """
         super().__setitem__(key, value)
-        if self.VTKObject is not None:
-            self.VTKObject.Modified()
+        vtk_object = self.VTKObject
+        if vtk_object is not None:
+            vtk_object.Modified()
 
         # the associated dataset should also be marked as modified
         dataset = self.dataset
-        if dataset is not None and dataset.Get() is not None:
-            dataset.Get().Modified()
+        if dataset is not None:
+            owner = dataset.Get()
+            if owner is not None:
+                owner.Modified()
 
     def __array_wrap__(self: pyvista_ndarray, out_arr, context=None, return_scalar: bool = False):  # noqa: ANN001, ANN204, FBT001, FBT002
         """Return a NumPy scalar if array is 0d.

--- a/pyvista/core/pyvista_ndarray.py
+++ b/pyvista/core/pyvista_ndarray.py
@@ -72,7 +72,7 @@ class pyvista_ndarray(_NoNewAttrMixin, np.ndarray):  # noqa: N801  # numpydoc ig
         association: FieldAssociation = FieldAssociation.NONE,
     ) -> pyvista_ndarray:
         """Allocate the array."""
-        # Write the instance dict directly; attribute assignment goes through _NoNewAttrMixin
+        # Optimization: write the instance dict directly, bypassing _NoNewAttrMixin.__setattr__
         if isinstance(array, _vtk.vtkAbstractArray):
             obj = _vtk_array_to_numpy(array).view(cls)
             obj.__dict__['VTKObject'] = array
@@ -103,6 +103,7 @@ class pyvista_ndarray(_NoNewAttrMixin, np.ndarray):  # noqa: N801  # numpydoc ig
             dataset = obj.dataset
             vtk_object = obj.VTKObject
             association = obj.association
+            # Optimization: an unassociated parent leaves the class defaults in place
             if (
                 dataset is not None
                 or vtk_object is not None

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -20,8 +20,8 @@ import numpy.typing as npt
 import pyvista as pv
 from pyvista import _vtk
 from pyvista._deprecate_positional_args import _deprecate_positional_args
+from pyvista.core._vtk_utilities import _MATRIX_GET_DATA_RETURNS_ELEMENTS
 from pyvista.core._vtk_utilities import DisableVtkSnakeCase
-from pyvista.core._vtk_utilities import vtk_version_info
 from pyvista.core.errors import AmbiguousDataError
 from pyvista.core.errors import MissingDataError
 
@@ -33,10 +33,6 @@ if TYPE_CHECKING:
     from pyvista.core._typing_core import NumpyArray
     from pyvista.core._typing_core import VectorLike
     from pyvista.core.dataset import _ActiveArrayExistsInfoTuple
-
-
-# vtkMatrix4x4.GetData() returns a pointer rather than the 16 elements before VTK 9.4
-_MATRIX_GET_DATA_RETURNS_TUPLE = vtk_version_info >= (9, 4)
 
 
 class FieldAssociation(Enum):
@@ -806,7 +802,7 @@ def array_from_vtkmatrix(matrix: _vtk.vtkMatrix3x3 | _vtk.vtkMatrix4x4) -> Numpy
             f' got {type(matrix).__name__} instead.'
         )
         raise TypeError(msg)
-    if _MATRIX_GET_DATA_RETURNS_TUPLE:
+    if _MATRIX_GET_DATA_RETURNS_ELEMENTS:
         return np.array(matrix.GetData(), dtype=float).reshape(shape)
     array = np.zeros(shape)
     for i, j in itertools.product(range(shape[0]), range(shape[1])):

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import UserDict
+from collections import deque
 from collections.abc import Sequence
 from enum import Enum
 import itertools
@@ -20,6 +21,7 @@ import pyvista as pv
 from pyvista import _vtk
 from pyvista._deprecate_positional_args import _deprecate_positional_args
 from pyvista.core._vtk_utilities import DisableVtkSnakeCase
+from pyvista.core._vtk_utilities import vtk_version_info
 from pyvista.core.errors import AmbiguousDataError
 from pyvista.core.errors import MissingDataError
 
@@ -31,6 +33,10 @@ if TYPE_CHECKING:
     from pyvista.core._typing_core import NumpyArray
     from pyvista.core._typing_core import VectorLike
     from pyvista.core.dataset import _ActiveArrayExistsInfoTuple
+
+
+# vtkMatrix4x4.GetData() returns a pointer rather than the 16 elements before VTK 9.4
+_MATRIX_GET_DATA_RETURNS_TUPLE = vtk_version_info >= (9, 4)
 
 
 class FieldAssociation(Enum):
@@ -90,23 +96,31 @@ def parse_field_choice(
 
     """
     if isinstance(field, str):
-        field_ = field.strip().lower()
-        if field_ in ['cell', 'c', 'cells']:
-            return FieldAssociation.CELL
-        elif field_ in ['point', 'p', 'points']:
-            return FieldAssociation.POINT
-        elif field_ in ['field', 'f', 'fields']:
-            return FieldAssociation.NONE
-        elif field_ in ['row', 'r']:
-            return FieldAssociation.ROW
-        else:
+        association = _FIELD_CHOICES.get(field.strip().lower())
+        if association is None:
             msg = f'Data field ({field}) not supported.'
             raise ValueError(msg)
+        return association
     elif isinstance(field, FieldAssociation):
         return field
     else:
         msg = f'Data field ({field}) not supported.'  # type: ignore[unreachable]
         raise TypeError(msg)
+
+
+_FIELD_CHOICES: dict[str, FieldAssociation] = {
+    'cell': FieldAssociation.CELL,
+    'c': FieldAssociation.CELL,
+    'cells': FieldAssociation.CELL,
+    'point': FieldAssociation.POINT,
+    'p': FieldAssociation.POINT,
+    'points': FieldAssociation.POINT,
+    'field': FieldAssociation.NONE,
+    'f': FieldAssociation.NONE,
+    'fields': FieldAssociation.NONE,
+    'row': FieldAssociation.ROW,
+    'r': FieldAssociation.ROW,
+}
 
 
 def _coerce_pointslike_arg(
@@ -298,40 +312,36 @@ def convert_array(  # noqa: PLR0917
         return None
     if isinstance(arr, (list, tuple, str)):
         arr = np.array(arr)
-    if isinstance(arr, np.ndarray):
-        if arr.dtype == np.dtype('O'):
-            arr = arr.astype('|S')
-        if arr.dtype.type in (np.str_, np.bytes_):
-            # This handles strings
-            if arr.ndim > 0:
-                # Do not call ascontiguousarray for scalar strings since this will reshape to 1D
-                # and scalars are already contiguous anyway
-                arr = np.ascontiguousarray(arr)
-            vtk_data = convert_string_array(arr)
-        else:
-            # This will handle numerical data
-            arr = np.ascontiguousarray(arr)
-            vtk_data = _vtk.numpy_to_vtk(num_array=arr, deep=deep, array_type=array_type)
-        if isinstance(name, str):
-            vtk_data.SetName(name)
-        return vtk_data
-    # Otherwise input must be a vtkDataArray
-    return _vtk_array_to_numpy(cast('_vtk.vtkAbstractArray', arr))
+    if not isinstance(arr, np.ndarray):
+        # Otherwise input must be a vtkDataArray
+        return _vtk_array_to_numpy(cast('_vtk.vtkAbstractArray', arr))
+
+    kind = arr.dtype.kind
+    if kind == 'O':
+        arr = arr.astype('|S')
+        kind = 'S'
+    if kind in 'US':
+        vtk_data: _vtk.vtkAbstractArray = convert_string_array(arr)
+    else:
+        # A scalar is stored as a single-tuple array; numpy_to_vtk makes the data contiguous
+        if arr.ndim == 0:
+            arr = arr.reshape(1)
+        vtk_data = _vtk.numpy_to_vtk(num_array=arr, deep=deep, array_type=array_type)
+    if isinstance(name, str):
+        vtk_data.SetName(name)
+    return vtk_data
 
 
 def _vtk_array_to_numpy(arr: _vtk.vtkAbstractArray) -> npt.NDArray[Any]:
     """Convert a VTK data, bit or string array to a NumPy array."""
-    if not isinstance(arr, (_vtk.vtkDataArray, _vtk.vtkBitArray, _vtk.vtkStringArray)):
-        msg = f'Invalid input array type ({type(arr)}).'
-        raise TypeError(msg)
-    # Handle booleans
-    if isinstance(arr, _vtk.vtkBitArray):
-        arr = vtk_bit_array_to_char(arr)
-    # Handle string arrays
+    if isinstance(arr, _vtk.vtkDataArray):
+        if isinstance(arr, _vtk.vtkBitArray):
+            arr = vtk_bit_array_to_char(arr)
+        return _vtk.vtk_to_numpy(arr)
     if isinstance(arr, _vtk.vtkStringArray):
         return convert_string_array(arr)
-    # Convert from vtkDataArry to NumPy
-    return _vtk.vtk_to_numpy(arr)
+    msg = f'Invalid input array type ({type(arr)}).'
+    raise TypeError(msg)
 
 
 @_deprecate_positional_args(allowed=['mesh', 'name'])
@@ -520,6 +530,13 @@ def raise_not_matching(scalars: npt.NDArray[Any], dataset: DataSet | Table) -> N
     raise ValueError(msg)
 
 
+_ASSOCIATION_ATTRIBUTES = {
+    'point': ('GetPointData', 'point_data'),
+    'cell': ('GetCellData', 'cell_data'),
+    'field': ('GetFieldData', 'field_data'),
+}
+
+
 def _assoc_array(
     obj: DataSet | _vtk.vtkDataSet, name: str, association: str = 'point'
 ) -> pyvista_ndarray | None:
@@ -529,8 +546,7 @@ def _assoc_array(
     behavior when using ``GetAbstractArray`` with an invalid key or index.
 
     """
-    vtk_attr = f'Get{association.title()}Data'
-    python_attr = f'{association.lower()}_data'
+    vtk_attr, python_attr = _ASSOCIATION_ATTRIBUTES[association]
 
     if isinstance(obj, pv.DataSet):
         try:
@@ -687,7 +703,8 @@ def vtk_id_list_to_array(vtk_id_list: _vtk.vtkIdList) -> NumpyArray[int]:
         Array of IDs.
 
     """
-    return np.array([vtk_id_list.GetId(i) for i in range(vtk_id_list.GetNumberOfIds())])
+    n_ids = vtk_id_list.GetNumberOfIds()
+    return np.fromiter(map(vtk_id_list.GetId, range(n_ids)), dtype=int, count=n_ids)
 
 
 def _set_string_scalar_object_name(vtkarr: _vtk.vtkStringArray) -> None:
@@ -735,27 +752,18 @@ def convert_string_array(
     """
     arr = np.array(arr) if isinstance(arr, str) else arr
     if isinstance(arr, np.ndarray):
+        flat_list = arr.reshape(-1).tolist()
         # VTK default fonts only support ASCII. See https://gitlab.kitware.com/vtk/vtk/-/issues/16904
-        if (
-            np.issubdtype(arr.dtype, np.str_) and not ''.join(arr.tolist()).isascii()
-        ):  # avoids segfault
+        if arr.dtype.kind == 'U' and not ''.join(flat_list).isascii():  # avoids segfault
             msg = 'String array contains non-ASCII characters that are not supported by VTK.'
             raise ValueError(msg)
         vtkarr = _vtk.vtkStringArray()
         if arr.ndim == 0:
-            arr = arr.reshape((1,))
-            # distinguish scalar inputs from array inputs by
-            # setting the object name
+            # The object name marks a scalar input
             _set_string_scalar_object_name(vtkarr)
 
-        # Pre-allocate the underlying storage instead of growing it via
-        # ``InsertNextValue`` per element. Iterating over ``arr.tolist()``
-        # avoids the per-element ``numpy.str_`` scalar boxing cost that
-        # iterating a numpy string array pays.
-        flat_list = arr.reshape(-1).tolist()
         vtkarr.SetNumberOfValues(len(flat_list))
-        for i, val in enumerate(flat_list):
-            vtkarr.SetValue(i, val)
+        deque(map(vtkarr.SetValue, range(len(flat_list)), flat_list), maxlen=0)
         if isinstance(name, str):
             vtkarr.SetName(name)
         return vtkarr
@@ -763,8 +771,7 @@ def convert_string_array(
     # ``np.array(list, dtype='|U')`` auto-sizes the unicode width to the
     # longest value; passing dtype='|U' to np.empty defaults to width 1
     # which truncates strings.
-    nvalues = arr.GetNumberOfValues()
-    arr_out = np.array([arr.GetValue(i) for i in range(nvalues)], dtype='|U')
+    arr_out = np.array(list(map(arr.GetValue, range(arr.GetNumberOfValues()))), dtype='|U')
     try:
         if arr.GetObjectName() == 'scalar':
             return np.array(''.join(arr_out))
@@ -798,6 +805,8 @@ def array_from_vtkmatrix(matrix: _vtk.vtkMatrix3x3 | _vtk.vtkMatrix4x4) -> Numpy
             f' got {type(matrix).__name__} instead.'
         )
         raise TypeError(msg)
+    if _MATRIX_GET_DATA_RETURNS_TUPLE:
+        return np.array(matrix.GetData(), dtype=float).reshape(shape)
     array = np.zeros(shape)
     for i, j in itertools.product(range(shape[0]), range(shape[1])):
         array[i, j] = matrix.GetElement(i, j)
@@ -828,9 +837,7 @@ def vtkmatrix_from_array(array: NumpyArray[float]) -> _vtk.vtkMatrix3x3 | _vtk.v
     else:
         msg = f'Invalid shape {array.shape}, must be (3, 3) or (4, 4).'
         raise ValueError(msg)
-    m, n = array.shape
-    for i, j in itertools.product(range(m), range(n)):
-        matrix.SetElement(i, j, array[i, j])
+    matrix.DeepCopy(array.ravel().tolist())
     return matrix
 
 

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -726,6 +726,11 @@ def convert_string_array(
 
     If a scalar string is provided, it is converted to a :vtk:`vtkCharArray`
 
+    .. versionchanged:: 0.49
+        A two-dimensional array keeps its second axis, held as the components of
+        the :vtk:`vtkStringArray`. It was previously flattened. An array with more
+        dimensions raises instead of being flattened.
+
     Parameters
     ----------
     arr : numpy.ndarray | str
@@ -747,6 +752,9 @@ def convert_string_array(
     """
     arr = np.array(arr) if isinstance(arr, str) else arr
     if isinstance(arr, np.ndarray):
+        if arr.ndim > 2:
+            msg = f'String array must be at most 2-dimensional, got shape {arr.shape}.'
+            raise ValueError(msg)
         flat_list = arr.reshape(-1).tolist()
         # VTK default fonts only support ASCII. See https://gitlab.kitware.com/vtk/vtk/-/issues/16904
         if arr.dtype.kind == 'U' and not ''.join(flat_list).isascii():  # np.str_, avoids segfault
@@ -756,6 +764,9 @@ def convert_string_array(
         if arr.ndim == 0:
             # The object name marks a scalar input
             _set_string_scalar_object_name(vtkarr)
+        elif arr.ndim == 2:
+            # The second axis is stored as components, as it is for numeric arrays
+            vtkarr.SetNumberOfComponents(arr.shape[1])
 
         vtkarr.SetNumberOfValues(len(flat_list))
         # Optimization: a zero-length deque drives the map without building a list
@@ -773,6 +784,9 @@ def convert_string_array(
             return np.array(''.join(arr_out))
     except AttributeError:
         pass
+    n_components = arr.GetNumberOfComponents()
+    if n_components > 1:
+        return arr_out.reshape(-1, n_components)
     return arr_out
 
 

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -52,6 +52,20 @@ CellLiteral = Literal[FieldAssociation.CELL, 'cell']
 FieldLiteral = Literal[FieldAssociation.NONE, 'field']
 RowLiteral = Literal[FieldAssociation.ROW, 'row']
 
+_FIELD_CHOICES: dict[str, FieldAssociation] = {
+    'cell': FieldAssociation.CELL,
+    'c': FieldAssociation.CELL,
+    'cells': FieldAssociation.CELL,
+    'point': FieldAssociation.POINT,
+    'p': FieldAssociation.POINT,
+    'points': FieldAssociation.POINT,
+    'field': FieldAssociation.NONE,
+    'f': FieldAssociation.NONE,
+    'fields': FieldAssociation.NONE,
+    'row': FieldAssociation.ROW,
+    'r': FieldAssociation.ROW,
+}
+
 
 @overload
 def parse_field_choice(
@@ -102,21 +116,6 @@ def parse_field_choice(
     else:
         msg = f'Data field ({field}) not supported.'  # type: ignore[unreachable]
         raise TypeError(msg)
-
-
-_FIELD_CHOICES: dict[str, FieldAssociation] = {
-    'cell': FieldAssociation.CELL,
-    'c': FieldAssociation.CELL,
-    'cells': FieldAssociation.CELL,
-    'point': FieldAssociation.POINT,
-    'p': FieldAssociation.POINT,
-    'points': FieldAssociation.POINT,
-    'field': FieldAssociation.NONE,
-    'f': FieldAssociation.NONE,
-    'fields': FieldAssociation.NONE,
-    'row': FieldAssociation.ROW,
-    'r': FieldAssociation.ROW,
-}
 
 
 def _coerce_pointslike_arg(

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -742,8 +742,8 @@ def convert_string_array(
 
     Notes
     -----
-    Note that this is terribly inefficient. If you have ideas on how
-    to make this faster, please consider opening a pull request.
+    Values cross between Python and VTK one at a time, so conversion cost grows
+    with the number of strings rather than with their total length.
 
     """
     arr = np.array(arr) if isinstance(arr, str) else arr

--- a/pyvista/core/utilities/arrays.py
+++ b/pyvista/core/utilities/arrays.py
@@ -317,10 +317,10 @@ def convert_array(  # noqa: PLR0917
         return _vtk_array_to_numpy(cast('_vtk.vtkAbstractArray', arr))
 
     kind = arr.dtype.kind
-    if kind == 'O':
+    if kind == 'O':  # np.object_
         arr = arr.astype('|S')
-        kind = 'S'
-    if kind in 'US':
+        kind = 'S'  # np.bytes_
+    if kind in 'US':  # np.str_ or np.bytes_
         vtk_data: _vtk.vtkAbstractArray = convert_string_array(arr)
     else:
         # A scalar is stored as a single-tuple array; numpy_to_vtk makes the data contiguous
@@ -754,7 +754,7 @@ def convert_string_array(
     if isinstance(arr, np.ndarray):
         flat_list = arr.reshape(-1).tolist()
         # VTK default fonts only support ASCII. See https://gitlab.kitware.com/vtk/vtk/-/issues/16904
-        if arr.dtype.kind == 'U' and not ''.join(flat_list).isascii():  # avoids segfault
+        if arr.dtype.kind == 'U' and not ''.join(flat_list).isascii():  # np.str_, avoids segfault
             msg = 'String array contains non-ASCII characters that are not supported by VTK.'
             raise ValueError(msg)
         vtkarr = _vtk.vtkStringArray()
@@ -763,6 +763,7 @@ def convert_string_array(
             _set_string_scalar_object_name(vtkarr)
 
         vtkarr.SetNumberOfValues(len(flat_list))
+        # Optimization: a zero-length deque drives the map without building a list
         deque(map(vtkarr.SetValue, range(len(flat_list)), flat_list), maxlen=0)
         if isinstance(name, str):
             vtkarr.SetName(name)
@@ -837,6 +838,7 @@ def vtkmatrix_from_array(array: NumpyArray[float]) -> _vtk.vtkMatrix3x3 | _vtk.v
     else:
         msg = f'Invalid shape {array.shape}, must be (3, 3) or (4, 4).'
         raise ValueError(msg)
+    # DeepCopy fills the matrix from a flat sequence of its elements, in row-major order
     matrix.DeepCopy(array.ravel().tolist())
     return matrix
 

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -50,7 +50,7 @@ class lookup_table_ndarray(_NoNewAttrMixin, np.ndarray):  # noqa: N801
         obj = convert_array(array).view(cls)
         table_ref = _vtk.vtkWeakReference()
         table_ref.Set(table)
-        # Write the instance dict directly; attribute assignment goes through _NoNewAttrMixin
+        # Optimization: write the instance dict directly, bypassing _NoNewAttrMixin.__setattr__
         obj.__dict__.update(VTKObject=array, table=table_ref)
         return obj
 

--- a/pyvista/plotting/lookup_table.py
+++ b/pyvista/plotting/lookup_table.py
@@ -13,6 +13,7 @@ import pyvista as pv
 from pyvista import _vtk
 from pyvista._deprecate_positional_args import _deprecate_positional_args
 from pyvista.core._vtk_utilities import DisableVtkSnakeCase
+from pyvista.core._vtk_utilities import VTKObjectWrapperCheckSnakeCase
 from pyvista.core.utilities.arrays import convert_array
 from pyvista.core.utilities.misc import _NoNewAttrMixin
 
@@ -36,6 +37,10 @@ class lookup_table_ndarray(_NoNewAttrMixin, np.ndarray):  # noqa: N801
 
     """
 
+    # Metadata of an unassociated array; instances only store what differs
+    table: _vtk.vtkWeakReference | None = None
+    VTKObject: _vtk.vtkAbstractArray | None = None
+
     def __new__(
         cls,
         array,
@@ -43,22 +48,17 @@ class lookup_table_ndarray(_NoNewAttrMixin, np.ndarray):  # noqa: N801
     ):
         """Allocate the array."""
         obj = convert_array(array).view(cls)
-        obj.VTKObject = array
-
-        obj.table = _vtk.vtkWeakReference()
-        obj.table.Set(table)
-
+        table_ref = _vtk.vtkWeakReference()
+        table_ref.Set(table)
+        # Write the instance dict directly; attribute assignment goes through _NoNewAttrMixin
+        obj.__dict__.update(VTKObject=array, table=table_ref)
         return obj
 
     def __array_finalize__(self, obj):
         """Finalize array (associate with parent metadata)."""
-        _vtk.VTKArray.__array_finalize__(self, obj)  # type: ignore[arg-type]
-        if np.shares_memory(self, obj):
-            self.table = getattr(obj, 'table', None)
-            self.VTKObject = getattr(obj, 'VTKObject', None)
-        else:
-            self.table = None
-            self.VTKObject = None
+        # Views and slices keep their parent's metadata; copies and ufunc results do not
+        if isinstance(obj, lookup_table_ndarray) and np.may_share_memory(self, obj):
+            self.__dict__.update(table=obj.table, VTKObject=obj.VTKObject)
 
     def __setitem__(self, key, value):
         """Implement [] set operator.
@@ -68,14 +68,15 @@ class lookup_table_ndarray(_NoNewAttrMixin, np.ndarray):  # noqa: N801
         object.
         """
         super().__setitem__(key, value)
-        if self.VTKObject is not None:
-            self.VTKObject.Modified()
+        vtk_object = self.VTKObject
+        if vtk_object is not None:
+            vtk_object.Modified()
 
-        # the associated dataset should also be marked as modified
-        if self.table is not None and self.table.Get():
-            # this creates a new shallow copy and is necessary to update the
-            # internal VTK array
-            self.table.Get().values = self
+        # the associated table should also be marked as modified
+        table = None if self.table is None else self.table.Get()
+        if table is not None:
+            # Reassigning the values updates the table's internal VTK array
+            cast('LookupTable', table).values = self
 
     def __array_wrap__(self, out_arr, context=None, return_scalar: bool = False):  # noqa: FBT001, FBT002
         """Return a NumPy scalar if array is 0d.
@@ -89,7 +90,7 @@ class lookup_table_ndarray(_NoNewAttrMixin, np.ndarray):  # noqa: N801
         # Match numpy's behavior and return a numpy dtype scalar
         return out_arr[()]
 
-    __getattr__ = _vtk.VTKArray.__getattr__
+    __getattr__ = VTKObjectWrapperCheckSnakeCase.__getattr__
 
 
 class LookupTable(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkLookupTable):

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -406,6 +406,20 @@ def test_pickle_serialize_deserialize(datasets_no_pointset, pickle_format, capfd
             assert arr_have == pytest.approx(arr_expected)
 
 
+@pytest.mark.parametrize('pickle_format', ['vtk', 'xml', 'legacy'])
+def test_pickle_drops_cached_vtk_objects(pickle_format):
+    pv.set_pickle_format(pickle_format)
+    mesh = pv.Sphere()
+    mesh.find_closest_point((0.0, 0.0, 0.0))
+    assert isinstance(vars(mesh)['_point_locator'], pv._vtk.vtkObjectBase)
+    assert mesh.points.dataset.Get() is mesh
+
+    unpickled = pickle.loads(pickle.dumps(mesh))
+    assert not any(isinstance(value, pv._vtk.vtkObjectBase) for value in vars(unpickled).values())
+    assert unpickled == mesh
+    assert unpickled.points.dataset.Get() is unpickled
+
+
 def n_points(dataset):
     # used in multiprocessing test
     return dataset.n_points

--- a/tests/core/test_dataobject.py
+++ b/tests/core/test_dataobject.py
@@ -410,6 +410,8 @@ def test_pickle_serialize_deserialize(datasets_no_pointset, pickle_format, capfd
 def test_pickle_drops_cached_vtk_objects(pickle_format):
     pv.set_pickle_format(pickle_format)
     mesh = pv.Sphere()
+    # A bool array is tracked in the instance dict, which must survive the round trip
+    mesh.point_data['flags'] = np.ones(mesh.n_points, dtype=bool)
     mesh.find_closest_point((0.0, 0.0, 0.0))
     assert isinstance(vars(mesh)['_point_locator'], pv._vtk.vtkObjectBase)
     assert mesh.points.dataset.Get() is mesh
@@ -417,6 +419,7 @@ def test_pickle_drops_cached_vtk_objects(pickle_format):
     unpickled = pickle.loads(pickle.dumps(mesh))
     assert not any(isinstance(value, pv._vtk.vtkObjectBase) for value in vars(unpickled).values())
     assert unpickled == mesh
+    assert unpickled.point_data['flags'].dtype == np.bool_
     assert unpickled.points.dataset.Get() is unpickled
 
 

--- a/tests/core/test_datasetattributes.py
+++ b/tests/core/test_datasetattributes.py
@@ -194,11 +194,6 @@ def test_active_name_setter_ignores_string_array(plane, attr):
     assert before != 'strings'
 
 
-def test_patch_type_without_vtk_array(sphere):
-    array = pv.pyvista_ndarray([1.0, 2.0])
-    assert sphere.point_data._patch_type(array) is array
-
-
 def test_active_normals_name():
     # Load dataset known to have active normals by default
     sphere = pv.Sphere()

--- a/tests/core/test_pyvista_ndarray.py
+++ b/tests/core/test_pyvista_ndarray.py
@@ -12,6 +12,7 @@ from pyvista import _vtk
 from pyvista import examples
 from pyvista import pyvista_ndarray
 from pyvista import vtk_points
+from pyvista.core.utilities.arrays import FieldAssociation
 
 
 @pytest.fixture
@@ -183,3 +184,43 @@ def test_point_data_assignment_does_not_leak_vtk_weak_reference():
     assert after <= before, (
         f'point_data assignment leaked {after - before} vtkWeakReference instance(s)'
     )
+
+
+def test_unassociated_array_stores_no_metadata():
+    arr = pyvista_ndarray([1.0, 2.0, 3.0])
+    assert arr.VTKObject is None
+    assert arr.dataset is None
+    assert arr.association == FieldAssociation.NONE
+    assert not {'VTKObject', 'dataset', 'association'} & set(vars(arr))
+
+
+def test_association_without_dataset_propagates_to_views():
+    arr = pyvista_ndarray([1.0, 2.0, 3.0], association=FieldAssociation.POINT)
+    assert arr[1:].association == FieldAssociation.POINT
+    assert (arr + 1).association == FieldAssociation.NONE
+
+
+def test_copies_and_ufunc_results_are_not_associated():
+    points = pv.Sphere().points
+    assert points.VTKObject is not None
+    for result in (
+        points + 1,
+        points[[0, 1]],
+        points[points[:, 2] > 0],
+        points.astype(np.float64),
+        np.abs(points),
+    ):
+        assert isinstance(result, pyvista_ndarray)
+        assert result.VTKObject is None
+        assert result.dataset is None
+        assert result.association == FieldAssociation.NONE
+    assert points.T.VTKObject is points.VTKObject
+    assert points.reshape(-1).dataset is points.dataset
+
+
+def test_dataset_reference_targets_owner():
+    mesh = pv.Sphere()
+    assert mesh.points.dataset.Get() is mesh
+    assert mesh.point_data['Normals'].dataset.Get() is mesh
+    assert mesh.point_data.active_normals.dataset.Get() is mesh
+    assert mesh.point_data.active_scalars is None

--- a/tests/core/test_pyvista_ndarray.py
+++ b/tests/core/test_pyvista_ndarray.py
@@ -223,4 +223,9 @@ def test_dataset_reference_targets_owner():
     assert mesh.points.dataset.Get() is mesh
     assert mesh.point_data['Normals'].dataset.Get() is mesh
     assert mesh.point_data.active_normals.dataset.Get() is mesh
-    assert mesh.point_data.active_scalars is None
+
+
+def test_detached_array_attribute_error_names_the_attribute():
+    match = re.escape("'pyvista_ndarray' object has no attribute 'GetNumberOfTuples'")
+    with pytest.raises(AttributeError, match=match):
+        pyvista_ndarray([1.0, 2.0]).GetNumberOfTuples()

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -3246,9 +3246,14 @@ def test_deprecate_positional_args_post_deprecation():
 def test_deprecate_positional_args_allowed():
     # Test single allowed
     @_deprecate_positional_args(allowed=['bar'])
-    def foo(bar, baz): ...
+    def foo(bar, baz):
+        return bar, baz
 
-    foo(True, baz=True)
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        assert foo(True, baz=False) == (True, False)
+    with pytest.warns(pv.PyVistaDeprecationWarning):
+        assert foo(True, False) == (True, False)
 
     # Too many allowed args
     match = (

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -1767,6 +1767,20 @@ def test_convert_string_array_scalar_string():
     assert str(out) == 'hello'
 
 
+@pytest.mark.parametrize(
+    'array', [np.array([['a', 'b'], ['c', 'd']]), np.array([[b'a', b'b'], [b'c', b'd']])]
+)
+def test_convert_string_array_flattens_multidimensional(array):
+    # A vtkStringArray built here has a single component, so the second axis is not kept
+    vtk_arr = convert_string_array(array)
+    assert vtk_arr.GetNumberOfValues() == 4
+    assert vtk_arr.GetNumberOfComponents() == 1
+
+    out = convert_string_array(vtk_arr)
+    assert out.shape == (4,)
+    assert np.array_equal(out, ['a', 'b', 'c', 'd'])
+
+
 def test_convert_string_array_rejects_non_ascii():
     with pytest.raises(ValueError, match='non-ASCII'):
         convert_string_array(np.array(['hello', 'wörld']))

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -735,6 +735,9 @@ def test_convert_id_list():
 def test_vtkmatrix_from_array_like():
     values = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     matrix = pv.vtkmatrix_from_array(values)
+    # Pin the row-major convention; a round trip alone would pass on a transposed matrix
+    assert matrix.GetElement(0, 2) == 3
+    assert matrix.GetElement(2, 0) == 7
     assert np.array_equal(pv.array_from_vtkmatrix(matrix), values)
 
     strided = np.asarray(values, dtype=np.float32)[::-1]
@@ -749,6 +752,13 @@ def test_convert_array_scalar_and_strided():
 
     strided = np.arange(10.0)[::2]
     assert np.array_equal(convert_array(convert_array(strided)), strided)
+
+    # Multi-component and non-contiguous, so the component count is read off a copy
+    strided_2d = np.arange(12.0).reshape(3, 4)[:, ::2]
+    assert not strided_2d.flags.c_contiguous
+    roundtrip = convert_array(convert_array(strided_2d))
+    assert roundtrip.shape == (3, 2)
+    assert np.array_equal(roundtrip, strided_2d)
 
     strings = np.array(['a', 'bb', 'ccc', 'dddd'])[::2]
     assert np.array_equal(convert_array(convert_array(strings)), strings)
@@ -3281,6 +3291,14 @@ def test_deprecate_positional_args_allowed():
         assert foo(True, baz=False) == (True, False)
     with pytest.warns(pv.PyVistaDeprecationWarning):
         assert foo(True, False) == (True, False)
+
+    # An allowed argument that is not first still leaves the ones before it deprecated
+    @_deprecate_positional_args(allowed=['baz'])
+    def qux(bar, baz):
+        return bar, baz
+
+    with pytest.warns(pv.PyVistaDeprecationWarning):
+        assert qux(True, baz=False) == (True, False)
 
     # Too many allowed args
     match = (

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -1770,15 +1770,37 @@ def test_convert_string_array_scalar_string():
 @pytest.mark.parametrize(
     'array', [np.array([['a', 'b'], ['c', 'd']]), np.array([[b'a', b'b'], [b'c', b'd']])]
 )
-def test_convert_string_array_flattens_multidimensional(array):
-    # A vtkStringArray built here has a single component, so the second axis is not kept
+def test_convert_string_array_keeps_second_axis(array):
     vtk_arr = convert_string_array(array)
     assert vtk_arr.GetNumberOfValues() == 4
-    assert vtk_arr.GetNumberOfComponents() == 1
+    assert vtk_arr.GetNumberOfComponents() == 2
+    assert vtk_arr.GetNumberOfTuples() == 2
 
     out = convert_string_array(vtk_arr)
-    assert out.shape == (4,)
-    assert np.array_equal(out, ['a', 'b', 'c', 'd'])
+    assert out.shape == (2, 2)
+    assert np.array_equal(out, [['a', 'b'], ['c', 'd']])
+
+
+def test_convert_string_array_single_column_is_not_flattened():
+    column = np.array([['a'], ['b'], ['c']])
+    vtk_arr = convert_string_array(column)
+    assert vtk_arr.GetNumberOfComponents() == 1
+    # A single component cannot be told apart from a 1D array once stored
+    assert convert_string_array(vtk_arr).shape == (3,)
+
+
+def test_convert_string_array_rejects_more_than_two_dimensions():
+    match = re.escape('String array must be at most 2-dimensional, got shape (2, 2, 2).')
+    with pytest.raises(ValueError, match=match):
+        convert_string_array(np.full((2, 2, 2), 'a'))
+
+
+def test_string_field_data_round_trips_shape():
+    mesh = pv.Sphere()
+    values = np.array([['a', 'bb'], ['ccc', 'dddd'], ['e', 'ff']])
+    mesh.field_data['labels'] = values
+    assert mesh.field_data['labels'].shape == (3, 2)
+    assert np.array_equal(mesh.field_data['labels'], values)
 
 
 def test_convert_string_array_rejects_non_ascii():

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -725,6 +725,33 @@ def test_convert_id_list():
         id_list.SetId(i, v)
     converted = vtk_id_list_to_array(id_list)
     assert np.allclose(converted, ids)
+    assert np.issubdtype(converted.dtype, np.integer)
+
+    empty = vtk_id_list_to_array(_vtk.vtkIdList())
+    assert empty.shape == (0,)
+    assert np.issubdtype(empty.dtype, np.integer)
+
+
+def test_vtkmatrix_from_array_like():
+    values = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    matrix = pv.vtkmatrix_from_array(values)
+    assert np.array_equal(pv.array_from_vtkmatrix(matrix), values)
+
+    strided = np.asarray(values, dtype=np.float32)[::-1]
+    matrix = pv.vtkmatrix_from_array(strided)
+    assert np.array_equal(pv.array_from_vtkmatrix(matrix), strided)
+
+
+def test_convert_array_scalar_and_strided():
+    vtk_scalar = convert_array(np.array(1.5))
+    assert vtk_scalar.GetNumberOfTuples() == 1
+    assert vtk_scalar.GetValue(0) == 1.5
+
+    strided = np.arange(10.0)[::2]
+    assert np.array_equal(convert_array(convert_array(strided)), strided)
+
+    strings = np.array(['a', 'bb', 'ccc', 'dddd'])[::2]
+    assert np.array_equal(convert_array(convert_array(strings)), strings)
 
 
 def test_progress_monitor():

--- a/tests/plotting/test_lookup_table.py
+++ b/tests/plotting/test_lookup_table.py
@@ -303,3 +303,14 @@ def test_to_opacity_tf(lut, clamping):
     tf = lut.to_opacity_tf(clamping=clamping)
     assert isinstance(tf, _vtk.vtkPiecewiseFunction)
     assert tf.GetClamping() == int(clamping)
+
+
+def test_values_views_keep_table(lut):
+    values = lut.values
+    assert values.table.Get() is lut
+    assert values.VTKObject is lut.GetTable()
+    assert values[:2].table is values.table
+    assert values[:2].VTKObject is values.VTKObject
+    assert values.copy().table is None
+    assert values.copy().VTKObject is None
+    assert values.GetNumberOfTuples() == lut.n_values


### PR DESCRIPTION
Stacked on #9113, which pins the flattening this changes. Review that one first; the diff here is the last commit only.

A 2-D string array was flattened on the way into a `vtkStringArray` and came back 1-D. A numeric array of the same shape round-trips, because VTK stores the second axis as components. `convert_string_array` now sets those components on the way in and reshapes by them on the way out, so string arrays follow the numeric rules identically, at every dimensionality:

| assigned to `point_data` | numeric | string, before | string, after |
| --- | --- | --- | --- |
| `(n,)` | `(n,)` | `(n,)` | `(n,)` |
| `(n, 1)` | `(n,)` | `(n,)` | `(n,)` |
| `(n, 2)` | `(n, 2)` | `(2n,)` | `(n, 2)` |
| `(n, 2, 2)` | `(n, 4)` | `(4n,)` | `(n, 4)` |
| `(n, 2, 2, 2)` | raises | `(8n,)` | raises |

No reshaping convention is introduced. The second axis is the one VTK represents directly, so there is no ravel order to choose and nothing to record, and the component count survives a save and reload in both `.vtp` and `.vtk`. Restoring the axes VTK cannot hold stays the subject of #7098 and #7100.

- A `(n, 1)` array still reads back as `(n,)`. A single component is indistinguishable from a flat array once stored, exactly as for numeric.
- More than two dimensions now raises rather than flattening silently. Numeric refuses those too, from inside `numpy_to_vtk`.
- A `vtkStringArray` that already carries components, including one read from a file, now converts to 2-D where it previously came back flat.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
