### PR TITLE
Fix flaky `test_sample_function_raises` on Python 3.10 and 3.11

### DIFF
--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -43,6 +43,7 @@ from pyvista.core._vtk_utilities import is_vtk_attribute
 from pyvista.core.celltype import _CELL_TYPE_INFO
 from pyvista.core.filters import _update_alg
 from pyvista.core.utilities import cells
+from pyvista.core.utilities import features
 from pyvista.core.utilities import fileio
 from pyvista.core.utilities import fit_line_to_points
 from pyvista.core.utilities import fit_plane_to_points
@@ -118,7 +119,8 @@ def transform():
 
 def test_sample_function_raises(monkeypatch: pytest.MonkeyPatch):
     with monkeypatch.context() as m:
-        m.setattr(os, 'name', 'nt')
+        # Scope the fake to this module: a global os.name breaks pathlib.Path
+        m.setattr(features, 'os', SimpleNamespace(name='nt'))
         with pytest.raises(
             ValueError,
             match='This function on Windows only supports int32 or smaller',


### PR DESCRIPTION
`test_sample_function_raises` fakes Windows by patching the process-wide `os.name`. On Python 3.10 and 3.11 `pathlib.Path` picks `WindowsPath` from `os.name` at instantiation and then refuses it on POSIX, and VTK's wheel resolves every lazy `vtkmodules` import through a `find_spec` hook that calls `Path(...)`. Since `sample_function` touches `_vtk.vtkSampleFunction` before it validates `output_type`, a worker that had not already imported `vtkImagingHybrid` got `NotImplementedError` instead of the expected `ValueError` — as in [this macOS 3.10 job](https://github.com/pyvista/pyvista/actions/runs/34043027187/job/101513080944).

The patch now swaps `os` in the `features` namespace, the way this file already fakes `_vtk`, so nothing outside the module under test sees a Windows `os.name`.

- reproduced by emulating the 3.10 `pathlib` dispatch with `vtkmodules.vtkImagingHybrid` dropped from `sys.modules`: fails on `main`, passes here
- no other test fakes `os.name`

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
