### PR TITLE
Apply the `pinned` dependency group to every tox resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ docs = [
   'jupyter-sphinx==0.5.3',
   'jupyterlab==4.6.3',
   'lxml==6.1.2',
-  'matplotlib>=3.11; python_version >= "3.11"', # colormap tables read okabe_ito
+  'matplotlib>=3.11; python_version >= "3.11"',
   'meshio==5.3.5',
   'mypy-extensions==1.1.0',
   'mypy==2.3.1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,10 +56,10 @@ jupyter = ['ipywidgets', 'nest-asyncio2', 'trame-pyvista']
 
 [dependency-groups]
 pinned = [ # Pinned versions of core dependencies
-  'cyclopts<4.24.0',
+  'cyclopts<4.25.1',
   'filelock<3.33.0', # not a core dep; serializes parallel example downloads
-  'matplotlib<3.10.10',
-  'numpy<2.5.0',
+  'matplotlib<3.11.2', # docs tables need okabe_ito, added in 3.11
+  'numpy<2.5.4',
   'pillow<12.4.0',
   'pooch<1.10.0',
   'pyobjc-framework-Cocoa<12.3.0; sys_platform == "darwin"',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ docs = [
   'jupyter-sphinx==0.5.3',
   'jupyterlab==4.6.3',
   'lxml==6.1.2',
-  'matplotlib>=3.11', # the colormap tables read okabe_ito
+  'matplotlib>=3.11; python_version >= "3.11"', # colormap tables read okabe_ito
   'meshio==5.3.5',
   'mypy-extensions==1.1.0',
   'mypy==2.3.1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ docs = [
   'jupyter-sphinx==0.5.3',
   'jupyterlab==4.6.3',
   'lxml==6.1.2',
+  'matplotlib>=3.11', # the colormap tables read okabe_ito
   'meshio==5.3.5',
   'mypy-extensions==1.1.0',
   'mypy==2.3.1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ jupyter = ['ipywidgets', 'nest-asyncio2', 'trame-pyvista']
 pinned = [ # Pinned versions of core dependencies
   'cyclopts<4.25.1',
   'filelock<3.33.0', # not a core dep; serializes parallel example downloads
-  'matplotlib<3.11.2', # docs tables need okabe_ito, added in 3.11
+  'matplotlib<3.11.2',
   'numpy<2.5.4',
   'pillow<12.4.0',
   'pooch<1.10.0',

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,10 @@ env_list =
 
 # ================= DEFAULT ENVIRONMENTS =================
 [testenv]
+# `--group pinned` keeps that group's caps in every resolution: tox re-resolves
+# `[project] dependencies` in a step of its own, where `--upgrade` otherwise lifts them.
 install_command =
-    uv pip install --upgrade {opts} {packages}
+    uv pip install --upgrade --group pinned {opts} {packages}
 description = Run the tests for python {basepython}
 package =
     cov: editable # Otherwise, the coverage is not computed correctly
@@ -209,6 +211,9 @@ description =
     pyvistaqt: Run the integration tests for pyvistaqt
 
 skip_install = true # added since commands_pre that install the target package might override the current pyvista installation
+# Drops [testenv]'s `--group pinned` for the same reason the group below is empty.
+install_command =
+    uv pip install --upgrade {opts} {packages}
 basepython =
     pyvistaqt: py3.14
     trame,mne: py3.14


### PR DESCRIPTION
tox installs the dependency groups and then re-resolves `[project] dependencies` in a step of its own, where `install_command`'s `--upgrade` is free to pick anything. That lifted every cap in the `pinned` group that is also a runtime dependency, which is all of them except `filelock`. Adding `--group pinned` to `install_command` keeps those caps in both resolutions; the external-project integration environments keep the old command, for the same reason their dependency group is empty.

Three caps had drifted below what CI was already installing, so they are raised to the versions in use rather than quietly downgrading the matrix. matplotlib is the one that mattered: `make_tables.py` reads `okabe_ito`, which matplotlib added in 3.11, so restoring `<3.10.10` failed the documentation build outright. That floor is now declared in the `docs` group, where a cap below it fails resolution instead of the build.

| package | old cap | new cap | resolved, before and after |
| --- | --- | --- | --- |
| cyclopts | `<4.24.0` | `<4.25.1` | 4.25.0 |
| matplotlib | `<3.10.10` | `<3.11.2` | 3.11.1 |
| numpy | `<2.5.0` | `<2.5.4` | 2.5.3 |

matplotlib 3.11 is also what changed `ListedColormap`'s default `name` from `from_list` to `unnamed`, the scalar bar title drift noticed in #9089. It reached the documentation build through this hole on 2026-08-16, in #8914.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
