### PR TITLE
Skip the orientation transform for an unrotated geometric source

### DIFF
--- a/pyvista/core/utilities/geometric_sources.py
+++ b/pyvista/core/utilities/geometric_sources.py
@@ -111,6 +111,9 @@ class _AlgorithmSource(_NoNewAttrMixin, DisableVtkSnakeCase, _vtk.vtkAlgorithm):
         return _apply_points_dtype(wrap(self.GetOutput()), algorithm=self)
 
 
+_IDENTITY3 = np.eye(3)
+
+
 def _translate_and_orient(
     surf: DataSet,
     center: VectorLike[float] = (0.0, 0.0, 0.0),
@@ -151,7 +154,9 @@ def _translate_and_orient(
     trans[:3, 2] = normz
     trans[3, 3] = 1
 
-    surf.transform(trans, inplace=True)
+    # Optimization: skip the transform filter for a mesh already facing this direction
+    if not np.array_equal(trans[:3, :3], _IDENTITY3):
+        surf.transform(trans, inplace=True)
     if not np.allclose(center, [0.0, 0.0, 0.0]):
         surf.points += np.array(center, dtype=surf.points.dtype)
 


### PR DESCRIPTION
### Overview

A follow-up to the performance sweep, revisiting the candidates I measured and set aside. Only one produced a clear win.

Every geometric and parametric object orients the mesh its source generated by running the transform filter, including when the requested direction is the one the mesh already faces and the transform is the identity. That filter costs about as much as generating the mesh, so it is now skipped in that case. The output keeps the array order the source produced, and its float32 normals are the source's rather than the filter's renormalization of them, which differ by at most 6e-8.

| Call (VTK 9.7.0 on this machine, min of 5) | Before | After |
| --- | ---: | ---: |
| `pv.Cylinder()` | 516 µs | 332 µs |
| `pv.Arrow()` | 406 µs | 237 µs |
| `pv.Sphere()`, whose default direction is not the mesh's | 491 µs | 491 µs |

Changes drafted by Claude Opus 5 but fully understood by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
