### PR TITLE
Fix six bugs found while profiling

### DIFF
--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -7967,14 +7967,24 @@ class DataSetFilters(DataObjectFilters):
                         raise TypeError(msg)
                     # Avoid unnecessary conversion and set color sequence directly in float cases
                     cmap_colors = cast('list[list[float]]', cmap.colors)
-                    if color_type == 'float_rgb':
-                        color_rgb_sequence = cmap_colors
+                    # A listed colormap's colors are RGB or RGBA floats in the range [0, 1]
+                    n_channels = len(cmap_colors[0]) if len(cmap_colors) else 0
+                    if color_type == 'float_rgb' and n_channels in (3, 4):
+                        color_rgb_sequence = (
+                            cmap_colors if n_channels == 3 else [c[:3] for c in cmap_colors]
+                        )
                         _is_rgb_sequence = True
-                    elif color_type == 'float_rgba':
-                        color_rgb_sequence = [(*c, 1.0) for c in cmap_colors]
+                    elif color_type == 'float_rgba' and n_channels in (3, 4):
+                        color_rgb_sequence = (
+                            cmap_colors if n_channels == 4 else [(*c, 1.0) for c in cmap_colors]  # type: ignore[misc]
+                        )
                         _is_rgb_sequence = True
                     else:
-                        colors = cmap_colors
+                        colors = (
+                            cmap_colors.tolist()
+                            if isinstance(cmap_colors, np.ndarray)
+                            else cmap_colors
+                        )
 
             table = None
             if not _is_rgb_sequence:

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -7967,8 +7967,13 @@ class DataSetFilters(DataObjectFilters):
                         raise TypeError(msg)
                     # Avoid unnecessary conversion and set color sequence directly in float cases
                     cmap_colors = cast('list[list[float]]', cmap.colors)
-                    # A listed colormap's colors are RGB or RGBA floats in the range [0, 1]
-                    n_channels = len(cmap_colors[0]) if len(cmap_colors) else 0
+                    # Only float RGB or RGBA rows can be used without validating them
+                    color_array = np.asarray(cmap_colors)
+                    n_channels = (
+                        color_array.shape[1]
+                        if color_array.ndim == 2 and color_array.dtype.kind == 'f'
+                        else 0
+                    )
                     if color_type == 'float_rgb' and n_channels in (3, 4):
                         color_rgb_sequence = (
                             cmap_colors if n_channels == 3 else [c[:3] for c in cmap_colors]
@@ -7981,7 +7986,7 @@ class DataSetFilters(DataObjectFilters):
                         _is_rgb_sequence = True
                     else:
                         # The colors may be an array, which is not a valid color sequence
-                        colors = np.asarray(cmap_colors).tolist()
+                        colors = color_array.tolist()
 
             table = None
             if not _is_rgb_sequence:

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -7893,9 +7893,10 @@ class DataSetFilters(DataObjectFilters):
                 )
                 raise ValueError(msg)
 
-        def _is_index_like(array_, max_value):
-            min_value = -max_value if negative_indexing else 0
-            return (array_ == np.floor(array_)) & (array_ >= min_value) & (array_ <= max_value)
+        def _is_index_like(array_, n_colors_):
+            """Return which values can be used to index ``n_colors_`` colors."""
+            min_value = -n_colors_ if negative_indexing else 0
+            return (array_ == np.floor(array_)) & (array_ >= min_value) & (array_ < n_colors_)
 
         _validation.check_contains(
             ['int_rgb', 'float_rgb', 'int_rgba', 'float_rgba'],
@@ -7990,7 +7991,7 @@ class DataSetFilters(DataObjectFilters):
                     color_rgb_sequence = color_rgb_sequence * len(array)
 
             n_colors = len(color_rgb_sequence)
-            index_like = np.all(_is_index_like(array, max_value=n_colors))
+            index_like = np.all(_is_index_like(array, n_colors_=n_colors))
             if coloring_mode is None:
                 coloring_mode = 'index' if index_like else 'cycle'
 
@@ -8019,11 +8020,9 @@ class DataSetFilters(DataObjectFilters):
                     mapping = {
                         label: color_rgb_sequence[label] for label in keys if label in present
                     }
-                # Negative labels index the sequence from the end like the negative keys, and
-                # a label equal to ``n_colors`` passes the check above but has no color
+                # Negative labels index the sequence from the end like the negative keys
                 indices[indices < 0] += n_colors
-                default_row = np.full((1, num_components), default_channel_value, color_dtype)
-                colors_out = np.vstack((table, default_row))[indices]
+                colors_out = table[indices]
             else:  # 'cycle', validated above
                 if negative_indexing:
                     msg = "Negative indexing is not supported with 'cycle' mode enabled."

--- a/pyvista/core/filters/data_set.py
+++ b/pyvista/core/filters/data_set.py
@@ -7976,15 +7976,12 @@ class DataSetFilters(DataObjectFilters):
                         _is_rgb_sequence = True
                     elif color_type == 'float_rgba' and n_channels in (3, 4):
                         color_rgb_sequence = (
-                            cmap_colors if n_channels == 4 else [(*c, 1.0) for c in cmap_colors]  # type: ignore[misc]
+                            cmap_colors if n_channels == 4 else [[*c, 1.0] for c in cmap_colors]
                         )
                         _is_rgb_sequence = True
                     else:
-                        colors = (
-                            cmap_colors.tolist()
-                            if isinstance(cmap_colors, np.ndarray)
-                            else cmap_colors
-                        )
+                        # The colors may be an array, which is not a valid color sequence
+                        colors = np.asarray(cmap_colors).tolist()
 
             table = None
             if not _is_rgb_sequence:

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -493,9 +493,15 @@ class ImageDataFilters(DataSetFilters):
         crop
 
         """
+        voi = _validation.validate_arrayN(
+            voi, must_have_length=6, must_be_integer=True, dtype_out=int, name='voi'
+        )
         extent = self.extent
         if np.any(np.not_equal(ImageDataFilters._clip_extent(voi, clip_to=extent), voi)):
-            msg = f'VOI {tuple(voi)} is outside the extent of the input {extent}.'
+            msg = (
+                f'The requested volume of interest {tuple(voi.tolist())} '
+                f"is outside the input's extent {extent}."
+            )
             raise ValueError(msg)
 
         alg = _vtk.vtkExtractVOI()
@@ -608,7 +614,8 @@ class ImageDataFilters(DataSetFilters):
 
         extent : VectorLike[int], optional
             Length-6 vector of integers specifying the full :attr:`~pyvista.ImageData.extent` of
-            the cropping region.
+            the cropping region. If the region extends beyond the extents of this mesh, it is
+            clipped to the part this mesh covers.
 
         normalized_bounds : VectorLike[float], optional
             Normalized bounds relative to the input. These are floats between ``0.0`` and ``1.0``
@@ -692,7 +699,7 @@ class ImageDataFilters(DataSetFilters):
             Threshold-like filter which may be used to generate a mask for cropping.
 
         extract_subset
-            Equivalent filter to ``crop(extent=voi, rebase_coordinates=True)``.
+            Similar filter which requires the region to be inside the image.
 
         Examples
         --------
@@ -1003,13 +1010,14 @@ class ImageDataFilters(DataSetFilters):
             )
             raise TypeError(msg)
 
-        # Crop to the part of the requested region which the image actually covers
-        voi = ImageDataFilters._clip_extent(voi, clip_to=self.extent)
-
         # Ensure dimensions are all at least one
+        voi = np.array(voi)
         voi[1] = max(voi[0:2])
         voi[3] = max(voi[2:4])
         voi[5] = max(voi[4:6])
+
+        # Crop to the part of the requested region which the image actually covers
+        voi = ImageDataFilters._clip_extent(voi, clip_to=self.extent)
 
         cropped = self.extract_subset(
             voi, rebase_coordinates=rebase_coordinates, progress_bar=progress_bar

--- a/pyvista/core/filters/image_data.py
+++ b/pyvista/core/filters/image_data.py
@@ -449,7 +449,7 @@ class ImageDataFilters(DataSetFilters):
         voi : sequence[int]
             Length 6 iterable of ``int``\ s: ``(x_min, x_max, y_min, y_max, z_min, z_max)``.
             These bounds specify the volume of interest in i-j-k min/max
-            indices.
+            indices. Must be within this mesh's :attr:`~pyvista.ImageData.extent`.
 
         rate : sequence[int], default: (1, 1, 1)
             Length 3 iterable of ``int``\ s: ``(xrate, yrate, zrate)``.
@@ -493,6 +493,11 @@ class ImageDataFilters(DataSetFilters):
         crop
 
         """
+        extent = self.extent
+        if np.any(np.not_equal(ImageDataFilters._clip_extent(voi, clip_to=extent), voi)):
+            msg = f'VOI {tuple(voi)} is outside the extent of the input {extent}.'
+            raise ValueError(msg)
+
         alg = _vtk.vtkExtractVOI()
         alg.SetVOI(voi)
         alg.SetInputDataObject(self)
@@ -998,8 +1003,10 @@ class ImageDataFilters(DataSetFilters):
             )
             raise TypeError(msg)
 
+        # Crop to the part of the requested region which the image actually covers
+        voi = ImageDataFilters._clip_extent(voi, clip_to=self.extent)
+
         # Ensure dimensions are all at least one
-        voi = np.array(voi)
         voi[1] = max(voi[0:2])
         voi[3] = max(voi[2:4])
         voi[5] = max(voi[4:6])

--- a/pyvista/plotting/lights.py
+++ b/pyvista/plotting/lights.py
@@ -1141,6 +1141,10 @@ class Light(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkLight):
         light.cone_angle = vtk_light.GetConeAngle()
         light.attenuation_values = vtk_light.GetAttenuationValues()
         trans = vtk_light.GetTransformMatrix()
+        if trans is not None:
+            matrix = _vtk.vtkMatrix4x4()
+            matrix.DeepCopy(trans)
+            trans = matrix
         light.transform_matrix = trans
         light.shadow_attenuation = vtk_light.GetShadowAttenuation()
 

--- a/pyvista/plotting/plot_compare.py
+++ b/pyvista/plotting/plot_compare.py
@@ -324,8 +324,7 @@ def _validate_label_position(label_position: Any) -> TextPositionOptions | None:
 
 def _text_width(text: str, prop: Any, *, size: float, dpi: int, measurer: Any) -> float:
     """Return the width in pixels of the text drawn at the given font size."""
-    # A `pyvista.TextProperty` loads the theme into a property shared by all of them,
-    # which measuring has no business doing, so measure with a plain VTK one
+    # Measure with a plain VTK property, which needs no theme
     measured = _vtk.vtkTextProperty()
     # Copy what the text is drawn with, to measure its font rather than the default
     measured.ShallowCopy(prop)

--- a/pyvista/plotting/scalar_bars.py
+++ b/pyvista/plotting/scalar_bars.py
@@ -92,7 +92,6 @@ class ScalarBars(_NoNewAttrMixin):
                         render=render,
                     )
                     self._plotter._scalar_bar_slots.add(slot)
-            return
 
     @_deprecate_positional_args(allowed=['title'])
     def remove_scalar_bar(self, title=None, render: bool = True):  # noqa: FBT001, FBT002

--- a/pyvista/plotting/text.py
+++ b/pyvista/plotting/text.py
@@ -560,7 +560,6 @@ class TextProperty(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkTextProperty):
     ):
         """Initialize text's property."""
         super().__init__()
-        # snapshot the theme so later edits to the source theme do not reach this property
         self._theme = Theme._from_theme(pv.global_theme if theme is None else theme)
         self.color = color
         self.font_family = font_family

--- a/pyvista/plotting/text.py
+++ b/pyvista/plotting/text.py
@@ -537,7 +537,6 @@ class TextProperty(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkTextProperty):
 
     """
 
-    _theme = Theme()
     _color_set = None
     _background_color_set = None
     _font_family = None
@@ -561,12 +560,8 @@ class TextProperty(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkTextProperty):
     ):
         """Initialize text's property."""
         super().__init__()
-        if theme is None:
-            # copy global theme to ensure local property theme is fixed
-            # after creation.
-            self._theme.load_theme(pv.global_theme)
-        else:
-            self._theme.load_theme(theme)
+        # snapshot the theme so later edits to the source theme do not reach this property
+        self._theme = Theme._from_theme(pv.global_theme if theme is None else theme)
         self.color = color
         self.font_family = font_family
         if orientation is not None:

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -5005,6 +5005,7 @@ def test_color_labels_label_equal_to_number_of_colors():
     colored, mapping = labels.color_labels(colors, return_dict=True)
     assert list(mapping.keys()) == [0, 1, 2, 3]
     assert mapping[3] == pv.Color('red').int_rgb
+    assert np.array_equal(colored.active_scalars, [mapping[label] for label in labels['data']])
 
 
 def test_color_labels_does_not_modify_colormap():

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -3674,6 +3674,26 @@ def test_extract_subset(uniform, rebase_coordinates):
     assert cropped == voi
 
 
+@pytest.mark.parametrize(
+    'voi',
+    [(-5, 5, 0, 5, 0, 5), (0, 100, 0, 5, 0, 5), (0, 5, 0, 5, 0, 100)],
+)
+def test_extract_subset_voi_outside_extent_raises(uniform, voi):
+    match = f'VOI {voi} is outside the extent of the input {uniform.extent}.'
+    with pytest.raises(ValueError, match=re.escape(match)):
+        uniform.extract_subset(voi)
+
+
+def test_crop_clips_to_the_image_extent(uniform):
+    extent = uniform.extent
+    oversized = (extent[0] - 5, extent[1] + 5, extent[2], extent[3], extent[4], extent[5])
+
+    cropped = uniform.crop(extent=oversized)
+
+    assert cropped.extent == extent
+    assert cropped == uniform.crop(extent=extent)
+
+
 def test_gaussian_smooth_output_type():
     volume = examples.load_uniform()
     volume_smooth = volume.gaussian_smooth()

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -5019,6 +5019,35 @@ def test_color_labels_does_not_modify_colormap():
     assert np.array_equal(first.active_scalars, second.active_scalars)
 
 
+@pytest.mark.parametrize('as_array', [True, False])
+@pytest.mark.parametrize(
+    ('color_type', 'red', 'opaque'),
+    [
+        ('float_rgb', (1.0, 0.0, 0.0), None),
+        ('float_rgba', (1.0, 0.0, 0.0), 1.0),
+        ('int_rgb', (255, 0, 0), None),
+        ('int_rgba', (255, 0, 0), 255),
+    ],
+)
+def test_color_labels_listed_colormap_colors(as_array, color_type, red, opaque):
+    rgb = [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+    rgba = [(*color, 0.25) for color in rgb]
+    labels = pv.ImageData(dimensions=(3, 1, 1))
+    labels['data'] = [0, 1, 0]
+
+    def first_color(colors):
+        cmap = ListedColormap(np.array(colors) if as_array else colors)
+        colored = labels.color_labels(cmap, coloring_mode='index', color_type=color_type)
+        return colored.active_scalars[0]
+
+    assert np.allclose(first_color(rgb)[:3], red)
+    assert np.allclose(first_color(rgba)[:3], red)
+    if opaque is not None:
+        assert np.isclose(first_color(rgb)[3], opaque)
+        # The colormap's own alpha is used when it has one
+        assert np.isclose(first_color(rgba)[3], 0.25 * opaque, atol=1)
+
+
 def test_color_labels_return_dict_cycle_mode():
     labels = pv.ImageData(dimensions=(4, 1, 1))
     labels['data'] = [3, 1, 3, 7]

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -4973,8 +4973,7 @@ def test_color_labels_return_dict(labeled_image, color_type):
     ('negative_indexing', 'label_data', 'expected_keys'),
     [
         (True, [0, -1, 2, -6], [0, 2, -1, -6]),
-        # A label equal to the number of colors is allowed but has no color
-        (False, [0, 2, 2, 6], [0, 2]),
+        (False, [0, 2, 2, 5], [0, 2, 5]),
     ],
 )
 def test_color_labels_return_dict_index_mode(negative_indexing, label_data, expected_keys):
@@ -4988,8 +4987,24 @@ def test_color_labels_return_dict_index_mode(negative_indexing, label_data, expe
     assert list(mapping.keys()) == expected_keys
     for key in expected_keys:
         assert mapping[key] == pv.Color(colors[key]).int_rgb
-    expected_colors = [mapping.get(label, (0, 0, 0)) for label in label_data]
+    expected_colors = [mapping[label] for label in label_data]
     assert np.array_equal(colored.active_scalars, expected_colors)
+
+
+def test_color_labels_label_equal_to_number_of_colors():
+    colors = ['red', 'green', 'blue']
+    labels = pv.ImageData(dimensions=(4, 1, 1))
+    labels['data'] = [0, 1, 2, 3]
+
+    # A label equal to the number of colors cannot index the colors
+    match = 'Index coloring mode cannot be used'
+    with pytest.raises(ValueError, match=match):
+        labels.color_labels(colors, coloring_mode='index')
+
+    # Cycle mode is used by default instead, so every label is colored
+    colored, mapping = labels.color_labels(colors, return_dict=True)
+    assert list(mapping.keys()) == [0, 1, 2, 3]
+    assert mapping[3] == pv.Color('red').int_rgb
 
 
 def test_color_labels_does_not_modify_colormap():

--- a/tests/core/test_dataset_filters.py
+++ b/tests/core/test_dataset_filters.py
@@ -3679,19 +3679,11 @@ def test_extract_subset(uniform, rebase_coordinates):
     [(-5, 5, 0, 5, 0, 5), (0, 100, 0, 5, 0, 5), (0, 5, 0, 5, 0, 100)],
 )
 def test_extract_subset_voi_outside_extent_raises(uniform, voi):
-    match = f'VOI {voi} is outside the extent of the input {uniform.extent}.'
+    match = (
+        f"The requested volume of interest {voi} is outside the input's extent {uniform.extent}."
+    )
     with pytest.raises(ValueError, match=re.escape(match)):
         uniform.extract_subset(voi)
-
-
-def test_crop_clips_to_the_image_extent(uniform):
-    extent = uniform.extent
-    oversized = (extent[0] - 5, extent[1] + 5, extent[2], extent[3], extent[4], extent[5])
-
-    cropped = uniform.crop(extent=oversized)
-
-    assert cropped.extent == extent
-    assert cropped == uniform.crop(extent=extent)
 
 
 def test_gaussian_smooth_output_type():
@@ -5041,31 +5033,49 @@ def test_color_labels_does_not_modify_colormap():
 
 @pytest.mark.parametrize('as_array', [True, False])
 @pytest.mark.parametrize(
-    ('color_type', 'red', 'opaque'),
+    ('color_type', 'red', 'green', 'opaque', 'quarter'),
     [
-        ('float_rgb', (1.0, 0.0, 0.0), None),
-        ('float_rgba', (1.0, 0.0, 0.0), 1.0),
-        ('int_rgb', (255, 0, 0), None),
-        ('int_rgba', (255, 0, 0), 255),
+        ('float_rgb', (1.0, 0.0, 0.0), (0.0, 1.0, 0.0), None, None),
+        ('float_rgba', (1.0, 0.0, 0.0), (0.0, 1.0, 0.0), 1.0, 0.25),
+        ('int_rgb', (255, 0, 0), (0, 255, 0), None, None),
+        ('int_rgba', (255, 0, 0), (0, 255, 0), 255, 64),
     ],
 )
-def test_color_labels_listed_colormap_colors(as_array, color_type, red, opaque):
+def test_color_labels_listed_colormap_colors(as_array, color_type, red, green, opaque, quarter):
     rgb = [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
     rgba = [(*color, 0.25) for color in rgb]
     labels = pv.ImageData(dimensions=(3, 1, 1))
     labels['data'] = [0, 1, 0]
 
-    def first_color(colors):
+    def colors_of(colors):
         cmap = ListedColormap(np.array(colors) if as_array else colors)
         colored = labels.color_labels(cmap, coloring_mode='index', color_type=color_type)
-        return colored.active_scalars[0]
+        return np.asarray(colored.active_scalars)
 
-    assert np.allclose(first_color(rgb)[:3], red)
-    assert np.allclose(first_color(rgba)[:3], red)
+    assert np.allclose(colors_of(rgb)[:, :3], [red, green, red])
+    assert np.allclose(colors_of(rgba)[:, :3], [red, green, red])
     if opaque is not None:
-        assert np.isclose(first_color(rgb)[3], opaque)
+        assert np.allclose(colors_of(rgb)[:, 3], opaque)
         # The colormap's own alpha is used when it has one
-        assert np.isclose(first_color(rgba)[3], 0.25 * opaque, atol=1)
+        assert np.allclose(colors_of(rgba)[:, 3], quarter)
+
+
+@pytest.mark.parametrize('as_array', [True, False])
+@pytest.mark.parametrize('color_type', ['float_rgb', 'float_rgba', 'int_rgb', 'int_rgba'])
+def test_color_labels_return_dict_listed_colormap(as_array, color_type):
+    colors = [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+    cmap = ListedColormap(np.array(colors) if as_array else colors)
+    labels = pv.ImageData(dimensions=(3, 1, 1))
+    labels['data'] = [0, 1, 0]
+
+    colored, mapping = labels.color_labels(
+        cmap, coloring_mode='index', color_type=color_type, return_dict=True
+    )
+
+    assert list(mapping.keys()) == [0, 1]
+    for label, color in mapping.items():
+        assert pv.Color(color) == pv.Color(colors[label])
+        assert np.array_equal(colored.active_scalars[label], color)
 
 
 def test_color_labels_return_dict_cycle_mode():

--- a/tests/core/test_imagedata_filters.py
+++ b/tests/core/test_imagedata_filters.py
@@ -2037,6 +2037,16 @@ def test_crop_keep_dimensions(image2x2, fill_value):
     assert cropped.user_dict == user_dict
 
 
+def test_crop_clips_to_the_image_extent(uncropped_image):
+    extent = uncropped_image.extent
+    oversized = (extent[0] - 5, extent[1] + 5, extent[2], extent[3], extent[4], extent[5])
+
+    cropped = uncropped_image.crop(extent=oversized)
+
+    assert cropped.extent == extent
+    assert cropped == uncropped_image.crop(extent=extent)
+
+
 def test_crop_raises():
     background = 0.0
     img = pv.ImageData(dimensions=(1, 1, 1))

--- a/tests/plotting/test_lights.py
+++ b/tests/plotting/test_lights.py
@@ -314,6 +314,12 @@ def test_from_vtk():
         else:
             assert getattr(light, pvname) == value
 
+    # the transformation matrix is copied, not shared with the source light
+    source_matrix = vtk_light.GetTransformMatrix()
+    assert light.transform_matrix is not source_matrix
+    source_matrix.SetElement(0, 3, 42.0)
+    assert light.transform_matrix.GetElement(0, 3) != 42.0
+
     # invalid case
     with pytest.raises(TypeError):
         pv.Light.from_vtk('invalid')

--- a/tests/plotting/test_scalar_bars.py
+++ b/tests/plotting/test_scalar_bars.py
@@ -187,3 +187,17 @@ def test_add_scalar_bar_shared_range_resync(sphere):
     actors.append(pl.add_mesh(mid.copy(), scalars='data'))
     assert [m.scalar_range for m in mappers] == [(-1.0, 5.0)] * 6
     pl.close()
+
+
+def test_remove_actor_removes_mapper_from_every_scalar_bar(sphere):
+    """Test that removing an actor clears its mapper from all of its scalar bars."""
+    sphere[KEY] = sphere.points[:, 2]
+    pl = pv.Plotter()
+    actor = pl.add_mesh(sphere, scalars=KEY)
+    pl.add_scalar_bar('Second')
+    mappers = pl.scalar_bars._scalar_bar_mappers
+    assert [title for title, m in mappers.items() if actor.mapper in m] == [KEY, 'Second']
+
+    pl.remove_actor(actor)
+    assert [title for title, m in mappers.items() if actor.mapper in m] == []
+    pl.close()

--- a/tests/plotting/test_scalar_bars.py
+++ b/tests/plotting/test_scalar_bars.py
@@ -200,4 +200,5 @@ def test_remove_actor_removes_mapper_from_every_scalar_bar(sphere):
 
     pl.remove_actor(actor)
     assert [title for title, m in mappers.items() if actor.mapper in m] == []
+    assert len(pl.scalar_bars) == 0
     pl.close()

--- a/tests/plotting/test_text.py
+++ b/tests/plotting/test_text.py
@@ -336,3 +336,18 @@ def test_add_text_actor_follows_the_theme_of_the_plotter():
     assert actor.prop.color == pv.Color('blue')
     assert actor.prop.font_family == 'times'
     pl.close()
+
+
+def test_text_property_theme_is_not_shared():
+    """Test that a property's theme is its own and is fixed after creation."""
+    default = pv.TextProperty()
+
+    theme = pv.themes.Theme()
+    theme.font.color = 'red'
+    other = pv.TextProperty(theme=theme)
+    assert other.color == pv.Color('red')
+    assert default.color == pv.Color(pv.global_theme.font.color)
+    assert default._theme is not other._theme
+
+    theme.font.color = 'blue'
+    assert other.color == pv.Color('red')

--- a/tests/plotting/test_text.py
+++ b/tests/plotting/test_text.py
@@ -339,15 +339,15 @@ def test_add_text_actor_follows_the_theme_of_the_plotter():
 
 
 def test_text_property_theme_is_not_shared():
-    """Test that a property's theme is its own and is fixed after creation."""
-    default = pv.TextProperty()
-
+    """Test that a property keeps its own theme when another property is created."""
     theme = pv.themes.Theme()
     theme.font.color = 'red'
-    other = pv.TextProperty(theme=theme)
-    assert other.color == pv.Color('red')
-    assert default.color == pv.Color(pv.global_theme.font.color)
-    assert default._theme is not other._theme
+    custom = pv.TextProperty(theme=theme)
 
-    theme.font.color = 'blue'
-    assert other.color == pv.Color('red')
+    # A property made from the global theme does not take the custom theme's color
+    default = pv.TextProperty()
+    assert default.color == pv.Color(pv.global_theme.font.color)
+
+    # Nor does it leave the custom property resolving colors from the global theme
+    custom.color = None
+    assert custom.color == pv.Color('red')


### PR DESCRIPTION
### Overview

Six unrelated bugs found while profiling for the performance sweep, one commit each. All predate the sweep PRs.

- `TextProperty` held its theme in a class attribute, so all text properties shared one theme and creating one with a custom theme restyled the others.
- `Light.from_vtk` shared the source's transformation matrix instead of copying it, as its docstring promises.
- Removing an actor cleared its mapper from only the first scalar bar holding it.
- `color_labels` accepted a label equal to the number of colors as an index, silently coloring it with the default instead of raising or cycling.
- `color_labels` assumed a `ListedColormap` holds RGB triples, so RGBA colors and the `ListedColormap(colormap(numpy.linspace(0, 1, n)))` idiom failed.
- `extract_subset` positioned its output using indices VTK had silently clamped, returning the right voxels in the wrong place; it now raises, and `crop` clips its region first and is unchanged.

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
